### PR TITLE
[codex] Remove dead local runtime HTTP error branches

### DIFF
--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -123,7 +123,6 @@ let error_message_of_http_error = function
             | _ -> Printf.sprintf "HTTP %d" code)
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
-  | _ -> "Unknown Error"
 
 let per_runtime_breakdown_to_yojson counts =
   counts

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -131,7 +131,6 @@ let error_message_of_http_error = function
             | _ -> Printf.sprintf "HTTP %d" code)
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
-  | _ -> "Unknown Error"
 
 let probe_chat_completion_compatible
     ?(timeout_sec = 5)


### PR DESCRIPTION
## Summary
- remove unreachable fallback branches from `error_message_of_http_error` in local runtime bench and verify tools
- keep the behavior for `NetworkError`, `AcceptRejected`, and `HttpError` unchanged

## Why
`Llm_provider.Http_client` is already exhaustive here, so the `_ -> "Unknown Error"` branch is dead code. With warnings treated as errors, that redundant case blocks `dune build --root .` on `main`.

## Product impact
This is build-only cleanup. Runtime behavior does not change.

## Root cause
The local runtime helpers were updated to handle the current `Http_client` constructors explicitly, but the legacy catch-all branch was left behind. OCaml now reports that branch as redundant (`warning 11`), and this repo treats that warning as an error.

## Evidence
- `bash scripts/check-oas-pin.sh --local-only`
- `DUNE_BUILD_DIR=_build_local_runtime_fix dune build --root . --display short`

## Review evidence
- Reviewer: `sb glm-text` (direct ZAI GLM)
- Timestamp: 2026-04-10 14:52 KST
- Scope: correctness/regressions only for the two-line diff
- Result: `No findings.`

## Linked issue
- Refs #5030
