### PR TITLE
refactor: rename team_session → execution_session everywhere [#6107 final]

### DIFF
--- a/lib/command_plane/cp_lifecycle_search.ml
+++ b/lib/command_plane/cp_lifecycle_search.ml
@@ -423,7 +423,7 @@ let make_detachment_runtime config (target_unit : unit_record) (operation : oper
       session_id;
       checkpoint_ref = option_first_some operation.checkpoint_ref base.checkpoint_ref;
       runtime_kind =
-        (if target_count = 1 && session_id <> None then Some "team_session"
+        (if target_count = 1 && session_id <> None then Some "execution_session"
          else Some "managed");
       runtime_ref =
         (if target_count = 1 then option_first_some session_id (Some target_unit.unit_id)

--- a/lib/dashboard/dashboard_execution_fixture.ml
+++ b/lib/dashboard/dashboard_execution_fixture.ml
@@ -6,9 +6,9 @@ let execution_smoke_fixture_json () =
     handoff_json
       ~surface:"intervene"
       ~label:"세션 개입 열기"
-      ~target_type:"team_session"
+      ~target_type:"execution_session"
       ~target_id:"ts-execution-fixture-001"
-      ~focus_kind:"team_session"
+      ~focus_kind:"execution_session"
       ()
   in
   let command_handoff =
@@ -17,7 +17,7 @@ let execution_smoke_fixture_json () =
       ~command_surface:"operations"
       ~operation_id:"op-runtime-001"
       ~label:"작전 원인 보기"
-      ~target_type:"team_session"
+      ~target_type:"execution_session"
       ~target_id:"ts-execution-fixture-001"
       ~focus_kind:"operation"
       ()
@@ -60,7 +60,7 @@ let execution_smoke_fixture_json () =
                 ("severity", `String "bad");
                 ("status", `String "interrupted");
                 ("summary", `String "session has 2 failed spawn event(s)");
-                ("target_type", `String "team_session");
+                ("target_type", `String "execution_session");
                 ("target_id", `String "ts-execution-fixture-001");
                 ("linked_session_id", `String "ts-execution-fixture-001");
                 ("linked_operation_id", `String "op-runtime-001");
@@ -97,7 +97,7 @@ let execution_smoke_fixture_json () =
                 ("title", `String "ts-execution-fixture-001");
                 ("subtitle", `String "session has 2 failed spawn event(s)");
                 ("timestamp", `String generated_at);
-                ("target_type", `String "team_session");
+                ("target_type", `String "execution_session");
                 ("target_id", `String "ts-execution-fixture-001");
               ];
             `Assoc

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -259,9 +259,9 @@ let build_session_contexts seeds operation_contexts : session_context list =
            handoff_json
              ~surface:"intervene"
              ~label:intervene_label
-             ~target_type:"team_session"
+             ~target_type:"execution_session"
              ~target_id:seed.session_id
-             ~focus_kind:"team_session"
+             ~focus_kind:"execution_session"
              ()
          in
          let command_handoff =
@@ -271,10 +271,10 @@ let build_session_contexts seeds operation_contexts : session_context list =
                (if Option.is_some linked_operation_id then "operations" else "swarm")
              ?operation_id:linked_operation_id
              ~label:"세션 원인 보기"
-             ~target_type:"team_session"
+             ~target_type:"execution_session"
              ~target_id:seed.session_id
              ~focus_kind:
-               (if Option.is_some linked_operation_id then "operation" else "team_session")
+               (if Option.is_some linked_operation_id then "operation" else "execution_session")
              ()
          in
          let top_handoff =
@@ -369,7 +369,7 @@ let build_execution_queue session_contexts operation_contexts =
                    ("severity", `String (string_of_tone session.severity));
                    ("status", member_assoc "status" session.json);
                    ("summary", `String (queue_summary_of_session session));
-                   ("target_type", `String "team_session");
+                   ("target_type", `String "execution_session");
                    ("target_id", `String session.session_id);
                    ("linked_session_id", `String session.session_id);
                    ("linked_operation_id", option_to_json (fun value -> `String value) session.linked_operation_id);

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -370,7 +370,7 @@ let is_internal_attention incident =
 
 let related_sessions_for_attention incident sessions =
   let direct_session =
-    if String.equal (string_field "target_type" incident) "team_session" then
+    if String.equal (string_field "target_type" incident) "execution_session" then
       trim_to_option (string_field "target_id" incident)
       |> Option.to_list
     else
@@ -490,7 +490,7 @@ let build_session_briefs sessions attention_queue actions =
                match top_attention_json with
                | Some attention -> matching_action_for_incident attention actions
                | None ->
-                   matching_action "team_session" (Some session.session_id) actions)
+                   matching_action "execution_session" (Some session.session_id) actions)
          in
          let health_tone =
            match top_attention_json with

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -215,12 +215,12 @@ let parse_session_judgment ~config ~generated_at ~generated_at_unix ~model_used 
             in
             Some
               (Operator_judgment.record config ~surface:"command.swarm"
-                 ~target_type:Operator_judgment.Team_session
+                 ~target_type:Operator_judgment.Execution_session
                  ~target_id:(Some session_id) ~summary ~confidence
                  ?model_name:(Some model_used)
                  ?recommended_action:
                    (build_recommended_action ~actor:keeper_name
-                      ~target_type:"team_session" ~target_id:(Some session_id)
+                      ~target_type:"execution_session" ~target_id:(Some session_id)
                       (json |> member "recommended_action"))
                  ~evidence_refs:(parse_string_list json "evidence_refs")
                  ~disagreement_with_truth:

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -153,7 +153,7 @@ let all_entries =
       refs =
         {
           fixture_harness = Some "./scripts/harness_dashboard_mission_smoke.sh";
-          live_spotcheck = Some "./scripts/harness/workload/supervisor_team_session.sh";
+          live_spotcheck = Some "./scripts/harness/workload/supervisor_execution_session.sh";
           logs_ref = Some "/api/v1/dashboard/logs";
           metrics_ref = Some "/metrics";
           proof_ref = Some "/api/v1/dashboard/proof";

--- a/lib/mcp_prompt_surface.ml
+++ b/lib/mcp_prompt_surface.ml
@@ -28,7 +28,7 @@ let prompt_defs =
         ];
     };
     {
-      name = "team_session_proof";
+      name = "execution_session_proof";
       title = "Execution Session Proof";
       description = "Summarize auditable collaboration evidence for an execution session (deprecated: team session layer removed).";
       icons = [ Mcp_server.themed_icon ~label:"TP" ~bg:"#7C3AED" ~fg:"#F5F3FF" ];
@@ -150,11 +150,11 @@ let tool_help_text ~tool_name ~focus schemas =
            @
            (if entry.doc_refs = [] then [] else "" :: "Docs:" :: List.map (fun item -> "- " ^ item) entry.doc_refs)))
 
