### PR TITLE
fix(keeper): preserve docker playground safety gates

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -419,6 +419,23 @@ end
     Thresholds used by the dashboard keeper health scorer and harness health
     panels.  Distinct from compaction triggers — these affect UI display only. *)
 
+(** {1 Docker Playground} *)
+
+module DockerPlayground = struct
+  (** Route keeper_bash commands through a Docker container instead of
+      local subprocess.  The container must be running and named
+      [keeper-playground].  When disabled, commands run locally with
+      the existing allowlist restrictions.
+      Env: [MASC_KEEPER_DOCKER_PLAYGROUND]. Default: false. *)
+  let enabled =
+    Feature_flag_registry.get_bool "MASC_KEEPER_DOCKER_PLAYGROUND"
+
+  (** Docker container name for keeper playground execution.
+      Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playground". *)
+  let container_name =
+    get_string ~default:"keeper-playground" "MASC_KEEPER_DOCKER_CONTAINER"
+end
+
 module DashboardHealth = struct
   let ctx_critical = get_float ~default:0.9 "MASC_DASHBOARD_HEALTH_CTX_CRITICAL"
   let ctx_warn = get_float ~default:0.8 "MASC_DASHBOARD_HEALTH_CTX_WARN"

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -423,9 +423,10 @@ end
 
 module DockerPlayground = struct
   (** Route keeper_bash commands through a Docker container instead of
-      local subprocess.  The container must be running and named
-      [keeper-playground].  When disabled, commands run locally with
-      the existing allowlist restrictions.
+      local subprocess.  The container must be running; by default its
+      name is [keeper-playground], configurable via
+      [MASC_KEEPER_DOCKER_CONTAINER].  When disabled, commands run
+      locally with the existing allowlist restrictions.
       Env: [MASC_KEEPER_DOCKER_PLAYGROUND]. Default: false. *)
   let enabled =
     Feature_flag_registry.get_bool "MASC_KEEPER_DOCKER_PLAYGROUND"

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -196,6 +196,12 @@ let all_flags : flag list = [
     default = true; category = "runtime";
     lifecycle = Active; since = "2.162.0" };
 
+  (* ── Docker Playground ─────────────────────────────────────── *)
+  { env_name = "MASC_KEEPER_DOCKER_PLAYGROUND";
+    description = "Route keeper_bash through Docker container for unrestricted playground execution";
+    default = false; category = "keeper";
+    lifecycle = Experimental; since = "2.262.0" };
+
 ]
 
 (** Lookup a flag by env var name. O(n) — acceptable for ~30 flags. *)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -184,7 +184,8 @@ let docker_container_playground_root = "/home/keeper/playground"
 
 let docker_playground_cwd ~playground_abs ~(meta : keeper_meta) host_cwd =
   let keeper_root =
-    Printf.sprintf "%s/%s" docker_container_playground_root meta.name
+    Printf.sprintf "%s/%s" docker_container_playground_root
+      (Keeper_alerting_path.sanitize_keeper_name meta.name)
   in
   let normalized_prefix =
     Keeper_alerting_path.normalize_path_for_check playground_abs
