### PR TITLE
feat(gate): advertise connector descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,15 @@ For planner / implementer / supervisor separation:
 
 The dashboard is a read-heavy UI for repo coordination and keeper/runtime visibility. Canonical write paths remain MCP tools.
 
+For external channel adapters, treat the Channel Gate as the boundary owner:
+
+- write/traffic path: `/api/v1/gate/message`
+- read/descriptor path: `/api/v1/gate/connectors`
+- per-channel metrics path: `/api/v1/gate/status`
+
+The dashboard should learn connector type and status from the gate descriptor
+surface instead of hardcoding vendor-specific assumptions.
+
 - `scripts/run-local.sh` does not build the dashboard automatically. Append `--build-dashboard` only when needed.
 - `start-masc-mcp.sh` automatically builds the dashboard SPA if `pnpm` or `corepack pnpm` is available.
 - To run the dev server separately, use:

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -3,6 +3,11 @@ import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.setConfig({
+  testTimeout: 40000,
+  hookTimeout: 40000,
+})
+
 function sampleGateResponse(overrides?: Partial<Record<string, unknown>>) {
   return {
     channels: [

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -78,45 +78,57 @@ function sampleGateResponse(overrides?: Partial<Record<string, unknown>>) {
   }
 }
 
-function sampleLiveResponse(overrides?: Partial<Record<string, unknown>>) {
+function sampleConnectorsResponse(overrides?: Partial<Record<string, unknown>>) {
   return {
-    available: true,
-    connected: true,
-    stale: false,
-    stale_after_sec: 30,
-    error: '',
-    status_path: '/tmp/discord_status.json',
-    binding_store_path: '/tmp/discord_bindings.json',
-    audit_path: '/tmp/discord_binding_audit.jsonl',
-    updated_at: '2026-04-03T00:00:00Z',
-    last_ready_at: '2026-04-03T00:00:00Z',
-    bot_user_name: 'sangsu',
-    bot_user_id: '1489985300729172039',
-    guild_count: 2,
-    gate_base_url: 'http://localhost:8935',
-    gate_healthy: true,
-    gate_health_checked_at: '2026-04-03T00:00:00Z',
-    binding_source: 'persisted',
-    runtime_bindings_count: 1,
-    pid: 4242,
-    configured_bindings: [
+    connectors: [
       {
-        channel_id: '123456',
-        keeper_name: 'luna',
+        connector_id: 'discord',
+        display_name: 'Discord',
+        channel: 'discord',
+        capabilities: ['runtime_status', 'bindings', 'audit'],
+        status: 'connected',
+        available: true,
+        connected: true,
+        stale: false,
+        stale_after_sec: 30,
+        error: '',
+        status_path: '/tmp/discord_status.json',
+        binding_store_path: '/tmp/discord_bindings.json',
+        audit_path: '/tmp/discord_binding_audit.jsonl',
+        updated_at: '2026-04-03T00:00:00Z',
+        last_ready_at: '2026-04-03T00:00:00Z',
+        bot_user_name: 'sangsu',
+        bot_user_id: '1489985300729172039',
+        guild_count: 2,
+        gate_base_url: 'http://localhost:8935',
+        gate_healthy: true,
+        gate_health_checked_at: '2026-04-03T00:00:00Z',
+        binding_source: 'persisted',
+        runtime_bindings_count: 1,
+        pid: 4242,
+        configured_bindings: [
+          {
+            channel_id: '123456',
+            keeper_name: 'luna',
+          },
+        ],
+        recent_audit: [
+          {
+            timestamp: '2026-04-03T00:00:00Z',
+            action: 'bind',
+            guild_id: 'guild-1',
+            channel_id: '123456',
+            keeper_name: 'luna',
+            actor_id: 'dashboard',
+            actor_name: 'dashboard',
+            previous_keeper: '',
+          },
+        ],
       },
     ],
-    recent_audit: [
-      {
-        timestamp: '2026-04-03T00:00:00Z',
-        action: 'bind',
-        guild_id: 'guild-1',
-        channel_id: '123456',
-        keeper_name: 'luna',
-        actor_id: 'dashboard',
-        actor_name: 'dashboard',
-        previous_keeper: '',
-      },
-    ],
+    total: 1,
+    active_count: 1,
+    generated_at: '2026-04-03T00:00:00Z',
     ...overrides,
   }
 }
@@ -196,7 +208,7 @@ describe('ConnectorStatusPanel', () => {
   it('renders direct Discord runtime and gate-observed health together', async () => {
     const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
       if (path === '/api/v1/gate/status') return sampleGateResponse()
-      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse()
+      if (path === '/api/v1/gate/connectors') return sampleConnectorsResponse()
       if (path === '/api/v1/gate/keepers?limit=50&detailed=true') return sampleKeepersResponse()
       throw new Error(`unexpected path: ${path}`)
     })
@@ -211,11 +223,12 @@ describe('ConnectorStatusPanel', () => {
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
     expect(get).toHaveBeenCalledWith('/api/v1/gate/status')
-    expect(get).toHaveBeenCalledWith('/api/v1/gate/discord/status')
+    expect(get).toHaveBeenCalledWith('/api/v1/gate/connectors')
     expect(get).toHaveBeenCalledWith('/api/v1/gate/keepers?limit=50&detailed=true')
-    expect(text).toContain('Connector Operations')
-    expect(text).toContain('Discord Direct')
+    expect(text).toContain('Channel Gate Connectors')
+    expect(text).toContain('Gate-Advertised Connector')
     expect(text).toContain('connected')
+    expect(text).toContain('Discord')
     expect(text).toContain('sangsu')
     expect(text).toContain('keeper dir 2')
     expect(text).toContain('keeper-luna-agent')
@@ -229,7 +242,14 @@ describe('ConnectorStatusPanel', () => {
   it('still renders direct runtime when gate metrics are unavailable', async () => {
     const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
       if (path === '/api/v1/gate/status') throw new Error('GET /api/v1/gate/status: 503 Service Unavailable')
-      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse({ connected: false, stale: true })
+      if (path === '/api/v1/gate/connectors') return sampleConnectorsResponse({
+        connectors: [{
+          ...sampleConnectorsResponse().connectors[0],
+          connected: false,
+          stale: true,
+          status: 'stale',
+        }],
+      })
       if (path === '/api/v1/gate/keepers?limit=50&detailed=true') throw new Error('GET /api/v1/gate/keepers: 401 Unauthorized')
       throw new Error(`unexpected path: ${path}`)
     })
@@ -243,17 +263,17 @@ describe('ConnectorStatusPanel', () => {
     await flushUi()
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
-    expect(text).toContain('Discord Direct')
+    expect(text).toContain('Gate-Advertised Connector')
     expect(text).toContain('stale')
     expect(text).toContain('Gate metrics unavailable')
-    expect(text).toContain('Direct Discord runtime is visible')
+    expect(text).toContain('Gate-advertised connector runtime is visible')
     expect(text).toContain('keeper directory unavailable, manual entry only')
   })
 
   it('posts bind and unbind actions through the dashboard endpoints', async () => {
     const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
       if (path === '/api/v1/gate/status') return sampleGateResponse()
-      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse()
+      if (path === '/api/v1/gate/connectors') return sampleConnectorsResponse()
       if (path === '/api/v1/gate/keepers?limit=50&detailed=true') return sampleKeepersResponse()
       throw new Error(`unexpected path: ${path}`)
     })
@@ -310,7 +330,7 @@ describe('ConnectorStatusPanel', () => {
   it('shows selected keeper runtime metadata from the keeper directory', async () => {
     const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
       if (path === '/api/v1/gate/status') return sampleGateResponse()
-      if (path === '/api/v1/gate/discord/status') return sampleLiveResponse()
+      if (path === '/api/v1/gate/connectors') return sampleConnectorsResponse()
       if (path === '/api/v1/gate/keepers?limit=50&detailed=true') return sampleKeepersResponse()
       throw new Error(`unexpected path: ${path}`)
     })

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -270,6 +270,35 @@ describe('ConnectorStatusPanel', () => {
     expect(text).toContain('keeper directory unavailable, manual entry only')
   })
 
+  it('prefers backend-advertised connector status over derived booleans', async () => {
+    const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
+      if (path === '/api/v1/gate/status') return sampleGateResponse()
+      if (path === '/api/v1/gate/connectors') return sampleConnectorsResponse({
+        connectors: [{
+          ...sampleConnectorsResponse().connectors[0],
+          available: true,
+          connected: false,
+          stale: false,
+          status: 'connected',
+        }],
+      })
+      if (path === '/api/v1/gate/keepers?limit=50&detailed=true') return sampleKeepersResponse()
+      throw new Error(`unexpected path: ${path}`)
+    })
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      get,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+
+    expect(text).toContain('connected')
+    expect(text).not.toContain('disconnected')
+  })
+
   it('posts bind and unbind actions through the dashboard endpoints', async () => {
     const get = vi.fn<(path: string) => Promise<unknown>>().mockImplementation(async path => {
       if (path === '/api/v1/gate/status') return sampleGateResponse()

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -86,7 +86,42 @@ interface DiscordAuditEntry {
   previous_keeper: string
 }
 
-interface DiscordLiveStatusData {
+interface ConnectorStoragePaths {
+  status_path: string
+  binding_store_path: string
+  audit_path: string
+}
+
+interface ConnectorRuntimeSummary {
+  available: boolean
+  connected: boolean
+  stale: boolean
+  stale_after_sec: number
+  status: string
+  error: string
+  updated_at: string
+  last_ready_at: string
+  bot_user_name: string
+  bot_user_id: string
+  guild_count: number
+  gate_base_url: string
+  gate_healthy: boolean | null
+  gate_health_checked_at: string
+  pid: number
+}
+
+interface ConnectorBindingSummary {
+  binding_source: string
+  runtime_bindings_count: number
+  configured_bindings_count: number
+}
+
+interface GateConnectorInfo {
+  connector_id: string
+  display_name: string
+  channel: string
+  capabilities: string[]
+  status: string
   available: boolean
   connected: boolean
   stale: boolean
@@ -108,6 +143,17 @@ interface DiscordLiveStatusData {
   pid: number
   configured_bindings: DiscordConfiguredBinding[]
   recent_audit: DiscordAuditEntry[]
+  storage_paths: ConnectorStoragePaths
+  runtime_summary: ConnectorRuntimeSummary
+  binding_summary: ConnectorBindingSummary
+  observed_channel?: ChannelInfo | null
+}
+
+interface GateConnectorsData {
+  connectors: GateConnectorInfo[]
+  total: number
+  active_count: number
+  generated_at: string
 }
 
 interface BindingInfo {
@@ -143,10 +189,10 @@ interface GateEventInfo {
 }
 
 const data = signal<GateStatusData | null>(null)
-const discordLive = signal<DiscordLiveStatusData | null>(null)
+const connectorsData = signal<GateConnectorsData | null>(null)
 const loading = signal(false)
 const error = signal<string | null>(null)
-const liveError = signal<string | null>(null)
+const connectorError = signal<string | null>(null)
 const keeperDirectory = signal<GateKeeperInfo[]>([])
 const keeperDirectoryError = signal<string | null>(null)
 const actionLoading = signal(false)
@@ -155,6 +201,12 @@ const keeperDraft = signal('')
 
 let inflightRequest: Promise<void> | null = null
 const GATE_KEEPERS_PATH = '/api/v1/gate/keepers?limit=50&detailed=true'
+const GATE_CONNECTORS_PATH = '/api/v1/gate/connectors'
+
+function preferredConnector(payload: GateConnectorsData | null): GateConnectorInfo | null {
+  if (!payload || payload.connectors.length === 0) return null
+  return payload.connectors.find(connector => connector.capabilities.includes('bindings')) ?? payload.connectors[0] ?? null
+}
 
 async function refresh() {
   if (inflightRequest) return
@@ -168,17 +220,18 @@ async function refresh() {
       error.value = e instanceof Error ? e.message : 'fetch failed'
     }
     try {
-      const liveResult = await get<DiscordLiveStatusData>('/api/v1/gate/discord/status')
-      discordLive.value = liveResult
-      liveError.value = null
-      if (!channelDraft.value && liveResult.configured_bindings.length > 0) {
-        channelDraft.value = liveResult.configured_bindings[0]?.channel_id ?? ''
+      const connectorResult = await get<GateConnectorsData>(GATE_CONNECTORS_PATH)
+      connectorsData.value = connectorResult
+      connectorError.value = null
+      const primaryConnector = preferredConnector(connectorResult)
+      if (!channelDraft.value && (primaryConnector?.configured_bindings.length ?? 0) > 0) {
+        channelDraft.value = primaryConnector?.configured_bindings[0]?.channel_id ?? ''
       }
-      if (!keeperDraft.value && liveResult.configured_bindings.length > 0) {
-        keeperDraft.value = liveResult.configured_bindings[0]?.keeper_name ?? ''
+      if (!keeperDraft.value && (primaryConnector?.configured_bindings.length ?? 0) > 0) {
+        keeperDraft.value = primaryConnector?.configured_bindings[0]?.keeper_name ?? ''
       }
     } catch (e) {
-      liveError.value = e instanceof Error ? e.message : 'fetch failed'
+      connectorError.value = e instanceof Error ? e.message : 'fetch failed'
     }
     try {
       const keepersResult = await get<GateKeepersData>(GATE_KEEPERS_PATH)
@@ -292,15 +345,15 @@ function keeperLabel(keeper: GateKeeperInfo): string {
   return [keeper.name, status, model, runtime].filter(Boolean).join(' · ')
 }
 
-function discordStateLabel(live: DiscordLiveStatusData | null): string {
-  if (!live?.available) return 'offline'
-  if (live.stale) return 'stale'
-  if (live.connected) return 'connected'
+function connectorStateLabel(connector: GateConnectorInfo | null): string {
+  if (!connector?.available) return 'offline'
+  if (connector.stale) return 'stale'
+  if (connector.connected) return 'connected'
   return 'disconnected'
 }
 
-function discordStateTone(live: DiscordLiveStatusData | null): string {
-  const label = discordStateLabel(live)
+function connectorStateTone(connector: GateConnectorInfo | null): string {
+  const label = connectorStateLabel(connector)
   if (label === 'connected') {
     return 'border-emerald-400/30 bg-emerald-500/12 text-emerald-100'
   }
@@ -347,94 +400,104 @@ async function unbindDiscordChannel(channelIdOverride?: string) {
 }
 
 function DiscordLivePanel({
-  live,
+  connector,
   gate,
 }: {
-  live: DiscordLiveStatusData | null
+  connector: GateConnectorInfo | null
   gate: GateStatusData | null
 }) {
   const keepers = keeperDirectory.value
   const keeperByName = new Map(keepers.map(keeper => [keeper.name, keeper] as const))
-  const configuredBindings = live?.configured_bindings ?? []
-  const audit = live?.recent_audit ?? []
+  const configuredBindings = connector?.configured_bindings ?? []
+  const audit = connector?.recent_audit ?? []
   const observedRooms = uniqueStrings([
     ...(gate?.bindings ?? [])
-      .filter(binding => binding.channel === 'discord')
+      .filter(binding => binding.channel === (connector?.channel ?? ''))
       .map(binding => binding.room_id),
     ...(gate?.recent_events ?? [])
-      .filter(event => event.channel === 'discord')
+      .filter(event => event.channel === (connector?.channel ?? ''))
       .map(event => event.room_id),
     ...configuredBindings.map(binding => binding.channel_id),
   ])
   const suggestedKeepers = uniqueStrings([
     ...(gate?.bindings ?? [])
-      .filter(binding => binding.channel === 'discord')
+      .filter(binding => binding.channel === (connector?.channel ?? ''))
       .map(binding => binding.keeper),
     ...(gate?.recent_events ?? [])
-      .filter(event => event.channel === 'discord')
+      .filter(event => event.channel === (connector?.channel ?? ''))
       .map(event => event.keeper),
     ...configuredBindings.map(binding => binding.keeper_name),
   ])
   const selectedKeeper = keeperByName.get(keeperDraft.value.trim()) ?? null
-  const directLabel = discordStateLabel(live)
-  const directTone = discordStateTone(live)
+  const directLabel = connectorStateLabel(connector)
+  const directTone = connectorStateTone(connector)
+  const bindingActionsEnabled =
+    connector?.connector_id === 'discord' && connector.capabilities.includes('bindings')
+  const connectorName = connector?.display_name || 'Connector'
+  const channelInputLabel = `${connectorName} channel id`
 
   return html`
     <div class="mb-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(135deg,rgba(88,101,242,0.16),rgba(88,101,242,0.04))] p-4">
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="min-w-0">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">Discord Direct</div>
+          <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">Gate-Advertised Connector</div>
           <div class="mt-1 flex flex-wrap items-center gap-2">
             <span class=${`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] ${directTone}`}>
               ${directLabel}
             </span>
             <span class="text-[13px] font-medium text-[var(--text-body)]">
-              ${live?.bot_user_name ? `${live.bot_user_name} · ${truncateMiddle(live.bot_user_id, 24)}` : 'No live bot identity yet'}
+              ${connector?.bot_user_name
+                ? `${connectorName} · ${connector.bot_user_name} · ${truncateMiddle(connector.bot_user_id, 24)}`
+                : `${connectorName} runtime has not reported identity yet`}
             </span>
           </div>
           <div class="mt-2 flex flex-wrap gap-3 text-[11px] text-[var(--text-dim)]">
-            <span>heartbeat ${timeAgo(live?.updated_at ?? '')}</span>
-            <span>ready ${timeAgo(live?.last_ready_at ?? '')}</span>
-            <span>guilds ${live?.guild_count ?? 0}</span>
-            <span>runtime bindings ${live?.runtime_bindings_count ?? configuredBindings.length}</span>
-            <span>source ${live?.binding_source || 'unknown'}</span>
+            <span>heartbeat ${timeAgo(connector?.updated_at ?? '')}</span>
+            <span>ready ${timeAgo(connector?.last_ready_at ?? '')}</span>
+            <span>guilds ${connector?.guild_count ?? 0}</span>
+            <span>runtime bindings ${connector?.runtime_bindings_count ?? configuredBindings.length}</span>
+            <span>source ${connector?.binding_source || 'unknown'}</span>
             <span>keeper dir ${keepers.length}</span>
             <span>
-              gate ${live?.gate_healthy == null ? 'unknown' : live.gate_healthy ? 'healthy' : 'unhealthy'}
+              gate ${connector?.gate_healthy == null ? 'unknown' : connector.gate_healthy ? 'healthy' : 'unhealthy'}
             </span>
           </div>
         </div>
         <div class="flex flex-wrap gap-2">
           <${ActionButton} variant="ghost" size="sm" disabled=${loading.value || actionLoading.value} onClick=${() => { void refresh() }}>Refresh<//>
-          <${ActionButton}
-            variant="primary"
-            size="sm"
-            disabled=${actionLoading.value || channelDraft.value.trim().length === 0 || keeperDraft.value.trim().length === 0}
-            onClick=${() => { void bindDiscordChannel() }}
-          >
-            ${actionLoading.value ? 'Applying...' : 'Bind'}
-          <//>
-          <${ActionButton}
-            variant="danger"
-            size="sm"
-            disabled=${actionLoading.value || channelDraft.value.trim().length === 0}
-            onClick=${() => { void unbindDiscordChannel() }}
-          >
-            Unbind
-          <//>
+          ${bindingActionsEnabled
+            ? html`
+                <${ActionButton}
+                  variant="primary"
+                  size="sm"
+                  disabled=${actionLoading.value || channelDraft.value.trim().length === 0 || keeperDraft.value.trim().length === 0}
+                  onClick=${() => { void bindDiscordChannel() }}
+                >
+                  ${actionLoading.value ? 'Applying...' : 'Bind'}
+                <//>
+                <${ActionButton}
+                  variant="danger"
+                  size="sm"
+                  disabled=${actionLoading.value || channelDraft.value.trim().length === 0}
+                  onClick=${() => { void unbindDiscordChannel() }}
+                >
+                  Unbind
+                <//>
+              `
+            : null}
         </div>
       </div>
 
-      ${liveError.value || live?.error
-        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">${liveError.value ?? live?.error}</div>`
+      ${connectorError.value || connector?.error
+        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">${connectorError.value ?? connector?.error}</div>`
         : null}
 
-      ${live
+      ${connector
         ? html`
             <div class="mt-3 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
-              <span>status ${live.status_path || '-'}</span>
-              <span>bindings ${live.binding_store_path || '-'}</span>
-              <span>audit ${live.audit_path || '-'}</span>
+              <span>status ${connector.status_path || '-'}</span>
+              <span>bindings ${connector.binding_store_path || '-'}</span>
+              <span>audit ${connector.audit_path || '-'}</span>
             </div>
           `
         : null}
@@ -445,8 +508,8 @@ function DiscordLivePanel({
             <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Channel ID</div>
             <${TextInput}
               value=${channelDraft.value}
-              placeholder="Discord channel snowflake"
-              ariaLabel="Discord channel id"
+              placeholder=${`${connectorName} channel identifier`}
+              ariaLabel=${channelInputLabel}
               onInput=${(e: Event) => { channelDraft.value = (e.target as HTMLInputElement).value }}
             />
           </div>
@@ -530,7 +593,7 @@ function DiscordLivePanel({
           <div>
             <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Configured bindings</div>
             ${configuredBindings.length === 0
-              ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">저장된 Discord 바인딩 없음</div>`
+              ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No persisted connector bindings yet</div>`
               : html`
                   <div class="space-y-2">
                     ${configuredBindings.map(binding => html`
@@ -557,7 +620,9 @@ function DiscordLivePanel({
                               channelDraft.value = binding.channel_id
                               keeperDraft.value = binding.keeper_name
                             }}>Use<//>
-                            <${ActionButton} variant="danger" size="sm" disabled=${actionLoading.value} onClick=${() => { void unbindDiscordChannel(binding.channel_id) }}>Unbind<//>
+                            ${bindingActionsEnabled
+                              ? html`<${ActionButton} variant="danger" size="sm" disabled=${actionLoading.value} onClick=${() => { void unbindDiscordChannel(binding.channel_id) }}>Unbind<//>`
+                              : null}
                           </div>
                         </div>
                       </div>
@@ -779,7 +844,7 @@ export function ConnectorStatusPanel() {
   }, [lastEvent.value])
 
   const d = data.value
-  const live = discordLive.value
+  const live = preferredConnector(connectorsData.value)
 
   if (loading.value && !d && !live) {
     return html`<${LoadingState}>커넥터 상태 불러오는 중...<//>`
@@ -795,18 +860,18 @@ export function ConnectorStatusPanel() {
     <div>
       <div class="mb-3 flex items-center justify-between gap-3">
         <div>
-          <h3 class="text-sm font-semibold text-[var(--text-body)]">Connector Operations</h3>
+          <h3 class="text-sm font-semibold text-[var(--text-body)]">Channel Gate Connectors</h3>
           <div class="mt-1 text-[11px] text-[var(--text-dim)]">
-            Discord direct runtime + Gate-observed traffic in one surface.
+            Gate advertises connector descriptors; traffic health comes from gate metrics.
           </div>
         </div>
         <div class="text-right text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">
-          <div>${d ? `success ${d.success_rate_pct}%` : `direct ${discordStateLabel(live)}`}</div>
+          <div>${d ? `success ${d.success_rate_pct}%` : `descriptor ${connectorStateLabel(live)}`}</div>
           <div>${d ? `uptime ${formatUptime(d.uptime_seconds)}` : 'gate metrics unavailable'}</div>
         </div>
       </div>
 
-      <${DiscordLivePanel} live=${live} gate=${d} />
+      <${DiscordLivePanel} connector=${live} gate=${d} />
 
       ${error.value
         ? html`
@@ -819,7 +884,7 @@ export function ConnectorStatusPanel() {
       ${!d
         ? html`
             <div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">
-              Direct Discord runtime is visible, but Gate-observed traffic is not available yet.
+              Gate-advertised connector runtime is visible, but Gate-observed traffic is not available yet.
             </div>
           `
         : html`
@@ -885,10 +950,10 @@ export function ConnectorStatusPanel() {
 
 export function resetConnectorStatusState() {
   data.value = null
-  discordLive.value = null
+  connectorsData.value = null
   loading.value = false
   error.value = null
-  liveError.value = null
+  connectorError.value = null
   keeperDirectory.value = []
   keeperDirectoryError.value = null
   actionLoading.value = false

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -346,6 +346,10 @@ function keeperLabel(keeper: GateKeeperInfo): string {
 }
 
 function connectorStateLabel(connector: GateConnectorInfo | null): string {
+  const advertised = connector?.status?.trim().toLowerCase()
+  if (advertised === 'offline' || advertised === 'stale' || advertised === 'connected' || advertised === 'disconnected') {
+    return advertised
+  }
   if (!connector?.available) return 'offline'
   if (connector.stale) return 'stale'
   if (connector.connected) return 'connected'

--- a/lib/channel_gate_discord_state.ml
+++ b/lib/channel_gate_discord_state.ml
@@ -16,9 +16,17 @@ type audit_event = {
   previous_keeper : string;
 }
 
-let default_status_path = "sidecars/discord-bot/.gate/discord_status.json"
-let default_binding_store_path = "sidecars/discord-bot/.gate/discord_bindings.json"
-let default_binding_audit_path =
+let connector_id = "discord"
+let connector_display_name = "Discord"
+let connector_channel = "discord"
+
+let default_status_path = ".masc/connectors/discord/status.json"
+let default_binding_store_path = ".masc/connectors/discord/bindings.json"
+let default_binding_audit_path = ".masc/connectors/discord/binding_audit.jsonl"
+
+let legacy_status_path = "sidecars/discord-bot/.gate/discord_status.json"
+let legacy_binding_store_path = "sidecars/discord-bot/.gate/discord_bindings.json"
+let legacy_binding_audit_path =
   "sidecars/discord-bot/.gate/discord_binding_audit.jsonl"
 
 let stale_after_sec () =
@@ -30,21 +38,43 @@ let resolve_path raw_path =
   else
     raw_path
 
-let configured_path env_name ~default =
+let configured_write_path env_name ~default =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
   | Some raw -> resolve_path raw
   | None -> resolve_path default
 
+let configured_read_path env_name ~default ~legacy =
+  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
+  | Some raw -> resolve_path raw
+  | None ->
+      let preferred = resolve_path default in
+      let legacy = resolve_path legacy in
+      if Sys.file_exists preferred then preferred
+      else if Sys.file_exists legacy then legacy
+      else preferred
+
 let status_path () =
-  configured_path "MASC_DISCORD_STATUS_PATH" ~default:default_status_path
+  configured_read_path "MASC_DISCORD_STATUS_PATH" ~default:default_status_path
+    ~legacy:legacy_status_path
+
+let status_write_path () =
+  configured_write_path "MASC_DISCORD_STATUS_PATH" ~default:default_status_path
 
 let binding_store_path () =
-  configured_path "MASC_DISCORD_BINDING_STORE_PATH"
+  configured_write_path "MASC_DISCORD_BINDING_STORE_PATH"
     ~default:default_binding_store_path
 
+let binding_store_read_path () =
+  configured_read_path "MASC_DISCORD_BINDING_STORE_PATH"
+    ~default:default_binding_store_path ~legacy:legacy_binding_store_path
+
 let binding_audit_path () =
-  configured_path "MASC_DISCORD_BINDING_AUDIT_PATH"
+  configured_write_path "MASC_DISCORD_BINDING_AUDIT_PATH"
     ~default:default_binding_audit_path
+
+let binding_audit_read_path () =
+  configured_read_path "MASC_DISCORD_BINDING_AUDIT_PATH"
+    ~default:default_binding_audit_path ~legacy:legacy_binding_audit_path
 
 let read_json_file_opt path =
   if not (Sys.file_exists path) then
@@ -71,7 +101,7 @@ let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
   | _ -> []
 
 let read_bindings () : binding list =
-  match read_json_file_opt (binding_store_path ()) with
+  match read_json_file_opt (binding_store_read_path ()) with
   | Some json -> normalize_bindings_json json
   | None -> []
 
@@ -140,7 +170,7 @@ let rec drop_left n xs =
     | _ :: tl -> drop_left (n - 1) tl
 
 let read_recent_audit ~limit =
-  let path = binding_audit_path () in
+  let path = binding_audit_read_path () in
   if limit <= 0 || not (Sys.file_exists path) then
     []
   else
@@ -183,9 +213,17 @@ let stale_of_updated_at updated_at =
   | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
   | None -> true
 
+let connector_state_label ~available ~connected ~stale =
+  if not available then "offline"
+  else if stale then "stale"
+  else if connected then "connected"
+  else "disconnected"
+
 let status_json ?(audit_limit = 10) () =
   let status_path = status_path () in
   let live_status = read_json_file_opt status_path in
+  let binding_store_path = binding_store_read_path () in
+  let audit_path = binding_audit_read_path () in
   let configured_bindings = read_bindings () in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let available = Option.is_some live_status in
@@ -215,10 +253,11 @@ let status_json ?(audit_limit = 10) () =
       ("connected", `Bool connected);
       ("stale", `Bool stale);
       ("stale_after_sec", `Int (stale_after_sec ()));
+      ("status", `String (connector_state_label ~available ~connected ~stale));
       ("error", `String error);
       ("status_path", `String status_path);
-      ("binding_store_path", `String (binding_store_path ()));
-      ("audit_path", `String (binding_audit_path ()));
+      ("binding_store_path", `String binding_store_path);
+      ("audit_path", `String audit_path);
       ("updated_at", `String updated_at);
       ( "last_ready_at",
         `String (status_field "last_ready_at" string_member "") );
@@ -244,6 +283,135 @@ let status_json ?(audit_limit = 10) () =
       ( "configured_bindings",
         `List (List.map binding_json configured_bindings) );
       ("recent_audit", `List recent_audit);
+    ]
+
+let list_assoc_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let find_assoc_by_string_field ~field ~value = function
+  | `List rows ->
+      List.find_map
+        (function
+          | (`Assoc _ as row) -> (
+              match list_assoc_field field row with
+              | Some (`String candidate) when String.equal candidate value ->
+                  Some row
+              | _ -> None)
+          | _ -> None)
+        rows
+  | _ -> None
+
+let connector_json ?gate_status_json ?(audit_limit = 10) () =
+  let status = status_json ~audit_limit () in
+  let observed_channel =
+    match gate_status_json with
+    | None -> `Null
+    | Some json -> (
+        match list_assoc_field "channels" json with
+        | Some channels -> (
+            match
+              find_assoc_by_string_field ~field:"channel" ~value:connector_channel
+                channels
+            with
+            | Some row -> row
+            | None -> `Null)
+        | None -> `Null)
+  in
+  let storage_paths =
+    `Assoc
+      [
+        ("status_path", `String (string_member status "status_path"));
+        ( "binding_store_path",
+          `String (string_member status "binding_store_path") );
+        ("audit_path", `String (string_member status "audit_path"));
+      ]
+  in
+  let runtime_summary =
+    `Assoc
+      [
+        ("available", `Bool (bool_member status "available"));
+        ("connected", `Bool (bool_member status "connected"));
+        ("stale", `Bool (bool_member status "stale"));
+        ("stale_after_sec", `Int (int_member status "stale_after_sec"));
+        ("status", `String (string_member status "status"));
+        ("error", `String (string_member status "error"));
+        ("updated_at", `String (string_member status "updated_at"));
+        ("last_ready_at", `String (string_member status "last_ready_at"));
+        ("bot_user_name", `String (string_member status "bot_user_name"));
+        ("bot_user_id", `String (string_member status "bot_user_id"));
+        ("guild_count", `Int (int_member status "guild_count"));
+        ("gate_base_url", `String (string_member status "gate_base_url"));
+        ( "gate_healthy",
+          Option.value ~default:`Null
+            (Option.map (fun value -> `Bool value)
+               (bool_option_member status "gate_healthy")) );
+        ( "gate_health_checked_at",
+          `String (string_member status "gate_health_checked_at") );
+        ("pid", `Int (int_member status "pid"));
+      ]
+  in
+  let binding_summary =
+    `Assoc
+      [
+        ("binding_source", `String (string_member status "binding_source"));
+        ( "runtime_bindings_count",
+          `Int (int_member status "runtime_bindings_count") );
+        ( "configured_bindings_count",
+          `Int
+            (status |> U.member "configured_bindings" |> U.to_list |> List.length)
+        );
+      ]
+  in
+  `Assoc
+    [
+      ("connector_id", `String connector_id);
+      ("display_name", `String connector_display_name);
+      ("channel", `String connector_channel);
+      ("capabilities", `List [ `String "runtime_status"; `String "bindings"; `String "audit" ]);
+      ("status", `String (string_member status "status"));
+      ("available", `Bool (bool_member status "available"));
+      ("connected", `Bool (bool_member status "connected"));
+      ("stale", `Bool (bool_member status "stale"));
+      ("stale_after_sec", `Int (int_member status "stale_after_sec"));
+      ("error", `String (string_member status "error"));
+      ("status_path", `String (string_member status "status_path"));
+      ("binding_store_path", `String (string_member status "binding_store_path"));
+      ("audit_path", `String (string_member status "audit_path"));
+      ("updated_at", `String (string_member status "updated_at"));
+      ("last_ready_at", `String (string_member status "last_ready_at"));
+      ("bot_user_name", `String (string_member status "bot_user_name"));
+      ("bot_user_id", `String (string_member status "bot_user_id"));
+      ("guild_count", `Int (int_member status "guild_count"));
+      ("gate_base_url", `String (string_member status "gate_base_url"));
+      ( "gate_healthy",
+        Option.value ~default:`Null
+          (Option.map (fun value -> `Bool value)
+             (bool_option_member status "gate_healthy")) );
+      ( "gate_health_checked_at",
+        `String (string_member status "gate_health_checked_at") );
+      ("binding_source", `String (string_member status "binding_source"));
+      ("runtime_bindings_count", `Int (int_member status "runtime_bindings_count"));
+      ("pid", `Int (int_member status "pid"));
+      ("configured_bindings", status |> U.member "configured_bindings");
+      ("recent_audit", status |> U.member "recent_audit");
+      ("storage_paths", storage_paths);
+      ("runtime_summary", runtime_summary);
+      ("binding_summary", binding_summary);
+      ("observed_channel", observed_channel);
+    ]
+
+let connectors_json ?gate_status_json ?(audit_limit = 10) () =
+  let connector = connector_json ?gate_status_json ~audit_limit () in
+  let active_count =
+    if bool_member connector "available" then 1 else 0
+  in
+  `Assoc
+    [
+      ("connectors", `List [ connector ]);
+      ("total", `Int 1);
+      ("active_count", `Int active_count);
+      ("generated_at", `String (Server_utils.iso8601_of_unix (Unix.gettimeofday ())));
     ]
 
 let rollback_bindings original_bindings =

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -314,6 +314,7 @@ let is_public_read_path path =
   || String.equal path "/health/ready"
   || String.equal path "/api/v1/gate/health"
   || String.equal path "/api/v1/gate/status"
+  || String.equal path "/api/v1/gate/connectors"
   || String.equal path "/api/v1/gate/discord/status"
   || String.equal path "/api/v1/gate/events"
   || String.equal path "/"

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -202,6 +202,25 @@ let handle_gate_status _state request reqd =
   respond_json_with_cors ~status:`OK request reqd
     (Yojson.Safe.to_string json)
 
+(** GET /api/v1/gate/connectors
+
+    Generic connector descriptor surface for dashboard/ops consumers.
+    The gate advertises which connectors exist and their current runtime
+    snapshots without requiring the caller to hardcode vendor-specific
+    knowledge. *)
+let handle_gate_connectors _state request reqd =
+  let audit_limit =
+    int_query_param request "audit_limit" ~default:10
+    |> fun value -> max 1 (min 50 value)
+  in
+  let gate_status = Channel_gate_metrics.snapshot_json () in
+  let json =
+    Channel_gate_discord_state.connectors_json ~gate_status_json:gate_status
+      ~audit_limit ()
+  in
+  respond_json_with_cors ~status:`OK request reqd
+    (Yojson.Safe.to_string json)
+
 (** GET /api/v1/gate/discord/status
 
     Dashboard-facing live connector status sourced from the Discord bot's
@@ -407,6 +426,11 @@ let add_routes ~sw ~clock router =
         with_public_read (fun state _req reqd ->
           handle_gate_status state request reqd
         ) request reqd)
+
+  |> Http.Router.get "/api/v1/gate/connectors" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         handle_gate_connectors state request reqd
+       ) request reqd)
 
   |> Http.Router.get "/api/v1/gate/discord/status" (fun request reqd ->
        with_public_read (fun state _req reqd ->

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -69,7 +69,8 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 ## Durable Runtime Bindings
 
 `/keeper-bind` and `/keeper-unbind` now persist the effective channel map to
-`DISCORD_BINDING_STORE_PATH` (default: `.gate/discord_bindings.json`).
+`DISCORD_BINDING_STORE_PATH` (default:
+`.masc/connectors/discord/bindings.json`).
 
 - If the store file does not exist, the bot starts from `DISCORD_KEEPER_MAP`
 - Once an operator persists a runtime bind/unbind, the store file becomes the
@@ -77,12 +78,17 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 - `/keeper-map` shows the active binding source and store path for operators
 - successful bind/unbind operations also append an audit record to
   `DISCORD_BINDING_AUDIT_PATH` (default:
-  `.gate/discord_binding_audit.jsonl`)
+  `.masc/connectors/discord/binding_audit.jsonl`)
 - the bot also writes a direct runtime snapshot to `DISCORD_STATUS_PATH`
-  (default: `.gate/discord_status.json`) every `STATUS_HEARTBEAT_SEC`
+  (default: `.masc/connectors/discord/status.json`) every `STATUS_HEARTBEAT_SEC`
   seconds so the dashboard can show live Discord connection state
 - runtime binding changes written by the dashboard are hot-reloaded by the bot
   without a process restart
+- relative connector paths resolve from `MASC_BASE_PATH` when it is set; this
+  keeps the bot on the same project data root as the MASC server
+- when the new default binding path is empty but the legacy sidecar-local
+  `.gate/discord_bindings.json` exists, the bot loads that legacy map as a
+  compatibility fallback and reports `binding_source=legacy-fallback`
 
 ## Operations Upgrades
 
@@ -92,6 +98,8 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 - `/keeper-map`: inspect resolved binding + loaded runtime map
 - `/keeper-audit [limit]`: inspect recent bind/unbind audit entries
 - Keeper names support slash-command autocomplete via `/api/v1/gate/keepers`
+- dashboards and other read-only ops surfaces should prefer
+  `/api/v1/gate/connectors`; it is the gate-owned connector descriptor surface
 - The bot now forwards attachment-only messages by synthesizing a deterministic
   `Attachments:` block instead of dropping them as empty content
 - A lightweight transport circuit breaker prevents repeated timeouts / 5xx

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -83,11 +83,23 @@ class GateBot(discord.Client):
         self.status_store = StatusStore(self.cfg.status_path())
         persisted_bindings = self.binding_store.load()
         if persisted_bindings is None:
-            self.keeper_bindings = self.cfg.keeper_map()
-            self.binding_source = "env-seed"
+            legacy_binding_store = BindingStore(self.cfg.legacy_binding_store_path())
+            legacy_bindings = legacy_binding_store.load()
+            if legacy_bindings is not None:
+                self.keeper_bindings = legacy_bindings
+                self.binding_source = "legacy-fallback"
+            else:
+                self.keeper_bindings = self.cfg.keeper_map()
+                self.binding_source = "env-seed"
         else:
             self.keeper_bindings = persisted_bindings
             self.binding_source = "persisted"
+        if self.binding_source == "legacy-fallback":
+            logger.info(
+                "Loaded Discord bindings from legacy store %s; new writes go to %s",
+                self.cfg.legacy_binding_store_path(),
+                self.binding_store.path,
+            )
         self._binding_store_mtime_ns = self.binding_store.modified_time_ns()
         self._last_gate_health: bool | None = None
         self._last_gate_health_at = ""

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -23,6 +23,7 @@ DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
 LEGACY_BINDING_STORE_PATH: Final[str] = ".gate/discord_bindings.json"
 LEGACY_BINDING_AUDIT_PATH: Final[str] = ".gate/discord_binding_audit.jsonl"
 LEGACY_STATUS_PATH: Final[str] = ".gate/discord_status.json"
+LEGACY_BASE_ROOT: Final[Path] = Path("sidecars/discord-bot")
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -220,6 +221,15 @@ class BotConfig(BaseSettings):
             return base_root / path
         return Path.cwd() / path
 
+    def _resolve_legacy_storage_path(self, legacy_cwd_path: str) -> Path:
+        path = Path(legacy_cwd_path).expanduser()
+        if path.is_absolute():
+            return path
+        base_root = self.base_path_root()
+        if base_root is not None:
+            return base_root / LEGACY_BASE_ROOT / path
+        return Path.cwd() / path
+
     def binding_store_path(self) -> Path:
         """Return the durable binding store path.
 
@@ -235,13 +245,13 @@ class BotConfig(BaseSettings):
         return self._resolve_storage_path(self.discord_status_path)
 
     def legacy_binding_store_path(self) -> Path:
-        return Path.cwd() / LEGACY_BINDING_STORE_PATH
+        return self._resolve_legacy_storage_path(LEGACY_BINDING_STORE_PATH)
 
     def legacy_binding_audit_path(self) -> Path:
-        return Path.cwd() / LEGACY_BINDING_AUDIT_PATH
+        return self._resolve_legacy_storage_path(LEGACY_BINDING_AUDIT_PATH)
 
     def legacy_status_path(self) -> Path:
-        return Path.cwd() / LEGACY_STATUS_PATH
+        return self._resolve_legacy_storage_path(LEGACY_STATUS_PATH)
 
     def gate_message_url(self) -> str:
         base = self.gate_base_url.rstrip("/")

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -8,12 +8,21 @@ from __future__ import annotations
 
 import ipaddress
 import json
+import os
 from pathlib import Path
 from typing import Final, cast
 from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/discord/bindings.json"
+DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/discord/binding_audit.jsonl"
+DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
+
+LEGACY_BINDING_STORE_PATH: Final[str] = ".gate/discord_bindings.json"
+LEGACY_BINDING_AUDIT_PATH: Final[str] = ".gate/discord_binding_audit.jsonl"
+LEGACY_STATUS_PATH: Final[str] = ".gate/discord_status.json"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -52,21 +61,21 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("DISCORD_KEEPER_MAP", "discord_keeper_map"),
     )
     discord_binding_store_path: str = Field(
-        default=".gate/discord_bindings.json",
+        default=DEFAULT_BINDING_STORE_PATH,
         validation_alias=AliasChoices(
             "DISCORD_BINDING_STORE_PATH",
             "discord_binding_store_path",
         ),
     )
     discord_binding_audit_path: str = Field(
-        default=".gate/discord_binding_audit.jsonl",
+        default=DEFAULT_BINDING_AUDIT_PATH,
         validation_alias=AliasChoices(
             "DISCORD_BINDING_AUDIT_PATH",
             "discord_binding_audit_path",
         ),
     )
     discord_status_path: str = Field(
-        default=".gate/discord_status.json",
+        default=DEFAULT_STATUS_PATH,
         validation_alias=AliasChoices(
             "DISCORD_STATUS_PATH",
             "discord_status_path",
@@ -196,28 +205,43 @@ class BotConfig(BaseSettings):
         typed_raw = cast(dict[object, object], raw)
         return {str(key): str(value) for key, value in typed_raw.items()}
 
+    def base_path_root(self) -> Path | None:
+        raw = os.getenv("MASC_BASE_PATH", "").strip()
+        if not raw:
+            return None
+        return Path(raw).expanduser()
+
+    def _resolve_storage_path(self, raw_path: str) -> Path:
+        path = Path(raw_path).expanduser()
+        if path.is_absolute():
+            return path
+        base_root = self.base_path_root()
+        if base_root is not None:
+            return base_root / path
+        return Path.cwd() / path
+
     def binding_store_path(self) -> Path:
         """Return the durable binding store path.
 
-        Relative paths are resolved from the current working directory so the
-        bot can be started from the sidecar directory without extra flags.
+        Relative paths resolve from MASC_BASE_PATH when set; otherwise they
+        fall back to the current working directory for local sidecar-only runs.
         """
-        path = Path(self.discord_binding_store_path).expanduser()
-        if path.is_absolute():
-            return path
-        return Path.cwd() / path
+        return self._resolve_storage_path(self.discord_binding_store_path)
 
     def binding_audit_path(self) -> Path:
-        path = Path(self.discord_binding_audit_path).expanduser()
-        if path.is_absolute():
-            return path
-        return Path.cwd() / path
+        return self._resolve_storage_path(self.discord_binding_audit_path)
 
     def status_path(self) -> Path:
-        path = Path(self.discord_status_path).expanduser()
-        if path.is_absolute():
-            return path
-        return Path.cwd() / path
+        return self._resolve_storage_path(self.discord_status_path)
+
+    def legacy_binding_store_path(self) -> Path:
+        return Path.cwd() / LEGACY_BINDING_STORE_PATH
+
+    def legacy_binding_audit_path(self) -> Path:
+        return Path.cwd() / LEGACY_BINDING_AUDIT_PATH
+
+    def legacy_status_path(self) -> Path:
+        return Path.cwd() / LEGACY_STATUS_PATH
 
     def gate_message_url(self) -> str:
         base = self.gate_base_url.rstrip("/")

--- a/sidecars/discord-bot/tests/test_binding_store.py
+++ b/sidecars/discord-bot/tests/test_binding_store.py
@@ -86,3 +86,53 @@ def test_config_falls_back_to_cwd_when_base_path_missing(tmp_path: Path) -> None
         if previous_base_path is not None:
             os.environ["MASC_BASE_PATH"] = previous_base_path
         os.chdir(original_cwd)
+
+
+def test_config_resolves_legacy_paths_from_base_path(tmp_path: Path) -> None:
+    base_path = tmp_path / "workspace"
+    base_path.mkdir()
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        gate_api_token="test-api-token",
+    )
+
+    previous_base_path = os.getenv("MASC_BASE_PATH")
+    original_cwd = Path.cwd()
+    try:
+        os.environ["MASC_BASE_PATH"] = str(base_path)
+        os.chdir(tmp_path)
+        assert cfg.legacy_binding_store_path() == (
+            base_path / "sidecars" / "discord-bot" / ".gate" / "discord_bindings.json"
+        )
+        assert cfg.legacy_binding_audit_path() == (
+            base_path / "sidecars" / "discord-bot" / ".gate" / "discord_binding_audit.jsonl"
+        )
+        assert cfg.legacy_status_path() == (
+            base_path / "sidecars" / "discord-bot" / ".gate" / "discord_status.json"
+        )
+    finally:
+        if previous_base_path is None:
+            os.environ.pop("MASC_BASE_PATH", None)
+        else:
+            os.environ["MASC_BASE_PATH"] = previous_base_path
+        os.chdir(original_cwd)
+
+
+def test_config_resolves_legacy_paths_from_cwd_without_base_path(tmp_path: Path) -> None:
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        gate_api_token="test-api-token",
+    )
+
+    previous_base_path = os.getenv("MASC_BASE_PATH")
+    original_cwd = Path.cwd()
+    try:
+        os.environ.pop("MASC_BASE_PATH", None)
+        os.chdir(tmp_path)
+        assert cfg.legacy_binding_store_path() == tmp_path / ".gate" / "discord_bindings.json"
+        assert cfg.legacy_binding_audit_path() == tmp_path / ".gate" / "discord_binding_audit.jsonl"
+        assert cfg.legacy_status_path() == tmp_path / ".gate" / "discord_status.json"
+    finally:
+        if previous_base_path is not None:
+            os.environ["MASC_BASE_PATH"] = previous_base_path
+        os.chdir(original_cwd)

--- a/sidecars/discord-bot/tests/test_binding_store.py
+++ b/sidecars/discord-bot/tests/test_binding_store.py
@@ -39,6 +39,8 @@ def test_binding_store_ignores_invalid_json(tmp_path: Path) -> None:
 
 
 def test_config_resolves_relative_binding_store_path(tmp_path: Path) -> None:
+    base_path = tmp_path / "workspace"
+    base_path.mkdir()
     cfg = BotConfig(
         discord_bot_token="test-token",
         gate_api_token="test-api-token",
@@ -47,11 +49,40 @@ def test_config_resolves_relative_binding_store_path(tmp_path: Path) -> None:
         discord_status_path="status/discord.json",
     )
 
+    previous_base_path = os.getenv("MASC_BASE_PATH")
     original_cwd = Path.cwd()
     try:
+        os.environ["MASC_BASE_PATH"] = str(base_path)
+        os.chdir(tmp_path)
+        assert cfg.binding_store_path() == base_path / "state" / "discord.json"
+        assert cfg.binding_audit_path() == base_path / "audit" / "discord.jsonl"
+        assert cfg.status_path() == base_path / "status" / "discord.json"
+    finally:
+        if previous_base_path is None:
+            os.environ.pop("MASC_BASE_PATH", None)
+        else:
+            os.environ["MASC_BASE_PATH"] = previous_base_path
+        os.chdir(original_cwd)
+
+
+def test_config_falls_back_to_cwd_when_base_path_missing(tmp_path: Path) -> None:
+    cfg = BotConfig(
+        discord_bot_token="test-token",
+        gate_api_token="test-api-token",
+        discord_binding_store_path="state/discord.json",
+        discord_binding_audit_path="audit/discord.jsonl",
+        discord_status_path="status/discord.json",
+    )
+
+    previous_base_path = os.getenv("MASC_BASE_PATH")
+    original_cwd = Path.cwd()
+    try:
+        os.environ.pop("MASC_BASE_PATH", None)
         os.chdir(tmp_path)
         assert cfg.binding_store_path() == tmp_path / "state" / "discord.json"
         assert cfg.binding_audit_path() == tmp_path / "audit" / "discord.jsonl"
         assert cfg.status_path() == tmp_path / "status" / "discord.json"
     finally:
+        if previous_base_path is not None:
+            os.environ["MASC_BASE_PATH"] = previous_base_path
         os.chdir(original_cwd)

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -91,6 +91,61 @@ let test_unbind_removes_existing_binding () =
         check string "latest audit action" "unbind"
           (List.hd audit |> U.member "action" |> U.to_string))
 
+let test_connectors_json_advertises_gate_connector_descriptor () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    ignore
+      (Discord_state.bind ~channel_id:"1234567890" ~keeper_name:"luna"
+         ~actor_name:"dashboard");
+    let status_path = Filename.concat dir "status.json" in
+    Yojson.Safe.to_file status_path
+      (`Assoc
+        [
+          ("updated_at", `String "2026-04-09T00:00:00Z");
+          ("connected", `Bool true);
+          ("bot_user_name", `String "keeper-gateway");
+          ("bot_user_id", `String "bot-1");
+          ("guild_count", `Int 2);
+          ("gate_base_url", `String "http://127.0.0.1:8935");
+          ("gate_healthy", `Bool true);
+          ("gate_health_checked_at", `String "2026-04-09T00:00:00Z");
+          ("last_ready_at", `String "2026-04-09T00:00:00Z");
+          ("binding_source", `String "persisted");
+          ("runtime_bindings_count", `Int 1);
+          ("pid", `Int 4242);
+        ]);
+    let gate_status_json =
+      `Assoc
+        [
+          ( "channels",
+            `List
+              [
+                `Assoc
+                  [
+                    ("channel", `String "discord");
+                    ("message_count", `Int 3);
+                    ("success_rate_pct", `Int 100);
+                  ];
+              ] );
+        ]
+    in
+    let json = Discord_state.connectors_json ~gate_status_json () in
+    let connectors = json |> U.member "connectors" |> U.to_list in
+    check int "one connector" 1 (List.length connectors);
+    let connector = List.hd connectors in
+    check string "connector id" "discord"
+      (connector |> U.member "connector_id" |> U.to_string);
+    check string "display name" "Discord"
+      (connector |> U.member "display_name" |> U.to_string);
+    check bool "bindings capability exposed" true
+      (connector |> U.member "capabilities" |> U.to_list
+       |> List.exists (function
+            | `String "bindings" -> true
+            | _ -> false));
+    check string "observed channel surfaced" "discord"
+      (connector |> U.member "observed_channel" |> U.member "channel"
+       |> U.to_string))
+
 let () =
   Random.self_init ();
   run "channel_gate_discord_state"
@@ -103,5 +158,7 @@ let () =
             test_bind_persists_binding_and_audit;
           test_case "unbind removes binding" `Quick
             test_unbind_removes_existing_binding;
+          test_case "connectors json advertises connector descriptor" `Quick
+            test_connectors_json_advertises_gate_connector_descriptor;
         ] );
     ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -139,6 +139,10 @@ let test_route_auth_contracts () =
     (file_contains_pattern
        "lib/server/server_auth.ml"
        {|String.equal path "/api/v1/gate/events"|});
+  check bool "channel gate connectors route stays public read" true
+    (file_contains_pattern
+       "lib/server/server_auth.ml"
+       {|String.equal path "/api/v1/gate/connectors"|});
   check bool "discord gate status route stays public read" true
     (file_contains_pattern
        "lib/server/server_auth.ml"
@@ -151,6 +155,10 @@ let test_route_auth_contracts () =
     (file_contains_pattern
        "lib/server/server_routes_http_routes_channel_gate.ml"
        {|Http.Router.get "/api/v1/gate/discord/status"|});
+  check bool "channel gate connectors route is registered" true
+    (file_contains_pattern
+       "lib/server/server_routes_http_routes_channel_gate.ml"
+       {|Http.Router.get "/api/v1/gate/connectors"|});
   check bool "discord gate bind route is registered" true
     (file_contains_pattern
        "lib/server/server_routes_http_routes_channel_gate.ml"


### PR DESCRIPTION
## Summary
- make the Channel Gate advertise connector descriptors via `/api/v1/gate/connectors`
- update the dashboard to consume gate-advertised connector runtime instead of hardcoding a Discord-only direct surface
- move Discord connector runtime storage to `.masc/connectors/discord/*` with legacy sidecar-local fallback and document the boundary ownership

## Verification
- `pnpm exec tsc --noEmit --pretty -p tsconfig.json` (dashboard worktree; passed via temporary local `node_modules` symlink for dependency resolution only)
- `pnpm exec vitest run src/components/connector-status.test.ts`
- `PYTHONPATH=sidecars/discord-bot/src /Users/dancer/me/workspace/yousleepwhen/masc-mcp/sidecars/discord-bot/.venv/bin/pytest sidecars/discord-bot/tests/test_binding_store.py -q`
- `/opt/homebrew/bin/ruff check sidecars/discord-bot/src/bot.py sidecars/discord-bot/src/config.py sidecars/discord-bot/tests/test_binding_store.py`
- `_build/default/test/test_channel_gate_discord_state.exe`
- `_build/default/test/test_ci_hardening_source.exe`

## Notes
- `pyright` was not available in this environment.
- the temporary dashboard `node_modules` symlink was removed after verification.
