### PR TITLE
fix(keeper): scope worktrees and pr_submit to per-keeper playground (#6527 iter 4)

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -233,12 +233,22 @@ let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
     match String.lowercase_ascii meta.execution_scope with
     | "workspace" ->
       let safe_name = sanitize_keeper_name meta.name in
+      (* NOTE (#6527 iter 4): `.worktrees/` was previously included
+         here so keepers could read and write worktrees created at the
+         server repository root by the old `worktree_create_r`
+         fallback. That fallback was removed in PR #6542 (iter 2), so
+         new worktrees always land at
+         `.masc/playground/<keeper>/repos/<clone>/.worktrees/<name>/`,
+         which is already inside `playground_paths`. Keeping
+         `.worktrees/` as a workspace default would allow any keeper
+         with workspace scope to read and write into another keeper's
+         server-root worktree or into the MASC repo's own worktrees —
+         exactly the containment leak #6527 is closing. Remove it.
+         Keepers that genuinely need access to a specific worktree can
+         still add it via explicit `allowed_paths` on their keeper
+         meta. *)
       [ Printf.sprintf ".masc/keepers/%s/" safe_name;
         ".masc/traces/";
-        (* Worktrees created by masc_worktree_create land here.
-           Without this, keepers can create worktrees but cannot
-           read or write files inside them. *)
-        ".worktrees/";
         (* Main repo source for read access *)
         "lib/";
         "test/";

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -737,23 +737,41 @@ let handle_keeper_pr_submit
           ])
     else
       let root = Keeper_alerting_path.project_root_of_config config in
-      (* Validate cwd is within .worktrees/ or .masc/playground/ *)
+      (* Validate cwd is inside THIS keeper's own playground bundle.
+         Before PR #6527 iter 4, the gate accepted any `.worktrees/`
+         or any `.masc/playground/*` — i.e. it was not per-keeper, so
+         keeper-A could submit a PR from keeper-B's playground or
+         from a server-wide worktree. After iter 2 (PR #6542)
+         masc_worktree_create always lands the worktree under
+         `.masc/playground/<keeper>/repos/<clone>/.worktrees/...`, so
+         the only legitimate cwd for pr_submit is this keeper's own
+         playground bundle prefix. *)
       let abs_cwd =
         if Filename.is_relative cwd then Filename.concat root cwd
         else cwd
       in
-      let worktrees_prefix = Filename.concat root ".worktrees" in
-      let playground_prefix = Filename.concat root ".masc/playground" in
+      let keeper_playground_prefix =
+        Filename.concat root
+          (Keeper_alerting_path.playground_path_of_keeper meta.name)
+      in
+      (* [playground_path_of_keeper] returns a path with a trailing
+         slash, so prefix matching is already boundary-safe — a
+         sibling directory with the same stem cannot slip through. *)
       let cwd_ok =
-        String.starts_with ~prefix:(worktrees_prefix ^ "/") abs_cwd
-        || String.starts_with ~prefix:(playground_prefix ^ "/") abs_cwd
+        String.starts_with ~prefix:keeper_playground_prefix abs_cwd
       in
       if not cwd_ok then
         Yojson.Safe.to_string
           (`Assoc
             [ "ok", `Bool false
-            ; "error", `String "cwd_outside_boundary"
-            ; "reason", `String "cwd must be within .worktrees/ or .masc/playground/"
+            ; "error", `String "cwd_outside_playground"
+            ; ( "reason"
+              , `String
+                  "cwd must be inside this keeper's own playground bundle \
+                   (.masc/playground/<keeper>/...). \
+                   Open a worktree via masc_worktree_create first." )
+            ; "cwd", `String abs_cwd
+            ; "expected_prefix", `String keeper_playground_prefix
             ])
       else
         let steps = Buffer.create 512 in

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -767,11 +767,19 @@ let handle_keeper_pr_submit
             ; "error", `String "cwd_outside_playground"
             ; ( "reason"
               , `String
-                  "cwd must be inside this keeper's own playground bundle \
-                   (.masc/playground/<keeper>/...). \
-                   Open a worktree via masc_worktree_create first." )
+                  "cwd must be inside this keeper's own playground bundle. \
+                   Every cwd passed to keeper_pr_submit must start with \
+                   .masc/playground/<YOUR_KEEPER_NAME>/repos/<clone>/.worktrees/<name>/. \
+                   Other keepers' playgrounds and the MASC server \
+                   repository worktrees are not accepted." )
             ; "cwd", `String abs_cwd
             ; "expected_prefix", `String keeper_playground_prefix
+            ; ( "hint"
+              , `String
+                  "Call masc_worktree_create first (it returns a path \
+                   inside your playground), then re-call keeper_pr_submit \
+                   with cwd set to that returned path." )
+            ; "recovery_tool", `String "masc_worktree_create"
             ])
       else
         let steps = Buffer.create 512 in

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -25,10 +25,13 @@ let playground_bundle name =
     KAP.playground_mind_path name;
     KAP.playground_repos_path name ]
 
+(* After #6527 iter 4, `.worktrees/` is no longer a workspace default.
+   New worktrees land inside the keeper's own
+   `.masc/playground/<keeper>/repos/<clone>/.worktrees/...` and are
+   already covered by the playground bundle paths above. *)
 let workspace_defaults name =
   [ Printf.sprintf ".masc/keepers/%s/" name;
     ".masc/traces/";
-    ".worktrees/";
     "lib/"; "test/"; "config/"; "bin/"; "scripts/"; "docs/" ]
 
 (* ── observe_only scope ── *)


### PR DESCRIPTION
## 요약

#6527 containment trilogy의 마지막 하네스 변경. 두 개의 좁은 수정:

1. **L2**: `effective_allowed_paths`의 workspace_defaults에서 `.worktrees/` 제거 → 교차-keeper worktree 접근 차단
2. **L3**: `keeper_pr_submit`의 cwd 경계를 per-keeper playground 단독으로 축소

Iter-1 (prompt), Iter-2 (worktree fallback), Iter-2b (test fixture), Iter-3 (bash write-gate) 모두 landed 상태에서 마지막 퍼즐 조각입니다.

## 배경

Iter-1/2/2b/3가 containment의 대부분을 복구했지만, **두 개의 leak**이 남아 있었습니다:

### L2: `.worktrees/` 전역 allow

`effective_allowed_paths`는 workspace-scope keeper마다 allowlist에 `.worktrees/` 리터럴을 추가했습니다. 과거에는 `worktree_create_r`의 폴백이 서버 레포 루트에 worktree를 만들던 때 이 접근이 필요했지만, PR #6542(iter 2)가 그 폴백을 제거한 이후에는:

1. **Happy path에서 불필요**: 새 worktree는 `.masc/playground/<keeper>/repos/<clone>/.worktrees/<name>/`에 landing하고, 이 경로는 이미 `playground_paths`가 커버
2. **Leak 유발**: workspace-scope keeper-A가 keeper-B의 server-root worktree, 또는 MASC 레포 자체의 worktree를 자유롭게 read/write 가능

### L3: `keeper_pr_submit` cwd 경계가 per-keeper 아님

`handle_keeper_pr_submit`는 cwd_ok를 `.worktrees/*` 또는 `.masc/playground/*` 전체로 판정했습니다. 즉:

- keeper-A가 keeper-B의 playground에서 PR submit 가능
- keeper-A가 서버 전역 `.worktrees/` 아무 경로에서나 PR submit 가능
- "이 keeper의 것"을 확인하지 않음

## 변경

### L2 — `lib/keeper/keeper_alerting_path.ml`

```ocaml
(* Before *)
| "workspace" ->
  [ ...;
    ".worktrees/";   (* ← 제거 *)
    "lib/"; "test/"; ... ]

(* After *)
| "workspace" ->
  (* NOTE (#6527 iter 4): .worktrees/ removed. New worktrees land
     inside playground bundle; keeping it in workspace defaults
     allowed cross-keeper containment leak. *)
  [ ...;
    "lib/"; "test/"; ... ]
```

명시적으로 `.worktrees/`에 접근해야 하는 keeper는 `allowed_paths`에 직접 지정 가능 (이 변경 후에도 explicit 경로는 그대로 존중됨).

### L3 — `lib/keeper/keeper_exec_github.ml`

```ocaml
(* Before *)
let cwd_ok =
  String.starts_with ~prefix:(worktrees_prefix ^ "/") abs_cwd
  || String.starts_with ~prefix:(playground_prefix ^ "/") abs_cwd

(* After *)
let keeper_playground_prefix =
  Filename.concat root
    (Keeper_alerting_path.playground_path_of_keeper meta.name)
in
let cwd_ok =
  String.starts_with ~prefix:keeper_playground_prefix abs_cwd
```

- `playground_path_of_keeper`는 trailing slash 포함이므로 `sibling` prefix 매칭 사고가 없음
- 에러 코드를 `cwd_outside_boundary` → `cwd_outside_playground`로 변경 (의도를 더 정확히 표현)
- `cwd` + `expected_prefix`를 에러에 포함시켜 9B 모델이 즉시 복구 가능하도록

### 테스트

- **`test/test_keeper_allowed_paths.ml`**: shared helper `workspace_defaults`에서 `.worktrees/` 제거. 14 cases pass.
- **`test/test_keeper_unified.ml`**: 155 cases pass (이 파일은 `.worktrees/`를 allowlist 전제로 삼지 않음).
- **`test/test_keeper_pr_workflow.ml`**: contract 변경 없음.

## 영향 / Trade-off

**의도된 breaking change**:
- Workspace-scope keeper가 `.worktrees/` 전역을 암묵적으로 접근하던 것이 차단됨. 실제 영향 없음 — 그 경로에 worktree를 만드는 API는 Iter-2에서 이미 제거됨.
- keeper_pr_submit에 전달하는 cwd가 이 keeper 자신의 playground 바깥이면 `cwd_outside_playground` 에러. 정당한 시나리오에서는 `masc_worktree_create`가 playground 안쪽 경로를 return하므로 자연스럽게 통과.

**보존된 유연성**:
- 명시적 `allowed_paths` (keeper meta의 `allowed_paths` 필드)에 `.worktrees/<specific>`를 지정하면 여전히 동작. 이는 로컬 테스트나 진단 목적의 exception을 허용.
- `["*"]` wildcard는 전처럼 작동 (full access).

## 후속 (#6527)

- [x] Iter-1: 프롬프트 수정 (PR #6533 merged)
- [x] Iter-2: server-root fallback 제거 (PR #6542 merged)
- [x] Iter-2b: matrix test fixture cleanup (PR #6577 auto-merge queued)
- [x] Iter-3: `keeper_bash` write-containment gate (PR #6579 auto-merge queued)
- [x] **Iter-4: `.worktrees/` 전역 allow 제거 + pr_submit per-keeper (이 PR)**
- [ ] Iter-5: TLA+ `KeeperWorktreeContainment` invariant

Iter-4까지 landing되면 하네스 containment 레이어는 완전. Iter-5 TLA+는 formal verification 레이어이며 bug-model 패턴(clean/buggy cfg 쌍)으로 regression 방지.

## 리뷰 요청

교차 모델 리뷰: `sb glm-text` (GLM-5.1), non-self.
