### PR TITLE
fix(keeper): whitelist keeper meta files by dot-free stem

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1366,23 +1366,15 @@ let read_meta_file_path path : (keeper_meta option, string) result =
          Error e))
 ;;
 
-(** Sidecar stem suffixes (without the trailing .json).
-    A file like [keeper.manual_reconcile.json] has stem
-    [keeper.manual_reconcile]; stripping [.json] and checking
-    [String.ends_with ~suffix] on this stem avoids false-positives
-    for keeper names that happen to contain dots (e.g. [foo.dataset]). *)
-let keeper_sidecar_stem_suffixes =
-  [ ".manual_reconcile"; ".dataset" ]
-
+(** Keeper meta files are [{name}.json] where [name] contains no dots.
+    Sidecar files use [{name}.{kind}.json] (e.g. [keeper.manual_reconcile.json]).
+    This whitelist approach (Absence > Prohibition) means new sidecar types
+    are automatically excluded without updating a blacklist. *)
 let is_keeper_meta_file f =
   if not (Filename.check_suffix f ".json") then false
   else
     let stem = Filename.chop_suffix f ".json" in
-    not
-      (List.exists
-         (fun suf -> String.length stem > String.length suf
-                     && String.ends_with ~suffix:suf stem)
-         keeper_sidecar_stem_suffixes)
+    stem <> "" && not (String.contains stem '.')
 let keeper_names config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with


### PR DESCRIPTION
## Summary
- Sidecar files (e.g. `keeper.manual_reconcile.json`) were excluded by a blacklist of known suffixes
- New sidecar types required updating the list — easy to forget
- Switch to whitelist: keeper meta = `{name}.json` where stem has no dots
- Sidecar = `{name}.{kind}.json` — automatically excluded

## Before/After
| | Before | After |
|---|---|---|
| `sangsu.json` | keeper | keeper |
| `sangsu.manual_reconcile.json` | excluded (blacklist) | excluded (has dot) |
| `sangsu.stats.json` | **keeper (bug)** | excluded (has dot) |
| `sangsu.tla-trace.json` | N/A (.jsonl) | N/A (.jsonl) |

## Design
Absence > Prohibition: no suffix list to maintain.

## Test plan
- [ ] `dune build` passes
- [ ] CI Build and Test passes
- [ ] Verified: no existing keeper names contain dots (checked `~/me/.masc/keepers/`)

Closes #6305

🤖 Generated with [Claude Code](https://claude.com/claude-code)