### PR TITLE
[codex] Harden OAS ownership boundaries

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -46,6 +46,7 @@ OAS  ──does not know──→ MASC
 - OAS가 소유한 설정 결과를 MASC가 소비하는 것은 허용된다. 다만 MASC는 provider allowlist, cascade parsing rule, proof-store layout 같은 OAS-owned shape를 자체 meta/profile schema로 다시 소유하면 안 된다.
 - 따라서 runtime convenience label(예: `provider:auto`)은 OAS 차원에서 존재할 수 있지만, checked-in repo defaults는 review 안정성을 위해 explicit `provider:model_id`를 선호한다.
 - legacy `allowed_providers` keeper TOML/meta fields는 compatibility input일 뿐이며, active runtime policy로 취급하지 않는다.
+- persisted legacy keeper meta tool-policy fields are scrubbed into canonical `tool_access` on read; direct `meta_of_json` callers must use canonical keeper meta keys.
 
 ## Current Integration Status
 

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -43,7 +43,9 @@ OAS  ──does not know──→ MASC
 - `config/cascade.json`은 **OAS cascade contract**를 따르는 설정 파일이다.
 - cascade schema, parsing, label semantics의 owner는 OAS다.
 - MASC는 그 contract를 재정의하지 않고, 이 저장소에 체크인할 repo-level default만 선택한다.
+- OAS가 소유한 설정 결과를 MASC가 소비하는 것은 허용된다. 다만 MASC는 provider allowlist, cascade parsing rule, proof-store layout 같은 OAS-owned shape를 자체 meta/profile schema로 다시 소유하면 안 된다.
 - 따라서 runtime convenience label(예: `provider:auto`)은 OAS 차원에서 존재할 수 있지만, checked-in repo defaults는 review 안정성을 위해 explicit `provider:model_id`를 선호한다.
+- legacy `allowed_providers` keeper TOML/meta fields는 compatibility input일 뿐이며, active runtime policy로 취급하지 않는다.
 
 ## Current Integration Status
 
@@ -54,6 +56,7 @@ OAS  ──does not know──→ MASC
 | Checkpoint integration | Partial complete | OAS checkpoint is used in shared worker/runtime paths, and the public OAS worker API now keeps the extra JSON as a neutral checkpoint sidecar. Keeper runtime still persists its own `working_context` / serialized checkpoint path in `lib/keeper/keeper_exec_context.ml` |
 | Memory bridge | Partial complete | long-term + procedural + institution episodic are bridged; broader memory unification is still separate |
 | Team-session swarm | Partial complete | OAS Swarm runner is active; current bridge uses `swarm_config` / `agent_entry` + worker metadata while intentionally omitting `collaboration_context`, so fidelity is still incomplete |
+| Provider selection ownership | Improved | MASC persists `cascade_name` only; provider allowlists remain OAS-owned and legacy `allowed_providers` inputs are ignored |
 
 ## Boundary Audit Snapshot
 
@@ -71,6 +74,7 @@ OAS  ──does not know──→ MASC
 - keeper continuity still leaks domain semantics through raw message text (`[STATE]`, goal/memory markers)
 - `memory_oas_bridge.ml` still owns imperative seeding/flushing instead of a hook-first boundary
 - team-session bridge fidelity and runtime-health signaling are still incomplete
+- proof-store and `oas-runtime` filesystem layout must stay behind thin adapters instead of being reconstructed ad hoc
 
 ## Delivery-Contract Split
 

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -58,6 +58,9 @@ The main remaining problems are no longer “missing migration” at large. They
 - path/layout ownership is narrower.
   - `cdal_loader` now resolves proof-store contract paths through `proof_artifact_reader`
   - team-session evidence readers now reuse the shared `oas-runtime` session-root helper
+- keeper meta compatibility is narrower.
+  - persisted legacy tool-policy fields are scrubbed into canonical `tool_access`
+  - direct keeper meta parsing now rejects legacy compatibility keys instead of silently carrying them forward
 - this work also exposed and fixed a real pre-existing bug:
   - `Institution_eio.load_recent_episodes_jsonl` ignored `limit` when the log was larger than the requested window
 

--- a/docs/OAS-UTILIZATION-AUDIT.md
+++ b/docs/OAS-UTILIZATION-AUDIT.md
@@ -14,6 +14,7 @@ The main remaining problems are no longer “missing migration” at large. They
 1. incomplete bridge fidelity,
 2. a few remaining duplicated runtime paths,
 3. stale docs that still describe already-removed or already-migrated systems.
+4. a small number of boundary ownership leaks where MASC still reconstructs OAS-owned config or layout details locally.
 
 ## Pin Policy
 
@@ -29,6 +30,7 @@ The main remaining problems are no longer “missing migration” at large. They
 | Memory bridge | Partial but real | `memory_oas_bridge.ml` now seeds long-term, procedural, and episodic memory; Working/Scratchpad remain runtime-only |
 | Team session swarm | Partial but real | `team_session_swarm_runner.ml` runs through OAS Swarm and now receives a real supported-tool dispatch bundle |
 | Runtime dedupe | Improving | dashboard single-run and initial local worker run now reuse shared OAS execution helpers |
+| Provider ownership | Improving | keeper state now treats OAS-owned provider allowlists in legacy TOML/meta as compatibility-only input and keeps active selection at `cascade_name` |
 
 ## Boundary Audit Snapshot
 
@@ -53,6 +55,9 @@ The main remaining problems are no longer “missing migration” at large. They
 - runtime duplication was reduced.
   - dashboard provider single-run now uses `Oas_worker.run_model`
   - initial local worker execution now uses `Worker_oas.run_worker_via_oas`
