### PR TITLE
fix(keeper): tighten parse error predicates per review

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -72,9 +72,12 @@ let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
   match err with
   | Oas.Error.Api (InvalidRequest { message }) ->
       let lower = String.lowercase_ascii message in
-      string_contains_substring ~needle:"closing" lower
-      || string_contains_substring ~needle:"can't find" lower
-      || string_contains_substring ~needle:"unexpected character" lower
+      (* Compound patterns to avoid false positives on generic messages
+         like "Service closing" or "Can't find the specified tool".
+         Each pattern targets a specific JSON parser error family. *)
+      (string_contains_substring ~needle:"can't find closing" lower
+       || string_contains_substring ~needle:"find end of" lower)
+      || string_contains_substring ~needle:"unexpected character in json" lower
       || string_contains_substring ~needle:"unterminated" lower
       || string_contains_substring ~needle:"parse error" lower
   | _ -> false

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -76,7 +76,7 @@ val broadcast_lifecycle_events :
 val is_transient_network_error : Oas.Error.sdk_error -> bool
 
 (** Detect server-side request body parse errors (e.g. Ollama yyjson
-    rejecting a malformed or oversized request body).  The LLM never
+    rejecting a malformed request body).  The LLM never
     processed the request, so committed tool results are not at risk
     of duplication.  Used to auto-recover reconcile-safe tools instead
     of requiring manual reconcile. *)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1932,12 +1932,52 @@ let test_server_rejected_parse_error_unterminated () =
   check bool "unterminated is parse error" true
     (UT.is_server_rejected_parse_error err)
 
+let test_server_rejected_parse_error_unexpected_char () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "Unexpected character in JSON at position 42" })
+  in
+  check bool "unexpected character in json is parse error" true
+    (UT.is_server_rejected_parse_error err)
+
+let test_server_rejected_parse_error_parse_error () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "Parse error at position 1024" })
+  in
+  check bool "parse error is parse error" true
+    (UT.is_server_rejected_parse_error err)
+
+let test_server_rejected_parse_error_case_insensitive () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "PARSE ERROR in request body" })
+  in
+  check bool "uppercase PARSE ERROR detected" true
+    (UT.is_server_rejected_parse_error err)
+
 let test_server_rejected_parse_error_generic_invalid_request () =
   let err =
     Agent_sdk.Error.Api
       (InvalidRequest { message = "bad tool schema" })
   in
   check bool "generic InvalidRequest is NOT parse error" false
+    (UT.is_server_rejected_parse_error err)
+
+let test_server_rejected_parse_error_generic_closing () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "Service closing for maintenance" })
+  in
+  check bool "generic 'closing' is NOT parse error" false
+    (UT.is_server_rejected_parse_error err)
+
+let test_server_rejected_parse_error_generic_cant_find () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "Can't find the specified tool 'my_tool'" })
+  in
+  check bool "generic 'can't find' is NOT parse error" false
     (UT.is_server_rejected_parse_error err)
 
 let test_server_rejected_parse_error_network_error () =
@@ -2841,8 +2881,18 @@ let () =
             test_server_rejected_parse_error_ollama_closing_brace;
           test_case "unterminated JSON detected as server parse error" `Quick
             test_server_rejected_parse_error_unterminated;
+          test_case "unexpected character in JSON detected" `Quick
+            test_server_rejected_parse_error_unexpected_char;
+          test_case "parse error detected" `Quick
+            test_server_rejected_parse_error_parse_error;
+          test_case "case insensitive detection" `Quick
+            test_server_rejected_parse_error_case_insensitive;
           test_case "generic InvalidRequest is NOT server parse error" `Quick
             test_server_rejected_parse_error_generic_invalid_request;
+          test_case "generic 'closing' is NOT server parse error" `Quick
+            test_server_rejected_parse_error_generic_closing;
+          test_case "generic 'can't find' is NOT server parse error" `Quick
+            test_server_rejected_parse_error_generic_cant_find;
           test_case "network error is NOT server parse error" `Quick
             test_server_rejected_parse_error_network_error;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick


### PR DESCRIPTION
## Summary

Follow-up to #6370 — tighten `is_server_rejected_parse_error` predicates per GLM-5.1 cross-model review.

- loose `"closing"` / `"can't find"` 단독 매칭을 compound 패턴으로 교체
  - `"can't find closing"`, `"find end of"` — Ollama yyjson 에러 전용
  - `"unexpected character in json"` — 일반 JSON 파서 에러 전용
- false-positive regression 테스트 추가: `"Service closing"`, `"Can't find the specified tool"` 등 비파싱 메시지가 매칭되지 않는지 검증
- mli 문서에서 "oversized" 제거 (코드가 감지하지 않는 기능)

## Test plan

- [x] 150개 테스트 전체 통과
- [x] 5개 신규 테스트 (positive: unexpected char, parse error, case insensitive; negative: generic closing, generic can't find)
- [x] 기존 테스트 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)