### PR TITLE
fix(keeper): add recovery hint for hallucinated issue/PR numbers

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -144,12 +144,21 @@ let handle_keeper_github
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
         in
+        let not_found_hint =
+          if st <> Unix.WEXITED 0
+             && Re.execp (Re.compile (Re.str "Could not resolve")) out
+          then
+            [ "hint", `String
+                "The issue/PR number does not exist. Do not guess numbers. \
+                 Use 'issue list' or 'pr list' to find valid targets first." ]
+          else []
+        in
         Yojson.Safe.to_string
           (`Assoc
-              [ "ok", `Bool (st = Unix.WEXITED 0)
-              ; "status", Keeper_alerting_path.process_status_to_json st
-              ; "output", `String out
-              ])))
+              ([ "ok", `Bool (st = Unix.WEXITED 0)
+               ; "status", Keeper_alerting_path.process_status_to_json st
+               ; "output", `String out
+               ] @ not_found_hint))))
 ;;
 
 let handle_keeper_pr_workflow

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -127,12 +127,21 @@ let handle_keeper_github
           in
           let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
           let st, out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
+          let not_found_hint =
+            if st <> Unix.WEXITED 0
+               && Re.execp (Re.compile (Re.str "Could not resolve")) out
+            then
+              [ "hint", `String
+                  "The issue/PR number does not exist. Do not guess numbers. \
+                   Use 'issue list' or 'pr list' to find valid targets first." ]
+            else []
+          in
           Yojson.Safe.to_string
             (`Assoc
-                [ "ok", `Bool (st = Unix.WEXITED 0)
-                ; "status", Keeper_alerting_path.process_status_to_json st
-                ; "output", `String out
-                ]))
+                ([ "ok", `Bool (st = Unix.WEXITED 0)
+                 ; "status", Keeper_alerting_path.process_status_to_json st
+                 ; "output", `String out
+                 ] @ not_found_hint)))
       else (
         let gh_cmd =
           if cmd <> ""

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -1,6 +1,28 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(** Pre-compiled regex for gh CLI "not found" error messages.
+    Matches case-insensitively against multiple known error phrases
+    to detect hallucinated issue/PR numbers. *)
+let gh_not_found_re =
+  Re.compile
+    (Re.alt
+       [ Re.no_case (Re.str "Could not resolve")
+       ; Re.no_case (Re.str "Could not find")
+       ; Re.no_case (Re.str "No such issue")
+       ; Re.no_case (Re.str "not found")
+       ])
+
+(** Return a hint field list when gh exits non-zero and output matches
+    a known "not found" pattern, indicating a hallucinated issue/PR number. *)
+let gh_not_found_hint ~(st : Unix.process_status) ~(out : string) =
+  if st <> Unix.WEXITED 0 && Re.execp gh_not_found_re out
+  then
+    [ "hint", `String
+        "The issue/PR number does not exist. Do not guess numbers. \
+         Use 'issue list' or 'pr list' to find valid targets first." ]
+  else []
+
 let handle_keeper_github
       ~(config : Room.config)
       ~(meta : keeper_meta)
@@ -127,21 +149,12 @@ let handle_keeper_github
           in
           let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
           let st, out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
-          let not_found_hint =
-            if st <> Unix.WEXITED 0
-               && Re.execp (Re.compile (Re.str "Could not resolve")) out
-            then
-              [ "hint", `String
-                  "The issue/PR number does not exist. Do not guess numbers. \
-                   Use 'issue list' or 'pr list' to find valid targets first." ]
-            else []
-          in
           Yojson.Safe.to_string
             (`Assoc
                 ([ "ok", `Bool (st = Unix.WEXITED 0)
                  ; "status", Keeper_alerting_path.process_status_to_json st
                  ; "output", `String out
-                 ] @ not_found_hint)))
+                 ] @ gh_not_found_hint ~st ~out)))
       else (
         let gh_cmd =
           if cmd <> ""
@@ -153,21 +166,12 @@ let handle_keeper_github
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
         in
-        let not_found_hint =
-          if st <> Unix.WEXITED 0
-             && Re.execp (Re.compile (Re.str "Could not resolve")) out
-          then
-            [ "hint", `String
-                "The issue/PR number does not exist. Do not guess numbers. \
-                 Use 'issue list' or 'pr list' to find valid targets first." ]
-          else []
-        in
         Yojson.Safe.to_string
           (`Assoc
               ([ "ok", `Bool (st = Unix.WEXITED 0)
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "output", `String out
-               ] @ not_found_hint))))
+               ] @ gh_not_found_hint ~st ~out))))
 ;;
 
 let handle_keeper_pr_workflow

--- a/lib/keeper/keeper_exec_github.mli
+++ b/lib/keeper/keeper_exec_github.mli
@@ -1,5 +1,14 @@
 (** Keeper GitHub tool handlers — git commands and PR workflow. *)
 
+(** Return a [("hint", `String ...)] field when [st] is a non-zero exit
+    and [out] matches a known "not found" error pattern from gh CLI.
+    Returns [[]] otherwise. Useful for detecting hallucinated issue/PR
+    numbers. *)
+val gh_not_found_hint :
+  st:Unix.process_status ->
+  out:string ->
+  (string * Yojson.Safe.t) list
+
 val handle_keeper_github :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/dune
+++ b/test/dune
@@ -355,7 +355,8 @@
         test_governance_yojson_roundtrip
         test_eval_calibration
         test_goal_janitor
