### PR TITLE
[codex] Fix keeper readonly ambiguity classification

### DIFF
--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -31,6 +31,15 @@ val core_discovery_tools : string list
 (** Returns [core_discovery_tools].  Discovery mode is the default. *)
 val effective_core_tools : unit -> string list
 
+(** Keeper-local read-only tools that do not always flow through Tool_spec. *)
+val keeper_read_only_tools : string list
+
+(** [true] when a keeper-only tool is inherently read-only. *)
+val is_keeper_read_only_tool : string -> bool
+
+(** Read-only classification with keeper-local fallback. *)
+val is_effectively_read_only_tool : string -> bool
+
 (** Schema for the keeper_tool_search tool. *)
 val keeper_tool_search_schema : Types.tool_schema
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -78,6 +78,43 @@ let core_always_set : (string, unit) Hashtbl.t =
 let is_core_always_tool (name : string) : bool =
   Hashtbl.mem core_always_set name
 
+(* ── Read-only keeper tools ───────────────────────────────────── *)
+
+(** Keeper-only tools are declared via [Tool_shard] schemas, so many never
+    flow through [Tool_spec.register]. Keep a local read-only SSOT for
+    integrity checks that run before or outside full MCP server bootstrap. *)
+let keeper_read_only_tools =
+  [
+    "keeper_stay_silent";
+    "keeper_time_now";
+    "keeper_context_status";
+    "keeper_memory_search";
+    "keeper_tools_list";
+    "keeper_tool_search";
+    "keeper_board_get";
+    "keeper_board_list";
+    "keeper_board_stats";
+    "keeper_board_search";
+    "keeper_fs_read";
+    "keeper_shell_readonly";
+    "keeper_library_search";
+    "keeper_library_read";
+    "keeper_tasks_list";
+    "keeper_tasks_audit";
+    "keeper_voice_sessions";
+  ]
+
+let keeper_read_only_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length keeper_read_only_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) keeper_read_only_tools;
+  tbl
+
+let is_keeper_read_only_tool (name : string) : bool =
+  Hashtbl.mem keeper_read_only_set name
+
+let is_effectively_read_only_tool (name : string) : bool =
+  Tool_dispatch.is_read_only name || is_keeper_read_only_tool name
+
 (* ── Boring tools (non-productive observation/polling) ─────── *)
 
 (** Tools that gather status but produce no side effects.

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -54,7 +54,7 @@ let ambiguous_side_effect_error_prefix =
 let committed_mutating_tools tool_names =
   tool_names
   |> dedupe_keep_order
-  |> List.filter (fun name -> not (Tool_dispatch.is_read_only name))
+  |> List.filter (fun name -> not (Keeper_exec_tools.is_effectively_read_only_tool name))
 
 let is_ambiguous_side_effect_error (err : Oas.Error.sdk_error) : bool =
   match err with
@@ -981,7 +981,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          with each other's save/restore lifecycle. *)
       let mutating_tools_committed = ref [] in
       let side_effect_observer ~tool_name ~success =
-        if success && not (Tool_dispatch.is_read_only tool_name) then
+        if success && not (Keeper_exec_tools.is_effectively_read_only_tool tool_name) then
           mutating_tools_committed := tool_name :: !mutating_tools_committed
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -67,12 +67,13 @@ type mcp_session_record = Mcp_server_eio_governance.mcp_session_record = {
 let mcp_session_to_json = Mcp_server_eio_governance.mcp_session_to_json
 let mcp_session_of_json = Mcp_server_eio_governance.mcp_session_of_json
 
-(** {1 Tool Lists — inline sub-library tools only}
+(** {1 Tool Lists — inline sub-library tools plus keeper read-only fallback}
 
     Most tools register read_only/requires_join via Tool_spec.register
     in their own modules. These lists cover only tools from
     Tool_schemas_inline (lib/tool_schemas/ sub-library) which cannot
-    depend on Tool_spec. *)
+    depend on Tool_spec, plus keeper read-only tools declared via
+    Tool_shard schemas. *)
 
 let read_only_tools_inline =
   ["masc_status"; "masc_who"; "masc_messages"]
@@ -84,7 +85,9 @@ let mcp_context_required_tools_inline =
   Tool_schemas_inline.schemas
   |> List.map (fun (schema : Types.tool_schema) -> schema.name)
 
-let () = Tool_dispatch.init_read_only_set read_only_tools_inline
+let () =
+  Tool_dispatch.init_read_only_set
+    (read_only_tools_inline @ Keeper_exec_tools.keeper_read_only_tools)
 let () = Tool_dispatch.init_requires_join_set requires_join_tools_inline
 let () = Tool_dispatch.init_mcp_context_required_set mcp_context_required_tools_inline
 (* Tools whose arguments contain executable commands subject to

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -86,6 +86,9 @@ let mcp_context_required_tools_inline =
   |> List.map (fun (schema : Types.tool_schema) -> schema.name)
 
 let () =
+  (* [Keeper_exec_tools.keeper_read_only_tools] is the keeper SSOT.
+     Server bootstrap mirrors that list into Tool_dispatch so protocol
+     annotations and non-keeper callers see the same read-only metadata. *)
   Tool_dispatch.init_read_only_set
     (read_only_tools_inline @ Keeper_exec_tools.keeper_read_only_tools)
 let () = Tool_dispatch.init_requires_join_set requires_join_tools_inline

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1480,6 +1480,40 @@ let test_side_effect_reclassification_marks_any_post_commit_error () =
   check bool "auth error becomes ambiguous partial" true
     (UT.is_ambiguous_side_effect_error reclassified)
 
+let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
+  let original =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  let reclassified =
+    UT.reclassify_error_after_side_effect
+      ~tool_names:["keeper_tasks_list"; "keeper_memory_search"] original
+  in
+  check bool "read-only keeper tools stay transient" true
+    (UT.is_transient_network_error reclassified);
+  check bool "read-only keeper tools are not ambiguous" false
+    (UT.is_ambiguous_side_effect_error reclassified)
+
+let test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set () =
+  let original =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  let reclassified =
+    UT.reclassify_error_after_side_effect
+      ~tool_names:["keeper_tasks_list"; "keeper_fs_edit"; "keeper_memory_search"]
+      original
+  in
+  let rendered = Agent_sdk.Error.to_string reclassified in
+  check bool "mixed set is ambiguous" true
+    (UT.is_ambiguous_side_effect_error reclassified);
+  check bool "keeps mutating tool" true
+    (contains_substring rendered "keeper_fs_edit");
+  check bool "drops tasks_list from ambiguous set" false
+    (contains_substring rendered "keeper_tasks_list");
+  check bool "drops memory_search from ambiguous set" false
+    (contains_substring rendered "keeper_memory_search")
+
 let test_metrics_mixed_response () =
   let result =
     make_run_result ~text:"Done." ~tools:["keeper_fs_read"]
@@ -2142,6 +2176,10 @@ let () =
             test_side_effect_reclassification_requires_committed_tools;
           test_case "any post-commit error becomes ambiguous partial" `Quick
             test_side_effect_reclassification_marks_any_post_commit_error;
+          test_case "read-only keeper tools do not become ambiguous partial" `Quick
+            test_side_effect_reclassification_ignores_keeper_read_only_tools;
+          test_case "mixed tool sets only keep mutating keeper tools" `Quick
+            test_side_effect_reclassification_drops_keeper_read_only_tools_from_mixed_set;
           test_case "overflow detection and limit parsing" `Quick
             test_overflow_detection_and_limit_parsing;
         ] );

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -111,6 +111,12 @@ let () =
                 (Tool_dispatch.is_read_only "masc_broadcast");
               check bool "masc_add_task not read_only" false
                 (Tool_dispatch.is_read_only "masc_add_task"));
