### PR TITLE
fix: resync keeper tool access from config

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -23,6 +23,28 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
+let resynced_tool_access
+    (defaults : Keeper_types_profile.keeper_profile_defaults)
+    (meta : keeper_meta) =
+  let current_preset =
+    match meta.tool_access with
+    | Preset { preset; _ } -> Some preset
+    | Custom _ -> None
+  in
+  let current_also_allow = tool_access_also_allowlist meta.tool_access in
+  let target_preset =
+    match defaults.tool_preset with
+    | Some raw -> tool_preset_of_string raw
+    | None -> current_preset
+  in
+  let target_also_allow =
+    apply_default defaults.tool_also_allow current_also_allow
+  in
+  match target_preset with
+  | Some preset ->
+      Preset { preset; also_allow = target_also_allow }
+  | None -> meta.tool_access
+
 let ensure_keeper_meta config name =
   match read_meta config name with
   | Ok (Some meta) ->
@@ -48,6 +70,7 @@ let ensure_keeper_meta config name =
     in
     let target_denylist = apply_default defaults.tool_denylist meta.tool_denylist in
     let target_cascade_name = apply_default defaults.cascade_name meta.cascade_name in
+    let target_tool_access = resynced_tool_access defaults meta in
 
     (* --- Personality --- *)
     let target_goal = apply_default defaults.goal meta.goal in
@@ -110,6 +133,7 @@ let ensure_keeper_meta config name =
       || meta.room_scope <> target_room_scope
       || meta.scope_kind <> target_scope_kind
       || meta.mention_targets <> target_mention_targets
+      || meta.tool_access <> target_tool_access
       || meta.execution_scope <> target_execution_scope
       || meta.allowed_paths <> target_allowed_paths in
     let discovery_changed =
@@ -161,6 +185,7 @@ let ensure_keeper_meta config name =
         room_scope = target_room_scope;
         scope_kind = target_scope_kind;
         mention_targets = target_mention_targets;
+        tool_access = target_tool_access;
         execution_scope = target_execution_scope;
         allowed_paths = target_allowed_paths;
         work_discovery_enabled = target_wd_enabled;

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -147,6 +147,71 @@ policy_voice_enabled = false
       check string "room_scope" "current" updated.room_scope;
       check bool "policy_voice_enabled" false updated.policy_voice_enabled
 
