### PR TITLE
fix(grpc): guarantee typed_stream close on subscribe fiber exit paths

### DIFF
--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -91,6 +91,22 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
   (* Transform raw stream items to typed events *)
   let typed_stream = Grpc_eio.Stream.create 64 in
   Eio.Fiber.fork ~sw (fun () ->
+    let push_closed = `Closed in
+    let push_typed item =
+      if Grpc_eio.Stream.is_closed typed_stream
+      then push_closed
+      else
+        try
+          Grpc_eio.Stream.add typed_stream item;
+          `Added
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          if Grpc_eio.Stream.is_closed typed_stream then push_closed else `Failed exn
+    in
+    let push_error message =
+      push_typed (Error message)
+    in
     let close_typed () =
       try Grpc_eio.Stream.close typed_stream with _ -> ()
     in
@@ -98,17 +114,17 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
       match Grpc_eio.Stream.take raw_stream with
       | Ok bytes ->
         (try
-          Grpc_eio.Stream.add typed_stream (Ok (T.Event.of_bytes bytes))
+          push_typed (Ok (T.Event.of_bytes bytes))
         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-          Grpc_eio.Stream.add typed_stream
-            (Error (Printf.sprintf "event decode error: %s"
-              (Printexc.to_string exn))));
+          push_error
+            (Printf.sprintf "event decode error: %s"
+               (Printexc.to_string exn)));
         loop ()
       | Error status ->
         if not (Grpc_core.Status.is_ok status) then
-          Grpc_eio.Stream.add typed_stream
-            (Error (Printf.sprintf "subscribe stream error: %s"
-              (Grpc_core.Status.to_string status)));
+          push_error
+            (Printf.sprintf "subscribe stream error: %s"
+               (Grpc_core.Status.to_string status));
         close_typed ()
       | exception End_of_file ->
         close_typed ()
@@ -119,10 +135,24 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
       close_typed ();
       raise e
     | exn ->
-      Log.Transport.error
-        "gRPC subscribe fiber died outside iteration: %s"
-        (Printexc.to_string exn);
-      close_typed ());
+      let message =
+        Printf.sprintf "gRPC subscribe fiber died outside iteration: %s"
+          (Printexc.to_string exn)
+      in
+      let delivery = push_error message in
+      close_typed ();
+      (match delivery with
+       | `Added ->
+         Log.Transport.error "%s" message
+       | `Closed ->
+         Log.Transport.debug
+           "gRPC subscribe fiber exit after typed stream closed: %s"
+           (Printexc.to_string exn)
+       | `Failed push_exn ->
+         Log.Transport.error
+           "%s (failed to deliver error to typed stream: %s)"
+           message
+           (Printexc.to_string push_exn)));
   typed_stream
 
 let heartbeat_stream t ~sw ~env =

--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -91,6 +91,9 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
   (* Transform raw stream items to typed events *)
   let typed_stream = Grpc_eio.Stream.create 64 in
   Eio.Fiber.fork ~sw (fun () ->
+    let close_typed () =
+      try Grpc_eio.Stream.close typed_stream with _ -> ()
+    in
     let rec loop () =
       match Grpc_eio.Stream.take raw_stream with
       | Ok bytes ->
@@ -106,11 +109,20 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
           Grpc_eio.Stream.add typed_stream
             (Error (Printf.sprintf "subscribe stream error: %s"
               (Grpc_core.Status.to_string status)));
-        Grpc_eio.Stream.close typed_stream
+        close_typed ()
       | exception End_of_file ->
-        Grpc_eio.Stream.close typed_stream
+        close_typed ()
     in
-    loop ());
+    try loop ()
+    with
+    | Eio.Cancel.Cancelled _ as e ->
+      close_typed ();
+      raise e
+    | exn ->
+      Log.Transport.error
+        "gRPC subscribe fiber died outside iteration: %s"
+        (Printexc.to_string exn);
+      close_typed ());
   typed_stream
 
 let heartbeat_stream t ~sw ~env =


### PR DESCRIPTION
fix(grpc): guarantee typed_stream close on subscribe fiber exit paths

`lib/grpc/masc_grpc_client.ml:93` spawns a fiber to transform raw
`Grpc_eio.Stream` items into typed `T.Event.t` results on a
`typed_stream` exposed to callers. The per-iteration decode was
already wrapped in `try/with` that propagates decode errors through
the stream as `Error _` items — good.

But the outer loop had three holes:

1. `Grpc_eio.Stream.add typed_stream ...` itself can raise if the
   downstream typed_stream is closed. That raises OUT of the inner
   try (which only wraps `T.Event.of_bytes`).
2. `Grpc_eio.Stream.take raw_stream` can raise exceptions other than
   `End_of_file` (the match only catches `Ok`, `Error status`, and
   `exception End_of_file`).
3. Any such unhandled exception kills the fiber with `typed_stream`
   open. Callers waiting on `Grpc_eio.Stream.take typed_stream` then
   block forever — identical fiber-leak + deadlock pattern fixed in
   PR #6524 for the heartbeat streams.

Add a shared `close_typed ()` helper and wrap `loop ()` in an outer
`try/with` that calls it on either `Eio.Cancel.Cancelled` (then
re-raises per the structured-concurrency contract) or any other
exception, logging the latter before exiting.

## Verification

```
dune build --root . lib/   # exit 0
```

Part of OCaml audit sweep Cycle 13 (Cat B silent failure +
concurrency correctness). Same pattern as PR #6524 applied to the
third bidi-stream fiber in the gRPC layer.