### PR TITLE
fix: add idempotent check and positive-sense mutating predicate

### DIFF
--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -37,8 +37,15 @@ val keeper_read_only_tools : string list
 (** [true] when a keeper-only tool is inherently read-only. *)
 val is_keeper_read_only_tool : string -> bool
 
-(** Read-only classification with keeper-local fallback. *)
+(** [true] when [name] is read-only or idempotent (safe to retry).
+    Keeper-local fast-path (no mutex), then Tool_dispatch.is_read_only,
+    then Tool_dispatch.is_idempotent. Prefer {!has_mutating_side_effect}
+    at call sites for positive-sense readability. *)
 val is_effectively_read_only_tool : string -> bool
+
+(** [true] when calling [name] may produce non-idempotent side effects.
+    Used by the side-effect observer to block retry after committed mutations. *)
+val has_mutating_side_effect : string -> bool
 
 (** Schema for the keeper_tool_search tool. *)
 val keeper_tool_search_schema : Types.tool_schema

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -109,7 +109,14 @@ let is_keeper_read_only_tool (name : string) : bool =
   Hashtbl.mem keeper_read_only_set name
 
 let is_effectively_read_only_tool (name : string) : bool =
-  Tool_dispatch.is_read_only name || is_keeper_read_only_tool name
+  (* Keeper-local check first (bare Hashtbl, no mutex) before
+     Tool_dispatch (requires Eio.Mutex acquire). *)
+  is_keeper_read_only_tool name
+  || Tool_dispatch.is_read_only name
+  || Tool_dispatch.is_idempotent name
+
+let has_mutating_side_effect (name : string) : bool =
+  not (is_effectively_read_only_tool name)
 
 (* ── Boring tools (non-productive observation/polling) ─────── *)
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -65,7 +65,7 @@ let ambiguous_side_effect_error_prefix =
 let committed_mutating_tools tool_names =
   tool_names
   |> dedupe_keep_order
-  |> List.filter (fun name -> not (Keeper_exec_tools.is_effectively_read_only_tool name))
+  |> List.filter Keeper_exec_tools.has_mutating_side_effect
 
 let is_ambiguous_side_effect_error (err : Oas.Error.sdk_error) : bool =
   match err with
@@ -1002,7 +1002,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          with each other's save/restore lifecycle. *)
       let mutating_tools_committed = ref [] in
       let side_effect_observer ~tool_name ~success =
-        if success && not (Keeper_exec_tools.is_effectively_read_only_tool tool_name) then
+        if success && Keeper_exec_tools.has_mutating_side_effect tool_name then
           mutating_tools_committed := tool_name :: !mutating_tools_committed
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;


### PR DESCRIPTION
## Summary
/simplify 리뷰에서 발견된 3개 이슈 수정:

1. **`is_idempotent` 누락**: `is_effectively_read_only_tool`이 idempotent 도구를 미포함
2. **평가 순서**: mutex-free path를 먼저 체크
3. **이중 부정 제거**: `has_mutating_side_effect` positive-sense helper

## Test plan
- [x] `test_keeper_unified.exe` — 113 tests passed
- [x] `dune build` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)