### PR TITLE
feat(harness): expose cross-model enforcement rate on dashboard

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -359,6 +359,20 @@ let overview_json
     if total_verdicts = 0 then 0.0
     else float_of_int fallback_count /. float_of_int total_verdicts
   in
+  (* Cross-model enforcement ratio: of verdicts that recorded both a
+     generator and an evaluator cascade, what fraction used distinct
+     cascades? This is the *runtime* rate at which the cross-model
+     review policy (anti_rationalization.mli, #3067) actually fired. *)
+  let verdicts_with_generator =
+    Safe_ops.json_int ~default:0 "verdicts_with_generator_cascade" calibration
+  in
+  let cross_model_match =
+    Safe_ops.json_int ~default:0 "cross_model_match_count" calibration
+  in
+  let cross_model_rate =
+    if verdicts_with_generator = 0 then 0.0
+    else float_of_int cross_model_match /. float_of_int verdicts_with_generator
+  in
   let last_signal_at =
     max_timestamp verdict_last (max_timestamp pre_compact_last handoff_last)
   in
@@ -374,6 +388,9 @@ let overview_json
       ("pre_compact_last_event_at", Json_util.float_opt_to_json pre_compact_last);
       ("handoff_last_event_at", Json_util.float_opt_to_json handoff_last);
       ("fallback_ratio", `Float fallback_ratio);
+      ("cross_model_rate", `Float cross_model_rate);
+      ("cross_model_match_count", `Int cross_model_match);
+      ("verdicts_with_generator_cascade", `Int verdicts_with_generator);
       ( "latest_pre_compact_ratio",
         Json_util.float_opt_to_json (Option.map pre_compact_ratio latest_pre_compact) );
       ( "latest_handoff_generation",

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -298,6 +298,12 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
   let recent_fallback_reasons : string list ref = ref [] in
   let max_fallback_reasons = 5 in
   let fallback_tag = Anti_rationalization.gate_to_string Fallback in
+  (* Cross-model accounting: how many verdicts were produced by an
+     evaluator cascade distinct from the generator cascade? This is
+     the *runtime enforcement* rate of the cross-model review policy
+     declared in anti_rationalization.mli (#3067). *)
+  let verdicts_with_generator = ref 0 in
+  let cross_model_match = ref 0 in
   List.iter (fun json ->
     let rt = string_field json "record_type" in
     let hash = string_field json "notes_hash" in
@@ -310,6 +316,13 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
       let prev = Option.value ~default:0 (Hashtbl.find_opt gate_counts gate) in
       Hashtbl.replace gate_counts gate (prev + 1);
       Hashtbl.replace verdict_hashes hash v;
+      let ev_cascade = string_field json "evaluator_cascade" in
+      let gen_cascade = string_field json "generator_cascade" in
+      if gen_cascade <> "" && ev_cascade <> "" then begin
+        incr verdicts_with_generator;
+        if not (String.equal gen_cascade ev_cascade) then
+          incr cross_model_match
+      end;
       if gate = fallback_tag && List.length !recent_fallback_reasons < max_fallback_reasons then
         (let reason = string_field json "fallback_reason" in
          if reason <> "" then
@@ -344,6 +357,10 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
     Option.value ~default:0
       (Hashtbl.find_opt gate_counts (Anti_rationalization.gate_to_string Fallback))
   in
+  let cross_model_rate =
+    if !verdicts_with_generator = 0 then 0.0
+    else float_of_int !cross_model_match /. float_of_int !verdicts_with_generator
+  in
   `Assoc [
     ("total_verdicts", `Int !total_verdicts);
     ("approve_count", `Int !approve_count);
@@ -354,6 +371,9 @@ let calibration_stats ?(since = "") ?(until = "") () : Yojson.Safe.t =
     ("false_negative_count", `Int !false_neg);
     ("agreement_rate", `Float agreement_rate);
     ("fallback_count", `Int fallback_count);
+    ("verdicts_with_generator_cascade", `Int !verdicts_with_generator);
+    ("cross_model_match_count", `Int !cross_model_match);
+    ("cross_model_rate", `Float cross_model_rate);
     ("recent_fallback_reasons",
      `List (List.rev_map (fun s -> `String s) !recent_fallback_reasons));
   ]

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -65,6 +65,15 @@ let review_completion_notes
                        ("verdict", `String (verdict_to_string result));
                        ( "evaluator_cascade",
                          `String result.evaluator_cascade );
+                       ( "generator_cascade",
+                         match result.generator_cascade with
+                         | Some c -> `String c
+                         | None -> `Null );
+                       ( "cross_model",
+                         `Bool
+                           (match result.generator_cascade with
+                            | Some g -> not (String.equal g result.evaluator_cascade)
+                            | None -> false) );
                        ( "fallback_reason",
                          match result.fallback_reason with
                          | Some reason -> `String reason

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -25,6 +25,54 @@ let verdict_to_string (result : Anti_rationalization.review_result) =
   | Anti_rationalization.Approve -> "approve"
   | Anti_rationalization.Reject reason -> "reject:" ^ reason
 
+(** True when both cascades are non-empty AND distinct.
+
+    Must match {!Eval_calibration.calibration_stats} inclusion criteria
+    exactly (both [evaluator_cascade <> ""] and [generator_cascade <> ""])
+    so that a real-time SSE event and the aggregated cross_model_rate
+    agree on which verdicts count as cross-model. *)
+let is_cross_model_verdict (result : Anti_rationalization.review_result) : bool =
+  match result.generator_cascade with
+  | None -> false
+  | Some g ->
+    g <> ""
+    && result.evaluator_cascade <> ""
+    && not (String.equal g result.evaluator_cascade)
+
+(** Build the [verdict_recorded] SSE payload for a finished review.
+
+    Pure function: no IO, no broadcast, no logging. Extracted so the
+    payload contract can be exercised by unit tests. *)
+let build_verdict_sse_payload
+    ~(now : float)
+    ~(task_id : string)
+    ~(req : Anti_rationalization.review_request)
+    ~(result : Anti_rationalization.review_result) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("type", `String "oas:masc:harness:verdict_recorded");
+      ( "payload",
+        `Assoc
+          [
+            ("timestamp", `Float now);
+            ("task_id", `String task_id);
+            ("task_title", `String req.task_title);
+            ("agent_name", `String req.agent_name);
+            ("gate", `String (Anti_rationalization.gate_to_string result.gate));
+            ("verdict", `String (verdict_to_string result));
+            ("evaluator_cascade", `String result.evaluator_cascade);
+            ( "generator_cascade",
+              match result.generator_cascade with
+              | Some c -> `String c
+              | None -> `Null );
+            ("cross_model", `Bool (is_cross_model_verdict result));
+            ( "fallback_reason",
+              match result.fallback_reason with
+              | Some reason -> `String reason
+              | None -> `Null );
+          ] );
+    ]
+
 (** Validate task_id is non-empty. Prevents phantom operations on empty IDs. *)
 let validate_task_id task_id =
   if task_id = "" then Error (Types.TaskNotFound "")
@@ -51,35 +99,9 @@ let review_completion_notes
           ~task_id ~req:ar_req ~result ();
         (try
            Sse.broadcast
-             (`Assoc
-               [
-                 ("type", `String "oas:masc:harness:verdict_recorded");
-                 ( "payload",
-                   `Assoc
-                     [
-                       ("timestamp", `Float (Time_compat.now ()));
-                       ("task_id", `String task_id);
-                       ("task_title", `String ar_req.task_title);
-                       ("agent_name", `String ar_req.agent_name);
-                       ("gate", `String (Anti_rationalization.gate_to_string result.gate));
-                       ("verdict", `String (verdict_to_string result));
-                       ( "evaluator_cascade",
-                         `String result.evaluator_cascade );
-                       ( "generator_cascade",
-                         match result.generator_cascade with
-                         | Some c -> `String c
-                         | None -> `Null );
-                       ( "cross_model",
-                         `Bool
-                           (match result.generator_cascade with
-                            | Some g -> not (String.equal g result.evaluator_cascade)
-                            | None -> false) );
-                       ( "fallback_reason",
-                         match result.fallback_reason with
-                         | Some reason -> `String reason
-                         | None -> `Null );
-                     ] );
-               ])
+             (build_verdict_sse_payload
+                ~now:(Time_compat.now ())
+                ~task_id ~req:ar_req ~result)
          with
         | Eio.Cancel.Cancelled _ as e -> raise e
         | exn ->

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -24,3 +24,27 @@ val handle_archive_view : context -> Yojson.Safe.t -> tool_result
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> tool_result option
 
 val schemas : Types.tool_schema list
+
+(** [is_cross_model_verdict result] is [true] iff [result] has both
+    [generator_cascade = Some g] and [evaluator_cascade] non-empty,
+    and [g <> evaluator_cascade].
+
+    Inclusion criteria align exactly with
+    {!Eval_calibration.calibration_stats} so the live SSE event and
+    the aggregated [cross_model_rate] never disagree on whether a
+    given verdict counts. *)
+val is_cross_model_verdict : Anti_rationalization.review_result -> bool
+
+(** [build_verdict_sse_payload ~now ~task_id ~req ~result] builds the
+    [verdict_recorded] SSE envelope for a finished review.
+
+    Pure function — no IO, no broadcast, no logging. Exposed so that
+    the payload contract (field names, nullability, [cross_model]
+    semantics) can be exercised by unit tests without touching
+    Sse.broadcast or the review pipeline. *)
+val build_verdict_sse_payload :
+  now:float ->
+  task_id:string ->
+  req:Anti_rationalization.review_request ->
+  result:Anti_rationalization.review_result ->
+  Yojson.Safe.t

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -277,6 +277,55 @@ let test_calibration_stats () =
   check int "total = 3" 3 total;
   check int "approves = 2" 2 approves;
   check int "rejects = 1" 1 rejects;
+  (* None of the above passed ~gen_cascade, so the cross-model
+     counters should be zero and the rate degenerate to 0.0. *)
+  let with_gen =
+    Yojson.Safe.Util.(stats |> member "verdicts_with_generator_cascade" |> to_int) in
+  let cross_match =
+    Yojson.Safe.Util.(stats |> member "cross_model_match_count" |> to_int) in
+  let cross_rate =
+    Yojson.Safe.Util.(stats |> member "cross_model_rate" |> to_number) in
+  check int "verdicts_with_generator_cascade = 0 when not recorded" 0 with_gen;
+  check int "cross_model_match_count = 0 when no generator" 0 cross_match;
+  check (float 1e-6) "cross_model_rate = 0.0 when no generator" 0.0 cross_rate;
+  Cal.reset_store_for_testing ()
+
+let test_calibration_stats_cross_model_mix () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir () in
+  Cal.set_store_for_testing ~base_dir:dir;
+  (* Four verdicts:
+     - same cascade (generator = evaluator)     → NOT cross-model
+     - distinct cascade (generator ≠ evaluator) → cross-model
+     - distinct cascade                          → cross-model
+     - no generator recorded                     → excluded from denominator
+     Expected: denominator=3, cross_match=2, rate=2/3 ≈ 0.667. *)
+  let same_cascade =
+    make_result ~cascade:"verifier" ~gen_cascade:"verifier" () in
+  let cross_a =
+    make_result ~cascade:"verifier" ~gen_cascade:"keeper_unified" () in
+  let cross_b =
+    make_result ~cascade:"cross_verifier" ~gen_cascade:"local_only" () in
+  let no_generator = make_result ~cascade:"verifier" () in
+  let req = make_req () in
+  Cal.record_verdict ~task_id:"cm1"
+    ~req:(make_req ~title:"a" ~notes:"na" ()) ~result:same_cascade ();
+  Cal.record_verdict ~task_id:"cm2"
+    ~req:(make_req ~title:"b" ~notes:"nb" ()) ~result:cross_a ();
+  Cal.record_verdict ~task_id:"cm3"
+    ~req:(make_req ~title:"c" ~notes:"nc" ()) ~result:cross_b ();
+  Cal.record_verdict ~task_id:"cm4" ~req ~result:no_generator ();
+  let stats = Cal.calibration_stats () in
+  let with_gen =
+    Yojson.Safe.Util.(stats |> member "verdicts_with_generator_cascade" |> to_int) in
+  let cross_match =
+    Yojson.Safe.Util.(stats |> member "cross_model_match_count" |> to_int) in
+  let cross_rate =
+    Yojson.Safe.Util.(stats |> member "cross_model_rate" |> to_number) in
+  check int "verdicts_with_generator_cascade = 3 (one was Null)" 3 with_gen;
+  check int "cross_model_match_count = 2 (two distinct)" 2 cross_match;
+  check (float 1e-3) "cross_model_rate ≈ 0.667" (2.0 /. 3.0) cross_rate;
   Cal.reset_store_for_testing ()
 
 (* ================================================================ *)
@@ -396,6 +445,7 @@ let () =
     ];
     "stats", [
       test_case "counts" `Quick test_calibration_stats;
+      test_case "cross_model mix" `Quick test_calibration_stats_cross_model_mix;
     ];
     "oas_conversion", [
       test_case "approve verdict" `Quick test_to_harness_verdict_approve;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -601,4 +601,114 @@ let () = test "get_int_opt_missing" (fun () ->
   assert (Tool_args.get_int_opt args "key" = None)
 )
 
+(* ================================================================ *)
+(* verdict_recorded SSE payload contract                             *)
+(*                                                                   *)
+(* The payload is built by Tool_task.build_verdict_sse_payload —     *)
+(* a pure helper — so dashboard subscribers depend on a stable       *)
+(* JSON shape. The cross_model bool must match Eval_calibration's    *)
+(* inclusion rule (both cascades non-empty AND distinct).            *)
+(* ================================================================ *)
+
+let make_review_request () : Anti_rationalization.review_request =
+  { task_title = "Fix login bug";
+    task_description = "desc";
+    completion_notes = "notes";
+    agent_name = "dreamer" }
+
+let make_review_result
+    ?(verdict = Anti_rationalization.Approve)
+    ?(evaluator_cascade = "verifier")
+    ?generator_cascade
+    ?(gate = Anti_rationalization.Structured_tool)
+    ?fallback_reason
+    () : Anti_rationalization.review_result =
+  { verdict; evaluator_cascade; generator_cascade; gate; fallback_reason }
+
+let payload_member key (json : Yojson.Safe.t) : Yojson.Safe.t =
+  match json with
+  | `Assoc fields -> List.assoc "payload" fields |> (function
+      | `Assoc payload_fields -> List.assoc key payload_fields
+      | _ -> failwith "payload is not an object")
+  | _ -> failwith "top-level is not an object"
+
+let () = test "build_verdict_sse_payload: distinct cascades = cross_model true" (fun () ->
+  let req = make_review_request () in
+  let result =
+    make_review_result
+      ~evaluator_cascade:"verifier"
+      ~generator_cascade:"keeper_unified"
+      () in
+  let json = Tool_task.build_verdict_sse_payload
+    ~now:1234567890.0 ~task_id:"t1" ~req ~result in
+  assert (payload_member "cross_model" json = `Bool true);
+  assert (payload_member "generator_cascade" json = `String "keeper_unified");
+  assert (payload_member "evaluator_cascade" json = `String "verifier");
+  assert (payload_member "task_id" json = `String "t1")
+)
+
+let () = test "build_verdict_sse_payload: same cascade = cross_model false" (fun () ->
+  let req = make_review_request () in
+  let result =
+    make_review_result
+      ~evaluator_cascade:"verifier"
+      ~generator_cascade:"verifier"
+      () in
+  let json = Tool_task.build_verdict_sse_payload
+    ~now:1234567890.0 ~task_id:"t2" ~req ~result in
+  assert (payload_member "cross_model" json = `Bool false);
+  assert (payload_member "generator_cascade" json = `String "verifier")
+)
+
+let () = test "build_verdict_sse_payload: no generator = cross_model false + null" (fun () ->
+  let req = make_review_request () in
+  let result =
+    make_review_result ~evaluator_cascade:"verifier" () in
+  let json = Tool_task.build_verdict_sse_payload
+    ~now:1234567890.0 ~task_id:"t3" ~req ~result in
+  assert (payload_member "cross_model" json = `Bool false);
+  assert (payload_member "generator_cascade" json = `Null)
+)
+
+let () = test "build_verdict_sse_payload: empty generator string = cross_model false" (fun () ->
+  (* Defensive: align with Eval_calibration which excludes empty
+     strings from the denominator. Without this guard SSE and stats
+     would disagree when a cascade is empty. *)
+  let req = make_review_request () in
+  let result =
+    make_review_result
+      ~evaluator_cascade:"verifier"
+      ~generator_cascade:""
+      () in
+  let json = Tool_task.build_verdict_sse_payload
+    ~now:1234567890.0 ~task_id:"t4" ~req ~result in
+  assert (payload_member "cross_model" json = `Bool false);
+  assert (payload_member "generator_cascade" json = `String "")
+)
+
+let () = test "build_verdict_sse_payload: empty evaluator string = cross_model false" (fun () ->
+  let req = make_review_request () in
+  let result =
+    make_review_result
+      ~evaluator_cascade:""
+      ~generator_cascade:"keeper_unified"
+      () in
+  let json = Tool_task.build_verdict_sse_payload
+    ~now:1234567890.0 ~task_id:"t5" ~req ~result in
+  assert (payload_member "cross_model" json = `Bool false)
+)
+
+let () = test "build_verdict_sse_payload: fallback_reason serialized" (fun () ->
+  let req = make_review_request () in
+  let result =
+    make_review_result
+      ~fallback_reason:"llm timeout"
+      ~gate:Anti_rationalization.Fallback
+      () in
+  let json = Tool_task.build_verdict_sse_payload
+    ~now:1234567890.0 ~task_id:"t6" ~req ~result in
+  assert (payload_member "fallback_reason" json = `String "llm timeout");
+  assert (payload_member "gate" json = `String "fallback")
+)
+
 let () = Printf.printf "\n✅ All Tool_task tests passed!\n"


### PR DESCRIPTION
## Summary

P1-2 from the multi-agent coordination improvement plan (follows #6556). Make the runtime cross-model enforcement rate of the anti_rationalization gate visible on the dashboard, so a misconfigured cascade cannot regress silently.

- **Observation-only**. No policy change, no cascade routing change.
- **MASC-side only**. OAS API untouched.
- **Additive SSE payload**. Existing subscribers are not broken.

## Why

`anti_rationalization.review` has supported cross-model separation since #3067 (the [`evaluator_cascade` / `generator_cascade`] pair on `review_result`). The policy is: generator ≠ reviewer. But the dashboard had no signal for how often that policy actually fired at runtime. A misconfigured `default_cascade_name` or a regression in cascade selection could silently produce 100% self-reviewed verdicts.

This PR surfaces the runtime rate.

## What changed

| File | Change | Rationale |
|---|---|---|
| `lib/tool_task.ml` | SSE `verdict_recorded` payload gains `generator_cascade` (nullable) and derived `cross_model` bool | Subscribers can bucket without re-querying JSONL |
| `lib/eval_calibration.ml` | `calibration_stats()` counts `verdicts_with_generator_cascade` + `cross_model_match_count` + `cross_model_rate` | Read-side aggregation over existing schema |
| `lib/dashboard/dashboard_harness_health.ml` | `overview_json()` surfaces `cross_model_rate` at the top level | Operator-visible metric |
| `test/test_eval_calibration.ml` | +1 test: `stats/cross_model mix` (4 verdicts, asserts 2/3 = 0.667) | Deterministic aggregation proof |

No schema migration. `record_verdict` already persists `evaluator_cascade` and `generator_cascade` to the JSONL store.

## Det / NonDet

- **Deterministic** (covered by the new test): JSONL → counters → JSON payload. 4-verdict fixture with mixed cascades asserts exact 2/3 ratio within 1e-3.
- **Non-deterministic** (out of scope for this PR): the LLM verdicts themselves. Gate mechanics are unchanged.

## OAS boundary

All changes are MASC-side. Cascade selection still lives in `keeper_config.ml` (`default_cascade_name = "keeper_unified"`) and `anti_rationalization.mli` (`~evaluator_cascade`). This PR observes, does not decide.

## Tests

| Suite | Result |
|---|---|
| `test_eval_calibration` | 22/22 (new: `stats/cross_model mix`) |
| `test_dashboard_harness_health` | 6/6 |
| `test_tool_task_coverage` | all pass |
| `test_anti_rationalization_coverage` | all pass |

## Future work (not in this PR)

- Downgrade `evaluator_status` to `Warning` when `cross_model_rate` falls below a configured threshold. Would require a new `runtime_params` surface for the threshold (`harness.cross_model_rate_floor` or similar).
- Expose `cross_model_rate` on the text dashboard in the Swarm Health section. Today it's only in the HTTP overview JSON; `dashboard.ml` would need to read it via `Safe_ops.json_float`.

## Test plan

- [x] `dune build` — exit 0
- [x] `dune runtest test/test_eval_calibration.exe` — 22/22
- [x] `dune runtest test/test_dashboard_harness_health.exe` — 6/6
- [x] `dune runtest test/test_tool_task_coverage.exe` — pass
- [x] `dune runtest test/test_anti_rationalization_coverage.exe` — pass
- [ ] Cross-model review (GLM-5.1)
- [ ] Manual: run a keeper through a verdict, curl `/harness/health`, confirm `cross_model_rate` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)