### PR TITLE
Handle keeper partial commits as manual reconcile state

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -295,6 +295,17 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | Some entry -> Some (Keeper_state_machine.phase_to_string entry.phase)
             | None -> None
           in
+          let reconcile_status =
+            match registry_entry with
+            | Some entry when
+                entry.turn_consecutive_failures > 0
+                && (match entry.last_failure_reason with
+                    | Some reason ->
+                        Keeper_registry.failure_reason_requires_manual_reconcile reason
+                    | None -> false) ->
+                Some "manual_reconcile_required"
+            | _ -> None
+          in
           let supervisor_diagnostics =
             let max_restarts =
               Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
@@ -463,6 +474,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("phase",
                 match phase with
                 | Some p -> `String p
+                | None -> `Null);
+              ("reconcile_status",
+                match reconcile_status with
+                | Some status -> `String status
                 | None -> `Null);
               ("supervisor_diagnostics", supervisor_diagnostics);
               ("agent_name", `String m.agent_name);

--- a/lib/keeper/keeper_invariant_check.ml
+++ b/lib/keeper/keeper_invariant_check.ml
@@ -64,14 +64,19 @@ let check_step_invariants
   if new_phase = SM.Dead && new_conditions.restart_budget_remaining then
     fail "DeadRequiresNoBudget" "phase=Dead but restart_budget_remaining=true";
 
-  (* 9. DerivePhaseAgreement — derive_phase must agree with recorded phase *)
+  (* 9. RunningClearsManualReconcile — Running implies no sticky reconcile flag *)
+  if new_phase = SM.Running && new_conditions.manual_reconcile_required then
+    fail "RunningClearsManualReconcile"
+      "phase=Running but manual_reconcile_required=true";
+
+  (* 10. DerivePhaseAgreement — derive_phase must agree with recorded phase *)
   let derived = SM.derive_phase new_conditions in
   if derived <> new_phase then
     fail "DerivePhaseAgreement"
       (Printf.sprintf "derive_phase=%s but recorded=%s"
          (SM.phase_to_string derived) (SM.phase_to_string new_phase));
 
-  (* 10. TransitionMatrixAgreement — phase change must be allowed *)
+  (* 11. TransitionMatrixAgreement — phase change must be allowed *)
   if prev_phase <> new_phase
      && not (SM.can_transition ~from_phase:prev_phase ~to_phase:new_phase) then
     fail "TransitionMatrixAgreement"

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -535,17 +535,32 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
       ~base_path:ctx.config.base_path meta.name
   in
   if stale_turn_failures > 0 then begin
-    Keeper_registry.reset_turn_failures
-      ~base_path:ctx.config.base_path meta.name;
-    ignore (Keeper_registry.dispatch_event
-      ~base_path:ctx.config.base_path meta.name
-      Keeper_state_machine.Heartbeat_ok);
-    ignore (Keeper_registry.dispatch_event
-      ~base_path:ctx.config.base_path meta.name
-      Keeper_state_machine.Turn_succeeded);
-    Log.Keeper.info
-      "heartbeat recovery: reset %d stale turn failures for %s"
-      stale_turn_failures meta.name
+    let sticky_manual_reconcile =
+      match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
+      | Some entry ->
+          (match entry.last_failure_reason with
+           | Some reason ->
+               Keeper_registry.failure_reason_requires_manual_reconcile reason
+           | None -> false)
+      | None -> false
+    in
+    if sticky_manual_reconcile then
+      Log.Keeper.warn
+        "heartbeat recovery: preserving %d turn failures for %s because manual reconcile is still required"
+        stale_turn_failures meta.name
+    else begin
+      Keeper_registry.reset_turn_failures
+        ~base_path:ctx.config.base_path meta.name;
+      ignore (Keeper_registry.dispatch_event
+        ~base_path:ctx.config.base_path meta.name
+        Keeper_state_machine.Heartbeat_ok);
+      ignore (Keeper_registry.dispatch_event
+        ~base_path:ctx.config.base_path meta.name
+        Keeper_state_machine.Turn_succeeded);
+      Log.Keeper.info
+        "heartbeat recovery: reset %d stale turn failures for %s"
+        stale_turn_failures meta.name
+    end
   end
 
 let sync_keeper_presence

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -4,7 +4,8 @@
 
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout. If the execution is cancelled by a timeout or global stop,
-    the exception is caught, the context mutations are discarded (functional rollback),
+    the exception is caught, OAS-local context mutations are discarded
+    (functional rollback), external tool side effects are not reverted,
     and an OAS timeout error is returned. *)
 let run_with_timeout_and_fallback ~timeout_s fn =
   let do_timeout fn =
@@ -16,13 +17,16 @@ let run_with_timeout_and_fallback ~timeout_s fn =
     do_timeout fn
   with
   | Eio.Time.Timeout ->
-    Log.Keeper.warn "keeper_llm_bridge: OAS execution timed out after %.1fs (structural rollback)" timeout_s;
+    Log.Keeper.warn
+      "keeper_llm_bridge: OAS execution timed out after %.1fs (OAS context rollback only; external tool side effects are not reverted)"
+      timeout_s;
     Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
   | Eio.Cancel.Cancelled _ ->
     (* TLA+: FiberHandlesCancellation -> Rollback context.
        Since Oas_worker_exec returns the new context functionally inside the run_result,
        we inherently discard intermediate state when cancelled here. *)
-    Log.Keeper.warn "keeper_llm_bridge: OAS execution cancelled (structural rollback)";
+    Log.Keeper.warn
+      "keeper_llm_bridge: OAS execution cancelled (OAS context rollback only; external tool side effects are not reverted)";
     Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
   | exn ->
     (* TLA+: HandleError -> Rollback context *)

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -2,7 +2,8 @@
 
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout. If the execution is cancelled by a timeout or global stop,
-    the exception is caught, the context mutations are discarded (functional rollback),
+    the exception is caught, OAS-local context mutations are discarded
+    (functional rollback), external tool side effects are not reverted,
     and an OAS timeout error is returned. *)
 val run_with_timeout_and_fallback :
   timeout_s:float ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -26,6 +26,7 @@ module StringMap = Map.Make (String)
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
+  | Ambiguous_partial_commit of string
   | Fiber_unresolved
   | Exception of string
 
@@ -34,8 +35,17 @@ let failure_reason_to_string = function
       Printf.sprintf "heartbeat_consecutive_failures(%d)" n
   | Turn_consecutive_failures n ->
       Printf.sprintf "turn_consecutive_failures(%d)" n
+  | Ambiguous_partial_commit s ->
+      Printf.sprintf "ambiguous_partial_commit(%s)" s
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception s -> Printf.sprintf "exception(%s)" s
+
+let failure_reason_requires_manual_reconcile = function
+  | Ambiguous_partial_commit _ -> true
+  | Heartbeat_consecutive_failures _
+  | Turn_consecutive_failures _
+  | Fiber_unresolved
+  | Exception _ -> false
 
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -16,10 +16,12 @@ module StringMap : Map.S with type key = string
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
+  | Ambiguous_partial_commit of string
   | Fiber_unresolved
   | Exception of string
 
 val failure_reason_to_string : failure_reason -> string
+val failure_reason_requires_manual_reconcile : failure_reason -> bool
 
 (** Pure control-flow signal for immediate fiber termination (RFC-0002).
     Carries no state — failure reason must be pre-stored via

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -53,6 +53,7 @@ type conditions = {
   fiber_alive : bool;
   heartbeat_healthy : bool;
   turn_healthy : bool;
+  manual_reconcile_required : bool;
   context_within_budget : bool;
   context_handoff_needed : bool;
   compaction_active : bool;
@@ -69,6 +70,7 @@ let default_conditions = {
   fiber_alive = false;
   heartbeat_healthy = true;
   turn_healthy = true;
+  manual_reconcile_required = false;
   context_within_budget = true;
   context_handoff_needed = false;
   compaction_active = false;
@@ -98,6 +100,7 @@ type event =
   | Heartbeat_failed of { consecutive : int; max_allowed : int }
   | Turn_succeeded
   | Turn_failed of { consecutive : int; max_allowed : int }
+  | Manual_reconcile_required of { reason : string }
   | Context_measured of {
       context_ratio : float;
       message_count : int;
@@ -128,6 +131,8 @@ let event_to_string = function
   | Turn_succeeded -> "turn_succeeded"
   | Turn_failed r ->
     Printf.sprintf "turn_failed(%d/%d)" r.consecutive r.max_allowed
+  | Manual_reconcile_required r ->
+    Printf.sprintf "manual_reconcile_required(%s)" r.reason
   | Context_measured r ->
     Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
   | Compaction_started -> "compaction_started"
@@ -267,7 +272,10 @@ let derive_phase (c : conditions) : phase =
   else if c.handoff_active then HandingOff
   else if c.compaction_active then Compacting
   (* 7. Health degradation *)
-  else if not c.heartbeat_healthy || not c.turn_healthy then Failing
+  else if not c.heartbeat_healthy
+          || not c.turn_healthy
+          || c.manual_reconcile_required
+  then Failing
   (* 8. Healthy running *)
   else if c.fiber_alive then Running
   (* 9. Initial / unreachable fallback *)
@@ -286,10 +294,15 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     let _ = max_allowed in
     { c with heartbeat_healthy = consecutive = 0 }
   | Turn_succeeded ->
-    { c with turn_healthy = true }
+    { c with
+      turn_healthy = true;
+      manual_reconcile_required = false;
+    }
   | Turn_failed { consecutive; max_allowed } ->
     let _ = max_allowed in
     { c with turn_healthy = consecutive = 0 }
+  | Manual_reconcile_required _ ->
+    { c with manual_reconcile_required = true }
   | Context_measured { auto_rules; _ } ->
     { c with
       guardrail_triggered = auto_rules.guardrail_stop;
@@ -335,6 +348,7 @@ let update_conditions (c : conditions) (ev : event) : conditions =
       fiber_alive = true;
       heartbeat_healthy = true;
       turn_healthy = true;
+      manual_reconcile_required = false;
       compaction_active = false;
       handoff_active = false;
       backoff_elapsed = false;
@@ -441,6 +455,7 @@ let conditions_to_json (c : conditions) =
     "fiber_alive", `Bool c.fiber_alive;
     "heartbeat_healthy", `Bool c.heartbeat_healthy;
     "turn_healthy", `Bool c.turn_healthy;
+    "manual_reconcile_required", `Bool c.manual_reconcile_required;
     "context_within_budget", `Bool c.context_within_budget;
     "context_handoff_needed", `Bool c.context_handoff_needed;
     "compaction_active", `Bool c.compaction_active;
@@ -468,6 +483,8 @@ let event_to_json (ev : event) : Yojson.Safe.t =
       "consecutive", `Int r.consecutive;
       "max_allowed", `Int r.max_allowed;
     ]
