### PR TITLE
fix(keeper): let read-only tools pass through mutation boundary

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -923,8 +923,10 @@ let run_turn
       ~session
       ~ctx_snapshot
       ~generation
-      ~pre_tool_use_guard:(fun ~tool_name:_ ~input:_ ->
+      ~pre_tool_use_guard:(fun ~tool_name ~input:_ ->
         match !mutation_boundary_tool_name with
+        | Some _ when Keeper_tool_registry.is_effectively_read_only_tool tool_name ->
+          None (* read-only tools pass through mutation boundary *)
         | Some _ -> Some (mutation_boundary_summary ())
         | None -> None)
       ~on_tool_executed:(fun ~tool_name ~input:_ ~output_text:_ ~success ->


### PR DESCRIPTION
## Summary
Mutation boundary blocked ALL tools after first write — including reads. Now read-only tools pass through.

## Evidence
```
keeper:analyst pre_tool_use guard blocked keeper_broadcast  (read-only!)
keeper:analyst pre_tool_use guard blocked keeper_bash       (mutating — correct)
```
14/15 turns wasted because reads were blocked.

## Fix
Check `is_effectively_read_only_tool` in pre_tool_use_guard. Read-only tools skip the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)