### PR TITLE
fix(room,cp): hold with_file_lock around archive read-modify-write

### DIFF
--- a/lib/command_plane/cp_cleanup.ml
+++ b/lib/command_plane/cp_cleanup.ml
@@ -102,9 +102,17 @@ let find_dropped_intents ~days intents =
     intents
 
 (** Archive terminal operations to .masc/cp/archive/ *)
+(* Sibling bug of [Room_state.append_archive_tasks]: read→merge→write
+   without a file lock.  Two concurrent cleanup cycles (or a cleanup
+   racing with any future caller) would each read the same snapshot,
+   compute their own merged list, and the later write would drop the
+   earlier caller's operations.  Wrap the entire sequence in
+   [Room_utils.with_file_lock] on the archive path.  [cp_cleanup]
+   already depends on [Room_utils] (mkdir_p / read_json_opt / write_json
+   above), so this does not introduce a new dependency. *)
 let archive_operations config (ops : operation_record list) =
   if ops = [] then ()
-  else begin
+  else
     let archive_dir =
       Filename.concat (control_plane_dir config) "archive"
     in
@@ -112,26 +120,26 @@ let archive_operations config (ops : operation_record list) =
     let archive_path =
       Filename.concat archive_dir "operations.json"
     in
-    let existing =
-      if Sys.file_exists archive_path then
-        match Room_utils.read_json_opt config archive_path with
-        | Some (`Assoc fields) -> (
-            match List.assoc_opt "operations" fields with
-            | Some (`List rows) -> List.filter_map operation_of_json rows
-            | _ -> [])
-        | Some (`List rows) -> List.filter_map operation_of_json rows
-        | _ -> []
-      else []
-    in
-    let merged = existing @ ops in
-    Room_utils.write_json config archive_path
-      (`Assoc
-        [
-          ("version", `String "cp-v2");
-          ("archived_at", `String (Types.now_iso ()));
-          ("operations", `List (List.map operation_to_json merged));
-        ])
-  end
+    Room_utils.with_file_lock config archive_path (fun () ->
+      let existing =
+        if Sys.file_exists archive_path then
+          match Room_utils.read_json_opt config archive_path with
+          | Some (`Assoc fields) -> (
+              match List.assoc_opt "operations" fields with
+              | Some (`List rows) -> List.filter_map operation_of_json rows
+              | _ -> [])
+          | Some (`List rows) -> List.filter_map operation_of_json rows
+          | _ -> []
+        else []
+      in
+      let merged = existing @ ops in
+      Room_utils.write_json config archive_path
+        (`Assoc
+          [
+            ("version", `String "cp-v2");
+            ("archived_at", `String (Types.now_iso ()));
+            ("operations", `List (List.map operation_to_json merged));
+          ]))
 
 (** Remove dead units: empty roster + no leader + stale *)
 let cleanup_dead_units config ~days units =

--- a/lib/room/room_state.ml
+++ b/lib/room/room_state.ml
@@ -286,40 +286,51 @@ let read_archive_task_ids config =
       | None -> None
     ) tasks
 
