### PR TITLE
fix: adapt broadcast_typed to OAS v0.121.0 structured parse errors

### DIFF
--- a/lib/tool_broadcast_typed.ml
+++ b/lib/tool_broadcast_typed.ml
@@ -35,12 +35,20 @@ let handle_broadcast ((message, _format) : string * string)
     let mention = Mention.extract trimmed in
     Ok { delivered = true; room_message = trimmed; mention }
 
+let parse_broadcast json =
+  Sg.parse broadcast_schema json
+  |> Result.map_error (fun errs ->
+    errs
+    |> List.map (fun (e : Agent_sdk.Tool_input_validation.field_error) ->
+      Printf.sprintf "%s: expected %s, got %s" e.path e.expected e.actual)
+    |> String.concat "; ")
+
 let tool = Typed_tool_masc.create
   ~name:"masc_broadcast_typed"
   ~description:"[Typed PoC] Send a message visible to ALL agents via SSE push."
   ~module_tag:Tool_dispatch.Mod_room
   ~params:(Sg.to_params broadcast_schema)
-  ~parse:(Sg.parse broadcast_schema)
+  ~parse:parse_broadcast
   ~handler:handle_broadcast
   ~encode:encode_broadcast
   ~requires_join:true

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -2,7 +2,15 @@
 
 open Masc_mcp
 
-let parse = Agent_sdk.Tool_schema_gen.parse Tool_broadcast_typed.broadcast_schema
+let format_parse_errors errs =
+  errs
+  |> List.map (fun (e : Agent_sdk.Tool_input_validation.field_error) ->
+    Printf.sprintf "%s: expected %s, got %s" e.path e.expected e.actual)
+  |> String.concat "; "
+
+let parse json =
+  Agent_sdk.Tool_schema_gen.parse Tool_broadcast_typed.broadcast_schema json
+  |> Result.map_error format_parse_errors
 
 let test_parse_valid () =
   let json = `Assoc [("message", `String "hello world")] in


### PR DESCRIPTION
## Summary
- OAS #810 changed `Tool_schema_gen.parse` return from `(a, string) result` to `(a, field_error list) result`
- Add `Result.map_error` adapter in `tool_broadcast_typed.ml` and test helper
- Unblocks OAS v0.121.0 pin bump (CI was failing on #6601 due to this type mismatch)

## Test plan
- [x] 16/16 typed_tool_masc tests pass
- [x] `dune build @check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)