### PR TITLE
refactor(config): deduplicate 65536 output cap and min context constants

### DIFF
--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -32,9 +32,12 @@ let protect ~module_name ~finally_label ~finally f =
              ~during_exception:true ~backtrace:bt2 ex2);
       Printexc.raise_with_backtrace ex bt
 
+(** Maximum output bytes for tool responses. SSOT for the 64KB cap. *)
+let max_tool_output_bytes = 65_536
+
 (** BUG-016: Truncate large tool responses to prevent MCP transport overload.
     Default max: 64KB. Appends truncation metadata when trimmed. *)
-let truncate_response ?(max_bytes=65536) ~total_count response =
+let truncate_response ?(max_bytes=max_tool_output_bytes) ~total_count response =
   let len = String.length response in
   if len <= max_bytes then response
   else

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -6,6 +6,10 @@ open Tool_args
     reference this constant instead of using the string literal. *)
 let default_cascade_name = "keeper_unified"
 
+(** Minimum context window (tokens) for any keeper turn.
+    Prevents running with a context too small for effective reasoning. *)
+let min_keeper_context_tokens = 65_536
+
 let bool_default_true_of_env name =
   match Sys.getenv_opt name with
   | None -> true

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -691,12 +691,12 @@ let handle_keeper_pr_review_read
         [ "/bin/zsh"; "-lc"; meta_cmd ] in
     (* Get PR diff (truncated) *)
     let diff_cmd = Printf.sprintf
-      "cd %s && gh pr diff %d%s 2>&1 | head -c 65536"
-      (Filename.quote root) pr_number repo_flag in
+      "cd %s && gh pr diff %d%s 2>&1 | head -c %d"
+      (Filename.quote root) pr_number repo_flag Common.max_tool_output_bytes in
     let st_diff, out_diff =
       Process_eio.run_argv_with_status ~timeout_sec:15.0
         [ "/bin/zsh"; "-lc"; diff_cmd ] in
-    let diff_truncated = String.length out_diff >= 65536 in
+    let diff_truncated = String.length out_diff >= Common.max_tool_output_bytes in
     Yojson.Safe.to_string
       (`Assoc
           [ "ok", `Bool (st_meta = Unix.WEXITED 0)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -247,7 +247,7 @@ let write_heartbeat_snapshot
     |> Oas_model_resolve.filter_by_providers meta_current.allowed_providers
   in
   let max_cascade_context =
-    let min_keeper_context = 65_536 in
+    let min_keeper_context = Keeper_config.min_keeper_context_tokens in
     let raw = match meta_current.max_context_override with
       | Some v -> v
       | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -182,7 +182,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          Progress.Tracker.step turn_tracker ~message:"Building turn prompt" ();
          ignore (Oas_model_resolve.refresh_local_discovery_if_possible effective_models);
          let max_cascade_context =
-           let min_keeper_context = 65_536 in
+           let min_keeper_context = Keeper_config.min_keeper_context_tokens in
            let raw =
              match meta.max_context_override with
              | Some v ->

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -185,7 +185,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let voice_agent_id_opt = get_string_opt args "voice_agent_id" in
     let mention_targets_in = get_string_list args "mention_targets" in
     let max_context_override_opt =
-      let min_keeper_context = 65_536 in
+      let min_keeper_context = Keeper_config.min_keeper_context_tokens in
       match Safe_ops.json_int_opt "max_context_override" args with
       | None -> None
       | Some v when v >= min_keeper_context && v <= 1_000_000 -> Some v

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -905,7 +905,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   | Ok () ->
       ignore (Oas_model_resolve.refresh_local_discovery_if_possible model_labels);
       let max_cascade_context =
-        let min_keeper_context = 65_536 in
+        let min_keeper_context = Keeper_config.min_keeper_context_tokens in
         let raw =
           match meta.max_context_override with
           | Some v ->

--- a/lib/tool_output_validation.ml
+++ b/lib/tool_output_validation.ml
@@ -17,7 +17,7 @@
     context budget concern.  64 KB covers any reasonable structured
     result while preventing multi-MB shell dumps from persisting
     in the message list. *)
-let max_output_chars = 65_536
+let max_output_chars = Common.max_tool_output_bytes
 
 let cap (output : string) : string =
   let len = String.length output in


### PR DESCRIPTION
## Summary
- `Common.max_tool_output_bytes` (masc_core): SSOT for 64KB tool output cap
- `Keeper_config.min_keeper_context_tokens`: SSOT for 65536-token keeper floor
- Replaced 7 hardcoded `65536` literals across 8 files
- TCP port validation in `env_config_core.ml` left as-is (unrelated)

## Test plan
- [x] `dune build --root .` passes
- [ ] `dune runtest --root .` passes
- [ ] Unaccounted `65536` grep returns 0 results

Part of SSOT audit 2026-04-09