### PR TITLE
refactor: unshadow Stdlib.result — rename type result to tool_result in all tool modules

### DIFF
--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -10,7 +10,7 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 let handle_poll_events _ctx args =
   let subscription_id = get_string args "subscription_id" "" in
@@ -51,7 +51,7 @@ let handle_heartbeat_result _ctx args =
     | Error e -> (false, Printf.sprintf "Submit result failed: %s" e)
 
 (* Dispatch function - returns None if tool not handled *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_poll_events" -> Some (handle_poll_events ctx args)
   | "masc_heartbeat_result" -> Some (handle_heartbeat_result ctx args)

--- a/lib/tool_a2a.mli
+++ b/lib/tool_a2a.mli
@@ -6,12 +6,12 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
-val handle_poll_events : context -> Yojson.Safe.t -> result
-val handle_heartbeat_result : context -> Yojson.Safe.t -> result
+val handle_poll_events : context -> Yojson.Safe.t -> tool_result
+val handle_heartbeat_result : context -> Yojson.Safe.t -> tool_result
 
 (** Tool schemas for MCP tools/list *)
 val schemas : Types.tool_schema list
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -11,7 +11,7 @@
 
 open Tool_args
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config : Room.config;
@@ -428,7 +428,7 @@ let schemas : Types.tool_schema list =
   ]
 
 (* Handler *)
-let handle_agent_timeline (ctx : context) args : result =
+let handle_agent_timeline (ctx : context) args : tool_result =
   let agent_name = get_string args "agent_name" "" in
   if String.length agent_name = 0 then
     (false, "agent_name is required")
@@ -445,7 +445,7 @@ let handle_agent_timeline (ctx : context) args : result =
     (true, Yojson.Safe.to_string json)
 
 (* Dispatch *)
-let dispatch (ctx : context) ~name ~args : result option =
+let dispatch (ctx : context) ~name ~args : tool_result option =
   match name with
   | "masc_agent_timeline" -> Some (handle_agent_timeline ctx args)
   | _ -> None

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -7,7 +7,7 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 let target_agent_name ctx args =
   match get_string args "agent_name" ctx.agent_name |> String.trim with
@@ -159,7 +159,7 @@ let handle_auth_list ctx _args =
     (true, Buffer.contents buf)
   end
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_auth_enable" -> Some (handle_auth_enable ctx args)
   | "masc_auth_disable" -> Some (handle_auth_disable ctx args)

--- a/lib/tool_auth.mli
+++ b/lib/tool_auth.mli
@@ -5,16 +5,16 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
-val handle_auth_enable : context -> Yojson.Safe.t -> result
-val handle_auth_disable : context -> Yojson.Safe.t -> result
-val handle_auth_status : context -> Yojson.Safe.t -> result
-val handle_auth_create_token : context -> Yojson.Safe.t -> result
-val handle_auth_refresh : context -> Yojson.Safe.t -> result
-val handle_auth_revoke : context -> Yojson.Safe.t -> result
-val handle_auth_list : context -> Yojson.Safe.t -> result
+val handle_auth_enable : context -> Yojson.Safe.t -> tool_result
+val handle_auth_disable : context -> Yojson.Safe.t -> tool_result
+val handle_auth_status : context -> Yojson.Safe.t -> tool_result
+val handle_auth_create_token : context -> Yojson.Safe.t -> tool_result
+val handle_auth_refresh : context -> Yojson.Safe.t -> tool_result
+val handle_auth_revoke : context -> Yojson.Safe.t -> tool_result
+val handle_auth_list : context -> Yojson.Safe.t -> tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val schemas : Types.tool_schema list

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -16,7 +16,7 @@ include Tool_autoresearch_repo_synthesis
 
 let schemas = Tool_autoresearch_schemas.schemas
 
