### PR TITLE
feat(dashboard): move connector panel to dedicated command section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ logs/
 
 # Dashboard SPA (Vite)
 dashboard/node_modules/
+dashboard/package-lock.json
 dashboard/dist/
 assets/dashboard/
 viewer/dist-build/

--- a/dashboard/src/components/control.test.ts
+++ b/dashboard/src/components/control.test.ts
@@ -1,0 +1,99 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+void vi
+
+const route = { value: { tab: 'command' as string, params: {} as Record<string, string> } }
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadOperations() {
+  vi.resetModules()
+  vi.doMock('../router', () => ({ route }))
+  vi.doMock('./ops', () => ({
+    Ops: () => html`<div data-testid="ops">Ops</div>`,
+  }))
+  vi.doMock('./governance', () => ({
+    Governance: () => html`<div data-testid="governance">Governance</div>`,
+  }))
+  vi.doMock('./connector-status', () => ({
+    ConnectorStatusPanel: () => html`<div data-testid="connectors">Connectors</div>`,
+  }))
+  return import('./control')
+}
+
+describe('Operations control surface', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    route.value = { tab: 'command', params: {} }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../router')
+    vi.doUnmock('./ops')
+    vi.doUnmock('./governance')
+    vi.doUnmock('./connector-status')
+  })
+
+  it('renders Ops by default when section is not set', async () => {
+    route.value.params = {}
+    const { Operations } = await loadOperations()
+    render(html`<${Operations} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Ops')
+    expect(container.textContent).not.toContain('Governance')
+    expect(container.textContent).not.toContain('Connectors')
+  })
+
+  it('renders Ops when section is intervene', async () => {
+    route.value.params = { section: 'intervene' }
+    const { Operations } = await loadOperations()
+    render(html`<${Operations} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Ops')
+  })
+
+  it('renders Governance when section is governance', async () => {
+    route.value.params = { section: 'governance' }
+    const { Operations } = await loadOperations()
+    render(html`<${Operations} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Governance')
+    expect(container.textContent).not.toContain('Ops')
+  })
+
+  it('renders ConnectorStatusPanel when section is connectors', async () => {
+    route.value.params = { section: 'connectors' }
+    const { Operations } = await loadOperations()
+    render(html`<${Operations} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Connectors')
+    expect(container.textContent).not.toContain('Ops')
+    expect(container.textContent).not.toContain('Governance')
+  })
+
+  it('falls back to Ops for unknown section values', async () => {
+    route.value.params = { section: 'unknown-section' }
+    const { Operations } = await loadOperations()
+    render(html`<${Operations} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Ops')
+  })
+})

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -1,16 +1,18 @@
 // MASC Dashboard — Operations Surface
-// Operator dashboard split: intervene + governance.
+// Operator dashboard split: intervene + governance + connectors.
 
 import { html } from 'htm/preact'
 import { route } from '../router'
 import { Ops } from './ops'
 import { Governance } from './governance'
+import { ConnectorStatusPanel } from './connector-status'
 
-type OperationsSection = 'intervene' | 'governance'
+type OperationsSection = 'intervene' | 'governance' | 'connectors'
 
 function currentSection(): OperationsSection {
   const section = route.value.params.section
   if (section === 'governance') return section
+  if (section === 'connectors') return section
   return 'intervene'
 }
 
@@ -22,7 +24,9 @@ export function Operations() {
       <div class="transition-opacity duration-300">
         ${section === 'governance'
           ? html`<${Governance} />`
-          : html`<${Ops} />`}
+          : section === 'connectors'
+            ? html`<${ConnectorStatusPanel} />`
+            : html`<${Ops} />`}
       </div>
     </div>
   `

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -16,17 +16,24 @@ function currentSection(): OperationsSection {
   return 'intervene'
 }
 
+function renderSection(section: OperationsSection) {
+  switch (section) {
+    case 'governance':
+      return html`<${Governance} />`
+    case 'connectors':
+      return html`<${ConnectorStatusPanel} />`
+    case 'intervene':
+      return html`<${Ops} />`
+  }
+}
+
 export function Operations() {
   const section = currentSection()
 
   return html`
     <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
-        ${section === 'governance'
-          ? html`<${Governance} />`
-          : section === 'connectors'
-            ? html`<${ConnectorStatusPanel} />`
-            : html`<${Ops} />`}
+        ${renderSection(section)}
       </div>
     </div>
   `

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -78,9 +78,6 @@ async function loadOverview() {
   vi.doMock('../perf-snapshot', () => ({
     PerfSnapshotPanel: () => html`<div>Perf</div>`,
   }))
-  vi.doMock('../connector-status', () => ({
-    ConnectorStatusPanel: () => html`<div>Connector Panel</div>`,
-  }))
   return import('./overview')
 }
 
@@ -131,7 +128,7 @@ describe('Overview freshness strip', () => {
     vi.doUnmock('./agent-avatar')
     vi.doUnmock('../transport-health')
     vi.doUnmock('../perf-snapshot')
-    vi.doUnmock('../connector-status')
+
   })
 
   it('shows a stale warning when the oldest overview snapshot is over 5 minutes old', async () => {
@@ -163,14 +160,6 @@ describe('Overview freshness strip', () => {
 
     expect(refreshNamespaceTruth).toHaveBeenCalledWith({ force: true })
     expect(refreshMissionSnapshot).toHaveBeenCalledWith({ force: true })
-  }, 15000)
-
-  it('renders the connector operations card as a top-level overview section', async () => {
-    const { Overview } = await loadOverview()
-    render(html`<${Overview} />`, container)
-    await flushUi()
-
-    expect(container.textContent).toContain('Connector Panel')
   }, 15000)
 
   it('hides the config truth card when shell truth is unavailable', async () => {
@@ -426,7 +415,7 @@ describe('ToolCallHealthPanel', () => {
     vi.doUnmock('./agent-avatar')
     vi.doUnmock('../transport-health')
     vi.doUnmock('../perf-snapshot')
-    vi.doUnmock('../connector-status')
+
   })
 
   it('hides the panel when serverStatus is null', async () => {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -15,7 +15,6 @@ import { AttentionSpotlight } from './attention-spotlight'
 import { NarrativeTimeline } from './narrative-timeline'
 import { AgentAvatar } from './agent-avatar'
 import { TransportHealthPanel } from '../transport-health'
-import { ConnectorStatusPanel } from '../connector-status'
 import { PerfSnapshotPanel } from '../perf-snapshot'
 import { RouteLink } from '../common/route-link'
 import {
@@ -797,10 +796,6 @@ export function Overview() {
       ${agentPulse ? html`<div class=${OVERVIEW_CARD}>${agentPulse}</div>` : null}
 
       ${toolHealth ? html`<div class=${OVERVIEW_CARD}>${toolHealth}</div>` : null}
-
-      <div class=${OVERVIEW_CARD}>
-        <${ConnectorStatusPanel} />
-      </div>
 
       <details class=${OVERVIEW_CARD}>
         <summary class="cursor-pointer text-xs font-semibold text-[var(--text-strong)] uppercase tracking-wider select-none list-none flex items-center gap-2">

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -29,7 +29,7 @@ describe('lab navigation', () => {
 })
 
 describe('command navigation', () => {
-  it('keeps operations visible with intervene and governance sections', () => {
+  it('keeps operations visible with intervene, governance, and connectors sections', () => {
     expect(defaultParamsForTab('command')).toEqual({ section: 'intervene' })
 
     const commandSections = visibleSectionItemsForTab('command')
@@ -37,11 +37,13 @@ describe('command navigation', () => {
     expect(commandSections.map(item => item.id)).toEqual([
       'intervene',
       'governance',
+      'connectors',
     ])
 
     expect(commandSections.map(item => item.label)).toEqual([
       '실시간 개입',
       '거버넌스',
+      '커넥터',
     ])
   })
 })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -19,6 +19,7 @@ export type SurfaceSectionId =
   | 'telemetry'
   | 'tool-quality'
   | 'fleet'
+  | 'connectors'
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 
@@ -157,6 +158,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '거버넌스',
       description: '에이전트 자율 결정의 검토/승인 기록. 위험 행동 방지 레이어.',
       params: { section: 'governance' },
+    },
+    {
+      id: 'connectors',
+      label: '커넥터',
+      description: '외부 채널(Discord 등) 연결 상태, 바인딩 관리, 이벤트 로그.',
+      params: { section: 'connectors' },
     },
   ],
   workspace: [


### PR DESCRIPTION
## Summary
- ConnectorStatusPanel을 오버뷰에서 분리하여 운영(command) surface 하위 독립 섹션으로 이동
- bind/unbind 등 운영 행위가 운영 메뉴에서 접근 가능
- `dashboard/package-lock.json` gitignore 추가

## Changes
- `navigation.ts`: `connectors` SurfaceSectionId + command 하위 섹션 등록
- `control.ts`: connectors 섹션 → ConnectorStatusPanel 라우팅
- `overview.ts`: ConnectorStatusPanel import/렌더 제거
- 테스트 업데이트 (overview, navigation)

## Test plan
- [x] `npm run typecheck` 통과
- [x] `npm test` 78/78 파일, 423/423 테스트 통과
- [ ] 대시보드에서 운영 → 커넥터 메뉴 진입 확인
- [ ] Discord 봇 연결 상태가 커넥터 패널에 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)