### PR TITLE
fix(config): align cascade comment with pinned model

### DIFF
--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -66,7 +66,7 @@ execution_scope = "workspace"
 tool_preset = "social"
 also_allow = ["keeper_voice_speak", "keeper_voice_listen"]
 
-# Local LLM only — uses "local_only" cascade (ollama:auto)
+# Local LLM only — uses "local_only" cascade (ollama:qwen3.5:35b-a3b-nvfp4)
 cascade_name = "local_only"
 
 # Telemetry Feedback


### PR DESCRIPTION
## Summary
sangsu.toml comment said `ollama:auto` but cascade.json pins local_only to `ollama:qwen3.5:35b-a3b-nvfp4`. Updated comment to match reality.

Only change: 1 comment line in `config/keepers/sangsu.toml`.

Closes #6283