### PR TITLE
chore: fix stale comments — version placeholder and old type name

### DIFF
--- a/lib/config/masc_time_constants.ml
+++ b/lib/config/masc_time_constants.ml
@@ -4,7 +4,7 @@
     the codebase.  All values are in seconds (float) unless suffixed with
     [_int].
 
-    @since 2.XXX.0 *)
+    @since 0.4.0 *)
 
 (** Seconds in one minute. *)
 let minute = 60.0

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -14,7 +14,7 @@
 *)
 
 (** Re-export shared types so callers can use
-    [Tool_inline_dispatch.context] and [Tool_inline_dispatch.result]
+    [Tool_inline_dispatch.context] and [Tool_inline_dispatch.tool_result]
     without knowing about the types sub-module. *)
 type tool_result = Tool_inline_dispatch_types.tool_result
 type context = Tool_inline_dispatch_types.context = {


### PR DESCRIPTION
## Summary
- Fix `@since 2.XXX.0` version placeholder in masc_time_constants.ml
- Update stale `Tool_inline_dispatch.result` reference to `tool_result` (post #6482)

## Test plan
- [x] Comment-only changes, no logic affected
- [ ] CI

Part of #6476

Generated with [Claude Code](https://claude.com/claude-code)
