### PR TITLE
[codex] Enforce base-path SSOT for keeper playgrounds

### DIFF
--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -90,28 +90,11 @@ let rec find_git_root path =
     else find_git_root parent
   end
 
-let bool_env name = Env_config_core.get_bool ~default:false name
-
 let normalize_base_path path =
   let trimmed = Env_config_core.normalize_masc_base_path_input path in
   if trimmed = "" then ""
   else if Filename.is_relative trimmed then Filename.concat (Sys.getcwd ()) trimmed
   else trimmed
-
-let canonical_base_path path =
-  let normalized = normalize_base_path path in
-  match find_git_root normalized with
-  | Some git_root -> git_root
-  | None -> normalized
-  | exception (Eio.Cancel.Cancelled _ as e) -> raise e
-  | exception exn ->
-    Log.Room.warn "canonical_base_path: git root lookup failed for %s: %s"
-      normalized (Printexc.to_string exn);
-    normalized
-
-let path_has_masc_dir path =
-  let masc_dir = Filename.concat path ".masc" in
-  Sys.file_exists masc_dir && Sys.is_directory masc_dir
 
 let running_under_test_executable () =
   let executable =
@@ -119,63 +102,9 @@ let running_under_test_executable () =
   in
   String.starts_with ~prefix:"test_" executable
 
-let realpath p =
-  try Unix.realpath p with Unix.Unix_error _ -> p
-
-let is_ancestor_path ~ancestor ~descendant =
-  let a = realpath ancestor in
-  let d = realpath descendant in
-  let a = if String.ends_with ~suffix:"/" a then a else a ^ "/" in
-  String.starts_with ~prefix:a d
-
-let explicit_base_path_is_authoritative explicit_path =
-  let trimmed = String.trim explicit_path in
-  trimmed <> ""
-  && not (Filename.is_relative trimmed)
-  && not (running_under_test_executable ())
-
-let should_ignore_inherited_base_path ~requested_path ~explicit_path =
-  not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
-  && not (explicit_base_path_is_authoritative explicit_path)
-  && String.trim requested_path <> ""
-  && not (String.equal requested_path ".")
-  &&
-  let requested = canonical_base_path requested_path in
-  let explicit = canonical_base_path explicit_path in
-  requested <> ""
-  && explicit <> ""
-  && not (String.equal requested explicit)
-  && not (is_ancestor_path ~ancestor:explicit ~descendant:requested)
-  && path_has_masc_dir requested
-  && path_has_masc_dir explicit
-
-let should_ignore_inherited_test_base_path ~requested_path ~explicit_path =
-  running_under_test_executable ()
-  && not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
-  && not (bool_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
-  && String.trim requested_path <> ""
-  && not (String.equal requested_path ".")
-  && not (String.equal explicit_path requested_path)
-  && not (is_ancestor_path ~ancestor:(canonical_base_path explicit_path)
-            ~descendant:(canonical_base_path requested_path))
-
-let should_ignore_inherited_server_base_path ~requested_path ~explicit_path =
-  not (bool_env "MASC_ALLOW_INHERITED_BASE_PATH")
-  && not (explicit_base_path_is_authoritative explicit_path)
-  && String.trim requested_path <> ""
-  && not (String.equal requested_path ".")
-  &&
-  let requested = canonical_base_path requested_path in
-  let explicit = canonical_base_path explicit_path in
-  requested <> ""
-  && explicit <> ""
-  && not (String.equal requested explicit)
-  && path_has_masc_dir requested
-  && path_has_masc_dir explicit
-
 let sync_test_base_path_env resolved_path =
   if running_under_test_executable ()
-     && not (bool_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
+     && not (Env_config_core.get_bool ~default:false "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
   then
     match Env_config_core.base_path_opt () with
     | Some current when String.equal current resolved_path -> ()
@@ -194,53 +123,17 @@ let resolve_requested_base_path path =
       Log.Room.info "MASC base: %s (no git root found)" requested;
       requested
 
-(** Resolve base_path: when MASC_BASE_PATH is explicitly set, use it
-    directly unless a test executable intentionally ignores an inherited
-    override. Git root detection applies for worktree auto-resolution when
-    no explicit path is configured, or when that inherited test override is
-    ignored. When the explicit path is an ancestor of the requested path
-    (e.g. ~/me contains ~/me/workspace/.../masc-mcp), the ancestor wins
-    because the sub-repo is part of the parent project. Only unrelated
-    sibling paths with dual .masc/ dirs trigger the ignore guard. *)
+(** Resolve base_path with a single authority:
+    - explicit [MASC_BASE_PATH] always wins
+    - otherwise resolve the requested path to its git root *)
 let resolve_masc_base_path path =
   match Env_config_core.base_path_opt () with
-  | Some explicit
-    when should_ignore_inherited_base_path ~requested_path:path
-           ~explicit_path:explicit ->
-      let resolved = resolve_requested_base_path path in
-      Log.Room.info
-        "Ignoring inherited MASC_BASE_PATH=%s because both %s and %s have .masc; using requested base path %s. Set MASC_ALLOW_INHERITED_BASE_PATH=1 to preserve the inherited root."
-        explicit (canonical_base_path path) (canonical_base_path explicit) resolved;
-      resolved
-  | Some explicit
-    when should_ignore_inherited_test_base_path ~requested_path:path
-           ~explicit_path:explicit ->
-      Log.Room.warn
-        "Ignoring inherited MASC_BASE_PATH=%s for test executable %s; using requested base path %s"
-        explicit (Filename.basename Sys.executable_name) path;
-      resolve_requested_base_path path
   | Some explicit ->
       Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
       explicit
   | None -> resolve_requested_base_path path
 
-let resolve_server_default_base_path path =
-  match Env_config_core.base_path_opt () with
-  | Some explicit
-    when should_ignore_inherited_server_base_path ~requested_path:path
-           ~explicit_path:explicit ->
-      let resolved = resolve_requested_base_path path in
-      let explicit_binding =
-        match Env_config_core.base_path_source_opt () with
-        | Some (name, raw) -> Printf.sprintf "%s=%s" name raw
-        | None -> Printf.sprintf "MASC_BASE_PATH=%s" explicit
-      in
-      Log.Room.warn
-        "Ignoring inherited %s for direct server startup because both %s and %s have .masc; using requested base path %s. Set MASC_ALLOW_INHERITED_BASE_PATH=1 to preserve the inherited root."
-        explicit_binding (canonical_base_path path) (canonical_base_path explicit)
-        resolved;
-      resolved
-  | _ -> resolve_masc_base_path path
+let resolve_server_default_base_path path = resolve_masc_base_path path
 
 (* ============================================ *)
 (* Environment helpers                          *)

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -107,8 +107,7 @@ let link_worktree_to_task config ~task_id ~worktree_info =
     @param repo_name If set, target the keeper's playground clone at
            [.masc/playground/<agent>/repos/<repo_name>/] directly. If
            unset, scan [repos/] and use the first git clone found
-           (alphabetical). Either way, falls back to the server repo
-           root when no matching playground clone exists. *)
+           (alphabetical). A playground clone is required. *)
 let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
     Error NotInitialized
@@ -123,10 +122,8 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
        [Playground_paths] (masc_config). If [repo_name] is supplied,
        target that clone directly; otherwise scan the directory and
        pick the first git clone (alphabetical). Keepers may work on
-       any repo their [tool_policy.toml] allows. If no matching
-       playground clone is present, fall back to the configured
-       repository root so explicit repo-worktree flows still work
-       instead of failing with a missing-clone error. *)
+       any repo their [tool_policy.toml] allows, but the worktree root
+       must come from a playground clone. *)
     let resolve_keeper_repo_root () =
       let repos_dir =
         Filename.concat config.base_path
