### PR TITLE
refactor(keeper): remove redundant UTF-8 sanitize calls on LLM input path

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -393,13 +393,6 @@ let run_turn
   let { system_prompt = turn_system_prompt; dynamic_context } =
     build_turn_prompt ~base_system_prompt ~messages:ctx_work.messages
   in
-  (* Defense in depth: unified prompt builders sanitize their own output,
-     but run_turn is shared by other callers and is the final boundary before
-     handing prompts/history to OAS. Keep this sanitization here even when
-     upstream builders already cleaned their strings. *)
-  let turn_system_prompt = Inference_utils.sanitize_text_utf8 turn_system_prompt in
-  let dynamic_context = Inference_utils.sanitize_text_utf8 dynamic_context in
-  let user_message = Inference_utils.sanitize_text_utf8 user_message in
   let prompt_metrics =
     build_prompt_metrics ~system_prompt:turn_system_prompt ~dynamic_context
       ~user_message

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -269,7 +269,6 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   in
   let system_prompt =
     Printf.sprintf "%s\n\n## Turn Intent\n%s" base_system_prompt turn_intent_block
-    |> Inference_utils.sanitize_text_utf8
   in
   (* User message: structured world observation *)
   let ubuf = Buffer.create 1024 in
@@ -559,6 +558,6 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
        Buffer.add_string ubuf "\n"
    | _ -> ());
   let user_message =
-    Buffer.contents ubuf |> Inference_utils.sanitize_text_utf8
+    Buffer.contents ubuf
   in
   (system_prompt, user_message)


### PR DESCRIPTION
## Summary

Extracted from #6555 which is currently CONFLICTING/DIRTY because its OAS pin bump commit (to 0.121.0) is stale — main is already on OAS v0.122.0 (#6601, #6618, #6631). This PR keeps only the sanitize cleanup portion.

Removed 5 calls in the LLM input path:
- \`keeper_unified_prompt.ml\`: system prompt and user message builders
- \`keeper_agent_run.ml\`: run_turn entry point (3 calls)

Retained 8 calls for non-LLM paths: checkpoint I/O (filesystem data integrity) and token metrics computation (local estimation).

Addresses masc-mcp#5626 L5 (sanitize_text_utf8 boundary violation).

## Provenance

Cherry-picked \`b8e0018fa\` from \`origin/refactor/remove-sanitize-calls\` (#6555) onto fresh \`origin/main\`. The OAS pin commit \`867c7bb12\` was dropped because:
- Main already has \`9c9cc20fe chore(oas): bump agent_sdk pin to 0.122.0\` (#6631)
- Main already has \`5c41e5715 feat: bridge Agent_sdk.Log → bump OAS pin to 0.121.0\` (#6618)
- Main already has \`c710d1f05 chore(oas): bump agent_sdk to v0.121.0\` (#6601)

## Test plan

- [x] \`dune build @lib/keeper/all\` clean
- [ ] After merge: close #6555 as superseded by this PR