### PR TITLE
fix(keeper): expose 6 missing val declarations in keeper_config.mli

### DIFF
--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -15,6 +15,20 @@ val default_cascade_name : string
 (** Minimum context window (tokens) for any keeper turn. *)
 val min_keeper_context_tokens : int
 
+(** {2 Alert Preview Truncation Lengths}
+
+    Invariant: [excerpt_min < message_max < reply_max]. *)
+
+val alert_error_detail_max_chars : int
+val alert_excerpt_min_chars : int
+val alert_message_preview_max_chars : int
+val alert_reply_preview_max_chars : int
+
+(** {2 Tool Policy Display Thresholds} *)
+
+val tool_policy_count_warn_threshold : int
+val tool_first_sentence_max_chars : int
+
 val default_execution_scope : string
 val default_proactive_enabled : bool
 val default_proactive_idle_sec : int


### PR DESCRIPTION
## Summary
- `keeper_config.ml`에 정의된 6개 상수(alert preview 4개 + tool policy 2개)가 `.mli`에 선언되지 않아 빌드 실패
- Warning 32 (unused) + Unbound value 동시 발생 — `.mli` 누락의 전형적 증상
- `.mli`에 `val` 선언 추가하여 해결

## Changed
- `lib/keeper/keeper_config.mli`: 6개 `val` 선언 추가 (+14 lines)

## Test plan
- [x] `dune build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)