### PR TITLE
[codex] Sanitize inherited base path defaults

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -217,10 +217,18 @@ let get_port ~default name =
     Used by board, checkpoint, thompson_sampling, voice, keeper.
     Set at startup; may be overridden via Unix.putenv before use.
     Returns None when MASC_BASE_PATH is unset or empty. *)
-let base_path_raw_opt () =
+let base_path_source_opt () =
   match Sys.getenv_opt "MASC_BASE_PATH_INPUT" |> trim_opt with
-  | Some _ as value -> value
-  | None -> Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt
+  | Some value -> Some ("MASC_BASE_PATH_INPUT", value)
+  | None ->
+      (match Sys.getenv_opt "MASC_BASE_PATH" |> trim_opt with
+       | Some value -> Some ("MASC_BASE_PATH", value)
+       | None -> None)
+
+let base_path_raw_opt () =
+  match base_path_source_opt () with
+  | Some (_name, value) -> Some value
+  | None -> None
 
 let base_path_opt () =
   base_path_raw_opt () |> Option.map normalize_masc_base_path_input

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -187,6 +187,19 @@ let should_ignore_inherited_test_base_path ~requested_path ~explicit_path =
   && not (is_ancestor_path ~ancestor:(canonical_base_path explicit_path)
             ~descendant:(canonical_base_path requested_path))
 
