### PR TITLE
fix(shutdown): serialize initiate via per-state atomic CAS gate

### DIFF
--- a/lib/shutdown.ml
+++ b/lib/shutdown.ml
@@ -62,6 +62,10 @@ type state = {
   mutable phase : phase;
   mutable started_at : float;
   mutable reason : string;
+  entered : bool Atomic.t;
+    (** CAS gate: ensures [initiate] runs phases at most once per state.
+        Separate from the global [shutting_down_flag] which is a
+        process-wide sticky observability flag. *)
   config : config;
 }
 
@@ -69,6 +73,7 @@ let create ?(config = config_from_env ()) () = {
   phase = Running;
   started_at = 0.0;
   reason = "";
+  entered = Atomic.make false;
   config;
 }
 
@@ -159,7 +164,16 @@ let phase_exit state ~exit_fn =
     @param drain_check Returns true when all in-flight work is complete
     @param exit_fn Called to terminate the process (e.g., Eio.Switch.fail) *)
 let initiate state ~clock ~reason ~notify_fn ~drain_check ~exit_fn =
-  if state.phase <> Running then begin
+  (* CAS on per-state [entered] flag as the single-entry gate. The old
+     code checked [state.phase <> Running] non-atomically, which races
+     when two signals arrive in close succession (e.g. SIGTERM then
+     SIGINT): both callers observe [Running] before either writes the
+     new phase, both proceed, and the phases double-run with clobbered
+     [started_at]/[reason]. Per-state CAS serializes entry at the CPU
+     level without depending on the global [shutting_down_flag], which
+     is documented as a sticky observability flag and must not gate
+     repeated [initiate] calls on distinct [state]s (e.g. in tests). *)
+  if not (Atomic.compare_and_set state.entered false true) then begin
     Log.Server.warn "[Shutdown] already in progress (phase=%s), ignoring"
       (phase_to_string state.phase);
   end else begin


### PR DESCRIPTION
fix(shutdown): serialize initiate via per-state atomic CAS gate

`lib/shutdown.ml:initiate` used a plain `state.phase <> Running` check
as its single-entry gate. This is a classic check-then-set race: two
signals arriving in close succession (e.g. SIGTERM followed by SIGINT)
can both observe `phase = Running` before either writes the transition,
and the shutdown sequence runs twice — doubled notifications, doubled
drain waits, clobbered `started_at`/`reason`, and each phase's log
lines interleaving in telemetry.

## Change

Add a per-state `entered : bool Atomic.t` field seeded `false` by
`create`. `initiate` CAS'es it from `false` to `true`; on CAS failure
the caller logs the in-progress phase and returns without running
any phases.

Kept as a separate field rather than reusing the module-global
`shutting_down_flag`, which is documented as a sticky
process-wide observability flag (see the comment at lines 83-88).
Using the global as an entry gate would prevent fresh `state`
instances from running shutdown in tests, where the first test
sets the flag and every subsequent state sees it as permanently
"shutting down". Separating concerns keeps each flag's contract
clean.

The global `shutting_down_flag` is still set inside the CAS-success
branch so external observers (transport layer, load balancer
probes) see the same signal as before.

## Verification

```
dune build --root . lib/                      # exit 0
dune exec --root . -- ./test/test_lifecycle.exe
# 7 passed, 0 failed (was 5 passed / 2 failed in a first draft that
# incorrectly gated on the global flag — the tests exposed the bug
# before the fix landed)
```

## Test-driven discovery note

The first draft of this fix CAS'd the global `shutting_down_flag`
directly. The existing `test_lifecycle.ml` suite caught this
immediately: two tests share the global flag across test cases in
the same process, and the second test's `initiate` refused to run
because the flag was still sticky from the first test. Switched to
per-state field and both tests pass. Good example of the
module-level global being an observability concern and the entry
mutex being a state-instance concern — they need separate gates.

Part of OCaml audit sweep Cycle 19 deep-read of `lib/shutdown.ml`
(197 lines). The check-then-set race is a semantic bug that only
surfaces when the function is read end-to-end with a concurrency
mindset — grep audits in Cycles 1-16 focused on exception
boundaries and wouldn't have flagged it.
