### PR TITLE
fix: remove ToolResult.json field after OAS pin 0.116.1

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -130,13 +130,12 @@ let mask_tool_result_content ~(tool_name : string option) ~(tool_use_id : string
 let mask_tool_result_message ~(tool_names : (string * string) list)
     (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
   let content = List.map (function
-    | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; json } ->
+    | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error } ->
       let tool_name = List.assoc_opt tool_use_id tool_names in
       Agent_sdk.Types.ToolResult {
         tool_use_id;
         content = mask_tool_result_content ~tool_name ~tool_use_id ~content;
         is_error;
-        json;
       }
     | other -> other
   ) m.content in

--- a/lib/inference_utils.ml
+++ b/lib/inference_utils.ml
@@ -102,7 +102,7 @@ let rec sanitize_content_blocks_utf8
         | Agent_sdk.Types.Text s ->
             let sanitized = sanitize_text_utf8 s in
             if sanitized == s then block else Agent_sdk.Types.Text sanitized
-        | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; json } ->
+        | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error } ->
             let sanitized_tool_use_id = sanitize_text_utf8 tool_use_id in
             let sanitized_content = sanitize_text_utf8 content in
             if sanitized_tool_use_id == tool_use_id && sanitized_content == content
@@ -112,7 +112,6 @@ let rec sanitize_content_blocks_utf8
                 tool_use_id = sanitized_tool_use_id;
                 content = sanitized_content;
                 is_error;
-                json;
               }
         | _ -> block
       in

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -143,7 +143,7 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   match role with
   | Agent_sdk.Types.Tool ->
     let tool_use_id = json |> member "tool_call_id" |> to_string_option |> Option.value ~default:"masc-tool" in
-    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id; content = text; is_error = false; json = None }]; name = None; tool_call_id = None }
+    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id; content = text; is_error = false }]; name = None; tool_call_id = None }
   | _ ->
     { Agent_sdk.Types.role; content = [Agent_sdk.Types.Text text]; name = None; tool_call_id = None }
 

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -117,7 +117,7 @@ let parse_message (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let content = json |> member "content" |> to_string in
   match role with
   | Agent_sdk.Types.Tool ->
-    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id = "compact"; content; is_error = false; json = None }]; name = None; tool_call_id = None }
+    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id = "compact"; content; is_error = false }]; name = None; tool_call_id = None }
   | _ ->
     { Agent_sdk.Types.role; content = [Agent_sdk.Types.Text content]; name = None; tool_call_id = None }
 

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -15,7 +15,7 @@ let msg role text : Agent_sdk.Types.message =
 
 let tool_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
   { role = Types.Tool;
-    content = [Types.ToolResult { tool_use_id = id; content = text; is_error = false; json = None }];
+    content = [Types.ToolResult { tool_use_id = id; content = text; is_error = false }];
     name = None; tool_call_id = None }
 
 let tool_use_msg ?(id = "tool-1") ?(name = "grep_search") () : Agent_sdk.Types.message =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1390,7 +1390,6 @@ let test_sanitize_messages_utf8_cleans_history_path () =
                 tool_use_id = "tool\001id";
                 content = "result\127payload";
                 is_error = false;
-                json = None;
               };
           ];
         name = None;

--- a/test/test_oas_adapters.ml
+++ b/test/test_oas_adapters.ml
@@ -17,7 +17,7 @@ let make_test_messages () : Agent_sdk.Types.message list =
     Agent_sdk.Types.user_msg "Hello, what is 2+2?";
     Agent_sdk.Types.assistant_msg "The answer is 4.";
     { Agent_sdk.Types.role = Agent_sdk.Types.Tool;
-      content = [ Agent_sdk.Types.ToolResult { tool_use_id = "call-1"; content = "result: 4"; is_error = false; json = None } ];
+      content = [ Agent_sdk.Types.ToolResult { tool_use_id = "call-1"; content = "result: 4"; is_error = false } ];
       name = None; tool_call_id = None };
     Agent_sdk.Types.user_msg "Thanks, now solve x^2 = 9.";
     Agent_sdk.Types.assistant_msg "x = 3 or x = -3.";
@@ -58,7 +58,7 @@ let test_roundtrip_system_msg_dropped () =
 let test_roundtrip_tool_msg () =
   let msg : Agent_sdk.Types.message =
     { role = Agent_sdk.Types.Tool;
-      content = [ Agent_sdk.Types.ToolResult { tool_use_id = "tc-1"; content = "tool output here"; is_error = false; json = None } ];
+      content = [ Agent_sdk.Types.ToolResult { tool_use_id = "tc-1"; content = "tool output here"; is_error = false } ];
       name = None; tool_call_id = None } in
   match (fun (m : Agent_sdk.Types.message) -> match m.role with Agent_sdk.Types.System -> None | _ -> Some m) msg with
   | None -> Alcotest.fail "tool message should not be dropped"

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -764,7 +764,7 @@ let tool_result_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
     content =
       [
         Agent_sdk.Types.ToolResult
-          { tool_use_id = id; content = text; is_error = false; json = None };
+          { tool_use_id = id; content = text; is_error = false };
       ];
     name = None;
     tool_call_id = None;


### PR DESCRIPTION
## Summary
OAS 0.116.1 (#5928)에서 `Types.content_block.ToolResult`의 `json` 필드가 제거됨. 8파일에서 해당 필드 참조 제거.

## Files (4 lib + 4 test)
- `lib/inference_utils.ml` — sanitize 경로
- `lib/context_compact_oas.ml` — mask 경로
- `lib/tool_compact.ml` — compact message 생성
- `lib/keeper/keeper_context_core.ml` — context message 생성
- `test/test_context_compact_oas_coverage.ml`
- `test/test_oas_adapters.ml`
- `test/test_oas_worker.ml`
- `test/test_keeper_unified.ml`

## Test plan
- [x] `dune build --root .` pass
- [ ] CI Build and Test

Closes #5935

🤖 Generated with [Claude Code](https://claude.com/claude-code)