### PR TITLE
fix: audit hardcoding + approval telemetry + named constants

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -44,8 +44,13 @@ let risk_level_of_contract_risk = function
 
 (* ── Risk Assessment ────────────────────────────────────────── *)
 
-(** Pattern sets for risk classification.
-    Each pattern is checked against the tool name (case-insensitive substring). *)
+(** {2 Risk pattern sets — security-critical SSOT}
+
+    Each pattern is checked against the tool name (case-insensitive substring).
+    These are intentionally in code (not TOML) because changing risk
+    classification is a security policy change that requires code review.
+    Governance LEVEL (development/production/enterprise/paranoid) is the
+    configurable dial — see [MASC_GOVERNANCE_LEVEL] env var. *)
 
 (** Explicit per-tool risk overrides.
     Checked BEFORE pattern matching. Use this to correct misclassifications

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -29,6 +29,42 @@ type decision = Oas.Hooks.approval_decision
 let mu = Eio.Mutex.create ()
 let pending : (string, pending_approval) Hashtbl.t = Hashtbl.create 8
 
+(* ── Persistent audit log ────────────────────────────────── *)
+
+(** Dated JSONL audit trail for approval events.
+    Stored at [<base_path>/.masc/audit-approvals/YYYY-MM/DD.jsonl].
+    Independent of Room.config — approval is a global resource. *)
+let audit_store_ref : Dated_jsonl.t option ref = ref None
+
+let get_audit_store () =
+  match !audit_store_ref with
+  | Some s -> Some s
+  | None ->
+    let base = Env_config_core.base_path () in
+    let dir = Filename.concat base ".masc/audit-approvals" in
+    (match Dated_jsonl.create ~base_dir:dir () with
+     | store ->
+       audit_store_ref := Some store;
+       Some store
+     | exception _ -> None)
+
+let audit_approval_event ~event_type ~id ~keeper_name ~tool_name
+    ~risk_level ?(decision="") () =
+  match get_audit_store () with
+  | None -> ()
+  | Some store ->
+    let json = `Assoc [
+      ("ts", `Float (Unix.gettimeofday ()));
+      ("event", `String event_type);
+      ("id", `String id);
+      ("keeper", `String keeper_name);
+      ("tool", `String tool_name);
+      ("risk", `String risk_level);
+      ("decision", `String decision);
+    ] in
+    (try Dated_jsonl.append store json
+     with _ -> ())
+
 let generate_id () =
   let entropy =
     Printf.sprintf "appr|%d|%.6f|%d"
@@ -56,6 +92,8 @@ let submit_and_await ~keeper_name ~tool_name ~input ~risk_level
   Log.Keeper.info
     "HITL_APPROVAL_PENDING: id=%s keeper=%s tool=%s risk=%s"
     id keeper_name tool_name risk_level;
+  audit_approval_event ~event_type:"pending" ~id ~keeper_name
+    ~tool_name ~risk_level ();
   (* Broadcast SSE event so dashboard picks it up *)
   (try
      Sse.broadcast
@@ -107,6 +145,9 @@ let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) resul
       Log.Keeper.info
         "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
         entry.id entry.keeper_name entry.tool_name decision_str;
+      audit_approval_event ~event_type:"resolved" ~id:entry.id
+        ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
+        ~risk_level:entry.risk_level ~decision:decision_str ();
       Eio.Promise.resolve entry.resolver decision;
       (* Broadcast resolution *)
       (try
@@ -165,5 +206,8 @@ let expire_stale ~max_wait_s =
         "approval timed out after %.0fs" (now -. entry.requested_at) in
       Log.Keeper.warn "HITL_APPROVAL_EXPIRED: id=%s keeper=%s tool=%s"
         id entry.keeper_name entry.tool_name;
+      audit_approval_event ~event_type:"expired" ~id
+        ~keeper_name:entry.keeper_name ~tool_name:entry.tool_name
+        ~risk_level:entry.risk_level ~decision:("reject:" ^ reason) ();
       Eio.Promise.resolve entry.resolver (Oas.Hooks.Reject reason)
     ) stale)

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -968,9 +968,13 @@ let auth_detail_of_provider provider =
 
 (** Classify a model into a family bucket based on locality and context window.
     Shared SSOT to avoid duplication across oas_events and dashboard modules. *)
+
+let small_local_context_ceiling = 64_000
+let large_cloud_context_floor = 200_000
+
 let classify_model_family ~is_local ~context_window =
-  if is_local && context_window < 64_000 then "small_local"
-  else if context_window >= 200_000 then "large_cloud"
+  if is_local && context_window < small_local_context_ceiling then "small_local"
+  else if context_window >= large_cloud_context_floor then "large_cloud"
   else "medium_cloud"
 
 (* is_spawnable removed: use is_spawnable_agent directly. *)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -234,6 +234,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
       in
       let runtime_model_valid =
         match (spawn_agent_name, model_name) with
+        (* Stable provider name — see Provider_adapter.cn_llama *)
         | "llama", None -> Error "model is required when agent_name=llama"
         | "llama", Some raw ->
             let spec_name =

--- a/lib/tool_team_session_routing.ml
+++ b/lib/tool_team_session_routing.ml
@@ -24,7 +24,7 @@ let normalize_spawn_agent agent_name =
 let is_local_spawn_agent agent_name =
   match normalize_spawn_agent agent_name with
   | "default" -> true
-  | "llama" -> true
+  | "llama" -> true (* Stable provider name — see Provider_adapter.cn_llama *)
   | _ -> false
 
 let legacy_spawn_fields = [ "spawn_agent"; "spawn_model" ]


### PR DESCRIPTION
## Summary

최근 4시간 병합 코드 audit에서 발견된 이슈 수정:

- **P1**: Governance risk patterns 문서화 — 보안 분류 패턴이 코드에 있는 이유를 명시 (TOML이 아닌 코드: 변경 시 code review 강제)
- **P2**: HITL Approval 이벤트에 persistent audit log 추가 — `Dated_jsonl`로 `.masc/audit-approvals/YYYY-MM/DD.jsonl`에 pending/resolved/expired 이벤트 기록
- **P4**: `classify_model_family`의 매직넘버 64000/200000을 named constants로 추출 (`small_local_context_ceiling`, `large_cloud_context_floor`)
- **P5**: `"llama"` 리터럴 pattern match 사이트에 SSOT 참조 주석 추가

## Test plan

- [x] `test_hitl_approval.exe` 13/13 pass
- [x] `test_governance_pipeline.exe` 74/74 pass
- [x] `test_keeper_state_machine.exe` 102/102 pass
- [x] `dune build --root .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)