### PR TITLE
fix(state_product): cap Nondet_attempt retries to prevent unbounded loop

### DIFF
--- a/lib/state_product.ml
+++ b/lib/state_product.ml
@@ -78,7 +78,9 @@ module Tool_validation = struct
 
   type transition = Applied of phase | Ignored of { phase: phase; event: event }
 
-  let apply_event ~current event =
+  let default_max_nondet_retries = 3
+
+  let apply_event ?(max_nondet_retries = default_max_nondet_retries) ~current event =
     match current, event with
     | Unchecked, Validate_start -> Applied Det_correcting
     | Unchecked, Skip_validation -> Applied Valid
@@ -88,11 +90,13 @@ module Tool_validation = struct
     | Det_invalid, Nondet_attempt _ -> Applied Nondet_retrying
     | Nondet_retrying, Nondet_fixed -> Applied Valid
     | Nondet_retrying, Nondet_exhausted -> Applied Rejected
-    | Nondet_retrying, Nondet_attempt _ -> Applied Nondet_retrying
+    | Nondet_retrying, Nondet_attempt n ->
+      if n < max_nondet_retries then Applied Nondet_retrying
+      else Applied Rejected
     | phase, event -> Ignored { phase; event }
 
-  let apply_event_lossy ~current event =
-    match apply_event ~current event with
+  let apply_event_lossy ?max_nondet_retries ~current event =
+    match apply_event ?max_nondet_retries ~current event with
     | Applied p | Ignored { phase = p; _ } -> p
 end
 
@@ -173,14 +177,16 @@ let apply_turn_event state event =
   | Ok () -> Ok new_state
   | Error reason -> Error reason
 
-let apply_validation_event state event =
+let apply_validation_event ?max_nondet_retries state event =
   (* Guard: validation events only accepted during Dispatching (TLA+ spec). *)
   if state.turn <> Agent_turn.Dispatching then
     Error (Printf.sprintf "validation event %s rejected: turn=%s (expected Dispatching)"
              (Tool_validation.event_to_string event)
              (Agent_turn.phase_to_string state.turn))
   else
-    let new_validation = Tool_validation.apply_event_lossy ~current:state.validation event in
+    let new_validation =
+      Tool_validation.apply_event_lossy ?max_nondet_retries ~current:state.validation event
+    in
     let new_state = { state with validation = new_validation } in
     match check_invariants new_state with
     | Ok () -> Ok new_state

--- a/lib/state_product.mli
+++ b/lib/state_product.mli
@@ -81,8 +81,19 @@ module Tool_validation : sig
 
   type transition = Applied of phase | Ignored of { phase: phase; event: event }
 
-  val apply_event : current:phase -> event -> transition
-  val apply_event_lossy : current:phase -> event -> phase
+  val default_max_nondet_retries : int
+  (** Default cap on [Nondet_attempt] transitions (3). *)
+
+  val apply_event :
+    ?max_nondet_retries:int -> current:phase -> event -> transition
+  (** Pure transition function. When [current = Nondet_retrying] and
+      [event = Nondet_attempt n], the attempt is rejected (transitions to
+      [Rejected]) if [n >= max_nondet_retries] (default {!default_max_nondet_retries}).
+      Returns [Ignored] for otherwise invalid transitions. *)
+
+  val apply_event_lossy :
+    ?max_nondet_retries:int -> current:phase -> event -> phase
+  (** Like [apply_event] but silently returns the phase on invalid transitions. *)
 end
 
 (** {4 Product State} *)
@@ -118,8 +129,10 @@ val apply_turn_event :
   product -> Agent_turn.event -> (product, string) result
 
 (** Apply a validation event.
-    Guarded: validation events are only accepted when [turn = Dispatching]. *)
+    Guarded: validation events are only accepted when [turn = Dispatching].
+    @param max_nondet_retries cap on [Nondet_attempt] retries (default 3). *)
 val apply_validation_event :
