### PR TITLE
fix(keeper): SSOT playground paths — drop hardcoded masc-mcp and container root

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -6,9 +6,9 @@ category: keeper
 ## Rules (violating these wastes your turn budget)
 
 Before any file or path operation, follow this order:
-1. Call keeper_context_status to learn your keeper name.
-2. Use that name to construct paths: .masc/playground/{your-name}/
-3. Call keeper_shell op=ls on the path to verify it exists.
+1. Call keeper_context_status. The response gives you `name` plus three ready-made relative paths — `playground_bundle`, `playground_mind`, `playground_repos`. Prefer these over reconstructing `.masc/playground/<name>/...` strings yourself.
+2. If you need a subpath (e.g. a specific repo), append to `playground_repos` — e.g. `<playground_repos>/<repo-name>/<file>`.
+3. Call keeper_shell op=ls on the path to verify it exists before reading/writing.
 4. Then proceed with the file operation.
 
 NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs` — do not invent repos outside that list.
@@ -40,7 +40,7 @@ File operations:
 Workspace:
 - Your writable workspace is `.masc/playground/YOUR_KEEPER_NAME/`. Use keeper_fs_edit to write files there.
 - The playground bundle has three canonical subdirs: `mind/` (notes and scratch), `repos/` (cloned repos for coding), and the bundle root itself for general work.
-- Your clones live under `.masc/playground/YOUR_KEEPER_NAME/repos/<REPO_NAME>/` — use `keeper_shell op=ls path=.masc/playground/YOUR_KEEPER_NAME/repos/` to see which clones you currently have.
+- Your clones live under `.masc/playground/YOUR_KEEPER_NAME/repos/<REPO_NAME>/` — this is your default coding workspace. Use `keeper_shell op=ls path=.masc/playground/YOUR_KEEPER_NAME/repos/` to see which clones you currently have.
 - If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
 - playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` picks the first git clone under your playground `repos/` (alphabetical); if none, it falls back to the server's repo root.
 - Default to the playground clone. If no clone exists, create one first, then open a worktree.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -11,7 +11,7 @@ Before any file or path operation, follow this order:
 3. Call keeper_shell op=ls on the path to verify it exists.
 4. Then proceed with the file operation.
 
-NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The ONLY repo is jeong-sik/masc-mcp.
+NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs` — do not invent repos outside that list.
 NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call. Split into separate calls.
 NEVER request files without verifying they exist via keeper_shell op=ls.
 When a tool call fails, read the error message carefully. Do not retry with the same arguments.
@@ -38,14 +38,16 @@ File operations:
 - GitHub CLI: keeper_github with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
 
 Workspace:
-- Your writable workspace is .masc/playground/YOUR_KEEPER_NAME/. Use keeper_fs_edit to write files there.
-- Your playground clone is at .masc/playground/YOUR_KEEPER_NAME/repos/masc-mcp/. This is your default coding workspace.
-- playground is your sandbox; worktree is a repo workflow path for isolated branch-based changes.
-- Default to the playground clone. If that clone is missing, repo worktrees are the fallback workflow.
+- Your writable workspace is `.masc/playground/YOUR_KEEPER_NAME/`. Use keeper_fs_edit to write files there.
+- The playground bundle has three canonical subdirs: `mind/` (notes and scratch), `repos/` (cloned repos for coding), and the bundle root itself for general work.
+- Your clones live under `.masc/playground/YOUR_KEEPER_NAME/repos/<REPO_NAME>/` — use `keeper_shell op=ls path=.masc/playground/YOUR_KEEPER_NAME/repos/` to see which clones you currently have.
+- If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
+- playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` picks the first git clone under your playground `repos/` (alphabetical); if none, it falls back to the server's repo root.
+- Default to the playground clone. If no clone exists, create one first, then open a worktree.
 - `keeper_pr_submit` is the canonical submit step after editing.
 - `keeper_pr_workflow` is a legacy one-shot worktree helper. Prefer `keeper_pr_submit`.
 - PR creation workflow (requires Coding, Delivery, or Full preset):
-  1. masc_worktree_create task_id=<your-task-id>  (creates worktree in your playground clone)
+  1. masc_worktree_create task_id=<your-task-id>  (creates worktree under the playground clone that `repos/` resolves to)
   2. masc_code_read path=<file-to-modify>  (read the file first — understand before editing)
   3. masc_code_edit path=<path> old_string=<before> new_string=<after>  (edit the file)
   4. masc_code_git action=add cwd=<worktree-path>  (stage changes)

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -44,6 +44,7 @@ Workspace:
 - If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
 - playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` picks the first git clone under your playground `repos/` (alphabetical); if none, it falls back to the server's repo root.
 - Default to the playground clone. If no clone exists, create one first, then open a worktree.
+- If you have multiple clones and want to target a specific one, pass `repo_name=<clone-dir-name>` to `masc_worktree_create`. Example: `repo_name='masc-mcp'` when your repos/ has both `masc-mcp/` and `kirin/`.
 - `keeper_pr_submit` is the canonical submit step after editing.
 - `keeper_pr_workflow` is a legacy one-shot worktree helper. Prefer `keeper_pr_submit`.
 - PR creation workflow (requires Coding, Delivery, or Full preset):

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -6,9 +6,11 @@ category: keeper
 ## Paths and Identity
 
 Call keeper_context_status to learn your keeper name. Then use it in paths below.
-Playground is your default sandbox: `.masc/playground/{your-name}/`
-Cloned repos go to: `.masc/playground/{your-name}/repos/masc-mcp/`
-Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`. Use them only when a worktree tool or workflow gives you that path explicitly.
+Playground is your default sandbox, relative to the server `base_path`:
+- `.masc/playground/{your-name}/` — bundle root (general workspace)
+- `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
+- `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
+Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), so make sure you have cloned the target repo before creating a worktree.
 
 WRONG paths (these do not exist, never use them):
 - `/repos/...`
