### PR TITLE
fix(tools): resolve keeper name and MCP prefix boundary issues

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -258,18 +258,33 @@ let handle_keeper_status ctx args : tool_result =
      Yojson.Safe.pretty_to_string
        (annotate_keeper_json ~runtime_class:"keeper" json))
 
-let ensure_keeper_exists ctx args =
+let name_from_agent_name agent_name =
+  let prefix = "keeper-" and suffix = "-agent" in
+  let plen = String.length prefix and slen = String.length suffix in
+  let alen = String.length agent_name in
+  if alen > plen + slen
+     && String.sub agent_name 0 plen = prefix
+     && String.sub agent_name (alen - slen) slen = suffix
+  then Some (String.sub agent_name plen (alen - plen - slen))
+  else None
+
+let resolve_keeper_name ctx args =
   let name = get_string args "name" "" in
   match read_meta ctx.config name with
-  | Ok (Some _) -> Ok ()
-  | Ok None -> Error (Printf.sprintf "❌ keeper not found: %s" name)
+  | Ok (Some _) -> Ok name
+  | Ok None ->
+    (match name_from_agent_name name with
+     | Some stripped ->
+       (match read_meta ctx.config stripped with
+        | Ok (Some _) -> Ok stripped
+        | _ -> Error (Printf.sprintf "❌ keeper not found: %s (also tried %s)" name stripped))
+     | None -> Error (Printf.sprintf "❌ keeper not found: %s" name))
   | Error err -> Error (Printf.sprintf "❌ %s" err)
 
 let handle_keeper_msg ctx args : tool_result =
-  match ensure_keeper_exists ctx args with
+  match resolve_keeper_name ctx args with
   | Error err -> (false, err)
-  | Ok _ ->
-      let name = get_string args "name" "" in
+  | Ok name ->
       let request_id = Keeper_msg_async.submit ~sw:ctx.sw
         ~keeper_name:name
         ~f:(fun () ->
@@ -300,10 +315,9 @@ let handle_keeper_msg_result _ctx args : tool_result =
       (true, Yojson.Safe.to_string (Keeper_msg_async.entry_to_json entry))
 
 let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
-  match ensure_keeper_exists ctx args with
+  match resolve_keeper_name ctx args with
   | Error err -> (false, err)
-  | Ok _ ->
-      let name = get_string args "name" "" in
+  | Ok name ->
       let ok, body = Turn.handle_keeper_msg ~on_text_delta ctx args in
       if not ok then (ok, body)
       else begin

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -87,13 +87,21 @@ let handle_tool_stats _ctx args =
   let report = Tool_registry.stats_report ~top_n ~all_tool_names in
   (true, Yojson.Safe.to_string report)
 
+let strip_mcp_prefix name =
+  let prefix = "mcp__masc__" in
+  let plen = String.length prefix in
+  if String.length name > plen && String.sub name 0 plen = prefix
+  then String.sub name plen (String.length name - plen)
+  else name
+
 let handle_tool_help _ctx args =
-  let tool_name = String.trim (get_string args "tool_name" "") in
-  if tool_name = "" then
+  let raw_name = String.trim (get_string args "tool_name" "") in
+  if raw_name = "" then
     (false, "❌ tool_name is required")
   else
+    let tool_name = strip_mcp_prefix raw_name in
     match Tool_help_registry.find_entry Config.raw_all_tool_schemas tool_name with
-    | None -> (false, Printf.sprintf "❌ unknown tool: %s" tool_name)
+    | None -> (false, Printf.sprintf "❌ unknown tool: %s" raw_name)
     | Some entry ->
         (true, Yojson.Safe.to_string (Tool_help_registry.entry_json entry))
 


### PR DESCRIPTION
## Summary

- `masc_keeper_msg`: agent_name (e.g. `keeper-analyst-agent`) → name (`analyst`) fallback 추가
- `masc_tool_help`: `mcp__masc__` transport prefix strip 후 registry lookup

## 배경

프로덕션 로그에서 발견된 tool 에러 3건 중 2건이 경계 위반:
1. keeper의 `name` vs `agent_name` 식별자가 구분 없이 단일 lookup
2. MCP transport naming convention이 application tool dispatch에 유입

## 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/tool_misc.ml` | `strip_mcp_prefix` 추가, `handle_tool_help`에서 prefix strip |
| `lib/tool_keeper.ml` | `name_from_agent_name` + `resolve_keeper_name` fallback |

## 관련 이슈

- Closes 관련 에러 패턴 (별도 이슈 없음 — 로그 기반 발견)
- See also: #5965 (cp_snapshot perf), #5966 (bounded_run 0-turn)

## Test plan

- [ ] `dune build` 통과
- [ ] `dune build @lint` 통과
- [ ] `masc_keeper_msg name="keeper-analyst-agent"` → analyst keeper로 resolve 확인
- [ ] `masc_tool_help tool_name="mcp__masc__masc_bounded_run"` → 정상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)