### PR TITLE
fix(keeper): clear reconcile on-disk record during auto-clear

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -779,14 +779,25 @@ let run_keepalive_unified_turn
           ~keeper_name:meta_after_triage.name
       in
       (* Auto-clear manual_reconcile to break deadlock: reconcile blocks
-         turns, but turns are needed to clear reconcile. Log and proceed. *)
-      if manual_reconcile_pending then (
-        Log.Keeper.info
-          "keeper:%s auto-clearing manual_reconcile to break deadlock"
-          meta_after_triage.name;
-        ignore (Keeper_registry.dispatch_event
-          ~base_path:ctx.config.base_path meta_after_triage.name
-          Keeper_state_machine.Manual_reconcile_cleared));
+         turns, but turns are needed to clear reconcile.  Clear both the
+         on-disk record AND the registry state, then proceed as if clean. *)
+      let manual_reconcile_pending =
+        if manual_reconcile_pending then (
+          Log.Keeper.info
+            "keeper:%s auto-clearing manual_reconcile to break deadlock"
+            meta_after_triage.name;
+          ignore (Keeper_manual_reconcile.clear ctx.config
+            ~keeper_name:meta_after_triage.name
+            ~actor:"auto_clear_deadlock_break"
+            ~resolution:"Automatic deadlock break: stale reconcile cleared to restore keeper activity"
+            ~evidence_refs:[]
+            ~idempotency_key:None);
+          ignore (Keeper_registry.dispatch_event
+            ~base_path:ctx.config.base_path meta_after_triage.name
+            Keeper_state_machine.Manual_reconcile_cleared);
+          false (* reconcile is now cleared — proceed as normal *))
+        else false
+      in
       let should_run_turn =
         (not (Atomic.get stop))
         && turn_decision.should_run


### PR DESCRIPTION
## Summary
- Auto-clear 로직이 registry 상태만 변경하고 on-disk JSON은 건드리지 않아서 다음 keepalive cycle에서 stale pending 파일을 다시 읽고 무한 skip 루프에 빠짐
- `Keeper_manual_reconcile.clear`를 호출하여 on-disk record도 함께 cleared로 변경
- `manual_reconcile_pending` 로컬 변수를 false로 shadow하여 현재 cycle도 정상 진행

## Root Cause
1. keepalive가 on-disk JSON에서 `status: pending` 읽음
2. `Manual_reconcile_cleared` event를 registry에 dispatch → Running 전환
3. **on-disk 파일은 여전히 pending** → 다음 cycle에서 다시 Failing 전환
4. 결과: 모든 keeper가 "auto-clear → skip → auto-clear" 무한 루프

## Test plan
- [ ] `dune build` 통과
- [ ] 서버 재시작 후 stale reconcile이 한 번만 auto-clear되고 keeper 턴이 정상 진행되는지 로그 확인
- [ ] manual_reconcile JSON 파일이 `status: cleared`로 변경되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)