@@ -18,8 +20,8 @@ WRONG paths (these do not exist, never use them):
 
 ## Project
 
-- GitHub repository: jeong-sik/masc-mcp (this is the ONLY repo — do not guess other org/repo names)
-- To clone the project: keeper_shell with op=git_clone, url=https://github.com/jeong-sik/masc-mcp
+- Primary GitHub repository: jeong-sik/masc-mcp. Additional repos may be allowed via `config/tool_policy.toml` under `[git_clone] allowed_orgs` — never invent an org/repo outside that list.
+- To clone the primary project: keeper_shell with op=git_clone, url=https://github.com/jeong-sik/masc-mcp
 - To check open PRs: keeper_github with cmd="pr list --repo jeong-sik/masc-mcp"
 - To check issues: keeper_github with cmd="issue list --repo jeong-sik/masc-mcp"
 

--- a/lib/config/dune
+++ b/lib/config/dune
@@ -12,6 +12,7 @@
    env_config_snapshot
    feature_flag_registry
    masc_network_defaults
-   masc_time_constants)
+   masc_time_constants
+   playground_paths)
  (wrapped false)
  (libraries masc_core masc_log yojson uri))

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -436,6 +436,15 @@ module DockerPlayground = struct
       Env: [MASC_KEEPER_DOCKER_CONTAINER]. Default: "keeper-playground". *)
   let container_name =
     get_string ~default:"keeper-playground" "MASC_KEEPER_DOCKER_CONTAINER"
+
+  (** Container-side root under which keeper playground bundles are mounted.
+      Host [<base_path>/.masc/playground/<keeper>/…] maps to
+      [<container_playground_root>/<keeper>/…] inside the container.
+      Env: [MASC_KEEPER_DOCKER_PLAYGROUND_ROOT].
+      Default: "/home/keeper/playground". *)
+  let container_playground_root =
+    get_string ~default:"/home/keeper/playground"
+      "MASC_KEEPER_DOCKER_PLAYGROUND_ROOT"
 end
 
 module DashboardHealth = struct

--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -17,12 +17,25 @@
 let all_playgrounds_prefix : string = ".masc/playground"
 
 (** Sanitize a keeper name into a filesystem-safe component. Allows
-    [A-Za-z0-9._-] and replaces everything else with [_]. *)
+    [A-Za-z0-9._-] and replaces everything else with [_]. An empty
+    input or the special path components [.] / [..] are replaced with
+    [_], so [sanitize_keeper_name ".."] returns ["__"] rather than
+    returning a traversal segment as a directory name. *)
 let sanitize_keeper_name (name : string) : string =
-  String.map (fun c ->
-    if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-       || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
-    then c else '_') name
+  let mapped =
+    String.map (fun c ->
+      if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+         || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
+      then c else '_') name
+  in
+  (* Reject empty, "." and ".." explicitly — these are filesystem
+     special directory references, not real keeper names, and would
+     let a poisoned [meta.name] escape the playground bundle. *)
+  match mapped with
+  | "" -> "_"
+  | "." -> "_"
+  | ".." -> "__"
+  | _ -> mapped
 
 (** Relative path [".masc/playground/<safe_name>/"] (trailing slash). *)
 let bundle_root (name : string) : string =

--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -1,0 +1,37 @@
+(** Playground path SSOT.
+
+    Canonical layout for a keeper's playground bundle, relative to the
+    server [base_path]:
+
+    - [.masc/playground/<keeper>/]        — bundle root
+    - [.masc/playground/<keeper>/mind/]   — notes, drafts, scratch
+    - [.masc/playground/<keeper>/repos/]  — git clones (one dir per repo)
+
+    These helpers are the single source of truth. Both [masc_room]
+    (worktree resolver) and the keeper modules
+    ([Keeper_alerting_path.playground_*]) delegate here so the literal
+    [".masc/playground"] and sanitization rules exist in one place. *)
+
+(** Sanitize a keeper name into a filesystem-safe component. Allows
+    [A-Za-z0-9._-] and replaces everything else with [_]. *)
+let sanitize_keeper_name (name : string) : string =
+  String.map (fun c ->
+    if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+       || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
+    then c else '_') name
+
+(** Relative path [".masc/playground/<safe_name>/"] (trailing slash). *)
+let bundle_root (name : string) : string =
+  Printf.sprintf ".masc/playground/%s/" (sanitize_keeper_name name)
+
+(** Relative path [".masc/playground/<safe_name>/mind/"]. *)
+let mind_path (name : string) : string =
+  Printf.sprintf ".masc/playground/%s/mind/" (sanitize_keeper_name name)
+
+(** Relative path [".masc/playground/<safe_name>/repos/"]. *)
+let repos_path (name : string) : string =
+  Printf.sprintf ".masc/playground/%s/repos/" (sanitize_keeper_name name)
+
+(** All three bundle subdirs in canonical order. *)
+let bundle_paths (name : string) : string list =
+  [ bundle_root name; mind_path name; repos_path name ]

--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -12,6 +12,10 @@
     ([Keeper_alerting_path.playground_*]) delegate here so the literal
     [".masc/playground"] and sanitization rules exist in one place. *)
 
