### PR TITLE
refactor: remove dead Room_eio task infrastructure

### DIFF
--- a/lib/room/room_eio.ml
+++ b/lib/room/room_eio.ml
@@ -111,14 +111,12 @@ let test_config ~fs base_path =
 (** {1 Key Utilities} *)
 
 let agents_key = "agents"
-let tasks_key = "tasks"
 let messages_key = "messages"
 let locks_key = "locks"
 let state_key = "state"
 let events_key = "events"
 
 let agent_key name = Printf.sprintf "%s:%s" agents_key name
-let task_key id = Printf.sprintf "%s:%s" tasks_key id
 let message_key seq = Printf.sprintf "%s:%06d" messages_key seq
 let lock_key resource = Printf.sprintf "%s:%s" locks_key resource
 let event_key seq = Printf.sprintf "%s:%06d" events_key seq
@@ -130,8 +128,6 @@ type event_type =
   | AgentJoin
   | AgentLeave
   | Broadcast
-  | TaskClaim
-  | TaskDone
   | LockAcquire
   | LockRelease
 
@@ -139,8 +135,6 @@ let event_type_to_string = function
   | AgentJoin -> "agent_join"
   | AgentLeave -> "agent_leave"
   | Broadcast -> "broadcast"
-  | TaskClaim -> "task_claim"
-  | TaskDone -> "task_done"
   | LockAcquire -> "lock_acquire"
   | LockRelease -> "lock_release"
 
@@ -650,206 +644,6 @@ let get_message config ~seq =
       Error (match e with
         | Backend.IOError msg -> msg
         | _ -> "Failed to get message")
