### PR TITLE
[codex] fix keeper mutation boundary and manual reconcile lifecycle

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -314,15 +314,18 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             | None -> None
           in
           let reconcile_status =
-            match registry_entry with
-            | Some entry when
-                entry.turn_consecutive_failures > 0
-                && (match entry.last_failure_reason with
-                    | Some reason ->
-                        Keeper_registry.failure_reason_requires_manual_reconcile reason
-                    | None -> false) ->
+            if Keeper_manual_reconcile.is_pending config m.name then
                 Some "manual_reconcile_required"
-            | _ -> None
+            else
+              match registry_entry with
+              | Some entry when
+                  entry.turn_consecutive_failures > 0
+                  && (match entry.last_failure_reason with
+                      | Some reason ->
+                          Keeper_registry.failure_reason_requires_manual_reconcile reason
+                      | None -> false) ->
+                  Some "manual_reconcile_required"
+              | _ -> None
           in
           let runtime_blocker_fields =
             runtime_blocker_fields_json config m

--- a/lib/dune
+++ b/lib/dune
@@ -409,6 +409,7 @@
    keeper_types_support
    keeper_types
    keeper_memory
+   keeper_manual_reconcile
    keeper_memory_policy
    keeper_memory_bank
    keeper_memory_recall
@@ -643,6 +644,7 @@
   keeper_memory_policy
   keeper_memory_bank
   keeper_memory_recall
+  keeper_manual_reconcile
   ;; godsplit-phase1: file split sub-modules
   keeper_status_bridge
   ;; godsplit-phase2: additional sub-modules

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -277,6 +277,7 @@ let run_turn
       ?(max_idle_turns : int = 3)
       ?(history_user_source = "direct_user")
       ?(history_assistant_source = "direct_assistant")
+      ?(allow_empty_without_tools = false)
       ?guardrails
       ?temperature
       ?max_tokens
@@ -1590,7 +1591,11 @@ let run_turn
          Keeper_tool_disclosure.merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
        in
        let usage = Keeper_exec_context.usage_of_response result.response in
-       (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
+       (match
+          Keeper_tool_disclosure.normalize_response_text
+            ~allow_empty_without_tools
+            ~text ~tool_names ()
+        with
         | Error e -> Error (Oas.Error.Internal e)
         | Ok response_text ->
           (* Ensure every generation has a [STATE] block for continuity.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -277,7 +277,6 @@ let run_turn
       ?(max_idle_turns : int = 3)
       ?(history_user_source = "direct_user")
       ?(history_assistant_source = "direct_assistant")
-      ?(allow_empty_without_tools = false)
       ?guardrails
       ?temperature
       ?max_tokens
@@ -450,6 +449,9 @@ let run_turn
     | None -> 5
   in
   let discovered_ref = ref (Keeper_discovered_tools.create ~decay_turns) in
+  let completion_contract_ref =
+    ref Keeper_tool_disclosure.Allow_text_or_tool
+  in
   (* L1 Tool Affinity: pre-populate discovered tools from trajectory history.
      Solves the 9B text_response trap by making proven tools visible at
      turn 0 without requiring keeper_tool_search first.  #5566 *)
@@ -1326,6 +1328,11 @@ let run_turn
                 then current_params.tool_choice (* last turn: Auto for [STATE] block *)
                 else Some Agent_sdk.Types.Any (* all other turns: force tool use *)
               in
+              (match tool_choice with
+               | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) ->
+                 completion_contract_ref :=
+                   Keeper_tool_disclosure.Require_tool_use
+               | _ -> ());
               let lane =
                 if is_retry then "retry"
                 else (
@@ -1592,48 +1599,52 @@ let run_turn
        in
        let usage = Keeper_exec_context.usage_of_response result.response in
        (match
-          Keeper_tool_disclosure.normalize_response_text
-            ~allow_empty_without_tools
-            ~text ~tool_names ()
+          Keeper_tool_disclosure.validate_completion_contract
+            ~contract:!completion_contract_ref
+            ~tool_names
+            ()
         with
         | Error e -> Error (Oas.Error.Internal e)
-        | Ok response_text ->
-          (* Ensure every generation has a [STATE] block for continuity.
+        | Ok () ->
+          (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
+           | Error e -> Error (Oas.Error.Internal e)
+           | Ok response_text ->
+             (* Ensure every generation has a [STATE] block for continuity.
                 If the model omitted it, synthesize one deterministically
                 from tool usage and stop reason. *)
-          let response_text =
-            match Keeper_memory_policy.find_state_block response_text with
-            | Some _ -> response_text
-            | None ->
-              let stop_reason_str =
-                match result.stop_reason with
-                | Oas_worker.Completed -> "completed"
-                | Oas_worker.TurnBudgetExhausted _ -> "budget_exhausted"
-                | Oas_worker.MutationBoundaryReached { tool_name; _ } ->
-                    (match tool_name with
-                     | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
-                     | None -> "mutation_boundary")
-              in
-              let synth =
-                Keeper_memory_policy.synthesize_state_from_run_result
-                  ~goal:meta.goal
-                  ~tools_used:tool_names
-                  ~stop_reason:stop_reason_str
-                  ~response_text
-              in
-              let block = Keeper_memory_policy.render_state_block synth in
-              Log.Keeper.info
-                "keeper:%s [STATE] missing, synthesized from %d tools (stop=%s)"
-                meta.name
-                (List.length tool_names)
-                stop_reason_str;
-              response_text ^ "\n" ^ block
-          in
-          let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
-          Keeper_exec_context.persist_message
-            ~source:history_assistant_source
-            session
-            assistant_msg;
+             let response_text =
+               match Keeper_memory_policy.find_state_block response_text with
+               | Some _ -> response_text
+               | None ->
+                 let stop_reason_str =
+                   match result.stop_reason with
+                   | Oas_worker.Completed -> "completed"
+                   | Oas_worker.TurnBudgetExhausted _ -> "budget_exhausted"
+                   | Oas_worker.MutationBoundaryReached { tool_name; _ } ->
+                       (match tool_name with
+                        | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
+                        | None -> "mutation_boundary")
+                 in
+                 let synth =
+                   Keeper_memory_policy.synthesize_state_from_run_result
+                     ~goal:meta.goal
+                     ~tools_used:tool_names
+                     ~stop_reason:stop_reason_str
+                     ~response_text
+                 in
+                 let block = Keeper_memory_policy.render_state_block synth in
+                 Log.Keeper.info
+                   "keeper:%s [STATE] missing, synthesized from %d tools (stop=%s)"
+                   meta.name
+                   (List.length tool_names)
+                   stop_reason_str;
+                 response_text ^ "\n" ^ block
+             in
+             let assistant_msg = Agent_sdk.Types.assistant_msg response_text in
+             Keeper_exec_context.persist_message
+               ~source:history_assistant_source
+               session
+               assistant_msg;
           (* ctx_snapshot is immutable — assistant message is persisted
                 via checkpoint (OAS) and persist_message (history file).
                 No in-memory mutation needed; next turn reconstructs
@@ -1784,19 +1795,19 @@ let run_turn
                "keeper:%s post_turn_eval jsonl append failed: %s"
                meta.name
                (Printexc.to_string exn));
-          Ok
-            { response_text
-            ; model_used = model
-            ; prompt_metrics
-            ; cascade_observation = result.cascade_observation
-            ; turn_count = result.turns
-            ; tool_calls_made = List.length tool_names
-            ; usage
-            ; tools_used = tool_names
-            ; checkpoint = saved_checkpoint
-            ; proof = result.proof
-            ; run_validation = result.run_validation
-            ; stop_reason = result.stop_reason
-            ; inference_telemetry = result.response.telemetry
-            }))
+             Ok
+               { response_text
+               ; model_used = model
+               ; prompt_metrics
+               ; cascade_observation = result.cascade_observation
+               ; turn_count = result.turns
+               ; tool_calls_made = List.length tool_names
+               ; usage
+               ; tools_used = tool_names
+               ; checkpoint = saved_checkpoint
+               ; proof = result.proof
+               ; run_validation = result.run_validation
+               ; stop_reason = result.stop_reason
+               ; inference_telemetry = result.response.telemetry
+               })))
 ;;

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -913,6 +913,16 @@ let run_turn
     | Some r -> r
     | None -> ref Agent_sdk.Tool_op.Keep_all
   in
+  let mutation_boundary_tool_name : string option ref = ref None in
+  let mutation_boundary_summary () =
+    match !mutation_boundary_tool_name with
+    | Some tool_name ->
+        Printf.sprintf
+          "previous committed tool '%s' created a mutation boundary; checkpoint and resume next cycle"
+          tool_name
+    | None ->
+        "a previous committed tool created a mutation boundary; checkpoint and resume next cycle"
+  in
   let base_hooks =
     Keeper_hooks_oas.make_hooks
       ~config
@@ -920,6 +930,21 @@ let run_turn
       ~session
       ~ctx_snapshot
       ~generation
+      ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->
+        match !mutation_boundary_tool_name with
+        | Some _ -> Some (mutation_boundary_summary ())
+        | None -> None)
+      ~on_tool_executed:(fun ~tool_name ~input:_ ~output_text:_ ~success ->
+        if success
+           && Keeper_exec_tools.has_mutating_side_effect tool_name
+           && not (Keeper_tool_registry.is_reconcile_safe_tool tool_name)
+           && Option.is_none !mutation_boundary_tool_name
+        then begin
+          mutation_boundary_tool_name := Some tool_name;
+          Log.Keeper.info
+            "keeper:%s mutation boundary opened after committed tool=%s"
+            meta.name tool_name
+        end)
       ?max_cost_usd
       ?trajectory_acc
       ()
@@ -1459,7 +1484,20 @@ let run_turn
            ~approval:(Governance_pipeline.to_oas_approval_callback
                         ~governance_level:(Env_config_core.governance_level ())
                         ~keeper_name:meta.name)
-            ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
+           ~enable_thinking:(Keeper_config.keeper_enable_thinking ())
+           ~exit_condition:(fun _turn_count ->
+             Option.is_some !mutation_boundary_tool_name)
+           ~exit_condition_result:(fun turn_count ->
+             let tool_name = !mutation_boundary_tool_name in
+             ( Oas_worker.MutationBoundaryReached
+                 { turns_used = turn_count; tool_name },
+               Some
+                 (match tool_name with
+                  | Some tool ->
+                      Printf.sprintf
+                        "[mutation boundary reached after committed tool: %s]"
+                        tool
+                  | None -> "[mutation boundary reached]") ))
            ?oas_checkpoint:raw_oas_checkpoint
            ?event_bus
            ())
