### PR TITLE
refactor: eliminate vendor hardcoding outside provider_adapter boundary

### DIFF
--- a/config/personas/sangsu/scripts/sangsu-character-profiler.py
+++ b/config/personas/sangsu/scripts/sangsu-character-profiler.py
@@ -159,7 +159,7 @@ Return ONLY JSON, no explanation."""
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=1000,
             messages=[{"role": "user", "content": prompt}]
         )

--- a/config/personas/sangsu/scripts/sangsu-llm-emotion-detector.py
+++ b/config/personas/sangsu/scripts/sangsu-llm-emotion-detector.py
@@ -96,7 +96,7 @@ def detect_emotion_llm(user_message: str, context: dict = None) -> dict:
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=300,
             messages=[{"role": "user", "content": prompt}]
         )

--- a/config/personas/sangsu/scripts/sangsu-master-orchestrator.py
+++ b/config/personas/sangsu/scripts/sangsu-master-orchestrator.py
@@ -307,7 +307,7 @@ class SangsuOrchestrator:
         # Call Claude
         try:
             message = client.messages.create(
-                model="claude-sonnet-4-5-20250929",
+                model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-5-20250929"),
                 max_tokens=150,
                 temperature=0.9,
                 system=persona,

--- a/config/personas/shared/voice/voice-agent-cognitive-pipeline.py
+++ b/config/personas/shared/voice/voice-agent-cognitive-pipeline.py
@@ -125,7 +125,7 @@ JSON만 반환하고 다른 설명은 하지 마세요."""
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=500,
             messages=[{"role": "user", "content": prompt}]
         )
@@ -316,7 +316,7 @@ Return JSON:
 
     try:
         response_a = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=1000,
             messages=[{"role": "user", "content": prompt_a}]
         )
@@ -357,7 +357,7 @@ Return JSON:
 
     try:
         response_b = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=1000,
             messages=[{"role": "user", "content": prompt_b}]
         )
@@ -392,7 +392,7 @@ Return JSON:
 
     try:
         response_c = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=1000,
             messages=[{"role": "user", "content": prompt_c}]
         )
@@ -535,7 +535,7 @@ Return JSON:
 
     try:
         response = client.messages.create(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=300,
             messages=[{"role": "user", "content": prompt}]
         )

