### PR TITLE
feat(keeper): keeper_name substitution + error category improvement

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -728,7 +728,7 @@ let keeper_config_json (config : Room.config) (name : string)
           ~goal:m.goal ~short_goal:m.short_goal ~mid_goal:m.mid_goal
           ~long_goal:m.long_goal ~will:m.will
           ~needs:m.needs ~desires:m.desires ~instructions:m.instructions
-          ~persona_extended ()
+          ~persona_extended ~keeper_name:m.name ()
       in
       let prompt =
         `Assoc [

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -374,6 +374,7 @@ let run_turn
       ~desires:meta.desires
       ~instructions:meta.instructions
       ~persona_extended
+      ~keeper_name:meta.name
       ()
   in
   (* 4. Create or restore working context, re-apply current prompt *)

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -213,6 +213,7 @@ val build_keeper_system_prompt :
   desires:string ->
   instructions:string ->
   ?persona_extended:string ->
+  ?keeper_name:string ->
   unit ->
   string
 

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -88,6 +88,7 @@ val build_keeper_system_prompt :
   desires:string ->
   instructions:string ->
   ?persona_extended:string ->
+  ?keeper_name:string ->
   unit ->
   string
 

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -15,7 +15,7 @@ let keeper_constitution () =
 
 let build_keeper_system_prompt
     ~goal ~short_goal ~mid_goal ~long_goal ~will ~needs ~desires
-    ~instructions ?(persona_extended = "") () =
+    ~instructions ?(persona_extended = "") ?(keeper_name = "") () =
   let goal = normalize_goal_horizon_text goal in
   let short_goal, mid_goal, long_goal =
     resolve_goal_horizons ~goal ~short_goal_opt:(Some short_goal)
@@ -42,6 +42,15 @@ let build_keeper_system_prompt
     if s = "" then ""
     else Printf.sprintf "\nCustom instructions:\n%s\n" s
   in
+  let substitute_keeper_name s =
+    if keeper_name = "" then s
+    else
+      let re_curly = Re.(compile (str "{your-name}")) in
+      let re_upper = Re.(compile (str "YOUR_KEEPER_NAME")) in
+      s
+      |> Re.replace_string re_curly ~by:keeper_name
+      |> Re.replace_string re_upper ~by:keeper_name
+  in
   let persona_block =
     let s = String.trim persona_extended in
     if s = "" then ""
@@ -51,7 +60,7 @@ let build_keeper_system_prompt
     [
       persona_block;
       "<world>\n";
-      Prompt_registry.get_prompt Keeper_prompt_names.world;
+      substitute_keeper_name (Prompt_registry.get_prompt Keeper_prompt_names.world);
       "\n</world>\n\
        \n\
        <identity>\n\
@@ -95,7 +104,7 @@ let build_keeper_system_prompt
        - If you can answer from conversation context alone, respond directly.\n\
        \n\
        <capabilities>\n";
-      Prompt_registry.get_prompt Keeper_prompt_names.capabilities;
+      substitute_keeper_name (Prompt_registry.get_prompt Keeper_prompt_names.capabilities);
       "\n</capabilities>\n\
        \n\
        ";

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -6,6 +6,11 @@ open Keeper_types
 
 let contains_ci = String_util.contains_substring_ci
 
+(* Pre-compiled patterns for keeper name substitution in prompt templates.
+   Top-level to avoid re-compilation on every build_keeper_system_prompt call. *)
+let re_keeper_name_curly = Re.(compile (str "{your-name}"))
+let re_keeper_name_upper = Re.(compile (str "YOUR_KEEPER_NAME"))
+
 let exact_direct_mention_present ~(targets : string list) (content : string) :
     bool =
   Mention.any_mentioned ~targets content
@@ -45,11 +50,9 @@ let build_keeper_system_prompt
   let substitute_keeper_name s =
     if keeper_name = "" then s
     else
-      let re_curly = Re.(compile (str "{your-name}")) in
-      let re_upper = Re.(compile (str "YOUR_KEEPER_NAME")) in
       s
-      |> Re.replace_string re_curly ~by:keeper_name
-      |> Re.replace_string re_upper ~by:keeper_name
+      |> Re.replace_string re_keeper_name_curly ~by:keeper_name
+      |> Re.replace_string re_keeper_name_upper ~by:keeper_name
   in
   let persona_block =
     let s = String.trim persona_extended in

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -16,6 +16,7 @@ val build_keeper_system_prompt :
   desires:string ->
   instructions:string ->
   ?persona_extended:string ->
+  ?keeper_name:string ->
   unit ->
   string
 

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -220,6 +220,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             ~desires
             ~instructions
             ~persona_extended
+            ~keeper_name:p.name
             ()
       in
       let ctx0 = Keeper_exec_context.create ~system_prompt ~max_tokens:primary_max_context in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -566,14 +566,18 @@ let append_decision_record
                   let contains needle =
                     string_contains_substring ~needle e_lower
                   in
+                  (* starts_with checks first (more specific), then contains *)
                   if starts_with "invalid request" then "invalid_request"
-                  else if starts_with "network error" || contains "connection_failure"
+                  else if starts_with "network error" then "network_error"
+                  else if starts_with "internal error" then "internal_error"
+                  else if starts_with "input to" then "input_budget_exceeded"
+                  (* contains checks second (broader, order matters) *)
+                  else if contains "turn outcome ambiguous" then "ambiguous_side_effect"
+                  else if contains "connection_failure"
                           || contains "connection refused" then "network_error"
                   else if contains "timeout" || contains "timed out" then "timeout"
-                  else if starts_with "internal error" then "internal_error"
-                  else if starts_with "input to" || contains "context length"
+                  else if contains "context length"
                           || contains "token budget" then "input_budget_exceeded"
-                  else if contains "turn outcome ambiguous" then "ambiguous_side_effect"
                   else "other"
                 | _ -> "unknown"
               in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -559,10 +559,21 @@ let append_decision_record
                 match error with
                 | Some e when String.length e > 0 ->
                   let e_lower = String.lowercase_ascii e in
-                  if String.length e_lower >= 15 && String.sub e_lower 0 15 = "invalid request" then "invalid_request"
-                  else if String.length e_lower >= 13 && String.sub e_lower 0 13 = "network error" then "network_error"
-                  else if String.length e_lower >= 14 && String.sub e_lower 0 14 = "internal error" then "internal_error"
-                  else if String.length e_lower >= 8 && String.sub e_lower 0 8 = "input to" then "input_budget_exceeded"
+                  let starts_with prefix =
+                    String.length e_lower >= String.length prefix
+                    && String.sub e_lower 0 (String.length prefix) = prefix
+                  in
+                  let contains needle =
+                    string_contains_substring ~needle e_lower
+                  in
+                  if starts_with "invalid request" then "invalid_request"
+                  else if starts_with "network error" || contains "connection_failure"
+                          || contains "connection refused" then "network_error"
+                  else if contains "timeout" || contains "timed out" then "timeout"
+                  else if starts_with "internal error" then "internal_error"
+                  else if starts_with "input to" || contains "context length"
+                          || contains "token budget" then "input_budget_exceeded"
+                  else if contains "turn outcome ambiguous" then "ambiguous_side_effect"
                   else "other"
                 | _ -> "unknown"
               in


### PR DESCRIPTION
## Summary

Keeper 에러 감소 Tier 2 — 코드 변경.

### Commit 1: keeper_name template substitution (PR 2-A)
- `build_keeper_system_prompt`에 `~keeper_name` 파라미터 추가
- `keeper.world.md`와 `keeper.capabilities.md`의 `{your-name}` / `YOUR_KEEPER_NAME` 플레이스홀더를 실제 keeper 이름으로 치환
- 27건/일 shell path 에러의 근본 원인(keeper가 자기 이름/경로를 추측)을 해소
- 변경 파일: `keeper_prompt.ml/mli`, `keeper_agent_run.ml`, `keeper_exec_context.mli`, `keeper_execution.mli`

### Commit 2: error_category classification improvement (PR 2-C)
- decision log의 에러 분류를 5→7 카테고리로 확장
- 추가: `timeout` (기존 "other"에 포함), `ambiguous_side_effect` (post-commit failure)
- `connection_failure`, `connection refused`, `context length`, `token budget` 패턴 매칭 추가
- 변경 파일: `keeper_unified_turn.ml`

## Note on PR 2-B
transient network error의 failure counter 제외는 이미 구현되어 있음 (line 1387: `if not is_transient then increment_turn_failures`). 별도 작업 불필요.

## Test plan
- [ ] `dune build` 통과 (우리 파일 에러 0)
- [ ] keeper 실행 시 system prompt에 실제 keeper 이름이 포함되는지 확인
- [ ] decision log에 새 카테고리(timeout, ambiguous_side_effect)가 올바르게 기록되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)