### PR TITLE
fix(keeper): should_run_turn now consults manual_reconcile_pending (closes #6500)

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -807,9 +807,17 @@ let run_keepalive_unified_turn
           false (* reconcile is now cleared — proceed as normal *))
         else false
       in
+      (* Honor a pending manual reconcile: the "keepalive turn skipped" log
+         at line 821 claims to skip, but previously should_run_turn did not
+         consult manual_reconcile_pending, so the log was a lie whenever the
+         reconcile record survived the auto-clear block above (e.g. the
+         record is too fresh per the age-threshold gate in #6497, or the
+         gate was never enabled). Make the skip real so the log matches
+         behavior and the pending record acts as a turn brake. *)
       let should_run_turn =
         (not (Atomic.get stop))
         && turn_decision.should_run
+        && (not manual_reconcile_pending)
       in
       let meta_after_observe =
         Keeper_world_observation.apply_message_cursor_updates


### PR DESCRIPTION
## 배경

Closes #6500 — OCaml audit sweep Cycle 10.

Cycle 5 PR #6497 작업 중 발견한 latent bug 를 Cycle 10 에서 직접 수정. `keeper_keepalive.ml` 에 log/behavior mismatch 가 있었습니다:

- **Line 821** 는 `manual_reconcile_pending && turn_decision.should_run` 일 때 `"keepalive turn skipped for %s: manual reconcile pending"` 을 로그
- **Line 810** 의 `should_run_turn` 계산은 `Atomic.get stop` 과 `turn_decision.should_run` 만 체크, `manual_reconcile_pending` **미참조**
- 결과: 로그는 "skipped" 라고 주장하는데 line 875 `else if should_run_turn then run_unified_turn ...` 에서 턴이 **그대로 실행됨**

이전에는 바로 위의 auto-clear 블록이 매 cycle 마다 `manual_reconcile_pending` 을 무조건 `false` 로 리셋해서 이 lying log 조건이 실제로 도달하지 않았습니다. PR #6497 의 age-threshold 가 들어가면 fresh record 에서 pending 플래그가 살아 있게 되고, 이 불일치가 드러납니다.

## 변경

```ocaml
let should_run_turn =
  (not (Atomic.get stop))
  && turn_decision.should_run
  && (not manual_reconcile_pending)   (* NEW *)
in
```

## 효과

| 상태 | 동작 |
|---|---|
| **현재 main** (#6497 미머지) | `manual_reconcile_pending` 이 auto-clear 로 항상 `false` → 이 PR 은 실질 no-op, 계약만 명확해짐 |
| **#6497 머지 후** | fresh record 가 age threshold 내라면 `manual_reconcile_pending = true` 유지 → `should_run_turn` 이 이를 존중하여 실제로 턴 skip. line 821 로그 가 진실이 됨. age threshold 경과 후 auto-clear → 턴 자동 재개 |

#6497 과 merge 순서는 무관합니다. 이 변경은 **계약 수정** 이지 **동작 변경** 이 아님 (main 기준).

## 검증

```
dune build --root . lib/keeper/   # exit 0
```

Full test build (`test/test_keeper_reconcile_tool.exe`) 은 현재 main 의 **unrelated** pre-existing 이슈 — `lib/oas_worker_cascade.ml` 가 `on_http_status` record field 누락 (PR #6514 롤아웃 중간 상태) — 로 실패. 이 PR 변경은 `lib/keeper/keeper_keepalive.ml` 1 파일에만 국한.

## 관련

- Issue #6500 — 이 PR 이 직접 해결
- PR #6497 Cycle 5 — auto-clear age threshold, 본 PR 과 함께 manual reconcile 세멘틱을 회복
- Cycle 3 handoff finding — Cycle 5, 10 에 걸쳐 해결
