### PR TITLE
fix: isolate keeper read access to playground roots

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -116,10 +116,8 @@ let maybe_resolve_missing_relative_read_path ~(roots : string list) ~(raw_path :
       let suffix_rel = join_path_components rest in
       let matches =
         roots
-        |> List.fold_left
-             (fun acc root ->
-                acc @ find_suffix_matches_under_root ~root ~anchor ~suffix_rel ())
-             []
+        |> List.concat_map (fun root ->
+             find_suffix_matches_under_root ~root ~anchor ~suffix_rel ())
         |> List.sort_uniq String.compare
       in
       (match matches with

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -106,7 +106,7 @@ let find_suffix_matches_under_root ~root ~anchor ~suffix_rel
   in
   walk ~dirs_seen:0 [] root |> snd |> List.rev
 
-let maybe_resolve_missing_relative_read_path ~(root : string) ~(raw_path : string) :
+let maybe_resolve_missing_relative_read_path ~(roots : string list) ~(raw_path : string) :
     (string option, string) result =
   let parts = split_relative_components raw_path in
   match parts with
@@ -115,7 +115,12 @@ let maybe_resolve_missing_relative_read_path ~(root : string) ~(raw_path : strin
   | anchor :: rest ->
       let suffix_rel = join_path_components rest in
       let matches =
-        find_suffix_matches_under_root ~root ~anchor ~suffix_rel ()
+        roots
+        |> List.fold_left
+             (fun acc root ->
+                acc @ find_suffix_matches_under_root ~root ~anchor ~suffix_rel ())
+             []
+        |> List.sort_uniq String.compare
       in
       (match matches with
        | [] -> Ok None
@@ -134,6 +139,13 @@ let allows_missing_leaf_read ~(raw : string) ~(candidate : string) : bool =
   parent_exists candidate
   && List.length parts > 1
   && not trailing_slash
+
+let is_within_allowed_norms ~(target_norm : string) (allowed_norms : string list) : bool =
+  List.exists
+    (fun allowed_norm ->
+       target_norm = allowed_norm
+       || starts_with ~prefix:(allowed_norm ^ "/") target_norm)
+    allowed_norms
 
 let absolute_allowed_paths ~(config : Room.config) ~(allowed_paths : string list)
     : string list =
@@ -237,10 +249,12 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   | ["*"] -> []
   | explicit -> playground :: playground_sub @ workspace_defaults @ explicit
 
-(** Resolve a path for read-only access: allow any path within the
-    project root, regardless of allowed_paths.  Write operations must
-    use {!resolve_keeper_target_path} which enforces allowed_paths. *)
-let resolve_keeper_read_path ~(config : Room.config) ~(raw_path : string)
+(** Resolve a path for read-only access within the keeper's effective
+    allowlist. The allowlist is usually the keeper playground bundle
+    plus any explicit custom paths; explicit ["*"] still means full
+    project-root access. *)
+let resolve_keeper_read_path ~(config : Room.config)
+    ~(allowed_paths : string list) ~(raw_path : string)
     : (string, string) result =
   let raw = String.trim raw_path in
   if raw = "" then Error "path_required"
@@ -259,22 +273,58 @@ let resolve_keeper_read_path ~(config : Room.config) ~(raw_path : string)
       Error
         (Printf.sprintf "path_outside_project_root: %s (root=%s)"
            target_norm root_norm)
-    else if path_exists candidate || allows_missing_leaf_read ~raw ~candidate then
-      Ok candidate
-    else if Filename.is_relative raw then
-      (match maybe_resolve_missing_relative_read_path ~root ~raw_path:raw with
-       | Ok (Some resolved) -> Ok resolved
-       | Ok None ->
-           Error
-             (Printf.sprintf
-                "path_not_found_under_project_root: %s (root=%s)"
-                raw root_norm)
-       | Error e -> Error e)
     else
-      Error
-        (Printf.sprintf
-           "path_not_found_under_project_root: %s (root=%s)"
-           target_norm root_norm)
+      let allowed_norms =
+        if allowed_paths = [] then []
+        else
+          allowed_paths
+          |> List.filter_map (normalize_allowed_path_for_check ~root:root_norm)
+      in
+      if allowed_paths <> [] && allowed_norms = [] then
+        Error
+          (Printf.sprintf
+             "allowed_paths_normalized_empty: [%s]"
+             (String.concat ", " allowed_paths))
+      else
+      let within_allowed =
+        allowed_norms = [] || is_within_allowed_norms ~target_norm allowed_norms
+      in
+      let search_roots =
+        if allowed_norms = [] then [root_norm] else allowed_norms
+      in
+      if not within_allowed then
+        if Filename.is_relative raw then
+          (match maybe_resolve_missing_relative_read_path ~roots:search_roots ~raw_path:raw with
+           | Ok (Some resolved) -> Ok resolved
+           | Ok None ->
+               Error
+                 (Printf.sprintf
+                    "path_not_in_allowed_paths: %s (allowed: [%s])"
+                    raw (String.concat ", " allowed_norms))
+           | Error e -> Error e)
+        else
+          Error
+            (Printf.sprintf
+               "path_not_in_allowed_paths: %s (allowed: [%s])"
+               raw (String.concat ", " allowed_norms))
+      else if path_exists candidate || allows_missing_leaf_read ~raw ~candidate then
+        Ok candidate
+      else if Filename.is_relative raw then
+        (match maybe_resolve_missing_relative_read_path ~roots:search_roots ~raw_path:raw with
+         | Ok (Some resolved) -> Ok resolved
+         | Ok None ->
+             Error
+               (Printf.sprintf
+                  "path_not_found_under_allowed_roots: %s (roots=[%s])"
+                  raw (String.concat ", " search_roots))
+         | Error e -> Error e)
+      else
+        Error
+          (Printf.sprintf
+             "path_not_found_under_allowed_roots: %s (roots=[%s])"
+             target_norm
+             (String.concat ", "
+                (if allowed_norms = [] then [root_norm] else allowed_norms)))
 
 let process_status_to_json (st : Unix.process_status) : Yojson.Safe.t =
   match st with

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -3,31 +3,31 @@ open Keeper_exec_shared
 
 let is_missing_read_path_error (e : string) =
   String.starts_with ~prefix:"path_not_found:" e
-  || String.starts_with ~prefix:"path_not_found_under_project_root:" e
+  || String.starts_with ~prefix:"path_not_found_under_allowed_roots:" e
 
 let handle_keeper_fs_read
       ~(config : Room.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   =
-  ignore meta;
   let path = Safe_ops.json_string ~default:"" "path" args in
   let max_bytes =
     Safe_ops.json_int ~default:20000 "max_bytes" args |> fun n -> max 512 (min 200000 n)
   in
-  match resolve_keeper_read_path ~config ~raw_path:path with
+  let fallback_dir = keeper_default_read_root ~config ~meta in
+  match resolve_keeper_read_path ~config ~meta ~raw_path:path with
   | Error e when is_missing_read_path_error e ->
     (* Path within root but doesn't exist — use structured error with suggestions *)
     let root = Keeper_alerting_path.project_root_of_config config in
     let target =
       if Filename.is_relative path then Filename.concat root path else path
     in
-    missing_file_error_json ~config ~target ~error:e
+    missing_file_error_json ~config ~target ~fallback_dir ~error:e
   | Error e -> error_json e
   | Ok target ->
     (match Safe_ops.read_file_safe target with
      | Error e when String.starts_with ~prefix:file_not_found_prefix e ->
-       missing_file_error_json ~config ~target ~error:e
+       missing_file_error_json ~config ~target ~fallback_dir ~error:e
      | Error e -> error_json ~fields:[ "path", `String target ] e
      | Ok content ->
         let total = String.length content in

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -16,11 +16,12 @@ let max_suggested_entries = 12
 let file_not_found_prefix = "File not found:"
 
 let missing_file_error_json ~(config : Room.config) ~(target : string)
-      ~(error : string) =
-  let project_root = Keeper_alerting_path.project_root_of_config config in
+      ~(fallback_dir : string) ~(error : string) =
+  ignore config;
   let parent = Filename.dirname target in
   let suggestion_dir =
-    if Sys.file_exists parent && Sys.is_directory parent then parent else project_root
+    if Sys.file_exists parent && Sys.is_directory parent then parent
+    else fallback_dir
   in
   let suggested_entries =
     match Safe_ops.list_dir_safe suggestion_dir with
@@ -58,6 +59,25 @@ let keeper_effective_allowed_paths ~(meta : keeper_meta) =
   Keeper_alerting_path.effective_allowed_paths ~meta
 ;;
 
+let keeper_default_read_root ~(config : Room.config) ~(meta : keeper_meta) =
+  let project_root = Keeper_alerting_path.project_root_of_config config in
+  match keeper_effective_allowed_paths ~meta with
+  | [] -> project_root
+  | first :: _ ->
+    (match
+       Keeper_alerting_path.resolve_keeper_target_path
+         ~config ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+         ~raw_path:first
+     with
+     | Ok path ->
+       Fs_compat.mkdir_p path;
+       path
+     | Error _ ->
+       let fallback = Filename.concat project_root first in
+       Fs_compat.mkdir_p fallback;
+       fallback)
+;;
+
 let resolve_keeper_path ~(config : Room.config) ~(meta : keeper_meta) ~(raw_path : string)
   =
   resolve_keeper_target_path
@@ -66,8 +86,12 @@ let resolve_keeper_path ~(config : Room.config) ~(meta : keeper_meta) ~(raw_path
     ~raw_path
 ;;
 
-let resolve_keeper_read_path ~(config : Room.config) ~(raw_path : string) =
-  Keeper_alerting_path.resolve_keeper_read_path ~config ~raw_path
+let resolve_keeper_read_path ~(config : Room.config) ~(meta : keeper_meta)
+      ~(raw_path : string) =
+  Keeper_alerting_path.resolve_keeper_read_path
+    ~config
+    ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+    ~raw_path
 ;;
 
 let keeper_agent_sender ~(meta : keeper_meta) =
@@ -149,4 +173,3 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
     (cat, `List (List.map (fun s -> `String s) list)) :: acc
   ) map [] in
   Yojson.Safe.to_string (`Assoc assoc)
-

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -12,6 +12,38 @@ let io_timeout_sec = 30.0
 let read_timeout_sec = 15.0
 let user_timeout_max_sec = 180.0
 
+let resolve_keeper_shell_read_cwd
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
+  let resolved =
+    if raw_cwd = ""
+    then Ok (keeper_default_read_root ~config ~meta)
+    else resolve_keeper_read_path ~config ~meta ~raw_path:raw_cwd
+  in
+  match resolved with
+  | Error _ as err -> err
+  | Ok cwd when Sys.file_exists cwd && Sys.is_directory cwd -> Ok cwd
+  | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
+
+let resolve_keeper_shell_write_cwd
+      ~(config : Room.config)
+      ~(meta : keeper_meta)
+      ~(args : Yojson.Safe.t)
+  =
+  let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
+  let resolved =
+    if raw_cwd = ""
+    then Ok (keeper_default_read_root ~config ~meta)
+    else resolve_keeper_path ~config ~meta ~raw_path:raw_cwd
+  in
+  match resolved with
+  | Error _ as err -> err
+  | Ok cwd when Sys.file_exists cwd && Sys.is_directory cwd -> Ok cwd
+  | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
+
 let handle_keeper_bash
       ~(config : Room.config)
       ~(meta : keeper_meta)
@@ -73,9 +105,8 @@ let handle_keeper_bash
                      etc.) and is blocked for all presets." )
               ; "cmd", `String cmd_for_log
               ]))
-      (* Branch-switch guard: keeper_bash runs in the main repo root.
-         git checkout/switch/branch -b would mutate main's HEAD or create
-         branches in the shared repo. Use keeper_pr_workflow instead. *)
+      (* Branch-switch guard: keeper_bash must not mutate git branch state.
+         Use keeper_pr_workflow to create changes in an isolated clone/worktree. *)
       else if Worker_dev_tools.is_git_branch_switch cmd
       then (
         Log.Keeper.info "keeper_bash branch-switch blocked: %s (keeper=%s)" cmd_for_log meta.name;
@@ -107,19 +138,26 @@ let handle_keeper_bash
               ; "cmd", `String cmd_for_log
               ]))
       else (
-        if write_enabled && Worker_dev_tools.is_write_operation cmd then
-          Log.Keeper.info "WRITE_AUDIT: keeper=%s cmd=%s" meta.name cmd_for_log;
-        let root = Keeper_alerting_path.project_root_of_config config in
-        let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) cmd in
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec [ "/bin/bash"; "-lc"; shell_cmd ]
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool (st = Unix.WEXITED 0)
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String out
-              ]))
+        match resolve_keeper_shell_write_cwd ~config ~meta ~args with
+        | Error e -> error_json e
+        | Ok cwd ->
+          (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+           | Error e -> error_json e
+           | Ok () ->
+             if write_enabled && Worker_dev_tools.is_write_operation cmd then
+               Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s"
+                 meta.name cwd cmd_for_log;
+             let st, out =
+               Process_eio.run_argv_with_status ~cwd ~timeout_sec
+                 [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
+             in
+             Yojson.Safe.to_string
+               (`Assoc
+                   [ "ok", `Bool (st = Unix.WEXITED 0)
+                   ; "cwd", `String cwd
+                   ; "status", Keeper_alerting_path.process_status_to_json st
+                   ; "output", `String out
+                   ])))
 ;;
 
 let handle_keeper_shell_readonly
@@ -146,25 +184,38 @@ let handle_keeper_shell_readonly
   let root = Keeper_alerting_path.project_root_of_config config in
   let read_target () =
     let raw_path = Safe_ops.json_string ~default:"." "path" args in
-    resolve_keeper_read_path ~config ~raw_path
+    resolve_keeper_read_path ~config ~meta ~raw_path
   in
-  let render_process_result ~cmd argv =
-    let st, out = Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec argv in
+  let cwd_target () = resolve_keeper_shell_read_cwd ~config ~meta ~args in
+  let render_process_result ?cwd ~cmd argv =
+    let st, out =
+      Process_eio.run_argv_with_status ?cwd ~timeout_sec:io_timeout_sec argv
+    in
     Yojson.Safe.to_string
       (`Assoc
           [ "ok", `Bool (st = Unix.WEXITED 0)
           ; "op", `String op
           ; "cmd", `String cmd
+          ; ( "cwd"
+            , match cwd with
+              | Some dir -> `String dir
+              | None -> `Null )
           ; "status", Keeper_alerting_path.process_status_to_json st
           ; "output", `String out
           ])
   in
   match op with
-  | "pwd" -> render_process_result ~cmd:"pwd" [ "/bin/pwd" ]
+  | "pwd" ->
+    (match cwd_target () with
+     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Ok cwd -> render_process_result ~cwd ~cmd:"pwd" [ "/bin/pwd" ])
   | "git_status" ->
-    render_process_result
-      ~cmd:"git -C <root> --no-optional-locks status --short --branch"
-      [ "git"; "-C"; root; "--no-optional-locks"; "status"; "--short"; "--branch" ]
+    (match cwd_target () with
+     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Ok cwd ->
+       render_process_result ~cwd
+         ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
+         [ "git"; "-C"; cwd; "--no-optional-locks"; "status"; "--short"; "--branch" ])
   | "ls" ->
     (match read_target () with
      | Error e -> error_json ~fields:[ "op", `String op ] e
@@ -234,24 +285,30 @@ let handle_keeper_shell_readonly
               ; "matches", lines_to_json ~limit out
               ]))
   | "git_log" ->
