### PR TITLE
refactor: root cause fixes for JSONL parsing, keeper_github repo, preset validation

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -164,17 +164,52 @@ let mkdir_p (path : string) : unit =
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)
 
-(** Load JSONL file as list of JSON values.
-    Filters out malformed lines. *)
-let load_jsonl (path : string) : Yojson.Safe.t list =
-  if not (file_exists path) then []
+(** Load JSONL file, returning parsed values and count of malformed lines.
+    Logs each malformed line with file path for diagnostics. *)
+let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
+  if not (file_exists path) then ([], 0)
   else
     let content = load_file path in
-    String.split_on_char '\n' content
-    |> List.filter (fun line -> String.length (String.trim line) > 0)
-    |> List.filter_map (fun line ->
-        try Some (Yojson.Safe.from_string line)
-        with Yojson.Json_error _ -> None)
+    let malformed = ref 0 in
+    let parsed =
+      String.split_on_char '\n' content
+      |> List.filter (fun line -> String.length (String.trim line) > 0)
+      |> List.filter_map (fun line ->
+          match Yojson.Safe.from_string line with
+          | json -> Some json
+          | exception Yojson.Json_error msg ->
+              incr malformed;
+              Printf.eprintf "[fs_compat] malformed JSONL in %s: %s\n%!"
+                (Filename.basename path) msg;
+              None)
+    in
+    (parsed, !malformed)
+
+(** Load JSONL file as list of JSON values.
+    Malformed lines are logged and dropped. *)
+let load_jsonl (path : string) : Yojson.Safe.t list =
+  fst (load_jsonl_diagnostics path)
+
+(** Parse pre-read string lines as JSONL.
+    Use when lines come from [Keeper_memory.read_file_tail_lines] or
+    other non-file sources.  Logs malformed lines with [source] tag. *)
+let parse_jsonl_lines ~(source : string) (lines : string list)
+    : Yojson.Safe.t list * int =
+  let malformed = ref 0 in
+  let parsed =
+    List.filter_map (fun line ->
+      let trimmed = String.trim line in
+      if trimmed = "" then None
+      else
+        match Yojson.Safe.from_string trimmed with
+        | json -> Some json
+        | exception Yojson.Json_error msg ->
+            incr malformed;
+            Printf.eprintf "[fs_compat] malformed JSONL (%s): %s\n%!" source msg;
+            None
+    ) lines
+  in
+  (parsed, !malformed)
 
 (** Append JSON value as line to JSONL file. *)
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -164,32 +164,6 @@ let mkdir_p (path : string) : unit =
       let eio_path = Eio.Path.(fs / path) in
       Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path)
 
-(** Load JSONL file, returning parsed values and count of malformed lines.
-    Logs each malformed line with file path for diagnostics. *)
-let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
-  if not (file_exists path) then ([], 0)
-  else
-    let content = load_file path in
-    let malformed = ref 0 in
-    let parsed =
-      String.split_on_char '\n' content
-      |> List.filter (fun line -> String.length (String.trim line) > 0)
-      |> List.filter_map (fun line ->
-          match Yojson.Safe.from_string line with
-          | json -> Some json
-          | exception Yojson.Json_error msg ->
-              incr malformed;
-              Printf.eprintf "[fs_compat] malformed JSONL in %s: %s\n%!"
-                (Filename.basename path) msg;
-              None)
-    in
-    (parsed, !malformed)
-
-(** Load JSONL file as list of JSON values.
-    Malformed lines are logged and dropped. *)
-let load_jsonl (path : string) : Yojson.Safe.t list =
-  fst (load_jsonl_diagnostics path)
-
 (** Parse pre-read string lines as JSONL.
     Use when lines come from [Keeper_memory.read_file_tail_lines] or
     other non-file sources.  Logs malformed lines with [source] tag. *)
@@ -210,6 +184,20 @@ let parse_jsonl_lines ~(source : string) (lines : string list)
     ) lines
   in
   (parsed, !malformed)
+
+(** Load JSONL file, returning parsed values and count of malformed lines.
+    Delegates to [parse_jsonl_lines] for the actual parsing. *)
+let load_jsonl_diagnostics (path : string) : Yojson.Safe.t list * int =
+  if not (file_exists path) then ([], 0)
+  else
+    let content = load_file path in
+    let lines = String.split_on_char '\n' content in
+    parse_jsonl_lines ~source:(Filename.basename path) lines
+
+(** Load JSONL file as list of JSON values.
+    Malformed lines are logged and dropped. *)
+let load_jsonl (path : string) : Yojson.Safe.t list =
+  fst (load_jsonl_diagnostics path)
 
 (** Append JSON value as line to JSONL file. *)
 let append_jsonl (path : string) (json : Yojson.Safe.t) : unit =

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -50,7 +50,18 @@ val mkdir_p : string -> unit
 (** Create directory recursively. *)
 
 val load_jsonl : string -> Yojson.Safe.t list
