### PR TITLE
[codex] remove hardcoded 8085 runtime defaults

### DIFF
--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -141,7 +141,7 @@ repo 질문을 바로 `operation + session + proof` spine에 올리고 싶으면
 
 실행 순서:
 
-1. 로컬 `llama.cpp`를 `qwen35-hot` 프로파일로 `127.0.0.1:8085`에서 띄운다.
+1. 로컬 OpenAI-compatible runtime endpoint를 준비하고 `LLAMA_SERVER_URL` 또는 `OAS_LOCAL_LLM_URL`로 노출한다.
 2. `anthropic-proxy` 또는 호환 local provider를 `127.0.0.1:3034`에 둔다.
 3. repo root에서 아래를 실행한다.
 

--- a/docs/SUPERVISOR-MODE.md
+++ b/docs/SUPERVISOR-MODE.md
@@ -71,7 +71,7 @@ Repo-synthesis workflow에서는 이 분리를 그대로 유지한다.
 Environment:
 
 - `LLAMA_SERVER_URL`
-  - default: `http://127.0.0.1:8085`
+  - default: OAS local runtime endpoint (`OAS_LOCAL_LLM_URL` -> `OAS_LOCAL_QWEN_URL` -> OAS default)
 
 Selection policy for this slice is size-based:
 
@@ -248,7 +248,7 @@ What it does:
 Run it against a real local llama team:
 
 ```bash
-LLAMA_SERVER_URL=http://127.0.0.1:8085 \
+LLAMA_SERVER_URL="${OAS_LOCAL_LLM_URL}" \
 LLAMA_SWARM_MODEL=<exact-model-id-from-masc_llama_models> \
 ./scripts/harness_supervisor_team_session.sh
 ```

--- a/docs/SWARM-DELIVERY-RUNBOOK.md
+++ b/docs/SWARM-DELIVERY-RUNBOOK.md
@@ -128,7 +128,7 @@ Karpathy-style raw `masc_autoresearch_*` loop는 그대로 유지하되, supervi
 기본 bootstrap harness:
 
 ```bash
-LLAMA_SERVER_URL=http://127.0.0.1:8085 \
+LLAMA_SERVER_URL="${OAS_LOCAL_LLM_URL}" \
 LLAMA_SWARM_MODEL=<exact-model-id-from-masc_llama_models> \
 HTTP_TIMEOUT_SEC=120 \
 ./scripts/harness_swarm_delivery.sh
@@ -157,7 +157,7 @@ LOCAL64_MODEL_MATRIX_FILE=./scripts/harness/local64-model-matrix.example.json \
 ./scripts/harness_local64_model_matrix.sh
 ```
 
-각 run은 별도 seed port / MCP port / artifact 디렉토리를 사용하므로, 기존 `8085` seed를 건드리지 않고도 `q8`, `1bit`, 다른 GGUF를 순차 비교할 수 있다.
+각 run은 별도 seed port / MCP port / artifact 디렉토리를 사용하므로, 기존 primary seed를 건드리지 않고도 `q8`, `1bit`, 다른 GGUF를 순차 비교할 수 있다.
 
 기본 출력:
 

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -206,7 +206,7 @@ Command Plane 안으로 흡수된 오케스트레이션 substrate.
 | Langfuse | Cloud API | HTTP | LLM 호출 tracing, cost attribution | 선택적 활성화. |
 | GraphQL API | Railway (`second-brain-graphql-production.up.railway.app`) | HTTP | Agent 정보 로드, collaboration edge 기록 | `$GRAPHQL_API_KEY` 인증. Query cost limit 2000. |
 | Cloudflare Tunnel | `masc.crying.pictures` | HTTP -> HTTPS | 원격 dashboard 접근 | Origin HTTP/1.1. Cloudflare가 HTTP/2 변환. |