@@ -1566,6 +1604,10 @@ let run_turn
                 match result.stop_reason with
                 | Oas_worker.Completed -> "completed"
                 | Oas_worker.TurnBudgetExhausted _ -> "budget_exhausted"
+                | Oas_worker.MutationBoundaryReached { tool_name; _ } ->
+                    (match tool_name with
+                     | Some tool -> Printf.sprintf "mutation_boundary(%s)" tool
+                     | None -> "mutation_boundary")
               in
               let synth =
                 Keeper_memory_policy.synthesize_state_from_run_result

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -128,7 +128,6 @@ val run_turn :
   -> ?max_idle_turns:int
   -> ?history_user_source:string
   -> ?history_assistant_source:string
-  -> ?allow_empty_without_tools:bool
   -> ?guardrails:Agent_sdk.Guardrails.t
   -> ?temperature:float
   -> ?max_tokens:int

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -128,6 +128,7 @@ val run_turn :
   -> ?max_idle_turns:int
   -> ?history_user_source:string
   -> ?history_assistant_source:string
+  -> ?allow_empty_without_tools:bool
   -> ?guardrails:Agent_sdk.Guardrails.t
   -> ?temperature:float
   -> ?max_tokens:int

--- a/lib/keeper/keeper_guard.ml
+++ b/lib/keeper/keeper_guard.ml
@@ -19,6 +19,7 @@ let event_priority = function
   | Context_measured _ -> 5
   | Heartbeat_ok -> 10
   | Turn_succeeded -> 10
+  | Manual_reconcile_cleared -> 10
   | _ -> 10
 
 let evaluate (s : measurement_snapshot) : event list =

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -145,6 +145,8 @@ let emit_cost_event
     @param generation Current generation counter
     @param max_cost_usd Optional cost budget (rejects tool calls above limit)
     @param destructive_check Enable destructive pattern detection (default true)
+    @param pre_tool_use_guard Optional callback that can short-circuit a tool
+           before execution by returning an inline override response.
     @param on_tool_executed Optional callback after each tool execution
     @param trajectory_acc Optional trajectory accumulator for cost attribution *)
 
@@ -234,8 +236,13 @@ let make_hooks
     ~(generation : int)
     ?(max_cost_usd : float option)
     ?(destructive_check : bool = true)
-    ?(on_tool_executed : string -> Yojson.Safe.t -> string -> unit =
-        fun _ _ _ -> ())
+    ?(pre_tool_use_guard :
+        tool_name:string -> input:Yojson.Safe.t -> string option =
+        fun ~tool_name:_ ~input:_ -> None)
+    ?(on_tool_executed :
+        tool_name:string -> input:Yojson.Safe.t -> output_text:string ->
+        success:bool -> unit =
+        fun ~tool_name:_ ~input:_ ~output_text:_ ~success:_ -> ())
     ?(trajectory_acc : Trajectory.accumulator option)
     ()
   : Agent_sdk.Hooks.hooks =
@@ -368,7 +375,12 @@ let make_hooks
              ?lane ?tool_choice ?thinking_enabled ?thinking_budget
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-        (try on_tool_executed tool_name input output_text
+        (try
+           on_tool_executed
+             ~tool_name
+             ~input
+             ~output_text
+             ~success:(outcome = "ok")
          with Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
               Log.Keeper.error "keeper:%s on_tool_executed callback failed for %s: %s"
@@ -384,6 +396,19 @@ let make_hooks
       | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
         tool_start_time := Time_compat.now ();
         let keeper_name = (!meta_ref).name in
+        (match pre_tool_use_guard ~tool_name ~input with
+         | Some reason ->
+           Log.Keeper.info
+             "keeper:%s pre_tool_use guard blocked %s"
+             keeper_name tool_name;
+           broadcast_tool_skipped ~keeper_name ~tool_name
+             ~reason_code:"pre_tool_use_guard";
+           Agent_sdk.Hooks.Override
+             (render_inline_skip_reason
+                ~tool_name
+                ~reason_code:"pre_tool_use_guard"
+                ~reason_text:reason)
+         | None ->
         (* Same-name streak gate: block when the same tool name is called
            streak_threshold+ times consecutively, regardless of args.
            Returns Override (tool NOT executed) with a directive to switch tools.
@@ -480,7 +505,7 @@ let make_hooks
              if needs_approval then
                Agent_sdk.Hooks.ApprovalRequired
              else
-               Agent_sdk.Hooks.Continue)
+               Agent_sdk.Hooks.Continue))
       | _ -> Agent_sdk.Hooks.Continue);
 
     on_idle = Some (fun event ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -540,6 +540,40 @@ let keeper_agent_status (meta : keeper_meta) =
     | None -> Types.Active)
 ;;
 
