### PR TITLE
fix(keeper): auto-recover reconcile-safe tools on server parse errors

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -59,6 +59,26 @@ let is_transient_network_error (err : Oas.Error.sdk_error) : bool =
   | Oas.Error.Api (ServerError { status = 503; _ }) -> true
   | _ -> false
 
+(** Detect server-side request body parse errors (e.g. Ollama yyjson
+    rejecting a request with "Value looks like object, but can't find
+    closing '}' symbol").  The LLM API never processed the request, so
+    committed tool results are not at risk of duplication.
+
+    These errors may recur with the same payload, so they are NOT
+    eligible for same-turn retry.  They ARE eligible for auto-recovery
+    (skip manual reconcile) when all committed tools are reconcile-safe:
+    the keeper's next heartbeat cycle will build a fresh prompt. *)
+let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
+  match err with
+  | Oas.Error.Api (InvalidRequest { message }) ->
+      let lower = String.lowercase_ascii message in
+      string_contains_substring ~needle:"closing" lower
+      || string_contains_substring ~needle:"can't find" lower
+      || string_contains_substring ~needle:"unexpected character" lower
+      || string_contains_substring ~needle:"unterminated" lower
+      || string_contains_substring ~needle:"parse error" lower
+  | _ -> false
+
 let ambiguous_side_effect_error_prefix =
   "turn outcome ambiguous after committed mutating tool call(s)"
 
@@ -1170,17 +1190,23 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 if committed_tools <> []
                    && Keeper_tool_registry.all_tools_reconcile_safe
                         committed_tools
-                   && is_transient_network_error err
+                   && (is_transient_network_error err
+                       || is_server_rejected_parse_error err)
                 then begin
                   (* All committed tools are board-like (duplicate-tolerant)
-                     AND the failure is transient.  Permanent errors (401, 403,
-                     malformed request) must NOT bypass — they would loop
-                     forever on retry.  Duplicate board posts are an acceptable
-                     cost vs. a permanently stuck keeper. *)
+                     AND the failure is transient or the server rejected the
+                     request body before processing (parse error).  Parse
+                     errors mean the LLM never saw the request, so no risk
+                     of duplicate processing.  The keeper's next cycle will
+                     build a fresh prompt that may avoid the parse issue. *)
                   let err_preview = short_preview (Oas.Error.to_string err) in
+                  let reason =
+                    if is_server_rejected_parse_error err then "server parse rejection"
+                    else "transient error"
+                  in
                   Log.Keeper.warn
-                    "%s: transient error after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (error: %s)"
-                    meta.name
+                    "%s: %s after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (error: %s)"
+                    meta.name reason
                     (String.concat ", " committed_tools)
                     err_preview;
                   Error err

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -75,6 +75,13 @@ val broadcast_lifecycle_events :
     Uses structured [Oas.Error.sdk_error] pattern matching. *)
 val is_transient_network_error : Oas.Error.sdk_error -> bool
 
+(** Detect server-side request body parse errors (e.g. Ollama yyjson
+    rejecting a malformed or oversized request body).  The LLM never
+    processed the request, so committed tool results are not at risk
+    of duplication.  Used to auto-recover reconcile-safe tools instead
+    of requiring manual reconcile. *)
+val is_server_rejected_parse_error : Oas.Error.sdk_error -> bool
+
 (** Reclassify any post-commit turn error as a persistent integrity error when
     mutating tool calls already committed in the same turn. *)
 val reclassify_error_after_side_effect :

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1914,6 +1914,40 @@ let test_post_commit_failure_kind_marks_non_timeouts_as_failures () =
     (KR.ambiguous_partial_commit_kind_to_string
        (UT.post_commit_failure_kind_of_error auth_error))
 
+let test_server_rejected_parse_error_ollama_closing_brace () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = {|Value looks like object, but can't find closing '}' symbol|} })
+  in
+  check bool "ollama closing brace is parse error" true
+    (UT.is_server_rejected_parse_error err);
+  check bool "ollama closing brace is NOT transient network" false
+    (UT.is_transient_network_error err)
+
+let test_server_rejected_parse_error_unterminated () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "Unterminated string in JSON" })
+  in
+  check bool "unterminated is parse error" true
+    (UT.is_server_rejected_parse_error err)
+
+let test_server_rejected_parse_error_generic_invalid_request () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "bad tool schema" })
+  in
+  check bool "generic InvalidRequest is NOT parse error" false
+    (UT.is_server_rejected_parse_error err)
+
+let test_server_rejected_parse_error_network_error () =
+  let err =
+    Agent_sdk.Error.Api
+      (NetworkError { message = "connection refused" })
+  in
+  check bool "network error is NOT parse error" false
+    (UT.is_server_rejected_parse_error err)
+
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api
@@ -2803,6 +2837,14 @@ let () =
             test_post_commit_failure_kind_marks_timeouts;
           test_case "non-timeout classified as post-commit failure" `Quick
             test_post_commit_failure_kind_marks_non_timeouts_as_failures;
+          test_case "ollama closing brace detected as server parse error" `Quick
+            test_server_rejected_parse_error_ollama_closing_brace;
+          test_case "unterminated JSON detected as server parse error" `Quick
+            test_server_rejected_parse_error_unterminated;
+          test_case "generic InvalidRequest is NOT server parse error" `Quick
+            test_server_rejected_parse_error_generic_invalid_request;
+          test_case "network error is NOT server parse error" `Quick
+            test_server_rejected_parse_error_network_error;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick


### PR DESCRIPTION
## Summary

- Ollama yyjson가 요청 본문을 파싱 못할 때 (`"Value looks like object, but can't find closing '}' symbol"`), LLM이 요청을 처리하지 않았으므로 committed tool의 중복 실행 위험이 없음
- `is_server_rejected_parse_error` predicate 추가: Ollama/LLM 서버의 JSON 파싱 거부 에러를 감지
- `reconcile_safe` 도구만 committed된 경우, 서버 파싱 에러에서도 자동 복구 (manual reconcile 불필요)
- **sangsu** (`keeper_board_comment`) 같은 keeper가 불필요하게 stuck 되는 문제 해결

## Root cause

`is_transient_network_error`가 `NetworkError/Timeout/Overloaded/503`만 매칭하고, Ollama의 `InvalidRequest` (JSON 파싱 실패)는 매칭하지 않음. reconcile-safe 도구의 자동 복구 조건이 `transient && reconcile_safe`였는데, 서버 파싱 에러는 transient이 아니라 빠졌음.

## Changes

| File | Change |
|------|--------|
| `keeper_unified_turn.ml` | `is_server_rejected_parse_error` predicate 추가, 자동 복구 조건 확장, 로그 메시지 개선 |
| `keeper_unified_turn.mli` | 새 predicate 인터페이스 노출 |
| `test_keeper_unified.ml` | 4개 테스트 추가 (ollama closing brace, unterminated, generic NOT, network NOT) |

## Test plan

- [x] `dune build @install` 빌드 성공
- [x] `test_keeper_unified.exe` 145개 테스트 전체 통과
- [x] 새 테스트 4개 (test 15-18) 통과
- [ ] sangsu/example reconcile clear 후 다음 cycle에서 stuck 안 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)