### PR TITLE
fix(keeper): use Eio.Lazy for decision_audit env caches

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -9,15 +9,10 @@
 (* Feature flag                                                     *)
 (* ================================================================ *)
 
-(* Eio.Lazy instead of Stdlib.Lazy: concurrent Lazy.force from multiple
-   fibers raises [CamlinternalLazy.Undefined]; Eio.Lazy blocks the
-   second caller until init completes, and [cancel:`Protect] keeps
-   init running even if the forcing fiber is cancelled. *)
 let decision_layer_level_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
+  lazy (Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
 
-let decision_layer_level () = Eio.Lazy.force decision_layer_level_cached
+let decision_layer_level () = Lazy.force decision_layer_level_cached
 
 let audit_enabled () = decision_layer_level () >= 1
 
@@ -76,10 +71,9 @@ let to_json (r : decision_record) : Yojson.Safe.t =
 (* ================================================================ *)
 
 let ring_capacity_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
+  lazy (Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
 
-let ring_capacity () = max 1 (Eio.Lazy.force ring_capacity_cached)
+let ring_capacity () = max 1 (Lazy.force ring_capacity_cached)
 
 type ring = {
   buf : decision_record option array;
@@ -92,6 +86,8 @@ type ring = {
 let rings : (string, ring) Hashtbl.t = Hashtbl.create 8
 
 let flush_interval_sec_cached =
+  (* Flush cadence is only consulted from keeper runtime fibers, so use
+     Eio.Lazy here to avoid concurrent Stdlib.Lazy.force hazards. *)
   Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     Env_config_core.get_float ~default:60.0
       "MASC_DECISION_AUDIT_FLUSH_INTERVAL_SEC")

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -9,10 +9,15 @@
 (* Feature flag                                                     *)
 (* ================================================================ *)
 
+(* Eio.Lazy instead of Stdlib.Lazy: concurrent Lazy.force from multiple
+   fibers raises [CamlinternalLazy.Undefined]; Eio.Lazy blocks the
+   second caller until init completes, and [cancel:`Protect] keeps
+   init running even if the forcing fiber is cancelled. *)
 let decision_layer_level_cached =
-  lazy (Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
 
-let decision_layer_level () = Lazy.force decision_layer_level_cached
+let decision_layer_level () = Eio.Lazy.force decision_layer_level_cached
 
 let audit_enabled () = decision_layer_level () >= 1
 
@@ -71,9 +76,10 @@ let to_json (r : decision_record) : Yojson.Safe.t =
 (* ================================================================ *)
 
 let ring_capacity_cached =
-  lazy (Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
 
-let ring_capacity () = max 1 (Lazy.force ring_capacity_cached)
+let ring_capacity () = max 1 (Eio.Lazy.force ring_capacity_cached)
 
 type ring = {
   buf : decision_record option array;
@@ -86,14 +92,18 @@ type ring = {
 let rings : (string, ring) Hashtbl.t = Hashtbl.create 8
 
 let flush_interval_sec_cached =
-  lazy (Env_config_core.get_float ~default:60.0 "MASC_DECISION_AUDIT_FLUSH_INTERVAL_SEC")
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    Env_config_core.get_float ~default:60.0
+      "MASC_DECISION_AUDIT_FLUSH_INTERVAL_SEC")
 
-let flush_interval_sec () = Lazy.force flush_interval_sec_cached
+let flush_interval_sec () = Eio.Lazy.force flush_interval_sec_cached
 
 let flush_batch_size_cached =
-  lazy (Env_config_core.get_int ~default:10 "MASC_DECISION_AUDIT_FLUSH_BATCH_SIZE")
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    Env_config_core.get_int ~default:10
+      "MASC_DECISION_AUDIT_FLUSH_BATCH_SIZE")
 
-let flush_batch_size () = Lazy.force flush_batch_size_cached
+let flush_batch_size () = Eio.Lazy.force flush_batch_size_cached
 
 let get_or_create_ring name =
   match Hashtbl.find_opt rings name with


### PR DESCRIPTION
fix(keeper): use Eio.Lazy for decision_audit env caches

`lib/keeper/keeper_decision_audit.ml` cached four environment-variable
reads (`decision_layer_level`, `ring_capacity`, `flush_interval_sec`,
`flush_batch_size`) via `Stdlib.Lazy` + `Lazy.force`.

Per the project's fiber-safety rule (already enforced in
`lib/core/circuit_breaker.ml:340` and `lib/rate_limit.ml`),
`Lazy.force` from multiple fibers in the same Eio domain can raise
`CamlinternalLazy.Undefined`: once one fiber enters the lazy slot,
a second fiber that calls force before init finishes sees the slot
in an in-progress state and crashes. Any audit-path caller that races
the keepalive fiber on the same cache — for example
`audit_enabled ()` called from `append` concurrently with a keeper
cycle spinning up — is a latent crash surface.

Switch all four caches to
`Eio.Lazy.from_fun ~cancel:\`Protect` + `Eio.Lazy.force`:

- The second caller blocks on the first's init rather than racing it
- `cancel:\`Protect` keeps init running if the forcing fiber is
  cancelled mid-force, avoiding partial writes to the cache slot

Environment-variable reads are idempotent, so the change is purely
a fiber-safety upgrade — no behavior difference under single-fiber
load.

Mirrors the canonical pattern documented at
`lib/core/circuit_breaker.ml:338-344`:

> Uses [Eio.Lazy] instead of [Stdlib.Lazy] because [Lazy.force] is
> not fiber-safe: concurrent forcing raises
> [CamlinternalLazy.Undefined]. [Eio.Lazy] blocks the second caller
> until init completes. [cancel:`Protect] ensures init finishes
> even if the forcing fiber is cancelled.

## Verification

```
dune build --root . lib/keeper/   # exit 0
```

Full `dune build lib/` currently fails on main because of an
unrelated pre-existing issue in `lib/grpc/masc_grpc_client.ml` (the
`push_typed` polymorphic-variant rework from the PR #6529 merge has
a type mismatch at line 116-121: `try/with` branch returns the
delivery variant but is used in a sequence position). That breakage
is not introduced by this patch — it's fixed upstream and my change
is confined to `lib/keeper/keeper_decision_audit.ml`.

Part of OCaml audit sweep Cycle 14 (Cat B concurrency correctness).
Follows the `Eio.Lazy` axis identified from memory feedback
`feedback_eio-lazy-over-stdlib-lazy.md` ("Eio 서버에서 Stdlib.Lazy
금지").
