### PR TITLE
[codex] Normalize .masc base path inputs

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -328,6 +328,7 @@ let guard_self_repo_base_path base_path =
 
 let run_cmd host port base_path =
   Printexc.record_backtrace true;
+  let raw_base_path = String.trim base_path in
   let normalized_base_path =
     Env_config.normalize_masc_base_path_input base_path
   in
@@ -343,6 +344,7 @@ let run_cmd host port base_path =
     Log.Server.warn
       "Normalizing --base-path from %s to %s because runtime base paths must point at the workspace root, not the .masc directory."
       base_path normalized_base_path;
+  Unix.putenv "MASC_BASE_PATH_INPUT" raw_base_path;
   Unix.putenv "MASC_BASE_PATH" normalized_base_path;
   (* Persist logs inside .masc/logs/ — colocated with state, not a sibling.
      Previous code wrote to base_path/logs/ which diverged from .masc/ when

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -301,6 +301,7 @@ let acquire_pid_lock port =
     Detects by checking if the running executable lives under base_path/_build/.
     Runtime state (.masc/keepers, traces, logs) must not pollute the repo. *)
 let guard_self_repo_base_path base_path =
+  let base_path = Env_config.normalize_masc_base_path_input base_path in
   let abs_base =
     try Unix.realpath base_path with Unix.Unix_error _ -> base_path
   in
@@ -327,19 +328,31 @@ let guard_self_repo_base_path base_path =
 
 let run_cmd host port base_path =
   Printexc.record_backtrace true;
-  guard_self_repo_base_path base_path;
+  let normalized_base_path =
+    Env_config.normalize_masc_base_path_input base_path
+  in
+  let stripped_base_path =
+    Env_config.strip_path_trailing_slashes (String.trim base_path)
+  in
+  guard_self_repo_base_path normalized_base_path;
   acquire_pid_lock port;
   Log.init_from_env ();
-  Unix.putenv "MASC_BASE_PATH" base_path;
+  if stripped_base_path <> ""
+     && String.equal (Filename.basename stripped_base_path) ".masc"
+  then
+    Log.Server.warn
+      "Normalizing --base-path from %s to %s because runtime base paths must point at the workspace root, not the .masc directory."
+      base_path normalized_base_path;
+  Unix.putenv "MASC_BASE_PATH" normalized_base_path;
   (* Persist logs inside .masc/logs/ — colocated with state, not a sibling.
      Previous code wrote to base_path/logs/ which diverged from .masc/ when
      base_path differed from the repo checkout directory. *)
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Filename.concat normalized_base_path ".masc" in
   let log_dir = Filename.concat masc_dir "logs" in
   Fs_compat.mkdir_p masc_dir;
   Fs_compat.mkdir_p log_dir;
   (* Migration: move .jsonl files from old base_path/logs/ if they exist *)
-  let old_log_dir = Filename.concat base_path "logs" in
+  let old_log_dir = Filename.concat normalized_base_path "logs" in
   (if Sys.file_exists old_log_dir && Sys.is_directory old_log_dir then
      let files = try Sys.readdir old_log_dir with Sys_error _ -> [||] in
      Array.iter (fun fname ->
@@ -350,7 +363,7 @@ let run_cmd host port base_path =
            (try Sys.rename src dst;
                 Log.info "log migration: moved %s -> .masc/logs/" fname
             with Sys_error _ -> ())
-       end) files);
+          end) files);
   Log.Ring.init_file_sink log_dir;
   Log.Ring.cleanup_old_files log_dir;
   Eio_main.run @@ fun env ->

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -61,6 +61,27 @@ let strip_trailing_slashes value =
   in
   loop (String.length value)
 
+let strip_path_trailing_slashes value =
+  let trimmed = String.trim value in
+  let rec loop current =
+    let len = String.length current in
+    if len > 1 && current.[len - 1] = '/' then
+      loop (String.sub current 0 (len - 1))
+    else
+      current
+  in
+  if trimmed = "" then "" else loop trimmed
+
+let normalize_masc_base_path_input path =
+  let normalized = strip_path_trailing_slashes path in
+  if normalized = "" then ""
+  else if String.equal (Filename.basename normalized) ".masc" then
+    match Filename.dirname normalized with
+    | "" -> "."
+    | parent -> parent
+  else
+    normalized
+
 let existing_dir path =
   Sys.file_exists path && Sys.is_directory path
 
