### PR TITLE
[codex] bootstrap base-path config root and drop legacy ME_ROOT fallback

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -5,7 +5,6 @@ type source =
   | Invalid_env
   | Exe_relative
   | Cwd
-  | Legacy_me_root
   | Missing
 
 type status =
@@ -37,9 +36,6 @@ type inputs = {
   env_config_dir : string option;
   env_personas_dir : string option;
   env_home : string option;
-  env_me_root : string option;
-  env_workspace_root : string option;
-  env_dune_sourceroot : string option;
 }
 
 let trim_opt = Env_config_core.trim_opt
@@ -59,7 +55,6 @@ let source_to_string = function
   | Invalid_env -> "invalid_env"
   | Exe_relative -> "exe_relative"
   | Cwd -> "cwd"
-  | Legacy_me_root -> "legacy_me_root"
   | Missing -> "missing"
 
 let status_to_string = function
@@ -131,18 +126,6 @@ let path_from_local_masc (inputs : inputs) =
       let candidate = Filename.concat (Filename.concat base_path ".masc") "config" in
       if config_signature_exists candidate then Some candidate else None
 
-let legacy_me_root_candidates (inputs : inputs) =
-  [ inputs.env_me_root; inputs.env_workspace_root; inputs.env_dune_sourceroot ]
-  |> List.filter_map trim_opt
-  |> List.map (fun root ->
-         Filename.concat
-           (Filename.concat root "workspace/yousleepwhen/masc-mcp")
-           "config")
-
-let path_from_legacy_me_root inputs =
-  legacy_me_root_candidates inputs
-  |> List.find_opt config_signature_exists
-
 let default_missing_root (inputs : inputs) =
   match trim_opt inputs.env_home with
   | Some home -> Filename.concat home ".masc/config"
@@ -173,18 +156,11 @@ let config_root_resolution (inputs : inputs) =
                   match path_from_executable ~cwd:inputs.cwd inputs.executable_name with
                   | Some path -> ({ path; exists = true; source = Exe_relative }, [])
                   | None ->
-                      match path_from_legacy_me_root inputs with
-                      | Some path ->
-                          ( { path; exists = true; source = Legacy_me_root },
-                            [ Printf.sprintf
-                                "Using legacy config fallback from ME_ROOT-style path: %s"
-                                path ] )
-                      | None ->
-                          let path = default_missing_root inputs in
-                          ( { path; exists = false; source = Missing },
-                            [ Printf.sprintf
-                                "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
-                                path ] )
+                      let path = default_missing_root inputs in
+                      ( { path; exists = false; source = Missing },
+                        [ Printf.sprintf
+                            "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
+                            path ] )
 
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in
@@ -216,9 +192,6 @@ let inputs_from_env () =
     env_config_dir = Env_config_core.config_dir_opt ();
     env_personas_dir = Env_config_core.personas_dir_opt ();
     env_home = Sys.getenv_opt "HOME";
-    env_me_root = Env_config_core.me_root_opt ();
-    env_workspace_root = Env_config_core.me_root_opt ();
-    env_dune_sourceroot = Sys.getenv_opt "DUNE_SOURCEROOT";
   }
 
 let resolve_with inputs =
@@ -240,7 +213,7 @@ let resolve_with inputs =
     match config_root.source with
     | Invalid_env -> Invalid_env_status
     | Missing -> Missing_status
-    | Env | Local_masc | Home_masc | Exe_relative | Cwd | Legacy_me_root ->
+    | Env | Local_masc | Home_masc | Exe_relative | Cwd ->
         if warnings = [] then Ready else Warn
   in
   { status; warnings; config_root; cascade; prompts; keepers; personas }
@@ -284,29 +257,14 @@ let personas_dirs_with inputs resolution =
     if resolution.personas.exists then [ resolution.personas.path ] else []
   in
   let explicit_personas_dir_override = trim_opt inputs.env_personas_dir in
-  (* inputs.env_personas_dir is populated only from MASC_PERSONAS_DIR, so
-     only that explicit override becomes sole-source. A generic config-root
-     env override still leaves HOME/base personas discovery enabled. *)
+  (* Persona resolution is intentionally single-source:
+     - MASC_PERSONAS_DIR when explicitly set
+     - otherwise the resolved config root's personas/
+     Hidden secondary searches (~/.masc/personas, $MASC_BASE_PATH/.masc/personas)
+     make the dashboard/config panel lie about the actual source of truth. *)
   match explicit_personas_dir_override with
   | Some _ -> dedupe_paths primary
