### PR TITLE
fix(dashboard): simplify import.meta.env.DEV access in sse-store

### DIFF
--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -382,11 +382,9 @@ export function setupSSEReaction(): () => void {
 
 // --- Periodic refresh ---
 
-const PERIODIC_REFRESH_MS =
-  typeof import.meta !== 'undefined'
-    && Boolean((import.meta as unknown as { env?: { DEV?: unknown } }).env?.DEV)
-    ? PERIODIC_REFRESH_DEV_MS
-    : PERIODIC_REFRESH_PROD_MS
+const PERIODIC_REFRESH_MS = import.meta.env.DEV
+  ? PERIODIC_REFRESH_DEV_MS
+  : PERIODIC_REFRESH_PROD_MS
 
 let _periodicId: ReturnType<typeof setInterval> | null = null
 


### PR DESCRIPTION
## Summary

\`sse-store.ts\` had a triple-guarded \`import.meta\` access:

\`\`\`ts
const PERIODIC_REFRESH_MS =
  typeof import.meta !== 'undefined'
    && Boolean((import.meta as unknown as { env?: { DEV?: unknown } }).env?.DEV)
    ? PERIODIC_REFRESH_DEV_MS
    : PERIODIC_REFRESH_PROD_MS
\`\`\`

\`vite-env.d.ts\` already declares \`/// <reference types=\"vite/client\" />\`, which types \`import.meta.env.DEV\` as a plain \`boolean\`. The \`typeof\` check and the \`as unknown as\` double cast are both unnecessary — Vite guarantees \`import.meta\` exists at build time.

## Change

\`\`\`ts
const PERIODIC_REFRESH_MS = import.meta.env.DEV
  ? PERIODIC_REFRESH_DEV_MS
  : PERIODIC_REFRESH_PROD_MS
\`\`\`

Net: \`+3 / -5\`. One more \`as unknown as\` gone from production code.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed)