### PR TITLE
feat(dashboard): enrich OAS worker observability

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -56,6 +56,13 @@
  (libraries masc_mcp yojson unix eio_main eio masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider ))
 
 (executable
+ (name team_session_worker_run_meta_repair)
+ (modules team_session_worker_run_meta_repair)
+ (public_name masc-team-session-worker-run-meta-repair)
+ (package masc_mcp)
+ (libraries masc_mcp cmdliner yojson unix masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process masc_eio_context fmt str eio_main eio mirage-crypto-rng.unix caqti-eio httpun cohttp cohttp-eio masc_mcp.team_session_types masc_mcp.prompt_registry masc_mcp.mcp_transport_protocol agent_sdk agent_sdk.llm_provider ))
+
+(executable
  (name keeper_room_signal_eval)
  (modules keeper_room_signal_eval)
  (libraries masc_mcp masc_mcp.prompt_registry masc_eio_context fs_compat yojson unix eio_main eio mirage-crypto-rng.unix))

--- a/bin/team_session_worker_run_meta_repair.ml
+++ b/bin/team_session_worker_run_meta_repair.ml
@@ -1,0 +1,48 @@
+open Cmdliner
+
+module Lib = Masc_mcp
+
+let run base_path session_id worker_run_id apply =
+  let config = Lib.Room.default_config base_path in
+  match
+    Lib.Team_session_worker_run_meta.repair_session ~config ~session_id
+      ?worker_run_id ~dry_run:(not apply) ()
+  with
+  | Ok summary ->
+      summary
+      |> Lib.Team_session_worker_run_meta.repair_summary_to_yojson
+      |> Yojson.Safe.pretty_to_string
+      |> print_endline
+  | Error msg ->
+      prerr_endline msg;
+      exit 1
+
+let base_path_arg =
+  let doc =
+    "Workspace path that owns the .masc state. Defaults to the current working \
+     directory."
+  in
+  Arg.(value & opt string (Sys.getcwd ()) & info [ "base-path" ] ~docv:"DIR" ~doc)
+
+let session_id_arg =
+  let doc = "Team session id to repair." in
+  Arg.(required & opt (some string) None & info [ "session-id" ] ~docv:"SESSION" ~doc)
+
+let worker_run_id_arg =
+  let doc = "Optional single worker_run_id to repair instead of the full session." in
+  Arg.(value & opt (some string) None & info [ "worker-run-id" ] ~docv:"WORKER_RUN" ~doc)
+
+let apply_arg =
+  let doc = "Write repaired meta back to disk. Without this flag the command is dry-run only." in
+  Arg.(value & flag & info [ "apply" ] ~doc)
+
+let cmd =
+  let doc =
+    "Repair historical worker_run meta for a team session using persisted OAS \
+     evidence and proof artifacts."
+  in
+  let info = Cmd.info "masc-team-session-worker-run-meta-repair" ~doc in
+  Cmd.v info
+    Term.(const run $ base_path_arg $ session_id_arg $ worker_run_id_arg $ apply_arg)
+
+let () = exit (Cmd.eval cmd)

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -383,6 +383,72 @@ export function fetchDashboardMissionSession(sessionId: string): Promise<Dashboa
   return get(`/api/v1/dashboard/session${query}`)
 }
 
