### PR TITLE
fix(keeper): delete manual_reconcile file on clear to unblock legacy binaries

### DIFF
--- a/lib/keeper/keeper_manual_reconcile.ml
+++ b/lib/keeper/keeper_manual_reconcile.ml
@@ -197,10 +197,22 @@ let open_pending config ~keeper_name ~blocker_class ~summary ~failure_reason
   write_record config record;
   record
 
+let remove_file_best_effort config keeper_name =
+  let path = record_path config keeper_name in
+  try Sys.remove path with Sys_error _ -> ()
+
+(* Delete-on-clear: the on-disk record is removed once the caller is
+   handed a Cleared_record. Legacy binaries predating #6518 treat any
+   existing .manual_reconcile.json as a blocker, so leaving behind a
+   status=Cleared file can deadlock a rolling restart. The Cleared_record
+   returned from this function is the one-shot audit surface; callers
+   that need persistence must store it themselves. *)
 let clear config ~keeper_name ~actor ~resolution ~evidence_refs ~idempotency_key =
   match read config keeper_name with
   | None -> No_record
-  | Some ({ status = Cleared; _ } as record) -> Already_cleared record
+  | Some ({ status = Cleared; _ } as record) ->
+      remove_file_best_effort config keeper_name;
+      Already_cleared record
   | Some record ->
       let updated =
         {
@@ -214,5 +226,5 @@ let clear config ~keeper_name ~actor ~resolution ~evidence_refs ~idempotency_key
           clear_idempotency_key = idempotency_key;
         }
       in
-      write_record config updated;
+      remove_file_best_effort config keeper_name;
       Cleared_record updated

--- a/test/test_keeper_reconcile_tool.ml
+++ b/test/test_keeper_reconcile_tool.ml
@@ -234,6 +234,151 @@ let test_keeper_reconcile_clear_without_record_clears_runtime_blocker () =
         Yojson.Safe.Util.(
           status_after_json |> member "runtime" |> member "phase" |> to_string))
 
+let record_path_for config keeper_name =
+  Filename.concat
+    (Keeper_types.keeper_dir config)
+    (keeper_name ^ ".manual_reconcile.json")
+
+let test_module_clear_removes_file () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "delete-on-clear-keeper" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let path = record_path_for config keeper_name in
+      let _opened =
+        Keeper_manual_reconcile.open_pending
+          config
+          ~keeper_name
+          ~blocker_class:"ambiguous_post_commit_timeout"
+          ~summary:"unit test blocker"
+          ~failure_reason:(Some "timeout")
+          ~trace_id:(Some "trace-unit")
+          ~generation:(Some 1)
+          ~committed_tools:[]
+      in
+      check bool "record file exists before clear" true
+        (Sys.file_exists path);
+      check bool "is_pending before clear" true
+        (Keeper_manual_reconcile.is_pending config keeper_name);
+      let outcome1 =
+        Keeper_manual_reconcile.clear
+          config
+          ~keeper_name
+          ~actor:"operator"
+          ~resolution:"unit test clear"
+          ~evidence_refs:[ "trace:unit" ]
+          ~idempotency_key:(Some "idem-1")
+      in
+      (match outcome1 with
+       | Keeper_manual_reconcile.Cleared_record record ->
+           check string "cleared record name" keeper_name record.keeper_name;
+           check bool "resolution populated" true
+             (match record.resolution with
+              | Some value -> value = "unit test clear"
+              | None -> false)
+       | Keeper_manual_reconcile.Already_cleared _ ->
+           fail "expected Cleared_record on first clear"
+       | Keeper_manual_reconcile.No_record ->
+           fail "expected Cleared_record on first clear");
+      check bool "record file removed after clear" false
+        (Sys.file_exists path);
+      check bool "is_pending false after clear" false
+        (Keeper_manual_reconcile.is_pending config keeper_name);
+      let outcome2 =
+        Keeper_manual_reconcile.clear
+          config
+          ~keeper_name
+          ~actor:"operator"
+          ~resolution:"retry"
+          ~evidence_refs:[]
+          ~idempotency_key:(Some "idem-1")
+      in
+      (match outcome2 with
+       | Keeper_manual_reconcile.No_record -> ()
+       | Keeper_manual_reconcile.Cleared_record _ ->
+           fail "expected No_record on idempotent retry after delete"
+       | Keeper_manual_reconcile.Already_cleared _ ->
+           fail "expected No_record, not Already_cleared, after delete-on-clear");
+      check bool "file still absent after retry" false
+        (Sys.file_exists path))
+
+let write_raw_cleared_json path ~keeper_name =
+  let json : Yojson.Safe.t =
+    `Assoc
+      [
+        ("version", `Int 1);
+        ("keeper_name", `String keeper_name);
+        ("blocker_class", `String "ambiguous_post_commit_timeout");
+        ("summary", `String "legacy");
+        ("failure_reason", `Null);
+        ("trace_id", `Null);
+        ("generation", `Null);
+        ("committed_tools", `List []);
+        ("opened_at", `String "2026-04-11T00:00:00Z");
+        ("updated_at", `String "2026-04-11T00:00:01Z");
+        ("status", `String "cleared");
+        ("resolution", `String "cleared by legacy binary");
+        ("evidence_refs", `List []);
+        ("cleared_at", `String "2026-04-11T00:00:01Z");
+        ("cleared_by", `String "legacy-binary");
+        ("clear_idempotency_key", `Null);
+      ]
+  in
+  let dir = Filename.dirname path in
+  if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
+  let oc = open_out path in
+  output_string oc (Yojson.Safe.to_string json);
+  close_out oc
+
+let test_module_clear_removes_legacy_cleared_file () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  let keeper_name = "legacy-cleared-keeper" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let path = record_path_for config keeper_name in
+      write_raw_cleared_json path ~keeper_name;
+      check bool "legacy cleared file present" true (Sys.file_exists path);
+      let outcome =
+        Keeper_manual_reconcile.clear
+          config
+          ~keeper_name
+          ~actor:"operator"
+          ~resolution:"cleanup"
+          ~evidence_refs:[]
+          ~idempotency_key:None
+      in
+      (match outcome with
+       | Keeper_manual_reconcile.Already_cleared _ -> ()
+       | _ -> fail "expected Already_cleared on pre-existing cleared file");
+      check bool "legacy cleared file removed" false (Sys.file_exists path);
+      let outcome_after =
+        Keeper_manual_reconcile.clear
+          config
+          ~keeper_name
+          ~actor:"operator"
+          ~resolution:"cleanup"
+          ~evidence_refs:[]
+          ~idempotency_key:None
+      in
+      (match outcome_after with
+       | Keeper_manual_reconcile.No_record -> ()
+       | Keeper_manual_reconcile.Already_cleared _ ->
+           fail "second clear should not re-observe Already_cleared after delete"
+       | Keeper_manual_reconcile.Cleared_record _ ->
+           fail "second clear must not mutate — file was already gone"))
+
 let () =
   run "keeper_reconcile_tool"
     [
@@ -243,5 +388,12 @@ let () =
             test_keeper_reconcile_inspect_and_clear;
           test_case "clear without record clears runtime blocker" `Quick
             test_keeper_reconcile_clear_without_record_clears_runtime_blocker;
+        ] );
+      ( "module",
+        [
+          test_case "clear removes pending file (delete-on-clear)" `Quick
+            test_module_clear_removes_file;
+          test_case "clear removes legacy Cleared file defensively" `Quick
+            test_module_clear_removes_legacy_cleared_file;
         ] );
     ]

