### PR TITLE
[codex] classify keeper post-commit timeout blockers

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -96,14 +96,16 @@ async function refreshAfterRuntimeAction(): Promise<void> {
 }
 
 function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
+  const runtimeBlockerClass = keeper.runtime_blocker_class
+  const runtimeBlocker = keeper.runtime_blocker_summary?.trim()
   const blocker = keeper.last_blocker?.trim()
   const hbTs = keeper.last_heartbeat ? Date.parse(keeper.last_heartbeat) : null
   const hbAgeMs = hbTs != null && !Number.isNaN(hbTs) ? Date.now() - hbTs : null
   const hbStale = hbAgeMs != null && hbAgeMs > 300_000 // 5 minutes
-  const needsAttention = keeper.paused || Boolean(blocker) || hbStale
+  const needsAttention = keeper.paused || Boolean(runtimeBlocker) || Boolean(blocker) || hbStale
   if (!needsAttention && !keeper.last_autonomous_action_at) return null
 
-  const toneClass = keeper.paused || blocker || hbStale
+  const toneClass = keeper.paused || runtimeBlocker || blocker || hbStale
     ? 'border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)]'
     : 'border-[var(--card-border)] bg-[var(--white-3)]'
 
@@ -119,6 +121,16 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
         ${hbStale
           ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-[rgba(239,68,68,0.14)] text-[var(--bad)]">Heartbeat stale</span>
             <span>마지막 하트비트: <${TimeAgo} timestamp=${keeper.last_heartbeat} /></span>`
+          : null}
+        ${runtimeBlockerClass
+          ? html`
+              <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-[rgba(239,68,68,0.14)] text-[var(--bad)]">
+                ${runtimeBlockerClass === 'ambiguous_post_commit_timeout' ? 'Post-commit timeout' : 'Post-commit failure'}
+              </span>
+            `
+          : null}
+        ${runtimeBlocker
+          ? html`<span><strong class="text-[var(--text-strong)]">런타임 차단</strong> · ${runtimeBlocker}</span>`
           : null}
         ${blocker
           ? html`<span><strong class="text-[var(--text-strong)]">차단 요인</strong> · ${blocker}</span>`

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -145,7 +145,9 @@ function KeeperRow({ keeper }: { keeper: Keeper }) {
         <${MetricPill} label="Gen" value=${keeper.generation ?? 0} />
         <${MetricPill} label="Turn" value=${keeper.turn_count ?? 0} />
         <${MetricPill} label="Tool" value=${toolCount > 0 ? toolCount : '-'} />
-        ${keeper.last_blocker ? html`<${MetricPill} label="Blocker" value="yes" tone="warn" />` : null}
+        ${keeper.runtime_blocker_class || keeper.last_blocker
+          ? html`<${MetricPill} label="Blocker" value="yes" tone="warn" />`
+          : null}
         ${summary.band.key === 'paused' ? html`<${MetricPill} label="Pause" value="on" tone="paused" />` : null}
       </div>
     </button>

--- a/dashboard/src/components/mission-agent-cards.test.ts
+++ b/dashboard/src/components/mission-agent-cards.test.ts
@@ -55,4 +55,21 @@ describe('mission keeper runtime helpers', () => {
 
     expect(keeperRuntimeHint(keeper)).toBe('일시정지됨')
   })
+
+  it('prefers structured runtime blocker hints over paused/blocker text', () => {
+    const keeper = {
+      name: 'uranium666',
+      status: 'idle',
+      paused: true,
+      keepalive_running: true,
+      runtime_blocker_class: 'ambiguous_post_commit_timeout',
+      runtime_blocker_summary:
+        'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+      last_blocker: 'missing social headers',
+    } as Keeper
+
+    expect(keeperRuntimeHint(keeper)).toBe(
+      'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+    )
+  })
 })

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -263,6 +263,10 @@ describe('normalizeKeepers lifecycle metrics', () => {
         status: 'idle',
         paused: true,
         keepalive_running: true,
+        runtime_blocker_class: 'ambiguous_post_commit_timeout',
+        runtime_blocker_summary:
+          'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+        runtime_blocker_manual_reconcile: true,
         last_blocker: 'missing social headers',
         last_speech_act: 'defer',
         last_need: '현재 대화 맥락',
@@ -276,6 +280,10 @@ describe('normalizeKeepers lifecycle metrics', () => {
     expect(keeper).toMatchObject({
       paused: true,
       keepalive_running: true,
+      runtime_blocker_class: 'ambiguous_post_commit_timeout',
+      runtime_blocker_summary:
+        'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+      runtime_blocker_manual_reconcile: true,
       last_blocker: 'missing social headers',
       last_speech_act: 'defer',
       last_need: '현재 대화 맥락',

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -327,6 +327,13 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
           typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
         proactive_idle_sec: asNumber(row.proactive_idle_sec),
         proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
+        runtime_blocker_class:
+          (asString(row.runtime_blocker_class) as Keeper['runtime_blocker_class']) ?? null,
+        runtime_blocker_summary: asString(row.runtime_blocker_summary) ?? null,
+        runtime_blocker_manual_reconcile:
+          typeof row.runtime_blocker_manual_reconcile === 'boolean'
+            ? row.runtime_blocker_manual_reconcile
+            : null,
         created_at: toIsoTimestamp(row.created_at) ?? asString(row.created_at),
         updated_at: toIsoTimestamp(row.updated_at) ?? asString(row.updated_at),
         last_heartbeat: asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen),

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -75,6 +75,8 @@ export function keeperRecentActionLabel(
 
 export function keeperRuntimeHint(keeper: Keeper | null | undefined): string | null {
   if (!keeper) return null
+  const runtimeBlocker = keeper.runtime_blocker_summary?.trim()
+  if (runtimeBlocker) return runtimeBlocker
   const blocker = keeper.last_blocker?.trim()
   if (keeper.paused && blocker) return `일시정지 · ${blocker}`
   if (keeper.paused && keeper.keepalive_running) return '일시정지 · 하트비트만 유지 중'

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -73,6 +73,25 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.hint).toContain('오류')
   })
 
+  it('prioritizes structured runtime blockers over generic social blockers', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        runtime_blocker_class: 'ambiguous_post_commit_timeout',
+        runtime_blocker_summary:
+          'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+        last_blocker: 'missing social headers',
+      }),
+    )
+
+    expect(summary.band.key).toBe('attention')
+    expect(summary.hint).toBe(
+      'Mutating tools [keeper_fs_edit] committed before the turn timed out.',
+    )
+  })
+
   it('keeps never-booted keepers in the offline band', () => {
     const summary = summarizeKeeperMonitoring(
       makeKeeper({

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -180,6 +180,16 @@ function isHeartbeatStale(keeper: Keeper): boolean {
   return Date.now() - ts > HEARTBEAT_STALE_MS
 }
 
+function runtimeBlockerHint(keeper: Keeper): string | null {
+  const blockerClass = keeper.runtime_blocker_class
+  if (!blockerClass) return null
+  if (keeper.runtime_blocker_summary?.trim()) return keeper.runtime_blocker_summary.trim()
+  if (blockerClass === 'ambiguous_post_commit_timeout') {
+    return '변경 도구 실행 뒤 턴이 timeout으로 끝났습니다. 중복 실행을 막기 위해 재시도하지 않았고 수동 정합성 확인이 필요합니다.'
+  }
+  return '변경 도구 실행 뒤 턴이 실패했습니다. 중복 실행을 막기 위해 재시도하지 않았고 수동 정합성 확인이 필요합니다.'
+}
+
 function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): RuntimeBand {
   if (keeper.paused || phaseKey === 'Paused' || lifecycleKey === 'paused') return 'paused'
   if (
@@ -193,6 +203,7 @@ function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): Run
   }
   if (
     ATTENTION_PHASES.has(phaseKey)
+    || Boolean(keeper.runtime_blocker_class)
     || Boolean(keeper.last_blocker?.trim())
     || isHeartbeatStale(keeper)
     || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= CONTEXT_ATTENTION_RATIO)
@@ -203,6 +214,8 @@ function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): Run
 }
 
 function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string | null {
+  const runtimeBlocker = runtimeBlockerHint(keeper)
+  if (runtimeBlocker) return runtimeBlocker
   const blocker = keeper.last_blocker?.trim()
   if (blocker) return blocker
   if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -570,6 +570,9 @@ export interface Keeper {
   proactive_enabled?: boolean
   proactive_idle_sec?: number
   proactive_cooldown_sec?: number
+  runtime_blocker_class?: 'ambiguous_post_commit_timeout' | 'ambiguous_post_commit_failure' | null
+  runtime_blocker_summary?: string | null
+  runtime_blocker_manual_reconcile?: boolean | null
   active_goal_ids?: string[]
   last_autonomous_action_at?: string | null
   autonomous_action_count?: number
@@ -735,6 +738,9 @@ export interface KeeperConfigRuntime {
   fiber_health: string
   presence_keepalive: boolean
   presence_keepalive_sec: number
+  runtime_blocker_class?: 'ambiguous_post_commit_timeout' | 'ambiguous_post_commit_failure' | null
+  runtime_blocker_summary?: string | null
+  runtime_blocker_manual_reconcile?: boolean | null
 }
 
 export interface KeeperConfigCoordination {

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -306,6 +306,9 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 Some "manual_reconcile_required"
             | _ -> None
           in
+          let runtime_blocker_fields =
+            runtime_blocker_fields_json config m
+          in
           let supervisor_diagnostics =
             let max_restarts =
               Runtime_params.get Governance_registry.keeper_supervisor_max_restarts in
@@ -493,6 +496,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 match reconcile_status with
                 | Some status -> `String status
                 | None -> `Null);
+            ] @ runtime_blocker_fields @ [
               ("supervisor_diagnostics", supervisor_diagnostics);
               ("agent_name", `String m.agent_name);
               ("emoji", `String (let (e, _) = get_agent_identity m.name in e));

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -23,20 +23,35 @@ module StringMap = Map.Make (String)
 
 (** Structured failure reason for cohort detection in self-preservation.
     ADT matching replaces string prefix matching for crash_msg grouping. *)
+type ambiguous_partial_commit_kind =
+  | Post_commit_timeout
+  | Post_commit_failure
+
+type ambiguous_partial_commit = {
+  kind : ambiguous_partial_commit_kind;
+  detail : string;
+}
+
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
-  | Ambiguous_partial_commit of string
+  | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string
+
+let ambiguous_partial_commit_kind_to_string = function
+  | Post_commit_timeout -> "post_commit_timeout"
+  | Post_commit_failure -> "post_commit_failure"
 
 let failure_reason_to_string = function
   | Heartbeat_consecutive_failures n ->
       Printf.sprintf "heartbeat_consecutive_failures(%d)" n
   | Turn_consecutive_failures n ->
       Printf.sprintf "turn_consecutive_failures(%d)" n
-  | Ambiguous_partial_commit s ->
-      Printf.sprintf "ambiguous_partial_commit(%s)" s
+  | Ambiguous_partial_commit { kind; detail } ->
+      Printf.sprintf "ambiguous_partial_commit(%s:%s)"
+        (ambiguous_partial_commit_kind_to_string kind)
+        detail
   | Fiber_unresolved -> "fiber_unresolved"
   | Exception s -> Printf.sprintf "exception(%s)" s
 

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -13,12 +13,24 @@ open Keeper_types
 module StringMap : Map.S with type key = string
 
 (** Structured failure reason for crash cohort detection. *)
+type ambiguous_partial_commit_kind =
+  | Post_commit_timeout
+  | Post_commit_failure
+
+type ambiguous_partial_commit = {
+  kind : ambiguous_partial_commit_kind;
+  detail : string;
+}
+
 type failure_reason =
   | Heartbeat_consecutive_failures of int
   | Turn_consecutive_failures of int
-  | Ambiguous_partial_commit of string
+  | Ambiguous_partial_commit of ambiguous_partial_commit
   | Fiber_unresolved
   | Exception of string
+
+val ambiguous_partial_commit_kind_to_string :
+  ambiguous_partial_commit_kind -> string
 
 val failure_reason_to_string : failure_reason -> string
 val failure_reason_requires_manual_reconcile : failure_reason -> bool

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -163,7 +163,10 @@ let handle_keeper_list ctx args : tool_result =
                         ("authoritative", `Bool false);
 	                  ]
 	            in
