### PR TITLE
test(keeper): cheolsu → ollama-only for slot queuing test

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -47,6 +47,9 @@ execution_scope = "workspace"
 tool_preset = "social"
 also_allow = ["keeper_github", "keeper_fs_read", "keeper_shell_readonly"]
 
+# Ollama-only: test local LLM slot queuing (2026-04-09)
+allowed_providers = ["ollama"]
+
 # Telemetry Feedback
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24


### PR DESCRIPTION
## Summary
Set cheolsu keeper to `allowed_providers = ["ollama"]` to test Ollama slot 1 queuing under real keeper workload.

## Why
- `OLLAMA_NUM_PARALLEL=1` but Ollama is never used (GLM primary, cascade 3rd)
- Content-Length fix (oas#735) now deployed — Ollama should respond correctly
- Need one keeper to actively use Ollama to verify queuing behavior

## Rollback
Remove the `allowed_providers` line from `config/keepers/cheolsu.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)