### PR TITLE
fix(keeper): gate auto-clear of manual reconcile behind age threshold

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -789,22 +789,60 @@ let run_keepalive_unified_turn
       in
       (* Auto-clear manual_reconcile to break deadlock: reconcile blocks
          turns, but turns are needed to clear reconcile.  Clear both the
-         on-disk record AND the registry state, then proceed as if clean. *)
+         on-disk record AND the registry state, then proceed as if clean.
+
+         Age gate: only auto-clear records older than
+         [auto_clear_min_age_sec]. Without a threshold this races with
+         explicit operator clears that immediately follow reconcile
+         openings — triage fires auto-clear first, operator's explicit
+         [masc_keeper_reconcile clear] then hits [Already_cleared]
+         returning [cleared=false], and any inspect/clear contract
+         test becomes flaky. Records older than the threshold are
+         genuinely stuck and still get the deadlock-break treatment. *)
+      let auto_clear_min_age_sec = 300.0 in
       let manual_reconcile_pending =
         if manual_reconcile_pending then (
-          Log.Keeper.info
-            "keeper:%s auto-clearing manual_reconcile to break deadlock"
-            meta_after_triage.name;
-          ignore (Keeper_manual_reconcile.clear ctx.config
-            ~keeper_name:meta_after_triage.name
-            ~actor:"auto_clear_deadlock_break"
-            ~resolution:"Automatic deadlock break: stale reconcile cleared to restore keeper activity"
-            ~evidence_refs:[]
-            ~idempotency_key:None);
-          ignore (Keeper_registry.dispatch_event
-            ~base_path:ctx.config.base_path meta_after_triage.name
-            Keeper_state_machine.Manual_reconcile_cleared);
-          false (* reconcile is now cleared — proceed as normal *))
+          let should_auto_clear =
+            match
+              Keeper_manual_reconcile.read
+                ctx.config
+                meta_after_triage.name
+            with
+            | Some record -> (
+                match Types.parse_iso8601_opt record.opened_at with
+                | Some opened_unix ->
+                    let age = Time_compat.now () -. opened_unix in
+                    age >= auto_clear_min_age_sec
+                | None ->
+                    (* Unparseable timestamp: treat as stale so a
+                       corrupted record doesn't keep a keeper blocked
+                       forever. *)
+                    true)
+            | None ->
+                (* Legacy pending flag without an on-disk record:
+                   preserve prior behavior and proceed as clean. *)
+                true
+          in
+          if should_auto_clear then (
+            Log.Keeper.info
+              "keeper:%s auto-clearing manual_reconcile to break deadlock"
+              meta_after_triage.name;
+            ignore (Keeper_manual_reconcile.clear ctx.config
+              ~keeper_name:meta_after_triage.name
+              ~actor:"auto_clear_deadlock_break"
+              ~resolution:"Automatic deadlock break: stale reconcile cleared to restore keeper activity"
+              ~evidence_refs:[]
+              ~idempotency_key:None);
+            ignore (Keeper_registry.dispatch_event
+              ~base_path:ctx.config.base_path meta_after_triage.name
+              Keeper_state_machine.Manual_reconcile_cleared);
+            false (* reconcile is now cleared — proceed as normal *))
+          else (
+            Log.Keeper.debug
+              "keeper:%s manual_reconcile pending but below age threshold, \
+               leaving for operator"
+              meta_after_triage.name;
+            true))
         else false
       in
       (* Honor a pending manual reconcile: the "keepalive turn skipped" log


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 5. Cycle 3 에서 발견한 구조적 finding 의 직접 수정.

Issue #6473 재현 중 발견: `keeper_keepalive.ml:790-808` 의 "deadlock break" auto-clear 로직은 triage cycle 마다 **무조건** 발동합니다. 의도는 "오래 stuck 된 keeper 를 복구" 였지만 (PR #6411), 시간 임계치가 없어서:

1. **explicit operator clear 와 race**: `test_keeper_reconcile_tool` 가 보여준 시퀀스
   ```
   open_pending → inspect(pending=true) → status(blocker) → clear → Already_cleared (cleared=false)
   ```
   triage fiber 가 inspect 와 explicit clear 사이에 auto-clear 를 먼저 실행하여 explicit clear 가 `Already_cleared` 브랜치를 맞아 `cleared: false` 를 반환합니다. PR #6460 이 이 현상을 테스트 어서션 완화로 우회했지만 근본 원인은 남아 있었습니다.
2. **operator 의 manual reconcile 이 사실상 무효화**: 오퍼레이터가 `masc_keeper_reconcile` 로 evidence 를 붙여 reconcile 을 open 해도, 다음 keepalive triage cycle 에서 즉시 stale 취급되어 자동 삭제. 인간 개입 시그널 이 생존 불가.

## 변경

`auto_clear_min_age_sec = 300.0` 나이 임계치 추가. `Keeper_manual_reconcile.read` 로 record 의 `opened_at` 을 읽고 `Types.parse_iso8601_opt` 로 unix 시각 환산하여 5분 이상 경과한 것만 auto-clear 대상. Fresh record 는 오퍼레이터 몫으로 남겨둡니다.

엣지 케이스:
- `Some record` + `parse_iso8601_opt` success → age 비교 후 결정
- `Some record` + timestamp unparseable → stale 로 간주 (corrupted record 가 영구 block 방지)
- `None` + legacy pending flag → 기존 동작 유지 (항상 proceed)

## 검증

```
dune build --root . lib/                                  # exit 0
./test/test_keeper_reconcile_tool.exe                     # 2/2 pass
./test/test_smart_heartbeat_keepalive.exe                 # 14/14 pass
```

## 이 PR 범위 밖 (별도 이슈)

`should_run_turn` (line 810) 계산은 `manual_reconcile_pending` 을 참조하지 않습니다. 따라서 이 gate 만으로는:

- Fresh reconcile 이 pending record 를 유지하게 되나
- 같은 triage cycle 의 turn 실행은 막지 못함 (line 821 "keepalive turn skipped" 로그 는 사실 거짓)

Line 821 의 log-message 와 line 810 의 should_run_turn 사이의 불일치는 별도 버그입니다. 이번 PR 에서 다루지 않고 follow-up 이슈로 분리합니다. 이 gate 만으로도 explicit clear contract 와 operator 개입 가시성은 회복됩니다.

## 관련

- Issue #6473 (closed) — 증상 보고서, upstream #6460 이 테스트 어서션 완화로 우회
- PR #6411 — 이 auto-clear 의 on-disk 확장을 도입한 원본
- Cycle 3 handoff finding: memory/project_masc-ocaml-audit-sweep-2026-04-11.md
