### PR TITLE
[codex] fix startup base path and keeper cwd defaults

### DIFF
--- a/lib/backend/backend.ml
+++ b/lib/backend/backend.ml
@@ -315,9 +315,8 @@ module FileSystem = struct
        | Ok () -> ()
        | Error (Eio.Cancel.Cancelled _ as exn) -> raise exn
        | Error exn ->
-           Log.legacy_traceln ~level:Log.Debug ~module_name:"Backend"
-             (Printf.sprintf "key_index populate wait failed: %s"
-                (Printexc.to_string exn)))
+           Log.Backend.debug "key_index populate wait failed: %s"
+             (Printexc.to_string exn))
     | `Populate r ->
       (try
          let keys =
@@ -326,8 +325,7 @@ module FileSystem = struct
          ki_replace_bulk t (List.map (fun k -> (k, ())) keys);
          let len = ki_length t in
          if len > 0 then
-           Log.legacy_traceln ~level:Log.Info ~module_name:"Backend"
-             (Printf.sprintf "key_index populated: %d keys" len);
+           Log.Backend.info "key_index populated: %d keys" len;
          Eio.Promise.resolve_ok r ()
        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
          Mutex.lock t.key_index_mu;
@@ -337,9 +335,8 @@ module FileSystem = struct
          match exn with
          | Eio.Cancel.Cancelled _ -> raise exn
          | _ ->
-           Log.legacy_traceln ~level:Log.Warn ~module_name:"Backend"
-             (Printf.sprintf "key_index population failed: %s"
-                (Printexc.to_string exn)))
+           Log.Backend.warn "key_index population failed: %s"
+             (Printexc.to_string exn))
 
   (** Check if key exists (in-memory index first, filesystem fallback) *)
   let exists t key =

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -59,60 +59,19 @@ let keeper_effective_allowed_paths ~(meta : keeper_meta) =
   Keeper_alerting_path.effective_allowed_paths ~meta
 ;;
 
-let authored_default_read_root_candidates ~(meta : keeper_meta) =
-  let is_internal_path raw =
-    let path = String.trim raw in
-    path = "" || String.starts_with ~prefix:".masc/" path
-  in
-  match meta.allowed_paths with
-  | ["*"] -> []
-  | explicit ->
-    let preferred, fallback =
-      List.partition (fun raw -> not (is_internal_path raw)) explicit
-    in
-    Keeper_types.dedupe_keep_order (preferred @ fallback)
+let keeper_playground_root ~(config : Room.config) ~(meta : keeper_meta) =
+  ignore (Keeper_alerting_path.ensure_playground_bundle ~config ~name:meta.name);
+  Filename.concat
+    (Keeper_alerting_path.project_root_of_config config)
+    (Keeper_alerting_path.playground_path_of_keeper meta.name)
 ;;
 
 let keeper_default_write_root ~(config : Room.config) ~(meta : keeper_meta) =
-  let project_root = Keeper_alerting_path.project_root_of_config config in
-  match keeper_effective_allowed_paths ~meta with
-  | [] -> project_root
-  | first :: _ ->
-    (match
-       Keeper_alerting_path.resolve_keeper_target_path
-         ~config ~allowed_paths:(keeper_effective_allowed_paths ~meta)
-         ~raw_path:first
-     with
-     | Ok path ->
-       Fs_compat.mkdir_p path;
-       path
-     | Error _ ->
-       let fallback = Filename.concat project_root first in
-       Fs_compat.mkdir_p fallback;
-       fallback)
+  keeper_playground_root ~config ~meta
 ;;
 
 let keeper_default_read_root ~(config : Room.config) ~(meta : keeper_meta) =
-  let project_root = Keeper_alerting_path.project_root_of_config config in
-  let resolve_existing_dir raw_path =
-    match
-      Keeper_alerting_path.resolve_keeper_read_path
-        ~config
-        ~allowed_paths:(keeper_effective_allowed_paths ~meta)
-        ~raw_path
-    with
-    | Ok path when Fs_compat.file_exists path && Sys.is_directory path -> Some path
-    | _ -> None
-  in
-  match keeper_effective_allowed_paths ~meta with
-  | [] -> project_root
-  | _ -> (
-      match
-        List.find_map resolve_existing_dir
-          (authored_default_read_root_candidates ~meta)
-      with
-      | Some path -> path
-      | None -> keeper_default_write_root ~config ~meta)
+  keeper_playground_root ~config ~meta
 ;;
 
 let resolve_keeper_path ~(config : Room.config) ~(meta : keeper_meta) ~(raw_path : string)

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -684,6 +684,10 @@ let handle_keeper_status ctx args : tool_result =
            let playground_abs = Filename.concat ctx.config.base_path playground_rel in
            "execution_context", `Assoc [
              ("playground_path", `String playground_rel);
+             ("default_cwd",
+               `String
+                 (Keeper_exec_shared.keeper_default_write_root
+                    ~config:ctx.config ~meta:m));
              ("execution_scope", `String m.execution_scope);
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",

--- a/lib/room/room_init.ml
+++ b/lib/room/room_init.ml
@@ -13,7 +13,7 @@ let init config ~agent_name =
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir "keepers" in
-  let root_perpetual_dir = Filename.concat root_dir "perpetual" in
+  let root_traces_dir = Filename.concat root_dir "traces" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
@@ -21,7 +21,7 @@ let init config ~agent_name =
     [
       root_agents_dir;
       root_keepers_dir;
-      root_perpetual_dir;
+      root_traces_dir;
       root_tasks_dir;
       root_messages_dir;
     ];

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -390,7 +390,7 @@ let ensure_room_bootstrap config =
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_keepers_dir = Filename.concat root_dir "keepers" in
-  let root_perpetual_dir = Filename.concat root_dir "perpetual" in
+  let root_traces_dir = Filename.concat root_dir "traces" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
@@ -398,7 +398,7 @@ let ensure_room_bootstrap config =
     [
       root_agents_dir;
       root_keepers_dir;
-      root_perpetual_dir;
+      root_traces_dir;
       root_tasks_dir;
       root_messages_dir;
     ];

--- a/lib/server/server_bootstrap_http.ml
+++ b/lib/server/server_bootstrap_http.ml
@@ -45,12 +45,11 @@ let print_startup_banner ~(config : Http.config) ~resolved_base ~base_path
   Printf.printf "   DELETE /mcp → Session termination\n%!";
   Printf.printf
     "   POST /graphql → GraphQL (read-only)\n%!";
-  Printf.printf "   GET  /sse → legacy SSE stream (deprecated; use /mcp)\n%!";
   Printf.printf "   GET  /api/v1/activity/events → Activity replay API\n%!";
   Printf.printf "   GET  /api/v1/activity/graph → Activity graph snapshot\n%!";
-  Printf.printf
-    "   POST /messages → legacy client->server messages (deprecated)\n%!";
   Printf.printf "   GET  /health → Health check\n%!";
+  Printf.printf
+    "   Compatibility (deprecated): GET /sse, POST /messages → use /mcp\n%!";
   if Masc_grpc_server.is_enabled () then
     Printf.printf
       "   gRPC :%d → Coordination + grpc.health.v1.Health + reflection\n%!"

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -10,7 +10,9 @@ type t = {
   resolution_source : string option;
   cwd_masc_root : string;
   cwd_has_masc_dir : bool;
+  cwd_legacy_dirs : string list;
   effective_has_masc_dir : bool;
+  effective_legacy_dirs : string list;
   roots_diverge : bool;
   dual_masc_roots : bool;
   fail_fast_enabled : bool;
@@ -43,6 +45,19 @@ let normalize_path ~cwd path =
 let dir_exists path =
   Sys.file_exists path && Sys.is_directory path
 
+let legacy_dir_names = [ "perpetual"; "resident-keepers"; "rooms" ]
+
+let legacy_dirs_under masc_root =
+  if not (dir_exists masc_root) then
+    []
+  else
+    List.filter (fun name -> dir_exists (Filename.concat masc_root name))
+      legacy_dir_names
+
+let format_legacy_dirs = function
+  | [] -> "none"
+  | dirs -> String.concat ", " dirs
+
 let fail_fast_env_enabled () =
   match Sys.getenv_opt "MASC_BASE_PATH_STRICT" with
   | Some raw -> (
@@ -72,7 +87,9 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
   let effective_masc_norm = normalize_path ~cwd effective_masc_root in
   let cwd_masc_root = normalize_path ~cwd (Filename.concat cwd_norm ".masc") in
   let cwd_has_masc_dir = dir_exists cwd_masc_root in
+  let cwd_legacy_dirs = legacy_dirs_under cwd_masc_root in
   let effective_has_masc_dir = dir_exists effective_masc_norm in
+  let effective_legacy_dirs = legacy_dirs_under effective_masc_norm in
   let roots_diverge = not (String.equal cwd_norm effective_base_norm) in
   let dual_masc_roots =
     roots_diverge
@@ -88,16 +105,26 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
   let resolution_source = resolution_source_opt ?resolution_source () in
   let warning =
     if dual_masc_roots then
+      let stale_suffix =
+        if cwd_legacy_dirs = [] then
+          ""
+        else
+          Printf.sprintf
+            "; ignored cwd .masc still contains legacy dirs (%s)"
+            (format_legacy_dirs cwd_legacy_dirs)
+      in
       if explicit_resolution_source resolution_source then
         Some
           (Printf.sprintf
-             "process cwd (%s) differs from explicit effective base path (%s) and both .masc roots exist (%s vs %s); runtime will use the explicit base path, but operator surfaces may inspect stale state from cwd"
-             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm)
+             "process cwd (%s) differs from explicit effective base path (%s) and both .masc roots exist (%s vs %s); runtime will use the explicit base path, but operator surfaces may inspect stale state from cwd%s"
+             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm
+             stale_suffix)
       else
         Some
           (Printf.sprintf
-             "process cwd (%s) differs from effective base path (%s) and both .masc roots exist (%s vs %s); operator surfaces may inspect stale state"
-             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm)
+             "process cwd (%s) differs from effective base path (%s) and both .masc roots exist (%s vs %s); operator surfaces may inspect stale state%s"
+             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm
+             stale_suffix)
     else
       None
   in
@@ -110,7 +137,9 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     resolution_source;
     cwd_masc_root;
     cwd_has_masc_dir;
+    cwd_legacy_dirs;
     effective_has_masc_dir;
+    effective_legacy_dirs;
     roots_diverge;
     dual_masc_roots;
     fail_fast_enabled;
@@ -139,6 +168,18 @@ let startup_lines (diag : t) =
       (match diag.warning with
        | Some message -> Some (Printf.sprintf "   Path warning: %s" message)
        | None -> None);
+      (if diag.dual_masc_roots then
+         Some
+           (Printf.sprintf "   Ignored cwd .masc legacy dirs: %s"
+              (format_legacy_dirs diag.cwd_legacy_dirs))
+       else
+         None);
+      (if diag.effective_has_masc_dir then
+         Some
+           (Printf.sprintf "   Active .masc legacy dirs: %s"
+              (format_legacy_dirs diag.effective_legacy_dirs))
+       else
+         None);
       (if diag.fail_fast_enabled then
          Some "   Path strict mode: enabled"
        else
@@ -172,7 +213,10 @@ let to_yojson (diag : t) =
        ("effective_masc_root", `String diag.effective_masc_root);
        ("cwd_masc_root", `String diag.cwd_masc_root);
        ("cwd_has_masc_dir", `Bool diag.cwd_has_masc_dir);
+       ("cwd_legacy_dirs", `List (List.map (fun dir -> `String dir) diag.cwd_legacy_dirs));
        ("effective_has_masc_dir", `Bool diag.effective_has_masc_dir);
+       ( "effective_legacy_dirs",
+         `List (List.map (fun dir -> `String dir) diag.effective_legacy_dirs) );
        ("roots_diverge", `Bool diag.roots_diverge);
        ("dual_masc_roots", `Bool diag.dual_masc_roots);
        ("fail_fast_enabled", `Bool diag.fail_fast_enabled);

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -481,14 +481,18 @@ fi
 if [ "$PORT_EXPLICIT" != "1" ]; then
     PORT="$(default_port_for_path "$SCRIPT_DIR")"
     if [ "$PORT" != "8935" ]; then
-        if [ -z "$MASC_GRPC_PORT" ]; then
-            export MASC_GRPC_PORT="$((PORT + 1))"
-        fi
-        if [ -z "$MASC_WS_PORT" ]; then
-            export MASC_WS_PORT="$((PORT + 2))"
-        fi
-        WORKTREE_PORT_HINT="Using worktree-derived default port $PORT (gRPC=$MASC_GRPC_PORT, WS=$MASC_WS_PORT) for $(basename "$SCRIPT_DIR") (override with MASC_MCP_PORT or --port)."
+        WORKTREE_PORT_HINT="Using worktree-derived default port $PORT for $(basename "$SCRIPT_DIR") (override with MASC_MCP_PORT or --port)."
     fi
+fi
+
+if [ -z "${MASC_GRPC_PORT:-}" ] && [ "$PORT" != "8935" ]; then
+    export MASC_GRPC_PORT="$((PORT + 1))"
+fi
+if [ -z "${MASC_WS_PORT:-}" ] && [ "$PORT" != "8935" ]; then
+    export MASC_WS_PORT="$((PORT + 2))"
+fi
+if [ -n "$WORKTREE_PORT_HINT" ] && [ "$PORT" != "8935" ]; then
+    WORKTREE_PORT_HINT="$WORKTREE_PORT_HINT (gRPC=$MASC_GRPC_PORT, WS=$MASC_WS_PORT)"
 fi
 
 if [ "$PRINT_PORT_ONLY" = "1" ]; then
@@ -719,6 +723,14 @@ if [ "$HTTP_MODE" = "true" ]; then
     fi
 fi
 
+launch_from_base_path() {
+    if ! cd "$RESOLVED_BASE_PATH"; then
+        echo "Error: failed to chdir to base path: $RESOLVED_BASE_PATH" >&2
+        exit 1
+    fi
+    exec "$@"
+}
+
 # Eio server has different CLI format and is HTTP-only
 if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
     echo "Starting MASC MCP server (HTTP mode, $RUNTIME_NAME)..." >&2
@@ -736,7 +748,7 @@ if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
     fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
     echo "  Legacy Accept fallback: MASC_ALLOW_LEGACY_ACCEPT=1" >&2
-    exec "$SELECTED_EXE" --host="$HOST" --port="$PORT" --base-path="$RESOLVED_BASE_PATH"
+    launch_from_base_path "$SELECTED_EXE" --host="$HOST" --port="$PORT" --base-path="$RESOLVED_BASE_PATH"
 elif [ "$HTTP_MODE" = "true" ]; then
     echo "Starting MASC MCP server (HTTP mode, $RUNTIME_NAME)..." >&2
     echo "  Host: $HOST" >&2
@@ -753,7 +765,7 @@ elif [ "$HTTP_MODE" = "true" ]; then
     fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
     echo "  Legacy Accept fallback: MASC_ALLOW_LEGACY_ACCEPT=1" >&2
-    exec "$SELECTED_EXE" --http --port "$PORT" --path "$RESOLVED_BASE_PATH"
+    launch_from_base_path "$SELECTED_EXE" --http --port "$PORT" --path "$RESOLVED_BASE_PATH"
 else
     echo "Starting MASC MCP server (stdio mode, $RUNTIME_NAME)..." >&2
     echo "  Base path: $RESOLVED_BASE_PATH" >&2
@@ -762,8 +774,8 @@ else
     fi
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
     if [ "$EIO_MODE" = "true" ]; then
-        exec "$SELECTED_EXE" --base-path "$RESOLVED_BASE_PATH"
+        launch_from_base_path "$SELECTED_EXE" --base-path "$RESOLVED_BASE_PATH"
     else
-        exec "$SELECTED_EXE" --stdio --path "$RESOLVED_BASE_PATH"
+        launch_from_base_path "$SELECTED_EXE" --stdio --path "$RESOLVED_BASE_PATH"
     fi
 fi

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -3,6 +3,7 @@
 
 open Alcotest
 module KAP = Masc_mcp.Keeper_alerting_path
+module KES = Masc_mcp.Keeper_exec_shared
 module KT = Masc_mcp.Keeper_types
 
 let make_meta ?(execution_scope = "observe_only") ?(allowed_paths = [])
@@ -152,6 +153,48 @@ let test_ensure_playground_bundle_creates_subdirs () =
       check bool ("is_dir: " ^ path) true (Sys.is_directory path)
     ) created)
 
