### PR TITLE
docs(keepers): fix prompt-layer drift teaching server-root .worktrees/ (#6644)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,11 @@ jobs:
           chmod +x scripts/check-toml-syntax.sh
           scripts/check-toml-syntax.sh
 
+      - name: Check keeper prompt paths drift (#6527 iter9)
+        run: |
+          chmod +x scripts/validate-prompt-paths.sh
+          scripts/validate-prompt-paths.sh
+
       - name: Check MASC/OAS boundary ratchet
         run: |
           chmod +x scripts/check-boundary-guard.sh

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -38,7 +38,7 @@ idle 규칙:
 에러 방지:
 - 파일을 읽기 전에 keeper_shell op=ls로 해당 경로가 존재하는지 먼저 확인하라.
 - playground clone 작업 시 경로는 .masc/playground/{your-name}/repos/masc-mcp/ 하위를 사용하라. keeper_context_status로 이름 확인.
-- repo worktree 작업 시 경로는 .worktrees/<branch-or-task>/ 하위를 사용하라.
+- repo worktree 작업 시 경로는 .masc/playground/{your-name}/repos/masc-mcp/.worktrees/<branch-or-task>/ 하위를 사용하라. masc_worktree_create가 반환하는 경로가 정답이다. server-root 상대 경로(.worktrees/...)는 harness에 차단된다(write_outside_playground_blocked).
 - 없는 파일을 요청하면 에러가 난다. 같은 경로를 재시도하지 말고 ls로 실제 구조를 확인하라.
 """
 

--- a/config/personas/coder/AGENT.md
+++ b/config/personas/coder/AGENT.md
@@ -16,7 +16,12 @@ keeper_task_claim id=<task-id>
 ```
 masc_worktree_create branch=fix/<short-description>
 ```
-This creates `.worktrees/fix/<short-description>/` — all subsequent work happens here.
+The returned path is `<playground-worktree-path>` — always under
+`.masc/playground/<your-name>/repos/masc-mcp/.worktrees/fix/<short-description>/`.
+Call `keeper_context_status` first if you need your name. Treat
+`<playground-worktree-path>` as a variable in every step below; never substitute
+a server-root path (see the WRONG paths list in `keeper.world.md`), which the
+harness blocks as `cwd_outside_playground` / `write_outside_playground_blocked`.
 
 ### Step 3: Read and understand
 ```
@@ -28,22 +33,22 @@ keeper_shell op=rg args=["pattern", "lib/"]  (search codebase)
 
 ### Step 4: Edit code
 ```
-masc_code_write path=.worktrees/fix/<name>/<file> content=<full-content>
-masc_code_edit path=.worktrees/fix/<name>/<file> old=<old> new=<new>
+masc_code_write path=<playground-worktree-path>/<file> content=<full-content>
+masc_code_edit path=<playground-worktree-path>/<file> old=<old> new=<new>
 ```
 
 ### Step 5: Build and test
 ```
-masc_code_shell cmd="dune build --root ." cwd=.worktrees/fix/<name>
-masc_code_shell cmd="dune exec test/<relevant_test>.exe" cwd=.worktrees/fix/<name>
+masc_code_shell cmd="dune build --root ." cwd=<playground-worktree-path>
+masc_code_shell cmd="dune exec test/<relevant_test>.exe" cwd=<playground-worktree-path>
 ```
 If build fails, fix the error and retry. Never proceed to commit with a broken build.
 
 ### Step 6: Commit and push
 ```
-masc_code_git action=add args=["<file1>", "<file2>"] cwd=.worktrees/fix/<name>
-masc_code_git action=commit args=["-m", "fix(<scope>): <description>"] cwd=.worktrees/fix/<name>
-masc_code_git action=push args=["origin", "fix/<name>"] cwd=.worktrees/fix/<name>
+masc_code_git action=add args=["<file1>", "<file2>"] cwd=<playground-worktree-path>
+masc_code_git action=commit args=["-m", "fix(<scope>): <description>"] cwd=<playground-worktree-path>
+masc_code_git action=push args=["origin", "fix/<name>"] cwd=<playground-worktree-path>
 ```
 
 ### Step 7: Create draft PR
@@ -59,7 +64,7 @@ keeper_broadcast msg="PR #<number> created for <task-title>"
 
 ## Rules
 
-1. All file operations must be inside `.worktrees/`. Never edit files in the repo root.
+1. All file operations must be inside your playground worktree (the `<playground-worktree-path>` returned by `masc_worktree_create`, under `.masc/playground/<your-name>/repos/masc-mcp/.worktrees/...`). Never edit files in the repo root, and never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked`.
 2. Never push to main or master. Always push to a feature branch.
 3. Always create PRs with `--draft`. Human review is required before merge.
 4. Build must pass before committing. If tests exist for the changed area, they must pass too.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -10,12 +10,13 @@ Playground is your default sandbox, relative to the server `base_path`:
 - `.masc/playground/{your-name}/` — bundle root (general workspace)
 - `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
 - `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), so make sure you have cloned the target repo before creating a worktree.
+Repo worktrees live *inside* your playground clone — the canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist, never use them):
 - `/repos/...`
 - `/playground/...`
 - `/home/.../repos/...`
+- `.worktrees/...` (server-root relative — worktrees must live inside your playground clone at `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/...`)
 - Any guessed absolute path outside the path returned by your tools
 
 ## Project

--- a/scripts/validate-prompt-paths.sh
+++ b/scripts/validate-prompt-paths.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# validate-prompt-paths.sh — keeper prompt/config drift gate for #6527.
+#
+# Invariant: every `.worktrees/<...>` reference in config/ must be preceded
+# by a playground prefix (`.masc/playground/.../`). A bare `.worktrees/...`
+# string teaches keepers a server-root relative path that the harness blocks
+# (iter3 cwd_outside_playground / iter6 write_outside_playground_blocked).
+#
+# Re-run locally:
+#   bash scripts/validate-prompt-paths.sh
+#
+# Exit codes:
+#   0 — all .worktrees/ references are playground-prefixed (OK)
+#   1 — bare .worktrees/... reference found (drift)
+#   2 — required tool missing
+
+set -u
+set -o pipefail
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "validate-prompt-paths: ripgrep (rg) is required" >&2
+  exit 2
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+SEARCH_ROOTS=(
+  "config/prompts"
+  "config/keepers"
+  "config/personas"
+)
+
+# If any of the search roots has been removed by a future refactor, skip
+# with a clear message instead of letting ripgrep fail with a generic
+# "No such file or directory" that masks the actual state.
+for d in "${SEARCH_ROOTS[@]}"; do
+  if [ ! -d "$d" ]; then
+    echo "validate-prompt-paths: $d not found (skipping drift check)" >&2
+    exit 0
+  fi
+done
+
+# Detection is strictly per-line: the first rg emits one output line per
+# source line that mentions `.worktrees/`, and the second rg filters each
+# of those output lines independently. A drifted bare `.worktrees/...`
+# line is caught even if the line immediately above or below contains
+# the playground prefix.
+drift_hits="$(
+  rg --no-heading --with-filename --line-number --color=never \
+     '\.worktrees/' "${SEARCH_ROOTS[@]}" \
+    | rg -v '\.masc/playground/' \
+    || true
+)"
+
+if [ -n "$drift_hits" ]; then
+  cat <<'EOF' >&2
+✗ validate-prompt-paths: bare `.worktrees/...` reference found in config/
+
+Keepers see every config/prompts, config/keepers/*.toml, and config/personas/*
+as part of their system prompt. A bare `.worktrees/<branch>` path is relative
+to the server root, not the keeper playground — the harness rejects it
+as write_outside_playground_blocked / cwd_outside_playground (#6527 iter3/iter6).
+
+Every .worktrees reference in config/ MUST be prefixed with the playground
+path, for example:
+  .masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/
+
+Offending lines:
+EOF
+  echo "$drift_hits" >&2
+  echo "" >&2
+  echo "Fix the lines above, then re-run this script." >&2
+  exit 1
+fi
+
+echo "✓ validate-prompt-paths: all .worktrees/ references are playground-rooted"
+exit 0


### PR DESCRIPTION
## Summary

Closes #6644. Prompt side of the #6527 playground containment trilogy. `keeper.world.md:13`, `masc-improver.toml:41`, and `coder/AGENT.md` (9 lines) all still taught keepers to use server-root `.worktrees/<branch>/` paths even though iter3/iter4/iter6 harness gates now reject exactly those paths. Iter1 PR #6533 updated `keeper.capabilities.md` but the sweep stopped there. This PR finishes the sweep and adds a CI drift gate so the same drift can't recur.

Discovery: `/loop` tick 18 audit (`rg '\.worktrees/' config/`) surfaced 12 hits — 11 drift, 1 correct (iter1).

## Product impact

`keeper.world.md` is loaded into every keeper's system prompt `<world>` block. Every MASC keeper was therefore being instructed, at the prompt level, to use a path that its own tools would reject:

| Harness gate | Rejection reason |
|---|---|
| iter3 #6579 `keeper_exec_shell` | `write_outside_playground_blocked` |
| iter4 #6580 `effective_allowed_paths` | `.worktrees/` removed |
| iter6 #6610 `tool_code_write.validate_writable_path` | per-agent rejection |

This drift is a plausible cause of why the #6527 trilogy kept surfacing "new" dispatcher families across iter1~iter7 — the prompt kept re-teaching a false path, and each successive keeper run funneled that false path through a different dispatcher, making each rejection look like a new bug rather than a repeat of the same mis-education.

`masc-improver` is an active autonomous keeper running in production; it was most directly affected. `coder/AGENT.md` is dormant (no keeper currently maps to that persona) but would silently break on enable.

No functional OCaml change, no runtime surface change, no behaviour change for a correctly-pathed keeper. The only keepers this impacts are those who were previously following the drifted prompt — they now see a prompt that matches the harness.

## Evidence

Manual verification:

```
$ bash scripts/validate-prompt-paths.sh
✓ validate-prompt-paths: all .worktrees/ references are playground-rooted

$ bash scripts/check-toml-syntax.sh
Checking TOML syntax...
All 5 TOML files parsed successfully.
```

The drift gate script self-tested during development: my first draft of `coder/AGENT.md` included a warning that mentioned `.worktrees/...` without a playground prefix on the same line, and the gate correctly caught that line. Rewording the warning to point at `keeper.world.md`'s WRONG-paths list cleared the check — exactly the intended signal.

CI state on this PR:

- ✅ Lint (includes new drift gate)
- ✅ TLA+ Model Checking
- ✅ Dashboard typecheck + tests
- ✅ PR Hygiene / PR Sync / Release Train
- ❌ Build and Test — pre-existing main blocker tracked in #6625 (same `MASC_BASE_PATH` resolution failure reproduces on main HEAD, unrelated to this doc-only PR)
- ❌ Health — same root cause as Build and Test

## Review evidence

Cross-model review per `workflow-pr.md`: `sb glm-text` (GLM-5.1, non-self), 6-category rubric (correctness / drift gate robustness / doc-vs-code boundary / CI integration / commit message / deferred).

Findings:

- **Correctness** — ✓ canonical form consistent across all 3 modified files, no residual drift
- **HIGH (drift gate logic false alarm)** — GLM doubted the `rg '\.worktrees/' | rg -v '\.masc/playground/'` pipeline's per-line semantics, claiming it might false-negative on code-block wrong/right examples on adjacent lines. In practice `rg -v` filters each matched line independently, and the self-test (line 23 of AGENT.md caught even though line 20 above had the playground prefix) confirmed correct behaviour. **Response**: annotated the script with the per-line invariant so future readers don't repeat the doubt.
- **MEDIUM (CI directory guard)** — GLM correctly noted that if any of `config/prompts`, `config/keepers`, `config/personas` is ever moved, ripgrep errors with a generic "No such file or directory" rather than a drift-specific message. **Response**: added a guard at the top of the script that exits 0 with a skip message if any search root is absent.
- **MEDIUM (commit cross-references)** — GLM couldn't see the commit body and raised a false alarm about `#6527 iter9` vs `#6644` mismatch. The commit body explicitly links both and describes the iter9 placement in the trilogy. No change needed.
- **LOW (style — bare branch refs in git args)** — `args=["origin", "fix/<name>"]` in `coder/AGENT.md` uses a git ref, not a filesystem path. Out of scope for this PR; can be a followup if `<playground-branch-name>` placeholder is desired.
- **LOW (`repos/` class sweep)** — GLM suggested the same methodology could extend to bare `repos/` references. Legitimate followup, but worktree paths were the acute pain point per #6527.

Net: 1 actual fix (CI guard), 1 preemptive clarity comment, 3 deferred / explained. Gate re-run confirmed clean after fix-up.

## Linked issue

Closes #6644.

Parent trilogy: #6527. Iter1 (`keeper.capabilities.md` only) was #6533. This PR finishes the sweep that iter1 started.

Adjacent issues found with the same `/loop` audit methodology but not fixed here (separate PRs when approved):

- #6637 — `tool_code.ml` read handlers allow cross-keeper playground reads (write counterpart: iter6 #6610)
- #6641 — `tool_repair_loop` / `tool_keeper.handle_keeper_repair` accept cross-keeper `working_dir` (same iter1-style "`Sys.getcwd ()` as boundary" shape)

Feedback memory references: `feedback_structural-bug-class-rg-sweep.md`, `feedback_policy-runtime-drift-gate.md`.



<!-- tick 21 re-trigger -->
