### PR TITLE
fix(cascade): drop unsupported groq labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Full list: `lib/config/env_config_keeper.ml`. Per-keeper config: `config/keepers
 - OAS owns cascade schema, parsing, and label semantics.
 - MASC uses that contract to choose repo-level checked-in defaults; each keeper can override via `cascade_name` in its TOML.
 - For committed defaults, prefer explicit `provider:model_id` labels instead of convenience labels.
-- Any committed `groq:*` tier requires `GROQ_API_KEY` in the runtime environment for that fallback to be usable.
+- Checked-in defaults must stay limited to providers recognized by the currently pinned OAS parser.
 - See [docs/OAS-MASC-BOUNDARY.md](docs/OAS-MASC-BOUNDARY.md), [docs/spec/13-oas-integration.md](docs/spec/13-oas-integration.md), and [docs/spec/14-configuration.md](docs/spec/14-configuration.md).
 
 ## Safe Starting Paths

--- a/config/cascade.json
+++ b/config/cascade.json
@@ -3,7 +3,6 @@
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
-    "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "local_only_models": [
@@ -13,17 +12,15 @@
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
-    "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "coding_first_models": [
     "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
-    "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "glm-coding = Coding Plan (subscription). glm = general API (pay-per-use). groq = Groq LPU ($0.29/$0.59 per M, GROQ_API_KEY). local last.",
+  "_comment": "glm-coding = Coding Plan (subscription). glm = general API (pay-per-use). local last.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -326,7 +326,6 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
 | `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
 | `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
-| `groq` | runtime env | requires `GROQ_API_KEY` |
 | `gemini` | `Gemini` | `MASC_GEMINI_DEFAULT_MODEL` |
 | `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |
 


### PR DESCRIPTION
## Summary
- remove unsupported `groq:qwen/qwen3-32b` labels from committed cascade defaults
- align README and configuration docs with the providers recognized by the currently pinned OAS parser

## Why
`test_cascade_config_validity` now hard-fails unknown providers in checked-in `config/cascade.json`. The committed `groq:*` entries are not recognized by the current parser, so every PR inherits a red `Build and Test` check from `main` even when the PR itself is unrelated.

## Impact
- checked-in cascade defaults only include providers the current runtime can parse
- `Build and Test` can go green again for unrelated PRs
- no advertised Groq fallback remains until parser support exists in the pinned OAS version

## Evidence
- local `dune test --root . test/test_cascade_config_validity.exe`
- local `env -u DUNE_RPC DUNE_BUILD_DIR=.codex_build_groq dune test --root . test/test_observability_provider_contracts.exe`

## Review evidence
- pending: direct `sb glm-text` diff review after PR creation

## Linked issue
- Refs #6550