### PR TITLE
feat(dashboard): improve fleet telemetry panel

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fetchDashboardTools } from './dashboard'
+import { fetchDashboardTools, fetchToolQuality } from './dashboard'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -74,5 +74,33 @@ describe('fetchDashboardTools', () => {
 
     const result = await fetchDashboardTools()
     expect(result.tool_inventory).toBeDefined()
+  })
+})
+
+describe('fetchToolQuality', () => {
+  it('passes through the requested sample window', async () => {
+    const rawResponse = {
+      total: 1,
+      success: 1,
+      failure: 0,
+      success_rate: 100,
+      by_tool: [],
+      by_keeper: [],
+      failure_categories: [],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchToolQuality({ n: 250 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?n=250')
+    expect(result.total).toBe(1)
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -169,6 +169,51 @@ export function fetchDashboardExecution(): Promise<DashboardExecutionResponse> {
   return get('/api/v1/dashboard/execution')
 }
 
+export type ToolQualityToolStat = {
+  name: string
+  calls: number
+  success_pct: number
+  avg_ms: number
+  output_truncated_count?: number
+  avg_output_chars?: number
+}
+
+export type ToolQualityKeeperStat = {
+  name: string
+  calls: number
+  success_pct: number
+}
+
+export type ToolQualityFailureCategory = {
+  category: string
+  count: number
+}
+
+export type ToolQualityHourlyPoint = {
+  hour: string
+  calls: number
+  success: number
+  success_rate: number
+}
+
+export type ToolQualityResponse = {
+  total: number
+  success: number
+  failure: number
+  success_rate: number
+  by_tool: ToolQualityToolStat[]
+  by_keeper: ToolQualityKeeperStat[]
+  failure_categories: ToolQualityFailureCategory[]
+  hourly_trend?: ToolQualityHourlyPoint[]
+}
+
+export function fetchToolQuality(opts?: { n?: number }): Promise<ToolQualityResponse> {
+  const params = new URLSearchParams()
+  if (opts?.n != null) params.set('n', String(opts.n))
+  const qs = params.toString()
+  return get<ToolQualityResponse>(`/api/v1/dashboard/tool-quality${qs ? `?${qs}` : ''}`)
+}
+
 export interface DashboardPerfRow {
   benchmark: string
   avg_ms: number

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -1,0 +1,171 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TelemetrySummaryResponse, ToolQualityResponse } from '../api/dashboard'
+import type { DashboardExecutionResponse } from '../types'
+
+const executionResponse = {
+  generated_at: '2026-04-09T08:10:00Z',
+  keepers: [
+    {
+      name: 'keeper-alpha',
+      status: 'active',
+      keepalive_running: true,
+      context_ratio: 0.82,
+      total_turns: 48,
+      last_latency_ms: 2300,
+      last_activity_ago_s: 30,
+      last_model_used: 'gpt-5.4',
+      recent_tool_names: ['masc_status', 'masc_dashboard'],
+    },
+    {
+      name: 'keeper-beta',
+      status: 'idle',
+      keepalive_running: true,
+      context_ratio: 0.12,
+      total_turns: 9,
+      last_latency_ms: 980,
+      last_activity_ago_s: 320,
+      last_model_used: 'glm-5',
+      recent_tool_names: [],
+    },
+  ],
+} satisfies DashboardExecutionResponse
+
+const toolQualityResponse: ToolQualityResponse = {
+  total: 22,
+  success: 21,
+  failure: 1,
+  success_rate: 95.5,
+  by_tool: [],
+  by_keeper: [
+    {
+      name: 'keeper-alpha',
+      calls: 22,
+      success_pct: 95.5,
+    },
+  ],
+  failure_categories: [
+    {
+      category: 'timeout',
+      count: 1,
+    },
+  ],
+  hourly_trend: [],
+}
+
+const telemetrySummaryResponse: TelemetrySummaryResponse = {
+  generated_at: '2026-04-09T08:11:00Z',
+  total_entries: 321,
+  sources: [
+    {
+      source: 'keeper_metric',
+      entry_count: 200,
+      keeper_count: 2,
+      exists: true,
+    },
+    {
+      source: 'tool_metric',
+      entry_count: 121,
+      exists: true,
+    },
+  ],
+}
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+    }
+  })
+}
+
+async function loadPanel(mocks: {
+  fetchDashboardExecution: () => Promise<DashboardExecutionResponse>
+  fetchToolQuality: () => Promise<ToolQualityResponse>
+  fetchTelemetrySummary: () => Promise<TelemetrySummaryResponse>
+}) {
+  vi.resetModules()
+  vi.doMock('../api/dashboard', () => ({
+    fetchDashboardExecution: mocks.fetchDashboardExecution,
+    fetchToolQuality: mocks.fetchToolQuality,
+    fetchTelemetrySummary: mocks.fetchTelemetrySummary,
+  }))
+  return import('./fleet-telemetry-panel')
+}
+
+describe('FleetTelemetryPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard')
+  })
+
+  it('renders the full fleet even when tool telemetry exists for only one keeper', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue(executionResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue(toolQualityResponse)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchDashboardExecution).toHaveBeenCalledTimes(1)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(1)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('Fleet Coverage')
+    expect(container.textContent).toContain('1/2 keepers emitted recent tool telemetry.')
+    expect(container.textContent).toContain('keeper-alpha')
+    expect(container.textContent).toContain('keeper-beta')
+    expect(container.textContent).toContain('Keeper metrics')
+    expect(container.textContent).toContain('Failure Categories')
+  })
+
+  it('shows partial telemetry warnings while keeping degraded data visible', async () => {
+    const fetchDashboardExecution = vi.fn().mockRejectedValue(new Error('execution down'))
+    const fetchToolQuality = vi.fn().mockResolvedValue({
+      ...toolQualityResponse,
+      by_keeper: [
+        {
+          name: 'keeper-fallback',
+          calls: 3,
+          success_pct: 100,
+        },
+      ],
+    })
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('Partial telemetry')
+    expect(container.textContent).toContain('Execution snapshot unavailable: execution down')
+    expect(container.textContent).toContain('keeper-fallback')
+    expect(container.textContent).toContain('Telemetry Stores')
+  })
+})

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -1,266 +1,590 @@
-/**
- * Fleet Telemetry Panel — cross-keeper comparison dashboard.
- *
- * Shows: error categories, fleet tok/sec + latency, model cascade
- * distribution, and compaction timeline. Uses existing API endpoints.
- *
- * @since 2.262.0
- */
 import { html } from 'htm/preact'
