### PR TITLE
feat(tla): KeeperDecisionPipeline — Phase B0 gate

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -52,6 +52,43 @@ run_tlc() {
   echo ""
 }
 
+# Run a buggy spec that MUST violate an invariant or property.
+# TLC exit codes: 12 = safety violation, 13 = liveness violation.
+# If TLC exits 0 (no violation), the spec is too weak and the test fails.
+run_tlc_buggy() {
+  local spec_dir="$1"
+  local tla_file="$2"
+  local cfg_file="${tla_file%.tla}-buggy.cfg"
+
+  if [ ! -f "$spec_dir/$cfg_file" ]; then
+    echo "SKIP $tla_file buggy (no -buggy.cfg file)"
+    return 0
+  fi
+
+  echo "=== Checking $spec_dir/$tla_file (buggy, expect violation) ==="
+  local rc=0
+  "$JAVA" -XX:+UseParallelGC -Xmx4g \
+    -cp "$TLC_JAR" tlc2.TLC \
+    -config "$spec_dir/$cfg_file" \
+    -workers auto \
+    -deadlock \
+    "$spec_dir/$tla_file" || rc=$?
+
+  if [ "$rc" -eq 12 ] || [ "$rc" -eq 13 ]; then
+    echo "OK: buggy model correctly violated (exit $rc)."
+    echo ""
+    return 0
+  elif [ "$rc" -eq 0 ]; then
+    echo "FAIL: buggy model passed without violation. Invariant/property too weak."
+    echo ""
+    return 1
+  else
+    echo "FAIL: unexpected TLC exit code $rc."
+    echo ""
+    return 1
+  fi
+}
+
 ensure_trace_data() {
   local trace_data="$REPO_ROOT/specs/keeper-state-machine/TraceData.tla"
   local trace_source="${MASC_TLA_TRACE_JSONL:-$REPO_ROOT/specs/keeper-state-machine/synthetic.tla-trace.jsonl}"
@@ -75,6 +112,7 @@ run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperTurnCycle.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperOASBridge.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperOASAdvanced.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperDecisionPipeline.tla"
+run_tlc_buggy "$REPO_ROOT/specs/keeper-state-machine" "KeeperDecisionPipeline.tla"
 
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -74,6 +74,7 @@ run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperStateMachine.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperTurnCycle.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperOASBridge.tla"
 run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperOASAdvanced.tla"
+run_tlc "$REPO_ROOT/specs/keeper-state-machine" "KeeperDecisionPipeline.tla"
 
 # Optional: run TraceSpec if --trace flag provided
 if [ "${1:-}" = "--trace" ]; then

--- a/specs/keeper-state-machine/KeeperDecisionPipeline-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperDecisionPipeline-buggy.cfg
@@ -1,0 +1,26 @@
+\* TLC Model Checking Configuration for KeeperDecisionPipeline (Buggy)
+\*
+\* Uses SpecBuggy which includes BugRemoveRecoveryFloor action.
+\* Expected: RecoveryFloorMaintained (and ToolSetNeverEmpty) violated.
+\* TLC exit code 12 or 13 = violation found = test passes.
+\*
+\* The violation trace demonstrates why recovery floor is necessary:
+\*   GuardFires → ToolRestriction (x3) → BugRemoveRecoveryFloor → tool_count = 0
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxAlpha = 5
+    MaxBeta = 5
+    PenaltyCapPerCycle = 1
+    TotalRemovableShards = 3
+    RecoveryFloorSize = 1
+
+INVARIANTS
+    TypeOK
+    ToolSetNeverEmpty
+    RecoveryFloorMaintained
+    PenaltyCapEnforced
+
+PROPERTIES
+    FailingEventuallyRecovers

--- a/specs/keeper-state-machine/KeeperDecisionPipeline.cfg
+++ b/specs/keeper-state-machine/KeeperDecisionPipeline.cfg
@@ -1,0 +1,22 @@
+\* TLC Model Checking Configuration for KeeperDecisionPipeline (Clean)
+\*
+\* State space: 2 x 5 x 5 x 5 x 2 x 3 = 1500 states (< 1 second)
+\* Expected: all invariants and properties pass.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxAlpha = 5
+    MaxBeta = 5
+    PenaltyCapPerCycle = 1
+    TotalRemovableShards = 3
+    RecoveryFloorSize = 1
+
+INVARIANTS
+    TypeOK
+    ToolSetNeverEmpty
+    RecoveryFloorMaintained
+    PenaltyCapEnforced
+
+PROPERTIES
+    FailingEventuallyRecovers

--- a/specs/keeper-state-machine/KeeperDecisionPipeline.tla
+++ b/specs/keeper-state-machine/KeeperDecisionPipeline.tla
@@ -1,0 +1,220 @@
+---- MODULE KeeperDecisionPipeline ----
+\* Keeper Decision Pipeline — TLA+ Formal Specification
+\*
+\* Models the feedback loop between Guard evaluation, Thompson Sampling,
+\* and Tool Policy restriction.  Verifies that proposed damping mechanisms
+\* (penalty cap per cycle + recovery floor shards) prevent death spirals.
+\*
+\* Key properties verified:
+\*   - ToolSetNeverEmpty:          recovery floor guarantees minimum tools
+\*   - RecoveryFloorMaintained:    tool_count >= RecoveryFloorSize (stronger)
+\*   - PenaltyCapEnforced:         at most PenaltyCapPerCycle penalties per cycle
+\*   - FailingEventuallyRecovers:  Failing always reaches Running (liveness)
+\*
+\* Bug model: BugRemoveRecoveryFloor demonstrates that removing the recovery
+\* floor allows ToolSetNeverEmpty violation and breaks FailingEventuallyRecovers.
+\*
+\* Mirrors: Phase B of Keeper Decision Layer v2 plan (Rev.5)
+\* OCaml mapping (E7 table, plan Part 2.5):
+\*   fsm_phase                  ↔ Keeper_state_machine.DerivePhase
+\*   tool_count                 ↔ |keeper_tool_policy.resolve_tools| (cardinality)
+\*   thompson_alpha             ↔ Thompson_sampling.agent_stats.alpha (discretized)
+\*   thompson_beta              ↔ Thompson_sampling.agent_stats.beta  (discretized)
+\*   guard_penalties_this_cycle ↔ per-cycle counter (B1: guard→thompson bridge)
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxAlpha,              \* Upper bound for Thompson alpha (state space limit)
+    MaxBeta,               \* Upper bound for Thompson beta  (state space limit)
+    PenaltyCapPerCycle,    \* Max guard→thompson penalties per heartbeat cycle (design: 1)
+    TotalRemovableShards,  \* Removable shards (board, filesystem, shell, ...)
+    RecoveryFloorSize      \* Non-removable shards (base; shard.removable = false)
+
+ASSUME RecoveryFloorSize >= 1  \* At least one non-removable shard must exist
+
+VARIABLES
+    fsm_phase,                  \* "Running" | "Failing"
+    tool_count,                 \* Total available tools (floor..max)
+    thompson_alpha,             \* Beta prior: successes (discretized, min 1)
+    thompson_beta,              \* Beta prior: failures  (discretized, min 1)
+    guard_penalties_this_cycle, \* Per-cycle penalty counter
+    turn_outcome                \* "None" | "Success" | "Failure"
+
+vars == <<fsm_phase, tool_count, thompson_alpha, thompson_beta,
+          guard_penalties_this_cycle, turn_outcome>>
+
+MaxToolCount == TotalRemovableShards + RecoveryFloorSize
+
+\* ── Initial State ─────────────────────────────────────────
+
+Init ==
+    /\ fsm_phase = "Running"
+    /\ tool_count = MaxToolCount          \* All shards granted at start
+    /\ thompson_alpha = 2                 \* Slightly positive prior
+    /\ thompson_beta = 1                  \* (alpha > beta → healthy)
+    /\ guard_penalties_this_cycle = 0
+    /\ turn_outcome = "None"
+
+\* ── Actions ───────────────────────────────────────────────
+
+\* Guard fires: measurement thresholds exceeded (repetition, alignment, context).
+\* Transitions to Failing; applies Thompson penalty capped per cycle.
+\* Mirrors: keeper_guard.ml evaluate → Guardrail_stop event.
+\*          B1: guard→thompson bridge with penalty cap.
+GuardFires ==
+    /\ fsm_phase \in {"Running", "Failing"}
+    /\ guard_penalties_this_cycle < PenaltyCapPerCycle
+    /\ thompson_beta' = IF thompson_beta < MaxBeta
+                         THEN thompson_beta + 1
+                         ELSE thompson_beta
+    /\ guard_penalties_this_cycle' = guard_penalties_this_cycle + 1
+    /\ fsm_phase' = "Failing"
+    /\ UNCHANGED <<tool_count, thompson_alpha, turn_outcome>>
+
+\* Tool restriction: Failing phase removes removable shards.
+\* Recovery floor (non-removable shards) enforces a hard lower bound.
+\* Mirrors: B2 — keeper_tool_policy.ml Failing → recovery_minimum_shards.
+\*          tool_shard.ml: shard.removable = false → cannot be revoked.
+ToolRestriction ==
+    /\ fsm_phase = "Failing"
+    /\ tool_count > RecoveryFloorSize     \* Floor enforced
+    /\ tool_count' = tool_count - 1
+    /\ UNCHANGED <<fsm_phase, thompson_alpha, thompson_beta,
+                   guard_penalties_this_cycle, turn_outcome>>
+
+\* Turn succeeds: keeper completes a task with available tools.
+\* Positive Thompson signal (alpha increases).
+\* Mirrors: keeper_state_machine.ml TurnSucceeded event.
+TurnSucceeds ==
+    /\ fsm_phase \in {"Running", "Failing"}
+    /\ tool_count > 0
+    /\ turn_outcome' = "Success"
+    /\ thompson_alpha' = IF thompson_alpha < MaxAlpha
+                          THEN thompson_alpha + 1
+                          ELSE thompson_alpha
+    /\ UNCHANGED <<fsm_phase, tool_count, thompson_beta,
+                   guard_penalties_this_cycle>>
+
+\* Turn fails: task not completed (insufficient tools, complexity, etc.).
+\* Does NOT directly update Thompson — guard evaluation handles negatives.
+\* Mirrors: keeper_state_machine.ml TurnFailed event.
+TurnFails ==
+    /\ fsm_phase \in {"Running", "Failing"}
+    /\ tool_count > 0
+    /\ turn_outcome' = "Failure"
+    /\ UNCHANGED <<fsm_phase, tool_count, thompson_alpha, thompson_beta,
+                   guard_penalties_this_cycle>>
+
+\* Recovery heartbeat: successful turn clears Failing condition.
+\* Mirrors: keeper_state_machine.ml HeartbeatOk clearing guardrail_triggered.
+RecoveryHeartbeat ==
+    /\ fsm_phase = "Failing"
+    /\ turn_outcome = "Success"
+    /\ fsm_phase' = "Running"
+    /\ guard_penalties_this_cycle' = 0    \* Reset on recovery
+    /\ UNCHANGED <<tool_count, thompson_alpha, thompson_beta, turn_outcome>>
+
+\* Shard restoration: Running keeper with positive score regains shards.
+\* Mirrors: B2 — tool_shard.grant_shard on improved performance.
+ShardRestoration ==
+    /\ fsm_phase = "Running"
+    /\ tool_count < MaxToolCount
+    /\ thompson_alpha > thompson_beta     \* Positive Thompson score
+    /\ tool_count' = tool_count + 1
+    /\ UNCHANGED <<fsm_phase, thompson_alpha, thompson_beta,
+                   guard_penalties_this_cycle, turn_outcome>>
+
+\* Cycle boundary: heartbeat cycle advances, per-cycle penalty counter resets.
+NewCycle ==
+    /\ guard_penalties_this_cycle > 0
+    /\ guard_penalties_this_cycle' = 0
+    /\ UNCHANGED <<fsm_phase, tool_count, thompson_alpha, thompson_beta,
+                   turn_outcome>>
+
+\* ── Next State ────────────────────────────────────────────
+
+Next ==
+    \/ GuardFires
+    \/ ToolRestriction
+    \/ TurnSucceeds
+    \/ TurnFails
+    \/ RecoveryHeartbeat
+    \/ ShardRestoration
+    \/ NewCycle
+
+\* ── Bug Model ─────────────────────────────────────────────
+
+\* BUG: Recovery floor removed — tool_count can drop below RecoveryFloorSize.
+\* Models: revoke_shard ignoring removable=false, or recovery_minimum_shards
+\* not enforced in Failing phase.
+\* Consequence: tool_count reaches 0 → TurnSucceeds permanently disabled
+\*              → RecoveryHeartbeat never fires → Failing forever (death spiral).
+BugRemoveRecoveryFloor ==
+    /\ fsm_phase = "Failing"
+    /\ tool_count > 0
+    \* BUG: ignores RecoveryFloorSize, removes shard below floor
+    /\ tool_count' = tool_count - 1
+    /\ UNCHANGED <<fsm_phase, thompson_alpha, thompson_beta,
+                   guard_penalties_this_cycle, turn_outcome>>
+
+NextBuggy ==
+    \/ Next
+    \/ BugRemoveRecoveryFloor
+
+\* ── Fairness ──────────────────────────────────────────────
+
+Fairness ==
+    /\ WF_vars(TurnSucceeds)           \* Turns eventually succeed if tools available
+    /\ SF_vars(RecoveryHeartbeat)      \* Strong fairness: recovery fires even if
+                                        \* intermittently disabled by guard/turn events.
+                                        \* Justified: heartbeat runs on periodic timer,
+                                        \* independent of guard evaluation order.
+    /\ WF_vars(NewCycle)               \* Heartbeat cycles advance
+    /\ WF_vars(ShardRestoration)       \* Shards restored when score positive
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ Fairness
+
+\* ── Safety Properties ─────────────────────────────────────
+
+\* S1: Tool set never completely empty.
+\* Recovery floor (non-removable shards) always provides minimum tools.
+\* Clean: satisfied — ToolRestriction stops at RecoveryFloorSize.
+\* Buggy: violated — BugRemoveRecoveryFloor bypasses floor → tool_count = 0.
+ToolSetNeverEmpty == tool_count > 0
+
+\* S2: Recovery floor maintained — stronger than S1.
+\* tool_count never drops below non-removable shard count.
+RecoveryFloorMaintained == tool_count >= RecoveryFloorSize
+
+\* S3: Guard penalty bounded per heartbeat cycle.
+\* Prevents rapid Thompson degradation from consecutive guard firings.
+PenaltyCapEnforced == guard_penalties_this_cycle <= PenaltyCapPerCycle
+
+\* ── Type Invariant ────────────────────────────────────────
+
+TypeOK ==
+    /\ fsm_phase \in {"Running", "Failing"}
+    /\ tool_count \in 0..MaxToolCount
+    /\ thompson_alpha \in 1..MaxAlpha
+    /\ thompson_beta \in 1..MaxBeta
+    /\ guard_penalties_this_cycle \in 0..PenaltyCapPerCycle
+    /\ turn_outcome \in {"None", "Success", "Failure"}
+
+\* ── Liveness Properties ───────────────────────────────────
+
+\* L1: Failing eventually recovers to Running.
+\* Proof sketch (clean model):
+\*   1. tool_count >= RecoveryFloorSize > 0 always         (S1, ASSUME)
+\*   2. TurnSucceeds enabled (tool_count > 0) and fair     (WF)
+\*   3. turn_outcome = "Success" eventually                 (WF step 2)
+\*   4. RecoveryHeartbeat enabled and fair                  (WF)
+\*   5. fsm_phase = "Running"                               (WF step 4)
+\*
+\* Buggy model: at tool_count = 0, TurnSucceeds is permanently disabled,
+\* breaking step 2. Failing persists forever → liveness violation.
+FailingEventuallyRecovers == (fsm_phase = "Failing") ~> (fsm_phase = "Running")
+
+====

--- a/specs/keeper-state-machine/KeeperDecisionPipeline.tla
+++ b/specs/keeper-state-machine/KeeperDecisionPipeline.tla
@@ -108,13 +108,17 @@ TurnFails ==
                    guard_penalties_this_cycle>>
 
 \* Recovery heartbeat: successful turn clears Failing condition.
+\* Resets turn_outcome so subsequent cycles start from a clean state;
+\* without this, a stale "Success" would let recovery re-fire immediately
+\* after the next GuardFires→Failing transition.
 \* Mirrors: keeper_state_machine.ml HeartbeatOk clearing guardrail_triggered.
 RecoveryHeartbeat ==
     /\ fsm_phase = "Failing"
     /\ turn_outcome = "Success"
     /\ fsm_phase' = "Running"
+    /\ turn_outcome' = "None"            \* Reset: require fresh TurnSucceeds for next recovery
     /\ UNCHANGED <<tool_count, thompson_alpha, thompson_beta,
-                   guard_penalties_this_cycle, turn_outcome>>
+                   guard_penalties_this_cycle>>
 
 \* Shard restoration: Running keeper with positive score regains shards.
 \* Mirrors: B2 — tool_shard.grant_shard on improved performance.
@@ -127,11 +131,15 @@ ShardRestoration ==
                    guard_penalties_this_cycle, turn_outcome>>
 
 \* Cycle boundary: heartbeat cycle advances, per-cycle penalty counter resets.
+\* This is the sole reset point for guard_penalties_this_cycle ("per-cycle"
+\* semantics).  RecoveryHeartbeat intentionally does NOT reset it — recovery
+\* is a phase transition within a cycle, not a cycle boundary.
+\* Also resets turn_outcome so stale results do not leak across cycles.
 NewCycle ==
     /\ guard_penalties_this_cycle > 0
     /\ guard_penalties_this_cycle' = 0
-    /\ UNCHANGED <<fsm_phase, tool_count, thompson_alpha, thompson_beta,
-                   turn_outcome>>
+    /\ turn_outcome' = "None"            \* Fresh cycle, fresh outcome
+    /\ UNCHANGED <<fsm_phase, tool_count, thompson_alpha, thompson_beta>>
 
 \* ── Next State ────────────────────────────────────────────
 
@@ -167,11 +175,13 @@ NextBuggy ==
 
 Fairness ==
     /\ WF_vars(TurnSucceeds)           \* Turns eventually succeed if tools available
-    /\ SF_vars(RecoveryHeartbeat)      \* Strong fairness: GuardFires resets turn_outcome
-                                        \* to "None", intermittently disabling recovery.
-                                        \* WF insufficient: TurnSucceeds re-enables it,
-                                        \* but GuardFires can preempt before it fires.
-                                        \* SF justified: heartbeat timer is independent.
+    /\ SF_vars(RecoveryHeartbeat)      \* Strong fairness required: RecoveryHeartbeat is
+                                        \* repeatedly enabled (TurnSucceeds sets turn_outcome
+                                        \* = "Success") but GuardFires can preempt, resetting
+                                        \* turn_outcome to "None" before recovery executes.
+                                        \* WF would require continuous enablement; SF fires
+                                        \* if the action is infinitely often enabled, which
+                                        \* holds because TurnSucceeds is WF-fair.
     /\ WF_vars(NewCycle)               \* Heartbeat cycles advance
     /\ WF_vars(ShardRestoration)       \* Shards restored when score positive
 

--- a/specs/keeper-state-machine/KeeperDecisionPipeline.tla
+++ b/specs/keeper-state-machine/KeeperDecisionPipeline.tla
@@ -70,7 +70,8 @@ GuardFires ==
                          ELSE thompson_beta
     /\ guard_penalties_this_cycle' = guard_penalties_this_cycle + 1
     /\ fsm_phase' = "Failing"
-    /\ UNCHANGED <<tool_count, thompson_alpha, turn_outcome>>
+    /\ turn_outcome' = "None"             \* Stale success invalidated on guard event
+    /\ UNCHANGED <<tool_count, thompson_alpha>>
 
 \* Tool restriction: Failing phase removes removable shards.
 \* Recovery floor (non-removable shards) enforces a hard lower bound.
@@ -112,8 +113,8 @@ RecoveryHeartbeat ==
     /\ fsm_phase = "Failing"
     /\ turn_outcome = "Success"
     /\ fsm_phase' = "Running"
-    /\ guard_penalties_this_cycle' = 0    \* Reset on recovery
-    /\ UNCHANGED <<tool_count, thompson_alpha, thompson_beta, turn_outcome>>
+    /\ UNCHANGED <<tool_count, thompson_alpha, thompson_beta,
+                   guard_penalties_this_cycle, turn_outcome>>
 
 \* Shard restoration: Running keeper with positive score regains shards.
 \* Mirrors: B2 — tool_shard.grant_shard on improved performance.
@@ -166,10 +167,11 @@ NextBuggy ==
 
 Fairness ==
     /\ WF_vars(TurnSucceeds)           \* Turns eventually succeed if tools available
-    /\ SF_vars(RecoveryHeartbeat)      \* Strong fairness: recovery fires even if
-                                        \* intermittently disabled by guard/turn events.
-                                        \* Justified: heartbeat runs on periodic timer,
-                                        \* independent of guard evaluation order.
+    /\ SF_vars(RecoveryHeartbeat)      \* Strong fairness: GuardFires resets turn_outcome
+                                        \* to "None", intermittently disabling recovery.
+                                        \* WF insufficient: TurnSucceeds re-enables it,
+                                        \* but GuardFires can preempt before it fires.
+                                        \* SF justified: heartbeat timer is independent.
     /\ WF_vars(NewCycle)               \* Heartbeat cycles advance
     /\ WF_vars(ShardRestoration)       \* Shards restored when score positive
 
@@ -210,8 +212,10 @@ TypeOK ==
 \*   1. tool_count >= RecoveryFloorSize > 0 always         (S1, ASSUME)
 \*   2. TurnSucceeds enabled (tool_count > 0) and fair     (WF)
 \*   3. turn_outcome = "Success" eventually                 (WF step 2)
-\*   4. RecoveryHeartbeat enabled and fair                  (WF)
-\*   5. fsm_phase = "Running"                               (WF step 4)
+\*   4. GuardFires may reset turn_outcome to "None"         (preemption)
+\*   5. But TurnSucceeds re-enables recovery (WF, step 2)   (infinitely often)
+\*   6. RecoveryHeartbeat infinitely often enabled           (SF applies)
+\*   7. fsm_phase = "Running"                               (SF fires)
 \*
 \* Buggy model: at tool_count = 0, TurnSucceeds is permanently disabled,
 \* breaking step 2. Failing persists forever → liveness violation.


### PR DESCRIPTION
## Summary
- KeeperDecisionPipeline.tla: Guard→Thompson→ToolPolicy 피드백 루프의 형식 검증
- 2중 댐핑(penalty cap + recovery floor)이 death spiral을 방지하는지 증명
- Bug model: recovery floor 제거 시 6 스텝만에 `ToolSetNeverEmpty` 위반

## Properties Verified

| Property | Type | Clean | Buggy |
|---|---|---|---|
| TypeOK | Invariant | Pass | Pass |
| ToolSetNeverEmpty | Safety | Pass | **Violated** (exit 12) |
| RecoveryFloorMaintained | Safety | Pass | **Violated** |
| PenaltyCapEnforced | Safety | Pass | Pass |
| FailingEventuallyRecovers | Liveness | Pass | N/A (invariant fails first) |

## Key Discovery
- `SF_vars(RecoveryHeartbeat)` 필수 — WF로는 불충분
- Guard가 turn 사이에 `turn_outcome`을 간헐적으로 끊어 WF 조건을 깨뜨림
- 구현 시 heartbeat recovery 처리가 guard 재평가보다 우선되어야 함

## Context
- Plan: Keeper Decision Layer v2 (Rev.5), Phase B0
- Tracking: #6230
- State space: 360 states, <1s 완전 탐색
- OCaml 매핑: `keeper_state_machine.ml`, `thompson_sampling.ml`, `keeper_tool_policy.ml`, `tool_shard.ml`

## Test plan
- [x] TLC clean spec: exit 0 (no error)
- [x] TLC buggy spec: exit 12 (ToolSetNeverEmpty violated)
- [ ] CI `make check-keeper` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)