### PR TITLE
fix(subscriptions): silence unwired push_event_to_sessions after first warn

### DIFF
--- a/lib/subscriptions.ml
+++ b/lib/subscriptions.ml
@@ -150,11 +150,22 @@ end
     so agents can poll notifications without SSE subscription. *)
 let session_registry_ref : (Yojson.Safe.t -> int) option ref = ref None
 
+(** One-shot gate for the "registry not wired" message below. Keeps the
+    log from flooding when callers on a hot path (Tool_task,
+    tool_inline_dispatch_comm) invoke push_event_to_sessions before
+    bootstrap wires the bridge — or in test harnesses that never wire
+    it at all. *)
+let unwired_warned = Atomic.make false
+
 let set_session_push_fn (fn : Yojson.Safe.t -> int) =
   (match !session_registry_ref with
    | Some _ -> Log.Sub.warn "WARNING: session push fn already set, overwriting"
    | None -> ());
-  session_registry_ref := Some fn
+  session_registry_ref := Some fn;
+  (* Reset the one-shot gate so a subsequent unwire (if any future
+     code paths clear the ref) would warn again. Current code never
+     clears the ref, but the reset keeps the gate honest. *)
+  Atomic.set unwired_warned false
 
 (** Push a structured event to all active agent sessions.
     Used by modules (e.g. Tool_task) that lack direct Session.registry access. *)
@@ -164,7 +175,10 @@ let push_event_to_sessions (event : Yojson.Safe.t) : unit =
       (try ignore (push_fn event)
        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Sub.error "push_event failed: %s" (Printexc.to_string exn))
   | None ->
-      Log.Sub.info "push_event_to_sessions: registry not wired"
+      if Atomic.compare_and_set unwired_warned false true then
+        Log.Sub.info
+          "push_event_to_sessions: registry not wired \
+           (further calls silenced until set_session_push_fn runs)"
 
 (** Notify all subscribers of a resource change *)
 let notify_change ~(resource : resource_type) ~(change : change_type)


### PR DESCRIPTION
fix(subscriptions): silence unwired push_event_to_sessions after first warn

`push_event_to_sessions` logged `Log.Sub.info "push_event_to_sessions:
registry not wired"` **on every call** when
`session_registry_ref = None`. The two call sites in `tool_task.ml`
and `tool_inline_dispatch_comm.ml` fire on every task/message
dispatch, so a process that doesn't wire the session bridge
(typical in tests, and possible in minimal server configs that
don't enable the notification harness) spams the log with a
recurring info line for every user interaction.

Add a process-wide `Atomic.bool` one-shot gate. The first unwired
call logs; subsequent calls short-circuit silently until
`set_session_push_fn` is called (which resets the gate, so a
later unwire+rewire sequence would warn again if such a sequence
ever gets introduced).

## Why this is better than demoting to debug

A `debug` level would disappear under production log config, but
then the bridge-not-wired state would be invisible during server
startup when you actually want to know. The one-shot info keeps
the "bridge disabled" observability signal present but bounds it
to a single line per configuration, not a per-request flood.

## Verification

```
dune build --root . lib/                           # exit 0
dune exec --root . -- ./test/test_subscriptions.exe
# Test Successful. 25 tests run.
```

Part of OCaml audit sweep Cycle 20 deep-read of `lib/subscriptions.ml`
(292 lines). The chatty info log was not a correctness bug but a
telemetry noise issue that grep patterns wouldn't catch without
contextual knowledge of caller hotness.

## Other findings from the read (not in this PR)

- `SubscriptionStore` uses plain `Hashtbl` without any Mutex. Safe
  under single-domain cooperative Eio but the assumption is
  undocumented. If anything ever runs subscription ops across
  domains the tables will corrupt silently. Worth an Issue after
  confirming the single-domain invariant is intended.
- `find_matching` is O(n_subs) per notification — a latent scaling
  cliff at high subscription counts. Not a bug at current scale.
- `filter = Some "*"` and `filter = None` are equivalent semantics
  but different JSON representations exposed to clients. Minor
  ambiguity.
