### PR TITLE
fix: surface silent exception swallowing with diagnostic warnings

### DIFF
--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -46,7 +46,11 @@ let get_audit_store () =
      | store ->
        audit_store_ref := Some store;
        Some store
-     | exception _ -> None)
+     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
+     | exception exn ->
+       Log.Keeper.warn "approval_queue: audit store creation failed: %s"
+         (Printexc.to_string exn);
+       None)
 
 let audit_approval_event ~event_type ~id ~keeper_name ~tool_name
     ~risk_level ?(decision="") () =

--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -63,7 +63,10 @@ let parse_decision_line (line : string) : parsed_decision option =
     let tools_used = Safe_ops.json_string_list "tools_used" json in
     Some { timestamp_unix; outcome; tool_call_count; tools_used }
   | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-  | exception _ -> None
+  | exception exn ->
+    Log.Keeper.warn "telemetry_feedback: turn record parse failed: %s"
+      (Printexc.to_string exn);
+    None
 
 (* ------------------------------------------------------------------ *)
 (* Stats computation                                                   *)

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -142,7 +142,10 @@ let canonical_base_path path =
   | Some git_root -> git_root
   | None -> normalized
   | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-  | exception _ -> normalized
+  | exception exn ->
+    Log.Room.warn "canonical_base_path: git root lookup failed for %s: %s"
+      normalized (Printexc.to_string exn);
+    normalized
 
 let path_has_masc_dir path =
   let masc_dir = Filename.concat path ".masc" in

--- a/lib/telemetry_unified.ml
+++ b/lib/telemetry_unified.ml
@@ -145,7 +145,10 @@ let read_fixed_source dir source ~n : Yojson.Safe.t list =
       let entries = Dated_jsonl.read_recent store n in
       List.map (tag_entry source) entries
     | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-    | exception _ -> []
+    | exception exn ->
+      Log.Telemetry.warn "read_fixed_source: %s store open failed: %s"
+        (source_to_string source) (Printexc.to_string exn);
+      []
 
 (* ── Read keeper metrics (per-keeper directories) ───── *)
 
@@ -212,17 +215,23 @@ let count_fixed_source_entries ~masc_root ~base_path source : int =
       (match Dated_jsonl.create ~base_dir:dir () with
        | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-       | exception _ -> 0)
+       | exception exn ->
+         Log.Telemetry.warn "count_source_entries: %s store open failed: %s"
+           (source_to_string source) (Printexc.to_string exn);
+         0)
 
 let summary_json ~base_path ~masc_root () : Yojson.Safe.t =
   let keeper_dirs = discover_keeper_metric_dirs masc_root in
   let keeper_total =
-    List.fold_left (fun acc (_, dir) ->
+    List.fold_left (fun acc (name, dir) ->
       acc +
       (match Dated_jsonl.create ~base_dir:dir () with
        | store -> Dated_jsonl.count_entries store
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-       | exception _ -> 0)
+       | exception exn ->
+         Log.Telemetry.warn "summary_json: keeper %s store open failed: %s"
+           name (Printexc.to_string exn);
+         0)
     ) 0 keeper_dirs
   in
   let source_json source =


### PR DESCRIPTION
## Summary
- 6 `exception _ -> fallback` patterns silently discarded errors
- Now all sites log the exception before returning the same fallback
- No behavior change for callers — same return values
- Added missing `Eio.Cancel.Cancelled` re-raise in `keeper_approval_queue.ml`

## Files changed
| File | Issue |
|---|---|
| `lib/telemetry_unified.ml` | 3 sites: `[]` or `0` on Dated_jsonl open failure |
| `lib/keeper/keeper_telemetry_feedback.ml` | `None` on turn record parse failure |
| `lib/keeper/keeper_approval_queue.ml` | `None` on audit store creation + missing Cancel re-raise |
| `lib/room/room_utils_backend_setup.ml` | `normalized` on git root lookup failure |

## Test plan
- [ ] `dune build` passes (verified locally)
- [ ] CI Build and Test passes
- [ ] Grep for remaining `exception _` patterns: 0 new silent swallowers

Part of #6290

🤖 Generated with [Claude Code](https://claude.com/claude-code)