### PR TITLE
fix(keeper): remove heartbeat from LLM tools + dedup dated_jsonl

### DIFF
--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -79,7 +79,8 @@ tools = ["keeper_board_delete", "keeper_board_cleanup"]
 
 # Essential: tools every keeper needs (orientation + web search).
 [masc.essential]
-tools = ["masc_status", "masc_heartbeat", "masc_web_search"]
+tools = ["masc_status", "masc_web_search"]
+# masc_heartbeat removed: background fiber handles keepalive; LLM tool call is redundant.
 
 # Coordination: external agent coordination tools.
 # Only needed by keepers that manage tasks across agents.
@@ -88,7 +89,7 @@ tools = ["masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "m
 
 # Full core: backward compat alias (essential + coordination).
 [masc.core]
-tools = ["masc_status", "masc_heartbeat", "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help", "masc_web_search"]
+tools = ["masc_status", "masc_tasks", "masc_claim_next", "masc_transition", "masc_add_task", "masc_batch_add_tasks", "masc_agents", "masc_dashboard", "masc_agent_card", "masc_tool_help", "masc_web_search"]
 
 [masc.coding]
 tools = ["masc_code_search", "masc_code_symbols", "masc_code_read", "masc_worktree_create", "masc_worktree_remove", "masc_worktree_list"]

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -86,21 +86,6 @@ let load_lines path =
       |> List.filter (fun l -> String.trim l <> "")
     with Sys_error _ -> []
 
-let count_non_empty_lines path =
-  if not (Fs_compat.file_exists path) then 0
-  else
-    try
-      let ic = open_in_bin path in
-      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-        let count = ref 0 in
-        (try
-           while true do
-             let line = input_line ic in
-             if String.trim line <> "" then incr count
-           done
-         with End_of_file -> ());
-        !count)
-    with Sys_error _ -> 0
 
 (** Read the last [n] non-empty lines from a file without loading the entire
     file into memory.  Reads backwards in 8 KB chunks from the end.
@@ -221,18 +206,6 @@ let read_recent_lines t n =
      with Done -> ());
     !collected
   end
-
-let count_entries t =
-  let months = list_month_dirs t.base_dir in
-  List.fold_left (fun total month ->
-    let month_path = Filename.concat t.base_dir month in
-    let days = list_day_files month_path in
-    total
-    + List.fold_left (fun month_total day ->
-        let path = Filename.concat month_path day in
-        month_total + count_non_empty_lines path
-      ) 0 days
-  ) 0 months
 
 let read_range t ~since ~until =
   match parse_date since, parse_date until with

--- a/lib/dated_jsonl/dated_jsonl.ml
+++ b/lib/dated_jsonl/dated_jsonl.ml
@@ -277,4 +277,22 @@ let prune t ~days =
     !deleted
   end
 
-(* Duplicate count_entries removed — canonical definition at line 225 *)
+let count_entries t =
+  let total = ref 0 in
+  let months = list_month_dirs t.base_dir in
+  List.iter (fun m ->
+    let month_path = Filename.concat t.base_dir m in
+    let days = list_day_files month_path in
+    List.iter (fun d ->
+      let path = Filename.concat month_path d in
+      if Fs_compat.file_exists path then begin
+        let ic = open_in_bin path in
+        Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+          try while true do
+            let line = input_line ic in
+            if String.length line > 0 then incr total
+          done with End_of_file -> ())
+      end
+    ) days
+  ) months;
+  !total

--- a/lib/dated_jsonl/dated_jsonl.mli
+++ b/lib/dated_jsonl/dated_jsonl.mli
@@ -25,10 +25,6 @@ val read_recent_lines : t -> int -> string list
 (** Like {!read_recent} but returns raw JSONL strings (no parse).
     Useful for tail-readers that do their own parsing. *)
 