@@ -322,10 +323,44 @@ let handle_keeper_bash
                    etc.) and is blocked for all presets." )
             ; "cmd", `String cmd_for_log
             ]))
+    else if Worker_dev_tools.is_git_branch_switch cmd
+            && not (write_enabled && in_playground)
+    then (
+      Log.Keeper.info
+        "keeper_bash branch-switch blocked: %s (keeper=%s, write_enabled=%b, playground=%b)"
+        cmd_for_log meta.name write_enabled in_playground;
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool false
+            ; "error", `String "branch_switch_blocked"
+            ; ( "reason"
+              , `String
+                  "git checkout/switch/branch mutations require a write-enabled preset \
+                   (Coding/Delivery/Full) and a playground clone. \
+                   Clone into your playground first (keeper_shell op=git_clone), \
+                   then set cwd to the cloned repo path." )
+            ; "cmd", `String cmd_for_log
+            ; "hint", `String "Use cwd=.masc/playground/YOUR_KEEPER_NAME/repos/REPO"
+            ]))
+    else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
+    then (
+      Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s, playground=%b)"
+        cmd_for_log meta.name in_playground;
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool false
+            ; "error", `String "write_operation_gated"
+            ; ( "reason"
+              , `String
+                  "This command modifies state (git push/commit, make deploy, etc.). \
+                   A write-enabled preset (Coding/Delivery/Full) is required." )
+            ; "cmd", `String cmd_for_log
+            ]))
     else if use_docker then (
-      (* Docker playground path: skip command whitelist and path validation.
-         The container provides isolation — chaining, pipes, tee are safe.
-         Only the destructive guard above is retained. *)
+      (* Docker playground path: skip host-shell allowlist and host-path validation.
+         The container provides filesystem isolation, but preset-based write and
+         branch-switch gates still apply above. Intentionally use a non-login shell:
+         playground containers are minimal and should not depend on profile startup. *)
       Log.Keeper.info "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s"
         meta.name cwd cmd_for_log;
       let container = Env_config_keeper.DockerPlayground.container_name in
@@ -386,42 +421,7 @@ let handle_keeper_bash
               ; "hint", `String hint
               ])
       | Ok () ->
-        (* Branch-switch guard *)
-        if Worker_dev_tools.is_git_branch_switch cmd
-                && not (write_enabled && in_playground)
-        then (
-          Log.Keeper.info
-            "keeper_bash branch-switch blocked: %s (keeper=%s, write_enabled=%b, playground=%b)"
-            cmd_for_log meta.name write_enabled in_playground;
-          Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool false
-                ; "error", `String "branch_switch_blocked"
-                ; ( "reason"
-                  , `String
-                      "git checkout/switch/branch mutations require a write-enabled preset \
-                       (Coding/Delivery/Full) and a playground clone. \
-                       Clone into your playground first (keeper_shell op=git_clone), \
-                       then set cwd to the cloned repo path." )
-                ; "cmd", `String cmd_for_log
-                ; "hint", `String "Use cwd=.masc/playground/YOUR_KEEPER_NAME/repos/REPO"
-                ]))
-        (* Write gate *)
-        else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
-        then (
-          Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s, playground=%b)"
-            cmd_for_log meta.name in_playground;
-          Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool false
-                ; "error", `String "write_operation_gated"
-                ; ( "reason"
-                  , `String
-                      "This command modifies state (git push/commit, make deploy, etc.). \
-                       A write-enabled preset (Coding/Delivery/Full) is required." )
-                ; "cmd", `String cmd_for_log
-                ]))
-        else (
+        (
             (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
              | Error e -> error_json e
              | Ok () ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -169,6 +169,21 @@ let resolve_keeper_shell_write_cwd
   | Ok cwd when Fs_compat.file_exists cwd && Sys.is_directory cwd -> Ok cwd
   | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
 
+(* Docker playground path mapping: host → container.
+   Host:      /Users/dancer/me/.masc/playground/cheolsu/repos/X
+   Container: /home/keeper/playground/cheolsu/repos/X *)
+let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd =
+  let root = Keeper_alerting_path.project_root_of_config config in
+  let playground_prefix = Filename.concat root ".masc/playground" in
+  if String.starts_with ~prefix:playground_prefix host_cwd then
+    let suffix =
+      String.sub host_cwd (String.length playground_prefix)
+        (String.length host_cwd - String.length playground_prefix)
+    in
+    "/home/keeper/playground" ^ suffix
+  else
+    Printf.sprintf "/home/keeper/playground/%s" meta.name
+
 (* Common wrong path prefixes that keepers use.
    Maps wrong prefix → corrected relative path using keeper playground. *)
 let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
@@ -358,8 +373,22 @@ let handle_keeper_bash
                Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s playground=%b"
                  meta.name cwd cmd_for_log in_playground;
              let st, out =
-               Process_eio.run_argv_with_status ~cwd ~timeout_sec
-                 [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
+               if Env_config_keeper.DockerPlayground.enabled
+                  && in_playground then
+                 (* Docker playground: route through container.
+                    Map host playground path to container path. *)
+                 let container = Env_config_keeper.DockerPlayground.container_name in
+                 let container_cwd =
+                   docker_playground_cwd ~config ~meta cwd
+                 in
+                 Process_eio.run_argv_with_status
+                   ~cwd:(Sys.getcwd ()) ~timeout_sec
+                   [ "docker"; "exec"; "-u"; "keeper";
+                     "-w"; container_cwd;
+                     container; "bash"; "-c"; cmd ^ " 2>&1" ]
+               else
+                 Process_eio.run_argv_with_status ~cwd ~timeout_sec
+                   [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
              in
              Yojson.Safe.to_string
                (`Assoc

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -21,6 +21,10 @@ let clamp_shell_timeout ?(min_sec = 1.0) ~default args =
 let re_hint_chain = Re.(compile (Pcre.re "chain|redirect|pipe|semicolon"))
 let re_hint_inject = Re.(compile (Pcre.re "inject|symbol"))
 
+let path_has_prefix_boundary ~prefix path =
+  String.equal prefix path
+  || String.starts_with ~prefix:(prefix ^ "/") path
+
 let lowercase_shell_words text =
   text
   |> String.map (function '\t' | '\r' | '\n' -> ' ' | c -> c)
@@ -179,6 +183,9 @@ let resolve_keeper_shell_write_cwd
 let docker_container_playground_root = "/home/keeper/playground"
 
 let docker_playground_cwd ~playground_abs ~(meta : keeper_meta) host_cwd =
+  let keeper_root =
+    Printf.sprintf "%s/%s" docker_container_playground_root meta.name
+  in
   let normalized_prefix =
     Keeper_alerting_path.normalize_path_for_check playground_abs
     |> Keeper_alerting_path.strip_trailing_slashes
@@ -187,14 +194,14 @@ let docker_playground_cwd ~playground_abs ~(meta : keeper_meta) host_cwd =
     Keeper_alerting_path.normalize_path_for_check host_cwd
     |> Keeper_alerting_path.strip_trailing_slashes
   in
-  if String.starts_with ~prefix:normalized_prefix normalized_cwd then
+  if path_has_prefix_boundary ~prefix:normalized_prefix normalized_cwd then
     let suffix =
       String.sub normalized_cwd (String.length normalized_prefix)
         (String.length normalized_cwd - String.length normalized_prefix)
     in
-    docker_container_playground_root ^ suffix
+    keeper_root ^ suffix
   else
-    Printf.sprintf "%s/%s" docker_container_playground_root meta.name
+    keeper_root
 
 (* Common wrong path prefixes that keepers use.
    Maps wrong prefix → corrected relative path using keeper playground. *)
@@ -296,8 +303,7 @@ let handle_keeper_bash
       normalize_path_for_containment (Filename.concat root playground_rel)
     in
     let in_playground =
-      String.starts_with ~prefix:(playground_abs ^ "/") (cwd_canonical ^ "/")
-      || String.equal playground_abs cwd_canonical
+      path_has_prefix_boundary ~prefix:playground_abs cwd_canonical
     in
     let use_docker =
       Env_config_keeper.DockerPlayground.enabled && in_playground

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -265,138 +265,146 @@ let handle_keeper_bash
   then error_json "cmd is required. Good: cmd='ls -la lib/'. Bad: cmd=''."
 
   else
-    let validate =
-      if write_enabled then Worker_dev_tools.validate_command_coding
-      else Worker_dev_tools.validate_command
+    (* Resolve cwd early — needed for playground detection before validation. *)
+    match resolve_keeper_shell_write_cwd ~config ~meta ~args with
+    | Error e -> error_json e
+    | Ok cwd ->
+    let normalize_path_for_containment path =
+      Keeper_alerting_path.normalize_path_for_check path
+      |> Keeper_alerting_path.strip_trailing_slashes
     in
-    match validate cmd with
-    | Error reason ->
-      Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd_for_log;
-      let hint =
-        if String.length reason > 0 &&
-           (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
-        then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
-        else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)
-        then "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
-        else "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
-      in
+    let cwd_canonical =
+      normalize_path_for_containment cwd
+    in
+    let playground_rel =
+      Keeper_alerting_path.playground_path_of_keeper meta.name
+    in
+    let root = Keeper_alerting_path.project_root_of_config config in
+    let playground_abs =
+      normalize_path_for_containment (Filename.concat root playground_rel)
+    in
+    let in_playground =
+      String.starts_with ~prefix:(playground_abs ^ "/") (cwd_canonical ^ "/")
+      || String.equal playground_abs cwd_canonical
+    in
+    let use_docker =
+      Env_config_keeper.DockerPlayground.enabled && in_playground
+    in
+    (* Destructive guard: always active regardless of Docker or preset *)
+    if Worker_dev_tools.is_destructive_bash_operation cmd
+    then (
+      Log.Keeper.warn "keeper_bash DESTRUCTIVE blocked: %s (keeper=%s)" cmd_for_log meta.name;
       Yojson.Safe.to_string
         (`Assoc
             [ "ok", `Bool false
-            ; "error", `String "command_blocked"
-            ; "reason", `String reason
-            ; "hint", `String hint
-            ])
-    | Ok () ->
-      (* Resolve cwd early — needed for playground detection in guards below *)
-      match resolve_keeper_shell_write_cwd ~config ~meta ~args with
-      | Error e -> error_json e
-      | Ok cwd ->
-      let normalize_path_for_containment path =
-        Keeper_alerting_path.normalize_path_for_check path
-        |> Keeper_alerting_path.strip_trailing_slashes
+            ; "error", `String "destructive_operation_blocked"
+            ; ( "reason"
+              , `String
+                  "This command is destructive (force push, push to main, rm -rf, \
+                   etc.) and is blocked for all presets." )
+            ; "cmd", `String cmd_for_log
+            ]))
+    else if use_docker then (
+      (* Docker playground path: skip command whitelist and path validation.
+         The container provides isolation — chaining, pipes, tee are safe.
+         Only the destructive guard above is retained. *)
+      Log.Keeper.info "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s"
+        meta.name cwd cmd_for_log;
+      let container = Env_config_keeper.DockerPlayground.container_name in
+      let container_cwd = docker_playground_cwd ~config ~meta cwd in
+      let st, out =
+        Process_eio.run_argv_with_status
+          ~cwd:(Sys.getcwd ()) ~timeout_sec
+          [ "docker"; "exec"; "-u"; "keeper";
+            "-w"; container_cwd;
+            container; "bash"; "-c"; cmd ^ " 2>&1" ]
       in
-      (* Canonicalize both cwd and the playground root for containment checks.
-         This closes both path traversal and symlink-mismatch cases. *)
-      let cwd_canonical =
-        normalize_path_for_containment cwd
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool (st = Unix.WEXITED 0)
+            ; "cwd", `String cwd
+            ; "status", Keeper_alerting_path.process_status_to_json st
+            ; "output", `String out
+            ]))
+    else
+      (* Local execution path: full validation applies *)
+      let validate =
+        if write_enabled then Worker_dev_tools.validate_command_coding
+        else Worker_dev_tools.validate_command
       in
-      (* Playground sandbox: git write ops are allowed inside the keeper's
-         playground clone (.masc/playground/<name>/repos/<repo>).
-         Both paths must be canonicalized to prevent ../traversal bypass. *)
-      let playground_rel =
-        Keeper_alerting_path.playground_path_of_keeper meta.name
-      in
-      let root = Keeper_alerting_path.project_root_of_config config in
-      let playground_abs =
-        normalize_path_for_containment (Filename.concat root playground_rel)
-      in
-      let in_playground =
-        String.starts_with ~prefix:(playground_abs ^ "/") (cwd_canonical ^ "/")
-        || String.equal playground_abs cwd_canonical
-      in
-      (* Destructive guard: always active regardless of preset or location *)
-      if Worker_dev_tools.is_destructive_bash_operation cmd
-      then (
-        Log.Keeper.warn "keeper_bash DESTRUCTIVE blocked: %s (keeper=%s)" cmd_for_log meta.name;
+      match validate cmd with
+      | Error reason ->
+        Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd_for_log;
+        let hint =
+          if String.length reason > 0 &&
+             (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
+          then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
+          else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)
+          then "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
+          else "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
+        in
         Yojson.Safe.to_string
           (`Assoc
               [ "ok", `Bool false
-              ; "error", `String "destructive_operation_blocked"
-              ; ( "reason"
-                , `String
-                    "This command is destructive (force push, push to main, rm -rf, \
-                     etc.) and is blocked for all presets." )
-              ; "cmd", `String cmd_for_log
-              ]))
-      (* Branch-switch guard: requires a write-enabled preset and a playground cwd. *)
-      else if Worker_dev_tools.is_git_branch_switch cmd
-              && not (write_enabled && in_playground)
-      then (
-        Log.Keeper.info
-          "keeper_bash branch-switch blocked: %s (keeper=%s, write_enabled=%b, playground=%b)"
-          cmd_for_log meta.name write_enabled in_playground;
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool false
-              ; "error", `String "branch_switch_blocked"
-              ; ( "reason"
-                , `String
-                    "git checkout/switch/branch mutations require a write-enabled preset \
-                     (Coding/Delivery/Full) and a playground clone. \
-                     Clone into your playground first (keeper_shell op=git_clone), \
-                     then set cwd to the cloned repo path." )
-              ; "cmd", `String cmd_for_log
-              ; "hint", `String "Use cwd=.masc/playground/YOUR_KEEPER_NAME/repos/REPO"
-              ]))
-      (* Write gate: playground location must not bypass preset-based write policy. *)
-      else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
-      then (
-        Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s, playground=%b)"
-          cmd_for_log meta.name in_playground;
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool false
-              ; "error", `String "write_operation_gated"
-              ; ( "reason"
-                , `String
-                    "This command modifies state (git push/commit, make deploy, etc.). \
-                     A write-enabled preset (Coding/Delivery/Full) is required." )
-              ; "cmd", `String cmd_for_log
-              ]))
-      else (
-          (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
-           | Error e -> error_json e
-           | Ok () ->
-             if write_enabled
-                && Worker_dev_tools.is_write_operation cmd then
-               Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s playground=%b"
-                 meta.name cwd cmd_for_log in_playground;
-             let st, out =
-               if Env_config_keeper.DockerPlayground.enabled
-                  && in_playground then
-                 (* Docker playground: route through container.
-                    Map host playground path to container path. *)
-                 let container = Env_config_keeper.DockerPlayground.container_name in
-                 let container_cwd =
-                   docker_playground_cwd ~config ~meta cwd
-                 in
-                 Process_eio.run_argv_with_status
-                   ~cwd:(Sys.getcwd ()) ~timeout_sec
-                   [ "docker"; "exec"; "-u"; "keeper";
-                     "-w"; container_cwd;
-                     container; "bash"; "-c"; cmd ^ " 2>&1" ]
-               else
+              ; "error", `String "command_blocked"
+              ; "reason", `String reason
+              ; "hint", `String hint
+              ])
+      | Ok () ->
+        (* Branch-switch guard *)
+        if Worker_dev_tools.is_git_branch_switch cmd
+                && not (write_enabled && in_playground)
+        then (
+          Log.Keeper.info
+            "keeper_bash branch-switch blocked: %s (keeper=%s, write_enabled=%b, playground=%b)"
+            cmd_for_log meta.name write_enabled in_playground;
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String "branch_switch_blocked"
+                ; ( "reason"
+                  , `String
+                      "git checkout/switch/branch mutations require a write-enabled preset \
+                       (Coding/Delivery/Full) and a playground clone. \
+                       Clone into your playground first (keeper_shell op=git_clone), \
+                       then set cwd to the cloned repo path." )
+                ; "cmd", `String cmd_for_log
+                ; "hint", `String "Use cwd=.masc/playground/YOUR_KEEPER_NAME/repos/REPO"
+                ]))
+        (* Write gate *)
+        else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
+        then (
+          Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s, playground=%b)"
+            cmd_for_log meta.name in_playground;
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String "write_operation_gated"
+                ; ( "reason"
+                  , `String
+                      "This command modifies state (git push/commit, make deploy, etc.). \
+                       A write-enabled preset (Coding/Delivery/Full) is required." )
+                ; "cmd", `String cmd_for_log
+                ]))
+        else (
+            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
+             | Error e -> error_json e
+             | Ok () ->
+               if write_enabled
+                  && Worker_dev_tools.is_write_operation cmd then
+                 Log.Keeper.info "WRITE_AUDIT: keeper=%s cwd=%s cmd=%s playground=%b"
+                   meta.name cwd cmd_for_log in_playground;
+               let st, out =
                  Process_eio.run_argv_with_status ~cwd ~timeout_sec
                    [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
-             in
-             Yojson.Safe.to_string
-               (`Assoc
-                   [ "ok", `Bool (st = Unix.WEXITED 0)
-                   ; "cwd", `String cwd
-                   ; "status", Keeper_alerting_path.process_status_to_json st
-                   ; "output", `String out
-                   ])))
+               in
+               Yojson.Safe.to_string
+                 (`Assoc
+                     [ "ok", `Bool (st = Unix.WEXITED 0)
+                     ; "cwd", `String cwd
+                     ; "status", Keeper_alerting_path.process_status_to_json st
+                     ; "output", `String out
+                     ])))
 ;;
 
 let handle_keeper_shell

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -16,6 +16,11 @@ let clamp_shell_timeout ?(min_sec = 1.0) ~default args =
   Safe_ops.json_float ~default "timeout_sec" args
   |> fun n -> max min_sec (min user_timeout_max_sec n)
 
+(* Pre-compiled regex patterns for blocked-command hint classification.
+   Hoisted to module level to avoid recompilation on every rejected call. *)
+let re_hint_chain = Re.(compile (Pcre.re "chain|redirect|pipe|semicolon"))
+let re_hint_inject = Re.(compile (Pcre.re "inject|symbol"))
+
 let lowercase_shell_words text =
   text
   |> String.map (function '\t' | '\r' | '\n' -> ' ' | c -> c)
@@ -170,19 +175,26 @@ let resolve_keeper_shell_write_cwd
   | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
 
 (* Docker playground path mapping: host → container.
-   Host:      /Users/dancer/me/.masc/playground/cheolsu/repos/X
-   Container: /home/keeper/playground/cheolsu/repos/X *)
-let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd =
-  let root = Keeper_alerting_path.project_root_of_config config in
-  let playground_prefix = Filename.concat root ".masc/playground" in
-  if String.starts_with ~prefix:playground_prefix host_cwd then
+   Maps <root>/.masc/playground/<name>/... → /home/keeper/playground/<name>/... *)
+let docker_container_playground_root = "/home/keeper/playground"
+
+let docker_playground_cwd ~playground_abs ~(meta : keeper_meta) host_cwd =
+  let normalized_prefix =
+    Keeper_alerting_path.normalize_path_for_check playground_abs
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  let normalized_cwd =
+    Keeper_alerting_path.normalize_path_for_check host_cwd
+    |> Keeper_alerting_path.strip_trailing_slashes
+  in
+  if String.starts_with ~prefix:normalized_prefix normalized_cwd then
     let suffix =
-      String.sub host_cwd (String.length playground_prefix)
-        (String.length host_cwd - String.length playground_prefix)
+      String.sub normalized_cwd (String.length normalized_prefix)
+        (String.length normalized_cwd - String.length normalized_prefix)
     in
-    "/home/keeper/playground" ^ suffix
+    docker_container_playground_root ^ suffix
   else
-    Printf.sprintf "/home/keeper/playground/%s" meta.name
+    Printf.sprintf "%s/%s" docker_container_playground_root meta.name
 
 (* Common wrong path prefixes that keepers use.
    Maps wrong prefix → corrected relative path using keeper playground. *)
@@ -311,21 +323,38 @@ let handle_keeper_bash
       Log.Keeper.info "DOCKER_EXEC: keeper=%s cwd=%s cmd=%s"
         meta.name cwd cmd_for_log;
       let container = Env_config_keeper.DockerPlayground.container_name in
-      let container_cwd = docker_playground_cwd ~config ~meta cwd in
+      let container_cwd =
+        docker_playground_cwd ~playground_abs ~meta cwd
+      in
       let st, out =
         Process_eio.run_argv_with_status
-          ~cwd:(Sys.getcwd ()) ~timeout_sec
+          ~cwd:root ~timeout_sec
           [ "docker"; "exec"; "-u"; "keeper";
             "-w"; container_cwd;
             container; "bash"; "-c"; cmd ^ " 2>&1" ]
       in
-      Yojson.Safe.to_string
-        (`Assoc
-            [ "ok", `Bool (st = Unix.WEXITED 0)
-            ; "cwd", `String cwd
-            ; "status", Keeper_alerting_path.process_status_to_json st
-            ; "output", `String out
-            ]))
+      (* Detect Docker daemon errors (container not running, not found) *)
+      match st with
+      | Unix.WEXITED 125 | Unix.WEXITED 126 | Unix.WEXITED 127 ->
+        Log.Keeper.warn "DOCKER_EXEC failed: keeper=%s exit=%d output=%s"
+          meta.name
+          (match st with Unix.WEXITED n -> n | _ -> -1)
+          (Worker_dev_tools.truncate_for_log out);
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool false
+              ; "error", `String "docker_exec_failed"
+              ; "reason", `String "Docker container is not running or command not found in container."
+              ; "output", `String out
+              ])
+      | _ ->
+        Yojson.Safe.to_string
+          (`Assoc
+              [ "ok", `Bool (st = Unix.WEXITED 0)
+              ; "cwd", `String cwd
+              ; "status", Keeper_alerting_path.process_status_to_json st
+              ; "output", `String out
+              ]))
     else
       (* Local execution path: full validation applies *)
       let validate =
