### PR TITLE
fix(deploy): align config dir default with base-path

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -149,7 +149,7 @@ else
 
     MASC_ORCHESTRATOR_ENABLED=0 \
     MASC_AUTO_RESPOND=true \
-    MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$REPO_DIR/config}" \
+    MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$BASE_PATH/.masc/config}" \
         nohup "$RELEASE_EXE" \
             --port="$PROD_PORT" \
             --base-path="$BASE_PATH" \
@@ -199,7 +199,7 @@ else
             fi
             MASC_ORCHESTRATOR_ENABLED=0 \
             MASC_AUTO_RESPOND=true \
-            MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$REPO_DIR/config}" \
+            MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$BASE_PATH/.masc/config}" \
                 nohup "$RELEASE_EXE" \
                     --port="$PROD_PORT" \
                     --base-path="$BASE_PATH" \


### PR DESCRIPTION
## Summary
deploy.sh defaulted `MASC_CONFIG_DIR` to `$REPO_DIR/config` while run-local.sh used `$BASE_PATH/.masc/config`. Dashboard showed path mismatch between config and runtime data.

## Change
```diff
- MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$REPO_DIR/config}"
+ MASC_CONFIG_DIR="${MASC_CONFIG_DIR:-$BASE_PATH/.masc/config}"
```

Applied to both normal start (L152) and rollback start (L202).

## Verification
- `~/me/.masc/config/` exists with cascade.json, keepers/, prompts/, personas/
- run-local.sh already uses `$TARGET_DIR/.masc/config` as default
- Config_dir_resolver.path_from_local_masc resolves the same path

Closes #6192

🤖 Generated with [Claude Code](https://claude.com/claude-code)