### PR TITLE
test(keeper-registry): replace tautological assertions with observable post-conditions

### DIFF
--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -159,7 +159,8 @@ let test_noop_on_missing () =
   R.set_grpc_close ~base_path:bp "ghost" None;
   R.wakeup ~base_path:bp "ghost";
   R.unregister ~base_path:bp "ghost";
-  check bool "no crash on missing" true true
+  check bool "ghost never materialized via no-op ops" true
+    (Option.is_none (R.get ~base_path:bp "ghost"))
 
 let test_register_replaces () =
   R.clear ();
@@ -431,7 +432,8 @@ let test_directive_unknown_no_crash () =
 let test_directive_nonexistent_agent () =
   R.clear ();
   KK.process_directive ~agent_name:"ghost-agent" "pause";
-  check bool "no crash on missing agent" true true
+  check bool "directive on ghost agent leaves registry empty" true
+    (Option.is_none (R.get ~base_path:bp "ghost-agent"))
 
 let test_stop_keepalive_scoped_to_base_path () =
   R.clear ();


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 6 — Cat F (가짜 테스트 제거). `test/test_keeper_registry.ml` 에 `check bool "..." true true` 패턴 2건 발견.

## 문제

```ocaml
(* line 162, test_noop_on_missing *)
check bool "no crash on missing" true true

(* line 434, test_directive_nonexistent_agent *)
check bool "no crash on missing agent" true true
```

두 assertion 모두 `true = true` 를 검증하므로 코드가 어떻게 동작하든 pass. 의도는 "crash 없이 동작" 확인이었지만 Alcotest 는 이미 uncaught exception 에서 실패하므로 이 assertion 은 **순수 noise** 입니다. Coverage 신호가 거짓 (“assertion 있으니 뭔가 검증되고 있다”) 이라 오히려 해롭습니다.

## 변경

**test_noop_on_missing**: 7 개 no-op 연산(update_meta/dispatch_event/record_restart/record_error/record_crash/set_grpc_close/wakeup/unregister) 을 unregistered "ghost" 에 호출한 뒤, `R.get ~base_path:bp "ghost"` 가 `None` 인지 확인. 누군가 실수로 `update_meta` 가 missing key 에서 placeholder 를 만들게 수정하면 이 테스트가 잡습니다.

**test_directive_nonexistent_agent**: `KK.process_directive ~agent_name:"ghost-agent" "pause"` 호출 후 registry 가 비어있는지 확인. directive 경로가 ghost entry 를 생성하지 않음을 보장.

## 검증

```
dune build --root . test/test_keeper_registry.exe   # exit 0
./test/test_keeper_registry.exe                     # 45/45 pass
```

## 관련

- Cycle 1 PR #6463 (board_dispatch silent failure) — 같은 "누락된 assertion" 카테고리
- Cycle 4 PR #6484 (gRPC fork wrap) — silent failure
- Cycle 5 PR #6497 (keeper reconcile age threshold)
