### PR TITLE
fix: remove redundant match cases in http error handlers

### DIFF
--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -123,7 +123,6 @@ let error_message_of_http_error = function
             | _ -> Printf.sprintf "HTTP %d" code)
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
-  | _ -> "Unknown Error"
 
 let per_runtime_breakdown_to_yojson counts =
   counts

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -131,7 +131,6 @@ let error_message_of_http_error = function
             | _ -> Printf.sprintf "HTTP %d" code)
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
-  | _ -> "Unknown Error"
 
 let probe_chat_completion_compatible
     ?(timeout_sec = 5)


### PR DESCRIPTION
## Summary
- `http_error` type has exactly 3 variants — catch-all wildcard at line 126/134 is unreachable
- OCaml warning 11 (redundant-case) is fatal in CI, blocking Build and Test on all branches
- Removes the dead `| _ -> "Unknown Error"` branch from both `tool_local_runtime_bench.ml` and `tool_local_runtime_verify.ml`

## Test plan
- [ ] CI Build and Test passes without warning 11

Generated with [Claude Code](https://claude.com/claude-code)