### PR TITLE
fix(operator): restore cleanup compatibility aliases

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -868,6 +868,7 @@ let keeper_config_json (config : Room.config) (name : string)
          ("proactive", proactive);
          ("drift", drift);
          ("auto_execution_session", auto_execution_session_surface_json ());
+         ("auto_team_session", auto_execution_session_surface_json ());
          ("handoff", handoff);
          ("tools", tools_access);
          ("hooks", Keeper_hooks_oas.hook_introspection_json ());

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -601,6 +601,8 @@ let handle_keeper_status ctx args : tool_result =
            ]);
            ("auto_execution_session", auto_execution_session_surface_json ());
            ("auto_execution_session_enabled", `Bool false);
+           ("auto_team_session", auto_execution_session_surface_json ());
+           ("auto_team_session_enabled", `Bool false);
            ("autonomy", `Assoc [
              ("turn_count", `Int m.runtime.autonomous_turn_count);
              ("tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -234,7 +234,12 @@ let delegated_tool_for action_type =
   | Some action -> action.tool_name
   | None ->
     (match action_type with
-     | "team_turn" -> "masc_operator_action"
+     | "team_turn"
+     | "team_note"
+     | "team_broadcast"
+     | "team_task_inject"
+     | "team_worker_spawn_batch"
+     | "team_stop" -> "masc_operator_action"
      | "review_resolve" | "review_defer" -> "review_state"
      | _ -> "unknown")
 

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -270,6 +270,21 @@ let available_actions : available_action list =
     make_available_action ~action_type:"task_inject" ~tool_name:"masc_add_task"
       ~target_type:"namespace"
       ~description:"Inject a backlog task into the namespace.";
+    make_available_action ~action_type:"team_note" ~tool_name:"masc_operator_action"
+      ~target_type:"team_session"
+      ~description:"Attach an operator note to the active team session.";
+    make_available_action ~action_type:"team_broadcast" ~tool_name:"masc_operator_action"
+      ~target_type:"team_session"
+      ~description:"Broadcast an operator message to the active team session.";
+    make_available_action ~action_type:"team_task_inject" ~tool_name:"masc_operator_action"
+      ~target_type:"team_session"
+      ~description:"Inject a task into the active team session.";
+    make_available_action ~action_type:"team_worker_spawn_batch" ~tool_name:"masc_operator_action"
+      ~target_type:"team_session"
+      ~description:"Adjust worker allocation for the active team session.";
+    make_available_action ~action_type:"team_stop" ~tool_name:"masc_operator_action"
+      ~target_type:"team_session"
+      ~description:"Stop the active team session.";
     make_available_action ~action_type:"keeper_message" ~tool_name:"masc_keeper_msg"
       ~target_type:"keeper"
       ~description:"Send a direct operator message to a keeper.";

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -41,10 +41,13 @@ let add_finding ~base_path ~worker_name ~finding =
   let dir = Filename.dirname path in
   Fs_compat.mkdir_p dir;
   let entry =
-    Printf.sprintf {|{"worker":"%s","finding":"%s","ts":%.0f}|}
-      (String.escaped worker_name)
-      (String.escaped finding)
-      (Time_compat.now ())
+    `Assoc
+      [
+        ("worker", `String worker_name);
+        ("finding", `String finding);
+        ("ts", `Float (Time_compat.now ()));
+      ]
+    |> Yojson.Safe.to_string
   in
   Fs_compat.append_file path (entry ^ "\n")
 
@@ -79,12 +82,20 @@ let build ~base_path =
 let truncate_list n lst =
   List.filteri (fun i _ -> i < n) lst
 
+let has_visible_content ctx =
+  String.trim ctx.team_goal <> ""
+  || ctx.prior_decisions <> []
+  || ctx.shared_findings <> []
+  || ctx.active_workers <> []
+  || ctx.task_tree <> []
+
 let to_prompt_section ctx =
-  if ctx.team_goal = "" then ""
+  if not (has_visible_content ctx) then ""
   else
     let buf = Buffer.create 512 in
     Buffer.add_string buf "--- Team Context ---\n";
