### PR TITLE
docs(prompt): require keeper worktree under own playground clone (#6527 iter 1)

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -42,8 +42,8 @@ Workspace:
 - The playground bundle has three canonical subdirs: `mind/` (notes and scratch), `repos/` (cloned repos for coding), and the bundle root itself for general work.
 - Your clones live under `.masc/playground/YOUR_KEEPER_NAME/repos/<REPO_NAME>/` — this is your default coding workspace. Use `keeper_shell op=ls path=.masc/playground/YOUR_KEEPER_NAME/repos/` to see which clones you currently have.
 - If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
-- playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` picks the first git clone under your playground `repos/` (alphabetical); if none, it falls back to the server's repo root.
-- Default to the playground clone. If no clone exists, create one first, then open a worktree.
+- playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` always opens the worktree under a git clone inside your playground `repos/` (alphabetical first clone, or whichever `repo_name` you pass). It never creates worktrees outside your playground.
+- You MUST have a clone under `.masc/playground/YOUR_KEEPER_NAME/repos/` before calling `masc_worktree_create`. If `repos/` is empty, call `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` first, then open the worktree. Do not try to operate on the MASC server repository directly.
 - If you have multiple clones and want to target a specific one, pass `repo_name=<clone-dir-name>` to `masc_worktree_create`. Example: `repo_name='masc-mcp'` when your repos/ has both `masc-mcp/` and `kirin/`.
 - `keeper_pr_submit` is the canonical submit step after editing.
 - `keeper_pr_workflow` is a legacy one-shot worktree helper. Prefer `keeper_pr_submit`.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -44,17 +44,21 @@ Workspace:
 - If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
 - playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` always opens the worktree under a git clone inside your playground `repos/` (alphabetical first clone, or whichever `repo_name` you pass). It never creates worktrees outside your playground.
 - You MUST have a clone under `.masc/playground/YOUR_KEEPER_NAME/repos/` before calling `masc_worktree_create`. If `repos/` is empty, call `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` first, then open the worktree. Do not try to operate on the MASC server repository directly.
+- Refusal pattern when `repos/` is empty — follow these three steps in order and do NOT call `masc_worktree_create` in the same turn:
+  1. Observation: "repos/ is empty, I have no clone yet."
+  2. Action: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git`
+  3. Only on the NEXT turn, after the clone returns ok, call `masc_worktree_create`.
 - If you have multiple clones and want to target a specific one, pass `repo_name=<clone-dir-name>` to `masc_worktree_create`. Example: `repo_name='masc-mcp'` when your repos/ has both `masc-mcp/` and `kirin/`.
 - `keeper_pr_submit` is the canonical submit step after editing.
 - `keeper_pr_workflow` is a legacy one-shot worktree helper. Prefer `keeper_pr_submit`.
-- PR creation workflow (requires Coding, Delivery, or Full preset):
-  1. masc_worktree_create task_id=<your-task-id>  (creates worktree under the playground clone that `repos/` resolves to)
+- PR creation workflow (requires Coding, Delivery, or Full preset). Every `cwd` in this sequence MUST resolve under `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/.worktrees/<worktree-name>/`. Never pass a `cwd` outside your playground.
+  1. masc_worktree_create task_id=<your-task-id>  (creates worktree INSIDE the playground clone that `repos/` resolves to — the returned path starts with `.masc/playground/YOUR_KEEPER_NAME/repos/`)
   2. masc_code_read path=<file-to-modify>  (read the file first — understand before editing)
   3. masc_code_edit path=<path> old_string=<before> new_string=<after>  (edit the file)
-  4. masc_code_git action=add cwd=<worktree-path>  (stage changes)
-  5. masc_code_git action=commit cwd=<worktree-path> args=["-m","<commit-message>"]  (commit)
-  6. masc_code_git action=push cwd=<worktree-path>  (push)
-  7. keeper_pr_submit cwd=<worktree-path> commit_message=<commit-message> pr_title=<title>  (create draft PR)
+  4. masc_code_git action=add cwd=<playground-worktree-path>  (stage changes)
+  5. masc_code_git action=commit cwd=<playground-worktree-path> args=["-m","<commit-message>"]  (commit)
+  6. masc_code_git action=push cwd=<playground-worktree-path>  (push)
+  7. keeper_pr_submit cwd=<playground-worktree-path> commit_message=<commit-message> pr_title=<title>  (create draft PR)
   NOTE: Do NOT use keeper_pr_workflow — it is deprecated and will error.
 
 Knowledge lookup:

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -42,7 +42,7 @@ Workspace:
 - The playground bundle has three canonical subdirs: `mind/` (notes and scratch), `repos/` (cloned repos for coding), and the bundle root itself for general work.
 - Your clones live under `.masc/playground/YOUR_KEEPER_NAME/repos/<REPO_NAME>/` — this is your default coding workspace. Use `keeper_shell op=ls path=.masc/playground/YOUR_KEEPER_NAME/repos/` to see which clones you currently have.
 - If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
-- playground is your sandbox; worktrees are repo-scoped branch workflows. `masc_worktree_create` always opens the worktree under a git clone inside your playground `repos/` (alphabetical first clone, or whichever `repo_name` you pass). It never creates worktrees outside your playground.
+- playground is your sandbox; worktrees are repo-scoped branch workflows. Use `masc_worktree_create` only for worktrees under a git clone inside your playground `repos/` (alphabetical first clone, or whichever `repo_name` you pass). If `repos/` is empty, do not call it yet; clone first and treat any worktree path outside your playground as invalid.
 - You MUST have a clone under `.masc/playground/YOUR_KEEPER_NAME/repos/` before calling `masc_worktree_create`. If `repos/` is empty, call `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` first, then open the worktree. Do not try to operate on the MASC server repository directly.
 - Refusal pattern when `repos/` is empty — follow these three steps in order and do NOT call `masc_worktree_create` in the same turn:
   1. Observation: "repos/ is empty, I have no clone yet."


### PR DESCRIPTION
## 요약

Keeper capabilities 프롬프트에서 "clone이 없으면 `masc_worktree_create`가 서버 레포 루트로 폴백한다"는 문장을 삭제하고, "worktree 생성 전에 반드시 playground에 clone하라"는 MUST 문구로 교체했습니다.

이슈 #6527의 Iter-1이며, 하네스는 변경하지 않는 프롬프트-only 수정입니다.

## 배경

현재 `config/prompts/keeper.capabilities.md`는 keeper에게 다음과 같이 가르칩니다(수정 전):

> `masc_worktree_create` picks the first git clone under your playground `repos/` (alphabetical); **if none, it falls back to the server's repo root.**

이 문장은 "playground is your sandbox"라는 상위 규칙과 모순됩니다. 9B 모델은 이 문장을 그대로 따라가 clone을 만들지 않은 채 `masc_worktree_create`를 호출하고, worktree는 MASC 서버 저장소 (`.worktrees/<keeper>-<task>`) 안에 생성됩니다. 이 경로는 어느 keeper의 playground에도 속하지 않으므로 격리가 깨지고, Docker playground mount에도 포함되지 않아 격리 실행 경로도 우회됩니다.

## 변경

`config/prompts/keeper.capabilities.md` 45-46라인:

**Before**
- 폴백 문장이 leak을 정상 경로로 문서화
- "Default to the playground clone" 가 soft preference로 해석 가능

**After**
- `masc_worktree_create` 가 "never creates worktrees outside your playground" 라고 선언
- clone이 없으면 "You MUST" `keeper_shell op=git_clone` 을 먼저 호출해야 한다는 강제 문구
- "Do not try to operate on the MASC server repository directly" 를 명시적으로 금지

## Trade-off / 주의

프롬프트가 이제 "worktree는 playground 바깥으로 안 나간다" 라고 선언하지만, **하네스는 여전히 서버 레포 루트로 폴백합니다** (`lib/room/room_worktree.ml:195`). 즉, 모델이 프롬프트 지침을 따르지 않으면 여전히 leak이 발생할 수 있고 프롬프트는 실제 동작과 한 점에서 괴리됩니다.

이 불일치를 의도적으로 수용하는 이유는 다음 두 가지입니다:

1. **언어 레이어 방어가 먼저**: 현재 대부분의 leak 사례는 "모델이 clone을 생략하고 worktree_create 호출"에서 발생합니다. 프롬프트를 먼저 강화하면 행동 변화는 즉시 나타나고, 하네스 변경 없이 rollback이 쉽습니다.
2. **단계별 안전망**: Iter-2 (`room_worktree.ml` 폴백 제거) 는 legacy keeper의 backward-compat 영향을 검토해야 하므로 별도 PR로 분리합니다. 프롬프트-only 수정을 먼저 merge 하면 그 사이에 발생하는 leak 빈도를 낮추면서 Iter-2 검토 시간을 벌 수 있습니다.

## 후속 작업 (#6527)

- [ ] Iter-2: `lib/room/room_worktree.ml:195` 폴백 제거 + 구조화된 error 반환
- [ ] Iter-3: `lib/keeper/keeper_exec_shell.ml:411` write-gate에 `in_keeper_area` 조건 추가
- [ ] Iter-4: `lib/keeper/keeper_alerting_path.ml:241` workspace_defaults 의 `.worktrees/` 제거 + `keeper_exec_github.ml:744-750` cwd 경계 per-keeper로 축소
- [ ] Iter-5: TLA+ `KeeperWorktreeContainment` invariant

## 테스트 계획

- 프롬프트-only 변경이므로 빌드/테스트 runtime 영향 없음
- 변경 후 keeper 동작 확인: clone이 없는 상태에서 keeper가 `masc_worktree_create`를 호출하는지, 아니면 `git_clone`부터 호출하는지 smoke test 필요 (9B와 35B-A3B 각각)
- smoke test는 Iter-2 머지 전까지 비공식 관찰로 진행 가능

## 리뷰 요청

- 교차 리뷰: `sb glm-text` (GLM-5.1), non-self 모델
- 리뷰 프롬프트: "config/prompts/keeper.capabilities.md의 45-46라인 수정이 keeper에게 전달되는 의도와 하네스 실제 동작의 불일치를 iter-1 수준에서 올바르게 다루고 있는가?"
