### PR TITLE
fix(cascade): drop glm-coding:glm-4.7 — 100% HTTP 500 on keeper bodies

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,6 +1,5 @@
 {
   "default_models": [
-    "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
@@ -9,18 +8,16 @@
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "keeper_unified_models": [
-    "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "coding_first_models": [
-    "glm-coding:glm-4.7",
     "glm-coding:glm-5.1",
     "glm:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "glm-coding = Coding Plan (subscription). glm = general API (pay-per-use). local last.",
+  "_comment": "glm-coding = Coding Plan (subscription). glm = general API (pay-per-use). local last. glm-4.7 dropped 2026-04-11: 100% HTTP 500 on keeper-size bodies (#6567); glm-5.1 succeeds, fallback unchanged.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,


### PR DESCRIPTION
## Summary

Metrics-driven cascade trim. `glm-coding:glm-4.7` returned 100% HTTP 500 across a 27-min observation window; removing it eliminates ~10s of wasted latency per keeper turn with zero behavioural change (fallback to `glm-coding:glm-5.1` already succeeds on every turn).

## Evidence

Counter snapshot on live server (0.5.3, uptime ~48min) via `masc_llm_provider_http_status_total`:

\`\`\`
glm provider / glm-4.7 / 500 = 5   (100%)
glm provider / glm-5.1 / 200 = 5
glm provider / glm-5.1 / 429 = 2   (general API quota — expected, hard-quota skip from #798 active)
ollama    / 35b-a3b    / 400 = 2
\`\`\`

Minimal curl to `https://api.z.ai/api/coding/paas/v4/chat/completions` with a trivial \`{model: glm-4.7, messages: [ping], max_tokens: 16}\` returns **200**, so the model+endpoint pair is healthy. The 500 is body-specific — keeper unified turn bodies run ~300KB including tool schemas, and only `glm-5.1` accepts them on the coding endpoint.

## Change

Drop `glm-coding:glm-4.7` from all three cascade profiles (`default_models`, `keeper_unified_models`, `coding_first_models`). `glm-coding:glm-5.1` stays as step 1.

\`\`\`diff
 "default_models": [
-  "glm-coding:glm-4.7",
   "glm-coding:glm-5.1",
   "glm:glm-5.1",
   "ollama:qwen3.5:35b-a3b-nvfp4"
 ]
\`\`\`

## Risk

- None observed — fallback path is already validated in production (every 500 in the counter paired with a 200 on step 2).
- If small-body calls (tool_rerank, local probe) benefited from glm-4.7, they used different profiles that didn't list it anyway.
- Config hot-reload means takes effect without restart.

## References

- #6567 — investigation tracking issue
- #6475 — prior cascade switch to glm-coding-first
- #6558 — prior cascade trim (groq removal) with the same pattern: drop labels that 100% fail
- #798 (oas) — hard-quota skip for GLM 1113 (prevents general API retry loop)

## Test plan

- [ ] JSON syntax: `jq . config/cascade.json`
- [ ] CI: existing tests must pass (no hardcoded reference to `glm-coding:glm-4.7` in test/ — verified)
- [ ] Post-deploy: `masc_llm_provider_http_status_total{model="glm-4.7"}` should stop incrementing; `glm-5.1 200` rate should ~double

🤖 Generated with [Claude Code](https://claude.com/claude-code)