@@ -196,8 +217,11 @@ let get_port ~default name =
     Used by board, checkpoint, thompson_sampling, voice, keeper.
     Set at startup; may be overridden via Unix.putenv before use.
     Returns None when MASC_BASE_PATH is unset or empty. *)
-let base_path_opt () =
+let base_path_raw_opt () =
   Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
+
+let base_path_opt () =
+  base_path_raw_opt () |> Option.map normalize_masc_base_path_input
 
 (** Project base path with "." fallback when unset. *)
 let base_path () =

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -218,7 +218,9 @@ let get_port ~default name =
     Set at startup; may be overridden via Unix.putenv before use.
     Returns None when MASC_BASE_PATH is unset or empty. *)
 let base_path_raw_opt () =
-  Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
+  match Sys.getenv_opt "MASC_BASE_PATH_INPUT" |> trim_opt with
+  | Some _ as value -> value
+  | None -> Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
 
 let base_path_opt () =
   base_path_raw_opt () |> Option.map normalize_masc_base_path_input

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -122,7 +122,11 @@ let path_from_local_masc (inputs : inputs) =
   match trim_opt inputs.env_base_path with
   | None -> None
   | Some base_path ->
-      let base_path = absolute_path_from ~cwd:inputs.cwd base_path in
+      let base_path =
+        base_path
+        |> Env_config_core.normalize_masc_base_path_input
+        |> absolute_path_from ~cwd:inputs.cwd
+      in
       let candidate = Filename.concat (Filename.concat base_path ".masc") "config" in
       if config_signature_exists candidate then Some candidate else None
 

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -131,7 +131,7 @@ let rec find_git_root path =
 let bool_env name = Env_config_core.get_bool ~default:false name
 
 let normalize_base_path path =
-  let trimmed = String.trim path in
+  let trimmed = Env_config_core.normalize_masc_base_path_input path in
   if trimmed = "" then ""
   else if Filename.is_relative trimmed then Filename.concat (Sys.getcwd ()) trimmed
   else trimmed
@@ -199,13 +199,14 @@ let sync_test_base_path_env resolved_path =
           resolved_path (Filename.basename Sys.executable_name)
 
 let resolve_requested_base_path path =
-  match find_git_root path with
+  let requested = normalize_base_path path in
+  match find_git_root requested with
   | Some git_root ->
-      Log.Room.info "MASC base resolved: %s → %s (git root)" path git_root;
+      Log.Room.info "MASC base resolved: %s → %s (git root)" requested git_root;
       git_root
   | None ->
