### PR TITLE
fix(keeper): switch sangsu cascade to keeper_unified

### DIFF
--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -65,8 +65,8 @@ execution_scope = "workspace"
 tool_preset = "social"
 also_allow = ["keeper_voice_speak", "keeper_voice_listen"]
 
-# Local Ollama — tool_choice contract relaxed in OAS 0.119.1 (oas#786)
-cascade_name = "local_only"
+# GLM Coding Plan first, Ollama fallback (oas#786 relaxes tool_choice)
+cascade_name = "keeper_unified"
 
 # Telemetry Feedback
 telemetry_feedback_enabled = true


### PR DESCRIPTION
## Summary

sangsu keeper를 `local_only` → `keeper_unified` cascade로 전환.

## Problem

sangsu가 Ollama-only cascade로 300KB+ JSON 요청을 보내 파싱 실패 반복.
`Invalid request: Value looks like object, but can't find closing '}' symbol`

## Fix

`keeper_unified` cascade 사용: GLM Coding Plan (포함 요금) → Ollama fallback.
GLM은 서버 사이드 파싱으로 대용량 요청도 처리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)