### PR TITLE
Add any-model tool-quality aggregation

### DIFF
--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -87,12 +87,77 @@ let classify_failure_output (output : string) : string =
            |> Option.value ~default:"unknown_error")
     | exception Yojson.Json_error _ -> "parse_error"
 
+let bucket_key record field ~default =
+  Safe_ops.json_string_opt field record |> Option.value ~default
+
+let thinking_mode_of_record record =
+  match record with
+  | `Assoc fields ->
+    (match List.assoc_opt "thinking_enabled" fields with
+     | Some (`Bool true) -> "enabled"
+     | Some (`Bool false) -> "disabled"
+     | _ -> "unknown")
+  | _ -> "unknown"
+
+let hour_key_of_record record =
+  let hour_of_unix ts =
+    let tm = Unix.gmtime ts in
+    Printf.sprintf "%04d-%02d-%02dT%02d"
+      (tm.Unix.tm_year + 1900)
+      (tm.Unix.tm_mon + 1)
+      tm.Unix.tm_mday
+      tm.Unix.tm_hour
+  in
+  match record with
+  | `Assoc fields ->
+    (match List.assoc_opt "ts" fields with
+     | Some (`Float f) -> hour_of_unix f
+     | Some (`Int i) -> hour_of_unix (Float.of_int i)
+     | Some (`String s) when String.length s >= 13 -> String.sub s 0 13
+     | Some (`String s) -> s
+     | _ -> "unknown")
+  | _ -> "unknown"
+
+let update_rate_table table key ok =
+  let key = if String.trim key = "" then "unknown" else key in
+  let calls, successes =
+    match Hashtbl.find_opt table key with
+    | Some counts -> counts
+    | None ->
+      let counts = (ref 0, ref 0) in
+      Hashtbl.replace table key counts;
+      counts
+  in
+  incr calls;
+  if ok then incr successes
+
+let render_rate_table ~field table =
+  Hashtbl.fold (fun name (c, s) acc ->
+    let calls = !c in
+    let successes = !s in
+    let pct =
+      if calls > 0
+      then Float.of_int successes /. Float.of_int calls *. 100.0
+      else 0.0
+    in
+    (calls, `Assoc [
+      (field, `String name);
+      ("calls", `Int calls);
+      ("success_pct", `Float pct);
+    ]) :: acc
+  ) table []
+  |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
+  |> List.map snd
+
 let aggregate ?(n = 5000) () : Yojson.Safe.t =
   let records = Keeper_tool_call_log.read_recent ~n () in
   if records = [] then
