### PR TITLE
feat(governance): Lethal Trifecta combinatorial risk detection

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -42,6 +42,83 @@ let risk_level_of_contract_risk = function
   | Agent_sdk.Risk_class.High -> High
   | Agent_sdk.Risk_class.Critical -> Critical
 
+(* ── Lethal Trifecta — Combinatorial Risk Assessment ─────────
+   Simon Willison's "Lethal Trifecta": an agent simultaneously holding
+   (1) untrusted external input, (2) sensitive data access, and
+   (3) state modification capability = security incident.
+
+   Meta AI's "Rule of Two": restrict to max 2 of 3 simultaneously.
+   When all 3 are present, escalate state_modification tool risk.
+
+   Classification is in code (not TOML) for the same reason as risk
+   patterns: security policy changes require code review. *)
+
+type capability_class =
+  | External_input      (** Receives data from untrusted external sources *)
+  | Sensitive_access    (** Can read potentially sensitive data *)
+  | State_modification  (** Can modify system state *)
+
+(** Per-tool capability classification.
+    A tool may belong to multiple classes (e.g. keeper_bash spans all 3). *)
+let capability_classification : (string * capability_class list) list = [
+  (* External input sources *)
+  ("masc_web_search",          [External_input]);
+  ("masc_web_fetch",           [External_input]);
+  (* Shell can curl/wget external data AND read secrets AND execute *)
+  ("keeper_bash",              [External_input; Sensitive_access; State_modification]);
+  ("keeper_shell_readonly",    [External_input; Sensitive_access]);
+  (* Sensitive data access *)
+  ("keeper_fs_read",           [Sensitive_access]);
+  ("keeper_memory_search",     [Sensitive_access]);
+  ("keeper_library_search",    [Sensitive_access]);
+  ("keeper_library_read",      [Sensitive_access]);
+  (* State modification *)
+  ("keeper_fs_edit",           [State_modification]);
+  ("keeper_pr_submit",         [State_modification]);
+  ("keeper_pr_workflow",       [State_modification]);
+  ("keeper_github",            [State_modification]);
+]
+
+let tool_capabilities name =
+  match List.assoc_opt name capability_classification with
+  | Some caps -> caps
+  | None -> []
+
+let has_capability cls caps =
+  List.mem cls caps
+
+(** Compute trifecta status from a set of active tool names.
+    Returns (class_count, has_external, has_sensitive, has_state_mod). *)
+let assess_trifecta ~active_tool_names =
+  let has_ext = ref false in
+  let has_sens = ref false in
+  let has_mod = ref false in
+  List.iter (fun name ->
+    let caps = tool_capabilities name in
+    if has_capability External_input caps then has_ext := true;
+    if has_capability Sensitive_access caps then has_sens := true;
+    if has_capability State_modification caps then has_mod := true;
+  ) active_tool_names;
+  let count =
+    (if !has_ext then 1 else 0)
+    + (if !has_sens then 1 else 0)
+    + (if !has_mod then 1 else 0)
+  in
+  (count, !has_ext, !has_sens, !has_mod)
+
+(** When trifecta is active (all 3 classes present), escalate risk
+    of state_modification tools to at least High.
+    This ensures HITL gates fire at lower governance levels. *)
+let combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk =
+  if trifecta_active then
+    let caps = tool_capabilities tool_name in
+    if has_capability State_modification caps then
+      max_risk_level base_risk High
+    else
+      base_risk
+  else
+    base_risk
+
 (* ── Risk Assessment ────────────────────────────────────────── *)
 
 (** {2 Risk pattern sets — security-critical SSOT}
@@ -366,8 +443,26 @@ let install ~config ~governance_level =
     Tools below the threshold are auto-approved. *)
 let to_oas_approval_callback
       ~governance_level ~keeper_name : Oas.Hooks.approval_callback =
+  (* Pre-compute trifecta status from keeper's active shard tool set.
+     Computed once per keeper session, captured by the closure. *)
+  let active_shards = Tool_shard.get_agent_shards keeper_name in
+  let active_tool_names =
+    Tool_shard.tools_of_shards active_shards
+    |> List.map (fun (s : Types.tool_schema) -> s.name)
+  in
+  let (trifecta_count, _, _, _) = assess_trifecta ~active_tool_names in
+  let trifecta_active = trifecta_count >= 3 in
+  if trifecta_active then
+    Log.Governance.warn
+      "lethal trifecta: keeper=%s has all 3 capability classes \
+       (external_input + sensitive_access + state_modification). \
+       State-modifying tools will be escalated to High+ risk."
+      keeper_name;
   fun ~tool_name ~input ->
-    let risk = assess_risk ~tool_name ~input in
+    let base_risk = assess_risk ~tool_name ~input in
+    let risk =
+      combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk
+    in
     let needs_approval =
       match confirm_threshold governance_level with
       | Some threshold -> risk_level_to_int risk >= risk_level_to_int threshold

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -66,11 +66,43 @@ val install : config:Room.config -> governance_level:string -> unit
     Reads governance level from the [governance_level] argument.
     Called once at server startup. *)
 
