### PR TITLE
fix(cascade): add glm-5-turbo fallback for GLM-5.1 outage

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,9 +1,10 @@
 {
   "default_models": [
     "glm:auto",
+    "glm:glm-5-turbo",
     "ollama:auto"
   ],
-  "_comment": "glm:auto = ZAI GLM (primary), ollama:auto = local Ollama MLX (fallback). OAS discovery resolves ollama:auto via /api/tags.",
+  "_comment": "glm:auto = GLM-5.1 (primary), glm:glm-5-turbo = fast ZAI fallback when 5.1 is down, ollama:auto = local Ollama MLX (last resort). OAS discovery resolves ollama:auto via /api/tags.",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,


### PR DESCRIPTION
## Summary
- cascade.json에 `glm:glm-5-turbo`를 `glm:auto`(=5.1)와 `ollama:auto` 사이에 추가
- GLM-5.1 장애 시 ZAI 내부에서 5-turbo로 fallback한 후 ollama로 넘어감

## Context
GLM-5.1이 coding/paas/v4 엔드포인트에서 120초 타임아웃 (0 bytes). 7개 keeper 전부 ~9시간 stuck.
`glm-5-turbo`는 paas/v4에서 <5s 응답 확인 (직접 테스트).

Fixes #5901

## Evidence
```
curl glm-5.1 → 30s timeout, 0 bytes
curl glm-5-turbo → 200 OK, instant response
keeper cascade: glm:auto(=5.1) → HTTP 500 → ollama → OAS reject → all stuck
```

## Test plan
- [x] `glm-5-turbo` 직접 호출 정상 확인
- [ ] merge 후 서버 hot reload → keeper cascade 복구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)