### PR TITLE
chore: update OAS pin to 0.117.0

### DIFF
--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -2,7 +2,7 @@
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-04-06
+> Last Updated: 2026-04-09
 > Snapshot baseline: `dune-project` version `2.262.0`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.

--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.116.1))
+  (agent_sdk (>= 0.117.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.116.1"}
+  "agent_sdk" {>= "0.117.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.116.1"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.117.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="e7ae5a541e3cab95744285ce101e9dc2f037094d"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.116.1"
+readonly OAS_AGENT_SDK_SHA="af96b0c0936cd3fde182ae0cd67ba4fa70674a1c"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.117.0"


### PR DESCRIPTION
## Summary
- raise the `agent_sdk` dependency floor from `0.116.1` to `0.117.0`
- pin OAS to `main@af96b0c0936cd3fde182ae0cd67ba4fa70674a1c` with base tag `v0.117.0`
- keep `dune-project`, `masc_mcp.opam`, and `scripts/oas-agent-sdk-pin.sh` aligned

## Validation
- `bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test --with-doc -y`
- `bash scripts/check-oas-pin.sh`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-pin-0-117-0`
