### PR TITLE
[codex] Clarify keeper identity and status surfaces

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -409,13 +409,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             </div>
 
             <label class="flex w-full max-w-[320px] flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
-              <span>에이전트 이름으로 찾기</span>
+              <span>키퍼/런타임 이름으로 찾기</span>
               <${TextInput}
                 class="rounded-2xl bg-[var(--white-3)] px-4 py-3 text-[14px] text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
                 name="agent_search"
-                ariaLabel="에이전트 이름 검색"
+                ariaLabel="키퍼 또는 런타임 이름 검색"
                 autoComplete="off"
-                placeholder="에이전트 이름으로 찾기"
+                placeholder="키퍼 또는 런타임 이름으로 찾기"
                 value=${search}
                 onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
               />

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -23,6 +23,11 @@ import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
+import {
+  keeperIdentitySearchTerms,
+  keeperPrimaryName,
+  runtimeAgentName,
+} from './common/keeper-identity'
 import { AgentAvatar } from './overview/agent-avatar'
 import { openAgentDetail } from './agent-detail'
 import { openKeeperDetail } from './keeper-detail'
@@ -53,6 +58,8 @@ function runtimeBadgeClass(band: RuntimeBand): string {
 }
 
 interface KeeperInfo {
+  name?: string
+  agent_name?: string | null
   generation?: number | null
   context_ratio?: number | null
   model?: string | null
@@ -119,7 +126,7 @@ const FILTER_META: Record<StatusFilter, { label: string; description: string }> 
   },
   attention: {
     label: '주의 필요',
-    description: '오류, 복구, 승계, stale heartbeat, blocker 등 운영 확인이 필요한 상태입니다.',
+    description: '응답 지연, 오류, 복구, 승계 등으로 상태 확인이 필요한 항목입니다.',
   },
   paused: {
     label: '일시정지',
@@ -305,20 +312,29 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     scopedAgents.map(agent => [agent.name, runtimeBandMetaForAgent(agent, findKeeperRuntime(agent.name, keeperList))] as const),
   )
   const pageTitle = keeperFilter === 'keeper-only'
-    ? '키퍼 런타임'
+    ? '키퍼 목록'
     : keeperFilter === 'agent-only'
       ? '일반 에이전트'
-      : '통합 런타임 목록'
+      : '에이전트 & 키퍼 목록'
   const pageDescription = keeperFilter === 'keeper-only'
-    ? '키퍼 런타임만 따로 봅니다.'
+    ? '키퍼만 따로 보고, 런타임 이름은 보조 정보로 확인합니다.'
     : keeperFilter === 'agent-only'
       ? '키퍼가 연결되지 않은 일반 에이전트만 봅니다.'
