### PR TITLE
[codex] Harden keeper runtime SSOT and reactivity

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -332,6 +332,29 @@ let run_cmd host port base_path =
   let normalized_base_path =
     Env_config.normalize_masc_base_path_input base_path
   in
+  let resolution_source =
+    match Sys.getenv_opt "MASC_BASE_PATH_RESOLUTION_SOURCE" with
+    | Some source when String.trim source <> "" -> String.trim source
+    | _ ->
+        let inherited_env_matches =
+          match Sys.getenv_opt "MASC_BASE_PATH" with
+          | Some existing ->
+              String.equal
+                (Env_config.normalize_masc_base_path_input existing)
+                normalized_base_path
+          | None -> false
+        in
+        if inherited_env_matches then
+          "explicit_env"
+        else
+          let default_path =
+            Env_config.normalize_masc_base_path_input (default_base_path ())
+          in
+          if String.equal default_path normalized_base_path then
+            "implicit_repo_root"
+          else
+            "explicit_cli"
+  in
   let stripped_base_path =
     Env_config.strip_path_trailing_slashes (String.trim base_path)
   in
@@ -346,6 +369,7 @@ let run_cmd host port base_path =
       base_path normalized_base_path;
   Unix.putenv "MASC_BASE_PATH_INPUT" raw_base_path;
   Unix.putenv "MASC_BASE_PATH" normalized_base_path;
+  Unix.putenv "MASC_BASE_PATH_RESOLUTION_SOURCE" resolution_source;
   (* Persist logs inside .masc/logs/ — colocated with state, not a sibling.
      Previous code wrote to base_path/logs/ which diverged from .masc/ when
      base_path differed from the repo checkout directory. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -272,6 +272,7 @@ let run_turn
       ~(cascade_name : string)
       ?provider_filter
       ~(generation : int)
+      ?(actionable_signal = false)
       ?(max_turns : int = Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call)
       (* Per-call turn budget. Keeper resumes via checkpoint if exhausted. *)
       ?(max_idle_turns : int = 3)
@@ -1292,6 +1293,26 @@ let run_turn
                   turn
                   max_turns
                   is_last_turn;
+              let all_allowed =
+                if actionable_signal && not is_last_turn
+                then
+                  let pruned =
+                    Keeper_exec_tools.prune_boring_tools_for_actionable_turn
+                      all_allowed
+                  in
+                  if List.length pruned <> List.length all_allowed then (
+                    let removed =
+                      List.filter
+                        (fun name -> not (List.mem name pruned))
+                        all_allowed
+                    in
+                    Log.Keeper.info
+                      "keeper:%s actionable turn pruned boring tools: %s"
+                      meta.name
+                      (String.concat ", " removed));
+                  pruned
+                else all_allowed
+              in
               (* Context overflow guard: Tool_selector.select already respects
            the k limit, but overlays can grow the visible set beyond
            max_tools.  Cap the post-overlay set to stay inside small-model

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -124,6 +124,7 @@ val run_turn :
   -> cascade_name:string
   -> ?provider_filter:string list
   -> generation:int
+  -> ?actionable_signal:bool
   -> ?max_turns:int
   -> ?max_idle_turns:int
   -> ?history_user_source:string

--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -9,6 +9,9 @@ val keeper_allowed_model_tools :
     scope so progressive disclosure can surface tools beyond the preset. *)
 val keeper_universe_tool_names : keeper_meta -> string list
 
+(** Keeper-facing runtime candidate names before policy filtering. *)
+val keeper_internal_candidate_tool_names : string list
+
 (** Universe model tool schemas.  Returns schemas for all universe tools
     so [make_tools] can build Agent_sdk.Tool.t for the full search scope. *)
 val keeper_universe_model_tools : keeper_meta -> Types.tool_schema list
@@ -53,8 +56,16 @@ val keeper_tool_search_schema : Types.tool_schema
 (** Injected masc_* tool schemas (populated at startup by [inject_masc_schemas]). *)
 val masc_schemas_ref : Types.tool_schema list ref
 
+(** Injected masc_* tool names (populated at startup by [inject_masc_schemas]). *)
+val injected_masc_tool_names : unit -> string list
+
 (** [is_core_always_tool name] — true if [name] bypasses policy restrictions. *)
 val is_core_always_tool : string -> bool
+
+(** Drop boring observation tools when a turn already has actionable work.
+    Returns the original set when every tool is boring so callers do not end
+    up with an empty allowlist. *)
+val prune_boring_tools_for_actionable_turn : string list -> string list
 
 (** Deduplicate tool names, preserving order. *)
 val dedupe_tool_names : string list -> string list

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -23,6 +23,14 @@ let apply_default opt current = match opt with Some v -> v | None -> current
 (** Same as [apply_default] but both TOML and meta are option-typed. *)
 let apply_default_opt opt current = match opt with Some _ -> opt | None -> current
 
+let effective_declarative_cascade_name
+    (defaults : Keeper_types_profile.keeper_profile_defaults)
+    (meta : keeper_meta) =
+  match defaults.cascade_name, defaults.manifest_path with
+  | Some cascade_name, _ -> cascade_name
+  | None, Some _ -> Keeper_config.default_cascade_name
+  | None, None -> meta.cascade_name
+
 let resynced_tool_access
     (defaults : Keeper_types_profile.keeper_profile_defaults)
     (meta : keeper_meta) =
@@ -69,7 +77,9 @@ let ensure_keeper_meta config name =
             defaults.room_signal_prompt_enabled
     in
     let target_denylist = apply_default defaults.tool_denylist meta.tool_denylist in
-    let target_cascade_name = apply_default defaults.cascade_name meta.cascade_name in
+    let target_cascade_name =
+      effective_declarative_cascade_name defaults meta
+    in
     let target_tool_access = resynced_tool_access defaults meta in
 
     (* --- Personality --- *)

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -45,8 +45,19 @@ let coordination_surface_json (meta : keeper_meta) =
       ("joined_room_ids", string_list_to_json meta.joined_room_ids);
     ]
 
+let effective_declarative_cascade_name
+    (defaults : keeper_profile_defaults)
+    (meta : keeper_meta) =
+  match defaults.cascade_name, defaults.manifest_path with
+  | Some cascade_name, _ -> cascade_name
+  | None, Some _ -> Keeper_config.default_cascade_name
+  | None, None -> meta.cascade_name
+
 let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_defaults) :
     string list =
+  let effective_cascade_name =
+    effective_declarative_cascade_name defaults meta
+  in
   let add_if label cond acc = if cond then label :: acc else acc in
   []
   |> add_if "prompt.goal"
