### PR TITLE
docs(ocaml): add .mli interfaces for 4 high-priority modules

### DIFF
--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -1,0 +1,195 @@
+(** Keeper_alerting — alert fanout, signal scoring, skill routing, and
+    path safety checks for keeper execution.
+
+    Includes {!Keeper_skill_routing} and {!Keeper_alerting_path} via
+    [include] for backward-compatible access by downstream modules.
+
+    @since v2.200.0 *)
+
+open Keeper_types
+open Keeper_memory
+
+(** {1 Included: Keeper_skill_routing types} *)
+
+type selection_mode =
+  | Heuristic
+  | Model_selected of string
+  | Model_rejected of string
+
+type keeper_skill_route = {
+  primary_skill : string;
+  secondary_skill : string option;
+  reason : string;
+  selection_mode : selection_mode;
+}
+
+(** {1 Usage Merging} *)
+
+(** Merge two API usage records by summing all fields. *)
+val merge_usage :
+  Agent_sdk.Types.api_usage ->
+  Agent_sdk.Types.api_usage ->
+  Agent_sdk.Types.api_usage
+
+(** {1 Alert Retry Logic} *)
+
+(** Check whether an error message indicates a retryable condition
+    (timeout, 429, 502-504, connection errors, etc.). *)
+val alert_retryable_error : string -> bool
+
+(** Compute retry delay in seconds with exponential backoff. *)
+val alert_retry_delay_seconds : int -> float
+
+(** Run a single alert channel with retry logic. *)
+val run_alert_channel_with_retry :
+  _ context ->
+  channel:string ->
+  enabled:bool ->
+  send_once:(unit -> bool * string option) ->
+  alert_channel_result
+
+(** {1 Alert Deduplication} *)
+
+(** Time window (seconds) for suppressing duplicate alerts. *)
+val alert_dedup_window_sec : float
+
+(** Check if an alert was already emitted within the dedup window.
+    Records the alert if not deduplicated. *)
+val is_alert_deduplicated :
+  keeper_name:string -> reasons:string list -> bool
+
+(** {1 Alert Signal Scoring} *)
+
+(** Keyword weights for alert severity scoring. *)
+val alert_keyword_weights : (string * float) list
+
+val signal_bonus_guardrail_stop : float
+val signal_bonus_handoff_pressure : float
+val signal_bonus_low_alignment : float
+val signal_bonus_multi_tool : float
+
+val handoff_pressure_threshold : unit -> float
+val goal_alignment_floor : float
+val response_alignment_floor : float
+val multi_tool_min_count : int
+
+(** Compute alert signal score, reasons, and matched keywords.
+    Returns [(score, reasons, keywords)]. *)
+val keeper_alert_signal :
+  message:string ->
+  reply:string ->
+  context_ratio:float ->
+  goal_alignment:float ->
+  response_alignment:float ->
+  tool_call_count:int ->
+  auto_rules:keeper_auto_rule_eval ->
+  float * string list * string list
+
+(** Format alert text for fanout channels. *)
+val keeper_alert_text :
+  meta:keeper_meta ->
+  score:float ->
+  reasons:string list ->
+  keywords:string list ->
+  message:string ->
+  reply:string ->
+  work_kind:string ->
+  context_ratio:float ->
+  goal_alignment:float ->
+  response_alignment:float ->
+  string
+
+(** {1 Alert Channel Posting} *)
+
+val post_keeper_alert_board :
+  alert_text:string -> bool * string option
+
+val post_keeper_alert_slack :
+  alert_text:string -> bool * string option
+
+val post_keeper_alert_slack_dm :
+  alert_text:string -> user_id:string -> bool * string option
+
+val post_keeper_alert_github :
+  title:string -> body:string -> bool * string option
+
+(** {1 Alert Orchestration} *)
+
+(** Evaluate alert signal and fan out to configured channels
+    (board, Slack webhook, Slack DM, GitHub issue).
+    Handles dedup, JSONL logging, retry, and dead-letter queuing. *)
+val maybe_emit_interesting_alert :
+  _ context ->
+  meta:keeper_meta ->
+  message:string ->
+  reply:string ->
+  work_kind:string ->
+  tool_call_count:int ->
+  context_ratio:float ->
+  goal_alignment:float ->
+  response_alignment:float ->
+  auto_rules:keeper_auto_rule_eval ->
+  interesting_alert_result
+
+(** {1 Slack API Helpers} *)
+
+val slack_alert_token : unit -> string option
+
+val slack_api_post_json :
+  token:string ->
+  endpoint:string ->
+  payload:Yojson.Safe.t ->
+  (Yojson.Safe.t, string) result
+
+val slack_ok_or_error : Yojson.Safe.t -> (unit, string) result
+
+(** {1 Included: Keeper_skill_routing} *)
+
+val keeper_allowed_skills : string list
+val is_valid_keeper_skill : string -> bool
+val keeper_skill_priority : string -> int
+val route_keeper_skill : message:string -> keeper_skill_route
+val format_skill_route_line : keeper_skill_route -> string
+val format_skill_route_reason : keeper_skill_route -> string
+val strip_skill_route_lines : string -> string
+val parse_skill_route_response :
+  string -> fallback_route:keeper_skill_route -> keeper_skill_route
+val keeper_skill_routing_instructions :
+  fallback_route:keeper_skill_route -> string
+val skill_route_context_text :
+  fallback_route:keeper_skill_route -> string
+
+(** {1 Included: Keeper_alerting_path} *)
+
+val project_root_of_config : Room.config -> string
+val normalize_path_for_check : string -> string
+val normalize_allowed_path_for_check :
+  root:string -> string -> string option
+val is_within_root_norm : root_norm:string -> string -> bool
+val absolute_allowed_paths :
+  config:Room.config -> allowed_paths:string list -> string list
+val absolute_allowed_paths_result :
+  config:Room.config -> allowed_paths:string list -> (string list, string) result
+val resolve_keeper_target_path :
+  config:Room.config ->
+  allowed_paths:string list ->
+  raw_path:string ->
+  (string, string) result
+val sanitize_keeper_name : string -> string
+val playground_path_of_keeper : string -> string
+val playground_mind_path : string -> string
+val playground_repos_path : string -> string
+val effective_allowed_paths : meta:keeper_meta -> string list
+val resolve_keeper_read_path :
+  config:Room.config ->
+  allowed_paths:string list ->
+  raw_path:string ->
+  (string, string) result
+val process_status_to_json : Unix.process_status -> Yojson.Safe.t
+val extract_user_messages : working_context -> string list
+
+(** {1 Re-exported Utilities} *)
+
+val keeper_model_tools : Types.tool_schema list
+val dedup_strings : string list -> string list
+val split_csv_nonempty : string -> string list

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -1,0 +1,204 @@
+(** Keeper configuration — defaults, environment variable parsing, profiles.
+
+    Central SSOT for keeper runtime constants, environment variable parsing,
+    compaction profiles, and runtime parameter registrations.
+
+    @since v2.128.0 *)
+
+(** {1 Core Constants} *)
+
+(** Default cascade name for keeper turns.  All keeper code must reference
+    this constant instead of using the string literal.
+    @since v2.128.0 *)
+val default_cascade_name : string
+
+(** Minimum context window (tokens) for any keeper turn. *)
+val min_keeper_context_tokens : int
+
+val default_execution_scope : string
+val default_proactive_enabled : bool
+val default_proactive_idle_sec : int
+val default_proactive_cooldown_sec : int
+val default_keeper_will : string
+val default_keeper_needs : string
+val default_keeper_desires : string
+val default_room_signal_prompt_enabled : bool
+val default_goal_horizon_max_chars : int
+val default_drift_max_clauses : int
+val default_drift_max_chars : int
+
+(** {1 Environment Variable Parsing} *)
+
+(** Parse a boolean env var where the default is [true] when unset. *)
+val bool_default_true_of_env : string -> bool
+
+(** Parse a boolean env var with an explicit default.
+    Recognizes 1/true/yes/y/on and 0/false/no/n/off. *)
+val bool_of_env_default : string -> default:bool -> bool
+
+(** Parse a boolean env var, returning [None] when unset or unrecognized. *)
+val bool_of_env_opt : string -> bool option
+
+(** Parse an integer env var with default and clamping. *)
+val int_of_env_default : string -> default:int -> min_v:int -> max_v:int -> int
+
+(** Parse a float env var with default and clamping. *)
+val float_of_env_default : string -> default:float -> min_v:float -> max_v:float -> float
+
+(** Clamp an integer to [min_v, max_v]. *)
+val clamp_int : int -> min_v:int -> max_v:int -> int
+
+(** {1 Name Validation} *)
+
+(** Validate a keeper name: non-empty, alphanumeric with dots, dashes, underscores. *)
+val validate_name : string -> bool
+
+(** {1 Removed Key Detection} *)
+
+(** Field names that are no longer accepted in keeper creation/update input. *)
+val removed_keeper_input_key_names : string list
+
+(** Field names that are no longer accepted in keeper message input. *)
+val removed_keeper_msg_input_key_names : string list
+
+(** Field names that are no longer accepted in keeper metadata. *)
+val removed_keeper_meta_key_names : string list
+
+(** Return which [keys] are present as top-level keys in the JSON object. *)
+val present_json_keys : string list -> Yojson.Safe.t -> string list
+
+(** Reject removed keeper input keys.  Returns [Error msg] listing the offending fields. *)
+val reject_removed_keeper_input_keys :
+  tool_name:string -> Yojson.Safe.t -> (unit, string) result
+
+(** Reject removed keeper message input keys. *)
+val reject_removed_keeper_msg_input_keys :
+  tool_name:string -> Yojson.Safe.t -> (unit, string) result
+
+(** {1 UTF-8 Safety} *)
+
+(** Truncate a string to at most [max_bytes] bytes on a valid UTF-8 boundary. *)
+val utf8_safe_prefix_bytes : string -> max_bytes:int -> string
+
+(** Replace invalid UTF-8 sequences with U+FFFD. *)
+val utf8_repair_string : string -> string
+
+(** {1 Text Normalization} *)
+
+val normalize_self_model_text : ?max_len:int -> string -> string
+val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_horizon_opt : string option -> string option
+val parse_goal_horizon_opt : Yojson.Safe.t -> string -> string option
+
+(** Resolve short/mid/long goal horizons with fallback to [goal]. *)
+val resolve_goal_horizons :
+  goal:string ->
+  short_goal_opt:string option ->
+  mid_goal_opt:string option ->
+  long_goal_opt:string option ->
+  string * string * string
+
+val split_semicolon_clauses : string -> string list
+val take_last : int -> 'a list -> 'a list
+
+(** Compact self-model text: take last N clauses, truncate to max chars. *)
+val compact_self_model_text :
+  ?max_clauses:int -> ?max_chars:int -> string -> string
+
+val parse_self_model_opt : Yojson.Safe.t -> string -> string option
+
+(** {1 Compaction Configuration} *)
+
+val default_compaction_profile : string
+val canonical_compaction_profile : string -> string option
+val parse_compaction_profile_opt :
+  Yojson.Safe.t -> string -> (string option, string) result
+
+(** Return (ratio, message_gate, token_gate) for a named profile. *)
+val compaction_policy_of_profile : string -> float * int * int
+
+(** Resolve compaction policy from explicit overrides with profile-based fallbacks. *)
+val resolve_compaction_policy :
+  profile_opt:string option ->
+  ratio_opt:float option ->
+  message_opt:int option ->
+  token_opt:int option ->
+  fallback_profile:string ->
+  fallback_ratio:float ->
+  fallback_message:int ->
+  fallback_token:int ->
+  string * float * int * int
+
+val normalize_compaction_ratio_gate : float -> float
+val normalize_compaction_message_gate : int -> int
+val normalize_compaction_token_gate : int -> int
+val normalize_continuity_compaction_cooldown_sec : int -> int
+
+val normalize_proactive_idle_sec : int -> int
+val normalize_proactive_cooldown_sec : int -> int
+
+(** {1 Runtime Parameters}
+
+    These functions return the current runtime-tunable value.
+    Each parameter is registered with [Runtime_params] and can be
+    adjusted via the dashboard at runtime. *)
+
+val keeper_compact_ratio : unit -> float
+val keeper_compact_max_messages : unit -> int
+val keeper_compact_max_tokens : unit -> int
+val keeper_continuity_compaction_cooldown_sec : unit -> int
+val keeper_compaction_policy_from_env : unit -> float * int * int
+
+val keeper_bootstrap_proactive_warmup_sec : unit -> int
+val keeper_bootstrap_stagger_step_sec : unit -> int
+val keeper_bootstrap_retry_max : unit -> int
+val keeper_bootstrap_retry_interval_sec : unit -> int
+
+val keeper_proactive_min_cooldown_sec : unit -> int
+val keeper_proactive_task_cooldown_divisor : unit -> int
+val keeper_proactive_task_min_cooldown_sec : unit -> int
+
+val keeper_batch_limit : unit -> int
+val keeper_tool_cost_max_usd : unit -> float
+val keeper_max_tools_per_turn : unit -> int
+val keeper_retry_max_tools_per_turn : unit -> int
+val keeper_board_event_limit : unit -> int
+val keeper_llm_rerank_enabled : unit -> bool
+val keeper_llm_rerank_cascade : unit -> string
+
+val keeper_rule_reflect_repetition_threshold : unit -> float
+val keeper_rule_plan_goal_alignment_threshold : unit -> float
+val keeper_rule_plan_response_alignment_threshold : unit -> float
+val keeper_rule_guardrail_repetition_threshold : unit -> float
+val keeper_rule_guardrail_goal_alignment_threshold : unit -> float
+val keeper_rule_guardrail_response_alignment_threshold : unit -> float
+val keeper_rule_guardrail_context_threshold : unit -> float
+
+val keeper_unified_temperature : unit -> float
+val keeper_unified_max_tokens : unit -> int
+val keeper_tool_search_top_k : unit -> int
+
+val keeper_status_fast_default : unit -> bool
+
+val keeper_llama_slots : unit -> int
+
+(** Compute a deterministic slot_id for a keeper name.
+    Returns [None] when slot pinning is disabled. *)
+val keeper_slot_id : string -> int option
+
+val keeper_boring_exit_threshold : unit -> int
+val keeper_enable_thinking : unit -> bool
+val keeper_adaptive_thinking_enabled : unit -> bool
+
+(** {1 Runtime Param Handles}
+
+    Exposed for test use only (e.g. [Runtime_params.clear]). *)
+
+val keeper_boring_exit_threshold_rp : int Runtime_params.param
+
+(** Room signal prompt enabled override from env var. *)
+val keeper_room_signal_prompt_enabled_override : unit -> bool option
+
+(** Force module initialization to guarantee all runtime params are registered
+    before [Runtime_params.restore].  Call from server bootstrap. *)
+val ensure_runtime_params_init : unit -> unit

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -1,0 +1,143 @@
+(** Keeper_tool_policy — tool access control, presets, and allowed-tool resolution.
+
+    Preset definitions are loaded from [config/tool_policy.toml] at startup
+    via {!Keeper_tool_policy_config}.  Consumes {!Keeper_tool_registry} for
+    candidate aggregation and core tools.
+
+    @since v2.200.0 *)
+
+open Keeper_types
+
+(** {1 Policy Initialization} *)
+
+(** Load tool policy configuration from [config/tool_policy.toml].
+    Must be called once at server startup before any preset resolution. *)
+val init_policy_config :
+  base_path:string -> (unit, string) result
+
+(** Return the loaded policy config, if any.  Used for validation. *)
+val policy_config_for_validation :
+  unit -> Keeper_tool_policy_config.t option
+
+(** {1 Preset Names and Mapping} *)
+
+(** Convert a [tool_preset] variant to its string name. *)
+val preset_name_of_tool_preset : tool_preset -> string
+
+(** Return configured preset names (excluding "full") for schema enum generation. *)
+val configured_preset_names : unit -> string list
+
+(** Check if [agent_preset] subsumes [required_preset] per the config hierarchy. *)
+val preset_can_satisfy :
+  agent_preset:string -> required_preset:string -> bool
+
+(** {1 Workflow and Shell Permissions} *)
+
+val allows_workflow_for_preset : tool_preset -> bool
+val allows_shell_write_for_preset : tool_preset -> bool
+
+(** {1 Git Clone Config} *)
+
+val git_clone_allowed_orgs : unit -> string list
+val git_clone_denied_repos : unit -> string list
+val clone_depth : unit -> int
+val clone_timeout_sec : unit -> float
+val push_timeout_sec : unit -> float
+val pr_create_timeout_sec : unit -> float
+
+(** {1 MASC Schema Injection} *)
+
+(** Filter and inject MASC schemas for keeper tool selection.
+    Call once after MASC schemas are registered. *)
+val inject_masc_schemas : Types.tool_schema list -> unit
+
+(** Filter names to only those present in the injected MASC set. *)
+val select_existing_masc_tool_names : string list -> string list
+
+(** {1 Tool Access Lookup}
+
+    O(1) per-tool access checks using hash tables. *)
+
+type tool_access_lookup = {
+  candidate_names : string list;
+  candidate_set : (string, unit) Hashtbl.t;
+  allow_set : (string, unit) Hashtbl.t;
+  deny_set : (string, unit) Hashtbl.t;
+}
+
+(** Build a hash set from a list of tool names. *)
+val tool_name_set : string list -> (string, unit) Hashtbl.t
+
+(** Build a lookup structure from keeper metadata. *)
+val tool_access_lookup_of_meta : keeper_meta -> tool_access_lookup
+
+(** Check if a tool passes candidate + policy + deny filters. *)
+val filter_by_access : lookup:tool_access_lookup -> string -> bool
+
+(** Check candidate membership minus denied, ignoring policy.
+    Used as execution gate for BM25-discovered tools. *)
+val filter_by_universe : lookup:tool_access_lookup -> string -> bool
+
+(** Execution gate: core tools bypass policy, others require allowlist.
+    Rejects hallucinated tool names not in candidate_set. *)
+val can_execute : lookup:tool_access_lookup -> string -> bool
+
+(** {1 Tool Name Queries} *)
+
+(** Policy-filtered MASC tool names for a keeper. *)
+val keeper_masc_tool_names : keeper_meta -> string list
+
+(** Policy-filtered MASC tool schemas for a keeper. *)
+val keeper_masc_tool_schemas : keeper_meta -> Types.tool_schema list
+
+(** Universe (policy-independent) MASC tool schemas for BM25 indexing. *)
+val keeper_universe_masc_tool_schemas : keeper_meta -> Types.tool_schema list
+
+(** Default model tools (keeper_model_tools + voice + tool_search). *)
+val keeper_default_model_tools : keeper_meta -> Types.tool_schema list
+
+(** Policy-filtered allowed tool names.
+    Returns empty list when [write_done] is true. *)
+val keeper_allowed_tool_names :
+  ?write_done:bool -> keeper_meta -> string list
+
+(** Universe tool names: candidates minus denied, no policy filter. *)
+val keeper_universe_tool_names : keeper_meta -> string list
+
+(** Preset-scoped universe: preset allowlist + core_always - denied. *)
+val keeper_preset_universe_tool_names : keeper_meta -> string list
+
+(** Tools safe to call on the keeper's last turn. *)
+val last_turn_safe_tool_names : unit -> string list
+
+(** {1 Tool Schema Assembly} *)
+
+(** Policy-filtered model tool schemas. *)
+val keeper_allowed_model_tools :
+  ?write_done:bool -> keeper_meta -> Types.tool_schema list
+
+(** Universe model tool schemas for Agent.run(). *)
+val keeper_universe_model_tools : keeper_meta -> Types.tool_schema list
+
+(** Preset-scoped universe model tool schemas for BM25 indexing. *)
+val keeper_preset_universe_model_tools : keeper_meta -> Types.tool_schema list
+
+(** Filter schemas by a set of allowed names.  O(1) per schema. *)
+val filter_schemas_by_names :
+  string list -> Types.tool_schema list -> Types.tool_schema list
+
+(** Deduplicate tool schemas by name. *)
+val dedupe_tool_schemas :
+  Types.tool_schema list -> Types.tool_schema list
+
+(** {1 Tool Description Lookup} *)
+
+(** Lookup tool hint (first sentence + enum/required hints) by name.
+    Returns [None] for unknown tools. *)
+val tool_hint_of : string -> string option
+
+(** Check if a tool name is in the keeper denied set. *)
+val is_keeper_denied : string -> bool
+
+(** Check if a tool requires MCP context injection. *)
+val is_keeper_mcp_context_required : string -> bool

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -1,0 +1,281 @@
+(** Provider_adapter — provider registry, auth resolution, voice bridge,
+    and cascade label construction.
+
+    Single source of truth for all LLM and voice provider adapters.
+    Adding a new provider = adding one entry to [direct_adapters].
+
+    @since v2.100.0 *)
+
+(** {1 Types} *)
+
+type runtime_kind =
+  | Local
+  | Direct_api
+
+type auth_mode =
+  | No_auth
+  | Api_key of string
+  | Vertex_adc of {
+      project_env : string;
+      location_env : string;
+    }
+
+type voice_transport =
+  | Voice_openai_compat
+  | Voice_elevenlabs_direct
+  | Voice_mcp
+
+type adapter = {
+  canonical_name : string;
+  runtime_kind : runtime_kind;
+  auth_mode : auth_mode;
+  aliases : string list;
+  spawn_key : string option;
+  cascade_prefix : string;
+  default_voice : string option;
+  endpoint_url : string option;
+  default_model_id : string option;
+}
+
+type voice_adapter = {
+  canonical_name : string;
+  transport : voice_transport;
+  auth_mode : auth_mode;
+  aliases : string list;
+}
+
+type voice_http_request = {
+  url : string;
+  headers : (string * string) list;
+  body_json : Yojson.Safe.t;
+}
+
+type voice_stt_request = {
+  url : string;
+  headers : (string * string) list;
+  form_fields : (string * string) list;
+  file_field : string * string;
+}
+
+type gemini_direct_auth =
+  | Gemini_vertex_adc of {
+      project : string;
+      location : string;
+    }
+  | Gemini_api_key
+  | Gemini_auth_missing of string
+
+type auth_detail = {
+  auth_kind : string;
+  status : string;
+  available : bool;
+  supports_run : bool;
+  endpoint_url : string option;
+  note : string option;
+}
+
+(** {1 Canonical Provider Names} *)
+
+val cn_llama : string
+val cn_ollama : string
+val cn_claude : string
+val cn_codex : string
+val cn_gemini : string
+val cn_glm : string
+val cn_openrouter : string
+val cn_custom : string
+
+(** {1 String Converters} *)
+
+val string_of_runtime_kind : runtime_kind -> string
+val string_of_auth_mode : auth_mode -> string
+val string_of_voice_transport : voice_transport -> string
+
+(** {1 Adapter Registry} *)
+
+(** All registered LLM provider adapters. *)
+val direct_adapters : adapter list
+
+(** All registered voice provider adapters. *)
+val voice_adapters : voice_adapter list
+
+(** {1 Label and Provider Resolution} *)
+
+(** Normalize a label to lowercase trimmed form. *)
+val normalize_label : string -> string
+
+(** SSOT cascade prefix for local models. *)
+val local_cascade_prefix : string
+
+(** Build a cascade model label for a local model.
+    Single entry point; other modules must not concatenate prefix manually. *)
+val make_local_label : string -> string
+
+(** Map OAS [Provider_config.provider_kind] to MASC adapter canonical_name. *)
+val string_of_provider_kind :
+  Llm_provider.Provider_config.provider_kind -> string
+
+(** Resolve an adapter by canonical name or alias. *)
+val resolve_direct_adapter : string -> adapter option
+
+(** Resolve the canonical name for a provider label. *)
+val resolve_direct_canonical_name : string -> string option
+
+(** Resolve spawn_key for an agent label. *)
+val resolve_spawn_key : string -> string option
+
+(** Check if a name is a known direct adapter label or alias. *)
+val is_known_provider : string -> bool
+
+(** Check if a name is a CLI-spawnable agent (has a spawn_key). *)
+val is_spawnable_agent : string -> bool
+
+(** Return canonical names of all spawnable adapters. *)
+val spawnable_canonical_names : unit -> string list
+
+(** Returns true if the provider uses runtime discovery (e.g. live /props probe). *)
+val requires_discovery : string -> bool
+
+(** Returns true if the provider is self-hosted and always available. *)
+val is_local_provider : string -> bool
+
+(** {1 Voice Adapter Resolution} *)
+
+val resolve_voice_adapter : string -> voice_adapter option
+val voice_adapter_for_endpoint : Voice_config.endpoint -> voice_adapter
+val voice_adapter_for_endpoint_kind : Voice_config.endpoint_kind -> voice_adapter
+val voice_adapter_labels : voice_adapter -> string list
+val voice_endpoint_matches_provider_label : string -> Voice_config.endpoint -> bool
+val select_voice_endpoints :
+  ?provider:string -> Voice_config.endpoint list -> Voice_config.endpoint list
+(** Resolve auth env var name for a voice adapter, with optional endpoint override. *)
+val voice_auth_env_name :
+  ?endpoint_api_key_env:string -> voice_adapter -> string option
+
+val voice_endpoint_auth_env_name : Voice_config.endpoint -> string option
+val voice_transport_supports_http_tts : voice_adapter -> bool
+val voice_endpoint_supports_http_tts : Voice_config.endpoint -> bool
+
+(** All agent voices as [(canonical_name, voice_name)] pairs. *)
+val all_agent_voices : unit -> (string * string) list
+
+(** {1 Voice Session URLs} *)
+
+val default_voice_session_url : path:string -> string
+val voice_session_endpoint_result :
+  Voice_config.t -> (Voice_config.endpoint, string) result
+val voice_session_mcp_url_of_endpoint :
+  Voice_config.endpoint -> (string, string) result
+val voice_session_health_url_of_endpoint :
+  Voice_config.endpoint -> (string, string) result
+
+(** {1 Voice HTTP Requests} *)
+
+val voice_http_request_for_tts :
+  Voice_config.endpoint ->
+  api_key:string ->
+  message:string ->
+  voice:string ->
+  model:string ->
+  tuning:Voice_config.voice_tuning ->
+  (voice_http_request, string) result
+
+val voice_stt_request_for_endpoint :
+  Voice_config.endpoint ->
+  api_key:string ->
+  audio_file:string ->
+  model:string ->
+  (voice_stt_request, string) result
+
+(** {1 Model Label Resolution} *)
+
+(** Default fallback label for local runtime when no preferred models exist. *)
+val default_local_fallback_label : unit -> string
+
+(** Preferred execution model labels in priority order. *)
+val preferred_execution_model_labels : unit -> string list
+
+(** Preferred verifier model labels in priority order. *)
+val preferred_verifier_model_labels : unit -> string list
+
+(** Configured default model label (first from MASC_DEFAULT_CASCADE or
+    MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL). *)
+val configured_default_model_label_result : unit -> (string, string) result
+
+(** Configured verifier model label (MASC_DEFAULT_VERIFIER_MODEL fallback to default). *)
+val configured_verifier_model_label_result : unit -> (string, string) result
+
+(** Default model label(s) result. *)
+val default_model_labels_result : unit -> (string list, string) result
+
+(** First default model label. *)
+val default_model_label_result : unit -> (string, string) result
+
+(** Extract provider prefix from a "provider:model" label. *)
+val provider_prefix_of_label_result : string -> (string, string) result
+
+(** Provider prefix of the default model label. *)
+val default_model_provider_prefix_result : unit -> (string, string) result
+
+(** Override the model portion of the default model label. *)
+val default_model_override_label_result : string -> (string, string) result
+
+(** Default local model label; raises [Invalid_arg] if unconfigured. *)
+val default_local_model_label : unit -> string
+
+(** {1 Llama Model Resolution} *)
+
+val explicit_llama_model_id_result : unit -> (string, string) result
+val explicit_llama_model_id : unit -> string
+val explicit_llama_model_label_result : unit -> (string, string) result
+val explicit_llama_model_label : unit -> string
+
+(** {1 Ollama} *)
+
+val bare_ollama_migration_message : unit -> string
+val is_bare_ollama_label : string -> bool
+
+(** {1 Auth} *)
+
+(** Check whether a provider has auth credentials configured. *)
+val provider_auth_available : string -> bool
+
+(** Derive auth_kind string for a provider canonical name. *)
+val auth_kind_for_canonical_name : string -> string
+
+(** Provider-agnostic auth detail for dashboard display. *)
+val auth_detail_of_provider : string -> auth_detail
+
+(** Cascade prefix from adapter record. *)
+val cascade_prefix_of_adapter : adapter -> string
+
+(** Endpoint URL from adapter record. *)
+val endpoint_url_of_adapter : adapter -> string option
+
+(** Best-effort mapping from OAS provider_kind to cascade prefix. *)
+val cascade_prefix_of_provider_kind :
+  Llm_provider.Provider_config.provider_kind -> string
+
+(** {1 Gemini Auth} *)
+
+val gemini_direct_available : unit -> bool
+val resolve_gemini_direct_auth : unit -> gemini_direct_auth
+
+(** Compute the Vertex AI OpenAI-compatible endpoint URL. *)
+val gemini_vertex_openai_base_url : project:string -> location:string -> string
+
+(** {1 Model Family Classification} *)
+
+(** Classify a model into a family bucket based on locality and context window.
+    Returns "small_local", "medium_cloud", or "large_cloud". *)
+val classify_model_family : is_local:bool -> context_window:int -> string
+
+(** {1 Misc} *)
+
+val default_cli_agent_name : unit -> string
+
+(** Build "provider:model" label, returns [None] if model is empty. *)
+val provider_model_label : string -> string -> string option
+
+(** Extract the env var name from an adapter's [auth_mode], if any. *)
+val auth_env_var_of_adapter : adapter -> string option


### PR DESCRIPTION
## Summary
- 4개 .mli 인터페이스 파일 추가 (+823 LOC)
- 32.5% → 33.1% .mli 커버리지 (220 → 224)
- 내부 헬퍼 함수는 숨기고 공개 API만 노출

## 대상 모듈 (우선순위 기반)

| 모듈 | LOC | .mli 선정 사유 |
|------|-----|---------------|
| `keeper_config.ml` | 460+ | 핵심 설정, 새 상수 SSOT |
| `keeper_alerting.ml` | 350+ | 보안 민감 (Slack 알림) |
| `keeper_tool_policy.ml` | 480+ | 도구 접근 제어 |
| `provider_adapter.ml` | 980 | API 키/토큰 처리 |

## 비공개 처리된 내부 함수 (예시)
- `keeper_config`: `_rp_validate_*`, `_rp_deser_*` 등록 헬퍼
- `keeper_alerting`: `contains_ci`, `alert_dedup_table`
- `keeper_tool_policy`: `policy_config` ref, `first_sentence`, `enum_hints_of_schema`
- `provider_adapter`: `trim_opt`, `normalize_base_url`, `auto_detect_adapters`

## Test plan
- [ ] CI build green
- [ ] `dune test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)