### PR TITLE
fix(session): hold registry.lock on all hashtable reads; drop dead unregister_sync

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -74,13 +74,6 @@ let unregister registry ~agent_name =
       agent_name (Hashtbl.length registry.sessions)
   )
 
-(** @deprecated Use [unregister] instead. Direct Hashtbl.remove without
-    mutex creates a race window with concurrent register/heartbeat calls
-    (see TLA+ SessionRegistryGhost spec). *)
-let unregister_sync (registry : registry) ~agent_name =
-  Hashtbl.remove registry.sessions agent_name;
-  Log.Session.info "Session unregistered (sync): %s (total: %d)"
-    agent_name (Hashtbl.length registry.sessions)
 
 (** Update activity timestamp *)
 let update_activity registry ~agent_name ?(is_listening = None) () =
@@ -293,10 +286,22 @@ let wait_for_message registry ~agent_name ~timeout =
   let start_time = Time_compat.now () in
   let check_interval = 2.0 in
 
-  (* Ensure session exists *)
-  (match Hashtbl.find_opt registry.sessions agent_name with
-   | Some _ -> ()
-   | None -> ignore (register registry ~agent_name));
+  (* Ensure session exists — check under lock so the read of
+     [registry.sessions] is atomic with respect to concurrent
+     [register]/[unregister]/[push_message] calls.  [register] itself
+     takes [with_lock] internally, but the existence probe here must
+     also be guarded; without it, a concurrent [unregister] between
+     the probe and the [register] call could cause a redundant
+     re-registration that clobbers a session that was just restored. *)
+  with_lock registry (fun () ->
+    if not (Hashtbl.mem registry.sessions agent_name) then
+      ignore (Hashtbl.replace registry.sessions agent_name {
+        agent_name;
+        connected_at = Time_compat.now ();
+        last_activity = Time_compat.now ();
+        is_listening = false;
+        message_queue = [];
+      }));
 
   update_activity registry ~agent_name ~is_listening:(Some true) ();
 
@@ -325,32 +330,43 @@ let wait_for_message registry ~agent_name ~timeout =
 
 (** Get inactive agents (idle > threshold seconds) *)
 let get_inactive_agents registry ~threshold =
-  let now = Time_compat.now () in
-  Hashtbl.fold (fun name session acc ->
-    if now -. session.last_activity > threshold then
-      name :: acc
-    else
-      acc
-  ) registry.sessions []
+  (* [session.last_activity] is mutable and is written by
+     [update_activity] under [registry.lock]; folding the hashtable
+     without the same lock is a contract violation of the type
+     declaration ("accessed exclusively under registry.lock").  Build
+     the result inside the critical section and return it. *)
+  with_lock registry (fun () ->
+    let now = Time_compat.now () in
+    Hashtbl.fold (fun name session acc ->
+      if now -. session.last_activity > threshold then
+        name :: acc
+      else
+        acc
+    ) registry.sessions [])
 
 (** Get all agent statuses *)
 let get_agent_statuses registry =
-  let now = Time_compat.now () in
-  Hashtbl.fold (fun name session acc ->
-    let idle_secs = int_of_float (now -. session.last_activity) in
-    let status_icon =
-      if session.is_listening then "🎧"
-      else if idle_secs > 60 then "💤"
-      else "🔨"
-    in
-    let status = `Assoc [
-      ("name", `String name);
-      ("listening", `Bool session.is_listening);
-      ("idle_seconds", `Int idle_secs);
-      ("status", `String status_icon);
-    ] in
-    status :: acc
-  ) registry.sessions []
+  (* Reads mutable [is_listening] and [last_activity] fields plus the
+     hashtable itself.  Must hold [registry.lock] to match the
+     contract and to avoid observing torn state after a concurrent
+     [update_activity]/[register]/[unregister]. *)
+  with_lock registry (fun () ->
+    let now = Time_compat.now () in
+    Hashtbl.fold (fun name session acc ->
+      let idle_secs = int_of_float (now -. session.last_activity) in
+      let status_icon =
+        if session.is_listening then "🎧"
+        else if idle_secs > 60 then "💤"
+        else "🔨"
+      in
+      let status = `Assoc [
+        ("name", `String name);
+        ("listening", `Bool session.is_listening);
+        ("idle_seconds", `Int idle_secs);
+        ("status", `String status_icon);
+      ] in
+      status :: acc
+    ) registry.sessions [])
 
 (** Format status for display *)
 let status_string registry =
@@ -389,7 +405,11 @@ let status_string registry =
 
 (** Connected agent names *)
 let connected_agents registry =
-  Hashtbl.fold (fun name _ acc -> name :: acc) registry.sessions []
+  (* Reading [registry.sessions] without [registry.lock] races with
+     [register]/[unregister] which write under the lock; the type
+     declaration explicitly forbids lock-free access. *)
+  with_lock registry (fun () ->
+    Hashtbl.fold (fun name _ acc -> name :: acc) registry.sessions [])
 
 (** Restore sessions from disk (call on server startup) *)
 let restore_from_disk registry ~agents_path =

--- a/lib/session.mli
+++ b/lib/session.mli
@@ -54,10 +54,6 @@ val register : registry -> agent_name:string -> session
 (** Unregister an agent session (mutex-protected). *)
 val unregister : registry -> agent_name:string -> unit
 
-(** Unregister synchronously without extra mutex layer.
-    Safe in single-fiber Eio context. *)
-val unregister_sync : registry -> agent_name:string -> unit
-
 (** Update the activity timestamp and optionally the listening flag. *)
 val update_activity :
   registry -> agent_name:string -> ?is_listening:bool option -> unit -> unit

