### PR TITLE
fix(pulse): catch raised consumer exceptions to honor "never crash pulse" invariant

### DIFF
--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -138,7 +138,26 @@ let dispatch_consumers_with_recovery t beat =
     if List.mem C.name t.disabled_consumers then
       ()  (* skip disabled consumers *)
     else if C.should_act beat then begin
-      match C.on_beat beat with
+      (* Convert raised exceptions to Error so they flow through the
+         same recovery pathway as explicit [Error _] returns. The
+         module doc comment promises "Consumer errors are logged but
+         never crash the pulse"; without this try/with, a consumer
+         that raises (Failure, Invalid_argument, or anything other
+         than a Result wrapper) would escape [dispatch], propagate
+         out of [tick], out of [loop], and kill the pulse fiber
+         entirely — silently breaking the "never crash the pulse"
+         invariant for every future beat. [Eio.Cancel.Cancelled] is
+         re-raised per the structured-concurrency contract. *)
+      let result =
+        try C.on_beat beat
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            Error
+              (Printf.sprintf "uncaught exception: %s"
+                 (Printexc.to_string exn))
+      in
+      match result with
       | Ok () ->
           (* Reset consecutive failure count on success *)
           Hashtbl.remove t.consumer_failures C.name


### PR DESCRIPTION
fix(pulse): catch raised consumer exceptions to honor "never crash pulse" invariant

The module doc comment at `lib/pulse.ml:8` promises:

> Consumer errors are logged but never crash the pulse.

but `dispatch_consumers_with_recovery` only handles the
`(unit, string) result` return from `C.on_beat beat`. Any consumer
that **raises** an exception (Failure, Invalid_argument, uncaught
OS errors, a bug in on_beat's happy path) propagates the exception
out of `dispatch` → out of `tick` → out of `loop` → kills the pulse
fiber entirely. The `Always_on` and `Bounded` lifecycles both lose
their beat source for all subsequent beats — a silent runtime-wide
pulse failure that violates the doc contract.

The existing recovery path (per-consumer consecutive-failure
tracking, auto-disable at threshold, re-enable API) is built to
isolate bad consumers; it just doesn't fire for exceptional ones.

## Change

Wrap `C.on_beat beat` in a try/with inside the loop:

- `Eio.Cancel.Cancelled _` is re-raised (structured-concurrency
  contract — let cancel propagate out of the pulse).
- Any other exception becomes
  `Error (Printf.sprintf "uncaught exception: %s" ...)` and flows
  through the existing failure counter / auto-disable path.

Now a consumer that raises gets logged, counted, and disabled at
the same threshold as an explicit `Error _`. The pulse fiber
keeps beating for well-behaved consumers.

## Verification

```
dune build --root . lib/                      # exit 0
dune exec --root . -- ./test/test_pulse.exe
# Pulse tests: 21 passed, 0 failed
```

The existing `test_pulse.ml` suite covers the explicit-Error
recovery flow (flaky consumer, disable, reenable) and all 21 tests
still pass. Raising-consumer test coverage is a separate follow-up
— the current test suite doesn't exercise a consumer that raises.

## Finding source

Cycle 21 deep-read of `lib/pulse.ml` (349 lines, the 5th module in
the deep-read series). The bug is a **doc-vs-code contract
violation**: the doc comment encodes the invariant but the code
doesn't enforce it for one pathway. Cycles 17-20 found similar
semantic gaps (phantom idempotency_key, lifetime-vs-window counter
drift, check-then-set race, per-call telemetry noise). Grep audits
don't catch these because the violation is relational, not
pattern-based.
