### PR TITLE
fix(playground): post-#6468 follow-up — docker cwd double-slash escape + schema drift note

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -196,11 +196,24 @@ let docker_playground_cwd ~(config : Room.config) ~(meta : keeper_meta) host_cwd
   if starts_at_boundary then
     if host_cwd = playground_prefix then container_root
     else
-      let suffix =
+      let raw_suffix =
         String.sub host_cwd (String.length prefix_with_sep)
           (String.length host_cwd - String.length prefix_with_sep)
       in
-      Filename.concat container_root suffix
+      (* A [host_cwd] like ".../.masc/playground//cheolsu/..." produces a
+         [raw_suffix] that starts with "/". [Filename.concat] would then
+         treat [raw_suffix] as an absolute path and drop [container_root],
+         silently escaping the mount. Strip any leading slashes so the
+         suffix is always a strict relative segment. *)
+      let suffix =
+        let n = String.length raw_suffix in
+        let i = ref 0 in
+        while !i < n && raw_suffix.[!i] = '/' do incr i done;
+        if !i = 0 then raw_suffix
+        else String.sub raw_suffix !i (n - !i)
+      in
+      if suffix = "" then container_root
+      else Filename.concat container_root suffix
   else
     (* meta.name is sanitized through Playground_paths so a poisoned
        name cannot escape the container_root. *)

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -31,7 +31,13 @@ masc_worktree_remove.";
         ]);
         ("repo_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-] — a single directory name, no slashes, no path traversal, no '.' or '..'. Leave empty to auto-pick the first clone alphabetically.");
+          ("description", `String "Optional. Disambiguates which playground clone to use when you have multiple repos under .masc/playground/<your-name>/repos/. Example: repo_name='masc-mcp'. Allowed characters: [A-Za-z0-9._-]. Must be a single directory name — no slashes, no path traversal. The special values '.' and '..' match the character class above but are rejected at runtime in tool_worktree.handle_worktree_create and Room_worktree.worktree_create_r. Leave empty to auto-pick the first clone alphabetically.");
+          (* Negative lookahead is not supported by JSON Schema Draft 7
+             (used by most MCP clients), so the pattern below only
+             enforces the character class. The ".", ".." special cases
+             are enforced at runtime so the three layers (schema,
+             tool dispatch, Room resolver) agree on the same rule even
+             though the schema cannot express it. *)
           ("pattern", `String "^[A-Za-z0-9._-]+$");
         ]);
       ]);


### PR DESCRIPTION
## 배경
`#6468` (SSOT playground paths)는 머지되었습니다 (11:22 UTC). 머지 직전에 Copilot PR reviewer가 2건의 인라인 코멘트를 추가로 남겼는데, 본 PR에서 대응합니다.

## 변경

### 1. `keeper_exec_shell.docker_playground_cwd` — double slash escape
**문제**: `host_cwd`가 `".../.masc/playground//cheolsu/repos/X"`와 같이 **double slash**를 포함하면 `String.sub`로 계산된 `suffix`가 `/`로 시작합니다. `Filename.concat container_root suffix`는 OCaml 의미상 `suffix`가 absolute path이면 `container_root`를 **drop**하고 `suffix`만 반환합니다 — 결과적으로 컨테이너 cwd가 mount를 **silently 벗어납니다**.

**수정**: suffix 앞의 leading slashes를 모두 strip한 후 concat. stripped suffix가 빈 문자열이면 `container_root` 그대로 반환.

### 2. `tool_schemas_worktree` repo_name pattern — schema-runtime drift
**문제**: 스키마 pattern `^[A-Za-z0-9._-]+$`이 `.`과 `..`를 match합니다. 하지만 `tool_worktree.handle_worktree_create`와 `Room_worktree.worktree_create_r`는 두 값을 runtime에서 거부합니다. Schema가 runtime보다 느슨해서 문서가 잘못된 계약을 약속합니다.

**제약**: JSON Schema Draft 7 (대부분 MCP 클라이언트가 사용)은 **negative lookahead를 지원하지 않습니다**. 따라서 pattern으로는 `.`, `..`를 제외할 수 없습니다.

**수정**: description에 ".'와 '..'은 character class와 match하지만 runtime에서 거부됨"을 **명시적으로 적음**. Pattern 뒤에 주석을 추가해 이 drift가 의도적이며 3레이어(스키마/tool dispatch/Room resolver)가 동일한 규칙을 강제함을 설명.

## 검증
- `dune build lib`: pass (agent_sdk v0.120.0 SHA 2fc2be29)
- `test_keeper_bash_safety` 17 pass
- `test_playground_paths` 7 pass
- `test_room` 99 pass
- **합계 123 pass**

## 범위
2 files, +22/-3 lines. 둘 다 `#6468`에서 소개한 validation을 edge case 두 건에 대해 강화할 뿐 새 기능 없음.

---

Copilot 리뷰 링크:
- https://github.com/jeong-sik/masc-mcp/pull/6468#discussion_r...(double slash)
- https://github.com/jeong-sik/masc-mcp/pull/6468#discussion_r...(schema drift)