### PR TITLE
fix(voice): allow empty session.endpoints in voice_config

### DIFF
--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -315,8 +315,11 @@ let parse_session json =
   let* endpoints_json =
     require_list ~ctx:"session" ~field:"endpoints" session_json
   in
-  let* endpoints = parse_endpoints ~ctx:"session.endpoints" [] endpoints_json in
-  Ok { endpoints }
+  match endpoints_json with
+  | [] -> Ok { endpoints = [] }
+  | items ->
+    let* endpoints = parse_endpoints ~ctx:"session.endpoints" [] items in
+    Ok { endpoints }
 
 let parse_local_playback json =
   match Yojson.Safe.Util.member "local_playback" json with

--- a/test/dune
+++ b/test/dune
@@ -359,7 +359,8 @@
         test_eval_calibration
         test_goal_janitor
         test_keeper_pr_workflow
-        test_keeper_github_hint)
+        test_keeper_github_hint
+        test_voice_config)
  (modules
         test_runtime_params
         test_config_dir_resolver
@@ -508,7 +509,8 @@
         test_eval_calibration
         test_goal_janitor
         test_keeper_pr_workflow
-        test_keeper_github_hint)
+        test_keeper_github_hint
+        test_voice_config)
  (libraries masc_test_deps))
 
 (test

--- a/test/test_voice_config.ml
+++ b/test/test_voice_config.ml
@@ -1,0 +1,93 @@
+open Alcotest
+
+module Vc = Masc_mcp.Voice_config
+
+let minimal_config_json ~session_endpoints =
+  Printf.sprintf {|{
+  "tts": {
+    "default_model": "eleven_multilingual_v2",
+    "default_voice": "Roger",
+    "default_voice_settings": {},
+    "endpoints": [
+      { "id": "elevenlabs-roger", "kind": "elevenlabs_direct",
+        "api_key_env": "ELEVENLABS_API_KEY", "enabled": true }
+    ]
+  },
+  "stt": {
+    "default_model": "scribe_v1",
+    "endpoints": [
+      { "id": "elevenlabs-stt", "kind": "elevenlabs_direct",
+        "api_key_env": "ELEVENLABS_API_KEY", "enabled": true }
+    ]
+  },
+  "session": {
+    "endpoints": %s
+  }
+}|} session_endpoints
+
+let parse json_str =
+  let tmp = Filename.temp_file "test_voice_config" ".json" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove tmp with Sys_error _ -> ())
+    (fun () ->
+      let oc = open_out tmp in
+      output_string oc json_str;
+      close_out oc;
+      (* Voice_config.load reads from config_path(), but we need to parse
+         the JSON directly.  Use the internal parse chain via Yojson. *)
+      let json = Yojson.Safe.from_string json_str in
+      (* Replicate the load() pipeline without file I/O *)
+      let open Result in
+      let ( let* ) = bind in
+      let* tts = Vc.parse_tts json in
+      let* stt = Vc.parse_stt json in
+      let* session = Vc.parse_session json in
+      let* local_playback = Vc.parse_local_playback json in
+      Ok { Vc.tts; stt; session; local_playback })
+
+let test_session_empty_endpoints_ok () =
+  let json = minimal_config_json ~session_endpoints:"[]" in
+  match parse json with
+  | Ok config ->
+    check int "session endpoints empty" 0 (List.length config.session.endpoints)
+  | Error err ->
+    fail (Printf.sprintf "expected Ok, got Error: %s" err)
+
+let test_session_with_endpoint_ok () =
+  let session_ep =
+    {|[{ "id": "voice-mcp", "kind": "voice_mcp",
+         "mcp_url": "http://localhost:8936/mcp", "enabled": true }]|}
+  in
+  let json = minimal_config_json ~session_endpoints:session_ep in
+  match parse json with
+  | Ok config ->
+    check int "session endpoints 1" 1 (List.length config.session.endpoints)
+  | Error err ->
+    fail (Printf.sprintf "expected Ok, got Error: %s" err)
+
+let test_tts_endpoints_reachable_when_session_empty () =
+  let json = minimal_config_json ~session_endpoints:"[]" in
+  match parse json with
+  | Ok config ->
+    check int "tts endpoints available" 1
+      (List.length config.tts.endpoints);
+    let enabled =
+      List.filter (fun (ep : Vc.endpoint) -> ep.enabled) config.tts.endpoints
+    in
+    check int "tts endpoints enabled" 1 (List.length enabled)
+  | Error err ->
+    fail (Printf.sprintf "expected Ok for tts check, got Error: %s" err)
+
+let () =
+  Alcotest.run "voice_config"
+    [
+      ( "session_endpoints",
+        [
+          test_case "empty session endpoints parses ok"
+            `Quick test_session_empty_endpoints_ok;
+          test_case "session with endpoint parses ok"
+            `Quick test_session_with_endpoint_ok;
+          test_case "tts reachable when session empty"
+            `Quick test_tts_endpoints_reachable_when_session_empty;
+        ] );
+    ]

--- a/test/test_voice_config.ml
+++ b/test/test_voice_config.ml
@@ -26,24 +26,14 @@ let minimal_config_json ~session_endpoints =
 }|} session_endpoints
 
 let parse json_str =
-  let tmp = Filename.temp_file "test_voice_config" ".json" in
-  Fun.protect
-    ~finally:(fun () -> try Sys.remove tmp with Sys_error _ -> ())
-    (fun () ->
-      let oc = open_out tmp in
-      output_string oc json_str;
-      close_out oc;
-      (* Voice_config.load reads from config_path(), but we need to parse
-         the JSON directly.  Use the internal parse chain via Yojson. *)
-      let json = Yojson.Safe.from_string json_str in
-      (* Replicate the load() pipeline without file I/O *)
-      let open Result in
-      let ( let* ) = bind in
-      let* tts = Vc.parse_tts json in
-      let* stt = Vc.parse_stt json in
-      let* session = Vc.parse_session json in
-      let* local_playback = Vc.parse_local_playback json in
-      Ok { Vc.tts; stt; session; local_playback })
+  let json = Yojson.Safe.from_string json_str in
+  let open Result in
+  let ( let* ) = bind in
+  let* tts = Vc.parse_tts json in
+  let* stt = Vc.parse_stt json in
+  let* session = Vc.parse_session json in
+  let* local_playback = Vc.parse_local_playback json in
+  Ok { Vc.tts; stt; session; local_playback }
 
 let test_session_empty_endpoints_ok () =
   let json = minimal_config_json ~session_endpoints:"[]" in
@@ -78,6 +68,29 @@ let test_tts_endpoints_reachable_when_session_empty () =
   | Error err ->
     fail (Printf.sprintf "expected Ok for tts check, got Error: %s" err)
 
+let test_session_invalid_endpoint_rejected () =
+  let json = minimal_config_json ~session_endpoints:{|[{"bad": true}]|} in
+  match parse json with
+  | Ok _ -> fail "expected Error for invalid endpoint, got Ok"
+  | Error _ -> ()
+
+let test_tts_empty_endpoints_rejected () =
+  let json_str = {|{
+  "tts": {
+    "default_model": "m", "default_voice": "v",
+    "default_voice_settings": {},
+    "endpoints": []
+  },
+  "stt": {
+    "default_model": "s",
+    "endpoints": [{ "id": "stt", "kind": "elevenlabs_direct", "enabled": true }]
+  },
+  "session": { "endpoints": [] }
+}|} in
+  match parse json_str with
+  | Ok _ -> fail "expected Error for empty tts endpoints, got Ok"
+  | Error _ -> ()
+
 let () =
   Alcotest.run "voice_config"
     [
@@ -89,5 +102,12 @@ let () =
             `Quick test_session_with_endpoint_ok;
           test_case "tts reachable when session empty"
             `Quick test_tts_endpoints_reachable_when_session_empty;
+        ] );
+      ( "error_paths",
+        [
+          test_case "invalid session endpoint rejected"
+            `Quick test_session_invalid_endpoint_rejected;
+          test_case "empty tts endpoints still rejected"
+            `Quick test_tts_empty_endpoints_rejected;
         ] );
     ]


### PR DESCRIPTION
## Summary
- `parse_session`이 빈 `session.endpoints`를 거부 → 전체 voice_config 로드 실패 → keeper_voice_speak "no configured TTS endpoint" 에러
- `parse_session`에서 빈 endpoints를 `Ok { endpoints = [] }`로 직접 처리하여 TTS 파이프라인이 정상 동작하도록 수정
- `test_voice_config.ml` 추가 (3 test cases)

## Root Cause
`voice_config.json`의 `session.endpoints: []`가 `parse_endpoints`의 "must not be empty" 검증에 걸림.
`let*` (Result bind) 체인에서 session 파싱 실패가 TTS/STT 포함 전체 config를 `Error`로 만듦.

## Test plan
- [x] `test_voice_config`: empty session endpoints parses ok
- [x] `test_voice_config`: session with endpoint parses ok
- [x] `test_voice_config`: tts reachable when session empty
- [x] `test_provider_adapter`: 기존 21 tests 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)