--- a/config/personas/shared/voice/voice-chat-elevenlabs.py
+++ b/config/personas/shared/voice/voice-chat-elevenlabs.py
@@ -122,7 +122,7 @@ def get_claude_response(user_message: str) -> str:
     client = Anthropic(api_key=ANTHROPIC_API_KEY)
 
     message = client.messages.create(
-        model="claude-sonnet-4-5-20250929",
+        model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-5-20250929"),
         max_tokens=1024,
         messages=[
             {"role": "user", "content": user_message}

--- a/config/personas/shared/voice/voice-claude.py
+++ b/config/personas/shared/voice/voice-claude.py
@@ -133,7 +133,7 @@ def query_claude(text: str):
         print("🤖 Claude: ", end="", flush=True)
 
         with anthropic_client.messages.stream(
-            model="claude-sonnet-4-20250514",
+            model=os.getenv("MASC_PERSONA_MODEL", "claude-sonnet-4-20250514"),
             max_tokens=4096,
             messages=[{"role": "user", "content": text}]
         ) as stream:

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -147,7 +147,11 @@ let generate_code_change = Autoresearch_codegen.generate_code_change
 (* Loop State Management                                             *)
 (* ================================================================ *)
 
-let create_state ~goal ~metric_fn ?(model_model = "glm") ~target_file ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn ?(lower_is_better = false) ~workdir () =
+let create_state ~goal ~metric_fn ?model_model ~target_file ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn ?(lower_is_better = false) ~workdir () =
+  let model_model = match model_model with
+    | Some m -> m
+    | None -> Provider_adapter.default_model_provider_prefix_result () |> Result.value ~default:"auto"
+  in
   let now = Time_compat.now () in
   let patience = match patience with
     | Some p -> p

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -978,18 +978,30 @@ let classify_model_family ~is_local ~context_window =
   else "medium_cloud"
 
 let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string list =
-  let cn = string_of_provider_kind kind in
-  match resolve_direct_adapter cn with
-  | None -> []
-  | Some adapter ->
-    match adapter.auth_mode with
-    | No_auth -> []
-    | Api_key env_name -> [ env_name ]
-    | Vertex_adc { project_env; location_env } -> [ project_env; location_env ]
+  match kind with
+  | Llm_provider.Provider_config.Anthropic -> [ "ANTHROPIC_API_KEY" ]
+  | Llm_provider.Provider_config.Glm -> [ "ZAI_API_KEY" ]
+  | Llm_provider.Provider_config.OpenAI_compat -> [ "OPENAI_API_KEY" ]
+  | Llm_provider.Provider_config.Gemini -> [ google_cloud_project_env; google_cloud_location_env ]
+  | Llm_provider.Provider_config.Claude_code
+  | Llm_provider.Provider_config.Ollama -> []
+
+let is_loopback_host = function
+  | Some "localhost" | Some "127.0.0.1" -> true
+  | Some host when String.starts_with ~prefix:"127." host -> true
+  | _ -> false
+
+let docker_auth_env_keys_of_provider_config (cfg : Llm_provider.Provider_config.t) : string list =
+  match cfg.kind with
+  | Llm_provider.Provider_config.OpenAI_compat ->
+    let uri = Uri.of_string cfg.base_url in
+    if is_loopback_host (Uri.host uri) then [] else auth_env_keys_of_provider_kind cfg.kind
+  | Llm_provider.Provider_config.Gemini -> [ "GEMINI_API_KEY" ]
+  | _ -> auth_env_keys_of_provider_kind cfg.kind
 
 let all_auth_env_keys () : string list =
   direct_adapters
-  |> List.filter_map (fun adapter ->
+  |> List.filter_map (fun (adapter : adapter) ->
     match adapter.auth_mode with
     | No_auth -> None
     | Api_key env_name -> Some env_name

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -977,4 +977,23 @@ let classify_model_family ~is_local ~context_window =
   else if context_window >= large_cloud_context_floor then "large_cloud"
   else "medium_cloud"
 
+let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string list =
+  let cn = string_of_provider_kind kind in
+  match resolve_direct_adapter cn with
+  | None -> []
+  | Some adapter ->
+    match adapter.auth_mode with
+    | No_auth -> []
+    | Api_key env_name -> [ env_name ]
+    | Vertex_adc { project_env; location_env } -> [ project_env; location_env ]
+
+let all_auth_env_keys () : string list =
+  direct_adapters
+  |> List.filter_map (fun adapter ->
+    match adapter.auth_mode with
+    | No_auth -> None
+    | Api_key env_name -> Some env_name
+    | Vertex_adc _ -> None)
+  |> List.sort_uniq String.compare
+
 (* is_spawnable removed: use is_spawnable_agent directly. *)

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -115,6 +115,17 @@ val make_local_label : string -> string
 val string_of_provider_kind :
   Llm_provider.Provider_config.provider_kind -> string
 
+(** Resolve required auth env keys for a provider kind. *)
+val auth_env_keys_of_provider_kind :
+  Llm_provider.Provider_config.provider_kind -> string list
+
+(** Resolve Docker worker auth env keys for a provider config. *)
+val docker_auth_env_keys_of_provider_config :
+  Llm_provider.Provider_config.t -> string list
+
+(** Collect all auth env keys across direct adapters. *)
+val all_auth_env_keys : unit -> string list
+
 (** Resolve an adapter by canonical name or alias. *)
 val resolve_direct_adapter : string -> adapter option
 

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -159,7 +159,7 @@ let auth_requirements_of_model_label model_label =
   match Llm_provider.Cascade_config.parse_model_string model_label with
   | None -> Ok []
   | Some cfg ->
-    let keys = Provider_adapter.auth_env_keys_of_provider_kind cfg.Llm_provider.Provider_config.kind in
+    let keys = Provider_adapter.docker_auth_env_keys_of_provider_config cfg in
     let missing = List.filter (fun key ->
       match Sys.getenv_opt key with Some v -> String.trim v = "" | None -> true
     ) keys in

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -60,12 +60,8 @@ let rewrite_spec_for_container (spec : Worker_execution_spec.t) =
 
 let allowlisted_env_pairs () =
   let keys =
-    [
-      "ANTHROPIC_API_KEY";
-      "OPENAI_API_KEY";
-      "GEMINI_API_KEY";
-      "ZAI_API_KEY";
-      "OPENROUTER_API_KEY";
+    Provider_adapter.all_auth_env_keys ()
+    @ [
       "GOOGLE_CLOUD_PROJECT";
       "GOOGLE_CLOUD_LOCATION";
       "MASC_STORAGE_TYPE";
@@ -162,22 +158,15 @@ let mount_args (spec : Worker_execution_spec.t) =
 let auth_requirements_of_model_label model_label =
   match Llm_provider.Cascade_config.parse_model_string model_label with
   | None -> Ok []
-  | Some cfg -> (
-      match cfg.Llm_provider.Provider_config.kind with
-      | Llm_provider.Provider_config.Anthropic -> Ok [ "ANTHROPIC_API_KEY" ]
-      | Llm_provider.Provider_config.Glm -> Ok [ "ZAI_API_KEY" ]
-      | Llm_provider.Provider_config.OpenAI_compat ->
-          let base_url = cfg.Llm_provider.Provider_config.base_url in
-          let uri = Uri.of_string base_url in
-          if is_loopback_host (Uri.host uri) then Ok [] else Ok [ "OPENAI_API_KEY" ]
-      | Llm_provider.Provider_config.Gemini ->
-          if Sys.getenv_opt "GEMINI_API_KEY" |> Option.is_some then
-            Ok [ "GEMINI_API_KEY" ]
-          else
-            Error
-              "Gemini Docker workers currently require GEMINI_API_KEY; Vertex ADC is unsupported in v1"
-      | Llm_provider.Provider_config.Claude_code -> Ok []
-      | Llm_provider.Provider_config.Ollama -> Ok [])
+  | Some cfg ->
+    let keys = Provider_adapter.auth_env_keys_of_provider_kind cfg.Llm_provider.Provider_config.kind in
+    let missing = List.filter (fun key ->
+      match Sys.getenv_opt key with Some v -> String.trim v = "" | None -> true
+    ) keys in
+    if missing = [] then Ok keys
+    else
+      let kind_name = Provider_adapter.cascade_prefix_of_provider_kind cfg.Llm_provider.Provider_config.kind in
+      Error (Printf.sprintf "%s Docker workers require %s" kind_name (String.concat ", " missing))
 
 let missing_required_envs keys =
   keys

--- a/scripts/generate_oil_paintings.py
+++ b/scripts/generate_oil_paintings.py
@@ -51,7 +51,7 @@ def generate_image(prompt: str, output_path: Path, size: tuple[int, int]) -> boo
 
     try:
         response = client.models.generate_content(
-            model="gemini-2.5-flash-image",
+            model=os.getenv("MASC_IMAGE_MODEL", "gemini-2.5-flash-image"),
             contents=full_prompt,
             config=types.GenerateContentConfig(
                 response_modalities=["IMAGE", "TEXT"],


### PR DESCRIPTION
## Problem

3-agent 전수 감사 결과 provider_adapter.ml 외부에서 벤더 하드코딩 발견:
- `autoresearch.ml:150`: `model_model = "glm"` 기본값
- `worker_runtime_docker.ml:61-180`: 환경변수명 6개 + provider kind 직접 분기

## Principle

MASC는 벤더/모델을 모른다. `provider_adapter.ml`이 유일한 매핑 레이어.

## Changes

- `provider_adapter.ml`: `auth_env_keys_of_provider_kind()`, `all_auth_env_keys()` 추가
- `worker_runtime_docker.ml`: 하드코딩된 env key list → `all_auth_env_keys()`, provider kind switch → `auth_env_keys_of_provider_kind()`
- `autoresearch.ml`: `"glm"` → `Provider_adapter.default_model_provider_prefix_result()`

## Test plan

- [x] `dune build` passes

Generated with [Claude Code](https://claude.com/claude-code)