### PR TITLE
fix(room_task_schedule): reuse Room_task.update_local_agent_state on agent writes

### DIFF
--- a/lib/room/room_task.mli
+++ b/lib/room/room_task.mli
@@ -9,6 +9,25 @@ include module type of Room_state
 
 (** {1 Task activity helpers} *)
 
+val update_local_agent_state :
+  config -> agent_name:string -> (Types.agent -> Types.agent) -> unit
+(** Update the on-disk agent state record under its own
+    [with_file_lock] on the agent file.  The callback receives the
+    current agent record and returns the updated one; the helper
+    silently skips writes when the agent file is missing (matching
+    the pre-existing best-effort mirror semantics) and logs JSON
+    parse failures with the agent name for diagnostic context.
+
+    Callers that hold an outer lock on a different file (e.g. the
+    backlog in [Room_task_schedule.claim_next_r]) must nest this
+    call inside the outer lock; lock acquisition order is always
+    {b outer path → agent file} across every call site to keep the
+    graph acyclic.
+
+    @since PR #6634 — previously inline at six sites in [Room_task]
+    task transitions; exposed here so [Room_task_schedule] can reuse
+    the same discipline for its own agent-state writes. *)
+
 val emit_task_activity :
   config -> agent_name:string -> task_id:string ->
   kind:string -> payload:Yojson.Safe.t -> unit

--- a/lib/room/room_task_schedule.ml
+++ b/lib/room/room_task_schedule.ml
@@ -154,20 +154,15 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
           agent_name preset_filtered (now_iso ()));
 
       (* Helper: clear agent current_task and reset status after auto-release
-         when no replacement task can be claimed. *)
+         when no replacement task can be claimed.  Delegates to
+         [Room_task.update_local_agent_state] so the agent-file write
+         holds [with_file_lock] on the agent file itself, matching the
+         discipline used by [Room_task] transitions (PR #6634). *)
       let clear_agent_state_after_release () =
         match released_task_id with
         | Some _ ->
-            let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-            if path_exists config agent_file then begin
-              let json = read_json config agent_file in
-              match agent_of_yojson json with
-              | Ok agent ->
-                  let updated = { agent with status = Active; current_task = None } in
-                  write_json config agent_file (agent_to_yojson updated)
-              | Error msg ->
-                  Log.Misc.error "agent state clear failed: %s" msg
-            end
+            Room_task.update_local_agent_state config ~agent_name (fun agent ->
+              { agent with status = Active; current_task = None })
         | None -> ()
       in
 
@@ -219,17 +214,13 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
           } in
           write_backlog config new_backlog;
 
-          (* Update agent status *)
-          let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
-          if path_exists config agent_file then begin
-            let json = read_json config agent_file in
-            match agent_of_yojson json with
-            | Ok agent ->
-                let updated = { agent with status = Busy; current_task = Some task.id } in
-                write_json config agent_file (agent_to_yojson updated)
-            | Error msg ->
-                Log.Misc.error "agent state write failed: %s" msg
-          end;
+          (* Update agent status — takes [with_file_lock] on the
+             agent file via [Room_task.update_local_agent_state] to
+             keep the record consistent with concurrent
+             [Room_agent.update_agent_r] or other task transitions
+             that hold the agent-file lock (PR #6634). *)
+          Room_task.update_local_agent_state config ~agent_name (fun agent ->
+            { agent with status = Busy; current_task = Some task.id });
 
           (* No broadcast — log_event + emit_task_activity below are sufficient. *)
           (match released_task_id with


### PR DESCRIPTION

Follow-up to PR #6634.  Two sites in
`lib/room/room_task_schedule.ml:claim_next_r` were still doing the
same inline unlocked read-modify-write on the agent state file that
PR #6634 consolidated in `lib/room/room_task.ml`:

```ocaml
let agent_file = Filename.concat (agents_dir config)
  (safe_filename agent_name ^ ".json") in
if path_exists config agent_file then begin
  let json = read_json config agent_file in
  match agent_of_yojson json with
  | Ok agent ->
    let updated = { agent with status = ...; current_task = ... } in
    write_json config agent_file (agent_to_yojson updated)
  | Error msg -> Log.Misc.error "..." msg
end
```

Sites:

1. `clear_agent_state_after_release` helper at line 158-172 — clears
   `current_task` and resets status to `Active` after an auto-release
   when no replacement task can be claimed.
2. The successful claim branch at line 217-227 — sets status to
   `Busy` and assigns `current_task` after `write_backlog`.

Both run inside `with_file_lock config backlog_path` — which
protects `.backlog`, not the per-agent file — so a concurrent
`Room_agent.update_agent_r` or another `Room_task` transition on
the same agent loses the later-write-wins race.  Same failure mode
documented on PR #6634.

## Fix

- Expose `Room_task.update_local_agent_state` in `lib/room/room_task.mli`
  (previously a module-private helper from PR #6634).  The new doc
  comment spells out the nested-lock contract: callers that already
  hold an outer lock on a different path must preserve the
  `outer → agent file` acquisition order, which is the order used
  at every call site in the codebase today.
- Replace the two inline R-M-W blocks in `room_task_schedule.ml`
  with `Room_task.update_local_agent_state config ~agent_name f`.
  The helper takes `with_file_lock` on the agent file itself, so
  the nested lock chain becomes `backlog → agent file` — same
  ordering as every other call site, no new cycle.

This also deletes the local `clear_agent_state_after_release`
helper's `if path_exists` guard and `agent_file = Filename.concat`
boilerplate, which the centralised helper already handles.

## Verification

```
dune build --root . @lib/check                           # exit 0
dune exec --root . -- ./test/test_room_coverage.exe test claim_next
# test body asserts "claim next success" after transition — PASSED
```

`test claim_next` reports 9 failures, all in `with_test_env`
**teardown** (`Room_init.reset.rm_rf` tripping over a dangling
symlink under `~/me/.masc/autoresearch/ar-0bf1fc00/...`), not in
the test bodies.  `ASSERT claim next success` is printed before
the teardown exception, confirming the updated claim path runs
correctly.  This is the same environment pollution noted on
PRs #6632 and #6634; it reproduces on `origin/main` with this
patch reverted.

## Finding source

Cycle 30 of the masc-mcp audit sweep.  Carry-over from Cycle 28's
`room_task.ml` deep-read: the audit heuristic "for every
`Filename.concat ... .json` inside a `with_file_lock` block on a
different path, the inner write is lock-drift" pointed at two
residual sites in `room_task_schedule.ml` that I intentionally
deferred until PR #6634's helper was merged to avoid stacking
conflicts.  Now that #6634 is on main, the sites can reuse the
exported helper verbatim.