+(** Test: TOML tool policy and allowed_paths overwrite stale runtime JSON values. *)
+let test_tool_policy_resync () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "tool-policy-resync-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "test"
+execution_scope = "workspace"
+allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
+tool_preset = "social"
+also_allow = ["keeper_github", "keeper_shell"]
+|};
+  let config = Room.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-tool-policy-resync");
+            ("execution_scope", `String "workspace");
+            ("allowed_paths", `List [ `String ".masc/playground/old" ]);
+            ( "tool_access",
+              `Assoc
+                [
+                  ("kind", `String "preset");
+                  ("preset", `String "delivery");
+                  ("also_allow", `List [ `String "masc_board_post" ]);
+                ] );
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      let preset =
+        match Keeper_types.tool_access_preset updated.Keeper_types.tool_access with
+        | Some preset -> Keeper_types.tool_preset_to_string preset
+        | None -> fail "expected preset-based tool_access"
+      in
+      check string "tool_preset" "social" preset;
+      check
+        (list string)
+        "tool_also_allow"
+        [ "keeper_github"; "keeper_shell" ]
+        (Keeper_types.tool_access_also_allowlist updated.tool_access);
+      check
+        (list string)
+        "allowed_paths"
+        [ "workspace/yousleepwhen/masc-mcp" ]
+        updated.allowed_paths
+
 (** Test: fields absent from TOML (None) preserve runtime JSON values. *)
 let test_none_preserves_runtime () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -316,6 +381,10 @@ let () =
             "TOML policy fields overwrite stale runtime JSON"
             `Quick
             test_policy_resync;
+          test_case
+            "TOML tool policy fields overwrite stale runtime JSON"
+            `Quick
+            test_tool_policy_resync;
         ] );
       ( "none_preserve",
         [

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -212,6 +212,68 @@ also_allow = ["keeper_github", "keeper_shell"]
         [ "workspace/yousleepwhen/masc-mcp" ]
         updated.allowed_paths
 
+(** Test: custom tool_access stays custom when TOML omits tool_preset. *)
+let test_custom_tool_access_preserved_without_preset () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "tool-policy-custom-preserve-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "test"
+execution_scope = "workspace"
+allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
+|};
+  let config = Room.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-tool-policy-custom-preserve");
+            ("execution_scope", `String "workspace");
+            ("allowed_paths", `List [ `String ".masc/playground/old" ]);
+            ( "tool_access",
+              `Assoc
+                [
+                  ("kind", `String "custom");
+                  ("tools", `List [ `String "keeper_board_get"; `String "masc_status" ]);
+                ] );
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check
+        (option string)
+        "custom access keeps no preset"
+        None
+        (Keeper_types.tool_access_preset updated.Keeper_types.tool_access
+         |> Option.map Keeper_types.tool_preset_to_string);
+      check
+        (option (list string))
+        "custom allowlist preserved"
+        (Some [ "keeper_board_get"; "masc_status" ])
+        (Keeper_types.tool_access_custom_allowlist updated.tool_access);
+      check
+        (list string)
+        "allowed_paths"
+        [ "workspace/yousleepwhen/masc-mcp" ]
+        updated.allowed_paths
+
 (** Test: fields absent from TOML (None) preserve runtime JSON values. *)
 let test_none_preserves_runtime () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -385,6 +447,10 @@ let () =
             "TOML tool policy fields overwrite stale runtime JSON"
             `Quick
             test_tool_policy_resync;
+          test_case
+            "custom tool_access is preserved when TOML omits preset"
+            `Quick
+            test_custom_tool_access_preserved_without_preset;
         ] );
       ( "none_preserve",
         [

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -58,6 +58,10 @@ let with_temp_dir prefix f =
   Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
 
 let run_shell ?(env = []) ~cwd cmd =
+  let env =
+    if List.mem_assoc "MASC_ALLOW_PORT_REUSE" env then env
+    else ("MASC_ALLOW_PORT_REUSE", "1") :: env
+  in
   let env_prefix =
     env
     |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -5,7 +5,9 @@ open Alcotest
 
 module Tool_code_write = Masc_mcp.Tool_code_write
 
-let with_env name value f =
+(* OCaml's Unix module does not expose unsetenv; for config overrides that are
+   read via Env_config_core.trim_opt, an empty string is equivalent to unset. *)
+let with_trimmed_env name value f =
   let saved = Sys.getenv_opt name in
   (match value with
    | Some v -> Unix.putenv name v
@@ -140,7 +142,12 @@ let test_ssh_allowed () =
 let test_missing_base_path_without_config_fails_closed () =
   Tool_code_write.reset_policy_config_cache ();
   Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
-    with_env "MASC_CONFIG_DIR" None @@ fun () ->
+    with_trimmed_env "MASC_CONFIG_DIR" None @@ fun () ->
+    check
+      (option string)
+      "blank override trims to None"
+      None
+      (Env_config.config_dir_opt ());
     match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
       "https://github.com/evil-corp/repo.git" with
     | Error _ -> ()
@@ -151,7 +158,12 @@ let test_explicit_config_dir_override_still_validates () =
   let config_dir = Filename.concat project_root "config" in
   Tool_code_write.reset_policy_config_cache ();
   Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
-    with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+    with_trimmed_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+    check
+      (option string)
+      "explicit override survives trimming"
+      (Some config_dir)
+      (Env_config.config_dir_opt ());
     match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
       "https://github.com/evil-corp/repo.git" with
     | Error _ -> ()

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -5,6 +5,18 @@ open Alcotest
 
 module Tool_code_write = Masc_mcp.Tool_code_write
 
+let with_env name value f =
+  let saved = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+
 (* ── extract_github_org ──────────────────────────────────────────── *)
 
 let test_https_url () =
@@ -125,16 +137,26 @@ let test_ssh_allowed () =
     (Tool_code_write.validate_clone_url ~base_path:bp
        "git@github.com:jeong-sik/oas.git")
 
-(* test_fallback_config_still_validates: even with a non-existent base_path,
-   CWD fallback finds config/tool_policy.toml — so validation still applies.
-   A disallowed org should be rejected. *)
-let test_fallback_config_still_validates () =
+let test_missing_base_path_without_config_fails_closed () =
   Tool_code_write.reset_policy_config_cache ();
   Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
+    with_env "MASC_CONFIG_DIR" None @@ fun () ->
     match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
       "https://github.com/evil-corp/repo.git" with
-    | Error _msg -> ()
-    | Ok () -> fail "disallowed org should be rejected even with fallback config")
+    | Error _ -> ()
+    | Ok () -> fail "validation should fail closed when config root is missing")
+
+let test_explicit_config_dir_override_still_validates () =
+  let project_root = project_base_path () in
+  let config_dir = Filename.concat project_root "config" in
+  Tool_code_write.reset_policy_config_cache ();
+  Fun.protect ~finally:Tool_code_write.reset_policy_config_cache (fun () ->
+    with_env "MASC_CONFIG_DIR" (Some config_dir) @@ fun () ->
+    match Tool_code_write.validate_clone_url ~base_path:"/nonexistent"
+      "https://github.com/evil-corp/repo.git" with
+    | Error _ -> ()
+    | Ok () ->
+        fail "disallowed org should still be rejected with explicit config override")
 
 let test_mixed_case_org () =
   let bp = project_base_path () in
@@ -170,7 +192,8 @@ let () =
       test_case "disallowed org" `Quick test_disallowed_org;
       test_case "non-github rejected" `Quick test_non_github_rejected;
       test_case "ssh allowed" `Quick test_ssh_allowed;
-      test_case "fallback config rejects disallowed" `Quick test_fallback_config_still_validates;
+      test_case "missing config fails closed" `Quick test_missing_base_path_without_config_fails_closed;
+      test_case "explicit config dir override still validates" `Quick test_explicit_config_dir_override_still_validates;
       test_case "mixed-case org" `Quick test_mixed_case_org;
     ]);
   ]


### PR DESCRIPTION
## Summary
- resync persisted keeper `tool_access` from declarative keeper config during runtime bootstrap
- add a regression test that stale runtime JSON tool presets and allowlists are overwritten by TOML
- harden config-root-sensitive tests and script tests so the follow-up stays deterministic

## Why
`#6197` moved config resolution toward base-path SSOT, but persisted keeper meta could still carry stale `tool_access` values even when TOML had already changed. This follow-up keeps runtime meta aligned with declarative config.

## Testing
- `dune build --root .`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_tool_code_write_coverage.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`