### PR TITLE
fix(dashboard): add aria-labels to unlabeled filter controls

### DIFF
--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -295,6 +295,7 @@ function PostCard({ post }: { post: BoardPost }) {
       <!-- Select checkbox -->
       <div class="flex items-start pt-1">
         <input type="checkbox"
+          aria-label=${`게시글 선택: ${post.id}`}
           class="w-3.5 h-3.5 rounded cursor-pointer accent-[var(--accent)]"
           checked=${selectedPostIds.value.has(post.id)}
           onClick=${(e: Event) => togglePostSelection(post.id, e)}

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -699,6 +699,7 @@ export function TelemetryUnified() {
 
       <div class="flex items-center gap-3 flex-wrap">
         <select
+          aria-label="텔레메트리 소스 필터"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
           value=${sourceFilter.value}
           onChange=${(e: Event) => { sourceFilter.value = (e.target as HTMLSelectElement).value as TelemetrySource | '' }}
@@ -709,6 +710,7 @@ export function TelemetryUnified() {
         <input
           type="text"
           placeholder="키퍼 이름..."
+          aria-label="키퍼 이름 필터"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-32"
           value=${keeperFilter.value}
           onInput=${(e: Event) => { keeperFilter.value = (e.target as HTMLInputElement).value }}
@@ -716,6 +718,7 @@ export function TelemetryUnified() {
         <input
           type="text"
           placeholder="session_id"
+          aria-label="session_id 필터"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
           value=${sessionFilter.value}
           onInput=${(e: Event) => { sessionFilter.value = (e.target as HTMLInputElement).value.trim() }}
@@ -723,6 +726,7 @@ export function TelemetryUnified() {
         <input
           type="text"
           placeholder="operation_id"
+          aria-label="operation_id 필터"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
           value=${operationFilter.value}
           onInput=${(e: Event) => { operationFilter.value = (e.target as HTMLInputElement).value.trim() }}
@@ -730,11 +734,13 @@ export function TelemetryUnified() {
         <input
           type="text"
           placeholder="worker_run_id"
+          aria-label="worker_run_id 필터"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-40 font-mono"
           value=${workerRunFilter.value}
           onInput=${(e: Event) => { workerRunFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
         <select
+          aria-label="표시 개수 제한"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
           value=${String(limit.value)}
           onChange=${(e: Event) => { limit.value = Number((e.target as HTMLSelectElement).value) }}


### PR DESCRIPTION
## Summary

Follow-up to PR #6496 (accessibility — buttons and form labels). Six form controls had no programmatic label; screen-reader users heard only the \`placeholder\` (on inputs) or just \"combobox\" / \"checkbox\" (on selects and checkboxes), which is not a reliable label per WCAG 1.3.1 (Info and Relationships).

## Changes

| File | Control | aria-label added |
|---|---|---|
| \`telemetry-unified.ts\` | 키퍼 이름 input | 키퍼 이름 필터 |
| \`telemetry-unified.ts\` | session_id input | session_id 필터 |
| \`telemetry-unified.ts\` | operation_id input | operation_id 필터 |
| \`telemetry-unified.ts\` | worker_run_id input | worker_run_id 필터 |
| \`telemetry-unified.ts\` | source filter select | 텔레메트리 소스 필터 |
| \`telemetry-unified.ts\` | display-limit select | 표시 개수 제한 |
| \`memory.ts\` | board-post selection checkbox | \`게시글 선택: \${post.id}\` |

Each board-post checkbox gets a distinct label via the post id so screen readers can distinguish rows in the accessibility tree.

No visual change.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (461 passed)
- [ ] Manual screen-reader spot check after merge