### PR TITLE
[codex] fix dashboard keeper telemetry health projection

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -169,6 +169,7 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     | None -> name
   in
   let audit = tool_audit_snapshot agent_name in
+  let agent = member_assoc "agent" keeper in
   let status = string_field ~default:"unknown" "status" keeper in
   let context_ratio =
     match member_assoc "context_ratio" keeper with
@@ -180,17 +181,23 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     trim_to_option (string_field "last_autonomous_action_at" keeper)
   in
   let last_heartbeat_at =
-    trim_to_option (string_field "updated_at" keeper)
+    latest_iso_timestamp
+      [
+        trim_to_option (string_field "updated_at" keeper);
+        trim_to_option (string_field "last_seen" agent);
+        audit.tool_audit_at;
+      ]
   in
-  let last_signal_at =
-    match last_action_at with
-    | Some _ -> last_action_at
-    | None -> last_heartbeat_at
-  in
+  let last_signal_at = latest_iso_timestamp [ last_action_at; last_heartbeat_at ] in
   let last_action_ts = parse_iso_opt last_action_at |> Option.value ~default:0.0 in
   let last_signal_ts = parse_iso_opt last_signal_at |> Option.value ~default:0.0 in
   let last_action_age_s =
     if last_action_ts > 0.0 then max 0.0 (now_ts -. last_action_ts)
+    else infinity
+  in
+  let effective_activity_age_s =
+    if last_action_ts > 0.0 then last_action_age_s
+    else if last_signal_ts > 0.0 then max 0.0 (now_ts -. last_signal_ts)
     else infinity
   in
   let autonomous_action_count = int_field "autonomous_action_count" keeper in
@@ -218,9 +225,9 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
     else if autonomous_turn_count = 0 && turn_count > 0 then
       ("warning", Tone_warn,
        Printf.sprintf "자율 턴 없음 (턴 %d회 수행)" turn_count)
-    else if last_action_age_s >= keeper_action_stale_sec then
+    else if effective_activity_age_s >= keeper_action_stale_sec then
       ("warning", Tone_warn,
-       Printf.sprintf "마지막 행동 %.0f시간 전" (last_action_age_s /. 3600.0))
+       Printf.sprintf "마지막 활동 %.0f시간 전" (effective_activity_age_s /. 3600.0))
     else
       ("healthy", Tone_ok, "정상 동작 중")
   in

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -130,6 +130,23 @@ let compact_text ?(max_len = 160) raw =
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 let string_list_of_json = Dashboard_utils.string_list_of_json
 
+let latest_iso_timestamp values =
+  let pick_latest best candidate =
+    match candidate with
+    | None -> best
+    | Some candidate -> (
+        match parse_iso_opt (Some candidate) with
+        | None -> best
+        | Some candidate_ts -> (
+            match best with
+            | Some (best_value, best_ts) when best_ts >= candidate_ts ->
+                Some (best_value, best_ts)
+            | _ -> Some (candidate, candidate_ts)))
+  in
+  values
+  |> List.fold_left pick_latest None
+  |> Option.map fst
+
 let string_list_json values =
   `List (List.map (fun value -> `String value) values)
 

