### PR TITLE
fix(ci): restore keeper reset surface and typed tool expectations

### DIFF
--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -212,6 +212,8 @@ let explicit_metadata : (string * metadata) list =
     ("masc_tool_revoke", destructive_tool);
     ( "masc_keeper_reconcile",
       { default_metadata with required_permission = Some Types.CanBroadcast } );
+    ( "masc_keeper_reset",
+      { default_metadata with required_permission = Some Types.CanBroadcast } );
     ( "masc_operation_stop",
       destructive_tool );
     ( "masc_operation_pause",

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -124,7 +124,8 @@ let public_mcp_surface_tools =
     "masc_heartbeat";
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
-    "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reconcile"; "masc_keeper_down";
+    "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reconcile"; "masc_keeper_reset";
+    "masc_keeper_down";
     "masc_persona_list";
     (* Board *)
     "masc_board_post"; "masc_board_list"; "masc_board_get";

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -592,7 +592,7 @@ let handle_keeper_reconcile ctx args : tool_result =
                      [
                        ("name", `String name);
                        ("action", `String "clear");
-                       ("cleared", `Bool false);
+                       ("cleared", `Bool true);
                        ("already_cleared", `Bool true);
                        ("legacy_only", `Bool false);
                        ("record", Keeper_manual_reconcile.record_to_yojson record);
@@ -609,11 +609,12 @@ let handle_keeper_reconcile ctx args : tool_result =
                        ("record", `Null);
                      ]
                | Keeper_manual_reconcile.No_record ->
+                   clear_registry_manual_reconcile ~ctx ~name;
                    `Assoc
                      [
                        ("name", `String name);
                        ("action", `String "clear");
-                       ("cleared", `Bool false);
+                       ("cleared", `Bool true);
                        ("already_cleared", `Bool false);
                        ("legacy_only", `Bool false);
                        ("record", `Null);

--- a/test/test_keeper_reconcile_tool.ml
+++ b/test/test_keeper_reconcile_tool.ml
@@ -152,6 +152,69 @@ let test_keeper_reconcile_inspect_and_clear () =
         Yojson.Safe.Util.(
           status_after_json |> member "runtime" |> member "phase" |> to_string))
 
+let test_keeper_reconcile_clear_without_record_clears_runtime_blocker () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "reconcile-no-record" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_keepalive.stop_keepalive keeper_name;
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, _body =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Exercise no-record reconcile clear");
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      check bool "keeper up ok" true ok;
+      ignore
+        (Keeper_registry.dispatch_event
+           ~base_path:config.base_path
+           keeper_name
+           (Keeper_state_machine.Manual_reconcile_required
+              { reason = "stale runtime blocker" }));
+      let ok, clear_body =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_reconcile"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("action", `String "clear");
+                ("resolution", `String "runtime state was already clear");
+              ])
+      in
+      check bool "clear ok" true ok;
+      let clear_json = parse_json_exn clear_body in
+      check bool "clear result true" true
+        Yojson.Safe.Util.(clear_json |> member "cleared" |> to_bool);
+      check bool "not already cleared" false
+        Yojson.Safe.Util.(clear_json |> member "already_cleared" |> to_bool);
+      check bool "not legacy only" false
+        Yojson.Safe.Util.(clear_json |> member "legacy_only" |> to_bool);
+      check bool "record null" true
+        Yojson.Safe.Util.(clear_json |> member "record" = `Null);
+      let ok, status_body_after =
+        dispatch_keeper_exn ctx ~name:"masc_keeper_status"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      check bool "status ok after clear" true ok;
+      let status_after_json = parse_json_exn status_body_after in
+      check string "phase recovered to running" "running"
+        Yojson.Safe.Util.(
+          status_after_json |> member "runtime" |> member "phase" |> to_string))
+
 let () =
   run "keeper_reconcile_tool"
     [
@@ -159,5 +222,7 @@ let () =
         [
           test_case "inspect -> clear" `Quick
             test_keeper_reconcile_inspect_and_clear;
+          test_case "clear without record clears runtime blocker" `Quick
+            test_keeper_reconcile_clear_without_record_clears_runtime_blocker;
         ] );
     ]

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -27,12 +27,18 @@ let test_parse_missing_message () =
   | Error _ -> ()
 
 let test_parse_wrong_type () =
-  (* OAS ≥0.100.0 coerces Int→String via try_coerce, so `Int 42` would
-     succeed as "42".  Use a non-coercible type (List) to test rejection. *)
   let json = `Assoc [("message", `List [`String "a"])] in
   match parse json with
   | Ok _ -> Alcotest.fail "expected parse error"
   | Error _ -> ()
+
+let test_parse_coerces_int_message () =
+  let json = `Assoc [("message", `Int 42)] in
+  match parse json with
+  | Ok (message, format) ->
+    Alcotest.(check string) "message coerced" "42" message;
+    Alcotest.(check string) "format default" "" format
+  | Error e -> Alcotest.fail ("expected coercion: " ^ e)
 
 let test_handler_success () =
   match Tool_broadcast_typed.handle_broadcast ("hello @claude", "") with
@@ -78,10 +84,20 @@ let test_e2e_success () =
 
 let test_e2e_parse_error () =
   let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
-  (* Use non-coercible type (List) — Int would be coerced to String by OAS ≥0.100.0. *)
   match Agent_sdk.Typed_tool.execute oas_tool (`Assoc [("message", `List [`Int 1])]) with
   | Ok _ -> Alcotest.fail "expected error"
   | Error e -> Alcotest.(check bool) "recoverable" true e.recoverable
+
+let test_e2e_coerced_input () =
+  let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
+  match Agent_sdk.Typed_tool.execute oas_tool (`Assoc [("message", `Int 99)]) with
+  | Ok { content } ->
+    let result = Yojson.Safe.from_string content in
+    let open Yojson.Safe.Util in
+    Alcotest.(check bool) "delivered" true (result |> member "delivered" |> to_bool);
+    Alcotest.(check string) "room_message" "99"
+      (result |> member "room_message" |> to_string)
+  | Error e -> Alcotest.fail ("expected coercion success: " ^ e.message)
 
 let test_e2e_handler_error () =
   let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
@@ -105,6 +121,7 @@ let () =
       Alcotest.test_case "with format" `Quick test_parse_with_format;
       Alcotest.test_case "missing message" `Quick test_parse_missing_message;
       Alcotest.test_case "wrong type" `Quick test_parse_wrong_type;
+      Alcotest.test_case "int coerces to string" `Quick test_parse_coerces_int_message;
     ]);
     ("handler", [
       Alcotest.test_case "success" `Quick test_handler_success;
@@ -118,6 +135,7 @@ let () =
     ("e2e", [
       Alcotest.test_case "success" `Quick test_e2e_success;
       Alcotest.test_case "parse error" `Quick test_e2e_parse_error;
+      Alcotest.test_case "coerced input" `Quick test_e2e_coerced_input;
       Alcotest.test_case "handler error" `Quick test_e2e_handler_error;
     ]);
     ("registration", [


### PR DESCRIPTION
## Summary
- restore `masc_keeper_reset` to the public/tool-role catalogs so surface SSOT stays consistent
- make `masc_keeper_reconcile clear` treat missing manual-reconcile records as a successful runtime unblock without misreporting `already_cleared`
- update `test_typed_tool_masc` to match current `agent_sdk` coercion behavior for `int -> string`
- add reconcile coverage for the no-record runtime-blocker path

## Product impact
- fixes CI regressions introduced after #6467 merge
- keeps keeper reset reachable through the public MCP surface again
- prevents reconcile clear from leaving stale runtime manual-reconcile blockers when no record file exists

## Evidence
- `dune build --root . @check`
- `./_build/default/test/test_tool_surface_ssot.exe test ssot_validation 0 -v`
- `./_build/default/test/test_keeper_reconcile_tool.exe`
- `./_build/default/test/test_typed_tool_masc.exe`
- reproduced prior failing CI cases from job `70887400412` (`test_tool_surface_ssot`, `test_keeper_reconcile_tool`, `test_typed_tool_masc`)

## Review evidence
- GLM-5.1 fresh-context review run on 2026-04-11 KST against the working diff
- result: no actionable findings after triage; remaining comments were partial-diff false positives

## Linked issue
- Follow-up to #6467