### PR TITLE
fix(keeper): cap Eio.Semaphore.acquire wait in with_keeper_turn_slot

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -53,6 +53,33 @@ let () =
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
 
+(** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
+    turn slot. Without this, a keeper whose peers hold all slots while
+    their LLM calls stall for the entire 1200s turn budget would block
+    unboundedly, because [Eio.Semaphore.acquire] has no intrinsic timeout.
+
+    Empirical motivation (2026-04-11): [semaphore_wait_ms] of 1.1-2.1 Ms
+    observed in keeper decision logs — the sitting keeper waited past its
+    own turn budget because peers held slots for the full outer wall-clock.
+
+    Default 60s = short enough that keepers fail fast and fall back to the
+    next heartbeat cycle (giving real slot holders time to release), long
+    enough that legitimate turn contention (3+ concurrent keepers on a
+    fast provider) does not mis-trigger.
+
+    Env: [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]. Default 60. Range [5, 600]. *)
+let semaphore_wait_timeout_sec =
+  Keeper_config.float_of_env_default
+    "MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC"
+    ~default:60.0 ~min_v:5.0 ~max_v:600.0
+;;
+
+(** Raised by [with_keeper_turn_slot] when [semaphore_wait_timeout_sec]
+    elapses before both turn semaphores could be acquired. The caller
+    should treat this as "skip this turn, retry on next heartbeat"; it is
+    not a keeper failure in the unified-turn sense. *)
+exception Semaphore_wait_timeout of float
+
 let with_keeper_turn_slot ~channel f =
   let is_autonomous =
     match channel with
@@ -64,8 +91,31 @@ let with_keeper_turn_slot ~channel f =
     (if is_autonomous then "autonomous" else "reactive")
     (Eio.Semaphore.get_value autonomous_turn_semaphore)
     (Eio.Semaphore.get_value turn_semaphore);
-  if is_autonomous then Eio.Semaphore.acquire autonomous_turn_semaphore;
-  Eio.Semaphore.acquire turn_semaphore;
+  let acquire_bounded ~label sem =
+    match Eio_context.get_clock_opt () with
+    | Some clock ->
+      (try
+        Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
+          Eio.Semaphore.acquire sem)
+      with Eio.Time.Timeout ->
+        Log.Keeper.warn
+          "semaphore_wait: %s semaphore wait exceeded %.0fs (channel=%s), \
+           skipping turn"
+          label semaphore_wait_timeout_sec
+          (if is_autonomous then "autonomous" else "reactive");
+        raise (Semaphore_wait_timeout semaphore_wait_timeout_sec))
+    | None ->
+      (* No Eio clock (e.g. unit tests running outside an Eio main):
+         fall back to unbounded acquire. *)
+      Eio.Semaphore.acquire sem
+  in
+  if is_autonomous then acquire_bounded ~label:"autonomous" autonomous_turn_semaphore;
+  (try acquire_bounded ~label:"turn" turn_semaphore
+   with exn ->
+     (* Autonomous semaphore already acquired above — release it so we
+        do not leak a slot on timeout. *)
+     if is_autonomous then Eio.Semaphore.release autonomous_turn_semaphore;
+     raise exn);
   let semaphore_wait_ms =
     int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
   Fun.protect
@@ -935,6 +985,15 @@ let run_keepalive_unified_turn
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | Keeper_registry.Keeper_fiber_crash as e -> raise e
+    | Semaphore_wait_timeout wait_sec ->
+      (* Peers held the turn semaphore longer than the wait cap — not a
+         keeper failure. Skip this cycle and let the next heartbeat retry
+         once a slot opens up. Meta is left untouched so failure counters
+         do not tick. *)
+      Log.Keeper.warn
+        "%s: skipping turn (semaphore wait > %.0fs, peers holding slot)"
+        meta_after_triage.name wait_sec;
+      meta_after_triage
     | exn ->
       Log.Keeper.error "%s: unified turn exception: %s"
         meta_after_triage.name (Printexc.to_string exn);

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -91,6 +91,13 @@ let with_keeper_turn_slot ~channel f =
     (if is_autonomous then "autonomous" else "reactive")
     (Eio.Semaphore.get_value autonomous_turn_semaphore)
     (Eio.Semaphore.get_value turn_semaphore);
+  (* Track acquisitions in mutable flags so the outer Fun.protect can
+     release exactly the slots we hold — regardless of which exception
+     path fires (Semaphore_wait_timeout, Eio.Cancel.Cancelled, or any
+     other). This keeps resource cleanup independent of Eio.Semaphore's
+     internal cancel-race handling. *)
+  let acquired_autonomous = ref false in
+  let acquired_turn = ref false in
   let acquire_bounded ~label sem =
     match Eio_context.get_clock_opt () with
     | Some clock ->
