### PR TITLE
fix(room_task): hold with_file_lock on agent state writes

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -26,6 +26,41 @@ let read_backlog_or_raise config =
   | Ok backlog -> backlog
   | Error msg -> raise (Invalid_argument msg)
 
+(** Update the on-disk agent state record under its own file lock.
+
+    Task transitions ([claim], [complete], [cancel], …) need to
+    reflect the new task assignment on the agent record at
+    [<agents_dir>/<name>.json].  Every pre-existing call site in this
+    module did the read→modify→write inline without holding any lock
+    on that file — the enclosing [with_file_lock config backlog_path]
+    only serializes backlog writers, not agent-state writers.  Sibling
+    writers in [Room_agent.update_agent_r] correctly take
+    [with_file_lock_r config agent_file], so concurrent
+    [update_agent_r] or concurrent room_task transitions can race and
+    lose each other's updates.
+
+    This helper centralises the pattern, takes [with_file_lock] on the
+    agent file, and silently skips the write when the file is missing
+    (matching the pre-existing [if Sys.file_exists agent_file]
+    guards).  It never blocks the caller on a missing/corrupt agent
+    record — the backlog transition is the source of truth and the
+    agent mirror is best-effort telemetry.  On JSON parse failure the
+    error is logged with the agent name for diagnostic context. *)
+let update_local_agent_state config ~agent_name f =
+  let agent_file =
+    Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
+  in
+  if Sys.file_exists agent_file then
+    with_file_lock config agent_file (fun () ->
+      let json = read_json config agent_file in
+      match agent_of_yojson json with
+      | Ok agent ->
+          write_json config agent_file (agent_to_yojson (f agent))
+      | Error msg ->
+          Log.Misc.error
+            "update_local_agent_state: parse failed for %s: %s"
+            agent_name msg)
+
 (** Tighter variant of [resolve_agent_name] for task ownership guards.
     Only accepts the resolved identity when it is the exact [-agent] suffix
     form of the normalised input (e.g. "keeper-coder" -> "keeper-coder-agent").
@@ -402,16 +437,8 @@ let claim_task config ~agent_name ~task_id =
               version = backlog.version + 1;
             } in
             write_backlog config new_backlog;
-            let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-            if Sys.file_exists agent_file then begin
-              let json = read_json config agent_file in
-              match agent_of_yojson json with
-              | Ok agent ->
-                  let updated = { agent with status = Busy; current_task = Some task_id } in
-                  write_json config agent_file (agent_to_yojson updated)
-              | Error msg ->
-                  Log.Misc.error "agent state write failed: %s" msg
-            end;
+            update_local_agent_state config ~agent_name (fun agent ->
+              { agent with status = Busy; current_task = Some task_id });
             let _ = broadcast config ~from_agent:agent_name ~content:(Printf.sprintf "📋 Claimed %s" task_id) in
             emit_task_activity config ~agent_name ~task_id ~kind:"task.claimed"
               ~payload:(`Assoc [ ("task_id", `String task_id) ]);
@@ -513,16 +540,8 @@ let claim_task_r config ~agent_name ~task_id
               version = backlog.version + 1;
             } in
             write_backlog config new_backlog;
-            let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-            if Sys.file_exists agent_file then begin
-              let json = read_json config agent_file in
-              match agent_of_yojson json with
-              | Ok agent ->
-                  let updated = { agent with status = Busy; current_task = Some task_id } in
-                  write_json config agent_file (agent_to_yojson updated)
-              | Error msg ->
-                  Log.Misc.error "agent state write failed: %s" msg
-            end;
+            update_local_agent_state config ~agent_name (fun agent ->
+              { agent with status = Busy; current_task = Some task_id });
             let _ = broadcast config ~from_agent:agent_name ~content:(Printf.sprintf "📋 Claimed %s" task_id) in
             emit_task_activity config ~agent_name ~task_id ~kind:"task.claimed"
               ~payload:(`Assoc [ ("task_id", `String task_id) ]);
@@ -674,24 +693,14 @@ let transition_task_r config ~agent_name ~task_id ~action
           version = backlog.version + 1;
         } in
         write_backlog config new_backlog;