+let should_ignore_inherited_server_base_path ~requested_path ~explicit_path =
+  not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
+  && String.trim requested_path <> ""
+  && not (String.equal requested_path ".")
+  &&
+  let requested = canonical_base_path requested_path in
+  let explicit = canonical_base_path explicit_path in
+  requested <> ""
+  && explicit <> ""
+  && not (String.equal requested explicit)
+  && path_has_masc_dir requested
+  && path_has_masc_dir explicit
+
 let sync_test_base_path_env resolved_path =
   if running_under_test_executable ()
      && not (bool_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
@@ -237,6 +250,18 @@ let resolve_masc_base_path path =
       Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
       explicit
   | None -> resolve_requested_base_path path
+
+let resolve_server_default_base_path path =
+  match Env_config_core.base_path_opt () with
+  | Some explicit
+    when should_ignore_inherited_server_base_path ~requested_path:path
+           ~explicit_path:explicit ->
+      let resolved = resolve_requested_base_path path in
+      Log.Room.warn
+        "Ignoring inherited MASC_BASE_PATH=%s for direct server startup because both %s and %s have .masc; using requested base path %s. Set MASC_ALLOW_INHERITED_BASE_PATH=1 to preserve the inherited root."
+        explicit (canonical_base_path path) (canonical_base_path explicit) resolved;
+      resolved
+  | _ -> resolve_masc_base_path path
 
 (* ============================================ *)
 (* Environment helpers                          *)

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -257,9 +257,15 @@ let resolve_server_default_base_path path =
     when should_ignore_inherited_server_base_path ~requested_path:path
            ~explicit_path:explicit ->
       let resolved = resolve_requested_base_path path in
+      let explicit_binding =
+        match Env_config_core.base_path_source_opt () with
+        | Some (name, raw) -> Printf.sprintf "%s=%s" name raw
+        | None -> Printf.sprintf "MASC_BASE_PATH=%s" explicit
+      in
       Log.Room.warn
-        "Ignoring inherited MASC_BASE_PATH=%s for direct server startup because both %s and %s have .masc; using requested base path %s. Set MASC_ALLOW_INHERITED_BASE_PATH=1 to preserve the inherited root."
-        explicit (canonical_base_path path) (canonical_base_path explicit) resolved;
+        "Ignoring inherited %s for direct server startup because both %s and %s have .masc; using requested base path %s. Set MASC_ALLOW_INHERITED_BASE_PATH=1 to preserve the inherited root."
+        explicit_binding (canonical_base_path path) (canonical_base_path explicit)
+        resolved;
       resolved
   | _ -> resolve_masc_base_path path
 

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -17,7 +17,7 @@ let session_mutex = Eio.Mutex.create ()
 let default_base_path () =
   (* Match the launcher guard: a direct binary launch from a checkout with its
      own .masc must not silently inherit a stale parent MASC_BASE_PATH. *)
-  Room_utils_backend_setup.resolve_masc_base_path (Sys.getcwd ())
+  Room_utils_backend_setup.resolve_server_default_base_path (Sys.getcwd ())
 
 let is_valid_protocol_version version =
   List.mem version mcp_protocol_versions

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -99,6 +99,15 @@ let test_base_path_raw_prefers_preserved_input_env () =
       check (option string) "base_path_raw_opt prefers preserved input env"
         (Some "/tmp/masc-custom-root/.masc")
         (Env_config.base_path_raw_opt ());
+      begin
+        match Env_config.base_path_source_opt () with
+        | Some (name, value) ->
+            check string "base_path_source_opt prefers preserved input env name"
+              "MASC_BASE_PATH_INPUT" name;
+            check string "base_path_source_opt prefers preserved input env value"
+              "/tmp/masc-custom-root/.masc" value
+        | None -> fail "expected base_path_source_opt"
+      end;
       check (option string) "base_path_opt still returns normalized path"
         (Some "/tmp/masc-custom-root")
         (Env_config.base_path_opt ());

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -115,9 +115,8 @@ let test_default_base_path_sanitizes_inherited_dual_roots () =
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
-  (* ancestor explicit path wins: base_path is parent of repo *)
-  Alcotest.(check string) "default base path preserves ancestor explicit path"
-    (canonical_path base_path)
+  Alcotest.(check string) "default base path ignores inherited parent root"
+    (canonical_path repo)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
 let test_default_base_path_respects_opt_in_for_inherited_root () =
@@ -134,6 +133,19 @@ let test_default_base_path_respects_opt_in_for_inherited_root () =
     (canonical_path base_path)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
+let test_default_base_path_keeps_inherited_root_without_local_masc () =
+  with_temp_dir "base-path-default-no-local-masc" @@ fun root ->
+  let base_path = Filename.concat root "base" in
+  let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
+  mkdir_p repo;
+  Unix.mkdir (Filename.concat base_path ".masc") 0o755;
+  with_cwd repo @@ fun () ->
+  with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
+  with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
+  Alcotest.(check string) "default base path keeps inherited root without local .masc"
+    (canonical_path base_path)
+    (Server_mcp_transport_http.default_base_path () |> canonical_path)
+
 let () =
   Alcotest.run "Server_base_path_diagnostics"
     [
@@ -145,9 +157,12 @@ let () =
             test_strict_violation_respects_env;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
-          Alcotest.test_case "default base path preserves ancestor explicit path"
+          Alcotest.test_case "default base path sanitizes inherited parent root"
             `Quick test_default_base_path_sanitizes_inherited_dual_roots;
           Alcotest.test_case "default base path honors inherited opt-in" `Quick
             test_default_base_path_respects_opt_in_for_inherited_root;
+          Alcotest.test_case
+            "default base path keeps inherited root without local .masc"
+            `Quick test_default_base_path_keeps_inherited_root_without_local_masc;
         ] );
     ]

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -114,6 +114,7 @@ let test_default_base_path_sanitizes_inherited_dual_roots () =
   Unix.mkdir (Filename.concat repo ".masc") 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
   with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
   Alcotest.(check string) "default base path ignores inherited parent root"
     (canonical_path repo)
@@ -128,6 +129,7 @@ let test_default_base_path_respects_opt_in_for_inherited_root () =
   Unix.mkdir (Filename.concat repo ".masc") 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
   with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "1") @@ fun () ->
   Alcotest.(check string) "opt-in keeps inherited root"
     (canonical_path base_path)
@@ -141,6 +143,7 @@ let test_default_base_path_keeps_inherited_root_without_local_masc () =
   Unix.mkdir (Filename.concat base_path ".masc") 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
   with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
   Alcotest.(check string) "default base path keeps inherited root without local .masc"
     (canonical_path base_path)


### PR DESCRIPTION
## Summary
- align direct HTTP/stdio startup default base-path resolution with the launcher guard for inherited `MASC_BASE_PATH`
- ignore inherited parent roots during direct startup when both the inherited root and current checkout have their own `.masc` directories
- keep the existing opt-in (`MASC_ALLOW_INHERITED_BASE_PATH=1`) and non-ambiguous inherited-root behavior intact

## Why
- `start-masc-mcp.sh` already sanitized inherited parent roots, but `default_base_path()` still accepted them during direct binary/stdio startup
- that mismatch let restart paths drift back to a stale parent `.masc` root even after the launcher side was fixed

## Product impact
- direct `main_eio` / `main_stdio_eio` startup now prefers the current checkout when an inherited parent root would create a dual-`.masc` ambiguity
- inherited roots still win when the current checkout does not have its own `.masc`
- `MASC_ALLOW_INHERITED_BASE_PATH=1` still preserves the inherited root for deliberate shared-root setups

## Evidence
- `env OCAMLPARAM='_,warn-error=-32' dune build --root . --build-dir /tmp/masc-4568-fix bin/main_eio.exe test/test_server_base_path_diagnostics.exe test/test_room_utils_coverage.exe`
- `/tmp/masc-4568-fix/default/test/test_server_base_path_diagnostics.exe --show-errors`
- `/tmp/masc-4568-fix/default/test/test_room_utils_coverage.exe --show-errors`

## Review evidence
- Reviewer: GLM-5 via `sb glm-text`
- Reviewed commit: `c0eded399`
- Reviewed scope: `origin/main...fix/default-base-path-inherited-env`
- Timestamp: 2026-04-10 11:22 KST
- Result: `No findings.`

## Linked issue
- Refs #4568
