### PR TITLE
fix(keeper): distinguish Cancel from Timeout in LLM bridge

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -262,29 +262,17 @@ module KeeperKeepalive = struct
 
   (** Per-call timeout in seconds for a single OAS Agent.run execution.
       Guards against indefinite LLM response waits within a turn.
-      With large context (200k+), each LLM call takes 60-120s, so
-      a 5-turn Agent.run can need 300-600s.
 
       When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
-      Otherwise, {!oas_timeout_for_context} computes an adaptive timeout
-      based on max_context tokens: base 180s + 1.5s per 1K context tokens,
-      capped at [30, turn_timeout_sec].
+      Otherwise, {!oas_timeout_for_context} computes an adaptive timeout:
+        base + ctx/1K × per_1k + min(oas_max_turns_per_call × 4, 40) × per_turn
+      References {!oas_max_turns_per_call} (default 15) directly to avoid
+      default drift.  Previous formula used 4× headroom on a default of 5,
+      producing min(20, 40)=20 effective turns.  With default 15, the 4×
+      multiplier would always saturate the cap, erasing context differentiation.
 
-      The formula includes both context-proportional overhead and a
-      per-turn budget.  extend_turns (ceiling=200) lets keepers run
-      20+ turns per OAS call; the previous formula (180 + ctx/1K × 1.5,
-      cap 600) yielded 573s at 262K context — right at the edge where
-      20-turn sessions would timeout, triggering manual_reconcile on
-      committed board mutations.
-
-      The new formula:
-        base + ctx/1K × per_1k + min(max_turns × 4, 40) × per_turn
-      adds an explicit turn budget with 4× headroom for extend_turns,
-      capped at 40 effective turns.
-
-      At 262K context, 5 initial turns:
-        Old: 180 + 393 = 573s  →  20-turn sessions timeout
-        New: 120 + 393 + 600 = 1113s  →  30+ turns fit comfortably
+      At 262K context, 15 turns/call:
+        120 + 393 + min(15,40)×30 = 120+393+450 = 963
 
       Env: [MASC_KEEPER_OAS_TIMEOUT_SEC]. Default: adaptive.
       Range: [30, turn_timeout_sec]. *)
@@ -294,29 +282,6 @@ module KeeperKeepalive = struct
       Some (Float.max 30.0 (Float.min turn_timeout_sec
         (Option.value ~default:300.0 (Float.of_string_opt (String.trim raw)))))
     | None -> None
