### PR TITLE
fix(dashboard): standardize ops sub-column + activity-stream empty states

### DIFF
--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -10,6 +10,7 @@ import {
   type LiveFilterKind,
 } from '../../live-store'
 import { connected, totalEvents } from '../../sse'
+import { EmptyState, ErrorState } from '../common/feedback-state'
 import { formatTimeAgo } from '../common/time-ago'
 
 const FILTER_OPTIONS: { kind: LiveFilterKind; label: string; cssClass: string }[] = [
@@ -51,14 +52,11 @@ export function ActivityStream() {
       <${FilterBar} />
       <div class="activity-stream-list grid gap-2 content-start">
         ${entries.length === 0
-          ? html`<div class="py-6 text-center text-[13px]">
-              ${!connected.value
-                ? html`<div class="text-[var(--bad)]">실시간 연결이 끊겨있습니다. 서버 상태를 확인하세요.</div>`
-                : liveFilters.value.size > 0
-                  ? html`<div class="text-[var(--text-muted)]">선택한 필터에 맞는 이벤트가 없습니다. 필터를 해제해 보세요.</div>`
-                  : html`<div class="text-[var(--text-muted)]">아직 수신된 이벤트가 없습니다. 에이전트가 활동하면 여기에 표시됩니다.</div>`
-              }
-            </div>`
+          ? !connected.value
+            ? html`<${ErrorState} message="실시간 연결이 끊겨있습니다. 서버 상태를 확인하세요." />`
+            : liveFilters.value.size > 0
+              ? html`<${EmptyState} message="선택한 필터에 맞는 이벤트가 없습니다. 필터를 해제해 보세요." />`
+              : html`<${EmptyState} message="아직 수신된 이벤트가 없습니다. 에이전트가 활동하면 여기에 표시됩니다." />`
           : entries.map((entry, i) => html`
             <div
               key=${`${entry.timestamp}-${i}`}

--- a/dashboard/src/components/ops/ops-keeper-column.ts
+++ b/dashboard/src/components/ops/ops-keeper-column.ts
@@ -2,6 +2,7 @@
 
 import { html } from 'htm/preact'
 import { CARD_STANDARD } from '../common/card'
+import { EmptyState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { openKeeperDetail } from '../keeper-detail'
 import { findKeeper } from '../execution/shared'
@@ -85,7 +86,7 @@ export function OpsKeeperColumn() {
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45]">keeper를 선택하면 아래에서 메시지를 보내거나 상세 정보를 볼 수 있습니다.</p>
 
         <div class="flex flex-col gap-2">
-          ${keepers.length === 0 ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 보이는 keeper가 없습니다.</div>` : keepers.map(keeper => html`
+          ${keepers.length === 0 ? html`<${EmptyState} message="지금 보이는 keeper가 없습니다." compact />` : keepers.map(keeper => html`
             ${(() => {
               const tone = keeperPriorityTone(keeper)
               const prioritySummary = keeperPrioritySummary(keeper)
@@ -134,7 +135,7 @@ export function OpsKeeperColumn() {
         <p class="text-[12px] text-[var(--text-muted)] leading-[1.45] mt-3">Persistent agent alias는 같은 keeper 런타임을 호환 표기로 보여줍니다.</p>
         <div class="flex flex-col gap-2">
           ${persistentAgents.length === 0
-            ? html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">분리된 persistent agent는 없습니다.</div>`
+            ? html`<${EmptyState} message="분리된 persistent agent는 없습니다." compact />`
             : persistentAgents.map(agent => html`
                 <article key=${agent.name} class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
                   <div class="flex justify-between items-center gap-3 max-[880px]:flex-col max-[880px]:items-start">
@@ -191,14 +192,14 @@ export function OpsKeeperColumn() {
               메시지 보내기
             <//>
           </div>
-        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">키퍼를 선택하면 바로 메시지를 보낼 수 있습니다.</div>`}
+        ` : html`<${EmptyState} message="키퍼를 선택하면 바로 메시지를 보낼 수 있습니다." compact />`}
       </section>
 
       <section class="${CARD_STANDARD} flex flex-col gap-3 min-h-0">
         <h3 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider pb-2 border-b border-[var(--card-border)]">최근 개입 로그</h3>
         <div class="flex flex-col gap-2">
           ${operatorActionLog.value.length === 0 ? html`
-            <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">이 세션에서 실행한 개입이 아직 없습니다.</div>
+            <${EmptyState} message="이 세션에서 실행한 개입이 아직 없습니다." compact />
           ` : operatorActionLog.value.map(entry => html`
             <article key=${entry.id} class="py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded ${logEntryBorderClass(entry.outcome)}">
               <div class="text-[11px] text-[var(--text-muted)] whitespace-nowrap overflow-hidden text-ellipsis flex gap-2">

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -6,7 +6,7 @@ import { signal } from '@preact/signals'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
 import { useRef } from 'preact/hooks'
-import { LoadingState } from '../common/feedback-state'
+import { EmptyState, LoadingState } from '../common/feedback-state'
 import {
   operatorActionBusy,
   operatorDigestLoading,
@@ -131,7 +131,7 @@ export function OpsRoomColumn() {
             `)}
           </div>
         ` : html`
-          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">지금 떠 있는 추천 개입은 없습니다.</div>
+          <${EmptyState} message="지금 떠 있는 추천 개입은 없습니다." compact />
         `}
       </section>
 
@@ -209,11 +209,12 @@ export function OpsRoomColumn() {
             `})}
           </div>
         ` : html`
-          <div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">
-            ${pendingConfirms.length > 0
+          <${EmptyState}
+            message=${pendingConfirms.length > 0
               ? '선택한 필터에는 승인 대기가 없습니다. 전체 목록으로 돌아가서 다시 확인하세요.'
               : '지금 승인 대기는 없습니다.'}
-          </div>
+            compact
+          />
         `}
       </section>
 
@@ -348,7 +349,7 @@ export function OpsRoomColumn() {
               </article>
             `)}
           </div>
-        ` : html`<div class="p-3 rounded-xl border border-dashed border-[var(--card-border)] text-[var(--text-muted)] text-[13px]">최근 전체 메시지가 없습니다.</div>`}
+        ` : html`<${EmptyState} message="최근 전체 메시지가 없습니다." compact />`}
       </section>
     </div>
   `


### PR DESCRIPTION
## Summary

Follow-up to PR #6573 (\`ops/index.ts\` empty states). Three more files had the same \"dashed-border empty-div\" Tailwind pattern repeated across ops columns and the live activity stream.

## Changes

| File | Replacements |
|---|---|
| \`ops/ops-keeper-column.ts\` | 4 raw divs → \`<EmptyState compact>\` |
| \`ops/ops-room-column.ts\` | 3 raw divs → \`<EmptyState compact>\` |
| \`live/activity-stream.ts\` | 3 branches → \`<ErrorState>\` (disconnected) + \`<EmptyState>\` (filtered / empty) |

\`activity-stream.ts\` had a subtle bug: the \`disconnected\` state was rendered as a plain red text div with no icon. Now it uses \`<ErrorState>\` which renders an AlertTriangle icon so users notice the connection failure.

Imports consolidated to \`common/feedback-state.ts\` (already present for \`LoadingState\` in \`ops-room-column.ts\`).

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed)