### PR TITLE
[codex] Improve fleet telemetry evidence and cache freshness

### DIFF
--- a/docs/spec/07-team-session.md
+++ b/docs/spec/07-team-session.md
@@ -98,7 +98,7 @@ Team Session Engine (Eio)
 
 | Field | Type | 설명 |
 |-------|------|------|
-| `turn_count` | int | 누적 turn 수 |
+| `turn_count` | int | 누적 session orchestration turn 수 (`team_turn` + swarm iteration) |
 | `agent_names` | string list | 참여 agent 목록 |
 | `planned_workers` | planned_worker list | 계획된 worker 사양 |
 | `broadcast_count` | int | broadcast 횟수 |

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -441,6 +441,8 @@ let invalidate_prefix prefix =
     in
     List.iter Eio.Condition.broadcast conds
   else
+    (* Non-Eio fallback matches [get_or_compute_simple]: no fibers, no shared
+       concurrent mutation, so direct Hashtbl removal is sufficient. *)
     let keys =
       Hashtbl.fold
         (fun key _ acc ->

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -402,6 +402,53 @@ let invalidate key =
     Option.iter Eio.Condition.broadcast cond_opt
   else Hashtbl.remove table key
 
+let invalidate_prefix prefix =
+  if String.trim prefix = "" then
+    if Eio_guard.is_ready () then
+      let conds =
+        Eio.Mutex.use_rw ~protect:true mu (fun () ->
+          let cs =
+            Hashtbl.fold
+              (fun _key slot acc ->
+                match slot with Computing { cond; _ } -> cond :: acc | _ -> acc)
+              table []
+          in
+          Hashtbl.clear table;
+          cs)
+      in
+      List.iter Eio.Condition.broadcast conds
+    else
+      Hashtbl.clear table
+  else if Eio_guard.is_ready () then
+    let conds =
+      Eio.Mutex.use_rw ~protect:true mu (fun () ->
+        let keys, conds =
+          Hashtbl.fold
+            (fun key slot (keys_acc, conds_acc) ->
+              if String.starts_with ~prefix key then
+                let conds_acc =
+                  match slot with
+                  | Computing { cond; _ } -> cond :: conds_acc
+                  | _ -> conds_acc
+                in
+                (key :: keys_acc, conds_acc)
+              else
+                (keys_acc, conds_acc))
+            table ([], [])
+        in
+        List.iter (fun key -> Hashtbl.remove table key) keys;
+        conds)
+    in
+    List.iter Eio.Condition.broadcast conds
+  else
+    let keys =
+      Hashtbl.fold
+        (fun key _ acc ->
+          if String.starts_with ~prefix key then key :: acc else acc)
+        table []
+    in
+    List.iter (fun key -> Hashtbl.remove table key) keys
+
 let invalidate_all () =
   if Eio_guard.is_ready () then
     let conds =

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -47,6 +47,11 @@ val invalidate : string -> unit
 (** Remove a single cache entry.  If the key is currently being computed,
     waiting fibers are woken and will recompute. *)
 
+val invalidate_prefix : string -> unit
+(** Remove all cache entries whose key starts with the given prefix.  If any
+    matching entry is currently being computed, waiting fibers are woken and
+    will recompute. *)
+
 val invalidate_all : unit -> unit
 (** Remove all cache entries. Useful after mutations that change dashboard state. *)
 

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -46,7 +46,11 @@ let event_summary event_json =
     trim_to_option (string_field "event_type" event_json)
     |> Option.value ~default:"event"
   in
-  let actor = trim_to_option (string_field "actor" detail) in
+  let actor =
+    match trim_to_option (string_field "actor" detail) with
+    | Some value -> Some value
+    | None -> trim_to_option (string_field "agent" detail)
+  in
   let task_title =
     match trim_to_option (string_field "task_title" detail) with
     | Some value -> Some value
@@ -54,15 +58,20 @@ let event_summary event_json =
   in
   let result = trim_to_option (compact_text (string_field "result" detail)) in
   let reason = trim_to_option (compact_text (string_field "reason" detail)) in
-  match task_title, result, reason with
-  | Some title, _, _ ->
+  let output_preview =
+    trim_to_option (compact_text (string_field "output_preview" detail))
+  in
+  match task_title, result, reason, output_preview with
+  | Some title, _, _, _ ->
       compact_text
         (Printf.sprintf "%s%s"
            (match actor with Some value -> value ^ " · " | None -> "")
            title)
-  | None, Some value, _ -> value
-  | None, None, Some value -> value
-  | None, None, None -> String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
+  | None, Some value, _, _ -> value
+  | None, None, Some value, _ -> value
+  | None, None, None, Some value -> value
+  | None, None, None, None ->
+      String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
 
 let session_severity ~health ~status ~runtime_blocker =
   if status = "completed" then

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -104,7 +104,11 @@ let event_summary event_json =
     trim_to_option (string_field "event_type" event_json)
     |> Option.value ~default:"event"
   in
-  let actor = trim_to_option (string_field "actor" detail) in
+  let actor =
+    match trim_to_option (string_field "actor" detail) with
+    | Some value -> Some value
+    | None -> trim_to_option (string_field "agent" detail)
+  in
   let task_title =
     match trim_to_option (string_field "task_title" detail) with
     | Some value -> Some value
@@ -112,13 +116,18 @@ let event_summary event_json =
   in
   let result = trim_to_option (compact_text (string_field "result" detail)) in
   let reason = trim_to_option (compact_text (string_field "reason" detail)) in
-  match task_title, result, reason with
-  | Some title, _, _ ->
+  let output_preview =
+    trim_to_option (compact_text (string_field "output_preview" detail))
+  in
+  match task_title, result, reason, output_preview with
+  | Some title, _, _, _ ->
       compact_text
         (Printf.sprintf "%s%s" (match actor with Some value -> value ^ " · " | None -> "") title)
-  | None, Some value, _ -> value
-  | None, None, Some value -> value
-  | None, None, None -> String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
+  | None, Some value, _, _ -> value
+  | None, None, Some value, _ -> value
+  | None, None, None, Some value -> value
+  | None, None, None, None ->
+      String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
 
 let session_origin_kind session_meta =
   let created_by =

--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -18,7 +18,11 @@ let event_summary event_json =
     trim_to_option (string_field "event_type" event_json)
     |> Option.value ~default:"event"
   in
-  let actor = trim_to_option (string_field "actor" detail) in
+  let actor =
+    match trim_to_option (string_field "actor" detail) with
+    | Some value -> Some value
+    | None -> trim_to_option (string_field "agent" detail)
+  in
   let task_title =
     match trim_to_option (string_field "task_title" detail) with
     | Some value -> Some value
@@ -26,13 +30,17 @@ let event_summary event_json =
   in
   let result = trim_to_option (compact_text (string_field "result" detail)) in
   let reason = trim_to_option (compact_text (string_field "reason" detail)) in
-  match task_title, result, reason with
-  | Some title, _, _ ->
+  let output_preview =
+    trim_to_option (compact_text (string_field "output_preview" detail))
+  in
+  match task_title, result, reason, output_preview with
+  | Some title, _, _, _ ->
       compact_text
         (Printf.sprintf "%s%s" (match actor with Some value -> value ^ " \xc2\xb7 " | None -> "") title)
-  | None, Some value, _ -> value
-  | None, None, Some value -> value
-  | None, None, None -> String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
+  | None, Some value, _, _ -> value
+  | None, None, Some value, _ -> value
+  | None, None, None, Some value -> value
+  | None, None, None, None -> String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
 
 let session_recent_events session_json = list_field "recent_events" session_json
 

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -566,6 +566,10 @@ let session_timeline_json session_json =
              ("id", `String (Printf.sprintf "event-%d" idx));
              ("timestamp", member_assoc "ts_iso" event_json);
              ("event_type", member_assoc "event_type" event_json);
-             ("actor", json_string_option (trim_to_option (string_field "actor" detail)));
+             ( "actor",
+               json_string_option
+                 (match trim_to_option (string_field "actor" detail) with
+                 | Some value -> Some value
+                 | None -> trim_to_option (string_field "agent" detail)) );
              ("summary", `String (event_summary event_json));
            ])

