### PR TITLE
[codex] improve Discord connector manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ For external channel adapters, treat the Channel Gate as the boundary owner:
 - write/traffic path: `/api/v1/gate/message`
 - read/descriptor path: `/api/v1/gate/connectors`
 - per-channel metrics path: `/api/v1/gate/status`
+- Discord bot setup and live verification: [sidecars/discord-bot/README.md](sidecars/discord-bot/README.md)
 
 The dashboard should learn connector type and status from the gate descriptor
 surface instead of hardcoding vendor-specific assumptions.

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -259,6 +259,10 @@ Current host note:
 
 Notes:
 
+- Discord connector runtime files are shared between the gate server and the
+  Discord bot. When the bot uses relative paths, resolve them against the same
+  `MASC_BASE_PATH` as the server. Operational setup and verification steps live
+  in `sidecars/discord-bot/README.md`.
 - `VOICE_MCP_HOST` and `VOICE_MCP_PORT` remain legacy environment fallbacks.
 - The voice session directory follows the selected voice-config directory, not an unrelated global path.
 

--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -15,14 +15,15 @@ GATE_API_TOKEN=
 DISCORD_KEEPER_MAP={"1234567890": "luna"}
 
 # Durable store for runtime bind/unbind changes.
-# If this file exists, it becomes the effective binding SSOT on restart.
-DISCORD_BINDING_STORE_PATH=.gate/discord_bindings.json
+# Default runtime root is .masc/connectors/discord/* and should usually share
+# the same MASC_BASE_PATH as the server.
+DISCORD_BINDING_STORE_PATH=.masc/connectors/discord/bindings.json
 
 # Append-only operator audit trail for bind/unbind changes.
-DISCORD_BINDING_AUDIT_PATH=.gate/discord_binding_audit.jsonl
+DISCORD_BINDING_AUDIT_PATH=.masc/connectors/discord/binding_audit.jsonl
 
 # Runtime status heartbeat used by the dashboard's direct Discord panel.
