### PR TITLE
fix(ci): require tool_policy.toml in config_signature_exists to skip _build shards

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -84,14 +84,21 @@ let to_json (resolution : resolution) =
       ("personas", item_to_json resolution.personas);
     ]
 
+(* A config root is identified by [tool_policy.toml] — the SSOT file that
+   keeper/tool runtime cannot start without. Any config directory that
+   lacks tool_policy.toml is a partial build artifact (e.g. dune materializes
+   [config/cascade.json] into [_build/default/config/] when a test declares
+   it as a dep), and must not be picked as the resolved root.
+
+   Before this change the signature was [tool_policy.toml OR prompts OR
+   keepers OR personas OR cascade.json]. The OR semantics caused
+   [_build/default/config/] with only cascade.json to be picked ahead of
+   the real source [config/], making init_policy_config fail in CI with
+   "tool policy config not found at resolved config root …/_build/default/
+   config/tool_policy.toml". *)
 let config_signature_exists config_dir =
-  let cascade = Filename.concat config_dir "cascade.json" in
-  let prompts = Filename.concat config_dir "prompts" in
-  let keepers = Filename.concat config_dir "keepers" in
-  let personas = Filename.concat config_dir "personas" in
-  existing_dir config_dir
-  && (existing_file cascade || existing_dir prompts || existing_dir keepers
-     || existing_dir personas)
+  let tool_policy = Filename.concat config_dir "tool_policy.toml" in
+  existing_dir config_dir && existing_file tool_policy
 
 let rec ancestor_dirs path =
   let dir = absolute_path path in

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -35,6 +35,17 @@ let make_config_root root =
   mkdir_p (Filename.concat config "keepers");
   mkdir_p (Filename.concat config "personas");
   write_file (Filename.concat config "cascade.json") "{}";
+  write_file (Filename.concat config "tool_policy.toml") "# test marker\n";
+  config
+
+(* A partial config dir that mimics dune's [_build/default/config/]
+   materialisation: cascade.json is promoted but tool_policy.toml is
+   absent. The resolver must NOT pick this as the config root; it
+   should keep walking up. *)
+let make_partial_config_root root =
+  let config = Filename.concat root "config" in
+  mkdir_p config;
+  write_file (Filename.concat config "cascade.json") "{}";
   config
 
 let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir
@@ -139,6 +150,37 @@ let test_local_masc_fallback_collapses_explicit_masc_dir () =
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check string "root path" local_config resolution.config_root.path
 
+(* Regression: dune materialises [config/cascade.json] into
+   [_build/default/config/cascade.json] when a test declares it as a
+   [(deps %{workspace_root}/config/cascade.json)] rule. Before the
+   config_signature_exists tightening, the executable-relative lookup
+   matched [_build/default/config/] on that lone file and reported a
+   broken config root. With tool_policy.toml required, the lookup
+   walks past _build and picks the real source config. *)
+let test_build_dir_partial_config_is_skipped () =
+  with_temp_dir "config-dir-build-partial" @@ fun root ->
+  let real_config = make_config_root root in
+  let build_config_parent = Filename.concat root "_build/default/test" in
+  mkdir_p build_config_parent;
+  let exe = Filename.concat build_config_parent "test_runner.exe" in
+  write_file exe "#!/bin/sh\n";
+  Unix.chmod exe 0o755;
+  (* Partial config mimicking _build/default/config materialisation:
+     cascade.json is promoted but tool_policy.toml is absent. *)
+  let _partial =
+    make_partial_config_root (Filename.concat root "_build/default")
+  in
+  let resolution =
+    Lib.Config_dir_resolver.resolve_with
+      (make_inputs ~cwd:build_config_parent ~executable_name:exe ())
+  in
+  check string "status ready" "ready"
+    (Lib.Config_dir_resolver.status_to_string resolution.status);
+  check string "skipped partial _build config" real_config
+    resolution.config_root.path;
+  check string "source is exe_relative" "exe_relative"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source)
+
 let test_no_legacy_me_root_fallback () =
   with_temp_dir "config-dir-no-legacy" @@ fun me_root ->
   let _repo_root =
@@ -200,6 +242,7 @@ let test_personas_dirs_ignores_base_path_fallback () =
   mkdir_p (Filename.concat config_root "keepers");
   mkdir_p (Filename.concat config_root "personas");
   write_file (Filename.concat config_root "cascade.json") "{}";
+  write_file (Filename.concat config_root "tool_policy.toml") "# test marker\n";
   let base = Filename.dirname config_root in
   let base_personas = Filename.concat (Filename.concat base ".masc") "personas" in
   mkdir_p base_personas;
@@ -225,6 +268,8 @@ let () =
           test_case "local masc fallback collapses explicit .masc dir"
             `Quick test_local_masc_fallback_collapses_explicit_masc_dir;
           test_case "home masc fallback" `Quick test_home_masc_fallback;
