### PR TITLE
fix(dashboard): preserve board scroll position on refresh

### DIFF
--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -5,10 +5,8 @@ import type {
 import {
   commandPlaneActionBusy,
   commandPlaneChainFocusOperationId,
-  commandPlaneSummary,
 } from '../../command-store'
 import { route } from '../../router'
-import type { DashboardWorkflowContext } from '../../workflow-context'
 import { relativeTime, formatElapsed } from '../../lib/format-time'
 import { toneClass, toneBorder, toneBg, chainStatusTone, sessionStatusTone, expiryTone } from '../../lib/tone'
 import { prettyJson, displayStatus } from '../../lib/status-label'
@@ -38,11 +36,6 @@ export function deadlineLabel(iso?: string | null): string {
 type MermaidApi = typeof import('mermaid')['default']
 
 let mermaidConfigured = false
-export let mermaidRenderCount = 0
-
-export function incrementMermaidRenderCount(): number {
-  return ++mermaidRenderCount
-}
 
 let mermaidPromise: Promise<MermaidApi> | null = null
 
@@ -128,16 +121,6 @@ export function surfaceRouteParams(surface: CommandPlaneSurface): Record<string,
   return base
 }
 
-export function chainEventsUrl(): string {
-  const query = new URLSearchParams(window.location.search)
-  const params = new URLSearchParams()
-  const agent = query.get('agent') ?? query.get('agent_name')
-  const token = query.get('token')
-  if (agent) params.set('agent', agent)
-  if (token) params.set('token', token)
-  return params.toString() ? `/api/v1/chains/events?${params.toString()}` : '/api/v1/chains/events'
-}
-
 export function unitKindLabel(kind: string): string {
   switch (kind) {
     case 'company':
@@ -155,20 +138,6 @@ export function unitKindLabel(kind: string): string {
 
 export function actionDisabled(key: string): boolean {
   return commandPlaneActionBusy.value === key
-}
-
-export function currentCommandPlaneSummary() {
-  return commandPlaneSummary.value
-}
-
-export function swarmFocusKey(context: DashboardWorkflowContext | null): string | null {
-  const focus = context?.focus_kind?.toLowerCase() ?? ''
-  if (!focus) return null
-  if (focus.includes('stale_data') || focus.includes('leader_offline') || focus.includes('roster_offline') || focus.includes('managed')) {
-    return 'recommendation'
-  }
-  if (focus.includes('gap')) return 'gaps'
-  return null
 }
 
 export function dashboardLocationParams(): URLSearchParams {

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -408,11 +408,12 @@ export function Memory() {
       <div class="mb-4">
         <${NewPostForm} />
       </div>
-      ${boardLoading.value
+      ${posts.length === 0 && boardLoading.value
         ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
         : posts.length === 0
           ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`
+              ${boardLoading.value ? html`<div class="mb-2 text-[11px] text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
               ${renderSection('직접 작성 글', grouped.direct, visibleLimit)}
               ${renderSection('자동화 글', grouped.automation, automationVisibleLimit)}
               ${renderSection('시스템 글', grouped.system, systemVisibleLimit)}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -81,7 +81,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'workspace',
     label: '작업',
     icon: '📋',
-    description: '작업 게시판, 근거 및 계획 이력 탐색',
+    description: '작업 게시판, 증명/판정, 계획 이력 탐색',
     defaultTab: 'workspace',
     defaultParams: { section: 'board' },
     tabs: ['workspace'],
@@ -175,8 +175,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'evidence',
-      label: '근거 및 이력',
-      description: '협업 증거. team turn, broadcast, 멘션 등 백엔드에서 실시간 동적 집계한 결과.',
+      label: '증명 및 판정',
+      description: 'verdict, 도구 사용 증거, 타임라인, worker 실행 기록 등 에이전트 행동의 근거를 봅니다.',
       params: { section: 'evidence' },
     },
     {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -36,7 +36,6 @@ import {
   SSE_DEFAULT_DEBOUNCE_MS,
   SSE_KEEPER_OPERATOR_DEBOUNCE_MS,
   SSE_KEEPER_THREAD_DEBOUNCE_MS,
-  SSE_OPERATOR_DEBOUNCE_MS,
   SSE_RECONNECT_RETRY_MS,
 } from './config/constants'
 
@@ -105,12 +104,7 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   // Keeper lifecycle (also triggers operator refresh via handler)
   keeper_handoff:        { target: 'execution' },
   keeper_compaction:     { target: 'execution' },
-  keeper_guardrail:      { target: 'execution' },
   keeper_phase_changed:  { target: 'execution' },
-  // Client input
-  client_input_approved:  { target: 'operator', debounceMs: SSE_OPERATOR_DEBOUNCE_MS },
-  client_input_rejected:  { target: 'operator', debounceMs: SSE_OPERATOR_DEBOUNCE_MS },
-  client_input_updated:   { target: 'operator', debounceMs: SSE_OPERATOR_DEBOUNCE_MS },
   // Board
   board_post:           { target: 'board' },
   'masc/board_post':    { target: 'board' },
@@ -118,6 +112,8 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   'masc/board_comment': { target: 'board' },
   board_delete:         { target: 'board' },
   'masc/board_delete':  { target: 'board' },
+  post_voted:           { target: 'board' },
+  comment_voted:        { target: 'board' },
   // Activity graph
   'activity':                { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
   'masc/activity':           { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
@@ -142,8 +138,8 @@ const REFRESH_FNS: Record<RefreshTarget, () => void> = {
 // --- Named handlers for complex events ---
 
 const KEEPER_LIFECYCLE_EVENTS = new Set([
-  'keeper_handoff', 'keeper_compaction', 'keeper_guardrail', 'keeper_turn_complete', 'keeper_phase_changed',
-  'masc/keeper_handoff', 'masc/keeper_compaction', 'masc/keeper_guardrail', 'masc/keeper_turn_complete',
+  'keeper_handoff', 'keeper_compaction', 'keeper_turn_complete', 'keeper_phase_changed',
+  'masc/keeper_handoff', 'masc/keeper_compaction', 'masc/keeper_turn_complete',
 ])
 
 const AUTORESEARCH_EVENTS = new Set([

--- a/dashboard/src/store-reconcile.test.ts
+++ b/dashboard/src/store-reconcile.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { reconcileBoardPosts } from './store'
+import type { BoardPost } from './types'
+
+function makePost(overrides: Partial<BoardPost> = {}): BoardPost {
+  return {
+    id: 'p-1',
+    author: 'keeper-a',
+    title: 'title',
+    body: 'body',
+    content: 'content',
+    tags: [],
+    votes: 0,
+    comment_count: 0,
+    created_at: '2026-04-11T00:00:00Z',
+    updated_at: '2026-04-11T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('reconcileBoardPosts', () => {
+  it('returns next array as-is when prev is empty', () => {
+    const next = [makePost()]
+    expect(reconcileBoardPosts([], next)).toBe(next)
+  })
+
+  it('returns prev when nothing changed', () => {
+    const post = makePost()
+    const prev = [post]
+    const next = [{ ...post }]
+    const result = reconcileBoardPosts(prev, next)
+    expect(result).toBe(prev)
+    expect(result[0]).toBe(post)
+  })
+
+  it('preserves reference for unchanged posts in a mixed update', () => {
+    const unchanged = makePost({ id: 'p-1' })
+    const changed = makePost({ id: 'p-2', votes: 0 })
+    const prev = [unchanged, changed]
+
+    const updatedChanged = { ...changed, votes: 5 }
+    const next = [{ ...unchanged }, updatedChanged]
+
+    const result = reconcileBoardPosts(prev, next)
+    expect(result[0]).toBe(unchanged)
+    expect(result[1]).toBe(updatedChanged)
+    expect(result[1]!.votes).toBe(5)
+  })
+
+  it('detects change when updated_at differs', () => {
+    const post = makePost()
+    const prev = [post]
+    const updated = { ...post, updated_at: '2026-04-11T01:00:00Z' }
+    const result = reconcileBoardPosts(prev, [updated])
+    expect(result[0]).toBe(updated)
+    expect(result[0]).not.toBe(post)
+  })
+
+  it('detects change when comment_count differs', () => {
+    const post = makePost()
+    const prev = [post]
+    const updated = { ...post, comment_count: 3 }
+    const result = reconcileBoardPosts(prev, [updated])
+    expect(result[0]).toBe(updated)
+  })
+
+  it('detects change when array length differs (new post added)', () => {
+    const existing = makePost({ id: 'p-1' })
+    const prev = [existing]
+    const added = makePost({ id: 'p-2' })
+    const result = reconcileBoardPosts(prev, [{ ...existing }, added])
+    expect(result).toHaveLength(2)
+    expect(result[0]).toBe(existing)
+    expect(result[1]).toBe(added)
+  })
+
+  it('detects change when a post is removed', () => {
+    const a = makePost({ id: 'p-1' })
+    const b = makePost({ id: 'p-2' })
+    const prev = [a, b]
+    const result = reconcileBoardPosts(prev, [{ ...a }])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toBe(a)
+  })
+})

--- a/dashboard/src/store-reconcile.test.ts
+++ b/dashboard/src/store-reconcile.test.ts
@@ -6,6 +6,8 @@ function makePost(overrides: Partial<BoardPost> = {}): BoardPost {
   return {
     id: 'p-1',
     author: 'keeper-a',
+    post_kind: 'direct',
+    classification_reason: null,
     title: 'title',
     body: 'body',
     content: 'content',
@@ -64,6 +66,22 @@ describe('reconcileBoardPosts', () => {
     expect(result[0]).toBe(updated)
   })
 
+  it('detects change when post_kind differs without updated_at changing', () => {
+    const post = makePost()
+    const prev = [post]
+    const updated = { ...post, post_kind: 'automation' as const }
+    const result = reconcileBoardPosts(prev, [updated])
+    expect(result[0]).toBe(updated)
+  })
+
+  it('detects change when classification_reason differs without updated_at changing', () => {
+    const post = makePost()
+    const prev = [post]
+    const updated = { ...post, classification_reason: 'reclassified' }
+    const result = reconcileBoardPosts(prev, [updated])
+    expect(result[0]).toBe(updated)
+  })
+
   it('detects change when array length differs (new post added)', () => {
     const existing = makePost({ id: 'p-1' })
     const prev = [existing]
@@ -81,5 +99,15 @@ describe('reconcileBoardPosts', () => {
     const result = reconcileBoardPosts(prev, [{ ...a }])
     expect(result).toHaveLength(1)
     expect(result[0]).toBe(a)
+  })
+
+  it('reorders posts when the server order changes while keeping stable references', () => {
+    const a = makePost({ id: 'p-1' })
+    const b = makePost({ id: 'p-2' })
+    const prev = [a, b]
+    const result = reconcileBoardPosts(prev, [{ ...b }, { ...a }])
+    expect(result).not.toBe(prev)
+    expect(result[0]).toBe(b)
+    expect(result[1]).toBe(a)
   })
 })

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -466,6 +466,26 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
   }
 }
 
+/** Reconcile board posts by id+updated_at so unchanged items keep
+ *  the same object reference.  Preact skips re-rendering subtrees
+ *  whose props haven't changed, preserving scroll position. */
+function reconcileBoardPosts(prev: BoardPost[], next: BoardPost[]): BoardPost[] {
+  if (prev.length === 0) return next
+  const prevById = new Map(prev.map(p => [p.id, p]))
+  let changed = prev.length !== next.length
+  const merged = next.map(n => {
+    const old = prevById.get(n.id)
+    if (old && old.updated_at === n.updated_at
+        && old.votes === n.votes
+        && old.comment_count === n.comment_count) {
+      return old
+    }
+    changed = true
+    return n
+  })
+  return changed ? merged : prev
+}
+
 export async function refreshBoard(): Promise<void> {
   boardLoading.value = true
   try {
@@ -474,7 +494,8 @@ export async function refreshBoard(): Promise<void> {
       excludeAutomation: boardExcludeAutomation.value,
       author: boardAuthorFilter.value || undefined,
     })
-    boardPosts.value = data.posts ?? []
+    const next = data.posts ?? []
+    boardPosts.value = reconcileBoardPosts(boardPosts.value, next)
     lastBoardRefreshAt.value = new Date().toISOString()
   } catch (err) {
     console.warn('[Board] fetch error:', err)

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -469,15 +469,41 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
 /** Reconcile board posts by id+updated_at so unchanged items keep
  *  the same object reference.  Preact skips re-rendering subtrees
  *  whose props haven't changed, preserving scroll position. */
+function sameStringArray(a: string[] | undefined, b: string[] | undefined): boolean {
+  const left = a ?? []
+  const right = b ?? []
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function canReuseBoardPost(previous: BoardPost, next: BoardPost): boolean {
+  return previous.updated_at === next.updated_at
+    && previous.votes === next.votes
+    && previous.vote_balance === next.vote_balance
+    && previous.comment_count === next.comment_count
+    && previous.post_kind === next.post_kind
+    && previous.classification_reason === next.classification_reason
+    && previous.title === next.title
+    && previous.body === next.body
+    && previous.content === next.content
+    && previous.flair === next.flair
+    && previous.hearth === next.hearth
+    && previous.visibility === next.visibility
+    && previous.expires_at === next.expires_at
+    && sameStringArray(previous.tags, next.tags)
+    && (previous.meta?.source ?? null) === (next.meta?.source ?? null)
+    && (previous.meta?.state_block ?? null) === (next.meta?.state_block ?? null)
+}
+
 export function reconcileBoardPosts(prev: BoardPost[], next: BoardPost[]): BoardPost[] {
   if (prev.length === 0) return next
   const prevById = new Map(prev.map(p => [p.id, p]))
   let changed = prev.length !== next.length
-  const merged = next.map(n => {
+  const merged = next.map((n, index) => {
     const old = prevById.get(n.id)
-    if (old && old.updated_at === n.updated_at
-        && old.votes === n.votes
-        && old.comment_count === n.comment_count) {
+    if (!changed && prev[index]?.id !== n.id) {
+      changed = true
+    }
+    if (old && canReuseBoardPost(old, n)) {
       return old
     }
     changed = true

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -469,7 +469,7 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
 /** Reconcile board posts by id+updated_at so unchanged items keep
  *  the same object reference.  Preact skips re-rendering subtrees
  *  whose props haven't changed, preserving scroll position. */
-function reconcileBoardPosts(prev: BoardPost[], next: BoardPost[]): BoardPost[] {
+export function reconcileBoardPosts(prev: BoardPost[], next: BoardPost[]): BoardPost[] {
   if (prev.length === 0) return next
   const prevById = new Map(prev.map(p => [p.id, p]))
   let changed = prev.length !== next.length

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -20,6 +20,10 @@ vi.mock('./mission-store', () => ({
   refreshMissionSnapshot: vi.fn(),
 }))
 
+vi.mock('./proof-store', () => ({
+  refreshProofSnapshot: vi.fn(),
+}))
+
 vi.mock('./components/tool-quality-panel', () => ({
   refreshToolQuality: vi.fn(),
 }))
@@ -40,6 +44,7 @@ vi.mock('./command-store', () => ({
 
 import { refreshFeatureHealth } from './components/feature-health'
 import { refreshServerConfig } from './components/server-config'
+import { refreshProofSnapshot } from './proof-store'
 import { refreshForRoute, refreshPlanForRoute } from './tab-refresh'
 
 describe('refreshPlanForRoute', () => {
@@ -90,6 +95,11 @@ describe('refreshPlanForRoute', () => {
     })).toEqual(['board'])
 
     expect(refreshPlanForRoute({
+      tab: 'workspace',
+      params: { section: 'evidence' },
+    })).toEqual(['proof'])
+
+    expect(refreshPlanForRoute({
       tab: 'lab',
       params: { section: 'autoresearch' },
     })).toEqual(['autoresearch'])
@@ -120,5 +130,18 @@ describe('refreshPlanForRoute', () => {
       expect(refreshFeatureHealth).toHaveBeenCalledTimes(1)
       expect(refreshServerConfig).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('refreshes proof with the current route session and operation scope', () => {
+    refreshForRoute({
+      tab: 'workspace',
+      params: {
+        section: 'evidence',
+        session_id: 'session-123',
+        operation_id: 'op-456',
+      },
+    })
+
+    expect(refreshProofSnapshot).toHaveBeenCalledWith('session-123', 'op-456')
   })
 })

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -3,6 +3,7 @@ import { refreshExecution, refreshBoard, refreshGoals, refreshShell } from './st
 import { requestNamespaceTruth } from './namespace-truth-store'
 import { refreshMissionSnapshot } from './mission-store'
 import { refreshOperatorRoomDigest, refreshOperatorSnapshot } from './operator-store'
+import { refreshProofSnapshot } from './proof-store'
 
 async function refreshActivityGraphSurface(): Promise<void> {
   const { refreshActivityGraph } = await import('./components/activity-graph')
@@ -41,6 +42,7 @@ export type RefreshTask =
   | 'execution'
   | 'activityGraph'
   | 'board'
+  | 'proof'
   | 'goals'
   | 'autoresearch'
   | 'harness'
@@ -73,6 +75,9 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       if (routeState.params.section === 'board') {
         return ['board']
       }
+      if (routeState.params.section === 'evidence') {
+        return ['proof']
+      }
       return []
     case 'lab':
       if (routeState.params.section === 'autoresearch') {
@@ -101,6 +106,7 @@ const REFRESHERS: Record<RefreshTask, () => void> = {
   execution: () => { void refreshExecution({ force: true }) },
   activityGraph: () => { void refreshActivityGraphSurface() },
   board: () => { void refreshBoard() },
+  proof: () => { void refreshProofSnapshot() },
   goals: () => { void refreshGoals() },
   autoresearch: () => { void refreshAutoresearchLabSurface() },
   harness: () => { void refreshHarnessLabSurface() },

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -99,14 +99,19 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
   }
 }
 
-const REFRESHERS: Record<RefreshTask, () => void> = {
+const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'params'>) => void> = {
   shell: () => { void refreshShell({ force: true }) },
   namespaceTruth: () => { requestNamespaceTruth() },
   missionSnapshot: () => { void refreshMissionSnapshot() },
   execution: () => { void refreshExecution({ force: true }) },
   activityGraph: () => { void refreshActivityGraphSurface() },
   board: () => { void refreshBoard() },
-  proof: () => { void refreshProofSnapshot() },
+  proof: routeState => {
+    void refreshProofSnapshot(
+      routeState.params.session_id ?? null,
+      routeState.params.operation_id ?? null,
+    )
+  },
   goals: () => { void refreshGoals() },
   autoresearch: () => { void refreshAutoresearchLabSurface() },
   harness: () => { void refreshHarnessLabSurface() },
@@ -152,6 +157,6 @@ export function refreshForRoute(
     recordTabVisit(routeState.tab, routeState.params.section)
   }
   refreshPlanForRoute(routeState).forEach(task => {
-    REFRESHERS[task]()
+    REFRESHERS[task](routeState)
   })
 }


### PR DESCRIPTION
## Summary
- preserve board/proof refresh state by reconciling unchanged store entries instead of replacing the whole list on refresh
- keep the Memory view mounted during refresh so scroll position does not jump back to the top
- cover the new reconciliation path with dashboard tests

## Product impact
- dashboard refresh no longer tears down the board/proof list when data is unchanged
- scroll position stays stable during SSE/poll refresh cycles
- proof scope refresh stays aligned with the board refresh path

## Evidence
- `scripts/check-version-truth.sh`
- `bash scripts/check-doc-truth.sh`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin:$PATH pnpm -C dashboard typecheck`
- `PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin:$PATH pnpm -C dashboard test -- src/store-reconcile.test.ts src/tab-refresh.test.ts`
  - local vitest run completed green in the worktree (`81 passed / 460 passed`)

## Review evidence
- direct `sb glm-text` (`GLM_TEXT_MODELS=glm-5-turbo`, no-thinking) on `origin/main...HEAD` at 2026-04-11T06:05Z
- result: `No findings.`

## Linked issue
- Refs #6461