-type result = bool * string
+type tool_result = bool * string
 
 let persisted_summary_json (summary : Autoresearch.persisted_summary) =
   `Assoc
@@ -430,7 +430,7 @@ let handle_search_findings _ctx args =
     ]
 
 (** Dispatch an autoresearch tool call (standard MCP pattern). *)
-let dispatch (ctx : context) ~name ~args : result option =
+let dispatch (ctx : context) ~name ~args : tool_result option =
   match name with
   | "masc_autoresearch_start" -> Some (wrap_result (handle_start ctx args))
   | "masc_autoresearch_swarm_start" ->

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -40,7 +40,7 @@ let strip_state_blocks_text (s : string) : string =
   loop 0 buf;
   Buffer.contents buf
 
-type result = bool * string
+type tool_result = bool * string
 
 
 (** {1 Helpers} *)

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -18,7 +18,7 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 (* Security: Binary file extensions *)
 let binary_extensions = [
@@ -336,7 +336,7 @@ let handle_code_read ctx args =
   end
 
 (* Dispatch function - returns None if tool not handled *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_code_search" -> Some (handle_code_search ctx args)
   | "masc_code_symbols" -> Some (handle_code_symbols ctx args)

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -19,7 +19,7 @@ type context = {
   agent_name : string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 let max_write_size = 1024 * 1024 (* 1MB *)
 
@@ -606,7 +606,7 @@ let handle_code_git ctx args =
   end
 
 (* Dispatch *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_code_write" -> Some (handle_code_write ctx args)
   | "masc_code_edit" -> Some (handle_code_edit ctx args)

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -9,7 +9,7 @@ type ('clock, 'net) context = ('clock, 'net) Tool_command_plane_support.context 
   auth_token : string option;
 }
 
-type result = Tool_command_plane_support.result
+type tool_result = Tool_command_plane_support.tool_result
 
 let dispatch = Tool_command_plane_dispatch.dispatch
 

--- a/lib/tool_command_plane_dispatch.ml
+++ b/lib/tool_command_plane_dispatch.ml
@@ -2,7 +2,7 @@ open Tool_command_plane_support
 open Tool_command_plane_mutations
 open Tool_command_plane_operations
 
-let dispatch (ctx : (_, _) context) ~name ~args : result option =
+let dispatch (ctx : (_, _) context) ~name ~args : tool_result option =
   match name with
   | "masc_unit_define" -> Some (handle_unit_define ctx args)
   | "masc_unit_list" -> Some (handle_unit_list ctx)

--- a/lib/tool_command_plane_mutations.ml
+++ b/lib/tool_command_plane_mutations.ml
@@ -1,65 +1,65 @@
 open Tool_command_plane_support
 
-let handle_unit_update (ctx : (_, _) context) args : result =
+let handle_unit_update (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.unit_update_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_unit_reparent (ctx : (_, _) context) args : result =
+let handle_unit_reparent (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.unit_reparent_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_unit_reassign (ctx : (_, _) context) args : result =
+let handle_unit_reassign (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.unit_reassign_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_operation_pause (ctx : (_, _) context) args : result =
+let handle_operation_pause (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.pause_operation_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_operation_resume (ctx : (_, _) context) args : result =
+let handle_operation_resume (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.resume_operation_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_operation_stop (ctx : (_, _) context) args : result =
+let handle_operation_stop (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.stop_operation_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_operation_finalize (ctx : (_, _) context) args : result =
+let handle_operation_finalize (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.finalize_operation_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_dispatch_plan (ctx : (_, _) context) args : result =
+let handle_dispatch_plan (ctx : (_, _) context) args : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.dispatch_plan_json ctx.config args))
 
-let handle_dispatch_route (ctx : (_, _) context) args : result =
+let handle_dispatch_route (ctx : (_, _) context) args : tool_result =
   handle_dispatch_plan ctx args
 
-let handle_dispatch_assign (ctx : (_, _) context) args : result =
+let handle_dispatch_assign (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.dispatch_assign_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_dispatch_rebalance (ctx : (_, _) context) args : result =
+let handle_dispatch_rebalance (ctx : (_, _) context) args : tool_result =
   json_result
     (Command_plane_v2.dispatch_rebalance_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_dispatch_escalate (ctx : (_, _) context) args : result =
+let handle_dispatch_escalate (ctx : (_, _) context) args : tool_result =
   json_result
     (Command_plane_v2.dispatch_escalate_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_dispatch_recall (ctx : (_, _) context) args : result =
+let handle_dispatch_recall (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.dispatch_recall_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_dispatch_tick (ctx : (_, _) context) args : result =
+let handle_dispatch_tick (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.dispatch_tick_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_policy_status (ctx : (_, _) context) : result =
+let handle_policy_status (ctx : (_, _) context) : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.policy_status_json ctx.config))
 
-let handle_policy_approve (ctx : (_, _) context) args : result =
+let handle_policy_approve (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.policy_approve_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_policy_deny (ctx : (_, _) context) args : result =
+let handle_policy_deny (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.policy_deny_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_policy_update (ctx : (_, _) context) args : result =
+let handle_policy_update (ctx : (_, _) context) args : tool_result =
   json_result (Command_plane_v2.policy_update_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_policy_freeze_unit (ctx : (_, _) context) args : result =
+let handle_policy_freeze_unit (ctx : (_, _) context) args : tool_result =
   json_result
     (Command_plane_v2.policy_freeze_unit_json ctx.config ~actor:ctx.agent_name args)
 
-let handle_policy_kill_switch (ctx : (_, _) context) args : result =
+let handle_policy_kill_switch (ctx : (_, _) context) args : tool_result =
   json_result
     (Command_plane_v2.policy_kill_switch_json ctx.config ~actor:ctx.agent_name args)

--- a/lib/tool_command_plane_operations.ml
+++ b/lib/tool_command_plane_operations.ml
@@ -204,13 +204,13 @@ let blocker_json ~code ~detail =
 
 (* --- Operation handlers --- *)
 
-let handle_operation_status (ctx : (_, _) context) args : result =
+let handle_operation_status (ctx : (_, _) context) args : tool_result =
   let operation_id = get_string_opt args "operation_id" in
   ( true,
     Yojson.Safe.to_string
       (Command_plane_v2.operation_status_json ctx.config ?operation_id ()) )
 
-let handle_operation_start (ctx : (_, _) context) args : result =
+let handle_operation_start (ctx : (_, _) context) args : tool_result =
   try
     match
       Command_plane_v2.start_operation ctx.config ~actor:ctx.agent_name args
@@ -225,7 +225,7 @@ let handle_operation_start (ctx : (_, _) context) args : result =
     | Error message -> (false, json_error message)
   with Invalid_argument message -> (false, json_error message)
 
-let handle_operation_checkpoint (ctx : (_, _) context) args : result =
+let handle_operation_checkpoint (ctx : (_, _) context) args : tool_result =
   try
     match Command_plane_v2.checkpoint_operation ctx.config ~actor:ctx.agent_name args with
     | Ok operation ->
@@ -240,21 +240,21 @@ let handle_operation_checkpoint (ctx : (_, _) context) args : result =
 
 (* --- Intent handlers --- *)
 
-let handle_intent_create (ctx : (_, _) context) args : result =
+let handle_intent_create (ctx : (_, _) context) args : tool_result =
   (match Command_plane_v2.create_intent_json ctx.config ~actor:ctx.agent_name args with
   | Ok intent -> (true, json_ok [ ("result", Command_plane_v2.intent_to_json intent) ])
   | Error message -> (false, json_error message))
 
-let handle_intent_status (ctx : (_, _) context) args : result =
+let handle_intent_status (ctx : (_, _) context) args : tool_result =
   let intent_id = get_string_opt args "intent_id" in
   (true, Yojson.Safe.to_string (Command_plane_v2.list_intents_json ?intent_id ctx.config))
 
-let handle_intent_update (ctx : (_, _) context) args : result =
+let handle_intent_update (ctx : (_, _) context) args : tool_result =
   (match Command_plane_v2.update_intent_json ctx.config ~actor:ctx.agent_name args with
   | Ok intent -> (true, json_ok [ ("result", Command_plane_v2.intent_to_json intent) ])
   | Error message -> (false, json_error message))
 
-let handle_intent_forecast (ctx : (_, _) context) args : result =
+let handle_intent_forecast (ctx : (_, _) context) args : tool_result =
   let intent_id =
     match get_string_opt args "intent_id" with
     | Some value -> value
@@ -269,16 +269,16 @@ let handle_intent_forecast (ctx : (_, _) context) args : result =
 
 (* --- Observe handlers --- *)
 
-let handle_observe_topology (ctx : (_, _) context) : result =
+let handle_observe_topology (ctx : (_, _) context) : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.topology_json ctx.config))
 
-let handle_observe_alerts (ctx : (_, _) context) : result =
+let handle_observe_alerts (ctx : (_, _) context) : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.list_alerts_json ctx.config))
 
-let handle_observe_operations (ctx : (_, _) context) : result =
+let handle_observe_operations (ctx : (_, _) context) : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.observe_operations_json ctx.config))
 
-let handle_observe_swarm (ctx : (_, _) context) args : result =
+let handle_observe_swarm (ctx : (_, _) context) args : tool_result =
   let run_id =
     match get_string_opt args "run_id" with
     | Some value -> Some value
@@ -430,10 +430,10 @@ let handle_observe_swarm (ctx : (_, _) context) args : result =
                   ] );
             ] ) )
 
-let handle_observe_capacity (ctx : (_, _) context) : result =
+let handle_observe_capacity (ctx : (_, _) context) : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.observe_capacity_json ctx.config))
 
-let handle_observe_traces (ctx : (_, _) context) args : result =
+let handle_observe_traces (ctx : (_, _) context) args : tool_result =
   let operation_id = get_string_opt args "operation_id" in
   let limit =
     match Yojson.Safe.Util.member "limit" args with

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -11,7 +11,7 @@ type ('clock, 'net) context = {
   auth_token : string option;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 let get_string_opt = Tool_args.get_string_opt
 let get_bool = Tool_args.get_bool
@@ -335,7 +335,7 @@ let swarm_live_error_payload config ~run_id ~message ?proc () =
   | Some process -> Yojson.Safe.to_string (json_with_process_metadata payload process)
   | None -> Yojson.Safe.to_string payload
 
-let handle_unit_define (ctx : (_, _) context) args : result =
+let handle_unit_define (ctx : (_, _) context) args : tool_result =
   try
     match Command_plane_v2.upsert_unit ctx.config ~actor:ctx.agent_name args with
     | Ok unit ->
@@ -348,7 +348,7 @@ let handle_unit_define (ctx : (_, _) context) args : result =
     | Error message -> (false, json_error message)
   with Invalid_argument message -> (false, json_error message)
 
-let handle_unit_list (ctx : (_, _) context) : result =
+let handle_unit_list (ctx : (_, _) context) : tool_result =
   (true, Yojson.Safe.to_string (Command_plane_v2.list_units_json ctx.config))
 
 let object_schema = Tool_schema_dsl.object_schema

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -76,7 +76,7 @@ Each message has 'role' (system/user/assistant/tool) and 'content' (string).");
 (* Types                                                            *)
 (* ================================================================ *)
 
-type result = bool * string
+type tool_result = bool * string
 
 (* ================================================================ *)
 (* Helpers                                                          *)
@@ -132,7 +132,7 @@ let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
 (* Handler                                                          *)
 (* ================================================================ *)
 
-let handle_compact args : result =
+let handle_compact args : tool_result =
   try
     let open Yojson.Safe.Util in
     let messages_json = args |> member "messages" |> to_list in
@@ -198,7 +198,7 @@ let handle_compact args : result =
 (* Dispatcher                                                       *)
 (* ================================================================ *)
 
-let dispatch ~name ~args : result option =
+let dispatch ~name ~args : tool_result option =
   match name with
   | "masc_compact_context" -> Some (handle_compact args)
   | _ -> None

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -5,7 +5,7 @@
 
 open Tool_args
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config: Room.config;
@@ -101,7 +101,7 @@ let handle_pause_status ctx args =
 let schemas = Tool_schemas_control.schemas
 
 (* Dispatch function *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_pause" -> Some (handle_pause ctx args)
   | "masc_resume" -> Some (handle_resume ctx args)

--- a/lib/tool_dispatch.mli
+++ b/lib/tool_dispatch.mli
@@ -5,7 +5,7 @@
     that captures its own context, so the dispatch layer does not need
     to know about heterogeneous context types. *)
 
-(** Unified handler type: every tool call is [name * args -> result option].
+(** Unified handler type: every tool call is [name * args -> tool_result option].
     [None] means "this handler does not know this tool". *)
 type handler = name:string -> args:Yojson.Safe.t -> (bool * string) option
 

--- a/lib/tool_handover.ml
+++ b/lib/tool_handover.ml
@@ -11,7 +11,7 @@ type context = {
   sw: Eio.Switch.t option;  (* Only needed when fs and proc_mgr are Some *)
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 (* Individual handlers *)
 let handle_handover_create ctx args =
@@ -227,7 +227,7 @@ Pair with masc_handover_list to browse available handovers first.";
 ]
 
 (* Dispatch function - returns None if tool not handled *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_handover_create" -> Some (handle_handover_create ctx args)
   | "masc_handover_list" -> Some (handle_handover_list ctx args)

--- a/lib/tool_handover.mli
+++ b/lib/tool_handover.mli
@@ -8,13 +8,13 @@ type context = {
   sw: Eio.Switch.t option;  (** Only needed when fs and proc_mgr are Some *)
 }
 
-type result = bool * string
+type tool_result = bool * string
 
-val handle_handover_create : context -> Yojson.Safe.t -> result
-val handle_handover_list : context -> Yojson.Safe.t -> result
-val handle_handover_claim : context -> Yojson.Safe.t -> result
-val handle_handover_get : context -> Yojson.Safe.t -> result
+val handle_handover_create : context -> Yojson.Safe.t -> tool_result
+val handle_handover_list : context -> Yojson.Safe.t -> tool_result
+val handle_handover_claim : context -> Yojson.Safe.t -> tool_result
+val handle_handover_get : context -> Yojson.Safe.t -> tool_result
 
 val schemas : Types.tool_schema list
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -9,7 +9,7 @@ type 'a context = {
   clock: 'a Eio.Time.clock;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 (* Eio cancellation is structured control flow, not an operational error. *)
 let log_non_cancelled prefix = function
@@ -117,7 +117,7 @@ let handle_heartbeat_list _ctx args =
   in
   (true, list_str)
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_heartbeat" -> Some (handle_heartbeat ctx args)
   | "masc_heartbeat_start" -> Some (handle_heartbeat_start ctx args)

--- a/lib/tool_heartbeat.mli
+++ b/lib/tool_heartbeat.mli
@@ -7,12 +7,12 @@ type 'a context = {
   clock: 'a Eio.Time.clock;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
-val handle_heartbeat : _ context -> Yojson.Safe.t -> result
-val handle_heartbeat_start : _ context -> Yojson.Safe.t -> result
-val handle_heartbeat_stop : _ context -> Yojson.Safe.t -> result
-val handle_heartbeat_list : _ context -> Yojson.Safe.t -> result
+val handle_heartbeat : _ context -> Yojson.Safe.t -> tool_result
+val handle_heartbeat_start : _ context -> Yojson.Safe.t -> tool_result
+val handle_heartbeat_stop : _ context -> Yojson.Safe.t -> tool_result
+val handle_heartbeat_list : _ context -> Yojson.Safe.t -> tool_result
 
 (** Canonical masc_heartbeat schema — SSOT.
     Other modules derive their projections from this value. *)
@@ -21,4 +21,4 @@ val heartbeat_schema : Types.tool_schema
 (** Tool schemas for MCP tools/list *)
 val schemas : Types.tool_schema list
 
-val dispatch : _ context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : _ context -> name:string -> args:Yojson.Safe.t -> tool_result option

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -16,7 +16,7 @@
 (** Re-export shared types so callers can use
     [Tool_inline_dispatch.context] and [Tool_inline_dispatch.result]
     without knowing about the types sub-module. *)
-type result = Tool_inline_dispatch_types.result
+type tool_result = Tool_inline_dispatch_types.tool_result
 type context = Tool_inline_dispatch_types.context = {
   config : Room.config;
   agent_name : string;
@@ -45,7 +45,7 @@ let safe_exec = Tool_inline_dispatch_types.safe_exec
 (** Dispatch a tool call.
     Returns [Some (success, message)] if the tool name is handled,
     [None] if the tool name is not recognized by this module. *)
-let dispatch (ctx : context) ~(name : string) : result option =
+let dispatch (ctx : context) ~(name : string) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let state = ctx.state in

--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -27,7 +27,7 @@ let invalid_bounded_agents (agents : string list) : string list =
   List.sort_uniq String.compare invalid
 
 (** masc_bounded_run — run a bounded multi-agent execution *)
-let handle_bounded_run (ctx : context) : result option =
+let handle_bounded_run (ctx : context) : tool_result option =
   let module U = Yojson.Safe.Util in
   let state = ctx.state in
   let sw = ctx.sw in
@@ -70,7 +70,7 @@ let handle_bounded_run (ctx : context) : result option =
       Some (result.Bounded.status = `Goal_reached, Yojson.Safe.pretty_to_string json)
 
 (** masc_broadcast — broadcast a message to the room *)