--- a/test/test_phase2_self_preservation.ml
+++ b/test/test_phase2_self_preservation.ml
@@ -273,15 +273,36 @@ let test_manual_reconcile_store_roundtrip () =
   with
   | KMR.Cleared_record cleared ->
       check bool "not pending after clear" false (KMR.is_pending config "k1");
-      check string "status cleared" "cleared"
+      (* delete-on-clear: the on-disk record is gone after a successful
+         clear so legacy readers can never mistake a Cleared file for a
+         blocker. The in-memory Cleared_record is the one-shot audit. *)
+      check string "record removed after clear" "missing"
         (match KMR.read config "k1" with
          | Some record -> (
              match record.status with
              | KMR.Cleared -> "cleared"
              | KMR.Pending -> "pending")
          | None -> "missing");
-      check string "resolution persisted" "verified downstream side effects"
-        (Option.value ~default:"" cleared.resolution)
+      check string "resolution carried in return value"
+        "verified downstream side effects"
+        (Option.value ~default:"" cleared.resolution);
+      check string "cleared_by carried in return value" "tester"
+        (Option.value ~default:"" cleared.cleared_by);
+      (* Idempotent retry: on delete-on-clear, a second clear with the
+         same idempotency key returns No_record because the file is gone.
+         This is a deliberate semantic change — callers that previously
+         relied on the Already_cleared signal must treat No_record as
+         "already handled". *)
+      (match KMR.clear config ~keeper_name:"k1" ~actor:"tester"
+               ~resolution:"retry"
+               ~evidence_refs:[]
+               ~idempotency_key:(Some "idem-1")
+       with
+       | KMR.No_record -> ()
+       | KMR.Cleared_record _ ->
+           fail "retry should not reopen a cleared record"
+       | KMR.Already_cleared _ ->
+           fail "retry cannot observe Already_cleared after delete-on-clear")
   | KMR.Already_cleared _ -> fail "expected first clear to mutate"
   | KMR.No_record -> fail "expected persisted record"
 


