### PR TITLE
fix(dashboard): strip error prefix before JSON categorization

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -5,6 +5,29 @@
 
     @since 2.260.0 *)
 
+(** Classify a failed tool call output string into an error category.
+    Strips known prefixes ("error: ", "tool_error: ") before JSON parsing
+    so prefixed outputs like ["error: {\"ok\":false,\"error\":\"msg\"}"]
+    yield the actual error key instead of "parse_error". *)
+let classify_failure_output (output : string) : string =
+  if String.length output = 0 then "empty_output"
+  else
+    let json_str =
+      let prefixes = ["error: "; "tool_error: "] in
+      match List.find_opt (fun p ->
+        String.length output > String.length p
+        && String.sub output 0 (String.length p) = p
+      ) prefixes with
+      | Some p -> String.sub output (String.length p)
+                    (String.length output - String.length p)
+      | None -> output
+    in
+    match Yojson.Safe.from_string json_str with
+    | j ->
+      Safe_ops.json_string_opt "error" j
+      |> Option.value ~default:"unknown_error"
+    | exception Yojson.Json_error _ -> "parse_error"
+
 let aggregate ?(n = 5000) () : Yojson.Safe.t =
   let records = Keeper_tool_call_log.read_recent ~n () in
   if records = [] then
@@ -107,15 +130,7 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
         Safe_ops.json_string_opt "output" record
         |> Option.value ~default:""
       in
-      let cat =
-        if String.length output > 0 then
-          (* Extract error key from JSON output *)
-          (match Yojson.Safe.from_string output with
-           | j ->
-             Safe_ops.json_string_opt "error" j
-             |> Option.value ~default:"unknown_error"
-           | exception Yojson.Json_error _ -> "parse_error")
-        else "empty_output"
+      let cat = classify_failure_output output
       in
       let r = match Hashtbl.find_opt failure_cats cat with
         | Some r -> r

--- a/specs/bug-models/AmbiguousPartialCommit.cfg
+++ b/specs/bug-models/AmbiguousPartialCommit.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxToolCalls = 3
+    MaxRetries = 2
+
+INVARIANT TypeOK
+INVARIANT Safety