-	            Some (`Assoc [
+              let runtime_blocker_fields =
+                runtime_blocker_fields_json ctx.config m
+              in
+	            Some (`Assoc ([
               ("name", `String m.name);
               ("agent_name", `String m.agent_name);
               ("trace_id", `String m.runtime.trace_id);
@@ -231,6 +234,7 @@ let handle_keeper_list ctx args : tool_result =
                 if String.trim m.runtime.last_need = ""
                 then `Null
                 else `String m.runtime.last_need);
+            ] @ runtime_blocker_fields @ [
               ("continuity_summary",
                 if String.trim m.continuity_summary = ""
                 then `Null
@@ -265,7 +269,7 @@ let handle_keeper_list ctx args : tool_result =
                 ("session_dir", `String (keeper_session_dir ctx.config m.runtime.trace_id));
                 ("history", `String (keeper_history_path ctx.config m.runtime.trace_id));
               ]);
-            ])
+            ]))
         ) keeper_names
       in
       let json = `Assoc [

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -116,6 +116,49 @@ let runtime_keepalive_started_at (config : Room_utils.config)
     (meta : keeper_meta) =
   Keeper_registry.started_at ~base_path:config.base_path meta.name
 
+let runtime_blocker_surface_of_registry_entry
+    (entry_opt : Keeper_registry.registry_entry option) =
+  match entry_opt with
+  | Some
+      {
+        last_failure_reason =
+          Some
+            (Keeper_registry.Ambiguous_partial_commit { kind; detail });
+        _;
+      } ->
+      let blocker_class, default_summary =
+        match kind with
+        | Keeper_registry.Post_commit_timeout ->
+            ( "ambiguous_post_commit_timeout",
+              "Mutating tools committed before the turn timed out. Retry stayed disabled and manual reconcile is required." )
+        | Keeper_registry.Post_commit_failure ->
+            ( "ambiguous_post_commit_failure",
+              "Mutating tools committed before the turn failed. Retry stayed disabled and manual reconcile is required." )
+      in
+      let summary =
+        let trimmed = String.trim detail in
+        if trimmed = "" then default_summary else trimmed
+      in
+      Some (blocker_class, summary, true)
+  | _ -> None
+
+let runtime_blocker_fields_json
+    (config : Room_utils.config)
+    (meta : keeper_meta) =
+  match runtime_blocker_surface_of_registry_entry (runtime_registry_entry config meta.name) with
+  | Some (blocker_class, summary, manual_reconcile) ->
+      [
+        ("runtime_blocker_class", `String blocker_class);
+        ("runtime_blocker_summary", `String summary);
+        ("runtime_blocker_manual_reconcile", `Bool manual_reconcile);
+      ]
+  | None ->
+      [
+        ("runtime_blocker_class", `Null);
+        ("runtime_blocker_summary", `Null);
+        ("runtime_blocker_manual_reconcile", `Null);
+      ]
+
 let runtime_surface_json config (meta : keeper_meta) =
   let keepalive_running = runtime_keepalive_running config meta in
   let fiber_health =
@@ -131,16 +174,17 @@ let runtime_surface_json config (meta : keeper_meta) =
     | None -> None
   in
   `Assoc
-    [
-      ("paused", `Bool meta.paused);
-      ("keepalive_running", `Bool keepalive_running);
-      ("phase",
-       match phase with
-       | Some p -> `String p
-       | None -> `Null);
-      ( "fiber_health",
-        `String (Keeper_exec_status.string_of_fiber_health fiber_health) );
-    ]
+    ([
+       ("paused", `Bool meta.paused);
+       ("keepalive_running", `Bool keepalive_running);
+       ("phase",
+        match phase with
+        | Some p -> `String p
+        | None -> `Null);
+       ( "fiber_health",
+         `String (Keeper_exec_status.string_of_fiber_health fiber_health) );
+     ]
+     @ runtime_blocker_fields_json config meta)
 
 let source_provenance_json config (meta : keeper_meta) =
   let snapshot = keeper_default_source_snapshot meta.name in

--- a/lib/keeper/keeper_status_bridge.mli
+++ b/lib/keeper/keeper_status_bridge.mli
@@ -36,6 +36,9 @@ val runtime_keepalive_running :
 val runtime_keepalive_started_at :
   Room_utils.config -> keeper_meta -> float option
 
+val runtime_blocker_fields_json :
+  Room_utils.config -> keeper_meta -> (string * Yojson.Safe.t) list
+
 val runtime_surface_json :
   Room_utils.config -> keeper_meta -> Yojson.Safe.t
 

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -486,8 +486,11 @@ let handle_keeper_status ctx args : tool_result =
           Keeper_types.tool_access_custom_allowlist m.tool_access
           |> Option.value ~default:[]
         in
+        let runtime_blocker_fields =
+          runtime_blocker_fields_json ctx.config m
+        in
 
-         let json = `Assoc [
+         let json = `Assoc ([
            ("name", `String name);
            ("meta", meta_to_json m);
            ("goal", `String m.goal);
@@ -609,6 +612,7 @@ let handle_keeper_status ctx args : tool_result =
                then `Null
                else `String m.runtime.last_need);
           ]);
