### PR TITLE
fix: disable Ollama thinking for keepers + remove ToolResult.json field

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1378,6 +1378,7 @@ let run_turn
            ~approval:(Governance_pipeline.to_oas_approval_callback
                         ~governance_level:(Env_config_core.governance_level ())
                         ~keeper_name:meta.name)
+            ~enable_thinking:false
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
            ())

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -111,6 +111,7 @@ val run_named :
   ?context_injector:Oas.Hooks.context_injector ->
   ?context:Oas.Context.t ->
   ?slot_id:int ->
+  ?enable_thinking:bool ->
   ?approval:Oas.Hooks.approval_callback ->
   ?oas_checkpoint:Oas.Checkpoint.t ->
   ?event_bus:Oas.Event_bus.t ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -153,6 +153,7 @@ let run_named
     ?context_injector
     ?context
     ?slot_id
+    ?enable_thinking
     ?approval
     ?oas_checkpoint
     ?event_bus
@@ -206,6 +207,7 @@ let run_named
       context_injector;
       context;
       slot_id;
+      enable_thinking;
       event_bus;
       approval;
     }


### PR DESCRIPTION
## Summary
- disable Ollama/Qwen keeper thinking by wiring `~enable_thinking:false` through the keeper OAS execution path
- keep `ToolResult.json` handling unchanged on the pinned SDK after rechecking the current `agent_sdk` shape
- rebase the PR onto current `origin/main`

## Product impact
- restores normal keeper text replies on Ollama setups that otherwise burn output budget into reasoning-only responses
- no intended behavior change outside keeper OAS execution; ToolResult handling stays aligned with current main

## Evidence
- `env DUNE_BUILD_DIR=_build_pr5948_targets2 dune build --root . ./test/test_oas_worker.exe ./test/test_oas_adapters.exe ./test/test_context_compact_oas_coverage.exe ./test/test_keeper_unified.exe`
- `env DUNE_BUILD_DIR=_build_pr5948_targets2 dune exec --root . ./test/test_oas_worker.exe`
- `env DUNE_BUILD_DIR=_build_pr5948_targets2 dune exec --root . ./test/test_oas_adapters.exe`
- `env DUNE_BUILD_DIR=_build_pr5948_targets2 dune exec --root . ./test/test_context_compact_oas_coverage.exe`
- `env DUNE_BUILD_DIR=_build_pr5948_targets2 dune exec --root . ./test/test_keeper_unified.exe`

## Review evidence
- rechecked the current compile behavior on the rebased branch: removing `ToolResult.json` is incorrect for the pinned SDK, so that portion was reverted in follow-up commit `d6a7f1b20`
- direct external reviewer verdict is still pending in-session; latest update is recorded in PR comments with the local validation evidence

## Linked issue
- Closes #5943
- Refs #5935
