### PR TITLE
fix(keeper): break boring tool polling loop by forcing silent

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -150,7 +150,11 @@ let prune_boring_tools_after_recent_polling
       && not (String.equal name "keeper_stay_silent")
     | None -> false
   in
-  if (not productive_visible) || not just_polled then visible_tools
+  if not just_polled then visible_tools
+  else if not productive_visible then
+    (* All visible tools are boring and we just used one — force silent
+       to break the polling loop instead of offering the same boring tools. *)
+    List.filter (fun name -> String.equal name "keeper_stay_silent") visible_tools
   else
     List.filter
       (fun name ->


### PR DESCRIPTION
## Summary
Keepers could enter an idle loop calling `masc_status` repeatedly because the pruning fallback preserved all boring tools when no productive tools were available.

## Before
All tools boring + just polled → fallback: keep all tools → LLM picks `masc_status` again → loop

## After  
All tools boring + just polled → only `keeper_stay_silent` available → LLM skips turn → loop broken

## Impact
- Saves ~560s + tokens per idle loop occurrence (from 4+ boring turns to 1)
- Does not affect keepers with productive tools available

Closes #6152

🤖 Generated with [Claude Code](https://claude.com/claude-code)