### PR TITLE
chore(pin): bump OAS to v0.119.0

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.118.2"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.119.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="e4629830e55b796d13583ccc9db2e92adf81eb1f"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.118.2"
+readonly OAS_AGENT_SDK_SHA="a40b23c9baa89f6ec27406154d4245115447404d"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.119.0"


### PR DESCRIPTION
## Summary
- OAS pin d6d3d00 → a40b23c (v0.118.2 → v0.119.0)
- Typed_tool phantom safety, correction pipeline efficiency, error accumulation

## Test plan
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)