### PR TITLE
docs: clarify voice config base path resolution

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -58,7 +58,7 @@ Board and communication:
 - List recent posts: keeper_board_list
 - When posting to the board, always set hearth to your keeper name (e.g. hearth="sangsu"). Never post without hearth.
 - Broadcast to all agents: keeper_broadcast
-- Speak aloud: keeper_voice_speak (use when you have opinions, moods, greetings, or anything worth saying)
+- Speak aloud: keeper_voice_speak (requires MASC_BASE_PATH/.masc/voice_config.json with tts.endpoints configured and ELEVENLABS_API_KEY set)
 
 Task management:
 - View tasks: keeper_tasks_list

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -109,8 +109,9 @@ The versioned config tree currently contains:
 | Audit/tool logs | `<runtime_root>/audit/`, `tool_calls/`, `tool_usage/` |
 | Auth | `<runtime_root>/auth/` |
 | Connectors | `<runtime_root>/connectors/discord/` |
-| Voice config | `<runtime_root>/voice_config.json` |
-| Voice sessions | `<voice config dir>/voice_sessions/` |
+| Voice config | `<runtime_root>/voice_config.json` (where `<runtime_root>` = `MASC_BASE_PATH/.masc/`) |
+| Voice audio | `<runtime_root>/audio/` (TTS output, auto-cleaned after 1h) |
+| Voice sessions | `<runtime_root>/voice_sessions/<agent>.json` |
 | Legacy compat | `<runtime_root>/team-sessions/`, `local-workers/`, `oas-runtime/` |
 
 ## 3. Runtime State by Domain
@@ -256,7 +257,8 @@ Current host note:
 - `<runtime_root>/connectors/discord/bindings.json`
 - `<runtime_root>/connectors/discord/binding_audit.jsonl`
 - `<runtime_root>/voice_config.json`
-- `<voice config dir>/voice_sessions/<agent>.json`
+- `<runtime_root>/audio/<timestamp>_<agent>.mp3` (TTS output, auto-cleaned)
+- `<runtime_root>/voice_sessions/<agent>.json`
 
 Notes:
 
@@ -265,7 +267,12 @@ Notes:
   `MASC_BASE_PATH` as the server. Operational setup and verification steps live
   in `sidecars/discord-bot/README.md`.
 - `VOICE_MCP_HOST` and `VOICE_MCP_PORT` remain legacy environment fallbacks.
-- The voice session directory follows the selected voice-config directory, not an unrelated global path.
+- All voice paths resolve relative to `MASC_BASE_PATH/.masc/`.
+  `voice_config.json` is discovered at `<runtime_root>/voice_config.json`
+  where `<runtime_root>` = `MASC_BASE_PATH/.masc/`.
+- `session.endpoints` in `voice_config.json` may be empty (`[]`).
+  HTTP TTS (e.g. ElevenLabs direct) works without a session endpoint.
+  Only Voice MCP session management requires a session endpoint.
 
 ### 3.10 Legacy / Compat Execution Artifacts
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -85,8 +85,20 @@ repo-managed config는 별도 규칙을 가진다: `MASC_CONFIG_DIR` -> `<MASC_B
 | `NEO4J_HTTP_URI` | string | `""` | Neo4j HTTP API URI |
 | `NEO4J_USER` | string | `"neo4j"` | Neo4j 사용자 |
 | `NEO4J_PASSWORD` | string | (필수) | Neo4j 비밀번호 |
-| `VOICE_MCP_HOST` | string | `"127.0.0.1"` | Legacy voice session fallback host. Prefer `.masc/voice_config.json` `session.endpoints` or `MASC_HTTP_*`. |
-| `VOICE_MCP_PORT` | int | 8936 | Legacy voice session fallback port. Prefer `.masc/voice_config.json` `session.endpoints` or `MASC_HTTP_*`. |
+| `VOICE_MCP_HOST` | string | `"127.0.0.1"` | Legacy voice session fallback host. Prefer `MASC_BASE_PATH/.masc/voice_config.json` `session.endpoints`. |
+| `VOICE_MCP_PORT` | int | 8936 | Legacy voice session fallback port. Prefer `MASC_BASE_PATH/.masc/voice_config.json` `session.endpoints`. |
+
+**Voice Configuration** (`MASC_BASE_PATH/.masc/voice_config.json`):
+
+All voice paths resolve relative to `MASC_BASE_PATH/.masc/`. The config file
+contains four sections: `tts`, `stt`, `session`, `local_playback`.
+
+| Section | Required endpoints | Notes |
+|---------|-------------------|-------|
+| `tts.endpoints` | At least 1 | TTS provider (e.g. `elevenlabs_direct`, `openai_compat`) |
+| `stt.endpoints` | At least 1 | STT provider (e.g. `elevenlabs_direct`) |
+| `session.endpoints` | 0 or more | Voice MCP session server. Empty `[]` is valid for HTTP-only TTS. |
+| `local_playback` | N/A | Optional local audio playback via ffplay/mpg123. |
 
 **Timeout 모듈** (통합 타임아웃):
 


### PR DESCRIPTION
## Summary
- voice_config.json 경로가 `MASC_BASE_PATH/.masc/`에서 해석된다는 점을 문서 3곳에 명시
- `session.endpoints`가 비어있어도 유효하다는 규칙 문서화 (#6357 보완)
- keeper capabilities에 voice 도구 사전 조건(config + API key) 명시

## Changed files
- `docs/BOOT-ENV-STATE-INVENTORY.md` — voice path resolution 설명 보강
- `docs/spec/14-configuration.md` — Voice Configuration 테이블 추가
- `config/prompts/keeper.capabilities.md` — voice tool prerequisites

## Test plan
- [x] `dune build` 통과
- docs-only PR, 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)