@@ -100,6 +111,8 @@ let live_override_fields (meta : keeper_meta) (defaults : keeper_profile_default
        (match defaults.tool_denylist with
         | Some authored -> authored <> meta.tool_denylist
         | None -> false)
+  |> add_if "model.cascade_name"
+       (effective_cascade_name <> meta.cascade_name)
   |> add_if "proactive.enabled"
        (match defaults.proactive_enabled with
         | Some value -> value <> meta.proactive.enabled

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -134,7 +134,7 @@ let is_keeper_mcp_context_required name =
   List.mem name keeper_mcp_context_required_tools
   || Tool_dispatch.is_mcp_context_required name
 
-let inject_masc_schemas (schemas : Types.tool_schema list) =
+let keeper_supported_masc_schemas (schemas : Types.tool_schema list) =
   let supported_in_keeper name =
     if Tool_dispatch.is_registered name then
       true
@@ -160,14 +160,21 @@ let inject_masc_schemas (schemas : Types.tool_schema list) =
     | "masc_board_vote" | "masc_board_delete" -> true
     | _ -> false
   in
-  masc_schemas_ref :=
-    List.filter (fun (s : Types.tool_schema) ->
+  List.filter (fun (s : Types.tool_schema) ->
       String.starts_with ~prefix:"masc_" s.name
       && not (is_keeper_mcp_context_required s.name)
       && supported_in_keeper s.name
       && not (is_keeper_denied s.name)
       && not (has_keeper_board_wrapper s.name))
       schemas
+
+let keeper_supported_masc_tool_names_from_schemas schemas =
+  keeper_supported_masc_schemas schemas
+  |> List.map (fun (schema : Types.tool_schema) -> schema.name)
+  |> dedupe_tool_names
+
+let inject_masc_schemas (schemas : Types.tool_schema list) =
+  masc_schemas_ref := keeper_supported_masc_schemas schemas
 
 let select_existing_masc_tool_names names =
   let injected = injected_masc_tool_names () in

--- a/lib/keeper/keeper_tool_policy.mli
+++ b/lib/keeper/keeper_tool_policy.mli
@@ -51,6 +51,14 @@ val pr_create_timeout_sec : unit -> float
     Call once after MASC schemas are registered. *)
 val inject_masc_schemas : Types.tool_schema list -> unit
 
+(** Filter raw schemas down to the masc_* subset a keeper can actually see. *)
+val keeper_supported_masc_schemas :
+  Types.tool_schema list -> Types.tool_schema list
+
+(** Return names from [keeper_supported_masc_schemas]. *)
+val keeper_supported_masc_tool_names_from_schemas :
+  Types.tool_schema list -> string list
+
 (** Filter names to only those present in the injected MASC set. *)
 val select_existing_masc_tool_names : string list -> string list
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -171,6 +171,13 @@ let boring_tools_set : (string, unit) Hashtbl.t =
 let is_boring_tool (name : string) : bool =
   Hashtbl.mem boring_tools_set name
 
+let prune_boring_tools_for_actionable_turn (tool_names : string list) :
+    string list =
+  let actionable =
+    List.filter (fun name -> not (is_boring_tool name)) tool_names
+  in
+  if actionable = [] then tool_names else actionable
+
 (* ── Dynamic schema injection (masc_* tools) ──────────────────── *)
 
 let masc_schemas_ref : Types.tool_schema list ref = ref []

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1130,7 +1130,10 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:meta.cascade_name
-              ~generation:run_generation ~max_idle_turns
+              ~generation:run_generation
+              ~actionable_signal:
+                (Keeper_world_observation.actionable_signal_present observation)
+              ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -694,6 +694,14 @@ let observe ~(pending_board_events : pending_board_event list option)
     behavioral_stats;
   }
 
+let actionable_signal_present (observation : world_observation) =
+  observation.pending_mentions <> []
+  || observation.pending_board_events <> []
+  || observation.pending_scope_messages <> []
+  || observation.unclaimed_task_count > 0
+  || observation.failed_task_count > 0
+  || observation.work_discovery_due
+
 (** Compute effective scheduled autonomous cooldown with idle decay.
     After extended idle (> base cooldown), halve the cooldown each
     additional period, down to a configurable floor.  This prevents

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -192,6 +192,8 @@ val observe :
   meta:Keeper_types.keeper_meta ->
   world_observation
 
+val actionable_signal_present : world_observation -> bool
+
 val apply_message_cursor_updates :
   Keeper_types.keeper_meta ->
   (string * int) list ->

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -53,28 +53,33 @@ let should_orchestrate room_config =
     Log.Orchestrator.debug "room is paused, skipping";
     false
   end else begin
-  (* Get unclaimed tasks with priority <= min_priority *)
-  let tasks = Room.get_tasks_raw room_config in
-  let unclaimed_important = List.filter (fun (task: Types.task) ->
-    task.task_status = Types.Todo && task.priority <= 2
-  ) tasks in
+  match Room.read_backlog_r room_config with
+  | Error msg ->
+      Log.Orchestrator.error
+        "backlog unavailable, skipping orchestration check: %s" msg;
+      false
+  | Ok backlog ->
+      (* Get unclaimed tasks with priority <= min_priority *)
+      let unclaimed_important = List.filter (fun (task: Types.task) ->
+        task.task_status = Types.Todo && task.priority <= 2
+      ) backlog.tasks in
 
-  (* Get active (non-zombie) agents *)
-  let agents = Room.get_agents_raw room_config in
-  let active_agents = List.filter (fun (agent: Types.agent) ->
-    not (Resilience.Zombie.is_zombie agent.last_seen)
-  ) agents in
+      (* Get active (non-zombie) agents *)
+      let agents = Room.get_agents_raw room_config in
+      let active_agents = List.filter (fun (agent: Types.agent) ->
+        not (Resilience.Zombie.is_zombie agent.last_seen)
+      ) agents in
 
-  (* Need orchestration if: important tasks exist AND no active agents *)
-  let needs_orchestration =
-    List.length unclaimed_important > 0 && List.length active_agents = 0
-  in
+      (* Need orchestration if: important tasks exist AND no active agents *)
+      let needs_orchestration =
+        List.length unclaimed_important > 0 && List.length active_agents = 0
+      in
 
-  if needs_orchestration then
-    Log.Orchestrator.info "%d unclaimed tasks, %d active agents, spawning"
-      (List.length unclaimed_important) (List.length active_agents);
+      if needs_orchestration then
+        Log.Orchestrator.info "%d unclaimed tasks, %d active agents, spawning"
+          (List.length unclaimed_important) (List.length active_agents);
 
-  needs_orchestration
+      needs_orchestration
   end  (* end of else begin for pause check *)
 
 (** The orchestrator prompt - MCP tools are now available via --allowedTools! *)

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -175,11 +175,25 @@ let pause_info config =
 (* ============================================ *)
 
 (** Read backlog *)
+let read_backlog_r config =
+  match read_json_result config (backlog_path config) with
+  | Error msg -> Error msg
+  | Ok json ->
+      (match backlog_of_yojson json with
+       | Ok backlog -> Ok backlog
+       | Error msg ->
+           Error
+             (Printf.sprintf
+                "[read_backlog] backlog decode failed for %s: %s"
+                (backlog_path config)
+                msg))
+
 let read_backlog config =
-  let json = read_json config (backlog_path config) in
-  match backlog_of_yojson json with
+  match read_backlog_r config with
   | Ok backlog -> backlog
-  | Error _ -> { tasks = []; last_updated = now_iso (); version = 1 }
+  | Error msg ->
+      Log.Misc.error "%s" msg;
+      { tasks = []; last_updated = now_iso (); version = 1 }
 
 (** Write backlog *)
 let write_backlog config backlog =

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -174,56 +174,61 @@ let find_duplicate_task (backlog : backlog) (title : string) : string option =
 let add_task ?contract ?required_preset config ~title ~priority ~description =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-  with_file_lock config backlog_path (fun () ->
-    let backlog = read_backlog_or_raise config in
-    (* Dedup guard: reject if an active task with the same normalized title exists *)
-    (match find_duplicate_task backlog title with
-    | Some existing_id ->
-      Printf.sprintf "⚠️ Duplicate rejected: '%s' matches existing %s. Use that task instead."
-        title existing_id
-    | None ->
-    let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
-    let contract = Option.map normalize_task_contract contract in
+  try
+    with_file_lock config backlog_path (fun () ->
+      let backlog = read_backlog_or_raise config in
+      (* Dedup guard: reject if an active task with the same normalized title exists *)
+      (match find_duplicate_task backlog title with
+      | Some existing_id ->
+        Printf.sprintf "⚠️ Duplicate rejected: '%s' matches existing %s. Use that task instead."
+          title existing_id
+      | None ->
+      let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
+      let contract = Option.map normalize_task_contract contract in
 
-    let new_task = {
-      id = task_id;
-      title;
-      description;
-      task_status = Todo;
-      priority;
-      files = [];
-      created_at = now_iso ();
-      worktree = None;
-      required_role = Types_core.Unassigned;
-      required_preset;
-      stage = None;
-      contract;
-      handoff_context = None;
-    } in
+      let new_task = {
+        id = task_id;
+        title;
+        description;
+        task_status = Todo;
+        priority;
+        files = [];
+        created_at = now_iso ();
+        worktree = None;
+        required_role = Types_core.Unassigned;
+        required_preset;
+        stage = None;
+        contract;
+        handoff_context = None;
+      } in
 
-    let new_backlog = {
-      tasks = backlog.tasks @ [new_task];
-      last_updated = now_iso ();
-      version = backlog.version + 1;
-    } in
-    write_backlog config new_backlog;
-    emit_task_activity config ~agent_name:"system" ~task_id ~kind:"task.created"
-      ~payload:
-        (`Assoc
-          [
-            ("task_id", `String task_id);
-            ("title", `String title);
-            ("priority", `Int priority);
-            ( "strict_contract",
-              `Bool
-                (match contract with
-                | Some contract -> contract.strict
-                | None -> false) );
-          ]);
+      let new_backlog = {
+        tasks = backlog.tasks @ [new_task];
+        last_updated = now_iso ();
+        version = backlog.version + 1;
+      } in
+      write_backlog config new_backlog;
+      emit_task_activity config ~agent_name:"system" ~task_id ~kind:"task.created"
+        ~payload:
+          (`Assoc
+            [
+              ("task_id", `String task_id);
+              ("title", `String title);
+              ("priority", `Int priority);
+              ( "strict_contract",
+                `Bool
+                  (match contract with
+                  | Some contract -> contract.strict
+                  | None -> false) );
+            ]);
 
-    !Room_hooks.on_task_mutation_fn ();
-    let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title) in
-    Printf.sprintf "✅ Added %s: %s" task_id title))
+      !Room_hooks.on_task_mutation_fn ();
+      let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title) in
+      Printf.sprintf "✅ Added %s: %s" task_id title))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
+      Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
 
 (** Add task with a required role constraint — file-locked.
     Same dedup guard as [add_task]. *)
