### PR TITLE
feat: add Groq to cascade fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Full list: `lib/config/env_config_keeper.ml`. Per-keeper config: `config/keepers
 - OAS owns cascade schema, parsing, and label semantics.
 - MASC uses that contract to choose repo-level checked-in defaults; each keeper can override via `cascade_name` in its TOML.
 - For committed defaults, prefer explicit `provider:model_id` labels instead of convenience labels.
+- Any committed `groq:*` tier requires `GROQ_API_KEY` in the runtime environment for that fallback to be usable.
 - See [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md), [docs/spec/13-oas-integration.md](docs/spec/13-oas-integration.md), and [docs/spec/14-configuration.md](docs/spec/14-configuration.md).
 
 ## Safe Starting Paths

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -12,6 +12,7 @@
   "keeper_unified_models": [
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
+    "glm:glm-5.1",
     "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -3,6 +3,7 @@
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
+    "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "local_only_models": [
@@ -11,15 +12,17 @@
   "keeper_unified_models": [
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
+    "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "coding_first_models": [
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
+    "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "glm-coding = Coding Plan endpoint (included in subscription). glm = general API (pay-per-use). Coding Plan first, API fallback, local last.",
+  "_comment": "glm-coding = Coding Plan (subscription). glm = general API (pay-per-use). groq = Groq LPU ($0.29/$0.59 per M, GROQ_API_KEY). local last.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -326,6 +326,7 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
 | `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
 | `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
+| `groq` | runtime env | requires `GROQ_API_KEY` |
 | `gemini` | `Gemini` | `MASC_GEMINI_DEFAULT_MODEL` |
 | `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |
 


### PR DESCRIPTION
## Summary
- Add `groq:qwen/qwen3-32b` to default, keeper_unified, and coding_first cascade profiles
- Cascade order: glm-coding (subscription) → glm (API) → **groq** → ollama (local)
- Groq LPU: 662 tok/s, $0.29/$0.59 per M tokens

## Dependencies
- OAS >= 0.120.0 (jeong-sik/oas#789 merged: multi-vendor provider registry)
- `GROQ_API_KEY` environment variable

## Test plan
- [ ] Keeper starts and resolves `groq:qwen/qwen3-32b` in cascade
- [ ] GLM failure → Groq fallback works
- [ ] Groq rate limit (429) → local fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)