### PR TITLE
refactor(dashboard): deduplicate utilities and parallelize gate fetches

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -1,5 +1,5 @@
 import { get, post, withRetries, defaultBoardVoter } from './core'
-import { isRecord, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
+import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } from '../components/common/normalize'
 import type {
   BoardPost, BoardComment, BoardSortMode,
   GovernanceCaseBrief, GovernanceCaseBundle, GovernanceContextRef,
@@ -26,12 +26,6 @@ export function asNullableIsoTimestamp(value: unknown): string | null {
     return new Date(ms).toISOString()
   }
   return null
-}
-
-function asNullableString(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
 }
 
 export function normalizePendingConfirmation(raw: unknown): PendingConfirmation | null {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1,6 +1,6 @@
 // MASC Dashboard — Dashboard projections, resource fetchers, tool metrics
 
-import { isRecord, asBoolean, asInt, asNumber, asRecordArray, asString, asStringArray } from '../components/common/normalize'
+import { isRecord, asBoolean, asInt, asNullableString, asNumber, asRecordArray, asString, asStringArray } from '../components/common/normalize'
 import {
   asNullableIsoTimestamp,
   normalizeGovernanceDecisionItem,
@@ -929,11 +929,6 @@ export function clearPromptOverride(key: string): Promise<PromptMutationResponse
   return post('/api/v1/prompts', { action: 'clear', key })
 }
 
-function asNullableString(value: unknown): string | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return trimmed !== '' ? trimmed : null
-}
 
 function asLooseBoolean(value: unknown, fallback = false): boolean {
   const booleanValue = asBoolean(value)

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -929,7 +929,6 @@ export function clearPromptOverride(key: string): Promise<PromptMutationResponse
   return post('/api/v1/prompts', { action: 'clear', key })
 }
 
-
 function asLooseBoolean(value: unknown, fallback = false): boolean {
   const booleanValue = asBoolean(value)
   if (booleanValue !== undefined) return booleanValue

--- a/dashboard/src/api/transport-health.ts
+++ b/dashboard/src/api/transport-health.ts
@@ -222,10 +222,6 @@ export function decodeTransportHealthData(raw: unknown): TransportHealthData | n
   }
 }
 
-export function hydrateTransportHealthData(raw: unknown): TransportHealthData | null {
-  return decodeTransportHealthData(raw)
-}
-
 export async function fetchTransportHealth(opts?: AbortableRequestOptions): Promise<TransportHealthData> {
   const raw = await get<Record<string, unknown>>('/api/v1/dashboard/transport-health', { signal: opts?.signal })
   const decoded = decodeTransportHealthData(raw)

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -15,7 +15,6 @@ import {
   type GateConnectorsData,
   type GateEventInfo,
   type GateKeeperInfo,
-  type GateKeepersData,
   type GateStatusData,
 } from '../api/gate'
 import { formatElapsedCompact, formatTimeAgoEn } from '../lib/format-time'
@@ -68,24 +67,29 @@ async function refresh() {
       keeperError: null,
     }
 
-    try {
-      next.gate = await fetchGateStatus(signal)
-    } catch (error) {
-      next.gateError = error instanceof Error ? error.message : 'fetch failed'
+    const [gateResult, connResult, keeperResult] = await Promise.allSettled([
+      fetchGateStatus(signal),
+      fetchGateConnectors(signal),
+      fetchGateKeepers(signal),
+    ])
+
+    if (gateResult.status === 'fulfilled') {
+      next.gate = gateResult.value
+    } else {
+      next.gateError = gateResult.reason instanceof Error ? gateResult.reason.message : 'fetch failed'
     }
 
-    try {
-      next.connectors = await fetchGateConnectors(signal)
-    } catch (error) {
-      next.connectorError = error instanceof Error ? error.message : 'fetch failed'
+    if (connResult.status === 'fulfilled') {
+      next.connectors = connResult.value
+    } else {
+      next.connectorError = connResult.reason instanceof Error ? connResult.reason.message : 'fetch failed'
     }
 
-    try {
-      const keepersResult: GateKeepersData = await fetchGateKeepers(signal)
-      next.keepers = keepersResult.keepers ?? []
-    } catch (error) {
+    if (keeperResult.status === 'fulfilled') {
+      next.keepers = keeperResult.value.keepers ?? []
+    } else {
       next.keepers = []
-      next.keeperError = error instanceof Error ? error.message : 'fetch failed'
+      next.keeperError = keeperResult.reason instanceof Error ? keeperResult.reason.message : 'fetch failed'
     }
 
     return next
@@ -114,7 +118,6 @@ function channelIcon(ch: string): string {
   return CHANNEL_ICONS[ch] ?? '\u{1F517}'
 }
 
-// Time formatting delegated to lib/format-time (SSOT)
 const formatUptime = formatElapsedCompact
 const timeAgo = formatTimeAgoEn
 

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -15,6 +15,7 @@ import { normalizeKeepers } from '../keeper-store-normalize'
 import { telemetrySourceLabel } from '../config/telemetry-sources'
 import { formatElapsedCompact, formatTimeAgo } from '../lib/format-time'
 import type { Keeper } from '../types'
+import { isAbortError } from '../lib/async-state'
 
 // Fleet-level thresholds (lower than individual keeper thresholds in config/constants)
 // because fleet view highlights keepers that are approaching limits, not yet at them
@@ -72,9 +73,6 @@ function emptyState(): FleetTelemetryState {
   }
 }
 
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError'
-}
 
 // Delegated to config/telemetry-sources (SSOT)
 const sourceLabel = telemetrySourceLabel

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -73,7 +73,6 @@ function emptyState(): FleetTelemetryState {
   }
 }
 
-
 // Delegated to config/telemetry-sources (SSOT)
 const sourceLabel = telemetrySourceLabel
 

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -18,6 +18,7 @@ import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
 import { formatTimeAgo } from '../lib/format-time'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { isAbortError } from '../lib/async-state'
 
 interface StoreSnapshot {
   keepers: number
@@ -126,9 +127,6 @@ function normalizeText(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
 }
 
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError'
-}
 
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '') : []

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -127,7 +127,6 @@ function normalizeText(value: unknown): string | null {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : null
 }
 
