### PR TITLE
fix(governance): add pre-merge review gate to keeper_github

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -68,26 +68,29 @@ let handle_keeper_github
          cross-agent review. Ref: #5906 *)
       else if Worker_dev_tools.is_gh_pr_merge gh_raw then (
         let root = Keeper_alerting_path.project_root_of_config config in
-        (* Extract PR number from command args *)
-        let pr_number =
-          let parts = String.split_on_char ' ' gh_raw in
-          List.find_opt (fun s ->
-            String.length s > 0 && s.[0] >= '0' && s.[0] <= '9') parts
+        let review_check =
+          let merge_target = Worker_dev_tools.gh_pr_merge_target gh_raw in
+          let target_arg =
+            match merge_target with
+            | Some target -> " " ^ Filename.quote target
+            | None -> ""
+          in
+          let check_cmd = Printf.sprintf
+            "cd %s && gh pr view%s --json reviews --jq '.reviews | map(select(.state != \"DISMISSED\")) | length' 2>&1"
+            (Filename.quote root) target_arg
+          in
+          let st, out = Process_eio.run_argv_with_status ~timeout_sec:10.0
+            [ "/bin/zsh"; "-lc"; check_cmd ]
+          in
+          if st = Unix.WEXITED 0 then
+            let count = String.trim out in
+            if count = "0" || count = "" then `Blocked_no_reviews
+            else `Allowed
+          else
+            `Check_failed (String.trim out)
         in
-        let review_ok = match pr_number with
-          | None -> true (* no PR number found — let gh handle the error *)
-          | Some num ->
-            let check_cmd = Printf.sprintf
-              "cd %s && gh pr view %s --json reviews --jq '[.[] | select(.state != \"DISMISSED\")] | length' 2>&1"
-              (Filename.quote root) num in
-            let st, out = Process_eio.run_argv_with_status ~timeout_sec:10.0
-              [ "/bin/zsh"; "-lc"; check_cmd ] in
-            if st = Unix.WEXITED 0 then
-              let count = String.trim out in
-              count <> "0" && count <> ""
-            else true (* gh failed — let the merge attempt proceed and fail naturally *)
-        in
-        if not review_ok then (
+        match review_check with
+        | `Blocked_no_reviews ->
           Log.Keeper.warn "keeper_github merge-review-gate: blocked %s (keeper=%s, no reviews)"
             gh_raw meta.name;
           Yojson.Safe.to_string
@@ -100,9 +103,28 @@ let handle_keeper_github
                        Every PR requires at least one cross-agent review before merge. \
                        Post a review first, then retry." )
                 ; "cmd", `String ("gh " ^ gh_raw)
-                ]))
-        else (
-          let gh_cmd = "gh " ^ (if cmd <> "" then cmd else String.concat " " (List.map Filename.quote gh_args)) in
+                ])
+        | `Check_failed err ->
+          Log.Keeper.warn
+            "keeper_github merge-review-gate: verification failed %s (keeper=%s, err=%s)"
+            gh_raw meta.name (if err = "" then "<empty>" else err);
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String "merge_review_check_failed"
+                ; ( "reason"
+                  , `String
+                      "Cannot verify PR review state for this merge target. \
+                       Resolve the gh pr view failure or request operator approval, \
+                       then retry." )
+                ; "details", `String err
+                ; "cmd", `String ("gh " ^ gh_raw)
+                ])
+        | `Allowed ->
+          let gh_cmd =
+            "gh "
+            ^ (if cmd <> "" then cmd else String.concat " " (List.map Filename.quote gh_args))
+          in
           let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
           let st, out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
           Yojson.Safe.to_string
@@ -110,7 +132,7 @@ let handle_keeper_github
                 [ "ok", `Bool (st = Unix.WEXITED 0)
                 ; "status", Keeper_alerting_path.process_status_to_json st
                 ; "output", `String out
-                ])))
+                ]))
       else (
         let gh_cmd =
           if cmd <> ""

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -63,6 +63,54 @@ let handle_keeper_github
                      or request operator approval." )
               ; "cmd", `String ("gh " ^ gh_raw)
               ]))
+      (* Pre-merge review gate: verify PR has at least one non-dismissed review
+         before allowing gh pr merge. Prevents agents from self-merging without
+         cross-agent review. Ref: #5906 *)
+      else if Worker_dev_tools.is_gh_pr_merge gh_raw then (
+        let root = Keeper_alerting_path.project_root_of_config config in
+        (* Extract PR number from command args *)
+        let pr_number =
+          let parts = String.split_on_char ' ' gh_raw in
+          List.find_opt (fun s ->
+            String.length s > 0 && s.[0] >= '0' && s.[0] <= '9') parts
+        in
+        let review_ok = match pr_number with
+          | None -> true (* no PR number found — let gh handle the error *)
+          | Some num ->
+            let check_cmd = Printf.sprintf
+              "cd %s && gh pr view %s --json reviews --jq '[.[] | select(.state != \"DISMISSED\")] | length' 2>&1"
+              (Filename.quote root) num in
+            let st, out = Process_eio.run_argv_with_status ~timeout_sec:10.0
+              [ "/bin/zsh"; "-lc"; check_cmd ] in
+            if st = Unix.WEXITED 0 then
+              let count = String.trim out in
+              count <> "0" && count <> ""
+            else true (* gh failed — let the merge attempt proceed and fail naturally *)
+        in
+        if not review_ok then (
+          Log.Keeper.warn "keeper_github merge-review-gate: blocked %s (keeper=%s, no reviews)"
+            gh_raw meta.name;
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String "merge_blocked_no_reviews"
+                ; ( "reason"
+                  , `String
+                      "Cannot merge: PR has no non-dismissed reviews. \
+                       Every PR requires at least one cross-agent review before merge. \
+                       Post a review first, then retry." )
+                ; "cmd", `String ("gh " ^ gh_raw)
+                ]))
+        else (
+          let gh_cmd = "gh " ^ (if cmd <> "" then cmd else String.concat " " (List.map Filename.quote gh_args)) in
+          let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
+          let st, out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool (st = Unix.WEXITED 0)
+                ; "status", Keeper_alerting_path.process_status_to_json st
+                ; "output", `String out
+                ])))
       else (
         let gh_cmd =
           if cmd <> ""

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -636,6 +636,58 @@ let is_gh_pr_merge cmd =
   | "pr" :: rest -> has_positional_subcmd [ "merge" ] rest
   | _ -> false
 
+let gh_raw_parts cmd =
+  String.split_on_char ' ' (String.trim cmd)
+  |> List.filter (fun s -> s <> "")
+
+let gh_option_takes_value tok =
+  let tok = String.lowercase_ascii tok in
+  not (contains_substring tok "=")
+  && List.mem tok
+       [ "-r"; "--repo";
+         "-b"; "--body";
+         "-f"; "--body-file";
+         "-t"; "--subject";
+         "--match-head-commit";
+         "--author-email" ]
+
+(** Return the explicit target passed to [gh pr merge], if any.
+    Supports numeric PR ids, branch names, and PR URLs. Returns [None]
+    when the merge command targets the current branch's PR. *)
+let gh_pr_merge_target cmd =
+  let raw_parts = gh_raw_parts cmd in
+  let lower_parts = List.map String.lowercase_ascii raw_parts in
+  let rec drop_until_merge raw lower =
+    match raw, lower with
+    | _raw_hd :: raw_tl, lower_hd :: lower_tl ->
+        if lower_hd = "merge" then Some (raw_tl, lower_tl)
+        else drop_until_merge raw_tl lower_tl
+    | _ -> None
+  in
+  let rec find_target raw lower =
+    match raw, lower with
+    | [], [] -> None
+    | raw_hd :: raw_tl, lower_hd :: lower_tl ->
+        if String.length lower_hd > 0 && lower_hd.[0] = '-' then
+          if gh_option_takes_value lower_hd then
+            (match raw_tl, lower_tl with
+             | _value :: raw_rest, _value_lower :: lower_rest ->
+                 find_target raw_rest lower_rest
+             | _ -> None)
+          else
+            find_target raw_tl lower_tl
+        else
+          Some raw_hd
+    | _ -> None
+  in
+  match lower_parts with
+  | "pr" :: _ -> (
+      match drop_until_merge raw_parts lower_parts with
+      | Some (raw_after_merge, lower_after_merge) ->
+          find_target raw_after_merge lower_after_merge
+      | None -> None)
+  | _ -> None
+
 (** Check if a gh command is a dangerous irreversible operation (delete,
     archive, transfer). Always gated regardless of preset. *)
 let is_gh_dangerous_operation cmd =

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -629,6 +629,13 @@ let is_gh_workflow_operation cmd =
          [ "/merge"; "/merges"; "state=closed"; "state=\"closed\""; "state='closed'" ]
   | _ -> false
 
+(** Check if a gh command is specifically [gh pr merge]. *)
+let is_gh_pr_merge cmd =
+  let parts = gh_op_parts cmd in
+  match parts with
+  | "pr" :: rest -> has_positional_subcmd [ "merge" ] rest
+  | _ -> false
+
 (** Check if a gh command is a dangerous irreversible operation (delete,
     archive, transfer). Always gated regardless of preset. *)
 let is_gh_dangerous_operation cmd =

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -582,6 +582,30 @@ let () =
         Alcotest.(check bool) "git commit" false
           (Worker_dev_tools.is_destructive_bash_operation "git commit -m 'fix'"));
     ];
