### PR TITLE
fix(dashboard): rename harness rail labels to match actual state

### DIFF
--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -327,7 +327,7 @@ function OutcomeVsHarnessCallout({ loopCount }: { loopCount: number }) {
           <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Safety Harness</div>
           <div class="mt-1 text-sm font-medium text-[var(--text-strong)]">심판 기계의 건강도는 별도로 봅니다.</div>
           <div class="mt-2 text-sm leading-[1.6] text-[var(--text-body)]">
-            evaluator fallback, pre-compaction pressure, continuity DNA quality는 하네스에서 봅니다.
+            평가 모델, 압축 전 상태, 세대 교체 rail 상태는 하네스에서 봅니다.
           </div>
           <button
             type="button"

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -208,7 +208,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'harness',
       label: '세이프티 하네스',
-      description: 'Evaluator, compaction, DNA safety rail 감시 상태.',
+      description: '평가 모델, 압축 전 상태, 세대 교체 rail 감시 상태.',
       params: { section: 'harness' },
     },
     {


### PR DESCRIPTION
## Summary

Navigation and autoresearch copy referenced a non-existent "DNA safety rail" / "continuity DNA quality" for the Safety Harness surface. The actual HarnessHealth component exposes three rails, none of which is a DNA rail:

| Rail key    | Display title | Source field                         |
|-------------|---------------|--------------------------------------|
| evaluator   | 평가 모델     | `overview.evaluator_last_event_at`   |
| pre_compact | 압축 전 상태  | `overview.pre_compact_last_event_at` |
| handoff     | 세대 교체     | `overview.handoff_last_event_at`     |

A user clicking "하네스 열기" from autoresearch or reading the lab > harness description would look for a DNA rail and never find one. This PR aligns the user-facing strings with what the harness panel actually renders.

## Changes

- `dashboard/src/config/navigation.ts`: lab > harness description → `평가 모델, 압축 전 상태, 세대 교체 rail 감시 상태.`
- `dashboard/src/components/autoresearch.ts`: Safety Harness summary card body → same three rail names.

Label-only; no runtime or routing change.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (460 passed)
- [ ] Visual spot check in browser after merge