### PR TITLE
fix(ci): use semver >= comparison in OAS pin version check

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -113,6 +113,21 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
   fi
 fi
 
+# Portable semver comparison: returns 0 (true) if $1 >= $2.
+# Handles 3-part versions (major.minor.patch); missing parts default to 0.
+version_gte() {
+  local IFS='.'
+  # shellcheck disable=SC2206
+  local a=($1) b=($2)
+  local i
+  for i in 0 1 2; do
+    local va=${a[$i]:-0} vb=${b[$i]:-0}
+    if (( va > vb )); then return 0; fi
+    if (( va < vb )); then return 1; fi
+  done
+  return 0
+}
+
 if command -v opam >/dev/null 2>&1; then
   installed_packages="$(opam list --installed --columns=name,version --short 2>/dev/null)"
   installed_version="$(awk '$1 == "agent_sdk" { print $2 }' <<<"${installed_packages}")"
@@ -121,8 +136,8 @@ if command -v opam >/dev/null 2>&1; then
     echo "repair: bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test --with-doc -y" >&2
     exit 1
   fi
-  if [[ "${installed_version}" != "${OAS_AGENT_SDK_MIN_VERSION}" ]]; then
-    echo "installed agent_sdk version is ${installed_version}, expected ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+  if ! version_gte "${installed_version}" "${OAS_AGENT_SDK_MIN_VERSION}"; then
+    echo "installed agent_sdk version is ${installed_version}, expected >= ${OAS_AGENT_SDK_MIN_VERSION}" >&2
     echo "repair: bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test --with-doc -y" >&2
     exit 1
   fi
@@ -151,7 +166,7 @@ if command -v opam >/dev/null 2>&1; then
         ;;
     esac
   else
-    echo "WARN: could not read agent_sdk pin source from opam; installed version matches ${OAS_AGENT_SDK_MIN_VERSION}" >&2
+    echo "WARN: could not read agent_sdk pin source from opam; installed version ${installed_version} satisfies floor ${OAS_AGENT_SDK_MIN_VERSION}" >&2
   fi
 fi
 


### PR DESCRIPTION
## Summary
- **Problem**: `check-oas-pin.sh` uses exact string match for installed OAS version vs floor → `0.119.0 != 0.118.0` fails even though `0.119.0 >= 0.118.0`
- **Root cause**: `OAS_AGENT_SDK_MIN_VERSION` implies `>=` semantics but implementation was `==`
- **Fix**: portable `version_gte()` function — 3-part semver numeric comparison, no GNU `sort -V` dependency

## Incident reference
PR #6049 (opam floor bump) broke CI because installed OAS version exceeded the declared floor. Three failed attempts before the issue was identified.

## Test plan
- [x] `version_gte "0.119.0" "0.118.0"` → true (higher minor)
- [x] `version_gte "0.118.0" "0.118.0"` → true (equal)
- [x] `version_gte "0.117.0" "0.118.0"` → false (lower minor)
- [x] `version_gte "1.0.0" "0.999.0"` → true (higher major)
- [x] `version_gte "0.118.1" "0.118.0"` → true (higher patch)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)