### PR TITLE
refactor(keeper): decompose keeper_agent_run.ml — extract telemetry + tool disclosure

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -483,6 +483,7 @@
    keeper_hooks_oas
    keeper_extend_turns
    keeper_llm_bridge
+   keeper_turn_telemetry
    keeper_agent_run
    keeper_world_observation
    keeper_unified_prompt

--- a/lib/dune
+++ b/lib/dune
@@ -652,6 +652,8 @@
   keeper_compact_policy
   keeper_rollover
   keeper_post_turn
+  keeper_tool_disclosure
+  keeper_turn_telemetry
   keeper_exec_context
   keeper_turn_session
   keeper_turn_setup

--- a/lib/dune
+++ b/lib/dune
@@ -483,6 +483,7 @@
    keeper_hooks_oas
    keeper_extend_turns
    keeper_llm_bridge
+   keeper_tool_disclosure
    keeper_turn_telemetry
    keeper_agent_run
    keeper_world_observation

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -73,110 +73,7 @@ type run_result =
   ; inference_telemetry : Agent_sdk.Types.inference_telemetry option
   }
 
-let keeper_tool_usage_snapshot ~base_path ~keeper_name : (string * int) list =
-  Keeper_registry.tool_usage_of ~base_path keeper_name
-  |> List.map (fun (tool_name, entry) -> tool_name, entry.Keeper_types.count)
-  |> List.sort (fun (left, _) (right, _) -> String.compare left right)
-;;
-
-let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) list)
-  : string list
-  =
-  let before_counts = Hashtbl.create 16 in
-  List.iter
-    (fun (tool_name, count) -> Hashtbl.replace before_counts tool_name count)
-    before;
-  after
-  |> List.concat_map (fun (tool_name, after_count) ->
-    let before_count =
-      Option.value ~default:0 (Hashtbl.find_opt before_counts tool_name)
-    in
-    List.init (max 0 (after_count - before_count)) (fun _ -> tool_name))
-;;
-
-let merge_reported_and_observed_tool_names
-      ~(reported_tool_names : string list)
-      ~(observed_tool_names : string list)
-  : string list
-  =
-  match observed_tool_names with
-  | [] -> reported_tool_names
-  | _ ->
-    let observed = Hashtbl.create 16 in
-    List.iter (fun tool_name -> Hashtbl.replace observed tool_name ()) observed_tool_names;
-    observed_tool_names
-    @ List.filter
-        (fun tool_name -> not (Hashtbl.mem observed tool_name))
-        reported_tool_names
-;;
-
-let normalize_response_text ~(text : string) ~(tool_names : string list) ()
-  : (string, string) result
-  =
-  let trimmed = String.trim text in
-  if trimmed <> ""
-  then Ok text
-  else (
-    match tool_names with
-    | [] -> Error "keeper turn completed with no textual reply"
-    | _ ->
-      Ok
-        (Printf.sprintf
-           "Completed without a textual reply. Tools used: %s."
-           (String.concat ", " tool_names)))
-;;
-
-let tool_query_text_of_user_message (text : string) : string =
-  let allowed_sections =
-    [ "### Pending Mentions"
-    ; "### Scope Messages"
-    ; "### Active Goals"
-    ; "### Namespace State"
-    ; "### Board Activity"
-    ; "### Actionable Routes"
-    ; "### Live Worktree Delta"
-    ]
-  in
-  let is_allowed_section section =
-    List.exists
-      (fun allowed -> String.starts_with ~prefix:allowed section)
-      allowed_sections
-  in
-  let lines = String.split_on_char '\n' text in
-  let rec loop current_section kept = function
-    | [] ->
-      let filtered = List.rev kept |> String.concat "\n" |> String.trim in
-      if filtered <> "" then filtered else String.trim text
-    | line :: rest ->
-      let trimmed = String.trim line in
-      let current_section =
-        if String.starts_with ~prefix:"### " trimmed
-        then Some trimmed
-        else current_section
-      in
-      let keep_line =
-        match current_section with
-        | None -> String.starts_with ~prefix:"## Current World State" trimmed
-        | Some section -> is_allowed_section section
-      in
-      if keep_line
-      then loop current_section (line :: kept) rest
-      else loop current_section kept rest
-  in
-  loop None [] lines
-;;
-
-let merge_tool_selection_boundary
-    ~(core : string list)
-    ~(deterministic_prefilter : string list)
-    ~(llm_selected : string list)
-    ~(discovered : string list) : string list =
-  let sorted_discovered = List.sort String.compare discovered in
-  let deterministic_floor =
-    Keeper_types.dedupe_keep_order
-      (core @ deterministic_prefilter @ sorted_discovered)
-  in
-  Keeper_types.dedupe_keep_order (deterministic_floor @ llm_selected)
+(* Tool selection & disclosure — extracted to Keeper_tool_disclosure (#5732) *)
 
 (* Deterministic selection floor size: keep the executable surface small
    enough for prompt budgets while still surfacing a handful of relevant
@@ -477,7 +374,7 @@ let run_turn
   let extend_turns_tool = Keeper_extend_turns.make ~agent_ref ~max_turns () in
   let tools = extend_turns_tool :: keeper_tools in
   let tool_usage_before =
-    keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
+    Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
   in
   (* Progressive tool disclosure via OAS Tool_selector.
      Delegates BM25 retrieval, confidence gating, fallback, and optional
@@ -990,7 +887,7 @@ let run_turn
               in
               let query_text =
                 (if String.trim last_user_text <> "" then last_user_text else user_message)
-                |> tool_query_text_of_user_message
+                |> Keeper_tool_disclosure.tool_query_text_of_user_message
               in
               let max_tools = max_tools_per_turn in
               let portal_ctx : Tool_portal.context = { config; agent_name = meta.name } in
@@ -1105,7 +1002,7 @@ let run_turn
                   | None -> []
                 in
                 let merged =
-                  merge_tool_selection_boundary
+                  Keeper_tool_disclosure.merge_tool_selection_boundary
                     ~core
                     ~deterministic_prefilter
                     ~llm_selected
@@ -1561,16 +1458,16 @@ let run_turn
            result.response.content
        in
        let tool_usage_after =
-         keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
+         Keeper_tool_disclosure.keeper_tool_usage_snapshot ~base_path:config.base_path ~keeper_name:meta.name
        in
        let observed_tool_names =
-         tool_usage_delta ~before:tool_usage_before ~after:tool_usage_after
+         Keeper_tool_disclosure.tool_usage_delta ~before:tool_usage_before ~after:tool_usage_after
        in
        let tool_names =
-         merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
+         Keeper_tool_disclosure.merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
        in
        let usage = Keeper_exec_context.usage_of_response result.response in
-       (match normalize_response_text ~text ~tool_names () with
+       (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
         | Error e -> Error (Oas.Error.Internal e)
         | Ok response_text ->
           (* Ensure every generation has a [STATE] block for continuity.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -224,112 +224,7 @@ let tool_index_entry_of_tool
   in
   Agent_sdk.Tool_index.{ name; description = t.schema.description; group; aliases }
 
-let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
-  let status_string =
-    Agent_sdk.Cdal_proof.show_result_status proof.result_status
-    |> fun raw ->
-    match String.rindex_opt raw '.' with
-    | Some idx when idx + 1 < String.length raw ->
-      String.sub raw (idx + 1) (String.length raw - idx - 1)
-    | _ -> raw |> String.lowercase_ascii
-  in
-  match proof.result_status with
-  | Agent_sdk.Cdal_proof.Completed ->
-    if Keeper_types_profile.keeper_debug
-    then
-      Log.Keeper.debug
-        "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
-        keeper_name
-        proof.run_id
-        (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
-        status_string
-        (List.length proof.raw_evidence_refs)
-  | _ ->
-    Log.Keeper.warn
-      "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
-      keeper_name
-      proof.run_id
-      (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
-      status_string
-      (List.length proof.raw_evidence_refs)
-;;
-
-let log_keeper_contract_verdict
-      ~(keeper_name : string)
-      (verdict : Cdal_types.contract_verdict)
-  =
-  match verdict.status with
-  | Cdal_types.Satisfied ->
-    if Keeper_types_profile.keeper_debug
-    then
-      Log.Keeper.debug
-        "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
-        keeper_name
-        (Cdal_types.contract_status_to_string verdict.status)
-        verdict.claim_scope
-        verdict.judgment_hash
-  | Cdal_types.Violated | Cdal_types.Inconclusive ->
-    Log.Keeper.warn
-      "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
-      keeper_name
-      (Cdal_types.contract_status_to_string verdict.status)
-      verdict.claim_scope
-      verdict.judgment_hash
-;;
-
-let log_keeper_friction
-      ~(keeper_name : string)
-      (fp : Cdal_friction_projection.friction_projection)
-  =
-  let blocked = fp.blocked_attempt_count in
-  let groups = List.length fp.blocked_attempt_groups in
-  let tripwires = List.length fp.review_tripwires in
-  if tripwires > 0
-  then
-    Log.Keeper.warn
-      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
-      keeper_name
-      blocked
-      groups
-      tripwires
-  else if blocked > 0 || groups > 0
-  then
-    Log.Keeper.debug
-      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
-      keeper_name
-      blocked
-      groups
-      tripwires
-  else if Keeper_types_profile.keeper_debug
-  then
-    Log.Keeper.debug
-      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
-      keeper_name
-      blocked
-      groups
-      tripwires
-;;
-
-let log_keeper_memory_write
-      ~(keeper_name : string)
-      ~(notes_written : int)
-      ~(kinds_written : string list)
-  =
-  if notes_written >= 10
-  then
-    Log.Keeper.info
-      "keeper:%s memory_write: %d notes, kinds=[%s]"
-      keeper_name
-      notes_written
-      (String.concat "," kinds_written)
-  else if Keeper_types_profile.keeper_debug
-  then
-    Log.Keeper.debug
-      "keeper:%s memory_write: %d notes, kinds=[%s]"
-      keeper_name
-      notes_written
-      (String.concat "," kinds_written)
-;;
+(* Post-turn telemetry logging — extracted to Keeper_turn_telemetry (#5732) *)
 
 (** Run a single keeper turn via OAS Agent.run().
 
@@ -1741,12 +1636,12 @@ let run_turn
           in
           (match result.proof with
            | Some p ->
-             log_keeper_proof ~keeper_name:meta.name p;
+             Keeper_turn_telemetry.log_keeper_proof ~keeper_name:meta.name p;
              let store = Agent_sdk.Proof_store.default_config in
              let outcome = Cdal_eval_v1.evaluate ~store p in
              let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
              Cdal_eval_v1.persist verdict;
-             log_keeper_contract_verdict ~keeper_name:meta.name verdict;
+             Keeper_turn_telemetry.log_keeper_contract_verdict ~keeper_name:meta.name verdict;
              (match outcome with
               | Cdal_eval_v1.Load_failure (err, _) ->
                 Log.Keeper.warn
@@ -1755,7 +1650,7 @@ let run_turn
                   (Cdal_loader.load_error_to_string err)
               | Cdal_eval_v1.Verdict (_, _) -> ());
              (match Cdal_eval_v1.friction_of_outcome outcome with
-              | Some fp -> log_keeper_friction ~keeper_name:meta.name fp
+              | Some fp -> Keeper_turn_telemetry.log_keeper_friction ~keeper_name:meta.name fp
               | None -> ())
            | None -> ());
           (* Post-turn deterministic memory write.
@@ -1771,7 +1666,7 @@ let run_turn
              in
              if notes_written > 0
              then
-               log_keeper_memory_write
+               Keeper_turn_telemetry.log_keeper_memory_write
                  ~keeper_name:meta.name
                  ~notes_written
                  ~kinds_written

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -1,0 +1,110 @@
+(** Keeper_tool_disclosure — tool selection, usage tracking, and response normalization.
+
+    Extracted from keeper_agent_run.ml as part of #5732 god-module split.
+    Contains helpers for tool usage snapshots, delta computation, response
+    validation, query text extraction, and tool selection boundary merging. *)
+
+let keeper_tool_usage_snapshot ~base_path ~keeper_name : (string * int) list =
+  Keeper_registry.tool_usage_of ~base_path keeper_name
+  |> List.map (fun (tool_name, entry) -> tool_name, entry.Keeper_types.count)
+  |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+;;
+
+let tool_usage_delta ~(before : (string * int) list) ~(after : (string * int) list)
+  : string list
+  =
+  let before_counts = Hashtbl.create 16 in
+  List.iter
+    (fun (tool_name, count) -> Hashtbl.replace before_counts tool_name count)
+    before;
+  after
+  |> List.concat_map (fun (tool_name, after_count) ->
+    let before_count =
+      Option.value ~default:0 (Hashtbl.find_opt before_counts tool_name)
+    in
+    List.init (max 0 (after_count - before_count)) (fun _ -> tool_name))
+;;
+
+let merge_reported_and_observed_tool_names
+      ~(reported_tool_names : string list)
+      ~(observed_tool_names : string list)
+  : string list
+  =
+  match observed_tool_names with
+  | [] -> reported_tool_names
+  | _ ->
+    let observed = Hashtbl.create 16 in
+    List.iter (fun tool_name -> Hashtbl.replace observed tool_name ()) observed_tool_names;
+    observed_tool_names
+    @ List.filter
+        (fun tool_name -> not (Hashtbl.mem observed tool_name))
+        reported_tool_names
+;;
+
+let normalize_response_text ~(text : string) ~(tool_names : string list) ()
+  : (string, string) result
+  =
+  let trimmed = String.trim text in
+  if trimmed <> ""
+  then Ok text
+  else (
+    match tool_names with
+    | [] -> Error "keeper turn completed with no textual reply"
+    | _ ->
+      Ok
+        (Printf.sprintf
+           "Completed without a textual reply. Tools used: %s."
+           (String.concat ", " tool_names)))
+;;
+
+let tool_query_text_of_user_message (text : string) : string =
+  let allowed_sections =
+    [ "### Pending Mentions"
+    ; "### Scope Messages"
+    ; "### Active Goals"
+    ; "### Namespace State"
+    ; "### Board Activity"
+    ; "### Actionable Routes"
+    ; "### Live Worktree Delta"
+    ]
+  in
+  let is_allowed_section section =
+    List.exists
+      (fun allowed -> String.starts_with ~prefix:allowed section)
+      allowed_sections
+  in
+  let lines = String.split_on_char '\n' text in
+  let rec loop current_section kept = function
+    | [] ->
+      let filtered = List.rev kept |> String.concat "\n" |> String.trim in
+      if filtered <> "" then filtered else String.trim text
+    | line :: rest ->
+      let trimmed = String.trim line in
+      let current_section =
+        if String.starts_with ~prefix:"### " trimmed
+        then Some trimmed
+        else current_section
+      in
+      let keep_line =
+        match current_section with
+        | None -> String.starts_with ~prefix:"## Current World State" trimmed
+        | Some section -> is_allowed_section section
+      in
+      if keep_line
+      then loop current_section (line :: kept) rest
+      else loop current_section kept rest
+  in
+  loop None [] lines
+;;
+
+let merge_tool_selection_boundary
+    ~(core : string list)
+    ~(deterministic_prefilter : string list)
+    ~(llm_selected : string list)
+    ~(discovered : string list) : string list =
+  let sorted_discovered = List.sort String.compare discovered in
+  let deterministic_floor =
+    Keeper_types.dedupe_keep_order
+      (core @ deterministic_prefilter @ sorted_discovered)
+  in
+  Keeper_types.dedupe_keep_order (deterministic_floor @ llm_selected)

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -1,0 +1,112 @@
+(** Keeper_turn_telemetry — post-turn observability logging.
+
+    Extracted from keeper_agent_run.ml as part of #5732 god-module split.
+    Contains logging helpers for CDAL proofs, contract verdicts, friction
+    projections, and memory-bank writes. *)
+
+let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
+  let status_string =
+    Agent_sdk.Cdal_proof.show_result_status proof.result_status
+    |> fun raw ->
+    match String.rindex_opt raw '.' with
+    | Some idx when idx + 1 < String.length raw ->
+      String.sub raw (idx + 1) (String.length raw - idx - 1)
+    | _ -> raw |> String.lowercase_ascii
+  in
+  match proof.result_status with
+  | Agent_sdk.Cdal_proof.Completed ->
+    if Keeper_types_profile.keeper_debug
+    then
+      Log.Keeper.debug
+        "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
+        keeper_name
+        proof.run_id
+        (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+        status_string
+        (List.length proof.raw_evidence_refs)
+  | _ ->
+    Log.Keeper.warn
+      "keeper:%s proof: run_id=%s mode=%s status=%s evidence_refs=%d"
+      keeper_name
+      proof.run_id
+      (Agent_sdk.Execution_mode.to_string proof.effective_execution_mode)
+      status_string
+      (List.length proof.raw_evidence_refs)
+;;
+
+let log_keeper_contract_verdict
+      ~(keeper_name : string)
+      (verdict : Cdal_types.contract_verdict)
+  =
+  match verdict.status with
+  | Cdal_types.Satisfied ->
+    if Keeper_types_profile.keeper_debug
+    then
+      Log.Keeper.debug
+        "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+        keeper_name
+        (Cdal_types.contract_status_to_string verdict.status)
+        verdict.claim_scope
+        verdict.judgment_hash
+  | Cdal_types.Violated | Cdal_types.Inconclusive ->
+    Log.Keeper.warn
+      "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+      keeper_name
+      (Cdal_types.contract_status_to_string verdict.status)
+      verdict.claim_scope
+      verdict.judgment_hash
+;;
+
+let log_keeper_friction
+      ~(keeper_name : string)
+      (fp : Cdal_friction_projection.friction_projection)
+  =
+  let blocked = fp.blocked_attempt_count in
+  let groups = List.length fp.blocked_attempt_groups in
+  let tripwires = List.length fp.review_tripwires in
+  if tripwires > 0
+  then
+    Log.Keeper.warn
+      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name
+      blocked
+      groups
+      tripwires
+  else if blocked > 0 || groups > 0
+  then
+    Log.Keeper.debug
+      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name
+      blocked
+      groups
+      tripwires
+  else if Keeper_types_profile.keeper_debug
+  then
+    Log.Keeper.debug
+      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      keeper_name
+      blocked
+      groups
+      tripwires
+;;
+
+let log_keeper_memory_write
+      ~(keeper_name : string)
+      ~(notes_written : int)
+      ~(kinds_written : string list)
+  =
+  if notes_written >= 10
+  then
+    Log.Keeper.info
+      "keeper:%s memory_write: %d notes, kinds=[%s]"
+      keeper_name
+      notes_written
+      (String.concat "," kinds_written)
+  else if Keeper_types_profile.keeper_debug
+  then
+    Log.Keeper.debug
+      "keeper:%s memory_write: %d notes, kinds=[%s]"
+      keeper_name
+      notes_written
+      (String.concat "," kinds_written)
+;;

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -204,7 +204,7 @@ let test_selection_boundary_preserves_deterministic_floor () =
   let deterministic_prefilter = ["keeper_fs_read"; "keeper_board_post"] in
   let llm_selected = ["keeper_board_post"] in
   let merged =
-    Keeper_agent_run.merge_tool_selection_boundary
+    Keeper_tool_disclosure.merge_tool_selection_boundary
       ~core:["keeper_context_status"]
       ~deterministic_prefilter
       ~llm_selected
@@ -233,7 +233,7 @@ let test_selection_boundary_preserves_deterministic_floor () =
 
 let test_selection_boundary_appends_llm_only_extras () =
   let merged =
-    Keeper_agent_run.merge_tool_selection_boundary
+    Keeper_tool_disclosure.merge_tool_selection_boundary
       ~core:["keeper_context_status"]
       ~deterministic_prefilter:["keeper_fs_read"]
       ~llm_selected:["keeper_bash"; "keeper_fs_read"; "keeper_board_post"]
@@ -267,14 +267,14 @@ let test_selection_boundary_sorts_discovered () =
   (* discovered arrives in Hashtbl.fold order (non-deterministic).
      merge_tool_selection_boundary must sort it for stable output. *)
   let merged_ab =
-    Keeper_agent_run.merge_tool_selection_boundary
+    Keeper_tool_disclosure.merge_tool_selection_boundary
       ~core:["core_tool"]
       ~deterministic_prefilter:[]
       ~llm_selected:[]
       ~discovered:["tool_b"; "tool_a"]
   in
   let merged_ba =
-    Keeper_agent_run.merge_tool_selection_boundary
+    Keeper_tool_disclosure.merge_tool_selection_boundary
       ~core:["core_tool"]
       ~deterministic_prefilter:[]
       ~llm_selected:[]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -4,6 +4,7 @@ module WO = Masc_mcp.Keeper_world_observation
 module UP = Masc_mcp.Keeper_unified_prompt
 module UT = Masc_mcp.Keeper_unified_turn
 module KAR = Masc_mcp.Keeper_agent_run
+module KTD = Masc_mcp.Keeper_tool_disclosure
 module KEC = Masc_mcp.Keeper_exec_context
 module KSM = Masc_mcp.Keeper_social_model
 module KD = Masc_mcp.Keeper_deliberation
@@ -1458,12 +1459,12 @@ let test_metrics_mixed_response () =
      in found)
 
 let test_normalize_response_text_passthrough () =
-  match KAR.normalize_response_text ~text:"All good." ~tool_names:[] () with
+  match KTD.normalize_response_text ~text:"All good." ~tool_names:[] () with
   | Ok text -> check string "keeps text" "All good." text
   | Error e -> fail ("unexpected error: " ^ e)
 
 let test_normalize_response_text_tool_only_synthesizes () =
-  match KAR.normalize_response_text
+  match KTD.normalize_response_text
           ~text:""
           ~tool_names:["keeper_board_post"; "keeper_board_comment"]
           ()
@@ -1486,7 +1487,7 @@ let test_normalize_response_text_tool_only_synthesizes () =
   | Error e -> fail ("unexpected error: " ^ e)
 
 let test_normalize_response_text_empty_without_tools_errors () =
-  match KAR.normalize_response_text ~text:"" ~tool_names:[] () with
+  match KTD.normalize_response_text ~text:"" ~tool_names:[] () with
   | Ok text -> fail ("expected error, got: " ^ text)
   | Error e ->
       check bool "error mentions textual reply" true
@@ -1518,7 +1519,7 @@ let test_tool_usage_delta_uses_registry_counts () =
   in
   check (list string) "delta tracks repeated calls"
     [ "keeper_fs_read"; "keeper_voice_agent"; "keeper_voice_agent" ]
-    (KAR.tool_usage_delta ~before ~after)
+    (KTD.tool_usage_delta ~before ~after)
 
 let test_tool_usage_delta_ignores_removed_tools () =
   let before =
@@ -1534,11 +1535,11 @@ let test_tool_usage_delta_ignores_removed_tools () =
   in
   check (list string) "no phantom tools when counts drop"
     []
-    (KAR.tool_usage_delta ~before ~after)
+    (KTD.tool_usage_delta ~before ~after)
 
 let test_merge_reported_and_observed_tool_names_preserves_synthetic_tools () =
   let merged =
-    KAR.merge_reported_and_observed_tool_names
+    KTD.merge_reported_and_observed_tool_names
       ~reported_tool_names:[ "keeper_board_post" ]
       ~observed_tool_names:[ "keeper_voice_agent"; "keeper_voice_agent" ]
   in
@@ -1553,7 +1554,7 @@ let test_tool_query_text_of_user_message_strips_continuity_noise () =
   let user_message =
     "## Current World State\n\n### Namespace State\n- Failed tasks: 5\n\n### Actionable Routes\n- Failed tasks: audit them with keeper_tasks_audit before deciding there is nothing meaningful to do.\n\n### Autonomous Trigger\n- Scheduler: scheduled autonomous keepalive turn.\n\n### Continuity\nDONE: 하트비트 갱신\nNEXT: 대기 유지\n\n### Live Worktree Delta\n<git_status_change>\n?? lib/example.ml\n</git_status_change>\n"
   in
-  let query = KAR.tool_query_text_of_user_message user_message in
+  let query = KTD.tool_query_text_of_user_message user_message in
   check bool "continuity heading stripped" false
     (contains_substring query "### Continuity");
   check bool "heartbeat residue stripped" false
@@ -1577,7 +1578,7 @@ let test_tool_query_text_of_user_message_keeps_counted_headers () =
     }
   in
   let _sys, user = UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs () in
-  let query = KAR.tool_query_text_of_user_message user in
+  let query = KTD.tool_query_text_of_user_message user in
   check bool "keeps counted pending mentions header" true
     (contains_substring query "### Pending Mentions (1)");
   check bool "keeps mention content" true
@@ -1774,7 +1775,7 @@ let test_normalize_override_passthrough () =
     "[tool_skipped] tool=keeper_bash source=keeper_hook code=keeper_deny \
      reason=tool%20is%20on%20the%20keeper%20deny%20list"
   in
-  match KAR.normalize_response_text
+  match KTD.normalize_response_text
           ~text:override_text
           ~tool_names:["keeper_bash"]
           ()


### PR DESCRIPTION
## Summary

- extract `keeper_tool_disclosure` and `keeper_turn_telemetry` out of `keeper_agent_run.ml`
- keep the new helper modules private in `lib/dune` so the library public surface does not grow accidentally
- update keeper test references to the extracted module locations

## Product impact

- Promise affected: `none/internal`
- User-visible change:
  Keeper execution behavior is unchanged; this is a refactor and library-surface cleanup only.

## Evidence

- `dune build --root . test/test_keeper_topk_llm.exe test/test_keeper_unified.exe`
- CI checks for the PR are green

## Review evidence

- owner review flagged missing `private_modules` entries for `keeper_tool_disclosure` and `keeper_turn_telemetry`
- fixed in follow-up commit `439870cf5`
- direct external GLM review evidence is posted in PR comments

## Future

Further extractions (`tool_indexing`, `run_hooks`) can follow in separate PRs.

## Linked issue

Refs #5732
