### PR TITLE
refactor(keeper): simplify playground status code

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -395,6 +395,7 @@ export function KeeperDetailOverlay() {
                 ${(() => {
                   const preset = peekLoadedKeeperConfig(keeper.name)?.tools?.tool_preset
                   if (!preset) return null
+                  // SSOT: config/tool_policy.toml [git_clone.workflow_presets]
                   const canPR = ['coding', 'delivery', 'full'].includes(preset)
                   return html`
                     <span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold uppercase tracking-wide

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -661,15 +661,14 @@ let handle_keeper_status ctx args : tool_result =
                    (Room_utils.safe_filename m.name)
                    (Room_utils.safe_filename m.runtime.trace_id))));
            ]);
-           ("execution_context", `Assoc [
-             ("playground_path", `String
-               (Keeper_alerting_path.playground_path_of_keeper m.name));
+           (let playground_rel = Keeper_alerting_path.playground_path_of_keeper m.name in
+           let playground_abs = Filename.concat ctx.config.base_path playground_rel in
+           "execution_context", `Assoc [
+             ("playground_path", `String playground_rel);
              ("execution_scope", `String m.execution_scope);
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",
-               let cache_path = Filename.concat
-                 (Filename.concat ctx.config.base_path
-                   (Keeper_alerting_path.playground_path_of_keeper m.name))
+               let cache_path = Filename.concat playground_abs
                  ".playground_state.json" in
                try
                  match Yojson.Safe.from_file cache_path with
@@ -680,21 +679,12 @@ let handle_keeper_status ctx args : tool_result =
                  | _ -> `List []
                with Sys_error _ | Yojson.Json_error _ -> `List []);
              ("pr_history",
-               let pr_path = Filename.concat
-                 (Filename.concat ctx.config.base_path
-                   (Keeper_alerting_path.playground_path_of_keeper m.name))
+               let pr_path = Filename.concat playground_abs
                  ".playground_pr_history.jsonl" in
                try
                  let entries = Fs_compat.load_jsonl pr_path in
-                 (* Last 10 PRs, most recent first.
-                    Rev first, then take up to 10 — O(N) single pass. *)
-                 let rev = List.rev entries in
-                 let rec take n acc = function
-                   | [] -> List.rev acc
-                   | _ when n <= 0 -> List.rev acc
-                   | x :: rest -> take (n - 1) (x :: acc) rest
-                 in
-                 `List (take 10 [] rev)
+                 (* Last 10 PRs, most recent first *)
+                 `List (List.take 10 (List.rev entries))
                with Sys_error _ -> `List []);
              ("active_worktrees",
                let worktrees_dir = Filename.concat ctx.config.base_path ".worktrees" in


### PR DESCRIPTION
## Summary
/simplify 리뷰 결과 수정 3건:
- `List.take` stdlib 사용 (hand-rolled take 함수 제거, 코드베이스 내 10번째 복사본이었음)
- `playground_path_of_keeper` 3회 호출 → `let playground_rel/playground_abs` 바인딩으로 통합
- `canPR` 하드코딩 preset 목록에 SSOT 코멘트 (`config/tool_policy.toml` 참조)

## Follows
- #6053, #6060, #6083 (playground audit 시리즈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)