### PR TITLE
[codex] centralize keeper entrypoint alias resolution

### DIFF
--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -275,14 +275,14 @@ let handle_keeper_list ctx args : tool_result =
       (true, Yojson.Safe.to_string json)
 
 let handle_keeper_trajectory ctx args : tool_result =
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
+  let requested_name = String.trim (get_string args "name" "") in
+  if not (validate_name requested_name) then
     (false, "invalid keeper name")
   else
-    match read_meta ctx.config name with
+    match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "read error: " ^ e)
-    | Ok None -> (false, Printf.sprintf "keeper not found: %s" name)
-    | Ok (Some m) ->
+    | Ok None -> (false, Printf.sprintf "keeper not found: %s" requested_name)
+    | Ok (Some (_resolved_name, m)) ->
       let limit = get_int args "limit" 20 in
       let masc_root = Filename.concat ctx.config.base_path ".masc" in
       let entries =
@@ -297,11 +297,11 @@ let handle_keeper_trajectory ctx args : tool_result =
           List.filteri (fun i _e -> i >= drop) entries
       in
       if recent = [] then
-        (true, Printf.sprintf "Keeper %s (trace: %s) has no trajectory entries." name m.runtime.trace_id)
+        (true, Printf.sprintf "Keeper %s (trace: %s) has no trajectory entries." m.name m.runtime.trace_id)
       else
         let json_list = List.map Trajectory.entry_to_json recent in
         let json = `Assoc [
-          ("keeper", `String name);
+          ("keeper", `String m.name);
           ("trace_id", `String m.runtime.trace_id);
           ("generation", `Int m.runtime.generation);
           ("total_entries", `Int total);
@@ -311,21 +311,21 @@ let handle_keeper_trajectory ctx args : tool_result =
         (true, Yojson.Safe.to_string json)
 
 let handle_keeper_eval ctx args : tool_result =
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
+  let requested_name = String.trim (get_string args "name" "") in
+  if not (validate_name requested_name) then
     (false, "invalid keeper name")
   else
-    match read_meta ctx.config name with
+    match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "read error: " ^ e)
-    | Ok None -> (false, Printf.sprintf "keeper not found: %s" name)
-    | Ok (Some m) ->
+    | Ok None -> (false, Printf.sprintf "keeper not found: %s" requested_name)
+    | Ok (Some (_resolved_name, m)) ->
       let scenario_file = get_string_opt args "scenario_file" in
       let masc_root = Filename.concat ctx.config.base_path ".masc" in
       let entries =
         Trajectory.read_entries ~masc_root ~keeper_name:m.name ~trace_id:m.runtime.trace_id
       in
       if entries = [] then
-        (true, Printf.sprintf "Keeper %s has no trajectory data to evaluate." name)
+        (true, Printf.sprintf "Keeper %s has no trajectory data to evaluate." m.name)
       else
         let total = List.length entries in
         (* Build a lightweight eval summary from trajectory *)
@@ -359,7 +359,7 @@ let handle_keeper_eval ctx args : tool_result =
                  (List.length scenarios) sf))
         in
         let json = `Assoc [
-          ("keeper", `String name);
+          ("keeper", `String m.name);
           ("trace_id", `String m.runtime.trace_id);
           ("generation", `Int m.runtime.generation);
           ("total_turns", `Int m.runtime.usage.total_turns);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -40,11 +40,28 @@ let effective_status_name (ctx : _ context) args =
   | "" -> normalize_status_name ctx.agent_name
   | value -> value
 
+let resolve_status_target (ctx : _ context) args =
+  let requested_name = effective_status_name ctx args in
+  if not (validate_name requested_name) then
+    Error "❌ invalid keeper name"
+  else
+    match read_meta_resolved ctx.config requested_name with
+    | Error e -> Error ("❌ " ^ e)
+    | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
+    | Ok None ->
+        (match keeper_name_from_agent_name requested_name with
+         | Some stripped_name ->
+             Error
+               (Printf.sprintf
+                  "❌ keeper not found: %s (also tried %s)"
+                  requested_name stripped_name)
+         | None -> Error (Printf.sprintf "❌ keeper not found: %s" requested_name))
+
 (** Hash the status-affecting args so different parameter combos
     get separate cache entries (e.g. fast=true vs fast=false). *)
