### PR TITLE
fix(auth): restore loopback cross-port relaxation (unblocks main CI)

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -203,7 +203,17 @@ let ensure_same_origin_browser_request request :
                (normalize_loopback_host request_host) ->
           let default = default_port_of_scheme scheme in
           let norm p = match p with Some _ -> p | None -> default in
-          if norm origin_port = norm request_port then Ok ()
+          (* Loopback relaxation: when both origin and host resolve to a
+             loopback address (localhost / 127.0.0.1 / ::1), cross-port
+             mutations are allowed. The dev proxy (vite 5173 → backend
+             8935) relies on this, and remote attackers cannot forge a
+             loopback Origin. For public hosts we still require an
+             exact port match. Restores the behaviour that
+             test_auth_coverage.test_same_origin_allows_different_
+             explicit_port_on_loopback expects after #6449. *)
+          if is_loopback_host (normalize_loopback_host origin_host) then
+            Ok ()
+          else if norm origin_port = norm request_port then Ok ()
           else (
             Log.Auth.debug
               "same-origin port mismatch: origin=%S host=%s"


### PR DESCRIPTION
## 문제

`#6449`가 `test_auth_coverage`의 `test_same_origin_rejects_different_explicit_port`를 `test_same_origin_allows_different_explicit_port_on_loopback`로 **이름과 기대값만 변경**(rejects→allows)하고 `lib/server/server_auth.ml` 구현은 함께 업데이트하지 않았습니다. 결과:

- `origin/main` (99f92e454)에서 `test_auth_coverage.http_auth/9`가 **실패**하는 상태.
- main에 rebase하는 모든 PR이 `Build and Test`에서 같은 지점에 걸립니다 (제 `#6468` 포함).

로컬 재현: `git worktree add probe origin/main && cd probe && dune exec test/test_auth_coverage.exe` → `1 failure! 89 tests run`.

## 수정

`ensure_same_origin_browser_request`에 "loopback relaxation" 분기를 다시 넣었습니다:

```ocaml
if is_loopback_host (normalize_loopback_host origin_host) then
  Ok ()
else if norm origin_port = norm request_port then Ok ()
else (Error Forbidden ...)
```

- origin과 host 둘 다 loopback(`localhost`/`127.0.0.1`/`::1`)으로 정규화되면 포트 불일치를 허용합니다. vite 개발 프록시(5173→8935)가 의존하던 원래 동작.
- public host에서는 여전히 정확한 포트 매칭을 요구합니다 — `test_same_origin_rejects_different_explicit_port_on_public_host`가 이 경로를 계속 검증합니다.
- `#6483`가 도입한 `normalize_loopback_host` 헬퍼와 새 로직은 모두 유지 (host name 정규화는 그대로 동작).

## 검증

`test_auth_coverage.exe` on `fix/loopback-port-allow`: **89 tests pass** (실패 없음).

## 범위

단일 파일 11줄 추가. 위험도 낮음. main CI 복구가 즉시 필요해서 별도 surgical PR로 올립니다.