### PR TITLE
fix(dashboard): wave 2 consistency — ErrorState + centralized time format

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -4,7 +4,7 @@
 import { html } from 'htm/preact'
 import { useRef } from 'preact/hooks'
 import { Card } from './common/card'
-import { EmptyState } from './common/empty-state'
+import { EmptyState, ErrorState } from './common/feedback-state'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { resolveUnifiedStatus } from '../lib/unified-status'
@@ -178,7 +178,7 @@ export function AgentDetailOverlay() {
           </div>
         </div>
 
-        ${detailError.value ? html`<div class="p-4 text-bad border border-bad/30 rounded-xl bg-bad/10 shadow-sm font-medium text-sm">${detailError.value}</div>` : null}
+        ${detailError.value ? html`<${ErrorState} message=${detailError.value} />` : null}
 
         <${AgentSessionReport} agentName=${agentName} />
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { ActionButton } from '../common/button'
+import { formatTimeHms } from '../../lib/format-time'
 import type { KeeperConversationDetails, KeeperConversationEntry } from '../../types'
 
 export type ChatTranscriptVariant = 'default' | 'messenger'
@@ -10,7 +11,7 @@ function timeLabel(timestamp?: string | null): string | null {
   if (!timestamp) return null
   const value = new Date(timestamp)
   if (Number.isNaN(value.getTime())) return null
-  return value.toLocaleTimeString()
+  return formatTimeHms(value.getTime() / 1000)
 }
 
 function deliveryLabel(entry: KeeperConversationEntry): string {

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -5,8 +5,7 @@ import { signal } from '@preact/signals'
 import { useRef, useEffect } from 'preact/hooks'
 import type { ComponentChildren } from 'preact'
 import autoAnimate from '@formkit/auto-animate'
-import { EmptyState } from '../common/empty-state'
-import { LoadingState } from '../common/feedback-state'
+import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
@@ -209,8 +208,8 @@ export function TaskBacklog() {
   if (hasError && !hasData) {
     return html`
       <${Card} title="태스크 백로그" class="section">
-        <div class="text-center py-6">
-          <div class="text-[13px] text-bad mb-3">데이터를 불러오지 못했습니다.</div>
+        <div class="flex flex-col items-center gap-3 py-6">
+          <${ErrorState} message="데이터를 불러오지 못했습니다." />
           <${ActionButton} variant="ghost" size="sm" onClick=${() => refreshExecution({ force: true })}>재시도<//>
         </div>
       <//>


### PR DESCRIPTION
## Summary

Follow-up to PR #6494 (error state standardization) and PR #6491 (time display standardization). Three more call sites had re-implemented the same patterns inline.

| File | Before | After |
|---|---|---|
| \`components/agent-detail.ts\` | raw \`text-bad border-bad/30\` error div | \`<ErrorState>\` |
| \`components/goals/kanban-components.ts\` | raw \`text-bad\` empty-state error line | \`<ErrorState>\` + retry button |
| \`components/chat/primitives.ts\` | \`value.toLocaleTimeString()\` (no locale) | \`formatTimeHms()\` — ko-KR consistent |

Imports consolidated to the canonical \`common/feedback-state.ts\` where applicable (\`common/empty-state.ts\` is a re-export).

Chat timestamp locale normalization is the only user-visible effect (previously varied by browser locale).

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (461 passed)