### PR TITLE
[codex] Add Discord connector runtime dashboard controls

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -3,7 +3,7 @@ import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
+function sampleGateResponse(overrides?: Partial<Record<string, unknown>>) {
   return {
     channels: [
       {
@@ -78,6 +78,49 @@ function sampleResponse(overrides?: Partial<Record<string, unknown>>) {
   }
 }
 
+function sampleLiveResponse(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    available: true,
+    connected: true,
+    stale: false,
+    stale_after_sec: 30,
+    error: '',
+    status_path: '/tmp/discord_status.json',
+    binding_store_path: '/tmp/discord_bindings.json',
+    audit_path: '/tmp/discord_binding_audit.jsonl',
+    updated_at: '2026-04-03T00:00:00Z',
+    last_ready_at: '2026-04-03T00:00:00Z',
+    bot_user_name: 'sangsu',
+    bot_user_id: '1489985300729172039',
+    guild_count: 2,
+    gate_base_url: 'http://localhost:8935',
+    gate_healthy: true,
+    gate_health_checked_at: '2026-04-03T00:00:00Z',
+    binding_source: 'persisted',
+    runtime_bindings_count: 1,
+    pid: 4242,
+    configured_bindings: [
+      {
+        channel_id: '123456',
+        keeper_name: 'luna',
+      },
+    ],
+    recent_audit: [
+      {
+        timestamp: '2026-04-03T00:00:00Z',
+        action: 'bind',
+        guild_id: 'guild-1',
+        channel_id: '123456',
+        keeper_name: 'luna',
+        actor_id: 'dashboard',
+        actor_name: 'dashboard',
+        previous_keeper: '',
+      },
+    ],
+    ...overrides,
+  }
+}
+
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()
@@ -87,14 +130,20 @@ async function flushUi(): Promise<void> {
 
 async function loadComponentWithApi(api: {
   get: (path: string) => Promise<unknown>
+  post?: (path: string, body: unknown) => Promise<unknown>
   lastEvent: { value: unknown }
+  showToast?: (message: string, type?: string) => void
 }) {
   vi.resetModules()
   vi.doMock('../api/core', () => ({
     get: api.get,
+    post: api.post ?? vi.fn().mockResolvedValue({ ok: true }),
   }))
   vi.doMock('../sse', () => ({
     lastEvent: api.lastEvent,
+  }))
+  vi.doMock('./common/toast', () => ({
+    showToast: api.showToast ?? vi.fn(),
   }))
   const module = await import('./connector-status')
   module.resetConnectorStatusState()
@@ -118,12 +167,15 @@ describe('ConnectorStatusPanel', () => {
     vi.clearAllMocks()
     vi.doUnmock('../api/core')
     vi.doUnmock('../sse')
+    vi.doUnmock('./common/toast')
   })
 
-  it('renders enriched connector health details from gate status', async () => {
-    const get = vi.fn<(path: string) => Promise<unknown>>().mockResolvedValue(
-      sampleResponse(),
-    )
+  it('renders direct Discord runtime and gate-observed health together', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
+      if (path === '/api/v1/gate/status') return sampleGateResponse()
+      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse()
+      throw new Error(`unexpected path: ${path}`)
+    })
 
     const { ConnectorStatusPanel } = await loadComponentWithApi({
       get,
@@ -135,16 +187,93 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
     expect(get).toHaveBeenCalledWith('/api/v1/gate/status')
-    expect(text).toContain('Channel Gate')
-    expect(text).toContain('success 91%')
-    expect(text).toContain('duplicates')
-    expect(text).toMatch(/namespaces\s*2/)
-    expect(text).toContain('last namespace 123456')
-    expect(text).toContain('Channel bindings')
-    expect(text).toContain('room 123456')
+    expect(get).toHaveBeenCalledWith('/api/v1/gate/discord/status')
+    expect(text).toContain('Connector Operations')
+    expect(text).toContain('Discord Direct')
+    expect(text).toContain('connected')
+    expect(text).toContain('sangsu')
+    expect(text).toContain('Observed room bindings')
+    expect(text).toContain('Recent binding audit')
     expect(text).toContain('Recent gate events')
     expect(text).toContain('keeper_error')
-    expect(text).toContain('upstream timeout')
-    expect(container.innerHTML).toContain('degraded')
+    expect(text).toContain('/tmp/discord_status.json')
+  })
+
+  it('still renders direct runtime when gate metrics are unavailable', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
+      if (path === '/api/v1/gate/status') throw new Error('GET /api/v1/gate/status: 503 Service Unavailable')
+      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse({ connected: false, stale: true })
+      throw new Error(`unexpected path: ${path}`)
+    })
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      get,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+
+    expect(text).toContain('Discord Direct')
+    expect(text).toContain('stale')
+    expect(text).toContain('Gate metrics unavailable')
+    expect(text).toContain('Direct Discord runtime is visible')
+  })
+
+  it('posts bind and unbind actions through the dashboard endpoints', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
+      if (path === '/api/v1/gate/status') return sampleGateResponse()
+      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse()
+      throw new Error(`unexpected path: ${path}`)
+    })
+    const post = vi.fn<(path: string, body: unknown) => Promise<unknown>>().mockResolvedValue({ ok: true })
+    const showToast = vi.fn()
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      get,
+      post,
+      lastEvent: signal(null),
+      showToast,
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const channelInput = container.querySelector('input[aria-label="Discord channel id"]') as HTMLInputElement | null
+    const keeperInput = container.querySelector('input[aria-label="Keeper name"]') as HTMLInputElement | null
+    expect(channelInput).not.toBeNull()
+    expect(keeperInput).not.toBeNull()
+
+    if (!channelInput || !keeperInput) {
+      throw new Error('expected bind form inputs to exist')
+    }
+
+    channelInput.value = '999999'
+    channelInput.dispatchEvent(new Event('input', { bubbles: true }))
+    keeperInput.value = 'nova'
+    keeperInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const bindButton = Array.from(container.querySelectorAll('button'))
+      .find(candidate => candidate.textContent?.trim() === 'Bind')
+    bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(post).toHaveBeenCalledWith('/api/v1/gate/discord/bind', {
+      channel_id: '999999',
+      keeper_name: 'nova',
+    })
+    expect(showToast).toHaveBeenCalledWith('Bound 999999 -> nova', 'success')
+
+    const unbindButton = Array.from(container.querySelectorAll('button'))
+      .find(candidate => candidate.textContent?.trim() === 'Unbind')
+    unbindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(post).toHaveBeenCalledWith('/api/v1/gate/discord/unbind', {
+      channel_id: '999999',
+    })
+    expect(showToast).toHaveBeenCalledWith('Unbound 999999', 'success')
   })
 })

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -4,9 +4,12 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { get } from '../api/core'
+import { get, post } from '../api/core'
 import { lastEvent } from '../sse'
 import { StatCard } from './common/stat-card'
