### PR TITLE
fix(task): warn on preset mismatch in manual task claim

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -256,12 +256,15 @@ let handle_claim ctx args =
     | "" -> Types_core.Unassigned
     | s -> Types_core.role_of_string s
   in
+  let preset_warning = check_preset_mismatch ctx.config ~agent_name:ctx.agent_name ~task_id in
   let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
-  (* Notification harness: push claim event to all active sessions *)
   (match result with
    | Ok _ ->
-       (* Auto-set current_task so planning tools pick it up immediately *)
        Planning_eio.set_current_task ctx.config ~task_id;
+       (match preset_warning with
+        | Some warning ->
+            Log.Task.warn "%s (agent=%s)" warning ctx.agent_name
+        | None -> ());
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_claimed");
          ("task_id", `String task_id);
@@ -269,7 +272,10 @@ let handle_claim ctx args =
          ("timestamp", `Float (Time_compat.now ()));
        ])
    | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
-  result_to_response result
+  let (ok, msg) = result_to_response result in
+  match preset_warning, ok with
+  | Some warning, true -> (true, msg ^ "\n⚠️ " ^ warning)
+  | _ -> (ok, msg)
 
 (** Extract preset token from capabilities (e.g., ["keeper"; "preset:delivery"]). *)
 let preset_from_capabilities caps =
@@ -313,6 +319,32 @@ let resolve_agent_preset config agent_name =
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | _ -> None
+
+(** Check if the agent's preset can satisfy the task's required_preset.
+    Returns a warning string if there is a mismatch, None if OK or
+    no preset requirement exists.  Used by [handle_claim] to warn on
+    manual claims that bypass preset-fit filtering. *)
+let check_preset_mismatch config ~agent_name ~task_id =
+  let agent_preset = resolve_agent_preset config agent_name in
+  let tasks = Room.get_tasks_raw config in
+  match List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks with
+  | None -> None
+  | Some task ->
+      match task.required_preset, agent_preset with
+      | None, _ -> None
+      | Some required, None ->
+          Some (Printf.sprintf
+            "preset_mismatch: task %s requires preset '%s' but agent has no preset. \
+             Consider reassigning or changing the agent's preset."
+            task_id required)
+      | Some required, Some preset ->
+          if Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
+          then None
+          else Some (Printf.sprintf
+            "preset_mismatch: task %s requires preset '%s' but agent has '%s'. \
+             The agent may lack tools needed for this task. \
+             Consider reassigning or upgrading the preset."
+            task_id required preset)
 
 (** Build a task_filter closure that checks required_preset against the agent's preset. *)
 let preset_task_filter ~agent_preset (task : Types.task) =

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -244,39 +244,6 @@ let handle_batch_add_tasks ctx args =
     in
     (true, Room.batch_add_tasks_with_contracts ctx.config tasks)
 
-let handle_claim ctx args =
-  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
-    result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
-  else
-  let task_id = get_string args "task_id" "" in
-  match validate_task_id task_id with
-  | Error e -> result_to_response (Error e)
-  | Ok task_id ->
-  let agent_role = match get_string args "agent_role" "" with
-    | "" -> Types_core.Unassigned
-    | s -> Types_core.role_of_string s
-  in
-  let preset_warning = check_preset_mismatch ctx.config ~agent_name:ctx.agent_name ~task_id in
-  let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
-  (match result with
-   | Ok _ ->
-       Planning_eio.set_current_task ctx.config ~task_id;
-       (match preset_warning with
-        | Some warning ->
-            Log.Task.warn "%s (agent=%s)" warning ctx.agent_name
-        | None -> ());
-       Subscriptions.push_event_to_sessions (`Assoc [
-         ("type", `String "masc/task_claimed");
-         ("task_id", `String task_id);
-         ("agent_name", `String ctx.agent_name);
-         ("timestamp", `Float (Time_compat.now ()));
-       ])
-   | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
-  let (ok, msg) = result_to_response result in
-  match preset_warning, ok with
-  | Some warning, true -> (true, msg ^ "\n⚠️ " ^ warning)
-  | _ -> (ok, msg)
-
 (** Extract preset token from capabilities (e.g., ["keeper"; "preset:delivery"]). *)
 let preset_from_capabilities caps =
   List.find_map
@@ -345,6 +312,39 @@ let check_preset_mismatch config ~agent_name ~task_id =
              The agent may lack tools needed for this task. \
              Consider reassigning or upgrading the preset."
             task_id required preset)
+
+let handle_claim ctx args =
+  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
+    result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
+  else
+  let task_id = get_string args "task_id" "" in
+  match validate_task_id task_id with
+  | Error e -> result_to_response (Error e)
+  | Ok task_id ->
+  let agent_role = match get_string args "agent_role" "" with
+    | "" -> Types_core.Unassigned
+    | s -> Types_core.role_of_string s
+  in
+  let preset_warning = check_preset_mismatch ctx.config ~agent_name:ctx.agent_name ~task_id in
+  let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
+  (match result with
+   | Ok _ ->
+       Planning_eio.set_current_task ctx.config ~task_id;
+       (match preset_warning with
+        | Some warning ->
+            Log.Task.warn "%s (agent=%s)" warning ctx.agent_name
+        | None -> ());
+       Subscriptions.push_event_to_sessions (`Assoc [
+         ("type", `String "masc/task_claimed");
+         ("task_id", `String task_id);
+         ("agent_name", `String ctx.agent_name);
+         ("timestamp", `Float (Time_compat.now ()));
+       ])
+   | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
+  let (ok, msg) = result_to_response result in
+  match preset_warning, ok with
+  | Some warning, true -> (true, msg ^ "\n⚠️ " ^ warning)
+  | _ -> (ok, msg)
 
 (** Build a task_filter closure that checks required_preset against the agent's preset. *)
 let preset_task_filter ~agent_preset (task : Types.task) =


### PR DESCRIPTION
## Summary

`handle_claim` (수동 task claim)에 preset mismatch 검증 추가.

**문제**: `handle_claim_next`는 `preset_task_filter`로 preset 적합성을 검증하지만, `handle_claim`(task_id 직접 지정)은 검증 없이 claim 성공. research preset keeper에게 coding task를 배정하면 tool 부족으로 stall.

**수정**: claim 성공 후 preset mismatch 경고를 응답에 포함. blocking하지 않음 — 수동 claim은 의도적일 수 있으므로 경고만.

## Design

- `check_preset_mismatch`: `resolve_agent_preset` + task의 `required_preset` 비교
- mismatch 시: `Log.Task.warn` + 응답 메시지에 `⚠️ preset_mismatch: ...` 추가
- 기존 `preset_can_satisfy` 로직 재사용 (tool_policy.toml의 preset hierarchy)

## Test plan

- [x] `dune build` 통과
- [ ] preset mismatch task claim 시 경고 메시지 확인
- [ ] 정상 preset claim 시 기존 동작 유지

Closes #6089

🤖 Generated with [Claude Code](https://claude.com/claude-code)