### PR TITLE
fix(keeper): register board_delete/cleanup in tool registry

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -62,6 +62,7 @@ let core_discovery_tools =
     (* Board: core interaction *)
     "keeper_board_get"; "keeper_board_post";
     "keeper_board_comment"; "keeper_board_vote"; "keeper_board_list";
+    "keeper_board_delete"; "keeper_board_cleanup";
     (* Shell: readonly + execution (action symmetry) *)
     "keeper_shell"; "keeper_bash";
     (* VCS: essential for coding keepers *)


### PR DESCRIPTION
## Summary
`keeper_board_delete`와 `keeper_board_cleanup`이 dispatch(`keeper_exec_board.ml`)에는 등록되어 있지만 `keeper_tool_registry.ml`의 candidate 목록에 빠져있어 startup 시 warning 발생.

```
tool_policy unknown tool names (2): keeper_board_cleanup, keeper_board_delete
```

1줄 fix.

## Test plan
- [x] `dune build --root .` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)