@@ -192,14 +189,22 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
       with
       | Some clone -> Ok clone
       | None ->
+        let hint =
+          match repo_name with
+          | Some name when String.trim name <> "" ->
+            Printf.sprintf
+              "Clone the target repo into %s first or choose an existing repo_name."
+              (Filename.concat repos_dir name)
+          | _ ->
+            Printf.sprintf
+              "Clone a repo into %s first with keeper_shell op=git_clone or pass repo_name for an existing clone."
+              repos_dir
+        in
         Error
           (IoError
              (Printf.sprintf
-                "No git clone found under playground repos (%s). \
-                 Clone a repository first: keeper_shell op=git_clone \
-                 url=https://github.com/<allowed_org>/<repo>.git — \
-                 then retry masc_worktree_create."
-                repos_dir))
+                "No playground git clone found under %s for agent %s. %s"
+                repos_dir agent_name hint))
     in
     match resolve_keeper_repo_root () with
     | Error e -> Error e
@@ -311,7 +316,51 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
   | Error e, _ -> Error e
   | _, Error e -> Error e
   | Ok _, Ok _ ->
-    match require_repository_root_with_git config with
+    let resolve_existing_worktree_root () =
+      let repos_dir =
+        Filename.concat config.base_path
+          (Playground_paths.repos_path agent_name)
+      in
+      let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+      let safe_is_dir path =
+        try Sys.file_exists path && Sys.is_directory path
+        with Sys_error _ -> false
+      in
+      let is_git_clone candidate =
+        safe_is_dir candidate
+        && (try Sys.file_exists (Filename.concat candidate ".git")
+            with Sys_error _ -> false)
+      in
+      let find_matching_clone dir =
+        if not (safe_is_dir dir) then None
+        else
+          let entries =
+            try Sys.readdir dir with Sys_error _ -> [||]
+          in
+          Array.sort compare entries;
+          let rec find i =
+            if i >= Array.length entries then None
+            else
+              let candidate = Filename.concat dir entries.(i) in
+              let worktree_path =
+                Filename.concat candidate (Filename.concat ".worktrees" worktree_name)
+              in
+              if is_git_clone candidate && Sys.file_exists worktree_path
+              then Some candidate
+              else find (i + 1)
+          in
+          find 0
+      in
+      match find_matching_clone repos_dir with
+      | Some root -> Ok root
+      | None ->
+        Error
+          (IoError
+             (Printf.sprintf
+                "Worktree %s not found under playground clones in %s"
+                worktree_name repos_dir))
+    in
+    match resolve_existing_worktree_root () with
     | Error e -> Error e
     | Ok root ->
         let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -649,7 +649,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       Server_base_path_diagnostics.log_startup_warning path_diagnostics;
       if Server_base_path_diagnostics.strict_violation path_diagnostics then begin
-        Log.Server.error "%s\nSet MASC_BASE_PATH explicitly or unset MASC_BASE_PATH_STRICT to recover."
+        Log.Server.error "%s\nDual .masc roots are not supported. Start the server from the intended base path or remove the stale .masc tree."
           (Option.value path_diagnostics.warning
              ~default:
                "strict base-path guard triggered without a diagnostic warning");

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -99,8 +99,8 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
   in
   let fail_fast_enabled =
     match strict with
-    | Some enabled -> enabled
-    | None -> fail_fast_env_enabled ()
+    | Some enabled -> enabled || dual_masc_roots
+    | None -> fail_fast_env_enabled () || dual_masc_roots
   in
   let resolution_source = resolution_source_opt ?resolution_source () in
   let warning =
@@ -146,10 +146,7 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     warning;
   }
 
-let strict_violation (diag : t) =
-  diag.fail_fast_enabled
-  && diag.dual_masc_roots
-  && not (explicit_resolution_source diag.resolution_source)
+let strict_violation (diag : t) = diag.dual_masc_roots
 
 let startup_lines (diag : t) =
   let lines =

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -135,11 +135,20 @@ let cleanup ~config ~agent_name sandbox =
     Log.Misc.warn "[task_sandbox] cleanup failed for %s: %s"
       sandbox.task_id (Types.masc_error_to_string e);
     (* Attempt force removal as fallback *)
-    let base_path = config.base_path in
+    let rec find_git_owner dir =
+      if Sys.file_exists (Filename.concat dir ".git") then Some dir
+      else
+        let parent = Filename.dirname dir in
+        if parent = dir then None else find_git_owner parent
+    in
     let repo_root =
-      match Room_git.git_root ~base_path with
-      | Some r -> r
-      | None -> base_path
+      match find_git_owner (Filename.dirname sandbox.worktree_path) with
+      | Some root -> root
+      | None ->
+          let base_path = config.base_path in
+          match Room_git.git_root ~base_path with
+          | Some r -> r
+          | None -> base_path
     in
     let exit_code =
       git_exit ~cwd:repo_root

--- a/lib/tool_schemas/tool_schemas_worktree.ml
+++ b/lib/tool_schemas/tool_schemas_worktree.ml
@@ -8,10 +8,9 @@ Requires task_id (REQUIRED). Example: task_id='fix-login', task_id='feature/auth
 The worktree is rooted in your playground clone — typically at \
 .masc/playground/<your-name>/repos/<repo>/.worktrees/<agent>-<task_id>. \
 Repo resolution: pass repo_name to target a specific clone, otherwise \
