### PR TITLE
fix(keeper): switch sangsu to local_only cascade

### DIFF
--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -50,6 +50,9 @@ execution_scope = "workspace"
 
 tool_preset = "social"
 
+# Local LLM only — uses "local_only" cascade (ollama:auto)
+cascade_name = "local_only"
+
 # Telemetry Feedback
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24


### PR DESCRIPTION
## Summary
- sangsu keeper: add `cascade_name = "local_only"` (ollama:auto)
- Avoids 573s GLM cloud timeouts that caused ambiguous partial commits

## Evidence
- sangsu 573.2s timeout after committed [board_post, board_comment, task_claim] (2026-04-09 dashboard log)
- cheolsu already on local_only since #6041

## Test plan
- [x] TOML syntax valid
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)