@@ -337,9 +366,9 @@ let handle_keeper_bash
         Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd_for_log;
         let hint =
           if String.length reason > 0 &&
-             (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
+             Re.execp re_hint_chain (String.lowercase_ascii reason)
           then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
-          else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)
+          else if Re.execp re_hint_inject (String.lowercase_ascii reason)
           then "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
           else "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
         in

--- a/lib/keeper/keeper_exec_shell.mli
+++ b/lib/keeper/keeper_exec_shell.mli
@@ -13,6 +13,12 @@ val handle_keeper_bash :
   args:Yojson.Safe.t ->
   string
 
+val docker_playground_cwd :
+  playground_abs:string ->
+  meta:Keeper_types.keeper_meta ->
+  string ->
+  string
+
 val handle_keeper_shell :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/test/test_keeper_bash_safety.ml
+++ b/test/test_keeper_bash_safety.ml
@@ -302,6 +302,39 @@ let test_git_write_classification () =
   Alcotest.(check bool) "push is not destructive"
     false (is_destructive "git push origin my-branch")
 
+let docker_meta =
+  match Masc_mcp.Keeper_types.meta_of_json
+    (`Assoc [("name", `String "cheolsu"); ("trace_id", `String "trace-docker-cwd")])
+  with
+  | Ok meta -> meta
+  | Error e -> failwith ("docker_meta failed: " ^ e)
+
+let test_docker_playground_cwd_mapping () =
+  let playground_abs = "/project/.masc/playground/cheolsu" in
+  let mapped =
+    Masc_mcp.Keeper_exec_shell.docker_playground_cwd
+      ~playground_abs ~meta:docker_meta
+      "/project/.masc/playground/cheolsu/repos/masc-mcp"
+  in
+  Alcotest.(check string) "nested path maps into container playground"
+    "/home/keeper/playground/cheolsu/repos/masc-mcp" mapped;
+  let exact =
+    Masc_mcp.Keeper_exec_shell.docker_playground_cwd
+      ~playground_abs ~meta:docker_meta playground_abs
+  in
+  Alcotest.(check string) "exact playground dir maps to keeper root"
+    "/home/keeper/playground/cheolsu" exact
+
+let test_docker_playground_cwd_prefix_boundary () =
+  let playground_abs = "/project/.masc/playground/cheolsu" in
+  let mapped =
+    Masc_mcp.Keeper_exec_shell.docker_playground_cwd
+      ~playground_abs ~meta:docker_meta
+      "/project/.masc/playground/cheolsu2/repos/masc-mcp"
+  in
+  Alcotest.(check string) "prefix attack falls back to keeper root"
+    "/home/keeper/playground/cheolsu" mapped
+
 let () =
   Alcotest.run "Keeper bash safety" [
     ("allowlist", [
@@ -325,6 +358,10 @@ let () =
         test_cleanup_dir_does_not_follow_symlinks;
       Alcotest.test_case "path traversal blocked after canonicalization" `Quick test_playground_guard_traversal;
       Alcotest.test_case "git write classification" `Quick test_git_write_classification;
+      Alcotest.test_case "docker playground cwd maps nested paths" `Quick
+        test_docker_playground_cwd_mapping;
+      Alcotest.test_case "docker playground cwd rejects prefix attacks" `Quick
+        test_docker_playground_cwd_prefix_boundary;
     ]);
     ("edge", [
       Alcotest.test_case "empty command blocked" `Quick test_empty_command;

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -36,6 +36,20 @@ let make_meta_with_preset preset_str =
   | Ok meta -> meta
   | Error e -> failwith (Printf.sprintf "make_meta_with_preset('%s') failed: %s" preset_str e)
 
+let make_meta_with_custom_tools tools =
+  match Keeper_types.meta_of_json
+    (`Assoc
+      [ "name", `String "test-keeper"
+      ; "agent_name", `String "test-keeper"
+      ; "trace_id", `String "test-trace-pr"
+      ; "tool_access", `Assoc
+          [ "kind", `String "custom"
+          ; "tools", `List (List.map (fun tool -> `String tool) tools)
+          ]
+      ]) with
+  | Ok meta -> meta
+  | Error e -> failwith ("make_meta_with_custom_tools failed: " ^ e)
+
 let make_ctx_work () =
   Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
 