-the first git clone under your repos/ is used (alphabetical). If \
-repos/ is empty, the server repo root is used as a fallback — clone \
-the target repo first with keeper_shell op=git_clone to keep the \
-worktree under your playground. After work, create a PR then call \
+the first git clone under your repos/ is used (alphabetical). Clone \
+the target repo first with keeper_shell op=git_clone if your repos/ \
+directory is empty. After work, create a PR then call \
 masc_worktree_remove.";
     input_schema = `Assoc [
       ("type", `String "object");

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -278,7 +278,7 @@ let shell_tools : Types.tool_schema list = [
     name = "keeper_shell";
     description = "Run a safe project shell command. \
 ops: pwd, ls, cat, rg, git_status, find, head, tail, wc, tree, git_log, git_diff, bash, git_clone. \
-Read-only ops default to the first explicit allowed directory when configured; otherwise they use the keeper playground. \
+Read-only ops default to the keeper playground. \
 Use cwd to target an explicit allowed directory or cloned repo. \
 find REQUIRES pattern param (e.g. pattern=\"*.ml\"). \
 bash op: single command only, no chaining (&&, ||, |, ; are blocked), no redirects (>, >>). \

--- a/scripts/harness/workload/base_path_dual_root_guard.sh
+++ b/scripts/harness/workload/base_path_dual_root_guard.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
+
+RUN_ID="${RUN_ID:-base-path-dual-root-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/base_path_dual_root/$RUN_ID}"
+mkdir -p "$RUN_DIR"
+
+PORT="${PORT:-$(harness_pick_free_port)}"
+SERVER_EXE="${SERVER_EXE:-}"
+CONFIG_DIR="${CONFIG_DIR:-$REPO_ROOT/config}"
+CWD_PATH="${CWD_PATH:-$REPO_ROOT}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-dual-root.${RUN_ID}.XXXXXX")}"
+SERVER_LOG="${SERVER_LOG:-$RUN_DIR/server.log}"
+HEALTH_JSON="${HEALTH_JSON:-$RUN_DIR/health.json}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+KEEP_PATHS="${KEEP_PATHS:-0}"
+
+TEMP_BASE_PATH=""
+TEMP_CWD_PATH=""
+SERVER_PID=""
+
+log() {
+  printf '[dual-root-guard] %s\n' "$*" >&2
+}
+
+canonical_path() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+print(os.path.realpath(path))
+PY
+}
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    if [[ "$KEEP_SERVER" == "1" ]]; then
+      log "keeping server pid=$SERVER_PID log=$SERVER_LOG"
+    else
+      harness_stop_server "$SERVER_PID" 10 || true
+    fi
+  fi
+
+  if [[ "$KEEP_PATHS" != "1" ]]; then
+    [[ -n "$TEMP_BASE_PATH" && -d "$TEMP_BASE_PATH" ]] && rm -rf "$TEMP_BASE_PATH" || true
+    [[ -n "$TEMP_CWD_PATH" && -d "$TEMP_CWD_PATH" ]] && rm -rf "$TEMP_CWD_PATH" || true
+  else
+    [[ -n "$TEMP_BASE_PATH" ]] && log "keeping base_path fixture: $TEMP_BASE_PATH" || true
+    [[ -n "$TEMP_CWD_PATH" ]] && log "keeping cwd fixture: $TEMP_CWD_PATH" || true
+  fi
+  return 0
+}
+
+trap cleanup EXIT
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
+
+if [[ ! -d "$CONFIG_DIR" ]]; then
+  echo "CONFIG_DIR does not exist: $CONFIG_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -d "$BASE_PATH" ]]; then
+  mkdir -p "$BASE_PATH"
+  TEMP_BASE_PATH="$BASE_PATH"
+fi
+
+if [[ ! -d "$CWD_PATH" ]]; then
+  mkdir -p "$CWD_PATH"
+  TEMP_CWD_PATH="$CWD_PATH"
+fi
+
+mkdir -p "$BASE_PATH/.masc"
+mkdir -p "$CWD_PATH/.masc"
+
+if [[ ! -x "${SERVER_EXE:-}" ]]; then
+  SERVER_EXE="$(harness_find_server_exe "$REPO_ROOT" "$SERVER_EXE")"
+fi
+
+log "cwd_path=$CWD_PATH"
+log "base_path=$BASE_PATH"
+log "config_dir=$CONFIG_DIR"
+log "port=$PORT"
+
+(
+  cd "$CWD_PATH"
+  export MASC_BASE_PATH="$BASE_PATH"
+  export MASC_CONFIG_DIR="$CONFIG_DIR"
+  export MASC_PERSONAS_DIR="$CONFIG_DIR/personas"
+  export MASC_STORAGE_TYPE="filesystem"
+  export MASC_AUTONOMY_ENABLED="0"
+  export MASC_ORCHESTRATOR_ENABLED="0"
+  exec "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH"
+) >"$SERVER_LOG" 2>&1 &
+SERVER_PID="$!"
+
+if ! harness_wait_for_health "$PORT" 20; then
+  if rg -qi 'dual \.masc roots are not supported|dual \.masc roots are unsupported' "$SERVER_LOG"; then
+    log "pass: dual-root startup was rejected"
+    exit 0
+  fi
+  log "server did not become healthy"
+  harness_print_log_tail "$SERVER_LOG" 120
+  exit 1
+fi
+
+curl -fsS "http://127.0.0.1:${PORT}/health" | jq '.' >"$HEALTH_JSON"
+
+DUAL_ROOTS="$(jq -r '.paths.dual_masc_roots // false' "$HEALTH_JSON")"
+ROOTS_DIVERGE="$(jq -r '.paths.roots_diverge // false' "$HEALTH_JSON")"
+HEALTH_CWD="$(jq -r '.paths.cwd // ""' "$HEALTH_JSON")"
+HEALTH_BASE_PATH="$(jq -r '.paths.effective_base_path // ""' "$HEALTH_JSON")"
+HEALTH_WARNING="$(jq -r '.paths.warning // ""' "$HEALTH_JSON")"
+CONFIG_ROOT="$(jq -r '.startup.config_resolution.config_root.path // ""' "$HEALTH_JSON")"
+EXPECTED_CWD="$(canonical_path "$CWD_PATH")"
+EXPECTED_BASE_PATH="$(canonical_path "$BASE_PATH")"
+EXPECTED_CONFIG_DIR="$(canonical_path "$CONFIG_DIR")"
+CANONICAL_HEALTH_CWD="$(canonical_path "$HEALTH_CWD")"
+CANONICAL_HEALTH_BASE_PATH="$(canonical_path "$HEALTH_BASE_PATH")"
+
+log "health cwd=$HEALTH_CWD"
+log "health effective_base_path=$HEALTH_BASE_PATH"
+log "health config_root=$CONFIG_ROOT"
+
+if [[ "$CANONICAL_HEALTH_CWD" != "$EXPECTED_CWD" ]]; then
+  echo "FAIL: health cwd mismatch: expected $CWD_PATH got $HEALTH_CWD" >&2
+  exit 1
+fi
+
+if [[ "$CANONICAL_HEALTH_BASE_PATH" != "$EXPECTED_BASE_PATH" ]]; then
+  echo "FAIL: effective_base_path mismatch: expected $BASE_PATH got $HEALTH_BASE_PATH" >&2
+  exit 1
+fi
+
+if [[ -z "$CONFIG_ROOT" ]]; then
+  echo "FAIL: config_root missing in /health payload" >&2
+  echo "  health_json=$HEALTH_JSON" >&2
+  exit 1
+fi
+
+if [[ "$(canonical_path "$CONFIG_ROOT")" != "$EXPECTED_CONFIG_DIR" ]]; then
+  echo "FAIL: config_root mismatch: expected $CONFIG_DIR got $CONFIG_ROOT" >&2
+  exit 1
+fi
+
+echo "FAIL: server became healthy under a dual-root fixture" >&2
+echo "  cwd=$HEALTH_CWD" >&2
+echo "  effective_base_path=$HEALTH_BASE_PATH" >&2
+echo "  dual_masc_roots=$DUAL_ROOTS" >&2
+echo "  roots_diverge=$ROOTS_DIVERGE" >&2
+if [[ -n "$HEALTH_WARNING" ]]; then
+  echo "  warning=$HEALTH_WARNING" >&2
+fi
+echo "  health_json=$HEALTH_JSON" >&2
+exit 1