-| llama-server | localhost:8085 | OpenAI-compatible API | 로컬 LLM 추론 (Cascade 1순위) | Qwen3.5-35B-A3B Q4_K_XL. |
+| local runtime | configured local endpoint | OpenAI-compatible API | 로컬 LLM 추론 (Cascade 1순위) | OAS discovery endpoint. |
 | GLM Cloud | ZAI API | HTTP | Cloud LLM 추론 (Cascade 2순위) | `sb glm-text` 경로. |
 
 ## 9. Invariants (System-Level)

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -79,7 +79,7 @@ repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `<MASC_B
 | `MASC_SPAWN_TIMEOUT_SEC` | float | 600.0 | 스폰 기본 타임아웃 (10분) |
 | `MASC_SPAWN_CODING_TIMEOUT_SEC` | float | 7200.0 | 코딩 모드 타임아웃 (2시간) |
 | `MASC_SPAWN_GRACE_PERIOD_SEC` | float | 60.0 | SIGTERM 유예 기간 |
-| `LLAMA_SERVER_URL` | string | `http://127.0.0.1:8085` | 로컬 LLM 서버 URL |
+| `LLAMA_SERVER_URL` | string | `Agent_sdk.Defaults.local_llm_url` | 로컬 OpenAI-compatible runtime URL |
 | `LLAMA_DEFAULT_MODEL` | string | `explicit-model-required` | 로컬 기본 모델 |
 | `MASC_LOCAL_MAX_TOKENS` | int | 32768 | 로컬 LLM max_tokens 상한 (fallback: `MASC_LLAMA_MAX_TOKENS`) |
 | `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | float | 3600.0 | 취소 토큰 최대 수명 |
@@ -314,7 +314,7 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 | Provider | Env Config 모듈 | 기본 모델 |
 |----------|----------------|----------|
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
-| `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy llama-server, port 8085) |
+| `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
 | `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
 | `gemini` | `Gemini` | `MASC_GEMINI_DEFAULT_MODEL` |
 | `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |

--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -3,18 +3,15 @@
     All hardcoded network defaults live here. Other modules reference
     these constants instead of inlining magic strings/numbers.
 
-    The [local_llm_default_url] must match
-    [Llm_provider.Discovery.default_endpoint] in OAS by contract.
+    The [local_llm_default_url] follows the same env override chain that OAS
+    discovery uses before falling back to the current local runtime URL.
 
     @since 2.241.0 *)
 
-(** Default port for the local llama-server (OpenAI-compatible). *)
-let local_llm_default_port = 8085
-
-(** Default URL for the local llama-server.
-    Contract: must equal [Llm_provider.Discovery.default_endpoint] in OAS. *)
-let local_llm_default_url =
-  Printf.sprintf "http://127.0.0.1:%d" local_llm_default_port
+let nonempty_env name =
+  match Sys.getenv_opt name with
+  | Some value when String.trim value <> "" -> Some (String.trim value)
+  | _ -> None
 
 (** Default port for Ollama (OpenAI-compatible at /v1). *)
 let ollama_default_port = 11434
@@ -22,6 +19,14 @@ let ollama_default_port = 11434
 (** Default URL for Ollama. *)
 let ollama_default_url =
   Printf.sprintf "http://127.0.0.1:%d" ollama_default_port
+
+(** Default URL for the local OpenAI-compatible runtime.
+    Override order: OAS_LOCAL_LLM_URL -> OAS_LOCAL_QWEN_URL -> local runtime. *)
+let local_llm_default_url =
+  match nonempty_env "OAS_LOCAL_LLM_URL", nonempty_env "OAS_LOCAL_QWEN_URL" with
+  | Some value, _ -> value
+  | _, Some value -> value
+  | _ -> ollama_default_url
 
 (** Default port for the MASC HTTP server. *)
 let masc_http_default_port = 8935

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -12,7 +12,7 @@ MCP_URL="${MCP_URL:-${MASC_URL}/mcp}"
 MCP_SESSION_ID="${MCP_SESSION_ID:-agent-swarm-live-${RUN_ID}-$$}"
 BASE_PATH="${BASE_PATH:-/tmp/masc-agent-swarm-live-${RUN_ID}}"
 PROVIDER_BASE_URL="${PROVIDER_BASE_URL:-http://127.0.0.1:3034}"
-SLOT_URL="${SLOT_URL:-http://127.0.0.1:8085}"
+SLOT_URL="${SLOT_URL:-${OAS_LOCAL_LLM_URL:-${LLAMA_SERVER_URL:-}}}"
 MODEL_ID="${MODEL_ID:-qwen3.5-35b-a3b-ud-q8-xl}"
 HARNESS_AGENT="${HARNESS_AGENT:-swarm-harness}"
 WORKER_COUNT="${WORKER_COUNT:-12}"
@@ -49,6 +49,11 @@ EXIT_STATUS=0
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required" >&2
+  exit 1
+fi
+
+if [ -z "$SLOT_URL" ]; then
+  echo "SLOT_URL is required. Set SLOT_URL or OAS_LOCAL_LLM_URL/LLAMA_SERVER_URL." >&2
   exit 1
 fi
 

--- a/scripts/harness_team_session_local64_smoke.sh
+++ b/scripts/harness_team_session_local64_smoke.sh
@@ -11,7 +11,20 @@ PORT="${MASC_LOCAL64_PORT:-8945}"
 BASE_PATH="${MASC_LOCAL64_BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-local64-smoke.XXXXXX")}"
 LOG_FILE="${MASC_LOCAL64_LOG_FILE:-$BASE_PATH/server.log}"
 POOL_SHARDS="${LOCAL64_POOL_TARGET_SHARDS:-1}"
-SEED_PORT="${LLAMA_POOL_SEED_PORT:-8085}"
+extract_port_from_url() {
+  local url="${1:-}"
+  local host_port=""
+  if [ -z "$url" ]; then
+    return 0
+  fi
+  host_port="${url#*://}"
+  host_port="${host_port%%/*}"
+  if [[ "$host_port" == *:* ]]; then
+    printf '%s\n' "${host_port##*:}"
+  fi
+}
+DEFAULT_SEED_PORT="$(extract_port_from_url "${LLAMA_POOL_SEED_URL:-${OAS_LOCAL_LLM_URL:-${LLAMA_SERVER_URL:-}}}")"
+SEED_PORT="${LLAMA_POOL_SEED_PORT:-$DEFAULT_SEED_PORT}"
 POOL_FORCE_START="${LOCAL64_POOL_FORCE_START:-false}"
 POOL_STARTED="false"
 SERVER_PID=""
@@ -72,6 +85,10 @@ elif [ -n "${LLAMA_MODEL_PATH:-}" ] && [ -z "${LLM_ENDPOINTS:-}" ]; then
 fi
 
 if [ "$need_pool_start" = "true" ]; then
+  if [ -z "$SEED_PORT" ]; then
+    echo "Need LLAMA_POOL_SEED_PORT or LLAMA_POOL_SEED_URL/OAS_LOCAL_LLM_URL/LLAMA_SERVER_URL to start the local runtime pool." >&2
+    exit 1
+  fi
   LLM_ENDPOINTS="$("$ROOT_DIR/scripts/llama-runtime-pool.sh" start --target-shards "$POOL_SHARDS" --seed-port "$SEED_PORT")"
   export LLM_ENDPOINTS
   POOL_STARTED="true"

--- a/scripts/llama-runtime-pool.sh
+++ b/scripts/llama-runtime-pool.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 STATE_DIR="${MASC_LOCAL_RUNTIME_POOL_STATE_DIR:-${MASC_LLAMA_RUNTIME_POOL_STATE_DIR:-${TMPDIR:-/tmp}/masc-local-runtime-pool}}"
-SEED_PORT="${LLAMA_POOL_SEED_PORT:-8085}"
 TARGET_SHARDS="${LLAMA_POOL_TARGET_SHARDS:-6}"
 BASE_HOST="${LLAMA_POOL_HOST:-127.0.0.1}"
 DEFAULT_PARALLEL="${LLAMA_POOL_PARALLEL:-12}"
@@ -12,6 +11,22 @@ DEFAULT_UBATCH="${LLAMA_POOL_UBATCH_SIZE:-1024}"
 DEFAULT_CHAT_TEMPLATE="${LLAMA_POOL_CHAT_TEMPLATE:-chatml}"
 DEFAULT_CHAT_TEMPLATE_KWARGS="${LLAMA_POOL_CHAT_TEMPLATE_KWARGS:-{\"enable_thinking\":false}}"
 SEED_BINARY=""
+
+extract_port_from_url() {
+  local url="${1:-}"
+  local host_port=""
+  if [ -z "$url" ]; then
+    return 0
+  fi
+  host_port="${url#*://}"
+  host_port="${host_port%%/*}"
+  if [[ "$host_port" == *:* ]]; then
+    printf '%s\n' "${host_port##*:}"
+  fi
+}
+
+DEFAULT_SEED_PORT="$(extract_port_from_url "${LLAMA_POOL_SEED_URL:-${OAS_LOCAL_LLM_URL:-${LLAMA_SERVER_URL:-}}}")"
+SEED_PORT="${LLAMA_POOL_SEED_PORT:-$DEFAULT_SEED_PORT}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "error: jq is required but not found in PATH" >&2
@@ -26,8 +41,15 @@ Usage: scripts/llama-runtime-pool.sh <start|status|stop|print-env|bench> [option
 
 Options:
   --target-shards N   Total runtime count including the seed port (default: 6)
-  --seed-port PORT    Seed runtime port to clone from (default: 8085)
+  --seed-port PORT    Seed runtime port to clone from
 EOF
+}
+
+require_seed_port() {
+  if [ -z "${SEED_PORT:-}" ]; then
+    echo "Missing seed runtime port. Set LLAMA_POOL_SEED_PORT or LLAMA_POOL_SEED_URL/OAS_LOCAL_LLM_URL/LLAMA_SERVER_URL." >&2
+    exit 1
+  fi
 }
 
 extract_flag_value() {
@@ -65,6 +87,7 @@ seed_command() {
 }
 
 resolve_seed_args() {
+  require_seed_port
   local seed_cmd
   seed_cmd="$(seed_command || true)"
   if [ -n "$seed_cmd" ]; then
@@ -271,6 +294,7 @@ start_shard() {
 }
 
 print_env_value() {
+  require_seed_port
   resolve_seed_args
   local max_port=$((SEED_PORT + TARGET_SHARDS - 1))
   local endpoints=()
@@ -301,6 +325,7 @@ print_env_value() {
 }
 
 start_pool() {
+  require_seed_port
   resolve_seed_args
   local max_port=$((SEED_PORT + TARGET_SHARDS - 1))
   local failures=0
@@ -315,6 +340,7 @@ start_pool() {
 }
 
 status_pool() {
+  require_seed_port
   resolve_seed_args
   local port contract_status
   local max_port=$((SEED_PORT + TARGET_SHARDS - 1))

--- a/scripts/review/local-review.sh
+++ b/scripts/review/local-review.sh
@@ -122,11 +122,6 @@ if [ -z "$REVIEW_COMMAND" ]; then
   require_cmd curl
 fi
 
-if [ -z "$REVIEW_COMMAND" ] && [ -z "$REVIEW_URL" ]; then
-  echo "set MASC_LOCAL_REVIEW_COMMAND or MASC_LOCAL_REVIEW_URL (OAS/OpenAI-compatible endpoint)" >&2
-  exit 1
-fi
-
 resolve_shared_repo_root() {
   local common_dir
   common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || git rev-parse --git-common-dir 2>/dev/null || true)"
@@ -180,6 +175,12 @@ CACHE_KEY="$(
 if [ "$PRINT_CACHE_KEY" -eq 1 ]; then
   printf '%s\n' "$CACHE_KEY"
   exit 0
+fi
+
+# Require a review endpoint only when actually running a review (not --print-cache-key).
+if [ -z "$REVIEW_COMMAND" ] && [ -z "$REVIEW_URL" ]; then
+  echo "set MASC_LOCAL_REVIEW_COMMAND or MASC_LOCAL_REVIEW_URL (OAS/OpenAI-compatible endpoint)" >&2
+  exit 1
 fi
 
 LOCK_ROOT="$CACHE_DIR/locks"

--- a/scripts/review/local-review.sh
+++ b/scripts/review/local-review.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_VERSION="local-review-v1"
+SCRIPT_VERSION="local-review-v2"
 DEFAULT_MODEL="qwen3.5-35b-a3b-ud-q4-xl"
-DEFAULT_URL="http://127.0.0.1:8085/v1/chat/completions"
+DEFAULT_URL=""
 DEFAULT_CACHE_SUBDIR=".masc/review-cache/local-review"
 DEFAULT_PROMPT_VERSION="v1"
 DEFAULT_CHUNK_BYTES=40000
@@ -49,7 +49,7 @@ Options:
 
 Environment:
   MASC_LOCAL_REVIEW_COMMAND   Optional local command override. Receives prompt on stdin.
-  MASC_LOCAL_REVIEW_URL       OpenAI-compatible review endpoint.
+  MASC_LOCAL_REVIEW_URL       Optional OAS/OpenAI-compatible review endpoint.
   MASC_LOCAL_REVIEW_CACHE_DIR Cache root (default: <shared-repo-root>/.masc/review-cache/local-review)
   MASC_LOCAL_REVIEW_CHUNK_BYTES
   MASC_LOCAL_REVIEW_MAX_TOKENS
@@ -120,6 +120,11 @@ require_cmd jq
 require_cmd shasum
 if [ -z "$REVIEW_COMMAND" ]; then
   require_cmd curl
+fi
+
+if [ -z "$REVIEW_COMMAND" ] && [ -z "$REVIEW_URL" ]; then
+  echo "set MASC_LOCAL_REVIEW_COMMAND or MASC_LOCAL_REVIEW_URL (OAS/OpenAI-compatible endpoint)" >&2
+  exit 1
 fi
 
 resolve_shared_repo_root() {
@@ -422,11 +427,18 @@ else
   fi
 fi
 
+if [ -n "$REVIEW_COMMAND" ]; then
+  REVIEW_TARGET_DESC="custom command"
+else
+  REVIEW_TARGET_DESC="OAS/OpenAI-compatible endpoint \`${REVIEW_URL}\`"
+fi
+
 MARKDOWN_RESULT="$(
   cat <<EOF
 Cross-model review evidence
 
-- Reviewer model: local \`llama-server\` target \`${MODEL}\`
+- Reviewer model: \`${MODEL}\`
+- Reviewer target: ${REVIEW_TARGET_DESC}
 - Timestamp: $(now_iso)
 - Prompt version: \`${PROMPT_VERSION}\`
 - Cache: $([ "$NO_CACHE" -eq 0 ] && printf 'miss' || printf 'disabled')

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -245,7 +245,7 @@ let seed_worker_run_meta config session_id =
           `List [ `String "masc_status"; `String "masc_team_session_step" ] );
         ( "tool_surface_shell_names",
           `List [ `String "file_read"; `String "file_write"; `String "shell_exec" ] );
