### PR TITLE
[codex] Expose telemetry source degradation

### DIFF
--- a/lib/activity_feed.ml
+++ b/lib/activity_feed.ml
@@ -67,13 +67,13 @@ let load_jsonl_safe ?(kind = "jsonl") (path : string) : Yojson.Safe.t list =
                    warn_parse_failure ~kind ~path ~line_no msg;
                    None)
 
-let parse_created_at_or_now ~kind ~path raw =
+let parse_created_at ~kind ~path raw =
   let raw = String.trim raw in
-  let fallback () =
-    Log.Feed.warn "%s timestamp parse fallback for %s: %S" kind path raw;
-    Time_compat.now ()
+  let invalid message =
+    Log.Feed.warn "%s timestamp invalid for %s: %s raw=%S" kind path message raw;
+    None
   in
-  if raw = "" then fallback ()
+  if raw = "" then invalid "empty timestamp"
   else
     try
       Scanf.sscanf raw "%d-%d-%dT%d:%d:%d"
@@ -86,13 +86,12 @@ let parse_created_at_or_now ~kind ~path raw =
            let local_epoch, _ = Unix.mktime tm in
            let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
            let tz_offset = local_epoch -. utc_as_local in
-           local_epoch +. tz_offset)
+           Some (local_epoch +. tz_offset))
     with
-    | Scanf.Scan_failure _ | Failure _ | End_of_file -> fallback ()
+    | Scanf.Scan_failure _ | Failure _ | End_of_file ->
+        invalid "parse failure"
     | exn ->
-        Log.Feed.warn "%s timestamp parse error for %s: %s" kind path
-          (Printexc.to_string exn);
-        fallback ()
+        invalid (Printexc.to_string exn)
 
 (** {1 Source Readers} *)
 
@@ -122,18 +121,21 @@ let task_activities (config : Room.config) : activity_item list =
           let assignee = Safe_ops.json_string ~default:"" "assignee" json in
           let title = Safe_ops.json_string ~default:"" "title" json in
           let created_at_str = Safe_ops.json_string ~default:"" "created_at" json in
-          let created_at = parse_created_at_or_now ~kind:"task activity" ~path created_at_str in
           let agent = if assignee <> "" then assignee else "system" in
           let summary = Printf.sprintf "Task %s: %s (%s)" id title status in
-          if id = "" then None
-          else Some {
-            id = "act-task-" ^ id;
-            kind = "task";
-            agent_name = agent;
-            summary;
-            detail_json = json;
-            created_at;
-          })
+          match parse_created_at ~kind:"task activity" ~path created_at_str with
+          | None -> None
+          | Some created_at ->
+              if id = "" then None
+              else
+                Some {
+                  id = "act-task-" ^ id;
+                  kind = "task";
+                  agent_name = agent;
+                  summary;
+                  detail_json = json;
+                  created_at;
+                })
 
 (** Read board post activity from `.masc/board_posts.jsonl`. *)
 let board_post_activities (config : Room.config) : activity_item list =
@@ -149,9 +151,9 @@ let board_post_activities (config : Room.config) : activity_item list =
         | Some ts -> ts
         | None ->
             Log.Feed.warn "board post missing/invalid created_at for %s" path;
-            Time_compat.now ()
+            -1.0
       in
-      if id = "" then None
+      if id = "" || created_at < 0.0 then None
       else
         let preview = if title <> "" then title
           else if String.length content > 80 then String.sub content 0 80 ^ "..."
@@ -179,9 +181,9 @@ let board_comment_activities (config : Room.config) : activity_item list =
         | Some ts -> ts
         | None ->
             Log.Feed.warn "board comment missing/invalid created_at for %s" path;
-            Time_compat.now ()
+            -1.0
       in
-      if id = "" then None
+      if id = "" || created_at < 0.0 then None
       else
         let preview =
           if String.length content > 80 then String.sub content 0 80 ^ "..."
@@ -210,9 +212,9 @@ let mention_activities (config : Room.config) : activity_item list =
         | Some ts -> ts
         | None ->
             Log.Feed.warn "mention inbox missing/invalid created_at for %s" path;
