### PR TITLE
fix(cascade): use Coding Plan endpoint before pay-per-use API

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,23 +1,25 @@
 {
   "default_models": [
+    "glm-coding:glm-4.7",
+    "glm-coding:glm-5.1",
     "glm:glm-5.1",
-    "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "local_only_models": [
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "keeper_unified_models": [
-    "glm:glm-5.1",
-    "glm:glm-5-turbo",
+    "glm-coding:glm-4.7",
+    "glm-coding:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "coding_first_models": [
+    "glm-coding:glm-4.7",
+    "glm-coding:glm-5.1",
     "glm:glm-5.1",
-    "glm:glm-5-turbo",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "keeper_unified = 5.1(3s) -> 5-turbo -> local. coding_first = same order. flashx removed: hangs on api.z.ai (2026-04-11). local_only = Ollama only.",
+  "_comment": "glm-coding = Coding Plan endpoint (included in subscription). glm = general API (pay-per-use). Coding Plan first, API fallback, local last.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,


### PR DESCRIPTION
## Problem

GLM 일반 API 잔액 0 → 모든 keeper 429 실패.
Coding Max 구독 중이지만 cascade가 일반 API endpoint만 사용.

## Root Cause

- `glm:` prefix → `open.bigmodel.cn/api/paas/v4` (종량제, 잔액 0)
- `glm-coding:` prefix → `api.z.ai/api/coding/paas/v4` (구독 quota)

cascade.json이 전부 `glm:`으로 설정되어 있었음.

## Fix

Coding Plan endpoint 먼저, 일반 API fallback:
1. `glm-coding:glm-4.7` (구독 포함, 1x quota)
2. `glm-coding:glm-5.1` (구독 포함, 2-3x quota)
3. `glm:glm-5.1` (종량제 fallback)
4. `ollama:qwen3.5:35b-a3b-nvfp4` (로컬)

## Test plan

- [ ] keeper가 Coding Plan endpoint로 응답받는지 확인
- [ ] 429 시 local fallback 동작

Generated with [Claude Code](https://claude.com/claude-code)