### PR TITLE
refactor: broadcast PoC uses Tool_schema_gen combinators

### DIFF
--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -1,26 +1,19 @@
-(** Typed broadcast tool — Phase 1 PoC for Typed_tool_masc. *)
+(** Typed broadcast tool — Phase 1 PoC for Typed_tool_masc.
+    Derives parse + params from Tool_schema_gen combinators. *)
 
-type broadcast_input = {
-  message : string;
-  format : string option;
-}
+module Sg = Agent_sdk.Tool_schema_gen
+
+let broadcast_schema = Sg.two
+  (Sg.string_field "message" ~required:true
+     ~desc:"Message content to broadcast to all agents")
+  (Sg.string_field "format" ~required:false
+     ~desc:"Output format: compact or verbose (default: verbose)")
 
 type broadcast_output = {
   delivered : bool;
   room_message : string;
   mention : string option;
 }
-
-let parse_broadcast (json : Yojson.Safe.t) : (broadcast_input, string) result =
-  let open Yojson.Safe.Util in
-  try
-    match json |> member "message" |> to_string_option with
-    | None -> Error "missing required field: message"
-    | Some message ->
-      let format = json |> member "format" |> to_string_option in
-      Ok { message; format }
-  with
-  | Yojson.Safe.Util.Type_error (msg, _) -> Error msg
 
 let encode_broadcast (output : broadcast_output) : Yojson.Safe.t =
   `Assoc ([
@@ -30,34 +23,20 @@ let encode_broadcast (output : broadcast_output) : Yojson.Safe.t =
     | Some m -> [("mention", `String m)]
     | None -> [])
 
-let broadcast_params : Agent_sdk.Types.tool_param list = [
-  { name = "message";
-    description = "Message content to broadcast to all agents";
-    param_type = Agent_sdk.Types.String;
-    required = true };
-  { name = "format";
-    description = "Output format: compact or verbose (default: verbose)";
-    param_type = Agent_sdk.Types.String;
-    required = false };
-]
-
-let handle_broadcast (input : broadcast_input) : (broadcast_output, string) result =
-  let trimmed = String.trim input.message in
+let handle_broadcast ((message, _format) : string * string)
+    : (broadcast_output, string) result =
+  let trimmed = String.trim message in
   if trimmed = "" then Error "Broadcast message cannot be empty"
   else
     let mention = Mention.extract trimmed in
-    Ok {
-      delivered = true;
-      room_message = trimmed;
-      mention;
-    }
+    Ok { delivered = true; room_message = trimmed; mention }
 
 let tool = Typed_tool_masc.create
   ~name:"masc_broadcast_typed"
   ~description:"[Typed PoC] Send a message visible to ALL agents via SSE push."
   ~module_tag:Tool_dispatch.Mod_room
-  ~params:broadcast_params
-  ~parse:parse_broadcast
+  ~params:(Sg.to_params broadcast_schema)
+  ~parse:(Sg.parse broadcast_schema)
   ~handler:handle_broadcast
   ~encode:encode_broadcast
   ~requires_join:true

--- a/lib/tool_broadcast_typed.mli
+++ b/lib/tool_broadcast_typed.mli
@@ -1,11 +1,7 @@
 (** Typed broadcast tool — Phase 1 PoC for compile-time tool safety.
+    Schema and parse derived from {!Agent_sdk.Tool_schema_gen} combinators.
 
     @since 2.260.0 *)
