### PR TITLE
fix: clean CI log noise and TLA workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -139,6 +139,8 @@ describe('Ops intervene surface', () => {
     expect(container.textContent).toContain('보류 1')
     expect(container.textContent).toContain('최근 처리 2')
     expect(container.textContent).toContain('프로젝트 진행 중')
+    expect(container.textContent).toContain('QuickIntervene')
+    expect(container.textContent).toContain('FlowControlPanel')
     expect(container.textContent).not.toContain('Active Queue')
     expect(container.textContent).not.toContain('Healthy Console')
 
@@ -221,6 +223,8 @@ describe('Ops intervene surface', () => {
 
     expect(container.textContent).toContain('즉시 검토 1')
     expect(container.textContent).toContain('프로젝트 일시정지')
+    expect(container.textContent).toContain('QuickIntervene')
+    expect(container.textContent).toContain('FlowControlPanel')
     expect(container.textContent).toContain('실행 작업대')
     expect(container.textContent).toContain('현재 상태')
     expect(container.textContent).toContain('마찰 요인')

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -114,17 +114,19 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
       match Grpc_eio.Stream.take raw_stream with
       | Ok bytes ->
         (try
-          push_typed (Ok (T.Event.of_bytes bytes))
+          ignore (push_typed (Ok (T.Event.of_bytes bytes)))
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          push_error
-            (Printf.sprintf "event decode error: %s"
-               (Printexc.to_string exn)));
+          ignore
+            (push_error
+               (Printf.sprintf "event decode error: %s"
+                  (Printexc.to_string exn))));
         loop ()
       | Error status ->
         if not (Grpc_core.Status.is_ok status) then
-          push_error
-            (Printf.sprintf "subscribe stream error: %s"
-               (Grpc_core.Status.to_string status));
+          ignore
+            (push_error
+               (Printf.sprintf "subscribe stream error: %s"
+                  (Grpc_core.Status.to_string status)));
         close_typed ()
       | exception End_of_file ->
         close_typed ()

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -8,9 +8,9 @@
     [Eio.Cancel.Cancelled] is always re-raised to preserve structured concurrency. *)
 let run_safe ~timeout_s fn =
   let do_timeout fn =
-    match (Masc_eio_env.get ()).clock with
-    | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
-    | None -> fn ()
+    match Masc_eio_env.get_opt () with
+    | Some { clock = Some clock; _ } -> Eio.Time.with_timeout_exn clock timeout_s fn
+    | Some { clock = None; _ } | None -> fn ()
   in
   try
     do_timeout fn

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -304,7 +304,6 @@ let cascade_metrics_for_candidates
   in
   let metrics : Llm_provider.Metrics.t =
     {
-      Llm_provider.Metrics.noop with
       on_cache_hit = (fun ~model_id:_ -> ());
       on_cache_miss = (fun ~model_id:_ -> ());
       on_request_start =

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -304,6 +304,7 @@ let cascade_metrics_for_candidates
   in
   let metrics : Llm_provider.Metrics.t =
     {
+      Llm_provider.Metrics.noop with
       on_cache_hit = (fun ~model_id:_ -> ());
       on_cache_miss = (fun ~model_id:_ -> ());
       on_request_start =

--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -3,11 +3,15 @@
 
 module Sg = Agent_sdk.Tool_schema_gen
 
-let broadcast_schema = Sg.two
-  (Sg.string_field "message" ~required:true
-     ~desc:"Message content to broadcast to all agents" ())
-  (Sg.string_field "format" ~required:false
-     ~desc:"Output format: compact or verbose (default: verbose)" ())
+let message_field =
+  Sg.string_field "message" ~required:true
+    ~desc:"Message content to broadcast to all agents" ()
+
+let format_field =
+  Sg.string_field "format" ~required:false
+    ~desc:"Output format: compact or verbose (default: verbose)" ()
+
+let broadcast_schema = Sg.two message_field format_field
 
 type broadcast_output = {
   delivered : bool;

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -54,8 +54,8 @@ curl_post_mcp() {
 
 initialize_mcp_session() {
   local headers_file body_file
-  headers_file="$(mktemp -t masc-mcp-init-headers)"
-  body_file="$(mktemp -t masc-mcp-init-body)"
+  headers_file="$(mcp_mktemp_file "masc-mcp-init-headers")"
+  body_file="$(mcp_mktemp_file "masc-mcp-init-body")"
 
   if curl -sS -m "$CURL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" -X POST "$MCP_URL" \
     -H 'Content-Type: application/json' \

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -337,7 +337,7 @@ write_runtime_doctor() {
   local stage="${1:-$CURRENT_STAGE}"
   [ -n "$RUNTIME_DOCTOR_FILE" ] || return 0
   local verify_file
-  verify_file="$(mktemp -t agent-swarm-live-runtime-verify).json"
+  verify_file="$(mcp_mktemp_file "agent-swarm-live-runtime-verify" ".json")"
   runtime_verify_result "" "$MODEL_ID" "$EXPECTED_SLOTS" "$EXPECTED_CTX" >"$verify_file"
 
   python3 - "$verify_file" "$PROVIDER_BASE_URL" "$SLOT_URL" \
@@ -683,7 +683,7 @@ printf "%s" "$MANIFEST_JSON" \
     done
 CURRENT_STAGE="run-harness"
 echo "[9/12] run live harness against local qwen"
-HARNESS_RESULT_FILE="$(mktemp -t agent-swarm-live-result)"
+HARNESS_RESULT_FILE="$(mcp_mktemp_file "agent-swarm-live-result")"
 start_slot_sampler
 run_compat_swarm_harness >"$HARNESS_RESULT_FILE" &
 HARNESS_PID="$!"

--- a/scripts/harness/workload/team_session_local64_soak.sh
+++ b/scripts/harness/workload/team_session_local64_soak.sh
@@ -80,7 +80,7 @@ record_metric "$(jq -cn \
 success=0
 for round in $(seq 1 "$ROUNDS"); do
   echo "[soak] round=$round/$ROUNDS"
-  round_log="$(mktemp -t "local64-soak-round.${round}")"
+  round_log="$(mcp_mktemp_file "local64-soak-round.${round}" ".log")"
   if MCP_URL="$MCP_URL" \
     COORD_AGENT="${COORD_AGENT}-r${round}" \
     WORKER_COUNT="$WORKER_COUNT" \

--- a/scripts/viewer-local-e2e-check.sh
+++ b/scripts/viewer-local-e2e-check.sh
@@ -161,13 +161,14 @@ ensure_mcp_harness() {
 }
 
 ensure_viewer_mcp_session() {
+  ensure_mcp_harness
   if [ -n "$VIEWER_MCP_SESSION_ID" ]; then
     return 0
   fi
 
   local headers_file body_file
-  headers_file="$(mktemp -t viewer-mcp-init-headers)"
-  body_file="$(mktemp -t viewer-mcp-init-body)"
+  headers_file="$(mcp_mktemp_file "viewer-mcp-init-headers")"
+  body_file="$(mcp_mktemp_file "viewer-mcp-init-body")"
 
   if ! curl -sS -m 30 -D "$headers_file" -o "$body_file" -X POST "$MCP_URL" \
     -H 'Content-Type: application/json' \

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -515,6 +515,7 @@ let test_last_good_shell_fallback_preserves_counts () =
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      ignore (Lib.Room.init state.Lib.Mcp_server.room_config ~agent_name:None);
       warm_execution_cache ();
       (* Warm the shell cache so _last_good_shell gets populated. *)
       Lib.Server_dashboard_http.warm_shell_cache state;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -100,10 +100,15 @@ let () = test "dispatch_tasks" (fun () ->
 )
 
 let () = test "masc_oas_bridge_runs_without_eio_env" (fun () ->
-  match Masc_oas_bridge.run_safe ~timeout_s:0.1 (fun () -> Ok "ok") with
-  | Ok "ok" -> ()
-  | Ok other -> failwith ("unexpected result: " ^ other)
-  | Error err -> failwith (Oas.Error.to_string err)
+  match Masc_eio_env.get_opt () with
+  | Some _ ->
+    failwith
+      "masc_oas_bridge_runs_without_eio_env requires Masc_eio_env.get_opt () = None before calling run_safe"
+  | None ->
+    match Masc_oas_bridge.run_safe ~timeout_s:0.1 (fun () -> Ok "ok") with
+    | Ok "ok" -> ()
+    | Ok other -> failwith ("unexpected result: " ^ other)
+    | Error err -> failwith (Oas.Error.to_string err)
 )
 
 (* Test dispatch transition claim *)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -99,6 +99,13 @@ let () = test "dispatch_tasks" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "masc_oas_bridge_runs_without_eio_env" (fun () ->
+  match Masc_oas_bridge.run_safe ~timeout_s:0.1 (fun () -> Ok "ok") with
+  | Ok "ok" -> ()
+  | Ok other -> failwith ("unexpected result: " ^ other)
+  | Error err -> failwith (Oas.Error.to_string err)
+)
+
 (* Test dispatch transition claim *)
 let () = test "dispatch_transition_claim" (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## Summary
- bump the TLA+ workflow from `actions/setup-java@v4` to `@v5` to remove the Node 20 deprecation warning
- replace BSD-only `mktemp -t` calls with portable harness temp helpers in the scripts that showed log noise on Linux
- let `Masc_oas_bridge.run_safe` execute without a preinitialized Eio env and add a regression test for that path

## Validation
- `bash -n scripts/harness/lib/test_framework.sh`
- `bash -n scripts/viewer-local-e2e-check.sh`
- `bash -n scripts/harness/workload/agent_swarm_live.sh`
- `bash -n scripts/harness/workload/team_session_local64_soak.sh`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/ci-log-hygiene @check`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/ci-log-hygiene test/test_tool_task_coverage.exe`
- `bash -lc 'source scripts/harness/lib/mcp_jsonrpc.sh; f=$(mcp_mktemp_file masc-jsonrpc .json); test -f "$f" && [[ "$f" == *.json ]] && rm -f "$f"'`
- `bash -lc 'source scripts/harness/lib/server_bootstrap.sh; a=$(harness_mktemp_file masc-helper .log); d=$(harness_mktemp_dir masc-helper-dir); test -f "$a" && [[ "$a" == *.log ]] && test -d "$d" && rm -f "$a" && rmdir "$d"'`
- `make -C specs check-all`

## Review Evidence
- `sb glm-text` strict diff review on 2026-04-11: `No findings.`