+let manual_reconcile_blocker_detail (config : Room.config) keeper_name =
+  match Keeper_manual_reconcile.read config keeper_name with
+  | Some ({ status = Keeper_manual_reconcile.Pending; summary; failure_reason; _ } as record)
+    ->
+      let detail =
+        match failure_reason with
+        | Some value when String.trim value <> "" -> value
+        | _ when String.trim summary <> "" -> summary
+        | _ -> record.blocker_class
+      in
+      `Pending detail
+  | Some { status = Keeper_manual_reconcile.Cleared; _ } -> `Cleared
+  | None ->
+      (match Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+           (match entry.last_failure_reason with
+            | Some reason
+              when Keeper_registry.failure_reason_requires_manual_reconcile reason ->
+                `Legacy_pending (Keeper_registry.failure_reason_to_string reason)
+            | _ -> `Absent)
+       | None -> `Absent)
+
+let sync_manual_reconcile_condition ~(config : Room.config) ~(keeper_name : string) =
+  match
+    manual_reconcile_blocker_detail config keeper_name,
+    Keeper_registry.get ~base_path:config.base_path keeper_name
+  with
+  | `Pending detail, Some entry
+    when not entry.conditions.manual_reconcile_required ->
+      ignore (Keeper_registry.dispatch_event
+        ~base_path:config.base_path keeper_name
+        (Keeper_state_machine.Manual_reconcile_required { reason = detail }))
+  | _ -> ()
+
 (** Reset stale turn failures so the keeper can exit Failing phase.
     Called unconditionally after presence sync (whether I/O was skipped or not).
     If the underlying issue persists, the next turn will re-fail. *)
@@ -549,23 +583,19 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
       ~base_path:ctx.config.base_path meta.name
   in
   if stale_turn_failures > 0 then begin
+    sync_manual_reconcile_condition ~config:ctx.config ~keeper_name:meta.name;
+    let blocker_detail = manual_reconcile_blocker_detail ctx.config meta.name in
     let sticky_manual_reconcile =
-      match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
-      | Some entry ->
-          (match entry.last_failure_reason with
-           | Some reason ->
-               Keeper_registry.failure_reason_requires_manual_reconcile reason
-           | None -> false)
-      | None -> false
+      match blocker_detail with
+      | `Pending _ | `Legacy_pending _ -> true
+      | `Cleared | `Absent -> false
     in
     if sticky_manual_reconcile then begin
       let reason_str =
-        match Keeper_registry.get ~base_path:ctx.config.base_path meta.name with
-        | Some entry ->
-            (match entry.last_failure_reason with
-             | Some reason -> Keeper_registry.failure_reason_to_string reason
-             | None -> "none")
-        | None -> "no_entry"
+        match blocker_detail with
+        | `Pending detail | `Legacy_pending detail -> detail
+        | `Cleared -> "cleared"
+        | `Absent -> "none"
       in
       Log.Keeper.warn
         "heartbeat recovery: auto-clearing %d turn failures for %s (reason=%s). Cursors already advanced — re-trigger risk is low."
@@ -577,23 +607,26 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
       ignore (Keeper_registry.dispatch_event
         ~base_path:ctx.config.base_path meta.name
         Keeper_state_machine.Heartbeat_ok);
-      ignore (Keeper_registry.dispatch_event
-        ~base_path:ctx.config.base_path meta.name
-        Keeper_state_machine.Turn_succeeded);
-      Log.Keeper.info
-        "heartbeat recovery: reset %d stale turn failures for %s"
-        stale_turn_failures meta.name
+      if sticky_manual_reconcile
+      then
+        Log.Keeper.info
+          "heartbeat recovery: reset %d stale turn failures for %s but retained manual reconcile blocker"
+          stale_turn_failures meta.name
+      else (
+        ignore (Keeper_registry.dispatch_event
+          ~base_path:ctx.config.base_path meta.name
+          Keeper_state_machine.Turn_succeeded);
+        Log.Keeper.info
+          "heartbeat recovery: reset %d stale turn failures for %s"
+          stale_turn_failures meta.name)
     end
   end
 
-let keeper_requires_manual_reconcile ~base_path ~keeper_name =
-  match Keeper_registry.get ~base_path keeper_name with
-  | Some entry ->
-      (match entry.last_failure_reason with
-       | Some reason ->
-           Keeper_registry.failure_reason_requires_manual_reconcile reason
-       | None -> false)
-  | None -> false
+let keeper_requires_manual_reconcile ~(config : Room.config) ~keeper_name =
+  sync_manual_reconcile_condition ~config ~keeper_name;
+  match manual_reconcile_blocker_detail config keeper_name with
+  | `Pending _ | `Legacy_pending _ -> true
+  | `Cleared | `Absent -> false
 
 let sync_keeper_presence
       ~(ctx : _ context)
@@ -730,7 +763,7 @@ let run_keepalive_unified_turn
       in
       let manual_reconcile_pending =
         keeper_requires_manual_reconcile
-          ~base_path:ctx.config.base_path
+          ~config:ctx.config
           ~keeper_name:meta_after_triage.name
       in
       let should_run_turn =

--- a/lib/keeper/keeper_manual_reconcile.ml
+++ b/lib/keeper/keeper_manual_reconcile.ml
@@ -1,0 +1,202 @@
+module U = Yojson.Safe.Util
+
+open Keeper_types
+
+type status =
+  | Pending
+  | Cleared
+
+type record = {
+  version : int;
+  keeper_name : string;
+  blocker_class : string;
+  summary : string;
+  failure_reason : string option;
+  trace_id : string option;
+  generation : int option;
+  committed_tools : string list;
+  opened_at : string;
+  updated_at : string;
+  status : status;
+  resolution : string option;
+  evidence_refs : string list;
+  cleared_at : string option;
+  cleared_by : string option;
+  clear_idempotency_key : string option;
+}
+
+type clear_outcome =
+  | Cleared_record of record
+  | Already_cleared of record
+  | No_record
+
+let record_version = 1
+
+let status_to_string = function
+  | Pending -> "pending"
+  | Cleared -> "cleared"
+
+let status_of_string = function
+  | "pending" -> Some Pending
+  | "cleared" -> Some Cleared
+  | _ -> None
+
+let record_path (config : Room.config) keeper_name =
+  Filename.concat (keeper_dir config) (keeper_name ^ ".manual_reconcile.json")
+
+let now_iso () =
+  Types.iso8601_of_unix_seconds (Time_compat.now ())
+
+let string_option_to_json = Json_util.option_to_yojson (fun value -> `String value)
+
+let int_option_to_json = Json_util.option_to_yojson (fun value -> `Int value)
+
+let string_list_to_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let record_to_yojson (record : record) =
+  `Assoc
+    [
+      ("version", `Int record.version);
+      ("keeper_name", `String record.keeper_name);
+      ("blocker_class", `String record.blocker_class);
+      ("summary", `String record.summary);
+      ("failure_reason", string_option_to_json record.failure_reason);
+      ("trace_id", string_option_to_json record.trace_id);
+      ("generation", int_option_to_json record.generation);
+      ("committed_tools", string_list_to_json record.committed_tools);
+      ("opened_at", `String record.opened_at);
+      ("updated_at", `String record.updated_at);
+      ("status", `String (status_to_string record.status));
+      ("resolution", string_option_to_json record.resolution);
+      ("evidence_refs", string_list_to_json record.evidence_refs);
+      ("cleared_at", string_option_to_json record.cleared_at);
+      ("cleared_by", string_option_to_json record.cleared_by);
+      ( "clear_idempotency_key",
+        string_option_to_json record.clear_idempotency_key );
+    ]
+
+let record_of_yojson json =
+  try
+    let status =
+      json |> U.member "status" |> U.to_string |> status_of_string
+    in
+    match status with
+    | None -> None
+    | Some status ->
+        Some
+          {
+            version =
+              (json |> U.member "version" |> U.to_int_option
+               |> Option.value ~default:record_version);
+            keeper_name = json |> U.member "keeper_name" |> U.to_string;
+            blocker_class = json |> U.member "blocker_class" |> U.to_string;
+            summary = json |> U.member "summary" |> U.to_string;
+            failure_reason =
+              json |> U.member "failure_reason" |> U.to_string_option;
+            trace_id = json |> U.member "trace_id" |> U.to_string_option;
+            generation = json |> U.member "generation" |> U.to_int_option;
+            committed_tools =
+              (match json |> U.member "committed_tools" with
+               | `List xs ->
+                   xs
+                   |> List.filter_map (function
+                        | `String value when String.trim value <> "" -> Some value
+                        | _ -> None)
+               | _ -> []);
+            opened_at = json |> U.member "opened_at" |> U.to_string;
+            updated_at = json |> U.member "updated_at" |> U.to_string;
+            status;
+            resolution = json |> U.member "resolution" |> U.to_string_option;
+            evidence_refs =
+              (match json |> U.member "evidence_refs" with
+               | `List xs ->
+                   xs
+                   |> List.filter_map (function
+                        | `String value when String.trim value <> "" -> Some value
+                        | _ -> None)
+               | _ -> []);
+            cleared_at = json |> U.member "cleared_at" |> U.to_string_option;
+            cleared_by = json |> U.member "cleared_by" |> U.to_string_option;
+            clear_idempotency_key =
+              json |> U.member "clear_idempotency_key" |> U.to_string_option;
+          }
+  with U.Type_error _ | Yojson.Json_error _ | Failure _ -> None
+
+let read (config : Room.config) keeper_name =
+  match Room_utils.read_json_opt config (record_path config keeper_name) with
+  | Some json -> record_of_yojson json
+  | None -> None
+
+let pending_record config keeper_name =
+  match read config keeper_name with
+  | Some ({ status = Pending; _ } as record) -> Some record
+  | _ -> None
+
+let is_pending config keeper_name =
+  Option.is_some (pending_record config keeper_name)
+
+let cache_key config keeper_name =
+  match read config keeper_name with
+  | None -> "none"
+  | Some record ->
+      String.concat "|"
+        [
+          status_to_string record.status;
+          record.updated_at;
+          record.blocker_class;
+        ]
+
+let write_record config record =
+  Room_utils.write_json config (record_path config record.keeper_name)
+    (record_to_yojson record)
+
+let open_pending config ~keeper_name ~blocker_class ~summary ~failure_reason
+    ~trace_id ~generation ~committed_tools =
+  let opened_at =
+    match pending_record config keeper_name with
+    | Some record -> record.opened_at
+    | None -> now_iso ()
+  in
+  let record =
+    {
+      version = record_version;
+      keeper_name;
+      blocker_class;
+      summary;
+      failure_reason;
+      trace_id;
+      generation;
+      committed_tools;
+      opened_at;
+      updated_at = now_iso ();
+      status = Pending;
+      resolution = None;
+      evidence_refs = [];
+      cleared_at = None;
+      cleared_by = None;
+      clear_idempotency_key = None;
+    }
+  in
+  write_record config record;
+  record
+
+let clear config ~keeper_name ~actor ~resolution ~evidence_refs ~idempotency_key =
+  match read config keeper_name with
+  | None -> No_record
+  | Some ({ status = Cleared; _ } as record) -> Already_cleared record
+  | Some record ->
+      let updated =
+        {
+          record with
+          updated_at = now_iso ();
+          status = Cleared;
+          resolution = Some resolution;
+          evidence_refs;
+          cleared_at = Some (now_iso ());
+          cleared_by = Some actor;
+          clear_idempotency_key = idempotency_key;
+        }
+      in
+      write_record config updated;
+      Cleared_record updated

