### PR TITLE
fix: silent failure wave 2 + timestamp sentinel removal

### DIFF
--- a/lib/autoresearch/autoresearch_storage.ml
+++ b/lib/autoresearch/autoresearch_storage.ml
@@ -33,7 +33,9 @@ let ensure_dir path =
   let rec mkdir_p dir =
     if not (Sys.file_exists dir) then begin
       mkdir_p (Filename.dirname dir);
-      (try Sys.mkdir dir 0o755 with Sys_error _ -> ())
+      (try Sys.mkdir dir 0o755
+       with Sys_error msg ->
+         Log.Misc.warn "ensure_dir: mkdir %s failed: %s" dir msg)
     end
   in
   mkdir_p path
@@ -235,4 +237,9 @@ let scan_persisted_loop_ids ~base_path =
       |> List.filter (fun name ->
              let state_path = Filename.concat (Filename.concat dir name) "state.json" in
              Fs_compat.file_exists state_path)
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Misc.warn "get_loop_ids_with_state: readdir %s failed: %s"
+        dir (Printexc.to_string exn);
+      []

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -47,7 +47,7 @@ let append_pair ~base_dir ~keeper_name
 type chat_message = {
   role : string;
   content : string;
-  ts : float;
+  ts : float option;
 }
 
 let parse_line (line : string) : chat_message option =
@@ -56,7 +56,9 @@ let parse_line (line : string) : chat_message option =
     let open Yojson.Safe.Util in
     let role = member "role" json |> to_string_option |> Option.value ~default:"" in
     let content = member "content" json |> to_string_option |> Option.value ~default:"" in
-    let ts = (try member "ts" json |> to_float with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 0.0) in
+    let ts =
+      (try Some (member "ts" json |> to_float)
+       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None) in
     if role = "" || content = "" then None
     else Some { role; content; ts }
   with Yojson.Json_error _ -> None
@@ -93,9 +95,9 @@ let to_json_array (messages : chat_message list) : Yojson.Safe.t =
     (List.map
        (fun m ->
          `Assoc
-           [
-             ("role", `String m.role);
-             ("content", `String m.content);
-             ("ts", `Float m.ts);
-           ])
+           ([ ("role", `String m.role);
+              ("content", `String m.content);
+            ] @ (match m.ts with
+                 | Some t -> [("ts", `Float t)]
+                 | None -> [])))
        messages)

--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -39,7 +39,7 @@ let empty_stats ~window_hours =
 (* ------------------------------------------------------------------ *)
 
 type parsed_decision = {
-  timestamp_unix : float;
+  timestamp_unix : float option;
   outcome : string;
   tool_call_count : int;
   tools_used : string list;
@@ -48,10 +48,7 @@ type parsed_decision = {
 let parse_decision_line (line : string) : parsed_decision option =
   match Yojson.Safe.from_string line with
   | json ->
-    let timestamp_unix =
-      Safe_ops.json_float_opt "timestamp_unix" json
-      |> Option.value ~default:0.0
-    in
+    let timestamp_unix = Safe_ops.json_float_opt "timestamp_unix" json in
     let outcome =
       Safe_ops.json_string_opt "outcome" json
       |> Option.value ~default:"unknown"
@@ -92,7 +89,10 @@ let compute_stats ~decision_log_path ~window_hours =
   let decisions =
     lines
     |> List.filter_map parse_decision_line
-    |> List.filter (fun d -> d.timestamp_unix >= window_start)
+    |> List.filter (fun d ->
+      match d.timestamp_unix with
+      | Some ts -> ts >= window_start
+      | None -> false)
   in
   let total_turns = List.length decisions in
   if total_turns = 0 then
@@ -132,7 +132,9 @@ let compute_stats ~decision_log_path ~window_hours =
       decisions
       |> List.filter (fun d -> not (is_silent d))
       |> List.fold_left (fun acc d ->
-        max acc d.timestamp_unix) 0.0
+        match d.timestamp_unix with
+        | Some ts -> max acc ts
+        | None -> acc) 0.0
     in
     let last_visible_action_age_sec =
       if last_visible_ts <= 0.0 then

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -139,10 +139,18 @@ let handle_compact args : result =
     let strategy_str = args |> member "strategy" |> to_string in
     let max_tokens =
       (try args |> member "max_tokens" |> to_int
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 128_000) in
+       with Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Misc.warn "handle_compact: max_tokens parse failed (%s), using 128000"
+           (Printexc.to_string exn);
+         128_000) in
     let system_prompt =
       (try args |> member "system_prompt" |> to_string
-       with Eio.Cancel.Cancelled _ as e -> raise e | _ -> "") in
+       with Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Misc.warn "handle_compact: system_prompt parse failed (%s), using empty"
+           (Printexc.to_string exn);
+         "") in
     let strategies = match strategies_of_string strategy_str with
       | Ok s -> s
       | Error msg -> raise (Invalid_argument msg)


### PR DESCRIPTION
## Summary
Follow-up to #6378 (merged). Two additional fixes:

### Wave 2: Silent failures in autoresearch and tool_compact
- `autoresearch_storage.ml`: mkdir and readdir failures now logged
- `tool_compact.ml`: max_tokens/system_prompt parse failures now logged

### Timestamp 0.0 sentinel → float option
- `keeper_telemetry_feedback.ml`: `timestamp_unix: float` → `float option`
  - Entries with None timestamps excluded from window filter
  - last_visible_ts fold skips None entries
- `keeper_chat_store.ml`: `ts: float` → `float option`
  - JSON output omits "ts" when None instead of emitting 0.0

Part of #6290

🤖 Generated with [Claude Code](https://claude.com/claude-code)