### PR TITLE
fix(telemetry): wire keeper tool metrics and uncap entry count (#5999, #6000)

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -233,7 +233,6 @@ let count_entries t =
         month_total + count_non_empty_lines path
       ) 0 days
   ) 0 months
-
 let read_range t ~since ~until =
   match parse_date since, parse_date until with
   | None, _ | _, None -> []

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -120,7 +120,14 @@ let () =
   Keeper_exec_tools.on_keeper_tool_call :=
     (fun ~tool_name ~success ~duration_ms ->
        Tool_registry.record_call ~source:Keeper_internal
-         ~tool_name ~success ~duration_ms ());
+         ~tool_name ~success ~duration_ms ();
+       Tool_metrics_persist.enqueue {
+         Tool_result.success; tool_name;
+         duration_ms = Float.of_int duration_ms;
+         data = `Null;
+       };
+       Tool_usage_log.log_call ~tool_name ~success
+         ~caller:(Some "keeper_internal"));
   (* Wire tag-based dispatch for keeper masc_* tools.
      Breaks the same Config dependency cycle as on_keeper_tool_call.
      See #4579: keeper_exec_tools uses handler registry (Tool_Board only),


### PR DESCRIPTION
## Summary

- **#5999**: keeper tool 실행이 Tool_metrics_persist + Tool_usage_log에 기록되지 않음 → `on_keeper_tool_call` callback에 두 호출 추가
- **#6000**: tool_call_io 카운트가 10,000에서 멈춤 → `Dated_jsonl.count_entries` (라인 카운트, JSON 파싱 없음) 추가

## 변경 파일

| 파일 | 변경 |
|------|------|
| `lib/mcp_server_eio.ml` | `on_keeper_tool_call`에 `Tool_metrics_persist.enqueue` + `Tool_usage_log.log_call` 추가 |
| `lib/dated_jsonl/dated_jsonl.ml` + `.mli` | `count_entries` 함수 추가 (파일 라인 수 카운트, 메모리 할당 없음) |
| `lib/telemetry_unified.ml` | `read_recent 10_000` + `List.length` → `count_entries` 교체 (2곳) |

Closes #5999, Closes #6000

## Test plan

- [x] `dune build` 통과
- [ ] CI green
- [ ] 서버 재시작 후 `data/tool-metrics/` 디렉토리에 keeper tool 기록 확인
- [ ] telemetry summary에서 count > 10,000 정확도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)