### PR TITLE
feat(keeper): PR history + worktree listing in playground panel

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -259,6 +259,31 @@ function isPlaygroundRepo(r: unknown): r is PlaygroundRepo {
     && typeof r.last_action === 'string'
 }
 
+interface PlaygroundPR {
+  pr_url: string
+  branch: string
+  title: string
+  draft: boolean
+}
+
+function isPlaygroundPR(r: unknown): r is PlaygroundPR {
+  if (!isRecord(r)) return false
+  return typeof r.pr_url === 'string'
+    && typeof r.branch === 'string'
+    && typeof r.title === 'string'
+    && typeof r.draft === 'boolean'
+}
+
+interface PlaygroundWorktree {
+  name: string
+  path: string
+}
+
+function isPlaygroundWorktree(r: unknown): r is PlaygroundWorktree {
+  if (!isRecord(r)) return false
+  return typeof r.name === 'string' && typeof r.path === 'string'
+}
+
 function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
   const detail = keeperStatusDetails.value[keeperName]
   if (!detail?.rawStatus) return null
@@ -266,27 +291,63 @@ function PlaygroundReposPanel({ keeperName }: { keeperName: string }) {
   if (!isRecord(raw)) return null
   const execCtx = raw.execution_context
   if (!isRecord(execCtx)) return null
-  const repos = Array.isArray(execCtx.playground_repos) ? execCtx.playground_repos : []
-  if (repos.length === 0) return null
 
-  const items = repos.filter(isPlaygroundRepo)
+  const repos = (Array.isArray(execCtx.playground_repos) ? execCtx.playground_repos : []).filter(isPlaygroundRepo)
+  const prs = (Array.isArray(execCtx.pr_history) ? execCtx.pr_history : []).filter(isPlaygroundPR)
+  const worktrees = (Array.isArray(execCtx.active_worktrees) ? execCtx.active_worktrees : []).filter(isPlaygroundWorktree)
+
+  if (repos.length === 0 && prs.length === 0 && worktrees.length === 0) return null
 
   return html`
-    <${SectionCard} title="Playground (${items.length})">
-      <div class="flex flex-col gap-2">
-        ${items.map(r => html`
-          <div class="flex items-center gap-3 px-3 py-2 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
-                <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
-                ${r.shallow ? html`<span class="text-[9px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">shallow</span>` : null}
-              </div>
-              <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
+    <${SectionCard} title="Playground">
+      <div class="flex flex-col gap-3">
+        ${repos.length > 0 ? html`
+          <div>
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Repos (${repos.length})</div>
+            <div class="flex flex-col gap-1.5">
+              ${repos.map(r => html`
+                <div class="flex items-center gap-3 px-3 py-2 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
+                  <div class="flex-1 min-w-0">
+                    <div class="flex items-center gap-2">
+                      <span class="text-xs font-medium text-[var(--text-strong)] truncate">${r.name}</span>
+                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${r.branch}</span>
+                      ${r.shallow ? html`<span class="text-[9px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">shallow</span>` : null}
+                    </div>
+                    <div class="text-[10px] text-[var(--text-muted)] font-mono mt-0.5 truncate">${r.latest_commit}</div>
+                  </div>
+                  <span class="text-[10px] text-[var(--text-dim)] flex-shrink-0">${r.last_action}</span>
+                </div>
+              `)}
             </div>
-            <span class="text-[10px] text-[var(--text-dim)] flex-shrink-0">${r.last_action}</span>
           </div>
-        `)}
+        ` : null}
+
+        ${prs.length > 0 ? html`
+          <div>
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">PRs (${prs.length})</div>
+            <div class="flex flex-col gap-1.5">
+              ${prs.map(pr => html`
+                <div class="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)]">
+                  <span class="text-xs text-[var(--text-strong)] truncate flex-1">${pr.title}</span>
+                  <span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.15)]">${pr.branch}</span>
+                  ${pr.draft ? html`<span class="text-[9px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">draft</span>` : null}
+                  <a href=${pr.pr_url} target="_blank" rel="noopener" class="text-[10px] text-[var(--accent)] hover:underline flex-shrink-0">PR</a>
+                </div>
+              `)}
+            </div>
+          </div>
+        ` : null}
+
+        ${worktrees.length > 0 ? html`
+          <div>
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] mb-1.5">Worktrees (${worktrees.length})</div>
+            <div class="flex flex-wrap gap-1.5">
+              ${worktrees.map(w => html`
+                <span class="text-[10px] font-mono px-2 py-1 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-muted)]" title=${w.path}>${w.name}</span>
+              `)}
+            </div>
+          </div>
+        ` : null}
       </div>
     <//>
   `

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -658,6 +658,28 @@ let handle_keeper_pr_submit
             Ok (Printf.sprintf "PR created: %s" (String.trim out))
           end
         ) in
