### PR TITLE
fix(keeper): resolve timeout-reconcile deadlock for board mutations

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -268,13 +268,30 @@ module KeeperKeepalive = struct
       When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
       Otherwise, {!oas_timeout_for_context} computes an adaptive timeout
       based on max_context tokens: base 180s + 1.5s per 1K context tokens,
-      capped at [30, 600].
+      capped at [30, turn_timeout_sec].
 
-      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive. Range: [30, 600]. *)
+      The formula includes both context-proportional overhead and a
+      per-turn budget.  extend_turns (ceiling=200) lets keepers run
+      20+ turns per OAS call; the previous formula (180 + ctx/1K × 1.5,
+      cap 600) yielded 573s at 262K context — right at the edge where
+      20-turn sessions would timeout, triggering manual_reconcile on
+      committed board mutations.
+
+      The new formula:
+        base + ctx/1K × per_1k + min(max_turns × 4, 40) × per_turn
+      adds an explicit turn budget with 4× headroom for extend_turns,
+      capped at 40 effective turns.
+
+      At 262K context, 5 initial turns:
+        Old: 180 + 393 = 573s  →  20-turn sessions timeout
+        New: 120 + 393 + 600 = 1113s  →  30+ turns fit comfortably
+
+      Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive.
+      Range: [30, turn_timeout_sec]. *)
   let oas_timeout_sec_override =
     match Sys.getenv_opt "MASC_KEEPER_OAS_TIMEOUT_SEC" with
     | Some raw ->