-            Time_compat.now ()
+            -1.0
       in
-      if id = "" then None
+      if id = "" || created_at < 0.0 then None
       else Some {
         id = "act-mention-" ^ id;
         kind = "mention";

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -326,9 +326,13 @@ let rec add_routes ~sw ~clock router =
            Telemetry_unified.read_unified ~base_path ~masc_root ~sources
              ?keeper_name ?session_id ?operation_id ?worker_run_id ~n ()
          in
+         let summary =
+           Telemetry_unified.summary_json ~base_path ~masc_root ()
+         in
          let json = `Assoc [
            ("generated_at", `String (Types.now_iso ()));
            ("count", `Int (List.length entries));
+           ("summary", summary);
            ("entries", `List entries);
          ] in
          Http.Response.json ~compress:true ~request:req

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -38,6 +38,42 @@ let source_of_string = function
 
 let all_sources = [Keeper_metric; Agent_event; Tool_call_io; Tool_usage; Tool_metric]
 
+type source_status =
+  | Source_ok
+  | Source_missing
+  | Source_degraded of string
+
+let source_status_to_string = function
+  | Source_ok -> "ok"
+  | Source_missing -> "missing"
+  | Source_degraded _ -> "degraded"
+
+let dir_status path =
+  try
+    if not (Sys.file_exists path) then Source_missing
+    else if Sys.is_directory path then Source_ok
+    else Source_degraded "not a directory"
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Source_degraded (Printexc.to_string exn)
+
+let warn_source_failure ~source ~path ~action message =
+  Log.Telemetry.warn
+    "telemetry_unified %s failed: source=%s path=%s err=%s" action
+    (source_to_string source) path message
+
+let parse_recent_lines ~source ~path lines =
+  lines
+  |> List.mapi (fun index line -> (index + 1, line))
+  |> List.filter_map (fun (index, line) ->
+         try Some (Yojson.Safe.from_string line)
+         with
+         | Yojson.Json_error msg ->
+             Log.Telemetry.warn
+               "telemetry_unified parse failed: source=%s path=%s recent_row=%d err=%s"
+               (source_to_string source) path index msg;
+             None)
+
 (* ── Store paths ────────────────────────────────────── *)
 
 (** Fixed-path sources (single directory per source).
@@ -55,21 +91,36 @@ let fixed_store_dir ~masc_root ~base_path = function
 (** Discover all keeper metric directories under [masc_root/keepers/]. *)
 let discover_keeper_metric_dirs masc_root : (string * string) list =
   let keepers_dir = Filename.concat masc_root "keepers" in
-  if not (Sys.file_exists keepers_dir) then []
-  else
-    let entries =
-      try Array.to_list (Sys.readdir keepers_dir)
-      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
-    in
-    List.filter_map (fun name ->
-      let metrics_dir = Filename.concat keepers_dir (name ^ "/metrics") in
-      if Sys.file_exists metrics_dir then Some (name, metrics_dir)
-      else None
-    ) entries
+  match dir_status keepers_dir with
+  | Source_missing -> []
+  | Source_degraded message ->
+      warn_source_failure ~source:Keeper_metric ~path:keepers_dir
+        ~action:"discover" message;
+      []
+  | Source_ok -> (
+      match Safe_ops.list_dir_safe keepers_dir with
+      | Error message ->
+          warn_source_failure ~source:Keeper_metric ~path:keepers_dir
+            ~action:"discover" message;
+          []
+      | Ok entries ->
+          List.filter_map
+            (fun name ->
+              let metrics_dir =
+                Filename.concat keepers_dir (name ^ "/metrics")
+              in
+              match dir_status metrics_dir with
+              | Source_ok -> Some (name, metrics_dir)
+              | Source_missing -> None
+              | Source_degraded message ->
+                  warn_source_failure ~source:Keeper_metric ~path:metrics_dir
+                    ~action:"discover" message;
+                  None)
+            entries)
 
 (* ── Timestamp extraction ───────────────────────────── *)
 
-let extract_ts (json : Yojson.Safe.t) : float =
+let extract_ts_opt (json : Yojson.Safe.t) : float option =
   match json with
   | `Assoc fields ->
     (* Try ts_unix first (keeper metrics), then ts, then timestamp *)
@@ -80,19 +131,19 @@ let extract_ts (json : Yojson.Safe.t) : float =
       | _ -> None
     in
     (match try_field "ts_unix" with
-     | Some f -> f
+     | Some f -> Some f
      | None ->
        match try_field "ts" with
-       | Some f -> f
+       | Some f -> Some f
        | None ->
          match try_field "timestamp" with
-         | Some f -> f
+         | Some f -> Some f
          | None ->
            (match List.assoc_opt "ts_iso" fields with
             | Some (`String iso) ->
