### PR TITLE
fix(ci): align OAS pin SHA and opam floor to 0.118.0

### DIFF
--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.117.0"}
+  "agent_sdk" {>= "0.118.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_TAG="v0.118.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="33397b8370cfd061ebc28e3327191163aac9e344"
+readonly OAS_AGENT_SDK_SHA="817295653d1c7f6403e0008b4e6e5b06f082211d"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.118.0"


### PR DESCRIPTION
## Summary
- Bump OAS pin SHA from 33397b8 to 8172956 (includes opam version fix)
- Bump masc_mcp.opam agent_sdk floor from 0.117.0 to 0.118.0
- Previous pin had dune-project at 0.118.0 but agent_sdk.opam at 0.117.0

## Root cause
OAS commit 33397b8 bumped dune-project version but did not regenerate
agent_sdk.opam. check-oas-pin.sh requires opam floor == MIN_VERSION,
making the floor bump mandatory, but opam resolver rejected >= 0.118.0
because the pinned package reported 0.117.0.

OAS HEAD (8172956) has the corrected opam file.

## Verification
- [x] `scripts/check-oas-pin.sh --local-only` passes
- [x] `dune build` with `OCAMLPARAM='_,warn-error=+a'` passes
- [x] `opam install . --deps-only` resolves agent_sdk 0.118.0
- [ ] CI Health + Build + Lint green

Closes #6046

Generated with [Claude Code](https://claude.com/claude-code)