### PR TITLE
fix(dashboard): restore command-plane control surface in Ops

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -18,6 +18,9 @@ async function loadOps() {
   vi.doMock('../flow-control/flow-control-panel', () => ({
     FlowControlPanel: () => html`<div data-testid="flow-control-panel">FlowControlPanel</div>`,
   }))
+  vi.doMock('../command/control', () => ({
+    ControlSurface: () => html`<div data-testid="control-surface">ControlSurface</div>`,
+  }))
 
   const router = await import('../../router')
   const operatorStore = await import('../../operator-store')
@@ -54,6 +57,7 @@ describe('Ops intervene surface', () => {
     vi.clearAllMocks()
     vi.doUnmock('./quick-intervene')
     vi.doUnmock('../flow-control/flow-control-panel')
+    vi.doUnmock('../command/control')
   })
 
   it('renders a combined activity timeline for healthy mode without legacy KPI cards', async () => {
@@ -140,6 +144,7 @@ describe('Ops intervene surface', () => {
     expect(container.textContent).toContain('보류 1')
     expect(container.textContent).toContain('최근 처리 2')
     expect(container.textContent).toContain('프로젝트 진행 중')
+    expect(container.textContent).toContain('ControlSurface')
     expect(container.textContent).not.toContain('Active Queue')
     expect(container.textContent).not.toContain('Healthy Console')
 
@@ -222,6 +227,7 @@ describe('Ops intervene surface', () => {
 
     expect(container.textContent).toContain('즉시 검토 1')
     expect(container.textContent).toContain('프로젝트 일시정지')
+    expect(container.textContent).toContain('ControlSurface')
     expect(container.textContent).toContain('실행 작업대')
     expect(container.textContent).toContain('현재 상태')
     expect(container.textContent).toContain('마찰 요인')

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -44,6 +44,7 @@ import {
   workflowTargetReady,
 } from './helpers'
 import { FlowControlPanel } from '../flow-control/flow-control-panel'
+import { ControlSurface } from '../command/control'
 import { displayStatus } from '../../lib/status-label'
 
 function severityClass(value?: string | null): string {
@@ -440,6 +441,7 @@ export function Ops() {
       ` : null}
 
       ${renderSummaryBadges(activeCount, deferredCount, recentCount)}
+      <${ControlSurface} />
 
       ${healthy ? html`
         <section class="grid grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)] gap-4 max-[1200px]:grid-cols-1">


### PR DESCRIPTION
## Summary
- render `ControlSurface` from the Ops intervene view again
- keep command-plane approvals and capacity controls reachable in both healthy and review-heavy intervene states
- lock the routing back in with Ops surface tests

## Product impact
- Promise affected: `ops visibility`
- User-visible change: the intervene view shows the command-plane approval and capacity panel again

## Evidence
- local tests: `pnpm test -- src/components/ops/index.test.ts src/components/control.test.ts`
- local typecheck: `pnpm typecheck`
- both were run from `dashboard/` in the worktree after linking existing local dependencies for validation

## Review evidence
- direct `sb glm-text` review recorded in PR comments
- result: No findings

## Linked issue
- Closes #6465
- Relates #6099
