### PR TITLE
fix(ci): narrow to Keeper_tool_policy_config shortcut, revert #6595 signature tightening

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -84,21 +84,14 @@ let to_json (resolution : resolution) =
       ("personas", item_to_json resolution.personas);
     ]
 
-(* A config root is identified by [tool_policy.toml] — the SSOT file that
-   keeper/tool runtime cannot start without. Any config directory that
-   lacks tool_policy.toml is a partial build artifact (e.g. dune materializes
-   [config/cascade.json] into [_build/default/config/] when a test declares
-   it as a dep), and must not be picked as the resolved root.
-
-   Before this change the signature was [tool_policy.toml OR prompts OR
-   keepers OR personas OR cascade.json]. The OR semantics caused
-   [_build/default/config/] with only cascade.json to be picked ahead of
-   the real source [config/], making init_policy_config fail in CI with
-   "tool policy config not found at resolved config root …/_build/default/
-   config/tool_policy.toml". *)
 let config_signature_exists config_dir =
-  let tool_policy = Filename.concat config_dir "tool_policy.toml" in
-  existing_dir config_dir && existing_file tool_policy
+  let cascade = Filename.concat config_dir "cascade.json" in
+  let prompts = Filename.concat config_dir "prompts" in
+  let keepers = Filename.concat config_dir "keepers" in
+  let personas = Filename.concat config_dir "personas" in
+  existing_dir config_dir
+  && (existing_file cascade || existing_dir prompts || existing_dir keepers
+     || existing_dir personas)
 
 let rec ancestor_dirs path =
   let dir = absolute_path path in

--- a/lib/keeper/keeper_tool_policy_config.ml
+++ b/lib/keeper/keeper_tool_policy_config.ml
@@ -146,11 +146,25 @@ let parse_git_clone (doc : Keeper_toml_loader.toml_doc) : git_clone_config =
   { allowed_orgs; denied_repos; default_depth;
     clone_timeout_sec; push_timeout_sec; pr_create_timeout_sec }
 
+(* Shortcut: if the caller's [base_path] already points at a project root
+   that has [base_path/config/tool_policy.toml], prefer that directly.
+   This is the common case when callers pass the result of
+   [Masc_test_deps.find_project_root ()] in tests or the repo root in
+   production. The direct check avoids the executable-relative walk in
+   [Config_dir_resolver] which can pick up partial config shards
+   materialised by dune into [_build/default/config/cascade.json] and
+   resolve the wrong root. Scoped to this loader only — the generic
+   resolver (used by dashboard/runtime code that reads per-env state
+   from the resolved root) is untouched. *)
 let config_root_for_base_path ~base_path =
-  let inputs = Config_dir_resolver.inputs_from_env () in
-  let inputs = { inputs with env_base_path = Some base_path } in
-  let resolution = Config_dir_resolver.resolve_with inputs in
-  (resolution.Config_dir_resolver.config_root.path, resolution.warnings)
+  let direct_config = Filename.concat base_path "config" in
+  let direct_policy = Filename.concat direct_config "tool_policy.toml" in
+  if Sys.file_exists direct_policy then (direct_config, [])
+  else
+    let inputs = Config_dir_resolver.inputs_from_env () in
+    let inputs = { inputs with env_base_path = Some base_path } in
+    let resolution = Config_dir_resolver.resolve_with inputs in
+    (resolution.Config_dir_resolver.config_root.path, resolution.warnings)
 
 let load ~base_path : (t, string) result =
   let config_root, resolution_warnings = config_root_for_base_path ~base_path in

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -38,16 +38,6 @@ let make_config_root root =
   write_file (Filename.concat config "tool_policy.toml") "# test marker\n";
   config
 
-(* A partial config dir that mimics dune's [_build/default/config/]
-   materialisation: cascade.json is promoted but tool_policy.toml is
-   absent. The resolver must NOT pick this as the config root; it
-   should keep walking up. *)
-let make_partial_config_root root =
-  let config = Filename.concat root "config" in
-  mkdir_p config;
-  write_file (Filename.concat config "cascade.json") "{}";
-  config
-
 let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir
     ?env_home ?(cwd = "/tmp/cwd") ?(executable_name = "/tmp/bin/masc-mcp") () =
   Lib.Config_dir_resolver.
@@ -150,37 +140,6 @@ let test_local_masc_fallback_collapses_explicit_masc_dir () =
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check string "root path" local_config resolution.config_root.path
 
-(* Regression: dune materialises [config/cascade.json] into
-   [_build/default/config/cascade.json] when a test declares it as a
-   [(deps %{workspace_root}/config/cascade.json)] rule. Before the
-   config_signature_exists tightening, the executable-relative lookup
-   matched [_build/default/config/] on that lone file and reported a
-   broken config root. With tool_policy.toml required, the lookup
-   walks past _build and picks the real source config. *)
-let test_build_dir_partial_config_is_skipped () =
-  with_temp_dir "config-dir-build-partial" @@ fun root ->
-  let real_config = make_config_root root in
-  let build_config_parent = Filename.concat root "_build/default/test" in
-  mkdir_p build_config_parent;
-  let exe = Filename.concat build_config_parent "test_runner.exe" in
-  write_file exe "#!/bin/sh\n";
-  Unix.chmod exe 0o755;
-  (* Partial config mimicking _build/default/config materialisation:
-     cascade.json is promoted but tool_policy.toml is absent. *)
-  let _partial =
-    make_partial_config_root (Filename.concat root "_build/default")
-  in
-  let resolution =
-    Lib.Config_dir_resolver.resolve_with
-      (make_inputs ~cwd:build_config_parent ~executable_name:exe ())
-  in
-  check string "status ready" "ready"
-    (Lib.Config_dir_resolver.status_to_string resolution.status);
-  check string "skipped partial _build config" real_config
-    resolution.config_root.path;
-  check string "source is exe_relative" "exe_relative"
-    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source)
-
 let test_no_legacy_me_root_fallback () =
   with_temp_dir "config-dir-no-legacy" @@ fun me_root ->
   let _repo_root =
