### PR TITLE
fix: remove fake no-op Dashboard_cache setters

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -360,9 +360,9 @@ let run_cmd host port base_path =
   (* Enable Eio-aware locking globally (single call replaces per-module enable_eio) *)
   Eio_guard.enable ();
   Masc_mcp.Transport_metrics.init ();
-  Masc_mcp.Dashboard_cache.set_clock (Eio.Stdenv.clock env);
 
-  (* Set global clock for Time_compat (Eio-native timestamps) *)
+  (* Set global clock for Time_compat (Eio-native timestamps).
+     Dashboard_cache.now() reads from Time_compat directly. *)
   Time_compat.set_clock (Eio.Stdenv.clock env);
 
   (* Initialize thread-safe token store for cancellation support *)

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -83,14 +83,6 @@ let [@warning "-32"] cleanup_expired () =
     List.iter (fun key -> Hashtbl.remove table key) victims;
     List.length victims)
 
-(* clock_ref removed: Time_compat.sleep is the single sleep path
-   since the Fiber.yield spin-loop fix (#4948). *)
-let set_clock _clk = ()
-
-(* _bg_sw removed: uses Eio_context.get_switch_opt() directly.
-   set_sw retained as no-op for backward compat with server_runtime_bootstrap. *)
-let set_sw _sw = ()
-
 let now () = Time_compat.now ()
 
 (** Default stale grace multiplier: stale data is served for [ttl * stale_factor]

--- a/lib/dashboard/dashboard_cache.mli
+++ b/lib/dashboard/dashboard_cache.mli
@@ -7,15 +7,11 @@
 
     After a cached value expires, it is still served as stale data for
     [ttl * 3] additional seconds while a background fiber recomputes.
-    This prevents slow endpoints from blocking HTTP responses. *)
+    This prevents slow endpoints from blocking HTTP responses.
 
-val set_clock : _ Eio.Time.clock -> unit
-(** No-op since #4948 (Time_compat.sleep is the sole sleep path).
-    Retained for backward compatibility with existing callers. *)
-
-val set_sw : Eio.Switch.t -> unit
-(** Register the server switch for background revalidation fibers.
-    Call inside the main [Eio.Switch.run]. *)
+    {b Runtime prerequisites}: callers must initialise [Time_compat.set_clock]
+    and [Eio_context.set_switch] before using the cache. Background
+    stale-while-revalidate fibers are forked via [Eio_context.get_switch_opt]. *)
 
 val get_or_compute : string -> ttl:float -> (unit -> Yojson.Safe.t) -> Yojson.Safe.t
 (** [get_or_compute key ~ttl f] returns a cached value if [key] exists and
@@ -24,7 +20,7 @@ val get_or_compute : string -> ttl:float -> (unit -> Yojson.Safe.t) -> Yojson.Sa
 
     If the entry is expired but within the stale grace period ([ttl * 3]),
     the stale value is returned immediately and [f] runs in a background
-    fiber (requires [set_sw] to have been called).
+    fiber (requires [Eio_context.set_switch] to have been called).
 
     Safe to nest: [f] may call [get_or_compute] for a different key without
     deadlocking.  Concurrent requests for the same key are serialised — only

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -61,7 +61,6 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   Eio_context.set_switch sw;
-  Dashboard_cache.set_sw sw;
   Eio_context.set_net net;
   Eio_context.set_clock clock;
   Eio_context.set_mono_clock mono_clock;

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -189,7 +189,7 @@ let test_invalidate_all_wakes_waiters () =
     JSON.  (Regression test for Codex review P2 on PR #1314.) *)
 let test_stale_preserved_on_timeout ~clock ~sw () =
   Dashboard_cache.invalidate_all ();
-  Dashboard_cache.set_sw sw;
+  Eio_context.set_switch sw;
   let original = `String "original_data" in
   (* 1. Seed the cache with a short-lived entry (TTL 0.1s, stale grace 0.3s) *)
   let v0 =
@@ -297,7 +297,6 @@ let () =
   let clock = Eio.Stdenv.clock env in
   Eio_guard.enable ();
   Time_compat.set_clock clock;
-  Dashboard_cache.set_clock clock;
   let open Alcotest in
   run ~and_exit:false "Dashboard_cache"
     [


### PR DESCRIPTION
## Summary
- remove the fake no-op `Dashboard_cache.set_clock` and `Dashboard_cache.set_sw` API
- wire callers to the real shared runtime context instead of misleading setters
- document the actual `Time_compat` / `Eio_context` prerequisites and update the cache test

## Verification
- `env DUNE_BUILD_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-remove-fake-dashboard-setters/_build_codex_remove_fake dune build --root . 2>&1`
- `./_build_codex_remove_fake/default/test/test_dashboard_cache.exe`