### PR TITLE
perf(dashboard): drop 60fps rAF loop from session-progress ElapsedTimer

### DIFF
--- a/dashboard/src/components/session-progress-header.ts
+++ b/dashboard/src/components/session-progress-header.ts
@@ -2,7 +2,7 @@
 // Lightweight: all metric KPIs live in KpiGrid to avoid duplication.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import type { Keeper } from '../types'
 import { formatDuration } from './tool-call-shared'
@@ -47,23 +47,13 @@ function statusLabel(status: string): { text: string; color: string; bgColor: st
 
 function ElapsedTimer({ startMs }: { startMs: number }) {
   const elapsed = useSignal(Date.now() - startMs)
-  const rafRef = useRef<number>(0)
 
   useEffect(() => {
-    let mounted = true
-    const tick = () => {
-      if (!mounted) return
+    // Format granularity is seconds, so a 1 Hz tick is sufficient.
+    const interval = setInterval(() => {
       elapsed.value = Date.now() - startMs
-      rafRef.current = requestAnimationFrame(tick)
-    }
-    // Update once per second instead of every frame
-    const interval = setInterval(() => { elapsed.value = Date.now() - startMs }, 1000)
-    tick()
-    return () => {
-      mounted = false
-      cancelAnimationFrame(rafRef.current)
-      clearInterval(interval)
-    }
+    }, 1000)
+    return () => clearInterval(interval)
   }, [startMs])
 
   return html`<span class="font-mono tabular-nums">${formatDuration(elapsed.value)}</span>`


### PR DESCRIPTION
## Summary

\`ElapsedTimer\` in \`session-progress-header.ts\` was running **both** a \`requestAnimationFrame\` recursion **and** a 1-second \`setInterval\`. The rAF path wrote \`elapsed.value = Date.now() - startMs\` every frame (~60 Hz) even though the rendered output goes through \`formatDuration\`, which only has second-level granularity.

The in-file comment already said _"Update once per second instead of every frame"_ — but the rAF loop was never removed.

## Fix

Keep the 1 Hz \`setInterval\` path, delete the rAF recursion, its ref, and the extra cleanup branch.

## Impact

Every keeper-detail overlay with an open session drops from **~60 signal writes/sec → 1/sec** on this timer. Downstream \`formatDuration\` was masking the duplicate writes as visually identical, but every signal write still triggered Preact reconciliation for the \`<span>\` and any memoized parents that happened to read \`elapsed.value\`.

Pure cleanup — no API, layout, or behavior change visible to users.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed)
- [ ] Manual spot check: session overlay still updates its timer every second after merge