### PR TITLE
fix(build): remove dead http error fallback arms

### DIFF
--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -123,7 +123,6 @@ let error_message_of_http_error = function
             | _ -> Printf.sprintf "HTTP %d" code)
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
-  | _ -> "Unknown Error"
 
 let per_runtime_breakdown_to_yojson counts =
   counts

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -131,7 +131,6 @@ let error_message_of_http_error = function
             | _ -> Printf.sprintf "HTTP %d" code)
         | _ -> Printf.sprintf "HTTP %d" code
       with Yojson.Json_error _ -> Printf.sprintf "HTTP %d" code)
-  | _ -> "Unknown Error"
 
 let probe_chat_completion_compatible
     ?(timeout_sec = 5)


### PR DESCRIPTION
## Summary
- remove unreachable `_ -> "Unknown Error"` branches from two closed `http_error` matches
- restore `dune build @install --force` on current `main`

## Root cause
- `Llm_provider.Http_client.http_error` is now exhaustively covered by `NetworkError | AcceptRejected | HttpError`
- the fallback arm became unreachable and `warning 11` is promoted to error in CI

## Verification
- `opam exec -- dune build @install --force --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-main-build --build-dir /tmp/masc-fix-main-build`

Refs main build break after `632b04781d00db2e8441bf5b2d10f61fdfdd52a8`