### PR TITLE
fix(keeper): address sandbox review follow-ups

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -40,16 +40,18 @@ File operations:
 Workspace:
 - Your writable workspace is .masc/playground/YOUR_KEEPER_NAME/. Use keeper_fs_edit to write files there.
 - Your playground clone is at .masc/playground/YOUR_KEEPER_NAME/repos/masc-mcp/. This is your default coding workspace.
-- Do NOT create worktrees in the main repo .worktrees/ — that is the human workspace.
+- playground is your sandbox; worktree is a repo workflow path for isolated branch-based changes.
+- Default to the playground clone. If that clone is missing, repo worktrees are the fallback workflow.
 - `keeper_pr_submit` is the canonical submit step after editing.
+- `keeper_pr_workflow` is a legacy one-shot worktree helper. Prefer `keeper_pr_submit`.
 - PR creation workflow (requires Coding, Delivery, or Full preset):
   1. masc_worktree_create task_id=<your-task-id>  (creates worktree in your playground clone)
   2. masc_code_read path=<file-to-modify>  (read the file first — understand before editing)
-  3. masc_code_edit file_path=<path> old_text=<before> new_text=<after>  (edit the file)
+  3. masc_code_edit path=<path> old_string=<before> new_string=<after>  (edit the file)
   4. masc_code_git action=add cwd=<worktree-path>  (stage changes)
-  5. masc_code_git action=commit cwd=<worktree-path> args=<commit-message>  (commit)
+  5. masc_code_git action=commit cwd=<worktree-path> args=["-m","<commit-message>"]  (commit)
   6. masc_code_git action=push cwd=<worktree-path>  (push)
