### PR TITLE
fix(keeper): log when open_pending overwrites a Cleared reconcile record

### DIFF
--- a/lib/keeper/keeper_manual_reconcile.ml
+++ b/lib/keeper/keeper_manual_reconcile.ml
@@ -156,7 +156,23 @@ let open_pending config ~keeper_name ~blocker_class ~summary ~failure_reason
   let opened_at =
     match pending_record config keeper_name with
     | Some record -> record.opened_at
-    | None -> now_iso ()
+    | None ->
+        (* If a Cleared record exists on disk, this open overwrites its
+           resolution/cleared_at/cleared_by/idempotency_key metadata
+           silently — a contract bug tracked in #6561. Until the full
+           audit-history redesign lands, emit a warn log so the erase
+           is at least visible in operations. *)
+        (match read config keeper_name with
+         | Some { status = Cleared; cleared_at; cleared_by; _ } ->
+             Log.Keeper.warn
+               "keeper:%s manual_reconcile open_pending overwrites prior \
+                Cleared record (cleared_at=%s cleared_by=%s); audit trail \
+                for the previous clear is lost. See #6561."
+               keeper_name
+               (Option.value cleared_at ~default:"?")
+               (Option.value cleared_by ~default:"?")
+         | _ -> ());
+        now_iso ()
   in
   let record =
     {


### PR DESCRIPTION
fix(keeper): log when open_pending overwrites a Cleared reconcile record

Partial mitigation for #6561 finding 2.

`Keeper_manual_reconcile.open_pending` writes a fresh Pending record
to the same path as any existing on-disk state. When a Cleared record
already exists, the overwrite is silent: `resolution`, `cleared_at`,
`cleared_by`, `clear_idempotency_key`, and `evidence_refs` are all
wiped. Forensics/incident postmortem on "how was this keeper reconciled
last time?" is then impossible — there's no trace in logs or on disk.

The full fix requires an audit-history store (append-only log or
`.history/` directory) and is tracked in #6561. Until then, emit a
warn log with the prior clear metadata so the erasure is at least
visible in operations when it happens.

The log fires only on the Cleared path — a Pending-to-Pending
re-open is expected (same invariant that the `opened_at` preservation
branch already relies on) and does not need to warn.

## Verification

```
dune build --root . lib/keeper/   # exit 0
```

Part of OCaml audit sweep Cycle 17. Same module as Cycles 3, 5, 10
(#6497, #6518) but this finding is from a top-to-bottom deep read
rather than a grep sweep — demonstrating that `grep -> fix` audits
miss contract-level issues that only surface when the module is
read as a single unit.
