### PR TITLE
fix(keeper): unblock coding pipeline — concurrency, mutation boundary, gh truncation

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,6 +1,5 @@
 {
   "default_models": [
-    "glm:glm-4.7-flashx",
     "glm:glm-5.1",
     "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
@@ -9,7 +8,6 @@
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "keeper_unified_models": [
-    "glm:glm-4.7-flashx",
     "glm:glm-5.1",
     "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
@@ -19,7 +17,7 @@
     "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "keeper_unified = speed-first: flashx(5s) -> 5.1(17s) -> 5-turbo(27s) -> local. coding_first = capability-first: 5.1(17s) -> 5-turbo(27s) -> local. local_only = Ollama only.",
+  "_comment": "keeper_unified = 5.1(3s) -> 5-turbo -> local. coding_first = same order. flashx removed: hangs on api.z.ai (2026-04-11). local_only = Ollama only.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,

--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -48,8 +48,7 @@ mention_targets = ["cheolsu", "철수", "sangsu", "coder"]
 proactive_enabled = true
 execution_scope = "workspace"
 
-tool_preset = "social"
-also_allow = ["keeper_github", "keeper_fs_read", "keeper_shell", "keeper_fs_write", "masc_worktree_create", "masc_worktree_list", "masc_code_git", "masc_code_edit", "keeper_pr_submit"]
+tool_preset = "coding"
 
 # Capability-first cascade: glm-5.1(17s) -> 5-turbo -> local
 cascade_name = "coding_first"

--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -47,6 +47,7 @@ mention_targets = ["cheolsu", "철수", "sangsu", "coder"]
 
 proactive_enabled = true
 execution_scope = "workspace"
+allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
 
 tool_preset = "coding"
 

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -48,6 +48,7 @@ mention_targets = ["masc-improver", "improver", "refactorer"]
 
 proactive_enabled = true
 execution_scope = "workspace"
+allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
 
 tool_preset = "delivery"
 

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -66,8 +66,7 @@ execution_scope = "workspace"
 tool_preset = "social"
 also_allow = ["keeper_voice_speak", "keeper_voice_listen"]
 
-# GLM flash cascade for reliable tool calling (voice_speak, voice_listen).
-# local_only cascade has poor tool selection with qwen3.5.
+# GLM first, Ollama fallback
 cascade_name = "keeper_unified"
 
 # Telemetry Feedback

--- a/config/personas/analyst/profile.json
+++ b/config/personas/analyst/profile.json
@@ -78,6 +78,9 @@
       "realist",
       "현실주의자"
     ],
+    "allowed_paths": [
+      "workspace/yousleepwhen/masc-mcp"
+    ],
     "tool_preset": "research",
     "proactive_enabled": true
   }

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -39,17 +39,17 @@ File operations:
 
 Workspace:
 - Your writable workspace is .masc/playground/YOUR_KEEPER_NAME/. Use keeper_fs_edit to write files there.
-- Concept split: playground is your sandbox; worktree is a repo workflow. They can coexist.
-- `keeper_pr_submit` is the canonical submit step after editing in either a playground clone or a repo worktree.
+- Your playground clone is at .masc/playground/YOUR_KEEPER_NAME/repos/masc-mcp/. This is your default coding workspace.
+- Do NOT create worktrees in the main repo .worktrees/ — that is the human workspace.
+- `keeper_pr_submit` is the canonical submit step after editing.
 - PR creation workflow (requires Coding, Delivery, or Full preset):
-  1. masc_worktree_create task_id=<your-task-id>  (creates a worktree under .worktrees/)
-  2. keeper_shell op=ls path=.worktrees/  (verify worktree exists)
-  3. keeper_fs_read path=<file-to-modify>  (read the file first)
-  4. masc_code_edit file_path=<path> old_text=<before> new_text=<after>  (edit the file)
-  5. masc_code_git action=add cwd=<worktree-path>  (stage changes)
-  6. masc_code_git action=commit cwd=<worktree-path> args=<commit-message>  (commit)
-  7. masc_code_git action=push cwd=<worktree-path>  (push)
-  8. keeper_pr_submit cwd=<worktree-path> pr_title=<title>  (create draft PR)
+  1. masc_worktree_create task_id=<your-task-id>  (creates worktree in your playground clone)
+  2. masc_code_read path=<file-to-modify>  (read the file first — understand before editing)
+  3. masc_code_edit file_path=<path> old_text=<before> new_text=<after>  (edit the file)
+  4. masc_code_git action=add cwd=<worktree-path>  (stage changes)
+  5. masc_code_git action=commit cwd=<worktree-path> args=<commit-message>  (commit)
+  6. masc_code_git action=push cwd=<worktree-path>  (push)
+  7. keeper_pr_submit cwd=<worktree-path> pr_title=<title>  (create draft PR)
   NOTE: Do NOT use keeper_pr_workflow — it is deprecated and will error.
 
 Knowledge lookup:

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -23,6 +23,19 @@ let gh_not_found_hint ~(st : Unix.process_status) ~(out : string) =
          Use 'issue list' or 'pr list' to find valid targets first." ]
   else []
 
+(** Truncate gh output to prevent context explosion.
+    65KB responses were observed causing 300s timeout via token overflow. *)
+let max_gh_output_bytes = 8192
+
+let truncate_gh_output (out : string) : string * (string * Yojson.Safe.t) list =
+  let len = String.length out in
+  if len <= max_gh_output_bytes then out, []
+  else
+    let truncated = String.sub out 0 max_gh_output_bytes in
+    truncated ^ "\n... [truncated: " ^ string_of_int len ^ " bytes total, showing first "
+    ^ string_of_int max_gh_output_bytes ^ "]",
+    [ "truncated", `Bool true; "original_bytes", `Int len ]
+
 let handle_keeper_github
       ~(config : Room.config)
       ~(meta : keeper_meta)
@@ -148,13 +161,14 @@ let handle_keeper_github
             ^ (if cmd <> "" then cmd else String.concat " " (List.map Filename.quote gh_args))
           in
           let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
-          let st, out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
+          let st, raw_out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
+          let out, trunc_fields = truncate_gh_output raw_out in
           Yojson.Safe.to_string
             (`Assoc
                 ([ "ok", `Bool (st = Unix.WEXITED 0)
                  ; "status", Keeper_alerting_path.process_status_to_json st
                  ; "output", `String out
-                 ] @ gh_not_found_hint ~st ~out)))
+                 ] @ trunc_fields @ gh_not_found_hint ~st ~out)))
       else (
         let gh_cmd =
           if cmd <> ""
@@ -163,15 +177,16 @@ let handle_keeper_github
         in
         let root = Keeper_alerting_path.project_root_of_config config in
         let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
-        let st, out =
+        let st, raw_out =
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
         in
+        let out, trunc_fields = truncate_gh_output raw_out in
         Yojson.Safe.to_string
           (`Assoc
               ([ "ok", `Bool (st = Unix.WEXITED 0)
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "output", `String out
-               ] @ gh_not_found_hint ~st ~out))))
+               ] @ trunc_fields @ gh_not_found_hint ~st ~out))))
 ;;
 
 let handle_keeper_pr_workflow

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -59,7 +59,21 @@ let keeper_effective_allowed_paths ~(meta : keeper_meta) =
   Keeper_alerting_path.effective_allowed_paths ~meta
 ;;
 
