### PR TITLE
fix(dashboard): surface malformed JSONL diagnostics instead of silent drops

### DIFF
--- a/bin/masc_tui_loader.ml
+++ b/bin/masc_tui_loader.ml
@@ -59,7 +59,9 @@ let read_last_lines path n =
         if len <= n then all
         else
           List.filteri (fun i _ -> i >= len - n) all)
-  with Sys_error _ -> []
+  with Sys_error err ->
+    Printf.eprintf "[masc-tui] read_last_lines %s: %s\n%!" path err;
+    []
 
 (** Parse a single metrics JSONL line into a log_entry *)
 let parse_log_entry (line : string) : log_entry option =

--- a/lib/channel_gate_discord_state.ml
+++ b/lib/channel_gate_discord_state.ml
@@ -81,8 +81,14 @@ let read_json_file_opt path =
   if not (Sys.file_exists path) then
     None
   else
-    try Some (Yojson.Safe.from_file path) with
-    | Sys_error _ | Yojson.Json_error _ -> None
+    match Yojson.Safe.from_file path with
+    | json -> Some json
+    | exception Sys_error msg ->
+        Log.warn "channel_gate: cannot read %s: %s" path msg;
+        None
+    | exception Yojson.Json_error msg ->
+        Log.warn "channel_gate: corrupt JSON in %s: %s" path msg;
+        None
 
 let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
   match json with
@@ -189,8 +195,12 @@ let read_recent_audit ~limit =
                let trimmed = String.trim line in
                if trimmed = "" then None
                else
-                 try Some (Yojson.Safe.from_string trimmed) with
-                 | Yojson.Json_error _ -> None)
+                 match Yojson.Safe.from_string trimmed with
+                 | json -> Some json
+                 | exception Yojson.Json_error msg ->
+                     Log.warn
+                       "channel_gate: malformed audit JSONL line: %s" msg;
+                     None)
         |> List.rev
         |> fun rows ->
         let total = List.length rows in

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -10,6 +10,24 @@ open Keeper_status_bridge
 
 include Dashboard_http_keeper_detail
 