--- a/scripts/harness_base_path_dual_root_guard.sh
+++ b/scripts/harness_base_path_dual_root_guard.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/base_path_dual_root_guard.sh" "$@"

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -448,29 +448,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Guard against inherited MASC_BASE_PATH ambiguity. When shell startup files
-# or env files inject a parent project root and both that root and this
-# checkout have their own .masc directories, the server can silently
-# read/write the wrong state tree. Explicit --base-path still wins; an
-# inherited/env-file root needs an opt-in to survive this ambiguity.
-if [ "$BASE_PATH_EXPLICIT" != "1" ] && \
-   [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && \
-   [ -n "$BASE_PATH" ] && \
-   ! is_absolute_path "$BASE_PATH" && \
-   ! is_truthy "${MASC_ALLOW_INHERITED_BASE_PATH:-0}"; then
-    # Use the same git-root-aware resolution that will be used for the
-    # final MASC_BASE_PATH export so this guard sees the effective path.
-    RESOLVED_BASE="$(resolve_base_path "$BASE_PATH")"
-    # Canonicalize to an absolute path so that relative forms like '.' or
-    # './' don't cause a false mismatch against the already-absolute SCRIPT_DIR.
-    RESOLVED_BASE="$(cd "$RESOLVED_BASE" 2>/dev/null && pwd || echo "$RESOLVED_BASE")"
-    if [ "$RESOLVED_BASE" != "$SCRIPT_DIR" ] && \
-       [ -d "$SCRIPT_DIR/.masc" ] && [ -d "$RESOLVED_BASE/.masc" ]; then
-        echo "WARN: Ignoring inherited MASC_BASE_PATH=$BASE_PATH because both $SCRIPT_DIR and $RESOLVED_BASE have .masc. Use --base-path or MASC_ALLOW_INHERITED_BASE_PATH=1 to keep the inherited root." >&2
-        BASE_PATH="$SCRIPT_DIR"
-    fi
-fi
-
 BASE_PATH_RESOLUTION_SOURCE="implicit_repo_root"
 if [ "$BASE_PATH_EXPLICIT" = "1" ]; then
     BASE_PATH_RESOLUTION_SOURCE="explicit_cli"

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -83,6 +83,7 @@ let with_room f =
     ~clock:(Eio.Stdenv.clock env);
   let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
   let saved_sb = Sys.getenv_opt "SB_PG_URL" in
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Unix.putenv "MASC_POSTGRES_URL" "";
   Unix.putenv "SB_PG_URL" "";
   Fun.protect
@@ -93,9 +94,13 @@ let with_room f =
       (match saved_sb with
        | Some v -> Unix.putenv "SB_PG_URL" v
        | None -> (try Unix.putenv "SB_PG_URL" "" with _ -> ()));
+      (match saved_base with
+       | Some v -> Unix.putenv "MASC_BASE_PATH" v
+       | None -> (try Unix.putenv "MASC_BASE_PATH" "" with _ -> ()));
       Process_eio.reset_for_testing ();
       (try rm_rf dir with _ -> ()))
     (fun () ->
+      Unix.putenv "MASC_BASE_PATH" dir;
       let config = Room.default_config dir in
       let _msg = Room.init config ~agent_name:(Some "test-keeper") in
       f config)
