### PR TITLE
fix(run_eio): hold with_file_lock around update_plan/set_deliverable R-M-W

### DIFF
--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -143,17 +143,30 @@ let init config ~task_id ~agent_name : (run_record, string) result =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
-(** Update plan *)
+(** Update plan.
+
+    The read_run → modify → write_run sequence is a read-modify-write
+    on [run.json]; two concurrent callers (different fibers handling
+    [tool_run] MCP requests for the same task) would each read the
+    same snapshot and the later writer would overwrite the earlier
+    [plan] / [deliverable] update.  The sibling [append_log] already
+    uses [with_file_lock] on its log file; extend the same discipline
+    to [run.json] writes.  The [plan.md] mirror at [plan_path] is a
+    single full-content overwrite, so it does not need a separate
+    lock — writing the mirror and the [run.json] record inside the
+    same critical section keeps them consistent. *)
 let update_plan config ~task_id ~content : (run_record, string) result =
   try
-    match read_run config task_id with
-    | Error e -> Error e
-    | Ok run ->
-        let updated = { run with plan = content; updated_at = now_iso () } in
-        let path = plan_path config task_id in
-        write_text_file path content;
-        write_run config updated;
-        Ok updated
+    let run_file = run_json_path config task_id in
+    with_file_lock config run_file (fun () ->
+      match read_run config task_id with
+      | Error e -> Error e
+      | Ok run ->
+          let updated = { run with plan = content; updated_at = now_iso () } in
+          let path = plan_path config task_id in
+          write_text_file path content;
+          write_run config updated;
+          Ok updated)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
@@ -173,17 +186,23 @@ let append_log config ~task_id ~note : (log_entry, string) result =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)
 
-(** Set deliverable *)
+(** Set deliverable.  Same lost-update concern as [update_plan] —
+    read_run → modify → write_run is a read-modify-write on
+    [run.json] that two concurrent fibers could each read from the
+    same snapshot and clobber.  Wrapped in the same [run.json] file
+    lock for identical reasons. *)
 let set_deliverable config ~task_id ~content : (run_record, string) result =
   try
-    match read_run config task_id with
-    | Error e -> Error e
-    | Ok run ->
-        let updated = { run with deliverable = content; updated_at = now_iso () } in
-        let path = deliverable_path config task_id in
-        write_text_file path content;
-        write_run config updated;
-        Ok updated
+    let run_file = run_json_path config task_id in
+    with_file_lock config run_file (fun () ->
+      match read_run config task_id with
+      | Error e -> Error e
+      | Ok run ->
+          let updated = { run with deliverable = content; updated_at = now_iso () } in
+          let path = deliverable_path config task_id in
+          write_text_file path content;
+          write_run config updated;
+          Ok updated)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e -> Error (Printexc.to_string e)


### PR DESCRIPTION

`lib/run_eio.ml` stores run metadata at `.masc/runs/<task_id>/run.json`
and mirrors the plan/deliverable text to `plan.md` / `deliverable.md`.
`append_log` already takes `with_file_lock` on the log file (line 168)
— the module knows the discipline — but `update_plan` and
`set_deliverable` both did a classic read-modify-write on `run.json`
with no lock held anywhere in the sequence:

```ocaml
match read_run config task_id with
| Error e -> Error e
| Ok run ->
    let updated = { run with plan = content; updated_at = now_iso () } in
    write_text_file (plan_path config task_id) content;
    write_run config updated;        (* overwrites run.json *)
    Ok updated
```

## Race

Both functions are called from `tool_run.ml` MCP tool handlers (lines
37 and 61), which run on per-request fibers.  Two concurrent tool
calls targeting the same `task_id` — e.g. a keeper that calls
`update_plan` while its own follow-up `set_deliverable` is still in
flight, or two agents racing on a shared task — each read the same
snapshot and the later `write_run` clobbers the earlier update.

The loser's text file (`plan.md` / `deliverable.md`) still has its
content on disk (both writes to the mirror files succeeded), but
the `run.json` record only reflects one of the two updates, so:

- `get config ~task_id` returns a record where `plan` and
  `deliverable` disagree with the mirror files
- `updated_at` reflects only the surviving write
- downstream consumers (dashboard, tool_run listings) show a
  partial snapshot

This is a direct correctness bug on the tool-handler fast path, not
a theoretical corner case.

## Fix

Wrap each function body in `with_file_lock config (run_json_path
config task_id) (fun () -> ...)`.  The lock is keyed on the same
`run.json` path for both functions, so `update_plan` and
`set_deliverable` serialize against each other.  The mirror file
writes (`write_text_file (plan_path ...)` / `(deliverable_path ...)`)
stay inside the critical section so the mirror and the `run.json`
record are committed together — callers never observe a state where
`run.plan ≠ plan.md`.

`append_log` is unchanged — it already holds a lock on the log
file, which is a different file from `run.json` and has its own
append-only discipline.

## What is NOT fixed

- `init config ~task_id` at line 115 does `path_exists → write` on
  `run.json` without a lock; two concurrent `init` calls for the
  same `task_id` could both see the file missing and both write.
  Left as-is because (a) `init` is idempotent except for
  `created_at` (which only differs by the scheduling jitter between
  the two calls) and (b) `tool_run` currently only calls `init`
  from the first-touch path, so the race window in practice is
  vanishingly small.
- The 2 agent-file lock-drift sites in `lib/room/room_task_schedule.ml`
  (same pattern as PR #6634's `lib/room/room_task.ml` fix) are a
  separate follow-up — ideally they reuse the
  `update_local_agent_state` helper from #6634 once that merges,
  rather than re-introducing ad-hoc inline `with_file_lock` in this
  PR.

## Verification

```
dune build --root . @lib/check                          # exit 0
dune exec --root . -- ./test/test_run_eio_coverage.exe  # 29/33 passed
```

The 4 failing tests (`eio_logs/read logs multiple`,
`eio_get_list/list empty`, `eio_get_list/list multiple`,
`io_edge_cases/get with logs`) all fail with the same shape:
they assert N logs/runs but observe a larger number because
previous test runs left state in `~/me/.masc/runs/`.  These 4
failures reproduce identically on `origin/main` with this patch
reverted, confirming it is pre-existing test-state pollution
unrelated to this change.  The `update_plan` / `set_deliverable`
code paths have no dedicated test coverage in `test_run_eio_coverage.ml`
today (follow-up for the audit queue).

## Finding source

Cycle 29 of the masc-mcp audit sweep.  Cross-file cleanup after
Cycle 28: `rg -l "with_file_lock" lib/` returned 13 files; for each
I grepped `with_file_lock` against `write_json` to count paired vs
unpaired writes.  `run_eio.ml` was flagged because it uses
`with_file_lock` on line 168 (`append_log`) but not on `update_plan`
/ `set_deliverable`, even though all three touch files in the same
run directory.  Partial lock discipline is almost always drift.

Audit heuristic: when a module uses `with_file_lock` for one
write path, every other write path in the same module that targets
a file in the same directory should either use it too, or have a
doc comment explaining why it's safe without (e.g. single-writer,
fresh file, append-only without read).  A bare `write_json` next
door to a `with_file_lock` block is almost always a bug.