-DISCORD_STATUS_PATH=.gate/discord_status.json
+DISCORD_STATUS_PATH=.masc/connectors/discord/status.json
 STATUS_HEARTBEAT_SEC=10
 
 # Discord role ID for admin commands (optional)

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -11,6 +11,37 @@ Discord <-> This Bot <-> Channel Gate (/api/v1/gate/*) <-> Keeper
 This bot is a **protocol adapter**. It translates between Discord's API and
 the Channel Gate's HTTP API. No business logic, no LLM calls.
 
+## What "Working" Means
+
+The Discord path is healthy only when all of the following are true:
+
+1. The MASC server is running and `/api/v1/gate/health` returns `ok=true`.
+2. The Discord bot process is running and logged into Discord.
+3. The bot and the server resolve the same runtime root for connector state.
+4. `/api/v1/gate/discord/status` reports `connected=true`.
+
+If the gate says `offline` with `connector status file not found`, the server is
+up but the Discord bot has not written its runtime heartbeat yet.
+
+## Quick Start
+
+Run the bot from `sidecars/discord-bot`, but make sure its runtime root matches
+the server's `MASC_BASE_PATH`.
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc-mcp/sidecars/discord-bot
+cp .env.example .env
+
+# Required for shared connector state with the local MASC server.
+export MASC_BASE_PATH=~/me
+
+# Install dependencies once.
+uv pip install -e ".[dev]"
+
+# Start the bot from this directory so .env is auto-loaded.
+python -m src
+```
+
 ## Setup
 
 ### 1. Create Discord Bot
@@ -35,7 +66,40 @@ cp .env.example .env
 can omit it when the server keeps `require_token=false`; in that mode the
 connector falls back to same-origin auth headers against `127.0.0.1`/`localhost`.
 
-### 3. Run
+### 3. Match The Server Runtime Root
+
+By default the bot writes runtime files under:
+
+- `.masc/connectors/discord/bindings.json`
+- `.masc/connectors/discord/binding_audit.jsonl`
+- `.masc/connectors/discord/status.json`
+
+Relative paths resolve from `MASC_BASE_PATH` when it is set; otherwise they
+resolve from the bot's current working directory.
+
+For local development, the server usually owns the runtime root. The safest
+pattern is:
+
+```bash
+export MASC_BASE_PATH=~/me
+```
+
+That keeps the bot aligned with a server process that also runs with
+`MASC_BASE_PATH=~/me`, so both sides read and write the same connector state.
+
+If you intentionally want sidecar-local files instead, set explicit paths in
+`.env`:
+
+```bash
+DISCORD_BINDING_STORE_PATH=.gate/discord_bindings.json
+DISCORD_BINDING_AUDIT_PATH=.gate/discord_binding_audit.jsonl
+DISCORD_STATUS_PATH=.gate/discord_status.json
+```
+
+Use that mode only if the server is configured to read the same files via
+`MASC_DISCORD_*` overrides or matching base-path rules.
+
+### 4. Run
 
 ```bash
 # Install dependencies
@@ -45,11 +109,44 @@ uv pip install -e ".[dev]"
 python -m src
 ```
 
-### 4. Test
+### 5. Test
 
 ```bash
 uv pip install -e ".[dev]"
 pytest tests/
+```
+
+## Verify End-To-End
+
+Before starting the bot:
+
+```bash
+curl -sfS http://127.0.0.1:8935/api/v1/gate/health
+curl -sfS http://127.0.0.1:8935/api/v1/gate/discord/status
+```
+
+Expected state before the bot is ready:
+
+- `/gate/health` returns `{"ok":true,...}`
+- `/gate/discord/status` may show `offline`
+
+After the bot is logged in and heartbeats are being written:
+
+```bash
+curl -sfS http://127.0.0.1:8935/api/v1/gate/discord/status
+curl -sfS http://127.0.0.1:8935/api/v1/gate/connectors
+```
+
+Expected state after the bot is ready:
+
+- `connected=true`
+- `status="connected"`
+- `status_path` points at the same runtime root the bot is using
+
+If you want a quick process check:
+
+```bash
+ps -ef | rg "python(3)? -m src|discord-gate-bot"
 ```
 
 ## Channel-Keeper Mapping
@@ -104,3 +201,39 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
   `Attachments:` block instead of dropping them as empty content
 - A lightweight transport circuit breaker prevents repeated timeouts / 5xx
   storms from hammering the gate while still serving cached status data
+
+## Troubleshooting
+
+### Gate shows `offline`
+
+Check these in order:
+
+1. The bot process is running.
+2. `MASC_BASE_PATH` matches the server runtime root.
+3. `DISCORD_STATUS_PATH` resolves to the file the server is reading.
+4. The bot token is valid and the bot has logged into Discord.
+
+Useful checks:
+
+```bash
+curl -sfS http://127.0.0.1:8935/api/v1/gate/discord/status
+ls -la ~/me/.masc/connectors/discord
+```
+
+### Messages are ignored in a channel
+
+The bot only forwards messages from mapped channels.
+
+Check:
+
+- `DISCORD_KEEPER_MAP` in `.env`
+- `/keeper-map`
+- `/keeper-bind <keeper>`
+
+### Dashboard bind/unbind works but the bot does not follow changes
+
+The bot hot-reloads the durable binding store. If it does not react:
+
+1. Confirm the dashboard and the bot are writing the same `bindings.json`.
+2. Confirm the file mtime changes after bind/unbind.
+3. Restart the bot once to rule out a stale process.

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -29,11 +29,13 @@ Run the bot from `sidecars/discord-bot`, but make sure its runtime root matches
 the server's `MASC_BASE_PATH`.
 
 ```bash
-cd ~/me/workspace/yousleepwhen/masc-mcp/sidecars/discord-bot
+REPO_ROOT=$(git rev-parse --show-toplevel) &&
+cd "$REPO_ROOT/sidecars/discord-bot" &&
 cp .env.example .env
 
 # Required for shared connector state with the local MASC server.
-export MASC_BASE_PATH=~/me
+# Match the same runtime root the server uses.
+export MASC_BASE_PATH=/path/to/server/runtime/root
 
 # Install dependencies once.
 uv pip install -e ".[dev]"
@@ -217,7 +219,7 @@ Useful checks:
 
 ```bash
 curl -sfS http://127.0.0.1:8935/api/v1/gate/discord/status
-ls -la ~/me/.masc/connectors/discord
+ls -la "${MASC_BASE_PATH:-$(pwd)}/.masc/connectors/discord"
 ```
 
 ### Messages are ignored in a channel

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -83,11 +83,11 @@ For local development, the server usually owns the runtime root. The safest
 pattern is:
 
 ```bash
-export MASC_BASE_PATH=~/me
+export MASC_BASE_PATH=/path/to/your/project
 ```
 
 That keeps the bot aligned with a server process that also runs with
-`MASC_BASE_PATH=~/me`, so both sides read and write the same connector state.
+the same `MASC_BASE_PATH`, so both sides read and write the same connector state.
 
 If you intentionally want sidecar-local files instead, set explicit paths in
 `.env`:


### PR DESCRIPTION
## Summary
- expand the Discord connector operator manual in `sidecars/discord-bot/README.md`
- align `sidecars/discord-bot/.env.example` with the current `.masc/connectors/discord/*` defaults
- add entry-point links from the root README and boot/env inventory

## Product impact
- promise: `ops visibility`
- makes Discord connector bring-up and troubleshooting less guessy for local operators
- reduces confusion between current `.masc` defaults and intentional legacy `.gate` overrides

## Evidence
- `git diff --check`
- manual local gate inspection via:
  - `/api/v1/gate/health`
  - `/api/v1/gate/status`
  - `/api/v1/gate/connectors`
  - `/api/v1/gate/discord/status`
- connector-side tests had already passed during investigation:
  - `./.venv/bin/pytest tests/test_masc_client.py tests/test_binding_store.py tests/test_status_store.py tests/test_formatters.py tests/test_audit_store.py`
  - `dune runtest test/test_channel_gate_connector_routes.exe test/test_channel_gate_discord_state.exe test/test_channel_gate.exe test/test_channel_gate_metrics.exe`

## Review evidence
- reviewer model: `glm-5.1`
- reviewer path: direct `sb glm-text`
- timestamp: `2026-04-10T01:08:07Z`
- scope: `origin/main...docs/discord-readme-manual`
- result: `No findings.`

## Linked issue
- Refs #4751