+(** Shared prefix for all keeper playgrounds, relative to the
+    server's [base_path]. *)
+let all_playgrounds_prefix : string = ".masc/playground"
+
 (** Sanitize a keeper name into a filesystem-safe component. Allows
     [A-Za-z0-9._-] and replaces everything else with [_]. *)
 let sanitize_keeper_name (name : string) : string =
@@ -22,15 +26,15 @@ let sanitize_keeper_name (name : string) : string =
 
 (** Relative path [".masc/playground/<safe_name>/"] (trailing slash). *)
 let bundle_root (name : string) : string =
-  Printf.sprintf ".masc/playground/%s/" (sanitize_keeper_name name)
+  Printf.sprintf "%s/%s/" all_playgrounds_prefix (sanitize_keeper_name name)
 
 (** Relative path [".masc/playground/<safe_name>/mind/"]. *)
 let mind_path (name : string) : string =
-  Printf.sprintf ".masc/playground/%s/mind/" (sanitize_keeper_name name)
+  Printf.sprintf "%s/%s/mind/" all_playgrounds_prefix (sanitize_keeper_name name)
 
 (** Relative path [".masc/playground/<safe_name>/repos/"]. *)
 let repos_path (name : string) : string =
-  Printf.sprintf ".masc/playground/%s/repos/" (sanitize_keeper_name name)
+  Printf.sprintf "%s/%s/repos/" all_playgrounds_prefix (sanitize_keeper_name name)
 
 (** All three bundle subdirs in canonical order. *)
 let bundle_paths (name : string) : string list =

--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -211,30 +211,15 @@ let resolve_keeper_target_path ~(config : Room.config)
      [`allowed_paths`] explicitly if needed.)
     - [`*`] → [] (full access, explicit opt-in bypasses path checks)
     - other  → playground :: workspace_defaults @ explicit *)
-let sanitize_keeper_name (name : string) : string =
-  String.map (fun c ->
-    if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-       || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
-    then c else '_') name
-
-let playground_path_of_keeper (name : string) : string =
-  let safe_name = sanitize_keeper_name name in
-  Printf.sprintf ".masc/playground/%s/" safe_name
-
-let playground_mind_path (name : string) : string =
-  let safe_name = sanitize_keeper_name name in
-  Printf.sprintf ".masc/playground/%s/mind/" safe_name
-
-let playground_repos_path (name : string) : string =
-  let safe_name = sanitize_keeper_name name in
-  Printf.sprintf ".masc/playground/%s/repos/" safe_name
-
-let playground_bundle_paths (name : string) : string list =
-  [
-    playground_path_of_keeper name;
-    playground_mind_path name;
-    playground_repos_path name;
-  ]
+(* Playground path SSOT lives in [Playground_paths] (masc_config). These
+   names preserve the historical keeper-facing API. Do not re-implement
+   the literal ".masc/playground" layout here — edit [Playground_paths]
+   if it ever changes. *)
+let sanitize_keeper_name = Playground_paths.sanitize_keeper_name
+let playground_path_of_keeper = Playground_paths.bundle_root
+let playground_mind_path = Playground_paths.mind_path
+let playground_repos_path = Playground_paths.repos_path
+let playground_bundle_paths = Playground_paths.bundle_paths
 
 let ensure_playground_bundle ~(config : Room.config) ~(name : string) : string list =
   let root = project_root_of_config config in