+import { ActionButton } from './common/button'
+import { TextInput } from './common/input'
+import { showToast } from './common/toast'
 
 interface ChannelInfo {
   channel: string
@@ -48,6 +51,46 @@ interface GateStatusData {
   uptime_seconds: number
 }
 
+interface DiscordConfiguredBinding {
+  channel_id: string
+  keeper_name: string
+}
+
+interface DiscordAuditEntry {
+  timestamp: string
+  action: string
+  guild_id: string
+  channel_id: string
+  keeper_name: string
+  actor_id: string
+  actor_name: string
+  previous_keeper: string
+}
+
+interface DiscordLiveStatusData {
+  available: boolean
+  connected: boolean
+  stale: boolean
+  stale_after_sec: number
+  error: string
+  status_path: string
+  binding_store_path: string
+  audit_path: string
+  updated_at: string
+  last_ready_at: string
+  bot_user_name: string
+  bot_user_id: string
+  guild_count: number
+  gate_base_url: string
+  gate_healthy: boolean | null
+  gate_health_checked_at: string
+  binding_source: string
+  runtime_bindings_count: number
+  pid: number
+  configured_bindings: DiscordConfiguredBinding[]
+  recent_audit: DiscordAuditEntry[]
+}
+
 interface BindingInfo {
   channel: string
   room_id: string
@@ -81,8 +124,13 @@ interface GateEventInfo {
 }
 
 const data = signal<GateStatusData | null>(null)
+const discordLive = signal<DiscordLiveStatusData | null>(null)
 const loading = signal(false)
 const error = signal<string | null>(null)
+const liveError = signal<string | null>(null)
+const actionLoading = signal(false)
+const channelDraft = signal('')
+const keeperDraft = signal('')
 
 let inflightRequest: Promise<void> | null = null
 
@@ -91,11 +139,24 @@ async function refresh() {
   loading.value = true
   inflightRequest = (async () => {
     try {
-      const result = await get<GateStatusData>('/api/v1/gate/status')
-      data.value = result
+      const gateResult = await get<GateStatusData>('/api/v1/gate/status')
+      data.value = gateResult
       error.value = null
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'fetch failed'
+    }
+    try {
+      const liveResult = await get<DiscordLiveStatusData>('/api/v1/gate/discord/status')
+      discordLive.value = liveResult
+      liveError.value = null
+      if (!channelDraft.value && liveResult.configured_bindings.length > 0) {
+        channelDraft.value = liveResult.configured_bindings[0]?.channel_id ?? ''
+      }
+      if (!keeperDraft.value && liveResult.configured_bindings.length > 0) {
+        keeperDraft.value = liveResult.configured_bindings[0]?.keeper_name ?? ''
+      }
+    } catch (e) {
+      liveError.value = e instanceof Error ? e.message : 'fetch failed'
     } finally {
       loading.value = false
       inflightRequest = null
@@ -127,8 +188,10 @@ function formatUptime(seconds: number): string {
 }
 
 function timeAgo(iso: string): string {
+  if (!iso.trim()) return 'unknown'
   if (iso === 'never') return 'never'
   const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (Number.isNaN(diff)) return 'unknown'
   if (diff < 60) return 'just now'
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
   if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
@@ -180,6 +243,267 @@ function truncateMiddle(value: string, limit = 18): string {
   const tail = Math.max(4, Math.floor(budget / 3))
   const head = Math.max(2, budget - tail)
   return `${trimmed.slice(0, head)}…${trimmed.slice(-tail)}`
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>()
+  const ordered: string[] = []
+  values.forEach(value => {
+    const trimmed = value.trim()
+    if (!trimmed || seen.has(trimmed)) return
+    seen.add(trimmed)
+    ordered.push(trimmed)
+  })
+  return ordered
+}
+
+function discordStateLabel(live: DiscordLiveStatusData | null): string {
+  if (!live?.available) return 'offline'
+  if (live.stale) return 'stale'
+  if (live.connected) return 'connected'
+  return 'disconnected'
+}
+
+function discordStateTone(live: DiscordLiveStatusData | null): string {
+  const label = discordStateLabel(live)
+  if (label === 'connected') {
+    return 'border-emerald-400/30 bg-emerald-500/12 text-emerald-100'
+  }
+  if (label === 'disconnected') {
+    return 'border-rose-400/30 bg-rose-500/12 text-rose-100'
+  }
+  return 'border-amber-400/30 bg-amber-500/12 text-amber-100'
+}
+
+async function bindDiscordChannel() {
+  const channelId = channelDraft.value.trim()
+  const keeperName = keeperDraft.value.trim()
+  if (!channelId || !keeperName) return
+
+  actionLoading.value = true
+  try {
+    await post('/api/v1/gate/discord/bind', { channel_id: channelId, keeper_name: keeperName })
+    await refresh()
+    showToast(`Bound ${channelId} -> ${keeperName}`, 'success')
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : 'bind failed', 'error')
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+async function unbindDiscordChannel(channelIdOverride?: string) {
+  const channelId = (channelIdOverride ?? channelDraft.value).trim()
+  if (!channelId) return
+
+  actionLoading.value = true
+  try {
+    await post('/api/v1/gate/discord/unbind', { channel_id: channelId })
+    if (channelDraft.value.trim() === channelId) {
+      channelDraft.value = ''
+    }
+    await refresh()
+    showToast(`Unbound ${channelId}`, 'success')
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : 'unbind failed', 'error')
+  } finally {
+    actionLoading.value = false
+  }
+}
+
+function DiscordLivePanel({
+  live,
+  gate,
+}: {
+  live: DiscordLiveStatusData | null
+  gate: GateStatusData | null
+}) {
+  const configuredBindings = live?.configured_bindings ?? []
+  const audit = live?.recent_audit ?? []
+  const observedRooms = uniqueStrings([
+    ...(gate?.bindings ?? [])
+      .filter(binding => binding.channel === 'discord')
+      .map(binding => binding.room_id),
+    ...(gate?.recent_events ?? [])
+      .filter(event => event.channel === 'discord')
+      .map(event => event.room_id),
+    ...configuredBindings.map(binding => binding.channel_id),
+  ])
+  const suggestedKeepers = uniqueStrings([
+    ...(gate?.bindings ?? [])
+      .filter(binding => binding.channel === 'discord')
+      .map(binding => binding.keeper),
+    ...(gate?.recent_events ?? [])
+      .filter(event => event.channel === 'discord')
+      .map(event => event.keeper),
+    ...configuredBindings.map(binding => binding.keeper_name),
+  ])
+  const directLabel = discordStateLabel(live)
+  const directTone = discordStateTone(live)
+
+  return html`
+    <div class="mb-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(135deg,rgba(88,101,242,0.16),rgba(88,101,242,0.04))] p-4">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">Discord Direct</div>
+          <div class="mt-1 flex flex-wrap items-center gap-2">
+            <span class=${`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] ${directTone}`}>
+              ${directLabel}
+            </span>
+            <span class="text-[13px] font-medium text-[var(--text-body)]">
+              ${live?.bot_user_name ? `${live.bot_user_name} · ${truncateMiddle(live.bot_user_id, 24)}` : 'No live bot identity yet'}
+            </span>
+          </div>
+          <div class="mt-2 flex flex-wrap gap-3 text-[11px] text-[var(--text-dim)]">
+            <span>heartbeat ${timeAgo(live?.updated_at ?? '')}</span>
+            <span>ready ${timeAgo(live?.last_ready_at ?? '')}</span>
+            <span>guilds ${live?.guild_count ?? 0}</span>
+            <span>runtime bindings ${live?.runtime_bindings_count ?? configuredBindings.length}</span>
+            <span>source ${live?.binding_source || 'unknown'}</span>
+            <span>
+              gate ${live?.gate_healthy == null ? 'unknown' : live.gate_healthy ? 'healthy' : 'unhealthy'}
+            </span>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <${ActionButton} variant="ghost" size="sm" disabled=${loading.value || actionLoading.value} onClick=${() => { void refresh() }}>Refresh<//>
+          <${ActionButton}
+            variant="primary"
+            size="sm"
+            disabled=${actionLoading.value || channelDraft.value.trim().length === 0 || keeperDraft.value.trim().length === 0}
+            onClick=${() => { void bindDiscordChannel() }}
+          >
+            ${actionLoading.value ? 'Applying...' : 'Bind'}
+          <//>
+          <${ActionButton}
+            variant="danger"
+            size="sm"
+            disabled=${actionLoading.value || channelDraft.value.trim().length === 0}
+            onClick=${() => { void unbindDiscordChannel() }}
+          >
+            Unbind
+          <//>
+        </div>
+      </div>
+
+      ${liveError.value || live?.error
+        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">${liveError.value ?? live?.error}</div>`
+        : null}
+
+      ${live
+        ? html`
+            <div class="mt-3 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
+              <span>status ${live.status_path || '-'}</span>
+              <span>bindings ${live.binding_store_path || '-'}</span>
+              <span>audit ${live.audit_path || '-'}</span>
+            </div>
+          `
+        : null}
+
+      <div class="mt-4 grid grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] gap-4 max-[980px]:grid-cols-1">
+        <div class="space-y-3">
+          <div>
+            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Channel ID</div>
+            <${TextInput}
+              value=${channelDraft.value}
+              placeholder="Discord channel snowflake"
+              ariaLabel="Discord channel id"
+              onInput=${(e: Event) => { channelDraft.value = (e.target as HTMLInputElement).value }}
+            />
+          </div>
+          <div>
+            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Keeper</div>
+            <${TextInput}
+              value=${keeperDraft.value}
+              placeholder="keeper name"
+              ariaLabel="Keeper name"
+              onInput=${(e: Event) => { keeperDraft.value = (e.target as HTMLInputElement).value }}
+            />
+          </div>
+          ${observedRooms.length > 0
+            ? html`
+                <div>
+                  <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Observed rooms</div>
+                  <div class="flex flex-wrap gap-2">
+                    ${observedRooms.slice(0, 8).map(roomId => html`
+                      <button
+                        type="button"
+                        class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-1 text-[10px] text-[var(--text-body)] cursor-pointer hover:bg-[var(--white-8)]"
+                        onClick=${() => { channelDraft.value = roomId }}
+                      >
+                        ${truncateMiddle(roomId, 22)}
+                      </button>
+                    `)}
+                  </div>
+                </div>
+              `
+            : null}
+          ${suggestedKeepers.length > 0
+            ? html`
+                <div>
+                  <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Suggested keepers</div>
+                  <div class="flex flex-wrap gap-2">
+                    ${suggestedKeepers.slice(0, 8).map(name => html`
+                      <button
+                        type="button"
+                        class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-1 text-[10px] text-[var(--text-body)] cursor-pointer hover:bg-[var(--white-8)]"
+                        onClick=${() => { keeperDraft.value = name }}
+                      >
+                        ${name}
+                      </button>
+                    `)}
+                  </div>
+                </div>
+              `
+            : null}
+        </div>
+
+        <div class="space-y-3">
+          <div>
+            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Configured bindings</div>
+            ${configuredBindings.length === 0
+              ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No persisted Discord bindings yet</div>`
+              : html`
+                  <div class="space-y-2">
+                    ${configuredBindings.map(binding => html`
+                      <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
+                        <div class="flex items-start justify-between gap-3">
+                          <div class="min-w-0">
+                            <div class="text-xs font-medium text-[var(--text-body)]">${truncateMiddle(binding.channel_id, 26)}</div>
+                            <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">keeper ${binding.keeper_name}</div>
+                          </div>
+                          <div class="flex gap-2">
+                            <${ActionButton} variant="ghost" size="sm" onClick=${() => {
+                              channelDraft.value = binding.channel_id
+                              keeperDraft.value = binding.keeper_name
+                            }}>Use<//>
+                            <${ActionButton} variant="danger" size="sm" disabled=${actionLoading.value} onClick=${() => { void unbindDiscordChannel(binding.channel_id) }}>Unbind<//>
+                          </div>
+                        </div>
+                      </div>
+                    `)}
+                  </div>
+                `}
+          </div>
+          ${audit.length > 0
+            ? html`
+                <div>
+                  <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Recent binding audit</div>
+                  <div class="space-y-2">
+                    ${audit.slice(0, 4).map(entry => html`
+                      <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2 text-[11px] text-[var(--text-dim)]">
+                        <div class="font-medium text-[var(--text-body)]">${entry.action} · ${truncateMiddle(entry.channel_id, 22)} · ${entry.keeper_name}</div>
+                        <div class="mt-1">${entry.actor_name || 'dashboard'} · ${timeAgo(entry.timestamp)}</div>
+                      </div>
+                    `)}
+                  </div>
+                </div>
+              `
+            : null}
+        </div>
+      </div>
+    </div>
+  `
 }
 
 function ChannelCard({ ch }: { ch: ChannelInfo }) {
@@ -359,77 +683,104 @@ export function ConnectorStatusPanel() {
   }, [lastEvent.value])
 
   const d = data.value
+  const live = discordLive.value
 
-  if (loading.value && !d) {
+  if (loading.value && !d && !live) {
     return html`<div class="text-xs text-[var(--text-dim)]">Loading connector status...</div>`
   }
 
-  if (error.value && !d) {
+  if (error.value && !d && !live) {
     return html`<div class="text-xs text-[var(--red)]">Gate: ${error.value}</div>`
   }
 
-  if (!d) return null
+  if (!d && !live) return null
 
   return html`
     <div>
       <div class="mb-3 flex items-center justify-between gap-3">
-        <h3 class="text-sm font-semibold text-[var(--text-body)]">Channel Gate</h3>
-        <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
-          success ${d.success_rate_pct}% · uptime ${formatUptime(d.uptime_seconds)}
-        </div>
-      </div>
-
-      <div class="mb-3 grid grid-cols-4 gap-2 max-[720px]:grid-cols-2">
-        <${StatCard} label="Messages" value=${d.total_messages} />
-        <${StatCard} label="Success" value=${d.total_success} />
-        <${StatCard} label="Errors" value=${d.total_errors} />
-        <${StatCard} label="Dedup Keys" value=${d.dedup_table_size} />
-      </div>
-
-      <div class="mb-4 grid grid-cols-2 gap-2 text-[11px] text-[var(--text-dim)] max-[720px]:grid-cols-1">
-        <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
-          duplicate suppressions
-          <span class="ml-2 font-mono text-[var(--text-body)]">${d.total_duplicates}</span>
-        </div>
-        <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
-          active connectors
-          <span class="ml-2 font-mono text-[var(--text-body)]">${d.channels.length}</span>
-        </div>
-      </div>
-
-      <div class="mb-4 grid grid-cols-2 gap-3 max-[900px]:grid-cols-1">
         <div>
-          <div class="mb-2 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
-            Channel bindings
+          <h3 class="text-sm font-semibold text-[var(--text-body)]">Connector Operations</h3>
+          <div class="mt-1 text-[11px] text-[var(--text-dim)]">
+            Discord direct runtime + Gate-observed traffic in one surface.
           </div>
-          ${d.bindings.length === 0
-            ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No observed room bindings yet</div>`
-            : html`
-                <div class="space-y-2">
-                  ${d.bindings.slice(0, 6).map(binding => html`<${BindingRow} binding=${binding} />`)}
-                </div>
-              `}
         </div>
-
-        <div>
-          <div class="mb-2 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
-            Recent gate events
-          </div>
-          ${d.recent_events.length === 0
-            ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No connector events recorded yet</div>`
-            : html`
-                <div class="space-y-2">
-                  ${d.recent_events.slice(0, 8).map(event => html`<${EventRow} event=${event} />`)}
-                </div>
-              `}
+        <div class="text-right text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+          <div>${d ? `success ${d.success_rate_pct}%` : `direct ${discordStateLabel(live)}`}</div>
+          <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
         </div>
       </div>
 
-      ${d.channels.length === 0
-        ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">No active connectors</div>`
+      <${DiscordLivePanel} live=${live} gate=${d} />
+
+      ${error.value
+        ? html`
+            <div class="mb-4 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">
+              Gate metrics unavailable: ${error.value}
+            </div>
+          `
+        : null}
+
+      ${!d
+        ? html`
+            <div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">
+              Direct Discord runtime is visible, but Gate-observed traffic is not available yet.
+            </div>
+          `
         : html`
-            <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
-              ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
+            <div>
+              <div class="mb-3 grid grid-cols-4 gap-2 max-[720px]:grid-cols-2">
+                <${StatCard} label="Messages" value=${d.total_messages} />
+                <${StatCard} label="Success" value=${d.total_success} />
+                <${StatCard} label="Errors" value=${d.total_errors} />
+                <${StatCard} label="Dedup Keys" value=${d.dedup_table_size} />
+              </div>
+
+              <div class="mb-4 grid grid-cols-2 gap-2 text-[11px] text-[var(--text-dim)] max-[720px]:grid-cols-1">
+                <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
+                  duplicate suppressions
+                  <span class="ml-2 font-mono text-[var(--text-body)]">${d.total_duplicates}</span>
+                </div>
+                <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
+                  active connectors
+                  <span class="ml-2 font-mono text-[var(--text-body)]">${d.channels.length}</span>
+                </div>
+              </div>
+
+              <div class="mb-4 grid grid-cols-2 gap-3 max-[900px]:grid-cols-1">
+                <div>
+                  <div class="mb-2 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                    Observed room bindings
+                  </div>
+                  ${d.bindings.length === 0
+                    ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No observed room bindings yet</div>`
+                    : html`
+                        <div class="space-y-2">
+                          ${d.bindings.slice(0, 6).map(binding => html`<${BindingRow} binding=${binding} />`)}
+                        </div>
+                      `}
+                </div>
+
+                <div>
+                  <div class="mb-2 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
+                    Recent gate events
+                  </div>
+                  ${d.recent_events.length === 0
+                    ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No connector events recorded yet</div>`
+                    : html`
+                        <div class="space-y-2">
+                          ${d.recent_events.slice(0, 8).map(event => html`<${EventRow} event=${event} />`)}
+                        </div>
+                      `}
+                </div>
+              </div>
+
+              ${d.channels.length === 0
+                ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">No active connectors</div>`
+                : html`
+                    <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
+                      ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
+                    </div>
+                  `}
             </div>
           `}
     </div>
@@ -438,7 +789,12 @@ export function ConnectorStatusPanel() {
 
 export function resetConnectorStatusState() {
   data.value = null
+  discordLive.value = null
   loading.value = false
   error.value = null
+  liveError.value = null
+  actionLoading.value = false
+  channelDraft.value = ''
+  keeperDraft.value = ''
   inflightRequest = null
 }

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -74,6 +74,9 @@ async function loadOverview() {
   vi.doMock('../perf-snapshot', () => ({
     PerfSnapshotPanel: () => html`<div>Perf</div>`,
   }))
+  vi.doMock('../connector-status', () => ({
+    ConnectorStatusPanel: () => html`<div>Connector Panel</div>`,
+  }))
   return import('./overview')
 }
 
@@ -122,6 +125,7 @@ describe('Overview freshness strip', () => {
     vi.doUnmock('./agent-avatar')
     vi.doUnmock('../transport-health')
     vi.doUnmock('../perf-snapshot')
+    vi.doUnmock('../connector-status')
   })
 
   it('shows a stale warning when the oldest overview snapshot is over 5 minutes old', async () => {
@@ -153,6 +157,14 @@ describe('Overview freshness strip', () => {
 
     expect(refreshNamespaceTruth).toHaveBeenCalledWith({ force: true })
     expect(refreshMissionSnapshot).toHaveBeenCalledWith({ force: true })
+  }, 15000)
+
+  it('renders the connector operations card as a top-level overview section', async () => {
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Connector Panel')
   }, 15000)
 
   it('renders the meta-cognition summary card when shell data is available', async () => {
@@ -267,6 +279,7 @@ describe('ToolCallHealthPanel', () => {
     vi.doUnmock('./agent-avatar')
     vi.doUnmock('../transport-health')
     vi.doUnmock('../perf-snapshot')
+    vi.doUnmock('../connector-status')
   })
 
   it('hides the panel when serverStatus is null', async () => {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -545,17 +545,20 @@ export function Overview() {
 
       ${toolHealth ? html`<div class=${OVERVIEW_CARD}>${toolHealth}</div>` : null}
 
+      <div class=${OVERVIEW_CARD}>
+        <${ConnectorStatusPanel} />
+      </div>
+
       <details class=${OVERVIEW_CARD}>
         <summary class="cursor-pointer text-xs font-semibold text-[var(--text-strong)] uppercase tracking-wider select-none list-none flex items-center gap-2">
           인프라 상태
-          <span class="text-[10px] font-normal normal-case tracking-normal text-[var(--text-muted)]">Transport · 성능 · 커넥터</span>
+          <span class="text-[10px] font-normal normal-case tracking-normal text-[var(--text-muted)]">Transport · 성능</span>
         </summary>
         <div class="mt-4 flex flex-col gap-4">
           <div class="grid grid-cols-2 gap-4 max-[1100px]:grid-cols-1">
             <${TransportHealthPanel} />
             <${PerfSnapshotPanel} />
           </div>
-          <${ConnectorStatusPanel} />
         </div>
       </details>
 

--- a/lib/channel_gate_discord_state.ml
+++ b/lib/channel_gate_discord_state.ml
@@ -1,0 +1,335 @@
+module U = Yojson.Safe.Util
+
+type binding = {
+  channel_id : string;
+  keeper_name : string;
+}
+
+type audit_event = {
+  timestamp : string;
+  action : string;
+  guild_id : string;
+  channel_id : string;
+  keeper_name : string;
+  actor_id : string;
+  actor_name : string;
+  previous_keeper : string;
+}
+
+let default_status_path = "sidecars/discord-bot/.gate/discord_status.json"
+let default_binding_store_path = "sidecars/discord-bot/.gate/discord_bindings.json"
+let default_binding_audit_path =
+  "sidecars/discord-bot/.gate/discord_binding_audit.jsonl"
+
+let stale_after_sec () =
+  Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"
+
+let resolve_path raw_path =
+  if Filename.is_relative raw_path then
+    Filename.concat (Env_config_core.base_path ()) raw_path
+  else
+    raw_path
+
+let configured_path env_name ~default =
+  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
+  | Some raw -> resolve_path raw
+  | None -> resolve_path default
+
+let status_path () =
+  configured_path "MASC_DISCORD_STATUS_PATH" ~default:default_status_path
+
+let binding_store_path () =
+  configured_path "MASC_DISCORD_BINDING_STORE_PATH"
+    ~default:default_binding_store_path
+
+let binding_audit_path () =
+  configured_path "MASC_DISCORD_BINDING_AUDIT_PATH"
+    ~default:default_binding_audit_path
+
+let read_json_file_opt path =
+  if not (Sys.file_exists path) then
+    None
+  else
+    try Some (Yojson.Safe.from_file path) with
+    | Sys_error _ | Yojson.Json_error _ -> None
+
+let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
+  match json with
+  | `Assoc items ->
+      items
+      |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
+             let channel_id = String.trim raw_channel_id in
+             let keeper_name =
+               match raw_keeper_name with
+               | `String value -> String.trim value
+               | _ -> ""
+             in
+             if channel_id = "" || keeper_name = "" then None
+             else Some ({ channel_id; keeper_name } : binding))
+      |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+  | _ -> []
+
+let read_bindings () : binding list =
+  match read_json_file_opt (binding_store_path ()) with
+  | Some json -> normalize_bindings_json json
+  | None -> []
+
+let binding_json (binding : binding) =
+  `Assoc
+    [
+      ("channel_id", `String binding.channel_id);
+      ("keeper_name", `String binding.keeper_name);
+    ]
+
+let save_bindings (bindings : binding list) =
+  let path = binding_store_path () in
+  let normalized =
+    bindings
+    |> List.sort (fun (a : binding) (b : binding) ->
+           String.compare a.channel_id b.channel_id)
+    |> List.fold_left
+         (fun acc (binding : binding) ->
+           (binding.channel_id, `String binding.keeper_name) :: acc)
+         []
+    |> List.rev
+    |> fun items -> `Assoc items
+  in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let tmp = path ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
+  Sys.rename tmp path
+
+let audit_event_json event =
+  `Assoc
+    [
+      ("timestamp", `String event.timestamp);
+      ("action", `String event.action);
+      ("guild_id", `String event.guild_id);
+      ("channel_id", `String event.channel_id);
+      ("keeper_name", `String event.keeper_name);
+      ("actor_id", `String event.actor_id);
+      ("actor_name", `String event.actor_name);
+      ("previous_keeper", `String event.previous_keeper);
+    ]
+
+let append_audit_event event =
+  let path = binding_audit_path () in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let oc =
+    open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644 path
+  in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (Yojson.Safe.to_string (audit_event_json event));
+      output_char oc '\n';
+      flush oc;
+      Unix.fsync (Unix.descr_of_out_channel oc))
+
+let rec drop_left n xs =
+  if n <= 0 then xs
+  else
+    match xs with
+    | [] -> []
+    | _ :: tl -> drop_left (n - 1) tl
+
+let read_recent_audit ~limit =
+  let path = binding_audit_path () in
+  if limit <= 0 || not (Sys.file_exists path) then
+    []
+  else
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let rec loop acc =
+          match input_line ic with
+          | line -> loop (line :: acc)
+          | exception End_of_file -> acc
+        in
+        loop []
+        |> List.filter_map (fun line ->
+               let trimmed = String.trim line in
+               if trimmed = "" then None
+               else
+                 try Some (Yojson.Safe.from_string trimmed) with
+                 | Yojson.Json_error _ -> None)
+        |> List.rev
+        |> fun rows ->
+        let total = List.length rows in
+        if total <= limit then List.rev rows
+        else rows |> drop_left (total - limit) |> List.rev)
+
+let string_member json key =
+  json |> U.member key |> U.to_string_option |> Option.value ~default:""
+
+let int_member json key =
+  json |> U.member key |> U.to_int_option |> Option.value ~default:0
+
+let bool_member json key =
+  json |> U.member key |> U.to_bool_option |> Option.value ~default:false
+
+let bool_option_member json key =
+  json |> U.member key |> U.to_bool_option
+
+let stale_of_updated_at updated_at =
+  match Types.parse_iso8601_opt updated_at with
+  | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
+  | None -> true
+
+let status_json ?(audit_limit = 10) () =
+  let status_path = status_path () in
+  let live_status = read_json_file_opt status_path in
+  let configured_bindings = read_bindings () in
+  let recent_audit = read_recent_audit ~limit:audit_limit in
+  let available = Option.is_some live_status in
+  let updated_at =
+    match live_status with
+    | Some json -> string_member json "updated_at"
+    | None -> ""
+  in
+  let stale = if not available then true else stale_of_updated_at updated_at in
+  let connected =
+    match live_status with
+    | Some json -> bool_member json "connected" && not stale
+    | None -> false
+  in
+  let error =
+    if available then ""
+    else "discord connector status file not found"
+  in
+  let status_field key f default =
+    match live_status with
+    | Some json -> f json key
+    | None -> default
+  in
+  `Assoc
+    [
+      ("available", `Bool available);
+      ("connected", `Bool connected);
+      ("stale", `Bool stale);
+      ("stale_after_sec", `Int (stale_after_sec ()));
+      ("error", `String error);
+      ("status_path", `String status_path);
+      ("binding_store_path", `String (binding_store_path ()));
+      ("audit_path", `String (binding_audit_path ()));
+      ("updated_at", `String updated_at);
+      ( "last_ready_at",
+        `String (status_field "last_ready_at" string_member "") );
+      ( "bot_user_name",
+        `String (status_field "bot_user_name" string_member "") );
+      ("bot_user_id", `String (status_field "bot_user_id" string_member ""));
+      ("guild_count", `Int (status_field "guild_count" int_member 0));
+      ( "gate_base_url",
+        `String (status_field "gate_base_url" string_member "") );
+      ( "gate_healthy",
+        Option.value ~default:`Null
+          (Option.map (fun value -> `Bool value)
+             (match live_status with
+              | Some json -> bool_option_member json "gate_healthy"
+              | None -> None)) );
+      ( "gate_health_checked_at",
+        `String (status_field "gate_health_checked_at" string_member "") );
+      ( "binding_source",
+        `String (status_field "binding_source" string_member "") );
+      ( "runtime_bindings_count",
+        `Int (status_field "runtime_bindings_count" int_member 0) );
+      ("pid", `Int (status_field "pid" int_member 0));
+      ( "configured_bindings",
+        `List (List.map binding_json configured_bindings) );
+      ("recent_audit", `List recent_audit);
+    ]
+
+let rollback_bindings original_bindings =
+  try save_bindings original_bindings with
+  | Sys_error _ -> ()
+
+let bind ~channel_id ~keeper_name ~actor_name =
+  let channel_id = String.trim channel_id in
+  let keeper_name = String.trim keeper_name in
+  if channel_id = "" then
+    Error "channel_id is required"
+  else if keeper_name = "" then
+    Error "keeper_name is required"
+  else
+    let original_bindings = read_bindings () in
+    let previous_keeper =
+      original_bindings
+      |> List.find_map (fun (binding : binding) ->
+             if String.equal binding.channel_id channel_id then
+               Some binding.keeper_name
+             else
+               None)
+      |> Option.value ~default:""
+    in
+    let updated_bindings =
+      (({ channel_id; keeper_name } : binding)
+       :: List.filter
+            (fun (binding : binding) ->
+              not (String.equal binding.channel_id channel_id))
+            original_bindings)
+      |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+    in
+    try
+      save_bindings updated_bindings;
+      append_audit_event
+        {
+          timestamp = Server_utils.iso8601_of_unix (Unix.gettimeofday ());
+          action = "bind";
+          guild_id = "";
+          channel_id;
+          keeper_name;
+          actor_id = actor_name;
+          actor_name;
+          previous_keeper;
+        };
+      Ok (status_json ())
+    with
+    | Sys_error msg ->
+        rollback_bindings original_bindings;
+        Error msg
+
+let unbind ~channel_id ~actor_name =
+  let channel_id = String.trim channel_id in
+  if channel_id = "" then
+    Error "channel_id is required"
+  else
+    let original_bindings = read_bindings () in
+    match
+      original_bindings
+      |> List.find_opt (fun (binding : binding) ->
+             String.equal binding.channel_id channel_id)
+    with
+    | None -> Error "binding not found"
+    | Some (removed_binding : binding) ->
+        let updated_bindings =
+          List.filter
+            (fun (binding : binding) ->
+              not (String.equal binding.channel_id channel_id))
+            original_bindings
+        in
+        try
+          save_bindings updated_bindings;
+          append_audit_event
+            {
+              timestamp = Server_utils.iso8601_of_unix (Unix.gettimeofday ());
+              action = "unbind";
+              guild_id = "";
+              channel_id;
+              keeper_name = removed_binding.keeper_name;
+              actor_id = actor_name;
+              actor_name;
+              previous_keeper = removed_binding.keeper_name;
+            };
+          Ok (status_json ())
+        with
+        | Sys_error msg ->
+            rollback_bindings original_bindings;
+            Error msg

--- a/lib/dune
+++ b/lib/dune
@@ -33,6 +33,7 @@
    cancellation
    channel_gate
    channel_gate_metrics
+   channel_gate_discord_state
    gate_protocol
    gate_keeper_backend
    command_plane_v2

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -314,6 +314,7 @@ let is_public_read_path path =
   || String.equal path "/health/ready"
   || String.equal path "/api/v1/gate/health"
   || String.equal path "/api/v1/gate/status"
+  || String.equal path "/api/v1/gate/discord/status"
   || String.equal path "/api/v1/gate/events"
   || String.equal path "/"
   || String.equal path "/dashboard"

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -202,6 +202,18 @@ let handle_gate_status _state request reqd =
   respond_json_with_cors ~status:`OK request reqd
     (Yojson.Safe.to_string json)
 
+(** GET /api/v1/gate/discord/status
+
+    Dashboard-facing live connector status sourced from the Discord bot's
+    status file plus the durable binding/audit stores. *)
+let handle_gate_discord_status _state request reqd =
+  let limit =
+    int_query_param request "audit_limit" ~default:10
+    |> fun value -> max 1 (min 50 value)
+  in
+  respond_json_with_cors ~status:`OK request reqd
+    (Yojson.Safe.to_string (Channel_gate_discord_state.status_json ~audit_limit:limit ()))
+
 let gate_keeper_ctx ~sw ~clock state =
   {
     Tool_keeper.config = state.Mcp_server.room_config;
@@ -211,6 +223,20 @@ let gate_keeper_ctx ~sw ~clock state =
     proc_mgr = state.Mcp_server.proc_mgr;
     net = state.Mcp_server.net;
   }
+
+let keeper_exists ~sw ~clock state keeper_name =
+  let args = `Assoc [ ("name", `String keeper_name) ] in
+  match
+    Tool_keeper.dispatch (gate_keeper_ctx ~sw ~clock state)
+      ~name:"masc_keeper_status" ~args
+  with
+  | Some (true, _) -> Ok true
+  | Some (false, err) ->
+      if String_util.contains_substring
+           (String.lowercase_ascii err) "keeper not found"
+      then Ok false
+      else Error err
+  | None -> Error "keeper dispatch unavailable"
 
 let respond_keeper_tool_json ~sw ~clock state request reqd ~tool_name ~args =
   match
@@ -275,6 +301,95 @@ let handle_gate_keeper_status ~sw ~clock state request reqd =
         (Yojson.Safe.to_string
            (Channel_gate.error_json "name is required"))
 
+let handle_gate_discord_bind ~sw ~clock state request reqd =
+  Http.Request.read_body_async reqd (fun body_str ->
+    try
+      let json = Yojson.Safe.from_string body_str in
+      let channel_id =
+        json |> Yojson.Safe.Util.member "channel_id"
+        |> Yojson.Safe.Util.to_string_option
+        |> Option.value ~default:""
+        |> String.trim
+      in
+      let keeper_name =
+        json |> Yojson.Safe.Util.member "keeper_name"
+        |> Yojson.Safe.Util.to_string_option
+        |> Option.value ~default:""
+        |> String.trim
+      in
+      if channel_id = "" then
+        respond_json_with_cors ~status:`Bad_request request reqd
+          (Yojson.Safe.to_string
+             (Channel_gate.error_json "channel_id is required"))
+      else if keeper_name = "" then
+        respond_json_with_cors ~status:`Bad_request request reqd
+          (Yojson.Safe.to_string
+             (Channel_gate.error_json "keeper_name is required"))
+      else
+        match keeper_exists ~sw ~clock state keeper_name with
+        | Error err ->
+            respond_json_with_cors ~status:`Service_unavailable request reqd
+              (Yojson.Safe.to_string (Channel_gate.error_json err))
+        | Ok false ->
+            respond_json_with_cors ~status:`Not_found request reqd
+              (Yojson.Safe.to_string
+                 (Channel_gate.error_json ("unknown keeper: " ^ keeper_name)))
+        | Ok true -> (
+            let actor_name =
+              agent_from_request request
+              |> Option.value ~default:"dashboard"
+              |> String.trim
+            in
+            match
+              Channel_gate_discord_state.bind ~channel_id ~keeper_name ~actor_name
+            with
+            | Ok payload ->
+                respond_json_with_cors ~status:`OK request reqd
+                  (Yojson.Safe.to_string payload)
+            | Error err ->
+                respond_json_with_cors ~status:`Internal_server_error request reqd
+                  (Yojson.Safe.to_string (Channel_gate.error_json err)) ) 
+    with
+    | Yojson.Json_error _ ->
+        respond_json_with_cors ~status:`Bad_request request reqd
+          (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")) )
+
+let handle_gate_discord_unbind ~sw:_ ~clock:_ _state request reqd =
+  Http.Request.read_body_async reqd (fun body_str ->
+    try
+      let json = Yojson.Safe.from_string body_str in
+      let channel_id =
+        json |> Yojson.Safe.Util.member "channel_id"
+        |> Yojson.Safe.Util.to_string_option
+        |> Option.value ~default:""
+        |> String.trim
+      in
+      if channel_id = "" then
+        respond_json_with_cors ~status:`Bad_request request reqd
+          (Yojson.Safe.to_string
+             (Channel_gate.error_json "channel_id is required"))
+      else
+        let actor_name =
+          agent_from_request request
+          |> Option.value ~default:"dashboard"
+          |> String.trim
+        in
+        match Channel_gate_discord_state.unbind ~channel_id ~actor_name with
+        | Ok payload ->
+            respond_json_with_cors ~status:`OK request reqd
+              (Yojson.Safe.to_string payload)
+        | Error "binding not found" ->
+            respond_json_with_cors ~status:`Not_found request reqd
+              (Yojson.Safe.to_string
+                 (Channel_gate.error_json "binding not found"))
+        | Error err ->
+            respond_json_with_cors ~status:`Internal_server_error request reqd
+              (Yojson.Safe.to_string (Channel_gate.error_json err))
+    with
+    | Yojson.Json_error _ ->
+        respond_json_with_cors ~status:`Bad_request request reqd
+          (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")) )
+
 (** Register all gate routes on the router. *)
 let add_routes ~sw ~clock router =
   router
@@ -293,6 +408,11 @@ let add_routes ~sw ~clock router =
           handle_gate_status state request reqd
         ) request reqd)
 
+  |> Http.Router.get "/api/v1/gate/discord/status" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         handle_gate_discord_status state request reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/gate/events" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          handle_gate_events state request reqd
@@ -306,4 +426,14 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/gate/keeper-status" (fun request reqd ->
        with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
          handle_gate_keeper_status ~sw ~clock state request reqd
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/gate/discord/bind" (fun request reqd ->
+       with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
+         handle_gate_discord_bind ~sw ~clock state request reqd
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/gate/discord/unbind" (fun request reqd ->
+       with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
+         handle_gate_discord_unbind ~sw ~clock state request reqd
        ) request reqd)

--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -21,6 +21,10 @@ DISCORD_BINDING_STORE_PATH=.gate/discord_bindings.json
 # Append-only operator audit trail for bind/unbind changes.
 DISCORD_BINDING_AUDIT_PATH=.gate/discord_binding_audit.jsonl
 
+# Runtime status heartbeat used by the dashboard's direct Discord panel.
+DISCORD_STATUS_PATH=.gate/discord_status.json
+STATUS_HEARTBEAT_SEC=10
+
 # Discord role ID for admin commands (optional)
 DISCORD_ADMIN_ROLE_ID=
 

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -78,6 +78,11 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 - successful bind/unbind operations also append an audit record to
   `DISCORD_BINDING_AUDIT_PATH` (default:
   `.gate/discord_binding_audit.jsonl`)
+- the bot also writes a direct runtime snapshot to `DISCORD_STATUS_PATH`
+  (default: `.gate/discord_status.json`) every `STATUS_HEARTBEAT_SEC`
+  seconds so the dashboard can show live Discord connection state
+- runtime binding changes written by the dashboard are hot-reloaded by the bot
+  without a process restart
 
 ## Operations Upgrades
 

--- a/sidecars/discord-bot/src/binding_store.py
+++ b/sidecars/discord-bot/src/binding_store.py
@@ -36,6 +36,12 @@ class BindingStore:
     def __init__(self, path: Path) -> None:
         self.path = path
 
+    def modified_time_ns(self) -> int | None:
+        try:
+            return self.path.stat().st_mtime_ns
+        except FileNotFoundError:
+            return None
+
     def load(self) -> dict[str, str] | None:
         """Return persisted bindings, or None when no valid store exists."""
         if not self.path.exists():

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 import time
 from typing import Any, cast
@@ -30,6 +31,7 @@ from .formatters import (
     render_structured_embeds,
 )
 from .gate_client import BreakerSnapshot, GateClient, GateResponse
+from .status_store import ConnectorRuntimeStatus, StatusStore
 
 logging.basicConfig(
     level=logging.INFO,
@@ -78,6 +80,7 @@ class GateBot(discord.Client):
         self.cfg = get_config()
         self.binding_store = BindingStore(self.cfg.binding_store_path())
         self.audit_store = BindingAuditStore(self.cfg.binding_audit_path())
+        self.status_store = StatusStore(self.cfg.status_path())
         persisted_bindings = self.binding_store.load()
         if persisted_bindings is None:
             self.keeper_bindings = self.cfg.keeper_map()
@@ -85,6 +88,12 @@ class GateBot(discord.Client):
         else:
             self.keeper_bindings = persisted_bindings
             self.binding_source = "persisted"
+        self._binding_store_mtime_ns = self.binding_store.modified_time_ns()
+        self._last_gate_health: bool | None = None
+        self._last_gate_health_at = ""
+        self._last_ready_at = ""
+        self._status_task: asyncio.Task[None] | None = None
+        self._write_runtime_status(connected_override=False)
 
     async def setup_hook(self) -> None:
         """Register slash commands on startup."""
@@ -95,15 +104,26 @@ class GateBot(discord.Client):
         self.tree.add_command(keeper_map)  # pyright: ignore[reportUnknownArgumentType]
         self.tree.add_command(keeper_audit)  # pyright: ignore[reportUnknownArgumentType]
         await self.tree.sync()
+        self._status_task = asyncio.create_task(self._status_heartbeat_loop())
+        self._write_runtime_status()
         logger.info("Slash commands synced")
 
     async def close(self) -> None:
         """Release resources on shutdown."""
+        if self._status_task is not None:
+            self._status_task.cancel()
+            try:
+                await self._status_task
+            except asyncio.CancelledError:
+                pass
+            self._status_task = None
+        self._write_runtime_status(connected_override=False)
         await self.gate.aclose()
         await super().close()
 
     async def on_ready(self) -> None:
         assert self.user is not None
+        self._last_ready_at = utc_now_iso()
         logger.info("Bot ready: %s (id=%s)", self.user.name, self.user.id)
         logger.info(
             "Keeper map (%s @ %s, audit %s): %s",
@@ -114,12 +134,15 @@ class GateBot(discord.Client):
         )
 
         healthy = await self.gate.health_check()
+        self._note_gate_health(healthy)
+        self._write_runtime_status()
         if healthy:
             logger.info("Gate health check: OK")
         else:
             logger.warning("Gate health check: FAILED (bot will retry on messages)")
 
     def _resolve_keeper_for_channel(self, channel: discord.abc.Snowflake) -> str | None:
+        self._maybe_reload_bindings()
         channel_id = str(channel.id)
         direct = self.keeper_bindings.get(channel_id)
         if direct is not None:
@@ -129,6 +152,7 @@ class GateBot(discord.Client):
         return None
 
     def channel_binding_debug(self, channel: discord.abc.Snowflake) -> tuple[str | None, str]:
+        self._maybe_reload_bindings()
         channel_id = str(channel.id)
         direct = self.keeper_bindings.get(channel_id)
         if direct is not None:
@@ -150,6 +174,8 @@ class GateBot(discord.Client):
     def persist_bindings(self) -> None:
         self.binding_store.save(self.keeper_bindings)
         self.binding_source = "persisted"
+        self._binding_store_mtime_ns = self.binding_store.modified_time_ns()
+        self._write_runtime_status()
 
     def append_binding_audit(
         self,
@@ -175,6 +201,77 @@ class GateBot(discord.Client):
 
     def _compose_gate_content(self, message: discord.Message) -> str:
         return compose_gate_content(message.content, attachment_lines(message))
+
+    def _note_gate_health(self, healthy: bool) -> None:
+        self._last_gate_health = healthy
+        self._last_gate_health_at = utc_now_iso()
+
+    def _maybe_reload_bindings(self) -> None:
+        current_mtime = self.binding_store.modified_time_ns()
+        if current_mtime == self._binding_store_mtime_ns:
+            return
+
+        if current_mtime is None:
+            self._binding_store_mtime_ns = None
+            return
+
+        persisted_bindings = self.binding_store.load()
+        self._binding_store_mtime_ns = current_mtime
+        if persisted_bindings is None:
+            return
+
+        if persisted_bindings != self.keeper_bindings:
+            logger.info(
+                "Reloaded %d Discord binding(s) from %s",
+                len(persisted_bindings),
+                self.binding_store.path,
+            )
+            self.keeper_bindings = persisted_bindings
+            self.binding_source = "persisted"
+            self._write_runtime_status()
+
+    def _write_runtime_status(self, *, connected_override: bool | None = None) -> None:
+        user_name = self.user.name if self.user is not None else ""
+        user_id = str(self.user.id) if self.user is not None else ""
+        connected = (
+            connected_override
+            if connected_override is not None
+            else self.is_ready() and not self.is_closed()
+        )
+        status = ConnectorRuntimeStatus(
+            updated_at=utc_now_iso(),
+            connected=connected,
+            bot_user_name=user_name,
+            bot_user_id=user_id,
+            guild_count=len(self.guilds),
+            gate_base_url=self.cfg.gate_base_url,
+            gate_healthy=self._last_gate_health,
+            gate_health_checked_at=self._last_gate_health_at,
+            last_ready_at=self._last_ready_at,
+            binding_source=self.binding_source,
+            runtime_bindings_count=len(self.keeper_bindings),
+            binding_store_path=str(self.binding_store.path),
+            audit_store_path=str(self.audit_store.path),
+            pid=os.getpid(),
+        )
+        try:
+            self.status_store.write(status)
+        except OSError as exc:
+            logger.warning("Failed to write Discord status store %s: %s", self.status_store.path, exc)
+
+    async def _status_heartbeat_loop(self) -> None:
+        interval = max(5, self.cfg.status_heartbeat_sec)
+        while True:
+            try:
+                self._maybe_reload_bindings()
+                healthy = await self.gate.health_check()
+                self._note_gate_health(healthy)
+                self._write_runtime_status()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning("Discord status heartbeat failed: %s", exc)
+            await asyncio.sleep(interval)
 
     def is_admin(self, interaction: discord.Interaction) -> bool:
         member = interaction.user
@@ -277,6 +374,7 @@ class GateBot(discord.Client):
         if not message.guild:
             return
 
+        self._maybe_reload_bindings()
         keeper_name = self._resolve_keeper_for_channel(message.channel)
         if keeper_name is None:
             return

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -65,6 +65,13 @@ class BotConfig(BaseSettings):
             "discord_binding_audit_path",
         ),
     )
+    discord_status_path: str = Field(
+        default=".gate/discord_status.json",
+        validation_alias=AliasChoices(
+            "DISCORD_STATUS_PATH",
+            "discord_status_path",
+        ),
+    )
 
     # Optional
     discord_admin_role_id: str = Field(
@@ -104,6 +111,10 @@ class BotConfig(BaseSettings):
         default=30,
         validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
     )
+    status_heartbeat_sec: int = Field(
+        default=10,
+        validation_alias=AliasChoices("STATUS_HEARTBEAT_SEC", "status_heartbeat_sec"),
+    )
 
     @field_validator("discord_bot_token")
     @classmethod
@@ -141,7 +152,11 @@ class BotConfig(BaseSettings):
             raise ValueError(f"DISCORD_KEEPER_MAP is not valid JSON: {e}") from e
         return v
 
-    @field_validator("discord_binding_store_path", "discord_binding_audit_path")
+    @field_validator(
+        "discord_binding_store_path",
+        "discord_binding_audit_path",
+        "discord_status_path",
+    )
     @classmethod
     def validate_non_empty_path(cls, v: str) -> str:
         if not v.strip():
@@ -161,6 +176,7 @@ class BotConfig(BaseSettings):
         "keeper_cache_ttl_sec",
         "gate_breaker_failure_threshold",
         "gate_breaker_reset_sec",
+        "status_heartbeat_sec",
     )
     @classmethod
     def validate_non_negative_ints(cls, v: int) -> int:
@@ -193,6 +209,12 @@ class BotConfig(BaseSettings):
 
     def binding_audit_path(self) -> Path:
         path = Path(self.discord_binding_audit_path).expanduser()
+        if path.is_absolute():
+            return path
+        return Path.cwd() / path
+
+    def status_path(self) -> Path:
+        path = Path(self.discord_status_path).expanduser()
         if path.is_absolute():
             return path
         return Path.cwd() / path

--- a/sidecars/discord-bot/src/status_store.py
+++ b/sidecars/discord-bot/src/status_store.py
@@ -1,0 +1,71 @@
+"""Durable runtime status store for the Discord connector."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorRuntimeStatus:
+    """One connector runtime snapshot for dashboard consumption."""
+
+    updated_at: str
+    connected: bool
+    bot_user_name: str
+    bot_user_id: str
+    guild_count: int
+    gate_base_url: str
+    gate_healthy: bool | None
+    gate_health_checked_at: str
+    last_ready_at: str
+    binding_source: str
+    runtime_bindings_count: int
+    binding_store_path: str
+    audit_store_path: str
+    pid: int
+
+    @staticmethod
+    def from_json(data: dict[str, Any]) -> ConnectorRuntimeStatus:
+        raw_gate_healthy = data.get("gate_healthy")
+        gate_healthy = raw_gate_healthy if isinstance(raw_gate_healthy, bool) else None
+        return ConnectorRuntimeStatus(
+            updated_at=str(data.get("updated_at", "")),
+            connected=bool(data.get("connected", False)),
+            bot_user_name=str(data.get("bot_user_name", "")),
+            bot_user_id=str(data.get("bot_user_id", "")),
+            guild_count=int(data.get("guild_count", 0)),
+            gate_base_url=str(data.get("gate_base_url", "")),
+            gate_healthy=gate_healthy,
+            gate_health_checked_at=str(data.get("gate_health_checked_at", "")),
+            last_ready_at=str(data.get("last_ready_at", "")),
+            binding_source=str(data.get("binding_source", "")),
+            runtime_bindings_count=int(data.get("runtime_bindings_count", 0)),
+            binding_store_path=str(data.get("binding_store_path", "")),
+            audit_store_path=str(data.get("audit_store_path", "")),
+            pid=int(data.get("pid", 0)),
+        )
+
+
+class StatusStore:
+    """Persist connector runtime snapshots atomically."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def write(self, status: ConnectorRuntimeStatus) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
+        payload = json.dumps(asdict(status), indent=2, sort_keys=True)
+        try:
+            tmp_path.write_text(f"{payload}\n", encoding="utf-8")
+            os.replace(tmp_path, self.path)
+        except OSError:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise

--- a/sidecars/discord-bot/tests/test_binding_store.py
+++ b/sidecars/discord-bot/tests/test_binding_store.py
@@ -13,6 +13,7 @@ from src.config import BotConfig
 def test_binding_store_load_returns_none_when_missing(tmp_path: Path) -> None:
     store = BindingStore(tmp_path / "bindings.json")
     assert store.load() is None
+    assert store.modified_time_ns() is None
 
 
 def test_binding_store_round_trips_saved_bindings(tmp_path: Path) -> None:
@@ -26,6 +27,7 @@ def test_binding_store_round_trips_saved_bindings(tmp_path: Path) -> None:
         "123": "luna",
         "456": "sangsu",
     }
+    assert store.modified_time_ns() is not None
 
 
 def test_binding_store_ignores_invalid_json(tmp_path: Path) -> None:
@@ -42,6 +44,7 @@ def test_config_resolves_relative_binding_store_path(tmp_path: Path) -> None:
         gate_api_token="test-api-token",
         discord_binding_store_path="state/discord.json",
         discord_binding_audit_path="audit/discord.jsonl",
+        discord_status_path="status/discord.json",
     )
 
     original_cwd = Path.cwd()
@@ -49,5 +52,6 @@ def test_config_resolves_relative_binding_store_path(tmp_path: Path) -> None:
         os.chdir(tmp_path)
         assert cfg.binding_store_path() == tmp_path / "state" / "discord.json"
         assert cfg.binding_audit_path() == tmp_path / "audit" / "discord.jsonl"
+        assert cfg.status_path() == tmp_path / "status" / "discord.json"
     finally:
         os.chdir(original_cwd)

--- a/sidecars/discord-bot/tests/test_status_store.py
+++ b/sidecars/discord-bot/tests/test_status_store.py
@@ -1,0 +1,49 @@
+"""Tests for Discord runtime status persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.status_store import ConnectorRuntimeStatus, StatusStore
+
+
+def test_status_store_writes_connector_runtime_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "state" / "discord_status.json"
+    store = StatusStore(path)
+
+    store.write(
+        ConnectorRuntimeStatus(
+            updated_at="2026-04-08T13:00:00Z",
+            connected=True,
+            bot_user_name="sangsu",
+            bot_user_id="1489985300729172039",
+            guild_count=3,
+            gate_base_url="http://localhost:8935",
+            gate_healthy=True,
+            gate_health_checked_at="2026-04-08T13:00:00Z",
+            last_ready_at="2026-04-08T12:59:55Z",
+            binding_source="persisted",
+            runtime_bindings_count=2,
+            binding_store_path="/tmp/discord_bindings.json",
+            audit_store_path="/tmp/discord_binding_audit.jsonl",
+            pid=4242,
+        )
+    )
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "audit_store_path": "/tmp/discord_binding_audit.jsonl",
+        "binding_source": "persisted",
+        "binding_store_path": "/tmp/discord_bindings.json",
+        "bot_user_id": "1489985300729172039",
+        "bot_user_name": "sangsu",
+        "connected": True,
+        "gate_base_url": "http://localhost:8935",
+        "gate_health_checked_at": "2026-04-08T13:00:00Z",
+        "gate_healthy": True,
+        "guild_count": 3,
+        "last_ready_at": "2026-04-08T12:59:55Z",
+        "pid": 4242,
+        "runtime_bindings_count": 2,
+        "updated_at": "2026-04-08T13:00:00Z",
+    }

--- a/test/dune
+++ b/test/dune
@@ -725,6 +725,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_channel_gate_discord_state)
+ (modules test_channel_gate_discord_state)
+ (libraries masc_test_deps))
+
+(test
  (name test_gate_protocol)
  (modules test_gate_protocol)
  (libraries masc_test_deps))

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -1,0 +1,107 @@
+open Alcotest
+
+module Discord_state = Masc_mcp.Channel_gate_discord_state
+module U = Yojson.Safe.Util
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let with_temp_dir f =
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "discord-state-%06x" (Random.bits ()))
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then (
+            Sys.readdir path
+            |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          ) else Sys.remove path
+      in
+      rm_rf base)
+    (fun () -> f base)
+
+let with_discord_paths dir f =
+  let status_path = Filename.concat dir "status.json" in
+  let binding_path = Filename.concat dir "bindings.json" in
+  let audit_path = Filename.concat dir "audit.jsonl" in
+  with_env "MASC_DISCORD_STATUS_PATH" (Some status_path) (fun () ->
+    with_env "MASC_DISCORD_BINDING_STORE_PATH" (Some binding_path) (fun () ->
+      with_env "MASC_DISCORD_BINDING_AUDIT_PATH" (Some audit_path) f))
+
+let test_status_json_reports_missing_live_status () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    let json = Discord_state.status_json () in
+    check bool "available false" false
+      (json |> U.member "available" |> U.to_bool);
+    check bool "connected false" false
+      (json |> U.member "connected" |> U.to_bool);
+    check bool "stale true" true
+      (json |> U.member "stale" |> U.to_bool);
+    check int "no configured bindings" 0
+      (json |> U.member "configured_bindings" |> U.to_list |> List.length))
+
+let test_bind_persists_binding_and_audit () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    match
+      Discord_state.bind ~channel_id:"1234567890" ~keeper_name:"luna"
+        ~actor_name:"dashboard"
+    with
+    | Error err -> fail err
+    | Ok json ->
+        let bindings = json |> U.member "configured_bindings" |> U.to_list in
+        check int "one configured binding" 1 (List.length bindings);
+        check string "keeper persisted" "luna"
+          (List.hd bindings |> U.member "keeper_name" |> U.to_string);
+        let audit = json |> U.member "recent_audit" |> U.to_list in
+        check int "one audit event" 1 (List.length audit);
+        check string "audit actor" "dashboard"
+          (List.hd audit |> U.member "actor_name" |> U.to_string))
+
+let test_unbind_removes_existing_binding () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    ignore
+      (Discord_state.bind ~channel_id:"1234567890" ~keeper_name:"luna"
+         ~actor_name:"dashboard");
+    match
+      Discord_state.unbind ~channel_id:"1234567890" ~actor_name:"dashboard"
+    with
+    | Error err -> fail err
+    | Ok json ->
+        check int "bindings cleared" 0
+          (json |> U.member "configured_bindings" |> U.to_list |> List.length);
+        let audit = json |> U.member "recent_audit" |> U.to_list in
+        check int "two audit events" 2 (List.length audit);
+        check string "latest audit action" "unbind"
+          (List.hd audit |> U.member "action" |> U.to_string))
+
+let () =
+  Random.self_init ();
+  run "channel_gate_discord_state"
+    [
+      ( "status",
+        [
+          test_case "missing live status" `Quick
+            test_status_json_reports_missing_live_status;
+          test_case "bind persists binding and audit" `Quick
+            test_bind_persists_binding_and_audit;
+          test_case "unbind removes binding" `Quick
+            test_unbind_removes_existing_binding;
+        ] );
+    ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -126,10 +126,26 @@ let test_route_auth_contracts () =
     (file_contains_pattern
        "lib/server/server_auth.ml"
        {|String.equal path "/api/v1/gate/events"|});
+  check bool "discord gate status route stays public read" true
+    (file_contains_pattern
+       "lib/server/server_auth.ml"
+       {|String.equal path "/api/v1/gate/discord/status"|});
   check bool "channel gate health route is registered" true
     (file_contains_pattern
         "lib/server/server_routes_http_routes_channel_gate.ml"
-        {|Http.Router.get "/api/v1/gate/health"|})
+        {|Http.Router.get "/api/v1/gate/health"|});
+  check bool "discord gate status route is registered" true
+    (file_contains_pattern
+       "lib/server/server_routes_http_routes_channel_gate.ml"
+       {|Http.Router.get "/api/v1/gate/discord/status"|});
+  check bool "discord gate bind route is registered" true
+    (file_contains_pattern
+       "lib/server/server_routes_http_routes_channel_gate.ml"
+       {|Http.Router.post "/api/v1/gate/discord/bind"|});
+  check bool "discord gate unbind route is registered" true
+    (file_contains_pattern
+       "lib/server/server_routes_http_routes_channel_gate.ml"
+       {|Http.Router.post "/api/v1/gate/discord/unbind"|})
 
 let test_http_write_auth_contracts () =
   check bool "server auth no longer accepts query token fallback" true


### PR DESCRIPTION
## What changed
- add a direct Discord runtime status surface to the dashboard so operators can see bot connection state separately from Gate-observed traffic
- add dashboard bind/unbind actions backed by new Channel Gate HTTP routes
- persist Discord runtime status, binding store, and binding audit state so the core server can read and mutate connector state without a separate admin sidecar

## Why
- MASC knew only Gate-observed connector traffic, not whether the Discord bot itself was directly connected
- operators needed a single dashboard surface for both visibility and channel-to-keeper control

## Impact
- Overview now shows Connector Operations as a top-level card
- Discord bindings can be managed from the dashboard and hot-reloaded by the bot
- the server exposes `/api/v1/gate/discord/status`, `/api/v1/gate/discord/bind`, and `/api/v1/gate/discord/unbind`

## Validation
- `npm run typecheck`
- `npm test -- connector-status.test.ts overview/overview.test.ts`
- `ruff check src/binding_store.py src/bot.py src/config.py src/status_store.py tests/test_binding_store.py tests/test_status_store.py`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/sidecars/discord-bot/.venv/bin/pytest tests/`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/discord-dashboard-ui ./test/test_ci_hardening_source.exe`
- `env DUNE_BUILD_DIR=_build_discord_ui dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/discord-dashboard-ui ./test/test_channel_gate_discord_state.exe`

## Notes
- `pyright` was not available in this environment, so Python type-checking was not run.
- the PR is draft because it adds new dashboard and connector control surfaces.