### PR TITLE
test(http-auth): align loopback same-origin expectations

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -225,6 +225,18 @@ let explicit_metadata : (string * metadata) list =
     (* Voice MCP tool: deprecated after voice group removal from tool_policy.toml.
        Schema still registered in keeper_schema.ml for backward compat dispatch. *)
     ("masc_voice_ping_pong", deprecated "Voice group removed from tool_policy.toml");
+    (* Incomplete addition: schema + dispatch exist (keeper_schema.ml:497,
+       tool_keeper.ml:673) but tool was never wired to any surface, auth.ml
+       permission map, operator_control, prefilter, or access_role. Marking
+       Deprecated with direct-call retained keeps the handler reachable for
+       any internal caller without leaving it as an SSOT orphan. If an owner
+       wants to expose it publicly, re-promote by adding to
+       tool_catalog_surfaces.public_mcp_surface_tools and updating auth.ml. *)
+    ( "masc_keeper_reset",
+      deprecated
+        ~allow_direct_call_when_hidden:true
+        ~implementation_status:Real
+        "orphaned — schema/handler present but no caller wiring" );
   ]
 
 (* ================================================================ *)

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -225,16 +225,13 @@ let explicit_metadata : (string * metadata) list =
     (* Voice MCP tool: deprecated after voice group removal from tool_policy.toml.
        Schema still registered in keeper_schema.ml for backward compat dispatch. *)
     ("masc_voice_ping_pong", deprecated "Voice group removed from tool_policy.toml");
-    (* Incomplete addition: schema + dispatch exist (keeper_schema.ml:497,
-       tool_keeper.ml:673) but tool was never wired to any surface, auth.ml
-       permission map, operator_control, prefilter, or access_role. Marking
-       Deprecated with direct-call retained keeps the handler reachable for
-       any internal caller without leaving it as an SSOT orphan. If an owner
-       wants to expose it publicly, re-promote by adding to
-       tool_catalog_surfaces.public_mcp_surface_tools and updating auth.ml. *)
+    (* Incomplete addition: schema + dispatch exist for masc_keeper_reset,
+       but the tool was never wired to any surface, auth.ml permission map,
+       operator_control, prefilter, or access_role. Keep it Deprecated and
+       hidden until an owner explicitly re-promotes it by wiring the public
+       surface and permission path. *)
     ( "masc_keeper_reset",
       deprecated
-        ~allow_direct_call_when_hidden:true
         ~implementation_status:Real
         "orphaned — schema/handler present but no caller wiring" );
   ]

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -225,15 +225,6 @@ let explicit_metadata : (string * metadata) list =
     (* Voice MCP tool: deprecated after voice group removal from tool_policy.toml.
        Schema still registered in keeper_schema.ml for backward compat dispatch. *)
     ("masc_voice_ping_pong", deprecated "Voice group removed from tool_policy.toml");
-    (* Incomplete addition: schema + dispatch exist for masc_keeper_reset,
-       but the tool was never wired to any surface, auth.ml permission map,
-       operator_control, prefilter, or access_role. Keep it Deprecated and
-       hidden until an owner explicitly re-promotes it by wiring the public
-       surface and permission path. *)
-    ( "masc_keeper_reset",
-      deprecated
-        ~implementation_status:Real
-        "orphaned — schema/handler present but no caller wiring" );
   ]
 
 (* ================================================================ *)

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -327,7 +327,7 @@ let test_same_origin_https_tunnel_same_host () =
   | Ok () -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
-let test_same_origin_rejects_different_explicit_port () =
+let test_same_origin_allows_different_explicit_port_on_loopback () =
   let module Server_auth = Masc_mcp.Server_auth in
   let headers =
     Httpun.Headers.of_list
@@ -338,7 +338,21 @@ let test_same_origin_rejects_different_explicit_port () =
   in
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
-  | Ok () -> fail "expected different-port request to be rejected"
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_same_origin_rejects_different_explicit_port_on_public_host () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "example.com:9000");
+        ("origin", "http://example.com:8935");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+  match Server_auth.ensure_same_origin_browser_request request with
+  | Ok () -> fail "expected different-port public host request to be rejected"
   | Error (Types.Forbidden _) -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
@@ -766,8 +780,10 @@ let () =
         test_same_origin_browser_request_rejects_cross_origin;
       test_case "same-origin allows https tunnel same host" `Quick
         test_same_origin_https_tunnel_same_host;
-      test_case "same-origin rejects different explicit port" `Quick
-        test_same_origin_rejects_different_explicit_port;
+      test_case "same-origin allows different explicit port on loopback" `Quick
+        test_same_origin_allows_different_explicit_port_on_loopback;
+      test_case "same-origin rejects different explicit port on public host" `Quick
+        test_same_origin_rejects_different_explicit_port_on_public_host;
       test_case "same-origin allows explicit default port https" `Quick
         test_same_origin_allows_explicit_default_port_https;
       test_case "same-origin allows explicit default port http" `Quick


### PR DESCRIPTION
## Summary
- align `test_auth_coverage` with the already-merged loopback same-origin behavior in `server_auth`
- split the old single different-port assertion into two cases: loopback ports are allowed, public hosts are still rejected

## Product impact
- removes a pre-existing red CI expectation drift that still blocked unrelated PRs after #6459 merged
- keeps browser same-origin enforcement strict for public hosts while matching current dev-loopback behavior

## Evidence
- `dune build --root . test/test_auth_coverage.exe`
- `./_build/default/test/test_auth_coverage.exe --compact --color=never`

## Review evidence
- direct `sb glm-text` (`GLM_TEXT_MODELS=glm-5-turbo`, no-thinking) on `origin/main...HEAD` at 2026-04-11T05:57Z
- result: `No findings.`

## Linked issue
- Refs #6459
- Refs #6449