-let team_session_proof_text ~config:_ ~session_id ~operation_id:_ =
+let execution_session_proof_text ~config:_ ~session_id ~operation_id:_ =
   (* Dashboard_proof removed *)
   String.concat "\n"
     [
-      "Team session proof is not available (team session layer removed).";
+      "Execution session proof is not available (execution session layer removed).";
       Printf.sprintf "Session: %s" session_id;
     ]
 
@@ -204,11 +204,11 @@ let get_json ~config ~name ~arguments schemas =
                 let focus = assoc_string arguments "focus" in
                 tool_help_text ~tool_name ~focus schemas
             | None -> Error "tool_name is required")
-        | "team_session_proof" -> (
+        | "execution_session_proof" -> (
             match assoc_string arguments "session_id" with
             | Some session_id ->
                 let operation_id = assoc_string arguments "operation_id" in
-                Ok (team_session_proof_text ~config ~session_id ~operation_id)
+                Ok (execution_session_proof_text ~config ~session_id ~operation_id)
             | None -> Error "session_id is required")
         | "command_truth" ->
             let operation_id = assoc_string arguments "operation_id" in

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -17,8 +17,8 @@ let normalize_judgment_target_type value =
   let normalized = String.trim value |> String.lowercase_ascii in
   match normalized with
   | "room" | "namespace" -> Ok ("namespace", Operator_judgment.Room)
-  | "team_session" -> Ok ("team_session", Operator_judgment.Team_session)
-  | _ -> Error "target_type must be namespace or team_session"
+  | "execution_session" -> Ok ("execution_session", Operator_judgment.Execution_session)
+  | _ -> Error "target_type must be namespace or execution_session"
 
 let default_fresh_ttl_sec surface =
   match surface with
@@ -35,9 +35,9 @@ let judgment_write_json (ctx : 'a context) args =
   let summary = get_string args "summary" "" |> String.trim in
   if summary = "" then Error "summary is required"
   else if
-    judgment_target_type = Operator_judgment.Team_session && Option.is_none target_id
+    judgment_target_type = Operator_judgment.Execution_session && Option.is_none target_id
   then
-    Error "target_id is required when target_type=team_session"
+    Error "target_id is required when target_type=execution_session"
   else
     let now_unix = Unix.gettimeofday () in
     let generated_at = iso_of_unix now_unix in
@@ -89,9 +89,9 @@ let judgment_latest_json (_ctx : 'a context) args =
   in
   let target_id = get_string_opt args "target_id" in
   if
-    judgment_target_type = Operator_judgment.Team_session && Option.is_none target_id
+    judgment_target_type = Operator_judgment.Execution_session && Option.is_none target_id
   then
-    Error "target_id is required when target_type=team_session"
+    Error "target_id is required when target_type=execution_session"
   else
     let require_fresh = get_bool args "require_fresh" true in
     let judgment =
@@ -143,16 +143,16 @@ let canonical_action_type action_type =
 let normalize_action_target_type target_type =
   match String.trim target_type |> String.lowercase_ascii with
   | "room" | "namespace" -> Ok "namespace"
-  | "team_session" | "keeper" | "review_item" as value -> Ok value
+  | "execution_session" | "keeper" | "review_item" as value -> Ok value
   | "" -> Ok ""
-  | _ -> Error "target_type must be namespace, team_session, keeper, or review_item"
+  | _ -> Error "target_type must be namespace, execution_session, keeper, or review_item"
 
 let default_target_type_for action_type =
   match action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "task_inject" | "social_sweep" -> "namespace"
   | "team_turn" | "team_note" | "team_broadcast" | "team_task_inject"
   | "team_worker_spawn_batch" | "team_stop" ->
-      "team_session"
+      "execution_session"
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
   | "review_resolve" | "review_defer" -> "review_item"
   | _ -> ""

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -387,7 +387,7 @@ let urgency_rank = function
 
 let target_rank = function
   | "room" | "namespace" -> 3
-  | "team_session" -> 2
+  | "execution_session" -> 2
   | "keeper" -> 1
   | _ -> 0
 
@@ -806,6 +806,6 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
             ]
             @ review_queue_json ~actor:actor_name active_reviews deferred_reviews recent_reviews
             @ active_guidance))