-  | _ ->
-    let extra_candidates =
-      (* $HOME/.masc/personas *)
-      (match trim_opt inputs.env_home with
-       | Some home ->
-           let p = Filename.concat home ".masc/personas" in
-           if existing_dir p then [ p ] else []
-       | None -> [])
-      @
-      (* $MASC_BASE_PATH/.masc/personas *)
-      (match trim_opt inputs.env_base_path with
-       | Some base ->
-           let base = absolute_path_from ~cwd:inputs.cwd base in
-           let p = Filename.concat (Filename.concat base ".masc") "personas" in
-           if existing_dir p then [ p ] else []
-       | None -> [])
-    in
-    dedupe_paths (primary @ extra_candidates)
+  | None -> dedupe_paths primary
 
 let personas_dirs () =
   let resolution = resolve () in

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -146,61 +146,27 @@ let parse_git_clone (doc : Keeper_toml_loader.toml_doc) : git_clone_config =
   { allowed_orgs; denied_repos; default_depth;
     clone_timeout_sec; push_timeout_sec; pr_create_timeout_sec }
 
-let project_root_from_executable () =
-  let raw_exe =
-    try Sys.executable_name with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
-  in
-  let exe =
-    if String.equal raw_exe "" then ""
-    else
-      try Unix.realpath raw_exe
-      with Unix.Unix_error _ | Sys_error _ | Invalid_argument _ ->
-        raw_exe
-  in
-  if String.equal exe "" then None
-  else
-    let rec walk_up dir =
-      let parent = Filename.dirname dir in
-      if String.equal parent dir then None
-      else if String.equal (Filename.basename dir) "_build" then Some parent
-      else walk_up parent
-    in
-    walk_up (Filename.dirname exe)
+let config_root_for_base_path ~base_path =
+  let inputs = Config_dir_resolver.inputs_from_env () in
+  let inputs = { inputs with env_base_path = Some base_path } in
+  let resolution = Config_dir_resolver.resolve_with inputs in
+  (resolution.Config_dir_resolver.config_root.path, resolution.warnings)
 
 let load ~base_path : (t, string) result =
-  let rel = "config/tool_policy.toml" in
-  let base_candidate = Filename.concat base_path rel in
-  let cwd_candidate = Filename.concat (Sys.getcwd ()) rel in
-  let exe_candidate = match project_root_from_executable () with
-    | Some root -> Some (Filename.concat root rel)
-    | None -> None
-  in
-  let candidates =
-    [ base_candidate; cwd_candidate ]
-    @ (match exe_candidate with Some c -> [ c ] | None -> [])
-    |> List.fold_left (fun acc x ->
-      if List.exists (String.equal x) acc then acc else x :: acc
-    ) []
-    |> List.rev
-  in
-  let rec try_candidates failures = function
-    | [] ->
-      let detail =
-        failures
-        |> List.rev_map (fun (p, m) -> Printf.sprintf "%s: %s" p m)
-        |> String.concat "; "
+  let config_root, resolution_warnings = config_root_for_base_path ~base_path in
+  let path = Filename.concat config_root "tool_policy.toml" in
+  match Safe_ops.read_file_safe path with
+  | Error msg ->
+      let warning_detail =
+        match resolution_warnings with
+        | [] -> ""
+        | warnings -> Printf.sprintf " warnings: %s" (String.concat " | " warnings)
       in
       Error
         (Printf.sprintf
-           "tool policy config not found in base directory or current working directory. %s" detail)
-    | path :: rest ->
-      (match Safe_ops.read_file_safe path with
-       | Ok content -> Ok (path, content)
-       | Error msg -> try_candidates ((path, msg) :: failures) rest)
-  in
-  match try_candidates [] candidates with
-  | Error _ as e -> e
-  | Ok (path, content) ->
+           "tool policy config not found at resolved config root %s (%s).%s"
+           path msg warning_detail)
+  | Ok content ->
     match Keeper_toml_loader.parse_toml content with
     | Error msg -> Error (Printf.sprintf "tool policy config parse error in %s: %s" path msg)
     | Ok doc ->

--- a/lib/keeper/keeper_tool_policy_config.mli
+++ b/lib/keeper/keeper_tool_policy_config.mli
@@ -14,7 +14,8 @@ type preset_resolution =
   | All_candidates        (** Use the entire candidate tool set *)
   | Subset of string list (** Use exactly this list of tool names *)
 
-(** Load and parse config/tool_policy.toml relative to [base_path].
+(** Load and parse [tool_policy.toml] from the resolved config root for
+    [base_path] (honoring [MASC_CONFIG_DIR] when present).
     Returns [Error msg] if the file is missing or malformed. *)
 val load : base_path:string -> (t, string) result
 

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -221,10 +221,10 @@ let persona_profile_path_opt name =
         Log.Keeper.warn "personas_dirs unexpected: %s" (Printexc.to_string exn);
         []
   in
-  (* Search all persona dirs; later dirs (local) override earlier (repo).
-     We reverse so local ~/.masc/personas wins over config/personas. *)
+  (* Search the resolved persona roots only.
+     Config_dir_resolver.personas_dirs now returns a single source of truth:
+     explicit MASC_PERSONAS_DIR or resolved CONFIG_ROOT/personas. *)
   dirs
-  |> List.rev
   |> List.find_map (fun root ->
          let path = Filename.concat (Filename.concat root name) "profile.json" in
          if Sys.file_exists path then Some path else None)
@@ -308,7 +308,12 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
           (match str "tool_preset" with
            | None -> None
            | Some raw -> normalize_tool_preset_raw raw);
-        tool_also_allow = normalize_name_list_opt (strs "tool_also_allow");
+        tool_also_allow =
+          (match normalize_name_list_opt (strs "tool_also_allow") with
+           | Some _ as explicit -> explicit
+           | None ->
+               (* Backward-compat alias kept in some live keeper TOMLs. *)
+               normalize_name_list_opt (strs "also_allow"));
         tool_denylist = normalize_name_list_opt (strs "tool_denylist");
         work_discovery_enabled = bool_ "work_discovery_enabled";
         work_discovery_sources =

--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -6,25 +6,9 @@
 let existing_dir path =
   Sys.file_exists path && Sys.is_directory path
 
-let dedupe_preserving_order items =
-  let seen = Hashtbl.create (List.length items) in
-  List.filter
-    (fun item ->
-      if Hashtbl.mem seen item then
-        false
-      else (
-        Hashtbl.add seen item ();
-        true))
-    items
-
 let prompt_markdown_dir_candidates ~workspace_path ~base_path =
-  dedupe_preserving_order
-    [
-      Filename.concat workspace_path "config/prompts";
-      Filename.concat base_path "config/prompts";
-      Filename.concat (Sys.getcwd ()) "config/prompts";
-      Config_dir_resolver.prompts_dir ();
-    ]
+  let _ = workspace_path, base_path in
+  [ Config_dir_resolver.prompts_dir () ]
 
 let resolve_prompt_markdown_dir ~workspace_path ~base_path =
   match

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -150,9 +150,10 @@ let runtime_resolution_json (config : Room.config) =
   let prompt_markdown_dir =
     Prompt_registry.get_markdown_dir () |> Option.value ~default:""
   in
-  let prompt_outside_workspace =
+  let expected_prompt_dir = Config_dir_resolver.prompts_dir () in
+  let prompt_dir_mismatch =
     prompt_markdown_dir <> ""
-    && not (String.starts_with ~prefix:config.workspace_path prompt_markdown_dir)
+    && not (String.equal prompt_markdown_dir expected_prompt_dir)
   in
   let source_mismatch =
     match runtime_commit, workspace_commit with
@@ -174,10 +175,10 @@ let runtime_resolution_json (config : Room.config) =
       :: acc
     else acc
     |> fun acc ->
-    if prompt_outside_workspace then
+    if prompt_dir_mismatch then
       (Printf.sprintf
-         "Prompt markdown dir resolves outside workspace path: %s"
-         prompt_markdown_dir)
+         "Prompt markdown dir (%s) differs from resolved config root (%s)."
+         prompt_markdown_dir expected_prompt_dir)
       :: acc
     else acc
     |> fun acc ->

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -26,6 +26,103 @@ let ensure_default_oas_cascade_timeout_env () =
       Unix.putenv "OAS_CASCADE_MODEL_TIMEOUT_SEC"
         (Printf.sprintf "%.0f" derived_timeout_s)
 