-        let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-        if Sys.file_exists agent_file then begin
-          let json = read_json config agent_file in
-          match agent_of_yojson json with
-          | Ok agent ->
-              let updated =
-                match set_current with
-                | Some _ -> { agent with status = Busy; current_task = Some task_id }
-                | None ->
-                    if agent.current_task = Some task_id then
-                      { agent with status = Active; current_task = None }
-                    else
-                      agent
-              in
-              write_json config agent_file (agent_to_yojson updated)
-          | Error msg ->
-              Log.Misc.error "agent state write failed: %s" msg
-        end;
+        update_local_agent_state config ~agent_name (fun agent ->
+          match set_current with
+          | Some _ -> { agent with status = Busy; current_task = Some task_id }
+          | None ->
+              if agent.current_task = Some task_id then
+                { agent with status = Active; current_task = None }
+              else
+                agent);
         log_event config
           (Yojson.Safe.to_string
              (`Assoc
@@ -854,16 +863,8 @@ let complete_task config ~agent_name ~task_id ~notes =
               version = backlog.version + 1;
             } in
             write_backlog config new_backlog;
-            let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-            if Sys.file_exists agent_file then begin
-              let json = read_json config agent_file in
-              match agent_of_yojson json with
-              | Ok agent ->
-                  let updated = { agent with status = Active; current_task = None } in
-                  write_json config agent_file (agent_to_yojson updated)
-              | Error msg ->
-                  Log.Misc.error "agent state write failed: %s" msg
-            end;
+            update_local_agent_state config ~agent_name (fun agent ->
+              { agent with status = Active; current_task = None });
             let msg = if notes = "" then Printf.sprintf "✅ Completed %s" task_id
                       else Printf.sprintf "✅ Completed %s - %s" task_id notes in
             let _ = broadcast config ~from_agent:agent_name ~content:msg in
@@ -970,14 +971,8 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                 version = backlog.version + 1;
               } in
               write_backlog config new_backlog;
-              let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-              if Sys.file_exists agent_file then begin
-                let json = read_json config agent_file in
-                match agent_of_yojson json with
-                | Ok agent -> let updated = { agent with status = Active; current_task = None } in write_json config agent_file (agent_to_yojson updated)
-                | Error msg ->
-                    Log.Misc.error "agent state write failed: %s" msg
-              end;
+              update_local_agent_state config ~agent_name (fun agent ->
+                { agent with status = Active; current_task = None });
               let msg = if notes = "" then Printf.sprintf "✅ Completed %s" task_id else Printf.sprintf "✅ Completed %s - %s" task_id notes in
               let _ = broadcast config ~from_agent:agent_name ~content:msg in
               emit_task_activity config ~agent_name ~task_id ~kind:"task.done"
@@ -1056,15 +1051,11 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
               } in
               write_backlog config new_backlog;
               (* Update agent status if they had this task *)
-              let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-              if Sys.file_exists agent_file then begin
-                let json = read_json config agent_file in
-                match agent_of_yojson json with
-                | Ok agent when agent.current_task = Some task_id ->
-                    let updated = { agent with status = Active; current_task = None } in
-                    write_json config agent_file (agent_to_yojson updated)
-                | _ -> ()
-              end;
+              update_local_agent_state config ~agent_name (fun agent ->
+                if agent.current_task = Some task_id then
+                  { agent with status = Active; current_task = None }
+                else
+                  agent);
               let msg = if reason = "" then Printf.sprintf "🚫 Cancelled %s" task_id else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason in
               let _ = broadcast config ~from_agent:agent_name ~content:msg in
               emit_task_activity config ~agent_name ~task_id


### PR DESCRIPTION

`lib/room/room_task.ml` has six task-transition functions
(`claim_task`, `claim_task_r`, `transition_task_r`, `complete_task`,
`complete_task_r`, `cancel_task_r`) that each do a
read→modify→write on `<agents_dir>/<name>.json` to reflect the new
task assignment on the agent mirror record.  Every one of those
writes was inline and **unlocked**:

```ocaml
let agent_file = Filename.concat (agents_dir config)
  (safe_filename agent_name ^ ".json") in
if Sys.file_exists agent_file then begin
  let json = read_json config agent_file in
  match agent_of_yojson json with
  | Ok agent ->
    let updated = { agent with status = ...; current_task = ... } in
    write_json config agent_file (agent_to_yojson updated)
  | Error msg -> Log.Misc.error "..." msg
end
```

The enclosing `with_file_lock config backlog_path` serializes
*backlog* writers, not agent-file writers — the agent record is a
different file with its own contention domain.  The sibling
`Room_agent.update_agent_r` in the same directory correctly uses
`with_file_lock_r config agent_file` (line 91) for exactly this
reason, so the room_task sites were silently out of discipline.

## Race scenarios

1. Two concurrent transitions on the same agent — e.g. keeper A
   completes task X while keeper B claims task Y assigned to the
   same name — each reads its own snapshot of agent.json and the
   later write loses the earlier.  The backlog is consistent but
   the agent mirror shows only one of the two transitions.
2. A task transition racing with `Room_agent.update_agent_r` (which
   does take the agent-file lock): the transition writes a stale
   snapshot after `update_agent_r` committed, reverting a capability
   or status change.
3. Heartbeat fibers that rewrite `last_seen` via the same code path
   could be clobbered by a transition (though this codebase routes
   heartbeats through `update_agent_r` at present).

## Fix

Introduce a module-private helper `update_local_agent_state config
~agent_name f` at the top of `room_task.ml`:

```ocaml
let update_local_agent_state config ~agent_name f =
  let agent_file =
    Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json")
  in
  if Sys.file_exists agent_file then
    with_file_lock config agent_file (fun () ->
      let json = read_json config agent_file in
      match agent_of_yojson json with
      | Ok agent ->
          write_json config agent_file (agent_to_yojson (f agent))
      | Error msg ->
          Log.Misc.error
            "update_local_agent_state: parse failed for %s: %s"
            agent_name msg)
```

All six sites now call this helper with a transformation function.
The helper takes the agent-file lock, matching `Room_agent`'s
discipline.  The `if Sys.file_exists` guard and the
silently-skip-on-parse-failure behavior are preserved — the agent
file is a best-effort mirror; the backlog (already written inside
its own lock) remains the source of truth.

Log message for parse failures now includes the agent name so
future operators can grep the target from the log.

## Nested lock safety

Each caller holds `with_file_lock config backlog_path` when it
invokes the helper, which then takes `with_file_lock config
agent_file`.  Lock ordering is always `backlog → agent_file` across
every site touched.  No reverse-order acquisition exists in the
codebase today (grep confirmed: no function takes agent_file first
and then backlog_path).  `Eio.Mutex` is non-reentrant, so a bug
that accidentally nested `update_local_agent_state` twice would
deadlock on the second call — acceptable since it's a
single-function helper used from a constrained set of sites.

## Verification

```
dune build --root . @lib/check                            # exit 0
dune exec --root . -- ./test/test_room_coverage.exe test claim_next
# test body asserts "claim next success" after transition — PASSED
```

The `test claim_next` run reports failures in `with_test_env`
**teardown** (same pre-existing `Room_init.reset.rm_rf` choking on a
dangling symlink under `~/me/.masc/autoresearch/ar-0bf1fc00/...`),
not in the test bodies.  `ASSERT claim next success` is printed
before the teardown exception, confirming the transition logic
ran correctly under the new locking.  This is the same environment
pollution noted in PR #6632 — it reproduces on `origin/main` with
the patch reverted.

## Finding source

Cycle 28 of the masc-mcp audit sweep.  Deep-read of
`lib/room/room_task.ml` (1225 lines).  Initial grep of
`with_file_lock` / `read_backlog` / `write_backlog` showed correct
backlog discipline (32 hits, all paired inside `with_file_lock`),
which is why earlier cycles missed this.  The pattern only surfaced
via `rg "agent_file.*Filename.concat"` after noticing
`Room_agent.update_agent_r` used a different discipline for the
same file.

Audit heuristic added: when a function takes `with_file_lock` on
path A and then does `read_json`/`write_json` on path B inside that
lock, the outer lock does **not** protect path B.  Every path-B
write inside a path-A lock needs its own `with_file_lock config
path_B`, or needs to call an API that takes the path-B lock for it.
Check every `filename = Filename.concat` followed by `write_json`
inside an enclosing `with_file_lock` — the inner write is almost
always a lock-drift bug.