### PR TITLE
perf(board): move Agent_economy.earn outside store.mutex

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -315,43 +315,54 @@ let create_post store ~author ~content ?title ?body ~post_kind ?meta_json
     Error (Validation_error "Content cannot be empty")
   else
 
-  with_lock store (fun () ->
-    (* Check capacity *)
-    if !(store.post_count) >= Limits.max_posts then
-      Error (Capacity_exceeded { current = !(store.post_count); max = Limits.max_posts })
-    else begin
-      let now = Time_compat.now () in
-      let post = {
-        id = Post_id.generate ();
-        author = author_id;
-        title = normalized_title;
-        body = normalized_body;
-        content = normalized_body;
-        post_kind = normalized_kind;
-        meta_json = normalized_meta;
-        visibility;
-        created_at = now;
-        updated_at = now;  (* Initially same as created_at *)
-        expires_at;
-        votes_up = 0;
-        votes_down = 0;
-        reply_count = 0;
-        hearth;
-        thread_id;
-      } in
-      Hashtbl.add store.posts (Post_id.to_string post.id) post;
-      incr store.post_count;
-      invalidate_post_caches store;
-      append_post post;
-      (* Agent Economy: earn credits for board post *)
-      (match Agent_economy.earn
-         ~base_path:(board_base_path ()) ~agent_name:author
-         ~kind:Earn_board_post ~reason:"board post" () with
-       | Ok _ -> ()
-       | Error msg -> Log.BoardLog.warn "economy earn (post): %s" msg);
-      Ok post
-    end
-  )
+  let board_result =
+    with_lock store (fun () ->
+      (* Check capacity *)
+      if !(store.post_count) >= Limits.max_posts then
+        Error (Capacity_exceeded { current = !(store.post_count); max = Limits.max_posts })
+      else begin
+        let now = Time_compat.now () in
+        let post = {
+          id = Post_id.generate ();
+          author = author_id;
+          title = normalized_title;
+          body = normalized_body;
+          content = normalized_body;
+          post_kind = normalized_kind;
+          meta_json = normalized_meta;
+          visibility;
+          created_at = now;
+          updated_at = now;  (* Initially same as created_at *)
+          expires_at;
+          votes_up = 0;
+          votes_down = 0;
+          reply_count = 0;
+          hearth;
+          thread_id;
+        } in
+        Hashtbl.add store.posts (Post_id.to_string post.id) post;
+        incr store.post_count;
+        invalidate_post_caches store;
+        append_post post;
+        Ok post
+      end)
+  in
+  (* Agent Economy: earn credits for board post.  Moved OUTSIDE
+     [with_lock] because [Agent_economy.earn] does its own disk I/O
+     against a ledger file unrelated to the board store, and modifies
+     no board state — holding [store.mutex] across it was pure
+     contention that blocked every other board reader/writer while
+     the ledger write landed.  If the earn fails we log at warn; the
+     post itself is already in the store and on disk. *)
+  (match board_result with
+   | Ok post ->
+       (match Agent_economy.earn
+          ~base_path:(board_base_path ()) ~agent_name:author
+          ~kind:Earn_board_post ~reason:"board post" () with
+        | Ok _ -> ()
+        | Error msg -> Log.BoardLog.warn "economy earn (post): %s" msg);
+       Ok post
+   | Error _ as e -> e)
 
 let get_post store ~post_id : (post, board_error) result =
   maybe_sweep store;

--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -49,6 +49,16 @@ let rewrite_vote_log store =
      | Error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg)
   with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_vote_log): %s" msg
 
+(* [vote_outcome] carries the information needed to run the post-lock
+   [Agent_economy.earn] call.  [earn_upvote_for] is [Some author] only
+   on the fresh-upvote path — a vote flip does not earn credits
+   (prevents down/up alternation abuse), and a downvote does not earn
+   at all. *)
+type vote_outcome = {
+  delta : int;
+  earn_upvote_for : string option;
+}
+
 let vote store ~voter ~post_id ~direction : (int, board_error) result =
   match Agent_id.of_string voter with
   | Error e -> Error e