+        ] @ runtime_blocker_fields @ [
            ("compaction_policy", `Assoc [
              ("profile", `String m.compaction.profile);
              ("ratio_gate", `Float compact_ratio_gate);
@@ -725,7 +729,7 @@ let handle_keeper_status ctx args : tool_result =
                | Ok () -> `Bool true
                | Error _ -> `Bool false);
            ]);
-         ] in
+         ]) in
          let response = Yojson.Safe.pretty_to_string json in
          Hashtbl.replace _cache name
            { updated_at = m.updated_at; args_hash; response };

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -87,6 +87,54 @@ let reclassify_error_after_side_effect
          "%s: [%s]; retry disabled to avoid duplicate mutation; original_error=%s"
          ambiguous_side_effect_error_prefix tools original)
 
+let post_commit_failure_kind_of_error (err : Oas.Error.sdk_error) =
+  match err with
+  | Oas.Error.Api (Timeout _) -> Keeper_registry.Post_commit_timeout
+  | _ -> Keeper_registry.Post_commit_failure
+
+let summarize_post_commit_failure
+    ~(tool_names : string list)
+    ~(kind : Keeper_registry.ambiguous_partial_commit_kind)
+    (err : Oas.Error.sdk_error) =
+  let tools = String.concat ", " (committed_mutating_tools tool_names) in
+  let err_preview = short_preview (Oas.Error.to_string err) in
+  match kind with
+  | Keeper_registry.Post_commit_timeout ->
+      Printf.sprintf
+        "Mutating tools [%s] committed before the turn timed out; retry stayed disabled and manual reconcile is required (error: %s)"
+        tools
+        err_preview
+  | Keeper_registry.Post_commit_failure ->
+      Printf.sprintf
+        "Mutating tools [%s] committed before the turn failed; retry stayed disabled and manual reconcile is required (error: %s)"
+        tools
+        err_preview
+
+let classify_post_commit_failure
+    ~(tool_names : string list)
+    ?kind
+    (err : Oas.Error.sdk_error) =
+  let committed_tools = committed_mutating_tools tool_names in
+  if committed_tools = []
+  then None
+  else
+    let resolved_kind =
+      Option.value ~default:(post_commit_failure_kind_of_error err) kind
+    in
+    let reclassified =
+      reclassify_error_after_side_effect ~tool_names:committed_tools err
+    in
+    let detail =
+      summarize_post_commit_failure
+        ~tool_names:committed_tools
+        ~kind:resolved_kind
+        err
+    in
+    Some
+      ( reclassified,
+        Keeper_registry.Ambiguous_partial_commit
+          { kind = resolved_kind; detail } )
+
 (** Max transient retries (excluding the initial attempt).  Total attempts
     = 1 initial + max_transient_retries.  OAS internal retry is 3 per
     provider; this outer retry covers cases where all providers fail
@@ -1003,6 +1051,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
          an independent observer, so concurrent keepers cannot interfere
          with each other's save/restore lifecycle. *)
       let mutating_tools_committed = ref [] in
+      let post_commit_failure_reason = ref None in
       let side_effect_observer ~tool_name ~success =
         if success && Keeper_exec_tools.has_mutating_side_effect tool_name then
           mutating_tools_committed := tool_name :: !mutating_tools_committed
@@ -1051,10 +1100,26 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                   committed_mutating_tools !mutating_tools_committed
                 in
                 if committed_tools <> [] then begin
-                  let reclassified =
-                    reclassify_error_after_side_effect
-                      ~tool_names:committed_tools err
+                  let reclassified, failure_reason =
+                    match
+                      classify_post_commit_failure
+                        ~tool_names:committed_tools
+                        err
+                    with
+                    | Some classified -> classified
+                    | None ->
+                        ( reclassify_error_after_side_effect
+                            ~tool_names:committed_tools err,
+                          Keeper_registry.Ambiguous_partial_commit {
+                            kind = Keeper_registry.Post_commit_failure;
+                            detail =
+                              summarize_post_commit_failure
+                                ~tool_names:committed_tools
+                                ~kind:Keeper_registry.Post_commit_failure
+                                err;
+                          } )
                   in
+                  post_commit_failure_reason := Some failure_reason;
                   let err_preview = short_preview (Oas.Error.to_string err) in
                   if is_transient_network_error err then
                     Log.Keeper.error
@@ -1125,7 +1190,42 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 timeout_sec
             in
             Log.Keeper.error "%s: %s" meta.name msg;
-            Error (Oas.Error.Internal msg))))
+            let committed_tools =
+              committed_mutating_tools !mutating_tools_committed
+            in
+            if committed_tools <> [] then begin
+              let timeout_err =
+                Oas.Error.Api (Timeout { message = msg })
+              in
+              let reclassified, failure_reason =
+                match
+                  classify_post_commit_failure
+                    ~tool_names:committed_tools
+                    ~kind:Keeper_registry.Post_commit_timeout
+                    timeout_err
+                with
+                | Some classified -> classified
+                | None ->
+                    ( reclassify_error_after_side_effect
+                        ~tool_names:committed_tools
+                        timeout_err,
+                      Keeper_registry.Ambiguous_partial_commit {
+                        kind = Keeper_registry.Post_commit_timeout;
+                        detail =
+                          summarize_post_commit_failure
+                            ~tool_names:committed_tools
+                            ~kind:Keeper_registry.Post_commit_timeout
+                            timeout_err;
+                      } )
+              in
+              post_commit_failure_reason := Some failure_reason;
+              Log.Keeper.error
+                "%s: turn wall-clock timeout after committed mutating tool call(s) [%s] — treating as integrity failure, manual reconcile required"
+                meta.name
+                (String.concat ", " committed_tools);
+              Error reclassified
+            end else
+              Error (Oas.Error.Internal msg))))
       in
       match run_result with
       | Error err ->
@@ -1151,7 +1251,14 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           if is_ambiguous_partial then begin
             Keeper_registry.set_failure_reason ~base_path:config.base_path
               meta.name
-              (Some (Keeper_registry.Ambiguous_partial_commit e_str));
+              (Some
+                 (Option.value
+                    ~default:
+                      (Keeper_registry.Ambiguous_partial_commit {
+                        kind = Keeper_registry.Post_commit_failure;
+                        detail = e_str;
+                      })
+                    !post_commit_failure_reason));
             ignore (Keeper_registry.dispatch_event
               ~base_path:config.base_path meta.name
               (Keeper_state_machine.Manual_reconcile_required {

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -82,6 +82,9 @@ val reclassify_error_after_side_effect :
   Oas.Error.sdk_error ->
   Oas.Error.sdk_error
 
+val post_commit_failure_kind_of_error :
+  Oas.Error.sdk_error -> Keeper_registry.ambiguous_partial_commit_kind
+
 (** [true] when an error represents an ambiguous partial commit after a
     mutating tool call succeeded but the turn failed before a clean result. *)
 val is_ambiguous_side_effect_error : Oas.Error.sdk_error -> bool

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -1,7 +1,10 @@
 open Alcotest
 
 module ES = Masc_mcp.Keeper_exec_status
+module KSB = Masc_mcp.Keeper_status_bridge
+module KR = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
+module Room = Masc_mcp.Room
 
 let make_meta ?(name = "keeper-exec-status-test")
     ?(trace_id = "trace-keeper-exec-status") () =
@@ -242,6 +245,29 @@ let test_diagnostic_ignores_stale_error_when_live_signal_is_newer () =
     "healthy"
     (diagnostic |> member "health_state" |> to_string)
 
+let test_runtime_surface_exposes_post_commit_timeout_blocker () =
+  KR.clear ();
+  let meta = make_meta ~name:"runtime-blocker-test" () in
+  let config = Room.default_config "/tmp/test-keeper-exec-status-runtime" in
+  ignore (KR.register ~base_path:config.base_path meta.name meta);
+  KR.set_failure_reason ~base_path:config.base_path meta.name
+    (Some
+       (KR.Ambiguous_partial_commit
+          {
+            kind = KR.Post_commit_timeout;
+            detail = "Mutating tools [keeper_fs_edit] committed before the turn timed out.";
+          }));
+  let runtime = KSB.runtime_surface_json config meta in
+  let open Yojson.Safe.Util in
+  check string "runtime blocker class"
+    "ambiguous_post_commit_timeout"
+    (runtime |> member "runtime_blocker_class" |> to_string);
+  check bool "manual reconcile required" true
+    (runtime |> member "runtime_blocker_manual_reconcile" |> to_bool);
+  check string "runtime blocker summary"
+    "Mutating tools [keeper_fs_edit] committed before the turn timed out."
+    (runtime |> member "runtime_blocker_summary" |> to_string)
+
 let () =
   run "keeper_exec_status"
     [
@@ -280,5 +306,7 @@ let () =
             test_keeper_surface_status_maps_zombie_to_inactive;
           test_case "maps dead to inactive" `Quick
             test_keeper_surface_status_maps_dead_to_inactive;
+          test_case "runtime surface exposes post-commit blocker" `Quick
+            test_runtime_surface_exposes_post_commit_timeout_blocker;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -3,6 +3,7 @@ open Alcotest
 module WO = Masc_mcp.Keeper_world_observation
 module UP = Masc_mcp.Keeper_unified_prompt
 module UT = Masc_mcp.Keeper_unified_turn
+module KR = Masc_mcp.Keeper_registry
 module KAR = Masc_mcp.Keeper_agent_run
 module KTD = Masc_mcp.Keeper_tool_disclosure
 module KEC = Masc_mcp.Keeper_exec_context
@@ -1543,6 +1544,24 @@ let test_side_effect_reclassification_marks_any_post_commit_error () =
   check bool "auth error becomes ambiguous partial" true
     (UT.is_ambiguous_side_effect_error reclassified)
 
+let test_post_commit_failure_kind_marks_timeouts () =
+  let timeout_error =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  check string "timeout kind" "post_commit_timeout"
+    (KR.ambiguous_partial_commit_kind_to_string
+       (UT.post_commit_failure_kind_of_error timeout_error))
+
+let test_post_commit_failure_kind_marks_non_timeouts_as_failures () =
+  let auth_error =
+    Agent_sdk.Error.Api
+      (AuthError { message = "Unauthorized" })
+  in
+  check string "failure kind" "post_commit_failure"
+    (KR.ambiguous_partial_commit_kind_to_string
+       (UT.post_commit_failure_kind_of_error auth_error))
+
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api
@@ -2241,6 +2260,10 @@ let () =
             test_side_effect_reclassification_requires_committed_tools;
           test_case "any post-commit error becomes ambiguous partial" `Quick
             test_side_effect_reclassification_marks_any_post_commit_error;
+          test_case "timeout classified as post-commit timeout" `Quick
+            test_post_commit_failure_kind_marks_timeouts;
+          test_case "non-timeout classified as post-commit failure" `Quick
+            test_post_commit_failure_kind_marks_non_timeouts_as_failures;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -104,15 +104,28 @@ let test_failure_reason_exception () =
 let test_failure_reason_ambiguous_partial_commit () =
   let s =
     R.failure_reason_to_string
-      (R.Ambiguous_partial_commit "turn outcome ambiguous")
+      (R.Ambiguous_partial_commit
+         {
+           kind = R.Post_commit_timeout;
+           detail = "turn outcome ambiguous";
+         })
   in
   check string "ambiguous partial commit reason"
-    "ambiguous_partial_commit(turn outcome ambiguous)" s
+    "ambiguous_partial_commit(post_commit_timeout:turn outcome ambiguous)" s
+
+let test_failure_reason_ambiguous_partial_commit_kind_string () =
+  check string "ambiguous partial commit kind string"
+    "post_commit_timeout"
+    (R.ambiguous_partial_commit_kind_to_string R.Post_commit_timeout)
 
 let test_failure_reason_manual_reconcile_required () =
   check bool "ambiguous partial commit requires manual reconcile" true
     (R.failure_reason_requires_manual_reconcile
-       (R.Ambiguous_partial_commit "turn outcome ambiguous"));
+       (R.Ambiguous_partial_commit
+          {
+            kind = R.Post_commit_failure;
+            detail = "turn outcome ambiguous";
+          }));
   check bool "turn failures do not require manual reconcile" false
     (R.failure_reason_requires_manual_reconcile
        (R.Turn_consecutive_failures 2))
@@ -255,6 +268,8 @@ let () =
       test_case "exception" `Quick test_failure_reason_exception;
       test_case "ambiguous partial commit" `Quick
         test_failure_reason_ambiguous_partial_commit;
+      test_case "ambiguous partial commit kind string" `Quick
+        test_failure_reason_ambiguous_partial_commit_kind_string;
       test_case "manual reconcile helper" `Quick
         test_failure_reason_manual_reconcile_required;
     ];


