### PR TITLE
[codex] Polish board copy labels

### DIFF
--- a/dashboard/src/components/memory.test.ts
+++ b/dashboard/src/components/memory.test.ts
@@ -108,7 +108,7 @@ describe('Memory Component', () => {
       },
     ] as any
     render(h(Memory, null))
-    expect(screen.getByText(/자율 글 \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/자동화 글 \(1\)/)).toBeInTheDocument()
     expect(screen.getByText('Automation Post')).toBeInTheDocument()
   })
 

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -182,8 +182,8 @@ function SortBar() {
         </button>
         <input
           type="text"
-          placeholder="Author"
-          aria-label="Filter posts by author"
+          placeholder="작성자"
+          aria-label="작성자 필터"
           value=${boardAuthorFilter.value}
           class="px-2.5 py-1 rounded-lg text-[11px] font-medium border bg-transparent text-[var(--text)] border-[var(--border-slate-16)] placeholder:text-[var(--text-muted)] w-28 focus:outline-none focus:border-[var(--accent)]"
           onKeyDown=${(e: KeyboardEvent) => {
@@ -236,9 +236,9 @@ function MemorySummary() {
       <span class="font-semibold text-[var(--text-strong)] tabular-nums text-[15px]">${visibleCount}</span>
       <span>개 표시 중</span>
       <span class="text-[var(--text-muted)]">·</span>
-      <span>직접 ${grouped.direct.length}</span>
+      <span>직접 작성 ${grouped.direct.length}</span>
       <span class="text-[var(--text-muted)]">·</span>
-      <span>자율 ${grouped.automation.length}</span>
+      <span>자동화 ${grouped.automation.length}</span>
       <span class="text-[var(--text-muted)]">·</span>
       <span>시스템 ${grouped.system.length}</span>
       ${lastBoardRefreshAt.value ? html`
@@ -414,7 +414,7 @@ export function Memory() {
           ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`
               ${renderSection('직접 작성 글', grouped.direct, visibleLimit)}
-              ${renderSection('자율 글', grouped.automation, automationVisibleLimit)}
+              ${renderSection('자동화 글', grouped.automation, automationVisibleLimit)}
               ${renderSection('시스템 글', grouped.system, systemVisibleLimit)}
             `}
     </div>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -164,7 +164,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'board',
       label: '작업 게시판',
-      description: '에이전트 간 지식 공유 게시판. 직접 작성 글, 자동화 글, 시스템 글을 함께 보여줍니다.',
+      description: '에이전트가 남긴 직접 작성 글, 자동화 글, 시스템 글을 한 곳에서 봅니다.',
       params: { section: 'board' },
     },
     {


### PR DESCRIPTION
## Summary
- unified board page terminology so the same post kind is not shown as both `자율` and `자동화`
- localized the author filter input on the board page
- tightened the board section description to read more cleanly in the workspace header

## Product impact
- operators scanning the board now see one term for automation posts across the summary strip, section heading, and card badges
- the board filter input is fully Korean instead of mixing English placeholder and aria copy into a Korean page
- the workspace board header reads more cleanly and avoids repeating `게시판` semantics unnecessarily

## Evidence
- `pnpm test src/components/memory.test.ts`
- `pnpm typecheck`
- browser verification on `http://127.0.0.1:5176/dashboard/#workspace?section=board`
- confirmed summary reads `직접 작성 / 자동화 / 시스템`
- confirmed the automation section heading reads `자동화 글`
- confirmed the author filter textbox exposes `작성자 필터`

## Review evidence
- Cross-model review: GLM-5.1 via `sb glm-text`
- Timestamp: 2026-04-09 15:33 KST
- Result: No findings
- Full note in PR comment: https://github.com/jeong-sik/masc-mcp/pull/6085#issuecomment-4211953134

## Linked issue
- none
