### PR TITLE
fix(approval_queue): clean up pending entry on fiber cancellation

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -77,8 +77,17 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | _ -> ());
-  (* SUSPEND the agent fiber until operator resolves *)
-  Eio.Promise.await promise
+  (* SUSPEND the agent fiber until operator resolves.
+     Fun.protect ensures the pending entry is cleaned up if the fiber
+     is cancelled (e.g. keeper shutdown via Eio.Switch cancellation).
+     Without this, orphan entries accumulate in the hashtbl. (#5949) *)
+  Fun.protect
+    (fun () -> Eio.Promise.await promise)
+    ~finally:(fun () ->
+      (try
+         Eio.Mutex.use_rw ~protect:true mu (fun () ->
+           Hashtbl.remove pending id)
+       with _ -> ()))
 
 (* ── Resolve (operator action) ────────────────────────────── *)
 

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -208,6 +208,30 @@ let test_approval_resolve_nonexistent () =
       (String.length msg > 0)
   | Ok () -> Alcotest.fail "expected error for nonexistent id"
 
+let test_approval_queue_cancel_cleans_up () =
+  Eio_main.run @@ fun _env ->
+  (* Simulate: agent fiber is cancelled (Switch closes) while awaiting.
+     The pending entry must be cleaned up from the hashtbl. (#5949) *)
+  let initial_count = AQ.pending_count () in
+  (try
+     Eio.Switch.run @@ fun sw ->
+     Eio.Fiber.fork ~sw (fun () ->
+       let _decision =
+         AQ.submit_and_await
+           ~keeper_name:"cancel-test"
+           ~tool_name:"masc_dangerous"
+           ~input:(`Assoc [])
+           ~risk_level:"critical"
+       in
+       ());
+     Eio.Fiber.yield ();
+     (* Cancel the switch — this cancels the awaiting fiber *)
+     Eio.Switch.fail sw (Failure "simulated shutdown")
+   with Failure _ -> ());
+  (* After cancellation, the pending entry should be cleaned up *)
+  let final_count = AQ.pending_count () in
+  Alcotest.(check int) "no orphan entries" initial_count final_count
+
 (* ── 4. Approval callback integration ────────────────────── *)
 
 let test_callback_approves_low_risk () =
@@ -241,6 +265,7 @@ let () =
       Alcotest.test_case "submit and reject" `Quick test_approval_queue_reject;
       Alcotest.test_case "expire stale" `Quick test_approval_queue_expire_stale;
       Alcotest.test_case "resolve nonexistent" `Quick test_approval_resolve_nonexistent;
+      Alcotest.test_case "cancel cleans up" `Quick test_approval_queue_cancel_cleans_up;
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;


### PR DESCRIPTION
## Summary
Fix orphan entry leak in Keeper_approval_queue when agent fiber is cancelled.

## Problem
When `Eio.Switch` is cancelled (e.g., keeper shutdown), fibers in `submit_and_await` receive `Eio.Cancel.Cancelled` but the pending hashtbl entry was not cleaned up — leading to resolver orphans.

## Fix
Wrap `Eio.Promise.await` in `Fun.protect ~finally` that removes the entry. The `~finally` handler catches exceptions internally to avoid `Fun.Finally_raised`.

## Evidence
- New test: `cancel cleans up` — cancels a Switch while a fiber is awaiting, verifies `pending_count` returns to initial value
- 13/13 tests pass (0.006s)

Closes #5949