### PR TITLE
[codex] fix: consume retry-safe keeper tool metadata correctly

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -145,6 +145,47 @@ let boring_tools_set : (string, unit) Hashtbl.t =
 let is_boring_tool (name : string) : bool =
   Hashtbl.mem boring_tools_set name
 
+(* ── Retry-safe tools (read-only or harmless to replay) ───────── *)
+
+let retry_safe_fallback_tools =
+  boring_tools @
+  [ "keeper_fs_read";
+    "keeper_memory_search";
+    "keeper_library_search";
+    "keeper_library_read";
+    "keeper_time_now";
+    "keeper_tasks_audit";
+    "keeper_board_get";
+    "keeper_board_list";
+    "keeper_board_stats";
+    "keeper_board_search";
+    "keeper_shell_readonly";
+    "keeper_voice_agent";
+    "keeper_voice_sessions";
+    "keeper_tool_search";
+    "masc_heartbeat";
+    "masc_heartbeat_list";
+  ]
+
+let retry_safe_fallback_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length retry_safe_fallback_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) retry_safe_fallback_tools;
+  tbl
+
+let has_registered_retry_safe_metadata (name : string) : bool =
+  Tool_dispatch.is_read_only name || Tool_dispatch.is_idempotent name
+
+let is_retry_safe_tool (name : string) : bool =
+  has_registered_retry_safe_metadata name
+  || Hashtbl.mem retry_safe_fallback_set name
+  ||
+  match Tool_catalog_surfaces.keeper_internal_replacement name with
+  | Some replacement -> has_registered_retry_safe_metadata replacement
+  | None -> false
+
+let has_retry_unsafe_side_effect (name : string) : bool =
+  not (is_retry_safe_tool name)
+
 (* ── Dynamic schema injection (masc_* tools) ──────────────────── *)
 
 let masc_schemas_ref : Types.tool_schema list ref = ref []

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -163,7 +163,6 @@ let retry_safe_fallback_tools =
     "keeper_voice_agent";
     "keeper_voice_sessions";
     "keeper_tool_search";
-    "masc_heartbeat";
     "masc_heartbeat_list";
   ]
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -54,7 +54,7 @@ let ambiguous_side_effect_error_prefix =
 let committed_mutating_tools tool_names =
   tool_names
   |> dedupe_keep_order
-  |> List.filter (fun name -> not (Keeper_exec_tools.is_effectively_read_only_tool name))
+  |> List.filter Keeper_tool_registry.has_retry_unsafe_side_effect
 
 let is_ambiguous_side_effect_error (err : Oas.Error.sdk_error) : bool =
   match err with
@@ -981,7 +981,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          with each other's save/restore lifecycle. *)
       let mutating_tools_committed = ref [] in
       let side_effect_observer ~tool_name ~success =
-        if success && not (Keeper_exec_tools.is_effectively_read_only_tool tool_name) then
+        if success && Keeper_tool_registry.has_retry_unsafe_side_effect tool_name then
           mutating_tools_committed := tool_name :: !mutating_tools_committed
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -859,6 +859,9 @@ let _tool_spec_read_only =
   ]
 
 let register () =
+  Tool_dispatch.register_module_tag
+    ~schemas:tools
+    ~tag:Tool_dispatch.Mod_inline;
   Tool_dispatch.register_module
     ~schemas:tools
     ~handler:(fun ~name ~args -> Some (handle_tool name args));

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -848,7 +848,7 @@ let handle_tool name args =
   | "masc_board_cleanup" -> handle_board_cleanup args
   | _ -> (false, Printf.sprintf "Unknown tool: %s" name)
 
