### PR TITLE
chore: update OAS pin SHA to v0.118.2

### DIFF
--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -112,6 +112,7 @@ let raw_completion ~model_id ~prompt ~max_tokens ~timeout_sec () =
 
 let error_message_of_http_error = function
   | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -120,6 +120,7 @@ let first_endpoint_url endpoints =
 
 let error_message_of_http_error = function
   | Llm_provider.Http_client.NetworkError { message } -> message
+  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
   | Llm_provider.Http_client.HttpError { code; body } -> (
       try
         let json = Yojson.Safe.from_string body in

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.118.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.118.2"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="120710afaf6188e6b97685b60d3deb2538b00304"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.118.0"
+readonly OAS_AGENT_SDK_SHA="14e169af76f15e0870f263fc2791507ad53c0e4e"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.118.2"


### PR DESCRIPTION
## Summary
- OAS pin SHA를 v0.118.2 (14e169a)로 업데이트
- #6302 머지 시 SHA가 구버전(120710a)을 가리키고 있던 문제 수정
- oas#771 (Stdlib.Mutex + GLM flash capabilities) 반영

## Test plan
- [ ] CI Build and Test 통과 (OAS 0.118.2 resolve 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)