-    `Assoc [("total", `Int 0); ("success_rate", `Float 0.0);
+    `Assoc [("total", `Int 0); ("success", `Int 0); ("failure", `Int 0);
+            ("success_rate", `Float 0.0);
             ("by_tool", `List []); ("by_keeper", `List []);
-            ("failure_categories", `List [])]
+            ("by_model", `List []); ("by_lane", `List []);
+            ("by_thinking_mode", `List []); ("by_tool_choice", `List []);
+            ("failure_categories", `List []); ("hourly_trend", `List [])]
   else
   let total = ref 0 in
   let success = ref 0 in
@@ -105,6 +170,19 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
   (* keeper -> (calls, successes) *)
   let keeper_stats : (string, int ref * int ref) Hashtbl.t =
     Hashtbl.create 16
+  in
+  (* model/lane/thinking/tool_choice -> (calls, successes) *)
+  let model_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 16
+  in
+  let lane_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 8
+  in
+  let thinking_mode_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 4
+  in
+  let tool_choice_stats : (string, int ref * int ref) Hashtbl.t =
+    Hashtbl.create 8
   in
   (* error category -> count *)
   let failure_cats : (string, int ref) Hashtbl.t = Hashtbl.create 32 in
@@ -149,12 +227,7 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
     in
     if ok then incr success;
     (* hourly trend bucketing *)
-    let hour_key =
-      Safe_ops.json_string_opt "ts" record
-      |> Option.map (fun ts ->
-        if String.length ts >= 13 then String.sub ts 0 13 else ts)
-      |> Option.value ~default:"unknown"
-    in
+    let hour_key = hour_key_of_record record in
     let (hc, hs) =
       match Hashtbl.find_opt hourly_trend hour_key with
       | Some v -> v
@@ -183,6 +256,11 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
         Hashtbl.replace keeper_stats keeper v; v
     in
     incr kc; if ok then incr ks;
+    update_rate_table model_stats (bucket_key record "model" ~default:"unknown") ok;
+    update_rate_table lane_stats (bucket_key record "lane" ~default:"unknown") ok;
+    update_rate_table thinking_mode_stats (thinking_mode_of_record record) ok;
+    update_rate_table tool_choice_stats
+      (bucket_key record "tool_choice" ~default:"unknown") ok;
     (* failure category *)
     if not ok then begin
       let output =
@@ -231,21 +309,15 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
     |> List.map snd
   in
   let by_keeper =
-    Hashtbl.fold (fun name (c, s) acc ->
-      let calls = !c in
-      let successes = !s in
-      let pct = if calls > 0
-        then Float.of_int successes /. Float.of_int calls *. 100.0
-        else 0.0
-      in
-      (calls, `Assoc [
-        ("name", `String name);
-        ("calls", `Int calls);
-        ("success_pct", `Float pct);
-      ]) :: acc
-    ) keeper_stats []
-    |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
-    |> List.map snd
+    render_rate_table ~field:"name" keeper_stats
+  in
+  let by_model = render_rate_table ~field:"name" model_stats in
+  let by_lane = render_rate_table ~field:"name" lane_stats in
+  let by_thinking_mode =
+    render_rate_table ~field:"name" thinking_mode_stats
+  in
+  let by_tool_choice =
+    render_rate_table ~field:"name" tool_choice_stats
   in
   let failure_categories =
     Hashtbl.fold (fun cat r acc ->
@@ -279,6 +351,10 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
     ("success_rate", `Float (Float.round (rate *. 100.0) /. 100.0));
     ("by_tool", `List by_tool);
     ("by_keeper", `List by_keeper);
+    ("by_model", `List by_model);
+    ("by_lane", `List by_lane);
+    ("by_thinking_mode", `List by_thinking_mode);
+    ("by_tool_choice", `List by_tool_choice);
     ("failure_categories", `List failure_categories);
     ("hourly_trend", `List hourly);
   ]

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1273,6 +1273,25 @@ let run_turn
                 then current_params.tool_choice (* last turn: Auto for [STATE] block *)
                 else Some Agent_sdk.Types.Any (* all other turns: force tool use *)
               in
+              let lane =
+                if is_retry then "retry"
+                else (
+                  match tool_choice with
+                  | Some Agent_sdk.Types.Any -> "tool_required"
+                  | Some Agent_sdk.Types.None_ -> "tool_disabled"
+                  | _ -> "tool_optional")
+              in
+              Keeper_tool_call_log.set_turn_context
+                ~keeper_name:meta.name
+                ~lane
+                ?tool_choice:(Option.map
+                  (fun choice ->
+                    Yojson.Safe.to_string
+                      (Agent_sdk.Types.tool_choice_to_json choice))
+                  tool_choice)
+                ~thinking_enabled:(Keeper_config.keeper_enable_thinking ())
+                ?thinking_budget:current_params.thinking_budget
+                ();
               (* Tool disclosure telemetry: emitted after all allow-list rewrites
            (last-turn intersect, max_tools cap) so that
            final_visible and hook_ms reflect the actual state sent to AdjustParams.

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -323,7 +323,7 @@ let make_hooks
 
     post_tool_use = Some (fun event ->
       match event with
-      | Agent_sdk.Hooks.PostToolUse { tool_name; input; output; _ } ->
+      | Agent_sdk.Hooks.PostToolUse { tool_name; input; output; duration_ms = hook_duration_ms; _ } ->
         let output_text = match output with
           | Ok { Agent_sdk.Types.content; _ } -> content
           | Error { Agent_sdk.Types.message; _ } -> message
@@ -342,7 +342,9 @@ let make_hooks
            tool_start_time is keeper-local (one ref per make_hooks call).
            Tool calls within Agent.run are sequential, so no race. *)
         let duration_ms =
-          (Time_compat.now () -. !tool_start_time) *. 1000.0
+          if hook_duration_ms > 0.0
+          then hook_duration_ms
+          else (Time_compat.now () -. !tool_start_time) *. 1000.0
         in
         (* Consume truncation info set by keeper_tools_oas before returning
            the (possibly truncated) result to OAS. Falls back to out_len
@@ -352,6 +354,10 @@ let make_hooks
             ~keeper_name:(!meta_ref).name ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in
+        let lane, tool_choice, thinking_enabled, thinking_budget =
+          Keeper_tool_call_log.get_turn_context
+            ~keeper_name:(!meta_ref).name ()
+        in
         (try
            Keeper_tool_call_log.log_call
              ~keeper_name:(!meta_ref).name
@@ -359,6 +365,7 @@ let make_hooks
              ~success:(outcome = "ok") ~duration_ms
              ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
                      if m = "" then (!meta_ref).cascade_name else m)
+             ?lane ?tool_choice ?thinking_enabled ?thinking_budget
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         (try on_tool_executed tool_name input output_text

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -22,6 +22,22 @@ let max_output_len = 4000
     sequential so set→consume ordering is guaranteed. *)
 let pending_truncation : (string, int * int option) Hashtbl.t = Hashtbl.create 8
 
+type turn_context = {
+  lane: string option;
+  tool_choice: string option;
+  thinking_enabled: bool option;
+  thinking_budget: int option;
+}
+
+let empty_turn_context = {
+  lane = None;
+  tool_choice = None;
+  thinking_enabled = None;
+  thinking_budget = None;
+}
+
+let pending_turn_context : (string, turn_context) Hashtbl.t = Hashtbl.create 8
+
 let set_truncation_info ~keeper_name ~original_bytes ?truncated_to () =
   Hashtbl.replace pending_truncation keeper_name (original_bytes, truncated_to)
 
@@ -29,6 +45,19 @@ let consume_truncation_info ~keeper_name () =
   match Hashtbl.find_opt pending_truncation keeper_name with
   | Some info -> Hashtbl.remove pending_truncation keeper_name; info
   | None -> (0, None)
+
+let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
+    ?thinking_budget () =
+  Hashtbl.replace pending_turn_context keeper_name
+    { lane; tool_choice; thinking_enabled; thinking_budget }
+
+let get_turn_context ~keeper_name () =
+  let ctx =
+    match Hashtbl.find_opt pending_turn_context keeper_name with
+    | Some ctx -> ctx
+    | None -> empty_turn_context
+  in
+  (ctx.lane, ctx.tool_choice, ctx.thinking_enabled, ctx.thinking_budget)
 
 let store_ref : Dated_jsonl.t option ref = ref None
 
@@ -42,7 +71,9 @@ let init ~base_path =
        (Printexc.to_string exn))
 
 let reset_for_testing () =
-  store_ref := None
+  store_ref := None;
+  Hashtbl.reset pending_truncation;
+  Hashtbl.reset pending_turn_context
 
 let suffix = "...(truncated)"
 let suffix_len = String.length suffix
@@ -55,12 +86,30 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
-    ?(model : string = "") ?result_bytes ?truncated_to () =
+    ?(model : string = "") ?lane ?tool_choice ?thinking_enabled
+    ?thinking_budget ?result_bytes ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
     match !store_ref with
     | None -> ()
     | Some store ->
+      let ctx_lane, ctx_tool_choice, ctx_thinking_enabled, ctx_thinking_budget =
+        get_turn_context ~keeper_name ()
+      in
+      let lane = match lane with Some _ -> lane | None -> ctx_lane in
+      let tool_choice =
+        match tool_choice with Some _ -> tool_choice | None -> ctx_tool_choice
+      in
+      let thinking_enabled =
+        match thinking_enabled with
+        | Some _ -> thinking_enabled
+        | None -> ctx_thinking_enabled
+      in
+      let thinking_budget =
+        match thinking_budget with
+        | Some _ -> thinking_budget
+        | None -> ctx_thinking_budget
+      in
       let model_field =
         if model = "" then [] else [("model", `String model)]
       in
@@ -70,6 +119,22 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
       in
       let truncated_to_field = match truncated_to with
         | Some n -> [("truncated_to", `Int n)]
+        | None -> []
+      in
+      let lane_field = match lane with
+        | Some value -> [("lane", `String value)]
+        | None -> []
+      in
+      let tool_choice_field = match tool_choice with
+        | Some value -> [("tool_choice", `String value)]
+        | None -> []
+      in
+      let thinking_enabled_field = match thinking_enabled with
+        | Some value -> [("thinking_enabled", `Bool value)]
+        | None -> []
+      in
+      let thinking_budget_field = match thinking_budget with
+        | Some value -> [("thinking_budget", `Int value)]
         | None -> []
       in
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
@@ -83,7 +148,9 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
           ; ("output", `String safe_output)
           ; ("success", `Bool success)
           ; ("duration_ms", `Float duration_ms)
-          ] @ model_field @ result_bytes_field @ truncated_to_field)
+          ] @ model_field @ lane_field @ tool_choice_field
+            @ thinking_enabled_field @ thinking_budget_field
+            @ result_bytes_field @ truncated_to_field)
       in
       (try Dated_jsonl.append store json
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -26,6 +26,24 @@ val consume_truncation_info :
     the pending state. Returns [(0, None)] when no truncation info
     was set (e.g. OAS-internal tool call that bypassed the wrapper). *)
 
+val set_turn_context :
+  keeper_name:string ->
+  ?lane:string ->
+  ?tool_choice:string ->
+  ?thinking_enabled:bool ->
+  ?thinking_budget:int ->
+  unit ->
+  unit
+(** [set_turn_context ...] stores the current effective turn policy for
+    subsequent tool-call logs emitted by the keeper during this turn. *)
+
+val get_turn_context :
+  keeper_name:string ->
+  unit ->
+  string option * string option * bool option * int option
+(** Returns [(lane, tool_choice, thinking_enabled, thinking_budget)] for
+    the keeper, or [None] values when no turn context has been recorded. *)
+
 val init : base_path:string -> unit
 (** [init ~base_path] creates the Dated_jsonl store. Call once at startup. *)
 
@@ -37,15 +55,21 @@ val log_call :
   success:bool ->
   duration_ms:float ->
   ?model:string ->
+  ?lane:string ->
+  ?tool_choice:string ->
+  ?thinking_enabled:bool ->
+  ?thinking_budget:int ->
   ?result_bytes:int ->
   ?truncated_to:int ->
   unit ->
   unit
 (** [log_call ...] persists a single tool call record with full I/O.
     Output is truncated to 4000 bytes. [model] records which LLM generated
-    the tool call (for 9B vs GLM comparison). [result_bytes] is the original
-    output size before any truncation. [truncated_to] is present when
-    Tool_output_validation truncated the output. Best-effort (failures logged). *)
+    the tool call. Turn-policy fields ([lane], [tool_choice],
+    [thinking_enabled], [thinking_budget]) capture the effective tool
+    selection context. [result_bytes] is the original output size before
+    any truncation. [truncated_to] is present when Tool_output_validation
+    truncated the output. Best-effort (failures logged). *)
 
 val read_recent :
   ?keeper_name:string ->

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -25,6 +25,21 @@ let with_tmp_log f =
       ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
     (fun () -> f ())
 
+let with_tmp_log_dir f =
+  incr counter;
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test-keeper-tool-call-log-%d-%d-%d"
+       (Unix.getpid ()) !counter
+       (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  Fs_compat.mkdir_p dir;
+  Keeper_tool_call_log.reset_for_testing ();
+  Keeper_tool_call_log.init ~base_path:dir;
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_tool_call_log.reset_for_testing ();
+      ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir))))
+    (fun () -> f dir)
+
 (* ── read_recent edge cases ─────────────────────────── *)
 
 let test_read_recent_n_zero () =
@@ -136,6 +151,30 @@ let test_turn_context_fields_stored () =
     Alcotest.(check int) "thinking_budget field" 1024
       (Safe_ops.json_int ~default:0 "thinking_budget" entry))
 
+let test_turn_context_fields_absent_without_context () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k" ~tool_name:"masc_status"
+      ~input:(`Assoc []) ~output_text:"ok"
+      ~success:true ~duration_ms:2.0 ();
+    let entries = Keeper_tool_call_log.read_recent () in
+    Alcotest.(check int) "one entry" 1 (List.length entries);
+    let entry = List.hd entries in
+    Alcotest.(check (option string)) "lane absent"
+      None
+      (Safe_ops.json_string_opt "lane" entry);
+    Alcotest.(check (option string)) "tool_choice absent"
+      None
+      (Safe_ops.json_string_opt "tool_choice" entry);
+    Alcotest.(check bool) "thinking_enabled absent" true
+      (match Yojson.Safe.Util.member "thinking_enabled" entry with
+       | `Null -> true
+       | _ -> false);
+    Alcotest.(check bool) "thinking_budget absent" true
+      (match Yojson.Safe.Util.member "thinking_budget" entry with
+       | `Null -> true
+       | _ -> false))
+
 let find_bucket name json =
   json
   |> Yojson.Safe.Util.to_list
@@ -176,6 +215,47 @@ let test_dashboard_aggregate_groups_runtime_fields () =
     Alcotest.(check int) "auto tool_choice calls" 1
       (Safe_ops.json_int ~default:0 "calls" auto_bucket))
 
+let test_dashboard_hourly_trend_numeric_ts () =
+  with_tmp_log_dir (fun dir ->
+    let store =
+      Dated_jsonl.create
+        ~base_dir:(Filename.concat dir ".masc/tool_calls")
+        ()
+    in
+    let ts = 1_710_000_000 in
+    Dated_jsonl.append store
+      (`Assoc
+         [ ("ts", `Int ts)
+         ; ("keeper", `String "k")
+         ; ("tool", `String "masc_status")
+         ; ("input", `Assoc [])
+         ; ("output", `String "ok")
+         ; ("success", `Bool true)
+         ; ("duration_ms", `Float 2.0)
+         ]);
+    let expected_hour =
+      let tm = Unix.gmtime (Float.of_int ts) in
+      Printf.sprintf "%04d-%02d-%02dT%02d"
+        (tm.Unix.tm_year + 1900)
+        (tm.Unix.tm_mon + 1)
+        tm.Unix.tm_mday
+        tm.Unix.tm_hour
+    in
+    let hourly =
+      Dashboard_http_tool_quality.aggregate ~n:10 ()
+      |> Yojson.Safe.Util.member "hourly_trend"
+      |> Yojson.Safe.Util.to_list
+    in
+    let bucket =
+      List.find (fun item ->
+        Safe_ops.json_string_opt "hour" item = Some expected_hour
+      ) hourly
+    in
+    Alcotest.(check int) "hour bucket calls" 1
+      (Safe_ops.json_int ~default:0 "calls" bucket);
+    Alcotest.(check int) "hour bucket success" 1
+      (Safe_ops.json_int ~default:0 "success" bucket))
+
 let () =
   Alcotest.run "keeper_tool_call_log"
     [ ( "read_recent",
@@ -188,7 +268,11 @@ let () =
         ; eio_test "sensitive input fields redacted" test_sensitive_input_fields_redacted
         ; eio_test "model field stored" test_model_field_stored
         ; eio_test "turn context fields stored" test_turn_context_fields_stored
+        ; eio_test "turn context fields absent without context"
+            test_turn_context_fields_absent_without_context
         ; eio_test "dashboard aggregate groups runtime fields"
             test_dashboard_aggregate_groups_runtime_fields
+        ; eio_test "dashboard hourly trend buckets numeric ts"
+            test_dashboard_hourly_trend_numeric_ts
         ] )
     ]

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -107,6 +107,75 @@ let test_model_field_stored () =
     Alcotest.(check bool) "model field present" true
       (Observability_redact.contains_substring ~sub:"glm-4-9b" entry_str))
 
