### PR TITLE
fix: revert cn_llama indirection, propagate error instead

### DIFF
--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -77,11 +77,10 @@ let prepare_start_params (ctx : context) args =
   let source_workdir = get_string args "workdir" ctx.base_path in
   let max_cycles = get_int args "max_cycles" 100 in
   let cycle_timeout_s = get_float args "cycle_timeout_s" 300.0 in
-  let default_model =
-    match Provider_adapter.default_model_label_result () with
-    | Ok label -> label
-    | Error _ -> Provider_adapter.cn_llama
-  in
+  let default_model_result = Provider_adapter.default_model_label_result () in
+  match default_model_result with
+  | Error e -> Error (Printf.sprintf "no default model configured: %s" e)
+  | Ok default_model ->
   let model_model = get_string args "model_model" default_model in
   if goal = "" then
     Error "goal is required"

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -77,11 +77,14 @@ let prepare_start_params (ctx : context) args =
   let source_workdir = get_string args "workdir" ctx.base_path in
   let max_cycles = get_int args "max_cycles" 100 in
   let cycle_timeout_s = get_float args "cycle_timeout_s" 300.0 in
-  let default_model_result = Provider_adapter.default_model_label_result () in
-  match default_model_result with
+  let model_model_result =
+    match get_string_opt args "model_model" with
+    | Some m -> Ok m
+    | None -> Provider_adapter.default_model_label_result ()
+  in
+  match model_model_result with
   | Error e -> Error (Printf.sprintf "no default model configured: %s" e)
-  | Ok default_model ->
-  let model_model = get_string args "model_model" default_model in
+  | Ok model_model ->
   if goal = "" then
     Error "goal is required"
   else if metric_fn = "" then

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -213,8 +213,8 @@ let dispatch (ctx : context) ~(name : string) : result option =
       in
       let runtime_model_valid =
         match (spawn_agent_name, model_name) with
-        | agent, None when String.equal agent Provider_adapter.cn_llama -> Error "model is required when agent_name=llama"
-        | agent, Some raw when String.equal agent Provider_adapter.cn_llama ->
+        | "llama", None -> Error "model is required when agent_name=llama"
+        | "llama", Some raw ->
             let spec_name =
               if String.contains raw ':' then raw else Provider_adapter.make_local_label raw
             in

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -24,7 +24,7 @@ let normalize_spawn_agent agent_name =
 let is_local_spawn_agent agent_name =
   match normalize_spawn_agent agent_name with
   | "default" -> true
-  | s when String.equal s Provider_adapter.cn_llama -> true
+  | "llama" -> true
   | _ -> false
 
 let legacy_spawn_fields = [ "spawn_agent"; "spawn_model" ]

--- a/test/test_autoresearch_oas_primitives.ml
+++ b/test/test_autoresearch_oas_primitives.ml
@@ -327,6 +327,7 @@ let test_start_seeds_source_only_target_file_into_managed_worktree () =
             ("metric_fn", `String "/usr/bin/printf 1.0");
             ("target_file", `String target_file);
             ("workdir", `String repo);
+            ("model_model", `String "test:dummy");
             ("max_cycles", `Int 1);
           ])
   with

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2472,6 +2472,7 @@ let test_execute_tool_autoresearch_uses_resolved_session_agent () =
                 ("metric_fn", `String "echo");
                 ("target_file", `String "target.txt");
                 ("workdir", `String workdir_path);
+                ("model_model", `String "test:dummy");
                 ("max_cycles", `Int 1);
               ])
       in


### PR DESCRIPTION
## Summary
- Revert `Provider_adapter.cn_llama` when-guards back to `"llama"` literals
- Fix the actual bug: error propagation instead of silent fallback in `tool_autoresearch`

## Why
`"llama"` is a stable external provider identifier. Wrapping it in a constant
added OCaml when-guard complexity with no type safety benefit (both are `string`).
The real HARD violation was silent error swallowing, not the string literal.

## Changes
- `tool_autoresearch.ml`: `Error _ -> "llama"` -> proper `Error` propagation
- `tool_team_session_routing.ml`: `when String.equal s Provider_adapter.cn_llama` -> `| "llama"`
- `tool_inline_dispatch.ml`: same revert to pattern match
- tests: pass explicit `model_model` in the autoresearch paths that previously relied on silent fallback

## Product impact
- `masc_autoresearch_start` now fails loudly when no default model is configured instead of silently routing to local llama
- the stable external provider identifier remains `"llama"` without extra when-guard indirection

## Evidence
- previous CI run `24141815050` failed on the old head because autoresearch tests still assumed silent fallback when no default model was configured
- follow-up commit `7025a81` supplies explicit `model_model` in the affected autoresearch tests
- current CI rerun for head `7025a81`: `24142662027`

## Review evidence
- direct GLM review requested via `sb glm-text` on 2026-04-09 KST; response still pending at the time of this update
- local `dune build --root . test/test_autoresearch_oas_primitives.exe` from this shell is blocked by an unrelated local `Agent_sdk.Types.ToolResult` type mismatch, so GitHub Actions is the source of truth for pass/fail on this branch

## Linked issue
- Refs #5680

## Test plan
- [ ] CI build passes
- [ ] CI tests pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