-  7. keeper_pr_submit cwd=<worktree-path> pr_title=<title>  (create draft PR)
+  7. keeper_pr_submit cwd=<worktree-path> commit_message=<commit-message> pr_title=<title>  (create draft PR)
   NOTE: Do NOT use keeper_pr_workflow — it is deprecated and will error.
 
 Knowledge lookup:

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -925,14 +925,14 @@ let run_turn
       ~generation
       ~pre_tool_use_guard:(fun ~tool_name ~input ->
         match !mutation_boundary_tool_name with
-        | Some _ when Keeper_tool_registry.is_read_only_with_input
+        | Some _ when Keeper_tool_registry.is_main_worktree_boundary_exempt_with_input
                         ~tool_name ~input ->
-          None (* read-only tools/subcommands pass through mutation boundary *)
+          None (* coordination/worktree-sandbox tools pass through boundary *)
         | Some _ -> Some (mutation_boundary_summary ())
         | None -> None)
       ~on_tool_executed:(fun ~tool_name ~input ~output_text:_ ~success ->
         if success
-           && not (Keeper_tool_registry.is_read_only_with_input
+           && not (Keeper_tool_registry.is_main_worktree_boundary_exempt_with_input
                      ~tool_name ~input)
            && not (Keeper_tool_registry.is_reconcile_safe_tool tool_name)
            && Option.is_none !mutation_boundary_tool_name

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -31,21 +31,26 @@ let truncate_gh_output (out : string) : string * (string * Yojson.Safe.t) list =
   let len = String.length out in
   if len <= max_gh_output_bytes then out, []
   else
+    let banner shown_bytes =
+      Printf.sprintf
+        "\n... [truncated: %d bytes total, showing first %d]"
+        len shown_bytes
+    in
     let render prefix =
       let shown_bytes = String.length prefix in
-      let banner =
-        Printf.sprintf
-          "\n... [truncated: %d bytes total, showing first %d]"
-          len shown_bytes
-      in
-      prefix ^ banner, shown_bytes
+      let banner = banner shown_bytes in
+      prefix ^ banner, shown_bytes, String.length banner
     in
     let rec fit budget =
       let prefix = Keeper_config.utf8_safe_prefix_bytes out ~max_bytes:budget in
-      let rendered, shown_bytes = render prefix in
+      let rendered, shown_bytes, banner_len = render prefix in
       if String.length rendered <= max_gh_output_bytes || budget = 0
       then rendered, shown_bytes
-      else fit (budget - 1)
+      else
+        let next_budget = max 0 (max_gh_output_bytes - banner_len) in
+        if next_budget >= budget
+        then rendered, shown_bytes
+        else fit next_budget
     in
     let rendered, shown_bytes = fit max_gh_output_bytes in
     rendered,

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -31,10 +31,27 @@ let truncate_gh_output (out : string) : string * (string * Yojson.Safe.t) list =
   let len = String.length out in
   if len <= max_gh_output_bytes then out, []
   else
-    let truncated = String.sub out 0 max_gh_output_bytes in
-    truncated ^ "\n... [truncated: " ^ string_of_int len ^ " bytes total, showing first "
-    ^ string_of_int max_gh_output_bytes ^ "]",
-    [ "truncated", `Bool true; "original_bytes", `Int len ]
+    let render prefix =
+      let shown_bytes = String.length prefix in
+      let banner =
+        Printf.sprintf
+          "\n... [truncated: %d bytes total, showing first %d]"
+          len shown_bytes
+      in
+      prefix ^ banner, shown_bytes
+    in
+    let rec fit budget =
+      let prefix = Keeper_config.utf8_safe_prefix_bytes out ~max_bytes:budget in
+      let rendered, shown_bytes = render prefix in
+      if String.length rendered <= max_gh_output_bytes || budget = 0
+      then rendered, shown_bytes
+      else fit (budget - 1)
+    in
+    let rendered, shown_bytes = fit max_gh_output_bytes in
+    rendered,
+    [ "truncated", `Bool true;
+      "original_bytes", `Int len;
+      "shown_bytes", `Int shown_bytes ]
 
 let handle_keeper_github
       ~(config : Room.config)

--- a/lib/keeper/keeper_exec_github.mli
+++ b/lib/keeper/keeper_exec_github.mli
@@ -9,6 +9,12 @@ val gh_not_found_hint :
   out:string ->
   (string * Yojson.Safe.t) list
 
+val max_gh_output_bytes : int
+
+val truncate_gh_output :
+  string ->
+  string * (string * Yojson.Safe.t) list
+
 val handle_keeper_github :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -60,7 +60,7 @@ let with_keeper_turn_slot ~channel f =
     | Keeper_world_observation.Reactive -> false
   in
   let t0 = Time_compat.now () in
-  Log.Keeper.info "semaphore_acquire: channel=%s autonomous_available=%d turn_available=%d"
+  Log.Keeper.debug "semaphore_acquire: channel=%s autonomous_available=%d turn_available=%d"
     (if is_autonomous then "autonomous" else "reactive")
     (Eio.Semaphore.get_value autonomous_turn_semaphore)
     (Eio.Semaphore.get_value turn_semaphore);

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -38,9 +38,9 @@ let turn_semaphore = Eio.Semaphore.make keeper_turn_throttle_limit
    keepers fire scheduled turns simultaneously on a shared LLM server.
    Reactive turns (explicit mentions, board events) bypass this gate
    so they are never starved by slow autonomous turns.
-   Default 1 = with 1-slot llama-server, only one request can be in-flight
-   at a time. Higher values cause queue buildup and TCP keepalive timeouts.
-   For 8-slot servers, set MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4. *)
+   Default 3 = a conservative parallelism level for shared remote providers.
+   Lower to 1 for single-slot local servers. For 8-slot servers,
+   MASC_KEEPER_AUTONOMOUS_CONCURRENCY=3-4 is a reasonable range. *)
 let autonomous_turn_limit =
   Keeper_config.int_of_env_default
     "MASC_KEEPER_AUTONOMOUS_CONCURRENCY" ~default:3 ~min_v:1 ~max_v:8

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -120,10 +120,9 @@ let has_mutating_side_effect (name : string) : bool =
   not (is_effectively_read_only_tool name)
 
 (* ── Input-aware read-only check ─────────────────────────────
-   Some tools (keeper_github) mix read-only and mutating subcommands
-   within a single tool name.  This function inspects the JSON input
-   to distinguish read-only invocations so that the mutation boundary
-   lets them through without opening a reconcile window. *)
+   Some tools (keeper_github, masc_code_git) mix read-only and mutating
+   subcommands within a single tool name. This function inspects the
+   JSON input to distinguish calls with no side effects. *)
 
 let gh_read_only_prefixes =
   [ "pr list"; "pr view"; "pr diff"; "pr checks"; "pr status"
@@ -206,6 +205,14 @@ let gh_effective_cmd (input : Yojson.Safe.t) : string =
 let git_read_only_actions =
   [ "diff"; "status"; "log"; "branch"; "fetch" ]
 
+let git_action_of_input (input : Yojson.Safe.t) : string =
+  match input with
+  | `Assoc fields ->
+    (match List.assoc_opt "action" fields with
+     | Some (`String s) -> String.lowercase_ascii (String.trim s)
+     | _ -> "")
+  | _ -> ""
+
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
   if is_effectively_read_only_tool tool_name then true
   else match tool_name with
@@ -221,29 +228,32 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
         String.length cmd_lower >= String.length prefix
         && String.sub cmd_lower 0 (String.length prefix) = prefix
       ) gh_read_only_prefixes
-  | "masc_code_git" ->
-    let action =
-      match input with
-      | `Assoc fields ->
-        (match List.assoc_opt "action" fields with
-         | Some (`String s) -> String.lowercase_ascii (String.trim s)
-         | _ -> "")
-      | _ -> ""
-    in
-    List.mem action git_read_only_actions
+  | "masc_code_git" -> List.mem (git_action_of_input input) git_read_only_actions
   | "masc_worktree_list" -> true
-  (* MASC coordination tools: internal state only, no filesystem mutation *)
-  | "keeper_task_claim" | "keeper_task_done" | "keeper_tasks_list"
-  | "keeper_board_post" | "keeper_board_comment" | "keeper_board_vote"
-  | "keeper_board_list" | "keeper_board_get"
-  | "keeper_broadcast" -> true
-  (* Coding tools: operate in worktree scope (not main), safe for
-     multi-step coding pipelines. Without this, mutation boundary blocks
-     the create-worktree → edit → commit → push → PR pipeline. *)
-  | "masc_code_edit" | "masc_code_write" | "masc_code_delete"
-  | "masc_code_shell" | "masc_worktree_create"
-  | "keeper_pr_submit" | "keeper_fs_edit" -> true
   | _ -> false
+
+(* ── Input-aware mutation-boundary bypass ────────────────────
+   Some tools do mutate state, but they should not open the
+   main-worktree checkpoint boundary because they either:
+   - only touch MASC coordination state, or
+   - operate inside an explicit worktree/playground sandbox.
+
+   Keep these tools mutating for reconcile/error handling; this predicate
+   only controls whether the per-turn boundary blocks follow-up tools. *)
+let is_main_worktree_boundary_exempt_with_input
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t) : bool =
+  if is_read_only_with_input ~tool_name ~input then true
+  else
+    match tool_name with
+    | "keeper_task_claim" | "keeper_task_done" | "keeper_tasks_list"
+    | "keeper_board_post" | "keeper_board_comment" | "keeper_board_vote"
+    | "keeper_board_list" | "keeper_board_get"
+    | "keeper_broadcast" -> true
+    | "masc_code_edit" | "masc_code_write" | "masc_code_delete"
+    | "masc_code_shell" | "masc_code_git" | "masc_worktree_create"
+    | "keeper_pr_submit" | "keeper_fs_edit" -> true
+    | _ -> false
 
 (* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)
 

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -89,8 +89,9 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
-    (* Default to playground clone; fall back to base_path git root.
-       Keeper coding should happen in playground, not the main repo. *)
+    (* Prefer the keeper's playground clone. If it is missing, fall back
+       to the configured repository root so explicit repo-worktree flows
+       still work instead of failing with a missing-clone error. *)
     let resolve_keeper_repo_root () =
       let playground_repo =
         Filename.concat config.base_path

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -1,7 +1,8 @@
 (** Code Write Tools — File write, edit, delete, shell, git for keeper agents.
 
     Security model:
-    - All write operations restricted to .worktrees/ directories
+    - Write operations restricted to allowed sandboxes
+      (.worktrees/ checkouts and keeper playground clones)
     - Shell commands restricted to allowlist
     - Git push to main/master blocked
     - Git clone restricted to allowed GitHub orgs (config/tool_policy.toml)
@@ -22,38 +23,74 @@ type result = bool * string
 
 let max_write_size = 1024 * 1024 (* 1MB *)
 
-(* Security: Validate path is within a .worktrees/ directory.
+let normalize_dir_prefix path =
+  Tool_code.normalize_path path ^ "/"
+
+let first_nonempty_line output =
+  output
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.find_opt (fun s -> s <> "")
+
+let git_common_root path =
+  try
+    match
+      Process_eio.run_argv_with_status
+        ~timeout_sec:5.0
+        [ "git"; "-C"; path; "rev-parse"; "--git-common-dir" ]
+    with
+    | Unix.WEXITED 0, output ->
+      (match first_nonempty_line output with
+       | None -> None
+       | Some git_common_dir ->
+         let git_common_dir =
+           if Filename.is_relative git_common_dir
+           then Filename.concat path git_common_dir
+           else git_common_dir
+         in
+         Some (Tool_code.normalize_path (Filename.dirname git_common_dir)))
+    | _ -> None
+  with _ -> None
+
+let dedupe_keep_order paths =
+  let seen = Hashtbl.create (List.length paths) in
+  List.filter
+    (fun path ->
+      if Hashtbl.mem seen path then false
+      else (
+        Hashtbl.replace seen path ();
+        true))
+    paths
+
+let allowed_worktree_prefixes config =
+  [ git_common_root config.Room.base_path;
+    git_common_root (Sys.getcwd ()) ]
+  |> List.filter_map (fun root -> root)
+  |> dedupe_keep_order
+  |> List.map (fun root -> normalize_dir_prefix (Filename.concat root ".worktrees"))
+
+(* Security: Validate path is within an allowed writable sandbox.
    Uses canonical paths from Tool_code.validate_path — already normalized.
-   Checks both the base_path git root AND the process cwd git root,
-   because base_path may be ~/me while the actual repo worktrees live
-   under ~/me/workspace/.../masc-mcp/.worktrees/. *)
+   Worktree paths are anchored to actual git common roots so a nested
+   "/.worktrees/" segment elsewhere in the tree is not accepted. *)
 let validate_writable_path config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
   | Ok canonical_path ->
-    (* Path must be inside a safe sandbox:
-       - any /.worktrees/ ancestor (git worktree checkouts)
-       - {base_path}/.masc/playground/ (keeper personal clones) *)
-    let has_segment path marker =
-      let mlen = String.length marker in
-      let plen = String.length path in
-      let rec scan i =
-        if i + mlen > plen then false
-        else if String.sub path i mlen = marker then true
-        else scan (i + 1)
-      in
-      scan 0
-    in
+    let worktree_prefixes = allowed_worktree_prefixes config in
     let playground_prefix =
-      Tool_code.normalize_path
-        (Filename.concat config.Room.base_path ".masc/playground") ^ "/"
+      normalize_dir_prefix
+        (Filename.concat config.Room.base_path ".masc/playground")
     in
-    if has_segment canonical_path "/.worktrees/"
+    if List.exists
+         (fun prefix -> String.starts_with ~prefix canonical_path)
+         worktree_prefixes
        || String.starts_with ~prefix:playground_prefix canonical_path then
       Ok canonical_path
     else
       Error (IoError (Printf.sprintf
-        "Write restricted to .worktrees/ directory (got: %s)"
+        "Write restricted to allowed sandboxes: /.worktrees/ or %s (got: %s)"
+        playground_prefix
         canonical_path))
 
 (* Shell command allowlist *)
@@ -579,7 +616,8 @@ let dispatch ctx ~name ~args : result option =
 let schemas : Types.tool_schema list = [
   {
     name = "masc_code_write";
-    description = "Create or overwrite a file in a worktree (.worktrees/ only). \
+    description = "Create or overwrite a file in an allowed coding sandbox \
+(.worktrees/ or .masc/playground/). \
 Use to generate new source files, configs, or replace entire file contents. \
 For partial edits (change a function, fix a line), use masc_code_edit instead. \
 Returns bytes_written. Max 1MB. Set up a worktree first with masc_worktree_create.";
@@ -588,7 +626,7 @@ Returns bytes_written. Max 1MB. Set up a worktree first with masc_worktree_creat
       ("properties", `Assoc [
         ("path", `Assoc [
           ("type", `String "string");
-          ("description", `String "File path to write (must be within .worktrees/)");
+          ("description", `String "File path to write (must be within .worktrees/ or .masc/playground/)");
         ]);
         ("content", `Assoc [
           ("type", `String "string");
@@ -606,7 +644,8 @@ Returns bytes_written. Max 1MB. Set up a worktree first with masc_worktree_creat
 
   {
     name = "masc_code_edit";
-    description = "Replace text in a file in a worktree (.worktrees/ only). \
+    description = "Replace text in a file in an allowed coding sandbox \
+(.worktrees/ or .masc/playground/). \
 Use for surgical edits: fix a bug, update a function, change a config value. \
 old_string must match exactly once (unless replace_all=true). Returns replacement_count. \
 For full file replacement, use masc_code_write. Read the file first with masc_code_read \
@@ -616,7 +655,7 @@ to get the exact text to replace.";
       ("properties", `Assoc [
         ("path", `Assoc [
           ("type", `String "string");
-          ("description", `String "File path to edit (must be within .worktrees/)");
+          ("description", `String "File path to edit (must be within .worktrees/ or .masc/playground/)");
         ]);
         ("old_string", `Assoc [
           ("type", `String "string");
@@ -638,14 +677,15 @@ to get the exact text to replace.";
 
   {
     name = "masc_code_delete";
-    description = "Delete a file in a worktree (.worktrees/ only). Cannot delete directories. \
+    description = "Delete a file in an allowed coding sandbox \
+(.worktrees/ or .masc/playground/). Cannot delete directories. \
 Use when removing generated, obsolete, or conflicting files during code work.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("path", `Assoc [
           ("type", `String "string");
-          ("description", `String "File path to delete (must be within .worktrees/)");
+          ("description", `String "File path to delete (must be within .worktrees/ or .masc/playground/)");
         ]);
       ]);
       ("required", `List [`String "path"]);
@@ -654,7 +694,8 @@ Use when removing generated, obsolete, or conflicting files during code work.";
 
   {
     name = "masc_code_shell";
-    description = "Run an allowlisted command in a worktree (.worktrees/ only). \
+    description = "Run an allowlisted command in an allowed coding sandbox \
+(.worktrees/ or .masc/playground/). \
 Allowed: dune, make, npm, npx, node, git, ls, cat, head, tail, wc, rg, find, \
 diff, patch, mkdir, opam, ocamlfind, tsc. Use for building and testing code \
 in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
@@ -668,7 +709,7 @@ Returns exit_code and stdout (truncated at 10KB).";
         ]);
         ("cwd", `Assoc [
           ("type", `String "string");
-          ("description", `String "Working directory (must be within .worktrees/)");
+          ("description", `String "Working directory (must be within .worktrees/ or .masc/playground/)");
         ]);
         ("timeout", `Assoc [
           ("type", `String "integer");
@@ -682,7 +723,8 @@ Returns exit_code and stdout (truncated at 10KB).";
 
   {
     name = "masc_code_git";
-    description = "Run git commands in a worktree (.worktrees/ only). Structured alternative \
+    description = "Run git commands in an allowed coding sandbox \
+(.worktrees/ or .masc/playground/). Structured alternative \
 to masc_code_shell for git operations. Supports: add, commit, push, diff, status, \
 log, branch, checkout, stash, fetch, clone. Force push and push to main/master are blocked. \
 Clone is restricted to allowed GitHub orgs (configured in config/tool_policy.toml). \
@@ -702,7 +744,7 @@ Returns git command output.";
         ]);
         ("cwd", `Assoc [
           ("type", `String "string");
-          ("description", `String "Worktree directory (must be within .worktrees/)");
+          ("description", `String "Working directory (must be within .worktrees/ or .masc/playground/)");
         ]);
       ]);
       ("required", `List [`String "action"; `String "cwd"]);

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -50,7 +50,10 @@ let git_common_root path =
          in
          Some (Tool_code.normalize_path (Filename.dirname git_common_dir)))
     | _ -> None
-  with _ -> None
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | Unix.Unix_error _ -> None
+  | Sys_error _ -> None
 
 let dedupe_keep_order paths =
   let seen = Hashtbl.create (List.length paths) in

--- a/test/test_keeper_github_hint.ml
+++ b/test/test_keeper_github_hint.ml
@@ -13,6 +13,8 @@
 open Alcotest
 
 let hint = Masc_mcp.Keeper_exec_github.gh_not_found_hint
+let truncate = Masc_mcp.Keeper_exec_github.truncate_gh_output
+let max_gh_output_bytes = Masc_mcp.Keeper_exec_github.max_gh_output_bytes
 
 let has_hint result =
   List.exists (fun (k, _) -> k = "hint") result
@@ -118,6 +120,32 @@ let test_hint_text_content () =
             with Not_found -> false)
   | _ -> fail "expected hint key with string value"
 
+let test_truncate_preserves_short_output () =
+  let out = "short gh output" in
+  let truncated, fields = truncate out in
+  check string "unchanged output" out truncated;
+  check int "no metadata" 0 (List.length fields)
+
+let test_truncate_caps_total_length () =
+  let out = String.make (max_gh_output_bytes + 512) 'a' in
+  let truncated, fields = truncate out in
+  check bool "marked truncated"
+    true
+    (List.mem_assoc "truncated" fields);
+  check (option int) "original bytes recorded"
+    (Some (String.length out))
+    (match List.assoc_opt "original_bytes" fields with
+     | Some (`Int n) -> Some n
+     | _ -> None);
+  check bool "shown bytes recorded"
+    true
+    (match List.assoc_opt "shown_bytes" fields with
+     | Some (`Int n) -> n >= 0
+     | _ -> false);
+  check bool "total output is capped"
+    true
+    (String.length truncated <= max_gh_output_bytes)
+
 let () =
   run "keeper_github_hint"
     [ "not_found_detection",
@@ -141,5 +169,9 @@ let () =
           test_signaled_with_matching_output
       ; test_case "hint text content" `Quick
           test_hint_text_content
+      ; test_case "short output unchanged" `Quick
+          test_truncate_preserves_short_output
+      ; test_case "truncate caps total length" `Quick
+          test_truncate_caps_total_length
       ]
     ]

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -15,6 +15,10 @@ open Masc_mcp
 let is_ro ~tool_name ~input =
   Keeper_tool_registry.is_read_only_with_input ~tool_name ~input
 
+let is_boundary_exempt ~tool_name ~input =
+  Keeper_tool_registry.is_main_worktree_boundary_exempt_with_input
+    ~tool_name ~input
+
 let mk_cmd cmd =
   `Assoc [ ("cmd", `String cmd) ]
 
@@ -24,6 +28,9 @@ let mk_args args =
 let mk_cmd_and_args cmd args =
   `Assoc [ ("cmd", `String cmd);
            ("args", `List (List.map (fun s -> `String s) args)) ]
+
+let mk_action action =
+  `Assoc [ ("action", `String action) ]
 
 (* ================================================================ *)
 (* Read-only subcommands via cmd                                     *)
@@ -197,6 +204,36 @@ let test_api_via_args () =
        ~input:(mk_args ["api"; "-X"; "POST"; "/repos/o/r/pulls/1/merge"]))
 
 (* ================================================================ *)
+(* Main-worktree mutation-boundary exemptions                        *)
+(* ================================================================ *)
+
+let test_task_claim_is_mutating_but_boundary_exempt () =
+  Alcotest.(check bool) "task claim is not read-only"
+    false
+    (is_ro ~tool_name:"keeper_task_claim" ~input:(`Assoc []));
+  Alcotest.(check bool) "task claim bypasses boundary"
+    true
+    (is_boundary_exempt ~tool_name:"keeper_task_claim" ~input:(`Assoc []))
+
+let test_masc_code_git_write_actions_bypass_boundary () =
+  List.iter
+    (fun action ->
+      Alcotest.(check bool)
+        (Printf.sprintf "git %s is mutating" action)
+        false
+        (is_ro ~tool_name:"masc_code_git" ~input:(mk_action action));
+      Alcotest.(check bool)
+        (Printf.sprintf "git %s bypasses boundary" action)
+        true
+        (is_boundary_exempt ~tool_name:"masc_code_git" ~input:(mk_action action)))
+    [ "add"; "commit"; "push" ]
+
+let test_keeper_bash_still_opens_boundary () =
+  Alcotest.(check bool) "keeper_bash not exempt"
+    false
+    (is_boundary_exempt ~tool_name:"keeper_bash" ~input:(mk_cmd "git status"))
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -241,5 +278,11 @@ let () =
             test_non_keeper_github_tool;
           Alcotest.test_case "api via args" `Quick
             test_api_via_args;
+          Alcotest.test_case "task claim mutating but boundary exempt" `Quick
+            test_task_claim_is_mutating_but_boundary_exempt;
+          Alcotest.test_case "masc_code_git write actions bypass boundary" `Quick
+            test_masc_code_git_write_actions_bypass_boundary;
+          Alcotest.test_case "keeper_bash still opens boundary" `Quick
+            test_keeper_bash_still_opens_boundary;
         ] );
     ]


### PR DESCRIPTION
## Summary
- address follow-up review feedback after #6433 merged
- separate mutation-boundary bypass from true read-only classification
- tighten writable sandbox checks and make gh truncation UTF-8 safe
- align keeper workflow docs with actual tool schemas and required params

## Context
This is a narrow follow-up to PR #6433. The original branch merged, but Copilot review comments still called out boundary semantics, sandbox messaging, and workflow-doc mismatches that were worth fixing directly.

## Product impact
- Promise affected: `none/internal`
- User-visible change: none
- Operator impact: keeper coding workflows and sandbox errors are more predictable

## Evidence
- `dune build --root .`
- `./_build/default/test/test_keeper_github_read_only.exe`
- `./_build/default/test/test_keeper_github_hint.exe`
- `./_build/default/test/test_keeper_unified.exe`

## Review evidence
- addressed Copilot review feedback on `tool_code_write`, `keeper_tool_registry`, `keeper_exec_github`, `room_worktree`, and keeper capability docs
- verified `keeper_task_claim` stays mutating while bypassing the main-worktree boundary
- verified `masc_code_git` write actions continue through the coding sandbox flow and `gh` truncation stays within the 8KB cap

## Linked issue
- Refs #6433