-    | "team_session" ->
-        Error "team_session is no longer supported (removed in Phase 2 of #6107)"
+    | "execution_session" ->
+        Error "execution_session digest is no longer supported (removed in Phase 2 of #6107)"
     | _ -> Error "unsupported target_type"

--- a/lib/operator/operator_digest_guidance.ml
+++ b/lib/operator/operator_digest_guidance.ml
@@ -8,12 +8,12 @@ module U = Yojson.Safe.Util
 
 let judgment_surface_for_target_type = function
   | "room" | "namespace" -> "command.namespace"
-  | "team_session" -> "command.swarm"
+  | "execution_session" -> "command.swarm"
   | _ -> "command.namespace"
 
 let judgment_target_type_of_string = function
   | "room" | "namespace" -> Operator_judgment.Room
-  | "team_session" -> Operator_judgment.Team_session
+  | "execution_session" -> Operator_judgment.Execution_session
   | _ -> Operator_judgment.Room
 
 let fresh_operator_judgment config ~target_type ~target_id =

--- a/lib/operator/operator_digest_types.ml
+++ b/lib/operator/operator_digest_types.ml
@@ -357,8 +357,8 @@ let normalize_digest_target_type value =
   | Some raw -> (
       match String.trim raw |> String.lowercase_ascii with
       | "room" | "namespace" -> Ok "namespace"
-      | "team_session" -> Ok "team_session"
-      | _ -> Error "target_type must be one of: namespace, team_session")
+      | "execution_session" -> Ok "execution_session"
+      | _ -> Error "target_type must be one of: namespace, execution_session")
   | None -> Ok "namespace"
 
 (* review_item type + helpers are in Operator_digest_review_types

--- a/lib/operator/operator_judgment.ml
+++ b/lib/operator/operator_judgment.ml
@@ -4,7 +4,7 @@ open Result_syntax
 
 type target_type =
   | Room
-  | Team_session
+  | Execution_session
 
 type record = {
   judgment_id : string;
@@ -30,11 +30,11 @@ type record = {
 
 let target_type_to_string = function
   | Room -> "namespace"
-  | Team_session -> "team_session"
+  | Execution_session -> "execution_session"
 
 let target_type_of_string = function
   | "room" | "namespace" -> Some Room
-  | "team_session" -> Some Team_session
+  | "execution_session" -> Some Execution_session
   | _ -> None
 
 let option_to_yojson = Json_util.option_to_yojson

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -91,7 +91,7 @@ let dashboard_namespace_truth_focus_json ~initialized ~runtime_count
             None,
             `Assoc
               [
-                ("target_type", `String "team_session");
+                ("target_type", `String "execution_session");
                 ("target_id", `String session_id);
               ] )
       | None -> (

--- a/lib/swarm_status/swarm_status_classify.ml
+++ b/lib/swarm_status/swarm_status_classify.ml
@@ -39,7 +39,7 @@ let classify_detachment operations_by_id (detachment : detachment_info) =
     Managed
   else
     match detachment.runtime_kind with
-    | Some "team_session" -> Supervised
+    | Some "execution_session" -> Supervised
     | Some "swarm_projection" -> Projected
     | _ -> (
         match List.assoc_opt detachment.operation_id operations_by_id with
@@ -61,11 +61,11 @@ let classify_decision operations_by_id (decision : decision_info) =
     | Some operation_id -> Option.value ~default:Managed (List.assoc_opt operation_id operations_by_id)
     | None -> (
         match decision.scope_type with
-        | Some "team_session" -> Supervised
+        | Some "execution_session" -> Supervised
         | _ -> Managed)
 
 let classify_trace operations_by_id (trace : trace_info) =
-  if String.equal trace.source "team_session" || String.equal trace.source "operator" then
+  if String.equal trace.source "execution_session" || String.equal trace.source "operator" then
     Supervised
   else if String.equal trace.source "swarm"
           || String.starts_with ~prefix:"swarm-trace-" trace.trace_id
@@ -310,7 +310,7 @@ let lane_timeline_events kind traces sessions decisions =
                  session.goal session.session_id;
              tone =
                if String.equal session.status "running" then "ok" else "warn";
-             source = "team_session";
+             source = "execution_session";
            })
   in
   let approval_events =

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -39,7 +39,7 @@ let legacy_action_alias_enums =
     `String "autonomy_tick" ]
 
 let target_type_enums =
-  [ `String "namespace"; `String "team_session"; `String "keeper"; `String "review_item" ]
+  [ `String "namespace"; `String "execution_session"; `String "keeper"; `String "review_item" ]
 
 let snapshot_schema ~remote =
   {
@@ -65,7 +65,7 @@ let snapshot_schema ~remote =
         ];
   }
 
-let digest_target_type_enums = [ `String "namespace"; `String "team_session" ]
+let digest_target_type_enums = [ `String "namespace"; `String "execution_session" ]
 let judgment_surface_enums =
   [
     `String "command.namespace";

