### PR TITLE
simplify monitoring agents runtime view

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -22,14 +22,17 @@ import { missionKeeperBriefs, missionAgentBriefs } from '../mission-signals'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { EmptyState } from './common/empty-state'
+import { TimeAgo } from './common/time-ago'
 import { AgentAvatar } from './overview/agent-avatar'
 import { openAgentDetail } from './agent-detail'
+import { openKeeperDetail } from './keeper-detail'
 import { formatDuration, trimText } from './mission-utils'
 import { namespaceTruth } from '../namespace-truth-store'
 import {
   keeperPhaseForDisplay,
   runtimeBandMeta,
   runtimeBandMetaForAgent,
+  summarizeMonitoringEvidence,
   summarizeKeeperMonitoring,
   type RuntimeBand,
 } from '../lib/monitoring-runtime'
@@ -55,6 +58,11 @@ interface KeeperInfo {
   model?: string | null
   current_work?: string | null
   last_turn_ago_s?: number | null
+  last_autonomous_action_at?: string | null
+  recent_tool_names?: string[]
+  latest_tool_names?: string[]
+  latest_tool_call_count?: number | null
+  tool_audit_at?: string | null
 }
 
 function findKeeper(agentName: string, keeperList: Keeper[], keeperBriefs: DashboardMissionKeeperBrief[]): KeeperInfo | null {
@@ -121,6 +129,20 @@ const FILTER_META: Record<StatusFilter, { label: string; description: string }> 
     label: '오프라인',
     description: '프로세스가 내려갔거나 아직 기동되지 않은 상태입니다.',
   },
