### PR TITLE
Scope keeper flows and restore operator REST surfaces

### DIFF
--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -220,8 +220,8 @@ let action_matches_incident incident action =
       let action_type = string_field "action_type" action in
       List.mem action_type (incident_action_types (string_field "kind" incident))
 
-let build_keeper_briefs config (keepers : Yojson.Safe.t list) =
-  let all_entries = Keeper_registry.all () in
+let build_keeper_briefs (config : Room.config) (keepers : Yojson.Safe.t list) =
+  let all_entries = Keeper_registry.all ~base_path:config.base_path () in
   let registry_lookup name =
     List.find_opt (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name) all_entries
   in

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -99,8 +99,8 @@ let interruptible_sleep ~clock ~stop ~wakeup duration =
 (** Wake up a specific keeper immediately, causing it to skip the rest of
     its sleep and run the next heartbeat cycle. Used by broadcast notification
     when a @mention targets a running keeper. *)
-let wakeup_keeper name =
-  Keeper_registry.all ()
+let wakeup_keeper ?base_path name =
+  Keeper_registry.all ?base_path ()
   |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
     if String.equal entry.name name && entry.phase = Keeper_state_machine.Running
     then Keeper_registry.wakeup ~base_path:entry.base_path name)
@@ -108,7 +108,14 @@ let wakeup_keeper name =
 
 (** Wake up all running keepers — used when a broadcast mentions @@all
     or when a system-wide event requires immediate attention. *)
-let wakeup_all_keepers () = Keeper_registry.wakeup_all ()
+let wakeup_all_keepers ?base_path () =
+  match base_path with
+  | None -> Keeper_registry.wakeup_all ()
+  | Some expected ->
+      Keeper_registry.all ~base_path:expected ()
+      |> List.iter (fun (entry : Keeper_registry.registry_entry) ->
+           if entry.phase = Keeper_state_machine.Running then
+             Keeper_registry.wakeup ~base_path:entry.base_path entry.name)
 
 let board_reactive_wakeup_allowed ~base_path ~keeper_name ~post_id =
   Keeper_registry.board_wakeup_allowed
@@ -123,7 +130,7 @@ let wakeup_relevant_keeper_for_board_signal
       (signal : Board_dispatch.keeper_board_signal)
   =
   let running_names =
-    Keeper_registry.all ()
+    Keeper_registry.all ~base_path:config.base_path ()
     |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
       if e.phase = Keeper_state_machine.Running then Some e.name else None)
   in
@@ -161,7 +168,7 @@ let wakeup_relevant_keeper_for_board_signal
         ~keeper_name:meta.name
         ~post_id:signal.post_id
     then (
-      wakeup_keeper meta.name;
+      wakeup_keeper ~base_path:config.base_path meta.name;
       Log.Keeper.info
         "board signal wakeup: keeper=%s reason=%s post=%s"
         meta.name
@@ -1207,7 +1214,7 @@ let wakeup_keeper_by_agent_name ~agent_name =
     ~agent_name
     ~on_missing:(fun () ->
       Log.Keeper.warn "directive wakeup: agent %s not in registry" agent_name)
-    (fun entry -> wakeup_keeper entry.name)
+    (fun entry -> wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
 
 let assign_keeper_task_from_directive ~agent_name ~task_id =
@@ -1220,7 +1227,7 @@ let assign_keeper_task_from_directive ~agent_name ~task_id =
          ~base_path:entry.base_path
          entry.name
          { entry.meta with current_task_id = Some task_id };
-       wakeup_keeper entry.name)
+       wakeup_keeper ~base_path:entry.base_path entry.name)
 ;;
 
 (** Process a single directive received from a gRPC HeartbeatAck.

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -107,7 +107,8 @@ let wakeup_keeper ?base_path name =
 ;;
 
 (** Wake up all running keepers — used when a broadcast mentions @@all
-    or when a system-wide event requires immediate attention. *)
+    or when a system-wide event requires immediate attention.
+    [None] preserves the legacy global wakeup behavior. *)
 let wakeup_all_keepers ?base_path () =
   match base_path with
   | None -> Keeper_registry.wakeup_all ()

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1595,10 +1595,11 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
           Keeper_registry.cleanup_tracking ~base_path:ctx.config.base_path live_meta.name)))
 ;;
 
-let stop_keepalive name =
+let stop_keepalive ?base_path name =
   let entries =
