### PR TITLE
[codex] Follow up keeper identity review findings

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -72,6 +72,34 @@ interface KeeperInfo {
   tool_audit_at?: string | null
 }
 
+function registerKeeperLookup<T extends Pick<KeeperInfo, 'name' | 'agent_name'>>(
+  lookup: Map<string, T>,
+  source: T,
+) {
+  const candidates = [source.agent_name, source.name]
+  for (const candidate of candidates) {
+    const key = candidate?.trim()
+    if (!key || lookup.has(key)) continue
+    lookup.set(key, source)
+  }
+}
+
+function buildKeeperInfoLookup(
+  keeperList: Keeper[],
+  keeperBriefs: DashboardMissionKeeperBrief[],
+): Map<string, KeeperInfo> {
+  const lookup = new Map<string, KeeperInfo>()
+  for (const brief of keeperBriefs) registerKeeperLookup(lookup, brief)
+  for (const keeper of keeperList) registerKeeperLookup(lookup, keeper)
+  return lookup
+}
+
+function buildKeeperRuntimeLookup(keeperList: Keeper[]): Map<string, Keeper> {
+  const lookup = new Map<string, Keeper>()
+  for (const keeper of keeperList) registerKeeperLookup(lookup, keeper)
+  return lookup
+}
+
 function findKeeper(agentName: string, keeperList: Keeper[], keeperBriefs: DashboardMissionKeeperBrief[]): KeeperInfo | null {
   // Try keeper briefs first (richer data from mission snapshot)
   for (const kb of keeperBriefs) {
@@ -308,8 +336,29 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     briefs.map(brief => [brief.agent_name, brief] as const),
   )
   const scopedAgents = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, keeperFilter)
+  const keeperInfoLookup = buildKeeperInfoLookup(keeperList, keeperBriefs)
+  const keeperRuntimeLookup = buildKeeperRuntimeLookup(keeperList)
   const bandByAgent = new Map(
-    scopedAgents.map(agent => [agent.name, runtimeBandMetaForAgent(agent, findKeeperRuntime(agent.name, keeperList))] as const),
+    scopedAgents.map(agent => [
+      agent.name,
+      runtimeBandMetaForAgent(
+        agent,
+        keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList),
+      ),
+    ] as const),
+  )
+  const normalizedSearch = search.trim().toLowerCase()
+  const searchTermsByAgent = new Map(
+    scopedAgents.map(agent => {
+      const keeper = keeperInfoLookup.get(agent.name) ?? findKeeper(agent.name, keeperList, keeperBriefs)
+      return [
+        agent.name,
+        keeperIdentitySearchTerms(
+          keeper?.name ?? null,
+          keeper?.agent_name ?? agent.name,
+        ).map(term => term.toLowerCase()),
+      ] as const
+    }),
   )
   const pageTitle = keeperFilter === 'keeper-only'
     ? '키퍼 목록'
