### PR TITLE
[codex] Fix keeper playground bundle path contract

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1444,6 +1444,7 @@ let run_turn
     else None
   in
   let priority = Option.value priority ~default:Llm_provider.Request_priority.Proactive in
+  ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
   let effective_allowed_paths = Keeper_alerting_path.effective_allowed_paths ~meta in
   match
     Keeper_alerting_path.absolute_allowed_paths_result

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -229,12 +229,21 @@ let playground_repos_path (name : string) : string =
   let safe_name = sanitize_keeper_name name in
   Printf.sprintf ".masc/playground/%s/repos/" safe_name
 
+let playground_bundle_paths (name : string) : string list =
+  [
+    playground_path_of_keeper name;
+    playground_mind_path name;
+    playground_repos_path name;
+  ]
+
+let ensure_playground_bundle ~(config : Room.config) ~(name : string) : string list =
+  let root = project_root_of_config config in
+  playground_bundle_paths name
+  |> List.map (Filename.concat root)
+  |> List.map Keeper_fs.ensure_dir
+
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
-  let playground = playground_path_of_keeper meta.name in
-  let playground_sub = [
-    playground_mind_path meta.name;
-    playground_repos_path meta.name;
-  ] in
+  let playground_paths = playground_bundle_paths meta.name in
   let workspace_defaults =
     match String.lowercase_ascii meta.execution_scope with
     | "workspace" ->
@@ -245,7 +254,7 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   in
   match meta.allowed_paths with
   | ["*"] -> []
-  | explicit -> playground :: playground_sub @ workspace_defaults @ explicit
+  | explicit -> playground_paths @ workspace_defaults @ explicit
 
 (** Resolve a path for read-only access within the keeper's effective
     allowlist. The allowlist is usually the keeper playground bundle

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -597,8 +597,8 @@ let handle_keeper_shell
                     ; "output", `String out
                     ]))))
   | "git_clone" ->
-    (* Clone a repo into this keeper's playground directory.
-       Sandboxed: always targets .masc/playground/<keeper_name>/<repo_name>.
+    (* Clone a repo into this keeper's playground repos directory.
+       Sandboxed: always targets .masc/playground/<keeper_name>/repos/<repo_name>.
        Validates against tool_policy.toml git_clone.allowed_orgs. *)
     let url = Safe_ops.json_string ~default:"" "url" args |> String.trim in
     if url = "" then
@@ -617,9 +617,11 @@ let handle_keeper_shell
                ; "url", `String url
                ])
        | Ok () ->
+         ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
          let playground = Filename.concat root
            (Keeper_alerting_path.playground_path_of_keeper meta.name) in
-         Fs_compat.mkdir_p playground;
+         let repos_dir = Filename.concat root
+           (Keeper_alerting_path.playground_repos_path meta.name) in
          (* Derive repo name from URL: strip trailing slash, .git, then basename.
             Guard against empty/traversal names (e.g. url ending with "/" or ".."). *)
          let repo_name =
@@ -643,7 +645,7 @@ let handle_keeper_shell
            in
            if safe = "" || safe = "." || safe = ".." then "repo" else safe
          in
-         let clone_path = Filename.concat playground repo_name in
+         let clone_path = Filename.concat repos_dir repo_name in
          if Sys.file_exists clone_path then
            (* Already cloned — pull latest instead *)
            let st, out =

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -203,10 +203,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
       let base_dir = session_base_dir ctx.config in
       (* Ensure full session dir tree, not just base_dir (issue #3019) *)
       ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
-      (* Ensure keeper playground directory exists *)
-      let playground_rel = Keeper_alerting_path.playground_path_of_keeper p.name in
-      let project_root = Keeper_alerting_path.project_root_of_config ctx.config in
-      ignore (Keeper_fs.ensure_dir (Filename.concat project_root playground_rel));
+      ignore (Keeper_alerting_path.ensure_playground_bundle ~config:ctx.config ~name:p.name);
       let session = Keeper_exec_context.create_session ~session_id:trace_id ~base_dir in
         let persona_extended =
           Keeper_types_profile.load_persona_extended p.name

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -124,6 +124,30 @@ let test_playground_always_present () =
       true (List.mem ".masc/playground/abc/" effective)
   ) scopes
 
+let test_ensure_playground_bundle_creates_subdirs () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "keeper_playground_bundle_%d" (Random.bits ())) in
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () ->
+    let rec rm path =
+      if Sys.file_exists path then
+        if Sys.is_directory path then begin
+          Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+          Unix.rmdir path
+        end else Sys.remove path
+    in
+    rm dir
+  ) (fun () ->
+    Eio_main.run @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    let config = Masc_mcp.Room.default_config dir in
+    let created = KAP.ensure_playground_bundle ~config ~name:"abc" in
+    check int "bundle size" 3 (List.length created);
+    List.iter (fun path ->
+      check bool ("exists: " ^ path) true (Sys.file_exists path);
+      check bool ("is_dir: " ^ path) true (Sys.is_directory path)
+    ) created)
+
 (* ── Runner ── *)
 
 let () =
@@ -156,5 +180,7 @@ let () =
             test_playground_path_sanitizes_name;
           test_case "playground always in allowed_paths" `Quick
             test_playground_always_present;
+          test_case "ensure playground bundle creates subdirs" `Quick
+            test_ensure_playground_bundle_creates_subdirs;
         ] );
     ]


### PR DESCRIPTION
## What changed
- create the full keeper playground bundle (`playground/`, `mind/`, `repos/`) instead of only the top-level playground directory
- self-heal the playground bundle before keeper turns run so existing keepers recover under a `base_path` root
- align `keeper_shell git_clone` with the documented/preflighted `.../playground/<keeper>/repos/<repo>` target
- add a regression test for bundle directory creation

## Why
`effective_allowed_paths` exposed `.../playground/<keeper>/repos/`, but the runtime did not always create that directory. Under `base_path=~/me`, keepers could legitimately resolve the path and still fail `ls` with `No such file or directory`. `git_clone` also used a different target than the `repos/` contract.

## Impact
Keepers using `base_path` now get a consistent playground layout and `keeper_shell` read operations no longer fail on missing default bundle directories.

## Validation
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-playground-bundle test/test_keeper_allowed_paths.exe`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-playground-bundle test/test_keeper_tool_exposure.exe`