@@ -268,8 +227,6 @@ let () =
           test_case "local masc fallback collapses explicit .masc dir"
             `Quick test_local_masc_fallback_collapses_explicit_masc_dir;
           test_case "home masc fallback" `Quick test_home_masc_fallback;
-          test_case "build dir partial config is skipped (cascade-only)"
-            `Quick test_build_dir_partial_config_is_skipped;
           test_case "does not fallback to legacy me_root repo path" `Quick
             test_no_legacy_me_root_fallback;
         ] );

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -78,7 +78,12 @@ let voice_guard_fragments =
 let init_keeper_bridge () =
   Masc_test_deps.init_keeper_tool_registry ();
   ignore (Masc_mcp.Mcp_server_eio.get_clock_opt ());
-  (match KET.init_policy_config ~base_path:(Sys.getcwd ()) with
+  (* Use find_project_root — the test cwd is _build/default/test/ which
+     does not contain config/tool_policy.toml, so Sys.getcwd fails the
+     direct shortcut and falls into the exe-relative walk that picks up
+     the partial _build/default/config/cascade.json. *)
+  let base_path = Masc_test_deps.find_project_root () in
+  (match KET.init_policy_config ~base_path with
    | Ok () -> ()
    | Error err -> Printf.eprintf "[WARN] init_policy_config failed: %s\n" err);
   Masc_mcp.Keeper_exec_shared.tag_dispatch_fn := Masc_mcp.Keeper_tag_dispatch.dispatch;


### PR DESCRIPTION
## Follow-up to #6595 — narrower, less invasive fix

#6595 was merged fast to unblock CI but the approach (tightening \`Config_dir_resolver.config_signature_exists\` to require \`tool_policy.toml\` universally) was too broad. It fixed the primary abort but shifted the resolved \`config_root\` for every caller, causing ~35 additional test failures that were pre-existing but previously hidden.

This PR:
1. **Reverts** \`config_signature_exists\` to the original permissive form (cascade.json OR prompts OR keepers OR personas)
2. **Adds** a narrow shortcut in \`Keeper_tool_policy_config.config_root_for_base_path\`: if \`base_path/config/tool_policy.toml\` exists directly, return that path without going through the generic resolver

\`\`\`ocaml
let config_root_for_base_path ~base_path =
  let direct_config = Filename.concat base_path \"config\" in
  let direct_policy = Filename.concat direct_config \"tool_policy.toml\" in
  if Sys.file_exists direct_policy then (direct_config, [])
  else
    (* existing resolver path unchanged *)
\`\`\`

## Why narrower is better

\`base_path\` is typically the result of \`Masc_test_deps.find_project_root ()\` in tests or the repo root in production runtime. Both of those already know where \`tool_policy.toml\` lives; the extra resolver walk was unnecessary and was the mechanism that picked up the partial \`_build/default/config/cascade.json\` materialised by dune.

The shortcut is scoped to \`Keeper_tool_policy_config.load\` only. The generic \`Config_dir_resolver\` is byte-for-byte back to pre-#6595 — dashboard/runtime code paths that read per-env state from the resolved root are untouched.

## Net effect vs pre-#6595 main

- \`test_operator_control\` line 3 \`Result.get_ok\` abort: **fixed** (same as #6595)
- Pre-existing test_room_state_recovery, dashboard_perf, core, eio, bootstrap, operator, make_tools failures: **unchanged** (these were always broken, just hidden behind the abort; they need their own issues)
- \`Config_dir_resolver\` semantics for dashboard/runtime consumers: **unchanged** (reverted to pre-#6595)

## Tests

- \`test_config_dir_resolver\`: 11/11 pass (removed the regression test added in #6595 because the resolver itself no longer has the tightened signature; the new shortcut is tested indirectly via \`test_keeper_tool_policy_config\`)
- \`test_keeper_tool_policy_config\`: 11/11 pass
- Local \`test_operator_control\` init succeeds (primary abort gone)

## Residual pre-existing failures not fixed here

- #6581 \`test_room_state_recovery\` env pollution writing \`.masc/state.json\` without mkdir_p
- Other pre-existing failures in dashboard_perf, core, eio, bootstrap, operator, make_tools

These are tracked separately and will need their own fixes.

## Urgency

Main is still effectively red from downstream cascades of #6595's broad change. This narrowing should restore main to its pre-#6595 CI state (still red on pre-existing issues, but not WORSE than before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)