+  ?max_nondet_retries:int ->
   product -> Tool_validation.event -> (product, string) result
 
 (** {7 Serialization} *)

--- a/test/test_state_product.ml
+++ b/test/test_state_product.ml
@@ -50,6 +50,37 @@ let test_validation_rejected () =
   let s = TV.apply_event_lossy ~current:Nondet_retrying Nondet_exhausted in
   Alcotest.(check string) "rejected" "rejected" (TV.phase_to_string s)
 
+(* ── Nondet Retry Cap ──────────────────────────────────── *)
+
+let test_nondet_attempt_under_cap () =
+  (* attempt n=2 with default cap 3 -> still retrying *)
+  let s = TV.apply_event ~current:Nondet_retrying (Nondet_attempt 2) in
+  match s with
+  | Applied Nondet_retrying -> ()
+  | Applied p -> Alcotest.fail (Printf.sprintf "expected Nondet_retrying, got %s" (TV.phase_to_string p))
+  | Ignored _ -> Alcotest.fail "expected Applied, got Ignored"
+
+let test_nondet_attempt_at_cap () =
+  (* attempt n=3 with default cap 3 -> rejected *)
+  let s = TV.apply_event ~current:Nondet_retrying (Nondet_attempt 3) in
+  match s with
+  | Applied Rejected -> ()
+  | Applied p -> Alcotest.fail (Printf.sprintf "expected Rejected, got %s" (TV.phase_to_string p))
+  | Ignored _ -> Alcotest.fail "expected Applied, got Ignored"
+
+let test_nondet_custom_cap () =
+  (* custom cap of 1: attempt n=0 ok, attempt n=1 rejected *)
+  let s0 = TV.apply_event ~max_nondet_retries:1 ~current:Nondet_retrying (Nondet_attempt 0) in
+  (match s0 with
+   | Applied Nondet_retrying -> ()
+   | Applied p -> Alcotest.fail (Printf.sprintf "n=0: expected Nondet_retrying, got %s" (TV.phase_to_string p))
+   | Ignored _ -> Alcotest.fail "n=0: expected Applied, got Ignored");
+  let s1 = TV.apply_event ~max_nondet_retries:1 ~current:Nondet_retrying (Nondet_attempt 1) in
+  (match s1 with
+   | Applied Rejected -> ()
+   | Applied p -> Alcotest.fail (Printf.sprintf "n=1: expected Rejected, got %s" (TV.phase_to_string p))
+   | Ignored _ -> Alcotest.fail "n=1: expected Applied, got Ignored")
+
 let test_validation_skip () =
   let s = TV.apply_event_lossy ~current:Unchecked Skip_validation in
   Alcotest.(check string) "valid" "valid" (TV.phase_to_string s)
@@ -132,6 +163,9 @@ let () =
       Alcotest.test_case "nondet retry" `Quick test_validation_nondet_retry;
       Alcotest.test_case "rejected" `Quick test_validation_rejected;
       Alcotest.test_case "skip" `Quick test_validation_skip;
+      Alcotest.test_case "nondet attempt under cap" `Quick test_nondet_attempt_under_cap;
+      Alcotest.test_case "nondet attempt at cap" `Quick test_nondet_attempt_at_cap;
+      Alcotest.test_case "nondet custom cap" `Quick test_nondet_custom_cap;
     ]);
     ("invariants", [
       Alcotest.test_case "initial ok" `Quick test_initial_ok;


### PR DESCRIPTION
## Summary
- Add `?max_nondet_retries` parameter (default 3) to `Tool_validation.apply_event`
- When `Nondet_attempt n >= max_nondet_retries`, transition to `Rejected` instead of looping
- Expose `default_max_nondet_retries` constant, thread parameter through product-level API
- 3 new test cases covering cap boundary and custom values

## Test plan
- [x] 23/23 state_product tests pass (20 existing + 3 new)
- [x] `dune build @check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)