-      Some (Float.max 30.0 (Float.min 600.0
+      Some (Float.max 30.0 (Float.min turn_timeout_sec
         (Option.value ~default:300.0 (Float.of_string_opt (String.trim raw)))))
     | None -> None
 
@@ -282,10 +299,19 @@ module KeeperKeepalive = struct
     match oas_timeout_sec_override with
     | Some v -> v
     | None ->
-      let base = 180.0 in
+      let base = 120.0 in
       let per_1k = 1.5 in
-      let extra = Float.of_int max_context /. 1000.0 *. per_1k in
-      Float.max 30.0 (Float.min 600.0 (base +. extra))
+      let per_turn = 30.0 in
+      let context_time = Float.of_int max_context /. 1000.0 *. per_1k in
+      let max_turns_per_call =
+        max 1 (min 50 (get_int ~default:5 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
+      in
+      let effective_turns =
+        Float.of_int (min (max_turns_per_call * 4) 40)
+      in
+      let turn_time = effective_turns *. per_turn in
+      Float.max 30.0
+        (Float.min turn_timeout_sec (base +. context_time +. turn_time))
 
   (** Backward-compatible accessor: returns the env override or 300s default.
       Prefer {!oas_timeout_for_context} when max_context is available. *)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -118,6 +118,29 @@ let is_effectively_read_only_tool (name : string) : bool =
 let has_mutating_side_effect (name : string) : bool =
   not (is_effectively_read_only_tool name)
 
+(* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)
+
+(** Tools that produce side effects but are safe to leave un-reconciled
+    after a timeout.  Board mutations (post, comment, vote) may create
+    duplicates on retry, but a duplicate post is harmless compared to
+    a permanently stuck keeper.  When ALL committed tools in a failed
+    turn belong to this set, manual_reconcile is skipped. *)
+let reconcile_safe_tools =
+  [ "keeper_board_post"; "keeper_board_comment";
+    "keeper_board_vote"; "keeper_board_comment_vote";
+    "keeper_board_list"; "keeper_board_get" ]
+
+let reconcile_safe_set : (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create (List.length reconcile_safe_tools) in
+  List.iter (fun name -> Hashtbl.replace tbl name ()) reconcile_safe_tools;
+  tbl
+
+let is_reconcile_safe_tool (name : string) : bool =
+  Hashtbl.mem reconcile_safe_set name
+
+let all_tools_reconcile_safe (names : string list) : bool =
+  names <> [] && List.for_all is_reconcile_safe_tool names
+
 (* ── Boring tools (non-productive observation/polling) ─────── *)
 
 (** Tools that gather status but produce no side effects.

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -121,14 +121,18 @@ let has_mutating_side_effect (name : string) : bool =
 (* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)
 
 (** Tools that produce side effects but are safe to leave un-reconciled
-    after a timeout.  Board mutations (post, comment, vote) may create
-    duplicates on retry, but a duplicate post is harmless compared to
-    a permanently stuck keeper.  When ALL committed tools in a failed
-    turn belong to this set, manual_reconcile is skipped. *)
+    after a transient failure or timeout.  Board mutations (post, comment,
+    vote) are not strictly idempotent — retries may create duplicate
+    content — but duplicate posts are an acceptable cost vs. a permanently
+    stuck keeper.  When ALL committed tools in a failed turn belong to
+    this set AND the failure is transient, manual_reconcile is skipped.
+
+    Read-only tools (board_list, board_get) are excluded: they never
+    appear in [committed_mutating_tools] so including them here would
+    be misleading dead entries. *)
 let reconcile_safe_tools =
   [ "keeper_board_post"; "keeper_board_comment";
-    "keeper_board_vote"; "keeper_board_comment_vote";
-    "keeper_board_list"; "keeper_board_get" ]
+    "keeper_board_vote"; "keeper_board_comment_vote" ]
 
 let reconcile_safe_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length reconcile_safe_tools) in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1087,14 +1087,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 if committed_tools <> []
                    && Keeper_tool_registry.all_tools_reconcile_safe
                         committed_tools
+                   && is_transient_network_error err
                 then begin
-                  (* All committed tools are board-like (idempotent enough).
-                     Duplicate mutations are harmless vs. a permanently stuck
-                     keeper, so we skip manual_reconcile and propagate as a
-                     normal transient error. *)
+                  (* All committed tools are board-like (duplicate-tolerant)
+                     AND the failure is transient.  Permanent errors (401, 403,
+                     malformed request) must NOT bypass — they would loop
+                     forever on retry.  Duplicate board posts are an acceptable
+                     cost vs. a permanently stuck keeper. *)
                   let err_preview = short_preview (Oas.Error.to_string err) in
                   Log.Keeper.warn
-                    "%s: error after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (error: %s)"
+                    "%s: transient error after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (error: %s)"
                     meta.name
                     (String.concat ", " committed_tools)
                     err_preview;
@@ -1197,10 +1199,17 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                && Keeper_tool_registry.all_tools_reconcile_safe
                     committed_tools
             then begin
+              (* Timeouts are inherently transient — the provider was
+                 reachable (tools executed) but took too long.  Board-only
+                 committed tools are duplicate-tolerant, so we skip
+                 manual_reconcile.  Unlike the retry_loop path, no
+                 is_transient check is needed: a wall-clock timeout after
+                 successful tool execution is always transient by nature. *)
               Log.Keeper.warn
-                "%s: turn wall-clock timeout after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile"
+                "%s: turn wall-clock timeout after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (timeout: %s)"
                 meta.name
-                (String.concat ", " committed_tools);
+                (String.concat ", " committed_tools)
+                msg;
               Error (Oas.Error.Api (Timeout { message = msg }))
             end else if committed_tools <> [] then begin
               let timeout_err =

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1084,7 +1084,22 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 let committed_tools =
                   committed_mutating_tools !mutating_tools_committed
                 in
-                if committed_tools <> [] then begin
+                if committed_tools <> []
+                   && Keeper_tool_registry.all_tools_reconcile_safe
+                        committed_tools
+                then begin
+                  (* All committed tools are board-like (idempotent enough).
+                     Duplicate mutations are harmless vs. a permanently stuck
+                     keeper, so we skip manual_reconcile and propagate as a
+                     normal transient error. *)
+                  let err_preview = short_preview (Oas.Error.to_string err) in
+                  Log.Keeper.warn
+                    "%s: error after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (error: %s)"
+                    meta.name
+                    (String.concat ", " committed_tools)
+                    err_preview;
+                  Error err
+                end else if committed_tools <> [] then begin
                   let reclassified, failure_reason =
                     match
                       classify_post_commit_failure
@@ -1178,7 +1193,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             let committed_tools =
               committed_mutating_tools !mutating_tools_committed
             in
-            if committed_tools <> [] then begin
+            if committed_tools <> []
+               && Keeper_tool_registry.all_tools_reconcile_safe
+                    committed_tools
+            then begin
+              Log.Keeper.warn
+                "%s: turn wall-clock timeout after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile"
+                meta.name
+                (String.concat ", " committed_tools);
+              Error (Oas.Error.Api (Timeout { message = msg }))
+            end else if committed_tools <> [] then begin
               let timeout_err =
                 Oas.Error.Api (Timeout { message = msg })
               in


### PR DESCRIPTION
## Summary

- OAS per-call timeout cap을 600s → `turn_timeout_sec`(1200s)로 변경하여 extend_turns와의 설계 충돌 해소
- Board 계열 도구(post/comment/vote)를 `reconcile_safe_tools`로 분류하여 timeout 후 자동 복구
- 두 곳의 post-commit failure path(retry_loop + timeout handler)에 reconcile-safe 경로 추가

## Problem

Keeper가 board_post 호출 후 573.2초 OAS timeout에 걸리면 `manual_reconcile_required` 상태에 진입하고, 이후 모든 turn이 차단되어 heartbeat만 가능한 상태가 됨. 모든 keeper가 동일 패턴으로 stuck.

**Root cause**: `oas_timeout_for_context(262K)` = 573.2s (cap 600s)인데, `extend_turns`(ceiling=200)로 20+ 턴 확장 가능. 시간 예산과 턴 예산이 서로를 모르는 구조적 버그.

## Changes

| 파일 | 변경 |
|------|------|
| `lib/config/env_config_keeper.ml` | `oas_timeout` cap: 600s → `turn_timeout_sec` |
| `lib/keeper/keeper_tool_registry.ml` | `reconcile_safe_tools` 분류 + `all_tools_reconcile_safe` 함수 추가 |
| `lib/keeper/keeper_unified_turn.ml` | retry_loop + timeout handler에 reconcile-safe 자동 복구 경로 |

## Test plan

- [x] `dune build` 성공
- [x] `dune runtest` — 기존 실패만 (keeper_tool_matrix pre-existing, 변경 무관)
- [ ] MASC 서버 재시작 후 keeper board activity 관찰
- [ ] manual_reconcile_required 발생 빈도 모니터링 (목표: board-only timeout에서 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)