+          test_case "build dir partial config is skipped (cascade-only)"
+            `Quick test_build_dir_partial_config_is_skipped;
           test_case "does not fallback to legacy me_root repo path" `Quick
             test_no_legacy_me_root_fallback;
         ] );


### PR DESCRIPTION
## Why — main CI is red

Every main commit after \`afd9fb6a9\` has had Build and Test fail with:

\`\`\`
Fatal error: exception Invalid_argument(\"result is Error _\")
Called from Stdlib__Result.get_ok in file \"result.ml\"
Called from Dune__exe__Test_operator_control in file \"test/test_operator_control.ml\", line 3, characters 9-83
\`\`\`

Preceded by:

\`\`\`
init_policy_config failed: tool policy config not found at resolved config root
/home/runner/work/masc-mcp/masc-mcp/_build/default/config/tool_policy.toml
(File not found). warnings: Resolved config child is missing: prompts | keepers | personas
\`\`\`

\`test_operator_control\` aborts at line 3 (\`Result.get_ok (init_policy_config …)\`), which poisons the \`--quick\` suite. Every open PR also inherits this failure.

## Root cause

\`test/dune\` declares \`(deps %{workspace_root}/config/cascade.json)\` for \`test_cascade_config_validity\`. Dune materialises **just that one file** into \`_build/default/config/cascade.json\` — the rest of \`config/\` (\`tool_policy.toml\`, \`prompts/\`, \`keepers/\`, \`personas/\`) stays in source only.

\`Config_dir_resolver.config_signature_exists\` was permissive:

\`\`\`ocaml
existing_dir config_dir
&& (existing_file cascade || existing_dir prompts || existing_dir keepers
   || existing_dir personas)
\`\`\`

During the executable-relative walk from \`_build/default/test/<exe>\`, the resolver finds \`_build/default/config/\` with the materialised \`cascade.json\`, declares it the config root, and short-circuits the walk **before reaching the real source \`config/\`**. \`init_policy_config\` then looks for \`_build/default/config/tool_policy.toml\`, which doesn't exist, and returns \`Error\`.

## Fix

Tighten the signature to require \`tool_policy.toml\`:

\`\`\`ocaml
let config_signature_exists config_dir =
  let tool_policy = Filename.concat config_dir \"tool_policy.toml\" in
  existing_dir config_dir && existing_file tool_policy
\`\`\`

\`tool_policy.toml\` is the SSOT the keeper/tool runtime cannot start without — requiring it is consistent with the actual invariant. Any config directory without \`tool_policy.toml\` is — by definition — a partial build artifact that must not be picked.

With this change the exe-relative walk skips \`_build/default/config\` (cascade-only) and keeps walking until it finds the real source \`config/\`.

## Surface area

- \`config_signature_exists\` has **4 call sites**, all in the same file (\`config_dir_resolver.ml\`), all inside the lookup priority chain. No external callers.
- Does not touch runtime resolution for real installs (\`~/.masc/config/\`, \`\$MASC_BASE_PATH/.masc/config/\`, repo \`config/\`) — these all have \`tool_policy.toml\`.
- Does not affect \`MASC_CONFIG_DIR\` override path (that path doesn't use the signature check).

## Tests

- **Existing resolver tests updated**: \`make_config_root\` now writes a \`tool_policy.toml\` marker alongside \`cascade.json\`/\`prompts/\`/\`keepers/\`/\`personas/\`, so all four resolution sources still match. The one test that builds its config inline (\`test_personas_dirs_ignores_base_path_fallback\`) also writes the marker.
- **New regression test**: \`test_build_dir_partial_config_is_skipped\` mimics dune's partial \`_build/default/config/cascade.json\` materialisation by writing cascade.json only, placing a mock exe under \`_build/default/test/\`, and asserting the resolver walks past the partial dir and picks the real source config. The assertion also checks \`source = exe_relative\` so we know the walk actually ran.
- 12/12 \`test_config_dir_resolver\` tests pass locally.
- \`test_operator_control\` no longer trips on line 3 \`Result.get_ok\` — \`init_policy_config\` now succeeds. Residual local failures in the snapshot/actions submodules are **pre-existing and unrelated** to this fix (they did not appear in the CI log because the init abort cut execution short).

## Not fixing here

- Pre-existing test assertion failures in \`test_operator_control_snapshot.ml\` and \`test_operator_control_actions.ml\` that become visible once init succeeds. Those are scoped to a separate issue.
- The underlying dune materialisation side-effect (\`cascade.json\` bleeding into \`_build/default/\` when declared as a dep of a single test). Arguably test should use \`(deps …)\` with a sandbox, but that's a test-side change and orthogonal to this resolver fix.

## How to verify locally

\`\`\`bash
# reproduce the old failure on current main:
git checkout main
eval \$(opam env)
dune build
dune exec test/test_operator_control.exe
# -> Fatal error: exception Invalid_argument(\"result is Error _\")

# after this PR:
git checkout fix/ci-config-resolver-tool-policy-required
dune build
dune exec test/test_config_dir_resolver.exe
# -> 12/12 pass including \"build dir partial config is skipped\"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)