### PR TITLE
[codex] Cache and harden default command-plane trace events

### DIFF
--- a/lib/command_plane/cp_snapshot_summaries.ml
+++ b/lib/command_plane/cp_snapshot_summaries.ml
@@ -2,40 +2,59 @@ include Cp_snapshot_core
 
 let iso_of_unix = Dashboard_utils.iso_of_unix
 
+let file_fingerprint path =
+  try
+    let stats = Unix.stat path in
+    Some (stats.st_mtime, stats.st_size)
+  with Unix.Unix_error _ -> None
+
 let file_mtime path =
-  try Some (Unix.stat path).st_mtime with Unix.Unix_error _ -> None
+  match file_fingerprint path with
+  | Some (mtime, _) -> Some mtime
+  | None -> None
 
 type default_trace_cache_entry = {
-  cp_events_mtime : float option;
-  operator_log_mtime : float option;
-  limit : int;
+  cp_events_fingerprint : (float * int) option;
+  operator_log_fingerprint : (float * int) option;
   events : Yojson.Safe.t list;
 }
 
-let default_trace_cache : (string, default_trace_cache_entry) Hashtbl.t =
-  Hashtbl.create 4
+let default_trace_cache :
+    ((string * int), default_trace_cache_entry) Hashtbl.t =
+  Hashtbl.create 8
 
-let default_trace_cache_key config = Room.masc_dir config
+let max_default_trace_cache_entries = 16
 
-let default_trace_cache_mtimes config =
-  (file_mtime (events_path config), file_mtime (operator_action_log_path config))
+let default_trace_cache_key config ~limit =
+  (Room.masc_dir config, limit)
+
+let default_trace_cache_fingerprints config =
+  ( file_fingerprint (events_path config),
+    file_fingerprint (operator_action_log_path config) )
 
 let cached_default_trace_events config ~limit =
-  let key = default_trace_cache_key config in
-  let cp_events_mtime, operator_log_mtime = default_trace_cache_mtimes config in
+  let key = default_trace_cache_key config ~limit in
+  let cp_events_fingerprint, operator_log_fingerprint =
+    default_trace_cache_fingerprints config
+  in
   match Hashtbl.find_opt default_trace_cache key with
   | Some entry
-    when entry.limit = limit
-         && entry.cp_events_mtime = cp_events_mtime
-         && entry.operator_log_mtime = operator_log_mtime ->
+    when entry.cp_events_fingerprint = cp_events_fingerprint
+         && entry.operator_log_fingerprint = operator_log_fingerprint ->
       Some entry.events
   | _ -> None
 
 let store_default_trace_events config ~limit ~events =
-  let key = default_trace_cache_key config in
-  let cp_events_mtime, operator_log_mtime = default_trace_cache_mtimes config in
+  let key = default_trace_cache_key config ~limit in
+  let cp_events_fingerprint, operator_log_fingerprint =
+    default_trace_cache_fingerprints config
+  in
+  if
+    Hashtbl.length default_trace_cache >= max_default_trace_cache_entries
+    && not (Hashtbl.mem default_trace_cache key)
+  then Hashtbl.reset default_trace_cache;
   Hashtbl.replace default_trace_cache key
-    { cp_events_mtime; operator_log_mtime; limit; events }
+    { cp_events_fingerprint; operator_log_fingerprint; events }
 
 let traces_json_of_events events =
   `Assoc

--- a/lib/command_plane/cp_snapshot_summaries.ml
+++ b/lib/command_plane/cp_snapshot_summaries.ml
@@ -5,6 +5,46 @@ let iso_of_unix = Dashboard_utils.iso_of_unix
 let file_mtime path =
   try Some (Unix.stat path).st_mtime with Unix.Unix_error _ -> None
 
+type default_trace_cache_entry = {
+  cp_events_mtime : float option;
+  operator_log_mtime : float option;
+  limit : int;
+  events : Yojson.Safe.t list;
+}
+
+let default_trace_cache : (string, default_trace_cache_entry) Hashtbl.t =
+  Hashtbl.create 4
+
+let default_trace_cache_key config = Room.masc_dir config
+
+let default_trace_cache_mtimes config =
+  (file_mtime (events_path config), file_mtime (operator_action_log_path config))
+
+let cached_default_trace_events config ~limit =
+  let key = default_trace_cache_key config in
+  let cp_events_mtime, operator_log_mtime = default_trace_cache_mtimes config in
+  match Hashtbl.find_opt default_trace_cache key with
+  | Some entry
+    when entry.limit = limit
+         && entry.cp_events_mtime = cp_events_mtime
+         && entry.operator_log_mtime = operator_log_mtime ->
+      Some entry.events
+  | _ -> None
+
+let store_default_trace_events config ~limit ~events =
+  let key = default_trace_cache_key config in
+  let cp_events_mtime, operator_log_mtime = default_trace_cache_mtimes config in
+  Hashtbl.replace default_trace_cache key
+    { cp_events_mtime; operator_log_mtime; limit; events }
+
+let traces_json_of_events events =
+  `Assoc
+    [
+      ("version", `String "cp-v2");
+      ("generated_at", `String (Types.now_iso ()));
+      ("events", `List events);
+    ]
+
 let swarm_slot_samples_tail_lines () =
   Dashboard_http_helpers.int_of_env_default
     "MASC_CP_SWARM_SLOT_SAMPLE_TAIL_LINES"
@@ -646,19 +686,9 @@ let recent_swarm_trace_events config limit =
         |> List.filteri (fun idx _ -> idx < limit)
     | _ -> []
 
-let list_traces_json config ?operation_id ?(limit = 25) () =
+let build_default_trace_events config ~limit =
   let events =
-    (match operation_id with
-     | None -> read_recent_events config ~limit:(max limit 50)
-     | Some _ -> read_events ~max_lines:(limit * 3) config)
-    |> List.filter (fun (event : event_record) ->
-           match operation_id with
-           | None -> true
-           | Some operation_ref ->
-               (match event.operation_id with
-               | Some value -> String.equal value operation_ref
-               | None -> false)
-               || String.equal event.trace_id operation_ref)
+    read_recent_events config ~limit:(max limit 50)
   in
   let cp_events =
     events
@@ -679,9 +709,50 @@ let list_traces_json config ?operation_id ?(limit = 25) () =
                ("detail", event.detail);
              ])
   in
-  let team_session_events =
-    match operation_id with
-    | Some operation_ref -> (
+  let operator_events = recent_operator_trace_events config limit in
+  cp_events @ operator_events
+
+let list_traces_json config ?operation_id ?(limit = 25) () =
+  match operation_id with
+  | None ->
+      let events =
+        match cached_default_trace_events config ~limit with
+        | Some events -> events
+        | None ->
+            let events = build_default_trace_events config ~limit in
+            store_default_trace_events config ~limit ~events;
+            events
+      in
+      traces_json_of_events events
+  | Some operation_ref ->
+      let events =
+        read_events ~max_lines:(limit * 3) config
+        |> List.filter (fun (event : event_record) ->
+               (match event.operation_id with
+               | Some value -> String.equal value operation_ref
+               | None -> false)
+               || String.equal event.trace_id operation_ref)
+      in
+      let cp_events =
+        events
+        |> List.rev
+        |> List.filteri (fun idx _ -> idx < limit)
+        |> List.rev
+        |> List.map (fun (event : event_record) ->
+               `Assoc
+                 [
+                   ("event_id", `String event.event_id);
+                   ("trace_id", `String event.trace_id);
+                   ("event_type", `String event.event_type);
+                   ("operation_id", Json_util.string_opt_to_json event.operation_id);
+                   ("unit_id", Json_util.string_opt_to_json event.unit_id);
+                   ("actor", Json_util.string_opt_to_json event.actor);
+                   ("source", `String event.source);
+                   ("timestamp", `String event.ts);
+                   ("detail", event.detail);
+                 ])
+      in
+      let team_session_events =
         let _, _, units, _ = topology_units config in
         let operations = all_operations config units in
         match
@@ -694,18 +765,9 @@ let list_traces_json config ?operation_id ?(limit = 25) () =
             match operation.detachment_session_id with
             | Some session_id -> recent_team_session_trace_events config session_id limit
             | None -> [])
-        | None -> [])
-    | None -> []
-  in
-  let operator_events =
-    match operation_id with
-    | Some operation_ref -> recent_operator_trace_events config ~trace_id:operation_ref limit
-    | None -> recent_operator_trace_events config limit
-  in
-  let merged = cp_events @ team_session_events @ operator_events in
-  `Assoc
-    [
-      ("version", `String "cp-v2");
-      ("generated_at", `String (Types.now_iso ()));
-      ("events", `List merged);
-    ]
+        | None -> []
+      in
+      let operator_events =
+        recent_operator_trace_events config ~trace_id:operation_ref limit
+      in
+      traces_json_of_events (cp_events @ team_session_events @ operator_events)

--- a/lib/command_plane/cp_snapshot_summaries.ml
+++ b/lib/command_plane/cp_snapshot_summaries.ml
@@ -5,17 +5,17 @@ let iso_of_unix = Dashboard_utils.iso_of_unix
 let file_fingerprint path =
   try
     let stats = Unix.stat path in
-    Some (stats.st_mtime, stats.st_size)
+    Some (stats.st_mtime, stats.st_ctime, stats.st_size)
   with Unix.Unix_error _ -> None
 
 let file_mtime path =
   match file_fingerprint path with
-  | Some (mtime, _) -> Some mtime
+  | Some (mtime, _, _) -> Some mtime
   | None -> None
 
 type default_trace_cache_entry = {
-  cp_events_fingerprint : (float * int) option;
-  operator_log_fingerprint : (float * int) option;
+  cp_events_fingerprint : (float * float * int) option;
+  operator_log_fingerprint : (float * float * int) option;
   events : Yojson.Safe.t list;
 }
 
@@ -24,6 +24,17 @@ let default_trace_cache :
   Hashtbl.create 8
 
 let max_default_trace_cache_entries = 16
+
+let evict_default_trace_cache_entry () =
+  let victim = ref None in
+  Hashtbl.iter (fun key _ ->
+      match !victim with
+      | Some _ -> ()
+      | None -> victim := Some key)
+    default_trace_cache;
+  match !victim with
+  | Some key -> Hashtbl.remove default_trace_cache key
+  | None -> ()
 
 let default_trace_cache_key config ~limit =
   (Room.masc_dir config, limit)
@@ -52,7 +63,7 @@ let store_default_trace_events config ~limit ~events =
   if
     Hashtbl.length default_trace_cache >= max_default_trace_cache_entries
     && not (Hashtbl.mem default_trace_cache key)
-  then Hashtbl.reset default_trace_cache;
+  then evict_default_trace_cache_entry ();
   Hashtbl.replace default_trace_cache key
     { cp_events_fingerprint; operator_log_fingerprint; events }
 

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -83,6 +83,16 @@ let () =
             `Quick
             Test_command_plane_v2_traces.test_trace_filter_reads_tail_bounded_operator_log;
           Alcotest.test_case
+            "default trace view reuses cached operator events"
+            `Quick
+            Test_command_plane_v2_traces
+              .test_default_trace_view_reuses_cached_operator_events_when_inputs_unchanged;
+          Alcotest.test_case
+            "default trace view invalidates cache on event log change"
+            `Quick
+            Test_command_plane_v2_traces
+              .test_default_trace_view_invalidates_cache_when_event_log_changes;
+          Alcotest.test_case
             "swarm proof fallback reads bounded slot-sample tail"
             `Quick
             Test_command_plane_v2_summary

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -93,6 +93,11 @@ let () =
             Test_command_plane_v2_traces
               .test_default_trace_view_invalidates_cache_when_event_log_changes;
           Alcotest.test_case
+            "default trace view invalidates cache when operator log grows"
+            `Quick
+            Test_command_plane_v2_traces
+              .test_default_trace_view_invalidates_cache_when_operator_log_grows_without_mtime_change;
+          Alcotest.test_case
             "swarm proof fallback reads bounded slot-sample tail"
             `Quick
             Test_command_plane_v2_summary

--- a/test/test_command_plane_v2_traces.ml
+++ b/test/test_command_plane_v2_traces.ml
@@ -176,3 +176,36 @@ let test_default_trace_view_invalidates_cache_when_event_log_changes () =
         "default trace cache refreshes after control-plane log change"
         true
         (List.mem "trace-new" (trace_ids json)))
+
+let test_default_trace_view_invalidates_cache_when_operator_log_grows_without_mtime_change
+    () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      with_eio_test base_dir @@ fun config ->
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      let path = operator_action_log_path config in
+      let initial_row =
+        make_operator_row ~trace_id:"trace-initial"
+          ~action_type:"operator_action"
+          ~created_at:"2026-03-23T00:10:00Z"
+      in
+      write_jsonl_rows path [ initial_row ];
+      ignore (Command_plane_v2.list_traces_json config ~limit:5 ());
+      let initial_stats = Unix.stat path in
+      let updated_rows =
+        [
+          initial_row;
+          make_operator_row ~trace_id:"trace-new"
+            ~action_type:"operator_action"
+            ~created_at:"2026-03-23T00:11:00Z";
+        ]
+      in
+      write_jsonl_rows path updated_rows;
+      Unix.utimes path initial_stats.st_atime initial_stats.st_mtime;
+      let json = Command_plane_v2.list_traces_json config ~limit:5 () in
+      Alcotest.(check bool)
+        "default trace cache refreshes when operator log size changes"
+        true
+        (List.mem "trace-new" (trace_ids json)))

--- a/test/test_command_plane_v2_traces.ml
+++ b/test/test_command_plane_v2_traces.ml
@@ -33,6 +33,14 @@ let event_sources json =
          Yojson.Safe.Util.member "source" event
          |> Yojson.Safe.Util.to_string_option)
 
+let event_ids json =
+  json
+  |> Yojson.Safe.Util.member "events"
+  |> Yojson.Safe.Util.to_list
+  |> List.filter_map (fun event ->
+         Yojson.Safe.Util.member "event_id" event
+         |> Yojson.Safe.Util.to_string_option)
+
 let make_cp_event ~event_id ~trace_id ~event_type ~ts =
   `Assoc
     [
@@ -122,3 +130,49 @@ let test_trace_filter_reads_tail_bounded_operator_log () =
         "operator source preserved"
         true
         (List.mem "operator" (event_sources json)))
+
+let test_default_trace_view_reuses_cached_operator_events_when_inputs_unchanged () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      with_eio_test base_dir @@ fun config ->
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      write_jsonl_rows (operator_action_log_path config)
+        [ make_operator_row ~trace_id:"trace-cached"
+            ~action_type:"operator_action"
+            ~created_at:"2026-03-23T00:10:00Z" ];
+      let first = Command_plane_v2.list_traces_json config ~limit:5 () in
+      let second = Command_plane_v2.list_traces_json config ~limit:5 () in
+      Alcotest.(check (list string))
+        "default trace view reuses synthetic operator event ids"
+        (event_ids first) (event_ids second))
+
+let test_default_trace_view_invalidates_cache_when_event_log_changes () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      with_eio_test base_dir @@ fun config ->
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      let initial_event =
+        make_cp_event ~event_id:"evt-initial" ~trace_id:"trace-initial"
+          ~event_type:"initial" ~ts:"2026-03-23T00:00:00Z"
+      in
+      write_jsonl_rows (control_plane_events_path config) [ initial_event ];
+      ignore (Command_plane_v2.list_traces_json config ~limit:5 ());
+      let updated_events =
+        [
+          initial_event;
+          make_cp_event ~event_id:"evt-new" ~trace_id:"trace-new"
+            ~event_type:"updated" ~ts:"2026-03-23T00:01:00Z";
+        ]
+      in
+      write_jsonl_rows (control_plane_events_path config) updated_events;
+      let now = Unix.gettimeofday () +. 1.0 in
+      Unix.utimes (control_plane_events_path config) now now;
+      let json = Command_plane_v2.list_traces_json config ~limit:5 () in
+      Alcotest.(check bool)
+        "default trace cache refreshes after control-plane log change"
+        true
+        (List.mem "trace-new" (trace_ids json)))


### PR DESCRIPTION
## Summary
- cache the default command-plane trace view when `list_traces_json` is called without an `operation_id`
- bound that cache by `(Room.masc_dir, limit)` and cap it at 16 entries instead of recomputing the same dashboard view on every request
- invalidate cached default trace events when the control-plane event log or operator action log fingerprint changes
- add regression coverage for cache reuse and invalidation, and remove the duplicated `Dated_jsonl.count_entries` declaration that was shadowing the real implementation

## Why
`cp_snapshot` still rebuilt the trace section on every default dashboard request even after `build_snapshot_state` gained section caching. The default trace path kept tail-reading `events.jsonl` and the operator action log, which matches the hot path described in #5965.

## Product impact
- repeated default dashboard snapshot reads avoid redundant trace log parsing when the underlying logs have not changed
- filtered trace reads by `operation_id` keep the previous behavior
- cache invalidation is stronger for rapid same-size log rewrites because the fingerprint now includes file metadata beyond plain mtime
- the build no longer trips over duplicated `Dated_jsonl.count_entries` declarations

## Root cause
The command-plane snapshot cached stateful sections, but the default trace section remained outside that cache and recomputed from log tails on every request.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/issue-5965-cp-snapshot-reopen test/test_command_plane_v2.exe test/test_dated_jsonl.exe`
- `./_build/default/test/test_command_plane_v2.exe`
- `./_build/default/test/test_dated_jsonl.exe`

## Review evidence
- Cross-model correctness review: direct `sb glm-text` on the GLM-5.1 review lane
- Review outcome: no blocking findings after follow-up cache hardening and fingerprint tightening
- GitHub checks passed: `label-and-review`, `phantom-fix-check`, `pr-hygiene`, `sweep-supersede-check`

## Linked issue
- Refs #5965