--- a/specs/bug-models/AmbiguousPartialCommit.tla
+++ b/specs/bug-models/AmbiguousPartialCommit.tla
@@ -1,0 +1,124 @@
+---- MODULE AmbiguousPartialCommit ----
+\* Models the keeper unified turn lifecycle where tool calls can commit
+\* side-effects before the LLM response completes. A timeout after
+\* committed mutations creates an "ambiguous partial commit" state.
+\*
+\* Safety property: MutationsNeverOrphan ensures that if mutations are
+\* committed, the turn either succeeds or enters manual_reconcile —
+\* never silently retried (which would cause duplicate mutations).
+\*
+\* Evidence: sangsu keeper, 2026-04-09. Timeout after 573.2s with
+\* committed [keeper_board_post, keeper_board_comment, keeper_task_claim].
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxToolCalls,   \* max tool calls per turn (e.g. 10)
+    MaxRetries      \* max transient retries (e.g. 2)
+
+VARIABLES
+    turn_phase,           \* "init" | "running" | "completed" | "failed" | "reconcile"
+    tool_calls_made,      \* count of tool calls executed
+    mutating_committed,   \* count of committed mutating tool calls
+    retry_count,          \* current retry attempt
+    provider_error,       \* "none" | "timeout" | "rate_limit" | "internal"
+    retry_performed       \* whether a retry was actually executed
+
+vars == <<turn_phase, tool_calls_made, mutating_committed,
+          retry_count, provider_error, retry_performed>>
+
+TypeOK ==
+    /\ turn_phase \in {"init", "running", "completed", "failed", "reconcile"}
+    /\ tool_calls_made \in 0..MaxToolCalls
+    /\ mutating_committed \in 0..MaxToolCalls
+    /\ retry_count \in 0..MaxRetries
+    /\ provider_error \in {"none", "timeout", "rate_limit", "internal"}
+    /\ retry_performed \in BOOLEAN
+
+Init ==
+    /\ turn_phase = "init"
+    /\ tool_calls_made = 0
+    /\ mutating_committed = 0
+    /\ retry_count = 0
+    /\ provider_error = "none"
+    /\ retry_performed = FALSE
+
+\* ── Actions ─────────────────────────────────────────────────
+
+StartTurn ==
+    /\ turn_phase = "init"
+    /\ turn_phase' = "running"
+    /\ UNCHANGED <<tool_calls_made, mutating_committed, retry_count,
+                    provider_error, retry_performed>>
+
+\* Execute a read-only tool call (no side effect)
+ReadOnlyToolCall ==
+    /\ turn_phase = "running"
+    /\ tool_calls_made < MaxToolCalls
+    /\ tool_calls_made' = tool_calls_made + 1
+    /\ UNCHANGED <<turn_phase, mutating_committed, retry_count,
+                    provider_error, retry_performed>>
+
+\* Execute a mutating tool call (commits side effect)
+MutatingToolCall ==
+    /\ turn_phase = "running"
+    /\ tool_calls_made < MaxToolCalls
+    /\ tool_calls_made' = tool_calls_made + 1
+    /\ mutating_committed' = mutating_committed + 1
+    /\ UNCHANGED <<turn_phase, retry_count, provider_error, retry_performed>>
+
+\* Turn completes successfully
+TurnSuccess ==
+    /\ turn_phase = "running"
+    /\ turn_phase' = "completed"
+    /\ provider_error' = "none"
+    /\ UNCHANGED <<tool_calls_made, mutating_committed, retry_count,
+                    retry_performed>>
+
+\* Provider error occurs (timeout, rate limit, etc.)
+ProviderError ==
+    /\ turn_phase = "running"
+    /\ provider_error' \in {"timeout", "rate_limit", "internal"}
+    /\ IF mutating_committed > 0
+       THEN \* Ambiguous partial commit — go to reconcile, no retry
+            /\ turn_phase' = "reconcile"
+            /\ UNCHANGED <<tool_calls_made, retry_count, retry_performed>>
+       ELSE IF retry_count < MaxRetries /\ provider_error' \in {"timeout", "rate_limit"}
+            THEN \* Transient error, no mutations — safe to retry
+                 /\ turn_phase' = "running"
+                 /\ retry_count' = retry_count + 1
+                 /\ retry_performed' = TRUE
+                 /\ tool_calls_made' = 0  \* reset for retry
+            ELSE \* Non-retryable or retries exhausted
+                 /\ turn_phase' = "failed"
+                 /\ UNCHANGED <<tool_calls_made, retry_count, retry_performed>>
+    /\ UNCHANGED mutating_committed
+
+\* ── Spec ────────────────────────────────────────────────────
+
+\* Terminal states stutter (prevent TLC deadlock detection)
+Done ==
+    /\ turn_phase \in {"completed", "failed", "reconcile"}
+    /\ UNCHANGED vars
+
+Next ==
+    \/ StartTurn
+    \/ ReadOnlyToolCall
+    \/ MutatingToolCall
+    \/ TurnSuccess
+    \/ ProviderError
+    \/ Done
+
+Spec == Init /\ [][Next]_vars
+
+\* ── Safety Properties ───────────────────────────────────────
+
+\* Committed mutations + error must go to reconcile, never to failed.
+\* "failed" with committed mutations means mutations were lost without notice.
+MutationsNeverOrphan ==
+    ~(turn_phase = "failed" /\ mutating_committed > 0)
+
+\* Combined safety invariant.
+Safety == MutationsNeverOrphan
+
+====

--- a/specs/bug-models/AmbiguousPartialCommitBug-buggy.cfg
+++ b/specs/bug-models/AmbiguousPartialCommitBug-buggy.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxToolCalls = 3
+    MaxRetries = 2
+
+INVARIANT TypeOK
+INVARIANT Safety

--- a/specs/bug-models/AmbiguousPartialCommitBug.tla
+++ b/specs/bug-models/AmbiguousPartialCommitBug.tla
@@ -1,0 +1,70 @@
+---- MODULE AmbiguousPartialCommitBug ----
+\* Bug model: retry IGNORES committed mutations.
+\* This simulates the pre-fix behavior where a transient error after
+\* mutating tool calls would still trigger retry, causing duplicate
+\* mutations.
+\*
+\* Expected: TLC finds Safety invariant violation.
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxToolCalls,
+    MaxRetries
+
+VARIABLES
+    turn_phase,
+    tool_calls_made,
+    mutating_committed,
+    retry_count,
+    provider_error,
+    retry_performed
+
+vars == <<turn_phase, tool_calls_made, mutating_committed,
+          retry_count, provider_error, retry_performed>>
+
+Clean == INSTANCE AmbiguousPartialCommit
+
+TypeOK == Clean!TypeOK
+
+Init == Clean!Init
+
+StartTurn == Clean!StartTurn
+ReadOnlyToolCall == Clean!ReadOnlyToolCall
+MutatingToolCall == Clean!MutatingToolCall
+TurnSuccess == Clean!TurnSuccess
+
+\* BUG: ProviderError retries even when mutations are committed.
+\* The clean version goes to "reconcile" when mutating_committed > 0.
+\* This buggy version ignores mutations and retries anyway.
+BugProviderError ==
+    /\ turn_phase = "running"
+    /\ provider_error' \in {"timeout", "rate_limit", "internal"}
+    /\ IF retry_count < MaxRetries /\ provider_error' \in {"timeout", "rate_limit"}
+       THEN \* BUG: retries regardless of committed mutations
+            /\ turn_phase' = "running"
+            /\ retry_count' = retry_count + 1
+            /\ retry_performed' = TRUE
+            /\ tool_calls_made' = 0
+       ELSE
+            /\ turn_phase' = "failed"
+            /\ UNCHANGED <<tool_calls_made, retry_count, retry_performed>>
+    /\ UNCHANGED mutating_committed
+
+Done == Clean!Done
+
+NextBuggy ==
+    \/ StartTurn
+    \/ ReadOnlyToolCall
+    \/ MutatingToolCall
+    \/ TurnSuccess
+    \/ BugProviderError
+    \/ Done
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* Same safety property — should be VIOLATED by the buggy model.
+MutationsNeverOrphan == Clean!MutationsNeverOrphan
+Safety == MutationsNeverOrphan
+
+====