-                Option.value ~default:0.0 (Types.parse_iso8601_opt iso)
-            | _ -> 0.0))
-  | _ -> 0.0
+                Types.parse_iso8601_opt iso
+            | _ -> None))
+  | _ -> None
 
 (* ── Entry tagging ──────────────────────────────────── *)
 
@@ -138,14 +189,24 @@ let matches_scope ?session_id ?operation_id ?worker_run_id (json : Yojson.Safe.t
 (* ── Read from a single fixed-path source ───────────── *)
 
 let read_fixed_source dir source ~n : Yojson.Safe.t list =
-  if not (Sys.file_exists dir) then []
-  else
-    match Dated_jsonl.create ~base_dir:dir () with
-    | store ->
-      let entries = Dated_jsonl.read_recent store n in
-      List.map (tag_entry source) entries
-    | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-    | exception _ -> []
+  match dir_status dir with
+  | Source_missing -> []
+  | Source_degraded message ->
+      warn_source_failure ~source ~path:dir ~action:"read" message;
+      []
+  | Source_ok -> (
+      match Dated_jsonl.create ~base_dir:dir () with
+      | store ->
+          let entries =
+            Dated_jsonl.read_recent_lines store n
+            |> parse_recent_lines ~source ~path:dir
+          in
+          List.map (tag_entry source) entries
+      | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+      | exception exn ->
+          warn_source_failure ~source ~path:dir ~action:"read"
+            (Printexc.to_string exn);
+          [])
 
 (* ── Read keeper metrics (per-keeper directories) ───── *)
 
@@ -195,68 +256,179 @@ let read_unified ~base_path ~masc_root ?(sources = all_sources) ?keeper_name
       filtered
   in
   (* Sort by timestamp descending (newest first) *)
-  let sorted = List.sort (fun a b ->
-    Float.compare (extract_ts b) (extract_ts a)
-  ) filtered in
+  let sorted =
+    List.sort
+      (fun a b ->
+        match (extract_ts_opt a, extract_ts_opt b) with
+        | Some ta, Some tb -> Float.compare tb ta
+        | Some _, None -> -1
+        | None, Some _ -> 1
+        | None, None -> 0)
+      filtered
+  in
   if List.length sorted <= n then sorted
   else List.filteri (fun i _ -> i < n) sorted
 
 (* ── Summary ────────────────────────────────────────── *)
 
-let count_fixed_source_entries ~masc_root ~base_path source : int =
+let fixed_source_status_json ~masc_root ~base_path source =
   match fixed_store_dir ~masc_root ~base_path source with
-  | None -> 0
+  | None ->
+      `Assoc
+        [
+          ("source", `String (source_to_string source));
+          ("path", `String "");
+          ("exists", `Bool false);
+          ("status", `String "missing");
+          ("entry_count", `Int 0);
+        ]
   | Some dir ->