-    Buffer.add_string buf (Printf.sprintf "Goal: %s\n" ctx.team_goal);
+    if String.trim ctx.team_goal <> "" then
+      Buffer.add_string buf (Printf.sprintf "Goal: %s\n" ctx.team_goal);
     (match truncate_list max_decisions ctx.prior_decisions with
      | [] -> ()
      | decisions ->

--- a/lib/tool_autoresearch_repo_synthesis.ml
+++ b/lib/tool_autoresearch_repo_synthesis.ml
@@ -139,28 +139,6 @@ type context = {
   clock : float Eio.Time.clock_ty Eio.Resource.t option;
 }
 
-let normalize_string_opt = function
-  | Some value ->
-      let trimmed = String.trim value in
-      if trimmed = "" then None else Some trimmed
-  | None -> None
-
-let parse_session_launch ctx json =
-  let open Yojson.Safe.Util in
-  let session_id = json |> member "session_id" |> to_string_option in
-  match normalize_string_opt session_id with
-  | None -> Error "team session launcher returned no session_id"
-  | Some session_id ->
-      let artifacts_dir =
-        json |> member "artifacts_dir" |> to_string_option
-        |> normalize_string_opt
-        |> Option.value
-             ~default:
-               (Filename.concat ctx.base_path
-                  (Filename.concat ".masc/team-sessions" session_id))
-      in
-      Ok (session_id, artifacts_dir)
-
 let handle_repo_synthesis_swarm_start _ctx _args =
   (* Team session engine removed — repo synthesis swarm start is no longer supported. *)
   ignore _ctx; ignore _args;
@@ -170,4 +148,3 @@ let handle_repo_synthesis_swarm_start _ctx _args =
         `String
           "masc_repo_synthesis_swarm_start is no longer supported (team session engine removed)" );
     ]
-

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -62,11 +62,8 @@ The MODEL receives the full file, generates a modified version, and writes it ba
 
   {
     name = "masc_autoresearch_swarm_start";
-    description = "Start an experiment loop with team coordination. Same experiment logic \
-as masc_autoresearch_start but also creates an execution session, seeds worker roles, and \
-links loop status to the team. Use when multiple agents should collaborate on the \
-research. Returns loop_id. Other agents can monitor via session \
-runtime tools. Note: team session engine has been removed; this tool returns an error.";
+    description = "Deprecated. Team session engine has been removed, so this tool now \
+returns an unsupported/deprecated error instead of starting a coordinated experiment loop.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -115,17 +112,14 @@ runtime tools. Note: team session engine has been removed; this tool returns an 
           ("description", `String "When true, lower metric values are better (e.g., loss, BPB). Default: false.");
         ]);
       ]);
-      ("required", `List [`String "goal"; `String "metric_fn"; `String "target_file"]);
+      ("required", `List []);
     ];
   };
 
   {
     name = "masc_repo_synthesis_swarm_start";
-    description = "Start a repository-scoped code synthesis task with team coordination. \
-Use for questions about a codebase (e.g. 'Generate a DB schema from these requirements'). \
-Creates an execution session and seeds workers to answer the question collaboratively. \
-Unlike autoresearch (metric-driven loops), this is question-driven with artifact output. \
-Returns synthesis_id. Note: team session engine has been removed; this tool returns an error.";
+    description = "Deprecated. Team session engine has been removed, so this tool now \
+returns an unsupported/deprecated error instead of launching a repository synthesis swarm.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -171,7 +165,7 @@ Returns synthesis_id. Note: team session engine has been removed; this tool retu
           ("description", `String "Optional baseline label for paired benchmark comparisons.");
         ]);
       ]);
