### PR TITLE
feat(connector): add iMessage channel connector

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -250,6 +250,7 @@ async function refresh() {
 
 const CHANNEL_ICONS: Record<string, string> = {
   discord: '\u{1F3AE}',
+  imessage: '\u{1F4F1}',
   telegram: '\u{2708}',
   slack: '\u{1F4AC}',
   signal: '\u{1F512}',

--- a/lib/channel_gate_imessage_state.ml
+++ b/lib/channel_gate_imessage_state.ml
@@ -1,0 +1,413 @@
+module U = Yojson.Safe.Util
+
+type binding = {
+  channel_id : string;
+  keeper_name : string;
+}
+
+type audit_event = {
+  timestamp : string;
+  action : string;
+  channel_id : string;
+  keeper_name : string;
+  actor_id : string;
+  actor_name : string;
+  previous_keeper : string;
+}
+
+let connector_id = "imessage"
+let display_name = "iMessage"
+let channel = "imessage"
+
+let default_status_path = ".masc/connectors/imessage/status.json"
+let default_binding_store_path = ".masc/connectors/imessage/bindings.json"
+let default_binding_audit_path = ".masc/connectors/imessage/binding_audit.jsonl"
+
+let stale_after_sec () =
+  Env_config_core.get_int ~default:30 "MASC_IMESSAGE_STATUS_STALE_SEC"
+
+let resolve_path raw_path =
+  if Filename.is_relative raw_path then
+    Filename.concat (Env_config_core.base_path ()) raw_path
+  else
+    raw_path
+
+let configured_write_path env_name ~default =
+  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
+  | Some raw -> resolve_path raw
+  | None -> resolve_path default
+
+let configured_read_path env_name ~default =
+  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
+  | Some raw -> resolve_path raw
+  | None -> resolve_path default
+
+let status_path () =
+  configured_read_path "MASC_IMESSAGE_STATUS_PATH" ~default:default_status_path
+
+let status_write_path () =
+  configured_write_path "MASC_IMESSAGE_STATUS_PATH" ~default:default_status_path
+
+let binding_store_path () =
+  configured_write_path "MASC_IMESSAGE_BINDING_STORE_PATH"
+    ~default:default_binding_store_path
+
+let binding_store_read_path () =
+  configured_read_path "MASC_IMESSAGE_BINDING_STORE_PATH"
+    ~default:default_binding_store_path
+
+let binding_audit_path () =
+  configured_write_path "MASC_IMESSAGE_BINDING_AUDIT_PATH"
+    ~default:default_binding_audit_path
+
+let binding_audit_read_path () =
+  configured_read_path "MASC_IMESSAGE_BINDING_AUDIT_PATH"
+    ~default:default_binding_audit_path
+
+let read_json_file_opt path =
+  if not (Sys.file_exists path) then
+    None
+  else
+    try Some (Yojson.Safe.from_file path) with
+    | Sys_error _ | Yojson.Json_error _ -> None
+
+let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
+  match json with
+  | `Assoc items ->
+      items
+      |> List.filter_map (fun (raw_channel_id, raw_keeper_name) ->
+             let channel_id = String.trim raw_channel_id in
+             let keeper_name =
+               match raw_keeper_name with
+               | `String value -> String.trim value
+               | _ -> ""
+             in
+             if channel_id = "" || keeper_name = "" then None
+             else Some ({ channel_id; keeper_name } : binding))
+      |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+  | _ -> []
+
+let read_bindings () : binding list =
+  match read_json_file_opt (binding_store_read_path ()) with
+  | Some json -> normalize_bindings_json json
+  | None -> []
+
+let binding_json (binding : binding) =
+  `Assoc
+    [
+      ("channel_id", `String binding.channel_id);
+      ("keeper_name", `String binding.keeper_name);
+    ]
+
+let save_bindings (bindings : binding list) =
+  let path = binding_store_path () in
+  let normalized =
+    bindings
+    |> List.sort (fun (a : binding) (b : binding) ->
+           String.compare a.channel_id b.channel_id)
+    |> List.fold_left
+         (fun acc (binding : binding) ->
+           (binding.channel_id, `String binding.keeper_name) :: acc)
+         []
+    |> List.rev
+    |> fun items -> `Assoc items
+  in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let tmp = path ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Yojson.Safe.pretty_to_string normalized ^ "\n"));
+  Sys.rename tmp path
+
+let audit_event_json event =
+  `Assoc
+    [
+      ("timestamp", `String event.timestamp);
+      ("action", `String event.action);
+      ("channel_id", `String event.channel_id);
+      ("keeper_name", `String event.keeper_name);
+      ("actor_id", `String event.actor_id);
+      ("actor_name", `String event.actor_name);
+      ("previous_keeper", `String event.previous_keeper);
+    ]
+
+let append_audit_event event =
+  let path = binding_audit_path () in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let oc =
+    open_out_gen [ Open_creat; Open_wronly; Open_append; Open_binary ] 0o644 path
+  in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (Yojson.Safe.to_string (audit_event_json event));
+      output_char oc '\n';
+      flush oc;
+      Unix.fsync (Unix.descr_of_out_channel oc))
+
+let rec drop_left n xs =
+  if n <= 0 then xs
+  else
+    match xs with
+    | [] -> []
+    | _ :: tl -> drop_left (n - 1) tl
+
+let read_recent_audit ~limit =
+  let path = binding_audit_read_path () in
+  if limit <= 0 || not (Sys.file_exists path) then
+    []
+  else
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let rec loop acc =
+          match input_line ic with
+          | line -> loop (line :: acc)
+          | exception End_of_file -> acc
+        in
+        loop []
+        |> List.filter_map (fun line ->
+               let trimmed = String.trim line in
+               if trimmed = "" then None
+               else
+                 try Some (Yojson.Safe.from_string trimmed) with
+                 | Yojson.Json_error _ -> None)
+        |> List.rev
+        |> fun rows ->
+        let total = List.length rows in
+        if total <= limit then List.rev rows
+        else rows |> drop_left (total - limit) |> List.rev)
+
+let string_member json key =
+  json |> U.member key |> U.to_string_option |> Option.value ~default:""
+
+let int_member json key =
+  json |> U.member key |> U.to_int_option |> Option.value ~default:0
+
+let bool_member json key =
+  json |> U.member key |> U.to_bool_option |> Option.value ~default:false
+
+let bool_option_member json key =
+  json |> U.member key |> U.to_bool_option
+
+let stale_of_updated_at updated_at =
+  match Types.parse_iso8601_opt updated_at with
+  | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
+  | None -> true
+
+let connector_state_label ~available ~connected ~stale =
+  if not available then "offline"
+  else if stale then "stale"
+  else if connected then "connected"
+  else "disconnected"
+
+let status_json ?(audit_limit = 10) () =
+  let status_path = status_path () in
+  let live_status = read_json_file_opt status_path in
+  let binding_store_path = binding_store_read_path () in
+  let audit_path = binding_audit_read_path () in
+  let configured_bindings = read_bindings () in
+  let recent_audit = read_recent_audit ~limit:audit_limit in
+  let available = Option.is_some live_status in
+  let updated_at =
+    match live_status with
+    | Some json -> string_member json "updated_at"
+    | None -> ""
+  in
+  let stale = if not available then true else stale_of_updated_at updated_at in
+  let connected =
+    match live_status with
+    | Some json -> bool_member json "connected" && not stale
+    | None -> false
+  in
+  let error = if available then "" else "connector status file not found" in
+  let status_field key f default =
+    match live_status with
+    | Some json -> f json key
+    | None -> default
+  in
+  `Assoc
+    [
+      ("channel", `String channel);
+      ("available", `Bool available);
+      ("connected", `Bool connected);
+      ("stale", `Bool stale);
+      ("stale_after_sec", `Int (stale_after_sec ()));
+      ("status", `String (connector_state_label ~available ~connected ~stale));
+      ("error", `String error);
+      ("status_path", `String status_path);
+      ("binding_store_path", `String binding_store_path);
+      ("audit_path", `String audit_path);
+      ("updated_at", `String updated_at);
+      ("last_message_at", `String (status_field "last_message_at" string_member ""));
+      ("messages_processed", `Int (status_field "messages_processed" int_member 0));
+      ("messages_failed", `Int (status_field "messages_failed" int_member 0));
+      ("cursor_rowid", `Int (status_field "cursor_rowid" int_member 0));
+      ("poll_interval_sec", `Float (status_field "poll_interval_sec" (fun j k -> j |> U.member k |> U.to_float_option |> Option.value ~default:2.0) 2.0));
+      ("gate_base_url", `String (status_field "gate_base_url" string_member ""));
+      ( "gate_healthy",
+        Option.value ~default:`Null
+          (Option.map (fun value -> `Bool value)
+             (match live_status with
+              | Some json -> bool_option_member json "gate_healthy"
+              | None -> None)) );
+      ( "gate_health_checked_at",
+        `String (status_field "gate_health_checked_at" string_member "") );
+      ("pid", `Int (status_field "pid" int_member 0));
+      ("configured_bindings", `List (List.map binding_json configured_bindings));
+      ("recent_audit", `List recent_audit);
+    ]
+
+let list_assoc_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let find_assoc_by_string_field ~field ~value = function
+  | `List rows ->
+      List.find_map
+        (function
+          | (`Assoc _ as row) -> (
+              match list_assoc_field field row with
+              | Some (`String candidate) when String.equal candidate value ->
+                  Some row
+              | _ -> None)
+          | _ -> None)
+        rows
+  | _ -> None
+
+let connector_json ?gate_status_json ?(audit_limit = 10) () =
+  let status = status_json ~audit_limit () in
+  let observed_channel =
+    match gate_status_json with
+    | None -> `Null
+    | Some json -> (
+        match list_assoc_field "channels" json with
+        | Some channels -> (
+            match
+              find_assoc_by_string_field ~field:"channel" ~value:channel channels
+            with
+            | Some row -> row
+            | None -> `Null)
+        | None -> `Null)
+  in
+  `Assoc
+    [
+      ("connector_id", `String connector_id);
+      ("display_name", `String display_name);
+      ("channel", `String channel);
+      ("capabilities", `List [ `String "runtime_status"; `String "bindings"; `String "audit" ]);
+      ("status", `String (string_member status "status"));
+      ("available", `Bool (bool_member status "available"));
+      ("connected", `Bool (bool_member status "connected"));
+      ("stale", `Bool (bool_member status "stale"));
+      ("stale_after_sec", `Int (int_member status "stale_after_sec"));
+      ("error", `String (string_member status "error"));
+      ("updated_at", `String (string_member status "updated_at"));
+      ("last_message_at", `String (string_member status "last_message_at"));
+      ("messages_processed", `Int (int_member status "messages_processed"));
+      ("messages_failed", `Int (int_member status "messages_failed"));
+      ("cursor_rowid", `Int (int_member status "cursor_rowid"));
+      ("poll_interval_sec", status |> U.member "poll_interval_sec");
+      ("gate_base_url", `String (string_member status "gate_base_url"));
+      ( "gate_healthy",
+        Option.value ~default:`Null
+          (Option.map (fun value -> `Bool value)
+             (bool_option_member status "gate_healthy")) );
+      ( "gate_health_checked_at",
+        `String (string_member status "gate_health_checked_at") );
+      ("pid", `Int (int_member status "pid"));
+      ("configured_bindings", status |> U.member "configured_bindings");
+      ("recent_audit", status |> U.member "recent_audit");
+      ("observed_channel", observed_channel);
+    ]
+
+let rollback_bindings original_bindings =
+  try save_bindings original_bindings with
+  | Sys_error _ -> ()
+
+let bind ~channel_id ~keeper_name ~actor_name =
+  let channel_id = String.trim channel_id in
+  let keeper_name = String.trim keeper_name in
+  if channel_id = "" then
+    Error "channel_id is required"
+  else if keeper_name = "" then
+    Error "keeper_name is required"
+  else
+    let original_bindings = read_bindings () in
+    let previous_keeper =
+      original_bindings
+      |> List.find_map (fun (binding : binding) ->
+             if String.equal binding.channel_id channel_id then
+               Some binding.keeper_name
+             else
+               None)
+      |> Option.value ~default:""
+    in
+    let updated_bindings =
+      (({ channel_id; keeper_name } : binding)
+       :: List.filter
+            (fun (binding : binding) ->
+              not (String.equal binding.channel_id channel_id))
+            original_bindings)
+      |> List.sort (fun (a : binding) (b : binding) ->
+             String.compare a.channel_id b.channel_id)
+    in
+    try
+      save_bindings updated_bindings;
+      append_audit_event
+        {
+          timestamp = Server_utils.iso8601_of_unix (Unix.gettimeofday ());
+          action = "bind";
+          channel_id;
+          keeper_name;
+          actor_id = actor_name;
+          actor_name;
+          previous_keeper;
+        };
+      Ok (status_json ())
+    with
+    | Sys_error msg ->
+        rollback_bindings original_bindings;
+        Error msg
+
+let unbind ~channel_id ~actor_name =
+  let channel_id = String.trim channel_id in
+  if channel_id = "" then
+    Error "channel_id is required"
+  else
+    let original_bindings = read_bindings () in
+    match
+      original_bindings
+      |> List.find_opt (fun (binding : binding) ->
+             String.equal binding.channel_id channel_id)
+    with
+    | None -> Error "binding not found"
+    | Some (removed_binding : binding) ->
+        let updated_bindings =
+          List.filter
+            (fun (binding : binding) ->
+              not (String.equal binding.channel_id channel_id))
+            original_bindings
+        in
+        try
+          save_bindings updated_bindings;
+          append_audit_event
+            {
+              timestamp = Server_utils.iso8601_of_unix (Unix.gettimeofday ());
+              action = "unbind";
+              channel_id;
+              keeper_name = removed_binding.keeper_name;
+              actor_id = actor_name;
+              actor_name;
+              previous_keeper = removed_binding.keeper_name;
+            };
+          Ok (status_json ())
+        with
+        | Sys_error msg ->
+            rollback_bindings original_bindings;
+            Error msg

--- a/lib/dune
+++ b/lib/dune
@@ -37,6 +37,7 @@
    channel_gate_connector
    channel_gate_metrics
    channel_gate_discord_state
+  channel_gate_imessage_state
    gate_protocol
    gate_keeper_backend
    command_plane_v2

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -9,6 +9,7 @@ module Http = Http_server_eio
 let make_routes ~port ~host ~sw ~clock =
   (* Register connectors before routes are wired up *)
   Channel_gate_connector.register (module Channel_gate_discord_state);
+  Channel_gate_connector.register (module Channel_gate_imessage_state);
   Http.Router.empty
   |> Server_routes_http_routes_frontend.add_routes ~port ~host
   |> Server_routes_http_routes_room.add_routes

--- a/sidecars/imessage-bot/requirements.txt
+++ b/sidecars/imessage-bot/requirements.txt
@@ -1,0 +1,3 @@
+pydantic>=2.0
+pydantic-settings>=2.0
+httpx>=0.27

--- a/sidecars/imessage-bot/src/__init__.py
+++ b/sidecars/imessage-bot/src/__init__.py
@@ -1,0 +1,1 @@
+"""iMessage Gate Bot -- Channel Gate consumer for MASC."""

--- a/sidecars/imessage-bot/src/__main__.py
+++ b/sidecars/imessage-bot/src/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point: python -m src.bot"""
+from .bot import main
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -75,8 +75,12 @@ class IMessageBot:
             return keeper
         return DEFAULT_KEEPER
 
-    async def _handle_message(self, msg: InboundMessage) -> None:
-        """Process one inbound message: gate dispatch + reply."""
+    async def _handle_message(self, msg: InboundMessage) -> bool:
+        """Process one inbound message: gate dispatch + reply.
+
+        Returns True if the message was processed successfully (or was a
+        benign duplicate), False on gate error (caller should stop batch).
+        """
         keeper = self._resolve_keeper(msg)
         logger.info(
             "Dispatching message from %s (chat=%s) to keeper %s",
@@ -111,24 +115,39 @@ class IMessageBot:
 
         if response.ok:
             self._messages_processed += 1
+        elif response.error == "duplicate message":
+            pass  # expected during at-least-once redelivery
         else:
             self._messages_failed += 1
+            return False
+
         self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
+        return True
 
     async def _poll_once(self) -> None:
-        """Single poll cycle: read new messages and dispatch."""
-        messages = read_new_messages()
+        """Single poll cycle: read new messages and dispatch.
+
+        At-least-once delivery: cursor advances only to the last successfully
+        processed ROWID. On first failure, processing stops and the cursor
+        stays behind so unprocessed messages are re-fetched on restart.
+        """
+        messages = await asyncio.to_thread(read_new_messages)
         if not messages:
             return
-        self._last_cursor_rowid = messages[-1].rowid
+        last_ok_rowid: int | None = None
         for msg in messages:
             try:
-                await self._handle_message(msg)
+                ok = await self._handle_message(msg)
             except Exception as e:
                 logger.error("Error handling message ROWID %d: %s", msg.rowid, e)
                 self._messages_failed += 1
-        # Advance cursor only after all messages are processed (at-least-once).
-        advance_cursor(Path(self.cfg.cursor_path), messages[-1].rowid)
+                break  # stop to keep cursor behind failed message
+            if not ok:
+                break  # gate error -- stop to allow retry on next cycle
+            last_ok_rowid = msg.rowid
+        if last_ok_rowid is not None:
+            advance_cursor(Path(self.cfg.cursor_path), last_ok_rowid)
+        self._last_cursor_rowid = last_ok_rowid or self._last_cursor_rowid
 
     async def _write_status(self) -> None:
         """Persist current status for dashboard consumption."""

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -1,0 +1,230 @@
+"""iMessage Gate Bot -- main event loop.
+
+Polls chat.db for new inbound iMessages, dispatches to MASC gate-backed
+keepers, and sends replies back via AppleScript.
+
+Usage:
+    python -m src.bot
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .config import get_config
+from .gate_client import GateClient, GateResponse
+from .imessage_bridge import InboundMessage, read_new_messages, send_message
+from .status_store import ConnectorRuntimeStatus, StatusStore
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+)
+logger = logging.getLogger("imessage-gate-bot")
+
+# Default keeper for MVP -- all inbound messages go to this keeper.
+# Binding management can be added later following the Discord pattern.
+DEFAULT_KEEPER = os.environ.get("IMESSAGE_DEFAULT_KEEPER", "sangsu")
+
+
+class IMessageBot:
+    """iMessage bot that routes messages to gate-backed keepers."""
+
+    def __init__(self) -> None:
+        self.cfg = get_config()
+        self.gate = GateClient()
+        self.status_store = StatusStore(Path(self.cfg.status_path))
+        self._running = False
+        self._messages_processed = 0
+        self._messages_failed = 0
+        self._last_message_at = ""
+        self._bindings: dict[str, str] = {}  # chat_id -> keeper_name
+
+    def _load_bindings(self) -> None:
+        """Load chat-to-keeper bindings from state file."""
+        path = Path(self.cfg.binding_store_path)
+        if not path.exists():
+            return
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                self._bindings = {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
+                logger.info("Loaded %d binding(s)", len(self._bindings))
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Failed to load bindings: %s", e)
+
+    def _resolve_keeper(self, msg: InboundMessage) -> str:
+        """Resolve which keeper handles a message.
+
+        Binding lookup order:
+        1. chat_identifier exact match
+        2. sender (handle) exact match
+        3. DEFAULT_KEEPER fallback
+        """
+        keeper = self._bindings.get(msg.chat_identifier)
+        if keeper:
+            return keeper
+        keeper = self._bindings.get(msg.sender)
+        if keeper:
+            return keeper
+        return DEFAULT_KEEPER
+
+    async def _handle_message(self, msg: InboundMessage) -> None:
+        """Process one inbound message: gate dispatch + reply."""
+        keeper = self._resolve_keeper(msg)
+        logger.info(
+            "Dispatching message from %s (chat=%s) to keeper %s",
+            msg.sender,
+            msg.chat_identifier,
+            keeper,
+        )
+
+        response = await self.gate.send_message(
+            keeper_name=keeper,
+            content=msg.text,
+            sender=msg.sender,
+            chat_id=msg.room_id,
+            message_rowid=msg.rowid,
+        )
+
+        if response.ok and response.reply:
+            sent = send_message(msg.sender, response.reply)
+            if sent:
+                logger.info(
+                    "Replied to %s (%d chars, keeper=%s, model=%s, %dms)",
+                    msg.sender,
+                    len(response.reply),
+                    response.keeper_name,
+                    response.model_used,
+                    response.duration_ms,
+                )
+            else:
+                logger.error("Failed to send reply to %s via AppleScript", msg.sender)
+        elif response.error and response.error != "duplicate message":
+            logger.warning("Gate error for %s: %s", msg.sender, response.error)
+
+        if response.ok:
+            self._messages_processed += 1
+        else:
+            self._messages_failed += 1
+        self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
+
+    async def _poll_once(self) -> None:
+        """Single poll cycle: read new messages and dispatch."""
+        messages = read_new_messages()
+        for msg in messages:
+            try:
+                await self._handle_message(msg)
+            except Exception as e:
+                logger.error("Error handling message ROWID %d: %s", msg.rowid, e)
+                self._messages_failed += 1
+
+    def _write_status(self) -> None:
+        """Persist current status for dashboard consumption."""
+        gate_healthy: bool | None = None
+        gate_health_checked_at = ""
+        try:
+            # Sync check -- best effort
+            import httpx
+            resp = httpx.get(self.cfg.gate_health_url(), timeout=5.0)
+            gate_healthy = resp.status_code < 400
+            gate_health_checked_at = datetime.now(tz=timezone.utc).isoformat()
+        except Exception:
+            gate_healthy = False
+
+        # Read cursor
+        cursor_rowid = 0
+        cursor_path = Path(self.cfg.cursor_path)
+        if cursor_path.exists():
+            try:
+                data = json.loads(cursor_path.read_text(encoding="utf-8"))
+                cursor_rowid = int(data.get("last_rowid", 0))
+            except Exception:
+                pass
+
+        self.status_store.write(
+            ConnectorRuntimeStatus(
+                updated_at=datetime.now(tz=timezone.utc).isoformat(),
+                connected=True,
+                gate_base_url=self.cfg.gate_base_url,
+                gate_healthy=gate_healthy,
+                gate_health_checked_at=gate_health_checked_at,
+                last_message_at=self._last_message_at,
+                messages_processed=self._messages_processed,
+                messages_failed=self._messages_failed,
+                cursor_rowid=cursor_rowid,
+                chat_db_path=self.cfg.chat_db_path,
+                poll_interval_sec=self.cfg.poll_interval_sec,
+                pid=os.getpid(),
+            )
+        )
+
+    async def run(self) -> None:
+        """Main event loop."""
+        self._running = True
+        self._load_bindings()
+
+        logger.info(
+            "iMessage bot starting (poll=%.1fs, gate=%s, default_keeper=%s)",
+            self.cfg.poll_interval_sec,
+            self.cfg.gate_base_url,
+            DEFAULT_KEEPER,
+        )
+
+        # Initial health check
+        healthy = await self.gate.health_check()
+        if not healthy:
+            logger.warning("Gate health check failed at %s", self.cfg.gate_base_url)
+        else:
+            logger.info("Gate healthy at %s", self.cfg.gate_base_url)
+
+        status_counter = 0
+
+        while self._running:
+            try:
+                await self._poll_once()
+            except Exception as e:
+                logger.error("Poll cycle error: %s", e)
+
+            # Write status every 5 cycles
+            status_counter += 1
+            if status_counter % 5 == 0:
+                try:
+                    self._write_status()
+                except Exception as e:
+                    logger.warning("Status write error: %s", e)
+
+            await asyncio.sleep(self.cfg.poll_interval_sec)
+
+    def stop(self) -> None:
+        """Signal the bot to stop."""
+        self._running = False
+        logger.info("Stop requested")
+
+
+async def main() -> None:
+    bot = IMessageBot()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, bot.stop)
+
+    try:
+        await bot.run()
+    finally:
+        await bot.gate.aclose()
+        bot._write_status()
+        logger.info("iMessage bot stopped (processed=%d, failed=%d)", bot._messages_processed, bot._messages_failed)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from .config import get_config
 from .gate_client import GateClient, GateResponse
-from .imessage_bridge import InboundMessage, read_new_messages, send_message
+from .imessage_bridge import InboundMessage, advance_cursor, read_new_messages, send_message
 from .status_store import ConnectorRuntimeStatus, StatusStore
 
 logging.basicConfig(
@@ -118,14 +118,17 @@ class IMessageBot:
     async def _poll_once(self) -> None:
         """Single poll cycle: read new messages and dispatch."""
         messages = read_new_messages()
-        if messages:
-            self._last_cursor_rowid = messages[-1].rowid
+        if not messages:
+            return
+        self._last_cursor_rowid = messages[-1].rowid
         for msg in messages:
             try:
                 await self._handle_message(msg)
             except Exception as e:
                 logger.error("Error handling message ROWID %d: %s", msg.rowid, e)
                 self._messages_failed += 1
+        # Advance cursor only after all messages are processed (at-least-once).
+        advance_cursor(Path(self.cfg.cursor_path), messages[-1].rowid)
 
     async def _write_status(self) -> None:
         """Persist current status for dashboard consumption."""

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -16,8 +16,6 @@ import os
 import signal
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
-
 from .config import get_config
 from .gate_client import GateClient, GateResponse
 from .imessage_bridge import InboundMessage, read_new_messages, send_message
@@ -46,6 +44,7 @@ class IMessageBot:
         self._messages_failed = 0
         self._last_message_at = ""
         self._bindings: dict[str, str] = {}  # chat_id -> keeper_name
+        self._last_cursor_rowid: int = 0
 
     def _load_bindings(self) -> None:
         """Load chat-to-keeper bindings from state file."""
@@ -119,6 +118,8 @@ class IMessageBot:
     async def _poll_once(self) -> None:
         """Single poll cycle: read new messages and dispatch."""
         messages = read_new_messages()
+        if messages:
+            self._last_cursor_rowid = messages[-1].rowid
         for msg in messages:
             try:
                 await self._handle_message(msg)
@@ -136,16 +137,6 @@ class IMessageBot:
         except Exception:
             gate_healthy = False
 
-        # Read cursor
-        cursor_rowid = 0
-        cursor_path = Path(self.cfg.cursor_path)
-        if cursor_path.exists():
-            try:
-                data = json.loads(cursor_path.read_text(encoding="utf-8"))
-                cursor_rowid = int(data.get("last_rowid", 0))
-            except Exception:
-                pass
-
         self.status_store.write(
             ConnectorRuntimeStatus(
                 updated_at=datetime.now(tz=timezone.utc).isoformat(),
@@ -156,7 +147,7 @@ class IMessageBot:
                 last_message_at=self._last_message_at,
                 messages_processed=self._messages_processed,
                 messages_failed=self._messages_failed,
-                cursor_rowid=cursor_rowid,
+                cursor_rowid=self._last_cursor_rowid,
                 chat_db_path=self.cfg.chat_db_path,
                 poll_interval_sec=self.cfg.poll_interval_sec,
                 pid=os.getpid(),

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -14,8 +14,6 @@ import json
 import logging
 import os
 import signal
-import sys
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -128,15 +126,12 @@ class IMessageBot:
                 logger.error("Error handling message ROWID %d: %s", msg.rowid, e)
                 self._messages_failed += 1
 
-    def _write_status(self) -> None:
+    async def _write_status(self) -> None:
         """Persist current status for dashboard consumption."""
         gate_healthy: bool | None = None
         gate_health_checked_at = ""
         try:
-            # Sync check -- best effort
-            import httpx
-            resp = httpx.get(self.cfg.gate_health_url(), timeout=5.0)
-            gate_healthy = resp.status_code < 400
+            gate_healthy = await self.gate.health_check()
             gate_health_checked_at = datetime.now(tz=timezone.utc).isoformat()
         except Exception:
             gate_healthy = False
@@ -195,13 +190,18 @@ class IMessageBot:
             except Exception as e:
                 logger.error("Poll cycle error: %s", e)
 
-            # Write status every 5 cycles
             status_counter += 1
+
+            # Write status every 5 cycles
             if status_counter % 5 == 0:
                 try:
-                    self._write_status()
+                    await self._write_status()
                 except Exception as e:
                     logger.warning("Status write error: %s", e)
+
+            # Reload bindings every 50 cycles (~100s at default 2s interval)
+            if status_counter % 50 == 0:
+                self._load_bindings()
 
             await asyncio.sleep(self.cfg.poll_interval_sec)
 
@@ -222,7 +222,7 @@ async def main() -> None:
         await bot.run()
     finally:
         await bot.gate.aclose()
-        bot._write_status()
+        await bot._write_status()
         logger.info("iMessage bot stopped (processed=%d, failed=%d)", bot._messages_processed, bot._messages_failed)
 
 

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import ipaddress
 import os
-from pathlib import Path
 from typing import Final
 from urllib.parse import urlparse
 
@@ -59,7 +58,6 @@ class BotConfig(BaseSettings):
 
     # Gate HTTP
     gate_timeout_sec: float = Field(default=30.0)
-    gate_max_retries: int = Field(default=1)
     gate_breaker_failure_threshold: int = Field(default=5)
     gate_breaker_reset_sec: int = Field(default=60)
 

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -1,0 +1,119 @@
+"""Configuration for iMessage Gate Bot.
+
+Loads and validates all required environment variables.
+Fails fast at startup if any required config is missing.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from pathlib import Path
+from typing import Final
+from urllib.parse import urlparse
+
+from pydantic import AliasChoices, Field, field_validator
+from pydantic_settings import BaseSettings
+
+DEFAULT_STATE_DIR: Final[str] = ".masc/connectors/imessage"
+DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/imessage/bindings.json"
+DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/imessage/binding_audit.jsonl"
+DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/imessage/status.json"
+DEFAULT_CURSOR_PATH: Final[str] = ".masc/connectors/imessage/cursor.json"
+CHAT_DB_PATH: Final[str] = os.path.expanduser("~/Library/Messages/chat.db")
+
+
+def _is_loopback_host(raw_host: str | None) -> bool:
+    if raw_host is None:
+        return False
+    host = raw_host.strip().lower()
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+class BotConfig(BaseSettings):
+    """Bot configuration from environment variables."""
+
+    model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
+
+    # Gate connection
+    gate_base_url: str = Field(
+        default="http://127.0.0.1:8935",
+        validation_alias=AliasChoices("MASC_GATE_URL", "gate_base_url"),
+    )
+    gate_api_token: str = Field(
+        default="",
+        validation_alias=AliasChoices("MASC_GATE_API_TOKEN", "gate_api_token"),
+    )
+
+    # Polling
+    poll_interval_sec: float = Field(
+        default=2.0,
+        validation_alias=AliasChoices("IMESSAGE_POLL_INTERVAL", "poll_interval_sec"),
+        description="Seconds between chat.db polls for new messages.",
+    )
+
+    # Gate HTTP
+    gate_timeout_sec: float = Field(default=30.0)
+    gate_max_retries: int = Field(default=1)
+    gate_breaker_failure_threshold: int = Field(default=5)
+    gate_breaker_reset_sec: int = Field(default=60)
+
+    # Cache
+    status_cache_ttl_sec: int = Field(default=10)
+    keeper_cache_ttl_sec: int = Field(default=30)
+
+    # State paths
+    state_dir: str = Field(default=DEFAULT_STATE_DIR)
+    binding_store_path: str = Field(default=DEFAULT_BINDING_STORE_PATH)
+    binding_audit_path: str = Field(default=DEFAULT_BINDING_AUDIT_PATH)
+    status_path: str = Field(default=DEFAULT_STATUS_PATH)
+    cursor_path: str = Field(default=DEFAULT_CURSOR_PATH)
+
+    # chat.db
+    chat_db_path: str = Field(default=CHAT_DB_PATH)
+
+    @field_validator("gate_base_url")
+    @classmethod
+    def validate_gate_url(cls, v: str) -> str:
+        parsed = urlparse(v)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"gate_base_url must be http(s), got {parsed.scheme}")
+        if not parsed.hostname:
+            raise ValueError("gate_base_url must have a hostname")
+        return v.rstrip("/")
+
+    @field_validator("poll_interval_sec")
+    @classmethod
+    def validate_poll_interval(cls, v: float) -> float:
+        if v < 0.5:
+            raise ValueError("poll_interval_sec must be >= 0.5")
+        return v
+
+    def gate_message_url(self) -> str:
+        return f"{self.gate_base_url}/api/v1/gate/message"
+
+    def gate_health_url(self) -> str:
+        return f"{self.gate_base_url}/api/v1/gate/health"
+
+    def gate_origin(self) -> str:
+        parsed = urlparse(self.gate_base_url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    def is_loopback(self) -> bool:
+        parsed = urlparse(self.gate_base_url)
+        return _is_loopback_host(parsed.hostname)
+
+
+_config: BotConfig | None = None
+
+
+def get_config() -> BotConfig:
+    global _config
+    if _config is None:
+        _config = BotConfig()
+    return _config

--- a/sidecars/imessage-bot/src/gate_client.py
+++ b/sidecars/imessage-bot/src/gate_client.py
@@ -179,9 +179,9 @@ class GateClient:
         except httpx.TimeoutException:
             self._note_failure(f"timeout after {self._timeout}s")
             return GateResponse.from_error(f"timeout after {self._timeout}s")
-        except httpx.HTTPError as e:
-            self._note_failure(f"http error: {e}")
-            return GateResponse.from_error(f"http error: {e}")
+        except httpx.HTTPError:
+            self._note_failure("http request failed")
+            return GateResponse.from_error("http request failed")
 
     async def health_check(self) -> bool:
         if self._breaker_is_open():

--- a/sidecars/imessage-bot/src/gate_client.py
+++ b/sidecars/imessage-bot/src/gate_client.py
@@ -90,6 +90,10 @@ class GateClient:
         if cfg.gate_api_token:
             headers["Authorization"] = f"Bearer {cfg.gate_api_token}"
         else:
+            logger.warning(
+                "gate_api_token not set; using Origin header fallback. "
+                "Set MASC_GATE_API_TOKEN if the gate requires authentication."
+            )
             headers["Origin"] = cfg.gate_origin()
         return headers
 

--- a/sidecars/imessage-bot/src/gate_client.py
+++ b/sidecars/imessage-bot/src/gate_client.py
@@ -1,0 +1,214 @@
+"""HTTP client for the Channel Gate API.
+
+Adapted from discord-bot/src/gate_client.py for iMessage connector.
+The gate API is connector-agnostic; only the context payload differs.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, cast
+
+import httpx
+
+from .config import get_config
+
+logger = logging.getLogger(__name__)
+
+CONNECTOR_AGENT_NAME = "imessage-gate-bot"
+
+
+@dataclass(frozen=True, slots=True)
+class GateResponse:
+    """Parsed response from POST /api/v1/gate/message."""
+
+    ok: bool
+    keeper_name: str
+    reply: str
+    model_used: str
+    duration_ms: int
+    tokens_used: int
+    error: str
+    structured: dict[str, Any] | None
+
+    @staticmethod
+    def from_json(data: dict[str, Any]) -> GateResponse:
+        raw_stats = data.get("turn_stats")
+        stats = cast(dict[str, Any], raw_stats) if isinstance(raw_stats, dict) else {}
+        raw_structured = data.get("structured")
+        structured = cast(dict[str, Any], raw_structured) if isinstance(raw_structured, dict) else None
+        return GateResponse(
+            ok=bool(data.get("ok", False)),
+            keeper_name=str(data.get("keeper_name", "")),
+            reply=str(data.get("reply", "")),
+            model_used=str(stats.get("model_used", "")),
+            duration_ms=int(stats.get("duration_ms", 0)),
+            tokens_used=int(stats.get("tokens_used", 0)),
+            error=str(data.get("error", "")),
+            structured=structured,
+        )
+
+    @staticmethod
+    def from_error(msg: str) -> GateResponse:
+        return GateResponse(
+            ok=False,
+            keeper_name="",
+            reply="",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error=msg,
+            structured=None,
+        )
+
+
+class GateClient:
+    """HTTP client for the Channel Gate API."""
+
+    def __init__(self) -> None:
+        cfg = get_config()
+        base = cfg.gate_base_url.rstrip("/")
+        self._url = cfg.gate_message_url()
+        self._health_url = cfg.gate_health_url()
+        self._keepers_url = f"{base}/api/v1/gate/keepers"
+        self._timeout = cfg.gate_timeout_sec
+        self._breaker_failure_threshold = cfg.gate_breaker_failure_threshold
+        self._breaker_reset_sec = cfg.gate_breaker_reset_sec
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+        self._last_failure = ""
+        self._headers = self._build_headers(cfg)
+        self._client: httpx.AsyncClient | None = None
+
+    def _build_headers(self, cfg: Any) -> dict[str, str]:
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "X-Gate-Agent": CONNECTOR_AGENT_NAME,
+        }
+        if cfg.gate_api_token:
+            headers["Authorization"] = f"Bearer {cfg.gate_api_token}"
+        else:
+            headers["Origin"] = cfg.gate_origin()
+        return headers
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _breaker_is_open(self) -> bool:
+        return self._breaker_open_until > self._now()
+
+    def _note_success(self) -> None:
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    def _note_failure(self, reason: str) -> None:
+        self._consecutive_failures += 1
+        self._last_failure = reason
+        if (
+            self._breaker_failure_threshold > 0
+            and self._consecutive_failures >= self._breaker_failure_threshold
+        ):
+            self._breaker_open_until = self._now() + self._breaker_reset_sec
+        logger.warning("Gate failure %d: %s", self._consecutive_failures, reason)
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=self._timeout, headers=self._headers)
+        return self._client
+
+    async def aclose(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    def _imessage_context(
+        self,
+        *,
+        sender: str,
+        chat_id: str,
+    ) -> dict[str, str]:
+        return {
+            "channel": "imessage",
+            "channel_user_id": sender,
+            "channel_user_name": sender,
+            "channel_room_id": chat_id,
+        }
+
+    async def send_message(
+        self,
+        *,
+        keeper_name: str,
+        content: str,
+        sender: str,
+        chat_id: str,
+        message_rowid: int,
+    ) -> GateResponse:
+        """Send a message to a keeper via the gate."""
+        if self._breaker_is_open():
+            remaining = max(1, int(round(self._breaker_open_until - self._now())))
+            return GateResponse.from_error(f"circuit open for {remaining}s")
+
+        payload = {
+            **self._imessage_context(sender=sender, chat_id=chat_id),
+            "keeper_name": keeper_name,
+            "content": content,
+            "idempotency_key": f"imessage-msg-{message_rowid}",
+        }
+
+        client = self._get_client()
+        try:
+            resp = await client.post(self._url, json=payload)
+            if resp.status_code == 409:
+                self._note_success()
+                return GateResponse.from_error("duplicate message")
+
+            if resp.status_code >= 500:
+                self._note_failure(f"gate returned {resp.status_code}")
+                return GateResponse.from_error(f"gate returned {resp.status_code}")
+
+            raw_data = resp.json()
+            if not isinstance(raw_data, dict):
+                self._note_success()
+                return GateResponse.from_error("gate returned invalid json")
+
+            self._note_success()
+            return GateResponse.from_json(cast(dict[str, Any], raw_data))
+
+        except httpx.TimeoutException:
+            self._note_failure(f"timeout after {self._timeout}s")
+            return GateResponse.from_error(f"timeout after {self._timeout}s")
+        except httpx.HTTPError as e:
+            self._note_failure(f"http error: {e}")
+            return GateResponse.from_error(f"http error: {e}")
+
+    async def health_check(self) -> bool:
+        if self._breaker_is_open():
+            return False
+        client = self._get_client()
+        try:
+            resp = await client.get(self._health_url)
+            return resp.status_code < 400
+        except Exception:
+            return False
+
+    async def list_keepers(self) -> list[str]:
+        client = self._get_client()
+        try:
+            resp = await client.get(self._keepers_url, params={"limit": "200"})
+            if resp.status_code >= 400:
+                return []
+            data = resp.json()
+            rows = data.get("keepers", [])
+            names: list[str] = []
+            for item in rows if isinstance(rows, list) else []:
+                if isinstance(item, dict):
+                    name = item.get("name")
+                    if isinstance(name, str) and name.strip():
+                        names.append(name.strip())
+                elif isinstance(item, str) and item.strip():
+                    names.append(item.strip())
+            return names
+        except Exception:
+            return []

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -89,8 +89,12 @@ def _read_cursor(path: Path) -> int:
         return 0
 
 
-def _write_cursor(path: Path, rowid: int) -> None:
-    """Persist last seen ROWID atomically."""
+def advance_cursor(path: Path, rowid: int) -> None:
+    """Persist last seen ROWID atomically.
+
+    Call after messages are successfully processed to ensure
+    at-least-once delivery: unprocessed messages are re-fetched on restart.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.tmp")
     try:
@@ -142,8 +146,7 @@ def read_new_messages() -> list[InboundMessage]:
                 )
                 messages.append(msg)
             if messages:
-                _write_cursor(cursor_path, messages[-1].rowid)
-                logger.info("Read %d new message(s), cursor now at ROWID %d", len(messages), messages[-1].rowid)
+                logger.info("Read %d new message(s) up to ROWID %d", len(messages), messages[-1].rowid)
         finally:
             conn.close()
     except sqlite3.OperationalError as e:
@@ -163,6 +166,9 @@ def read_new_messages() -> list[InboundMessage]:
 def send_message(recipient: str, text: str) -> bool:
     """Send an iMessage via AppleScript.
 
+    Uses ``on run argv`` to pass parameters as native AppleScript text
+    objects, eliminating string-literal injection risks entirely.
+
     Args:
         recipient: Phone number or Apple ID email.
         text: Message body.
@@ -170,21 +176,18 @@ def send_message(recipient: str, text: str) -> bool:
     Returns:
         True if AppleScript executed without error.
     """
-    # Escape special characters for AppleScript string literals.
-    # AppleScript does not support literal newlines in "..." strings.
-    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
-    escaped_recipient = recipient.replace("\\", "\\\\").replace('"', '\\"')
-
     script = (
-        f'tell application "Messages"\n'
-        f'  set targetBuddy to participant "{escaped_recipient}" of account 1\n'
-        f'  send "{escaped_text}" to targetBuddy\n'
-        f'end tell'
+        'on run argv\n'
+        '  tell application "Messages"\n'
+        '    set theBuddy to participant (item 1 of argv) of account 1\n'
+        '    send (item 2 of argv) to theBuddy\n'
+        '  end tell\n'
+        'end run'
     )
 
     try:
         result = subprocess.run(
-            ["osascript", "-e", script],
+            ["osascript", "-e", script, recipient, text],
             capture_output=True,
             text=True,
             timeout=15,

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -1,0 +1,200 @@
+"""iMessage bridge -- read chat.db, send via AppleScript.
+
+Apple's Messages.app stores messages in ~/Library/Messages/chat.db (SQLite).
+The date column uses Apple Core Data epoch (2001-01-01 00:00:00 UTC) in nanoseconds.
+
+This module provides:
+- read_new_messages(): poll for inbound messages since last cursor
+- send_message(): send a text via AppleScript osascript
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final
+
+from .config import get_config
+
+logger = logging.getLogger(__name__)
+
+APPLE_EPOCH = datetime(2001, 1, 1, tzinfo=timezone.utc)
+POLL_QUERY: Final[str] = """
+SELECT
+    m.ROWID,
+    m.text,
+    m.date,
+    m.is_from_me,
+    m.service,
+    h.id AS handle_id,
+    h.service AS handle_service,
+    c.chat_identifier,
+    c.display_name
+FROM message m
+LEFT JOIN handle h ON m.handle_id = h.ROWID
+LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+LEFT JOIN chat c ON cmj.chat_id = c.ROWID
+WHERE m.ROWID > ?
+  AND m.is_from_me = 0
+  AND m.text IS NOT NULL
+  AND m.text != ''
+  AND m.service = 'iMessage'
+ORDER BY m.ROWID ASC
+LIMIT 100
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class InboundMessage:
+    """A single inbound iMessage."""
+
+    rowid: int
+    text: str
+    date: datetime
+    service: str
+    sender: str  # phone number or email
+    chat_identifier: str
+    display_name: str
+
+    @property
+    def room_id(self) -> str:
+        """Use chat_identifier as room ID for gate routing."""
+        return self.chat_identifier or self.sender
+
+
+def _apple_date_to_datetime(apple_ns: int) -> datetime:
+    """Convert Apple Core Data timestamp (nanoseconds since 2001-01-01) to datetime."""
+    seconds = apple_ns / 1_000_000_000
+    return datetime.fromtimestamp(
+        (APPLE_EPOCH.timestamp() + seconds),
+        tz=timezone.utc,
+    )
+
+
+def _read_cursor(path: Path) -> int:
+    """Read last seen ROWID from cursor file. Returns 0 if not found."""
+    if not path.exists():
+        return 0
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return int(data.get("last_rowid", 0))
+    except (json.JSONDecodeError, OSError, ValueError):
+        logger.warning("Failed to read cursor from %s, starting from 0", path)
+        return 0
+
+
+def _write_cursor(path: Path, rowid: int) -> None:
+    """Persist last seen ROWID atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp.write_text(
+            json.dumps({"last_rowid": rowid, "updated_at": datetime.now(tz=timezone.utc).isoformat()}, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def read_new_messages() -> list[InboundMessage]:
+    """Poll chat.db for new inbound messages since last cursor.
+
+    Requires Full Disk Access for the calling process.
+    Returns messages ordered by ROWID ascending.
+    """
+    cfg = get_config()
+    db_path = Path(cfg.chat_db_path)
+    cursor_path = Path(cfg.cursor_path)
+
+    if not db_path.exists():
+        logger.error("chat.db not found at %s", db_path)
+        return []
+
+    last_rowid = _read_cursor(cursor_path)
+    messages: list[InboundMessage] = []
+
+    try:
+        # chat.db is WAL-mode; open read-only to avoid locking issues
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(POLL_QUERY, (last_rowid,)).fetchall()
+            for row in rows:
+                msg = InboundMessage(
+                    rowid=row["ROWID"],
+                    text=row["text"],
+                    date=_apple_date_to_datetime(row["date"]),
+                    service=row["service"] or "iMessage",
+                    sender=row["handle_id"] or "unknown",
+                    chat_identifier=row["chat_identifier"] or "",
+                    display_name=row["display_name"] or "",
+                )
+                messages.append(msg)
+            if messages:
+                _write_cursor(cursor_path, messages[-1].rowid)
+                logger.info("Read %d new message(s), cursor now at ROWID %d", len(messages), messages[-1].rowid)
+        finally:
+            conn.close()
+    except sqlite3.OperationalError as e:
+        if "authorization denied" in str(e).lower():
+            logger.error(
+                "chat.db access denied. Grant Full Disk Access to the terminal app: "
+                "System Settings > Privacy & Security > Full Disk Access"
+            )
+        else:
+            logger.error("chat.db read error: %s", e)
+    except Exception as e:
+        logger.error("Unexpected error reading chat.db: %s", e)
+
+    return messages
+
+
+def send_message(recipient: str, text: str) -> bool:
+    """Send an iMessage via AppleScript.
+
+    Args:
+        recipient: Phone number or Apple ID email.
+        text: Message body.
+
+    Returns:
+        True if AppleScript executed without error.
+    """
+    # Escape special characters for AppleScript string literals
+    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"')
+    escaped_recipient = recipient.replace("\\", "\\\\").replace('"', '\\"')
+
+    script = (
+        f'tell application "Messages"\n'
+        f'  set targetBuddy to participant "{escaped_recipient}" of account 1\n'
+        f'  send "{escaped_text}" to targetBuddy\n'
+        f'end tell'
+    )
+
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            logger.error("AppleScript send failed (rc=%d): %s", result.returncode, result.stderr.strip())
+            return False
+        return True
+    except subprocess.TimeoutExpired:
+        logger.error("AppleScript send timed out for %s", recipient)
+        return False
+    except Exception as e:
+        logger.error("AppleScript send error: %s", e)
+        return False

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 APPLE_EPOCH = datetime(2001, 1, 1, tzinfo=timezone.utc)
 POLL_QUERY: Final[str] = """
-SELECT
+SELECT DISTINCT
     m.ROWID,
     m.text,
     m.date,
@@ -170,8 +170,9 @@ def send_message(recipient: str, text: str) -> bool:
     Returns:
         True if AppleScript executed without error.
     """
-    # Escape special characters for AppleScript string literals
-    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"')
+    # Escape special characters for AppleScript string literals.
+    # AppleScript does not support literal newlines in "..." strings.
+    escaped_text = text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "")
     escaped_recipient = recipient.replace("\\", "\\\\").replace('"', '\\"')
 
     script = (

--- a/sidecars/imessage-bot/src/status_store.py
+++ b/sidecars/imessage-bot/src/status_store.py
@@ -6,9 +6,6 @@ import json
 import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
-
-
 @dataclass(frozen=True, slots=True)
 class ConnectorRuntimeStatus:
     """One connector runtime snapshot for dashboard consumption."""

--- a/sidecars/imessage-bot/src/status_store.py
+++ b/sidecars/imessage-bot/src/status_store.py
@@ -1,0 +1,48 @@
+"""Durable runtime status store for the iMessage connector."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorRuntimeStatus:
+    """One connector runtime snapshot for dashboard consumption."""
+
+    updated_at: str
+    connected: bool
+    gate_base_url: str
+    gate_healthy: bool | None
+    gate_health_checked_at: str
+    last_message_at: str
+    messages_processed: int
+    messages_failed: int
+    cursor_rowid: int
+    chat_db_path: str
+    poll_interval_sec: float
+    pid: int
+
+
+class StatusStore:
+    """Persist connector runtime snapshots atomically."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def write(self, status: ConnectorRuntimeStatus) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
+        payload = json.dumps(asdict(status), indent=2, sort_keys=True)
+        try:
+            tmp_path.write_text(f"{payload}\n", encoding="utf-8")
+            os.replace(tmp_path, self.path)
+        except OSError:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise


### PR DESCRIPTION
## Summary
- Add iMessage channel connector implementing `Channel_gate_connector.S` in OCaml
- Add Python sidecar (`sidecars/imessage-bot/`) that polls `~/Library/Messages/chat.db` for inbound messages and dispatches to MASC gate-backed keepers
- Outbound replies via AppleScript (`Messages` app)
- Dashboard icon for iMessage connector status

## Architecture
```
chat.db (Apple SQLite) → imessage_bridge.py (read) → bot.py (poll loop)
  → gate_client.py (HTTP POST /api/v1/gate/message) → MASC Gate
  → response → AppleScript (send reply)
```

## Key Components
- **`lib/channel_gate_imessage_state.ml`** (413 lines) — OCaml connector with binding store, audit trail, status parsing
- **`sidecars/imessage-bot/src/bot.py`** — Main event loop, binding resolution, health check heartbeat
- **`sidecars/imessage-bot/src/imessage_bridge.py`** — chat.db reader (Apple Core Data epoch), AppleScript sender, cursor management
- **`sidecars/imessage-bot/src/gate_client.py`** — HTTP client with circuit breaker pattern
- **`sidecars/imessage-bot/src/config.py`** — Pydantic settings with env var loading

## Test plan
- [ ] Verify `dune build` compiles the new OCaml module
- [ ] Start sidecar with `python -m src.bot` and confirm health check passes
- [ ] Send iMessage to bot account, verify gate dispatch and reply
- [ ] Check `status.json` is written with correct runtime snapshot
- [ ] Verify circuit breaker trips after consecutive gate failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)