### PR TITLE
fix(keeper): delegate context budget to OAS pipeline

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1401,8 +1401,8 @@ let run_turn
   in
   let reducer =
     Agent_sdk.Context_reducer.compose [
-      Agent_sdk.Context_reducer.Repair_dangling_tool_calls;
-      Agent_sdk.Context_reducer.Merge_contiguous;
+      Agent_sdk.Context_reducer.repair_dangling_tool_calls;
+      Agent_sdk.Context_reducer.merge_contiguous;
     ]
   in
   (* 8. Run Agent *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1400,17 +1400,10 @@ let run_turn
       ()
   in
   let reducer =
-    Agent_sdk.Context_reducer.dynamic (fun ~turn:_ ~messages:_ ->
-      (* Token_budget is the only constraint needed: with 262k context,
-       keeper conversations rarely approach the limit.  The previous
-       Stub_tool_results{keep_recent=3} after turn 5 operated on ALL
-       messages including initial_messages from the checkpoint, wiping
-       tool results from prior turns and destroying the history that
-       lets keepers learn from their own actions.
-       Merge_contiguous collapses adjacent same-role messages.
-       Rescued from orphaned commit db730c58a (post-merge on #5508). *)
-      let open Agent_sdk.Context_reducer in
-      Compose [ Merge_contiguous; Token_budget max_context ])
+    Agent_sdk.Context_reducer.compose [
+      Agent_sdk.Context_reducer.Repair_dangling_tool_calls;
+      Agent_sdk.Context_reducer.Merge_contiguous;
+    ]
   in
   (* 8. Run Agent *)
   let contract =

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -273,7 +273,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           message_gate = compaction_message_gate;
           token_gate = compaction_token_gate;
           cooldown_sec = continuity_compaction_cooldown_sec;
-          max_checkpoint_messages = 120;
+          max_checkpoint_messages = 80;
         };
         auto_handoff;
         handoff_threshold;


### PR DESCRIPTION
## Problem

Keeper의 context_reducer가 `Token_budget(262K)`를 사용 — cascade 전체 max context. Ollama(262K)의 값이 budget이 되어 300KB+ 요청 허용 → Ollama JSON 파싱 실패.

## Root Cause

`resolve_max_cascade_context`가 cascade 내 모든 모델의 **최대** context를 반환.
MASC가 이 값으로 Token_budget을 설정하면 OAS pipeline의 proactive_compact가 발동하지 않음.

## Fix

MASC → lightweight 정리만 (Repair_dangling + Merge_contiguous).
OAS pipeline에 위임:
- `proactive_compact`: watermark 기반 4단계 압축
- `emergency_compact`: ContextOverflow 감지 + 재시도
- `compact_ratio`: 이미 `meta.compaction.ratio_gate`로 전달 중

추가: `max_checkpoint_messages` 120 → 80.

## Test plan

- [x] `dune build` passes
- [ ] keeper 20+ turns: API 요청 < 150KB
- [ ] OAS `proactive_compact` 로그 확인

Generated with [Claude Code](https://claude.com/claude-code)