### PR TITLE
fix(discord): strip [STATE] blocks from keeper responses

### DIFF
--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -29,6 +29,7 @@ from .formatters import (
     format_keeper_embed,
     markdown_to_structured,
     render_structured_embeds,
+    strip_state_blocks,
 )
 from .gate_client import BreakerSnapshot, GateClient, GateResponse
 from .status_store import ConnectorRuntimeStatus, StatusStore
@@ -329,7 +330,7 @@ class GateBot(discord.Client):
             if now - last_edit < edit_interval:
                 continue
 
-            display = accumulated[:4000]
+            display = strip_state_blocks(accumulated)[:4000]
             if reply_msg is None:
                 reply_msg = await channel.send(display + " ...")
             else:
@@ -343,7 +344,7 @@ class GateBot(discord.Client):
             return False
 
         # Final edit with complete text
-        display = accumulated[:4000]
+        display = strip_state_blocks(accumulated)[:4000]
         if reply_msg is None:
             await channel.send(display)
         else:
@@ -365,6 +366,18 @@ class GateBot(discord.Client):
             embed = format_error_embed(response.error)
             await channel.send(embed=embed)
             return
+
+        # Strip keeper-internal [STATE] blocks before rendering
+        response = GateResponse(
+            ok=response.ok,
+            keeper_name=response.keeper_name,
+            reply=strip_state_blocks(response.reply),
+            error=response.error,
+            model_used=response.model_used,
+            duration_ms=response.duration_ms,
+            tokens_used=response.tokens_used,
+            structured=response.structured,
+        )
 
         # Try structured rendering (from gate or auto-parsed markdown)
         structured = response.structured or markdown_to_structured(response.reply)
@@ -594,7 +607,7 @@ async def keeper_ask(
         now = time.monotonic()
         if now - last_edit < edit_interval:
             continue
-        display = accumulated[:4000]
+        display = strip_state_blocks(accumulated)[:4000]
         if followup_msg is None:
             followup_msg = await interaction.followup.send(display + " ...", wait=True)
         else:
@@ -605,7 +618,7 @@ async def keeper_ask(
         last_edit = now
 
     if accumulated:
-        display = accumulated[:4000]
+        display = strip_state_blocks(accumulated)[:4000]
         if followup_msg is None:
             await interaction.followup.send(display)
         else:

--- a/sidecars/discord-bot/src/formatters.py
+++ b/sidecars/discord-bot/src/formatters.py
@@ -258,6 +258,16 @@ def format_error_embed(error_msg: str) -> discord.Embed:
     )
 
 
+_RE_STATE_BLOCK = re.compile(
+    r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL
+)
+
+
+def strip_state_blocks(text: str) -> str:
+    """Remove [STATE]...[/STATE] keeper metadata blocks from text."""
+    return _RE_STATE_BLOCK.sub("", text).strip()
+
+
 def compose_gate_content(text: str, attachment_lines: Sequence[str]) -> str:
     """Build deterministic gate content from text + Discord attachments."""
     parts: list[str] = []


### PR DESCRIPTION
## Summary
- keeper 응답의 `[STATE]...[/STATE]` 내부 메타데이터가 Discord에 노출되던 문제 수정
- 스트리밍 경로 (중간 edit + 최종 edit) 양쪽에 strip 적용
- batch 경로 (`_send_response`)에도 strip 적용
- `/keeper-ask` 슬래시 커맨드에도 동일 적용

## Test plan
- [x] `strip_state_blocks` 3가지 케이스 수동 검증 (완전 블록, 닫는 태그 없음, state 없음)
- [ ] Discord에서 `[STATE]` 블록이 더 이상 보이지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)