### PR TITLE
fix(tool_code_write): scope writable paths and clone cwd per-agent (#6527 iter 6)

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -101,8 +101,12 @@ let validate_writable_path ~(agent_name : string) config path =
       Ok canonical_path
     else
       Error (IoError (Printf.sprintf
-        "Write restricted to allowed sandboxes: /.worktrees/ or %s (got: %s). \
-         Cross-agent playground writes are blocked — use your own playground."
+        "Write restricted to allowed sandboxes for agent %s. \
+         Expected path prefix: %s (or /.worktrees/ for server ops). \
+         Got: %s. Cross-agent playground writes are blocked — write \
+         under your own playground only. Call masc_status if you are \
+         unsure of your agent_name."
+        agent_name
         agent_playground_prefix
         canonical_path))
 
@@ -296,10 +300,14 @@ let validate_clone_cwd ~(agent_name : string) config cwd =
         Ok canonical_path
       else
         Error (IoError (Printf.sprintf
-          "Clone restricted to .worktrees/ or this agent's own \
-           %srepos/ (got: %s). Cross-agent playground clones are blocked."
+          "Clone restricted to /.worktrees/ or this agent's own \
+           %srepos/ (got: %s). Cross-agent playground clones are blocked \
+           — clone into %srepos/<repo-name> instead. Call masc_status \
+           if you are unsure of your agent_name (currently %s)."
           agent_playground_prefix
-          canonical_path))
+          canonical_path
+          agent_playground_prefix
+          agent_name))
 
 (* Handler: masc_code_write — Create or overwrite a file *)
 let handle_code_write ctx args =

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -75,25 +75,35 @@ let allowed_worktree_prefixes config =
 (* Security: Validate path is within an allowed writable sandbox.
    Uses canonical paths from Tool_code.validate_path — already normalized.
    Worktree paths are anchored to actual git common roots so a nested
-   "/.worktrees/" segment elsewhere in the tree is not accepted. *)
-let validate_writable_path config path =
+   "/.worktrees/" segment elsewhere in the tree is not accepted.
+
+   Playground writes are gated per-agent (#6527 iter 6): the caller
+   must only be allowed to write inside its own
+   [.masc/playground/<agent_name>/] bundle. This prevents one agent
+   from mutating another agent's playground via the shared
+   `masc_code_*` dispatch. Server-wide `.worktrees/` remains allowed
+   so legacy server operations that need to touch repo worktrees
+   continue to work. *)
+let validate_writable_path ~(agent_name : string) config path =
   match Tool_code.validate_path config path with
   | Error e -> Error e
   | Ok canonical_path ->
     let worktree_prefixes = allowed_worktree_prefixes config in
-    let playground_prefix =
+    let agent_playground_prefix =
       normalize_dir_prefix
-        (Filename.concat config.Room.base_path ".masc/playground")
+        (Filename.concat config.Room.base_path
+           (Keeper_alerting_path.playground_path_of_keeper agent_name))
     in
     if List.exists
          (fun prefix -> String.starts_with ~prefix canonical_path)
          worktree_prefixes
-       || String.starts_with ~prefix:playground_prefix canonical_path then
+       || String.starts_with ~prefix:agent_playground_prefix canonical_path then
       Ok canonical_path
     else
       Error (IoError (Printf.sprintf
-        "Write restricted to allowed sandboxes: /.worktrees/ or %s (got: %s)"
-        playground_prefix
+        "Write restricted to allowed sandboxes: /.worktrees/ or %s (got: %s). \
+         Cross-agent playground writes are blocked — use your own playground."
+        agent_playground_prefix
         canonical_path))
 
 (* Shell command allowlist *)
