### PR TITLE
fix(room): preserve ancestor MASC_BASE_PATH instead of sub-repo override

### DIFF
--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -154,10 +154,14 @@ let running_under_test_executable () =
   in
   String.starts_with ~prefix:"test_" executable
 
+let realpath p =
+  try Unix.realpath p with Unix.Unix_error _ -> p
+
 let is_ancestor_path ~ancestor ~descendant =
-  let a = if String.ends_with ~suffix:"/" ancestor then ancestor
-          else ancestor ^ "/" in
-  String.starts_with ~prefix:a descendant
+  let a = realpath ancestor in
+  let d = realpath descendant in
+  let a = if String.ends_with ~suffix:"/" a then a else a ^ "/" in
+  String.starts_with ~prefix:a d
 
 let should_ignore_inherited_base_path ~requested_path ~explicit_path =
   not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -154,6 +154,11 @@ let running_under_test_executable () =
   in
   String.starts_with ~prefix:"test_" executable
 
+let is_ancestor_path ~ancestor ~descendant =
+  let a = if String.ends_with ~suffix:"/" ancestor then ancestor
+          else ancestor ^ "/" in
+  String.starts_with ~prefix:a descendant
+
 let should_ignore_inherited_base_path ~requested_path ~explicit_path =
   not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
   && String.trim requested_path <> ""
@@ -164,6 +169,7 @@ let should_ignore_inherited_base_path ~requested_path ~explicit_path =
   requested <> ""
   && explicit <> ""
   && not (String.equal requested explicit)
+  && not (is_ancestor_path ~ancestor:explicit ~descendant:requested)
   && path_has_masc_dir requested
   && path_has_masc_dir explicit
 
@@ -174,6 +180,8 @@ let should_ignore_inherited_test_base_path ~requested_path ~explicit_path =
   && String.trim requested_path <> ""
   && not (String.equal requested_path ".")
   && not (String.equal explicit_path requested_path)
+  && not (is_ancestor_path ~ancestor:(canonical_base_path explicit_path)
+            ~descendant:(canonical_base_path requested_path))
 
 let sync_test_base_path_env resolved_path =
   if running_under_test_executable ()
@@ -199,8 +207,10 @@ let resolve_requested_base_path path =
     directly unless a test executable intentionally ignores an inherited
     override. Git root detection applies for worktree auto-resolution when
     no explicit path is configured, or when that inherited test override is
-    ignored. This prevents a sub-repo .git (e.g. masc-mcp/) from hijacking
-    the intended base path. *)
+    ignored. When the explicit path is an ancestor of the requested path
+    (e.g. ~/me contains ~/me/workspace/.../masc-mcp), the ancestor wins
+    because the sub-repo is part of the parent project. Only unrelated
+    sibling paths with dual .masc/ dirs trigger the ignore guard. *)
 let resolve_masc_base_path path =
   match Env_config_core.base_path_opt () with
   | Some explicit

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -187,6 +187,30 @@ let test_resolve_masc_base_path_allows_dual_root_opt_in () =
           check string "opt-in preserves explicit dual-root env" explicit
             (Room_utils.resolve_masc_base_path requested)))
 
+let test_resolve_masc_base_path_preserves_ancestor_explicit_path () =
+  let scratch = Filename.temp_dir "room-utils-ancestor" "" in
+  let explicit = scratch in
+  let sub_repo = Filename.concat scratch "workspace/sub-repo" in
+  let rec mkdirs path =
+    if not (Sys.file_exists path) then begin
+      mkdirs (Filename.dirname path);
+      Unix.mkdir path 0o755
+    end
+  in
+  mkdirs sub_repo;
+  Unix.mkdir (Filename.concat explicit ".masc") 0o755;
+  Unix.mkdir (Filename.concat sub_repo ".masc") 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf scratch)
+    (fun () ->
+      with_envs
+        [ ("MASC_BASE_PATH", Some explicit);
+          ("MASC_ALLOW_INHERITED_BASE_PATH", None);
+          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+        (fun () ->
+          check string "ancestor explicit path wins over sub-repo" explicit
+            (Room_utils.resolve_masc_base_path sub_repo)))
+
 let test_default_config_syncs_test_base_path_env () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-sync-env"
@@ -618,6 +642,8 @@ let () =
         test_resolve_masc_base_path_ignores_dual_masc_roots_outside_test_override;
       test_case "allows dual-root opt-in" `Quick
         test_resolve_masc_base_path_allows_dual_root_opt_in;
+      test_case "preserves ancestor explicit path" `Quick
+        test_resolve_masc_base_path_preserves_ancestor_explicit_path;
       test_case "default config syncs test base env" `Quick
         test_default_config_syncs_test_base_path_env;
     ];

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -118,8 +118,9 @@ let test_default_base_path_sanitizes_inherited_dual_roots () =
   with_env "ME_ROOT" (Some me_root) @@ fun () ->
   with_env "MASC_BASE_PATH" (Some me_root) @@ fun () ->
   with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
-  Alcotest.(check string) "default base path prefers checkout root"
-    (canonical_path repo)
+  (* ancestor explicit path wins: me_root is parent of repo *)
+  Alcotest.(check string) "default base path preserves ancestor explicit path"
+    (canonical_path me_root)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
 let test_default_base_path_respects_opt_in_for_inherited_root () =
@@ -148,7 +149,7 @@ let () =
             test_strict_violation_respects_env;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
-          Alcotest.test_case "default base path sanitizes inherited dual roots"
+          Alcotest.test_case "default base path preserves ancestor explicit path"
             `Quick test_default_base_path_sanitizes_inherited_dual_roots;
           Alcotest.test_case "default base path honors inherited opt-in" `Quick
             test_default_base_path_respects_opt_in_for_inherited_root;


### PR DESCRIPTION
## Summary

- `should_ignore_inherited_base_path`가 parent-child 경로 관계를 구분하지 못해, 서버가 sub-repo의 git root를 effective_base_path로 사용하던 문제 수정
- `is_ancestor_path` 체크를 추가하여 explicit path가 requested path의 조상이면 inherited를 존중
- 테스트용 `should_ignore_inherited_test_base_path`에도 동일 가드 적용
- 기존 sibling dual-.masc/ 시나리오는 동작 변경 없음

## 근거

서버 health endpoint에서 `roots_diverge: true`:
```
effective_base_path: ~/me/workspace/.../masc-mcp  (sub-repo git root)
input_base_path: ~/me                              (ME_ROOT)
```

`~/me/.masc/`와 `~/me/workspace/.../masc-mcp/.masc/` 모두 존재하여 inherited가 무시되었음.

## Test plan

- [x] `test_room_utils_coverage.exe` 79 tests pass (기존 + 신규)
- [x] `dune build @runtest --root .` 전체 통과
- [ ] 서버 재시작 후 health endpoint에서 `roots_diverge: false` 확인

Closes #6153

🤖 Generated with [Claude Code](https://claude.com/claude-code)