### PR TITLE
[codex] Fix keeper task drift

### DIFF
--- a/lib/keeper/keeper_coordination.ml
+++ b/lib/keeper/keeper_coordination.ml
@@ -41,32 +41,4 @@ let set_room_cursor meta room_id seq =
 let room_ids_for_meta _config (_meta : keeper_meta) : string list =
   [ "default" ]
 
-let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
-  let room_ids = room_ids_for_meta config meta in
-  let successful_rooms =
-    List.fold_left
-      (fun acc room_id ->
-        try
-          if
-            not
-              (Room.is_agent_joined config
-                 ~agent_name:meta.agent_name)
-          then begin
-            Room.ensure_room_bootstrap config room_id;
-            let preset_cap = match Keeper_types.tool_access_preset meta.tool_access with
-              | Some p -> ["preset:" ^ Keeper_types.tool_preset_to_string p]
-              | None -> []
-            in
-            ignore
-              (Room.join config ~agent_name:meta.agent_name
-                 ~capabilities:(["keeper"] @ preset_cap) ())
-          end;
-          ignore
-            (Room.heartbeat config ~agent_name:meta.agent_name);
-          room_id :: acc
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          log_keeper_exn ~label:(Printf.sprintf "room presence sync failed for %s in %s" meta.name room_id) exn;
-          acc)
-      [] room_ids
-  in
-  { meta with joined_room_ids = List.rev successful_rooms }
+let ensure_keeper_room_presence = Keeper_exec_context.ensure_keeper_room_presence

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -179,26 +179,34 @@ let set_room_cursor meta room_id seq =
 let room_ids_for_meta _config (_meta : keeper_meta) : string list =
   [ "default" ]
 
+let keeper_room_capabilities (meta : keeper_meta) =
+  let preset_cap =
+    match Keeper_types.tool_access_preset meta.tool_access with
+    | Some p -> [ "preset:" ^ Keeper_types.tool_preset_to_string p ]
+    | None -> []
+  in
+  [ "keeper" ] @ preset_cap
+
 let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
   let room_ids = room_ids_for_meta config meta in
+  let capabilities = keeper_room_capabilities meta in
   let successful_rooms =
     List.fold_left
       (fun acc room_id ->
         try
+          Room.ensure_room_bootstrap config room_id;
           if
             not
               (Room.is_agent_joined config
                  ~agent_name:meta.agent_name)
           then begin
-            Room.ensure_room_bootstrap config room_id;
-            let preset_cap = match Keeper_types.tool_access_preset meta.tool_access with
-              | Some p -> ["preset:" ^ Keeper_types.tool_preset_to_string p]
-              | None -> []
-            in
             ignore
               (Room.join config ~agent_name:meta.agent_name
-                 ~capabilities:(["keeper"] @ preset_cap) ())
+                 ~capabilities ())
           end;
+          ignore
+            (Room.update_agent_r config ~agent_name:meta.agent_name
+               ~capabilities ());
           ignore
             (Room.heartbeat config ~agent_name:meta.agent_name);
           room_id :: acc

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -187,6 +187,23 @@ let keeper_room_capabilities (meta : keeper_meta) =
   in
   [ "keeper" ] @ preset_cap
 
+let keeper_room_capabilities_need_sync config (meta : keeper_meta) capabilities =
+  let agent_file =
+    Filename.concat (Room.agents_dir config)
+      (Room.safe_filename meta.agent_name ^ ".json")
+  in
+  if not (Sys.file_exists agent_file) then
+    true
+  else
+    try
+      let json = Room.read_json config agent_file in
+      match Types.agent_of_yojson json with
+      | Ok agent -> agent.capabilities <> capabilities
+      | Error _ -> true
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | _ -> true
+
 let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
   let room_ids = room_ids_for_meta config meta in
   let capabilities = keeper_room_capabilities meta in
