### PR TITLE
[codex] default iMessage replies to self-chat

### DIFF
--- a/dashboard/src/api/gate.ts
+++ b/dashboard/src/api/gate.ts
@@ -126,6 +126,8 @@ export interface ConnectorRuntimeSummary {
   status: string
   error: string
   updated_at: string
+  reply_mode: string
+  self_chat_guid: string
   last_ready_at: string
   bot_user_name: string
   bot_user_id: string
@@ -157,6 +159,8 @@ export interface GateConnectorInfo {
   binding_store_path: string
   audit_path: string
   updated_at: string
+  reply_mode: string
+  self_chat_guid: string
   last_ready_at: string
   bot_user_name: string
   bot_user_id: string
@@ -361,6 +365,8 @@ function decodeRuntimeSummary(raw: unknown): ConnectorRuntimeSummary {
     status: asString(record.status, ''),
     error: asString(record.error, ''),
     updated_at: asString(record.updated_at, ''),
+    reply_mode: asString(record.reply_mode, ''),
+    self_chat_guid: asString(record.self_chat_guid, ''),
     last_ready_at: asString(record.last_ready_at, ''),
     bot_user_name: asString(record.bot_user_name, ''),
     bot_user_id: asString(record.bot_user_id, ''),
@@ -410,6 +416,8 @@ function decodeGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
     binding_store_path: asString(raw.binding_store_path, ''),
     audit_path: asString(raw.audit_path, ''),
     updated_at: asString(raw.updated_at, ''),
+    reply_mode: asString(raw.reply_mode, ''),
+    self_chat_guid: asString(raw.self_chat_guid, ''),
     last_ready_at: asString(raw.last_ready_at, ''),
     bot_user_name: asString(raw.bot_user_name, ''),
     bot_user_id: asString(raw.bot_user_id, ''),

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -101,6 +101,8 @@ function sampleConnectorsResponse(overrides?: Partial<Record<string, unknown>>) 
         binding_store_path: '/tmp/discord_bindings.json',
         audit_path: '/tmp/discord_binding_audit.jsonl',
         updated_at: '2026-04-03T00:00:00Z',
+        reply_mode: '',
+        self_chat_guid: '',
         last_ready_at: '2026-04-03T00:00:00Z',
         bot_user_name: 'sangsu',
         bot_user_id: '1489985300729172039',
@@ -306,6 +308,35 @@ describe('ConnectorStatusPanel', () => {
 
     expect(text).toContain('connected')
     expect(text).not.toContain('disconnected')
+  })
+
+  it('renders iMessage reply mode metadata when advertised by the runtime', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        connector_id: 'imessage',
+        display_name: 'iMessage',
+        channel: 'imessage',
+        reply_mode: 'self-chat',
+        self_chat_guid: 'self-chat-guid',
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+
+    expect(text).toContain('reply self-chat')
+    expect(text).toContain('self-chat self-chat-guid')
   })
 
   it('posts bind and unbind actions through the dashboard endpoints', async () => {

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -335,6 +335,8 @@ function ConnectorLivePanel({
             <span>ready ${timeAgo(connector?.last_ready_at ?? '')}</span>
             <span>guilds ${connector?.guild_count ?? 0}</span>
             <span>runtime bindings ${connector?.runtime_bindings_count ?? configuredBindings.length}</span>
+            ${connector?.reply_mode ? html`<span>reply ${connector.reply_mode}</span>` : null}
+            ${connector?.self_chat_guid ? html`<span>self-chat ${truncateMiddle(connector.self_chat_guid, 28)}</span>` : null}
             <span>source ${connector?.binding_source || 'unknown'}</span>
             <span>keeper dir ${keepers.length}</span>
             <span>

--- a/lib/channel_gate_imessage_state.ml
+++ b/lib/channel_gate_imessage_state.ml
@@ -244,6 +244,8 @@ let status_json ?(audit_limit = 10) () =
       ("binding_store_path", `String binding_store_path);
       ("audit_path", `String audit_path);
       ("updated_at", `String updated_at);
+      ("reply_mode", `String (status_field "reply_mode" string_member ""));
+      ("self_chat_guid", `String (status_field "self_chat_guid" string_member ""));
       ("last_message_at", `String (status_field "last_message_at" string_member ""));
       ("messages_processed", `Int (status_field "messages_processed" int_member 0));
       ("messages_failed", `Int (status_field "messages_failed" int_member 0));
@@ -308,6 +310,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("stale_after_sec", `Int (int_member status "stale_after_sec"));
       ("error", `String (string_member status "error"));
       ("updated_at", `String (string_member status "updated_at"));
+      ("reply_mode", `String (string_member status "reply_mode"));
+      ("self_chat_guid", `String (string_member status "self_chat_guid"));
       ("last_message_at", `String (string_member status "last_message_at"));
       ("messages_processed", `Int (int_member status "messages_processed"));
       ("messages_failed", `Int (int_member status "messages_failed"));

--- a/lib/channel_gate_imessage_state.ml
+++ b/lib/channel_gate_imessage_state.ml
@@ -32,6 +32,17 @@ let resolve_path raw_path =
   else
     raw_path
 
+let redact_chat_guid raw =
+  let value = String.trim raw in
+  if value = "" then ""
+  else
+    match List.rev (String.split_on_char ';' value) with
+    | [] -> "[redacted]"
+    | _target :: rev_prefix -> (
+        match List.rev rev_prefix with
+        | [] -> "[redacted]"
+        | prefix -> String.concat ";" prefix ^ ";[redacted]")
+
 let configured_write_path env_name ~default =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
   | Some raw -> resolve_path raw
@@ -245,7 +256,9 @@ let status_json ?(audit_limit = 10) () =
       ("audit_path", `String audit_path);
       ("updated_at", `String updated_at);
       ("reply_mode", `String (status_field "reply_mode" string_member ""));
-      ("self_chat_guid", `String (status_field "self_chat_guid" string_member ""));
+      ( "self_chat_guid",
+        `String
+          (redact_chat_guid (status_field "self_chat_guid" string_member "")) );
       ("last_message_at", `String (status_field "last_message_at" string_member ""));
       ("messages_processed", `Int (status_field "messages_processed" int_member 0));
       ("messages_failed", `Int (status_field "messages_failed" int_member 0));

--- a/lib/channel_gate_imessage_state.ml
+++ b/lib/channel_gate_imessage_state.ml
@@ -37,11 +37,9 @@ let redact_chat_guid raw =
   if value = "" then ""
   else
     match List.rev (String.split_on_char ';' value) with
-    | [] -> "[redacted]"
-    | _target :: rev_prefix -> (
-        match List.rev rev_prefix with
-        | [] -> "[redacted]"
-        | prefix -> String.concat ";" prefix ^ ";[redacted]")
+    | _target :: rev_prefix when rev_prefix <> [] ->
+        String.concat ";" (List.rev rev_prefix) ^ ";[redacted]"
+    | _ -> "[redacted]"
 
 let configured_write_path env_name ~default =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -18,7 +18,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from .config import get_config
 from .gate_client import GateClient
-from .imessage_bridge import InboundMessage, advance_cursor, read_new_messages, send_message
+from .imessage_bridge import (
+    InboundMessage,
+    advance_cursor,
+    read_new_messages,
+    resolve_self_chat_guid,
+    send_message,
+)
 from .status_store import ConnectorRuntimeStatus, StatusStore
 
 logging.basicConfig(
@@ -45,6 +51,12 @@ class IMessageBot:
         self._last_message_at = ""
         self._bindings: dict[str, str] = {}  # chat_id -> keeper_name
         self._last_cursor_rowid: int = 0
+        self._self_chat_guid = ""
+        if self.cfg.reply_mode == "self-chat":
+            self._self_chat_guid = resolve_self_chat_guid(
+                self.cfg.chat_db_path,
+                self.cfg.self_chat_guid,
+            )
 
     def _load_bindings(self) -> None:
         """Load chat-to-keeper bindings from state file."""
@@ -75,6 +87,18 @@ class IMessageBot:
             return keeper
         return DEFAULT_KEEPER
 
+    def _resolve_reply_chat_guid(self, msg: InboundMessage) -> str:
+        """Resolve the outbound chat guid according to configured reply mode."""
+        if self.cfg.reply_mode == "source-chat":
+            return msg.chat_guid
+        if self._self_chat_guid:
+            return self._self_chat_guid
+        self._self_chat_guid = resolve_self_chat_guid(
+            self.cfg.chat_db_path,
+            self.cfg.self_chat_guid,
+        )
+        return self._self_chat_guid
+
     async def _handle_message(self, msg: InboundMessage) -> bool:
         """Process one inbound message: gate dispatch + reply.
 
@@ -98,23 +122,26 @@ class IMessageBot:
         )
 
         if response.ok and response.reply:
-            if not msg.chat_guid:
+            target_chat_guid = self._resolve_reply_chat_guid(msg)
+            if not target_chat_guid:
                 logger.error(
-                    "Refusing to send reply to %s: missing chat guid for chat=%s",
+                    "Refusing to send reply to %s: missing target chat guid (mode=%s, source_chat=%s)",
                     msg.sender,
-                    msg.chat_identifier or "unknown",
+                    self.cfg.reply_mode,
+                    msg.chat_identifier or msg.chat_guid or "unknown",
                 )
                 self._messages_failed += 1
                 return False
             sent = send_message(
                 text=response.reply,
-                chat_guid=msg.chat_guid,
+                chat_guid=target_chat_guid,
             )
             if sent:
                 logger.info(
-                    "Replied to %s (chat=%s, %d chars, keeper=%s, model=%s, %dms)",
+                    "Replied to %s (source_chat=%s, target_chat=%s, %d chars, keeper=%s, model=%s, %dms)",
                     msg.sender,
                     msg.chat_identifier or msg.chat_guid or "unknown",
+                    target_chat_guid,
                     len(response.reply),
                     response.keeper_name,
                     response.model_used,
@@ -122,9 +149,10 @@ class IMessageBot:
                 )
             else:
                 logger.error(
-                    "Failed to send reply to %s (chat=%s) via AppleScript",
+                    "Failed to send reply to %s (source_chat=%s, target_chat=%s) via AppleScript",
                     msg.sender,
                     msg.chat_identifier or msg.chat_guid or "unknown",
+                    target_chat_guid,
                 )
         elif response.error and response.error != "duplicate message":
             logger.warning("Gate error for %s: %s", msg.sender, response.error)
@@ -198,10 +226,11 @@ class IMessageBot:
         self._load_bindings()
 
         logger.info(
-            "iMessage bot starting (poll=%.1fs, gate=%s, default_keeper=%s)",
+            "iMessage bot starting (poll=%.1fs, gate=%s, default_keeper=%s, reply_mode=%s)",
             self.cfg.poll_interval_sec,
             self.cfg.gate_base_url,
             DEFAULT_KEEPER,
+            self.cfg.reply_mode,
         )
 
         # Initial health check

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -17,7 +17,7 @@ import signal
 from datetime import datetime, timezone
 from pathlib import Path
 from .config import get_config
-from .gate_client import GateClient, GateResponse
+from .gate_client import GateClient
 from .imessage_bridge import InboundMessage, advance_cursor, read_new_messages, send_message
 from .status_store import ConnectorRuntimeStatus, StatusStore
 
@@ -98,18 +98,34 @@ class IMessageBot:
         )
 
         if response.ok and response.reply:
-            sent = send_message(msg.sender, response.reply)
+            if not msg.chat_guid:
+                logger.error(
+                    "Refusing to send reply to %s: missing chat guid for chat=%s",
+                    msg.sender,
+                    msg.chat_identifier or "unknown",
+                )
+                self._messages_failed += 1
+                return False
+            sent = send_message(
+                text=response.reply,
+                chat_guid=msg.chat_guid,
+            )
             if sent:
                 logger.info(
-                    "Replied to %s (%d chars, keeper=%s, model=%s, %dms)",
+                    "Replied to %s (chat=%s, %d chars, keeper=%s, model=%s, %dms)",
                     msg.sender,
+                    msg.chat_identifier or msg.chat_guid or "unknown",
                     len(response.reply),
                     response.keeper_name,
                     response.model_used,
                     response.duration_ms,
                 )
             else:
-                logger.error("Failed to send reply to %s via AppleScript", msg.sender)
+                logger.error(
+                    "Failed to send reply to %s (chat=%s) via AppleScript",
+                    msg.sender,
+                    msg.chat_identifier or msg.chat_guid or "unknown",
+                )
         elif response.error and response.error != "duplicate message":
             logger.warning("Gate error for %s: %s", msg.sender, response.error)
 

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -210,6 +210,8 @@ class IMessageBot:
                 gate_base_url=self.cfg.gate_base_url,
                 gate_healthy=gate_healthy,
                 gate_health_checked_at=gate_health_checked_at,
+                reply_mode=self.cfg.reply_mode,
+                self_chat_guid=self._self_chat_guid,
                 last_message_at=self._last_message_at,
                 messages_processed=self._messages_processed,
                 messages_failed=self._messages_failed,

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -156,6 +156,7 @@ class IMessageBot:
                     msg.chat_identifier or msg.chat_guid or "unknown",
                     target_chat_guid,
                 )
+                self._messages_failed += 1
         elif response.error and response.error != "duplicate message":
             logger.warning("Gate error for %s: %s", msg.sender, response.error)
 

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -131,7 +131,9 @@ class IMessageBot:
                     msg.chat_identifier or msg.chat_guid or "unknown",
                 )
                 self._messages_failed += 1
-                return False
+                self._messages_processed += 1
+                self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
+                return True
             sent = send_message(
                 text=response.reply,
                 chat_guid=target_chat_guid,

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import signal
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from .config import get_config
@@ -21,6 +22,7 @@ from .gate_client import GateClient
 from .imessage_bridge import (
     InboundMessage,
     advance_cursor,
+    redact_chat_guid,
     read_new_messages,
     resolve_self_chat_guid,
     send_message,
@@ -52,11 +54,9 @@ class IMessageBot:
         self._bindings: dict[str, str] = {}  # chat_id -> keeper_name
         self._last_cursor_rowid: int = 0
         self._self_chat_guid = ""
+        self._self_chat_guid_retry_after = 0.0
         if self.cfg.reply_mode == "self-chat":
-            self._self_chat_guid = resolve_self_chat_guid(
-                self.cfg.chat_db_path,
-                self.cfg.self_chat_guid,
-            )
+            self._refresh_self_chat_guid(force=True)
 
     def _load_bindings(self) -> None:
         """Load chat-to-keeper bindings from state file."""
@@ -93,11 +93,26 @@ class IMessageBot:
             return msg.chat_guid
         if self._self_chat_guid:
             return self._self_chat_guid
+        return self._refresh_self_chat_guid()
+
+    def _refresh_self_chat_guid(self, *, force: bool = False) -> str:
+        if self._self_chat_guid:
+            return self._self_chat_guid
+        now = time.monotonic()
+        if not force and now < self._self_chat_guid_retry_after:
+            return ""
         self._self_chat_guid = resolve_self_chat_guid(
             self.cfg.chat_db_path,
             self.cfg.self_chat_guid,
         )
+        if self._self_chat_guid:
+            self._self_chat_guid_retry_after = 0.0
+        else:
+            self._self_chat_guid_retry_after = now + self.cfg.poll_interval_sec
         return self._self_chat_guid
+
+    def _log_chat_ref(self, msg: InboundMessage) -> str:
+        return redact_chat_guid(msg.chat_guid or msg.chat_identifier)
 
     async def _handle_message(self, msg: InboundMessage) -> bool:
         """Process one inbound message: gate dispatch + reply.
@@ -128,7 +143,7 @@ class IMessageBot:
                     "Refusing to send reply to %s: missing target chat guid (mode=%s, source_chat=%s)",
                     msg.sender,
                     self.cfg.reply_mode,
-                    msg.chat_identifier or msg.chat_guid or "unknown",
+                    self._log_chat_ref(msg) or "unknown",
                 )
                 self._messages_failed += 1
                 self._messages_processed += 1
@@ -142,8 +157,8 @@ class IMessageBot:
                 logger.info(
                     "Replied to %s (source_chat=%s, target_chat=%s, %d chars, keeper=%s, model=%s, %dms)",
                     msg.sender,
-                    msg.chat_identifier or msg.chat_guid or "unknown",
-                    target_chat_guid,
+                    self._log_chat_ref(msg) or "unknown",
+                    redact_chat_guid(target_chat_guid),
                     len(response.reply),
                     response.keeper_name,
                     response.model_used,
@@ -153,8 +168,8 @@ class IMessageBot:
                 logger.error(
                     "Failed to send reply to %s (source_chat=%s, target_chat=%s) via AppleScript",
                     msg.sender,
-                    msg.chat_identifier or msg.chat_guid or "unknown",
-                    target_chat_guid,
+                    self._log_chat_ref(msg) or "unknown",
+                    redact_chat_guid(target_chat_guid),
                 )
                 self._messages_failed += 1
         elif response.error and response.error != "duplicate message":

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -110,6 +110,11 @@ class BotConfig(BaseSettings):
             raise ValueError("reply_mode must be self-chat or source-chat")
         return normalized
 
+    @field_validator("self_chat_guid")
+    @classmethod
+    def validate_self_chat_guid(cls, v: str) -> str:
+        return v.strip()
+
     def gate_message_url(self) -> str:
         return f"{self.gate_base_url}/api/v1/gate/message"
 

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -55,6 +55,16 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("IMESSAGE_POLL_INTERVAL", "poll_interval_sec"),
         description="Seconds between chat.db polls for new messages.",
     )
+    reply_mode: str = Field(
+        default="self-chat",
+        validation_alias=AliasChoices("IMESSAGE_REPLY_MODE", "reply_mode"),
+        description="Outbound reply mode: self-chat or source-chat.",
+    )
+    self_chat_guid: str = Field(
+        default="",
+        validation_alias=AliasChoices("IMESSAGE_SELF_CHAT_GUID", "self_chat_guid"),
+        description="Optional explicit Messages.app chat guid for self-chat mode.",
+    )
 
     # Gate HTTP
     gate_timeout_sec: float = Field(default=30.0)
@@ -91,6 +101,14 @@ class BotConfig(BaseSettings):
         if v < 0.5:
             raise ValueError("poll_interval_sec must be >= 0.5")
         return v
+
+    @field_validator("reply_mode")
+    @classmethod
+    def validate_reply_mode(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in {"self-chat", "source-chat"}:
+            raise ValueError("reply_mode must be self-chat or source-chat")
+        return normalized
 
     def gate_message_url(self) -> str:
         return f"{self.gate_base_url}/api/v1/gate/message"

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -113,11 +113,11 @@ class BotConfig(BaseSettings):
 
     @field_validator("self_chat_guid", mode="before")
     @classmethod
-    def validate_self_chat_guid(cls, v: Any) -> Any:
+    def validate_self_chat_guid(cls, v: Any) -> str:
         if v is None:
             return ""
         if not isinstance(v, str):
-            return v
+            raise ValueError("self_chat_guid must be a string or null")
         return v.strip()
 
     def gate_message_url(self) -> str:

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+from typing import Any
 from typing import Final
 from urllib.parse import urlparse
 
@@ -110,9 +111,13 @@ class BotConfig(BaseSettings):
             raise ValueError("reply_mode must be self-chat or source-chat")
         return normalized
 
-    @field_validator("self_chat_guid")
+    @field_validator("self_chat_guid", mode="before")
     @classmethod
-    def validate_self_chat_guid(cls, v: str) -> str:
+    def validate_self_chat_guid(cls, v: Any) -> Any:
+        if v is None:
+            return ""
+        if not isinstance(v, str):
+            return v
         return v.strip()
 
     def gate_message_url(self) -> str:

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -34,6 +34,7 @@ SELECT DISTINCT
     m.service,
     h.id AS handle_id,
     h.service AS handle_service,
+    c.guid AS chat_guid,
     c.chat_identifier,
     c.display_name
 FROM message m
@@ -59,6 +60,7 @@ class InboundMessage:
     date: datetime
     service: str
     sender: str  # phone number or email
+    chat_guid: str
     chat_identifier: str
     display_name: str
 
@@ -141,6 +143,7 @@ def read_new_messages() -> list[InboundMessage]:
                     date=_apple_date_to_datetime(row["date"]),
                     service=row["service"] or "iMessage",
                     sender=row["handle_id"] or "unknown",
+                    chat_guid=row["chat_guid"] or "",
                     chat_identifier=row["chat_identifier"] or "",
                     display_name=row["display_name"] or "",
                 )
@@ -163,31 +166,37 @@ def read_new_messages() -> list[InboundMessage]:
     return messages
 
 
-def send_message(recipient: str, text: str) -> bool:
+def send_message(*, text: str, chat_guid: str = "") -> bool:
     """Send an iMessage via AppleScript.
 
     Uses ``on run argv`` to pass parameters as native AppleScript text
     objects, eliminating string-literal injection risks entirely.
 
     Args:
-        recipient: Phone number or Apple ID email.
         text: Message body.
+        chat_guid: Exact Messages.app chat identifier. Replies are sent only
+            when this value is available so the connector fails closed.
 
     Returns:
         True if AppleScript executed without error.
     """
+    if not chat_guid:
+        logger.error("AppleScript send aborted: missing chat_guid")
+        return False
+
     script = (
         'on run argv\n'
         '  tell application "Messages"\n'
-        '    set theBuddy to participant (item 1 of argv) of account 1\n'
-        '    send (item 2 of argv) to theBuddy\n'
+        '    set targetChat to first chat whose id is (item 1 of argv)\n'
+        '    send (item 2 of argv) to targetChat\n'
         '  end tell\n'
         'end run'
     )
+    argv = [chat_guid, text]
 
     try:
         result = subprocess.run(
-            ["osascript", "-e", script, recipient, text],
+            ["osascript", "-e", script, *argv],
             capture_output=True,
             text=True,
             timeout=15,
@@ -197,7 +206,7 @@ def send_message(recipient: str, text: str) -> bool:
             return False
         return True
     except subprocess.TimeoutExpired:
-        logger.error("AppleScript send timed out for %s", recipient)
+        logger.error("AppleScript send timed out for chat %s", chat_guid)
         return False
     except Exception as e:
         logger.error("AppleScript send error: %s", e)

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -50,6 +50,40 @@ ORDER BY m.ROWID ASC
 LIMIT 100
 """
 
+SELF_CHAT_GUID_QUERY: Final[str] = """
+WITH own_aliases AS (
+    SELECT DISTINCT
+        trim(
+            CASE
+                WHEN account_login LIKE 'E:%' OR account_login LIKE 'P:%'
+                    THEN substr(account_login, 3)
+                ELSE account_login
+            END
+        ) AS alias
+    FROM chat
+    WHERE service_name = 'iMessage'
+      AND account_login IS NOT NULL
+      AND trim(account_login) != ''
+),
+self_chats AS (
+    SELECT
+        c.guid AS chat_guid,
+        max(coalesce(m.date, 0)) AS last_date,
+        count(m.ROWID) AS msg_count
+    FROM chat c
+    JOIN own_aliases a ON c.chat_identifier = a.alias
+    LEFT JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
+    LEFT JOIN message m ON m.ROWID = cmj.message_id
+    WHERE c.service_name = 'iMessage'
+    GROUP BY c.ROWID
+)
+SELECT chat_guid
+FROM self_chats
+WHERE trim(chat_guid) != ''
+ORDER BY last_date DESC, msg_count DESC
+LIMIT 1
+"""
+
 
 @dataclass(frozen=True, slots=True)
 class InboundMessage:
@@ -164,6 +198,47 @@ def read_new_messages() -> list[InboundMessage]:
         logger.error("Unexpected error reading chat.db: %s", e)
 
     return messages
+
+
+def resolve_self_chat_guid(chat_db_path: str, explicit_chat_guid: str = "") -> str:
+    """Resolve the chat guid to use for self-chat mode.
+
+    Prefers an explicit override. Otherwise auto-detects the most recently
+    active self-chat whose chat identifier matches one of the account aliases
+    visible in Messages metadata.
+    """
+    explicit = explicit_chat_guid.strip()
+    if explicit:
+        return explicit
+
+    db_path = Path(chat_db_path)
+    if not db_path.exists():
+        logger.warning("Cannot resolve self-chat guid: chat.db not found at %s", db_path)
+        return ""
+
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(SELF_CHAT_GUID_QUERY).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.OperationalError as e:
+        logger.warning("Failed to resolve self-chat guid from chat.db: %s", e)
+        return ""
+    except Exception as e:
+        logger.warning("Unexpected error resolving self-chat guid: %s", e)
+        return ""
+
+    if row is None:
+        logger.warning("No self-chat guid candidate found in chat.db")
+        return ""
+
+    chat_guid = str(row["chat_guid"] or "").strip()
+    if chat_guid == "":
+        logger.warning("Resolved self-chat row without a chat guid")
+        return ""
+    return chat_guid
 
 
 def send_message(*, text: str, chat_guid: str = "") -> bool:

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -241,7 +241,7 @@ def resolve_self_chat_guid(chat_db_path: str, explicit_chat_guid: str = "") -> s
     return chat_guid
 
 
-def send_message(*, text: str, chat_guid: str = "") -> bool:
+def send_message(*, text: str, chat_guid: str) -> bool:
     """Send an iMessage via AppleScript.
 
     Uses ``on run argv`` to pass parameters as native AppleScript text

--- a/sidecars/imessage-bot/src/imessage_bridge.py
+++ b/sidecars/imessage-bot/src/imessage_bridge.py
@@ -104,6 +104,17 @@ class InboundMessage:
         return self.chat_identifier or self.sender
 
 
+def redact_chat_guid(raw: str) -> str:
+    """Redact the PII-bearing tail of a Messages chat guid for logs/UI."""
+    value = raw.strip()
+    if value == "":
+        return ""
+    parts = value.split(";")
+    if len(parts) <= 1:
+        return "[redacted]"
+    return ";".join(parts[:-1] + ["[redacted]"])
+
+
 def _apple_date_to_datetime(apple_ns: int) -> datetime:
     """Convert Apple Core Data timestamp (nanoseconds since 2001-01-01) to datetime."""
     seconds = apple_ns / 1_000_000_000
@@ -281,7 +292,7 @@ def send_message(*, text: str, chat_guid: str) -> bool:
             return False
         return True
     except subprocess.TimeoutExpired:
-        logger.error("AppleScript send timed out for chat %s", chat_guid)
+        logger.error("AppleScript send timed out for chat %s", redact_chat_guid(chat_guid))
         return False
     except Exception as e:
         logger.error("AppleScript send error: %s", e)

--- a/sidecars/imessage-bot/src/status_store.py
+++ b/sidecars/imessage-bot/src/status_store.py
@@ -15,6 +15,8 @@ class ConnectorRuntimeStatus:
     gate_base_url: str
     gate_healthy: bool | None
     gate_health_checked_at: str
+    reply_mode: str
+    self_chat_guid: str
     last_message_at: str
     messages_processed: int
     messages_failed: int

--- a/sidecars/imessage-bot/src/status_store.py
+++ b/sidecars/imessage-bot/src/status_store.py
@@ -15,8 +15,6 @@ class ConnectorRuntimeStatus:
     gate_base_url: str
     gate_healthy: bool | None
     gate_health_checked_at: str
-    reply_mode: str
-    self_chat_guid: str
     last_message_at: str
     messages_processed: int
     messages_failed: int
@@ -24,6 +22,8 @@ class ConnectorRuntimeStatus:
     chat_db_path: str
     poll_interval_sec: float
     pid: int
+    reply_mode: str = ""
+    self_chat_guid: str = ""
 
 
 class StatusStore:

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -163,3 +163,50 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(ok)
         resolve_self_chat_guid_mock.assert_not_called()
         send_message_mock.assert_not_called()
+
+    @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.resolve_self_chat_guid", return_value="")
+    @patch("src.bot.GateClient")
+    @patch("src.bot.get_config")
+    async def test_handle_message_replies_to_source_chat_guid_in_source_chat_mode(
+        self,
+        get_config_mock,
+        gate_client_cls,
+        resolve_self_chat_guid_mock,
+        send_message_mock,
+    ) -> None:
+        get_config_mock.return_value = self._config(reply_mode="source-chat")
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="reply text",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured=None,
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=9,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15550001111",
+            chat_guid="source-guid",
+            chat_identifier="chat789",
+            display_name="Test",
+        )
+
+        ok = await bot._handle_message(msg)
+
+        self.assertTrue(ok)
+        resolve_self_chat_guid_mock.assert_not_called()
+        send_message_mock.assert_called_once_with(
+            text="reply text",
+            chat_guid="source-guid",
+        )

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -117,7 +117,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         ok = await bot._handle_message(msg)
 
         self.assertTrue(ok)
-        self.assertEqual(resolve_self_chat_guid_mock.call_count, 2)
+        self.assertEqual(resolve_self_chat_guid_mock.call_count, 1)
         send_message_mock.assert_not_called()
         self.assertEqual(bot._messages_processed, 1)
         self.assertEqual(bot._messages_failed, 1)
@@ -167,6 +167,54 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         send_message_mock.assert_not_called()
         self.assertEqual(bot._messages_processed, 1)
         self.assertEqual(bot._messages_failed, 1)
+
+    @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.resolve_self_chat_guid", return_value="")
+    @patch("src.bot.GateClient")
+    @patch("src.bot.get_config")
+    async def test_handle_message_throttles_self_chat_guid_retries_after_failure(
+        self,
+        get_config_mock,
+        gate_client_cls,
+        resolve_self_chat_guid_mock,
+        send_message_mock,
+    ) -> None:
+        get_config_mock.return_value = self._config()
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="reply text",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured=None,
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=11,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15550003333",
+            chat_guid="source-guid",
+            chat_identifier="chat901",
+            display_name="Test",
+        )
+
+        first_ok = await bot._handle_message(msg)
+        second_ok = await bot._handle_message(msg)
+
+        self.assertTrue(first_ok)
+        self.assertTrue(second_ok)
+        self.assertEqual(resolve_self_chat_guid_mock.call_count, 1)
+        send_message_mock.assert_not_called()
+        self.assertEqual(bot._messages_processed, 2)
+        self.assertEqual(bot._messages_failed, 2)
 
     @patch("src.bot.send_message", return_value=True)
     @patch("src.bot.resolve_self_chat_guid", return_value="")

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -214,3 +214,52 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
             text="reply text",
             chat_guid="source-guid",
         )
+
+    @patch("src.bot.send_message", return_value=False)
+    @patch("src.bot.resolve_self_chat_guid", return_value="self-guid")
+    @patch("src.bot.GateClient")
+    @patch("src.bot.get_config")
+    async def test_handle_message_counts_reply_send_failure_without_retrying_gate(
+        self,
+        get_config_mock,
+        gate_client_cls,
+        resolve_self_chat_guid_mock,
+        send_message_mock,
+    ) -> None:
+        get_config_mock.return_value = self._config()
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="reply text",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured=None,
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=10,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15550002222",
+            chat_guid="source-guid",
+            chat_identifier="chat900",
+            display_name="Test",
+        )
+
+        ok = await bot._handle_message(msg)
+
+        self.assertTrue(ok)
+        resolve_self_chat_guid_mock.assert_called_once_with("/tmp/chat.db", "")
+        send_message_mock.assert_called_once_with(
+            text="reply text",
+            chat_guid="self-guid",
+        )
+        self.assertEqual(bot._messages_processed, 1)
+        self.assertEqual(bot._messages_failed, 1)

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -80,7 +80,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
     @patch("src.bot.resolve_self_chat_guid", return_value="")
     @patch("src.bot.GateClient")
     @patch("src.bot.get_config")
-    async def test_handle_message_fails_closed_without_self_chat_guid(
+    async def test_handle_message_skips_reply_without_self_chat_guid(
         self,
         get_config_mock,
         gate_client_cls,
@@ -116,15 +116,17 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
 
         ok = await bot._handle_message(msg)
 
-        self.assertFalse(ok)
+        self.assertTrue(ok)
         self.assertEqual(resolve_self_chat_guid_mock.call_count, 2)
         send_message_mock.assert_not_called()
+        self.assertEqual(bot._messages_processed, 1)
+        self.assertEqual(bot._messages_failed, 1)
 
     @patch("src.bot.send_message", return_value=True)
     @patch("src.bot.resolve_self_chat_guid", return_value="")
     @patch("src.bot.GateClient")
     @patch("src.bot.get_config")
-    async def test_handle_message_fails_closed_without_chat_guid(
+    async def test_handle_message_skips_reply_without_source_chat_guid(
         self,
         get_config_mock,
         gate_client_cls,
@@ -160,9 +162,11 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
 
         ok = await bot._handle_message(msg)
 
-        self.assertFalse(ok)
+        self.assertTrue(ok)
         resolve_self_chat_guid_mock.assert_not_called()
         send_message_mock.assert_not_called()
+        self.assertEqual(bot._messages_processed, 1)
+        self.assertEqual(bot._messages_failed, 1)
 
     @patch("src.bot.send_message", return_value=True)
     @patch("src.bot.resolve_self_chat_guid", return_value="")

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -216,7 +216,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch("src.bot.send_message", return_value=False)
-    @patch("src.bot.resolve_self_chat_guid", return_value="self-guid")
+    @patch("src.bot.resolve_self_chat_guid", return_value="source-guid")
     @patch("src.bot.GateClient")
     @patch("src.bot.get_config")
     async def test_handle_message_counts_reply_send_failure_without_retrying_gate(
@@ -259,7 +259,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         resolve_self_chat_guid_mock.assert_called_once_with("/tmp/chat.db", "")
         send_message_mock.assert_called_once_with(
             text="reply text",
-            chat_guid="self-guid",
+            chat_guid="source-guid",
         )
         self.assertEqual(bot._messages_processed, 1)
         self.assertEqual(bot._messages_failed, 1)

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -216,7 +216,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch("src.bot.send_message", return_value=False)
-    @patch("src.bot.resolve_self_chat_guid", return_value="source-guid")
+    @patch("src.bot.resolve_self_chat_guid", return_value="self-guid")
     @patch("src.bot.GateClient")
     @patch("src.bot.get_config")
     async def test_handle_message_counts_reply_send_failure_without_retrying_gate(
@@ -259,7 +259,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         resolve_self_chat_guid_mock.assert_called_once_with("/tmp/chat.db", "")
         send_message_mock.assert_called_once_with(
             text="reply text",
-            chat_guid="source-guid",
+            chat_guid="self-guid",
         )
         self.assertEqual(bot._messages_processed, 1)
         self.assertEqual(bot._messages_failed, 1)

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from src.bot import DEFAULT_KEEPER, IMessageBot
+from src.gate_client import GateResponse
+from src.imessage_bridge import InboundMessage
+
+
+class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
+    @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.GateClient")
+    async def test_handle_message_replies_to_chat_guid(
+        self,
+        gate_client_cls,
+        send_message_mock,
+    ) -> None:
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="reply text",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured=None,
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=7,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15551234567",
+            chat_guid="iMessage;-;+15551234567",
+            chat_identifier="chat123",
+            display_name="Test",
+        )
+
+        ok = await bot._handle_message(msg)
+
+        self.assertTrue(ok)
+        gate_client.send_message.assert_awaited_once_with(
+            keeper_name=DEFAULT_KEEPER,
+            content="hello",
+            sender="+15551234567",
+            chat_id="chat123",
+            message_rowid=7,
+        )
+        send_message_mock.assert_called_once_with(
+            text="reply text",
+            chat_guid="iMessage;-;+15551234567",
+        )
+
+    @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.GateClient")
+    async def test_handle_message_fails_closed_without_chat_guid(
+        self,
+        gate_client_cls,
+        send_message_mock,
+    ) -> None:
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="reply text",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured=None,
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=8,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15557654321",
+            chat_guid="",
+            chat_identifier="chat456",
+            display_name="Test",
+        )
+
+        ok = await bot._handle_message(msg)
+
+        self.assertFalse(ok)
+        send_message_mock.assert_not_called()

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 import unittest
 from unittest.mock import AsyncMock, patch
 
@@ -10,13 +11,29 @@ from src.imessage_bridge import InboundMessage
 
 
 class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
+    def _config(self, *, reply_mode: str = "self-chat", self_chat_guid: str = ""):
+        return SimpleNamespace(
+            status_path="/tmp/imessage-status.json",
+            binding_store_path="/tmp/imessage-bindings.json",
+            chat_db_path="/tmp/chat.db",
+            poll_interval_sec=2.0,
+            gate_base_url="http://127.0.0.1:8935",
+            reply_mode=reply_mode,
+            self_chat_guid=self_chat_guid,
+        )
+
     @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.resolve_self_chat_guid", return_value="self-guid")
     @patch("src.bot.GateClient")
+    @patch("src.bot.get_config")
     async def test_handle_message_replies_to_chat_guid(
         self,
+        get_config_mock,
         gate_client_cls,
+        resolve_self_chat_guid_mock,
         send_message_mock,
     ) -> None:
+        get_config_mock.return_value = self._config()
         gate_client = gate_client_cls.return_value
         gate_client.send_message = AsyncMock(
             return_value=GateResponse(
@@ -38,7 +55,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
             date=datetime.now(tz=timezone.utc),
             service="iMessage",
             sender="+15551234567",
-            chat_guid="iMessage;-;+15551234567",
+            chat_guid="source-guid",
             chat_identifier="chat123",
             display_name="Test",
         )
@@ -46,6 +63,7 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         ok = await bot._handle_message(msg)
 
         self.assertTrue(ok)
+        resolve_self_chat_guid_mock.assert_called_once_with("/tmp/chat.db", "")
         gate_client.send_message.assert_awaited_once_with(
             keeper_name=DEFAULT_KEEPER,
             content="hello",
@@ -55,16 +73,65 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         )
         send_message_mock.assert_called_once_with(
             text="reply text",
-            chat_guid="iMessage;-;+15551234567",
+            chat_guid="self-guid",
         )
 
     @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.resolve_self_chat_guid", return_value="")
     @patch("src.bot.GateClient")
-    async def test_handle_message_fails_closed_without_chat_guid(
+    @patch("src.bot.get_config")
+    async def test_handle_message_fails_closed_without_self_chat_guid(
         self,
+        get_config_mock,
         gate_client_cls,
+        resolve_self_chat_guid_mock,
         send_message_mock,
     ) -> None:
+        get_config_mock.return_value = self._config()
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="reply text",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured=None,
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=7,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15557654321",
+            chat_guid="source-guid",
+            chat_identifier="chat456",
+            display_name="Test",
+        )
+
+        ok = await bot._handle_message(msg)
+
+        self.assertFalse(ok)
+        self.assertEqual(resolve_self_chat_guid_mock.call_count, 2)
+        send_message_mock.assert_not_called()
+
+    @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.resolve_self_chat_guid", return_value="")
+    @patch("src.bot.GateClient")
+    @patch("src.bot.get_config")
+    async def test_handle_message_fails_closed_without_chat_guid(
+        self,
+        get_config_mock,
+        gate_client_cls,
+        resolve_self_chat_guid_mock,
+        send_message_mock,
+    ) -> None:
+        get_config_mock.return_value = self._config(reply_mode="source-chat")
         gate_client = gate_client_cls.return_value
         gate_client.send_message = AsyncMock(
             return_value=GateResponse(
@@ -94,4 +161,5 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         ok = await bot._handle_message(msg)
 
         self.assertFalse(ok)
+        resolve_self_chat_guid_mock.assert_not_called()
         send_message_mock.assert_not_called()

--- a/sidecars/imessage-bot/tests/test_config.py
+++ b/sidecars/imessage-bot/tests/test_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from src.config import BotConfig
+
+
+class BotConfigTests(unittest.TestCase):
+    def test_reply_mode_is_normalized(self) -> None:
+        cfg = BotConfig(reply_mode=" SOURCE-CHAT ")
+
+        self.assertEqual(cfg.reply_mode, "source-chat")
+
+    def test_reply_mode_rejects_invalid_values(self) -> None:
+        with self.assertRaises(ValidationError):
+            BotConfig(reply_mode="everyone")
+
+    def test_self_chat_guid_is_trimmed(self) -> None:
+        cfg = BotConfig(self_chat_guid=" any;-;forsyphilis@gmail.com  ")
+
+        self.assertEqual(cfg.self_chat_guid, "any;-;forsyphilis@gmail.com")

--- a/sidecars/imessage-bot/tests/test_config.py
+++ b/sidecars/imessage-bot/tests/test_config.py
@@ -21,3 +21,13 @@ class BotConfigTests(unittest.TestCase):
         cfg = BotConfig(self_chat_guid=" any;-;forsyphilis@gmail.com  ")
 
         self.assertEqual(cfg.self_chat_guid, "any;-;forsyphilis@gmail.com")
+
+    def test_self_chat_guid_whitespace_normalizes_to_empty_string(self) -> None:
+        cfg = BotConfig(self_chat_guid="   ")
+
+        self.assertEqual(cfg.self_chat_guid, "")
+
+    def test_self_chat_guid_none_normalizes_to_empty_string(self) -> None:
+        cfg = BotConfig(self_chat_guid=None)
+
+        self.assertEqual(cfg.self_chat_guid, "")

--- a/sidecars/imessage-bot/tests/test_config.py
+++ b/sidecars/imessage-bot/tests/test_config.py
@@ -18,9 +18,9 @@ class BotConfigTests(unittest.TestCase):
             BotConfig(reply_mode="everyone")
 
     def test_self_chat_guid_is_trimmed(self) -> None:
-        cfg = BotConfig(self_chat_guid=" any;-;forsyphilis@gmail.com  ")
+        cfg = BotConfig(self_chat_guid=" any;-;user@example.com  ")
 
-        self.assertEqual(cfg.self_chat_guid, "any;-;forsyphilis@gmail.com")
+        self.assertEqual(cfg.self_chat_guid, "any;-;user@example.com")
 
     def test_self_chat_guid_whitespace_normalizes_to_empty_string(self) -> None:
         cfg = BotConfig(self_chat_guid="   ")

--- a/sidecars/imessage-bot/tests/test_config.py
+++ b/sidecars/imessage-bot/tests/test_config.py
@@ -31,3 +31,7 @@ class BotConfigTests(unittest.TestCase):
         cfg = BotConfig(self_chat_guid=None)
 
         self.assertEqual(cfg.self_chat_guid, "")
+
+    def test_self_chat_guid_rejects_non_string_values(self) -> None:
+        with self.assertRaises(ValidationError):
+            BotConfig(self_chat_guid=123)

--- a/sidecars/imessage-bot/tests/test_imessage_bridge.py
+++ b/sidecars/imessage-bot/tests/test_imessage_bridge.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
-from src.imessage_bridge import resolve_self_chat_guid, send_message
+from src.imessage_bridge import redact_chat_guid, resolve_self_chat_guid, send_message
 
 
 class SendMessageTests(unittest.TestCase):
@@ -34,7 +34,7 @@ class SendMessageTests(unittest.TestCase):
                     "INSERT INTO chat VALUES (1, 'self-phone-guid', '+821029399460', 'P:+821029399460', 'iMessage')"
                 )
                 conn.execute(
-                    "INSERT INTO chat VALUES (2, 'self-email-guid', 'forsyphilis@gmail.com', 'E:forsyphilis@gmail.com', 'iMessage')"
+                    "INSERT INTO chat VALUES (2, 'self-email-guid', 'user@example.com', 'E:user@example.com', 'iMessage')"
                 )
                 conn.execute("INSERT INTO message VALUES (1, 100)")
                 conn.execute("INSERT INTO message VALUES (2, 200)")
@@ -73,3 +73,9 @@ class SendMessageTests(unittest.TestCase):
 
         self.assertFalse(ok)
         run_mock.assert_not_called()
+
+    def test_redact_chat_guid_redacts_tail(self) -> None:
+        self.assertEqual(
+            redact_chat_guid("any;-;user@example.com"),
+            "any;-;[redacted]",
+        )

--- a/sidecars/imessage-bot/tests/test_imessage_bridge.py
+++ b/sidecars/imessage-bot/tests/test_imessage_bridge.py
@@ -63,9 +63,13 @@ class SendMessageTests(unittest.TestCase):
         self.assertIn("first chat whose id is", command[2])
         self.assertEqual(command[3:], ["iMessage;-;+15551234567", "hello"])
 
+    def test_send_message_requires_chat_guid_argument(self) -> None:
+        with self.assertRaises(TypeError):
+            send_message(text="hello")  # type: ignore[call-arg]
+
     @patch("src.imessage_bridge.subprocess.run")
-    def test_send_message_rejects_missing_target(self, run_mock) -> None:
-        ok = send_message(text="hello")
+    def test_send_message_rejects_blank_target(self, run_mock) -> None:
+        ok = send_message(text="hello", chat_guid="")
 
         self.assertFalse(ok)
         run_mock.assert_not_called()

--- a/sidecars/imessage-bot/tests/test_imessage_bridge.py
+++ b/sidecars/imessage-bot/tests/test_imessage_bridge.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+from src.imessage_bridge import send_message
+
+
+class SendMessageTests(unittest.TestCase):
+    @patch("src.imessage_bridge.subprocess.run")
+    def test_send_message_targets_chat_guid_when_available(self, run_mock) -> None:
+        run_mock.return_value = SimpleNamespace(returncode=0, stderr="")
+
+        ok = send_message(
+            text="hello",
+            chat_guid="iMessage;-;+15551234567",
+        )
+
+        self.assertTrue(ok)
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[0:2], ["osascript", "-e"])
+        self.assertIn("first chat whose id is", command[2])
+        self.assertEqual(command[3:], ["iMessage;-;+15551234567", "hello"])
+
+    @patch("src.imessage_bridge.subprocess.run")
+    def test_send_message_rejects_missing_target(self, run_mock) -> None:
+        ok = send_message(text="hello")
+
+        self.assertFalse(ok)
+        run_mock.assert_not_called()

--- a/sidecars/imessage-bot/tests/test_imessage_bridge.py
+++ b/sidecars/imessage-bot/tests/test_imessage_bridge.py
@@ -1,13 +1,53 @@
 from __future__ import annotations
 
+import sqlite3
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 import unittest
 from unittest.mock import patch
 
-from src.imessage_bridge import send_message
+from src.imessage_bridge import resolve_self_chat_guid, send_message
 
 
 class SendMessageTests(unittest.TestCase):
+    def test_resolve_self_chat_guid_returns_explicit_override(self) -> None:
+        chat_guid = resolve_self_chat_guid("/tmp/does-not-matter.db", "self-guid")
+
+        self.assertEqual(chat_guid, "self-guid")
+
+    def test_resolve_self_chat_guid_detects_latest_self_chat(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "chat.db"
+            conn = sqlite3.connect(db_path)
+            try:
+                conn.execute(
+                    "CREATE TABLE chat (ROWID INTEGER PRIMARY KEY, guid TEXT, chat_identifier TEXT, account_login TEXT, service_name TEXT)"
+                )
+                conn.execute(
+                    "CREATE TABLE message (ROWID INTEGER PRIMARY KEY, date INTEGER)"
+                )
+                conn.execute(
+                    "CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER)"
+                )
+                conn.execute(
+                    "INSERT INTO chat VALUES (1, 'self-phone-guid', '+821029399460', 'P:+821029399460', 'iMessage')"
+                )
+                conn.execute(
+                    "INSERT INTO chat VALUES (2, 'self-email-guid', 'forsyphilis@gmail.com', 'E:forsyphilis@gmail.com', 'iMessage')"
+                )
+                conn.execute("INSERT INTO message VALUES (1, 100)")
+                conn.execute("INSERT INTO message VALUES (2, 200)")
+                conn.execute("INSERT INTO chat_message_join VALUES (1, 1)")
+                conn.execute("INSERT INTO chat_message_join VALUES (2, 2)")
+                conn.commit()
+            finally:
+                conn.close()
+
+            chat_guid = resolve_self_chat_guid(str(db_path))
+
+        self.assertEqual(chat_guid, "self-email-guid")
+
     @patch("src.imessage_bridge.subprocess.run")
     def test_send_message_targets_chat_guid_when_available(self, run_mock) -> None:
         run_mock.return_value = SimpleNamespace(returncode=0, stderr="")

--- a/test/dune
+++ b/test/dune
@@ -39,6 +39,7 @@
         test_subscriptions test_session test_progress test_spawn
         test_validation test_response
         test_channel_gate_connector_routes
+        test_channel_gate_imessage_state
         test_dashboard
         test_dashboard_perf
         test_dashboard_tool_host_events
@@ -113,6 +114,7 @@
           test_subscriptions test_session test_progress test_spawn
           test_validation test_response
           test_channel_gate_connector_routes
+          test_channel_gate_imessage_state
           test_dashboard
           test_dashboard_perf
           test_dashboard_tool_host_events

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -791,7 +791,7 @@ let () =
       test_case "same-origin allows matching origin" `Quick
         test_same_origin_browser_request_allows_matching_origin;
       test_case "same-origin rejects cross origin" `Quick
-        test_same_origin_browser_request_rejects_cross_origin;
+      test_same_origin_browser_request_rejects_cross_origin;
       test_case "same-origin allows https tunnel same host" `Quick
         test_same_origin_https_tunnel_same_host;
       test_case "same-origin allows loopback alias same port" `Quick

--- a/test/test_channel_gate_imessage_state.ml
+++ b/test/test_channel_gate_imessage_state.ml
@@ -1,0 +1,98 @@
+open Alcotest
+
+module IMessage_state = Masc_mcp.Channel_gate_imessage_state
+module U = Yojson.Safe.Util
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let temp_dir_counter = ref 0
+
+let with_temp_dir f =
+  incr temp_dir_counter;
+  let base =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "imessage-state-%d-%06d" (Unix.getpid ()) !temp_dir_counter)
+  in
+  Unix.mkdir base 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm_rf path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then (
+            Sys.readdir path
+            |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+            Unix.rmdir path
+          ) else Sys.remove path
+      in
+      rm_rf base)
+    (fun () -> f base)
+
+let with_imessage_paths dir f =
+  let status_path = Filename.concat dir "status.json" in
+  let binding_path = Filename.concat dir "bindings.json" in
+  let audit_path = Filename.concat dir "audit.jsonl" in
+  with_env "MASC_IMESSAGE_STATUS_PATH" (Some status_path) (fun () ->
+    with_env "MASC_IMESSAGE_BINDING_STORE_PATH" (Some binding_path) (fun () ->
+      with_env "MASC_IMESSAGE_BINDING_AUDIT_PATH" (Some audit_path) f))
+
+let sample_status_json =
+  `Assoc
+    [
+      ("updated_at", `String "2026-04-11T00:00:00Z");
+      ("connected", `Bool true);
+      ("gate_base_url", `String "http://127.0.0.1:8935");
+      ("gate_healthy", `Bool true);
+      ("gate_health_checked_at", `String "2026-04-11T00:00:00Z");
+      ("reply_mode", `String "self-chat");
+      ("self_chat_guid", `String "any;-;forsyphilis@gmail.com");
+      ("last_message_at", `String "2026-04-11T00:00:00Z");
+      ("messages_processed", `Int 3);
+      ("messages_failed", `Int 1);
+      ("cursor_rowid", `Int 42);
+      ("poll_interval_sec", `Float 2.0);
+      ("pid", `Int 4242);
+    ]
+
+let test_status_json_redacts_self_chat_guid () =
+  with_temp_dir @@ fun dir ->
+  with_imessage_paths dir (fun () ->
+    Yojson.Safe.to_file (Filename.concat dir "status.json") sample_status_json;
+    let json = IMessage_state.status_json () in
+    check string "reply mode surfaced" "self-chat"
+      (json |> U.member "reply_mode" |> U.to_string);
+    check string "self-chat guid redacted" "any;-;[redacted]"
+      (json |> U.member "self_chat_guid" |> U.to_string))
+
+let test_connector_json_keeps_redacted_guid () =
+  with_temp_dir @@ fun dir ->
+  with_imessage_paths dir (fun () ->
+    Yojson.Safe.to_file (Filename.concat dir "status.json") sample_status_json;
+    let json = IMessage_state.connector_json () in
+    check string "connector id" "imessage"
+      (json |> U.member "connector_id" |> U.to_string);
+    check string "reply mode surfaced" "self-chat"
+      (json |> U.member "reply_mode" |> U.to_string);
+    check string "self-chat guid redacted" "any;-;[redacted]"
+      (json |> U.member "self_chat_guid" |> U.to_string))
+
+let () =
+  run "channel_gate_imessage_state"
+    [
+      ( "status",
+        [
+          test_case "status json redacts self-chat guid" `Quick
+            test_status_json_redacts_self_chat_guid;
+          test_case "connector json keeps redacted self-chat guid" `Quick
+            test_connector_json_keeps_redacted_guid;
+        ] );
+    ]

--- a/test/test_channel_gate_imessage_state.ml
+++ b/test/test_channel_gate_imessage_state.ml
@@ -5,6 +5,8 @@ module U = Yojson.Safe.Util
 
 let with_env name value f =
   let previous = Sys.getenv_opt name in
+  (* OCaml stdlib lacks Unix.unsetenv; this test only exercises config paths
+     that route through Env_config_core.trim_opt, where "" behaves like unset. *)
   (match value with
    | Some v -> Unix.putenv name v
    | None -> Unix.putenv name "");

--- a/test/test_channel_gate_imessage_state.ml
+++ b/test/test_channel_gate_imessage_state.ml
@@ -56,7 +56,7 @@ let sample_status_json =
       ("gate_healthy", `Bool true);
       ("gate_health_checked_at", `String "2026-04-11T00:00:00Z");
       ("reply_mode", `String "self-chat");
-      ("self_chat_guid", `String "any;-;forsyphilis@gmail.com");
+      ("self_chat_guid", `String "any;-;user@example.com");
       ("last_message_at", `String "2026-04-11T00:00:00Z");
       ("messages_processed", `Int 3);
       ("messages_failed", `Int 1);


### PR DESCRIPTION
## Summary
- route outbound iMessage replies by Messages chat guid instead of sender handle resolution
- default replies to self-chat, with `source-chat` kept as an explicit opt-in mode
- surface the active reply mode in dashboard metadata while redacting the self-chat guid preview
- harden the iMessage sidecar with focused coverage for source-chat routing, skipped-reply cursor advancement, reply-send failure accounting, and config normalization

## Root Cause
The connector preserved the originating chat identity on ingest, but the outbound AppleScript path replied using only the sender handle. Messages could then resolve a different conversation than the one that produced the inbound event.

## Product impact
The default path is now fail-closed and self-directed: unless an operator explicitly switches to `source-chat`, the bot replies only to the user's own iMessage self-chat. When `source-chat` is enabled, replies stay pinned to the inbound chat guid instead of letting Messages guess. Missing target guids and local AppleScript send failures are recorded without poisoning the poll loop or causing the same inbound row to be re-sent to the gate forever.

## Evidence
- local `chat.db` inspection confirmed the misroute risk came from outbound conversation resolution, not from multi-recipient fan-out
- the sidecar resolves a self-chat guid from Messages metadata before sending in default mode and aborts outbound delivery when no target guid is available
- dashboard connector status now exposes `reply_mode` and only a redacted `self_chat_guid` preview so operators can verify mode without leaking full chat identifiers

## Review evidence
- direct `sb glm-text` review on the latest incremental patch at 2026-04-11 04:55:20Z reported `No findings.`
- latest Copilot review at 2026-04-11 04:43:31Z reviewed 17 changed files and generated no new comments
- earlier review findings on poison-pill retries, reply failure accounting, raw guid exposure, and test isolation were patched and their threads resolved

## Validation
- `PYTHONPATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/imessage-chat-target/sidecars/imessage-bot /Users/dancer/me/workspace/yousleepwhen/masc-mcp/sidecars/imessage-bot/.venv/bin/python -m unittest discover -s /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/imessage-chat-target/sidecars/imessage-bot/tests -p 'test_*.py'`
- `ruff check sidecars/imessage-bot/src/bot.py sidecars/imessage-bot/src/config.py sidecars/imessage-bot/src/imessage_bridge.py sidecars/imessage-bot/src/status_store.py sidecars/imessage-bot/tests/test_bot.py sidecars/imessage-bot/tests/test_config.py sidecars/imessage-bot/tests/test_imessage_bridge.py`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/imessage-chat-target ./test/test_channel_gate_imessage_state.exe`

## Linked issue
- None. This started as a user-reported production regression rather than a pre-existing GitHub issue.

## Notes
- I did not run a live Messages send while validating because the bug class is accidental delivery to the wrong recipient.
- I could not run dashboard Vitest / ESLint checks in this worktree because `dashboard/node_modules` is not installed locally.
