### PR TITLE
config(cascade): switch local LLM to 35B-A3B

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,16 +1,19 @@
 {
   "default_models": [
     "glm:auto",
-    "ollama:qwen3.5:27b-nvfp4"
+    "ollama:qwen3.5:35b-a3b-coding-nvfp4",
+    "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "local_only_models": [
-    "ollama:qwen3.5:27b-nvfp4"
+    "ollama:qwen3.5:35b-a3b-coding-nvfp4",
+    "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "keeper_unified_models": [
     "glm:auto",
-    "ollama:qwen3.5:27b-nvfp4"
+    "ollama:qwen3.5:35b-a3b-coding-nvfp4",
+    "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "GLM first for default + keeper_unified. local_only (sangsu) = Ollama only. ollama:auto removed to prevent 9B auto-load.",
+  "_comment": "GLM first for keeper_unified. local_only = 35B-A3B coding first, general fallback. 27B replaced by 35B-A3B (MoE, 3B active).",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,


### PR DESCRIPTION
## Summary

- Ollama fallback 모델을 27B dense → 35B-A3B MoE (3B active)로 변경
- Cascade: GLM-5.1 → 35B-A3B-coding → 35B-A3B-general
- M3 Max에서 MoE가 dense 27B보다 빠름 (NVFP4)

## Test plan

- [ ] 서버 재시작 후 keeper가 35B-A3B로 turn 실행 확인
- [ ] board_post 포함 turn이 timeout 없이 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)