### PR TITLE
fix(ci): read agent_sdk from active opam switch

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -113,7 +113,7 @@ version_gte() {
 }
 
 if command -v opam >/dev/null 2>&1; then
-  installed_packages="$(opam list --installed --columns=name,version --short 2>/dev/null)"
+  installed_packages="$(opam exec -- opam list --installed --columns=name,version --short 2>/dev/null)"
   installed_version="$(awk '$1 == "agent_sdk" { print $2 }' <<<"${installed_packages}")"
   if [[ -z "${installed_version}" ]]; then
     echo "agent_sdk is not installed in the current opam switch" >&2
@@ -126,7 +126,7 @@ if command -v opam >/dev/null 2>&1; then
     exit 1
   fi
 
-  pin_list_output="$(opam pin list 2>/dev/null || true)"
+  pin_list_output="$(opam exec -- opam pin list 2>/dev/null || true)"
   pin_line="$(awk '$1 ~ /^agent_sdk\./ { print }' <<<"${pin_list_output}")"
   if [[ -n "${pin_line}" ]]; then
     installed_pin_source="$(awk '{print $3}' <<<"${pin_line}")"


### PR DESCRIPTION
## Summary
- run the installed `agent_sdk` checks under `opam exec` so CI reads the active switch, not ambient global state
- keep OAS pin verification behavior unchanged apart from the switch source of truth

## Verification
- bash scripts/check-oas-pin.sh

## Review evidence
- pending GLM-5.1 review

Refs #6295