### PR TITLE
fix(keeper): add tool schemas for autonomy pipeline tools

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -409,6 +409,9 @@ let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Types.tool_schema list
   @ Tool_shard.autoresearch_keeper_tools
   @ Tool_shard.coding_tools
   @ Tool_code_write.schemas
+  @ Tool_shard.keeper_pr_submit_tools
+  @ Tool_shard.keeper_preflight_tools
+  @ Tool_shard.keeper_pr_review_tools
   @ (masc_schemas_fn meta)
 
 (** Filter schemas by a set of allowed names.  Uses Hashtbl for O(1) lookup

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -348,6 +348,96 @@ commit_message='fix typo', pr_title='Fix typo in foo'. Requires coding or delive
   };
 ]
 
+(** Keeper PR submit — multi-file commit + push + draft PR creation.
+    Supersedes keeper_pr_workflow for multi-file changes. *)
+let keeper_pr_submit_tools : Types.tool_schema list = [
+  {
+    name = "keeper_pr_submit";
+    description = "Commit staged changes with keeper identity, push, and open a draft PR. \
+Works in any worktree or playground repos directory. \
+Provide cwd (worktree path), commit_message, pr_title. \
+Optional: pr_body, base_branch (default: main), draft (default: true), files (array, default: git add -A).";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Working directory — must be inside .worktrees/ or .masc/playground/")]);
+        ("commit_message", `Assoc [("type", `String "string"); ("description", `String "Git commit message")]);
+        ("pr_title", `Assoc [("type", `String "string"); ("description", `String "Pull request title")]);
+        ("pr_body", `Assoc [("type", `String "string"); ("description", `String "PR description (defaults to pr_title)")]);
+        ("base_branch", `Assoc [("type", `String "string"); ("description", `String "Target branch (default: main)")]);
+        ("draft", `Assoc [("type", `String "boolean"); ("description", `String "Open as draft PR (default: true)")]);
+        ("files", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Specific files to stage (default: git add -A)")]);
+      ]);
+      ("required", `List [`String "cwd"; `String "commit_message"; `String "pr_title"]);
+    ];
+  };
+]
+
+(** Pre-flight validation for keeper autonomous work. *)
+let keeper_preflight_tools : Types.tool_schema list = [
+  {
+    name = "keeper_preflight_check";
+    description = "Validate prerequisites before starting autonomous work: \
+gh auth, repo access, keeper identity, preset level, clone target path. \
+Returns structured JSON with all check results. Read-only, no side effects.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name) to check access for")]);
+      ]);
+      ("required", `List [`String "repo"]);
+    ];
+  };
+]
+
+(** PR review tools — read diffs, leave comments, approve/request changes. *)
+let keeper_pr_review_tools : Types.tool_schema list = [
+  {
+    name = "keeper_pr_review_read";
+    description = "Read PR metadata, diff, reviews, and comments. \
+Returns title, body, changed files, review threads, and truncated diff (max 64KB). Read-only.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number")]);
+      ]);
+      ("required", `List [`String "repo"; `String "number"]);
+    ];
+  };
+  {
+    name = "keeper_pr_review_comment";
+    description = "Submit a PR review with optional inline comments. \
+Events: COMMENT, APPROVE, REQUEST_CHANGES. Requires delivery or coding preset.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number")]);
+        ("body", `Assoc [("type", `String "string"); ("description", `String "Review body text")]);
+        ("event", `Assoc [("type", `String "string"); ("enum", `List [`String "COMMENT"; `String "APPROVE"; `String "REQUEST_CHANGES"]); ("description", `String "Review event type")]);
+        ("path", `Assoc [("type", `String "string"); ("description", `String "File path for inline comment (optional)")]);
+        ("line", `Assoc [("type", `String "integer"); ("description", `String "Line number for inline comment (optional)")]);
+      ]);
+      ("required", `List [`String "repo"; `String "number"; `String "body"; `String "event"]);
+    ];
+  };
+  {
+    name = "keeper_pr_review_reply";
+    description = "Reply to a specific PR review comment. Requires delivery or coding preset.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number")]);
+        ("comment_id", `Assoc [("type", `String "integer"); ("description", `String "Comment ID to reply to")]);
+        ("body", `Assoc [("type", `String "string"); ("description", `String "Reply body text")]);
+      ]);
+      ("required", `List [`String "repo"; `String "number"; `String "comment_id"; `String "body"]);
+    ];
+  };
+]
+
 let coding_workspace_tool_names : string list =
   [ "masc_worktree_create"; "masc_worktree_list"; "masc_code_search";
     "masc_code_symbols"; "masc_code_read" ]

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -94,6 +94,15 @@ val coding_tools : Types.tool_schema list
 (** Coding shard tools (keeper_github/keeper_bash + worktree/code inspection).
     Not in default shards. *)
 
+val keeper_pr_submit_tools : Types.tool_schema list
+(** Multi-file PR submit tool schema. *)
+
+val keeper_preflight_tools : Types.tool_schema list
+(** Pre-flight validation tool schema. *)
+
+val keeper_pr_review_tools : Types.tool_schema list
+(** PR review tools (read, comment, reply) schemas. *)
+
 val shard_coding : shard
 (** Coding shard: github/shell bridge + worktree/code inspection. *)
 


### PR DESCRIPTION
## Summary
- 5 tools from #5945 had dispatch + policy but **no `Types.tool_schema`** definitions
- Without schemas, `make_tools` can't create `Agent_sdk.Tool.t` → pruned from dispatch universe every turn
- Evidence: 12 WARN entries in `system_log_2026-04-09.jsonl`: "AllowList pruned 5 tool(s) outside dispatch universe"

## Changes
- `lib/tool_shard.ml`: add schemas for `keeper_pr_submit`, `keeper_preflight_check`, `keeper_pr_review_read/comment/reply`
- `lib/tool_shard.mli`: export new schema lists
- `lib/keeper/keeper_tool_policy.ml`: register in `all_keeper_schemas`

## Test plan
- [x] `test_tool_code_write_coverage.exe` 20/20 pass
- [x] `test_keeper_allowed_paths.exe` 11/11 pass
- [x] `dune build` clean
- [ ] Verify WARN log disappears after server restart with this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)