### PR TITLE
fix(keeper): adaptive OAS timeout and per-call turn budget

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -262,12 +262,46 @@ module KeeperKeepalive = struct
 
   (** Per-call timeout in seconds for a single OAS Agent.run execution.
       Guards against indefinite LLM response waits within a turn.
-      Local LLMs with large context (200k+) can take 120-180s per call;
-      the previous hardcoded 45s was too short for local inference.
-      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: 300. Range: [30, 600]. *)
+      With large context (200k+), each LLM call takes 60-120s, so
+      a 5-turn Agent.run can need 300-600s.
+
+      When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
+      Otherwise, {!oas_timeout_for_context} computes an adaptive timeout
+      based on max_context tokens: base 180s + 1.5s per 1K context tokens,
+      capped at [30, 600].
+
+      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive. Range: [30, 600]. *)
+  let oas_timeout_sec_override =
+    match Sys.getenv_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
+    | Some raw ->
+      Some (Float.max 30.0 (Float.min 600.0
+        (Option.value ~default:300.0 (Float.of_string_opt (String.trim raw)))))
+    | None -> None
+
+  let oas_timeout_for_context ~(max_context : int) : float =
+    match oas_timeout_sec_override with
+    | Some v -> v
+    | None ->
+      let base = 180.0 in
+      let per_1k = 1.5 in
+      let extra = Float.of_int max_context /. 1000.0 *. per_1k in
+      Float.max 30.0 (Float.min 600.0 (base +. extra))
+
+  (** Backward-compatible accessor: returns the env override or 300s default.
+      Prefer {!oas_timeout_for_context} when max_context is available. *)
   let oas_timeout_sec =