@@ -245,8 +255,11 @@ let validate_clone_url ~base_path url =
         | _ -> Ok ()
 
 (** Validate cwd for clone: allows .worktrees/ itself (not just subdirs)
-    and .masc/playground/{name}/repos/ directories. *)
-let validate_clone_cwd config cwd =
+    and THIS agent's own .masc/playground/<agent_name>/repos/ directory.
+
+    #6527 iter 6 scoped this per-agent so agent A cannot drop a clone
+    into agent B's playground/repos/ via masc_code_git action=clone. *)
+let validate_clone_cwd ~(agent_name : string) config cwd =
   match Tool_code.validate_path config cwd with
   | Error e -> Error e
   | Ok canonical_path ->
@@ -255,33 +268,37 @@ let validate_clone_cwd config cwd =
     | Some root ->
       let worktree_prefix = Tool_code.normalize_path
         (Filename.concat root ".worktrees") in
-      let playground_prefix = Tool_code.normalize_path
-        (Filename.concat root ".masc/playground") in
+      let agent_playground_prefix = Tool_code.normalize_path
+        (Filename.concat root
+           (Keeper_alerting_path.playground_path_of_keeper agent_name)) in
       let in_worktrees =
         canonical_path = worktree_prefix ||
         String.starts_with ~prefix:(worktree_prefix ^ "/") canonical_path
       in
-      let in_playground_repos =
-        (* Match .masc/playground/{name}/repos or subdirs thereof.
-           Path after playground_prefix must be /{name}/repos[/...]. *)
-        if String.starts_with ~prefix:(playground_prefix ^ "/") canonical_path then
-          let suffix = String.sub canonical_path
-            (String.length playground_prefix + 1)
-            (String.length canonical_path - String.length playground_prefix - 1) in
-          match String.index_opt suffix '/' with
-          | None -> false
-          | Some idx ->
-            let after_name = String.sub suffix (idx + 1)
-              (String.length suffix - idx - 1) in
-            after_name = "repos" ||
-            String.starts_with ~prefix:"repos/" after_name
-        else false
+      let in_agent_playground_repos =
+        (* Match <agent_playground_prefix>/repos or subdirs thereof.
+           [playground_path_of_keeper] already ends with "/", and the
+           canonical normalisation strips trailing slashes, so we strip
+           the trailing slash before prefix matching. *)
+        let prefix_no_slash =
+          if String.length agent_playground_prefix > 0
+             && agent_playground_prefix.[String.length agent_playground_prefix - 1] = '/'
+          then String.sub agent_playground_prefix 0
+                 (String.length agent_playground_prefix - 1)
+          else agent_playground_prefix
+        in
+        canonical_path = Filename.concat prefix_no_slash "repos"
+        || String.starts_with
+             ~prefix:(Filename.concat prefix_no_slash "repos/")
+             canonical_path
       in
-      if in_worktrees || in_playground_repos then
+      if in_worktrees || in_agent_playground_repos then
         Ok canonical_path
       else
         Error (IoError (Printf.sprintf
-          "Clone restricted to .worktrees/ or .masc/playground/*/repos/ directory (got: %s)"
+          "Clone restricted to .worktrees/ or this agent's own \
+           %srepos/ (got: %s). Cross-agent playground clones are blocked."
+          agent_playground_prefix
           canonical_path))
 
 (* Handler: masc_code_write — Create or overwrite a file *)
@@ -298,7 +315,7 @@ let handle_code_write ctx args =
   else if Tool_code.is_binary_file path then
     (false, "Binary file extension not allowed for write")
   else begin
-    match validate_writable_path ctx.config path with
+    match validate_writable_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok abs_path ->
       try
@@ -329,7 +346,7 @@ let handle_code_edit ctx args =
   else if old_string = "" then (false, "old_string parameter required")
   else if old_string = new_string then (false, "old_string and new_string are identical")
   else begin
-    match validate_writable_path ctx.config path with
+    match validate_writable_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok abs_path ->
       if not (Sys.file_exists abs_path) then
@@ -414,7 +431,7 @@ let handle_code_delete ctx args =
 
   if path = "" then (false, "path parameter required")
   else begin