-
-  let oas_timeout_for_context ~(max_context : int) : float =
-    match oas_timeout_sec_override with
-    | Some v -> v
-    | None ->
-      let base = 120.0 in
-      let per_1k = 1.5 in
-      let per_turn = 30.0 in
-      let context_time = Float.of_int max_context /. 1000.0 *. per_1k in
-      let max_turns_per_call =
-        max 1 (min 50 (get_int ~default:5 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
-      in
-      let effective_turns =
-        Float.of_int (min (max_turns_per_call * 4) 40)
-      in
-      let turn_time = effective_turns *. per_turn in
-      Float.max 30.0
-        (Float.min turn_timeout_sec (base +. context_time +. turn_time))
-
-  (** Backward-compatible accessor: returns the env override or 300s default.
-      Prefer {!oas_timeout_for_context} when max_context is available. *)
-  let oas_timeout_sec =
-    Option.value ~default:300.0 oas_timeout_sec_override
 
   (** Maximum turns per single OAS Agent.run call.
       Keeper resumes via checkpoint in the next keepalive cycle when
@@ -330,6 +295,26 @@ module KeeperKeepalive = struct
       Env: [MASC_KEEPER_OAS_MAX_TURNS_PER_CALL]. Default: 15. Range: [1, 50]. *)
   let oas_max_turns_per_call =
     max 1 (min 50 (get_int ~default:15 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
+
+  let oas_timeout_for_context ~(max_context : int) : float =
+    match oas_timeout_sec_override with
+    | Some v -> v
+    | None ->
+      let base = 120.0 in
+      let per_1k = 1.5 in
+      let per_turn = 30.0 in
+      let context_time = Float.of_int max_context /. 1000.0 *. per_1k in
+      let effective_turns =
+        Float.of_int (min oas_max_turns_per_call 40)
+      in
+      let turn_time = effective_turns *. per_turn in
+      Float.max 30.0
+        (Float.min turn_timeout_sec (base +. context_time +. turn_time))
+
+  (** Backward-compatible accessor: returns the env override or 300s default.
+      Prefer {!oas_timeout_for_context} when max_context is available. *)
+  let oas_timeout_sec =
+    Option.value ~default:300.0 oas_timeout_sec_override
 
   (** Consecutive idle tool repetitions before on_idle hook issues Skip.
       Below this: graduated Nudge messages.

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -5,11 +5,25 @@
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
     structural timeout. If the execution is cancelled by a timeout or global stop,
     the exception is caught, OAS-local context mutations are discarded
-    (functional rollback), external tool side effects are not reverted,
-    and an OAS timeout error is returned. *)
+    (functional rollback), external tool side effects are not reverted.
+
+    Timeout returns [Oas.Error.Api (Timeout ...)].
+    Cancellation (server shutdown / parent fiber cancel) re-raises so the caller
+    exits immediately instead of retrying. *)
 let run_with_timeout_and_fallback ~timeout_s fn =
+  let clock_opt = (Masc_eio_env.get ()).clock in
+  let t0 =
+    match clock_opt with
+    | Some clock -> Eio.Time.now clock
+    | None -> Unix.gettimeofday ()
+  in
+  let elapsed () =
+    match clock_opt with
+    | Some clock -> Eio.Time.now clock -. t0
+    | None -> Unix.gettimeofday () -. t0
+  in
   let do_timeout fn =
-    match (Masc_eio_env.get ()).clock with
+    match clock_opt with
     | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
     | None -> fn ()
   in
@@ -17,17 +31,21 @@ let run_with_timeout_and_fallback ~timeout_s fn =
     do_timeout fn
   with
   | Eio.Time.Timeout ->
+    let wall = elapsed () in
     Log.Keeper.warn
-      "keeper_llm_bridge: OAS execution timed out after %.1fs (OAS context rollback only; external tool side effects are not reverted)"
-      timeout_s;
-    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
-  | Eio.Cancel.Cancelled _ ->
+      "keeper_llm_bridge: OAS execution timed out after %.1fs (budget=%.0fs; OAS context rollback only; external tool side effects are not reverted)"
+      wall timeout_s;
+    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Timeout after %.1fs (budget=%.0fs)" wall timeout_s }))
+  | Eio.Cancel.Cancelled _ as exn ->
     (* TLA+: FiberHandlesCancellation -> Rollback context.
-       Since Oas_worker_exec returns the new context functionally inside the run_result,
-       we inherently discard intermediate state when cancelled here. *)
+       Cancelled means a parent fiber (server shutdown, global stop) requested
+       cancellation — NOT a timeout. Re-raise so the keeper exits immediately
+       instead of entering the retry loop. *)
+    let wall = elapsed () in
     Log.Keeper.warn
-      "keeper_llm_bridge: OAS execution cancelled (OAS context rollback only; external tool side effects are not reverted)";
-    Error (Oas.Error.Api (Timeout { message = Printf.sprintf "Execution cancelled after %.1fs" timeout_s }))
+      "keeper_llm_bridge: OAS execution cancelled after %.1fs (re-raising; OAS context rollback only; external tool side effects are not reverted)"
+      wall;
+    raise exn
   | exn ->
     (* TLA+: HandleError -> Rollback context *)
     let bt = Printexc.get_backtrace () in

--- a/lib/keeper/keeper_llm_bridge.mli
+++ b/lib/keeper/keeper_llm_bridge.mli
@@ -1,10 +1,14 @@
 (* lib/keeper/keeper_llm_bridge.mli *)
 
 (** Runs a generic Eio execution (usually an OAS Agent.run or Model.call) with a strict
-    structural timeout. If the execution is cancelled by a timeout or global stop,
-    the exception is caught, OAS-local context mutations are discarded
-    (functional rollback), external tool side effects are not reverted,
-    and an OAS timeout error is returned. *)
+    structural timeout.
+
+    - Timeout: OAS-local context mutations are discarded (functional rollback),
+      external tool side effects are not reverted, returns [Error (Oas.Error.Api Timeout)].
+    - Cancellation (server shutdown / parent fiber cancel): re-raises
+      [Eio.Cancel.Cancelled] so the caller exits immediately without retrying.
+
+    @raises Eio.Cancel.Cancelled when the parent fiber/switch is cancelled. *)
 val run_with_timeout_and_fallback :
   timeout_s:float ->
   (unit -> ('a, Oas.Error.sdk_error) result) ->

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -73,20 +73,23 @@ let adaptive = Cfg.KeeperKeepalive.oas_timeout_for_context
 
 let test_oas_timeout_32k () =
   let v = adaptive ~max_context:32_000 in
-  check (float 1.0) "32K → ~768s" 768.0 v
+  (* 120 + 32*1.5 + min(15,40)*30 = 120+48+450 = 618 *)
+  check (float 1.0) "32K → 618s" 618.0 v
 
 let test_oas_timeout_128k () =
   let v = adaptive ~max_context:128_000 in
-  check (float 1.0) "128K → ~912s" 912.0 v
+  (* 120 + 128*1.5 + 450 = 762 *)
+  check (float 1.0) "128K → 762s" 762.0 v
 
 let test_oas_timeout_262k () =
   let v = adaptive ~max_context:262_144 in
-  (* 120 + 262.144 * 1.5 + 20 * 30 = 1113.216, which is below turn_timeout_sec. *)
-  check bool "262K → [1100, 1200]" true (v >= 1100.0 && v <= 1200.0)
+  (* 120 + 262.144*1.5 + min(15,40)*30 = 120+393.216+450 = 963.216 *)
+  check bool "262K → [960, 970]" true (v >= 960.0 && v <= 970.0)
 
 let test_oas_timeout_zero () =
   let v = adaptive ~max_context:0 in
-  check (float 1.0) "0 context → base+turn budget 720s" 720.0 v
+  (* 120 + 0 + min(15,40)*30 = 570 *)
+  check (float 1.0) "0 context → base+turn budget 570s" 570.0 v
 
 let test_oas_timeout_monotonic () =
   let v1 = adaptive ~max_context:32_000 in


### PR DESCRIPTION
## Summary
- **Cancel ≠ Timeout**: `Eio.Cancel.Cancelled` (서버 shutdown)를 `Oas.Error.Api Timeout`으로 변환하던 버그 수정. Cancel은 이제 re-raise되어 keeper가 즉시 종료됨
- **경과 시간 정확성**: 로그에 timeout ceiling(1113.2s) 대신 실제 wall clock 시간을 기록
- **Default 불일치 수정**: `oas_timeout_for_context`가 독립적인 `default:5`를 사용하던 것을 `oas_max_turns_per_call`(default:15)을 직접 참조하도록 변경. 4× headroom 제거

## Root Cause Analysis
서버 shutdown → `Eio.Cancel.Cancelled` → `keeper_llm_bridge`가 Timeout으로 변환 → `keeper_unified_turn`이 "transient network error"로 분류 → retry 시도 → shutdown 지연 + 오해 유발 로그

## Timeout Changes (no env override, 15 turns)
| Context | Before | After |
|---------|--------|-------|
| 0 | 720s | 570s |
| 32K | 768s | 618s |
| 128K | 912s | 762s |
| 262K | 1113s | 963s |

## Test plan
- [x] `test_work_as_heartbeat.exe` — 43 tests pass (timeout formula)
- [x] `test_keeper_unified.exe` — 153 tests pass (transient error classification)
- [x] `dune build` clean success

## Follow-up
- OAS `cascade_executor.ml` 문서: "default 1200s" → 실제 코드 30s (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)