### PR TITLE
fix(channel_gate): wire dedup_cleanup into orchestrator pulse

### DIFF
--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -121,6 +121,33 @@ let dedup_table_size () =
 (* Register dedup_table_size callback to break cycle *)
 let () = Channel_gate_metrics.register_dedup_size_fn dedup_table_size
 
+(* ── Pulse consumer for periodic dedup cleanup ─────────────── *)
+
+(* [dedup_cleanup] exists in the .mli and is documented as "Called
+   periodically", but no production code path wired it to a timer
+   or Pulse consumer — only the test suite invoked it. Without a
+   periodic sweep, TTL-expired entries never leave the table until
+   it hits [dedup_max_entries] (default 10_000), at which point
+   every subsequent insert falls into the O(n) "evict the oldest"
+   branch in [dedup_check] while holding the lock. This consumer
+   restores the intended behavior: each beat calls [dedup_cleanup]
+   so stale entries are reclaimed before the cap is reached. *)
+let make_dedup_cleanup_consumer () : (module Pulse.Consumer) =
+  (module struct
+    let name = "channel-gate-dedup-cleanup"
+    let should_act _beat = true
+    let on_beat _beat =
+      try
+        dedup_cleanup ~now:(Unix.gettimeofday ());
+        Ok ()
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+          Error
+            (Printf.sprintf "dedup_cleanup failed: %s"
+               (Printexc.to_string exn))
+  end)
+
 (* ── Delegated helpers ───────────────────────────────────────── *)
 
 let validation_error_to_string = Gate_protocol.validation_error_to_string

--- a/lib/channel_gate.mli
+++ b/lib/channel_gate.mli
@@ -64,10 +64,18 @@ val dedup_check : string -> bool
     within the TTL window (default 300 s).  Thread-safe. *)
 
 val dedup_cleanup : now:float -> unit
-(** Evict expired entries.  Called periodically. *)
+(** Evict expired entries.  Called periodically by the Pulse consumer
+    returned by {!make_dedup_cleanup_consumer}. *)
 
 val dedup_table_size : unit -> int
 (** Current number of entries in the dedup table.  For metrics. *)
+
+val make_dedup_cleanup_consumer : unit -> (module Pulse.Consumer)
+(** Pulse consumer that sweeps TTL-expired entries on every beat.
+    Wire into an existing Pulse engine (e.g. the orchestrator zombie
+    pulse) during server startup.  Without this, stale entries only
+    leave the table once it hits [dedup_max_entries] and the O(n)
+    evict-one-oldest branch takes over on every subsequent insert. *)
 
 (** {1 Dispatch} *)
 

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -237,7 +237,8 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   let neo4j_interval = Env_config_governance.Timeouts.neo4j_timeout_sec in
   Log.Orchestrator.debug "zero-zombie cleanup enabled (interval: %.0fs)" neo4j_interval;
   let zombie_consumer = make_zero_zombie_consumer ~sw ~room_config in
-  let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm neo4j_interval) ~lifecycle:Always_on ~consumers:[zombie_consumer] in
+  let dedup_consumer = Channel_gate.make_dedup_cleanup_consumer () in
+  let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm neo4j_interval) ~lifecycle:Always_on ~consumers:[zombie_consumer; dedup_consumer] in
   with_pulse_rw (fun () -> zombie_pulse := Some zp);
   Eio.Fiber.fork ~sw (fun () ->
     try Pulse.run ~sw zp


### PR DESCRIPTION

`lib/channel_gate.mli` exports [dedup_cleanup] with the doc string
"Called periodically", and [dedup_ttl_sec] defaults to 300s — the
intent is a periodic sweep that evicts TTL-expired dedup entries.
But nothing in production code called it. A grep for
`Channel_gate.dedup_cleanup` returns exactly one hit:
`test/test_channel_gate.ml`. The rest of the lifecycle is dead.

Without a periodic sweep, stale entries never leave the table until
it reaches [dedup_max_entries] (10_000 by default). At that point
every subsequent insert in [dedup_check] falls into the O(n)
"evict-the-single-oldest" branch while holding [dedup_mutex]:

```
if Hashtbl.length dedup_table >= dedup_max_entries then begin
  let oldest_key = ref "" in
  let oldest_ts = ref Float.max_float in
  Hashtbl.iter (fun k ts -> ...) dedup_table;  (* O(n) scan *)
  if !oldest_key <> "" then Hashtbl.remove dedup_table !oldest_key
end;
Hashtbl.replace dedup_table key now
```

So under sustained channel traffic the gate silently degrades from
"O(1) insert, periodic O(n) sweep" to "O(n) insert on every message
while holding the dedup mutex". The `dedup_table_size` metric also
pegs at 10_000 instead of reflecting real traffic — a telemetry
failure, not just a perf one.

## Fix

1. Add `Channel_gate.make_dedup_cleanup_consumer : unit -> (module
   Pulse.Consumer)` that calls `dedup_cleanup ~now:(Unix.gettimeofday ())`
   on each beat. Raised exceptions are converted to `Error _` so
   they flow through the existing Pulse consumer recovery pathway
   (`Eio.Cancel.Cancelled` is re-raised per the structured-
   concurrency contract).

2. Register the new consumer on the orchestrator zombie pulse in
   `Orchestrator.start`. The zombie pulse runs at
   `Env_config_governance.Timeouts.neo4j_timeout_sec` (default ~30s)
   which is well under the 300s TTL, so expired entries leave the
   table long before the cap is reached.

No new Pulse engine is created — reusing the existing zombie pulse
keeps resource usage flat. The consumer is added to the
`Pulse.create` consumers list directly (not via `Pulse.add_consumer`
after-the-fact) so it's dispatched from the first beat.

## Verification

```
dune build --root . lib/                           # exit 0
dune exec --root . -- ./test/test_channel_gate.exe # 14/14 passed
```

Existing `test_channel_gate.ml` covers the dedup TTL semantics
directly (it calls `dedup_cleanup` itself) and still passes, so the
behavior of `dedup_cleanup` is unchanged; this PR only adds a
production caller.

## Finding source

Cycle 23 of the masc-mcp audit sweep, applying the Cycle 22
locking-scheme drift heuristic ("for each shared state, scan all
write paths and check they use the same discipline") to
`lib/channel_gate.ml`. The drift here is a different shape — not
two paths with divergent locking, but one path that was exported
in the .mli but never wired up. Grep audits in earlier cycles
focused on `failwith`/`silent Error`/exception boundaries; a
wiring gap of this kind is invisible to pattern matching because
the issue is *absence of a caller*, not a bad caller.

Audit heuristic to add: for every function in a .mli whose doc
mentions "periodic", "background", "scheduled", or "on each beat",
grep for the function name and confirm at least one non-test
caller. If only `test/` references it, either wire it or remove
the export.