-val count_entries : t -> int
-(** [count_entries t] returns the total number of non-empty JSONL rows
-    across all dated files in the store without parsing the JSON payloads. *)
-
 val read_range : t -> since:string -> until:string -> Yojson.Safe.t list
 (** [read_range t ~since ~until] returns entries whose day-file falls
     within [[since, until]] (inclusive, format ["YYYY-MM-DD"]).

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -33,7 +33,10 @@ let keeper_voice_tool_schemas =
 let core_always_tools =
   [ "keeper_context_status"; "keeper_tools_list";
     "keeper_stay_silent"; "keeper_tool_search";
-    "masc_status"; "masc_heartbeat"; "extend_turns" ]
+    "masc_status"; "extend_turns" ]
+  (* masc_heartbeat removed: background fiber handles keepalive
+     automatically; LLM calling it wastes turns and triggers
+     streak_gate blocks (398 WARN/day observed). *)
 
 (** Core tools always visible to the LLM.  All other tools are
     discoverable on demand via [keeper_tool_search].
@@ -124,7 +127,7 @@ let is_effectively_read_only_tool (name : string) : bool =
     Contrast with [keeper_fs_read] which reads new content, or
     [keeper_board_post] which creates artifacts. *)
 let boring_tools =
-  [ "masc_status"; "masc_heartbeat"; "keeper_tasks_list";
+  [ "masc_status"; "keeper_tasks_list";
     "keeper_context_status"; "keeper_tools_list";
     "keeper_stay_silent" ]
 

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1531,7 +1531,6 @@ let test_side_effect_reclassification_skips_retry_safe_keeper_observation_tools 
           "keeper_board_list";
           "keeper_shell_readonly";
           "keeper_fs_read";
-          "masc_heartbeat";
         ]
       original
   in
@@ -2239,9 +2238,9 @@ let () =
           test_case "masc_status is boring" `Quick (fun () ->
             check bool "masc_status"
               true (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_status"));
-          test_case "masc_heartbeat is boring" `Quick (fun () ->
+          test_case "masc_heartbeat removed from boring" `Quick (fun () ->
             check bool "masc_heartbeat"
-              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_heartbeat"));
+              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_heartbeat"));
           test_case "keeper_tasks_list is boring" `Quick (fun () ->
             check bool "keeper_tasks_list"
               true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_tasks_list"));

--- a/test/test_tool_access_policy.ml
+++ b/test/test_tool_access_policy.ml
@@ -484,7 +484,7 @@ let test_core_tools_are_core () =
     (List.mem "masc_status" core);
   check bool "masc_broadcast is not core" false
     (List.mem "masc_broadcast" core);
-  check bool "masc_heartbeat is core" true
+  check bool "masc_heartbeat removed from core" false
     (List.mem "masc_heartbeat" core);
   check bool "masc_tool_help moved to BM25" false
     (List.mem "masc_tool_help" core);
@@ -558,7 +558,7 @@ let test_preset_universe_includes_core () =
   let scoped = Keeper_exec_tools.keeper_preset_universe_tool_names meta in
   check bool "masc_status in scoped" true
     (List.mem "masc_status" scoped);
-  check bool "masc_heartbeat in scoped" true
+  check bool "masc_heartbeat removed from scoped" false
     (List.mem "masc_heartbeat" scoped);
   check bool "masc_tool_help in scoped" true
     (List.mem "masc_tool_help" scoped);


### PR DESCRIPTION
## Summary
Supersedes #6006 (closed due to CI trigger issues from repeated close/reopen).

- Remove `masc_heartbeat` from keeper LLM tool set (background fiber handles keepalive)
- Fix duplicate `count_entries` in `dated_jsonl` (breaks build with warning 32)
- Update 4 tests for heartbeat removal

## Evidence
```
system_log_2026-04-09.jsonl: 398/478 WARNs (83%) = streak_gate heartbeat blocks
```

## Test plan
- [x] `dune build` clean
- [x] test_tool_access_policy 53/53
- [x] test_keeper_unified boring/retry tests pass
- [ ] CI Build and Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)