### PR TITLE
fix(grpc): wrap reflection process_loop fork with exception logger

### DIFF
--- a/lib/grpc/masc_grpc_server.ml
+++ b/lib/grpc/masc_grpc_server.ml
@@ -375,7 +375,14 @@ module Reflection_bridge = struct
             in
             try loop () with End_of_file -> ()
       in
-      Eio.Fiber.fork ~sw process_loop;
+      Eio.Fiber.fork ~sw (fun () ->
+        try process_loop ()
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            Log.Server.error
+              "gRPC reflection process_loop crashed: %s"
+              (Printexc.to_string exn));
       response_stream
     in
     Grpc_eio.Service.create service_name


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 4. Cycle 2에서 `Eio.Fiber.fork` 56건 전수 샘플 검사 시 `masc_grpc_server.ml:378` 의 `Eio.Fiber.fork ~sw process_loop;` 가 outer try/with 없이 bare fork로 남아 있는 것을 식별했습니다.

## 문제

`process_loop`는 내부에 `try loop () with End_of_file -> ()` 를 가지고 있지만 이는 `End_of_file` 만 수습합니다. 다른 모든 예외(Yojson.Json_error, Grpc_eio stream 오류, OOM 등)는 `process_loop` 바깥으로 전파되어:

1. Outer switch `sw` 가 cancel → 다른 fiber 에 cascade
2. **로그 한 줄 없음** → 운영에서 원인 파악 불가 (silent failure)

이 파일 내 다른 fork 패턴(server_bootstrap_loops.ml `fork_subsystem`, orchestrator.ml inline try/with) 은 모두 outer boundary 에서 예외를 log + classify 합니다. 이 reflection bidi 경로만 누락돼 있었습니다.

## 변경

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  try process_loop ()
  with
  | Eio.Cancel.Cancelled _ as e -> raise e
  | exn ->
      Log.Server.error
        "gRPC reflection process_loop crashed: %s"
        (Printexc.to_string exn));
```

- `Eio.Cancel.Cancelled` 는 반드시 re-raise (Eio 구조 동시성 계약)
- 그 외 모든 예외는 `Log.Server.error` 로 기록
- 기존 `process_loop` 내부의 `End_of_file` 정상 종료 경로는 그대로 유지

## 검증

```
dune build --root . lib/          # exit 0
```

## 맥락

이 PR 은 audit sweep 의 Cycle 4 산출물입니다. 관련 작업:

- PR #6463 (Draft) — Cycle 1 board_dispatch silent-failure log
- PR #6479 (상기타) — parse_keeper_identity failwith → Result (Issue #6464)
- PR #6480 — backend atomic_increment partial-write detection
- PR #6481 (merged) — FSM apply_event transition type — no silent swallow