+    "gh_pr_merge_target", [
+      Alcotest.test_case "extracts numeric pr id" `Quick (fun () ->
+        Alcotest.(check (option string)) "numeric target" (Some "5934")
+          (Worker_dev_tools.gh_pr_merge_target "pr merge 5934"));
+      Alcotest.test_case "extracts explicit branch target" `Quick (fun () ->
+        Alcotest.(check (option string)) "branch target" (Some "feature/review-gate")
+          (Worker_dev_tools.gh_pr_merge_target "pr merge feature/review-gate"));
+      Alcotest.test_case "extracts explicit url target" `Quick (fun () ->
+        Alcotest.(check (option string)) "url target"
+          (Some "https://github.com/jeong-sik/masc-mcp/pull/5934")
+          (Worker_dev_tools.gh_pr_merge_target
+             "pr merge https://github.com/jeong-sik/masc-mcp/pull/5934"));
+      Alcotest.test_case "skips repo flag value" `Quick (fun () ->
+        Alcotest.(check (option string)) "repo flag skipped" (Some "5934")
+          (Worker_dev_tools.gh_pr_merge_target
+             "pr merge --repo jeong-sik/masc-mcp 5934"));
+      Alcotest.test_case "returns none for current branch merge" `Quick (fun () ->
+        Alcotest.(check (option string)) "implicit current branch" None
+          (Worker_dev_tools.gh_pr_merge_target "pr merge --squash --delete-branch"));
+      Alcotest.test_case "skips match-head-commit value" `Quick (fun () ->
+        Alcotest.(check (option string)) "match-head-commit skipped" (Some "5934")
+          (Worker_dev_tools.gh_pr_merge_target
+             "pr merge --match-head-commit abc123 5934"));
+    ];
     "sanitize_command_for_log", [
       Alcotest.test_case "redacts url credentials" `Quick (fun () ->
         let redacted =


### PR DESCRIPTION
## Summary
`gh pr merge` 실행 전 PR 리뷰 상태를 검증하는 코드 레벨 gate 추가.

### 동작
1. `is_gh_pr_merge` — `gh pr merge` 명령 감지
2. PR 번호 추출 → `gh pr view <N> --json reviews` 실행
3. non-dismissed 리뷰가 0건이면 `merge_blocked_no_reviews` 에러 반환
4. 리뷰가 있으면 정상 실행

### 배경
- #5906: Gemini 에이전트가 BLOCK 리뷰 무시 후 merge
- keeper constitution 규칙(#5908)은 prompt 기반이라 무시됨
- 이 PR은 결정론적 코드 gate

## Product impact
- keeper_github 경로에서 리뷰가 전혀 없는 PR merge 시도를 코드 레벨에서 차단
- 프롬프트 준수 실패와 무관하게 최소 리뷰 gate를 강제

## Evidence
- Incident / repro source: #5906
- Existing governance guidance alone was insufficient: #5908
- This patch adds a deterministic pre-merge check before `gh pr merge`

## Review evidence
- Draft PR 기준 사전 triage 완료: unresolved review thread 없음
- Cross-model review evidence: pending
- As of 2026-04-08 23:55 KST, required CI checks are still running on this draft PR

## Linked issue
- Closes #5906
- Refs #5908

## Note
- Merge readiness is still gated on CI completion and external review

## Test plan
- [ ] main 빌드 fix 후 `dune build` pass 확인
- [ ] `is_gh_pr_merge` unit test 추가 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)
