### PR TITLE
fix(dashboard): null-safe JSON helpers, uncapped telemetry count, keeper post-hooks

### DIFF
--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -121,31 +121,36 @@ let safe_age_seconds_opt ~(now_ts : float) ~(event_ts : float) : int option =
     let bounded = max 0.0 (min delta (float_of_int max_int)) in
     Some (int_of_float bounded)
 
+let safe_member key json =
+  match json with
+  | `Assoc _ -> Yojson.Safe.Util.member key json
+  | _ -> `Null
+
 let json_list_field key json =
-  match Yojson.Safe.Util.member key json with
+  match safe_member key json with
   | `List items -> items
   | _ -> []
 
 let json_int_field key json ~default =
-  match Yojson.Safe.Util.member key json with
+  match safe_member key json with
   | `Int value -> value
   | `Intlit raw -> (Option.value ~default:default (int_of_string_opt raw))
   | _ -> default
 
 let json_string_field_opt key json =
-  match Yojson.Safe.Util.member key json with
+  match safe_member key json with
   | `String value ->
       let trimmed = String.trim value in
       if trimmed = "" then None else Some trimmed
   | _ -> None
 
 let json_assoc_field key json =
-  match Yojson.Safe.Util.member key json with
+  match safe_member key json with
   | `Assoc _ as value -> value
   | _ -> `Assoc []
 
 let json_record_field key json =
-  match Yojson.Safe.Util.member key json with
+  match safe_member key json with
   | `Assoc _ as value -> Some value
   | _ -> None
 

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -275,3 +275,36 @@ let prune t ~days =
     ) months;
     !deleted
   end
+
+let count_lines_in_file path =
+  if not (Fs_compat.file_exists path) then 0
+  else
+    let ic = open_in_bin path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let count = ref 0 in
+      let buf = Bytes.create 8192 in
+      let rec loop () =
+        let n = input ic buf 0 8192 in
+        if n = 0 then ()
+        else begin
+          for i = 0 to n - 1 do
+            if Bytes.get buf i = '\n' then incr count
+          done;
+          loop ()
+        end
+      in
+      loop ();
+      !count)
+
+let count_entries t =
+  let total = ref 0 in
+  let months = list_month_dirs t.base_dir in
+  List.iter (fun m ->
+    let month_path = Filename.concat t.base_dir m in
+    let days = list_day_files month_path in
+    List.iter (fun d ->
+      let path = Filename.concat month_path d in
+      total := !total + count_lines_in_file path
+    ) days
+  ) months;
+  !total

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -34,6 +34,10 @@ val prune : t -> days:int -> int
 (** [prune t ~days] deletes day-files older than [days] days ago.
     Returns the number of files deleted.  Removes empty month directories. *)
 
+val count_entries : t -> int
+(** [count_entries t] returns the total number of non-empty lines across all
+    day-files.  Scans files by counting newlines without JSON parsing. *)
+
 val load_tail_lines : string -> max_lines:int -> string list
 (** [load_tail_lines file ~max_lines] efficiently reads the last [max_lines]
     from a large file without loading the whole file into memory.

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -223,6 +223,9 @@ let make_tools
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:false;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:false ~duration_ms;
                 Keeper_exec_tools.notify_tool_call_observers ~tool_name:td.name ~success:false;
+                (let tr = Tool_result.{ tool_name = td.name; success = false;
+                    duration_ms = Float.of_int duration_ms; data = `Null } in
+                 ignore (Tool_dispatch.run_post_hooks tr));
                 let detail =
                   let s = String.trim result in
                   if String.length s <= sse_error_preview_max_chars then s
@@ -266,6 +269,9 @@ let make_tools
                 Keeper_registry.record_tool_use ~base_path:config.base_path meta.name ~tool_name:td.name ~success:true;
                 !Keeper_exec_tools.on_keeper_tool_call ~tool_name:td.name ~success:true ~duration_ms;
                 Keeper_exec_tools.notify_tool_call_observers ~tool_name:td.name ~success:true;
+                (let tr = Tool_result.{ tool_name = td.name; success = true;
+                    duration_ms = Float.of_int duration_ms; data = `Null } in
+                 ignore (Tool_dispatch.run_post_hooks tr));
                 let ts = Time_compat.now () in
                 (try Sse.broadcast
                   (`Assoc [

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -183,7 +183,7 @@ let count_fixed_source_entries ~masc_root ~base_path source : int =
     if not (Sys.file_exists dir) then 0
     else
       (match Dated_jsonl.create ~base_dir:dir () with
-       | store -> List.length (Dated_jsonl.read_recent store 10_000)
+       | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception _ -> 0)
 
@@ -193,7 +193,7 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
     List.fold_left (fun acc (_, dir) ->
       acc +
       (match Dated_jsonl.create ~base_dir:dir () with
-       | store -> List.length (Dated_jsonl.read_recent store 10_000)
+       | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception _ -> 0)
     ) 0 keeper_dirs

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -65,6 +65,11 @@ val run_pre_hooks :
     Returns [(Some rejection, _)] on short-circuit,
     or [(None, final_args)] when all hooks pass. *)
 
+val run_post_hooks : Tool_result.t -> Tool_result.t
+(** Execute registered post-hooks in order, threading the result.
+    Used by keeper dispatch to feed metrics/usage hooks for tools
+    that bypass [dispatch]. *)
+
 val dispatch_structured : token:Tool_token.t -> args:Yojson.Safe.t -> Tool_result.t option
 (** Structured dispatch with hook support.
     Execution order: pre-hooks -> handler -> post-hooks.


### PR DESCRIPTION
## Summary
- `json_assoc_field`와 형제 헬퍼 함수들이 non-Assoc 입력(null)에서 `Type_error` 크래시 발생 → `safe_member` 래퍼로 방어 처리
- `Dated_jsonl.count_entries` 추가: JSON 파싱 없이 라인 수만 카운트, 10,000개 hard cap 제거
- keeper 도구 디스패치에 `Tool_dispatch.run_post_hooks` 호출 추가: `Tool_metrics_persist`와 `Tool_usage_log`가 keeper_* 도구 호출 수집 가능

## Issues
Closes #5998 (keeper lifecycle null crash)
Closes #6000 (tool_call_io 10K cap)
Partial fix for #5999 (tool metrics/usage = 0)

## Test plan
- [ ] 서버 시작 시 keeper lifecycle listener 에러 로그 사라짐 확인
- [ ] 대시보드 도구 호출 I/O 카운트가 10,000 초과 표시 확인
- [ ] keeper 도구 호출 후 `data/tool-metrics/` 디렉토리에 JSONL 기록 확인
- [ ] dune build + dune runtest 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)