-let _tool_spec_read_only =
+let tool_spec_read_only =
   [
     "masc_board_list";
     "masc_board_get";
@@ -865,11 +865,11 @@ let register () =
   Tool_dispatch.register_module
     ~schemas:tools
     ~handler:(fun ~name ~args -> Some (handle_tool name args));
-  Tool_dispatch.init_read_only_set _tool_spec_read_only;
-  Tool_dispatch.init_idempotent_set _tool_spec_read_only;
+  Tool_dispatch.init_read_only_set tool_spec_read_only;
+  Tool_dispatch.init_idempotent_set tool_spec_read_only;
   List.iter
     (fun name ->
       let meta = Tool_catalog.metadata name in
       Tool_catalog.register_metadata name
         { meta with readonly = Some true; idempotent = Some true })
-    _tool_spec_read_only
+    tool_spec_read_only

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -848,7 +848,29 @@ let handle_tool name args =
   | "masc_board_cleanup" -> handle_board_cleanup args
   | _ -> (false, Printf.sprintf "Unknown tool: %s" name)
 
+let _tool_spec_read_only =
+  [
+    "masc_board_list";
+    "masc_board_get";
+    "masc_board_stats";
+    "masc_board_search";
+    "masc_board_profile";
+    "masc_board_hearths";
+  ]
+
 let register () =
   Tool_dispatch.register_module
     ~schemas:tools
-    ~handler:(fun ~name ~args -> Some (handle_tool name args))
+    ~handler:(fun ~name ~args -> Some (handle_tool name args));
+  List.iter
+    (fun (s : Types.tool_schema) ->
+      Tool_spec.register
+        (Tool_spec.create
+           ~name:s.name
+           ~description:s.description
+           ~module_tag:Tool_dispatch.Mod_misc
+           ~input_schema:s.input_schema
+           ~is_read_only:(List.mem s.name _tool_spec_read_only)
+           ~is_idempotent:(List.mem s.name _tool_spec_read_only)
+           ()))
+    tools

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -862,15 +862,11 @@ let register () =
   Tool_dispatch.register_module
     ~schemas:tools
     ~handler:(fun ~name ~args -> Some (handle_tool name args));
+  Tool_dispatch.init_read_only_set _tool_spec_read_only;
+  Tool_dispatch.init_idempotent_set _tool_spec_read_only;
   List.iter
-    (fun (s : Types.tool_schema) ->
-      Tool_spec.register
-        (Tool_spec.create
-           ~name:s.name
-           ~description:s.description
-           ~module_tag:Tool_dispatch.Mod_misc
-           ~input_schema:s.input_schema
-           ~is_read_only:(List.mem s.name _tool_spec_read_only)
-           ~is_idempotent:(List.mem s.name _tool_spec_read_only)
-           ()))
-    tools
+    (fun name ->
+      let meta = Tool_catalog.metadata name in
+      Tool_catalog.register_metadata name
+        { meta with readonly = Some true; idempotent = Some true })
+    _tool_spec_read_only

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -564,6 +564,29 @@ let test_patch_surface_json_for_running_keepers_tolerates_null_agent () =
               "idle"
               (row |> member "status" |> to_string))))
 
+let test_patch_keeper_row_tolerates_null_agent_shape () =
+  let row =
+    `Assoc
+      [
+        ("name", `String "keeper-alpha");
+        ("agent", `Null);
+        ("status", `String "unknown");
+      ]
+  in
+  let patched =
+    Lib.Server_dashboard_http.patch_keeper_row
+      ~keeper_name:"keeper-alpha"
+      ~event:"reconciled"
+      ~keepalive_running:true row
+  in
+  let open Yojson.Safe.Util in
+  check string "null agent falls back to idle"
+    "idle"
+    (patched |> member "status" |> to_string);
+  check string "phase still patched"
+    "running"
+    (patched |> member "phase" |> to_string)
+
 let () =
   Alcotest.run "Dashboard Execution"
     [
@@ -589,5 +612,7 @@ let () =
             test_patch_keeper_dependent_caches_tolerates_null_agent;
           Alcotest.test_case "running keeper patch tolerates null agent" `Quick
             test_patch_surface_json_for_running_keepers_tolerates_null_agent;
+          Alcotest.test_case "patch keeper row tolerates null agent shape" `Quick
+            test_patch_keeper_row_tolerates_null_agent_shape;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1538,6 +1538,7 @@ let test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools 
     (UT.is_transient_network_error reclassified);
   check bool "retry-safe observation tools do not become ambiguous partial" false
     (UT.is_ambiguous_side_effect_error reclassified)
+
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1540,6 +1540,20 @@ let test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools 
   check bool "retry-safe observation tools do not become ambiguous partial" false
     (UT.is_ambiguous_side_effect_error reclassified)
 
+let test_retry_safe_tool_registry_uses_metadata_and_fallbacks () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      ignore (Masc_mcp.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir ());
+      check bool "masc_board_list is retry-safe via metadata"
+        true (Masc_mcp.Keeper_tool_registry.is_retry_safe_tool "masc_board_list");
+      check bool "keeper_fs_read is retry-safe via fallback"
+        true (Masc_mcp.Keeper_tool_registry.is_retry_safe_tool "keeper_fs_read");
+      check bool "keeper_fs_edit stays retry-unsafe"
+        true
+        (Masc_mcp.Keeper_tool_registry.has_retry_unsafe_side_effect "keeper_fs_edit"))
+
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]
@@ -2208,6 +2222,8 @@ let () =
             test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set;
           test_case "retry-safe keeper observation tools stay retryable" `Quick
             test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools;
+          test_case "retry-safe registry uses metadata and fallbacks" `Quick
+            test_retry_safe_tool_registry_uses_metadata_and_fallbacks;
           test_case "overflow detection and limit parsing" `Quick
             test_overflow_detection_and_limit_parsing;
         ] );

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1519,6 +1519,25 @@ let test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_se
   check bool "drops memory_search from ambiguous set" false
     (contains_substring rendered "keeper_memory_search")
 
+let test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools () =
+  let original =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  let reclassified =
+    UT.reclassify_error_after_side_effect
+      ~tool_names:
+        [ "keeper_tasks_list";
+          "keeper_board_list";
+          "keeper_shell_readonly";
+          "keeper_fs_read";
+        ]
+      original
+  in
+  check bool "retry-safe observation tools keep transient classification" true
+    (UT.is_transient_network_error reclassified);
+  check bool "retry-safe observation tools do not become ambiguous partial" false
+    (UT.is_ambiguous_side_effect_error reclassified)
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]
@@ -2185,6 +2204,8 @@ let () =
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick
             test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set;
+          test_case "retry-safe keeper observation tools stay retryable" `Quick
+            test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools;
           test_case "overflow detection and limit parsing" `Quick
             test_overflow_detection_and_limit_parsing;
         ] );

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1531,6 +1531,7 @@ let test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools 
           "keeper_board_list";
           "keeper_shell_readonly";
           "keeper_fs_read";
+          "masc_heartbeat";
         ]
       original
   in

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -258,6 +258,20 @@ let test_board_delete_tag_registered () =
   | None ->
       Alcotest.fail "masc_board_delete missing from tag registry"
 
+let test_board_read_only_metadata_registered () =
+  ignore (Masc_mcp.Mcp_server_eio.create_state ~test_mode:true ~base_path:"/tmp/masc-pr5973-board-meta" ());
+  let meta = Masc_mcp.Tool_catalog.metadata "masc_board_list" in
+  Alcotest.(check bool) "board list is read-only in dispatch"
+    true (Masc_mcp.Tool_dispatch.is_read_only "masc_board_list");
+  Alcotest.(check bool) "board list is idempotent in dispatch"
+    true (Masc_mcp.Tool_dispatch.is_idempotent "masc_board_list");
+  Alcotest.(check (option bool)) "board list metadata readonly"
+    (Some true) meta.readonly;
+  Alcotest.(check (option bool)) "board list metadata idempotent"
+    (Some true) meta.idempotent;
+  Alcotest.(check bool) "board post stays mutable"
+    false (Masc_mcp.Tool_dispatch.is_read_only "masc_board_post")
+
 (* ── Test: keeper alias SSOT — capability_registry derives from surfaces ── *)
 
 let test_keeper_alias_ssot_consistency () =
@@ -315,6 +329,8 @@ let () =
             test_no_duplicate_schemas;
           Alcotest.test_case "board delete tag registered" `Quick
             test_board_delete_tag_registered;