-
 function normalizeStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '') : []
 }

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -5,6 +5,7 @@ import { fetchToolQuality, type ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { LoadingState } from './common/feedback-state'
+import { isAbortError } from '../lib/async-state'
 
 interface ToolStat {
   name: string
@@ -46,9 +47,6 @@ type RefreshToolQualityOptions = {
   signal?: AbortSignal
 }
 
-function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === 'AbortError'
-}
 
 function cancelActiveToolQualityRequest() {
   latestRequestId += 1

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -47,7 +47,6 @@ type RefreshToolQualityOptions = {
   signal?: AbortSignal
 }
 
-
 function cancelActiveToolQualityRequest() {
   latestRequestId += 1
   activeController?.abort()

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -105,7 +105,7 @@ async function loadComponentWithApi(api: {
   vi.resetModules()
   vi.doMock('../api/transport-health', () => ({
     fetchTransportHealth: api.fetchTransportHealth,
-    hydrateTransportHealthData: (payload: unknown) => payload,
+    decodeTransportHealthData: (payload: unknown) => payload,
   }))
   vi.doMock('../sse', () => ({
     lastEvent: api.lastEvent,

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -6,7 +6,7 @@ import type { SSEEvent } from '../types'
 import { FetchScheduler } from '../lib/fetch-scheduler'
 import {
   fetchTransportHealth,
-  hydrateTransportHealthData,
+  decodeTransportHealthData,
   type TransportHealthData,
 } from '../api/transport-health'
 import { createManagedAsyncResource } from '../lib/async-state'
@@ -32,7 +32,7 @@ export function resetTransportHealthState(): void {
 
 /** Hydrate transport health from SSE payload — zero HTTP fetch. */
 export function hydrateTransportHealthFromSSE(data: unknown): void {
-  const decoded = hydrateTransportHealthData(data)
+  const decoded = decodeTransportHealthData(data)
   if (!decoded) return
   transportHealthResource.reset(decoded)
 }

--- a/dashboard/src/lib/async-state.ts
+++ b/dashboard/src/lib/async-state.ts
@@ -120,7 +120,7 @@ function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
-function isAbortError(error: unknown): boolean {
+export function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError'
 }
 


### PR DESCRIPTION
## Summary
- Remove private `asNullableString` from `dashboard.ts` — already exported from `normalize.ts`
- Export `isAbortError` from `async-state.ts`, remove 3 identical copies across components
- Remove dead `hydrateTransportHealthData` alias, consumers use `decodeTransportHealthData` directly
- Parallelize 3 independent gate fetches via `Promise.allSettled` (was sequential)
- Remove WHAT comment

## Test plan
- [ ] `pnpm tsc --noEmit` — pass
- [ ] `pnpm lint` — pass
- [ ] `pnpm test` — 449 tests pass
- [ ] `pnpm build` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)