-    let count = max 1 (min 50 (Safe_ops.json_int ~default:10 "count" args)) in
-    let format = Safe_ops.json_string ~default:"%h %s" "format" args in
-    let file_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-    let base_argv =
-      [ "git"; "-C"; root; "--no-optional-locks"; "log";
-        Printf.sprintf "--format=%s" format;
-        Printf.sprintf "-%d" count ]
-    in
-    let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
-    let st, out = Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv in
-    Yojson.Safe.to_string
-      (`Assoc
-          [ "ok", `Bool (st = Unix.WEXITED 0)
-          ; "op", `String op
-          ; "count", `Int count
-          ; "status", Keeper_alerting_path.process_status_to_json st
-          ; "entries", lines_to_json ~limit:50 out
-          ])
+    (match cwd_target () with
+     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Ok cwd ->
+       let count = max 1 (min 50 (Safe_ops.json_int ~default:10 "count" args)) in
+       let format = Safe_ops.json_string ~default:"%h %s" "format" args in
+       let file_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
+       let base_argv =
+         [ "git"; "-C"; cwd; "--no-optional-locks"; "log";
+           Printf.sprintf "--format=%s" format;
+           Printf.sprintf "-%d" count ]
+       in
+       let argv = if file_path <> "" then base_argv @ [ "--"; file_path ] else base_argv in
+       let st, out =
+         Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
+       in
+       Yojson.Safe.to_string
+         (`Assoc
+             [ "ok", `Bool (st = Unix.WEXITED 0)
+             ; "op", `String op
+             ; "cwd", `String cwd
+             ; "count", `Int count
+             ; "status", Keeper_alerting_path.process_status_to_json st
+             ; "entries", lines_to_json ~limit:50 out
+             ]))
   | "find" ->
     let name_pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
     if name_pattern = ""
@@ -338,57 +395,68 @@ let handle_keeper_shell_readonly
              ; "entries", lines_to_json ~limit out
              ]))
   | "git_diff" ->
-    render_process_result
-      ~cmd:"git diff --stat"
-      [ "git"; "-C"; root; "--no-optional-locks"; "diff"; "--stat" ]
+    (match cwd_target () with
+     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Ok cwd ->
+       render_process_result ~cwd
+         ~cmd:"git diff --stat"
+         [ "git"; "-C"; cwd; "--no-optional-locks"; "diff"; "--stat" ])
   | "git_worktree" ->
     let action =
       Safe_ops.json_string ~default:"list" "action" args
       |> String.trim |> String.lowercase_ascii
     in
-    (match action with
-     | "list" ->
-       render_process_result ~cmd:"git worktree list"
-         [ "git"; "-C"; root; "worktree"; "list" ]
-     | "add" ->
-       let branch = Safe_ops.json_string ~default:"" "branch" args |> String.trim in
-       let base = Safe_ops.json_string ~default:"origin/main" "base" args |> String.trim in
-       if branch = "" then
-         error_json ~fields:[ "op", `String op ]
-           "branch is required. Good: action='add', branch='feature/my-task'. Bad: branch=''."
-       else
-         (* Schema-level validation: check if branch is already in a worktree BEFORE running *)
-         let _st, wt_out =
-           Process_eio.run_argv_with_status ~timeout_sec:5.0
-             [ "git"; "-C"; root; "worktree"; "list"; "--porcelain" ]
-         in
-         if String_util.contains_substring_ci wt_out branch then
-           let existing_path =
-             String.split_on_char '\n' wt_out
-             |> List.find_map (fun line ->
-               if String_util.contains_substring_ci line "worktree" &&
-                  String_util.contains_substring_ci wt_out branch
-               then Some (String.trim line) else None)
-             |> Option.value ~default:"(unknown)"
-           in
-           Yojson.Safe.to_string
-             (`Assoc
-                 [ "ok", `Bool false
-                 ; "op", `String op
-                 ; "error", `String "branch_already_in_worktree"
-                 ; "branch", `String branch
-                 ; "existing_worktree", `String existing_path
-                 ; "hint", `String "Branch is already in a worktree. Use 'cd' to the existing path, or choose a different branch name."
-                 ])
-         else
-           let wt_path = Printf.sprintf ".worktrees/%s"
-             (String.map (fun c -> if c = '/' then '-' else c) branch) in
-           render_process_result
-             ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
-             [ "git"; "-C"; root; "worktree"; "add"; wt_path; "-b"; branch; base ]
-     | other ->
-       error_json ~fields:[ "op", `String op ]
-         (Printf.sprintf "Unknown git_worktree action '%s'. Use: list, add." other))
+    begin match action with
+    | "list" ->
+      (match cwd_target () with
+       | Error e -> error_json ~fields:[ "op", `String op ] e
+       | Ok cwd ->
+         render_process_result ~cwd ~cmd:"git worktree list"
+           [ "git"; "-C"; cwd; "worktree"; "list" ])
+    | "add" ->
+      let branch = Safe_ops.json_string ~default:"" "branch" args |> String.trim in
+      let base = Safe_ops.json_string ~default:"origin/main" "base" args |> String.trim in
+      if branch = "" then
+        error_json ~fields:[ "op", `String op ]
+          "branch is required. Good: action='add', branch='feature/my-task'. Bad: branch=''."
+      else (
+        match cwd_target () with
+        | Error e -> error_json ~fields:[ "op", `String op ] e
+        | Ok cwd ->
+          let _st, wt_out =
+            Process_eio.run_argv_with_status ~timeout_sec:5.0
+              [ "git"; "-C"; cwd; "worktree"; "list"; "--porcelain" ]
+          in
+          if String_util.contains_substring_ci wt_out branch then
+            let existing_path =
+              String.split_on_char '\n' wt_out
+              |> List.find_map (fun line ->
+                if String_util.contains_substring_ci line "worktree"
+                   && String_util.contains_substring_ci wt_out branch
+                then Some (String.trim line) else None)
+              |> Option.value ~default:"(unknown)"
+            in
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool false
+                  ; "op", `String op
+                  ; "error", `String "branch_already_in_worktree"
+                  ; "branch", `String branch
+                  ; "existing_worktree", `String existing_path
+                  ; "hint", `String "Branch is already in a worktree. Use 'cd' to the existing path, or choose a different branch name."
+                  ])
+          else
+            let wt_path = Printf.sprintf ".worktrees/%s"
+              (String.map (fun c -> if c = '/' then '-' else c) branch)
+            in
+            render_process_result ~cwd
+              ~cmd:(Printf.sprintf "git worktree add %s -b %s %s" wt_path branch base)
+              [ "git"; "-C"; cwd; "worktree"; "add"; wt_path; "-b"; branch; base ]
+      )
+    | other ->
+      error_json ~fields:[ "op", `String op ]
+        (Printf.sprintf "Unknown git_worktree action '%s'. Use: list, add." other)
+    end
   | "bash" ->
     let cmd_str = Safe_ops.json_string ~default:"" "command" args |> String.trim in
     if cmd_str = "" then error_json ~fields:[ "op", `String op ] "command is required for bash op. Good: command='env'. Bad: command=''."
