### PR TITLE
[codex] Ignore keeper sidecar JSON files in meta scans

### DIFF
--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -18,6 +18,10 @@ let handle_keeper_status = Keeper_status_detail.handle_keeper_status
 let handle_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
+  let dir = keeper_dir ctx.config in
+  match Safe_ops.list_dir_safe dir with
+  | Error e -> (false, e)
+  | Ok _files ->
   let keeper_names = Keeper_types.keeper_names ctx.config |> take limit in
   if not detailed then
     let json = `Assoc [
@@ -54,35 +58,35 @@ let handle_keeper_list ctx args : tool_result =
           let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
             compaction_policy_of_keeper m
           in
-	            let metrics_store = keeper_metrics_store ctx.config m.name in
-	            let metrics_path = keeper_metrics_path ctx.config m.name in
-	            let metrics_window_lines =
-	              let dated = Dated_jsonl.read_recent_lines metrics_store 120 in
-	              if dated <> [] then dated
-	              else read_file_tail_lines metrics_path ~max_bytes:120000 ~max_lines:120
-	            in
-	            let last_metrics =
-	              match List.rev metrics_window_lines with
-	              | line :: _ -> (try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None)
-	              | [] -> None
-	            in
-	            let metrics_overview =
-	              summarize_metrics_lines metrics_window_lines ~default_generation:m.runtime.generation
-	            in
-	            let last_skill_metrics =
-	              let rec find_latest = function
-	                | [] -> None
-	                | line :: tl ->
-	                    (try
-	                       let j = Yojson.Safe.from_string line in
-	                       match Safe_ops.json_string_opt "skill_primary" j with
-	                       | Some primary when String.trim primary <> "" -> Some j
-	                       | _ -> find_latest tl
-	                     with Yojson.Json_error _ -> find_latest tl)
-	              in
-	              find_latest (List.rev metrics_window_lines)
-	            in
-            let memory_bank_summary =
+          let metrics_store = keeper_metrics_store ctx.config m.name in
+          let metrics_path = keeper_metrics_path ctx.config m.name in
+          let metrics_window_lines =
+            let dated = Dated_jsonl.read_recent_lines metrics_store 120 in
+            if dated <> [] then dated
+            else read_file_tail_lines metrics_path ~max_bytes:120000 ~max_lines:120
+          in
+          let last_metrics =
+            match List.rev metrics_window_lines with
+            | line :: _ -> (try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None)
+            | [] -> None
+          in
+          let metrics_overview =
+            summarize_metrics_lines metrics_window_lines ~default_generation:m.runtime.generation
+          in
+          let last_skill_metrics =
+            let rec find_latest = function
+              | [] -> None
+              | line :: tl ->
+                  (try
+                     let j = Yojson.Safe.from_string line in
+                     match Safe_ops.json_string_opt "skill_primary" j with
+                     | Some primary when String.trim primary <> "" -> Some j
+                     | _ -> find_latest tl
+                   with Yojson.Json_error _ -> find_latest tl)
+            in
+            find_latest (List.rev metrics_window_lines)
+          in
+          let memory_bank_summary =
               read_keeper_memory_summary
                 ctx.config
                 ~name:m.name
@@ -107,55 +111,55 @@ let handle_keeper_list ctx args : tool_result =
               else
                 let elapsed = now_ts -. last_reflection_ts in
                 max 0.0 (cooldown -. elapsed)
-            in
-	            let context_json =
-	              match last_metrics with
-	              | None -> `Assoc [("source", `String "none")]
-	              | Some metrics ->
-	                `Assoc [
-	                  ("source", `String "metrics");
-	                  ("context_ratio", `Float (Safe_ops.json_float "context_ratio" metrics));
-	                  ("context_tokens", `Int (Safe_ops.json_int "context_tokens" metrics));
-	                  ("context_max", `Int (Safe_ops.json_int "context_max" metrics));
-	                  ("message_count", `Int (Safe_ops.json_int "message_count" metrics));
-	                ]
-	            in
-	            let skill_route_json =
-	              let open Yojson.Safe.Util in
-                  let fallback_selection_mode_string = "agent" in
-                  let fallback_selection_provenance = "fallback" in
-	              match last_skill_metrics with
-	              | None -> `Null
-	              | Some metrics ->
-	                  let primary = Safe_ops.json_string_opt "skill_primary" metrics in
-	                  let secondary =
-	                    match metrics |> member "skill_secondary" with
-	                    | `List xs ->
-	                        xs
-	                        |> List.filter_map (fun v ->
-	                             match v with `String s when String.trim s <> "" -> Some s | _ -> None)
-	                    | _ -> []
-	                  in
-	                  let reason = Safe_ops.json_string_opt "skill_reason" metrics in
-	                  `Assoc [
-	                    ("primary", Json_util.string_opt_to_json primary);
-	                    ("secondary", `List (List.map (fun s -> `String s) secondary));
-	                    ("reason", Json_util.string_opt_to_json reason);
-                        ( "selection_mode",
-                          `String
-                            (Safe_ops.json_string_opt "skill_selection_mode" metrics
-                             |> Option.value ~default:fallback_selection_mode_string) );
-                        ( "provenance",
-                          `String
-                            (Safe_ops.json_string_opt "skill_provenance" metrics
-                             |> Option.value ~default:fallback_selection_provenance) );
-                        ("authoritative", `Bool false);
-	                  ]
-	            in
-              let runtime_blocker_fields =
-                runtime_blocker_fields_json ctx.config m
-              in
-	            Some (`Assoc ([
+          in
+          let context_json =
+            match last_metrics with
+            | None -> `Assoc [("source", `String "none")]
+            | Some metrics ->
+              `Assoc [
+                ("source", `String "metrics");
+                ("context_ratio", `Float (Safe_ops.json_float "context_ratio" metrics));
+                ("context_tokens", `Int (Safe_ops.json_int "context_tokens" metrics));
+                ("context_max", `Int (Safe_ops.json_int "context_max" metrics));
+                ("message_count", `Int (Safe_ops.json_int "message_count" metrics));
+              ]
+          in
+          let skill_route_json =
+            let open Yojson.Safe.Util in
+            let fallback_selection_mode_string = "agent" in
+            let fallback_selection_provenance = "fallback" in
+            match last_skill_metrics with
+            | None -> `Null
+            | Some metrics ->
+                let primary = Safe_ops.json_string_opt "skill_primary" metrics in
+                let secondary =
+                  match metrics |> member "skill_secondary" with
+                  | `List xs ->
+                      xs
+                      |> List.filter_map (fun v ->
+                           match v with `String s when String.trim s <> "" -> Some s | _ -> None)
+                  | _ -> []
+                in
+                let reason = Safe_ops.json_string_opt "skill_reason" metrics in
+                `Assoc [
+                  ("primary", Json_util.string_opt_to_json primary);
+                  ("secondary", `List (List.map (fun s -> `String s) secondary));
+                  ("reason", Json_util.string_opt_to_json reason);
+                  ( "selection_mode",
+                    `String
+                      (Safe_ops.json_string_opt "skill_selection_mode" metrics
+                       |> Option.value ~default:fallback_selection_mode_string) );
+                  ( "provenance",
+                    `String
+                      (Safe_ops.json_string_opt "skill_provenance" metrics
+                       |> Option.value ~default:fallback_selection_provenance) );
+                  ("authoritative", `Bool false);
+                ]
+          in
+          let runtime_blocker_fields =
+            runtime_blocker_fields_json ctx.config m
+          in
+          Some (`Assoc ([
               ("name", `String m.name);
               ("agent_name", `String m.agent_name);
               ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id));
@@ -241,12 +245,12 @@ let handle_keeper_list ctx args : tool_result =
               ("memory_note_count", `Int memory_bank_summary.total_notes);
               ("memory_top_kind",
                 Json_util.string_opt_to_json memory_bank_summary.top_kind);
-	              ("memory_recent_note",
-	                Json_util.string_opt_to_json memory_recent_note);
-	              ("context", context_json);
-	              ("skill_route", skill_route_json);
-	              ("metrics_overview", metrics_summary_to_json metrics_overview);
-	              ("memory_bank", memory_summary_to_json memory_bank_summary);
+              ("memory_recent_note",
+                Json_util.string_opt_to_json memory_recent_note);
+              ("context", context_json);
+              ("skill_route", skill_route_json);
+              ("metrics_overview", metrics_summary_to_json metrics_overview);
+              ("memory_bank", memory_summary_to_json memory_bank_summary);
               ("storage_paths", `Assoc [
                 ("meta", `String (keeper_meta_path ctx.config m.name));
                 ("metrics", `String (Dated_jsonl.base_dir metrics_store));

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -18,53 +18,42 @@ let handle_keeper_status = Keeper_status_detail.handle_keeper_status
 let handle_keeper_list ctx args : tool_result =
   let limit = max 0 (get_int args "limit" 50) in
   let detailed = get_bool args "detailed" false in
-  let dir = keeper_dir ctx.config in
-  match Safe_ops.list_dir_safe dir with
-  | Error e -> (false, "❌ " ^ e)
-  | Ok files ->
-    let keeper_names =
-      files
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.map Filename.remove_extension
-      |> List.filter validate_name
-      |> List.sort String.compare
-      |> take limit
-    in
-    if not detailed then
-      let json = `Assoc [
-        ("count", `Int (List.length keeper_names));
-        ("keepers", `List (List.map (fun k -> `String k) keeper_names));
-      ] in
-      (true, Yojson.Safe.to_string json)
-    else
-      let now_ts = Time_compat.now () in
-      let keepers =
-        List.filter_map (fun name ->
-          match read_meta ctx.config name with
-          | Error _ -> None
-          | Ok None -> None
-          | Ok (Some m) ->
-            let created_ts =
-              Resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
-            in
-            let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
-            let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
-            let last_proactive_ago_s =
-              if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
-            in
-            let last_visible_proactive_ago_s =
-              if m.runtime.proactive_rt.last_visible_ts <= 0.0 then 0.0
-              else now_ts -. m.runtime.proactive_rt.last_visible_ts
-            in
-            let active_model = active_model_of_meta m in
-            let next_model_hint = next_model_hint_of_meta m in
-            let trace_history_count = List.length m.runtime.trace_history in
-            let last_compaction_saved_tokens =
-              max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
-            in
-            let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
-              compaction_policy_of_keeper m
-            in
+  let keeper_names = Keeper_types.keeper_names ctx.config |> take limit in
+  if not detailed then
+    let json = `Assoc [
+      ("count", `Int (List.length keeper_names));
+      ("keepers", `List (List.map (fun k -> `String k) keeper_names));
+    ] in
+    (true, Yojson.Safe.to_string json)
+  else
+    let now_ts = Time_compat.now () in
+    let keepers =
+      List.filter_map (fun name ->
+        match read_meta ctx.config name with
+        | Error _ -> None
+        | Ok None -> None
+        | Ok (Some m) ->
+          let created_ts =
+            Resilience.Time.parse_iso8601_opt m.created_at |> Option.value ~default:0.0
+          in
+          let keeper_age_s = if created_ts <= 0.0 then 0.0 else now_ts -. created_ts in
+          let last_turn_ago_s = if m.runtime.usage.last_turn_ts <= 0.0 then 0.0 else now_ts -. m.runtime.usage.last_turn_ts in
+          let last_proactive_ago_s =
+            if m.runtime.proactive_rt.last_ts <= 0.0 then 0.0 else now_ts -. m.runtime.proactive_rt.last_ts
+          in
+          let last_visible_proactive_ago_s =
+            if m.runtime.proactive_rt.last_visible_ts <= 0.0 then 0.0
+            else now_ts -. m.runtime.proactive_rt.last_visible_ts
+          in
+          let active_model = active_model_of_meta m in
+          let next_model_hint = next_model_hint_of_meta m in
+          let trace_history_count = List.length m.runtime.trace_history in
+          let last_compaction_saved_tokens =
+            max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
+          in
+          let (compact_ratio_gate, compact_message_gate, compact_token_gate) =
+            compaction_policy_of_keeper m
+          in
 	            let metrics_store = keeper_metrics_store ctx.config m.name in
 	            let metrics_path = keeper_metrics_path ctx.config m.name in
 	            let metrics_window_lines =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1366,26 +1366,29 @@ let read_meta_file_path path : (keeper_meta option, string) result =
          Error e))
 ;;
 
-(** Known auxiliary suffixes that share the keepers/ directory.
-    Files matching [<name>.<suffix>.json] are excluded from autoboot scan.
-    Add new suffixes here when introducing new sidecar file types. *)
-let keeper_auxiliary_suffixes = [
-  ".manual_reconcile.json";
-  ".dataset.json";
-]
+(** Sidecar stem suffixes (without the trailing .json).
+    A file like [keeper.manual_reconcile.json] has stem
+    [keeper.manual_reconcile]; stripping [.json] and checking
+    [String.ends_with ~suffix] on this stem avoids false-positives
+    for keeper names that happen to contain dots (e.g. [foo.dataset]). *)
+let keeper_sidecar_stem_suffixes =
+  [ ".manual_reconcile"; ".dataset" ]
 
-(** Filter: only plain keeper meta files (e.g. "sangsu.json", "my.keeper.json").
-    Excludes known auxiliary sidecar files like "sangsu.manual_reconcile.json".
-    Uses an explicit suffix list rather than rejecting all dots in the stem,
-    because [validate_name] allows dots in keeper names. *)
 let is_keeper_meta_file f =
-  Filename.check_suffix f ".json"
-  && not (List.exists (fun suffix -> Filename.check_suffix f suffix)
-            keeper_auxiliary_suffixes)
+  if not (Filename.check_suffix f ".json") then false
+  else
+    let stem = Filename.chop_suffix f ".json" in
+    not
+      (List.exists
+         (fun suf -> String.length stem > String.length suf
+                     && String.ends_with ~suffix:suf stem)
+         keeper_sidecar_stem_suffixes)
 let keeper_names config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with
-  | Error _ -> []
+  | Error e ->
+    Log.Keeper.warn "keeper_names: failed to list directory %s: %s" dir e;
+    []
   | Ok files ->
     files
     |> List.filter is_keeper_meta_file

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1371,6 +1371,7 @@ let read_meta_file_path path : (keeper_meta option, string) result =
     Add new suffixes here when introducing new sidecar file types. *)
 let keeper_auxiliary_suffixes = [
   ".manual_reconcile.json";
+  ".dataset.json";
 ]
 
 (** Filter: only plain keeper meta files (e.g. "sangsu.json", "my.keeper.json").
@@ -1381,7 +1382,6 @@ let is_keeper_meta_file f =
   Filename.check_suffix f ".json"
   && not (List.exists (fun suffix -> Filename.check_suffix f suffix)
             keeper_auxiliary_suffixes)
-
 let keeper_names config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -216,16 +216,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       let config = state.room_config in
       let masc_root = Room.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
-      let all_count =
-        match Safe_ops.list_dir_safe keeper_dir with
-        | Ok files ->
-            List.length
-              (List.filter (fun f -> Filename.check_suffix f ".json") files)
-        | Error msg ->
-            Log.Keeper.warn "autoboot: failed to list keeper dir %s: %s"
-              keeper_dir msg;
-            0
-      in
+      let all_count = List.length (Keeper_types.keeper_names config) in
       Log.Keeper.info
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -216,7 +216,14 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       let config = state.room_config in
       let masc_root = Room.masc_root_dir config in
       let keeper_dir = Keeper_fs.keeper_dir config in
-      let all_count = List.length (Keeper_types.keeper_names config) in
+      let all_count =
+        (match Safe_ops.list_dir_safe keeper_dir with
+         | Ok _ -> ()
+         | Error e ->
+           Log.Keeper.warn "autoboot: failed to list keeper_dir %s: %s"
+             keeper_dir e);
+        List.length (Keeper_types.keeper_names config)
+      in
       Log.Keeper.info
         "autoboot: base_path=%s masc_root=%s keeper_dir=%s keeper_json_count=%d"
         config.base_path masc_root keeper_dir all_count;

--- a/test/dune
+++ b/test/dune
@@ -239,6 +239,7 @@
         test_server_runtime_bootstrap
         test_server_base_path_diagnostics
         test_server_startup_takeover
+        test_keeper_meta_listing
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -387,6 +388,7 @@
         test_server_runtime_bootstrap
         test_server_base_path_diagnostics
         test_server_startup_takeover
+        test_keeper_meta_listing
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -1,0 +1,121 @@
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_meta_listing_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let ensure_fs env =
+  if not (Fs_compat.has_fs ()) then
+    Fs_compat.set_fs (Eio.Stdenv.fs env)
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let write_json path json =
+  Out_channel.with_open_bin path (fun oc ->
+      output_string oc (Yojson.Safe.pretty_to_string json))
+
+let write_keeper_meta_exn config ~name ~trace_id =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
+        ("trace_id", `String trace_id);
+        ("goal", `String "test keeper");
+      ]
+  in
+  let meta =
+    match Keeper_types.meta_of_json json with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  match Keeper_types.write_meta ~force:true config meta with
+  | Ok () -> ()
+  | Error e -> fail ("write_meta failed: " ^ e)
+
+let parse_json_exn body =
+  try Yojson.Safe.from_string body
+  with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
+
+let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
+  {
+    config;
+    agent_name;
+    sw;
+    clock = Eio.Stdenv.clock env;
+    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    net = None;
+  }
+
+let test_keeper_listing_ignores_sidecar_json_files () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu";
+      write_keeper_meta_exn config ~name:"dot.name" ~trace_id:"trace-dot-name";
+      ignore
+        (Keeper_manual_reconcile.open_pending
+           config
+           ~keeper_name:"sangsu"
+           ~blocker_class:"ambiguous_post_commit_failure"
+           ~summary:"turn outcome ambiguous"
+           ~failure_reason:(Some "manual reconcile required")
+           ~trace_id:(Some "trace-sangsu")
+           ~generation:(Some 1)
+           ~committed_tools:["keeper_bash"]);
+      let dataset_path =
+        Filename.concat (Keeper_fs.keeper_dir config) "sangsu.dataset.json"
+      in
+      write_json dataset_path (`Assoc [ ("kind", `String "dataset") ]);
+      let names = Keeper_types.keeper_names config in
+      check (list string) "keeper_names filters sidecars"
+        [ "dot.name"; "sangsu" ] names;
+      let keepalive_names = Keeper_types.keepalive_keeper_names config in
+      check (list string) "keepalive_keeper_names filters sidecars"
+        [ "dot.name"; "sangsu" ] keepalive_names;
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        Keeper_status.handle_keeper_list ctx (`Assoc [ ("limit", `Int 10) ])
+      in
+      check bool "keeper status list ok" true ok;
+      let json = parse_json_exn body in
+      let listed =
+        Yojson.Safe.Util.(json |> member "keepers" |> to_list |> filter_string)
+      in
+      check (list string) "status handler filters sidecars"
+        [ "dot.name"; "sangsu" ] listed;
+      check int "status handler count filters sidecars" 2
+        Yojson.Safe.Util.(json |> member "count" |> to_int))
+
+let () =
+  run "keeper_meta_listing"
+    [
+      ( "listing",
+        [
+          test_case "keeper_names and keeper_list ignore sidecar json" `Quick
+            test_keeper_listing_ignores_sidecar_json_files;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
Exclude keeper sidecar JSON files from keeper meta discovery so `*.manual_reconcile.json` and `*.dataset.json` are not treated as live keeper metadata.

## Why
Keepers store both primary metadata and sidecar records under the same `keepers/` directory. The meta scanner was enumerating every `*.json` file, so sidecar records were parsed as keeper meta, which produced repeated `invalid keeper meta (bad name)` and unknown-key warnings.

## What changed
- add a keeper-meta filename filter that excludes sidecar suffixes
- route `Keeper_status.handle_keeper_list` through the shared keeper-name helper
- reuse the same filtered count in keeper autoboot logging
- add a regression test covering `manual_reconcile` and `dataset` sidecars while preserving dotted keeper names

## Product impact
- removes false-positive keeper meta warnings for sidecar records
- keeps keeper counts and listing surfaces aligned with actual persisted keeper meta files
- avoids future drift between keeper listing code paths

## Evidence
- reproduced the failure from a base-path-scoped keeper directory containing both `sangsu.json` and `sangsu.manual_reconcile.json`
- added regression coverage for `keeper_names`, `keepalive_keeper_names`, and `Keeper_status.handle_keeper_list`
- verified `manual_reconcile` behavior still passes after the listing change

## Review evidence
- direct `sb glm-text` (`GLM-5.1` path), 2026-04-10T04:08:45Z, result: `No findings.`
- detailed review evidence is also recorded in PR comment https://github.com/jeong-sik/masc-mcp/pull/6301#issuecomment-4220297407

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-sidecar-scan`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-sidecar-scan ./test/test_keeper_meta_listing.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-sidecar-scan ./test/test_keeper_reconcile_tool.exe`

## Root cause
The keeper directory scan matched every `*.json` file and relied on `Filename.remove_extension`, so sidecars like `sangsu.manual_reconcile.json` became a seemingly valid keeper name (`sangsu.manual_reconcile`) and were then parsed with the wrong schema.

## Linked issue
Fixes #6306
