### PR TITLE
fix(discord): isolate keeper sessions per room

### DIFF
--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -48,6 +48,8 @@ type gate_error = Gate_protocol.gate_error =
 type dispatch_fn =
   channel:string ->
   channel_user_id:string ->
+  channel_user_name:string ->
+  channel_room_id:string ->
   keeper_name:string ->
   content:string ->
   Gate_protocol.dispatch_result
@@ -158,6 +160,8 @@ let handle_inbound ~dispatch (msg : inbound_message) =
         dispatch
           ~channel
           ~channel_user_id:msg.channel_user_id
+          ~channel_user_name:msg.channel_user_name
+          ~channel_room_id:msg.channel_room_id
           ~keeper_name:keeper
           ~content:(String.trim msg.content)
       in

--- a/lib/channel_gate.mli
+++ b/lib/channel_gate.mli
@@ -84,6 +84,8 @@ val gate_error_to_string : gate_error -> string
 type dispatch_fn =
   channel:string ->
   channel_user_id:string ->
+  channel_user_name:string ->
+  channel_room_id:string ->
   keeper_name:string ->
   content:string ->
   Gate_protocol.dispatch_result

--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -44,13 +44,58 @@ let extract_structured (body : string) : Yojson.Safe.t option =
 
 (* ── Dispatch ────────────────────────────────────────────────── *)
 
+let normalized_context_value value =
+  value
+  |> String.to_seq
+  |> Seq.map (function
+       | '\n' | '\r' | '\t' -> ' '
+       | ch -> ch)
+  |> String.of_seq
+  |> String.trim
+
+let normalized_or_unknown value =
+  match normalized_context_value value with
+  | "" -> "unknown"
+  | trimmed -> trimmed
+
+let agent_name_for_channel_actor ~channel ~channel_room_id ~channel_user_id =
+  Printf.sprintf "gate:%s:%s:%s"
+    (normalized_or_unknown channel)
+    (normalized_or_unknown channel_room_id)
+    (normalized_or_unknown channel_user_id)
+
+let contextualize_message ~channel ~channel_user_id ~channel_user_name
+    ~channel_room_id ~content =
+  let safe_channel = normalized_or_unknown channel in
+  let safe_user_id = normalized_or_unknown channel_user_id in
+  let safe_user_name = normalized_or_unknown channel_user_name in
+  let safe_room_id = normalized_or_unknown channel_room_id in
+  let safe_content = String.trim content in
+  String.concat "\n"
+    [
+      "[External channel context]";
+      "channel: " ^ safe_channel;
+      "room_id: " ^ safe_room_id;
+      "user_id: " ^ safe_user_id;
+      "user_name: " ^ safe_user_name;
+      "";
+      "[User message]";
+      safe_content;
+    ]
+
 let dispatch ~sw ~clock ~proc_mgr ~net ~config
-    ~channel ~channel_user_id ~keeper_name ~content =
-  let agent_name = Printf.sprintf "gate:%s:%s" channel channel_user_id in
+    ~channel ~channel_user_id ~channel_user_name ~channel_room_id
+    ~keeper_name ~content =
+  let agent_name =
+    agent_name_for_channel_actor ~channel ~channel_room_id ~channel_user_id
+  in
   let args =
     `Assoc [
       ("name", `String (String.trim keeper_name));