@@ -457,18 +525,25 @@ let handle_keeper_shell_readonly
               ; "hint", `String hint
               ])
       | None ->
-        let st, out =
-          Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec
-            [ "bash"; "-c"; cmd_str ]
-        in
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool (st = Unix.WEXITED 0)
-              ; "op", `String op
-              ; "command", `String cmd_str
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String out
-              ]))
+        (match cwd_target () with
+         | Error e -> error_json ~fields:[ "op", `String op ] e
+         | Ok cwd ->
+           (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd_str with
+            | Error e -> error_json ~fields:[ "op", `String op ] e
+            | Ok () ->
+              let st, out =
+                Process_eio.run_argv_with_status ~cwd ~timeout_sec:io_timeout_sec
+                  [ "bash"; "-lc"; cmd_str ^ " 2>&1" ]
+              in
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool (st = Unix.WEXITED 0)
+                    ; "op", `String op
+                    ; "cwd", `String cwd
+                    ; "command", `String cmd_str
+                    ; "status", Keeper_alerting_path.process_status_to_json st
+                    ; "output", `String out
+                    ]))))
   | "git_clone" ->
     (* Clone a repo into this keeper's playground directory.
        Sandboxed: always targets .masc/playground/<keeper_name>/<repo_name>.
@@ -562,4 +637,3 @@ let handle_keeper_shell_readonly
                      "git_clone" ]) )
           ])
 ;;
-

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -5,7 +5,9 @@
     git-clone).
 
     Write-capable bash blocks dangerous commands (rm, mv, chmod, etc.)
-    and chaining operators (&&, ||, ;) via substring blocklist. *)
+    and chaining operators (&&, ||, ;) via substring blocklist.
+    Both tools default to the keeper playground unless an explicit
+    allowed [cwd] is provided. *)
 
 val handle_keeper_bash :
   config:Room.config ->

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -272,6 +272,7 @@ let shell_tools : Types.tool_schema list = [
     name = "keeper_shell_readonly";
     description = "Run a safe project shell command. \
 ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, bash, git_clone. \
+Defaults to the keeper playground; use cwd to target an explicit allowed directory or cloned repo. \
 find REQUIRES pattern param (e.g. pattern=\"*.ml\"). \
 bash op: single command only, no chaining (&&, ||, |, ; are blocked), no redirects (>, >>). \
 git_clone: clone a repo into your playground (url required, sandboxed to .masc/playground/<name>/). \
@@ -283,6 +284,7 @@ git_log/git_diff for repo history, bash for curl/jq/env/which.";
       ("properties", `Assoc [
         ("op", `Assoc [("type", `String "string"); ("enum", `List [`String "pwd"; `String "ls"; `String "cat"; `String "rg"; `String "git_status"; `String "find"; `String "head"; `String "tail"; `String "wc"; `String "tree"; `String "git_log"; `String "git_diff"; `String "bash"; `String "git_clone"]); ("description", `String "Command to run")]);
         ("path", `Assoc [("type", `String "string"); ("description", `String "Target path for ls/cat/rg/find/head/tail/wc/tree")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for pwd/git_status/git_log/git_diff/git_worktree/bash. Must stay within keeper playground or an explicit allowed path.")]);
         ("pattern", `Assoc [("type", `String "string"); ("description", `String "Search pattern for rg, or name glob for find (REQUIRED for find, e.g. \"*.ml\")")]);
         ("limit", `Assoc [("type", `String "integer"); ("description", `String "Result limit for ls/rg/find/tree, or line count for git_log")]);
         ("lines", `Assoc [("type", `String "integer"); ("description", `String "Number of lines for head/tail (default 20, max 200)")]);
@@ -302,11 +304,13 @@ let coding_keeper_bridge_tools : Types.tool_schema list = [
 NO chaining (&&, ||, ;), NO pipes (|), NO redirects (> >>). \
 Violations are blocked. Good: cmd='dune build', cmd='ls -la lib/'. \
 Bad: cmd='cd x && dune build', cmd='rg foo | wc -l'. \
+Runs in the keeper playground by default; use cwd to target an explicit allowed directory. \
 For read-only ops use keeper_shell_readonly, for file edits use keeper_fs_edit.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "Single command only. No chaining/pipe/redirect. Example: 'dune build', 'rg pattern lib/'")]);