--- a/scripts/harness/workload/supervisor_execution_session.sh
+++ b/scripts/harness/workload/supervisor_execution_session.sh
@@ -186,7 +186,7 @@ normalized_worker_batch_json() {
 
 require_success_response() {
   local payload="$1"
-  local label="${2:-supervisor_team_session response}"
+  local label="${2:-supervisor_execution_session response}"
   mcp_require_jsonrpc_ok "$payload" "$label"
 }
 

--- a/scripts/harness/workload/swarm_delivery.sh
+++ b/scripts/harness/workload/swarm_delivery.sh
@@ -19,4 +19,4 @@ if [ -n "${SWARM_WORKER_BATCH_FILE:-}" ] && [ -z "${SWARM_WORKER_BATCH_JSON:-}" 
   SWARM_WORKER_BATCH_JSON="$(cat "$SWARM_WORKER_BATCH_FILE")"
 fi
 
-exec "${SCRIPT_DIR}/supervisor_team_session.sh" "$@"
+exec "${SCRIPT_DIR}/supervisor_execution_session.sh" "$@"

--- a/scripts/harness_supervisor_execution_session.sh
+++ b/scripts/harness_supervisor_execution_session.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${SCRIPT_DIR}/harness/workload/supervisor_team_session.sh" "$@"
+exec "${SCRIPT_DIR}/harness/workload/supervisor_execution_session.sh" "$@"

--- a/test/test_activity_graph.ml
+++ b/test/test_activity_graph.ml
@@ -127,14 +127,14 @@ let test_graph_json_tracks_runtime_activity_kinds () =
         (Activity_graph.emit config           ~kind:"operation.started"
            ~actor:(Activity_graph.entity ~kind:"agent" "team-session")
            ~subject:(Activity_graph.entity ~kind:"operation" "sess-001")
-           ~tags:[ "team_session"; "operation.started" ]
+           ~tags:[ "execution_session"; "operation.started" ]
            ~payload:(`Assoc [ ("session_id", `String "sess-001") ])
            ());
       ignore
         (Activity_graph.emit config ~kind:"team.turn"
            ~actor:(Activity_graph.entity ~kind:"agent" "claude")
            ~subject:(Activity_graph.entity ~kind:"operation" "sess-001")
-           ~tags:[ "team_session"; "team.turn" ]
+           ~tags:[ "execution_session"; "team.turn" ]
            ~payload:(`Assoc [ ("kind", `String "broadcast") ])
            ());
       ignore

--- a/test/test_capability_registry.ml
+++ b/test/test_capability_registry.ml
@@ -65,8 +65,8 @@ let test_spawned_agent_surface_stays_curated () =
   let names = Lib.Capability_registry.spawned_agent_prefixed_tools in
   check bool "contains masc_status" true
     (List.mem "mcp__masc__masc_status" names);
