### PR TITLE
feat(dashboard): add Decision Pipeline FSM diagram to keeper detail

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -346,6 +346,7 @@ export interface KeeperStateDiagramResponse {
   keeper: string
   current_phase: string
   mermaid: string
+  decision_pipeline_mermaid?: string
 }
 
 export async function fetchKeeperTransitions(name: string, limit = 20): Promise<KeeperTransitionsResponse> {

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -82,6 +82,7 @@ function formatPhaseBadgeLabel(phase: string | null | undefined): string {
 
 export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStateDiagramProps) {
   const [mermaid, setMermaid] = useState<string | null>(null)
+  const [pipelineMermaid, setPipelineMermaid] = useState<string | null>(null)
   const [apiPhase, setApiPhase] = useState<string | null>(null)
   const [transitions, setTransitions] = useState<KeeperTransition[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -100,9 +101,11 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         if (cancelled) return
         if (diagramResult.status === 'fulfilled') {
           setMermaid(diagramResult.value.mermaid)
+          setPipelineMermaid(diagramResult.value.decision_pipeline_mermaid ?? null)
           setApiPhase(diagramResult.value.current_phase)
         } else {
           setMermaid(null)
+          setPipelineMermaid(null)
           setApiPhase(null)
           setError(diagramResult.reason instanceof Error ? diagramResult.reason.message : 'state diagram fetch failed')
         }
@@ -177,6 +180,20 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
           minHeightClass="min-h-[120px]"
         />
       </div>
+
+      ${pipelineMermaid ? html`
+        <div class="mt-2">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">Decision Pipeline (Guard → Thompson → ToolPolicy)</div>
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+            <${MermaidGraph}
+              source=${pipelineMermaid}
+              prefix="decision-pipeline"
+              diagramClass="[&_svg]:max-w-full [&_svg]:mx-auto"
+              minHeightClass="min-h-[120px]"
+            />
+          </div>
+        </div>
+      ` : null}
 
       ${transitions.length > 0 ? html`
         <div class="grid gap-2">

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -867,6 +867,20 @@ let keeper_config_json (config : Room.config) (name : string)
         Keeper_state_machine.phase_to_mermaid
           ~current:(Option.value ~default:Keeper_state_machine.Offline current_phase)
       in
+      let decision_pipeline_diagram =
+        let phase = Option.value ~default:Keeper_state_machine.Offline current_phase in
+        let stats = Thompson_sampling.get_stats m.agent_name in
+        let tool_count = List.length (Keeper_exec_tools.keeper_allowed_tool_names m) in
+        let recovery_floor_count =
+          List.length (Keeper_tool_policy.failing_minimum_tool_names ())
+        in
+        Keeper_decision_audit.decision_pipeline_to_mermaid
+          ~phase
+          ~thompson_alpha:stats.alpha
+          ~thompson_beta:stats.beta
+          ~tool_count
+          ~recovery_floor_count
+      in
       let tools_access =
         let allowed = Keeper_exec_tools.keeper_allowed_tool_names m in
         let masc_tools =
@@ -911,6 +925,7 @@ let keeper_config_json (config : Room.config) (name : string)
              (Keeper_alerting_path.effective_allowed_paths ~meta:m)));
          ("pipeline_stage", `String pipeline_stage);
          ("state_diagram", `String state_diagram);
+         ("decision_pipeline_diagram", `String decision_pipeline_diagram);
          ("prompt", prompt);
          ("execution", execution);
          ("compaction", compaction);

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -180,3 +180,59 @@ let flush_if_needed ~base_path ~keeper_name =
            | e -> Log.Keeper.warn "decision_audit flush failed: %s" (Printexc.to_string e));
         ring.last_flush_ts <- now
       end
+
+(* ================================================================ *)
+(* Decision Pipeline Mermaid diagram                               *)
+(* ================================================================ *)
+
+let decision_pipeline_to_mermaid
+    ~(phase : Keeper_state_machine.phase)
+    ~(thompson_alpha : float)
+    ~(thompson_beta : float)
+    ~(tool_count : int)
+    ~(recovery_floor_count : int)
+    : string =
+  let b = Buffer.create 512 in
+  let p fmt = Printf.bprintf b fmt in
+  let level = decision_layer_level () in
+  let score =
+    if thompson_alpha +. thompson_beta > 0.0
+    then thompson_alpha /. (thompson_alpha +. thompson_beta)
+    else 0.5
+  in
+  p "stateDiagram-v2\n";
+  p "    state Running {\n";
+  p "        [*] --> NormalOps\n";
+  p "        NormalOps --> GuardFires: guardrail_stop\n";
+  p "        GuardFires --> ThompsonPenalty: beta += 0.5\n";
+  p "        ThompsonPenalty --> NormalOps: cap 1/cycle\n";
+  p "    }\n";
+  p "    state Failing {\n";
+  p "        [*] --> ToolRestricted\n";
+  p "        ToolRestricted --> TurnAttempt: recovery floor (%d tools)\n"
+    recovery_floor_count;
+  p "        TurnAttempt --> TurnAttempt: turn fails\n";
+  p "        TurnAttempt --> RecoveryReady: turn succeeds\n";
+  p "    }\n";
+  p "    Running --> Failing: consecutive failures\n";
+  p "    Failing --> Running: heartbeat_ok\n";
+  p "    Running --> Running: shard restored\n";
+  p "\n";
+  p "    classDef active fill:#22c55e,stroke:#16a34a,color:#fff,stroke-width:3px\n";
+  p "    classDef warn fill:#f59e0b,stroke:#d97706,color:#fff,stroke-width:3px\n";
+  p "    classDef off fill:#6b7280,stroke:#4b5563,color:#fff\n";
+  (match phase with
+   | Keeper_state_machine.Running ->
+     p "    class Running active\n"
+   | Keeper_state_machine.Failing ->
+     p "    class Failing warn\n"
+   | _ ->
+     p "    class Running off\n";
+     p "    class Failing off\n");
+  p "\n";
+  p "    note right of Running\n";
+  p "      Thompson: %.2f (α=%.1f β=%.1f)\n" score thompson_alpha thompson_beta;
+  p "      Tools: %d / floor %d\n" tool_count recovery_floor_count;
+  p "      Level: %d\n" level;
+  p "    end note\n";
+  Buffer.contents b

--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -50,3 +50,14 @@ val flush_if_needed : base_path:string -> keeper_name:string -> unit
 
 (** Ring buffer capacity (env: MASC_DECISION_AUDIT_RING_CAPACITY, default 50, min 1). *)
 val ring_capacity : unit -> int
+
+(** Generate a Mermaid stateDiagram-v2 for the Decision Pipeline.
+    Shows the Guard→Thompson→ToolPolicy feedback loop with current
+    phase highlighted and Thompson score annotated. *)
+val decision_pipeline_to_mermaid :
+  phase:Keeper_state_machine.phase ->
+  thompson_alpha:float ->
+  thompson_beta:float ->
+  tool_count:int ->
+  recovery_floor_count:int ->
+  string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -548,8 +548,8 @@ let handle_keeper_get_subroutes state req request reqd =
       let mermaid = Keeper_state_machine.phase_to_mermaid ~current in
       let phase_str = Keeper_state_machine.phase_to_string current in
       let stats = Thompson_sampling.get_stats name in
-      let meta = Keeper_types.read_keeper_meta
-          ~config:state.Mcp_server.room_config name in
+      let meta = Keeper_types.read_meta
+          state.Mcp_server.room_config name in
       let tool_count = match meta with
         | Ok (Some m) ->
           List.length (Keeper_exec_tools.keeper_allowed_tool_names m)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -547,10 +547,30 @@ let handle_keeper_get_subroutes state req request reqd =
       let current = match phase with Some p -> p | None -> Keeper_state_machine.Offline in
       let mermaid = Keeper_state_machine.phase_to_mermaid ~current in
       let phase_str = Keeper_state_machine.phase_to_string current in
+      let stats = Thompson_sampling.get_stats name in
+      let meta = Keeper_types.read_keeper_meta
+          ~config:state.Mcp_server.room_config name in
+      let tool_count = match meta with
+        | Ok (Some m) ->
+          List.length (Keeper_exec_tools.keeper_allowed_tool_names m)
+        | _ -> 0
+      in
+      let recovery_floor_count =
+        List.length (Keeper_tool_policy.failing_minimum_tool_names ())
+      in
+      let decision_pipeline_mermaid =
+        Keeper_decision_audit.decision_pipeline_to_mermaid
+          ~phase:current
+          ~thompson_alpha:stats.alpha
+          ~thompson_beta:stats.beta
+          ~tool_count
+          ~recovery_floor_count
+      in
       let json = `Assoc [
         "keeper", `String name;
         "current_phase", `String phase_str;
         "mermaid", `String mermaid;
+        "decision_pipeline_mermaid", `String decision_pipeline_mermaid;
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Summary
Keeper has two cross-cutting FSMs:
1. **Lifecycle FSM** (Offline→Running→Failing→...) — already visualized
2. **Decision Pipeline** (Guard→Thompson→ToolPolicy feedback loop) — **new**

This PR adds a Mermaid stateDiagram-v2 for the Decision Pipeline, rendered below the existing Lifecycle diagram in keeper detail.

## What it shows
- Running state: NormalOps → GuardFires → ThompsonPenalty (cap 1/cycle)
- Failing state: ToolRestricted → TurnAttempt → RecoveryReady
- Transitions: Running ↔ Failing
- Annotations: Thompson score (α/β), tool count, recovery floor count, decision layer level
- Phase highlighting: green (Running), amber (Failing), grey (inactive)

## Files changed
| File | Change |
|---|---|
| `lib/keeper/keeper_decision_audit.ml` | `decision_pipeline_to_mermaid` function |
| `lib/keeper/keeper_decision_audit.mli` | export |
| `lib/dashboard/dashboard_http_keeper.ml` | include in keeper detail response |
| `lib/server/server_dashboard_http_keeper_api.ml` | include in state-diagram API |
| `dashboard/src/api/keeper.ts` | `decision_pipeline_mermaid` type |
| `dashboard/src/components/keeper-state-diagram.ts` | render pipeline diagram |

## Test plan
- [ ] `dune build` passes
- [ ] `tsc --noEmit` passes
- [ ] Dashboard renders both FSM diagrams in keeper detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)