### PR TITLE
feat(keeper): Guard → Thompson bridge (Phase B1)

### DIFF
--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -8,6 +8,11 @@
 
     @since Decision Layer v2 — Phase A2 (#6232) *)
 
+(** Current decision layer level (MASC_DECISION_LAYER_LEVEL, 0-4).
+    Cached at module init — no per-call env lookup.
+    Level 0: off, 1: audit, 2: +guard bridge, 3: +trust, 4: +claim. *)
+val decision_layer_level : unit -> int
+
 (** Whether audit is enabled (MASC_DECISION_LAYER_LEVEL >= 1).
     Cached at module init — no per-call env lookup. *)
 val audit_enabled : unit -> bool

--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -9,7 +9,7 @@
     @since Decision Layer v2 — Phase A2 (#6232) *)
 
 (** Current decision layer level (MASC_DECISION_LAYER_LEVEL, 0-4).
-    Cached at module init — no per-call env lookup.
+    Cached on first call — no per-call env lookup after initialization.
     Level 0: off, 1: audit, 2: +guard bridge, 3: +trust, 4: +claim. *)
 val decision_layer_level : unit -> int
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -444,6 +444,13 @@ let write_heartbeat_snapshot
           };
         })
     in
+    (* B1: Guard → Thompson bridge. When guardrail fires, record a negative
+       signal in Thompson β. Penalty cap 1/cycle is naturally enforced: guard
+       evaluates once per heartbeat call. Gated by MASC_DECISION_LAYER_LEVEL >= 2. *)
+    if auto_rules.guardrail_stop
+       && Keeper_decision_audit.decision_layer_level () >= 2
+    then
+      Thompson_sampling.record_guard_penalty ~agent_name:meta_current.name;
     let snapshot =
       `Assoc
         [ "ts", `String (now_iso ())

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -450,7 +450,10 @@ let write_heartbeat_snapshot
     if auto_rules.guardrail_stop
        && Keeper_decision_audit.decision_layer_level () >= 2
     then
-      Thompson_sampling.record_guard_penalty ~agent_name:meta_current.name;
+      (try Thompson_sampling.record_guard_penalty ~agent_name:meta_current.name
+       with exn ->
+         Log.Keeper.warn "guard→thompson penalty failed for %s: %s"
+           meta_current.name (Printexc.to_string exn));
     let snapshot =
       `Assoc
         [ "ts", `String (now_iso ())

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -371,6 +371,21 @@ let quality_pass_alpha_boost = 0.3
 let quality_warn_beta_nudge  = 0.1
 let quality_fail_beta_penalty = 0.5
 
+(** Guard penalty β nudge: same magnitude as quality_fail.
+    Configurable via MASC_GUARD_PENALTY_BETA for B-SIM calibration.
+    Default 0.5 is a conservative pre-calibration estimate. *)
+let guard_penalty_beta_nudge =
+  Env_config_core.get_float ~default:0.5 "MASC_GUARD_PENALTY_BETA"
+
+(** Record a guard penalty (Guardrail_stop) into Thompson β.
+    Phase B1: Guard → Thompson bridge.
+    Penalty cap (1/cycle) is enforced by the caller. *)
+let record_guard_penalty ~agent_name =
+  let s = get_stats agent_name in
+  s.beta <- s.beta +. guard_penalty_beta_nudge;
+  s.beta <- Float.max min_prior s.beta;
+  s.updated_at <- Time_compat.now ()
+
 (** Record Post Verifier result into Thompson Sampling priors. *)
 let record_quality_signal ~agent_name ~(verdict : Post_verifier.verdict) =
   let s = get_stats agent_name in

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -375,7 +375,7 @@ let quality_fail_beta_penalty = 0.5
     Configurable via MASC_GUARD_PENALTY_BETA for B-SIM calibration.
     Default 0.5 is a conservative pre-calibration estimate. *)
 let guard_penalty_beta_nudge =
-  Env_config_core.get_float ~default:0.5 "MASC_GUARD_PENALTY_BETA"
+  Float.max 0.0 (Env_config_core.get_float ~default:0.5 "MASC_GUARD_PENALTY_BETA")
 
 (** Record a guard penalty (Guardrail_stop) into Thompson β.
     Phase B1: Guard → Thompson bridge.

--- a/lib/thompson_sampling.mli
+++ b/lib/thompson_sampling.mli
@@ -118,6 +118,13 @@ val record_quality_signal :
   verdict:Post_verifier.verdict ->
   unit
 
+(** Record a guard penalty into Thompson β.
+    Called when Guardrail_stop fires during a heartbeat cycle.
+    Capped at 1 per heartbeat cycle by the caller (keeper_keepalive.ml).
+    Default β nudge: 0.5 (configurable via MASC_GUARD_PENALTY_BETA).
+    Part of Phase B1: Guard → Thompson bridge. *)
+val record_guard_penalty : agent_name:string -> unit
+
 (** {1 Persistence} *)
 
 (** Load stats from persistent storage (.masc/autonomy_stats.jsonl) *)


### PR DESCRIPTION
## Summary
- Guardrail_stop 발생 시 Thompson β에 negative signal 기록
- Guard → Thompson → ToolPolicy 피드백 루프의 첫 구현 단계
- `MASC_DECISION_LAYER_LEVEL >= 2`에서만 활성화 (Level 1은 audit만)

## Changes
| File | Change |
|------|--------|
| `lib/thompson_sampling.ml` | `record_guard_penalty` 추가 (β += 0.5, configurable) |
| `lib/thompson_sampling.mli` | 인터페이스 export |
| `lib/keeper/keeper_keepalive.ml` | heartbeat에서 guardrail_stop 시 bridge 호출 |
| `lib/keeper/keeper_decision_audit.mli` | `decision_layer_level` export |

## Design
- Penalty cap 1/cycle: guard가 heartbeat당 1회만 평가하므로 자연적 보장
- β nudge magnitude: 0.5 (quality_fail과 동등, `MASC_GUARD_PENALTY_BETA`로 조정 가능)
- TLA+ 대응: KeeperDecisionPipeline.tla의 `GuardFires` action

## Context
- Plan: Keeper Decision Layer v2 (Rev.5), Phase B1
- Tracking: #6230
- Depends on: Phase A (#6244 merged), Phase B0 (#6277 merged)
- TLA+ verified: FailingEventuallyRecovers holds with penalty cap + recovery floor

## Test plan
- [x] `dune build` passes
- [ ] CI Build and Test
- [ ] CI TLA+ Model Checking (no spec change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)