-      Log.Room.info "MASC base: %s (no git root found)" path;
-      path
+      Log.Room.info "MASC base: %s (no git root found)" requested;
+      requested
 
 (** Resolve base_path: when MASC_BASE_PATH is explicitly set, use it
     directly unless a test executable intentionally ignores an inherited

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -959,8 +959,8 @@ let dashboard_shell_timeout_s =
 
 let dashboard_shell_paths_json (config : Room.config) : Yojson.Safe.t =
   Server_base_path_diagnostics.detect
-    ?input_base_path:(Env_config_core.base_path_opt ())
-    ?env_masc_base_path:(Env_config_core.base_path_opt ())
+    ?input_base_path:(Env_config_core.base_path_raw_opt ())
+    ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
     ~effective_base_path:config.base_path
     ~effective_masc_root:(Room.masc_root_dir config)
     ()

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -144,7 +144,7 @@ let runtime_resolution_json (config : Room.config) =
   let workspace_commit = git_rev_parse_short config.workspace_path in
   let resolved_base_commit = git_rev_parse_short config.base_path in
   let base_path_input =
-    Env_config_core.base_path_opt ()
+    Env_config_core.base_path_raw_opt ()
     |> Option.value ~default:config.workspace_path
   in
   let prompt_markdown_dir =

--- a/lib/server/server_routes_http_runtime.ml
+++ b/lib/server/server_routes_http_runtime.ml
@@ -84,8 +84,8 @@ let health_path_diagnostics () =
   match current_server_state_opt () with
   | Some state ->
       Server_base_path_diagnostics.detect
-        ?input_base_path:(Env_config_core.base_path_opt ())
-        ?env_masc_base_path:(Env_config_core.base_path_opt ())
+        ?input_base_path:(Env_config_core.base_path_raw_opt ())
+        ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
         ~effective_base_path:state.room_config.base_path
         ~effective_masc_root:(Room.masc_root_dir state.room_config)
         ()
@@ -93,8 +93,8 @@ let health_path_diagnostics () =
       let effective_base_path = default_base_path () in
       let effective_masc_root = Filename.concat effective_base_path ".masc" in
       Server_base_path_diagnostics.detect
-        ?input_base_path:(Env_config_core.base_path_opt ())
-        ?env_masc_base_path:(Env_config_core.base_path_opt ())
+        ?input_base_path:(Env_config_core.base_path_raw_opt ())
+        ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
         ~effective_base_path ~effective_masc_root ()
 
 let make_health_json ?(listener = "http/1.1") request =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -97,6 +97,7 @@ let rec copy_missing_tree ~src ~dst =
     copy_file_if_missing ~src ~dst
 
 let bootstrap_base_path_config_root ~base_path =
+  let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   if Option.is_some (Env_config_core.config_dir_opt ()) then
     ()
   else
@@ -166,6 +167,7 @@ let init_runtime_context env =
 
 let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     : Mcp_server.server_state =
+  let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
@@ -220,7 +222,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
 let runtime_path_diagnostics ?input_base_path (state : Mcp_server.server_state) =
   Server_base_path_diagnostics.detect
     ?input_base_path
-    ?env_masc_base_path:(Env_config_core.base_path_opt ())
+    ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
     ~effective_base_path:state.room_config.base_path
     ~effective_masc_root:(Room.masc_root_dir state.room_config)
     ()

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -167,6 +167,11 @@ let init_runtime_context env =
 
 let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     : Mcp_server.server_state =
+  let input_base_path =
+    match String.trim base_path with
+    | "" -> None
+    | raw -> Some raw
+  in
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
   Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
@@ -184,6 +189,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
       method mono_clock = mono_clock
     end
   in
+  Unix.putenv "MASC_BASE_PATH_INPUT" (Option.value ~default:"" input_base_path);
   Unix.putenv "MASC_BASE_PATH" base_path;
   bootstrap_base_path_config_root ~base_path;
   (* RFC-0001 Gate A: initialize instrumentation stores *)
@@ -208,8 +214,8 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   in
   let path_diagnostics =
     Server_base_path_diagnostics.detect
-      ~input_base_path:base_path
-      ?env_masc_base_path:(Env_config_core.base_path_opt ())
+      ?input_base_path
+      ?env_masc_base_path:(Env_config_core.base_path_raw_opt ())
       ~effective_base_path:state.room_config.base_path
       ~effective_masc_root:(Room.masc_root_dir state.room_config)
       ()

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -123,6 +123,22 @@ let test_local_masc_fallback_precedes_home_masc () =
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check string "root path" local_config resolution.config_root.path
 
+let test_local_masc_fallback_collapses_explicit_masc_dir () =
+  with_temp_dir "config-dir-local-masc" @@ fun root ->
+  let target = Filename.concat root "target" in
+  let local_config = make_config_root (Filename.concat target ".masc") in
+  let resolution =
+    Lib.Config_dir_resolver.resolve_with
+      (make_inputs ~cwd:root
+         ~env_base_path:(Filename.concat target ".masc")
+         ~executable_name:"/tmp/nonexistent-masc" ())
+  in
+  check string "status" "ready"
+    (Lib.Config_dir_resolver.status_to_string resolution.status);
+  check string "root source" "local_masc"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check string "root path" local_config resolution.config_root.path
+
 let test_no_legacy_me_root_fallback () =
   with_temp_dir "config-dir-no-legacy" @@ fun me_root ->
   let _repo_root =
@@ -206,6 +222,8 @@ let () =
           test_case "cwd fallback" `Quick test_cwd_fallback;
           test_case "local masc fallback precedes home masc" `Quick
             test_local_masc_fallback_precedes_home_masc;
+          test_case "local masc fallback collapses explicit .masc dir"
+            `Quick test_local_masc_fallback_collapses_explicit_masc_dir;
           test_case "home masc fallback" `Quick test_home_masc_fallback;
           test_case "does not fallback to legacy me_root repo path" `Quick
             test_no_legacy_me_root_fallback;

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -214,6 +214,17 @@ let test_dashboard_shell_http_json_includes_paths () =
          | `List _ -> true
          | _ -> false))
 
