### PR TITLE
fix(eio): wrap oas_sse_bridge + rate_limit cleanup fibers with exception loggers

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -99,8 +99,15 @@ let start ~sw ~clock ~bus =
   in
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
-      let events = Agent_sdk.Event_bus.drain sub in
-      List.iter relay_event events;
+      (try
+         let events = Agent_sdk.Event_bus.drain sub in
+         List.iter relay_event events
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Misc.warn
+           "oas_sse_bridge: relay iteration failed: %s"
+           (Printexc.to_string exn));
       Eio.Time.sleep clock interval_s;
       loop ()
     in

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -117,10 +117,19 @@ let start_cleanup_loop ~sw ~clock ?(interval=Env_config.RateLimit.cleanup_interv
   Eio.Fiber.fork ~sw (fun () ->
     let rec loop () =
       Eio.Time.sleep clock interval;
-      let older_than_seconds = int_of_float Env_config.RateLimit.entry_max_age_seconds in
-      let removed = cleanup limiter ~older_than_seconds in
-      if removed > 0 then
-        Log.Misc.info "Cleaned up %d stale buckets" removed;
+      (try
+         let older_than_seconds =
+           int_of_float Env_config.RateLimit.entry_max_age_seconds
+         in
+         let removed = cleanup limiter ~older_than_seconds in
+         if removed > 0 then
+           Log.Misc.info "Cleaned up %d stale buckets" removed
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Misc.warn
+           "rate_limit cleanup iteration failed: %s"
+           (Printexc.to_string exn));
       loop ()
     in
     loop ()


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 11 — Cat B (Silent Failure) / 동시성 안전. Cycle 4 에서 `Eio.Fiber.fork` 56 건 rough 스캔 후 `masc_grpc_server.ml:378` 1건만 PR #6484 로 fix. Cycle 11 에서 다시 심층 스캔하여 나머지 fork 사이트를 전수 triage.

## 발견

`Eio.Fiber.fork ~sw` 로 spawn 된 background 주기 fiber 중 **exception boundary 0** 인 것 2건:

### 1. `lib/oas_sse_bridge.ml:100`

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    let events = Agent_sdk.Event_bus.drain sub in
    List.iter relay_event events;
    Eio.Time.sleep clock interval_s;
    loop ()
  in
  loop ())
```

`Event_bus.drain`, `relay_event`, 어떤 downstream receiver 에서도 예외가 나면 fiber escape → outer switch cancel → 로그 없음.

### 2. `lib/rate_limit.ml:117`

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    Eio.Time.sleep clock interval;
    let removed = cleanup limiter ~older_than_seconds in
    ...
    loop ()
  in
  loop ())
```

Hashtbl iteration 중 concurrent modification, arithmetic overflow on `int_of_float` of a very large `entry_max_age_seconds`, 모두 silent cascade.

## Triage 결론 (Cycle 11)

fork 56 건 중 `(fun () -> ...)` body 가 `let rec loop` 로 시작하는 14 개 파일을 전수 확인:

| 파일 | 상태 |
|---|---|
| `tool_metrics_persist.ml:103` | OK (inline try/with) |
| `server_bootstrap_loops.ml:39` | OK (inline try/with) |
| `server_bootstrap_loops.ml:351` | OK (별도 확인 필요) |
| `proactive_refresh.ml:60, 87` | OK (내부 try) |
| `worker_container.ml:291` | 확인 필요 (추후 cycle) |
| `grpc/masc_grpc_client.ml:93` | Partial try (Ok branch만) |
| `grpc/masc_grpc_client.ml:120` | 확인 필요 (bidi mapper, minimal) |
| `grpc/masc_grpc_service.ml:277` | 확인 필요 (추후 cycle) |
| `server_activity_http.ml:206` | OK (inline try + is_cancelled) |
| `server_mcp_transport_http_agui.ml:97, 115` | OK |
| **`oas_sse_bridge.ml:100`** | **FIX (이 PR)** |
| **`rate_limit.ml:117`** | **FIX (이 PR)** |

이 PR 은 2건만 처리. 나머지 "확인 필요" 는 후속 cycle 에서 개별 triage.

## 변경

양쪽 모두 `tool_metrics_persist.ml:103` 의 정립된 패턴을 복사:

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    (try
       ... 본문 ...
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Misc.warn "<subsystem>: <phase> failed: %s" (Printexc.to_string exn));
    Eio.Time.sleep clock interval;
    loop ()
  in
  loop ())
```

- Eio.Cancel.Cancelled 는 반드시 re-raise (구조 동시성 계약)
- 다른 예외는 `Log.Misc.warn` 으로 기록 후 다음 iteration 으로 계속
- sleep 은 try 밖에 두어 interval 규약을 유지

## 검증

```
dune build --root . lib/   # exit 0
```

(main 의 earlier `oas_worker_cascade.ml` `on_http_status` 문제는 이제 해결된 것으로 보임 — full lib build 가 성공)

## 관련

- PR #6484 Cycle 4 — gRPC reflection process_loop fork wrap
- PR #6497 Cycle 5 — keeper reconcile age threshold
- PR #6518 Cycle 10 — should_run_turn manual_reconcile_pending gate
