### PR TITLE
[codex] Fix base-path config root precedence

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -280,6 +280,41 @@ restore_env_override() {
 
 REPO_ENV_ROOT="$(resolve_repo_env_root)"
 
+repo_local_config_dir_match() {
+    local candidate="${1:-}"
+    candidate="${candidate%/}"
+    [ -n "$candidate" ] || return 1
+    [ "$candidate" = "$REPO_ENV_ROOT/config" ] || [ "$candidate" = "$SCRIPT_DIR/config" ]
+}
+
+repo_local_personas_dir_match() {
+    local candidate="${1:-}"
+    candidate="${candidate%/}"
+    [ -n "$candidate" ] || return 1
+    [ "$candidate" = "$REPO_ENV_ROOT/config/personas" ] || [ "$candidate" = "$SCRIPT_DIR/config/personas" ]
+}
+
+clear_repo_local_config_for_explicit_base_path() {
+    local resolved_base_path="$1"
+
+    if [ "$BASE_PATH_EXPLICIT" != "1" ]; then
+        return 0
+    fi
+    if [ "$resolved_base_path" = "$REPO_ENV_ROOT" ] || [ "$resolved_base_path" = "$SCRIPT_DIR" ]; then
+        return 0
+    fi
+
+    if repo_local_config_dir_match "${MASC_CONFIG_DIR:-}"; then
+        echo "[startup] Ignoring repo-local MASC_CONFIG_DIR=${MASC_CONFIG_DIR%/} because --base-path was supplied; defaulting to $resolved_base_path/.masc/config" >&2
+        unset MASC_CONFIG_DIR
+    fi
+
+    if repo_local_personas_dir_match "${MASC_PERSONAS_DIR:-}"; then
+        echo "[startup] Ignoring repo-local MASC_PERSONAS_DIR=${MASC_PERSONAS_DIR%/} because --base-path was supplied; personas will resolve from the active config root" >&2
+        unset MASC_PERSONAS_DIR
+    fi
+}
+
 # Caller-provided env must win over repo-local .env/.env.local files.
 for env_name in \
     MASC_STORAGE_TYPE \
@@ -611,6 +646,7 @@ if [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
 fi
 
 RESOLVED_BASE_PATH="$(resolve_base_path "$BASE_PATH")"
+clear_repo_local_config_for_explicit_base_path "$RESOLVED_BASE_PATH"
 export MASC_BASE_PATH="$RESOLVED_BASE_PATH"
 export MASC_BASE_PATH_RESOLUTION_SOURCE="$BASE_PATH_RESOLUTION_SOURCE"
 bootstrap_base_path_config "$RESOLVED_BASE_PATH"

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -476,6 +476,77 @@ let test_explicit_base_path_execs_from_base_path () =
       check bool "exec cwd matches explicit base path" true
         (contains_substring captured ("PWD=" ^ parent)))
 
+let test_explicit_base_path_ignores_repo_local_config_from_zshenv () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let parent = Filename.concat dir "parent-root" in
+      let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
+      let home_dir = Filename.concat dir "home" in
+      mkdir_p repo;
+      mkdir_p home_dir;
+      ignore (make_config_root repo);
+      write_file (Filename.concat home_dir ".zshenv")
+        (Printf.sprintf
+           "export MASC_CONFIG_DIR=%s\nexport MASC_PERSONAS_DIR=%s\n"
+           (Filename.concat repo "config")
+           (Filename.concat repo "config/personas"));
+      let script = Filename.concat repo "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe repo;
+      let capture = Filename.concat dir "captured-explicit-base-config.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
+            ]
+          (Printf.sprintf "%s --http --port 9967 --base-path %s"
+             (quote script) (quote parent))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "explicit base path resets config root to base path" true
+        (contains_substring captured
+           ("MASC_CONFIG_DIR=" ^ Filename.concat parent ".masc/config"));
+      check bool "stderr explains repo-local config ignore" true
+        (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR");
+      check bool "stderr explains repo-local personas ignore" true
+        (contains_substring stderr "Ignoring repo-local MASC_PERSONAS_DIR"))
+
+let test_explicit_base_path_ignores_repo_local_config_from_parent_env () =
+  with_temp_dir "start-masc-script" (fun dir ->
+      let parent = Filename.concat dir "parent-root" in
+      let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
+      mkdir_p repo;
+      ignore (make_config_root repo);
+      let script = Filename.concat repo "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      make_fake_eio_exe repo;
+      let capture = Filename.concat dir "captured-explicit-parent-env.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:repo
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_CONFIG_DIR", Filename.concat repo "config");
+              ("MASC_PERSONAS_DIR", Filename.concat repo "config/personas");
+            ]
+          (Printf.sprintf "%s --http --port 9968 --base-path %s"
+             (quote script) (quote parent))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "parent env repo-local config ignored under external base path"
+        true
+        (contains_substring captured
+           ("MASC_CONFIG_DIR=" ^ Filename.concat parent ".masc/config"));
+      check bool "parent env repo-local config ignore is logged" true
+        (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
+
 let test_explicit_http_port_derives_sidecar_ports () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
@@ -601,6 +672,14 @@ let () =
             test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved;
           test_case "explicit base path execs from base path" `Quick
             test_explicit_base_path_execs_from_base_path;
+          test_case
+            "explicit base path ignores repo-local config from zshenv"
+            `Quick
+            test_explicit_base_path_ignores_repo_local_config_from_zshenv;
+          test_case
+            "explicit base path ignores repo-local config from parent env"
+            `Quick
+            test_explicit_base_path_ignores_repo_local_config_from_parent_env;
           test_case "explicit http port derives sidecar ports" `Quick
             test_explicit_http_port_derives_sidecar_ports;
           test_case "grpc-direct banner is preserved in stderr" `Quick


### PR DESCRIPTION
## What changed
When `start-masc-mcp.sh` is launched with an explicit `--base-path`, it now ignores repo-local `config/` and `config/personas/` paths that leaked in from parent shell env or `~/.zshenv` when those paths belong to the checkout instead of the requested runtime base path.

## Why
The shared server at `--base-path=/Users/dancer/me` was still resolving `MASC_CONFIG_DIR` to the checked-in repo `config/` directory because a stale repo-local override survived startup env loading. That made the dashboard surface the wrong active config root and prompt registry.

## Impact
Shared-runtime startup now resolves config and prompt markdown under `<base-path>/.masc/config` unless the caller intentionally points at a different non-repo config root. Repo-local startup behavior is unchanged when the explicit base path is the repo checkout itself.

## Root cause
`start-masc-mcp.sh` preserved `MASC_CONFIG_DIR` and `MASC_PERSONAS_DIR` from parent env / `~/.zshenv` without checking whether those paths were just the checkout's `config/` fallback, even when `--base-path` targeted a different runtime root.

## Validation
- `dune build --root . ./test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- verified dashboard runtime on local `127.0.0.1:8935` now reports `/Users/dancer/me/.masc/config` and `/Users/dancer/me/.masc/config/prompts`