-      : '에이전트와 키퍼를 한 목록에서 봅니다.'
+      : '에이전트와 키퍼를 한 목록에서 보고, 운영 상태는 배지로 구분합니다.'
 
   const filtered = scopedAgents
     .filter((a: Agent) => {
       if (filter !== 'all' && bandByAgent.get(a.name)?.key !== filter) return false
-      if (search && !a.name.toLowerCase().includes(search.toLowerCase())) return false
+      if (search) {
+        const keeper = findKeeper(a.name, keeperList, keeperBriefs)
+        const terms = keeperIdentitySearchTerms(
+          keeper?.name ?? null,
+          keeper?.agent_name ?? a.name,
+        )
+        if (!terms.some(term => term.toLowerCase().includes(search.toLowerCase()))) {
+          return false
+        }
+      }
       return true
     })
     .sort((a: Agent, b: Agent) => {
@@ -365,19 +381,19 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     ? `키퍼 ${expectedScopedCount}개`
     : keeperFilter === 'agent-only'
       ? `일반 에이전트 ${expectedScopedCount}개`
-      : `런타임 ${expectedScopedCount}개`
+      : `에이전트/키퍼 ${expectedScopedCount}개`
   const fallbackStateTitle =
     executionError.value
-      ? 'execution 상세 불러오기 실패'
+      ? '상세 상태 불러오기 실패'
       : executionLoaded.value
-        ? '상세 runtime 부분 동기화'
-        : '상세 runtime 동기화 중'
+        ? '상세 상태 부분 동기화'
+        : '상세 상태 동기화 중'
   const fallbackStateMessage =
     executionError.value
-      ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있지만 execution 상세 projection을 아직 가져오지 못했습니다.`
+      ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있지만 상세 상태 정보를 아직 가져오지 못했습니다.`
       : executionLoaded.value
         ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있고 일부만 상세 목록에 반영됐습니다.`
-        : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다. execution 상세 projection이 올라오면 상태별 분류와 카드가 채워집니다.`
+        : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다. 상세 상태 정보가 올라오면 상태별 분류와 카드가 채워집니다.`
 
   return html`
     <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
@@ -410,7 +426,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div class="flex flex-col gap-1">
                 <div class="text-[11px] font-semibold tracking-[0.08em] text-[var(--text-strong)] uppercase">운영 상태</div>
-                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 phase와 현재 활동 근거를 확인합니다.</p>
+                <p class="m-0 text-[12px] leading-[1.5] text-[var(--text-muted)]">먼저 운영 상태로 걸러 보고, 필요할 때만 세부 상태와 최근 근거를 확인합니다.</p>
               </div>
               <${FilterChips}
                 chips=${statusChips}
@@ -494,9 +510,18 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             ?? keeper?.tool_audit_at
             ?? keeperRuntime?.tool_audit_at
             ?? null
+          const displayName =
+            keeperPrimaryName(
+              keeperRuntime?.name ?? keeper?.name ?? null,
+              keeperRuntime?.agent_name ?? keeper?.agent_name ?? agent.name,
+            )
+            ?? agent.name
+          const runtimeName = isKeeper
+            ? runtimeAgentName(displayName, keeperRuntime?.agent_name ?? keeper?.agent_name ?? agent.name)
+            : null
           const model = keeperRuntime?.model ?? keeper?.model
           const generation = keeperRuntime?.generation ?? keeper?.generation ?? null
-          const detailLabel = keeperRuntime ? `${agent.name} keeper 상세 보기` : `${agent.name} 상세 보기`
+          const detailLabel = keeperRuntime ? `${displayName} keeper 상세 보기` : `${displayName} 상세 보기`
           const openDetail = () => {
             if (keeperRuntime) {
               openKeeperDetail(keeperRuntime)
@@ -525,11 +550,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                 </div>
                 
                 <div class="flex flex-col min-w-0 flex-1 justify-center py-1">
-                  <strong class="mb-2 min-w-0 overflow-hidden text-[17px] text-[var(--text-strong)] font-semibold leading-[1.3] group-hover:text-[var(--accent)] transition-colors [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${agent.name}</strong>
+                  <strong class="mb-2 min-w-0 overflow-hidden text-[17px] text-[var(--text-strong)] font-semibold leading-[1.3] group-hover:text-[var(--accent)] transition-colors [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${displayName}</strong>
                   
                   <div class="flex items-center gap-1.5 flex-wrap mt-1">
                     <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
-                    <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼 런타임' : '일반 에이전트'}</span>
+                    <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼' : '일반 에이전트'}</span>
+                    ${runtimeName ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${runtimeName}</span>` : null}
                     ${agent.synthetic ? html`<span class="text-[10px] text-[var(--text-muted)] bg-[var(--white-6)] border border-dashed border-[var(--card-border)] px-1.5 py-px rounded italic" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">파생</span>` : null}
                     ${monitoringEvidence?.phase && keeperRuntime ? html`<${KeeperPhaseBadge} phase=${keeperPhaseForDisplay(keeperRuntime)} compact />` : null}
                     ${monitoringEvidence?.stage ? html`<span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]" title=${monitoringEvidence.stage.description}>활동 ${monitoringEvidence.stage.label}</span>` : null}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -22,7 +22,7 @@ const activeView = signal<AgentsView>('all')
 const CHIPS: { id: AgentsView; label: string; description: string }[] = [
   { id: 'all', label: '전체 보기', description: '에이전트와 키퍼를 한 목록에서 봅니다.' },
   { id: 'agents', label: '일반 에이전트', description: '키퍼가 연결되지 않은 일반 에이전트만 봅니다.' },
-  { id: 'keepers', label: '키퍼 런타임', description: '키퍼 런타임만 따로 봅니다.' },
+  { id: 'keepers', label: '키퍼', description: '키퍼만 따로 봅니다.' },
 ]
 
 export function AgentsUnified() {
@@ -57,25 +57,12 @@ export function AgentsUnified() {
   const totalCount = runtimeCounts.totalRuntimes
   const keeperCount = runtimeCounts.keepers
   const agentOnlyCount = runtimeCounts.agents
-  const currentViewMeta = CHIPS.find(chip => chip.id === currentView) ?? {
-    id: 'all' as const,
-    label: '전체 보기',
-    description: '에이전트와 키퍼를 한 목록에서 봅니다.',
-  }
-
   function chipCount(id: AgentsView): number | null {
     if (id === 'all') return totalCount
     if (id === 'agents') return agentOnlyCount
     if (id === 'keepers') return keeperCount
     return null
   }
-
-  const currentViewSummary =
-    currentView === 'all'
-      ? `일반 에이전트 ${agentOnlyCount}개와 키퍼 런타임 ${keeperCount}개를 한 목록에서 봅니다.`
-      : currentView === 'agents'
-        ? `일반 에이전트 ${agentOnlyCount}개만 표시합니다.`
-        : `키퍼 런타임 ${keeperCount}개만 표시합니다.`
   const viewChips = CHIPS.map(chip => ({
     key: chip.id,
     label: chip.label,
@@ -95,10 +82,6 @@ export function AgentsUnified() {
         tone="accent"
         class="monitor-muted-panel w-fit p-1.5 shadow-[inset_0_1px_0_var(--white-3)]"
       />
-      <div class="monitor-muted-panel bg-[linear-gradient(180deg,var(--accent-soft),var(--white-2))] px-4 py-3 text-[12px] leading-[1.5] text-[var(--text-body)]">
-        <strong class="mr-2 text-[var(--text-strong)]">${currentViewMeta.label}</strong>
-        <span>${currentViewSummary}</span>
-      </div>
 
       ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
 

--- a/dashboard/src/components/common/keeper-identity.test.ts
+++ b/dashboard/src/components/common/keeper-identity.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  keeperIdentitySearchTerms,
+  keeperPrimaryName,
+  runtimeAgentName,
+} from './keeper-identity'
+
+describe('keeper identity helpers', () => {
+  it('prefers keeper name as the primary identity', () => {
+    expect(keeperPrimaryName('sangsu', 'keeper-sangsu-agent')).toBe('sangsu')
+  })
+
+  it('keeps runtime name as secondary identity when it differs', () => {
+    expect(runtimeAgentName('sangsu', 'keeper-sangsu-agent')).toBe('keeper-sangsu-agent')
+  })
+
+  it('returns both keeper and runtime names for search matching', () => {
+    expect(keeperIdentitySearchTerms('sangsu', 'keeper-sangsu-agent')).toEqual([
+      'sangsu',
+      'keeper-sangsu-agent',
+    ])
+  })
+})

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -9,6 +9,25 @@ export function runtimeAgentName(
   return agent === keeper ? null : agent
 }
 
+export function keeperPrimaryName(
+  keeperName: string | null | undefined,
+  agentName: string | null | undefined,
+): string | null {
+  const keeper = keeperName?.trim()
+  if (keeper) return keeper
+  const agent = agentName?.trim()
+  return agent || null
+}
+
+export function keeperIdentitySearchTerms(
+  keeperName: string | null | undefined,
+  agentName: string | null | undefined,
+): string[] {
+  const primary = keeperPrimaryName(keeperName, agentName)
+  const runtime = runtimeAgentName(keeperName, agentName)
+  return [primary, runtime].filter((value): value is string => Boolean(value))
+}
+
 export function keeperRuntimeLabel(
   keeperName: string | null | undefined,
   agentName: string | null | undefined,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -305,11 +305,11 @@ function SurfaceLead() {
   const description = currentSection?.description ?? currentView?.description ?? null
 
   return html`
-    <div class="mb-3 flex flex-wrap items-baseline justify-between gap-2">
-      <h2 class="flex items-center gap-2 text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
+    <div class="mb-3 flex flex-col gap-1.5">
+      <h2 class="text-[22px] font-bold tracking-tight text-[var(--text-strong)]">
         ${currentSection?.label ?? currentView?.label ?? '홈'}
-        ${description ? html`<span class="text-[13px] font-normal text-[var(--text-dim)] truncate min-w-0">${description}</span>` : null}
       </h2>
+      ${description ? html`<p class="m-0 text-[13px] leading-[1.5] text-[var(--text-dim)]">${description}</p>` : null}
     </div>
   `
 }

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -123,7 +123,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'agents',
       label: '에이전트 & 키퍼',
-      description: '통합 런타임 상태.',
+      description: '이름과 운영 상태를 함께 봅니다.',
       params: { section: 'agents' },
     },
     {

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -68,14 +68,14 @@ const OFFLINE_STAGE_META: StageMeta = {
 const PHASE_LABELS: Record<string, PhaseMeta> = {
   Offline: { key: 'Offline', label: '오프라인', description: '런타임이 올라오지 않았거나 연결 정보가 없습니다.' },
   Running: { key: 'Running', label: '실행중', description: 'keeper_state_machine 기준으로 정상 실행 상태입니다.' },
-  Failing: { key: 'Failing', label: '오류중', description: '최근 턴 또는 heartbeat/reconcile 과정에서 실패를 감지했습니다.' },
-  Compacting: { key: 'Compacting', label: '압축중', description: '컨텍스트 정리를 위해 compaction을 수행 중입니다.' },
-  HandingOff: { key: 'HandingOff', label: '승계중', description: '새 세대로 handoff를 진행하고 있습니다.' },
-  Draining: { key: 'Draining', label: '종료중', description: '현재 턴을 비우고 정지 상태로 이동하는 중입니다.' },
+  Failing: { key: 'Failing', label: '오류중', description: '최근 실행에서 오류를 감지했습니다.' },
+  Compacting: { key: 'Compacting', label: '압축중', description: '컨텍스트를 정리하는 중입니다.' },
+  HandingOff: { key: 'HandingOff', label: '승계중', description: '새 세대로 넘기는 중입니다.' },
+  Draining: { key: 'Draining', label: '종료중', description: '현재 작업을 마무리하는 중입니다.' },
   Paused: { key: 'Paused', label: '일시정지', description: '운영자가 keeper를 일시정지했습니다.' },
   Stopped: { key: 'Stopped', label: '정지', description: '정상 정지된 런타임입니다.' },
   Crashed: { key: 'Crashed', label: '비정상종료', description: 'fiber가 비정상적으로 종료되었습니다.' },
-  Restarting: { key: 'Restarting', label: '재시작중', description: 'supervisor가 복구를 시도하고 있습니다.' },
+  Restarting: { key: 'Restarting', label: '재시작중', description: '복구를 시도하고 있습니다.' },
   Dead: { key: 'Dead', label: '종료', description: '재시도 budget이 소진된 종료 상태입니다.' },
   active: { key: 'active', label: '실행중', description: '프로세스는 살아 있지만 state projection이 부족합니다.' },
   busy: { key: 'busy', label: '작업중', description: '프로세스는 살아 있고 현재 작업을 수행 중입니다.' },
@@ -128,7 +128,7 @@ const BAND_META: Record<RuntimeBand, RuntimeBandMeta> = {
   attention: {
     key: 'attention',
     label: '주의 필요',
-    description: '실패, 복구, 승계, 드레이닝, blocker, stale heartbeat 등으로 확인이 필요한 상태입니다.',
+    description: '응답 지연, 오류, 복구, 승계 등으로 상태 확인이 필요합니다.',
   },
   paused: {
     key: 'paused',
@@ -206,9 +206,9 @@ function runtimeBlockerHint(keeper: Keeper): string | null {
   if (!blockerClass) return null
   if (keeper.runtime_blocker_summary?.trim()) return keeper.runtime_blocker_summary.trim()
   if (blockerClass === 'ambiguous_post_commit_timeout') {
-    return '변경 도구 실행 뒤 턴이 timeout으로 끝났습니다. 중복 실행을 막기 위해 재시도하지 않았고 수동 정합성 확인이 필요합니다.'
+    return '최근 변경 이후 응답이 끊겨 상태 확인이 필요합니다.'
   }
-  return '변경 도구 실행 뒤 턴이 실패했습니다. 중복 실행을 막기 위해 재시도하지 않았고 수동 정합성 확인이 필요합니다.'
+  return '최근 변경 이후 실패가 있어 상태 확인이 필요합니다.'
 }
 
 function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): RuntimeBand {
@@ -240,9 +240,9 @@ function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string
   const blocker = keeper.last_blocker?.trim()
   if (blocker) return blocker
   if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'
-  if (isHeartbeatStale(keeper)) return '하트비트가 오래되어 실제 프로세스 확인이 필요합니다.'
+  if (isHeartbeatStale(keeper)) return '오래 응답이 없어 실제 상태 확인이 필요합니다.'
   if (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= CONTEXT_ATTENTION_RATIO) {
-    return `컨텍스트 사용량 ${Math.round(keeper.context_ratio * 100)}%`
+    return `컨텍스트 사용량이 ${Math.round(keeper.context_ratio * 100)}%입니다.`
   }
   if (band === 'attention') return stage.description
   if (band === 'offline' && keeper.generation === 0 && (keeper.turn_count ?? 0) === 0) {

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -70,6 +70,25 @@ let remote_confirm_ttl_seconds = 900.0
 
 let iso_of_unix = Dashboard_utils.iso_of_unix
 
+let align_keeper_runtime_status
+    ~(surface_status : string)
+    ~(agent_status_json : Yojson.Safe.t)
+    ~(keepalive_running : bool) : string =
+  if not keepalive_running then
+    surface_status
+  else
+    let normalized_surface =
+      String.lowercase_ascii (String.trim surface_status)
+    in
+    let runtime_status =
+      match U.member "status" agent_status_json with
+      | `String (("active" | "busy" | "listening" | "idle") as status) -> Some status
+      | _ -> None
+    in
+    match (normalized_surface, runtime_status) with
+    | ("inactive" | "offline"), Some status -> status
+    | _ -> surface_status
+
 let remote_client_type_of_context (ctx : 'a context) =
   match ctx.mcp_session_id with
   | Some _ -> "mcp_remote"
@@ -284,6 +303,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                  let agent_status =
                    if not agent_exists then "offline"
                    else Keeper_exec_status.keeper_surface_status ~agent_status:agent_json ~diagnostic
+                 in
+                 let agent_status =
+                   align_keeper_runtime_status ~surface_status:agent_status
+                     ~agent_status_json:agent_json ~keepalive_running
                  in
                  let registry_phase =
                    Keeper_registry.get_phase ~base_path:config.base_path meta.name

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -70,8 +70,35 @@ let remote_confirm_ttl_seconds = 900.0
 
 let iso_of_unix = Dashboard_utils.iso_of_unix
 
+let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
+  let runtime_status =
+    match U.member "status" agent_status_json with
+    | `String (("active" | "busy" | "listening" | "idle") as status) -> Some status
+    | _ -> None
+  in
+  let last_seen_ago_s =
+    match U.member "last_seen_ago_s" agent_status_json with
+    | `Float value -> Some value
+    | `Int value -> Some (float_of_int value)
+    | _ -> None
+  in
+  let is_zombie =
+    match U.member "is_zombie" agent_status_json with
+    | `Bool value -> value
+    | _ -> false
+  in
+  match (runtime_status, last_seen_ago_s, is_zombie) with
+  | Some status, Some age_s, false when age_s <= 120.0 -> Some status
+  | _ -> None
+
+let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
+  match U.member "health_state" diagnostic with
+  | `String ("stale" | "degraded" | "zombie" | "dead") -> false
+  | _ -> true
+
 let align_keeper_runtime_status
     ~(surface_status : string)
+    ~(diagnostic : Yojson.Safe.t)
     ~(agent_status_json : Yojson.Safe.t)
     ~(keepalive_running : bool) : string =
   if not keepalive_running then
@@ -81,9 +108,9 @@ let align_keeper_runtime_status
       String.lowercase_ascii (String.trim surface_status)
     in
     let runtime_status =
-      match U.member "status" agent_status_json with
-      | `String (("active" | "busy" | "listening" | "idle") as status) -> Some status
-      | _ -> None
+      if health_state_allows_runtime_status_override diagnostic then
+        runtime_status_from_live_signal agent_status_json
+      else None
     in
     match (normalized_surface, runtime_status) with
     | ("inactive" | "offline"), Some status -> status
@@ -306,6 +333,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                  in
                  let agent_status =
                    align_keeper_runtime_status ~surface_status:agent_status
+                     ~diagnostic
                      ~agent_status_json:agent_json ~keepalive_running
                  in
                  let registry_phase =

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -724,8 +724,21 @@ let test_local_repo_worktree_runs_truth_via_absolute_bash () =
 (* --- keeper_bash branch-switch guard --- *)
 
 let assert_branch_switch_blocked config cmd label =
-  let meta = make_meta_with_preset "delivery" in
-  let args = `Assoc [ "cmd", `String cmd ] in
+  let shared_repo_rel = "workspace/yousleepwhen/oas" in
+  let shared_repo_abs =
+    Filename.concat (Keeper_alerting_path.project_root_of_config config) shared_repo_rel
+  in
+  Fs_compat.mkdir_p shared_repo_abs;
+  let meta =
+    { (make_meta_with_preset "delivery") with
+      allowed_paths = [ shared_repo_rel ^ "/" ] }
+  in
+  let args =
+    `Assoc
+      [ "cmd", `String cmd
+      ; "cwd", `String shared_repo_rel
+      ]
+  in
   let result = call_tool config meta "keeper_bash" args in
   let json = parse_json result in
   let error = try json_string "error" json with _ -> "" in

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -5,6 +5,18 @@ let () =
     [
       ( "operator",
         [
+          Alcotest.test_case "snapshot runtime alignment promotes fresh live signal"
+            `Quick
+            Test_operator_control_snapshot
+            .test_align_keeper_runtime_status_promotes_fresh_runtime_signal;
+          Alcotest.test_case "snapshot runtime alignment preserves attention health"
+            `Quick
+            Test_operator_control_snapshot
+            .test_align_keeper_runtime_status_preserves_attention_health;
+          Alcotest.test_case "snapshot runtime alignment ignores zombie runtime signal"
+            `Quick
+            Test_operator_control_snapshot
+            .test_align_keeper_runtime_status_ignores_zombie_runtime_signal;
           Alcotest.test_case "snapshot sections" `Quick
             Test_operator_control_snapshot.test_snapshot_has_expected_sections;
           Alcotest.test_case "snapshot pending confirm summary tracks actor scope"

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -1,6 +1,56 @@
 open Masc_mcp
 open Test_operator_control_support
 
+let test_align_keeper_runtime_status_promotes_fresh_runtime_signal () =
+  let status =
+    Operator_control_snapshot.align_keeper_runtime_status
+      ~surface_status:"inactive"
+      ~diagnostic:(`Assoc [ ("health_state", `String "offline") ])
+      ~agent_status_json:
+        (`Assoc
+          [
+            ("status", `String "busy");
+            ("last_seen_ago_s", `Float 5.0);
+            ("is_zombie", `Bool false);
+          ])
+      ~keepalive_running:true
+  in
+  Alcotest.(check string) "fresh runtime signal promotes keeper status" "busy"
+    status
+
+let test_align_keeper_runtime_status_preserves_attention_health () =
+  let status =
+    Operator_control_snapshot.align_keeper_runtime_status
+      ~surface_status:"inactive"
+      ~diagnostic:(`Assoc [ ("health_state", `String "degraded") ])
+      ~agent_status_json:
+        (`Assoc
+          [
+            ("status", `String "active");
+            ("last_seen_ago_s", `Float 5.0);
+            ("is_zombie", `Bool false);
+          ])
+      ~keepalive_running:true
+  in
+  Alcotest.(check string) "degraded health remains inactive" "inactive" status
+
+let test_align_keeper_runtime_status_ignores_zombie_runtime_signal () =
+  let status =
+    Operator_control_snapshot.align_keeper_runtime_status
+      ~surface_status:"inactive"
+      ~diagnostic:(`Assoc [ ("health_state", `String "offline") ])
+      ~agent_status_json:
+        (`Assoc
+          [
+            ("status", `String "active");
+            ("last_seen_ago_s", `Float 5.0);
+            ("is_zombie", `Bool true);
+          ])
+      ~keepalive_running:true
+  in
+  Alcotest.(check string) "zombie runtime does not override inactive" "inactive"
+    status
+
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->
   ensure_fs env;


### PR DESCRIPTION
## What changed
- made keeper identity use `name` as the primary display/search key and kept `agent_name` as secondary runtime context
- updated the unified dashboard roster so keeper cards render `sangsu`-style names first and show `keeper-...-agent` as a secondary chip
- aligned operator snapshot status with live runtime status when keepalive is still running, so keepers no longer drift to `inactive` while the runtime reports `busy`/`active`
- simplified monitoring copy to reduce identity/runtime wording overlap and shortened `주의 필요` hints into operator-facing language
- added focused tests for the new keeper identity helper behavior

## Why
Keeper data currently exposes two names with different roles:
- `name`: stable keeper identity
- `agent_name`: runtime actor name

The dashboard mixed those concepts and different projections could disagree on the same keeper status. That made keepers like `sangsu` look missing or inconsistent depending on where they were viewed.

## Impact
- keeper cards are easier to scan because the human/stable identity is primary
- searching by either keeper identity or runtime alias still works
- operator and execution surfaces are more consistent for live keepers
- status copy is shorter and easier to interpret during monitoring

## Root cause
The UI treated `agent_name` as the primary keeper label, while backend/operator projections could prefer stale surface status over live runtime status. That created both naming drift and status drift.

## Validation
- `pnpm --dir dashboard exec vitest run src/components/agent-roster.test.ts src/components/common/keeper-identity.test.ts src/lib/keeper-runtime-display.test.ts`
- `pnpm --dir dashboard run build`
- `env OCAMLPARAM='_,warn-error=-32' dune exec ./test/test_operator_control.exe`
- verified on local `127.0.0.1:8935` that the dashboard shows `sangsu` as the primary keeper name and `keeper-sangsu-agent` as the secondary runtime name