### PR DESCRIPTION
## Summary
- classify keeper post-commit integrity failures as structured runtime blockers instead of generic blocker text
- treat keeper wall-clock timeouts after committed mutating tools the same way as OAS timeout/failure paths
- surface `runtime_blocker_class` / `runtime_blocker_summary` through keeper status and dashboard monitoring/detail views

## Why
The runtime already refused retry after committed mutating tools to avoid duplicate side effects, but operator surfaces only saw generic blocker strings. Keeper wall-clock timeouts were also bypassing the existing ambiguous partial commit path.

## Product impact
Operators can now distinguish post-commit timeout vs post-commit failure directly from keeper monitoring without inventing a new runtime band. Both paths remain manual-reconcile-required and stay in the existing attention band.

## Root cause
`keeper_unified_turn` only reclassified post-commit failures inside the retry loop. The outer keeper wall-clock timeout path returned a plain internal error, so the structured failure reason and dashboard/runtime classification never appeared.

## Evidence
- backend runtime classification now distinguishes `ambiguous_post_commit_timeout` and `ambiguous_post_commit_failure`
- keeper status and dashboard JSON expose additive `runtime_blocker_class`, `runtime_blocker_summary`, and `runtime_blocker_manual_reconcile` fields
- dashboard monitoring/detail surfaces prioritize structured runtime blocker hints over generic blocker strings

## Review evidence
- Reviewer: `sb glm-text` (`GLM-5` direct)
- Timestamp: `2026-04-09 16:09:59 KST`
- Scope: PR diff vs `origin/main`
- Result: `No findings.`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-post-commit-timeout-classifier`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_phase2_self_preservation.exe`
- `./_build/default/test/test_keeper_exec_status.exe`
- `pnpm --dir dashboard exec vitest run src/lib/monitoring-runtime.test.ts src/components/mission-agent-cards.test.ts src/keeper-store-normalize.test.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit --project /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-post-commit-timeout-classifier/dashboard/tsconfig.json`
- `git diff --check`

## Linked issue
- Closes #6090