+- path/layout ownership is narrower.
+  - `cdal_loader` now resolves proof-store contract paths through `proof_artifact_reader`
+  - team-session evidence readers now reuse the shared `oas-runtime` session-root helper
 - this work also exposed and fixed a real pre-existing bug:
   - `Institution_eio.load_recent_episodes_jsonl` ignored `limit` when the log was larger than the requested window
 

--- a/lib/cdal_loader.ml
+++ b/lib/cdal_loader.ml
@@ -70,15 +70,11 @@ let load ~(store : Agent_sdk.Proof_store.config)
   if manifest_proof.schema_version <> Agent_sdk.Cdal_proof.schema_version_current then
     Error (Schema_unsupported manifest_proof.schema_version)
   else
-  (* 3. Compute contract path and read.
-     Note: Proof_store.contract_path exists in OAS but is not exposed
-     in the .mli. Using the same convention directly as adapter. *)
-  let contract_path =
-    Filename.concat
-      (Filename.concat
-         (Filename.concat store.root "proofs")
-         manifest_proof.run_id)
-      "contract.json"
+  (* 3. Compute contract path via the local proof-store adapter. *)
+  let* contract_path =
+    Proof_artifact_reader.run_artifact_path store
+      ~run_id:manifest_proof.run_id ~relative_path:"contract.json"
+    |> Result.map_error (fun msg -> Ref_resolution_error msg)
   in
   let* contract_json =
     read_json_file contract_path

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -285,7 +285,6 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         work_discovery_guidance = p.profile_defaults.work_discovery_guidance;
         telemetry_feedback_enabled = p.profile_defaults.telemetry_feedback_enabled;
         telemetry_feedback_window_hours = p.profile_defaults.telemetry_feedback_window_hours;
