### PR TITLE
fix(auth): gate cross-agent create_token and revoke on initial_admin (#6623)

### DIFF
--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -14,6 +14,27 @@ let target_agent_name ctx args =
   | "" -> ctx.agent_name
   | name -> name
 
+(* Authorisation gate for cross-agent admin actions (#6623).
+   Returns [true] when [ctx.agent_name] is allowed to act on a
+   different agent's credentials. The rule matches the existing
+   [initial_admin] concept written by [Auth.enable_auth] — the
+   agent that enabled auth is the bootstrap admin and retains
+   full permission. Any other caller must pass their own
+   [agent_name] (i.e. target == ctx), otherwise the cross-agent
+   action is rejected. *)
+let caller_is_initial_admin (ctx : context) : bool =
+  match Auth.read_initial_admin ctx.config.base_path with
+  | Some admin -> String.equal admin ctx.agent_name
+  | None -> false
+
+let cross_agent_forbidden_msg ~action ~(ctx : context) ~target =
+  Printf.sprintf
+    "%s is restricted: agent_name must match the authenticated \
+     agent (caller=%S) unless the caller is the initial admin. \
+     Requested target=%S. Cross-agent %s is blocked to prevent \
+     credential spoofing. See #6623."
+    action ctx.agent_name target action
+
 let handle_auth_enable ctx args =
   let require_token = get_bool args "require_token" false in
   let (secret, bootstrap_token) =
@@ -69,6 +90,17 @@ let create_token_failures = Hashtbl.create 16
 
 let handle_auth_create_token ctx args =
   let target_agent = target_agent_name ctx args in
+  (* #6623 iter 8 — reject cross-agent token creation unless the
+     caller is the initial_admin recorded at enable_auth time.
+     Without this gate, any authenticated caller could forge a
+     token for any other agent (including admin role) and hot-swap
+     identity. Matches the self-only guard already in
+     [handle_auth_refresh]. *)
+  if target_agent <> ctx.agent_name && not (caller_is_initial_admin ctx) then
+    (false, cross_agent_forbidden_msg
+              ~action:"masc_auth_create_token"
+              ~ctx ~target:target_agent)
+  else
   let failures = match Hashtbl.find_opt create_token_failures target_agent with Some f -> f | None -> 0 in
   if failures >= 3 then
     (false, Printf.sprintf "Circuit breaker open: masc_auth_create_token failed %d times for %s. Check auth directories permissions or secret key configuration." failures target_agent)
@@ -136,6 +168,15 @@ Expires: %s
 
 let handle_auth_revoke ctx args =
   let target_agent = target_agent_name ctx args in
+  (* #6623 iter 8 — same gate as handle_auth_create_token. Cross-agent
+     revoke is a denial-of-service primitive: any authenticated caller
+     could lock another agent out at will. Allow only self-revoke, or
+     revoke-by-initial-admin for legitimate credential rotation. *)
+  if target_agent <> ctx.agent_name && not (caller_is_initial_admin ctx) then
+    (false, cross_agent_forbidden_msg
+              ~action:"masc_auth_revoke"
+              ~ctx ~target:target_agent)
+  else
   match Auth.load_credential ctx.config.base_path target_agent with
   | None ->
       (false, Printf.sprintf "No credential found for %s" target_agent)

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -167,8 +167,14 @@ let () = test "dispatch_auth_revoke" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
-let () = test "handle_auth_create_token_respects_agent_name" (fun () ->
+(* #6623 iter 8 — cross-agent create_token must be gated on
+   initial_admin. This case pins the admin path: set [ctx.agent_name]
+   as the initial admin of the test config, then create a token for
+   a different target. Expected: success (admin can provision tokens
+   for any agent). *)
+let () = test "handle_auth_create_token_admin_can_target_others" (fun () ->
   let ctx = make_test_ctx () in
+  Auth.write_initial_admin ctx.config.base_path ctx.agent_name;
   let target = "dashboard-eager-manta" in
   let args =
     `Assoc [
@@ -183,6 +189,66 @@ let () = test "handle_auth_create_token_respects_agent_name" (fun () ->
   match Auth.verify_token ctx.config.base_path ~agent_name:target ~token:raw_token with
   | Ok _ -> ()
   | Error e -> failwith (Types.masc_error_to_string e)
+)
+
+(* #6623 iter 8 — negative case: non-admin caller cannot forge a
+   token for another agent. Rejection must be surfaced as
+   (false, msg) with a Cross-agent-blocked message. *)
+let () = test "handle_auth_create_token_non_admin_cross_agent_blocked" (fun () ->
+  let ctx = make_test_ctx () in
+  (* Do NOT write an initial_admin entry — ctx.agent_name is a plain
+     caller, not the bootstrap admin. *)
+  let target = "other-agent" in
+  let args =
+    `Assoc [
+      ("agent_name", `String target);
+      ("role", `String "worker");
+    ]
+  in
+  let (success, result) = Tool_auth.handle_auth_create_token ctx args in
+  assert (not success);
+  assert (contains_substring result "Cross-agent");
+  assert (contains_substring result "masc_auth_create_token");
+  assert (contains_substring result target);
+  (* The leaked credential should not have been persisted. *)
+  match Auth.load_credential ctx.config.base_path target with
+  | Some _ -> failwith "credential was persisted despite rejection"
+  | None -> ()
+)
+
+(* #6623 iter 8 — self path: caller == target must still work for
+   any agent, admin or not. This is the non-privileged happy path. *)
+let () = test "handle_auth_create_token_self_always_allowed" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc [
+      ("agent_name", `String ctx.agent_name);
+      ("role", `String "worker");
+    ]
+  in
+  let (success, result) = Tool_auth.handle_auth_create_token ctx args in
+  assert success;
+  assert (contains_substring result ctx.agent_name)
+)
+
+(* #6623 iter 8 — same rejection gate for revoke. *)
+let () = test "handle_auth_revoke_non_admin_cross_agent_blocked" (fun () ->
+  let ctx = make_test_ctx () in
+  (* Seed a credential for a foreign agent. The revoke attempt must
+     be rejected before reaching delete_credential. *)
+  let target = "victim-agent" in
+  (match Auth.create_token ctx.config.base_path ~agent_name:target ~role:Types.Worker with
+   | Ok _ -> ()
+   | Error e -> failwith (Types.masc_error_to_string e));
+  let args = `Assoc [ ("agent_name", `String target) ] in
+  let (success, result) = Tool_auth.handle_auth_revoke ctx args in
+  assert (not success);
+  assert (contains_substring result "Cross-agent");
+  assert (contains_substring result "masc_auth_revoke");
+  (* Credential must still exist. *)
+  match Auth.load_credential ctx.config.base_path target with
+  | Some _ -> ()
+  | None -> failwith "credential was deleted despite rejection"
 )
 
 let () = test "handle_auth_refresh_respects_agent_name" (fun () ->
@@ -220,8 +286,11 @@ let () = test "handle_auth_refresh_rejects_other_agent" (fun () ->
   assert (contains_substring result "authenticated agent")
 )
 
-let () = test "handle_auth_revoke_respects_agent_name" (fun () ->
+(* #6623 iter 8 — admin can revoke cross-agent credentials for
+   legitimate rotation. Mirrors the create_token admin path. *)
+let () = test "handle_auth_revoke_admin_can_target_others" (fun () ->
   let ctx = make_test_ctx () in
+  Auth.write_initial_admin ctx.config.base_path ctx.agent_name;
   let target = "dashboard-eager-manta" in
   ignore (Auth.create_token ctx.config.base_path ~agent_name:target ~role:Types.Worker);
   let args = `Assoc [("agent_name", `String target)] in


### PR DESCRIPTION
## 요약

Closes #6623. `handle_auth_create_token`과 `handle_auth_revoke`가 **admin 체크 없이** args의 `agent_name`을 verbatim으로 신뢰하던 critical privilege escalation을 수정합니다.

## 배경 (#6623)

기존 코드 (`lib/tool_auth.ml:70-112`, `:137-144`):

```ocaml
let handle_auth_create_token ctx args =
  let target_agent = target_agent_name ctx args in
  ...
  Auth.create_token ctx.config.base_path ~agent_name:target_agent ~role
```

`target_agent_name`은 `args.agent_name`을 그대로 반환합니다. 즉 keeper-A가 `masc_auth_create_token agent_name=keeper-B role=admin`을 호출하면:
- `target = "keeper-B"`
- `Auth.create_token`이 keeper-B의 raw token을 생성해서 **응답으로 반환**
- keeper-A는 그 token을 받아 이후 모든 요청에서 keeper-B로 **identity hot-swap**
- RBAC 전체 우회

`handle_auth_revoke`도 동일 — keeper-A가 keeper-B의 credential을 임의로 삭제(=lockout) 가능.

`handle_auth_refresh`는 이미 `target == ctx.agent_name` 체크가 있었습니다. 이 PR은 create/revoke도 같은 안전 수준으로 맞춥니다.

## 수정 (#6623 Option B: admin-gated)

### 새 헬퍼

```ocaml
let caller_is_initial_admin (ctx : context) : bool =
  match Auth.read_initial_admin ctx.config.base_path with
  | Some admin -> String.equal admin ctx.agent_name
  | None -> false

let cross_agent_forbidden_msg ~action ~ctx ~target =
  Printf.sprintf
    "%s is restricted: agent_name must match the authenticated \
     agent (caller=%S) unless the caller is the initial admin. \
     Requested target=%S. Cross-agent %s is blocked to prevent \
     credential spoofing. See #6623."
    action ctx.agent_name target action
```

### Gate 적용

`handle_auth_create_token` 선두 (circuit breaker 전):

```ocaml
if target_agent <> ctx.agent_name && not (caller_is_initial_admin ctx) then
  (false, cross_agent_forbidden_msg
            ~action:"masc_auth_create_token"
            ~ctx ~target:target_agent)
else
  ... existing body ...
```

`handle_auth_revoke` 동일 패턴.

### 왜 Option B (admin-gated) 를 택했는가

- 기존 `Auth.enable_auth`가 `write_initial_admin`으로 bootstrap admin을 기록하는 흐름이 이미 존재 — 이 SSOT를 재사용
- `Auth.get_role_for_agent` (auth.ml:309)도 initial_admin에게 `Admin` role을 부여 중 — consistency
- Legitimate admin 워크플로 (token rotation, re-provision) 보존
- Self-only (#6623 Option A)로 가면 lost-token 복구가 외부 툴 필요 — unnecessary friction

## 테스트

### 기존 leak-검증 테스트 2개 교체

- `handle_auth_create_token_respects_agent_name` → **삭제**. 이 테스트는 "agent-A가 agent-B의 token을 생성 가능"을 **정상 동작으로 pin**하고 있었음. 이름이 "respects_agent_name"이었지만 실제로는 leak을 assertion.
- `handle_auth_revoke_respects_agent_name` → **삭제**. 동일.

### 새 테스트 5개

1. `handle_auth_create_token_admin_can_target_others` — `Auth.write_initial_admin ... ctx.agent_name` 후 cross-agent create 성공. Raw token이 `verify_token`으로 통과.
2. `handle_auth_create_token_non_admin_cross_agent_blocked` — initial_admin 설정 없이 cross-agent 요청 → `(false, msg)` + `"Cross-agent"` + `"masc_auth_create_token"` interpolation. `Auth.load_credential`로 credential이 persist 안 됐음도 확인.
3. `handle_auth_create_token_self_always_allowed` — 어떤 caller든 `args.agent_name = ctx.agent_name`이면 admin 여부와 무관하게 성공.
4. `handle_auth_revoke_admin_can_target_others` — revoke admin path.
5. `handle_auth_revoke_non_admin_cross_agent_blocked` — negative. Victim credential이 실제로 **삭제되지 않았음**을 `Auth.load_credential`로 확인.

### 결과

| Test suite | Cases | 결과 |
|------------|-------|------|
| `test_tool_auth_coverage.ml` | 23 | ✅ all pass |
| `test_auth.ml` | 26 | ✅ all pass |
| `test_auth_coverage.ml` | 88 | ✅ all pass |
| **합계** | **137** | **✅** |

## Trade-off

**의도된 breaking change**: cross-agent create/revoke에 의존하던 caller (주로 dashboard/orchestrator 레벨)는 이제 `initial_admin`으로 등록된 identity에서만 동작합니다. MASC auth model의 명시적 의도와 일치하며, 기존 `get_role_for_agent`가 이미 admin 역할을 initial_admin에 한정하던 것과 consistency.

## 관련

- Issue #6623 (이 PR의 원본 diagnosis)
- Iter-7 PR #6617 — 같은 "args self-declaration 신뢰 금지" 패턴을 `tool_worktree.ml`에 적용. 이 PR은 auth 레이어에 대한 병렬 fix.

## 리뷰 요청

교차 모델 리뷰: `sb glm-text` (GLM-5.1), non-self. Security PR이므로 특히 Option B vs Option A trade-off, initial_admin API 사용 정확성, regression test coverage 중점.
