### PR TITLE
test(tool_worktree): agent_name spoof regression (#6527 iter 7 tests)

### DIFF
--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -81,6 +81,97 @@ let test_dispatch_unknown_tool () =
   | Some _ -> fail "expected None for unknown tool"
 
 (* ============================================================
+   Iter-7 (#6527) — agent_name spoof rejection
+   ============================================================
+   handle_worktree_create used to trust the `agent_name` MCP arg
+   verbatim, so agent-A could call
+       masc_worktree_create agent_name=agent-B task_id=foo
+   and land a worktree inside agent-B's playground. PR #6617 fixed
+   the dispatcher to reject any arg value that does not equal
+   ctx.agent_name. These cases lock the three-branch decision down
+   so a future refactor cannot silently re-introduce the leak. *)
+
+let contains needle haystack =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  if nlen = 0 then true
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_dispatch_worktree_create_spoofed_agent_blocked () =
+  let ctx = make_ctx () in
+  let args = `Assoc [
+    ("agent_name", `String "other-agent");
+    ("task_id", `String "task-spoof");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (true, _) -> fail "spoofed agent_name should have been rejected"
+  | Some (false, msg) ->
+    check bool "error mentions agent_name mismatch" true
+      (contains "agent_name mismatch" msg);
+    check bool "error mentions the caller ctx agent" true
+      (contains "test-agent" msg);
+    check bool "error mentions the spoofed arg value" true
+      (contains "other-agent" msg);
+    check bool "error explains cross-agent is blocked" true
+      (contains "Cross-agent" msg)
+
+let test_dispatch_worktree_create_matching_agent_passes_check () =
+  (* When the arg matches ctx.agent_name, the spoof gate must not
+     fire. The downstream Room.worktree_create_r call may still fail
+     because the fixture base_path is not a real git repository, so
+     we only assert that any error returned is NOT the spoof error. *)
+  let ctx = make_ctx () in
+  let args = `Assoc [
+    ("agent_name", `String "test-agent");
+    ("task_id", `String "task-match");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (_ok, msg) ->
+    check bool "matching agent_name does not trip spoof gate" false
+      (contains "agent_name mismatch" msg)
+
+let test_dispatch_worktree_create_empty_agent_falls_back () =
+  (* The 9B fallback: empty/missing agent_name arg uses ctx.agent_name
+     instead of rejecting. Same assertion shape as the matching case —
+     we only prove that the spoof branch is not taken. *)
+  let ctx = make_ctx () in
+  let args = `Assoc [
+    ("task_id", `String "task-empty-fallback");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (_ok, msg) ->
+    check bool "empty agent_name arg does not trip spoof gate" false
+      (contains "agent_name mismatch" msg)
+
+let test_dispatch_worktree_create_whitespace_agent_trimmed () =
+  (* Trailing/leading whitespace must be trimmed before the spoof
+     check so a 9B model that sends " " by mistake still gets the
+     empty-fallback path, not a mismatch rejection. *)
+  let ctx = make_ctx () in
+  let args = `Assoc [
+    ("agent_name", `String "   ");
+    ("task_id", `String "task-ws");
+    ("base_branch", `String "main");
+  ] in
+  match Tool_worktree.dispatch ctx ~name:"masc_worktree_create" ~args with
+  | None -> fail "dispatch returned None for masc_worktree_create"
+  | Some (_ok, msg) ->
+    check bool "whitespace agent_name trimmed to fallback" false
+      (contains "agent_name mismatch" msg)
+
+(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -100,5 +191,15 @@ let () =
       test_case "worktree_remove" `Quick test_dispatch_worktree_remove;
       test_case "worktree_list" `Quick test_dispatch_worktree_list;
       test_case "unknown" `Quick test_dispatch_unknown_tool;
+    ];
+    "iter7_agent_name_spoof_6527", [
+      test_case "spoofed agent_name blocked" `Quick
+        test_dispatch_worktree_create_spoofed_agent_blocked;
+      test_case "matching agent_name passes spoof gate" `Quick
+        test_dispatch_worktree_create_matching_agent_passes_check;
+      test_case "empty agent_name falls back to ctx" `Quick
+        test_dispatch_worktree_create_empty_agent_falls_back;
+      test_case "whitespace agent_name trimmed" `Quick
+        test_dispatch_worktree_create_whitespace_agent_trimmed;
     ];
   ]

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -192,7 +192,7 @@ let () =
       test_case "worktree_list" `Quick test_dispatch_worktree_list;
       test_case "unknown" `Quick test_dispatch_unknown_tool;
     ];
-    "iter7_agent_name_spoof_6527", [
+    "agent_name_spoof", [
       test_case "spoofed agent_name blocked" `Quick
         test_dispatch_worktree_create_spoofed_agent_blocked;
       test_case "matching agent_name passes spoof gate" `Quick


### PR DESCRIPTION
## 요약

PR #6617 (`#6527 iter 7`)의 `handle_worktree_create` agent_name spoof-rejection 3-branch 로직을 Alcotest regression으로 고정합니다. Iter-6 tests (#6615)와 동일한 follow-up 패턴.

## 변경

`test/test_tool_worktree_coverage.ml`에 새 suite `iter7_agent_name_spoof_6527` 추가:

1. **spoofed agent_name blocked** — `ctx.agent_name = "test-agent"`이고 `args.agent_name = "other-agent"`일 때 `(false, msg)` 반환, `msg`가 `"agent_name mismatch"` + 양쪽 값 + `"Cross-agent"` 포함
2. **matching agent_name passes spoof gate** — args가 ctx와 일치할 때 spoof 분기 트리거 안 함 (downstream `Room.worktree_create_r` error는 허용)
3. **empty agent_name falls back to ctx** — arg 생략 → 9B fallback path 확인
4. **whitespace agent_name trimmed** — `"   "` 값 → `String.trim` 후 empty fallback. future refactor가 `trim`을 제거하면 이 테스트가 fail해서 regression 포착

## 디자인 주의사항

- Dispatcher 레벨 테스트만. 실제 filesystem/git repo 없이 `Tool_worktree.dispatch` 반환값만 검증.
- 헬퍼 `contains` inline 함수로 별도 dep 없음.
- 기존 9 cases + 신규 4 cases = **13 cases pass** (`Test Successful in 0.131s`).

## 관련 PR 체인

- [x] Iter-1 ~ Iter-7 모두 main에 landing (#6533 ~ #6617)
- [x] Iter-6 tests #6615 merged
- [x] **Iter-7 tests (이 PR)** — regression lock

Trilogy + 확장이 이 PR 머지 후 완전 소진. 남은 후속은 orphan branch cleanup과 `Task_sandbox.create` future-proofing 정도.

## 리뷰 요청

교차 모델 리뷰: `sb glm-text` (GLM-5.1). test-only PR이므로 scope + helper 정확성만.
