### PR TITLE
fix(worktree): remove server-root fallback from worktree_create_r (#6527 iter 2)

### DIFF
--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -192,9 +192,14 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
       with
       | Some clone -> Ok clone
       | None ->
-        match require_repository_root_with_git config with
-        | Ok root -> Ok root
-        | Error e -> Error e
+        Error
+          (IoError
+             (Printf.sprintf
+                "No git clone found under playground repos (%s). \
+                 Clone a repository first: keeper_shell op=git_clone \
+                 url=https://github.com/<allowed_org>/<repo>.git — \
+                 then retry masc_worktree_create."
+                repos_dir))
     in
     match resolve_keeper_repo_root () with
     | Error e -> Error e


### PR DESCRIPTION
## 요약

`worktree_create_r`에서 keeper playground에 clone이 없을 때 서버 레포 루트로 폴백하던 경로를 제거하고, 구조화된 에러로 교체했습니다.

이슈 #6527의 Iter-2이며, Iter-1(PR #6533, 프롬프트 수정)의 후속입니다.

## 변경

`lib/room/room_worktree.ml:194-197`:

**Before** (폴백):
```ocaml
| None ->
  match require_repository_root_with_git config with
  | Ok root -> Ok root   (* 서버 masc-mcp 레포로 폴백 *)
  | Error e -> Error e
```

**After** (에러):
```ocaml
| None ->
  Error
    (IoError
       (Printf.sprintf
          "No git clone found under playground repos (%s). \
           Clone a repository first: keeper_shell op=git_clone \
           url=https://github.com/<allowed_org>/<repo>.git — \
           then retry masc_worktree_create."
          repos_dir))
```

## 영향 분석

- `require_repository_root_with_git` 함수 자체는 삭제하지 않음 — `worktree_remove_r` (line 314)에서 여전히 사용. 과거 서버 루트에 만들어진 legacy worktree를 정리하려면 해당 함수가 필요.
- 기존 테스트 (`test/test_room.ml:179-181`)는 non-git directory에서 `worktree_create_r` 호출 시 `Error _` 반환을 검증 → 내 변경은 Error가 발생하는 시점만 앞당기며, 여전히 `Error _`를 반환하므로 테스트는 통과함.
- 빌드 검증: `dune build --root .` 성공 확인.

## Trade-off

- keeper가 clone 없이 `masc_worktree_create`를 호출하면 이전에는 (잘못된 위치지만) worktree를 만들어줬는데, 이제는 에러를 반환함. keeper의 작업이 한 턴 늦어질 수 있음.
- 에러 메시지에 `keeper_shell op=git_clone` 힌트를 포함해서 keeper가 다음 행동을 즉시 알 수 있게 함.
- Iter-1에서 프롬프트를 먼저 강화했으므로, 이 에러에 도달하는 빈도 자체가 이미 낮아져 있음.

## 후속 작업 (#6527)

- [x] Iter-1: 프롬프트 수정 (PR #6533, auto-merge 예약)
- [x] **Iter-2: 서버 루트 폴백 제거 (이 PR)**
- [ ] Iter-3: `keeper_exec_shell.ml` write-gate에 `in_keeper_area` 조건 추가
- [ ] Iter-4: `.worktrees/` 전역 allow 제거 + PR cwd per-keeper 축소
- [ ] Iter-5: TLA+ `KeeperWorktreeContainment` invariant

## 테스트 계획

- [x] `dune build --root .` 성공
- [ ] `dune runtest --root .` 확인 (CI에서 검증)
- [ ] `test/test_room.ml:179-181` — Error 반환 검증 (기존 테스트 변경 불필요)