@@ -56,57 +66,71 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
-      with_lock store (fun () ->
-        match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
-        | None -> Error (Post_not_found post_id)
-        | Some post ->
-            let vote_key = "post:" ^ Post_id.to_string pid ^ ":" ^ voter in
-            let now = Time_compat.now () in
-            match Hashtbl.find_opt store.vote_log vote_key with
-            | Some prev when prev = direction ->
-                Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
-                  voter (vote_direction_to_string direction) post_id))
-            | Some _opposite ->
-                let flipped = match direction with
-                  | Up -> { post with votes_up = post.votes_up + 1;
-                                      votes_down = max 0 (post.votes_down - 1);
-                                      updated_at = now }
-                  | Down -> { post with votes_down = post.votes_down + 1;
-                                        votes_up = max 0 (post.votes_up - 1);
+      let board_result : (vote_outcome, board_error) result =
+        with_lock store (fun () ->
+          match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
+          | None -> Error (Post_not_found post_id)
+          | Some post ->
+              let vote_key = "post:" ^ Post_id.to_string pid ^ ":" ^ voter in
+              let now = Time_compat.now () in
+              match Hashtbl.find_opt store.vote_log vote_key with
+              | Some prev when prev = direction ->
+                  Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
+                    voter (vote_direction_to_string direction) post_id))
+              | Some _opposite ->
+                  let flipped = match direction with
+                    | Up -> { post with votes_up = post.votes_up + 1;
+                                        votes_down = max 0 (post.votes_down - 1);
                                         updated_at = now }
-                in
-                Hashtbl.replace store.posts (Post_id.to_string pid) flipped;
-                Hashtbl.replace store.vote_log vote_key direction;
-                store.dirty_posts <- true;  (* Deferred flush *)
-                invalidate_post_caches store;
-                append_vote_log ~target:vote_key ~voter ~direction;
-                (* Record vote for Thompson Sampling feedback *)
-                let author_name = Agent_id.to_string post.author in
-                let vote_dir = match direction with Up -> `Up | Down -> `Down in
-                Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
-                (* No economy earn on flip: prevents down/up alternation abuse *)
-                Ok (flipped.votes_up - flipped.votes_down)
-            | None ->
-                let updated = match direction with
-                  | Up -> { post with votes_up = post.votes_up + 1; updated_at = now }
-                  | Down -> { post with votes_down = post.votes_down + 1; updated_at = now }
-                in
-                Hashtbl.replace store.posts (Post_id.to_string pid) updated;
-                Hashtbl.replace store.vote_log vote_key direction;
-                store.dirty_posts <- true;  (* Deferred flush *)
-                invalidate_post_caches store;
-                append_vote_log ~target:vote_key ~voter ~direction;
-                (* Record vote for Thompson Sampling feedback *)
-                let author_name = Agent_id.to_string post.author in
-                let vote_dir = match direction with Up -> `Up | Down -> `Down in
-                Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
-                (* Agent Economy: earn credits for upvote received *)
-                (if direction = Up then
-                   ignore (Agent_economy.earn
-                     ~base_path:(board_base_path ()) ~agent_name:author_name
-                     ~kind:Earn_upvote ~reason:"upvote on post" ()));
-                Ok (updated.votes_up - updated.votes_down)
-      )
+                    | Down -> { post with votes_down = post.votes_down + 1;
+                                          votes_up = max 0 (post.votes_up - 1);
+                                          updated_at = now }
+                  in
+                  Hashtbl.replace store.posts (Post_id.to_string pid) flipped;
+                  Hashtbl.replace store.vote_log vote_key direction;
+                  store.dirty_posts <- true;  (* Deferred flush *)
+                  invalidate_post_caches store;
+                  append_vote_log ~target:vote_key ~voter ~direction;
+                  (* Record vote for Thompson Sampling feedback *)
+                  let author_name = Agent_id.to_string post.author in
+                  let vote_dir = match direction with Up -> `Up | Down -> `Down in
+                  Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
+                  (* No economy earn on flip: prevents down/up alternation abuse *)
+                  Ok { delta = flipped.votes_up - flipped.votes_down;
+                       earn_upvote_for = None }
+              | None ->
+                  let updated = match direction with
+                    | Up -> { post with votes_up = post.votes_up + 1; updated_at = now }
+                    | Down -> { post with votes_down = post.votes_down + 1; updated_at = now }
+                  in
+                  Hashtbl.replace store.posts (Post_id.to_string pid) updated;
+                  Hashtbl.replace store.vote_log vote_key direction;
+                  store.dirty_posts <- true;  (* Deferred flush *)
+                  invalidate_post_caches store;
+                  append_vote_log ~target:vote_key ~voter ~direction;
+                  (* Record vote for Thompson Sampling feedback *)
+                  let author_name = Agent_id.to_string post.author in
+                  let vote_dir = match direction with Up -> `Up | Down -> `Down in
+                  Thompson_sampling.record_vote ~agent_name:author_name ~direction:vote_dir;
+                  let earn =
+                    if direction = Up then Some author_name else None
+                  in
+                  Ok { delta = updated.votes_up - updated.votes_down;
+                       earn_upvote_for = earn })
+      in
+      (* Agent Economy: earn credits for an upvote received.  Moved
+         OUTSIDE the store lock — [Agent_economy.earn] writes its own
+         ledger file on an unrelated path and modifies no board state,
+         so holding [store.mutex] across its disk I/O was gratuitous
+         contention with every other reader/writer. *)
+      (match board_result with
+       | Ok { delta; earn_upvote_for = Some author_name } ->
+           ignore (Agent_economy.earn
+             ~base_path:(board_base_path ()) ~agent_name:author_name
+             ~kind:Earn_upvote ~reason:"upvote on post" ());
+           Ok delta
+       | Ok { delta; earn_upvote_for = None } -> Ok delta
+       | Error _ as e -> e)
 
 (** Vote on a comment *)
 let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result =


