### PR TITLE
[codex] fix: count telemetry entries without recent cap

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -86,6 +86,22 @@ let load_lines path =
       |> List.filter (fun l -> String.trim l <> "")
     with Sys_error _ -> []
 
+let count_non_empty_lines path =
+  if not (Fs_compat.file_exists path) then 0
+  else
+    try
+      let ic = open_in_bin path in
+      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+        let count = ref 0 in
+        (try
+           while true do
+             let line = input_line ic in
+             if String.trim line <> "" then incr count
+           done
+         with End_of_file -> ());
+        !count)
+    with Sys_error _ -> 0
+
 (** Read the last [n] non-empty lines from a file without loading the entire
     file into memory.  Reads backwards in 8 KB chunks from the end.
 
@@ -205,6 +221,18 @@ let read_recent_lines t n =
      with Done -> ());
     !collected
   end
+
+let count_entries t =
+  let months = list_month_dirs t.base_dir in
+  List.fold_left (fun total month ->
+    let month_path = Filename.concat t.base_dir month in
+    let days = list_day_files month_path in
+    total
+    + List.fold_left (fun month_total day ->
+        let path = Filename.concat month_path day in
+        month_total + count_non_empty_lines path
+      ) 0 days
+  ) 0 months
 
 let read_range t ~since ~until =
   match parse_date since, parse_date until with

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -25,6 +25,10 @@ val read_recent_lines : t -> int -> string list
 (** Like {!read_recent} but returns raw JSONL strings (no parse).
     Useful for tail-readers that do their own parsing. *)
 
+val count_entries : t -> int
+(** [count_entries t] returns the total number of non-empty JSONL rows
+    across all dated files in the store without parsing the JSON payloads. *)
+
 val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
 (** [read_range t ~since ~until] returns entries whose day-file falls
     within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -183,7 +183,7 @@ let count_fixed_source_entries ~masc_root ~base_path source : int =
     if not (Sys.file_exists dir) then 0
     else
       (match Dated_jsonl.create ~base_dir:dir () with
-       | store -> List.length (Dated_jsonl.read_recent store 10_000)
+       | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception _ -> 0)
 
@@ -193,7 +193,7 @@ let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
     List.fold_left (fun acc (_, dir) ->
       acc +
       (match Dated_jsonl.create ~base_dir:dir () with
-       | store -> List.length (Dated_jsonl.read_recent store 10_000)
+       | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception _ -> 0)
     ) 0 keeper_dirs

--- a/test/test_dated_jsonl.ml
+++ b/test/test_dated_jsonl.ml
@@ -96,6 +96,21 @@ let test_read_recent_lines () =
        with Yojson.Json_error _ -> false)
   ) lines
 
+let test_count_entries () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "dated_jsonl_count" in
+  let store = Dated_jsonl.create ~base_dir:dir () in
+  for i = 1 to 3 do
+    Dated_jsonl.append store (make_json i)
+  done;
+  let old_month = Filename.concat dir "2020-01" in
+  Fs_compat.mkdir_p old_month;
+  Fs_compat.append_file (Filename.concat old_month "15.jsonl")
+    "{\"i\":4}\n\n{\"i\":5}\n";
+  check int "counts non-empty rows across dated files" 5
+    (Dated_jsonl.count_entries store)
+
 (* ── read_range filters by date ────────────────────────── *)
 
 let test_read_range () =
@@ -201,6 +216,7 @@ let () =
       ( "read_recent_lines",
         [
           test_case "returns raw strings" `Quick test_read_recent_lines;
+          test_case "counts non-empty rows across files" `Quick test_count_entries;
         ] );
       ( "read_range",
         [

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -20,6 +20,26 @@ let write_jsonl dir entries =
   let store = Dated_jsonl.create ~base_dir:dir () in
   List.iter (fun json -> Dated_jsonl.append store json) entries
 
+let today_jsonl_path dir =
+  let open Unix in
+  let tm = gmtime (gettimeofday ()) in
+  let month = Printf.sprintf "%04d-%02d" (tm.tm_year + 1900) (tm.tm_mon + 1) in
+  let day = Printf.sprintf "%02d.jsonl" tm.tm_mday in
+  let month_dir = Filename.concat dir month in
+  Fs_compat.mkdir_p month_dir;
+  Filename.concat month_dir day
+
+let write_raw_jsonl_rows dir rows =
+  let path = today_jsonl_path dir in
+  let content =
+    List.init rows (fun i ->
+      Printf.sprintf
+        "{\"timestamp\": %.1f, \"event\": \"e%d\"}\n"
+        (float_of_int i) i)
+    |> String.concat ""
+  in
+  Fs_compat.append_file path content
+
 (* ── Source roundtrip ────────────────────────────── *)
 
 let test_source_roundtrip () =
@@ -172,6 +192,21 @@ let test_summary_with_data () =
     Alcotest.(check bool) "at least 1 entry" true (total >= 1)
   | _ -> Alcotest.fail "expected Assoc"
 
+let test_summary_counts_all_entries_beyond_recent_cap () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_summary_full_count" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  Fs_compat.mkdir_p telemetry_dir;
+  write_raw_jsonl_rows telemetry_dir 10_050;
+  let json = Telemetry_unified.summary_json ~base_path:dir ~masc_root:(masc_root dir) () in
+  match json with
+  | `Assoc fields ->
+    let total = match List.assoc_opt "total_entries" fields with
+      | Some (`Int n) -> n | _ -> -1 in
+    Alcotest.(check int) "counts all rows, not read_recent cap" 10_050 total
+  | _ -> Alcotest.fail "expected Assoc"
+
 (* ── Cluster-aware path ─────────────────────────── *)
 
 let test_cluster_aware_read () =
@@ -237,6 +272,8 @@ let () =
         [
           Alcotest.test_case "empty" `Quick test_summary_empty;
           Alcotest.test_case "with data" `Quick test_summary_with_data;
+          Alcotest.test_case "counts all rows beyond recent cap" `Quick
+            test_summary_counts_all_entries_beyond_recent_cap;
         ] );
       ( "cluster",
         [


### PR DESCRIPTION
## Summary
- add a dedicated `Dated_jsonl.count_entries` path that counts non-empty JSONL rows without parsing payloads
- switch telemetry summary counting off `read_recent 10_000` so fixed-source entry totals reflect the full store size
- lock the regression with direct coverage for store-wide counting and a telemetry summary case above the old 10k cap

## Root cause
- `Telemetry_unified.summary_json` used `List.length (Dated_jsonl.read_recent store 10_000)` for fixed-source totals and keeper metric totals
- that path was designed for tail reads, not counting, so it silently capped dashboard counts at 10,000 and paid unnecessary JSON parsing cost

## Product impact
- dashboard entry counts for sources such as `tool_call_io` no longer flatten at 10,000 when more rows exist
- telemetry summary counts now match the underlying JSONL store size
- counting no longer parses every JSON row just to compute totals

## Evidence
- `dune build --root . test/test_dated_jsonl.exe test/test_telemetry_unified.exe`
- `./_build/default/test/test_dated_jsonl.exe`
- `./_build/default/test/test_telemetry_unified.exe`

## Review evidence
- Reviewer: GLM-5.1 via direct `sb glm-text --no-thinking`
- Checked at: `2026-04-09 09:07:43 KST`
- Head: `36953646923fe2f5bb70fa0a0704690f078b41bd`
- Result: `No findings.`

## Linked issue
Fixes #6000