-let handle_broadcast (ctx : context) : result option =
+let handle_broadcast (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in
@@ -124,14 +124,14 @@ let handle_broadcast (ctx : context) : result option =
   end
 
 (** masc_messages — retrieve recent messages *)
-let handle_messages (ctx : context) : result option =
+let handle_messages (ctx : context) : tool_result option =
   let config = ctx.config in
   let since_seq = arg_get_int ctx "since_seq" 0 in
   let limit = arg_get_int ctx "limit" 10 in
   Some (true, Room.get_messages config ~since_seq ~limit)
 
 (** masc_listen — long-poll for a message addressed to this agent *)
-let handle_listen (ctx : context) : result option =
+let handle_listen (ctx : context) : tool_result option =
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in
   let timeout = float_of_int (arg_get_int ctx "timeout" 300) in
@@ -155,6 +155,6 @@ Call masc_listen again to continue listening.
        Some (true, Printf.sprintf "Listening timed out after %.0fs. No messages received." timeout))
 
 (** masc_who — list agents currently in the room *)
-let handle_who (ctx : context) : result option =
+let handle_who (ctx : context) : tool_result option =
   let registry = ctx.registry in
   Some (true, Session.status_string registry)

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -15,7 +15,7 @@ let arg_get_string_list ctx key =
   Safe_ops.json_string_list key ctx.arguments
 
 (** masc_start — compound onboarding (set project root + join + optional task) *)