-(** Load JSONL file as list of JSON values. *)
+(** Load JSONL file as list of JSON values.
+    Malformed lines are logged and dropped. *)
+
+val load_jsonl_diagnostics : string -> Yojson.Safe.t list * int
+(** Load JSONL file, returning parsed values and count of malformed lines.
+    Logs each malformed line with file path.  Use when the caller needs
+    to surface degraded state (e.g. dashboard malformed_lines field). *)
+
+val parse_jsonl_lines : source:string -> string list -> Yojson.Safe.t list * int
+(** Parse pre-read string lines as JSONL, returning parsed values and
+    malformed count.  [source] is used in log messages.
+    Use when lines come from tail-readers or non-file sources. *)
 
 val append_jsonl : string -> Yojson.Safe.t -> unit
 (** Append JSON value as line to JSONL file. *)

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -55,7 +55,7 @@ val load_jsonl : string -> Yojson.Safe.t list
 
 val load_jsonl_diagnostics : string -> Yojson.Safe.t list * int
 (** Load JSONL file, returning parsed values and count of malformed lines.
-    Logs each malformed line with file path.  Use when the caller needs
+    Logs each malformed line with the provided source label. Use when the caller needs
     to surface degraded state (e.g. dashboard malformed_lines field). *)
 
 val parse_jsonl_lines : source:string -> string list -> Yojson.Safe.t list * int

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -65,11 +65,28 @@ let handle_keeper_github
   =
   let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
   let gh_args = Safe_ops.json_string_list "args" args in
+  let repo_param = Safe_ops.json_string ~default:"" "repo" args |> String.trim in
   let timeout_sec =
     Safe_ops.json_float ~default:30.0 "timeout_sec" args |> fun n -> max 1.0 (min 180.0 n)
   in
-  let gh_raw =
+  let gh_raw_base =
     if cmd <> "" then cmd else if gh_args <> [] then String.concat " " gh_args else ""
