### PR TITLE
perf(dashboard): memoize expensive derived state in fleet and agent-roster

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -3,7 +3,7 @@
 // Keeper state (CTX gauge, generation, autonomy) shown inline on the card.
 
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import { useMemo, useState } from 'preact/hooks'
 import type { Agent, Keeper } from '../types'
 import type {
   DashboardMissionAgentBrief,
@@ -317,8 +317,28 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const keeperList = keepers.value
   const briefs = missionAgentBriefs.value
   const keeperBriefs = missionKeeperBriefs.value
-  const liveRuntimeCounts = countRuntimeKinds(agentList, keeperList, keeperBriefs)
-  const rosterAgents = buildAgentRoster(agentList, keeperList, keeperBriefs)
+
+  // Memoize roster and lookup Maps — these iterate full keeper/agent arrays
+  const rosterAgents = useMemo(
+    () => buildAgentRoster(agentList, keeperList, keeperBriefs),
+    [agentList, keeperList, keeperBriefs],
+  )
+  const keeperInfoLookup = useMemo(
+    () => buildKeeperInfoLookup(keeperList, keeperBriefs),
+    [keeperList, keeperBriefs],
+  )
+  const keeperRuntimeLookup = useMemo(
+    () => buildKeeperRuntimeLookup(keeperList),
+    [keeperList],
+  )
+
+  // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
+  const liveRuntimeCounts = useMemo(() => {
+    const keeperCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, 'keeper-only').length
+    const agentCount = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, 'agent-only').length
+    return { agents: agentCount, keepers: keeperCount, totalRuntimes: rosterAgents.length }
+  }, [rosterAgents, keeperList, keeperBriefs])
+
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: executionLoaded.value,
     agentsCount: liveRuntimeCounts.agents,
@@ -332,33 +352,43 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const namespaceName = namespaceStatus?.namespace ?? 'default'
   const namespaceBasePath = namespaceStatus?.namespace_base_path ?? null
 
-  const briefMap = new Map<string, DashboardMissionAgentBrief>(
-    briefs.map(brief => [brief.agent_name, brief] as const),
+  const briefMap = useMemo(
+    () => new Map<string, DashboardMissionAgentBrief>(
+      briefs.map(brief => [brief.agent_name, brief] as const),
+    ),
+    [briefs],
   )
-  const scopedAgents = scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, keeperFilter)
-  const keeperInfoLookup = buildKeeperInfoLookup(keeperList, keeperBriefs)
-  const keeperRuntimeLookup = buildKeeperRuntimeLookup(keeperList)
-  const bandByAgent = new Map(
-    scopedAgents.map(agent => [
-      agent.name,
-      runtimeBandMetaForAgent(
-        agent,
-        keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList),
-      ),
-    ] as const),
+  const scopedAgents = useMemo(
+    () => scopeAgentsByKeeperFilter(rosterAgents, keeperList, keeperBriefs, keeperFilter),
+    [rosterAgents, keeperList, keeperBriefs, keeperFilter],
+  )
+  const bandByAgent = useMemo(
+    () => new Map(
+      scopedAgents.map(agent => [
+        agent.name,
+        runtimeBandMetaForAgent(
+          agent,
+          keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList),
+        ),
+      ] as const),
+    ),
+    [scopedAgents, keeperRuntimeLookup, keeperList],
   )
   const normalizedSearch = search.trim().toLowerCase()
-  const searchTermsByAgent = new Map(
-    scopedAgents.map(agent => {
-      const keeper = keeperInfoLookup.get(agent.name) ?? findKeeper(agent.name, keeperList, keeperBriefs)
-      return [
-        agent.name,
-        keeperIdentitySearchTerms(
-          keeper?.name ?? null,
-          keeper?.agent_name ?? agent.name,
-        ).map(term => term.toLowerCase()),
-      ] as const
-    }),
+  const searchTermsByAgent = useMemo(
+    () => new Map(
+      scopedAgents.map(agent => {
+        const keeper = keeperInfoLookup.get(agent.name) ?? findKeeper(agent.name, keeperList, keeperBriefs)
+        return [
+          agent.name,
+          keeperIdentitySearchTerms(
+            keeper?.name ?? null,
+            keeper?.agent_name ?? agent.name,
+          ).map(term => term.toLowerCase()),
+        ] as const
+      }),
+    ),
+    [scopedAgents, keeperInfoLookup, keeperList, keeperBriefs],
   )
   const pageTitle = keeperFilter === 'keeper-only'
     ? '키퍼 목록'

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { LoadingState } from './common/feedback-state'
 import {
   fetchDashboardExecution,
@@ -689,7 +689,7 @@ export function FleetTelemetryPanel() {
   }, [])
 
   const value = state.value
-  const counts = summaryCounts(value.rows)
+  const counts = useMemo(() => summaryCounts(value.rows), [value.rows])
   const liveTone: 'neutral' | 'ok' | 'warn' =
     value.rows.length === 0
       ? 'neutral'


### PR DESCRIPTION
## Summary
- Wrap `buildKeeperInfoLookup`, `buildKeeperRuntimeLookup`, `buildAgentRoster`, `scopeAgentsByKeeperFilter`, `bandByAgent`, `searchTermsByAgent`, `briefMap` in `useMemo` in `AgentRoster` to avoid rebuilding Maps and iterating full keeper/agent arrays on every render cycle.
- Eliminate duplicate `buildAgentRoster` call that was hidden inside `countRuntimeKinds` — now the memoized roster is reused for count derivation.
- Memoize `summaryCounts` in `FleetTelemetryPanel` render path.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (449/449)
- [ ] Manual: open dashboard, verify agent roster and fleet telemetry panels render correctly
- [ ] Manual: verify filter/search interactions still work in agent roster

🤖 Generated with [Claude Code](https://claude.com/claude-code)