### PR TITLE
[codex] Fix GLM auto cascade fallback and dashboard null handling

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,10 +1,9 @@
 {
   "default_models": [
     "glm:auto",
-    "glm:glm-5-turbo",
     "ollama:auto"
   ],
-  "_comment": "glm:auto = GLM-5.1 (primary), glm:glm-5-turbo = fast ZAI fallback when 5.1 is down, ollama:auto = local Ollama MLX (last resort). OAS discovery resolves ollama:auto via /api/tags.",
+  "_comment": "glm:auto expands inside OAS to glm-5.1 -> glm-5-turbo -> glm-4.7 -> glm-4.7-flashx. ollama:auto remains the local last resort. OAS discovery resolves ollama:auto via /api/tags.",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -389,8 +389,11 @@ let persistent_agents_json ?keeper_names config =
               Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
             in
             let agent_status =
-              match agent_json |> U.member "status" with
-              | `String status -> status
+              match agent_json with
+              | `Assoc _ -> (
+                  match agent_json |> U.member "status" with
+                  | `String status -> status
+                  | _ -> "unknown")
               | _ -> "unknown"
             in
             Some

--- a/lib/operator/operator_digest_session.ml
+++ b/lib/operator/operator_digest_session.ml
@@ -556,14 +556,30 @@ let normalize_team_health = function
   | "critical" -> "bad"
   | other -> other
 
+let assoc_member json field =
+  match json with
+  | `Assoc _ -> U.member field json
+  | _ -> `Null
+
+let nested_string_member json ~parent ~child =
+  match assoc_member json parent with
+  | `Assoc _ as nested -> (
+      match U.member child nested with
+      | `String value -> Some value
+      | _ -> None)
+  | _ -> None
+
 let build_session_digest ?status_json:cached_status config (session : Team_session_types.session) ~now =
   let status_json =
     match cached_status with
     | Some s -> s
     | None -> Team_session_engine_eio.session_status_json config session
   in
-  let summary = U.member "summary" status_json in
-  let team_health = U.member "team_health" status_json in
+  let summary = assoc_member status_json "summary" in
+  let team_health = assoc_member status_json "team_health" in
+  let summary_member field = assoc_member summary field in
+  let team_health_member field = assoc_member team_health field in
+  let status_member field = assoc_member status_json field in
   let events = Team_session_store.read_events ~max_events:200 config session.session_id in
   let worker_cards = build_worker_cards ~session ~events ~now in
   let attention_items = session_attention_items ~session ~events ~worker_cards ~now in
@@ -571,7 +587,7 @@ let build_session_digest ?status_json:cached_status config (session : Team_sessi
     session_recommendations ~session ~attentions:attention_items ~worker_cards
   in
   let active_agent_count =
-    match U.member "active_agents" summary with
+    match summary_member "active_agents" with
     | `List xs -> List.length xs
     | _ -> 0
   in
@@ -586,22 +602,22 @@ let build_session_digest ?status_json:cached_status config (session : Team_sessi
     session_id = session.session_id;
     goal = session.goal;
     status =
-      (match U.member "session" status_json |> U.member "status" with
-      | `String status -> status
-      | _ -> Team_session_types.status_to_string session.status);
+      (match nested_string_member status_json ~parent:"session" ~child:"status" with
+      | Some status -> status
+      | None -> Team_session_types.status_to_string session.status);
     health =
       (let attention_health = health_from_attention_items attention_items in
        if not (String.equal attention_health "ok") then attention_health
        else
-         match U.member "status" team_health with
+         match team_health_member "status" with
          | `String status -> normalize_team_health status
          | _ -> attention_health);
     scale_profile =
-      (match U.member "scale_profile" summary with
+      (match summary_member "scale_profile" with
       | `String value -> value
       | _ -> Team_session_types.scale_profile_to_string session.scale_profile);
     control_profile =
-      (match U.member "control_profile" summary with
+      (match summary_member "control_profile" with
       | `String value -> value
       | _ ->
           Team_session_types.control_profile_to_string session.control_profile);
@@ -609,68 +625,68 @@ let build_session_digest ?status_json:cached_status config (session : Team_sessi
     active_agent_count;
     last_turn_age_sec;
     worker_class_counts =
-      (match U.member "worker_class_counts" summary with
+      (match summary_member "worker_class_counts" with
       | `Assoc _ as json -> json
       | _ ->
           Team_session_types.worker_class_counts session.planned_workers
           |> Team_session_types.counts_to_json);
     runtime_pool_counts =
-      (match U.member "runtime_pool_counts" summary with
+      (match summary_member "runtime_pool_counts" with
       | `Assoc _ as json -> json
       | _ ->
           Team_session_types.runtime_pool_counts session.planned_workers
           |> Team_session_types.counts_to_json);
     lane_counts =
-      (match U.member "lane_counts" summary with
+      (match summary_member "lane_counts" with
       | `Assoc _ as json -> json
       | _ ->
           Team_session_types.lane_counts session.planned_workers
           |> Team_session_types.counts_to_json);
     controller_counts =
-      (match U.member "controller_counts" summary with
+      (match summary_member "controller_counts" with
       | `Assoc _ as json -> json
       | _ ->
           Team_session_types.controller_level_counts session.planned_workers
           |> Team_session_types.counts_to_json);
     control_domain_counts =
-      (match U.member "control_domain_counts" summary with
+      (match summary_member "control_domain_counts" with
       | `Assoc _ as json -> json
       | _ ->
           Team_session_types.control_domain_counts session.planned_workers
           |> Team_session_types.counts_to_json);
     task_profile_counts =
-      (match U.member "task_profile_counts" summary with
+      (match summary_member "task_profile_counts" with
       | `Assoc _ as json -> json
       | _ ->
           Team_session_types.task_profile_counts session.planned_workers
           |> Team_session_types.counts_to_json);
     escalation_count =
-      (match U.member "escalation_count" summary with
+      (match summary_member "escalation_count" with
       | `Int value -> value
       | `Intlit raw -> (Option.value ~default:0 (int_of_string_opt raw))
       | _ -> Team_session_types.escalation_count session.planned_workers);
     controller_tree =
-      (match U.member "controller_tree" summary with
+      (match summary_member "controller_tree" with
       | `Assoc _ as json -> json
       | _ -> `Assoc []);
     lane_health =
-      (match U.member "lane_health" summary with
+      (match summary_member "lane_health" with
       | `Assoc _ as json -> json
       | _ -> `Assoc []);
     confidence_heatmap =
-      (match U.member "confidence_heatmap" summary with
+      (match summary_member "confidence_heatmap" with
       | `Assoc _ as json -> json
       | _ -> `Assoc []);
     context_pressure_by_lane =
-      (match U.member "context_pressure_by_lane" summary with
+      (match summary_member "context_pressure_by_lane" with
       | `Assoc _ as json -> json
       | _ -> `Assoc []);
     intervention_counters =
-      (match U.member "intervention_counters" summary with
+      (match summary_member "intervention_counters" with
       | `Assoc _ as json -> json
       | _ -> `Assoc []);
     local_runtime =
-      (match U.member "local_runtime" status_json with
+      (match status_member "local_runtime" with
       | `Assoc _ as json -> json
       | `Null as json -> json
       | _ -> `Null);
@@ -679,4 +695,3 @@ let build_session_digest ?status_json:cached_status config (session : Team_sessi
     worker_cards;
     risk_digest = Risk_digest.(compute ~session ~worker_cards |> to_yojson);
   }
-

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -15,6 +15,17 @@ let force_jsonl_fallback_env () =
 let requested_backend_mode () =
   Env_config_core.storage_type ()
 
+let ensure_default_oas_cascade_timeout_env () =
+  match Sys.getenv_opt "OAS_CASCADE_MODEL_TIMEOUT_SEC" |> Env_config_core.trim_opt with
+  | Some _ -> ()
+  | None ->
+      let keeper_oas_timeout_s = Env_config_keeper.KeeperKeepalive.oas_timeout_sec in
+      let derived_timeout_s =
+        Float.max 30.0 (Float.min 120.0 (keeper_oas_timeout_s /. 5.0))
+      in
+      Unix.putenv "OAS_CASCADE_MODEL_TIMEOUT_SEC"
+        (Printf.sprintf "%.0f" derived_timeout_s)
+
 (* GC tuning for long-running server with bursty allocation.
 
    Dashboard refresh loops create 2GB+ transient allocations per cycle.
@@ -54,6 +65,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Eio_context.set_net net;
   Eio_context.set_clock clock;
   Eio_context.set_mono_clock mono_clock;
+  ensure_default_oas_cascade_timeout_env ();
   Process_eio.init ~cwd_default:Eio.Path.(fs / base_path) ~proc_mgr ~clock;
   let caqti_env : Caqti_eio.stdenv =
     object

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -8,6 +8,7 @@
 
 val force_jsonl_fallback_env : unit -> unit
 val requested_backend_mode : unit -> string
+val ensure_default_oas_cascade_timeout_env : unit -> unit
 
 (** {1 Runtime Context}
 

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -21,6 +21,10 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_snapshot_lightweight_summary_omits_heavy_activity;
+          Alcotest.test_case "digest team session tolerates null nested status"
+            `Quick
+            Test_operator_control_snapshot
+            .test_digest_team_session_tolerates_null_nested_status;
           Alcotest.test_case
             "snapshot lightweight summary caps completed sessions by recency"
             `Quick

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -224,6 +224,40 @@ let test_snapshot_lightweight_summary_omits_heavy_activity () =
       Alcotest.(check int) "lightweight recent_actions omitted" 0
         Yojson.Safe.Util.(json |> member "recent_actions" |> to_list |> List.length))
 
+let test_digest_team_session_tolerates_null_nested_status () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      let session_id = start_session_exn (team_ctx env sw config "owner") in
+      let session =
+        match Team_session_store.load_session config session_id with
+        | Some session -> session
+        | None -> Alcotest.fail "expected persisted team session"
+      in
+      let digest =
+        Operator_digest.build_session_digest
+          ~status_json:
+            (`Assoc
+              [
+                ("session", `Null);
+                ("summary", `Null);
+                ("team_health", `Null);
+                ("local_runtime", `Null);
+              ])
+          config session ~now:(Time_compat.now ())
+      in
+      Alcotest.(check string) "session status falls back to persisted session state"
+        (Team_session_types.status_to_string session.status)
+        digest.status;
+      Alcotest.(check string) "health falls back to neutral" "ok" digest.health)
+
 let test_snapshot_lightweight_summary_caps_completed_sessions_by_recency () =
   Eio_main.run @@ fun env ->
   ensure_fs env;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -180,6 +180,20 @@ let test_force_jsonl_fallback_env () =
       Alcotest.(check string)
         "MASC_POSTGRES_URL cleared" "" (Sys.getenv "MASC_POSTGRES_URL"))
 
+let test_default_oas_cascade_timeout_tracks_keeper_timeout () =
+  with_env "OAS_CASCADE_MODEL_TIMEOUT_SEC" None @@ fun () ->
+  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" (Some "300") @@ fun () ->
+  Server_runtime_bootstrap.ensure_default_oas_cascade_timeout_env ();
+  Alcotest.(check string) "derived timeout reserves room for fallbacks" "60"
+    (Sys.getenv "OAS_CASCADE_MODEL_TIMEOUT_SEC")
+
+let test_default_oas_cascade_timeout_keeps_explicit_override () =
+  with_env "OAS_CASCADE_MODEL_TIMEOUT_SEC" (Some "45") @@ fun () ->
+  with_env "MASC_KEEPER_OAS_TIMEOUT_SEC" (Some "300") @@ fun () ->
+  Server_runtime_bootstrap.ensure_default_oas_cascade_timeout_env ();
+  Alcotest.(check string) "explicit override wins" "45"
+    (Sys.getenv "OAS_CASCADE_MODEL_TIMEOUT_SEC")
+
 let test_constructor_is_pure () =
   with_temp_dir "startup-pure" (fun dir ->
       let agents_dir = Room.agents_dir (Room.default_config dir) in
@@ -636,6 +650,12 @@ let () =
         [
           Alcotest.test_case "force_jsonl_fallback_env clears pg envs" `Quick
             test_force_jsonl_fallback_env;
+          Alcotest.test_case
+            "default OAS cascade timeout tracks keeper timeout"
+            `Quick test_default_oas_cascade_timeout_tracks_keeper_timeout;
+          Alcotest.test_case
+            "default OAS cascade timeout keeps explicit override"
+            `Quick test_default_oas_cascade_timeout_keeps_explicit_override;
           Alcotest.test_case "constructors stay pure" `Quick
             test_constructor_is_pure;
           Alcotest.test_case "restore_persisted_sessions uses flat agents dir"


### PR DESCRIPTION
## What changed
- remove the redundant outer `glm:glm-5-turbo` fallback and rely on OAS `glm:auto` multi-model expansion
- harden operator/dashboard status parsing so `agent`, `session`, `summary`, and `team_health` can be `null` without crashing dashboard offload
- derive a default `OAS_CASCADE_MODEL_TIMEOUT_SEC` from the keeper OAS budget so internal per-model fallback happens before the outer keeper timeout expires

## Why
- `glm:auto` had already been merged into OAS main, but keeper turns could still stall on a slow first GLM because OAS internal per-model timeout defaulted to 1200s while keeper OAS timeout defaulted to 300s
- dashboard execution surfaces still assumed nested status objects were always JSON objects, which produced `Can't get member 'status' of non-object type null` warnings and degraded execution views

## Impact
- keepers can fall through slow GLM models inside OAS instead of waiting for the outer 300s timeout
- dashboard/operator views stay stable when keeper/session telemetry contains partial or null nested objects

## Validation
- `dune build --root . test/test_server_runtime_bootstrap.exe test/test_dashboard_execution.exe test/test_operator_control.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_dashboard_execution.exe`
- `./_build/default/test/test_operator_control.exe`

## Notes
- OAS-side `glm:auto` expansion is already on OAS `main`, so this PR only adjusts `masc-mcp` integration and timeout behavior around that merged capability.