-    Float.max 30.0 (Float.min 600.0
-      (get_float ~default:300.0 "MASC_KEEPER_OAS_TIMEOUT_SEC"))
+    Option.value ~default:300.0 oas_timeout_sec_override
+
+  (** Maximum turns per single OAS Agent.run call.
+      Keeper resumes via checkpoint in the next keepalive cycle when
+      {!Oas_worker.TurnBudgetExhausted} is returned.
+      Previous default of 200 caused "ambiguous partial commit" errors:
+      the 300s timeout would fire mid-turn after tools had already executed,
+      leaving the keeper in an ambiguous state. With 5 turns per call and
+      adaptive timeout, each turn gets a realistic time budget.
+      Env: [MASC_KEEPER_OAS_MAX_TURNS_PER_CALL]. Default: 5. Range: [1, 50]. *)
+  let oas_max_turns_per_call =
+    max 1 (min 50 (get_int ~default:5 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
 
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -162,8 +162,8 @@ let run_turn
       ~(user_message : string)
       ~(cascade_name : string)
       ~(generation : int)
-      ?(max_turns : int = 200)
-      (* large budget: keeper needs research + code + PR in one cycle *)
+      ?(max_turns : int = Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call)
+      (* Per-call turn budget. Keeper resumes via checkpoint if exhausted. *)
       ?(max_idle_turns : int = 3)
       ?(history_user_source = "direct_user")
       ?(history_assistant_source = "direct_assistant")
@@ -1365,7 +1365,7 @@ let run_turn
   with
   | Error e -> Error (Oas.Error.Internal e)
   | Ok oas_allowed_paths ->
-    let timeout_s = Env_config_keeper.KeeperKeepalive.oas_timeout_sec in
+    let timeout_s = Env_config_keeper.KeeperKeepalive.oas_timeout_for_context ~max_context in
     (match
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
          Oas_worker.run_named

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -67,6 +67,52 @@ let test_keepalive_jitter_range () =
   check bool "jitter >= 0.0" true (v >= 0.0);
   check bool "jitter <= 0.5" true (v <= 0.5)
 
+(* ── OAS adaptive timeout tests ───────────────────────── *)
+
+let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_context
+
+let test_oas_timeout_32k () =
+  let v = adaptive ~max_context:32_000 in
+  check (float 1.0) "32K → ~228s" 228.0 v
+
+let test_oas_timeout_128k () =
+  let v = adaptive ~max_context:128_000 in
+  check (float 1.0) "128K → ~372s" 372.0 v
+
+let test_oas_timeout_262k () =
+  let v = adaptive ~max_context:262_144 in
+  (* 180 + 262.144 * 1.5 = 180 + 393.216 = 573.216, capped at 600 *)
+  check bool "262K → [500, 600]" true (v >= 500.0 && v <= 600.0)
+
+let test_oas_timeout_zero () =
+  let v = adaptive ~max_context:0 in
+  check (float 1.0) "0 context → base 180s" 180.0 v
+
+let test_oas_timeout_monotonic () =
+  let v1 = adaptive ~max_context:32_000 in
+  let v2 = adaptive ~max_context:128_000 in
+  let v3 = adaptive ~max_context:262_144 in
+  check bool "32K < 128K" true (v1 < v2);
+  check bool "128K < 262K" true (v2 < v3)
+
+let test_oas_timeout_cap () =
+  let v = adaptive ~max_context:1_000_000 in
+  check (float 0.1) "1M context → capped at 600" 600.0 v
+
+let test_max_turns_default () =
+  check int "default max_turns_per_call 5" 5
+    Cfg.KeeperKeepalive.oas_max_turns_per_call
+
+let test_max_turns_range () =
+  let v = Cfg.KeeperKeepalive.oas_max_turns_per_call in
+  check bool "max_turns >= 1" true (v >= 1);
+  check bool "max_turns <= 50" true (v <= 50)
+
+let test_oas_timeout_sec_compat () =
+  (* Without env override, oas_timeout_sec returns 300.0 default *)
+  let v = Cfg.KeeperKeepalive.oas_timeout_sec in
+  check (float 1.0) "backward compat default 300s" 300.0 v
+
 (* ── KeeperGrpc config defaults ────────────────────────── *)
 
 let test_grpc_max_reconnect_default () =
@@ -226,6 +272,17 @@ let () =
       test_case "sleep_chunk default" `Quick test_keepalive_sleep_chunk_default;
       test_case "jitter default" `Quick test_keepalive_jitter_default;
       test_case "jitter range" `Quick test_keepalive_jitter_range;
+    ];
+    "oas_timeout_adaptive", [
+      test_case "adaptive 32K context" `Quick test_oas_timeout_32k;
+      test_case "adaptive 128K context" `Quick test_oas_timeout_128k;
+      test_case "adaptive 262K context" `Quick test_oas_timeout_262k;
+      test_case "adaptive 0 context (floor)" `Quick test_oas_timeout_zero;
+      test_case "adaptive monotonic" `Quick test_oas_timeout_monotonic;
+      test_case "adaptive capped at 600" `Quick test_oas_timeout_cap;
+      test_case "max_turns default is 5" `Quick test_max_turns_default;
+      test_case "max_turns range" `Quick test_max_turns_range;
+      test_case "oas_timeout_sec backward compat" `Quick test_oas_timeout_sec_compat;
     ];
     "grpc_config", [
       test_case "max_reconnect default" `Quick test_grpc_max_reconnect_default;


### PR DESCRIPTION
## Summary

- OAS timeout을 context 크기 기반 adaptive로 변경 (262K→573s, 128K→372s)
- Per-call max_turns를 200→5로 축소 (TurnBudgetExhausted → checkpoint resume)

## 배경

7 keeper 전원이 300s OAS timeout으로 반복 실패 (Ollama + GLM 공통):
```
unified turn FAILED latency=300,011ms
→ ambiguous partial commit: tools already executed, LLM response pending
```

**근본 원인**: 300s timeout이 multi-turn Agent.run 전체를 커버. 262K context에서 LLM 1회=60-120s → 2-3 turn이면 300s 소진. Tool 실행 후 다음 LLM 호출 시점에 timeout.

## 변경

| 파라미터 | 이전 | 이후 | Env Override |
|----------|------|------|-------------|
| OAS timeout | 300s 고정 | 180s + 1.5s/1K ctx (max 600s) | `MASC_KEEPER_OAS_TIMEOUT_SEC` |
| max_turns/call | 200 | 5 | `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` |

## Adaptive timeout 계산

| Context | Timeout |
|---------|---------|
| 32K | 228s |
| 128K | 372s |
| 200K | 480s |
| 262K | 573s |

## 안전성

- `TurnBudgetExhausted`는 이미 정상 종료로 처리됨 (checkpoint → resume)
- Env override로 즉시 롤백 가능
- OAS 코드 변경 없음 (MASC 경계 준수)

## Test plan

- [ ] `dune build` + `dune build @lint` 통과
- [ ] 기존 test suite 통과
- [ ] 262K context keeper에서 `TurnBudgetExhausted` 정상 반환 확인
- [ ] "ambiguous partial commit" 에러 감소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)