### PR TITLE
fix: harden dashboard telemetry refresh flows

### DIFF
--- a/dashboard/src/api/core.test.ts
+++ b/dashboard/src/api/core.test.ts
@@ -41,6 +41,26 @@ describe('post', () => {
 })
 
 describe('get bootstrap warm-up mapping', () => {
+  it('preserves upstream abort signals instead of reporting them as timeouts', async () => {
+    const fetchMock = vi.fn().mockImplementation((_path: string, init?: RequestInit) => (
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('superseded request', 'AbortError'))
+        })
+      })
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const controller = new AbortController()
+    const request = get('/api/v1/dashboard/namespace-truth', { signal: controller.signal })
+    controller.abort()
+
+    await expect(request).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+  })
+
   it('maps dashboard namespace-truth not-initialized errors to initializing payloads', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('{"error":"not initialized"}', {

--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -124,7 +124,17 @@ class ApiRequestError extends Error {
 
 export async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController()
+  const upstreamSignal = init.signal
+  const abortFromUpstream = () => controller.abort()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+  if (upstreamSignal) {
+    if (upstreamSignal.aborted) {
+      controller.abort()
+    } else {
+      upstreamSignal.addEventListener('abort', abortFromUpstream, { once: true })
+    }
+  }
 
   try {
     return await fetch(path, {
@@ -133,6 +143,9 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
     })
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
+      if (upstreamSignal?.aborted) {
+        throw err
+      }
       const method = typeof init.method === 'string' ? init.method.toUpperCase() : 'GET'
       throw new ApiRequestError({
         method,
@@ -144,6 +157,7 @@ export async function fetchWithTimeout(path: string, init: RequestInit, timeoutM
     throw err
   } finally {
     clearTimeout(timer)
+    upstreamSignal?.removeEventListener('abort', abortFromUpstream)
   }
 }
 
@@ -275,12 +289,16 @@ export function defaultBoardVoter(): string {
 export type GetOptions = {
   timeoutMs?: number
   includeActorHeader?: boolean
+  signal?: AbortSignal
 }
 
 export async function get<T>(path: string, opts: GetOptions = {}): Promise<T> {
   const res = await fetchWithTimeout(
     path,
-    { headers: authHeaders({ includeActor: opts.includeActorHeader }) },
+    {
+      headers: authHeaders({ includeActor: opts.includeActorHeader }),
+      signal: opts.signal,
+    },
     opts.timeoutMs ?? DEFAULT_GET_TIMEOUT_MS,
   )
   if (!res.ok) {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -42,8 +42,12 @@ import type {
 
 // --- Dashboard projections ---
 
-export function fetchDashboardShell(): Promise<DashboardShellResponse> {
-  return get('/api/v1/dashboard/shell')
+type AbortableRequestOptions = {
+  signal?: AbortSignal
+}
+
+export function fetchDashboardShell(opts?: AbortableRequestOptions): Promise<DashboardShellResponse> {
+  return get('/api/v1/dashboard/shell', { signal: opts?.signal })
 }
 
 // --- System logs ---
@@ -180,12 +184,15 @@ export function fetchDashboardConfig(): Promise<DashboardConfigResponse> {
   return get('/api/v1/dashboard/config')
 }
 
-export function fetchDashboardNamespaceTruth(): Promise<DashboardNamespaceTruthResponse> {
-  return get('/api/v1/dashboard/namespace-truth', { timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS })
+export function fetchDashboardNamespaceTruth(opts?: AbortableRequestOptions): Promise<DashboardNamespaceTruthResponse> {
+  return get('/api/v1/dashboard/namespace-truth', {
+    timeoutMs: NAMESPACE_TRUTH_GET_TIMEOUT_MS,
+    signal: opts?.signal,
+  })
 }
 
-export function fetchDashboardExecution(): Promise<DashboardExecutionResponse> {
-  return get('/api/v1/dashboard/execution')
+export function fetchDashboardExecution(opts?: AbortableRequestOptions): Promise<DashboardExecutionResponse> {
+  return get('/api/v1/dashboard/execution', { signal: opts?.signal })
 }
 
 export type ToolQualityToolStat = {
@@ -226,11 +233,11 @@ export type ToolQualityResponse = {
   hourly_trend?: ToolQualityHourlyPoint[]
 }
 
-export function fetchToolQuality(opts?: { n?: number }): Promise<ToolQualityResponse> {
+export function fetchToolQuality(opts?: { n?: number; signal?: AbortSignal }): Promise<ToolQualityResponse> {
   const params = new URLSearchParams()
   if (opts?.n != null) params.set('n', String(opts.n))
   const qs = params.toString()
-  return get<ToolQualityResponse>(`/api/v1/dashboard/tool-quality${qs ? `?${qs}` : ''}`)
+  return get<ToolQualityResponse>(`/api/v1/dashboard/tool-quality${qs ? `?${qs}` : ''}`, { signal: opts?.signal })
 }
 
 export interface DashboardPerfRow {
@@ -679,8 +686,8 @@ export function fetchToolMetrics(): Promise<ToolMetricsResponse> {
   return get('/api/v1/tool-metrics')
 }
 
-export async function fetchDashboardTools(): Promise<DashboardToolsResponse> {
-  const raw = await get<DashboardToolsResponse>('/api/v1/dashboard/tools')
+export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promise<DashboardToolsResponse> {
+  const raw = await get<DashboardToolsResponse>('/api/v1/dashboard/tools', { signal: opts?.signal })
   const normalizedTools = raw.tool_inventory?.tools?.map(t => ({
     ...t,
     category: t.category ?? 'uncategorized',
@@ -1252,6 +1259,7 @@ export function fetchTelemetry(opts?: {
   operation_id?: string
   worker_run_id?: string
   n?: number
+  signal?: AbortSignal
 }): Promise<TelemetryResponse> {
   const params = new URLSearchParams()
   if (opts?.source) params.set('source', opts.source)
@@ -1261,11 +1269,11 @@ export function fetchTelemetry(opts?: {
   if (opts?.worker_run_id) params.set('worker_run_id', opts.worker_run_id)
   if (opts?.n) params.set('n', String(opts.n))
   const qs = params.toString()
-  return get<TelemetryResponse>(`/api/v1/dashboard/telemetry${qs ? '?' + qs : ''}`)
+  return get<TelemetryResponse>(`/api/v1/dashboard/telemetry${qs ? '?' + qs : ''}`, { signal: opts?.signal })
 }
 
-export function fetchTelemetrySummary(): Promise<TelemetrySummaryResponse> {
-  return get<TelemetrySummaryResponse>('/api/v1/dashboard/telemetry/summary')
+export function fetchTelemetrySummary(opts?: AbortableRequestOptions): Promise<TelemetrySummaryResponse> {
+  return get<TelemetrySummaryResponse>('/api/v1/dashboard/telemetry/summary', { signal: opts?.signal })
 }
 
 // --- Excuse Patterns ---

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -81,6 +81,16 @@ async function flushUi(): Promise<void> {
   })
 }
 
+function requireResolver<T>(
+  resolver: ((value: T) => void) | null,
+  label: string,
+): (value: T) => void {
+  if (!resolver) {
+    throw new Error(label)
+  }
+  return resolver
+}
+
 async function loadPanel(mocks: {
   fetchDashboardExecution: () => Promise<DashboardExecutionResponse>
   fetchToolQuality: () => Promise<ToolQualityResponse>
@@ -97,10 +107,16 @@ async function loadPanel(mocks: {
 
 describe('FleetTelemetryPanel', () => {
   let container: HTMLDivElement
+  const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
 
   beforeEach(() => {
+    vi.useFakeTimers()
     container = document.createElement('div')
     document.body.appendChild(container)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
   })
 
   afterEach(() => {
@@ -109,6 +125,10 @@ describe('FleetTelemetryPanel', () => {
     vi.clearAllMocks()
     vi.resetModules()
     vi.doUnmock('../api/dashboard')
+    vi.useRealTimers()
+    if (originalVisibility) {
+      Object.defineProperty(document, 'visibilityState', originalVisibility)
+    }
   })
 
   it('renders the full fleet even when tool telemetry exists for only one keeper', async () => {
@@ -167,5 +187,154 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Execution snapshot unavailable: execution down')
     expect(container.textContent).toContain('keeper-fallback')
     expect(container.textContent).toContain('Telemetry Stores')
+  })
+
+  it('refreshes automatically on a visible page', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue(executionResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue(toolQualityResponse)
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchDashboardExecution).toHaveBeenCalledTimes(1)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(1)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushUi()
+
+    expect(fetchDashboardExecution).toHaveBeenCalledTimes(2)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(2)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('30초 자동 갱신')
+  })
+
+  it('ignores out-of-order fleet telemetry refresh responses', async () => {
+    let executionCall = 0
+    let toolQualityCall = 0
+    let summaryCall = 0
+    let resolveExecutionSecond: ((value: DashboardExecutionResponse) => void) | null = null
+    let resolveExecutionThird: ((value: DashboardExecutionResponse) => void) | null = null
+    let resolveToolQualitySecond: ((value: ToolQualityResponse) => void) | null = null
+    let resolveToolQualityThird: ((value: ToolQualityResponse) => void) | null = null
+    let resolveSummarySecond: ((value: TelemetrySummaryResponse) => void) | null = null
+    let resolveSummaryThird: ((value: TelemetrySummaryResponse) => void) | null = null
+
+    const fetchDashboardExecution = vi.fn().mockImplementation(() => {
+      executionCall += 1
+      if (executionCall === 1) return Promise.resolve(executionResponse)
+      return new Promise<DashboardExecutionResponse>(resolve => {
+        if (executionCall === 2) resolveExecutionSecond = resolve
+        else resolveExecutionThird = resolve
+      })
+    })
+    const fetchToolQuality = vi.fn().mockImplementation(() => {
+      toolQualityCall += 1
+      if (toolQualityCall === 1) return Promise.resolve(toolQualityResponse)
+      return new Promise<ToolQualityResponse>(resolve => {
+        if (toolQualityCall === 2) resolveToolQualitySecond = resolve
+        else resolveToolQualityThird = resolve
+      })
+    })
+    const fetchTelemetrySummary = vi.fn().mockImplementation(() => {
+      summaryCall += 1
+      if (summaryCall === 1) return Promise.resolve(telemetrySummaryResponse)
+      return new Promise<TelemetrySummaryResponse>(resolve => {
+        if (summaryCall === 2) resolveSummarySecond = resolve
+        else resolveSummaryThird = resolve
+      })
+    })
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const refreshButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('새로고침'))
+    expect(refreshButton).toBeTruthy()
+
+    await act(async () => {
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    const applyExecutionThird = requireResolver(resolveExecutionThird, 'missing newest execution resolver')
+    const applyToolQualityThird = requireResolver(resolveToolQualityThird, 'missing newest tool quality resolver')
+    const applySummaryThird = requireResolver(resolveSummaryThird, 'missing newest summary resolver')
+    applyExecutionThird({
+      ...executionResponse,
+      keepers: [
+        {
+          ...executionResponse.keepers[0],
+          name: 'keeper-gamma',
+        },
+      ],
+    })
+    applyToolQualityThird({
+      ...toolQualityResponse,
+      by_keeper: [
+        {
+          name: 'keeper-gamma',
+          calls: 7,
+          success_pct: 100,
+        },
+      ],
+    })
+    applySummaryThird({
+      ...telemetrySummaryResponse,
+      total_entries: 999,
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('keeper-gamma')
+    expect(container.textContent).toContain('999')
+
+    const applyExecutionSecond = requireResolver(resolveExecutionSecond, 'missing stale execution resolver')
+    const applyToolQualitySecond = requireResolver(resolveToolQualitySecond, 'missing stale tool quality resolver')
+    const applySummarySecond = requireResolver(resolveSummarySecond, 'missing stale summary resolver')
+    applyExecutionSecond({
+      ...executionResponse,
+      keepers: [
+        {
+          ...executionResponse.keepers[0],
+          name: 'keeper-stale',
+        },
+      ],
+    })
+    applyToolQualitySecond({
+      ...toolQualityResponse,
+      by_keeper: [
+        {
+          name: 'keeper-stale',
+          calls: 1,
+          success_pct: 0,
+        },
+      ],
+    })
+    applySummarySecond({
+      ...telemetrySummaryResponse,
+      total_entries: 123,
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('keeper-gamma')
+    expect(container.textContent).not.toContain('keeper-stale')
   })
 })

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -92,9 +92,9 @@ function requireResolver<T>(
 }
 
 async function loadPanel(mocks: {
-  fetchDashboardExecution: () => Promise<DashboardExecutionResponse>
-  fetchToolQuality: () => Promise<ToolQualityResponse>
-  fetchTelemetrySummary: () => Promise<TelemetrySummaryResponse>
+  fetchDashboardExecution: (opts?: { signal?: AbortSignal }) => Promise<DashboardExecutionResponse>
+  fetchToolQuality: (opts?: { n?: number; signal?: AbortSignal }) => Promise<ToolQualityResponse>
+  fetchTelemetrySummary: (opts?: { signal?: AbortSignal }) => Promise<TelemetrySummaryResponse>
 }) {
   vi.resetModules()
   vi.doMock('../api/dashboard', () => ({
@@ -336,5 +336,51 @@ describe('FleetTelemetryPanel', () => {
 
     expect(container.textContent).toContain('keeper-gamma')
     expect(container.textContent).not.toContain('keeper-stale')
+  })
+
+  it('aborts superseded fleet telemetry requests before a newer refresh settles', async () => {
+    const abortedSignals: AbortSignal[] = []
+
+    const createAbortableResponse = <T,>(value: T) => {
+      let callCount = 0
+      return vi.fn().mockImplementation((opts?: { signal?: AbortSignal }) => {
+        callCount += 1
+        if (callCount > 1) return Promise.resolve(value)
+        return new Promise<T>((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => {
+            abortedSignals.push(opts.signal as AbortSignal)
+            reject(new DOMException('superseded request', 'AbortError'))
+          }, { once: true })
+        })
+      })
+    }
+
+    const fetchDashboardExecution = createAbortableResponse(executionResponse)
+    const abortableToolQuality = createAbortableResponse(toolQualityResponse)
+    const fetchToolQuality = vi.fn().mockImplementation((opts?: { n?: number; signal?: AbortSignal }) => (
+      abortableToolQuality(opts)
+    ))
+    const fetchTelemetrySummary = createAbortableResponse(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushUi()
+
+    expect(fetchDashboardExecution).toHaveBeenCalledTimes(2)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(2)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+    expect(abortedSignals.length).toBeGreaterThan(0)
+    expect(abortedSignals.every(signal => signal.aborted)).toBe(true)
+    expect(container.textContent).toContain('keeper-alpha')
   })
 })

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -71,6 +71,10 @@ function emptyState(): FleetTelemetryState {
   }
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
 // Delegated to config/telemetry-sources (SSOT)
 const sourceLabel = telemetrySourceLabel
 
@@ -441,9 +445,13 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
 
 export function FleetTelemetryPanel() {
   const latestRequestId = useRef(0)
+  const activeController = useRef<AbortController | null>(null)
   const state = useSignal<FleetTelemetryState>(emptyState())
 
   const loadFleetTelemetry = async () => {
+    activeController.current?.abort()
+    const controller = new AbortController()
+    activeController.current = controller
     const requestId = ++latestRequestId.current
     state.value = {
       ...state.value,
@@ -452,65 +460,77 @@ export function FleetTelemetryPanel() {
       warnings: [],
     }
 
-    const [executionResult, toolQualityResult, telemetrySummaryResult] = await Promise.allSettled([
-      fetchDashboardExecution(),
-      fetchToolQuality({ n: 5000 }),
-      fetchTelemetrySummary(),
-    ])
+    try {
+      const [executionResult, toolQualityResult, telemetrySummaryResult] = await Promise.allSettled([
+        fetchDashboardExecution({ signal: controller.signal }),
+        fetchToolQuality({ n: 5000, signal: controller.signal }),
+        fetchTelemetrySummary({ signal: controller.signal }),
+      ])
 
-    const warnings: string[] = []
+      if (controller.signal.aborted || requestId !== latestRequestId.current) return
 
-    const keepers =
-      executionResult.status === 'fulfilled'
-        ? normalizeKeepers(executionResult.value.keepers)
-        : []
-    if (executionResult.status === 'rejected') {
-      warnings.push(`Execution snapshot unavailable: ${errorMessage(executionResult.reason)}`)
-    }
+      const warnings: string[] = []
 
-    const toolQuality =
-      toolQualityResult.status === 'fulfilled'
-        ? toolQualityResult.value
-        : EMPTY_TOOL_QUALITY
-    if (toolQualityResult.status === 'rejected') {
-      warnings.push(`Tool quality unavailable: ${errorMessage(toolQualityResult.reason)}`)
-    }
+      const keepers =
+        executionResult.status === 'fulfilled'
+          ? normalizeKeepers(executionResult.value.keepers)
+          : []
+      if (executionResult.status === 'rejected' && !isAbortError(executionResult.reason)) {
+        warnings.push(`Execution snapshot unavailable: ${errorMessage(executionResult.reason)}`)
+      }
 
-    const telemetrySummary =
-      telemetrySummaryResult.status === 'fulfilled'
-        ? telemetrySummaryResult.value
-        : { generated_at: '', sources: [], total_entries: 0 }
-    if (telemetrySummaryResult.status === 'rejected') {
-      warnings.push(`Telemetry store summary unavailable: ${errorMessage(telemetrySummaryResult.reason)}`)
-    }
+      const toolQuality =
+        toolQualityResult.status === 'fulfilled'
+          ? toolQualityResult.value
+          : EMPTY_TOOL_QUALITY
+      if (toolQualityResult.status === 'rejected' && !isAbortError(toolQualityResult.reason)) {
+        warnings.push(`Tool quality unavailable: ${errorMessage(toolQualityResult.reason)}`)
+      }
 
-    const rows = buildFleetRows(keepers, toolQuality)
-    const updatedAt =
-      (executionResult.status === 'fulfilled' ? executionResult.value.generated_at : null)
-      || telemetrySummary.generated_at
-      || new Date().toISOString()
+      const telemetrySummary =
+        telemetrySummaryResult.status === 'fulfilled'
+          ? telemetrySummaryResult.value
+          : { generated_at: '', sources: [], total_entries: 0 }
+      if (telemetrySummaryResult.status === 'rejected' && !isAbortError(telemetrySummaryResult.reason)) {
+        warnings.push(`Telemetry store summary unavailable: ${errorMessage(telemetrySummaryResult.reason)}`)
+      }
 
-    const hasAnyData =
-      rows.length > 0
-      || toolQuality.total > 0
-      || telemetrySummary.total_entries > 0
+      const rows = buildFleetRows(keepers, toolQuality)
+      const updatedAt =
+        (executionResult.status === 'fulfilled' ? executionResult.value.generated_at : null)
+        || telemetrySummary.generated_at
+        || new Date().toISOString()
 
-    if (requestId !== latestRequestId.current) return
-    state.value = {
-      loading: false,
-      error: hasAnyData ? null : 'No fleet telemetry data available.',
-      warnings,
-      rows,
-      tool_quality: toolQuality,
-      telemetry_sources: telemetrySummary.sources,
-      total_telemetry_entries: telemetrySummary.total_entries,
-      updated_at: updatedAt,
+      const hasAnyData =
+        rows.length > 0
+        || toolQuality.total > 0
+        || telemetrySummary.total_entries > 0
+
+      state.value = {
+        loading: false,
+        error: hasAnyData ? null : 'No fleet telemetry data available.',
+        warnings,
+        rows,
+        tool_quality: toolQuality,
+        telemetry_sources: telemetrySummary.sources,
+        total_telemetry_entries: telemetrySummary.total_entries,
+        updated_at: updatedAt,
+      }
+    } finally {
+      if (activeController.current === controller) {
+        activeController.current = null
+      }
     }
   }
 
   useEffect(() => {
     void loadFleetTelemetry()
-    return setupVisibleAutoRefresh(loadFleetTelemetry, TELEMETRY_AUTO_REFRESH_MS)
+    const disposeAutoRefresh = setupVisibleAutoRefresh(loadFleetTelemetry, TELEMETRY_AUTO_REFRESH_MS)
+    return () => {
+      disposeAutoRefresh()
+      activeController.current?.abort()
+      activeController.current = null
+    }
   }, [])
 
   const value = state.value

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -10,7 +10,7 @@ import {
   type ToolQualityResponse,
 } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
@@ -546,7 +546,7 @@ export function FleetTelemetryPanel() {
             onClick=${() => { void loadFleetTelemetry() }}
             aria-label="Fleet 텔레메트리 새로고침"
           >새로고침</button>
-          <span class="text-[10px] text-[var(--text-dim)]">30초 자동 갱신</span>
+          <span class="text-[10px] text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         </div>
       </div>
 

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef } from 'preact/hooks'
 import { LoadingState } from './common/feedback-state'
 import {
   fetchDashboardExecution,
@@ -9,6 +9,8 @@ import {
   type TelemetrySourceSummary,
   type ToolQualityResponse,
 } from '../api/dashboard'
+import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
@@ -438,9 +440,11 @@ function FailureCategoryPanel({ toolQuality }: { toolQuality: ToolQualityRespons
 }
 
 export function FleetTelemetryPanel() {
+  const latestRequestId = useRef(0)
   const state = useSignal<FleetTelemetryState>(emptyState())
 
   const loadFleetTelemetry = async () => {
+    const requestId = ++latestRequestId.current
     state.value = {
       ...state.value,
       loading: true,
@@ -491,6 +495,7 @@ export function FleetTelemetryPanel() {
       || toolQuality.total > 0
       || telemetrySummary.total_entries > 0
 
+    if (requestId !== latestRequestId.current) return
     state.value = {
       loading: false,
       error: hasAnyData ? null : 'No fleet telemetry data available.',
@@ -505,6 +510,7 @@ export function FleetTelemetryPanel() {
 
   useEffect(() => {
     void loadFleetTelemetry()
+    return setupVisibleAutoRefresh(loadFleetTelemetry, TELEMETRY_AUTO_REFRESH_MS)
   }, [])
 
   const value = state.value
@@ -534,11 +540,14 @@ export function FleetTelemetryPanel() {
             ${value.updated_at ? `Updated ${formatTimeAgo(value.updated_at)}` : 'Runtime + telemetry store view'}
           </div>
         </div>
-        <button
-          class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)]"
-          onClick=${() => { void loadFleetTelemetry() }}
-          aria-label="Fleet 텔레메트리 새로고침"
-        >새로고침</button>
+        <div class="flex items-center gap-2">
+          <button
+            class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)]"
+            onClick=${() => { void loadFleetTelemetry() }}
+            aria-label="Fleet 텔레메트리 새로고침"
+          >새로고침</button>
+          <span class="text-[10px] text-[var(--text-dim)]">30초 자동 갱신</span>
+        </div>
       </div>
 
       <${WarningBanner} warnings=${value.warnings} />

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -42,6 +42,16 @@ async function flushUi(): Promise<void> {
   })
 }
 
+function requireResolver<T>(
+  resolver: ((value: T) => void) | null,
+  label: string,
+): (value: T) => void {
+  if (!resolver) {
+    throw new Error(label)
+  }
+  return resolver
+}
+
 async function loadPanel(
   fetchTelemetry: () => Promise<TelemetryResponse>,
   fetchTelemetrySummary: () => Promise<TelemetrySummaryResponse>,
@@ -83,7 +93,7 @@ describe('TelemetryUnified', () => {
     }
   })
 
-  it('does not poll automatically after the initial load', async () => {
+  it('polls automatically while the document is visible', async () => {
     const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
     const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)
     const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
@@ -97,11 +107,11 @@ describe('TelemetryUnified', () => {
     expect(fetchTelemetry).toHaveBeenCalledTimes(1)
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
 
-    await vi.advanceTimersByTimeAsync(15_000)
+    await vi.advanceTimersByTimeAsync(30_000)
     await flushUi()
 
-    expect(fetchTelemetry).toHaveBeenCalledTimes(1)
-    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
+    expect(fetchTelemetry).toHaveBeenCalledTimes(2)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
   })
 
   it('renders runtime diagnosis metadata for operators', async () => {
@@ -118,6 +128,7 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('Runtime Diagnosis')
     expect(container.textContent).toContain('MASC telemetry store')
     expect(container.textContent).toContain('Refresh')
+    expect(container.textContent).toContain('30초 자동 갱신')
     expect(container.textContent).toContain('MASC telemetry store entries')
     expect(container.textContent).toContain('mcp__masc__masc_status')
 
@@ -127,5 +138,80 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('Agent 현황 (live)')
     expect(container.textContent).toContain('1 활성 세션')
     expect(container.textContent).toContain('5 public')
+  })
+
+  it('ignores out-of-order telemetry refresh responses', async () => {
+    let telemetryCall = 0
+    let summaryCall = 0
+    let resolveTelemetryFirst: ((value: TelemetryResponse) => void) | null = null
+    let resolveTelemetrySecond: ((value: TelemetryResponse) => void) | null = null
+    let resolveSummaryFirst: ((value: TelemetrySummaryResponse) => void) | null = null
+    let resolveSummarySecond: ((value: TelemetrySummaryResponse) => void) | null = null
+
+    const fetchTelemetry = vi.fn().mockImplementation(() => {
+      telemetryCall += 1
+      return new Promise<TelemetryResponse>(resolve => {
+        if (telemetryCall === 1) resolveTelemetryFirst = resolve
+        else resolveTelemetrySecond = resolve
+      })
+    })
+    const fetchTelemetrySummary = vi.fn().mockImplementation(() => {
+      summaryCall += 1
+      return new Promise<TelemetrySummaryResponse>(resolve => {
+        if (summaryCall === 1) resolveSummaryFirst = resolve
+        else resolveSummarySecond = resolve
+      })
+    })
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const refreshButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Refresh'))
+    expect(refreshButton).toBeTruthy()
+
+    await act(async () => {
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+
+    const applyTelemetrySecond = requireResolver(resolveTelemetrySecond, 'missing second telemetry resolver')
+    const applySummarySecond = requireResolver(resolveSummarySecond, 'missing second summary resolver')
+    applyTelemetrySecond({
+      ...baseTelemetry,
+      entries: [{
+        source: 'tool_metric',
+        ts: 1_775_709_100,
+        tool_name: 'newer_tool',
+        duration_ms: 10,
+        success: true,
+      }],
+    })
+    applySummarySecond(baseSummary)
+    await flushUi()
+
+    expect(container.textContent).toContain('newer_tool')
+
+    const applyTelemetryFirst = requireResolver(resolveTelemetryFirst, 'missing first telemetry resolver')
+    const applySummaryFirst = requireResolver(resolveSummaryFirst, 'missing first summary resolver')
+    applyTelemetryFirst({
+      ...baseTelemetry,
+      entries: [{
+        source: 'tool_metric',
+        ts: 1_775_709_000,
+        tool_name: 'older_tool',
+        duration_ms: 42,
+        success: true,
+      }],
+    })
+    applySummaryFirst(baseSummary)
+    await flushUi()
+
+    expect(container.textContent).toContain('newer_tool')
+    expect(container.textContent).not.toContain('older_tool')
   })
 })

--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -53,16 +53,21 @@ function requireResolver<T>(
 }
 
 async function loadPanel(
-  fetchTelemetry: () => Promise<TelemetryResponse>,
-  fetchTelemetrySummary: () => Promise<TelemetrySummaryResponse>,
+  fetchTelemetry: (opts?: { signal?: AbortSignal }) => Promise<TelemetryResponse>,
+  fetchTelemetrySummary: (opts?: { signal?: AbortSignal }) => Promise<TelemetrySummaryResponse>,
+  opts?: {
+    fetchDashboardShell?: (args?: { signal?: AbortSignal }) => Promise<unknown>
+    fetchDashboardTools?: (args?: { signal?: AbortSignal }) => Promise<unknown>
+    fetchDashboardNamespaceTruth?: (args?: { signal?: AbortSignal }) => Promise<unknown>
+  },
 ) {
   vi.resetModules()
   vi.doMock('../api/dashboard', () => ({
     fetchTelemetry,
     fetchTelemetrySummary,
-    fetchDashboardShell: vi.fn().mockResolvedValue({ counts: { keepers: 2, agents: 0, tasks: 5 }, status: { version: '0.2.0', build: { uptime_seconds: 600 } } }),
-    fetchDashboardTools: vi.fn().mockResolvedValue({ tool_inventory: { count: 10, tools: [], surface_summary: { public_mcp: { count: 5, tools: [] } } }, tool_usage: { total_calls: 100, never_called_count: 0 } }),
-    fetchDashboardNamespaceTruth: vi.fn().mockResolvedValue({ execution: { summary: { active_sessions: 1, active_operations: 3, continuity_alerts: 0 } } }),
+    fetchDashboardShell: opts?.fetchDashboardShell ?? vi.fn().mockResolvedValue({ counts: { keepers: 2, agents: 0, tasks: 5 }, status: { version: '0.2.0', build: { uptime_seconds: 600 } } }),
+    fetchDashboardTools: opts?.fetchDashboardTools ?? vi.fn().mockResolvedValue({ tool_inventory: { count: 10, tools: [], surface_summary: { public_mcp: { count: 5, tools: [] } } }, tool_usage: { total_calls: 100, never_called_count: 0 } }),
+    fetchDashboardNamespaceTruth: opts?.fetchDashboardNamespaceTruth ?? vi.fn().mockResolvedValue({ execution: { summary: { active_sessions: 1, active_operations: 3, continuity_alerts: 0 } } }),
   }))
   return import('./telemetry-unified')
 }
@@ -213,5 +218,59 @@ describe('TelemetryUnified', () => {
 
     expect(container.textContent).toContain('newer_tool')
     expect(container.textContent).not.toContain('older_tool')
+  })
+
+  it('aborts superseded telemetry requests before starting a newer refresh', async () => {
+    const abortedSignals: AbortSignal[] = []
+
+    const createAbortableResponse = <T,>(value: T) => {
+      let callCount = 0
+      return vi.fn().mockImplementation((opts?: { signal?: AbortSignal }) => {
+        callCount += 1
+        if (callCount > 1) return Promise.resolve(value)
+        return new Promise<T>((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => {
+            abortedSignals.push(opts.signal as AbortSignal)
+            reject(new DOMException('superseded request', 'AbortError'))
+          }, { once: true })
+        })
+      })
+    }
+
+    const fetchTelemetry = createAbortableResponse(baseTelemetry)
+    const fetchTelemetrySummary = createAbortableResponse(baseSummary)
+    const fetchDashboardShell = createAbortableResponse({ counts: { keepers: 2, agents: 0, tasks: 5 }, status: { version: '0.2.0', build: { uptime_seconds: 600 } } })
+    const fetchDashboardTools = createAbortableResponse({ tool_inventory: { count: 10, tools: [], surface_summary: { public_mcp: { count: 5, tools: [] } } }, tool_usage: { total_calls: 100, never_called_count: 0 } })
+    const fetchDashboardNamespaceTruth = createAbortableResponse({ execution: { summary: { active_sessions: 1, active_operations: 3, continuity_alerts: 0 } } })
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary, {
+      fetchDashboardShell,
+      fetchDashboardTools,
+      fetchDashboardNamespaceTruth,
+    })
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const refreshButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('Refresh'))
+    expect(refreshButton).toBeTruthy()
+
+    await act(async () => {
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(2)
+    expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
+    expect(fetchDashboardShell).toHaveBeenCalledTimes(2)
+    expect(fetchDashboardTools).toHaveBeenCalledTimes(2)
+    expect(fetchDashboardNamespaceTruth).toHaveBeenCalledTimes(2)
+    expect(abortedSignals.length).toBeGreaterThan(0)
+    expect(abortedSignals.every(signal => signal.aborted)).toBe(true)
+    expect(container.textContent).toContain('mcp__masc__masc_status')
   })
 })

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -17,7 +17,7 @@ import { route } from '../router'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
 import { formatTimeAgo } from '../lib/format-time'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 
 interface StoreSnapshot {
   keepers: number
@@ -236,6 +236,7 @@ ${JSON.stringify(entry, null, 2)}</pre>
 export function TelemetryUnified() {
   const params = route.value.params
   const latestRequestId = useRef(0)
+  const autoRefreshLoadRef = useRef<() => Promise<void>>(async () => undefined)
   const state = useSignal<TelemetryState>({
     entries: [],
     summary: [],
@@ -320,10 +321,10 @@ export function TelemetryUnified() {
       }
     }
   }
+  autoRefreshLoadRef.current = load
 
   useEffect(() => {
     void load()
-    return setupVisibleAutoRefresh(load, TELEMETRY_AUTO_REFRESH_MS)
   }, [
     sourceFilter.value,
     keeperFilter.value,
@@ -332,6 +333,10 @@ export function TelemetryUnified() {
     workerRunFilter.value,
     limit.value,
   ])
+
+  useEffect(() => {
+    return setupVisibleAutoRefresh(() => autoRefreshLoadRef.current(), TELEMETRY_AUTO_REFRESH_MS)
+  }, [])
 
   const { entries, summary, totalEntries, store, loading, error } = state.value
 
@@ -437,7 +442,7 @@ export function TelemetryUnified() {
         >
           Refresh
         </button>
-        <span class="text-xs text-[var(--text-muted)]">30초 자동 갱신</span>
+        <span class="text-xs text-[var(--text-muted)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         ${loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
       </div>
 

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -1,7 +1,7 @@
 // Telemetry Unified — MASC runtime diagnosis view.
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import {
   fetchDashboardShell,
@@ -14,8 +14,10 @@ import {
   type TelemetrySourceSummary,
 } from '../api/dashboard'
 import { route } from '../router'
+import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
 import { formatTimeAgo } from '../lib/format-time'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 
 interface StoreSnapshot {
   keepers: number
@@ -233,6 +235,7 @@ ${JSON.stringify(entry, null, 2)}</pre>
 
 export function TelemetryUnified() {
   const params = route.value.params
+  const latestRequestId = useRef(0)
   const state = useSignal<TelemetryState>({
     entries: [],
     summary: [],
@@ -259,6 +262,7 @@ export function TelemetryUnified() {
   ])
 
   async function load() {
+    const requestId = ++latestRequestId.current
     state.value = { ...state.value, loading: true, error: null }
     try {
       const storePromise = Promise.all([
@@ -298,6 +302,7 @@ export function TelemetryUnified() {
         fetchTelemetrySummary(),
         storePromise,
       ])
+      if (requestId !== latestRequestId.current) return
       state.value = {
         entries: telemetry.entries,
         summary: summary.sources,
@@ -307,6 +312,7 @@ export function TelemetryUnified() {
         error: null,
       }
     } catch (e) {
+      if (requestId !== latestRequestId.current) return
       state.value = {
         ...state.value,
         loading: false,
@@ -315,7 +321,10 @@ export function TelemetryUnified() {
     }
   }
 
-  useEffect(() => { void load() }, [
+  useEffect(() => {
+    void load()
+    return setupVisibleAutoRefresh(load, TELEMETRY_AUTO_REFRESH_MS)
+  }, [
     sourceFilter.value,
     keeperFilter.value,
     sessionFilter.value,
@@ -428,6 +437,7 @@ export function TelemetryUnified() {
         >
           Refresh
         </button>
+        <span class="text-xs text-[var(--text-muted)]">30초 자동 갱신</span>
         ${loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
       </div>
 

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -78,6 +78,10 @@ function normalizeText(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '') : []
 }
@@ -236,6 +240,7 @@ ${JSON.stringify(entry, null, 2)}</pre>
 export function TelemetryUnified() {
   const params = route.value.params
   const latestRequestId = useRef(0)
+  const activeController = useRef<AbortController | null>(null)
   const autoRefreshLoadRef = useRef<() => Promise<void>>(async () => undefined)
   const state = useSignal<TelemetryState>({
     entries: [],
@@ -263,13 +268,21 @@ export function TelemetryUnified() {
   ])
 
   async function load() {
+    activeController.current?.abort()
+    const controller = new AbortController()
+    activeController.current = controller
     const requestId = ++latestRequestId.current
     state.value = { ...state.value, loading: true, error: null }
     try {
+      const catchStoreFailure = <T,>(promise: Promise<T>) =>
+        promise.catch(error => {
+          if (isAbortError(error)) throw error
+          return null
+        })
       const storePromise = Promise.all([
-        fetchDashboardShell().catch(() => null),
-        fetchDashboardTools().catch(() => null),
-        fetchDashboardNamespaceTruth().catch(() => null),
+        catchStoreFailure(fetchDashboardShell({ signal: controller.signal })),
+        catchStoreFailure(fetchDashboardTools({ signal: controller.signal })),
+        catchStoreFailure(fetchDashboardNamespaceTruth({ signal: controller.signal })),
       ]).then(([shell, tools, truth]) => {
         const counts = shell?.counts
         const execSummary = truth?.execution?.summary
@@ -299,8 +312,9 @@ export function TelemetryUnified() {
           operation_id: operationFilter.value || undefined,
           worker_run_id: workerRunFilter.value || undefined,
           n: limit.value,
+          signal: controller.signal,
         }),
-        fetchTelemetrySummary(),
+        fetchTelemetrySummary({ signal: controller.signal }),
         storePromise,
       ])
       if (requestId !== latestRequestId.current) return
@@ -313,11 +327,15 @@ export function TelemetryUnified() {
         error: null,
       }
     } catch (e) {
-      if (requestId !== latestRequestId.current) return
+      if (isAbortError(e) || requestId !== latestRequestId.current) return
       state.value = {
         ...state.value,
         loading: false,
         error: e instanceof Error ? e.message : String(e),
+      }
+    } finally {
+      if (activeController.current === controller) {
+        activeController.current = null
       }
     }
   }
@@ -335,7 +353,12 @@ export function TelemetryUnified() {
   ])
 
   useEffect(() => {
-    return setupVisibleAutoRefresh(() => autoRefreshLoadRef.current(), TELEMETRY_AUTO_REFRESH_MS)
+    const disposeAutoRefresh = setupVisibleAutoRefresh(() => autoRefreshLoadRef.current(), TELEMETRY_AUTO_REFRESH_MS)
+    return () => {
+      disposeAutoRefresh()
+      activeController.current?.abort()
+      activeController.current = null
+    }
   }, [])
 
   const { entries, summary, totalEntries, store, loading, error } = state.value

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -72,4 +72,64 @@ describe('ToolQualityPanel', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
+
+  it('replaces a stale in-flight request with the newest refresh', async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce((_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('replaced by newer refresh', 'AbortError'))
+        })
+      }))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => payload,
+      })
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel, refreshToolQuality } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('도구 품질 불러오는 중')
+
+    await act(async () => {
+      await refreshToolQuality()
+    })
+    await flushUi()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('95.5%')
+    expect(container.textContent).not.toContain('오류:')
+  })
+
+  it('stops auto-refresh after the panel unmounts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      render(null, container)
+      await Promise.resolve()
+    })
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushUi()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -1,0 +1,75 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const payload = {
+  total: 22,
+  success: 21,
+  failure: 1,
+  success_rate: 95.5,
+  by_tool: [],
+  by_keeper: [],
+  failure_categories: [],
+  hourly_trend: [],
+}
+
+async function flushUi(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 4; i += 1) {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(0)
+    }
+  })
+}
+
+describe('ToolQualityPanel', () => {
+  let container: HTMLDivElement
+  const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.useRealTimers()
+    if (originalVisibility) {
+      Object.defineProperty(document, 'visibilityState', originalVisibility)
+    }
+  })
+
+  it('auto-refreshes tool quality while visible', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const { ToolQualityPanel } = await import('./tool-quality-panel')
+
+    await act(async () => {
+      render(html`<${ToolQualityPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('30초 자동 갱신')
+    expect(container.textContent).toContain('95.5%')
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushUi()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -1,6 +1,8 @@
 import { html } from 'htm/preact'
 import { signal, computed, type Signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
+import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { LoadingState } from './common/feedback-state'
 
 interface ToolStat {
@@ -44,8 +46,10 @@ interface ToolQualityData {
 const data: Signal<ToolQualityData | null> = signal(null)
 const loading: Signal<boolean> = signal(false)
 const error: Signal<string | null> = signal(null)
+let latestRequestId = 0
 
-async function fetchToolQuality() {
+export async function refreshToolQuality() {
+  const requestId = ++latestRequestId
   loading.value = true
   error.value = null
   const controller = new AbortController()
@@ -55,8 +59,10 @@ async function fetchToolQuality() {
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     const json = await resp.json()
     if (typeof json?.total !== 'number') throw new Error('unexpected response shape')
+    if (requestId !== latestRequestId) return
     data.value = json as ToolQualityData
   } catch (e) {
+    if (requestId !== latestRequestId) return
     if (e instanceof DOMException && e.name === 'AbortError') {
       error.value = 'request timeout (15s)'
     } else {
@@ -64,6 +70,7 @@ async function fetchToolQuality() {
     }
   } finally {
     clearTimeout(timeout)
+    if (requestId !== latestRequestId) return
     loading.value = false
   }
 }
@@ -210,7 +217,10 @@ function FailureList({ categories }: { categories: FailureCategory[] }) {
 }
 
 export function ToolQualityPanel() {
-  useEffect(() => { void fetchToolQuality() }, [])
+  useEffect(() => {
+    void refreshToolQuality()
+    return setupVisibleAutoRefresh(refreshToolQuality, TELEMETRY_AUTO_REFRESH_MS)
+  }, [])
 
   const d = data.value
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
@@ -223,9 +233,10 @@ export function ToolQualityPanel() {
         <h2 class="text-sm font-medium">도구 호출 품질</h2>
         <button
           class="text-[10px] px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
-          onClick=${fetchToolQuality}
+          onClick=${refreshToolQuality}
           aria-label="도구 품질 새로고침"
         >새로고침</button>
+        <span class="text-[10px] text-[var(--text-dim)]">30초 자동 갱신</span>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { signal, computed, type Signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
-import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { LoadingState } from './common/feedback-state'
 
 interface ToolStat {
@@ -236,7 +236,7 @@ export function ToolQualityPanel() {
           onClick=${refreshToolQuality}
           aria-label="도구 품질 새로고침"
         >새로고침</button>
-        <span class="text-[10px] text-[var(--text-dim)]">30초 자동 갱신</span>
+        <span class="text-[10px] text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
       </div>
 
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -47,13 +47,22 @@ const data: Signal<ToolQualityData | null> = signal(null)
 const loading: Signal<boolean> = signal(false)
 const error: Signal<string | null> = signal(null)
 let latestRequestId = 0
+let activeController: AbortController | null = null
+let activeTimeout: ReturnType<typeof setTimeout> | null = null
 
 export async function refreshToolQuality() {
   const requestId = ++latestRequestId
+  activeController?.abort()
+  if (activeTimeout !== null) {
+    clearTimeout(activeTimeout)
+    activeTimeout = null
+  }
   loading.value = true
   error.value = null
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 15_000)
+  activeController = controller
+  activeTimeout = timeout
   try {
     const resp = await fetch('/api/v1/dashboard/tool-quality?n=5000', { signal: controller.signal })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
@@ -70,6 +79,8 @@ export async function refreshToolQuality() {
     }
   } finally {
     clearTimeout(timeout)
+    if (activeController === controller) activeController = null
+    if (activeTimeout === timeout) activeTimeout = null
     if (requestId !== latestRequestId) return
     loading.value = false
   }

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -33,6 +33,7 @@ export const SSE_KEEPER_THREAD_DEBOUNCE_MS = 800
 export const SSE_RECONNECT_RETRY_MS = 3_000
 export const PERIODIC_REFRESH_DEV_MS = 180_000
 export const PERIODIC_REFRESH_PROD_MS = 120_000
+export const TELEMETRY_AUTO_REFRESH_MS = 30_000
 
 // --- Context ratio thresholds ---
 // Lifecycle state thresholds (SSOT: lib/config/env_config_runtime.ml Dashboard module)

--- a/dashboard/src/lib/auto-refresh.test.ts
+++ b/dashboard/src/lib/auto-refresh.test.ts
@@ -3,12 +3,14 @@ import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from './auto-refresh'
 
 describe('auto-refresh', () => {
   const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
+  let visibilityState: DocumentVisibilityState = 'visible'
 
   beforeEach(() => {
     vi.useFakeTimers()
+    visibilityState = 'visible'
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
-      get: () => 'visible',
+      get: () => visibilityState,
     })
   })
 
@@ -84,5 +86,30 @@ describe('auto-refresh', () => {
     await vi.advanceTimersByTimeAsync(1_000)
 
     expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it('skips interval and event refreshes while the document is hidden', async () => {
+    visibilityState = 'hidden'
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 200)
+
+    window.dispatchEvent(new Event('focus'))
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(refresh).not.toHaveBeenCalled()
+    dispose()
+  })
+
+  it('refreshes immediately when the document becomes visible again', () => {
+    visibilityState = 'hidden'
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 200)
+
+    visibilityState = 'visible'
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+    dispose()
   })
 })

--- a/dashboard/src/lib/auto-refresh.test.ts
+++ b/dashboard/src/lib/auto-refresh.test.ts
@@ -42,4 +42,19 @@ describe('auto-refresh', () => {
     expect(refresh).toHaveBeenCalledTimes(2)
     dispose()
   })
+
+  it('keeps short interval refreshes active while deduplicating follow-up focus events', async () => {
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 200)
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    window.dispatchEvent(new Event('focus'))
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    dispose()
+  })
 })

--- a/dashboard/src/lib/auto-refresh.test.ts
+++ b/dashboard/src/lib/auto-refresh.test.ts
@@ -57,4 +57,32 @@ describe('auto-refresh', () => {
     expect(refresh).toHaveBeenCalledTimes(2)
     dispose()
   })
+
+  it('deduplicates an interval tick that lands right after an event-triggered refresh', async () => {
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 200)
+
+    await vi.advanceTimersByTimeAsync(190)
+    window.dispatchEvent(new Event('focus'))
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(600)
+    expect(refresh).toHaveBeenCalledTimes(2)
+    dispose()
+  })
+
+  it('stops interval and event refreshes after cleanup', async () => {
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 200)
+
+    dispose()
+    window.dispatchEvent(new Event('focus'))
+    document.dispatchEvent(new Event('visibilitychange'))
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(refresh).not.toHaveBeenCalled()
+  })
 })

--- a/dashboard/src/lib/auto-refresh.test.ts
+++ b/dashboard/src/lib/auto-refresh.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from './auto-refresh'
+
+describe('auto-refresh', () => {
+  const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    if (originalVisibility) {
+      Object.defineProperty(document, 'visibilityState', originalVisibility)
+    }
+  })
+
+  it('formats labels from the configured interval', () => {
+    expect(formatAutoRefreshLabel(30_000)).toBe('30초 자동 갱신')
+    expect(formatAutoRefreshLabel(60_000)).toBe('1분 자동 갱신')
+    expect(formatAutoRefreshLabel(500)).toBe('1초 자동 갱신')
+  })
+
+  it('deduplicates back-to-back visibility and focus refresh triggers', async () => {
+    const refresh = vi.fn()
+    const dispose = setupVisibleAutoRefresh(refresh, 30_000)
+
+    document.dispatchEvent(new Event('visibilitychange'))
+    window.dispatchEvent(new Event('focus'))
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(500)
+    window.dispatchEvent(new Event('focus'))
+
+    expect(refresh).toHaveBeenCalledTimes(2)
+    dispose()
+  })
+})

--- a/dashboard/src/lib/auto-refresh.ts
+++ b/dashboard/src/lib/auto-refresh.ts
@@ -13,17 +13,20 @@ export function setupVisibleAutoRefresh(
   intervalMs: number,
 ): () => void {
   let lastRefreshAt = 0
+  let lastRefreshSource: 'event' | 'interval' | null = null
 
-  const runRefresh = (dedupeRecentEvents: boolean) => {
+  const runRefresh = (source: 'event' | 'interval') => {
     if (typeof document.visibilityState === 'string' && document.visibilityState !== 'visible') return
     const now = Date.now()
-    if (dedupeRecentEvents && now - lastRefreshAt < AUTO_REFRESH_EVENT_DEDUPE_MS) return
+    const dedupeRecentRefresh = source === 'event' || lastRefreshSource === 'event'
+    if (dedupeRecentRefresh && now - lastRefreshAt < AUTO_REFRESH_EVENT_DEDUPE_MS) return
     lastRefreshAt = now
+    lastRefreshSource = source
     void refresh()
   }
 
-  const runIntervalRefresh = () => { runRefresh(false) }
-  const runEventRefresh = () => { runRefresh(true) }
+  const runIntervalRefresh = () => { runRefresh('interval') }
+  const runEventRefresh = () => { runRefresh('event') }
 
   const interval = window.setInterval(runIntervalRefresh, intervalMs)
   window.addEventListener('focus', runEventRefresh)

--- a/dashboard/src/lib/auto-refresh.ts
+++ b/dashboard/src/lib/auto-refresh.ts
@@ -1,9 +1,24 @@
+const AUTO_REFRESH_EVENT_DEDUPE_MS = 500
+
+export function formatAutoRefreshLabel(intervalMs: number): string {
+  const seconds = Math.max(1, Math.round(intervalMs / 1000))
+  if (seconds % 60 === 0) {
+    return `${seconds / 60}분 자동 갱신`
+  }
+  return `${seconds}초 자동 갱신`
+}
+
 export function setupVisibleAutoRefresh(
   refresh: () => void | Promise<void>,
   intervalMs: number,
 ): () => void {
+  let lastRefreshAt = 0
+
   const runRefresh = () => {
     if (typeof document.visibilityState === 'string' && document.visibilityState !== 'visible') return
+    const now = Date.now()
+    if (now - lastRefreshAt < AUTO_REFRESH_EVENT_DEDUPE_MS) return
+    lastRefreshAt = now
     void refresh()
   }
 

--- a/dashboard/src/lib/auto-refresh.ts
+++ b/dashboard/src/lib/auto-refresh.ts
@@ -1,0 +1,19 @@
+export function setupVisibleAutoRefresh(
+  refresh: () => void | Promise<void>,
+  intervalMs: number,
+): () => void {
+  const runRefresh = () => {
+    if (typeof document.visibilityState === 'string' && document.visibilityState !== 'visible') return
+    void refresh()
+  }
+
+  const interval = window.setInterval(runRefresh, intervalMs)
+  window.addEventListener('focus', runRefresh)
+  document.addEventListener('visibilitychange', runRefresh)
+
+  return () => {
+    window.clearInterval(interval)
+    window.removeEventListener('focus', runRefresh)
+    document.removeEventListener('visibilitychange', runRefresh)
+  }
+}

--- a/dashboard/src/lib/auto-refresh.ts
+++ b/dashboard/src/lib/auto-refresh.ts
@@ -14,21 +14,24 @@ export function setupVisibleAutoRefresh(
 ): () => void {
   let lastRefreshAt = 0
 
-  const runRefresh = () => {
+  const runRefresh = (dedupeRecentEvents: boolean) => {
     if (typeof document.visibilityState === 'string' && document.visibilityState !== 'visible') return
     const now = Date.now()
-    if (now - lastRefreshAt < AUTO_REFRESH_EVENT_DEDUPE_MS) return
+    if (dedupeRecentEvents && now - lastRefreshAt < AUTO_REFRESH_EVENT_DEDUPE_MS) return
     lastRefreshAt = now
     void refresh()
   }
 
-  const interval = window.setInterval(runRefresh, intervalMs)
-  window.addEventListener('focus', runRefresh)
-  document.addEventListener('visibilitychange', runRefresh)
+  const runIntervalRefresh = () => { runRefresh(false) }
+  const runEventRefresh = () => { runRefresh(true) }
+
+  const interval = window.setInterval(runIntervalRefresh, intervalMs)
+  window.addEventListener('focus', runEventRefresh)
+  document.addEventListener('visibilitychange', runEventRefresh)
 
   return () => {
     window.clearInterval(interval)
-    window.removeEventListener('focus', runRefresh)
-    document.removeEventListener('visibilitychange', runRefresh)
+    window.removeEventListener('focus', runEventRefresh)
+    document.removeEventListener('visibilitychange', runEventRefresh)
   }
 }

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -19,6 +19,10 @@ vi.mock('./mission-store', () => ({
   refreshMissionSnapshot: vi.fn(),
 }))
 
+vi.mock('./components/tool-quality-panel', () => ({
+  refreshToolQuality: vi.fn(),
+}))
+
 vi.mock('./command-store', () => ({
   commandPlaneSurface: { value: 'overview' },
   refreshCommandPlaneChainSummary: vi.fn(),
@@ -79,6 +83,11 @@ describe('refreshPlanForRoute', () => {
       tab: 'lab',
       params: { section: 'harness' },
     })).toEqual(['harness'])
+
+    expect(refreshPlanForRoute({
+      tab: 'lab',
+      params: { section: 'tool-quality' },
+    })).toEqual(['toolQuality'])
 
     expect(refreshPlanForRoute({
       tab: 'lab',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -19,6 +19,11 @@ async function refreshHarnessLabSurface(): Promise<void> {
   await refreshHarnessSurface()
 }
 
+async function refreshToolQualityLabSurface(): Promise<void> {
+  const { refreshToolQuality } = await import('./components/tool-quality-panel')
+  await refreshToolQuality()
+}
+
 async function refreshFeatureHealthSurface(): Promise<void> {
   const { refreshFeatureHealth } = await import('./components/feature-health')
   await refreshFeatureHealth()
@@ -39,6 +44,7 @@ export type RefreshTask =
   | 'goals'
   | 'autoresearch'
   | 'harness'
+  | 'toolQuality'
   | 'inspector'
   | 'operatorSnapshot'
   | 'operatorRoomDigest'
@@ -75,6 +81,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'harness') {
         return ['harness']
       }
+      if (routeState.params.section === 'tool-quality') {
+        return ['toolQuality']
+      }
       if (routeState.params.section === 'inspector') {
         return ['inspector']
       }
@@ -95,6 +104,7 @@ const REFRESHERS: Record<RefreshTask, () => void> = {
   goals: () => { void refreshGoals() },
   autoresearch: () => { void refreshAutoresearchLabSurface() },
   harness: () => { void refreshHarnessLabSurface() },
+  toolQuality: () => { void refreshToolQualityLabSurface() },
   inspector: () => {
     void refreshFeatureHealthSurface()
     void refreshServerConfigSurface()


### PR DESCRIPTION
## Summary
- add shared visible-only auto-refresh support for dashboard telemetry surfaces
- harden telemetry and fleet panels against out-of-order refresh responses
- extend tool quality with auto-refresh and wire lab tool-quality into route refresh

## Testing
- `pnpm vitest run src/components/telemetry-unified.test.ts src/components/fleet-telemetry-panel.test.ts src/components/tool-quality-panel.test.ts src/tab-refresh.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm typecheck`
- `pnpm build`