-let handle_start (ctx : context) : result option =
+let handle_start (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let state = ctx.state in
@@ -118,7 +118,7 @@ let handle_start (ctx : context) : result option =
       end
 
 (** masc_lock — acquire a file lock *)
-let handle_lock (ctx : context) : result option =
+let handle_lock (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let file = arg_get_string ctx "file" "" in
@@ -160,7 +160,7 @@ let handle_lock (ctx : context) : result option =
   end
 
 (** masc_unlock — release a file lock *)
-let handle_unlock (ctx : context) : result option =
+let handle_unlock (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let file = arg_get_string ctx "file" "" in
@@ -197,7 +197,7 @@ let handle_unlock (ctx : context) : result option =
   end
 
 (** masc_set_room — set the active MASC project root *)
-let handle_set_room (ctx : context) : result option =
+let handle_set_room (ctx : context) : tool_result option =
   let state = ctx.state in
   let path =
     let p = arg_get_string ctx "path" "" in
@@ -250,7 +250,7 @@ let handle_set_room (ctx : context) : result option =
     end
 
 (** masc_join — join the active MASC project namespace *)
-let handle_join (ctx : context) : result option =
+let handle_join (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in
@@ -317,7 +317,7 @@ let handle_join (ctx : context) : result option =
   Some (true, final_result)
 
 (** masc_leave — leave a MASC room *)
-let handle_leave (ctx : context) : result option =
+let handle_leave (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in
   let registry = ctx.registry in

--- a/lib/tool_inline_dispatch_types.ml
+++ b/lib/tool_inline_dispatch_types.ml
@@ -3,7 +3,7 @@
     Extracted to avoid circular dependencies between
     tool_inline_dispatch, tool_inline_dispatch_room, and tool_inline_dispatch_comm. *)
 
-type result = bool * string
+type tool_result = bool * string
 
 (** Context record capturing all bindings from execute_tool_eio
     that the inline dispatch block needs. *)

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -24,7 +24,7 @@ let string_contains ~sub s =
     in
     check 0
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   agent_name: string;
@@ -282,7 +282,7 @@ let handle_search _ctx args =
   end
 
 (* Dispatch *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_library_list" -> Some (handle_list ctx args)
   | "masc_library_read" -> Some (handle_read ctx args)

--- a/lib/tool_local_runtime.ml
+++ b/lib/tool_local_runtime.ml
@@ -25,7 +25,7 @@ let ollama_loaded_models_of_ps_json = Tool_local_runtime_probe.ollama_loaded_mod
 let ollama_probe_run_of_generate_json = Tool_local_runtime_probe.ollama_probe_run_of_generate_json
 let kv_cache_assessment_json = Tool_local_runtime_probe.kv_cache_assessment_json
 
-let handle_models _ctx : result =
+let handle_models _ctx : tool_result =
   match fetch_models () with
   | Error msg -> (false, json_error msg)
   | Ok (url, models) ->
@@ -43,7 +43,7 @@ let handle_models _ctx : result =
                 ] );
           ] )
 
-let handle_runtime_status _ctx args : result =
+let handle_runtime_status _ctx args : tool_result =
   let include_models =
     match Yojson.Safe.Util.member "include_models" args with
     | `Bool flag -> flag
@@ -51,7 +51,7 @@ let handle_runtime_status _ctx args : result =
   in
   (true, json_ok [ ("result", runtime_status_json ~include_models ()) ])
 
-let handle_runtime_verify _ctx args : result =
+let handle_runtime_verify _ctx args : tool_result =
   let open Yojson.Safe.Util in
   let runtime_pool = member "runtime_pool" args |> to_string_option in
   let expected_model = member "expected_model" args |> to_string_option in
@@ -75,7 +75,7 @@ let handle_runtime_verify _ctx args : result =
             ?expected_model () );
       ] )
 
-let handle_runtime_bench _ctx args : result =
+let handle_runtime_bench _ctx args : tool_result =
   let open Yojson.Safe.Util in
   let model_id = member "model" args |> to_string_option in
   let runtime_pool = member "runtime_pool" args |> to_string_option in
@@ -127,7 +127,7 @@ let handle_runtime_bench _ctx args : result =
   | Ok json -> (true, json_ok [ ("result", json) ])
   | Error err -> (false, json_error err)
 
-let handle_runtime_ollama_probe _ctx args : result =
+let handle_runtime_ollama_probe _ctx args : tool_result =
   let open Yojson.Safe.Util in
   let server_url = member "server_url" args |> to_string_option in
   let model = member "model" args |> to_string_option in
@@ -159,7 +159,7 @@ let handle_runtime_ollama_probe _ctx args : result =
             ~probe_runs ~max_tokens ~timeout_sec () );
       ] )
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   (* Canonical names *)
   | "masc_runtime_verify" ->

--- a/lib/tool_local_runtime_core.ml
+++ b/lib/tool_local_runtime_core.ml
@@ -5,7 +5,7 @@ type context = {
   agent_name : string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 type llama_process = {
   pid : int option;

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -11,7 +11,7 @@
 
 open Tool_args
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config: Room.config;
@@ -192,7 +192,7 @@ let tool_inventory_json ctx ~include_hidden ~include_deprecated =
 (* Dispatch (facade)                                                *)
 (* ================================================================ *)
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   let admin_ctx : Tool_misc_admin.context =
     { config = ctx.config; agent_name = ctx.agent_name }
   in

--- a/lib/tool_misc.mli
+++ b/lib/tool_misc.mli
@@ -4,7 +4,7 @@
     dashboard, verify_handoff, gc, cleanup_zombies, tool_stats,
     tool_help, tool_admin, keeper_tool_catalog, deep_review. *)
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config : Room.config;
@@ -32,9 +32,9 @@ val web_search_simulate_for_test :
      | `Hits of (string * string * string) list
      ])
   list ->