+let test_turn_context_fields_stored () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.set_turn_context
+      ~keeper_name:"k"
+      ~lane:"tool_required"
+      ~tool_choice:"required"
+      ~thinking_enabled:false
+      ~thinking_budget:1024
+      ();
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k" ~tool_name:"masc_status"
+      ~input:(`Assoc []) ~output_text:"ok"
+      ~success:true ~duration_ms:2.0 ();
+    let entries = Keeper_tool_call_log.read_recent () in
+    Alcotest.(check int) "one entry" 1 (List.length entries);
+    let entry = List.hd entries in
+    Alcotest.(check (option string)) "lane field"
+      (Some "tool_required")
+      (Safe_ops.json_string_opt "lane" entry);
+    Alcotest.(check (option string)) "tool_choice field"
+      (Some "required")
+      (Safe_ops.json_string_opt "tool_choice" entry);
+    Alcotest.(check bool) "thinking_enabled present" true
+      (match Yojson.Safe.Util.member "thinking_enabled" entry with
+       | `Bool false -> true
+       | _ -> false);
+    Alcotest.(check int) "thinking_budget field" 1024
+      (Safe_ops.json_int ~default:0 "thinking_budget" entry))
+
+let find_bucket name json =
+  json
+  |> Yojson.Safe.Util.to_list
+  |> List.find (fun item ->
+         Safe_ops.json_string_opt "name" item = Some name)
+
+let test_dashboard_aggregate_groups_runtime_fields () =
+  with_tmp_log (fun () ->
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k1" ~tool_name:"masc_status"
+      ~input:(`Assoc []) ~output_text:"ok"
+      ~success:true ~duration_ms:2.0
+      ~model:"glm-5.1" ~lane:"tool_required"
+      ~tool_choice:"required"
+      ~thinking_enabled:false ~thinking_budget:1024 ();
+    Keeper_tool_call_log.log_call
+      ~keeper_name:"k2" ~tool_name:"masc_status"
+      ~input:(`Assoc []) ~output_text:"error: {\"ok\":false,\"error\":\"boom\"}"
+      ~success:false ~duration_ms:3.0
+      ~model:"qwen3.5-27b-unified" ~lane:"retry"
+      ~tool_choice:"auto"
+      ~thinking_enabled:true ~thinking_budget:4096 ();
+    let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
+    let by_model = Yojson.Safe.Util.member "by_model" summary in
+    let by_lane = Yojson.Safe.Util.member "by_lane" summary in
+    let by_thinking = Yojson.Safe.Util.member "by_thinking_mode" summary in
+    let by_tool_choice = Yojson.Safe.Util.member "by_tool_choice" summary in
+    let glm_bucket = find_bucket "glm-5.1" by_model in
+    let retry_bucket = find_bucket "retry" by_lane in
+    let enabled_bucket = find_bucket "enabled" by_thinking in
+    let auto_bucket = find_bucket "auto" by_tool_choice in
+    Alcotest.(check int) "glm bucket calls" 1
+      (Safe_ops.json_int ~default:0 "calls" glm_bucket);
+    Alcotest.(check int) "retry bucket calls" 1
+      (Safe_ops.json_int ~default:0 "calls" retry_bucket);
+    Alcotest.(check int) "enabled thinking calls" 1
+      (Safe_ops.json_int ~default:0 "calls" enabled_bucket);
+    Alcotest.(check int) "auto tool_choice calls" 1
+      (Safe_ops.json_int ~default:0 "calls" auto_bucket))
+
 let () =
   Alcotest.run "keeper_tool_call_log"
     [ ( "read_recent",
@@ -118,5 +187,8 @@ let () =
         [ eio_test "denied tool not logged" test_denied_tool_not_logged
         ; eio_test "sensitive input fields redacted" test_sensitive_input_fields_redacted
         ; eio_test "model field stored" test_model_field_stored
+        ; eio_test "turn context fields stored" test_turn_context_fields_stored
+        ; eio_test "dashboard aggregate groups runtime fields"
+            test_dashboard_aggregate_groups_runtime_fields
         ] )
     ]


### PR DESCRIPTION
## Summary
- record keeper turn tool-selection context without model-specific hardcoding
- propagate turn context into keeper tool-call logs
- add dashboard aggregations by model, lane, thinking mode, and tool choice

## Validation
- `dune build --root .`
- `./_build/default/test/test_keeper_tool_call_log.exe`
- `./_build/default/bin/main_eio.exe --base-path <tmp> --port 8967`
- `curl -s 'http://127.0.0.1:8967/api/v1/dashboard/tool-quality?n=10'`
- `curl -s http://127.0.0.1:8967/health`