### PR TITLE
fix(keeper): unblock worktree access + git read-only for PR creation

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -249,7 +249,18 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
     | "workspace" ->
       let safe_name = sanitize_keeper_name meta.name in
       [ Printf.sprintf ".masc/keepers/%s/" safe_name;
-        ".masc/traces/" ]
+        ".masc/traces/";
+        (* Worktrees created by masc_worktree_create land here.
+           Without this, keepers can create worktrees but cannot
+           read or write files inside them. *)
+        ".worktrees/";
+        (* Main repo source for read access *)
+        "lib/";
+        "test/";
+        "config/";
+        "bin/";
+        "scripts/";
+        "docs/" ]
     | _ -> []
   in
   match meta.allowed_paths with

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -203,6 +203,9 @@ let gh_effective_cmd (input : Yojson.Safe.t) : string =
       if args <> [] then String.concat " " args else ""
   | _ -> ""
 
+let git_read_only_actions =
+  [ "diff"; "status"; "log"; "branch"; "fetch" ]
+
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
   if is_effectively_read_only_tool tool_name then true
   else match tool_name with
@@ -218,6 +221,17 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
         String.length cmd_lower >= String.length prefix
         && String.sub cmd_lower 0 (String.length prefix) = prefix
       ) gh_read_only_prefixes
+  | "masc_code_git" ->
+    let action =
+      match input with
+      | `Assoc fields ->
+        (match List.assoc_opt "action" fields with
+         | Some (`String s) -> String.lowercase_ascii (String.trim s)
+         | _ -> "")
+      | _ -> ""
+    in
+    List.mem action git_read_only_actions
+  | "masc_worktree_list" -> true
   | _ -> false
 
 (* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)


### PR DESCRIPTION
## Summary
- keeper가 `masc_worktree_create`로 worktree를 만들어도 `.worktrees/` 경로가 allowed_paths에 없어서 파일 접근 차단
- `masc_code_git action=status/diff/log`가 mutation boundary를 열어 후속 `commit/push` 차단
- workspace scope keeper에 `.worktrees/`, `lib/`, `test/`, `config/`, `bin/`, `scripts/`, `docs/` 추가
- `masc_code_git` read-only actions (`diff`, `status`, `log`, `branch`, `fetch`) + `masc_worktree_list` 분류

## Context
keeper들이 task claim → worktree 생성 → 코드 읽기/수정 → PR 생성 워크플로를 시도하고 있으나, 이 두 장벽에서 매번 차단됨.

## Test plan
- [ ] `dune build` 통과
- [ ] keeper가 worktree 내 파일을 읽고 수정 가능한지 로그 확인
- [ ] `masc_code_git action=status` 후 `action=commit`이 같은 턴에서 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)