-  result
+  tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val tool_inventory_json :
   context -> include_hidden:bool -> include_deprecated:bool -> Yojson.Safe.t

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -10,7 +10,7 @@ open Tool_args
 
 module U = Yojson.Safe.Util
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config: Room.config;
@@ -200,7 +200,7 @@ let enforcement_summary_json () =
 (* Handlers                                                         *)
 (* ================================================================ *)
 
-let handle_feature_flags args : result =
+let handle_feature_flags args : tool_result =
   let category_filter =
     match U.member "category" args with
     | `String c when String.trim c <> "" -> Some (String.lowercase_ascii (String.trim c))
@@ -230,7 +230,7 @@ let handle_feature_flags args : result =
   ] in
   (true, Yojson.Safe.to_string json)
 
-let handle_config args : result =
+let handle_config args : tool_result =
   let cat = get_string_opt args "category" in
   let json = Env_config_introspect.to_json_filtered ?cat () in
   (true, Yojson.Safe.to_string json)

--- a/lib/tool_misc_transport.ml
+++ b/lib/tool_misc_transport.ml
@@ -7,7 +7,7 @@
 
 open Tool_args
 
-type result = bool * string
+type tool_result = bool * string
 
 (* ================================================================ *)
 (* Local helpers (duplicated from tool_misc to avoid circular deps) *)
@@ -31,7 +31,7 @@ let env_flag_enabled name =
 (* Handlers                                                         *)
 (* ================================================================ *)
 
-let handle_transport_status _args : result =
+let handle_transport_status _args : tool_result =
   let ctx =
     Transport_read_model.context_from_env
       ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
@@ -39,7 +39,7 @@ let handle_transport_status _args : result =
   let json = Transport_read_model.transport_status_json ctx in
   (true, Yojson.Safe.to_string json)
 
-let handle_websocket_discovery _args : result =
+let handle_websocket_discovery _args : tool_result =
   let ctx =
     Transport_read_model.context_from_env
       ~allow_legacy_accept:(env_flag_enabled "MASC_ALLOW_LEGACY_ACCEPT") ()
@@ -47,7 +47,7 @@ let handle_websocket_discovery _args : result =
   let json = Transport_read_model.websocket_discovery_json ctx in
   (true, Yojson.Safe.to_string json)
 
-let handle_webrtc_offer args : result =
+let handle_webrtc_offer args : tool_result =
   if not (Server_webrtc_transport.is_enabled ()) then
     error_result "webrtc transport disabled"
   else
@@ -71,7 +71,7 @@ let handle_webrtc_offer args : result =
   | Ok body -> (true, pretty_json_string body)
   | Error msg -> error_result msg
 
-let handle_webrtc_answer args : result =
+let handle_webrtc_answer args : tool_result =
   if not (Server_webrtc_transport.is_enabled ()) then
     error_result "webrtc transport disabled"
   else

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -11,7 +11,7 @@ type 'a context = {
   mcp_session_id : string option;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 let schema_properties entries = `Assoc entries
 