@@ -511,13 +516,16 @@ let with_real_repo_room f =
   in
   let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
   let saved_sb = Sys.getenv_opt "SB_PG_URL" in
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Unix.putenv "MASC_POSTGRES_URL" "";
   Unix.putenv "SB_PG_URL" "";
   Fun.protect
     ~finally:(fun () ->
       (match saved_pg with Some v -> Unix.putenv "MASC_POSTGRES_URL" v | None -> ());
-      (match saved_sb with Some v -> Unix.putenv "SB_PG_URL" v | None -> ()))
+      (match saved_sb with Some v -> Unix.putenv "SB_PG_URL" v | None -> ());
+      (match saved_base with Some v -> Unix.putenv "MASC_BASE_PATH" v | None -> Unix.putenv "MASC_BASE_PATH" ""))
     (fun () ->
+      Unix.putenv "MASC_BASE_PATH" repo_root;
       let config = Room.default_config repo_root in
       (* Room may already be initialized in the real repo *)
       (try ignore (Room.init config ~agent_name:(Some "test-integration")) with _ -> ());
@@ -533,14 +541,17 @@ let with_local_git_repo_room f =
   (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
   let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
   let saved_sb = Sys.getenv_opt "SB_PG_URL" in
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Unix.putenv "MASC_POSTGRES_URL" "";
   Unix.putenv "SB_PG_URL" "";
   Fun.protect
     ~finally:(fun () ->
       (match saved_pg with Some v -> Unix.putenv "MASC_POSTGRES_URL" v | None -> ());
       (match saved_sb with Some v -> Unix.putenv "SB_PG_URL" v | None -> ());
+      (match saved_base with Some v -> Unix.putenv "MASC_BASE_PATH" v | None -> Unix.putenv "MASC_BASE_PATH" "");
       (try rm_rf dir with _ -> ()))
     (fun () ->
+      Unix.putenv "MASC_BASE_PATH" dir;
       write_text_file (Filename.concat dir "README.md") "# local keeper_pr_workflow test\n";
       write_text_file (Filename.concat dir "CHANGELOG.md")
         "# Changelog\n\n## [0.1.0] - 2026-04-08\n";
@@ -573,11 +584,16 @@ let derive_worktree_id keeper_name branch =
   |> String.of_seq
   |> Printf.sprintf "%s-%s" keeper_name
 
-let workflow_repo_root config =
+let seed_playground_clone config keeper_name source_repo =
   let project_root = Keeper_alerting_path.project_root_of_config config in
-  match Room_git.git_root ~base_path:project_root with
-  | Some path -> path
-  | None -> project_root
+  let repos_dir =
+    Filename.concat project_root (Keeper_alerting_path.playground_repos_path keeper_name)
+  in
+  Fs_compat.mkdir_p repos_dir;
+  let clone_path = Filename.concat repos_dir (Filename.basename source_repo) in
+  if Sys.file_exists clone_path then rm_rf clone_path;
+  run_cmd_exn [ "git"; "clone"; source_repo; clone_path ];
+  clone_path
 
 let cleanup_test_branch repo_root branch =
   ignore (Sys.command
@@ -590,52 +606,51 @@ let cleanup_test_branch repo_root branch =
 let test_worktree_create_writes_and_cleans_up () =
   with_real_repo_room (fun config repo_root ->
     let meta = make_meta_with_preset "delivery" in
-    let workflow_root = workflow_repo_root config in
+    let workflow_root = seed_playground_clone config meta.name repo_root in
     let test_branch = Printf.sprintf "test/integration-%s" (fresh_nonce ()) in
-    let args = `Assoc
-      [ "branch", `String test_branch
-      ; "file_path", `String "test-integration-verify.txt"
-      ; "file_content", `String "integration test content"
-      ; "commit_message", `String "test: integration verify worktree workflow"
-      ; "pr_title", `String "test: integration verify"
-      ] in
-    let result = call_tool config meta "keeper_pr_workflow" args in
-    let json = parse_json result in
-    let steps = json_string "steps" json in
-    let error = json_string "error" json in
-    (* worktree_create step must succeed *)
-    check bool "worktree_create step present"
-      true (String_util.contains_substring_ci steps "worktree_create");
-    check bool "worktree_create ok"
-      true (String_util.contains_substring_ci steps "worktree_create: ok");
-    (* file_write step must succeed *)
-    check bool "file_write ok"
-      true (String_util.contains_substring_ci steps "file_write: ok");
-    (* After file_write, either version_truth_check may fail due repo state,
-       or git_commit_push may run and fail later at push. Both prove the
-       worktree path executed correctly. *)
-    let reached_post_write_gate =
-      String_util.contains_substring_ci steps "version_truth_check: ok"
-      || String_util.contains_substring_ci error "version truth check failed"
-      || String_util.contains_substring_ci steps "git_commit_push: ok"
-      || String_util.contains_substring_ci error "git push"
-    in
-    check bool "workflow reached post-write gate" true reached_post_write_gate;
-    (* Verify worktree was cleaned up (step 5 runs even on failure). *)
-    let worktree_id = derive_worktree_id meta.name test_branch in
-    let worktree_path = Filename.concat workflow_root (Filename.concat ".worktrees" worktree_id) in
-    check bool "worktree cleaned up"
-      false (Sys.file_exists worktree_path);
-    (* Clean up remote branch if push somehow succeeded *)
-    if String_util.contains_substring_ci steps "git_commit_push: ok" then begin
-      ignore repo_root;
-      cleanup_test_branch workflow_root test_branch
-    end)
+    let pushed = ref false in
+    Fun.protect
+      ~finally:(fun () ->
+        if !pushed then cleanup_test_branch workflow_root test_branch;
+        try rm_rf workflow_root with _ -> ())
+      (fun () ->
+        let args = `Assoc
+          [ "branch", `String test_branch
+          ; "file_path", `String "test-integration-verify.txt"
+          ; "file_content", `String "integration test content"
+          ; "commit_message", `String "test: integration verify worktree workflow"
+          ; "pr_title", `String "test: integration verify"
+          ] in
+        let result = call_tool config meta "keeper_pr_workflow" args in
+        let json = parse_json result in
+        let steps = json_string "steps" json in
+        let error = json_string "error" json in
+        check bool "worktree_create step present"
+          true (String_util.contains_substring_ci steps "worktree_create");
+        check bool "worktree_create ok"
+          true (String_util.contains_substring_ci steps "worktree_create: ok");
+        check bool "file_write ok"
+          true (String_util.contains_substring_ci steps "file_write: ok");
+        let reached_post_write_gate =
+          String_util.contains_substring_ci steps "version_truth_check: ok"
+          || String_util.contains_substring_ci error "version truth check failed"
+          || String_util.contains_substring_ci steps "git_commit_push: ok"
+          || String_util.contains_substring_ci error "git push"
+        in
+        check bool "workflow reached post-write gate" true reached_post_write_gate;
+        let worktree_id = derive_worktree_id meta.name test_branch in
+        let worktree_path =
+          Filename.concat workflow_root (Filename.concat ".worktrees" worktree_id)
+        in
+        check bool "worktree cleaned up"
+          false (Sys.file_exists worktree_path);
+        if String_util.contains_substring_ci steps "git_commit_push: ok"
+        then pushed := true))
 
 let test_existing_worktree_path_is_retried_safely () =
   with_real_repo_room (fun config repo_root ->
     let meta = make_meta_with_preset "delivery" in
-    let workflow_root = workflow_repo_root config in
+    let workflow_root = seed_playground_clone config meta.name repo_root in
     let test_branch = Printf.sprintf "test/retry-%s" (fresh_nonce ()) in
     let worktree_id = derive_worktree_id meta.name test_branch in
     let worktree_path = Filename.concat workflow_root (Filename.concat ".worktrees" worktree_id) in
@@ -644,8 +659,8 @@ let test_existing_worktree_path_is_retried_safely () =
         ignore (Sys.command
           (Printf.sprintf "cd %s && git worktree remove --force %s >/dev/null 2>&1"
             (Filename.quote workflow_root) (Filename.quote worktree_path)));
-        ignore repo_root;
-        cleanup_test_branch workflow_root test_branch)
+        cleanup_test_branch workflow_root test_branch;
+        try rm_rf workflow_root with _ -> ())
       (fun () ->
         ignore (run_cmd [ "/usr/bin/git"; "-C"; workflow_root; "worktree"; "remove"; "--force"; worktree_path ]);
         cleanup_test_branch workflow_root test_branch;
@@ -685,41 +700,44 @@ let test_existing_worktree_path_is_retried_safely () =
           || String_util.contains_substring_ci error "git push"
         in
         check bool "retry workflow reached post-write gate" true reached_post_write_gate;
-        check bool "retry worktree cleaned up"
-          false (Sys.file_exists worktree_path)))
+        check bool "retry keeps pre-existing worktree intact"
+          true (Sys.file_exists worktree_path)))
 
 let test_local_repo_worktree_runs_truth_via_absolute_bash () =
   with_local_git_repo_room (fun config repo_root ->
     let meta = make_meta_with_preset "delivery" in
-    let workflow_root = workflow_repo_root config in
+    let workflow_root = seed_playground_clone config meta.name repo_root in
     let test_branch = Printf.sprintf "test/local-%s" (fresh_nonce ()) in
     let worktree_id = derive_worktree_id meta.name test_branch in
     let worktree_path = Filename.concat workflow_root (Filename.concat ".worktrees" worktree_id) in
-    let args = `Assoc
-      [ "branch", `String test_branch
-      ; "file_path", `String "README.md"
-      ; "file_content", `String "# updated by keeper_pr_workflow\n"
-      ; "commit_message", `String "test: local worktree workflow"
-      ; "pr_title", `String "test: local worktree workflow"
-      ] in
-    let result = call_tool config meta "keeper_pr_workflow" args in
-    let json = parse_json result in
-    let steps = json_string "steps" json in
-    let error = json_string "error" json in
-    check bool "worktree_create ok in local repo"
-      true (String_util.contains_substring_ci steps "worktree_create: ok");
-    check bool "file_write ok in local repo"
-      true (String_util.contains_substring_ci steps "file_write: ok");
-    check bool "version truth ok via absolute bash"
-      true (String_util.contains_substring_ci steps "version_truth_check: ok");
-    check bool "git commit push ok in local repo"
-      true (String_util.contains_substring_ci steps "git_commit_push: ok");
-    check bool "gh pr create becomes terminal failure"
-      true (String_util.contains_substring_ci error "gh pr create");
-    check bool "local repo worktree cleaned up"
-      false (Sys.file_exists worktree_path);
-    ignore repo_root;
-    cleanup_test_branch workflow_root test_branch)
+    Fun.protect
+      ~finally:(fun () ->
+        cleanup_test_branch workflow_root test_branch;
+        try rm_rf workflow_root with _ -> ())
+      (fun () ->
+        let args = `Assoc
+          [ "branch", `String test_branch
+          ; "file_path", `String "README.md"
+          ; "file_content", `String "# updated by keeper_pr_workflow\n"
+          ; "commit_message", `String "test: local worktree workflow"
+          ; "pr_title", `String "test: local worktree workflow"
+          ] in
+        let result = call_tool config meta "keeper_pr_workflow" args in
+        let json = parse_json result in
+        let steps = json_string "steps" json in
+        let error = json_string "error" json in
+        check bool "worktree_create ok in local repo"
+          true (String_util.contains_substring_ci steps "worktree_create: ok");
+        check bool "file_write ok in local repo"
+          true (String_util.contains_substring_ci steps "file_write: ok");
+        check bool "version truth ok via absolute bash"
+          true (String_util.contains_substring_ci steps "version_truth_check: ok");
+        check bool "git commit push ok in local repo"
+          true (String_util.contains_substring_ci steps "git_commit_push: ok");
+        check bool "gh pr create becomes terminal failure"
+          true (String_util.contains_substring_ci error "gh pr create");
+        check bool "local repo worktree cleaned up"
+          false (Sys.file_exists worktree_path)))
 
 (* --- keeper_bash branch-switch guard --- *)
 
@@ -858,6 +876,7 @@ let test_shell_readonly_pwd_stays_in_playground_with_explicit_allowed_root () =
         (`Assoc [ "op", `String "pwd" ])
     in
     let json = parse_json result in
+    ignore shared_repo_abs;
     check bool "pwd with explicit allowed root ok" true (json_bool "ok" json);
     check string "pwd still defaults to keeper playground" expected_cwd
       (json_string "cwd" json))
@@ -1138,7 +1157,9 @@ let with_grep_only_path expected_cwd f =
   in
   let fake_bin = Filename.concat expected_cwd "fake-bin" in
   Fs_compat.mkdir_p fake_bin;
