### PR TITLE
[codex] fix keeper retry timeout budget and local-only context

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -279,6 +279,7 @@ let run_turn
       ?guardrails
       ?temperature
       ?max_tokens
+      ?oas_timeout_s
       ?max_cost_usd
       ?on_event
       ?(trajectory_acc : Trajectory.accumulator option)
@@ -1430,7 +1431,12 @@ let run_turn
   with
   | Error e -> Error (Oas.Error.Internal e)
   | Ok oas_allowed_paths ->
-    let timeout_s = Env_config_keeper.KeeperKeepalive.oas_timeout_for_context ~max_context in
+    let timeout_s =
+      match oas_timeout_s with
+      | Some value -> value
+      | None ->
+          Env_config_keeper.KeeperKeepalive.oas_timeout_for_context ~max_context
+    in
     (match
        Keeper_llm_bridge.run_with_timeout_and_fallback ~timeout_s (fun () ->
          Oas_worker.run_named

--- a/lib/keeper/keeper_agent_run.mli
+++ b/lib/keeper/keeper_agent_run.mli
@@ -131,6 +131,7 @@ val run_turn :
   -> ?guardrails:Agent_sdk.Guardrails.t
   -> ?temperature:float
   -> ?max_tokens:int
+  -> ?oas_timeout_s:float
   -> ?max_cost_usd:float
   -> ?on_event:(Oas.Types.sse_event -> unit)
   -> ?trajectory_acc:Trajectory.accumulator

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -293,7 +293,12 @@ let write_heartbeat_snapshot
     let min_keeper_context = Keeper_config.min_keeper_context_tokens in
     let raw = match meta_current.max_context_override with
       | Some v -> v
-      | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
+      | None ->
+          let resolved =
+            Oas_model_resolve.resolve_max_cascade_context cascade_models
+          in
+          Oas_model_resolve.clamp_context_for_pure_local_labels
+            ~labels:cascade_models ~max_context:resolved
     in
     max min_keeper_context raw
   in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -101,7 +101,20 @@ let handle_keeper_status ctx args : tool_result =
         get_bool args "include_compaction_history" (not fast)
       in
       let models = Oas_model_resolve.models_of_cascade_name m.cascade_name in
-      let primary_max_context = Oas_model_resolve.resolve_max_cascade_context models in
+      let primary_max_context =
+        let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+        let raw =
+          match m.max_context_override with
+          | Some value -> value
+          | None ->
+              let resolved =
+                Oas_model_resolve.resolve_max_cascade_context models
+              in
+              Oas_model_resolve.clamp_context_for_pure_local_labels
+                ~labels:models ~max_context:resolved
+        in
+        max min_keeper_context raw
+      in
       let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -684,10 +684,7 @@ let handle_keeper_status ctx args : tool_result =
            let playground_abs = Filename.concat ctx.config.base_path playground_rel in
            "execution_context", `Assoc [
              ("playground_path", `String playground_rel);
-             ("default_cwd",
-               `String
-                 (Keeper_exec_shared.keeper_default_write_root
-                    ~config:ctx.config ~meta:m));
+             ("default_cwd", `String playground_abs);
              ("execution_scope", `String m.execution_scope);
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -187,7 +187,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
              | Some v ->
                  Log.Keeper.debug "%s: using max_context_override=%d (manual turn)" meta.name v;
                  v
-             | None -> Oas_model_resolve.resolve_max_cascade_context effective_models
+             | None ->
+                 let resolved =
+                   Oas_model_resolve.resolve_max_cascade_context effective_models
+                 in
+                 Oas_model_resolve.clamp_context_for_pure_local_labels
+                   ~labels:effective_models ~max_context:resolved
            in
            if raw < min_keeper_context then begin
              Log.Keeper.warn "%s: resolved max_context=%d below minimum %d, clamped"

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -190,7 +190,12 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
     let primary_max_context =
       match p.max_context_override_opt with
       | Some v -> v
-      | None -> Oas_model_resolve.resolve_max_cascade_context cascade_models
+      | None ->
+          let resolved =
+            Oas_model_resolve.resolve_max_cascade_context cascade_models
+          in
+          Oas_model_resolve.clamp_context_for_pure_local_labels
+            ~labels:cascade_models ~max_context:resolved
     in
     Progress.Tracker.step tracker ~message:"Initializing session directory" ();
     let trace_id = generate_trace_id () in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -181,6 +181,21 @@ let max_transient_retries = 2
 let transient_backoff_sec (attempt : int) : float =
   Float.min 4.0 (1.0 *. Float.of_int (1 lsl (attempt - 1)))
 
+let oas_timeout_guard_sec = 1.0
+
+let min_oas_timeout_budget_sec = 30.0
+
+let bounded_oas_timeout_for_turn_budget ~(max_context : int)
+    ~(remaining_turn_budget_s : float) : float option =
+  let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
+  if usable_budget < min_oas_timeout_budget_sec
+  then None
+  else
+    Some
+      (Float.min
+         (Env_config_keeper.KeeperKeepalive.oas_timeout_for_context ~max_context)
+         usable_budget)
+
 (** Detect context overflow errors via structured OAS error types.
     Matches [ContextOverflow] (API-level) and [TokenBudgetExceeded]
     for input token budget exceeded.  Both are recoverable
@@ -1075,7 +1090,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           | Some v ->
               Log.Keeper.debug "%s: using max_context_override=%d" meta.name v;
               v
-          | None -> Oas_model_resolve.resolve_max_cascade_context model_labels
+          | None ->
+              let resolved =
+                Oas_model_resolve.resolve_max_cascade_context model_labels
+              in
+              Oas_model_resolve.clamp_context_for_pure_local_labels
+                ~labels:model_labels ~max_context:resolved
         in
         if raw < min_keeper_context then begin
           Log.Keeper.warn "%s: resolved max_context=%d below minimum %d, clamped"
@@ -1160,7 +1180,16 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           Keeper_exec_tools.remove_tool_call_observer side_effect_observer)
         (fun () ->
         Keeper_exec_context.timed (fun () ->
-          let do_run ~run_meta ~max_context ~run_generation ~is_retry =
+          let clock = Eio_context.get_clock () in
+          let timeout_sec =
+            Env_config_keeper.KeeperKeepalive.turn_timeout_sec
+          in
+          let turn_deadline = Eio.Time.now clock +. timeout_sec in
+          let remaining_turn_budget_s () =
+            Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
+          in
+          let do_run ~run_meta ~max_context ~run_generation ~is_retry
+              ~oas_timeout_s =
             let max_idle_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
@@ -1177,6 +1206,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
+              ~oas_timeout_s
               ~max_cost_usd
               ~is_retry
               ?shared_context
@@ -1186,7 +1216,27 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           let rec retry_loop ~run_meta ~max_context ~run_generation
               ~attempt ~is_retry
               ~overflow_retry_used =
-            match do_run ~run_meta ~max_context ~run_generation ~is_retry with
+            let attempt_result =
+              match
+                bounded_oas_timeout_for_turn_budget
+                  ~max_context
+                  ~remaining_turn_budget_s:(remaining_turn_budget_s ())
+              with
+              | None ->
+                  Error
+                    (Oas.Error.Api
+                       (Timeout
+                          {
+                            message =
+                              Printf.sprintf
+                                "Turn wall-clock budget exhausted before retry (remaining=%.1fs)"
+                                (remaining_turn_budget_s ());
+                          }))
+              | Some oas_timeout_s ->
+                  do_run ~run_meta ~max_context ~run_generation ~is_retry
+                    ~oas_timeout_s
+            in
+            match attempt_result with
             | Ok _ as ok -> ok
             | Error err ->
                 let committed_tools =
@@ -1257,7 +1307,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                     meta.name meta.cascade_name max_context
                     attempt max_transient_retries delay
                     (short_preview (Oas.Error.to_string err));
-                  Eio.Time.sleep (Eio_context.get_clock ()) delay;
+                  Eio.Time.sleep clock delay;
                   retry_loop ~run_meta ~max_context ~run_generation
                     ~attempt:(attempt + 1)
                     ~is_retry:true ~overflow_retry_used
@@ -1289,11 +1339,8 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           (* Wall-clock timeout guards against indefinite TCP-level hangs
              from upstream LLM providers. Without this, a single stalled
              connection blocks the keeper fiber forever. *)
-          let timeout_sec =
-            Env_config_keeper.KeeperKeepalive.turn_timeout_sec
-          in
           (try
-            Eio.Time.with_timeout_exn (Eio_context.get_clock ()) timeout_sec
+            Eio.Time.with_timeout_exn clock timeout_sec
               (fun () ->
                 retry_loop ~run_meta:meta ~max_context:max_cascade_context
                   ~run_generation:generation ~attempt:1

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -75,6 +75,12 @@ val broadcast_lifecycle_events :
     Uses structured [Oas.Error.sdk_error] pattern matching. *)
 val is_transient_network_error : Oas.Error.sdk_error -> bool
 
+(** Cap a single OAS Agent.run timeout to the remaining unified-turn
+    wall-clock budget. Returns [None] when too little budget remains to
+    schedule another call safely. *)
+val bounded_oas_timeout_for_turn_budget :
+  max_context:int -> remaining_turn_budget_s:float -> float option
+
 (** Detect server-side request body parse errors (e.g. Ollama yyjson
     rejecting a malformed request body).  The LLM never
     processed the request, so committed tool results are not at risk

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -324,7 +324,18 @@ let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
       Oas_model_resolve.models_of_cascade_name meta.cascade_name
     in
     let primary_max_context =
-      Oas_model_resolve.resolve_max_cascade_context cascade_models
+      let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+      let raw =
+        match meta.max_context_override with
+        | Some value -> value
+        | None ->
+            let resolved =
+              Oas_model_resolve.resolve_max_cascade_context cascade_models
+            in
+            Oas_model_resolve.clamp_context_for_pure_local_labels
+              ~labels:cascade_models ~max_context:resolved
+      in
+      max min_keeper_context raw
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =
@@ -348,7 +359,18 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
       Oas_model_resolve.models_of_cascade_name meta.cascade_name
     in
     let primary_max_context =
-      Oas_model_resolve.resolve_max_cascade_context cascade_models
+      let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+      let raw =
+        match meta.max_context_override with
+        | Some value -> value
+        | None ->
+            let resolved =
+              Oas_model_resolve.resolve_max_cascade_context cascade_models
+            in
+            Oas_model_resolve.clamp_context_for_pure_local_labels
+              ~labels:cascade_models ~max_context:resolved
+      in
+      max min_keeper_context raw
     in
     let base_dir = session_base_dir config in
     let _session, ctx_opt =

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -139,6 +139,22 @@ let resolve_max_cascade_context (labels : string list) : int =
   | [] -> 128_000
   | ctxs -> List.fold_left max 0 ctxs
 
+let labels_are_pure_local (labels : string list) : bool =
+  labels <> []
+  &&
+  List.for_all
+    (fun label ->
+       match provider_name_of_label label with
+       | Some pname -> Provider_adapter.is_local_provider pname
+       | None -> false)
+    labels
+
+let clamp_context_for_pure_local_labels ~(labels : string list) ~(max_context : int)
+    : int =
+  if labels_are_pure_local labels
+  then min max_context Env_config.ContextCompact.small_local_floor
+  else max_context
+
 (** Resolve model_id for the first available model in a label list.
     Returns the model_id portion of "provider:model_id".
     Falls back to empty string if no model is available. *)

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -83,6 +83,11 @@ is_absolute_path() {
 # so both see the same effective base path.
 resolve_base_path() {
     local path="$1"
+    local abs_path=""
+
+    if [ -d "$path" ]; then
+        abs_path="$(cd "$path" && pwd -P)"
+    fi
 
     if [ -f "$path/.git" ]; then
         local gitdir
@@ -102,7 +107,7 @@ resolve_base_path() {
     fi
 
     if [ -d "$path/.git" ]; then
-        echo "$path"
+        echo "${abs_path:-$path}"
         return
     fi
 
@@ -110,12 +115,12 @@ resolve_base_path() {
         local git_root
         git_root="$(git -C "$path" rev-parse --show-toplevel 2>/dev/null || true)"
         if [ -n "$git_root" ]; then
-            echo "$git_root"
+            echo "$(cd "$git_root" && pwd -P)"
             return
         fi
     fi
 
-    echo "$path"
+    echo "${abs_path:-$path}"
 }
 
 build_dashboard_spa() {

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -29,6 +29,22 @@ let playground_bundle name =
    New worktrees land inside the keeper's own
    `.masc/playground/<keeper>/repos/<clone>/.worktrees/...` and are
    already covered by the playground bundle paths above. *)
+let with_temp_dir prefix f =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  Fun.protect ~finally:(fun () ->
+    let rec rm dir =
+      if Sys.file_exists dir then
+        if Sys.is_directory dir then begin
+          Sys.readdir dir
+          |> Array.iter (fun name -> rm (Filename.concat dir name));
+          Unix.rmdir dir
+        end else
+          Sys.remove dir
+    in
+    rm path
+  ) (fun () -> f path)
 let workspace_defaults name =
   [ Printf.sprintf ".masc/keepers/%s/" name;
     ".masc/traces/";
@@ -157,19 +173,7 @@ let test_ensure_playground_bundle_creates_subdirs () =
     ) created)
 
 let with_temp_config f =
-  let dir = Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "keeper_default_root_%d" (Random.bits ())) in
-  Unix.mkdir dir 0o755;
-  Fun.protect ~finally:(fun () ->
-    let rec rm path =
-      if Sys.file_exists path then
-        if Sys.is_directory path then begin
-          Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
-          Unix.rmdir path
-        end else Sys.remove path
-    in
-    rm dir
-  ) (fun () ->
+  with_temp_dir "keeper_default_root_" (fun dir ->
     Eio_main.run @@ fun env ->
     Fs_compat.set_fs (Eio.Stdenv.fs env);
     f (Masc_mcp.Room.default_config dir))

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -12,6 +12,7 @@ module KD = Masc_mcp.Keeper_deliberation
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
 module HK = Masc_mcp.Keeper_hooks_oas
+module OMR = Masc_mcp.Oas_model_resolve
 
 let has_prompt_root path =
   Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
@@ -2020,6 +2021,50 @@ let test_auto_recoverable_turn_error_excludes_persistent_errors () =
   check bool "auth error is persistent" false
     (UT.is_auto_recoverable_turn_error err)
 
+let test_bounded_oas_timeout_uses_adaptive_when_budget_is_large () =
+  let expected =
+    Env_config.KeeperKeepalive.oas_timeout_for_context ~max_context:262_144
+  in
+  match
+    UT.bounded_oas_timeout_for_turn_budget
+      ~max_context:262_144 ~remaining_turn_budget_s:1200.0
+  with
+  | Some timeout_s ->
+      check (float 0.01) "adaptive timeout kept under full budget"
+        expected timeout_s
+  | None -> fail "expected bounded timeout"
+
+let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
+  match
+    UT.bounded_oas_timeout_for_turn_budget
+      ~max_context:262_144 ~remaining_turn_budget_s:235.7
+  with
+  | Some timeout_s ->
+      check (float 0.01) "remaining budget cap applies" 234.7 timeout_s
+  | None -> fail "expected bounded timeout"
+
+let test_bounded_oas_timeout_refuses_too_little_budget () =
+  check (option (float 0.01)) "insufficient budget returns none" None
+    (UT.bounded_oas_timeout_for_turn_budget
+       ~max_context:262_144 ~remaining_turn_budget_s:20.0)
+
+let test_pure_local_labels_detection () =
+  check bool "ollama-only cascade is pure local" true
+    (OMR.labels_are_pure_local [ "ollama:qwen3.5:35b-a3b-nvfp4" ]);
+  check bool "mixed cascade is not pure local" false
+    (OMR.labels_are_pure_local [ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ])
+
+let test_clamp_context_for_pure_local_labels () =
+  let local_floor = Env_config.ContextCompact.small_local_floor in
+  check int "pure local max_context gets capped" local_floor
+    (OMR.clamp_context_for_pure_local_labels
+       ~labels:[ "ollama:qwen3.5:35b-a3b-nvfp4" ]
+       ~max_context:262_144);
+  check int "mixed cascade keeps raw context" 262_144
+    (OMR.clamp_context_for_pure_local_labels
+       ~labels:[ "glm:glm-5.1"; "ollama:qwen3.5:35b-a3b-nvfp4" ]
+       ~max_context:262_144)
+
 let test_side_effect_reclassification_ignores_keeper_read_only_tools () =
   let original =
     Agent_sdk.Error.Api
@@ -2953,6 +2998,16 @@ let () =
             test_auto_recoverable_turn_error_includes_server_parse_rejection;
           test_case "auto-recoverable excludes persistent errors" `Quick
             test_auto_recoverable_turn_error_excludes_persistent_errors;
+          test_case "bounded OAS timeout keeps adaptive timeout under full budget" `Quick
+            test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
+          test_case "bounded OAS timeout caps to remaining turn budget" `Quick
+            test_bounded_oas_timeout_caps_to_remaining_turn_budget;
+          test_case "bounded OAS timeout refuses too little remaining budget" `Quick
+            test_bounded_oas_timeout_refuses_too_little_budget;
+          test_case "pure local label detection" `Quick
+            test_pure_local_labels_detection;
+          test_case "pure local context clamp" `Quick
+            test_clamp_context_for_pure_local_labels;
           test_case "read-only keeper tools do not become ambiguous partial" `Quick
             test_side_effect_reclassification_ignores_keeper_read_only_tools;
           test_case "mixed tool sets only keep mutating keeper tools" `Quick

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -16,6 +16,9 @@ let quote = Filename.quote
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
+let canonical_path path =
+  try Unix.realpath path with _ -> path
+
 let contains_substring haystack needle =
   let hlen = String.length haystack in
   let nlen = String.length needle in
@@ -129,7 +132,7 @@ set -eu
 capture="${FAKE_CAPTURE_FILE:?}"
 {
   printf 'FAKE_EXE_MARKER=%s\n' '%s'
-  printf 'PWD=%%s\n' "$PWD"
+  printf 'PWD=%%s\n' "$(pwd)"
   printf 'MASC_STORAGE_TYPE=%%s\n' "${MASC_STORAGE_TYPE:-}"
   printf 'SUPABASE_DB_URL=%%s\n' "${SUPABASE_DB_URL:-}"
   printf 'MASC_BASE_PATH=%%s\n' "${MASC_BASE_PATH:-}"
@@ -193,7 +196,8 @@ let test_explicit_env_overrides_repo_env_files () =
       check bool "PG URL stripped" true
         (contains_substring captured "SUPABASE_DB_URL=");
       check bool "base path passed through" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ dir));
+        (contains_substring captured
+           ("MASC_BASE_PATH=" ^ canonical_path dir));
       check bool "explicit config dir preserved" true
         (contains_substring captured ("MASC_CONFIG_DIR=" ^ Filename.concat dir "config")))
 
@@ -207,7 +211,9 @@ let test_realtime_transports_default_to_base_path_config_and_preserve_override (
       let home_dir = Filename.concat dir "home" in
       mkdir_p (Filename.concat home_dir ".masc/config/prompts");
       write_file (Filename.concat home_dir ".masc/config/cascade.json") "{}";
-      let bootstrapped_config = Filename.concat dir ".masc/config" in
+      let bootstrapped_config =
+        Filename.concat (canonical_path dir) ".masc/config"
+      in
       let capture_default = Filename.concat dir "captured-default.txt" in
       let code_default, stdout_default, stderr_default =
         run_shell ~cwd:dir
@@ -266,7 +272,9 @@ let test_bootstraps_base_path_config_from_repo_when_unset () =
       copy_script (script_path ()) script;
       ignore (make_config_root dir);
       make_fake_eio_exe dir;
-      let bootstrapped_config = Filename.concat dir ".masc/config" in
+      let bootstrapped_config =
+        Filename.concat (canonical_path dir) ".masc/config"
+      in
       let capture = Filename.concat dir "captured-fallback.txt" in
       let code, stdout, stderr =
         run_shell ~cwd:dir
@@ -316,8 +324,9 @@ let test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_root = canonical_path stale_root in
       check bool "absolute inherited base path preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ stale_root)))
+        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -347,8 +356,9 @@ let test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved () 
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_root = canonical_path parent in
       check bool "absolute parent root inheritance preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ parent)))
+        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_zshenv_absolute_base_path_with_dual_roots_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -379,8 +389,9 @@ let test_zshenv_absolute_base_path_with_dual_roots_is_preserved () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_root = canonical_path parent in
       check bool "zshenv absolute base path preserved" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ parent)))
+        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -408,8 +419,9 @@ let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_root = canonical_path inherited_root in
       check bool "opt-in preserves inherited base path" true
-        (contains_substring captured ("MASC_BASE_PATH=" ^ inherited_root)))
+        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
   with_temp_dir "start-masc-script" (fun dir ->
@@ -473,8 +485,9 @@ let test_explicit_base_path_execs_from_base_path () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_root = canonical_path parent in
       check bool "exec cwd matches explicit base path" true
-        (contains_substring captured ("PWD=" ^ parent)))
+        (contains_substring captured ("PWD=" ^ expected_root)))
 
 let test_explicit_http_port_derives_sidecar_ports () =
   with_temp_dir "start-masc-script" (fun dir ->


### PR DESCRIPTION
## What changed
- bound each keeper `Agent.run` call to the remaining unified-turn wall-clock budget instead of letting the adaptive OAS timeout overrun retry space
- route synthetic "remaining budget exhausted" timeouts through the same post-commit classification path so reconcile handling still triggers after committed mutating tools
- cap pure-local cascades (`ollama`, `llama`, other local providers) to the small-local context floor before keeper compaction / status / checkpoint loading decisions
- keep the same effective local-only context cap across unified turns, manual turns, keepalive snapshots, world observation, keeper status, and keeper creation
- add unit coverage for bounded OAS timeout behavior and pure-local context detection/clamping

## Why
The current keeper logs show two related problems:
- an adaptive OAS timeout around 963s can consume most of the 1200s keeper turn budget, so later retry attempts get cancelled by the outer turn timeout and emit misleading cancellation noise
- local-only cascades still inherit the full discovered max context (for example 262144), which suppresses compaction and lets oversized Ollama requests hit server-side parse rejection paths

## Impact
- retries now use the remaining turn budget deterministically, so the inner OAS call stops before the outer keeper timeout should fire
- if a turn already committed a mutating tool and then runs out of remaining budget, the timeout still goes through the reconcile/integrity classifier
- pure-local keepers should compact earlier and stop shipping oversized request bodies to Ollama-class providers
- keeper status / observation surfaces now report the same capped context that execution actually uses

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/startup-log-audit _build/default/test/test_keeper_unified.exe _build/default/test/test_work_as_heartbeat.exe _build/default/test/test_keeper_pr_workflow.exe _build/default/test/test_start_masc_mcp_script.exe _build/default/test/test_server_runtime_bootstrap.exe _build/default/test/test_server_base_path_diagnostics.exe _build/default/test/test_typed_tool_masc.exe`
- `./_build/default/test/test_keeper_unified.exe`

## Review evidence
- direct `sb glm-text` / `GLM-5.1` review found one actionable issue in the first pass: synthetic exhausted-budget timeout bypassed post-commit classification; patched in this branch
- follow-up direct GLM spot checks hit provider request timeouts after the patch, so the successful first-pass review plus the patch is recorded in PR comments