### PR TITLE
fix(dashboard): standardize remaining loading states to <LoadingState>

### DIFF
--- a/dashboard/src/components/excuse-patterns.ts
+++ b/dashboard/src/components/excuse-patterns.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { Card } from './common/card'
+import { LoadingState } from './common/feedback-state'
 import { fetchExcusePatterns, updateExcusePatterns } from '../api/dashboard'
 import type { ExcusePattern } from '../api/dashboard'
 import { createAsyncResource } from '../lib/async-state'
@@ -51,7 +52,7 @@ export function ExcusePatterns() {
   if (s.status === 'loading') {
     return html`
       <${Card} title="Anti-Rationalization Excuse Patterns">
-        <div class="p-4 text-[var(--text-muted)]">핑계 패턴 로딩 중...</div>
+        <${LoadingState}>핑계 패턴 불러오는 중...<//>
       </Card>
     `
   }

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -10,6 +10,7 @@ import type { KeeperConfig } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens } from '../lib/format-number'
 import { showToast } from './common/toast'
+import { ErrorState, LoadingState } from './common/feedback-state'
 import { createAsyncResource, loaded } from '../lib/async-state'
 
 // ── State ────────────────────────────────────────────────
@@ -345,11 +346,11 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
   }
 
   if (state.status === 'loading') {
-    return html`<div class="py-3 text-xs text-[var(--text-muted)]">설정 로딩 중...</div>`
+    return html`<${LoadingState}>설정 불러오는 중...<//>`
   }
 
   if (state.status === 'error') {
-    return html`<div class="py-3 text-xs text-[var(--bad)]">${state.message}</div>`
+    return html`<${ErrorState} message=${state.message} />`
   }
 
   if (state.status !== 'loaded') return null

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -6,6 +6,7 @@ import { useEffect } from 'preact/hooks'
 import { keepers } from '../store'
 import { fetchKeeperTransitions, type KeeperTransition, type KeeperTransitionsResponse } from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
+import { LoadingState } from './common/feedback-state'
 import { getPhaseStyle } from './keeper-phase-indicator'
 
 const transitionData = signal<Map<string, KeeperTransitionsResponse>>(new Map())
@@ -114,7 +115,7 @@ export function KeeperPhaseTimeline() {
   const keeperList = keepers.value
 
   if (isLoading && data.size === 0) {
-    return html`<div class="text-[12px] text-[var(--text-muted)] py-4 text-center">페이즈 타임라인 로딩 중...</div>`
+    return html`<${LoadingState}>페이즈 타임라인 불러오는 중...<//>`
   }
 
   if (keeperList.length === 0) {

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -5,7 +5,7 @@
 import { html } from 'htm/preact'
 import { useEffect, useRef, useCallback } from 'preact/hooks'
 import { ActionButton } from '../common/button'
-import { EmptyState } from '../common/empty-state'
+import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { SessionTraceEntry } from './session-trace-entry'
 import { SessionTraceFilter } from './session-trace-filter'
 import {
@@ -122,14 +122,14 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
 
   // Loading state
   if (loading && events.length === 0) {
-    return html`<div class="py-8 text-center text-[var(--text-muted)] text-xs">활동 추적 로딩 중...</div>`
+    return html`<${LoadingState}>활동 추적 불러오는 중...<//>`
   }
 
   // Error state
   if (error) {
     return html`
-      <div class="py-4">
-        <div class="text-xs text-[var(--bad)] mb-2">${error}</div>
+      <div class="flex flex-col items-center gap-3 py-4">
+        <${ErrorState} message=${error} />
         <${ActionButton} variant="ghost" size="sm" onClick=${handleRefresh}>재시도<//>
       </div>
     `


### PR DESCRIPTION
## Summary

Follow-up to the ErrorState / LoadingState standardization passes (#6494, #6525, #6550). Four raw loading divs and a couple of adjacent error divs were still hand-rolled with ad-hoc Tailwind classes.

## Changes

| File | Raw pattern → |
|---|---|
| \`excuse-patterns.ts\` | \`핑계 패턴 로딩 중...\` → \`<LoadingState>\` |
| \`keeper-config-panel.ts\` | \`설정 로딩 중...\` → \`<LoadingState>\` + inline \`text-[var(--bad)]\` → \`<ErrorState>\` |
| \`keeper-phase-strip.ts\` | \`페이즈 타임라인 로딩 중...\` → \`<LoadingState>\` |
| \`session-trace-view.ts\` | \`활동 추적 로딩 중...\` → \`<LoadingState>\` + inline error div → \`<ErrorState>\` alongside retry button |

Imports consolidated to \`common/feedback-state.ts\`.

No behavior change beyond consistent spinner/icon treatment across these panels.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed)