### PR TITLE
refactor: FSM transition result type — detect invalid events

### DIFF
--- a/lib/state_product.ml
+++ b/lib/state_product.ml
@@ -29,18 +29,24 @@ module Agent_turn = struct
     | Tools_dispatched -> "tools_dispatched" | Results_collected -> "results_collected"
     | Turn_complete -> "turn_complete" | Turn_error s -> "turn_error:" ^ s
 
+  type transition = Applied of phase | Ignored of { phase: phase; event: event }
+
   let apply_event ~current event =
     match current, event with
-    | Idle, Turn_start -> Prompting
-    | Prompting, Prompt_ready -> Awaiting
-    | Awaiting, Response_received -> Parsing
-    | Parsing, Parse_complete -> Dispatching
-    | Dispatching, Tools_dispatched -> Collecting
-    | Collecting, Results_collected -> Finalizing
-    | Finalizing, Turn_complete -> Idle
-    | _, Turn_error _ -> Idle
-    | _, Turn_complete -> Idle
-    | phase, _ -> phase  (* ignore invalid transitions *)
+    | Idle, Turn_start -> Applied Prompting
+    | Prompting, Prompt_ready -> Applied Awaiting
+    | Awaiting, Response_received -> Applied Parsing
+    | Parsing, Parse_complete -> Applied Dispatching
+    | Dispatching, Tools_dispatched -> Applied Collecting
+    | Collecting, Results_collected -> Applied Finalizing
+    | Finalizing, Turn_complete -> Applied Idle
+    | _, Turn_error _ -> Applied Idle
+    | _, Turn_complete -> Applied Idle
+    | phase, event -> Ignored { phase; event }
+
+  let apply_event_lossy ~current event =
+    match apply_event ~current event with
+    | Applied p | Ignored { phase = p; _ } -> p
 end
 
 (* ── Dimension 3: Tool Validation ───────────────────────── *)
@@ -70,18 +76,24 @@ module Tool_validation = struct
     | Nondet_fixed -> "nondet_fixed" | Nondet_exhausted -> "nondet_exhausted"
     | Skip_validation -> "skip_validation"
 
+  type transition = Applied of phase | Ignored of { phase: phase; event: event }
+
   let apply_event ~current event =
     match current, event with
-    | Unchecked, Validate_start -> Det_correcting
-    | Unchecked, Skip_validation -> Valid
-    | Det_correcting, Det_fixed -> Det_valid
-    | Det_correcting, Det_failed -> Det_invalid
-    | Det_valid, Skip_validation -> Valid  (* explicit advance *)
-    | Det_invalid, Nondet_attempt _ -> Nondet_retrying
-    | Nondet_retrying, Nondet_fixed -> Valid
-    | Nondet_retrying, Nondet_exhausted -> Rejected
-    | Nondet_retrying, Nondet_attempt _ -> Nondet_retrying  (* retry loop *)
-    | phase, _ -> phase  (* ignore invalid transitions — no global reset *)
+    | Unchecked, Validate_start -> Applied Det_correcting
+    | Unchecked, Skip_validation -> Applied Valid
+    | Det_correcting, Det_fixed -> Applied Det_valid
+    | Det_correcting, Det_failed -> Applied Det_invalid
+    | Det_valid, Skip_validation -> Applied Valid
+    | Det_invalid, Nondet_attempt _ -> Applied Nondet_retrying
+    | Nondet_retrying, Nondet_fixed -> Applied Valid
+    | Nondet_retrying, Nondet_exhausted -> Applied Rejected
+    | Nondet_retrying, Nondet_attempt _ -> Applied Nondet_retrying
+    | phase, event -> Ignored { phase; event }
+
+  let apply_event_lossy ~current event =
+    match apply_event ~current event with
+    | Applied p | Ignored { phase = p; _ } -> p
 end
 
 (* ── Product State ──────────────────────────────────────── *)
@@ -147,7 +159,7 @@ let check_invariants (state : product) : (unit, string) result =
 (* ── Per-Dimension Event Application ────────────────────── *)
 
 let apply_turn_event state event =
-  let new_turn = Agent_turn.apply_event ~current:state.turn event in
+  let new_turn = Agent_turn.apply_event_lossy ~current:state.turn event in
   (* TLA+ bug fix: TurnError and TurnFinalize must reset validation to
      Unchecked, otherwise orphaned NondetRetrying violates invariant.
      TurnStart also resets validation for the new turn. *)
@@ -168,7 +180,7 @@ let apply_validation_event state event =
              (Tool_validation.event_to_string event)
              (Agent_turn.phase_to_string state.turn))
   else
-    let new_validation = Tool_validation.apply_event ~current:state.validation event in
+    let new_validation = Tool_validation.apply_event_lossy ~current:state.validation event in
     let new_state = { state with validation = new_validation } in
     match check_invariants new_state with
     | Ok () -> Ok new_state

--- a/lib/state_product.mli
+++ b/lib/state_product.mli
@@ -44,8 +44,13 @@ module Agent_turn : sig
 
   val event_to_string : event -> string
 