-  check bool "omits team_session_step" false
-    (List.mem "mcp__masc__masc_team_session_step" names);
+  check bool "omits execution_session_step" false
+    (List.mem "mcp__masc__masc_execution_session_step" names);
   check bool "omits a2a_delegate" false
     (List.mem "mcp__masc__masc_a2a_delegate" names);
   check bool "omits portal_send" false

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -71,7 +71,7 @@ let test_health_and_ci_runner_diagnostics () =
   check bool "ci runner tracks active build dir for diagnostics" true
     (file_contains_pattern "scripts/ci-run-tests.sh" "ACTIVE_TEST_BUILD_DIR")
 
-let test_contract_harness_and_team_session_authz_contracts () =
+let test_contract_harness_and_execution_session_authz_contracts () =
   check bool "contract harness exposes extract_text helper" true
     (file_contains_pattern "scripts/harness/lib/test_framework.sh"
        "extract_text()");
@@ -614,7 +614,7 @@ let test_oas_capacity_restore_contracts () =
     (file_contains_pattern "lib/autoresearch_codegen.ml"
        "Eio_context.get_switch_opt (), Eio_context.get_net_opt ()")
 
-let test_team_session_spawn_tool_contracts () =
+let test_execution_session_spawn_tool_contracts () =
   (* team session spawn tool contracts removed — team session cleanup *)
   ()
 
