### PR TITLE
refactor: derive keeper read-only tools from Tool_shard metadata (#5983 고도화)

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -83,29 +83,20 @@ let is_core_always_tool (name : string) : bool =
 
 (* ── Read-only keeper tools ───────────────────────────────────── *)
 
-(** Keeper-only tools are declared via [Tool_shard] schemas, so many never
-    flow through [Tool_spec.register]. Keep a local read-only SSOT for
-    integrity checks that run before or outside full MCP server bootstrap. *)
+(** Derived from [Tool_shard.shard.read_only_tools] metadata.
+    Each shard declares which of its tools are read-only at the
+    definition site, eliminating drift between tool schemas and
+    read-only classification.
+
+    Non-shard tools (injected outside Tool_shard, e.g. keeper_tool_search)
+    are listed explicitly below. *)
+let non_shard_read_only_tools = [
+  "keeper_tool_search";  (* injected by Keeper_tool_policy, not in any shard *)
+]
+
 let keeper_read_only_tools =
-  [
-    "keeper_stay_silent";
-    "keeper_time_now";
-    "keeper_context_status";
-    "keeper_memory_search";
-    "keeper_tools_list";
-    "keeper_tool_search";
-    "keeper_board_get";
-    "keeper_board_list";
-    "keeper_board_stats";
-    "keeper_board_search";
-    "keeper_fs_read";
-    "keeper_shell_readonly";
-    "keeper_library_search";
-    "keeper_library_read";
-    "keeper_tasks_list";
-    "keeper_tasks_audit";
-    "keeper_voice_sessions";
-  ]
+  Tool_shard.all_read_only_keeper_tools () @ non_shard_read_only_tools
+  |> List.sort_uniq String.compare
 
 let keeper_read_only_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length keeper_read_only_tools) in

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -9,6 +9,7 @@
 type shard = {
   name : string;
   tools : Types.tool_schema list;
+  read_only_tools : string list;
   removable : bool;  (** true = can be revoked at runtime *)
   description : string;
 }
@@ -654,13 +655,21 @@ accomplished so other agents can verify.";
 let shard_base : shard = {
   name = "base";
   tools = base_tools;
-  removable = false;  (* Always present *)
+  read_only_tools = [
+    "keeper_stay_silent"; "keeper_time_now"; "keeper_context_status";
+    "keeper_memory_search"; "keeper_tools_list";
+  ];
+  removable = false;
   description = "Core tools: time, context, memory";
 }
 
 let shard_board : shard = {
   name = "board";
   tools = board_tools;
+  read_only_tools = [
+    "keeper_board_get"; "keeper_board_list";
+    "keeper_board_stats"; "keeper_board_search";
+  ];
   removable = true;
   description = "MASC Board: post, list, comment";
 }
@@ -668,6 +677,7 @@ let shard_board : shard = {
 let shard_filesystem : shard = {
   name = "filesystem";
   tools = filesystem_tools;
+  read_only_tools = ["keeper_fs_read"];
   removable = true;
   description = "File I/O: read and write";
 }
@@ -675,6 +685,7 @@ let shard_filesystem : shard = {
 let shard_shell : shard = {
   name = "shell";
   tools = shell_tools;
+  read_only_tools = ["keeper_shell_readonly"];
   removable = true;
   description = "Read-only shell: pwd, ls, cat, rg, git_status";
 }
@@ -682,6 +693,7 @@ let shard_shell : shard = {
 let shard_coding : shard = {
   name = "coding";
   tools = coding_tools;
+  read_only_tools = [];
   removable = true;
   description =
     "Coding tools: github/shell bridge + worktree/code inspection";
@@ -690,6 +702,7 @@ let shard_coding : shard = {
 let shard_voice : shard = {
   name = "voice";
   tools = voice_tools;
+  read_only_tools = ["keeper_voice_sessions"];
   removable = true;
   description = "Voice bridge speak output";
 }
@@ -697,6 +710,7 @@ let shard_voice : shard = {
 let shard_library : shard = {
   name = "library";
   tools = library_tools;
+  read_only_tools = ["keeper_library_search"; "keeper_library_read"];
   removable = true;
   description = "Knowledge library: search, read documents";
 }
@@ -704,6 +718,7 @@ let shard_library : shard = {
 let shard_taskboard : shard = {
   name = "taskboard";
   tools = taskboard_tools;
+  read_only_tools = ["keeper_tasks_list"; "keeper_tasks_audit"];
   removable = true;
   description = "Task board management: list, audit, force-release, force-done, broadcast";
 }
@@ -717,6 +732,7 @@ let autoresearch_keeper_tools : Types.tool_schema list =
 let shard_autoresearch : shard = {
   name = "autoresearch";
   tools = autoresearch_keeper_tools;
+  read_only_tools = [];
   removable = true;
   description = "Autonomous experiment loop: start, cycle, status, inject, stop";
 }
@@ -760,6 +776,12 @@ let all_shards : shard StringMap.t =
     shard_taskboard;
     shard_autoresearch;
   ]
+
+let all_read_only_keeper_tools () : string list =
+  StringMap.fold (fun _name shard acc ->
+    shard.read_only_tools @ acc
+  ) all_shards []
+  |> List.sort_uniq String.compare
 
 (** Get a shard by name *)
 let get_shard (name : string) : shard option =

--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -6,6 +6,10 @@
 type shard = {
   name : string;
   tools : Types.tool_schema list;
+  read_only_tools : string list;
+  (** Tool names within this shard that have no side effects.
+      Used by [Keeper_tool_registry] to derive the read-only set
+      instead of maintaining a separate hardcoded list. *)
   removable : bool;
   description : string;
 }
@@ -51,6 +55,9 @@ val revoke_shard : string list -> string -> (string list, string) result
     @param active_shards Current list of granted shard names
     @param shard_name Shard to revoke (must be removable)
     @return Ok new_list on success, Error msg on failure *)
+
+val all_read_only_keeper_tools : unit -> string list
+(** Collect read_only_tools from all shards. *)
 
 val list_all_shards : unit -> (string * bool * int) list
 (** List all available shards with their status.


### PR DESCRIPTION
## Summary

#5983에서 도입한 17개 하드코딩 `keeper_read_only_tools` 리스트를 Tool_shard metadata에서 파생하도록 고도화.

### 변경 사항

- `Tool_shard.shard` 타입에 `read_only_tools : string list` 필드 추가
- 9개 shard 정의에 각각의 read-only 도구 목록 선언
- `Tool_shard.all_read_only_keeper_tools()` 함수로 전체 수집
- `keeper_tool_registry.ml`에서 shard-derived 16개 + non-shard 1개 (`keeper_tool_search`)로 구성

### 왜 이 방식인가

- **SSOT**: read-only 상태가 tool 정의 사이트에서 선언됨 (drift 제거)
- **확장성**: 새 read-only keeper tool 추가 시 shard 정의에만 추가
- **안전**: non-shard tools (`keeper_tool_search`)은 명시적으로 분리되어 있어 누락 방지

## Test plan

- [x] `test_tool_dispatch.exe` 18/18 pass (read_only_set 4개 포함)
- [x] `test_keeper_unified.exe` 113/113 pass
- [x] `dune build --root .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)