+let project_root_from_executable () =
+  let raw_exe =
+    try Sys.executable_name with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ""
+  in
+  let exe =
+    if String.equal raw_exe "" then ""
+    else
+      try Unix.realpath raw_exe
+      with Unix.Unix_error _ | Sys_error _ | Invalid_argument _ -> raw_exe
+  in
+  if String.equal exe "" then None
+  else
+    let rec walk_up dir =
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then None
+      else if String.equal (Filename.basename dir) "_build" then Some parent
+      else walk_up parent
+    in
+    walk_up (Filename.dirname exe)
+
+let dedupe_keep_order items =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item then
+        false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+
+let versioned_config_root_candidates () =
+  let cwd_candidate = Filename.concat (Sys.getcwd ()) "config" in
+  let exe_candidate =
+    match project_root_from_executable () with
+    | Some root -> Some (Filename.concat root "config")
+    | None -> None
+  in
+  [ Some cwd_candidate; exe_candidate ]
+  |> List.filter_map (fun x -> x)
+  |> dedupe_keep_order
+  |> List.filter (fun path -> Sys.file_exists path && Sys.is_directory path)
+
+let copy_file_if_missing ~src ~dst =
+  if Sys.file_exists dst then
+    ()
+  else begin
+    Fs_compat.mkdir_p (Filename.dirname dst);
+    Fs_compat.save_file dst (Fs_compat.load_file src)
+  end
+
+let rec copy_missing_tree ~src ~dst =
+  if Sys.is_directory src then begin
+    if Sys.file_exists dst && not (Sys.is_directory dst) then
+      Log.Server.warn
+        "config bootstrap: refusing to replace file with directory (%s -> %s)"
+        src dst
+    else begin
+      Fs_compat.mkdir_p dst;
+      Sys.readdir src
+      |> Array.iter (fun name ->
+             copy_missing_tree
+               ~src:(Filename.concat src name)
+               ~dst:(Filename.concat dst name))
+    end
+  end else if Sys.file_exists dst then
+    ()
+  else
+    copy_file_if_missing ~src ~dst
+
+let bootstrap_base_path_config_root ~base_path =
+  if Option.is_some (Env_config_core.config_dir_opt ()) then
+    ()
+  else
+    let config_root =
+      Filename.concat (Filename.concat base_path ".masc") "config"
+    in
+    let source_root =
+      versioned_config_root_candidates () |> List.find_opt Sys.file_exists
+    in
+    (match source_root with
+     | Some source ->
+         copy_missing_tree ~src:source ~dst:config_root;
+         Log.Server.info
+           "bootstrapped base-path config root: %s <- %s"
+           config_root source
+     | None ->
+         Fs_compat.mkdir_p (Filename.concat config_root "prompts");
+         Fs_compat.mkdir_p (Filename.concat config_root "keepers");
+         Fs_compat.mkdir_p (Filename.concat config_root "personas");
+         if not (Sys.file_exists (Filename.concat config_root "cascade.json")) then
+           Fs_compat.save_file (Filename.concat config_root "cascade.json") "{}";
+         Log.Server.warn
+           "bootstrapped minimal base-path config root without versioned source: %s"
+           config_root);
+    Config_dir_resolver.reset ()
+
 (* GC tuning for long-running server with bursty allocation.
 
    Dashboard refresh loops create 2GB+ transient allocations per cycle.
@@ -74,6 +171,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     end
   in
   Unix.putenv "MASC_BASE_PATH" base_path;
+  bootstrap_base_path_config_root ~base_path;
   (* RFC-0001 Gate A: initialize instrumentation stores *)
   Heuristic_metrics.init ~base_path;
   Agent_stress.init ~base_path;
@@ -326,11 +424,11 @@ let bootstrap_prompt_state (state : Mcp_server.server_state) =
       ~workspace_path:state.room_config.workspace_path
       ~base_path:state.room_config.base_path
   in
-  if prompt_markdown_dir
-     <> Filename.concat state.room_config.workspace_path "config/prompts"
-  then
-    Log.Misc.info "prompt markdown dir resolved outside room base: %s"
-      prompt_markdown_dir;
+  let expected_prompt_dir = Config_dir_resolver.prompts_dir () in
+  if prompt_markdown_dir <> expected_prompt_dir then
+    Log.Misc.warn
+      "prompt markdown dir diverges from resolved config root: %s (expected %s)"
+      prompt_markdown_dir expected_prompt_dir;
   let missing_prompt_files = Prompt_registry.validate_required_prompt_files () in
   if missing_prompt_files <> [] then
     Log.Misc.error "required prompt files missing: %s"

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -9,6 +9,7 @@
 val force_jsonl_fallback_env : unit -> unit
 val requested_backend_mode : unit -> string
 val ensure_default_oas_cascade_timeout_env : unit -> unit
+val bootstrap_base_path_config_root : base_path:string -> unit
 
 (** {1 Runtime Context}
 

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -37,8 +37,8 @@ let make_config_root root =
   write_file (Filename.concat config "cascade.json") "{}";
   config
 
-let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir ?env_me_root ?env_workspace_root
-    ?env_dune_sourceroot ?env_home ?(cwd = "/tmp/cwd") ?(executable_name = "/tmp/bin/masc-mcp") () =
+let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir
+    ?env_home ?(cwd = "/tmp/cwd") ?(executable_name = "/tmp/bin/masc-mcp") () =
   Lib.Config_dir_resolver.
     {
       cwd;
@@ -47,9 +47,6 @@ let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir ?env_me_root ?e
       env_config_dir;
       env_personas_dir;
       env_home;
-      env_me_root;
-      env_workspace_root;
-      env_dune_sourceroot;
     }
 
 let test_env_override_valid () =
@@ -126,21 +123,19 @@ let test_local_masc_fallback_precedes_home_masc () =
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check string "root path" local_config resolution.config_root.path
 
-let test_legacy_me_root_fallback () =
-  with_temp_dir "config-dir-legacy" @@ fun me_root ->
-  let repo_root =
+let test_no_legacy_me_root_fallback () =
+  with_temp_dir "config-dir-no-legacy" @@ fun me_root ->
+  let _repo_root =
     Filename.concat me_root "workspace/yousleepwhen/masc-mcp"
   in
-  let _config = make_config_root repo_root in
   let resolution =
     Lib.Config_dir_resolver.resolve_with
       (make_inputs ~cwd:"/tmp/missing-cwd"
-         ~executable_name:"/tmp/nonexistent-masc"
-         ~env_me_root:me_root ())
+         ~executable_name:"/tmp/nonexistent-masc" ())
   in
-  check string "status" "warn"
+  check string "status" "missing"
     (Lib.Config_dir_resolver.status_to_string resolution.status);
-  check string "root source" "legacy_me_root"
+  check string "root source" "missing"
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check bool "warning present" true (resolution.warnings <> [])
 
@@ -157,7 +152,7 @@ let test_personas_dirs_default_repo_only () =
   check (list string) "repo personas only"
     [ Filename.concat config "personas" ] dirs
 
-let test_personas_dirs_includes_home () =
+let test_personas_dirs_ignores_home_fallback () =
   with_temp_dir "pd-home" @@ fun root ->
   let config = make_config_root root in
   let home = Filename.concat root "home" in
@@ -166,8 +161,8 @@ let test_personas_dirs_includes_home () =
   let inputs = make_inputs ~env_config_dir:config ~env_home:home () in
   let resolution = Lib.Config_dir_resolver.resolve_with inputs in
   let dirs = Lib.Config_dir_resolver.personas_dirs_with inputs resolution in
-  check (list string) "repo + home personas"
-    [ Filename.concat config "personas"; home_personas ] dirs
+  check (list string) "repo personas only despite HOME fallback"
+    [ Filename.concat config "personas" ] dirs
 
 let test_personas_dirs_env_override_is_sole_source () =
   with_temp_dir "pd-env" @@ fun root ->
@@ -182,34 +177,23 @@ let test_personas_dirs_env_override_is_sole_source () =
   (* MASC_PERSONAS_DIR overrides: only the env dir, no home dir *)
   check (list string) "env override only" [ env_personas ] dirs
 
-let test_personas_dirs_dedup_overlapping () =
-  with_temp_dir "pd-dedup" @@ fun root ->
+let test_personas_dirs_ignores_base_path_fallback () =
+  with_temp_dir "pd-base" @@ fun root ->
   let config_root = Filename.concat root "config" in
   mkdir_p (Filename.concat config_root "prompts");
   mkdir_p (Filename.concat config_root "keepers");
   mkdir_p (Filename.concat config_root "personas");
   write_file (Filename.concat config_root "cascade.json") "{}";
-  (* Set HOME so that $HOME/.masc/personas points to the same config dir.
-     config_root = root/config, so home = root means
-     $HOME/.masc/personas does NOT exist (different path).
-     Instead, make them overlap by pointing MASC_BASE_PATH so that
-     $MASC_BASE_PATH/.masc/personas == config/personas *)
   let base = Filename.dirname config_root in
-  (* base/.masc/personas must exist for overlap *)
   let base_personas = Filename.concat (Filename.concat base ".masc") "personas" in
   mkdir_p base_personas;
-  (* Make config/personas and base/.masc/personas the same via symlink *)
   let config_personas = Filename.concat config_root "personas" in
   let inputs = make_inputs ~env_config_dir:config_root ~env_base_path:base
       ~cwd:root () in
   let resolution = Lib.Config_dir_resolver.resolve_with inputs in
   let dirs = Lib.Config_dir_resolver.personas_dirs_with inputs resolution in
-  (* Both config_personas and base_personas are different paths, so both appear *)
-  check bool "no exact duplicates"
-    (List.length dirs = List.length (List.sort_uniq String.compare dirs))
-    true;
-  check bool "config personas present"
-    (List.mem config_personas dirs) true
+  check (list string) "base path fallback ignored"
+    [ config_personas ] dirs
 
 let () =
   run "config_dir_resolver"
@@ -223,18 +207,18 @@ let () =
           test_case "local masc fallback precedes home masc" `Quick
             test_local_masc_fallback_precedes_home_masc;
           test_case "home masc fallback" `Quick test_home_masc_fallback;
-          test_case "legacy me_root fallback" `Quick
-            test_legacy_me_root_fallback;
+          test_case "does not fallback to legacy me_root repo path" `Quick
+            test_no_legacy_me_root_fallback;
         ] );
       ( "personas_dirs",
         [
           test_case "default returns repo personas only" `Quick
             test_personas_dirs_default_repo_only;
-          test_case "includes HOME .masc/personas" `Quick
-            test_personas_dirs_includes_home;
+          test_case "ignores HOME .masc/personas fallback" `Quick
+            test_personas_dirs_ignores_home_fallback;
           test_case "MASC_PERSONAS_DIR overrides as sole source" `Quick
             test_personas_dirs_env_override_is_sole_source;
-          test_case "dedup overlapping paths" `Quick
-            test_personas_dirs_dedup_overlapping;
+          test_case "ignores base_path .masc/personas fallback" `Quick
+            test_personas_dirs_ignores_base_path_fallback;
         ] );
     ]

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -2,6 +2,43 @@ open Alcotest
 
 module KTPC = Masc_mcp.Keeper_tool_policy_config
 
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  let rec rm_rf path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
+let rec mkdir_p dir =
+  if dir = "" || dir = "." || dir = "/" then ()
+  else if Sys.file_exists dir then ()
+  else begin
+    mkdir_p (Filename.dirname dir);
+    Unix.mkdir dir 0o755
+  end
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let read_file path =
+  In_channel.with_open_bin path In_channel.input_all
+
 let test_load_falls_back_to_resolved_config_dir () =
   (* Use the real project root so config/tool_policy.toml is found *)
   let base_path = Masc_test_deps.find_project_root () in
@@ -15,6 +52,27 @@ let test_load_falls_back_to_resolved_config_dir () =
         (Printf.sprintf
            "expected config load to succeed for base_path=%s: %s"
            base_path msg)
+
+let test_load_honors_masc_config_dir_override () =
+  with_temp_dir "tool-policy-config" @@ fun root ->
+  let source_root = Masc_test_deps.find_project_root () in
+  let config_dir = Filename.concat root "custom-config" in
+  mkdir_p config_dir;
+  let source_policy = Filename.concat source_root "config/tool_policy.toml" in
+  let target_policy = Filename.concat config_dir "tool_policy.toml" in
+  Out_channel.with_open_bin target_policy (fun oc ->
+      output_string oc (read_file source_policy));
+  with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+  match KTPC.load ~base_path:"/tmp/unrelated-base-path" with
+  | Ok cfg ->
+      let presets = KTPC.preset_names cfg in
+      check bool "loads config from MASC_CONFIG_DIR override" true
+        (List.mem "full" presets && List.mem "messaging" presets)
+  | Error msg ->
+      fail
+        (Printf.sprintf
+           "expected config load to succeed for override config_dir=%s: %s"
+           config_dir msg)
 
 (* ── preset_can_satisfy tests ───────────────────────────────── *)
 
@@ -123,6 +181,8 @@ let () =
         [
           test_case "falls back to resolved config dir" `Quick
             test_load_falls_back_to_resolved_config_dir;
+          test_case "honors MASC_CONFIG_DIR override" `Quick
+            test_load_honors_masc_config_dir_override;
         ] );
       ( "preset_can_satisfy",
         [

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -53,6 +53,34 @@ let with_temp_dir prefix f =
   Unix.mkdir dir 0o755;
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
+let with_cwd path f =
+  let saved = Sys.getcwd () in
+  Unix.chdir path;
+  Fun.protect ~finally:(fun () -> Unix.chdir saved) f
+
+let rec mkdir_p path =
+  if path = "" || path = "." || path = "/" then
+    ()
+  else if Sys.file_exists path then
+    ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let make_config_root root =
+  let config = Filename.concat root "config" in
+  mkdir_p (Filename.concat config "prompts");
+  mkdir_p (Filename.concat config "keepers");
+  mkdir_p (Filename.concat config "personas");
+  write_file (Filename.concat config "cascade.json") "{\"seed\":\"repo\"}";
+  write_file (Filename.concat config "tool_policy.toml")
+    "[groups.base]\ntools = [\"keeper_time_now\"]\n[presets.minimal]\ngroups = [\"base\"]\n";
+  write_file (Filename.concat config "prompts/keeper.unified.system.md") "prompt";
+  write_file (Filename.concat config "keepers/example.toml") "[keeper]\ngoal = \"example\"\n";
+  write_file (Filename.concat config "personas/example.txt") "persona";
+  config
+
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -193,6 +221,65 @@ let test_default_oas_cascade_timeout_keeps_explicit_override () =
   Server_runtime_bootstrap.ensure_default_oas_cascade_timeout_env ();
   Alcotest.(check string) "explicit override wins" "45"
     (Sys.getenv "OAS_CASCADE_MODEL_TIMEOUT_SEC")
+
+let test_bootstrap_base_path_config_root_copies_versioned_config () =
+  with_temp_dir "startup-config-bootstrap" (fun dir ->
+      let repo = Filename.concat dir "repo" in
+      mkdir_p repo;
+      ignore (make_config_root repo);
+      let base_path = Filename.concat dir "base" in
+      mkdir_p base_path;
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_cwd repo @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path;
+      let config_root = Filename.concat base_path ".masc/config" in
+      Alcotest.(check bool) "config root created" true (Sys.is_directory config_root);
+      Alcotest.(check string) "cascade copied" "{\"seed\":\"repo\"}"
+        (read_file (Filename.concat config_root "cascade.json"));
+      Alcotest.(check bool) "tool policy copied" true
+        (Sys.file_exists (Filename.concat config_root "tool_policy.toml"));
+      Alcotest.(check bool) "prompt copied" true
+        (Sys.file_exists
+           (Filename.concat config_root "prompts/keeper.unified.system.md"));
+      Alcotest.(check bool) "keeper TOML copied" true
+        (Sys.file_exists (Filename.concat config_root "keepers/example.toml")))
+
+let test_bootstrap_base_path_config_root_repairs_partial_root () =
+  with_temp_dir "startup-config-repair" (fun dir ->
+      let repo = Filename.concat dir "repo" in
+      mkdir_p repo;
+      ignore (make_config_root repo);
+      let base_path = Filename.concat dir "base" in
+      let config_root = Filename.concat base_path ".masc/config" in
+      mkdir_p config_root;
+      write_file (Filename.concat config_root "cascade.json") "{\"seed\":\"local\"}";
+      mkdir_p (Filename.concat config_root "personas");
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_cwd repo @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path;
+      Alcotest.(check string) "existing cascade preserved" "{\"seed\":\"local\"}"
+        (read_file (Filename.concat config_root "cascade.json"));
+      Alcotest.(check bool) "keepers repaired" true
+        (Sys.is_directory (Filename.concat config_root "keepers"));
+      Alcotest.(check bool) "prompts repaired" true
+        (Sys.is_directory (Filename.concat config_root "prompts"));
+      Alcotest.(check bool) "tool policy repaired" true
+        (Sys.file_exists (Filename.concat config_root "tool_policy.toml")))
+
+let test_bootstrap_base_path_config_root_skips_explicit_config_override () =
+  with_temp_dir "startup-config-explicit" (fun dir ->
+      let repo = Filename.concat dir "repo" in
+      mkdir_p repo;
+      ignore (make_config_root repo);
+      let base_path = Filename.concat dir "base" in
+      mkdir_p base_path;
+      let explicit = Filename.concat dir "override-config" in
+      mkdir_p explicit;
+      with_env "MASC_CONFIG_DIR" (Some explicit) @@ fun () ->
+      with_cwd repo @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root ~base_path;
+      Alcotest.(check bool) "base-path config not bootstrapped" false
+        (Sys.file_exists (Filename.concat base_path ".masc/config")))
 
 let test_constructor_is_pure () =
   with_temp_dir "startup-pure" (fun dir ->
@@ -593,6 +680,25 @@ let test_prompt_markdown_dir_falls_back_to_resolved_config_dir () =
       Alcotest.(check string) "temp room falls back to resolved prompt dir"
         expected resolved)
 
+let test_prompt_markdown_dir_honors_masc_config_dir_override () =
+  with_temp_dir "startup-prompts-override" (fun dir ->
+      let workspace_prompts = Filename.concat dir "config/prompts" in
+      let override_root = Filename.concat dir "override-config" in
+      let override_prompts = Filename.concat override_root "prompts" in
+      Fs_compat.mkdir_p workspace_prompts;
+      Fs_compat.mkdir_p override_prompts;
+      with_env "MASC_CONFIG_DIR" (Some override_root) @@ fun () ->
+      Config_dir_resolver.reset ();
+      let resolved =
+        Fun.protect
+          ~finally:(fun () -> Config_dir_resolver.reset ())
+          (fun () ->
+             Prompt_defaults.resolve_prompt_markdown_dir
+               ~workspace_path:dir ~base_path:dir)
+      in
+      Alcotest.(check string) "resolved config root wins over workspace prompts"
+        override_prompts resolved)
+
 let test_main_eio_serves_health_before_lazy_startup () =
   with_temp_dir "startup-health" (fun dir ->
       let exe = find_main_eio_exe () in
@@ -661,6 +767,16 @@ let () =
           Alcotest.test_case
             "default OAS cascade timeout keeps explicit override"
             `Quick test_default_oas_cascade_timeout_keeps_explicit_override;
+          Alcotest.test_case
+            "bootstrap base-path config copies versioned config"
+            `Quick test_bootstrap_base_path_config_root_copies_versioned_config;
+          Alcotest.test_case
+            "bootstrap base-path config repairs partial root"
+            `Quick test_bootstrap_base_path_config_root_repairs_partial_root;
+          Alcotest.test_case
+            "bootstrap base-path config skips explicit override"
+            `Quick
+            test_bootstrap_base_path_config_root_skips_explicit_config_override;
           Alcotest.test_case "constructors stay pure" `Quick
             test_constructor_is_pure;
           Alcotest.test_case "restore_persisted_sessions uses flat agents dir"
@@ -715,6 +831,8 @@ let () =
             test_startup_state_json_includes_watchdog;
           Alcotest.test_case "prompt markdown dir falls back to resolved config dir"
             `Quick test_prompt_markdown_dir_falls_back_to_resolved_config_dir;
+          Alcotest.test_case "prompt markdown dir honors MASC_CONFIG_DIR override"
+            `Quick test_prompt_markdown_dir_honors_masc_config_dir_override;
           Alcotest.test_case "main_eio serves health before lazy startup"
             `Slow test_main_eio_serves_health_before_lazy_startup;
         ] );


### PR DESCRIPTION
## Summary
- remove legacy `ME_ROOT`-style config fallback so config resolution no longer silently reaches into repo-relative paths
- make prompt, persona, and tool policy loading follow the resolved config root consistently
- bootstrap `base_path/.masc/config` on server startup by copying only missing config from the versioned repo config and repairing partial roots without overwriting existing files
- add regression coverage for config resolution, base-path bootstrap repair, and `MASC_CONFIG_DIR` tool policy override behavior

## Product impact
Promise: `repo coordination`

When `MASC_BASE_PATH` points at a non-repo root such as `~/me`, runtime config now comes from the expected source of truth instead of hidden repo-relative fallback paths. This keeps dashboard resolution, keeper config loading, prompt lookup, and tool policy loading aligned.

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-config-partial-root ./test/test_server_runtime_bootstrap.exe ./test/test_keeper_tool_policy_config.exe ./test/test_config_dir_resolver.exe ./test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_tool_policy_config.exe`
- `./_build/default/test/test_config_dir_resolver.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe` with only the pre-existing environment failure `main_eio executable not found`
- `gh pr checks 6197 --repo jeong-sik/masc-mcp`
  - `label-and-review`: pass
  - `pr-hygiene`: pass
  - `sweep-supersede-check`: pass

## Review evidence
- direct `sb glm-text` (`GLM-5`) cross-model review completed at `2026-04-09 20:45:48 KST`
- result: no accepted material findings
- detailed review note is recorded in a PR comment for auditability

## Linked issue
- Relates #6192