@@ -325,13 +374,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const filtered = scopedAgents
     .filter((a: Agent) => {
       if (filter !== 'all' && bandByAgent.get(a.name)?.key !== filter) return false
-      if (search) {
-        const keeper = findKeeper(a.name, keeperList, keeperBriefs)
-        const terms = keeperIdentitySearchTerms(
-          keeper?.name ?? null,
-          keeper?.agent_name ?? a.name,
-        )
-        if (!terms.some(term => term.toLowerCase().includes(search.toLowerCase()))) {
+      if (normalizedSearch) {
+        const terms = searchTermsByAgent.get(a.name) ?? [a.name.toLowerCase()]
+        if (!terms.some(term => term.includes(normalizedSearch))) {
           return false
         }
       }
@@ -461,8 +506,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         ${filtered.map((agent: Agent) => {
           const brief = briefMap.get(agent.name)
-          const keeper = findKeeper(agent.name, keeperList, keeperBriefs)
-          const keeperRuntime = findKeeperRuntime(agent.name, keeperList)
+          const keeper = keeperInfoLookup.get(agent.name) ?? findKeeper(agent.name, keeperList, keeperBriefs)
+          const keeperRuntime = keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
           const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null

--- a/lib/keeper/keeper_exec_status.mli
+++ b/lib/keeper/keeper_exec_status.mli
@@ -3,6 +3,8 @@ open Keeper_types
 val active_model_of_meta : keeper_meta -> string
 val next_model_hint_of_meta : keeper_meta -> string option
 val string_of_fiber_health : fiber_health -> string
+val agent_status_text : Yojson.Safe.t -> string
+val agent_runtime_has_live_signal : Yojson.Safe.t -> bool
 val parse_agent_status : Room.config -> agent_name:string -> Yojson.Safe.t
 val keeper_reply_snapshot_of_history :
   Yojson.Safe.t list -> Yojson.Safe.t * Yojson.Safe.t * Yojson.Safe.t

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -72,23 +72,20 @@ let iso_of_unix = Dashboard_utils.iso_of_unix
 
 let runtime_status_from_live_signal (agent_status_json : Yojson.Safe.t) =
   let runtime_status =
-    match U.member "status" agent_status_json with
-    | `String (("active" | "busy" | "listening" | "idle") as status) -> Some status
+    match Keeper_exec_status.agent_status_text agent_status_json with
+    | ("active" | "busy" | "listening" | "idle") as status -> Some status
     | _ -> None
   in
-  let last_seen_ago_s =
-    match U.member "last_seen_ago_s" agent_status_json with
-    | `Float value -> Some value
-    | `Int value -> Some (float_of_int value)
-    | _ -> None
+  let has_live_signal =
+    Keeper_exec_status.agent_runtime_has_live_signal agent_status_json
   in
   let is_zombie =
     match U.member "is_zombie" agent_status_json with
     | `Bool value -> value
     | _ -> false
   in
-  match (runtime_status, last_seen_ago_s, is_zombie) with
-  | Some status, Some age_s, false when age_s <= 120.0 -> Some status
+  match (runtime_status, has_live_signal, is_zombie) with
+  | Some status, true, false -> Some status
   | _ -> None
 
 let health_state_allows_runtime_status_override (diagnostic : Yojson.Safe.t) =
@@ -327,12 +324,12 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                    if lightweight then ([], [], None, None, None, None)
                    else keeper_tool_audit_fields config meta
                  in
-                 let agent_status =
+                 let surface_status =
                    if not agent_exists then "offline"
                    else Keeper_exec_status.keeper_surface_status ~agent_status:agent_json ~diagnostic
                  in
-                 let agent_status =
-                   align_keeper_runtime_status ~surface_status:agent_status
+                 let aligned_status =
+                   align_keeper_runtime_status ~surface_status
                      ~diagnostic
                      ~agent_status_json:agent_json ~keepalive_running
                  in
@@ -362,7 +359,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        ("short_goal", `String meta.short_goal);
                        ("mid_goal", `String meta.mid_goal);
                        ("long_goal", `String meta.long_goal);
-                       ("status", `String agent_status);
+                       ("status", `String aligned_status);
                        ("agent", agent_json);
                        ("generation", `Int meta.runtime.generation);
                        ("turn_count", `Int meta.runtime.usage.total_turns);


### PR DESCRIPTION
## Summary
- cache keeper lookup/search terms once per render in the unified roster instead of re-running keeper scans inside every filter pass
- reuse exported keeper runtime helper functions in the operator snapshot runtime-status alignment path
- rename the intermediate keeper status variables from `agent_status` rebinding to `surface_status` / `aligned_status`

## Product impact
- no intended user-facing behavior change from `#6236`
- reduces roster filter work as the runtime list grows
- keeps runtime liveness threshold logic sourced from one helper path instead of duplicating it in the operator snapshot layer
- makes the status alignment code easier to read during operator/debug work

## Evidence
- `git diff --check`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/pr-6236-review ./test/test_operator_control.exe`
- `pnpm --dir dashboard exec vitest run src/components/agent-roster.test.ts src/components/common/keeper-identity.test.ts src/lib/keeper-runtime-display.test.ts`
- `pnpm --dir dashboard run build`

## Review evidence
- cross-model review: direct `sb glm-text` (`GLM-5.x` path)
- reviewed commit: `31268185b`
- result: `No findings.`

## Linked issue
- `Refs #6236`
