### PR TITLE
Improve telemetry dashboard freshness

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -1,0 +1,122 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TelemetryResponse, TelemetrySummaryResponse } from '../api/dashboard'
+
+void vi
+
+const baseTelemetry: TelemetryResponse = {
+  generated_at: '2026-04-09T05:10:00Z',
+  count: 1,
+  entries: [
+    {
+      source: 'tool_metric',
+      ts: 1_775_709_000,
+      tool_name: 'mcp__masc__masc_status',
+      duration_ms: 42,
+      success: true,
+    },
+  ],
+}
+
+const baseSummary: TelemetrySummaryResponse = {
+  generated_at: '2026-04-09T05:10:00Z',
+  sources: [
+    {
+      source: 'tool_metric',
+      entry_count: 1,
+      keeper_count: 1,
+      exists: true,
+    },
+  ],
+  total_entries: 1,
+}
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    }
+  })
+}
+
+async function loadPanel(
+  fetchTelemetry: () => Promise<TelemetryResponse>,
+  fetchTelemetrySummary: () => Promise<TelemetrySummaryResponse>,
+) {
+  vi.resetModules()
+  vi.doMock('../api/dashboard', () => ({
+    fetchTelemetry,
+    fetchTelemetrySummary,
+  }))
+  return import('./telemetry-unified')
+}
+
+describe('TelemetryUnified', () => {
+  let container: HTMLDivElement
+  const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard')
+    vi.useRealTimers()
+    if (originalVisibility) {
+      Object.defineProperty(document, 'visibilityState', originalVisibility)
+    }
+  })
+
+  it('polls automatically after the initial load', async () => {
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(1)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(2)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders local and UTC snapshot metadata for operators', async () => {
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('Telemetry Stream')
+    expect(container.textContent).toContain('Auto 15s ON')
+    expect(container.textContent).toContain('Local')
+    expect(container.textContent).toContain('UTC')
+    expect(container.textContent).toContain('Latest Entries')
+    expect(container.textContent).toContain('mcp__masc__masc_status')
+  })
+})

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -226,6 +226,7 @@ function EntryRow({
         class="flex flex-wrap items-start gap-3 px-3 py-3 text-xs cursor-pointer select-none"
         role="button"
         tabIndex=${0}
+        aria-expanded=${expanded.value}
         onClick=${() => { expanded.value = !expanded.value }}
         onKeyDown=${(event: KeyboardEvent) => {
           if (event.key === 'Enter' || event.key === ' ') {

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -5,12 +5,42 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchTelemetry, fetchTelemetrySummary } from '../api/dashboard'
+import { FetchScheduler } from '../lib/fetch-scheduler'
 import { formatTimeAgo } from '../lib/format-time'
 import type {
   TelemetryEntry,
   TelemetrySource,
   TelemetrySourceSummary,
 } from '../api/dashboard'
+
+const TELEMETRY_AUTO_REFRESH_MS = 15_000
+const TELEMETRY_CLOCK_TICK_MS = 5_000
+const TELEMETRY_SNAPSHOT_STALE_MS = 45_000
+const TELEMETRY_FILTER_DEBOUNCE_MS = 250
+const TELEMETRY_REFRESH_COOLDOWN_MS = 5_000
+
+const LOCAL_TS_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+  timeZoneName: 'short',
+})
+
+const UTC_TS_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+  timeZone: 'UTC',
+  timeZoneName: 'short',
+})
 
 // ── Source labels & colors ───────────────────────────
 
