### PR TITLE
Add local OAS pin drift doctor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 all: build-all
 
 # Build OCaml + dashboard (dashboard rebuilds only when sources changed)
-build:
+build: doctor-oas-pin
 	dune build --root .
 	@scripts/build-dashboard-if-needed.sh
 
@@ -23,11 +23,10 @@ dev-dashboard:
 build-all: build
 
 # Run tests (alias for test-unit)
-test:
-	scripts/ci-run-tests.sh "opam exec -- dune test --root ."
+test: test-unit
 
 # Unit tests only (no server required)
-test-unit:
+test-unit: doctor-oas-pin
 	scripts/ci-run-tests.sh "opam exec -- dune test --root ."
 
 # Contract harness (self-bootstrapping, hermetic local server)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
+.PHONY: build test test-unit test-contract test-contract-live test-transport test-webrtc-live-env test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps pin-external-deps doctor-oas-pin dev-setup fmt fmt-check health ci dashboard dev-dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check check-memory-leak
 
 # Default target — OCaml + dashboard
 all: build-all
@@ -83,8 +83,16 @@ doc:
 install-deps:
 	opam install . --deps-only --with-test --with-doc -y
 
+# Align first-party opam pins (agent_sdk, grpc-direct, etc.) to repo SSOT.
+pin-external-deps:
+	bash scripts/opam-pin-external-deps.sh
+
+# Fast local-only doctor for OAS/agent_sdk pin drift in the current switch.
+doctor-oas-pin:
+	bash scripts/check-oas-pin.sh --local-only
+
 # Development setup
-dev-setup: install-deps
+dev-setup: pin-external-deps install-deps
 	@echo "Development environment ready!"
 
 # Format code (if ocamlformat is installed)

--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -3,6 +3,36 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCAL_ONLY=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-oas-pin.sh [--local-only]
+
+Options:
+  --local-only   Skip upstream remote drift lookup and verify only repository
+                 manifests plus the current local opam switch.
+  -h, --help     Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local-only)
+      LOCAL_ONLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
 
 # GitHub release metadata can lag for this repo. Keep the dependency floor
 # aligned with the pinned SDK's declared opam version, and ratchet the runtime
@@ -12,20 +42,23 @@ source "${SCRIPT_DIR}/oas-agent-sdk-pin.sh"
 min_version_re="${OAS_AGENT_SDK_MIN_VERSION//./\\.}"
 default_pin_source="${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}"
 pin_source="${AGENT_SDK_PIN_URL:-${default_pin_source}}"
+expected_opam_pin_source="git+${OAS_AGENT_SDK_URL}#${OAS_AGENT_SDK_SHA}"
 
 if [[ "${pin_source}" == "${default_pin_source}" ]]; then
-  latest_main_sha="$(
-    git ls-remote "${OAS_AGENT_SDK_URL}" "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
-      | awk '{print $1}'
-  )"
+  if [[ "${LOCAL_ONLY}" -eq 0 ]]; then
+    latest_main_sha="$(
+      git ls-remote "${OAS_AGENT_SDK_URL}" "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
+        | awk '{print $1}'
+    )"
 
-  if [[ -z "${latest_main_sha}" ]]; then
-    echo "failed to resolve upstream ${OAS_AGENT_SDK_TRACK_REF} SHA" >&2
-    exit 1
-  fi
+    if [[ -z "${latest_main_sha}" ]]; then
+      echo "failed to resolve upstream ${OAS_AGENT_SDK_TRACK_REF} SHA" >&2
+      exit 1
+    fi
 
-  if [[ "${OAS_AGENT_SDK_SHA}" != "${latest_main_sha}" ]]; then
-    echo "::warning::OAS main drift: pinned ${OAS_AGENT_SDK_SHA}, upstream ${latest_main_sha} — update pin when API-compatible"
+    if [[ "${OAS_AGENT_SDK_SHA}" != "${latest_main_sha}" ]]; then
+      echo "::warning::OAS main drift: pinned ${OAS_AGENT_SDK_SHA}, upstream ${latest_main_sha} — update pin when API-compatible"
+    fi
   fi
 else
   echo "OAS pin override in use: ${pin_source}"
@@ -46,6 +79,48 @@ if grep -Eq '0\.81\.0' \
   "${REPO_ROOT}/docs/OAS-UTILIZATION-AUDIT.md"; then
   echo "stale OAS version references remain in keeper/OAS docs" >&2
   exit 1
+fi
+
+if command -v opam >/dev/null 2>&1; then
+  installed_packages="$(opam list --installed --columns=name,version --short 2>/dev/null)"
+  installed_version="$(awk '$1 == "agent_sdk" { print $2 }' <<<"${installed_packages}")"
+  if [[ -z "${installed_version}" ]]; then
+    echo "agent_sdk is not installed in the current opam switch" >&2
+    echo "repair: bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test --with-doc -y" >&2
+    exit 1
+  fi
+  if [[ "${installed_version}" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
+    echo "installed agent_sdk version is ${installed_version}, expected ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+    echo "repair: bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test --with-doc -y" >&2
+    exit 1
+  fi
+
+  pin_list_output="$(opam pin list 2>/dev/null || true)"
+  pin_line="$(awk '$1 ~ /^agent_sdk\./ { print }' <<<"${pin_list_output}")"
+  if [[ -n "${pin_line}" ]]; then
+    installed_pin_source="$(awk '{print $3}' <<<"${pin_line}")"
+    case "${installed_pin_source}" in
+      "${expected_opam_pin_source}")
+        ;;
+      git+file://*)
+        local_pin_path="${installed_pin_source#git+file://}"
+        local_pin_path="${local_pin_path%%#*}"
+        local_pin_head="$(git -C "${local_pin_path}" rev-parse HEAD 2>/dev/null || true)"
+        if [[ "${local_pin_head}" != "${OAS_AGENT_SDK_SHA}" ]]; then
+          echo "local agent_sdk pin points to ${local_pin_path}@${local_pin_head:-unknown}, expected ${OAS_AGENT_SDK_SHA}" >&2
+          echo "repair: bash scripts/opam-pin-external-deps.sh" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        echo "agent_sdk pin source is ${installed_pin_source}, expected ${expected_opam_pin_source}" >&2
+        echo "repair: bash scripts/opam-pin-external-deps.sh" >&2
+        exit 1
+        ;;
+    esac
+  else
+    echo "WARN: could not read agent_sdk pin source from opam; installed version matches ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+  fi
 fi
 
 if [[ "${pin_source}" == "${default_pin_source}" ]]; then


### PR DESCRIPTION
## Summary
- add a local-only OAS pin doctor mode that checks the current opam switch for `agent_sdk` version drift
- make `dev-setup` align external pinned dependencies before installing repo deps
- add explicit `pin-external-deps` and `doctor-oas-pin` make targets so the expected setup path is visible

## Product impact
- reduces local environment drift that can masquerade as source breakage
- catches stale `agent_sdk` installations before developers start editing code in the wrong direction

## Evidence
- `bash -n scripts/check-oas-pin.sh`
- `bash scripts/check-oas-pin.sh --local-only`
- `make -n doctor-oas-pin dev-setup`

## Review evidence
- patch is limited to setup/doctoring paths (`Makefile`, `scripts/check-oas-pin.sh`)
- verified against the reproduced stale-pin scenario where local `agent_sdk 0.114.0` caused a false `ToolResult.json` regression diagnosis

## Linked issue
Refs #5935