-
-type broadcast_input = {
-  message : string;
-  format : string option;
-}
 
 type broadcast_output = {
   delivered : bool;
@@ -13,8 +9,7 @@ type broadcast_output = {
   mention : string option;
 }
 
-val parse_broadcast : Yojson.Safe.t -> (broadcast_input, string) result
+val broadcast_schema : (string * string) Agent_sdk.Tool_schema_gen.schema
 val encode_broadcast : broadcast_output -> Yojson.Safe.t
-val broadcast_params : Agent_sdk.Types.tool_param list
-val handle_broadcast : broadcast_input -> (broadcast_output, string) result
-val tool : (broadcast_input, broadcast_output) Typed_tool_masc.t
+val handle_broadcast : string * string -> (broadcast_output, string) result
+val tool : (string * string, broadcast_output) Typed_tool_masc.t

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -2,38 +2,38 @@
 
 open Masc_mcp
 
+let parse = Agent_sdk.Tool_schema_gen.parse Tool_broadcast_typed.broadcast_schema
+
 let test_parse_valid () =
   let json = `Assoc [("message", `String "hello world")] in
-  match Tool_broadcast_typed.parse_broadcast json with
-  | Ok input ->
-    Alcotest.(check string) "message" "hello world" input.message;
-    Alcotest.(check bool) "format is none" true (input.format = None)
+  match parse json with
+  | Ok (message, format) ->
+    Alcotest.(check string) "message" "hello world" message;
+    Alcotest.(check string) "format default" "" format
   | Error e -> Alcotest.fail ("parse failed: " ^ e)
 
 let test_parse_with_format () =
   let json = `Assoc [("message", `String "hi"); ("format", `String "compact")] in
-  match Tool_broadcast_typed.parse_broadcast json with
-  | Ok input ->
-    Alcotest.(check string) "message" "hi" input.message;
-    Alcotest.(check (option string)) "format" (Some "compact") input.format
+  match parse json with
+  | Ok (message, format) ->
+    Alcotest.(check string) "message" "hi" message;
+    Alcotest.(check string) "format" "compact" format
   | Error e -> Alcotest.fail ("parse failed: " ^ e)
 
 let test_parse_missing_message () =
   let json = `Assoc [("format", `String "compact")] in
-  match Tool_broadcast_typed.parse_broadcast json with
+  match parse json with
   | Ok _ -> Alcotest.fail "expected parse error"
   | Error _ -> ()
 
 let test_parse_wrong_type () =
   let json = `Assoc [("message", `Int 42)] in
-  match Tool_broadcast_typed.parse_broadcast json with
+  match parse json with
   | Ok _ -> Alcotest.fail "expected parse error"
   | Error _ -> ()
 
 let test_handler_success () =
-  let input : Tool_broadcast_typed.broadcast_input =
-    { message = "hello @claude"; format = None } in
-  match Tool_broadcast_typed.handle_broadcast input with
+  match Tool_broadcast_typed.handle_broadcast ("hello @claude", "") with
   | Ok output ->
     Alcotest.(check bool) "delivered" true output.delivered;
     Alcotest.(check string) "message" "hello @claude" output.room_message;
@@ -41,16 +41,12 @@ let test_handler_success () =
   | Error e -> Alcotest.fail ("handler failed: " ^ e)
 
 let test_handler_empty () =
-  let input : Tool_broadcast_typed.broadcast_input =
-    { message = "   "; format = None } in
-  match Tool_broadcast_typed.handle_broadcast input with
+  match Tool_broadcast_typed.handle_broadcast ("   ", "") with
   | Ok _ -> Alcotest.fail "expected error"
   | Error _ -> ()
 
 let test_handler_trim () =
-  let input : Tool_broadcast_typed.broadcast_input =
-    { message = "  trimmed  "; format = None } in
-  match Tool_broadcast_typed.handle_broadcast input with
+  match Tool_broadcast_typed.handle_broadcast ("  trimmed  ", "") with
   | Ok output -> Alcotest.(check string) "trimmed" "trimmed" output.room_message
   | Error e -> Alcotest.fail e
 


### PR DESCRIPTION
## Summary
- Replace hand-rolled parse + params with `Tool_schema_gen.two` combinator
- Remove `broadcast_input` record type (replaced by `string * string` tuple)
- Single declaration derives both parse and params — the stated purpose of Tool_schema_gen

## Test plan
- [ ] 14/14 typed_tool_masc tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)