### PR TITLE
chore: bump MASC to v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-04-11
+
+### Changed
+- Eliminate vendor hardcoding outside provider_adapter boundary (#6495)
+- Root cause fixes for JSONL parsing, keeper_github repo, preset validation (#6457)
+
+### Fixed
+- Restore loopback cross-port relaxation in auth (#6504)
+- Delegate context budget to OAS pipeline (#6488)
+
 ## [0.5.1] - 2026-04-11
 
 ### Changed

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 0.5.1)
+(version 0.5.2)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- 0.5.1 → 0.5.2
- 2 refactors (vendor boundary, JSONL/github), 2 fixes (auth, context budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)