### PR TITLE
fix(keeper): tolerate text_response when provider ignores tool_choice

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1590,21 +1590,31 @@ let run_turn
           (which wastes the entire OAS run), log a warning and treat the
           text response as valid. The turn is counted as text_response
           in telemetry via keeper_unified_turn. See #5566. *)
-       let () =
+       let text =
          match
            Keeper_tool_disclosure.validate_completion_contract
              ~contract:!completion_contract_ref
              ~tool_names
              ()
          with
-         | Ok () -> ()
+         | Ok () -> text
          | Error reason ->
+           let contract_str =
+             match !completion_contract_ref with
+             | Keeper_tool_disclosure.Allow_text_or_tool -> "Allow_text_or_tool"
+             | Keeper_tool_disclosure.Require_tool_use -> "Require_tool_use"
+           in
            Log.Keeper.warn
              "keeper:%s text_response trap: tool contract violated \
-              (turn=%d, tools=0, contract=Require_tool_use). \
+              (turn=%d, tools=0, contract=%s). \
               Provider likely ignored tool_choice=Any. Tolerating text-only \
               response to avoid wasting OAS run. Reason: %s"
-             meta.name result.turns reason
+             meta.name result.turns contract_str reason;
+           (* When both text and tool_names are empty, normalize_response_text
+              would hard-fail. Synthesize minimal text so the turn survives. *)
+           if String.trim text = "" && tool_names = []
+           then "[no output]"
+           else text
        in
        (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
         | Error e -> Error (Oas.Error.Internal e)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1323,7 +1323,8 @@ let run_turn
                 if is_retry then "retry"
                 else (
                   match tool_choice with
-                  | Some Agent_sdk.Types.Any -> "tool_required"
+                  | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) ->
+                    "tool_required"
                   | Some Agent_sdk.Types.None_ -> "tool_disabled"
                   | _ -> "tool_optional")
               in

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1317,11 +1317,8 @@ let run_turn
                 then current_params.tool_choice (* last turn: Auto for [STATE] block *)
                 else Some Agent_sdk.Types.Any (* all other turns: force tool use *)
               in
-              (match tool_choice with
-               | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) ->
-                 completion_contract_ref :=
-                   Keeper_tool_disclosure.Require_tool_use
-               | _ -> ());
+              completion_contract_ref :=
+                Keeper_tool_disclosure.completion_contract_of_tool_choice tool_choice;
               let lane =
                 if is_retry then "retry"
                 else (

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1587,22 +1587,36 @@ let run_turn
          Keeper_tool_disclosure.merge_reported_and_observed_tool_names ~reported_tool_names ~observed_tool_names
        in
        let usage = Keeper_exec_context.usage_of_response result.response in
-       (match
-          Keeper_tool_disclosure.validate_completion_contract
-            ~contract:!completion_contract_ref
-            ~tool_names
-            ()
-        with
+       (* Text-response trap tolerance: when tool_choice=Any is set but
+          the provider ignores it (e.g. Ollama #14493), the model returns
+          text-only on non-last turns. Instead of hard-failing the turn
+          (which wastes the entire OAS run), log a warning and treat the
+          text response as valid. The turn is counted as text_response
+          in telemetry via keeper_unified_turn. See #5566. *)
+       let () =
+         match
+           Keeper_tool_disclosure.validate_completion_contract
+             ~contract:!completion_contract_ref
+             ~tool_names
+             ()
+         with
+         | Ok () -> ()
+         | Error reason ->
+           Log.Keeper.warn
+             "keeper:%s text_response trap: tool contract violated \
+              (turn=%d, tools=0, contract=Require_tool_use). \
+              Provider likely ignored tool_choice=Any. Tolerating text-only \
+              response to avoid wasting OAS run. Reason: %s"
+             meta.name result.turns reason
+       in
+       (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
         | Error e -> Error (Oas.Error.Internal e)
-        | Ok () ->
-          (match Keeper_tool_disclosure.normalize_response_text ~text ~tool_names () with
-           | Error e -> Error (Oas.Error.Internal e)
-           | Ok response_text ->
-             (* Ensure every generation has a [STATE] block for continuity.
-                If the model omitted it, synthesize one deterministically
-                from tool usage and stop reason. *)
-             let response_text =
-               match Keeper_memory_policy.find_state_block response_text with
+        | Ok response_text ->
+          (* Ensure every generation has a [STATE] block for continuity.
+             If the model omitted it, synthesize one deterministically
+             from tool usage and stop reason. *)
+          let response_text =
+            match Keeper_memory_policy.find_state_block response_text with
                | Some _ -> response_text
                | None ->
                  let stop_reason_str =
@@ -1798,5 +1812,5 @@ let run_turn
                ; run_validation = result.run_validation
                ; stop_reason = result.stop_reason
                ; inference_telemetry = result.response.telemetry
-               })))
+               }))
 ;;

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -45,6 +45,14 @@ type completion_contract =
   | Allow_text_or_tool
   | Require_tool_use
 