-      ("message", `String (String.trim content));
+      ( "message",
+        `String
+          (contextualize_message ~channel ~channel_user_id ~channel_user_name
+             ~channel_room_id ~content) );
       ("direct_reply", `Bool true);
     ]
   in

--- a/lib/gate_keeper_backend.mli
+++ b/lib/gate_keeper_backend.mli
@@ -18,9 +18,31 @@ val dispatch :
   config:Room.config ->
   channel:string ->
   channel_user_id:string ->
+  channel_user_name:string ->
+  channel_room_id:string ->
   keeper_name:string ->
   content:string ->
   Gate_protocol.dispatch_result
 (** Build a keeper context, call [Tool_keeper.dispatch], and parse
     the response.  The [channel] and [channel_user_id] are used to
-    construct the agent name ([gate:<channel>:<user_id>]). *)
+    construct the agent name ([gate:<channel>:<room_id>:<user_id>]).  The other
+    connector fields are injected into the keeper-visible message body so
+    external user identity survives memory and handoff boundaries. *)
+
+val agent_name_for_channel_actor :
+  channel:string ->
+  channel_room_id:string ->
+  channel_user_id:string ->
+  string
+(** Deterministic keeper session key for one external actor inside one
+    external room/thread. *)
+
+val contextualize_message :
+  channel:string ->
+  channel_user_id:string ->
+  channel_user_name:string ->
+  channel_room_id:string ->
+  content:string ->
+  string
+(** Render a stable external-channel context envelope ahead of the raw
+    user message so keeper memory can retain actor/channel metadata. *)

--- a/lib/server/server_routes_http_keeper_stream.ml
+++ b/lib/server/server_routes_http_keeper_stream.ml
@@ -7,6 +7,10 @@ type keeper_chat_stream_request = {
   name : string;
   message : string;
   timeout_sec : int option;
+  channel : string;
+  channel_user_id : string;
+  channel_user_name : string;
+  channel_room_id : string;
 }
 
 let keeper_chat_stream_error_json message =
@@ -113,6 +117,29 @@ let parse_keeper_chat_stream_request body_str =
         json |> member "message" |> to_string_option |> Option.value ~default:""
         |> String.trim
       in
+      let channel =
+        json |> member "channel" |> to_string_option |> Option.value ~default:""
+        |> String.trim
+      in
+      let channel_user_id =
+        json |> member "channel_user_id" |> to_string_option
+        |> Option.value ~default:""
+        |> String.trim
+      in
+      let channel_user_name =
+        json |> member "channel_user_name" |> to_string_option
+        |> Option.value ~default:""
+        |> String.trim
+      in
+      let channel_room_id =
+        json |> member "channel_room_id" |> to_string_option
+        |> Option.value ~default:""
+        |> String.trim
+      in
+      let has_connector_context =
+        channel <> "" || channel_user_id <> ""
+        || channel_user_name <> "" || channel_room_id <> ""
+      in
       let legacy_models_present =
         match json |> member "models" with
         | `Null -> false
@@ -131,12 +158,27 @@ let parse_keeper_chat_stream_request body_str =
         Error "name is required"
       else if message = "" then
         Error "message is required"
+      else if has_connector_context
+              && (channel = "" || channel_user_id = "" || channel_room_id = "")
+      then
+        Error
+          "channel, channel_user_id, and channel_room_id are required when connector context is supplied"
       else if legacy_models_present then
         Error
           "legacy keeper model args removed for masc_keeper_msg: models. Keepers now use cascade_name and last_model_used only."
       else
         match timeout_sec with
-        | Ok timeout_sec -> Ok { name; message; timeout_sec }
+        | Ok timeout_sec ->
+            Ok
+              {
+                name;
+                message;
+                timeout_sec;
+                channel;
+                channel_user_id;
+                channel_user_name;
+                channel_room_id;
+              }
         | Error err -> Error err
   with Yojson.Json_error e ->
     Error ("invalid json: " ^ e)
@@ -386,16 +428,36 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                  make_event ~thread_id ~run_id:(Some run_id)
                    ~message_id:(Some message_id)
                    ~role:(Some Assistant) Text_message_start));
+          let has_connector_context =
+            payload.channel <> "" && payload.channel_user_id <> ""
+          in
+          let message =
+            if has_connector_context then
+              Gate_keeper_backend.contextualize_message
+                ~channel:payload.channel
+                ~channel_user_id:payload.channel_user_id
+                ~channel_user_name:payload.channel_user_name
+                ~channel_room_id:payload.channel_room_id
+                ~content:payload.message
+            else
+              payload.message
+          in
           let args =
             `Assoc
               [ ("name", `String payload.name);
