### PR TITLE
fix(board): log vote/vote_comment errors instead of silent drop

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -388,7 +388,10 @@ let vote ~voter ~post_id ~direction =
    | Ok _score ->
        emit_board_sse_event
          (Post_voted { post_id; voter; direction })
-   | Error _ -> ());
+   | Error e ->
+       Log.BoardLog.warn
+         "board vote failed: post_id=%s voter=%s: %s"
+         post_id voter (Board_types.show_board_error e));
   result
 
 let vote_comment ~voter ~comment_id ~direction =
@@ -400,7 +403,10 @@ let vote_comment ~voter ~comment_id ~direction =
    | Ok _score ->
        emit_board_sse_event
          (Comment_voted { comment_id; voter; direction })
-   | Error _ -> ());
+   | Error e ->
+       Log.BoardLog.warn
+         "board vote_comment failed: comment_id=%s voter=%s: %s"
+         comment_id voter (Board_types.show_board_error e));
   result
 
 let stats () =


### PR DESCRIPTION
## 배경

OCaml audit sweep (시작 2026-04-11) 1차 이터레이션.  
`lib/board_dispatch.ml` 에서 `vote`/`vote_comment` 의 `Error` 브랜치가 완전히 조용히 소실되고 있었습니다. SSE event 도 없고, 로그도 없어서 Postgres/JSONL 백엔드가 vote 를 거절할 때 조사 단서가 전혀 남지 않습니다.

## 변경

같은 파일의 line 355 / 376 에서 이미 `get_post` 실패를 `Log.BoardLog.warn ... (Board_types.show_board_error e)` 패턴으로 기록 중이라 동일 포맷으로 정렬했습니다.

\`\`\`ocaml
| Error e ->
    Log.BoardLog.warn
      "board vote failed: post_id=%s voter=%s: %s"
      post_id voter (Board_types.show_board_error e));
\`\`\`

## 영향

- Happy path: 무변경
- Error: 원래 `result`가 그대로 caller 로 전파되므로 외부 계약 유지, 추가된 것은 **로그 한 줄** 뿐
- Runtime assertion / exception 변경 없음

## 검증

- \`dune build --root . lib/\` → exit 0

## 후속 (audit sweep 연속 PR)

이 PR 은 audit sweep 의 첫 chunk 입니다. 같은 sweep 에서 다음 항목이 별도 PR 로 옵니다:
- \`lib/keeper/keeper_types.ml:802,807\` — \`failwith\` → Result 리팩터 (parse_keeper_identity)
- \`Stdlib.Mutex\` 17건 Eio context boundary 재검증 (heuristic_metrics / agent_stress 는 문서화된 정당 사용)
- telemetry/로깅 정합성 audit
- SSOT drift 탐지