### PR TITLE
fix(dashboard): standardize error display to CSS variable color scheme

### DIFF
--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -4,7 +4,7 @@
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
 import { EmptyState } from '../common/empty-state'
-import { LoadingState } from '../common/feedback-state'
+import { ErrorState, LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
 import { JsonViewerCard, parseJsonLikeData } from '../common/json-viewer'
 import { Settings, MessageSquare, CheckSquare, Heart, RefreshCcw, Dot, ChevronRight } from 'lucide-preact'
@@ -82,7 +82,7 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
               <${JsonViewerCard} data=${parseJsonLikeData(event.toolResult)} title="Result" />
             </div>
           ` : null}
-          ${event.error ? html`<div class="text-[11px] text-bad mt-1">${event.error}</div>` : null}
+          ${event.error ? html`<div class="text-[11px] text-[var(--bad-light)] mt-1">${event.error}</div>` : null}
           ${event.cost_usd != null ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
         </div>
       ` : null}
@@ -102,7 +102,7 @@ export function TaskActivityList({
   showToolCalls: boolean
 }) {
   if (loading) return html`<${LoadingState}>활동 불러오는 중...<//>`
-  if (error) return html`<div class="text-[12px] text-bad py-2">${error}</div>`
+  if (error) return html`<${ErrorState} message=${error} />`
   if (events.length === 0) return html`<${EmptyState} message="담당자의 최근 활동이 없습니다" compact />`
 
   const filter = activeFilter.value

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -6,7 +6,7 @@ import { Check, X, ArrowRight, Dot, UserPlus } from 'lucide-preact'
 import { DialogOverlay } from '../common/dialog'
 import { StatusBadge } from '../common/status-badge'
 import { EmptyState } from '../common/empty-state'
-import { LoadingState } from '../common/feedback-state'
+import { ErrorState, LoadingState } from '../common/feedback-state'
 import { TimeAgo } from '../common/time-ago'
 import { findKeeper } from '../../lib/keeper-utils'
 import {
@@ -51,7 +51,7 @@ function TaskEventsSection() {
   const error = taskEventsError.value
 
   if (loading) return html`<${LoadingState}>이벤트 불러오는 중...<//>`
-  if (error) return html`<div class="text-[12px] text-bad py-2">${error}</div>`
+  if (error) return html`<${ErrorState} message=${error} />`
   if (events.length === 0) return html`<${EmptyState} message="기록된 이벤트가 없습니다" compact />`
 
   return html`

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -11,7 +11,7 @@ import {
 } from '../api/dashboard'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
-import { LoadingState } from './common/feedback-state'
+import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
@@ -96,7 +96,7 @@ export function RuntimeMonitor() {
       </div>
 
       ${current.error
-        ? html`<div class="rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">${current.error}</div>`
+        ? html`<${ErrorState} message=${current.error} />`
         : null}
 
       ${current.loading && !providers && !metrics

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -1,5 +1,6 @@
 // Tool Metrics — P4 Phase 4.5
 import { ActionButton } from './common/button'
+import { ErrorState } from './common/feedback-state'
 // Displays tool usage statistics from Tool_unified.summary_report()
 
 import { html } from 'htm/preact'
@@ -103,7 +104,7 @@ export function ToolMetrics() {
         <//>
       </div>
 
-      ${error ? html`<div class="px-2.5 py-3 bg-[var(--bad-12)] border border-[rgba(239,68,68,0.34)] text-[#fecaca] text-base rounded-lg">${error}</div>` : null}
+      ${error ? html`<${ErrorState} message=${error} />` : null}
 
       ${data ? html`
         <div class="text-[11px] text-[var(--text-muted)] mb-3">

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -277,7 +277,7 @@ export function ToolQualityPanel() {
 
   const d = data.value
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
-  if (error.value) return html`<${ErrorState} message=${`오류: ${error.value}`} class="m-4" />`
+  if (error.value) return html`<${ErrorState} message=${error.value} class="m-4" />`
   if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
 
   return html`

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -4,7 +4,7 @@ import { useEffect } from 'preact/hooks'
 import { fetchToolQuality, type ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
-import { LoadingState } from './common/feedback-state'
+import { ErrorState, LoadingState } from './common/feedback-state'
 import { isAbortError } from '../lib/async-state'
 
 interface ToolStat {
@@ -277,7 +277,7 @@ export function ToolQualityPanel() {
 
   const d = data.value
   if (loading.value && !d) return html`<${LoadingState}>도구 품질 불러오는 중...<//>`
-  if (error.value) return html`<div class="p-4 text-[11px] text-red-400">오류: ${error.value}</div>`
+  if (error.value) return html`<${ErrorState} message=${`오류: ${error.value}`} class="m-4" />`
   if (!d || d.total === 0) return html`<div class="p-4 text-[11px] text-[var(--text-dim)]">도구 호출 데이터 없음</div>`
 
   return html`

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -9,6 +9,7 @@ import {
   type PromptSource,
 } from '../../api'
 import { Card } from '../common/card'
+import { ErrorState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { TextArea } from '../common/input'
 
@@ -116,7 +117,7 @@ export function PromptRegistryPanel() {
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>
       </div>
 
-      ${error ? html`<div class="mb-4 rounded-lg border border-[rgba(244,63,94,0.28)] bg-[rgba(244,63,94,0.08)] px-3 py-2 text-[12px] text-[#fecdd3]">${error}</div>` : null}
+      ${error ? html`<${ErrorState} message=${error} class="mb-4" />` : null}
       ${status ? html`<div class="mb-4 rounded-lg border border-[rgba(56,189,248,0.28)] bg-[rgba(56,189,248,0.08)] px-3 py-2 text-[12px] text-[#bae6fd]">${status}</div>` : null}
 
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">

--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback } from 'preact/hooks'
 import { VirtualList } from '../common/virtual-list'
 import { EmptyState } from '../common/empty-state'
+import { ErrorState } from '../common/feedback-state'
 import { TextInput } from '../common/input'
 import { route } from '../../router'
 import type { DashboardToolInventoryItem } from '../../api'
@@ -196,7 +197,7 @@ export function FullInventoryView({
       </div>
     </div>
 
-    ${error ? html`<div class="px-3 py-2.5 bg-[var(--bad-12)] border border-[var(--bad-30)] text-[#fecaca] text-[13px] rounded-lg mt-2">${error}</div>` : null}
+    ${error ? html`<${ErrorState} message=${error} class="mt-2" />` : null}
 
     <div ref=${listContainerRef} class="overflow-y-auto max-h-[calc(100vh-420px)] min-h-[300px]">
       ${filtered.length > 0


### PR DESCRIPTION
## Summary
- Replace 7 raw error divs across dashboard components with the shared `ErrorState` component from `feedback-state.ts`
- Eliminates inconsistent inline styling (raw Tailwind `red-500/30`, hardcoded `rgba()`, hex `#fecaca`/`#fecdd3`) in favor of the semantic `--bad`/`--bad-light`/`--bad-12`/`--bad-30` CSS variable palette
- One inline event error text updated from `text-bad` to `text-[var(--bad-light)]` to match ErrorState's text color without the full component overhead

## Files changed
1. `runtime-monitor.ts` — raw `border-red-500/30 bg-red-500/10 text-red-400` → `ErrorState`
2. `tool-metrics.ts` — mixed CSS vars + hardcoded rgba/hex → `ErrorState`
3. `prompt-registry-panel.ts` — raw `rgba(244,63,94,...)` + hex → `ErrorState`
4. `tool-full-inventory.ts` — CSS vars + hardcoded `#fecaca` → `ErrorState`
5. `tool-quality-panel.ts` — raw `text-red-400` → `ErrorState`
6. `task-detail-overlay.ts` — minimal `text-bad` → `ErrorState`
7. `task-activity-list.ts` — container error → `ErrorState`, inline event error → `text-[var(--bad-light)]`

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (80 files, 449 tests)
- [ ] Visual verification that error states render correctly in the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)