+(** {1 Combinatorial Risk — Lethal Trifecta}
+
+    Simon Willison's "Lethal Trifecta": an agent simultaneously holding
+    untrusted input + sensitive access + state modification = security risk.
+    When all 3 classes are present, state-modifying tools get risk escalation.
+
+    @since 2.264.0 *)
+
+type capability_class =
+  | External_input      (** Receives data from untrusted external sources *)
+  | Sensitive_access    (** Can read potentially sensitive data *)
+  | State_modification  (** Can modify system state *)
+
+val tool_capabilities : string -> capability_class list
+(** Return capability classes for a tool name. Empty for unclassified tools. *)
+
+val assess_trifecta :
+  active_tool_names:string list -> int * bool * bool * bool
+(** Compute trifecta status from active tool names.
+    Returns [(class_count, has_external, has_sensitive, has_state_mod)]. *)
+
+val combinatorial_risk_escalation :
+  trifecta_active:bool ->
+  tool_name:string ->
+  base_risk:risk_level ->
+  risk_level
+(** If trifecta is active and the tool is a state_modification tool,
+    escalate risk to at least High. Otherwise return base_risk unchanged. *)
+
 val to_oas_approval_callback :
   governance_level:string ->
   keeper_name:string ->
   Oas.Hooks.approval_callback
 (** Build an OAS approval callback with genuine HITL fiber suspension.
+
+    Pre-computes trifecta status from the keeper's active shard tool set.
+    When trifecta is active, state-modifying tools get risk escalation.
 
     When a tool exceeds the governance threshold, the agent fiber
     suspends via [Keeper_approval_queue.submit_and_await]. An operator

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -743,6 +743,116 @@ let test_case_insensitive_matching () =
   Alcotest.(check string) "uppercase delete is critical"
     "critical" (Gp.risk_level_to_string risk)
 
+(* ── Lethal Trifecta Tests ─────────────────────────────────── *)
+
+let test_trifecta_all_three_classes () =
+  let (count, ext, sens, state) =
+    Gp.assess_trifecta ~active_tool_names:[
+      "masc_web_search";     (* External_input *)
+      "keeper_fs_read";      (* Sensitive_access *)
+      "keeper_fs_edit";      (* State_modification *)
+    ]
+  in
+  Alcotest.(check int) "3 classes" 3 count;
+  Alcotest.(check bool) "has external" true ext;
+  Alcotest.(check bool) "has sensitive" true sens;
+  Alcotest.(check bool) "has state_mod" true state
+
+let test_trifecta_two_classes_no_escalation () =
+  let (count, _, _, _) =
+    Gp.assess_trifecta ~active_tool_names:[
+      "keeper_fs_read";      (* Sensitive_access *)
+      "keeper_fs_edit";      (* State_modification *)
+    ]
+  in
+  Alcotest.(check int) "2 classes" 2 count
+
+let test_trifecta_one_class () =
+  let (count, _, _, _) =
+    Gp.assess_trifecta ~active_tool_names:[
+      "keeper_fs_read";      (* Sensitive_access *)
+      "keeper_memory_search"; (* Sensitive_access *)
+    ]
+  in
+  Alcotest.(check int) "1 class" 1 count
+
+let test_trifecta_empty () =
+  let (count, _, _, _) =
+    Gp.assess_trifecta ~active_tool_names:[]
+  in
+  Alcotest.(check int) "0 classes" 0 count
+
+let test_trifecta_bash_spans_all () =
+  (* keeper_bash alone has all 3 classes *)
+  let (count, ext, sens, state) =
+    Gp.assess_trifecta ~active_tool_names:["keeper_bash"]
+  in
+  Alcotest.(check int) "bash alone = 3 classes" 3 count;
+  Alcotest.(check bool) "has external" true ext;
+  Alcotest.(check bool) "has sensitive" true sens;
+  Alcotest.(check bool) "has state_mod" true state
+
+let test_trifecta_unclassified_tools_ignored () =
+  let (count, _, _, _) =
+    Gp.assess_trifecta ~active_tool_names:[
+      "keeper_time_now";       (* not in classification *)
+      "keeper_context_status"; (* not in classification *)
+    ]
+  in
+  Alcotest.(check int) "unclassified = 0" 0 count
+
+let test_escalation_state_mod_in_trifecta () =
+  (* keeper_fs_edit is normally High (contains "modify"/"set" pattern).
+     With trifecta, state_modification tools escalate to at least High. *)
+  let escalated =
+    Gp.combinatorial_risk_escalation
+      ~trifecta_active:true
+      ~tool_name:"keeper_fs_edit"
+      ~base_risk:Gp.Medium
+  in
+  Alcotest.(check string) "escalated to high"
+    "high" (Gp.risk_level_to_string escalated)
+
+let test_escalation_keeps_higher_risk () =
+  (* If base_risk is already Critical, escalation doesn't downgrade *)
+  let escalated =
+    Gp.combinatorial_risk_escalation
+      ~trifecta_active:true
+      ~tool_name:"keeper_fs_edit"
+      ~base_risk:Gp.Critical
+  in
+  Alcotest.(check string) "stays critical"
+    "critical" (Gp.risk_level_to_string escalated)
+
+let test_escalation_no_trifecta_no_change () =
+  let unchanged =
+    Gp.combinatorial_risk_escalation
+      ~trifecta_active:false
+      ~tool_name:"keeper_fs_edit"
+      ~base_risk:Gp.Low
+  in
+  Alcotest.(check string) "stays low without trifecta"
+    "low" (Gp.risk_level_to_string unchanged)
+
+let test_escalation_non_state_mod_unchanged () =
+  (* Non-state_modification tools are not escalated even in trifecta *)
+  let unchanged =
+    Gp.combinatorial_risk_escalation
+      ~trifecta_active:true
+      ~tool_name:"keeper_fs_read"
+      ~base_risk:Gp.Low
+  in
+  Alcotest.(check string) "read-only stays low"
+    "low" (Gp.risk_level_to_string unchanged)
+
+let test_tool_capabilities_known () =
+  let caps = Gp.tool_capabilities "keeper_bash" in
+  Alcotest.(check int) "bash has 3 capabilities" 3 (List.length caps)
+
+let test_tool_capabilities_unknown () =
+  let caps = Gp.tool_capabilities "unknown_tool" in
+  Alcotest.(check int) "unknown has 0 capabilities" 0 (List.length caps)
+
 (* ── Runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -818,6 +928,29 @@ let () =
       Alcotest.test_case "contract beats low override" `Quick
         test_risk_contract_beats_low_override;
       Alcotest.test_case "case insensitive" `Quick test_case_insensitive_matching;
+    ];
+    "lethal_trifecta", [
+      Alcotest.test_case "all 3 classes detected" `Quick
+        test_trifecta_all_three_classes;
+      Alcotest.test_case "2 classes no escalation" `Quick
+        test_trifecta_two_classes_no_escalation;
+      Alcotest.test_case "1 class only" `Quick test_trifecta_one_class;
+      Alcotest.test_case "empty tool set" `Quick test_trifecta_empty;
+      Alcotest.test_case "bash spans all 3" `Quick test_trifecta_bash_spans_all;
+      Alcotest.test_case "unclassified tools ignored" `Quick
+        test_trifecta_unclassified_tools_ignored;
+      Alcotest.test_case "escalation: state_mod in trifecta" `Quick
+        test_escalation_state_mod_in_trifecta;
+      Alcotest.test_case "escalation: keeps higher risk" `Quick
+        test_escalation_keeps_higher_risk;
+      Alcotest.test_case "escalation: no trifecta no change" `Quick
+        test_escalation_no_trifecta_no_change;
+      Alcotest.test_case "escalation: non-state_mod unchanged" `Quick
+        test_escalation_non_state_mod_unchanged;
+      Alcotest.test_case "capabilities: known tool" `Quick
+        test_tool_capabilities_known;
+      Alcotest.test_case "capabilities: unknown tool" `Quick
+        test_tool_capabilities_unknown;
     ];
     "governance_levels", [
       Alcotest.test_case "development allows all" `Quick


### PR DESCRIPTION
## Summary

Simon Willison의 "Lethal Trifecta" 패턴과 Meta AI의 "Rule of Two"를 governance pipeline에 구현합니다.

- 도구를 3개 capability class로 분류: `External_input`, `Sensitive_access`, `State_modification`
- keeper의 active tool set이 3개 class를 모두 포함하면 state-modifying 도구의 risk를 High 이상으로 escalate
- `keeper_bash` 단독으로도 trifecta 트리거 (curl + cat .env + rm 가능)
- API 변경 없음 — `to_oas_approval_callback` 내부에서 pre-compute

## Motivation

"From Prompt to Harness" 글 분석(2026-04-05) + Fowler 2x2 Harness Quadrant로 MASC 시스템 매핑 결과,
Non-Deterministic Feed-Back 외에 **per-tool이 아닌 per-combination 위험 평가** 부재를 확인.
기존 governance는 개별 도구만 분류하므로 {web_search + fs_read + bash} 동시 보유 위험 미검출.

## Changes

- `lib/governance_pipeline.ml` — capability_class type, classification list, assess_trifecta, combinatorial_risk_escalation
- `lib/governance_pipeline.mli` — 새 타입/함수 노출
- `test/test_governance_pipeline.ml` — 12개 새 테스트 (detection, escalation, edge cases)

## Test plan

- [x] `test_governance_pipeline.exe`: 86/86 pass (기존 50 + 신규 12 + 기존 pre_hook/levels/trace)
- [x] `test_keeper_unified.exe`: 115/115 pass (regression 없음)
- [x] `test_tool_dispatch.exe`: 18/18 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)