### PR TITLE
chore(board): remove unused delete_posts_by_predicate

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -428,18 +428,6 @@ let delete_post ~post_id =
   | Jsonl store -> Board.delete_post store ~post_id
   | Postgres t -> Board_pg.delete_post t ~post_id
 
-let delete_posts_by_predicate ~predicate ?(limit=5200) () =
-  list_posts ~sort_by:Recent ~limit ()
-  |> List.fold_left
-       (fun acc (post : Board.post) ->
-         if predicate post then
-           match delete_post ~post_id:(Board.Post_id.to_string post.id) with
-           | Ok () -> acc + 1
-           | Error _ -> acc
-         else
-           acc)
-       0
-
 let search ~query ~limit =
   match backend () with
   | Jsonl store ->


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 7 — Cat C (telemetry/로깅 정합성) 광역 스캔 중 `Error _ -> acc` silent drop 후보로 `lib/board_dispatch.ml:438` 을 확인.

## 발견

`delete_posts_by_predicate` 는 **dead code** 입니다:

```
$ rg 'delete_posts_by_predicate' .
lib/board_dispatch.ml:431:let delete_posts_by_predicate ~predicate ?(limit=5200) () =
```

(정의 1건 외 호출자 0건 — `lib/`, `bin/`, `test/`, `scripts/`, `docs/` 전부 제로)

게다가 이 함수는 silent failure 가 내장되어 있었습니다:

```ocaml
|> List.fold_left
     (fun acc (post : Board.post) ->
       if predicate post then
         match delete_post ~post_id:(...) with
         | Ok () -> acc + 1
         | Error _ -> acc     (* ← 개별 삭제 실패가 로그/카운트 없이 증발 *)
       else acc)
     0
```

호출자는 "몇 건 삭제됐다" 는 `int` 만 받고, 몇 건이 실패했는지, 어떤 `post_id` 가 실패했는지는 전혀 알 수 없습니다. Bulk delete operation 의 telemetry 공백.

## 선택

두 가지 옵션을 검토:

1. **로그 추가** (`Log.BoardLog.warn "bulk delete failed: ..."`) — Cycle 1 PR #6463 과 동일 패턴
2. **함수 삭제** — unreachable 하므로 silent failure 를 fix 해도 실효성이 0

옵션 2 를 선택. 미호출 함수에 defensive 로깅을 추가하는 것은 유지보수 비용만 늘립니다. 향후 필요해지면 structured return type (`{ deleted: int; failed: (Post_id.t * string) list }`) 로 부활시키는 편이 낫습니다.

## 변경

`lib/board_dispatch.ml:431-441` 의 11 줄 함수 본체 + 1 줄 blank 제거. `delete_post` (singular) 는 유지됨 — 실제 호출자 7건:

- `lib/room/room_hooks.ml`
- `lib/room.ml`
- `lib/tool_board.ml`
- `lib/board_votes.ml`
- `lib/server/server_dashboard_http_delete_actions.ml`
- `lib/board_pg_admin.ml`
- `docs/spec/11-board.md`

## 검증

```
dune build --root . lib/   # exit 0
```

## 관련

- PR #6463 Cycle 1 — board_dispatch vote/vote_comment silent-failure log
- PR #6497 Cycle 5 — keeper reconcile age threshold
- PR #6506 Cycle 6 — fake test assertions