+        (* Record PR in playground history (best-effort, JSONL append) *)
+        if !step_ok && !pr_url <> "" then begin
+          try
+            let playground_dir = Filename.concat root
+              (Keeper_alerting_path.playground_path_of_keeper meta.name) in
+            Fs_compat.mkdir_p playground_dir;
+            let history_path = Filename.concat playground_dir
+              ".playground_pr_history.jsonl" in
+            let entry = `Assoc [
+              "pr_url", `String !pr_url;
+              "branch", `String !branch_name;
+              "title", `String pr_title;
+              "draft", `Bool draft;
+              "base", `String base_branch;
+              "cwd", `String cwd;
+              "created_at", `String (Printf.sprintf "%.0f" (Unix.gettimeofday ()));
+            ] in
+            Fs_compat.append_jsonl history_path entry
+          with exn ->
+            Log.Keeper.warn "pr_history append failed: %s (keeper=%s)"
+              (Printexc.to_string exn) meta.name
+        end;
         Yojson.Safe.to_string
           (`Assoc
             [ "ok", `Bool !step_ok

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -679,6 +679,37 @@ let handle_keeper_status ctx args : tool_result =
                     | repos -> repos)
                  | _ -> `List []
                with Sys_error _ | Yojson.Json_error _ -> `List []);
+             ("pr_history",
+               let pr_path = Filename.concat
+                 (Filename.concat ctx.config.base_path
+                   (Keeper_alerting_path.playground_path_of_keeper m.name))
+                 ".playground_pr_history.jsonl" in
+               try
+                 let entries = Fs_compat.load_jsonl pr_path in
+                 (* Last 10 PRs, most recent first.
+                    Rev first, then take up to 10 — O(N) single pass. *)
+                 let rev = List.rev entries in
+                 let rec take n acc = function
+                   | [] -> List.rev acc
+                   | _ when n <= 0 -> List.rev acc
+                   | x :: rest -> take (n - 1) (x :: acc) rest
+                 in
+                 `List (take 10 [] rev)
+               with Sys_error _ -> `List []);
+             ("active_worktrees",
+               let worktrees_dir = Filename.concat ctx.config.base_path ".worktrees" in
+               try
+                 let entries = Sys.readdir worktrees_dir |> Array.to_list in
+                 let keeper_prefix = Keeper_alerting_path.sanitize_keeper_name m.name in
+                 let matching = List.filter (fun name ->
+                   String.starts_with ~prefix:(keeper_prefix ^ "-") name
+                   || String.starts_with ~prefix:(keeper_prefix ^ "/") name
+                   || name = keeper_prefix) entries in
+                 `List (List.map (fun name -> `Assoc [
+                   "name", `String name;
+                   "path", `String (Filename.concat ".worktrees" name);
+                 ]) matching)
+               with Sys_error _ -> `List []);
              ("last_evidence",
                match Keeper_evidence.latest_evidence
                  ~base_path:ctx.config.base_path


### PR DESCRIPTION
## Summary
- **PR 추적**: `keeper_pr_submit` 성공 시 `.playground_pr_history.jsonl`에 PR 메타데이터(URL, branch, title, draft, base) append. status API에서 최근 10건 노출.
- **Worktree 목록**: `.worktrees/` 스캔으로 keeper prefix 매칭. status API `execution_context.active_worktrees`로 노출.
- **대시보드**: `PlaygroundReposPanel` 확장 — Repos / PRs / Worktrees 3섹션. PR 링크, draft 표시, worktree path tooltip.

## Follows
- #6053 (Phase 1+4: depth/timeout SSOT + preset badge)
- #6060 (Phase 2+3: playground state cache + repos panel)

## Review
- GLM 리뷰 완료: type guard 완성(branch+draft), O(N) tail-take 최적화 반영.
- OCaml build + TypeScript type check pass.

## Test plan
- [ ] keeper가 `keeper_pr_submit`으로 PR 생성 후 `.playground_pr_history.jsonl`에 entry 추가 확인
- [ ] 대시보드 keeper detail에서 PR 섹션 렌더링 + 링크 동작 확인
- [ ] `.worktrees/` 디렉토리에 keeper 이름으로 시작하는 worktree가 있을 때 Worktrees 섹션 표시 확인
- [ ] 모든 섹션이 비어 있을 때 Playground 패널 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)