### PR TITLE
fix(cascade): promote Ollama to primary while ZAI quota exhausted

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,23 +1,23 @@
 {
   "default_models": [
+    "ollama:qwen3.5:35b-a3b-nvfp4",
     "glm:glm-5.1",
-    "glm:glm-5-turbo",
-    "ollama:qwen3.5:35b-a3b-nvfp4"
+    "glm:glm-5-turbo"
   ],
   "local_only_models": [
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "keeper_unified_models": [
+    "ollama:qwen3.5:35b-a3b-nvfp4",
     "glm:glm-5.1",
-    "glm:glm-5-turbo",
-    "ollama:qwen3.5:35b-a3b-nvfp4"
+    "glm:glm-5-turbo"
   ],
   "coding_first_models": [
+    "ollama:qwen3.5:35b-a3b-nvfp4",
     "glm:glm-5.1",
-    "glm:glm-5-turbo",
-    "ollama:qwen3.5:35b-a3b-nvfp4"
+    "glm:glm-5-turbo"
   ],
-  "_comment": "keeper_unified = 5.1(3s) -> 5-turbo -> local. coding_first = same order. flashx removed: hangs on api.z.ai (2026-04-11). local_only = Ollama only.",
+  "_comment": "Ollama primary (2026-04-11): ZAI quota exhausted (HTTP 429 code:1113 'Insufficient balance'). OAS GLM client misparses 429 body as 'Value looks like object' invalid_request, which cascade_health_filter classifies as non-cascadable -> no fall-through to Ollama -> 857 silent errors/13h. Reorder is reversible: restore GLM-first ordering after ZAI top-up. local_only = Ollama only.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,


### PR DESCRIPTION
## 증상

- 모든 keeper proactive turn이 1번의 heartbeat 후 외부에 침묵 (실제로는 매 80초마다 silent error로 loop)
- `~/me/.masc/keepers/*.decisions.jsonl`: `outcome=error`, `error_category=invalid_request`, `last_model_used=glm:glm-5.1`, `tool_call_count=0`, `delivery_surface=silent`
- `~/me/.masc/logs/system_log_2026-04-11.jsonl`: 13시간 동안 857건의 동일 에러, 0건의 cascade fallback, 0건의 Ollama dispatch, 59건의 success(전부 GLM)
- 40회 keeper restart, 37 SIGTERM (crash loop)

## Root Cause (3중 결함)

**1. ZAI 계정 잔액 소진**
직접 curl 4-variant 테스트로 확인. \`api.z.ai/api/paas/v4/chat/completions\` 모든 호출이 HTTP 429 + body 반환:
\`\`\`json
{\"error\":{\"code\":\"1113\",\"message\":\"Insufficient balance or no resource package. Please recharge.\"}}
\`\`\`
glm-5.1과 glm-5-turbo 모두 동일 (같은 account quota pool).

**2. OAS GLM client의 응답 body 파서 버그**
ZAI 원본 body는 valid JSON이지만, OAS GLM HTTP client가 429 에러 body를 잘못 파싱해 다음 형태로 변형:
\`\`\`
Invalid request: {\"error\":\"Value looks like object, but can't find closing '}' symbol\"}
\`\`\`
원본의 \`code:1113\`이 사라지고 일반 \`invalid_request\`로 마스킹됨. (오프닝 \`{\` + 단일 inner string parsing의 전형적 버그.)

**3. Cascade fallback gate**
\`oas/lib/llm_provider/cascade_health_filter.ml:13-23\` 의 \`should_cascade_to_next\`:
\`\`\`ocaml
| Http_client.HttpError { code; _ } ->
  List.mem code Constants.Http.cascadable_codes
\`\`\`
\`cascadable_codes = [401; 403; 429; 500; 502; 503; 529]\`. 429는 원래 cascade 대상이지만, 위 (2) 때문에 에러가 \`invalid_request\`(400-shape)로 도착해 \`List.mem\` 실패 → cascade가 rung 1에서 중단 → Ollama로 절대 fall-through 안 함.

## 흐름

\`\`\`
keeper proactive turn
  → cascade keeper_unified [glm-5.1, glm-5-turbo, ollama:35b-a3b]
  → glm-5.1 호출 → ZAI HTTP 429 + code:1113
  → OAS GLM client: body 파서 버그로 \"closing '}' symbol\" 에러로 변형
  → error_category: invalid_request (실제론 quota)
  → cascade_health_filter: 400 → cascadable=false
  → cascade STOP at rung 1
  → tool_call_count=0, speech_act=defer, delivery_surface=silent
  → 80초 후 동일 반복 (무한 silent loop)
\`\`\`

## 이 PR의 변경

config/cascade.json에서 \`default_models\`, \`keeper_unified_models\`, \`coding_first_models\` 3개 프로필의 모델 순서를 reorder. Ollama를 1순위로:

- Before: \`[glm:glm-5.1, glm:glm-5-turbo, ollama:qwen3.5:35b-a3b-nvfp4]\`
- After:  \`[ollama:qwen3.5:35b-a3b-nvfp4, glm:glm-5.1, glm:glm-5-turbo]\`

\`local_only_models\`는 변경 없음 (이미 Ollama only).

## 검증 근거

Ollama가 keeper-shape 요청을 정상 처리함을 직접 probe로 확인:
- \`qwen3.5:35b-a3b-nvfp4\` resident, 25.87 GB VRAM, 262144 context, 핀고정
- 21 tools + Korean system prompt + \`num_predict=4096\` 시나리오 → **2.79초**, \`finish_reason=tool_calls\`, 정확한 tool 선택 (\`keeper_board_list\` for \"board 상태 점검\")
- 1 tool minimal 시나리오 → 정상 \`tool_calls\` 응답

## 한계 / 트레이드오프

- **이건 대증요법**. 진짜 root cause는 (1) ZAI 잔액 (2) OAS GLM client 파서 (3) cascade gate의 invalid_request 분류. 별도 PR로 처리 필요.
- Ollama 1순위가 되면 GLM은 fallback이지만, cascade gate가 여전히 4xx에서 fall-through 안 하므로 Ollama가 4xx를 던지면 GLM으로 못 넘어감. Ollama 4xx는 드물어서 수용 가능.
- 비용 영향 0 (Ollama는 로컬, GLM은 어차피 quota 0).
- ZAI 충전 후 reorder를 되돌리려면 이 PR을 그대로 revert.

## Test plan

- [ ] dune build pass
- [ ] config/cascade.json JSON 유효 (이미 \`python3 -c json.load\` 통과)
- [ ] PR 머지 + masc-mcp 서버 재시작 후 \`~/me/.masc/keepers/*.decisions.jsonl\`에 \`last_model_used=ollama:qwen3.5:35b-a3b-nvfp4\` 등장 + \`outcome=ok\` 비율 회복 확인
- [ ] system_log에 \"Value looks like object\" 에러 0건으로 떨어지는지 모니터링

## 후속 작업 (별도 이슈/PR)

- [ ] OAS \`oas/lib/llm_provider/glm_*\` (HTTP client/response parser) 수정: 429+code:1113을 정확히 surface
- [ ] OAS \`cascade_health_filter.ml\` 강화: provider 자체 실패는 무조건 cascade, 또는 GLM family 전체가 같은 quota pool이면 first GLM 실패 시 모든 GLM rung skip
- [ ] masc-mcp 텔레메트리: per-cascade-step 이벤트 (\`cascade_attempt/step_failed/advance/exhausted\`), raw request body SHA, ZAI request_id 보존
- [ ] \`outcome=error\` + \`delivery_surface=silent\` 조합 차단: 최소 board에 1줄 broadcast로 에러 가시화
- [ ] \`cascade=local_only\` 라우팅 버그: 28건의 local_only가 여전히 GLM으로 라우트되는 문제 추적

🤖 Generated with [Claude Code](https://claude.com/claude-code)