### PR TITLE
[codex] fix fleet telemetry sort order

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.sort.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.sort.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { buildFleetRows } from './fleet-telemetry-panel'
+import type { ToolQualityResponse } from '../api/dashboard'
+import type { Keeper } from '../types'
+
+function toolQualityByKeeper(
+  entries: Array<{ name: string; calls: number; success_pct: number }>,
+): ToolQualityResponse {
+  return {
+    total: entries.reduce((sum, entry) => sum + entry.calls, 0),
+    success: 0,
+    failure: 0,
+    success_rate: 0,
+    by_tool: [],
+    by_keeper: entries,
+    failure_categories: [],
+    hourly_trend: [],
+  }
+}
+
+describe('buildFleetRows sort order', () => {
+  it('prefers recent live activity before less recent live keepers', () => {
+    const keepers = [
+      {
+        name: 'recent-tools',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.1,
+        total_turns: 5,
+        last_activity_ago_s: 30,
+      },
+      {
+        name: 'older-more-tools',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.9,
+        total_turns: 20,
+        last_activity_ago_s: 600,
+      },
+    ] satisfies Keeper[]
+
+    const rows = buildFleetRows(
+      keepers,
+      toolQualityByKeeper([
+        { name: 'recent-tools', calls: 12, success_pct: 100 },
+        { name: 'older-more-tools', calls: 120, success_pct: 100 },
+      ]),
+    )
+
+    expect(rows.map(row => row.name)).toEqual(['recent-tools', 'older-more-tools'])
+  })
+
+  it('falls back to tool volume before context pressure when activity is unavailable', () => {
+    const keepers = [
+      {
+        name: 'high-context-fewer-tools',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.92,
+        total_turns: 12,
+      },
+      {
+        name: 'more-tools-lower-context',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.21,
+        total_turns: 18,
+      },
+      {
+        name: 'inactive-heavy-tools',
+        status: 'inactive',
+        keepalive_running: false,
+        context_ratio: 0.4,
+        total_turns: 99,
+      },
+    ] satisfies Keeper[]
+
+    const rows = buildFleetRows(
+      keepers,
+      toolQualityByKeeper([
+        { name: 'high-context-fewer-tools', calls: 40, success_pct: 100 },
+        { name: 'more-tools-lower-context', calls: 180, success_pct: 100 },
+        { name: 'inactive-heavy-tools', calls: 500, success_pct: 100 },
+      ]),
+    )
+
+    expect(rows.map(row => row.name)).toEqual([
+      'more-tools-lower-context',
+      'high-context-fewer-tools',
+      'inactive-heavy-tools',
+    ])
+  })
+})

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -135,14 +135,22 @@ function buildToolQualityMap(toolQuality: ToolQualityResponse): Map<string, { ca
   return byKeeper
 }
 
-function fleetSortScore(row: FleetRow): [number, number, number, number, string] {
+function fleetSortScore(row: FleetRow): [number, number, number, number, number, number, string] {
   const liveScore = row.keepalive_running ? 1 : 0
-  const pressureScore = row.context_ratio >= PRESSURE_HOT_RATIO ? 2 : row.context_ratio >= PRESSURE_WARN_RATIO ? 1 : 0
+  const hasActivityScore =
+    row.last_activity_ago_s != null
+    && Number.isFinite(row.last_activity_ago_s)
+    && row.last_activity_ago_s >= 0
+      ? 1
+      : 0
+  const activityScore = hasActivityScore === 1 ? row.last_activity_ago_s ?? Number.POSITIVE_INFINITY : Number.POSITIVE_INFINITY
   return [
     liveScore,
-    pressureScore,
+    hasActivityScore,
+    activityScore,
+    row.tool_calls,
+    row.turn_count,
     row.context_ratio,
-    row.tool_calls + row.turn_count,
     row.name,
   ]
 }
@@ -152,9 +160,11 @@ function compareFleetRows(a: FleetRow, b: FleetRow): number {
   const bScore = fleetSortScore(b)
   if (aScore[0] !== bScore[0]) return bScore[0] - aScore[0]
   if (aScore[1] !== bScore[1]) return bScore[1] - aScore[1]
-  if (aScore[2] !== bScore[2]) return bScore[2] - aScore[2]
+  if (aScore[2] !== bScore[2]) return aScore[2] - bScore[2]
   if (aScore[3] !== bScore[3]) return bScore[3] - aScore[3]
-  return aScore[4].localeCompare(bScore[4])
+  if (aScore[4] !== bScore[4]) return bScore[4] - aScore[4]
+  if (aScore[5] !== bScore[5]) return bScore[5] - aScore[5]
+  return aScore[6].localeCompare(bScore[6])
 }
 
 export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityResponse): FleetRow[] {


### PR DESCRIPTION
## Summary
- adjust fleet telemetry default sorting to prioritize live keepers with recent activity
- use tool volume and turn count before context ratio when recent activity is unavailable
- add focused tests that lock the intended row ordering

## Product impact
- Promise: `ops visibility`
- operators now see active keepers with fresher activity higher in the fleet comparison table
- tool-heavy live keepers no longer lose priority only because another keeper has higher context pressure
- inactive keepers still stay below live keepers even when their aggregate counts are larger

## Evidence
- local validation:
  - `pnpm exec vitest run src/components/fleet-telemetry-panel.test.ts src/components/fleet-telemetry-panel.sort.test.ts --no-file-parallelism --maxWorkers=1`
  - `pnpm exec tsc --noEmit --pretty false`
- repro basis: fleet telemetry table ordering previously felt inconsistent with the operator view because the comparator weighted `context_ratio` before more immediate activity signals
- CI status: GitHub Actions checks are running for this draft PR and are being monitored via `gh pr checks 6142 --watch`

## Review evidence
- 2026-04-09T09:04:11Z UTC
- reviewer: direct `sb glm-text` (`GLM-5.1` path)
- scope: correctness-only review of the PR diff
- result: `No findings.`

## Linked issue
- Fixes #6145
