### PR TITLE
fix(grpc): guarantee cleanup on heartbeat fiber exit paths

### DIFF
--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -118,25 +118,33 @@ let heartbeat_stream t ~sw ~env =
   (* Map typed pings to raw bytes *)
   let raw_requests = Grpc_eio.Stream.create 16 in
   Eio.Fiber.fork ~sw (fun () ->
+    let close_request_stream () =
+      try Grpc_eio.Stream.close request_stream with _ -> ()
+    in
+    let close_raw_requests () =
+      try Grpc_eio.Stream.close raw_requests with _ -> ()
+    in
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with
       | bytes ->
         Grpc_eio.Stream.add raw_requests bytes;
         loop ()
       | exception End_of_file ->
-        Grpc_eio.Stream.close raw_requests
+        close_raw_requests ()
     in
     try loop ()
     with
     | Eio.Cancel.Cancelled _ as e ->
-      (* Close the downstream to unblock any receiver before propagating. *)
-      (try Grpc_eio.Stream.close raw_requests with _ -> ());
+      (* Close both sides so senders and downstream receivers unblock. *)
+      close_request_stream ();
+      close_raw_requests ();
       raise e
     | exn ->
       Log.Transport.error
         "gRPC heartbeat request-mapper crashed: %s"
         (Printexc.to_string exn);
-      (try Grpc_eio.Stream.close raw_requests with _ -> ()));
+      close_request_stream ();
+      close_raw_requests ());
   let raw_responses =
     Grpc_eio.Client.call_bidi ~sw ~env t.client
       ~service ~method_:"Heartbeat" ~requests:raw_requests

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -126,7 +126,17 @@ let heartbeat_stream t ~sw ~env =
       | exception End_of_file ->
         Grpc_eio.Stream.close raw_requests
     in