+          Alcotest.test_case "board read-only metadata registered" `Quick
+            test_board_read_only_metadata_registered;
           Alcotest.test_case "keeper_backend_tool_name matches keeper_internal_replacement" `Quick
             test_keeper_alias_ssot_consistency;
         ] );


### PR DESCRIPTION
## Summary
- classify keeper retry safety from OAS/tool metadata first, with keeper-local fallback only for observation tools that do not yet publish metadata
- register `masc_board_*` read-only/idempotent metadata so board read tools are treated as retry-safe across keeper and OAS boundaries
- keep regression coverage for the null-agent dashboard keeper-row path after the runtime fix landed on `main` in #5971

## Root cause
- keeper ambiguous-side-effect classification only excluded tools marked `read_only`; when metadata was missing, read-only observation tools like `keeper_tasks_list` and `keeper_board_list` were escalated as committed mutating tools
- board read tools were registered in `Tool_dispatch` but not exposing complete shared retry-safety metadata, so downstream consumers could not reliably infer replay safety from canonical tool metadata alone
- the dashboard null-agent crash path is already fixed on `main`; this branch keeps a direct row-level regression test so that path does not silently regress

## Product impact
- keepers no longer enter `manual_reconcile_required` after provider timeouts that only followed observation-only tool calls
- retry suppression remains reserved for tools with retry-unsafe side effects
- dashboard null-agent handling keeps direct regression coverage at the `patch_keeper_row` layer in addition to the upstream cache and surface coverage

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-null-status`
- `./_build/default/test/test_keeper_unified.exe test transient_network_error 12`
- `./_build/default/test/test_dashboard_execution.exe test read_model 11`
- `./_build/default/test/test_mcp_server_eio.exe test eio 39`
- `./_build/default/test/test_tool_registration_consistency.exe test linter 8`

## Review evidence
- Reviewer: GLM-5.1 via direct `sb glm-text`
- Latest PR head: `029c908c348a5ab62dae8b3b7bf9597089e2176b`
- Result: `No findings.`
- Follow-up incremental review notes are recorded in the PR conversation for the board metadata/tag-registration fixups

## Linked issue
Fixes #5972