+}
+
+function uniqueToolNames(...groups: Array<string[] | null | undefined>): string[] {
+  const seen = new Set<string>()
+  const names: string[] = []
+  for (const group of groups) {
+    for (const entry of group ?? []) {
+      const name = entry.trim()
+      if (!name || seen.has(name)) continue
+      seen.add(name)
+      names.push(name)
+    }
+  }
+  return names
 }
 
 function matchesKeeperFilter(
@@ -278,9 +300,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const briefMap = new Map<string, DashboardMissionAgentBrief>(
     briefs.map(brief => [brief.agent_name, brief] as const),
   )
-  const hasKeeperRuntime =
-    keeperFilter !== 'agent-only'
-    && (keeperList.length > 0 || keeperBriefs.length > 0 || runtimeCounts.keepers > 0)
   const scopedAgents = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, keeperFilter)
   const bandByAgent = new Map(
     scopedAgents.map(agent => [agent.name, runtimeBandMetaForAgent(agent, findKeeperRuntime(agent.name, keeperList))] as const),
@@ -289,12 +308,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     ? '키퍼 런타임'
     : keeperFilter === 'agent-only'
       ? '일반 에이전트'
-      : '에이전트 목록'
+      : '통합 런타임 목록'
   const pageDescription = keeperFilter === 'keeper-only'
-    ? '장기 컨텍스트를 유지하는 상주 런타임만 보여줍니다.'
+    ? '키퍼 런타임만 따로 봅니다.'
     : keeperFilter === 'agent-only'
-      ? '키퍼가 연결되지 않은 일반 에이전트만 보여줍니다.'
-      : '등록된 모든 런타임을 보여줍니다. 키퍼는 장기 컨텍스트를 유지하는 상주 런타임입니다.'
+      ? '키퍼가 연결되지 않은 일반 에이전트만 봅니다.'
+      : '에이전트와 키퍼를 한 목록에서 봅니다.'
 
   const filtered = scopedAgents
     .filter((a: Agent) => {
@@ -359,26 +378,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       : executionLoaded.value
         ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있고 일부만 상세 목록에 반영됐습니다.`
         : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다. execution 상세 projection이 올라오면 상태별 분류와 카드가 채워집니다.`
-  const legendCards = [
-    {
-      title: '운영 상태',
-      body: '가장 먼저 보는 값입니다. 가동중 / 주의 필요 / 일시정지 / 오프라인으로 운영 우선순위를 보여줍니다.',
-    },
-    {
-      title: 'Phase',
-      body: 'TLA lifecycle state입니다. Running, Failing, Paused, Restarting 같은 전이 근거를 그대로 보여줍니다.',
-    },
-    {
-      title: 'Stage',
-      body: '현재 턴에서 무엇을 하는지 보여주는 세부 활동 단계입니다. idle, thinking, tool, handoff를 분리해서 봅니다.',
-    },
-    ...(hasKeeperRuntime
-      ? [{
-          title: '세대 / 컨텍스트 사용량',
-          body: '세대는 키퍼 핸드오프가 일어날 때 올라가는 런타임 번호입니다. 컨텍스트 사용량은 현재 창을 얼마나 쓰고 있는지 보여줍니다.',
-        }]
-      : []),
-  ]
 
   return html`
     <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
@@ -411,7 +410,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
                 <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">운영 상태</div>
-                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">phase와 stage를 운영 관점으로 한 번 더 요약한 밴드입니다. 먼저 이상 신호를 모으고, 그다음 phase와 stage를 확인합니다.</p>
+                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 phase와 현재 활동 근거를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -440,18 +439,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
               `
             : null}
-
-          <details class="monitor-muted-panel px-4 py-3">
-            <summary class="cursor-pointer text-[11px] font-semibold text-[var(--text-muted)] uppercase tracking-wider select-none list-none">범례</summary>
-            <div class="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-              ${legendCards.map(card => html`
-                <div class="monitor-muted-panel px-3 py-3">
-                  <div class="text-[11px] font-semibold text-[var(--text-strong)]">${card.title}</div>
-                  <p class="m-0 mt-1.5 text-[11px] leading-[1.5] text-[var(--text-muted)]">${card.body}</p>
-                </div>
-              `)}
-            </div>
-          </details>
         </div>
       </section>
 
@@ -462,19 +449,68 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           const keeperRuntime = findKeeperRuntime(agent.name, keeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
+          const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
           const isKeeper = keeper != null
           const currentWork = keeper?.current_work ?? brief?.current_work ?? agent.current_task ?? null
-          const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
-          const ctxPct = keeper?.context_ratio != null ? Math.round(keeper.context_ratio * 100) : null
-          const workPreview = trimText(currentWork, 140) ?? '표시할 작업 정보가 없습니다.'
-          const lastActivityLabel = lastActivity != null ? `${formatDuration(lastActivity)} 전` : '활동 기록 없음'
+          const lastActivityAge = keeperRuntime?.last_activity_ago_s ?? keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
+          const lastActivityAt =
+            brief?.last_activity_at
+            ?? keeper?.last_autonomous_action_at
+            ?? keeperRuntime?.last_autonomous_action_at
+            ?? keeperRuntime?.last_heartbeat
+            ?? agent.last_seen
+            ?? null
+          const ctxPct = (keeperRuntime?.context_ratio ?? keeper?.context_ratio) != null
+            ? Math.round((keeperRuntime?.context_ratio ?? keeper?.context_ratio ?? 0) * 100)
+            : null
+          const workPreview =
+            trimText(currentWork, 140)
+            ?? trimText(brief?.recent_output_preview, 140)
+            ?? trimText(keeperRuntime?.recent_output_preview, 140)
+            ?? trimText(brief?.recent_input_preview, 140)
+            ?? trimText(keeperRuntime?.recent_input_preview, 140)
+            ?? '최근 활동 요약 없음'
+          const summaryText =
+            band.key === 'active'
+              ? workPreview
+              : keeperMonitoring?.hint ?? workPreview
+          const recentTools = uniqueToolNames(
+            brief?.recent_tool_names,
+            brief?.latest_tool_names,
+            keeperRuntime?.recent_tool_names,
+            keeperRuntime?.latest_tool_names,
+            keeper?.recent_tool_names,
+            keeper?.latest_tool_names,
+          )
+          const visibleTools = recentTools.slice(0, 2)
+          const hiddenToolCount = Math.max(0, recentTools.length - visibleTools.length)
+          const toolCallCount =
+            brief?.latest_tool_call_count
+            ?? keeper?.latest_tool_call_count
+            ?? keeperRuntime?.latest_tool_call_count
+            ?? null
+          const toolAuditAt =
+            brief?.tool_audit_at
+            ?? keeper?.tool_audit_at
+            ?? keeperRuntime?.tool_audit_at
+            ?? null
+          const model = keeperRuntime?.model ?? keeper?.model
+          const generation = keeperRuntime?.generation ?? keeper?.generation ?? null
+          const detailLabel = keeperRuntime ? `${agent.name} keeper 상세 보기` : `${agent.name} 상세 보기`
+          const openDetail = () => {
+            if (keeperRuntime) {
+              openKeeperDetail(keeperRuntime)
+              return
+            }
+            openAgentDetail(agent.name)
+          }
 
           return html`
             <button type="button"
               class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-4 rounded-[22px] p-5 text-left transition-all duration-200 cursor-pointer hover:border-[var(--border-slate-22)] hover:bg-[var(--bg-1)] hover:-translate-y-0.5"
               key=${agent.name}
-              aria-label=${`${agent.name} 상세 보기`}
-              onClick=${() => openAgentDetail(agent.name)}
+              aria-label=${detailLabel}
+              onClick=${openDetail}
             >
               <div class="flex items-start gap-4">
                 <div class="shrink-0 relative">
@@ -484,7 +520,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     traits=${agent.traits}
                     size="xl"
                     currentWork=${currentWork}
-                    activityAge=${lastActivity}
+                    activityAge=${lastActivityAge}
                   />
                 </div>
                 
@@ -495,20 +531,24 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
                     <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼 런타임' : '일반 에이전트'}</span>
                     ${agent.synthetic ? html`<span class="text-[10px] text-[var(--text-muted)] bg-[var(--white-6)] border border-dashed border-[var(--card-border)] px-1.5 py-px rounded italic" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">파생</span>` : null}
-                    ${keeperMonitoring ? html`<${KeeperPhaseBadge} phase=${keeperRuntime ? keeperPhaseForDisplay(keeperRuntime) : null} compact />` : null}
-                    ${keeperMonitoring ? html`<span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]" title=${keeperMonitoring.stage.description}>stage ${keeperMonitoring.stage.label}</span>` : null}
-                    ${keeper?.model ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${keeper.model}</span>` : null}
-                    ${keeper?.generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[var(--accent-10)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${keeper.generation}</span>` : null}
+                    ${monitoringEvidence?.phase && keeperRuntime ? html`<${KeeperPhaseBadge} phase=${keeperPhaseForDisplay(keeperRuntime)} compact />` : null}
+                    ${monitoringEvidence?.stage ? html`<span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]" title=${monitoringEvidence.stage.description}>활동 ${monitoringEvidence.stage.label}</span>` : null}
+                    ${model ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${model}</span>` : null}
+                    ${generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[var(--accent-10)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${generation}</span>` : null}
                   </div>
                 </div>
               </div>
 
               <div class="flex flex-1 flex-col gap-3 border-t border-[var(--border-slate-12)] pt-3">
-                <p class="m-0 text-[13px] leading-[1.5] text-[var(--text-body)] break-words line-clamp-3" title=${currentWork ?? ''}>${keeperMonitoring?.hint ?? workPreview}</p>
+                <p class="m-0 text-[13px] leading-[1.5] text-[var(--text-body)] break-words line-clamp-3" title=${summaryText}>${summaryText}</p>
 
                 <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
                   <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
-                    ${lastActivityLabel}
+                    최근 활동 ${lastActivityAt
+                      ? html`<${TimeAgo} timestamp=${lastActivityAt} />`
+                      : lastActivityAge != null
+                        ? `${formatDuration(lastActivityAge)} 전`
+                        : '기록 없음'}
                   </span>
                   ${isKeeper && ctxPct != null ? html`
                     <span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
@@ -520,6 +560,37 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     </span>
                   ` : null}
                 </div>
+
+                ${(visibleTools.length > 0 || toolCallCount != null || toolAuditAt) ? html`
+                  <div class="flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                    <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5">tool</span>
+                    ${visibleTools.map(name => html`
+                      <span class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-[10px] text-[var(--text-body)]">
+                        ${name}
+                      </span>
+                    `)}
+                    ${hiddenToolCount > 0 ? html`
+                      <span class="inline-flex items-center rounded-full border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                        +${hiddenToolCount}
+                      </span>
+                    ` : null}
+                    ${visibleTools.length === 0 && toolCallCount === 0 ? html`
+                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                        최근 도구 없음
+                      </span>
+                    ` : null}
+                    ${visibleTools.length === 0 && toolCallCount != null && toolCallCount > 0 ? html`
+                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                        도구 ${toolCallCount}회
+                      </span>
+                    ` : null}
+                    ${toolAuditAt ? html`
+                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                        감사 <${TimeAgo} timestamp=${toolAuditAt} />
+                      </span>
+                    ` : null}
+                  </div>
+                ` : null}
               </div>
             </button>
           `

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -20,9 +20,9 @@ type AgentsView = 'all' | 'agents' | 'keepers'
 const activeView = signal<AgentsView>('all')
 
 const CHIPS: { id: AgentsView; label: string; description: string }[] = [
-  { id: 'all', label: '전체 보기', description: '등록된 모든 런타임을 함께 봅니다.' },
+  { id: 'all', label: '전체 보기', description: '에이전트와 키퍼를 한 목록에서 봅니다.' },
   { id: 'agents', label: '일반 에이전트', description: '키퍼가 연결되지 않은 일반 에이전트만 봅니다.' },
-  { id: 'keepers', label: '키퍼 런타임', description: '장기 컨텍스트를 유지하는 상주 런타임만 봅니다.' },
+  { id: 'keepers', label: '키퍼 런타임', description: '키퍼 런타임만 따로 봅니다.' },
 ]
 
 export function AgentsUnified() {
@@ -60,7 +60,7 @@ export function AgentsUnified() {
   const currentViewMeta = CHIPS.find(chip => chip.id === currentView) ?? {
     id: 'all' as const,
     label: '전체 보기',
-    description: '등록된 모든 런타임을 함께 봅니다.',
+    description: '에이전트와 키퍼를 한 목록에서 봅니다.',
   }
 
   function chipCount(id: AgentsView): number | null {
@@ -72,10 +72,10 @@ export function AgentsUnified() {
 
   const currentViewSummary =
     currentView === 'all'
-      ? `일반 에이전트 ${agentOnlyCount}개와 키퍼 런타임 ${keeperCount}개를 함께 보여줍니다.`
+      ? `일반 에이전트 ${agentOnlyCount}개와 키퍼 런타임 ${keeperCount}개를 한 목록에서 봅니다.`
       : currentView === 'agents'
-        ? `지속 실행용 키퍼가 없는 일반 에이전트 ${agentOnlyCount}개만 표시합니다.`
-        : `장기 컨텍스트를 유지하는 키퍼 런타임 ${keeperCount}개만 표시합니다.`
+        ? `일반 에이전트 ${agentOnlyCount}개만 표시합니다.`
+        : `키퍼 런타임 ${keeperCount}개만 표시합니다.`
   const viewChips = CHIPS.map(chip => ({
     key: chip.id,
     label: chip.label,
@@ -97,26 +97,8 @@ export function AgentsUnified() {
       />
       <div class="monitor-muted-panel bg-[linear-gradient(180deg,var(--accent-soft),var(--white-2))] px-4 py-3 text-[12px] leading-[1.5] text-[var(--text-body)]">
         <strong class="mr-2 text-[var(--text-strong)]">${currentViewMeta.label}</strong>
-        <span>${currentViewMeta.description} ${currentViewSummary}</span>
+        <span>${currentViewSummary}</span>
       </div>
-
-      <details class="rounded-lg border border-card-border/30 bg-card/12 overflow-hidden">
-        <summary class="px-3 py-2 cursor-pointer text-[11px] text-text-muted hover:text-text-body transition-colors">모니터링 읽는 법</summary>
-        <div class="px-3 pb-3 grid gap-3 text-[11px] text-text-muted md:grid-cols-3">
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2.5">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-strong)]">운영 상태</div>
-            <p class="m-0 mt-1 leading-[1.5]">운영자가 먼저 볼 신호입니다. 가동중, 주의 필요, 일시정지, 오프라인으로 요약합니다.</p>
-          </div>
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2.5">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-strong)]">Phase</div>
-            <p class="m-0 mt-1 leading-[1.5]">keeper_state_machine의 TLA 라이프사이클 상태입니다. Running, Failing, Paused 같은 전이 근거를 보여줍니다.</p>
-          </div>
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2.5">
-            <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-strong)]">Stage</div>
-            <p class="m-0 mt-1 leading-[1.5]">현재 턴에서 무엇을 하는지 보여주는 활동 단계입니다. idle, thinking, tool, handoff를 분리해서 봅니다.</p>
-          </div>
-        </div>
-      </details>
 
       ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
 

--- a/dashboard/src/components/common/time-ago.ts
+++ b/dashboard/src/components/common/time-ago.ts
@@ -1,13 +1,43 @@
 // Relative time display — "2분 전", "3시간 전" 등.
 
+import { signal } from '@preact/signals'
 import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
 import { formatTimeAgo } from '../../lib/format-time'
 
 interface TimeAgoProps {
   timestamp: string | number
 }
 
+const CLOCK_TICK_MS = 30_000
+const relativeClock = signal(Date.now())
+let relativeClockTimer: number | null = null
+let relativeClockSubscribers = 0
+
+function startRelativeClock(): void {
+  if (relativeClockTimer != null || typeof window === 'undefined') return
+  relativeClockTimer = window.setInterval(() => {
+    relativeClock.value = Date.now()
+  }, CLOCK_TICK_MS)
+}
+
+function stopRelativeClock(): void {
+  if (relativeClockTimer == null || typeof window === 'undefined') return
+  window.clearInterval(relativeClockTimer)
+  relativeClockTimer = null
+}
+
 export function TimeAgo({ timestamp }: TimeAgoProps) {
+  useEffect(() => {
+    relativeClockSubscribers += 1
+    startRelativeClock()
+    return () => {
+      relativeClockSubscribers = Math.max(0, relativeClockSubscribers - 1)
+      if (relativeClockSubscribers === 0) stopRelativeClock()
+    }
+  }, [])
+
+  void relativeClock.value
   const text = formatTimeAgo(timestamp)
   const title =
     typeof timestamp === 'string'

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -62,7 +62,7 @@ function FleetSummary({ keepers }: { keepers: Keeper[] }) {
           value=${`${(avgCtx * 100).toFixed(0)}%`}
           tone=${avgCtx > CONTEXT_RATIO_CRITICAL ? 'warn' : avgCtx > CONTEXT_RATIO_FLEET_WARN ? 'paused' : 'ok'}
         />
-        <${MetricPill} label="최근 도구" value=${totalTools} />
+        ${totalTools > 0 ? html`<${MetricPill} label="최근 도구" value=${totalTools} />` : null}
         ${totalCompactions > 0 ? html`
           <${MetricPill}
             label="압축"

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -1,70 +1,10 @@
 import { html } from 'htm/preact'
 
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_FLEET_WARN } from '../config/constants'
-import { keeperPhaseForDisplay, summarizeKeeperMonitoring } from '../lib/monitoring-runtime'
+import { summarizeKeeperMonitoring } from '../lib/monitoring-runtime'
 import type { Keeper } from '../types/core'
-import { openKeeperDetail } from './keeper-detail'
-import { KeeperPhaseBadge } from './keeper-phase-indicator'
 
 type ToneKey = 'ok' | 'warn' | 'paused' | 'muted'
-
-interface ToneStyle {
-  text: string
-  bg: string
-  border: string
-}
-
-const BAND_STYLES: Record<string, ToneStyle> = {
-  active: { text: 'var(--ok)', bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.2)' },
-  attention: { text: 'var(--warn)', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.2)' },
-  paused: { text: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.22)' },
-  offline: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
-}
-
-const STAGE_STYLES: Record<string, ToneStyle> = {
-  thinking: { text: 'var(--accent)', bg: 'rgba(71,184,255,0.12)', border: 'rgba(71,184,255,0.2)' },
-  tool_use: { text: 'var(--ok)', bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.2)' },
-  compacting: { text: '#a855f7', bg: 'rgba(168,85,247,0.12)', border: 'rgba(168,85,247,0.2)' },
-  handoff: { text: '#f472b6', bg: 'rgba(244,114,182,0.12)', border: 'rgba(244,114,182,0.2)' },
-  scheduled_autonomous: { text: 'var(--accent)', bg: 'rgba(71,184,255,0.1)', border: 'rgba(71,184,255,0.18)' },
-  failing: { text: 'var(--warn)', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.2)' },
-  draining: { text: '#fb923c', bg: 'rgba(251,146,60,0.12)', border: 'rgba(251,146,60,0.2)' },
-  paused: { text: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.2)' },
-  restarting: { text: '#38bdf8', bg: 'rgba(56,189,248,0.12)', border: 'rgba(56,189,248,0.2)' },
-  crashed: { text: 'var(--bad)', bg: 'rgba(239,68,68,0.12)', border: 'rgba(239,68,68,0.2)' },
-  idle: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
-  offline: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
-}
-
-function pillStyle(tone: ToneStyle): string {
-  return `color:${tone.text};background:${tone.bg};border:1px solid ${tone.border};`
-}
-
-function ContextBar({ ratio }: { ratio: number | undefined }) {
-  const pct = (ratio ?? 0) * 100
-  const color = pct > 85 ? 'var(--bad)' : pct > 60 ? 'var(--warn)' : 'var(--ok)'
-  return html`
-    <div class="flex items-center gap-1.5">
-      <div class="flex-1 h-1.5 rounded-full bg-[var(--white-6)] overflow-hidden">
-        <div
-          class="h-full rounded-full transition-all duration-500"
-          style="width: ${pct.toFixed(0)}%; background: ${color}"
-        ></div>
-      </div>
-      <span class="text-[10px] font-mono w-8 text-right" style="color: ${color}">
-        ${pct > 0 ? `${pct.toFixed(0)}%` : '-'}
-      </span>
-    </div>
-  `
-}
-
-function formatRecency(agoS: number | undefined): string {
-  if (agoS == null) return '-'
-  if (agoS < 60) return `${Math.round(agoS)}초`
-  if (agoS < 3600) return `${Math.floor(agoS / 60)}분`
-  if (agoS < 86400) return `${Math.floor(agoS / 3600)}시간`
-  return `${Math.floor(agoS / 86400)}일`
-}
 
 function MetricPill({
   label,
@@ -89,68 +29,6 @@ function MetricPill({
       <span>${label}</span>
       <span class="font-mono text-[var(--text-strong)]">${value}</span>
     </span>
-  `
-}
-
-function KeeperRow({ keeper }: { keeper: Keeper }) {
-  const summary = summarizeKeeperMonitoring(keeper)
-  const bandTone = BAND_STYLES[summary.band.key] ?? BAND_STYLES.offline!
-  const stageTone = STAGE_STYLES[summary.stage.key] ?? STAGE_STYLES.offline!
-  const toolCount = keeper.latest_tool_call_count ?? keeper.metrics_window?.tool_call_count ?? 0
-
-  return html`
-    <button
-      type="button"
-      class="group grid w-full gap-3 rounded-2xl border border-[var(--card-border)] bg-[linear-gradient(180deg,var(--white-2),rgba(255,255,255,0.02))] px-4 py-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--accent-30)] hover:bg-[linear-gradient(180deg,var(--accent-soft),rgba(255,255,255,0.04))]"
-      onClick=${() => openKeeperDetail(keeper)}
-      aria-label=${`${keeper.name} keeper 상세 보기`}
-    >
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="min-w-0 flex-1">
-          <div class="flex flex-wrap items-center gap-2">
-            <span
-              class="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold tracking-[0.08em] uppercase"
-              style=${pillStyle(bandTone)}
-              title=${summary.band.description}
-            >${summary.band.label}</span>
-            <${KeeperPhaseBadge} phase=${keeperPhaseForDisplay(keeper)} compact />
-            <span
-              class="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-medium"
-              style=${pillStyle(stageTone)}
-              title=${summary.stage.description}
-            >stage ${summary.stage.label}</span>
-          </div>
-          <div class="mt-2 flex items-center gap-2">
-            <span class="truncate text-[15px] font-semibold text-[var(--text-strong)]">${keeper.name}</span>
-            ${keeper.model ? html`<span class="truncate rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-mono text-[var(--text-muted)]">${keeper.model}</span>` : null}
-          </div>
-          <p class="mt-2 mb-0 text-[12px] leading-[1.55] text-[var(--text-body)]">
-            ${summary.hint ?? summary.phase.description}
-          </p>
-        </div>
-
-        <div class="grid min-w-[208px] gap-2 text-[10px] text-[var(--text-muted)] sm:grid-cols-2">
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-            <div>컨텍스트</div>
-            <div class="mt-1"><${ContextBar} ratio=${keeper.context_ratio} /></div>
-          </div>
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-            <div>최근 활동</div>
-            <div class="mt-1 text-[12px] font-mono text-[var(--text-strong)]">${formatRecency(keeper.last_activity_ago_s)}</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="flex flex-wrap items-center gap-2">
-        <${MetricPill} label="Gen" value=${keeper.generation ?? 0} />
-        <${MetricPill} label="Turn" value=${keeper.turn_count ?? 0} />
-        <${MetricPill} label="Tool" value=${toolCount > 0 ? toolCount : '-'} />
-        ${keeper.runtime_blocker_class || keeper.last_blocker
-          ? html`<${MetricPill} label="Blocker" value="yes" tone="warn" />`
-          : null}
-        ${summary.band.key === 'paused' ? html`<${MetricPill} label="Pause" value="on" tone="paused" />` : null}
-      </div>
-    </button>
   `
 }
 
@@ -184,7 +62,7 @@ function FleetSummary({ keepers }: { keepers: Keeper[] }) {
           value=${`${(avgCtx * 100).toFixed(0)}%`}
           tone=${avgCtx > CONTEXT_RATIO_CRITICAL ? 'warn' : avgCtx > CONTEXT_RATIO_FLEET_WARN ? 'paused' : 'ok'}
         />
-        ${totalTools > 0 ? html`<${MetricPill} label="도구 호출" value=${totalTools} />` : null}
+        ${totalTools > 0 ? html`<${MetricPill} label="최근 도구" value=${totalTools} />` : null}
         ${totalCompactions > 0 ? html`
           <${MetricPill}
             label="압축"
@@ -200,34 +78,18 @@ function FleetSummary({ keepers }: { keepers: Keeper[] }) {
 export function KeeperFleetOverview({ keepers: allKeepers }: { keepers: Keeper[] }) {
   if (allKeepers.length === 0) return null
 
-  const sorted = [...allKeepers].sort((left, right) => {
-    const leftSummary = summarizeKeeperMonitoring(left)
-    const rightSummary = summarizeKeeperMonitoring(right)
-    const rank = { attention: 0, active: 1, paused: 2, offline: 3 }
-    if (rank[leftSummary.band.key] !== rank[rightSummary.band.key]) {
-      return rank[leftSummary.band.key] - rank[rightSummary.band.key]
-    }
-    return (left.last_activity_ago_s ?? Number.POSITIVE_INFINITY) - (right.last_activity_ago_s ?? Number.POSITIVE_INFINITY)
-  })
-
   return html`
     <section class="monitor-surface-card monitor-surface-card-medium mb-6 p-4 md:p-5">
       <div class="flex flex-col gap-4">
-        <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-          <div class="min-w-0">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Keeper 운영판</div>
-            <h3 class="m-0 mt-1 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">먼저 볼 것은 state가 아니라 운영 상태입니다</h3>
-            <p class="m-0 mt-2 max-w-[720px] text-[12px] leading-[1.6] text-[var(--text-body)]">
-              가동중, 주의 필요, 일시정지, 오프라인은 운영 우선순위이고, 그 아래의 phase와 stage는 왜 그런지 설명하는 근거입니다.
-            </p>
-          </div>
+        <div class="flex flex-col gap-1.5">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">키퍼 운영 요약</div>
+          <h3 class="m-0 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">키퍼 fleet 상태만 먼저 요약합니다</h3>
+          <p class="m-0 max-w-[720px] text-[12px] leading-[1.6] text-[var(--text-body)]">
+            여기서는 fleet 상태만 요약하고, 상세 확인은 아래 통합 목록에서 같은 기준으로 이어서 봅니다.
+          </p>
         </div>
 
         <${FleetSummary} keepers=${allKeepers} />
-
-        <div class="grid gap-3">
-          ${sorted.map(keeper => html`<${KeeperRow} key=${keeper.name} keeper=${keeper} />`)}
-        </div>
       </div>
     </section>
   `

--- a/dashboard/src/components/keeper-fleet-overview.ts
+++ b/dashboard/src/components/keeper-fleet-overview.ts
@@ -1,70 +1,10 @@
 import { html } from 'htm/preact'
 
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_FLEET_WARN } from '../config/constants'
-import { keeperPhaseForDisplay, summarizeKeeperMonitoring } from '../lib/monitoring-runtime'
+import { summarizeKeeperMonitoring } from '../lib/monitoring-runtime'
 import type { Keeper } from '../types/core'
-import { openKeeperDetail } from './keeper-detail'
-import { KeeperPhaseBadge } from './keeper-phase-indicator'
 
 type ToneKey = 'ok' | 'warn' | 'paused' | 'muted'
-
-interface ToneStyle {
-  text: string
-  bg: string
-  border: string
-}
-
-const BAND_STYLES: Record<string, ToneStyle> = {
-  active: { text: 'var(--ok)', bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.2)' },
-  attention: { text: 'var(--warn)', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.2)' },
-  paused: { text: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.22)' },
-  offline: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
-}
-
-const STAGE_STYLES: Record<string, ToneStyle> = {
-  thinking: { text: 'var(--accent)', bg: 'rgba(71,184,255,0.12)', border: 'rgba(71,184,255,0.2)' },
-  tool_use: { text: 'var(--ok)', bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.2)' },
-  compacting: { text: '#a855f7', bg: 'rgba(168,85,247,0.12)', border: 'rgba(168,85,247,0.2)' },
-  handoff: { text: '#f472b6', bg: 'rgba(244,114,182,0.12)', border: 'rgba(244,114,182,0.2)' },
-  scheduled_autonomous: { text: 'var(--accent)', bg: 'rgba(71,184,255,0.1)', border: 'rgba(71,184,255,0.18)' },
-  failing: { text: 'var(--warn)', bg: 'rgba(251,191,36,0.12)', border: 'rgba(251,191,36,0.2)' },
-  draining: { text: '#fb923c', bg: 'rgba(251,146,60,0.12)', border: 'rgba(251,146,60,0.2)' },
-  paused: { text: '#a78bfa', bg: 'rgba(167,139,250,0.12)', border: 'rgba(167,139,250,0.2)' },
-  restarting: { text: '#38bdf8', bg: 'rgba(56,189,248,0.12)', border: 'rgba(56,189,248,0.2)' },
-  crashed: { text: 'var(--bad)', bg: 'rgba(239,68,68,0.12)', border: 'rgba(239,68,68,0.2)' },
-  idle: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
-  offline: { text: 'var(--text-dim)', bg: 'var(--white-4)', border: 'var(--white-8)' },
-}
-
-function pillStyle(tone: ToneStyle): string {
-  return `color:${tone.text};background:${tone.bg};border:1px solid ${tone.border};`
-}
-
-function ContextBar({ ratio }: { ratio: number | undefined }) {
-  const pct = (ratio ?? 0) * 100
-  const color = pct > 85 ? 'var(--bad)' : pct > 60 ? 'var(--warn)' : 'var(--ok)'
-  return html`
-    <div class="flex items-center gap-1.5">
-      <div class="flex-1 h-1.5 rounded-full bg-[var(--white-6)] overflow-hidden">
-        <div
-          class="h-full rounded-full transition-all duration-500"
-          style="width: ${pct.toFixed(0)}%; background: ${color}"
-        ></div>
-      </div>
-      <span class="text-[10px] font-mono w-8 text-right" style="color: ${color}">
-        ${pct > 0 ? `${pct.toFixed(0)}%` : '-'}
-      </span>
-    </div>
-  `
-}
-
-function formatRecency(agoS: number | undefined): string {
-  if (agoS == null) return '-'
-  if (agoS < 60) return `${Math.round(agoS)}초`
-  if (agoS < 3600) return `${Math.floor(agoS / 60)}분`
-  if (agoS < 86400) return `${Math.floor(agoS / 3600)}시간`
-  return `${Math.floor(agoS / 86400)}일`
-}
 
 function MetricPill({
   label,
@@ -89,66 +29,6 @@ function MetricPill({
       <span>${label}</span>
       <span class="font-mono text-[var(--text-strong)]">${value}</span>
     </span>
-  `
-}
-
-function KeeperRow({ keeper }: { keeper: Keeper }) {
-  const summary = summarizeKeeperMonitoring(keeper)
-  const bandTone = BAND_STYLES[summary.band.key] ?? BAND_STYLES.offline!
-  const stageTone = STAGE_STYLES[summary.stage.key] ?? STAGE_STYLES.offline!
-  const toolCount = keeper.latest_tool_call_count ?? keeper.metrics_window?.tool_call_count ?? 0
-
-  return html`
-    <button
-      type="button"
-      class="group grid w-full gap-3 rounded-2xl border border-[var(--card-border)] bg-[linear-gradient(180deg,var(--white-2),rgba(255,255,255,0.02))] px-4 py-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-[var(--accent-30)] hover:bg-[linear-gradient(180deg,var(--accent-soft),rgba(255,255,255,0.04))]"
-      onClick=${() => openKeeperDetail(keeper)}
-      aria-label=${`${keeper.name} keeper 상세 보기`}
-    >
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="min-w-0 flex-1">
-          <div class="flex flex-wrap items-center gap-2">
-            <span
-              class="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold tracking-[0.08em] uppercase"
-              style=${pillStyle(bandTone)}
-              title=${summary.band.description}
-            >${summary.band.label}</span>
-            <${KeeperPhaseBadge} phase=${keeperPhaseForDisplay(keeper)} compact />
-            <span
-              class="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-medium"
-              style=${pillStyle(stageTone)}
-              title=${summary.stage.description}
-            >stage ${summary.stage.label}</span>
-          </div>
-          <div class="mt-2 flex items-center gap-2">
-            <span class="truncate text-[15px] font-semibold text-[var(--text-strong)]">${keeper.name}</span>
-            ${keeper.model ? html`<span class="truncate rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-mono text-[var(--text-muted)]">${keeper.model}</span>` : null}
-          </div>
-          <p class="mt-2 mb-0 text-[12px] leading-[1.55] text-[var(--text-body)]">
-            ${summary.hint ?? summary.phase.description}
-          </p>
-        </div>
-
-        <div class="grid min-w-[208px] gap-2 text-[10px] text-[var(--text-muted)] sm:grid-cols-2">
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-            <div>컨텍스트</div>
-            <div class="mt-1"><${ContextBar} ratio=${keeper.context_ratio} /></div>
-          </div>
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
-            <div>최근 활동</div>
-            <div class="mt-1 text-[12px] font-mono text-[var(--text-strong)]">${formatRecency(keeper.last_activity_ago_s)}</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="flex flex-wrap items-center gap-2">
-        <${MetricPill} label="Gen" value=${keeper.generation ?? 0} />
-        <${MetricPill} label="Turn" value=${keeper.turn_count ?? 0} />
-        <${MetricPill} label="Tool" value=${toolCount > 0 ? toolCount : '-'} />
-        ${keeper.last_blocker ? html`<${MetricPill} label="Blocker" value="yes" tone="warn" />` : null}
-        ${summary.band.key === 'paused' ? html`<${MetricPill} label="Pause" value="on" tone="paused" />` : null}
-      </div>
-    </button>
   `
 }
 
@@ -182,7 +62,7 @@ function FleetSummary({ keepers }: { keepers: Keeper[] }) {
           value=${`${(avgCtx * 100).toFixed(0)}%`}
           tone=${avgCtx > CONTEXT_RATIO_CRITICAL ? 'warn' : avgCtx > CONTEXT_RATIO_FLEET_WARN ? 'paused' : 'ok'}
         />
-        ${totalTools > 0 ? html`<${MetricPill} label="도구 호출" value=${totalTools} />` : null}
+        <${MetricPill} label="최근 도구" value=${totalTools} />
         ${totalCompactions > 0 ? html`
           <${MetricPill}
             label="압축"
@@ -198,34 +78,18 @@ function FleetSummary({ keepers }: { keepers: Keeper[] }) {
 export function KeeperFleetOverview({ keepers: allKeepers }: { keepers: Keeper[] }) {
   if (allKeepers.length === 0) return null
 
-  const sorted = [...allKeepers].sort((left, right) => {
-    const leftSummary = summarizeKeeperMonitoring(left)
-    const rightSummary = summarizeKeeperMonitoring(right)
-    const rank = { attention: 0, active: 1, paused: 2, offline: 3 }
-    if (rank[leftSummary.band.key] !== rank[rightSummary.band.key]) {
-      return rank[leftSummary.band.key] - rank[rightSummary.band.key]
-    }
-    return (left.last_activity_ago_s ?? Number.POSITIVE_INFINITY) - (right.last_activity_ago_s ?? Number.POSITIVE_INFINITY)
-  })
-
   return html`
     <section class="monitor-surface-card monitor-surface-card-medium mb-6 p-4 md:p-5">
       <div class="flex flex-col gap-4">
-        <div class="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-          <div class="min-w-0">
-            <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">Keeper 운영판</div>
-            <h3 class="m-0 mt-1 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">먼저 볼 것은 state가 아니라 운영 상태입니다</h3>
-            <p class="m-0 mt-2 max-w-[720px] text-[12px] leading-[1.6] text-[var(--text-body)]">
-              가동중, 주의 필요, 일시정지, 오프라인은 운영 우선순위이고, 그 아래의 phase와 stage는 왜 그런지 설명하는 근거입니다.
-            </p>
-          </div>
+        <div class="flex flex-col gap-1.5">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">키퍼 운영 요약</div>
+          <h3 class="m-0 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">키퍼 fleet 상태만 먼저 요약합니다</h3>
+          <p class="m-0 max-w-[720px] text-[12px] leading-[1.6] text-[var(--text-body)]">
+            여기서는 fleet 상태만 요약하고, 상세 확인은 아래 통합 목록에서 같은 기준으로 이어서 봅니다.
+          </p>
         </div>
 
         <${FleetSummary} keepers=${allKeepers} />
-
-        <div class="grid gap-3">
-          ${sorted.map(keeper => html`<${KeeperRow} key=${keeper.name} keeper=${keeper} />`)}
-        </div>
       </div>
     </section>
   `

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -123,7 +123,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'agents',
       label: '에이전트 & 키퍼',
-      description: '에이전트 = 작업 수행 프로세스. 키퍼 = 장기 컨텍스트를 유지하는 상주 런타임.',
+      description: '통합 런타임 상태.',
       params: { section: 'agents' },
     },
     {

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -4,6 +4,7 @@ import type { Agent, Keeper } from '../types'
 import {
   keeperPhaseForDisplay,
   runtimeBandForAgent,
+  summarizeMonitoringEvidence,
   summarizeKeeperMonitoring,
 } from './monitoring-runtime'
 
@@ -29,7 +30,11 @@ describe('summarizeKeeperMonitoring', () => {
 
     expect(summary.band.key).toBe('active')
     expect(summary.phase.label).toBe('실행중')
-    expect(summary.stage.label).toBe('대기')
+    expect(summary.stage.label).toBe('활동 없음')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: null,
+    })
   })
 
   it('promotes paused keepers into the paused operator band', () => {
@@ -45,6 +50,10 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('paused')
     expect(summary.phase.label).toBe('일시정지')
     expect(summary.stage.label).toBe('일시정지')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: null,
+    })
   })
 
   it('prefers paused display phase even when backend phase still says Running', () => {
@@ -71,6 +80,27 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('attention')
     expect(summary.phase.label).toBe('오류중')
     expect(summary.hint).toContain('오류')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: summary.phase,
+      stage: null,
+    })
+  })
+
+  it('does not repeat Running as evidence when attention comes from another signal', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        last_blocker: 'heartbeat stale',
+      }),
+    )
+
+    expect(summary.band.key).toBe('attention')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: null,
+    })
   })
 
   it('keeps never-booted keepers in the offline band', () => {
@@ -87,6 +117,21 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('offline')
     expect(summary.phase.label).toBe('오프라인')
     expect(summary.hint).toContain('부팅')
+  })
+
+  it('keeps active stages only when they add new activity context', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'tool_use',
+      }),
+    )
+
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: summary.stage,
+    })
   })
 })
 

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -133,6 +133,22 @@ describe('summarizeKeeperMonitoring', () => {
       stage: summary.stage,
     })
   })
