### PR TITLE
fix(goal-janitor): surface write_meta Error instead of ignoring

### DIFF
--- a/lib/goal/goal_janitor.ml
+++ b/lib/goal/goal_janitor.ml
@@ -121,9 +121,15 @@ let run ?(config = default_config) (room_config : Room.config) : sweep_result =
             prune_active_goal_ids ~valid_goal_ids:valid_ids meta.active_goal_ids
           in
           if removed > 0 then begin
-            total_orphans := !total_orphans + removed;
             let updated = { meta with active_goal_ids = pruned_ids } in
-            ignore (Keeper_types.write_meta room_config updated)
+            match Keeper_types.write_meta room_config updated with
+            | Ok () ->
+                total_orphans := !total_orphans + removed
+            | Error e ->
+                Log.Misc.warn
+                  "[GoalJanitor] failed to persist orphan-pruned meta for \
+                   keeper=%s removed=%d: %s"
+                  name removed e
           end
         | _ -> ()
       end);


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 8 — Cat B (Silent Failure) / Cat C (telemetry 정합성).

`lib/` 전수 `ignore (...)` 스캔에서 3건의 의심 패턴 발견:

```
lib/goal/goal_janitor.ml:126:            ignore (Keeper_types.write_meta room_config updated)
lib/server/server_runtime_bootstrap.ml:800:                ignore (Server_mcp_transport_ws.send_to_session ...)
lib/server/server_runtime_bootstrap.ml:818:                  ignore (Server_webrtc_transport.send_to_peer ...)
```

이 중 가장 해로운 `goal_janitor.ml:126` 부터 수정.

## 문제

`Keeper_types.write_meta : ... -> (unit, string) result` (lib/keeper/keeper_types.ml:1435). `goal_janitor` 는 orphan goal_id 를 정리한 뒤 meta 를 disk 에 쓰는데, `ignore` 로 Error 를 묵살:

```ocaml
if removed > 0 then begin
  total_orphans := !total_orphans + removed;
  let updated = { meta with active_goal_ids = pruned_ids } in
  ignore (Keeper_types.write_meta room_config updated)
end
```

결과적으로:

1. `total_orphans` 가 증가하여 `"[GoalJanitor] sweep done: orphans=N"` 로그는 "고쳤다" 고 보고
2. Disk 상 meta 파일은 그대로 남아 orphan 유지 (`write_meta` 가 실패했는데도)
3. 호출자는 `result.orphans = N` 을 성공으로 해석

전형적인 **"로그는 fixed, 실제로는 unchanged"** silent failure. 다음 sweep 에서 같은 orphan 이 다시 잡혀 카운트 reconcile 이 깨집니다.

## 변경

```ocaml
if removed > 0 then begin
  let updated = { meta with active_goal_ids = pruned_ids } in
  match Keeper_types.write_meta room_config updated with
  | Ok () ->
      total_orphans := !total_orphans + removed
  | Error e ->
      Log.Misc.warn
        "[GoalJanitor] failed to persist orphan-pruned meta for \
         keeper=%s removed=%d: %s"
        name removed e
end
```

- `total_orphans` 은 **실제로 persist 된** 케이스에만 증가 (sweep summary 가 진실 반영)
- Error 는 `Log.Misc.warn` 으로 keeper 이름 + 시도한 pruning 수 + underlying error 와 함께 기록
- Exception 은 발생시키지 않음 — 다른 keeper 처리 계속

## 검증

```
dune build --root . lib/goal/   # exit 0
```

**주의**: 이 시점 main 의 `dune build --root . lib/` 는 `lib/tool_broadcast_typed.ml` 의 `Sg.string_field` 인자 개수 불일치로 pre-existing 실패 상태. PR #6511 이 수정 중. 본 PR 의 수정은 `lib/goal/goal_janitor.ml` 에만 국한되며 `lib/goal/` 서브 빌드는 깨끗이 통과합니다. CI 가 실패해 보여도 본 PR 원인 아님.

## 후속

같은 audit sweep 에서 나머지 2 건 `ignore (...)` (`server_runtime_bootstrap.ml:800, 818` WS/WebRTC send) 은 less critical 이고 반환 타입이 `bool` + 내부 cleanup 이 따라오므로 별도 PR 에서 log-on-false 로 보강 예정.

## 관련

- PR #6463 Cycle 1 — board_dispatch vote/vote_comment silent-failure log
- PR #6484 Cycle 4 — gRPC reflection fork wrap
- PR #6497 Cycle 5 — keeper reconcile auto-clear age threshold
- PR #6506 Cycle 6 — registry fake test assertions
- PR #6509 Cycle 7 — dead delete_posts_by_predicate removal