-    loop ());
+    try loop ()
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      (* Close the downstream to unblock any receiver before propagating. *)
+      (try Grpc_eio.Stream.close raw_requests with _ -> ());
+      raise e
+    | exn ->
+      Log.Transport.error
+        "gRPC heartbeat request-mapper crashed: %s"
+        (Printexc.to_string exn);
+      (try Grpc_eio.Stream.close raw_requests with _ -> ()));
   let raw_responses =
     Grpc_eio.Client.call_bidi ~sw ~env t.client
       ~service ~method_:"Heartbeat" ~requests:raw_requests

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -275,80 +275,100 @@ let handle_heartbeat
   Atomic.incr active_heartbeat_streams;
   Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
   Eio.Fiber.fork ~sw (fun () ->
+    let cleanup () =
+      Atomic.decr active_heartbeat_streams;
+      Transport_metrics.set_grpc_active_streams
+        (Atomic.get active_heartbeat_streams);
+      (try Grpc_eio.Stream.close response_stream with _ -> ())
+    in
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with
       | bytes ->
-        let t0 = Unix.gettimeofday () in
-        let ping = T.HeartbeatPing.of_bytes bytes in
-        (* Update agent last_seen *)
         (try
-          let agent_file =
-            Filename.concat
-              (Filename.concat
-                (Filename.concat room_config.base_path ".masc")
-                "agents")
-              (safe_filename ping.agent_name ^ ".json")
+          let t0 = Unix.gettimeofday () in
+          let ping = T.HeartbeatPing.of_bytes bytes in
+          (* Update agent last_seen *)
+          (try
+            let agent_file =
+              Filename.concat
+                (Filename.concat
+                  (Filename.concat room_config.base_path ".masc")
+                  "agents")
+                (safe_filename ping.agent_name ^ ".json")
+            in
+            if Sys.file_exists agent_file then begin
+              let json = Yojson.Safe.from_string (read_file_safe agent_file) in
+              match Types.agent_of_yojson json with
+              | Ok agent ->
+                let now = Unix.gettimeofday () in
+                let iso_now =
+                  let tm = Unix.gmtime now in
+                  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+                    (1900 + tm.tm_year) (1 + tm.tm_mon) tm.tm_mday
+                    tm.tm_hour tm.tm_min tm.tm_sec
+                in
+                let updated = { agent with Types.last_seen = iso_now } in
+                let content =
+                  Yojson.Safe.to_string (Types.agent_to_yojson updated)
+                in
+                let tmp_path = agent_file ^ ".tmp" in
+                Fs_compat.save_file tmp_path content;
+                Unix.rename tmp_path agent_file
+              | Error e ->
+                  Log.Transport.warn "gRPC heartbeat: invalid agent JSON for %s: %s"
+                    ping.agent_name e
+            end
+          with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Transport.error "gRPC heartbeat update failed: %s" (Printexc.to_string exn));
+          (* Count active agents and pending tasks *)
+          let masc_dir = Filename.concat room_config.base_path ".masc" in
+          let agents_dir = Filename.concat masc_dir "agents" in
+          let agent_count =
+            if Sys.file_exists agents_dir then
+              Array.length (Sys.readdir agents_dir)
+            else 0
           in
-          if Sys.file_exists agent_file then begin
-            let json = Yojson.Safe.from_string (read_file_safe agent_file) in
-            match Types.agent_of_yojson json with
-            | Ok agent ->
-              let now = Unix.gettimeofday () in
-              let iso_now =
-                let tm = Unix.gmtime now in
-                Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
-                  (1900 + tm.tm_year) (1 + tm.tm_mon) tm.tm_mday
-                  tm.tm_hour tm.tm_min tm.tm_sec
-              in
-              let updated = { agent with Types.last_seen = iso_now } in
-              let content =
-                Yojson.Safe.to_string (Types.agent_to_yojson updated)
-              in
-              let tmp_path = agent_file ^ ".tmp" in
-              Fs_compat.save_file tmp_path content;
-              Unix.rename tmp_path agent_file
-            | Error e ->
-                Log.Transport.warn "gRPC heartbeat: invalid agent JSON for %s: %s"
-                  ping.agent_name e
-          end
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Transport.error "gRPC heartbeat update failed: %s" (Printexc.to_string exn));
-        (* Count active agents and pending tasks *)
-        let masc_dir = Filename.concat room_config.base_path ".masc" in
-        let agents_dir = Filename.concat masc_dir "agents" in
-        let agent_count =
-          if Sys.file_exists agents_dir then
-            Array.length (Sys.readdir agents_dir)
-          else 0
-        in
-        let tasks_dir = Filename.concat masc_dir "tasks" in
-        let pending_count =
-          if Sys.file_exists tasks_dir then
-            Sys.readdir tasks_dir
-            |> Array.to_list
-            |> List.filter (fun f -> Filename.check_suffix f ".json")
-            |> List.length
-          else 0
-        in
-        let directives =
-          compute_directives ~room_config ~agent_name:ping.agent_name
-        in
-        let ack = T.HeartbeatAck.{
-          timestamp_ms = now_ms ();
-          active_agent_count = agent_count;
-          pending_task_count = pending_count;
-          directives;
-        } in
-        Grpc_eio.Stream.add response_stream (T.HeartbeatAck.to_bytes ack);
-        (* Record heartbeat latency *)
-        let latency = Unix.gettimeofday () -. t0 in
-        Transport_metrics.observe_grpc_heartbeat_latency latency;
+          let tasks_dir = Filename.concat masc_dir "tasks" in
+          let pending_count =
+            if Sys.file_exists tasks_dir then
+              Sys.readdir tasks_dir
+              |> Array.to_list
+              |> List.filter (fun f -> Filename.check_suffix f ".json")
+              |> List.length
+            else 0
+          in
+          let directives =
+            compute_directives ~room_config ~agent_name:ping.agent_name
+          in
+          let ack = T.HeartbeatAck.{
+            timestamp_ms = now_ms ();
+            active_agent_count = agent_count;
+            pending_task_count = pending_count;
+            directives;
+          } in
+          Grpc_eio.Stream.add response_stream (T.HeartbeatAck.to_bytes ack);
+          (* Record heartbeat latency *)
+          let latency = Unix.gettimeofday () -. t0 in
+          Transport_metrics.observe_grpc_heartbeat_latency latency
+         with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+           Log.Transport.error
+             "gRPC heartbeat iteration crashed: %s"
+             (Printexc.to_string exn));
         loop ()
       | exception End_of_file ->
-        Atomic.decr active_heartbeat_streams;
-        Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
-        Grpc_eio.Stream.close response_stream
+        cleanup ()
     in
-    loop ());
+    try loop ()
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      cleanup ();
+      raise e
+    | exn ->
+      Log.Transport.error
+        "gRPC heartbeat fiber died outside iteration: %s"
+        (Printexc.to_string exn);
+      cleanup ());
   response_stream
 
 (** Subscribe server-streaming handler: push room events to the agent. *)


### PR DESCRIPTION
## 배경

OCaml audit sweep Cycle 12 — Cat B (Silent Failure) + 동시성 안전. Cycle 11 PR #6519 의 fork triage 후속. 남은 의심 사이트 3건 (`worker_container:291`, `grpc_client:120`, `grpc_service:277`) 을 심층 확인한 결과:

- **`worker_container:291`** — 이미 outer `try/with Cancelled | exn -> log error` 존재, **이상 없음**
- **`grpc_client:120`** — 단순 매퍼, `End_of_file` 만 catch, **FIX**
- **`grpc_service:277`** — inner try 는 있지만 outer 경로에 metric leak 가능, **FIX**

## 두 버그의 심각도

### `masc_grpc_service.ml:277` (서버측 heartbeat handler)

```ocaml
Atomic.incr active_heartbeat_streams;
Transport_metrics.set_grpc_active_streams (...);
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    match Grpc_eio.Stream.take request_stream with
    | bytes ->
      let ping = T.HeartbeatPing.of_bytes bytes in   (* parse can raise *)
      (try ... agent_file update ... with exn -> log);
      let directives = compute_directives ~room_config ~agent_name:ping.agent_name in
      (* ↑ can raise *)
      Grpc_eio.Stream.add response_stream (T.HeartbeatAck.to_bytes ack);
      loop ()
    | exception End_of_file ->
      Atomic.decr active_heartbeat_streams;  (* ← cleanup only on EOF *)
      ...
```

- **`T.HeartbeatPing.of_bytes`** parse 실패 (corrupt protobuf) → 외부 경로로 propagate → **`Atomic.decr` 실행 안 됨**
- **`compute_directives`** 실패 → 동일
- **`Grpc_eio.Stream.add`** on closed downstream → 동일

결과:
1. `active_heartbeat_streams` 카운터가 영구 leak → `Transport_metrics.set_grpc_active_streams` 가 유령 스트림 수를 영원히 보고
2. `response_stream` 는 close 안 됨 → downstream receiver 가 dead stream 에서 영구 block

### `masc_grpc_client.ml:120` (클라측 request mapper)

```ocaml
Eio.Fiber.fork ~sw (fun () ->
  let rec loop () =
    match Grpc_eio.Stream.take request_stream with
    | bytes ->
      Grpc_eio.Stream.add raw_requests bytes;
      loop ()
    | exception End_of_file ->
      Grpc_eio.Stream.close raw_requests
  in
  loop ())
```

`End_of_file` 외 어떤 예외도 `raw_requests` 를 close 안 함. 바로 아래 `call_bidi ~requests:raw_requests` 는 이 스트림에서 대기 → deadlock.

## 변경

### `masc_grpc_service.ml:277`

```ocaml
let cleanup () =
  Atomic.decr active_heartbeat_streams;
  Transport_metrics.set_grpc_active_streams (Atomic.get active_heartbeat_streams);
  (try Grpc_eio.Stream.close response_stream with _ -> ())
in
let rec loop () =
  match Grpc_eio.Stream.take request_stream with
  | bytes ->
    (try
       ... 전체 iteration body ...
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | exn ->
       Log.Transport.error "gRPC heartbeat iteration crashed: %s" (Printexc.to_string exn));
    loop ()  (* 한 ping 실패가 전체 stream 을 죽이지 않음 *)
  | exception End_of_file ->
    cleanup ()
in
try loop ()
with
| Eio.Cancel.Cancelled _ as e -> cleanup (); raise e
| exn ->
  Log.Transport.error "gRPC heartbeat fiber died outside iteration: %s"
    (Printexc.to_string exn);
  cleanup ()
```

두 계층 방어: per-iteration try 는 transient 실패가 loop 를 안 죽이게, outer try 는 Cancelled 또는 catastrophic 실패에서도 cleanup 보장. 기존 inner try (line 284-314) 는 targeted 메시지 유지 차원에서 그대로 남김 (중첩되지만 diff 최소).

### `masc_grpc_client.ml:120`

```ocaml
try loop ()
with
| Eio.Cancel.Cancelled _ as e ->
  (try Grpc_eio.Stream.close raw_requests with _ -> ());
  raise e
| exn ->
  Log.Transport.error "gRPC heartbeat request-mapper crashed: %s" (Printexc.to_string exn);
  (try Grpc_eio.Stream.close raw_requests with _ -> ())
```

`raw_requests` 를 모든 exit path 에서 close → downstream deadlock 방지.

## 검증

```
dune build --root . lib/   # exit 0
```

## 관련

- PR #6484 Cycle 4 — gRPC reflection process_loop fork wrap
- PR #6519 Cycle 11 — oas_sse_bridge + rate_limit cleanup fibers 
- Cycle 12 로 fork triage 일단락. 14 파일 중 모든 `let rec loop` 기반 fork 가 exception boundary + cleanup guarantee 확보.