@@ -105,24 +112,32 @@ let with_keeper_turn_slot ~channel f =
           (if is_autonomous then "autonomous" else "reactive");
         raise (Semaphore_wait_timeout semaphore_wait_timeout_sec))
     | None ->
-      (* No Eio clock (e.g. unit tests running outside an Eio main):
-         fall back to unbounded acquire. *)
+      (* No Eio clock available: we are running outside an Eio main loop
+         (e.g. Alcotest without [Eio_main.run]). Production masc-mcp
+         always provides a clock via [Masc_eio_env.init]; reaching this
+         branch at runtime would indicate an environment-setup drift,
+         so log it prominently before falling back to unbounded acquire. *)
+      Log.Keeper.warn
+        "semaphore_wait: no Eio clock available — %s acquire will be unbounded (environment drift?)"
+        label;
       Eio.Semaphore.acquire sem
   in
-  if is_autonomous then acquire_bounded ~label:"autonomous" autonomous_turn_semaphore;
-  (try acquire_bounded ~label:"turn" turn_semaphore
-   with exn ->
-     (* Autonomous semaphore already acquired above — release it so we
-        do not leak a slot on timeout. *)
-     if is_autonomous then Eio.Semaphore.release autonomous_turn_semaphore;
-     raise exn);
-  let semaphore_wait_ms =
-    int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
   Fun.protect
     ~finally:(fun () ->
-      Eio.Semaphore.release turn_semaphore;
-      if is_autonomous then Eio.Semaphore.release autonomous_turn_semaphore)
-    (fun () -> f ~semaphore_wait_ms)
+      (* Release exactly what we acquired. Order does not matter because
+         these two semaphores do not contend with each other. *)
+      if !acquired_turn then Eio.Semaphore.release turn_semaphore;
+      if !acquired_autonomous then Eio.Semaphore.release autonomous_turn_semaphore)
+    (fun () ->
+      if is_autonomous then begin
+        acquire_bounded ~label:"autonomous" autonomous_turn_semaphore;
+        acquired_autonomous := true
+      end;
+      acquire_bounded ~label:"turn" turn_semaphore;
+      acquired_turn := true;
+      let semaphore_wait_ms =
+        int_of_float ((Time_compat.now () -. t0) *. 1000.0) in
+      f ~semaphore_wait_ms)
 ;;
 
 (** Optional gRPC client + env — WORM Atomic: set at server bootstrap

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -28,6 +28,20 @@ val keeper_turn_throttle_limit : int
 (** Runtime keeper turn concurrency limit derived from
     [MASC_KEEPER_AUTOBOOT_MAX]. *)
 
+val semaphore_wait_timeout_sec : float
+(** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
+    turn slot. Derived from [MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC]
+    (default 60.0, range [5, 600]). Keepers whose peers hold slots past
+    this cap are skipped for the current cycle and retry on the next
+    heartbeat. *)
+
+exception Semaphore_wait_timeout of float
+(** Raised inside [with_keeper_turn_slot] when acquiring either the
+    autonomous or turn semaphore exceeds [semaphore_wait_timeout_sec].
+    The float carries the wait cap so the caller can render it without
+    re-reading the env var. Callers should treat this as "skip this
+    turn, retry on next heartbeat" rather than a keeper failure. *)
+
 val wakeup_relevant_keeper_for_board_signal :
   config:Room.config -> Board_dispatch.keeper_board_signal -> unit
 

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -120,6 +120,28 @@ let test_oas_timeout_sec_compat () =
   let v = Cfg.KeeperKeepalive.oas_timeout_sec in
   check (float 1.0) "backward compat default 300s" 300.0 v
 
+(* ── Semaphore wait timeout (defense against peer slot hoarding) ── *)
+
+let test_semaphore_wait_timeout_default () =
+  (* Default 60s — short enough to unblock starved keepers, long enough
+     to not mis-trigger under legitimate contention. *)
+  check (float 0.1) "default semaphore wait timeout 60s" 60.0
+    KK.semaphore_wait_timeout_sec
+
+let test_semaphore_wait_timeout_range () =
+  let v = KK.semaphore_wait_timeout_sec in
+  check bool "wait timeout >= 5s" true (v >= 5.0);
+  check bool "wait timeout <= 600s" true (v <= 600.0)
+
+let test_semaphore_wait_timeout_exception_shape () =
+  (* The exception carries the wait cap in seconds so the caller can
+     render it in a log line without re-reading the env var. *)
+  let carried =
+    try raise (KK.Semaphore_wait_timeout 42.5); -1.0
+    with KK.Semaphore_wait_timeout v -> v
+  in
+  check (float 0.001) "exception carries wait sec" 42.5 carried
+
 (* ── KeeperGrpc config defaults ────────────────────────── *)
 
 let test_grpc_max_reconnect_default () =
@@ -291,6 +313,11 @@ let () =
       test_case "max_turns default is 5" `Quick test_max_turns_default;
       test_case "max_turns range" `Quick test_max_turns_range;
       test_case "oas_timeout_sec backward compat" `Quick test_oas_timeout_sec_compat;
+    ];
+    "semaphore_wait_timeout", [
+      test_case "default 60s" `Quick test_semaphore_wait_timeout_default;
+      test_case "range [5, 600]" `Quick test_semaphore_wait_timeout_range;
+      test_case "exception carries wait sec" `Quick test_semaphore_wait_timeout_exception_shape;
     ];
     "grpc_config", [
       test_case "max_reconnect default" `Quick test_grpc_max_reconnect_default;

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -137,7 +137,8 @@ let test_semaphore_wait_timeout_exception_shape () =
   (* The exception carries the wait cap in seconds so the caller can
      render it in a log line without re-reading the env var. *)
   let carried =
-    try raise (KK.Semaphore_wait_timeout 42.5); -1.0
+    try
+      raise (KK.Semaphore_wait_timeout 42.5)
     with KK.Semaphore_wait_timeout v -> v
   in
   check (float 0.001) "exception carries wait sec" 42.5 carried


### PR DESCRIPTION
## Summary
MASC `with_keeper_turn_slot` used unbounded `Eio.Semaphore.acquire` for both the global `turn_semaphore` (limit 12) and the `autonomous_turn_semaphore` (limit 3). When peers held slots while their LLM calls hung for the full 1200s outer turn wall-clock, the waiting keeper also hung for that entire window — observed in decision logs as `semaphore_wait_ms` values of **1.1–2.1 megaseconds (18–35 minutes)**.

This PR adds a bounded wait (default 60s, `MASC_KEEPER_SEMAPHORE_WAIT_TIMEOUT_SEC`, range [5, 600]) so starved keepers fast-skip their current cycle and let the next heartbeat retry once a slot opens.

## Root cause chain (empirical)

Observed on 2026-04-11, 6 of 7 keepers stuck at `last_latency_ms ≈ 1200s` with `tool_call_count = 0`:

1. 3 keepers hold MASC `autonomous_turn_semaphore` (limit 3)
2. Each turn cascades to an LLM provider whose response stalls (qwen35moe decode serialization + cascade edge cases)
3. Turn wall-clock hits 1200s → error, slots release
4. 4 waiting keepers had been blocked in `Eio.Semaphore.acquire` for ~1200s each
5. Same pattern repeats every cycle — keepers never make progress

`Eio.Semaphore.acquire` has no intrinsic timeout, so the design bug is a **missing bound**, not a pathological LLM. This PR fixes the bound.

## Changes
- `lib/keeper/keeper_keepalive.ml`
  - New `semaphore_wait_timeout_sec` config (default 60s)
  - New `Semaphore_wait_timeout` exception carrying the wait cap
  - `with_keeper_turn_slot` wraps both acquires in `Eio.Time.with_timeout_exn`; on timeout, releases the already-acquired autonomous semaphore (no slot leak) and raises
  - Falls back to unbounded acquire when no Eio clock is present (unit tests outside Eio main)
- `do_unified_turn` call site: catches `Semaphore_wait_timeout` separately from the generic `exn` handler. Warn log, returns `meta_after_triage` unchanged — failure counters do not tick because this is "skip this turn", not "keeper failed"
- `test/test_work_as_heartbeat.ml`: 3 new tests (default, range invariants, exception shape)

## Defense in depth
Complementary to provider/cascade-level fixes (#6543, oas#805 pending). Even if an LLM call legitimately hangs, it can no longer hold the whole keeper pool hostage past the wait cap.

## Not in scope
- Root-causing *why* Ollama/cascade stalls in the first place. This PR only prevents the cascade from freezing the whole keeper fleet.
- Increasing `MASC_KEEPER_AUTONOMOUS_CONCURRENCY`. The 3-slot limit is intentional for shared remote providers.

## Test plan
- [x] `dune build lib/keeper/` — clean
- [x] `test_work_as_heartbeat.ml` new tests: default/range/exception
- [ ] Runtime: after merge + restart, verify `semaphore_wait_ms` no longer exceeds `~62000ms` under contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)