### PR DESCRIPTION
## Why

Cycle 19 incident (2026-04-11): all 8 keepers deadlocked with empty CTX and no turn progress. Root cause: stale `<keeper>.manual_reconcile.json` files on disk with `status=cleared`, being read by a 5-hour-old server binary that predated #6518 (the fix that made `should_run_turn` consult `manual_reconcile_pending` rather than just file existence). The old binary treated any existing file as a blocker regardless of status.

#6518 fixed the live binary, but **stale cleared files on disk are still a foot-gun during rolling restarts**: any operator running a binary from before #6518 will re-trigger the same deadlock.

## What

`Keeper_manual_reconcile.clear` now deletes the file once the caller receives a `Cleared_record`. The returned in-memory `Cleared_record` is the one-shot audit surface — `resolution`, `cleared_at`, `cleared_by`, `clear_idempotency_key` are all populated and returned to the caller exactly like before. Only the disk persistence is removed.

```ocaml
let clear config ~keeper_name ~actor ~resolution ~evidence_refs ~idempotency_key =
  match read config keeper_name with
  | None -> No_record
  | Some ({ status = Cleared; _ } as record) ->
      remove_file_best_effort config keeper_name;   (* defensive: wipe legacy leftover *)
      Already_cleared record
  | Some record ->
      let updated = { record with status = Cleared; ... } in
      remove_file_best_effort config keeper_name;   (* primary path: delete on clear *)
      Cleared_record updated
```

## Semantic change — please review

A second `clear` call with the same `idempotency_key` now returns `No_record` instead of `Already_cleared` (the file is gone). This is a deliberate trade: we lose the on-disk idempotency marker but gain certainty that legacy readers can never misinterpret a cleared file.

**Caller audit**: `rg 'Keeper_manual_reconcile\.clear'` finds exactly one caller in `lib/tool_keeper.ml`. That caller maps both `Cleared_record` and `Already_cleared` to `cleared: true` in the response, and maps `No_record` to `cleared: true, already_cleared: false, record: null`. The wire-level behavior on an idempotent retry flips from `already_cleared: true` to `already_cleared: false` with `record: null`, but `cleared: true` is preserved, so callers that only check `cleared` are unaffected.

The `Already_cleared` branch remains in the code as a **defensive cleanup path** for legacy Cleared files written by old binaries. After this branch deletes the file, any subsequent `clear` call collapses to `No_record`.

## Trade-offs / what this does NOT do

- **No audit trail on disk.** Each clear event is audit-visible only in the single tool response. If we ever want a durable audit log, that's a follow-up (append-only JSONL per keeper).
- **No TOCTOU hardening.** Two concurrent `clear` calls for the same keeper can both observe a `Pending` record and both return `Cleared_record`. This race existed before (parallel `write_record`) and is not a regression. Production serializes clears per-keeper via the MCP tool dispatch path.
- **No change to `tool_keeper.ml` response shape.** The `already_cleared` field still exists; its value flips for idempotent retries.

## Tests

All four relevant test files pass locally.

- `test/test_keeper_reconcile_tool.ml`
  - New `test_module_clear_removes_file`: open_pending → assert file exists → clear → assert `Cleared_record` + file gone + `is_pending` false → retry clear → assert `No_record` + file still gone
  - New `test_module_clear_removes_legacy_cleared_file`: write a raw Cleared JSON file → call clear → assert `Already_cleared` + file gone → call clear again → assert `No_record` (verifies the legacy-cleanup branch collapses on retry, per GLM review feedback)
  - Existing `inspect -> clear` and `clear without record` cases unchanged
- `test/test_phase2_self_preservation.ml`
  - Replaces the old "status cleared" assertion (which codified the keep-file-on-disk behavior) with "record removed after clear" and verifies the in-memory `Cleared_record` still carries `resolution` and `cleared_by`. Also adds an idempotent-retry check.

## Cross-model review

Reviewed with `sb glm-text` (GLM-5.1). Severity: HIGH. Three flags:
1. Concurrency with `Sys.remove` — acknowledged as pre-existing race, not a regression. Production serializes per-keeper via tool dispatch.
2. Audit `Already_cleared` callers — done. Only one in-tree caller (`tool_keeper.ml`), no side-effect gating on that branch.
3. Test gap: `Already_cleared → No_record` transition on retry — **fixed** by adding a second `clear` call to `test_module_clear_removes_legacy_cleared_file` asserting `No_record`.

## Related

- PR #6518: `should_run_turn` consults `manual_reconcile_pending` (the in-binary fix)
- PR #6497: gate auto-clear of manual reconcile behind age threshold
- Cycle 19 incident: 8 keepers deadlocked, resolved by manual `rm <keeper>.manual_reconcile.json` — this PR eliminates the need for that manual step during rolling restarts with older binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)