### PR TITLE
fix(test): unblock CI — add masc_keeper_reset to Admin surface

### DIFF
--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -201,6 +201,7 @@ let admin_surface_tools =
     "masc_auth_disable"; "masc_auth_enable"; "masc_auth_list";
     "masc_auth_refresh"; "masc_auth_revoke"; "masc_auth_status";
     "masc_keeper_create_from_persona";
+    "masc_keeper_reset";
     "masc_pause"; "masc_resume";
     "masc_runtime_verify"; "masc_runtime_ollama_probe"; "masc_tool_list";
   ]


### PR DESCRIPTION
## Summary
- `masc_keeper_reset` schema and handler were added in #6428 but never assigned to a surface.
- This makes `test_tool_surface_ssot` ssot_validation "no orphaned tools" fail on main and blocks every downstream PR.
- Added to Admin surface next to `masc_keeper_create_from_persona` (both are keeper lifecycle management tools).

The earlier fix attempt (#6436) was closed without merging. This is a minimal single-line re-apply of that fix.

## Test plan
- [x] `dune exec test/test_tool_surface_ssot.exe` — 25/25 pass (previously 24/25 with `{masc_keeper_reset}` orphan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)