### PR TITLE
fix(config): align config truth with runtime paths

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -142,7 +142,7 @@ describe('KeeperConfigPanel', () => {
 
     expect(mocks.fetchKeeperConfig).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('편집 가능 범위')
-    expect(container.textContent).toContain('config/cascade.json')
+    expect(container.textContent).toContain('resolved config root의 cascade.json')
     expect(container.textContent).toContain('런타임 설정')
     expect(container.textContent).toContain('/tmp/.masc/keepers/keeper-sangsu/live.json')
     expect(container.textContent).toContain('활성 모델')

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -496,7 +496,7 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
 
       <${Callout}
         title="편집 가능 범위"
-        body="여기서 저장되는 값은 keeper 프롬프트와 live override 계층입니다. 활성 모델은 keeper별 설정이 아니라 config/cascade.json 해석 결과로 결정됩니다."
+        body="여기서 저장되는 값은 keeper 프롬프트와 live override 계층입니다. 활성 모델은 keeper별 설정이 아니라 resolved config root의 cascade.json 해석 결과로 결정됩니다."
       />
 
       ${promptSection}

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -178,29 +178,29 @@ describe('Overview freshness strip', () => {
       status: 'warn',
       warnings: ['Resolved config child is missing: keepers'],
       config_root: {
-        path: '/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config',
+        path: '/Users/dancer/me/.masc/config',
         exists: true,
-        source: 'env',
+        source: 'local_masc',
       },
       cascade: {
-        path: '/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/cascade.json',
+        path: '/Users/dancer/me/.masc/config/cascade.json',
         exists: true,
-        source: 'config_root',
+        source: 'local_masc',
       },
       prompts: {
-        path: '/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/prompts',
+        path: '/Users/dancer/me/.masc/config/prompts',
         exists: true,
-        source: 'config_root',
+        source: 'local_masc',
       },
       keepers: {
-        path: '/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/keepers',
+        path: '/Users/dancer/me/.masc/config/keepers',
         exists: false,
-        source: 'config_root',
+        source: 'local_masc',
       },
       personas: {
-        path: '/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas',
+        path: '/Users/dancer/me/.masc/config/personas',
         exists: true,
-        source: 'config_root',
+        source: 'local_masc',
       },
     }
     shellRuntimeResolution.value = {
@@ -250,7 +250,7 @@ describe('Overview freshness strip', () => {
     expect(container.textContent).toContain('설정 Truth')
     expect(container.textContent).toContain('warning 3')
     expect(container.textContent).toContain('config root')
-    expect(container.textContent).toContain('/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config')
+    expect(container.textContent).toContain('/Users/dancer/me/.masc/config')
     expect(container.textContent).toContain('runtime root')
     expect(container.textContent).toContain('/Users/dancer/me/.masc')
     expect(container.textContent).toContain('personas')

--- a/dashboard/src/components/tools/config-resolution-panel.test.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.test.ts
@@ -229,4 +229,24 @@ describe('ConfigResolutionPanel', () => {
     expect(container.textContent).toContain('home config')
     expect(container.textContent).toContain('/home/test/.masc/config')
   })
+
+  it('renders local .masc source label', () => {
+    render(
+      html`<${ConfigResolutionPanel}
+        resolution=${{
+          status: 'ready',
+          warnings: [],
+          config_root: { path: '/tmp/project/.masc/config', exists: true, source: 'local_masc' },
+          cascade: { path: '/tmp/project/.masc/config/cascade.json', exists: true, source: 'local_masc' },
+          prompts: { path: '/tmp/project/.masc/config/prompts', exists: true, source: 'local_masc' },
+          keepers: { path: '/tmp/project/.masc/config/keepers', exists: true, source: 'local_masc' },
+          personas: { path: '/tmp/project/.masc/config/personas', exists: true, source: 'local_masc' },
+        }}
+      />`,
+      container,
+    )
+
+    expect(container.textContent).toContain('local .masc')
+    expect(container.textContent).toContain('/tmp/project/.masc/config')
+  })
 })

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -398,7 +398,7 @@ export function ConfigResolutionPanel({
   return html`
     <${Card} title="설정 경로" class="section mb-4">
       <div class="mb-4 text-[12px] leading-relaxed text-[var(--text-muted)]">
-        repo-managed config root와 실제 runtime/data root를 함께 보여줍니다. 실행 중인 서버가 어떤 worktree와 경로를 보고 있는지 바로 비교할 수 있습니다.
+        서버가 실제로 해석한 config root와 runtime/data root를 함께 보여줍니다. 체크인된 repo config는 fallback/default source일 뿐이며, 현재 실행이 바라보는 경로와는 다를 수 있습니다.
       </div>
 
       ${resolution
@@ -411,7 +411,7 @@ export function ConfigResolutionPanel({
                 <span class="rounded-full border border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
                   ${sourceLabel(resolution.config_root.source)}
                 </span>
-                <span class="text-[12px] text-[var(--text-muted)]">repo-managed config root</span>
+                <span class="text-[12px] text-[var(--text-muted)]">resolved config root</span>
               </div>
 
               <div class="mb-4">

--- a/dashboard/src/components/tools/config-resolution-panel.ts
+++ b/dashboard/src/components/tools/config-resolution-panel.ts
@@ -30,6 +30,8 @@ function sourceLabel(source: string): string {
       return 'env override'
     case 'home_masc':
       return 'home config'
+    case 'local_masc':
+      return 'local .masc'
     case 'invalid_env':
       return 'invalid env'
     case 'exe_relative':

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -303,10 +303,10 @@ Current observed state on the inspected host:
 - Effective runtime root:
   - `/Users/dancer/me/.masc`
 - Effective config root:
-  - `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config`
-  - Reason: `MASC_CONFIG_DIR` is present in the live server environment.
-- Passive base-path config root also exists:
   - `/Users/dancer/me/.masc/config`
+  - Reason: for the normal `--base-path=/Users/dancer/me` runtime without an explicit `MASC_CONFIG_DIR` override, config resolves under the base path.
+- Checked-in fallback/default config tree:
+  - `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config`
 - Home fallback config root is absent on this host right now:
   - `/Users/dancer/.masc/config` does not exist.
 - Both of these trees exist at the same time:
@@ -317,7 +317,8 @@ Interpretation:
 
 - `/Users/dancer/me/.masc` is the current canonical runtime root.
 - `/Users/dancer/me/.masc/.masc` should be treated as historical drift from earlier runs that used `/Users/dancer/me/.masc` itself as `base_path`.
-- The active config root is the repo-managed override, not the passive base-path copy under `/Users/dancer/me/.masc/config`.
+- The active config root should be treated as the resolved runtime config root under `/Users/dancer/me/.masc/config` unless `MASC_CONFIG_DIR` explicitly points elsewhere.
+- The checked-in repo `config/` tree is the versioned default/fallback source, not the live runtime truth by itself.
 
 Current host definitely has live filesystem data for:
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -294,7 +294,7 @@ Memory compaction 시 어떤 정보를 우선 보존할지는 통합 정책(`kee
 
 ### 4.3 모델 해석
 
-Keeper 모델 선택은 profile.json 인자가 아니라 `cascade_name`으로 결정된다. 기본 keeper는 `keeper_unified` cascade를 사용하고, 실제 모델 목록은 `config/cascade.json`에서 해석된다.
+Keeper 모델 선택은 profile.json 인자가 아니라 `cascade_name`으로 결정된다. 기본 keeper는 `keeper_unified` cascade를 사용하고, 실제 모델 목록은 resolved config root의 `cascade.json`에서 해석된다.
 
 ### 4.4 작성 예시
 
@@ -378,7 +378,7 @@ masc_keeper_create_from_persona(persona_name: "sangsu")
 flowchart TD
     A[last_model_used 확인] -->|있으면| Z[Active Model 결정]
     A -->|없으면| B[cascade_name 해석]
-    B --> C[config/cascade.json 첫 모델]
+    B --> C[resolved config root/cascade.json 첫 모델]
     C --> Z
 
     style Z fill:#e8f5e9
@@ -388,7 +388,7 @@ flowchart TD
 
 Next Model Hint는 handoff 시 successor에게 추천할 모델이다.
 
-1. `config/cascade.json`에서 `cascade_name`의 모델 목록을 읽는다
+1. resolved config root의 `cascade.json`에서 `cascade_name`의 모델 목록을 읽는다
 2. 현재 `active_model`과 다른 첫 번째 모델을 고른다
 3. 다른 모델이 없으면 현재 모델을 반환한다
 4. cascade가 비어 있으면 `None`
@@ -411,7 +411,7 @@ Next Model Hint는 handoff 시 successor에게 추천할 모델이다.
 
 - keeper는 per-call `models` override나 persisted `active_model` pinning을 지원하지 않는다
 - handoff 시 cross-model 정규화가 자동 적용된다: Llama는 Tool 메시지 변환, Claude는 alternating 규칙 적용
-- cascade fallback은 `config/cascade.json`의 해당 cascade 순서대로 시도한다
+- cascade fallback은 resolved config root의 `cascade.json`에 있는 해당 cascade 순서대로 시도한다
 
 ---
 
@@ -571,7 +571,7 @@ flowchart TD
 |------|----------|
 | 의도한 모델이 사용 안 됨 | `active_model` vs `last_model_used` 비교 |
 | cascade가 fallback으로 넘어감 | MODEL provider 연결 상태 확인 (API key, 서버 상태 등) |
-| `active_model`이 빈 문자열 | `config/cascade.json`의 `keeper_unified` 설정 확인 |
+| `active_model`이 빈 문자열 | resolved config root의 `cascade.json`에서 `keeper_unified` 설정 확인 |
 
 **Cascade 디버깅**:
 ```
@@ -609,7 +609,7 @@ Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는 `docs/
 
 별도 keepalive 등록 레지스트리는 없다. keeper의 선언과 런타임 상태는 `.masc/keepers/<name>.json`에 함께 저장되고, keeper는 durable always-on으로 취급된다. 멈춤은 설정값이 아니라 `paused` 또는 `keeper_down` 상태 전이로 표현한다.
 
-repo-managed config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 `<MASC_BASE_PATH>/.masc/config`를 먼저 초기화/사용한다. 그 다음 `~/.masc/config`, 마지막으로 repo `config/` fallback chain을 사용한다. `MASC_PERSONAS_DIR`는 persona만 별도 override한다. 즉 웹/대시보드는 파일을 직접 읽지 않고, 서버가 해석한 config root와 persona root를 사용한다.
+resolved config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리를 우선 사용하고, 없으면 `<MASC_BASE_PATH>/.masc/config`를 먼저 초기화/사용한다. 그 다음 `~/.masc/config`, 마지막으로 repo `config/` fallback chain을 사용한다. repo `config/`는 체크인된 default/example source이며, 웹/대시보드는 파일을 직접 읽지 않고 서버가 해석한 config root와 persona root를 사용한다.
 
 ### 8.2 Template 변경 반영
 
@@ -630,11 +630,11 @@ dir-local 실행에서 shared keeper 상태가 보이지 않는 것은 정상이
 
 해결: dir-local 개발은 `scripts/run-local.sh --target-dir <dir>`를 사용하고, shared `.masc/`를 봐야 할 때만 `./start-masc-mcp.sh --http` 또는 explicit `--base-path`를 사용한다.
 
-이 값은 `.masc/` data root를 결정하고, explicit `MASC_CONFIG_DIR`가 없을 때는 `<MASC_BASE_PATH>/.masc/config`를 repo-managed config의 첫 fallback으로도 사용한다.
+이 값은 `.masc/` data root를 결정하고, explicit `MASC_CONFIG_DIR`가 없을 때는 `<MASC_BASE_PATH>/.masc/config`를 resolved config root의 첫 후보로도 사용한다.
 
 ### 8.4 모델 실행
 
-모델 선택은 `config/cascade.json`이 유일한 권위다. Keeper 설정에 모델 필드를 직접 지정하지 않는다. `cascade_name` (기본 `"keeper_unified"`)이 cascade를 지정하고 `Oas_model_resolve`가 실행 모델을 결정한다.
+모델 선택은 resolved config root의 `cascade.json`이 유일한 권위다. Keeper 설정에 모델 필드를 직접 지정하지 않는다. `cascade_name` (기본 `"keeper_unified"`)이 cascade를 지정하고 `Oas_model_resolve`가 실행 모델을 결정한다.
 
 ---
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -294,7 +294,7 @@ Memory compaction 시 어떤 정보를 우선 보존할지는 통합 정책(`kee
 
 ### 4.3 모델 해석
 
-Keeper 모델 선택은 profile.json 인자가 아니라 `cascade_name`으로 결정된다. 기본 keeper는 `keeper_unified` cascade를 사용하고, 실제 모델 목록은 resolved config root의 `cascade.json`에서 해석된다.
+Keeper 모델 선택은 profile.json 인자가 아니라 `cascade_name`으로 결정된다. 기본 keeper는 `keeper_unified` cascade를 사용하고, 실제 모델 목록은 저장소의 고정 경로 `config/cascade.json`이 아니라 resolved config root 기준의 `<resolved-config-root>/cascade.json`에서 해석된다.
 
 ### 4.4 작성 예시
 


### PR DESCRIPTION
## Summary
- relabel dashboard config-truth copy from repo-managed config wording to resolved runtime config wording
- update dashboard fixtures/tests to use the base-path `.masc/config` runtime shape instead of repo `config/`
- correct operator docs so repo `config/` is described as a checked-in fallback/default source, not live runtime truth

## Product impact
- Promise affected: `repo coordination`
- User-visible change: dashboard and docs now describe config truth using the actual resolved runtime path model

## Evidence
- `pnpm test -- src/components/tools/config-resolution-panel.test.ts src/components/overview/overview.test.ts src/components/keeper-config-panel.test.ts`
- `pnpm typecheck`

## Review evidence
- direct `sb glm-text` review at `2026-04-11 06:48:27Z`: `No findings.`

## Linked issue
- Closes #6502