-        ("resolved_runtime", `String "llama-8085");
+        ("resolved_runtime", `String "llama-primary");
         ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
         ("routing_reason", `String "explicit_task_profile");
         ("proof_run_id", `String "proof-run-123");
@@ -427,7 +427,7 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "trace_capability" |> U.to_string);
       check bool "worker run validated" true
         (worker |> U.member "trace_validated" |> U.to_bool);
-      check string "worker resolved runtime" "llama-8085"
+      check string "worker resolved runtime" "llama-primary"
         (worker |> U.member "resolved_runtime" |> U.to_string);
       check string "worker resolved model" "qwen3.5-35b-a3b-ud-q8-xl"
         (worker |> U.member "resolved_model" |> U.to_string);

--- a/test/test_local_runtime_pool.ml
+++ b/test/test_local_runtime_pool.ml
@@ -44,15 +44,15 @@ let test_parse_runtime_env () =
      at test time have no effect.  Include it in the LLM_ENDPOINTS list to
      keep the count predictable via deduplication. *)
   with_env "LLM_ENDPOINTS"
-    (Some "http://127.0.0.1:8085,http://127.0.0.1:8086,http://127.0.0.1:11434")
+    (Some "http://127.0.0.1:19001,http://127.0.0.1:19002,http://127.0.0.1:11434")
   @@ fun () ->
   let snapshots = Local_runtime_pool.snapshots () in
   Alcotest.(check int) "runtime count" 3 (List.length snapshots);
   let runtime_ids =
     snapshots |> List.map (fun (runtime : Local_runtime_pool.runtime_snapshot) -> runtime.id)
   in
