### PR TITLE
chore: bump OAS pin to e7ae5a5 (Content-Length fix)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.116.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="1f6a4d4d7f10891423ee27323fd4ceab00c805a0"
+readonly OAS_AGENT_SDK_SHA="e7ae5a541e3cab95744285ce101e9dc2f037094d"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.116.1"


### PR DESCRIPTION
## Summary
OAS pin SHA 업데이트: `1f6a4d4` → `e7ae5a5`

포함된 OAS 변경: oas#735 — HTTP POST에 명시적 Content-Length 헤더 추가.
Ollama yyjson "closing '}'" 에러 (04-08 504건) 방지.

## Test plan
- [ ] CI build + OAS pin check 통과
- [ ] keeper 재시작 후 Ollama JSON parse error 모니터링

Addresses #5841

🤖 Generated with [Claude Code](https://claude.com/claude-code)