### PR TITLE
fix(ci): resolve Health check false-negative for agent_sdk detection

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -113,10 +113,23 @@ version_gte() {
 }
 
 if command -v opam >/dev/null 2>&1; then
-  installed_packages="$(opam exec -- opam list --installed --columns=name,version --short 2>/dev/null)"
+  # Refresh switch environment — opam install may have changed the switch
+  # state on disk without updating the current shell's env vars.
+  eval "$(opam env --switch=. --set-switch 2>/dev/null)" || true
+
+  # Use opam list directly (not opam exec --) to avoid stale environment
+  # from a cached exec context. Keep stderr visible for diagnostics.
+  installed_packages="$(opam list --installed --columns=name,version --short 2>&1)" || true
   installed_version="$(awk '$1 == "agent_sdk" { print $2 }' <<<"${installed_packages}")"
+
+  # Fallback: opam show reads package metadata directly from the switch.
+  if [[ -z "${installed_version}" ]]; then
+    installed_version="$(opam show agent_sdk --field=version 2>/dev/null || true)"
+  fi
+
   if [[ -z "${installed_version}" ]]; then
     echo "agent_sdk is not installed in the current opam switch" >&2
+    echo "  opam list output: ${installed_packages:-<empty>}" >&2
     echo "repair: bash scripts/opam-pin-external-deps.sh && opam install . --deps-only --with-test --with-doc -y" >&2
     exit 1
   fi
@@ -126,7 +139,7 @@ if command -v opam >/dev/null 2>&1; then
     exit 1
   fi
 
-  pin_list_output="$(opam exec -- opam pin list 2>/dev/null || true)"
+  pin_list_output="$(opam pin list 2>/dev/null || true)"
   pin_line="$(awk '$1 ~ /^agent_sdk\./ { print }' <<<"${pin_list_output}")"
   if [[ -n "${pin_line}" ]]; then
     installed_pin_source="$(awk '{print $3}' <<<"${pin_line}")"


### PR DESCRIPTION
## Summary
- Health CI reports `agent_sdk is not installed` despite successful `opam install` 10 seconds earlier
- Root cause: `opam exec -- opam list` reads stale switch environment post-install
- Fix: refresh opam env, drop redundant `opam exec --`, add `opam show` fallback + diagnostics

## Changes
1. `eval $(opam env --switch=. --set-switch)` before package detection
2. `opam list` directly instead of `opam exec -- opam list`
3. `opam show agent_sdk --field=version` fallback when `opam list` returns empty
4. Diagnostic output: `opam list output: <...>` on failure

## Test plan
- [ ] CI Health check passes on this PR (self-validating)
- [ ] Local `scripts/check-oas-pin.sh --local-only` reaches version comparison (confirmed: detects 0.118.1)

Closes #6374

🤖 Generated with [Claude Code](https://claude.com/claude-code)