-      ("required", `List [`String "goal"; `String "question"; `String "repo_root"]);
+      ("required", `List []);
     ];
   };
 

--- a/test/test_autonomy_liberation.ml
+++ b/test/test_autonomy_liberation.ml
@@ -208,6 +208,48 @@ let test_finding_accumulation () =
   (try Sys.rmdir masc_dir with Sys_error _ -> ());
   (try Sys.rmdir base_path with Sys_error _ -> ())
 
+let test_finding_accumulation_json_escaping () =
+  let base_path =
+    Filename.concat (Filename.get_temp_dir_name ()) "test_findings_escape"
+  in
+  let masc_dir = Filename.concat base_path ".masc" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove (Filename.concat masc_dir "shared_findings.jsonl") with Sys_error _ -> ());
+      (try Sys.rmdir masc_dir with Sys_error _ -> ());
+      (try Sys.rmdir base_path with Sys_error _ -> ()))
+    (fun () ->
+      (try Sys.mkdir base_path 0o755 with Sys_error _ -> ());
+      (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
+      Team_context.add_finding ~base_path ~worker_name:"w\"1"
+        ~finding:"quote \" and slash \\\\ and newline\nok";
+      let findings = Team_context.load_findings ~base_path in
+      Alcotest.(check int) "one escaped finding" 1 (List.length findings);
+      Alcotest.(check bool) "quote preserved" true
+        (List.exists
+           (fun f -> contains_s f "quote \" and slash \\\\ and newline")
+           findings))
+
+let test_team_context_build_renders_findings_without_goal () =
+  let base_path =
+    Filename.concat (Filename.get_temp_dir_name ()) "test_findings_prompt"
+  in
+  let masc_dir = Filename.concat base_path ".masc" in
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove (Filename.concat masc_dir "shared_findings.jsonl") with Sys_error _ -> ());
+      (try Sys.rmdir masc_dir with Sys_error _ -> ());
+      (try Sys.rmdir base_path with Sys_error _ -> ()))
+    (fun () ->
+      (try Sys.mkdir base_path 0o755 with Sys_error _ -> ());
+      (try Sys.mkdir masc_dir 0o755 with Sys_error _ -> ());
+      Team_context.add_finding ~base_path ~worker_name:"w1"
+        ~finding:"render me";
+      let ctx = Team_context.build ~base_path in
+      let section = Team_context.to_prompt_section ctx in
+      Alcotest.(check bool) "section rendered without goal" true
+        (contains_s section "render me"))
+
 let test_scope_default_unchanged () =
   (* Limited_code_change is still the default for unknown strings *)
   let scope = Worker_types.execution_scope_of_string "whatever" in
@@ -270,6 +312,10 @@ let () =
             test_autonomous_tool_count;
           Alcotest.test_case "finding accumulation roundtrip" `Quick
             test_finding_accumulation;
+          Alcotest.test_case "finding accumulation uses valid json escaping"
+            `Quick test_finding_accumulation_json_escaping;
+          Alcotest.test_case "build renders findings without goal" `Quick
+            test_team_context_build_renders_findings_without_goal;
           Alcotest.test_case "scope default unchanged" `Quick
             test_scope_default_unchanged;
         ] );

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -162,6 +162,11 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       Alcotest.(check string) "auto team session removed" "removed"
         Yojson.Safe.Util.(
           status_json |> member "auto_execution_session" |> member "status" |> to_string);
+      Alcotest.(check string) "legacy auto_team_session alias preserved" "removed"
+        Yojson.Safe.Util.(
+          status_json |> member "auto_team_session" |> member "status" |> to_string);
+      Alcotest.(check bool) "legacy auto_team_session_enabled alias preserved" false
+        Yojson.Safe.Util.(status_json |> member "auto_team_session_enabled" |> to_bool);
       Alcotest.(check bool) "keepalive running false" false
         Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool))
 


### PR DESCRIPTION
## Summary
- restore backward-compatible auto_team_session aliases on keeper and dashboard status payloads
- fix team_context JSONL serialization and render shared findings even without team_goal
- restore operator team action routing/surfaces and mark removed swarm-start tools as deprecated unsupported stubs

## Test plan
- dune build --root ./.worktrees/feature-6107-final-cleanup ./test/test_autonomy_liberation.exe ./test/test_operator_control.exe ./test/test_tool_repo_synthesis.exe ./test/test_tools_coverage.exe --display short
- ./_build/default/test/test_autonomy_liberation.exe
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_tool_repo_synthesis.exe
- ./_build/default/test/test_tools_coverage.exe