### PR TITLE
feat(keeper): add masc_keeper_reset for stale runtime state

### DIFF
--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -493,6 +493,22 @@ let keeper_schemas : tool_schema list = [
     ];
   };
 
+  {
+    name = "masc_keeper_reset";
+    description = "Reset a keeper's runtime state (usage counters, last_model_used, token stats). \
+Clears stale data from previous sessions. Does not affect configuration, goals, or persona.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle to reset");
+        ]);
+      ]);
+      ("required", `List [`String "name"]);
+    ];
+  };
+
 ]
 
 let schemas : tool_schema list =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -458,6 +458,15 @@ let map_usage (f : usage_metrics -> usage_metrics) (m : keeper_meta) : keeper_me
   { m with runtime = { m.runtime with usage = f m.runtime.usage } }
 ;;
 
+let zero_usage : usage_metrics =
+  { total_turns = 0; total_input_tokens = 0; total_output_tokens = 0
+  ; total_tokens = 0; total_cost_usd = 0.0; last_turn_ts = 0.0
+  ; last_model_used = ""; last_input_tokens = 0; last_output_tokens = 0
+  ; last_total_tokens = 0; last_latency_ms = 0 }
+
+let reset_runtime_state (m : keeper_meta) : keeper_meta =
+  map_usage (fun _ -> zero_usage) m
+
 let map_compaction_rt (f : compaction_runtime -> compaction_runtime) (m : keeper_meta)
   : keeper_meta
   =

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -189,6 +189,8 @@ val tool_access_of_meta_json : Yojson.Safe.t -> (tool_access, string) result
 
 val map_runtime : (agent_runtime_state -> agent_runtime_state) -> keeper_meta -> keeper_meta
 val map_usage : (usage_metrics -> usage_metrics) -> keeper_meta -> keeper_meta
+val zero_usage : usage_metrics
+val reset_runtime_state : keeper_meta -> keeper_meta
 val map_compaction_rt : (compaction_runtime -> compaction_runtime) -> keeper_meta -> keeper_meta
 val map_proactive_rt : (proactive_runtime -> proactive_runtime) -> keeper_meta -> keeper_meta
 val map_scheduled_autonomous_rt :

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -643,6 +643,19 @@ let maybe_bootstrap_existing_keepalives ctx ~name ~args =
     Do not retarget requests across other base_path registries. *)
 let resolve_ctx ctx ~name:_ _args = ctx
 
+let handle_keeper_reset ctx args : tool_result =
+  match resolve_keeper_meta ctx args with
+  | Error err -> (false, err)
+  | Ok meta ->
+    let reset_meta = Keeper_types.reset_runtime_state meta in
+    (match Keeper_types.write_meta ctx.config reset_meta with
+     | Ok () ->
+       (true, Printf.sprintf
+         "Reset runtime state for %s: usage counters zeroed, last_model_used cleared."
+         meta.name)
+     | Error err ->
+       (false, Printf.sprintf "Failed to write reset meta for %s: %s" meta.name err))
+
 let dispatch ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
@@ -657,6 +670,7 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_reconcile" -> Some (handle_keeper_reconcile ctx args)
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)
+  | "masc_keeper_reset" -> Some (handle_keeper_reset ctx args)
   | _ -> None
 
 (** Streaming dispatch: only handles keeper_msg with text delta forwarding.


### PR DESCRIPTION
## Summary
New MCP tool `masc_keeper_reset` zeros runtime usage state without touching configuration.

## What it resets
- total_turns, total_tokens, total_cost_usd → 0
- last_model_used → ""
- last_turn_ts, last_latency_ms → 0

## What it preserves
- goal, will, needs, desires
- tool_preset, cascade_name
- execution_scope, allowed_paths

## Usage
```json
{"name": "masc_keeper_reset", "arguments": {"name": "sangsu"}}
```

## Files
| File | Change |
|---|---|
| `lib/keeper/keeper_types.ml` | `zero_usage`, `reset_runtime_state` |
| `lib/keeper/keeper_types.mli` | exports |
| `lib/keeper/keeper_schema.ml` | tool schema |
| `lib/tool_keeper.ml` | handler + dispatch |

Closes #6186

🤖 Generated with [Claude Code](https://claude.com/claude-code)