+let test_dashboard_shell_http_json_prefers_preserved_base_path_input () =
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  let raw_input = Filename.concat config.base_path ".masc" in
+  with_env "MASC_BASE_PATH_INPUT" raw_input @@ fun () ->
+  with_env "MASC_BASE_PATH" config.base_path @@ fun () ->
+  let json = Lib.Server_dashboard_http_core.dashboard_shell_http_json config in
+  let open Yojson.Safe.Util in
+  check string "runtime base_path preserves raw input" raw_input
+    (json |> member "runtime_resolution" |> member "base_path" |> member "path"
+   |> to_string)
+
 let () =
   run "dashboard_http_core"
     [
@@ -227,5 +238,7 @@ let () =
             test_run_dashboard_compute_with_pool_uses_executor_domain;
           test_case "shell payload includes paths diagnostics" `Quick
             test_dashboard_shell_http_json_includes_paths;
+          test_case "shell runtime base_path prefers preserved input" `Quick
+            test_dashboard_shell_http_json_prefers_preserved_base_path_input;
         ] );
     ]

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -82,6 +82,17 @@ let test_base_path_prefers_env () =
       (Env_config.base_path_opt ());
     check string "base_path" "/tmp/masc-custom-root" (Env_config.base_path ()))
 
+let test_base_path_collapses_masc_dir_env () =
+  with_env "MASC_BASE_PATH" "/tmp/masc-custom-root/.masc" (fun () ->
+    check (option string) "raw base path keeps original env"
+      (Some "/tmp/masc-custom-root/.masc")
+      (Env_config.base_path_raw_opt ());
+    check (option string) "base_path_opt collapses .masc leaf"
+      (Some "/tmp/masc-custom-root")
+      (Env_config.base_path_opt ());
+    check string "base_path collapses .masc leaf"
+      "/tmp/masc-custom-root" (Env_config.base_path ()))
+
 let test_masc_http_base_url_prefers_env_and_trims () =
   with_env "MASC_HTTP_BASE_URL" "http://example.test:9911/" (fun () ->
     check (result string string) "base url result trimmed"
@@ -387,6 +398,8 @@ let () =
     ];
     "path_helpers", [
       test_case "base_path prefers env" `Quick test_base_path_prefers_env;
+      test_case "base_path collapses .masc env input" `Quick
+        test_base_path_collapses_masc_dir_env;
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
       test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
       test_case "sb_path_result missing is error" `Quick test_sb_path_result_missing_is_error;

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -93,6 +93,18 @@ let test_base_path_collapses_masc_dir_env () =
     check string "base_path collapses .masc leaf"
       "/tmp/masc-custom-root" (Env_config.base_path ()))
 
+let test_base_path_raw_prefers_preserved_input_env () =
+  with_env "MASC_BASE_PATH_INPUT" "/tmp/masc-custom-root/.masc" (fun () ->
+    with_env "MASC_BASE_PATH" "/tmp/masc-custom-root" (fun () ->
+      check (option string) "base_path_raw_opt prefers preserved input env"
+        (Some "/tmp/masc-custom-root/.masc")
+        (Env_config.base_path_raw_opt ());
+      check (option string) "base_path_opt still returns normalized path"
+        (Some "/tmp/masc-custom-root")
+        (Env_config.base_path_opt ());
+      check string "base_path stays normalized"
+        "/tmp/masc-custom-root" (Env_config.base_path ())))
+
 let test_masc_http_base_url_prefers_env_and_trims () =
   with_env "MASC_HTTP_BASE_URL" "http://example.test:9911/" (fun () ->
     check (result string string) "base url result trimmed"
@@ -400,6 +412,8 @@ let () =
       test_case "base_path prefers env" `Quick test_base_path_prefers_env;
       test_case "base_path collapses .masc env input" `Quick
         test_base_path_collapses_masc_dir_env;
+      test_case "base_path raw prefers preserved input env" `Quick
+        test_base_path_raw_prefers_preserved_input_env;
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
       test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
       test_case "sb_path_result missing is error" `Quick test_sb_path_result_missing_is_error;

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -136,6 +136,32 @@ let test_resolve_masc_base_path_keeps_matching_explicit_env () =
       check string "matching explicit env preserved" requested
         (Room_utils.resolve_masc_base_path requested))
 
+let test_resolve_masc_base_path_collapses_requested_masc_dir () =
+  let requested =
+    Filename.concat
+      (Filename.concat (Filename.get_temp_dir_name ()) "room-utils-collapse")
+      ".masc"
+  in
+  with_envs
+    [ ("MASC_BASE_PATH", None);
+      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+    (fun () ->
+      check string "requested .masc input collapses to parent"
+        (Filename.dirname requested)
+        (Room_utils.resolve_masc_base_path requested))
+
+let test_resolve_masc_base_path_collapses_explicit_env_masc_dir () =
+  let requested =
+    Filename.concat (Filename.get_temp_dir_name ()) "room-utils-explicit"
+  in
+  let explicit = Filename.concat requested ".masc" in
+  with_envs
+    [ ("MASC_BASE_PATH", Some explicit);
+      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+    (fun () ->
+      check string "explicit .masc env collapses to parent" requested
+        (Room_utils.resolve_masc_base_path requested))
+
 let test_resolve_masc_base_path_allows_test_opt_in () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-opt-in"
@@ -636,6 +662,10 @@ let () =
         test_resolve_masc_base_path_ignores_inherited_env_in_test;
       test_case "keeps matching explicit env" `Quick
         test_resolve_masc_base_path_keeps_matching_explicit_env;
+      test_case "collapses requested .masc path" `Quick
+        test_resolve_masc_base_path_collapses_requested_masc_dir;
+      test_case "collapses explicit .masc env" `Quick
+        test_resolve_masc_base_path_collapses_explicit_env_masc_dir;
       test_case "allows explicit opt-in to inherited env" `Quick
         test_resolve_masc_base_path_allows_test_opt_in;
       test_case "ignores dual .masc roots by default" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -773,6 +773,41 @@ let test_create_server_state_records_runtime_resolution () =
         (json |> member "path_diagnostics" |> member "effective_masc_root"
        |> to_string))
 
+let test_create_server_state_preserves_raw_input_base_path () =
+  with_temp_dir "startup-create-state-raw-input" (fun dir ->
+      let repo = Filename.concat dir "repo" in
+      let raw_input = Filename.concat dir ".masc" in
+      mkdir_p repo;
+      mkdir_p raw_input;
+      ignore (make_config_root repo);
+      with_env "MASC_STORAGE_TYPE" (Some "filesystem") @@ fun () ->
+      with_env "MASC_POSTGRES_URL" None @@ fun () ->
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_BASE_PATH" None @@ fun () ->
+      with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
+      with_cwd repo @@ fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let clock, mono_clock, net, _domain_mgr, proc_mgr, fs =
+        Server_runtime_bootstrap.init_runtime_context env
+      in
+      Eio.Switch.run @@ fun sw ->
+      Server_startup_state.reset ~backend_mode:"filesystem" ();
+      ignore
+        (Server_runtime_bootstrap.create_server_state ~sw ~base_path:raw_input
+           ~clock ~mono_clock ~net ~proc_mgr ~fs);
+      let json = Server_startup_state.to_yojson () in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "raw input base path preserved in diagnostics"
+        raw_input
+        (json |> member "path_diagnostics" |> member "input_base_path"
+       |> to_string);
+      Alcotest.(check (option string)) "raw input env preserved"
+        (Some raw_input)
+        (Env_config_core.base_path_raw_opt ());
+      Alcotest.(check string) "normalized env remains effective workspace root"
+        dir (Sys.getenv "MASC_BASE_PATH"))
+
 let test_prompt_markdown_dir_falls_back_to_resolved_config_dir () =
   with_temp_dir "startup-prompts" (fun dir ->
       let expected =
@@ -976,6 +1011,9 @@ let () =
           Alcotest.test_case
             "create_server_state records runtime resolution"
             `Quick test_create_server_state_records_runtime_resolution;
+          Alcotest.test_case
+            "create_server_state preserves raw input base path"
+            `Quick test_create_server_state_preserves_raw_input_base_path;
           Alcotest.test_case "prompt markdown dir falls back to resolved config dir"
             `Quick test_prompt_markdown_dir_falls_back_to_resolved_config_dir;
           Alcotest.test_case "prompt markdown dir honors MASC_CONFIG_DIR override"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -313,6 +313,22 @@ let test_startup_config_resolution_preserves_explicit_override () =
       Alcotest.(check (option string)) "env override unchanged" (Some explicit)
         (Sys.getenv_opt "MASC_CONFIG_DIR"))
 