--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -29,23 +29,22 @@ type room_snapshot = {
 
 (* ===== ISO Timestamp Parsing (moved here to break cycle) ===== *)
 
-(** Parse ISO timestamp to Unix time (UTC) *)
+(** Parse dashboard timestamps as UTC.
+    Dashboard surfaces mostly emit whole-second ISO8601 timestamps, but a few
+    read models still append fractional seconds. Strip the fractional suffix so
+    we stay aligned with the canonical UTC parser used elsewhere in the repo. *)
 let parse_iso_timestamp (s : string) : float option =
-  try
-    let open Scanf in
-    sscanf s "%d-%d-%dT%d:%d:%d" (fun y m d h min sec ->
-      let tm = {
-        Unix.tm_sec = sec; tm_min = min; tm_hour = h;
-        tm_mday = d; tm_mon = m - 1; tm_year = y - 1900;
-        tm_wday = 0; tm_yday = 0; tm_isdst = false
-      } in
-      let (local_t, _) = Unix.mktime tm in
-      let utc_tm = Unix.gmtime local_t in
-      let (utc_as_local, _) = Unix.mktime utc_tm in
-      let tz_offset = local_t -. utc_as_local in
-      Some (local_t -. tz_offset)
-    )
-  with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
+  let normalized =
+    let trimmed = String.trim s in
+    let len = String.length trimmed in
+    if len = 0 then None
+    else
+      match String.index_opt trimmed '.' with
+      | Some dot when dot > 0 && trimmed.[len - 1] = 'Z' ->
+          Some (String.sub trimmed 0 dot ^ "Z")
+      | _ -> Some trimmed
+  in
+  Option.bind normalized Types.parse_iso8601_opt
 
 let format_elapsed now timestamp fallback =
   match parse_iso_timestamp timestamp with

--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -29,22 +29,120 @@ type room_snapshot = {
 
 (* ===== ISO Timestamp Parsing (moved here to break cycle) ===== *)
 
-(** Parse dashboard timestamps as UTC.
-    Dashboard surfaces mostly emit whole-second ISO8601 timestamps, but a few
-    read models still append fractional seconds. Strip the fractional suffix so
-    we stay aligned with the canonical UTC parser used elsewhere in the repo. *)
+(** Parse dashboard timestamps to Unix time.
+    Accepts canonical UTC timestamps, fractional-second RFC3339 variants,
+    numeric UTC offsets, and bare local timestamps from older read models. *)
 let parse_iso_timestamp (s : string) : float option =
-  let normalized =
-    let trimmed = String.trim s in
-    let len = String.length trimmed in
+  let is_digit c = c >= '0' && c <= '9' in
+  let all_digits raw =
+    let len = String.length raw in
+    len > 0 && String.for_all is_digit raw
+  in
+  let parse_tz_offset raw =
+    let len = String.length raw in
     if len = 0 then None
     else
-      match String.index_opt trimmed '.' with
-      | Some dot when dot > 0 && trimmed.[len - 1] = 'Z' ->
-          Some (String.sub trimmed 0 dot ^ "Z")
-      | _ -> Some trimmed
+      let sign =
+        match raw.[0] with
+        | '+' -> 1
+        | '-' -> -1
+        | _ -> 0
+      in
+      if sign = 0 then None
+      else
+        match len with
+        | 6 when raw.[3] = ':' ->
+            let hh = String.sub raw 1 2 in
+            let mm = String.sub raw 4 2 in
+            if all_digits hh && all_digits mm then
+              Some (sign * ((int_of_string hh * 3600) + (int_of_string mm * 60)))
+            else
+              None
+        | 5 ->
+            let hh = String.sub raw 1 2 in
+            let mm = String.sub raw 3 2 in
+            if all_digits hh && all_digits mm then
+              Some (sign * ((int_of_string hh * 3600) + (int_of_string mm * 60)))
+            else
+              None
+        | _ -> None
   in
-  Option.bind normalized Types.parse_iso8601_opt
+  let split_timezone raw =
+    let len = String.length raw in
+    if len = 0 then None
+    else
+      match raw.[len - 1] with
+      | 'Z' | 'z' -> Some (String.sub raw 0 (len - 1), Some 0)
+      | _ ->
+          let rec find idx =
+            if idx < 19 then None
+            else
+              match raw.[idx] with
+              | '+' | '-' -> Some idx
+              | _ -> find (idx - 1)
+          in
+          (match find (len - 1) with
+          | Some idx -> (
+              match parse_tz_offset (String.sub raw idx (len - idx)) with
+              | Some offset ->
+                  Some (String.sub raw 0 idx, Some offset)
+              | None -> None)
+          | None -> Some (raw, None))
+  in
+  let split_fraction raw =
+    match String.index_opt raw '.' with
+    | None -> Some (raw, 0.0)
+    | Some dot ->
+        let main = String.sub raw 0 dot in
+        let fraction = String.sub raw (dot + 1) (String.length raw - dot - 1) in
+        if String.length main <> 19 || not (all_digits fraction) then None
+        else Some (main, float_of_string ("0." ^ fraction))
+  in
+  let parse_main raw =
+    if String.length raw <> 19 then None
+    else
+      try
+        Some
+          (Scanf.sscanf raw "%04d-%02d-%02dT%02d:%02d:%02d"
+             (fun year mon day hour min sec -> (year, mon, day, hour, min, sec)))
+      with
+      | Scanf.Scan_failure _ | Failure _ | End_of_file -> None
+  in
+  let trimmed = String.trim s in
+  if trimmed = "" then None
+  else
+    match split_timezone trimmed with
+    | None -> None
+    | Some (raw_main, source_offset_opt) -> (
+        match split_fraction raw_main with
+        | None -> None
+        | Some (main, fraction_s) -> (
+            match parse_main main with
+            | None -> None
+            | Some (year, mon, day, hour, min, sec) ->
+                let tm =
+                  {
+                    Unix.tm_sec = sec;
+                    tm_min = min;
+                    tm_hour = hour;
+                    tm_mday = day;
+                    tm_mon = mon - 1;
+                    tm_year = year - 1900;
+                    tm_wday = 0;
+                    tm_yday = 0;
+                    tm_isdst = false;
+                  }
+                in
+                let local_epoch, _ = Unix.mktime tm in
+                let utc_tm = Unix.gmtime local_epoch in
+                let utc_as_local, _ = Unix.mktime utc_tm in
+                let local_offset_s = local_epoch -. utc_as_local in
+                let source_offset_s =
+                  match source_offset_opt with
+                  | Some offset -> float_of_int offset
+                  | None -> local_offset_s
+                in
+                Some (local_epoch +. local_offset_s -. source_offset_s +. fraction_s)))
 
 let format_elapsed now timestamp fallback =
   match parse_iso_timestamp timestamp with

--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -67,6 +67,16 @@ let parse_iso_timestamp (s : string) : float option =
               None
         | _ -> None
   in
+  let parse_fraction_seconds raw =
+    if not (all_digits raw) then None
+    else
+      let numerator =
+        String.fold_left
+          (fun acc ch -> (acc *. 10.0) +. float_of_int (Char.code ch - Char.code '0'))
+          0.0 raw
+      in
+      Some (numerator /. (10.0 ** float_of_int (String.length raw)))
+  in
   let split_timezone raw =
     let len = String.length raw in
     if len = 0 then None
@@ -74,20 +84,15 @@ let parse_iso_timestamp (s : string) : float option =
       match raw.[len - 1] with
       | 'Z' | 'z' -> Some (String.sub raw 0 (len - 1), Some 0)
       | _ ->
-          let rec find idx =
-            if idx < 19 then None
-            else
-              match raw.[idx] with
-              | '+' | '-' -> Some idx
-              | _ -> find (idx - 1)
+          let suffix_opt width =
+            if len > width then Some (String.sub raw (len - width) width) else None
           in
-          (match find (len - 1) with
-          | Some idx -> (
-              match parse_tz_offset (String.sub raw idx (len - idx)) with
-              | Some offset ->
-                  Some (String.sub raw 0 idx, Some offset)
-              | None -> None)
-          | None -> Some (raw, None))
+          (match Option.bind (suffix_opt 6) parse_tz_offset with
+          | Some offset -> Some (String.sub raw 0 (len - 6), Some offset)
+          | None -> (
+              match Option.bind (suffix_opt 5) parse_tz_offset with
+              | Some offset -> Some (String.sub raw 0 (len - 5), Some offset)
+              | None -> Some (raw, None)))
   in
   let split_fraction raw =
     match String.index_opt raw '.' with
@@ -95,8 +100,8 @@ let parse_iso_timestamp (s : string) : float option =
     | Some dot ->
         let main = String.sub raw 0 dot in
         let fraction = String.sub raw (dot + 1) (String.length raw - dot - 1) in
-        if String.length main <> 19 || not (all_digits fraction) then None
-        else Some (main, float_of_string ("0." ^ fraction))
+        if String.length main <> 19 then None
+        else Option.map (fun fraction_s -> (main, fraction_s)) (parse_fraction_seconds fraction)
   in
   let parse_main raw =
     if String.length raw <> 19 then None

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -91,6 +91,31 @@ let json_float_opt key json =
   | `Int value -> Some (float_of_int value)
   | _ -> None
 
+let agent_status_text agent_status =
+  json_string_opt "status" agent_status
+  |> Option.value ~default:"unknown"
+  |> String.lowercase_ascii
+
+let agent_last_seen_ts_opt agent_status =
+  match json_string_opt "last_seen" agent_status with
+  | Some value -> Resilience.Time.parse_iso8601_opt value
+  | None -> None
+
+let agent_last_seen_ago_s agent_status =
+  json_float_opt "last_seen_ago_s" agent_status |> Option.value ~default:max_float
+
+let agent_runtime_has_live_signal agent_status =
+  match agent_status_text agent_status with
+  | "active" | "busy" | "listening" | "idle" ->
+      agent_last_seen_ago_s agent_status <= 120.0
+  | _ -> false
+
+let agent_runtime_has_live_work agent_status =
+  match agent_status_text agent_status with
+  | "active" | "busy" | "listening" ->
+      agent_last_seen_ago_s agent_status <= 120.0
+  | _ -> false
+
 let string_contains_ci haystack needle =
   let haystack = String.lowercase_ascii haystack in
   let needle = String.lowercase_ascii needle in
@@ -191,12 +216,24 @@ let keeper_error_hint ~agent_status ~meta =
 let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts =
   let quiet_active = quiet_hours_active () in
   let agent_exists = json_bool "exists" agent_status false in
-  let agent_status_text =
-    json_string_opt "status" agent_status
-    |> Option.value ~default:"unknown"
-    |> String.lowercase_ascii
+  let agent_status_text = agent_status_text agent_status in
+  let live_signal_supersedes_persisted_error =
+    keepalive_running
+    && agent_exists
+    && agent_runtime_has_live_signal agent_status
+    &&
+    match agent_last_seen_ts_opt agent_status with
+    | Some last_seen_ts ->
+        let persisted_error_ts =
+          max meta.runtime.proactive_rt.last_ts meta.runtime.usage.last_turn_ts
+        in
+        last_seen_ts > persisted_error_ts
+    | None -> false
   in
-  let error_hint = keeper_error_hint ~agent_status ~meta in
+  let error_hint =
+    if live_signal_supersedes_persisted_error then None
+    else keeper_error_hint ~agent_status ~meta
+  in
   if not meta.proactive.enabled then
     Some "disabled"
   else if not keepalive_running then
@@ -217,8 +254,10 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
     Some "quiet_hours"
   else
     match error_hint with
-    | Some reason when string_contains_ci reason "graphql" -> Some "graphql_error"
-    | Some reason when looks_error_like reason -> Some "model_error"
+    | Some reason when string_contains_ci reason "graphql" ->
+        Some "graphql_error"
+    | Some reason when looks_error_like reason ->
+        Some "model_error"
     | Some _ -> Some "unknown"
     | None ->
         let last_turn_ago_s =
@@ -229,12 +268,21 @@ let classify_keeper_quiet_reason ~meta ~keepalive_running ~agent_status ~now_ts 
           if meta.runtime.proactive_rt.last_ts <= 0.0 then None
           else Some (max 0.0 (now_ts -. meta.runtime.proactive_rt.last_ts))
         in
+        let effective_activity_ago_s =
+          match last_turn_ago_s with
+          | Some age when agent_runtime_has_live_work agent_status ->
+              Some (min age (agent_last_seen_ago_s agent_status))
+          | Some _ as age -> age
+          | None when agent_runtime_has_live_work agent_status ->
+              Some (agent_last_seen_ago_s agent_status)
+          | None -> None
+        in
         if meta.proactive.enabled then
           match last_proactive_ago_s with
           | Some age when age < float_of_int meta.proactive.cooldown_sec ->
               Some "min_gap"
           | _ -> (
-              match last_turn_ago_s with
+              match effective_activity_ago_s with
               | Some age when age < float_of_int meta.proactive.idle_sec ->
                   Some "no_recent_activity"
               | _ -> None)
@@ -263,6 +311,12 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
     if meta.runtime.usage.last_turn_ts <= 0.0 then max_float
     else max 0.0 (now_ts -. meta.runtime.usage.last_turn_ts)
   in
+  let effective_activity_ago_s =
+    if agent_runtime_has_live_work agent_status then
+      min last_turn_ago_s last_seen_ago_s
+    else
+      last_turn_ago_s
+  in
   if not agent_exists || agent_status_text = "offline" || agent_status_text = "inactive"
   then "offline"
   (* H-4 fix: true zombies are stale regardless of keepalive state *)
@@ -280,7 +334,7 @@ let keeper_health_state ?(fiber_health = Fiber_unknown)
     | Some "graphql_error" | Some "model_error" -> "degraded"
     | _ ->
         if meta.runtime.usage.total_turns = 0 && meta.runtime.proactive_rt.count_total = 0 then "idle"
-        else if last_turn_ago_s > float_of_int (max meta.proactive.idle_sec 900)
+        else if effective_activity_ago_s > float_of_int (max meta.proactive.idle_sec 900)
         then "idle"
         else "healthy")
   (* Keepalive NOT running — fall back to last_seen for stale detection *)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -946,6 +946,16 @@ let dashboard_shell_timeout_s =
   float_of_env_default "MASC_DASHBOARD_SHELL_TIMEOUT_S"
     ~default:8.0 ~min_v:2.0 ~max_v:30.0
 
+let dashboard_shell_paths_json (config : Room.config) : Yojson.Safe.t =
+  Server_base_path_diagnostics.detect
+    ?input_base_path:(Env_config_core.base_path_opt ())
+    ?env_masc_base_path:(Env_config_core.base_path_opt ())
+    ?env_me_root:(Env_config_core.me_root_opt ())
+    ~effective_base_path:config.base_path
+    ~effective_masc_root:(Room.masc_root_dir config)
+    ()
+  |> Server_base_path_diagnostics.to_yojson
+
 let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
   let current_room = dashboard_current_room_id config in
   let canonical_namespace = Room.default_namespace_id in
@@ -970,6 +980,7 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
     [
       ("generated_at", `String (Types.now_iso ()));
       ("status", status_json);
+      ("paths", dashboard_shell_paths_json config);
       ( "counts",
         `Assoc
           [

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -126,19 +126,55 @@ let keepalive_running_of_lifecycle_event = function
   | "stopped" | "crashed" | "dead" -> Some false
   | _ -> None
 
-let patch_keeper_row ~keeper_name ~keepalive_running = function
+let phase_of_lifecycle_event = function
+  | "started" | "restarted" | "reconciled" -> Some "running"
+  | "stopped" -> Some "stopped"
+  | "crashed" -> Some "crashed"
+  | "dead" -> Some "dead"
+  | _ -> None
+
+let pipeline_stage_of_lifecycle_event = function
+  | "started" | "restarted" | "reconciled" -> Some "idle"
+  | "stopped" | "dead" -> Some "offline"
+  | "crashed" -> Some "crashed"
+  | _ -> None
+
+let patched_keeper_status row ~keepalive_running =
+  if not keepalive_running then
+    `String "offline"
+  else
+    match Yojson.Safe.Util.member "agent" row |> Yojson.Safe.Util.member "status" with
+    | `String (("busy" | "active" | "listening" | "idle") as status) ->
+        `String status
+    | `String ("offline" | "inactive") -> `String "offline"
+    | _ -> `String "idle"
+
+let patch_keeper_row ~keeper_name ~event ~keepalive_running = function
   | `Assoc fields as row -> (
       match Yojson.Safe.Util.member "name" row with
       | `String name when String.equal name keeper_name ->
           let row_fields : (string * Yojson.Safe.t) list = fields in
-          `Assoc
-            (row_fields
-            |> upsert_assoc_field "keepalive_running" (`Bool keepalive_running))
+          let row_fields =
+            row_fields
+            |> upsert_assoc_field "keepalive_running" (`Bool keepalive_running)
+            |> upsert_assoc_field "status" (patched_keeper_status row ~keepalive_running)
+          in
+          let row_fields =
+            match phase_of_lifecycle_event event with
+            | Some phase -> upsert_assoc_field "phase" (`String phase) row_fields
+            | None -> row_fields
+          in
+          let row_fields =
+            match pipeline_stage_of_lifecycle_event event with
+            | Some stage -> upsert_assoc_field "pipeline_stage" (`String stage) row_fields
+            | None -> row_fields
+          in
+          `Assoc row_fields
       | _ -> row)
   | other -> other
 
-let patch_keeper_rows ~keeper_name ~keepalive_running rows =
-  List.map (patch_keeper_row ~keeper_name ~keepalive_running) rows
+let patch_keeper_rows ~keeper_name ~event ~keepalive_running rows =
+  List.map (patch_keeper_row ~keeper_name ~event ~keepalive_running) rows
 
 let running_keeper_names (config : Room.config) =
   Keeper_types.keeper_names config
@@ -157,7 +193,8 @@ let patch_surface_json_for_running_keepers (config : Room.config) = function
         let patch_rows rows =
           List.fold_left
             (fun acc keeper_name ->
-              patch_keeper_rows ~keeper_name ~keepalive_running:true acc)
+              patch_keeper_rows ~keeper_name ~event:"reconciled"
+                ~keepalive_running:true acc)
             rows running
         in
         (match List.assoc_opt "keepers" fields with
@@ -177,7 +214,7 @@ let patch_surface_json_for_running_keepers (config : Room.config) = function
          | _ -> json)
   | other -> other
 
-let patch_execution_cache_for_keeper ~keeper_name ~keepalive_running =
+let patch_execution_cache_for_keeper ~keeper_name ~event ~keepalive_running =
   match _execution_cache.json with
   | `Assoc fields -> (
       match List.assoc_opt "keepers" fields with
@@ -185,12 +222,12 @@ let patch_execution_cache_for_keeper ~keeper_name ~keepalive_running =
           _execution_cache.json <-
             `Assoc
               (upsert_assoc_field "keepers"
-                 (`List (patch_keeper_rows ~keeper_name ~keepalive_running rows))
+                 (`List (patch_keeper_rows ~keeper_name ~event ~keepalive_running rows))
                  fields)
       | _ -> ())
   | _ -> ()
 
-let patch_operator_snapshot_cache_for_keeper ~keeper_name ~keepalive_running =
+let patch_operator_snapshot_cache_for_keeper ~keeper_name ~event ~keepalive_running =
   match _operator_snapshot_cache.json with
   | `Assoc fields -> (
       match List.assoc_opt "keepers" fields with
@@ -199,7 +236,7 @@ let patch_operator_snapshot_cache_for_keeper ~keeper_name ~keepalive_running =
           | Some (`List rows) ->
               let keeper_fields =
                 upsert_assoc_field "items"
-                  (`List (patch_keeper_rows ~keeper_name ~keepalive_running rows))
+                  (`List (patch_keeper_rows ~keeper_name ~event ~keepalive_running rows))
                   keeper_fields
               in
               _operator_snapshot_cache.json <-
@@ -213,8 +250,8 @@ let patch_keeper_dependent_caches ~keeper_name ~event =
   match keepalive_running_of_lifecycle_event event with
   | None -> ()
   | Some keepalive_running ->
-      patch_execution_cache_for_keeper ~keeper_name ~keepalive_running;
-      patch_operator_snapshot_cache_for_keeper ~keeper_name ~keepalive_running
+      patch_execution_cache_for_keeper ~keeper_name ~event ~keepalive_running;
+      patch_operator_snapshot_cache_for_keeper ~keeper_name ~event ~keepalive_running
 
 (** Late-bound broadcast hook. Set after [broadcast_namespace_truth_snapshot]
     is defined in [Server_dashboard_http_namespace_truth]. *)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -148,12 +148,15 @@ let test_dashboard_shell_http_json_includes_paths () =
   let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
   let open Yojson.Safe.Util in
   let paths = json |> member "paths" in
+  let effective_base_path = paths |> member "effective_base_path" |> to_string in
+  let effective_masc_root = paths |> member "effective_masc_root" |> to_string in
+  let expected_masc_root = Unix.realpath (Filename.concat config.base_path ".masc") in
   check bool "paths present" true
     (match paths with `Assoc _ -> true | _ -> false);
-  check bool "paths include effective_base_path" true
-    (match paths |> member "effective_base_path" with
-     | `String value -> String.length value > 0
-     | _ -> false);
+  check string "effective_base_path matches config" (Unix.realpath config.base_path)
+    effective_base_path;
+  check string "effective_masc_root matches config" expected_masc_root
+    effective_masc_root;
   check bool "paths include cwd" true
     (match paths |> member "cwd" with
      | `String value -> String.length value > 0

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -143,6 +143,22 @@ let test_run_dashboard_compute_without_pool_uses_isolated_pg_backend () =
         reused_shared_pool
   | Room_utils.Memory _ | Room_utils.FileSystem _ -> ()
 
+let test_dashboard_shell_http_json_includes_paths () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
+  let open Yojson.Safe.Util in
+  let paths = json |> member "paths" in
+  check bool "paths present" true
+    (match paths with `Assoc _ -> true | _ -> false);
+  check bool "paths include effective_base_path" true
+    (match paths |> member "effective_base_path" with
+     | `String value -> String.length value > 0
+     | _ -> false);
+  check bool "paths include cwd" true
+    (match paths |> member "cwd" with
+     | `String value -> String.length value > 0
+     | _ -> false)
+
 let () =
   run "dashboard_http_core"
     [
@@ -154,5 +170,7 @@ let () =
             test_run_dashboard_compute_without_pool_uses_isolated_pg_backend;
           test_case "pool uses executor domain" `Quick
             test_run_dashboard_compute_with_pool_uses_executor_domain;
+          test_case "shell payload includes paths diagnostics" `Quick
+            test_dashboard_shell_http_json_includes_paths;
         ] );
     ]

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -118,6 +118,18 @@ let test_parse_iso_timestamp_local_without_timezone_is_supported () =
   | None ->
       Alcotest.fail "expected dashboard parser to accept bare local timestamps"
 
+let test_parse_iso_timestamp_empty_rejected () =
+  Alcotest.(check (option (float 0.001))) "empty timestamps are rejected" None
+    (Lib.Dashboard_labels.parse_iso_timestamp "")
+
+let test_parse_iso_timestamp_garbage_rejected () =
+  Alcotest.(check (option (float 0.001))) "garbage timestamps are rejected" None
+    (Lib.Dashboard_labels.parse_iso_timestamp "garbage")
+
+let test_parse_iso_timestamp_partial_rejected () =
+  Alcotest.(check (option (float 0.001))) "partial timestamps are rejected" None
+    (Lib.Dashboard_labels.parse_iso_timestamp "2026-04-08")
+
 let test_idle_agent () =
   let now = Unix.gettimeofday () in
   let result =
@@ -324,6 +336,12 @@ let () =
             test_parse_iso_timestamp_fractional_offset_matches_utc);
           ("bare local timestamp", `Quick,
             test_parse_iso_timestamp_local_without_timezone_is_supported);
+          ("empty timestamp rejected", `Quick,
+            test_parse_iso_timestamp_empty_rejected);
+          ("garbage timestamp rejected", `Quick,
+            test_parse_iso_timestamp_garbage_rejected);
+          ("partial timestamp rejected", `Quick,
+            test_parse_iso_timestamp_partial_rejected);
           ("idle agent", `Quick, test_idle_agent);
           ("offline agent", `Quick, test_offline_agent);
         ] );

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -58,6 +58,19 @@ let test_parse_iso_timestamp_matches_canonical_utc () =
         (abs_float (actual -. expected) < 0.001)
   | _ -> Alcotest.fail "expected both parsers to accept UTC timestamp"
 
+let test_parse_iso_timestamp_fractional_utc_normalizes () =
+  let ts = "2026-04-08T12:38:15.123Z" in
+  match
+    Lib.Dashboard_labels.parse_iso_timestamp ts,
+    Types.parse_iso8601_opt "2026-04-08T12:38:15Z"
+  with
+  | Some actual, Some expected ->
+      Alcotest.(check bool) "fractional UTC normalizes to canonical parser" true
+        (abs_float (actual -. expected) < 0.001)
+  | _ ->
+      Alcotest.fail
+        "expected dashboard parser to normalize fractional UTC timestamp"
+
 let test_idle_agent () =
   let now = Unix.gettimeofday () in
   let result =
@@ -258,6 +271,7 @@ let () =
           ("working agent", `Quick, test_working_agent);
           ("stuck agent", `Quick, test_stuck_agent);
           ("utc parser matches canonical", `Quick, test_parse_iso_timestamp_matches_canonical_utc);
+          ("fractional utc normalizes", `Quick, test_parse_iso_timestamp_fractional_utc_normalizes);
           ("idle agent", `Quick, test_idle_agent);
           ("offline agent", `Quick, test_offline_agent);
         ] );

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -65,11 +65,58 @@ let test_parse_iso_timestamp_fractional_utc_normalizes () =
     Types.parse_iso8601_opt "2026-04-08T12:38:15Z"
   with
   | Some actual, Some expected ->
-      Alcotest.(check bool) "fractional UTC normalizes to canonical parser" true
-        (abs_float (actual -. expected) < 0.001)
+      Alcotest.(check bool) "fractional UTC keeps sub-second precision" true
+        (abs_float (actual -. (expected +. 0.123)) < 0.001)
   | _ ->
       Alcotest.fail
-        "expected dashboard parser to normalize fractional UTC timestamp"
+        "expected dashboard parser to preserve fractional UTC timestamp"
+
+let test_parse_iso_timestamp_offset_matches_utc () =
+  let ts = "2026-04-08T21:38:15+09:00" in
+  match
+    Lib.Dashboard_labels.parse_iso_timestamp ts,
+    Types.parse_iso8601_opt "2026-04-08T12:38:15Z"
+  with
+  | Some actual, Some expected ->
+      Alcotest.(check bool) "numeric offset normalizes to UTC" true
+        (abs_float (actual -. expected) < 0.001)
+  | _ -> Alcotest.fail "expected dashboard parser to accept timezone offsets"
+
+let test_parse_iso_timestamp_fractional_offset_matches_utc () =
+  let ts = "2026-04-08T21:38:15.250+09:00" in
+  match
+    Lib.Dashboard_labels.parse_iso_timestamp ts,
+    Types.parse_iso8601_opt "2026-04-08T12:38:15Z"
+  with
+  | Some actual, Some expected ->
+      Alcotest.(check bool) "fractional offset keeps sub-second precision" true
+        (abs_float (actual -. (expected +. 0.250)) < 0.001)
+  | _ ->
+      Alcotest.fail
+        "expected dashboard parser to preserve fractional timezone offsets"
+
+let test_parse_iso_timestamp_local_without_timezone_is_supported () =
+  let ts = "2026-04-08T12:38:15.125" in
+  match Lib.Dashboard_labels.parse_iso_timestamp ts with
+  | Some actual ->
+      let tm =
+        {
+          Unix.tm_sec = 15;
+          tm_min = 38;
+          tm_hour = 12;
+          tm_mday = 8;
+          tm_mon = 3;
+          tm_year = 126;
+          tm_wday = 0;
+          tm_yday = 0;
+          tm_isdst = false;
+        }
+      in
+      let expected, _ = Unix.mktime tm in
+      Alcotest.(check bool) "bare local timestamps stay parseable" true
+        (abs_float (actual -. (expected +. 0.125)) < 0.001)
+  | None ->
+      Alcotest.fail "expected dashboard parser to accept bare local timestamps"
 
 let test_idle_agent () =
   let now = Unix.gettimeofday () in
@@ -272,6 +319,11 @@ let () =
           ("stuck agent", `Quick, test_stuck_agent);
           ("utc parser matches canonical", `Quick, test_parse_iso_timestamp_matches_canonical_utc);
           ("fractional utc normalizes", `Quick, test_parse_iso_timestamp_fractional_utc_normalizes);
+          ("numeric offset normalizes", `Quick, test_parse_iso_timestamp_offset_matches_utc);
+          ("fractional offset normalizes", `Quick,
+            test_parse_iso_timestamp_fractional_offset_matches_utc);
+          ("bare local timestamp", `Quick,
+            test_parse_iso_timestamp_local_without_timezone_is_supported);
           ("idle agent", `Quick, test_idle_agent);
           ("offline agent", `Quick, test_offline_agent);
         ] );

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -47,6 +47,17 @@ let test_stuck_agent () =
        true
      with Not_found -> false)
 
+let test_parse_iso_timestamp_matches_canonical_utc () =
+  let ts = "2026-04-08T12:38:15Z" in
+  match
+    Lib.Dashboard_labels.parse_iso_timestamp ts,
+    Types.parse_iso8601_opt ts
+  with
+  | Some actual, Some expected ->
+      Alcotest.(check bool) "dashboard parser matches canonical UTC parser" true
+        (abs_float (actual -. expected) < 0.001)
+  | _ -> Alcotest.fail "expected both parsers to accept UTC timestamp"
+
 let test_idle_agent () =
   let now = Unix.gettimeofday () in
   let result =
@@ -246,6 +257,7 @@ let () =
         [
           ("working agent", `Quick, test_working_agent);
           ("stuck agent", `Quick, test_stuck_agent);
+          ("utc parser matches canonical", `Quick, test_parse_iso_timestamp_matches_canonical_utc);
           ("idle agent", `Quick, test_idle_agent);
           ("offline agent", `Quick, test_offline_agent);
         ] );

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -19,6 +19,13 @@ let make_meta ?(name = "keeper-exec-status-test")
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
 
+let iso_of_seconds_ago age_s =
+  let ts = Time_compat.now () -. age_s in
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
 let test_keeper_surface_status_preserves_live_agent_states () =
   let status =
     ES.keeper_surface_status
@@ -76,6 +83,7 @@ let make_agent_status ?(exists = true) ?(status = "active")
   `Assoc [
     ("exists", `Bool exists);
     ("status", `String status);
+    ("last_seen", `String (iso_of_seconds_ago last_seen_ago_s));
     ("last_seen_ago_s", `Float last_seen_ago_s);
     ("is_zombie", `Bool is_zombie);
   ]
@@ -168,6 +176,46 @@ let test_health_keepalive_not_running_not_stale_is_offline () =
   in
   check string "no keepalive + not stale → offline" "offline" health
 
+let test_diagnostic_ignores_stale_error_when_live_signal_is_newer () =
+  let now_ts = Time_compat.now () in
+  let base = make_meta () in
+  let stale_error_ts = now_ts -. 1800.0 in
+  let meta =
+    {
+      base with
+      updated_at = iso_of_seconds_ago 1800.0;
+      runtime =
+        {
+          base.runtime with
+          usage =
+            {
+              base.runtime.usage with
+              total_turns = 5;
+              last_turn_ts = stale_error_ts;
+            };
+          proactive_rt =
+            {
+              base.runtime.proactive_rt with
+              count_total = 5;
+              last_ts = stale_error_ts;
+              last_outcome = KT.Proactive_error;
+              last_reason =
+                "unified:error:Timeout: Execution cancelled after 300.0s";
+              last_preview = "Timeout: Execution cancelled after 300.0s";
+            };
+        };
+    }
+  in
+  let diagnostic =
+    ES.keeper_diagnostic_json ~meta ~keepalive_running:true
+      ~agent_status:(make_agent_status ~status:"busy" ~last_seen_ago_s:10.0 ())
+      ~history_items:[] ~now_ts
+  in
+  let open Yojson.Safe.Util in
+  check string "fresh live signal suppresses stale degraded status"
+    "healthy"
+    (diagnostic |> member "health_state" |> to_string)
+
 let () =
   run "keeper_exec_status"
     [
@@ -189,6 +237,8 @@ let () =
             test_health_keepalive_running_fresh_is_healthy;
           test_case "no keepalive + not stale → offline" `Quick
             test_health_keepalive_not_running_not_stale_is_offline;
+          test_case "fresh live signal suppresses stale error degradation" `Quick
+            test_diagnostic_ignores_stale_error_when_live_signal_is_newer;
         ] );
       ( "surface_status",
         [

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -167,6 +167,32 @@ let test_health_keepalive_running_fresh_is_healthy () =
   in
   check string "keepalive + fresh + turns → healthy" "healthy" health
 
+let test_health_keepalive_running_recent_live_signal_avoids_idle () =
+  let now_ts = Time_compat.now () in
+  let meta =
+    let base = make_meta () in
+    {
+      base with
+      runtime =
+        {
+          base.runtime with
+          usage =
+            {
+              base.runtime.usage with
+              total_turns = 5;
+              last_turn_ts = now_ts -. 3600.0;
+            };
+        };
+    }
+  in
+  let agent_status = make_agent_status ~status:"active" ~last_seen_ago_s:10.0 () in
+  let health =
+    ES.keeper_health_state ~meta ~keepalive_running:true
+      ~agent_status ~quiet_reason:None ~now_ts ()
+  in
+  check string "fresh live signal keeps keeper healthy despite stale last turn"
+    "healthy" health
+
 let test_health_keepalive_not_running_not_stale_is_offline () =
   let meta = make_meta () in
   let agent_status = make_agent_status ~last_seen_ago_s:50.0 () in
@@ -235,6 +261,8 @@ let () =
             test_health_zombie_overrides_keepalive;
           test_case "keepalive + fresh turns → healthy" `Quick
             test_health_keepalive_running_fresh_is_healthy;
+          test_case "keepalive + recent live signal avoids idle" `Quick
+            test_health_keepalive_running_recent_live_signal_avoids_idle;
           test_case "no keepalive + not stale → offline" `Quick
             test_health_keepalive_not_running_not_stale_is_offline;
           test_case "fresh live signal suppresses stale error degradation" `Quick


### PR DESCRIPTION
## What changed
- fixed dashboard label timestamp parsing so UTC `Z` timestamps do not produce false stuck ages
- exposed repo/base-path diagnostics in the shell dashboard payload
- made keeper health projection prefer fresh live agent signals over stale persisted error state
- made continuity briefs use the freshest keeper signal source instead of only persisted `updated_at`
- patched execution cache keeper lifecycle updates so autobooted keepers surface `phase`, `pipeline_stage`, and `status` immediately
- added regression coverage for dashboard label parsing, shell path telemetry, and keeper health classification

## Why
The dashboard was misreporting keeper health in two ways:
- stale UTC parsing could show false long-running stuck states
- execution/cache projections could keep freshly running keepers in `offline`/`inactive` after autoboot because persisted error or pre-autoboot cache state won over live signals

## Impact
- operators get repo-scoped path truth directly in dashboard telemetry
- keeper health/status is closer to real runtime state during recovery and autoboot
- continuity views no longer overstate inactivity when agent presence is fresh

## Root cause
Multiple dashboard projections trusted stale persisted fields more than live runtime signals, and execution cache patching only toggled `keepalive_running` without updating the visible phase/status fields.

## Validation
- `dune build --root . bin/main_eio.exe test/test_keeper_exec_status.exe test/test_dashboard_execution.exe`
- `./_build/default/test/test_keeper_exec_status.exe`
- `./_build/default/test/test_dashboard_execution.exe`
- live verification on repo-scoped server `http://127.0.0.1:9725/health`
- live verification on repo-scoped server `http://127.0.0.1:9725/api/v1/dashboard/execution`
