### PR TITLE
feat(keeper): playground state proactive cache + dashboard panel

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -8,12 +8,14 @@ import { keeperDisplayStatus } from '../lib/keeper-runtime-display'
 import { signal } from '@preact/signals'
 import { useRef, useState } from 'preact/hooks'
 import { requestConfirm } from './common/confirm-dialog'
+import { isRecord } from './common/normalize'
 import { currentDashboardActor, runOperatorAction } from '../api'
 import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
 import { selectKeeper } from '../keeper-runtime'
+import { keeperStatusDetails } from '../keeper-state'
 import { findKeeper } from '../lib/keeper-utils'
 import {
   KeeperConversationPanel,
@@ -234,6 +236,59 @@ function ProfileField({ label, value, color }: { label: string; value: string; c
       <span class="flex-shrink-0">${label}:</span>
       <span class="font-medium leading-relaxed" style="color: ${color}">${value}</span>
     </div>
+  `
+}
+
+// ── Playground Repos Panel ──────────────────────────────
+
+interface PlaygroundRepo {
+  name: string
+  branch: string
+  latest_commit: string
+  shallow: boolean
+  last_action: string
+  updated_at: string
+}
+
+function isPlaygroundRepo(r: unknown): r is PlaygroundRepo {
+  if (!isRecord(r)) return false
+  return typeof r.name === 'string'
+    && typeof r.branch === 'string'
+    && typeof r.latest_commit === 'string'
+    && typeof r.shallow === 'boolean'
+    && typeof r.last_action === 'string'
+}
+
+function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
+  const detail = keeperStatusDetails.value[keeperName]
+  if (!detail?.rawStatus) return null
+  const raw = detail.rawStatus
+  if (!isRecord(raw)) return null
+  const execCtx = raw.execution_context
+  if (!isRecord(execCtx)) return null
+  const repos = Array.isArray(execCtx.playground_repos) ? execCtx.playground_repos : []
+  if (repos.length === 0) return null
+
+  const items = repos.filter(isPlaygroundRepo)
+
+  return html`
+    <${SectionCard} title="Playground (${items.length})">
+      <div class="flex flex-col gap-2">
+        ${items.map(r => html`
+          <div class="flex items-center gap-3 px-3 py-2 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
+                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
+                ${r.shallow ? html`<span class="text-[9px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">shallow</span>` : null}
+              </div>
+              <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
+            </div>
+            <span class="text-[10px] text-[var(--text-dim)] flex-shrink-0">${r.last_action}</span>
+          </div>
+        `)}
+      </div>
+    <//>
   `
 }
 
@@ -479,6 +534,8 @@ export function KeeperDetailOverlay() {
               <${KeeperNeighborhood} keeper=${keeper} />
             </div>
           </details>
+
+          <${PlaygroundReposPanel} keeperName=${keeper.name} />
 
           <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -12,6 +12,58 @@ let io_timeout_sec = 30.0
 let read_timeout_sec = 15.0
 let user_timeout_max_sec = 180.0
 
+(** Write playground repo state cache after successful clone/pull.
+    Reads git metadata from [repo_path] and upserts into
+    [playground_dir/.playground_state.json]. Best-effort: failures are logged
+    but do not propagate. *)
+let update_playground_repo_cache
+      ~(playground_dir : string) ~(repo_name : string) ~(repo_path : string)
+      ~(action : string) ~(shallow : bool) : unit =
+  try
+    let branch =
+      let st, s = Process_eio.run_argv_with_status ~timeout_sec:5.0
+        [ "git"; "-C"; repo_path; "rev-parse"; "--abbrev-ref"; "HEAD" ] in
+      if st = Unix.WEXITED 0 then String.trim s else "unknown"
+    in
+    let commit =
+      let st, s = Process_eio.run_argv_with_status ~timeout_sec:5.0
+        [ "git"; "-C"; repo_path; "log"; "--oneline"; "-1" ] in
+      if st = Unix.WEXITED 0 then String.trim s else ""
+    in
+    let ts = Printf.sprintf "%.0f" (Unix.gettimeofday ()) in
+    let entry = `Assoc [
+      "name", `String repo_name;
+      "branch", `String branch;
+      "latest_commit", `String commit;
+      "shallow", `Bool shallow;
+      "last_action", `String action;
+      "updated_at", `String ts;
+    ] in
+    let cache_path = Filename.concat playground_dir ".playground_state.json" in
+    let existing =
+      try
+        let json = Yojson.Safe.from_file cache_path in
+        (match Yojson.Safe.Util.member "repos" json with
+         | `List repos -> repos
+         | _ -> [])
+      with Sys_error _ | Yojson.Json_error _ -> []
+    in
+    let updated =
+      entry :: List.filter (fun r ->
+        match Yojson.Safe.Util.member "name" r with
+        | `String n -> n <> repo_name
+        | _ -> true) existing
+    in
+    let json = `Assoc [
+      "repos", `List updated;
+      "last_updated", `String ts;
+    ] in
+    ignore (Fs_compat.save_file_atomic cache_path
+      (Yojson.Safe.pretty_to_string json ^ "\n"))
+  with exn ->
+    Logs.warn (fun f -> f "playground cache update failed: %s"
+      (Printexc.to_string exn))
+
 let resolve_keeper_shell_read_cwd
       ~(config : Room.config)
       ~(meta : keeper_meta)
@@ -598,6 +650,10 @@ let handle_keeper_shell_readonly
              Process_eio.run_argv_with_status ~timeout_sec:60.0
                [ "git"; "-C"; clone_path; "pull"; "--ff-only" ]
            in
+           if st = Unix.WEXITED 0 then
+             update_playground_repo_cache
+               ~playground_dir:playground ~repo_name ~repo_path:clone_path
+               ~action:"pull" ~shallow:false;
            Yojson.Safe.to_string
              (`Assoc
                  [ "ok", `Bool (st = Unix.WEXITED 0)
@@ -612,11 +668,16 @@ let handle_keeper_shell_readonly
            let depth_args =
              if depth > 0 then ["--depth"; string_of_int depth] else []
            in
+           let shallow = depth > 0 in
            let st, out =
              Process_eio.run_argv_with_status
                ~timeout_sec:(Keeper_tool_policy.clone_timeout_sec ())
                ("git" :: "clone" :: depth_args @ [ url; clone_path ])
            in
+           if st = Unix.WEXITED 0 then
+             update_playground_repo_cache
+               ~playground_dir:playground ~repo_name ~repo_path:clone_path
+               ~action:"clone" ~shallow;
            Yojson.Safe.to_string
              (`Assoc
                  [ "ok", `Bool (st = Unix.WEXITED 0)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -675,6 +675,19 @@ let handle_keeper_status ctx args : tool_result =
                (Keeper_alerting_path.playground_path_of_keeper m.name));
              ("execution_scope", `String m.execution_scope);
              ("allowed_paths", string_list_to_json m.allowed_paths);
+             ("playground_repos",
+               let cache_path = Filename.concat
+                 (Filename.concat ctx.config.base_path
+                   (Keeper_alerting_path.playground_path_of_keeper m.name))
+                 ".playground_state.json" in
+               try
+                 match Yojson.Safe.from_file cache_path with
+                 | `Assoc _ as json ->
+                   (match Yojson.Safe.Util.member "repos" json with
+                    | `Null -> `List []
+                    | repos -> repos)
+                 | _ -> `List []
+               with Sys_error _ | Yojson.Json_error _ -> `List []);
              ("last_evidence",
                match Keeper_evidence.latest_evidence
                  ~base_path:ctx.config.base_path


### PR DESCRIPTION
## Summary
- **Phase 2 (backend)**: clone/pull 성공 시 `.playground_state.json`에 repo 메타데이터(branch, commit, shallow, action, timestamp)를 proactive cache로 기록. status 조회 시 캐시 파일만 읽어 git 명령 실행 비용 0.
- **Phase 3 (frontend)**: `PlaygroundReposPanel` 컴포넌트 추가. `rawStatus.execution_context.playground_repos`에서 데이터를 읽어 repo 카드(branch badge, commit hash, shallow 표시, last action) 렌더링.

## Design decisions
- **Proactive cache** (event-driven write, read-only query): Eio proactive cache 피드백 원칙 준수. on-demand git 실행 방식 대신 clone/pull 이벤트 시점에 메타데이터 수집.
- **TOCTOU-free**: `Sys.file_exists` 가드 제거, exception-based fallback (`Sys_error | Yojson.Json_error`).
- **Runtime type guard**: `isPlaygroundRepo`로 각 repo 필드를 검증. `as unknown as` double assertion 미사용.
- **Best-effort**: 캐시 기록 실패는 `Logs.warn`으로 로깅하고 clone/pull 응답에 영향 없음.

## Review
- GLM-5.1 리뷰 완료: git exit status 체크, TOCTOU 제거, type guard, 예외 범위 좁힘 반영.
- OCaml build pass, TypeScript type check pass.

## Test plan
- [ ] keeper가 git_clone 실행 후 `.masc/playground/<name>/.playground_state.json` 생성 확인
- [ ] 같은 repo pull 시 기존 엔트리 업데이트 확인 (중복 아닌 upsert)
- [ ] 대시보드 keeper detail에서 Playground 패널 렌더링 확인
- [ ] clone 실패 시 캐시 기록 안 됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)