### PR TITLE
fix(dashboard): add MASC_CP_SUMMARY_REFRESH_DISABLED escape hatch for #6633

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -882,8 +882,27 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
          Proactive_refresh config. Heavy surfaces delay their initial warm
          compute to avoid concurrent CPU/PG contention.  Lightweight surfaces
          (cp-summary, execution, transport_health) start immediately. *)
-      Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
-      Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock;
+      (* MASC_CP_SUMMARY_REFRESH_DISABLED=1: skip the cp-summary warm cache
+         loop. Used as an escape hatch when Command_plane_v2.summary_json or
+         Swarm_status.build_json_from_snapshot trips an OCaml Stack overflow
+         on a specific dataset and CPU-pins the Eio scheduler (issue #6633).
+         The dashboard /command-plane/summary endpoint will return the empty
+         initial ref in that mode, which is preferable to a server hang. *)
+      let cp_summary_refresh_disabled =
+        match Sys.getenv_opt "MASC_CP_SUMMARY_REFRESH_DISABLED" with
+        | Some v ->
+          let v = String.trim v in
+          v = "1" || String.lowercase_ascii v = "true"
+        | None -> false
+      in
+      if cp_summary_refresh_disabled then
+        Log.Dashboard.warn
+          "cp-summary refresh loop DISABLED via MASC_CP_SUMMARY_REFRESH_DISABLED \
+           — /command-plane/summary will return empty cached ref"
+      else begin
+        Server_command_plane_http_support.start_cp_summary_refresh_loop ~state ~sw ~clock;
+        Server_command_plane_http_support.start_cp_snapshot_refresh_loop ~state ~sw ~clock
+      end;
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock;
       Server_dashboard_http.start_transport_health_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;


### PR DESCRIPTION
## Summary

Add `MASC_CP_SUMMARY_REFRESH_DISABLED` env-var escape hatch to skip starting the cp-summary + cp-snapshot warm cache refresh loops at server bootstrap. Mitigation for issue #6633 where the compute trips an OCaml Stack overflow after ~990s and CPU-pins the Eio scheduler, hanging `/health` and blocking keeper turns.

Relates #6633.

## Product impact

Operators can unblock the server without the full root-cause fix landing. When the flag is set:
- `/command-plane/summary` and `/command-plane/snapshot` return the empty "initializing" cached ref (dashboard panels show empty).
- Keeper turns, MCP traffic, HTTP `/health`, and all other refresh loops (execution, mission, operator snapshot, transport_health) continue unaffected.

Default behavior (flag unset) is preserved — the refresh loops start as before.

## Why

Issue #6633 documents two reproducible Stack overflow events during this session:

| Time | Uptime at failure | Symptom |
|---|---|---|
| 2026-04-11T18:44:20Z | 990.4s | cp-summary warm cache failed (Stack overflow) |
| 2026-04-11T19:28:31Z | 993.6s | same |

In both cases the running server ended up at 277-294% CPU with LISTEN socket open but curl timing out on `/health`. SIGTERM was ignored; only SIGKILL recovered. The cp-summary refresh loop retries the failing compute under `Proactive_refresh.start`, and because the recursion is CPU-bound without cancellation points the `Eio.Time.with_timeout` (90s) wrapping it does not fire.

Root cause is a recursive JSON serialization somewhere in `Command_plane_v2.snapshot_json` / `summary_json` / `Swarm_status.build_json_from_snapshot` — proper fix is iterative traversal in those call sites, a larger refactor. This PR is the operational escape hatch, not the fix.

## Diff

- `lib/server/server_runtime_bootstrap.ml`: read `MASC_CP_SUMMARY_REFRESH_DISABLED` (accepts `"1"` or `"true"`), skip both `start_cp_summary_refresh_loop` and `start_cp_snapshot_refresh_loop` when set. Emits a `WARN` log line so the disabled state is visible in `/health` and log search.

## Evidence

- `dune build bin/main_eio.exe` — clean
- Log pattern on startup with flag set:
  ```
  level=WARN module=Dashboard
  message="cp-summary refresh loop DISABLED via MASC_CP_SUMMARY_REFRESH_DISABLED — /command-plane/summary will return empty cached ref"
  ```

## Review evidence

To be added: GLM-5.1 cross-model review via `sb glm-text` before Ready.

## Linked issue

Relates #6633 (cp-summary warm cache Stack overflow after 990s).

## Follow-up

Issue #6633 tracks the root cause fix. This flag is mitigation, not resolution; once the root cause is addressed, the flag can remain as a safety valve or be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
