### PR TITLE
docs: fix Draining invariant doc to match TLA+-verified implementation

### DIFF
--- a/lib/state_product.mli
+++ b/lib/state_product.mli
@@ -97,7 +97,7 @@ val initial : product
 
     Invariants enforced:
     - Keeper in [Stopped | Dead] -> turn must be [Idle]
-    - Keeper in [Draining] -> turn must be [Idle | Finalizing]
+    - Keeper in [Draining] -> turn must not be [Prompting] (in-progress turns allowed; drain waits for completion)
     - Validation in [Nondet_retrying] -> turn must be [Dispatching]
     - Keeper in [Compacting] -> turn must not be [Prompting | Awaiting] *)
 val check_invariants : product -> (unit, string) result


### PR DESCRIPTION
## Summary
- `.mli` documented "turn must be Idle | Finalizing" but implementation only checks `turn != Prompting`
- TLA+ verified: in-progress turns (Awaiting, Parsing, etc.) are allowed during drain
- Test `draining+awaiting ok (TLA+ refined)` already asserts this

## Test plan
- [ ] 20/20 State Product tests pass locally
- [ ] Doc matches implementation and TLA+ spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)