-        allowed_providers = p.profile_defaults.allowed_providers;
         runtime = {
           usage = {
             total_turns = 0;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -292,12 +292,6 @@ let json_member_present key (json : Yojson.Safe.t) =
   | _ -> false
 ;;
 
-let json_object_member_present key (json : Yojson.Safe.t) =
-  match Yojson.Safe.Util.member key json with
-  | `Assoc _ -> true
-  | _ -> false
-;;
-
 let string_list_field_result ?label ~field_name (json : Yojson.Safe.t) =
   let label = Option.value ~default:field_name label in
   match Yojson.Safe.Util.member field_name json with
@@ -329,7 +323,11 @@ let parse_tool_preset_projection (json : Yojson.Safe.t) =
   | _ -> Error "keeper tool_preset must be a string"
 ;;
 
-let tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
+let default_tool_access_of_meta_json () =
+  migrate_legacy_restricted_tools legacy_session_min_tool_names
+;;
+
+let legacy_tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
   let custom_present = json_member_present "tool_custom_allowlist" json in
   let preset_present = json_member_present "tool_preset" json in
   let also_allow_present = json_member_present "tool_also_allow" json in
@@ -352,12 +350,12 @@ let tool_access_projection_of_meta_json (json : Yojson.Safe.t) =
     match string_list_field_result ~field_name:"tool_allowlist" json with
     | Ok names -> Ok (migrate_legacy_restricted_tools names)
     | Error msg -> Error msg)
-  else Ok (migrate_legacy_restricted_tools legacy_session_min_tool_names)
+  else Ok (default_tool_access_of_meta_json ())
 ;;
 
-let tool_access_of_meta_json (json : Yojson.Safe.t) =
+let legacy_tool_access_of_meta_json (json : Yojson.Safe.t) =
   match Yojson.Safe.Util.member "tool_access" json with
-  | `Null -> tool_access_projection_of_meta_json json
+  | `Null -> legacy_tool_access_projection_of_meta_json json
   | `Assoc _ as access_json ->
     let kind =
       Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
@@ -374,6 +372,47 @@ let tool_access_of_meta_json (json : Yojson.Safe.t) =
         with
         | Ok tools -> Ok (migrate_legacy_restricted_tools tools)
         | Error msg -> Error msg)
+     | Some "preset" ->
+       let preset_raw =
+         Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
+       in
+       (match preset_raw with
+        | None -> Error "keeper tool_access.preset required"
+        | Some raw ->
+          (match tool_preset_of_string raw with
+           | None -> Error (Printf.sprintf "invalid keeper tool_access.preset: %s" raw)
+           | Some preset ->
+             (match
+                string_list_field_opt_result
+                  ~field_name:"also_allow"
+                  ~label:"tool_access.also_allow"
+                  access_json
+              with
+              | Ok also_allow ->
+                Ok (normalize_tool_access (Preset { preset; also_allow }))
+              | Error msg -> Error msg)))
+     | Some "custom" ->
+       (match
+          string_list_field_result
+            ~field_name:"tools"
+            ~label:"tool_access.tools"
+            access_json
+        with
+        | Ok tools -> Ok (normalize_tool_access (Custom tools))
+        | Error msg -> Error msg)
+     | Some other -> Error (Printf.sprintf "invalid keeper tool_access.kind: %s" other)
+     | None -> Error "keeper tool_access.kind required")
+  | _ -> Error "keeper tool_access must be an object"
+;;
+
+let tool_access_of_meta_json (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member "tool_access" json with
+  | `Null -> Ok (default_tool_access_of_meta_json ())
+  | `Assoc _ as access_json ->
+    let kind =
+      Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
+    in
+    (match kind with
      | Some "preset" ->
        let preset_raw =
          Yojson.Safe.Util.member "preset" access_json |> Yojson.Safe.Util.to_string_option
@@ -477,15 +516,83 @@ let reject_removed_keeper_meta_fields (json : Yojson.Safe.t) =
     Error (Printf.sprintf "removed keeper meta fields: %s" (String.concat ", " fields))
 ;;
 
+let legacy_keeper_meta_tool_policy_key_names =
+  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+;;
+
+let legacy_keeper_meta_key_names =
+  "allowed_providers" :: legacy_keeper_meta_tool_policy_key_names
+;;
+
+let reject_legacy_keeper_meta_fields (json : Yojson.Safe.t) =
+  let present = present_json_keys legacy_keeper_meta_key_names json in
+  match present with
+  | [] -> Ok ()
+  | fields ->
+    Error
+      (Printf.sprintf
+         "legacy keeper meta fields require scrub via read_meta_file_path: %s"
+         (String.concat ", " fields))
+;;
+
+let legacy_tool_access_kind_needs_scrub (json : Yojson.Safe.t) =
+  match Yojson.Safe.Util.member "tool_access" json with
+  | `Assoc _ as access_json ->
+    (match
+       Yojson.Safe.Util.member "kind" access_json |> Yojson.Safe.Util.to_string_option
+     with
+     | Some "restricted" | Some "unrestricted" -> true
+     | _ -> false)
+  | _ -> false
+;;
+
+let scrub_legacy_tool_policy_meta_json (json : Yojson.Safe.t) : Yojson.Safe.t * string list =
+  let present = present_json_keys legacy_keeper_meta_key_names json in
+  let missing_tool_access = not (json_member_present "tool_access" json) in
+  let legacy_tool_access_kind = legacy_tool_access_kind_needs_scrub json in
+  let needs_tool_access_rewrite =
+    present <> [] || missing_tool_access || legacy_tool_access_kind
+  in
+  if not needs_tool_access_rewrite
+  then json, []
+  else
+    match legacy_tool_access_of_meta_json json with
+    | Error _ ->
+      let dropped =
+        present |> List.filter (fun key -> String.equal key "allowed_providers")
+      in
+      if dropped = []
+      then json, []
+      else
+        (drop_assoc_keys dropped json, dropped)
+    | Ok tool_access ->
+      let rewrite_reasons =
+        (if missing_tool_access then [ "tool_access(defaulted)" ] else [])
+        @ (if legacy_tool_access_kind then [ "tool_access(legacy-kind)" ] else [])
+        @ present
+      in
+      let base = drop_assoc_keys legacy_keeper_meta_key_names json in
+      let scrubbed =
+        match base with
+        | `Assoc fields ->
+          `Assoc
+            (("tool_access", tool_access_to_json tool_access)
+             :: List.remove_assoc "tool_access" fields)
+        | _ -> base
+      in
+      scrubbed, rewrite_reasons
+;;
+
 let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.t * bool =
+  let json, legacy_tool_policy_rewrites = scrub_legacy_tool_policy_meta_json json in
   match json with
   | `Assoc fields ->
-    let present =
+    let removed_present =
       fields
       |> List.filter_map (fun (key, _) ->
         if List.mem key removed_keeper_meta_key_names then Some key else None)
     in
-    if present = []
+    if removed_present = [] && legacy_tool_policy_rewrites = []
     then json, false
     else (
       let migrate_legacy_disabled_keepalive =
@@ -505,9 +612,9 @@ let scrub_persisted_keeper_meta_json ~path (json : Yojson.Safe.t) : Yojson.Safe.
       (try
          Fs_compat.save_file path content;
          Log.Keeper.info
-           "scrubbed removed keeper meta fields for %s: %s%s"
+           "scrubbed legacy keeper meta fields for %s: %s%s"
            path
-           (String.concat ", " present)
+           (String.concat ", " (legacy_tool_policy_rewrites @ removed_present))
            (if migrate_legacy_disabled_keepalive
             then " (migrated presence_keepalive=false to paused=true)"
             else "")
@@ -1009,7 +1116,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
   try
     match reject_removed_keeper_meta_fields json with
     | Error e -> Error e
-    | Ok () ->
+    | Ok () -> (
+      match reject_legacy_keeper_meta_fields json with
+      | Error e -> Error e
+      | Ok () ->
       let identity = parse_keeper_identity json in
       (match parse_keeper_policy json ~keeper_name:identity.pk_name with
        | Error _ as e -> e
@@ -1089,6 +1199,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; telemetry_feedback_window_hours = Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
              ; runtime = state.ps_runtime
              })
+      )
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "meta parse error: %s" (Printexc.to_string exn))
@@ -1210,26 +1321,13 @@ let canonical_keeper_meta_key_names =
     fallback_canonical_keeper_meta_key_names
 ;;
 
-let compatibility_keeper_meta_key_names =
-  [
-    "tool_preset";
-    "tool_also_allow";
-    "tool_custom_allowlist";
-    "tool_allowlist";
-    "allowed_providers";
-  ]
-;;
-
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
-    let known_keeper_meta_key_names =
-      canonical_keeper_meta_key_names @ compatibility_keeper_meta_key_names
-    in
     let unknown =
       fields
       |> List.filter_map (fun (key, _) ->
-        if List.mem key known_keeper_meta_key_names then None else Some key)
+        if List.mem key canonical_keeper_meta_key_names then None else Some key)
       |> dedupe_keep_order
     in
     if unknown <> []
@@ -1241,27 +1339,6 @@ let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =
   | _ -> ()
 ;;
 
-let warn_tool_access_compat_keys ~path (json : Yojson.Safe.t) =
-  let compat_present =
-    compatibility_keeper_meta_key_names
-    |> List.filter (fun key -> json_member_present key json)
-  in
-  match compat_present with
-  | [] -> ()
-  | fields ->
-    if json_object_member_present "tool_access" json
-    then
-      Log.Keeper.warn
-        "keeper meta %s has tool_access plus compatibility tool keys; ignoring %s"
-        path
-        (String.concat ", " fields)
-    else
-      Log.Keeper.warn
-        "keeper meta %s uses compatibility tool keys (%s); prefer canonical tool_access"
-        path
-        (String.concat ", " fields)
-;;
-
 let read_meta_file_path path : (keeper_meta option, string) result =
   if not (Sys.file_exists path)
   then Ok None
@@ -1271,7 +1348,6 @@ let read_meta_file_path path : (keeper_meta option, string) result =
     | Ok json ->
       let json, _scrubbed = scrub_persisted_keeper_meta_json ~path json in
       warn_unknown_keeper_meta_keys ~path json;
-      warn_tool_access_compat_keys ~path json;
       (match meta_of_json json with
        | Ok meta -> Ok (Some meta)
        | Error e ->

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -166,7 +166,6 @@ type keeper_meta =
   ; work_discovery_guidance : string option
   ; telemetry_feedback_enabled : bool option
   ; telemetry_feedback_window_hours : int option
-  ; allowed_providers : string list option
   ; (* -- Agent runtime state (usage, tracing, autonomy metrics) -- *)
     runtime : agent_runtime_state
   }
@@ -624,10 +623,6 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "work_discovery_guidance", Json_util.string_opt_to_json m.work_discovery_guidance
     ; "telemetry_feedback_enabled", Json_util.bool_opt_to_json m.telemetry_feedback_enabled
     ; "telemetry_feedback_window_hours", Json_util.int_opt_to_json m.telemetry_feedback_window_hours
-    ; "allowed_providers"
-      , (match m.allowed_providers with
-         | Some xs -> `List (List.map (fun s -> `String s) xs)
-         | None -> `Null)
     ]
 ;;
 
@@ -1092,7 +1087,6 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; work_discovery_guidance = Safe_ops.json_string_opt "work_discovery_guidance" json
              ; telemetry_feedback_enabled = Safe_ops.json_bool_opt "telemetry_feedback_enabled" json
              ; telemetry_feedback_window_hours = Safe_ops.json_int_opt "telemetry_feedback_window_hours" json
-             ; allowed_providers = Keeper_types_profile.lower_string_list_opt (Safe_ops.json_string_list "allowed_providers" json)
              ; runtime = state.ps_runtime
              })
   with
@@ -1193,7 +1187,6 @@ let fallback_canonical_keeper_meta_key_names =
   ; "work_discovery_guidance"
   ; "telemetry_feedback_enabled"
   ; "telemetry_feedback_window_hours"
-  ; "allowed_providers"
   ]
 ;;
 
@@ -1218,7 +1211,13 @@ let canonical_keeper_meta_key_names =
 ;;
 
 let compatibility_keeper_meta_key_names =
-  [ "tool_preset"; "tool_also_allow"; "tool_custom_allowlist"; "tool_allowlist" ]
+  [
+    "tool_preset";
+    "tool_also_allow";
+    "tool_custom_allowlist";
+    "tool_allowlist";
+    "allowed_providers";
+  ]
 ;;
 
 let warn_unknown_keeper_meta_keys ~path (json : Yojson.Safe.t) =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -164,7 +164,6 @@ type keeper_meta = {
   work_discovery_guidance : string option;
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
-  allowed_providers : string list option;
   runtime: agent_runtime_state;
 }
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -155,7 +155,6 @@ type keeper_profile_defaults = {
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
-  allowed_providers : string list option;
   cascade_name : string option;
 }
 
@@ -198,7 +197,6 @@ let empty_keeper_profile_defaults = {
   work_discovery_guidance = None;
   telemetry_feedback_enabled = None;
   telemetry_feedback_window_hours = None;
-  allowed_providers = None;
   cascade_name = None;
 }
 
@@ -321,10 +319,6 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         work_discovery_guidance = str "work_discovery_guidance";
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
-        allowed_providers =
-          (match strs "allowed_providers" with
-           | [] -> None
-           | xs -> Some (List.map String.lowercase_ascii xs));
         cascade_name = str "cascade_name";
       })
     result
@@ -451,7 +445,6 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
-                allowed_providers = lower_string_list_opt (Safe_ops.json_string_list "allowed_providers" keeper_json);
                 cascade_name = Safe_ops.json_string_opt "cascade_name" keeper_json;
               }
           | _ -> { empty_keeper_profile_defaults with manifest_path = Some path })

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1029,7 +1029,6 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:Keeper_config.default_cascade_name
-              ?provider_filter:run_meta.allowed_providers
               ~generation:run_generation ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"

--- a/lib/proof_artifact_reader.ml
+++ b/lib/proof_artifact_reader.ml
@@ -5,22 +5,40 @@
 let prefix = "proof-store://"
 let prefix_len = String.length prefix
 
+let proofs_root (config : Agent_sdk.Proof_store.config) =
+  Filename.concat config.root "proofs"
+
+let validate_relative_path ~raw ~label =
+  let segments = String.split_on_char '/' raw in
+  let has_traversal =
+    String.contains raw '\000'
+    || List.exists (fun segment -> segment = "..") segments
+  in
+  if has_traversal then
+    Error (Printf.sprintf "path traversal rejected in %s: %s" label raw)
+  else
+    Ok raw
+
+let run_artifact_path (config : Agent_sdk.Proof_store.config)
+    ~(run_id : string) ~(relative_path : string) : (string, string) result =
+  Result.bind
+    (validate_relative_path ~raw:run_id ~label:"run_id")
+    (fun clean_run_id ->
+      Result.bind
+        (validate_relative_path ~raw:relative_path ~label:"relative_path")
+        (fun clean_relative_path ->
+          Ok
+            (Filename.concat
+               (Filename.concat (proofs_root config) clean_run_id)
+               clean_relative_path)))
+
 let resolve_path (config : Agent_sdk.Proof_store.config)
     (ref_ : Agent_sdk.Cdal_proof.artifact_ref) : (string, string) result =
   if String.length ref_ > prefix_len
      && String.sub ref_ 0 prefix_len = prefix then
     let rel = String.sub ref_ prefix_len (String.length ref_ - prefix_len) in
-    (* Reject path traversal: no ".." components or null bytes. *)
-    let segments = String.split_on_char '/' rel in
-    let has_traversal =
-      String.contains rel '\000'
-      || List.exists (fun s -> s = "..") segments
-    in
-    if has_traversal then
-      Error (Printf.sprintf "path traversal rejected: %s" ref_)
-    else
-      let proofs_root = Filename.concat config.root "proofs" in
-      Ok (Filename.concat proofs_root rel)
+    validate_relative_path ~raw:rel ~label:"artifact_ref"
+    |> Result.map (fun clean_rel -> Filename.concat (proofs_root config) clean_rel)
   else
     Error (Printf.sprintf "invalid artifact ref: %s" ref_)
 

--- a/lib/proof_artifact_reader.mli
+++ b/lib/proof_artifact_reader.mli
@@ -12,6 +12,17 @@ val resolve_path :
   Agent_sdk.Cdal_proof.artifact_ref ->
   (string, string) result
 
+(** Root directory for proof-store artifacts under the configured store. *)
+val proofs_root : Agent_sdk.Proof_store.config -> string
+
+(** Resolve a relative artifact path under a run directory.
+    Returns [Error] when the run id or relative path attempts traversal. *)
+val run_artifact_path :
+  Agent_sdk.Proof_store.config ->
+  run_id:string ->
+  relative_path:string ->
+  (string, string) result
+
 (** Read and parse a JSON artifact from the proof store.
     Returns [Error] if the file does not exist or is not valid JSON. *)
 val read_json :

--- a/lib/team_session_worker_run_meta.ml
+++ b/lib/team_session_worker_run_meta.ml
@@ -12,7 +12,8 @@ type oas_worker_evidence = Tool_team_session_step_types.oas_worker_evidence = {
 let proof_result_status_to_string = Oas_worker_exec.proof_result_status_to_string
 
 let oas_trace_session_root config =
-  Filename.concat (Room_utils.masc_dir config) "oas-runtime"
+  let base_path = Filename.dirname (Room_utils.masc_dir config) in
+  Worker_container.oas_trace_session_root ~base_path
 
 let load_oas_worker_evidence ~(config : Room.config)
     ~(evidence_session_id : string) =

--- a/lib/tool_team_session_support.ml
+++ b/lib/tool_team_session_support.ml
@@ -245,7 +245,8 @@ let load_worker_run_meta config session_id worker_run_id =
     Ok (Room_utils.read_json config path)
 
 let oas_trace_session_root config =
-  Filename.concat (Room_utils.masc_dir config) "oas-runtime"
+  let base_path = Filename.dirname (Room_utils.masc_dir config) in
+  Worker_container.oas_trace_session_root ~base_path
 
 type trace_run_locator = {
   worker_run_id : string;

--- a/scripts/check-boundary-guard.sh
+++ b/scripts/check-boundary-guard.sh
@@ -25,6 +25,41 @@ check() {
   fi
 }
 
+check_forbidden_outside() {
+  local label="$1" pattern="$2" path="$3"
+  shift 3
+  local allowed=("$@")
+  if [[ ! -e "$REPO_ROOT/$path" ]]; then
+    echo "BOUNDARY ERROR: $label — path $path does not exist"
+    rc=1
+    return
+  fi
+  local hits=()
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    local file="${line%%:*}"
+    local allowed_hit=0
+    local rel_file="${file#$REPO_ROOT/}"
+    for allow in "${allowed[@]}"; do
+      if [[ "$rel_file" == "$allow" ]]; then
+        allowed_hit=1
+        break
+      fi
+    done
+    if [[ "$allowed_hit" -eq 0 ]]; then
+      hits+=("$line")
+    fi
+  done < <(grep -rn --include='*.ml' --include='*.mli' "$pattern" "$REPO_ROOT/$path" 2>/dev/null || true)
+
+  if [[ "${#hits[@]}" -gt 0 ]]; then
+    echo "BOUNDARY FAIL: $label — found ${#hits[@]} forbidden match(es)"
+    printf '%s\n' "${hits[@]:0:5}"
+    rc=1
+  else
+    echo "BOUNDARY INFO: $label — no forbidden matches"
+  fi
+}
+
 # V2: MASC-specific importance_scores in keeper working_context wrapper
 # These wrap OAS Context.t with domain-specific scoring that should
 # be handled by OAS custom closures instead.
@@ -72,6 +107,24 @@ check "V8-agent-state-mutation" 2 \
 check "V9-masc-llama-envvar" 7 \
   'MASC_LLAMA' \
   "lib/"
+
+# V10: OAS-owned provider filters must not be re-owned outside compatibility loaders.
+check_forbidden_outside "V10-provider-filter-ownership" \
+  'allowed_providers' \
+  "lib/" \
+  "lib/keeper/keeper_types.ml"
+
+# V11: proof-store layout knowledge must stay inside the proof reader adapter.
+check_forbidden_outside "V11-proof-store-layout" \
+  'Filename\.concat .*"proofs"' \
+  "lib/" \
+  "lib/proof_artifact_reader.ml"
+
+# V12: oas-runtime session root literal must stay inside the runtime path adapter.
+check_forbidden_outside "V12-oas-runtime-layout" \
+  '"oas-runtime"' \
+  "lib/" \
+  "lib/local/worker_container.ml"
 
 if [[ "$rc" -eq 0 ]]; then
   echo "BOUNDARY: all checks within baseline"

--- a/test/test_cdal_loader.ml
+++ b/test/test_cdal_loader.ml
@@ -122,8 +122,14 @@ let test_missing_manifest () =
 let test_malformed_manifest () =
   let (store, _tmp) = setup_store () in
   let run_id = "bad-manifest" in
-  let run_dir = Filename.concat
-    (Filename.concat store.root "proofs") run_id in
+  let run_dir =
+    match
+      Masc_mcp.Proof_artifact_reader.run_artifact_path store ~run_id
+        ~relative_path:"manifest.json"
+    with
+    | Ok path -> Filename.dirname path
+    | Error msg -> Alcotest.fail msg
+  in
   mkdirp run_dir;
   let manifest_path = Filename.concat run_dir "manifest.json" in
   let oc = open_out manifest_path in
@@ -166,10 +172,14 @@ let test_malformed_contract () =
   Agent_sdk.Proof_store.init_run store ~run_id;
   Agent_sdk.Proof_store.write_manifest store ~run_id proof;
   (* Write invalid contract JSON *)
-  let contract_path = Filename.concat
-    (Filename.concat
-       (Filename.concat store.root "proofs") run_id)
-    "contract.json" in
+  let contract_path =
+    match
+      Masc_mcp.Proof_artifact_reader.run_artifact_path store ~run_id
+        ~relative_path:"contract.json"
+    with
+    | Ok path -> path
+    | Error msg -> Alcotest.fail msg
+  in
   let oc = open_out contract_path in
   output_string oc "{not valid contract json}}}";
   close_out oc;

--- a/test/test_keeper_masc_bridge.ml
+++ b/test/test_keeper_masc_bridge.ml
@@ -10,6 +10,32 @@ let prime_keeper_bridge () =
   ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
   KET.inject_masc_schemas Masc_mcp.Config.raw_all_tool_schemas
 
+let temp_dir () =
+  let path = Filename.temp_file "keeper_meta_bridge_" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Sys.readdir path
+        |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let write_json_file path json =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out oc)
+    (fun () -> output_string oc (Yojson.Safe.pretty_to_string json))
+
+let read_json_file path = Yojson.Safe.from_file path
+
 
 let make_meta ?tool_access ?(tool_denylist = []) () =
   let tool_access =
@@ -221,104 +247,109 @@ let test_tool_access_missing_migrates_legacy_standard_policy () =
   Alcotest.(check bool) "does not silently expand to full" false
     (List.mem "masc_autoresearch_cycle" names)
 
-let test_tool_access_legacy_unrestricted_maps_to_full () =
-  let names =
-    allowed_names_of_json
-      (`Assoc
-        [
-          ("name", `String "legacy-unrestricted");
-          ("agent_name", `String "legacy-unrestricted");
-          ("trace_id", `String "legacy-unrestricted-trace");
-          ("tool_access", `Assoc [ ("kind", `String "unrestricted") ]);
-        ])
-  in
-  Alcotest.(check bool) "full keeps keeper internal tool" true
-    (List.mem "keeper_fs_edit" names);
-  Alcotest.(check bool) "full keeps autoresearch tool" true
-    (List.mem "masc_autoresearch_cycle" names)
+let test_read_meta_file_scrubs_compat_tool_keys () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let path = Filename.concat dir "compat-preset.json" in
+      write_json_file path
+        (`Assoc
+          [
+            ("name", `String "compat-preset");
+            ("agent_name", `String "compat-preset");
+            ("trace_id", `String "compat-preset-trace");
+            ("tool_preset", `String "coding");
+            ("tool_also_allow", `List [ `String "masc_governance_status" ]);
+            ("allowed_providers", `List [ `String "glm" ]);
+          ]);
+      match Masc_mcp.Keeper_types.read_meta_file_path path with
+      | Error e -> Alcotest.fail e
+      | Ok None -> Alcotest.fail "expected keeper meta"
+      | Ok (Some meta) ->
+          (match meta.Masc_mcp.Keeper_types.tool_access with
+           | Masc_mcp.Keeper_types.Preset
+               { preset = Masc_mcp.Keeper_types.Coding; also_allow } ->
+               Alcotest.(check (list string))
+                 "compat preset scrub keeps also_allow"
+                 [ "masc_governance_status" ] also_allow
+           | _ -> Alcotest.fail "expected coding preset after scrub");
+          let scrubbed = read_json_file path in
+          Alcotest.(check bool) "tool_access persisted" true
+            (Yojson.Safe.Util.member "tool_access" scrubbed <> `Null);
+          Alcotest.(check bool) "tool_preset removed" true
+            (Yojson.Safe.Util.member "tool_preset" scrubbed = `Null);
+          Alcotest.(check bool) "tool_also_allow removed" true
+            (Yojson.Safe.Util.member "tool_also_allow" scrubbed = `Null);
+          Alcotest.(check bool) "allowed_providers removed" true
+            (Yojson.Safe.Util.member "allowed_providers" scrubbed = `Null))
 
