### PR TITLE
chore(dashboard): enable noImplicitReturns in tsconfig

### DIFF
--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -17,6 +17,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
     "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
## Summary

Add \`\"noImplicitReturns\": true\` to \`dashboard/tsconfig.json\`.

## Why this is safe

The existing codebase **already satisfies** the flag. \`pnpm typecheck\` passes cleanly with **zero fixes needed**. This commit only closes the door on future regressions where a function forgets a \`return\` on one branch of a conditional.

\`\`\`
Before: 462/462 tests passing, typecheck ok
After:  462/462 tests passing, typecheck ok (with the new flag enforced)
\`\`\`

## Placement

Added between \`noFallthroughCasesInSwitch\` and \`noUncheckedIndexedAccess\` to keep the strict-mode flags grouped visually.

## Net change

\`+1 / -0\` in \`dashboard/tsconfig.json\`. No code change. No test change.