--- a/lib/keeper/keeper_manual_reconcile.mli
+++ b/lib/keeper/keeper_manual_reconcile.mli
@@ -1,0 +1,54 @@
+type status =
+  | Pending
+  | Cleared
+
+type record = {
+  version : int;
+  keeper_name : string;
+  blocker_class : string;
+  summary : string;
+  failure_reason : string option;
+  trace_id : string option;
+  generation : int option;
+  committed_tools : string list;
+  opened_at : string;
+  updated_at : string;
+  status : status;
+  resolution : string option;
+  evidence_refs : string list;
+  cleared_at : string option;
+  cleared_by : string option;
+  clear_idempotency_key : string option;
+}
+
+type clear_outcome =
+  | Cleared_record of record
+  | Already_cleared of record
+  | No_record
+
+val record_path : Room.config -> string -> string
+val record_to_yojson : record -> Yojson.Safe.t
+val read : Room.config -> string -> record option
+val pending_record : Room.config -> string -> record option
+val is_pending : Room.config -> string -> bool
+val cache_key : Room.config -> string -> string
+
+val open_pending :
+  Room.config ->
+  keeper_name:string ->
+  blocker_class:string ->
+  summary:string ->
+  failure_reason:string option ->
+  trace_id:string option ->
+  generation:int option ->
+  committed_tools:string list ->
+  record
+
+val clear :
+  Room.config ->
+  keeper_name:string ->
+  actor:string ->
+  resolution:string ->
+  evidence_refs:string list ->
+  idempotency_key:string option ->
+  clear_outcome

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -416,6 +416,43 @@ let keeper_schemas : tool_schema list = [
   };
 
   {
+    name = "masc_keeper_reconcile";
+    description = "Inspect or clear a keeper manual-reconcile blocker. Use inspect to review the persisted blocker record, then clear with operator evidence once the committed side effects have been reconciled.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle");
+        ]);
+        ("action", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "inspect"; `String "clear"]);
+          ("description", `String "inspect returns the persisted blocker record. clear marks it cleared and re-enables keepalive turns.");
+        ]);
+        ("resolution", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Required for clear. Operator summary of how the ambiguous side effects were reconciled.");
+        ]);
+        ("evidence_refs", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Optional evidence references (task ids, board posts, logs, notes) that justify the clear.");
+        ]);
+        ("actor", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional operator identity. Defaults to the calling agent_name.");
+        ]);
+        ("idempotency_key", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional idempotency key for repeated clear requests.");
+        ]);
+      ]);
+      ("required", `List [`String "name"; `String "action"]);
+    ];
+  };
+
+  {
     name = "masc_keeper_down";
     description = "Stop a keeper. Optionally remove underlying files.";
     input_schema = `Assoc [

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -200,11 +200,14 @@ let inferred_tool_surface tools =
 let tool_only_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(result : Keeper_agent_run.run_result) =
+  let visible_reply =
+    Keeper_text_processing.strip_internal_reply_markup result.response_text
+  in
   let speech_act, delivery_surface =
     match inferred_tool_surface result.tools_used with
     | Some routed -> routed
     | None ->
-        if String.trim result.response_text <> "" then (Inform, Visible_reply)
+        if String.trim visible_reply <> "" then (Inform, Visible_reply)
         else (Defer, Silent)
   in
   {
@@ -327,7 +330,10 @@ let apply_to_result ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     (result : Keeper_agent_run.run_result) =
   let headers, response_body = parse_header_block result.response_text in
-  let has_text_reply = String.trim response_body <> "" in
+  let visible_response_body =
+    Keeper_text_processing.strip_internal_reply_markup response_body
+  in
+  let has_text_reply = String.trim visible_response_body <> "" in
   let state =
     (* Tool calls are the authoritative record of action.
        When tools are present, infer social state from tool calls regardless
@@ -373,7 +379,7 @@ let apply_to_result ~(meta : keeper_meta)
   | Stay_silent, Silent when result.tools_used = [] ->
       ({ result with response_text = "" }, state)
   | _ ->
-      ({ result with response_text = response_body }, state)
+      ({ result with response_text = visible_response_body }, state)
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)

--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -101,6 +101,7 @@ type event =
   | Turn_succeeded
   | Turn_failed of { consecutive : int; max_allowed : int }
   | Manual_reconcile_required of { reason : string }
+  | Manual_reconcile_cleared
   | Context_measured of {
       context_ratio : float;
       message_count : int;
@@ -133,6 +134,7 @@ let event_to_string = function
     Printf.sprintf "turn_failed(%d/%d)" r.consecutive r.max_allowed
   | Manual_reconcile_required r ->
     Printf.sprintf "manual_reconcile_required(%s)" r.reason
+  | Manual_reconcile_cleared -> "manual_reconcile_cleared"
   | Context_measured r ->
     Printf.sprintf "context_measured(ratio=%.3f)" r.context_ratio
   | Compaction_started -> "compaction_started"
@@ -294,15 +296,14 @@ let update_conditions (c : conditions) (ev : event) : conditions =
     let _ = max_allowed in
     { c with heartbeat_healthy = consecutive = 0 }
   | Turn_succeeded ->
-    { c with
-      turn_healthy = true;
-      manual_reconcile_required = false;
-    }
+    { c with turn_healthy = true }
   | Turn_failed { consecutive; max_allowed } ->
     let _ = max_allowed in
     { c with turn_healthy = consecutive = 0 }
   | Manual_reconcile_required _ ->
     { c with manual_reconcile_required = true }
+  | Manual_reconcile_cleared ->
+    { c with manual_reconcile_required = false }
   | Context_measured { auto_rules; _ } ->
     { c with
       guardrail_triggered = auto_rules.guardrail_stop;
@@ -485,6 +486,7 @@ let event_to_json (ev : event) : Yojson.Safe.t =
     ]
   | Manual_reconcile_required r ->
     obj "manual_reconcile_required" ["reason", `String r.reason]
+  | Manual_reconcile_cleared -> obj "manual_reconcile_cleared" []
   | Context_measured r ->
     obj "context_measured" [
       "context_ratio", `Float r.context_ratio;

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -95,6 +95,7 @@ type event =
   | Turn_succeeded
   | Turn_failed of { consecutive : int; max_allowed : int }
   | Manual_reconcile_required of { reason : string }
+  | Manual_reconcile_cleared
   | Context_measured of {
       context_ratio : float;
       message_count : int;

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -145,7 +145,24 @@ let runtime_blocker_surface_of_registry_entry
 let runtime_blocker_fields_json
     (config : Room_utils.config)
     (meta : keeper_meta) =
-  match runtime_blocker_surface_of_registry_entry (runtime_registry_entry config meta.name) with
+  match Keeper_manual_reconcile.read config meta.name with
+  | Some { status = Keeper_manual_reconcile.Pending; blocker_class; summary; _ } ->
+      [
+        ("runtime_blocker_class", `String blocker_class);
+        ("runtime_blocker_summary", `String summary);
+        ("runtime_blocker_manual_reconcile", `Bool true);
+      ]
+  | Some { status = Keeper_manual_reconcile.Cleared; _ } ->
+      [
+        ("runtime_blocker_class", `Null);
+        ("runtime_blocker_summary", `Null);
+        ("runtime_blocker_manual_reconcile", `Null);
+      ]
+  | None ->
+      (match
+         runtime_blocker_surface_of_registry_entry
+           (runtime_registry_entry config meta.name)
+       with
   | Some (blocker_class, summary, manual_reconcile) ->
       [
         ("runtime_blocker_class", `String blocker_class);
@@ -157,7 +174,7 @@ let runtime_blocker_fields_json
         ("runtime_blocker_class", `Null);
         ("runtime_blocker_summary", `Null);
         ("runtime_blocker_manual_reconcile", `Null);
-      ]
+      ])
 
 let runtime_surface_json config (meta : keeper_meta) =
   let keepalive_running = runtime_keepalive_running config meta in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -59,9 +59,10 @@ let resolve_status_target (ctx : _ context) args =
 
 (** Hash the status-affecting args so different parameter combos
     get separate cache entries (e.g. fast=true vs fast=false). *)
-let hash_status_args resolved_name args =
+let hash_status_args config resolved_name args =
   let parts = [
     resolved_name;
+    Keeper_manual_reconcile.cache_key config resolved_name;
     string_of_bool (get_bool args "fast" false);
     string_of_bool (get_bool args "include_context" false);
     string_of_bool (get_bool args "include_metrics_overview" false);
@@ -77,7 +78,7 @@ let handle_keeper_status ctx args : tool_result =
   match resolve_status_target ctx args with
   | Error err -> (false, err)
   | Ok (name, m) ->
-      let args_hash = hash_status_args name args in
+      let args_hash = hash_status_args ctx.config name args in
       (* Cache hit: same updated_at + same args → return cached response *)
       (match Hashtbl.find_opt _cache name with
        | Some entry
@@ -662,6 +663,7 @@ let handle_keeper_status ctx args : tool_result =
            ("compaction_history_count", `Int (snd compaction_history_tail));
            ("storage_paths", `Assoc [
              ("meta", `String (keeper_meta_path ctx.config m.name));
+             ("manual_reconcile", `String (Keeper_manual_reconcile.record_path ctx.config m.name));
              ("metrics", `String (Dated_jsonl.base_dir metrics_store));
              ("metrics_single_file", `String metrics_path);
              ("memory_bank", `String memory_bank_path);

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -41,11 +41,26 @@ let merge_reported_and_observed_tool_names
         reported_tool_names
 ;;
 
-let normalize_response_text
-      ?(allow_empty_without_tools = false)
-      ~(text : string)
+type completion_contract =
+  | Allow_text_or_tool
+  | Require_tool_use
+
+let validate_completion_contract
+      ~(contract : completion_contract)
       ~(tool_names : string list)
       ()
+  : (unit, string) result
+  =
+  match contract with
+  | Allow_text_or_tool -> Ok ()
+  | Require_tool_use ->
+    (match tool_names with
+     | _ :: _ -> Ok ()
+     | [] ->
+       Error
+         "keeper turn violated required tool contract: no tools were called")
+
+let normalize_response_text ~(text : string) ~(tool_names : string list) ()
   : (string, string) result
   =
   let trimmed = String.trim text in
@@ -53,10 +68,7 @@ let normalize_response_text
   then Ok text
   else (
     match tool_names with
-    | [] ->
-      if allow_empty_without_tools
-      then Ok ""
-      else Error "keeper turn completed with no textual reply"
+    | [] -> Error "keeper turn completed with no textual reply"
     | _ ->
       Ok
         (Printf.sprintf

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -41,7 +41,11 @@ let merge_reported_and_observed_tool_names
         reported_tool_names
 ;;
 
-let normalize_response_text ~(text : string) ~(tool_names : string list) ()
+let normalize_response_text
+      ?(allow_empty_without_tools = false)
+      ~(text : string)
+      ~(tool_names : string list)
+      ()
   : (string, string) result
   =
   let trimmed = String.trim text in
@@ -49,7 +53,10 @@ let normalize_response_text ~(text : string) ~(tool_names : string list) ()
   then Ok text
   else (
     match tool_names with
-    | [] -> Error "keeper turn completed with no textual reply"
+    | [] ->
+      if allow_empty_without_tools
+      then Ok ""
+      else Error "keeper turn completed with no textual reply"
     | _ ->
       Ok
         (Printf.sprintf

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -110,6 +110,15 @@ let summarize_post_commit_failure
         tools
         err_preview
 
+let blocker_class_of_failure_reason = function
+  | Keeper_registry.Ambiguous_partial_commit
+      { kind = Keeper_registry.Post_commit_timeout; _ } ->
+      "ambiguous_post_commit_timeout"
+  | Keeper_registry.Ambiguous_partial_commit
+      { kind = Keeper_registry.Post_commit_failure; _ } ->
+      "ambiguous_post_commit_failure"
+  | _ -> "manual_reconcile_required"
+
 let classify_post_commit_failure
     ~(tool_names : string list)
     ?kind
@@ -491,12 +500,18 @@ let append_decision_record
                     ]
                 | None -> []
               in
-              let stop_reason_str =
-                match r.stop_reason with
-                | Oas_worker.Completed -> "completed"
-                | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
-                    Printf.sprintf "turn_budget_exhausted(%d/%d)" turns_used limit
-              in
+                let stop_reason_str =
+                  match r.stop_reason with
+                  | Oas_worker.Completed -> "completed"
+                  | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
+                      Printf.sprintf "turn_budget_exhausted(%d/%d)" turns_used limit
+                  | Oas_worker.MutationBoundaryReached { turns_used; tool_name } ->
+                      (match tool_name with
+                       | Some tool ->
+                           Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
+                       | None ->
+                           Printf.sprintf "mutation_boundary(%d)" turns_used)
+                in
               let inference_fields =
                 match r.inference_telemetry with
                 | Some t ->
@@ -1315,16 +1330,30 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_transient ~social_state ()
           in
           if is_ambiguous_partial then begin
+            let failure_reason =
+              Option.value
+                ~default:
+                  (Keeper_registry.Ambiguous_partial_commit {
+                    kind = Keeper_registry.Post_commit_failure;
+                    detail = e_str;
+                  })
+                !post_commit_failure_reason
+            in
             Keeper_registry.set_failure_reason ~base_path:config.base_path
               meta.name
-              (Some
-                 (Option.value
-                    ~default:
-                      (Keeper_registry.Ambiguous_partial_commit {
-                        kind = Keeper_registry.Post_commit_failure;
-                        detail = e_str;
-                      })
-                    !post_commit_failure_reason));
+              (Some failure_reason);
+            ignore
+              (Keeper_manual_reconcile.open_pending
+                 config
+                 ~keeper_name:meta.name
+                 ~blocker_class:(blocker_class_of_failure_reason failure_reason)
+                 ~summary:(short_preview e_str)
+                 ~failure_reason:
+                   (Some (Keeper_registry.failure_reason_to_string failure_reason))
+                 ~trace_id:(Some meta.runtime.trace_id)
+                 ~generation:(Some meta.runtime.generation)
+                 ~committed_tools:
+                   (committed_mutating_tools !mutating_tools_committed));
             ignore (Keeper_registry.dispatch_event
               ~base_path:config.base_path meta.name
               (Keeper_state_machine.Manual_reconcile_required {
@@ -1514,10 +1543,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             (result.usage.input_tokens + result.usage.output_tokens)
             latency_ms
             (selected_mode_of_result result)
-            (match result.stop_reason with
-             | Oas_worker.Completed -> "completed"
-             | Oas_worker.TurnBudgetExhausted { turns_used; limit; _ } ->
-                 Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit);
+             (match result.stop_reason with
+              | Oas_worker.Completed -> "completed"
+              | Oas_worker.TurnBudgetExhausted { turns_used; limit; _ } ->
+                 Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit
+              | Oas_worker.MutationBoundaryReached { turns_used; tool_name } ->
+                 (match tool_name with
+                  | Some tool ->
+                      Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
+                  | None ->
+                      Printf.sprintf "mutation_boundary(%d)" turns_used));
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with
            | Ok () -> ()
@@ -1532,6 +1567,13 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
              (* Do NOT increment turn_failures — this is not a crash.
                 The keeper made progress and saved a checkpoint.
                 Reset failures since the turn itself ran successfully. *)
+             Keeper_registry.reset_turn_failures ~base_path:config.base_path
+               updated_meta.name
+           | Oas_worker.MutationBoundaryReached { tool_name; _ } ->
+             Log.Keeper.info
+               "keeper:%s mutation boundary reached after %s, checkpoint saved — will resume next cycle"
+               updated_meta.name
+               (match tool_name with Some tool -> tool | None -> "committed tool");
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name
            | Oas_worker.Completed ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1133,10 +1133,6 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~generation:run_generation ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
-              ~allow_empty_without_tools:
-                (match channel with
-                 | Keeper_world_observation.Scheduled_autonomous -> true
-                 | Keeper_world_observation.Reactive -> false)
               ~temperature ~max_tokens
               ~max_cost_usd
               ~is_retry

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1131,6 +1131,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~generation:run_generation ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
+              ~allow_empty_without_tools:
+                (match channel with
+                 | Keeper_world_observation.Scheduled_autonomous -> true
+                 | Keeper_world_observation.Reactive -> false)
               ~temperature ~max_tokens
               ~max_cost_usd
               ~is_retry

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -237,6 +237,7 @@ let custom_tool_titles : (string * string) list = [
   ("masc_keeper_up", "Start Keeper");
   ("masc_keeper_msg", "Send Keeper Message");
   ("masc_keeper_repair", "Keeper Repair");
+  ("masc_keeper_reconcile", "Keeper Reconcile");
   ("masc_keeper_status", "Keeper Status");
   ("masc_keeper_down", "Stop Keeper");
   ("masc_keeper_create_from_persona", "Create Keeper from Persona");

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -51,6 +51,7 @@ type cascade_observation = {
 type stop_reason =
   | Completed
   | TurnBudgetExhausted of { turns_used : int; limit : int }
+  | MutationBoundaryReached of { turns_used : int; tool_name : string option }
 
 type run_result = {
   response : Oas.Types.api_response;
@@ -116,6 +117,7 @@ val run_named :
   ?enable_thinking:bool ->
   ?approval:Oas.Hooks.approval_callback ->
   ?exit_condition:(int -> bool) ->
+  ?exit_condition_result:(int -> stop_reason * string option) ->
   ?oas_checkpoint:Oas.Checkpoint.t ->
   ?event_bus:Oas.Event_bus.t ->
   ?sw:Eio.Switch.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -10,6 +10,11 @@
 (* Configuration                                                     *)
 (* ================================================================ *)
 
+type stop_reason =
+  | Completed
+  | TurnBudgetExhausted of { turns_used : int; limit : int }
+  | MutationBoundaryReached of { turns_used : int; tool_name : string option }
+
 type config = {
   name : string;
   provider : Oas.Provider.config;
@@ -48,6 +53,7 @@ type config = {
   slot_id : int option;
   approval : Oas.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
+  exit_condition_result : (int -> stop_reason * string option) option;
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -83,15 +89,8 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     slot_id = None;
     approval = None;
     exit_condition = None;
+    exit_condition_result = None;
   }
-
-(* ================================================================ *)
-(* Result type                                                       *)
-(* ================================================================ *)
-
-type stop_reason =
-  | Completed
-  | TurnBudgetExhausted of { turns_used : int; limit : int }
 
 type run_result = {
   response : Oas.Types.api_response;
@@ -187,6 +186,20 @@ let build_checkpoint ~session_id ?checkpoint_sidecar (agent : Oas.Agent.t) =
         ~context:(Oas.Agent.context agent)
         ~mcp_clients:(Oas.Agent.options agent).mcp_clients
         ()
+
+let partial_response_of_stop
+    ~(session_id : string)
+    ~(model_id : string)
+    ~(text : string)
+  : Oas.Types.api_response =
+  {
+    id = session_id;
+    model = model_id;
+    stop_reason = Oas.Types.EndTurn;
+    content = [ Oas.Types.Text text ];
+    usage = None;
+    telemetry = None;
+  }
 
 (* ================================================================ *)
 (* Build                                                             *)
@@ -560,14 +573,13 @@ let run
           stop_reason = Completed;
         }
     | Error (Oas.Error.Agent (Oas.Error.MaxTurnsExceeded r)) ->
-      let partial_response : Oas.Types.api_response = {
-        id = session_id; model = config.model_id;
-        stop_reason = Oas.Types.EndTurn;
-        content = [Oas.Types.Text (Printf.sprintf
-          "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)];
-        usage = None;
-        telemetry = None;
-      } in
+      let partial_response =
+        partial_response_of_stop
+          ~session_id
+          ~model_id:config.model_id
+          ~text:(Printf.sprintf
+            "[turn budget exhausted: %d/%d turns used]" r.turns r.limit)
+      in
       Ok
         {
           response = partial_response;
@@ -580,6 +592,35 @@ let run
           cascade_observation = None;
           stop_reason = TurnBudgetExhausted { turns_used = r.turns; limit = r.limit };
         }
+    | Error (Oas.Error.Agent (Oas.Error.ExitConditionMet r)) -> (
+      match config.exit_condition_result with
+      | Some render ->
+        let stop_reason, response_text_opt = render r.turn in
+        let response_text =
+          match response_text_opt with
+          | Some text when String.trim text <> "" -> text
+          | _ -> Printf.sprintf "[exit condition met at turn %d]" r.turn
+        in
+        let partial_response =
+          partial_response_of_stop
+            ~session_id
+            ~model_id:config.model_id
+            ~text:response_text
+        in
+        Ok
+          {
+            response = partial_response;
+            checkpoint;
+            session_id;
+            turns;
+            trace_ref;
+            run_validation;
+            proof;
+            cascade_observation = None;
+            stop_reason;
+          }
+      | None ->
+        Error (Oas.Error.Agent (Oas.Error.ExitConditionMet r)))
     | Error err ->
       let detail = Oas.Error.to_string err in
       let detail =

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -157,6 +157,7 @@ let run_named
     ?enable_thinking
     ?approval
     ?exit_condition
+    ?exit_condition_result
     ?oas_checkpoint
     ?event_bus
     ?sw
@@ -213,6 +214,7 @@ let run_named
       event_bus;
       approval;
       exit_condition;
+      exit_condition_result;
     }
   in
   let config = { config with named_cascade = Some named_cascade; initial_messages; raw_trace; yield_on_tool } in

--- a/lib/tool_access_role.ml
+++ b/lib/tool_access_role.ml
@@ -80,6 +80,7 @@ let worker_only_tools =
     "masc_keeper_msg";
     "masc_keeper_msg_result";
     "masc_keeper_repair";
+    "masc_keeper_reconcile";
     "masc_keeper_create_from_persona";
     (* CanBroadcast — org units *)
     "masc_unit_define";

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -210,6 +210,8 @@ let explicit_metadata : (string * metadata) list =
         (hidden_active "Direct execution can apply privileged side effects and should be treated as destructive.") );
     ("masc_tool_grant", destructive_tool);
     ("masc_tool_revoke", destructive_tool);
+    ( "masc_keeper_reconcile",
+      { default_metadata with required_permission = Some Types.CanBroadcast } );
     ( "masc_operation_stop",
       destructive_tool );
     ( "masc_operation_pause",

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -124,7 +124,7 @@ let public_mcp_surface_tools =
     "masc_heartbeat";
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
-    "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_down";
+    "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reconcile"; "masc_keeper_down";
     "masc_persona_list";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -489,6 +489,141 @@ let handle_keeper_list ctx args : tool_result =
   in
   (true, body)
 
+let keeper_failure_reason_json (config : Room.config) name =
+  match Keeper_registry.get ~base_path:config.base_path name with
+  | Some entry ->
+      Json_util.option_to_yojson
+        (fun reason -> `String (Keeper_registry.failure_reason_to_string reason))
+        entry.last_failure_reason
+  | None -> `Null
+
+let keeper_phase_json (config : Room.config) name =
+  match Keeper_registry.get ~base_path:config.base_path name with
+  | Some entry -> `String (Keeper_state_machine.phase_to_string entry.phase)
+  | None -> `Null
+
+let keeper_manual_reconcile_record_json (config : Room.config) name =
+  Json_util.option_to_yojson
+    Keeper_manual_reconcile.record_to_yojson
+    (Keeper_manual_reconcile.read config name)
+
+let clear_registry_manual_reconcile ~(ctx : _ context) ~(name : string) =
+  Keeper_registry.set_failure_reason ~base_path:ctx.config.base_path name None;
+  Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path name;
+  (match Keeper_registry.get ~base_path:ctx.config.base_path name with
+   | Some _ ->
+       ignore
+         (Keeper_registry.dispatch_event
+            ~base_path:ctx.config.base_path
+            name
+            Keeper_state_machine.Manual_reconcile_cleared)
+   | None -> ());
+  invalidate_keeper_list_cache ();
+  invalidate_status_cache name;
+  Keeper_keepalive.wakeup_keeper ~base_path:ctx.config.base_path name
+
+let handle_keeper_reconcile ctx args : tool_result =
+  match resolve_keeper_name ctx args with
+  | Error err -> (false, err)
+  | Ok name ->
+      let action = String.lowercase_ascii (String.trim (get_string args "action" "")) in
+      let record_opt = Keeper_manual_reconcile.read ctx.config name in
+      let pending = Keeper_manual_reconcile.is_pending ctx.config name in
+      (match action with
+       | "inspect" ->
+           (true,
+            Yojson.Safe.to_string
+              (`Assoc
+                [
+                  ("name", `String name);
+                  ("action", `String "inspect");
+                  ("exists", `Bool (Option.is_some record_opt));
+                  ("pending", `Bool pending);
+                  ("record", keeper_manual_reconcile_record_json ctx.config name);
+                  ("phase", keeper_phase_json ctx.config name);
+                  ("last_failure_reason", keeper_failure_reason_json ctx.config name);
+                ]))
+       | "clear" ->
+           let resolution = String.trim (get_string args "resolution" "") in
+           if resolution = "" then
+             error_result_typed ~code:Validation_error
+               "resolution is required for action=clear"
+           else
+             let actor =
+               match get_string_opt args "actor" with
+               | Some value -> value
+               | None -> ctx.agent_name
+             in
+             let evidence_refs = get_string_list args "evidence_refs" in
+             let idempotency_key = get_string_opt args "idempotency_key" in
+             let legacy_pending =
+               match Keeper_registry.get ~base_path:ctx.config.base_path name with
+               | Some entry ->
+                   (match entry.last_failure_reason with
+                    | Some reason ->
+                        Keeper_registry.failure_reason_requires_manual_reconcile reason
+                    | None -> false)
+               | None -> false
+             in
+             let body =
+               match
+                 Keeper_manual_reconcile.clear
+                   ctx.config
+                   ~keeper_name:name
+                   ~actor
+                   ~resolution
+                   ~evidence_refs
+                   ~idempotency_key
+               with
+               | Keeper_manual_reconcile.Cleared_record record ->
+                   clear_registry_manual_reconcile ~ctx ~name;
+                   `Assoc
+                     [
+                       ("name", `String name);
+                       ("action", `String "clear");
+                       ("cleared", `Bool true);
+                       ("already_cleared", `Bool false);
+                       ("legacy_only", `Bool false);
+                       ("record", Keeper_manual_reconcile.record_to_yojson record);
+                     ]
+               | Keeper_manual_reconcile.Already_cleared record ->
+                   clear_registry_manual_reconcile ~ctx ~name;
+                   `Assoc
+                     [
+                       ("name", `String name);
+                       ("action", `String "clear");
+                       ("cleared", `Bool false);
+                       ("already_cleared", `Bool true);
+                       ("legacy_only", `Bool false);
+                       ("record", Keeper_manual_reconcile.record_to_yojson record);
+                     ]
+               | Keeper_manual_reconcile.No_record when legacy_pending ->
+                   clear_registry_manual_reconcile ~ctx ~name;
+                   `Assoc
+                     [
+                       ("name", `String name);
+                       ("action", `String "clear");
+                       ("cleared", `Bool true);
+                       ("already_cleared", `Bool false);
+                       ("legacy_only", `Bool true);
+                       ("record", `Null);
+                     ]
+               | Keeper_manual_reconcile.No_record ->
+                   `Assoc
+                     [
+                       ("name", `String name);
+                       ("action", `String "clear");
+                       ("cleared", `Bool false);
+                       ("already_cleared", `Bool false);
+                       ("legacy_only", `Bool false);
+                       ("record", `Null);
+                     ]
+             in
+             (true, Yojson.Safe.to_string body)
+       | _ ->
+           error_result_typed ~code:Validation_error
+             "action must be one of: inspect, clear")
+
 (* Recurring loop tools (#3190) removed: zero callers. *)
 
 let should_bootstrap_existing_keepalives name args =
@@ -519,6 +654,7 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_msg" -> Some (handle_keeper_msg ctx args)
   | "masc_keeper_msg_result" -> Some (handle_keeper_msg_result ctx args)
   | "masc_keeper_repair" -> Some (handle_keeper_repair ctx args)
+  | "masc_keeper_reconcile" -> Some (handle_keeper_reconcile ctx args)
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)
   | _ -> None
@@ -540,6 +676,10 @@ let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
 
 let _tool_spec_read_only = [ "masc_keeper_list"; "masc_keeper_status" ]
 
+let tool_required_permission = function
+  | "masc_keeper_reconcile" -> Some Types.CanBroadcast
+  | _ -> None
+
 let () =
   List.iter
     (fun (s : Types.tool_schema) ->
@@ -552,5 +692,6 @@ let () =
            ~handler_binding:Tag_dispatch
            ~is_read_only:(List.mem s.name _tool_spec_read_only)
            ~is_idempotent:(List.mem s.name _tool_spec_read_only)
+           ?required_permission:(tool_required_permission s.name)
            ()))
     schemas

--- a/test/dune
+++ b/test/dune
@@ -101,6 +101,7 @@
         test_run_local_script
         test_tool_prefilter
         test_keeper_state_machine
+        test_keeper_reconcile_tool
         test_telemetry_unified
         test_keeper_topk_llm
         test_warn_root_causes)
@@ -172,6 +173,7 @@
           test_run_local_script
           test_tool_prefilter
           test_keeper_state_machine
+          test_keeper_reconcile_tool
           test_telemetry_unified
           test_keeper_topk_llm
           test_warn_root_causes)

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -509,6 +509,11 @@ let test_permission_for_tool_keeper_create_from_persona () =
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
+let test_permission_for_tool_keeper_reconcile () =
+  match Auth.permission_for_tool "masc_keeper_reconcile" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
 let test_permission_for_tool_set_param () =
   match Auth.permission_for_tool "masc_set_param" with
   | Some Types.CanAdmin -> ()
