### PR TITLE
fix(transport): surface WS and WebRTC send failures in server bootstrap

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -796,8 +796,16 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
                   ~mcp_session_id:ws_session_id state body_str
               in
               let response_str = Yojson.Safe.to_string response_json in
-              if response_str <> "null" then
-                ignore (Server_mcp_transport_ws.send_to_session ws_session_id response_str)
+              if response_str <> "null" then begin
+                if not
+                     (Server_mcp_transport_ws.send_to_session
+                        ws_session_id response_str)
+                then
+                  Log.Server.warn
+                    "WS send_to_session dropped response for session=%s (session \
+                     gone or write failed; session cleaned up by transport)"
+                    ws_session_id
+              end
             with
             | Eio.Cancel.Cancelled _ as e -> raise e
             | exn ->
@@ -814,8 +822,16 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
                     ~mcp_session_id:peer_id state body_str
                 in
                 let response_str = Yojson.Safe.to_string response_json in
-                if response_str <> "null" then
-                  ignore (Server_webrtc_transport.send_to_peer peer_id response_str)
+                if response_str <> "null" then begin
+                  match
+                    Server_webrtc_transport.send_to_peer peer_id response_str
+                  with
+                  | Ok _bytes -> ()
+                  | Error e ->
+                    Log.Server.warn
+                      "WebRTC send_to_peer dropped response for peer=%s: %s"
+                      peer_id e
+                end
               with
               | Eio.Cancel.Cancelled _ as e -> raise e
               | exn ->


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 9 — Cat B (Silent Failure) / Cat C (telemetry 정합성). Cycle 8 에서 시작한 `ignore (...)` 전수 스캔의 나머지 2건 (server_runtime_bootstrap.ml:800, 818) 마무리.

## 문제

`server_runtime_bootstrap.ml` 는 MCP handle_request 의 응답을 WS / WebRTC 로 돌려보낼 때 의미있는 반환 값을 bare `ignore` 로 묵살:

```ocaml
(* WS *)
ignore (Server_mcp_transport_ws.send_to_session ws_session_id response_str)

(* WebRTC *)
ignore (Server_webrtc_transport.send_to_peer peer_id response_str)
```

시그니처 확인:

- `send_to_session : string -> string -> bool` (lib/server/server_mcp_transport_ws.ml:157) — `false` 는 세션이 없거나 socket write 실패. 내부에서 `cleanup_session` 은 실행되지만 호출자는 진단 단서 0건.
- `send_to_peer : string -> string -> (int, string) result` (lib/server/server_webrtc_transport.ml:352) — Error 브랜치가 명시적 reason string (peer not connected, no datachannel, webrtc 전송 실패 등) 을 담는데 완전히 손실됨.

클라이언트가 응답을 못 받아 operator 가 디버깅할 때, 이 두 경로에는 로그 한 줄도 없음.

## 변경

두 경로 모두 warn-level 로그로 실패를 surface:

```ocaml
(* WS *)
if not (Server_mcp_transport_ws.send_to_session ws_session_id response_str) then
  Log.Server.warn
    "WS send_to_session dropped response for session=%s (session \
     gone or write failed; session cleaned up by transport)"
    ws_session_id

(* WebRTC *)
match Server_webrtc_transport.send_to_peer peer_id response_str with
| Ok _bytes -> ()
| Error e ->
  Log.Server.warn
    "WebRTC send_to_peer dropped response for peer=%s: %s"
    peer_id e
```

- Happy path 동작 변경 없음
- Exception 안 raise → dispatch fiber 는 다음 메시지 계속 처리
- Bytes_sent 는 현재 로그에 포함 안 함 (디버깅 필요 시 추가 가능)

## 검증

```
dune build --root . lib/server/   # exit 0
```

Full `dune build --root . lib/` 는 main 의 2건 pre-existing 실패로 빨간불:

1. `lib/oas_worker_cascade.ml` — `on_http_status` record field 누락
2. `lib/tool_broadcast_typed.ml` — `Sg.string_field` 인자 개수 (earlier, likely resolved now)

본 PR 은 `lib/server/server_runtime_bootstrap.ml` 1 파일에만 국한. 서브 빌드 통과.

## 관련

- PR #6463 Cycle 1 — board_dispatch vote/vote_comment silent-failure log
- PR #6484 Cycle 4 — gRPC reflection fork wrap  
- PR #6513 Cycle 8 — goal_janitor write_meta Error surfacing
- Cycle 8 handoff: `ignore` 스캔 3건 중 janitor 완료, 이 PR 이 나머지 2건 (WS + WebRTC) 처리
