### PR TITLE
docs(keeper): document post-turn-lifecycle invariant (closes follow-up #6592)

### DIFF
--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -90,7 +90,37 @@ type auto_rule_summary = {
 
 (** Typed events that trigger condition re-evaluation.
     These are the ONLY inputs to the deterministic state machine.
-    Non-deterministic measurements become typed events at the boundary. *)
+    Non-deterministic measurements become typed events at the boundary.
+
+    {2 Post-turn lifecycle contract (implicit invariant)}
+
+    [Compaction_started] / [Handoff_started] / their matching
+    [_completed] / [_failed] events MUST be dispatched only from
+    {!Keeper_post_turn.apply_post_turn_lifecycle}, which runs
+    synchronously at the tail of a keeper turn (inside
+    [Keeper_unified_turn.run_unified_turn] or the legacy
+    [Keeper_turn] path).
+
+    The keepalive loop ({!Keeper_keepalive.run_heartbeat_loop}) does
+    NOT explicitly gate dispatch on [phase]. It relies on the
+    structural property that [Compaction_started] and [Handoff_started]
+    are always paired with their [_completed] / [_failed] counterparts
+    inside a single [run_unified_turn] call, so the next keepalive
+    iteration can never observe the keeper in [Compacting] or
+    [HandingOff] phase at its dispatch decision point.
+
+    Violating this rule — for example, by emitting [Compaction_started]
+    from a separate async monitor fiber while a turn is still in flight
+    — reopens the {b KeepalivePhaseConsistency} safety bug formalized in
+    [specs/bug-models/KeepalivePhaseConsistency.tla]. That spec's
+    [NoDrainTransition] / [GhostDispatch] actions are the exact
+    counterexamples TLC will find.
+
+    If a future change needs to emit these events from outside
+    [apply_post_turn_lifecycle], add an explicit phase gate to the
+    keepalive dispatch site (roughly: [phase_allows_dispatch] reading
+    [Keeper_registry.get] before [run_unified_turn]) and re-verify
+    the TLA+ spec against the new code path. *)
 type event =
   | Heartbeat_ok
   | Heartbeat_failed of { consecutive : int; max_allowed : int }
@@ -105,11 +135,19 @@ type event =
       auto_rules : auto_rule_summary;
     }
   | Compaction_started
+    (** Emit ONLY from {!Keeper_post_turn.apply_post_turn_lifecycle}.
+        See the post-turn lifecycle contract above. *)
   | Compaction_completed of { before_tokens : int; after_tokens : int }
+    (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Compaction_failed of { reason : string }
+    (** Must fire in the same turn as the matching [Compaction_started]. *)
   | Handoff_started
+    (** Emit ONLY from {!Keeper_post_turn.apply_post_turn_lifecycle}.
+        See the post-turn lifecycle contract above. *)
   | Handoff_completed of { new_trace_id : string; generation : int }
+    (** Must fire in the same turn as the matching [Handoff_started]. *)
   | Handoff_failed of { reason : string }
+    (** Must fire in the same turn as the matching [Handoff_started]. *)
   | Operator_pause
   | Operator_resume
   | Operator_stop of { remove_meta : bool }


### PR DESCRIPTION
## Summary

Document the implicit structural property that makes `KeepalivePhaseConsistency` (from #6556) hold in the current codebase, so a future refactor doesn't silently break it.

Triaged from issue #6592 (audit of the keepalive dispatch path). No code change. Adds 39 lines of docstring to `lib/keeper/keeper_state_machine.mli` — specifically to the `event` variant and the six compaction/handoff constructors.

## Context

`KeepalivePhaseConsistency.tla` (introduced in #6556) formalizes:
```
phase ∈ {Offline, Compacting, HandingOff, Stopped, Dead} ⇒ ¬turn_in_flight
```

The original audit (#6592) asked: *does the real keepalive dispatch path enforce this?* Grep showed no explicit phase gate anywhere along the path:

- `keeper_keepalive.ml:889-891` — dispatch site reads `should_run_turn`, which has no phase input
- `keeper_world_observation.ml:719` — `unified_turn_decision` does not read `phase`
- `keeper_keepalive.ml:56-76` — `with_keeper_turn_slot` is a pure counting semaphore
- `keeper_keepalive.ml:1172` — loop header only reads the local `stop` atomic
- `keeper_registry.ml:588-691` — `dispatch_event_with_audit` updates the registry entry but never touches `fiber_stop` / `fiber_wakeup` / `grpc_close`
- `keeper_supervisor.ml:60-150` — supervisor forks into the server-level switch; no phase-driven `Switch.fail` or `Fiber.cancel`

So the question was: is this a latent bug, or is there an implicit structural property?

## What actually makes the code safe

`Compaction_started` and `Handoff_started` are dispatched **only** from inside `apply_post_turn_lifecycle` (`keeper_unified_turn.ml:1499-1507`, `keeper_turn.ml:332-340`), which runs synchronously at the tail of a keeper turn. The call sequence for compaction:

```
run_unified_turn — turn body completes
  → apply_post_turn_lifecycle
      → dispatch_event Compaction_started         phase → Compacting
      → do the actual compaction
      → dispatch_event Compaction_completed       phase → Running
  → run_unified_turn returns
→ keepalive loop next iteration
  → observes phase = Running again
```

The `Compacting` and `HandingOff` phases never persist across a turn boundary. The next keepalive iteration cannot observe the keeper in a non-dispatchable phase at its dispatch decision point, **because the `_completed` event always fires before `run_unified_turn` returns**. Same argument for `Handoff_started` / `Handoff_completed`. `mark_dead` only runs from external paths (`stop_keepalive`, shutdown, supervisor crash handler), all of which also tear down the fiber.

The safety is structural, not explicit. The TLA+ bug model is doing its job: it describes the discipline the code must preserve.

## What this PR does

Expands the doc comment on the `event` type in `lib/keeper/keeper_state_machine.mli`:

- The top-level docstring now includes a `{2 Post-turn lifecycle contract}` section that states the invariant explicitly, cites the TLA+ spec, and names the counterexample actions (`NoDrainTransition`, `GhostDispatch`) a regression would trigger.
- Each of the six affected constructors (`Compaction_started`, `_completed`, `_failed`, `Handoff_started`, `_completed`, `_failed`) gets a short "Emit ONLY from `apply_post_turn_lifecycle`" or "Must fire in the same turn as..." comment.

Now anyone touching compaction or handoff emission points sees the constraint in their IDE's type-info popup, not buried in a `specs/` directory they may never open.

## What this PR does NOT do

- Does not add an explicit phase gate to the dispatch path. The "belt-and-suspenders" proposal from #6592 is left for a separate PR if anyone decides the defense-in-depth is worth the one-`Keeper_registry.get`-per-loop-iter cost.
- Does not change any TLA+ spec or cfg.
- Does not change any OCaml implementation file. `keeper_state_machine.ml` is unchanged; only the `.mli` picks up the doc comment.
- Does not triage `KeeperTaskInterlock` (#6574). A parallel audit of `mark_dead` and task-release paths is the next follow-up.

## Test plan

- [x] `dune build lib/masc_mcp.cma` — exit 0 (doc comment only, no type change)
- [x] Manual read of the rendered `.mli` in the editor
- [x] Narrative traced in issue #6592 comment
- [ ] No CI test expected to change — behavior preserved, only docs

## Closes

Triage of #6592 concluded "no-op; spec documents a safe-by-construction property". This PR is the documentation follow-up from that triage. The issue will close when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)