--- a/test/dune
+++ b/test/dune
@@ -223,6 +223,7 @@
         test_dashboard_harness_health
         test_dashboard_repo_synthesis
         test_dashboard_tools
+        test_tool_quality_classify
         test_tui_decode
         test_dashboard_governance
         test_dashboard_labels
@@ -365,6 +366,7 @@
         test_dashboard_harness_health
         test_dashboard_repo_synthesis
         test_dashboard_tools
+        test_tool_quality_classify
         test_tui_decode
         test_dashboard_governance
         test_dashboard_labels

--- a/test/test_tool_quality_classify.ml
+++ b/test/test_tool_quality_classify.ml
@@ -1,0 +1,55 @@
+(** Unit tests for Dashboard_http_tool_quality.classify_failure_output.
+
+    Verifies that error category classification correctly strips known
+    prefixes and extracts the actual error key from JSON output. *)
+
+open Alcotest
+
+let classify = Masc_mcp.Dashboard_http_tool_quality.classify_failure_output
+
+let test_bare_json_error () =
+  let output = {|{"ok":false,"error":"Invalid task state"}|} in
+  check string "bare JSON extracts error key"
+    "Invalid task state" (classify output)
+
+let test_error_prefix_stripped () =
+  let output = {|error: {"ok":false,"error":"❌ Invalid task state: Cannot start"}|} in
+  check string "error: prefix stripped, key extracted"
+    "\xe2\x9d\x8c Invalid task state: Cannot start" (classify output)
+
+let test_tool_error_prefix_stripped () =
+  let output = {|tool_error: {"ok":false,"error":"command_blocked"}|} in
+  check string "tool_error: prefix stripped"
+    "command_blocked" (classify output)
+
+let test_empty_output () =
+  check string "empty output classified"
+    "empty_output" (classify "")
+
+let test_plain_text_is_parse_error () =
+  check string "plain text remains parse_error"
+    "parse_error" (classify "something went wrong")
+
+let test_no_error_key_is_unknown () =
+  let output = {|{"ok":false,"detail":"missing field"}|} in
+  check string "JSON without error key"
+    "unknown_error" (classify output)
+
+let test_nested_json_in_error_prefix () =
+  let output = {|error: {"ok":false,"error":"path blocked","detail":{"path":"/etc"}}|} in
+  check string "nested JSON after prefix"
+    "path blocked" (classify output)
+
+let () =
+  run "tool_quality_classify"
+    [
+      ("classify_failure_output", [
+           test_case "bare JSON error" `Quick test_bare_json_error;
+           test_case "error: prefix stripped" `Quick test_error_prefix_stripped;
+           test_case "tool_error: prefix stripped" `Quick test_tool_error_prefix_stripped;
+           test_case "empty output" `Quick test_empty_output;
+           test_case "plain text -> parse_error" `Quick test_plain_text_is_parse_error;
+           test_case "no error key -> unknown_error" `Quick test_no_error_key_is_unknown;
+           test_case "nested JSON after prefix" `Quick test_nested_json_in_error_prefix;
+         ]);
+    ]


### PR DESCRIPTION
## Summary
- Tool call error outputs arrive as `error: {...}` not bare JSON
- `Yojson.from_string` fails on the prefix, categorizing 158+ errors as `parse_error`
- Strip `error: ` and `tool_error: ` prefixes before JSON parse
- Dashboard will now show actual error types instead of a single `parse_error` blob

## Evidence
04/07 data: 681 failures / 6498 total (10.5%). Top failures: keeper_shell_readonly 237, keeper_bash 138.
Sample output: `error: {"ok":false,"error":"Invalid task state..."}`

## Test plan
- [x] `dune build` with `OCAMLPARAM='_,warn-error=+a'`
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)