### PR TITLE
fix(keeper): filter auxiliary JSON from autoboot scan

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1355,12 +1355,21 @@ let read_meta_file_path path : (keeper_meta option, string) result =
          Error e))
 ;;
 
-(** Filter: only plain keeper meta files (e.g. "sangsu.json").
-    Excludes dotted-suffix files like "sangsu.manual_reconcile.json"
-    which are auxiliary data stored in the same directory. *)
+(** Known auxiliary suffixes that share the keepers/ directory.
+    Files matching [<name>.<suffix>.json] are excluded from autoboot scan.
+    Add new suffixes here when introducing new sidecar file types. *)
+let keeper_auxiliary_suffixes = [
+  ".manual_reconcile.json";
+]
+
+(** Filter: only plain keeper meta files (e.g. "sangsu.json", "my.keeper.json").
+    Excludes known auxiliary sidecar files like "sangsu.manual_reconcile.json".
+    Uses an explicit suffix list rather than rejecting all dots in the stem,
+    because [validate_name] allows dots in keeper names. *)
 let is_keeper_meta_file f =
   Filename.check_suffix f ".json"
-  && not (String.contains (Filename.remove_extension f) '.')
+  && not (List.exists (fun suffix -> Filename.check_suffix f suffix)
+            keeper_auxiliary_suffixes)
 
 let keeper_names config =
   let dir = keeper_dir config in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1355,13 +1355,20 @@ let read_meta_file_path path : (keeper_meta option, string) result =
          Error e))
 ;;
 
+(** Filter: only plain keeper meta files (e.g. "sangsu.json").
+    Excludes dotted-suffix files like "sangsu.manual_reconcile.json"
+    which are auxiliary data stored in the same directory. *)
+let is_keeper_meta_file f =
+  Filename.check_suffix f ".json"
+  && not (String.contains (Filename.remove_extension f) '.')
+
 let keeper_names config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with
   | Error _ -> []
   | Ok files ->
     files
-    |> List.filter (fun f -> Filename.check_suffix f ".json")
+    |> List.filter is_keeper_meta_file
     |> List.map Filename.remove_extension
     |> List.filter validate_name
     |> List.sort String.compare


### PR DESCRIPTION
## Summary
- `keeper_names()` 가 `keepers/*.json` 전체를 스캔하면서 `sangsu.manual_reconcile.json` 같은 보조 파일도 keeper meta로 파싱 시도
- 30초마다 반복되는 파싱 에러 + autoboot retry 루프 발생
- `is_keeper_meta_file` 필터 추가: stem에 `.`이 없는 파일만 keeper meta로 인식 (e.g. `sangsu.json` O, `sangsu.manual_reconcile.json` X)

## Root cause
`keeper_manual_reconcile.ml`이 reconcile 결과를 `keepers/<name>.manual_reconcile.json`으로 저장하는데, keeper meta 스캔이 suffix를 구분하지 않음.

## Test plan
- [x] `dune build` clean (기존 Llm_provider 경고는 무관)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)