### PR TITLE
fix(dashboard): unify phase colors, time utils, reduce visual monotony

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -63,17 +63,8 @@ function decisionLabel(decision: string): string {
   return decision === 'keep' ? '유지' : '삭제'
 }
 
-function formatTimestamp(ts: number): string {
-  return formatTimestampKo(ts)
-}
-
 function liveLabel(loop: Pick<AutoresearchLoopSummary, 'live'>): string {
   return loop.live ? '실시간' : '저장됨'
-}
-
-function formatUpdatedAt(ts: number | null): string {
-  if (ts == null) return '알 수 없음'
-  return formatTimestamp(ts)
 }
 
 // --- Sub-components ---
@@ -137,7 +128,7 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
           </div>
           <div>
             <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">최근 갱신</div>
-            <div class="text-[var(--text-body)] text-sm font-mono">${formatUpdatedAt(loop.updated_at)}</div>
+            <div class="text-[var(--text-body)] text-sm font-mono">${loop.updated_at != null ? formatTimestampKo(loop.updated_at) : '알 수 없음'}</div>
           </div>
         </div>
       </div>
@@ -227,7 +218,7 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
                     : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
                 }">${decisionLabel(c.decision)}</span>
               </td>
-              <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestamp(c.timestamp)}</td>
+              <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
             </tr>
           `)}
         </tbody>
@@ -268,7 +259,7 @@ function WarningsList({ warnings }: { warnings: string[] }) {
 }
 
 function ResearchBrief({ loop }: { loop: AutoresearchLoopSummary }) {
-  const linkedAt = loop.linked_at != null ? formatTimestamp(loop.linked_at) : '미연결'
+  const linkedAt = loop.linked_at != null ? formatTimestampKo(loop.linked_at) : '미연결'
 
   return html`
     <${SurfaceCard} variant="compact">

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -6,6 +6,7 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { get, post } from '../api/core'
 import { formatElapsedCompact, formatTimeAgoEn } from '../lib/format-time'
+import { LoadingState } from './common/feedback-state'
 import { lastEvent } from '../sse'
 import { StatCard } from './common/stat-card'
 import { ActionButton } from './common/button'