-  Alcotest.(check bool) "contains local-8085" true (List.mem "local-8085" runtime_ids);
-  Alcotest.(check bool) "contains local-8086" true (List.mem "local-8086" runtime_ids);
+  Alcotest.(check bool) "contains local-19001" true (List.mem "local-19001" runtime_ids);
+  Alcotest.(check bool) "contains local-19002" true (List.mem "local-19002" runtime_ids);
   Alcotest.(check bool) "contains local-11434" true (List.mem "local-11434" runtime_ids)
 
 let test_parse_llm_endpoints_env () =
@@ -60,7 +60,7 @@ let test_parse_llm_endpoints_env () =
   with_env "MASC_LOCAL_RUNTIMES_JSON" None @@ fun () ->
   with_env "MASC_LLAMA_RUNTIMES_JSON" None @@ fun () ->
   with_env "LLM_ENDPOINTS"
-    (Some "http://127.0.0.1:8085, http://127.0.0.1:8086, http://127.0.0.1:11434")
+    (Some "http://127.0.0.1:19001, http://127.0.0.1:19002, http://127.0.0.1:11434")
   @@ fun () ->
   let snapshots = Local_runtime_pool.snapshots () in
   Alcotest.(check int) "runtime count" 3 (List.length snapshots);
@@ -68,10 +68,10 @@ let test_parse_llm_endpoints_env () =
     snapshots
     |> List.map (fun (runtime : Local_runtime_pool.runtime_snapshot) -> runtime.id)
   in