-                ("message", `String payload.message);
+                ("message", `String message);
                 ("direct_reply", `Bool true) ]
           in
           let agent_name =
-            match agent_from_request request with
-            | Some raw when String.trim raw <> "" -> String.trim raw
-            | _ -> "unknown"
+            if has_connector_context then
+              Gate_keeper_backend.agent_name_for_channel_actor
+                ~channel:payload.channel
+                ~channel_room_id:payload.channel_room_id
+                ~channel_user_id:payload.channel_user_id
+            else
+              match agent_from_request request with
+              | Some raw when String.trim raw <> "" -> String.trim raw
+              | _ -> "unknown"
           in
           (* Track whether any text deltas were streamed to the client.
              When streaming is active, the MODEL text is sent token-by-token

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -289,6 +289,10 @@ class GateBot(discord.Client):
         channel: discord.abc.Messageable,
         keeper_name: str,
         content: str,
+        *,
+        channel_user_id: str,
+        channel_user_name: str,
+        channel_room_id: str,
     ) -> bool:
         """Stream a keeper response with progressive Discord message edits.
 
@@ -303,6 +307,9 @@ class GateBot(discord.Client):
         async for delta in self.gate.stream_message(
             keeper_name=keeper_name,
             content=content,
+            channel_user_id=channel_user_id,
+            channel_user_name=channel_user_name,
+            channel_room_id=channel_room_id,
         ):
             accumulated += delta
 
@@ -387,7 +394,12 @@ class GateBot(discord.Client):
         # Try streaming first, fall back to batch
         async with message.channel.typing():
             streamed = await self._stream_to_channel(
-                message.channel, keeper_name, content,
+                message.channel,
+                keeper_name,
+                content,
+                channel_user_id=str(message.author.id),
+                channel_user_name=str(message.author),
+                channel_room_id=str(message.channel.id),
             )
             if streamed:
                 return
@@ -562,6 +574,9 @@ async def keeper_ask(
     async for delta in bot.gate.stream_message(
         keeper_name=keeper,
         content=message.strip(),
+        channel_user_id=str(interaction.user.id),
+        channel_user_name=str(interaction.user),
+        channel_room_id=str(interaction.channel_id or "unknown"),
     ):
         accumulated += delta
         now = time.monotonic()

--- a/sidecars/discord-bot/src/gate_client.py
+++ b/sidecars/discord-bot/src/gate_client.py
@@ -179,6 +179,20 @@ class GateClient:
     def _cache_fresh(self, cache: tuple[float, Any] | None, ttl: int) -> bool:
         return cache is not None and (self._now() - cache[0]) < ttl
 
+    def _discord_context(
+        self,
+        *,
+        channel_user_id: str,
+        channel_user_name: str,
+        channel_room_id: str,
+    ) -> dict[str, str]:
+        return {
+            "channel": "discord",
+            "channel_user_id": channel_user_id,
+            "channel_user_name": channel_user_name,
+            "channel_room_id": channel_room_id,
+        }
+
     def _get_client(self) -> httpx.AsyncClient:
         """Return the shared client, lazily creating it on first use."""
         if self._client is None or self._client.is_closed:
@@ -255,10 +269,11 @@ class GateClient:
             return GateResponse.from_error(self._breaker_error())
 
         payload = {
-            "channel": "discord",
-            "channel_user_id": channel_user_id,
-            "channel_user_name": channel_user_name,
-            "channel_room_id": channel_room_id,
+            **self._discord_context(
+                channel_user_id=channel_user_id,
+                channel_user_name=channel_user_name,
+                channel_room_id=channel_room_id,
+            ),
             "keeper_name": keeper_name,
             "content": content,
             "idempotency_key": f"discord-msg-{message_id}",
@@ -367,6 +382,9 @@ class GateClient:
         *,
         keeper_name: str,
         content: str,
+        channel_user_id: str,
+        channel_user_name: str,
+        channel_room_id: str,
     ) -> AsyncIterator[str]:
         """Stream a message to a keeper via SSE, yielding text deltas.
 
@@ -377,7 +395,15 @@ class GateClient:
         if self._breaker_is_open():
             return
 
-        payload = {"name": keeper_name, "message": content}
+        payload = {
+            "name": keeper_name,
+            "message": content,
+            **self._discord_context(
+                channel_user_id=channel_user_id,
+                channel_user_name=channel_user_name,
+                channel_room_id=channel_room_id,
+            ),
+        }
         client = self._get_client()
 
         try:
@@ -403,18 +429,20 @@ class GateClient:
                         continue
                     if not isinstance(event, dict):
                         continue
-                    event_type = event.get("type", "")
+                    event_data = cast(dict[str, Any], event)
+                    event_type = str(event_data.get("type", ""))
                     if event_type == "TEXT_MESSAGE_CONTENT":
-                        delta = event.get("delta", "")
+                        delta = str(event_data.get("delta", ""))
                         if delta:
                             yield delta
                     elif event_type == "RUN_ERROR":
-                        custom = event.get("customValue", {})
-                        err = custom.get("message", "") if isinstance(custom, dict) else ""
+                        custom_raw = event_data.get("customValue", {})
+                        custom = cast(dict[str, Any], custom_raw) if isinstance(custom_raw, dict) else {}
+                        err = str(custom.get("message", ""))
                         logger.warning("Keeper stream error: %s", err)
                         return
         except httpx.TimeoutException:
-            self._note_transport_failure(f"stream timeout after 300s")
+            self._note_transport_failure("stream timeout after 300s")
         except httpx.HTTPError as e:
             self._note_transport_failure(f"stream http error: {e}")
         except Exception as e:  # pragma: no cover

--- a/sidecars/discord-bot/tests/test_masc_client.py
+++ b/sidecars/discord-bot/tests/test_masc_client.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from collections.abc import Iterator
 
 import httpx
-import logging
 import pytest
 
 from src import config as config_module
@@ -116,6 +117,44 @@ async def test_send_message_does_not_retry_non_replay_safe_post() -> None:
     assert response.ok is False
     assert response.error == "gate returned 503"
     assert attempts == 1
+
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_message_sends_discord_context_payload() -> None:
+    seen_payload: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal seen_payload
+        seen_payload = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=b'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"pong"}\n\n',
+        )
+
+    client = make_client(httpx.MockTransport(handler))
+    deltas = [
+        delta
+        async for delta in client.stream_message(
+            keeper_name="luna",
+            content="hello",
+            channel_user_id="u1",
+            channel_user_name="alice",
+            channel_room_id="room-7",
+        )
+    ]
+
+    assert deltas == ["pong"]
+    assert seen_payload == {
+        "name": "luna",
+        "message": "hello",
+        "channel": "discord",
+        "channel_user_id": "u1",
+        "channel_user_name": "alice",
+        "channel_room_id": "room-7",
+    }
 
     await client.aclose()
 

--- a/test/dune
+++ b/test/dune
@@ -41,6 +41,7 @@
         test_dashboard
         test_dashboard_perf
         test_dashboard_tool_host_events
+        test_gate_keeper_backend
         test_transport_read_model
         test_multi_room test_worktree_detection test_bounded test_mention
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
@@ -110,6 +111,7 @@
           test_dashboard
           test_dashboard_perf
           test_dashboard_tool_host_events
+          test_gate_keeper_backend
           test_transport_read_model
           test_multi_room test_worktree_detection test_bounded test_mention
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health

--- a/test/test_channel_gate.ml
+++ b/test/test_channel_gate.ml
@@ -140,17 +140,20 @@ let test_inbound_of_json_normalizes_channel_label () =
 
 (* ── Mock dispatch for handle_inbound tests ──────────────────── *)
 
-let mock_dispatch_ok ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
+let mock_dispatch_ok ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+    ~channel_room_id:_ ~keeper_name:_ ~content:_ =
   Gate_protocol.Reply {
     content = "mock reply";
     structured = None;
     stats = Some { Gate_protocol.model_used = "test-model"; duration_ms = 42; tokens_used = 10 };
   }
 
-let mock_dispatch_error ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
+let mock_dispatch_error ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+    ~channel_room_id:_ ~keeper_name:_ ~content:_ =
   Gate_protocol.Keeper_error_result "mock keeper error"
 
-let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~keeper_name:_ ~content:_ =
+let mock_dispatch_unavailable ~channel:_ ~channel_user_id:_ ~channel_user_name:_
+    ~channel_room_id:_ ~keeper_name:_ ~content:_ =
   Gate_protocol.Unavailable_result
 
 let test_handle_inbound_success () =
@@ -190,6 +193,37 @@ let test_handle_inbound_validation_blocks_dispatch () =
   | Error _ -> fail "expected Validation(Empty_content)"
   | Ok _ -> fail "expected validation to block dispatch"
 
+let test_handle_inbound_passes_channel_context_to_dispatch () =
+  reset_dedup ();
+  let seen = ref None in
+  let dispatch ~channel ~channel_user_id ~channel_user_name ~channel_room_id
+      ~keeper_name:_ ~content:_ =
+    seen :=
+      Some (channel, channel_user_id, channel_user_name, channel_room_id);
+    Gate_protocol.Reply {
+      content = "ok";
+      structured = None;
+      stats = None;
+    }
+  in
+  let msg =
+    {
+      (make_message ~idempotency_key:(unique_key "dispatch-context") ()) with
+      channel_user_name = "Alice";
+      channel_room_id = "thread-7";
+    }
+  in
+  match Channel_gate.handle_inbound ~dispatch msg with
+  | Ok _ -> (
+      match !seen with
+      | Some (channel, user_id, user_name, room_id) ->
+          check string "channel" "discord" channel;
+          check string "user id" "user-1" user_id;
+          check string "user name" "Alice" user_name;
+          check string "room id" "thread-7" room_id
+      | None -> fail "dispatch should receive connector context" )
+  | Error e -> fail (Channel_gate.gate_error_to_string e)
+
 let () =
   Alcotest.run "Channel_gate"
     [
@@ -218,6 +252,8 @@ let () =
         [
           test_case "dispatches and returns reply" `Quick
             test_handle_inbound_success;
+          test_case "passes channel context to dispatch" `Quick
+            test_handle_inbound_passes_channel_context_to_dispatch;
           test_case "returns keeper error" `Quick
             test_handle_inbound_keeper_error;
           test_case "returns unavailable" `Quick

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -1,0 +1,106 @@
+open Alcotest
+open Masc_mcp
+
+let test_agent_name_for_channel_actor () =
+  let agent_name =
+    Gate_keeper_backend.agent_name_for_channel_actor
+      ~channel:"  discord  " ~channel_room_id:" thread-9 "
+      ~channel_user_id:" user-42 "
+  in
+  check string "stable external actor session key"
+    "gate:discord:thread-9:user-42" agent_name
+
+let test_agent_name_for_channel_actor_separates_rooms () =
+  let left =
+    Gate_keeper_backend.agent_name_for_channel_actor
+      ~channel:"discord" ~channel_room_id:"room-a" ~channel_user_id:"user-42"
+  in
+  let right =
+    Gate_keeper_backend.agent_name_for_channel_actor
+      ~channel:"discord" ~channel_room_id:"room-b" ~channel_user_id:"user-42"
+  in
+  check bool "different external rooms should not share keeper session"
+    true (left <> right)
+
+let test_contextualize_message_includes_external_metadata () =
+  let rendered =
+    Gate_keeper_backend.contextualize_message
+      ~channel:"discord"
+      ~channel_user_id:"user-42"
+      ~channel_user_name:"Alice"
+      ~channel_room_id:"room-9"
+      ~content:"hello keeper"
+  in
+  check string "message envelope"
+    {|[External channel context]
+channel: discord
+room_id: room-9
+user_id: user-42
+user_name: Alice
+
+[User message]
+hello keeper|}
+    rendered
+
+let test_contextualize_message_sanitizes_context_lines () =
+  let rendered =
+    Gate_keeper_backend.contextualize_message
+      ~channel:"discord\nbot"
+      ~channel_user_id:"user-42"
+      ~channel_user_name:"Alice\tOps"
+      ~channel_room_id:"room-9\rthread"
+      ~content:"hello keeper"
+  in
+  check string "sanitized context"
+    {|[External channel context]
+channel: discord bot
+room_id: room-9 thread
+user_id: user-42
+user_name: Alice Ops
+
+[User message]
+hello keeper|}
+    rendered
+
+let test_parse_keeper_chat_stream_request_accepts_connector_context () =
+  let body =
+    {|{"name":"luna","message":"hello","channel":"discord","channel_user_id":"user-42","channel_user_name":"Alice","channel_room_id":"room-9"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok payload ->
+      check string "channel" "discord" payload.channel;
+      check string "user id" "user-42" payload.channel_user_id;
+      check string "user name" "Alice" payload.channel_user_name;
+      check string "room id" "room-9" payload.channel_room_id
+  | Error err -> fail ("expected connector context to parse: " ^ err)
+
+let test_parse_keeper_chat_stream_request_rejects_partial_connector_context () =
+  let body =
+    {|{"name":"luna","message":"hello","channel":"discord"}|}
+  in
+  match Server_routes_http_keeper_stream.parse_keeper_chat_stream_request body with
+  | Ok _ -> fail "expected partial connector context to be rejected"
+  | Error err ->
+      check string "validation message"
+        "channel, channel_user_id, and channel_room_id are required when connector context is supplied"
+        err
+
+let () =
+  Alcotest.run "Gate_keeper_backend"
+    [
+      ( "helpers",
+        [
+          test_case "agent name is stable" `Quick
+            test_agent_name_for_channel_actor;
+          test_case "agent name separates rooms" `Quick
+            test_agent_name_for_channel_actor_separates_rooms;
+          test_case "contextualized message keeps external metadata" `Quick
+            test_contextualize_message_includes_external_metadata;
+          test_case "context envelope sanitizes metadata lines" `Quick
+            test_contextualize_message_sanitizes_context_lines;
+          test_case "stream request accepts connector context" `Quick
+            test_parse_keeper_chat_stream_request_accepts_connector_context;
+          test_case "stream request rejects partial connector context" `Quick
+            test_parse_keeper_chat_stream_request_rejects_partial_connector_context;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- pass Discord channel user and room context through both batch and streaming keeper paths
- scope external keeper sessions by `channel + room_id + user_id` so the same Discord user does not share memory across channels or threads
- add regression coverage for gate dispatch context, stream request parsing, room-aware session keys, and Discord stream payloads

## Verification
- `uv run --with pyright pyright --outputjson src/gate_client.py src/bot.py tests/test_masc_client.py`
- `ruff check sidecars/discord-bot/src/gate_client.py sidecars/discord-bot/src/bot.py sidecars/discord-bot/tests/test_masc_client.py`
- `uv run --extra dev pytest tests/test_masc_client.py -q`
- `dune build --root . --build-dir _build-codex test/test_channel_gate.exe test/test_gate_keeper_backend.exe`
- `./_build-codex/default/test/test_channel_gate.exe`
- `./_build-codex/default/test/test_gate_keeper_backend.exe`

## Notes
- this intentionally makes keeper memory room-scoped for Discord, including threads
- external context lines are sanitized before entering keeper-visible prompt text