+(** Parse JSONL lines, returning both parsed values and the count of
+    malformed (unparseable) lines.  Surfaces degraded state instead of
+    silently dropping bad rows. *)
+let parse_jsonl_with_diagnostics (lines : string list)
+    : Yojson.Safe.t list * int =
+  let malformed = ref 0 in
+  let parsed =
+    List.filter_map (fun line ->
+      match Yojson.Safe.from_string line with
+      | json -> Some json
+      | exception Yojson.Json_error msg ->
+          incr malformed;
+          Log.Dashboard.warn "malformed JSONL line dropped: %s" msg;
+          None
+    ) lines
+  in
+  (parsed, !malformed)
+
 (** Context-ratio thresholds for keeper health scoring.
     These are distinct from Dashboard.ctx_* (compaction triggers) —
     health scoring penalizes keepers approaching context limits.
@@ -108,7 +126,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
     (List.mapi (fun idx name -> fun () ->
       results.(idx) <- (
       match Keeper_types.read_meta config name with
-      | Error _ | Ok None -> None
+      | Error msg ->
+          Log.Dashboard.warn "keeper %s meta read error (degraded): %s" name msg;
+          None
+      | Ok None -> None
       | Ok (Some (m : Keeper_types.keeper_meta)) ->
           let agent = Keeper_exec_status.parse_agent_status config ~agent_name:m.agent_name in
 
@@ -177,10 +198,8 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
             else keeper_metrics_24h_json ~metrics_lines:all_metrics_lines ~now_ts
           in
           let metrics_lines = all_metrics_lines in
-          let parsed_metrics =
-            List.filter_map (fun line ->
-              try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
-            ) metrics_lines
+          let (parsed_metrics, metrics_malformed) =
+            parse_jsonl_with_diagnostics metrics_lines
           in
 	          let last_metrics =
 	            match List.rev parsed_metrics with
@@ -414,7 +433,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                      `Assoc [("has_checkpoint", `Bool false)]
                  | _ ->
                      let primary_max_context =
-                       (match cfgs with c :: _ -> c.Llm_provider.Provider_config.max_tokens | [] -> 128_000)
+                       Oas_model_resolve.resolve_primary_max_context effective_models
                      in
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =
@@ -533,7 +552,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ("conversation_tail", conversation_tail);
                   ("k2k_recent", k2k_recent);
                   ("trust_observatory", trust_observatory);
-                ]
+                ] @ (if metrics_malformed > 0 then
+                       [("metrics_malformed_lines", `Int metrics_malformed)]
+                     else [])
+
               in
 	            `Assoc ([
               ("name", `String m.name);
@@ -738,21 +760,21 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
     ) names);
   let summaries = Array.to_list results |> List.filter_map Fun.id in
   (* H-9 fix: include recent alerts so BAD alerts are visible on dashboard *)
-  let recent_alerts =
+  let (recent_alerts, alerts_malformed) =
     let alerts_path = Keeper_types.keeper_alerts_path config in
     let lines =
       Keeper_memory.read_file_tail_lines alerts_path ~max_bytes:50000 ~max_lines:10
     in
-    List.filter_map (fun line ->
-      try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
-    ) lines
+    parse_jsonl_with_diagnostics lines
   in
-  `Assoc [
+  `Assoc ([
     ("keepers", `List summaries);
     ("total", `Int (List.length summaries));
     ("recent_alerts", `List recent_alerts);
     ("alert_count", `Int (List.length recent_alerts));
-  ]
+  ] @ (if alerts_malformed > 0 then
+         [("alerts_malformed_lines", `Int alerts_malformed)]
+       else []))
 
 (** Build a structured config JSON for a single keeper, grouped by category.
     Returns (http_status, json). *)

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -498,22 +498,25 @@ let latest_snapshot_of_lines lines ~parse_snapshot ~has_legacy_shape =
   | None ->
       List.find_map
         (fun line ->
-          try
-            let json = Yojson.Safe.from_string line in
-            match parse_snapshot line with
-            | Some _ as snapshot -> snapshot
-            | None ->
-                if has_legacy_shape json then
-                  Some
-                    {
-                      latest_tool_names = [];
-                      latest_tool_call_count = Some 0;
-                      latest_action_source = None;
-                      tool_audit_source = None;
-                      tool_audit_at = json_iso_opt json;
-                    }
-                else None
-          with Yojson.Json_error _ -> None)
+          match Yojson.Safe.from_string line with
+          | json ->
+              (match parse_snapshot line with
+               | Some _ as snapshot -> snapshot
+               | None ->
+                   if has_legacy_shape json then
+                     Some
+                       {
+                         latest_tool_names = [];
+                         latest_tool_call_count = None;
+                         latest_action_source = None;
+                         tool_audit_source = Some "legacy_shape";
+                         tool_audit_at = json_iso_opt json;
+                       }
+                   else None)
+          | exception Yojson.Json_error msg ->
+              Log.Keeper.warn
+                "tool audit: malformed JSONL line skipped: %s" msg;
+              None)
         ordered
 
 let latest_tool_audit_snapshot_from_decisions config keeper_name =
@@ -522,28 +525,31 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
   else
     let lines = Keeper_memory.read_file_tail_lines path ~max_bytes:40000 ~max_lines:12 in
     let parse_snapshot line =
-      try
-        let json = Yojson.Safe.from_string line in
-        let tools = json_string_list_member "tools_used" json in
-        let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
-        let tool_call_count =
-          match raw_tool_call_count with
-          | Some _ as value -> value
-          | None -> Some (List.length tools)
-        in
-        let action_source = action_source_opt_member json in
-        if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
-        then None
-        else
-          Some
-            {
-              latest_tool_names = List.sort_uniq String.compare tools;
-              latest_tool_call_count = tool_call_count;
-              latest_action_source = action_source;
-              tool_audit_source = Some "keeper_decision_log";
-              tool_audit_at = json_iso_opt json;
-            }
-      with Yojson.Json_error _ -> None
+      match Yojson.Safe.from_string line with
+      | json ->
+          let tools = json_string_list_member "tools_used" json in
+          let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
+          let tool_call_count =
+            match raw_tool_call_count with
+            | Some _ as value -> value
+            | None -> Some (List.length tools)
+          in
+          let action_source = action_source_opt_member json in
+          if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
+          then None
+          else
+            Some
+              {
+                latest_tool_names = List.sort_uniq String.compare tools;
+                latest_tool_call_count = tool_call_count;
+                latest_action_source = action_source;
+                tool_audit_source = Some "keeper_decision_log";
+                tool_audit_at = json_iso_opt json;
+              }
+      | exception Yojson.Json_error msg ->
+          Log.Keeper.warn
+            "tool audit (decisions): malformed JSONL skipped: %s" msg;
+          None
     in
     latest_snapshot_of_lines lines
       ~parse_snapshot
@@ -563,31 +569,34 @@ let latest_tool_audit_snapshot_from_decisions config keeper_name =
 let latest_tool_audit_snapshot_from_metrics config keeper_name =
   let lines = read_recent_metrics_lines config keeper_name in
   let parse_snapshot line =
-    try
-      let json = Yojson.Safe.from_string line in
-      let tools =
-        json_string_list_member "tools_used" json
-        |> List.sort_uniq String.compare
-      in
-      let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
-      let tool_call_count =
-        match raw_tool_call_count with
-        | Some _ as value -> value
-        | None -> Some (List.length tools)
-      in
-      let action_source = action_source_opt_member json in
-      if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
-      then None
-      else
-        Some
-          {
-            latest_tool_names = tools;
-            latest_tool_call_count = tool_call_count;
-            latest_action_source = action_source;
-            tool_audit_source = Some "keeper_metrics";
-            tool_audit_at = json_iso_opt json;
-          }
-    with Yojson.Json_error _ -> None
+    match Yojson.Safe.from_string line with
+    | json ->
+        let tools =
+          json_string_list_member "tools_used" json
+          |> List.sort_uniq String.compare
+        in
+        let raw_tool_call_count = json_int_opt_member "tool_call_count" json in
+        let tool_call_count =
+          match raw_tool_call_count with
+          | Some _ as value -> value
+          | None -> Some (List.length tools)
+        in
+        let action_source = action_source_opt_member json in
+        if not (has_tool_audit_evidence ~tools ~raw_tool_call_count ~action_source)
+        then None
+        else
+          Some
+            {
+              latest_tool_names = tools;
+              latest_tool_call_count = tool_call_count;
+              latest_action_source = action_source;
+              tool_audit_source = Some "keeper_metrics";
+              tool_audit_at = json_iso_opt json;
+            }
+    | exception Yojson.Json_error msg ->
+        Log.Keeper.warn
+          "tool audit (metrics): malformed JSONL skipped: %s" msg;
+        None
   in
   latest_snapshot_of_lines lines
     ~parse_snapshot


### PR DESCRIPTION
## Summary

#6296 전체 해결: dashboard/keeper/connector/TUI의 silent drop 패턴 일괄 수정.

### Slice 1: `dashboard_http_keeper.ml`
- `parse_jsonl_with_diagnostics` 헬퍼 — 맬포먼드 행 수 추적 + 로그
- Keeper metrics: `metrics_malformed_lines` 필드 노출 (> 0일 때만)
- Alerts: `alerts_malformed_lines` 필드 노출
- `read_meta` Error와 Ok None 구분 (에러 vs 부재)
- 128_000 하드코딩 → `Oas_model_resolve.resolve_primary_max_context` SSOT

### Slice 2: `keeper_exec_status_metrics.ml`
- `latest_snapshot_of_lines`: try/with → match/exception + warn log
- Legacy shape: `tool_call_count = Some 0` → `None` (false-zero 제거)
- Legacy shape: `tool_audit_source = None` → `Some "legacy_shape"` (provenance)
- `parse_snapshot` 콜백 2곳: 동일 패턴 수정

### Slice 3: `channel_gate_discord_state.ml` + `bin/masc_tui_loader.ml`
- `read_json_file_opt`: Sys_error(읽기 실패)와 Json_error(파일 깨짐) 구분
- Audit JSONL 파싱: malformed 행 로그
- TUI `read_last_lines`: Sys_error 로그

## Design

**원칙: 기존 fallback 동작은 유지, 진단 가시성만 추가**

맬포먼드 데이터는 여전히 drop/fallback하되, 운영자가 원인을 추적할 수 있도록:
1. 로그에 에러 메시지 기록
2. JSON 응답에 malformed count 포함 (0 초과 시에만)
3. Error와 None(absent)을 구분하는 로그

## Test plan

- [x] `dune build` 통과 (3 commits 모두)
- [ ] 대시보드에서 정상 keeper 표시 확인
- [ ] 맬포먼드 JSONL 행 삽입 후 `metrics_malformed_lines` 필드 확인

Closes #6296

🤖 Generated with [Claude Code](https://claude.com/claude-code)