### PR TITLE
feat(keeper): auto-correct common wrong path prefixes

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -169,17 +169,54 @@ let resolve_keeper_shell_write_cwd
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
   | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
 
+(* Common wrong path prefixes that keepers use.
+   Maps wrong prefix → corrected relative path using keeper playground. *)
+let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
+  let playground = Printf.sprintf ".masc/playground/%s" meta.name in
+  let try_strip prefix replacement =
+    let plen = String.length prefix in
+    if String.length raw >= plen
+       && String.sub raw 0 plen = prefix
+    then Some (replacement ^ String.sub raw plen (String.length raw - plen))
+    else None
+  in
+  (* /repos/X → .masc/playground/<name>/repos/X *)
+  match try_strip "/repos/" (playground ^ "/repos/") with
+  | Some _ as r -> r
+  | None ->
+  match try_strip "repos/" (playground ^ "/repos/") with
+  | Some _ as r -> r
+  | None ->
+  match try_strip "playground/" ".masc/playground/" with
+  | Some _ as r -> r
+  | None -> None
+
 let resolve_keeper_shell_read_path
       ~(config : Room.config)
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   =
   let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
+  let resolve_with_autocorrect raw_path_to_resolve =
+    match resolve_keeper_read_path ~config ~meta ~raw_path:raw_path_to_resolve with
+    | Ok _ as ok -> ok
+    | Error original_err ->
+      (* Try auto-correcting common wrong prefixes *)
+      match auto_correct_path ~meta raw_path_to_resolve with
+      | Some corrected ->
+        (match resolve_keeper_read_path ~config ~meta ~raw_path:corrected with
+         | Ok resolved ->
+           Log.Keeper.info "%s: auto-corrected path %S → %S"
+             meta.name raw_path_to_resolve resolved;
+           Ok resolved
+         | Error _ -> Error original_err)
+      | None -> Error original_err
+  in
   match resolve_keeper_shell_read_cwd ~config ~meta ~args with
   | Error _ as err when raw_path = "" -> err
   | Error _ ->
     let fallback_path = if raw_path = "" then "." else raw_path in
-    resolve_keeper_read_path ~config ~meta ~raw_path:fallback_path
+    resolve_with_autocorrect fallback_path
   | Ok cwd ->
     let resolved_raw_path =
       if raw_path = "" then
@@ -189,7 +226,7 @@ let resolve_keeper_shell_read_path
       else
         raw_path
     in
-    resolve_keeper_read_path ~config ~meta ~raw_path:resolved_raw_path
+    resolve_with_autocorrect resolved_raw_path
 
 let handle_keeper_bash
       ~(config : Room.config)


### PR DESCRIPTION
## Summary

Keeper shell 경로 에러 27건/일 감소를 위한 자동 보정.

keeper가 `/repos/X`, `repos/X`, `playground/X` 같은 잘못된 prefix를 사용할 때,
에러를 반환하기 전에 올바른 경로(`.masc/playground/<keeper>/repos/X`)로 자동 보정을 시도.

Samchon harness의 "type coercion" 패턴 적용:
- 잘못된 입력을 거부하지 않고 의도를 추론하여 교정
- 성공한 보정은 로깅하여 빈도 추적 가능

## Changes

`lib/keeper/keeper_exec_shell.ml`:
- `auto_correct_path`: 3가지 wrong prefix 패턴 → playground 경로로 매핑
- `resolve_keeper_shell_read_path`: Error 시 auto_correct_path로 재시도

## Test plan

- [ ] `dune build` 통과
- [ ] keeper가 `/repos/masc-mcp` 요청 시 `.masc/playground/<name>/repos/masc-mcp`로 자동 보정되는지 로그 확인
- [ ] auto-correct 실패 시 원래 에러 메시지가 그대로 반환되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)