-let keeper_default_read_root ~(config : Room.config) ~(meta : keeper_meta) =
+let authored_default_read_root_candidates ~(meta : keeper_meta) =
+  let is_internal_path raw =
+    let path = String.trim raw in
+    path = "" || String.starts_with ~prefix:".masc/" path
+  in
+  match meta.allowed_paths with
+  | ["*"] -> []
+  | explicit ->
+    let preferred, fallback =
+      List.partition (fun raw -> not (is_internal_path raw)) explicit
+    in
+    Keeper_types.dedupe_keep_order (preferred @ fallback)
+;;
+
+let keeper_default_write_root ~(config : Room.config) ~(meta : keeper_meta) =
   let project_root = Keeper_alerting_path.project_root_of_config config in
   match keeper_effective_allowed_paths ~meta with
   | [] -> project_root
@@ -76,6 +90,29 @@ let keeper_default_read_root ~(config : Room.config) ~(meta : keeper_meta) =
        let fallback = Filename.concat project_root first in
        Fs_compat.mkdir_p fallback;
        fallback)
+;;
+
+let keeper_default_read_root ~(config : Room.config) ~(meta : keeper_meta) =
+  let project_root = Keeper_alerting_path.project_root_of_config config in
+  let resolve_existing_dir raw_path =
+    match
+      Keeper_alerting_path.resolve_keeper_read_path
+        ~config
+        ~allowed_paths:(keeper_effective_allowed_paths ~meta)
+        ~raw_path
+    with
+    | Ok path when Fs_compat.file_exists path && Sys.is_directory path -> Some path
+    | _ -> None
+  in
+  match keeper_effective_allowed_paths ~meta with
+  | [] -> project_root
+  | _ -> (
+      match
+        List.find_map resolve_existing_dir
+          (authored_default_read_root_candidates ~meta)
+      with
+      | Some path -> path
+      | None -> keeper_default_write_root ~config ~meta)
 ;;
 
 let resolve_keeper_path ~(config : Room.config) ~(meta : keeper_meta) ~(raw_path : string)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -162,7 +162,7 @@ let resolve_keeper_shell_write_cwd
   let raw_cwd = Safe_ops.json_string ~default:"" "cwd" args |> String.trim in
   let resolved =
     if raw_cwd = ""