--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -249,6 +249,12 @@ let keeper_context_status_json ~(meta : keeper_meta) ~(ctx_work : working_contex
     then 0.0
     else float_of_int ctx_tokens /. float_of_int ctx_work.max_tokens
   in
+  (* Give the keeper the three canonical playground paths from the SSOT
+     so it does not need to re-interpolate ".masc/playground/<name>/..."
+     strings every turn. These are relative to the server base_path. *)
+  let playground_bundle = Playground_paths.bundle_root meta.name in
+  let playground_mind = Playground_paths.mind_path meta.name in
+  let playground_repos = Playground_paths.repos_path meta.name in
   Yojson.Safe.to_string
     (`Assoc
         [ "name", `String meta.name
@@ -259,6 +265,9 @@ let keeper_context_status_json ~(meta : keeper_meta) ~(ctx_work : working_contex
         ; "context_max", `Int ctx_work.max_tokens
         ; "message_count", `Int (List.length ctx_work.messages)
         ; "last_model_used", `String meta.runtime.usage.last_model_used
+        ; "playground_bundle", `String playground_bundle
+        ; "playground_mind", `String playground_mind
+        ; "playground_repos", `String playground_repos
         ; ( "continuity_state"
           , match continuity with
             | None -> `Null

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -178,7 +178,9 @@ let resolve_keeper_shell_write_cwd
    mount point is configurable (default "/home/keeper/playground"). *)
 let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd =
   let root = Keeper_alerting_path.project_root_of_config config in
-  let playground_prefix = Filename.concat root ".masc/playground" in
+  let playground_prefix =
+    Filename.concat root Playground_paths.all_playgrounds_prefix
+  in
   let container_root =
     Env_config_keeper.DockerPlayground.container_playground_root
   in

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -209,8 +209,11 @@ let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd
 
 (* Common wrong path prefixes that keepers use.
    Maps wrong prefix → corrected relative path using the keeper
-   playground SSOT ([Playground_paths]). The keeper name is sanitized
-   here so a poisoned meta.name cannot escape the playground. *)
+   playground SSOT ([Playground_paths]). [sanitize_keeper_name] in the
+   SSOT rejects "", "." and ".." as whole-name segments (substituting
+   "_", "_", "__" respectively), so a poisoned [meta.name] cannot
+   produce a ".."/"." directory component and cannot escape the
+   playground bundle via [Filename.concat]. *)
 let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
   (* bundle_root yields ".masc/playground/<safe>/" — strip the trailing
      slash so we can append "/repos/..." cleanly. *)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -171,19 +171,25 @@ let resolve_keeper_shell_write_cwd
   | Ok cwd -> Error (Printf.sprintf "cwd_not_directory: %s" cwd)
 
 (* Docker playground path mapping: host → container.
-   Host:      /Users/dancer/me/.masc/playground/cheolsu/repos/X
-   Container: /home/keeper/playground/cheolsu/repos/X *)
+   Host:      <base_path>/.masc/playground/<keeper>/repos/X
+   Container: <container_playground_root>/<keeper>/repos/X
+   The container-side root comes from
+   [Env_config_keeper.DockerPlayground.container_playground_root] so the
+   mount point is configurable (default "/home/keeper/playground"). *)
 let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd =
   let root = Keeper_alerting_path.project_root_of_config config in
   let playground_prefix = Filename.concat root ".masc/playground" in
+  let container_root =
+    Env_config_keeper.DockerPlayground.container_playground_root
+  in
   if String.starts_with ~prefix:playground_prefix host_cwd then
     let suffix =
       String.sub host_cwd (String.length playground_prefix)
         (String.length host_cwd - String.length playground_prefix)
     in
-    "/home/keeper/playground" ^ suffix
+    container_root ^ suffix
   else
-    Printf.sprintf "/home/keeper/playground/%s" meta.name
+    Filename.concat container_root meta.name
 
 (* Common wrong path prefixes that keepers use.
    Maps wrong prefix → corrected relative path using keeper playground. *)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -192,9 +192,19 @@ let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd
     Filename.concat container_root meta.name
 
 (* Common wrong path prefixes that keepers use.
-   Maps wrong prefix → corrected relative path using keeper playground. *)
+   Maps wrong prefix → corrected relative path using the keeper
+   playground SSOT ([Playground_paths]). The keeper name is sanitized
+   here so a poisoned meta.name cannot escape the playground. *)
 let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
-  let playground = Printf.sprintf ".masc/playground/%s" meta.name in
+  (* bundle_root yields ".masc/playground/<safe>/" — strip the trailing
+     slash so we can append "/repos/..." cleanly. *)
+  let playground_bundle = Playground_paths.bundle_root meta.name in
+  let playground =
+    if String.length playground_bundle > 0
+       && playground_bundle.[String.length playground_bundle - 1] = '/'
+    then String.sub playground_bundle 0 (String.length playground_bundle - 1)
+    else playground_bundle
+  in
   let try_strip prefix replacement =
     let plen = String.length prefix in
     if String.length raw >= plen
@@ -202,7 +212,7 @@ let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
     then Some (replacement ^ String.sub raw plen (String.length raw - plen))
     else None
   in
-  (* /repos/X → .masc/playground/<name>/repos/X *)
+  (* /repos/X → .masc/playground/<safe-name>/repos/X *)
   match try_strip "/repos/" (playground ^ "/repos/") with
   | Some _ as r -> r
   | None ->

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -184,14 +184,28 @@ let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd
   let container_root =
     Env_config_keeper.DockerPlayground.container_playground_root
   in
-  if String.starts_with ~prefix:playground_prefix host_cwd then
-    let suffix =
-      String.sub host_cwd (String.length playground_prefix)
-        (String.length host_cwd - String.length playground_prefix)
-    in
-    container_root ^ suffix
+  (* Boundary-safe prefix match: require either an exact match or a
+     prefix ending at a path separator. Without this, host paths like
+     "<root>/.masc/playgroundXYZ/..." would match "<root>/.masc/playground"
+     and leak into the container playground. *)
+  let prefix_with_sep = playground_prefix ^ "/" in
+  let starts_at_boundary =
+    host_cwd = playground_prefix
+    || String.starts_with ~prefix:prefix_with_sep host_cwd
+  in
+  if starts_at_boundary then
+    if host_cwd = playground_prefix then container_root
+    else
+      let suffix =
+        String.sub host_cwd (String.length prefix_with_sep)
+          (String.length host_cwd - String.length prefix_with_sep)
+      in
+      Filename.concat container_root suffix
   else
-    Filename.concat container_root meta.name
+    (* meta.name is sanitized through Playground_paths so a poisoned
+       name cannot escape the container_root. *)
+    Filename.concat container_root
+      (Playground_paths.sanitize_keeper_name meta.name)
 
 (* Common wrong path prefixes that keepers use.
    Maps wrong prefix → corrected relative path using the keeper

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -132,20 +132,44 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
         Filename.concat config.base_path
           (Playground_paths.repos_path agent_name)
       in
+      (* [Sys.is_directory] raises [Sys_error] on permission errors or
+         if the path disappears between [file_exists] and [is_directory]
+         (TOCTOU). Swallow those errors and treat the candidate as
+         "not a clone" so a broken entry under [repos/] never crashes
+         the worktree resolver. *)
+      let safe_is_dir path =
+        try Sys.file_exists path && Sys.is_directory path
+        with Sys_error _ -> false
+      in
       let is_git_clone candidate =
-        Sys.file_exists candidate
-        && Sys.is_directory candidate
-        && Sys.file_exists (Filename.concat candidate ".git")
+        safe_is_dir candidate
+        && (try Sys.file_exists (Filename.concat candidate ".git")
+            with Sys_error _ -> false)
+      in
+      (* Reject repo_name values that aren't a single safe path
+         component. This prevents "../kirin" or "foo/bar" from escaping
+         the repos/ directory via [Filename.concat]. Keeper names are
+         already sanitized by [Playground_paths], but [repo_name] comes
+         straight from MCP tool args and needs its own gate. *)
+      let safe_repo_name name =
+        name <> "" && name <> "." && name <> ".."
+        && not (String.contains name '/')
+        && not (String.contains name '\\')
+        && not (String.contains name '\x00')
+        && String.for_all (fun c ->
+          (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+          || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.') name
       in
       let explicit_repo =
         match repo_name with
         | None | Some "" -> None
+        | Some name when not (safe_repo_name name) -> None
         | Some name ->
           let candidate = Filename.concat repos_dir name in
           if is_git_clone candidate then Some candidate else None
       in
       let scan_first_git_repo dir =
-        if not (Sys.file_exists dir && Sys.is_directory dir) then None
+        if not (safe_is_dir dir) then None
         else
           let entries =
             try Sys.readdir dir with Sys_error _ -> [||]

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -103,8 +103,13 @@ let link_worktree_to_task config ~task_id ~worktree_info =
         end
 
 (** Create worktree for agent - Result version
-    @param link_task If true, links worktree info to the task in backlog (default: true) *)
-let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch : string masc_result =
+    @param link_task If true, links worktree info to the task in backlog (default: true)
+    @param repo_name If set, target the keeper's playground clone at
+           [.masc/playground/<agent>/repos/<repo_name>/] directly. If
+           unset, scan [repos/] and use the first git clone found
+           (alphabetical). Either way, falls back to the server repo
+           root when no matching playground clone exists. *)
+let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
     Error NotInitialized
   else if not (is_git_repo config) then
@@ -115,17 +120,29 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
   | Ok _, Ok _ ->
     (* Prefer a keeper's playground clone under
        [.masc/playground/<agent>/repos/]. The layout is the SSOT in
-       [Playground_paths] (masc_config). Scan the directory for any
-       cloned git repo (first match wins, alphabetical) instead of
-       hardcoding a repo name — keepers may work on any repo their
-       [tool_policy.toml] allows. If no playground clone is present,
-       fall back to the configured repository root so explicit
-       repo-worktree flows still work instead of failing with a
-       missing-clone error. *)
+       [Playground_paths] (masc_config). If [repo_name] is supplied,
+       target that clone directly; otherwise scan the directory and
+       pick the first git clone (alphabetical). Keepers may work on
+       any repo their [tool_policy.toml] allows. If no matching
+       playground clone is present, fall back to the configured
+       repository root so explicit repo-worktree flows still work
+       instead of failing with a missing-clone error. *)
     let resolve_keeper_repo_root () =
       let repos_dir =
         Filename.concat config.base_path
           (Playground_paths.repos_path agent_name)
+      in
+      let is_git_clone candidate =
+        Sys.file_exists candidate
+        && Sys.is_directory candidate
+        && Sys.file_exists (Filename.concat candidate ".git")
+      in
+      let explicit_repo =
+        match repo_name with
+        | None | Some "" -> None
+        | Some name ->
+          let candidate = Filename.concat repos_dir name in
+          if is_git_clone candidate then Some candidate else None
       in
       let scan_first_git_repo dir =
         if not (Sys.file_exists dir && Sys.is_directory dir) then None
@@ -138,13 +155,17 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
             if i >= Array.length entries then None
             else
               let candidate = Filename.concat dir entries.(i) in
-              if Sys.file_exists (Filename.concat candidate ".git")
+              if is_git_clone candidate
               then Some candidate
               else find (i + 1)
           in
           find 0
       in
-      match scan_first_git_repo repos_dir with
+      match
+        match explicit_repo with
+        | Some _ as r -> r
+        | None -> scan_first_git_repo repos_dir
+      with
       | Some clone -> Ok clone
       | None ->
         match require_repository_root_with_git config with

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -114,17 +114,18 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
   | _, Error e -> Error e
   | Ok _, Ok _ ->
     (* Prefer a keeper's playground clone under
-       [.masc/playground/<agent>/repos/]. Scan the directory for any
-       cloned git repo (first match wins) instead of hardcoding a repo
-       name — keepers may work on any repo their tool_policy allows.
-       If no playground clone is present, fall back to the configured
-       repository root so explicit repo-worktree flows still work
-       instead of failing with a missing-clone error. *)
+       [.masc/playground/<agent>/repos/]. The layout is the SSOT in
+       [Playground_paths] (masc_config). Scan the directory for any
+       cloned git repo (first match wins, alphabetical) instead of
+       hardcoding a repo name — keepers may work on any repo their
+       [tool_policy.toml] allows. If no playground clone is present,
+       fall back to the configured repository root so explicit
+       repo-worktree flows still work instead of failing with a
+       missing-clone error. *)
     let resolve_keeper_repo_root () =
       let repos_dir =
         Filename.concat config.base_path
-          (Printf.sprintf ".masc/playground/%s/repos"
-             (safe_filename agent_name))
+          (Playground_paths.repos_path agent_name)
       in
       let scan_first_git_repo dir =
         if not (Sys.file_exists dir && Sys.is_directory dir) then None

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -113,19 +113,39 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
-    (* Prefer the keeper's playground clone. If it is missing, fall back
-       to the configured repository root so explicit repo-worktree flows
-       still work instead of failing with a missing-clone error. *)
+    (* Prefer a keeper's playground clone under
+       [.masc/playground/<agent>/repos/]. Scan the directory for any
+       cloned git repo (first match wins) instead of hardcoding a repo
+       name — keepers may work on any repo their tool_policy allows.
+       If no playground clone is present, fall back to the configured
+       repository root so explicit repo-worktree flows still work
+       instead of failing with a missing-clone error. *)
     let resolve_keeper_repo_root () =
-      let playground_repo =
+      let repos_dir =
         Filename.concat config.base_path
-          (Printf.sprintf ".masc/playground/%s/repos/masc-mcp"
+          (Printf.sprintf ".masc/playground/%s/repos"
              (safe_filename agent_name))
       in
-      if Sys.file_exists playground_repo
-         && Sys.file_exists (Filename.concat playground_repo ".git")
-      then Ok playground_repo
-      else
+      let scan_first_git_repo dir =
+        if not (Sys.file_exists dir && Sys.is_directory dir) then None
+        else
+          let entries =
+            try Sys.readdir dir with Sys_error _ -> [||]
+          in
+          Array.sort compare entries;
+          let rec find i =
+            if i >= Array.length entries then None
+            else
+              let candidate = Filename.concat dir entries.(i) in
+              if Sys.file_exists (Filename.concat candidate ".git")
+              then Some candidate
+              else find (i + 1)
+          in
+          find 0
+      in
+      match scan_first_git_repo repos_dir with
+      | Some clone -> Ok clone
+      | None ->
         match require_repository_root_with_git config with
         | Ok root -> Ok root
         | Error e -> Error e

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -5,8 +5,14 @@ let schemas : tool_schema list = [
     name = "masc_worktree_create";
     description = "Create an isolated Git worktree for a task. \
 Requires task_id (REQUIRED). Example: task_id='fix-login', task_id='feature/auth'. \
-Optional base_branch (default: auto-detect main/develop). \
-Use before starting file edits. After work, create PR then call masc_worktree_remove.";
+The worktree is rooted in your playground clone — typically at \
+.masc/playground/<your-name>/repos/<repo>/.worktrees/<agent>-<task_id>. \
+Repo resolution: pass repo_name to target a specific clone, otherwise \
+the first git clone under your repos/ is used (alphabetical). If \
+repos/ is empty, the server repo root is used as a fallback — clone \
+the target repo first with keeper_shell op=git_clone to keep the \
+worktree under your playground. After work, create a PR then call \
+masc_worktree_remove.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -22,6 +28,10 @@ Use before starting file edits. After work, create PR then call masc_worktree_re
           ("type", `String "string");
           ("description", `String "Base branch (default: auto-detect). Rarely needed.");
           ("default", `String "develop");
+        ]);
+        ("repo_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Leave empty to auto-pick the first clone alphabetically.");
         ]);
       ]);
       ("required", `List [`String "task_id"]);

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -31,7 +31,8 @@ masc_worktree_remove.";
         ]);
         ("repo_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Leave empty to auto-pick the first clone alphabetically.");
