### PR TITLE
fix(dashboard): drop `undefined as unknown as number` + duplicate event cast

### DIFF
--- a/dashboard/src/components/common/number-input.ts
+++ b/dashboard/src/components/common/number-input.ts
@@ -10,13 +10,13 @@ interface NumberInputProps {
   step?: number | 'any'
   min?: number
   max?: number
-  onInput?: (value: number) => void
+  onInput?: (value: number | undefined) => void
 }
 
 export function NumberInput({ value, placeholder, disabled, class: cx, step, min, max, onInput }: NumberInputProps) {
   const handleInput = (e: Event) => {
     const raw = (e.target as HTMLInputElement).value
-    if (raw === '') { onInput?.(undefined as unknown as number); return }
+    if (raw === '') { onInput?.(undefined); return }
     const num = Number(raw)
     if (!Number.isNaN(num)) onInput?.(num)
   }

--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -226,9 +226,7 @@ function processHarnessEvent(evt: unknown): void {
     || type === 'keeper_handoff'
     || type === 'masc/keeper_handoff'
   ) {
-    const fallbackEvent = evt as unknown as Record<string, unknown>
-    const handoffPayload: Record<string, unknown> =
-      payload ?? fallbackEvent ?? {}
+    const handoffPayload: Record<string, unknown> = payload ?? event
     const hasTimestamp =
       handoffPayload.timestamp != null || handoffPayload.ts_unix != null
     const hasKeeperIdentity =

--- a/dashboard/src/components/tool-executor/schema-field.ts
+++ b/dashboard/src/components/tool-executor/schema-field.ts
@@ -63,7 +63,7 @@ export function SchemaField({ name, schema, value, required, onChange }: SchemaF
         <label class="text-[11px] text-[var(--text-muted)] font-medium">${name}${requiredMark}</label>
         ${hint}
         <${NumberInput} value=${(value as number) ?? (schema.default as number) ?? ''} placeholder=${name}
-          step=${schema.type === 'integer' ? 1 : 'any'} onInput=${(v: number) => onChange(name, v)} />
+          step=${schema.type === 'integer' ? 1 : 'any'} onInput=${(v: number | undefined) => onChange(name, v)} />
       </div>
     `
   }


### PR DESCRIPTION
## Summary

Two unrelated but small type-safety improvements from the \`as unknown as\` audit.

## Changes

### 1. \`components/common/number-input.ts\` + \`schema-field.ts\`

\`NumberInput.onInput\` was typed \`(value: number) => void\`. This forced the clear-field path to lie to the type system:
\`\`\`ts
if (raw === '') { onInput?.(undefined as unknown as number); return }
\`\`\`
Even though the handler was **intentionally designed** to pass \`undefined\` on empty input. Widened the prop to \`(value: number | undefined) => void\` — the cast is gone. The single caller (\`tool-executor/schema-field.ts\`) updates its \`(v: number)\` to \`(v: number | undefined)\` and forwards through the \`onChange(name, unknown)\` dispatcher — no behaviour change.

### 2. \`components/harness-health-state.ts\`

\`processHarnessEvent\` already narrows at the top:
\`\`\`ts
const event = evt as Record<string, unknown>
\`\`\`
The handoff branch was re-casting the same \`evt\` via \`as unknown as Record<string, unknown>\` into a new \`fallbackEvent\` variable. Deleted that line and reused \`event\` in the \`handoffPayload\` coalesce.

## Not fixed (on purpose)

\`operator-normalizers.ts:309\` was the third candidate but its double cast (\`as unknown as OperatorDigest['swarm_status']\`) is actually necessary — \`isRecord\` narrows to \`Record<string, unknown>\` which has no overlap with the \`swarm_status\` union, so TS rejects a single assertion with \`TS2352\`. Leaving that one until a real normalizer is added.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed)