### PR TITLE
[codex] remove keeper boring gate

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -308,8 +308,6 @@ module KeeperKeepalive = struct
       With tool_choice=Any, the model always calls tools, so idle
       detection triggers on repeated tool calls.  4 catches loops
       quickly while still allowing legitimate exploration.
-      (Lowered from 8: combined with the boring-tool gate in
-      keeper_hooks_oas.ml, 4 is sufficient.  See #5617.)
       Env: [MASC_KEEPER_IDLE_SKIP_THRESHOLD]. Default: 4. *)
   let idle_skip_threshold =
     max 2 (min 20 (get_int ~default:4 "MASC_KEEPER_IDLE_SKIP_THRESHOLD"))

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -261,7 +261,6 @@ let run_turn
       ?(is_retry = false)
       ?shared_context
       ?event_bus
-      ?boring_consecutive_turns_ref
       ()
   : (run_result, Oas.Error.sdk_error) result
   =
@@ -887,16 +886,6 @@ let run_turn
     | Some r -> r
     | None -> ref Agent_sdk.Tool_op.Keep_all
   in
-  (* Boring-tool gate: shared counter between after_turn (writer) and
-     before_turn_params (reader). Tracks consecutive turns where only
-     boring tools (status/heartbeat/tasks_list) were called.
-     When provided externally (from keepalive loop), persists across
-     run_turn calls to detect inter-run polling patterns. *)
-  let boring_consecutive_turns =
-    match boring_consecutive_turns_ref with
-    | Some r -> r
-    | None -> ref 0
-  in
   let base_hooks =
     Keeper_hooks_oas.make_hooks
       ~config
@@ -906,7 +895,6 @@ let run_turn
       ~generation
       ?max_cost_usd
       ?trajectory_acc
-      ~boring_consecutive_turns
       ()
   in
   (* BM25 Tool_selector removed: discovery mode uses core + keeper_tool_search.
@@ -1230,78 +1218,6 @@ let run_turn
                        max_turns)
                 else ctx
               in
-              (* Boring-tool gate: graduated response to consecutive turns
-           with only non-productive tools (status/heartbeat/tasks_list).
-           This catches the polling loop that bypasses OAS's exact-fingerprint
-           idle detection when keepers alternate boring tools.
-
-           Escalation levels — respect LLM judgment while constraining waste:
-           Level 1 (>=2): context warning — LLM decides.
-           Level 2 (>=3): tool_choice=None_ (no tool calls) + idle directive.
-             LLM still runs but can only produce text. Prompt directs concise
-             idle report. This respects non-deterministic judgment: if new work
-             appeared in context, the LLM can describe it and the next turn
-             (with boring_consecutive reset) will have tools again.
-           Level 3 (>=4): tool_choice=None_ + boring tools stripped + stronger
-             directive. LLM budget is not reduced — quality over cost.
-           Level 4 (>=6): same constraints + explicit exit signal.
-             The prompt tells the LLM this is the last chance to act. *)
-              let boring_streak = !boring_consecutive_turns in
-              let ctx =
-                if boring_streak >= 6
-                then
-                  append_ctx
-                    ctx
-                    (Printf.sprintf
-                       "[IDLE EXIT] %d consecutive idle turns. You have had no \
-                        productive work for %d turns. If you have genuinely new work \
-                        to report, describe it now in under 30 tokens. Otherwise, \
-                        output a single sentence: your current status and that you \
-                        are idle. This is your final turn before the session pauses."
-                       boring_streak boring_streak)
-                else if boring_streak >= 4
-                then
-                  append_ctx
-                    ctx
-                    (Printf.sprintf
-                       "[IDLE — NO TOOLS] %d consecutive idle turns. Tool calls are \
-                        disabled. You may only respond with text. If there is new work \
-                        in your context (board posts, mentions, tasks), describe what \
-                        you would do in under 100 tokens. If nothing has changed, \
-                        state your idle status in one sentence."
-                       boring_streak)
-                else if boring_streak >= 3
-                then
-                  append_ctx
-                    ctx
-                    (Printf.sprintf
-                       "[IDLE — TEXT ONLY] %d consecutive turns with no productive \
-                        tool calls. Tool calls are now disabled for this turn. \
-                        Review your context: has anything new appeared (board posts, \
-                        mentions, claimed tasks)? If yes, describe what action you \
-                        would take and why — tools will be restored next turn. \
-                        If nothing new, reply in under 50 tokens with your idle \
-                        status. Do not apologize or explain at length."
-                       boring_streak)
-                else if boring_streak >= 2
-                then
-                  append_ctx
-                    ctx
-                    "[POLLING DETECTED] 2 consecutive turns with only observation \
-                     tool calls (status/heartbeat/task-list). Check if there is \
-                     genuinely new work. If not, use keeper_stay_silent or respond \
-                     briefly. Next turn without productive action will disable tool \
-                     calls."
-                else ctx
-              in
-              let all_allowed =
-                if boring_streak >= 4
-                then
-                  List.filter
-                    (fun name -> not (Keeper_tool_registry.is_boring_tool name))
-                    all_allowed
-                else all_allowed
-              in
               let safe_last_turn_tools =
                 Keeper_tool_policy.last_turn_safe_tool_names ()
               in
@@ -1347,24 +1263,18 @@ let run_turn
                 else all_allowed
               in
               let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
-              (* Tool choice: graduated by keeper state.
+              (* Tool choice: graduated by turn budget.
            Normal turns: tool_choice=Any forces tool call format (deterministic
            at API level). WHICH tool is called is non-deterministic (model decides).
            Last turn: Auto allows [STATE] text block.
-           Boring >= 3: None_ disables tool calls entirely. The LLM can only
-           produce text — respecting its judgment to describe context or idle
-           status without consuming tool execution budget. Tools are restored
-           when boring_consecutive resets to 0 (i.e., after a productive turn).
            See #5566 for tool_choice=Any rationale. *)
               let tool_choice =
-                if boring_streak >= 3
-                then Some Agent_sdk.Types.None_  (* idle: text-only response *)
-                else if is_last_turn || List.length all_allowed = 0
+                if is_last_turn || List.length all_allowed = 0
                 then current_params.tool_choice (* last turn: Auto for [STATE] block *)
                 else Some Agent_sdk.Types.Any (* all other turns: force tool use *)
               in
               (* Tool disclosure telemetry: emitted after all allow-list rewrites
-           (boring-tool gate, last-turn intersect, max_tools cap) so that
+           (last-turn intersect, max_tools cap) so that
            final_visible and hook_ms reflect the actual state sent to AdjustParams.
            Capture now once so ts_unix and hook_ms are consistent. *)
               (let now = Time_compat.now () in
@@ -1506,13 +1416,6 @@ let run_turn
             ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
-           ~exit_condition:(fun _turn ->
-             (* OAS checks this predicate before each internal turn.
-                When boring_consecutive >= threshold, the keeper has had no
-                productive work — exit Agent.run early to avoid further
-                token spend. Threshold configurable via Runtime_params
-                "keeper.turn.boring_exit_threshold" (default: 8). *)
-             !boring_consecutive_turns >= Keeper_config.keeper_boring_exit_threshold ())
            ())
      with
      | Error e -> Error e

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -103,8 +103,7 @@ val adaptive_thinking_budget :
     @param priority Optional priority for scheduling
     @param is_retry When [true], replays current user message without persisting
     @param shared_context Optional shared OAS context for cross-turn state
-    @param event_bus Optional MASC event bus
-    @param boring_consecutive_turns_ref Mutable counter for idle-turn detection *)
+    @param event_bus Optional MASC event bus *)
 val run_turn :
      config:Room.config
   -> meta:Keeper_types.keeper_meta
@@ -133,6 +132,5 @@ val run_turn :
   -> ?is_retry:bool
   -> ?shared_context:Agent_sdk.Context.t
   -> ?event_bus:Agent_sdk.Event_bus.t
-  -> ?boring_consecutive_turns_ref:int ref
   -> unit
   -> (run_result, Oas.Error.sdk_error) result

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -753,18 +753,6 @@ let keeper_slot_id (name : string) : int option =
     let h = Hashtbl.hash name in
     Some (h mod num_slots)
 
-
-let keeper_boring_exit_threshold_rp =
-  _rp_int ~key:"keeper.turn.boring_exit_threshold"
-    ~default:(fun () ->
-      int_of_env_default "MASC_KEEPER_BORING_EXIT_THRESHOLD"
-        ~default:8 ~min_v:2 ~max_v:50)
-    ~min_v:2 ~max_v:50
-    ~description:"Consecutive boring turns before exit_condition triggers and keepalive skips proactive turns" ()
-
-let keeper_boring_exit_threshold () : int =
-  Runtime_params.get keeper_boring_exit_threshold_rp
-
 let keeper_enable_thinking_rp =
   _rp_bool ~key:"keeper.turn.enable_thinking"
     ~default:(fun () -> bool_of_env_default "MASC_KEEPER_ENABLE_THINKING" ~default:false)

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -200,15 +200,12 @@ val keeper_llama_slots : unit -> int
     Returns [None] when slot pinning is disabled. *)
 val keeper_slot_id : string -> int option
 
