### PR TITLE
[codex] Surface prompt fingerprint telemetry in keeper dashboard

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -390,6 +390,114 @@ export function TokenTrendChart({ keeper }: { keeper: Keeper }) {
   `
 }
 
+function formatFingerprint(value: string | null | undefined): string {
+  if (!value) return '-'
+  return value.length > 16 ? `${value.slice(0, 16)}…` : value
+}
+
+function formatSegmentLabel(key: string): string {
+  return key.replace(/[_-]+/g, ' ')
+}
+
+export function PromptTelemetryPanel({ keeper }: { keeper: Keeper }) {
+  const series = keeper.metrics_series ?? []
+  const promptPoints = series.filter(
+    (p: KeeperMetricPoint) => p.prompt_metrics != null || p.prompt_fingerprint != null,
+  )
+  if (promptPoints.length === 0) return null
+
+  const latest = promptPoints[promptPoints.length - 1] ?? null
+  const latestPrompt = latest?.prompt_metrics ?? null
+  const latestSegments = Object.entries(latestPrompt?.segments ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+  const promptTotals = promptPoints.map(
+    (p: KeeperMetricPoint) => p.prompt_metrics?.estimated_total_tokens ?? 0,
+  )
+  const latestTotal = latestPrompt?.estimated_total_tokens ?? null
+  const latestCacheable = latestPrompt?.estimated_cacheable_tokens ?? null
+  const cacheableRatio =
+    latestTotal && latestCacheable != null && latestTotal > 0
+      ? latestCacheable / latestTotal
+      : null
+
+  const fingerprints = promptPoints
+    .map((p: KeeperMetricPoint) => p.prompt_fingerprint ?? p.prompt_metrics?.fingerprint ?? null)
+    .filter((value): value is string => Boolean(value))
+  const uniqueFingerprintCount = new Set(fingerprints).size
+  let fingerprintTransitions = 0
+  let lastFingerprint: string | null = null
+  for (const current of fingerprints) {
+    if (lastFingerprint != null && current !== lastFingerprint) fingerprintTransitions += 1
+    lastFingerprint = current
+  }
+
+  const W = SPARKLINE_W, H = SPARKLINE_H
+  const totalLine = miniSparkline(promptTotals)
+
+  return html`
+    <div class="mb-5">
+      <div class="flex items-center gap-2 mb-2">
+        <span class="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">Prompt Fingerprint</span>
+        <span class="text-[10px] text-[var(--text-dim)]">${promptPoints.length} snapshots</span>
+        ${latest?.prompt_fingerprint
+          ? html`<span class="text-[9px] px-1.5 py-0.5 rounded bg-[var(--white-5)] text-[var(--text-dim)] font-mono" title=${latest.prompt_fingerprint}>${formatFingerprint(latest.prompt_fingerprint)}</span>`
+          : null}
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
+        <div class="md:col-span-2 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+          <div class="flex items-center justify-between mb-1.5">
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">estimated prompt tokens</span>
+            <span class="text-xs font-mono tabular-nums text-[var(--accent)]">${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
+          </div>
+          <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
+            ${totalLine ? html`<polyline points="${totalLine}" fill="none" stroke="#f59e0b" stroke-width="1.5"/>` : null}
+          </svg>
+          <div class="mt-1 flex flex-wrap gap-2 text-[9px] text-[var(--text-dim)]">
+            <span>latest ${latestTotal != null ? formatTokens(latestTotal) : '-'}</span>
+            <span>cacheable ${latestCacheable != null ? formatTokens(latestCacheable) : '-'}</span>
+            ${cacheableRatio != null ? html`<span>${Math.round(cacheableRatio * 100)}% cacheable</span>` : null}
+          </div>
+        </div>
+
+        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">fingerprint revisions</span>
+          <span class="text-lg font-mono tabular-nums text-[var(--warn)]">${fingerprintTransitions}</span>
+          <span class="text-[9px] text-[var(--text-dim)]">${uniqueFingerprintCount} unique</span>
+        </div>
+
+        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col justify-between">
+          <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest fingerprint</span>
+          <span class="text-sm font-mono break-all text-[var(--text-strong)]">${latest?.prompt_fingerprint ? formatFingerprint(latest.prompt_fingerprint) : '-'}</span>
+          <span class="text-[9px] text-[var(--text-dim)]">${latestSegments.length} segments</span>
+        </div>
+      </div>
+
+      ${latestSegments.length > 0 ? html`
+        <div class="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+          ${latestSegments.map(([segmentKey, segment]) => html`
+            <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
+              <div class="flex items-center justify-between gap-2 mb-2">
+                <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">${formatSegmentLabel(segmentKey)}</span>
+                <span class="text-[9px] font-mono text-[var(--text-dim)]" title=${segment.fingerprint ?? ''}>${formatFingerprint(segment.fingerprint)}</span>
+              </div>
+              <div class="grid grid-cols-2 gap-2 text-xs">
+                <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
+                  <div class="text-[9px] uppercase tracking-wider text-[var(--text-dim)]">tokens</div>
+                  <div class="mt-1 font-mono tabular-nums text-[var(--accent)]">${formatTokens(segment.estimated_tokens)}</div>
+                </div>
+                <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-2">
+                  <div class="text-[9px] uppercase tracking-wider text-[var(--text-dim)]">bytes</div>
+                  <div class="mt-1 font-mono tabular-nums text-[var(--text-strong)]">${segment.bytes.toLocaleString()}</div>
+                </div>
+              </div>
+            </div>
+          `)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 // ── Metrics Charts (Latency + Cost + Model) ─────────────
 
 const SPARKLINE_W = 200

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -29,6 +29,7 @@ import {
   InferenceTelemetryPanel,
   KpiGrid,
   MetricsCharts,
+  PromptTelemetryPanel,
   RawDataDebug,
   RelationshipList,
   TokenTrendChart,
@@ -426,6 +427,9 @@ export function KeeperDetailOverlay() {
 
         ${'' /* ── Per-turn token trend (input vs output) ── */}
         <${TokenTrendChart} keeper=${keeper} />
+
+        ${'' /* ── Prompt fingerprint / segment telemetry ── */}
+        <${PromptTelemetryPanel} keeper=${keeper} />
 
         ${'' /* ── Inference Telemetry (tok/s, cache, reasoning) ── */}
         <${InferenceTelemetryPanel} keeper=${keeper} />

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -208,6 +208,54 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(keeper as unknown as Record<string, unknown>).not.toHaveProperty('allowed_tool_names')
   })
 
+  it('normalizes prompt telemetry dynamically from keeper metric points', () => {
+    const [keeper] = normalizeKeepers([
+      {
+        name: 'prompt-keeper',
+        status: 'active',
+        metrics_series: [
+          {
+            ts_unix: 4,
+            context_ratio: 0.42,
+            context_tokens: 420,
+            context_max: 1000,
+            latency_ms: 110,
+            generation: 2,
+            channel: 'turn',
+            model_used: 'glm-5',
+            cost_usd: 0.03,
+            compacted: false,
+            prompt_fingerprint: 'prompt-fp-001',
+            prompt: {
+              fingerprint: 'prompt-fp-001',
+              estimated_total_tokens: 321,
+              estimated_cacheable_tokens: 144,
+              system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
+              dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
+              user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(keeper?.metrics_series).toHaveLength(1)
+    const metric = keeper?.metrics_series?.[0]
+    expect(metric).toBeDefined()
+    if (!metric) throw new Error('metric missing')
+    expect(metric.prompt_fingerprint).toBe('prompt-fp-001')
+    expect(metric.prompt_metrics).toEqual({
+      fingerprint: 'prompt-fp-001',
+      estimated_total_tokens: 321,
+      estimated_cacheable_tokens: 144,
+      segments: {
+        system_prompt: { bytes: 512, estimated_tokens: 144, fingerprint: 'seg-system' },
+        dynamic_context: { bytes: 220, estimated_tokens: 61, fingerprint: 'seg-dynamic' },
+        user_message: { bytes: 98, estimated_tokens: 28, fingerprint: 'seg-user' },
+      },
+    })
+  })
+
   it('preserves paused runtime signals and blocker metadata for keeper UI', () => {
     const [keeper] = normalizeKeepers([
       {

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -4,6 +4,7 @@ import type {
   KeeperMetricPoint,
   KeeperPhase,
   PipelineStage,
+  PromptTelemetry,
 } from './types'
 import { isRecord, asString, asNumber, asBoolean, asStringArray, toIsoTimestamp } from './components/common/normalize'
 import { isOfflineStatus } from './lib/status-utils'
@@ -123,6 +124,35 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         handoffObj
           ? (typeof handoffObj.to_model === 'string' ? handoffObj.to_model : null)
           : (typeof item.handoff_to_model === 'string' ? item.handoff_to_model : null)
+      const rawPrompt = isRecord(item.prompt) ? item.prompt : null
+      const promptSegments: NonNullable<PromptTelemetry['segments']> = {}
+      if (rawPrompt) {
+        for (const [key, value] of Object.entries(rawPrompt)) {
+          if (key === 'fingerprint' || key === 'estimated_total_tokens' || key === 'estimated_cacheable_tokens') continue
+          if (!isRecord(value)) continue
+          const bytes = asNumber(value.bytes)
+          const estimatedTokens = asNumber(value.estimated_tokens)
+          const fingerprint = typeof value.fingerprint === 'string' ? value.fingerprint : null
+          if (bytes == null && estimatedTokens == null && fingerprint == null) continue
+          promptSegments[key] = {
+            bytes: bytes ?? 0,
+            estimated_tokens: estimatedTokens ?? 0,
+            fingerprint,
+          }
+        }
+      }
+      const promptFingerprint =
+        (typeof item.prompt_fingerprint === 'string' ? item.prompt_fingerprint : null)
+        ?? (rawPrompt && typeof rawPrompt.fingerprint === 'string' ? rawPrompt.fingerprint : null)
+      const prompt_metrics =
+        promptFingerprint != null || rawPrompt != null || Object.keys(promptSegments).length > 0
+          ? {
+              fingerprint: promptFingerprint,
+              estimated_total_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_total_tokens) ?? null) : null,
+              estimated_cacheable_tokens: rawPrompt ? (asNumber(rawPrompt.estimated_cacheable_tokens) ?? null) : null,
+              segments: promptSegments,
+            }
+          : null
       const rawTel = isRecord(item.inference_telemetry) ? item.inference_telemetry : null
       const rawTimings = rawTel && isRecord(rawTel.timings) ? rawTel.timings : null
       const inference_telemetry = rawTel ? {
@@ -158,6 +188,8 @@ function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
         cost_usd: asNumber(item.cost_usd) ?? Number.NaN,
         handoff_to_model: handoffToModel,
         handoff_new_generation: handoffNewGeneration,
+        prompt_fingerprint: promptFingerprint,
+        prompt_metrics,
         inference_telemetry,
         fallback_applied: cascadeObj ? cascadeObj.fallback_applied === true : false,
         fallback_hops: cascadeObj ? (asNumber(cascadeObj.fallback_hops) ?? 0) : 0,

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -161,6 +161,19 @@ export interface InferenceTelemetry {
   request_latency_ms: number
 }
 
+export interface PromptSegmentTelemetry {
+  bytes: number
+  estimated_tokens: number
+  fingerprint: string | null
+}
+
+export interface PromptTelemetry {
+  fingerprint: string | null
+  estimated_total_tokens: number | null
+  estimated_cacheable_tokens: number | null
+  segments: Record<string, PromptSegmentTelemetry>
+}
+
 export interface KeeperMetricPoint {
   ts: number
   context_ratio: number
@@ -177,6 +190,8 @@ export interface KeeperMetricPoint {
   cost_usd: number
   handoff_to_model: string | null
   handoff_new_generation: number | null
+  prompt_fingerprint: string | null
+  prompt_metrics: PromptTelemetry | null
   inference_telemetry: InferenceTelemetry | null
   fallback_applied: boolean
   fallback_hops: number

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -480,6 +480,8 @@ let compute_metrics_window
                     ("latency_ms", `Int latency_ms);
                     ("cost_usd", `Float cost_usd);
                     ("model_used", `String model_used);
+                    ("prompt_fingerprint", j |> member "prompt_fingerprint");
+                    ("prompt", j |> member "prompt");
                     ("compaction_before_tokens", `Int before_tokens);
                     ("compaction_after_tokens", `Int after_tokens);
                     ("compaction_saved_tokens", `Int saved_tokens);

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -58,10 +58,92 @@ type turn_prompt =
   ; dynamic_context : string
   }
 
+(** Prompt segment metrics for effective keeper input attribution.
+    Bytes are stored rather than character counts because prompts are UTF-8. *)
+type prompt_segment_metrics =
+  { bytes : int
+  ; estimated_tokens : int
+  ; fingerprint : string option
+  }
+
+(** Effective prompt metrics for a keeper turn.
+    [estimated_cacheable_tokens] tracks the system prompt portion only because
+    OAS prompt caching is enabled via [cache_system_prompt:true]. *)
+type prompt_metrics =
+  { fingerprint : string
+  ; estimated_total_tokens : int
+  ; estimated_cacheable_tokens : int
+  ; system_prompt_segment : prompt_segment_metrics
+  ; dynamic_context_segment : prompt_segment_metrics
+  ; user_message_segment : prompt_segment_metrics
+  }
+
+let prompt_segment_metrics_of_text (text : string) : prompt_segment_metrics =
+  let text = Inference_utils.sanitize_text_utf8 text in
+  {
+    bytes = String.length text;
+    estimated_tokens =
+      (if text = "" then 0 else Agent_sdk.Context_reducer.estimate_char_tokens text);
+    fingerprint =
+      (if text = ""
+       then None
+       else Some Digestif.SHA256.(digest_string text |> to_hex));
+  }
+
+let build_prompt_metrics ~(system_prompt : string) ~(dynamic_context : string)
+    ~(user_message : string) : prompt_metrics =
+  let system_prompt = Inference_utils.sanitize_text_utf8 system_prompt in
+  let dynamic_context = Inference_utils.sanitize_text_utf8 dynamic_context in
+  let user_message = Inference_utils.sanitize_text_utf8 user_message in
+  let system_prompt_metrics = prompt_segment_metrics_of_text system_prompt in
+  let dynamic_context_metrics = prompt_segment_metrics_of_text dynamic_context in
+  let user_message_metrics = prompt_segment_metrics_of_text user_message in
+  let fingerprint_input =
+    `Assoc
+      [
+        ("system_prompt", `String system_prompt);
+        ("dynamic_context", `String dynamic_context);
+        ("user_message", `String user_message);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  {
+    fingerprint = Digestif.SHA256.(digest_string fingerprint_input |> to_hex);
+    estimated_total_tokens =
+      (system_prompt_metrics.estimated_tokens
+       + dynamic_context_metrics.estimated_tokens
+       + user_message_metrics.estimated_tokens);
+    estimated_cacheable_tokens = system_prompt_metrics.estimated_tokens;
+    system_prompt_segment = system_prompt_metrics;
+    dynamic_context_segment = dynamic_context_metrics;
+    user_message_segment = user_message_metrics;
+  }
+
+let prompt_segment_metrics_to_json (segment : prompt_segment_metrics) :
+    Yojson.Safe.t =
+  `Assoc
+    [
+      ("bytes", `Int segment.bytes);
+      ("estimated_tokens", `Int segment.estimated_tokens);
+      ("fingerprint", Json_util.string_opt_to_json segment.fingerprint);
+    ]
+
+let prompt_metrics_to_json (metrics : prompt_metrics) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("fingerprint", `String metrics.fingerprint);
+      ("estimated_total_tokens", `Int metrics.estimated_total_tokens);
+      ("estimated_cacheable_tokens", `Int metrics.estimated_cacheable_tokens);
+      ("system_prompt", prompt_segment_metrics_to_json metrics.system_prompt_segment);
+      ("dynamic_context", prompt_segment_metrics_to_json metrics.dynamic_context_segment);
+      ("user_message", prompt_segment_metrics_to_json metrics.user_message_segment);
+    ]
+
 (** Result of a single Agent.run() keeper turn. *)
 type run_result =
   { response_text : string
   ; model_used : string
+  ; prompt_metrics : prompt_metrics
   ; cascade_observation : Oas_worker.cascade_observation option
   ; turn_count : int
   ; tool_calls_made : int
@@ -289,7 +371,12 @@ let run_turn
      handing prompts/history to OAS. Keep this sanitization here even when
      upstream builders already cleaned their strings. *)
   let turn_system_prompt = Inference_utils.sanitize_text_utf8 turn_system_prompt in
+  let dynamic_context = Inference_utils.sanitize_text_utf8 dynamic_context in
   let user_message = Inference_utils.sanitize_text_utf8 user_message in
+  let prompt_metrics =
+    build_prompt_metrics ~system_prompt:turn_system_prompt ~dynamic_context
+      ~user_message
+  in
   (* 6. Append user message and persist.
      On retry (is_retry=true), the user message was already persisted by the
      first attempt.  Checkpoint reload does not include it (checkpoint is
@@ -1685,6 +1772,7 @@ let run_turn
           Ok
             { response_text
             ; model_used = model
+            ; prompt_metrics
             ; cascade_observation = result.cascade_observation
             ; turn_count = result.turns
             ; tool_calls_made = List.length tool_names

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -689,6 +689,8 @@ let append_metrics_snapshot ~(config : Room.config) ~(meta : keeper_meta)
         ("trace_id", `String meta.runtime.trace_id);
         ("generation", `Int turn_generation);
         ("model_used", `String result.model_used);
+        ("prompt_fingerprint", `String result.prompt_metrics.fingerprint);
+        ("prompt", Keeper_agent_run.prompt_metrics_to_json result.prompt_metrics);
         ( "usage",
           `Assoc
             [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -887,11 +887,18 @@ let test_meta_defaults_social_model () =
 
 (* ---------- Metrics observation tests ---------- *)
 
+let sample_prompt_metrics ?(system_prompt = "You are a keeper.")
+    ?(dynamic_context = "")
+    ?(user_message = "Check the board.")
+    () =
+  KAR.build_prompt_metrics ~system_prompt ~dynamic_context ~user_message
+
 let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     : Masc_mcp.Keeper_agent_run.run_result =
   {
     response_text = text;
     model_used = model;
+    prompt_metrics = sample_prompt_metrics ();
     cascade_observation = None;
     turn_count = 1;
     tool_calls_made = List.length tools;
@@ -902,6 +909,32 @@ let make_run_result ~text ~tools ~model ~input_tok ~output_tok
     stop_reason = Masc_mcp.Oas_worker.Completed;
     inference_telemetry = None;
   }
+
+let test_prompt_metrics_fingerprint_is_deterministic () =
+  let metrics_a =
+    sample_prompt_metrics ~system_prompt:"sys" ~dynamic_context:"ctx"
+      ~user_message:"user" ()
+  in
+  let metrics_b =
+    sample_prompt_metrics ~system_prompt:"sys" ~dynamic_context:"ctx"
+      ~user_message:"user" ()
+  in
+  let metrics_c =
+    sample_prompt_metrics ~system_prompt:"sys" ~dynamic_context:"ctx"
+      ~user_message:"changed user" ()
+  in
+  check string "same inputs -> same fingerprint"
+    metrics_a.fingerprint metrics_b.fingerprint;
+  check bool "different prompt inputs -> different fingerprint" true
+    (metrics_a.fingerprint <> metrics_c.fingerprint);
+  check int "cacheable tokens follow system prompt"
+    metrics_a.system_prompt_segment.estimated_tokens
+    metrics_a.estimated_cacheable_tokens;
+  check int "total estimated tokens are additive"
+    (metrics_a.system_prompt_segment.estimated_tokens
+     + metrics_a.dynamic_context_segment.estimated_tokens
+     + metrics_a.user_message_segment.estimated_tokens)
+    metrics_a.estimated_total_tokens
 
 let test_metrics_text_response () =
   let result =
@@ -1100,6 +1133,12 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
           (make_run_result ~text:"Observed" ~tools:[]
              ~model:"openai:qwen3.5-35b" ~input_tok:40 ~output_tok:20)
           with
+          prompt_metrics =
+            sample_prompt_metrics
+              ~system_prompt:"You are a keeper focused on triage."
+              ~dynamic_context:"Pending mentions: 2"
+              ~user_message:"Review the board and decide what to do next."
+              ();
           cascade_observation =
             Some
               {
@@ -1207,7 +1246,26 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
       check string "nested deliberation execution source persisted" "baseline"
         Yojson.Safe.Util.(
           json |> member "deliberation_execution" |> member "action_source"
-          |> to_string))
+          |> to_string);
+      check string "top-level prompt fingerprint persisted"
+        result.prompt_metrics.fingerprint
+        Yojson.Safe.Util.(json |> member "prompt_fingerprint" |> to_string);
+      check int "prompt total tokens persisted"
+        result.prompt_metrics.estimated_total_tokens
+        Yojson.Safe.Util.(
+          json |> member "prompt" |> member "estimated_total_tokens"
+          |> to_int);
+      check int "system prompt bytes persisted"
+        result.prompt_metrics.system_prompt_segment.bytes
+        Yojson.Safe.Util.(
+          json |> member "prompt" |> member "system_prompt" |> member "bytes"
+          |> to_int);
+      check string "user message fingerprint persisted"
+        (Option.value ~default:""
+           result.prompt_metrics.user_message_segment.fingerprint)
+        Yojson.Safe.Util.(
+          json |> member "prompt" |> member "user_message"
+          |> member "fingerprint" |> to_string))
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
@@ -2079,6 +2137,8 @@ let () =
         ] );
       ( "metrics_observation",
         [
+          test_case "prompt metrics fingerprint" `Quick
+            test_prompt_metrics_fingerprint_is_deterministic;
           test_case "text response" `Quick test_metrics_text_response;
           test_case "tool response" `Quick test_metrics_tool_response;
           test_case "noop response" `Quick test_metrics_noop_response;


### PR DESCRIPTION
## Summary
- record prompt fingerprint and per-segment prompt telemetry in keeper metrics snapshots
- expose prompt fingerprint data through the keeper detail API and dashboard normalization layer
- render a dynamic prompt telemetry panel in keeper detail without hardcoded segment names

## Why
- keeper metrics already capture model/runtime telemetry, but prompt-shape changes were not visible in the dashboard
- this makes prompt revisions and segment cost visible when prompt composition changes across turns

## Impact
- keeper metrics JSONL now includes `prompt_fingerprint` and a nested `prompt` object
- keeper detail shows prompt revisions, estimated prompt token trend, cacheable share, and segment-level bytes/tokens/fingerprints
- frontend segment handling stays schema-driven by iterating prompt object keys instead of assuming fixed names in the UI layer

## Validation
- `dune build --root .`
- `dune runtest --root . test/test_keeper_unified.exe test/test_keeper_prompt_metrics.exe`
- `pnpm exec vitest run src/keeper-store-normalize.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`

## Notes
- `pnpm test -- keeper-store-normalize.test.ts` currently expands to the broader dashboard suite and still hits unrelated existing failures in `src/api/mcp.test.ts`; targeted vitest invocation for the touched file passes.