### PR TITLE
[codex] Ignore local scratch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,10 +95,10 @@ issue*.md
 .nvimlog
 config/personas/uranium666
 .ci_build/
-.gitignore.bak
-.playwright-mcp/
-.tmp_verify/
-merged_prs.json
-pr_list.txt
-scripts/changelog_unreleased.txt
-specs/bug-models/*_TTrace_*.bin
+/.gitignore.bak
+/.playwright-mcp/
+/.tmp_verify/
+/merged_prs.json
+/pr_list.txt
+/scripts/changelog_unreleased.txt
+/specs/bug-models/*_TTrace_*.bin

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,10 @@ issue*.md
 .nvimlog
 config/personas/uranium666
 .ci_build/
+.gitignore.bak
+.playwright-mcp/
+.tmp_verify/
+merged_prs.json
+pr_list.txt
+scripts/changelog_unreleased.txt
+specs/bug-models/*_TTrace_*.bin


### PR DESCRIPTION
## Summary
- ignore local Playwright, verify, changelog scratch, and TTrace binary artifacts in tracked `.gitignore`
- keep repo-root `main` clean immediately with matching local-only excludes in `.git/info/exclude`
- leave potentially real project files such as root helper scripts, `uv.lock`, and copied TLA scratch local-only instead of broad repo-wide ignores

## Validation
- `git -C /Users/dancer/me/workspace/yousleepwhen/masc-mcp status --short`
- `git -C /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-oas-boundary-hardening status --short`
- `git -C /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-oas-boundary-hardening diff --check`