-    match validate_writable_path ctx.config path with
+    match validate_writable_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok abs_path ->
       if not (Sys.file_exists abs_path) then
@@ -457,7 +474,7 @@ let handle_code_shell ctx args =
       (* Validate cwd if provided *)
       let cwd_result =
         if cwd = "" then Ok None
-        else match validate_writable_path ctx.config cwd with
+        else match validate_writable_path ~agent_name:ctx.agent_name ctx.config cwd with
           | Ok abs_cwd -> Ok (Some abs_cwd)
           | Error e -> Error e
       in
@@ -518,7 +535,7 @@ let handle_code_git ctx args =
       match validate_clone_url ~base_path:ctx.config.Room.base_path url with
       | Error msg -> (false, msg)
       | Ok () ->
-        match validate_clone_cwd ctx.config cwd with
+        match validate_clone_cwd ~agent_name:ctx.agent_name ctx.config cwd with
         | Error e -> (false, Types.masc_error_to_string e)
         | Ok abs_cwd ->
           (* Only pass the validated URL — no extra args allowed.
@@ -571,7 +588,7 @@ let handle_code_git ctx args =
       let cwd_result =
         if cwd = "" then (false, "cwd parameter required for git operations") |> fun (ok, msg) ->
           if ok then Ok None else Error (IoError msg)
-        else match validate_writable_path ctx.config cwd with
+        else match validate_writable_path ~agent_name:ctx.agent_name ctx.config cwd with
           | Ok abs_cwd -> Ok (Some abs_cwd)
           | Error e -> Error e
       in


### PR DESCRIPTION
## 요약

`tool_code_write.ml`의 `validate_writable_path`와 `validate_clone_cwd`를 per-agent로 축소합니다. 이슈 #6527 trilogy (iter 1~5)가 닫은 containment 불변식을 `masc_code_*` 공유 dispatch 표면까지 확장합니다.

## 배경

Iter 1~5는 다음을 닫았습니다:
- (1) keeper prompt — fallback 문장 삭제
- (2) `worktree_create_r` — server-root 폴백 제거
- (2b) matrix test fixture — playground clone 강제
- (3) `keeper_bash` — write-gate에 `in_playground` 추가
- (4) `keeper_alerting_path.effective_allowed_paths` — `.worktrees/` workspace_default 제거 + `keeper_pr_submit` cwd per-keeper 축소
- (5) TLA+ `KeeperWorktreeKind` / `KeeperWorktreeOwner` invariant

하지만 `masc_code_*` 계열 (`masc_code_write/edit/delete/shell/git`) 은 공유 dispatch `Tool_code_write.dispatch`로 내려가고, 여기서 `validate_writable_path`는 `.masc/playground/` **전체**를 허용했습니다:

```ocaml
let playground_prefix =
  normalize_dir_prefix
    (Filename.concat config.Room.base_path ".masc/playground")
...
|| String.starts_with ~prefix:playground_prefix canonical_path
```

즉 agent-A가 `masc_code_write path=.masc/playground/<agent-B>/mind/note.md content=...` 같은 호출로 **다른 agent의 playground에 파일을 쓸 수 있었음**. 같은 leak이 edit/delete/shell cwd/clone cwd 모두에 걸쳐 있었습니다.

**dispatch context에는 이미 `agent_name`이 있음** — 따라서 per-agent 제한은 local refactor로 해결:

```ocaml
type context = {
  config : Room.config;
  agent_name : string;
}
```

## 변경

`lib/tool_code_write.ml` (1 파일):

### 1. `validate_writable_path ~agent_name config path`

```ocaml
(* Before *)
let playground_prefix =
  normalize_dir_prefix
    (Filename.concat config.Room.base_path ".masc/playground")

(* After *)
let agent_playground_prefix =
  normalize_dir_prefix
    (Filename.concat config.Room.base_path
       (Keeper_alerting_path.playground_path_of_keeper agent_name))
```

- `.worktrees/` 경계는 `allowed_worktree_prefixes`로 유지 — legacy server-side worktree 운영 보존
- 에러 메시지에 "Cross-agent playground writes are blocked — use your own playground." 추가

### 2. `validate_clone_cwd ~agent_name config cwd`

`.masc/playground/*/repos/` 전역 수락 → `.masc/playground/<agent_name>/repos/` 단독 수락. 이전에는 `masc_code_git action=clone cwd=.masc/playground/<other-agent>/repos/...`로 다른 에이전트의 repos/에 clone 가능했습니다.

### 3. 모든 call site (`ctx.agent_name` 전달)

- `handle_code_write` (line 318)
- `handle_code_edit` (line 349)
- `handle_code_delete` (line 434)
- `handle_code_shell` (line 477, cwd 파라미터 검증)
- `handle_code_git` clone branch (line 538)
- `handle_code_git` other actions (line 591)

총 6개 call site. `sed -i`로 일괄 `validate_writable_path ctx.config` → `validate_writable_path ~agent_name:ctx.agent_name ctx.config`.

## Trade-off

**의도된 breaking change**: 기존 cross-agent permissiveness에 의존하던 caller가 있다면 `Write restricted to allowed sandboxes: ... Cross-agent playground writes are blocked` 에러를 받게 됨. 이는 프롬프트가 이미 선언한 "playground is your sandbox" invariant와 일치하므로 정당한 정렬.

**`.worktrees/` 경계는 유지**: server-wide `.worktrees/` 접근은 legacy server operation (non-keeper)이 필요로 할 수 있어서 보존. keeper trilogy의 L2/L3가 workspace_defaults에서 `.worktrees/`를 제거했지만, 이는 keeper execution_scope 한정 변경. `tool_code_write.ml`은 non-keeper agent도 호출하므로 scope가 다름.

## 로컬 빌드 노트

현재 main의 `dune build @all`이 내 변경과 **무관한** pre-existing 에러로 fail:

- `lib/oas_sse_bridge.ml`: `Agent_sdk.Event_bus.TurnStarted`/`TurnCompleted`/`ContextCompacted` record에 최근 `session_id`/`worker_run_id` 필드가 추가됐는데 consumer pattern이 업데이트 안 됨 (warning 9 → error).
- `test/test_typed_tool_masc.ml`: `Agent_sdk.Tool_input_validation.parse`의 에러 타입이 `field_error list`로 변경됐는데 caller가 여전히 `string`으로 취급.

이 에러들은 fresh `origin/main` 체크아웃에서도 재현되며 **이 PR과 무관**. Main이 unblock되면 CI가 이 PR을 독립 검증합니다.

이 PR은 `lib/tool_code_write.ml`만 수정하며, 새로운 빌드 에러를 도입하지 않습니다 (문법/타입 레벨 검토 완료).

## 후속 작업 (follow-up, 별도 커밋)

- `test/test_tool_code_write.ml` 또는 신규 test 파일에 per-agent rejection 사례 추가. 이 PR을 surgical하게 유지하기 위해 분리.
- 만약 main build 문제가 지속되면 `oas_sse_bridge.ml` pre-existing 에러를 별도 PR로 수정.

## 이슈 trilogy

- [x] Iter-1 #6533 — prompt
- [x] Iter-2 #6542 — worktree_create_r
- [x] Iter-2b #6577 — matrix fixture
- [x] Iter-3 #6579 — keeper_bash write-gate
- [x] Iter-4 #6580 — effective_allowed_paths + keeper_pr_submit
- [x] Iter-5 #6584 — TLA+ invariant
- [x] **Iter-6 (이 PR) — tool_code_write per-agent**

## 리뷰 요청

교차 모델 리뷰: `sb glm-text` (GLM-5.1), non-self.