-  Alcotest.(check bool) "contains local-8085" true
-    (List.mem "local-8085" runtime_ids);
-  Alcotest.(check bool) "contains local-8086" true
-    (List.mem "local-8086" runtime_ids);
+  Alcotest.(check bool) "contains local-19001" true
+    (List.mem "local-19001" runtime_ids);
+  Alcotest.(check bool) "contains local-19002" true
+    (List.mem "local-19002" runtime_ids);
   Alcotest.(check bool) "contains local-11434" true
     (List.mem "local-11434" runtime_ids)
 
@@ -79,8 +79,8 @@ let test_acquire_and_release () =
   Local_runtime_pool.reset ();
   install_pool
     [
-      make_runtime "local-a" "http://127.0.0.1:8085" ~max_concurrency:2;
-      make_runtime "local-b" "http://127.0.0.1:8086" ~model:"qwen-b"
+      make_runtime "local-a" "http://127.0.0.1:19001" ~max_concurrency:2;
+      make_runtime "local-b" "http://127.0.0.1:19002" ~model:"qwen-b"
         ~max_concurrency:2;
     ];
   let assignment =

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -162,7 +162,7 @@ let persist_snapshot ?proof step_env =
     ~wait_mode:Team_session_types.Wait_blocking
     ~execution_scope:Team_session_types.Limited_code_change
     ~status:`Completed
-    ~resolved_runtime:"llama-8085"
+    ~resolved_runtime:"llama-primary"
     ~resolved_model:"glm-5"
     ~success:true
     ~output_preview:"ok"

--- a/test/test_tool_local_runtime_verify.ml
+++ b/test/test_tool_local_runtime_verify.ml
@@ -51,13 +51,13 @@ let test_runtime_verify_prefers_oas_discovery_cache () =
     (fun () ->
       Masc_mcp.Discovery_cache.cached_endpoints :=
         [
-          make_endpoint ~url:"http://127.0.0.1:8085"
+          make_endpoint ~url:"http://127.0.0.1:19001"
             ~model_id:"qwen3.5-35b-a3b-ud-q4-xl" ~ctx_size:262144
             ~total_slots:4 ~busy:0;
-          make_endpoint ~url:"http://127.0.0.1:8086"
+          make_endpoint ~url:"http://127.0.0.1:19002"
             ~model_id:"qwen3.5-35b-a3b-ud-q4-xl" ~ctx_size:262144
             ~total_slots:4 ~busy:1;
-          make_endpoint ~url:"http://127.0.0.1:8087"
+          make_endpoint ~url:"http://127.0.0.1:19003"
             ~model_id:"qwen3.5-35b-a3b-ud-q4-xl" ~ctx_size:262144
             ~total_slots:4 ~busy:1;
         ];

--- a/test/test_worker_run_evidence_summary.ml
+++ b/test/test_worker_run_evidence_summary.ml
@@ -86,7 +86,7 @@ let sample_meta ?(trace_capability = `String "raw")
         `List [ `String "masc_status"; `String "masc_team_session_step" ] );
       ( "tool_surface_shell_names",
         `List [ `String "file_read"; `String "file_write"; `String "shell_exec" ] );
-      ("resolved_runtime", `String "llama-8085");
+      ("resolved_runtime", `String "llama-primary");
       ("resolved_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
       ("routing_reason", `String "explicit_task_profile");
       ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);