-let hash_status_args ctx args =
+let hash_status_args resolved_name args =
   let parts = [
-    effective_status_name ctx args;
+    resolved_name;
     string_of_bool (get_bool args "fast" false);
     string_of_bool (get_bool args "include_context" false);
     string_of_bool (get_bool args "include_metrics_overview" false);
@@ -57,15 +74,10 @@ let hash_status_args ctx args =
   Digest.string (String.concat "|" parts) |> Digest.to_hex
 
 let handle_keeper_status ctx args : tool_result =
-  let name = effective_status_name ctx args in
-  if not (validate_name name) then
-    (false, "❌ invalid keeper name")
-  else
-    match read_meta ctx.config name with
-    | Error e -> (false, "❌ " ^ e)
-    | Ok None -> (false, Printf.sprintf "❌ keeper not found: %s" name)
-    | Ok (Some m) ->
-      let args_hash = hash_status_args ctx args in
+  match resolve_status_target ctx args with
+  | Error err -> (false, err)
+  | Ok (name, m) ->
+      let args_hash = hash_status_args name args in
       (* Cache hit: same updated_at + same args → return cached response *)
       (match Hashtbl.find_opt _cache name with
        | Some entry

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -15,11 +15,15 @@ let handle_keeper_down ctx args : tool_result =
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
+    stop_keepalive requested_name;
+    (match keeper_name_from_agent_name requested_name with
+     | Some resolved_name when not (String.equal resolved_name requested_name) ->
+         stop_keepalive resolved_name
+     | _ -> ());
     match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "❌ " ^ e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" requested_name)
     | Ok (Some (name, m)) ->
-      stop_keepalive name;
       ignore
         (Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
            ~target_type:"keeper" ~target_id:(Some name));

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -9,17 +9,17 @@ open Keeper_keepalive
 type tool_result = Keeper_types.tool_result
 
 let handle_keeper_down ctx args : tool_result =
-  let name = get_string args "name" "" in
-  if not (validate_name name) then
+  let requested_name = String.trim (get_string args "name" "") in
+  if not (validate_name requested_name) then
     (false, "❌ invalid keeper name")
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
-    stop_keepalive name;
-    match read_meta ctx.config name with
+    match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "❌ " ^ e)
-    | Ok None -> (true, Printf.sprintf "keeper already absent: %s" name)
-    | Ok (Some m) ->
+    | Ok None -> (true, Printf.sprintf "keeper already absent: %s" requested_name)
+    | Ok (Some (name, m)) ->
+      stop_keepalive name;
       ignore
         (Operator_pending_confirm.remove_pending_confirms_by_target ctx.config
            ~target_type:"keeper" ~target_id:(Some name));

--- a/lib/keeper/keeper_turn_setup.ml
+++ b/lib/keeper/keeper_turn_setup.ml
@@ -8,7 +8,7 @@ let ensure_keeper_exists
     ~(ctx : _ context)
     ~name
   : (keeper_meta, string) result =
-  match read_meta ctx.config name with
+  match read_meta_resolved ctx.config name with
   | Error e -> Error e
-  | Ok (Some m) -> Ok m
+  | Ok (Some (_resolved_name, m)) -> Ok m
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1329,16 +1329,53 @@ let write_meta ?(force = false) config (m : keeper_meta) : (unit, string) result
     Error (Printf.sprintf "failed to write meta %s: %s" path (Printexc.to_string exn))
 ;;
 
+let keeper_name_from_agent_name agent_name =
+  let prefix = "keeper-" and suffix = "-agent" in
+  let plen = String.length prefix and slen = String.length suffix in
+  let alen = String.length agent_name in
+  if alen > plen + slen
+     && String.sub agent_name 0 plen = prefix
+     && String.sub agent_name (alen - slen) slen = suffix
+  then
+    let keeper_name = String.sub agent_name plen (alen - plen - slen) in
+    if validate_name keeper_name then Some keeper_name else None
+  else
+    None
+;;
+
+let read_meta_resolved config name : ((string * keeper_meta) option, string) result =
+  let requested_name = String.trim name in
+  let read_candidate candidate =
+    read_meta_file_path (keeper_meta_path config candidate)
+    |> Result.map (Option.map (fun meta -> (candidate, meta)))
+  in
+  if requested_name = "" then
+    Ok None
+  else
+    match read_candidate requested_name with
+    | Ok None -> (
+        match keeper_name_from_agent_name requested_name with
+        | Some alias_name when not (String.equal alias_name requested_name) ->
+            read_candidate alias_name
+        | _ -> Ok None)
+    | Ok (Some _) as ok -> ok
+    | Error _ as err -> err
+;;
+
 let read_meta config name : (keeper_meta option, string) result =
-  let path = keeper_meta_path config name in
+  let requested_name = String.trim name in
+  let path = keeper_meta_path config requested_name in
   if keeper_debug
   then
     Log.Keeper.debug
       "read_meta name=%s path=%s exists=%b"
-      name
+      requested_name
       path
       (Sys.file_exists path);
-  read_meta_file_path path
+  match read_meta_resolved config requested_name with
+  | Ok (Some (_resolved_name, meta)) -> Ok (Some meta)
+  | Ok None -> Ok None
+  | Error _ as err -> err
 ;;
 
 (** Read keeper meta only if the file's mtime has changed since [last_mtime].
@@ -1347,15 +1384,25 @@ let read_meta config name : (keeper_meta option, string) result =
     operator has modified the meta file. *)
 let read_meta_if_changed config name ~(last_mtime : float)
   : (keeper_meta * float) option =
-  let path = keeper_meta_path config name in
-  if not (Sys.file_exists path) then None
-  else
-    let stat = Unix.stat path in
-    if stat.Unix.st_mtime <= last_mtime then None
+  let requested_name = String.trim name in
+  let read_candidate candidate =
+    let path = keeper_meta_path config candidate in
+    if not (Sys.file_exists path) then None
     else
-      match read_meta_file_path path with
-      | Ok (Some meta) -> Some (meta, stat.Unix.st_mtime)
-      | _ -> None
+      let stat = Unix.stat path in
+      if stat.Unix.st_mtime <= last_mtime then None
+      else
+        match read_meta_file_path path with
+        | Ok (Some meta) -> Some (meta, stat.Unix.st_mtime)
+        | _ -> None
+  in
+  match read_candidate requested_name with
+  | Some _ as changed -> changed
+  | None -> (
+      match keeper_name_from_agent_name requested_name with
+      | Some alias_name when not (String.equal alias_name requested_name) ->
+          read_candidate alias_name
+      | _ -> None)
 ;;
 
 (* Model selection, path utilities, and JSONL helpers

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -228,6 +228,9 @@ val keepalive_keeper_names : Room.config -> string list
 val persistent_agent_names : Room.config -> string list
 val fresher_meta : Room.config -> keeper_meta -> keeper_meta
 val write_meta : ?force:bool -> Room.config -> keeper_meta -> (unit, string) result
+val keeper_name_from_agent_name : string -> string option
+val read_meta_resolved :
+  Room.config -> string -> ((string * keeper_meta) option, string) result
 val read_meta : Room.config -> string -> (keeper_meta option, string) result
 
 (** Read keeper meta only if the file's mtime changed since [last_mtime].

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -22,11 +22,16 @@ let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
   | Some (false, err) -> Error err
   | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
 
-let keeper_diagnostic_for_name (ctx : 'a context) ~(name : string) =
-  match Keeper_types.read_meta ctx.config name with
+let resolve_keeper_meta_for_name (ctx : 'a context) ~(name : string) =
+  match Keeper_types.read_meta_resolved ctx.config name with
   | Error err -> Error err
   | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
-  | Ok (Some meta) ->
+  | Ok (Some (resolved_name, meta)) -> Ok (resolved_name, meta)
+
+let keeper_diagnostic_for_name (ctx : 'a context) ~(name : string) =
+  match resolve_keeper_meta_for_name ctx ~name with
+  | Error err -> Error err
+  | Ok (_resolved_name, meta) ->
       let keepalive_running =
         Keeper_status_bridge.runtime_keepalive_running ctx.config meta
       in
@@ -384,7 +389,10 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
   | "keeper_recover" ->
       let* () = validate_target_type "keeper" request in
       let* name = require_target_id request in
-      let* before_diagnostic = keeper_diagnostic_for_name ctx ~name in
+      let* (resolved_name, _meta) =
+        resolve_keeper_meta_for_name ctx ~name
+      in
+      let* before_diagnostic = keeper_diagnostic_for_name ctx ~name:resolved_name in
       let recoverable =
         match U.member "recoverable" before_diagnostic with
         | `Bool value -> value
@@ -406,13 +414,13 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
       else
         let* down_result =
           dispatch_keeper_json ctx ~tool_name:"masc_keeper_down"
-            ~args:(`Assoc [ ("name", `String name) ])
+            ~args:(`Assoc [ ("name", `String resolved_name) ])
         in
         let* up_result =
           dispatch_keeper_json ctx ~tool_name:"masc_keeper_up"
-            ~args:(`Assoc [ ("name", `String name) ])
+            ~args:(`Assoc [ ("name", `String resolved_name) ])
         in
-        let* after_diagnostic = keeper_diagnostic_for_name ctx ~name in
+        let* after_diagnostic = keeper_diagnostic_for_name ctx ~name:resolved_name in
         let recovered, skipped_reason =
           keeper_recovery_outcome after_diagnostic
         in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -203,6 +203,12 @@ let keeper_list_row_json ~runtime_class config name =
 let invalidate_status_cache name =
   Keeper_status_detail.invalidate_status_cache_for name
 
+let with_keeper_name args name =
+  match args with
+  | `Assoc fields ->
+      `Assoc (("name", `String name) :: List.remove_assoc "name" fields)
+  | other -> other
+
 let handle_keeper_create_from_persona ctx args : tool_result =
   if not Server_startup_state.((!state).state_ready) then begin
     let elapsed = Server_startup_state.elapsed_since_start () in
@@ -258,37 +264,29 @@ let handle_keeper_status ctx args : tool_result =
      Yojson.Safe.pretty_to_string
        (annotate_keeper_json ~runtime_class:"keeper" json))
 
-let name_from_agent_name agent_name =
-  let prefix = "keeper-" and suffix = "-agent" in
-  let plen = String.length prefix and slen = String.length suffix in
-  let alen = String.length agent_name in
-  if alen > plen + slen
-     && String.sub agent_name 0 plen = prefix
-     && String.sub agent_name (alen - slen) slen = suffix
-  then Some (String.sub agent_name plen (alen - plen - slen))
-  else None
-
 let resolve_keeper_name ctx args =
-  let name = get_string args "name" "" in
-  match read_meta ctx.config name with
-  | Ok (Some _) -> Ok name
+  let name = String.trim (get_string args "name" "") in
+  match read_meta_resolved ctx.config name with
+  | Ok (Some (resolved_name, _meta)) -> Ok resolved_name
   | Ok None ->
-    (match name_from_agent_name name with
-     | Some stripped ->
-       (match read_meta ctx.config stripped with
-        | Ok (Some _) -> Ok stripped
-        | _ -> Error (Printf.sprintf "❌ keeper not found: %s (also tried %s)" name stripped))
-     | None -> Error (Printf.sprintf "❌ keeper not found: %s" name))
+      (match keeper_name_from_agent_name name with
+       | Some stripped ->
+           Error
+             (Printf.sprintf
+                "❌ keeper not found: %s (also tried %s)"
+                name stripped)
+       | None -> Error (Printf.sprintf "❌ keeper not found: %s" name))
   | Error err -> Error (Printf.sprintf "❌ %s" err)
 
 let handle_keeper_msg ctx args : tool_result =
   match resolve_keeper_name ctx args with
   | Error err -> (false, err)
   | Ok name ->
+      let resolved_args = with_keeper_name args name in
       let request_id = Keeper_msg_async.submit ~sw:ctx.sw
         ~keeper_name:name
         ~f:(fun () ->
-          let ok, body = Turn.handle_keeper_msg ctx args in
+          let ok, body = Turn.handle_keeper_msg ctx resolved_args in
           if ok then begin
             invalidate_keeper_list_cache ();
             invalidate_status_cache name
@@ -318,7 +316,8 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
   match resolve_keeper_name ctx args with
   | Error err -> (false, err)
   | Ok name ->
-      let ok, body = Turn.handle_keeper_msg ~on_text_delta ctx args in
+      let resolved_args = with_keeper_name args name in
+      let ok, body = Turn.handle_keeper_msg ~on_text_delta ctx resolved_args in
       if not ok then (ok, body)
       else begin
         invalidate_keeper_list_cache ();
@@ -332,9 +331,9 @@ let handle_keeper_msg_stream ~on_text_delta ctx args : tool_result =
       end
 
 let resolve_keeper_meta ctx args =
-  let name = get_string args "name" "" in
-  match read_meta ctx.config name with
-  | Ok (Some meta) -> Ok meta
+  let name = String.trim (get_string args "name" "") in
+  match read_meta_resolved ctx.config name with
+  | Ok (Some (_resolved_name, meta)) -> Ok meta
   | Ok None -> Error (Printf.sprintf "❌ keeper not found: %s" name)
   | Error err -> Error (Printf.sprintf "❌ %s" err)
 

--- a/test/test_keeper_agent_isolation.ml
+++ b/test/test_keeper_agent_isolation.ml
@@ -283,6 +283,16 @@ let test_keeper_agent_name_prefixed () =
     "no double prefix in agent_name" "keeper-admin-agent"
     (Keeper_types.keeper_agent_name "keeper-admin")
 
+let test_keeper_name_from_agent_name_roundtrip () =
+  Alcotest.(check (option string))
+    "agent alias resolves to keeper name" (Some "sangsu")
+    (Keeper_types.keeper_name_from_agent_name "keeper-sangsu-agent")
+
+let test_keeper_name_from_agent_name_rejects_plain_name () =
+  Alcotest.(check (option string))
+    "plain keeper name is not treated as agent alias" None
+    (Keeper_types.keeper_name_from_agent_name "sangsu")
+
 (* ============================================================
    Test runner
    ============================================================ *)
@@ -327,5 +337,9 @@ let () =
       Alcotest.test_case "sender prefixed name" `Quick test_keeper_agent_sender_prefixed_name;
       Alcotest.test_case "agent_name plain" `Quick test_keeper_agent_name_plain;
       Alcotest.test_case "agent_name prefixed" `Quick test_keeper_agent_name_prefixed;
+      Alcotest.test_case "agent alias roundtrip" `Quick
+        test_keeper_name_from_agent_name_roundtrip;
+      Alcotest.test_case "plain name is not alias" `Quick
+        test_keeper_name_from_agent_name_rejects_plain_name;
     ]);
   ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -118,6 +118,16 @@ let () =
           Alcotest.test_case "keeper status defaults name to caller" `Quick
             Test_operator_control_keeper
             .test_keeper_status_defaults_name_to_caller;
+          Alcotest.test_case "keeper status accepts agent alias" `Quick
+            Test_operator_control_keeper
+            .test_keeper_status_accepts_agent_name_alias;
+          Alcotest.test_case "keeper down accepts agent alias" `Quick
+            Test_operator_control_keeper
+            .test_keeper_down_accepts_agent_name_alias;
+          Alcotest.test_case "operator keeper probe accepts agent alias"
+            `Quick
+            Test_operator_control_keeper
+            .test_operator_keeper_probe_accepts_agent_name_alias;
           Alcotest.test_case "keeper status schema makes name optional" `Quick
             Test_operator_control_keeper
             .test_keeper_status_schema_makes_name_optional;

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -128,6 +128,10 @@ let () =
             `Quick
             Test_operator_control_keeper
             .test_operator_keeper_probe_accepts_agent_name_alias;
+          Alcotest.test_case "operator keeper recover accepts agent alias"
+            `Quick
+            Test_operator_control_keeper
+            .test_operator_keeper_recover_accepts_agent_name_alias;
           Alcotest.test_case "keeper status schema makes name optional" `Quick
             Test_operator_control_keeper
             .test_keeper_status_schema_makes_name_optional;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -371,6 +371,76 @@ let test_operator_keeper_probe_accepts_agent_name_alias () =
       Alcotest.(check bool) "probe includes diagnostic" true
         Yojson.Safe.Util.(delegated_result |> member "diagnostic" <> `Null))
 
+let test_operator_keeper_recover_accepts_agent_name_alias () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "probe-keeper" in
+  let keeper_agent_name = "keeper-probe-keeper-agent" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Probe keeper runtime");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      Keeper_keepalive.stop_keepalive keeper_name;
+      let ctx = operator_ctx env sw config "operator" in
+      let action_json =
+        match
+          Operator_control.action_json ctx
+            (`Assoc
+              [
+                ("actor", `String "operator");
+                ("action_type", `String "keeper_recover");
+                ("target_type", `String "keeper");
+                ("target_id", `String keeper_agent_name);
+              ])
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check string) "recover delegates to keeper recover"
+        "masc_keeper_recover"
+        Yojson.Safe.Util.(action_json |> member "tool_name" |> to_string);
+      let delegated_result =
+        Yojson.Safe.Util.(action_json |> member "result" |> member "result")
+      in
+      Alcotest.(check bool) "recover path marked recoverable before action" true
+        Yojson.Safe.Util.(delegated_result |> member "before" |> member "recoverable" |> to_bool);
+      Alcotest.(check string) "recover down resolves canonical keeper name"
+        keeper_name
+        Yojson.Safe.Util.(delegated_result |> member "down" |> member "name" |> to_string);
+      Alcotest.(check string) "recover up resolves canonical keeper name"
+        keeper_name
+        Yojson.Safe.Util.(delegated_result |> member "up" |> member "name" |> to_string);
+      Alcotest.(check bool) "recover reports after diagnostic" true
+        Yojson.Safe.Util.(delegated_result |> member "after" <> `Null))
+
 let test_keeper_status_schema_makes_name_optional () =
   let schema =
     List.find

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -210,6 +210,167 @@ let test_keeper_status_defaults_name_to_caller () =
       Alcotest.(check string) "status resolved caller keeper" keeper_name
         Yojson.Safe.Util.(status_json |> member "name" |> to_string))
 
+let test_keeper_status_accepts_agent_name_alias () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "probe-keeper" in
+  let keeper_agent_name = "keeper-probe-keeper-agent" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Probe keeper runtime");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_agent_name); ("fast", `Bool true) ])
+      in
+      Alcotest.(check bool) "status ok via agent alias" true ok;
+      let status_json = parse_json_exn body in
+      Alcotest.(check string) "status resolves canonical keeper name" keeper_name
+        Yojson.Safe.Util.(status_json |> member "name" |> to_string))
+
+let test_keeper_down_accepts_agent_name_alias () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "probe-keeper" in
+  let keeper_agent_name = "keeper-probe-keeper-agent" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Probe keeper runtime");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
+          ~args:(`Assoc [ ("name", `String keeper_agent_name) ])
+      in
+      Alcotest.(check bool) "keeper down ok via agent alias" true ok;
+      let down_json = parse_json_exn body in
+      Alcotest.(check string) "down resolves canonical keeper name" keeper_name
+        Yojson.Safe.Util.(down_json |> member "name" |> to_string);
+      match Masc_mcp.Keeper_types.read_meta config keeper_name with
+      | Ok (Some meta) ->
+          Alcotest.(check bool) "keeper paused after down via alias" true meta.paused
+      | Ok None -> Alcotest.fail "keeper meta missing after down"
+      | Error err -> Alcotest.fail ("meta read failed: " ^ err))
+
+let test_operator_keeper_probe_accepts_agent_name_alias () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "probe-keeper" in
+  let keeper_agent_name = "keeper-probe-keeper-agent" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Probe keeper runtime");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let ctx = operator_ctx env sw config "operator" in
+      let action_json =
+        match
+          Operator_control.action_json ctx
+            (`Assoc
+              [
+                ("actor", `String "operator");
+                ("action_type", `String "keeper_probe");
+                ("target_type", `String "keeper");
+                ("target_id", `String keeper_agent_name);
+              ])
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check string) "probe delegates to keeper status"
+        "masc_keeper_status"
+        Yojson.Safe.Util.(action_json |> member "tool_name" |> to_string);
+      let delegated_result =
+        Yojson.Safe.Util.(action_json |> member "result" |> member "result")
+      in
+      Alcotest.(check string) "probe status resolves canonical keeper name"
+        keeper_name
+        Yojson.Safe.Util.(delegated_result |> member "status" |> member "name" |> to_string);
+      Alcotest.(check bool) "probe includes diagnostic" true
+        Yojson.Safe.Util.(delegated_result |> member "diagnostic" <> `Null))
+
 let test_keeper_status_schema_makes_name_optional () =
   let schema =
     List.find


### PR DESCRIPTION
## Summary
- centralize keeper entrypoint name resolution in `Keeper_types` so operator, status, turn, and lifecycle paths share one canonical alias resolver
- accept runtime agent aliases like `keeper-foo-agent` across `masc_keeper_status`, `masc_keeper_down`, operator `keeper_probe`, and operator `keeper_recover`
- rewrite keeper message args to the canonical keeper name before deeper turn handling so downstream entrypoints stop re-parsing mismatched names
- add regression coverage for alias roundtrip plus status, down, probe, and recover entrypoints

## Product impact
- `keeper not found: keeper-...-agent` failures stop depending on which entrypoint the dashboard or operator path used
- keeper control-plane behavior now matches the runtime agent naming convention instead of requiring callers to know the persisted meta filename
- alias-based recovery no longer risks drifting between lookup names and canonical keeper names during stop/down/up flows

## Evidence
- `dune build --root . _build/default/test/test_operator_control.exe _build/default/test/test_keeper_agent_isolation.exe`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_keeper_agent_isolation.exe`

## Review evidence
- direct external review via `sb glm-text` with `GLM-5.1` on April 9, 2026 identified one behavioral regression in `keeper_down` ordering and one missing `keeper_recover` alias regression test
- review-driven follow-up landed in `83e8d9eef` to restore pre-I/O keepalive stop ordering and add the `keeper_recover` alias coverage
- second direct external review via `sb glm-text` with `GLM-5.1` on April 9, 2026 reported only non-blocking follow-up observations (redundant resolve paths and additional edge-case unit-test ideas), with no new material correctness findings

## Related
- follow-up to #6058