--- a/test/test_session_coverage.ml
+++ b/test/test_session_coverage.ml
@@ -378,7 +378,12 @@ let test_handle_mcp_session_tool_no_action () =
    status_string Tests (requires Eio runtime - basic only)
    ============================================================ *)
 
+(* [status_string] / [connected_agents] now take [registry.lock]
+   (Eio.Mutex) to match the contract on [registry]: all fields
+   accessed exclusively under the lock.  Eio.Mutex requires an active
+   Eio context, so both tests run inside [Eio_main.run]. *)
 let test_status_string_empty () =
+  Eio_main.run @@ fun _env ->
   let registry = Session.create () in
   let status = Session.status_string registry in
   check bool "says no agents" true (
@@ -392,6 +397,7 @@ let test_status_string_empty () =
    ============================================================ *)
 
 let test_connected_agents_empty () =
+  Eio_main.run @@ fun _env ->
   let registry = Session.create () in
   let agents = Session.connected_agents registry in
   check (list string) "empty" [] agents


### PR DESCRIPTION

`lib/session.ml` declares its lock contract explicitly at the type
definition (line 15-17):

> All fields are mutable and accessed exclusively under
> [registry.lock].  No lock-free access — the mutex is the single
> synchronization mechanism.

Register/unregister/update_activity/push_*/pop_message/rate_limit all
honor this contract via [with_lock].  Four public readers did not:

1. `wait_for_message` line 297 — `Hashtbl.find_opt registry.sessions`
   outside `with_lock`, then calls `register` (which takes the lock)
   from the `None` branch.  A concurrent `unregister` between probe
   and register could have the register clobber a freshly-cleared
   session on the next write path.
2. `get_inactive_agents` line 329 — `Hashtbl.fold` reading
   `session.last_activity` (a mutable field written under the lock
   by `update_activity`) without the lock.
3. `get_agent_statuses` line 339 — same, reading both
   `session.is_listening` and `session.last_activity`.
4. `connected_agents` line 392 — `Hashtbl.fold` over `registry.sessions`.

Under OCaml 5's memory model these lock-free reads are undefined
behavior: a concurrent writer holding the lock has no happens-before
relationship with these readers, so they can observe torn state
(half-removed bucket, pre-write mutable field, inconsistent session
count).  In single-domain Eio the cooperative scheduler makes the
window extremely small (fibers only yield on explicit I/O points,
and `Hashtbl.fold` does none), but the contract is still violated
and any future multi-domain work would turn the issue acute.

## Changes

- `wait_for_message`: combine the "probe + register" into a single
  `with_lock` that checks `Hashtbl.mem` and installs a fresh session
  directly.  This also removes a check-then-act gap where a
  concurrent unregister between the probe and the `register` call
  could have caused a double-registration path.
- `get_inactive_agents`, `get_agent_statuses`, `connected_agents`:
  build the result inside `with_lock registry` and return it.  The
  critical sections are short (O(|sessions|) pure hashtable folds)
  and allocate nothing that yields, so there's no contention concern.
- Delete `unregister_sync` entirely.  It was already marked
  `@deprecated` with a doc comment pointing at a TLA+ spec
  (`SessionRegistryGhost`) and a concurrent-call race; it has zero
  callers in `lib/` and zero callers in `test/`.  Leaving dead and
  known-broken code as a public API is strictly worse than removing
  it — the next audit pass wastes time re-discovering it, and a
  future caller could pick it up thinking "it compiled, must be
  fine".  Entry removed from `session.mli` as well.

## Test fix

`test_status_string_empty` and `test_connected_agents_empty` in
`test/test_session_coverage.ml` previously relied on these functions
being lock-free and ran outside an Eio context.  `Eio.Mutex.use_rw`
requires an active fiber, so both tests now wrap their body in
`Eio_main.run`.  No semantic change — they still assert the same
empty-registry invariants.

## Known gap (not fixed in this PR)

`Session.McpSessionStore` (lines 433-498) has a module-level
`(string, mcp_session) Hashtbl.t` with **no mutex at all**.  Its
operations (`create`, `get`, `cleanup_stale`, `list_all`, `remove`)
are called from HTTP handler fibers concurrently with the background
`start_mcp_session_cleanup_loop` fiber at line 502.  Adding a mutex
there is a larger change that touches every call site and changes
the access type; filed as a separate follow-up issue rather than
bundled with this PR.

## Verification

```
dune build --root . @lib/check                             # exit 0
dune exec --root . -- ./test/test_session.exe              # 23/23 passed
dune exec --root . -- ./test/test_session_coverage.exe     # 49/49 passed
dune exec --root . -- ./test/test_mcp_session_coverage.exe # 41/41 passed
```

## Finding source

Cycle 26 of the masc-mcp audit sweep.  Deep-read of `lib/session.ml`
(572 lines) following the Cycle 25 heuristic "deep-reads keep
finding what grep audits miss".  Pattern here is **doc-vs-code
contract violation** again (same class as Cycle 21 `pulse.ml`): the
type declaration encodes the invariant, but four readers silently
break it.

Audit heuristic added: when a module declares a mutex contract in
its type definition comment, grep for every `Hashtbl.` access on
that field and confirm it is textually inside a `with_lock`.  Any
bare `Hashtbl.fold`/`find_opt`/`mem` outside the lock is a contract
violation by construction — no behavioral verification needed.