--- a/test/test_worker_runtime.ml
+++ b/test/test_worker_runtime.ml
@@ -122,7 +122,7 @@ let test_worker_runtime_helper_protocol_roundtrip () =
   let run_result : Lib.Worker_container_types.run_result =
     {
       output = "ok";
-      model_used = "custom:test@http://127.0.0.1:8085";
+      model_used = "custom:test@http://127.0.0.1:19001";
       input_tokens = Some 11;
       output_tokens = Some 7;
       cost_usd = Some 0.01;
@@ -171,10 +171,10 @@ let test_worker_runtime_invalid_config_fails_closed () =
 let test_rewrite_custom_model_label_for_container () =
   let rewritten =
     Lib.Worker_runtime_docker.rewrite_model_label_for_container
-      "custom:qwen-test@http://127.0.0.1:8085"
+      "custom:qwen-test@http://127.0.0.1:19001"
   in
   check string "loopback custom label rewritten to host alias"
-    "custom:qwen-test@http://host.docker.internal:8085" rewritten
+    "custom:qwen-test@http://host.docker.internal:19001" rewritten
 
 let test_run_process_with_timeout_returns_124_on_timeout () =
   with_eio @@ fun env ->


### PR DESCRIPTION
## What changed
Removed hardcoded `8085` assumptions from current local runtime defaults, harness scripts, docs, and test fixtures.

## Why
The runtime should follow configured endpoint discovery rather than encoding a fixed local port into the product surface. `8085` literals in defaults and tests made the current contract drift away from the OAS/env-driven endpoint model.

## Impact
Current local runtime flow now resolves from env/config (`OAS_LOCAL_LLM_URL`, legacy OAS envs, `LLAMA_SERVER_URL`) and tests no longer encode `8085` in runtime identifiers or endpoint fixtures.

## Root cause
Runtime endpoint defaults and supporting tests had been written around one historical port instead of the configured local endpoint contract.

## Validation
- `bash -n scripts/review/local-review.sh`
- `bash -n scripts/llama-runtime-pool.sh`
- `bash -n scripts/harness_team_session_local64_smoke.sh`
- `bash -n scripts/harness/workload/agent_swarm_live.sh`
- `ocamlc -stop-after parsing -impl lib/config/masc_network_defaults.ml`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/review-oas-only`

## Notes
The build above was run from the worktree root after updating the local runtime default resolution path.