### PR TITLE
chore(dashboard): simplify lint script to `eslint src` — drop duplicate file list

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "MASC_DASHBOARD_PROXY_TARGET=http://127.0.0.1:8935 vite",
     "build": "tsc --noEmit && vite build",
-    "lint": "eslint src/api/gate.ts src/api/transport-health.ts src/components/common/async-container.ts src/components/common/empty-state.ts src/components/common/feedback-state.ts src/components/common/markdown.ts src/components/connector-status.ts src/components/harness-health-state.ts src/components/harness-health.ts src/components/keeper-tool-call-inspector.ts src/components/keeper-tool-telemetry.ts src/components/logs.ts src/components/mission.ts src/components/runtime-monitor.ts src/components/transport-health.ts src/lib/async-state.ts src/components/common/normalize.ts src/components/common/markdown.test.ts src/components/connector-status.test.ts src/components/keeper-tool-call-inspector.test.ts src/components/transport-health.test.ts src/lib/async-state.test.ts",
+    "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest run --no-file-parallelism --maxWorkers=1",


### PR DESCRIPTION
## Summary

The \`lint\` script in \`dashboard/package.json\` was hardcoding the same 22 file paths that also appear in \`eslint.config.mjs\` (\`TARGET_FILES\` + \`TEST_FILES\`). Any time a new file is whitelisted for linting, both places had to be updated in lockstep — a drift hazard.

## Change

\`\`\`diff
-    "lint": "eslint src/api/gate.ts src/api/transport-health.ts src/components/common/async-container.ts ... (22 files)",
+    "lint": "eslint src",
\`\`\`

ESLint's flat config already uses the \`files\` pattern inside \`eslint.config.mjs\` to restrict which files receive which rule set. Unmatched files under \`src/\` produce a benign \`\"File ignored because no matching configuration was supplied\"\` warning and \`exit 0\`.

After this change, the **single source of truth** for the lint whitelist is \`eslint.config.mjs\`. To expand coverage, add the file to \`TARGET_FILES\` there and no other edit is required.

## Verified

- \`pnpm lint\` still exits 0 with the same rule application (whitelisted files get rules, others are ignored)
- \`pnpm typecheck\` clean
- \`pnpm test\` 462/462 pass

## Net change

\`+1 / -1\` in \`dashboard/package.json\`. Only the script line changed.