--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -153,18 +153,18 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
     || checkpoints_count > 0
   in
   let worker_run_meta = Dashboard_proof_actors.worker_run_meta_jsons config session_id in
-  let stored_worker_proof_count =
+  let worker_run_evidence_count =
     worker_run_meta
     |> List.fold_left
          (fun acc json ->
-           match U.member "proof_present" json with
-           | `Bool true -> acc + 1
+           match Dashboard_proof_actors.worker_run_trace_capability json with
+           | Some "raw" | Some "summary_only" -> acc + 1
            | _ -> acc)
          0
   in
   let evidence_present =
     tool_evidence_count > 0 || deliverable_count > 0 || checkpoints_count > 0
-    || Option.is_some proof_doc || stored_worker_proof_count > 0
+    || Option.is_some proof_doc || worker_run_evidence_count > 0
   in
   let raw_trace_run_count =
     worker_run_meta
@@ -254,7 +254,7 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
           ~interaction_count
           ~evidence_count:
             (tool_evidence_count + deliverable_count + checkpoints_count
-           + stored_worker_proof_count)
+           + worker_run_evidence_count)
           ~cp_trace_count ~raw_trace_run_count ~validated_worker_run_count
           ~live_verdict ~historical_verdict ~verdict_basis );
       ("timeline", Dashboard_proof_verdict.timeline_json ?session_id ?operation_id events cp_traces);

--- a/lib/dashboard/dashboard_proof_events.ml
+++ b/lib/dashboard/dashboard_proof_events.ml
@@ -7,7 +7,9 @@ let event_actor json =
   let detail = detail_of_event json in
   match string_field "actor" detail with
   | Some actor -> Some actor
-  | None -> string_field "runtime_actor" detail
+  | None ->
+      string_field "runtime_actor" detail
+      |> option_or_else (fun () -> string_field "agent" detail)
 
 let event_related_actor json =
   let detail = detail_of_event json in
@@ -24,6 +26,7 @@ let event_summary json =
       string_field "title" detail;
       string_field "reason" detail;
       string_field "result" detail;
+      string_field "output_preview" detail;
       string_field "content" detail;
       string_field "task_description" detail;
       string_field "goal" detail;
@@ -59,6 +62,7 @@ let event_output_preview json =
       string_field "summary" detail;
       string_field "content" detail;
       string_field "result" detail;
+      string_field "output_preview" detail;
     ]
   in
   match List.find_opt Option.is_some candidates with

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -132,6 +132,13 @@ let on_task_mutation_fn
   : (unit -> unit) ref
   = ref (fun () -> ())
 
+(** Invalidate team-session-derived dashboard caches after session writes.
+    Wired by server bootstrap to avoid circular dependency between
+    Team_session_store and dashboard surfaces. *)
+let on_team_session_mutation_fn
+  : (Room_utils_backend_setup.config -> session_id:string -> unit) ref
+  = ref (fun _config ~session_id:_ -> ())
+
 (** Auto-subscribe agent to messages on join — wraps Subscriptions.SubscriptionStore. *)
 let subscribe_messages_fn
   : (subscriber:string -> unit) ref

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -12,6 +12,31 @@ open Server_utils
 let () =
   Room_hooks.on_task_mutation_fn := invalidate_execution_cache
 
+let invalidate_team_session_dashboard_caches config ~session_id:_ =
+  let invalidate_prefix prefix =
+    try
+      Dashboard_cache.invalidate_prefix
+        (room_scoped_cache_key config prefix "")
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Dashboard.error "Failed to invalidate %s cache prefix: %s"
+          prefix (Printexc.to_string exn)
+  in
+  (try invalidate_cached_surface _mission_cache
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Dashboard.error "Failed to invalidate mission cached surface: %s"
+         (Printexc.to_string exn));
+  invalidate_prefix "mission";
+  invalidate_prefix "mission_briefing";
+  invalidate_prefix "proof"
+
+let () =
+  Room_hooks.on_team_session_mutation_fn :=
+    invalidate_team_session_dashboard_caches
+
 let dashboard_namespace_truth_focus_json =
   Server_dashboard_http_namespace_truth_support.dashboard_namespace_truth_focus_json
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -70,8 +70,27 @@ let _dashboard_mission_timeout_s =
   float_of_env_default "MASC_DASHBOARD_MISSION_TIMEOUT_S"
     ~default:25.0 ~min_v:10.0 ~max_v:120.0
 
+let _dashboard_proof_cache_ttl_s =
+  float_of_env_default "MASC_DASHBOARD_PROOF_CACHE_TTL_S"
+    ~default:5.0 ~min_v:1.0 ~max_v:30.0
+
 let _session_list_timeout_s =
   dashboard_session_list_timeout_s ()
+
+let normalized_query_value = function
+  | Some value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let dashboard_proof_cache_selector ?session_id ?operation_id () =
+  let value_or_star = function
+    | Some value -> value
+    | None -> "*"
+  in
+  Printf.sprintf "session=%s|operation=%s"
+    (value_or_star session_id)
+    (value_or_star operation_id)
 
 let dashboard_active_or_recent_sessions ~clock config =
   let cutoff_unix = Time_compat.now () -. 86400.0 in
@@ -834,10 +853,20 @@ let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
       ~clock ~timeout_sec:_dashboard_mission_timeout_s compute
 
 let dashboard_proof_http_json ~state request =
-  let session_id = query_param request "session_id" in
-  let operation_id = query_param request "operation_id" in
-  Dashboard_proof.json ?actor:(operator_actor_hint request) ?session_id
-    ?operation_id ~config:state.Mcp_server.room_config ()
+  let session_id =
+    query_param request "session_id" |> normalized_query_value
+  in
+  let operation_id =
+    query_param request "operation_id" |> normalized_query_value
+  in
+  let cache_key =
+    room_scoped_cache_key state.Mcp_server.room_config "proof"
+      (dashboard_proof_cache_selector ?session_id ?operation_id ())
+  in
+  Dashboard_cache.get_or_compute cache_key ~ttl:_dashboard_proof_cache_ttl_s
+    (fun () ->
+      Dashboard_proof.json ?actor:(operator_actor_hint request) ?session_id
+        ?operation_id ~config:state.Mcp_server.room_config ())
 
 let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let room_state = Room.read_state config in

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -345,7 +345,6 @@ let trace_ref_to_json (trace_ref : Oas.Raw_trace.run_ref) =
   `Assoc
     [
       ("worker_run_id", `String trace_ref.worker_run_id);
-      ("path", `String trace_ref.path);
       ("start_seq", `Int trace_ref.start_seq);
       ("end_seq", `Int trace_ref.end_seq);
       ("agent_name", `String trace_ref.agent_name);
@@ -371,6 +370,19 @@ let worker_name_of_planned_worker ~(fallback : string)
   | Some actor when String.trim actor <> "" -> String.trim actor
   | _ -> fallback
 
+let sanitize_worker_run_component value =
+  let buf = Buffer.create (String.length value) in
+  String.iter
+    (function
+      | ('A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-') as ch ->
+          Buffer.add_char buf ch
+      | _ -> ())
+    value;
+  let sanitized = Buffer.contents buf in
+  if sanitized = "" then "worker"
+  else if String.length sanitized <= 48 then sanitized
+  else String.sub sanitized 0 48
+
 let is_safe_worker_run_id value =
   let len = String.length value in
   len > 0
@@ -382,7 +394,45 @@ let is_safe_worker_run_id value =
          | _ -> false)
        value
 
-let persist_worker_run_proof_if_present ~(config : Room.config)
+let fallback_worker_run_id ~(fallback_name : string) =
+  Printf.sprintf "swarm-%s-%Ld"
+    (sanitize_worker_run_component fallback_name)
+    (Int64.of_float (Time_compat.now () *. 1000.0))
+
+let valid_worker_run_id_opt ~(label : string) value_opt =
+  match value_opt with
+  | Some value when is_safe_worker_run_id value -> Some value
+  | Some value ->
+      Log.Session.warn
+        "team_session_oas_bridge: ignoring unsafe %s %S" label value;
+      None
+  | None -> None
+
+let worker_run_id_of_artifacts ~(fallback_name : string)
+    ~(trace_ref : Oas.Raw_trace.run_ref option)
+    (proof_opt : Oas.Cdal_proof.t option) =
+  let trace_worker_run_id =
+    valid_worker_run_id_opt ~label:"trace_ref.worker_run_id"
+      (Option.map
+         (fun (trace : Oas.Raw_trace.run_ref) -> trace.worker_run_id)
+         trace_ref)
+  in
+  let proof_run_id =
+    valid_worker_run_id_opt ~label:"proof.run_id"
+      (Option.map (fun (proof : Oas.Cdal_proof.t) -> proof.run_id) proof_opt)
+  in
+  match trace_worker_run_id, proof_run_id with
+  | Some trace_worker_run_id, Some proof_run_id
+    when not (String.equal trace_worker_run_id proof_run_id) ->
+      Log.Session.warn
+        "team_session_oas_bridge: worker_run_id mismatch trace=%s proof=%s; using trace worker_run_id"
+        trace_worker_run_id proof_run_id;
+      trace_worker_run_id
+  | Some worker_run_id, _ -> worker_run_id
+  | None, Some worker_run_id -> worker_run_id
+  | None, None -> fallback_worker_run_id ~fallback_name
+
+let persist_worker_run_artifacts ~(config : Room.config)
     ~(session_id : string)
     ~(fallback_name : string)
     ~(planned_worker : Team_session_types.planned_worker)
@@ -392,130 +442,169 @@ let persist_worker_run_proof_if_present ~(config : Room.config)
     ~(output_preview : string option)
     ~(error : string option)
     (proof_opt : Oas.Cdal_proof.t option) =
-  match proof_opt with
-  | None -> ()
-  | Some proof ->
-      if not (is_safe_worker_run_id proof.run_id) then
-        Log.Session.warn
-          "team_session_oas_bridge: skipping proof persistence for unsafe worker run id %S"
-          proof.run_id
-      else
-        let effective_execution_scope =
-          Team_session_types.effective_execution_scope_of_planned_worker
-            planned_worker
-        in
-        let tool_surface_masc_names =
-          supported_local_worker_tool_names_for_scope
-            (Some effective_execution_scope)
-          |> Team_session_types.dedup_strings |> List.sort String.compare
-        in
-        let tool_surface_names =
-          Team_session_types.dedup_strings
-            (proof.capability_snapshot.tools @ tool_surface_masc_names)
-          |> List.sort String.compare
-        in
-        let tool_surface_status =
-          if tool_surface_names <> [] then `String "available" else `String "missing"
-        in
-        let tool_surface_source =
-          if tool_surface_names <> [] then `String "swarm_masc_tools" else `Null
-        in
-        let worker_run_id = proof.run_id in
-        let worker_name =
-          worker_name_of_planned_worker ~fallback:fallback_name planned_worker
-        in
+  let worker_run_id =
+    worker_run_id_of_artifacts ~fallback_name ~trace_ref proof_opt
+  in
+  let effective_execution_scope =
+    Team_session_types.effective_execution_scope_of_planned_worker
+      planned_worker
+  in
+  let tool_surface_masc_names =
+    supported_local_worker_tool_names_for_scope
+      (Some effective_execution_scope)
+    |> Team_session_types.dedup_strings |> List.sort String.compare
+  in
+  let proof_tool_names =
+    match proof_opt with
+    | Some proof -> proof.capability_snapshot.tools
+    | None -> []
+  in
+  let tool_surface_names =
+    Team_session_types.dedup_strings
+      (proof_tool_names @ tool_surface_masc_names)
+    |> List.sort String.compare
+  in
+  let tool_surface_status =
+    if tool_surface_names <> [] then `String "available" else `String "missing"
+  in
+  let tool_surface_source =
+    if tool_surface_names <> [] then `String "swarm_masc_tools" else `Null
+  in
+  let worker_name =
+    worker_name_of_planned_worker ~fallback:fallback_name planned_worker
+  in
+  let proof_fields =
+    let null_fields =
+      [
+        ("cdal_run_id", `Null);
+        ("contract_id", `Null);
+        ("requested_execution_mode", `Null);
+        ("effective_execution_mode", `Null);
+        ("risk_class", `Null);
+        ("result_status", `Null);
+        ("tool_trace_refs", `List []);
+        ("raw_evidence_refs", `List []);
+        ("checkpoint_ref", `Null);
+        ("proof_path", `Null);
+        ("proof_present", `Bool false);
+        ("proof_run_id", `Null);
+        ("proof_status", `Null);
+        ("proof_risk_class", `Null);
+        ("proof_execution_mode", `Null);
+        ("proof_evidence_count", `Null);
+      ]
+    in
+    match proof_opt with
+    | Some proof when is_safe_worker_run_id proof.run_id ->
         let proof_path =
           Team_session_store.worker_run_proof_path config session_id worker_run_id
         in
         Team_session_store.save_worker_run_proof_json config session_id
           worker_run_id (Oas.Cdal_proof.to_json proof);
-        Team_session_store.save_worker_run_meta_json config session_id
-          worker_run_id
-          (`Assoc
-            [
-              ("worker_run_id", `String worker_run_id);
-              ("worker_name", `String worker_name);
-              ("mode", `String "swarm");
-              ("status", `String (if success then "completed" else "failed"));
-              ("wait_mode", `String "background");
-              ( "trace_capability",
-                `String
-                  (if Option.is_some trace_ref then "raw" else "summary_only")
-              );
-              ("success", `Bool success);
-              ( "execution_scope",
-                Option.fold ~none:`Null
-                  ~some:(fun scope ->
-                    `String
-                      (Team_session_types.execution_scope_to_string scope))
-                  planned_worker.execution_scope );
-              ("tool_surface_status", tool_surface_status);
-              ("tool_surface_source", tool_surface_source);
-              ( "tool_surface_names",
-                `List
-                  (List.map (fun value -> `String value) tool_surface_names)
-              );
-              ( "tool_surface_masc_names",
-                `List
-                  (List.map
-                     (fun value -> `String value)
-                     tool_surface_masc_names) );
-              ("tool_surface_shell_names", `List []);
-              ( "requested_worker_class",
-                Option.fold ~none:`Null
-                  ~some:(fun kind ->
-                    `String
-                      (Team_session_types.worker_class_to_string kind))
-                  planned_worker.worker_class );
-              ("resolved_runtime", `String "oas_swarm");
-              ( "resolved_model",
-                Option.fold ~none:`Null ~some:(fun value -> `String value)
-                  resolved_model );
-              ( "routing_reason",
-                Option.fold ~none:`Null ~some:(fun value -> `String value)
-                  planned_worker.routing_reason );
-              ( "output_preview",
-                Option.fold ~none:`Null ~some:(fun value -> `String value)
-                  output_preview );
-              ("error", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
-              ( "trace_ref",
-                Option.fold ~none:`Null ~some:trace_ref_to_json trace_ref );
-              ("trace_summary", `Null);
-              ("trace_validation", `Null);
-              ("evidence_session_id", `Null);
-              ("oas_worker_run", `Null);
-              ("session_conformance", `Null);
-              ("validated", `Null);
-              ("final_text", Option.fold ~none:`Null ~some:(fun value -> `String value) output_preview);
-              ("stop_reason", `Null);
-              ("failure_reason", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
-              ("ts_iso", `String (Types.now_iso ()));
-              ("cdal_run_id", `String proof.run_id);
-              ("contract_id", `String proof.contract_id);
-              ( "requested_execution_mode",
-                `String
-                  (Oas.Execution_mode.to_string proof.requested_execution_mode)
-              );
-              ( "effective_execution_mode",
-                `String
-                  (Oas.Execution_mode.to_string proof.effective_execution_mode)
-              );
-              ("risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
-              ("result_status", `String (proof_result_status_to_string proof.result_status));
-              ( "tool_trace_refs",
-                `List
-                  (List.map (fun ref_ -> `String ref_) proof.tool_trace_refs)
-              );
-              ( "raw_evidence_refs",
-                `List
-                  (List.map (fun ref_ -> `String ref_) proof.raw_evidence_refs)
-              );
-              ( "checkpoint_ref",
-                Option.fold ~none:`Null ~some:(fun ref_ -> `String ref_)
-                  proof.checkpoint_ref );
-              ("proof_path", `String proof_path);
-              ("proof_present", `Bool true);
-            ])
+        [
+          ("cdal_run_id", `String proof.run_id);
+          ("contract_id", `String proof.contract_id);
+          ( "requested_execution_mode",
+            `String
+              (Oas.Execution_mode.to_string proof.requested_execution_mode)
+          );
+          ( "effective_execution_mode",
+            `String
+              (Oas.Execution_mode.to_string proof.effective_execution_mode)
+          );
+          ("risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
+          ("result_status", `String (proof_result_status_to_string proof.result_status));
+          ( "tool_trace_refs",
+            `List
+              (List.map (fun ref_ -> `String ref_) proof.tool_trace_refs)
+          );
+          ( "raw_evidence_refs",
+            `List
+              (List.map (fun ref_ -> `String ref_) proof.raw_evidence_refs)
+          );
+          ( "checkpoint_ref",
+            Option.fold ~none:`Null ~some:(fun ref_ -> `String ref_)
+              proof.checkpoint_ref );
+          ("proof_path", `String proof_path);
+          ("proof_present", `Bool true);
+          ("proof_run_id", `String proof.run_id);
+          ("proof_status", `String (proof_result_status_to_string proof.result_status));
+          ("proof_risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
+          ( "proof_execution_mode",
+            `String
+              (Oas.Execution_mode.to_string proof.effective_execution_mode)
+          );
+          ("proof_evidence_count", `Int (List.length proof.raw_evidence_refs));
+        ]
+    | Some proof ->
+        Log.Session.warn
+          "team_session_oas_bridge: skipping proof persistence for unsafe worker run id %S"
+          proof.run_id;
+        null_fields
+    | None -> null_fields
+  in
+  Team_session_store.save_worker_run_meta_json config session_id
+    worker_run_id
+    (`Assoc
+      ([
+        ("worker_run_id", `String worker_run_id);
+        ("worker_name", `String worker_name);
+        ("mode", `String "swarm");
+        ("status", `String (if success then "completed" else "failed"));
+        ("wait_mode", `String "background");
+        ( "trace_capability",
+          `String
+            (if Option.is_some trace_ref then "raw" else "summary_only")
+        );
+        ("success", `Bool success);
+        ( "execution_scope",
+          Option.fold ~none:`Null
+            ~some:(fun scope ->
+              `String
+                (Team_session_types.execution_scope_to_string scope))
+            planned_worker.execution_scope );
+        ("tool_surface_status", tool_surface_status);
+        ("tool_surface_source", tool_surface_source);
+        ( "tool_surface_names",
+          `List
+            (List.map (fun value -> `String value) tool_surface_names)
+        );
+        ( "tool_surface_masc_names",
+          `List
+            (List.map
+               (fun value -> `String value)
+               tool_surface_masc_names) );
+        ("tool_surface_shell_names", `List []);
+        ( "requested_worker_class",
+          Option.fold ~none:`Null
+            ~some:(fun kind ->
+              `String
+                (Team_session_types.worker_class_to_string kind))
+            planned_worker.worker_class );
+        ("resolved_runtime", `String "oas_swarm");
+        ( "resolved_model",
+          Option.fold ~none:`Null ~some:(fun value -> `String value)
+            resolved_model );
+        ( "routing_reason",
+          Option.fold ~none:`Null ~some:(fun value -> `String value)
+            planned_worker.routing_reason );
+        ( "output_preview",
+          Option.fold ~none:`Null ~some:(fun value -> `String value)
+            output_preview );
+        ("error", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
+        ( "trace_ref",
+          Option.fold ~none:`Null ~some:trace_ref_to_json trace_ref );
+        ("trace_summary", `Null);
+        ("trace_validation", `Null);
+        ("evidence_session_id", `Null);
+        ("oas_worker_run", `Null);
+        ("session_conformance", `Null);
+        ("validated", `Null);
+        ("final_text", Option.fold ~none:`Null ~some:(fun value -> `String value) output_preview);
+        ("stop_reason", `Null);
+        ("failure_reason", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
+        ("ts_iso", `String (Types.now_iso ()));
+      ] @ proof_fields))
 
 let make_convergence_metric ~(entry_count : int)
     (success_by_agent : (string, bool) Hashtbl.t) :
@@ -676,7 +765,7 @@ let planned_worker_to_entry_with_state
         let proof_opt =
           match result.proof with Some _ as proof -> proof | None -> !proof_ref
         in
-        persist_worker_run_proof_if_present ~config ~session_id
+        persist_worker_run_artifacts ~config ~session_id
           ~fallback_name:name ~planned_worker:pw
           ~resolved_model:(Some result.response.model)
           ~trace_ref:result.trace_ref ~success:true ~output_preview
@@ -686,7 +775,7 @@ let planned_worker_to_entry_with_state
         let e_str = Oas.Error.to_string err in
         Hashtbl.replace success_by_agent name false;
         telemetry_ref := Swarm.Swarm_types.empty_telemetry;
-        persist_worker_run_proof_if_present ~config ~session_id
+        persist_worker_run_artifacts ~config ~session_id
           ~fallback_name:name ~planned_worker:pw ~resolved_model:None
           ~trace_ref:None ~success:false
           ~output_preview:(preview_text_opt e_str) ~error:(Some e_str) !proof_ref;
@@ -822,11 +911,10 @@ let apply_swarm_result
   : Team_session_types.session =
   let final_status, stop_reason = final_outcome_of_swarm_result result in
   let now = Time_compat.now () in
+  let iteration_turns = List.length result.iterations in
   { session with
     status = final_status;
-    turn_count = session.turn_count +
-      List.fold_left (fun acc (r : Swarm.Swarm_types.iteration_record) ->
-        acc + List.length r.agent_results) 0 result.iterations;
+    turn_count = session.turn_count + iteration_turns;
     stopped_at = Some now;
     last_event_at = Some now;
     updated_at_iso = Types.now_iso ();

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -383,6 +383,8 @@ let sanitize_worker_run_component value =
   else if String.length sanitized <= 48 then sanitized
   else String.sub sanitized 0 48
 
+let fallback_worker_run_seq = Atomic.make 0
+
 let is_safe_worker_run_id value =
   let len = String.length value in
   len > 0
@@ -395,9 +397,11 @@ let is_safe_worker_run_id value =
        value
 
 let fallback_worker_run_id ~(fallback_name : string) =
-  Printf.sprintf "swarm-%s-%Ld"
+  let seq = Atomic.fetch_and_add fallback_worker_run_seq 1 in
+  Printf.sprintf "swarm-%s-%Ld-%d"
     (sanitize_worker_run_component fallback_name)
     (Int64.of_float (Time_compat.now () *. 1000.0))
+    seq
 
 let valid_worker_run_id_opt ~(label : string) value_opt =
   match value_opt with

--- a/lib/team_session/team_session_report_core.ml
+++ b/lib/team_session/team_session_report_core.ml
@@ -268,7 +268,7 @@ let mcp_improvements (session : Team_session_types.session) events checkpoints_c
   in
   let with_turns =
     if session.turn_count > 0 then
-      "Turn-level orchestration evidence exists via team_turn session events."
+      "Turn-level orchestration evidence exists in the session history."
       :: with_fallback
     else with_fallback
   in
@@ -703,7 +703,7 @@ let markdown_of_report ~(session : Team_session_types.session)
       "## Communication/Cascade Metrics";
       Printf.sprintf "- Broadcast count: %d" broadcast_count;
       Printf.sprintf "- Portal signal count: %d" portal_count;
-      Printf.sprintf "- Recorded turns: %d" turn_count;
+      Printf.sprintf "- Recorded orchestration turns: %d" turn_count;
       Printf.sprintf "- Alerts emitted: %d" alert_count;
       Printf.sprintf "- Cascade attempted: %d" cascade_attempted;
       Printf.sprintf "- Cascade failed: %d" cascade_failed;

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -510,28 +510,30 @@ let read_events ?max_events config session_id : Yojson.Safe.t list =
 let write_checkpoint config session_id (checkpoint : Team_session_types.checkpoint) =
   let filename = Printf.sprintf "%Ld.json" (Int64.of_float (checkpoint.ts *. 1000.0)) in
   let path = Filename.concat (checkpoints_dir config session_id) filename in
-  write_json config path (Team_session_types.checkpoint_to_yojson checkpoint);
+  with_file_lock config path (fun () ->
+      write_json config path (Team_session_types.checkpoint_to_yojson checkpoint));
   notify_team_session_mutation config ~session_id
 
 let save_worker_run_json config session_id worker_run_id json =
   let path = worker_run_json_path config session_id worker_run_id in
-  write_json config path json;
+  with_file_lock config path (fun () -> write_json config path json);
   notify_team_session_mutation config ~session_id
 
 let save_worker_run_checkpoint_text config session_id worker_run_id content =
   let path = worker_run_checkpoint_path config session_id worker_run_id in
-  write_text_file path content;
+  with_file_lock config path (fun () -> write_text_file path content);
   notify_team_session_mutation config ~session_id
 
 let save_worker_run_meta_json config session_id worker_run_id json =
   let path = worker_run_meta_path config session_id worker_run_id in
-  write_json config path
-    (normalize_worker_run_meta_json config ~session_id ~worker_run_id json);
+  with_file_lock config path (fun () ->
+      write_json config path
+        (normalize_worker_run_meta_json config ~session_id ~worker_run_id json));
   notify_team_session_mutation config ~session_id
 
 let save_worker_run_proof_json config session_id worker_run_id json =
   let path = worker_run_proof_path config session_id worker_run_id in
-  write_json config path json;
+  with_file_lock config path (fun () -> write_json config path json);
   notify_team_session_mutation config ~session_id
 
 let immediate_dir_entries config dir =

--- a/lib/team_session/team_session_store.ml
+++ b/lib/team_session/team_session_store.ml
@@ -145,10 +145,14 @@ let write_artifact_text config path content =
 let append_artifact_text config path content =
   Room_utils.append_text config path content
 
+let notify_team_session_mutation config ~session_id =
+  !Room_hooks.on_team_session_mutation_fn config ~session_id
+
 let save_session config (session : Team_session_types.session) =
   let path = session_json_path config session.session_id in
   with_file_lock config path (fun () ->
-      write_json config path (Team_session_types.session_to_yojson session))
+      write_json config path (Team_session_types.session_to_yojson session));
+  notify_team_session_mutation config ~session_id:session.session_id
 
 let load_session config session_id : Team_session_types.session option =
   let path = session_json_path config session_id in
@@ -212,18 +216,33 @@ let trace_ref_json_session_worker ~session_id ~worker_run_id json =
              (option_or_else (fun () -> Some session_id)
                 (json_string_member_opt "session_id" json))
         |> assoc_put_opt_string "worker_run_id"
-             (json_string_member_opt "worker_run_id" json
+                (json_string_member_opt "worker_run_id" json
              |> option_or_else (fun () -> Some worker_run_id)))
   | _ -> json
 
+let trace_ref_json_of_json json =
+  match U.member "trace_ref" json with
+  | `Assoc _ as trace_ref -> Some trace_ref
+  | _ -> (
+      match U.member "telemetry" json with
+      | `Assoc _ as telemetry -> (
+          match U.member "trace_ref" telemetry with
+          | `Assoc _ as trace_ref -> Some trace_ref
+          | _ -> None)
+      | _ -> None)
+
+let worker_run_id_of_json json =
+  json_string_member_opt "worker_run_id" json
+  |> option_or_else (fun () ->
+         match trace_ref_json_of_json json with
+         | Some trace_ref -> json_string_member_opt "worker_run_id" trace_ref
+         | None -> None)
+
 let evidence_refs_of_json json =
-  let trace_ref_path =
-    match U.member "trace_ref" json with
-    | `Assoc _ as trace_ref -> (
-        match json_string_member_opt "path" trace_ref with
-        | Some path -> [ path ]
-        | None -> [])
-    | _ -> []
+  let worker_run_refs =
+    match worker_run_id_of_json json with
+    | Some worker_run_id -> [ "worker-run:" ^ worker_run_id ]
+    | None -> []
   in
   Team_session_types.dedup_strings
     (json_string_list_member "evidence_refs" json
@@ -233,7 +252,7 @@ let evidence_refs_of_json json =
     (match json_string_member_opt "checkpoint_ref" json with
     | Some value -> [ value ]
     | None -> [])
-    @ trace_ref_path)
+    @ worker_run_refs)
 
 let normalize_session_event_detail config ~session_id detail =
   let detail =
@@ -245,13 +264,7 @@ let normalize_session_event_detail config ~session_id detail =
     json_string_member_opt "operation_id" detail
     |> option_or_else (fun () -> operation_id_for_session config session_id)
   in
-  let worker_run_id =
-    json_string_member_opt "worker_run_id" detail
-    |> option_or_else (fun () ->
-           match U.member "trace_ref" detail with
-           | `Assoc _ as trace_ref -> json_string_member_opt "worker_run_id" trace_ref
-           | _ -> None)
-  in
+  let worker_run_id = worker_run_id_of_json detail in
   let evidence_refs = evidence_refs_of_json detail in
   match detail with
   | `Assoc fields ->
@@ -392,7 +405,8 @@ let append_event config session_id ~(event_type : string) ~(detail : Yojson.Safe
   let line = Yojson.Safe.to_string (Team_session_types.event_entry_to_yojson entry) ^ "\n" in
   let path = events_jsonl_path config session_id in
   with_file_lock config path (fun () -> append_artifact_text config path line);
-  emit_activity_event config ~session_id ~event_type ~detail
+  emit_activity_event config ~session_id ~event_type ~detail;
+  notify_team_session_mutation config ~session_id
 
 let take_last n lst =
   if n <= 0 then []
@@ -496,24 +510,29 @@ let read_events ?max_events config session_id : Yojson.Safe.t list =
 let write_checkpoint config session_id (checkpoint : Team_session_types.checkpoint) =
   let filename = Printf.sprintf "%Ld.json" (Int64.of_float (checkpoint.ts *. 1000.0)) in
   let path = Filename.concat (checkpoints_dir config session_id) filename in
-  write_json config path (Team_session_types.checkpoint_to_yojson checkpoint)
+  write_json config path (Team_session_types.checkpoint_to_yojson checkpoint);
+  notify_team_session_mutation config ~session_id
 
 let save_worker_run_json config session_id worker_run_id json =
   let path = worker_run_json_path config session_id worker_run_id in
-  write_json config path json
+  write_json config path json;
+  notify_team_session_mutation config ~session_id
 
 let save_worker_run_checkpoint_text config session_id worker_run_id content =
   let path = worker_run_checkpoint_path config session_id worker_run_id in
-  write_text_file path content
+  write_text_file path content;
+  notify_team_session_mutation config ~session_id
 
 let save_worker_run_meta_json config session_id worker_run_id json =
   let path = worker_run_meta_path config session_id worker_run_id in
   write_json config path
-    (normalize_worker_run_meta_json config ~session_id ~worker_run_id json)
+    (normalize_worker_run_meta_json config ~session_id ~worker_run_id json);
+  notify_team_session_mutation config ~session_id
 
 let save_worker_run_proof_json config session_id worker_run_id json =
   let path = worker_run_proof_path config session_id worker_run_id in
-  write_json config path json
+  write_json config path json;
+  notify_team_session_mutation config ~session_id
 
 let immediate_dir_entries config dir =
   Room_utils.list_dir config dir

--- a/lib/team_session/team_session_swarm_callbacks.ml
+++ b/lib/team_session/team_session_swarm_callbacks.ml
@@ -23,7 +23,6 @@ let trace_ref_to_json (trace_ref : Agent_sdk.Raw_trace.run_ref) =
   `Assoc
     [
       ("worker_run_id", `String trace_ref.worker_run_id);
-      ("path", `String trace_ref.path);
       ("start_seq", `Int trace_ref.start_seq);
       ("end_seq", `Int trace_ref.end_seq);
       ("agent_name", `String trace_ref.agent_name);
@@ -97,6 +96,21 @@ let make_callbacks ~(config : Room.config) ~(session_id : string)
       | Working -> ("working", 0.0, "", Swarm.Swarm_types.empty_telemetry)
       | Idle -> ("idle", 0.0, "", Swarm.Swarm_types.empty_telemetry)
     in
+    let trace_ref =
+      match telemetry.trace_ref with
+      | Some trace_ref -> trace_ref_to_json trace_ref
+      | None -> `Null
+    in
+    let worker_run_id =
+      match telemetry.trace_ref with
+      | Some trace_ref -> `String trace_ref.worker_run_id
+      | None -> `Null
+    in
+    let evidence_refs =
+      match telemetry.trace_ref with
+      | Some trace_ref -> `List [ `String ("worker-run:" ^ trace_ref.worker_run_id) ]
+      | None -> `List []
+    in
     Team_session_store.append_event config session_id
       ~event_type:"swarm_agent_done"
       ~detail:(`Assoc [
@@ -104,6 +118,9 @@ let make_callbacks ~(config : Room.config) ~(session_id : string)
         ("status", `String status_str);
         ("elapsed", `Float elapsed);
         ("output_preview", `String output_preview);
+        ("worker_run_id", worker_run_id);
+        ("trace_ref", trace_ref);
+        ("evidence_refs", evidence_refs);
         ("telemetry", telemetry_to_json telemetry);
       ])
   in

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -69,6 +69,44 @@ let test_invalidate () =
   Alcotest.(check int) "recompute after invalidate" 2 !counter;
   check_json "new value" (`Int 2) v
 
+let test_invalidate_prefix () =
+  Dashboard_cache.invalidate_all ();
+  let proof_counter = ref 0 in
+  let mission_counter = ref 0 in
+  ignore
+    (Dashboard_cache.get_or_compute "proof:room-a:default:one" ~ttl:5.0
+       (fun () ->
+         incr proof_counter;
+         `Int !proof_counter));
+  ignore
+    (Dashboard_cache.get_or_compute "proof:room-a:default:two" ~ttl:5.0
+       (fun () ->
+         incr proof_counter;
+         `Int !proof_counter));
+  ignore
+    (Dashboard_cache.get_or_compute "mission:room-a:default:one" ~ttl:5.0
+       (fun () ->
+         incr mission_counter;
+         `Int !mission_counter));
+  Dashboard_cache.invalidate_prefix "proof:room-a:default:";
+  ignore
+    (Dashboard_cache.get_or_compute "proof:room-a:default:one" ~ttl:5.0
+       (fun () ->
+         incr proof_counter;
+         `Int !proof_counter));
+  ignore
+    (Dashboard_cache.get_or_compute "proof:room-a:default:two" ~ttl:5.0
+       (fun () ->
+         incr proof_counter;
+         `Int !proof_counter));
+  ignore
+    (Dashboard_cache.get_or_compute "mission:room-a:default:one" ~ttl:5.0
+       (fun () ->
+         incr mission_counter;
+         `Int !mission_counter));
+  Alcotest.(check int) "proof entries recomputed" 4 !proof_counter;
+  Alcotest.(check int) "non-matching prefix preserved" 1 !mission_counter
+
 (* -- 5. Stats reports active + computing ------------------------------------ *)
 
 let test_stats () =
@@ -272,6 +310,7 @@ let () =
         [
           test_case "cache hit" `Quick test_cache_hit;
           test_case "invalidate" `Quick test_invalidate;
+          test_case "invalidate_prefix" `Quick test_invalidate_prefix;
           test_case "stats" `Quick test_stats;
           test_case "exception recovery" `Quick test_exception_recovery;
           test_case "invalidate_all wakes waiters" `Quick

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -22,6 +22,9 @@ let cleanup_dir dir =
   in
   rm dir
 
+let request target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
+
 let sample_session ?(min_agents = 2) ?(agent_names = [ "worker-a"; "worker-b" ]) now session_id =
   let open Team_session_types in
   {
@@ -306,6 +309,46 @@ let seed_worker_run_meta config session_id =
             ] );
       ])
 
+let seed_raw_only_worker_run_meta config session_id =
+  Lib.Team_session_store.save_worker_run_meta_json config session_id
+    "wr-raw-only"
+    (`Assoc
+      [
+        ("worker_run_id", `String "wr-raw-only");
+        ("worker_name", `String "worker-raw");
+        ("status", `String "completed");
+        ("mode", `String "swarm");
+        ("wait_mode", `String "background");
+        ("trace_capability", `String "raw");
+        ("success", `Bool true);
+        ("proof_present", `Bool false);
+        ("proof_run_id", `Null);
+        ("proof_status", `Null);
+        ("proof_risk_class", `Null);
+        ("proof_execution_mode", `Null);
+        ("proof_evidence_count", `Null);
+        ("resolved_runtime", `String "oas_swarm");
+        ("resolved_model", `String "glm:auto");
+        ("output_preview", `String "Raw trace completed without proof.");
+        ( "trace_ref",
+          `Assoc
+            [
+              ("worker_run_id", `String "wr-raw-only");
+              ("start_seq", `Int 1);
+              ("end_seq", `Int 4);
+              ("agent_name", `String "worker-raw");
+              ("session_id", `String session_id);
+            ] );
+        ("trace_summary", `Null);
+        ("trace_validation", `Null);
+        ("tool_surface_status", `String "available");
+        ("tool_surface_source", `String "swarm_masc_tools");
+        ("tool_surface_names", `List [ `String "masc_status" ]);
+        ("tool_surface_masc_names", `List [ `String "masc_status" ]);
+        ("tool_surface_shell_names", `List []);
+        ("ts_iso", `String "2026-04-08T00:00:00Z");
+      ])
+
 let test_dashboard_proof_projection () =
   let dir = test_dir () in
   Fun.protect
@@ -416,6 +459,111 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         ((worker_proof |> U.member "proof_path") = `Null);
       check bool "worker proof evidence meta path hidden" true
         ((worker_proof |> U.member "meta_path") = `Null))
+
+let test_dashboard_proof_exposes_raw_only_worker_run_evidence () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      let session_id = "ts-proof-raw-only-worker-run" in
+      seed_session_artifacts config session_id;
+      seed_raw_only_worker_run_meta config session_id;
+      let json = Lib.Dashboard_proof.json ~config ~session_id () in
+      check int "raw trace run count" 1
+        (json |> U.member "summary" |> U.member "raw_trace_run_count" |> U.to_int);
+      let worker_proofs = json |> U.member "worker_proof_evidence" |> U.to_list in
+      check int "worker proof evidence absent without proof" 0
+        (List.length worker_proofs);
+      let worker_runs = json |> U.member "worker_run_evidence" |> U.to_list in
+      check int "worker run evidence count" 1 (List.length worker_runs);
+      let worker = List.hd worker_runs in
+      check string "worker run id" "wr-raw-only"
+        (worker |> U.member "worker_run_id" |> U.to_string);
+      check string "output preview surfaced" "Raw trace completed without proof."
+        (worker |> U.member "output_preview" |> U.to_string);
+      check bool "proof_present false preserved" false
+        (worker |> U.member "proof_present" |> U.to_bool);
+      check bool "proof run id omitted in summary" true
+        (worker |> U.member "proof_run_id" = `Null))
+
+let test_dashboard_proof_http_cache_isolation_by_selection () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let session_a = "ts-proof-cache-a" in
+      let session_b = "ts-proof-cache-b" in
+      Eio_main.run @@ fun env ->
+      Eio_guard.enable ();
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      seed_session_artifacts config session_a;
+      seed_session_artifacts config session_b;
+      Lib.Dashboard_cache.invalidate_all ();
+      let state =
+        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir ()
+      in
+      let json_a =
+        Lib.Server_dashboard_http.dashboard_proof_http_json
+          ~state
+          (request
+             "/api/v1/dashboard/proof?session_id=ts-proof-cache-a&operation_id=op-cache-a")
+      in
+      let json_b =
+        Lib.Server_dashboard_http.dashboard_proof_http_json
+          ~state
+          (request
+             "/api/v1/dashboard/proof?session_id=ts-proof-cache-b&operation_id=op-cache-b")
+      in
+      let open Yojson.Safe.Util in
+      check string "first selection keeps session a" session_a
+        (json_a |> member "session_id" |> to_string);
+      check string "first selection keeps operation a" "op-cache-a"
+        (json_a |> member "operation_id" |> to_string);
+      check string "second selection keeps session b" session_b
+        (json_b |> member "session_id" |> to_string);
+      check string "second selection keeps operation b" "op-cache-b"
+        (json_b |> member "operation_id" |> to_string))
+
+let test_dashboard_proof_http_cache_invalidates_on_worker_run_write () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let session_id = "ts-proof-cache-refresh" in
+      Eio_main.run @@ fun env ->
+      Eio_guard.enable ();
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      seed_session_artifacts config session_id;
+      Lib.Dashboard_cache.invalidate_all ();
+      let state =
+        Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir ()
+      in
+      let proof_request =
+        request ("/api/v1/dashboard/proof?session_id=" ^ session_id)
+      in
+      let json_before =
+        Lib.Server_dashboard_http.dashboard_proof_http_json ~state
+          proof_request
+      in
+      check int "initial worker run evidence empty" 0
+        (json_before |> U.member "worker_run_evidence" |> U.to_list
+        |> List.length);
+      seed_raw_only_worker_run_meta config session_id;
+      let json_after =
+        Lib.Server_dashboard_http.dashboard_proof_http_json ~state
+          proof_request
+      in
+      check int "worker run evidence refreshed after write" 1
+        (json_after |> U.member "worker_run_evidence" |> U.to_list
+        |> List.length))
 
 let test_dashboard_proof_prefers_attached_session_operation_id () =
   let dir = test_dir () in
@@ -707,6 +855,12 @@ let () =
           test_case "builds collaboration proof projection" `Quick test_dashboard_proof_projection;
           test_case "exposes validated worker run evidence" `Quick
             test_dashboard_proof_exposes_validated_worker_run_evidence;
+          test_case "exposes raw-only worker run evidence" `Quick
+            test_dashboard_proof_exposes_raw_only_worker_run_evidence;
+          test_case "http cache isolates proof selections" `Quick
+            test_dashboard_proof_http_cache_isolation_by_selection;
+          test_case "http cache refreshes after worker run write" `Quick
+            test_dashboard_proof_http_cache_invalidates_on_worker_run_write;
           test_case "prefers attached session operation id" `Quick
             test_dashboard_proof_prefers_attached_session_operation_id;
           test_case "projects worker proof metadata into session proof" `Quick

--- a/test/test_team_session_swarm_runner.ml
+++ b/test/test_team_session_swarm_runner.ml
@@ -146,9 +146,25 @@ let test_agent_done_event_includes_telemetry () =
   Alcotest.(check string) "trace ref worker_run_id" "run-telemetry"
     (detail |> member "telemetry" |> member "trace_ref"
      |> member "worker_run_id" |> to_string);
+  Alcotest.(check string) "top-level worker_run_id" "run-telemetry"
+    (detail |> member "worker_run_id" |> to_string);
+  Alcotest.(check string) "top-level trace ref worker_run_id" "run-telemetry"
+    (detail |> member "trace_ref" |> member "worker_run_id" |> to_string);
+  Alcotest.(check bool) "trace path omitted from event detail" true
+    (detail |> member "trace_ref" |> member "path" = `Null);
+  Alcotest.(check (list string)) "evidence refs use worker-run ref"
+    [ "worker-run:run-telemetry" ]
+    (detail |> member "evidence_refs" |> to_list |> List.map to_string);
   Alcotest.(check int) "usage api_calls" 2
     (detail |> member "telemetry" |> member "usage" |> member "api_calls"
-     |> to_int)
+     |> to_int);
+  Alcotest.(check (option string)) "proof events parse agent from swarm callback"
+    (Some "agent-a") (Dashboard_proof_events.event_actor event);
+  Alcotest.(check (option string)) "proof events parse output preview"
+    (Some "completed")
+    (Dashboard_proof_events.event_output_preview event);
+  Alcotest.(check string) "proof events use output preview in summary"
+    "completed" (Dashboard_proof_events.event_summary event)
 
 (* ================================================================ *)
 (* apply_swarm_result tests                                         *)
@@ -231,8 +247,66 @@ let test_apply_partial_result () =
   let updated = Team_session_oas_bridge.apply_swarm_result session result in
   Alcotest.(check string) "status interrupted"
     "interrupted" (Team_session_types.status_to_string updated.status);
+  Alcotest.(check int) "turn_count increments by iteration count" 1
+    updated.turn_count;
   Alcotest.(check string) "stop_reason partial"
     "swarm_partial_completion" (Option.get updated.stop_reason)
+
+let test_apply_result_counts_iterations_as_turns () =
+  let session = { (make_test_session "s-turns") with turn_count = 4 } in
+  let result : Swarm.Swarm_types.swarm_result = {
+    iterations = [
+      {
+        Swarm.Swarm_types.iteration = 1;
+        metric_value = Some 0.2;
+        agent_results = [
+          ( "agent-1",
+            Swarm.Swarm_types.Done_ok
+              {
+                elapsed = 0.8;
+                text = "done";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+          ( "agent-2",
+            Swarm.Swarm_types.Done_ok
+              {
+                elapsed = 0.9;
+                text = "done";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+        ];
+        elapsed = 1.8;
+        timestamp = Time_compat.now ();
+        trace_refs = [];
+      };
+      {
+        Swarm.Swarm_types.iteration = 2;
+        metric_value = Some 0.4;
+        agent_results = [
+          ( "agent-1",
+            Swarm.Swarm_types.Done_ok
+              {
+                elapsed = 1.0;
+                text = "done";
+                telemetry = Swarm.Swarm_types.empty_telemetry;
+              } );
+        ];
+        elapsed = 1.0;
+        timestamp = Time_compat.now ();
+        trace_refs = [];
+      };
+    ];
+    final_metric = Some 0.4;
+    converged = false;
+    total_elapsed = 2.8;
+    total_usage = { Agent_sdk.Types.total_input_tokens = 0;
+      total_output_tokens = 0; total_cache_creation_input_tokens = 0;
+      total_cache_read_input_tokens = 0; api_calls = 0;
+      estimated_cost_usd = 0.0 };
+  } in
+  let updated = Team_session_oas_bridge.apply_swarm_result session result in
+  Alcotest.(check int) "turn_count adds iteration count, not agent results" 6
+    updated.turn_count
 
 let test_apply_all_agents_failed_result () =
   let session = make_test_session "s-all-failed" in
@@ -409,6 +483,8 @@ let () =
         test_apply_exhausted_result;
       Alcotest.test_case "partial result" `Quick
         test_apply_partial_result;
+      Alcotest.test_case "counts iterations as turns" `Quick
+        test_apply_result_counts_iterations_as_turns;
       Alcotest.test_case "all agents failed result" `Quick
         test_apply_all_agents_failed_result;
       Alcotest.test_case "updates stopped_at" `Quick


### PR DESCRIPTION
## What changed
- persist Fleet worker-run metadata even when proof is absent, and normalize worker-run correlation fields so session events, worker evidence, and dashboard projections join cleanly
- hide raw trace path leakage from public telemetry payloads and surface `output_preview` plus raw-only worker evidence in proof/mission summaries
- add short proof HTTP caching with room/session/operation-scoped keys, plus mutation-driven cache invalidation so proof and mission surfaces refresh immediately after team-session writes
- align `turn_count` semantics with session orchestration turns instead of agent-result fanout, and update the team-session spec/report wording accordingly

## Why
Fleet telemetry was dropping raw-only runs, making proof evidence incomplete and correlation unnecessarily hard. The proof surface also relied on TTL-only freshness, so newly written worker-run evidence could remain stale for a short window.

## Impact
- raw trace runs without proof now remain visible in dashboard proof evidence
- Fleet completion events carry stable `worker_run_id`/`evidence_refs` joins
- proof reads refresh immediately after session or worker-run writes instead of waiting for cache expiry
- session `turn_count` is now consistent with orchestration-level turns

## Validation
- `dune runtest --root . test/test_dashboard_cache.exe test/test_dashboard_proof.exe test/test_dashboard_mission.exe test/test_team_session_swarm_runner.exe test/test_team_session_oas_bridge.exe test/test_worker_run_evidence_summary.exe`

## Root cause
Fleet persistence only wrote worker-run metadata when proof existed, while event normalization and dashboard summaries assumed correlation/evidence fields would always be present. Proof HTTP responses also lacked mutation-aware cache invalidation.