### PR TITLE
docs: add @boundary-contract comments to OAS/MASC interface modules

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -392,7 +392,19 @@ let observation_summary = function
     - Large-context cloud (>= 500K): quality-preserving with summarization
     - Normal: standard DropLowImportance *)
 
-(** Context ratio thresholds for dynamic strategy selection.
+(** {1 Dynamic Strategy Selection}
+
+    @boundary-contract
+    - MASC owns: world-aware strategy resolution (which strategies to apply
+      based on agent count, task focus, model class, context ratio).
+      All thresholds are env-configurable, not hardcoded.
+    - OAS owns: strategy execution (PruneToolOutputs, MergeContiguous are
+      OAS built-ins), context_reducer pipeline, compaction algorithm.
+    - Neither may: MASC must not execute compaction directly (only select
+      strategies); OAS must not select strategies based on world state
+      (it has no world awareness).
+
+    Context ratio thresholds for dynamic strategy selection.
     Distinct from Dashboard.ctx_* (display) — these drive compaction behavior. *)
 let dynamic_multi_agent_ctx = Env_config.ContextCompact.dynamic_multi_agent_ratio
 let dynamic_focused_ctx = Env_config.ContextCompact.dynamic_focused_ratio

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -44,7 +44,16 @@ let ensure_dir path =
 
     All OAS Context_reducer estimation calls in MASC pass through this
     module.  Other keeper modules must NOT call
-    [Agent_sdk.Context_reducer.estimate_*] directly for decision-making. *)
+    [Agent_sdk.Context_reducer.estimate_*] directly for decision-making.
+
+    @boundary-contract
+    - MASC owns: observation (context_ratio for logging, compaction strategy
+      selection, dashboard display). Token estimates are read-only signals.
+    - OAS owns: authoritative token estimation (CJK-aware, ceil-based),
+      context budget enforcement during Agent.run, compaction execution.
+    - Neither may: MASC must not add safety buffers on top of OAS estimates
+      (removed in #5053); OAS estimates must not be used as exact counts
+      for billing or hard limits. *)
 
 (** Estimate token count for a raw string (CJK-aware). *)
 let estimate_char_tokens (s : string) : int =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -37,6 +37,17 @@ let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
     ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
 
+(** {1 Retry & Side-Effect Safety}
+
+    @boundary-contract
+    - MASC owns: side-effect detection (blocking retry after mutating tools),
+      cross-provider retry (2 attempts after all OAS per-provider retries
+      exhaust), error reclassification for ambiguous outcomes.
+    - OAS owns: per-provider retry (3 attempts), HTTP backoff, timeout
+      handling, provider failover within a single cascade call.
+    - Neither may: retry silently after a mutating tool succeeded (integrity
+      over availability); duplicate OAS per-provider retry counts. *)
+
 (** Detect transient network errors that warrant retry with short backoff.
     Uses structured [Oas.Error.sdk_error] pattern matching instead of
     substring matching on stringified error messages. *)
@@ -109,7 +120,15 @@ type overflow_retry_plan = {
     Extracts the token limit directly from the structured [ContextOverflow]
     error instead of re-parsing stringified error messages.
     No local token-budget math — OAS owns context budgeting.
-    MASC only decides whether to compact and retry. *)
+    MASC only decides whether to compact and retry.
+
+    @boundary-contract
+    - MASC owns: "compact & retry?" decision (at most once per turn),
+      extracting the limit from OAS structured errors, generation tracking.
+    - OAS owns: context overflow detection, ContextOverflow/TokenBudgetExceeded
+      error emission, checkpoint compaction algorithm, token budget enforcement.
+    - Neither may: MASC must not invent token limits or run its own budget
+      math; OAS must not auto-retry on overflow (MASC needs to decide). *)
 let recover_context_overflow_retry
     ~(meta : keeper_meta)
     ~(base_dir : string)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -362,7 +362,17 @@ let enrich_idle_detail (detail : string) (messages : Oas.Types.message list) : s
 
     [max_turns] and [max_cost_usd] are adjusted to account for
     cumulative values in the checkpoint — the keeper's per-call budget
-    is added on top of the checkpoint's accumulated state. *)
+    is added on top of the checkpoint's accumulated state.
+
+    @boundary-contract
+    - MASC owns: per-turn config selection (model, temperature, tools,
+      system_prompt), per-turn budget allocation, checkpoint field patching
+      to align MASC intent with OAS resume semantics.
+    - OAS owns: cumulative token/cost accounting, turn_count tracking,
+      Agent.resume state restoration, loop guard enforcement.
+    - Neither may: MASC must not set [max_total_tokens] (OAS SSOT for
+      cumulative budgets); OAS must not override MASC model/temperature
+      selection after resume. *)
 let resume_from_checkpoint
     ~(net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
     ~(config : config)


### PR DESCRIPTION
## Summary
- Added `@boundary-contract` doc comments to 5 critical OAS/MASC interface points
- Each contract specifies: MASC owns / OAS owns / Neither may
- Doc-only change, zero behavioral impact

## Modules documented
- `keeper_unified_turn.ml` — retry, side-effect safety, overflow recovery
- `oas_worker_exec.ml` — checkpoint resume, budget conversion
- `keeper_context_core.ml` — token estimation facade
- `context_compact_oas.ml` — dynamic strategy selection

## Test plan
- [x] `dune build --root .` passes (doc comments only)

Closes #5991