@@ -231,58 +236,63 @@ let add_task_with_role ?contract config ~title ~priority ~description
     ~required_role =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-  with_file_lock config backlog_path (fun () ->
-    let backlog = read_backlog_or_raise config in
-    (match find_duplicate_task backlog title with
-    | Some existing_id ->
-      Printf.sprintf "⚠️ Duplicate rejected: '%s' matches existing %s. Use that task instead."
-        title existing_id
-    | None ->
-    let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
-    let contract = Option.map normalize_task_contract contract in
+  try
+    with_file_lock config backlog_path (fun () ->
+      let backlog = read_backlog_or_raise config in
+      (match find_duplicate_task backlog title with
+      | Some existing_id ->
+        Printf.sprintf "⚠️ Duplicate rejected: '%s' matches existing %s. Use that task instead."
+          title existing_id
+      | None ->
+      let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
+      let contract = Option.map normalize_task_contract contract in
 
-    let new_task = {
-      id = task_id;
-      title;
-      description;
-      task_status = Todo;
-      priority;
-      files = [];
-      created_at = now_iso ();
-      worktree = None;
-      required_role;
-      required_preset = None;
-      stage = None;
-      contract;
-      handoff_context = None;
-    } in
+      let new_task = {
+        id = task_id;
+        title;
+        description;
+        task_status = Todo;
+        priority;
+        files = [];
+        created_at = now_iso ();
+        worktree = None;
+        required_role;
+        required_preset = None;
+        stage = None;
+        contract;
+        handoff_context = None;
+      } in
 
-    let new_backlog = {
-      tasks = backlog.tasks @ [new_task];
-      last_updated = now_iso ();
-      version = backlog.version + 1;
-    } in
-    write_backlog config new_backlog;
-    emit_task_activity config ~agent_name:"system" ~task_id ~kind:"task.created"
-      ~payload:
-        (`Assoc
-          [
-            ("task_id", `String task_id);
-            ("title", `String title);
-            ("priority", `Int priority);
-            ( "required_role",
-              `String (Types_core.role_to_string required_role) );
-            ( "strict_contract",
-              `Bool
-                (match contract with
-                | Some contract -> contract.strict
-                | None -> false) );
-          ]);
+      let new_backlog = {
+        tasks = backlog.tasks @ [new_task];
+        last_updated = now_iso ();
+        version = backlog.version + 1;
+      } in
+      write_backlog config new_backlog;
+      emit_task_activity config ~agent_name:"system" ~task_id ~kind:"task.created"
+        ~payload:
+          (`Assoc
+            [
+              ("task_id", `String task_id);
+              ("title", `String title);
+              ("priority", `Int priority);
+              ( "required_role",
+                `String (Types_core.role_to_string required_role) );
+              ( "strict_contract",
+                `Bool
+                  (match contract with
+                  | Some contract -> contract.strict
+                  | None -> false) );
+            ]);
 