+let with_temp_config f =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "keeper_default_root_%d" (Random.bits ())) in
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () ->
+    let rec rm path =
+      if Sys.file_exists path then
+        if Sys.is_directory path then begin
+          Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+          Unix.rmdir path
+        end else Sys.remove path
+    in
+    rm dir
+  ) (fun () ->
+    Eio_main.run @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    f (Masc_mcp.Room.default_config dir))
+
+let check_default_roots_use_playground (meta : KT.keeper_meta) =
+  with_temp_config (fun config ->
+    let expected =
+      Filename.concat
+        (KAP.project_root_of_config config)
+        (KAP.playground_path_of_keeper meta.name)
+    in
+    let write_root = KES.keeper_default_write_root ~config ~meta in
+    let read_root = KES.keeper_default_read_root ~config ~meta in
+    check string "default write root is playground" expected write_root;
+    check string "default read root is playground" expected read_root;
+    check bool "playground dir exists" true (Sys.file_exists expected);
+    check bool "playground dir is directory" true (Sys.is_directory expected))
+
+let test_default_roots_use_playground_with_explicit_paths () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["workspace/yousleepwhen/oas/"] ~name:"keeper" () in
+  check_default_roots_use_playground meta
+
+let test_default_roots_use_playground_with_full_access () =
+  let meta = make_meta ~execution_scope:"workspace"
+      ~allowed_paths:["*"] ~name:"keeper" () in
+  check_default_roots_use_playground meta
+
 (* ── Runner ── *)
 
 let () =