+let completion_contract_of_tool_choice
+      (tool_choice : Agent_sdk.Types.tool_choice option)
+  : completion_contract
+  =
+  match tool_choice with
+  | Some (Agent_sdk.Types.Any | Agent_sdk.Types.Tool _) -> Require_tool_use
+  | _ -> Allow_text_or_tool
+
 let validate_completion_contract
       ~(contract : completion_contract)
       ~(tool_names : string list)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2153,6 +2153,22 @@ let test_validate_completion_contract_accepts_stay_silent () =
   | Ok () -> ()
   | Error e -> fail ("unexpected error: " ^ e)
 
+let test_completion_contract_of_tool_choice_allows_auto () =
+  check bool "auto allows text" true
+    (match KTD.completion_contract_of_tool_choice None with
+     | KTD.Allow_text_or_tool -> true
+     | KTD.Require_tool_use -> false);
+  check bool "none allows text" true
+    (match KTD.completion_contract_of_tool_choice (Some Agent_sdk.Types.None_) with
+     | KTD.Allow_text_or_tool -> true
+     | KTD.Require_tool_use -> false)
+
+let test_completion_contract_of_tool_choice_requires_any () =
+  check bool "any requires tool use" true
+    (match KTD.completion_contract_of_tool_choice (Some Agent_sdk.Types.Any) with
+     | KTD.Require_tool_use -> true
+     | KTD.Allow_text_or_tool -> false)
+
 let test_tool_usage_delta_uses_registry_counts () =
   let before =
     [
@@ -2818,6 +2834,10 @@ let () =
             test_validate_completion_contract_requires_tool_use;
           test_case "completion contract accepts stay silent" `Quick
             test_validate_completion_contract_accepts_stay_silent;
+          test_case "completion contract mapping allows auto" `Quick
+            test_completion_contract_of_tool_choice_allows_auto;
+          test_case "completion contract mapping requires any" `Quick
+            test_completion_contract_of_tool_choice_requires_any;
           test_case "tool usage delta uses registry counts" `Quick
             test_tool_usage_delta_uses_registry_counts;
           test_case "tool usage delta ignores removed tools" `Quick


### PR DESCRIPTION
## Summary
- Change `validate_completion_contract` failure from hard error to warn-and-continue
- When Ollama ignores `tool_choice=Any` and returns text-only, the turn is accepted instead of killing the OAS agent run
- Text responses flow through normal processing (normalize → STATE synthesis → checkpoint)
- `text_response_turns` metric in telemetry already counts these turns

Addresses keeper text_response trap from Ollama tool_choice limitation (#14493).

## Test plan
- [x] `dune build @check` clean
- [ ] E2E: keeper turn with Ollama should produce warning log instead of error

🤖 Generated with [Claude Code](https://claude.com/claude-code)