### PR TITLE
feat: surface OAS exit_condition in run_named for boring gate

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1409,6 +1409,14 @@ let run_turn
             ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
+           ~exit_condition:(fun _turn ->
+             (* OAS checks this predicate before each internal turn.
+                When boring_consecutive >= 8, the keeper has had no productive
+                work for 8+ turns — exit Agent.run early to avoid further
+                token spend. This complements the keepalive-level hard skip
+                (which prevents turn start) by catching mid-session boring
+                accumulation when Agent.run has multiple internal turns. *)
+             !boring_consecutive_turns >= 8)
            ())
      with
      | Error e -> Error e

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -113,6 +113,7 @@ val run_named :
   ?slot_id:int ->
   ?enable_thinking:bool ->
   ?approval:Oas.Hooks.approval_callback ->
+  ?exit_condition:(int -> bool) ->
   ?oas_checkpoint:Oas.Checkpoint.t ->
   ?event_bus:Oas.Event_bus.t ->
   ?sw:Eio.Switch.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -47,6 +47,7 @@ type config = {
   context : Oas.Context.t option;
   slot_id : int option;
   approval : Oas.Hooks.approval_callback option;
+  exit_condition : (int -> bool) option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -81,6 +82,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     context = None;
     slot_id = None;
     approval = None;
+    exit_condition = None;
   }
 
 (* ================================================================ *)
@@ -307,6 +309,10 @@ let build
   in
   let builder = match config.approval with
     | Some cb -> Oas.Builder.with_approval cb builder
+    | None -> builder
+  in
+  let builder = match config.exit_condition with
+    | Some cond -> Oas.Builder.with_exit_condition cond builder
     | None -> builder
   in
   Oas.Builder.build_safe builder

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -155,6 +155,7 @@ let run_named
     ?slot_id
     ?enable_thinking
     ?approval
+    ?exit_condition
     ?oas_checkpoint
     ?event_bus
     ?sw
@@ -210,6 +211,7 @@ let run_named
       enable_thinking;
       event_bus;
       approval;
+      exit_condition;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in


### PR DESCRIPTION
## Summary
Plumb OAS `Builder.with_exit_condition` through MASC's `run_named` wrapper
and use it for keeper boring turn gate.

## Changes
- `lib/oas_worker_exec.ml`: Add `exit_condition` to config type + Builder chain
- `lib/oas_worker_named.ml`: Add `?exit_condition` parameter
- `lib/oas_worker.mli`: Expose in public interface
- `lib/keeper/keeper_agent_run.ml`: Set `exit_condition` to exit when `boring_consecutive >= 8`

## Design
`exit_condition` is an OAS public API (`Builder.with_exit_condition`) that
evaluates a predicate before each internal Agent.run turn. It's a hard,
deterministic gate — when the predicate returns true, Agent.run exits
immediately with `ExitConditionMet`.

The keeper captures `boring_consecutive_turns` ref in the closure, giving
OAS access to MASC's boring state without OAS knowing about MASC concepts.
Clean boundary: MASC owns the signal, OAS owns the enforcement.

This complements the keepalive-level hard skip (#5968) by catching
mid-session boring accumulation when Agent.run has multiple internal turns.

## Test plan
- [ ] CI build passes
- [ ] exit_condition fires when boring >= 8 (verify via `ExitConditionMet` log)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>