-val keeper_boring_exit_threshold : unit -> int
 val keeper_enable_thinking : unit -> bool
 val keeper_adaptive_thinking_enabled : unit -> bool
 
 (** {1 Runtime Param Handles}
 
     Exposed for test use only (e.g. [Runtime_params.clear]). *)
-
-val keeper_boring_exit_threshold_rp : int Runtime_params.param
 
 (** Room signal prompt enabled override from env var. *)
 val keeper_room_signal_prompt_enabled_override : unit -> bool option

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -237,7 +237,6 @@ let make_hooks
     ?(on_tool_executed : string -> Yojson.Safe.t -> string -> unit =
         fun _ _ _ -> ())
     ?(trajectory_acc : Trajectory.accumulator option)
-    ?(boring_consecutive_turns : int ref = ref 0)
     ()
   : Agent_sdk.Hooks.hooks =
   let sse_turn_complete = "keeper_turn_complete" in
@@ -245,13 +244,6 @@ let make_hooks
     [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_vote" ]
   in
   let tool_start_time = ref 0.0 in
-  (* Boring-tool gate: track whether current turn has any productive tool call.
-     A "boring" tool is one that reads status without side effects
-     (masc_status, masc_heartbeat, keeper_tasks_list, etc.).
-     Alternating boring tools bypasses OAS's exact-fingerprint idle detection.
-     This gate catches the broader pattern: consecutive turns with ONLY
-     boring tools, regardless of which specific boring tool was called. *)
-  let turn_has_productive_tool = ref false in
   (* Same-name streak gate: track consecutive calls to the same tool
      name (regardless of args). OAS idle detection requires exact
      name+args match, so board_get("a") → board_get("b") is never
@@ -326,18 +318,6 @@ let make_hooks
            carry across turns (e.g., 4 calls in turn N + 1 in turn N+1
            should not hit threshold 5). *)
         tool_name_streak := ("", 0);
-        (* Boring-tool gate: update consecutive counter at end of turn.
-           If no productive tool was called this turn, increment the
-           boring streak; otherwise reset to 0. *)
-        if !turn_has_productive_tool then
-          boring_consecutive_turns := 0
-        else begin
-          incr boring_consecutive_turns;
-          Log.Keeper.info
-            "keeper:%s boring_consecutive=%d (turn=%d had no productive tool)"
-            meta.name !boring_consecutive_turns turn
-        end;
-        turn_has_productive_tool := false;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 
@@ -381,10 +361,6 @@ let make_hooks
                      if m = "" then (!meta_ref).cascade_name else m)
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-        (* Boring-tool gate: mark turn as productive only for genuinely
-           productive tools. keeper_stay_silent is in the boring set. *)
-        if not (Keeper_tool_registry.is_boring_tool tool_name) then
-          turn_has_productive_tool := true;
         (try on_tool_executed tool_name input output_text
          with Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -694,7 +694,6 @@ let run_keepalive_unified_turn
       ~(stop : bool Atomic.t)
       ~(proactive_warmup_elapsed : bool)
       ~(shared_context : Agent_sdk.Context.t)
-      ~(boring_consecutive_turns_ref : int ref)
   : keeper_meta
   =
   if not proactive_warmup_elapsed
@@ -715,26 +714,6 @@ let run_keepalive_unified_turn
           ~meta:meta_after_triage
           obs
       in
-      (* Boring-turn gate: once the non-reactive idle streak reaches the
-         configured threshold, skip the turn entirely. Reactive turns
-         (mentions, board events) always run — new stimulus resets the boring
-         counter. Lower streaks are handled inside before_turn_params
-         (graduated prompt escalation + tool_choice=None_ at >=3) to let the
-         LLM judge whether new work appeared. Crossing the configured threshold
-         is the deterministic hard exit — no LLM call, no token spend. *)
-      let boring_skip =
-        let streak = !boring_consecutive_turns_ref in
-        let is_reactive =
-          turn_decision.channel = Keeper_world_observation.Reactive
-        in
-        let boring_threshold = Keeper_config.keeper_boring_exit_threshold () in
-        if streak >= boring_threshold && not is_reactive then begin
-          Log.Keeper.info
-            "keeper:%s boring_consecutive=%d >= %d, skipping proactive turn (hard gate)"
-            meta_after_triage.name streak boring_threshold;
-          true
-        end else false
-      in
       let manual_reconcile_pending =
         keeper_requires_manual_reconcile
           ~base_path:ctx.config.base_path
@@ -743,7 +722,6 @@ let run_keepalive_unified_turn
       let should_run_turn =
         (not (Atomic.get stop))
         && turn_decision.should_run
-        && (not boring_skip)
         && (not manual_reconcile_pending)
       in
       let meta_after_observe =
@@ -789,7 +767,6 @@ let run_keepalive_unified_turn
               ~channel:turn_decision.channel
               ~semaphore_wait_ms:semaphore_wait_ms
               ~shared_context
-              ~boring_consecutive_turns_ref
               ()
           with
           | Error err ->
@@ -1045,11 +1022,6 @@ let run_heartbeat_loop
      and tool-call counters are recreated inside run_turn and therefore
      do not accumulate for the full keeper lifecycle. *)
   let shared_context = Agent_sdk.Context.create () in