@@ -194,19 +211,21 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
     List.fold_left
       (fun acc room_id ->
         try
-          Room.ensure_room_bootstrap config room_id;
-          if
-            not
-              (Room.is_agent_joined config
-                 ~agent_name:meta.agent_name)
+          let joined =
+            Room.is_agent_joined config ~agent_name:meta.agent_name
+          in
+          if not joined
           then begin
+            Room.ensure_room_bootstrap config room_id;
             ignore
               (Room.join config ~agent_name:meta.agent_name
                  ~capabilities ())
           end;
-          ignore
-            (Room.update_agent_r config ~agent_name:meta.agent_name
-               ~capabilities ());
+          if joined && keeper_room_capabilities_need_sync config meta capabilities
+          then
+            ignore
+              (Room.update_agent_r config ~agent_name:meta.agent_name
+                 ~capabilities ());
           ignore
             (Room.heartbeat config ~agent_name:meta.agent_name);
           room_id :: acc

--- a/lib/room/room_task_schedule.ml
+++ b/lib/room/room_task_schedule.ml
@@ -7,6 +7,53 @@ open Types
 include Room_utils
 include Room_state
 
+let agent_current_task_matches_backlog backlog ~agent_name task_id =
+  match
+    List.find_opt
+      (fun (task : Types.task) -> String.equal task.id task_id)
+      backlog.tasks
+  with
+  | Some task -> (
+      match task.task_status with
+      | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+          String.equal assignee agent_name
+      | Todo | Done _ | Cancelled _ -> false)
+  | None -> false
+
+let reconcile_agent_current_task_with_backlog config ~agent_name backlog =
+  let agent_file =
+    Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
+  in
+  if Sys.file_exists agent_file then
+    match read_agent_with_repair config agent_file with
+    | Ok agent -> (
+        match agent.current_task with
+        | Some task_id
+          when not
+                 (agent_current_task_matches_backlog backlog ~agent_name task_id)
+          ->
+            let updated_status =
+              match agent.status with
+              | Inactive -> Inactive
+              | Active | Busy | Listening -> Active
+            in
+            let updated =
+              {
+                agent with
+                status = updated_status;
+                current_task = None;
+                last_seen = now_iso ();
+              }
+            in
+            write_json config agent_file (agent_to_yojson updated);
+            log_event config
+              (Printf.sprintf
+                 "{\"type\":\"agent_current_task_reconciled\",\"agent\":\"%s\",\"stale_task\":\"%s\",\"ts\":\"%s\"}"
+                 agent_name task_id (now_iso ()))
+        | Some _ | None -> ())
+    | Error msg ->
+        Log.Misc.error "agent state reconcile failed: %s" msg
+
 (** Claim next highest priority unclaimed task.
     Optional [exclude_task_ids] prevents re-claiming known bad tasks in the same loop run.
 
@@ -21,6 +68,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
   with_file_lock config backlog_path (fun () ->
     try
       let backlog = read_backlog config in
+      reconcile_agent_current_task_with_backlog config ~agent_name backlog;
 
       (* BUG-004: Detect and auto-release previous claim to prevent orphaned tasks.
          If this agent already holds a Claimed or InProgress task, release it

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -271,22 +271,53 @@ let handle_claim ctx args =
    | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
   result_to_response result
 
-(** Extract agent's preset from capabilities list (e.g., ["keeper", "preset:delivery"] -> Some "delivery"). *)
-let resolve_agent_preset config agent_name =
-  let agent_file = Filename.concat (Room.agents_dir config) (Room.safe_filename agent_name ^ ".json") in
-  try
-    let json = Room.read_json config agent_file in
-    let caps = Yojson.Safe.Util.(json |> member "capabilities" |> to_list |> List.map to_string) in
-    List.find_map (fun c ->
+(** Extract preset token from capabilities (e.g., ["keeper"; "preset:delivery"]). *)
+let preset_from_capabilities caps =
+  List.find_map
+    (fun c ->
       let prefix = "preset:" in
       let plen = String.length prefix in
-      if String.length c > plen && String.sub c 0 plen = prefix then
-        Some (String.sub c plen (String.length c - plen))
-      else None
-    ) caps
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> None
+      if String.length c > plen && String.sub c 0 plen = prefix
+      then Some (String.sub c plen (String.length c - plen))
+      else None)
+    caps
+
+let resolve_keeper_preset config agent_name =
+  match Keeper_types.keeper_name_from_agent_name agent_name with
+  | None -> None
+  | Some keeper_name -> (
+      match Keeper_runtime.ensure_keeper_meta config keeper_name with
+      | Ok meta ->
+          Keeper_types.tool_access_preset meta.tool_access
+          |> Option.map Keeper_types.tool_preset_to_string
+      | Error _ -> (
+          match Keeper_types.read_meta config keeper_name with
+          | Ok (Some meta) ->
+              Keeper_types.tool_access_preset meta.tool_access
+              |> Option.map Keeper_types.tool_preset_to_string
+          | Ok None | Error _ -> None))
+
+(** Resolve an agent preset.
+    Keepers read from live keeper meta first so claim_next follows the
+    reconciled runtime/declarative SSOT rather than a stale join snapshot. *)
+let resolve_agent_preset config agent_name =
+  match resolve_keeper_preset config agent_name with
+  | Some _ as preset -> preset
+  | None ->
+      let agent_file =
+        Filename.concat (Room.agents_dir config)
+          (Room.safe_filename agent_name ^ ".json")
+      in
+      try
+        let json = Room.read_json config agent_file in
+        let caps =
+          Yojson.Safe.Util.(
+            json |> member "capabilities" |> to_list |> List.map to_string)
+        in
+        preset_from_capabilities caps
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> None
 
 (** Build a task_filter closure that checks required_preset against the agent's preset. *)
 let preset_task_filter ~agent_preset (task : Types.task) =

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -286,16 +286,11 @@ let resolve_keeper_preset config agent_name =
   match Keeper_types.keeper_name_from_agent_name agent_name with
   | None -> None
   | Some keeper_name -> (
-      match Keeper_runtime.ensure_keeper_meta config keeper_name with
-      | Ok meta ->
+      match Keeper_types.read_meta config keeper_name with
+      | Ok (Some meta) ->
           Keeper_types.tool_access_preset meta.tool_access
           |> Option.map Keeper_types.tool_preset_to_string
-      | Error _ -> (
-          match Keeper_types.read_meta config keeper_name with
-          | Ok (Some meta) ->
-              Keeper_types.tool_access_preset meta.tool_access
-              |> Option.map Keeper_types.tool_preset_to_string
-          | Ok None | Error _ -> None))
+      | Ok None | Error _ -> None)
 
 (** Resolve an agent preset.
     Keepers read from live keeper meta first so claim_next follows the

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -371,6 +371,54 @@ work_discovery_guidance = "TOML guidance"
       check (option string) "work_discovery_guidance"
         (Some "TOML guidance") updated.work_discovery_guidance
 
+(** Test: room presence sync updates stale agent capabilities from live keeper meta. *)
+let test_room_presence_syncs_capabilities () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "room-presence-sync-test" in
+  let agent_name = Keeper_types.keeper_agent_name keeper_name in
+  let config = Room.default_config room_dir in
+  let _ = Room.init config ~agent_name:None in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String agent_name);
+            ("trace_id", `String "trace-room-presence-sync");
+            ( "tool_access",
+              `Assoc
+                [
+                  ("kind", `String "preset");
+                  ("preset", `String "social");
+                ] );
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  ignore
+    (Room.join config ~agent_name ~capabilities:[ "keeper"; "preset:minimal" ] ());
+  let _synced = Keeper_exec_context.ensure_keeper_room_presence config initial_meta in
+  let agent =
+    Room.get_agents_raw config
+    |> List.find_opt (fun (agent : Types.agent) -> String.equal agent.name agent_name)
+  in
+  match agent with
+  | None -> fail "expected keeper agent after room presence sync"
+  | Some agent ->
+      check
+        (list string)
+        "capabilities synced from live meta"
+        [ "keeper"; "preset:social" ]
+        agent.capabilities
+
 (** Test: update_field_in_content replaces existing field *)
 let test_toml_update_existing () =
   let input = {|[keeper]
@@ -465,6 +513,10 @@ let () =
             "TOML work_discovery fields overwrite stale meta"
             `Quick
             test_discovery_resync;
+          test_case
+            "room presence sync overwrites stale agent capabilities"
+            `Quick
+            test_room_presence_syncs_capabilities;
         ] );
       ( "toml_writer",
         [

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -204,6 +204,49 @@ let test_claim_next_consecutive () =
       (str_contains r1 "task-001" || str_contains r2 "task-002")
   )
 
+let test_claim_next_reconciles_stale_agent_current_task () =
+  with_test_env (fun config ->
+    let agent_name =
+      match Room.get_agents_raw config with
+      | [ agent ] -> agent.Types.name
+      | _ -> Alcotest.fail "expected exactly one joined agent"
+    in
+    let _ = Room.add_task config ~title:"Done already" ~priority:1 ~description:"" in
+    let _ = Room.claim_task config ~agent_name ~task_id:"task-001" in
+    (match
+       Room.complete_task_r config ~agent_name ~task_id:"task-001" ~notes:"done"
+     with
+    | Ok _ -> ()
+    | Error e -> Alcotest.fail (Types.masc_error_to_string e));
+    let agent_file =
+      Filename.concat (Room.agents_dir config)
+        (Room.safe_filename agent_name ^ ".json")
+    in
+    let stale_agent =
+      match Room.read_json config agent_file |> Types.agent_of_yojson with
+      | Ok agent ->
+          { agent with status = Types.Busy; current_task = Some "task-001" }
+      | Error msg -> Alcotest.fail ("agent parse failed: " ^ msg)
+    in
+    Room.write_json config agent_file (Types.agent_to_yojson stale_agent);
+    match Room.claim_next_r config ~agent_name () with
+    | Room.Claim_next_no_unclaimed ->
+        let agents = Room.get_agents_raw config in
+        let agent_after =
+          List.find_opt (fun (agent : Types.agent) ->
+            String.equal agent.name agent_name) agents
+        in
+        (match agent_after with
+        | Some agent ->
+            Alcotest.(check (option string))
+              "stale current_task cleared" None agent.current_task;
+            Alcotest.(check string)
+              "status reset to active" "active"
+              (Types.agent_status_to_string agent.status)
+        | None -> Alcotest.fail "agent missing after reconcile")
+    | _ -> Alcotest.fail "expected no_unclaimed after stale reconcile"
+  )
+
 (* ============================================================ *)
 (* BUG-004: claim_next auto-release Tests                        *)
 (* ============================================================ *)
@@ -1008,6 +1051,8 @@ let () =
       Alcotest.test_case "empty backlog" `Quick test_claim_next_empty_backlog;
       Alcotest.test_case "all claimed" `Quick test_claim_next_all_claimed;
       Alcotest.test_case "consecutive" `Quick test_claim_next_consecutive;
+      Alcotest.test_case "reconciles stale current_task" `Quick
+        test_claim_next_reconciles_stale_agent_current_task;
       Alcotest.test_case "BUG-004: auto-releases previous" `Quick test_claim_next_auto_releases_previous;
       Alcotest.test_case "BUG-004: released task claimable" `Quick test_claim_next_released_task_claimable_by_others;
       Alcotest.test_case "BUG-004: released_task_id field" `Quick test_claim_next_r_released_task_field;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -17,14 +17,16 @@ let test name f =
 
 (* Create test context *)
 let test_counter = ref 0
-let make_test_ctx () =
+let make_test_ctx_with_agent agent_name =
   incr test_counter;
   let tmp = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc-task-test-%d-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) !test_counter) in
   Unix.mkdir tmp 0o755;
   let config = Room.default_config tmp in
-  let _ = Room.init config ~agent_name:(Some "test-agent") in
-  { Tool_task.config; agent_name = "test-agent"; sw = None }
+  let _ = Room.init config ~agent_name:(Some agent_name) in
+  { Tool_task.config; agent_name; sw = None }
+
+let make_test_ctx () = make_test_ctx_with_agent "test-agent"
 
 let make_temp_dir prefix =
   incr test_counter;
@@ -303,6 +305,58 @@ let () = test "handle_claim_next_sets_planning_current_task" (fun () ->
   let (success, _result) = Tool_task.handle_claim_next ctx (`Assoc []) in
   assert success;
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
+)
+
+let () = test "handle_claim_next_prefers_live_keeper_preset" (fun () ->
+  let agent_name = "keeper-social-sync-agent" in
+  let keeper_name = "social-sync" in
+  let ctx = make_test_ctx_with_agent agent_name in
+  let base_path = Masc_test_deps.find_project_root () in
+  ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path));
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String agent_name);
+            ("trace_id", `String "trace-social-sync");
+            ( "tool_access",
+              `Assoc
+                [
+                  ("kind", `String "preset");
+                  ("preset", `String "social");
+                ] );
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> failwith ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true ctx.config initial_meta with
+  | Ok () -> ()
+  | Error e -> failwith ("write_meta failed: " ^ e));
+  (match
+     Room.update_agent_r ctx.config ~agent_name
+       ~capabilities:[ "keeper"; "preset:minimal" ] ()
+   with
+  | Ok _ -> ()
+  | Error e -> failwith (Types.masc_error_to_string e));
+  let _ =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Needs social");
+          ("required_preset", `String "social");
+        ])
+  in
+  let success, result = Tool_task.handle_claim_next ctx (`Assoc []) in
+  assert success;
+  match Room.get_tasks_raw ctx.config with
+  | [ task ] -> (
+      match task.task_status with
+      | Types.Claimed { assignee; _ } -> assert (assignee = agent_name)
+      | _ -> failwith ("expected task to be claimed: " ^ result))
+  | _ -> failwith ("expected exactly one task: " ^ result)
 )
 
 let () = test "transition_claim_leaves_planning_current_task_unset" (fun () ->


### PR DESCRIPTION
## What changed
- made `claim_next` resolve keeper presets from live keeper meta before falling back to room agent capability snapshots
- synced keeper room capabilities on room-presence refresh instead of only at initial join
- reconciled stale `agent.current_task` against backlog state before scheduling the next task
- added regression tests for live preset resolution, stale task cleanup, and capability sync

## Why
Keeper scheduling was reading a stale capability snapshot from `agents/*.json` while keeper runtime truth lived in keeper meta and declarative defaults. That let `claim_next` reject valid tasks after persona/TOML changes and left finished or reassigned tasks stuck in agent progress state.

## Impact
- keeper task eligibility now follows live runtime/declarative SSOT
- heartbeat/room-presence refresh rewrites stale `preset:*` capability tags
- agents no longer keep `current_task` pointing at done or foreign backlog items

## Root cause
The deterministic scheduler depended on join-time capability snapshots, while keeper configuration could drift later via TOML/persona reconciliation. Agent progress state also lacked backlog-based reconciliation before scheduling.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-task-drift`
- `_build/default/test/test_tool_task_coverage.exe`
- `_build/default/test/test_room_coverage.exe`
- `_build/default/test/test_keeper_runtime_config_ssot.exe`
