### PR TITLE
refactor(config): centralize SearXNG, OTel, allowed_origins in network defaults

### DIFF
--- a/lib/config/masc_network_defaults.ml
+++ b/lib/config/masc_network_defaults.ml
@@ -37,3 +37,29 @@ let masc_http_default_port_s =
 
 (** Default host for the MASC HTTP server. *)
 let masc_http_default_host = "127.0.0.1"
+
+(** Default port for SearXNG local search. *)
+let searxng_default_port = 8888
+
+(** Default URL for SearXNG. *)
+let searxng_default_url =
+  Printf.sprintf "http://localhost:%d" searxng_default_port
+
+(** Default port for OpenTelemetry OTLP HTTP exporter. *)
+let otel_default_port = 4318
+
+(** Default URL for OpenTelemetry OTLP HTTP endpoint. *)
+let otel_default_url =
+  Printf.sprintf "http://localhost:%d" otel_default_port
+
+(** Allowed origins for DNS rebinding / CORS protection.
+    Update here; [server_routes_http_common.ml] reads this list. *)
+let allowed_origins = [
+  "http://localhost";
+  "https://localhost";
+  "http://127.0.0.1";
+  "https://127.0.0.1";
+  (* Cloudflare tunnel *)
+  "https://masc.crying.pictures";
+  "https://masc-dev.crying.pictures";
+]

--- a/lib/otel/otel_config.ml
+++ b/lib/otel/otel_config.ml
@@ -10,7 +10,7 @@ let enabled =
 
 let endpoint =
   Sys.getenv_opt "OTEL_EXPORTER_OTLP_ENDPOINT"
-  |> Option.value ~default:"http://localhost:4318"
+  |> Option.value ~default:Masc_network_defaults.otel_default_url
 
 let service_name =
   Sys.getenv_opt "OTEL_SERVICE_NAME"

--- a/lib/server/server_routes_http_common.ml
+++ b/lib/server/server_routes_http_common.ml
@@ -311,16 +311,9 @@ let starts_with ~prefix s =
   let plen = String.length prefix in
   String.length s >= plen && String.sub s 0 plen = prefix
 
-(** Allowed origins for DNS rebinding protection *)
-let allowed_origins = [
-  "http://localhost";
-  "https://localhost";
-  "http://127.0.0.1";
-  "https://127.0.0.1";
-  (* Cloudflare tunnel *)
-  "https://masc.crying.pictures";
-  "https://masc-dev.crying.pictures";
-]
+(** Allowed origins for DNS rebinding protection.
+    SSOT: [Masc_network_defaults.allowed_origins]. *)
+let allowed_origins = Masc_network_defaults.allowed_origins
 
 (** Validate Origin header for DNS rebinding protection *)
 let validate_origin (request : Httpun.Request.t) =

--- a/lib/tool_misc_web_search.ml
+++ b/lib/tool_misc_web_search.ml
@@ -424,7 +424,7 @@ let endpoint_error ~fallback detail =
   let detail = redact_transport_error_detail detail |> String.trim in
   if detail = "" then fallback else Printf.sprintf "%s (%s)" fallback detail
 
-let searxng_default_url = "http://localhost:8888"
+let searxng_default_url = Masc_network_defaults.searxng_default_url
 
 let strip_trailing_slashes s =
   let rec find_last_non_slash i =


### PR DESCRIPTION
## Summary
- Extended `masc_network_defaults.ml` with `searxng_default_url`, `otel_default_url`, `allowed_origins`
- Replaced hardcoded `localhost:8888` and `localhost:4318` in 3 consumer files
- Zero remaining hardcoded endpoint URLs

## Test plan
- [x] `dune build --root .` passes
- [ ] `dune runtest --root .` passes
- [ ] `grep -rn 'localhost:8888\|localhost:4318' lib/` returns 0 results

Part of SSOT audit 2026-04-09