-    let role_str = Types_core.role_to_string required_role in
-    let _ = broadcast config ~from_agent:"system"
-      ~content:(Printf.sprintf "📋 New quest: %s (requires: %s)" title role_str) in
-    Printf.sprintf "✅ Added %s: %s (required_role: %s)" task_id title role_str))
+      let role_str = Types_core.role_to_string required_role in
+      let _ = broadcast config ~from_agent:"system"
+        ~content:(Printf.sprintf "📋 New quest: %s (requires: %s)" title role_str) in
+      Printf.sprintf "✅ Added %s: %s (required_role: %s)" task_id title role_str))
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
+      Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
 
 (** Add multiple tasks in a batch *)
 let batch_add_tasks_internal config tasks =

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -21,6 +21,11 @@ let trim_opt = function
       if trimmed = "" then None else Some trimmed
   | None -> None
 
+let read_backlog_or_raise config =
+  match read_backlog_r config with
+  | Ok backlog -> backlog
+  | Error msg -> raise (Invalid_argument msg)
+
 (** Tighter variant of [resolve_agent_name] for task ownership guards.
     Only accepts the resolved identity when it is the exact [-agent] suffix
     form of the normalised input (e.g. "keeper-coder" -> "keeper-coder-agent").
@@ -170,7 +175,7 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
-    let backlog = read_backlog config in
+    let backlog = read_backlog_or_raise config in
     (* Dedup guard: reject if an active task with the same normalized title exists *)
     (match find_duplicate_task backlog title with
     | Some existing_id ->
@@ -227,7 +232,7 @@ let add_task_with_role ?contract config ~title ~priority ~description
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
-    let backlog = read_backlog config in
+    let backlog = read_backlog_or_raise config in
     (match find_duplicate_task backlog title with
     | Some existing_id ->
       Printf.sprintf "⚠️ Duplicate rejected: '%s' matches existing %s. Use that task instead."
@@ -285,7 +290,7 @@ let batch_add_tasks_internal config tasks =
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     try
-      let backlog = read_backlog config in
+      let backlog = read_backlog_or_raise config in
       let next_num = ref (next_task_number config backlog) in
       let added_tasks = List.map (fun (title, priority, description, contract) ->
         let task_id = Printf.sprintf "task-%03d" !next_num in
@@ -363,7 +368,7 @@ let claim_task config ~agent_name ~task_id =
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     try
-      let backlog = read_backlog config in
+      let backlog = read_backlog_or_raise config in
       let found = ref false in
       let already_claimed = ref None in
       let new_tasks = List.map (fun task ->
@@ -451,7 +456,7 @@ let claim_task_r config ~agent_name ~task_id
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     try
-      let backlog = read_backlog config in
+      let backlog = read_backlog_or_raise config in
       (* Check role constraint before attempting claim *)
       let target_task = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
       let* task =
@@ -562,7 +567,7 @@ let transition_task_r config ~agent_name ~task_id ~action
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     try
-      let backlog = read_backlog config in
+      let backlog = read_backlog_or_raise config in
       let* () =
         match expected_version with
         | Some v when backlog.version <> v ->
@@ -811,7 +816,7 @@ let complete_task config ~agent_name ~task_id ~notes =
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     try
-      let backlog = read_backlog config in
+      let backlog = read_backlog_or_raise config in
       let task_opt = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
       match task_opt with
       | None ->
@@ -916,7 +921,7 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
     with_file_lock config backlog_path (fun () ->
       try
-        let backlog = read_backlog config in
+        let backlog = read_backlog_or_raise config in
         let task_opt = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
         match task_opt with
         | None -> Error (Types.TaskNotFound task_id)
@@ -1012,7 +1017,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
     with_file_lock config backlog_path (fun () ->
       try
-        let backlog = read_backlog config in
+        let backlog = read_backlog_or_raise config in
         let task_opt = List.find_opt (fun t -> t.id = task_id) backlog.tasks in
         match task_opt with
         | None -> Error (Types.TaskNotFound task_id)
@@ -1119,7 +1124,7 @@ let link_task_execution_artifacts_r config ~task_id ?session_id ?operation_id
     let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
     with_file_lock config backlog_path (fun () ->
         try
-          let backlog = read_backlog config in
+          let backlog = read_backlog_or_raise config in
           match List.find_opt (fun task -> task.id = task_id) backlog.tasks with
           | None -> Error (Types.TaskNotFound task_id)
           | Some task ->

--- a/lib/room/room_task_schedule.ml
+++ b/lib/room/room_task_schedule.ml
@@ -20,7 +20,11 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   with_file_lock config backlog_path (fun () ->
     try
-      let backlog = read_backlog config in
+      let backlog =
+        match read_backlog_r config with
+        | Ok backlog -> backlog
+        | Error msg -> raise (Invalid_argument msg)
+      in
 
       (* BUG-004: Detect and auto-release previous claim to prevent orphaned tasks.
          If this agent already holds a Claimed or InProgress task, release it
@@ -244,36 +248,47 @@ let claim_next config ~agent_name =
 let release_stale_claims config ~ttl_seconds =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
-  with_file_lock config backlog_path (fun () ->
-    let backlog = read_backlog config in
-    let now_str = now_iso () in
-    let now_f = Time_compat.now () in
-    let stale_tasks = ref [] in
-    let updated_tasks = List.map (fun (task : task) ->
-      match task.task_status with
-      | Claimed { assignee; claimed_at } ->
-          let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) claimed_at in
-          if now_f -. ts > ttl_seconds then begin
-            stale_tasks := (task.id, assignee) :: !stale_tasks;
-            log_event config (Printf.sprintf
-              "{\"type\":\"stale_claim_released\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"age_s\":%.0f,\"ts\":\"%s\"}"
-              task.id assignee (now_f -. ts) now_str);
-            { task with task_status = Todo }
-          end else task
-      | InProgress { assignee; started_at } ->
-          let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) started_at in
-          if now_f -. ts > ttl_seconds then begin
-            stale_tasks := (task.id, assignee) :: !stale_tasks;
-            log_event config (Printf.sprintf
-              "{\"type\":\"stale_inprogress_released\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"age_s\":%.0f,\"ts\":\"%s\"}"
-              task.id assignee (now_f -. ts) now_str);
-            { task with task_status = Todo }
-          end else task
-      | Todo | Done _ | Cancelled _ -> task
-    ) backlog.tasks in
-    if !stale_tasks <> [] then begin
-      let updated_backlog = { tasks = updated_tasks; last_updated = now_str; version = backlog.version + 1 } in
-      write_backlog config updated_backlog
-    end;
-    List.rev !stale_tasks
-  )
+  try
+    with_file_lock config backlog_path (fun () ->
+      let backlog =
+        match read_backlog_r config with
+        | Ok backlog -> backlog
+        | Error msg ->
+            Log.Orchestrator.error
+              "[stale-claims] skipping backlog mutation due to read failure: %s"
+              msg;
+            raise Exit
+      in
+      let now_str = now_iso () in
+      let now_f = Time_compat.now () in
+      let stale_tasks = ref [] in
+      let updated_tasks = List.map (fun (task : task) ->
+        match task.task_status with
+        | Claimed { assignee; claimed_at } ->
+            let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) claimed_at in
+            if now_f -. ts > ttl_seconds then begin
+              stale_tasks := (task.id, assignee) :: !stale_tasks;
+              log_event config (Printf.sprintf
+                "{\"type\":\"stale_claim_released\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"age_s\":%.0f,\"ts\":\"%s\"}"
+                task.id assignee (now_f -. ts) now_str);
+              { task with task_status = Todo }
+            end else task
+        | InProgress { assignee; started_at } ->
+            let ts = parse_iso8601 ~default_time:(now_f -. ttl_seconds -. 1.0) started_at in
+            if now_f -. ts > ttl_seconds then begin
+              stale_tasks := (task.id, assignee) :: !stale_tasks;
+              log_event config (Printf.sprintf
+                "{\"type\":\"stale_inprogress_released\",\"task_id\":\"%s\",\"assignee\":\"%s\",\"age_s\":%.0f,\"ts\":\"%s\"}"
+                task.id assignee (now_f -. ts) now_str);
+              { task with task_status = Todo }
+            end else task
+        | Todo | Done _ | Cancelled _ -> task
+      ) backlog.tasks in
+      if !stale_tasks <> [] then begin
+        let updated_backlog = { tasks = updated_tasks; last_updated = now_str; version = backlog.version + 1 } in
+        write_backlog config updated_backlog
+      end;
+      List.rev !stale_tasks
+    )
+  with
+  | Exit -> []

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -163,8 +163,15 @@ let is_ancestor_path ~ancestor ~descendant =
   let a = if String.ends_with ~suffix:"/" a then a else a ^ "/" in
   String.starts_with ~prefix:a d
 
+let explicit_base_path_is_authoritative explicit_path =
+  let trimmed = String.trim explicit_path in
+  trimmed <> ""
+  && not (Filename.is_relative trimmed)
+  && not (running_under_test_executable ())
+
 let should_ignore_inherited_base_path ~requested_path ~explicit_path =
   not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
+  && not (explicit_base_path_is_authoritative explicit_path)
   && String.trim requested_path <> ""
   && not (String.equal requested_path ".")
   &&
@@ -189,6 +196,7 @@ let should_ignore_inherited_test_base_path ~requested_path ~explicit_path =
 
 let should_ignore_inherited_server_base_path ~requested_path ~explicit_path =
   not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
+  && not (explicit_base_path_is_authoritative explicit_path)
   && String.trim requested_path <> ""
   && not (String.equal requested_path ".")
   &&

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -120,12 +120,15 @@ let read_json_local path =
     Log.Misc.warn "[read_json_local] %s" msg;
     `Assoc []
 
+let read_json_local_result path =
+  Safe_ops.read_json_file_safe path
+
 let write_json_local path json =
   mkdir_p (Filename.dirname path);
   let content = Yojson.Safe.pretty_to_string json in
-  let tmp_path = path ^ ".tmp" in
-  Fs_compat.save_file tmp_path content;
-  Unix.rename tmp_path path
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> invalid_arg msg
 
 (* Root-scoped JSON helpers for shared room registry/current_room metadata. *)
 let read_json_root config path =
@@ -202,6 +205,30 @@ let read_json config path =
         `Assoc []
     end
   | None -> read_json_local path
+
+let read_json_result config path =
+  let parse_backend_json ~context content =
+    let trimmed = String.trim content in
+    if trimmed = "" then Ok (`Assoc [])
+    else Safe_ops.parse_json_safe ~context trimmed
+  in
+  match key_of_path config path with
+  | Some key -> begin
+      match config.backend with
+      | FileSystem _ when Sys.file_exists path -> read_json_local_result path
+      | Memory _ | FileSystem _ | PostgresNative _ ->
+      match backend_get config ~key with
+      | Ok (Some content) ->
+          parse_backend_json ~context:"read_json_result" content
+      | Ok None -> Ok (`Assoc [])
+      | Error e ->
+          Error
+            (Printf.sprintf
+               "[read_json_result] backend_get failed for %s: %s"
+               key
+               (Backend_types.show_error e))
+    end
+  | None -> read_json_local_result path
 
 let read_text config path =
   match key_of_path config path with

--- a/lib/room/room_utils_ops.ml
+++ b/lib/room/room_utils_ops.ml
@@ -128,7 +128,7 @@ let write_json_local path json =
   let content = Yojson.Safe.pretty_to_string json in
   match Fs_compat.save_file_atomic path content with
   | Ok () -> ()
-  | Error msg -> invalid_arg msg
+  | Error msg -> raise (Sys_error msg)
 
 (* Root-scoped JSON helpers for shared room registry/current_room metadata. *)
 let read_json_root config path =

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -7,6 +7,7 @@ type t = {
   effective_base_path : string;
   effective_masc_root : string;
   env_masc_base_path : string option;
+  resolution_source : string option;
   cwd_masc_root : string;
   cwd_has_masc_dir : bool;
   effective_has_masc_dir : bool;
@@ -50,7 +51,16 @@ let fail_fast_env_enabled () =
       | _ -> false)
   | None -> false
 
-let detect ?cwd ?env_masc_base_path ?strict ?input_base_path
+let resolution_source_opt ?resolution_source () =
+  match resolution_source with
+  | Some raw -> trim_opt (Some raw)
+  | None -> trim_opt (Sys.getenv_opt "MASC_BASE_PATH_RESOLUTION_SOURCE")
+
+let explicit_resolution_source = function
+  | Some ("explicit_env" | "explicit_cli") -> true
+  | _ -> false
+
+let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     ~effective_base_path ~effective_masc_root () =
   let cwd =
     match cwd with
@@ -75,12 +85,19 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path
     | Some enabled -> enabled
     | None -> fail_fast_env_enabled ()
   in
+  let resolution_source = resolution_source_opt ?resolution_source () in
   let warning =
     if dual_masc_roots then
-      Some
-        (Printf.sprintf
-           "process cwd (%s) differs from effective base path (%s) and both .masc roots exist (%s vs %s); operator surfaces may inspect stale state"
-           cwd_norm effective_base_norm cwd_masc_root effective_masc_norm)
+      if explicit_resolution_source resolution_source then
+        Some
+          (Printf.sprintf
+             "process cwd (%s) differs from explicit effective base path (%s) and both .masc roots exist (%s vs %s); runtime will use the explicit base path, but operator surfaces may inspect stale state from cwd"
+             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm)
+      else
+        Some
+          (Printf.sprintf
+             "process cwd (%s) differs from effective base path (%s) and both .masc roots exist (%s vs %s); operator surfaces may inspect stale state"
+             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm)
     else
       None
   in
@@ -90,6 +107,7 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path
     effective_base_path = effective_base_norm;
     effective_masc_root = effective_masc_norm;
     env_masc_base_path = trim_opt env_masc_base_path;
+    resolution_source;
     cwd_masc_root;
     cwd_has_masc_dir;
     effective_has_masc_dir;
@@ -100,7 +118,9 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path
   }
 
 let strict_violation (diag : t) =
-  diag.fail_fast_enabled && diag.dual_masc_roots
+  diag.fail_fast_enabled
+  && diag.dual_masc_roots
+  && not (explicit_resolution_source diag.resolution_source)
 
 let startup_lines (diag : t) =
   let lines =
@@ -112,6 +132,9 @@ let startup_lines (diag : t) =
        | _ -> None);
       (match diag.env_masc_base_path with
        | Some path -> Some (Printf.sprintf "   MASC_BASE_PATH(env): %s" path)
+       | None -> None);
+      (match diag.resolution_source with
+       | Some source -> Some (Printf.sprintf "   Base path source: %s" source)
        | None -> None);
       (match diag.warning with
        | Some message -> Some (Printf.sprintf "   Path warning: %s" message)
@@ -159,5 +182,6 @@ let to_yojson (diag : t) =
         [
           option_field "input_base_path" diag.input_base_path;
           option_field "env_masc_base_path" diag.env_masc_base_path;
+          option_field "resolution_source" diag.resolution_source;
           option_field "warning" diag.warning;
         ])

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -14,13 +14,10 @@ let add_names names tbl =
   tbl
 
 let runtime_keeper_tool_names () =
-  let schema_names =
-    Config.raw_all_tool_schemas
-    |> List.map (fun (schema : Types.tool_schema) -> schema.name)
-  in
   Hashtbl.create 512
-  |> add_names schema_names
-  |> add_names Keeper_exec_tools.core_always_tools
+  |> add_names Keeper_exec_tools.keeper_internal_candidate_tool_names
+  |> add_names (Keeper_exec_tools.effective_core_tools ())
+  |> add_names (Keeper_exec_tools.injected_masc_tool_names ())
 
 let validate () : validation_result =
   match Keeper_tool_policy.policy_config_for_validation () with

--- a/lib/tool_registration_check.ml
+++ b/lib/tool_registration_check.ml
@@ -17,7 +17,9 @@ let runtime_keeper_tool_names () =
   Hashtbl.create 512
   |> add_names Keeper_exec_tools.keeper_internal_candidate_tool_names
   |> add_names (Keeper_exec_tools.effective_core_tools ())
-  |> add_names (Keeper_exec_tools.injected_masc_tool_names ())
+  |> add_names
+       (Keeper_tool_policy.keeper_supported_masc_tool_names_from_schemas
+          Config.raw_all_tool_schemas)
 
 let validate () : validation_result =
   match Keeper_tool_policy.policy_config_for_validation () with

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -74,6 +74,13 @@ is_truthy() {
     esac
 }
 
+is_absolute_path() {
+    case "${1:-}" in
+        /*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Resolve a path to its git-root equivalent (worktree-aware).
 # Used both by the ambiguity guard and the final MASC_BASE_PATH export
 # so both see the same effective base path.
@@ -451,6 +458,7 @@ done
 if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
    [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && \
    [ -n "$BASE_PATH" ] && \
+   ! is_absolute_path "$BASE_PATH" && \
    ! is_truthy "${MASC_ALLOW_INHERITED_BASE_PATH:-0}"; then
     # Use the same git-root-aware resolution that will be used for the
     # final MASC_BASE_PATH export so this guard sees the effective path.
@@ -463,6 +471,13 @@ if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
         echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH because both $SCRIPT_DIR and $RESOLVED_BASE have .masc. Use --base-path or MASC_ALLOW_INHERITED_BASE_PATH=1 to keep the inherited root." >&2
         BASE_PATH="$SCRIPT_DIR"
     fi
+fi
+
+BASE_PATH_RESOLUTION_SOURCE="implicit_repo_root"
+if [ "$BASE_PATH_EXPLICIT" = "1" ]; then
+    BASE_PATH_RESOLUTION_SOURCE="explicit_cli"
+elif [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && is_absolute_path "$BASE_PATH"; then
+    BASE_PATH_RESOLUTION_SOURCE="explicit_env"
 fi
 
 if [ "$PORT_EXPLICIT" != "1" ]; then
@@ -618,6 +633,7 @@ fi
 
 RESOLVED_BASE_PATH="$(resolve_base_path "$BASE_PATH")"
 export MASC_BASE_PATH="$RESOLVED_BASE_PATH"
+export MASC_BASE_PATH_RESOLUTION_SOURCE="$BASE_PATH_RESOLUTION_SOURCE"
 bootstrap_base_path_config "$RESOLVED_BASE_PATH"
 if [ -z "${MASC_CONFIG_DIR:-}" ]; then
     export MASC_CONFIG_DIR="$RESOLVED_BASE_PATH/.masc/config"

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -461,7 +461,8 @@ let test_room_presence_syncs_capabilities () =
         "capabilities synced from live meta"
         [ "keeper"; "preset:social" ]
         agent.capabilities
-(** Test: update_field_in_content replaces existing field *)
+
+(* Test: update_field_in_content replaces existing field *)
 let test_toml_update_existing () =
   let input = {|[keeper]
 goal = "old goal"

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -371,6 +371,49 @@ work_discovery_guidance = "TOML guidance"
       check (option string) "work_discovery_guidance"
         (Some "TOML guidance") updated.work_discovery_guidance
 
+(** Test: declarative keepers reset stale live cascade_name to the default
+    keeper cascade when the authored config omits cascade_name. *)
+let test_cascade_defaults_resync () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "cascade-default-resync-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "TOML goal"
+tool_preset = "social"
+|};
+  let config = Room.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-cascade-default-resync");
+            ("goal", `String "stale goal");
+            ("cascade_name", `String "local_only");
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check string "goal" "TOML goal" updated.Keeper_types.goal;
+      check string "cascade_name reset to keeper default"
+        Keeper_config.default_cascade_name updated.cascade_name
+
 (** Test: update_field_in_content replaces existing field *)
 let test_toml_update_existing () =
   let input = {|[keeper]
@@ -465,6 +508,10 @@ let () =
             "TOML work_discovery fields overwrite stale meta"
             `Quick
             test_discovery_resync;
+          test_case
+            "declarative keepers reset stale live cascade_name to default"
+            `Quick
+            test_cascade_defaults_resync;
         ] );
       ( "toml_writer",
         [

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2729,6 +2729,20 @@ let () =
           test_case "keeper_context_status is boring" `Quick (fun () ->
             check bool "keeper_context_status"
               true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_context_status"));
+          test_case "actionable turns prune boring tools when alternatives exist" `Quick (fun () ->
+            let pruned =
+              Masc_mcp.Keeper_tool_registry.prune_boring_tools_for_actionable_turn
+                [ "masc_status"; "keeper_tasks_list"; "keeper_board_post" ]
+            in
+            check (list string) "boring tools removed"
+              [ "keeper_board_post" ] pruned);
+          test_case "actionable turns keep boring tools when nothing else exists" `Quick (fun () ->
+            let pruned =
+              Masc_mcp.Keeper_tool_registry.prune_boring_tools_for_actionable_turn
+                [ "masc_status"; "keeper_tasks_list" ]
+            in
+            check (list string) "boring-only set preserved"
+              [ "masc_status"; "keeper_tasks_list" ] pruned);
           test_case "keeper_fs_read is NOT boring" `Quick (fun () ->
             check bool "keeper_fs_read"
               false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_fs_read"));

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -613,6 +613,25 @@ let test_room_bootstrap_ignores_invalid_room_id_in_flat_mode () =
       (Room.is_initialized config)
   )
 
+let test_read_backlog_r_reports_parse_error () =
+  with_test_env (fun config ->
+    Out_channel.with_open_text (Room.backlog_path config) (fun oc ->
+      output_string oc "{\n  \"tasks\": [\n");
+    match Room.read_backlog_r config with
+    | Ok _ -> Alcotest.fail "expected backlog parse error"
+    | Error msg ->
+        Alcotest.(check bool) "mentions backlog decode/read failure" true
+          (str_contains msg "read_backlog" || str_contains msg "JSON parse error")
+  )
+
+let test_release_stale_claims_skips_invalid_backlog () =
+  with_test_env (fun config ->
+    Out_channel.with_open_text (Room.backlog_path config) (fun oc ->
+      output_string oc "{\n  \"tasks\": [\n");
+    let released = Room.release_stale_claims config ~ttl_seconds:60.0 in
+    Alcotest.(check (list (pair string string))) "no stale claims released" [] released
+  )
+
 
 let test_heartbeat_nonexistent_agent () =
   with_test_env (fun config ->
@@ -1653,6 +1672,10 @@ let () =
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "backend bootstrap preserves room state" `Quick test_room_bootstrap_preserves_backend_state;
       Alcotest.test_case "bootstrap ignores invalid room id in flat mode" `Quick test_room_bootstrap_ignores_invalid_room_id_in_flat_mode;
+      Alcotest.test_case "read_backlog_r reports parse error" `Quick
+        test_read_backlog_r_reports_parse_error;
+      Alcotest.test_case "release stale claims skips invalid backlog" `Quick
+        test_release_stale_claims_skips_invalid_backlog;
       Alcotest.test_case "cleanup zombies empty" `Quick test_cleanup_zombies_empty;
       Alcotest.test_case "cleanup detects regular zombie" `Quick test_cleanup_zombies_detects_regular;
       Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -87,6 +87,28 @@ let test_strict_violation_respects_env () =
   Alcotest.(check bool) "strict violation" true
     (Server_base_path_diagnostics.strict_violation diag)
 
+let test_explicit_resolution_source_bypasses_strict_violation () =
+  with_temp_dir "base-path-explicit" @@ fun root ->
+  let cwd = Filename.concat root "repo" in
+  let effective = Filename.concat root "workspace" in
+  Unix.mkdir cwd 0o755;
+  Unix.mkdir effective 0o755;
+  Unix.mkdir (Filename.concat cwd ".masc") 0o755;
+  Unix.mkdir (Filename.concat effective ".masc") 0o755;
+  with_env "MASC_BASE_PATH_STRICT" (Some "true") @@ fun () ->
+  let diag =
+    Server_base_path_diagnostics.detect ~cwd
+      ~resolution_source:"explicit_env"
+      ~input_base_path:effective
+      ~env_masc_base_path:effective
+      ~effective_base_path:effective
+      ~effective_masc_root:(Filename.concat effective ".masc")
+      ()
+  in
+  Alcotest.(check bool) "strict enabled" true diag.fail_fast_enabled;
+  Alcotest.(check bool) "explicit source skips strict violation" false
+    (Server_base_path_diagnostics.strict_violation diag)
+
 let test_to_yojson_exposes_effective_paths () =
   let diag =
     Server_base_path_diagnostics.detect ~cwd:"/tmp/repo"
@@ -104,6 +126,21 @@ let test_to_yojson_exposes_effective_paths () =
     (json |> member "effective_masc_root" |> to_string);
   Alcotest.(check bool) "roots diverge field" true
     (json |> member "roots_diverge" |> to_bool)
+
+let test_to_yojson_exposes_resolution_source () =
+  let diag =
+    Server_base_path_diagnostics.detect ~cwd:"/tmp/repo"
+      ~resolution_source:"explicit_cli"
+      ~input_base_path:"/tmp/workspace"
+      ~env_masc_base_path:"/tmp/workspace"
+      ~effective_base_path:"/tmp/workspace"
+      ~effective_masc_root:"/tmp/workspace/.masc"
+      ()
+  in
+  let open Yojson.Safe.Util in
+  let json = Server_base_path_diagnostics.to_yojson diag in
+  Alcotest.(check string) "resolution source" "explicit_cli"
+    (json |> member "resolution_source" |> to_string)
 
 let test_default_base_path_sanitizes_inherited_dual_roots () =
   with_temp_dir "base-path-default" @@ fun root ->
@@ -158,8 +195,14 @@ let () =
             test_detects_dual_masc_roots;
           Alcotest.test_case "strict violation respects env" `Quick
             test_strict_violation_respects_env;
+          Alcotest.test_case
+            "explicit resolution source bypasses strict violation"
+            `Quick
+            test_explicit_resolution_source_bypasses_strict_violation;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
+          Alcotest.test_case "json exposes resolution source" `Quick
+            test_to_yojson_exposes_resolution_source;
           Alcotest.test_case "default base path sanitizes inherited parent root"
             `Quick test_default_base_path_sanitizes_inherited_dual_roots;
           Alcotest.test_case "default base path honors inherited opt-in" `Quick

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -62,16 +62,39 @@ let run_shell ?(env = []) ~cwd cmd =
     if List.mem_assoc "MASC_ALLOW_PORT_REUSE" env then env
     else ("MASC_ALLOW_PORT_REUSE", "1") :: env
   in
+  let scrubbed_env =
+    [
+      "MASC_STORAGE_TYPE";
+      "MASC_POSTGRES_URL";
+      "DATABASE_URL";
+      "SUPABASE_DB_URL";
+      "SB_PG_URL";
+      "MASC_KEEPER_BOOTSTRAP_ENABLED";
+      "MASC_MCP_PORT";
+      "MASC_HOST";
+      "MASC_BASE_PATH";
+      "MASC_BASE_PATH_INPUT";
+      "MASC_BASE_PATH_RESOLUTION_SOURCE";
+      "MASC_CONFIG_DIR";
+      "MASC_PERSONAS_DIR";
+      "MASC_WS_ENABLED";
+      "MASC_WEBRTC_ENABLED";
+    ]
+    |> List.map (fun name -> Printf.sprintf "-u %s" name)
+    |> String.concat " "
+  in
   let env_prefix =
     env
     |> List.map (fun (k, v) -> Printf.sprintf "%s=%s" k (quote v))
     |> String.concat " "
   in
+  let shell_cmd =
+    match String.trim env_prefix with
+    | "" -> Printf.sprintf "env %s %s" scrubbed_env cmd
+    | _ -> Printf.sprintf "env %s %s %s" scrubbed_env env_prefix cmd
+  in
   let full =
-    if env_prefix = "" then
-      Printf.sprintf "cd %s && %s" (quote cwd) cmd
-    else
-      Printf.sprintf "cd %s && %s %s" (quote cwd) env_prefix cmd
+    Printf.sprintf "cd %s && %s" (quote cwd) shell_cmd
   in
   let out = Filename.temp_file "start-masc-out" ".txt" in
   let err = Filename.temp_file "start-masc-err" ".txt" in
@@ -253,7 +276,7 @@ let test_bootstraps_base_path_config_from_repo_when_unset () =
       check bool "repo config copied to base path config" true
         (Sys.file_exists (Filename.concat bootstrapped_config "cascade.json")))
 
-let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
+let test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
@@ -279,10 +302,10 @@ let test_inherited_base_path_with_dual_masc_roots_is_sanitized () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
-      check bool "inherited base path corrected to script root" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ dir)))
+      check bool "absolute inherited base path preserved" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ stale_root)))
 
-let test_parent_project_base_path_with_dual_masc_roots_is_sanitized () =
+let test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let parent = Filename.concat dir "parent-root" in
       let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
@@ -310,10 +333,10 @@ let test_parent_project_base_path_with_dual_masc_roots_is_sanitized () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
-      check bool "parent root inheritance corrected to repo root" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ repo)))
+      check bool "absolute parent root inheritance preserved" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ parent)))
 
-let test_zshenv_inherited_base_path_with_dual_roots_is_sanitized () =
+let test_zshenv_absolute_base_path_with_dual_roots_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let parent = Filename.concat dir "parent-root" in
       let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
@@ -342,8 +365,8 @@ let test_zshenv_inherited_base_path_with_dual_roots_is_sanitized () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
-      check bool "zshenv inherited base path corrected to repo root" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ repo)))
+      check bool "zshenv absolute base path preserved" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ parent)))
 
 let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -473,12 +496,16 @@ let () =
             test_realtime_transports_default_to_base_path_config_and_preserve_override;
           test_case "bootstraps base path config from repo when unset" `Quick
             test_bootstraps_base_path_config_from_repo_when_unset;
-          test_case "inherited base path with dual .masc roots is sanitized" `Quick
-            test_inherited_base_path_with_dual_masc_roots_is_sanitized;
-          test_case "parent project inherited base path is sanitized" `Quick
-            test_parent_project_base_path_with_dual_masc_roots_is_sanitized;
-          test_case "zshenv inherited base path is sanitized" `Quick
-            test_zshenv_inherited_base_path_with_dual_roots_is_sanitized;
+          test_case
+            "absolute inherited base path with dual .masc roots is preserved"
+            `Quick
+            test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved;
+          test_case
+            "absolute parent project inherited base path is preserved"
+            `Quick
+            test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved;
+          test_case "zshenv absolute base path is preserved" `Quick
+            test_zshenv_absolute_base_path_with_dual_roots_is_preserved;
           test_case "dual roots opt-in preserves inherited base path" `Quick
             test_dual_masc_roots_opt_in_preserves_inherited_base_path;
           test_case "worktree prefers local build over workspace build" `Quick

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -228,6 +228,24 @@ let test_docs_do_not_reintroduce_removed_mode_surface () =
             "masc_tool_disable" ])
     paths
 
+let test_tool_registration_check_does_not_depend_on_injected_masc_schemas () =
+  match Keeper_exec_tools.init_policy_config ~base_path:(repo_root ()) with
+  | Error msg ->
+      Alcotest.failf "failed to load tool policy config: %s" msg
+  | Ok () ->
+      let saved = !(Keeper_exec_tools.masc_schemas_ref) in
+      Fun.protect
+        ~finally:(fun () -> Keeper_exec_tools.masc_schemas_ref := saved)
+        (fun () ->
+          Keeper_exec_tools.masc_schemas_ref := [];
+          let validation = Tool_registration_check.validate () in
+          let masc_orphans =
+            validation.Tool_registration_check.orphan_toml
+            |> List.filter (String.starts_with ~prefix:"masc_")
+          in
+          Alcotest.(check (list string))
+            "no masc orphan_toml without injected schemas" [] masc_orphans)
+
 (* ── Test 3: No duplicate tool names in schemas ──────────────── *)
 
 let test_no_duplicate_schemas () =
@@ -330,6 +348,10 @@ let () =
             test_board_delete_tag_registered;
           Alcotest.test_case "board read-only metadata registered" `Quick
             test_board_read_only_metadata_registered;
+          Alcotest.test_case
+            "tool registration check does not depend on injected masc schemas"
+            `Quick
+            test_tool_registration_check_does_not_depend_on_injected_masc_schemas;
           Alcotest.test_case "keeper_backend_tool_name matches keeper_internal_replacement" `Quick
             test_keeper_alias_ssot_consistency;
         ] );


### PR DESCRIPTION
## Summary
- make explicit absolute `MASC_BASE_PATH` authoritative end-to-end and expose resolution source in startup/health diagnostics
- resync declarative keeper `cascade_name` to authored/default config and surface live drift in status
- prune boring status tools from actionable keeper turns, fail closed on backlog parse errors, and harden JSON writes with atomic temp files
- validate keeper tool policy against the keeper runtime tool universe to remove false-positive startup warnings

## Why
The runtime was mixing repo-local and inherited `.masc` roots, keepers could retain stale live `cascade_name` state, autonomous turns were satisfying tool-use with status polling, and transient backlog corruption could look like an empty backlog to automation.

## Impact
This should restore keeper reactivity, keep explicit base-path selection consistent across launcher/runtime diagnostics, and prevent task schedulers or stale-claim release from mutating state when backlog reads fail.

## Validation
- `dune build --root .`
- `./_build/default/test/test_server_base_path_diagnostics.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_keeper_runtime_denylist.exe`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_room.exe`
- `./_build/default/test/test_room_utils_coverage.exe`
- `./_build/default/test/test_tool_registration_consistency.exe`

## Follow-up
- live server restart and keeper recycle were not performed in this branch
- post-deploy operator recovery should restart contaminated keepers such as `cheolsu`, `janitor`, and `masc-improver`
