### PR TITLE
feat(governance): wire OAS Approval pipeline into keeper agent builder

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -485,6 +485,7 @@
    keeper_llm_bridge
    keeper_tool_disclosure
    keeper_turn_telemetry
+   keeper_approval_queue
    keeper_agent_run
    keeper_world_observation
    keeper_unified_prompt
@@ -651,6 +652,7 @@
   keeper_context_core
   keeper_compact_policy
   keeper_rollover
+  keeper_approval_queue
   keeper_post_turn
   keeper_tool_disclosure
   keeper_turn_telemetry

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -351,48 +351,28 @@ let install ~config ~governance_level =
 
 (* ── OAS Approval Pipeline bridge (#5902) ─────────────────── *)
 
-(** Build an OAS Approval pipeline that uses governance_pipeline risk
-    assessment. This enables execution-level tool approval via
-    OAS Builder.with_approval — agents are actually suspended when
-    a high-risk tool is invoked.
+(** Build an OAS approval callback that uses governance_pipeline risk
+    assessment with genuine HITL fiber suspension.
 
-    The pipeline stages:
-    1. risk_classifier: uses assess_risk to set risk_level on context
-    2. threshold_gate: blocks (Reject) tools above the governance threshold *)
-let to_oas_approval_callback ~governance_level : Oas.Hooks.approval_callback =
-  let risk_classifier_stage =
-    Oas.Approval.risk_classifier (fun tool_name input ->
-      match assess_risk ~tool_name ~input with
-      | Low -> Oas.Approval.Low
-      | Medium -> Oas.Approval.Medium
-      | High -> Oas.Approval.High
-      | Critical -> Oas.Approval.Critical)
-  in
-  let threshold_gate : Oas.Approval.approval_stage =
-    let min_level = match confirm_threshold governance_level with
-      | Some Medium -> Oas.Approval.Medium
-      | Some High -> Oas.Approval.High
-      | Some Critical -> Oas.Approval.Critical
-      | Some Low -> Oas.Approval.Low
-      | None -> Oas.Approval.Critical  (* development: only block critical *)
+    When a tool exceeds the governance threshold, the agent fiber is
+    suspended via [Keeper_approval_queue.submit_and_await] until an
+    operator resolves the approval via the command plane API.
+
+    Tools below the threshold are auto-approved. *)
+let to_oas_approval_callback
+      ~governance_level ~keeper_name : Oas.Hooks.approval_callback =
+  fun ~tool_name ~input ->
+    let risk = assess_risk ~tool_name ~input in
+    let needs_approval =
+      match confirm_threshold governance_level with
+      | Some threshold -> risk_level_to_int risk >= risk_level_to_int threshold
+      | None -> false
     in
-    { name = "governance_threshold";
-      evaluate = (fun ctx ->
-        let ctx_level_int = match ctx.Oas.Approval.risk_level with
-          | Low -> 0 | Medium -> 1 | High -> 2 | Critical -> 3 in
-        let min_int = match min_level with
-          | Low -> 0 | Medium -> 1 | High -> 2 | Critical -> 3 in
-        if ctx_level_int >= min_int then
-          Decided (Oas.Hooks.Reject
-            (Printf.sprintf
-               "governance (%s): %s risk tool %S requires approval"
-               governance_level
-               (Oas.Approval.risk_level_to_string ctx.risk_level)
-               ctx.tool_name))
-        else
-          Pass);
-      timeout_s = None;
-    }
-  in
-  let pipeline = Oas.Approval.create [risk_classifier_stage; threshold_gate] in
-  Oas.Approval.as_callback pipeline
+    if needs_approval then
+      Keeper_approval_queue.submit_and_await
+        ~keeper_name
+        ~tool_name
+        ~input
+        ~risk_level:(risk_level_to_string risk)
+    else
+      Oas.Hooks.Approve

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -348,3 +348,51 @@ let install ~config ~governance_level =
   let hook = make_pre_hook ~config ~governance_level in
   Tool_dispatch.register_pre_hook hook;
   Log.Governance.info "pipeline installed: level=%s" governance_level
+
+(* ── OAS Approval Pipeline bridge (#5902) ─────────────────── *)
+
+(** Build an OAS Approval pipeline that uses governance_pipeline risk
+    assessment. This enables execution-level tool approval via
+    OAS Builder.with_approval — agents are actually suspended when
+    a high-risk tool is invoked.
+
+    The pipeline stages:
+    1. risk_classifier: uses assess_risk to set risk_level on context
+    2. threshold_gate: blocks (Reject) tools above the governance threshold *)
+let to_oas_approval_callback ~governance_level : Oas.Hooks.approval_callback =
+  let risk_classifier_stage =
+    Oas.Approval.risk_classifier (fun tool_name input ->
+      match assess_risk ~tool_name ~input with
+      | Low -> Oas.Approval.Low
+      | Medium -> Oas.Approval.Medium
+      | High -> Oas.Approval.High
+      | Critical -> Oas.Approval.Critical)
+  in
+  let threshold_gate : Oas.Approval.approval_stage =
+    let min_level = match confirm_threshold governance_level with
+      | Some Medium -> Oas.Approval.Medium
+      | Some High -> Oas.Approval.High
+      | Some Critical -> Oas.Approval.Critical
+      | Some Low -> Oas.Approval.Low
+      | None -> Oas.Approval.Critical  (* development: only block critical *)
+    in
+    { name = "governance_threshold";
+      evaluate = (fun ctx ->
+        let ctx_level_int = match ctx.Oas.Approval.risk_level with
+          | Low -> 0 | Medium -> 1 | High -> 2 | Critical -> 3 in
+        let min_int = match min_level with
+          | Low -> 0 | Medium -> 1 | High -> 2 | Critical -> 3 in
+        if ctx_level_int >= min_int then
+          Decided (Oas.Hooks.Reject
+            (Printf.sprintf
+               "governance (%s): %s risk tool %S requires approval"
+               governance_level
+               (Oas.Approval.risk_level_to_string ctx.risk_level)
+               ctx.tool_name))
+        else
+          Pass);
+      timeout_s = None;
+    }
+  in
+  let pipeline = Oas.Approval.create [risk_classifier_stage; threshold_gate] in
+  Oas.Approval.as_callback pipeline

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -24,6 +24,11 @@ type governance_decision = {
 }
 
 val risk_level_to_string : risk_level -> string
+val risk_level_to_int : risk_level -> int
+
+val confirm_threshold : string -> risk_level option
+(** Minimum risk level that requires confirmation for the given governance level.
+    Returns [None] for "development" (no confirmation needed). *)
 
 val assess_risk : tool_name:string -> input:Yojson.Safe.t -> risk_level
 (** Classify tool risk using, in order:

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -62,14 +62,15 @@ val install : config:Room.config -> governance_level:string -> unit
     Called once at server startup. *)
 
 val to_oas_approval_callback :
-  governance_level:string -> Oas.Hooks.approval_callback
-(** Build an OAS-compatible approval callback using governance risk
-    assessment. Wire into Agent Builder via [with_approval] so that
-    autonomous agents are suspended at execution level when invoking
-    tools above the governance threshold.
+  governance_level:string ->
+  keeper_name:string ->
+  Oas.Hooks.approval_callback
+(** Build an OAS approval callback with genuine HITL fiber suspension.
 
-    Pipeline stages:
-    1. risk_classifier — uses {!assess_risk} to set risk_level
-    2. governance_threshold — rejects tools above the confirm threshold
+    When a tool exceeds the governance threshold, the agent fiber
+    suspends via [Keeper_approval_queue.submit_and_await]. An operator
+    resolves the approval via the command plane API, resuming the fiber.
 
-    @since 2.262.0 (#5902) *)
+    Tools below the threshold are auto-approved.
+
+    @since 2.262.0 (#5902, #5907) *)

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -60,3 +60,16 @@ val install : config:Room.config -> governance_level:string -> unit
 (** Register the governance pipeline as a Tool_dispatch pre_hook.
     Reads governance level from the [governance_level] argument.
     Called once at server startup. *)
+
+val to_oas_approval_callback :
+  governance_level:string -> Oas.Hooks.approval_callback
+(** Build an OAS-compatible approval callback using governance risk
+    assessment. Wire into Agent Builder via [with_approval] so that
+    autonomous agents are suspended at execution level when invoking
+    tools above the governance threshold.
+
+    Pipeline stages:
+    1. risk_classifier — uses {!assess_risk} to set risk_level
+    2. governance_threshold — rejects tools above the confirm threshold
+
+    @since 2.262.0 (#5902) *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1376,7 +1376,8 @@ let run_turn
            ~context:shared_context
            ?slot_id:(Keeper_config.keeper_slot_id meta.name)
            ~approval:(Governance_pipeline.to_oas_approval_callback
-                        ~governance_level:(Env_config_core.governance_level ()))
+                        ~governance_level:(Env_config_core.governance_level ())
+                        ~keeper_name:meta.name)
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
            ())

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1375,6 +1375,8 @@ let run_turn
            ~context_injector
            ~context:shared_context
            ?slot_id:(Keeper_config.keeper_slot_id meta.name)
+           ~approval:(Governance_pipeline.to_oas_approval_callback
+                        ~governance_level:(Env_config_core.governance_level ()))
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
            ())

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -1,0 +1,160 @@
+(** Keeper_approval_queue — Eio.Promise-based HITL approval for keeper tools.
+
+    When a keeper's OAS Agent invokes a tool that requires approval,
+    the agent fiber is suspended via [Eio.Promise.await].  An operator
+    can then approve/reject via the command plane API, which resolves
+    the promise and resumes the agent.
+
+    This replaces the manual "pending_approval" state machine with
+    actual execution-level suspension using Eio structured concurrency.
+
+    @since 2.262.0 (#5907) *)
+
+(* ── Types ────────────────────────────────────────────────── *)
+
+type pending_approval = {
+  id : string;
+  keeper_name : string;
+  tool_name : string;
+  input : Yojson.Safe.t;
+  risk_level : string;
+  requested_at : float;
+  resolver : Oas.Hooks.approval_decision Eio.Promise.u;
+}
+
+type decision = Oas.Hooks.approval_decision
+
+(* ── Global queue (Eio.Mutex-protected) ───────────────────── *)
+
+let mu = Eio.Mutex.create ()
+let pending : (string, pending_approval) Hashtbl.t = Hashtbl.create 8
+
+let generate_id () =
+  let entropy =
+    Printf.sprintf "appr|%d|%.6f|%d"
+      (Unix.getpid ()) (Unix.gettimeofday ()) (Random.bits ())
+  in
+  let digest = Digestif.SHA256.(digest_string entropy |> to_hex) in
+  "appr_" ^ String.sub digest 0 12
+
+(* ── Submit & await ───────────────────────────────────────── *)
+
+(** Submit a tool call for approval and suspend the calling fiber.
+    Returns the operator's decision when the promise is resolved.
+    Called from the OAS approval_callback (inside agent fiber). *)
+let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
+  : Oas.Hooks.approval_decision =
+  let id = generate_id () in
+  let promise, resolver = Eio.Promise.create () in
+  let entry = {
+    id; keeper_name; tool_name; input; risk_level;
+    requested_at = Unix.gettimeofday ();
+    resolver;
+  } in
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    Hashtbl.replace pending id entry);
+  Log.Keeper.info
+    "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s risk=%s"
+    id keeper_name tool_name risk_level;
+  (* Broadcast SSE event so dashboard picks it up *)
+  (try
+     Sse.broadcast
+       (`Assoc [
+          ("type", `String "approval:pending");
+          ("payload", `Assoc [
+             ("id", `String id);
+             ("keeper_name", `String keeper_name);
+             ("tool_name", `String tool_name);
+             ("risk_level", `String risk_level);
+             ("requested_at", `Float entry.requested_at);
+             ("input_preview",
+              `String (String.sub
+                         (Yojson.Safe.to_string input)
+                         0
+                         (min 200 (String.length (Yojson.Safe.to_string input)))));
+           ]);
+        ])
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | _ -> ());
+  (* SUSPEND the agent fiber until operator resolves *)
+  Eio.Promise.await promise
+
+(* ── Resolve (operator action) ────────────────────────────── *)
+
+(** Resolve a pending approval. Returns [Ok ()] if found, [Error msg] if not.
+    Called from the command plane HTTP handler. *)
+let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) result =
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    match Hashtbl.find_opt pending id with
+    | None -> Error (Printf.sprintf "approval %s not found or already resolved" id)
+    | Some entry ->
+      Hashtbl.remove pending id;
+      let decision_str = match decision with
+        | Oas.Hooks.Approve -> "approve"
+        | Oas.Hooks.Reject reason -> "reject:" ^ reason
+        | Oas.Hooks.Edit _ -> "edit"
+      in
+      Log.Keeper.info
+        "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
+        entry.id entry.keeper_name entry.tool_name decision_str;
+      Eio.Promise.resolve entry.resolver decision;
+      (* Broadcast resolution *)
+      (try
+         Sse.broadcast
+           (`Assoc [
+              ("type", `String "approval:resolved");
+              ("payload", `Assoc [
+                 ("id", `String id);
+                 ("keeper_name", `String entry.keeper_name);
+                 ("tool_name", `String entry.tool_name);
+                 ("decision", `String decision_str);
+               ]);
+            ])
+       with _ -> ());
+      Ok ())
+
+(* ── Query ────────────────────────────────────────────────── *)
+
+(** List all pending approvals as JSON. *)
+let list_pending_json () : Yojson.Safe.t =
+  Eio.Mutex.use_ro mu (fun () ->
+    let entries = Hashtbl.fold (fun _id entry acc ->
+      `Assoc [
+        ("id", `String entry.id);
+        ("keeper_name", `String entry.keeper_name);
+        ("tool_name", `String entry.tool_name);
+        ("risk_level", `String entry.risk_level);
+        ("requested_at", `Float entry.requested_at);
+        ("waiting_s", `Float (Unix.gettimeofday () -. entry.requested_at));
+      ] :: acc
+    ) pending [] in
+    `List (List.sort (fun a b ->
+      let ts_a = Yojson.Safe.Util.(member "requested_at" a |> to_float) in
+      let ts_b = Yojson.Safe.Util.(member "requested_at" b |> to_float) in
+      Float.compare ts_a ts_b
+    ) entries))
+
+let pending_count () : int =
+  Eio.Mutex.use_ro mu (fun () -> Hashtbl.length pending)
+
+(* ── Timeout cleanup ──────────────────────────────────────── *)
+
+(** Reject all approvals that have been waiting longer than [max_wait_s].
+    Call periodically from a health loop. *)
+let expire_stale ~max_wait_s =
+  let now = Unix.gettimeofday () in
+  Eio.Mutex.use_rw ~protect:true mu (fun () ->
+    let stale = Hashtbl.fold (fun id entry acc ->
+      if now -. entry.requested_at > max_wait_s
+      then (id, entry) :: acc
+      else acc
+    ) pending [] in
+    List.iter (fun (id, entry) ->
+      Hashtbl.remove pending id;
+      let reason = Printf.sprintf
+        "approval timed out after %.0fs" (now -. entry.requested_at) in
+      Log.Keeper.warn "HITL_APPROVAL_EXPIRED: id=%s keeper=%s tool=%s"
+        id entry.keeper_name entry.tool_name;
+      Eio.Promise.resolve entry.resolver (Oas.Hooks.Reject reason)
+    ) stale)

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -466,9 +466,38 @@ let make_hooks
                Agent_sdk.Hooks.Override
                  (render_inline_skip_reason
                     ~tool_name ~reason_code:"destructive_guard" ~reason_text)
-             | None -> Agent_sdk.Hooks.Continue
+             | None ->
+               (* Governance approval gate: check risk level and request
+                  approval for high-risk tools via OAS ApprovalRequired.
+                  The approval_callback (Keeper_approval_queue) will
+                  suspend the fiber until operator resolves. (#5907) *)
+               let governance_level = Env_config_core.governance_level () in
+               let risk = Governance_pipeline.assess_risk ~tool_name ~input in
+               let needs_approval =
+                 match Governance_pipeline.confirm_threshold governance_level with
+                 | Some threshold ->
+                   Governance_pipeline.risk_level_to_int risk
+                   >= Governance_pipeline.risk_level_to_int threshold
+                 | None -> false
+               in
+               if needs_approval then
+                 Agent_sdk.Hooks.ApprovalRequired
+               else
+                 Agent_sdk.Hooks.Continue
            else
-             Agent_sdk.Hooks.Continue)
+             let governance_level = Env_config_core.governance_level () in
+             let risk = Governance_pipeline.assess_risk ~tool_name ~input in
+             let needs_approval =
+               match Governance_pipeline.confirm_threshold governance_level with
+               | Some threshold ->
+                 Governance_pipeline.risk_level_to_int risk
+                 >= Governance_pipeline.risk_level_to_int threshold
+               | None -> false
+             in
+             if needs_approval then
+               Agent_sdk.Hooks.ApprovalRequired
+             else
+               Agent_sdk.Hooks.Continue)
       | _ -> Agent_sdk.Hooks.Continue);
 
     on_idle = Some (fun event ->

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -111,6 +111,7 @@ val run_named :
   ?context_injector:Oas.Hooks.context_injector ->
   ?context:Oas.Context.t ->
   ?slot_id:int ->
+  ?approval:Oas.Hooks.approval_callback ->
   ?oas_checkpoint:Oas.Checkpoint.t ->
   ?event_bus:Oas.Event_bus.t ->
   ?sw:Eio.Switch.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -46,6 +46,7 @@ type config = {
   context_injector : Oas.Hooks.context_injector option;
   context : Oas.Context.t option;
   slot_id : int option;
+  approval : Oas.Hooks.approval_callback option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -79,6 +80,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     context_injector = None;
     context = None;
     slot_id = None;
+    approval = None;
   }
 
 (* ================================================================ *)
@@ -301,6 +303,10 @@ let build
   in
   let builder = match config.slot_id with
     | Some id -> Oas.Builder.with_slot_id id builder
+    | None -> builder
+  in
+  let builder = match config.approval with
+    | Some cb -> Oas.Builder.with_approval cb builder
     | None -> builder
   in
   Oas.Builder.build_safe builder

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -74,6 +74,7 @@ let config_for_label
     ?enable_thinking
     ?compact_ratio
     ?contract
+    ?approval
     ~(description : string option)
     () : Oas_worker_exec.config =
   let provider = Oas_worker_exec.resolve_provider_of_label model_label in
@@ -103,6 +104,7 @@ let config_for_label
     contract;
     description;
     compact_ratio;
+    approval;
   }
 
 (** Run a single Agent.run() call with cascade model fallback.
@@ -151,6 +153,7 @@ let run_named
     ?context_injector
     ?context
     ?slot_id
+    ?approval
     ?oas_checkpoint
     ?event_bus
     ?sw
@@ -204,6 +207,7 @@ let run_named
       context;
       slot_id;
       event_bus;
+      approval;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -95,6 +95,27 @@ let dispatch (ctx : context) ~(name : string) : result option =
   | "masc_listen" -> Tool_inline_dispatch_comm.handle_listen ctx
   | "masc_who" -> Tool_inline_dispatch_comm.handle_who ctx
 
+  (* ── HITL Approval Queue (#5907) ─────────────────────────────── *)
+  | "masc_approval_pending" ->
+      let json = Keeper_approval_queue.list_pending_json () in
+      Some (true, Yojson.Safe.to_string json)
+  | "masc_approval_resolve" ->
+      let id = arg_get_string "id" "" in
+      let decision_str = arg_get_string "decision" "approve" in
+      if id = "" then Some (false, "id is required")
+      else
+        let decision = match String.lowercase_ascii decision_str with
+          | "approve" -> Oas.Hooks.Approve
+          | "reject" ->
+            let reason = arg_get_string "reason" "operator rejected" in
+            Oas.Hooks.Reject reason
+          | _ -> Oas.Hooks.Reject (Printf.sprintf "unknown decision: %s" decision_str)
+        in
+        (match Keeper_approval_queue.resolve ~id ~decision with
+         | Ok () ->
+           Some (true, Printf.sprintf "{\"resolved\":\"%s\",\"decision\":\"%s\"}" id decision_str)
+         | Error msg -> Some (false, msg))
+
   (* ── Verification ───────────────────────────────────────────── *)
   | "masc_verify_request" | "masc_verify_submit" | "masc_verify_status"
   | "masc_verify_pending" | "masc_verify_auto" ->

--- a/test/dune
+++ b/test/dune
@@ -69,6 +69,7 @@
         test_keeper_tool_policy_config
         test_keeper_toml_config_validation
         test_keeper_bash_safety
+        test_hitl_approval
         test_keeper_discovered_tools
         test_keeper_tool_affinity
         test_keeper_github_safety
@@ -137,6 +138,7 @@
           test_keeper_tool_policy_config
           test_keeper_toml_config_validation
           test_keeper_bash_safety
+          test_hitl_approval
           test_keeper_discovered_tools
           test_keeper_tool_affinity
           test_keeper_github_safety

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1,0 +1,248 @@
+(** Tests for the HITL approval pipeline (#5907).
+
+    Proves:
+    1. Governance risk classification maps tool names to correct levels
+    2. Governance threshold × risk level → correct approval decisions
+    3. Approval queue: fiber suspension via Eio.Promise, resolution resumes
+    4. Approval queue: stale entries expire with Reject
+    5. Approval callback returns correct OAS decisions *)
+
+module GP = Masc_mcp.Governance_pipeline
+module AQ = Masc_mcp.Keeper_approval_queue
+
+let check = Alcotest.(check string)
+
+(* ── 1. Risk classification ──────────────────────────────── *)
+
+let test_risk_classification_critical () =
+  let tools = [
+    ("masc_code_delete", GP.Critical);
+    ("masc_force_reset", GP.Critical);
+    ("keeper_destroy", GP.Critical);
+  ] in
+  List.iter (fun (tool_name, expected) ->
+    let actual = GP.assess_risk ~tool_name ~input:(`Assoc []) in
+    check
+      (Printf.sprintf "%s → %s" tool_name (GP.risk_level_to_string expected))
+      (GP.risk_level_to_string expected)
+      (GP.risk_level_to_string actual)
+  ) tools
+
+let test_risk_classification_high () =
+  let tools = [
+    ("masc_code_write", GP.High);
+    ("keeper_write", GP.High);
+    ("masc_create_task", GP.High);
+  ] in
+  List.iter (fun (tool_name, expected) ->
+    let actual = GP.assess_risk ~tool_name ~input:(`Assoc []) in
+    let actual_int = GP.risk_level_to_int actual in
+    let expected_int = GP.risk_level_to_int expected in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s ≥ %s" tool_name (GP.risk_level_to_string expected))
+      true
+      (actual_int >= expected_int)
+  ) tools
+
+let test_risk_classification_low () =
+  let tools = [
+    ("masc_status", GP.Low);
+    ("keeper_context_status", GP.Low);
+    ("masc_board_list", GP.Low);
+  ] in
+  List.iter (fun (tool_name, expected) ->
+    let actual = GP.assess_risk ~tool_name ~input:(`Assoc []) in
+    check
+      (Printf.sprintf "%s → %s" tool_name (GP.risk_level_to_string expected))
+      (GP.risk_level_to_string expected)
+      (GP.risk_level_to_string actual)
+  ) tools
+
+(* ── 2. Threshold decisions ──────────────────────────────── *)
+
+let test_development_allows_all () =
+  (* development: no confirmation needed for any risk level *)
+  Alcotest.(check (option string))
+    "development → None"
+    None
+    (Option.map GP.risk_level_to_string (GP.confirm_threshold "development"))
+
+let test_paranoid_blocks_medium () =
+  (* paranoid: confirmation from Medium upward *)
+  match GP.confirm_threshold "paranoid" with
+  | Some GP.Medium -> ()
+  | Some other ->
+    Alcotest.fail
+      (Printf.sprintf "expected Medium, got %s" (GP.risk_level_to_string other))
+  | None -> Alcotest.fail "expected Some Medium, got None"
+
+let test_production_blocks_critical () =
+  match GP.confirm_threshold "production" with
+  | Some GP.Critical -> ()
+  | Some other ->
+    Alcotest.fail
+      (Printf.sprintf "expected Critical, got %s" (GP.risk_level_to_string other))
+  | None -> Alcotest.fail "expected Some Critical, got None"
+
+let test_enterprise_blocks_high () =
+  match GP.confirm_threshold "enterprise" with
+  | Some GP.High -> ()
+  | Some other ->
+    Alcotest.fail
+      (Printf.sprintf "expected High, got %s" (GP.risk_level_to_string other))
+  | None -> Alcotest.fail "expected Some High, got None"
+
+(* ── 3. Approval queue: Eio.Promise-based suspend/resume ── *)
+
+let test_approval_queue_submit_and_resolve () =
+  Eio_main.run @@ fun _env ->
+  (* Simulate: agent fiber submits, operator fiber resolves *)
+  Eio.Switch.run @@ fun sw ->
+  let result = ref None in
+  (* Agent fiber: submit and await (will block until resolved) *)
+  Eio.Fiber.fork ~sw (fun () ->
+    let decision =
+      AQ.submit_and_await
+        ~keeper_name:"test-keeper"
+        ~tool_name:"masc_code_delete"
+        ~input:(`Assoc [("path", `String "/dangerous")])
+        ~risk_level:"critical"
+    in
+    result := Some decision
+  );
+  (* Give agent fiber time to submit *)
+  Eio.Fiber.yield ();
+  (* Verify pending *)
+  let pending_count = AQ.pending_count () in
+  Alcotest.(check bool) "1 pending" true (pending_count >= 1);
+  (* Get pending list to find ID *)
+  let pending_json = AQ.list_pending_json () in
+  let entries = match pending_json with
+    | `List entries -> entries
+    | _ -> Alcotest.fail "expected list"
+  in
+  Alcotest.(check bool) "has entries" true (List.length entries >= 1);
+  let id = match List.hd entries with
+    | `Assoc kvs ->
+      (match List.assoc_opt "id" kvs with
+       | Some (`String id) -> id
+       | _ -> Alcotest.fail "no id field")
+    | _ -> Alcotest.fail "bad entry"
+  in
+  (* Operator resolves: approve *)
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+  (* Agent fiber should resume *)
+  Eio.Fiber.yield ();
+  match !result with
+  | Some Agent_sdk.Hooks.Approve -> ()
+  | Some (Agent_sdk.Hooks.Reject r) ->
+    Alcotest.fail ("expected Approve, got Reject: " ^ r)
+  | Some (Agent_sdk.Hooks.Edit _) ->
+    Alcotest.fail "expected Approve, got Edit"
+  | None -> Alcotest.fail "agent fiber did not resume"
+
+let test_approval_queue_reject () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let result = ref None in
+  Eio.Fiber.fork ~sw (fun () ->
+    let decision =
+      AQ.submit_and_await
+        ~keeper_name:"test-keeper"
+        ~tool_name:"masc_force_reset"
+        ~input:(`Assoc [])
+        ~risk_level:"critical"
+    in
+    result := Some decision
+  );
+  Eio.Fiber.yield ();
+  let pending_json = AQ.list_pending_json () in
+  let id = match pending_json with
+    | `List (`Assoc kvs :: _) ->
+      (match List.assoc_opt "id" kvs with
+       | Some (`String id) -> id
+       | _ -> "")
+    | _ -> ""
+  in
+  (match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "too dangerous") with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+  Eio.Fiber.yield ();
+  match !result with
+  | Some (Agent_sdk.Hooks.Reject reason) ->
+    Alcotest.(check bool) "reason contains text" true
+      (String.length reason > 0)
+  | _ -> Alcotest.fail "expected Reject"
+
+let test_approval_queue_expire_stale () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let result = ref None in
+  Eio.Fiber.fork ~sw (fun () ->
+    let decision =
+      AQ.submit_and_await
+        ~keeper_name:"test-keeper"
+        ~tool_name:"masc_dangerous_tool"
+        ~input:(`Assoc [])
+        ~risk_level:"critical"
+    in
+    result := Some decision
+  );
+  Eio.Fiber.yield ();
+  (* Expire with max_wait_s=0 → everything is stale *)
+  AQ.expire_stale ~max_wait_s:0.0;
+  Eio.Fiber.yield ();
+  match !result with
+  | Some (Agent_sdk.Hooks.Reject reason) ->
+    Alcotest.(check bool) "timeout reason" true
+      (String.starts_with ~prefix:"approval timed out" reason)
+  | _ -> Alcotest.fail "expected Reject from timeout"
+
+let test_approval_resolve_nonexistent () =
+  Eio_main.run @@ fun _env ->
+  match AQ.resolve ~id:"nonexistent_id" ~decision:Agent_sdk.Hooks.Approve with
+  | Error msg ->
+    Alcotest.(check bool) "error message" true
+      (String.length msg > 0)
+  | Ok () -> Alcotest.fail "expected error for nonexistent id"
+
+(* ── 4. Approval callback integration ────────────────────── *)
+
+let test_callback_approves_low_risk () =
+  (* development level: no confirmation needed *)
+  let cb = GP.to_oas_approval_callback
+    ~governance_level:"development" ~keeper_name:"test" in
+  let decision = cb ~tool_name:"masc_status" ~input:(`Assoc []) in
+  match decision with
+  | Agent_sdk.Hooks.Approve -> ()
+  | Agent_sdk.Hooks.Reject r ->
+    Alcotest.fail ("expected Approve for low-risk tool, got Reject: " ^ r)
+  | _ -> Alcotest.fail "unexpected decision"
+
+(* ── Test runner ──────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "HITL Approval" [
+    ("risk_classification", [
+      Alcotest.test_case "critical tools" `Quick test_risk_classification_critical;
+      Alcotest.test_case "high-risk tools" `Quick test_risk_classification_high;
+      Alcotest.test_case "low-risk tools" `Quick test_risk_classification_low;
+    ]);
+    ("threshold_decisions", [
+      Alcotest.test_case "development allows all" `Quick test_development_allows_all;
+      Alcotest.test_case "paranoid blocks medium+" `Quick test_paranoid_blocks_medium;
+      Alcotest.test_case "production blocks critical" `Quick test_production_blocks_critical;
+      Alcotest.test_case "enterprise blocks high+" `Quick test_enterprise_blocks_high;
+    ]);
+    ("approval_queue", [
+      Alcotest.test_case "submit and approve" `Quick test_approval_queue_submit_and_resolve;
+      Alcotest.test_case "submit and reject" `Quick test_approval_queue_reject;
+      Alcotest.test_case "expire stale" `Quick test_approval_queue_expire_stale;
+      Alcotest.test_case "resolve nonexistent" `Quick test_approval_resolve_nonexistent;
+    ]);
+    ("callback_integration", [
+      Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

- wire `Governance_pipeline.assess_risk` into the OAS `Builder.with_approval` path used by keeper agents
- add `keeper_approval_queue` to suspend a keeper fiber on approval-required tool calls until an operator resolves the decision
- expose command-plane hooks for listing and resolving pending approvals
- keep the new queue module private in `lib/dune`

## Problem

MASC previously ignored the OAS SDK approval pipeline at the agent execution layer. High-risk tools could be tracked in command-plane state, but keeper execution itself was not suspended inside the OAS run loop.

## Solution

Wire a governance-backed OAS approval callback through `run_named` and `Builder.with_approval`, then back it with an `Eio.Promise` queue so approval decisions resume the suspended keeper fiber.

## Product impact

- Promise affected: `none/internal`
- User-visible change:
  High-risk keeper tool calls now go through the OAS approval callback path instead of bypassing it.

## Evidence

- `dune build --root . bin/main_eio.exe test/test_tool_surface_ssot.exe test/test_command_plane_help.exe`
- CI checks for the PR are green

## Review evidence

- local review found `keeper_approval_queue` should stay private like the other keeper helper sub-modules
- fixed in follow-up commit `18192b83b`
- direct external GLM review evidence is posted in PR comments

## What this does NOT do

- does not remove the manual approval state machine yet
- does not implement durable approval persistence beyond the in-process queue

## Linked issue

Refs #5902