+        ("cwd", `Assoc [("type", `String "string"); ("description", `String "Optional working directory for the command. Must stay within keeper playground or an explicit allowed path.")]);
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180)")]);
       ]);
       ("required", `List [`String "cmd"]);

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -252,6 +252,90 @@ let validate_command_coding cmd =
       in
       validate_segments segments
 
+let strip_wrapping_quotes token =
+  let len = String.length token in
+  if len >= 2 then
+    let first = token.[0] and last = token.[len - 1] in
+    if (first = '"' && last = '"') || (first = '\'' && last = '\'')
+    then String.sub token 1 (len - 2)
+    else token
+  else token
+
+let looks_like_url token =
+  let token = strip_wrapping_quotes token in
+  match String.index_opt token ':' with
+  | Some idx when idx + 2 < String.length token ->
+    token.[idx + 1] = '/' && token.[idx + 2] = '/'
+  | _ -> false
+
+let is_path_flag token =
+  match strip_wrapping_quotes token with
+  | "-C" | "--git-dir" | "--work-tree" | "--exec-path" -> true
+  | _ -> false
+
+let path_value_of_flagged_token token =
+  let token = strip_wrapping_quotes token in
+  let prefixes =
+    [ "--git-dir="; "--work-tree="; "--exec-path=" ]
+  in
+  List.find_map
+    (fun prefix ->
+       if String.starts_with ~prefix token then
+         Some
+           (String.sub token (String.length prefix)
+              (String.length token - String.length prefix))
+       else None)
+    prefixes
+
+let looks_like_path_token token =
+  let token = strip_wrapping_quotes token in
+  token <> ""
+  && not (looks_like_url token)
+  &&
+  (token = "." || token = ".."
+   || String.starts_with ~prefix:"/" token
+   || String.starts_with ~prefix:"./" token
+   || String.starts_with ~prefix:"../" token
+   || String.starts_with ~prefix:"~/" token
+   || String.contains token '/')
+
+let validate_command_paths ?workdir cmd =
+  match workdir with
+  | None -> Ok ()
+  | Some _ ->
+    let rec loop expect_path_value = function
+      | [] -> Ok ()
+      | token :: rest ->
+        let token = strip_wrapping_quotes token in
+        if token = "" then loop expect_path_value rest
+        else if expect_path_value then
+          if validate_path ?workdir token then loop false rest
+          else
+            Error
+              (Printf.sprintf
+                 "Path blocked: %s (outside allowed directories for this keeper command)"
+                 token)
+        else
+          match path_value_of_flagged_token token with
+          | Some value ->
+            if validate_path ?workdir value then loop false rest
+            else
+              Error
+                (Printf.sprintf
+                   "Path blocked: %s (outside allowed directories for this keeper command)"
+                   value)
+          | None when is_path_flag token -> loop true rest
+          | None when looks_like_path_token token ->
+            if validate_path ?workdir token then loop false rest
+            else
+              Error
+                (Printf.sprintf
+                   "Path blocked: %s (outside allowed directories for this keeper command)"
+                   token)
+          | None -> loop false rest
+    in
+    cmd |> split_shell_tokens |> loop false
+
 (** Check if a command performs write/mutating operations.
     Returns [true] for commands like [git push], [git commit],
     [make deploy], [npm publish], [mv], [cp], etc.

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -299,10 +299,21 @@ let looks_like_path_token token =
    || String.starts_with ~prefix:"~/" token
    || String.contains token '/')
 
+let has_path_rewrite_syntax cmd =
+  String.exists
+    (function
+      | '\'' | '"' | '\\' | '*' | '?' | '[' | ']' | '{' | '}' -> true
+      | _ -> false)
+    cmd
+
 let validate_command_paths ?workdir cmd =
   match workdir with
   | None -> Ok ()
   | Some _ ->
+    if String.contains cmd '/' && has_path_rewrite_syntax cmd then
+      Error
+        "Path syntax blocked: shell quoting, globbing, brace expansion, and backslash escapes are not allowed for path-bearing keeper commands. Use plain unquoted paths and explicit cwd."
+    else
     let rec loop expect_path_value = function
       | [] -> Ok ()
       | token :: rest ->

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -867,6 +867,44 @@ let test_bash_blocks_absolute_path_outside_playground () =
     check bool "absolute path blocked" true
       (String.starts_with ~prefix:"Path blocked:" (json_string "error" json)))
 
+let test_bash_blocks_quoted_absolute_path_outside_playground () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let shared_file =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+        "workspace/yousleepwhen/oas/lib/approval.ml"
+    in
+    write_text_file shared_file "let approval = true\n";
+    let quoted_cmd = Printf.sprintf "cat \"%s\"" shared_file in
+    let result =
+      call_tool config meta "keeper_bash"
+        (`Assoc [ "cmd", `String quoted_cmd ])
+    in
+    let json = parse_json result in
+    check bool "returns path syntax blocked error" true
+      (match json with `Assoc fields -> List.mem_assoc "error" fields | _ -> false);
+    check bool "quoted absolute path blocked" true
+      (String.starts_with ~prefix:"Path syntax blocked:" (json_string "error" json)))
+
+let test_readonly_bash_blocks_quoted_absolute_path_outside_playground () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let shared_file =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+        "workspace/yousleepwhen/oas/lib/approval.ml"
+    in
+    write_text_file shared_file "let approval = true\n";
+    let quoted_cmd = Printf.sprintf "cat \"%s\"" shared_file in
+    let result =
+      call_tool config meta "keeper_shell_readonly"
+        (`Assoc [ "op", `String "bash"; "command", `String quoted_cmd ])
+    in
+    let json = parse_json result in
+    check bool "returns path syntax blocked error" true
+      (match json with `Assoc fields -> List.mem_assoc "error" fields | _ -> false);
+    check bool "quoted readonly absolute path blocked" true
+      (String.starts_with ~prefix:"Path syntax blocked:" (json_string "error" json)))
+
 let () =
   run "keeper_pr_workflow"
     [ "required_fields",
@@ -923,6 +961,10 @@ let () =
           test_fs_read_allows_explicit_custom_path
       ; test_case "bash blocks absolute path outside playground" `Quick
           test_bash_blocks_absolute_path_outside_playground
+      ; test_case "bash blocks quoted absolute path outside playground" `Quick
+          test_bash_blocks_quoted_absolute_path_outside_playground
+      ; test_case "readonly bash blocks quoted absolute path outside playground" `Quick
+          test_readonly_bash_blocks_quoted_absolute_path_outside_playground
       ]
     ; "integration",
       [ test_case "worktree workflow e2e" `Slow test_worktree_create_writes_and_cleans_up

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -63,23 +63,7 @@ let run_cmd argv =
   Sys.command cmd
 
 let policy_init_once = lazy (
-  (* Load tool_policy.toml from the repo root so presets resolve correctly.
-     The repo root is derived by walking up from the test executable's location. *)
-  let repo_root =
-    let cwd = Sys.getcwd () in
-    (* dune runs tests from the repo root *)
-    if Sys.file_exists (Filename.concat cwd "config/tool_policy.toml")
-    then cwd
-    else
-      (* fallback: try parent dirs *)
-      let rec go d =
-        if d = "/" then failwith "cannot find config/tool_policy.toml"
-        else if Sys.file_exists (Filename.concat d "config/tool_policy.toml")
-        then d
-        else go (Filename.dirname d)
-      in
-      go (Filename.dirname cwd)
-  in
+  let repo_root = Masc_test_deps.find_project_root () in
   Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path:repo_root)
 )
 

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -12,6 +12,15 @@
 open Alcotest
 open Masc_mcp
 
+let fresh_nonce =
+  let counter = ref 0 in
+  fun () ->
+    incr counter;
+    Printf.sprintf "%d-%d-%d"
+      (Unix.getpid ())
+      (int_of_float (Unix.gettimeofday () *. 1_000_000.))
+      !counter
+
 let make_meta_with_preset preset_str =
   match Keeper_types.meta_of_json
     (`Assoc
@@ -49,6 +58,10 @@ let run_cmd_exn argv =
   | 0 -> ()
   | code -> failwith (Printf.sprintf "command failed (%d): %s" code cmd)
 
+let run_cmd argv =
+  let cmd = String.concat " " (List.map Filename.quote argv) in
+  Sys.command cmd
+
 let policy_init_once = lazy (
   (* Load tool_policy.toml from the repo root so presets resolve correctly.
      The repo root is derived by walking up from the test executable's location. *)
@@ -75,7 +88,7 @@ let with_room f =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Lazy.force policy_init_once;
   let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_pr_%d" (Random.int 1_000_000)) in
+    (Printf.sprintf "test_keeper_pr_%s" (fresh_nonce ())) in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
   let saved_sb = Sys.getenv_opt "SB_PG_URL" in
@@ -520,7 +533,7 @@ let with_local_git_repo_room f =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Lazy.force policy_init_once;
   let dir = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "test_keeper_pr_git_%d" (Random.int 1_000_000)) in
+    (Printf.sprintf "test_keeper_pr_git_%s" (fresh_nonce ())) in
   let remote_dir = Filename.concat dir ".remote.git" in
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
@@ -583,7 +596,7 @@ let test_worktree_create_writes_and_cleans_up () =
   with_real_repo_room (fun config repo_root ->
     let meta = make_meta_with_preset "delivery" in
     let workflow_root = workflow_repo_root config in
-    let test_branch = Printf.sprintf "test/integration-%d" (Random.int 100_000) in
+    let test_branch = Printf.sprintf "test/integration-%s" (fresh_nonce ()) in
     let args = `Assoc
       [ "branch", `String test_branch
       ; "file_path", `String "test-integration-verify.txt"
@@ -628,7 +641,7 @@ let test_existing_worktree_path_is_retried_safely () =
   with_real_repo_room (fun config repo_root ->
     let meta = make_meta_with_preset "delivery" in
     let workflow_root = workflow_repo_root config in
-    let test_branch = Printf.sprintf "test/retry-%d" (Random.int 100_000) in
+    let test_branch = Printf.sprintf "test/retry-%s" (fresh_nonce ()) in
     let worktree_id = derive_worktree_id meta.name test_branch in
     let worktree_path = Filename.concat workflow_root (Filename.concat ".worktrees" worktree_id) in
     Fun.protect
@@ -639,12 +652,21 @@ let test_existing_worktree_path_is_retried_safely () =
         ignore repo_root;
         cleanup_test_branch workflow_root test_branch)
       (fun () ->
-        let seed_rc = Sys.command
-          (Printf.sprintf "cd %s && git fetch origin >/dev/null 2>&1 && git worktree add -b %s %s %s >/dev/null 2>&1"
-            (Filename.quote workflow_root)
-            (Filename.quote test_branch)
-            (Filename.quote worktree_path)
-            (Filename.quote "origin/main")) in
+        ignore (run_cmd [ "/usr/bin/git"; "-C"; workflow_root; "worktree"; "remove"; "--force"; worktree_path ]);
+        cleanup_test_branch workflow_root test_branch;
+        let seed_rc =
+          run_cmd
+            [ "/usr/bin/git"
+            ; "-C"
+            ; workflow_root
+            ; "worktree"
+            ; "add"
+            ; "-b"
+            ; test_branch
+            ; worktree_path
+            ; "HEAD"
+            ]
+        in
         check int "seed worktree created" 0 seed_rc;
         let args = `Assoc
           [ "branch", `String test_branch
@@ -675,7 +697,7 @@ let test_local_repo_worktree_runs_truth_via_absolute_bash () =
   with_local_git_repo_room (fun config repo_root ->
     let meta = make_meta_with_preset "delivery" in
     let workflow_root = workflow_repo_root config in
-    let test_branch = Printf.sprintf "test/local-%d" (Random.int 100_000) in
+    let test_branch = Printf.sprintf "test/local-%s" (fresh_nonce ()) in
     let worktree_id = derive_worktree_id meta.name test_branch in
     let worktree_path = Filename.concat workflow_root (Filename.concat ".worktrees" worktree_id) in
     let args = `Assoc
@@ -772,6 +794,79 @@ let test_bash_git_status_allowed () =
     check bool "git status returns normal execution shape"
       true has_status)
 
+let test_shell_readonly_pwd_defaults_to_playground () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let expected_cwd =
+      Filename.concat
+        (Keeper_alerting_path.project_root_of_config config)
+        (Keeper_alerting_path.playground_path_of_keeper meta.name)
+    in
+    Fs_compat.mkdir_p expected_cwd;
+    let result =
+      call_tool config meta "keeper_shell_readonly"
+        (`Assoc [ "op", `String "pwd" ])
+    in
+    let json = parse_json result in
+    check bool "pwd ok" true (json_bool "ok" json);
+    check string "pwd cwd" expected_cwd (json_string "cwd" json))
+
+let test_fs_read_blocks_shared_repo_by_default () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let shared_file =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+        "workspace/yousleepwhen/oas/lib/approval.ml"
+    in
+    write_text_file shared_file "let approval = true\n";
+    let result =
+      call_tool config meta "keeper_fs_read"
+        (`Assoc [ "path", `String "workspace/yousleepwhen/oas/lib/approval.ml" ])
+    in
+    let json = parse_json result in
+    check bool "returns error payload" true
+      (match json with `Assoc fields -> List.mem_assoc "error" fields | _ -> false);
+    check bool "reports allowed path boundary" true
+      (String.starts_with ~prefix:"path_not_in_allowed_paths" (json_string "error" json)))
+
+let test_fs_read_allows_explicit_custom_path () =
+  with_room (fun config ->
+    let meta =
+      { (make_meta_with_preset "delivery") with
+        allowed_paths = [ "workspace/yousleepwhen/oas/" ] }
+    in
+    let shared_file =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+        "workspace/yousleepwhen/oas/lib/approval.ml"
+    in
+    write_text_file shared_file "let approval = true\n";
+    let result =
+      call_tool config meta "keeper_fs_read"
+        (`Assoc [ "path", `String "workspace/yousleepwhen/oas/lib/approval.ml" ])
+    in
+    let json = parse_json result in
+    check bool "explicit custom path read ok" true (json_bool "ok" json);
+    check bool "content included" true
+      (String.starts_with ~prefix:"let approval" (json_string "content" json)))
+
+let test_bash_blocks_absolute_path_outside_playground () =
+  with_room (fun config ->
+    let meta = make_meta_with_preset "delivery" in
+    let shared_file =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+        "workspace/yousleepwhen/oas/lib/approval.ml"
+    in
+    write_text_file shared_file "let approval = true\n";
+    let result =
+      call_tool config meta "keeper_bash"
+        (`Assoc [ "cmd", `String (Printf.sprintf "cat %s" shared_file) ])
+    in
+    let json = parse_json result in
+    check bool "returns path blocked error" true
+      (match json with `Assoc fields -> List.mem_assoc "error" fields | _ -> false);
+    check bool "absolute path blocked" true
+      (String.starts_with ~prefix:"Path blocked:" (json_string "error" json)))
+
 let () =
   run "keeper_pr_workflow"
     [ "required_fields",
@@ -820,6 +915,14 @@ let () =
       ; test_case "branch list allowed" `Quick test_bash_git_branch_list_allowed
       ; test_case "branch delete allowed" `Quick test_bash_git_branch_delete_allowed
       ; test_case "status allowed" `Quick test_bash_git_status_allowed
+      ; test_case "readonly pwd defaults to playground" `Quick
+          test_shell_readonly_pwd_defaults_to_playground
+      ; test_case "fs read blocks shared repo by default" `Quick
+          test_fs_read_blocks_shared_repo_by_default
+      ; test_case "fs read allows explicit custom path" `Quick
+          test_fs_read_allows_explicit_custom_path
+      ; test_case "bash blocks absolute path outside playground" `Quick
+          test_bash_blocks_absolute_path_outside_playground
       ]
     ; "integration",
       [ test_case "worktree workflow e2e" `Slow test_worktree_create_writes_and_cleans_up

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -67,6 +67,8 @@ let policy_init_once = lazy (
   Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path:repo_root)
 )
 
+let repo_root = lazy (Masc_test_deps.find_project_root ())
+
 let with_room f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -836,11 +838,7 @@ let test_fs_read_allows_explicit_custom_path () =
 let test_bash_blocks_absolute_path_outside_playground () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
-    let shared_file =
-      Filename.concat (Keeper_alerting_path.project_root_of_config config)
-        "workspace/yousleepwhen/oas/lib/approval.ml"
-    in
-    write_text_file shared_file "let approval = true\n";
+    let shared_file = Filename.concat (Lazy.force repo_root) "dune-project" in
     let result =
       call_tool config meta "keeper_bash"
         (`Assoc [ "cmd", `String (Printf.sprintf "cat %s" shared_file) ])
@@ -854,11 +852,7 @@ let test_bash_blocks_absolute_path_outside_playground () =
 let test_bash_blocks_quoted_absolute_path_outside_playground () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
-    let shared_file =
-      Filename.concat (Keeper_alerting_path.project_root_of_config config)
-        "workspace/yousleepwhen/oas/lib/approval.ml"
-    in
-    write_text_file shared_file "let approval = true\n";
+    let shared_file = Filename.concat (Lazy.force repo_root) "dune-project" in
     let quoted_cmd = Printf.sprintf "cat \"%s\"" shared_file in
     let result =
       call_tool config meta "keeper_bash"
@@ -873,11 +867,7 @@ let test_bash_blocks_quoted_absolute_path_outside_playground () =
 let test_readonly_bash_blocks_quoted_absolute_path_outside_playground () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
-    let shared_file =
-      Filename.concat (Keeper_alerting_path.project_root_of_config config)
-        "workspace/yousleepwhen/oas/lib/approval.ml"
-    in
-    write_text_file shared_file "let approval = true\n";
+    let shared_file = Filename.concat (Lazy.force repo_root) "dune-project" in
     let quoted_cmd = Printf.sprintf "cat \"%s\"" shared_file in
     let result =
       call_tool config meta "keeper_shell_readonly"

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -473,23 +473,34 @@ let test_path_empty_allowed_permits_all_within_root () =
     check bool "src ok with empty allowed" true (Result.is_ok r2))
 
 (* ============================================================
-   10b. Read-path: resolve_keeper_read_path ignores allowed_paths
+   10b. Read-path: resolve_keeper_read_path respects allowlists
    ============================================================ *)
 
-let test_read_path_ignores_allowed_paths () =
+let test_read_path_empty_allowlist_permits_full_root () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
     Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
-    (* Read path should succeed for any path within root,
-       even when write path would reject it *)
     let read_lib = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"lib/foo.ml" in
+      ~config ~allowed_paths:[] ~raw_path:"lib/foo.ml" in
     let read_src = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"src/bar.ml" in
+      ~config ~allowed_paths:[] ~raw_path:"src/bar.ml" in
     check bool "read lib ok" true (Result.is_ok read_lib);
     check bool "read src ok" true (Result.is_ok read_src))
+
+let test_read_path_respects_allowed_paths () =
+  let dir = make_path_test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
+    Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Room.default_config dir in
+    let read_lib = Keeper_alerting_path.resolve_keeper_read_path
+      ~config ~allowed_paths:["lib"] ~raw_path:"lib/foo.ml" in
+    let read_src = Keeper_alerting_path.resolve_keeper_read_path
+      ~config ~allowed_paths:["lib"] ~raw_path:"src/bar.ml" in
+    check bool "read lib ok" true (Result.is_ok read_lib);
+    check bool "read src rejected" true (Result.is_error read_src))
 
 let test_read_path_rejects_outside_root () =
   let dir = make_path_test_dir () in
@@ -498,10 +509,10 @@ let test_read_path_rejects_outside_root () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"/etc/passwd" in
+      ~config ~allowed_paths:[] ~raw_path:"/etc/passwd" in
     check bool "read outside root rejected" true (Result.is_error result))
 
-let test_read_vs_write_path_separation () =
+let test_read_vs_write_path_alignment () =
   let dir = make_path_test_dir () in
   Fun.protect ~finally:(fun () -> cleanup_path_test_dir dir) (fun () ->
     Eio_main.run @@ fun env ->
@@ -514,13 +525,13 @@ let test_read_vs_write_path_separation () =
       ~config ~allowed_paths:["lib"] ~raw_path:"src/bar.ml" in
     check bool "write lib ok" true (Result.is_ok write_lib);
     check bool "write src rejected" true (Result.is_error write_src);
-    (* Read: both allowed *)
+    (* Read: same allowlist behavior *)
     let read_lib = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"lib/foo.ml" in
+      ~config ~allowed_paths:["lib"] ~raw_path:"lib/foo.ml" in
     let read_src = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"src/bar.ml" in
+      ~config ~allowed_paths:["lib"] ~raw_path:"src/bar.ml" in
     check bool "read lib ok" true (Result.is_ok read_lib);
-    check bool "read src ok (read ignores allowed_paths)" true (Result.is_ok read_src))
+    check bool "read src rejected like write" true (Result.is_error read_src))
 
 (* ============================================================
    10c. Read-path: resolve_keeper_read_path bounded suffix resolution
@@ -534,11 +545,11 @@ let test_read_path_rejects_nonexistent () =
     let config = Room.default_config dir in
     (* Path within root but does not exist on disk *)
     let result = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"nonexistent-repo/" in
+      ~config ~allowed_paths:[] ~raw_path:"nonexistent-repo/" in
     check bool "nonexistent path rejected" true (Result.is_error result);
     let err = Result.get_error result in
-    check bool "error mentions project root miss" true
-      (String_util.contains_substring_ci err "path_not_found_under_project_root"))
+    check bool "error mentions allowed roots miss" true
+      (String_util.contains_substring_ci err "path_not_found_under_allowed_roots"))
 
 let test_read_path_resolves_unique_nested_repo_suffix () =
   let dir = make_path_test_dir () in
@@ -558,9 +569,13 @@ let test_read_path_resolves_unique_nested_repo_suffix () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"masc-mcp/lib" in
+      ~config ~allowed_paths:["workspace"] ~raw_path:"masc-mcp/lib" in
     check bool "unique nested repo suffix resolved" true (Result.is_ok result);
-    check string "resolved to discovered repo lib" lib_dir (Result.get_ok result))
+    let expected_lib_dir =
+      try Unix.realpath lib_dir with Unix.Unix_error _ -> lib_dir
+    in
+    check string "resolved to discovered repo lib" expected_lib_dir
+      (Result.get_ok result))
 
 let test_read_path_rejects_ambiguous_nested_repo_suffix () =
   let dir = make_path_test_dir () in
@@ -582,7 +597,7 @@ let test_read_path_rejects_ambiguous_nested_repo_suffix () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
     let config = Room.default_config dir in
     let result = Keeper_alerting_path.resolve_keeper_read_path
-      ~config ~raw_path:"masc-mcp/lib" in
+      ~config ~allowed_paths:["workspace-a"; "workspace-b"] ~raw_path:"masc-mcp/lib" in
     check bool "ambiguous nested repo suffix rejected" true (Result.is_error result);
     let err = Result.get_error result in
     check bool "error mentions ambiguity" true
@@ -614,11 +629,11 @@ let test_read_path_does_not_follow_symlink_outside_root () =
     Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
       let result = Keeper_alerting_path.resolve_keeper_read_path
-        ~config ~raw_path:"masc-mcp/lib" in
+        ~config ~allowed_paths:[] ~raw_path:"masc-mcp/lib" in
       check bool "symlink escape is rejected" true (Result.is_error result);
       let err = Result.get_error result in
       check bool "symlink escape does not resolve outside root" true
-        (String_util.contains_substring_ci err "path_not_found_under_project_root"))
+        (String_util.contains_substring_ci err "path_not_found_under_allowed_roots"))
 
 (* ============================================================
    11. Keeper-reported allowed_paths symlink bug
@@ -770,7 +785,10 @@ let () =
       test_case "empty path rejected" `Quick test_path_empty_rejected;
       test_case "whitespace only rejected" `Quick test_path_whitespace_only_rejected;
       test_case "empty allowed permits all" `Quick test_path_empty_allowed_permits_all_within_root;
-      test_case "read path ignores allowed_paths" `Quick test_read_path_ignores_allowed_paths;
+      test_case "read path empty allowlist permits full root" `Quick
+        test_read_path_empty_allowlist_permits_full_root;
+      test_case "read path respects allowed_paths" `Quick
+        test_read_path_respects_allowed_paths;
       test_case "read path rejects outside root" `Quick test_read_path_rejects_outside_root;
       test_case "read path rejects nonexistent" `Quick test_read_path_rejects_nonexistent;
       test_case "read path resolves unique nested repo suffix" `Quick
@@ -779,7 +797,7 @@ let () =
         test_read_path_rejects_ambiguous_nested_repo_suffix;
       test_case "read path does not follow symlink outside root" `Quick
         test_read_path_does_not_follow_symlink_outside_root;
-      test_case "read vs write path separation" `Quick test_read_vs_write_path_separation;
+      test_case "read vs write path alignment" `Quick test_read_vs_write_path_alignment;
       test_case "keeper-reported nonexistent subdir" `Quick
         test_keeper_reported_nonexistent_subdir;
       test_case "keeper-reported observe_only scope" `Quick

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -93,15 +93,9 @@ let test_org_with_dots () =
 
 (* ── validate_clone_url ──────────────────────────────────────────── *)
 
-(* Use the real project base_path so config/tool_policy.toml is loaded.
-   Sys.getcwd () returns the project root when tests run via dune. *)
-let project_base_path () =
-  let cwd = Sys.getcwd () in
-  (* dune runs tests from _build/default/test, walk up to project root *)
-  if Sys.file_exists (Filename.concat cwd "config/tool_policy.toml") then cwd
-  else if Sys.file_exists (Filename.concat (Filename.dirname cwd) "config/tool_policy.toml")
-  then Filename.dirname cwd
-  else cwd
+(* Use the shared project-root resolver so isolated build dirs such as
+   [.ci_build/default/test] still find config/tool_policy.toml reliably. *)
+let project_base_path () = Masc_test_deps.find_project_root ()
 
 let test_allowed_org () =
   let bp = project_base_path () in


### PR DESCRIPTION
## Summary
- make keeper read-path resolution honor the keeper effective allowlist instead of the whole base path
- default keeper read and shell cwd to the keeper playground root, while still allowing explicit custom paths
- block obvious command path escapes and add regressions for shared-repo reads plus worktree retry coverage

## Product impact
- keepers no longer read sibling repos directly just because `MASC_BASE_PATH` is broad
- the default view for `keeper_fs_read`, `keeper_shell_readonly`, and `keeper_bash` is the keeper playground
- explicit custom paths still work, and full-root access still requires intentional configuration

## Evidence
- repro: a keeper attached to a broad base path could directly read `workspace/yousleepwhen/oas/lib/approval.ml`
- fix: read-path resolution and default shell cwd now follow the keeper effective allow roots instead of inheriting the whole coordination base path
- regressions: added coverage for shared-repo read blocking, explicit custom-path reads, quoted absolute-path shell escapes, and worktree retry behavior

## Validation
- `dune build --root . test/test_keeper_pr_workflow.exe test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_keeper_tool_exposure.exe`
- `./_build/default/test/test_keeper_pr_workflow.exe`

## Review evidence
- direct non-self review used `sb glm-text`
- actionable review finding on shell path rewrite escapes was patched in follow-up commit `75b7c17a56bb136dbbfefa5948ba7940acbcc04d`
- incremental re-review on the latest delta returned `No findings.`
- detailed evidence is recorded in the PR discussion comment

## Linked issue
- Fixes #6040