-import { signal, type Signal } from '@preact/signals'
+import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { fetchKeeperConfig } from '../api/dashboard'
-import type { KeeperConfigMetrics } from '../types/core'
+import {
+  fetchDashboardExecution,
+  fetchTelemetrySummary,
+  fetchToolQuality,
+  type TelemetrySourceSummary,
+  type ToolQualityResponse,
+} from '../api/dashboard'
+import { normalizeKeepers } from '../keeper-store-normalize'
+import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
+import type { Keeper } from '../types'
 
-// ── Types ─────────────────────────────────────────────────
+const PRESSURE_HOT_RATIO = 0.75
+const PRESSURE_WARN_RATIO = 0.5
+const STALE_ACTIVITY_SEC = 900
 
-interface KeeperFleetEntry {
+const SOURCE_LABELS: Record<string, string> = {
+  keeper_metric: 'Keeper metrics',
+  agent_event: 'Agent events',
+  tool_call_io: 'Tool call I/O',
+  tool_usage: 'Tool usage',
+  tool_metric: 'Tool metrics',
+}
+
+interface FleetRow {
   name: string
-  metrics: KeeperConfigMetrics
-  cascade_name: string
-  model_used: string
+  status: string
+  keepalive_running: boolean
   context_ratio: number
-  compaction_count: number
+  turn_count: number
+  last_latency_ms: number
+  last_activity_ago_s: number | null
+  model: string
+  tool_calls: number
+  tool_success_pct: number | null
+  recent_tools: string[]
 }
 
-interface ToolQualityData {
-  total: number
-  success: number
-  failure: number
-  success_rate: number
-  by_tool: Array<{ name: string; calls: number; success_pct: number; avg_ms: number }>
-  by_keeper: Array<{ name: string; calls: number; success_pct: number }>
-  failure_categories: Array<{ category: string; count: number }>
+interface FleetTelemetryState {
+  loading: boolean
+  error: string | null
+  warnings: string[]
+  rows: FleetRow[]
+  tool_quality: ToolQualityResponse
+  telemetry_sources: TelemetrySourceSummary[]
+  total_telemetry_entries: number
+  updated_at: string | null
 }
 
-// ── State ─────────────────────────────────────────────────
+const EMPTY_TOOL_QUALITY: ToolQualityResponse = {
+  total: 0,
+  success: 0,
+  failure: 0,
+  success_rate: 0,
+  by_tool: [],
+  by_keeper: [],
+  failure_categories: [],
+  hourly_trend: [],
+}
 
-const fleet: Signal<KeeperFleetEntry[]> = signal([])
-const toolQuality: Signal<ToolQualityData | null> = signal(null)
-const loading: Signal<boolean> = signal(false)
-const error: Signal<string | null> = signal(null)
-
-async function fetchFleetData() {
-  loading.value = true
-  error.value = null
-  try {
-    // 1. Get keeper names from tool quality (already has by_keeper)
-    const tqResp = await fetch('/api/v1/dashboard/tool-quality?n=5000')
-    if (!tqResp.ok) throw new Error(`tool-quality: HTTP ${tqResp.status}`)
-    const tq: ToolQualityData = await tqResp.json()
-    toolQuality.value = tq
-
-    // 2. Fetch each keeper's config for metrics
-    const keeperNames = tq.by_keeper.map(k => k.name)
-    const entries: KeeperFleetEntry[] = []
-    const configs = await Promise.allSettled(
-      keeperNames.map(name => fetchKeeperConfig(name))
-    )
-    for (let i = 0; i < keeperNames.length; i++) {
-      const settled = configs[i]
-      if (settled && settled.status === 'fulfilled') {
-        const cfg = settled.value as unknown as Record<string, unknown>
-        const m = cfg.metrics as KeeperConfigMetrics | undefined
-        if (m) {
-          const cascadeName = (cfg.cascade_name as string) ?? ''
-          entries.push({
-            name: keeperNames[i] ?? 'unknown',
-            metrics: m,
-            cascade_name: cascadeName,
-            model_used: m.last_model_used || cascadeName || '',
-            context_ratio: ((cfg.context as Record<string, unknown>)?.ratio as number) ?? 0,
-            compaction_count: m.compaction_count ?? 0,
-          })
-        }
-      }
-    }
-    fleet.value = entries
-  } catch (e) {
-    error.value = e instanceof Error ? e.message : 'fetch failed'
-  } finally {
-    loading.value = false
+function emptyState(): FleetTelemetryState {
+  return {
+    loading: false,
+    error: null,
+    warnings: [],
+    rows: [],
+    tool_quality: EMPTY_TOOL_QUALITY,
+    telemetry_sources: [],
+    total_telemetry_entries: 0,
+    updated_at: null,
   }
 }
 
-// ── 1. Error Category Breakdown ───────────────────────────
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source
+}
 
-function ErrorCategoryPanel() {
-  const tq = toolQuality.value
-  if (!tq || tq.failure_categories.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">No failure data</div>`
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : 'unknown error'
+}
+
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>()
+  const items: string[] = []
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (trimmed === '' || seen.has(trimmed)) continue
+    seen.add(trimmed)
+    items.push(trimmed)
   }
-  const cats = tq.failure_categories.slice(0, 10)
-  const maxCount = cats[0]?.count ?? 1
+  return items
+}
+
+function keeperModel(keeper: Keeper): string {
+  return keeper.last_model_used
+    || keeper.active_model
+    || keeper.model
+    || keeper.primary_model
+    || 'unknown'
+}
+
+function keeperLastLatencyMs(keeper: Keeper): number {
+  if (typeof keeper.last_latency_ms === 'number' && Number.isFinite(keeper.last_latency_ms)) {
+    return keeper.last_latency_ms
+  }
+  const lastMetric = keeper.metrics_series?.[keeper.metrics_series.length - 1]
+  return lastMetric?.latency_ms ?? 0
+}
+
+function successClass(rate: number | null): string {
+  if (rate == null || !Number.isFinite(rate)) return 'text-[var(--text-dim)]'
+  if (rate >= 97) return 'text-emerald-400'
+  if (rate >= 90) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+function keeperRecentTools(keeper: Keeper): string[] {
+  return uniqueStrings([
+    ...(keeper.recent_tool_names ?? []),
+    ...(keeper.latest_tool_names ?? []),
+  ]).slice(0, 3)
+}
+
+function buildToolQualityMap(toolQuality: ToolQualityResponse): Map<string, { calls: number; success_pct: number }> {
+  const byKeeper = new Map<string, { calls: number; success_pct: number }>()
+  for (const keeper of toolQuality.by_keeper) {
+    byKeeper.set(keeper.name, {
+      calls: keeper.calls,
+      success_pct: keeper.success_pct,
+    })
+  }
+  return byKeeper
+}
+
+function fleetSortScore(row: FleetRow): [number, number, number, number, string] {
+  const liveScore = row.keepalive_running ? 1 : 0
+  const pressureScore = row.context_ratio >= PRESSURE_HOT_RATIO ? 2 : row.context_ratio >= PRESSURE_WARN_RATIO ? 1 : 0
+  return [
+    liveScore,
+    pressureScore,
+    row.context_ratio,
+    row.tool_calls + row.turn_count,
+    row.name,
+  ]
+}
+
+function compareFleetRows(a: FleetRow, b: FleetRow): number {
+  const aScore = fleetSortScore(a)
+  const bScore = fleetSortScore(b)
+  if (aScore[0] !== bScore[0]) return bScore[0] - aScore[0]
+  if (aScore[1] !== bScore[1]) return bScore[1] - aScore[1]
+  if (aScore[2] !== bScore[2]) return bScore[2] - aScore[2]
+  if (aScore[3] !== bScore[3]) return bScore[3] - aScore[3]
+  return aScore[4].localeCompare(bScore[4])
+}
+
+export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityResponse): FleetRow[] {
+  const toolStats = buildToolQualityMap(toolQuality)
+  const rows =
+    keepers.length > 0
+      ? keepers.map((keeper): FleetRow => {
+          const toolQualityForKeeper = toolStats.get(keeper.name)
+          return {
+            name: keeper.name,
+            status: keeper.status ?? (keeper.keepalive_running ? 'active' : 'offline'),
+            keepalive_running: keeper.keepalive_running === true,
+            context_ratio: keeper.context_ratio ?? 0,
+            turn_count: keeper.total_turns ?? keeper.turn_count ?? 0,
+            last_latency_ms: keeperLastLatencyMs(keeper),
+            last_activity_ago_s: keeper.last_activity_ago_s ?? null,
+            model: keeperModel(keeper),
+            tool_calls: toolQualityForKeeper?.calls ?? 0,
+            tool_success_pct: toolQualityForKeeper?.success_pct ?? null,
+            recent_tools: keeperRecentTools(keeper),
+          }
+        })
+      : toolQuality.by_keeper.map((keeper): FleetRow => ({
+          name: keeper.name,
+          status: 'unknown',
+          keepalive_running: false,
+          context_ratio: 0,
+          turn_count: 0,
+          last_latency_ms: 0,
+          last_activity_ago_s: null,
+          model: 'unknown',
+          tool_calls: keeper.calls,
+          tool_success_pct: keeper.success_pct,
+          recent_tools: [],
+        }))
+
+  return [...rows].sort(compareFleetRows)
+}
+
+function toneForToolSuccess(rate: number): 'neutral' | 'ok' | 'warn' {
+  if (rate >= 97) return 'ok'
+  if (rate >= 90) return 'neutral'
+  return 'warn'
+}
+
+function toneForPressure(hot: number, warn: number): 'neutral' | 'ok' | 'warn' {
+  if (hot > 0) return 'warn'
+  if (warn > 0) return 'neutral'
+  return 'ok'
+}
+
+function pressureClass(ratio: number): string {
+  if (ratio >= PRESSURE_HOT_RATIO) return 'text-red-400'
+  if (ratio >= PRESSURE_WARN_RATIO) return 'text-yellow-400'
+  return 'text-emerald-400'
+}
+
+function statusClass(row: FleetRow): string {
+  if (!row.keepalive_running || row.status === 'offline' || row.status === 'stopped') return 'text-red-400'
+  if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-yellow-400'
+  return 'text-emerald-400'
+}
+
+function formatPercent(value: number | null, digits = 0): string {
+  if (value == null || !Number.isFinite(value)) return '-'
+  return `${value.toFixed(digits)}%`
+}
+
+function formatLatency(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '-'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  return `${(ms / 1000).toFixed(1)}s`
+}
+
+function formatActivity(seconds: number | null): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return '-'
+  return formatElapsedCompact(seconds)
+}
+
+function summaryCounts(rows: FleetRow[]) {
+  const live = rows.filter(row => row.keepalive_running).length
+  const toolCovered = rows.filter(row => row.tool_calls > 0).length
+  const hot = rows.filter(row => row.keepalive_running && row.context_ratio >= PRESSURE_HOT_RATIO).length
+  const warn = rows.filter(row =>
+    row.keepalive_running
+    && row.context_ratio >= PRESSURE_WARN_RATIO
+    && row.context_ratio < PRESSURE_HOT_RATIO,
+  ).length
+  const stale = rows.filter(row =>
+    row.keepalive_running
+    && row.last_activity_ago_s != null
+    && row.last_activity_ago_s >= STALE_ACTIVITY_SEC,
+  ).length
+  return { live, toolCovered, hot, warn, stale }
+}
+
+function SummaryCard({
+  title,
+  value,
+  detail,
+  tone = 'neutral',
+}: {
+  title: string
+  value: string
+  detail: string
+  tone?: 'neutral' | 'ok' | 'warn'
+}) {
+  const toneClass =
+    tone === 'ok'
+      ? 'border-emerald-500/20 bg-emerald-500/5'
+      : tone === 'warn'
+        ? 'border-amber-500/20 bg-amber-500/5'
+        : 'border-[var(--card-border)] bg-[rgba(255,255,255,0.02)]'
+
   return html`
-    <div class="flex flex-col gap-1.5">
-      ${cats.map(c => html`
-        <div class="flex items-center gap-2 text-[11px]">
-          <div class="flex-1 flex items-center gap-1.5">
-            <div class="h-1.5 rounded-full bg-red-500/60 transition-all"
-                 style="width: ${Math.max(4, (c.count / maxCount) * 100)}%" />
-            <span class="font-mono text-red-400/80 truncate">${c.category.slice(0, 40)}</span>
+    <div class="rounded-lg border ${toneClass} p-3">
+      <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">${title}</div>
+      <div class="mt-1 text-xl font-semibold text-[var(--text)]">${value}</div>
+      <div class="mt-1 text-[11px] leading-relaxed text-[var(--text-dim)]">${detail}</div>
+    </div>
+  `
+}
+
+function WarningBanner({ warnings }: { warnings: string[] }) {
+  if (warnings.length === 0) return null
+  return html`
+    <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-200">
+      <div class="font-medium text-amber-100">Partial telemetry</div>
+      <div class="mt-1 flex flex-col gap-1">
+        ${warnings.map(warning => html`<div>${warning}</div>`)}
+      </div>
+    </div>
+  `
+}
+
+function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
+  const watchlist = rows
+    .filter(row =>
+      row.keepalive_running
+      && (
+        row.context_ratio >= PRESSURE_WARN_RATIO
+        || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
+      ),
+    )
+    .slice(0, 5)
+
+  if (watchlist.length === 0) {
+    return html`
+      <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 text-[11px] text-[var(--text-dim)]">
+        No keepers are near context pressure or stale activity thresholds.
+      </div>
+    `
+  }
+
+  return html`
+    <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)]">
+      ${watchlist.map(row => html`
+        <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2 text-[11px] last:border-b-0">
+          <div class="min-w-0">
+            <div class="font-mono text-[var(--text)]">${row.name}</div>
+            <div class="text-[var(--text-dim)]">
+              ${row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC
+                ? `stale ${formatActivity(row.last_activity_ago_s)}`
+                : `ctx ${formatPercent(row.context_ratio * 100, 1)}`}
+            </div>
           </div>
-          <span class="text-[var(--text-dim)] shrink-0 tabular-nums">${c.count}</span>
+          <div class="text-right">
+            <div class="font-mono ${pressureClass(row.context_ratio)}">${formatPercent(row.context_ratio * 100, 1)}</div>
+            <div class="text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</div>
+          </div>
         </div>
       `)}
     </div>
   `
 }
 
-// ── 2. Fleet Comparison Table ─────────────────────────────
-
-function FleetComparisonTable() {
-  const entries = fleet.value
-  if (entries.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">No keeper data</div>`
+function FleetComparisonTable({ rows }: { rows: FleetRow[] }) {
+  if (rows.length === 0) {
+    return html`<div class="text-[11px] text-[var(--text-dim)]">No keeper fleet data available.</div>`
   }
-  // Sort by total tokens descending
-  const sorted = [...entries].sort((a, b) => b.metrics.total_tokens - a.metrics.total_tokens)
+
   return html`
     <div class="overflow-x-auto">
       <table class="w-full text-[11px]">
         <thead>
-          <tr class="text-[var(--text-dim)] border-b border-[var(--card-border)]">
-            <th class="text-left py-1 font-normal">Keeper</th>
-            <th class="text-right py-1 font-normal">Turns</th>
-            <th class="text-right py-1 font-normal">tok/s</th>
-            <th class="text-right py-1 font-normal">Latency</th>
-            <th class="text-right py-1 font-normal">Ctx%</th>
-            <th class="text-right py-1 font-normal">Model</th>
+          <tr class="border-b border-[var(--card-border)] text-[var(--text-dim)]">
+            <th class="py-1 text-left font-normal">Keeper</th>
+            <th class="py-1 text-right font-normal">Status</th>
+            <th class="py-1 text-right font-normal">Activity</th>
+            <th class="py-1 text-right font-normal">Tools</th>
+            <th class="py-1 text-right font-normal">Success</th>
+            <th class="py-1 text-right font-normal">Ctx</th>
+            <th class="py-1 text-right font-normal">Latency</th>
+            <th class="py-1 text-right font-normal">Model</th>
           </tr>
         </thead>
         <tbody>
-          ${sorted.map(e => {
-            const tokSec = e.metrics.last_output_tokens_per_sec
-            const tokColor = tokSec != null
-              ? (tokSec >= 30 ? 'text-emerald-400' : tokSec >= 10 ? 'text-yellow-400' : 'text-red-400')
-              : 'text-[var(--text-dim)]'
-            const ctxPct = (e.context_ratio * 100)
-            const ctxColor = ctxPct >= 70 ? 'text-red-400' : ctxPct >= 40 ? 'text-yellow-400' : 'text-[var(--text-dim)]'
-            return html`
-              <tr class="border-b border-[var(--card-border)] border-opacity-30">
-                <td class="py-0.5 font-mono">${e.name}</td>
-                <td class="text-right py-0.5 text-[var(--text-dim)]">${e.metrics.total_turns}</td>
-                <td class="text-right py-0.5 font-mono ${tokColor}">${tokSec != null ? tokSec.toFixed(1) : '-'}</td>
-                <td class="text-right py-0.5 text-[var(--text-dim)]">${e.metrics.last_latency_ms > 0 ? `${(e.metrics.last_latency_ms / 1000).toFixed(1)}s` : '-'}</td>
-                <td class="text-right py-0.5 font-mono ${ctxColor}">${ctxPct.toFixed(1)}%</td>
-                <td class="text-right py-0.5 text-[10px] text-[var(--text-dim)] truncate max-w-[80px]">${e.model_used}</td>
-              </tr>
-            `
-          })}
+          ${rows.map(row => html`
+            <tr class="border-b border-[var(--card-border)] border-opacity-30 align-top">
+              <td class="py-1.5">
+                <div class="font-mono text-[var(--text)]">${row.name}</div>
+                <div class="max-w-[240px] truncate text-[10px] text-[var(--text-dim)]" title=${row.recent_tools.join(', ') || 'No recent tools'}>
+                  ${row.recent_tools.length > 0 ? row.recent_tools.join(', ') : 'No recent tools'}
+                </div>
+              </td>
+              <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
+              <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</td>
+              <td class="py-1.5 text-right font-mono text-[var(--text)]">${row.tool_calls.toLocaleString()}</td>
+              <td class="py-1.5 text-right font-mono ${successClass(row.tool_success_pct)}">
+                ${formatPercent(row.tool_success_pct, 1)}
+              </td>
+              <td class="py-1.5 text-right font-mono ${pressureClass(row.context_ratio)}">${formatPercent(row.context_ratio * 100, 1)}</td>
+              <td class="py-1.5 text-right text-[var(--text-dim)]">${formatLatency(row.last_latency_ms)}</td>
+              <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
+            </tr>
+          `)}
         </tbody>
       </table>
     </div>
   `
 }
 
