### PR TITLE
feat: add startup TOML cross-validation for tool registration

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -382,6 +382,7 @@
    tool_unified
    tool_help_registry
    tool_registry
+   tool_registration_check
    tool_code
    tool_code_write
    tool_suspend

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -16,6 +16,8 @@ open Keeper_tool_registry
    None = config not yet loaded (init_policy_config not yet called). *)
 let policy_config : Keeper_tool_policy_config.t option ref = ref None
 
+let policy_config_for_validation () = !policy_config
+
 let init_policy_config ~base_path =
   match Keeper_tool_policy_config.load ~base_path with
   | Ok cfg ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -83,6 +83,9 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
    | Error msg ->
        Log.Server.error "Fatal tool policy config load failure: %s" msg;
        exit 1);
+  (* Validate Tool_spec <-> TOML coverage *)
+  let validation = Tool_registration_check.validate () in
+  Tool_registration_check.log_validation_result validation;
   let state =
     Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock
       ~mono_clock ~net

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -1,0 +1,49 @@
+(** Tool_registration_check — Startup validation of Tool_spec ↔ TOML coverage.
+
+    Detects drift between registered Tool_spec tools and config/tool_policy.toml
+    group definitions. Called once after init_policy_config succeeds. *)
+
+type validation_result = {
+  orphan_toml : string list;
+  uncovered : string list;
+}
+
+let validate () : validation_result =
+  let registered =
+    let tbl = Hashtbl.create 256 in
+    List.iter (fun n -> Hashtbl.replace tbl n ()) (Tool_spec.all_registered_names ());
+    tbl
+  in
+  match Keeper_tool_policy.policy_config_for_validation () with
+  | None -> { orphan_toml = []; uncovered = [] }
+  | Some cfg ->
+    let configured =
+      let tbl = Hashtbl.create 256 in
+      List.iter (fun n -> Hashtbl.replace tbl n ())
+        (Keeper_tool_policy_config.all_group_tools cfg
+         @ Keeper_tool_policy_config.all_masc_tools cfg);
+      tbl
+    in
+    let orphan_toml =
+      Hashtbl.fold (fun name () acc ->
+        if not (Hashtbl.mem registered name) then name :: acc else acc
+      ) configured []
+      |> List.sort String.compare
+    in
+    let uncovered =
+      Hashtbl.fold (fun name () acc ->
+        if not (Hashtbl.mem configured name) then name :: acc else acc
+      ) registered []
+      |> List.sort String.compare
+    in
+    { orphan_toml; uncovered }
+
+let log_validation_result (r : validation_result) =
+  if r.orphan_toml <> [] then
+    Log.Server.warn "TOML->Tool_spec orphans (%d): %s"
+      (List.length r.orphan_toml)
+      (String.concat ", " (List.filteri (fun i _ -> i < 10) r.orphan_toml));
+  if r.uncovered <> [] then
+    Log.Server.warn "Tool_spec->TOML uncovered (%d): %s"
+      (List.length r.uncovered)
+      (String.concat ", " (List.filteri (fun i _ -> i < 10) r.uncovered))

--- a/lib/tool_registration_check.mli
+++ b/lib/tool_registration_check.mli
@@ -1,0 +1,15 @@
+(** Tool_registration_check — Startup validation of Tool_spec vs TOML coverage. *)
+
+type validation_result = {
+  orphan_toml : string list;
+  (** In TOML groups but no Tool_spec registration *)
+  uncovered : string list;
+  (** Registered in Tool_spec but not in any TOML group *)
+}
+
+val validate : unit -> validation_result
+(** Cross-validate registered Tool_spec names against tool_policy.toml groups.
+    Returns orphan/uncovered tool names. Safe to call when policy not loaded. *)
+
+val log_validation_result : validation_result -> unit
+(** Log warnings for any mismatches. *)


### PR DESCRIPTION
## Summary

- 서버 시작 시 Tool_spec 등록과 tool_policy.toml 간 drift를 자동 감지
- `orphan_toml`: TOML group에 있지만 Tool_spec 미등록 tool
- `uncovered`: Tool_spec 등록됐지만 어느 TOML group에도 없는 tool
- #6073 (handler_binding variant) 후속 — 등록 경로 1개 + TOML 교차 검증으로 완결

## Files

- `lib/tool_registration_check.ml/mli` — validate() + log_validation_result()
- `lib/keeper/keeper_tool_policy.ml` — policy_config_for_validation accessor
- `lib/server/server_runtime_bootstrap.ml` — 시작 시 검증 와이어링

## Test plan

- [ ] CI Build and Test 통과
- [ ] 서버 시작 시 orphan/uncovered WARN 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)