### PR TITLE
feat(gate): connector registry with module type and generic routes

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -367,14 +367,14 @@ function connectorStateTone(connector: GateConnectorInfo | null): string {
   return 'border-amber-400/30 bg-amber-500/12 text-amber-100'
 }
 
-async function bindDiscordChannel() {
+async function bindConnector(connectorId: string) {
   const channelId = channelDraft.value.trim()
   const keeperName = keeperDraft.value.trim()
   if (!channelId || !keeperName) return
 
   actionLoading.value = true
   try {
-    await post('/api/v1/gate/discord/bind', { channel_id: channelId, keeper_name: keeperName })
+    await post(`/api/v1/gate/connector/bind?name=${encodeURIComponent(connectorId)}`, { channel_id: channelId, keeper_name: keeperName })
     await refresh()
     showToast(`Bound ${channelId} -> ${keeperName}`, 'success')
   } catch (err) {
@@ -384,13 +384,13 @@ async function bindDiscordChannel() {
   }
 }
 
-async function unbindDiscordChannel(channelIdOverride?: string) {
+async function unbindConnector(connectorId: string, channelIdOverride?: string) {
   const channelId = (channelIdOverride ?? channelDraft.value).trim()
   if (!channelId) return
 
   actionLoading.value = true
   try {
-    await post('/api/v1/gate/discord/unbind', { channel_id: channelId })
+    await post(`/api/v1/gate/connector/unbind?name=${encodeURIComponent(connectorId)}`, { channel_id: channelId })
     if (channelDraft.value.trim() === channelId) {
       channelDraft.value = ''
     }
@@ -403,7 +403,7 @@ async function unbindDiscordChannel(channelIdOverride?: string) {
   }
 }
 
-function DiscordLivePanel({
+function ConnectorLivePanel({
   connector,
   gate,
 }: {
@@ -435,8 +435,9 @@ function DiscordLivePanel({
   const selectedKeeper = keeperByName.get(keeperDraft.value.trim()) ?? null
   const directLabel = connectorStateLabel(connector)
   const directTone = connectorStateTone(connector)
+  const connectorId = connector?.connector_id ?? ''
   const bindingActionsEnabled =
-    connector?.connector_id === 'discord' && connector.capabilities.includes('bindings')
+    connectorId !== '' && connector?.capabilities.includes('bindings')
   const connectorName = connector?.display_name || 'Connector'
   const channelInputLabel = `${connectorName} channel id`
 
@@ -475,7 +476,7 @@ function DiscordLivePanel({
                   variant="primary"
                   size="sm"
                   disabled=${actionLoading.value || channelDraft.value.trim().length === 0 || keeperDraft.value.trim().length === 0}
-                  onClick=${() => { void bindDiscordChannel() }}
+                  onClick=${() => { void bindConnector(connectorId) }}
                 >
                   ${actionLoading.value ? 'Applying...' : 'Bind'}
                 <//>
@@ -483,7 +484,7 @@ function DiscordLivePanel({
                   variant="danger"
                   size="sm"
                   disabled=${actionLoading.value || channelDraft.value.trim().length === 0}
-                  onClick=${() => { void unbindDiscordChannel() }}
+                  onClick=${() => { void unbindConnector(connectorId) }}
                 >
                   Unbind
                 <//>
@@ -625,7 +626,7 @@ function DiscordLivePanel({
                               keeperDraft.value = binding.keeper_name
                             }}>Use<//>
                             ${bindingActionsEnabled
-                              ? html`<${ActionButton} variant="danger" size="sm" disabled=${actionLoading.value} onClick=${() => { void unbindDiscordChannel(binding.channel_id) }}>Unbind<//>`
+                              ? html`<${ActionButton} variant="danger" size="sm" disabled=${actionLoading.value} onClick=${() => { void unbindConnector(connectorId, binding.channel_id) }}>Unbind<//>`
                               : null}
                           </div>
                         </div>
@@ -875,7 +876,7 @@ export function ConnectorStatusPanel() {
         </div>
       </div>
 
-      <${DiscordLivePanel} connector=${live} gate=${d} />
+      <${ConnectorLivePanel} connector=${live} gate=${d} />
 
       ${error.value
         ? html`

--- a/lib/channel_gate_connector.ml
+++ b/lib/channel_gate_connector.ml
@@ -1,0 +1,62 @@
+(** Channel_gate_connector -- connector interface and registry.
+
+    @since 2.260.0 *)
+
+module type S = sig
+  val connector_id : string
+  val display_name : string
+  val channel : string
+  val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
+  val connector_json :
+    ?gate_status_json:Yojson.Safe.t ->
+    ?audit_limit:int ->
+    unit ->
+    Yojson.Safe.t
+  val bind :
+    channel_id:string ->
+    keeper_name:string ->
+    actor_name:string ->
+    (Yojson.Safe.t, string) result
+  val unbind :
+    channel_id:string ->
+    actor_name:string ->
+    (Yojson.Safe.t, string) result
+end
+
+module U = Yojson.Safe.Util
+
+let registry : (string, (module S)) Hashtbl.t = Hashtbl.create 4
+
+let register (module C : S) =
+  Hashtbl.replace registry C.connector_id (module C : S)
+
+let find name = Hashtbl.find_opt registry name
+
+let all () =
+  Hashtbl.fold (fun _k v acc -> v :: acc) registry []
+
+let connectors_json ?gate_status_json ?(audit_limit = 10) () =
+  let connectors = all () in
+  let connector_jsons =
+    List.map
+      (fun (module C : S) ->
+        C.connector_json ?gate_status_json ~audit_limit ())
+      connectors
+  in
+  let active_count =
+    List.fold_left
+      (fun acc json ->
+        if json |> U.member "available" |> U.to_bool_option
+           |> Option.value ~default:false
+        then acc + 1
+        else acc)
+      0 connector_jsons
+  in
+  `Assoc
+    [
+      ("connectors", `List connector_jsons);
+      ("total", `Int (List.length connectors));
+      ("active_count", `Int active_count);
+      ("generated_at",
+       `String (Server_utils.iso8601_of_unix (Unix.gettimeofday ())));
+    ]

--- a/lib/channel_gate_connector.mli
+++ b/lib/channel_gate_connector.mli
@@ -1,0 +1,67 @@
+(** Channel_gate_connector -- connector interface and registry.
+
+    Defines the module type that every connector must satisfy
+    and provides a name-based registry for dispatch.
+
+    This module does not know about any specific connector (Discord,
+    OpenClaw, etc.).  Concrete connectors register themselves at
+    startup via {!register}.
+
+    Relationship to other modules:
+    - {!Channel_gate} handles message routing (inbound/outbound).
+    - {!Channel_gate_connector} handles connector state (status/bind/unbind).
+    - {!Channel_gate_metrics} tracks per-channel traffic metrics.
+
+    @since 2.260.0 *)
+
+(** {1 Connector Module Type} *)
+
+module type S = sig
+  val connector_id : string
+  (** Unique identifier for this connector (e.g. "discord", "openclaw"). *)
+
+  val display_name : string
+  (** Human-readable name (e.g. "Discord", "OpenClaw"). *)
+
+  val channel : string
+  (** Channel identifier used in gate message routing. *)
+
+  val status_json : ?audit_limit:int -> unit -> Yojson.Safe.t
+  (** Runtime status snapshot for this connector. *)
+
+  val connector_json :
+    ?gate_status_json:Yojson.Safe.t ->
+    ?audit_limit:int ->
+    unit ->
+    Yojson.Safe.t
+  (** Full connector descriptor for dashboard consumption. *)
+
+  val bind :
+    channel_id:string ->
+    keeper_name:string ->
+    actor_name:string ->
+    (Yojson.Safe.t, string) result
+  (** Create or update a channel-to-keeper binding. *)
+
+  val unbind :
+    channel_id:string ->
+    actor_name:string ->
+    (Yojson.Safe.t, string) result
+  (** Remove a channel-to-keeper binding. *)
+end
+
+(** {1 Registry} *)
+
+val register : (module S) -> unit
+(** Register a connector.  Replaces any existing connector with the
+    same [connector_id].  Call at server startup. *)
+
+val find : string -> (module S) option
+(** [find name] returns the connector registered under [name], if any. *)
+
+val all : unit -> (module S) list
+(** All registered connectors, in unspecified order. *)
+
+val connectors_json : ?gate_status_json:Yojson.Safe.t -> ?audit_limit:int -> unit -> Yojson.Safe.t
+(** Aggregate descriptor for all registered connectors.
+    Returns [{connectors: [...], total: N, active_count: N, generated_at: "..."}]. *)

--- a/lib/channel_gate_discord_state.ml
+++ b/lib/channel_gate_discord_state.ml
@@ -17,8 +17,12 @@ type audit_event = {
 }
 
 let connector_id = "discord"
-let connector_display_name = "Discord"
-let connector_channel = "discord"
+let display_name = "Discord"
+let channel = "discord"
+
+(* Backward-compatible aliases used internally *)
+let connector_display_name = display_name
+let connector_channel = channel
 
 let default_status_path = ".masc/connectors/discord/status.json"
 let default_binding_store_path = ".masc/connectors/discord/bindings.json"
@@ -400,18 +404,7 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("observed_channel", observed_channel);
     ]
 
-let connectors_json ?gate_status_json ?(audit_limit = 10) () =
-  let connector = connector_json ?gate_status_json ~audit_limit () in
-  let active_count =
-    if bool_member connector "available" then 1 else 0
-  in
-  `Assoc
-    [
-      ("connectors", `List [ connector ]);
-      ("total", `Int 1);
-      ("active_count", `Int active_count);
-      ("generated_at", `String (Server_utils.iso8601_of_unix (Unix.gettimeofday ())));
-    ]
+(* connectors_json removed — use Channel_gate_connector.connectors_json instead *)
 
 let rollback_bindings original_bindings =
   try save_bindings original_bindings with

--- a/lib/dune
+++ b/lib/dune
@@ -34,6 +34,7 @@
    cascade_inference
    cancellation
    channel_gate
+   channel_gate_connector
    channel_gate_metrics
    channel_gate_discord_state
    gate_protocol

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -315,6 +315,7 @@ let is_public_read_path path =
   || String.equal path "/api/v1/gate/health"
   || String.equal path "/api/v1/gate/status"
   || String.equal path "/api/v1/gate/connectors"
+  || String.equal path "/api/v1/gate/connector/status"
   || String.equal path "/api/v1/gate/discord/status"
   || String.equal path "/api/v1/gate/connector/status"
   || String.equal path "/api/v1/gate/events"

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -7,6 +7,8 @@ include Server_routes_http_keeper_stream
 module Http = Http_server_eio
 
 let make_routes ~port ~host ~sw ~clock =
+  (* Register connectors before routes are wired up *)
+  Channel_gate_connector.register (module Channel_gate_discord_state);
   Http.Router.empty
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
   |> Server_routes_http_routes_room.add_routes

--- a/lib/server/server_routes_http_routes_channel_gate.ml
+++ b/lib/server/server_routes_http_routes_channel_gate.ml
@@ -207,7 +207,7 @@ let handle_gate_status _state request reqd =
     Generic connector descriptor surface for dashboard/ops consumers.
     The gate advertises which connectors exist and their current runtime
     snapshots without requiring the caller to hardcode vendor-specific
-    knowledge. *)
+    knowledge.  Delegates to {!Channel_gate_connector.connectors_json}. *)
 let handle_gate_connectors _state request reqd =
   let audit_limit =
     int_query_param request "audit_limit" ~default:10
@@ -215,11 +215,34 @@ let handle_gate_connectors _state request reqd =
   in
   let gate_status = Channel_gate_metrics.snapshot_json () in
   let json =
-    Channel_gate_discord_state.connectors_json ~gate_status_json:gate_status
+    Channel_gate_connector.connectors_json ~gate_status_json:gate_status
       ~audit_limit ()
   in
   respond_json_with_cors ~status:`OK request reqd
     (Yojson.Safe.to_string json)
+
+(** GET /api/v1/gate/connector/status?name=<connector>&audit_limit=<n>
+
+    Single connector status by name.  Returns 404 if the connector
+    is not registered. *)
+let handle_gate_connector_status _state request reqd =
+  match query_param request "name" with
+  | None | Some "" ->
+      respond_json_with_cors ~status:`Bad_request request reqd
+        (Yojson.Safe.to_string (Channel_gate.error_json "name is required"))
+  | Some name -> (
+      match Channel_gate_connector.find name with
+      | None ->
+          respond_json_with_cors ~status:`Not_found request reqd
+            (Yojson.Safe.to_string
+               (Channel_gate.error_json ("unknown connector: " ^ name)))
+      | Some (module C) ->
+          let audit_limit =
+            int_query_param request "audit_limit" ~default:10
+            |> fun value -> max 1 (min 50 value)
+          in
+          respond_json_with_cors ~status:`OK request reqd
+            (Yojson.Safe.to_string (C.status_json ~audit_limit ())))
 
 (** GET /api/v1/gate/discord/status
     Dashboard-facing live connector status sourced from the Discord bot's
@@ -430,21 +453,133 @@ let handle_gate_discord_unbind ~sw:_ ~clock:_ _state request reqd =
         respond_json_with_cors ~status:`Bad_request request reqd
           (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")) )
 
-let handle_gate_connector_bind ~sw ~clock state request reqd =
-  match resolve_connector_channel request with
-  | Error err ->
-      respond_json_with_cors ~status:`Bad_request request reqd
-        (Yojson.Safe.to_string (Channel_gate.error_json err))
-  | Ok "discord" -> handle_gate_discord_bind ~sw ~clock state request reqd
-  | Ok _ -> assert false
+(** POST /api/v1/gate/connector/bind?name=<connector>
 
-let handle_gate_connector_unbind ~sw ~clock state request reqd =
-  match resolve_connector_channel request with
-  | Error err ->
-      respond_json_with_cors ~status:`Bad_request request reqd
-        (Yojson.Safe.to_string (Channel_gate.error_json err))
-  | Ok "discord" -> handle_gate_discord_unbind ~sw ~clock state request reqd
-  | Ok _ -> assert false
+    Generic connector bind.  Dispatches to the registered connector's
+    [bind] function.  Validates keeper existence before binding. *)
+let handle_gate_connector_bind ~sw ~clock state request reqd =
+  let connector_name =
+    query_param request "name"
+    |> Option.map String.trim
+    |> Option.value ~default:""
+  in
+  if connector_name = "" then
+    respond_json_with_cors ~status:`Bad_request request reqd
+      (Yojson.Safe.to_string (Channel_gate.error_json "name is required"))
+  else
+    match Channel_gate_connector.find connector_name with
+    | None ->
+        respond_json_with_cors ~status:`Not_found request reqd
+          (Yojson.Safe.to_string
+             (Channel_gate.error_json
+                ("unknown connector: " ^ connector_name)))
+    | Some (module C) ->
+        Http.Request.read_body_async reqd (fun body_str ->
+          try
+            let json = Yojson.Safe.from_string body_str in
+            let channel_id =
+              json |> Yojson.Safe.Util.member "channel_id"
+              |> Yojson.Safe.Util.to_string_option
+              |> Option.value ~default:""
+              |> String.trim
+            in
+            let keeper_name =
+              json |> Yojson.Safe.Util.member "keeper_name"
+              |> Yojson.Safe.Util.to_string_option
+              |> Option.value ~default:""
+              |> String.trim
+            in
+            if channel_id = "" then
+              respond_json_with_cors ~status:`Bad_request request reqd
+                (Yojson.Safe.to_string
+                   (Channel_gate.error_json "channel_id is required"))
+            else if keeper_name = "" then
+              respond_json_with_cors ~status:`Bad_request request reqd
+                (Yojson.Safe.to_string
+                   (Channel_gate.error_json "keeper_name is required"))
+            else
+              match keeper_exists ~sw ~clock state keeper_name with
+              | Error err ->
+                  respond_json_with_cors ~status:`Service_unavailable request
+                    reqd
+                    (Yojson.Safe.to_string (Channel_gate.error_json err))
+              | Ok false ->
+                  respond_json_with_cors ~status:`Not_found request reqd
+                    (Yojson.Safe.to_string
+                       (Channel_gate.error_json
+                          ("unknown keeper: " ^ keeper_name)))
+              | Ok true -> (
+                  let actor_name =
+                    agent_from_request request
+                    |> Option.value ~default:"dashboard"
+                    |> String.trim
+                  in
+                  match C.bind ~channel_id ~keeper_name ~actor_name with
+                  | Ok payload ->
+                      respond_json_with_cors ~status:`OK request reqd
+                        (Yojson.Safe.to_string payload)
+                  | Error err ->
+                      respond_json_with_cors ~status:`Internal_server_error
+                        request reqd
+                        (Yojson.Safe.to_string (Channel_gate.error_json err)))
+          with Yojson.Json_error _ ->
+            respond_json_with_cors ~status:`Bad_request request reqd
+              (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")))
+
+(** POST /api/v1/gate/connector/unbind?name=<connector>
+
+    Generic connector unbind. *)
+let handle_gate_connector_unbind _state request reqd =
+  let connector_name =
+    query_param request "name"
+    |> Option.map String.trim
+    |> Option.value ~default:""
+  in
+  if connector_name = "" then
+    respond_json_with_cors ~status:`Bad_request request reqd
+      (Yojson.Safe.to_string (Channel_gate.error_json "name is required"))
+  else
+    match Channel_gate_connector.find connector_name with
+    | None ->
+        respond_json_with_cors ~status:`Not_found request reqd
+          (Yojson.Safe.to_string
+             (Channel_gate.error_json
+                ("unknown connector: " ^ connector_name)))
+    | Some (module C) ->
+        Http.Request.read_body_async reqd (fun body_str ->
+          try
+            let json = Yojson.Safe.from_string body_str in
+            let channel_id =
+              json |> Yojson.Safe.Util.member "channel_id"
+              |> Yojson.Safe.Util.to_string_option
+              |> Option.value ~default:""
+              |> String.trim
+            in
+            if channel_id = "" then
+              respond_json_with_cors ~status:`Bad_request request reqd
+                (Yojson.Safe.to_string
+                   (Channel_gate.error_json "channel_id is required"))
+            else
+              let actor_name =
+                agent_from_request request
+                |> Option.value ~default:"dashboard"
+                |> String.trim
+              in
+              match C.unbind ~channel_id ~actor_name with
+              | Ok payload ->
+                  respond_json_with_cors ~status:`OK request reqd
+                    (Yojson.Safe.to_string payload)
+              | Error "binding not found" ->
+                  respond_json_with_cors ~status:`Not_found request reqd
+                    (Yojson.Safe.to_string
+                       (Channel_gate.error_json "binding not found"))
+              | Error err ->
+                  respond_json_with_cors ~status:`Internal_server_error request
+                    reqd
+                    (Yojson.Safe.to_string (Channel_gate.error_json err))
+          with Yojson.Json_error _ ->
+            respond_json_with_cors ~status:`Bad_request request reqd
+              (Yojson.Safe.to_string (Channel_gate.error_json "invalid json")))
 
 (** Register all gate routes on the router. *)
 let add_routes ~sw ~clock router =
@@ -504,12 +639,13 @@ let add_routes ~sw ~clock router =
          handle_gate_discord_unbind ~sw ~clock state request reqd
        ) request reqd)
 
+  (* Generic connector routes — dispatch by ?name=<connector> *)
   |> Http.Router.post "/api/v1/gate/connector/bind" (fun request reqd ->
        with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
          handle_gate_connector_bind ~sw ~clock state request reqd
        ) request reqd)
 
   |> Http.Router.post "/api/v1/gate/connector/unbind" (fun request reqd ->
-       with_tool_auth ~tool_name:"channel_gate" (fun state _req reqd ->
-         handle_gate_connector_unbind ~sw ~clock state request reqd
+       with_tool_auth ~tool_name:"channel_gate" (fun _state _req reqd ->
+         handle_gate_connector_unbind _state request reqd
        ) request reqd)

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -136,7 +136,8 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
               ] );
         ]
     in
-    let json = Discord_state.connectors_json ~gate_status_json () in
+    Masc_mcp.Channel_gate_connector.register (module Discord_state);
+    let json = Masc_mcp.Channel_gate_connector.connectors_json ~gate_status_json () in
     let connectors = json |> U.member "connectors" |> U.to_list in
     check int "one connector" 1 (List.length connectors);
     let connector = List.hd connectors in


### PR DESCRIPTION
## Summary
- `Channel_gate_connector` 모듈 타입(`S`) + 이름 기반 registry 추가. OAS-MASC 경계 패턴 적용 — 인터페이스는 특정 커넥터를 모름.
- Generic route 추가: `/api/v1/gate/connector/{status,bind,unbind}?name=<connector_id>`
- Dashboard bind/unbind가 connector id 기반으로 dispatch (Discord 하드코딩 제거)
- Discord 전용 route는 backward compat으로 유지
- `connectors_json`을 discord_state에서 registry로 이관 (모든 등록된 커넥터 집계)

## 변경 파일
| 파일 | 변경 |
|------|------|
| `lib/channel_gate_connector.{ml,mli}` | 새 파일 — module type `S`, registry |
| `lib/channel_gate_discord_state.ml` | `S` 인터페이스 만족, `connectors_json` 제거 |
| `lib/server/server_routes_http_routes_channel_gate.ml` | generic connector route 추가 |
| `lib/server/server_auth.ml` | `/connector/status` public read 추가 |
| `lib/server/server_routes_http.ml` | startup 시 Discord 등록 |
| `dashboard/src/components/connector-status.ts` | `bindConnector`/`unbindConnector` generic 전환 |
| `test/test_channel_gate_discord_state.ml` | registry 경유 테스트 |

## 새 커넥터 추가 방법
1. `Channel_gate_connector.S`를 만족하는 모듈 작성
2. `server_routes_http.ml`의 `make_routes`에서 `Channel_gate_connector.register` 호출
3. generic route가 자동으로 작동

## Test plan
- [x] `dune build` green (no compilation errors)
- [x] `tsc --noEmit` green (dashboard type check)
- [x] 기존 테스트 통과 (`test_channel_gate_discord_state`, `test_ci_hardening_source`)
- [ ] 수동: dashboard에서 bind/unbind 동작 확인
- [ ] 수동: `/api/v1/gate/connector/status?name=discord` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)