### PR TITLE
refactor(types): add canonical Severity.t with domain coercion functions

### DIFF
--- a/lib/dashboard/dashboard_attention.ml
+++ b/lib/dashboard/dashboard_attention.ml
@@ -26,6 +26,12 @@ let severity_icon = function
 
 let severity_order = function Critical -> 0 | Warning -> 1 | Info -> 2
 
+(** Coerce to canonical [Severity.t] for cross-module communication. *)
+let to_severity : severity -> Severity.t = function
+  | Critical -> Critical
+  | Warning -> Warning
+  | Info -> Info
+
 (* ===== Detection Rules ===== *)
 
 (** Detect stuck agents: Active/Busy but last_seen > threshold *)

--- a/lib/failure_envelope.ml
+++ b/lib/failure_envelope.ml
@@ -44,6 +44,12 @@ let recoverability_of_string = function
   | "fatal" -> Ok Fatal
   | other -> Error ("unknown failure recoverability: " ^ other)
 
+(** Coerce to canonical [Severity.t] for cross-module communication. *)
+let to_severity : severity -> Severity.t = function
+  | Warn -> Warning
+  | Bad -> Error
+  | Critical -> Critical
+
 let option_to_json f = function
   | Some value -> f value
   | None -> `Null

--- a/lib/failure_envelope.mli
+++ b/lib/failure_envelope.mli
@@ -22,6 +22,7 @@ type t = {
 
 val tool_host_log_module_name : string
 val severity_to_string : severity -> string
+val to_severity : severity -> Severity.t
 val recoverability_to_string : recoverability -> string
 val to_yojson : t -> Yojson.Safe.t
 val of_yojson : Yojson.Safe.t -> (t, string) result

--- a/lib/response/dune
+++ b/lib/response/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.response)
  (modules response)
  (wrapped false)
- (libraries yojson time_compat))
+ (libraries yojson time_compat masc_types))

--- a/lib/response/response.ml
+++ b/lib/response/response.ml
@@ -58,6 +58,12 @@ let severity_of_string_default ?(default=Info) s =
   | Ok sev -> sev
   | Error _ -> default
 
+(** Coerce to canonical [Severity.t] for cross-module communication. *)
+let to_severity : severity -> Severity.t = function
+  | Fatal -> Critical
+  | Warning -> Warning
+  | Info -> Info
+
 (** Error detail to JSON *)
 let error_to_json (e : error_detail) : Yojson.Safe.t =
   `Assoc [

--- a/lib/types/dune
+++ b/lib/types/dune
@@ -3,6 +3,6 @@
  (name masc_types)
  (public_name masc_mcp.masc_types)
  (wrapped false)
- (modules ids types_core types_auth error types task_stage typed_state)
+ (modules ids types_core types_auth error types task_stage typed_state severity)
  (libraries yojson unix time_compat masc_core)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/types/error.ml
+++ b/lib/types/error.ml
@@ -165,6 +165,14 @@ let string_of_severity = function
   | Error -> "ERROR"
   | Critical -> "CRITICAL"
 
+(** Coerce to canonical [Severity.t] for cross-module communication. *)
+let to_severity : severity -> Severity.t = function
+  | Debug -> Debug
+  | Info -> Info
+  | Warning -> Warning
+  | Error -> Error
+  | Critical -> Critical
+
 (** {1 Migration Bridge}
 
     Convert [Error.t] to [Types_auth.masc_error] for incremental

--- a/lib/types/error.mli
+++ b/lib/types/error.mli
@@ -97,6 +97,9 @@ val severity_of_error : t -> severity
 
 val string_of_severity : severity -> string
 
+val to_severity : severity -> Severity.t
+(** Coerce to canonical {!Severity.t} for cross-module communication. *)
+
 (** {1 Migration Bridge} *)
 
 val to_masc_error : t -> Types_auth.masc_error

--- a/lib/types/severity.ml
+++ b/lib/types/severity.ml
@@ -1,0 +1,47 @@
+(** Severity — Canonical severity levels shared across MASC modules.
+
+    Domain-specific severity types (Response.severity, Failure_envelope.severity,
+    Dashboard_attention.severity) remain for backwards compatibility.
+    Each provides a [to_severity] coercion for cross-module communication.
+
+    @since SSOT audit 2026-04-09, closes #5989 *)
+
+type t =
+  | Debug
+  | Info
+  | Warning
+  | Error
+  | Critical
+[@@deriving show, eq, yojson]
+
+let to_string = function
+  | Debug -> "debug"
+  | Info -> "info"
+  | Warning -> "warning"
+  | Error -> "error"
+  | Critical -> "critical"
+
+let of_string = function
+  | "debug" -> Ok Debug
+  | "info" -> Ok Info
+  | "warning" | "warn" -> Ok Warning
+  | "error" | "bad" -> Ok Error
+  | "critical" | "fatal" -> Ok Critical
+  | other -> Error ("unknown severity: " ^ other)
+
+let of_string_default ~default s =
+  match of_string s with Ok v -> v | Error _ -> default
+
+(** Numeric ordering: Debug=0 .. Critical=4.
+    Higher is more severe. *)
+let to_int = function
+  | Debug -> 0
+  | Info -> 1
+  | Warning -> 2
+  | Error -> 3
+  | Critical -> 4
+
+let compare a b = Int.compare (to_int a) (to_int b)
+
+(** [at_least ~threshold s] is [true] when [s >= threshold]. *)
+let at_least ~threshold s = to_int s >= to_int threshold


### PR DESCRIPTION
## Summary
- New `lib/types/severity.ml`: shared 5-level severity type with ordering, comparison, string conversion
- 4 domain modules gain `to_severity` coercion (additive, non-breaking)
- Domain types preserved for backwards compatibility
- Added `masc_types` dependency to `masc_response` library

## Mapping table
| Domain | Original | Severity.t |
|--------|----------|-----------|
| Error | Debug/Info/Warning/Error/Critical | identity |
| Response | Fatal/Warning/Info | Critical/Warning/Info |
| Failure_envelope | Warn/Bad/Critical | Warning/Error/Critical |
| Dashboard_attention | Critical/Warning/Info | identity subset |

## Test plan
- [x] `dune build --root .` passes
- [ ] `dune runtest --root .` passes

Closes #5989