### PR TITLE
fix(prompt_registry): merge validate+write into single mutex transaction

### DIFF
--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -737,29 +737,35 @@ let render_prompt_template key vars =
 (** Validate and apply a single override entry (shared logic for
     [set_override] and [restore_overrides]).  Caller must NOT hold [mu].
     Returns [Ok ()] on success or [Error msg] describing why the entry
-    was rejected. *)
+    was rejected.
+
+    Validation and the override write happen inside a single
+    [with_mutex] block so the [meta_tbl] snapshot we validated
+    against is still in effect when we install the override.  A
+    prior version split the two into separate mutex transactions —
+    a concurrent [unregister] or [register_prompt] landing between
+    them could invalidate the validation decision (e.g. overwrite a
+    key's metadata with a different [template_variables] set after
+    we validated but before we wrote the override). *)
 let apply_override_validated key value =
   let trimmed = String.trim value in
   if not (is_valid_prompt_key key) then Error "Invalid prompt key"
   else if trimmed = "" then Error "Prompt cannot be empty"
   else if String.length trimmed > 10000 then Error "Prompt too long (max 10000 chars)"
   else
-    match
-      with_mutex (fun () ->
-          match Hashtbl.find_opt meta_tbl key with
-          | None -> Error "Unknown prompt key"
-          | Some meta ->
-              let unexpected = unexpected_template_variables meta trimmed in
-              if unexpected <> [] then
-                Error
-                  (Printf.sprintf "Unknown template variables: %s"
-                     (String.concat ", " unexpected))
-              else Ok ())
-    with
-    | Error msg -> Error msg
-    | Ok () ->
-        with_mutex (fun () -> Hashtbl.replace override_tbl key trimmed);
-        Ok ()
+    with_mutex (fun () ->
+        match Hashtbl.find_opt meta_tbl key with
+        | None -> Error "Unknown prompt key"
+        | Some meta ->
+            let unexpected = unexpected_template_variables meta trimmed in
+            if unexpected <> [] then
+              Error
+                (Printf.sprintf "Unknown template variables: %s"
+                   (String.concat ", " unexpected))
+            else begin
+              Hashtbl.replace override_tbl key trimmed;
+              Ok ()
+            end)
 
 (** Set an override for a prompt *)
 let set_override key value = apply_override_validated key value


### PR DESCRIPTION

`apply_override_validated` was a classic TOCTOU across two separate
mutex acquisitions:

```ocaml
match
  with_mutex (fun () ->
    match Hashtbl.find_opt meta_tbl key with
    | None -> Error "Unknown prompt key"
    | Some meta ->
        let unexpected = unexpected_template_variables meta trimmed in
        if unexpected <> [] then Error "..." else Ok ())
with
| Error msg -> Error msg
| Ok () ->
    with_mutex (fun () -> Hashtbl.replace override_tbl key trimmed);
    Ok ()
```

The first `with_mutex` validates against `meta_tbl` — specifically
that the key exists and the trimmed value's template variables are a
subset of `meta.template_variables`.  The lock is then **released**,
and a second `with_mutex` transaction installs the override into
`override_tbl`.  Between the two transactions, another fiber can:

1. `unregister` the prompt — `meta_tbl` no longer has the key, but
   the override is still written for a now-unknown key.  Future
   `list_prompts` sees an override with no metadata; `get_prompt`
   returns the override value for a key that has been retired.
2. `register_prompt` with a different `template_variables` set — the
   override we're about to install would be rejected by
   `unexpected_template_variables` against the new metadata, but the
   validator already returned `Ok` against the old metadata.  We
   proceed to write an override whose template variables are no
   longer allowed.

Both scenarios leave the registry in a state that violates the
invariant "every override in `override_tbl` has a corresponding
`meta_tbl` entry whose `template_variables` cover the override's
template".

The callers are `set_override` and `restore_overrides`, both routed
through this helper.  `set_override` runs on MCP tool fibers
(`masc_set_prompt_override`); `restore_overrides` runs at server
startup.  Register/unregister come from the same MCP surface.
Concurrent fibers are the expected workload.

## Fix

Collapse both transactions into one.  Validation and the
`Hashtbl.replace override_tbl` happen inside the same
`with_mutex (fun () -> ...)` block, so the `meta_tbl` snapshot we
validated against is still in effect when we install the override.
The validation result and the write are now linearizable against any
other `with_mutex` caller.

No behavioral change on the happy path — single-fiber operation
observes identical semantics.  The fix only closes a window that
only fires under concurrent register/unregister traffic.

## Verification

```
dune build --root . @lib/check                            # exit 0
dune exec --root . -- ./test/test_prompt_registry_defaults.exe
# 11/11 passed, including override{rejects unknown key, rejects unknown templates, clear_override reverts to file}
```

The existing test suite exercises the successful-validation path and
both rejection paths.  A concurrent-caller regression test is not in
scope for this PR — the behavior change is the atomicity guarantee,
which needs a deliberately-scheduled two-fiber test (separate
follow-up).

## Finding source

Cycle 31 of the masc-mcp audit sweep.  Deep-read of
`lib/prompt_registry/prompt_registry.ml` (851 lines, no `.mli`).
Of the 20+ `with_mutex` sites in the module, all but this one hold
the lock for a single transaction.  The two-phase pattern jumped
out against the background.

Audit heuristic: when a module uses `with_mutex` pervasively and one
function calls it twice with an intervening `match` arm, verify the
two transactions are truly independent.  If the second transaction's
write depends on state the first transaction read, the second must
either re-validate inside its own block or merge with the first.
"Validate in one block, write in another" is almost always a TOCTOU
unless the state being validated is provably immutable for the
duration of the call.