### PR TITLE
fix(dashboard): improve accessibility — buttons and form labels

### DIFF
--- a/dashboard/src/components/auth-status.ts
+++ b/dashboard/src/components/auth-status.ts
@@ -77,6 +77,7 @@ function AuthPopover({ authenticated }: { authenticated: boolean }) {
           <input
             type="password"
             placeholder="Bearer token"
+            aria-label="Bearer token"
             class="w-full py-1.5 px-2 rounded-md text-[11px] border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] placeholder-[var(--text-muted)] outline-none focus:border-[rgba(71,184,255,0.5)]"
             value=${tokenInput.value}
             onInput=${(e: Event) => { tokenInput.value = (e.target as HTMLInputElement).value }}

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -83,7 +83,7 @@ function CommentItem({
       <div class="board-comment rounded-lg p-3 bg-[var(--white-3)] border border-[var(--border-slate-12)] ${depth > 0 ? 'border-l-2 border-l-[var(--accent-20)]' : ''}">
         <div class="flex items-center gap-2 mb-1.5">
           <span class="text-[12px]">${authorAvatar(comment.author)}</span>
-          <a class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigateToAuthor(comment.author)}>${comment.author}</a>
+          <button type="button" class="text-[12px] font-medium text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(comment.author)}>${comment.author}</button>
           <span class="text-[11px] text-[var(--text-muted)] opacity-60"><${TimeAgo} timestamp=${comment.created_at} /></span>
           <button type="button"
             class="text-[11px] text-[var(--text-muted)] hover:text-[var(--accent)] cursor-pointer bg-transparent border-0 ml-auto"
@@ -225,7 +225,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           <!-- Author and meta -->
           <div class="flex gap-2.5 items-center flex-wrap pt-3 border-t border-[var(--border-slate-12)]">
             <span class="text-[13px]">${authorAvatar(post.author)}</span>
-            <a class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer" onClick=${() => navigateToAuthor(post.author)}>${post.author}</a>
+            <button type="button" class="text-[12px] text-[var(--text-body)] hover:text-[var(--accent)] transition-colors cursor-pointer bg-transparent border-none p-0" onClick=${() => navigateToAuthor(post.author)}>${post.author}</button>
             <span class="text-[11px] text-[var(--text-muted)]"><${TimeAgo} timestamp=${post.created_at} /></span>
             <span class="text-[11px] text-[var(--text-muted)]">${post.votes ?? 0} votes</span>
           </div>


### PR DESCRIPTION
## Summary
- `<a onClick>` → `<button type="button">` for author navigation (memory-post-detail.ts) — keyboard accessible
- `aria-label` added to password input (auth-status.ts)

## Test plan
- [x] pnpm typecheck pass
- [x] pnpm test — 449 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)