### PR TITLE
fix(dashboard): align Harness types with cross_model fields from #6565

### DIFF
--- a/dashboard/src/components/harness-health-state.ts
+++ b/dashboard/src/components/harness-health-state.ts
@@ -33,6 +33,11 @@ export interface HarnessOverview {
   pre_compact_last_event_at: number | null
   handoff_last_event_at: number | null
   fallback_ratio: number
+  // Added by lib/dashboard/dashboard_harness_health.ml as part of #6565.
+  // Ratio of verdicts whose generator_cascade ≠ evaluator_cascade among
+  // verdicts that carried a generator_cascade. undefined when the backend
+  // had zero eligible verdicts to compute the ratio.
+  cross_model_rate?: number
   latest_pre_compact_ratio: number | null
   latest_handoff_generation: number | null
 }
@@ -45,6 +50,9 @@ export interface HarnessVerdictItem {
   gate: string
   verdict: string
   evaluator_cascade: string
+  // Added by lib/tool_task.ml#build_verdict_sse_payload as part of #6565.
+  generator_cascade?: string | null
+  cross_model?: boolean
   fallback_reason?: string | null
 }
 


### PR DESCRIPTION
## Summary

PR #6565 (\`feat(harness): expose cross-model enforcement rate on dashboard\`) added two new fields to the backend response shapes that the frontend was not yet aware of:

| Layer | Field | Source |
|---|---|---|
| \`HarnessOverview\` | \`cross_model_rate?: number\` | \`lib/dashboard/dashboard_harness_health.ml#overview_json\` |
| \`HarnessVerdictItem\` | \`generator_cascade?: string \| null\` | \`lib/tool_task.ml#build_verdict_sse_payload\` |
| \`HarnessVerdictItem\` | \`cross_model?: boolean\` | same |

Frontend types were silently dropping them. A future consumer that tries to read \`overview.cross_model_rate\` or \`item.cross_model\` would need an \`as any\` escape or a duplicated type definition.

## Change

Added the three fields as optional properties matching the backend shape:
- \`undefined\` when the ratio is indeterminate (backend had zero eligible verdicts)
- \`null\` for \`generator_cascade\` when absent on the verdict payload

Inline comments point to the backing backend call sites so the next drift is easy to catch.

## Scope

**No consumer yet** — this is purely a type-level sync so the next UI work on cross-model enforcement does not start with a type cast.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (462 passed)