@@ -28,125 +58,233 @@ function sourceMeta(source: string) {
 
 // ── Timestamp formatting ─────────────────────────────
 
-function entryTimestamp(e: TelemetryEntry): number {
-  return (e.ts_unix as number) ?? (e.ts as number) ?? (e.timestamp as number) ?? 0
+function timestampToMs(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return null
+    return value < 1_000_000_000_000 ? value * 1000 : value
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
 }
 
-function formatTs(ts: number): string {
-  if (ts === 0) return '-'
-  const d = new Date(ts * 1000)
-  return d.toLocaleString('ko-KR', {
-    month: '2-digit', day: '2-digit',
-    hour: '2-digit', minute: '2-digit', second: '2-digit',
-  })
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  return timestampToMs(
+    (entry.ts_unix as number | undefined)
+    ?? (entry.ts as number | undefined)
+    ?? (entry.timestamp as number | undefined),
+  )
 }
 
-function timeAgo(ts: number): string {
-  if (ts === 0) return ''
-  return formatTimeAgo(ts)
+function oldestTimestampMs(...timestamps: Array<string | null | undefined>): number | null {
+  const values = timestamps
+    .map(timestamp => timestampToMs(timestamp))
+    .filter((value): value is number => value != null)
+  if (values.length === 0) return null
+  return Math.min(...values)
+}
+
+function formatLocalTimestamp(ms: number | null): string {
+  return ms == null ? 'time n/a' : LOCAL_TS_FORMATTER.format(ms)
+}
+
+function formatUtcTimestamp(ms: number | null): string {
+  return ms == null ? 'time n/a' : UTC_TS_FORMATTER.format(ms)
+}
+
+function snapshotTone(ageMs: number | null): { label: string; className: string } {
+  if (ageMs == null) {
+    return {
+      label: 'snapshot unavailable',
+      className: 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]',
+    }
+  }
+  if (ageMs <= TELEMETRY_AUTO_REFRESH_MS) {
+    return {
+      label: 'live snapshot',
+      className: 'border-emerald-400/25 bg-emerald-500/12 text-emerald-100',
+    }
+  }
+  if (ageMs <= TELEMETRY_SNAPSHOT_STALE_MS) {
+    return {
+      label: 'recent snapshot',
+      className: 'border-sky-400/25 bg-sky-500/12 text-sky-100',
+    }
+  }
+  return {
+    label: 'stale snapshot',
+    className: 'border-amber-400/30 bg-amber-500/12 text-amber-100',
+  }
+}
+
+function entryAgeTone(ageMs: number | null): string {
+  if (ageMs == null) return 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)]'
+  if (ageMs <= 15_000) return 'border-emerald-400/25 bg-emerald-500/12 text-emerald-100'
+  if (ageMs <= 60_000) return 'border-sky-400/25 bg-sky-500/12 text-sky-100'
+  if (ageMs <= 300_000) return 'border-amber-400/30 bg-amber-500/12 text-amber-100'
+  return 'border-rose-400/30 bg-rose-500/12 text-rose-100'
+}
+
+function isDocumentVisible(): boolean {
+  return document.visibilityState !== 'hidden'
 }
 
 // ── Summary card ─────────────────────────────────────
 