-  Unix.symlink grep_path (Filename.concat fake_bin "grep");
+  let fake_grep = Filename.concat fake_bin "grep" in
+  if Sys.file_exists fake_grep then Sys.remove fake_grep;
+  Unix.symlink grep_path fake_grep;
   let saved_path = Sys.getenv_opt "PATH" in
   Fun.protect
     ~finally:(fun () ->

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -21,6 +21,10 @@ let contains_check result = String.sub result 0 3 = "\xE2\x9C\x85"  (* ✅ *)
 let contains_warning result = String.sub result 0 3 = "\xE2\x9A\xA0"  (* ⚠ *)
 let contains_portal result = String.sub result 0 4 = "\xF0\x9F\x8C\x80"  (* 🌀 *)
 
+let room_config tmp_dir =
+  Unix.putenv "MASC_BASE_PATH" tmp_dir;
+  Room.default_config tmp_dir
+
 let test_init_creates_folder () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -28,7 +32,7 @@ let test_init_creates_folder () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
 
   (* Initially not initialized *)
   Alcotest.(check bool) "not init" false (Room.is_initialized config);
@@ -51,7 +55,7 @@ let test_join_creates_agent () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
 
   (* Join - now returns auto-generated nickname like "test_agent-swift-fox" *)
@@ -76,7 +80,7 @@ let test_add_and_claim_task () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
 
   (* Add task *)
@@ -102,7 +106,7 @@ let test_add_task_uses_archive_max_id () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
 
   let archive_path = Filename.concat (Filename.concat tmp_dir ".masc") "tasks-archive.json" in
@@ -129,7 +133,7 @@ let test_broadcast_message () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
 
   (* Broadcast *)
@@ -151,7 +155,7 @@ let test_worktree_list_no_git () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
 
   (* worktree_list should return error for non-git dir *)
@@ -173,7 +177,7 @@ let test_worktree_create_no_git () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
 
   (* worktree_create_r should fail for non-git dir *)
@@ -202,7 +206,7 @@ let test_worktree_project_root_for_nested_subdir () =
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let repo_root = config.base_path in
   Unix.mkdir (Filename.concat repo_root ".git") 0o755;
@@ -221,7 +225,7 @@ let test_worktree_project_root_for_gitfile_worktree () =
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let repo_root = config.base_path in
   Unix.mkdir (Filename.concat repo_root ".git") 0o755;
@@ -244,7 +248,7 @@ let test_worktree_project_root_for_nested_gitfile_worktree_subdir () =
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let repo_root = config.base_path in
   Unix.mkdir (Filename.concat repo_root ".git") 0o755;
@@ -269,7 +273,7 @@ let test_worktree_project_root_for_masc_dir_base () =
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let repo_root = config.base_path in
   Unix.mkdir (Filename.concat repo_root ".git") 0o755;
@@ -287,7 +291,7 @@ let test_event_log () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
 
   (* Broadcast should create event log *)
@@ -316,7 +320,7 @@ let with_test_env f =
   let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   try
     f config;
@@ -609,7 +613,7 @@ let test_event_log_on_join () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:None in
   let _ = Room.join config ~agent_name:"test_agent" ~capabilities:["ocaml"] () in
 
@@ -630,7 +634,7 @@ let test_event_log_on_claim_done () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let _ = Room.add_task config ~title:"Test" ~priority:1 ~description:"" in
   let _ = Room.claim_task config ~agent_name:"claude" ~task_id:"task-001" in
@@ -1082,7 +1086,7 @@ let test_reset_clears_all_state () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let _ = Room.add_task config ~title:"Task" ~priority:1 ~description:"" in
   let _ = Room.broadcast config ~from_agent:"claude" ~content:"Hello" in
@@ -1102,7 +1106,7 @@ let test_reinit_after_reset () =
     (Printf.sprintf "masc_test_%d_%d" (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.))) in
   Unix.mkdir tmp_dir 0o755;
 
-  let config = Room.default_config tmp_dir in
+  let config = room_config tmp_dir in
   let _ = Room.init config ~agent_name:(Some "claude") in
   let _ = Room.reset config in
   (* Reinit should work *)

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -93,7 +93,7 @@ let rec rm_rf path =
 
 (* capture_stderr removed — legacy warning tests removed in room flat-path cleanup *)
 
-let test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored () =
+let test_resolve_masc_base_path_explicit_env_wins_over_git_root_resolution () =
   let scratch = Filename.temp_dir "room-utils-worktree" "" in
   let repo_root = Filename.concat scratch "repo" in
   let repo_git = Filename.concat repo_root ".git" in
@@ -111,10 +111,10 @@ let test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored () =
     [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
       ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
-      check string "ignored env still resolves git root" repo_root
+      check string "explicit env wins over git root" "/Users/dancer/me"
         (Room_utils.resolve_masc_base_path worktree_path))
 
-let test_resolve_masc_base_path_ignores_inherited_env_in_test () =
+let test_resolve_masc_base_path_preserves_explicit_env_in_test () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-requested"
   in
@@ -122,7 +122,7 @@ let test_resolve_masc_base_path_ignores_inherited_env_in_test () =
     [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
       ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
-      check string "requested temp path wins in tests" requested
+      check string "explicit env wins in tests" "/Users/dancer/me"
         (Room_utils.resolve_masc_base_path requested))
 
 let test_resolve_masc_base_path_keeps_matching_explicit_env () =