@@ -734,7 +734,7 @@ let () =
       ("source_guard", [
            test_case "sync and asset contracts" `Quick test_ci_sync_and_asset_contracts;
            test_case "contract harness and team session authz contracts" `Quick
-             test_contract_harness_and_team_session_authz_contracts;
+             test_contract_harness_and_execution_session_authz_contracts;
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
            test_case "http write auth contracts" `Quick test_http_write_auth_contracts;
@@ -768,7 +768,7 @@ let () =
            test_case "oas capacity restore contracts" `Quick
              test_oas_capacity_restore_contracts;
            test_case "team session spawn tool contracts" `Quick
-             test_team_session_spawn_tool_contracts;
+             test_execution_session_spawn_tool_contracts;
            test_case "dashboard timeout guard contracts" `Quick
              test_dashboard_timeout_guard_contracts;
            test_case "mermaid xss contracts" `Quick test_mermaid_xss_contracts;

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -46,7 +46,7 @@ let write_pending_confirm config session_id =
             ("trace_id", `String "ops_fixture_mission");
             ("actor", `String "dashboard-fixture");
             ("action_type", `String "team_stop");
-            ("target_type", `String "team_session");
+            ("target_type", `String "execution_session");
             ("target_id", `String session_id);
             ("payload", `Assoc [ ("reason", `String "fixture pending confirmation") ]);
             ("delegated_tool", `String "masc_operator_action");

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -115,7 +115,7 @@ let test_dashboard_tools_projection () =
         (match usage |> member "dispatch_v2_enabled" with
          | `Bool _ -> true
          | _ -> false);
-      (* masc_team_session_step: schema registered, not in public_mcp_tools,
+      (* masc_execution_session_step: schema registered, not in public_mcp_tools,
          so auto-hidden by Tool_catalog.metadata fallback. *)
       let hidden_tool =
         inventory_rows

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1184,7 +1184,7 @@ let test_handle_request_tools_list_include_deprecated_claim_alias_metadata () =
    | _ -> Alcotest.fail "tool is not an object");
   cleanup_dir base_path
 
-let _test_handle_request_tools_list_hides_team_session_turn_by_default () =
+let _test_handle_request_tools_list_hides_execution_session_turn_by_default () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let clock = Eio.Stdenv.clock env in
@@ -1192,13 +1192,13 @@ let _test_handle_request_tools_list_hides_team_session_turn_by_default () =
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
   let tools = tools_list_all ~clock ~sw state in
-  (* team_session_step is not in the public MCP surface *)
+  (* execution_session_step is not in the public MCP surface *)
   Alcotest.(check bool) "step hidden from public surface" false
     (List.exists
        (function
          | `Assoc fields -> (
              match List.assoc_opt "name" fields with
-             | Some (`String "masc_team_session_step") -> true
+             | Some (`String "masc_execution_session_step") -> true
              | _ -> false)
          | _ -> false)
        tools);
@@ -1308,7 +1308,7 @@ let _test_execute_tool_trpg_flow () =
 
 (* Governance status tool is no longer dispatched *)
 
-let _test_execute_tool_team_session_step_direct_call () =
+let _test_execute_tool_execution_session_step_direct_call () =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -1343,7 +1343,7 @@ let _test_execute_tool_team_session_step_direct_call () =
 
       let (ok_start, start_msg) =
         Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-          ~name:"masc_team_session_start"
+          ~name:"masc_execution_session_start"
           ~arguments:
             (`Assoc
               [
@@ -1362,7 +1362,7 @@ let _test_execute_tool_team_session_step_direct_call () =
 
       let (ok_turn, turn_msg) =
         Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
-          ~name:"masc_team_session_step"
+          ~name:"masc_execution_session_step"
           ~arguments:
             (`Assoc
               [
@@ -2558,7 +2558,7 @@ let eio_tests = [
     test_handle_request_tools_list_include_hidden_metadata;
   "handle tools/list include deprecated claim alias metadata", `Quick,
     test_handle_request_tools_list_include_deprecated_claim_alias_metadata;
-  (* team_session_turn hide test removed — team session cleanup *)
+  (* execution_session_turn hide test removed — team session cleanup *)
   "handle tools/list include usage metadata", `Quick,
     test_handle_request_tools_list_include_usage_metadata;
   "handle tools/list paginates", `Quick, test_handle_request_tools_list_paginates;
@@ -2584,7 +2584,7 @@ let eio_tests = [
   "handle method not found", `Quick, test_handle_request_method_not_found;
   (* TRPG tool tests removed — modules archived *)
   (* Governance status tool test removed *)
-  (* team_session_step direct call test removed — team session cleanup *)
+  (* execution_session_step direct call test removed — team session cleanup *)
   "legacy persisted agent read only for ephemeral names", `Quick,
     test_should_read_legacy_persisted_agent_name;
   "explicit agent_name not overridden", `Quick, test_execute_tool_explicit_agent_name_not_overridden;

--- a/test/test_memory_oas_5tier.ml
+++ b/test/test_memory_oas_5tier.ml
@@ -96,7 +96,7 @@ let test_create_memory_full_seeds_recent_episodes () =
   let dir = setup_tmp_dir () in
   ignore
     (Institution_eio.record_episode_jsonl
-       ~event_type:"team_session"
+       ~event_type:"execution_session"
        ~summary:"worker completed setup"
        ~participants:["worker-a"]
        ~outcome:`Success

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -152,7 +152,7 @@ let test_confirm_keeps_pending_token_when_delegated_action_fails () =
             ("trace_id", `String "trace-retry");
             ("actor", `String "operator");
             ("action_type", `String "team_stop");
-            ("target_type", `String "team_session");
+            ("target_type", `String "execution_session");
             ("target_id", `String "missing-session");
             ("payload", `Assoc []);
             ("delegated_tool", `String "masc_operator_action");

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -69,7 +69,7 @@ let test_snapshot_exposes_keeper_and_social_actions () =
             | Some row -> row
             | None -> Alcotest.fail "expected team_worker_spawn_batch in available_actions"
           in
-          Alcotest.(check string) "worker spawn batch target_type" "team_session"
+          Alcotest.(check string) "worker spawn batch target_type" "execution_session"
             Yojson.Safe.Util.(worker_spawn_batch |> member "target_type" |> to_string);
           Alcotest.(check bool) "worker spawn batch confirm true" true
             Yojson.Safe.Util.(worker_spawn_batch |> member "confirm_required" |> to_bool);
@@ -1086,7 +1086,7 @@ let test_keeper_msg_auto_execution_session_bridge () =
       else
         let first_json = parse_json_exn body in
         let open Yojson.Safe.Util in
-        Alcotest.(check string) "mode" "team_session"
+        Alcotest.(check string) "mode" "execution_session"
           (first_json |> member "mode" |> to_string);
         Alcotest.(check bool) "created" true
           (first_json |> member "created" |> to_bool);
@@ -1095,7 +1095,7 @@ let test_keeper_msg_auto_execution_session_bridge () =
         let session_id = first_json |> member "session_id" |> to_string in
         (* Team_session_store removed — skip session verification *)
         ignore session_id;
-        (* Team session tools removed — skip team_session_status dispatch test *)
+        (* Team session tools removed — skip execution_session_status dispatch test *)
         ignore (config, sw, env, session_id);
         Alcotest.(check bool) "spawn_error surfaced" true
           (first_json |> member "spawn_error" <> `Null);
@@ -1119,9 +1119,9 @@ let test_keeper_msg_auto_execution_session_bridge () =
         Alcotest.(check bool) "status exposes auto team session disabled" false
           Yojson.Safe.Util.(status_json |> member "auto_execution_session_enabled" |> to_bool);
         Alcotest.(check bool) "status omits team session state" true
-          Yojson.Safe.Util.(status_json |> member "team_session_state" = `Null);
+          Yojson.Safe.Util.(status_json |> member "execution_session_state" = `Null);
         Alcotest.(check bool) "status omits team session bridge" true
-          Yojson.Safe.Util.(status_json |> member "team_session_bridge" = `Null);
+          Yojson.Safe.Util.(status_json |> member "execution_session_bridge" = `Null);
         (* Team_session_store removed — skip event verification *)
         ignore (config, session_id);
         let ok, second_body =

--- a/test/test_operator_control_swarm.ml
+++ b/test/test_operator_control_swarm.ml
@@ -39,7 +39,7 @@ let test_confirm_rejects_expired_token () =
                        ("trace_id", `String "ops_expired");
                        ("actor", `String "operator");
                        ("action_type", `String "team_stop");
-                       ("target_type", `String "team_session");
+                       ("target_type", `String "execution_session");
                        ("target_id", `String "session-1");
                        ("payload", `Assoc []);
                        ("delegated_tool", `String "masc_operator_action");

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -518,7 +518,7 @@ let with_server ?(host = "127.0.0.1") ?(enable_auth = true) f =
         ~implementer_b_token ~supervisor_nickname ~planner_nickname
         ~implementer_a_nickname ~implementer_b_nickname)
 
-let _test_operator_mcp_supervises_team_session_impl () =
+let _test_operator_mcp_supervises_execution_session_impl () =
   (* Disabled: operator MCP sessions don't resolve agent_name from bearer token,
      so tool-level authorize_tool fails with "No credential found for <agent>".
      Needs production fix in mcp_server_eio_execute.ml to propagate credential
@@ -571,7 +571,7 @@ let _test_operator_mcp_supervises_team_session_impl () =
          ]));
   let start_json =
     call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"operator-supervisor"
-      ~id:5 ~name:"masc_team_session_start"
+      ~id:5 ~name:"masc_execution_session_start"
       (`Assoc
         [
           ("goal", `String "Exercise supervised MCP team session flow");
@@ -594,13 +594,13 @@ let _test_operator_mcp_supervises_team_session_impl () =
         ])
   in
   let session_id =