-    Keeper_registry.all ()
-    |> List.filter (fun (e : Keeper_registry.registry_entry) -> String.equal e.name name)
+    Keeper_registry.all ?base_path ()
+    |> List.filter (fun (e : Keeper_registry.registry_entry) ->
+         String.equal e.name name)
   in
   List.iter
     (fun (entry : Keeper_registry.registry_entry) ->

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -18,11 +18,11 @@ val process_directive : agent_name:string -> string -> unit
 
 (** Wake up a specific keeper immediately. Used by broadcast notification
     when a @mention targets a running keeper. *)
-val wakeup_keeper : string -> unit
+val wakeup_keeper : ?base_path:string -> string -> unit
 
 (** Wake up all running keepers. Used for @@all broadcast mentions
     or system-wide events. *)
-val wakeup_all_keepers : unit -> unit
+val wakeup_all_keepers : ?base_path:string -> unit -> unit
 
 val keeper_turn_throttle_limit : int
 (** Runtime keeper turn concurrency limit derived from

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -43,5 +43,5 @@ val percentile : float array -> float -> float
 
 val start_keepalive :
   ?proactive_warmup_sec:int -> 'a context -> keeper_meta -> unit
-val stop_keepalive : string -> unit
+val stop_keepalive : ?base_path:string -> string -> unit
 val stop_all_keepalives : unit -> unit

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -473,15 +473,10 @@ let resolve_config (config : Room_utils_backend_setup.config) keeper_name
     : Room_utils_backend_setup.config =
   if keeper_name = "" then config
   else
-    (* Fast path: scoped lookup in the caller's base_path (O(1) map) *)
+    (* Keeper config resolution is scoped to the caller's current base_path.
+       Do not retarget requests across other base_path registries. *)
     match get ~base_path:config.base_path keeper_name with
-    | Some _ -> config  (* already in the right scope *)
-    | None ->
-      (* Slow path: cross-base_path scan (O(n) registry) *)
-      match find_by_name keeper_name with
-      | Some entry when entry.base_path <> config.base_path ->
-        { config with base_path = entry.base_path }
-      | _ -> config  (* not found anywhere, keep original *)
+    | Some _ | None -> config
 
 (* -- Tool usage persistence ---------------------------------------- *)
 

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -321,8 +321,8 @@ let start_existing_keepalives ctx =
       raise exn
   end
 
-let stop_keepalive name =
-  Keeper_keepalive.stop_keepalive name
+let stop_keepalive ?base_path name =
+  Keeper_keepalive.stop_keepalive ?base_path name
 
 let reset_test_state base_path =
   stop_supervisor_sweep base_path;

--- a/lib/keeper/keeper_turn_lifecycle.ml
+++ b/lib/keeper/keeper_turn_lifecycle.ml
@@ -15,10 +15,10 @@ let handle_keeper_down ctx args : tool_result =
   else
     let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
-    stop_keepalive requested_name;
+    stop_keepalive ~base_path:ctx.config.base_path requested_name;
     (match keeper_name_from_agent_name requested_name with
      | Some resolved_name when not (String.equal resolved_name requested_name) ->
-         stop_keepalive resolved_name
+         stop_keepalive ~base_path:ctx.config.base_path resolved_name
      | _ -> ());
     match read_meta_resolved ctx.config requested_name with
     | Error e -> (false, "❌ " ^ e)

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -207,6 +207,6 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
   (match write_meta ctx.config updated with
    | Error e -> (false, e)
    | Ok () ->
-     stop_keepalive updated.name;
+     stop_keepalive ~base_path:ctx.config.base_path updated.name;
      start_keepalive ctx updated;
      (true, Yojson.Safe.to_string (meta_to_json updated)))

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -115,10 +115,12 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   let broadcast_mention_handler = (fun mention ->
     match mention with
     | Some target ->
-        Keeper_keepalive.wakeup_keeper target;
+        Keeper_keepalive.wakeup_keeper
+          ~base_path:state.room_config.base_path target;
         Log.Keeper.info "broadcast mention → wakeup keeper %s" target
     | None ->
-        Keeper_keepalive.wakeup_all_keepers ();
+        Keeper_keepalive.wakeup_all_keepers
+          ~base_path:state.room_config.base_path ();
         Log.Keeper.info "broadcast → wakeup all keepers (reactive push)") in
   Room_state.on_broadcast_mention := broadcast_mention_handler;
   Room_eio.on_broadcast_mention := broadcast_mention_handler;

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -694,9 +694,6 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       | `GET, p when String.starts_with ~prefix:"/api/v1/command-plane" p ->
           h2_respond_removed_surface h2_reqd ~surface:"command_plane" ~extra_headers:cors
 
-      | `GET, "/api/v1/operator"
-      | `GET, "/api/v1/operator/digest" ->
-          h2_respond_removed_surface h2_reqd ~surface:"operator" ~extra_headers:cors
       | `GET, "/api/v1/status" ->
           let state = get_server_state () in
           let config = state.Mcp_server.room_config in
@@ -786,11 +783,6 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `POST, p when String.starts_with ~prefix:"/api/v1/command-plane" p ->
           h2_respond_removed_surface h2_reqd ~surface:"command_plane" ~extra_headers:cors
-
-      | `POST, "/api/v1/operator/action"
-      | `POST, "/api/v1/operator/confirm" ->
-          h2_respond_removed_surface h2_reqd ~surface:"operator" ~extra_headers:cors
-
 
       (* ═══════════════════════════════════════════════════════════════════════
          Delegated route groups

--- a/lib/server/server_h2_gateway_routes_cp.ml
+++ b/lib/server/server_h2_gateway_routes_cp.ml
@@ -10,6 +10,14 @@ open Server_h2_gateway_helpers
 let dispatch ~sw ~clock ~h2_reqd ~httpun_request ~cors ~path
     (httpun_meth : [ `GET | `POST | `DELETE | `OPTIONS | `PUT | `HEAD
                     | `CONNECT | `TRACE | `Other of string ]) =
+  let h2_authorize_read_if_needed state =
+    if http_auth_strict_enabled () && not (is_public_read_path path) then
+      authorize_read_request
+        ~base_path:state.Mcp_server.room_config.base_path
+        httpun_request
+    else
+      Ok ()
+  in
   let h2_authorize_tool state ~tool_name =
     authorize_tool_request
       ~base_path:state.Mcp_server.room_config.base_path
@@ -18,6 +26,39 @@ let dispatch ~sw ~clock ~h2_reqd ~httpun_request ~cors ~path
   ignore (h2_authorize_tool);
   let handled = ref true in
   (match httpun_meth, path with
+      | `GET, "/api/v1/operator" ->
+          let state = get_server_state () in
+          (match h2_authorize_read_if_needed state with
+           | Error err ->
+               let status = http_status_of_auth_error err in
+               h2_respond_json h2_reqd (auth_error_json err) ~status
+                 ~extra_headers:cors
+           | Ok () ->
+               let json =
+                 operator_snapshot_http_json ~state ~sw ~clock httpun_request
+               in
+               h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+                 ~extra_headers:cors)
+
+      | `GET, "/api/v1/operator/digest" ->
+          let state = get_server_state () in
+          (match h2_authorize_read_if_needed state with
+           | Error err ->
+               let status = http_status_of_auth_error err in
+               h2_respond_json h2_reqd (auth_error_json err) ~status
+                 ~extra_headers:cors
+           | Ok () -> (
+               match
+                 operator_digest_http_json ~state ~sw ~clock httpun_request
+               with
+               | Ok json ->
+                   h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+                     ~extra_headers:cors
+               | Error message ->
+                   h2_respond_json h2_reqd
+                     (Yojson.Safe.to_string (operator_error_json message))
+                     ~status:`Bad_request ~extra_headers:cors))
+
       | `POST, "/api/v1/operator/action" ->
           let state = get_server_state () in
           (match h2_authorize_tool state ~tool_name:"masc_operator_action" with

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -10,6 +10,8 @@ let make_routes ~port ~host ~sw ~clock =
   Http.Router.empty
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
   |> Server_routes_http_routes_room.add_routes
+  |> Server_routes_http_routes_command_plane_read.add_routes
+  |> Server_routes_http_routes_command_plane_write.add_routes ~sw ~clock
   |> Server_routes_http_routes_dashboard.add_routes ~sw ~clock
   |> Server_routes_http_routes_provider_runs.add_routes ~sw
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -451,15 +451,14 @@ let handle_keeper_down ctx args : tool_result =
 let handle_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
-  let cache_key = Printf.sprintf "%d:%b" limit detailed in
+  let cache_key =
+    Printf.sprintf "%s:%d:%b" ctx.config.base_path limit detailed
+  in
   let body =
     cached_text_by_key _keeper_list_cache ~key:cache_key
       ~ttl_s:(keeper_list_cache_ttl_s ()) (fun () ->
-        (* Use registry as source of truth for live keepers.
-           Each entry carries its own base_path so cross-base_path
-           keepers are listed correctly. *)
         let entries =
-          Keeper_registry.all ()
+          Keeper_registry.all ~base_path:ctx.config.base_path ()
           |> List.sort (fun (a : Keeper_registry.registry_entry)
                             (b : Keeper_registry.registry_entry) ->
                String.compare a.name b.name)
@@ -469,8 +468,7 @@ let handle_keeper_list ctx args : tool_result =
         let rows =
           entries
           |> List.filter_map (fun (e : Keeper_registry.registry_entry) ->
-               let config = { ctx.config with base_path = e.base_path } in
-               keeper_list_row_json ~runtime_class:"keeper" config e.name)
+               keeper_list_row_json ~runtime_class:"keeper" ctx.config e.name)
         in
         let json =
           if not detailed then
@@ -506,16 +504,9 @@ let maybe_bootstrap_existing_keepalives ctx ~name ~args =
        Log.Keeper.error "start_existing_keepalives failed: %s"
          (Printexc.to_string exn))
 
-(** Resolve context base_path via central Keeper_registry.resolve_config.
-    Skipped for creation tools where the caller's base_path is authoritative. *)
-let resolve_ctx ctx ~name args =
-  match name with
-  | "masc_keeper_up" | "masc_keeper_create_from_persona" | "masc_persona_list" -> ctx
-  | _ ->
-    let keeper_name = get_string args "name" "" in
-    let config = Keeper_registry.resolve_config ctx.config keeper_name in
-    if config == ctx.config then ctx
-    else { ctx with config }
+(** Keeper tools are scoped to the caller's current base_path.
+    Do not retarget requests across other base_path registries. *)
+let resolve_ctx ctx ~name:_ _args = ctx
 
 let dispatch ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -164,6 +164,10 @@ module Rest = struct
     | "masc_tasks" -> [ (GET, "/api/v1/tasks") ]
     | "masc_who" -> [ (GET, "/api/v1/agents") ]
     | "masc_messages" -> [ (GET, "/api/v1/messages") ]
+    | "masc_operator_snapshot" -> [ (GET, "/api/v1/operator") ]
+    | "masc_operator_digest" -> [ (GET, "/api/v1/operator/digest") ]
+    | "masc_operator_action" -> [ (POST, "/api/v1/operator/action") ]
+    | "masc_operator_confirm" -> [ (POST, "/api/v1/operator/confirm") ]
     | "masc_websocket_discovery" -> [ (GET, "/ws") ]
     | "masc_webrtc_offer" -> [ (POST, "/webrtc/offer") ]
     | "masc_webrtc_answer" -> [ (POST, "/webrtc/answer") ]
@@ -526,6 +530,10 @@ module Rest = struct
       | "POST", "/webrtc/answer" -> "masc_webrtc_answer"
       | "GET", "/api/v1/tasks" -> "masc_tasks"
       | "GET", "/api/v1/agents" -> "masc_who"
+      | "GET", "/api/v1/operator" -> "masc_operator_snapshot"
+      | "GET", "/api/v1/operator/digest" -> "masc_operator_digest"
+      | "POST", "/api/v1/operator/action" -> "masc_operator_action"
+      | "POST", "/api/v1/operator/confirm" -> "masc_operator_confirm"
       | "POST", "/api/v1/broadcast" | "POST", "/broadcast" -> "masc_broadcast"
       | "GET", "/.well-known/agent.json"
       | "GET", "/.well-known/agent-card.json" -> "masc_agent_card"

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -110,6 +110,9 @@ let test_route_auth_contracts () =
   check bool "h2 gateway operator confirm uses tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
        {|h2_authorize_tool state ~tool_name:"masc_operator_confirm"|});
+  check bool "h2 gateway operator read routes honor read auth under strict mode" true
+    (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
+       {|authorize_read_request|});
   check bool "channel gate message route uses tool auth" true
     (file_contains_pattern
        "lib/server/server_routes_http_routes_channel_gate.ml"
@@ -247,6 +250,30 @@ let test_http_read_surface_contracts () =
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        {|"/api/v1/agent-runs/" (fun request reqd ->
        with_read_auth|})
+
+let test_operator_surface_route_contracts () =
+  check bool "http router registers command-plane read routes" true
+    (file_contains_pattern "lib/server/server_routes_http.ml"
+       "Server_routes_http_routes_command_plane_read.add_routes");
+  check bool "http router registers command-plane write routes" true
+    (file_contains_pattern "lib/server/server_routes_http.ml"
+       "Server_routes_http_routes_command_plane_write.add_routes ~sw ~clock");
+  check bool "h2 cp routes expose operator snapshot" true
+    (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
+       {|`GET, "/api/v1/operator" ->|});
+  check bool "h2 cp routes expose operator digest" true
+    (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
+       {|`GET, "/api/v1/operator/digest" ->|});
+  check bool "h2 gateway no longer removes operator read surface" true
+    (file_not_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|`GET, "/api/v1/operator"
+      | `GET, "/api/v1/operator/digest" ->
+          h2_respond_removed_surface|});
+  check bool "h2 gateway no longer removes operator write surface" true
+    (file_not_contains_pattern "lib/server/server_h2_gateway.ml"
+       {|`POST, "/api/v1/operator/action"
+      | `POST, "/api/v1/operator/confirm" ->
+          h2_respond_removed_surface|})
 
 let test_input_validation_contracts () =
   (* Bug #1602: broadcast must reject empty messages *)
@@ -725,6 +752,8 @@ let () =
            test_case "dashboard warm hydration contracts" `Quick
              test_dashboard_warm_hydration_contracts;
            test_case "http read surface contracts" `Quick test_http_read_surface_contracts;
+           test_case "operator surface route contracts" `Quick
+             test_operator_surface_route_contracts;
            test_case "input validation contracts" `Quick test_input_validation_contracts;
            test_case "room current validation contracts" `Quick
              test_room_current_validation_contracts;

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -107,12 +107,22 @@ let test_route_auth_contracts () =
   check bool "h2 gateway dispatch tick uses tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
        {|h2_authorize_tool state ~tool_name:"masc_dispatch_tick"|});
+  check bool "h2 gateway operator action uses tool auth" true
+    (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
+       {|h2_authorize_tool state ~tool_name:"masc_operator_action"|});
   check bool "h2 gateway operator confirm uses tool auth" true
     (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
        {|h2_authorize_tool state ~tool_name:"masc_operator_confirm"|});
-  check bool "h2 gateway operator read routes honor read auth under strict mode" true
+  check bool "h2 gateway operator snapshot read route honors read auth" true
     (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
-       {|authorize_read_request|});
+       {|`GET, "/api/v1/operator" ->
+          let state = get_server_state () in
+          (match h2_authorize_read_if_needed state with|});
+  check bool "h2 gateway operator digest read route honors read auth" true
+    (file_contains_pattern "lib/server/server_h2_gateway_routes_cp.ml"
+       {|`GET, "/api/v1/operator/digest" ->
+          let state = get_server_state () in
+          (match h2_authorize_read_if_needed state with|});
   check bool "channel gate message route uses tool auth" true
     (file_contains_pattern
        "lib/server/server_routes_http_routes_channel_gate.ml"
@@ -273,7 +283,10 @@ let test_operator_surface_route_contracts () =
     (file_not_contains_pattern "lib/server/server_h2_gateway.ml"
        {|`POST, "/api/v1/operator/action"
       | `POST, "/api/v1/operator/confirm" ->
-          h2_respond_removed_surface|})
+          h2_respond_removed_surface|});
+  check bool "h2 gateway still delegates command-plane and operator routes" true
+    (file_contains_pattern "lib/server/server_h2_gateway.ml"
+       "Server_h2_gateway_routes_cp.dispatch ~sw ~clock ~h2_reqd ~httpun_request ~cors ~path httpun_meth")
 
 let test_input_validation_contracts () =
   (* Bug #1602: broadcast must reject empty messages *)

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -730,6 +730,77 @@ let test_dashboard_mission_keeper_tool_audit_uses_decision_log () =
       check bool "decision log still reports empty tool list" true
         ((brief |> member "latest_tool_names" |> to_list) = []))
 
+let test_dashboard_mission_keeper_brief_registry_lookup_scoped_to_base_path () =
+  let root_dir = test_dir () in
+  let dir_a = Filename.concat root_dir "a-scope" in
+  let dir_z = Filename.concat root_dir "z-scope" in
+  let keeper_name = "shared-dashboard-keeper" in
+  let make_meta ~also_allow name =
+    match
+      Lib.Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String name);
+            ("agent_name", `String name);
+            ("trace_id", `String ("trace-" ^ name));
+            ( "tool_access",
+              Lib.Keeper_types.tool_access_to_json
+                (Lib.Keeper_types.Preset
+                   { preset = Lib.Keeper_types.Minimal; also_allow }) );
+          ])
+    with
+    | Ok meta -> meta
+    | Error err -> failwith ("make_meta failed: " ^ err)
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Lib.Keeper_registry.clear ();
+      cleanup_dir root_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      Unix.mkdir dir_a 0o755;
+      Unix.mkdir dir_z 0o755;
+      Masc_test_deps.init_keeper_tool_registry ();
+      let policy_base_path = Masc_test_deps.find_project_root () in
+      ignore (Result.get_ok (Lib.Keeper_exec_tools.init_policy_config ~base_path:policy_base_path));
+      let config_a = Room_utils.default_config dir_a in
+      let config_z = Room_utils.default_config dir_z in
+      ignore
+        (Lib.Keeper_registry.register ~base_path:config_a.base_path keeper_name
+           (make_meta ~also_allow:[ "keeper_board_vote" ] keeper_name));
+      ignore
+        (Lib.Keeper_registry.register ~base_path:config_z.base_path keeper_name
+           (make_meta ~also_allow:[ "keeper_board_post" ] keeper_name));
+      let briefs =
+        Lib.Dashboard_mission_assembly.build_keeper_briefs config_a
+          [
+            `Assoc
+              [
+                ("name", `String keeper_name);
+                ("agent_name", `String keeper_name);
+                ("status", `String "idle");
+                ("updated_at", `String (Types.now_iso ()));
+                ("allowed_tool_names", `Null);
+                ("latest_tool_names", `List []);
+                ("latest_tool_call_count", `Null);
+                ("tool_audit_source", `Null);
+                ("tool_audit_at", `Null);
+              ];
+          ]
+      in
+      let open Yojson.Safe.Util in
+      let brief =
+        briefs |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
+      in
+      let allowed_tool_names =
+        brief |> member "allowed_tool_names" |> to_list |> List.map to_string
+      in
+      check bool "current base path registry tools included" true
+        (List.mem "keeper_board_vote" allowed_tool_names);
+      check bool "other base path registry tools excluded" false
+        (List.mem "keeper_board_post" allowed_tool_names))
+
 let () =
   Alcotest.run "Dashboard Mission"
     [
@@ -749,5 +820,8 @@ let () =
             test_dashboard_mission_keeper_tool_audit_prefers_heartbeat_task;
           Alcotest.test_case "keeper brief uses decision log fallback" `Quick
             test_dashboard_mission_keeper_tool_audit_uses_decision_log;
+          Alcotest.test_case "keeper brief registry lookup scoped to base path"
+            `Quick
+            test_dashboard_mission_keeper_brief_registry_lookup_scoped_to_base_path;
         ] );
     ]

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -375,7 +375,7 @@ let test_resolve_config_cross_base_path () =
   let _entry = R.register ~base_path:bp2 "rc2" (make_meta "rc2") in
   let config = make_test_config bp in
   let resolved = R.resolve_config config "rc2" in
-  check string "cross-base_path resolves" bp2 resolved.base_path
+  check string "cross-base_path keeps original scope" bp resolved.base_path
 
 let test_resolve_config_not_found () =
   R.clear ();
@@ -432,6 +432,34 @@ let test_directive_nonexistent_agent () =
   R.clear ();
   KK.process_directive ~agent_name:"ghost-agent" "pause";
   check bool "no crash on missing agent" true true
+
+let test_wakeup_keeper_scoped_to_base_path () =
+  R.clear ();
+  let bp2 = "/tmp/wakeup-other" in
+  let entry_a = R.register ~base_path:bp "shared" (make_meta "shared") in
+  let entry_b = R.register ~base_path:bp2 "shared" (make_meta "shared") in
+  check bool "base path A wakeup initially false" false
+    (Atomic.get entry_a.fiber_wakeup);
+  check bool "base path B wakeup initially false" false
+    (Atomic.get entry_b.fiber_wakeup);
+  KK.wakeup_keeper ~base_path:bp "shared";
+  check bool "base path A wakeup set" true (Atomic.get entry_a.fiber_wakeup);
+  check bool "base path B wakeup stays unset" false
+    (Atomic.get entry_b.fiber_wakeup)
+
+let test_wakeup_all_scoped_to_base_path () =
+  R.clear ();
+  let bp2 = "/tmp/wakeup-all-other" in
+  let entry_a = R.register ~base_path:bp "all-a" (make_meta "all-a") in
+  let entry_b = R.register ~base_path:bp2 "all-b" (make_meta "all-b") in
+  check bool "base path A all wakeup initially false" false
+    (Atomic.get entry_a.fiber_wakeup);
+  check bool "base path B all wakeup initially false" false
+    (Atomic.get entry_b.fiber_wakeup);
+  KK.wakeup_all_keepers ~base_path:bp ();
+  check bool "base path A all wakeup set" true (Atomic.get entry_a.fiber_wakeup);
+  check bool "base path B all wakeup stays unset" false
+    (Atomic.get entry_b.fiber_wakeup)
 
 let () =
   run "Keeper_registry"
@@ -495,5 +523,9 @@ let () =
           eio_test "claim directive" test_directive_claim;
           eio_test "unknown directive no crash" test_directive_unknown_no_crash;
           eio_test "nonexistent agent no crash" test_directive_nonexistent_agent;
+          eio_test "wakeup keeper scoped to base_path"
+            test_wakeup_keeper_scoped_to_base_path;
+          eio_test "wakeup all scoped to base_path"
+            test_wakeup_all_scoped_to_base_path;
         ] );
     ]

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -433,6 +433,20 @@ let test_directive_nonexistent_agent () =
   KK.process_directive ~agent_name:"ghost-agent" "pause";
   check bool "no crash on missing agent" true true
 
+let test_stop_keepalive_scoped_to_base_path () =
+  R.clear ();
+  let bp2 = "/tmp/stop-other" in
+  let entry_a = R.register ~base_path:bp "shared-stop" (make_meta "shared-stop") in
+  let entry_b = R.register ~base_path:bp2 "shared-stop" (make_meta "shared-stop") in
+  check bool "base path A stop initially false" false
+    (Atomic.get entry_a.fiber_stop);
+  check bool "base path B stop initially false" false
+    (Atomic.get entry_b.fiber_stop);
+  KK.stop_keepalive ~base_path:bp "shared-stop";
+  check bool "base path A stop set" true (Atomic.get entry_a.fiber_stop);
+  check bool "base path B stop stays unset" false
+    (Atomic.get entry_b.fiber_stop)
+
 let test_wakeup_keeper_scoped_to_base_path () =
   R.clear ();
   let bp2 = "/tmp/wakeup-other" in
@@ -523,6 +537,8 @@ let () =
           eio_test "claim directive" test_directive_claim;
           eio_test "unknown directive no crash" test_directive_unknown_no_crash;
           eio_test "nonexistent agent no crash" test_directive_nonexistent_agent;
+          eio_test "stop keepalive scoped to base_path"
+            test_stop_keepalive_scoped_to_base_path;
           eio_test "wakeup keeper scoped to base_path"
             test_wakeup_keeper_scoped_to_base_path;
           eio_test "wakeup all scoped to base_path"

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -124,6 +124,16 @@ let () =
           Alcotest.test_case "keeper down accepts agent alias" `Quick
             Test_operator_control_keeper
             .test_keeper_down_accepts_agent_name_alias;
+          Alcotest.test_case "keeper list scoped to current base path" `Quick
+            Test_operator_control_keeper
+            .test_keeper_list_scoped_to_current_base_path;
+          Alcotest.test_case "keeper status does not cross base path" `Quick
+            Test_operator_control_keeper
+            .test_keeper_status_does_not_cross_base_path;
+          Alcotest.test_case "keeper down only pauses current base path"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_down_only_pauses_current_base_path;
           Alcotest.test_case "operator keeper probe accepts agent alias"
             `Quick
             Test_operator_control_keeper

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -441,6 +441,237 @@ let test_operator_keeper_recover_accepts_agent_name_alias () =
       Alcotest.(check bool) "recover reports after diagnostic" true
         Yojson.Safe.Util.(delegated_result |> member "after" <> `Null))
 
+let test_keeper_list_scoped_to_current_base_path () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir_a = temp_dir () in
+  let base_dir_b = temp_dir () in
+  let keeper_name_a = "alpha-scope" in
+  let keeper_name_b = "beta-scope" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name_a;
+      Keeper_keepalive.stop_keepalive keeper_name_b;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir_a;
+      Keeper_runtime.reset_test_state base_dir_b;
+      cleanup_dir base_dir_a;
+      cleanup_dir base_dir_b)
+    (fun () ->
+      let config_a = Room.default_config base_dir_a in
+      let config_b = Room.default_config base_dir_b in
+      ignore (Room.init config_a ~agent_name:(Some "operator-a"));
+      ignore (Room.init config_b ~agent_name:(Some "operator-b"));
+      let keeper_ctx_a : _ Tool_keeper.context =
+        {
+          config = config_a;
+          agent_name = "operator-a";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let keeper_ctx_b : _ Tool_keeper.context =
+        {
+          config = config_b;
+          agent_name = "operator-b";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx_a ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name_a);
+                ("goal", `String "Scoped to base path A");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok in base path A" true ok;
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx_b ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name_b);
+                ("goal", `String "Scoped to base path B");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok in base path B" true ok;
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx_a ~name:"masc_keeper_list"
+          ~args:(`Assoc [ ("limit", `Int 10) ])
+      in
+      Alcotest.(check bool) "keeper list ok" true ok;
+      let list_json = parse_json_exn body in
+      let open Yojson.Safe.Util in
+      let keeper_names =
+        list_json |> member "keepers" |> to_list |> List.map to_string
+      in
+      Alcotest.(check (list string)) "list only includes current base path keeper"
+        [ keeper_name_a ] keeper_names;
+      let listed_items = list_json |> member "items" |> to_list in
+      Alcotest.(check int) "list item count scoped to current base path" 1
+        (List.length listed_items);
+      Alcotest.(check string) "listed item name stays local" keeper_name_a
+        (listed_items |> List.hd |> member "name" |> to_string))
+
+let test_keeper_status_does_not_cross_base_path () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir_a = temp_dir () in
+  let base_dir_b = temp_dir () in
+  let keeper_name = "remote-scope" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir_a;
+      Keeper_runtime.reset_test_state base_dir_b;
+      cleanup_dir base_dir_a;
+      cleanup_dir base_dir_b)
+    (fun () ->
+      let config_a = Room.default_config base_dir_a in
+      let config_b = Room.default_config base_dir_b in
+      ignore (Room.init config_a ~agent_name:(Some "operator-a"));
+      ignore (Room.init config_b ~agent_name:(Some "operator-b"));
+      let keeper_ctx_a : _ Tool_keeper.context =
+        {
+          config = config_a;
+          agent_name = "operator-a";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let keeper_ctx_b : _ Tool_keeper.context =
+        {
+          config = config_b;
+          agent_name = "operator-b";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx_b ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Only exists in base path B");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok in base path B" true ok;
+      match
+        Masc_mcp.Tool_keeper.dispatch keeper_ctx_a ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ])
+      with
+      | Some (false, err) ->
+          Alcotest.(check bool) "status reports keeper missing outside current base path"
+            true (contains_substring err ("keeper not found: " ^ keeper_name))
+      | Some (true, body) ->
+          Alcotest.failf "keeper status unexpectedly crossed base path: %s" body
+      | None -> Alcotest.fail "missing keeper status dispatch")
+
+let test_keeper_down_only_pauses_current_base_path () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir_a = temp_dir () in
+  let base_dir_b = temp_dir () in
+  let keeper_name = "shared-scope" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir_a;
+      Keeper_runtime.reset_test_state base_dir_b;
+      cleanup_dir base_dir_a;
+      cleanup_dir base_dir_b)
+    (fun () ->
+      let config_a = Room.default_config base_dir_a in
+      let config_b = Room.default_config base_dir_b in
+      ignore (Room.init config_a ~agent_name:(Some "operator-a"));
+      ignore (Room.init config_b ~agent_name:(Some "operator-b"));
+      let keeper_ctx_a : _ Tool_keeper.context =
+        {
+          config = config_a;
+          agent_name = "operator-a";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let keeper_ctx_b : _ Tool_keeper.context =
+        {
+          config = config_b;
+          agent_name = "operator-b";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx_a ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Shared name in base path A");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok in base path A" true ok;
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx_b ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Shared name in base path B");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok in base path B" true ok;
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx_a ~name:"masc_keeper_down"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "keeper down ok in base path A" true ok;
+      let down_json = parse_json_exn body in
+      Alcotest.(check string) "down returns scoped keeper name" keeper_name
+        Yojson.Safe.Util.(down_json |> member "name" |> to_string);
+      let meta_a =
+        match Masc_mcp.Keeper_types.read_meta config_a keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta missing in base path A"
+        | Error err -> Alcotest.fail ("meta read failed in base path A: " ^ err)
+      in
+      let meta_b =
+        match Masc_mcp.Keeper_types.read_meta config_b keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta missing in base path B"
+        | Error err -> Alcotest.fail ("meta read failed in base path B: " ^ err)
+      in
+      Alcotest.(check bool) "base path A keeper paused" true meta_a.paused;
+      Alcotest.(check bool) "base path B keeper unchanged" false meta_b.paused;
+      Alcotest.(check bool) "base path B keeper remains running" true
+        (Keeper_registry.is_running ~base_path:config_b.base_path keeper_name))
+
 let test_keeper_status_schema_makes_name_optional () =
   let schema =
     List.find

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -471,6 +471,26 @@ let test_rest_tool_to_endpoint_broadcast () =
   check string "method" "POST" (Transport.Rest.method_to_string m);
   check string "path" "/api/v1/broadcast" path
 
+let test_rest_tool_to_endpoint_operator_snapshot () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_operator_snapshot" in
+  check string "method" "GET" (Transport.Rest.method_to_string m);
+  check string "path" "/api/v1/operator" path
+
+let test_rest_tool_to_endpoint_operator_digest () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_operator_digest" in
+  check string "method" "GET" (Transport.Rest.method_to_string m);
+  check string "path" "/api/v1/operator/digest" path
+
+let test_rest_tool_to_endpoint_operator_action () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_operator_action" in
+  check string "method" "POST" (Transport.Rest.method_to_string m);
+  check string "path" "/api/v1/operator/action" path
+
+let test_rest_tool_to_endpoint_operator_confirm () =
+  let (m, path) = Transport.Rest.tool_to_endpoint "masc_operator_confirm" in
+  check string "method" "POST" (Transport.Rest.method_to_string m);
+  check string "path" "/api/v1/operator/confirm" path
+
 let test_rest_tool_to_endpoint_agent_card () =
   let (m, path) = Transport.Rest.tool_to_endpoint "masc_agent_card" in
   check string "method" "GET" (Transport.Rest.method_to_string m);
@@ -507,6 +527,37 @@ let test_rest_parse_request_tasks () =
 let test_rest_parse_request_agents () =
   let req = Transport.Rest.parse_request ~http_method:"GET" ~path:"/api/v1/agents" ~query_params:[] ~body:"" in
   check string "method_name" "masc_who" req.method_name
+
+let test_rest_parse_request_operator_snapshot () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"GET" ~path:"/api/v1/operator"
+      ~query_params:[] ~body:""
+  in
+  check string "method_name" "masc_operator_snapshot" req.method_name
+
+let test_rest_parse_request_operator_digest () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"GET"
+      ~path:"/api/v1/operator/digest"
+      ~query_params:[ ("target_type", `String "namespace") ] ~body:""
+  in
+  check string "method_name" "masc_operator_digest" req.method_name
+
+let test_rest_parse_request_operator_action () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"POST"
+      ~path:"/api/v1/operator/action" ~query_params:[]
+      ~body:"{\"action_type\":\"namespace_pause\"}"
+  in
+  check string "method_name" "masc_operator_action" req.method_name
+
+let test_rest_parse_request_operator_confirm () =
+  let req =
+    Transport.Rest.parse_request ~http_method:"POST"
+      ~path:"/api/v1/operator/confirm" ~query_params:[]
+      ~body:"{\"confirm_token\":\"token-1\"}"
+  in
+  check string "method_name" "masc_operator_confirm" req.method_name
 
 let test_rest_parse_request_agent_card () =
   let req = Transport.Rest.parse_request ~http_method:"GET" ~path:"/.well-known/agent-card.json" ~query_params:[] ~body:"" in
@@ -846,6 +897,14 @@ let () =
       test_case "join" `Quick test_rest_tool_to_endpoint_join;
       test_case "leave" `Quick test_rest_tool_to_endpoint_leave;
       test_case "broadcast" `Quick test_rest_tool_to_endpoint_broadcast;
+      test_case "operator snapshot" `Quick
+        test_rest_tool_to_endpoint_operator_snapshot;
+      test_case "operator digest" `Quick
+        test_rest_tool_to_endpoint_operator_digest;
+      test_case "operator action" `Quick
+        test_rest_tool_to_endpoint_operator_action;
+      test_case "operator confirm" `Quick
+        test_rest_tool_to_endpoint_operator_confirm;
       test_case "agent_card" `Quick test_rest_tool_to_endpoint_agent_card;
       test_case "websocket_discovery" `Quick test_rest_tool_to_endpoint_websocket_discovery;
       test_case "webrtc_offer" `Quick test_rest_tool_to_endpoint_webrtc_offer;
@@ -856,6 +915,14 @@ let () =
       test_case "status" `Quick test_rest_parse_request_status;
       test_case "tasks" `Quick test_rest_parse_request_tasks;
       test_case "agents" `Quick test_rest_parse_request_agents;
+      test_case "operator snapshot" `Quick
+        test_rest_parse_request_operator_snapshot;
+      test_case "operator digest" `Quick
+        test_rest_parse_request_operator_digest;
+      test_case "operator action" `Quick
+        test_rest_parse_request_operator_action;
+      test_case "operator confirm" `Quick
+        test_rest_parse_request_operator_confirm;
       test_case "agent_card" `Quick test_rest_parse_request_agent_card;
       test_case "agent_card canonical" `Quick
         test_rest_parse_request_agent_card_canonical;


### PR DESCRIPTION
## Summary
- scope keeper tool listing, status, control, dashboard fallback lookup, wakeups, and broadcast-driven wakeups to the caller's current `base_path`
- preserve legacy global behavior only for internal helper calls that intentionally omit `~base_path`
- restore operator REST control surfaces on both the standard HTTP router and H2 gateway
- add regression coverage for cross-base-path keeper flows plus operator route registration/auth and REST transport bindings

## Product impact
- keepers from other workspaces no longer leak into the current workspace's keeper surfaces
- same-name keepers under another `base_path` are no longer paused, restarted, or woken by the current workspace's control paths
- board and broadcast wakeups stay inside the active workspace scope
- `GET /api/v1/operator`, `GET /api/v1/operator/digest`, `POST /api/v1/operator/action`, and `POST /api/v1/operator/confirm` are available again for operator-driven intervention flows

## Evidence
- reproduced with same-name keepers registered under different `base_path` values and verified that current-scope operations now ignore the foreign entry
- verified dashboard keeper brief fallback only reads registry state from the active `base_path`
- verified operator REST/H2 routes are registered again, no longer shadowed by removed-surface stubs, and keep the expected read/tool auth contracts

## Review evidence
- cross-model review run with direct `sb glm-text` (`GLM-5`) on 2026-04-09 KST
- initial review on `aadccf9e1` flagged test-hardening gaps around operator route auth coverage
- patched in follow-up commit `927f1b536`
- final review on `a6996c0dc..927f1b536`: `No findings.`

## Linked issue
- Refs #4460

## Verification
- `/tmp/masc-codex-build-scope/default/test/test_operator_control.exe`
- `/tmp/masc-codex-build-scope/default/test/test_dashboard_mission.exe`
- `/tmp/masc-codex-build-scope/default/test/test_keeper_registry.exe`
- `/tmp/masc-codex-build-scope/default/test/test_ci_hardening_source.exe`
- `/tmp/masc-codex-build-scope/default/test/test_transport_coverage.exe`