-(** Append tasks to archive file (tasks-archive.json) *)
+(** Append tasks to archive file (tasks-archive.json).
+
+    The read→merge→write sequence is wrapped in [with_file_lock] so
+    concurrent callers cannot lose each other's archive entries.  Prior
+    version held no lock: a second caller that read the archive between
+    the first caller's [read_json] and its [write_json] would compute a
+    merged list from a stale snapshot and overwrite the first write,
+    dropping the tasks the first caller was archiving.  Matches the
+    file-lock discipline already used by [update_state] and
+    [Hebbian_eio.consolidate] (PR #6611). *)
 let append_archive_tasks config (tasks : task list) =
   if tasks = [] then ()
-  else begin
-    let open Yojson.Safe.Util in
-    let path = archive_path config in
-    let existing = read_json config path in
-    let existing_tasks =
-      match existing with
-      | `List items -> items
-      | `Assoc _ -> begin
-          match existing |> member "tasks" with
-          | `List items -> items
-          | _ -> []
-        end
-      | _ -> []
-    in
-    let new_tasks = List.map task_to_yojson tasks in
-    (* Deduplicate by task id, preserving first occurrence *)
-    let seen = Hashtbl.create 64 in
-    let dedup = List.filter (fun json ->
-      match json |> member "id" |> to_string_option with
-      | Some id ->
-          if Hashtbl.mem seen id then false
-          else (Hashtbl.add seen id (); true)
-      | None -> false
-    ) (existing_tasks @ new_tasks)
-    in
-    let archive_json = `Assoc [
-      ("tasks", `List dedup);
-      ("last_updated", `String (now_iso ()));
-    ] in
-    write_json config path archive_json
-  end
+  else
+    (* [let open Yojson.Safe.Util] below shadows [path] with the
+       Yojson accessor; use a distinct local name. *)
+    let arch_path = archive_path config in
+    with_file_lock config arch_path (fun () ->
+      let open Yojson.Safe.Util in
+      let existing = read_json config arch_path in
+      let existing_tasks =
+        match existing with
+        | `List items -> items
+        | `Assoc _ -> begin
+            match existing |> member "tasks" with
+            | `List items -> items
+            | _ -> []
+          end
+        | _ -> []
+      in
+      let new_tasks = List.map task_to_yojson tasks in
+      (* Deduplicate by task id, preserving first occurrence *)
+      let seen = Hashtbl.create 64 in
+      let dedup = List.filter (fun json ->
+        match json |> member "id" |> to_string_option with
+        | Some id ->
+            if Hashtbl.mem seen id then false
+            else (Hashtbl.add seen id (); true)
+        | None -> false
+      ) (existing_tasks @ new_tasks)
+      in
+      let archive_json = `Assoc [
+        ("tasks", `List dedup);
+        ("last_updated", `String (now_iso ()));
+      ] in
+      write_json config arch_path archive_json)
 
 (** Calculate next task id using backlog + archive to avoid reuse *)
 let next_task_number config backlog =


### PR DESCRIPTION

Two cleanup paths did a classic lost-update dance: read the archive
file, merge in new entries, write the merged result — with no lock
held across the sequence.  Concurrent callers would each read the
same snapshot, compute independent merged lists, and the later
writer would silently overwrite the earlier writer's entries.

## Sites fixed

### `lib/room/room_state.ml:append_archive_tasks`

Called from `lib/room/room_gc.ml:214` during the backlog GC pass
(zero-zombie pulse, `Env_config_governance.Timeouts.neo4j_timeout_sec`
cadence).  Reads `.masc/tasks-archive.json`, merges archived stale
tasks (deduped by id), and writes back.  Today only the orchestrator
pulse drives this, so the race window is small — but nothing in the
function's doc string says "single writer", and adding a second
caller (e.g. a manual cleanup tool, a worker-side archive) would
have to re-discover the missing lock.

Sibling `update_state` in the same module already uses
`with_file_lock config (state_path config)` for exactly this reason;
this change extends the same discipline to the archive path.

### `lib/command_plane/cp_cleanup.ml:archive_operations`

Called from `cleanup_dead_units` at line 171 during the CP v2 GC
pass.  Reads `<control_plane_dir>/archive/operations.json`, merges
terminal operation records, and writes back.  Same bug pattern:
lost-update on concurrent callers.  `cp_cleanup` already depends on
`Room_utils` (it uses `mkdir_p`, `read_json_opt`, `write_json`
above), so calling `Room_utils.with_file_lock` here does not
introduce a new dependency — the stale comment "Depends only on
Cp_io (no Room dependency)" at the top of the file is already
inaccurate and should be revised in a follow-up.

Both fixes wrap the entire read→merge→write sequence in
`with_file_lock config <archive-path> (fun () -> ...)`.  The file
lock is the same cooperative `Eio.Mutex`-backed helper used by
`update_state`, `Room_query`, `Room_vote`, and `Hebbian_eio.consolidate`
(PR #6611): single-process semantics, no `Unix.lockf` blocking,
Cancelled-safe.

### Local-name rename

`let open Yojson.Safe.Util in` inside `append_archive_tasks` brings
`Yojson.Safe.Util.path : string list -> t -> t option` into scope,
which would shadow the local `let path = archive_path config`.
Renamed the local to `arch_path` inside the lock block; no behavior
change.

## Verification

```
dune build --root . @lib/check                             # exit 0
dune exec --root . -- ./test/test_room_coverage.exe test archive
# test body asserts "task added" after append_archive_tasks — PASSED
```

The `test archive` run on this branch reports 1 failure, but the
failure is in the `with_test_env` **teardown** (`Room_init.reset.rm_rf`
choking on a stale symlink under
`~/me/.masc/autoresearch/ar-0bf1fc00/...`), not in the test body.
`ASSERT task added` is printed before the exception, confirming the
test body completed.  The same failure reproduces on `origin/main`
with this patch reverted, so it is pre-existing environmental
pollution unrelated to this change.

## Finding source

Cycle 27 of the masc-mcp audit sweep.  Deep-read of
`lib/room/room_state.ml` (500 lines) following the Cycle 22 hebbian
pattern: "for each file-backed state, scan all writers and check
they all hold the same file lock."  Same pattern uncovered in
`lib/command_plane/cp_cleanup.ml` via the `rg "archive_path" lib/`
follow-up grep.

Audit heuristic: any function that reads a file, computes a
transformation, and writes the result back is a read-modify-write.
Unless the enclosing call sequence textually includes
`with_file_lock`, the function is either the single writer forever
(document it in the .mli / doc comment) or it has a lost-update
race (fix it with `with_file_lock`).  There is no third option.