### PR TITLE
[codex] remove collaboration_context bridge

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -53,7 +53,7 @@ OAS  ──does not know──→ MASC
 | Event bus bridge | Complete for current `masc:*` flow | `oas_events.ml` publishes, `oas_sse_bridge.ml` relays to dashboard SSE |
 | Checkpoint integration | Partial complete | OAS checkpoint is used in shared worker/runtime paths, and the public OAS worker API now keeps the extra JSON as a neutral checkpoint sidecar. Keeper runtime still persists its own `working_context` / serialized checkpoint path in `lib/keeper/keeper_exec_context.ml` |
 | Memory bridge | Partial complete | long-term + procedural + institution episodic are bridged; broader memory unification is still separate |
-| Team-session swarm | Partial complete | OAS Swarm runner is active; current bridge uses `swarm_config` / `agent_entry` + worker metadata with `collaboration_context=None`, but fidelity is still incomplete |
+| Team-session swarm | Partial complete | OAS Swarm runner is active; current bridge uses `swarm_config` / `agent_entry` + worker metadata while intentionally omitting `collaboration_context`, so fidelity is still incomplete |
 
 ## Boundary Audit Snapshot
 

--- a/docs/architecture-boundary.md
+++ b/docs/architecture-boundary.md
@@ -44,7 +44,7 @@ Files that explicitly bridge MASC and OAS. Named with `_oas` or `_oas_adapter` s
 | File | Purpose |
 |---|---|
 | `verifier_oas.ml` | Verification verdict to OAS Hooks/Guardrails |
-| `team_session_oas_bridge.ml` | MASC session / planned_worker projection into OAS Swarm config and agent entries (`collaboration_context=None`) |
+| `team_session_oas_bridge.ml` | MASC session / planned_worker projection into OAS Swarm config and agent entries (`collaboration_context` omitted by design) |
 | `context_compact_oas.ml` | Context compaction via OAS Context_reducer |
 | `keeper_hooks_oas.ml` | Keeper lifecycle hooks to OAS hooks |
 