-
-(** {1 Task Operations} *)
-
-type task_status =
-  | Pending
-  | InProgress of string  (* agent_id *)
-  | Completed of string   (* agent_id *)
-  | Failed of string * string  (* agent_id, reason *)
-
-type complexity = {
-  estimated_turns: int;
-  reversibility: float;
-}
-
-type task = {
-  id: string;
-  description: string;
-  status: task_status;
-  created_at: float;
-  updated_at: float;
-  priority: int;
-  parent_task_id: string option;
-  goal_id: string option;
-  complexity_estimate: complexity option;
-}
-
-let complexity_to_json c =
-  `Assoc [
-    ("estimated_turns", `Int c.estimated_turns);
-    ("reversibility", `Float c.reversibility);
-  ]
-
-let complexity_of_json json =
-  let open Yojson.Safe.Util in
-  { estimated_turns = json |> member "estimated_turns" |> to_int;
-    reversibility = json |> member "reversibility" |> to_number }
-
-let task_status_to_json = function
-  | Pending -> `Assoc [("type", `String "pending")]
-  | InProgress agent -> `Assoc [("type", `String "in_progress"); ("agent", `String agent)]
-  | Completed agent -> `Assoc [("type", `String "completed"); ("agent", `String agent)]
-  | Failed (agent, reason) -> `Assoc [("type", `String "failed"); ("agent", `String agent); ("reason", `String reason)]
-
-let task_status_of_json json =
-  let open Yojson.Safe.Util in
-  match json |> member "type" |> to_string with
-  | "pending" -> Ok Pending
-  | "in_progress" -> Ok (InProgress (json |> member "agent" |> to_string))
-  | "completed" -> Ok (Completed (json |> member "agent" |> to_string))
-  | "failed" -> Ok (Failed (json |> member "agent" |> to_string, json |> member "reason" |> to_string))
-  | s -> Error ("Unknown task status: " ^ s)
-
-let json_string_opt_field name value =
-  match value with Some s -> [(name, `String s)] | None -> []
-
-let task_to_json task =
-  let base = [
-    ("id", `String task.id);
-    ("description", `String task.description);
-    ("status", task_status_to_json task.status);
-    ("created_at", `Float task.created_at);
-    ("updated_at", `Float task.updated_at);
-    ("priority", `Int task.priority);
-  ] in
-  let opt_fields =
-    json_string_opt_field "parent_task_id" task.parent_task_id
-    @ json_string_opt_field "goal_id" task.goal_id
-    @ (match task.complexity_estimate with
-       | Some c -> [("complexity_estimate", complexity_to_json c)]
-       | None -> [])
-  in
-  `Assoc (base @ opt_fields)
-
-let task_of_json json =
-  let open Yojson.Safe.Util in
-  try
-    match task_status_of_json (json |> member "status") with
-    | Error e -> Error e
-    | Ok status ->
-        let str_opt key = match json |> member key with
-          | `String s -> Some s | _ -> None
-        in
-        let complexity_opt = match json |> member "complexity_estimate" with
-          | `Assoc _ as j -> Some (complexity_of_json j)
-          | _ -> None
-        in
-        Ok {
-          id = json |> member "id" |> to_string;
-          description = json |> member "description" |> to_string;
-          status;
-          created_at = json |> member "created_at" |> to_float;
-          updated_at = json |> member "updated_at" |> to_float;
-          priority = json |> member "priority" |> to_int;
-          parent_task_id = str_opt "parent_task_id";
-          goal_id = str_opt "goal_id";
-          complexity_estimate = complexity_opt;
-        }
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | e -> Error (Printexc.to_string e)
-
-(** Create a new task *)
-let create_task config ~description ?(priority=1) ?parent_task_id ?goal_id ?complexity_estimate () =
-  let id = Printf.sprintf "task_%d_%04x" (int_of_float (Time_compat.now () *. 1000.)) (Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFF) in
-  let now = Time_compat.now () in
-  let task = {
-    id;
-    description;
-    status = Pending;
-    created_at = now;
-    updated_at = now;
-    priority;
-    parent_task_id;
-    goal_id;
-    complexity_estimate;
-  } in
-  let json_str = Yojson.Safe.to_string (task_to_json task) in
-  match Backend.FileSystem.set config.backend (task_key id) json_str with
-  | Ok () -> Ok task
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to create task")
-
-(** Claim a task (set to in_progress) *)
-let claim_task config ~task_id ~agent =
-  match Backend.FileSystem.get config.backend (task_key task_id) with
-  | Error (Backend.NotFound _) -> Error "Task not found"
-  | Error e -> Error (match e with Backend.IOError msg -> msg | _ -> "Get failed")
-  | Ok json_str ->
-      (try
-        let json = Yojson.Safe.from_string json_str in
-        match task_of_json json with
-        | Error e -> Error e
-        | Ok task ->
-            match task.status with
-            | Pending ->
-                let updated = { task with
-                  status = InProgress agent;
-                  updated_at = Time_compat.now ();
-                } in
-                let new_json = Yojson.Safe.to_string (task_to_json updated) in
-                (match Backend.FileSystem.set config.backend (task_key task_id) new_json with
-                 | Ok () -> Ok updated
-                 | Error _ -> Error "Failed to update task")
-            | InProgress other when other = agent ->
-                Ok task  (* Already claimed by this agent *)
-            | InProgress _ ->
-                Error "Task already claimed by another agent"
-            | Completed _ ->
-                Error "Task already completed"
-            | Failed _ ->
-                Error "Task failed"
-      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
-
-(** Complete a task *)
-let complete_task config ~task_id ~agent =
-  match Backend.FileSystem.get config.backend (task_key task_id) with
-  | Error (Backend.NotFound _) -> Error "Task not found"
-  | Error e -> Error (match e with Backend.IOError msg -> msg | _ -> "Get failed")
-  | Ok json_str ->
-      (try
-        let json = Yojson.Safe.from_string json_str in
-        match task_of_json json with
-        | Error e -> Error e
-        | Ok task ->
-            match task.status with
-            | InProgress claimer when claimer = agent ->
-                let updated = { task with
-                  status = Completed agent;
-                  updated_at = Time_compat.now ();
-                } in
-                let new_json = Yojson.Safe.to_string (task_to_json updated) in
-                (match Backend.FileSystem.set config.backend (task_key task_id) new_json with
-                 | Ok () -> Ok updated
-                 | Error _ -> Error "Failed to update task")
-            | InProgress _ ->
-                Error "Task claimed by another agent"
-            | Pending ->
-                Error "Task not claimed"
-            | Completed _ ->
-                Error "Task already completed"
-            | Failed _ ->
-                Error "Task failed"
-      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
-
-(** Get task by ID *)
-let get_task config ~task_id =
-  match Backend.FileSystem.get config.backend (task_key task_id) with
-  | Ok json_str ->
-      (try
-        let json = Yojson.Safe.from_string json_str in
-        task_of_json json
-      with Eio.Cancel.Cancelled _ as e -> raise e | e -> Error (Printexc.to_string e))
-  | Error (Backend.NotFound _) ->
-      Error "Task not found"
-  | Error e ->
-      Error (match e with
-        | Backend.IOError msg -> msg
-        | _ -> "Failed to get task")
 
 (** {1 Health Check} *)
 

--- a/lib/room/room_eio.mli
+++ b/lib/room/room_eio.mli
@@ -44,8 +44,6 @@ type event_type =
   | AgentJoin
   | AgentLeave
   | Broadcast
-  | TaskClaim
-  | TaskDone
   | LockAcquire
   | LockRelease
 
@@ -75,34 +73,6 @@ type message = {
   timestamp: float;
 }
 
-(** Task lifecycle status. *)
-type task_status =
-  | Pending
-  | InProgress of string  (** agent_id *)
-  | Completed of string   (** agent_id *)
-  | Failed of string * string  (** agent_id, reason *)
-
-(** Task complexity estimate for goal decomposition.
-    @since 2.223.0 *)
-type complexity = {
-  estimated_turns: int;
-  reversibility: float;
-}
-
-(** A coordination task with optional goal decomposition metadata.
-    New fields default to None for backward-compatible JSON deserialization. *)
-type task = {
-  id: string;
-  description: string;
-  status: task_status;
-  created_at: float;
-  updated_at: float;
-  priority: int;
-  parent_task_id: string option;
-  goal_id: string option;
-  complexity_estimate: complexity option;
-}
-
 (** {1 Helpers} *)
 
 (** Current time as ISO-8601 string (UTC, millisecond precision). *)
@@ -121,9 +91,6 @@ val test_config : fs:Eio.Fs.dir_ty Eio.Path.t -> string -> config
 (** Key prefix for agents namespace. *)
 val agents_key : string
 
-(** Key prefix for tasks namespace. *)
-val tasks_key : string
-
 (** Key prefix for messages namespace. *)
 val messages_key : string
 
@@ -138,9 +105,6 @@ val events_key : string
 
 (** Key for a specific agent. *)
 val agent_key : string -> string
-
-(** Key for a specific task. *)
-val task_key : string -> string
 
 (** Key for a specific message by sequence. *)
 val message_key : int -> string
@@ -237,38 +201,6 @@ val broadcast :
 
 (** Retrieve a message by sequence number. *)
 val get_message : config -> seq:int -> (message, string) result
-
-(** {1 Task Operations} *)
-
-(** Serialize task status to JSON. *)
-val task_status_to_json : task_status -> Yojson.Safe.t
-
-(** Deserialize task status from JSON. *)
-val task_status_of_json : Yojson.Safe.t -> (task_status, string) result
-
-(** Serialize a task to JSON. *)
-val task_to_json : task -> Yojson.Safe.t
-
-(** Deserialize a task from JSON. *)
-val task_of_json : Yojson.Safe.t -> (task, string) result
-
-(** Create a new task with the given description and optional priority. *)
-val create_task :
-  config -> description:string -> ?priority:int ->
-  ?parent_task_id:string -> ?goal_id:string ->
-  ?complexity_estimate:complexity -> unit ->
-  (task, string) result
-
-(** Claim a pending task for [agent].  Fails if already claimed. *)
-val claim_task :
-  config -> task_id:string -> agent:string -> (task, string) result
-
-(** Mark a claimed task as completed by [agent]. *)
-val complete_task :
-  config -> task_id:string -> agent:string -> (task, string) result
-
-(** Retrieve a task by ID. *)
-val get_task : config -> task_id:string -> (task, string) result
 
 (** {1 Event Log} *)
 

--- a/test/test_room_eio.ml
+++ b/test/test_room_eio.ml
@@ -146,74 +146,6 @@ let test_get_message () =
       | Error e ->
           Alcotest.failf "get_message failed: %s" e
 
-(** {1 Task Tests} *)
-
-let test_create_task () =
-  with_eio_env @@ fun config ->
-  match Room_eio.create_task config ~description:"Implement feature X" () with
-  | Ok task ->
-      Alcotest.(check bool) "has id" true (String.length task.id > 0);
-      Alcotest.(check string) "description" "Implement feature X" task.description
-  | Error e ->
-      Alcotest.failf "create_task failed: %s" e
-
-let test_claim_task () =
-  with_eio_env @@ fun config ->
-  (* Create task *)
-  let task = match Room_eio.create_task config ~description:"Review PR" () with
-    | Ok t -> t
-    | Error e -> Alcotest.failf "create_task failed: %s" e
-  in
-
-  (* Claim task *)
-  match Room_eio.claim_task config ~task_id:task.id ~agent:"claude" with
-  | Ok claimed ->
-      (match claimed.status with
-       | Room_eio.InProgress agent ->
-           Alcotest.(check string) "claimed by claude" "claude" agent
-       | _ ->
-           Alcotest.fail "task should be in_progress")
-  | Error e ->
-      Alcotest.failf "claim_task failed: %s" e
-
-let test_complete_task () =
-  with_eio_env @@ fun config ->
-  (* Create and claim *)
-  let task = match Room_eio.create_task config ~description:"Fix bug" () with
-    | Ok t -> t
-    | Error e -> Alcotest.failf "create_task failed: %s" e
-  in
-  let _ = Room_eio.claim_task config ~task_id:task.id ~agent:"claude" in
-
-  (* Complete *)
-  match Room_eio.complete_task config ~task_id:task.id ~agent:"claude" with
-  | Ok completed ->
-      (match completed.status with
-       | Room_eio.Completed agent ->
-           Alcotest.(check string) "completed by claude" "claude" agent
-       | _ ->
-           Alcotest.fail "task should be completed")
-  | Error e ->
-      Alcotest.failf "complete_task failed: %s" e
-
-let test_task_workflow () =
-  with_eio_env @@ fun config ->
-  (* Full workflow: create -> claim -> complete *)
-  let task = match Room_eio.create_task config ~description:"E2E task" ~priority:2 () with
-    | Ok t -> t
-    | Error e -> Alcotest.failf "create failed: %s" e
-  in
-
-  Alcotest.(check int) "priority" 2 task.priority;
-
-  (* Another agent tries to claim completed task *)
-  let _ = Room_eio.claim_task config ~task_id:task.id ~agent:"claude" in
-  let _ = Room_eio.complete_task config ~task_id:task.id ~agent:"claude" in
-
-  match Room_eio.claim_task config ~task_id:task.id ~agent:"gemini" with
-  | Error _ -> ()  (* Expected: can't claim completed task *)
-  | Ok _ -> Alcotest.fail "should not claim completed task"
-
 (** {1 State Tests} *)
 
 let test_room_state () =
@@ -263,12 +195,6 @@ let () =
       Alcotest.test_case "broadcast message" `Quick test_broadcast_message;
       Alcotest.test_case "mention extraction" `Quick test_mention_extraction;
       Alcotest.test_case "get message" `Quick test_get_message;
-    ];
-    "task", [
-      Alcotest.test_case "create task" `Quick test_create_task;
-      Alcotest.test_case "claim task" `Quick test_claim_task;
-      Alcotest.test_case "complete task" `Quick test_complete_task;
-      Alcotest.test_case "task workflow" `Quick test_task_workflow;
     ];
     "state", [
       Alcotest.test_case "room state" `Quick test_room_state;

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -734,8 +734,6 @@ let test_room_eio_event_type_to_string () =
   check string "AgentJoin" "agent_join" (Room_eio.event_type_to_string Room_eio.AgentJoin);
   check string "AgentLeave" "agent_leave" (Room_eio.event_type_to_string Room_eio.AgentLeave);
   check string "Broadcast" "broadcast" (Room_eio.event_type_to_string Room_eio.Broadcast);
-  check string "TaskClaim" "task_claim" (Room_eio.event_type_to_string Room_eio.TaskClaim);
-  check string "TaskDone" "task_done" (Room_eio.event_type_to_string Room_eio.TaskDone);
   check string "LockAcquire" "lock_acquire" (Room_eio.event_type_to_string Room_eio.LockAcquire);
   check string "LockRelease" "lock_release" (Room_eio.event_type_to_string Room_eio.LockRelease)
 
@@ -846,100 +844,6 @@ let test_room_eio_message_no_mention () =
   let json = Room_eio.message_to_json msg in
   let result = Room_eio.message_of_json json in
   check bool "roundtrip ok" true (is_ok result)
-
-(* ============================================================ *)
-(* Room_eio.task_status JSON Tests                               *)
-(* ============================================================ *)
-
-let test_room_eio_task_status_pending () =
-  let status = Room_eio.Pending in
-  let json = Room_eio.task_status_to_json status in
-  let result = Room_eio.task_status_of_json json in
-  check bool "roundtrip ok" true (is_ok result)
-
-let test_room_eio_task_status_in_progress () =
-  let status = Room_eio.InProgress "claude" in
-  let json = Room_eio.task_status_to_json status in
-  let result = Room_eio.task_status_of_json json in
-  check bool "roundtrip ok" true (is_ok result)
-
-let test_room_eio_task_status_completed () =
-  let status = Room_eio.Completed "gemini" in
-  let json = Room_eio.task_status_to_json status in
-  let result = Room_eio.task_status_of_json json in
-  check bool "roundtrip ok" true (is_ok result)
-
-let test_room_eio_task_status_failed () =
-  let status = Room_eio.Failed ("codex", "Test failed") in
-  let json = Room_eio.task_status_to_json status in
-  let result = Room_eio.task_status_of_json json in
-  check bool "roundtrip ok" true (is_ok result)
-
-let test_room_eio_task_status_unknown () =
-  let json = `Assoc [("type", `String "unknown_type")] in
-  let result = Room_eio.task_status_of_json json in
-  check bool "is error" true (is_error result)
-
-(* ============================================================ *)
-(* Room_eio.task JSON Tests                                      *)
-(* ============================================================ *)
-
-let test_room_eio_task_roundtrip () =
-  let task = Room_eio.{
-    id = "task-123";
-    description = "Implement feature X";
-    status = InProgress "claude";
-    created_at = 1704067200.0;
-    updated_at = 1704070800.0;
-    priority = 2;
-    parent_task_id = None;
-    goal_id = None;
-    complexity_estimate = None;
-  } in
-  let json = Room_eio.task_to_json task in
-  let result = Room_eio.task_of_json json in
-  check bool "roundtrip ok" true (is_ok result)
-
-let test_room_eio_task_with_goal_metadata () =
-  let task = Room_eio.{
-    id = "task-456";
-    description = "Sub-task: implement login";
-    status = Pending;
-    created_at = 1704067200.0;
-    updated_at = 1704067200.0;
-    priority = 1;
-    parent_task_id = Some "task-123";
-    goal_id = Some "goal-auth";
-    complexity_estimate = Some { estimated_turns = 5; reversibility = 0.8 };
-  } in
-  let json = Room_eio.task_to_json task in
-  let result = Room_eio.task_of_json json in
-  match result with
-  | Ok t ->
-    check bool "parent preserved" true (t.parent_task_id = Some "task-123");
-    check bool "goal preserved" true (t.goal_id = Some "goal-auth");
-    check bool "complexity preserved" true
-      (match t.complexity_estimate with
-       | Some c -> c.estimated_turns = 5 && c.reversibility = 0.8
-       | None -> false)
-  | Error e -> fail (Printf.sprintf "unexpected error: %s" e)
-
-let test_room_eio_task_backward_compat () =
-  (* Old JSON without new fields should still parse *)
-  let old_json = `Assoc [
-    ("id", `String "task-old");
-    ("description", `String "legacy task");
-    ("status", `Assoc [("type", `String "pending")]);
-    ("created_at", `Float 1704067200.0);
-    ("updated_at", `Float 1704067200.0);
-    ("priority", `Int 1);
-  ] in
-  match Room_eio.task_of_json old_json with
-  | Ok t ->
-    check bool "parent is none" true (t.parent_task_id = None);
-    check bool "goal is none" true (t.goal_id = None);
-    check bool "complexity is none" true (t.complexity_estimate = None)
-  | Error e -> fail (Printf.sprintf "backward compat failed: %s" e)
 
 (* ============================================================ *)
 (* Test Suite                                                    *)
@@ -1117,20 +1021,6 @@ let room_eio_message_tests = [
   "message no mention", `Quick, test_room_eio_message_no_mention;
 ]
 
-let room_eio_task_status_tests = [
-  "pending", `Quick, test_room_eio_task_status_pending;
-  "in_progress", `Quick, test_room_eio_task_status_in_progress;
-  "completed", `Quick, test_room_eio_task_status_completed;
-  "failed", `Quick, test_room_eio_task_status_failed;
-  "unknown error", `Quick, test_room_eio_task_status_unknown;
-]
-
-let room_eio_task_tests = [
-  "task roundtrip", `Quick, test_room_eio_task_roundtrip;
-  "task with goal metadata", `Quick, test_room_eio_task_with_goal_metadata;
-  "task backward compat", `Quick, test_room_eio_task_backward_compat;
-]
-
 let () =
   run "Types & Utils Coverage" [
     "Agent_id", agent_id_tests;
@@ -1160,6 +1050,4 @@ let () =
     "Room_eio.agent", room_eio_agent_tests;
     "Room_eio.lock", room_eio_lock_tests;
     "Room_eio.message", room_eio_message_tests;
-    "Room_eio.task_status", room_eio_task_status_tests;
-    "Room_eio.task", room_eio_task_tests;
   ]


### PR DESCRIPTION
## Summary
- Room_eio task 인프라 전체 제거 (-461줄)
- production caller 0개 — 테스트에서만 참조
- Types_core.task_status가 canonical SSOT

## Removed
- Types: `task_status`, `complexity`, `task`
- Operations: `create_task`, `claim_task`, `complete_task`, `get_task`
- Serialization: 6개 to/of_json 함수
- Keys: `tasks_key`, `task_key`
- Event variants: `TaskClaim`, `TaskDone`
- Tests: 15개 테스트 케이스

## Test plan
- [x] `test_room_eio.exe` — 12 tests passed
- [x] `test_types_utils_coverage.exe` — 91 tests passed
- [x] `dune build` — clean
- [ ] CI Build + Test

Refs #5990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)