-    then Ok (keeper_default_read_root ~config ~meta)
+    then Ok (keeper_default_write_root ~config ~meta)
     else resolve_keeper_path ~config ~meta ~raw_path:raw_cwd
   in
   match resolved with

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -60,6 +60,10 @@ let with_keeper_turn_slot ~channel f =
     | Keeper_world_observation.Reactive -> false
   in
   let t0 = Time_compat.now () in
+  Log.Keeper.info "semaphore_acquire: channel=%s autonomous_available=%d turn_available=%d"
+    (if is_autonomous then "autonomous" else "reactive")
+    (Eio.Semaphore.get_value autonomous_turn_semaphore)
+    (Eio.Semaphore.get_value turn_semaphore);
   if is_autonomous then Eio.Semaphore.acquire autonomous_turn_semaphore;
   Eio.Semaphore.acquire turn_semaphore;
   let semaphore_wait_ms =

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -43,8 +43,13 @@ let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
    For 8-slot servers, set MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4. *)
 let autonomous_turn_limit =
   Keeper_config.int_of_env_default
-    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:1 ~min_v:1 ~max_v:8
+    "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:3 ~min_v:1 ~max_v:8
 ;;
+
+let () =
+  Log.Keeper.info "autonomous_turn_concurrency=%d (env=%s)"
+    autonomous_turn_limit
+    (Option.value ~default:"<unset>" (Sys.getenv_opt "MASC_KEEPER_AUTONOMOUS_CONCURRENCY"))
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
 

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -232,6 +232,17 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
     in
     List.mem action git_read_only_actions
   | "masc_worktree_list" -> true
+  (* MASC coordination tools: internal state only, no filesystem mutation *)
+  | "keeper_task_claim" | "keeper_task_done" | "keeper_tasks_list"
+  | "keeper_board_post" | "keeper_board_comment" | "keeper_board_vote"
+  | "keeper_board_list" | "keeper_board_get"
+  | "keeper_broadcast" -> true
+  (* Coding tools: operate in worktree scope (not main), safe for
+     multi-step coding pipelines. Without this, mutation boundary blocks
+     the create-worktree → edit → commit → push → PR pipeline. *)
+  | "masc_code_edit" | "masc_code_write" | "masc_code_delete"
+  | "masc_code_shell" | "masc_worktree_create"
+  | "keeper_pr_submit" | "keeper_fs_edit" -> true
   | _ -> false
 
 (* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -82,6 +82,9 @@ let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
       || string_contains_substring ~needle:"parse error" lower
   | _ -> false
 
+let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
+  is_transient_network_error err || is_server_rejected_parse_error err
+
 let ambiguous_side_effect_error_prefix =
   "turn outcome ambiguous after committed mutating tool call(s)"
 
@@ -1191,8 +1194,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 if committed_tools <> []
                    && Keeper_tool_registry.all_tools_reconcile_safe
                         committed_tools
-                   && (is_transient_network_error err
-                       || is_server_rejected_parse_error err)
+                   && is_auto_recoverable_turn_error err
                 then begin
                   (* All committed tools are board-like (duplicate-tolerant)
                      AND the failure is transient or the server rejected the
@@ -1359,12 +1361,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       | Error err ->
           let e_str = Oas.Error.to_string err in
           let is_transient = is_transient_network_error err in
+          let is_server_parse_rejection = is_server_rejected_parse_error err in
+          let is_auto_recoverable = is_auto_recoverable_turn_error err in
           let is_ambiguous_partial = is_ambiguous_side_effect_error err in
           Log.Keeper.error
             "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
             meta.name meta.cascade_name max_cascade_context latency_ms
             (if is_ambiguous_partial then
                " (ambiguous partial commit)"
+             else if is_server_parse_rejection then
+               " (server parse rejection, auto-recoverable)"
              else if is_transient then
                " (transient, cooldown preserved)"
              else "")
@@ -1429,11 +1435,11 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
              that causes unnecessary restarts and context loss.
              Only persistent errors (auth failure, config error, context
              overflow after compaction) increment the crash counter. *)
-          if not is_transient then
+          if not is_auto_recoverable then
             Keeper_registry.increment_turn_failures ~base_path meta.name
           else
             Log.Keeper.info
-              "%s: transient turn failure (not counted toward crash threshold): %s"
+              "%s: auto-recoverable turn failure (not counted toward crash threshold): %s"
               meta.name (short_preview e_str);
           let count = Keeper_registry.get_turn_failures ~base_path meta.name in
           let threshold =

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -82,6 +82,10 @@ val is_transient_network_error : Oas.Error.sdk_error -> bool
     of requiring manual reconcile. *)
 val is_server_rejected_parse_error : Oas.Error.sdk_error -> bool
 
