### PR TITLE
fix(supervisor): backoff delay uses recent (pruned) restarts, not lifetime count

### DIFF
--- a/lib/supervisor.ml
+++ b/lib/supervisor.ml
@@ -97,10 +97,17 @@ let rec start_child ~sw ~clock cs =
             end else begin
               cs.restart_count <- cs.restart_count + 1;
               cs.restart_times <- Unix.gettimeofday () :: cs.restart_times;
-              (* Backoff delay: 1s * restart_count, capped at 30s *)
-              let delay = Float.min 30.0 (Float.of_int cs.restart_count) in
-              Log.Server.info "[Supervisor] restarting %s in %.0fs (attempt %d)"
-                name delay cs.restart_count;
+              (* Backoff delay based on *recent* restarts within the window
+                 (pruned by [restart_limit_exceeded] above), not the
+                 lifetime [restart_count]. A child that crashed heavily
+                 once and has been stable for a long time deserves a
+                 short delay on a new crash — using the lifetime counter
+                 would pin it at the 30s cap forever. *)
+              let recent = List.length cs.restart_times in
+              let delay = Float.min 30.0 (Float.of_int recent) in
+              Log.Server.info
+                "[Supervisor] restarting %s in %.0fs (recent %d in %.0fs, lifetime %d)"
+                name delay recent cs.spec.restart_window_s cs.restart_count;
               Eio.Time.sleep clock delay;
               start_child ~sw ~clock cs
             end)


### PR DESCRIPTION
fix(supervisor): backoff delay uses recent (pruned) restarts, not lifetime count

`lib/supervisor.ml` had a subtle counter divergence between the
restart-limit gate and the backoff delay:

- `restart_limit_exceeded` (line 63) prunes `restart_times` to the
  recent `restart_window_s` window, then checks
  `List.length pruned >= max_restarts`. So the disable gate is
  correctly windowed.
- The backoff delay (line 101) used `cs.restart_count`, a **lifetime
  monotonic counter** that never decays. After a child hits 30+
  restarts (30s cap) at any point in its lifetime — even if they all
  happened years ago — every subsequent restart had the maximum 30s
  backoff.

Net effect: a child that crashed heavily once and ran stable for the
next 24 hours could not earn back its short 1s backoff on a new
crash. Operators would see suspiciously slow restart cycles on
otherwise-healthy children.

Use `List.length cs.restart_times` (already pruned by the gate call
above) for the delay calculation. The lifetime `restart_count` is
still incremented and exposed via `child_status` for dashboards
that want "total restarts ever".

Log line now reports both the recent window count and the lifetime
count so operators can correlate.

## Verification

```
dune build --root . lib/   # exit 0
```

## Finding source

Cycle 18 deep-read of `lib/supervisor.ml` (167 lines) — grep
audits in Cycles 1-14 focused on exception boundaries and
`Eio.Fiber.fork` wrapping. The gate/delay counter divergence is a
semantic drift that only shows up when both functions are read
side by side, not by pattern matching. Same approach as Cycle 17
PR #6562 / Issue #6561 on `keeper_manual_reconcile.ml`.
