### PR TITLE
fix: align opam agent_sdk floor to 0.118.0

### DIFF
--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.117.0"}
+  "agent_sdk" {>= "0.118.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Summary
- `masc_mcp.opam` agent_sdk floor 0.117.0 → 0.118.0
- #6034 bumped `oas-agent-sdk-pin.sh` MIN_VERSION but missed the opam file
- Fixes `check-oas-pin.sh` Health check failure on all PR branches

## Test plan
- [x] `scripts/check-oas-pin.sh --local-only` passes
- [ ] CI Health check green

Generated with [Claude Code](https://claude.com/claude-code)