+          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-] — a single directory name, no slashes, no path traversal, no '.' or '..'. Leave empty to auto-pick the first clone alphabetically.");
+          ("pattern", `String "^[A-Za-z0-9._-]+$");
         ]);
       ]);
       ("required", `List [`String "task_id"]);

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -44,9 +44,13 @@ Use to timestamp events, check elapsed time, or include current time in reports.
   (* Context status *)
   {
     name = "keeper_context_status";
-    description = "Check your own context window usage and session state. Returns context_ratio (0.0-1.0), \
-token_count, message_count, generation, continuity_summary. Use when deciding whether to \
-compact context, extend turns, or hand off to the next generation.";
+    description = "Check your own context window usage and session state. Returns: \
+name (your keeper name), context_ratio (0.0-1.0), context_tokens, context_max, \
+message_count, generation, last_model_used, continuity_summary, and your three \
+canonical playground paths (playground_bundle, playground_mind, playground_repos) \
+relative to the server base_path. Use when deciding whether to compact context, \
+extend turns, hand off to the next generation, or resolve a path without \
+string-interpolating your own keeper name.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -21,6 +21,11 @@ let handle_worktree_create ctx args =
   in
   let raw_task_id = get_string args "task_id" "" in
   let base_branch = get_string args "base_branch" "develop" in
+  let repo_name =
+    match String.trim (get_string args "repo_name" "") with
+    | "" -> None
+    | s -> Some s
+  in
   if raw_task_id = "" then
     (false, "task_id is required. Example: task_id='fix-login', task_id='add-auth'. \
              Use a-z, 0-9, hyphen, underscore only. No slashes.")
@@ -31,7 +36,7 @@ let handle_worktree_create ctx args =
     |> Seq.map (fun c -> if c = '/' || c = '\\' then '-' else c)
     |> String.of_seq
   in
-  match Room.worktree_create_r ctx.config ~agent_name ~task_id ~base_branch with
+  match Room.worktree_create_r ?repo_name ctx.config ~agent_name ~task_id ~base_branch with
   | Ok msg -> (true, msg)
   | Error e -> (false, Types.masc_error_to_string e)
 

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -21,14 +21,41 @@ let handle_worktree_create ctx args =
   in
   let raw_task_id = get_string args "task_id" "" in
   let base_branch = get_string args "base_branch" "develop" in
-  let repo_name =
-    match String.trim (get_string args "repo_name" "") with
-    | "" -> None
-    | s -> Some s
+  (* repo_name comes straight from MCP tool args. Reject anything that
+     isn't a single safe directory component so it cannot escape
+     [.masc/playground/<keeper>/repos/]. Room.worktree_create_r also
+     re-validates defensively, but rejecting here gives a clearer
+     error message back to the caller. *)
+  let is_safe_repo_name s =
+    s <> "" && s <> "." && s <> ".."
+    && not (String.contains s '/')
+    && not (String.contains s '\\')
+    && not (String.contains s '\x00')
+    && String.for_all (fun c ->
+      (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+      || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.') s
   in
+  let raw_repo_name = String.trim (get_string args "repo_name" "") in
+  let repo_name, repo_name_error =
+    match raw_repo_name with
+    | "" -> (None, None)
+    | s when is_safe_repo_name s -> (Some s, None)
+    | bad ->
+      ( None,
+        Some (Printf.sprintf
+          "repo_name %S is invalid. Use a single directory name \
+           under your playground repos/ (e.g. repo_name='masc-mcp'). \
+           Allowed characters: [A-Za-z0-9._-]. No slashes, no \
+           path traversal, no '.'/'..' specials." bad) )
+  in
+  match repo_name_error with
+  | Some err -> (false, err)
+  | None ->
   if raw_task_id = "" then
-    (false, "task_id is required. Example: task_id='fix-login', task_id='add-auth'. \
-             Use a-z, 0-9, hyphen, underscore only. No slashes.")
+    (false, "task_id is required. Example: task_id='fix-login', \
+             task_id='add-auth'. Allowed characters: a-z, 0-9, hyphen, \
+             underscore. Slashes and backslashes are auto-normalized \
+             to hyphens, so 'feature/auth' becomes 'feature-auth'.")
   else
   (* Normalize: replace / and \ with - so LLMs can use branch-style names *)
   let task_id =

--- a/test/dune
+++ b/test/dune
@@ -57,6 +57,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_playground_paths
         test_keeper_llama_only
         test_keeper_meta_cwd_resilience
         test_metrics_rotation
@@ -131,6 +132,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_playground_paths
           test_keeper_llama_only
           test_keeper_meta_cwd_resilience
           test_metrics_rotation

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -18,8 +18,14 @@ let test_sanitize_replaces_unsafe_chars () =
   check string "slash becomes underscore"
     "a_b"
     (PP.sanitize_keeper_name "a/b");
-  check string "dot-dot becomes dots (still safe chars)"
-    ".."
+  check string "empty string becomes single underscore"
+    "_"
+    (PP.sanitize_keeper_name "");
+  check string "single dot is replaced with underscore"
+    "_"
+    (PP.sanitize_keeper_name ".");
+  check string "dot-dot is replaced with double underscore (no traversal)"
+    "__"
     (PP.sanitize_keeper_name "..");
   check string "path traversal with slash is neutralized"
     ".._.._etc_passwd"
@@ -64,10 +70,23 @@ let test_no_path_escape () =
     (String.length bundle >= String.length PP.all_playgrounds_prefix
      && String.sub bundle 0 (String.length PP.all_playgrounds_prefix)
         = PP.all_playgrounds_prefix);
-  check bool "no '..' remains as a path component"
+  (* After sanitization, every non-safe char becomes '_'. "../../../etc"
+     → ".._.._.._etc" which contains no "/" path separators at all, so
+     the canonical "/<..>/" traversal segment cannot appear. *)
+  check bool "no '/../' path segment remains in bundle"
     false
     (let re = Re.Pcre.re {|/\.\./|} |> Re.compile in
-     Re.execp re bundle)
+     Re.execp re bundle);
+  (* And neither ".." nor "." can appear as a whole directory component. *)
+  check string "dot-dot as whole name is neutralized"
+    ".masc/playground/__/"
+    (PP.bundle_root "..");
+  check string "single dot as whole name is neutralized"
+    ".masc/playground/_/"
+    (PP.bundle_root ".");
+  check string "empty name is neutralized"
+    ".masc/playground/_/"
+    (PP.bundle_root "")
 
 let () =
   run "Playground_paths"

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -1,0 +1,90 @@
+(** Unit tests for Playground_paths — the SSOT for
+    [.masc/playground/<keeper>/...] layout helpers. *)
+
+open Alcotest
+(* masc_config library is [wrapped = false], so Playground_paths is a
+   top-level module once we link against it. *)
+module PP = Playground_paths
+
+let test_sanitize_allows_safe_chars () =
+  check string "alphanumerics pass through"
+    "cheolsu_1.2-test"
+    (PP.sanitize_keeper_name "cheolsu_1.2-test");
+  check string "already sanitized stays the same"
+    "Abc-123_x.y"
+    (PP.sanitize_keeper_name "Abc-123_x.y")
+
+let test_sanitize_replaces_unsafe_chars () =
+  check string "slash becomes underscore"
+    "a_b"
+    (PP.sanitize_keeper_name "a/b");
+  check string "dot-dot becomes dots (still safe chars)"
+    ".."
+    (PP.sanitize_keeper_name "..");
+  check string "path traversal with slash is neutralized"
+    ".._.._etc_passwd"
+    (PP.sanitize_keeper_name "../../etc/passwd");
+  check string "whitespace and punctuation replaced"
+    "hi_there___"
+    (PP.sanitize_keeper_name "hi there!?*")
+
+let test_all_playgrounds_prefix_stable () =
+  check string "canonical prefix"
+    ".masc/playground" PP.all_playgrounds_prefix
+
+let test_bundle_root_format () =
+  check string "bundle root has trailing slash"
+    ".masc/playground/cheolsu/"
+    (PP.bundle_root "cheolsu");
+  check string "bundle root sanitizes name"
+    ".masc/playground/a_b/"
+    (PP.bundle_root "a/b")
+
+let test_mind_and_repos_paths () =
+  check string "mind path"
+    ".masc/playground/sangsu/mind/"
+    (PP.mind_path "sangsu");
+  check string "repos path"
+    ".masc/playground/sangsu/repos/"
+    (PP.repos_path "sangsu")
+
+let test_bundle_paths_order () =
+  check (list string) "bundle order: root, mind, repos"
+    [ ".masc/playground/k1/";
+      ".masc/playground/k1/mind/";
+      ".masc/playground/k1/repos/" ]
+    (PP.bundle_paths "k1")
+
+let test_no_path_escape () =
+  (* A poisoned name containing path separators must not produce a
+     path that escapes the playground prefix. *)
+  let bundle = PP.bundle_root "../../../etc" in
+  check bool "sanitized bundle stays under prefix"
+    true
+    (String.length bundle >= String.length PP.all_playgrounds_prefix
+     && String.sub bundle 0 (String.length PP.all_playgrounds_prefix)
+        = PP.all_playgrounds_prefix);
+  check bool "no '..' remains as a path component"
+    false
+    (let re = Re.Pcre.re {|/\.\./|} |> Re.compile in
+     Re.execp re bundle)
+
+let () =
+  run "Playground_paths"
+    [
+      ("sanitize", [
+        test_case "safe chars pass through" `Quick test_sanitize_allows_safe_chars;
+        test_case "unsafe chars replaced" `Quick test_sanitize_replaces_unsafe_chars;
+      ]);
+      ("prefix", [
+        test_case "all_playgrounds_prefix stable" `Quick test_all_playgrounds_prefix_stable;
+      ]);
+      ("paths", [
+        test_case "bundle_root format" `Quick test_bundle_root_format;
+        test_case "mind and repos paths" `Quick test_mind_and_repos_paths;
+        test_case "bundle_paths order" `Quick test_bundle_paths_order;
+      ]);
+      ("security", [
+        test_case "no path escape" `Quick test_no_path_escape;
+      ]);
+    ]