-  (* Inter-run boring-tool gate: persists across run_turn calls so
-     the anti-polling gate can detect heartbeat-level polling loops
-     (e.g., every heartbeat calls only masc_status then exits).
-     Intra-run counters reset on each run_turn; this ref does not. *)
-  let boring_consecutive_turns_ref = ref 0 in
   (* Mtime-based change detection for keeper meta disk reads.
      Avoids re-parsing the JSON file on every heartbeat cycle when
      no operator has modified it.  Initialized to 0.0 so the first
@@ -1141,7 +1113,6 @@ let run_heartbeat_loop
             ~stop
             ~proactive_warmup_elapsed
             ~shared_context
-            ~boring_consecutive_turns_ref
         in
         (* Turn failure threshold: registry tracks count (via unified_turn),
                  keepalive raises to terminate the fiber for supervisor restart. *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -122,14 +122,13 @@ let has_mutating_side_effect (name : string) : bool =
 
 (** Tools that gather status but produce no side effects.
     Calling only these tools across consecutive turns indicates a
-    polling loop.  This shared classification is used both by the
-    boring-tool gate in [Keeper_hooks_oas] to detect and break such
-    loops, and by allowlist gating through [is_boring_tool].
+    polling loop. This shared classification is still useful for
+    prompt shaping, telemetry, and tool-diversity heuristics.
 
     A tool is "boring" if calling it N times yields the same
     information as calling it once, and it mutates nothing.
     [keeper_stay_silent] is included: it is a no-op by design
-    and must not reset the boring-turn counter.
+    and should not be treated as productive work.
     Contrast with [keeper_fs_read] which reads new content, or
     [keeper_board_post] which creates artifacts. *)
 let boring_tools =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -955,20 +955,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
     ?(channel : Keeper_world_observation.unified_turn_channel = Scheduled_autonomous)
     ?(semaphore_wait_ms = 0)
     ?shared_context
-    ?boring_consecutive_turns_ref
     () : (keeper_meta, Oas.Error.sdk_error) result =
-  (* 0. Reactive channel resets boring counter.
-     Reactive turns are triggered by external stimulus (mentions, board events)
-     which means new work is available. Resetting before the turn ensures
-     before_turn_params sees boring_consecutive=0 and gives the LLM full tool
-     access. Without this, a keeper at boring=5 receiving a mention would
-     still get tool_choice=None_ from the boring gate. *)
-  (match channel, boring_consecutive_turns_ref with
-   | Keeper_world_observation.Reactive, Some ref when !ref > 0 ->
-     Log.Keeper.info "%s: reactive turn resets boring_consecutive from %d to 0"
-       meta.name !ref;
-     ref := 0
-   | _ -> ());
   (* 1. Check API keys *)
   let model_labels = Keeper_coordination.effective_model_labels_for_turn meta in
   match ensure_api_keys_for_labels model_labels with
@@ -1086,7 +1073,6 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_retry
               ?shared_context
               ?event_bus:(Keeper_event_bus.get ())
-              ?boring_consecutive_turns_ref
               ()
           in
           let rec retry_loop ~run_meta ~max_context ~run_generation

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -100,6 +100,5 @@ val run_unified_turn :
   ?channel:Keeper_world_observation.unified_turn_channel ->
   ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
-  ?boring_consecutive_turns_ref:int ref ->
   unit ->
   (Keeper_types.keeper_meta, Oas.Error.sdk_error) result

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2321,7 +2321,7 @@ let () =
           test_case "is_context_overflow only matches ContextOverflow" `Quick
             test_is_context_overflow_only_for_overflow_errors;
         ] );
-      ( "boring_tool_gate",
+      ( "boring_tools",
         [
           test_case "masc_status is boring" `Quick (fun () ->
             check bool "masc_status"

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -271,63 +271,6 @@ let () =
       true (has "keeper.dead_ttl_sec")
   in
 
-  let test_keeper_boring_exit_threshold_registered () =
-    Governance_registry.ensure_init ();
-    let entries = Runtime_params.registry () in
-    let entry =
-      List.find_opt
-        (fun (k, _, _, _, _) -> k = "keeper.turn.boring_exit_threshold")
-        entries
-    in
-    match entry with
-    | Some (_, current, default_json, has_override, Some meta) ->
-        Alcotest.(check string) "default value" "8"
-          (Yojson.Safe.to_string default_json);
-        Alcotest.(check string) "current value" "8"
-          (Yojson.Safe.to_string current);
-        Alcotest.(check bool) "no override by default" false has_override;
-        Alcotest.(check string) "value_type" "int" meta.value_type;
-        Alcotest.(check (option string)) "min_value"
-          (Some "2")
-          (Option.map Yojson.Safe.to_string meta.min_value);
-        Alcotest.(check (option string)) "max_value"
-          (Some "50")
-          (Option.map Yojson.Safe.to_string meta.max_value)
-    | Some (_, _, _, _, None) ->
-        Alcotest.fail "keeper.turn.boring_exit_threshold meta missing"
-    | None ->
-        Alcotest.fail "keeper.turn.boring_exit_threshold not registered"
-  in
-
-  let test_keeper_boring_exit_threshold_env_clamps () =
-    let key = "MASC_KEEPER_BORING_EXIT_THRESHOLD" in
-    let original = Sys.getenv_opt key in
-    let restore_env () =
-      match original with
-      | Some value -> Unix.putenv key value
-      (* OCaml stdlib lacks Unix.unsetenv; empty string is sufficient here
-         because int_of_env_default treats invalid/empty values as default. *)
-      | None -> Unix.putenv key ""
-    in
-    Fun.protect
-      ~finally:(fun () ->
-        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
-        restore_env ())
-      (fun () ->
-        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
-        Unix.putenv key "1";
-        Alcotest.(check int) "clamps env below min" 2
-          (Keeper_config.keeper_boring_exit_threshold ());
-        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
-        Unix.putenv key "100";
-        Alcotest.(check int) "clamps env above max" 50
-          (Keeper_config.keeper_boring_exit_threshold ());
-        Runtime_params.clear Keeper_config.keeper_boring_exit_threshold_rp;
-        Unix.putenv key "bogus";
-        Alcotest.(check int) "invalid env falls back to default" 8
-          (Keeper_config.keeper_boring_exit_threshold ()))
-  in
-
   let test_keeper_lifecycle_surface () =
     let surfaces = Governance_registry.surfaces in
     let keeper_surface =
@@ -481,10 +424,6 @@ let () =
         [
           Alcotest.test_case "keeper params registered" `Quick
             test_keeper_params_registered;
-          Alcotest.test_case "keeper boring exit threshold registered" `Quick
-            test_keeper_boring_exit_threshold_registered;
-          Alcotest.test_case "keeper boring exit threshold env clamps" `Quick
-            test_keeper_boring_exit_threshold_env_clamps;
           Alcotest.test_case "keeper_lifecycle surface" `Quick
             test_keeper_lifecycle_surface;
           Alcotest.test_case "keeper params meta shape" `Quick


### PR DESCRIPTION
## What changed
- removed the keeper boring gate hard-exit path from keepalive and the OAS `exit_condition`
- removed boring-streak-driven `tool_choice=None_` degradation and the associated counter plumbing
- deleted the obsolete `keeper.turn.boring_exit_threshold` runtime param surface and updated keeper/runtime tests

## Why
The keeper could self-lock once `boring_consecutive` crossed the threshold:
- boring streak increased only when no productive tool ran
- boring policy then disabled recovery paths and eventually skipped proactive turns entirely
- after that, the streak could not recover and keepers stopped acting under `~/me` basepath

This change makes scheduled turns depend on actionable-work admission only, instead of a local idle heuristic that could revoke execution rights.

## Impact
- keepers no longer pause themselves because of the `>= 8` hard gate
- scheduled autonomous turns are decided by `unified_turn_decision` plus existing reconcile/safety guards
- the old boring classification remains available for telemetry/heuristics, but it no longer controls lifecycle or tool access

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/bug-boring-recovery`
- `./_build/default/test/test_keeper_unified.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/bug-boring-recovery ./test/test_runtime_params.exe`