-let test_tool_access_legacy_restricted_keeps_internal_and_listed_tools () =
-  let names =
-    allowed_names_of_json
-      (`Assoc
-        [
-          ("name", `String "legacy-restricted");
-          ("agent_name", `String "legacy-restricted");
-          ("trace_id", `String "legacy-restricted-trace");
-          ( "tool_access",
-            `Assoc
-              [
-                ("kind", `String "restricted");
-                ("tools", `List [ `String "masc_status" ]);
-              ] );
-        ])
-  in
-  Alcotest.(check bool) "restricted keeps keeper internal tool" true
-    (List.mem "keeper_time_now" names);
-  Alcotest.(check bool) "restricted keeps listed masc tool" true
-    (List.mem "masc_status" names);
-  Alcotest.(check bool) "restricted does not unlock unrelated masc tool" false
-    (List.mem "masc_autoresearch_cycle" names)
+let test_read_meta_file_scrubs_legacy_tool_access_kind () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let path = Filename.concat dir "legacy-unrestricted.json" in
+      write_json_file path
+        (`Assoc
+          [
+            ("name", `String "legacy-unrestricted");
+            ("agent_name", `String "legacy-unrestricted");
+            ("trace_id", `String "legacy-unrestricted-trace");
+            ("tool_access", `Assoc [ ("kind", `String "unrestricted") ]);
+          ]);
+      match Masc_mcp.Keeper_types.read_meta_file_path path with
+      | Error e -> Alcotest.fail e
+      | Ok None -> Alcotest.fail "expected keeper meta"
+      | Ok (Some meta) ->
+          let names = KET.keeper_allowed_tool_names meta in
+          Alcotest.(check bool) "full keeps keeper internal tool" true
+            (List.mem "keeper_fs_edit" names);
+          Alcotest.(check bool) "full keeps autoresearch tool" true
+            (List.mem "masc_autoresearch_cycle" names);
+          let scrubbed = read_json_file path in
+          Alcotest.(check string) "legacy kind rewritten"
+            "preset"
+            (Yojson.Safe.Util.member "tool_access" scrubbed
+             |> Yojson.Safe.Util.member "kind"
+             |> Yojson.Safe.Util.to_string))
 
