### PR TITLE
fix(cascade): respect local_only cascade name, add GLM flash models

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,19 +1,20 @@
 {
   "default_models": [
-    "glm:auto",
-    "ollama:qwen3.5:35b-a3b-coding-nvfp4",
+    "glm:glm-4.7-flashx",
+    "glm:glm-5.1",
+    "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "local_only_models": [
-    "ollama:qwen3.5:35b-a3b-coding-nvfp4",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "keeper_unified_models": [
-    "glm:auto",
-    "ollama:qwen3.5:35b-a3b-coding-nvfp4",
+    "glm:glm-4.7-flashx",
+    "glm:glm-5.1",
+    "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "GLM first for keeper_unified. local_only = 35B-A3B coding first, general fallback. 27B replaced by 35B-A3B (MoE, 3B active).",
+  "_comment": "Speed-first GLM cascade: flashx(5s) -> 5.1(17s) -> 5-turbo(27s) -> local fallback. local_only = Ollama 35B-A3B only.",
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,

--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.118.0))
+  (agent_sdk (>= 0.118.2))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -14,16 +14,45 @@ let default_config_path () : string option =
   Config_dir_resolver.log_warnings ~context:"OasWorker" ();
   Config_dir_resolver.cascade_path_opt ()
 
+(** True when cascade_name implies local-only routing (e.g. "local_only").
+    Convention: any name containing "local" restricts defaults to
+    self-hosted providers so that cloud models never leak in via fallback. *)
+let is_local_only_cascade name =
+  let lc = String.lowercase_ascii name in
+  let rec contains s i =
+    let slen = String.length s in
+    let plen = 5 (* "local" *) in
+    if i > slen - plen then false
+    else if String.sub s i plen = "local" then true
+    else contains s (i + 1)
+  in
+  contains lc 0
+
+let is_local_label label =
+  match Oas_model_resolve.provider_name_of_label label with
+  | Some pname -> Provider_adapter.is_local_provider pname
+  | None -> true
+
 (** Hardcoded fallback defaults — used only when cascade.json is missing
     and the cascade name has no "{name}_models" entry.
+    When cascade_name contains "local", only self-hosted providers are
+    returned to prevent cloud models from leaking into local-only cascades.
     All profiles are now in config/cascade.json (hot-reloadable). *)
-let default_model_strings ~cascade_name:_ =
-  match Provider_adapter.explicit_llama_model_label_result () with
-  | Ok label -> [ label ]
-  | Error _ -> (
-      match Provider_adapter.preferred_execution_model_labels () with
-      | [] -> [ Provider_adapter.default_local_fallback_label () ]
-      | labels -> labels)
+let default_model_strings ~cascade_name =
+  let all_labels =
+    match Provider_adapter.explicit_llama_model_label_result () with
+    | Ok label -> [ label ]
+    | Error _ -> (
+        match Provider_adapter.preferred_execution_model_labels () with
+        | [] -> [ Provider_adapter.default_local_fallback_label () ]
+        | labels -> labels)
+  in
+  if is_local_only_cascade cascade_name then
+    match List.filter is_local_label all_labels with
+    | [] -> [ Provider_adapter.default_local_fallback_label () ]
+    | local -> local
+  else
+    all_labels
 
 (* ================================================================ *)
 (* Named model execution                                            *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -31,7 +31,7 @@ let is_local_only_cascade name =
 let is_local_label label =
   match Oas_model_resolve.provider_name_of_label label with
   | Some pname -> Provider_adapter.is_local_provider pname
-  | None -> true
+  | None -> false
 
 (** Hardcoded fallback defaults — used only when cascade.json is missing
     and the cascade name has no "{name}_models" entry.

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.118.0"}
+  "agent_sdk" {>= "0.118.2"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}


### PR DESCRIPTION
## Summary
- `default_model_strings`가 `cascade_name`을 무시하여 `local_only` cascade에 GLM(클라우드)이 포함되던 버그 수정
- cascade.json: coding 모델 중복 제거, GLM flash/turbo 모델 속도순 추가
- 의존: jeong-sik/oas#757 (Eio.Mutex → Stdlib.Mutex, flash capabilities)

## Test plan
- [x] `dune build --root .` 통과
- [ ] CI 전체 통과
- [ ] keeper sangsu 재시작 → `last_model_used`가 `ollama:*`인지 확인
- [ ] Discord `/keeper-ask` 응답 시간 <10초

🤖 Generated with [Claude Code](https://claude.com/claude-code)