@@ -739,6 +744,8 @@ let () =
         test_permission_for_tool_autoresearch_stop;
       test_case "keeper_create_from_persona" `Quick
         test_permission_for_tool_keeper_create_from_persona;
+      test_case "keeper_reconcile" `Quick
+        test_permission_for_tool_keeper_reconcile;
       test_case "set_param" `Quick test_permission_for_tool_set_param;
       test_case "unknown" `Quick test_permission_for_tool_unknown;
       test_case "empty" `Quick test_permission_for_tool_empty;

--- a/test/test_keeper_reconcile_tool.ml
+++ b/test/test_keeper_reconcile_tool.ml
@@ -1,0 +1,161 @@
+open Alcotest
+open Masc_mcp
+
+let () = Mirage_crypto_rng_unix.use_default ()
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_reconcile_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then
+    Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let parse_json_exn body =
+  try Yojson.Safe.from_string body
+  with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
+
+let dispatch_keeper_exn ctx ~name ~args =
+  match Tool_keeper.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("keeper dispatch missing: " ^ name)
+
+let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
+  {
+    config;
+    agent_name;
+    sw;
+    clock = Eio.Stdenv.clock env;
+    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    net = Some (Eio.Stdenv.net env);
+  }
+
+let test_keeper_reconcile_inspect_and_clear () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "reconcile-keeper" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, _body =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Exercise keeper reconcile tool");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      check bool "keeper up ok" true ok;
+      ignore
+        (Keeper_manual_reconcile.open_pending
+           config
+           ~keeper_name
+           ~blocker_class:"ambiguous_post_commit_timeout"
+           ~summary:"turn outcome ambiguous"
+           ~failure_reason:
+             (Some
+                "ambiguous_partial_commit(post_commit_timeout:turn outcome ambiguous)")
+           ~trace_id:(Some "trace-reconcile")
+           ~generation:(Some 3)
+           ~committed_tools:["keeper_shell"; "keeper_task_done"]);
+      Keeper_registry.set_failure_reason ~base_path:config.base_path keeper_name
+        (Some
+           (Keeper_registry.Ambiguous_partial_commit
+              {
+                kind = Keeper_registry.Post_commit_timeout;
+                detail = "turn outcome ambiguous";
+              }));
+      ignore
+        (Keeper_registry.dispatch_event
+           ~base_path:config.base_path
+           keeper_name
+           (Keeper_state_machine.Manual_reconcile_required
+              { reason = "turn outcome ambiguous" }));
+      let ok, inspect_body =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_reconcile"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("action", `String "inspect");
+              ])
+      in
+      check bool "inspect ok" true ok;
+      let inspect_json = parse_json_exn inspect_body in
+      check bool "inspect pending" true
+        Yojson.Safe.Util.(inspect_json |> member "pending" |> to_bool);
+      check string "inspect phase failing" "failing"
+        Yojson.Safe.Util.(inspect_json |> member "phase" |> to_string);
+      check string "inspect blocker class" "ambiguous_post_commit_timeout"
+        Yojson.Safe.Util.(
+          inspect_json |> member "record" |> member "blocker_class" |> to_string);
+      let ok, status_body =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      check bool "status ok before clear" true ok;
+      let status_json = parse_json_exn status_body in
+      check string "status exposes blocker" "ambiguous_post_commit_timeout"
+        Yojson.Safe.Util.(status_json |> member "runtime_blocker_class" |> to_string);
+      let ok, clear_body =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_reconcile"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("action", `String "clear");
+                ("resolution", `String "verified downstream mutations");
+                ( "evidence_refs",
+                  `List [ `String "board:p-1"; `String "task:T-1" ] );
+              ])
+      in
+      check bool "clear ok" true ok;
+      let clear_json = parse_json_exn clear_body in
+      check bool "clear result true" true
+        Yojson.Safe.Util.(clear_json |> member "cleared" |> to_bool);
+      let ok, status_body_after =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      check bool "status ok after clear" true ok;
+      let status_after_json = parse_json_exn status_body_after in
+      check bool "blocker removed after clear" true
+        Yojson.Safe.Util.(status_after_json |> member "runtime_blocker_class" = `Null);
+      check string "phase recovered to running" "running"
+        Yojson.Safe.Util.(
+          status_after_json |> member "runtime" |> member "phase" |> to_string))
+
+let () =
+  run "keeper_reconcile_tool"
+    [
+      ( "tool",
+        [
+          test_case "inspect -> clear" `Quick
+            test_keeper_reconcile_inspect_and_clear;
+        ] );
+    ]

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -291,7 +291,7 @@ let test_apply_heartbeat_ok_does_not_clear_manual_reconcile () =
   check bool "manual reconcile preserved" true
     tr.updated_conditions.manual_reconcile_required
 
