### PR TITLE
fix(pin): bump OAS to 0.119.1 — Ollama tool_choice contract relaxation

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.119.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="3d335f1b235b83fff814e1b317b7c084bbdb9404"
+readonly OAS_AGENT_SDK_SHA="0c870e81999ae884ed38ce20122b6e164d4eee1f"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.119.1"


### PR DESCRIPTION
## Summary

OAS pin 업데이트: Ollama provider에서 tool_choice contract violation 수정.

OAS changes (jeong-sik/oas#786):
- `supports_tool_choice=false` for Ollama
- `Completion_contract.of_tool_choice` relaxes to `Allow_text_or_tool` when unsupported
- Logging when contract is relaxed
- 6 inline tests

## Impact

`local_only` cascade (Ollama) keepers가 `tool_choice requested tool use, but no ToolUse block` 에러 없이 동작.

Generated with [Claude Code](https://claude.com/claude-code)