-let test_tool_access_projection_preset_keys_loaded () =
-  let meta =
-    match Masc_mcp.Keeper_types.meta_of_json
-      (`Assoc
-        [
-          ("name", `String "compat-preset");
-          ("agent_name", `String "compat-preset");
-          ("trace_id", `String "compat-preset-trace");
-          ("tool_preset", `String "coding");
-          ("tool_also_allow", `List [ `String "masc_governance_status" ]);
-        ])
-    with
-    | Ok meta -> meta
-    | Error e -> failwith e
-  in
-  match meta.Masc_mcp.Keeper_types.tool_access with
-  | Masc_mcp.Keeper_types.Preset
-      { preset = Masc_mcp.Keeper_types.Coding; also_allow } ->
-      Alcotest.(check (list string))
-        "compat preset keeps also_allow"
-        [ "masc_governance_status" ] also_allow
-  | _ -> Alcotest.fail "expected coding preset from compatibility keys"
+let test_read_meta_file_scrubs_missing_tool_access_default () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let path = Filename.concat dir "legacy-standard.json" in
+      write_json_file path
+        (`Assoc
+          [
+            ("name", `String "legacy-standard");
+            ("agent_name", `String "legacy-standard");
+            ("trace_id", `String "legacy-standard-trace");
+          ]);
+      match Masc_mcp.Keeper_types.read_meta_file_path path with
+      | Error e -> Alcotest.fail e
+      | Ok None -> Alcotest.fail "expected keeper meta"
+      | Ok (Some _meta) ->
+          let scrubbed = read_json_file path in
+          Alcotest.(check bool) "default tool_access persisted" true
+            (Yojson.Safe.Util.member "tool_access" scrubbed <> `Null))
 
-let test_tool_access_projection_custom_allowlist_loaded () =
-  let meta =
-    match Masc_mcp.Keeper_types.meta_of_json
-      (`Assoc
-        [
-          ("name", `String "compat-custom");
-          ("agent_name", `String "compat-custom");
-          ("trace_id", `String "compat-custom-trace");
-          ("tool_custom_allowlist", `List [ `String "masc_status" ]);
-        ])
-    with
-    | Ok meta -> meta
-    | Error e -> failwith e
-  in
-  match meta.Masc_mcp.Keeper_types.tool_access with
-  | Masc_mcp.Keeper_types.Custom names ->
-      Alcotest.(check (list string))
-        "compat custom allowlist preserved"
-        [ "masc_status" ] names
-  | _ -> Alcotest.fail "expected Custom allowlist from compatibility keys"
-
-let test_tool_access_projection_invalid_preset_rejected () =
+let test_meta_of_json_rejects_legacy_tool_policy_keys () =
   match Masc_mcp.Keeper_types.meta_of_json
     (`Assoc
       [
-        ("name", `String "compat-invalid-preset");
-        ("agent_name", `String "compat-invalid-preset");
-        ("trace_id", `String "compat-invalid-preset-trace");
-        ("tool_preset", `String "bogus");
+        ("name", `String "compat-preset");
+        ("agent_name", `String "compat-preset");
+        ("trace_id", `String "compat-preset-trace");
+        ("tool_preset", `String "coding");
       ])
   with
-  | Ok _ -> Alcotest.fail "expected invalid compatibility preset to fail"
+  | Ok _ -> Alcotest.fail "expected legacy tool policy key rejection"
   | Error e ->
       Alcotest.(check string)
-        "invalid compatibility preset error"
-        "meta parse error: invalid keeper tool_preset: bogus"
+        "legacy direct parse rejected"
+        "legacy keeper meta fields require scrub via read_meta_file_path: tool_preset"
         e
 
 let test_tool_access_preset_empty_json_preserved () =
@@ -601,18 +632,16 @@ let () =
         ] );
       ( "meta_json",
         [
-          Alcotest.test_case "missing tool_access migrates legacy standard policy" `Quick
+          Alcotest.test_case "missing tool_access defaults standard policy" `Quick
             test_tool_access_missing_migrates_legacy_standard_policy;
-          Alcotest.test_case "legacy unrestricted maps to full" `Quick
-            test_tool_access_legacy_unrestricted_maps_to_full;
-          Alcotest.test_case "legacy restricted keeps internal tools" `Quick
-            test_tool_access_legacy_restricted_keeps_internal_and_listed_tools;
-          Alcotest.test_case "compat preset keys load preset policy" `Quick
-            test_tool_access_projection_preset_keys_loaded;
-          Alcotest.test_case "compat custom allowlist loads custom policy" `Quick
-            test_tool_access_projection_custom_allowlist_loaded;
-          Alcotest.test_case "compat invalid preset rejected" `Quick
-            test_tool_access_projection_invalid_preset_rejected;
+          Alcotest.test_case "read_meta scrub compat keys to tool_access" `Quick
+            test_read_meta_file_scrubs_compat_tool_keys;
+          Alcotest.test_case "read_meta scrub legacy tool_access kind" `Quick
+            test_read_meta_file_scrubs_legacy_tool_access_kind;
+          Alcotest.test_case "read_meta scrub missing tool_access" `Quick
+            test_read_meta_file_scrubs_missing_tool_access_default;
+          Alcotest.test_case "direct meta_of_json rejects legacy tool keys" `Quick
+            test_meta_of_json_rejects_legacy_tool_policy_keys;
           Alcotest.test_case "preset empty json preserved" `Quick
             test_tool_access_preset_empty_json_preserved;
           Alcotest.test_case "custom empty json preserved" `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -651,14 +651,15 @@ let with_personas_dir f =
       Masc_mcp.Config_dir_resolver.reset ();
       f personas_dir)
 
