### PR TITLE
chore: OAS pin 0.118.0 — wire provider_filter end-to-end (#6001)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.117.0))
+  (agent_sdk (>= 0.118.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -174,12 +174,8 @@ let run_named
   in
   let candidate_cfgs = resolve_cascade_providers ~cascade_name in
   let capture, metrics = Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs () in
-  (* TODO(#6001): pass ?provider_filter to named_cascade after OAS pin bump *)
-  (match provider_filter with
-   | Some _ -> Log.Misc.warn "run_named: provider_filter not yet wired (pending oas#740/#6001)"
-   | None -> ());
   let named_cascade = Agent_sdk.Api.named_cascade ?config_path
-    ~metrics ~name:cascade_name ~defaults () in
+    ~metrics ?provider_filter ~name:cascade_name ~defaults () in
   let name = Printf.sprintf "oas-%s" cascade_name in
   match candidate_cfgs with
   | [] ->

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_TAG="v0.117.0"
+readonly OAS_AGENT_SDK_BASE_TAG="v0.118.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="af96b0c0936cd3fde182ae0cd67ba4fa70674a1c"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.117.0"
+readonly OAS_AGENT_SDK_SHA="33397b8370cfd061ebc28e3327191163aac9e344"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.118.0"


### PR DESCRIPTION
## Summary
- OAS pin bump: 0.117.0 → 0.118.0 (oas#740 + oas#743)
- Resolve TODO stub in oas_worker_named.ml: `provider_filter` now flows end-to-end
- `allowed_providers` in keeper TOML now actually restricts the cascade providers

## End-to-end path
```
cheolsu.toml: allowed_providers = ["ollama"]
  → keeper_meta.allowed_providers
  → keeper_unified_turn: ?provider_filter:run_meta.allowed_providers
  → keeper_agent_run: ?provider_filter
  → oas_worker_named: ?provider_filter → Api.named_cascade
  → OAS Cascade_config.complete_named ~provider_filter
  → apply_provider_filter: keep only Ollama providers
```

## Closes
- Resolves TODO(#6001) in oas_worker_named.ml

🤖 Generated with [Claude Code](https://claude.com/claude-code)