### PR TITLE
fix(hebbian): hold with_graph_lock during consolidate to prevent silent clobber

### DIFF
--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -264,32 +264,42 @@ let get_preferred_partner config ~agent_id : string option =
     | best :: _ -> Some best.to_agent
     | [] -> None (* unreachable but type-safe *)
 
-(** Consolidate - apply decay to old connections - synchronous *)
+(** Consolidate - apply decay to old connections - synchronous.
+
+    Must hold [with_graph_lock] around the read-modify-write cycle: a
+    concurrent [strengthen]/[weaken] that observes the same pre-decay
+    graph, writes its updated weight under the lock, then has its
+    write silently clobbered when consolidate's save lands on the
+    stale snapshot. Without the lock, consolidate can roll back any
+    strengthen/weaken that races it — an invariant violation for
+    hebbian learning. *)
 let consolidate config ?params ~decay_after_days () : int =
   let params = Option.value params ~default:(default_params ()) in
-  let graph = load_graph config in
-  let now = Time_compat.now () in
-  let cutoff = now -. Masc_time_constants.days_to_seconds decay_after_days in
+  with_graph_lock config (fun () ->
+    let graph = load_graph config in
+    let now = Time_compat.now () in
+    let cutoff = now -. Masc_time_constants.days_to_seconds decay_after_days in
 
-  let (decayed, pruned_count) = List.fold_left (fun (acc, count) synapse ->
-    if synapse.last_updated < cutoff then
-      (* Apply decay *)
-      let days_since = (now -. synapse.last_updated) /. Masc_time_constants.day in
-      let decay = params.decay_rate *. days_since in
-      let new_weight = max 0.0 (synapse.weight -. decay) in
-      if new_weight < params.min_weight then
-        (* Prune weak synapse *)
-        (acc, count + 1)
+    let (decayed, pruned_count) = List.fold_left (fun (acc, count) synapse ->
+      if synapse.last_updated < cutoff then
+        (* Apply decay *)
+        let days_since = (now -. synapse.last_updated) /. Masc_time_constants.day in
+        let decay = params.decay_rate *. days_since in
+        let new_weight = max 0.0 (synapse.weight -. decay) in
+        if new_weight < params.min_weight then
+          (* Prune weak synapse *)
+          (acc, count + 1)
+        else
+          let updated = { synapse with weight = new_weight; last_updated = now } in
+          (updated :: acc, count)
       else
-        let updated = { synapse with weight = new_weight; last_updated = now } in
-        (updated :: acc, count)
-    else
-      (synapse :: acc, count)
-  ) ([], 0) graph.synapses in
+        (synapse :: acc, count)
+    ) ([], 0) graph.synapses in
 
-  let new_graph = { synapses = decayed; last_consolidation = now } in
-  save_graph config new_graph;
-  pruned_count
+    let new_graph = { synapses = decayed; last_consolidation = now } in
+    save_graph config new_graph;
+    pruned_count
+  )
 
 (** Get collaboration graph as visualization data - synchronous *)
 let get_graph_data config : (synapse list * string list) =


### PR DESCRIPTION
fix(hebbian): hold with_graph_lock during consolidate to prevent silent clobber

`Hebbian_eio.consolidate` loaded the synapse graph, computed decayed
weights, and saved the result **without** taking `with_graph_lock`.
The sibling write APIs `strengthen` and `weaken` do take the lock, so
`consolidate` could silently roll back a concurrent strengthen/weaken:

1. Thread T1 calls `consolidate`, reads graph G0 (no lock)
2. Thread T2 calls `strengthen`, acquires lock, reads G0, writes G1
   with `A→B weight = 0.6`, releases lock
3. T1 computes decayed G0' from its stale G0 snapshot, with
   `A→B weight = 0.48` (original 0.5 × decay)
4. T1 writes G0' — overwrites T2's G1, silently erasing the
   strengthen

This is a real race: both `with_graph_lock`-holders assume they
observe the latest state, but `consolidate` can step on them. The
hebbian learning invariant ("successes monotonically strengthen,
failures monotonically weaken, decay is a background process that
does not reverse explicit updates") is violated.

## Fix

Wrap the entire `load_graph → fold → save_graph` sequence of
`consolidate` in `with_graph_lock config (fun () -> ...)`. This
makes consolidate atomic with respect to other graph writers and
reestablishes the hebbian invariant.

Behavior unchanged for the happy path (single-writer workloads);
contention cost is bounded by the existing flock retry policy used
by all other writers.

## Verification

```
dune build --root . lib/hebbian_eio.ml   # exit 0
```

Full `dune build lib/` currently fails on main due to unrelated
pre-existing issues in `lib/tool_broadcast_typed.ml` (Sg.parse type
mismatch) and `lib/oas_sse_bridge.ml` (Event_bus record pattern
warnings). Those are being fixed upstream and are not introduced by
this patch — the hebbian compilation unit itself is clean.

## Finding source

Cycle 22 deep-read of `lib/hebbian_eio.ml` (300 lines). Cycles 17-21
found semantic vapor, counter drift, non-atomic entry gate, telemetry
noise, and doc-vs-code contract violations. This cycle adds a new
class: **locking-scheme drift** — one code path correctly enforces
the lock, a sibling path on the same state silently bypasses it.
Same module, same state, different discipline.