-(* filter_by_providers tests removed — filtering now in OAS cascade.
-   See masc-mcp#6001, oas#740. *)
+(* Legacy allowed_providers is accepted for compatibility but ignored.
+   Provider ownership now lives with OAS cascade resolution. *)
 
-let test_profile_allowed_providers () =
+let test_profile_ignores_legacy_allowed_providers () =
   let input = {|
 [keeper]
 goal = "test"
 allowed_providers = ["Ollama", "GLM"]
+cascade_name = "local_only"
 |} in
   match TL.parse_toml input with
   | Error e -> fail e
@@ -666,21 +667,8 @@ allowed_providers = ["Ollama", "GLM"]
     (match KTP.profile_defaults_of_toml doc with
      | Error e -> fail e
      | Ok d ->
-       check (option (list string)) "lowercased"
-         (Some [ "ollama"; "glm" ]) d.allowed_providers)
-
-let test_profile_allowed_providers_absent () =
-  let input = {|
-[keeper]
-goal = "test"
-|} in
-  match TL.parse_toml input with
-  | Error e -> fail e
-  | Ok doc ->
-    (match KTP.profile_defaults_of_toml doc with
-     | Error e -> fail e
-     | Ok d ->
-       check (option (list string)) "absent" None d.allowed_providers)
+       check (option string) "cascade preserved"
+         (Some "local_only") d.cascade_name)
 
 let test_persona_resolver_defaults_to_research_tool_preset () =
   with_personas_dir @@ fun personas_dir ->
