### PR TITLE
fix(grpc): close helpers re-raise Cancelled to honor structured concurrency

### DIFF
--- a/lib/grpc/masc_grpc_client.ml
+++ b/lib/grpc/masc_grpc_client.ml
@@ -108,7 +108,15 @@ let subscribe t ~sw ~env ~agent_name ~session_id ~event_types ~since_seq =
       push_typed (Error message)
     in
     let close_typed () =
-      try Grpc_eio.Stream.close typed_stream with _ -> ()
+      (* [with _ -> ()] would swallow [Eio.Cancel.Cancelled]. This helper is
+         called from the [Error status] and [End_of_file] branches of [loop]
+         (outside any cancel handler); if [Stream.close] raises [Cancelled]
+         on those paths, the outer [try loop () with Cancelled _] at line 136
+         would never see it and the cancel would be silently absorbed. *)
+      try Grpc_eio.Stream.close typed_stream
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | _ -> ()
     in
     let rec loop () =
       match Grpc_eio.Stream.take raw_stream with
@@ -162,11 +170,18 @@ let heartbeat_stream t ~sw ~env =
   (* Map typed pings to raw bytes *)
   let raw_requests = Grpc_eio.Stream.create 16 in
   Eio.Fiber.fork ~sw (fun () ->
+    (* Both helpers must re-raise [Eio.Cancel.Cancelled] — they are called
+       from the [End_of_file] and generic-[exn] branches of the enclosing
+       loop (lines 177, 190-191), neither of which is a cancel handler.
+       [with _ -> ()] would swallow a cancel racing with [Stream.close],
+       leaving the fork fiber alive past the cancel boundary. *)
     let close_request_stream () =
-      try Grpc_eio.Stream.close request_stream with _ -> ()
+      try Grpc_eio.Stream.close request_stream
+      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
     in
     let close_raw_requests () =
-      try Grpc_eio.Stream.close raw_requests with _ -> ()
+      try Grpc_eio.Stream.close raw_requests
+      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ()
     in
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -279,7 +279,15 @@ let handle_heartbeat
       Atomic.decr active_heartbeat_streams;
       Transport_metrics.set_grpc_active_streams
         (Atomic.get active_heartbeat_streams);
-      (try Grpc_eio.Stream.close response_stream with _ -> ())
+      (* Called from [End_of_file] at line 360 and the generic-[exn] handler
+         at line 371 — neither is a cancel handler. [with _ -> ()] would
+         swallow [Eio.Cancel.Cancelled] racing with [Stream.close], leaving
+         the fiber to fall past the cancel boundary. The counters above are
+         decremented first, so re-raising here is safe. *)
+      (try Grpc_eio.Stream.close response_stream
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | _ -> ())
     in
     let rec loop () =
       match Grpc_eio.Stream.take request_stream with


### PR DESCRIPTION

Four `try Grpc_eio.Stream.close _ with _ -> ()` helpers in
`masc_grpc_client.ml` and `masc_grpc_service.ml` had a silent cancel-
absorption bug: they swallow **every** exception from `Stream.close`,
including `Eio.Cancel.Cancelled`. When the helper is called outside a
cancel handler (which happens on `Error status`, `End_of_file`, and
generic-`exn` branches of the enclosing loops), a cancel racing with
the close is silently absorbed and the fork fiber falls past the
cancel boundary.

## Sites fixed

`lib/grpc/masc_grpc_client.ml`:

- `close_typed` (line 111) — called from `Error status` at 130 and
  `End_of_file` at 132 (non-cancel paths); also from the cancel handler
  at 137.
- `close_request_stream` (line 166) — called from the cancel handler
  at 183 and the generic-`exn` handler at 190.
- `close_raw_requests` (line 169) — called from `End_of_file` at 177
  (non-cancel), the cancel handler at 184, and the generic-`exn`
  handler at 191.

`lib/grpc/masc_grpc_service.ml`:

- `cleanup` (line 278) — called from `End_of_file` at 360 and the
  generic-`exn` handler at 371 (both non-cancel paths); also from the
  cancel handler at 365.

All four now use:

```ocaml
try Grpc_eio.Stream.close <stream>
with
| Eio.Cancel.Cancelled _ as e -> raise e
| _ -> ()
```

This keeps the "swallow non-cancel close errors" behavior (which is
intentional for cleanup paths — we don't want a secondary close
failure to mask the primary reason we're tearing down) while
respecting the Eio structured-concurrency contract: `Cancelled` must
propagate out of any frame that wasn't explicitly handling cancel.

In the `masc_grpc_service.ml` cleanup, `Atomic.decr` and the metric
update happen **before** the close, so re-raising inside the close
no longer leaves the counters half-updated.

## Contrast with the safe pattern

`lib/process/process_eio.ml:308`, `lib/process/process_eio.ml:338-339`,
`lib/dashboard/dashboard_cache.ml:271`, and
`lib/worker_dev_tools.ml:985` also contain `try ... close ... with
_ -> ()` calls, but each of those is **inside** an outer
`Eio.Cancel.Cancelled _ as e -> ... raise e` handler — the inner
`_ -> ()` can safely eat the close-cancel because the outer `raise e`
immediately re-raises the original cancel on the next line. Those
sites were audited and left as-is.

## Verification

```
dune build --root . @lib/check                                 # exit 0
dune exec --root . -- ./test/test_grpc_client.exe              # 15/15 passed
dune exec --root . -- ./test/test_grpc_coordination.exe        # 18/18 passed
```

## Finding source

Cycle 25 of the masc-mcp audit sweep. New axis this cycle: grep for
`with _ -> ()` to find exception-absorbing `try` frames, then read
each site to classify "inside cancel handler" (safe) vs "called from
non-cancel paths" (bug). 9 sites found, 4 classified as bugs, 5 as
safe cleanup idioms. TLA+ and unit tests exercise normal close paths
but not cancel-racing-close, so the bug was static-analysis only.

Audit heuristic: `rg -n "with _ -> \(\)" lib/ --glob '*.ml'` — for
each hit, read the enclosing function and check whether the helper is
called exclusively from frames that re-raise cancel. Helpers called
from the generic `exn` branch of an outer `try ... loop () with ...
| exn -> cleanup ()` are always buggy because that branch does not
re-raise cancel.