@@ -104,6 +118,17 @@ let call_tool config meta name input =
   let ctx_work = make_ctx_work () in
   Keeper_exec_tools.execute_keeper_tool_call
     ~config ~meta ~ctx_work ~name ~input ()
+
+let with_env key value f =
+  let saved = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    (fun () ->
+      Unix.putenv key value;
+      f ())
 
 let parse_json s =
   try Yojson.Safe.from_string s
@@ -820,6 +845,30 @@ let test_bash_git_status_allowed () =
     check bool "git status returns normal execution shape"
       true has_status)
 
+let test_bash_docker_playground_preserves_write_gate () =
+  with_room (fun config ->
+    let meta = make_meta_with_custom_tools ["keeper_bash"] in
+    with_env "MASC_KEEPER_DOCKER_PLAYGROUND" "true" (fun () ->
+        let result =
+          call_tool config meta "keeper_bash"
+            (`Assoc [ "cmd", `String "git commit -m test" ])
+        in
+        let json = parse_json result in
+        check string "docker write gate preserved"
+          "write_operation_gated" (json_string "error" json)))
+
+let test_bash_docker_playground_preserves_branch_switch_gate () =
+  with_room (fun config ->
+    let meta = make_meta_with_custom_tools ["keeper_bash"] in
+    with_env "MASC_KEEPER_DOCKER_PLAYGROUND" "true" (fun () ->
+        let result =
+          call_tool config meta "keeper_bash"
+            (`Assoc [ "cmd", `String "git checkout feature/x" ])
+        in
+        let json = parse_json result in
+        check string "docker branch-switch gate preserved"
+          "branch_switch_blocked" (json_string "error" json)))
+
 let test_shell_readonly_pwd_defaults_to_playground () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
