### PR TITLE
fix(keeper): switch sangsu to keeper_unified for voice tool calling

### DIFF
--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -66,8 +66,9 @@ execution_scope = "workspace"
 tool_preset = "social"
 also_allow = ["keeper_voice_speak", "keeper_voice_listen"]
 
-# Local LLM only — uses "local_only" cascade (ollama:qwen3.5:35b-a3b-nvfp4)
-cascade_name = "local_only"
+# GLM flash cascade for reliable tool calling (voice_speak, voice_listen).
+# local_only cascade has poor tool selection with qwen3.5.
+cascade_name = "keeper_unified"
 
 # Telemetry Feedback
 telemetry_feedback_enabled = true


### PR DESCRIPTION
## Summary

- sangsu cascade를 `local_only` → `keeper_unified`로 전환
- local Ollama (qwen3.5)가 `tool_choice=required`를 위반하여 `keeper_voice_speak` 호출 실패
- GLM flash는 tool calling을 안정적으로 수행

## Why

`local_only` cascade에서 sangsu가 voice 도구를 전혀 선택하지 않음.
contract violation: `tool_choice requested tool use, but the model returned no ToolUse block`

## Test plan

- [ ] 서버 재시작 후 sangsu가 voice_speak를 자율적으로 호출하는지 확인
- [ ] GLM flash 응답 시간 (목표: <10초)

Generated with [Claude Code](https://claude.com/claude-code)