-// ── 3. Model Distribution ─────────────────────────────────
-
-function ModelDistribution() {
-  const entries = fleet.value
-  if (entries.length === 0) return null
-  // Count models
-  const modelCounts = new Map<string, number>()
-  for (const e of entries) {
-    const m = e.model_used || 'unknown'
-    modelCounts.set(m, (modelCounts.get(m) ?? 0) + 1)
+function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] }) {
+  if (sources.length === 0) {
+    return html`<div class="text-[11px] text-[var(--text-dim)]">Telemetry store summary is unavailable.</div>`
   }
-  const sorted = [...modelCounts.entries()].sort((a, b) => b[1] - a[1])
-  const total = entries.length
-  const colors = ['bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-purple-500', 'bg-red-500']
+
+  const sorted = [...sources].sort((a, b) => b.entry_count - a.entry_count)
   return html`
-    <div class="flex flex-col gap-2">
-      <div class="flex h-3 rounded-full overflow-hidden">
-        ${sorted.map(([, count], i) => html`
-          <div class="${colors[i % colors.length]} transition-all"
-               style="width: ${(count / total) * 100}%" />
-        `)}
-      </div>
-      <div class="flex flex-wrap gap-x-3 gap-y-1">
-        ${sorted.map(([model, count], i) => html`
-          <div class="flex items-center gap-1 text-[10px]">
-            <div class="w-2 h-2 rounded-full ${colors[i % colors.length]}" />
-            <span class="text-[var(--text-dim)]">${model}</span>
-            <span class="font-mono">${count}</span>
+    <div class="grid grid-cols-1 gap-2 md:grid-cols-2">
+      ${sorted.map(source => html`
+        <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-[11px] font-medium text-[var(--text)]">${sourceLabel(source.source)}</div>
+            <div class="font-mono text-[11px] ${source.entry_count > 0 ? 'text-emerald-400' : 'text-[var(--text-dim)]'}">
+              ${source.entry_count.toLocaleString()}
+            </div>
           </div>
-        `)}
-      </div>
-    </div>
-  `
-}
-
-// ── 4. Compaction Summary ─────────────────────────────────
-
-function CompactionSummary() {
-  const entries = fleet.value
-  if (entries.length === 0) return null
-  const totalCompactions = entries.reduce((sum, e) => sum + e.compaction_count, 0)
-  const keepersWithCompaction = entries.filter(e => e.compaction_count > 0)
-  if (totalCompactions === 0) {
-    return html`
-      <div class="flex items-center gap-2 p-2 rounded bg-[var(--bg-subtle)] text-[11px]">
-        <span class="text-yellow-400">0</span>
-        <span class="text-[var(--text-dim)]">compaction events across ${entries.length} keepers.
-          Context ratios are low enough that compaction gates never trigger.</span>
-      </div>
-    `
-  }
-  return html`
-    <div class="flex flex-col gap-1.5">
-      <div class="flex items-center gap-2 text-[11px]">
-        <span class="font-mono text-emerald-400">${totalCompactions}</span>
-        <span class="text-[var(--text-dim)]">compactions from ${keepersWithCompaction.length}/${entries.length} keepers</span>
-      </div>
-      ${keepersWithCompaction.map(e => html`
-        <div class="flex items-center justify-between text-[11px] px-2">
-          <span class="font-mono">${e.name}</span>
-          <span class="text-[var(--text-dim)]">${e.compaction_count}x</span>
+          <div class="mt-1 text-[10px] text-[var(--text-dim)]">
+            ${source.keeper_count != null
+              ? `${source.keeper_count} keepers tracked`
+              : source.exists === false
+                ? 'store missing'
+                : 'store available'}
+          </div>
         </div>
       `)}
     </div>
   `
 }
 
-// ── Main Panel ────────────────────────────────────────────
+function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityResponse }) {
+  if (toolQuality.failure_categories.length === 0) {
+    return html`<div class="text-[11px] text-[var(--text-dim)]">No recent failure categories.</div>`
+  }
+
+  const top = toolQuality.failure_categories.slice(0, 8)
+  const maxCount = top[0]?.count ?? 1
+
+  return html`
+    <div class="flex flex-col gap-1.5">
+      ${top.map(category => html`
+        <div class="flex items-center gap-2 text-[11px]">
+          <div class="flex min-w-0 flex-1 items-center gap-1.5">
+            <div
+              class="h-1.5 rounded-full bg-red-500/60"
+              style="width: ${Math.max(6, (category.count / maxCount) * 100)}%"
+            ></div>
+            <span class="truncate font-mono text-red-300" title=${category.category}>${category.category}</span>
+          </div>
+          <span class="text-[var(--text-dim)]">${category.count}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
 
 export function FleetTelemetryPanel() {
-  useEffect(() => { void fetchFleetData() }, [])
+  const state = useSignal<FleetTelemetryState>(emptyState())
 
-  if (loading.value && fleet.value.length === 0) {
+  const loadFleetTelemetry = async () => {
+    state.value = {
+      ...state.value,
+      loading: true,
+      error: null,
+      warnings: [],
+    }
+
+    const [executionResult, toolQualityResult, telemetrySummaryResult] = await Promise.allSettled([
+      fetchDashboardExecution(),
+      fetchToolQuality({ n: 5000 }),
+      fetchTelemetrySummary(),
+    ])
+
+    const warnings: string[] = []
+
+    const keepers =
+      executionResult.status === 'fulfilled'
+        ? normalizeKeepers(executionResult.value.keepers)
+        : []
+    if (executionResult.status === 'rejected') {
+      warnings.push(`Execution snapshot unavailable: ${errorMessage(executionResult.reason)}`)
+    }
+
+    const toolQuality =
+      toolQualityResult.status === 'fulfilled'
+        ? toolQualityResult.value
+        : EMPTY_TOOL_QUALITY
+    if (toolQualityResult.status === 'rejected') {
+      warnings.push(`Tool quality unavailable: ${errorMessage(toolQualityResult.reason)}`)
+    }
+
+    const telemetrySummary =
+      telemetrySummaryResult.status === 'fulfilled'
+        ? telemetrySummaryResult.value
+        : { generated_at: '', sources: [], total_entries: 0 }
+    if (telemetrySummaryResult.status === 'rejected') {
+      warnings.push(`Telemetry store summary unavailable: ${errorMessage(telemetrySummaryResult.reason)}`)
+    }
+
+    const rows = buildFleetRows(keepers, toolQuality)
+    const updatedAt =
+      (executionResult.status === 'fulfilled' ? executionResult.value.generated_at : null)
+      || telemetrySummary.generated_at
+      || new Date().toISOString()
+
+    const hasAnyData =
+      rows.length > 0
+      || toolQuality.total > 0
+      || telemetrySummary.total_entries > 0
+
+    state.value = {
+      loading: false,
+      error: hasAnyData ? null : 'No fleet telemetry data available.',
+      warnings,
+      rows,
+      tool_quality: toolQuality,
+      telemetry_sources: telemetrySummary.sources,
+      total_telemetry_entries: telemetrySummary.total_entries,
+      updated_at: updatedAt,
+    }
+  }
+
+  useEffect(() => {
+    void loadFleetTelemetry()
+  }, [])
+
+  const value = state.value
+  const counts = summaryCounts(value.rows)
+  const liveTone: 'neutral' | 'ok' | 'warn' =
+    value.rows.length === 0
+      ? 'neutral'
+      : counts.live === value.rows.length
+        ? 'ok'
+        : 'warn'
+  const sourcesWithData = value.telemetry_sources.filter(source => source.entry_count > 0).length
+
+  if (value.loading && value.rows.length === 0) {
     return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">Loading fleet telemetry...</div>`
   }
-  if (error.value) {
-    return html`<div class="p-4 text-[11px] text-red-400">Error: ${error.value}</div>`
+
+  if (value.error) {
+    return html`<div class="p-4 text-[11px] text-red-400">${value.error}</div>`
   }
 
   return html`
     <div class="flex flex-col gap-4 p-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-sm font-medium">Fleet Telemetry</h2>
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h2 class="text-sm font-medium">Fleet Telemetry</h2>
+          <div class="text-[10px] text-[var(--text-dim)]">
+            ${value.updated_at ? `Updated ${formatTimeAgo(value.updated_at)}` : 'Runtime + telemetry store view'}
+          </div>
+        </div>
         <button
-          class="text-[10px] px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
-          onClick=${fetchFleetData}
+          class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)]"
+          onClick=${() => { void loadFleetTelemetry() }}
+          aria-label="Refresh fleet telemetry"
         >Refresh</button>
       </div>
 
-      <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Error Categories</div>
-        <${ErrorCategoryPanel} />
+      <${WarningBanner} warnings=${value.warnings} />
+
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <${SummaryCard}
+          title="Fleet Coverage"
+          value=${`${counts.live}/${value.rows.length || 0}`}
+          detail=${`${counts.toolCovered}/${value.rows.length || 0} keepers emitted recent tool telemetry.`}
+          tone=${liveTone}
+        />
+        <${SummaryCard}
+          title="Runtime Pressure"
+          value=${`${counts.hot} hot / ${counts.warn} warn`}
+          detail=${counts.stale > 0 ? `${counts.stale} keepers are stale beyond ${Math.round(STALE_ACTIVITY_SEC / 60)}m.` : 'No stale keepers crossed the activity threshold.'}
+          tone=${toneForPressure(counts.hot, counts.warn)}
+        />
+        <${SummaryCard}
+          title="Tool Success"
+          value=${value.tool_quality.total > 0 ? formatPercent(value.tool_quality.success_rate, 1) : 'n/a'}
+          detail=${value.tool_quality.total > 0
+            ? `${value.tool_quality.failure.toLocaleString()} failures across ${value.tool_quality.total.toLocaleString()} recent calls.`
+            : 'No recent tool quality samples were recorded.'}
+          tone=${value.tool_quality.total > 0 ? toneForToolSuccess(value.tool_quality.success_rate) : 'neutral'}
+        />
+        <${SummaryCard}
+          title="Telemetry Stores"
+          value=${value.total_telemetry_entries.toLocaleString()}
+          detail=${`${sourcesWithData}/${value.telemetry_sources.length || 0} stores currently have data.`}
+          tone=${sourcesWithData > 0 ? 'ok' : 'warn'}
+        />
       </div>
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Keeper Comparison</div>
-        <${FleetComparisonTable} />
+        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Pressure Watchlist</div>
+        <${PressureWatchlist} rows=${value.rows} />
       </div>
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Model Distribution</div>
-        <${ModelDistribution} />
+        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Keeper Comparison</div>
+        <${FleetComparisonTable} rows=${value.rows} />
       </div>
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Compaction</div>
-        <${CompactionSummary} />
+        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Telemetry Sources</div>
+        <${TelemetrySourcesPanel} sources=${value.telemetry_sources} />
+      </div>
+
+      <div>
+        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Failure Categories</div>
+        <${FailureCategoryPanel} toolQuality=${value.tool_quality} />
       </div>
     </div>
   `

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -316,6 +316,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         model,
         primary_model: asString(row.primary_model),
         active_model: asString(row.active_model),
+        last_model_used: asString(row.last_model_used),
         next_model_hint: asString(row.next_model_hint) ?? null,
         status: normalizeKeeperAgentStatus(statusRaw),
         presence_keepalive:
@@ -333,6 +334,9 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_autonomous_action_at: toIsoTimestamp(row.last_autonomous_action_at) ?? asString(row.last_autonomous_action_at) ?? null,
         generation: asNumber(row.generation),
         turn_count: asNumber(row.turn_count) ?? asNumber(row.total_turns),
+        total_turns: asNumber(row.total_turns) ?? asNumber(row.turn_count),
+        total_tokens: asNumber(row.total_tokens),
+        last_latency_ms: asNumber(row.last_latency_ms),
         autonomous_action_count: asNumber(row.autonomous_action_count),
         autonomous_turn_count: asNumber(row.autonomous_turn_count),
         autonomous_text_turn_count: asNumber(row.autonomous_text_turn_count),

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -562,6 +562,7 @@ export interface Keeper {
   model?: string
   primary_model?: string
   active_model?: string
+  last_model_used?: string
   next_model_hint?: string | null
   status: string
   presence_keepalive?: boolean
@@ -596,6 +597,9 @@ export interface Keeper {
   drift_count_total?: number
   generation?: number
   turn_count?: number
+  total_turns?: number
+  total_tokens?: number
+  last_latency_ms?: number
   last_activity_ago_s?: number
   context_ratio?: number
   context_tokens?: number


### PR DESCRIPTION
## Summary
- rebuild fleet telemetry around the execution keeper roster so tool-quiet keepers still appear
- combine execution, tool-quality, and telemetry-summary data into a clearer fleet health view with partial-data warnings
- add typed tool-quality API helpers and frontend tests for fleet coverage and degraded-data behavior

## Product impact
- fleet operators now see all active keepers even when some of them have no recent tool telemetry
- the panel makes partial telemetry degradation explicit instead of silently dropping keepers from the fleet view
- keeper rows preserve more recent execution context, including model and latency details when available

## Evidence
- `pnpm typecheck`
- `pnpm exec vitest run src/components/fleet-telemetry-panel.test.ts src/api/dashboard.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`

## Review evidence
- Cross-model review by direct `sb glm-text` (`GLM-5.1`) at `2026-04-09T07:11:39Z`
- Scope: correctness/regressions, code quality, operator-facing UI/design omissions
- Result: `No findings.`
- PR comment: https://github.com/jeong-sik/masc-mcp/pull/6104#issuecomment-4212235770

## Linked issue
- Refs #6108

## Notes
- build still emits the pre-existing Vite warning about `tab-refresh.ts` being both dynamically and statically imported