@@ -776,10 +764,8 @@ let () =
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed initiative keys" `Quick
             test_profile_rejects_removed_initiative_keys;
-          test_case "allowed_providers parsed" `Quick
-            test_profile_allowed_providers;
-          test_case "allowed_providers absent" `Quick
-            test_profile_allowed_providers_absent;
+          test_case "legacy allowed_providers ignored" `Quick
+            test_profile_ignores_legacy_allowed_providers;
         ] );
       ( "file_loading",
         [

--- a/test/test_tool_team_session_support.ml
+++ b/test/test_tool_team_session_support.ml
@@ -131,7 +131,7 @@ let wait_until_terminal ctx session_id =
   loop 200
 
 let oas_trace_session_root base_dir =
-  Filename.concat (Filename.concat base_dir ".masc") "oas-runtime"
+  Worker_container.oas_trace_session_root ~base_path:base_dir
 
 let oas_trace_file_path base_dir ~session_id ~worker_name =
   Filename.concat


### PR DESCRIPTION
## Summary
- stop treating `allowed_providers` as MASC-owned keeper runtime/meta state while keeping legacy TOML compatibility
- centralize proof-store and `oas-runtime` layout knowledge behind shared adapters
- clean up legacy keeper meta parsing by scrubbing persisted old tool-policy shapes into canonical `tool_access` and rejecting direct legacy meta compatibility keys
- tighten the boundary guard and sync the OAS/MASC boundary docs with the new ownership rule

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-oas-boundary-hardening`
- `./_build/default/test/test_keeper_masc_bridge.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `./_build/default/test/test_cdal_loader.exe`
- `./_build/default/test/test_worker_run_evidence_summary.exe`
- `./_build/default/test/test_team_session_worker_run_meta_repair.exe`
- `./scripts/check-boundary-guard.sh`
- `git diff --check`

## Self Review
- found and fixed one compatibility gap: legacy keeper meta with `allowed_providers` should be ignored without surfacing unknown-key warnings
- found and fixed one guard gap: the boundary rule should allow the `allowed_providers` compatibility scrub site in `keeper_types.ml`, but nowhere else
- followed through by removing direct legacy keeper meta compatibility parsing, moving legacy tool-policy normalization into the persisted-meta scrub path, and covering that behavior in `test_keeper_masc_bridge`
