### PR TITLE
chore(oas): bump agent_sdk pin to 0.122.0 (keep_alive integer fix)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.121.0))
+  (agent_sdk (>= 0.122.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.121.0"}
+  "agent_sdk" {>= "0.122.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.121.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.122.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="3e145b74c3fac808e74d7456f659d78cd4f0667b"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.121.0"
+readonly OAS_AGENT_SDK_SHA="782c2875f3da0382cbb60742718068adb87cc933"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.122.0"


### PR DESCRIPTION
## Summary
Bump OAS agent_sdk pin from 0.121.0 → 0.122.0 to pick up [jeong-sik/oas#821](https://github.com/jeong-sik/oas/pull/821) which fixes the Ollama keep_alive wire format.

## Runtime evidence
After bootstrapping keepers on the new binary earlier today, all 6 GLM-cascade keepers failed within <2s per turn:

\`\`\`
ts=2026-04-11T17:59:56Z out=error lat=1275 sem=0 tools=0 \\
  err=Invalid request: time: missing unit in duration \"-1\"
ts=2026-04-11T18:01:07Z out=error lat=576  sem=0 tools=0 \\
  err=Invalid request: time: missing unit in duration \"-1\"
ts=2026-04-11T18:02:24Z out=error lat=498  sem=0 tools=0 \\
  err=Invalid request: time: missing unit in duration \"-1\"
\`\`\`

Root cause: PR #813 pinned keep_alive=-1 as string \`\` \`String \"-1\" \`\` but Ollama routes string keep_alive through Go's \`time.ParseDuration\` which requires a unit. oas#821 switches to \`\` \`Int (-1) \`\` when parseable and \`\` \`String v \`\` for duration strings ("5m", "-1m", etc).

## Changes
Following the \"OAS pin must bump version floor\" rule:
- \`scripts/oas-agent-sdk-pin.sh\`: SHA + BASE_VERSION + MIN_VERSION updated
- \`dune-project\`: \`(agent_sdk (>= 0.122.0))\`
- \`masc_mcp.opam\`: \`agent_sdk >= 0.122.0\`

## Verification
- Local \`opam install agent_sdk\`: successfully upgraded 0.121.0 → 0.122.0
- Local \`dune clean && dune build\`: clean success
- No API surface changes between 0.121.0 and 0.122.0 affecting masc-mcp

## Post-merge steps (for server recovery)
1. Pull main into the currently running worktree (\`fix/start-script-basepath-config-root\` or main)
2. \`opam install agent_sdk -y\` to sync the pin
3. \`dune build\` to produce the new binary
4. SIGTERM the running server and restart via \`start-masc-mcp.sh\`
5. Expected: all 6 keepers stop failing on the keep_alive error and resume normal turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)