@@ -162,19 +162,19 @@ let test_resolve_masc_base_path_collapses_explicit_env_masc_dir () =
       check string "explicit .masc env collapses to parent" requested
         (Room_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_allows_test_opt_in () =
+let test_resolve_masc_base_path_preserves_explicit_env_without_opt_in () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-opt-in"
   in
   let explicit = "/Users/dancer/me" in
   with_envs
     [ ("MASC_BASE_PATH", Some explicit);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", Some "true") ]
+      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
-      check string "opt-in preserves inherited env" explicit
+      check string "explicit env preserved without opt-in" explicit
         (Room_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_ignores_dual_masc_roots_outside_test_override ()
+let test_resolve_masc_base_path_preserves_explicit_env_with_dual_masc_roots ()
     =
   let scratch = Filename.temp_dir "room-utils-dual-roots" "" in
   let requested = Filename.concat scratch "repo" in
@@ -191,10 +191,10 @@ let test_resolve_masc_base_path_ignores_dual_masc_roots_outside_test_override ()
           ("MASC_ALLOW_INHERITED_BASE_PATH", None);
           ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
         (fun () ->
-          check string "dual roots prefer requested path" requested
+          check string "dual roots still preserve explicit path" explicit
             (Room_utils.resolve_masc_base_path requested)))
 
-let test_resolve_masc_base_path_allows_dual_root_opt_in () =
+let test_resolve_masc_base_path_dual_root_opt_in_is_noop () =
   let scratch = Filename.temp_dir "room-utils-dual-opt-in" "" in
   let requested = Filename.concat scratch "repo" in
   let explicit = Filename.concat scratch "parent-root" in
@@ -210,7 +210,7 @@ let test_resolve_masc_base_path_allows_dual_root_opt_in () =
           ("MASC_ALLOW_INHERITED_BASE_PATH", Some "true");
           ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
         (fun () ->
-          check string "opt-in preserves explicit dual-root env" explicit
+          check string "dual-root opt-in no longer changes result" explicit
             (Room_utils.resolve_masc_base_path requested)))
 
 let test_resolve_masc_base_path_preserves_ancestor_explicit_path () =
@@ -242,7 +242,7 @@ let test_default_config_syncs_test_base_path_env () =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-sync-env"
   in
   with_envs
-    [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
+    [ ("MASC_BASE_PATH", None);
       ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
       ignore (Room_utils.default_config requested);
@@ -652,22 +652,22 @@ let () =
       test_case "empty" `Quick test_parse_gitdir_empty;
       test_case "nested" `Quick test_parse_gitdir_nested_worktree;
       test_case "with spaces" `Quick test_parse_gitdir_with_spaces;
-      test_case "ignored env keeps git-root resolution" `Quick
-        test_resolve_masc_base_path_keeps_git_root_resolution_when_env_ignored;
-      test_case "ignores inherited base env in tests" `Quick
-        test_resolve_masc_base_path_ignores_inherited_env_in_test;
+      test_case "explicit env wins over git-root resolution" `Quick
+        test_resolve_masc_base_path_explicit_env_wins_over_git_root_resolution;
+      test_case "preserves explicit base env in tests" `Quick
+        test_resolve_masc_base_path_preserves_explicit_env_in_test;
       test_case "keeps matching explicit env" `Quick
         test_resolve_masc_base_path_keeps_matching_explicit_env;
       test_case "collapses requested .masc path" `Quick
         test_resolve_masc_base_path_collapses_requested_masc_dir;
       test_case "collapses explicit .masc env" `Quick
         test_resolve_masc_base_path_collapses_explicit_env_masc_dir;
-      test_case "allows explicit opt-in to inherited env" `Quick
-        test_resolve_masc_base_path_allows_test_opt_in;
-      test_case "ignores dual .masc roots by default" `Quick
-        test_resolve_masc_base_path_ignores_dual_masc_roots_outside_test_override;
-      test_case "allows dual-root opt-in" `Quick
-        test_resolve_masc_base_path_allows_dual_root_opt_in;
+      test_case "preserves explicit env without opt-in" `Quick
+        test_resolve_masc_base_path_preserves_explicit_env_without_opt_in;
+      test_case "preserves explicit env with dual .masc roots" `Quick
+        test_resolve_masc_base_path_preserves_explicit_env_with_dual_masc_roots;
+      test_case "dual-root opt-in is noop" `Quick
+        test_resolve_masc_base_path_dual_root_opt_in_is_noop;
       test_case "preserves ancestor explicit path" `Quick
         test_resolve_masc_base_path_preserves_ancestor_explicit_path;
       test_case "default config syncs test base env" `Quick

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -92,7 +92,7 @@ let test_detects_dual_masc_roots () =
            warning
      | None -> false)
 
-let test_strict_violation_respects_env () =
+let test_dual_roots_are_always_strict_violation () =
   with_temp_dir "base-path-strict" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -100,7 +100,7 @@ let test_strict_violation_respects_env () =
   Unix.mkdir effective 0o755;
   Unix.mkdir (Filename.concat cwd ".masc") 0o755;
   Unix.mkdir (Filename.concat effective ".masc") 0o755;
-  with_env "MASC_BASE_PATH_STRICT" (Some "true") @@ fun () ->
+  with_env "MASC_BASE_PATH_STRICT" (Some "false") @@ fun () ->
   let diag =
     Server_base_path_diagnostics.detect ~cwd
       ~effective_base_path:effective
@@ -111,7 +111,7 @@ let test_strict_violation_respects_env () =
   Alcotest.(check bool) "strict violation" true
     (Server_base_path_diagnostics.strict_violation diag)
 
-let test_explicit_resolution_source_bypasses_strict_violation () =
+let test_explicit_resolution_source_still_violates () =
   with_temp_dir "base-path-explicit" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -130,7 +130,7 @@ let test_explicit_resolution_source_bypasses_strict_violation () =
       ()
   in
   Alcotest.(check bool) "strict enabled" true diag.fail_fast_enabled;
-  Alcotest.(check bool) "explicit source skips strict violation" false
+  Alcotest.(check bool) "explicit source still violates" true
     (Server_base_path_diagnostics.strict_violation diag)
 
 let test_to_yojson_exposes_effective_paths () =
@@ -170,7 +170,7 @@ let test_to_yojson_exposes_resolution_source () =
   Alcotest.(check string) "resolution source" "explicit_cli"
     (json |> member "resolution_source" |> to_string)
 
-let test_default_base_path_sanitizes_inherited_dual_roots () =
+let test_default_base_path_preserves_explicit_parent_root () =
   with_temp_dir "base-path-default" @@ fun root ->
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
@@ -180,12 +180,11 @@ let test_default_base_path_sanitizes_inherited_dual_roots () =
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
-  with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
-  Alcotest.(check string) "default base path ignores inherited parent root"
-    (canonical_path repo)
+  Alcotest.(check string) "default base path preserves explicit parent root"
+    (canonical_path base_path)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
-let test_default_base_path_respects_opt_in_for_inherited_root () =
+let test_default_base_path_preserves_explicit_root_without_opt_in () =
   with_temp_dir "base-path-default-optin" @@ fun root ->
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
@@ -195,8 +194,7 @@ let test_default_base_path_respects_opt_in_for_inherited_root () =
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
-  with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "1") @@ fun () ->
-  Alcotest.(check string) "opt-in keeps inherited root"
+  Alcotest.(check string) "explicit root preserved without opt-in"
     (canonical_path base_path)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
@@ -209,7 +207,6 @@ let test_default_base_path_keeps_inherited_root_without_local_masc () =
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
-  with_env "MASC_ALLOW_INHERITED_BASE_PATH" (Some "") @@ fun () ->
   Alcotest.(check string) "default base path keeps inherited root without local .masc"
     (canonical_path base_path)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
@@ -221,20 +218,21 @@ let () =
         [
           Alcotest.test_case "detects dual .masc roots" `Quick
             test_detects_dual_masc_roots;
-          Alcotest.test_case "strict violation respects env" `Quick
-            test_strict_violation_respects_env;
+          Alcotest.test_case "dual roots are always strict violation" `Quick
+            test_dual_roots_are_always_strict_violation;
           Alcotest.test_case
-            "explicit resolution source bypasses strict violation"
+            "explicit resolution source still violates"
             `Quick
-            test_explicit_resolution_source_bypasses_strict_violation;
+            test_explicit_resolution_source_still_violates;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
           Alcotest.test_case "json exposes resolution source" `Quick
             test_to_yojson_exposes_resolution_source;
-          Alcotest.test_case "default base path sanitizes inherited parent root"
-            `Quick test_default_base_path_sanitizes_inherited_dual_roots;
-          Alcotest.test_case "default base path honors inherited opt-in" `Quick
-            test_default_base_path_respects_opt_in_for_inherited_root;
+          Alcotest.test_case "default base path preserves explicit parent root"
+            `Quick test_default_base_path_preserves_explicit_parent_root;
+          Alcotest.test_case
+            "default base path preserves explicit root without opt-in"
+            `Quick test_default_base_path_preserves_explicit_root_without_opt_in;
           Alcotest.test_case
             "default base path keeps inherited root without local .masc"
             `Quick test_default_base_path_keeps_inherited_root_without_local_masc;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -18,6 +18,11 @@ let with_pg_envs f =
   with_env "SUPABASE_DB_URL" (Some "postgresql://supabase/db") @@ fun () ->
   with_env "SB_PG_URL" (Some "postgresql://sb/db") f
 
+let with_clean_base_path_env f =
+  with_env "MASC_BASE_PATH" None @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
+  with_env "MASC_BASE_PATH_RESOLUTION_SOURCE" None f
+
 let write_file path content =
   Out_channel.with_open_bin path (fun oc -> output_string oc content)
 
@@ -51,7 +56,8 @@ let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
   Sys.remove dir;
   Unix.mkdir dir 0o755;
-  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+  Fun.protect ~finally:(fun () -> rm_rf dir)
+    (fun () -> with_clean_base_path_env (fun () -> f dir))
 
 let with_cwd path f =
   let saved = Sys.getcwd () in

--- a/test/test_task_sandbox.ml
+++ b/test/test_task_sandbox.ml
@@ -32,9 +32,14 @@ let make_temp_dir () =
 (** Run in temp dir without git (to test error paths). *)
 let with_non_git_room f =
   let dir = make_temp_dir () in
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
+    (match saved_base with
+     | Some v -> Unix.putenv "MASC_BASE_PATH" v
+     | None -> Unix.putenv "MASC_BASE_PATH" "");
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
   ) (fun () ->
+    Unix.putenv "MASC_BASE_PATH" dir;
     let config = Room.default_config dir in
     let _msg = Room.init config ~agent_name:None in
     f dir config
@@ -187,13 +192,30 @@ let run_cmd cmd =
   if exit_code <> 0 then
     failwith (Printf.sprintf "command failed (exit %d): %s" exit_code cmd)
 
+let seed_playground_clone ~base_path ~agent_name ~source_repo =
+  let repos_dir =
+    Filename.concat base_path
+      (Printf.sprintf ".masc/playground/%s/repos" agent_name)
+  in
+  let clone_path = Filename.concat repos_dir (Filename.basename source_repo) in
+  Fs_compat.mkdir_p repos_dir;
+  if Sys.file_exists clone_path then
+    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote clone_path)));
+  run_cmd (Printf.sprintf "git clone %s %s"
+    (Filename.quote source_repo) (Filename.quote clone_path));
+  clone_path
+
 let test_full_lifecycle () =
   let base = make_temp_dir () in
   let dir = base in
   let bare_dir = base ^ "-bare" in
   (* Remove the empty dir first since git clone wants a non-existent target *)
   ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