@@ -186,5 +229,9 @@ let () =
             test_playground_always_present;
           test_case "ensure playground bundle creates subdirs" `Quick
             test_ensure_playground_bundle_creates_subdirs;
+          test_case "default roots stay in playground with explicit paths" `Quick
+            test_default_roots_use_playground_with_explicit_paths;
+          test_case "default roots stay in playground with full access" `Quick
+            test_default_roots_use_playground_with_full_access;
         ] );
     ]

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -837,7 +837,7 @@ let test_shell_readonly_pwd_defaults_to_playground () =
     check bool "pwd ok" true (json_bool "ok" json);
     check string "pwd cwd" expected_cwd (json_string "cwd" json))
 
-let test_shell_readonly_pwd_prefers_explicit_allowed_root () =
+let test_shell_readonly_pwd_stays_in_playground_with_explicit_allowed_root () =
   with_room (fun config ->
     let shared_repo_rel = "workspace/yousleepwhen/oas" in
     let shared_repo_abs =
@@ -848,17 +848,21 @@ let test_shell_readonly_pwd_prefers_explicit_allowed_root () =
       { (make_meta_with_preset "delivery") with
         allowed_paths = [ shared_repo_rel ^ "/" ] }
     in
+    let expected_cwd =
+      Filename.concat
+        (Keeper_alerting_path.project_root_of_config config)
+        (Keeper_alerting_path.playground_path_of_keeper meta.name)
+    in
     let result =
       call_tool config meta "keeper_shell"
         (`Assoc [ "op", `String "pwd" ])
     in
     let json = parse_json result in
-    let expected_cwd = shared_repo_abs ^ "/" in
     check bool "pwd with explicit allowed root ok" true (json_bool "ok" json);
-    check string "pwd prefers explicit allowed root" expected_cwd
+    check string "pwd still defaults to keeper playground" expected_cwd
       (json_string "cwd" json))
 
-let test_shell_readonly_cat_defaults_to_explicit_allowed_root () =
+let test_shell_readonly_cat_uses_explicit_cwd_for_custom_root () =
   with_room (fun config ->
     let shared_repo_rel = "workspace/yousleepwhen/oas" in
     let shared_repo_abs =
@@ -870,19 +874,30 @@ let test_shell_readonly_cat_defaults_to_explicit_allowed_root () =
       { (make_meta_with_preset "delivery") with
         allowed_paths = [ shared_repo_rel ^ "/" ] }
     in
-    let result =
+    let default_result =
       call_tool config meta "keeper_shell"
         (`Assoc
           [ "op", `String "cat"
           ; "path", `String "lib/approval.ml"
           ])
     in