-let test_apply_turn_succeeded_clears_manual_reconcile () =
+let test_apply_turn_succeeded_does_not_clear_manual_reconcile () =
   let failing_conds = { running_conditions with
     turn_healthy = false;
     manual_reconcile_required = true;
@@ -300,7 +300,19 @@ let test_apply_turn_succeeded_clears_manual_reconcile () =
     ~current_phase:SM.Failing
     ~conditions:failing_conds
     ~event:SM.Turn_succeeded in
-  check phase_t "clean turn clears reconcile requirement" SM.Running tr.new_phase;
+  check phase_t "manual reconcile still blocks Running" SM.Failing tr.new_phase;
+  check bool "manual reconcile preserved" true
+    tr.updated_conditions.manual_reconcile_required
+
+let test_apply_manual_reconcile_cleared_clears_manual_reconcile () =
+  let failing_conds = { running_conditions with
+    manual_reconcile_required = true;
+  } in
+  let tr = apply_ok
+    ~current_phase:SM.Failing
+    ~conditions:failing_conds
+    ~event:SM.Manual_reconcile_cleared in
+  check phase_t "explicit clear returns to Running" SM.Running tr.new_phase;
   check bool "manual reconcile cleared" false
     tr.updated_conditions.manual_reconcile_required
 
@@ -1443,6 +1455,7 @@ let test_invariant_budget_exhaustion_permanent () =
   let all_events = [
     SM.Heartbeat_ok; SM.Fiber_started;
     SM.Manual_reconcile_required { reason="test" };
+    SM.Manual_reconcile_cleared;
     SM.Supervisor_restart_attempt { attempt=99 };
     SM.Restart_budget_exhausted;
     SM.Operator_resume;
@@ -1460,6 +1473,8 @@ let test_invariant_budget_exhaustion_permanent () =
           guardrail_triggered = false; drain_complete = false }
       | Manual_reconcile_required _ ->
         { conds_no_budget with manual_reconcile_required = true }
+      | Manual_reconcile_cleared ->
+        { conds_no_budget with manual_reconcile_required = false }
       | Supervisor_restart_attempt _ -> { conds_no_budget with backoff_elapsed = true }
       | Restart_budget_exhausted -> { conds_no_budget with restart_budget_remaining = false }
       | Operator_resume -> { conds_no_budget with operator_paused = false }
@@ -1712,7 +1727,8 @@ let () =
       test_case "Failing + fiber death -> Crashed" `Quick test_apply_failing_to_crashed;
       test_case "manual reconcile required -> Failing" `Quick test_apply_manual_reconcile_required_to_failing;
       test_case "heartbeat ok does not clear manual reconcile" `Quick test_apply_heartbeat_ok_does_not_clear_manual_reconcile;
-      test_case "turn succeeded clears manual reconcile" `Quick test_apply_turn_succeeded_clears_manual_reconcile;
+      test_case "turn succeeded does not clear manual reconcile" `Quick test_apply_turn_succeeded_does_not_clear_manual_reconcile;
+      test_case "manual reconcile cleared -> Running" `Quick test_apply_manual_reconcile_cleared_clears_manual_reconcile;
       test_case "partial heartbeat -> Failing" `Quick test_apply_partial_heartbeat_failure;
       test_case "fiber terminated -> Crashed" `Quick test_apply_fiber_terminated_crash;
       test_case "crash -> restart -> Running" `Quick test_apply_crash_restart_lifecycle;

--- a/test/test_keeper_state_machine_pbt.ml
+++ b/test/test_keeper_state_machine_pbt.ml
@@ -1,13 +1,13 @@
 (** test_keeper_state_machine_pbt — Property-based tests for keeper state machine.
 
     Two modes:
-    - Chaos: random events from all 22 variants. Tests rejection correctness.
+    - Chaos: random events from all 23 variants. Tests rejection correctness.
     - Guided: phase-aware events only. Tests state transition coverage. *)
 
 module SM = Masc_mcp.Keeper_state_machine
 module IC = Masc_mcp.Keeper_invariant_check
 
-(* ── Chaos Generator: all 22 event variants ────────────── *)
+(* ── Chaos Generator: all 23 event variants ────────────── *)
 
 let gen_auto_rules : SM.auto_rule_summary QCheck.Gen.t =
   let open QCheck.Gen in
@@ -30,6 +30,7 @@ let gen_event_chaos : SM.event QCheck.Gen.t =
     (let* consecutive = int_range 1 5 in
      return (SM.Turn_failed { consecutive; max_allowed = 3 }));
     return (SM.Manual_reconcile_required { reason = "pbt_test" });
+    return SM.Manual_reconcile_cleared;
     (let* ratio = float_range 0.0 1.0 in
      let* auto_rules = gen_auto_rules in
      return (SM.Context_measured {
@@ -67,6 +68,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
         SM.Turn_succeeded;
         SM.Turn_failed { consecutive = 1; max_allowed = 3 };
         SM.Manual_reconcile_required { reason = "test" };
+        SM.Manual_reconcile_cleared;
         SM.Context_measured {
           context_ratio = 0.5; message_count = 50; token_count = 5000;
           auto_rules = { reflect = false; plan = false; compact = false;
@@ -82,6 +84,7 @@ let valid_events_for_phase (phase : SM.phase) (c : SM.conditions) : SM.event lis
       ]
     | SM.Failing ->
       [ SM.Heartbeat_ok; SM.Turn_succeeded;
+        SM.Manual_reconcile_cleared;
         SM.Manual_reconcile_required { reason = "test" };
         SM.Fiber_terminated { outcome = "crash" };
         SM.Stop_requested; SM.Operator_pause;

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1967,15 +1967,36 @@ let test_normalize_response_text_empty_without_tools_errors () =
          in
          found)
 
-let test_normalize_response_text_empty_without_tools_can_be_allowed () =
+let test_validate_completion_contract_allows_text_without_tools () =
   match
-    KTD.normalize_response_text
-      ~allow_empty_without_tools:true
-      ~text:""
+    KTD.validate_completion_contract
+      ~contract:KTD.Allow_text_or_tool
       ~tool_names:[]
       ()
   with
-  | Ok text -> check string "empty text preserved" "" text
+  | Ok () -> ()
+  | Error e -> fail ("unexpected error: " ^ e)
+
+let test_validate_completion_contract_requires_tool_use () =
+  match
+    KTD.validate_completion_contract
+      ~contract:KTD.Require_tool_use
+      ~tool_names:[]
+      ()
+  with
+  | Ok () -> fail "expected tool contract failure"
+  | Error e ->
+      check bool "error mentions required tool contract" true
+        (contains_substring e "required tool contract")
+
+let test_validate_completion_contract_accepts_stay_silent () =
+  match
+    KTD.validate_completion_contract
+      ~contract:KTD.Require_tool_use
+      ~tool_names:["keeper_stay_silent"]
+      ()
+  with
+  | Ok () -> ()
   | Error e -> fail ("unexpected error: " ^ e)
 
 let test_tool_usage_delta_uses_registry_counts () =
@@ -2573,8 +2594,12 @@ let () =
             test_normalize_response_text_tool_only_synthesizes;
           test_case "normalize empty without tools errors" `Quick
             test_normalize_response_text_empty_without_tools_errors;
-          test_case "normalize empty without tools can be allowed" `Quick
-            test_normalize_response_text_empty_without_tools_can_be_allowed;
+          test_case "completion contract allows text without tools" `Quick
+            test_validate_completion_contract_allows_text_without_tools;
+          test_case "completion contract requires tool use" `Quick
+            test_validate_completion_contract_requires_tool_use;
+          test_case "completion contract accepts stay silent" `Quick
+            test_validate_completion_contract_accepts_stay_silent;
           test_case "tool usage delta uses registry counts" `Quick
             test_tool_usage_delta_uses_registry_counts;
           test_case "tool usage delta ignores removed tools" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1919,6 +1919,17 @@ let test_normalize_response_text_empty_without_tools_errors () =
          in
          found)
 
+let test_normalize_response_text_empty_without_tools_can_be_allowed () =
+  match
+    KTD.normalize_response_text
+      ~allow_empty_without_tools:true
+      ~text:""
+      ~tool_names:[]
+      ()
+  with
+  | Ok text -> check string "empty text preserved" "" text
+  | Error e -> fail ("unexpected error: " ^ e)
+
 let test_tool_usage_delta_uses_registry_counts () =
   let before =
     [
@@ -2069,6 +2080,44 @@ let test_social_model_empty_text_without_headers_stays_silent () =
     (Some "no tool calls and no social headers") state.blocker;
   check string "visible response suppressed" "" routed.response_text;
   check (list string) "no synthetic tools" [] routed.tools_used
+
+let test_social_model_state_only_reply_stays_silent () =
+  let result =
+    make_run_result
+      ~text:
+        "[STATE]\nGoal: keep things tidy\nProgress: no visible response needed\n[/STATE]"
+      ~tools:[]
+      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation result
+  in
+  check string "speech act" "defer"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "silent"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check string "visible response suppressed" "" routed.response_text
+
+let test_social_model_strips_state_block_from_visible_reply () =
+  let result =
+    make_run_result
+      ~text:
+        "Board checked.\n[STATE]\nGoal: keep things tidy\nProgress: board scanned\n[/STATE]"
+      ~tools:[]
+      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation result
+  in
+  check string "speech act" "inform"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "visible_reply"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check string "visible response strips state block"
+    "Board checked."
+    routed.response_text
 
 let test_social_model_routes_blocker_to_board_post () =
   let result =
@@ -2472,6 +2521,8 @@ let () =
             test_normalize_response_text_tool_only_synthesizes;
           test_case "normalize empty without tools errors" `Quick
             test_normalize_response_text_empty_without_tools_errors;
+          test_case "normalize empty without tools can be allowed" `Quick
+            test_normalize_response_text_empty_without_tools_can_be_allowed;
           test_case "tool usage delta uses registry counts" `Quick
             test_tool_usage_delta_uses_registry_counts;
           test_case "tool usage delta ignores removed tools" `Quick
@@ -2488,6 +2539,10 @@ let () =
             test_social_model_infers_visible_reply_without_headers;
           test_case "social model empty text without headers stays silent" `Quick
             test_social_model_empty_text_without_headers_stays_silent;
+          test_case "social model state-only reply stays silent" `Quick
+            test_social_model_state_only_reply_stays_silent;
+          test_case "social model strips state block from visible reply" `Quick
+            test_social_model_strips_state_block_from_visible_reply;
           test_case "social model routes blocker to board post" `Quick
             test_social_model_routes_blocker_to_board_post;
           test_case "social model tool-only turn skips protocol violation" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -97,6 +97,11 @@ let contains_substring ~needle haystack =
   in
   loop 0
 
+let response_text (resp : Oas.Types.api_response) =
+  resp.Oas.Types.content
+  |> List.filter_map (function Oas.Types.Text s -> Some s | _ -> None)
+  |> String.concat ""
+
 let start_multi_mock ~sw ~net ~port (responses : string list) =
   let idx = Atomic.make 0 in
   let handler _conn _req body =
@@ -693,6 +698,80 @@ let test_worker_build_agent_validation_retry_exhausted () =
                 Eio.Switch.fail sw Exit
             | Error err -> Alcotest.fail (Oas.Error.to_string err))
     | Error err -> Alcotest.fail err
+  with Exit -> ()
+
+let test_oas_worker_exec_run_exit_condition_result_returns_partial_success () =
+  try
+    Eio.Switch.run @@ fun sw ->
+    let responses =
+      [
+        openai_tool_use_response "noop" {|{}|};
+        openai_text_response ~id:"chatcmpl-should-not-run" "should not happen";
+      ]
+    in
+    let port =
+      match find_free_port () with Some port -> port | None -> Alcotest.skip ()
+    in
+    let url =
+      try start_multi_mock ~sw ~net:(require_test_net ()) ~port responses
+      with
+      | Unix.Unix_error (Unix.EPERM, "bind", _)
+      | Unix.Unix_error (Unix.EACCES, "bind", _) ->
+          Alcotest.skip ()
+    in
+    let provider : Oas.Provider.config =
+      {
+        provider = Oas.Provider.Local { base_url = url };
+        model_id = "mock-model";
+        api_key_env = "";
+      }
+    in
+    let noop_tool = make_noop_tool () in
+    let base_config =
+      Oas_worker_exec.default_config
+        ~name:"oas-worker-exit-condition"
+        ~provider
+        ~model_id:"mock-model"
+        ~system_prompt:"system"
+        ~tools:[ noop_tool ]
+    in
+    let config =
+      {
+        base_config with
+        exit_condition = Some (fun turn -> turn >= 1);
+        exit_condition_result =
+          Some
+            (fun turn ->
+              ( Oas_worker_exec.MutationBoundaryReached
+                  { turns_used = turn; tool_name = Some "keeper_shell" },
+                Some
+                  "[mutation boundary reached after committed tool: keeper_shell]" ));
+      }
+    in
+    match
+      Oas_worker_exec.run
+        ~sw
+        ~net:(require_test_net ())
+        ~config
+        "say hello"
+    with
+    | Ok result ->
+        Alcotest.(check int) "turn count preserved" 1 result.turns;
+        Alcotest.(check bool) "checkpoint present" true
+          (Option.is_some result.checkpoint);
+        (match result.stop_reason with
+         | Oas_worker_exec.MutationBoundaryReached { turns_used; tool_name } ->
+             Alcotest.(check int) "boundary turn count" 1 turns_used;
+             Alcotest.(check (option string)) "boundary tool"
+               (Some "keeper_shell") tool_name
+         | _ ->
+             Alcotest.fail "expected mutation boundary stop reason");
+        Alcotest.(check bool) "partial response mentions mutation boundary" true
+          (contains_substring
+             ~needle:"mutation boundary reached after committed tool: keeper_shell"
+             (response_text result.response));
+        Eio.Switch.fail sw Exit
+    | Error err -> Alcotest.fail (Oas.Error.to_string err)
   with Exit -> ()
 
 (* ================================================================ *)
@@ -1457,6 +1536,8 @@ let () =
         test_worker_build_agent_validation_retry_success;
       Alcotest.test_case "worker build_agent exhausts validation retries deterministically" `Quick
         test_worker_build_agent_validation_retry_exhausted;
+      Alcotest.test_case "exit_condition_result returns partial success" `Quick
+        test_oas_worker_exec_run_exit_condition_result_returns_partial_success;
     ];
     "keeper_checkpoint_boundary", [
       Alcotest.test_case "prefers OAS checkpoint over legacy" `Quick

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -6,6 +6,7 @@ open Alcotest
 module R = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
 module KSM = Masc_mcp.Keeper_state_machine
+module KMR = Masc_mcp.Keeper_manual_reconcile
 module Cfg = Env_config
 
 let bp = "/tmp/test-phase2"
@@ -246,6 +247,44 @@ let test_dead_tombstone_is_registered () =
   check bool "Dead is registered" true (R.is_registered ~base_path:bp "k1");
   check bool "Dead is not running" false (R.is_running ~base_path:bp "k1")
 
+let test_manual_reconcile_store_roundtrip () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ()) "test-phase2-manual-reconcile" in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let config = Masc_mcp.Room.default_config dir in
+  let record =
+    KMR.open_pending config
+      ~keeper_name:"k1"
+      ~blocker_class:"ambiguous_post_commit_timeout"
+      ~summary:"turn outcome ambiguous"
+      ~failure_reason:(Some "ambiguous_partial_commit(post_commit_timeout:test)")
+      ~trace_id:(Some "trace-k1")
+      ~generation:(Some 2)
+      ~committed_tools:["keeper_shell"; "keeper_task_done"]
+  in
+  check bool "pending after open" true (KMR.is_pending config "k1");
+  check string "cache key opened" record.updated_at
+    (match String.split_on_char '|' (KMR.cache_key config "k1") with
+     | _status :: updated_at :: _ -> updated_at
+     | _ -> "");
+  match KMR.clear config ~keeper_name:"k1" ~actor:"tester"
+          ~resolution:"verified downstream side effects"
+          ~evidence_refs:["board:p-1"; "task:T-1"]
+          ~idempotency_key:(Some "idem-1")
+  with
+  | KMR.Cleared_record cleared ->
+      check bool "not pending after clear" false (KMR.is_pending config "k1");
+      check string "status cleared" "cleared"
+        (match KMR.read config "k1" with
+         | Some record -> (
+             match record.status with
+             | KMR.Cleared -> "cleared"
+             | KMR.Pending -> "pending")
+         | None -> "missing");
+      check string "resolution persisted" "verified downstream side effects"
+        (Option.value ~default:"" cleared.resolution)
+  | KMR.Already_cleared _ -> fail "expected first clear to mutate"
+  | KMR.No_record -> fail "expected persisted record"
+
 (* ── Test runner ──────────────────────────────────────── *)
 
 let () =