+  in
+  (* Structured repo parameter: if provided, inject --repo flag.
+     If not provided but cmd contains --repo/-R with wrong owner, correct it.
+     This is the root fix for LLM hallucinating repo owners (#6043). *)
+  let gh_raw =
+    if repo_param <> "" then
+      (* Strip any --repo/-R from cmd to avoid duplication, then append *)
+      let stripped = Re.replace repo_flag_re ~f:(fun _ -> "") gh_raw_base |> String.trim in
+      Printf.sprintf "%s --repo %s" stripped repo_param
+    else
+      match project_repo_slug () with
+      | Some slug ->
+          let (corrected, _) = correct_repo_flag ~correct_slug:slug gh_raw_base in
+          corrected
+      | None -> gh_raw_base
+  in
   in
   if gh_raw = ""
   then error_json "cmd is required. \

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -58,6 +58,66 @@ let truncate_gh_output (out : string) : string * (string * Yojson.Safe.t) list =
       "original_bytes", `Int len;
       "shown_bytes", `Int shown_bytes ]
 
+(** Regex matching --repo owner/name or -R owner/name in gh CLI commands. *)
+let repo_flag_re =
+  Re.compile
+    (Re.seq
+       [ Re.alt [ Re.str "--repo"; Re.str "-R" ]
+       ; Re.rep1 Re.blank
+       ; Re.rep1 (Re.compl [ Re.blank ])
+       ])
+
+(** Cached owner/repo slug from git remote origin. *)
+let _repo_slug_cache : string option option ref = ref None
+
+let project_repo_slug () : string option =
+  match !_repo_slug_cache with
+  | Some cached -> cached
+  | None ->
+      let slug =
+        match Process_eio.run_argv_with_status ~timeout_sec:5.0
+                ["git"; "remote"; "get-url"; "origin"] with
+        | Unix.WEXITED 0, url ->
+            let url = String.trim url in
+            (* git@github.com:owner/repo.git or https://github.com/owner/repo.git *)
+            let strip_git s =
+              if String.length s > 4 && String.sub s (String.length s - 4) 4 = ".git"
+              then String.sub s 0 (String.length s - 4)
+              else s
+            in
+            (match String.split_on_char ':' url with
+             | [_; path] when String.contains url '@' ->
+                 Some (strip_git path)
+             | _ ->
+                 (* https://github.com/owner/repo.git *)
+                 let parts = String.split_on_char '/' url in
+                 let n = List.length parts in
+                 if n >= 2 then
+                   let owner = List.nth parts (n - 2) in
+                   let repo = strip_git (List.nth parts (n - 1)) in
+                   Some (owner ^ "/" ^ repo)
+                 else None)
+        | _ -> None
+      in
+      _repo_slug_cache := Some slug;
+      slug
+
+(** Replace a wrong --repo/-R slug in cmd with the correct one.
+    Returns (corrected_cmd, was_corrected). *)
+let correct_repo_flag ~(correct_slug : string) (cmd : string) : string * bool =
+  if Re.execp repo_flag_re cmd then
+    let corrected =
+      Re.replace repo_flag_re
+        ~f:(fun g ->
+          let matched = Re.Group.get g 0 in
+          let flag = if String.length matched > 2 && matched.[0] = '-' && matched.[1] = 'R'
+                     then "-R" else "--repo" in
+          flag ^ " " ^ correct_slug)
+        cmd
+    in
+    (corrected, corrected <> cmd)
+  else (cmd, false)
+
 let handle_keeper_github
       ~(config : Room.config)
       ~(meta : keeper_meta)
@@ -77,7 +137,6 @@ let handle_keeper_github
      This is the root fix for LLM hallucinating repo owners (#6043). *)
   let gh_raw =
     if repo_param <> "" then
-      (* Strip any --repo/-R from cmd to avoid duplication, then append *)
       let stripped = Re.replace repo_flag_re ~f:(fun _ -> "") gh_raw_base |> String.trim in
       Printf.sprintf "%s --repo %s" stripped repo_param
     else
@@ -86,7 +145,6 @@ let handle_keeper_github
           let (corrected, _) = correct_repo_flag ~correct_slug:slug gh_raw_base in
           corrected
       | None -> gh_raw_base
-  in
   in
   if gh_raw = ""
   then error_json "cmd is required. \

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -58,14 +58,52 @@ let truncate_gh_output (out : string) : string * (string * Yojson.Safe.t) list =
       "original_bytes", `Int len;
       "shown_bytes", `Int shown_bytes ]
 
-(** Regex matching --repo owner/name or -R owner/name in gh CLI commands. *)
+(** Regex matching --repo owner/name, --repo=owner/name, or -R owner/name in gh CLI commands. *)
 let repo_flag_re =
   Re.compile
     (Re.seq
        [ Re.alt [ Re.str "--repo"; Re.str "-R" ]
-       ; Re.rep1 Re.blank
+       ; Re.alt [ Re.rep1 Re.blank; Re.str "=" ]
        ; Re.rep1 (Re.compl [ Re.blank ])
        ])
+
+let has_repo_flag cmd =
+  Re.execp repo_flag_re cmd
+
+let is_valid_repo_segment segment =
+  segment <> ""
+  && String.for_all
+       (function
+         | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '.' | '-' | '_' -> true
+         | _ -> false)
+       segment
+
+let validate_repo_slug raw =
+  let slug = String.trim raw in
+  match String.split_on_char '/' slug with
+  | [ owner; repo ] when is_valid_repo_segment owner && is_valid_repo_segment repo ->
+      Ok (owner ^ "/" ^ repo)
+  | _ ->
+      Error
+        "repo must be an owner/repo slug without spaces or extra flags."
+
+let rec strip_repo_flags_from_args = function
+  | [] -> []
+  | "--repo" :: _value :: rest
+  | "-R" :: _value :: rest ->
+      strip_repo_flags_from_args rest
+  | arg :: rest when String.starts_with ~prefix:"--repo=" arg ->
+      strip_repo_flags_from_args rest
+  | arg :: rest ->
+      arg :: strip_repo_flags_from_args rest
+
+let args_have_repo_flag args =
+  List.exists
+    (fun arg -> arg = "--repo" || arg = "-R" || String.starts_with ~prefix:"--repo=" arg)
+    args
+
+let inject_repo_flag_args ~repo_slug args =
+  strip_repo_flags_from_args args @ [ "--repo"; repo_slug ]
 
 (** Cached owner/repo slug from git remote origin. *)
 let _repo_slug_cache : string option option ref = ref None
@@ -132,25 +170,51 @@ let handle_keeper_github
   let gh_raw_base =
     if cmd <> "" then cmd else if gh_args <> [] then String.concat " " gh_args else ""
   in
-  (* Structured repo parameter: if provided, inject --repo flag.
-     If not provided but cmd contains --repo/-R with wrong owner, correct it.
-     This is the root fix for LLM hallucinating repo owners (#6043). *)
-  let gh_raw =
-    if repo_param <> "" then
-      let stripped = Re.replace repo_flag_re ~f:(fun _ -> "") gh_raw_base |> String.trim in
-      Printf.sprintf "%s --repo %s" stripped repo_param
-    else
-      match project_repo_slug () with
-      | Some slug ->
-          let (corrected, _) = correct_repo_flag ~correct_slug:slug gh_raw_base in
-          corrected
-      | None -> gh_raw_base
-  in
-  if gh_raw = ""
+  let root = Keeper_alerting_path.project_root_of_config config in
+  if gh_raw_base = ""
   then error_json "cmd is required. \
                    Good: cmd='pr list --state open'. Bad: cmd=''. \
                    Single gh subcommand only, no chaining."
-  else (
+  else
+  let repo_slug =
+    if repo_param = "" then Ok None else Result.map Option.some (validate_repo_slug repo_param)
+  in
+  match repo_slug with
+  | Error reason -> error_json reason
+  | Ok repo_slug ->
+  (* Structured repo parameter: if provided, inject --repo flag.
+     If not provided but cmd contains --repo/-R with wrong owner, correct it.
+     This is the root fix for LLM hallucinating repo owners (#6043). *)
+  let gh_raw, gh_cmd =
+    match cmd <> "", repo_slug with
+    | true, Some slug ->
+        let normalized =
+          if has_repo_flag gh_raw_base then fst (correct_repo_flag ~correct_slug:slug gh_raw_base)
+          else Printf.sprintf "%s --repo %s" gh_raw_base slug
+        in
+        normalized, "gh " ^ normalized
+    | false, Some slug ->
+        let normalized_args = inject_repo_flag_args ~repo_slug:slug gh_args in
+        String.concat " " normalized_args,
+        "gh " ^ String.concat " " (List.map Filename.quote normalized_args)
+    | true, None -> (
+        match project_repo_slug () with
+        | Some slug when has_repo_flag gh_raw_base ->
+            let corrected, _ = correct_repo_flag ~correct_slug:slug gh_raw_base in
+            corrected, "gh " ^ corrected
+        | _ ->
+            gh_raw_base, "gh " ^ gh_raw_base)
+    | false, None -> (
+        match project_repo_slug () with
+        | Some slug when args_have_repo_flag gh_args ->
+            let normalized_args = inject_repo_flag_args ~repo_slug:slug gh_args in
+            String.concat " " normalized_args,
+            "gh " ^ String.concat " " (List.map Filename.quote normalized_args)
+        | _ ->
+            String.concat " " gh_args,
+            "gh " ^ String.concat " " (List.map Filename.quote gh_args))
+  in
+  (
     match Worker_dev_tools.validate_gh_command gh_raw with
     | Error reason ->
       Log.Keeper.warn "keeper_github blocked: %s (cmd=%s)" reason gh_raw;
@@ -253,10 +317,6 @@ let handle_keeper_github
                 ; "cmd", `String ("gh " ^ gh_raw)
                 ])
         | `Allowed ->
-          let gh_cmd =
-            "gh "
-            ^ (if cmd <> "" then cmd else String.concat " " (List.map Filename.quote gh_args))
-          in
           let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
           let st, raw_out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
           let out, trunc_fields = truncate_gh_output raw_out in
@@ -267,12 +327,6 @@ let handle_keeper_github
                  ; "output", `String out
                  ] @ trunc_fields @ gh_not_found_hint ~st ~out)))
       else (
-        let gh_cmd =
-          if cmd <> ""
-          then "gh " ^ cmd
-          else "gh " ^ String.concat " " (List.map Filename.quote gh_args)
-        in
-        let root = Keeper_alerting_path.project_root_of_config config in
         let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) gh_cmd in
         let st, raw_out =
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]

--- a/lib/keeper/keeper_exec_persona.ml
+++ b/lib/keeper/keeper_exec_persona.ml
@@ -23,8 +23,8 @@ let read_jsonl_rows path ~max_bytes ~max_lines : Yojson.Safe.t list =
     []
   else
     read_file_tail_lines path ~max_bytes ~max_lines
-    |> List.filter_map (fun line ->
-           try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None)
+    |> Fs_compat.parse_jsonl_lines ~source:"persona_metrics"
+    |> fst
 
 let find_jsonl_row_by_action_id rows action_id =
   rows

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -211,11 +211,10 @@ let handle_keeper_status ctx args : tool_result =
              else read_file_tail_lines metrics_path
                     ~max_bytes:tail_bytes ~max_lines:tail_turns
            in
-           `List
-             (List.filter_map
-                (fun line ->
-                  try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None)
-                lines)
+           let (parsed, _) =
+             Fs_compat.parse_jsonl_lines ~source:"keeper_metrics" lines
+           in
+           `List parsed
          in
          let metrics_window_lines =
            if include_metrics_overview then

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -19,13 +19,19 @@ let available_cascade_profiles () : string list =
   | Some path ->
     (match Yojson.Safe.from_file path with
      | `Assoc fields ->
-       "default" ::
-       (List.filter_map (fun (k, _) ->
-         if String.length k > 7
-            && String.sub k (String.length k - 7) 7 = "_models"
-         then Some (String.sub k 0 (String.length k - 7))
-         else None
-       ) fields)
+       let from_keys =
+         List.filter_map (fun (k, _) ->
+           if String.length k > 7
+              && String.sub k (String.length k - 7) 7 = "_models"
+           then Some (String.sub k 0 (String.length k - 7))
+           else None
+         ) fields
+       in
+       let with_default =
+         if List.mem "default" from_keys then from_keys
+         else "default" :: from_keys
+       in
+       List.sort_uniq String.compare with_default
      | _ -> ["default"]
      | exception Yojson.Json_error msg ->
        Log.Keeper.warn "cascade config parse error: %s" msg;

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -324,13 +324,15 @@ For read-only ops use keeper_shell, for file edits use keeper_fs_edit.";
     name = "keeper_github";
     description = "Run a single gh CLI command. \
 NO chaining (&&/||/;), NO pipes (|), NO redirects (>). \
-Good: cmd='pr list --state open'. Bad: cmd='pr list && echo done'. \
+Do NOT put --repo in cmd. Use the repo parameter instead, or omit it to use the current repo. \
+Good: cmd='pr list --state open'. Bad: cmd='pr list --repo owner/repo'. \
 Use for: issues, PRs, review comments, CI status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("cmd", `Assoc [("type", `String "string"); ("description", `String "gh subcommand string, e.g. 'issue create --title ...'")]);
         ("args", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Optional argv list for gh (without leading gh)")]);
+        ("repo", `Assoc [("type", `String "string"); ("description", `String "owner/repo slug. Omit to use the current repo from git remote. Do NOT guess.")]);
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180)")]);
       ]);
     ];

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -256,11 +256,24 @@ let handle_claim ctx args =
     | "" -> Types_core.Unassigned
     | s -> Types_core.role_of_string s
   in
+  (* Preset-fit check: same SSOT as claim_next, but soft (warn, don't block).
+     Manual claims are intentional — operator may override preset policy. *)
+  let preset_warning =
+    let agent_preset = resolve_agent_preset ctx.config ctx.agent_name in
+    let tasks = Room.get_tasks_raw ctx.config in
+    match List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks with
+    | None -> None
+    | Some task ->
+        match evaluate_preset_fit ~agent_preset ~required_preset:task.required_preset with
+        | Ok () -> None
+        | Error reason ->
+            let msg = Printf.sprintf "preset_mismatch: task %s %s" task_id reason in
+            Log.Task.warn "%s (agent=%s)" msg ctx.agent_name;
+            Some msg
+  in
   let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
-  (* Notification harness: push claim event to all active sessions *)
   (match result with
    | Ok _ ->
-       (* Auto-set current_task so planning tools pick it up immediately *)
        Planning_eio.set_current_task ctx.config ~task_id;
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_claimed");
@@ -269,7 +282,10 @@ let handle_claim ctx args =
          ("timestamp", `Float (Time_compat.now ()));
        ])
    | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
-  result_to_response result
+  let (ok, msg) = result_to_response result in
+  match preset_warning, ok with
+  | Some warning, true -> (true, msg ^ "\n⚠️ " ^ warning)
+  | _ -> (ok, msg)
 
 (** Extract preset token from capabilities (e.g., ["keeper"; "preset:delivery"]). *)
 let preset_from_capabilities caps =
@@ -314,13 +330,26 @@ let resolve_agent_preset config agent_name =
       | Eio.Cancel.Cancelled _ as e -> raise e
       | _ -> None
 
+(** Evaluate whether an agent's preset satisfies a task's requirement.
+    Returns [Ok ()] on match or no requirement, [Error reason] on mismatch.
+    SSOT for preset-fit logic — used by both claim and claim_next. *)
+let evaluate_preset_fit ~(agent_preset : string option)
+    ~(required_preset : string option) : (unit, string) result =
+  match required_preset, agent_preset with
+  | None, _ -> Ok ()
+  | Some required, None ->
+      Error (Printf.sprintf
+        "requires preset '%s' but agent has no preset" required)
+  | Some required, Some preset ->
+      if Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
+      then Ok ()
+      else Error (Printf.sprintf
+        "requires preset '%s' but agent has '%s'" required preset)
+
 (** Build a task_filter closure that checks required_preset against the agent's preset. *)
 let preset_task_filter ~agent_preset (task : Types.task) =
-  match task.required_preset, agent_preset with
-  | None, _ -> true
-  | Some _required, None -> false  (* agent without preset cannot satisfy preset requirement *)
-  | Some required, Some preset ->
-    Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
+  evaluate_preset_fit ~agent_preset ~required_preset:task.required_preset
+  |> Result.is_ok
 
 let handle_claim_next ctx _args =
   if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -329,13 +329,14 @@ let handle_claim ctx args =
         match evaluate_preset_fit ~agent_preset ~required_preset:task.required_preset with
         | Ok () -> None
         | Error reason ->
-            let msg = Printf.sprintf "preset_mismatch: task %s %s" task_id reason in
-            Log.Task.warn "%s (agent=%s)" msg ctx.agent_name;
-            Some msg
+            Some (Printf.sprintf "preset_mismatch: task %s %s" task_id reason)
   in
   let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
   (match result with
    | Ok _ ->
+       (match preset_warning with
+        | Some warning -> Log.Task.warn "%s (agent=%s)" warning ctx.agent_name
+        | None -> ());
        Planning_eio.set_current_task ctx.config ~task_id;
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_claimed");

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -720,10 +720,8 @@ let handle_task_history ctx args =
   let limit = get_int args "limit" 50 in
   let scan_limit = min 500 (limit * 5) in
   let lines = Mcp_server.read_event_lines ctx.config ~limit:scan_limit in
-  let parsed =
-    List.filter_map (fun line ->
-      try Some (Yojson.Safe.from_string line) with Yojson.Json_error _ -> None
-    ) lines
+  let (parsed, _malformed) =
+    Fs_compat.parse_jsonl_lines ~source:"task_events" lines
   in
   let matches_task json =
     let task = json |> member "task" |> to_string_option in

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -6,7 +6,7 @@
 
 open Yojson.Safe.Util
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config: Room.config;
@@ -804,7 +804,7 @@ let handle_archive_view ctx args =
 
 include Tool_task_schemas
 (* Dispatch function *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ctx args)

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -244,49 +244,6 @@ let handle_batch_add_tasks ctx args =
     in
     (true, Room.batch_add_tasks_with_contracts ctx.config tasks)
 
-let handle_claim ctx args =
-  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
-    result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
-  else
-  let task_id = get_string args "task_id" "" in
-  match validate_task_id task_id with
-  | Error e -> result_to_response (Error e)
-  | Ok task_id ->
-  let agent_role = match get_string args "agent_role" "" with
-    | "" -> Types_core.Unassigned
-    | s -> Types_core.role_of_string s
-  in
-  (* Preset-fit check: same SSOT as claim_next, but soft (warn, don't block).
-     Manual claims are intentional — operator may override preset policy. *)
-  let preset_warning =
-    let agent_preset = resolve_agent_preset ctx.config ctx.agent_name in
-    let tasks = Room.get_tasks_raw ctx.config in
-    match List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks with
-    | None -> None
-    | Some task ->
-        match evaluate_preset_fit ~agent_preset ~required_preset:task.required_preset with
-        | Ok () -> None
-        | Error reason ->
-            let msg = Printf.sprintf "preset_mismatch: task %s %s" task_id reason in
-            Log.Task.warn "%s (agent=%s)" msg ctx.agent_name;
-            Some msg
-  in
-  let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
-  (match result with
-   | Ok _ ->
-       Planning_eio.set_current_task ctx.config ~task_id;
-       Subscriptions.push_event_to_sessions (`Assoc [
-         ("type", `String "masc/task_claimed");
-         ("task_id", `String task_id);
-         ("agent_name", `String ctx.agent_name);
-         ("timestamp", `Float (Time_compat.now ()));
-       ])
-   | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
-  let (ok, msg) = result_to_response result in
-  match preset_warning, ok with
-  | Some warning, true -> (true, msg ^ "\n⚠️ " ^ warning)
-  | _ -> (ok, msg)
-
 (** Extract preset token from capabilities (e.g., ["keeper"; "preset:delivery"]). *)
 let preset_from_capabilities caps =
   List.find_map
@@ -350,6 +307,47 @@ let evaluate_preset_fit ~(agent_preset : string option)
 let preset_task_filter ~agent_preset (task : Types.task) =
   evaluate_preset_fit ~agent_preset ~required_preset:task.required_preset
   |> Result.is_ok
+
+let handle_claim ctx args =
+  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
+    result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
+  else
+  let task_id = get_string args "task_id" "" in
+  match validate_task_id task_id with
+  | Error e -> result_to_response (Error e)
+  | Ok task_id ->
+  let agent_role = match get_string args "agent_role" "" with
+    | "" -> Types_core.Unassigned
+    | s -> Types_core.role_of_string s
+  in
+  let preset_warning =
+    let agent_preset = resolve_agent_preset ctx.config ctx.agent_name in
+    let tasks = Room.get_tasks_raw ctx.config in
+    match List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks with
+    | None -> None
+    | Some task ->
+        match evaluate_preset_fit ~agent_preset ~required_preset:task.required_preset with
+        | Ok () -> None
+        | Error reason ->
+            let msg = Printf.sprintf "preset_mismatch: task %s %s" task_id reason in
+            Log.Task.warn "%s (agent=%s)" msg ctx.agent_name;
+            Some msg
+  in
+  let result = Room.claim_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~agent_role () in
+  (match result with
+   | Ok _ ->
+       Planning_eio.set_current_task ctx.config ~task_id;
+       Subscriptions.push_event_to_sessions (`Assoc [
+         ("type", `String "masc/task_claimed");
+         ("task_id", `String task_id);
+         ("agent_name", `String ctx.agent_name);
+         ("timestamp", `Float (Time_compat.now ()));
+       ])
+   | Error e -> Log.Task.debug "task claim failed for %s: %s" task_id (Types.masc_error_to_string e));
+  let (ok, msg) = result_to_response result in
+  match preset_warning, ok with
+  | Some warning, true -> (true, msg ^ "\n⚠️ " ^ warning)
+  | _ -> (ok, msg)
 
 let handle_claim_next ctx _args =
   if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -1,6 +1,6 @@
 (** Tool_task - Core task CRUD operations *)
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config: Room.config;
@@ -8,19 +8,19 @@ type context = {
   sw: Eio.Switch.t option;
 }
 
-val handle_add_task : context -> Yojson.Safe.t -> result
-val handle_batch_add_tasks : context -> Yojson.Safe.t -> result
-val handle_claim : context -> Yojson.Safe.t -> result
-val handle_claim_next : context -> Yojson.Safe.t -> result
-val handle_release : context -> Yojson.Safe.t -> result
-val handle_done : context -> Yojson.Safe.t -> result
-val handle_cancel_task : context -> Yojson.Safe.t -> result
-val handle_transition : context -> Yojson.Safe.t -> result
-val handle_update_priority : context -> Yojson.Safe.t -> result
-val handle_tasks : context -> Yojson.Safe.t -> result
-val handle_task_history : context -> Yojson.Safe.t -> result
-val handle_archive_view : context -> Yojson.Safe.t -> result
+val handle_add_task : context -> Yojson.Safe.t -> tool_result
+val handle_batch_add_tasks : context -> Yojson.Safe.t -> tool_result
+val handle_claim : context -> Yojson.Safe.t -> tool_result
+val handle_claim_next : context -> Yojson.Safe.t -> tool_result
+val handle_release : context -> Yojson.Safe.t -> tool_result
+val handle_done : context -> Yojson.Safe.t -> tool_result
+val handle_cancel_task : context -> Yojson.Safe.t -> tool_result
+val handle_transition : context -> Yojson.Safe.t -> tool_result
+val handle_update_priority : context -> Yojson.Safe.t -> tool_result
+val handle_tasks : context -> Yojson.Safe.t -> tool_result
+val handle_task_history : context -> Yojson.Safe.t -> tool_result
+val handle_archive_view : context -> Yojson.Safe.t -> tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val schemas : Types.tool_schema list

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -299,6 +299,62 @@ let () = test "handle_claim_sets_planning_current_task" (fun () ->
   assert (Planning_eio.get_current_task ctx.config = Some "task-001")
 )
 
+let () = test "handle_claim_appends_preset_warning_only_on_success" (fun () ->
+  let agent_name = "test-agent" in
+  let ctx = make_test_ctx_with_agent agent_name in
+  let base_path = Masc_test_deps.find_project_root () in
+  ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path));
+  (match
+     Room.update_agent_r ctx.config ~agent_name
+       ~capabilities:[ "preset:minimal" ] ()
+   with
+  | Ok _ -> ()
+  | Error e -> failwith (Types.masc_error_to_string e));
+  let _ =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Needs social");
+          ("required_preset", `String "social");
+        ])
+  in
+  let success, result =
+    Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  assert success;
+  assert (str_contains result "preset_mismatch")
+)
+
+let () = test "handle_claim_skips_preset_warning_on_failed_claim" (fun () ->
+  let agent_name = "test-agent" in
+  let ctx = make_test_ctx_with_agent agent_name in
+  let base_path = Masc_test_deps.find_project_root () in
+  ignore (Result.get_ok (Keeper_tool_policy.init_policy_config ~base_path));
+  (match
+     Room.update_agent_r ctx.config ~agent_name
+       ~capabilities:[ "preset:minimal" ] ()
+   with
+  | Ok _ -> ()
+  | Error e -> failwith (Types.masc_error_to_string e));
+  let _ =
+    Tool_task.handle_add_task ctx
+      (`Assoc
+        [
+          ("title", `String "Needs social");
+          ("required_preset", `String "social");
+        ])
+  in
+  let _ = Room.join ctx.config ~agent_name:"other-agent" ~capabilities:[] () in
+  (match Room.claim_task_r ctx.config ~agent_name:"other-agent" ~task_id:"task-001" () with
+  | Ok _ -> ()
+  | Error e -> failwith (Types.masc_error_to_string e));
+  let success, result =
+    Tool_task.handle_claim ctx (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  assert (not success);
+  assert (not (str_contains result "preset_mismatch"))
+)
+
 let () = test "handle_claim_next_sets_planning_current_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Claim next")]) in


### PR DESCRIPTION
## Summary

이전 밴드에이드 PR 3개(#6444, #6445, #6447)의 근본 원인 수정 + cascade 중복 fix.

### Commit 1: JSONL 파싱 중앙화
- `Fs_compat.load_jsonl_diagnostics`: 파일 기반, malformed count 반환
- `Fs_compat.parse_jsonl_lines`: 줄 리스트 기반, source 태그 포함
- 산포된 3곳의 인라인 패턴을 SSOT API 호출로 교체

### Commit 2: keeper_github repo 구조화
- `repo` 파라미터를 tool schema에 추가 (Parse Don't Validate)
- cmd string의 --repo 대신 구조화된 필드로 전달

### Commit 3: preset-fit 검증 통합
- `evaluate_preset_fit`: `(unit, string) result` 반환하는 SSOT
- `type result` → `type tool_result`로 rename, Stdlib.result 해방

### Commit 4: handle_claim 정의 순서 수정
- OCaml 순차 정의 요구사항 충족

### Commit 5: result type shadow 수정
- `type result = bool * string` → `type tool_result`

### Commit 6: cascade profile 중복 제거
- `available_cascade_profiles()`: 중복 "default" 제거, sort_uniq 적용

## Design Principle

**밴드에이드 → 근본 수정 기준:**
1. 같은 패턴 2곳+ → 공통 모듈 (JSONL)
2. 문자열 파싱으로 구조화 흉내 → 타입/스키마 분리 (repo param)
3. 같은 판단 반복 → 단일 함수 + 해석 분리 (preset)
4. 이름 충돌로 타입 사용 불가 → 이름 변경 (result shadow)

## Test plan

- [x] `dune build` 통과 (clean build)
- [x] `dune clean && dune build` 통과
- [ ] CI Lint 통과 대기

Supersedes: #6444, #6445, #6447
Closes: #6296 (root), #6043 (root), #6089 (root)
Partially addresses: #6165 (item 1 — cascade profile dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)