+  | Manual_reconcile_required r ->
+    obj "manual_reconcile_required" ["reason", `String r.reason]
   | Context_measured r ->
     obj "context_measured" [
       "context_ratio", `Float r.context_ratio;
@@ -542,14 +559,14 @@ let phase_to_mermaid ~(current : phase) : string =
   p "    Offline --> Running : Fiber_started\n";
   p "    Offline --> Draining : stop requested\n";
   p "    Offline --> Stopped : stop while not started\n";
-  p "    Running --> Failing : hb/turn fail\n";
+  p "    Running --> Failing : hb/turn/reconcile fail\n";
   p "    Running --> Compacting : compact start\n";
   p "    Running --> HandingOff : handoff start\n";
   p "    Running --> Draining : stop requested\n";
   p "    Running --> Paused : operator pause\n";
   p "    Running --> Stopped : stop requested\n";
   p "    Running --> Crashed : fiber death\n";
-  p "    Failing --> Running : hb/turn ok\n";
+  p "    Failing --> Running : clean turn recovery\n";
   p "    Failing --> Crashed : fiber death\n";
   p "    Failing --> Draining : stop requested\n";
   p "    Failing --> Paused : operator pause\n";

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -45,6 +45,9 @@ type conditions = {
   (** [consecutive_failures < max_hb_failures] *)
   turn_healthy : bool;
   (** [turn_consecutive_failures < max_turn_failures] *)
+  manual_reconcile_required : bool;
+  (** A prior turn committed an external side effect and ended ambiguously;
+      only a later clean turn may clear this sticky condition. *)
   context_within_budget : bool;
   (** [context_ratio < compaction.ratio_gate] *)
   context_handoff_needed : bool;
@@ -91,6 +94,7 @@ type event =
   | Heartbeat_failed of { consecutive : int; max_allowed : int }
   | Turn_succeeded
   | Turn_failed of { consecutive : int; max_allowed : int }
+  | Manual_reconcile_required of { reason : string }
   | Context_measured of {
       context_ratio : float;
       message_count : int;
@@ -161,7 +165,7 @@ val transition_error_to_string : transition_error -> string
     7. Paused (operator_paused)
     8. HandingOff (handoff_active)
     9. Compacting (compaction_active)
-    10. Failing (heartbeat or turn unhealthy)
+    10. Failing (heartbeat degraded, turn degraded, or manual reconcile required)
     11. Running (fiber_alive)
     12. Offline (default) *)
 val derive_phase : conditions -> phase

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -255,6 +255,7 @@ let cleanup_dead_tombstone (ctx : _ context)
 let cohort_key_of_reason = function
   | Some (Keeper_registry.Heartbeat_consecutive_failures _) -> "heartbeat_failures"
   | Some (Keeper_registry.Turn_consecutive_failures _) -> "turn_failures"
+  | Some (Keeper_registry.Ambiguous_partial_commit _) -> "ambiguous_partial_commit"
   | Some Keeper_registry.Fiber_unresolved -> "fiber_unresolved"
   | Some (Keeper_registry.Exception _) -> "exception"
   | None -> "unknown"

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -1,7 +1,7 @@
 (** Keeper_trace_emit — TLA+ trace validation용 상태 전이 기록.
 
     MASC_TLA_TRACE=1 일 때만 활성.
-    conditions_to_json 재사용으로 13필드 전체 기록. *)
+    conditions_to_json 재사용으로 14필드 전체 기록. *)
 
 module SM = Keeper_state_machine
 

--- a/lib/keeper/keeper_trace_validate.ml
+++ b/lib/keeper/keeper_trace_validate.ml
@@ -28,6 +28,7 @@ let parse_conditions (json : Yojson.Safe.t) : (SM.conditions, string) result =
   let* fiber_alive = get_bool json "fiber_alive" in
   let* heartbeat_healthy = get_bool json "heartbeat_healthy" in
   let* turn_healthy = get_bool json "turn_healthy" in
+  let* manual_reconcile_required = get_bool json "manual_reconcile_required" in
   let* context_within_budget = get_bool json "context_within_budget" in
   let* context_handoff_needed = get_bool json "context_handoff_needed" in
   let* compaction_active = get_bool json "compaction_active" in
@@ -39,7 +40,7 @@ let parse_conditions (json : Yojson.Safe.t) : (SM.conditions, string) result =
   let* guardrail_triggered = get_bool json "guardrail_triggered" in
   let* drain_complete = get_bool json "drain_complete" in
   Ok SM.{
-    fiber_alive; heartbeat_healthy; turn_healthy;
+    fiber_alive; heartbeat_healthy; turn_healthy; manual_reconcile_required;
     context_within_budget; context_handoff_needed;
     compaction_active; handoff_active; operator_paused;
     stop_requested; restart_budget_remaining;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -48,6 +48,34 @@ let is_transient_network_error (err : Oas.Error.sdk_error) : bool =
   | Oas.Error.Api (ServerError { status = 503; _ }) -> true
   | _ -> false
 
+let ambiguous_side_effect_error_prefix =
+  "turn outcome ambiguous after committed mutating tool call(s)"
+
+let committed_mutating_tools tool_names =
+  tool_names
+  |> dedupe_keep_order
+  |> List.filter (fun name -> not (Tool_dispatch.is_read_only name))
+
+let is_ambiguous_side_effect_error (err : Oas.Error.sdk_error) : bool =
+  match err with
+  | Oas.Error.Internal msg ->
+      string_contains_substring
+        ~needle:ambiguous_side_effect_error_prefix msg
+  | _ -> false
+
+let reclassify_error_after_side_effect
+    ~(tool_names : string list)
+    (err : Oas.Error.sdk_error) : Oas.Error.sdk_error =
+  let committed_tools = committed_mutating_tools tool_names in
+  if committed_tools = [] || is_ambiguous_side_effect_error err then err
+  else
+    let tools = String.concat ", " committed_tools in
+    let original = short_preview (Oas.Error.to_string err) in
+    Oas.Error.Internal
+        (Printf.sprintf
+         "%s: [%s]; retry disabled to avoid duplicate mutation; original_error=%s"
+         ambiguous_side_effect_error_prefix tools original)
+
 (** Max transient retries (excluding the initial attempt).  Total attempts
     = 1 initial + max_transient_retries.  OAS internal retry is 3 per
     provider; this outer retry covers cases where all providers fail
@@ -939,10 +967,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          wrapping the global [on_keeper_tool_call] ref. Each keeper registers
          an independent observer, so concurrent keepers cannot interfere
          with each other's save/restore lifecycle. *)
-      let side_effect_occurred = ref false in
+      let mutating_tools_committed = ref [] in
       let side_effect_observer ~tool_name ~success =
         if success && not (Tool_dispatch.is_read_only tool_name) then
-          side_effect_occurred := true
+          mutating_tools_committed := tool_name :: !mutating_tools_committed
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;
       let evidence_before_hash =
@@ -982,14 +1010,31 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~overflow_retry_used =
             match do_run ~run_meta ~max_context ~run_generation ~is_retry with
             | Ok _ as ok -> ok
-            | Error err when is_transient_network_error err
-                             && attempt <= max_transient_retries ->
-                if !side_effect_occurred then begin
-                  Log.Keeper.warn
-                    "%s: transient error after side-effecting tool call — skipping retry to prevent duplicate (error: %s)"
-                    meta.name (short_preview (Oas.Error.to_string err));
-                  Error err
-                end else begin
+            | Error err ->
+                let committed_tools =
+                  committed_mutating_tools !mutating_tools_committed
+                in
+                if committed_tools <> [] then begin
+                  let reclassified =
+                    reclassify_error_after_side_effect
+                      ~tool_names:committed_tools err
+                  in
+                  let err_preview = short_preview (Oas.Error.to_string err) in
+                  if is_transient_network_error err then
+                    Log.Keeper.error
+                      "%s: transient provider error after committed mutating tool call(s) [%s] — treating as integrity failure, skipping retry to prevent duplicate (error: %s)"
+                      meta.name
+                      (String.concat ", " committed_tools)
+                      err_preview
+                  else
+                    Log.Keeper.error
+                      "%s: error after committed mutating tool call(s) [%s] — turn outcome is ambiguous and requires reconcile (error: %s)"
+                      meta.name
+                      (String.concat ", " committed_tools)
+                      err_preview;
+                  Error reclassified
+                end else if is_transient_network_error err
+                              && attempt <= max_transient_retries then begin
                   let delay = transient_backoff_sec attempt in
                   Log.Keeper.warn
                     "%s: transient network error cascade=%s max_context=%d retry=%d/%d backoff=%.0fs: %s"
@@ -1000,30 +1045,30 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   retry_loop ~run_meta ~max_context ~run_generation
                     ~attempt:(attempt + 1)
                     ~is_retry:true ~overflow_retry_used
-                end
-            | Error err when (not overflow_retry_used)
-                             && is_context_overflow err -> (
-                match
-                  recover_context_overflow_retry ~meta ~base_dir
-                    ~max_cascade_context ~error:err
-                with
-                | Some retry_plan ->
-                    let retry_meta =
-                      if retry_plan.retry_generation = run_meta.runtime.generation
-                      then run_meta
-                      else
-                        map_runtime
-                          (fun rt ->
-                            { rt with generation = retry_plan.retry_generation })
-                          run_meta
-                    in
-                    Eio.Fiber.yield ();
-                    retry_loop ~run_meta:retry_meta
-                      ~max_context:retry_plan.retry_max_context
-                      ~run_generation:retry_plan.retry_generation ~attempt:1
-                      ~is_retry:true ~overflow_retry_used:true
-                | None -> Error err)
-            | Error err -> Error err
+                end else if (not overflow_retry_used)
+                             && is_context_overflow err then (
+                  match
+                    recover_context_overflow_retry ~meta ~base_dir
+                      ~max_cascade_context ~error:err
+                  with
+                  | Some retry_plan ->
+                      let retry_meta =
+                        if retry_plan.retry_generation = run_meta.runtime.generation
+                        then run_meta
+                        else
+                          map_runtime
+                            (fun rt ->
+                              { rt with generation = retry_plan.retry_generation })
+                            run_meta
+                      in
+                      Eio.Fiber.yield ();
+                      retry_loop ~run_meta:retry_meta
+                        ~max_context:retry_plan.retry_max_context
+                        ~run_generation:retry_plan.retry_generation ~attempt:1
+                        ~is_retry:true ~overflow_retry_used:true
+                  | None -> Error err)
+                else
+                  Error err
           in
           (* Wall-clock timeout guards against indefinite TCP-level hangs
              from upstream LLM providers. Without this, a single stalled
@@ -1050,10 +1095,15 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       | Error err ->
           let e_str = Oas.Error.to_string err in
           let is_transient = is_transient_network_error err in
+          let is_ambiguous_partial = is_ambiguous_side_effect_error err in
           Log.Keeper.error
             "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
             meta.name meta.cascade_name max_cascade_context latency_ms
-            (if is_transient then " (transient, cooldown preserved)" else "")
+            (if is_ambiguous_partial then
+               " (ambiguous partial commit)"
+             else if is_transient then
+               " (transient, cooldown preserved)"
+             else "")
             (short_preview e_str);
           let social_state =
             Social.derive_failure_state ~meta ~observation ~reason:e_str
@@ -1062,8 +1112,23 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             update_metrics_from_failure meta ~latency_ms ~observation ~reason:e_str
               ~is_transient ~social_state ()
           in
+          if is_ambiguous_partial then begin
+            Keeper_registry.set_failure_reason ~base_path:config.base_path
+              meta.name
+              (Some (Keeper_registry.Ambiguous_partial_commit e_str));
+            ignore (Keeper_registry.dispatch_event
+              ~base_path:config.base_path meta.name
+              (Keeper_state_machine.Manual_reconcile_required {
+                reason = short_preview e_str;
+              }))
+          end;
           append_decision_record ~config ~meta:updated_meta ~observation
-            ~latency_ms ~semaphore_wait_ms ~outcome:"error" ~selected_mode:"error"
+            ~latency_ms ~semaphore_wait_ms
+            ~outcome:(if is_ambiguous_partial then "partial" else "error")
+            ~selected_mode:
+              (if is_ambiguous_partial
+               then "ambiguous_side_effect_error"
+               else "error")
             ~social_state
             ~error:e_str ();
           (match write_meta config updated_meta with

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -75,6 +75,17 @@ val broadcast_lifecycle_events :
     Uses structured [Oas.Error.sdk_error] pattern matching. *)
 val is_transient_network_error : Oas.Error.sdk_error -> bool
 
+(** Reclassify any post-commit turn error as a persistent integrity error when
+    mutating tool calls already committed in the same turn. *)
+val reclassify_error_after_side_effect :
+  tool_names:string list ->
+  Oas.Error.sdk_error ->
+  Oas.Error.sdk_error
+
+(** [true] when an error represents an ambiguous partial commit after a
+    mutating tool call succeeded but the turn failed before a clean result. *)
+val is_ambiguous_side_effect_error : Oas.Error.sdk_error -> bool
+
 (** [true] when a structured error indicates context overflow. *)
 val is_context_overflow : Oas.Error.sdk_error -> bool
 

--- a/specs/keeper-state-machine/KeeperOASAdvanced.cfg
+++ b/specs/keeper-state-machine/KeeperOASAdvanced.cfg
@@ -9,5 +9,6 @@ INVARIANTS
 
 PROPERTIES
     AtomicCascadeFallback
+    CommittedSideEffectsRequireReconcile
     StrictStopPreemption
     EventualTermination

--- a/specs/keeper-state-machine/KeeperOASAdvanced.tla
+++ b/specs/keeper-state-machine/KeeperOASAdvanced.tla
@@ -1,6 +1,8 @@
 ---- MODULE KeeperOASAdvanced ----
-\* Formal specification of the OAS Bridge timeouts and fallback handling.
-\* Rigorously models Eio structured concurrency, cascade rollbacks, and global stop preemptions.
+\* Formal specification of the OAS Bridge timeout/error boundary.
+\* Models Eio structured concurrency, OAS-local context rollback, and the
+\* critical distinction between clean fallback and committed external tool side
+\* effects that require explicit reconcile.
 
 EXTENDS Naturals, Sequences
 
@@ -11,10 +13,14 @@ VARIABLES
     fiber_state,         \* {"Active", "Cancelling", "Terminated"}
     cascade_turn,        \* 0..MaxTurns: Current depth of the proactive cascade
     oas_api_state,       \* {"Idle", "Fetching", "Success", "Error"}
-    keeper_decision,     \* {"Unknown", "ExecuteSelf", "AutonomyFallback", "Delegate"}
-    context_polluted     \* Boolean: Tracks if intermediate cascade state leaked upon failure
+    keeper_decision,     \* {"Unknown", "ExecuteSelf", "AutonomyFallback", "Delegate", "NeedsReconcile"}
+    context_polluted,    \* Boolean: Tracks if intermediate OAS context leaked upon failure
+    external_side_effect_committed, \* Boolean: A mutating tool already committed outside OAS context
+    reconcile_required   \* Boolean: Human/explicit reconcile is required before claiming clean recovery
 
-vars == <<sys_stop_requested, fiber_state, cascade_turn, oas_api_state, keeper_decision, context_polluted>>
+vars == <<sys_stop_requested, fiber_state, cascade_turn, oas_api_state,
+          keeper_decision, context_polluted,
+          external_side_effect_committed, reconcile_required>>
 
 Init ==
     /\ sys_stop_requested = FALSE
@@ -23,6 +29,8 @@ Init ==
     /\ oas_api_state = "Idle"
     /\ keeper_decision = "Unknown"
     /\ context_polluted = FALSE
+    /\ external_side_effect_committed = FALSE
+    /\ reconcile_required = FALSE
 
 \* ── Events ────────────────────────────────────────────────
 
@@ -32,14 +40,16 @@ GlobalStopPreempts ==
     /\ sys_stop_requested' = TRUE
     \* If the fiber is active, the Eio switch immediately cancels it.
     /\ IF fiber_state = "Active" THEN fiber_state' = "Cancelling" ELSE fiber_state' = fiber_state
-    /\ UNCHANGED <<cascade_turn, oas_api_state, keeper_decision, context_polluted>>
+    /\ UNCHANGED <<cascade_turn, oas_api_state, keeper_decision, context_polluted,
+                   external_side_effect_committed, reconcile_required>>
 
 \* 2. Eio Timeout (can only happen if Active and Fetching)
 EioTimeoutTriggered ==
     /\ fiber_state = "Active"
     /\ oas_api_state = "Fetching"
     /\ fiber_state' = "Cancelling"
-    /\ UNCHANGED <<sys_stop_requested, cascade_turn, oas_api_state, keeper_decision, context_polluted>>
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, oas_api_state, keeper_decision,
+                   context_polluted, external_side_effect_committed, reconcile_required>>
 
 \* 3. Start fetching from OAS API
 StartFetching ==
@@ -47,7 +57,17 @@ StartFetching ==
     /\ oas_api_state \in {"Idle", "Success"}
     /\ cascade_turn < MaxTurns
     /\ oas_api_state' = "Fetching"
-    /\ UNCHANGED <<sys_stop_requested, fiber_state, cascade_turn, keeper_decision, context_polluted>>
+    /\ UNCHANGED <<sys_stop_requested, fiber_state, cascade_turn, keeper_decision,
+                   context_polluted, external_side_effect_committed, reconcile_required>>
+
+\* 3b. A mutating tool call commits outside the OAS-local context.
+ToolSideEffectCommitted ==
+    /\ fiber_state = "Active"
+    /\ oas_api_state = "Fetching"
+    /\ external_side_effect_committed = FALSE
+    /\ external_side_effect_committed' = TRUE
+    /\ UNCHANGED <<sys_stop_requested, fiber_state, cascade_turn, oas_api_state,
+                   keeper_decision, context_polluted, reconcile_required>>
 
 \* 4. OAS API Completes successfully
 OASApiCompletes ==
@@ -56,24 +76,40 @@ OASApiCompletes ==
     /\ oas_api_state' = "Success"
     /\ cascade_turn' = cascade_turn + 1
     /\ context_polluted' = TRUE \* Context is dirty (polluted) until cascade completes entirely or rolls back
-    /\ UNCHANGED <<sys_stop_requested, fiber_state, keeper_decision>>
+    /\ UNCHANGED <<sys_stop_requested, fiber_state, keeper_decision,
+                   external_side_effect_committed, reconcile_required>>
 
 \* 5. OAS API Fails (Network Error, etc.)
 OASApiError ==
     /\ fiber_state = "Active"
     /\ oas_api_state = "Fetching"
     /\ oas_api_state' = "Error"
-    /\ UNCHANGED <<sys_stop_requested, fiber_state, cascade_turn, keeper_decision, context_polluted>>
+    /\ UNCHANGED <<sys_stop_requested, fiber_state, cascade_turn, keeper_decision,
+                   context_polluted, external_side_effect_committed, reconcile_required>>
 
 \* 6. Bridge Handles OAS Error
 HandleError ==
     /\ fiber_state = "Active"
     /\ oas_api_state = "Error"
+    /\ external_side_effect_committed = FALSE
     /\ fiber_state' = "Terminated"
     /\ oas_api_state' = "Idle"
     /\ keeper_decision' = "AutonomyFallback"
     /\ context_polluted' = FALSE \* Rollback context to clean state
-    /\ UNCHANGED <<sys_stop_requested, cascade_turn>>
+    /\ reconcile_required' = FALSE
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, external_side_effect_committed>>
+
+\* 6b. Error after a committed external mutation cannot claim clean fallback.
+HandleErrorAfterCommittedSideEffect ==
+    /\ fiber_state = "Active"
+    /\ oas_api_state = "Error"
+    /\ external_side_effect_committed = TRUE
+    /\ fiber_state' = "Terminated"
+    /\ oas_api_state' = "Idle"
+    /\ keeper_decision' = "NeedsReconcile"
+    /\ context_polluted' = FALSE
+    /\ reconcile_required' = TRUE
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, external_side_effect_committed>>
 
 \* 7. Cascade Finishes successfully
 FinishCascade ==
@@ -84,16 +120,31 @@ FinishCascade ==
     /\ oas_api_state' = "Idle"
     /\ keeper_decision' = "Delegate"
     /\ context_polluted' = FALSE \* Commit context (no longer polluted)
-    /\ UNCHANGED <<sys_stop_requested, cascade_turn>>
+    /\ reconcile_required' = FALSE
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, external_side_effect_committed>>
 
 \* 8. Fiber Handles Cancellation (Interrupts Fetching or Idle/Success states safely)
 FiberHandlesCancellation ==
     /\ fiber_state = "Cancelling"
+    /\ external_side_effect_committed = FALSE
     /\ fiber_state' = "Terminated"
     /\ oas_api_state' = "Idle" \* Eio interrupts the fetch automatically
     /\ keeper_decision' = "AutonomyFallback"
-    /\ context_polluted' = FALSE \* Rollback context via Switch.on_release or try/with
-    /\ UNCHANGED <<sys_stop_requested, cascade_turn>>
+    /\ context_polluted' = FALSE \* Rollback OAS-local context via try/with
+    /\ reconcile_required' = FALSE
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, external_side_effect_committed>>
+
+\* 8b. Cancellation after a committed external mutation leaves context clean
+\*     but requires explicit reconcile because the outside world already changed.
+CancellationAfterCommittedSideEffect ==
+    /\ fiber_state = "Cancelling"
+    /\ external_side_effect_committed = TRUE
+    /\ fiber_state' = "Terminated"
+    /\ oas_api_state' = "Idle"
+    /\ keeper_decision' = "NeedsReconcile"
+    /\ context_polluted' = FALSE
+    /\ reconcile_required' = TRUE
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, external_side_effect_committed>>
 
 \* 9. [BUG MODEL] Catch-all absorbs cancellation — fiber returns Error instead
 \*     of propagating Cancelled to the parent switch. This creates a zombie:
@@ -105,7 +156,8 @@ CancelledAbsorbed ==
     \* BUG: keeper_decision becomes a normal result instead of fallback
     /\ keeper_decision' = "ExecuteSelf"
     /\ context_polluted' = TRUE  \* Context NOT rolled back — pollution persists
-    /\ UNCHANGED <<sys_stop_requested, cascade_turn>>
+    /\ reconcile_required' = FALSE
+    /\ UNCHANGED <<sys_stop_requested, cascade_turn, external_side_effect_committed>>
 
 TerminatedStutter ==
     /\ fiber_state = "Terminated"
@@ -116,11 +168,14 @@ Next ==
     \/ GlobalStopPreempts
     \/ EioTimeoutTriggered
     \/ StartFetching
+    \/ ToolSideEffectCommitted
     \/ OASApiCompletes
     \/ OASApiError
     \/ HandleError
+    \/ HandleErrorAfterCommittedSideEffect
     \/ FinishCascade
     \/ FiberHandlesCancellation
+    \/ CancellationAfterCommittedSideEffect
     \/ TerminatedStutter
 
 \* Buggy Next: includes CancelledAbsorbed to demonstrate that
@@ -133,11 +188,14 @@ NextBuggy ==
 Fairness ==
     \* Weak Fairness for progress operations
     /\ WF_vars(StartFetching)
+    /\ WF_vars(ToolSideEffectCommitted)
     /\ WF_vars(OASApiCompletes)
     /\ WF_vars(OASApiError)
     /\ WF_vars(HandleError)
+    /\ WF_vars(HandleErrorAfterCommittedSideEffect)
     /\ WF_vars(FinishCascade)
     /\ WF_vars(FiberHandlesCancellation)
+    /\ WF_vars(CancellationAfterCommittedSideEffect)
 
 Spec == Init /\ [][Next]_vars /\ Fairness
 
@@ -148,23 +206,46 @@ SpecBuggy == Init /\ [][NextBuggy]_vars /\ Fairness
 \* 1. A terminated fiber cannot leave a zombie OAS fetch running in the background.
 NoZombieFibers == ((fiber_state = "Terminated") => ~(oas_api_state = "Fetching"))
 
-\* 2. If a cascade falls back (due to error or cancel), the context must be rolled back cleanly.
-AtomicCascadeFallback == []( (fiber_state = "Terminated" /\ keeper_decision = "AutonomyFallback") => (context_polluted = FALSE) )
+\* 2. A clean fallback means OAS-local context rolled back AND no committed
+\*    external mutation remains unresolved.
+AtomicCascadeFallback ==
+    []((fiber_state = "Terminated" /\ keeper_decision = "AutonomyFallback") =>
+        /\ context_polluted = FALSE
+        /\ external_side_effect_committed = FALSE
+        /\ reconcile_required = FALSE)
 
-\* 3. Cancellation must never be absorbed — a terminated fiber with polluted
+\* 3. If a mutating tool already committed and the turn does not finish with
+\*    Delegate, the system must surface NeedsReconcile instead of pretending the
+\*    fallback was clean.
+CommittedSideEffectsRequireReconcile ==
+    []((fiber_state = "Terminated"
+        /\ external_side_effect_committed
+        /\ keeper_decision # "Delegate") =>
+        /\ keeper_decision = "NeedsReconcile"
+        /\ reconcile_required
+        /\ context_polluted = FALSE)
+
+\* 4. Cancellation must never be absorbed — a terminated fiber with polluted
 \*    context must never hold a normal decision (ExecuteSelf/Delegate).
 \*    State predicate (no temporal ops) — usable as INVARIANT.
 \*    Violation means a catch-all swallowed Eio.Cancel.Cancelled.
 CancelledNeverAbsorbed ==
     (fiber_state = "Terminated" /\ context_polluted = TRUE)
-      => (keeper_decision /= "ExecuteSelf" /\ keeper_decision /= "Delegate")
+      => (keeper_decision /= "ExecuteSelf"
+          /\ keeper_decision /= "Delegate"
+          /\ keeper_decision /= "NeedsReconcile")
 
 \* ── Liveness Properties ───────────────────────────────────
 
-\* 3. If a stop is requested before the fiber finishes, it MUST preempt and fall back. It cannot stubbornly Delegate.
-StrictStopPreemption == []( (sys_stop_requested /\ fiber_state /= "Terminated") ~> (fiber_state = "Terminated" /\ keeper_decision = "AutonomyFallback") )
+\* 5. If a stop is requested before the fiber finishes, it MUST preempt. The
+\*    terminal decision may be clean fallback or NeedsReconcile depending on
+\*    whether an external mutation already committed, but it cannot Delegate.
+StrictStopPreemption ==
+    []((sys_stop_requested /\ fiber_state /= "Terminated")
+      ~> (fiber_state = "Terminated"
+          /\ keeper_decision # "Delegate"))
 
-\* 4. The fiber must always eventually terminate (no deadlocks or infinite hangs).
+\* 6. The fiber must always eventually terminate (no deadlocks or infinite hangs).
 EventualTermination == <>(fiber_state = "Terminated")
 
 ====

--- a/specs/keeper-state-machine/KeeperStateMachine.cfg
+++ b/specs/keeper-state-machine/KeeperStateMachine.cfg
@@ -23,6 +23,7 @@ PROPERTIES
     RunningRequiresFiber
     StoppedRequiresDrain
     DeadRequiresNoBudget
+    RunningClearsManualReconcile
     FailingResolves
     CrashedRestartsEventually
     DrainingResolves

--- a/specs/keeper-state-machine/KeeperStateMachine.tla
+++ b/specs/keeper-state-machine/KeeperStateMachine.tla
@@ -2,7 +2,7 @@
 \* Keeper 11-State Machine — TLA+ Formal Specification (RFC-0002)
 \*
 \* Models the deterministic core (Layer 2) of the keeper lifecycle.
-\* Conditions (13 booleans) are primitive; Phase is derived via DerivePhase.
+\* Conditions (14 booleans) are primitive; Phase is derived via DerivePhase.
 \* Events update conditions; DerivePhase projects the new phase.
 \*
 \* Verifies temporal properties that unit tests cannot:
@@ -22,6 +22,7 @@ VARIABLES
     fiber_alive,
     heartbeat_healthy,
     turn_healthy,
+    manual_reconcile_required,
     compaction_active,
     handoff_active,
     operator_paused,
@@ -33,6 +34,7 @@ VARIABLES
     restart_count
 
 vars == <<fiber_alive, heartbeat_healthy, turn_healthy,
+          manual_reconcile_required,
           compaction_active, handoff_active, operator_paused,
           stop_requested, restart_budget_remaining, backoff_elapsed,
           guardrail_triggered, drain_complete, restart_count>>
@@ -51,7 +53,7 @@ DerivePhase ==
     ELSE IF operator_paused THEN "Paused"
     ELSE IF handoff_active THEN "HandingOff"
     ELSE IF compaction_active THEN "Compacting"
-    ELSE IF ~heartbeat_healthy \/ ~turn_healthy THEN "Failing"
+    ELSE IF ~heartbeat_healthy \/ ~turn_healthy \/ manual_reconcile_required THEN "Failing"
     ELSE IF fiber_alive THEN "Running"
     ELSE "Offline"
 
@@ -66,6 +68,7 @@ Init ==
     /\ fiber_alive = TRUE
     /\ heartbeat_healthy = TRUE
     /\ turn_healthy = TRUE
+    /\ manual_reconcile_required = FALSE
     /\ compaction_active = FALSE
     /\ handoff_active = FALSE
     /\ operator_paused = FALSE
@@ -81,7 +84,8 @@ Init ==
 HeartbeatOk ==
     /\ NotTerminal /\ fiber_alive
     /\ heartbeat_healthy' = TRUE
-    /\ UNCHANGED <<fiber_alive, turn_healthy, compaction_active,
+    /\ UNCHANGED <<fiber_alive, turn_healthy, manual_reconcile_required,
+                   compaction_active,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -89,7 +93,8 @@ HeartbeatOk ==
 HeartbeatFailed ==
     /\ NotTerminal /\ fiber_alive
     /\ heartbeat_healthy' = FALSE
-    /\ UNCHANGED <<fiber_alive, turn_healthy, compaction_active,
+    /\ UNCHANGED <<fiber_alive, turn_healthy, manual_reconcile_required,
+                   compaction_active,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -97,6 +102,7 @@ HeartbeatFailed ==
 TurnSucceeded ==
     /\ NotTerminal /\ fiber_alive
     /\ turn_healthy' = TRUE
+    /\ manual_reconcile_required' = FALSE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, compaction_active,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
@@ -105,9 +111,18 @@ TurnSucceeded ==
 TurnFailed ==
     /\ NotTerminal /\ fiber_alive
     /\ turn_healthy' = FALSE
-    /\ UNCHANGED <<fiber_alive, heartbeat_healthy, compaction_active,
+    /\ UNCHANGED <<fiber_alive, heartbeat_healthy, manual_reconcile_required,
+                   compaction_active,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
+                   guardrail_triggered, drain_complete, restart_count>>
+
+ManualReconcileRequired ==
+    /\ NotTerminal /\ fiber_alive
+    /\ manual_reconcile_required' = TRUE
+    /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   compaction_active, handoff_active, operator_paused,
+                   stop_requested, restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
 
 CompactionStarted ==
@@ -115,6 +130,7 @@ CompactionStarted ==
     /\ ~compaction_active /\ ~handoff_active
     /\ compaction_active' = TRUE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -123,6 +139,7 @@ CompactionCompleted ==
     /\ NotTerminal /\ compaction_active
     /\ compaction_active' = FALSE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -132,6 +149,7 @@ HandoffStarted ==
     /\ ~handoff_active /\ ~compaction_active
     /\ handoff_active' = TRUE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -140,6 +158,7 @@ HandoffCompleted ==
     /\ NotTerminal /\ handoff_active
     /\ handoff_active' = FALSE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -148,6 +167,7 @@ OperatorPause ==
     /\ NotTerminal /\ fiber_alive
     /\ operator_paused' = TRUE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -156,6 +176,7 @@ OperatorResume ==
     /\ NotTerminal /\ operator_paused
     /\ operator_paused' = FALSE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -164,6 +185,7 @@ StopRequested ==
     /\ NotTerminal /\ ~stop_requested
     /\ stop_requested' = TRUE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, operator_paused,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -173,6 +195,7 @@ DrainCompleteEv ==
     /\ ~compaction_active /\ ~handoff_active  \* buffer ops must finish first
     /\ drain_complete' = TRUE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, operator_paused,
                    stop_requested, restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, restart_count>>
@@ -180,7 +203,8 @@ DrainCompleteEv ==
 FiberTerminated ==
     /\ NotTerminal /\ fiber_alive
     /\ fiber_alive' = FALSE
-    /\ UNCHANGED <<heartbeat_healthy, turn_healthy, compaction_active,
+    /\ UNCHANGED <<heartbeat_healthy, turn_healthy, manual_reconcile_required,
+                   compaction_active,
                    handoff_active, operator_paused, stop_requested,
                    restart_budget_remaining, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -190,6 +214,7 @@ FiberStarted ==
     /\ fiber_alive' = TRUE
     /\ heartbeat_healthy' = TRUE
     /\ turn_healthy' = TRUE
+    /\ manual_reconcile_required' = FALSE
     /\ compaction_active' = FALSE
     /\ handoff_active' = FALSE
     /\ backoff_elapsed' = FALSE
@@ -206,6 +231,7 @@ SupervisorRestartAttempt ==
     /\ backoff_elapsed' = TRUE
     /\ restart_count' = restart_count + 1
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, operator_paused,
                    stop_requested, restart_budget_remaining,
                    guardrail_triggered, drain_complete>>
@@ -214,6 +240,7 @@ RestartBudgetExhausted ==
     /\ NotTerminal /\ restart_budget_remaining
     /\ restart_budget_remaining' = FALSE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, operator_paused,
                    stop_requested, backoff_elapsed,
                    guardrail_triggered, drain_complete, restart_count>>
@@ -222,6 +249,7 @@ GuardrailStop ==
     /\ NotTerminal /\ fiber_alive
     /\ guardrail_triggered' = TRUE
     /\ UNCHANGED <<fiber_alive, heartbeat_healthy, turn_healthy,
+                   manual_reconcile_required,
                    compaction_active, handoff_active, operator_paused,
                    stop_requested, restart_budget_remaining, backoff_elapsed,
                    drain_complete, restart_count>>
@@ -231,6 +259,7 @@ GuardrailStop ==
 Next ==
     \/ HeartbeatOk      \/ HeartbeatFailed
     \/ TurnSucceeded    \/ TurnFailed
+    \/ ManualReconcileRequired
     \/ CompactionStarted \/ CompactionCompleted
     \/ HandoffStarted   \/ HandoffCompleted
     \/ OperatorPause    \/ OperatorResume
@@ -244,6 +273,7 @@ Next ==
 
 Fairness ==
     /\ WF_vars(HeartbeatOk)
+    /\ WF_vars(ManualReconcileRequired)
     /\ WF_vars(CompactionCompleted)
     /\ WF_vars(HandoffCompleted)
     /\ SF_vars(DrainCompleteEv)     \* Strong fairness: drain fires even if intermittently enabled
@@ -280,6 +310,9 @@ StoppedRequiresDrain == [](Phase = "Stopped" => (stop_requested /\ drain_complet
 \* S8: Dead requires no budget
 DeadRequiresNoBudget == [](Phase = "Dead" => ~restart_budget_remaining)
 
+\* S9: Running cannot retain a pending manual reconcile requirement.
+RunningClearsManualReconcile == [](Phase = "Running" => ~manual_reconcile_required)
+
 \* ── Liveness Properties ───────────────────────────────────
 
 \* Stable phases = non-buffer phases that represent a settled state.
@@ -313,6 +346,7 @@ TypeOK ==
     /\ fiber_alive \in BOOLEAN
     /\ heartbeat_healthy \in BOOLEAN
     /\ turn_healthy \in BOOLEAN
+    /\ manual_reconcile_required \in BOOLEAN
     /\ compaction_active \in BOOLEAN
     /\ handoff_active \in BOOLEAN
     /\ operator_paused \in BOOLEAN

--- a/specs/keeper-state-machine/KeeperTurnCycle.tla
+++ b/specs/keeper-state-machine/KeeperTurnCycle.tla
@@ -27,15 +27,16 @@ VARIABLES
     tool_calls,         \* Number of tool calls made so far
     has_side_effect,    \* Whether a side-effecting tool was called
     compaction_needed,  \* Whether compaction should be applied
-    turn_outcome        \* "none" | "success" | "error" | "timeout"
+    turn_outcome,       \* "none" | "success" | "error" | "timeout" | "partial"
+    reconcile_required  \* Sticky until a later successful turn verifies clean recovery
 
 vars == <<turn_phase, retry_count, tool_calls,
-          has_side_effect, compaction_needed, turn_outcome>>
+          has_side_effect, compaction_needed, turn_outcome, reconcile_required>>
 
 TurnPhases == {"idle", "planning", "executing", "tool_call",
                "side_effect", "compacting", "done"}
 
-Outcomes == {"none", "success", "error", "timeout"}
+Outcomes == {"none", "success", "error", "timeout", "partial"}
 
 (***************************************************************************)
 (* Type invariant                                                          *)
@@ -48,6 +49,7 @@ TypeOK ==
     /\ has_side_effect \in BOOLEAN
     /\ compaction_needed \in BOOLEAN
     /\ turn_outcome \in Outcomes
+    /\ reconcile_required \in BOOLEAN
 
 (***************************************************************************)
 (* Initial state                                                           *)
@@ -60,6 +62,7 @@ Init ==
     /\ has_side_effect = FALSE
     /\ compaction_needed = FALSE
     /\ turn_outcome = "none"
+    /\ reconcile_required = FALSE
 
 (***************************************************************************)
 (* Turn trigger: Idle → Planning                                           *)
@@ -70,7 +73,7 @@ TurnTrigger ==
     /\ turn_phase = "idle"
     /\ turn_phase' = "planning"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* Planning phase: verify keys, build prompt, resolve params.              *)
@@ -81,14 +84,14 @@ PlanningSucceeds ==
     /\ turn_phase = "planning"
     /\ turn_phase' = "executing"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 PlanningFails ==
     /\ turn_phase = "planning"
     /\ turn_phase' = "done"
     /\ turn_outcome' = "error"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed>>
+                    compaction_needed, reconcile_required>>
 
 (***************************************************************************)
 (* Executing → ToolCall: model produces a tool call.                       *)
@@ -100,7 +103,7 @@ MakeToolCall ==
     /\ turn_phase' = "tool_call"
     /\ tool_calls' = tool_calls + 1
     /\ UNCHANGED <<retry_count, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* ToolCall → SideEffect: tool call is a side-effecting operation.         *)
@@ -112,7 +115,7 @@ ToolCallWithSideEffect ==
     /\ turn_phase' = "side_effect"
     /\ has_side_effect' = TRUE
     /\ UNCHANGED <<retry_count, tool_calls,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* ToolCall → Executing: tool call completes (no side effect or            *)
@@ -123,7 +126,7 @@ ToolCallCompletes ==
     /\ turn_phase = "tool_call"
     /\ turn_phase' = "executing"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* SideEffect → Executing: side-effecting tool completes.                  *)
@@ -133,7 +136,7 @@ SideEffectCompletes ==
     /\ turn_phase = "side_effect"
     /\ turn_phase' = "executing"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* Executing → Compacting: agent run completes successfully.               *)
@@ -145,19 +148,19 @@ ExecutionSucceeds ==
     /\ turn_phase' = "compacting"
     /\ turn_outcome' = "success"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed>>
+                    compaction_needed, reconcile_required>>
 
 (***************************************************************************)
-(* Executing → Compacting: transient error but side-effect occurred.       *)
-(* Cannot retry — proceed to compacting with error outcome.                *)
-(* OCaml: keeper_unified_turn.ml line 943.                                 *)
+(* Executing → Compacting: any error after a committed mutating tool call. *)
+(* Cannot retry — the turn outcome is partial and needs explicit reconcile.*)
 (***************************************************************************)
 
-TransientErrorAfterSideEffect ==
+ErrorAfterSideEffect ==
     /\ turn_phase = "executing"
     /\ has_side_effect = TRUE
     /\ turn_phase' = "compacting"
-    /\ turn_outcome' = "error"
+    /\ turn_outcome' = "partial"
+    /\ reconcile_required' = TRUE
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
                     compaction_needed>>
 
@@ -172,7 +175,7 @@ TransientErrorRetry ==
     /\ retry_count < MaxRetries
     /\ retry_count' = retry_count + 1
     /\ UNCHANGED <<turn_phase, tool_calls, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* Executing → Compacting: persistent error or retries exhausted.          *)
@@ -180,22 +183,36 @@ TransientErrorRetry ==
 
 PersistentError ==
     /\ turn_phase = "executing"
-    /\ \/ (has_side_effect = FALSE /\ retry_count >= MaxRetries)
+    /\ has_side_effect = FALSE
+    /\ \/ retry_count >= MaxRetries
        \/ turn_outcome = "error"  \* already marked as error
     /\ turn_phase' = "compacting"
     /\ turn_outcome' = "error"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed>>
+                    compaction_needed, reconcile_required>>
 
 (***************************************************************************)
-(* Timeout: any active phase → Compacting with timeout outcome.            *)
-(* OCaml: 120s wall-clock timeout.                                         *)
+(* Timeout before any committed mutation stays a plain timeout.            *)
 (***************************************************************************)
 
-Timeout ==
+TimeoutBeforeSideEffect ==
     /\ turn_phase \in {"executing", "tool_call", "side_effect"}
+    /\ has_side_effect = FALSE
     /\ turn_phase' = "compacting"
     /\ turn_outcome' = "timeout"
+    /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
+                    compaction_needed, reconcile_required>>
+
+(***************************************************************************)
+(* Timeout after a committed mutation is also a partial outcome.           *)
+(***************************************************************************)
+
+TimeoutAfterSideEffect ==
+    /\ turn_phase \in {"executing", "tool_call", "side_effect"}
+    /\ has_side_effect = TRUE
+    /\ turn_phase' = "compacting"
+    /\ turn_outcome' = "partial"
+    /\ reconcile_required' = TRUE
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
                     compaction_needed>>
 
@@ -207,7 +224,7 @@ CompactionDecision ==
     /\ turn_phase = "compacting"
     /\ turn_phase' = "done"
     /\ UNCHANGED <<retry_count, tool_calls, has_side_effect,
-                    compaction_needed, turn_outcome>>
+                    compaction_needed, turn_outcome, reconcile_required>>
 
 (***************************************************************************)
 (* Done → Idle: turn cycle completes, keeper returns to idle.              *)
@@ -222,6 +239,8 @@ TurnCompletes ==
     /\ has_side_effect' = FALSE
     /\ compaction_needed' = FALSE
     /\ turn_outcome' = "none"
+    /\ reconcile_required' =
+         IF turn_outcome = "success" THEN FALSE ELSE reconcile_required
 
 (***************************************************************************)
 (* Next-state relation                                                     *)
@@ -236,10 +255,11 @@ Next ==
     \/ ToolCallCompletes
     \/ SideEffectCompletes
     \/ ExecutionSucceeds
-    \/ TransientErrorAfterSideEffect
+    \/ ErrorAfterSideEffect
     \/ TransientErrorRetry
     \/ PersistentError
-    \/ Timeout
+    \/ TimeoutBeforeSideEffect
+    \/ TimeoutAfterSideEffect
     \/ CompactionDecision
     \/ TurnCompletes
 
@@ -257,6 +277,11 @@ NoDirectExecutingToIdle ==
 
 (* S2: SideEffect is only reachable from ToolCall.                         *)
 (*     (Enforced by transition structure, verifiable by model checking.)   *)
+
+(* S3: Partial outcome is sticky evidence that explicit reconcile is still
+       required until a later successful turn clears it.                   *)
+PartialOutcomeRequiresReconcile ==
+    (turn_outcome = "partial") => reconcile_required
 
 (* S3: No retry after side-effect with transient error.                    *)
 (*     If has_side_effect is TRUE, retry_count must not increase.          *)
@@ -291,6 +316,7 @@ Safety ==
     /\ RetryBounded
     /\ DoneHasOutcome
     /\ IdleIsClear
+    /\ PartialOutcomeRequiresReconcile
 
 (***************************************************************************)
 (* Liveness properties                                                     *)

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -127,6 +127,11 @@ let test_derive_failing_turn () =
   let c = { running_conditions with turn_healthy = false } in
   check phase_t "turn unhealthy = Failing" SM.Failing (SM.derive_phase c)
 
+let test_derive_failing_manual_reconcile () =
+  let c = { running_conditions with manual_reconcile_required = true } in
+  check phase_t "manual reconcile required = Failing"
+    SM.Failing (SM.derive_phase c)
+
 let test_derive_priority_stop_over_compact () =
   (* TLA+ fix: Stopped requires no buffer ops in flight.
      stop + drain_complete + compaction_active → Draining (not Stopped). *)
@@ -267,6 +272,38 @@ let test_apply_failing_to_crashed () =
     ~event:(SM.Fiber_terminated { outcome = "fatal" }) in
   check phase_t "Failing + fiber death -> Crashed" SM.Crashed tr.new_phase
 
+let test_apply_manual_reconcile_required_to_failing () =
+  let tr = apply_ok
+    ~current_phase:SM.Running
+    ~conditions:running_conditions
+    ~event:(SM.Manual_reconcile_required { reason = "ambiguous_partial_commit" }) in
+  check phase_t "Running -> Failing" SM.Failing tr.new_phase;
+  check bool "manual reconcile sticky" true
+    tr.updated_conditions.manual_reconcile_required
+
+let test_apply_heartbeat_ok_does_not_clear_manual_reconcile () =
+  let failing_conds = { running_conditions with manual_reconcile_required = true } in
+  let tr = apply_ok
+    ~current_phase:SM.Failing
+    ~conditions:failing_conds
+    ~event:SM.Heartbeat_ok in
+  check phase_t "still Failing until clean turn succeeds" SM.Failing tr.new_phase;
+  check bool "manual reconcile preserved" true
+    tr.updated_conditions.manual_reconcile_required
+
+let test_apply_turn_succeeded_clears_manual_reconcile () =
+  let failing_conds = { running_conditions with
+    turn_healthy = false;
+    manual_reconcile_required = true;
+  } in
+  let tr = apply_ok
+    ~current_phase:SM.Failing
+    ~conditions:failing_conds
+    ~event:SM.Turn_succeeded in
+  check phase_t "clean turn clears reconcile requirement" SM.Running tr.new_phase;
+  check bool "manual reconcile cleared" false
+    tr.updated_conditions.manual_reconcile_required
+
 let test_apply_partial_heartbeat_failure () =
   (* Partial failure (1/5) should still mark unhealthy and go to Failing *)
   let tr = apply_ok
@@ -406,6 +443,7 @@ let test_dead_rejects_all_events () =
       check phase_t "Dead" SM.Dead current
     | _ -> fail "expected Terminal_state error"
   ) [ SM.Heartbeat_ok; SM.Fiber_started; SM.Operator_resume;
+      SM.Manual_reconcile_required { reason = "test" };
       SM.Compaction_started; SM.Handoff_started ]
 
 let test_stopped_rejects_all_events () =
@@ -419,7 +457,8 @@ let test_stopped_rejects_all_events () =
     | SM.Terminal_state { current; _ } ->
       check phase_t "Stopped" SM.Stopped current
     | _ -> fail "expected Terminal_state error"
-  ) [ SM.Heartbeat_ok; SM.Fiber_started; SM.Operator_resume ]
+  ) [ SM.Heartbeat_ok; SM.Fiber_started; SM.Operator_resume;
+      SM.Manual_reconcile_required { reason = "test" } ]
 
 (* ── can_transition matrix tests ───────────────────────── *)
 
@@ -995,6 +1034,7 @@ let test_chain_no_phoenix () =
     SM.Heartbeat_failed { consecutive=1; max_allowed=5 };
     SM.Turn_succeeded;
     SM.Turn_failed { consecutive=1; max_allowed=10 };
+    SM.Manual_reconcile_required { reason="test" };
     SM.Context_measured {
       context_ratio=0.5; message_count=10; token_count=5000;
       auto_rules={ reflect=false; plan=false; compact=false;
@@ -1228,6 +1268,7 @@ let test_invariant_fiber_started_reset_exhaustive () =
     SM.fiber_alive = false;
     heartbeat_healthy = false;
     turn_healthy = false;
+    manual_reconcile_required = true;
     context_within_budget = false;
     context_handoff_needed = true;
     compaction_active = true;
@@ -1248,6 +1289,8 @@ let test_invariant_fiber_started_reset_exhaustive () =
   check bool "fiber_alive reset" true updated.fiber_alive;
   check bool "hb_healthy reset" true updated.heartbeat_healthy;
   check bool "turn_healthy reset" true updated.turn_healthy;
+  check bool "manual_reconcile_required reset" false
+    updated.manual_reconcile_required;
   check bool "compaction_active reset" false updated.compaction_active;
   check bool "handoff_active reset" false updated.handoff_active;
   check bool "backoff_elapsed reset" false updated.backoff_elapsed;
@@ -1343,6 +1386,7 @@ let test_invariant_stop_requested_monotonic () =
     SM.Heartbeat_failed { consecutive=1; max_allowed=5 };
     SM.Turn_succeeded;
     SM.Turn_failed { consecutive=1; max_allowed=10 };
+    SM.Manual_reconcile_required { reason="test" };
     SM.Compaction_started;
     SM.Compaction_completed { before_tokens=100; after_tokens=50 };
     SM.Handoff_started;
@@ -1398,6 +1442,7 @@ let test_invariant_budget_exhaustion_permanent () =
      can set restart_budget_remaining back to true. *)
   let all_events = [
     SM.Heartbeat_ok; SM.Fiber_started;
+    SM.Manual_reconcile_required { reason="test" };
     SM.Supervisor_restart_attempt { attempt=99 };
     SM.Restart_budget_exhausted;
     SM.Operator_resume;
@@ -1409,9 +1454,12 @@ let test_invariant_budget_exhaustion_permanent () =
       | Heartbeat_ok -> { conds_no_budget with heartbeat_healthy = true }
       | Fiber_started -> { conds_no_budget with
           fiber_alive = true; heartbeat_healthy = true;
-          turn_healthy = true; compaction_active = false;
+          turn_healthy = true; manual_reconcile_required = false;
+          compaction_active = false;
           handoff_active = false; backoff_elapsed = false;
           guardrail_triggered = false; drain_complete = false }
+      | Manual_reconcile_required _ ->
+        { conds_no_budget with manual_reconcile_required = true }
       | Supervisor_restart_attempt _ -> { conds_no_budget with backoff_elapsed = true }
       | Restart_budget_exhausted -> { conds_no_budget with restart_budget_remaining = false }
       | Operator_resume -> { conds_no_budget with operator_paused = false }
@@ -1431,6 +1479,7 @@ let test_invariant_derive_matches_matrix () =
     SM.Heartbeat_failed { consecutive=5; max_allowed=5 };
     SM.Turn_succeeded;
     SM.Turn_failed { consecutive=3; max_allowed=10 };
+    SM.Manual_reconcile_required { reason="test" };
     SM.Compaction_started;
     SM.Compaction_completed { before_tokens=100; after_tokens=50 };
     SM.Compaction_failed { reason="test" };
@@ -1498,6 +1547,7 @@ let test_invariant_priority_chain () =
     SM.fiber_alive = true;
     heartbeat_healthy = true;
     turn_healthy = true;
+    manual_reconcile_required = true;
     context_within_budget = true;
     context_handoff_needed = true;
     compaction_active = true;
@@ -1529,9 +1579,12 @@ let test_invariant_priority_chain () =
   (* Remove handoff: compaction wins *)
   let no_handoff = { no_paused with handoff_active = false } in
   check phase_t "no handoff: Compacting" SM.Compacting (SM.derive_phase no_handoff);
-  (* Remove compaction: Running (all health ok) *)
+  (* Remove compaction: manual reconcile still forces Failing *)
   let no_compact = { no_handoff with compaction_active = false } in
-  check phase_t "no compact: Running" SM.Running (SM.derive_phase no_compact)
+  check phase_t "no compact: manual reconcile -> Failing"
+    SM.Failing (SM.derive_phase no_compact);
+  let no_reconcile = { no_compact with manual_reconcile_required = false } in
+  check phase_t "no manual reconcile: Running" SM.Running (SM.derive_phase no_reconcile)
 
 (* ── Property: derive_phase x apply_event consistency ──── *)
 
@@ -1640,6 +1693,7 @@ let () =
       test_case "Compacting" `Quick test_derive_compacting;
       test_case "Failing (heartbeat)" `Quick test_derive_failing_heartbeat;
       test_case "Failing (turn)" `Quick test_derive_failing_turn;
+      test_case "Failing (manual reconcile)" `Quick test_derive_failing_manual_reconcile;
       test_case "priority: Stop > Compact" `Quick test_derive_priority_stop_over_compact;
       test_case "priority: Guardrail > Paused" `Quick test_derive_priority_guardrail_over_paused;
       test_case "priority: Handoff > Compact" `Quick test_derive_priority_handoff_over_compact;
@@ -1656,6 +1710,9 @@ let () =
       test_case "drain + fiber death -> Crashed" `Quick test_apply_drain_fiber_death;
       test_case "drain complete + fiber exit -> Stopped" `Quick test_apply_drain_complete_then_fiber_exit;
       test_case "Failing + fiber death -> Crashed" `Quick test_apply_failing_to_crashed;
+      test_case "manual reconcile required -> Failing" `Quick test_apply_manual_reconcile_required_to_failing;
+      test_case "heartbeat ok does not clear manual reconcile" `Quick test_apply_heartbeat_ok_does_not_clear_manual_reconcile;
+      test_case "turn succeeded clears manual reconcile" `Quick test_apply_turn_succeeded_clears_manual_reconcile;
       test_case "partial heartbeat -> Failing" `Quick test_apply_partial_heartbeat_failure;
       test_case "fiber terminated -> Crashed" `Quick test_apply_fiber_terminated_crash;
       test_case "crash -> restart -> Running" `Quick test_apply_crash_restart_lifecycle;
@@ -1718,7 +1775,7 @@ let () =
       test_case "guardrail during compaction" `Quick test_chain_guardrail_during_compaction;
       test_case "double failure (hb+turn) recovery" `Quick test_chain_double_failure_recovery;
       test_case "operator stop during handoff" `Quick test_chain_stop_during_handoff;
-      test_case "no phoenix (21 events on Dead)" `Quick test_chain_no_phoenix;
+      test_case "no phoenix (22 events on Dead)" `Quick test_chain_no_phoenix;
       test_case "triple restart survives" `Quick test_chain_triple_restart_survives;
       test_case "pause while failing then stop" `Quick test_chain_pause_while_failing_then_stop;
       test_case "maximum turbulence (7 phases)" `Quick test_chain_maximum_turbulence;

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -1,13 +1,13 @@
 (** test_keeper_state_machine_pbt — Property-based tests for keeper state machine.
 
     Two modes:
-    - Chaos: random events from all 21 variants. Tests rejection correctness.
+    - Chaos: random events from all 22 variants. Tests rejection correctness.
     - Guided: phase-aware events only. Tests state transition coverage. *)
 
 module SM = Masc_mcp.Keeper_state_machine
 module IC = Masc_mcp.Keeper_invariant_check
 
-(* ── Chaos Generator: all 21 event variants ────────────── *)
+(* ── Chaos Generator: all 22 event variants ────────────── *)
 
 let gen_auto_rules : SM.auto_rule_summary QCheck.Gen.t =
   let open QCheck.Gen in
@@ -29,6 +29,7 @@ let gen_event_chaos : SM.event QCheck.Gen.t =
     return SM.Turn_succeeded;
     (let* consecutive = int_range 1 5 in
      return (SM.Turn_failed { consecutive; max_allowed = 3 }));
+    return (SM.Manual_reconcile_required { reason = "pbt_test" });
     (let* ratio = float_range 0.0 1.0 in
      let* auto_rules = gen_auto_rules in
      return (SM.Context_measured {
@@ -65,6 +66,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Heartbeat_failed { consecutive = 1; max_allowed = 5 };
         SM.Turn_succeeded;
         SM.Turn_failed { consecutive = 1; max_allowed = 3 };
+        SM.Manual_reconcile_required { reason = "test" };
         SM.Context_measured {
           context_ratio = 0.5; message_count = 50; token_count = 5000;
           auto_rules = { reflect = false; plan = false; compact = false;
@@ -80,6 +82,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
       ]
     | SM.Failing ->
       [ SM.Heartbeat_ok; SM.Turn_succeeded;
+        SM.Manual_reconcile_required { reason = "test" };
         SM.Fiber_terminated { outcome = "crash" };
         SM.Stop_requested; SM.Operator_pause;
       ]

--- a/test/test_keeper_trace_validate.ml
+++ b/test/test_keeper_trace_validate.ml
@@ -7,28 +7,32 @@ module IC = Masc_mcp.Keeper_invariant_check
 (* ── Helpers ───────────────────────────────────────────── *)
 
 let make_step_json ~seq ~phase ~fiber_alive ~heartbeat_healthy ~turn_healthy
+    ~manual_reconcile_required
     ~stop_requested ~drain_complete ~restart_budget_remaining
     ~restart_count =
   Printf.sprintf
-    {|{"seq":%d,"ts_unix":1000.0,"event":"test","prev_phase":"running","new_phase":"%s","conditions_after":{"fiber_alive":%b,"heartbeat_healthy":%b,"turn_healthy":%b,"context_within_budget":true,"context_handoff_needed":false,"compaction_active":false,"handoff_active":false,"operator_paused":false,"stop_requested":%b,"restart_budget_remaining":%b,"backoff_elapsed":false,"guardrail_triggered":false,"drain_complete":%b},"restart_count":%d}|}
-    seq phase fiber_alive heartbeat_healthy turn_healthy
+    {|{"seq":%d,"ts_unix":1000.0,"event":"test","prev_phase":"running","new_phase":"%s","conditions_after":{"fiber_alive":%b,"heartbeat_healthy":%b,"turn_healthy":%b,"manual_reconcile_required":%b,"context_within_budget":true,"context_handoff_needed":false,"compaction_active":false,"handoff_active":false,"operator_paused":false,"stop_requested":%b,"restart_budget_remaining":%b,"backoff_elapsed":false,"guardrail_triggered":false,"drain_complete":%b},"restart_count":%d}|}
+    seq phase fiber_alive heartbeat_healthy turn_healthy manual_reconcile_required
     stop_requested restart_budget_remaining drain_complete restart_count
 
 let running_step seq =
   make_step_json ~seq ~phase:"running" ~fiber_alive:true
     ~heartbeat_healthy:true ~turn_healthy:true
+    ~manual_reconcile_required:false
     ~stop_requested:false ~drain_complete:false
     ~restart_budget_remaining:true ~restart_count:0
 
 let failing_step seq =
   make_step_json ~seq ~phase:"failing" ~fiber_alive:true
     ~heartbeat_healthy:false ~turn_healthy:true
+    ~manual_reconcile_required:false
     ~stop_requested:false ~drain_complete:false
     ~restart_budget_remaining:true ~restart_count:0
 
 let stopped_step seq =
   make_step_json ~seq ~phase:"stopped" ~fiber_alive:true
     ~heartbeat_healthy:true ~turn_healthy:true
+    ~manual_reconcile_required:false
     ~stop_requested:true ~drain_complete:true
     ~restart_budget_remaining:true ~restart_count:0
 
@@ -57,6 +61,7 @@ let test_valid_trace () =
 let test_dead_is_forever_violation () =
   let dead_step = make_step_json ~seq:2 ~phase:"dead"
       ~fiber_alive:false ~heartbeat_healthy:true ~turn_healthy:true
+      ~manual_reconcile_required:false
       ~stop_requested:false ~drain_complete:false
       ~restart_budget_remaining:false ~restart_count:0 in
   let trace = String.concat "\n" [
@@ -83,10 +88,12 @@ let test_dead_is_forever_violation () =
 let test_restart_count_monotonic_violation () =
   let step1 = make_step_json ~seq:1 ~phase:"running"
       ~fiber_alive:true ~heartbeat_healthy:true ~turn_healthy:true
+      ~manual_reconcile_required:false
       ~stop_requested:false ~drain_complete:false
       ~restart_budget_remaining:true ~restart_count:3 in
   let step2 = make_step_json ~seq:2 ~phase:"running"
       ~fiber_alive:true ~heartbeat_healthy:true ~turn_healthy:true
+      ~manual_reconcile_required:false
       ~stop_requested:false ~drain_complete:false
       ~restart_budget_remaining:true ~restart_count:1 in
   let trace = String.concat "\n" [ step1; step2 ] in
@@ -109,6 +116,7 @@ let test_restart_count_monotonic_violation () =
 let test_running_requires_fiber_violation () =
   let bad_step = make_step_json ~seq:2 ~phase:"running"
       ~fiber_alive:false ~heartbeat_healthy:true ~turn_healthy:true
+      ~manual_reconcile_required:false
       ~stop_requested:false ~drain_complete:false
       ~restart_budget_remaining:true ~restart_count:0 in
   let trace = String.concat "\n" [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1432,6 +1432,52 @@ let test_overflow_detection_and_limit_parsing () =
     (UT.is_context_overflow
        (Agent_sdk.Error.Api (NetworkError { message = "timeout" })))
 
+let test_side_effect_timeout_reclassified_as_persistent () =
+  let original =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  let reclassified =
+    UT.reclassify_error_after_side_effect
+      ~tool_names:["keeper_fs_edit"] original
+  in
+  check bool "marked ambiguous partial" true
+    (UT.is_ambiguous_side_effect_error reclassified);
+  check bool "no longer transient" false
+    (UT.is_transient_network_error reclassified);
+  check bool "mentions tool name" true
+    (contains_substring
+       (Agent_sdk.Error.to_string reclassified)
+       "keeper_fs_edit")
+
+let test_side_effect_reclassification_requires_committed_tools () =
+  let original =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  let reclassified =
+    UT.reclassify_error_after_side_effect
+      ~tool_names:[] original
+  in
+  check bool "no committed tool keeps transient" true
+    (UT.is_transient_network_error reclassified);
+  check bool "not marked ambiguous partial" false
+    (UT.is_ambiguous_side_effect_error reclassified)
+
+let test_side_effect_reclassification_marks_any_post_commit_error () =
+  let original =
+    Agent_sdk.Error.Api
+      (AuthError { message = "Unauthorized" })
+  in
+  let reclassified =
+    UT.reclassify_error_after_side_effect
+      ~tool_names:["keeper_fs_edit"] original
+  in
+  check bool "auth error stays non-transient" false
+    (UT.is_transient_network_error reclassified);
+  check bool "auth error becomes ambiguous partial" true
+    (UT.is_ambiguous_side_effect_error reclassified)
+
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]
@@ -2088,6 +2134,12 @@ let () =
             check bool "internal" false
               (UT.is_transient_network_error
                  (Agent_sdk.Error.Internal "some error")));
+          test_case "timeout after mutating tool becomes persistent" `Quick
+            test_side_effect_timeout_reclassified_as_persistent;
+          test_case "reclassification requires committed tools" `Quick
+            test_side_effect_reclassification_requires_committed_tools;
+          test_case "any post-commit error becomes ambiguous partial" `Quick
+            test_side_effect_reclassification_marks_any_post_commit_error;
           test_case "overflow detection and limit parsing" `Quick
             test_overflow_detection_and_limit_parsing;
         ] );

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -101,6 +101,22 @@ let test_failure_reason_exception () =
   let s = R.failure_reason_to_string (R.Exception "Sys_error(disk full)") in
   check string "exception reason" "exception(Sys_error(disk full))" s
 
+let test_failure_reason_ambiguous_partial_commit () =
+  let s =
+    R.failure_reason_to_string
+      (R.Ambiguous_partial_commit "turn outcome ambiguous")
+  in
+  check string "ambiguous partial commit reason"
+    "ambiguous_partial_commit(turn outcome ambiguous)" s
+
+let test_failure_reason_manual_reconcile_required () =
+  check bool "ambiguous partial commit requires manual reconcile" true
+    (R.failure_reason_requires_manual_reconcile
+       (R.Ambiguous_partial_commit "turn outcome ambiguous"));
+  check bool "turn failures do not require manual reconcile" false
+    (R.failure_reason_requires_manual_reconcile
+       (R.Turn_consecutive_failures 2))
+
 (* ── Config defaults ──────────────────────────────────── *)
 
 let test_self_preservation_ratio_default () =
@@ -237,6 +253,10 @@ let () =
       test_case "heartbeat" `Quick test_failure_reason_heartbeat;
       test_case "fiber_unresolved" `Quick test_failure_reason_fiber;
       test_case "exception" `Quick test_failure_reason_exception;
+      test_case "ambiguous partial commit" `Quick
+        test_failure_reason_ambiguous_partial_commit;
+      test_case "manual reconcile helper" `Quick
+        test_failure_reason_manual_reconcile_required;
     ];
     "config", [
       test_case "ratio default" `Quick test_self_preservation_ratio_default;


### PR DESCRIPTION
## Summary
- reclassify post-mutation keeper failures as ambiguous partial commits instead of clean transient fallbacks
- surface a sticky `manual_reconcile_required` condition through the lifecycle state machine and dashboard until a later clean turn succeeds
- extend the keeper TLA+ models and OCaml tests so OAS boundary, turn-cycle, and lifecycle semantics all agree

## Product impact
- Promise affected: `ops visibility`
- User-visible change: keepers that timeout or error after committing an external mutating tool call now stay in a failing/manual-reconcile-required state instead of looking like a clean transient recovery.

## Evidence
- `dune build --root .`
- `./_build/default/test/test_keeper_state_machine.exe`
- `./_build/default/test/test_keeper_trace_validate.exe`
- `./_build/default/test/test_heartbeat_integration.exe`
- `./_build/default/test/test_phase2_self_preservation.exe`
- `java -XX:+UseParallelGC -Xmx2g -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/keeper-state-machine/KeeperOASAdvanced.cfg -workers auto -deadlock specs/keeper-state-machine/KeeperOASAdvanced.tla`
- `java -XX:+UseParallelGC -Xmx2g -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/keeper-state-machine/KeeperTurnCycle.cfg -workers auto -deadlock specs/keeper-state-machine/KeeperTurnCycle.tla`
- `java -XX:+UseParallelGC -Xmx2g -cp ~/.local/lib/tla/tla2tools-1.8.0.jar tlc2.TLC -config specs/keeper-state-machine/KeeperStateMachine.cfg -workers auto -deadlock specs/keeper-state-machine/KeeperStateMachine.tla`

## Review evidence
- Cross-model review result: no findings.
- Reviewer used: Claude via `sb claude -- claude -p ...`.
- Fallback reason: direct `sb glm-text` did not return in-session; local llama fallback on `127.0.0.1:8085` was unavailable; Gemini fallback hit `429 MODEL_CAPACITY_EXHAUSTED`.
- Detailed review evidence is recorded in the PR conversation comment from `2026-04-08 15:09Z`.

## Linked issue
- Fixes #5941
