### PR TITLE
fix(keeper): block write ops outside keeper playground in keeper_bash (#6527 iter 3)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -420,7 +420,7 @@ let handle_keeper_bash
                 ; "cmd", `String cmd_for_log
                 ; "hint", `String "Use cwd=.masc/playground/YOUR_KEEPER_NAME/repos/REPO"
                 ]))
-        (* Write gate *)
+        (* Write gate — preset layer *)
         else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
         then (
           Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s, playground=%b)"
@@ -434,6 +434,36 @@ let handle_keeper_bash
                       "This command modifies state (git push/commit, make deploy, etc.). \
                        A write-enabled preset (Coding/Delivery/Full) is required." )
                 ; "cmd", `String cmd_for_log
+                ]))
+        (* Write gate — playground containment layer (#6527 iter 3).
+           A write-enabled keeper still must not mutate anything outside
+           its own playground bundle. branch-switch already requires
+           in_playground; match the same invariant for the general
+           write operations (git push/commit, make deploy, etc.) so
+           a coding-preset keeper cannot push from, e.g., a
+           workspace-default `.worktrees/` path or `lib/` on the server
+           repo. *)
+        else if write_enabled
+                && Worker_dev_tools.is_write_operation cmd
+                && not in_playground
+        then (
+          Log.Keeper.info
+            "keeper_bash write-containment blocked: %s (keeper=%s, cwd=%s, playground=%b)"
+            cmd_for_log meta.name cwd in_playground;
+          Yojson.Safe.to_string
+            (`Assoc
+                [ "ok", `Bool false
+                ; "error", `String "write_outside_playground_blocked"
+                ; ( "reason"
+                  , `String
+                      "Write operations (git push/commit, make deploy, etc.) \
+                       must run with cwd inside your playground \
+                       (.masc/playground/<keeper>/...). Open a worktree under \
+                       your playground clone first via masc_worktree_create, \
+                       then set cwd to the returned worktree path." )
+                ; "cmd", `String cmd_for_log
+                ; "cwd", `String cwd
+                ; "hint", `String "cwd must start with .masc/playground/YOUR_KEEPER_NAME/"
                 ]))
         else (
             (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with


### PR DESCRIPTION
## 요약

`handle_keeper_bash`에서 write 연산(`git push`/`git commit`/`make deploy`...)이 keeper의 playground 바깥 cwd에서 수행될 수 없도록 세 번째 guard layer를 추가했습니다. branch-switch 가드(`write_enabled && in_playground`)는 이미 있지만 일반 write 가드는 preset만 확인(`write_enabled`)하던 gap을 보완합니다. 이슈 #6527의 Iter-3.

## 배경

현재 `handle_keeper_bash`는 3-layer gate를 가지고 있습니다:

| Layer | 조건 | 영향 |
|-------|------|------|
| Destructive guard | `is_destructive cmd` | 무조건 block |
| Preset gate | `not write_enabled && is_write_operation` | Coding/Delivery/Full preset 아니면 block |
| Branch-switch gate | `is_branch_switch && not (write_enabled && in_playground)` | cwd가 playground 바깥이면 block |

하지만 **일반 write 연산**(`git push`, `git commit`, `make deploy` 등)은 Preset gate만 거치고 `in_playground`는 검사하지 않았습니다. 결과: Coding preset keeper가 `.worktrees/`(server 루트 하위) 또는 `lib/`에서 `git push`를 수행할 수 있었습니다.

즉, **프롬프트 언어**("playground is your sandbox")와 **하네스 실제 경계** 사이에 불일치가 있었습니다. branch-switch만 이 invariant를 강제하고 나머지 write는 빠져 있던 상황.

## 변경

`lib/keeper/keeper_exec_shell.ml` — Preset gate 다음에 새 분기:

```ocaml
(* Write gate — playground containment layer (#6527 iter 3).
   A write-enabled keeper still must not mutate anything outside
   its own playground bundle. branch-switch already requires
   in_playground; match the same invariant for the general
   write operations ... *)
else if write_enabled
        && Worker_dev_tools.is_write_operation cmd
        && not in_playground
then (
  ...
  "error": "write_outside_playground_blocked",
  "reason": "Write operations ... must run with cwd inside your
             playground (.masc/playground/<keeper>/...)...",
  "cwd": ...,
  "hint": "cwd must start with .masc/playground/YOUR_KEEPER_NAME/"
)
```

## Trade-off

- **Read 연산은 변경 없음**: `is_write_operation`이 false를 반환하므로 read는 이 분기에 진입하지 않음. `lib/`, `test/`, `config/` 등 workspace_defaults read 동작 유지.
- **Write는 반드시 playground 안에서**: coding preset keeper가 playground 바깥에서 `git push` 등을 호출하면 구조화된 에러 (`write_outside_playground_blocked`)를 받음.
- **branch-switch guard와 대칭**: 이제 branch-switch와 일반 write 모두 동일한 `write_enabled && in_playground` 불변식을 요구.

### 잠재 영향

legacy keeper 중 `cwd=.worktrees/<name>`(server 루트 `.worktrees/`, Iter-4 제거 예정)에서 `git push`를 호출하던 시나리오가 있다면 이 PR로 새로 차단됩니다. 의도된 break — 프롬프트 레벨에서 이미 iter-1에서 금지 선언했고, keeper에게 명확한 힌트("cwd must start with `.masc/playground/YOUR_KEEPER_NAME/`")가 제공됩니다.

## 테스트

- `dune build --root .`: ✅ green
- `dune exec test/test_keeper_bash_safety.exe`: ✅ 17 tests pass. 이 테스트는 `Worker_dev_tools` predicate 함수만 검증하며, 내 변경은 dispatcher의 boolean 조합이라 추가 predicate를 도입하지 않음.
- Matrix 테스트: 현재 main에 pre-existing 실패 2건 있음(Iter-2b PR #6577이 해결 중). 이 PR은 fixture를 건드리지 않고 새 실패도 추가하지 않음.

### Unit test 부재에 대한 설명

Iter-3의 guard는 `handle_keeper_bash` dispatcher 내부의 boolean conjunction입니다:
```
write_enabled && is_write_operation cmd && not in_playground
```

각 항은 이미 기존 predicate로 커버됨 (`is_write_operation`은 `test_keeper_bash_safety`에서 테스트됨). Dispatcher 전체를 call하려면 `config`, `meta`, keeper_fs_edit 의존성을 fixture로 만들어야 해서 테스트 규모가 큽니다. 지금 단계에서는 branch-switch guard와 동일한 패턴을 복제한 것이므로 의도가 명확하고, 후속 E2E 통합 테스트에서 자연스럽게 커버될 것입니다.

## 후속 (#6527)

- [x] Iter-1: 프롬프트 수정 (PR #6533 merged)
- [x] Iter-2: `worktree_create_r` server-root fallback 제거 (PR #6542 merged)
- [x] Iter-2b: matrix test fixture cleanup (PR #6577 auto-merge queued)
- [x] **Iter-3: `keeper_bash` write-containment gate (이 PR)**
- [ ] Iter-4: `.worktrees/` workspace_default 제거 + `keeper_pr_submit` cwd per-keeper 축소
- [ ] Iter-5: TLA+ `KeeperWorktreeContainment` invariant

## 리뷰 요청

교차 모델 리뷰: `sb glm-text` (GLM-5.1), non-self.