@@ -224,7 +224,7 @@ let json_string_of_result = function
   | Ok json -> (true, Yojson.Safe.to_string json)
   | Error message -> (false, Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String message) ]))
 
-let dispatch (ctx : 'a context) ~name ~args : result option =
+let dispatch (ctx : 'a context) ~name ~args : tool_result option =
   let control_ctx : 'a Operator_control.context =
     {
       config = ctx.config;

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -11,13 +11,13 @@ type context = {
 }
 
 (** Tool result type *)
-type result = bool * string
+type tool_result = bool * string
 
 open Tool_args
 
 (** {1 Individual Handlers} *)
 
-let handle_plan_init ctx args : result =
+let handle_plan_init ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   let result = Planning_eio.init ctx.config ~task_id in
   match result with
@@ -31,7 +31,7 @@ let handle_plan_init ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to init planning: %s" e)
 
-let handle_plan_update ctx args : result =
+let handle_plan_update ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   let content = get_string args "content" "" in
   let result = Planning_eio.update_plan ctx.config ~task_id ~content in
@@ -46,7 +46,7 @@ let handle_plan_update ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to update plan: %s" e)
 
-let handle_note_add ctx args : result =
+let handle_note_add ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   let note = get_string args "note" "" in
   let result = Planning_eio.add_note ctx.config ~task_id ~note in
@@ -61,7 +61,7 @@ let handle_note_add ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to add note: %s" e)
 
-let handle_deliver ctx args : result =
+let handle_deliver ctx args : tool_result =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
   | Error e -> (false, Printf.sprintf "❌ %s" e)
@@ -82,7 +82,7 @@ let handle_deliver ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to set deliverable: %s" e)
 
-let handle_plan_get ctx args : result =
+let handle_plan_get ctx args : tool_result =
   let task_id_input = get_string args "task_id" "" in
   match Planning_eio.resolve_task_id ctx.config ~task_id:task_id_input with
   | Error e -> (false, Printf.sprintf "❌ %s" e)
@@ -100,7 +100,7 @@ let handle_plan_get ctx args : result =
       | Error e ->
           (false, Printf.sprintf "❌ Planning context not found: %s" e)
 
-let handle_error_add ctx args : result =
+let handle_error_add ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   let error_type = get_string args "error_type" "" in
   let message = get_string args "message" "" in
@@ -120,7 +120,7 @@ let handle_error_add ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to add error: %s" e)
 
-let handle_error_resolve ctx args : result =
+let handle_error_resolve ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   let error_index = get_int args "error_index" 0 in
   let result = Planning_eio.resolve_error ctx.config ~task_id ~index:error_index in
@@ -137,7 +137,7 @@ let handle_error_resolve ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to resolve error: %s" e)
 
-let handle_plan_set_task ctx args : result =
+let handle_plan_set_task ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if task_id = "" then
     (false, "❌ task_id is required")
@@ -150,7 +150,7 @@ let handle_plan_set_task ctx args : result =
     (true, Yojson.Safe.to_string response)
   end
 
-let handle_plan_get_task ctx _args : result =
+let handle_plan_get_task ctx _args : tool_result =
   match Planning_eio.get_current_task ctx.config with
   | Some task_id ->
       let response = `Assoc [
@@ -164,7 +164,7 @@ let handle_plan_get_task ctx _args : result =
       ] in
       (true, Yojson.Safe.to_string response)
 
-let handle_plan_clear_task ctx _args : result =
+let handle_plan_clear_task ctx _args : tool_result =
   Planning_eio.clear_current_task ctx.config;
   let response = `Assoc [
     ("status", `String "cleared");
@@ -174,7 +174,7 @@ let handle_plan_clear_task ctx _args : result =
 
 (** {1 Dispatcher} *)
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_plan_init" -> Some (handle_plan_init ctx args)
   | "masc_plan_update" -> Some (handle_plan_update ctx args)

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -11,24 +11,24 @@ type context = {
 }
 
 (** Tool result type *)
-type result = bool * string
+type tool_result = bool * string
 
 (** {1 Individual Handlers} *)
 
-val handle_plan_init : context -> Yojson.Safe.t -> result
-val handle_plan_update : context -> Yojson.Safe.t -> result
-val handle_note_add : context -> Yojson.Safe.t -> result
-val handle_deliver : context -> Yojson.Safe.t -> result
-val handle_plan_get : context -> Yojson.Safe.t -> result
-val handle_error_add : context -> Yojson.Safe.t -> result
-val handle_error_resolve : context -> Yojson.Safe.t -> result
-val handle_plan_set_task : context -> Yojson.Safe.t -> result
-val handle_plan_get_task : context -> Yojson.Safe.t -> result
-val handle_plan_clear_task : context -> Yojson.Safe.t -> result
+val handle_plan_init : context -> Yojson.Safe.t -> tool_result
+val handle_plan_update : context -> Yojson.Safe.t -> tool_result
+val handle_note_add : context -> Yojson.Safe.t -> tool_result
+val handle_deliver : context -> Yojson.Safe.t -> tool_result
+val handle_plan_get : context -> Yojson.Safe.t -> tool_result
+val handle_error_add : context -> Yojson.Safe.t -> tool_result
+val handle_error_resolve : context -> Yojson.Safe.t -> tool_result
+val handle_plan_set_task : context -> Yojson.Safe.t -> tool_result
+val handle_plan_get_task : context -> Yojson.Safe.t -> tool_result
+val handle_plan_clear_task : context -> Yojson.Safe.t -> tool_result
 
 (** {1 Dispatcher} *)
 
 (** Dispatch plan tool by name. Returns None if not a plan tool. *)
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val schemas : Types.tool_schema list

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -9,7 +9,7 @@ type context = {
   proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 let handle_relay_status ctx args =
   let*! messages = get_int_required args "messages" in
@@ -274,7 +274,7 @@ Returns relay recommendation before you commit. Pair with masc_relay_now if rela
 
 ]
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_relay_status" -> Some (handle_relay_status ctx args)
   | "masc_relay_checkpoint" -> Some (handle_relay_checkpoint ctx args)

--- a/lib/tool_relay.mli
+++ b/lib/tool_relay.mli
@@ -7,13 +7,13 @@ type context = {
   proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
-val handle_relay_status : context -> Yojson.Safe.t -> result
-val handle_relay_checkpoint : context -> Yojson.Safe.t -> result
-val handle_relay_now : context -> Yojson.Safe.t -> result
-val handle_relay_smart_check : context -> Yojson.Safe.t -> result
+val handle_relay_status : context -> Yojson.Safe.t -> tool_result
+val handle_relay_checkpoint : context -> Yojson.Safe.t -> tool_result
+val handle_relay_now : context -> Yojson.Safe.t -> tool_result
+val handle_relay_smart_check : context -> Yojson.Safe.t -> tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val schemas : Types.tool_schema list

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -7,7 +7,7 @@
 
 open Yojson.Safe.Util
 
-type result = bool * string
+type tool_result = bool * string
 
 type context = {
   config: Room.config;
@@ -577,7 +577,7 @@ let handle_check ctx args =
   (true, Yojson.Safe.to_string result)
 
 (* Dispatch function *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_status" -> Some (handle_status ctx args)
   | "masc_init" -> Some (handle_init ctx args)

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -10,13 +10,13 @@ type context = {
 }
 
 (** Tool result type *)
-type result = bool * string
+type tool_result = bool * string
 
 open Tool_args
 
 (** {1 Individual Handlers} *)
 
-let handle_run_init ctx args : result =
+let handle_run_init ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if task_id = "" then
     (false, "task_id is required")
@@ -28,7 +28,7 @@ let handle_run_init ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to init run: %s" e)
 
-let handle_run_plan ctx args : result =
+let handle_run_plan ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if task_id = "" then
     (false, "task_id is required")
@@ -40,7 +40,7 @@ let handle_run_plan ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to update run plan: %s" e)
 
-let handle_run_log ctx args : result =
+let handle_run_log ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if task_id = "" then
     (false, "task_id is required")
@@ -52,7 +52,7 @@ let handle_run_log ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to append run log: %s" e)
 
-let handle_run_deliverable ctx args : result =
+let handle_run_deliverable ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if task_id = "" then
     (false, "task_id is required")
@@ -64,7 +64,7 @@ let handle_run_deliverable ctx args : result =
   | Error e ->
       (false, Printf.sprintf "❌ Failed to set run deliverable: %s" e)
 
-let handle_run_get ctx args : result =
+let handle_run_get ctx args : tool_result =
   let task_id = get_string args "task_id" "" in
   if task_id = "" then
     (false, "task_id is required")
@@ -73,13 +73,13 @@ let handle_run_get ctx args : result =
     | Ok json -> (true, Yojson.Safe.to_string json)
     | Error e -> (false, Printf.sprintf "❌ Failed to get run: %s" e)
 
-let handle_run_list ctx _args : result =
+let handle_run_list ctx _args : tool_result =
   let json = Run_eio.list ctx.config in
   (true, Yojson.Safe.to_string json)
 
 (** {1 Dispatcher} *)
 
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_run_init" -> Some (handle_run_init ctx args)
   | "masc_run_plan" -> Some (handle_run_plan ctx args)

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -10,16 +10,16 @@ type context = {
 }
 
 (** Tool result type *)
-type result = bool * string
+type tool_result = bool * string
 
 (** {1 Individual Handlers} *)
 
-val handle_run_init : context -> Yojson.Safe.t -> result
-val handle_run_plan : context -> Yojson.Safe.t -> result
-val handle_run_log : context -> Yojson.Safe.t -> result
-val handle_run_deliverable : context -> Yojson.Safe.t -> result
-val handle_run_get : context -> Yojson.Safe.t -> result
-val handle_run_list : context -> Yojson.Safe.t -> result
+val handle_run_init : context -> Yojson.Safe.t -> tool_result
+val handle_run_plan : context -> Yojson.Safe.t -> tool_result
+val handle_run_log : context -> Yojson.Safe.t -> tool_result
+val handle_run_deliverable : context -> Yojson.Safe.t -> tool_result
+val handle_run_get : context -> Yojson.Safe.t -> tool_result
+val handle_run_list : context -> Yojson.Safe.t -> tool_result
 
 (** {1 Dispatcher} *)
 
@@ -27,4 +27,4 @@ val handle_run_list : context -> Yojson.Safe.t -> result
 (** Tool schemas for MCP tools/list *)
 val schemas : Types.tool_schema list
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option

--- a/lib/tool_verification.ml
+++ b/lib/tool_verification.ml
@@ -12,7 +12,7 @@
 open Yojson.Safe.Util
 open Tool_args
 
-type result = bool * string
+type tool_result = bool * string
 
 (** masc_verify_request: Create a verification request *)
 let handle_request config agent_name args =
@@ -111,7 +111,7 @@ let handle_auto config _agent_name args =
     | Error e -> (false, e)
 
 (** Dispatch tool calls *)
-let dispatch config agent_name tool_name args : result =
+let dispatch config agent_name tool_name args : tool_result =
   match tool_name with
   | "masc_verify_request" -> handle_request config agent_name args
   | "masc_verify_submit" -> handle_submit config agent_name args

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -8,7 +8,7 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
 (* Individual handlers *)
 let handle_worktree_create ctx args =
@@ -49,7 +49,7 @@ let handle_worktree_list ctx _args =
   (true, Yojson.Safe.to_string json)
 
 (* Dispatch function - returns None if tool not handled *)
-let dispatch ctx ~name ~args : result option =
+let dispatch ctx ~name ~args : tool_result option =
   match name with
   | "masc_worktree_create" -> Some (handle_worktree_create ctx args)
   | "masc_worktree_remove" -> Some (handle_worktree_remove ctx args)

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -5,12 +5,12 @@ type context = {
   agent_name: string;
 }
 
-type result = bool * string
+type tool_result = bool * string
 
-val handle_worktree_create : context -> Yojson.Safe.t -> result
-val handle_worktree_remove : context -> Yojson.Safe.t -> result
-val handle_worktree_list : context -> Yojson.Safe.t -> result
+val handle_worktree_create : context -> Yojson.Safe.t -> tool_result
+val handle_worktree_remove : context -> Yojson.Safe.t -> tool_result
+val handle_worktree_list : context -> Yojson.Safe.t -> tool_result
 
-val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary
- Rename `type result = bool * string` to `type tool_result = bool * string` across all 38 tool module files
- Unshadows `Stdlib.result`, enabling use of `Result.t` in tool modules
- Zero logic changes — purely mechanical type alias rename

## Why
Every `tool_*.ml` module independently defined `type result = bool * string`, shadowing `Stdlib.result`. This prevents using `Result.t` (Ok/Error) in the same scope and causes confusion when reading type errors. The rename aligns with `tool_task.ml` (PR #6457) and `tool_keeper.ml` which already use `tool_result`.

## Scope
45 files changed, 200 insertions, 200 deletions. All changes are `result` -> `tool_result` in type definitions and annotations.

## Test plan
- [x] `dune build` passes — compiler verified all references updated
- [x] `grep "type result = bool" lib/tool_*.ml` returns 0 matches
- [ ] CI: TLA+ Model Checking
- [ ] CI: Build and Test

Part of #6476

Generated with [Claude Code](https://claude.com/claude-code)
