### PR TITLE
fix(tool_worktree): reject cross-agent agent_name in masc_worktree_create (#6527 iter 7)

### DIFF
--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -14,11 +14,31 @@ type tool_result = bool * string
 let handle_worktree_create ctx args =
   (* LLM may omit agent_name in args; fall back to context agent_name.
      This prevents Validation.Agent_id failures when the 9B model
-     sends empty or missing agent_name. *)
-  let agent_name =
-    let from_args = get_string args "agent_name" "" in
-    if from_args = "" then ctx.agent_name else from_args
+     sends empty or missing agent_name.
+
+     #6527 iter 7: We must NOT trust an arbitrary agent_name from the
+     caller — that would let keeper-A do
+         masc_worktree_create agent_name=keeper-B task_id=...
+     and land a worktree inside keeper-B's playground, defeating the
+     per-keeper containment invariant established in iters 1–6. If
+     the caller supplies an agent_name that differs from
+     ctx.agent_name, reject it. Empty/missing still falls back to
+     ctx.agent_name. *)
+  let agent_name_result =
+    let from_args = String.trim (get_string args "agent_name" "") in
+    if from_args = "" then Ok ctx.agent_name
+    else if from_args = ctx.agent_name then Ok ctx.agent_name
+    else
+      Error (Printf.sprintf
+        "agent_name mismatch: arg=%S but context agent is %S. \
+         Cross-agent worktree creation is blocked — omit agent_name \
+         (or pass your own) so the worktree lands in your own \
+         playground."
+        from_args ctx.agent_name)
   in
+  match agent_name_result with
+  | Error msg -> (false, msg)
+  | Ok agent_name ->
   let raw_task_id = get_string args "task_id" "" in
   let base_branch = get_string args "base_branch" "develop" in
   (* repo_name comes straight from MCP tool args. Reject anything that


### PR DESCRIPTION
## 요약

`masc_worktree_create`가 **caller가 args로 전달한 `agent_name`을 verbatim으로 신뢰**하는 leak (#6527 iter 7). keeper-A가 `agent_name=keeper-B` 파라미터로 호출하면 worktree가 keeper-B의 playground에 생성되던 문제를 수정합니다.

## 배경

Iters 1–6이 `worktree_create_r` fallback, `keeper_bash` write-gate, `effective_allowed_paths` workspace defaults, `keeper_pr_submit` cwd, 그리고 `tool_code_write.ml`의 `validate_writable_path`/`validate_clone_cwd`까지 모두 per-agent 축소했습니다. 하지만 **entry point** 레벨에서 caller가 agent identity를 스스로 선언하는 lane이 하나 남아 있었습니다:

`lib/tool_worktree.ml:14-21` (pre-iter7):

```ocaml
let handle_worktree_create ctx args =
  let agent_name =
    let from_args = get_string args "agent_name" "" in
    if from_args = "" then ctx.agent_name else from_args
  in
  ...
  Room.worktree_create_r ?repo_name ctx.config ~agent_name ~task_id ~base_branch
```

주석에 "LLM may omit agent_name in args; fall back to context agent_name"이라고 Qwen3.5-9B가 이 필드를 놓치는 케이스를 언급하지만, **양방향 우회**의 문을 열어 두었습니다:

- 정상 경로: `agent_name=""` → `ctx.agent_name` 사용 (OK)
- 악용 경로: `agent_name="other-keeper"` → **other-keeper 사용됨** (LEAK)

keeper-A가 세션 identity = `keeper-A`로 로그인한 상태에서도, MCP arg만으로 다른 keeper의 playground에 worktree를 생성할 수 있었습니다. iters 1–6가 닫은 어떤 gate도 이 entry를 막지 않습니다 — 왜냐하면 `Room.worktree_create_r` 이후의 모든 validation이 `~agent_name`을 신뢰하기 때문.

`handle_worktree_remove` (line 75)는 이 문제가 없습니다. `ctx.agent_name`만 사용하고 args의 `agent_name`을 무시합니다.

## 변경

`lib/tool_worktree.ml`: `agent_name` resolution을 세 갈래로 축소:

```ocaml
let agent_name_result =
  let from_args = String.trim (get_string args "agent_name" "") in
  if from_args = "" then Ok ctx.agent_name                  (* 9B fallback *)
  else if from_args = ctx.agent_name then Ok ctx.agent_name (* explicit match *)
  else
    Error (Printf.sprintf
      "agent_name mismatch: arg=%S but context agent is %S. \
       Cross-agent worktree creation is blocked — omit agent_name \
       (or pass your own) so the worktree lands in your own \
       playground."
      from_args ctx.agent_name)
in
match agent_name_result with
| Error msg -> (false, msg)
| Ok agent_name -> ...
```

- 빈 값 / 생략: 기존 9B fallback 유지 (behavior preserved)
- 일치: 통과 (기존 정상 경로)
- 불일치: 명시적 에러로 reject + 양쪽 값 interpolation 힌트

## 테스트

| Test | 결과 |
|------|------|
| `dune exec test/test_room.exe` | ✅ 99 cases pass |
| `dune exec test/test_mcp_tool_matrix.exe` | ✅ 2/2 (matrix fixture의 agent_name이 ctx와 일치) |
| `dune exec test/test_keeper_tool_matrix.exe` | `masc_worktree_*` 실패 **없음**. 14개 pre-existing failure는 keeper_pr_*/keeper_voice_*/keeper_board_*/masc_claim_next/masc_select_agent로 이 PR과 무관 |

## Trade-off

**의도된 privilege tightening**: 이전 동작은 latent privilege escalation — 어떤 keeper든 `masc_worktree_create`만 호출 가능하면 args 조작으로 타 keeper의 playground를 건드릴 수 있었습니다. iter 7 이후 `ctx.agent_name`이 worktree 생성 경로에서 유일한 ownership SSOT.

다른 agent를 위한 legitimate worktree 생성이 필요하다면, 그건 별도 authorisation이 붙은 별도 tool로 분리되어야 하지 — 공유 LLM-facing tool의 silent default로 제공되어서는 안 됨.

## 관련 PR 체인

- [x] Iter-1 #6533 — prompt
- [x] Iter-2 #6542 — `worktree_create_r` fallback
- [x] Iter-2b #6577 — matrix fixture
- [x] Iter-3 #6579 — `keeper_bash` write-gate
- [x] Iter-4 #6580 — `effective_allowed_paths` + `keeper_pr_submit`
- [x] Iter-5 #6584 — TLA+ invariant
- [x] Iter-6 #6610 — `tool_code_write` per-agent
- [x] Iter-6 tests #6615 — regression suite
- [x] **Iter-7 (이 PR) — `tool_worktree` agent_name spoof block**

## 리뷰 요청

교차 모델 리뷰: `sb glm-text` (GLM-5.1), non-self.