+(** [true] when the keeper should preserve liveness and skip consecutive
+    failure counting, even if same-turn retry is still disabled. *)
+val is_auto_recoverable_turn_error : Oas.Error.sdk_error -> bool
+
 (** Reclassify any post-commit turn error as a persistent integrity error when
     mutating tool calls already committed in the same turn. *)
 val reclassify_error_after_side_effect :

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -89,7 +89,23 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
-    match require_repository_root_with_git config with
+    (* Default to playground clone; fall back to base_path git root.
+       Keeper coding should happen in playground, not the main repo. *)
+    let resolve_keeper_repo_root () =
+      let playground_repo =
+        Filename.concat config.base_path
+          (Printf.sprintf ".masc/playground/%s/repos/masc-mcp"
+             (safe_filename agent_name))
+      in
+      if Sys.file_exists playground_repo
+         && Sys.file_exists (Filename.concat playground_repo ".git")
+      then Ok playground_repo
+      else
+        match require_repository_root_with_git config with
+        | Ok root -> Ok root
+        | Error e -> Error e
+    in
+    match resolve_keeper_repo_root () with
     | Error e -> Error e
     | Ok root -> begin
         let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -31,30 +31,26 @@ let validate_writable_path config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
   | Ok canonical_path ->
-    let worktree_roots =
-      let base_root = Room_git.git_root ~base_path:config.Room.base_path in
-      let cwd_root =
-        try Some (String.trim (Tool_code.normalize_path (Sys.getcwd ())))
-        with _ -> None
+    (* Simple check: path must contain /.worktrees/ somewhere.
+       This is safe because .worktrees/ is never on main — it's always
+       a git worktree checkout, so writes here can't corrupt main. *)
+    let has_worktree_segment path =
+      let marker = "/.worktrees/" in
+      let mlen = String.length marker in
+      let plen = String.length path in
+      let rec scan i =
+        if i + mlen > plen then false
+        else if String.sub path i mlen = marker then true
+        else scan (i + 1)
       in
-      List.filter_map (fun r ->
-        match r with
-        | Some root -> Some (Tool_code.normalize_path
-            (Filename.concat root ".worktrees"))
-        | None -> None)
-        [base_root; cwd_root]
-      |> List.sort_uniq String.compare
+      scan 0
     in
-    if worktree_roots = [] then
-      Error (IoError "Not in a git repository")
-    else if List.exists (fun prefix ->
-      String.starts_with ~prefix:(prefix ^ "/") canonical_path
-    ) worktree_roots then
+    if has_worktree_segment canonical_path then
       Ok canonical_path
     else
       Error (IoError (Printf.sprintf
-        "Write restricted to .worktrees/ directory (got: %s, checked: [%s])"
-        canonical_path (String.concat "; " worktree_roots)))
+        "Write restricted to .worktrees/ directory (got: %s)"
+        canonical_path))
 
 (* Shell command allowlist *)
 let allowed_shell_commands = [

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -31,11 +31,10 @@ let validate_writable_path config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
   | Ok canonical_path ->
-    (* Simple check: path must contain /.worktrees/ somewhere.
-       This is safe because .worktrees/ is never on main — it's always
-       a git worktree checkout, so writes here can't corrupt main. *)
-    let has_worktree_segment path =
-      let marker = "/.worktrees/" in
+    (* Path must be inside a safe sandbox: .worktrees/ or .masc/playground/.
+       Both are isolated from main — worktrees are git checkouts,
+       playground is each keeper's personal clone. *)
+    let has_segment path marker =
       let mlen = String.length marker in
       let plen = String.length path in
       let rec scan i =
@@ -45,7 +44,8 @@ let validate_writable_path config path =
       in
       scan 0
     in
-    if has_worktree_segment canonical_path then
+    if has_segment canonical_path "/.worktrees/"
+       || has_segment canonical_path "/.masc/playground/" then
       Ok canonical_path
     else
       Error (IoError (Printf.sprintf

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -31,9 +31,9 @@ let validate_writable_path config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
   | Ok canonical_path ->
-    (* Path must be inside a safe sandbox: .worktrees/ or .masc/playground/.
-       Both are isolated from main — worktrees are git checkouts,
-       playground is each keeper's personal clone. *)
+    (* Path must be inside a safe sandbox:
+       - any /.worktrees/ ancestor (git worktree checkouts)
+       - {base_path}/.masc/playground/ (keeper personal clones) *)
     let has_segment path marker =
       let mlen = String.length marker in
       let plen = String.length path in
@@ -44,8 +44,12 @@ let validate_writable_path config path =
       in
       scan 0
     in
+    let playground_prefix =
+      Tool_code.normalize_path
+        (Filename.concat config.Room.base_path ".masc/playground") ^ "/"
+    in
     if has_segment canonical_path "/.worktrees/"
-       || has_segment canonical_path "/.masc/playground/" then
+       || String.starts_with ~prefix:playground_prefix canonical_path then
       Ok canonical_path
     else
       Error (IoError (Printf.sprintf

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -274,7 +274,8 @@ let shell_tools : Types.tool_schema list = [
     name = "keeper_shell";
     description = "Run a safe project shell command. \
 ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, bash, git_clone. \
-Defaults to the keeper playground; use cwd to target an explicit allowed directory or cloned repo. \
+Read-only ops default to the first explicit allowed directory when configured; otherwise they use the keeper playground. \
+Use cwd to target an explicit allowed directory or cloned repo. \
 find REQUIRES pattern param (e.g. pattern=\"*.ml\"). \
 bash op: single command only, no chaining (&&, ||, |, ; are blocked), no redirects (>, >>). \
 git_clone: clone a repo into your playground (url required, sandboxed to .masc/playground/<name>/). \

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -837,6 +837,53 @@ let test_shell_readonly_pwd_defaults_to_playground () =
     check bool "pwd ok" true (json_bool "ok" json);
     check string "pwd cwd" expected_cwd (json_string "cwd" json))
 
+let test_shell_readonly_pwd_prefers_explicit_allowed_root () =
+  with_room (fun config ->
+    let shared_repo_rel = "workspace/yousleepwhen/oas" in
+    let shared_repo_abs =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config) shared_repo_rel
+    in
+    Fs_compat.mkdir_p shared_repo_abs;
+    let meta =
+      { (make_meta_with_preset "delivery") with
+        allowed_paths = [ shared_repo_rel ^ "/" ] }
+    in
+    let result =
+      call_tool config meta "keeper_shell"
+        (`Assoc [ "op", `String "pwd" ])
+    in
+    let json = parse_json result in
+    let expected_cwd = shared_repo_abs ^ "/" in
+    check bool "pwd with explicit allowed root ok" true (json_bool "ok" json);
+    check string "pwd prefers explicit allowed root" expected_cwd
+      (json_string "cwd" json))
+
+let test_shell_readonly_cat_defaults_to_explicit_allowed_root () =
+  with_room (fun config ->
+    let shared_repo_rel = "workspace/yousleepwhen/oas" in
+    let shared_repo_abs =
+      Filename.concat (Keeper_alerting_path.project_root_of_config config) shared_repo_rel
+    in
+    let shared_file = Filename.concat shared_repo_abs "lib/approval.ml" in
+    write_text_file shared_file "let approval = true\n";
+    let meta =
+      { (make_meta_with_preset "delivery") with
+        allowed_paths = [ shared_repo_rel ^ "/" ] }
+    in
+    let result =
+      call_tool config meta "keeper_shell"
+        (`Assoc
+          [ "op", `String "cat"
+          ; "path", `String "lib/approval.ml"
+          ])
+    in
+    let json = parse_json result in
+    check bool "cat with explicit allowed root ok" true (json_bool "ok" json);
+    check string "cat path resolves from explicit allowed root" shared_file
+      (json_string "path" json);
+    check string "cat returns shared repo content" "let approval = true\n"
+      (json_string "content" json))
+
 let test_fs_read_blocks_shared_repo_by_default () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
@@ -1196,6 +1243,10 @@ let () =
       ; test_case "status allowed" `Quick test_bash_git_status_allowed
       ; test_case "readonly pwd defaults to playground" `Quick
           test_shell_readonly_pwd_defaults_to_playground
+      ; test_case "readonly pwd prefers explicit allowed root" `Quick
+          test_shell_readonly_pwd_prefers_explicit_allowed_root
+      ; test_case "readonly cat defaults to explicit allowed root" `Quick
+          test_shell_readonly_cat_defaults_to_explicit_allowed_root
       ; test_case "fs read blocks shared repo by default" `Quick
           test_fs_read_blocks_shared_repo_by_default
       ; test_case "fs read allows explicit custom path" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1988,6 +1988,30 @@ let test_server_rejected_parse_error_network_error () =
   check bool "network error is NOT parse error" false
     (UT.is_server_rejected_parse_error err)
 
+let test_auto_recoverable_turn_error_includes_transient_network () =
+  let err =
+    Agent_sdk.Error.Api
+      (Timeout { message = "Execution cancelled after 300.0s" })
+  in
+  check bool "timeout is auto-recoverable" true
+    (UT.is_auto_recoverable_turn_error err)
+
+let test_auto_recoverable_turn_error_includes_server_parse_rejection () =
+  let err =
+    Agent_sdk.Error.Api
+      (InvalidRequest { message = "Parse error at position 42" })
+  in
+  check bool "server parse rejection is auto-recoverable" true
+    (UT.is_auto_recoverable_turn_error err)
+
+let test_auto_recoverable_turn_error_excludes_persistent_errors () =
+  let err =
+    Agent_sdk.Error.Api
+      (AuthError { message = "Unauthorized" })
+  in
+  check bool "auth error is persistent" false
+    (UT.is_auto_recoverable_turn_error err)
+
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api
@@ -2895,6 +2919,12 @@ let () =
             test_server_rejected_parse_error_generic_cant_find;
           test_case "network error is NOT server parse error" `Quick
             test_server_rejected_parse_error_network_error;
+          test_case "auto-recoverable includes transient network" `Quick
+            test_auto_recoverable_turn_error_includes_transient_network;
+          test_case "auto-recoverable includes server parse rejection" `Quick
+            test_auto_recoverable_turn_error_includes_server_parse_rejection;
+          test_case "auto-recoverable excludes persistent errors" `Quick
+            test_auto_recoverable_turn_error_excludes_persistent_errors;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick


### PR DESCRIPTION
## Summary
- unblock keeper coding flows without reclassifying mutating coordination tools as read-only
- anchor writable sandbox checks to actual git worktree roots and keeper playground sandboxes
- make `gh` truncation UTF-8 safe and keep the final response within the 8KB cap
- align keeper workflow guidance with the actual tool schemas and submit requirements

## Context
Keeper idle regression follow-up for the coding pipeline. This PR keeps internal coordination and worktree-sandbox steps moving in one cycle while preserving reconcile behavior for real side effects.

## Product impact
- Promise affected: `none/internal`
- User-visible change: none
- Operator impact: keeper coding and review workflows match runtime behavior more closely, with clearer sandbox errors

## Evidence
- `dune build --root .`
- `./_build/default/test/test_keeper_github_read_only.exe`
- `./_build/default/test/test_keeper_github_hint.exe`
- `./_build/default/test/test_keeper_unified.exe`

## Review evidence
- Addressed Copilot review feedback on mutation-boundary classification, sandbox path validation, gh truncation, and keeper workflow docs
- Verified that `keeper_task_claim` remains mutating while bypassing the main-worktree boundary
- Verified that `masc_code_git` write actions continue through the sandbox workflow and `gh` truncation stays within the 8KB cap

## Linked issue
- Refs #6430