### PR DESCRIPTION
## 왜

키퍼 playground/worktree/docker 연결 체인에 두 종류의 하드코딩이 섞여 있어 SSOT가 깨져 있었습니다.

1. `lib/room/room_worktree.ml`이 키퍼 플레이그라운드 레포 경로를 `.masc/playground/<agent>/repos/masc-mcp`로 고정. 다른 허용 레포(`jeong-sik/*`)를 클론하면 worktree resolver가 그 클론을 못 봅니다.
2. `lib/keeper/keeper_exec_shell.ml`의 `docker_playground_cwd`가 컨테이너 측 마운트 루트 `/home/keeper/playground`를 리터럴로 박아둠. `Env_config_keeper.DockerPlayground`에는 이 값을 조정할 키가 없었습니다.
3. `config/prompts/keeper.capabilities.md` / `keeper.world.md`가 동일한 `repos/masc-mcp` 리터럴을 프롬프트에 반복해 키퍼들이 다른 클론 레이아웃에서 길을 잃었습니다.

## 무엇을 바꿨나

- `Env_config_keeper.DockerPlayground.container_playground_root`(env `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT`, 기본 `/home/keeper/playground`) 신설. 컨테이너 측 마운트 루트의 단일 소스.
- `keeper_exec_shell.docker_playground_cwd` — 리터럴 대신 위 SSOT를 읽음.
- `room_worktree.resolve_keeper_repo_root` — `.masc/playground/<agent>/repos/`를 스캔해 첫 git 클론(정렬 순)을 선택. 클론이 없으면 서버 `base_path`로 폴백.
- `keeper.capabilities.md` / `keeper.world.md` — `repos/masc-mcp` 하드코딩 제거. 일반화된 `repos/<REPO>/` 레이아웃과 `tool_policy.toml` allow-list로 안내. playground(샌드박스) vs worktree(브랜치 격리 플로우) 관계, 스캔 동작 명시.

