### PR TITLE
fix: remove duplicate count_entries in dated_jsonl (unbreaks main)

### DIFF
--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -304,35 +304,3 @@ let prune t ~days =
     !deleted
   end
 
-let count_lines_in_file path =
-  if not (Fs_compat.file_exists path) then 0
-  else
-    let ic = open_in_bin path in
-    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-      let count = ref 0 in
-      let buf = Bytes.create 8192 in
-      let rec loop () =
-        let n = input ic buf 0 8192 in
-        if n = 0 then ()
-        else begin
-          for i = 0 to n - 1 do
-            if Bytes.get buf i = '\n' then incr count
-          done;
-          loop ()
-        end
-      in
-      loop ();
-      !count)
-
-let count_entries t =
-  let total = ref 0 in
-  let months = list_month_dirs t.base_dir in
-  List.iter (fun m ->
-    let month_path = Filename.concat t.base_dir m in
-    let days = list_day_files month_path in
-    List.iter (fun d ->
-      let path = Filename.concat month_path d in
-      total := !total + count_lines_in_file path
-    ) days
-  ) months;
-  !total

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -38,10 +38,6 @@ val prune : t -> days:int -> int
 (** [prune t ~days] deletes day-files older than [days] days ago.
     Returns the number of files deleted.  Removes empty month directories. *)
 
-val count_entries : t -> int
-(** [count_entries t] returns the total number of non-empty lines across all
-    day-files.  Scans files by counting newlines without JSON parsing. *)
-
 val load_tail_lines : string -> max_lines:int -> string list
 (** [load_tail_lines file ~max_lines] efficiently reads the last [max_lines]
     from a large file without loading the whole file into memory.


### PR DESCRIPTION
## Summary
- Remove duplicate `count_entries` definition in `dated_jsonl.ml`
- Two PRs (#6004, #6009) both added `count_entries`, second shadows first
- Warning 32 (unused-value-declaration) breaks CI on main and all open PRs

## Fix
Keep first definition (line 225, `count_non_empty_lines` — skips blank rows).
Remove second definition (line 327, `count_lines_in_file` — counts all lines including empty).