+          test_case "keeper read-only tools use shipped registry policy" `Quick (fun () ->
+              ignore (Mcp_eio.get_clock_opt ());
+              check bool "keeper_tasks_list read_only" true
+                (Tool_dispatch.is_read_only "keeper_tasks_list");
+              check bool "keeper_memory_search read_only" true
+                (Tool_dispatch.is_read_only "keeper_memory_search"));
         ] );
       ( "requires_join_set",
         [

--- a/test/test_tool_dispatch.ml
+++ b/test/test_tool_dispatch.ml
@@ -2,6 +2,7 @@
 
 module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Mcp_eio = Masc_mcp.Mcp_server_eio
+module KE = Masc_mcp.Keeper_exec_tools
 module Types = Types
 
 (** Helper: create a minimal tool_schema for registration. *)
@@ -117,6 +118,15 @@ let () =
                 (Tool_dispatch.is_read_only "keeper_tasks_list");
               check bool "keeper_memory_search read_only" true
                 (Tool_dispatch.is_read_only "keeper_memory_search"));
+          test_case "keeper read-only helper matches canonical list" `Quick (fun () ->
+              check bool "tasks_list helper" true
+                (KE.is_keeper_read_only_tool "keeper_tasks_list");
+              check bool "memory_search helper" true
+                (KE.is_keeper_read_only_tool "keeper_memory_search");
+              check bool "fs_edit helper false" false
+                (KE.is_keeper_read_only_tool "keeper_fs_edit");
+              check bool "effective helper keeps mutating false" false
+                (KE.is_effectively_read_only_tool "keeper_fs_edit"));
         ] );
       ( "requires_join_set",
         [


### PR DESCRIPTION
## Summary
- add a keeper-local read-only SSOT for tools declared via `Tool_shard` that do not always flow through `Tool_spec.register`
- use that fallback when deciding whether a completed tool call should be treated as a mutating side effect in the unified keeper turn
- register keeper read-only tools into the server read-only registry during bootstrap and add regression coverage for the affected timeout path

## Root cause
`keeper_tasks_list` and `keeper_memory_search` are read-only keeper tools, but they were not guaranteed to be present in `Tool_dispatch.is_read_only`. When a provider timeout happened after those tools ran, unified turn recovery misclassified them as committed mutations and escalated the turn into an ambiguous partial commit requiring manual reconcile.

## Product impact
- false integrity failures and `manual_reconcile_required` transitions are avoided when a keeper turn only executed read-only keeper tools before timing out
- retry-unsafe mutating tools still follow the existing ambiguous-partial-commit protection path
- keeper-local read-only policy and server bootstrap metadata stay aligned through shared regression coverage

## Evidence
- `dune build --root .`
- `./_build/default/test/test_tool_dispatch.exe`
- `./_build/default/test/test_keeper_unified.exe`

## Review evidence
- Reviewer: GLM-5.1 via `sb glm-text`
- Timestamp: 2026-04-09 08:17 KST
- Scope: final PR diff against `origin/main`
- Prompt mode: correctness, regressions, and missing tests only
- Result: `No findings.`
- Follow-up: explicit helper coverage for `is_keeper_read_only_tool` and comments clarifying that `keeper_read_only_tools` is the keeper SSOT mirrored into `Tool_dispatch` during bootstrap

## Linked issue
Refs #5972