-    let json = parse_json result in
-    check bool "cat with explicit allowed root ok" true (json_bool "ok" json);
-    check string "cat path resolves from explicit allowed root" shared_file
-      (json_string "path" json);
+    let default_json = parse_json default_result in
+    check bool "default cat stays in playground and misses shared repo" true
+      (match default_json with `Assoc fields -> List.mem_assoc "error" fields | _ -> false);
+    let explicit_result =
+      call_tool config meta "keeper_shell"
+        (`Assoc
+          [ "op", `String "cat"
+          ; "cwd", `String (shared_repo_abs ^ "/")
+          ; "path", `String "lib/approval.ml"
+          ])
+    in
+    let explicit_json = parse_json explicit_result in
+    check bool "cat with explicit cwd ok" true (json_bool "ok" explicit_json);
+    check string "cat path resolves from explicit cwd" shared_file
+      (json_string "path" explicit_json);
     check string "cat returns shared repo content" "let approval = true\n"
-      (json_string "content" json))
+      (json_string "content" explicit_json))
 
 let test_fs_read_blocks_shared_repo_by_default () =
   with_room (fun config ->
@@ -1243,10 +1258,10 @@ let () =
       ; test_case "status allowed" `Quick test_bash_git_status_allowed
       ; test_case "readonly pwd defaults to playground" `Quick
           test_shell_readonly_pwd_defaults_to_playground
-      ; test_case "readonly pwd prefers explicit allowed root" `Quick
-          test_shell_readonly_pwd_prefers_explicit_allowed_root
-      ; test_case "readonly cat defaults to explicit allowed root" `Quick
-          test_shell_readonly_cat_defaults_to_explicit_allowed_root
+      ; test_case "readonly pwd stays in playground with explicit allowed root" `Quick
+          test_shell_readonly_pwd_stays_in_playground_with_explicit_allowed_root
+      ; test_case "readonly cat uses explicit cwd for custom root" `Quick
+          test_shell_readonly_cat_uses_explicit_cwd_for_custom_root
       ; test_case "fs read blocks shared repo by default" `Quick
           test_fs_read_blocks_shared_repo_by_default
       ; test_case "fs read allows explicit custom path" `Quick

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -46,27 +46,51 @@ let canonical_path path =
   try Unix.realpath path with
   | Unix.Unix_error _ -> path
 
+let string_contains ~needle haystack =
+  let needle_len = String.length needle in
+  let hay_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > hay_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  if needle_len = 0 then true else loop 0
+
 let test_detects_dual_masc_roots () =
   with_temp_dir "base-path-diag" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
   Unix.mkdir cwd 0o755;
   Unix.mkdir effective 0o755;
-  Unix.mkdir (Filename.concat cwd ".masc") 0o755;
-  Unix.mkdir (Filename.concat effective ".masc") 0o755;
+  let cwd_masc = Filename.concat cwd ".masc" in
+  let effective_masc = Filename.concat effective ".masc" in
+  Unix.mkdir cwd_masc 0o755;
+  Unix.mkdir effective_masc 0o755;
+  Unix.mkdir (Filename.concat cwd_masc "perpetual") 0o755;
   let diag =
     Server_base_path_diagnostics.detect ~cwd
       ~input_base_path:effective
       ~env_masc_base_path:effective
       ~effective_base_path:effective
-      ~effective_masc_root:(Filename.concat effective ".masc")
+      ~effective_masc_root:effective_masc
       ()
   in
   Alcotest.(check bool) "roots diverge" true diag.roots_diverge;
   Alcotest.(check bool) "dual roots" true diag.dual_masc_roots;
   Alcotest.(check bool) "cwd .masc exists" true diag.cwd_has_masc_dir;
   Alcotest.(check bool) "effective .masc exists" true diag.effective_has_masc_dir;
-  Alcotest.(check bool) "warning present" true (Option.is_some diag.warning)
+  Alcotest.(check bool) "warning present" true (Option.is_some diag.warning);
+  Alcotest.(check (list string)) "cwd legacy dirs" [ "perpetual" ]
+    diag.cwd_legacy_dirs;
+  Alcotest.(check bool) "warning mentions ignored legacy dirs" true
+    (match diag.warning with
+     | Some warning ->
+         string_contains ~needle:"ignored cwd .masc still contains legacy dirs (perpetual)"
+           warning
+     | None -> false)
 
 let test_strict_violation_respects_env () =
   with_temp_dir "base-path-strict" @@ fun root ->
@@ -125,7 +149,11 @@ let test_to_yojson_exposes_effective_paths () =
   Alcotest.(check string) "effective masc root" "/tmp/workspace/.masc"
     (json |> member "effective_masc_root" |> to_string);
   Alcotest.(check bool) "roots diverge field" true
-    (json |> member "roots_diverge" |> to_bool)
+    (json |> member "roots_diverge" |> to_bool);
+  Alcotest.(check int) "cwd legacy dirs exposed" 0
+    (json |> member "cwd_legacy_dirs" |> to_list |> List.length);
+  Alcotest.(check int) "effective legacy dirs exposed" 0
+    (json |> member "effective_legacy_dirs" |> to_list |> List.length)
 
 let test_to_yojson_exposes_resolution_source () =
   let diag =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -371,11 +371,13 @@ let test_room_init_bootstraps_keeper_runtime_dirs () =
       ignore (Room.init config ~agent_name:None);
       let root_dir = Room.masc_root_dir config in
       let keeper_dir = Filename.concat root_dir "keepers" in
-      let perpetual_dir = Filename.concat root_dir "perpetual" in
+      let traces_dir = Filename.concat root_dir "traces" in
       Alcotest.(check bool) "keeper dir exists" true
         (Sys.file_exists keeper_dir && Sys.is_directory keeper_dir);
-      Alcotest.(check bool) "perpetual dir exists" true
-        (Sys.file_exists perpetual_dir && Sys.is_directory perpetual_dir))
+      Alcotest.(check bool) "traces dir exists" true
+        (Sys.file_exists traces_dir && Sys.is_directory traces_dir);
+      Alcotest.(check bool) "perpetual dir not recreated" false
+        (Sys.file_exists (Filename.concat root_dir "perpetual")))
 
 let test_otel_exporter_setup_failure_is_soft () =
   Otel_spans.shutdown ~enabled:true ();

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -129,11 +129,14 @@ set -eu
 capture="${FAKE_CAPTURE_FILE:?}"
 {
   printf 'FAKE_EXE_MARKER=%s\n' '%s'
+  printf 'PWD=%%s\n' "$PWD"
   printf 'MASC_STORAGE_TYPE=%%s\n' "${MASC_STORAGE_TYPE:-}"
   printf 'SUPABASE_DB_URL=%%s\n' "${SUPABASE_DB_URL:-}"
   printf 'MASC_BASE_PATH=%%s\n' "${MASC_BASE_PATH:-}"
   printf 'MASC_CONFIG_DIR=%%s\n' "${MASC_CONFIG_DIR:-}"
   printf 'MASC_KEEPER_BOOTSTRAP_ENABLED=%%s\n' "${MASC_KEEPER_BOOTSTRAP_ENABLED:-}"
+  printf 'MASC_GRPC_PORT=%%s\n' "${MASC_GRPC_PORT:-}"
+  printf 'MASC_WS_PORT=%%s\n' "${MASC_WS_PORT:-}"
   printf 'MASC_WS_ENABLED=%%s\n' "${MASC_WS_ENABLED:-}"
   printf 'MASC_WEBRTC_ENABLED=%%s\n' "${MASC_WEBRTC_ENABLED:-}"
   printf 'ARGS=%%s\n' "$*"
@@ -148,6 +151,18 @@ let make_fake_eio_exe repo_root =
   let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
   write_fake_eio_exe exe_path ~marker:"local"
 
+let make_fake_eio_exe_with_stderr repo_root =
+  let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
+  mkdir_p (Filename.dirname exe_path);
+  write_executable exe_path
+    {|
+#!/bin/sh
+set -eu
+echo "+[WARN] ℹ️  Running without TLS (plaintext h2c)" >&2
+echo "+[INFO] gRPC server on 127.0.0.1:9952" >&2
+echo "stderr-keep" >&2
+exit 0
+|}
 let test_explicit_env_overrides_repo_env_files () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
@@ -429,6 +444,87 @@ let test_worktree_prefers_local_build_over_workspace_build () =
       check bool "local build wins in worktree" true
         (contains_substring captured "FAKE_EXE_MARKER=local"))
 
+let test_explicit_base_path_execs_from_base_path () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let parent = Filename.concat dir "parent-root" in
+      let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
+      let home_dir = Filename.concat dir "empty-home" in
+      mkdir_p repo;
+      mkdir_p home_dir;
+      mkdir_p (Filename.concat parent ".masc");
+      mkdir_p (Filename.concat repo ".masc");
+      let script = Filename.concat repo "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe repo;
+      let capture = Filename.concat dir "captured-explicit-cwd.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
+              ("MASC_BASE_PATH", parent);
+              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
+            ]
+          (Printf.sprintf "%s --http --port 9966 --base-path %s"
+             (quote script) (quote parent))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "exec cwd matches explicit base path" true
+        (contains_substring captured ("PWD=" ^ parent)))
+
+let test_explicit_http_port_derives_sidecar_ports () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe dir;
+      let capture = Filename.concat dir "captured-sidecar-ports.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_BASE_PATH", dir);
+            ]
+          (Printf.sprintf "%s --http --port 9951 --base-path %s"
+             (quote script) (quote dir))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "grpc port derived from explicit http port" true
+        (contains_substring captured "MASC_GRPC_PORT=9952");
+      check bool "ws port derived from explicit http port" true
+        (contains_substring captured "MASC_WS_PORT=9953"))
+
+let test_grpc_direct_banner_is_preserved_in_stderr () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe_with_stderr dir;
+      let code, stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("MASC_BASE_PATH", dir);
+            ]
+          (Printf.sprintf "%s --http --port 9951 --base-path %s"
+             (quote script) (quote dir))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      check bool "grpc-direct tls banner preserved" true
+        (contains_substring stderr "Running without TLS (plaintext h2c)");
+      check bool "grpc-direct server banner preserved" true
+        (contains_substring stderr "gRPC server on 127.0.0.1:9952");
+      check bool "other stderr preserved" true
+        (contains_substring stderr "stderr-keep"))
+
 let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
     =
   with_temp_dir "start-loopback-script" (fun dir ->
@@ -503,6 +599,12 @@ let () =
             "absolute parent project inherited base path is preserved"
             `Quick
             test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved;
+          test_case "explicit base path execs from base path" `Quick
+            test_explicit_base_path_execs_from_base_path;
+          test_case "explicit http port derives sidecar ports" `Quick
+            test_explicit_http_port_derives_sidecar_ports;
+          test_case "grpc-direct banner is preserved in stderr" `Quick
+            test_grpc_direct_banner_is_preserved_in_stderr;
           test_case "zshenv absolute base path is preserved" `Quick
             test_zshenv_absolute_base_path_with_dual_roots_is_preserved;
           test_case "dual roots opt-in preserves inherited base path" `Quick


### PR DESCRIPTION
## What changed
- make `start-masc-mcp.sh` launch from the resolved base path so server `Process cwd` matches the effective base path
- keep startup diagnostics focused on active vs ignored legacy `.masc` directories and collapse deprecated transport lines into a compatibility summary
- stop recreating legacy `perpetual` roots during room bootstrap and keep traces rooted under `.masc/traces`
- force keeper default read/write cwd to each keeper playground under `.masc/playground/<keeper>/`, and expose that default cwd in keeper status
- update keeper/runtime/script tests to lock in the new base-path and playground-cwd behavior
- patch minor compile fallout from upstream API changes in `llm_provider.Metrics` and `Tool_schema_gen`

## Why
Running the server with `--base-path ~/me` while starting from the repo worktree still surfaced a mismatched process cwd and left room for stale cwd-root state to look authoritative. Keeper default cwd behavior also drifted away from the documented playground-first model whenever explicit allowlists were present.

## Impact
- server startup and `/health` now agree on the effective base path and process cwd
- deprecated legacy surfaces are still available but clearly marked as compatibility-only
- keepers default into their own playgrounds even when they can additionally access other allowed paths
- operator status output now shows the actual default cwd used for keeper execution

## Root cause
- startup script passed the right base path to the server, but did not change the process working directory before exec
- keeper default cwd resolution preferred project or explicit allowlist roots instead of always anchoring execution in the keeper playground
- room bootstrap paths still referenced retired legacy directory naming in a couple of places

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/startup-log-audit _build/default/test/test_keeper_allowed_paths.exe _build/default/test/test_keeper_pr_workflow.exe _build/default/test/test_start_masc_mcp_script.exe _build/default/test/test_server_runtime_bootstrap.exe _build/default/test/test_server_base_path_diagnostics.exe _build/default/test/test_typed_tool_masc.exe`
- `./_build/default/test/test_keeper_allowed_paths.exe`
- `./_build/default/test/test_keeper_pr_workflow.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_server_base_path_diagnostics.exe`
- `./_build/default/test/test_typed_tool_masc.exe`
- live restart via `tmux` and manual checks of `/tmp/masc-8935-fixed.log`, `/health`, and `masc_keeper_status` for `execution_context.default_cwd`