## 검증

- `dune build --root . lib` pass
- `dune exec test/test_keeper_bash_safety.exe` — 17 tests pass
- `dune exec test/test_room.exe` — 95 tests pass

테스트에서 `"repos/masc-mcp"`를 예제 문자열로 쓰는 `test_keeper_bash_safety` 케이스들은 containment 로직만 검증해서 영향 없음.

## 잠재적 영향

- `MASC_KEEPER_DOCKER_PLAYGROUND_ROOT`를 설정하지 않은 기존 배포는 기본값 `/home/keeper/playground`로 동작 그대로.
- worktree resolver는 기존에 `repos/masc-mcp`만 인식하던 것을 `repos/` 안의 아무 git 클론이나 인식. 기존에 `repos/masc-mcp` 클론이 있었던 환경도 동일하게 동작(스캔 첫 결과).
- 복수 클론이 있을 때 정렬 순 첫 항목이 선택됩니다. 명시적 레포 선택이 필요해지면 후속 PR에서 `masc_worktree_create` 인자에 `repo_name` 추가 고려.

## 후속 고려

- `Dockerfile.keeper-playground` (경량 키퍼 샌드박스 이미지) 및 `docker-compose.keeper.yml` 템플릿 부재 — 현재는 외부에서 수동 기동 전제. SSOT 정리가 완료됐으니 별도 PR에서 이미지 정의를 추가할 수 있습니다.