### PR TITLE
refactor(keeper): remove boring tool pruning from turn pipeline

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -271,7 +271,6 @@ let run_turn
       ~(cascade_name : string)
       ?provider_filter
       ~(generation : int)
-      ?(actionable_signal = false)
       ?(max_turns : int = Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call)
       (* Per-call turn budget. Keeper resumes via checkpoint if exhausted. *)
       ?(max_idle_turns : int = 3)
@@ -1190,16 +1189,6 @@ let run_turn
                     omitted_suffix);
                 validated
               in
-              let all_allowed_pruned =
-                if is_retry then all_allowed
-                else
-                  Keeper_tool_disclosure.prune_boring_tools_after_recent_polling
-                    ~visible_tools:all_allowed
-                    ~recent_entries:
-                      (match Keeper_tool_call_log.read_latest ~keeper_name:meta.name () with
-                       | Some entry -> [ entry ]
-                       | None -> [])
-              in
               let core_count = List.length (Keeper_exec_tools.effective_core_tools ()) in
               let discovered_count =
                 List.length (Keeper_discovered_tools.active_names !discovered_ref ~turn)
@@ -1216,7 +1205,7 @@ let run_turn
                   discovered_count
                   llm_selected_count
                   llm_rerank_enabled
-                  (List.length all_allowed_pruned)
+                  (List.length all_allowed)
                   (String.length query_text)
                   selection_mode;
               (* 3. Graceful last-turn: inject budget warnings and restrict
@@ -1277,8 +1266,8 @@ let run_turn
                 then
                   Agent_sdk.Tool_op.apply
                     (Agent_sdk.Tool_op.Intersect_with safe_last_turn_tools)
-                    all_allowed_pruned
-                else all_allowed_pruned
+                    all_allowed
+                else all_allowed
               in
               if is_warning_zone
               then
@@ -1288,26 +1277,6 @@ let run_turn
                   turn
                   max_turns
                   is_last_turn;
-              let all_allowed =
-                if actionable_signal && not is_last_turn
-                then
-                  let pruned =
-                    Keeper_exec_tools.prune_boring_tools_for_actionable_turn
-                      all_allowed
-                  in
-                  if List.length pruned <> List.length all_allowed then (
-                    let removed =
-                      List.filter
-                        (fun name -> not (List.mem name pruned))
-                        all_allowed
-                    in
-                    Log.Keeper.info
-                      "keeper:%s actionable turn pruned boring tools: %s"
-                      meta.name
-                      (String.concat ", " removed));
-                  pruned
-                else all_allowed
-              in
               (* Context overflow guard: Tool_selector.select already respects
            the k limit, but overlays can grow the visible set beyond
            max_tools.  Cap the post-overlay set to stay inside small-model

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -124,7 +124,6 @@ val run_turn :
   -> cascade_name:string
   -> ?provider_filter:string list
   -> generation:int
-  -> ?actionable_signal:bool
   -> ?max_turns:int
   -> ?max_idle_turns:int
   -> ?history_user_source:string

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1169,8 +1169,6 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:meta.cascade_name
               ~generation:run_generation
-              ~actionable_signal:
-                (Keeper_world_observation.actionable_signal_present observation)
               ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"


### PR DESCRIPTION
## Summary
Remove per-turn boring tool pruning. Keepers get full tool access.

## Removed
- `prune_boring_tools_after_recent_polling` call in turn pipeline
- `prune_boring_tools_for_actionable_turn` call + actionable_signal param
- -37 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)