### PR TITLE
feat(keeper): cascade config API + dashboard selector + TOML hot-reload

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -835,3 +835,13 @@ export function fetchExcusePatterns(): Promise<ExcusePattern[]> {
 export function updateExcusePatterns(patterns: ExcusePattern[]): Promise<{ ok: boolean }> {
   return post<{ ok: boolean }>('/api/v1/dashboard/config/excuse-patterns', patterns)
 }
+
+// --- Keeper Cascade Config ---
+
+export function fetchCascadeProfiles(): Promise<{ profiles: string[] }> {
+  return get<{ profiles: string[] }>('/api/v1/keeper/cascades')
+}
+
+export function updateKeeperCascade(keeper: string, cascade_name: string): Promise<{ ok: boolean }> {
+  return post<{ ok: boolean }>('/api/v1/keeper/cascade', { keeper, cascade_name })
+}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -14,6 +14,7 @@ import { bootKeeper, shutdownKeeper } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { fetchCascadeProfiles, updateKeeperCascade } from '../api/dashboard'
 import { selectKeeper } from '../keeper-runtime'
 import { keeperStatusDetails } from '../keeper-state'
 import { findKeeper } from '../lib/keeper-utils'
@@ -404,6 +405,30 @@ export function KeeperDetailOverlay() {
                       }"
                       title=${`Tool preset: ${preset}${canPR ? ' (clone/PR 가능)' : ''}`}
                     >${preset}</span>
+                  `
+                })()}
+                ${(() => {
+                  const [profiles, setProfiles] = useState<string[]>([])
+                  const [currentCascade, setCurrentCascade] = useState(keeper.cascade_name || 'default')
+                  if (profiles.length === 0) {
+                    fetchCascadeProfiles().then(r => setProfiles(r.profiles)).catch(() => {})
+                  }
+                  if (profiles.length <= 1) return null
+                  return html`
+                    <select
+                      class="py-0.5 px-1 rounded text-[10px] font-mono bg-[var(--white-5)] text-[var(--text-muted)] border border-[var(--white-8)] cursor-pointer"
+                      title="Cascade profile"
+                      value=${currentCascade}
+                      onChange=${(e: Event) => {
+                        const val = (e.target as HTMLSelectElement).value
+                        setCurrentCascade(val)
+                        updateKeeperCascade(keeper.name, val).then(() => {
+                          refreshDashboard()
+                        })
+                      }}
+                    >
+                      ${profiles.map(p => html`<option value=${p}>${p}</option>`)}
+                    </select>
                   `
                 })()}
               </div>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -563,6 +563,7 @@ export interface Keeper {
   primary_model?: string
   active_model?: string
   next_model_hint?: string | null
+  cascade_name?: string
   status: string
   presence_keepalive?: boolean
   presence_keepalive_sec?: number

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -50,7 +50,13 @@ let ensure_keeper_meta config name =
       | Some dl -> dl
       | None -> meta.tool_denylist
     in
+    let target_cascade_name =
+      match defaults.cascade_name with
+      | Some name -> name
+      | None -> meta.cascade_name
+    in
     let denylist_changed = meta.tool_denylist <> target_denylist in
+    let cascade_changed = meta.cascade_name <> target_cascade_name in
     let proactive_timers_changed =
       meta.proactive.idle_sec <> target_idle_sec
       || meta.proactive.cooldown_sec <> target_cooldown_sec
@@ -58,14 +64,17 @@ let ensure_keeper_meta config name =
     if meta.proactive.enabled <> target_proactive
        || proactive_timers_changed
        || meta.room_signal_prompt_enabled <> target_room_signal_prompt_enabled
-       || denylist_changed then begin
+       || denylist_changed
+       || cascade_changed then begin
       Log.Keeper.info
-        "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b, idle_sec %d -> %d, cooldown_sec %d -> %d, room_signal_prompt_enabled %b -> %b, denylist_changed %b for %s"
+        "ensure_keeper_meta: re-syncing proactive.enabled %b -> %b, idle_sec %d -> %d, cooldown_sec %d -> %d, room_signal_prompt_enabled %b -> %b, denylist_changed %b, cascade %s -> %s for %s"
         meta.proactive.enabled target_proactive
         meta.proactive.idle_sec target_idle_sec
         meta.proactive.cooldown_sec target_cooldown_sec
         meta.room_signal_prompt_enabled target_room_signal_prompt_enabled
-        denylist_changed meta.name;
+        denylist_changed
+        meta.cascade_name target_cascade_name
+        meta.name;
       let updated = { meta with
         proactive = {
           enabled = target_proactive;
@@ -74,6 +83,7 @@ let ensure_keeper_meta config name =
         };
         room_signal_prompt_enabled = target_room_signal_prompt_enabled;
         tool_denylist = target_denylist;
+        cascade_name = target_cascade_name;
         updated_at = now_iso ();
       } in
       match write_meta config updated with

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -574,3 +574,79 @@ and add_repo_synthesis_routes router =
                  (Printf.sprintf {|{"error":"%s"}|} (String.escaped msg))
                  reqd
        ) request reqd)
+
+  (* ── Keeper cascade config API ──────────────────────────────── *)
+
+  |> Http.Router.get "/api/v1/keeper/cascades" (fun request reqd ->
+       with_public_read (fun _state _req reqd ->
+         let config_path = Oas_model_resolve.cascade_config_path () in
+         let profiles =
+           match config_path with
+           | None -> ["default"]
+           | Some path ->
+             (try
+               let json = Yojson.Safe.from_file path in
+               match json with
+               | `Assoc fields ->
+                 "default" ::
+                 (List.filter_map (fun (k, _) ->
+                   if String.length k > 7
+                      && String.sub k (String.length k - 7) 7 = "_models"
+                   then Some (String.sub k 0 (String.length k - 7))
+                   else None
+                 ) fields)
+               | _ -> ["default"]
+             with _ -> ["default"])
+         in
+         Http.Response.json ~request:request
+           (Yojson.Safe.to_string (`Assoc [
+             ("profiles", `List (List.map (fun s -> `String s) profiles));
+           ])) reqd
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/keeper/cascade" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_status" (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let json = Yojson.Safe.from_string body_str in
+             let keeper_name = Safe_ops.json_string_opt "keeper" json in
+             let cascade_name = Safe_ops.json_string_opt "cascade_name" json in
+             match keeper_name, cascade_name with
+             | None, _ | _, None ->
+               Http.Response.json ~status:`Bad_request ~request:req
+                 {|{"ok":false,"error":"requires {\"keeper\":\"...\",\"cascade_name\":\"...\"}"}|}
+                 reqd
+             | Some name, Some cascade ->
+               let config = state.Mcp_server.room_config in
+               let meta_path =
+                 Filename.concat
+                   (Filename.concat (Room.masc_root_dir config) "keepers")
+                   (name ^ ".json")
+               in
+               if not (Sys.file_exists meta_path) then
+                 Http.Response.json ~status:`Not_found ~request:req
+                   (Printf.sprintf {|{"ok":false,"error":"keeper %s not found"}|}
+                     (String.escaped name))
+                   reqd
+               else begin
+                 let meta_json = Yojson.Safe.from_file meta_path in
+                 let updated = match meta_json with
+                   | `Assoc fields ->
+                     `Assoc (("cascade_name", `String cascade) ::
+                       List.filter (fun (k,_) -> k <> "cascade_name") fields)
+                   | other -> other
+                 in
+                 let oc = open_out meta_path in
+                 Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+                   output_string oc (Yojson.Safe.pretty_to_string updated));
+                 Http.Response.json ~request:req
+                   (Printf.sprintf {|{"ok":true,"keeper":"%s","cascade_name":"%s"}|}
+                     (String.escaped name) (String.escaped cascade))
+                   reqd
+               end
+           with Yojson.Json_error _ ->
+             Http.Response.json ~status:`Bad_request ~request:req
+               {|{"ok":false,"error":"invalid JSON body"}|}
+               reqd
+         )
+       ) request reqd)


### PR DESCRIPTION
## Summary
3 changes to let operators switch keeper cascade profiles without editing files:

1. **API**: `GET /api/v1/keeper/cascades` (list profiles), `POST /api/v1/keeper/cascade` (change keeper cascade)
2. **Dashboard**: cascade dropdown in keeper detail header
3. **TOML hot-reload**: `ensure_keeper_meta` syncs `cascade_name` from TOML on autoboot

## Motivation
sangsu/cheolsu cascade_name changes via TOML were ignored because runtime JSON takes precedence.
Operator had to manually edit `.masc/keepers/<name>.json` — bad UX.

## Test plan
- [x] `dune build` with `OCAMLPARAM='_,warn-error=+a'`
- [ ] CI Build + Lint + Health
- [ ] Dashboard cascade dropdown renders and updates

Generated with [Claude Code](https://claude.com/claude-code)