### PR TITLE
fix(worker): use actual model_id in MaxTurnsExceeded response

### DIFF
--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -548,7 +548,7 @@ let run
         }
     | Error (Oas.Error.Agent (Oas.Error.MaxTurnsExceeded r)) ->
       let partial_response : Oas.Types.api_response = {
-        id = session_id; model = "turn-exhausted";
+        id = session_id; model = config.model_id;
         stop_reason = Oas.Types.EndTurn;
         content = [Oas.Types.Text (Printf.sprintf
           "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];


### PR DESCRIPTION
## Summary
- `oas_worker_exec.ml`에서 `MaxTurnsExceeded` 에러 시 합성 `api_response`의 `model` 필드에 `"turn-exhausted"` 문자열을 하드코딩하고 있었음
- 상태 문자열이 모델 식별자 필드로 누수 — downstream에서 model 기반 필터링/집계/라우팅에 오류 유발 가능
- `config.model_id`로 교체하여 실제 모델명을 유지

## Root Cause
`MaxTurnsExceeded` 에러 핸들러가 partial response를 수동 구성할 때, 정상 경로와 달리 model 값을 OAS 응답에서 받지 않고 직접 리터럴을 넣음. **Unknown → Permissive Default 안티패턴**의 변형.

## Test plan
- [x] `dune build` 통과
- [ ] keeper가 turn budget exhaustion 시 dashboard에 실제 모델명이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)