-  (** Pure transition function. *)
-  val apply_event : current:phase -> event -> phase
+  type transition = Applied of phase | Ignored of { phase: phase; event: event }
+
+  (** Pure transition function. Returns [Ignored] for invalid transitions. *)
+  val apply_event : current:phase -> event -> transition
+
+  (** Like [apply_event] but silently returns the phase on invalid transitions. *)
+  val apply_event_lossy : current:phase -> event -> phase
 end
 
 (** {3 Dimension 3: Tool Validation Lifecycle} *)
@@ -74,8 +79,10 @@ module Tool_validation : sig
 
   val event_to_string : event -> string
 
-  (** Pure transition function. *)
-  val apply_event : current:phase -> event -> phase
+  type transition = Applied of phase | Ignored of { phase: phase; event: event }
+
+  val apply_event : current:phase -> event -> transition
+  val apply_event_lossy : current:phase -> event -> phase
 end
 
 (** {4 Product State} *)

--- a/test/test_state_product.ml
+++ b/test/test_state_product.ml
@@ -13,45 +13,45 @@ let mk ?(keeper=K.Offline) ?(turn=AT.Idle) ?(validation=TV.Unchecked) () : State
 
 let test_turn_happy_path () =
   let open AT in
-  let s = apply_event ~current:Idle Turn_start in
+  let s = apply_event_lossy ~current:Idle Turn_start in
   Alcotest.(check string) "prompting" "prompting" (phase_to_string s);
-  let s = apply_event ~current:s Prompt_ready in
+  let s = apply_event_lossy ~current:s Prompt_ready in
   Alcotest.(check string) "awaiting" "awaiting" (phase_to_string s);
-  let s = apply_event ~current:s Response_received in
+  let s = apply_event_lossy ~current:s Response_received in
   Alcotest.(check string) "parsing" "parsing" (phase_to_string s);
-  let s = apply_event ~current:s Parse_complete in
+  let s = apply_event_lossy ~current:s Parse_complete in
   Alcotest.(check string) "dispatching" "dispatching" (phase_to_string s);
-  let s = apply_event ~current:s Tools_dispatched in
+  let s = apply_event_lossy ~current:s Tools_dispatched in
   Alcotest.(check string) "collecting" "collecting" (phase_to_string s);
-  let s = apply_event ~current:s Results_collected in
+  let s = apply_event_lossy ~current:s Results_collected in
   Alcotest.(check string) "finalizing" "finalizing" (phase_to_string s);
-  let s = apply_event ~current:s Turn_complete in
+  let s = apply_event_lossy ~current:s Turn_complete in
   Alcotest.(check string) "back to idle" "idle" (phase_to_string s)
 
 let test_turn_error_resets () =
-  let s = AT.apply_event ~current:Awaiting (Turn_error "timeout") in
+  let s = AT.apply_event_lossy ~current:Awaiting (Turn_error "timeout") in
   Alcotest.(check string) "error resets" "idle" (AT.phase_to_string s)
 
 (* ── Tool Validation FSM ────────────────────────────────── *)
 
 let test_validation_det_fixed () =
-  let s = TV.apply_event ~current:Unchecked Validate_start in
+  let s = TV.apply_event_lossy ~current:Unchecked Validate_start in
   Alcotest.(check string) "det_correcting" "det_correcting" (TV.phase_to_string s);
-  let s = TV.apply_event ~current:s Det_fixed in
+  let s = TV.apply_event_lossy ~current:s Det_fixed in
   Alcotest.(check string) "det_valid" "det_valid" (TV.phase_to_string s)
 
 let test_validation_nondet_retry () =
-  let s = TV.apply_event ~current:Det_invalid (Nondet_attempt 1) in
+  let s = TV.apply_event_lossy ~current:Det_invalid (Nondet_attempt 1) in
   Alcotest.(check string) "nondet_retrying" "nondet_retrying" (TV.phase_to_string s);
-  let s = TV.apply_event ~current:s Nondet_fixed in
+  let s = TV.apply_event_lossy ~current:s Nondet_fixed in
   Alcotest.(check string) "valid" "valid" (TV.phase_to_string s)
 
 let test_validation_rejected () =
-  let s = TV.apply_event ~current:Nondet_retrying Nondet_exhausted in
+  let s = TV.apply_event_lossy ~current:Nondet_retrying Nondet_exhausted in
   Alcotest.(check string) "rejected" "rejected" (TV.phase_to_string s)
 
 let test_validation_skip () =
-  let s = TV.apply_event ~current:Unchecked Skip_validation in
+  let s = TV.apply_event_lossy ~current:Unchecked Skip_validation in
   Alcotest.(check string) "valid" "valid" (TV.phase_to_string s)
 
 (* ── Product Invariants ─────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- `apply_event` returns `Applied | Ignored` instead of silently preserving state
- `apply_event_lossy` for backward-compatible callers
- Enables logging/counting of dropped events in production

## Test plan
- [ ] 20/20 state product tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)