### PR TITLE
fix(local_runtime_pool): drop dead select_runtime; re-check fingerprint after env load

### DIFF
--- a/lib/local/local_runtime_pool.ml
+++ b/lib/local/local_runtime_pool.ml
@@ -326,7 +326,18 @@ let load_runtimes_from_env () =
 
 (* ensure_loaded: the only function that may yield (debug_log calls Log.LocalWorker.debug).
    Yield happens AFTER the ref swap, so callers reading !pool after this
-   function returns see a consistent snapshot. *)
+   function returns see a consistent snapshot.
+
+   The [load_runtimes_from_env] call and the fingerprint paired with it
+   must be captured atomically: both functions read environment
+   variables, and if env changes between them the installed
+   [(fingerprint, runtimes)] pair would be inconsistent (e.g.
+   fingerprint X with Y-era runtimes).  To avoid that, re-read the
+   fingerprint immediately after [load_runtimes_from_env] and only
+   install if the environment still looks like what we loaded.  If the
+   env flipped mid-load, we drop the work and let the next caller
+   (which will capture the new fingerprint at the top of its own
+   [ensure_loaded] call) redo the load for the current state. *)
 let ensure_loaded () =
   let fingerprint = current_fingerprint () in
   let needs_reload =
@@ -334,19 +345,27 @@ let ensure_loaded () =
   in
   if needs_reload then begin
     let loaded, errors = load_runtimes_from_env () in
-    let refreshed = List.map refresh_runtime_metrics loaded in
-    let reloaded =
-      with_pool_lock (fun () ->
-        let state = !pool in
-        if not (String.equal fingerprint state.fingerprint) then begin
-          pool := { state with runtimes = refreshed; fingerprint; parse_errors = errors };
-          true
-        end else
-          false)
-    in
-    if reloaded then
-      debug_log "reload runtimes count=%d errors=%d" (List.length loaded)
-        (List.length errors)
+    let loaded_fingerprint = current_fingerprint () in
+    if String.equal loaded_fingerprint fingerprint then begin
+      let refreshed = List.map refresh_runtime_metrics loaded in
+      let reloaded =
+        with_pool_lock (fun () ->
+          let state = !pool in
+          if not (String.equal fingerprint state.fingerprint) then begin
+            pool := { state with runtimes = refreshed; fingerprint; parse_errors = errors };
+            true
+          end else
+            false)
+      in
+      if reloaded then
+        debug_log "reload runtimes count=%d errors=%d" (List.length loaded)
+          (List.length errors)
+    end else
+      (* Env changed mid-load: drop this attempt.  The next caller will
+         capture [loaded_fingerprint] at its own top and redo the load
+         against the current env snapshot. *)
+      debug_log "env drift during reload (captured=%s, post-load=%s); skipping install"
+        fingerprint loaded_fingerprint
   end else begin
     with_pool_lock (fun () ->
       let state = !pool in
@@ -502,11 +521,6 @@ let select_runtime_from (runtimes : runtime list) ?preferred_pool ?model_name ()
               Error
                 (sprintf "no local runtime configured for model %s" requested)
           | None -> Error "no local runtimes configured")
-
-(* Backward-compatible wrapper that loads from env first. *)
-let select_runtime ?preferred_pool ?model_name () =
-  ensure_loaded ();
-  select_runtime_from (!pool).runtimes ?preferred_pool ?model_name ()
 
 (* acquire: ensure_loaded may yield (Log.LocalWorker.debug inside debug_log).
    After that, reading !pool and swapping pool := are yield-free. *)


### PR DESCRIPTION

Two small fixes to `lib/local/local_runtime_pool.ml`, both surfaced
by the cross-file lock-discipline audit in Cycle 33.

## 1. Delete dead `select_runtime`

`select_runtime` (line 507-509) was a wrapper around the pure
`select_runtime_from` helper that added an `ensure_loaded ()` call
and read `(!pool).runtimes` **outside** of `with_pool_lock`.

