### PR TITLE
fix(worktree): use config base_path for worktree root, not git rev-parse

### DIFF
--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -30,14 +30,22 @@ let git_root config =
 let is_git_repo config =
   Room_git.is_git_repo ~base_path:config.base_path
 
+(** Resolve the project root from config.base_path.
+    If base_path ends with ".masc", use its parent; otherwise use base_path.
+    This is the SSOT for where .worktrees/ lives — not git rev-parse. *)
+let project_root config =
+  Keeper_alerting_path.project_root_of_config config
+
 let require_repository_root_with_git config =
-  match git_root config with
-  | None -> Error (IoError "Cannot determine git root")
-  | Some root ->
-      let git_marker = Filename.concat root ".git" in
-      if Sys.file_exists git_marker then
-        Ok root
-      else
+  let root = project_root config in
+  let git_marker = Filename.concat root ".git" in
+  if Sys.file_exists git_marker then
+    Ok root
+  else
+    (* Worktree .git is a file, not a directory — also valid *)
+    match (try Some (Sys.is_directory git_marker) with Sys_error _ -> None) with
+    | Some false -> Ok root  (* .git file = git worktree, still valid *)
+    | _ ->
         Error
           (IoError
              (Printf.sprintf

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -32,9 +32,11 @@ let is_git_repo config =
 
 (** Resolve the project root from config.base_path.
     If base_path ends with ".masc", use its parent; otherwise use base_path.
-    This is the SSOT for where .worktrees/ lives — not git rev-parse. *)
+    This is the SSOT for where .worktrees/ lives — not git rev-parse.
+    Inlined from Keeper_alerting_path to avoid room→keeper dependency. *)
 let project_root config =
-  Keeper_alerting_path.project_root_of_config config
+  let base = config.base_path in
+  if Filename.basename base = ".masc" then Filename.dirname base else base
 
 let require_repository_root_with_git config =
   let root = project_root config in

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -22,37 +22,51 @@ let run_argv_exit argv =
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
 
-(** Get git root directory - delegates to Room_git *)
-let git_root config =
-  Room_git.git_root ~base_path:config.base_path
-
 (** Check if directory is a git repository - delegates to Room_git *)
 let is_git_repo config =
   Room_git.is_git_repo ~base_path:config.base_path
 
 (** Resolve the project root from config.base_path.
     If base_path ends with ".masc", use its parent; otherwise use base_path.
-    This is the SSOT for where .worktrees/ lives — not git rev-parse.
+    Then walk parent directories until we find the owning repository root
+    (.git directory). This keeps config.base_path as the anchor while still
+    handling nested subdirectories and worktree roots (.git file).
     Inlined from Keeper_alerting_path to avoid room→keeper dependency. *)
+let git_marker_kind path =
+  match (try Some (Sys.is_directory path) with Sys_error _ -> None) with
+  | Some true -> `Directory
+  | Some false -> `File
+  | None -> `Missing
+
 let project_root config =
   let base = config.base_path in
-  if Filename.basename base = ".masc" then Filename.dirname base else base
+  let candidate =
+    if Filename.basename base = ".masc" then Filename.dirname base else base
+  in
+  let rec find_repo_root dir =
+    let git_marker = Filename.concat dir ".git" in
+    match git_marker_kind git_marker with
+    | `Directory -> Some dir
+    | `File | `Missing ->
+        let parent = Filename.dirname dir in
+        if String.equal parent dir then None else find_repo_root parent
+  in
+  match find_repo_root candidate with
+  | Some root -> root
+  | None -> candidate
 
 let require_repository_root_with_git config =
   let root = project_root config in
   let git_marker = Filename.concat root ".git" in
-  if Sys.file_exists git_marker then
+  match git_marker_kind git_marker with
+  | `Directory | `File ->
     Ok root
-  else
-    (* Worktree .git is a file, not a directory — also valid *)
-    match (try Some (Sys.is_directory git_marker) with Sys_error _ -> None) with
-    | Some false -> Ok root  (* .git file = git worktree, still valid *)
-    | _ ->
-        Error
-          (IoError
-             (Printf.sprintf
-                "Worktree isolation requires repository root with .git: %s (current base path: %s)"
-                root config.base_path))
+  | `Missing ->
+    Error
+      (IoError
+         (Printf.sprintf
+            "Worktree isolation requires repository root with .git: %s (current base path: %s)"
+            root config.base_path))
 
 let ensure_worktree_path root worktree_name =
   let worktrees_dir = Filename.concat root ".worktrees" in

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -341,7 +341,7 @@ let test_same_origin_allows_loopback_alias_same_port () =
   | Ok () -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
-let test_same_origin_rejects_different_explicit_port () =
+let test_same_origin_allows_different_explicit_port_on_loopback () =
   let module Server_auth = Masc_mcp.Server_auth in
   let headers =
     Httpun.Headers.of_list
@@ -352,7 +352,21 @@ let test_same_origin_rejects_different_explicit_port () =
   in
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
-  | Ok () -> fail "expected different-port request to be rejected"
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_same_origin_rejects_different_explicit_port_on_public_host () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "example.com:9000");
+        ("origin", "http://example.com:8935");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+  match Server_auth.ensure_same_origin_browser_request request with
+  | Ok () -> fail "expected different-port public host request to be rejected"
   | Error (Types.Forbidden _) -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
@@ -782,8 +796,10 @@ let () =
         test_same_origin_https_tunnel_same_host;
       test_case "same-origin allows loopback alias same port" `Quick
         test_same_origin_allows_loopback_alias_same_port;
-      test_case "same-origin rejects different explicit port" `Quick
-        test_same_origin_rejects_different_explicit_port;
+      test_case "same-origin allows different explicit port on loopback" `Quick
+        test_same_origin_allows_different_explicit_port_on_loopback;
+      test_case "same-origin rejects different explicit port on public host" `Quick
+        test_same_origin_rejects_different_explicit_port_on_public_host;
       test_case "same-origin allows explicit default port https" `Quick
         test_same_origin_allows_explicit_default_port_https;
       test_case "same-origin allows explicit default port http" `Quick

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -238,6 +238,23 @@ let test_worktree_project_root_for_gitfile_worktree () =
   let _ = Room.reset config in
   rm_rf tmp_dir
 
+let test_worktree_project_root_for_masc_dir_base () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Room.default_config tmp_dir in
+  let _ = Room.init config ~agent_name:(Some "claude") in
+  let repo_root = config.base_path in
+  Unix.mkdir (Filename.concat repo_root ".git") 0o755;
+  let masc_config = { config with base_path = Filename.concat repo_root ".masc" } in
+  Alcotest.(check string) ".masc base path resolves to repo root"
+    repo_root
+    (Room.project_root masc_config);
+  let _ = Room.reset config in
+  rm_rf tmp_dir
+
 let test_event_log () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1664,6 +1681,8 @@ let () =
         test_worktree_project_root_for_nested_subdir;
       Alcotest.test_case "project root worktree gitfile" `Quick
         test_worktree_project_root_for_gitfile_worktree;
+      Alcotest.test_case "project root .masc base path" `Quick
+        test_worktree_project_root_for_masc_dir_base;
     ];
     "portal", [
       Alcotest.test_case "open and status" `Quick test_portal_open_and_status;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -184,6 +184,60 @@ let test_worktree_create_no_git () =
   let _ = Room.reset config in
   Unix.rmdir tmp_dir
 
+let write_file path content =
+  Out_channel.with_open_bin path (fun oc -> output_string oc content)
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let test_worktree_project_root_for_nested_subdir () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Room.default_config tmp_dir in
+  let _ = Room.init config ~agent_name:(Some "claude") in
+  let repo_root = config.base_path in
+  Unix.mkdir (Filename.concat repo_root ".git") 0o755;
+  let nested = Filename.concat repo_root "nested" in
+  Unix.mkdir nested 0o755;
+  let nested_config = { config with base_path = nested } in
+  Alcotest.(check string) "nested path resolves to repo root"
+    repo_root
+    (Room.project_root nested_config);
+  let _ = Room.reset config in
+  rm_rf tmp_dir
+
+let test_worktree_project_root_for_gitfile_worktree () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Room.default_config tmp_dir in
+  let _ = Room.init config ~agent_name:(Some "claude") in
+  let repo_root = config.base_path in
+  Unix.mkdir (Filename.concat repo_root ".git") 0o755;
+  let worktrees_dir = Filename.concat repo_root ".worktrees" in
+  Unix.mkdir worktrees_dir 0o755;
+  let worktree_root = Filename.concat worktrees_dir "agent-task" in
+  Unix.mkdir worktree_root 0o755;
+  write_file (Filename.concat worktree_root ".git")
+    "gitdir: /tmp/fake-common-dir/worktrees/agent-task\n";
+  let worktree_config = { config with base_path = worktree_root } in
+  Alcotest.(check string) "worktree path resolves to shared repo root"
+    repo_root
+    (Room.project_root worktree_config);
+  let _ = Room.reset config in
+  rm_rf tmp_dir
+
 let test_event_log () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1606,6 +1660,10 @@ let () =
     "worktree", [
       Alcotest.test_case "list no git" `Quick test_worktree_list_no_git;
       Alcotest.test_case "create no git" `Quick test_worktree_create_no_git;
+      Alcotest.test_case "project root nested subdir" `Quick
+        test_worktree_project_root_for_nested_subdir;
+      Alcotest.test_case "project root worktree gitfile" `Quick
+        test_worktree_project_root_for_gitfile_worktree;
     ];
     "portal", [
       Alcotest.test_case "open and status" `Quick test_portal_open_and_status;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -238,6 +238,31 @@ let test_worktree_project_root_for_gitfile_worktree () =
   let _ = Room.reset config in
   rm_rf tmp_dir
 
+let test_worktree_project_root_for_nested_gitfile_worktree_subdir () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Room.default_config tmp_dir in
+  let _ = Room.init config ~agent_name:(Some "claude") in
+  let repo_root = config.base_path in
+  Unix.mkdir (Filename.concat repo_root ".git") 0o755;
+  let worktrees_dir = Filename.concat repo_root ".worktrees" in
+  Unix.mkdir worktrees_dir 0o755;
+  let worktree_root = Filename.concat worktrees_dir "agent-task" in
+  Unix.mkdir worktree_root 0o755;
+  write_file (Filename.concat worktree_root ".git")
+    "gitdir: /tmp/fake-common-dir/worktrees/agent-task\n";
+  let nested = Filename.concat worktree_root "nested" in
+  Unix.mkdir nested 0o755;
+  let nested_config = { config with base_path = nested } in
+  Alcotest.(check string) "nested worktree path resolves to shared repo root"
+    repo_root
+    (Room.project_root nested_config);
+  let _ = Room.reset config in
+  rm_rf tmp_dir
+
 let test_worktree_project_root_for_masc_dir_base () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -1681,6 +1706,8 @@ let () =
         test_worktree_project_root_for_nested_subdir;
       Alcotest.test_case "project root worktree gitfile" `Quick
         test_worktree_project_root_for_gitfile_worktree;
+      Alcotest.test_case "project root nested worktree gitfile subdir" `Quick
+        test_worktree_project_root_for_nested_gitfile_worktree_subdir;
       Alcotest.test_case "project root .masc base path" `Quick
         test_worktree_project_root_for_masc_dir_base;
     ];


### PR DESCRIPTION
## Summary
- resolve worktree project root from `config.base_path` instead of `git rev-parse --show-toplevel`
- keep repo-root detection stable for nested subdirectories, `.masc` base paths, and repo-local worktree roots with a `.git` file marker
- align `test_auth_coverage` with the already-merged loopback same-origin behavior so this PR no longer inherits a pre-existing red test drift

## Product impact
- `masc_worktree_create` now writes under the intended repo-local `.worktrees/` path even when the server itself runs from a worktree
- avoids accumulating agent worktrees under nested worktree roots
- preserves stricter same-origin rejection for public hosts while matching current loopback behavior

## Evidence
- `scripts/check-version-truth.sh`
- `bash scripts/check-doc-truth.sh`
- `dune build --root .`
- `./_build/default/test/test_room.exe --compact --color=never`
- `./_build/default/test/test_tool_surface_ssot.exe test ssot_validation 0 -v`
- `./_build/default/test/test_dashboard_namespace_truth.exe --compact --color=never`
- `./_build/default/test/test_auth_coverage.exe --compact --color=never`

## Review evidence
- direct `sb glm-text` (`GLM_TEXT_MODELS=glm-5-turbo`, no-thinking) on the latest diff at 2026-04-11T06:01Z
- outcome: no blocking findings; one theoretical note about parsing arbitrary worktree `gitdir:` targets was triaged as out of scope because MASC worktrees are constrained to `<repo>/.worktrees/<name>`

## Linked issue
- Closes #6448
- Refs #6459