-    if not (Sys.file_exists dir) then 0
-    else
-      (match Dated_jsonl.create ~base_dir:dir () with
-       | store -> Dated_jsonl.count_entries store
-       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-       | exception _ -> 0)
+      let base_fields status entry_count =
+        [
+          ("source", `String (source_to_string source));
+          ("path", `String dir);
+          ("exists", `Bool (status <> Source_missing));
+          ("status", `String (source_status_to_string status));
+          ("entry_count", `Int entry_count);
+        ]
+      in
+      (match dir_status dir with
+       | Source_missing -> `Assoc (base_fields Source_missing 0)
+       | Source_degraded message ->
+           `Assoc
+             (base_fields (Source_degraded message) 0
+             @ [ ("error", `String message) ])
+       | Source_ok -> (
+           match Dated_jsonl.create ~base_dir:dir () with
+           | store -> `Assoc (base_fields Source_ok (Dated_jsonl.count_entries store))
+           | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+           | exception exn ->
+               let message = Printexc.to_string exn in
+               `Assoc
+                 (base_fields (Source_degraded message) 0
+                 @ [ ("error", `String message) ])))
+
+let keeper_metrics_status_json ~masc_root =
+  let keepers_dir = Filename.concat masc_root "keepers" in
+  let base_fields status keeper_count entry_count =
+    [
+      ("source", `String (source_to_string Keeper_metric));
+      ("path", `String keepers_dir);
+      ("exists", `Bool (status <> Source_missing));
+      ("status", `String (source_status_to_string status));
+      ("keeper_count", `Int keeper_count);
+      ("entry_count", `Int entry_count);
+    ]
+  in
+  match dir_status keepers_dir with
+  | Source_missing ->
+      `Assoc (base_fields Source_missing 0 0 @ [ ("keepers", `List []) ])
+  | Source_degraded message ->
+      `Assoc
+        (base_fields (Source_degraded message) 0 0
+        @ [ ("error", `String message); ("keepers", `List []) ])
+  | Source_ok -> (
+      match Safe_ops.list_dir_safe keepers_dir with
+      | Error message ->
+          `Assoc
+            (base_fields (Source_degraded message) 0 0
+            @ [ ("error", `String message); ("keepers", `List []) ])
+      | Ok entries ->
+          let keeper_items, degraded_count, total_entries =
+            List.fold_left
+              (fun (items, degraded_count, total_entries) name ->
+                let metrics_dir = Filename.concat keepers_dir (name ^ "/metrics") in
+                match dir_status metrics_dir with
+                | Source_missing -> (items, degraded_count, total_entries)
+                | Source_degraded message ->
+                    ( `Assoc
+                        [
+                          ("name", `String name);
+                          ("path", `String metrics_dir);
+                          ("status", `String "degraded");
+                          ("entry_count", `Int 0);
+                          ("error", `String message);
+                        ]
+                      :: items,
+                      degraded_count + 1,
+                      total_entries )
+                | Source_ok -> (
+                    match Dated_jsonl.create ~base_dir:metrics_dir () with
+                    | store ->
+                        let entry_count = Dated_jsonl.count_entries store in
+                        ( `Assoc
+                            [
+                              ("name", `String name);
+                              ("path", `String metrics_dir);
+                              ("status", `String "ok");
+                              ("entry_count", `Int entry_count);
+                            ]
+                          :: items,
+                          degraded_count,
+                          total_entries + entry_count )
+                    | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+                    | exception exn ->
+                        let message = Printexc.to_string exn in
+                        ( `Assoc
+                            [
+                              ("name", `String name);
+                              ("path", `String metrics_dir);
+                              ("status", `String "degraded");
+                              ("entry_count", `Int 0);
+                              ("error", `String message);
+                            ]
+                          :: items,
+                          degraded_count + 1,
+                          total_entries )))
+              ([], 0, 0) entries
+          in
+          let keeper_items = List.rev keeper_items in
+          let status =
+            if degraded_count > 0 then Source_degraded "one or more keeper metric stores degraded"
+            else Source_ok
+          in
+          let extra_fields =
+            match status with
+            | Source_ok | Source_missing -> []
+            | Source_degraded message -> [ ("error", `String message) ]
+          in
+          `Assoc
+            (base_fields status (List.length keeper_items) total_entries
+            @ extra_fields
+            @ [ ("keepers", `List keeper_items) ]))
 
 let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
-  let keeper_dirs = discover_keeper_metric_dirs masc_root in
-  let keeper_total =
-    List.fold_left (fun acc (_, dir) ->
-      acc +
-      (match Dated_jsonl.create ~base_dir:dir () with
-       | store -> Dated_jsonl.count_entries store
-       | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-       | exception _ -> 0)
-    ) 0 keeper_dirs
+  let sources_json =
+    List.map
+      (function
+        | Keeper_metric -> keeper_metrics_status_json ~masc_root
+        | source -> fixed_source_status_json ~masc_root ~base_path source)
+      all_sources
   in
-  let source_json source =
-    match source with
-    | Keeper_metric ->
-      `Assoc [
-        ("source", `String (source_to_string source));
-        ("keepers", `List (List.map (fun (name, dir) ->
-           `Assoc [
-             ("name", `String name);
-             ("path", `String dir);
-           ]) keeper_dirs));
-        ("keeper_count", `Int (List.length keeper_dirs));
-        ("entry_count", `Int keeper_total);
-      ]
-    | _ ->
-      let dir = match fixed_store_dir ~masc_root ~base_path source with
-        | Some d -> d | None -> "" in
-      let exists = dir <> "" && Sys.file_exists dir in
-      let count = if exists then count_fixed_source_entries ~masc_root ~base_path source else 0 in
-      `Assoc [
-        ("source", `String (source_to_string source));
-        ("path", `String dir);
-        ("exists", `Bool exists);
-        ("entry_count", `Int count);
-      ]
+  let degraded_sources =
+    List.fold_left
+      (fun acc -> function
+        | `Assoc fields -> (
+            match List.assoc_opt "status" fields with
+            | Some (`String "degraded") -> acc + 1
+            | _ -> acc)
+        | _ -> acc)
+      0 sources_json
   in
-  let fixed_total =
-    List.fold_left (fun acc s ->
-      acc + count_fixed_source_entries ~masc_root ~base_path s
-    ) 0 (List.filter (fun s -> s <> Keeper_metric) all_sources)
+  let total_entries =
+    List.fold_left
+      (fun acc -> function
+        | `Assoc fields -> (
+            match List.assoc_opt "entry_count" fields with
+            | Some (`Int count) -> acc + count
+            | _ -> acc)
+        | _ -> acc)
+      0 sources_json
   in
   `Assoc [
     ("generated_at", `String (Types.now_iso ()));
-    ("sources", `List (List.map source_json all_sources));
-    ("total_entries", `Int (keeper_total + fixed_total));
+    ("status", `String (if degraded_sources > 0 then "degraded" else "ok"));
+    ("degraded_source_count", `Int degraded_sources);
+    ("sources", `List sources_json);
+    ("total_entries", `Int total_entries);
   ]

--- a/lib/telemetry_unified.mli
+++ b/lib/telemetry_unified.mli
@@ -55,5 +55,8 @@ val summary_json :
   unit ->
   Yojson.Safe.t
 (** [summary_json ~base_path ~masc_root ()] returns a JSON overview of
-    each source: path, entry count, and whether the store directory
-    exists.  [masc_root] is the cluster-aware .masc directory. *)
+    each source: path, entry count, existence, and read status
+    (`ok`, `missing`, or `degraded`). Degraded sources also
+    include an error string so callers can distinguish corrupt paths from
+    genuinely empty telemetry. [masc_root] is the cluster-aware .masc
+    directory. *)

--- a/test/test_auto_recall_activity_coverage.ml
+++ b/test/test_auto_recall_activity_coverage.ml
@@ -342,6 +342,44 @@ let test_recent_activity_skips_bad_board_post_timestamp () =
   let items = Activity_feed.recent_activity config ~limit:10 () in
   check int "board post with bad timestamp skipped" 0 (List.length items)
 
+let test_recent_activity_skips_bad_board_comment_timestamp () =
+  with_temp_dir "activity-feed-comment-ts" @@ fun base_path ->
+  let config = Room.default_config base_path in
+  let masc_dir = Room.masc_dir config in
+  Fs_compat.mkdir_p masc_dir;
+  let comments_path = Filename.concat masc_dir "board_comments.jsonl" in
+  write_file comments_path
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("id", `String "comment-bad-ts");
+           ("author", `String "alice");
+           ("content", `String "body");
+           ("created_at", `String "nope");
+         ])
+    ^ "\n");
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "board comment with bad timestamp skipped" 0 (List.length items)
+
+let test_recent_activity_skips_bad_mention_timestamp () =
+  with_temp_dir "activity-feed-mention-ts" @@ fun base_path ->
+  let config = Room.default_config base_path in
+  let inbox_path = Mention_inbox.inbox_path config in
+  Fs_compat.mkdir_p (Filename.dirname inbox_path);
+  write_file inbox_path
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("id", `String "mention-bad-ts");
+           ("source_agent", `String "alice");
+           ("target_agent", `String "bob");
+           ("content_preview", `String "hello");
+           ("created_at", `String "nope");
+         ])
+    ^ "\n");
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "mention with bad timestamp skipped" 0 (List.length items)
+
 (* ============================================================
    Runner
    ============================================================ *)
@@ -401,5 +439,9 @@ let () =
         test_recent_activity_skips_bad_task_timestamp;
       test_case "skips bad board post timestamp" `Quick
         test_recent_activity_skips_bad_board_post_timestamp;
+      test_case "skips bad board comment timestamp" `Quick
+        test_recent_activity_skips_bad_board_comment_timestamp;
+      test_case "skips bad mention timestamp" `Quick
+        test_recent_activity_skips_bad_mention_timestamp;
     ];
   ]

--- a/test/test_auto_recall_activity_coverage.ml
+++ b/test/test_auto_recall_activity_coverage.ml
@@ -303,7 +303,7 @@ let test_recent_activity_skips_bad_task_file () =
         item.summary
   | _ -> fail "expected one task activity item"
 
-let test_recent_activity_falls_back_from_bad_task_timestamp () =
+let test_recent_activity_skips_bad_task_timestamp () =
   with_temp_dir "activity-feed-ts" @@ fun base_path ->
   let config = Room.default_config base_path in
   let masc_dir = Room.masc_dir config in
@@ -320,12 +320,27 @@ let test_recent_activity_falls_back_from_bad_task_timestamp () =
            ("created_at", `String "not-a-timestamp");
          ]));
   let items = Activity_feed.recent_activity config ~limit:10 () in
-  check int "task still included" 1 (List.length items);
-  match items with
-  | [item] ->
-      check bool "timestamp falls back to a real time value" true
-        (item.created_at > 0.0)
-  | _ -> fail "expected one task activity item"
+  check int "bad timestamp skipped" 0 (List.length items)
+
+let test_recent_activity_skips_bad_board_post_timestamp () =
+  with_temp_dir "activity-feed-board-ts" @@ fun base_path ->
+  let config = Room.default_config base_path in
+  let masc_dir = Room.masc_dir config in
+  Fs_compat.mkdir_p masc_dir;
+  let board_posts_path = Filename.concat masc_dir "board_posts.jsonl" in
+  write_file board_posts_path
+    (Yojson.Safe.to_string
+       (`Assoc
+         [
+           ("id", `String "post-bad-ts");
+           ("author", `String "alice");
+           ("title", `String "Hello");
+           ("content", `String "body");
+           ("created_at", `String "nope");
+         ])
+    ^ "\n");
+  let items = Activity_feed.recent_activity config ~limit:10 () in
+  check int "board post with bad timestamp skipped" 0 (List.length items)
 
 (* ============================================================
    Runner
@@ -382,7 +397,9 @@ let () =
         test_recent_activity_skips_malformed_jsonl_lines;
       test_case "skips bad task file" `Quick
         test_recent_activity_skips_bad_task_file;
-      test_case "falls back from bad task timestamp" `Quick
-        test_recent_activity_falls_back_from_bad_task_timestamp;
+      test_case "skips bad task timestamp" `Quick
+        test_recent_activity_skips_bad_task_timestamp;
+      test_case "skips bad board post timestamp" `Quick
+        test_recent_activity_skips_bad_board_post_timestamp;
     ];
   ]

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -40,6 +40,11 @@ let write_raw_jsonl_rows dir rows =
   in
   Fs_compat.append_file path content
 
+let write_raw_jsonl_lines dir lines =
+  let path = today_jsonl_path dir in
+  let content = String.concat "\n" lines ^ "\n" in
+  Fs_compat.append_file path content
+
 (* ── Source roundtrip ────────────────────────────── *)
 
 let test_source_roundtrip () =
@@ -134,6 +139,23 @@ let test_agent_event_source () =
       | Some (`String s) -> s | _ -> "" in
     Alcotest.(check string) "tagged as agent_event" "agent_event" source
   | _ -> Alcotest.fail "expected Assoc"
+
+let test_agent_event_source_skips_malformed_lines () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_agent_event_malformed" in
+  let telemetry_dir = Filename.concat dir ".masc/telemetry" in
+  Fs_compat.mkdir_p telemetry_dir;
+  write_raw_jsonl_lines telemetry_dir
+    [
+      {|{"timestamp":1000.0,"event":"good"}|};
+      "not-json";
+    ];
+  let entries =
+    Telemetry_unified.read_unified ~base_path:dir ~masc_root:(masc_root dir)
+      ~sources:[Telemetry_unified.Agent_event] ()
+  in
+  Alcotest.(check int) "malformed line skipped" 1 (List.length entries)
 
 (* ── Keeper metrics discovery ────────────────────── *)
 
@@ -324,6 +346,8 @@ let () =
         [
           Alcotest.test_case "empty base" `Quick test_empty_returns_empty;
           Alcotest.test_case "agent events" `Quick test_agent_event_source;
+          Alcotest.test_case "agent events skip malformed lines" `Quick
+            test_agent_event_source_skips_malformed_lines;
           Alcotest.test_case "keeper metrics" `Quick test_keeper_metrics_per_keeper;
           Alcotest.test_case "sorted newest first" `Quick test_sorted_newest_first;
           Alcotest.test_case "n limits output" `Quick test_n_limits_output;

--- a/test/test_telemetry_unified.ml
+++ b/test/test_telemetry_unified.ml
@@ -58,6 +58,32 @@ let test_source_of_string_unknown () =
 
 let masc_root dir = Filename.concat dir ".masc"
 
+let assoc_string key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> value
+      | _ -> "")
+  | _ -> ""
+
+let assoc_int key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Int value) -> value
+      | _ -> -1)
+  | _ -> -1
+
+let assoc_list key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`List items) -> items
+      | _ -> [])
+  | _ -> []
+
+let find_source_row json source_name =
+  assoc_list "sources" json
+  |> List.find_opt (fun row ->
+         String.equal (assoc_string "source" row) source_name)
+
 let test_empty_returns_empty () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -74,7 +100,14 @@ let test_summary_empty () =
   | `Assoc fields ->
     let total = match List.assoc_opt "total_entries" fields with
       | Some (`Int n) -> n | _ -> -1 in
-    Alcotest.(check int) "zero total" 0 total
+    Alcotest.(check int) "zero total" 0 total;
+    Alcotest.(check string) "top-level status stays ok" "ok"
+      (assoc_string "status" json);
+    (match find_source_row json "agent_event" with
+     | Some row ->
+         Alcotest.(check string) "missing source is explicit" "missing"
+           (assoc_string "status" row)
+     | None -> Alcotest.fail "expected agent_event source row")
   | _ -> Alcotest.fail "expected Assoc"
 
 (* ── Single source read ──────────────────────────── *)
@@ -189,7 +222,12 @@ let test_summary_with_data () =
   | `Assoc fields ->
     let total = match List.assoc_opt "total_entries" fields with
       | Some (`Int n) -> n | _ -> -1 in
-    Alcotest.(check bool) "at least 1 entry" true (total >= 1)
+    Alcotest.(check bool) "at least 1 entry" true (total >= 1);
+    (match find_source_row json "agent_event" with
+     | Some row ->
+         Alcotest.(check string) "existing source is ok" "ok"
+           (assoc_string "status" row)
+     | None -> Alcotest.fail "expected agent_event source row")
   | _ -> Alcotest.fail "expected Assoc"
 
 let test_summary_counts_all_entries_beyond_recent_cap () =
@@ -250,6 +288,28 @@ let test_cluster_keeper_metrics () =
   in
   Alcotest.(check int) "cluster keeper metric found" 1 (List.length entries)
 
+let test_summary_marks_non_directory_source_degraded () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "telem_degraded_source" in
+  let bad_path = Filename.concat dir ".masc/telemetry" in
+  Fs_compat.mkdir_p (Filename.dirname bad_path);
+  Fs_compat.save_file bad_path "not-a-directory";
+  let summary =
+    Telemetry_unified.summary_json ~base_path:dir ~masc_root:(masc_root dir) ()
+  in
+  Alcotest.(check string) "top-level degraded" "degraded"
+    (assoc_string "status" summary);
+  Alcotest.(check int) "one degraded source" 1
+    (assoc_int "degraded_source_count" summary);
+  match find_source_row summary "agent_event" with
+  | Some row ->
+      Alcotest.(check string) "source status degraded" "degraded"
+        (assoc_string "status" row);
+      Alcotest.(check bool) "error mentions directory" true
+        (String.length (assoc_string "error" row) > 0)
+  | None -> Alcotest.fail "expected agent_event source row"
+
 (* ── Runner ──────────────────────────────────────── *)
 
 let () =
@@ -274,6 +334,8 @@ let () =
           Alcotest.test_case "with data" `Quick test_summary_with_data;
           Alcotest.test_case "counts all rows beyond recent cap" `Quick
             test_summary_counts_all_entries_beyond_recent_cap;
+          Alcotest.test_case "non-directory source is degraded" `Quick
+            test_summary_marks_non_directory_source_degraded;
         ] );
       ( "cluster",
         [


### PR DESCRIPTION
## Summary
- surface `Telemetry_unified` source health as `ok` / `missing` / `degraded` instead of silently collapsing read-path failures to empty data
- stop `Activity_feed` from rewriting invalid timestamps to `now()` and skip malformed timestamped entries instead
- include telemetry source summary in the dashboard telemetry payload and add regression coverage for degraded source paths and timestamp rejection

## Why
Wave 2 hardened persisted team-session parsing, but telemetry and activity read models still hid operational failures behind empty arrays and invented timestamps. This stack makes degraded telemetry sources explicit so operators can distinguish empty data from corrupt paths or parse failures.

Stacked on:
- #6293

## Product impact
- dashboard telemetry consumers can now distinguish empty telemetry from unreadable or malformed source stores
- activity timelines no longer fabricate chronology by substituting `now()` for corrupted timestamps
- operators get a summary block in `/api/v1/dashboard/telemetry` that exposes source health without needing a separate diagnostics call

## Evidence
- `dune build --root . test/test_telemetry_unified.exe test/test_auto_recall_activity_coverage.exe`
- `dune build --root . test/test_dashboard_namespace_truth.exe`
- `./_build/default/test/test_telemetry_unified.exe`
- `./_build/default/test/test_auto_recall_activity_coverage.exe`

## Review evidence
- direct cross-model review via `sb glm-text`
- timestamp: `2026-04-10T04:09:48Z`
- scope: `feat/ocaml-core-audit-wave2-team-session...feat/ocaml-core-audit-wave3-telemetry-truth`
- result: `No findings.`
- comment: https://github.com/jeong-sik/masc-mcp/pull/6297#issuecomment-4220272922

## Linked issue
- Refs #6290
- Refs #6296

## Validation
- `dune build --root . test/test_telemetry_unified.exe test/test_auto_recall_activity_coverage.exe`
- `dune build --root . test/test_dashboard_namespace_truth.exe`
- `./_build/default/test/test_telemetry_unified.exe`
- `./_build/default/test/test_auto_recall_activity_coverage.exe`