+export interface DashboardRuntimeProviderDiscovery {
+  healthy?: boolean
+  discovered_model?: string | null
+  ctx_size?: number | null
+  total_slots?: number | null
+  busy_slots?: number | null
+  idle_slots?: number | null
+}
+
+export interface DashboardRuntimeProviderSnapshot {
+  provider: string
+  kind?: string | null
+  runtime_kind?: string | null
+  auth_kind?: string | null
+  status?: string | null
+  available?: boolean
+  supports_single_agent_run?: boolean
+  default_model?: string | null
+  model_count?: number | null
+  models: string[]
+  source?: string | null
+  endpoint_url?: string | null
+  note?: string | null
+  discovery?: DashboardRuntimeProviderDiscovery | null
+}
+
+export interface DashboardRuntimeProvidersResponse {
+  updated_at?: string
+  summary?: {
+    providers?: number
+    local_models?: number
+    cloud_models?: number
+  } | null
+  providers: DashboardRuntimeProviderSnapshot[]
+}
+
+export interface DashboardRuntimeModelMetric {
+  model_id: string
+  entry_count?: number | null
+  avg_tok_per_sec?: number | null
+  p50_tok_per_sec?: number | null
+  p95_tok_per_sec?: number | null
+  avg_latency_ms?: number | null
+  p50_latency_ms?: number | null
+  p95_latency_ms?: number | null
+  total_input_tokens?: number | null
+  total_output_tokens?: number | null
+  total_cache_read_tokens?: number | null
+  total_reasoning_tokens?: number | null
+  fallback_count?: number | null
+}
+
+export interface DashboardRuntimeModelMetricsResponse {
+  window_minutes?: number
+  total_entries?: number
+  models: DashboardRuntimeModelMetric[]
+}
+
+export function fetchRuntimeProviders(): Promise<DashboardRuntimeProvidersResponse> {
+  return get('/api/v1/providers')
+}
+
+export function fetchRuntimeModelMetrics(windowMinutes = 30): Promise<DashboardRuntimeModelMetricsResponse> {
+  return get(`/api/v1/models/metrics?window=${windowMinutes}`)
+}
+
 export interface DashboardVerificationRef {
   kind: string
   label: string

--- a/dashboard/src/components/mission-session-cards.ts
+++ b/dashboard/src/components/mission-session-cards.ts
@@ -9,6 +9,7 @@ import { ActionBar, ActionBtn } from './common/action-bar'
 import { StatusChip } from './common/status-chip'
 import { openAgentDetail } from './agent-detail'
 import { SessionFlowCard } from './mission-session-flow'
+import { WorkerRunEvidenceRow } from './proof-sections'
 import type {
   DashboardMissionSessionCard,
   DashboardMissionSessionDetailResponse,
@@ -136,6 +137,7 @@ export function SessionDetailCard({
   }
 
   const session = detail.session
+  const workerRuns = detail.worker_runs ?? null
   return html`
     <${Card} title="세션 상세" class="mission-list-card rounded-xl">
       <div class="grid gap-1.5 mb-4">
@@ -148,6 +150,93 @@ export function SessionDetailCard({
       <div class="mt-4">
         <${SessionFlowCard} detail=${detail} />
       </div>
+
+      ${workerRuns
+        ? html`
+            <div class="grid gap-4 mt-4">
+              <div class="flex justify-between gap-3 items-start flex-wrap">
+                <strong>워커 런타임</strong>
+                <${StatusChip}
+                  label=${`${workerRuns.completed_success_count ?? 0}/${workerRuns.requested_count ?? 0} 완료`}
+                  tone=${(workerRuns.completed_failed_count ?? 0) > 0 ? 'warn' : 'ok'}
+                />
+              </div>
+
+              <div class="grid grid-cols-2 gap-3">
+                <${StatCell}
+                  label="요청"
+                  value=${workerRuns.requested_count ?? 0}
+                  detail=${`in-flight ${workerRuns.in_flight_count ?? 0}`}
+                />
+                <${StatCell}
+                  label="완료"
+                  value=${workerRuns.completed_success_count ?? 0}
+                  detail=${`실패 ${workerRuns.completed_failed_count ?? 0}`}
+                />
+                <${StatCell}
+                  label="준비됨"
+                  value=${workerRuns.ready_worker_count ?? 0}
+                  detail=${workerRuns.ready_worker_names.join(', ') || '없음'}
+                />
+                <${StatCell}
+                  label="보류"
+                  value=${workerRuns.pending_worker_count ?? 0}
+                  detail=${workerRuns.pending_worker_names.join(', ') || '없음'}
+                />
+              </div>
+
+              <div class="grid grid-cols-2 gap-5">
+                <div class="grid gap-3">
+                  <div class="flex justify-between gap-3 items-start flex-wrap">
+                    <strong>Delegate Readiness</strong>
+                    <${StatusChip}
+                      label=${String(workerRuns.worker_readiness.length)}
+                      tone=${workerRuns.blocked_worker_names.length > 0 ? 'warn' : 'ok'}
+                    />
+                  </div>
+                  <div class="flex flex-col gap-3">
+                    ${workerRuns.worker_readiness.length > 0
+                      ? workerRuns.worker_readiness.map(readiness => html`
+                          <${ListItem}
+                            title=${readiness.worker_name}
+                            subtitle=${readiness.delegate_ready ? 'delegate ready' : readiness.blocked_reason ?? 'blocked'}
+                            detail=${readiness.guidance ?? '추가 지침 없음'}
+                          />
+                        `)
+                      : html`<${EmptyState} message="delegate readiness 기록이 없습니다." compact />`}
+                  </div>
+                </div>
+
+                <div class="grid gap-3">
+                  <div class="flex justify-between gap-3 items-start flex-wrap">
+                    <strong>워커 상태 묶음</strong>
+                    <${StatusChip}
+                      label=${`${workerRuns.in_flight_actor_names.length} active`}
+                      tone=${workerRuns.in_flight_actor_names.length > 0 ? 'warn' : 'ok'}
+                    />
+                  </div>
+                  <div class="grid gap-2 text-[13px] text-[var(--text-body)]">
+                    <div>in-flight · ${workerRuns.in_flight_actor_names.join(', ') || '없음'}</div>
+                    <div>delegate-ready · ${workerRuns.delegate_ready_worker_names.join(', ') || '없음'}</div>
+                    <div>blocked · ${workerRuns.blocked_worker_names.join(', ') || '없음'}</div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="grid gap-3">
+                <div class="flex justify-between gap-3 items-start flex-wrap">
+                  <strong>최근 워커 실행</strong>
+                  <${StatusChip} label=${String(workerRuns.recent_runs.length)} />
+                </div>
+                <div class="flex flex-col gap-3">
+                  ${workerRuns.recent_runs.length > 0
+                    ? workerRuns.recent_runs.map(item => html`<${WorkerRunEvidenceRow} item=${item} />`)
+                    : html`<${EmptyState} message="최근 worker run 증거가 없습니다." compact />`}
+                </div>
+              </div>
+            </div>
+          `
+        : null}
 
       <div class="grid grid-cols-2 gap-5 mt-4">
         <div class="grid gap-3">

--- a/dashboard/src/components/proof-helpers.test.ts
+++ b/dashboard/src/components/proof-helpers.test.ts
@@ -26,6 +26,17 @@ describe('workerRunEvidence helpers', () => {
     expect(workerRunEvidenceMeta(item)).toContain('도구 3')
   })
 
+  it('marks unvalidated raw traces as warn', () => {
+    const item = {
+      worker_run_id: 'worker-raw-observed',
+      trace_capability: 'raw',
+      trace_validated: false,
+    }
+
+    expect(workerRunEvidenceTone(item)).toBe('warn')
+    expect(workerRunEvidenceLabel(item)).toBe('raw observed')
+  })
+
   it('marks missing tool surface explicitly in meta', () => {
     const item = {
       worker_run_id: 'worker-surface-missing',

--- a/dashboard/src/components/proof-helpers.ts
+++ b/dashboard/src/components/proof-helpers.ts
@@ -162,7 +162,7 @@ export function toolEvidenceTags(item: DashboardProofToolEvidence): string[] {
 export function workerRunEvidenceTone(item: DashboardProofWorkerRunEvidence): string {
   if (item.trace_validated === true) return 'ok'
   if (item.success === false || item.failure_reason || item.error) return 'bad'
-  if (item.trace_capability === 'raw') return 'ok'
+  if (item.trace_capability === 'raw') return 'warn'
   if (item.trace_capability === 'summary_only') return 'warn'
   return 'warn'
 }
@@ -170,7 +170,7 @@ export function workerRunEvidenceTone(item: DashboardProofWorkerRunEvidence): st
 export function workerRunEvidenceLabel(item: DashboardProofWorkerRunEvidence): string {
   if (item.trace_validated === true) return '검증됨'
   if (item.success === false || item.failure_reason || item.error) return '실패'
-  if (item.trace_capability === 'raw') return 'raw trace'
+  if (item.trace_capability === 'raw') return 'raw observed'
   if (item.trace_capability === 'summary_only') return 'summary only'
   return item.status ?? '근거 수집'
 }
@@ -186,6 +186,7 @@ export function workerRunEvidenceMeta(item: DashboardProofWorkerRunEvidence): st
     item.resolved_runtime ?? null,
     item.resolved_model ?? null,
     item.mode ?? null,
+    item.proof_present ? (item.proof_status ?? 'proof') : null,
     item.tool_surface_status === 'missing'
       ? 'surface missing'
       : typeof toolSurfaceCount === 'number'

--- a/dashboard/src/components/proof-sections.ts
+++ b/dashboard/src/components/proof-sections.ts
@@ -92,6 +92,22 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
   const validationFailures = Array.isArray(item.validation_failures) ? item.validation_failures : []
   const toolSurfaceNames = Array.isArray(item.tool_surface_names) ? item.tool_surface_names : []
   const toolNames = Array.isArray(item.tool_names) ? item.tool_names : []
+  const traceWorkerRunId =
+    item.trace_ref && typeof item.trace_ref.worker_run_id === 'string'
+      ? item.trace_ref.worker_run_id
+      : null
+  const conformance =
+    item.session_conformance && typeof item.session_conformance === 'object' && !Array.isArray(item.session_conformance)
+      ? item.session_conformance
+      : null
+  const conformanceChecks = Array.isArray(conformance?.checks) ? conformance.checks : []
+  const conformanceFailures = conformanceChecks.filter(check => check && typeof check === 'object' && 'passed' in check && (check as { passed?: unknown }).passed === false)
+  const proofEvidenceCount =
+    typeof item.proof_evidence_count === 'number'
+      ? item.proof_evidence_count
+      : Array.isArray(item.raw_evidence_refs)
+        ? item.raw_evidence_refs.length
+        : null
   return html`
     <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm hover:border-accent/30 transition-all duration-200 flex flex-col gap-3">
       <div class="flex justify-between gap-4 items-start">
@@ -120,6 +136,26 @@ export function WorkerRunEvidenceRow({ item }: { item: DashboardProofWorkerRunEv
         ? html`<div class="flex flex-col gap-1.5 py-3 px-4 rounded-xl border border-warn/30 bg-warn/10 shadow-inner mt-1">
             <strong class="text-[11px] font-semibold uppercase tracking-widest text-warn">검증 실패</strong>
             <span class="text-[12px] text-text-body leading-relaxed whitespace-pre-wrap">${validationFailures.join(' · ')}</span>
+          </div>`
+        : null}
+      ${(traceWorkerRunId || item.evidence_session_id || item.proof_run_id || item.proof_status || conformance)
+        ? html`<div class="flex flex-col gap-2 mt-2 pt-3 border-t border-card-border/50">
+            <strong class="text-[11px] font-semibold uppercase tracking-widest text-text-muted">증거 식별자</strong>
+            <div class="grid gap-1.5 text-[11px] text-text-body">
+              ${traceWorkerRunId ? html`<div>trace_ref · <span class="font-mono">${traceWorkerRunId}</span></div>` : null}
+              ${item.evidence_session_id ? html`<div>evidence_session · <span class="font-mono">${item.evidence_session_id}</span></div>` : null}
+              ${item.proof_run_id ? html`<div>proof_run · <span class="font-mono">${item.proof_run_id}</span></div>` : null}
+              ${item.proof_status ? html`<div>proof_status · ${item.proof_status}${proofEvidenceCount != null ? ` · evidence ${proofEvidenceCount}` : ''}</div>` : null}
+              ${conformance
+                ? html`<div>
+                    conformance · ${conformanceFailures.length > 0
+                      ? `${conformanceFailures.length} failed`
+                      : conformanceChecks.length > 0
+                        ? `${conformanceChecks.length} checks ok`
+                        : 'report present'}
+                  </div>`
+                : null}
+            </div>
           </div>`
         : null}
       ${toolSurfaceNames.length > 0

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -1,0 +1,202 @@
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import {
+  fetchRuntimeModelMetrics,
+  fetchRuntimeProviders,
+  type DashboardRuntimeModelMetric,
+  type DashboardRuntimeModelMetricsResponse,
+  type DashboardRuntimeProviderSnapshot,
+  type DashboardRuntimeProvidersResponse,
+} from '../api/dashboard'
+import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
+import { LoadingState } from './common/feedback-state'
+import { StatCell } from './common/stat-cell'
+import { StatusChip } from './common/status-chip'
+
+interface RuntimeState {
+  providers: DashboardRuntimeProvidersResponse | null
+  metrics: DashboardRuntimeModelMetricsResponse | null
+  loading: boolean
+  error: string | null
+}
+
+function providerTone(provider: DashboardRuntimeProviderSnapshot): string {
+  if (provider.available === false) return 'bad'
+  if (provider.discovery?.healthy === false) return 'warn'
+  if (provider.available === true) return 'ok'
+  return 'warn'
+}
+
+function modelMetricTone(metric: DashboardRuntimeModelMetric): string {
+  if ((metric.entry_count ?? 0) <= 0) return 'warn'
+  if ((metric.fallback_count ?? 0) > 0) return 'warn'
+  return 'ok'
+}
+
+function fmtNumber(value?: number | null, digits = 0): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '--'
+  return value.toLocaleString('ko-KR', {
+    minimumFractionDigits: digits,
+    maximumFractionDigits: digits,
+  })
+}
+
+export function RuntimeMonitor() {
+  const state = useSignal<RuntimeState>({
+    providers: null,
+    metrics: null,
+    loading: true,
+    error: null,
+  })
+  const windowMinutes = useSignal(30)
+
+  async function load() {
+    state.value = { ...state.value, loading: true, error: null }
+    try {
+      const [providers, metrics] = await Promise.all([
+        fetchRuntimeProviders(),
+        fetchRuntimeModelMetrics(windowMinutes.value),
+      ])
+      state.value = {
+        providers,
+        metrics,
+        loading: false,
+        error: null,
+      }
+    } catch (error) {
+      state.value = {
+        ...state.value,
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  }, [windowMinutes.value])
+
+  const providers = state.value.providers
+  const metrics = state.value.metrics
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center gap-3 flex-wrap">
+        <select
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
+          value=${String(windowMinutes.value)}
+          onChange=${(e: Event) => { windowMinutes.value = Number((e.target as HTMLSelectElement).value) }}
+        >
+          <option value="15">15분</option>
+          <option value="30">30분</option>
+          <option value="60">60분</option>
+          <option value="180">180분</option>
+        </select>
+        <button
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          onClick=${() => void load()}
+        >
+          Refresh
+        </button>
+        ${state.value.loading ? html`<span class="text-xs text-[var(--text-muted)]">loading...</span>` : null}
+      </div>
+
+      ${state.value.error
+        ? html`<div class="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">${state.value.error}</div>`
+        : null}
+
+      ${state.value.loading && !providers && !metrics
+        ? html`<${LoadingState}>runtime snapshot 불러오는 중...<//>`
+        : null}
+
+      <${Card} title="Provider Runtime">
+        <div class="grid grid-cols-2 gap-3 mb-4">
+          <${StatCell}
+            label="Providers"
+            value=${providers?.summary?.providers ?? providers?.providers.length ?? 0}
+            detail=${providers?.updated_at ?? 'updated_at 없음'}
+          />
+          <${StatCell}
+            label="Local Models"
+            value=${providers?.summary?.local_models ?? 0}
+            detail=${`Cloud ${providers?.summary?.cloud_models ?? 0}`}
+          />
+        </div>
+        <div class="flex flex-col gap-3">
+          ${(providers?.providers ?? []).length > 0
+            ? providers?.providers.map(provider => html`
+                <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
+                  <div class="flex justify-between gap-3 items-start flex-wrap">
+                    <div class="grid gap-1">
+                      <strong class="text-[13px] text-text-strong">${provider.provider}</strong>
+                      <span class="text-[12px] text-text-muted">${provider.runtime_kind ?? 'runtime'} · ${provider.auth_kind ?? 'auth'} · ${provider.source ?? 'source unknown'}</span>
+                    </div>
+                    <${StatusChip}
+                      label=${provider.status ?? (provider.available ? 'available' : 'unknown')}
+                      tone=${providerTone(provider)}
+                    />
+                  </div>
+                  <div class="grid grid-cols-2 gap-3 text-[12px] text-text-body">
+                    <div>default model · ${provider.default_model ?? '없음'}</div>
+                    <div>catalog · ${provider.models.join(', ') || '없음'}</div>
+                    <div>single-run · ${provider.supports_single_agent_run ? 'yes' : 'no'}</div>
+                    <div>endpoint · ${provider.endpoint_url ?? '없음'}</div>
+                  </div>
+                  ${provider.discovery
+                    ? html`<div class="grid grid-cols-2 gap-3 text-[12px] text-text-body pt-2 border-t border-card-border/50">
+                        <div>discovery · ${provider.discovery.healthy ? 'healthy' : 'degraded'}</div>
+                        <div>ctx · ${fmtNumber(provider.discovery.ctx_size)}</div>
+                        <div>slots · ${fmtNumber(provider.discovery.busy_slots)}/${fmtNumber(provider.discovery.total_slots)}</div>
+                        <div>model · ${provider.discovery.discovered_model ?? '없음'}</div>
+                      </div>`
+                    : null}
+                  ${provider.note ? html`<div class="text-[12px] text-text-muted">${provider.note}</div>` : null}
+                </article>
+              `)
+            : html`<${EmptyState} message="provider runtime snapshot이 없습니다." compact />`}
+        </div>
+      <//>
+
+      <${Card} title="Model Metrics">
+        <div class="grid grid-cols-2 gap-3 mb-4">
+          <${StatCell}
+            label="Telemetry Window"
+            value=${`${metrics?.window_minutes ?? windowMinutes.value}m`}
+            detail=${`entries ${metrics?.total_entries ?? 0}`}
+          />
+          <${StatCell}
+            label="Tracked Models"
+            value=${metrics?.models.length ?? 0}
+            detail="append-only telemetry와 분리된 runtime snapshot"
+          />
+        </div>
+        <div class="flex flex-col gap-3">
+          ${(metrics?.models ?? []).length > 0
+            ? metrics?.models.map(metric => html`
+                <article class="p-4 rounded-xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm flex flex-col gap-2">
+                  <div class="flex justify-between gap-3 items-start flex-wrap">
+                    <div class="grid gap-1">
+                      <strong class="text-[13px] text-text-strong">${metric.model_id}</strong>
+                      <span class="text-[12px] text-text-muted">entries ${fmtNumber(metric.entry_count)} · fallback ${fmtNumber(metric.fallback_count)}</span>
+                    </div>
+                    <${StatusChip}
+                      label=${`${fmtNumber(metric.avg_tok_per_sec, 1)} tok/s`}
+                      tone=${modelMetricTone(metric)}
+                    />
+                  </div>
+                  <div class="grid grid-cols-2 gap-3 text-[12px] text-text-body">
+                    <div>latency avg/p95 · ${fmtNumber(metric.avg_latency_ms, 1)} / ${fmtNumber(metric.p95_latency_ms, 1)} ms</div>
+                    <div>tok/s p50/p95 · ${fmtNumber(metric.p50_tok_per_sec, 1)} / ${fmtNumber(metric.p95_tok_per_sec, 1)}</div>
+                    <div>input/output · ${fmtNumber(metric.total_input_tokens)} / ${fmtNumber(metric.total_output_tokens)}</div>
+                    <div>reasoning/cache-read · ${fmtNumber(metric.total_reasoning_tokens)} / ${fmtNumber(metric.total_cache_read_tokens)}</div>
+                  </div>
+                </article>
+              `)
+            : html`<${EmptyState} message="최근 model inference metrics가 없습니다." compact />`}
+        </div>
+      <//>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -1,18 +1,19 @@
 // MASC Dashboard — Status Surface
-// Conventional read-only status area: sessions, agents, activity, telemetry.
+// Conventional read-only status area: sessions, agents, activity, runtime, telemetry.
 
 import { html } from 'htm/preact'
 import { route } from '../router'
 import { Mission } from './mission'
 import { AgentsUnified } from './agents-unified'
 import { Activity } from './activity'
+import { RuntimeMonitor } from './runtime-monitor'
 import { TelemetryUnified } from './telemetry-unified'
 
-type StatusSection = 'sessions' | 'agents' | 'activity' | 'telemetry'
+type StatusSection = 'sessions' | 'agents' | 'activity' | 'runtime' | 'telemetry'
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
-  if (section === 'agents' || section === 'activity' || section === 'telemetry') return section
+  if (section === 'agents' || section === 'activity' || section === 'runtime' || section === 'telemetry') return section
   return 'sessions'
 }
 
@@ -26,6 +27,8 @@ export function Status() {
           ? html`<${AgentsUnified} />`
           : section === 'activity'
             ? html`<${Activity} />`
+            : section === 'runtime'
+              ? html`<${RuntimeMonitor} />`
             : section === 'telemetry'
               ? html`<${TelemetryUnified} />`
               : html`<${Mission} />`}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -15,6 +15,7 @@ export type SurfaceSectionId =
   | 'autoresearch'
   | 'harness'
   | 'inspector'
+  | 'runtime'
   | 'telemetry'
   | 'tool-quality'
   | 'fleet'
@@ -131,9 +132,15 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       params: { section: 'activity' },
     },
     {
+      id: 'runtime',
+      label: '런타임',
+      description: 'provider health, 슬롯 용량, model inference snapshot.',
+      params: { section: 'runtime' },
+    },
+    {
       id: 'telemetry',
       label: '텔레메트리',
-      description: '도구 호출, keeper 메트릭, 에이전트 이벤트 통합 뷰.',
+      description: 'append-only 이벤트 기록. runtime snapshot은 별도 런타임 탭에서 봅니다.',
       params: { section: 'telemetry' },
     },
   ],

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -30,9 +30,12 @@ import type {
   DashboardMissionSessionCard,
   DashboardMissionSessionDetailResponse,
   DashboardMissionSessionBrief,
+  DashboardMissionSessionWorkerRuns,
   DashboardMissionSummary,
   DashboardMissionTimelineItem,
+  DashboardMissionWorkerReadiness,
   DashboardMissionCommandFocus,
+  DashboardProofWorkerRunEvidence,
   DashboardMissionTargets,
   OperatorActionDescriptor,
   OperatorAttentionItem,
@@ -61,6 +64,134 @@ function normalizeSessionCard(raw: unknown): OperatorSessionCard | null {
     recommended_action_count: asNumber(raw.recommended_action_count),
     top_attention: normalizeAttentionItem(raw.top_attention),
     top_recommendation: normalizeRecommendedAction(raw.top_recommendation),
+  }
+}
+
+function normalizeWorkerRunEvidence(raw: unknown): DashboardProofWorkerRunEvidence | null {
+  if (!isRecord(raw)) return null
+  const workerRunId = asString(raw.worker_run_id)
+  if (!workerRunId) return null
+  return {
+    worker_run_id: workerRunId,
+    session_id: asString(raw.session_id) ?? null,
+    operation_id: asString(raw.operation_id) ?? null,
+    trace_ref: isRecord(raw.trace_ref) ? raw.trace_ref : null,
+    evidence_session_id: asString(raw.evidence_session_id) ?? null,
+    session_conformance: isRecord(raw.session_conformance) ? raw.session_conformance : null,
+    cdal_run_id: asString(raw.cdal_run_id) ?? null,
+    contract_id: asString(raw.contract_id) ?? null,
+    result_status: asString(raw.result_status) ?? null,
+    proof_present: asBoolean(raw.proof_present),
+    proof_run_id: asString(raw.proof_run_id) ?? null,
+    proof_status: asString(raw.proof_status) ?? null,
+    proof_risk_class: asString(raw.proof_risk_class) ?? null,
+    proof_execution_mode: asString(raw.proof_execution_mode) ?? null,
+    proof_evidence_count: asNumber(raw.proof_evidence_count),
+    checkpoint_ref: asString(raw.checkpoint_ref) ?? null,
+    tool_trace_refs: extractArray(raw.tool_trace_refs)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    raw_evidence_refs: extractArray(raw.raw_evidence_refs)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    worker_name: asString(raw.worker_name) ?? null,
+    status: asString(raw.status) ?? null,
+    mode: asString(raw.mode) ?? null,
+    wait_mode: asString(raw.wait_mode) ?? null,
+    trace_capability: asString(raw.trace_capability) ?? null,
+    trace_validated: asBoolean(raw.trace_validated),
+    validation_failures: extractArray(raw.validation_failures)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    success: asBoolean(raw.success),
+    execution_scope: asString(raw.execution_scope) ?? null,
+    requested_worker_class: asString(raw.requested_worker_class) ?? null,
+    requested_worker_size: asString(raw.requested_worker_size) ?? null,
+    tool_surface_status: asString(raw.tool_surface_status) ?? null,
+    tool_surface_source: asString(raw.tool_surface_source) ?? null,
+    tool_surface_names: extractArray(raw.tool_surface_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    tool_surface_masc_names: extractArray(raw.tool_surface_masc_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    tool_surface_shell_names: extractArray(raw.tool_surface_shell_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    tool_surface_count: asNumber(raw.tool_surface_count),
+    resolved_runtime: asString(raw.resolved_runtime) ?? null,
+    resolved_model: asString(raw.resolved_model) ?? null,
+    routing_reason: asString(raw.routing_reason) ?? null,
+    tool_names: extractArray(raw.tool_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    tool_call_count: asNumber(raw.tool_call_count),
+    output_preview: asString(raw.output_preview) ?? null,
+    record_count: asNumber(raw.record_count),
+    assistant_block_count: asNumber(raw.assistant_block_count),
+    final_text: asString(raw.final_text) ?? null,
+    stop_reason: asString(raw.stop_reason) ?? null,
+    failure_reason: asString(raw.failure_reason) ?? null,
+    error: asString(raw.error) ?? null,
+    evidence_refs: extractArray(raw.evidence_refs)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    ts_iso: asString(raw.ts_iso) ?? null,
+  }
+}
+
+function normalizeWorkerReadiness(raw: unknown): DashboardMissionWorkerReadiness | null {
+  if (!isRecord(raw)) return null
+  const workerName = asString(raw.worker_name)
+  if (!workerName) return null
+  return {
+    worker_name: workerName,
+    spawn_role: asString(raw.spawn_role) ?? null,
+    execution_scope: asString(raw.execution_scope) ?? null,
+    runtime_pool: asString(raw.runtime_pool) ?? null,
+    routing_reason: asString(raw.routing_reason) ?? null,
+    has_meta: asBoolean(raw.has_meta),
+    has_checkpoint: asBoolean(raw.has_checkpoint),
+    in_flight: asBoolean(raw.in_flight),
+    delegate_ready: asBoolean(raw.delegate_ready),
+    blocked_reason: asString(raw.blocked_reason) ?? null,
+    guidance: asString(raw.guidance) ?? null,
+  }
+}
+
+function normalizeSessionWorkerRuns(raw: unknown): DashboardMissionSessionWorkerRuns | null {
+  if (!isRecord(raw)) return null
+  return {
+    requested_count: asNumber(raw.requested_count),
+    completed_success_count: asNumber(raw.completed_success_count),
+    completed_failed_count: asNumber(raw.completed_failed_count),
+    in_flight_count: asNumber(raw.in_flight_count),
+    in_flight_run_ids: extractArray(raw.in_flight_run_ids)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    in_flight_actor_names: extractArray(raw.in_flight_actor_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    ready_worker_count: asNumber(raw.ready_worker_count),
+    ready_worker_names: extractArray(raw.ready_worker_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    delegate_ready_worker_names: extractArray(raw.delegate_ready_worker_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    blocked_worker_names: extractArray(raw.blocked_worker_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    pending_worker_count: asNumber(raw.pending_worker_count),
+    pending_worker_names: extractArray(raw.pending_worker_names)
+      .map(item => (typeof item === 'string' ? item.trim() : ''))
+      .filter(Boolean),
+    worker_readiness: extractArray(raw.worker_readiness)
+      .map(normalizeWorkerReadiness)
+      .filter((item): item is DashboardMissionWorkerReadiness => item !== null),
+    recent_runs: extractArray(raw.recent_runs)
+      .map(normalizeWorkerRunEvidence)
+      .filter((item): item is DashboardProofWorkerRunEvidence => item !== null),
   }
 }
 
@@ -287,6 +418,7 @@ export function normalizeMissionSessionDetail(raw: unknown): DashboardMissionSes
     keepers: extractArray(root.keepers)
       .map(normalizeKeeperRef)
       .filter((item): item is DashboardMissionKeeperRef => item !== null),
+    worker_runs: normalizeSessionWorkerRuns(root.worker_runs),
     error: asString(root.error) ?? null,
   }
 }

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -190,6 +190,37 @@ export interface DashboardMissionTimelineItem {
   summary: string
 }
 
+export interface DashboardMissionWorkerReadiness {
+  worker_name: string
+  spawn_role?: string | null
+  execution_scope?: string | null
+  runtime_pool?: string | null
+  routing_reason?: string | null
+  has_meta?: boolean | null
+  has_checkpoint?: boolean | null
+  in_flight?: boolean | null
+  delegate_ready?: boolean | null
+  blocked_reason?: string | null
+  guidance?: string | null
+}
+
+export interface DashboardMissionSessionWorkerRuns {
+  requested_count?: number | null
+  completed_success_count?: number | null
+  completed_failed_count?: number | null
+  in_flight_count?: number | null
+  in_flight_run_ids: string[]
+  in_flight_actor_names: string[]
+  ready_worker_count?: number | null
+  ready_worker_names: string[]
+  delegate_ready_worker_names: string[]
+  blocked_worker_names: string[]
+  pending_worker_count?: number | null
+  pending_worker_names: string[]
+  worker_readiness: DashboardMissionWorkerReadiness[]
+  recent_runs: DashboardProofWorkerRunEvidence[]
+}
+
 export interface DashboardMissionSessionDetailResponse {
   generated_at?: string
   session_id: string
@@ -198,6 +229,7 @@ export interface DashboardMissionSessionDetailResponse {
   participants: DashboardMissionParticipantPreview[]
   operations: DashboardMissionOperationBadge[]
   keepers: DashboardMissionKeeperRef[]
+  worker_runs?: DashboardMissionSessionWorkerRuns | null
   error?: string | null
 }
 
@@ -322,6 +354,21 @@ export interface DashboardProofWorkerRunEvidence {
   worker_run_id: string
   session_id?: string | null
   operation_id?: string | null
+  trace_ref?: Record<string, unknown> | null
+  evidence_session_id?: string | null
+  session_conformance?: Record<string, unknown> | null
+  cdal_run_id?: string | null
+  contract_id?: string | null
+  result_status?: string | null
+  proof_present?: boolean | null
+  proof_run_id?: string | null
+  proof_status?: string | null
+  proof_risk_class?: string | null
+  proof_execution_mode?: string | null
+  proof_evidence_count?: number | null
+  checkpoint_ref?: string | null
+  tool_trace_refs?: string[]
+  raw_evidence_refs?: string[]
   worker_name?: string | null
   status?: string | null
   mode?: string | null

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -780,6 +780,11 @@ let session_json ?actor ?command_plane_summary ?swarm_status ~session_id ~config
       (fun (session : session_context) -> String.equal session.session_id session_id)
       projection.sessions
   in
+  let worker_runs_json =
+    match Team_session_store.load_session config session_id with
+    | Some session -> U.member "worker_runs" (Team_session_engine_eio.session_status_json config session)
+    | None -> `Null
+  in
   let operation_contexts = Dashboard_mission_assembly.build_operation_contexts projection.command_json in
   let operations_json =
     match session_context with
@@ -811,6 +816,7 @@ let session_json ?actor ?command_plane_summary ?swarm_status ~session_id ~config
       ("participants", `List participants_json);
       ("operations", `List operations_json);
       ("keepers", `List keepers_json);
+      ("worker_runs", worker_runs_json);
       ( "error",
         match session_row_json with
         | Some _ -> `Null

--- a/lib/dashboard/dashboard_proof.ml
+++ b/lib/dashboard/dashboard_proof.ml
@@ -186,7 +186,7 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
   in
   let live_verdict =
     Dashboard_proof_verdict.proof_verdict ~active_actor_count ~interaction_present:(interaction_count > 0)
-      ~evidence_present ~artifact_present
+      ~evidence_present ~artifact_present ~validated_worker_run_count
   in
   let historical_verdict =
     Option.bind proof_doc Dashboard_proof_verdict.historical_verdict_of_proof_doc

--- a/lib/dashboard/dashboard_proof_verdict.ml
+++ b/lib/dashboard/dashboard_proof_verdict.ml
@@ -85,9 +85,9 @@ let artifact_ref_json kind path =
     ]
 
 let proof_verdict ~active_actor_count ~interaction_present ~evidence_present
-    ~artifact_present =
+    ~artifact_present ~validated_worker_run_count =
   if active_actor_count >= 2 && interaction_present && evidence_present
-     && artifact_present
+     && artifact_present && validated_worker_run_count > 0
   then
     "proven"
   else if active_actor_count >= 1

--- a/lib/dune
+++ b/lib/dune
@@ -275,6 +275,7 @@
    team_session_report_core
    team_session_report_proof_helpers
    team_session_report_proof
+   team_session_worker_run_meta
    team_session_engine_helpers
    team_session_engine_status
    team_session_engine_policy
@@ -690,6 +691,7 @@
   team_session_report_core
   team_session_report_proof_helpers
   team_session_report_proof
+  team_session_worker_run_meta
   ;; godsplit-phase1: file split sub-modules
   tool_team_session_step_exec
   keeper_status_bridge

--- a/lib/team_session/team_session_oas_bridge.ml
+++ b/lib/team_session/team_session_oas_bridge.ml
@@ -8,38 +8,11 @@
     @since 2.124.0 *)
 
 let supported_local_worker_tool_names =
-  Tool_catalog.tools_for_surface Tool_catalog.Local_worker
-
-let observe_only_policy : Tool_access_policy.t =
-  {
-    allow = Surface Tool_catalog.Local_worker;
-    deny = Names [
-      "masc_add_task";
-      "masc_claim_next";
-      "masc_transition";
-      "masc_board_post";
-      "masc_board_comment";
-      "masc_board_vote";
-      "masc_worktree_create";
-      "masc_worktree_remove";
-      "masc_run_init";
-      "masc_run_plan";
-      "masc_run_log";
-      "masc_run_deliverable";
-      "masc_repair_loop_start";
-      "masc_repair_loop_iterate";
-      "masc_repair_loop_stop";
-    ];
-  }
+  Team_session_worker_run_meta.supported_local_worker_tool_names
 
 let supported_local_worker_tool_names_for_scope execution_scope =
-  match execution_scope with
-  | Some Team_session_types.Observe_only ->
-      Tool_access_policy.resolve observe_only_policy
-  | Some Team_session_types.Limited_code_change
-  | Some Team_session_types.Autonomous
-  | None ->
-      supported_local_worker_tool_names
+  Team_session_worker_run_meta.supported_local_worker_tool_names_for_scope
+    execution_scope
 
 let supported_local_worker_tools () =
   match
@@ -341,28 +314,12 @@ let create_team_session_raw_trace ~(config : Room.config) ~(session_id : string)
         agent_name (Oas.Error.to_string err);
       None
 
-let trace_ref_to_json (trace_ref : Oas.Raw_trace.run_ref) =
-  `Assoc
-    [
-      ("worker_run_id", `String trace_ref.worker_run_id);
-      ("start_seq", `Int trace_ref.start_seq);
-      ("end_seq", `Int trace_ref.end_seq);
-      ("agent_name", `String trace_ref.agent_name);
-      ( "session_id",
-        match trace_ref.session_id with
-        | Some session_id -> `String session_id
-        | None -> `Null );
-    ]
-
 let preview_text text =
   String.sub text 0 (min 200 (String.length text))
 
 let preview_text_opt text =
   let trimmed = String.trim text in
   if trimmed = "" then None else Some (preview_text trimmed)
-
-let proof_result_status_to_string =
-  Oas_worker_exec.proof_result_status_to_string
 
 let worker_name_of_planned_worker ~(fallback : string)
     (pw : Team_session_types.planned_worker) =
@@ -442,6 +399,7 @@ let persist_worker_run_artifacts ~(config : Room.config)
     ~(planned_worker : Team_session_types.planned_worker)
     ~(resolved_model : string option)
     ~(trace_ref : Oas.Raw_trace.run_ref option)
+    ?evidence_session_id
     ~(success : bool)
     ~(output_preview : string option)
     ~(error : string option)
@@ -453,162 +411,24 @@ let persist_worker_run_artifacts ~(config : Room.config)
     Team_session_types.effective_execution_scope_of_planned_worker
       planned_worker
   in
-  let tool_surface_masc_names =
-    supported_local_worker_tool_names_for_scope
-      (Some effective_execution_scope)
-    |> Team_session_types.dedup_strings |> List.sort String.compare
-  in
-  let proof_tool_names =
-    match proof_opt with
-    | Some proof -> proof.capability_snapshot.tools
-    | None -> []
-  in
-  let tool_surface_names =
-    Team_session_types.dedup_strings
-      (proof_tool_names @ tool_surface_masc_names)
-    |> List.sort String.compare
-  in
-  let tool_surface_status =
-    if tool_surface_names <> [] then `String "available" else `String "missing"
-  in
-  let tool_surface_source =
-    if tool_surface_names <> [] then `String "swarm_masc_tools" else `Null
-  in
   let worker_name =
     worker_name_of_planned_worker ~fallback:fallback_name planned_worker
   in
-  let proof_fields =
-    let null_fields =
-      [
-        ("cdal_run_id", `Null);
-        ("contract_id", `Null);
-        ("requested_execution_mode", `Null);
-        ("effective_execution_mode", `Null);
-        ("risk_class", `Null);
-        ("result_status", `Null);
-        ("tool_trace_refs", `List []);
-        ("raw_evidence_refs", `List []);
-        ("checkpoint_ref", `Null);
-        ("proof_path", `Null);
-        ("proof_present", `Bool false);
-        ("proof_run_id", `Null);
-        ("proof_status", `Null);
-        ("proof_risk_class", `Null);
-        ("proof_execution_mode", `Null);
-        ("proof_evidence_count", `Null);
-      ]
-    in
-    match proof_opt with
-    | Some proof when is_safe_worker_run_id proof.run_id ->
-        let proof_path =
-          Team_session_store.worker_run_proof_path config session_id worker_run_id
-        in
-        Team_session_store.save_worker_run_proof_json config session_id
-          worker_run_id (Oas.Cdal_proof.to_json proof);
-        [
-          ("cdal_run_id", `String proof.run_id);
-          ("contract_id", `String proof.contract_id);
-          ( "requested_execution_mode",
-            `String
-              (Oas.Execution_mode.to_string proof.requested_execution_mode)
-          );
-          ( "effective_execution_mode",
-            `String
-              (Oas.Execution_mode.to_string proof.effective_execution_mode)
-          );
-          ("risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
-          ("result_status", `String (proof_result_status_to_string proof.result_status));
-          ( "tool_trace_refs",
-            `List
-              (List.map (fun ref_ -> `String ref_) proof.tool_trace_refs)
-          );
-          ( "raw_evidence_refs",
-            `List
-              (List.map (fun ref_ -> `String ref_) proof.raw_evidence_refs)
-          );
-          ( "checkpoint_ref",
-            Option.fold ~none:`Null ~some:(fun ref_ -> `String ref_)
-              proof.checkpoint_ref );
-          ("proof_path", `String proof_path);
-          ("proof_present", `Bool true);
-          ("proof_run_id", `String proof.run_id);
-          ("proof_status", `String (proof_result_status_to_string proof.result_status));
-          ("proof_risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
-          ( "proof_execution_mode",
-            `String
-              (Oas.Execution_mode.to_string proof.effective_execution_mode)
-          );
-          ("proof_evidence_count", `Int (List.length proof.raw_evidence_refs));
-        ]
-    | Some proof ->
-        Log.Session.warn
-          "team_session_oas_bridge: skipping proof persistence for unsafe worker run id %S"
-          proof.run_id;
-        null_fields
-    | None -> null_fields
+  let oas_evidence =
+    Option.bind evidence_session_id (fun session_id ->
+        Team_session_worker_run_meta.load_oas_worker_evidence ~config
+          ~evidence_session_id:session_id)
   in
-  Team_session_store.save_worker_run_meta_json config session_id
-    worker_run_id
-    (`Assoc
-      ([
-        ("worker_run_id", `String worker_run_id);
-        ("worker_name", `String worker_name);
-        ("mode", `String "swarm");
-        ("status", `String (if success then "completed" else "failed"));
-        ("wait_mode", `String "background");
-        ( "trace_capability",
-          `String
-            (if Option.is_some trace_ref then "raw" else "summary_only")
-        );
-        ("success", `Bool success);
-        ( "execution_scope",
-          Option.fold ~none:`Null
-            ~some:(fun scope ->
-              `String
-                (Team_session_types.execution_scope_to_string scope))
-            planned_worker.execution_scope );
-        ("tool_surface_status", tool_surface_status);
-        ("tool_surface_source", tool_surface_source);
-        ( "tool_surface_names",
-          `List
-            (List.map (fun value -> `String value) tool_surface_names)
-        );
-        ( "tool_surface_masc_names",
-          `List
-            (List.map
-               (fun value -> `String value)
-               tool_surface_masc_names) );
-        ("tool_surface_shell_names", `List []);
-        ( "requested_worker_class",
-          Option.fold ~none:`Null
-            ~some:(fun kind ->
-              `String
-                (Team_session_types.worker_class_to_string kind))
-            planned_worker.worker_class );
-        ("resolved_runtime", `String "oas_swarm");
-        ( "resolved_model",
-          Option.fold ~none:`Null ~some:(fun value -> `String value)
-            resolved_model );
-        ( "routing_reason",
-          Option.fold ~none:`Null ~some:(fun value -> `String value)
-            planned_worker.routing_reason );
-        ( "output_preview",
-          Option.fold ~none:`Null ~some:(fun value -> `String value)
-            output_preview );
-        ("error", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
-        ( "trace_ref",
-          Option.fold ~none:`Null ~some:trace_ref_to_json trace_ref );
-        ("trace_summary", `Null);
-        ("trace_validation", `Null);
-        ("evidence_session_id", `Null);
-        ("oas_worker_run", `Null);
-        ("session_conformance", `Null);
-        ("validated", `Null);
-        ("final_text", Option.fold ~none:`Null ~some:(fun value -> `String value) output_preview);
-        ("stop_reason", `Null);
-        ("failure_reason", Option.fold ~none:`Null ~some:(fun value -> `String value) error);
-        ("ts_iso", `String (Types.now_iso ()));
-      ] @ proof_fields))
+  Team_session_worker_run_meta.persist ~config ~session_id ~worker_run_id
+    ~worker_name ~mode:"swarm"
+    ~wait_mode:Team_session_types.Wait_background
+    ~execution_scope:effective_execution_scope
+    ?requested_worker_class:planned_worker.worker_class
+    ~resolved_runtime:"oas_swarm" ?resolved_model
+    ?routing_reason:planned_worker.routing_reason
+    ~status:(`String (if success then "completed" else "failed")) ~success
+    ?output_preview ?error ?trace_ref ?evidence_session_id ?oas_evidence
+    ?final_text:output_preview ?failure_reason:error ?proof:proof_opt ()
 
 let make_convergence_metric ~(entry_count : int)
     (success_by_agent : (string, bool) Hashtbl.t) :
@@ -772,6 +592,7 @@ let planned_worker_to_entry_with_state
         persist_worker_run_artifacts ~config ~session_id
           ~fallback_name:name ~planned_worker:pw
           ~resolved_model:(Some result.response.model)
+          ~evidence_session_id:result.session_id
           ~trace_ref:result.trace_ref ~success:true ~output_preview
           ~error:None proof_opt;
         Ok result.response

--- a/lib/team_session_worker_run_meta.ml
+++ b/lib/team_session_worker_run_meta.ml
@@ -1,0 +1,781 @@
+module U = Yojson.Safe.Util
+
+type oas_worker_evidence = Tool_team_session_step_types.oas_worker_evidence = {
+  trace_ref : Oas.Raw_trace.run_ref option;
+  trace_summary_json : Yojson.Safe.t option;
+  trace_validation_json : Yojson.Safe.t option;
+  worker_json : Yojson.Safe.t option;
+  conformance_json : Yojson.Safe.t option;
+  worker : Oas.Sessions.worker_run option;
+}
+
+let proof_result_status_to_string = Oas_worker_exec.proof_result_status_to_string
+
+let oas_trace_session_root config =
+  Filename.concat (Room_utils.masc_dir config) "oas-runtime"
+
+let load_oas_worker_evidence ~(config : Room.config)
+    ~(evidence_session_id : string) =
+  let session_root = oas_trace_session_root config in
+  match
+    Oas.Sessions.get_proof_bundle ~session_root ~session_id:evidence_session_id
+      (),
+    Oas.Conformance.run ~session_root ~session_id:evidence_session_id ()
+  with
+  | Ok bundle, Ok report ->
+      let latest_trace_run = bundle.latest_raw_trace_run in
+      let worker = bundle.latest_worker_run in
+      let trace_summary_json =
+        match latest_trace_run with
+        | Some run_ref -> (
+            match
+              List.find_opt
+                (fun (summary : Oas.Sessions.raw_trace_summary) ->
+                  String.equal summary.run_ref.worker_run_id
+                    run_ref.worker_run_id)
+                bundle.raw_trace_summaries
+            with
+            | Some summary -> Some (Oas.Raw_trace.run_summary_to_yojson summary)
+            | None -> None)
+        | None -> None
+      in
+      let trace_validation_json =
+        match latest_trace_run with
+        | Some run_ref -> (
+            match
+              List.find_opt
+                (fun (validation : Oas.Sessions.raw_trace_validation) ->
+                  String.equal validation.run_ref.worker_run_id
+                    run_ref.worker_run_id)
+                bundle.raw_trace_validations
+            with
+            | Some validation ->
+                Some (Oas.Raw_trace.run_validation_to_yojson validation)
+            | None -> None)
+        | None -> None
+      in
+      Some
+        {
+          trace_ref = latest_trace_run;
+          trace_summary_json;
+          trace_validation_json;
+          worker_json = Option.map Oas.Sessions.worker_run_to_yojson worker;
+          conformance_json = Some (Oas.Conformance.report_to_yojson report);
+          worker;
+        }
+  | _ -> None
+
+let supported_local_worker_tool_names =
+  Tool_catalog.tools_for_surface Tool_catalog.Local_worker
+
+let observe_only_policy : Tool_access_policy.t =
+  {
+    allow = Surface Tool_catalog.Local_worker;
+    deny =
+      Names
+        [
+          "masc_add_task";
+          "masc_claim_next";
+          "masc_transition";
+          "masc_board_post";
+          "masc_board_comment";
+          "masc_board_vote";
+          "masc_worktree_create";
+          "masc_worktree_remove";
+          "masc_run_init";
+          "masc_run_plan";
+          "masc_run_log";
+          "masc_run_deliverable";
+          "masc_repair_loop_start";
+          "masc_repair_loop_iterate";
+          "masc_repair_loop_stop";
+        ];
+  }
+
+let supported_local_worker_tool_names_for_scope execution_scope =
+  match execution_scope with
+  | Some Team_session_types.Observe_only ->
+      Tool_access_policy.resolve observe_only_policy
+  | Some Team_session_types.Limited_code_change
+  | Some Team_session_types.Autonomous
+  | None ->
+      supported_local_worker_tool_names
+
+let local_shell_tool_names_of_scope = function
+  | Team_session_types.Observe_only ->
+      [ "file_read"; "shell_exec" ]
+  | _ ->
+      [ "file_read"; "file_write"; "shell_exec" ]
+
+let json_string_list values =
+  `List (List.map (fun value -> `String value) values)
+
+let dedup_tool_names values =
+  Team_session_types.dedup_strings values |> List.sort String.compare
+
+let tool_surface_source_of_mode = function
+  | "swarm" -> Some "swarm_masc_tools"
+  | "spawn" | "delegate" -> Some "local_worker_tools"
+  | _ -> None
+
+let trace_capability_to_string : Oas.Sessions.trace_capability -> string =
+  function
+  | Oas.Sessions.Raw -> "raw"
+  | Oas.Sessions.Summary_only -> "summary_only"
+  | Oas.Sessions.No_trace -> "none"
+
+let prefer_option primary fallback =
+  match primary with Some _ -> primary | None -> fallback
+
+let prefer_nonempty_string primary fallback =
+  match primary with
+  | Some value when String.trim value <> "" -> Some value
+  | _ -> fallback
+
+let string_member_opt key json =
+  match U.member key json with
+  | `String value when String.trim value <> "" -> Some (String.trim value)
+  | _ -> None
+
+let int_member_opt key json =
+  match U.member key json with
+  | `Int value -> Some value
+  | `Intlit value -> int_of_string_opt value
+  | _ -> None
+
+let bool_member ~default key json =
+  match U.member key json with
+  | `Bool value -> value
+  | _ -> default
+
+let json_member_opt key json =
+  match U.member key json with `Null -> None | other -> Some other
+
+let string_list_member key json =
+  match U.member key json with
+  | `List items ->
+      items
+      |> List.filter_map (function
+           | `String value when String.trim value <> "" ->
+               Some (String.trim value)
+           | _ -> None)
+  | _ -> []
+
+let execution_scope_member_opt key json =
+  string_member_opt key json
+  |> Option.map (fun value ->
+         Team_session_types.execution_scope_of_string
+           (String.lowercase_ascii value))
+
+let worker_class_member_opt key json =
+  match string_member_opt key json with
+  | Some value ->
+      Team_session_types.worker_class_of_string
+        (String.lowercase_ascii value)
+  | None -> None
+
+let wait_mode_member key json =
+  string_member_opt key json
+  |> Option.map String.lowercase_ascii
+  |> Option.map Team_session_types.wait_mode_of_string
+  |> Option.value ~default:Team_session_types.Wait_background
+
+let trace_ref_member_opt key json =
+  match U.member key json with
+  | `Assoc _ as value -> (
+      match Oas.Raw_trace.run_ref_of_yojson value with
+      | Ok run_ref -> Some run_ref
+      | Error msg ->
+          Log.Session.warn
+            "team_session_worker_run_meta: dropping invalid trace_ref: %s"
+            msg;
+          None)
+  | _ -> None
+
+let load_saved_proof ~(config : Room.config) ~(session_id : string)
+    ~(worker_run_id : string) =
+  let path =
+    Team_session_store.worker_run_proof_path config session_id worker_run_id
+  in
+  if not (Room_utils.path_exists config path) then
+    None
+  else
+    match Oas.Cdal_proof.of_json (Room_utils.read_json config path) with
+    | Ok proof -> Some proof
+    | Error msg ->
+        Log.Session.warn
+          "team_session_worker_run_meta: dropping invalid saved proof for worker_run=%s: %s"
+          worker_run_id msg;
+        None
+
+let rec canonicalize_json = function
+  | `Assoc fields ->
+      `Assoc
+        (fields
+        |> List.map (fun (key, value) -> (key, canonicalize_json value))
+        |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | `List items -> `List (List.map canonicalize_json items)
+  | other -> other
+
+let comparable_json json =
+  match json with
+  | `Assoc fields ->
+      `Assoc
+        (fields
+        |> List.filter (fun (key, _) -> not (String.equal key "ts_iso"))
+        |> List.map (fun (key, value) -> (key, canonicalize_json value))
+        |> List.sort (fun (left, _) (right, _) -> String.compare left right))
+  | other -> canonicalize_json other
+
+let changed_fields ~before ~after =
+  let before_fields =
+    match before with `Assoc fields -> fields | _ -> []
+  in
+  let after_fields =
+    match after with `Assoc fields -> fields | _ -> []
+  in
+  let keys =
+    List.map fst before_fields @ List.map fst after_fields
+    |> List.filter (fun key -> not (String.equal key "ts_iso"))
+    |> Team_session_types.dedup_strings
+    |> List.sort String.compare
+  in
+  List.filter
+    (fun key ->
+      let before_value =
+        List.assoc_opt key before_fields |> Option.value ~default:`Null
+      in
+      let after_value =
+        List.assoc_opt key after_fields |> Option.value ~default:`Null
+      in
+      not
+        (Yojson.Safe.equal (canonicalize_json before_value)
+           (canonicalize_json after_value)))
+    keys
+
+let tool_surface_fields ~mode ?execution_scope ?(proof : Oas.Cdal_proof.t option)
+    () =
+  let tool_surface_masc_names =
+    match mode, execution_scope with
+    | "swarm", Some scope ->
+        supported_local_worker_tool_names_for_scope (Some scope)
+    | ("spawn" | "delegate"), Some scope ->
+        supported_local_worker_tool_names_for_scope (Some scope)
+    | _ -> []
+  in
+  let tool_surface_shell_names =
+    match mode, execution_scope with
+    | ("spawn" | "delegate"), Some scope ->
+        local_shell_tool_names_of_scope scope
+    | _ -> []
+  in
+  let tool_surface_names =
+    let proof_tool_names =
+      match proof with
+      | Some proof -> proof.capability_snapshot.tools
+      | None -> []
+    in
+    dedup_tool_names
+      (proof_tool_names @ tool_surface_masc_names @ tool_surface_shell_names)
+  in
+  [
+    ( "tool_surface_status",
+      `String
+        (if tool_surface_names <> [] then "available" else "missing") );
+    ( "tool_surface_source",
+      Option.fold ~none:`Null ~some:(fun value -> `String value)
+        (if tool_surface_names <> [] then tool_surface_source_of_mode mode
+         else None) );
+    ("tool_surface_names", json_string_list tool_surface_names);
+    ("tool_surface_masc_names", json_string_list tool_surface_masc_names);
+    ("tool_surface_shell_names", json_string_list tool_surface_shell_names);
+  ]
+
+let proof_fields ~(config : Room.config) ~(session_id : string)
+    ~(worker_run_id : string) ?(persist_proof_json = false)
+    ?(proof : Oas.Cdal_proof.t option) () =
+  let null_fields =
+    [
+      ("cdal_run_id", `Null);
+      ("contract_id", `Null);
+      ("requested_execution_mode", `Null);
+      ("effective_execution_mode", `Null);
+      ("risk_class", `Null);
+      ("result_status", `Null);
+      ("tool_trace_refs", `List []);
+      ("raw_evidence_refs", `List []);
+      ("checkpoint_ref", `Null);
+      ("proof_path", `Null);
+      ("proof_present", `Bool false);
+      ("proof_run_id", `Null);
+      ("proof_status", `Null);
+      ("proof_risk_class", `Null);
+      ("proof_execution_mode", `Null);
+      ("proof_evidence_count", `Null);
+    ]
+  in
+  match proof with
+  | None -> null_fields
+  | Some proof -> (
+      match Repo_synthesis_benchmark.validate_run_id proof.run_id with
+      | Error msg ->
+          Log.Session.warn
+            "team_session_worker_run_meta: dropping invalid proof_run_id for worker_run=%s: %s"
+            worker_run_id msg;
+          null_fields
+      | Ok run_id ->
+          let proof_path =
+            Team_session_store.worker_run_proof_path config session_id
+              worker_run_id
+          in
+          if persist_proof_json then
+            Team_session_store.save_worker_run_proof_json config session_id
+              worker_run_id (Oas.Cdal_proof.to_json proof);
+          [
+            ("cdal_run_id", `String run_id);
+            ("contract_id", `String proof.contract_id);
+            ( "requested_execution_mode",
+              `String
+                (Oas.Execution_mode.to_string proof.requested_execution_mode)
+            );
+            ( "effective_execution_mode",
+              `String
+                (Oas.Execution_mode.to_string proof.effective_execution_mode)
+            );
+            ("risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
+            ( "result_status",
+              `String (proof_result_status_to_string proof.result_status) );
+            ("tool_trace_refs", json_string_list proof.tool_trace_refs);
+            ("raw_evidence_refs", json_string_list proof.raw_evidence_refs);
+            ( "checkpoint_ref",
+              Option.fold ~none:`Null ~some:(fun value -> `String value)
+                proof.checkpoint_ref );
+            ("proof_path", `String proof_path);
+            ("proof_present", `Bool true);
+            ("proof_run_id", `String run_id);
+            ( "proof_status",
+              `String (proof_result_status_to_string proof.result_status) );
+            ("proof_risk_class", `String (Oas.Risk_class.to_string proof.risk_class));
+            ( "proof_execution_mode",
+              `String
+                (Oas.Execution_mode.to_string proof.effective_execution_mode)
+            );
+            ("proof_evidence_count", `Int (List.length proof.raw_evidence_refs));
+          ])
+
+let build_json ~(config : Room.config) ~(session_id : string)
+    ~(worker_run_id : string) ~(worker_name : string) ~(mode : string)
+    ~(wait_mode : Team_session_types.wait_mode) ?execution_scope
+    ?requested_worker_class ?resolved_runtime ?resolved_model ?routing_reason
+    ?(tool_names : string list option) ?tool_call_count ~(status : Yojson.Safe.t)
+    ~(success : bool) ?output_preview ?error ?trace_capability ?trace_ref
+    ?trace_summary ?trace_validation ?evidence_session_id
+    ?(oas_evidence : oas_worker_evidence option) ?final_text ?stop_reason
+    ?failure_reason ?(proof : Oas.Cdal_proof.t option)
+    ?(persist_proof_json = false) () =
+  let oas_worker = Option.bind oas_evidence (fun payload -> payload.worker) in
+  let effective_trace_ref =
+    prefer_option (Option.bind oas_evidence (fun payload -> payload.trace_ref))
+      trace_ref
+  in
+  let effective_trace_summary =
+    prefer_option
+      (Option.bind oas_evidence (fun payload -> payload.trace_summary_json))
+      trace_summary
+  in
+  let effective_trace_validation =
+    prefer_option
+      (Option.bind oas_evidence (fun payload -> payload.trace_validation_json))
+      trace_validation
+  in
+  let effective_status =
+    match oas_worker with
+    | Some worker -> Oas.Sessions.worker_status_to_yojson worker.status
+    | None -> status
+  in
+  let effective_trace_capability =
+    match oas_worker with
+    | Some worker ->
+        trace_capability_to_string worker.Oas.Sessions.trace_capability
+    | None -> (
+        match trace_capability with
+        | Some value -> value
+        | None when Option.is_some effective_trace_ref -> "raw"
+        | None -> "summary_only")
+  in
+  let effective_tool_names =
+    match oas_worker with
+    | Some worker when worker.tool_names <> [] -> worker.tool_names
+    | _ -> Option.value ~default:[] tool_names
+  in
+  let effective_resolved_model =
+    match oas_worker with
+    | Some worker -> prefer_option worker.resolved_model resolved_model
+    | None -> resolved_model
+  in
+  let effective_error =
+    match oas_worker with
+    | Some worker ->
+        prefer_nonempty_string worker.failure_reason
+          (prefer_nonempty_string worker.error error)
+    | None -> error
+  in
+  let effective_final_text =
+    match oas_worker with
+    | Some worker -> prefer_nonempty_string worker.final_text final_text
+    | None -> final_text
+  in
+  let effective_output_preview =
+    prefer_nonempty_string effective_final_text output_preview
+  in
+  let effective_stop_reason =
+    match oas_worker with
+    | Some worker -> prefer_nonempty_string worker.stop_reason stop_reason
+    | None -> stop_reason
+  in
+  let effective_failure_reason =
+    match oas_worker with
+    | Some worker ->
+        prefer_nonempty_string worker.failure_reason failure_reason
+    | None -> failure_reason
+  in
+  let tool_surface_fields =
+    tool_surface_fields ~mode ?execution_scope ?proof ()
+  in
+  let proof_fields =
+    proof_fields ~config ~session_id ~worker_run_id ~persist_proof_json ?proof
+      ()
+  in
+  `Assoc
+    ([
+       ("worker_run_id", `String worker_run_id);
+       ("worker_name", `String worker_name);
+       ("mode", `String mode);
+       ("status", effective_status);
+       ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
+       ("trace_capability", `String effective_trace_capability);
+       ("success", `Bool success);
+       ( "execution_scope",
+         Option.fold ~none:`Null
+           ~some:(fun scope ->
+             `String (Team_session_types.execution_scope_to_string scope))
+           execution_scope );
+       ( "requested_worker_class",
+         Option.fold ~none:`Null
+           ~some:(fun kind ->
+             `String (Team_session_types.worker_class_to_string kind))
+           requested_worker_class );
+       ( "resolved_runtime",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           resolved_runtime );
+       ( "resolved_model",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           effective_resolved_model );
+       ( "routing_reason",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           routing_reason );
+       ("tool_names", json_string_list effective_tool_names);
+       ( "tool_call_count",
+         Option.fold ~none:`Null ~some:(fun value -> `Int value)
+           tool_call_count );
+       ( "output_preview",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           effective_output_preview );
+       ( "error",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           effective_error );
+       ( "trace_ref",
+         Option.fold ~none:`Null ~some:Oas.Raw_trace.run_ref_to_yojson
+           effective_trace_ref );
+       ( "trace_summary",
+         Option.fold ~none:`Null ~some:(fun json -> json)
+           effective_trace_summary );
+       ( "trace_validation",
+         Option.fold ~none:`Null ~some:(fun json -> json)
+           effective_trace_validation );
+       ( "evidence_session_id",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           evidence_session_id );
+       ( "oas_worker_run",
+         Option.fold ~none:`Null ~some:(fun json -> json)
+           (Option.bind oas_evidence (fun payload -> payload.worker_json)) );
+       ( "session_conformance",
+         Option.fold ~none:`Null ~some:(fun json -> json)
+           (Option.bind oas_evidence (fun payload -> payload.conformance_json))
+       );
+       ( "validated",
+         Option.fold ~none:`Null
+           ~some:(fun worker -> `Bool worker.Oas.Sessions.validated)
+           oas_worker );
+       ( "final_text",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           effective_final_text );
+       ( "stop_reason",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           effective_stop_reason );
+       ( "failure_reason",
+         Option.fold ~none:`Null ~some:(fun value -> `String value)
+           effective_failure_reason );
+       ("ts_iso", `String (Types.now_iso ()));
+     ]
+    @ tool_surface_fields @ proof_fields)
+
+let persist ~(config : Room.config) ~(session_id : string)
+    ~(worker_run_id : string) ~(worker_name : string) ~(mode : string)
+    ~(wait_mode : Team_session_types.wait_mode) ?execution_scope
+    ?requested_worker_class ?resolved_runtime ?resolved_model ?routing_reason
+    ?(tool_names : string list option) ?tool_call_count ~(status : Yojson.Safe.t)
+    ~(success : bool) ?output_preview ?error ?trace_capability ?trace_ref
+    ?trace_summary ?trace_validation ?evidence_session_id
+    ?(oas_evidence : oas_worker_evidence option) ?final_text ?stop_reason
+    ?failure_reason ?(proof : Oas.Cdal_proof.t option) () =
+  let json =
+    build_json ~config ~session_id ~worker_run_id ~worker_name ~mode ~wait_mode
+      ?execution_scope ?requested_worker_class ?resolved_runtime
+      ?resolved_model ?routing_reason ?tool_names ?tool_call_count ~status
+      ~success ?output_preview ?error ?trace_capability ?trace_ref
+      ?trace_summary ?trace_validation ?evidence_session_id ?oas_evidence
+      ?final_text ?stop_reason ?failure_reason ?proof
+      ~persist_proof_json:true ()
+  in
+  Team_session_store.save_worker_run_meta_json config session_id worker_run_id
+    json
+
+type repair_status =
+  | Repair_would_apply
+  | Repair_applied
+  | Repair_unchanged
+  | Repair_skipped
+
+type repair_item = {
+  worker_run_id : string;
+  status : repair_status;
+  reason : string;
+  changed_fields : string list;
+  evidence_session_id : string option;
+}
+
+type repair_summary = {
+  session_id : string;
+  worker_run_filter : string option;
+  dry_run : bool;
+  scanned_count : int;
+  changed_count : int;
+  applied_count : int;
+  unchanged_count : int;
+  skipped_count : int;
+  items : repair_item list;
+}
+
+let repair_status_to_string = function
+  | Repair_would_apply -> "would_repair"
+  | Repair_applied -> "repaired"
+  | Repair_unchanged -> "unchanged"
+  | Repair_skipped -> "skipped"
+
+let repair_item_to_yojson (item : repair_item) =
+  `Assoc
+    [
+      ("worker_run_id", `String item.worker_run_id);
+      ("status", `String (repair_status_to_string item.status));
+      ("reason", `String item.reason);
+      ("changed_fields", json_string_list item.changed_fields);
+      ( "evidence_session_id",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          item.evidence_session_id );
+    ]
+
+let repair_summary_to_yojson (summary : repair_summary) =
+  `Assoc
+    [
+      ("session_id", `String summary.session_id);
+      ( "worker_run_id",
+        Option.fold ~none:`Null ~some:(fun value -> `String value)
+          summary.worker_run_filter );
+      ("dry_run", `Bool summary.dry_run);
+      ("scanned_count", `Int summary.scanned_count);
+      ("changed_count", `Int summary.changed_count);
+      ("applied_count", `Int summary.applied_count);
+      ("unchanged_count", `Int summary.unchanged_count);
+      ("skipped_count", `Int summary.skipped_count);
+      ("items", `List (List.map repair_item_to_yojson summary.items));
+    ]
+
+let mode_of_existing_meta json =
+  match string_member_opt "mode" json with
+  | Some value -> value
+  | None -> (
+      match string_member_opt "tool_surface_source" json with
+      | Some "swarm_masc_tools" -> "swarm"
+      | _ -> "delegate")
+
+let status_of_existing_meta json =
+  match U.member "status" json with
+  | `Null -> `String "failed"
+  | other -> other
+
+let candidate_json_of_existing_meta ~(config : Room.config)
+    ~(session_id : string) ~(worker_run_id : string) ~(existing_meta : Yojson.Safe.t)
+    ?(oas_evidence : oas_worker_evidence option)
+    ?(proof : Oas.Cdal_proof.t option) () =
+  build_json ~config ~session_id ~worker_run_id
+    ~worker_name:
+      (string_member_opt "worker_name" existing_meta
+      |> Option.value ~default:worker_run_id)
+    ~mode:(mode_of_existing_meta existing_meta)
+    ~wait_mode:(wait_mode_member "wait_mode" existing_meta)
+    ?execution_scope:(execution_scope_member_opt "execution_scope" existing_meta)
+    ?requested_worker_class:
+      (worker_class_member_opt "requested_worker_class" existing_meta)
+    ?resolved_runtime:(string_member_opt "resolved_runtime" existing_meta)
+    ?resolved_model:(string_member_opt "resolved_model" existing_meta)
+    ?routing_reason:(string_member_opt "routing_reason" existing_meta)
+    ?tool_names:(Some (string_list_member "tool_names" existing_meta))
+    ?tool_call_count:(int_member_opt "tool_call_count" existing_meta)
+    ~status:(status_of_existing_meta existing_meta)
+    ~success:(bool_member ~default:false "success" existing_meta)
+    ?output_preview:(string_member_opt "output_preview" existing_meta)
+    ?error:(string_member_opt "error" existing_meta)
+    ?trace_capability:(string_member_opt "trace_capability" existing_meta)
+    ?trace_ref:(trace_ref_member_opt "trace_ref" existing_meta)
+    ?trace_summary:(json_member_opt "trace_summary" existing_meta)
+    ?trace_validation:(json_member_opt "trace_validation" existing_meta)
+    ?evidence_session_id:(string_member_opt "evidence_session_id" existing_meta)
+    ?oas_evidence
+    ?final_text:(string_member_opt "final_text" existing_meta)
+    ?stop_reason:(string_member_opt "stop_reason" existing_meta)
+    ?failure_reason:(string_member_opt "failure_reason" existing_meta)
+    ?proof ~persist_proof_json:false ()
+
+let repair_session_with ~(config : Room.config) ~(session_id : string)
+    ?worker_run_id ~(dry_run : bool)
+    ~(load_oas_evidence : evidence_session_id:string -> oas_worker_evidence option)
+    ~(load_saved_proof :
+       session_id:string -> worker_run_id:string -> Oas.Cdal_proof.t option)
+    () =
+  match Team_session_store.load_session config session_id with
+  | None -> Error (Printf.sprintf "team session not found: %s" session_id)
+  | Some _ ->
+      let available_worker_run_ids =
+        Team_session_store.list_worker_run_ids config session_id
+      in
+      let worker_run_ids =
+        match worker_run_id with
+        | Some target when List.mem target available_worker_run_ids -> Ok [ target ]
+        | Some target ->
+            Error (Printf.sprintf "worker run not found: %s" target)
+        | None -> Ok available_worker_run_ids
+      in
+      Result.map
+        (fun worker_run_ids ->
+          let items =
+            List.map
+              (fun worker_run_id ->
+                let meta_path =
+                  Team_session_store.worker_run_meta_path config session_id
+                    worker_run_id
+                in
+                if not (Room_utils.path_exists config meta_path) then
+                  {
+                    worker_run_id;
+                    status = Repair_skipped;
+                    reason = "meta_missing";
+                    changed_fields = [];
+                    evidence_session_id = None;
+                  }
+                else
+                  let existing_meta = Room_utils.read_json config meta_path in
+                  let evidence_session_id =
+                    string_member_opt "evidence_session_id" existing_meta
+                  in
+                  let oas_evidence =
+                    Option.bind evidence_session_id (fun evidence_session_id ->
+                        load_oas_evidence ~evidence_session_id)
+                  in
+                  let proof =
+                    load_saved_proof ~session_id ~worker_run_id
+                  in
+                  if Option.is_none oas_evidence && Option.is_none proof then
+                    {
+                      worker_run_id;
+                      status = Repair_skipped;
+                      reason = "recoverable_source_missing";
+                      changed_fields = [];
+                      evidence_session_id;
+                    }
+                  else
+                    let candidate_json =
+                      candidate_json_of_existing_meta ~config ~session_id
+                        ~worker_run_id ~existing_meta ?oas_evidence ?proof ()
+                    in
+                    let candidate_json =
+                      Team_session_store.normalize_worker_run_meta_json config
+                        ~session_id ~worker_run_id candidate_json
+                    in
+                    let changed_fields =
+                      changed_fields ~before:existing_meta ~after:candidate_json
+                    in
+                    if changed_fields = [] then
+                      {
+                        worker_run_id;
+                        status = Repair_unchanged;
+                        reason = "already_enriched";
+                        changed_fields;
+                        evidence_session_id;
+                      }
+                    else (
+                      if not dry_run then begin
+                        Team_session_store.save_worker_run_meta_json config
+                          session_id worker_run_id candidate_json;
+                        Option.iter
+                          (fun proof ->
+                            Team_session_store.save_worker_run_proof_json config
+                              session_id worker_run_id
+                              (Oas.Cdal_proof.to_json proof))
+                          proof
+                      end;
+                      {
+                        worker_run_id;
+                        status =
+                          (if dry_run then Repair_would_apply
+                           else Repair_applied);
+                        reason =
+                          (if dry_run then "repair_available" else "repaired");
+                        changed_fields;
+                        evidence_session_id;
+                      }))
+              worker_run_ids
+          in
+          let count_by predicate =
+            List.fold_left
+              (fun acc item -> if predicate item then acc + 1 else acc)
+              0 items
+          in
+          {
+            session_id;
+            worker_run_filter = worker_run_id;
+            dry_run;
+            scanned_count = List.length worker_run_ids;
+            changed_count =
+              count_by (fun item ->
+                  match item.status with
+                  | Repair_would_apply | Repair_applied -> true
+                  | Repair_unchanged | Repair_skipped -> false);
+            applied_count =
+              count_by (fun item -> item.status = Repair_applied);
+            unchanged_count =
+              count_by (fun item -> item.status = Repair_unchanged);
+            skipped_count =
+              count_by (fun item -> item.status = Repair_skipped);
+            items;
+          })
+        worker_run_ids
+
+let repair_session ~(config : Room.config) ~(session_id : string) ?worker_run_id
+    ~(dry_run : bool) () =
+  repair_session_with ~config ~session_id ?worker_run_id ~dry_run
+    ~load_oas_evidence:(fun ~evidence_session_id ->
+      load_oas_worker_evidence ~config ~evidence_session_id)
+    ~load_saved_proof:(fun ~session_id ~worker_run_id ->
+      load_saved_proof ~config ~session_id ~worker_run_id)
+    ()

--- a/lib/tool_team_session_step_exec.ml
+++ b/lib/tool_team_session_step_exec.ml
@@ -33,14 +33,8 @@ let latest_delivery_verdict_json_for_session config session_id =
   Option.map Team_session_types.delivery_verdict_to_yojson
     (latest_delivery_verdict_for_session config session_id)
 
-let proof_result_status_to_string =
-  Oas_worker_exec.proof_result_status_to_string
-
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-
 let local_worker_tool_names_of_scope scope =
-  Team_session_oas_bridge.supported_local_worker_tool_names_for_scope
+  Team_session_worker_run_meta.supported_local_worker_tool_names_for_scope
     (Some scope)
 
 let local_shell_tool_names_of_scope = function
@@ -48,93 +42,6 @@ let local_shell_tool_names_of_scope = function
       [ "file_read"; "shell_exec" ]
   | _ ->
       [ "file_read"; "file_write"; "shell_exec" ]
-
-let tool_surface_source_of_mode = function
-  | "swarm" -> Some "swarm_masc_tools"
-  | "spawn" | "delegate" -> Some "local_worker_tools"
-  | _ -> None
-
-let dedup_tool_names values =
-  Team_session_types.dedup_strings values |> List.sort String.compare
-
-let tool_surface_fields ~mode ?execution_scope ?(proof : Oas.Cdal_proof.t option)
-    () =
-  let tool_surface_masc_names =
-    match mode, execution_scope with
-    | "swarm", Some scope ->
-        Team_session_oas_bridge.supported_local_worker_tool_names_for_scope
-          (Some scope)
-    | ("spawn" | "delegate"), Some scope ->
-        local_worker_tool_names_of_scope scope
-    | _ -> []
-  in
-  let tool_surface_shell_names =
-    match mode, execution_scope with
-    | ("spawn" | "delegate"), Some scope ->
-        local_shell_tool_names_of_scope scope
-    | _ -> []
-  in
-  let tool_surface_names =
-    let proof_tool_names =
-      match proof with
-      | Some proof -> proof.capability_snapshot.tools
-      | None -> []
-    in
-    dedup_tool_names
-      (proof_tool_names @ tool_surface_masc_names @ tool_surface_shell_names)
-  in
-  [
-    ( "tool_surface_status",
-      `String
-        (if tool_surface_names <> [] then "available" else "missing") );
-    ( "tool_surface_source",
-      Option.fold ~none:`Null ~some:(fun value -> `String value)
-        (if tool_surface_names <> [] then tool_surface_source_of_mode mode
-         else None) );
-    ("tool_surface_names", json_string_list tool_surface_names);
-    ("tool_surface_masc_names", json_string_list tool_surface_masc_names);
-    ("tool_surface_shell_names", json_string_list tool_surface_shell_names);
-  ]
-
-let proof_summary_fields ~(worker_run_id : string)
-    ?(proof : Oas.Cdal_proof.t option) () =
-  let null_fields =
-    [
-      ("proof_run_id", `Null);
-      ("proof_status", `Null);
-      ("proof_risk_class", `Null);
-      ("proof_execution_mode", `Null);
-      ("proof_evidence_count", `Null);
-    ]
-  in
-  match proof with
-  | None -> null_fields
-  | Some proof -> (
-      match Repo_synthesis_benchmark.validate_run_id proof.run_id with
-      | Ok run_id ->
-          [
-            ("proof_run_id", `String run_id);
-            ( "proof_status",
-              `String (proof_result_status_to_string proof.result_status) );
-            ( "proof_risk_class",
-              `String (Oas.Risk_class.to_string proof.risk_class) );
-            ( "proof_execution_mode",
-              `String
-                (Oas.Execution_mode.to_string
-                   proof.effective_execution_mode) );
-            ( "proof_evidence_count",
-              `Int (List.length proof.raw_evidence_refs) );
-            ("tool_trace_refs", json_string_list proof.tool_trace_refs);
-            ("raw_evidence_refs", json_string_list proof.raw_evidence_refs);
-            ( "checkpoint_ref",
-              Option.fold ~none:`Null ~some:(fun value -> `String value)
-                proof.checkpoint_ref );
-          ]
-      | Error msg ->
-          Log.Misc.warn
-            "team_session_step: dropping invalid proof_run_id for worker_run=%s: %s"
-            worker_run_id msg;
-          null_fields)
 
 let delivery_verdict_of_verification ~session_id ~worker_run_id
     ~(contract : Team_session_types.delivery_contract)
@@ -497,7 +404,7 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
     | Some worker -> env.deps.oas_worker_status_to_json worker.status
     | None -> env.deps.worker_run_status_to_json status
   in
-  let trace_capability =
+  let effective_trace_capability =
     match trace_capability with
     | _ when Option.is_some oas_worker ->
         Option.value ~default:"summary_only"
@@ -543,48 +450,28 @@ let persist_worker_run_snapshot (env : _ step_env) ~worker_run_id ~worker_name
         | _ -> output_preview)
     | None -> output_preview
   in
-  let proof_fields =
-    proof_summary_fields ~worker_run_id ?proof ()
-  in
-  let tool_surface_fields =
-    tool_surface_fields ~mode ?execution_scope ?proof ()
-  in
   if Room_utils.path_exists env.ctx.config checkpoint_path then
     Team_session_store.save_worker_run_checkpoint_text env.ctx.config
       env.session_id worker_run_id
       (Team_session_store.read_text_file checkpoint_path);
-  Team_session_store.save_worker_run_meta_json env.ctx.config env.session_id
-    worker_run_id
-    (`Assoc
-      ([
-        ("worker_run_id", `String worker_run_id);
-        ("worker_name", `String worker_name);
-        ("mode", `String mode);
-        ("status", effective_status);
-        ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
-        ("trace_capability", `String trace_capability);
-        ("success", `Bool success);
-        ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) execution_scope);
-        ("requested_worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) requested_worker_class);
-        ("resolved_runtime", Option.fold ~none:`Null ~some:(fun s -> `String s) resolved_runtime);
-        ("resolved_model", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_resolved_model);
-        ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) routing_reason);
-        ("tool_names", `List (List.map (fun name -> `String name) effective_tool_names));
-        ("tool_call_count", Option.fold ~none:`Null ~some:(fun n -> `Int n) tool_call_count);
-        ("output_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_output_preview);
-        ("error", Option.fold ~none:`Null ~some:(fun s -> `String s) effective_error);
-        ("trace_ref", Option.fold ~none:`Null ~some:env.deps.raw_trace_run_ref_to_json effective_trace_ref);
-        ("trace_summary", Option.fold ~none:`Null ~some:(fun json -> json) effective_trace_summary);
-        ("trace_validation", Option.fold ~none:`Null ~some:(fun json -> json) effective_trace_validation);
-        ("evidence_session_id", Option.fold ~none:`Null ~some:(fun s -> `String s) evidence_session_id);
-        ("oas_worker_run", Option.fold ~none:`Null ~some:(fun json -> json) (Option.bind oas_evidence (fun payload -> payload.worker_json)));
-        ("session_conformance", Option.fold ~none:`Null ~some:(fun json -> json) (Option.bind oas_evidence (fun payload -> payload.conformance_json)));
-        ("validated", Option.fold ~none:`Null ~some:(fun worker -> `Bool worker.Oas.Sessions.validated) oas_worker);
-        ("final_text", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.final_text) oas_worker);
-        ("stop_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.stop_reason) oas_worker);
-        ("failure_reason", Option.fold ~none:`Null ~some:(fun worker -> Option.fold ~none:`Null ~some:(fun s -> `String s) worker.Oas.Sessions.failure_reason) oas_worker);
-        ("ts_iso", `String (Types.now_iso ()));
-      ] @ tool_surface_fields @ proof_fields))
+  Team_session_worker_run_meta.persist ~config:env.ctx.config
+    ~session_id:env.session_id ~worker_run_id ~worker_name ~mode ~wait_mode
+    ?execution_scope ?requested_worker_class ?resolved_runtime
+    ?resolved_model:effective_resolved_model ?routing_reason
+    ~tool_names:effective_tool_names ?tool_call_count ~status:effective_status
+    ~success ?output_preview:effective_output_preview ?error:effective_error
+    ~trace_capability:effective_trace_capability
+    ?trace_ref:effective_trace_ref ?trace_summary:effective_trace_summary
+    ?trace_validation:effective_trace_validation ?evidence_session_id
+    ?oas_evidence
+    ?final_text:
+      (Option.bind oas_worker (fun worker -> worker.Oas.Sessions.final_text))
+    ?stop_reason:
+      (Option.bind oas_worker (fun worker -> worker.Oas.Sessions.stop_reason))
+    ?failure_reason:
+      (Option.bind oas_worker (fun worker ->
+           worker.Oas.Sessions.failure_reason))
+    ?proof ()
 
 let release_prepared_runtime (prepared : prepared_spawn) ~success
     ?error ?latency_ms () =

--- a/test/dune
+++ b/test/dune
@@ -201,6 +201,11 @@
  (modules test_worker_run_evidence_summary test_tool_team_session_support)
  (libraries masc_test_deps))
 
+(test
+ (name test_team_session_worker_run_meta_repair)
+ (modules test_team_session_worker_run_meta_repair)
+ (libraries masc_test_deps))
+
 ; ============================================================
 ; Group 3: Eio-native tests (single-module, standard deps)
 ; Merged from ~100 individual (test ...) stanzas.

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -253,6 +253,16 @@ let seed_worker_run_meta config session_id =
         ("proof_risk_class", `String "medium");
         ("proof_execution_mode", `String "execute");
         ("proof_evidence_count", `Int 2);
+        ("evidence_session_id", `String "oas-session-proof-raw");
+        ( "trace_ref",
+          `Assoc
+            [
+              ("worker_run_id", `String "wr-proof-raw");
+              ("start_seq", `Int 1);
+              ("end_seq", `Int 8);
+              ("agent_name", `String "worker-a");
+              ("session_id", `String session_id);
+            ] );
         ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
         ("tool_call_count", `Int 2);
         ("output_preview", `String "Patched calc.py and verification passed.");
@@ -321,6 +331,16 @@ let seed_raw_only_worker_run_meta config session_id =
         ("wait_mode", `String "background");
         ("trace_capability", `String "raw");
         ("success", `Bool true);
+        ("evidence_session_id", `String "oas-session-raw-only");
+        ( "trace_ref",
+          `Assoc
+            [
+              ("worker_run_id", `String "wr-raw-only");
+              ("start_seq", `Int 1);
+              ("end_seq", `Int 4);
+              ("agent_name", `String "worker-raw");
+              ("session_id", `String session_id);
+            ] );
         ("proof_present", `Bool false);
         ("proof_run_id", `Null);
         ("proof_status", `Null);
@@ -361,8 +381,14 @@ let test_dashboard_proof_projection () =
       let session_id = "ts-proof-fixture-001" in
       seed_session_artifacts config session_id;
       let json = Lib.Dashboard_proof.json ~config () in
-      check string "verdict" "proven"
+      check string "verdict requires validated worker evidence" "partial"
         (json |> U.member "proof_verdict" |> U.to_string);
+      check string "live verdict remains partial without validated worker run"
+        "partial"
+        (json |> U.member "summary" |> U.member "live_verdict" |> U.to_string);
+      check int "validated worker run count absent" 0
+        (json |> U.member "summary" |> U.member "validated_worker_run_count"
+       |> U.to_int);
       check string "session id" session_id
         (json |> U.member "session_id" |> U.to_string);
       check string "selection mode" "latest_auto_selected"
@@ -451,6 +477,11 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
         (worker |> U.member "proof_execution_mode" |> U.to_string);
       check int "worker proof evidence count" 2
         (worker |> U.member "proof_evidence_count" |> U.to_int);
+      check string "worker evidence session id" "oas-session-proof-raw"
+        (worker |> U.member "evidence_session_id" |> U.to_string);
+      check string "worker trace ref run id" "wr-proof-raw"
+        (worker |> U.member "trace_ref" |> U.member "worker_run_id"
+       |> U.to_string);
       check string "worker final text" "Patched calc.py and verification passed."
         (worker |> U.member "final_text" |> U.to_string);
       check bool "worker proof path hidden" true
@@ -483,6 +514,8 @@ let test_dashboard_proof_exposes_raw_only_worker_run_evidence () =
       let worker = List.hd worker_runs in
       check string "worker run id" "wr-raw-only"
         (worker |> U.member "worker_run_id" |> U.to_string);
+      check string "raw-only evidence session id" "oas-session-raw-only"
+        (worker |> U.member "evidence_session_id" |> U.to_string);
       check string "output preview surfaced" "Raw trace completed without proof."
         (worker |> U.member "output_preview" |> U.to_string);
       check bool "proof_present false preserved" false

--- a/test/test_persist_worker_run_snapshot.ml
+++ b/test/test_persist_worker_run_snapshot.ml
@@ -185,12 +185,18 @@ let test_persist_worker_run_snapshot_with_proof () =
     (json |> U.member "proof_run_id" |> U.to_string);
   check string "proof status" "completed"
     (json |> U.member "proof_status" |> U.to_string);
+  check string "contract id" "dc-proof"
+    (json |> U.member "contract_id" |> U.to_string);
   check string "proof risk class" "medium"
     (json |> U.member "proof_risk_class" |> U.to_string);
   check string "proof execution mode" "execute"
     (json |> U.member "proof_execution_mode" |> U.to_string);
   check int "proof evidence count" 2
     (json |> U.member "proof_evidence_count" |> U.to_int);
+  check bool "proof persisted" true
+    (json |> U.member "proof_present" |> U.to_bool);
+  check bool "proof path exists" true
+    (json |> U.member "proof_path" |> U.to_string |> Sys.file_exists);
   check string "tool surface status" "available"
     (json |> U.member "tool_surface_status" |> U.to_string);
   check string "tool surface source" "local_worker_tools"
@@ -208,6 +214,8 @@ let test_persist_worker_run_snapshot_without_proof () =
     (json |> U.member "session_id" |> U.to_string);
   check bool "proof_run_id null" true
     (json |> U.member "proof_run_id" = `Null);
+  check bool "contract_id null" true
+    (json |> U.member "contract_id" = `Null);
   check bool "proof_status null" true
     (json |> U.member "proof_status" = `Null);
   check bool "proof_risk_class null" true

--- a/test/test_team_session_worker_run_meta_repair.ml
+++ b/test/test_team_session_worker_run_meta_repair.ml
@@ -1,0 +1,323 @@
+module Lib = Masc_mcp
+module Oas = Agent_sdk
+module U = Yojson.Safe.Util
+
+open Alcotest
+
+let test_counter = ref 0
+
+let temp_dir prefix =
+  incr test_counter;
+  let dir =
+    Filename.temp_file (Printf.sprintf "%s_%d_" prefix !test_counter) ""
+  in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let sample_session session_id =
+  let now = Unix.gettimeofday () in
+  let open Team_session_types in
+  {
+    session_id;
+    goal = "repair worker run meta";
+    created_by = "repair-tester";
+    origin_kind = Origin_human;
+    room_id = "default";
+    operation_id = None;
+    status = Running;
+    duration_seconds = 300;
+    execution_scope = Limited_code_change;
+    checkpoint_interval_sec = 60;
+    min_agents = 1;
+    scale_profile = Scale_standard;
+    control_profile = Control_flat;
+    orchestration_mode = Assist;
+    communication_mode = Comm_broadcast;
+    model_cascade = [ "glm-5" ];
+    fallback_policy = Fallback_none;
+    instruction_profile = Profile_standard;
+    alert_channel = Alert_broadcast;
+    auto_resume = false;
+    report_formats = [ Markdown ];
+    turn_count = 0;
+    agent_names = [ "repair-tester" ];
+    planned_workers = [];
+    broadcast_count = 0;
+    portal_count = 0;
+    cascade_attempted = 0;
+    cascade_success = 0;
+    cascade_failed = 0;
+    fallback_task_created = 0;
+    min_agents_violation_streak = 0;
+    policy_violations = [];
+    baseline_done_counts = [];
+    final_done_delta_total = None;
+    final_done_delta_by_agent = None;
+    delivery_contract = None;
+    latest_delivery_verdict = None;
+    started_at = now -. 10.0;
+    planned_end_at = now +. 290.0;
+    stopped_at = None;
+    last_checkpoint_at = None;
+    last_event_at = None;
+    last_turn_at = None;
+    stop_reason = None;
+    generated_report = false;
+    artifacts_dir = Filename.concat ".masc/team-sessions" session_id;
+    created_at_iso = Types.now_iso ();
+    updated_at_iso = Types.now_iso ();
+  }
+
+let sample_proof ~(run_id : string) : Oas.Cdal_proof.t =
+  {
+    schema_version = Oas.Cdal_proof.schema_version_current;
+    run_id;
+    contract_id = "repair-contract";
+    requested_execution_mode = Oas.Execution_mode.Execute;
+    effective_execution_mode = Oas.Execution_mode.Execute;
+    mode_decision_source = "repair-test";
+    risk_class = Oas.Risk_class.Medium;
+    provider_snapshot =
+      {
+        Oas.Cdal_proof.provider_name = "glm";
+        model_id = "glm-5";
+        api_version = None;
+      };
+    capability_snapshot =
+      {
+        Oas.Cdal_proof.tools = [ "file_read"; "file_write"; "shell_exec" ];
+        mcp_servers = [];
+        max_turns = 8;
+        max_tokens = Some 4096;
+        thinking_enabled = None;
+      };
+    tool_trace_refs = [ "proof-store://repair/tool-trace-1" ];
+    raw_evidence_refs = [ "proof-store://repair/evidence-1" ];
+    checkpoint_ref = Some "proof-store://repair/checkpoint";
+    result_status = Oas.Cdal_proof.Completed;
+    started_at = 1.0;
+    ended_at = 2.0;
+    scope = None;
+  }
+
+let fake_trace_ref =
+  {
+    Oas.Raw_trace.worker_run_id = "wr-repair";
+    path = "/tmp/repair-trace.jsonl";
+    start_seq = 1;
+    end_seq = 4;
+    agent_name = "worker-a";
+    session_id = Some "evidence-session-1";
+  }
+
+let fake_oas_evidence =
+  {
+    Lib.Team_session_worker_run_meta.trace_ref = Some fake_trace_ref;
+    trace_summary_json =
+      Some
+        (`Assoc
+          [
+            ("run_ref", Oas.Raw_trace.run_ref_to_yojson fake_trace_ref);
+            ("event_count", `Int 4);
+          ]);
+    trace_validation_json =
+      Some
+        (`Assoc
+          [
+            ("run_ref", Oas.Raw_trace.run_ref_to_yojson fake_trace_ref);
+            ("ok", `Bool true);
+          ]);
+    worker_json =
+      Some
+        (`Assoc
+          [
+            ("worker_run_id", `String "wr-repair");
+            ("status", `String "completed");
+          ]);
+    conformance_json =
+      Some
+        (`Assoc
+          [
+            ("summary", `String "ok");
+            ("failed_checks", `Int 0);
+          ]);
+    worker = None;
+  }
+
+let with_fixture f =
+  let dir = temp_dir "worker_run_meta_repair" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "repair-tester"));
+      let session_id = "ts-1234567890000-abcdef123456789" in
+      Lib.Team_session_store.ensure_session_dirs config session_id;
+      Lib.Team_session_store.save_session config (sample_session session_id);
+      f config session_id)
+
+let seed_legacy_meta config session_id worker_run_id =
+  Lib.Team_session_store.save_worker_run_meta_json config session_id worker_run_id
+    (`Assoc
+      [
+        ("worker_run_id", `String worker_run_id);
+        ("worker_name", `String "worker-a");
+        ("mode", `String "swarm");
+        ("status", `String "completed");
+        ("wait_mode", `String "background");
+        ("trace_capability", `String "summary_only");
+        ("success", `Bool true);
+        ("evidence_session_id", `String "evidence-session-1");
+        ("trace_ref", `Null);
+        ("trace_summary", `Null);
+        ("trace_validation", `Null);
+        ("oas_worker_run", `Null);
+        ("session_conformance", `Null);
+        ("proof_run_id", `Null);
+        ("proof_status", `Null);
+      ])
+
+let read_meta_json config session_id worker_run_id =
+  Lib.Team_session_store.worker_run_meta_path config session_id worker_run_id
+  |> Room_utils.read_json config
+
+let read_meta_text config session_id worker_run_id =
+  Lib.Team_session_store.worker_run_meta_path config session_id worker_run_id
+  |> Room_utils.read_text config
+
+let repair_session_with config session_id ?worker_run_id ~dry_run () =
+  Lib.Team_session_worker_run_meta.repair_session_with ~config ~session_id
+    ?worker_run_id ~dry_run
+    ~load_oas_evidence:(fun ~evidence_session_id ->
+      if String.equal evidence_session_id "evidence-session-1" then
+        Some fake_oas_evidence
+      else
+        None)
+    ~load_saved_proof:(fun ~session_id:_ ~worker_run_id ->
+      if String.equal worker_run_id "wr-repair" then
+        Some (sample_proof ~run_id:"repair-proof-1")
+      else
+        None)
+    ()
+
+let test_repair_session_dry_run_and_apply () =
+  with_fixture @@ fun config session_id ->
+  let worker_run_id = "wr-repair" in
+  seed_legacy_meta config session_id worker_run_id;
+  let meta_before = read_meta_text config session_id worker_run_id in
+  let proof_path =
+    Lib.Team_session_store.worker_run_proof_path config session_id worker_run_id
+  in
+  let dry_run =
+    match repair_session_with config session_id ~worker_run_id ~dry_run:true () with
+    | Ok summary -> summary
+    | Error msg -> fail msg
+  in
+  check int "dry-run scanned" 1 dry_run.scanned_count;
+  check int "dry-run changed" 1 dry_run.changed_count;
+  check int "dry-run applied" 0 dry_run.applied_count;
+  let dry_item = List.hd dry_run.items in
+  check string "dry-run status" "would_repair"
+    (Lib.Team_session_worker_run_meta.repair_status_to_string dry_item.status);
+  check bool "trace_ref change detected" true
+    (List.mem "trace_ref" dry_item.changed_fields);
+  check bool "proof_run_id change detected" true
+    (List.mem "proof_run_id" dry_item.changed_fields);
+  check string "meta unchanged on dry-run" meta_before
+    (read_meta_text config session_id worker_run_id);
+  check bool "proof absent on dry-run" false (Sys.file_exists proof_path);
+  let applied =
+    match repair_session_with config session_id ~worker_run_id ~dry_run:false () with
+    | Ok summary -> summary
+    | Error msg -> fail msg
+  in
+  check int "apply changed" 1 applied.changed_count;
+  check int "apply applied" 1 applied.applied_count;
+  let applied_item = List.hd applied.items in
+  check string "apply status" "repaired"
+    (Lib.Team_session_worker_run_meta.repair_status_to_string
+       applied_item.status);
+  let repaired_meta = read_meta_json config session_id worker_run_id in
+  check bool "trace_ref repaired" true
+    (repaired_meta |> U.member "trace_ref" <> `Null);
+  check bool "trace_summary repaired" true
+    (repaired_meta |> U.member "trace_summary" <> `Null);
+  check bool "session_conformance repaired" true
+    (repaired_meta |> U.member "session_conformance" <> `Null);
+  check string "proof status repaired" "completed"
+    (repaired_meta |> U.member "proof_status" |> U.to_string);
+  check string "proof run id repaired" "repair-proof-1"
+    (repaired_meta |> U.member "proof_run_id" |> U.to_string);
+  check bool "proof file written" true (Sys.file_exists proof_path);
+  let meta_after_apply = read_meta_text config session_id worker_run_id in
+  let second_pass =
+    match repair_session_with config session_id ~worker_run_id ~dry_run:false () with
+    | Ok summary -> summary
+    | Error msg -> fail msg
+  in
+  check int "second pass changed" 0 second_pass.changed_count;
+  let second_item = List.hd second_pass.items in
+  check string "second pass status" "unchanged"
+    (Lib.Team_session_worker_run_meta.repair_status_to_string
+       second_item.status);
+  check string "meta unchanged after idempotent rerun" meta_after_apply
+    (read_meta_text config session_id worker_run_id)
+
+let test_repair_session_skips_without_recoverable_source () =
+  with_fixture @@ fun config session_id ->
+  let worker_run_id = "wr-legacy-only" in
+  Lib.Team_session_store.save_worker_run_meta_json config session_id worker_run_id
+    (`Assoc
+      [
+        ("worker_run_id", `String worker_run_id);
+        ("worker_name", `String "worker-b");
+        ("mode", `String "swarm");
+        ("status", `String "completed");
+        ("wait_mode", `String "background");
+        ("success", `Bool true);
+        ("trace_ref", `Null);
+      ]);
+  let meta_before = read_meta_text config session_id worker_run_id in
+  let result =
+    Lib.Team_session_worker_run_meta.repair_session_with ~config ~session_id
+      ~worker_run_id ~dry_run:false
+      ~load_oas_evidence:(fun ~evidence_session_id:_ -> None)
+      ~load_saved_proof:(fun ~session_id:_ ~worker_run_id:_ -> None)
+      ()
+  in
+  let summary =
+    match result with Ok summary -> summary | Error msg -> fail msg
+  in
+  check int "skip scanned" 1 summary.scanned_count;
+  check int "skip count" 1 summary.skipped_count;
+  let item = List.hd summary.items in
+  check string "skip status" "skipped"
+    (Lib.Team_session_worker_run_meta.repair_status_to_string item.status);
+  check string "skip reason" "recoverable_source_missing" item.reason;
+  check string "meta unchanged" meta_before
+    (read_meta_text config session_id worker_run_id)
+
+let () =
+  run "team_session_worker_run_meta_repair"
+    [
+      ( "repair",
+        [
+          test_case "dry-run then apply is idempotent" `Quick
+            test_repair_session_dry_run_and_apply;
+          test_case "skip without recoverable source" `Quick
+            test_repair_session_skips_without_recoverable_source;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- converge local and swarm `worker_run_meta` persistence behind a canonical helper and preserve OAS evidence and proof fields end-to-end
- expose existing `session_status.worker_runs` on the mission session detail surface and add a separate runtime snapshot monitor
- tighten proof semantics so live `proven` requires validated worker evidence, add drill-down fields, and add an idempotent historical repair path plus CLI

## Product impact
- promise: `ops visibility`
- mission session detail now surfaces worker readiness, recent runs, and execution state without forcing proof-page hops
- proof UI now distinguishes raw observed evidence from validated evidence and keeps green status aligned with validated runs only
- runtime inventory and model metrics now live on a separate snapshot surface instead of being conflated with the append-only telemetry feed

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/oas-dashboard-observability`
- `./_build/default/test/test_team_session_worker_run_meta_repair.exe`
- `./_build/default/test/test_persist_worker_run_snapshot.exe`
- `./_build/default/test/test_dashboard_proof.exe`
- `./_build/default/test/test_team_session_oas_bridge.exe`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run src/components/proof-helpers.test.ts src/components/mission-session-flow.test.ts --no-file-parallelism --maxWorkers=1`

## Review evidence
- direct non-self review path: `sb glm-text`
- reviewer smoke on exact model path: `env GLM_TEXT_MODELS=glm-5.1 sb glm-text "Say exactly OK and nothing else."` -> `OK`
- detailed review evidence and finding disposition are recorded in the PR comment thread

## Linked issue
- Refs #6065
- Refs #6066
- Refs #6070
- Refs #6068
- Refs #6069
- Refs #6067

## Notes
- adds `masc-team-session-worker-run-meta-repair` for session-scoped dry-run/apply repair of historical worker run meta
- keeps runtime snapshots separate from the append-only telemetry feed
- green/live-proven now means validated worker evidence, not raw trace presence alone