+    (match saved_base with
+     | Some v -> Unix.putenv "MASC_BASE_PATH" v
+     | None -> Unix.putenv "MASC_BASE_PATH" "");
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
   ) (fun () ->
@@ -223,10 +245,15 @@ let test_full_lifecycle () =
       let cwd = Eio.Stdenv.cwd env in
       Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock;
 
+      Unix.putenv "MASC_BASE_PATH" dir;
       let config = Room.default_config dir in
       let _msg = Room.init config ~agent_name:None in
       let _join = Room.join config ~agent_name:"lifecycle-agent"
         ~capabilities:["test"] () in
+      let clone_path =
+        seed_playground_clone ~base_path:dir
+          ~agent_name:"lifecycle-agent" ~source_repo:dir
+      in
 
       match Task_sandbox.create ~config ~task_id:"task-life"
               ~agent_name:"lifecycle-agent" () with
@@ -271,7 +298,8 @@ let test_full_lifecycle () =
         (match Task_sandbox.cleanup ~config ~agent_name:"lifecycle-agent" sb with
          | Ok changed ->
            check bool "cleanup returned files" true (List.length changed >= 0);
-           check bool "worktree removed" false (Sys.file_exists path_before)
+           check bool "worktree removed" false (Sys.file_exists path_before);
+           check bool "clone still exists" true (Sys.file_exists clone_path)
          | Error e ->
            (* On some platforms cleanup may fail but we should not crash *)
            Printf.eprintf "[WARN] cleanup error (acceptable in CI): %s\n%!" e)
@@ -283,7 +311,11 @@ let test_with_sandbox_lifecycle () =
   let dir = base in
   let bare_dir = base ^ "-bare" in
   ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
+    (match saved_base with
+     | Some v -> Unix.putenv "MASC_BASE_PATH" v
+     | None -> Unix.putenv "MASC_BASE_PATH" "");
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
   ) (fun () ->
@@ -311,10 +343,15 @@ let test_with_sandbox_lifecycle () =
       let cwd = Eio.Stdenv.cwd env in
       Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock;
 
+      Unix.putenv "MASC_BASE_PATH" dir;
       let config = Room.default_config dir in
       let _msg = Room.init config ~agent_name:None in
       let _join = Room.join config ~agent_name:"with-agent"
         ~capabilities:["test"] () in
+      let _clone_path =
+        seed_playground_clone ~base_path:dir
+          ~agent_name:"with-agent" ~source_repo:dir
+      in
 
       match Task_sandbox.with_sandbox ~config ~task_id:"task-with"
               ~agent_name:"with-agent"
@@ -333,7 +370,11 @@ let test_with_sandbox_cleans_up_on_exception () =
   let dir = base in
   let bare_dir = base ^ "-bare" in
   ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
+  let saved_base = Sys.getenv_opt "MASC_BASE_PATH" in
   Fun.protect ~finally:(fun () ->
+    (match saved_base with
+     | Some v -> Unix.putenv "MASC_BASE_PATH" v
+     | None -> Unix.putenv "MASC_BASE_PATH" "");
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)));
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote bare_dir)))
   ) (fun () ->
@@ -361,10 +402,15 @@ let test_with_sandbox_cleans_up_on_exception () =
       let cwd = Eio.Stdenv.cwd env in
       Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock;
 
+      Unix.putenv "MASC_BASE_PATH" dir;
       let config = Room.default_config dir in
       let _msg = Room.init config ~agent_name:None in
       let _join = Room.join config ~agent_name:"exc-agent"
         ~capabilities:["test"] () in
+      let _clone_path =
+        seed_playground_clone ~base_path:dir
+          ~agent_name:"exc-agent" ~source_repo:dir
+      in
 
       let worktree_path_ref = ref "" in
       (try


### PR DESCRIPTION
## What changed
- remove inherited/dual-root base-path fallback behavior and make `MASC_BASE_PATH` the single authority
- reject startup when `cwd` and effective base path both have different `.masc` roots
- force keeper default read/write cwd to `basepath/.masc/playground/<keeper>/`
- require keeper worktrees to be created from playground clones, and resolve removal/cleanup from playground roots too
- add a dual-root harness that passes only when startup is rejected
- update affected tests to run with explicit base-path fixtures and the new playground-root semantics

## Why
Keepers were going silent behind a mixed runtime state:
- process `cwd` and effective base path could diverge while both had `.masc`
- operator surfaces then inspected stale state from `cwd`
- keeper shell/worktree defaults could land outside the canonical playground root

This PR removes that ambiguity instead of trying to sanitize around it.

## Impact
- server startup now fails fast on dual `.masc` roots
- keeper default cwd/worktree behavior is deterministic and always rooted under the configured base path
- docker playground mapping still works because host playground roots remain canonical

## Validation
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix test/test_server_base_path_diagnostics.ml`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix test/test_room_utils_coverage.ml`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix test/test_keeper_pr_workflow.ml`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix test/test_task_sandbox.ml`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix test/test_room.ml`
- `dune runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix test/test_start_masc_mcp_script.ml`
- `KEEP_SERVER=0 KEEP_PATHS=1 SERVER_EXE=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix/_build/default/bin/main_eio.exe CWD_PATH=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix/config /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/basepath-playground-root-fix/scripts/harness_base_path_dual_root_guard.sh`