+
+  it('suppresses stage evidence when it matches the same lifecycle reason as phase', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Compacting',
+        pipeline_stage: 'compacting',
+      }),
+    )
+
+    expect(summary.band.key).toBe('attention')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: summary.phase,
+      stage: null,
+    })
+  })
 })
 
 describe('runtimeBandForAgent', () => {

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -4,6 +4,7 @@ import type { Agent, Keeper } from '../types'
 import {
   keeperPhaseForDisplay,
   runtimeBandForAgent,
+  summarizeMonitoringEvidence,
   summarizeKeeperMonitoring,
 } from './monitoring-runtime'
 
@@ -29,7 +30,11 @@ describe('summarizeKeeperMonitoring', () => {
 
     expect(summary.band.key).toBe('active')
     expect(summary.phase.label).toBe('실행중')
-    expect(summary.stage.label).toBe('대기')
+    expect(summary.stage.label).toBe('활동 없음')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: null,
+    })
   })
 
   it('promotes paused keepers into the paused operator band', () => {
@@ -45,6 +50,10 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('paused')
     expect(summary.phase.label).toBe('일시정지')
     expect(summary.stage.label).toBe('일시정지')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: null,
+    })
   })
 
   it('prefers paused display phase even when backend phase still says Running', () => {
@@ -71,6 +80,27 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('attention')
     expect(summary.phase.label).toBe('오류중')
     expect(summary.hint).toContain('오류')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: summary.phase,
+      stage: null,
+    })
+  })
+
+  it('does not repeat Running as evidence when attention comes from another signal', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        last_blocker: 'heartbeat stale',
+      }),
+    )
+
+    expect(summary.band.key).toBe('attention')
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: null,
+    })
   })
 
   it('prioritizes structured runtime blockers over generic social blockers', () => {
@@ -106,6 +136,21 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.band.key).toBe('offline')
     expect(summary.phase.label).toBe('오프라인')
     expect(summary.hint).toContain('부팅')
+  })
+
+  it('keeps active stages only when they add new activity context', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'tool_use',
+      }),
+    )
+
+    expect(summarizeMonitoringEvidence(summary)).toEqual({
+      phase: null,
+      stage: summary.stage,
+    })
   })
 })
 

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -28,6 +28,11 @@ export interface KeeperMonitoringSummary {
   hint: string | null
 }
 
