### PR TITLE
refactor: rename keeper_shell_readonly to keeper_shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 - OAS pin drift doctor — local switch validation in Makefile build/test targets (#5958)
 - Spawn stderr capture + cloexec pipes — child process observability and hang prevention (#5960)
 - Approval audit log — persistent JSONL records for pending/resolved/expired events (#5969)
-- Git clone sandboxing in keeper_shell_readonly (#5930)
+- Git clone sandboxing in keeper_shell (#5930)
 
 ### Fixed
 - Ollama thinking mode disabled for keepers — unblocked all keeper timeouts (#5948)

--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -45,7 +45,7 @@ proactive_enabled = true
 execution_scope = "workspace"
 
 tool_preset = "social"
-also_allow = ["keeper_github", "keeper_fs_read", "keeper_shell_readonly"]
+also_allow = ["keeper_github", "keeper_fs_read", "keeper_shell"]
 
 # Local LLM only — uses "local_only" cascade (ollama:auto)
 cascade_name = "local_only"

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -50,7 +50,7 @@ tool_also_allow = [
   "keeper_board_delete",
   "keeper_board_cleanup",
   "keeper_tasks_audit",
-  "keeper_shell_readonly",
+  "keeper_shell",
   "masc_cleanup_zombies",
 ]
 

--- a/config/personas/coder/AGENT.md
+++ b/config/personas/coder/AGENT.md
@@ -23,7 +23,7 @@ This creates `.worktrees/fix/<short-description>/` — all subsequent work happe
 masc_code_read path=<file>           (read specific file)
 masc_code_symbols path=<file>        (list functions/types)
 keeper_fs_read path=<file>           (alternative reader)
-keeper_shell_readonly op=rg args=["pattern", "lib/"]  (search codebase)
+keeper_shell op=rg args=["pattern", "lib/"]  (search codebase)
 ```
 
 ### Step 4: Edit code

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -7,12 +7,12 @@ What you can do with your tools:
 
 File operations:
 - Read a specific file: keeper_fs_read (preferred for single files)
-- Search file contents: keeper_shell_readonly with op=rg, pattern=<regex>, path=<dir> (optional: type=ml, glob="*.ts")
-- Find files by name: keeper_shell_readonly with op=find, name=<glob>, path=<dir>
-- List directory contents: keeper_shell_readonly with op=ls, path=<dir>
-- View file (raw): keeper_shell_readonly with op=cat, path=<file>
-- Git history: keeper_shell_readonly with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
-- Git status: keeper_shell_readonly with op=git_status
+- Search file contents: keeper_shell with op=rg, pattern=<regex>, path=<dir> (optional: type=ml, glob="*.ts")
+- Find files by name: keeper_shell with op=find, name=<glob>, path=<dir>
+- List directory contents: keeper_shell with op=ls, path=<dir>
+- View file (raw): keeper_shell with op=cat, path=<file>
+- Git history: keeper_shell with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
+- Git status: keeper_shell with op=git_status
 - Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Full preset)
 - Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable path: .masc/playground/YOUR_KEEPER_NAME/ (use keeper_context_status to confirm your name).
 - Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title (optional: base_branch, default "main"). Handles worktree, commit, and draft PR for a single file.

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -25,7 +25,7 @@ What you can do:
 - **Tasks**: claim tasks from the backlog (`keeper_task_claim`), work on them, mark done.
 - **GitHub**: if `keeper_github` is available, you can create branches, PRs, and even improve the codebase — including yourself.
 - **Library**: search and read shared knowledge (`keeper_library_search`, `keeper_library_read`).
-- **Shell**: read files and run queries (`keeper_fs_read`, `keeper_shell_readonly`).
+- **Shell**: read files and run queries (`keeper_fs_read`, `keeper_shell`).
 - **Memory**: your checkpoint and decision records persist. Use `keeper_memory_search` to recall past context.
 
 When you do not know what tools you have, call `keeper_tool_search` with a keyword before giving up.
@@ -38,7 +38,7 @@ When you see actionable context (mentions, board activity, tasks, worktree chang
 Decide what to do based on the current world state below.
 
 ### Tool-first principle
-- Read before concluding: if available, use `keeper_fs_read`, `keeper_shell_readonly`, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active under the current tool policy.
+- Read before concluding: if available, use `keeper_fs_read`, `keeper_shell`, or `keeper_library_search` to gather facts before stating opinions. Consult the Keeper Tools section to confirm which tools are active under the current tool policy.
 - Act before reporting: if available, call `keeper_task_claim`, `keeper_board_comment`, or `keeper_board_post` instead of just describing what you would do.
 - A turn with zero tool calls is acceptable only when `SPEECH_ACT: stay_silent`.
 
@@ -58,9 +58,9 @@ Use extend_turns only when a single coherent action genuinely requires more step
 - Run shell commands to investigate (`keeper_bash cmd="git log --oneline -10"`, `keeper_bash cmd="rg pattern lib/"`, if available)
 - Search the web (`masc_web_search`, if available) for tech context or documentation
 - Recall past context (`keeper_memory_search`, if available) before repeating past work
-- Search code patterns (`keeper_shell_readonly op=rg pattern=<regex> type=ml`, if available)
+- Search code patterns (`keeper_shell op=rg pattern=<regex> type=ml`, if available)
 - Audit failed tasks (`keeper_tasks_audit`, if available) before deciding there is nothing to do
-- Inspect worktree changes (`keeper_fs_read`, `keeper_shell_readonly`, `masc_code_read`, if available) and git history (`keeper_shell_readonly op=git_log count=10`)
+- Inspect worktree changes (`keeper_fs_read`, `keeper_shell`, `masc_code_read`, if available) and git history (`keeper_shell op=git_log count=10`)
 - Heartbeat is server-managed. You do not need to call any heartbeat tool.
 - If blocked, set `SPEECH_ACT: request_help`
 - If nothing meaningful to do, set `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`

--- a/config/tool_policy.toml
+++ b/config/tool_policy.toml
@@ -37,7 +37,7 @@ tools = ["keeper_tasks_list", "keeper_tasks_audit", "keeper_task_claim", "keeper
 # keeper_bash: full bash with 3-layer deterministic guard
 #   (validate_command → destructive_guard → write_gate).
 #   Non-coding presets get read-only mode (write_enabled=false).
-tools = ["keeper_shell_readonly", "keeper_bash"]
+tools = ["keeper_shell", "keeper_bash"]
 
 [groups.filesystem]
 tools = ["keeper_fs_read"]

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -16,7 +16,7 @@ such as preset selection, shard assignment, and tool access, not through a
 | **base** | `keeper_time_now`, `keeper_context_status`, `keeper_memory_search` | 3 | No |
 | **board** | `keeper_board_{get,post,list,comment,vote}` | 5 | Yes |
 | **filesystem** | `keeper_fs_read` | 1 | Yes |
-| **shell** | `keeper_shell_readonly` | 1 | Yes |
+| **shell** | `keeper_shell` | 1 | Yes |
 | **library** | `keeper_library_{search,read}` | 2 | Yes |
 | **taskboard** | `keeper_tasks_{list,audit}`, `keeper_task_{force_release,force_done,claim,done}`, `keeper_broadcast` | 7 | Yes |
 | **governance** | `masc_{cases,case_status,ruling_status,governance_status,governance_feed,case_brief_submit,petition_submit}` | 7 | Yes |

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -66,7 +66,7 @@ let capability_classification : (string * capability_class list) list = [
   ("masc_web_fetch",           [External_input]);
   (* Shell can curl/wget external data AND read secrets AND execute *)
   ("keeper_bash",              [External_input; Sensitive_access; State_modification]);
-  ("keeper_shell_readonly",    [External_input; Sensitive_access]);
+  ("keeper_shell",    [External_input; Sensitive_access]);
   (* Sensitive data access *)
   ("keeper_fs_read",           [Sensitive_access]);
   ("keeper_memory_search",     [Sensitive_access]);

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -177,7 +177,7 @@ let tool_index_entry_of_tool
     else if String.starts_with ~prefix:"keeper_task" name then Some "tasks"
     else if String.starts_with ~prefix:"keeper_voice_" name then Some "voice"
     else if String.starts_with ~prefix:"keeper_fs_" name
-         || name = "keeper_shell_readonly"
+         || name = "keeper_shell"
          || name = "keeper_bash"
          || name = "keeper_write" then Some "filesystem"
     else if name = "keeper_github" then Some "vcs"
@@ -507,7 +507,7 @@ let run_turn
     ; "keeper_voice_listen", "음성 듣기 마이크 녹음 입력"
     ; "keeper_fs_read", "파일 읽기 소스코드 설정"
     ; "keeper_fs_edit", "파일 쓰기 편집 저장 수정 생성"
-    ; "keeper_shell_readonly", "명령어 조회 검색 탐색"
+    ; "keeper_shell", "명령어 조회 검색 탐색"
     ; "keeper_bash", "명령어 실행 쉘 빌드 테스트"
     ; "keeper_github", "깃허브 이슈 풀리퀘스트 PR CI"
     ; "keeper_pr_workflow", "PR 생성 워크트리 커밋 푸시 풀리퀘스트 원���"

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -132,8 +132,8 @@ let handle_keeper_bash
            (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
         then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
         else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)
-        then "Avoid shell metacharacters. Use keeper_shell_readonly with a specific op (rg, find, ls) instead."
-        else "Check the command for blocked patterns. Use keeper_shell_readonly for safe read-only ops."
+        then "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
+        else "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
       in
       Yojson.Safe.to_string
         (`Assoc
@@ -212,7 +212,7 @@ let handle_keeper_bash
                    ])))
 ;;
 
-let handle_keeper_shell_readonly
+let handle_keeper_shell
       ~(config : Room.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -1,11 +1,9 @@
-(** Keeper shell tool handlers — bash execution and read-only ops.
+(** Keeper shell tool handlers — bash execution and structured shell ops.
 
-    Handles [keeper_bash] (write-capable) and [keeper_shell_readonly]
-    (ls, cat, find, grep, head, tail, wc, tree, git-log, git-diff, git-status,
-    git-clone).
+    Handles [keeper_bash] (arbitrary commands with blocklist) and
+    [keeper_shell] (structured ops: ls, cat, find, rg, head, tail, wc, tree,
+    git-log, git-diff, git-status, git-clone, git-worktree, bash).
 
-    Write-capable bash blocks dangerous commands (rm, mv, chmod, etc.)
-    and chaining operators (&&, ||, ;) via substring blocklist.
     Both tools default to the keeper playground unless an explicit
     allowed [cwd] is provided. *)
 
@@ -15,7 +13,7 @@ val handle_keeper_bash :
   args:Yojson.Safe.t ->
   string
 
-val handle_keeper_shell_readonly :
+val handle_keeper_shell :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->
   args:Yojson.Safe.t ->

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -127,7 +127,7 @@ let execute_keeper_tool_call
     | "keeper_fs_read" -> Keeper_exec_fs.handle_keeper_fs_read ~config ~meta ~args
     | "keeper_fs_edit" -> Keeper_exec_fs.handle_keeper_fs_edit ~config ~meta ~args
     | "keeper_bash" -> Keeper_exec_shell.handle_keeper_bash ~config ~meta ~args
-    | "keeper_shell_readonly" -> Keeper_exec_shell.handle_keeper_shell_readonly ~config ~meta ~args
+    | "keeper_shell" -> Keeper_exec_shell.handle_keeper_shell ~config ~meta ~args
     | "keeper_voice_speak"
     | "keeper_voice_listen"
     | "keeper_voice_agent"

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -63,7 +63,7 @@ let core_discovery_tools =
     "keeper_board_get"; "keeper_board_post";
     "keeper_board_comment"; "keeper_board_vote"; "keeper_board_list";
     (* Shell: readonly + execution (action symmetry) *)
-    "keeper_shell_readonly"; "keeper_bash";
+    "keeper_shell"; "keeper_bash";
     (* VCS: essential for coding keepers *)
     "keeper_pr_workflow"; "keeper_pr_submit"; "keeper_github";
     "keeper_preflight_check";

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -109,7 +109,7 @@ let actionable_routes ~(allowed_tools : string list)
       add
         "- Failed tasks are actionable, but task-audit tooling is unavailable under the current tool policy.";
   if Option.is_some observation.worktree_change_summary then
-    (match available [ "keeper_fs_read"; "keeper_shell_readonly"; "masc_code_read" ] with
+    (match available [ "keeper_fs_read"; "keeper_shell"; "masc_code_read" ] with
      | [] ->
          add
            "- Live worktree delta is actionable, but file-inspection tools are unavailable under the current tool policy."

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -44,7 +44,7 @@ let keeper_internal_tools =
     "keeper_board_search";
     (* keeper_board_delete removed from default shard in #4309.
        Dispatch still accepts it for backward compat. *)
-    "keeper_shell_readonly";
+    "keeper_shell";
     "keeper_bash";
     "keeper_github";
     "keeper_pr_workflow";

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -43,7 +43,7 @@ let synonyms : (string * string list) list =
     ("keeper_fs_edit",
      [ "write file"; "create file"; "edit file"; "save file"; "new file";
        "make file"; "update file"; "overwrite"; "append to file" ]);
-    ("keeper_shell_readonly",
+    ("keeper_shell",
      [ "run command"; "shell read only"; "safe command"; "grep"; "rg search";
        "list files"; "directory listing"; "git status"; "find file" ]);
     ("keeper_bash",

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -237,7 +237,7 @@ let filesystem_tools : Types.tool_schema list = [
     description = "Read a file as text (truncated at max_bytes). \
 path is REQUIRED. \
 Good: path='lib/foo.ml'. Bad: path=''. \
-For multi-file search, use keeper_shell_readonly with op=rg.";
+For multi-file search, use keeper_shell with op=rg.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -269,7 +269,7 @@ Creates parent dirs.";
 
 let shell_tools : Types.tool_schema list = [
   {
-    name = "keeper_shell_readonly";
+    name = "keeper_shell";
     description = "Run a safe project shell command. \
 ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, bash, git_clone. \
 Defaults to the keeper playground; use cwd to target an explicit allowed directory or cloned repo. \
@@ -305,7 +305,7 @@ NO chaining (&&, ||, ;), NO pipes (|), NO redirects (> >>). \
 Violations are blocked. Good: cmd='dune build', cmd='ls -la lib/'. \
 Bad: cmd='cd x && dune build', cmd='rg foo | wc -l'. \
 Runs in the keeper playground by default; use cwd to target an explicit allowed directory. \
-For read-only ops use keeper_shell_readonly, for file edits use keeper_fs_edit.";
+For read-only ops use keeper_shell, for file edits use keeper_fs_edit.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -689,9 +689,9 @@ let shard_filesystem : shard = {
 let shard_shell : shard = {
   name = "shell";
   tools = shell_tools;
-  read_only_tools = ["keeper_shell_readonly"];
+  read_only_tools = [];
   removable = true;
-  description = "Read-only shell: pwd, ls, cat, rg, git_status";
+  description = "Shell ops: pwd, ls, cat, rg, git_status, git_clone";
 }
 
 let shard_coding : shard = {

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -97,8 +97,8 @@ let test_messaging_preset_exposes_board () =
   (* Governance tools are no longer available *)
   Alcotest.(check bool) "no masc_governance_status" false
     (List.mem "masc_governance_status" names);
-  Alcotest.(check bool) "has keeper_shell_readonly" true
-    (List.mem "keeper_shell_readonly" names);
+  Alcotest.(check bool) "has keeper_shell" true
+    (List.mem "keeper_shell" names);
   (* github moved out of messaging to reduce surface; available in coding/delivery *)
   Alcotest.(check bool) "no keeper_github in messaging" false
     (List.mem "keeper_github" names);

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -790,7 +790,7 @@ let test_shell_readonly_pwd_defaults_to_playground () =
     in
     Fs_compat.mkdir_p expected_cwd;
     let result =
-      call_tool config meta "keeper_shell_readonly"
+      call_tool config meta "keeper_shell"
         (`Assoc [ "op", `String "pwd" ])
     in
     let json = parse_json result in
@@ -870,7 +870,7 @@ let test_readonly_bash_blocks_quoted_absolute_path_outside_playground () =
     let shared_file = Filename.concat (Lazy.force repo_root) "dune-project" in
     let quoted_cmd = Printf.sprintf "cat \"%s\"" shared_file in
     let result =
-      call_tool config meta "keeper_shell_readonly"
+      call_tool config meta "keeper_shell"
         (`Assoc [ "op", `String "bash"; "command", `String quoted_cmd ])
     in
     let json = parse_json result in

--- a/test/test_keeper_retrieval_quality.ml
+++ b/test/test_keeper_retrieval_quality.ml
@@ -42,7 +42,7 @@ let build_keeper_index () =
     "keeper_board_stats", "게시판 통계 활동 참여 게시글수";
     "keeper_fs_read", "파일 읽기 소스코드 설정";
     "keeper_fs_edit", "파일 쓰기 편집 저장 수정 생성";
-    "keeper_shell_readonly", "명령어 조회 검색 탐색";
+    "keeper_shell", "명령어 조회 검색 탐색";
     "keeper_bash", "명령어 실행 쉘 빌드 테스트";
     "keeper_github", "깃허브 이슈 풀리퀘스트 PR CI";
     "keeper_memory_search", "기억 검색 대화 이전 메시지";
@@ -130,7 +130,7 @@ let build_keeper_index () =
       else if String.starts_with ~prefix:"keeper_task" name then Some "tasks"
       else if String.starts_with ~prefix:"keeper_voice_" name then Some "voice"
       else if String.starts_with ~prefix:"keeper_fs_" name
-           || name = "keeper_shell_readonly"
+           || name = "keeper_shell"
            || name = "keeper_bash"
            || name = "keeper_write" then Some "filesystem"
       else if name = "keeper_github" then Some "vcs"
@@ -209,12 +209,12 @@ let test_file_write_kr () =
 let test_file_search_en () =
   let idx = build_keeper_index () in
   ignore (assert_retrieves ~label:"file_search_en" idx
-    "search for all occurrences of keeper_fs_edit in the codebase" "keeper_shell_readonly")
+    "search for all occurrences of keeper_fs_edit in the codebase" "keeper_shell")
 
 let test_file_search_kr () =
   let idx = build_keeper_index () in
   ignore (assert_retrieves ~label:"file_search_kr" idx
-    "명령어 검색 탐색" "keeper_shell_readonly")
+    "명령어 검색 탐색" "keeper_shell")
 
 (* ================================================================ *)
 (* Scenarios: knowledge lookup                                      *)

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -196,7 +196,7 @@ let test_all_keepers_get_full_toolset () =
   check bool "has keeper_fs_read" true (List.mem "keeper_fs_read" tools);
   check bool "has keeper_board_list" true (List.mem "keeper_board_list" tools);
   check bool "has keeper_board_get" true (List.mem "keeper_board_get" tools);
-  check bool "has keeper_shell_readonly" true (List.mem "keeper_shell_readonly" tools)
+  check bool "has keeper_shell" true (List.mem "keeper_shell" tools)
 
 let test_all_keepers_have_research_tools () =
   let meta = make_meta ~preset:Keeper_types.Research  () in
@@ -218,14 +218,14 @@ let test_messaging_preset_tools () =
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has board tools" true (List.mem "keeper_board_post" tools);
   check bool "has keeper_fs_read" true (List.mem "keeper_fs_read" tools);
-  check bool "has keeper_shell_readonly" true (List.mem "keeper_shell_readonly" tools);
+  check bool "has keeper_shell" true (List.mem "keeper_shell" tools);
   (* github removed from messaging to reduce surface; available in coding/delivery *)
   check bool "no keeper_github in messaging" false (List.mem "keeper_github" tools)
 
 let test_all_keepers_have_shell_and_coding () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "keeper_shell_readonly included" true (List.mem "keeper_shell_readonly" tools);
+  check bool "keeper_shell included" true (List.mem "keeper_shell" tools);
   check bool "keeper_fs_read included" true (List.mem "keeper_fs_read" tools);
   check bool "keeper_board_get included" true (List.mem "keeper_board_get" tools)
 

--- a/test/test_keeper_telemetry_feedback.ml
+++ b/test/test_keeper_telemetry_feedback.ml
@@ -39,7 +39,7 @@ let () =
     ; silent_ratio = 0.7
     ; tool_use_turns = 2
     ; text_response_turns = 1
-    ; unique_tools_used = ["keeper_board_list"; "keeper_shell_readonly"]
+    ; unique_tools_used = ["keeper_board_list"; "keeper_shell"]
     ; tool_utilization_rate = 0.9
     ; last_visible_action_age_sec = 3600
     ; pr_workflow_attempts = 0
@@ -100,11 +100,11 @@ let () =
   let tmp_path2 = Filename.temp_file "test_decisions_window_" ".jsonl" in
   let oc2 = open_out tmp_path2 in
   Printf.fprintf oc2
-    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell_readonly"]}|}
+    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell"]}|}
     (now -. 1800.0);  (* 30min ago — inside 1h window *)
   output_char oc2 '\n';
   Printf.fprintf oc2
-    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell_readonly"]}|}
+    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell"]}|}
     (now -. 7200.0);  (* 2h ago — outside 1h window *)
   output_char oc2 '\n';
   close_out oc2;
@@ -126,7 +126,7 @@ let () =
   let tmp_path3 = Filename.temp_file "test_decisions_cache_" ".jsonl" in
   let oc3 = open_out tmp_path3 in
   Printf.fprintf oc3
-    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell_readonly"]}|}
+    {|{"timestamp_unix":%.1f,"outcome":"tool_use","tool_call_count":1,"tools_used":["keeper_shell"]}|}
     (now -. 300.0);
   output_char oc3 '\n';
   close_out oc3;

--- a/test/test_keeper_tool_exposure.ml
+++ b/test/test_keeper_tool_exposure.ml
@@ -107,8 +107,8 @@ let test_custom_unknown_tool_names_are_dropped () =
 let test_coding_preset_has_shell_readonly () =
   let meta = make_meta ~preset:Keeper_types.Coding () in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
-  check bool "has keeper_shell_readonly" true
-    (has_tool "keeper_shell_readonly" tools)
+  check bool "has keeper_shell" true
+    (has_tool "keeper_shell" tools)
 
 (* ============================================================
    5. All keepers get coding tools (mode removed)
@@ -233,7 +233,7 @@ let test_research_plus_also_allow_combined () =
   in
   let tools = Keeper_exec_tools.keeper_allowed_tool_names meta in
   check bool "has board_get via also_allow" true (has_tool "keeper_board_get" tools);
-  check bool "has shell readonly" true (has_tool "keeper_shell_readonly" tools);
+  check bool "has shell readonly" true (has_tool "keeper_shell" tools);
   check bool "has autoresearch" true (has_any_prefix "masc_autoresearch_" tools);
   check bool "has board_post via also_allow" true (has_tool "keeper_board_post" tools);
   check bool "has read" true (has_tool "keeper_fs_read" tools)

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -243,7 +243,7 @@ let keeper_arguments fixture (schema : Types.tool_schema) =
           ("content", `String "matrix write\n");
           ("mode", `String "overwrite");
         ]
-  | "keeper_shell_readonly" -> `Assoc [ ("op", `String "git_status") ]
+  | "keeper_shell" -> `Assoc [ ("op", `String "git_status") ]
   | "keeper_bash" ->
       `Assoc [ ("cmd", `String "pwd"); ("timeout_sec", `Float 5.0) ]
   | "keeper_github" ->

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -48,7 +48,7 @@ let test_tools = [
   make_tool "keeper_board_list" "List recent board posts";
   make_tool "keeper_fs_read" "Read a file from the filesystem";
   make_tool "keeper_fs_edit" "Edit a file on the filesystem";
-  make_tool "keeper_shell_readonly" "Execute a read-only shell command";
+  make_tool "keeper_shell" "Execute a read-only shell command";
   make_tool "keeper_bash" "Execute a shell command";
   make_tool "keeper_github" "Interact with GitHub API";
   make_tool "keeper_memory_search" "Search agent memory";


### PR DESCRIPTION
## Summary

- `keeper_shell_readonly` gained `git_clone` (#5930) and `bash` ops — the name was a false safety guarantee
- **Bug fix**: tool was listed in `read_only_tools`, making `has_mutating_side_effect` return false for git_clone — retry guards and side-effect observer were blind to mutations
- 26 files, 50+ references renamed
- Removed from `read_only_tools` in `shard_shell`
- Updated shard description, prompt docs, and mli to reflect actual capabilities

## Changes

| Category | Files | Notes |
|----------|-------|-------|
| Core lib | 8 | tool_shard, exec_shell, exec_tools, tool_registry, agent_run, unified_prompt, governance, tool_catalog, prefilter |
| Config | 3 | tool_policy.toml, janitor.toml, cheolsu.toml |
| Prompts/Docs | 4 | keeper.capabilities.md, keeper.unified.system.md, AGENT.md, KEEPER-CAPABILITY-MATRIX.md |
| Tests | 8 | safety_gates, tool_exposure, telemetry_feedback, masc_bridge, retrieval_quality, pr_workflow, topk_llm, tool_matrix_cases |
| Other | 1 | CHANGELOG.md |

## Test plan

- [x] `dune build` passes
- [x] test_keeper_safety_gates (52 tests)
- [x] test_keeper_tool_exposure (58 tests)
- [x] test_keeper_retrieval_quality (29 tests)
- [ ] CI Build and Test

Closes #5932

Generated with [Claude Code](https://claude.com/claude-code)