### PR TITLE
[codex] fix: clamp keeper boring exit threshold env defaults

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -710,9 +710,8 @@ let keeper_slot_id (name : string) : int option =
 let keeper_boring_exit_threshold_rp =
   _rp_int ~key:"keeper.turn.boring_exit_threshold"
     ~default:(fun () ->
-      match Sys.getenv_opt "MASC_KEEPER_BORING_EXIT_THRESHOLD" with
-      | Some s -> (try int_of_string s with _ -> 8)
-      | None -> 8)
+      int_of_env_default "MASC_KEEPER_BORING_EXIT_THRESHOLD"
+        ~default:8 ~min_v:2 ~max_v:50)
     ~min_v:2 ~max_v:50
     ~description:"Consecutive boring turns before exit_condition triggers and keepalive skips proactive turns" ()
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -697,13 +697,13 @@ let run_keepalive_unified_turn
           ~meta:meta_after_triage
           obs
       in
-      (* Boring-turn gate: after 8+ consecutive idle turns on a non-reactive
-         channel, skip the turn entirely. Reactive turns (mentions, board
-         events) always run — new stimulus resets the boring counter.
-         Levels 1-7 are handled inside before_turn_params (graduated prompt
-         escalation + tool_choice=None_ at >=3) to let the LLM judge whether
-         new work appeared. Level 8 is the deterministic hard exit — no LLM
-         call, no token spend. *)
+      (* Boring-turn gate: once the non-reactive idle streak reaches the
+         configured threshold, skip the turn entirely. Reactive turns
+         (mentions, board events) always run — new stimulus resets the boring
+         counter. Lower streaks are handled inside before_turn_params
+         (graduated prompt escalation + tool_choice=None_ at >=3) to let the
+         LLM judge whether new work appeared. Crossing the configured threshold
+         is the deterministic hard exit — no LLM call, no token spend. *)
       let boring_skip =
         let streak = !boring_consecutive_turns_ref in
         let is_reactive =

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -305,6 +305,8 @@ let () =
     let restore_env () =
       match original with
       | Some value -> Unix.putenv key value
+      (* OCaml stdlib lacks Unix.unsetenv; empty string is sufficient here
+         because int_of_env_default treats invalid/empty values as default. *)
       | None -> Unix.putenv key ""
     in
     Fun.protect

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -271,6 +271,61 @@ let () =
       true (has "keeper.dead_ttl_sec")
   in
 
+  let test_keeper_boring_exit_threshold_registered () =
+    Governance_registry.ensure_init ();
+    let entries = Runtime_params.registry () in
+    let entry =
+      List.find_opt
+        (fun (k, _, _, _, _) -> k = "keeper.turn.boring_exit_threshold")
+        entries
+    in
+    match entry with
+    | Some (_, current, default_json, has_override, Some meta) ->
+        Alcotest.(check string) "default value" "8"
+          (Yojson.Safe.to_string default_json);
+        Alcotest.(check string) "current value" "8"
+          (Yojson.Safe.to_string current);
+        Alcotest.(check bool) "no override by default" false has_override;
+        Alcotest.(check string) "value_type" "int" meta.value_type;
+        Alcotest.(check (option string)) "min_value"
+          (Some "2")
+          (Option.map Yojson.Safe.to_string meta.min_value);
+        Alcotest.(check (option string)) "max_value"
+          (Some "50")
+          (Option.map Yojson.Safe.to_string meta.max_value)
+    | Some (_, _, _, _, None) ->
+        Alcotest.fail "keeper.turn.boring_exit_threshold meta missing"
+    | None ->
+        Alcotest.fail "keeper.turn.boring_exit_threshold not registered"
+  in
+
+  let test_keeper_boring_exit_threshold_env_clamps () =
+    let key = "MASC_KEEPER_BORING_EXIT_THRESHOLD" in
+    let original = Sys.getenv_opt key in
+    let restore_env () =
+      match original with
+      | Some value -> Unix.putenv key value
+      | None -> Unix.putenv key ""
+    in
+    Fun.protect
+      ~finally:(fun () ->
+        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
+        restore_env ())
+      (fun () ->
+        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
+        Unix.putenv key "1";
+        Alcotest.(check int) "clamps env below min" 2
+          (Keeper_config.keeper_boring_exit_threshold ());
+        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
+        Unix.putenv key "100";
+        Alcotest.(check int) "clamps env above max" 50
+          (Keeper_config.keeper_boring_exit_threshold ());
+        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
+        Unix.putenv key "bogus";
+        Alcotest.(check int) "invalid env falls back to default" 8
+          (Keeper_config.keeper_boring_exit_threshold ()))
+  in
+
   let test_keeper_lifecycle_surface () =
     let surfaces = Governance_registry.surfaces in
     let keeper_surface =
@@ -424,6 +479,10 @@ let () =
         [
           Alcotest.test_case "keeper params registered" `Quick
             test_keeper_params_registered;
+          Alcotest.test_case "keeper boring exit threshold registered" `Quick
+            test_keeper_boring_exit_threshold_registered;
+          Alcotest.test_case "keeper boring exit threshold env clamps" `Quick
+            test_keeper_boring_exit_threshold_env_clamps;
           Alcotest.test_case "keeper_lifecycle surface" `Quick
             test_keeper_lifecycle_surface;
           Alcotest.test_case "keeper params meta shape" `Quick


### PR DESCRIPTION
## Summary
- clamp the env-backed default for `keeper.turn.boring_exit_threshold` through the shared `int_of_env_default` helper
- add runtime-param regression coverage for registration metadata and env clamp behavior
- align the keepalive boring-gate comment with the new configurable threshold behavior

## Root cause
- `keeper.turn.boring_exit_threshold` used a custom `Sys.getenv_opt` + `int_of_string` path for its default value
- `Runtime_params.get` returns defaults without running validator hooks, so the documented `min=2` / `max=50` bounds were bypassed for env-sourced values

## Product impact
- `MASC_KEEPER_BORING_EXIT_THRESHOLD` now respects the documented `[2, 50]` range
- keepers no longer silently accept invalid boring-exit thresholds from the environment

## Evidence
- `dune build --root .`
- `./_build/default/test/test_runtime_params.exe`

## Review evidence
- Reviewer: GLM-5.1 via direct `sb glm-text`
- Scope: follow-up diff after merged PR #5997
- Result: `No findings.`

## Linked issue
- Fixes #6005