--- a/docs/spec/07-team-session.md
+++ b/docs/spec/07-team-session.md
@@ -338,7 +338,7 @@ type team_context = {
 현재 bridge의 핵심은 `Collaboration.t` 투영이 아니라 `session -> swarm_config`, `planned_worker -> agent_entry` 변환이다.
 
 - `team_session_oas_bridge.ml`은 OAS Swarm 실행에 필요한 typed 필드와 `worker_specs` metadata JSON을 구성한다.
-- `collaboration_context`는 현재 `None`으로 고정되어 있으며, `test_team_session_oas_bridge.ml`도 이 truth를 검증한다.
+- `collaboration_context`는 현재 의도적으로 비워 두는 개념이며, `test_team_session_oas_bridge.ml`도 `None` truth를 검증한다.
 - session semantics는 prompt, worker metadata, `resource_check`, telemetry/proof surface를 통해 유지되지만 fidelity gap은 아직 남아 있다.
 
 ---
@@ -415,7 +415,7 @@ type routing_decision = {
 | tool_team_session 분할 | 원래 4412줄 god file. 현재 9개 모듈로 분할 완료 | Resolved |
 | Legacy spawn field 거부 | `spawn_agent`, `spawn_model`, `model_tier` 직접 사용 불가. migration 에러 반환 | By design |
 | Manual/Assist + Auto 이원 경로 | Auto는 OAS Swarm, Manual/Assist는 기존 engine. 통합 미완 | In progress |
-| session record 47 fields | `swarm_config` / `worker_specs` bridge에 일부 fidelity gap이 남아 있음 (`collaboration_context=None`) | Architectural |
+| session record 47 fields | `swarm_config` / `worker_specs` bridge에 일부 fidelity gap이 남아 있으며 `collaboration_context`는 제거 개념으로 유지 | Architectural |
 | Checkpoint proof hash | `Proof_strong` 모드의 hash chain 구현 범위가 event log 무결성에 한정 | Enhancement candidate |
 
 ---

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -51,7 +51,7 @@
 | ~~Board Listener (polling)~~ | 11 | ~100 | **→ REMOVED** (PG relay, filesystem-first에서 불필요. Board_dispatch가 SSE 직접 발사) |
 | ~~Intent 도구 4종~~ | 06 | ~200 | **→ IMPL** (MCP tool registry 등록 + dispatch 완료) |
 | ~~Keeper OAS Memory.t 일부~~ | 05 | ~100 | **→ IMPL** (v2.140.0 filesystem-first 전환으로 완료) |
-| ~~Team Session lossy projection~~ | 07 | ~50 | **→ IMPL** (collaboration_context JSON 채움 + Prompt_composer로 system_prompt 보강. OAS #698에서 Collaboration.t→opaque JSON 전환 완료) |
+| ~~Team Session lossy projection~~ | 07 | ~50 | **→ IMPL** (`collaboration_context` 제거 + Prompt_composer 기반 context 유지. OAS #698에서 Collaboration.t→opaque JSON 전환 완료) |
 | ~~env-gated 테스트~~ | 15 | ~300 | **→ IMPL** (6종 전부 MASC_E2E_TESTS=true로 CI 실행 중. PG 의존 없음 — 서버 바이너리 의존) |
 | ~~MDAL dashboard surface~~ | 10 | ~50 | **→ REMOVED** (개념 폐기) |
 
@@ -118,7 +118,7 @@
 | Swarm Runner | Load→convert→callbacks→run→apply | IMPL | team_session_swarm_runner.ml |
 | Report/Proof | Markdown/JSON, Standard/Strong | IMPL | team_session_report_proof.ml 419 LOC |
 | Tool Surface | 9 handler modules, 4.5K LOC | IMPL | God file 분할 완료 |
-| Session Bridge Fidelity | collaboration_context JSON + Prompt_composer + `worker_specs` projection | IMPL | OAS #698 opaque JSON, fidelity gap remains |
+| Session Bridge Fidelity | Prompt_composer + `worker_specs` projection (`collaboration_context` intentionally omitted) | IMPL | OAS #698 opaque JSON, fidelity gap remains |
 
 ### 08-Governance (100% IMPL)
 
@@ -188,7 +188,7 @@ env-gated 6종은 CI에서 MASC_E2E_TESTS=true로 실행 확인.
 ### 완료된 항목
 - ~~Chain Engine~~ → 소스 삭제됨 (REMOVED)
 - ~~Intent 도구~~ → MCP 등록 완료 (IMPL)
-- ~~Team Session lossy projection~~ → collaboration_context + Prompt_composer (IMPL)
+- ~~Team Session lossy projection~~ → Prompt_composer + `worker_specs` projection (IMPL)
 - ~~env-gated 테스트~~ → CI에서 전부 실행 중 (IMPL)
 - ~~Board Listener~~ → 제거됨 (PG relay, Board_dispatch가 SSE 직접 발사)
 
@@ -203,7 +203,7 @@ env-gated 6종은 CI에서 MASC_E2E_TESTS=true로 실행 확인.
 |---------|------|------|
 | ~~1~~ | ~~Server: SSE rate limit 활성화~~ | **완료** (기본값 1s/60s-10 활성화) |
 | ~~2~~ | ~~Keeper: OAS Memory.t Long_term 백엔드 완성~~ | **완료** (v2.140.0 filesystem-first 전환) |
-| ~~1~~ | ~~Team Session: lossy projection 해소~~ | **완료** (collaboration_context JSON + Prompt_composer system_prompt 보강) |
+| 2 | Team Session: bridge fidelity 재설계 여부 결정 | `collaboration_context` 제거 상태에서 `worker_specs` / prompt context만으로 충분한지 판단 필요 |
 | ~~1~~ | ~~Board Listener: filesystem-first 재설계~~ | **완료** (제거됨 — Board_dispatch가 SSE 직접 발사, PG relay 불필요) |
 | 1 | Transport: HTTP/2 h2c 벤치마크 | opt-in→canonical 전환 판단 근거 |
 | 3 | Transport: live ICE/TURN/browser interop 증빙 lane | local smoke 확보됨, internet-grade만 남음 |

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -118,23 +118,6 @@ let build ~base_path ~team_session_id =
         task_tree;
       }
 
-let task_summary_to_json (t : task_summary) : Yojson.Safe.t =
-  `Assoc
-    ([ ("task_id", `String t.task_id);
-       ("title", `String t.title);
-       ("status", `String t.status) ]
-     @ (match t.assignee with
-        | Some a -> [ ("assignee", `String a) ]
-        | None -> []))
-
-let to_json (ctx : team_context) : Yojson.Safe.t =
-  `Assoc
-    [ ("team_goal", `String ctx.team_goal);
-      ("prior_decisions", `List (List.map (fun s -> `String s) ctx.prior_decisions));
-      ("shared_findings", `List (List.map (fun s -> `String s) ctx.shared_findings));
-      ("active_workers", `List (List.map (fun s -> `String s) ctx.active_workers));
-      ("task_tree", `List (List.map task_summary_to_json ctx.task_tree)) ]
-
 let truncate_list n lst =
   List.filteri (fun i _ -> i < n) lst
 

--- a/lib/team_context.mli
+++ b/lib/team_context.mli
@@ -37,9 +37,6 @@ val build :
     Output is capped to stay within ~500 tokens. *)
 val to_prompt_section : team_context -> string
 
-(** Serialize the team context to JSON for [collaboration_context]. *)
-val to_json : team_context -> Yojson.Safe.t
-
 (** Record a shared finding from a completed worker.
     [finding] should be 1-2 sentences summarizing the key result. *)
 val add_finding :

--- a/lib/team_session/PROJECTION_MAP.md
+++ b/lib/team_session/PROJECTION_MAP.md
@@ -3,7 +3,7 @@
 Current field map for `team_session_oas_bridge.ml`.
 
 **Current truth**: the bridge projects into OAS `swarm_config` / `agent_entry`
-and keeps `collaboration_context = None`. Session/worker semantics survive
+and intentionally omits `collaboration_context`. Session/worker semantics survive
 mainly through typed swarm fields plus `worker_specs` metadata JSON.
 
 ## planned_worker (23 fields) -> agent_entry (4 fields)
@@ -55,7 +55,7 @@ the remaining 18 are metadata-only in `worker_specs`, and 0 are truly dropped.
 | (hardcoded) | max_agent_retries | 1 |
 | (hardcoded) | enable_streaming | false |
 | (runtime) | resource_check | Health check closure |
-| (constant) | collaboration_context | Always `None` in current bridge |
+| (constant) | collaboration_context | Omitted by design |
 
 ### Preserved outside typed swarm_config fields
 
@@ -110,4 +110,4 @@ by apply_swarm_result after swarm execution completes.
 |-----------|--------|----------------|-----------------------------|---------------|
 | planned_worker -> agent_entry | 24 | 4 | `worker_specs` JSON | 0 |
 | session -> swarm_config | 47 | 12 | worker metadata + runtime/proof/session surfaces | 16 (metrics/post-exec) |
-| collaboration_context | 1 | 0 | none | 1 (`None` in current bridge) |
+| collaboration_context | 1 | 0 | none | 1 (removed by design) |

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -867,14 +867,13 @@ let session_to_swarm_config
               (Printexc.to_string ex);
             entry_count)
   in
-  let collaboration_context = Some (Team_context.to_json team_ctx) in
   { entries; mode;
     convergence = make_convergence_metric ~entry_count success_by_agent;
     max_parallel = max 1 entry_count;
     prompt = session.goal; timeout_sec;
     budget = budget_of_session_timeout timeout_sec;
     max_agent_retries = 1;
-    collaboration_context;
+    collaboration_context = None;
     resource_check = Some (session_runtime_health_check ~config ~session);
     max_concurrent_agents = Some (max 1 (min entry_count slot_aware_cap));
     enable_streaming = false }

--- a/test/test_team_session_oas_bridge.ml
+++ b/test/test_team_session_oas_bridge.ml
@@ -237,15 +237,8 @@ let test_session_to_swarm_config_health_contract () =
   Alcotest.(check int) "initial telemetry turn_count" 0 telemetry.turn_count;
   Alcotest.(check bool) "initial telemetry usage empty" true
     (Option.is_none telemetry.usage);
-  Alcotest.(check bool) "collaboration_context populated" true
-    (Option.is_some swarm_cfg.collaboration_context);
-  (match swarm_cfg.collaboration_context with
-   | Some (`Assoc fields) ->
-       Alcotest.(check bool) "has team_goal field" true
-         (List.mem_assoc "team_goal" fields);
-       Alcotest.(check bool) "has task_tree field" true
-         (List.mem_assoc "task_tree" fields)
-   | _ -> Alcotest.fail "collaboration_context should be JSON object");
+  Alcotest.(check bool) "collaboration_context omitted" true
+    (Option.is_none swarm_cfg.collaboration_context);
   let resource_ok = Option.get swarm_cfg.resource_check () in
   Alcotest.(check bool) "resource check passes for initialized room" true
     resource_ok;


### PR DESCRIPTION
## What changed
- stop projecting team-session state into `swarm_config.collaboration_context`
- remove the now-unused `Team_context.to_json` API and its implementation
- update the bridge test to assert that `collaboration_context` is intentionally omitted
- align boundary and team-session docs with the new bridge truth

## Why
`collaboration_context` is a retired bridge concept. The current team-session path already preserves context through prompt composition and `worker_specs`, so keeping a parallel JSON projection only adds redundant surface area and doc drift.

## Impact
- team-session swarm configs now omit `collaboration_context` by design
- prompt-level team context remains intact
- docs and tests now match the actual bridge behavior

## Root cause
A previous change introduced a JSON `collaboration_context` projection while multiple SSOT docs still described the bridge as `None`. That left the codebase with two competing truths for the same boundary.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/remove-collaboration-context`
- `./_build/default/test/test_team_session_oas_bridge.exe`
