### PR TITLE
[codex] Clarify monitoring runtime state model

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -91,10 +91,11 @@ describe('countAgentsByStatus', () => {
       'agent-only',
     )
 
-    expect(countAgentsByStatus(scoped)).toEqual({
+    expect(countAgentsByStatus(scoped, KEEPERS)).toEqual({
       all: 2,
       active: 1,
-      idle: 1,
+      attention: 1,
+      paused: 0,
       offline: 0,
     })
   })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -27,49 +27,26 @@ import { openAgentDetail } from './agent-detail'
 import { formatDuration, trimText } from './mission-utils'
 import { namespaceTruth } from '../namespace-truth-store'
 import {
+  keeperPhaseForDisplay,
+  runtimeBandMeta,
+  runtimeBandMetaForAgent,
+  summarizeKeeperMonitoring,
+  type RuntimeBand,
+} from '../lib/monitoring-runtime'
+import { KeeperPhaseBadge } from './keeper-phase-indicator'
+import {
   resolveRuntimeCounts,
   runtimeCountSourceLabel,
   shouldShowExecutionFallbackState,
 } from '../runtime-counts'
 
-type StatusFilter = 'all' | 'active' | 'idle' | 'offline'
+type StatusFilter = 'all' | RuntimeBand
 
-function statusCategory(status: string | undefined): StatusFilter {
-  if (!status) return 'idle'
-  const s = status.toLowerCase()
-  if (s === 'active' || s === 'busy' || s === 'listening' || s === 'working') return 'active'
-  if (s === 'offline' || s === 'inactive') return 'offline'
-  return 'idle'
-}
-
-function statusLabel(status: string | undefined): string {
-  if (!status) return '상태 미수집'
-  const labels: Record<string, string> = {
-    active: '온라인', busy: '처리 중', listening: '응답 대기', working: '작업 실행 중',
-    idle: '대기', offline: '오프라인', inactive: '종료됨',
-  }
-  return labels[status.toLowerCase()] ?? status
-}
-
-function statusDescription(status: string | undefined): string {
-  if (!status) return '런타임 상태를 아직 받지 못했습니다.'
-  const descriptions: Record<string, string> = {
-    active: '연결되어 있고 요청을 받을 수 있는 상태입니다.',
-    busy: '지금 응답이나 작업을 처리하고 있습니다.',
-    listening: '연결된 상태에서 입력이나 다음 지시를 기다리고 있습니다.',
-    working: '현재 작업을 수행 중입니다.',
-    idle: '연결은 유지되지만 지금 표시할 작업은 없습니다.',
-    offline: '하트비트가 없어 현재 접근할 수 없습니다. 수동으로 내렸거나 연결이 끊겼을 수 있습니다.',
-    inactive: '등록은 남아 있지만 명시적으로 내려간 상태입니다.',
-  }
-  return descriptions[status.toLowerCase()] ?? '정의되지 않은 상태값입니다.'
-}
-
-function statusBadgeClass(status: string | undefined): string {
-  const cat = statusCategory(status)
-  if (cat === 'active') return 'roster-badge--active'
-  if (cat === 'offline') return 'roster-badge--offline'
-  return 'roster-badge--idle'
+function runtimeBadgeClass(band: RuntimeBand): string {
+  if (band === 'active') return 'border-[rgba(52,211,153,0.2)] bg-[rgba(52,211,153,0.12)] text-[var(--ok)]'
+  if (band === 'attention') return 'border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.12)] text-[var(--warn)]'
+  if (band === 'paused') return 'border-[rgba(167,139,250,0.2)] bg-[rgba(167,139,250,0.12)] text-[#a78bfa]'
+  return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]'
 }
 
 interface KeeperInfo {
@@ -98,6 +75,20 @@ function findKeeper(agentName: string, keeperList: Keeper[], keeperBriefs: Dashb
   return null
 }
 
+function findKeeperRuntime(agentName: string, keeperList: Keeper[]): Keeper | null {
+  for (const keeper of keeperList) {
+    if (
+      keeper.name === agentName
+      || keeper.agent_name === agentName
+      || agentName.includes(keeper.name)
+      || keeper.name.includes(agentName)
+    ) {
+      return keeper
+    }
+  }
+  return null
+}
+
 type KeeperFilterMode = 'all' | 'agent-only' | 'keeper-only'
 
 function expectedCountForKeeperFilter(
@@ -115,16 +106,20 @@ const FILTER_META: Record<StatusFilter, { label: string; description: string }> 
     description: '등록된 런타임 전체를 보여줍니다.',
   },
   active: {
-    label: '온라인',
-    description: 'active, busy, listening, working 상태를 묶어 보여줍니다.',
+    label: '가동중',
+    description: '운영자 개입 없이 흐름을 지켜봐도 되는 상태를 묶어 보여줍니다.',
   },
-  idle: {
-    label: '작업 없음',
-    description: '연결은 살아 있지만 현재 잡힌 작업이 없는 상태입니다.',
+  attention: {
+    label: '주의 필요',
+    description: '오류, 복구, 승계, stale heartbeat, blocker 등 운영 확인이 필요한 상태입니다.',
+  },
+  paused: {
+    label: '일시정지',
+    description: '운영자가 멈춰 둔 상태를 따로 모아 봅니다.',
   },
   offline: {
-    label: '연결 끊김',
-    description: 'offline, inactive 상태를 묶어 보여줍니다.',
+    label: '오프라인',
+    description: '프로세스가 내려갔거나 아직 기동되지 않은 상태입니다.',
   },
 }
 
@@ -220,13 +215,25 @@ export function buildAgentRoster(
   return Array.from(roster.values())
 }
 
-export function countAgentsByStatus(agentList: Agent[]): Record<StatusFilter, number> {
-  return {
+export function countAgentsByStatus(
+  agentList: Agent[],
+  keeperList: Keeper[],
+): Record<StatusFilter, number> {
+  const counts: Record<StatusFilter, number> = {
     all: agentList.length,
-    active: agentList.filter((agent: Agent) => statusCategory(agent.status) === 'active').length,
-    idle: agentList.filter((agent: Agent) => statusCategory(agent.status) === 'idle').length,
-    offline: agentList.filter((agent: Agent) => statusCategory(agent.status) === 'offline').length,
+    active: 0,
+    attention: 0,
+    paused: 0,
+    offline: 0,
   }
+
+  for (const agent of agentList) {
+    const keeperRuntime = findKeeperRuntime(agent.name, keeperList)
+    const band = runtimeBandMetaForAgent(agent, keeperRuntime).key
+    counts[band] += 1
+  }
+
+  return counts
 }
 
 export function countRuntimeKinds(
@@ -275,6 +282,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     keeperFilter !== 'agent-only'
     && (keeperList.length > 0 || keeperBriefs.length > 0 || runtimeCounts.keepers > 0)
   const scopedAgents = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, keeperFilter)
+  const bandByAgent = new Map(
+    scopedAgents.map(agent => [agent.name, runtimeBandMetaForAgent(agent, findKeeperRuntime(agent.name, keeperList))] as const),
+  )
   const pageTitle = keeperFilter === 'keeper-only'
     ? '키퍼 런타임'
     : keeperFilter === 'agent-only'
@@ -288,24 +298,25 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   const filtered = scopedAgents
     .filter((a: Agent) => {
-      if (filter !== 'all' && statusCategory(a.status) !== filter) return false
+      if (filter !== 'all' && bandByAgent.get(a.name)?.key !== filter) return false
       if (search && !a.name.toLowerCase().includes(search.toLowerCase())) return false
       return true
     })
     .sort((a: Agent, b: Agent) => {
       const order: Record<StatusFilter, number> = {
         all: 0,
-        active: 0,
-        idle: 1,
-        offline: 2,
+        attention: 0,
+        active: 1,
+        paused: 2,
+        offline: 3,
       }
-      const aOrder = order[statusCategory(a.status)]
-      const bOrder = order[statusCategory(b.status)]
+      const aOrder = order[bandByAgent.get(a.name)?.key ?? 'attention']
+      const bOrder = order[bandByAgent.get(b.name)?.key ?? 'attention']
       if (aOrder !== bOrder) return aOrder - bOrder
       return a.name.localeCompare(b.name)
     })
 
-  const counts = countAgentsByStatus(scopedAgents)
+  const counts = countAgentsByStatus(scopedAgents, keeperList)
   const showExecutionFallbackState = shouldShowExecutionFallbackState({
     executionLoaded: executionLoaded.value,
     executionLoading: executionLoading.value,
@@ -325,7 +336,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ? `${filtered.length}개 표시 중`
             : `${filtered.length} / ${scopedAgents.length}개 표시 중`
         )
-  const statusChips = (['all', 'active', 'idle', 'offline'] as StatusFilter[]).map(key => ({
+  const statusChips = (['all', 'attention', 'active', 'paused', 'offline'] as StatusFilter[]).map(key => ({
     key,
     label: FILTER_META[key].label,
     count: executionLoaded.value || scopedAgents.length > 0 ? counts[key] : null,
@@ -350,16 +361,16 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다. execution 상세 projection이 올라오면 상태별 분류와 카드가 채워집니다.`
   const legendCards = [
     {
-      title: '온라인',
-      body: '응답을 받을 수 있는 연결 상태입니다. active, busy, listening, working 값을 한데 묶습니다.',
+      title: '운영 상태',
+      body: '가장 먼저 보는 값입니다. 가동중 / 주의 필요 / 일시정지 / 오프라인으로 운영 우선순위를 보여줍니다.',
     },
     {
-      title: '작업 없음',
-      body: '연결은 살아 있지만 지금 카드에 보여줄 현재 작업이 없는 상태입니다.',
+      title: 'Phase',
+      body: 'TLA lifecycle state입니다. Running, Failing, Paused, Restarting 같은 전이 근거를 그대로 보여줍니다.',
     },
     {
-      title: '연결 끊김',
-      body: '하트비트가 없거나 런타임이 내려간 상태입니다.',
+      title: 'Stage',
+      body: '현재 턴에서 무엇을 하는지 보여주는 세부 활동 단계입니다. idle, thinking, tool, handoff를 분리해서 봅니다.',
     },
     ...(hasKeeperRuntime
       ? [{
@@ -399,8 +410,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           <div class="monitor-muted-panel p-3.5 md:p-4">
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
-                <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">연결 상태</div>
-                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">상태별로 카드를 좁혀 보면서 현재 응답 가능 런타임과 유휴 런타임을 구분합니다.</p>
+                <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">운영 상태</div>
+                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">phase와 stage를 운영 관점으로 한 번 더 요약한 밴드입니다. 먼저 이상 신호를 모으고, 그다음 phase와 stage를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -448,6 +459,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         ${filtered.map((agent: Agent) => {
           const brief = briefMap.get(agent.name)
           const keeper = findKeeper(agent.name, keeperList, keeperBriefs)
+          const keeperRuntime = findKeeperRuntime(agent.name, keeperList)
+          const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
+          const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
           const isKeeper = keeper != null
           const currentWork = keeper?.current_work ?? brief?.current_work ?? agent.current_task ?? null
           const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
@@ -478,9 +492,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   <strong class="mb-2 min-w-0 overflow-hidden text-[17px] text-[var(--text-strong)] font-semibold leading-[1.3] group-hover:text-[var(--accent)] transition-colors [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${agent.name}</strong>
                   
                   <div class="flex items-center gap-1.5 flex-wrap mt-1">
-                    <span class="roster-badge ${statusBadgeClass(agent.status)}" title=${statusDescription(agent.status)}>${statusLabel(agent.status)}</span>
+                    <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
                     <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼 런타임' : '일반 에이전트'}</span>
                     ${agent.synthetic ? html`<span class="text-[10px] text-[var(--text-muted)] bg-[var(--white-6)] border border-dashed border-[var(--card-border)] px-1.5 py-px rounded italic" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">파생</span>` : null}
+                    ${keeperMonitoring ? html`<${KeeperPhaseBadge} phase=${keeperRuntime ? keeperPhaseForDisplay(keeperRuntime) : null} compact />` : null}
+                    ${keeperMonitoring ? html`<span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]" title=${keeperMonitoring.stage.description}>stage ${keeperMonitoring.stage.label}</span>` : null}
                     ${keeper?.model ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${keeper.model}</span>` : null}
                     ${keeper?.generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[var(--accent-10)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${keeper.generation}</span>` : null}
                   </div>
@@ -488,7 +504,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               </div>
 
               <div class="flex flex-1 flex-col gap-3 border-t border-[var(--border-slate-12)] pt-3">
-                <p class="m-0 text-[13px] leading-[1.5] text-[var(--text-body)] break-words line-clamp-3" title=${currentWork ?? ''}>${workPreview}</p>
+                <p class="m-0 text-[13px] leading-[1.5] text-[var(--text-body)] break-words line-clamp-3" title=${currentWork ?? ''}>${keeperMonitoring?.hint ?? workPreview}</p>
 
                 <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
                   <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -101,13 +101,20 @@ export function AgentsUnified() {
       </div>
 
       <details class="rounded-lg border border-card-border/30 bg-card/12 overflow-hidden">
-        <summary class="px-3 py-2 cursor-pointer text-[11px] text-text-muted hover:text-text-body transition-colors">에이전트 상태 안내</summary>
-        <div class="px-3 pb-2.5 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px] text-text-muted">
-          <span class="font-mono text-text-body">working</span><span>LLM이 현재 응답을 생성 중 (도구 실행 또는 텍스트 생성)</span>
-          <span class="font-mono text-text-body">busy</span><span>작업 중이지만 LLM 응답 대기 아닌 상태 (I/O, 파일 처리 등)</span>
-          <span class="font-mono text-text-body">listening</span><span>실시간 스트림 연결 상태. 작업 대기 중</span>
-          <span class="font-mono text-text-body">idle</span><span>최근 활동 없음. 하트비트는 유지 중</span>
-          <span class="font-mono text-text-body">offline</span><span>하트비트 끊김. 프로세스 종료됨</span>
+        <summary class="px-3 py-2 cursor-pointer text-[11px] text-text-muted hover:text-text-body transition-colors">모니터링 읽는 법</summary>
+        <div class="px-3 pb-3 grid gap-3 text-[11px] text-text-muted md:grid-cols-3">
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2.5">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-strong)]">운영 상태</div>
+            <p class="m-0 mt-1 leading-[1.5]">운영자가 먼저 볼 신호입니다. 가동중, 주의 필요, 일시정지, 오프라인으로 요약합니다.</p>
+          </div>
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2.5">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-strong)]">Phase</div>
+            <p class="m-0 mt-1 leading-[1.5]">keeper_state_machine의 TLA 라이프사이클 상태입니다. Running, Failing, Paused 같은 전이 근거를 보여줍니다.</p>
+          </div>
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2.5">
+            <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-strong)]">Stage</div>
+            <p class="m-0 mt-1 leading-[1.5]">현재 턴에서 무엇을 하는지 보여주는 활동 단계입니다. idle, thinking, tool, handoff를 분리해서 봅니다.</p>
+          </div>
         </div>
       </details>
 

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -1,45 +1,44 @@
-// Keeper fleet overview — compact comparison grid showing all keepers
-// at a glance: pipeline stage, context ratio, tool calls, generation,
-// and activity recency. Designed for the Agents tab header.
-
 import { html } from 'htm/preact'
-import { navigate } from '../router'
-import type { Keeper, PipelineStage } from '../types/core'
+
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_FLEET_WARN } from '../config/constants'
+import { keeperPhaseForDisplay, summarizeKeeperMonitoring } from '../lib/monitoring-runtime'
+import type { Keeper } from '../types/core'
+import { openKeeperDetail } from './keeper-detail'
 import { KeeperPhaseBadge } from './keeper-phase-indicator'
 
-// ── Pipeline stage styling ────────────────────────────
+type ToneKey = 'ok' | 'warn' | 'paused' | 'muted'
 
-interface StageStyle {
-  label: string
-  color: string
+interface ToneStyle {
+  text: string
   bg: string
-  pulse: boolean
+  border: string
 }
 
-const STAGE_STYLES: Record<string, StageStyle> = {
-  thinking:             { label: '사고',    color: 'var(--accent)',  bg: 'rgba(71,184,255,0.12)', pulse: true },
-  tool_use:             { label: '도구',    color: 'var(--ok)',      bg: 'rgba(52,211,153,0.12)', pulse: true },
-  compacting:           { label: '압축',    color: '#a855f7',        bg: 'rgba(168,85,247,0.12)', pulse: true },
-  handoff:              { label: '승계',    color: '#ef4444',        bg: 'rgba(239,68,68,0.12)',  pulse: true },
-  scheduled_autonomous: { label: '자율',    color: 'var(--accent)',  bg: 'rgba(71,184,255,0.08)', pulse: true },
-  failing:              { label: '오류',    color: 'var(--bad)',     bg: 'rgba(239,68,68,0.12)',  pulse: true },
-  crashed:              { label: '중단',    color: '#ef4444',        bg: 'rgba(239,68,68,0.15)',  pulse: false },
-  restarting:           { label: '재시작',  color: '#38bdf8',        bg: 'rgba(56,189,248,0.12)', pulse: true },
-  draining:             { label: '종료중',  color: '#fb923c',        bg: 'rgba(251,146,60,0.12)', pulse: true },
-  paused:               { label: '일시정지', color: '#a78bfa',       bg: 'rgba(167,139,250,0.12)', pulse: false },
-  idle:                 { label: '대기',    color: 'var(--text-dim)', bg: 'var(--white-5)',        pulse: false },
-  offline:              { label: '오프',    color: 'var(--text-dim)', bg: 'var(--white-3)',        pulse: false },
+const BAND_STYLES: Record<string, ToneStyle> = {
+  active: { text: 'var(--ok)', bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.2)' },
+  attention: { text: 'var(--warn)', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.2)' },
+  paused: { text: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.22)' },
+  offline: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
 }
 
-const ACTIVE_STAGES = new Set<string>(['thinking', 'tool_use', 'compacting', 'handoff', 'scheduled_autonomous', 'failing', 'restarting', 'draining'])
-
-function stageStyle(stage?: PipelineStage): StageStyle {
-  if (!stage) return STAGE_STYLES['offline']!
-  return STAGE_STYLES[stage] ?? STAGE_STYLES['offline']!
+const STAGE_STYLES: Record<string, ToneStyle> = {
+  thinking: { text: 'var(--accent)', bg: 'rgba(71,184,255,0.12)', border: 'rgba(71,184,255,0.2)' },
+  tool_use: { text: 'var(--ok)', bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.2)' },
+  compacting: { text: '#a855f7', bg: 'rgba(168,85,247,0.12)', border: 'rgba(168,85,247,0.2)' },
+  handoff: { text: '#f472b6', bg: 'rgba(244,114,182,0.12)', border: 'rgba(244,114,182,0.2)' },
+  scheduled_autonomous: { text: 'var(--accent)', bg: 'rgba(71,184,255,0.1)', border: 'rgba(71,184,255,0.18)' },
+  failing: { text: 'var(--warn)', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.2)' },
+  draining: { text: '#fb923c', bg: 'rgba(251,146,60,0.12)', border: 'rgba(251,146,60,0.2)' },
+  paused: { text: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.2)' },
+  restarting: { text: '#38bdf8', bg: 'rgba(56,189,248,0.12)', border: 'rgba(56,189,248,0.2)' },
+  crashed: { text: 'var(--bad)', bg: 'rgba(239,68,68,0.12)', border: 'rgba(239,68,68,0.2)' },
+  idle: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
+  offline: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
 }
 
-// ── Context bar ───────────────────────────────────────
+function pillStyle(tone: ToneStyle): string {
+  return `color:${tone.text};background:${tone.bg};border:1px solid ${tone.border};`
+}
 
 function ContextBar({ ratio }: { ratio: number | undefined }) {
   const pct = (ratio ?? 0) * 100
@@ -47,8 +46,10 @@ function ContextBar({ ratio }: { ratio: number | undefined }) {
   return html`
     <div class="flex items-center gap-1.5">
       <div class="flex-1 h-1.5 rounded-full bg-[var(--white-6)] overflow-hidden">
-        <div class="h-full rounded-full transition-all duration-500"
-          style="width: ${pct.toFixed(0)}%; background: ${color}"></div>
+        <div
+          class="h-full rounded-full transition-all duration-500"
+          style="width: ${pct.toFixed(0)}%; background: ${color}"
+        ></div>
       </div>
       <span class="text-[10px] font-mono w-8 text-right" style="color: ${color}">
         ${pct > 0 ? `${pct.toFixed(0)}%` : '-'}
@@ -56,8 +57,6 @@ function ContextBar({ ratio }: { ratio: number | undefined }) {
     </div>
   `
 }
-
-// ── Activity recency ──────────────────────────────────
 
 function formatRecency(agoS: number | undefined): string {
   if (agoS == null) return '-'
@@ -67,125 +66,167 @@ function formatRecency(agoS: number | undefined): string {
   return `${Math.floor(agoS / 86400)}일`
 }
 
-// ── Keeper row ────────────────────────────────────────
+function MetricPill({
+  label,
+  value,
+  tone = 'muted',
+}: {
+  label: string
+  value: string | number
+  tone?: ToneKey
+}) {
+  const style =
+    tone === 'ok'
+      ? 'text-[var(--ok)] bg-[rgba(52,211,153,0.12)] border-[rgba(52,211,153,0.2)]'
+      : tone === 'warn'
+        ? 'text-[var(--warn)] bg-[rgba(251,191,36,0.12)] border-[rgba(251,191,36,0.2)]'
+        : tone === 'paused'
+          ? 'text-[#a78bfa] bg-[rgba(167,139,250,0.12)] border-[rgba(167,139,250,0.2)]'
+          : 'text-[var(--text-muted)] bg-[var(--white-4)] border-[var(--white-8)]'
+
+  return html`
+    <span class="inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-medium ${style}">
+      <span>${label}</span>
+      <span class="font-mono text-[var(--text-strong)]">${value}</span>
+    </span>
+  `
+}
 
 function KeeperRow({ keeper }: { keeper: Keeper }) {
-  const stage = stageStyle(keeper.pipeline_stage)
-  const isActive = ACTIVE_STAGES.has(keeper.pipeline_stage ?? '')
+  const summary = summarizeKeeperMonitoring(keeper)
+  const bandTone = BAND_STYLES[summary.band.key] ?? BAND_STYLES.offline!
+  const stageTone = STAGE_STYLES[summary.stage.key] ?? STAGE_STYLES.offline!
   const toolCount = keeper.latest_tool_call_count ?? keeper.metrics_window?.tool_call_count ?? 0
 
   return html`
-    <div
-      class="flex items-center gap-3 py-2 px-3 rounded-lg cursor-pointer hover:bg-[var(--white-5)] transition-colors ${isActive ? 'ring-1 ring-[var(--accent-30)]' : ''}"
-      onClick=${() => navigate('monitoring', { section: 'agents', agent: keeper.name })}
+    <button
+      type="button"
+      class="group grid w-full gap-3 rounded-2xl border border-[var(--card-border)] bg-[linear-gradient(180deg,var(--white-2),rgba(255,255,255,0.02))] px-4 py-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--accent-30)] hover:bg-[linear-gradient(180deg,var(--accent-soft),rgba(255,255,255,0.04))]"
+      onClick=${() => openKeeperDetail(keeper)}
+      aria-label=${`${keeper.name} keeper 상세 보기`}
     >
-      ${'' /* Phase badge (lifecycle) + Stage badge (activity) */}
-      <div class="flex-shrink-0">
-        <${KeeperPhaseBadge} phase=${keeper.phase} compact />
-      </div>
-      <div
-        class="flex-shrink-0 px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider text-center w-12"
-        style="color: ${stage.color}; background: ${stage.bg}; ${stage.pulse ? 'animation: loadingPulse 2s ease-in-out infinite;' : ''}"
-      >
-        ${stage.label}
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <span
+              class="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold tracking-[0.08em] uppercase"
+              style=${pillStyle(bandTone)}
+              title=${summary.band.description}
+            >${summary.band.label}</span>
+            <${KeeperPhaseBadge} phase=${keeperPhaseForDisplay(keeper)} compact />
+            <span
+              class="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-medium"
+              style=${pillStyle(stageTone)}
+              title=${summary.stage.description}
+            >stage ${summary.stage.label}</span>
+          </div>
+          <div class="mt-2 flex items-center gap-2">
+            <span class="truncate text-[15px] font-semibold text-[var(--text-strong)]">${keeper.name}</span>
+            ${keeper.model ? html`<span class="truncate rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-mono text-[var(--text-muted)]">${keeper.model}</span>` : null}
+          </div>
+          <p class="mt-2 mb-0 text-[12px] leading-[1.55] text-[var(--text-body)]">
+            ${summary.hint ?? summary.phase.description}
+          </p>
+        </div>
+
+        <div class="grid min-w-[208px] gap-2 text-[10px] text-[var(--text-muted)] sm:grid-cols-2">
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
+            <div>컨텍스트</div>
+            <div class="mt-1"><${ContextBar} ratio=${keeper.context_ratio} /></div>
+          </div>
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
+            <div>최근 활동</div>
+            <div class="mt-1 text-[12px] font-mono text-[var(--text-strong)]">${formatRecency(keeper.last_activity_ago_s)}</div>
+          </div>
+        </div>
       </div>
 
-      ${'' /* Name */}
-      <div class="w-28 flex-shrink-0 truncate">
-        <span class="text-[12px] font-mono font-medium text-[var(--text-strong)]">${keeper.name}</span>
+      <div class="flex flex-wrap items-center gap-2">
+        <${MetricPill} label="Gen" value=${keeper.generation ?? 0} />
+        <${MetricPill} label="Turn" value=${keeper.turn_count ?? 0} />
+        <${MetricPill} label="Tool" value=${toolCount > 0 ? toolCount : '-'} />
+        ${keeper.last_blocker ? html`<${MetricPill} label="Blocker" value="yes" tone="warn" />` : null}
+        ${summary.band.key === 'paused' ? html`<${MetricPill} label="Pause" value="on" tone="paused" />` : null}
       </div>
-
-      ${'' /* Context bar */}
-      <div class="flex-1 min-w-20 max-w-40">
-        <${ContextBar} ratio=${keeper.context_ratio} />
-      </div>
-
-      ${'' /* Stats */}
-      <div class="flex items-center gap-4 flex-shrink-0 text-[10px] font-mono text-[var(--text-muted)]">
-        <span title="세대">G${keeper.generation ?? 0}</span>
-        <span title="턴">${keeper.turn_count ?? 0}t</span>
-        <span title="도구 호출">${toolCount > 0 ? `${toolCount}c` : '-'}</span>
-        <span title="마지막 활동" class="${(keeper.last_activity_ago_s ?? 999) < 120 ? 'text-[var(--ok)]' : ''}">
-          ${formatRecency(keeper.last_activity_ago_s)}
-        </span>
-      </div>
-    </div>
+    </button>
   `
 }
 
-// ── Fleet summary bar ─────────────────────────────────
-
 function FleetSummary({ keepers }: { keepers: Keeper[] }) {
-  const active = keepers.filter(k => ACTIVE_STAGES.has(k.pipeline_stage ?? '')).length
-  const idle = keepers.filter(k => k.pipeline_stage === 'idle').length
-  const offline = keepers.length - active - idle
-  const avgCtx = keepers.reduce((s, k) => s + (k.context_ratio ?? 0), 0) / (keepers.length || 1)
-  const totalTools = keepers.reduce((s, k) => s + (k.latest_tool_call_count ?? k.metrics_window?.tool_call_count ?? 0), 0)
-  const totalCompactions = keepers.reduce((s, k) => s + (k.compaction_count ?? 0), 0)
-  const compactKeepers = keepers.filter(k => k.metrics_window?.compaction_saved_ratio != null)
+  const counts = keepers.reduce(
+    (acc, keeper) => {
+      acc[summarizeKeeperMonitoring(keeper).band.key] += 1
+      return acc
+    },
+    { active: 0, attention: 0, paused: 0, offline: 0 },
+  )
+  const avgCtx = keepers.reduce((sum, keeper) => sum + (keeper.context_ratio ?? 0), 0) / (keepers.length || 1)
+  const totalTools = keepers.reduce((sum, keeper) => sum + (keeper.latest_tool_call_count ?? keeper.metrics_window?.tool_call_count ?? 0), 0)
+  const totalCompactions = keepers.reduce((sum, keeper) => sum + (keeper.compaction_count ?? 0), 0)
+  const compactKeepers = keepers.filter(keeper => keeper.metrics_window?.compaction_saved_ratio != null)
   const avgSavedRatio = compactKeepers.length > 0
-    ? compactKeepers.reduce((s, k) => s + (k.metrics_window?.compaction_saved_ratio ?? 0), 0) / compactKeepers.length
+    ? compactKeepers.reduce((sum, keeper) => sum + (keeper.metrics_window?.compaction_saved_ratio ?? 0), 0) / compactKeepers.length
     : null
 
   return html`
-    <div class="flex gap-3 flex-wrap text-[11px] mb-3">
-      <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
-        <span class="font-mono font-medium text-[var(--ok)]">${active}</span>
-        <span class="text-[var(--text-dim)]">활성</span>
-      </span>
-      <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
-        <span class="font-mono font-medium text-[var(--text-muted)]">${idle}</span>
-        <span class="text-[var(--text-dim)]">대기</span>
-      </span>
-      ${offline > 0 ? html`
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
-          <span class="font-mono font-medium text-[var(--text-dim)]">${offline}</span>
-          <span class="text-[var(--text-dim)]">오프</span>
-        </span>
-      ` : null}
-      <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
-        <span class="text-[var(--text-dim)]">평균 컨텍스트</span>
-        <span class="font-mono font-medium ${avgCtx > CONTEXT_RATIO_CRITICAL ? 'text-[var(--bad)]' : avgCtx > CONTEXT_RATIO_FLEET_WARN ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${(avgCtx * 100).toFixed(0)}%</span>
-      </span>
-      ${totalTools > 0 ? html`
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
-          <span class="font-mono font-medium text-[var(--text-strong)]">${totalTools}</span>
-          <span class="text-[var(--text-dim)]">총 도구 호출</span>
-        </span>
-      ` : null}
-      ${totalCompactions > 0 ? html`
-        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-[var(--white-4)] border border-[var(--white-6)]">
-          <span class="font-mono font-medium text-[#a855f7]">${totalCompactions}</span>
-          <span class="text-[var(--text-dim)]">압축</span>
-          ${avgSavedRatio != null ? html`
-            <span class="font-mono font-medium ${avgSavedRatio >= 0.4 ? 'text-[var(--ok)]' : avgSavedRatio >= 0.2 ? 'text-[var(--warn)]' : 'text-[var(--bad)]'}">${(avgSavedRatio * 100).toFixed(0)}%</span>
-            <span class="text-[var(--text-dim)]">절감</span>
-          ` : null}
-        </span>
-      ` : null}
+    <div class="grid gap-3 md:grid-cols-[1.5fr_1fr]">
+      <div class="grid gap-2 sm:grid-cols-4">
+        <${MetricPill} label="가동중" value=${counts.active} tone="ok" />
+        <${MetricPill} label="주의 필요" value=${counts.attention} tone="warn" />
+        <${MetricPill} label="일시정지" value=${counts.paused} tone="paused" />
+        <${MetricPill} label="오프라인" value=${counts.offline} />
+      </div>
+      <div class="flex flex-wrap justify-start gap-2 md:justify-end">
+        <${MetricPill}
+          label="평균 CTX"
+          value=${`${(avgCtx * 100).toFixed(0)}%`}
+          tone=${avgCtx > CONTEXT_RATIO_CRITICAL ? 'warn' : avgCtx > CONTEXT_RATIO_FLEET_WARN ? 'paused' : 'ok'}
+        />
+        ${totalTools > 0 ? html`<${MetricPill} label="도구 호출" value=${totalTools} />` : null}
+        ${totalCompactions > 0 ? html`
+          <${MetricPill}
+            label="압축"
+            value=${avgSavedRatio == null ? totalCompactions : `${totalCompactions} / ${(avgSavedRatio * 100).toFixed(0)}%`}
+            tone=${avgSavedRatio != null && avgSavedRatio >= 0.4 ? 'ok' : avgSavedRatio != null ? 'warn' : 'muted'}
+          />
+        ` : null}
+      </div>
     </div>
   `
 }
-
-// ── Main component ────────────────────────────────────
 
 export function KeeperFleetOverview({ keepers: allKeepers }: { keepers: Keeper[] }) {
   if (allKeepers.length === 0) return null
 
-  // Sort: active first, then by recency
-  const sorted = [...allKeepers].sort((a, b) => {
-    const aActive = ACTIVE_STAGES.has(a.pipeline_stage ?? '') ? 1 : 0
-    const bActive = ACTIVE_STAGES.has(b.pipeline_stage ?? '') ? 1 : 0
-    if (aActive !== bActive) return bActive - aActive
-    return (a.last_activity_ago_s ?? 9999) - (b.last_activity_ago_s ?? 9999)
+  const sorted = [...allKeepers].sort((left, right) => {
+    const leftSummary = summarizeKeeperMonitoring(left)
+    const rightSummary = summarizeKeeperMonitoring(right)
+    const rank = { attention: 0, active: 1, paused: 2, offline: 3 }
+    if (rank[leftSummary.band.key] !== rank[rightSummary.band.key]) {
+      return rank[leftSummary.band.key] - rank[rightSummary.band.key]
+    }
+    return (left.last_activity_ago_s ?? Number.POSITIVE_INFINITY) - (right.last_activity_ago_s ?? Number.POSITIVE_INFINITY)
   })
 
   return html`
-    <div class="mb-6">
-      <${FleetSummary} keepers=${allKeepers} />
-      <div class="flex flex-col gap-0.5 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] p-2">
-        ${sorted.map(k => html`<${KeeperRow} key=${k.name} keeper=${k} />`)}
+    <section class="monitor-surface-card monitor-surface-card-medium mb-6 p-4 md:p-5">
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div class="min-w-0">
+            <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Keeper 운영판</div>
+            <h3 class="m-0 mt-1 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">먼저 볼 것은 state가 아니라 운영 상태입니다</h3>
+            <p class="m-0 mt-2 max-w-[720px] text-[12px] leading-[1.6] text-[var(--text-body)]">
+              가동중, 주의 필요, 일시정지, 오프라인은 운영 우선순위이고, 그 아래의 phase와 stage는 왜 그런지 설명하는 근거입니다.
+            </p>
+          </div>
+        </div>
+
+        <${FleetSummary} keepers=${allKeepers} />
+
+        <div class="grid gap-3">
+          ${sorted.map(keeper => html`<${KeeperRow} key=${keeper.name} keeper=${keeper} />`)}
+        </div>
       </div>
-    </div>
+    </section>
   `
 }

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -1,12 +1,13 @@
-// Keeper state diagram panel — fetches and renders per-keeper
-// Mermaid stateDiagram-v2 showing the 11-state lifecycle
-// with current phase highlighted.
-
 import { html } from 'htm/preact'
-import { useEffect, useState } from 'preact/hooks'
-import { fetchKeeperStateDiagram } from '../api/keeper'
-import { MermaidGraph } from './common/mermaid-graph'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+
+import {
+  fetchKeeperStateDiagram,
+  fetchKeeperTransitions,
+  type KeeperTransition,
+} from '../api/keeper'
 import { EmptyState } from './common/empty-state'
+import { MermaidGraph } from './common/mermaid-graph'
 import type { KeeperPhase } from '../types'
 
 interface KeeperStateDiagramProps {
@@ -14,9 +15,75 @@ interface KeeperStateDiagramProps {
   currentPhase?: KeeperPhase | string | null
 }
 
+const BUFFER_PHASES = new Set(['Failing', 'Compacting', 'HandingOff', 'Draining', 'Restarting'])
+const TERMINAL_PHASES = new Set(['Stopped', 'Dead'])
+
+const PHASE_ID_MAP: Record<string, string> = {
+  Offline: 'Offline',
+  Running: 'Running',
+  Failing: 'Failing',
+  Compacting: 'Compacting',
+  HandingOff: 'HandingOff',
+  Draining: 'Draining',
+  Paused: 'Paused',
+  Stopped: 'Stopped',
+  Crashed: 'Crashed',
+  Restarting: 'Restarting',
+  Dead: 'Dead',
+  offline: 'Offline',
+  running: 'Running',
+  failing: 'Failing',
+  compacting: 'Compacting',
+  handing_off: 'HandingOff',
+  paused: 'Paused',
+  draining: 'Draining',
+  stopped: 'Stopped',
+  crashed: 'Crashed',
+  restarting: 'Restarting',
+  dead: 'Dead',
+}
+
+function normalizePhase(phase: string | null | undefined): string | null {
+  if (!phase) return null
+  return PHASE_ID_MAP[phase] ?? null
+}
+
+function phaseClass(phase: string | null): 'active' | 'buffer' | 'terminal' {
+  if (!phase) return 'active'
+  if (TERMINAL_PHASES.has(phase)) return 'terminal'
+  if (BUFFER_PHASES.has(phase)) return 'buffer'
+  return 'active'
+}
+
+function rewriteMermaidHighlight(source: string, phase: string | null): string {
+  if (!source.trim()) return source
+  const lines = source
+    .split('\n')
+    .filter(line => !/^\s*class\s+[A-Za-z0-9_]+\s+(active|buffer|terminal)\s*$/.test(line))
+  const target = normalizePhase(phase)
+  if (!target) return lines.join('\n')
+  lines.push(`    class ${target} ${phaseClass(target)}`)
+  return lines.join('\n')
+}
+
+function transitionType(selectedEvent: unknown): string {
+  if (selectedEvent && typeof selectedEvent === 'object' && 'type' in selectedEvent) {
+    const raw = (selectedEvent as { type?: unknown }).type
+    if (typeof raw === 'string' && raw.trim()) {
+      return raw.split('_').join(' ')
+    }
+  }
+  return 'event'
+}
+
+function formatPhaseBadgeLabel(phase: string | null | undefined): string {
+  return normalizePhase(phase) ?? phase ?? 'unknown'
+}
+
 export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {
   const [mermaid, setMermaid] = useState<string | null>(null)
   const [apiPhase, setApiPhase] = useState<string | null>(null)
+  const [transitions, setTransitions] = useState<KeeperTransition[]>([])
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -25,11 +92,27 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
     setLoading(true)
     setError(null)
 
-    fetchKeeperStateDiagram(keeperName)
-      .then(resp => {
+    Promise.allSettled([
+      fetchKeeperStateDiagram(keeperName),
+      fetchKeeperTransitions(keeperName, 5),
+    ])
+      .then(([diagramResult, transitionsResult]) => {
         if (cancelled) return
-        setMermaid(resp.mermaid)
-        setApiPhase(resp.current_phase)
+        if (diagramResult.status === 'fulfilled') {
+          setMermaid(diagramResult.value.mermaid)
+          setApiPhase(diagramResult.value.current_phase)
+        } else {
+          setMermaid(null)
+          setApiPhase(null)
+          setError(diagramResult.reason instanceof Error ? diagramResult.reason.message : 'state diagram fetch failed')
+        }
+
+        if (transitionsResult.status === 'fulfilled') {
+          setTransitions(transitionsResult.value.transitions ?? [])
+        } else {
+          setTransitions([])
+        }
+
         setLoading(false)
       })
       .catch(err => {
@@ -41,35 +124,75 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
     return () => { cancelled = true }
   }, [keeperName])
 
-  // Prefer API response current_phase, fall back to prop
-  const displayPhase = apiPhase ?? currentPhase
+  const livePhase = normalizePhase(currentPhase) ?? normalizePhase(apiPhase)
+  const registryPhase = normalizePhase(apiPhase)
+  const phaseMismatch = Boolean(livePhase && registryPhase && livePhase !== registryPhase)
+  const mermaidSource = useMemo(
+    () => (mermaid ? rewriteMermaidHighlight(mermaid, livePhase) : null),
+    [mermaid, livePhase],
+  )
 
   if (loading) {
     return html`
       <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
-        <span class="inline-block w-3 h-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin" aria-hidden="true"></span>
+        <span class="inline-block h-3 w-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin" aria-hidden="true"></span>
         상태 다이어그램 로딩중
       </div>
     `
   }
 
-  if (error || !mermaid) {
+  if (error || !mermaidSource) {
     return html`<${EmptyState} message=${error ?? '다이어그램 없음'} compact />`
   }
 
   return html`
-    <div>
-      ${displayPhase ? html`
-        <div class="mb-2 text-[10px] text-[var(--text-dim)]">
-          현재 phase: <span class="font-mono font-medium text-[var(--accent)]">${displayPhase}</span>
+    <div class="flex flex-col gap-3">
+      <div class="flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-dim)]">
+        <span class="inline-flex items-center rounded-full border border-[var(--accent-30)] bg-[var(--accent-10)] px-2 py-0.5 text-[var(--accent)]">
+          live phase ${formatPhaseBadgeLabel(livePhase)}
+        </span>
+        ${registryPhase ? html`
+          <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
+            registry ${formatPhaseBadgeLabel(registryPhase)}
+          </span>
+        ` : null}
+        ${transitions.length > 0 ? html`
+          <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
+            observed ${transitions.length} transitions
+          </span>
+        ` : null}
+      </div>
+
+      ${phaseMismatch ? html`
+        <div class="rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
+          Mermaid 강조는 execution projection phase를 기준으로 다시 칠했습니다. registry phase와 다르므로 현재는 다이어그램의 경로보다 아래 observed transition 기록을 더 신뢰하는 편이 안전합니다.
         </div>
       ` : null}
-      <${MermaidGraph}
-        source=${mermaid}
-        prefix="keeper-state-diagram"
-        diagramClass="[&_svg]:max-w-full [&_svg]:mx-auto"
-        minHeightClass="min-h-[120px]"
-      />
+
+      <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+        <${MermaidGraph}
+          source=${mermaidSource}
+          prefix="keeper-state-diagram"
+          diagramClass="[&_svg]:max-w-full [&_svg]:mx-auto"
+          minHeightClass="min-h-[120px]"
+        />
+      </div>
+
+      ${transitions.length > 0 ? html`
+        <div class="grid gap-2">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Observed transitions</div>
+          ${transitions.map(transition => html`
+            <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2 text-[11px] leading-[1.5] text-[var(--text-body)]">
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="font-mono text-[var(--text-strong)]">${formatPhaseBadgeLabel(transition.prev_phase)}</span>
+                <span class="text-[var(--text-dim)]">→</span>
+                <span class="font-mono text-[var(--accent)]">${formatPhaseBadgeLabel(transition.new_phase)}</span>
+                <span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${transitionType(transition.selected_event)}</span>
+              </div>
+            </div>
+          `)}
+        </div>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Agent, Keeper } from '../types'
+import {
+  keeperPhaseForDisplay,
+  runtimeBandForAgent,
+  summarizeKeeperMonitoring,
+} from './monitoring-runtime'
+
+function makeKeeper(overrides: Partial<Keeper> = {}): Keeper {
+  return {
+    name: 'analyst',
+    status: 'busy',
+    phase: 'Running',
+    pipeline_stage: 'idle',
+    ...overrides,
+  }
+}
+
+describe('summarizeKeeperMonitoring', () => {
+  it('treats a running keeper with idle pipeline as active, not offline', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+      }),
+    )
+
+    expect(summary.band.key).toBe('active')
+    expect(summary.phase.label).toBe('실행중')
+    expect(summary.stage.label).toBe('대기')
+  })
+
+  it('promotes paused keepers into the paused operator band', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'paused',
+        phase: 'Paused',
+        pipeline_stage: 'paused',
+        paused: true,
+      }),
+    )
+
+    expect(summary.band.key).toBe('paused')
+    expect(summary.phase.label).toBe('일시정지')
+    expect(summary.stage.label).toBe('일시정지')
+  })
+
+  it('prefers paused display phase even when backend phase still says Running', () => {
+    const keeper = makeKeeper({
+      status: 'idle',
+      phase: 'Running',
+      pipeline_stage: 'idle',
+      paused: true,
+    })
+
+    expect(keeperPhaseForDisplay(keeper)).toBe('Paused')
+    expect(summarizeKeeperMonitoring(keeper).phase.label).toBe('일시정지')
+  })
+
+  it('marks failing phases as attention-worthy', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Failing',
+        pipeline_stage: 'failing',
+      }),
+    )
+
+    expect(summary.band.key).toBe('attention')
+    expect(summary.phase.label).toBe('오류중')
+    expect(summary.hint).toContain('오류')
+  })
+
+  it('keeps never-booted keepers in the offline band', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'offline',
+        phase: 'Offline',
+        generation: 0,
+        turn_count: 0,
+        agent: { exists: false },
+      }),
+    )
+
+    expect(summary.band.key).toBe('offline')
+    expect(summary.phase.label).toBe('오프라인')
+    expect(summary.hint).toContain('부팅')
+  })
+})
+
+describe('runtimeBandForAgent', () => {
+  it('uses keeper semantics when a keeper runtime is attached', () => {
+    const agent = { name: 'keeper-analyst-agent', status: 'busy' } as Agent
+    const keeper = makeKeeper({
+      status: 'paused',
+      phase: 'Paused',
+      pipeline_stage: 'paused',
+      paused: true,
+    })
+
+    expect(runtimeBandForAgent(agent, keeper)).toBe('paused')
+  })
+
+  it('maps non-keeper offline agents into the offline band', () => {
+    const agent = { name: 'worker-1', status: 'offline' } as Agent
+    expect(runtimeBandForAgent(agent, null)).toBe('offline')
+  })
+
+  it('treats online non-keeper agents as active', () => {
+    const agent = { name: 'worker-1', status: 'listening' } as Agent
+    expect(runtimeBandForAgent(agent, null)).toBe('active')
+  })
+})

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -1,0 +1,254 @@
+import type { Agent, Keeper, KeeperPhase, PipelineStage } from '../types'
+import { keeperDisplayStatus } from './keeper-runtime-display'
+
+export type RuntimeBand = 'active' | 'attention' | 'paused' | 'offline'
+
+export interface RuntimeBandMeta {
+  key: RuntimeBand
+  label: string
+  description: string
+}
+
+export interface PhaseMeta {
+  key: string
+  label: string
+  description: string
+}
+
+export interface StageMeta {
+  key: string
+  label: string
+  description: string
+}
+
+export interface KeeperMonitoringSummary {
+  band: RuntimeBandMeta
+  phase: PhaseMeta
+  stage: StageMeta
+  hint: string | null
+}
+
+const HEARTBEAT_STALE_MS = 5 * 60 * 1000
+const CONTEXT_ATTENTION_RATIO = 0.85
+
+const CANONICAL_PHASE_KEYS = new Set([
+  'Offline',
+  'Running',
+  'Failing',
+  'Compacting',
+  'HandingOff',
+  'Draining',
+  'Paused',
+  'Stopped',
+  'Crashed',
+  'Restarting',
+  'Dead',
+])
+
+const OFFLINE_PHASES = new Set<string>(['Offline', 'Stopped', 'Dead'])
+const ATTENTION_PHASES = new Set<string>(['Failing', 'Compacting', 'HandingOff', 'Draining', 'Crashed', 'Restarting'])
+
+const UNKNOWN_PHASE_META: PhaseMeta = {
+  key: 'unknown',
+  label: '확인 필요',
+  description: 'phase 정보가 부족해 수동 확인이 필요합니다.',
+}
+
+const OFFLINE_STAGE_META: StageMeta = {
+  key: 'offline',
+  label: '오프라인',
+  description: '활동 정보를 확인하지 못했습니다.',
+}
+
+const PHASE_LABELS: Record<string, PhaseMeta> = {
+  Offline: { key: 'Offline', label: '오프라인', description: '런타임이 올라오지 않았거나 연결 정보가 없습니다.' },
+  Running: { key: 'Running', label: '실행중', description: 'keeper_state_machine 기준으로 정상 실행 상태입니다.' },
+  Failing: { key: 'Failing', label: '오류중', description: '최근 턴 또는 heartbeat/reconcile 과정에서 실패를 감지했습니다.' },
+  Compacting: { key: 'Compacting', label: '압축중', description: '컨텍스트 정리를 위해 compaction을 수행 중입니다.' },
+  HandingOff: { key: 'HandingOff', label: '승계중', description: '새 세대로 handoff를 진행하고 있습니다.' },
+  Draining: { key: 'Draining', label: '종료중', description: '현재 턴을 비우고 정지 상태로 이동하는 중입니다.' },
+  Paused: { key: 'Paused', label: '일시정지', description: '운영자가 keeper를 일시정지했습니다.' },
+  Stopped: { key: 'Stopped', label: '정지', description: '정상 정지된 런타임입니다.' },
+  Crashed: { key: 'Crashed', label: '비정상종료', description: 'fiber가 비정상적으로 종료되었습니다.' },
+  Restarting: { key: 'Restarting', label: '재시작중', description: 'supervisor가 복구를 시도하고 있습니다.' },
+  Dead: { key: 'Dead', label: '종료', description: '재시도 budget이 소진된 종료 상태입니다.' },
+  active: { key: 'active', label: '실행중', description: '프로세스는 살아 있지만 state projection이 부족합니다.' },
+  busy: { key: 'busy', label: '작업중', description: '프로세스는 살아 있고 현재 작업을 수행 중입니다.' },
+  listening: { key: 'listening', label: '대기중', description: '프로세스는 살아 있고 입력을 기다리고 있습니다.' },
+  idle: { key: 'idle', label: '대기', description: '프로세스는 살아 있지만 현재 턴 작업은 없습니다.' },
+  paused: { key: 'paused', label: '일시정지', description: '운영자가 keeper를 일시정지했습니다.' },
+  stopped: { key: 'stopped', label: '정지', description: '이전에 실행되었지만 현재는 정지 상태입니다.' },
+  unbooted: { key: 'unbooted', label: '미기동', description: '등록만 되어 있고 아직 부팅되지 않았습니다.' },
+  offline: { key: 'offline', label: '오프라인', description: '런타임 연결을 확인하지 못했습니다.' },
+  unknown: UNKNOWN_PHASE_META,
+}
+
+const STAGE_LABELS: Record<string, StageMeta> = {
+  idle: { key: 'idle', label: '대기', description: '현재 턴에서 진행 중인 세부 단계가 없습니다.' },
+  thinking: { key: 'thinking', label: '사고', description: '응답이나 다음 액션을 결정하는 중입니다.' },
+  tool_use: { key: 'tool_use', label: '도구', description: '도구를 호출하거나 결과를 소비하는 중입니다.' },
+  compacting: { key: 'compacting', label: '압축', description: '컨텍스트 압축 단계를 수행 중입니다.' },
+  handoff: { key: 'handoff', label: '승계', description: '다음 세대로 이어붙이는 중입니다.' },
+  scheduled_autonomous: { key: 'scheduled_autonomous', label: '자율', description: '예약된 자율 턴을 수행 중입니다.' },
+  failing: { key: 'failing', label: '오류', description: '세부 파이프라인 단계에서 오류를 감지했습니다.' },
+  draining: { key: 'draining', label: '종료', description: '활동 종료를 위해 파이프라인을 비우는 중입니다.' },
+  paused: { key: 'paused', label: '일시정지', description: '활동 단계도 함께 정지된 상태입니다.' },
+  crashed: { key: 'crashed', label: '중단', description: '파이프라인 실행이 비정상 종료되었습니다.' },
+  restarting: { key: 'restarting', label: '재시작', description: '파이프라인을 다시 올리는 중입니다.' },
+  offline: OFFLINE_STAGE_META,
+}
+
+const BAND_META: Record<RuntimeBand, RuntimeBandMeta> = {
+  active: {
+    key: 'active',
+    label: '가동중',
+    description: '운영자가 보기엔 현재 개입 없이 흐름을 지켜봐도 되는 상태입니다.',
+  },
+  attention: {
+    key: 'attention',
+    label: '주의 필요',
+    description: '실패, 복구, 승계, 드레이닝, blocker, stale heartbeat 등으로 확인이 필요한 상태입니다.',
+  },
+  paused: {
+    key: 'paused',
+    label: '일시정지',
+    description: '운영자가 의도적으로 멈춰 둔 상태입니다.',
+  },
+  offline: {
+    key: 'offline',
+    label: '오프라인',
+    description: '프로세스가 내려갔거나 아직 부팅되지 않았습니다.',
+  },
+}
+
+function phaseMeta(key: string | null | undefined): PhaseMeta {
+  if (!key) return UNKNOWN_PHASE_META
+  const meta = PHASE_LABELS[key]
+  return meta ?? UNKNOWN_PHASE_META
+}
+
+function stageMeta(key: string | null | undefined): StageMeta {
+  if (!key) return OFFLINE_STAGE_META
+  const meta = STAGE_LABELS[key]
+  return meta ?? OFFLINE_STAGE_META
+}
+
+function normalizePhase(phase: KeeperPhase | string | null | undefined): string | null {
+  if (!phase) return null
+  if (CANONICAL_PHASE_KEYS.has(phase)) return phase
+  const normalized = String(phase).trim().toLowerCase()
+  if (!normalized) return null
+  const lookup: Record<string, string> = {
+    offline: 'Offline',
+    running: 'Running',
+    failing: 'Failing',
+    compacting: 'Compacting',
+    handing_off: 'HandingOff',
+    handingoff: 'HandingOff',
+    draining: 'Draining',
+    paused: 'Paused',
+    stopped: 'Stopped',
+    crashed: 'Crashed',
+    restarting: 'Restarting',
+    dead: 'Dead',
+  }
+  return lookup[normalized] ?? null
+}
+
+function normalizeStage(stage: PipelineStage | string | null | undefined): string {
+  return stage ? String(stage) : 'offline'
+}
+
+export function keeperPhaseForDisplay(keeper: Keeper): string | null {
+  const lifecycleKey = keeperDisplayStatus(keeper)
+  const lifecyclePhase = normalizePhase(lifecycleKey)
+  if (
+    lifecyclePhase === 'Paused'
+    || lifecyclePhase === 'Stopped'
+    || lifecyclePhase === 'Offline'
+    || lifecyclePhase === 'Dead'
+  ) {
+    return lifecyclePhase
+  }
+  return normalizePhase(keeper.phase) ?? lifecyclePhase
+}
+
+function isHeartbeatStale(keeper: Keeper): boolean {
+  if (!keeper.last_heartbeat) return false
+  const ts = Date.parse(keeper.last_heartbeat)
+  if (Number.isNaN(ts)) return false
+  return Date.now() - ts > HEARTBEAT_STALE_MS
+}
+
+function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): RuntimeBand {
+  if (keeper.paused || phaseKey === 'Paused' || lifecycleKey === 'paused') return 'paused'
+  if (
+    lifecycleKey === 'offline'
+    || lifecycleKey === 'inactive'
+    || lifecycleKey === 'unbooted'
+    || lifecycleKey === 'stopped'
+    || OFFLINE_PHASES.has(phaseKey)
+  ) {
+    return 'offline'
+  }
+  if (
+    ATTENTION_PHASES.has(phaseKey)
+    || Boolean(keeper.last_blocker?.trim())
+    || isHeartbeatStale(keeper)
+    || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= CONTEXT_ATTENTION_RATIO)
+  ) {
+    return 'attention'
+  }
+  return 'active'
+}
+
+function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string | null {
+  const blocker = keeper.last_blocker?.trim()
+  if (blocker) return blocker
+  if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'
+  if (isHeartbeatStale(keeper)) return '하트비트가 오래되어 실제 프로세스 확인이 필요합니다.'
+  if (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= CONTEXT_ATTENTION_RATIO) {
+    return `컨텍스트 사용량 ${Math.round(keeper.context_ratio * 100)}%`
+  }
+  if (band === 'attention') return stage.description
+  if (band === 'offline' && keeper.generation === 0 && (keeper.turn_count ?? 0) === 0) {
+    return '아직 부팅된 적 없는 등록 런타임입니다.'
+  }
+  return stage.key === 'idle' ? '현재 활동 단계는 비어 있습니다.' : stage.description
+}
+
+export function summarizeKeeperMonitoring(keeper: Keeper): KeeperMonitoringSummary {
+  const lifecycleKey = keeperDisplayStatus(keeper)
+  const phaseKey = keeperPhaseForDisplay(keeper) ?? 'unknown'
+  const stage = stageMeta(normalizeStage(keeper.pipeline_stage))
+  const band = BAND_META[keeperBand(keeper, phaseKey, lifecycleKey)]
+
+  return {
+    band,
+    phase: phaseMeta(phaseKey),
+    stage,
+    hint: keeperHint(keeper, band.key, stage),
+  }
+}
+
+function agentBand(status: string | undefined | null): RuntimeBand {
+  const normalized = (status ?? '').trim().toLowerCase()
+  if (!normalized) return 'attention'
+  if (normalized === 'inactive' || normalized === 'offline' || normalized === 'dead' || normalized === 'left') {
+    return 'offline'
+  }
+  return 'active'
+}
+
+export function runtimeBandForAgent(agent: Agent, keeper?: Keeper | null): RuntimeBand {
+  if (keeper) return summarizeKeeperMonitoring(keeper).band.key
+  return agentBand(agent.status)
+}
+
+export function runtimeBandMetaForAgent(agent: Agent, keeper?: Keeper | null): RuntimeBandMeta {
+  return BAND_META[runtimeBandForAgent(agent, keeper)]
+}
+
+export function runtimeBandMeta(band: RuntimeBand): RuntimeBandMeta {
+  return BAND_META[band]
+}


### PR DESCRIPTION
## Summary
- introduced a shared monitoring runtime model for keeper/operator-facing state interpretation
- aligned the keeper fleet header and agent roster to use the same runtime bands and the same keeper-detail click path
- reframed the monitoring surface around operator band, TLA phase, and activity stage
- made the keeper state diagram safer by comparing live phase vs registry phase and surfacing observed transitions
- normalized paused keeper display so the operator band and phase badge no longer contradict each other

## Product impact
- operators can read the monitoring page in one order: operator state first, then phase, then stage
- keeper cards and agent cards now navigate consistently into the same keeper detail overlay
- Mermaid is treated as a projection with visible trust limits instead of implied source of truth
- paused keepers are easier to scan because the visible phase no longer stays misleadingly "Running"

## Evidence
- local browser verification on `http://localhost:5174/dashboard/#monitoring?section=agents`
- confirmed keeper-fleet click-through and agent-roster click-through both open the same keeper overlay
- confirmed paused keeper cards render as `일시정지 / phase 일시정지 / stage 대기`
- `pnpm typecheck`
- `pnpm test src/components/agent-roster.test.ts src/lib/monitoring-runtime.test.ts src/components/keeper-detail.test.ts`

## Review evidence
- Cross-model review: GLM-5.1 via `sb glm-text`
- Timestamp: 2026-04-09 14:55 KST
- Result: No findings
- Residual notes only: loose `includes` keeper matching could mis-associate similarly named runtimes, and heartbeat staleness depends on client clock skew
- Full review note is posted in PR comment: https://github.com/jeong-sik/masc-mcp/pull/6072#issuecomment-4211767743

## Linked issue
- Refs #5924
- Refs #6065

## What changed
- introduced a shared monitoring runtime model for keeper/operator-facing state interpretation
- aligned the keeper fleet header and agent roster to use the same runtime bands and click through to the same keeper detail flow
- rewrote the monitoring explainer around operator band, TLA phase, and activity stage
- made the keeper state diagram safer by showing live phase vs registry phase and listing observed transitions
- normalized paused keeper display so cards no longer show a paused operator band with a conflicting running phase badge

## Why
The monitoring surface was mixing several incompatible status concepts at once. The top keeper list, agent roster, and Mermaid phase view could all tell slightly different stories, which made it hard to know what to trust.

## Root cause
We were rendering different parts of the UI from different status heuristics:
- the keeper summary used one path
- the agent roster used another
- detail visualizations trusted raw registry/projection state too directly

That let lifecycle phase, operator pause state, and current pipeline stage drift apart in the UI.

## Impact
- operators get one primary runtime summary model across the monitoring page
- keeper cards and agent cards now navigate consistently
- Mermaid is presented as a projection with visible mismatch warnings instead of implied ground truth
- paused keepers read more cleanly at a glance

## Validation
- `pnpm typecheck`
- `pnpm test src/components/agent-roster.test.ts src/lib/monitoring-runtime.test.ts src/components/keeper-detail.test.ts`
- browser verification on `http://localhost:5174/dashboard/#monitoring?section=agents` for click-through consistency and paused/runtime badge alignment
