### PR TITLE
chore(dashboard): remove dead SSE route entries

### DIFF
--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -92,31 +92,27 @@ interface SimpleRoute {
   debounceMs?: number
 }
 
+// Route table maps SSE event type → refresh target. Only entries whose
+// corresponding server emitter exists in lib/ are kept; dead keys were
+// removed after cross-referencing the OCaml sources under lib/.
 const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
-  // Agent lifecycle (server may emit with or without "masc/" prefix)
-  agent_joined:          { target: 'execution' },
-  'masc/agent_joined':   { target: 'execution' },
-  agent_left:            { target: 'execution' },
-  'masc/agent_left':     { target: 'execution' },
-  // Broadcasts
-  broadcast:             { target: 'execution' },
-  'masc/broadcast':      { target: 'execution' },
+  // Agent lifecycle — emitted by lib/tool_inline_dispatch_room.ml
+  'masc/agent_joined':  { target: 'execution' },
+  'masc/agent_left':    { target: 'execution' },
+  // Broadcasts — emitted by lib/tool_inline_dispatch_comm.ml
+  'masc/broadcast':     { target: 'execution' },
   // Keeper lifecycle (also triggers operator refresh via handler)
-  keeper_handoff:        { target: 'execution' },
-  keeper_compaction:     { target: 'execution' },
-  keeper_phase_changed:  { target: 'execution' },
-  // Board
-  board_post:           { target: 'board' },
+  keeper_handoff:       { target: 'execution' },
+  keeper_compaction:    { target: 'execution' },
+  keeper_phase_changed: { target: 'execution' },
+  // Board — emitted by lib/tool_inline_dispatch_extra.ml
   'masc/board_post':    { target: 'board' },
   board_comment:        { target: 'board' },
-  'masc/board_comment': { target: 'board' },
-  board_delete:         { target: 'board' },
   'masc/board_delete':  { target: 'board' },
   post_voted:           { target: 'board' },
   comment_voted:        { target: 'board' },
   // Activity graph
-  'activity':                { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
-  'masc/activity':           { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
+  activity:             { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
 }
 
 // Prefix patterns for events that use startsWith matching

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -105,10 +105,11 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   keeper_handoff:       { target: 'execution' },
   keeper_compaction:    { target: 'execution' },
   keeper_phase_changed: { target: 'execution' },
-  // Board — emitted by lib/tool_inline_dispatch_extra.ml
+  // Board content — emitted by lib/tool_inline_dispatch_extra.ml
   'masc/board_post':    { target: 'board' },
   board_comment:        { target: 'board' },
   'masc/board_delete':  { target: 'board' },
+  // Board vote notifications — emitted by lib/server/server_bootstrap_loops.ml
   post_voted:           { target: 'board' },
   comment_voted:        { target: 'board' },
   // Activity graph


### PR DESCRIPTION
## Summary

Follow-up audit after PR #6461 (which added missing vote handlers and removed dead \`client_input_*\` handlers). Cross-referenced every \`SIMPLE_ROUTES\` key in \`sse-store.ts\` against its actual emitter in \`lib/*.ml\` to find keys that were registered but never reachable at runtime.

## Dead entries removed

| Key | Reason |
|---|---|
| \`agent_joined\` | server only emits \`masc/agent_joined\` (\`lib/tool_inline_dispatch_room.ml:311\`) |
| \`agent_left\` | server only emits \`masc/agent_left\` (\`lib/tool_inline_dispatch_room.ml:327\`) |
| \`broadcast\` | server only emits \`masc/broadcast\` (\`lib/tool_inline_dispatch_comm.ml:93\`) |
| \`board_post\` | server only emits \`masc/board_post\` (\`lib/tool_inline_dispatch_extra.ml:127\`). The bare string \`"board_post"\` appears only inside an activity-feed payload, not as an SSE event type |
| \`masc/board_comment\` | server only emits the non-prefixed \`board_comment\` (\`lib/tool_inline_dispatch_extra.ml:194\`) |
| \`board_delete\` | server only emits \`masc/board_delete\` (\`lib/tool_inline_dispatch_extra.ml:282\`) |
| \`masc/activity\` | server only emits the non-prefixed \`activity\` |

## Notes

- The stale comment \"server may emit with or without 'masc/' prefix\" is removed; the convention is actually fixed per event.
- Added brief \`// emitted by lib/...\` provenance comments for the kept keys so future audits can verify each entry quickly.
- **No runtime behaviour change**: these event names never reached the handler table at runtime; removing them only drops dead-code noise.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed — \`sse.test.ts\` covers URL builder only, not route table)