-function SummaryCard({ src }: { src: TelemetrySourceSummary }) {
+function SummaryCard({
+  src,
+  totalEntries,
+}: {
+  src: TelemetrySourceSummary
+  totalEntries: number
+}) {
   const meta = sourceMeta(src.source)
   const hasData = src.entry_count > 0
+  const sharePct = totalEntries > 0 ? Math.round((src.entry_count / totalEntries) * 100) : 0
 
   return html`
-    <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
-      <div class="flex items-center gap-2 mb-1">
-        <span class="font-mono font-bold ${meta.color}">${meta.icon}</span>
-        <span class="text-xs font-medium text-[var(--text-strong)]">${meta.label}</span>
+    <div class="min-w-[170px] rounded-xl border border-[var(--card-border)] bg-[rgba(255,255,255,0.03)] p-3 shadow-sm shadow-black/10">
+      <div class="mb-2 flex items-center gap-2">
+        <span class="inline-flex h-6 w-6 items-center justify-center rounded-lg border border-[var(--white-8)] bg-[rgba(255,255,255,0.04)] font-mono text-[11px] font-bold ${meta.color}">
+          ${meta.icon}
+        </span>
+        <div class="min-w-0">
+          <div class="text-[12px] font-medium text-[var(--text-strong)]">${meta.label}</div>
+          <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-dim)]">${src.source}</div>
+        </div>
       </div>
-      <div class="text-2xl font-bold ${hasData ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
+      <div class="text-[28px] font-semibold leading-none ${hasData ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'}">
         ${src.entry_count.toLocaleString()}
       </div>
-      ${src.keeper_count != null ? html`
-        <div class="text-xs text-[var(--text-muted)]">${src.keeper_count} keepers</div>
-      ` : null}
-      ${src.exists === false ? html`
-        <div class="text-xs text-[var(--text-muted)] italic">store not found</div>
-      ` : null}
+      <div class="mt-2 flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-muted)]">
+        ${src.keeper_count != null ? html`<span>${src.keeper_count} keepers</span>` : null}
+        ${hasData ? html`<span>${sharePct}% share</span>` : null}
+        ${src.exists === false ? html`<span class="italic">store missing</span>` : null}
+      </div>
     </div>
   `
 }
 
 // ── Entry row ────────────────────────────────────────
 
-function entryPreview(e: TelemetryEntry): string {
-  // Show key identifying fields based on source
-  switch (e.source) {
+function entryPreview(entry: TelemetryEntry): string {
+  switch (entry.source) {
     case 'keeper_metric': {
-      const name = e.name as string ?? ''
-      const channel = e.channel as string ?? ''
-      const model = e.model_used as string ?? ''
-      const tools = (e.tools_used as string[]) ?? []
-      const toolCount = e.tool_call_count as number ?? tools.length
+      const name = entry.name as string ?? ''
+      const channel = entry.channel as string ?? ''
+      const model = entry.model_used as string ?? ''
+      const tools = (entry.tools_used as string[]) ?? []
+      const toolCount = entry.tool_call_count as number ?? tools.length
       return `${name} [${channel}] model=${model} tools=${toolCount}`
     }
     case 'agent_event': {
-      const event = e.event
+      const event = entry.event
       if (Array.isArray(event)) return `${event[0] ?? 'unknown'}`
       return String(event ?? '')
     }
     case 'tool_call_io': {
-      const tool = e.tool as string ?? ''
-      const keeper = e.keeper as string ?? ''
+      const tool = entry.tool as string ?? ''
+      const keeper = entry.keeper as string ?? ''
       return `${keeper} -> ${tool}`
     }
     case 'tool_usage': {
-      const tool = e.tool_name as string ?? ''
-      const caller = e.caller as string ?? ''
+      const tool = entry.tool_name as string ?? ''
+      const caller = entry.caller as string ?? ''
       return `${caller || 'unknown'} -> ${tool}`
     }
     case 'tool_metric': {
-      const tool = e.tool_name as string ?? ''
-      const dur = e.duration_ms as number
-      return `${tool} ${dur != null ? dur.toFixed(0) + 'ms' : ''}`
+      const tool = entry.tool_name as string ?? ''
+      const dur = entry.duration_ms as number
+      return `${tool} ${dur != null ? `${dur.toFixed(0)}ms` : ''}`.trim()
     }
     default:
-      return JSON.stringify(e).slice(0, 80)
+      return JSON.stringify(entry).slice(0, 120)
   }
 }
 
-function EntryRow({ entry }: { entry: TelemetryEntry }) {
+function EntryRow({
+  entry,
+  nowMs,
+}: {
+  entry: TelemetryEntry
+  nowMs: number
+}) {
   const expanded = useSignal(false)
   const meta = sourceMeta(entry.source)
-  const ts = entryTimestamp(entry)
+  const tsMs = entryTimestampMs(entry)
   const success = entry.success as boolean | undefined
+  const ageMs = tsMs == null ? null : Math.max(0, nowMs - tsMs)
+  const ageLabel = tsMs == null ? 'time n/a' : formatTimeAgo(tsMs)
+  const localTs = formatLocalTimestamp(tsMs)
+  const utcTs = formatUtcTimestamp(tsMs)
 
   return html`
-    <div class="border-b border-[var(--card-border)] hover:bg-[var(--bg-panel-hover)] transition-colors">
+    <div class="border-b border-[var(--card-border)] last:border-b-0 hover:bg-[rgba(255,255,255,0.02)] transition-colors">
       <div
-        class="flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer select-none"
+        class="flex flex-wrap items-start gap-3 px-3 py-3 text-xs cursor-pointer select-none"
         role="button"
         tabIndex=${0}
         onClick=${() => { expanded.value = !expanded.value }}
-        onKeyDown=${(e: KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault()
+        onKeyDown=${(event: KeyboardEvent) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
             expanded.value = !expanded.value
           }
         }}
       >
-        <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
-        <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
-          ${timeAgo(ts)}
-        </span>
-        ${success != null ? html`
-          <span class="flex-shrink-0 w-4 ${success ? 'text-green-400' : 'text-red-400'}">
-            ${success ? 'O' : 'X'}
+        <div class="flex items-center gap-2 min-w-[96px]">
+          <span class="inline-flex h-7 w-7 items-center justify-center rounded-lg border border-[var(--white-8)] bg-[rgba(255,255,255,0.04)] font-mono text-[11px] font-bold ${meta.color}">
+            ${meta.icon}
           </span>
-        ` : html`<span class="w-4"></span>`}
-        <span class="font-mono text-[var(--text-strong)] truncate flex-1" title=${entryPreview(entry)}>
-          ${entryPreview(entry)}
-        </span>
-        <span class="flex-shrink-0 w-4 text-[var(--text-muted)]">${expanded.value ? '-' : '+'}</span>
+          <div class="min-w-0">
+            <div class="text-[11px] font-medium text-[var(--text-strong)]">${meta.label}</div>
+            <div class="text-[10px] uppercase tracking-[0.18em] text-[var(--text-dim)]">${entry.source}</div>
+          </div>
+        </div>
+
+        <div class="min-w-[108px]">
+          <div class=${`inline-flex rounded-full border px-2 py-1 text-[11px] font-medium ${entryAgeTone(ageMs)}`}>
+            ${ageLabel}
+          </div>
+          <div class="mt-1 text-[10px] text-[var(--text-dim)]">
+            ${success == null ? 'status n/a' : success ? 'success' : 'failure'}
+          </div>
+        </div>
+
+        <div class="min-w-[220px] font-mono text-[10px] leading-5 text-[var(--text-muted)]">
+          <div><span class="text-[var(--text-dim)]">Local</span> ${localTs}</div>
+          <div><span class="text-[var(--text-dim)]">UTC</span> ${utcTs}</div>
+        </div>
+
+        <div class="min-w-[260px] flex-1">
+          <div class="flex flex-wrap items-center gap-2">
+            ${success != null
+              ? html`
+                  <span class=${`inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] ${
+                    success
+                      ? 'border-emerald-400/25 bg-emerald-500/12 text-emerald-100'
+                      : 'border-rose-400/30 bg-rose-500/12 text-rose-100'
+                  }`}>
+                    ${success ? 'ok' : 'error'}
+                  </span>
+                `
+              : null}
+            <span class="inline-flex rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.03)] px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-[var(--text-muted)]">
+              ${expanded.value ? 'expanded' : 'collapsed'}
+            </span>
+          </div>
+          <div class="mt-1 font-mono text-[12px] leading-relaxed text-[var(--text-strong)] break-all" title=${entryPreview(entry)}>
+            ${entryPreview(entry)}
+          </div>
+        </div>
+
+        <div class="ml-auto text-[16px] leading-none text-[var(--text-dim)]">${expanded.value ? '−' : '+'}</div>
       </div>
       ${expanded.value ? html`
-        <div class="px-3 pb-2">
-          <pre class="text-[10px] font-mono text-[var(--text-muted)] bg-[rgba(0,0,0,0.3)] rounded p-2 overflow-x-auto max-h-[300px] overflow-y-auto whitespace-pre-wrap break-all">
-${JSON.stringify(entry, null, 2)}</pre>
+        <div class="px-3 pb-3">
+          <pre class="max-h-[320px] overflow-auto whitespace-pre-wrap break-all rounded-xl border border-[var(--white-8)] bg-[rgba(0,0,0,0.32)] p-3 text-[10px] font-mono text-[var(--text-muted)]">${JSON.stringify(entry, null, 2)}</pre>
         </div>
       ` : null}
     </div>
@@ -159,6 +297,9 @@ interface TelemetryState {
   entries: TelemetryEntry[]
   summary: TelemetrySourceSummary[]
   totalEntries: number
+  telemetryGeneratedAt: string | null
+  summaryGeneratedAt: string | null
+  lastLoadedAtMs: number | null
   loading: boolean
   error: string | null
 }
@@ -168,12 +309,17 @@ export function TelemetryUnified() {
     entries: [],
     summary: [],
     totalEntries: 0,
+    telemetryGeneratedAt: null,
+    summaryGeneratedAt: null,
+    lastLoadedAtMs: null,
     loading: true,
     error: null,
   })
   const sourceFilter = useSignal<TelemetrySource | ''>('')
   const keeperFilter = useSignal('')
   const limit = useSignal(100)
+  const autoRefresh = useSignal(true)
+  const now = useSignal(Date.now())
 
   async function load() {
     state.value = { ...state.value, loading: true, error: null }
@@ -190,93 +336,205 @@ export function TelemetryUnified() {
         entries: telemetry.entries,
         summary: summary.sources,
         totalEntries: summary.total_entries,
+        telemetryGeneratedAt: telemetry.generated_at ?? null,
+        summaryGeneratedAt: summary.generated_at ?? null,
+        lastLoadedAtMs: Date.now(),
         loading: false,
         error: null,
       }
-    } catch (e) {
+    } catch (error) {
       state.value = {
         ...state.value,
         loading: false,
-        error: e instanceof Error ? e.message : String(e),
+        error: error instanceof Error ? error.message : String(error),
       }
     }
   }
 
-  useEffect(() => { void load() }, [sourceFilter.value, keeperFilter.value, limit.value])
+  useEffect(() => {
+    now.value = Date.now()
+    const id = window.setInterval(() => { now.value = Date.now() }, TELEMETRY_CLOCK_TICK_MS)
+    return () => window.clearInterval(id)
+  }, [])
 
-  const { entries, summary, totalEntries, loading, error } = state.value
+  useEffect(() => {
+    const scheduler = new FetchScheduler(
+      () => load(),
+      {
+        cooldownMs: TELEMETRY_REFRESH_COOLDOWN_MS,
+        debounceMs: TELEMETRY_FILTER_DEBOUNCE_MS,
+      },
+    )
+
+    scheduler.requestNow()
+
+    const intervalId = window.setInterval(() => {
+      if (!autoRefresh.value || !isDocumentVisible()) return
+      scheduler.requestNow()
+    }, TELEMETRY_AUTO_REFRESH_MS)
+
+    const handleVisibilityChange = () => {
+      if (!autoRefresh.value || !isDocumentVisible()) return
+      scheduler.requestNow()
+    }
+
+    const handleWindowFocus = () => {
+      if (!autoRefresh.value) return
+      scheduler.request()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('focus', handleWindowFocus)
+
+    return () => {
+      window.clearInterval(intervalId)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('focus', handleWindowFocus)
+      scheduler.dispose()
+    }
+  }, [sourceFilter.value, keeperFilter.value, limit.value, autoRefresh.value])
+
+  const {
+    entries,
+    summary,
+    totalEntries,
+    telemetryGeneratedAt,
+    summaryGeneratedAt,
+    lastLoadedAtMs,
+    loading,
+    error,
+  } = state.value
+
+  const snapshotMs = oldestTimestampMs(telemetryGeneratedAt, summaryGeneratedAt)
+  const snapshotAgeMs = snapshotMs == null ? null : Math.max(0, now.value - snapshotMs)
+  const freshness = snapshotTone(snapshotAgeMs)
 
   return html`
     <div class="flex flex-col gap-4">
-      <!-- Summary cards -->
-      <div class="flex flex-wrap gap-3">
-        ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
-        <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
-          <div class="text-xs font-medium text-[var(--text-muted)] mb-1">Total</div>
-          <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
+      <section class="rounded-2xl border border-[var(--card-border)] bg-[linear-gradient(180deg,rgba(15,23,42,0.84),rgba(8,12,22,0.96))] p-4 shadow-lg shadow-black/12">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-0">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--text-dim)]">Telemetry Stream</div>
+            <div class="mt-1 text-[15px] font-medium text-[var(--text-strong)]">자동 갱신 + 상대시간 + 정확한 시각을 함께 보여줍니다.</div>
+            <div class="mt-1 text-[12px] text-[var(--text-muted)]">
+              탭이 보일 때는 ${Math.round(TELEMETRY_AUTO_REFRESH_MS / 1000)}초 간격으로 polling 하고, 다시 포커스되면 즉시 동기화합니다.
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              class=${`rounded-full border px-3 py-1.5 text-[11px] font-medium transition-colors ${
+                autoRefresh.value
+                  ? 'border-emerald-400/25 bg-emerald-500/12 text-emerald-100'
+                  : 'border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] text-[var(--text-muted)]'
+              }`}
+              onClick=${() => { autoRefresh.value = !autoRefresh.value }}
+            >
+              Auto ${Math.round(TELEMETRY_AUTO_REFRESH_MS / 1000)}s ${autoRefresh.value ? 'ON' : 'OFF'}
+            </button>
+            <button
+              class="rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-1.5 text-[11px] font-medium text-[var(--text-strong)] transition-colors hover:bg-[rgba(255,255,255,0.08)]"
+              onClick=${() => { void load() }}
+            >
+              ${loading ? 'Syncing...' : 'Refresh now'}
+            </button>
+          </div>
         </div>
-      </div>
 
-      <!-- Filters -->
-      <div class="flex items-center gap-3 flex-wrap">
-        <select
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
-          value=${sourceFilter.value}
-          onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
-        >
-          <option value="">All sources</option>
-          ${Object.entries(SOURCE_META).map(([key, m]) => html`
-            <option value=${key}>${m.label}</option>
-          `)}
-        </select>
-        <input
-          type="text"
-          placeholder="Keeper name..."
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-32"
-          value=${keeperFilter.value}
-          onInput=${(e: Event) => { keeperFilter.value = (e.target as HTMLInputElement).value }}
-        />
-        <select
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
-          value=${String(limit.value)}
-          onChange=${(e: Event) => { limit.value = Number((e.target as HTMLSelectElement).value) }}
-        >
-          <option value="50">50</option>
-          <option value="100">100</option>
-          <option value="200">200</option>
-          <option value="500">500</option>
-        </select>
-        <button
-          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
-          onClick=${() => void load()}
-        >
-          Refresh
-        </button>
-        ${loading ? html`<span class="text-xs text-[var(--text-muted)]">loading...</span>` : null}
-      </div>
+        <div class="mt-4 flex flex-wrap gap-2 text-[11px]">
+          <span class=${`rounded-full border px-2.5 py-1 ${freshness.className}`}>
+            ${freshness.label} ${snapshotMs == null ? '' : `· ${formatTimeAgo(snapshotMs)}`}
+          </span>
+          ${lastLoadedAtMs != null ? html`
+            <span class="rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 text-[var(--text-muted)]">
+              last fetch ${formatTimeAgo(lastLoadedAtMs)}
+            </span>
+          ` : null}
+          ${snapshotMs != null ? html`
+            <span class="rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 font-mono text-[var(--text-muted)]">
+              Local ${formatLocalTimestamp(snapshotMs)}
+            </span>
+          ` : null}
+          ${snapshotMs != null ? html`
+            <span class="rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 font-mono text-[var(--text-muted)]">
+              UTC ${formatUtcTimestamp(snapshotMs)}
+            </span>
+          ` : null}
+          <span class="rounded-full border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-2.5 py-1 text-[var(--text-muted)]">
+            showing ${entries.length} / ${limit.value}
+          </span>
+        </div>
+      </section>
 
-      <!-- Error -->
+      <section class="rounded-2xl border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3">
+        <div class="flex flex-wrap items-center gap-3">
+          <select
+            class="rounded-lg border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 text-xs text-[var(--text-strong)]"
+            value=${sourceFilter.value}
+            onChange=${(event: Event) => { sourceFilter.value = (event.target as HTMLSelectElement).value as TelemetrySource | '' }}
+          >
+            <option value="">All sources</option>
+            ${Object.entries(SOURCE_META).map(([key, meta]) => html`
+              <option value=${key}>${meta.label}</option>
+            `)}
+          </select>
+          <input
+            type="text"
+            placeholder="Keeper name..."
+            class="w-36 rounded-lg border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 text-xs text-[var(--text-strong)]"
+            value=${keeperFilter.value}
+            onInput=${(event: Event) => { keeperFilter.value = (event.target as HTMLInputElement).value }}
+          />
+          <select
+            class="rounded-lg border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-2 text-xs text-[var(--text-strong)]"
+            value=${String(limit.value)}
+            onChange=${(event: Event) => { limit.value = Number((event.target as HTMLSelectElement).value) }}
+          >
+            <option value="50">50 rows</option>
+            <option value="100">100 rows</option>
+            <option value="200">200 rows</option>
+            <option value="500">500 rows</option>
+          </select>
+          <span class="text-[11px] text-[var(--text-dim)]">
+            hidden tab에서는 polling을 멈추고, 다시 보이면 바로 새로고침합니다.
+          </span>
+        </div>
+      </section>
+
+      ${summary.length > 0 || totalEntries > 0 ? html`
+        <section class="flex flex-wrap gap-3">
+          ${summary.map(src => html`<${SummaryCard} src=${src} totalEntries=${totalEntries} />`)}
+          <div class="min-w-[170px] rounded-xl border border-[var(--card-border)] bg-[rgba(255,255,255,0.03)] p-3 shadow-sm shadow-black/10">
+            <div class="text-[12px] font-medium text-[var(--text-muted)]">Total</div>
+            <div class="mt-2 text-[28px] font-semibold leading-none text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
+            <div class="mt-2 text-[10px] text-[var(--text-muted)]">all telemetry sources</div>
+          </div>
+        </section>
+      ` : null}
+
       ${error ? html`
-        <div class="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+        <div class="rounded-xl border border-rose-500/25 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
           ${error}
         </div>
       ` : null}
 
-      <!-- Entry list -->
-      <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] overflow-hidden">
-        <div class="flex items-center gap-2 px-3 py-2 text-[10px] uppercase tracking-wider text-[var(--text-muted)] border-b border-[var(--card-border)] bg-[rgba(0,0,0,0.2)]">
-          <span class="w-4">Src</span>
-          <span class="w-28">Time</span>
-          <span class="w-4">Ok</span>
-          <span class="flex-1">Detail</span>
+      <section class="overflow-hidden rounded-2xl border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)]">
+        <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--card-border)] bg-[rgba(0,0,0,0.22)] px-3 py-2">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--text-dim)]">Latest Entries</div>
+          <div class="text-[11px] text-[var(--text-muted)]">${loading ? 'syncing telemetry…' : `${entries.length} rows loaded`}</div>
         </div>
         ${entries.length === 0 && !loading ? html`
-          <div class="px-3 py-8 text-center text-xs text-[var(--text-muted)]">
+          <div class="px-3 py-10 text-center text-xs text-[var(--text-muted)]">
             No telemetry entries found
           </div>
         ` : null}
-        ${entries.map(entry => html`<${EntryRow} key=${JSON.stringify(entry).slice(0, 50)} entry=${entry} />`)}
-      </div>
+        ${entries.map(entry => html`
+          <${EntryRow}
+            key=${JSON.stringify(entry).slice(0, 120)}
+            entry=${entry}
+            nowMs=${now.value}
+          />
+        `)}
+      </section>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- add automatic refresh to the telemetry dashboard with focus/visibility-aware polling
- show clearer freshness metadata with relative time plus Local and UTC timestamps
- improve telemetry entry readability and add regression tests for polling and timestamp metadata

## Product impact
- operators can trust the telemetry tab without manual refresh spam
- relative age is now paired with exact Local and UTC timestamps for faster debugging
- telemetry rows and summary cards are easier to scan when triaging freshness or stale-state questions

## Evidence
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/vitest run --no-file-parallelism --maxWorkers=1 src/components/telemetry-unified.test.ts`

## Review evidence
- `GLM-5.1` via direct `sb glm-text`
- reviewed at `2026-04-09T03:26:49Z`
- no blocking findings; patched follow-up accessibility nit (`aria-expanded`)

## Linked issue
- Refs #5924
