### PR TITLE
fix(keeper): convert parse_keeper_identity from failwith to Result

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -793,21 +793,23 @@ type parsed_keeper_state =
   ; ps_runtime : agent_runtime_state
   }
 
-let parse_keeper_identity (json : Yojson.Safe.t) : parsed_keeper_identity =
+let parse_keeper_identity (json : Yojson.Safe.t)
+    : (parsed_keeper_identity, string) result =
   let pk_name = Safe_ops.json_string ~default:"" "name" json in
   let pk_agent_name = Safe_ops.json_string ~default:"" "agent_name" json in
   let pk_trace_id_raw = Safe_ops.json_string ~default:"" "trace_id" json in
-  let pk_trace_id =
+  match
     if String.trim pk_trace_id_raw = "" then
-      failwith "keeper meta parse error: missing trace_id in persisted keeper identity"
+      Error "missing trace_id in persisted keeper identity"
     else
       match Keeper_id.Trace_id.of_string pk_trace_id_raw with
-      | Ok x -> x
+      | Ok x -> Ok x
       | Error err ->
-        failwith
-          ("keeper meta parse error: invalid trace_id in persisted keeper identity: "
-           ^ err)
-  in
+        Error
+          ("invalid trace_id in persisted keeper identity: " ^ err)
+  with
+  | Error e -> Error ("keeper meta parse error: " ^ e)
+  | Ok pk_trace_id ->
   let pk_trace_history =
     Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
   in
@@ -843,7 +845,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : parsed_keeper_identity =
   let pk_cascade_name =
     Safe_ops.json_string ~default:Keeper_config.default_cascade_name "cascade_name" json
   in
-  { pk_name
+  Ok { pk_name
   ; pk_agent_name
   ; pk_trace_id
   ; pk_trace_history
@@ -1140,8 +1142,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       match reject_legacy_keeper_meta_fields json with
       | Error e -> Error e
       | Ok () ->
-      let identity = parse_keeper_identity json in
-      (match parse_keeper_policy json ~keeper_name:identity.pk_name with
+      (match parse_keeper_identity json with
+       | Error _ as e -> e
+       | Ok identity ->
+      match parse_keeper_policy json ~keeper_name:identity.pk_name with
        | Error _ as e -> e
        | Ok policy ->
          let state =

--- a/test/dune
+++ b/test/dune
@@ -244,6 +244,7 @@
         test_server_base_path_diagnostics
         test_server_startup_takeover
         test_keeper_meta_listing
+        test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify
@@ -394,6 +395,7 @@
         test_server_base_path_diagnostics
         test_server_startup_takeover
         test_keeper_meta_listing
+        test_keeper_identity_parse
         test_worker_runtime
         test_capability_registry
         test_tool_local_runtime_verify

--- a/test/test_keeper_identity_parse.ml
+++ b/test/test_keeper_identity_parse.ml
@@ -1,0 +1,69 @@
+(** Test keeper identity parsing — specifically the Result error paths
+    introduced by the failwith→Result refactor (PR #6479). *)
+
+open Alcotest
+open Masc_mcp
+
+let () = Server_startup_state.mark_state_ready ~backend_mode:"test"
+
+let minimal_keeper_json ~trace_id =
+  `Assoc
+    [ ("name", `String "alice")
+    ; ("agent_name", `String "keeper-alice-agent")
+    ; ("trace_id", `String trace_id)
+    ; ("goal", `String "test")
+    ]
+
+let test_valid_trace_id () =
+  match Keeper_types.meta_of_json (minimal_keeper_json ~trace_id:"alice-001") with
+  | Ok meta ->
+      check string "name" "alice" meta.name;
+      check string "agent_name" "keeper-alice-agent" meta.agent_name
+  | Error e -> fail ("expected Ok, got Error: " ^ e)
+
+let test_missing_trace_id () =
+  let json =
+    `Assoc
+      [ ("name", `String "bob")
+      ; ("agent_name", `String "keeper-bob-agent")
+      ; ("goal", `String "test")
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Error msg ->
+      check bool "error mentions trace_id"
+        true
+        (String.length msg > 0
+         && (try ignore (Str.search_forward (Str.regexp_string "trace_id") msg 0); true
+             with Not_found -> false))
+  | Ok _ -> fail "expected Error for missing trace_id"
+
+let test_empty_trace_id () =
+  match Keeper_types.meta_of_json (minimal_keeper_json ~trace_id:"") with
+  | Error msg ->
+      check bool "error mentions missing trace_id"
+        true
+        (String.length msg > 0
+         && (try ignore (Str.search_forward (Str.regexp_string "missing trace_id") msg 0); true
+             with Not_found -> false))
+  | Ok _ -> fail "expected Error for empty trace_id"
+
+let test_invalid_trace_id () =
+  match Keeper_types.meta_of_json (minimal_keeper_json ~trace_id:"..") with
+  | Error msg ->
+      check bool "error mentions invalid trace_id"
+        true
+        (String.length msg > 0
+         && (try ignore (Str.search_forward (Str.regexp_string "invalid trace_id") msg 0); true
+             with Not_found -> false))
+  | Ok _ -> fail "expected Error for invalid trace_id '..'"
+
+let () =
+  run "keeper_identity_parse"
+    [ ( "parse_keeper_identity"
+      , [ test_case "valid trace_id" `Quick test_valid_trace_id
+        ; test_case "missing trace_id field" `Quick test_missing_trace_id
+        ; test_case "empty trace_id" `Quick test_empty_trace_id
+        ; test_case "invalid trace_id (..)" `Quick test_invalid_trace_id
+        ] )
+    ]


### PR DESCRIPTION
## Summary
- Convert `parse_keeper_identity` from `failwith` to `(parsed_keeper_identity, string) result`
- Caller `meta_of_json` now uses explicit Result matching instead of relying on catch-all exception handler

## Why
`parse_keeper_identity` used `failwith` for validation errors (missing/invalid trace_id), relying on `meta_of_json`'s outer `try/with exn -> Error ...` to convert exceptions to Results. This is problematic because:
1. If called outside `meta_of_json`, the exception is uncaught — keeper crashes
2. The catch-all `| exn -> Error ...` also swallows unexpected bugs, hiding real issues
3. `parse_keeper_policy` (same file, same pattern) already returns Result correctly

## Test plan
- [x] `dune build` passes
- [ ] CI: TLA+ Model Checking
- [ ] CI: Build and Test

Closes #6464
Part of #6476

Generated with [Claude Code](https://claude.com/claude-code)
