### PR TITLE
fix: null-safe JSON member access across 5 modules (#5974)

### DIFF
--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -420,8 +420,9 @@ let snapshot_json ?hearth ~limit config =
   let all_contested =
     all_beliefs
     |> List.filter (fun json ->
-           json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string
-           |> String.equal "contested")
+           (match Yojson.Safe.Util.member "status" json with
+            | `String s -> String.equal s "contested"
+            | _ -> false))
   in
   let total_contested_belief_count = List.length all_contested in
   let contested_beliefs = take limit all_contested in

--- a/lib/team_session/team_session_engine_helpers.ml
+++ b/lib/team_session/team_session_engine_helpers.ml
@@ -1,5 +1,12 @@
 (** Eio runtime engine for long-running team sessions. *)
 
+(** Null-safe nested JSON member access. Returns [`Null] if any
+    intermediate value is not an [`Assoc]. *)
+let detail_member key json =
+  match Yojson.Safe.Util.member "detail" json with
+  | `Assoc _ as detail -> Yojson.Safe.Util.member key detail
+  | _ -> `Null
+
 type runtime_state = {
   mutable stop_requested : bool;
   mutable stop_reason : string option;
@@ -57,14 +64,14 @@ let event_type_of_json json =
   | _ -> None
 
 let event_detail_actor_of_json json =
-  match Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "actor" with
+  match detail_member "actor" json with
   | `String actor ->
       let trimmed = String.trim actor in
       if trimmed = "" then None else Some trimmed
   | _ -> None
 
 let event_detail_string key json =
-  match Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member key with
+  match detail_member key json with
   | `String value ->
       let trimmed = String.trim value in
       if trimmed = "" then None else Some trimmed
@@ -104,7 +111,7 @@ let worker_run_event_snapshot ?events (config : Room.config)
       | Some ("team_step_spawn" | "team_step_delegate") -> (
           match event_detail_string "worker_run_id" json with
           | Some worker_run_id -> (
-              match Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "success" with
+              match detail_member "success" json with
               | `Bool success -> Hashtbl.replace completed worker_run_id success
               | _ -> ())
           | None -> ())
@@ -344,7 +351,7 @@ let lane_health_json ?events (config : Room.config) (session : Team_session_type
                | `Bool false, `String actor -> Some actor
                | _ -> None)
            | `String "session_agent_detached" -> (
-               match Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "actor" with
+               match detail_member "actor" json with
                | `String actor -> Some actor
                | _ -> None)
            | _ -> None)

--- a/lib/team_session/team_session_report_core.ml
+++ b/lib/team_session/team_session_report_core.ml
@@ -1,5 +1,11 @@
 (** Team session report generation (Markdown + JSON). *)
 
+(** Null-safe nested JSON member access for "detail" sub-fields. *)
+let detail_member key json =
+  match Yojson.Safe.Util.member "detail" json with
+  | `Assoc _ as detail -> Yojson.Safe.Util.member key detail
+  | _ -> `Null
+
 let report_schema_version = "1.0.0"
 let proof_schema_version = "1.0.0"
 
@@ -724,7 +730,7 @@ let collect_spawn_tool_names events =
              [ `String "team_step_spawn"; `String "team_step_delegate" ]
          then
            (match
-              Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "tool_names"
+              detail_member "tool_names" json
             with
            | `List xs ->
                xs
@@ -747,7 +753,7 @@ let sum_spawn_tool_call_count events =
              [ `String "team_step_spawn"; `String "team_step_delegate" ]
          then
            (match
-              Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "tool_call_count"
+              detail_member "tool_call_count" json
             with
            | `Int n -> acc + n
            | `Intlit s -> acc + Option.value ~default:0 (int_of_string_opt s)
@@ -762,7 +768,7 @@ let count_write_capable_spawns events =
          if Yojson.Safe.Util.member "event_type" json = `String "team_step_spawn"
          then
            match
-             Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "execution_scope"
+             detail_member "execution_scope" json
            with
            | `String "limited_code_change" -> acc + 1
            | _ -> acc

--- a/lib/team_session/team_session_report_proof_helpers.ml
+++ b/lib/team_session/team_session_report_proof_helpers.ml
@@ -23,7 +23,7 @@ let count_event_type events expected =
 let turn_actor_of_event (json : Yojson.Safe.t) =
   if has_event_type json "team_turn" then
     match
-      Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "actor"
+      detail_member "actor" json
     with
     | `String actor ->
         let actor = String.trim actor in
@@ -35,7 +35,7 @@ let turn_actor_of_event (json : Yojson.Safe.t) =
 let turn_kind_of_event (json : Yojson.Safe.t) =
   if has_event_type json "team_turn" then
     match
-      Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "kind"
+      detail_member "kind" json
     with
     | `String kind -> Some (String.lowercase_ascii (String.trim kind))
     | _ -> None
@@ -45,7 +45,7 @@ let turn_kind_of_event (json : Yojson.Safe.t) =
 let turn_message_of_event (json : Yojson.Safe.t) =
   if has_event_type json "team_turn" then
     match
-      Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "message"
+      detail_member "message" json
     with
     | `String message ->
         let message = String.trim message in

--- a/lib/tool_team_session_routing_workers.ml
+++ b/lib/tool_team_session_routing_workers.ml
@@ -478,6 +478,9 @@ let extract_vote_id (text : string) =
   | None -> None
 
 let status_of_engine_status_json (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member "session" json |> Yojson.Safe.Util.member "status" with
-  | `String s -> s
+  match Yojson.Safe.Util.member "session" json with
+  | `Assoc _ as session ->
+    (match Yojson.Safe.Util.member "status" session with
+     | `String s -> s
+     | _ -> "unknown")
   | _ -> "unknown"


### PR DESCRIPTION
## Summary

11건의 unsafe chained `Yojson.Safe.Util.member` 호출을 null-safe 패턴으로 교체.
`member "X" json |> member "Y"` → 중간값이 non-Assoc이면 crash.

## 변경 파일

| 파일 | 수정 수 | 패턴 |
|------|---------|------|
| tool_team_session_routing_workers.ml | 1 | session.status |
| team_session_engine_helpers.ml | 4 | detail.actor/success/key |
| team_session_report_core.ml | 3 | detail.tool_names/count/scope |
| team_session_report_proof_helpers.ml | 3 | detail.actor/kind/message |
| meta_cognition_snapshot.ml | 1 | status on belief JSON |

## 접근법

`detail_member` 로컬 helper: `member "detail"` 결과가 `Assoc`인지 확인 후 chaining. 기존 `Safe_ops.safe_member`는 다른 라이브러리에 있어 접근 불가.

Closes #5974

## Test plan

- [x] `dune build` 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)