### PR TITLE
feat: add rate_limit.mli — abstract type for token bucket limiter

### DIFF
--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -42,6 +42,9 @@ let create ?(rate=default_rate) ?(burst=default_burst) () =
     mutex = Eio.Mutex.create ();
   }
 
+let rate t = t.rate
+let burst t = t.burst
+
 let create_from_env () =
   create ~rate:(rate_from_env ()) ~burst:(burst_from_env ()) ()
 

--- a/lib/rate_limit.mli
+++ b/lib/rate_limit.mli
@@ -1,0 +1,64 @@
+(** Rate Limiting for masc-mcp
+
+    Provides token bucket rate limiting per client/agent.
+
+    Configuration via environment:
+    - MASC_RATE_LIMIT: requests per second (default: 60)
+    - MASC_RATE_BURST: burst capacity (default: 150)
+
+    @since 0.4.0 *)
+
+(** {1 Types} *)
+
+(** Opaque rate limiter instance. *)
+type t
+
+(** {1 Limiter Creation} *)
+
+val default_rate : float
+val default_burst : int
+val rate_from_env : unit -> float
+val burst_from_env : unit -> int
+val rate : t -> float
+val burst : t -> int
+val create : ?rate:float -> ?burst:int -> unit -> t
+val create_from_env : unit -> t
+
+(** {1 Rate Checking} *)
+
+(** [check limiter ~key] consumes one token for [key].
+    Returns [true] if the request is allowed, [false] if rate limited. *)
+val check : t -> key:string -> bool
+
+(** [remaining limiter ~key] returns available tokens for [key]. *)
+val remaining : t -> key:string -> int
+
+(** {1 Cleanup} *)
+
+(** Remove buckets not accessed in [older_than_seconds]. Returns count removed. *)
+val cleanup : t -> older_than_seconds:int -> int
+
+(** {1 Global Instance} *)
+
+val global : t Eio.Lazy.t
+val check_global : key:string -> bool
+val remaining_global : key:string -> int
+
+(** {1 Automatic Cleanup Loop} *)
+
+val start_cleanup_loop :
+  sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> ?interval:float -> t -> unit
+
+(** {1 HTTP Helpers} *)
+
+val headers : t -> key:string -> (string * string) list
+val too_many_requests_body : unit -> string
+val headers_global : key:string -> (string * string) list
+
+(** {1 Client Address Key Extraction} *)
+
+val key_of_sockaddr : Eio.Net.Sockaddr.stream -> string
+
+(** {1 Global Startup Helper} *)
+
+val start_global_cleanup_loop : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -25,21 +25,21 @@ let test_default_burst () =
 
 let test_create_default () =
   let limiter = Rate_limit.create () in
-  check (float 0.001) "rate" 60.0 limiter.rate;
-  check int "burst" 150 limiter.burst
+  check (float 0.001) "rate" 60.0 (Rate_limit.rate limiter);
+  check int "burst" 150 (Rate_limit.burst limiter)
 
 let test_create_custom_rate () =
   let limiter = Rate_limit.create ~rate:100.0 () in
-  check (float 0.001) "custom rate" 100.0 limiter.rate
+  check (float 0.001) "custom rate" 100.0 (Rate_limit.rate limiter)
 
 let test_create_custom_burst () =
   let limiter = Rate_limit.create ~burst:200 () in
-  check int "custom burst" 200 limiter.burst
+  check int "custom burst" 200 (Rate_limit.burst limiter)
 
 let test_create_both_custom () =
   let limiter = Rate_limit.create ~rate:50.0 ~burst:100 () in
-  check (float 0.001) "rate" 50.0 limiter.rate;
-  check int "burst" 100 limiter.burst
+  check (float 0.001) "rate" 50.0 (Rate_limit.rate limiter);
+  check int "burst" 100 (Rate_limit.burst limiter)
 
 (* ============================================================
    Check Tests
@@ -123,8 +123,8 @@ let test_burst_from_env_returns_int () =
 
 let test_create_from_env () =
   let limiter = Rate_limit.create_from_env () in
-  check bool "rate positive" true (limiter.rate > 0.0);
-  check bool "burst positive" true (limiter.burst > 0)
+  check bool "rate positive" true ((Rate_limit.rate limiter) > 0.0);
+  check bool "burst positive" true ((Rate_limit.burst limiter) > 0)
 
 (* ============================================================
    Global Instance Tests


### PR DESCRIPTION
## Summary
First P1 security .mli from #6160. Hides `bucket` internals and `Hashtbl` behind abstract `t`.

## Hidden from public API
- `bucket` type (mutable tokens/last_update)
- `with_lock` internal helper
- `buckets : (string, bucket) Hashtbl.t`

## Exposed via accessors
- `rate : t -> float`
- `burst : t -> int`

31/31 tests pass.

Part of #6160

🤖 Generated with [Claude Code](https://claude.com/claude-code)