-        test_keeper_pr_workflow)
+        test_keeper_pr_workflow
+        test_keeper_github_hint)
  (modules
         test_runtime_params
         test_config_dir_resolver
@@ -500,7 +501,8 @@
         test_governance_yojson_roundtrip
         test_eval_calibration
         test_goal_janitor
-        test_keeper_pr_workflow)
+        test_keeper_pr_workflow
+        test_keeper_github_hint)
  (libraries masc_test_deps))
 
 ; Tool diversity: Shannon entropy + QCheck PBT

--- a/test/test_keeper_github_hint.ml
+++ b/test/test_keeper_github_hint.ml
@@ -1,0 +1,145 @@
+(** Tests for keeper_exec_github.gh_not_found_hint.
+
+    Verifies the not-found hint logic that detects hallucinated
+    issue/PR numbers from gh CLI error output.
+
+    Cases:
+    1. WEXITED 1 + "Could not resolve..." -> hint present
+    2. WEXITED 0 + any output            -> hint absent
+    3. WEXITED 1 + unrelated error        -> hint absent
+    4. Case-insensitive matching works
+    5. Additional error phrases detected *)
+
+open Alcotest
+
+let hint = Masc_mcp.Keeper_exec_github.gh_not_found_hint
+
+let has_hint result =
+  List.exists (fun (k, _) -> k = "hint") result
+
+(* --- WEXITED 1 + "Could not resolve" -> hint present --- *)
+
+let test_exit1_could_not_resolve () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"Could not resolve to a pull request with the number 999" in
+  check bool "hint present for Could not resolve"
+    true (has_hint result)
+
+(* --- WEXITED 0 -> hint absent regardless of output --- *)
+
+let test_exit0_no_hint () =
+  let result = hint
+    ~st:(Unix.WEXITED 0)
+    ~out:"Could not resolve to a pull request with the number 999" in
+  check bool "hint absent when exit 0"
+    false (has_hint result)
+
+(* --- WEXITED 1 + unrelated error -> hint absent --- *)
+
+let test_exit1_other_error () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"HTTP 502: Bad Gateway" in
+  check bool "hint absent for unrelated error"
+    false (has_hint result)
+
+(* --- Case-insensitive: "could not resolve" (lowercase) --- *)
+
+let test_case_insensitive_resolve () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"could not resolve to a pull request" in
+  check bool "hint present for lowercase could not resolve"
+    true (has_hint result)
+
+(* --- Additional phrase: "Could not find" --- *)
+
+let test_could_not_find () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"Could not find issue #12345" in
+  check bool "hint present for Could not find"
+    true (has_hint result)
+
+(* --- Additional phrase: "No such issue" --- *)
+
+let test_no_such_issue () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"No such issue exists in this repository" in
+  check bool "hint present for No such issue"
+    true (has_hint result)
+
+(* --- Additional phrase: "not found" --- *)
+
+let test_not_found () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"issue not found" in
+  check bool "hint present for not found"
+    true (has_hint result)
+
+(* --- WEXITED 1 + empty output -> hint absent --- *)
+
+let test_exit1_empty_output () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"" in
+  check bool "hint absent for empty output"
+    false (has_hint result)
+
+(* --- Non-WEXITED status (e.g. WSIGNALED) + matching output -> hint present.
+       Any non-zero/non-WEXITED(0) status is treated as failure. --- *)
+
+let test_signaled_with_matching_output () =
+  let result = hint
+    ~st:(Unix.WSIGNALED 9)
+    ~out:"Could not resolve to a pull request" in
+  check bool "hint present for WSIGNALED with matching output"
+    true (has_hint result)
+
+(* --- Hint text content verification --- *)
+
+let test_hint_text_content () =
+  let result = hint
+    ~st:(Unix.WEXITED 1)
+    ~out:"Could not resolve to a pull request with the number 42" in
+  match List.assoc_opt "hint" result with
+  | Some (`String s) ->
+    check bool "hint mentions issue list"
+      true (String.length s > 0
+            && (try ignore (Str.search_forward
+                  (Str.regexp_string "issue list") s 0); true
+                with Not_found -> false));
+    check bool "hint mentions pr list"
+      true (try ignore (Str.search_forward
+                  (Str.regexp_string "pr list") s 0); true
+            with Not_found -> false)
+  | _ -> fail "expected hint key with string value"
+
+let () =
+  run "keeper_github_hint"
+    [ "not_found_detection",
+      [ test_case "exit1 + Could not resolve -> hint" `Quick
+          test_exit1_could_not_resolve
+      ; test_case "exit0 -> no hint" `Quick
+          test_exit0_no_hint
+      ; test_case "exit1 + other error -> no hint" `Quick
+          test_exit1_other_error
+      ; test_case "case insensitive resolve" `Quick
+          test_case_insensitive_resolve
+      ; test_case "Could not find" `Quick
+          test_could_not_find
+      ; test_case "No such issue" `Quick
+          test_no_such_issue
+      ; test_case "not found" `Quick
+          test_not_found
+      ; test_case "exit1 + empty -> no hint" `Quick
+          test_exit1_empty_output
+      ; test_case "WSIGNALED + match -> hint" `Quick
+          test_signaled_with_matching_output
+      ; test_case "hint text content" `Quick
+          test_hint_text_content
+      ]
+    ]


### PR DESCRIPTION
## Summary
- When `keeper_github` gets "Could not resolve" error from gh CLI, append a `hint` field directing the keeper to use `issue list`/`pr list` instead of guessing numbers
- Addresses observed GLM-5.1 hallucination of non-existent issue #6082

## Evidence
Observed in keeper tool log: `keeper_github cmd="issue view 6082"` → GraphQL not found error, model=glm-5.1, lane=tool_required

## Test plan
- [ ] `dune build --root .` passes
- [ ] Manual test: `gh issue view 99999` returns response with `hint` field