+export interface MonitoringEvidence {
+  phase: PhaseMeta | null
+  stage: StageMeta | null
+}
+
 const HEARTBEAT_STALE_MS = 5 * 60 * 1000
 const CONTEXT_ATTENTION_RATIO = 0.85
 
@@ -84,7 +89,7 @@ const PHASE_LABELS: Record<string, PhaseMeta> = {
 }
 
 const STAGE_LABELS: Record<string, StageMeta> = {
-  idle: { key: 'idle', label: '대기', description: '현재 턴에서 진행 중인 세부 단계가 없습니다.' },
+  idle: { key: 'idle', label: '활동 없음', description: '지금 진행 중인 세부 활동 단계가 없습니다.' },
   thinking: { key: 'thinking', label: '사고', description: '응답이나 다음 액션을 결정하는 중입니다.' },
   tool_use: { key: 'tool_use', label: '도구', description: '도구를 호출하거나 결과를 소비하는 중입니다.' },
   compacting: { key: 'compacting', label: '압축', description: '컨텍스트 압축 단계를 수행 중입니다.' },
@@ -96,6 +101,22 @@ const STAGE_LABELS: Record<string, StageMeta> = {
   crashed: { key: 'crashed', label: '중단', description: '파이프라인 실행이 비정상 종료되었습니다.' },
   restarting: { key: 'restarting', label: '재시작', description: '파이프라인을 다시 올리는 중입니다.' },
   offline: OFFLINE_STAGE_META,
+}
+
+const DEFAULT_PHASE_BY_BAND: Partial<Record<RuntimeBand, string>> = {
+  active: 'Running',
+  paused: 'Paused',
+  offline: 'Offline',
+}
+
+const STAGE_PHASE_EQUIVALENTS: Record<string, string> = {
+  compacting: 'Compacting',
+  handoff: 'HandingOff',
+  failing: 'Failing',
+  draining: 'Draining',
+  paused: 'Paused',
+  crashed: 'Crashed',
+  restarting: 'Restarting',
 }
 
 const BAND_META: Record<RuntimeBand, RuntimeBandMeta> = {
@@ -227,7 +248,8 @@ function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string
   if (band === 'offline' && keeper.generation === 0 && (keeper.turn_count ?? 0) === 0) {
     return '아직 부팅된 적 없는 등록 런타임입니다.'
   }
-  return stage.key === 'idle' ? '현재 활동 단계는 비어 있습니다.' : stage.description
+  if (stage.key === 'idle' || stage.key === 'offline') return null
+  return stage.description
 }
 
 export function summarizeKeeperMonitoring(keeper: Keeper): KeeperMonitoringSummary {
@@ -242,6 +264,25 @@ export function summarizeKeeperMonitoring(keeper: Keeper): KeeperMonitoringSumma
     stage,
     hint: keeperHint(keeper, band.key, stage),
   }
+}
+
+export function summarizeMonitoringEvidence(summary: KeeperMonitoringSummary): MonitoringEvidence {
+  const defaultPhase = DEFAULT_PHASE_BY_BAND[summary.band.key]
+  const phase =
+    summary.phase.key === 'unknown' || summary.phase.key === 'Running' || summary.phase.key === defaultPhase
+      ? null
+      : summary.phase
+
+  const stageMatchesPhase = STAGE_PHASE_EQUIVALENTS[summary.stage.key] === summary.phase.key
+  const stage =
+    summary.stage.key === 'idle'
+    || summary.stage.key === 'offline'
+    || (summary.band.key === 'paused' && summary.stage.key === 'paused')
+    || stageMatchesPhase
+      ? null
+      : summary.stage
+
+  return { phase, stage }
 }
 
 function agentBand(status: string | undefined | null): RuntimeBand {

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -28,6 +28,11 @@ export interface KeeperMonitoringSummary {
   hint: string | null
 }
 
+export interface MonitoringEvidence {
+  phase: PhaseMeta | null
+  stage: StageMeta | null
+}
+
 const HEARTBEAT_STALE_MS = 5 * 60 * 1000
 const CONTEXT_ATTENTION_RATIO = 0.85
 
@@ -84,7 +89,7 @@ const PHASE_LABELS: Record<string, PhaseMeta> = {
 }
 
 const STAGE_LABELS: Record<string, StageMeta> = {
-  idle: { key: 'idle', label: '대기', description: '현재 턴에서 진행 중인 세부 단계가 없습니다.' },
+  idle: { key: 'idle', label: '활동 없음', description: '지금 진행 중인 세부 활동 단계가 없습니다.' },
   thinking: { key: 'thinking', label: '사고', description: '응답이나 다음 액션을 결정하는 중입니다.' },
   tool_use: { key: 'tool_use', label: '도구', description: '도구를 호출하거나 결과를 소비하는 중입니다.' },
   compacting: { key: 'compacting', label: '압축', description: '컨텍스트 압축 단계를 수행 중입니다.' },
@@ -96,6 +101,22 @@ const STAGE_LABELS: Record<string, StageMeta> = {
   crashed: { key: 'crashed', label: '중단', description: '파이프라인 실행이 비정상 종료되었습니다.' },
   restarting: { key: 'restarting', label: '재시작', description: '파이프라인을 다시 올리는 중입니다.' },
   offline: OFFLINE_STAGE_META,
+}
+
+const DEFAULT_PHASE_BY_BAND: Partial<Record<RuntimeBand, string>> = {
+  active: 'Running',
+  paused: 'Paused',
+  offline: 'Offline',
+}
+
+const STAGE_PHASE_EQUIVALENTS: Record<string, string> = {
+  compacting: 'Compacting',
+  handoff: 'HandingOff',
+  failing: 'Failing',
+  draining: 'Draining',
+  paused: 'Paused',
+  crashed: 'Crashed',
+  restarting: 'Restarting',
 }
 
 const BAND_META: Record<RuntimeBand, RuntimeBandMeta> = {
@@ -214,7 +235,8 @@ function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string
   if (band === 'offline' && keeper.generation === 0 && (keeper.turn_count ?? 0) === 0) {
     return '아직 부팅된 적 없는 등록 런타임입니다.'
   }
-  return stage.key === 'idle' ? '현재 활동 단계는 비어 있습니다.' : stage.description
+  if (stage.key === 'idle' || stage.key === 'offline') return null
+  return stage.description
 }
 
 export function summarizeKeeperMonitoring(keeper: Keeper): KeeperMonitoringSummary {
@@ -229,6 +251,25 @@ export function summarizeKeeperMonitoring(keeper: Keeper): KeeperMonitoringSumma
     stage,
     hint: keeperHint(keeper, band.key, stage),
   }
+}
+
+export function summarizeMonitoringEvidence(summary: KeeperMonitoringSummary): MonitoringEvidence {
+  const defaultPhase = DEFAULT_PHASE_BY_BAND[summary.band.key]
+  const phase =
+    summary.phase.key === 'unknown' || summary.phase.key === 'Running' || summary.phase.key === defaultPhase
+      ? null
+      : summary.phase
+
+  const stageMatchesPhase = STAGE_PHASE_EQUIVALENTS[summary.stage.key] === summary.phase.key
+  const stage =
+    summary.stage.key === 'idle'
+    || summary.stage.key === 'offline'
+    || (summary.band.key === 'paused' && summary.stage.key === 'paused')
+    || stageMatchesPhase
+      ? null
+      : summary.stage
+
+  return { phase, stage }
 }
 
 function agentBand(status: string | undefined | null): RuntimeBand {


### PR DESCRIPTION
## Summary
- simplify the monitoring agents page into one runtime list instead of duplicating keeper rows above and below
- prioritize operator-facing runtime bands and suppress duplicate phase/stage labels when they do not add new evidence
- surface recent activity and observed tool audit on cards, and refresh relative timestamps on a live clock

## Product impact
- the agents/keepers screen is easier to scan because `가동중`, `주의 필요`, `일시정지`, and `오프라인` stay as the first signal
- keeper rows opened from the unified roster now go straight to keeper detail, matching operator intent
- recent activity labels no longer look frozen while the page remains open

## Evidence
- `pnpm typecheck`
- `pnpm test src/lib/monitoring-runtime.test.ts src/components/agent-roster.test.ts`
- verified in browser at `http://127.0.0.1:5177/dashboard/#monitoring?section=agents`

## Review evidence
- direct `sb glm-text` review with `GLM-5.1` on 2026-04-09 16:11 KST surfaced two minor items: the fleet summary showed a zero-value tool pill and `stageMatchesPhase` lacked direct test coverage
- patched those follow-ups in `825579cf0` and re-ran `pnpm typecheck` plus `pnpm test src/lib/monitoring-runtime.test.ts src/components/agent-roster.test.ts`
- a second `GLM-5.1` pass on 2026-04-09 16:13 KST raised only non-blocking observations; no high or critical findings remained

## Linked issue
- none
