### PR TITLE
feat(keeper): wire OAS tool_retry_policy + post_tool_use_failure hook

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1488,11 +1488,18 @@ let run_turn
            ~hooks
            ~context_reducer:reducer
            ~memory
-             (* Keepers rely on turn-level retry (multi-turn loop) rather than
-               per-call retry. Ideally this would be Tool_retry_policy.none, but
-               OAS does not expose a zero-retry variant yet. default_internal
-               (max_retries=1) is acceptable as a minimal fallback. *)
-           ~tool_retry_policy:Oas.Tool_retry_policy.default_internal
+             (* Keepers use turn-level retry for transient errors but benefit
+               from OAS per-call retry for validation errors (malformed tool
+               args). retry_on_validation_error=true lets OAS re-prompt the
+               LLM with structured feedback instead of wasting a full turn.
+               retry_on_recoverable_tool_error remains false — tool-level
+               errors are handled by MASC's consecutive failure guardrail. *)
+           ~tool_retry_policy:{
+             Oas.Tool_retry_policy.max_retries = 2;
+             retry_on_validation_error = true;
+             retry_on_recoverable_tool_error = false;
+             feedback_style = Oas.Tool_retry_policy.Structured_tool_result;
+           }
            ~max_turns
            ~max_idle_turns
            ~temperature

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -547,6 +547,23 @@ let make_hooks
           (!meta_ref).name tool_name error;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
+
+    post_tool_use_failure = Some (function
+      | Agent_sdk.Hooks.PostToolUseFailure { tool_name; error; _ } ->
+        let meta = !meta_ref in
+        Log.Keeper.warn "keeper:%s tool_use_failure: %s — %s"
+          meta.name tool_name error;
+        Heuristic_metrics.record {
+          module_name = "keeper_hooks_oas";
+          site = Printf.sprintf "post_tool_use_failure:%s" tool_name;
+          raw_value = 1.0;
+          threshold = 0.0;
+          triggered = true;
+          provenance = Pipeline_stage "post_tool_use_failure";
+          timestamp = Unix.gettimeofday ();
+        };
+        Agent_sdk.Hooks.Continue
+      | _ -> Agent_sdk.Hooks.Continue);
   }
 
 (** Static introspection of hook slot configuration.

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -555,7 +555,7 @@ let make_hooks
           meta.name tool_name error;
         Heuristic_metrics.record {
           module_name = "keeper_hooks_oas";
-          site = Printf.sprintf "post_tool_use_failure:%s" tool_name;
+          site = "post_tool_use_failure";
           raw_value = 1.0;
           threshold = 0.0;
           triggered = true;
@@ -629,6 +629,13 @@ let hook_introspection_json
       ("on_tool_error", `Assoc [
         ("active", `Bool true);
         ("source", `String "keeper_hooks_oas");
+      ]);
+      ("post_tool_use_failure", `Assoc [
+        ("active", `Bool true);
+        ("source", `String "keeper_hooks_oas");
+        ("effects", `List [
+          `String "heuristic_metrics";
+        ]);
       ]);
     ]);
     ("deny_list", denied_json);

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -112,6 +112,7 @@ let raw_completion ~model_id ~prompt ~max_tokens ~timeout_sec () =
 
 let error_message_of_http_error = function
   | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -120,6 +120,7 @@ let first_endpoint_url endpoints =
 
 let error_message_of_http_error = function
   | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in


### PR DESCRIPTION
## Summary

OAS에 이미 구현된 에러 복구 인프라를 keeper 실행 경로에 배선.

### 1. tool_retry_policy (keeper_agent_run.ml)
- `default_internal` (max_retries=1, 모든 retry off) → `max_retries=2, retry_on_validation_error=true`
- LLM이 잘못된 도구 인자를 보내면 OAS가 Structured_tool_result 피드백으로 재프롬프트
- Samchon harness의 "validate → precise feedback → retry" 패턴

### 2. post_tool_use_failure hook (keeper_hooks_oas.ml)
- 기존: 미연결 (Hooks.empty의 None)
- 추가: 도구 실패 시 로깅 + Heuristic_metrics 기록
- 어떤 도구가 얼마나 실패하는지 사후 분석 가능

## OAS 경계 보존
MASC는 OAS가 제공하는 `Tool_retry_policy.t` 레코드와 `Hooks.PostToolUseFailure` 이벤트만 사용. 새 validation 로직을 MASC에 구현하지 않음.

## Test plan
- [ ] `dune build` 통과
- [ ] keeper turn에서 validation error 발생 시 OAS 내부 retry 동작 확인
- [ ] heuristic_metrics.jsonl에 post_tool_use_failure 이벤트 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)