@@ -781,7 +782,7 @@ export function ConnectorStatusPanel() {
   const live = discordLive.value
 
   if (loading.value && !d && !live) {
-    return html`<div class="text-xs text-[var(--text-dim)]">커넥터 상태 로딩 중...</div>`
+    return html`<${LoadingState}>커넥터 상태 불러오는 중...<//>`
   }
 
   if (error.value && !d && !live) {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -5,6 +5,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { get, post } from '../api/core'
+import { formatElapsedCompact, formatTimeAgoEn } from '../lib/format-time'
 import { lastEvent } from '../sse'
 import { StatCard } from './common/stat-card'
 import { ActionButton } from './common/button'
@@ -207,24 +208,9 @@ function channelIcon(ch: string): string {
   return CHANNEL_ICONS[ch] ?? '\u{1F517}'
 }
 
-function formatUptime(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  return m > 0 ? `${h}h ${m}m` : `${h}h`
-}
-
-function timeAgo(iso: string): string {
-  if (!iso.trim()) return 'unknown'
-  if (iso === 'never') return 'never'
-  const diff = (Date.now() - new Date(iso).getTime()) / 1000
-  if (Number.isNaN(diff)) return 'unknown'
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
-}
+// Time formatting delegated to lib/format-time (SSOT)
+const formatUptime = formatElapsedCompact
+const timeAgo = formatTimeAgoEn
 
 function healthTone(health: string): { dot: string; badge: string; label: string } {
   switch (health) {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -529,7 +529,7 @@ function DiscordLivePanel({
           <div>
             <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Configured bindings</div>
             ${configuredBindings.length === 0
-              ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No persisted Discord bindings yet</div>`
+              ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">저장된 Discord 바인딩 없음</div>`
               : html`
                   <div class="space-y-2">
                     ${configuredBindings.map(binding => html`
@@ -781,7 +781,7 @@ export function ConnectorStatusPanel() {
   const live = discordLive.value
 
   if (loading.value && !d && !live) {
-    return html`<div class="text-xs text-[var(--text-dim)]">Loading connector status...</div>`
+    return html`<div class="text-xs text-[var(--text-dim)]">커넥터 상태 로딩 중...</div>`
   }
 
   if (error.value && !d && !live) {
@@ -847,7 +847,7 @@ export function ConnectorStatusPanel() {
                     Observed room bindings
                   </div>
                   ${d.bindings.length === 0
-                    ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No observed room bindings yet</div>`
+                    ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">관찰된 room 바인딩 없음</div>`
                     : html`
                         <div class="space-y-2">
                           ${d.bindings.slice(0, 6).map(binding => html`<${BindingRow} binding=${binding} />`)}
@@ -860,7 +860,7 @@ export function ConnectorStatusPanel() {
                     Recent gate events
                   </div>
                   ${d.recent_events.length === 0
-                    ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No connector events recorded yet</div>`
+                    ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">커넥터 이벤트 기록 없음</div>`
                     : html`
                         <div class="space-y-2">
                           ${d.recent_events.slice(0, 8).map(event => html`<${EventRow} event=${event} />`)}
@@ -870,7 +870,7 @@ export function ConnectorStatusPanel() {
               </div>
 
               ${d.channels.length === 0
-                ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">No active connectors</div>`
+                ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">활성 커넥터 없음</div>`
                 : html`
                     <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
                       ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -201,9 +201,10 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                   params=${surface.defaultParams}
                   class="flex items-center justify-center w-full rounded-xl border p-2 cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive ? 'bg-[var(--accent-soft)] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'border-transparent text-[var(--text-muted)] hover:bg-[var(--white-5)]'}"
                   title=${surface.label}
+                  aria-label=${surface.label}
                   ariaCurrent=${isSurfaceActive ? 'page' : undefined}
                 >
-                  <span class="text-[18px] drop-shadow-md">${surface.icon}</span>
+                  <span class="text-[18px] drop-shadow-md" aria-hidden="true">${surface.icon}</span>
                 <//>
               `
             }
@@ -216,7 +217,7 @@ export function SideRail({ collapsed, onToggle }: { collapsed?: boolean; onToggl
                   class="flex items-center gap-2 w-full rounded-lg border px-2 py-1.5 text-left cursor-pointer transition-[background-color,border-color,color,box-shadow] duration-200 ${isSurfaceActive && sections.length === 0 ? 'bg-[linear-gradient(135deg,rgba(71,184,255,0.14),rgba(71,184,255,0.04))] text-[var(--text-strong)] shadow-[inset_0_1px_1px_var(--white-10)] border-[var(--accent-20)]' : 'bg-transparent border-transparent text-[var(--text-strong)] hover:bg-[var(--white-5)]'}"
                   ariaCurrent=${isSurfaceActive && sections.length === 0 ? 'page' : undefined}
                 >
-                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-3)] text-[14px]">
+                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-3)] text-[14px]" aria-hidden="true">
                     ${surface.icon}
                   </span>
                   <div class="flex-1 min-w-0">

--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -51,7 +51,7 @@ export function ExcusePatterns() {
   if (s.status === 'loading') {
     return html`
       <${Card} title="Anti-Rationalization Excuse Patterns">
-        <div class="p-4 text-[var(--text-muted)]">Loading excuse patterns...</div>
+        <div class="p-4 text-[var(--text-muted)]">핑계 패턴 로딩 중...</div>
       </Card>
     `
   }

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -134,7 +134,7 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('1/2 keepers emitted recent tool telemetry.')
     expect(container.textContent).toContain('keeper-alpha')
     expect(container.textContent).toContain('keeper-beta')
-    expect(container.textContent).toContain('Keeper metrics')
+    expect(container.textContent).toContain('Keeper 턴 로그')
     expect(container.textContent).toContain('Failure Categories')
   })
 

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -9,6 +9,7 @@ import {
   type ToolQualityResponse,
 } from '../api/dashboard'
 import { normalizeKeepers } from '../keeper-store-normalize'
+import { telemetrySourceLabel } from '../config/telemetry-sources'
 import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
 import type { Keeper } from '../types'
 
@@ -17,14 +18,6 @@ import type { Keeper } from '../types'
 const PRESSURE_HOT_RATIO = 0.75
 const PRESSURE_WARN_RATIO = 0.5
 const STALE_ACTIVITY_SEC = 900
-
-const SOURCE_LABELS: Record<string, string> = {
-  keeper_metric: 'Keeper metrics',
-  agent_event: 'Agent events',
-  tool_call_io: 'Tool call I/O',
-  tool_usage: 'Tool usage',
-  tool_metric: 'Tool metrics',
-}
 
 interface FleetRow {
   name: string
@@ -75,9 +68,8 @@ function emptyState(): FleetTelemetryState {
   }
 }
 
-function sourceLabel(source: string): string {
-  return SOURCE_LABELS[source] ?? source
-}
+// Delegated to config/telemetry-sources (SSOT)
+const sourceLabel = telemetrySourceLabel
 
 function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : 'unknown error'

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -327,7 +327,7 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
 
 function FleetComparisonTable({ rows }: { rows: FleetRow[] }) {
   if (rows.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">No keeper fleet data available.</div>`
+    return html`<div class="text-[11px] text-[var(--text-dim)]">키퍼 fleet 데이터 없음.</div>`
   }
 
   return html`
@@ -402,7 +402,7 @@ function TelemetrySourcesPanel({ sources }: { sources: TelemetrySourceSummary[] 
 
 function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityResponse }) {
   if (toolQuality.failure_categories.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">No recent failure categories.</div>`
+    return html`<div class="text-[11px] text-[var(--text-dim)]">최근 실패 카테고리 없음.</div>`
   }
 
   const top = toolQuality.failure_categories.slice(0, 8)
@@ -507,7 +507,7 @@ export function FleetTelemetryPanel() {
   const sourcesWithData = value.telemetry_sources.filter(source => source.entry_count > 0).length
 
   if (value.loading && value.rows.length === 0) {
-    return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">Loading fleet telemetry...</div>`
+    return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">Fleet 텔레메트리 로딩 중...</div>`
   }
 
   if (value.error) {
@@ -526,8 +526,8 @@ export function FleetTelemetryPanel() {
         <button
           class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)]"
           onClick=${() => { void loadFleetTelemetry() }}
-          aria-label="Refresh fleet telemetry"
-        >Refresh</button>
+          aria-label="Fleet 텔레메트리 새로고침"
+        >새로고침</button>
       </div>
 
       <${WarningBanner} warnings=${value.warnings} />

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { LoadingState } from './common/feedback-state'
 import {
   fetchDashboardExecution,
   fetchTelemetrySummary,
@@ -507,7 +508,7 @@ export function FleetTelemetryPanel() {
   const sourcesWithData = value.telemetry_sources.filter(source => source.entry_count > 0).length
 
   if (value.loading && value.rows.length === 0) {
-    return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">Fleet 텔레메트리 로딩 중...</div>`
+    return html`<${LoadingState}>Fleet 텔레메트리 불러오는 중...<//>`
   }
 
   if (value.error) {

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -12,6 +12,8 @@ import { normalizeKeepers } from '../keeper-store-normalize'
 import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
 import type { Keeper } from '../types'
 
+// Fleet-level thresholds (lower than individual keeper thresholds in config/constants)
+// because fleet view highlights keepers that are approaching limits, not yet at them
 const PRESSURE_HOT_RATIO = 0.75
 const PRESSURE_WARN_RATIO = 0.5
 const STALE_ACTIVITY_SEC = 900

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -39,7 +39,7 @@ function getPhaseStyle(phase: KeeperPhase | string | null | undefined): PhaseSty
 export function KeeperPhaseBadge({ phase, compact }: { phase?: KeeperPhase | string | null; compact?: boolean }) {
   const style = getPhaseStyle(phase)
   const isBuffer = BUFFER_PHASES.has(phase ?? '')
-  const size = compact ? 'px-1.5 py-px text-[9px]' : 'px-2 py-0.5 text-[10px]'
+  const size = compact ? 'px-1.5 py-px text-[10px]' : 'px-2 py-0.5 text-[11px]'
 
   return html`
     <span
@@ -71,7 +71,7 @@ export function KeeperPhaseAndStage({
     <div class="flex items-center gap-2">
       <${KeeperPhaseBadge} phase=${phase} />
       ${stageLabel ? html`
-        <span class="text-[9px] text-[var(--text-dim)] font-mono tracking-tight opacity-70">${stageLabel}</span>
+        <span class="text-[10px] text-[var(--text-dim)] font-mono tracking-tight opacity-80">${stageLabel}</span>
       ` : null}
     </div>
   `

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -92,7 +92,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
       </div>
       <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-[24px]">
         ${transitions.length === 0
-          ? html`<span class="text-[11px] text-[var(--text-muted)]">no transitions</span>`
+          ? html`<span class="text-[11px] text-[var(--text-muted)]">전환 없음</span>`
           : transitions.map((t, i) => html`
               <${TransitionDot} t=${t} idx=${i} />
               ${i < transitions.length - 1 ? html`<div class="w-3 h-px bg-[var(--white-10)]" />` : null}
@@ -100,7 +100,7 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
         }
       </div>
       <div class="shrink-0 text-[11px] text-[var(--text-muted)] tabular-nums">
-        ${transitions.length} transitions
+        ${transitions.length}건
       </div>
     </div>
   `
@@ -114,22 +114,22 @@ export function KeeperPhaseTimeline() {
   const keeperList = keepers.value
 
   if (isLoading && data.size === 0) {
-    return html`<div class="text-[12px] text-[var(--text-muted)] py-4 text-center">Phase timeline loading...</div>`
+    return html`<div class="text-[12px] text-[var(--text-muted)] py-4 text-center">페이즈 타임라인 로딩 중...</div>`
   }
 
   if (keeperList.length === 0) {
-    return html`<div class="text-[12px] text-[var(--text-muted)] py-4 text-center">No keepers registered</div>`
+    return html`<div class="text-[12px] text-[var(--text-muted)] py-4 text-center">등록된 키퍼 없음</div>`
   }
 
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex items-center justify-between mb-1">
-        <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">Phase Transitions (recent 30)</div>
+        <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">페이즈 전환 (최근 30건)</div>
         <button
           type="button"
           class="text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)] transition-colors"
           onClick=${() => { void loadAll() }}
-        >refresh</button>
+        >새로고침</button>
       </div>
       ${keeperList.map(k => {
         const d = data.get(k.name)
@@ -138,7 +138,7 @@ export function KeeperPhaseTimeline() {
           : html`
             <div class="flex items-center gap-3 py-2 px-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)]" key=${k.name}>
               <div class="w-24 text-[13px] font-semibold text-[var(--text-strong)] truncate">${k.name}</div>
-              <span class="text-[11px] text-[var(--text-muted)]">no data</span>
+              <span class="text-[11px] text-[var(--text-muted)]">데이터 없음</span>
             </div>
           `
       })}

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -6,38 +6,25 @@ import { useEffect } from 'preact/hooks'
 import { keepers } from '../store'
 import { fetchKeeperTransitions, type KeeperTransition, type KeeperTransitionsResponse } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
+import { getPhaseStyle } from './keeper-phase-indicator'
 
 const transitionData = signal<Map<string, KeeperTransitionsResponse>>(new Map())
 const loading = signal(false)
 
-// Phase names come lowercase from the server (phase_to_string)
-const PHASE_COLORS: Record<string, string> = {
-  running: 'var(--ok)',
-  compacting: '#fbbf24',
-  handing_off: '#22d3ee',
-  failing: 'var(--bad)',
-  crashed: '#ef4444',
-  dead: '#6b7280',
-  paused: '#a78bfa',
-  draining: '#fb923c',
-  restarting: '#38bdf8',
-  stopped: '#9ca3af',
-  offline: '#4b5563',
+// Server sends lowercase (e.g. "running", "handing_off"); PHASE_STYLES uses PascalCase
+function toPascalPhase(phase: string): string {
+  return phase.toLowerCase()
+    .replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
+    .replace(/^./, s => s.toUpperCase())
 }
 
 function phaseColor(phase: string): string {
-  return PHASE_COLORS[phase.toLowerCase()] ?? '#6b7280'
+  return getPhaseStyle(toPascalPhase(phase)).color
 }
 
-function phaseBgClass(phase: string): string {
-  switch (phase.toLowerCase()) {
-    case 'running': return 'bg-[var(--ok)]/15 text-[var(--ok)]'
-    case 'failing': case 'crashed': return 'bg-[var(--bad)]/15 text-[var(--bad-light)]'
-    case 'compacting': return 'bg-[#fbbf24]/15 text-[#fbbf24]'
-    case 'handing_off': return 'bg-[#22d3ee]/15 text-[#22d3ee]'
-    case 'paused': return 'bg-[#a78bfa]/15 text-[#a78bfa]'
-    default: return 'bg-[var(--white-6)] text-[var(--text-muted)]'
-  }
+function phaseInlineStyle(phase: string): string {
+  const style = getPhaseStyle(toPascalPhase(phase))
+  return `color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border};`
 }
 
 // selected_event comes as object {type: "...", ...} from the server
@@ -96,8 +83,11 @@ function KeeperStrip({ name, data }: { name: string; data: KeeperTransitionsResp
     <div class="flex items-center gap-3 py-2 px-3 rounded-lg border border-[var(--white-6)] bg-[var(--white-3)]">
       <div class="w-24 shrink-0">
         <div class="text-[13px] font-semibold text-[var(--text-strong)] truncate">${name}</div>
-        <div class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium mt-1 ${phaseBgClass(phase)}">
-          ${phase}
+        <div
+          class="inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-semibold tracking-wide mt-1"
+          style="${phaseInlineStyle(phase)}"
+        >
+          ${getPhaseStyle(toPascalPhase(phase)).icon} ${getPhaseStyle(toPascalPhase(phase)).label}
         </div>
       </div>
       <div class="flex-1 flex items-center gap-1.5 overflow-x-auto min-h-[24px]">

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { Markdown } from "./common/markdown"
 import { useState } from 'preact/hooks'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
+import { relativeTime } from '../lib/format-time'
 import type { Keeper, KeeperDiagnostic } from '../types'
 import {
   abortKeeperThreadMessage,
@@ -111,11 +112,11 @@ function continuityStateLabel(state?: KeeperDiagnostic['continuity_state']): str
   }
 }
 
+// Delegated to lib/format-time (SSOT) — returns Korean relative time
 function formatTime(timestamp?: string | null): string | null {
   if (!timestamp) return null
-  const value = new Date(timestamp)
-  if (Number.isNaN(value.getTime())) return null
-  return value.toLocaleTimeString()
+  const result = relativeTime(timestamp)
+  return result === '정보 없음' ? null : result
 }
 
 function formatEligible(seconds?: number | null): string | null {

--- a/dashboard/src/components/keeper-tool-call-inspector.test.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.test.ts
@@ -51,7 +51,7 @@ describe('KeeperToolCallInspector', () => {
     render(html`<${KeeperToolCallInspector} keeperName="alice" />`, container)
     await Promise.resolve()
 
-    expect(container.textContent).toContain('Loading')
+    expect(container.textContent).toContain('불러오는 중')
   })
 
   it('renders entries after successful fetch', async () => {
@@ -77,7 +77,7 @@ describe('KeeperToolCallInspector', () => {
     render(html`<${KeeperToolCallInspector} keeperName="alice" />`, container)
 
     await waitFor(() => {
-      expect(container.textContent).toContain('No tool call data')
+      expect(container.textContent).toContain('도구 호출 데이터 없음')
     })
   })
 

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -110,7 +110,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   const sorted = useMemo(() => [...filtered].reverse(), [filtered])
 
   if (loading.value) {
-    return html`<div class="text-xs text-[var(--text-muted)] p-4">Loading tool calls...</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] p-4">도구 호출 로딩 중...</div>`
   }
 
   if (error.value) {
@@ -118,7 +118,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   }
 
   if (entries.value.length === 0) {
-    return html`<div class="text-xs text-[var(--text-muted)] p-4">No tool call data yet. Data is recorded after server restart with this update.</div>`
+    return html`<div class="text-xs text-[var(--text-muted)] p-4">도구 호출 데이터 없음. 서버 재시작 후 기록됩니다.</div>`
   }
 
   // Summary stats

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -6,12 +6,11 @@ import { useEffect, useMemo } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry } from '../api/dashboard'
+import { formatTimeHms } from '../lib/format-time'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 
-function formatTimestamp(ts: number): string {
-  const d = new Date(ts * 1000)
-  return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-}
+// Delegated to lib/format-time (SSOT)
+const formatTimestamp = formatTimeHms
 
 function formatInput(input: unknown): string {
   if (input == null) return '-'

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -7,6 +7,7 @@ import { useSignal } from '@preact/signals'
 import { fetchKeeperToolCalls } from '../api/dashboard'
 import type { ToolCallEntry } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
+import { LoadingState } from './common/feedback-state'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
 
 // Delegated to lib/format-time (SSOT)
@@ -110,7 +111,7 @@ export function KeeperToolCallInspector({ keeperName }: { keeperName: string }) 
   const sorted = useMemo(() => [...filtered].reverse(), [filtered])
 
   if (loading.value) {
-    return html`<div class="text-xs text-[var(--text-muted)] p-4">도구 호출 로딩 중...</div>`
+    return html`<${LoadingState}>도구 호출 불러오는 중...<//>`
   }
 
   if (error.value) {

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -4,6 +4,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import type { ReadonlySignal } from '@preact/signals'
+import { formatTimeOnly } from '../../lib/format-time'
 import type { JournalEntry } from '../../types'
 
 interface NarrativeTimelineProps {
@@ -72,11 +73,8 @@ function groupByTime(events: NarrativeEvent[]): TimeGroup[] {
   return groups
 }
 
-const timeOnlyFmt = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
-
-function formatTimestamp(ts: number): string {
-  return timeOnlyFmt.format(new Date(ts))
-}
+// Delegated to lib/format-time (SSOT)
+const formatTimestamp = formatTimeOnly
 
 export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps) {
   const baseLimit = maxItems ?? 8

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -98,9 +98,9 @@ export function RuntimeMonitor() {
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
           onClick=${() => void load()}
         >
-          Refresh
+          새로고침
         </button>
-        ${state.value.loading ? html`<span class="text-xs text-[var(--text-muted)]">loading...</span>` : null}
+        ${state.value.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
       </div>
 
       ${state.value.error

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -7,6 +7,7 @@ import { fetchDashboardConfig } from '../api/dashboard'
 import type { DashboardConfigResponse, ConfigEntry } from '../api/dashboard'
 import { createAsyncResource } from '../lib/async-state'
 import { formatElapsedCompact } from '../lib/format-time'
+import { LoadingState } from './common/feedback-state'
 
 const configResource = createAsyncResource<DashboardConfigResponse>()
 const searchQuery = signal('')
@@ -174,7 +175,7 @@ export function ServerConfig() {
       ` : null}
 
       ${loading && !data ? html`
-        <div class="text-sm text-[var(--text-muted)] py-8 text-center">로딩 중...</div>
+        <${LoadingState}>설정 불러오는 중...<//>
       ` : null}
 
       ${data ? html`

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -6,6 +6,7 @@ import { TransportHealthPanel } from './transport-health'
 import { fetchDashboardConfig } from '../api/dashboard'
 import type { DashboardConfigResponse, ConfigEntry } from '../api/dashboard'
 import { createAsyncResource } from '../lib/async-state'
+import { formatElapsedCompact } from '../lib/format-time'
 
 const configResource = createAsyncResource<DashboardConfigResponse>()
 const searchQuery = signal('')
@@ -29,14 +30,8 @@ function toggleCategory(name: string) {
   expandedCategories.value = next
 }
 
-function formatUptime(seconds: number): string {
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = Math.floor(seconds % 60)
-  if (h > 0) return `${h}h ${m}m ${s}s`
-  if (m > 0) return `${m}m ${s}s`
-  return `${s}s`
-}
+// Delegated to lib/format-time (SSOT)
+const formatUptime = formatElapsedCompact
 
 function matchesSearch(entry: ConfigEntry, query: string): boolean {
   if (!query) return true

--- a/dashboard/src/components/server-config.ts
+++ b/dashboard/src/components/server-config.ts
@@ -165,7 +165,7 @@ export function ServerConfig() {
           onClick=${() => void refreshServerConfig()}
           disabled=${loading}
         >
-          ${loading ? '...' : 'Refresh'}
+          ${loading ? '...' : '새로고침'}
         </button>
       </div>
 
@@ -174,7 +174,7 @@ export function ServerConfig() {
       ` : null}
 
       ${loading && !data ? html`
-        <div class="text-sm text-[var(--text-muted)] py-8 text-center">Loading...</div>
+        <div class="text-sm text-[var(--text-muted)] py-8 text-center">로딩 중...</div>
       ` : null}
 
       ${data ? html`

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -14,15 +14,8 @@ import {
   type TelemetrySourceSummary,
 } from '../api/dashboard'
 import { route } from '../router'
+import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
 import { formatTimeAgo } from '../lib/format-time'
-
-const SOURCE_META: Record<TelemetrySource, { label: string; sublabel: string; color: string; icon: string }> = {
-  keeper_metric: { label: 'Keeper 턴 로그', sublabel: 'heartbeat ~80%, 실제 추론 턴 ~20%', color: 'text-blue-400', icon: 'K' },
-  agent_event: { label: 'Agent 이벤트', sublabel: 'tool_called 다수, join/leave/task 포함', color: 'text-emerald-400', icon: 'A' },
-  tool_call_io: { label: 'Keeper Tool I/O', sublabel: 'keeper->tool 입출력 전체 기록', color: 'text-amber-400', icon: 'T' },
-  tool_usage: { label: 'Keeper 내부 호출', sublabel: 'keeper_internal caller 기록', color: 'text-purple-400', icon: 'U' },
-  tool_metric: { label: 'Tool 성능', sublabel: 'duration/success 측정', color: 'text-cyan-400', icon: 'M' },
-}
 
 interface StoreSnapshot {
   keepers: number
@@ -45,7 +38,6 @@ const EMPTY_STORE: StoreSnapshot = {
   toolsRegistered: 0, toolsPublic: 0, toolsTotalCalls: 0, toolsNeverCalled: 0,
   version: null, uptime: null,
 }
-
 interface TelemetryState {
   entries: TelemetryEntry[]
   summary: TelemetrySourceSummary[]
@@ -55,9 +47,7 @@ interface TelemetryState {
   error: string | null
 }
 
-function sourceMeta(source: string) {
-  return SOURCE_META[source as TelemetrySource] ?? { label: source, sublabel: '', color: 'text-gray-400', icon: '?' }
-}
+const sourceMeta = telemetrySourceMeta
 
 function entryTimestamp(e: TelemetryEntry): number {
   const numeric = (e.ts_unix as number) ?? (e.ts as number) ?? (e.timestamp as number) ?? 0
@@ -392,7 +382,7 @@ export function TelemetryUnified() {
           onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
         >
           <option value="">All sources</option>
-          ${Object.entries(SOURCE_META).map(([key, m]) => html`<option value=${key}>${m.label}</option>`)}
+          ${Object.entries(TELEMETRY_SOURCE_META).map(([key, m]) => html`<option value=${key}>${m.label}</option>`)}
         </select>
         <input
           type="text"

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -78,9 +78,8 @@ function formatTs(ts: number): string {
   })
 }
 
-function timeAgo(ts: number): string {
-  if (ts === 0) return ''
-  return formatTimeAgo(ts)
+function timeAgoSafe(ts: number): string {
+  return ts === 0 ? '' : formatTimeAgo(ts)
 }
 
 function normalizeText(value: unknown): string | null {
@@ -210,7 +209,7 @@ function EntryRow({ entry }: { entry: TelemetryEntry }) {
       >
         <span class="font-mono font-bold ${meta.color} w-4 text-center flex-shrink-0">${meta.icon}</span>
         <span class="font-mono text-[var(--text-muted)] w-28 flex-shrink-0" title=${formatTs(ts)}>
-          ${timeAgo(ts)}
+          ${timeAgoSafe(ts)}
         </span>
         ${success != null ? html`
           <span class="flex-shrink-0 w-4 ${success ? 'text-green-400' : 'text-red-400'}">

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -344,7 +344,7 @@ export function TelemetryUnified() {
       <div class="flex flex-wrap gap-3">
         ${summary.map(src => html`<${SummaryCard} src=${src} />`)}
         <div class="rounded-lg border border-[var(--card-border)] bg-[rgba(255,255,255,0.02)] p-3 min-w-[140px]">
-          <div class="text-xs font-medium text-[var(--text-muted)] mb-1">Total</div>
+          <div class="text-xs font-medium text-[var(--text-muted)] mb-1">전체</div>
           <div class="text-2xl font-bold text-[var(--text-strong)]">${totalEntries.toLocaleString()}</div>
         </div>
       </div>
@@ -381,12 +381,12 @@ export function TelemetryUnified() {
           value=${sourceFilter.value}
           onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
         >
-          <option value="">All sources</option>
+          <option value="">전체 소스</option>
           ${Object.entries(TELEMETRY_SOURCE_META).map(([key, m]) => html`<option value=${key}>${m.label}</option>`)}
         </select>
         <input
           type="text"
-          placeholder="Keeper name..."
+          placeholder="키퍼 이름..."
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-32"
           value=${keeperFilter.value}
           onInput=${(e: Event) => { keeperFilter.value = (e.target as HTMLInputElement).value }}
@@ -428,7 +428,7 @@ export function TelemetryUnified() {
         >
           Refresh
         </button>
-        ${loading ? html`<span class="text-xs text-[var(--text-muted)]">loading...</span>` : null}
+        ${loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
       </div>
 
       ${error ? html`

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -154,7 +154,7 @@ function TrendSparkline({ points }: { points: HourlyPoint[] }) {
   return html`
     <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-3">
       <div class="flex items-center justify-between mb-1.5">
-        <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Success Rate Trend</span>
+        <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">성공률 추이</span>
         <span class="text-xs font-mono" style="color:${lineColor}">${lastRate.toFixed(1)}%</span>
       </div>
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" class="rounded w-full" style="background:#0b1220;">
@@ -195,7 +195,7 @@ function KeeperRateBars({ keepers }: { keepers: KeeperStat[] }) {
 
 function FailureList({ categories }: { categories: FailureCategory[] }) {
   const top = categories.slice(0, 8)
-  if (top.length === 0) return html`<div class="text-[11px] text-[var(--text-dim)]">No failures</div>`
+  if (top.length === 0) return html`<div class="text-[11px] text-[var(--text-dim)]">실패 없음</div>`
   return html`
     <div class="flex flex-col gap-1">
       ${top.map(c => html`
@@ -212,25 +212,25 @@ export function ToolQualityPanel() {
   useEffect(() => { void fetchToolQuality() }, [])
 
   const d = data.value
-  if (loading.value && !d) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">Loading tool quality...</div>`
-  if (error.value) return html`<div class="p-4 text-[11px] text-red-400">Error: ${error.value}</div>`
-  if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">No tool call data</div>`
+  if (loading.value && !d) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 품질 로딩 중...</div>`
+  if (error.value) return html`<div class="p-4 text-[11px] text-red-400">오류: ${error.value}</div>`
+  if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
 
   return html`
     <div class="flex flex-col gap-4 p-4">
       <div class="flex items-center justify-between">
-        <h2 class="text-sm font-medium">Tool Call Quality</h2>
+        <h2 class="text-sm font-medium">도구 호출 품질</h2>
         <button
           class="text-[10px] px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
           onClick=${fetchToolQuality}
-          aria-label="Refresh tool quality metrics"
-        >Refresh</button>
+          aria-label="도구 품질 새로고침"
+        >새로고침</button>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
         <div class="text-center">
           <div class="text-lg font-mono ${successColor.value}">${d.success_rate.toFixed(1)}%</div>
-          <div class="text-[9px] text-[var(--text-dim)] uppercase">Success Rate</div>
+          <div class="text-[9px] text-[var(--text-dim)] uppercase">성공률</div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--text)]">${d.total.toLocaleString()}</div>
@@ -254,7 +254,7 @@ export function ToolQualityPanel() {
       </div>
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">Tool Success Rate</div>
+        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">도구별 성공률</div>
         <${ToolTable} tools=${d.by_tool} />
       </div>
 

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal, computed, type Signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { LoadingState } from './common/feedback-state'
 
 interface ToolStat {
   name: string
@@ -212,7 +213,7 @@ export function ToolQualityPanel() {
   useEffect(() => { void fetchToolQuality() }, [])
 
   const d = data.value
-  if (loading.value && !d) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 품질 로딩 중...</div>`
+  if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
   if (error.value) return html`<div class="p-4 text-[11px] text-red-400">오류: ${error.value}</div>`
   if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
 

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -433,7 +433,7 @@ export function TransportHealthPanel() {
         <button
           class="text-[10px] text-text-muted hover:text-text-body transition-colors"
           onClick=${() => void refreshTransportHealth()}
-        >refresh</button>
+        >새로고침</button>
       </div>
 
       <details class="group rounded-xl border border-card-border/50 bg-card/18 overflow-hidden" open=${hasAnyBadTransport}>

--- a/dashboard/src/config/telemetry-sources.ts
+++ b/dashboard/src/config/telemetry-sources.ts
@@ -1,0 +1,36 @@
+// Telemetry source metadata — SSOT for labels, colors, and icons.
+// Used by telemetry-unified, fleet-telemetry-panel, and any view rendering
+// the 5 append-only JSONL telemetry stores.
+
+export type TelemetrySourceKey =
+  | 'keeper_metric'
+  | 'agent_event'
+  | 'tool_call_io'
+  | 'tool_usage'
+  | 'tool_metric'
+
+export interface TelemetrySourceMeta {
+  label: string
+  sublabel: string
+  color: string
+  icon: string
+}
+
+export const TELEMETRY_SOURCE_META: Record<TelemetrySourceKey, TelemetrySourceMeta> = {
+  keeper_metric: { label: 'Keeper 턴 로그', sublabel: 'heartbeat ~80%, 실제 추론 턴 ~20%', color: 'text-blue-400', icon: 'K' },
+  agent_event: { label: 'Agent 이벤트', sublabel: 'tool_called 다수, join/leave/task 포함', color: 'text-emerald-400', icon: 'A' },
+  tool_call_io: { label: 'Keeper Tool I/O', sublabel: 'keeper->tool 입출력 전체 기록', color: 'text-amber-400', icon: 'T' },
+  tool_usage: { label: 'Keeper 내부 호출', sublabel: 'keeper_internal caller 기록', color: 'text-purple-400', icon: 'U' },
+  tool_metric: { label: 'Tool 성능', sublabel: 'duration/success 측정', color: 'text-cyan-400', icon: 'M' },
+}
+
+/** Get source label — returns Korean label, falls back to raw key. */
+export function telemetrySourceLabel(source: string): string {
+  return TELEMETRY_SOURCE_META[source as TelemetrySourceKey]?.label ?? source
+}
+
+/** Get full source meta — returns defaults for unknown sources. */
+export function telemetrySourceMeta(source: string): TelemetrySourceMeta {
+  return TELEMETRY_SOURCE_META[source as TelemetrySourceKey]
+    ?? { label: source, sublabel: '', color: 'text-gray-400', icon: '?' }
+}

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -80,6 +80,22 @@ export function formatTimestampKo(ts: number): string {
   })
 }
 
+// ── Time-only formatters (no date) ──
+
+const timeHhMm = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
+
+/** Format millisecond timestamp as "HH:MM" (24h, ko-KR). */
+export function formatTimeOnly(tsMs: number): string {
+  return timeHhMm.format(new Date(tsMs))
+}
+
+/** Format unix-seconds timestamp as "HH:MM:SS" (24h, ko-KR). */
+export function formatTimeHms(tsUnixSec: number): string {
+  return new Date(tsUnixSec * 1000).toLocaleTimeString('ko-KR', {
+    hour: '2-digit', minute: '2-digit', second: '2-digit',
+  })
+}
+
 /** Format ISO timestamp as English relative time — "just now", "5m ago", "2h ago". */
 export function formatTimeAgoEn(iso: string): string {
   if (!iso.trim()) return 'unknown'

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -80,6 +80,18 @@ export function formatTimestampKo(ts: number): string {
   })
 }
 
+/** Format ISO timestamp as English relative time — "just now", "5m ago", "2h ago". */
+export function formatTimeAgoEn(iso: string): string {
+  if (!iso.trim()) return 'unknown'
+  if (iso === 'never') return 'never'
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000
+  if (Number.isNaN(diff)) return 'unknown'
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
 /** Format a numeric delta with sign prefix. */
 export function formatDelta(delta: number, decimals = 4): string {
   const sign = delta >= 0 ? '+' : ''

--- a/dashboard/src/styles/base.css
+++ b/dashboard/src/styles/base.css
@@ -18,8 +18,10 @@ body {
   color: var(--text-body);
   line-height: 1.5;
   background:
-    radial-gradient(circle at 88% 14%, rgba(74, 222, 128, 0.10), transparent 20%),
-    linear-gradient(180deg, #06101d 0%, #0b1220 48%, #070d18 100%);
+    radial-gradient(circle at 88% 14%, rgba(74, 222, 128, 0.08), transparent 22%),
+    radial-gradient(circle at 8% 88%, rgba(251, 191, 36, 0.04), transparent 28%),
+    radial-gradient(circle at 50% 50%, rgba(71, 184, 255, 0.03), transparent 40%),
+    linear-gradient(180deg, #07111f 0%, #0c1424 48%, #080e1a 100%);
   background-attachment: fixed;
   position: relative;
 }

--- a/dashboard/src/styles/tokens.css
+++ b/dashboard/src/styles/tokens.css
@@ -1,11 +1,11 @@
 /* MASC Dashboard — Design Tokens (Tailwind v4 @theme) */
 
 @theme {
-  --color-bg-0: #0b1220;
-  --color-bg-1: #111a2e;
-  --color-bg-2: #16213c;
-  --color-card: rgba(16, 24, 42, 0.92);
-  --color-card-border: rgba(138, 163, 211, 0.2);
+  --color-bg-0: #0c1424;
+  --color-bg-1: #121c30;
+  --color-bg-2: #17233e;
+  --color-card: rgba(18, 27, 46, 0.94);
+  --color-card-border: rgba(138, 163, 211, 0.22);
   --color-text-strong: #eaf1ff;
   --color-text-body: #c0d2f2;
   --color-text-muted: #a8bfdf;

--- a/dashboard/src/styles/variables.css
+++ b/dashboard/src/styles/variables.css
@@ -6,10 +6,10 @@
      a full light-theme token migration lands. */
   color-scheme: dark;
 
-  /* Base & Backgrounds */
-  --bg-root: #0b1220;
-  --bg-panel: rgba(16, 24, 42, 0.92);
-  --bg-panel-hover: rgba(30, 41, 59, 0.95);
+  /* Base & Backgrounds — slightly lifted from pure dark for depth separation */
+  --bg-root: #0c1424;
+  --bg-panel: rgba(18, 27, 46, 0.94);
+  --bg-panel-hover: rgba(32, 44, 64, 0.96);
 
   /* Text & Typography */
   --text-strong: #eaf1ff;
@@ -51,11 +51,11 @@
   --bad-10: rgba(239, 68, 68, 0.10);
   --bad-20: rgba(239, 68, 68, 0.20);
 
-  /* Overlays (White Alpha) */
-  --white-3: rgba(255, 255, 255, 0.03);
-  --white-5: rgba(255, 255, 255, 0.05);
-  --white-10: rgba(255, 255, 255, 0.10);
-  --white-20: rgba(255, 255, 255, 0.20);
+  /* Overlays (White Alpha) — bumped from 3/5 to 4/6 for clearer surface elevation */
+  --white-3: rgba(255, 255, 255, 0.04);
+  --white-5: rgba(255, 255, 255, 0.06);
+  --white-10: rgba(255, 255, 255, 0.11);
+  --white-20: rgba(255, 255, 255, 0.21);
   --white-50: rgba(255, 255, 255, 0.50);
   --white-80: rgba(255, 255, 255, 0.80);
 


### PR DESCRIPTION
## Summary

MASC 대시보드 UI/UX 일관성 및 가독성 개선. 7 commits.

### 1. Phase 색상 SSOT + CSS warmth
- `keeper-phase-strip.ts`의 독립 `PHASE_COLORS` 제거 → `keeper-phase-indicator.ts`의 `getPhaseStyle` 사용
- 배경 luminance 상향, 카드 패널 opacity 개선, warm gradient 추가

### 2. 시간 포맷팅 통합
- 5개 컴포넌트의 로컬 시간 함수 → `lib/format-time.ts`로 통합
- `formatTimeAgoEn`, `formatTimeOnly`, `formatTimeHms` 추가

### 3. 접근성 + 폰트 크기 + 임계값 상수화
- 네비게이션 emoji에 `aria-label` + `aria-hidden` 추가
- phase badge 9px→10px, 10px→11px
- 인라인 임계값(85/60) → `CONTEXT_RATIO_CRITICAL`/`CONTEXT_RATIO_FLEET_WARN` 상수

### 4. 텔레메트리 소스 SSOT
- `config/telemetry-sources.ts` 생성 (label + sublabel + color + icon)
- `telemetry-unified`와 `fleet-telemetry-panel`의 독립 라벨 맵 제거

### 5-6. 한국어 통일 (~30건)
- "Loading...", "Refresh", "No data" 등 영문 UI → 한국어
- 기술 용어(Fleet, Phase, Discord)는 영문 유지

### 7. LoadingState 공유 컴포넌트 활용
- 인라인 로딩 표시 5건 → `LoadingState` (spinner + 일관된 스타일)

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `vite build` 성공
- [x] vitest 380/381 통과 (1건 기존 MCP auth timeout)
- [ ] CI green (Health 실패는 main 기존 이슈: README→REMOTE-MCP-OPERATOR.md)

Generated with [Claude Code](https://claude.com/claude-code)