@@ -295,5 +334,8 @@ let () =
     ];
     "dead_tombstone", [
       eio_test "Dead is registered but not running" test_dead_tombstone_is_registered;
+    ];
+    "manual_reconcile_store", [
+      eio_test "pending -> clear roundtrip" test_manual_reconcile_store_roundtrip;
     ];
   ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -534,6 +534,20 @@ let test_masc_keeper_repair_schema () =
             (List.mem_assoc "validator_profile" props)
       | None -> Alcotest.fail "masc_keeper_repair missing properties"
 
+let test_masc_keeper_reconcile_schema () =
+  match find_tool "masc_keeper_reconcile" with
+  | None -> Alcotest.fail "masc_keeper_reconcile not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has action" true
+            (List.mem_assoc "action" props);
+          Alcotest.(check bool) "has resolution" true
+            (List.mem_assoc "resolution" props);
+          Alcotest.(check bool) "has evidence_refs" true
+            (List.mem_assoc "evidence_refs" props)
+      | None -> Alcotest.fail "masc_keeper_reconcile missing properties"
+
 (* keeper policy schema tests removed — policy tool schemas no longer exist *)
 
 let test_masc_tool_admin_snapshot_schema () =
@@ -811,6 +825,8 @@ let () =
         test_masc_keeper_msg_schema;
       Alcotest.test_case "keeper-repair" `Quick
         test_masc_keeper_repair_schema;
+      Alcotest.test_case "keeper-reconcile" `Quick
+        test_masc_keeper_reconcile_schema;
     ];
     "runtime_admin_tools", [
       Alcotest.test_case "tool-admin-snapshot" `Quick


### PR DESCRIPTION
## Summary
- stop long-running keeper OAS calls at a mutation boundary after committed non-reconcile-safe tool activity and resume from a checkpoint on the next cycle
- add a durable manual reconcile record with explicit `pending -> cleared` lifecycle
- add `masc_keeper_reconcile` with `inspect` and `clear` actions
- move keepalive/status/dashboard blocker handling to the persisted reconcile record instead of relying only on sticky registry state
- add regression coverage for mutation-boundary handling, FSM clear semantics, auth/tool coverage, and the new reconcile tool

## Product impact
- ambiguous post-commit failures become persisted reconcile records instead of ad-hoc sticky failure state
- keepalive no longer clears manual reconcile implicitly through `Turn_succeeded`
- operators can inspect and clear reconcile state explicitly through MCP
- worker-level auth classification for `masc_keeper_reconcile` is consistent across legacy and policy-based paths

## Evidence
- root cause: keeper/OAS execution could time out after mutating tools had already committed, leaving an ambiguous partial-commit state while runtime health could drift from reconcile truth
- implementation: mutation boundary short-circuits the same run after non-reconcile-safe committed tool activity and persists manual reconcile state for explicit operator clearance
- local validation:
  - `./_build/default/test/test_tool_access_role.exe`
  - `./_build/default/test/test_keeper_reconcile_tool.exe`
  - previously validated on this branch before PR creation: `test_auth_coverage.exe`, `test_tool_surface_ssot.exe`, `test_tools_coverage.exe`, `test_oas_worker.exe`, `test_keeper_unified.exe`, `test_keeper_state_machine.exe`, `test_phase2_self_preservation.exe`, `test_keeper_exec_status.exe`

## Review evidence
- cross-model review: direct `sb glm-text` (`GLM-5` path)
- scope: PR diff vs `main`
- result: `No findings.`
- evidence comment: https://github.com/jeong-sik/masc-mcp/pull/6254#issuecomment-4219095574

## Linked issue
- Refs #5941
