### PR TITLE
test(tool-matrix): clone into playground before masc_worktree_* (#6527 iter 2b)

### DIFF
--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -319,7 +319,26 @@ let case_for_name name =
     let generic_case = Generic.case_for_name name in
     {
       init_mode = generic_case.init_mode;
-      prepare = (fun fixture -> Generic.prepare_for_name fixture.generic name);
+      prepare = (fun fixture ->
+        Generic.prepare_for_name fixture.generic name;
+        (* In the keeper tool matrix, masc_worktree_* runs inside a
+           keeper context whose meta.name is "keeper-tool-matrix", not
+           the generic fixture's "codex-tool-matrix". After PRs
+           #6533/#6542 the worktree resolver requires a clone under
+           the keeper's own playground, so mirror the generic
+           ensure_playground_clone for the keeper meta name too.
+           For masc_worktree_remove, also create the actual worktree
+           under the keeper name so the removal has a matching target. *)
+        if List.mem name [ "masc_worktree_create"; "masc_worktree_list" ] then
+          ignore
+            (Generic.ensure_playground_clone_for
+               ~agent:"keeper-tool-matrix" fixture.generic);
+        if name = "masc_worktree_remove" then begin
+          fixture.generic.worktree_task_id <- None;
+          ignore
+            (Generic.ensure_worktree_created_for
+               ~agent:"keeper-tool-matrix" fixture.generic)
+        end);
       arguments =
         (fun fixture schema -> Generic.tool_arguments fixture.generic schema);
       expectation =

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -489,22 +489,61 @@ let ensure_library_topic fixture =
       fixture.library_topic <- Some "tool-matrix-library";
       "tool-matrix-library"
 
-let ensure_worktree_created fixture =
+(* Ensure the keeper's playground has a git clone before calling
+   masc_worktree_create. After PRs #6533/#6542 removed the server-root
+   fallback, keepers must clone into
+   .masc/playground/<agent>/repos/<repo>/ first. This helper clones
+   the fixture's local bare remote into the playground repos
+   directory and is idempotent.
+
+   The [agent] parameter overrides [fixture.agent_name] for cases
+   where a different keeper identity is used at runtime (e.g. the
+   keeper tool matrix, whose runtime keeper meta name differs from
+   the generic fixture agent name). *)
+let ensure_playground_clone_for ?agent fixture =
+  let agent_name = match agent with Some n -> n | None -> fixture.agent_name in
+  let playground_repos =
+    Filename.concat fixture.base_path
+      (Printf.sprintf ".masc/playground/%s/repos" agent_name)
+  in
+  let clone_target = Filename.concat playground_repos "tool-matrix" in
+  if not (Sys.file_exists clone_target) then begin
+    mkdir_p playground_repos;
+    let remote_dir = Filename.concat fixture.base_path ".remote.git" in
+    run_cmd_exn [ "git"; "clone"; "-q"; remote_dir; clone_target ];
+    run_cmd_exn
+      [ "git"; "-C"; clone_target; "config"; "user.email"; "tool-matrix@example.test" ];
+    run_cmd_exn
+      [ "git"; "-C"; clone_target; "config"; "user.name"; "Tool Matrix" ]
+  end;
+  clone_target
+
+let ensure_playground_clone fixture = ensure_playground_clone_for fixture
+
+(* Create a worktree for a specific agent name (defaults to
+   [fixture.agent_name]). Takes [?agent] so the keeper tool matrix can
+   create the worktree under the real keeper meta name instead of the
+   generic fixture agent, keeping create and remove paths consistent. *)
+let ensure_worktree_created_for ?agent fixture =
+  let agent_name = match agent with Some n -> n | None -> fixture.agent_name in
   match fixture.worktree_task_id with
   | Some task_id -> task_id
   | None ->
       let task_id = ensure_task fixture in
+      let _ = ensure_playground_clone_for ?agent fixture in
       ignore
         (execute_tool_ok fixture ~name:"masc_worktree_create"
            ~arguments:
              (`Assoc
                [
-                 ("agent_name", `String fixture.agent_name);
+                 ("agent_name", `String agent_name);
                  ("task_id", `String task_id);
                  ("base_branch", `String "main");
                ]));
       fixture.worktree_task_id <- Some task_id;
       task_id
+
+let ensure_worktree_created fixture = ensure_worktree_created_for fixture
 
 let ensure_code_file fixture =
   match fixture.code_file_path with
@@ -537,6 +576,8 @@ let prepare_for_name fixture name =
     ignore (ensure_verification_request fixture);
   if name = "masc_webrtc_answer" then
     ignore (ensure_webrtc_offer fixture);
+  if List.mem name [ "masc_worktree_create"; "masc_worktree_list" ] then
+    ignore (ensure_playground_clone fixture);
   if name = "masc_worktree_remove" then
     ignore (ensure_worktree_created fixture);
   if List.mem name [ "masc_code_edit"; "masc_code_delete"; "masc_code_git"; "masc_code_shell"; "masc_code_read"; "masc_code_symbols" ] then


### PR DESCRIPTION
## 요약

PR #6533과 PR #6542 이후 `test_mcp_tool_matrix`와 `test_keeper_tool_matrix`에서 `masc_worktree_create`, `masc_worktree_list`, `masc_worktree_remove`가 실패하고 있었습니다. 이 PR은 tool-matrix fixture가 실제 playground clone을 갖도록 수정합니다. 이슈 #6527의 Iter-2b (test follow-up).

## 배경

PR #6542가 `worktree_create_r`에서 서버 레포 루트 폴백을 제거한 후, 그리고 이후 main의 다른 변경이 `worktree_remove_r`을 `resolve_existing_worktree_root`로 교체한 후 — matrix fixture는 여전히 **삭제된 폴백 동작에 의존** 중이었습니다.

예전 fixture는 `.masc/playground/<agent>/repos/`에 clone을 만들지 않았고, 이전엔 server-root 폴백 덕에 그럭저럭 동작했습니다. 이제 resolver가 playground clone을 요구하므로 매트릭스 테스트가 `"No playground git clone found under..."` 에러로 실패합니다.

main에서 재현:
```
$ dune exec test/test_mcp_tool_matrix.exe
1 failure! in 74s. 2 tests run.
  masc_worktree_create expected success but got error: ❌ IO error: 
  No playground git clone found under .../.masc/playground/codex-tool-matrix/repos/
```

## 변경

### `test/test_mcp_tool_matrix_cases.ml`

- **새 helper**: `ensure_playground_clone_for ?agent fixture`
  - fixture의 기존 `.remote.git` bare remote를 `<base>/.masc/playground/<agent>/repos/tool-matrix/`에 clone
  - user email/name 설정, idempotent (이미 존재하면 no-op)
  - `?agent` default = `fixture.agent_name`
- **Refactor**: `ensure_worktree_created` → `ensure_worktree_created_for ?agent`
  - caller가 다른 agent 이름으로 worktree를 만들 수 있게 함
  - zero-arg wrapper 유지 (backward compat)
- **`prepare_for_name` wiring**:
  - `masc_worktree_create`, `masc_worktree_list` → `ensure_playground_clone`
  - `masc_worktree_remove` → `ensure_worktree_created` (내부에서 clone도 함)

### `test/test_keeper_tool_matrix_cases.ml`

Keeper matrix의 runtime keeper meta name은 `keeper-tool-matrix`인 반면, 래핑된 generic fixture의 `agent_name`은 `codex-tool-matrix`입니다. 따라서 generic `prepare_for_name`만 호출하면 clone이 잘못된 playground에 들어가고 resolver가 여전히 empty `repos/`를 봅니다.

Generic preparation을 wrap한 뒤 세 개의 `masc_worktree_*` 케이스에 대해 명시적으로 keeper name으로 playground를 준비합니다:

- `masc_worktree_create`, `masc_worktree_list`: `ensure_playground_clone_for ~agent:"keeper-tool-matrix"`
- `masc_worktree_remove`: 공유 `worktree_task_id`를 reset한 뒤 `ensure_worktree_created_for ~agent:"keeper-tool-matrix"` — setup과 removal이 동일 keeper identity 사용하도록

## 테스트

| Test | Before | After |
|------|--------|-------|
| `test/test_mcp_tool_matrix.exe` | 1 failure (`masc_worktree_create`) | ✅ 2 tests pass |
| `test/test_keeper_tool_matrix.exe` — `masc_worktree_*` | 실패 | ✅ 3건 모두 pass |
| `test/test_keeper_tool_matrix.exe` — 나머지 | 14 failures | 14 failures (pre-existing, unrelated) |

남은 14건은 이 PR 범위 밖:
- `keeper_pr_*`, `keeper_preflight_check`, `keeper_stay_silent`, `keeper_tool_search`, `keeper_board_*` — "missing keeper arguments contract" (schema gap)
- `keeper_voice_listen`, `keeper_voice_speak` — TTS/audio endpoint not configured in test env
- `masc_claim_next` — "not a member of this room" (init state ordering)
- `masc_select_agent` — validation error

## Scope

- 테스트 fixture만 수정. library/production 코드는 건드리지 않음.
- `lib/room/room_worktree.ml`의 create/remove resolver는 이미 main에 반영된 버전 그대로 유지.
- `#6527` trilogy (Iter-1: prompt, Iter-2: fallback removal, Iter-2b: test fixture)의 마지막 퍼즐 조각.

## 후속 (#6527)

- [x] Iter-1: 프롬프트 수정 (PR #6533 merged)
- [x] Iter-2: server-root fallback 제거 (PR #6542 merged)
- [x] **Iter-2b: test fixture (이 PR)**
- [ ] Iter-3: `keeper_exec_shell.ml` write-gate에 `in_keeper_area` 조건
- [ ] Iter-4: `.worktrees/` 전역 allow 제거 + `keeper_pr_submit` cwd per-keeper 축소
- [ ] Iter-5: TLA+ `KeeperWorktreeContainment` invariant