-    start_json |> extract_tool_result_json "team_session_start"
+    start_json |> extract_tool_result_json "execution_session_start"
     |> U.member "session_id" |> U.to_string
   in
 
   ignore
     (call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"operator-supervisor"
-       ~id:6 ~name:"masc_team_session_step"
+       ~id:6 ~name:"masc_execution_session_step"
        (`Assoc
          [
            ("session_id", `String session_id);
@@ -613,7 +613,7 @@ let _test_operator_mcp_supervises_team_session_impl () =
   let worker_step token session_id_header id message =
     ignore
       (call_tool ~token ~path:"/mcp" ~session_id:session_id_header ~id
-         ~name:"masc_team_session_step"
+         ~name:"masc_execution_session_step"
          (`Assoc
            [
              ("session_id", `String session_id);
@@ -668,12 +668,12 @@ let _test_operator_mcp_supervises_team_session_impl () =
       (`Assoc
         [
           ("actor", `String supervisor_nickname);
-          ("target_type", `String "team_session");
+          ("target_type", `String "execution_session");
           ("target_id", `String session_id);
         ])
   in
   let digest_result = extract_tool_payload_json "operator_digest" digest_json in
-  check string "digest target type" "team_session"
+  check string "digest target type" "execution_session"
     (digest_result |> U.member "target_type" |> U.to_string);
   check string "digest target id" session_id
     (digest_result |> U.member "target_id" |> U.to_string);
@@ -740,7 +740,7 @@ let _test_operator_mcp_supervises_team_session_impl () =
 
   let events_json =
     call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"operator-supervisor" ~id:15
-      ~name:"masc_team_session_events"
+      ~name:"masc_execution_session_events"
       (`Assoc
         [
           ("session_id", `String session_id);
@@ -749,7 +749,7 @@ let _test_operator_mcp_supervises_team_session_impl () =
         ])
   in
   let events_text =
-    events_json |> extract_tool_result_json "team_session_events" |> Yojson.Safe.to_string
+    events_json |> extract_tool_result_json "execution_session_events" |> Yojson.Safe.to_string
   in
   check bool "planner event present" true (contains_substr "planner" events_text);
   check bool "implementer-a event present" true
@@ -768,7 +768,7 @@ let _test_operator_mcp_supervises_team_session_impl () =
   let finalize_json =
     call_tool ~token:supervisor_token ~max_time_sec:35 ~path:"/mcp"
       ~session_id:"operator-supervisor"
-      ~id:16 ~name:"masc_team_session_finalize"
+      ~id:16 ~name:"masc_execution_session_finalize"
       (`Assoc
         [
           ("session_id", `String session_id);
@@ -779,7 +779,7 @@ let _test_operator_mcp_supervises_team_session_impl () =
         ])
   in
   let finalize_result =
-    extract_tool_result_json "team_session_finalize" finalize_json
+    extract_tool_result_json "execution_session_finalize" finalize_json
   in
   check string "finalize terminal status" "interrupted"
     (finalize_result |> U.member "terminal_status" |> U.to_string);
@@ -790,14 +790,14 @@ let _test_operator_mcp_supervises_team_session_impl () =
 
   let report_json =
     call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"operator-supervisor"
-      ~id:17 ~name:"masc_team_session_report"
+      ~id:17 ~name:"masc_execution_session_report"
       (`Assoc
         [
           ("session_id", `String session_id);
           ("force_regenerate", `Bool false);
         ])
   in
-  let report_result = extract_tool_result_json "team_session_report" report_json in
+  let report_result = extract_tool_result_json "execution_session_report" report_json in
   check bool "report json path present" true
     (report_result |> U.member "json_path" <> `Null);
   check bool "report markdown path present" true
@@ -805,14 +805,14 @@ let _test_operator_mcp_supervises_team_session_impl () =
 
   let prove_json =
     call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"operator-supervisor"
-      ~id:18 ~name:"masc_team_session_prove"
+      ~id:18 ~name:"masc_execution_session_prove"
       (`Assoc
         [
           ("session_id", `String session_id);
           ("generate_report_if_missing", `Bool false);
         ])
   in
-  let prove_result = extract_tool_result_json "team_session_prove" prove_json in
+  let prove_result = extract_tool_result_json "execution_session_prove" prove_json in
   check bool "prove json path present" true
     (prove_result |> U.member "proof_json_path" <> `Null);
   check bool "prove markdown path present" true
@@ -877,7 +877,7 @@ let test_agent_json_route_served_on_canonical_path () =
   let (_json, name) = fetch_agent_card 3 in
   check string "agent card name present" "MASC-MCP" name
 
-let test_operator_mcp_supervises_team_session () =
+let test_operator_mcp_supervises_execution_session () =
   Alcotest.skip ()
 
 let () =
@@ -886,7 +886,7 @@ let () =
       ( "operator",
         [
           test_case "remote operator supervises team session over MCP" `Slow
-            test_operator_mcp_supervises_team_session;
+            test_operator_mcp_supervises_execution_session;
           test_case "full mcp requires auth on non-loopback bind" `Slow
             test_mcp_requires_auth_when_bound_non_loopback;
           test_case "canonical agent discovery route" `Quick

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -304,7 +304,7 @@ let test_terminal_projected_session_artifacts_do_not_keep_supervised_lane_presen
       operation_id = "detachment-ts-old";
       source = "projected";
       status = "cancelled";
-      runtime_kind = Some "team_session";
+      runtime_kind = Some "execution_session";
       session_id = Some "ts-old";
       roster = [ "worker-a"; "worker-b" ];
       leader_id = Some "worker-a";

--- a/test/test_tool_repo_synthesis.ml
+++ b/test/test_tool_repo_synthesis.ml
@@ -92,7 +92,7 @@ let test_repo_synthesis_swarm_start_avoids_saturated_platoon_cap () =
       ]
   in
   (* Team_session_engine_eio removed — swarm_start returns an error
-     because start_team_session is stubbed to return Error. Verify
+     because start_execution_session is stubbed to return Error. Verify
      the dispatch handles this gracefully. *)
   match
     Lib.Tool_autoresearch.dispatch ctx ~name:"masc_repo_synthesis_swarm_start"


### PR DESCRIPTION
## Summary
- `Team_session` variant → `Execution_session` 리네이밍
- 에러 메시지, 프롬프트, 분류기, 테스트 fixture에서 `team_session` 문자열 제거
- 스크립트 파일 리네이밍 (`supervisor_team_session.sh` → `supervisor_execution_session.sh`)
- **94 → 7건** (남은 7건은 backward-compat JSON key guard)
- 31 files, net zero (95 insertions, 95 deletions — pure rename)

Closes #6107

## #6107 Epic 전체 요약

| Phase | PR | 내용 | 줄 수 |
|---|---|---|---|
| 0 | #6127 | tool_team_session 모듈 | -10,000 |
| 1 | #6217 | core + proof + contract | -10,263 |
| 2 | #6272 | dead session code | -2,988 |
| 3 | #6303 | team_session_types 삭제 | -1,858 |
| 4 | #6331 | team_session_id 필드 제거 | -760 |
| **5** | **이 PR** | **문자열 리네이밍** | **~0 (rename)** |
| **합계** | **6 PR** | | **~-25,869줄** |

## Test plan
- [x] `dune build --root .` 통과
- [x] `grep team_session` → 7건 (backward-compat only)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)