### PR TITLE
fix(keeper): review follow-ups for #6543 (Cancel bridge bt + 40-cap doc)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -304,6 +304,10 @@ module KeeperKeepalive = struct
       let per_1k = 1.5 in
       let per_turn = 30.0 in
       let context_time = Float.of_int max_context /. 1000.0 *. per_1k in
+      (* Cap at 40 effective turns even if user sets MASC_KEEPER_OAS_MAX_TURNS_PER_CALL
+         higher.  This is a deliberate safety cap: with per_turn=30s, 40 turns alone
+         consume 1200s — the entire turn_timeout_sec budget.  Users pushing beyond
+         40 turns should instead raise turn_timeout_sec or split the work. *)
       let effective_turns =
         Float.of_int (min oas_max_turns_per_call 40)
       in

--- a/lib/keeper/keeper_llm_bridge.ml
+++ b/lib/keeper/keeper_llm_bridge.ml
@@ -41,11 +41,12 @@ let run_with_timeout_and_fallback ~timeout_s fn =
        Cancelled means a parent fiber (server shutdown, global stop) requested
        cancellation — NOT a timeout. Re-raise so the keeper exits immediately
        instead of entering the retry loop. *)
+    let bt = Printexc.get_raw_backtrace () in
     let wall = elapsed () in
     Log.Keeper.warn
       "keeper_llm_bridge: OAS execution cancelled after %.1fs (re-raising; OAS context rollback only; external tool side effects are not reverted)"
       wall;
-    raise exn
+    Printexc.raise_with_backtrace exn bt
   | exn ->
     (* TLA+: HandleError -> Rollback context *)
     let bt = Printexc.get_backtrace () in


### PR DESCRIPTION
## Summary
Cross-model review (GLM-5.1) of merged PR #6543 found 2 valid issues. Addresses them as follow-up.

1. **keeper_llm_bridge.ml**: After the Cancelled branch logs via `Log.Keeper.warn`, a bare `raise exn` can lose the original cancellation backtrace if the logger happens to throw a new exception. Capture raw backtrace *before* the log call and use `Printexc.raise_with_backtrace` to preserve the original stack.

2. **env_config_keeper.ml**: The 40-turn cap on `effective_turns` was undocumented. If a user sets `MASC_KEEPER_OAS_MAX_TURNS_PER_CALL` higher than 40, the timeout budget silently under-budgets. Add a comment explaining the cap is deliberate: 40 × 30s per_turn = 1200s = `turn_timeout_sec`.

## Test plan
- [x] `dune build` clean success
- [x] `test_work_as_heartbeat.exe` — 43 tests pass
- [x] No behavior change for default config; only safer error propagation + doc clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)