### PR TITLE
fix: make enable_thinking configurable via Runtime_params

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1406,7 +1406,7 @@ let run_turn
            ~approval:(Governance_pipeline.to_oas_approval_callback
                         ~governance_level:(Env_config_core.governance_level ())
                         ~keeper_name:meta.name)
-            ~enable_thinking:false
+            ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
            ())

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -703,6 +703,14 @@ let keeper_slot_id (name : string) : int option =
     Some (h mod num_slots)
 
 
+let keeper_enable_thinking_rp =
+  _rp_bool ~key:"keeper.turn.enable_thinking"
+    ~default:(fun () -> bool_of_env_default "MASC_KEEPER_ENABLE_THINKING" ~default:false)
+    ~description:"Pass enable_thinking to OAS (default: false; Ollama+Qwen3.5 consumes all tokens in thinking mode)" ()
+
+let keeper_enable_thinking () : bool =
+  Runtime_params.get keeper_enable_thinking_rp
+
 let keeper_adaptive_thinking_enabled_rp =
   _rp_bool ~key:"keeper.turn.adaptive_thinking"
     ~default:(fun () -> bool_of_env_default "MASC_KEEPER_ADAPTIVE_THINKING" ~default:false)


### PR DESCRIPTION
## Summary

- `~enable_thinking:false` 하드코딩 (#5948)을 `Keeper_config.keeper_enable_thinking()` Runtime_params로 교체
- 새 Runtime_param: `keeper.turn.enable_thinking` (대시보드 토글 가능)
- 환경변수: `MASC_KEEPER_ENABLE_THINKING` (기본값: `false`)
- 기본값 `false`를 유지하여 Ollama+Qwen3.5 호환성 보장

### 왜 하드코딩이 문제인가

#5948은 Ollama 0.20+Qwen3.5의 thinking 기본 ON → 386 timeout 사고 대응으로 정당한 긴급 fix였으나, 모든 keeper에서 thinking을 영구 비활성화하는 부작용이 있었음. Claude/Gemini 등 thinking을 안전하게 사용할 수 있는 provider에서도 비활성화됨.

### 설정 경로

1. Runtime_params 대시보드 토글 (runtime 변경, 재시작 불필요)
2. `MASC_KEEPER_ENABLE_THINKING=true` env var
3. Default: `false`

## Test plan

- [x] `dune build --root .` clean
- [x] `test_hitl_approval.exe` 13/13 pass
- [x] `test_governance_pipeline.exe` 74/74 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)