### PR TITLE
chore(pin): bump OAS to v0.119.1

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.119.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.119.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="cb8590575be63e265fa3db66832041e3465c9eb3"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.119.0"
+readonly OAS_AGENT_SDK_SHA="3d335f1b235b83fff814e1b317b7c084bbdb9404"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.119.1"


### PR DESCRIPTION
## Summary
- OAS pin cb85905 → 3d335f1 (v0.119.0 → v0.119.1)
- Includes 5 dedup PRs, schema gen try_coerce delegation

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)