### PR TITLE
[codex] fix(dashboard): reduce dashboard log noise

### DIFF
--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -17,6 +17,16 @@ interface NinjaKeysElement extends HTMLElement {
   data: CommandPaletteAction[]
 }
 
+const LIT_DEV_MODE_WARNING =
+  'Lit is in dev mode. Not recommended for production! See https://lit.dev/msg/dev-mode for more information.'
+
+function suppressKnownLitDevWarning() {
+  const globalScope = window as Window & { litIssuedWarnings?: Set<string> }
+  const issuedWarnings = globalScope.litIssuedWarnings ?? new Set<string>()
+  issuedWarnings.add(LIT_DEV_MODE_WARNING)
+  globalScope.litIssuedWarnings = issuedWarnings
+}
+
 export function CommandPalette() {
   const ref = useRef<NinjaKeysElement | null>(null)
   const [ready, setReady] = useState(false)
@@ -24,6 +34,9 @@ export function CommandPalette() {
   useEffect(() => {
     let cancelled = false
 
+    // ninja-keys brings Lit's dev bundle under Vite serve, which emits a
+    // known third-party warning that does not indicate a dashboard defect.
+    suppressKnownLitDevWarning()
     void import('ninja-keys')
       .then(() => {
         if (!cancelled) setReady(true)

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -298,6 +298,8 @@ export function LogViewer() {
         <div class="logs-toolbar flex shrink-0 flex-wrap items-center justify-between gap-4 border-b border-[rgba(255,255,255,0.06)] px-4 py-4">
           <div class="logs-filters flex flex-wrap gap-2 items-center">
             <select
+              name="log-level"
+              aria-label="로그 레벨"
               class="logs-select rounded-md border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               value=${levelFilter.value}
               onChange=${(e: Event) => {
@@ -315,6 +317,8 @@ export function LogViewer() {
 
             <${TextInput}
               class="min-w-[220px]"
+              name="log-module-filter"
+              ariaLabel="모듈 필터"
               placeholder="모듈 필터"
               value=${moduleFilter.value}
               onInput=${(e: Event) => {
@@ -337,6 +341,8 @@ export function LogViewer() {
             />
 
             <select
+              name="log-limit"
+              aria-label="로그 개수"
               class="logs-select rounded-md border border-[var(--white-10)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-[12px] text-[var(--text-body)]"
               value=${String(logLimit.value)}
               onChange=${(e: Event) => {
@@ -359,6 +365,8 @@ export function LogViewer() {
             <label class="logs-auto-label flex items-center gap-1.5 cursor-pointer">
               <input
                 type="checkbox"
+                name="log-auto-refresh"
+                aria-label="자동 새로고침"
                 checked=${autoRefresh.value}
                 onChange=${() => { autoRefresh.value = !autoRefresh.value }}
               />

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -1,22 +1,32 @@
-(** Tool_registration_check — Startup validation of Tool_spec ↔ TOML coverage.
+(** Tool_registration_check — Startup validation of keeper tool policy coverage.
 
-    Detects drift between registered Tool_spec tools and config/tool_policy.toml
-    group definitions. Called once after init_policy_config succeeds. *)
+    Detects drift between the runtime keeper tool universe and
+    config/tool_policy.toml group definitions.
+    Called once after init_policy_config succeeds. *)
 
 type validation_result = {
   orphan_toml : string list;
   uncovered : string list;
 }
 
-let validate () : validation_result =
-  let registered =
-    let tbl = Hashtbl.create 256 in
-    List.iter (fun n -> Hashtbl.replace tbl n ()) (Tool_spec.all_registered_names ());
-    tbl
+let add_names names tbl =
+  List.iter (fun name -> Hashtbl.replace tbl name ()) names;
+  tbl
+
+let runtime_keeper_tool_names () =
+  let schema_names =
+    Config.raw_all_tool_schemas
+    |> List.map (fun (schema : Types.tool_schema) -> schema.name)
   in
+  Hashtbl.create 512
+  |> add_names schema_names
+  |> add_names Keeper_exec_tools.core_always_tools
+
+let validate () : validation_result =
   match Keeper_tool_policy.policy_config_for_validation () with
   | None -> { orphan_toml = []; uncovered = [] }
   | Some cfg ->
+    let runtime_keeper_tools = runtime_keeper_tool_names () in
     let configured =
       let tbl = Hashtbl.create 256 in
       List.iter (fun n -> Hashtbl.replace tbl n ())
@@ -26,24 +36,22 @@ let validate () : validation_result =
     in
     let orphan_toml =
       Hashtbl.fold (fun name () acc ->
-        if not (Hashtbl.mem registered name) then name :: acc else acc
+        if not (Hashtbl.mem runtime_keeper_tools name) then name :: acc else acc
       ) configured []
       |> List.sort String.compare
     in
-    let uncovered =
-      Hashtbl.fold (fun name () acc ->
-        if not (Hashtbl.mem configured name) then name :: acc else acc
-      ) registered []
-      |> List.sort String.compare
-    in
+    (* tool_policy.toml describes the keeper-facing subset, not the full MCP
+       registry, so reverse "coverage" against all registered tools is noisy
+       and not actionable as a startup warning. *)
+    let uncovered = [] in
     { orphan_toml; uncovered }
 
 let log_validation_result (r : validation_result) =
   if r.orphan_toml <> [] then
-    Log.Server.warn "TOML->Tool_spec orphans (%d): %s"
+    Log.Server.warn "tool_policy unknown tool names (%d): %s"
       (List.length r.orphan_toml)
       (String.concat ", " (List.filteri (fun i _ -> i < 10) r.orphan_toml));
   if r.uncovered <> [] then
-    Log.Server.warn "Tool_spec->TOML uncovered (%d): %s"
+    Log.Server.info "tool_policy reverse coverage (%d): %s"
       (List.length r.uncovered)
       (String.concat ", " (List.filteri (fun i _ -> i < 10) r.uncovered))

--- a/lib/tool_registration_check.mli
+++ b/lib/tool_registration_check.mli
@@ -2,13 +2,13 @@
 
 type validation_result = {
   orphan_toml : string list;
-  (** In TOML groups but no Tool_spec registration *)
+  (** Configured in tool_policy.toml but missing from the runtime keeper tool universe. *)
   uncovered : string list;
-  (** Registered in Tool_spec but not in any TOML group *)
+  (** Reserved for reverse-coverage diagnostics; currently non-fatal and may be empty. *)
 }
 
 val validate : unit -> validation_result
-(** Cross-validate registered Tool_spec names against tool_policy.toml groups.
+(** Cross-validate tool_policy.toml against the runtime keeper tool universe.
     Returns orphan/uncovered tool names. Safe to call when policy not loaded. *)
 
 val log_validation_result : validation_result -> unit


### PR DESCRIPTION
## What changed
- add explicit `name` and accessible labels to the dashboard logs toolbar form controls
- suppress the known Lit dev-mode console warning emitted by `ninja-keys` in Vite dev
- change keeper tool policy validation to compare against the runtime keeper tool universe instead of the full Tool_spec registry
- rename the startup validation log message so it reflects actual tool-policy drift

## Why this changed
The logs dashboard was mixing real runtime warnings with avoidable frontend and startup noise, which made triage slower.

## User impact
- browser console noise on `#/logs` is reduced
- logs toolbar controls no longer trigger unnamed form field accessibility warnings
- startup no longer emits misleading tool-policy coverage warnings for valid keeper tools

## Root cause
- the logs toolbar rendered form controls without `name` attributes
- `ninja-keys` pulls Lit's dev bundle under Vite serve, which emits a known third-party warning
- the startup validator compared `tool_policy.toml` against the full MCP registration set instead of the keeper-facing runtime tool set

## Validation
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin/tsc --noEmit --pretty -p /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-log-warn-cleanup/dashboard/tsconfig.json`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-log-warn-cleanup`
- verified `http://127.0.0.1:4174/dashboard/#logs` no longer shows the Lit warning or unnamed form-field issue in DevTools console
