### PR TITLE
fix(agent-registry): guard String.sub on session_key prefix log

### DIFF
--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -134,7 +134,8 @@ let get_or_create_identity ?mcp_session_id params =
 
       Log.Session.info "[AgentRegistry] New identity: %s (session=%s, mcp=%s)"
         registered.agent_name
-        (String.sub registered.session_key 0 8)
+        (String.sub registered.session_key 0
+           (min 8 (String.length registered.session_key)))
         (Option.value mcp_session_id ~default:"none");
 
       maybe_evict_session_caches ();


### PR DESCRIPTION
fix(agent-registry): guard String.sub on session_key prefix log

`lib/agent_registry_eio.ml:137` logs a session-key prefix with
`String.sub registered.session_key 0 8` without a length guard.
If any caller produces a session_key shorter than 8 characters,
this raises `Invalid_argument "String.sub"` inside the log
statement — a crash hidden in a diagnostic path that nobody
exercises until a short key slips through.

Line 222 of the same file already uses the correct pattern:

```ocaml
(String.sub session_key 0 (min 8 (String.length session_key)))
```

Line 137 is a pure inconsistency. Apply the same guard so both
log sites handle short keys safely. Behavior unchanged for keys
of length >= 8 (which is the normal case for hex-encoded
session identifiers).

Part of OCaml audit sweep Cycle 13 (partial-function audit).
Full `String.sub` scan across `lib/` (530 hits) surfaced exactly
one unguarded call site against string length; every other use
is either preceded by an explicit length check or constructed
from a known-length source (SHA hex, fixed prefix match).

## Verification

```
dune build --root . lib/   # exit 0
```