@@ -1194,6 +1243,10 @@ let () =
       ; test_case "branch list allowed" `Quick test_bash_git_branch_list_allowed
       ; test_case "branch delete allowed" `Quick test_bash_git_branch_delete_allowed
       ; test_case "status allowed" `Quick test_bash_git_status_allowed
+      ; test_case "docker keeps write gate" `Quick
+          test_bash_docker_playground_preserves_write_gate
+      ; test_case "docker keeps branch-switch gate" `Quick
+          test_bash_docker_playground_preserves_branch_switch_gate
       ; test_case "readonly pwd defaults to playground" `Quick
           test_shell_readonly_pwd_defaults_to_playground
       ; test_case "fs read blocks shared repo by default" `Quick


### PR DESCRIPTION
## Summary
- preserve keeper_bash write and branch-switch gates even when Docker playground routing is enabled
- harden Docker playground cwd mapping with path-boundary checks and sanitized keeper names
- add regression coverage for Docker playground mapping and policy gates

## Test plan
- [x] bash scripts/check-feature-flag-consistency.sh
- [x] ./_build/default/test/test_keeper_bash_safety.exe
- [x] Docker-specific gate cases in ./_build/default/test/test_keeper_pr_workflow.exe
- [ ] Full PR CI

## Notes
-  still has one pre-existing unrelated failure on this branch: . The new Docker gate cases pass.