### PR TITLE
fix(tool): drop trailing unit arg on Sg.string_field in broadcast schema (unblocks main build)

### DIFF
--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -5,9 +5,9 @@ module Sg = Agent_sdk.Tool_schema_gen
 
 let broadcast_schema = Sg.two
   (Sg.string_field "message" ~required:true
-     ~desc:"Message content to broadcast to all agents" ())
+     ~desc:"Message content to broadcast to all agents")
   (Sg.string_field "format" ~required:false
-     ~desc:"Output format: compact or verbose (default: verbose)" ())
+     ~desc:"Output format: compact or verbose (default: verbose)")
 
 type broadcast_output = {
   delivered : bool;


### PR DESCRIPTION
## 문제

`#6489`가 OAS pin을 v0.119.2로 bump했는데 `Agent_sdk.Tool_schema_gen.string_field`의 시그니처가 `string -> required:bool -> desc:string -> unit -> field_spec`에서 `string -> required:bool -> desc:string -> field_spec`으로 바뀌어 trailing unit arg가 사라졌습니다. 하지만 `lib/tool_broadcast_typed.ml`의 두 호출부는 여전히 `()`를 넘기고 있어, **현재 origin/main 전체 빌드가 깨져 있습니다**.

```
File "lib/tool_broadcast_typed.ml", lines 7-8:
Error: The function Sg.string_field has type
         string -> required:bool -> desc:string -> field_spec
       It is applied to too many arguments
```

재현: `git worktree add probe origin/main && cd probe && dune build lib` → 위 에러.

## 수정

두 호출부에서 trailing `()` 제거. 2 line diff.

## 검증

- `dune build lib` pass (main HEAD 기준)
- `test_typed_tool_masc` 16개 pass (broadcast schema를 사용하는 유일한 테스트)

## 영향 범위

단일 파일, 2 line. `grep -rn 'string_field' lib/` 결과 `tool_broadcast_typed.ml` 외에 `Agent_sdk.Tool_schema_gen` API를 호출하는 곳은 더 있지 않습니다 (나머지는 로컬 `string_field` helper들).

## 스코프 근거

main 전체 빌드가 깨진 상태라 `#6468`(SSOT playground paths) 등 모든 open PR이 이 지점에서 block 당합니다. 별도 surgical PR로 즉시 unblock 필요. cycle 8에서 loopback-port PR `#6504`과 동일한 패턴.