```ocaml
let select_runtime ?preferred_pool ?model_name () =
  ensure_loaded ();
  select_runtime_from (!pool).runtimes ?preferred_pool ?model_name ()
```

Every other `!pool` read in this module goes through `with_pool_lock`
— `select_runtime` was the sole violator of the module's explicit
lock contract.  But it also had **zero production callers**:

```
$ rg -n 'Local_runtime_pool\.select_runtime\b' lib/ test/
# (no matches)
```

The test suite only calls `select_runtime_from` directly (the pure
helper).  `acquire` / `release` already call `select_runtime_from`
inside their own `with_pool_lock` blocks.  The wrapper was dead
code that doubled as the one module-wide lock-contract violation —
deleting it closes both problems in one step, and no caller needs
to be updated.

## 2. Re-check fingerprint after `load_runtimes_from_env`

`ensure_loaded` captures `current_fingerprint ()` at the top, then
calls `load_runtimes_from_env ()` to read the environment and parse
the runtime list.  Both functions read env vars independently.  If
`MASC_LOCAL_LLM_ENDPOINTS` (or any other env input to
`current_fingerprint`) changes between the two reads, the resulting
pair is inconsistent:

- `fingerprint` holds the pre-load env snapshot (`X`)
- `loaded` holds runtimes derived from the post-load env (`Y`)

`ensure_loaded` then installs `pool := { fingerprint = X;
runtimes = Y-era; ... }`.  A subsequent `ensure_loaded` call that
captures fingerprint `Y` sees `state.fingerprint = X ≠ Y`, decides
"needs reload", and redoes the work — eventually converging — but
in the interval between the bad install and the next reload, a
caller observing the pool sees X-labelled state with Y-era runtime
metadata.  Not catastrophic (env changes are rare, runtime lists
are small), but the kind of latent reasoning pitfall that future
audits waste time re-deriving.

## Fix

After `load_runtimes_from_env ()`, re-read `current_fingerprint ()`
and compare it to the originally-captured value.  If they match,
the env was stable across the load — install the
`(fingerprint, loaded, errors)` triple as before.  If they differ,
env drifted mid-load; drop this attempt and let the next caller
redo the load with its own fresh fingerprint capture.  The dropped
work is at most one env read + parse, which is bounded by the
number of runtimes in `MASC_LOCAL_LLM_ENDPOINTS` (small).

Emits a `debug_log` on drift so operators can correlate with env
mutation events if drift ever appears in production.

No test exercises env-mid-load drift directly (the race requires a
deliberately-racy env mutation), so the existing
`test_local_runtime_pool` suite is the regression coverage for the
happy path.  All 9 tests still pass.

## Verification

```
dune build --root . @lib/check                                # exit 0
dune exec --root . -- ./test/test_local_runtime_pool.exe      # 9/9 passed
```

## Finding source

Cycle 33 of the masc-mcp audit sweep.  `local_runtime_pool.ml` had
11 `with_pool_lock` hits — highest in the module for this audit
axis — so it was the natural next target after Cycle 32's
board/economy cleanup.

`select_runtime` was found by enumerating every `!pool` read and
cross-checking against `with_pool_lock` enclosure; the unlocked
read stood out.  The `ensure_loaded` fingerprint drift was a
carry-over from Cycle 25's first sweep of this module, deferred at
the time because it seemed theoretical.  Cycle 33 revisits it as
"reasoning pitfall eliminated even if the window is narrow" — the
fix is one extra env read and a comparison, not worth the ongoing
cost of re-deriving the race window in every future audit pass.

Audit heuristic: every read of env-derived state paired with a
read of env-derived state elsewhere in the same function should
either (a) use the same captured snapshot, or (b) re-validate that
both reads saw the same underlying env.  "Capture X, do work,
install X alongside Y-era data" is a latent drift regardless of
how rare the window is.