+let test_bootstrap_base_path_config_root_collapses_masc_input () =
+  with_temp_dir "startup-config-collapse" (fun dir ->
+      let repo = Filename.concat dir "repo" in
+      mkdir_p repo;
+      ignore (make_config_root repo);
+      let base_path = Filename.concat dir "base" in
+      mkdir_p (Filename.concat base_path ".masc");
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_cwd repo @@ fun () ->
+      Server_runtime_bootstrap.bootstrap_base_path_config_root
+        ~base_path:(Filename.concat base_path ".masc");
+      Alcotest.(check bool) "config root created under parent .masc" true
+        (Sys.file_exists (Filename.concat base_path ".masc/config/cascade.json"));
+      Alcotest.(check bool) "nested .masc/.masc config not created" false
+        (Sys.file_exists
+           (Filename.concat base_path ".masc/.masc/config/cascade.json")))
 let test_constructor_is_pure () =
   with_temp_dir "startup-pure" (fun dir ->
       let agents_dir = Room.agents_dir (Room.default_config dir) in
@@ -900,6 +916,9 @@ let () =
           Alcotest.test_case
             "startup config resolution preserves explicit override"
             `Quick test_startup_config_resolution_preserves_explicit_override;
+          Alcotest.test_case
+            "bootstrap base-path config collapses .masc input path"
+            `Quick test_bootstrap_base_path_config_root_collapses_masc_input;
           Alcotest.test_case "constructors stay pure" `Quick
             test_constructor_is_pure;
           Alcotest.test_case "restore_persisted_sessions uses flat agents dir"


### PR DESCRIPTION
## Summary
- normalize `--base-path` and `MASC_BASE_PATH` values that already end in `/.masc` back to the owning project root
- keep runtime/config introspection accurate while preventing nested `/.masc/.masc` runtime and config directories
- add regression coverage for env config, room setup, config resolution, and bootstrap path collapse

## Why
- operators observed mixed historical base-path usage where some launches passed the project root while others passed the `.masc` directory itself
- the runtime accepted both forms, which could create nested `/.masc/.masc` trees and drift between the active runtime root and bootstrapped config root

## Product impact
- `main_eio`, room setup, config resolution, and startup bootstrap all canonicalize `.masc`-suffixed base-path inputs to the parent root
- dashboard/runtime truth endpoints still expose the original input separately from the effective normalized root
- bootstrap no longer creates nested `/.masc/.masc/config` when launched with a `.masc` path

## Evidence
- `env OCAMLPARAM='_,warn-error=-32' dune build --root . bin/main_eio.exe test/test_config_dir_resolver.exe test/test_env_config_coverage.exe test/test_room_utils_coverage.exe test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_config_dir_resolver.exe --show-errors`
- `./_build/default/test/test_env_config_coverage.exe --show-errors`
- `./_build/default/test/test_room_utils_coverage.exe --show-errors`
- `./_build/default/test/test_server_runtime_bootstrap.exe --show-errors`

## Review evidence
- GLM-5 via `sb glm-text` reviewed the final diff; evidence comment updated on the PR

## Linked issue
- Refs #4568
