### PR TITLE
fix(keeper): auto-clear manual_reconcile + turn decision debug log

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -555,9 +555,9 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
     in
     if sticky_manual_reconcile then
       Log.Keeper.warn
-        "heartbeat recovery: preserving %d turn failures for %s because manual reconcile is still required"
-        stale_turn_failures meta.name
-    else begin
+        "heartbeat recovery: auto-clearing %d turn failures for %s (manual reconcile auto-resolved after heartbeat)"
+        stale_turn_failures meta.name;
+    begin
       Keeper_registry.reset_turn_failures
         ~base_path:ctx.config.base_path meta.name;
       ignore (Keeper_registry.dispatch_event
@@ -737,6 +737,19 @@ let run_keepalive_unified_turn
            | Keeper_world_observation.Reactive -> "reactive"
            | Keeper_world_observation.Scheduled_autonomous -> "scheduled_autonomous")
           (String.concat "," turn_decision.reasons);
+      if (not should_run_turn) && (not manual_reconcile_pending) then
+        Log.Keeper.info
+          "keepalive turn not scheduled for %s: should_run=%b channel=%s reasons=[%s] since_last=%s idle_gate=%s"
+          meta_after_triage.name
+          turn_decision.should_run
+          (match turn_decision.channel with
+           | Keeper_world_observation.Reactive -> "reactive"
+           | Keeper_world_observation.Scheduled_autonomous -> "scheduled_autonomous")
+          (String.concat "," turn_decision.reasons)
+          (match turn_decision.since_last_scheduled_autonomous with
+           | Some s -> string_of_int s | None -> "-")
+          (match turn_decision.idle_gate_sec with
+           | Some s -> string_of_int s | None -> "-");
       if should_run_turn then
         Log.Keeper.info
           "keepalive turn scheduled for %s: channel=%s reasons=%s"

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -553,10 +553,19 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
            | None -> false)
       | None -> false
     in
-    if sticky_manual_reconcile then
+    if sticky_manual_reconcile then begin
+      let reason_str =
+        match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
+        | Some entry ->
+            (match entry.last_failure_reason with
+             | Some reason -> Keeper_registry.failure_reason_to_string reason
+             | None -> "none")
+        | None -> "no_entry"
+      in
       Log.Keeper.warn
-        "heartbeat recovery: auto-clearing %d turn failures for %s (manual reconcile auto-resolved after heartbeat)"
-        stale_turn_failures meta.name;
+        "heartbeat recovery: auto-clearing %d turn failures for %s (reason=%s). Cursors already advanced — re-trigger risk is low."
+        stale_turn_failures meta.name reason_str
+    end;
     begin
       Keeper_registry.reset_turn_failures
         ~base_path:ctx.config.base_path meta.name;


### PR DESCRIPTION
## Summary

- Failing phase keeper가 영구 stuck되던 문제 수정: heartbeat recovery에서 `manual_reconcile` 자동 해소
- Running phase keeper의 턴 미실행 원인 추적을 위한 debug 로그 추가

## Product impact

Keeper가 573s timeout 후 Failing phase에 빠지면 서버 재시작 없이는 복구 불가능했음.
이 수정으로 heartbeat recovery가 자동으로 Failing → Running 전환하여 keeper가 다음 턴을 실행할 수 있게 됨.

## Evidence

- Board cursor: `collect_board_events`에서 턴 전 advance (`keeper_world_observation.ml:535-551`)
- Message cursor: `apply_message_cursor_updates`로 턴 전 persist (`keeper_keepalive.ml:748-755`)
- Task claim: same-agent idempotent (`room_task.ml:474` → `Already_mine`)
- 기존 `reconcile_safe` 자동복구 경로 존재 (`keeper_unified_turn.ml:1087`)
- Trigger event cursor가 턴 전에 소비되므로 recovery 후 중복 mutation 위험 낮음

## Review evidence

- `test_work_as_heartbeat.exe` 42 tests pass
- `dune build --root .` success
- 코드 경로 분석으로 cursor advance timing 확인 완료

## Linked issue

Closes #6210, Relates-to #6186

## Test plan

- [x] `test_work_as_heartbeat.exe` 42 tests pass
- [ ] 서버 재시작 후 Failing keeper 자동 복구 확인
- [ ] debug 로그로 Running keeper turn decision 원인 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)