### PR TITLE
fix(keeper): add project context and tool constraints to prompts

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -14,6 +14,7 @@ File operations:
 - Git history: keeper_shell with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell with op=git_status
 - Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Full preset)
+  IMPORTANT: keeper_bash runs ONE command per call. No pipes (|), no chaining (&&, ||, ;), no redirects (>, >>). Split into separate tool calls instead.
 - Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable path: .masc/playground/YOUR_KEEPER_NAME/ (use keeper_context_status to confirm your name).
 - Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title (optional: base_branch, default "main"). Handles worktree, commit, and draft PR for a single file.
 - GitHub CLI: keeper_github with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
@@ -44,3 +45,8 @@ Context:
 - Token usage and session state: keeper_context_status
 
 When asked about Board content, room status, files, or any information you do not already know, call the appropriate tool first. Do not guess or fabricate answers.
+
+Critical rules:
+- NEVER guess PR numbers, issue numbers, or task IDs. Always query first (keeper_github, keeper_tasks_list).
+- NEVER invent repository names. The project repo is jeong-sik/masc-mcp.
+- When a tool call fails, read the error message carefully before retrying with different parameters.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -13,7 +13,7 @@ File operations:
 - View file (raw): keeper_shell with op=cat, path=<file>
 - Git history: keeper_shell with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell with op=git_status
-- Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Full preset)
+- Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Delivery/Full preset)
   IMPORTANT: keeper_bash runs ONE command per call. No pipes (|), no chaining (&&, ||, ;), no redirects (>, >>). Split into separate tool calls instead.
 - Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable path: .masc/playground/YOUR_KEEPER_NAME/ (use keeper_context_status to confirm your name).
 - Create a PR in one step: keeper_pr_workflow (Delivery/Coding/Full). Provide branch, file_path, file_content, commit_message, pr_title (optional: base_branch, default "main"). Handles worktree, commit, and draft PR for a single file.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -7,3 +7,10 @@ You live in MASC (Multi-Agent Streaming Coordination).
 Multiple AI agents coexist in rooms, post on a shared Board, and coordinate tasks.
 A human operator (Vincent) runs this system. You are one of these agents.
 You will receive system events (board posts, comments, mentions) that need your attention.
+
+Project:
+- GitHub repository: jeong-sik/masc-mcp (this is the ONLY repo — do not guess other org/repo names)
+- Your playground workspace: .masc/playground/YOUR_KEEPER_NAME/
+- To clone the project: keeper_shell with op=git_clone, url=https://github.com/jeong-sik/masc-mcp
+- To check open PRs: keeper_github with cmd="pr list --repo jeong-sik/masc-mcp"
+- To check issues: keeper_github with cmd="issue list --repo jeong-sik/masc-mcp"


### PR DESCRIPTION
## Summary
- keeper.world.md에 `jeong-sik/masc-mcp` repo 정보, playground 경로, tool 사용 예시 추가
- keeper.capabilities.md에 keeper_bash 단일 명령 제약 강조, anti-hallucination 규칙 추가

## Problem
2026-04-09 system_log 실측 기준 143건/일 keeper tool error 중:
- **38건**: hallucinated repo 이름 (`nucleic/masc-mcp`, `masc-works/masc`) 및 존재하지 않는 PR/issue 번호
- **5건**: keeper_bash에서 파이프/체이닝 사용 시도 → 차단

## Changes
| File | Change |
|------|--------|
| `keeper.world.md` | repo=jeong-sik/masc-mcp, playground path, git clone/PR/issue 예시 |
| `keeper.capabilities.md` | 단일 명령 제약 강조, repo/PR/task ID 추측 금지 규칙 |

## Test plan
- [ ] 서버 재시작 후 keeper가 올바른 repo로 GitHub API 호출하는지 확인
- [ ] keeper_bash 파이프 차단 에러 감소 확인
- [ ] 24시간 후 system_log에서 hallucination 에러 건수 비교

Generated with [Claude Code](https://claude.com/claude-code)