### PR TITLE
fix(dashboard): standardize time display to formatTimeAgo

### DIFF
--- a/dashboard/src/components/feature-health.ts
+++ b/dashboard/src/components/feature-health.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { get } from '../api/core'
 import { createAsyncResource, type AsyncResource } from '../lib/async-state'
+import { formatTimeAgo } from '../lib/format-time'
 import { AsyncContainer } from './common/async-container'
 import { Card } from './common/card'
 import { StatCard } from './common/stat-card'
@@ -192,7 +193,7 @@ export function FeatureHealth() {
                   </div>
 
                   <div class="mt-4 text-xs text-[var(--text-dim)]">
-                    generated ${new Date(data.generated_at * 1000).toLocaleString('ko-KR')}
+                    generated ${formatTimeAgo(data.generated_at)}
                   </div>
                 </div>
 

--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -3,6 +3,7 @@
 // Extracted from keeper-detail.ts to reduce file size.
 
 import { html } from 'htm/preact'
+import { formatTimeAgo } from '../lib/format-time'
 import type { Keeper } from '../types'
 
 // ── Helpers ──────────────────────────────────────────────
@@ -79,7 +80,7 @@ function SpEventsPanel({ sp_events }: { sp_events: any[] }) {
       <div class="space-y-1 max-h-28 overflow-y-auto">
         ${sp_events.slice(0, 10).map((e: any) => html`
           <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[rgba(139,92,246,0.06)]">
-            <span class="font-mono text-[var(--text-muted)]">${new Date((e.ts ?? 0) * 1000).toLocaleTimeString()}</span>
+            <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
             <span class="text-[#8b5cf6]">${e.suppressed_count}/${e.total} 억제 (${e.dominant_cohort})</span>
           </div>
         `)}
@@ -132,7 +133,7 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
         ` : null}
         ${dead_since ? html`
           <div class="py-2 px-3 rounded-lg bg-[rgba(239,68,68,0.06)] border border-[rgba(239,68,68,0.15)] text-xs text-[#fb7185]">
-            ${new Date(dead_since * 1000).toLocaleString()} 이후 중단됨. 재기동 필요.
+            ${formatTimeAgo(dead_since)} 이후 중단됨. 재기동 필요.
           </div>
         ` : null}
         <${CrashCohortBar} crash_log=${crash_log} />
@@ -142,7 +143,7 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
             <div class="space-y-1 max-h-32 overflow-y-auto">
               ${crash_log.slice(0, 10).map((e: any) => html`
                 <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[var(--white-3)]">
-                  <span class="font-mono text-[var(--text-muted)]">${new Date((e.ts ?? 0) * 1000).toLocaleTimeString()}</span>
+                  <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
                   <span class="text-[#fb7185]">${e.reason ?? 'unknown'}</span>
                 </div>
               `)}

--- a/dashboard/src/components/tool-executor/tool-result-display.ts
+++ b/dashboard/src/components/tool-executor/tool-result-display.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
+import { formatTimeAgo } from '../../lib/format-time'
 import { CountBadge } from '../common/badge'
 import { ActionButton } from '../common/button'
 import { JsonViewer } from '../common/json-viewer'
@@ -22,7 +23,7 @@ function tryParseJson(text: string): { isJson: boolean; parsed: unknown } {
 export function ToolResultDisplay({ success, text, toolName, timestamp }: ToolResultProps) {
   const expanded = useSignal(true)
   const { isJson, parsed } = tryParseJson(text)
-  const timeStr = new Date(timestamp).toLocaleTimeString('ko-KR')
+  const timeStr = formatTimeAgo(timestamp)
   const lines = text.split('\n').length
   return html`
     <div class="flex flex-col gap-2 mt-3">


### PR DESCRIPTION
## Summary
- Replace manual `toLocaleTimeString()`, `toLocaleString('ko-KR')` calls with the existing `formatTimeAgo()` helper from `lib/format-time.ts`
- Gives consistent relative time display ("3분 전", "2시간 전") across all dashboard panels instead of mixed locale-dependent absolute formats
- 3 files changed: `feature-health.ts`, `keeper-supervisor-diagnostics.ts`, `tool-result-display.ts`

## Test plan
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm test` passes (80 files, 449 tests)
- [ ] Visual check: timestamps in Feature Health, Supervisor Diagnostics, and Tool Results panels show relative time

🤖 Generated with [Claude Code](https://claude.com/claude-code)