### PR DESCRIPTION

Both `Board_core.create_post` and `Board_votes.vote` called
`Agent_economy.earn` **inside** their `with_lock store` block:

```ocaml
with_lock store (fun () ->
  ...
  Hashtbl.add store.posts ... post;
  append_post post;                                    (* board ledger I/O *)
  (match Agent_economy.earn                            (* unrelated ledger I/O *)
     ~base_path:(board_base_path ())
     ~kind:Earn_board_post ~reason:"board post" () with
   | Ok _ -> ()
   | Error msg -> Log.BoardLog.warn "..." msg);
  Ok post)
```

`Agent_economy.earn` does its own disk I/O against a completely
separate ledger file (`agent_economy` module's append-transaction
path), and modifies **no** board state.  Holding the board's
`Eio.Mutex` across that ledger write was pure contention: every
other `list_posts` / `get_post` / `add_comment` / `sweep` call
spinning on `store.mutex` had to wait for the economy ledger write
to complete.  Same pattern the sibling `prompt_registry.ml` fixed
in #3335 (file I/O outside the mutex).

## Change

- `Board_core.create_post` — the `with_lock` block now returns the
  successfully-created `post`; the `Agent_economy.earn` call runs
  **after** the lock is released.  If the earn fails we still log
  at warn, but the post is already in the store and on disk.
- `Board_votes.vote` — same pattern.  The complication here is that
  the earn call is conditional: a fresh upvote earns credits, a
  flip does not (documented anti-abuse gate), and a fresh downvote
  does not.  To keep the decision inside the critical section
  (where it has access to the freshly-computed state) while moving
  the I/O outside, the locked block now returns a `vote_outcome`
  record carrying both the numeric `delta` and an optional
  `earn_upvote_for` author name.  The post-lock tail reads that
  field and runs `Agent_economy.earn` only when it is `Some`.

## Behavior

No change to observable semantics: same Thompson Sampling update,
same delta return, same earn decision, same log-on-earn-failure.
The only difference is that `Agent_economy.earn` now runs outside
the board mutex, so concurrent board reads and writes on a busy
store no longer block on an unrelated ledger write.

The Thompson Sampling update (`Thompson_sampling.record_vote`) is
**not** moved — it only touches in-memory state via its own
internal mutex (`with_ts_rw`), not file I/O, so there's no
contention benefit to moving it and the separate mutex already
decouples it.

## What is NOT fixed

While reading the module I also noted:

1. `Board_core.maybe_sweep` (line 139-145) reads `store.last_sweep`
   and `store.last_flush` without holding `store.mutex`, even
   though `sweep` writes `store.last_sweep <- now;` **under** the
   lock.  Low severity under single-domain Eio (cooperative
   scheduling narrows the window to effectively zero), but it is a
   contract drift.  Separate follow-up.
2. `append_post` / `append_comment` still run inside `with_lock`.
   This is arguably correct — the in-memory insert and the disk
   append need to be atomic for crash recovery — but the call
   sites should audit whether the atomic-rename / append semantics
   really require the mutex.  Separate follow-up.

## Verification

```
dune build --root . @lib/check                           # exit 0
dune exec --root . -- ./test/test_board_api_e2e.exe       # 1/1  passed
dune exec --root . -- ./test/test_board_dispatch.exe      # 25/25 passed
dune exec --root . -- ./test/test_board_ttl.exe           # all passed
```

No existing test covers the contention scenario directly — the
fix is a pure perf/concurrency improvement with identical
observable semantics, so the existing API-level tests are the
right regression coverage.

## Finding source

Cycle 32 of the masc-mcp audit sweep, extending the Cycle 31
"two-phase mutex" audit heuristic to a broader question: **for
every `with_lock` block in the codebase, does the block hold the
lock across any I/O that doesn't need it?**  `board_core.ml`'s
`with_lock` contains a `Hashtbl.add` (needs the lock) + an
`append_post` (arguably needs it) + an `Agent_economy.earn`
(definitely does not).  The pattern is the "I/O inside a mutex
that doesn't own that I/O" drift that prompt_registry `#3335`
already called out in-tree as an anti-pattern.

Audit heuristic: inside every `with_lock`/`with_mutex` block,
grep for any call site that hits the filesystem on a path unrelated
to the state the lock protects.  If the call touches a different
state domain and ignores its return value for everything but
logging, it belongs outside the lock.