### PR TITLE
fix(repair_loop): gate working_dir on caller playground (#6641) [WIP iter10]

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -367,33 +367,28 @@ let handle_keeper_repair ctx args : tool_result =
         (false, "task_spec is required")
       else
         let target_mode = get_string args "target_mode" "snippet" in
-        let working_dir_arg = get_string args "working_dir" (Sys.getcwd ()) in
+        let working_dir_arg = get_string args "working_dir" "" in
         let plugin_id = get_string args "plugin_id" "ocaml" in
         let target_file_opt = get_string_opt args "target_file" in
-        let cwd_root =
-          try Unix.realpath (Sys.getcwd ()) with
-          | Unix.Unix_error _ -> Sys.getcwd ()
-        in
-        let resolved_working_dir_result =
-          try Ok (Unix.realpath working_dir_arg) with
-          | Unix.Unix_error _ ->
-              Error "working_dir does not exist or is not accessible"
-        in
-        match resolved_working_dir_result with
+        (* #6641 iter10 — narrow working_dir to caller's playground.
+           Default (empty arg) resolves to the caller's own playground
+           bundle root, not [Sys.getcwd ()]. Cross-keeper targets are
+           rejected. Shares the resolver with tool_repair_loop so the
+           same fix applies to both dispatchers. *)
+        match
+          Tool_repair_loop.resolve_playground_working_dir
+            ~agent_name:ctx.agent_name
+            ~base_path:ctx.config.base_path
+            ~working_dir_arg
+        with
         | Error msg -> (false, msg)
         | Ok working_dir ->
-            if not
-                 (Tool_repair_loop.is_safe_subpath ~parent:cwd_root
-                    ~child:working_dir)
-            then
-              (false, "working_dir must be within the current workspace")
-            else
-              match
-                Tool_repair_loop.validate_target_file ~working_dir
-                  ~target_file:target_file_opt
-              with
-              | Error msg -> (false, msg)
-              | Ok validated_target_file ->
+            match
+              Tool_repair_loop.validate_target_file ~working_dir
+                ~target_file:target_file_opt
+            with
+            | Error msg -> (false, msg)
+            | Ok validated_target_file ->
                   let validator_profile =
                     get_string args "validator_profile"
                       (if

--- a/lib/tool_repair_loop.ml
+++ b/lib/tool_repair_loop.ml
@@ -245,32 +245,52 @@ let resolve_playground_working_dir ~agent_name ~base_path ~working_dir_arg =
   let playground_abs_raw =
     Filename.concat base_path playground_rel
   in
-  let playground_abs =
-    try Unix.realpath playground_abs_raw with
-    | Unix.Unix_error _ -> playground_abs_raw
-  in
-  let effective_arg =
-    if String.trim working_dir_arg = "" then playground_abs
-    else working_dir_arg
-  in
-  let resolved =
-    try Ok (Unix.realpath effective_arg) with
+  (* Fail closed: if the playground bundle does not yet exist we
+     cannot canonicalise it, so we cannot safely compare it against a
+     child path. Falling back to the raw (non-realpath) parent would
+     silently regress to pre-iter10 behaviour on filesystems where
+     symlinks or case-insensitivity flip the [starts_with] result
+     (notably macOS `/tmp` → `/private/tmp`). Surface an explicit
+     error that points the LLM at the recovery action instead.
+     Found by GLM-5.1 review of PR #6651, Issue 2. *)
+  match
+    try Ok (Unix.realpath playground_abs_raw) with
     | Unix.Unix_error _ ->
-        Error "working_dir does not exist or is not accessible"
-  in
-  match resolved with
-  | Error msg -> Error msg
-  | Ok working_dir ->
-      if is_safe_subpath ~parent:playground_abs ~child:working_dir then
-        Ok working_dir
-      else
         Error
           (Printf.sprintf
-             "working_dir must be inside your own keeper playground \
-              (%s). Cross-keeper repair loops are blocked — use \
-              masc_worktree_create to provision a workspace under your \
-              playground first. See #6527/#6641."
+             "keeper playground directory %S does not exist yet — cannot \
+              validate working_dir containment. Run masc_worktree_create \
+              to provision your playground first. See #6527/#6641."
              playground_rel)
+  with
+  | Error msg -> Error msg
+  | Ok playground_abs ->
+      let effective_arg =
+        if String.trim working_dir_arg = "" then playground_abs
+        else working_dir_arg
+      in
+      let resolved =
+        try Ok (Unix.realpath effective_arg) with
+        | Unix.Unix_error _ ->
+            Error "working_dir does not exist or is not accessible"
+      in
+      (match resolved with
+      | Error msg -> Error msg
+      | Ok working_dir ->
+          (* Both [playground_abs] and [working_dir] are Unix.realpath'd,
+             which strips trailing slashes and collapses symlinks, so
+             [is_safe_subpath]'s [String.starts_with] check is safe
+             from trailing-slash mismatch and macOS /private canonicalisation. *)
+          if is_safe_subpath ~parent:playground_abs ~child:working_dir then
+            Ok working_dir
+          else
+            Error
+              (Printf.sprintf
+                 "working_dir must be inside your own keeper playground \
+                  (%s). Cross-keeper repair loops are blocked — use \
+                  masc_worktree_create to provision a workspace under your \
+                  playground first. See #6527/#6641."
+                 playground_rel))
 
 let handle_start (ctx : _ context) args : tool_result =
   let*! task_spec = get_string_required args "task_spec" in

--- a/lib/tool_repair_loop.ml
+++ b/lib/tool_repair_loop.ml
@@ -228,32 +228,67 @@ let update_state_with_attempt (state : state) ~(attempt : attempt_record)
     stopped_at = if is_terminal_status status then Some now else None;
   }
 
+(* #6641 iter10 — per-agent playground containment for repair loop.
+
+   Resolves [working_dir] against the caller's playground bundle root
+   (.masc/playground/<agent_name>/) so keepers cannot pass a foreign
+   playground clone as the repair target. The default when [working_dir]
+   is omitted is the caller's own playground, not [Sys.getcwd ()].
+
+   Takes [agent_name] and [base_path] directly rather than a context
+   record so both [Tool_repair_loop.context] and [Keeper_types.context]
+   call sites can share the same helper without type unification. *)
+let resolve_playground_working_dir ~agent_name ~base_path ~working_dir_arg =
+  let playground_rel =
+    Keeper_alerting_path.playground_path_of_keeper agent_name
+  in
+  let playground_abs_raw =
+    Filename.concat base_path playground_rel
+  in
+  let playground_abs =
+    try Unix.realpath playground_abs_raw with
+    | Unix.Unix_error _ -> playground_abs_raw
+  in
+  let effective_arg =
+    if String.trim working_dir_arg = "" then playground_abs
+    else working_dir_arg
+  in
+  let resolved =
+    try Ok (Unix.realpath effective_arg) with
+    | Unix.Unix_error _ ->
+        Error "working_dir does not exist or is not accessible"
+  in
+  match resolved with
+  | Error msg -> Error msg
+  | Ok working_dir ->
+      if is_safe_subpath ~parent:playground_abs ~child:working_dir then
+        Ok working_dir
+      else
+        Error
+          (Printf.sprintf
+             "working_dir must be inside your own keeper playground \
+              (%s). Cross-keeper repair loops are blocked — use \
+              masc_worktree_create to provision a workspace under your \
+              playground first. See #6527/#6641."
+             playground_rel)
+
 let handle_start (ctx : _ context) args : tool_result =
   let*! task_spec = get_string_required args "task_spec" in
   match resolve_plugin_id args with
   | Error message -> error_result message
   | Ok plugin_id ->
       let target_mode = resolve_target_mode args in
-      let working_dir_arg = get_string args "working_dir" (Sys.getcwd ()) in
+      let working_dir_arg = get_string args "working_dir" "" in
       let target_file = get_string_opt args "target_file" in
-      (* Normalize current workspace root. *)
-      let cwd_root =
-        try Unix.realpath (Sys.getcwd ()) with
-        | Unix.Unix_error _ -> Sys.getcwd ()
-      in
-      (* Normalize and validate working_dir. *)
-      let resolved_working_dir_result =
-        try Ok (Unix.realpath working_dir_arg) with
-        | Unix.Unix_error _ ->
-            Error "working_dir does not exist or is not accessible"
-      in
-      (match resolved_working_dir_result with
+      (match
+         resolve_playground_working_dir
+           ~agent_name:ctx.agent_name
+           ~base_path:ctx.config.base_path
+           ~working_dir_arg
+       with
       | Error msg -> error_result msg
       | Ok working_dir ->
-          if not (is_safe_subpath ~parent:cwd_root ~child:working_dir) then
-            error_result "working_dir must be within the current workspace"
-          else
-            match validate_target_file ~working_dir ~target_file with
+          begin match validate_target_file ~working_dir ~target_file with
             | Error msg -> error_result msg
             | Ok validated_target_file ->
                 let validator_profile =
@@ -301,7 +336,8 @@ let handle_start (ctx : _ context) args : tool_result =
                         ( "target_mode",
                           `String (target_mode_to_string state.target_mode) );
                       ]);
-                  (true, state_json_string state))
+                  (true, state_json_string state)
+          end)
 
 let handle_status (ctx : _ context) args : tool_result =
   let*! loop_id = get_string_required args "loop_id" in

--- a/test/dune
+++ b/test/dune
@@ -583,6 +583,7 @@
         test_ag_ui_coverage test_tool_verification_coverage
         test_tool_suspend_coverage test_tool_code_coverage
         test_tool_code_write_coverage
+        test_tool_repair_loop_containment
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
         test_anti_rationalization_coverage test_field_validation)
@@ -618,6 +619,7 @@
         test_ag_ui_coverage test_tool_verification_coverage
         test_tool_suspend_coverage test_tool_code_coverage
         test_tool_code_write_coverage
+        test_tool_repair_loop_containment
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
         test_anti_rationalization_coverage test_field_validation)

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -655,9 +655,17 @@ let test_world_prompt_distinguishes_playground_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.world" in
   check bool "world prompt names playground sandbox" true
     (contains_substring prompt "Playground is your default sandbox");
-  check bool "world prompt names worktree workflow" true
+  (* #6648 iter9 — the worktree sentence was rewritten to place
+     worktrees *inside* the playground clone, closing the prompt-side
+     drift that iter1~iter8 left in place. Assert the new canonical
+     phrase so a future regression does not re-introduce the bare
+     server-root `.worktrees/` form. *)
+  check bool "world prompt names worktree workflow inside playground" true
     (contains_substring prompt
-       "Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`")
+       "Repo worktrees live *inside* your playground clone");
+  check bool "world prompt names canonical playground-rooted worktree path" true
+    (contains_substring prompt
+       ".masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/")
 
 let test_system_prompt_prefers_submit_over_legacy_workflow () =
   let sys =

--- a/test/test_tool_repair_loop_containment.ml
+++ b/test/test_tool_repair_loop_containment.ml
@@ -1,0 +1,184 @@
+(** Coverage tests for #6641 iter10 — per-agent playground containment
+    in [Tool_repair_loop.resolve_playground_working_dir].
+
+    These tests exercise the shared helper directly (flat field
+    signature — no Eio context, no Room config fixture) so that both
+    [Tool_repair_loop.handle_start] and [Tool_keeper.handle_keeper_repair]
+    inherit the same containment guarantees via a single unit-tested
+    function. *)
+
+open Masc_mcp
+
+let () = Printf.printf "\n=== Tool_repair_loop containment (#6641 iter10) ===\n"
+
+(* macOS canonicalises [$TMPDIR] through a symlink (`/var/folders/...`
+   vs `/private/var/folders/...`), which trips `String.starts_with` on
+   `playground_abs` when comparing against a realpath-ed child. Use
+   [Unix.realpath] on the tmp dir immediately so every downstream
+   [Unix.realpath] call returns a prefix that matches. *)
+let fresh_base_path ~tag =
+  let raw =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-repair-loop-containment-%s-%d" tag
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  Unix.mkdir raw 0o755;
+  try Unix.realpath raw with Unix.Unix_error _ -> raw
+
+let mkdir_p path =
+  let rec go acc = function
+    | [] -> ()
+    | head :: rest ->
+        let next = Filename.concat acc head in
+        (if not (Sys.file_exists next) then Unix.mkdir next 0o755);
+        go next rest
+  in
+  match String.split_on_char '/' path with
+  | "" :: parts -> go "/" parts
+  | parts -> go (Sys.getcwd ()) parts
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  nlen = 0 || loop 0
+
+let test name f =
+  try
+    f ();
+    Printf.printf "✓ %s passed\n" name
+  with e ->
+    Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
+    exit 1
+
+(* Build a tmp [base_path] with two keeper playgrounds + an
+   out-of-playground sibling dir so each branch of the gate can be
+   exercised. Returns [(base_path, own_abs, other_abs, outside_abs)]. *)
+let make_fixture ~tag =
+  let base_path = fresh_base_path ~tag in
+  let own_rel = ".masc/playground/agent-alpha" in
+  let other_rel = ".masc/playground/agent-beta" in
+  let outside_rel = "outside" in
+  mkdir_p (Filename.concat base_path own_rel);
+  mkdir_p (Filename.concat base_path other_rel);
+  mkdir_p (Filename.concat base_path outside_rel);
+  let own_abs =
+    try Unix.realpath (Filename.concat base_path own_rel)
+    with Unix.Unix_error _ -> Filename.concat base_path own_rel
+  in
+  let other_abs =
+    try Unix.realpath (Filename.concat base_path other_rel)
+    with Unix.Unix_error _ -> Filename.concat base_path other_rel
+  in
+  let outside_abs =
+    try Unix.realpath (Filename.concat base_path outside_rel)
+    with Unix.Unix_error _ -> Filename.concat base_path outside_rel
+  in
+  (base_path, own_abs, other_abs, outside_abs)
+
+(* 1. Empty [working_dir_arg] defaults to the caller's own playground.
+      Regression gate for the former [Sys.getcwd ()] default. *)
+let () =
+  test "empty_working_dir_defaults_to_own_playground" (fun () ->
+    let base_path, own_abs, _other, _outside = make_fixture ~tag:"empty" in
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:""
+    with
+    | Ok resolved ->
+        assert (resolved = own_abs)
+    | Error msg ->
+        failwith (Printf.sprintf "expected Ok, got Error %S" msg))
+
+(* 2. Whitespace-only [working_dir_arg] also defaults to own playground —
+      pins the [String.trim] behaviour so a regression that drops trim
+      does not fall through to [Unix.realpath ""]. *)
+let () =
+  test "whitespace_working_dir_defaults_to_own_playground" (fun () ->
+    let base_path, own_abs, _other, _outside = make_fixture ~tag:"ws" in
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:"   "
+    with
+    | Ok resolved -> assert (resolved = own_abs)
+    | Error msg ->
+        failwith (Printf.sprintf "expected Ok, got Error %S" msg))
+
+(* 3. A path under the caller's own playground is accepted. *)
+let () =
+  test "own_playground_subpath_accepted" (fun () ->
+    let base_path, own_abs, _other, _outside = make_fixture ~tag:"own_sub" in
+    let sub = Filename.concat own_abs "repos" in
+    Unix.mkdir sub 0o755;
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:sub
+    with
+    | Ok resolved ->
+        let sub_real =
+          try Unix.realpath sub with Unix.Unix_error _ -> sub
+        in
+        assert (resolved = sub_real)
+    | Error msg ->
+        failwith (Printf.sprintf "expected Ok, got Error %S" msg))
+
+(* 4. A path under another keeper's playground is rejected with a
+      clear cross-keeper message that names the SSOT playground path. *)
+let () =
+  test "cross_keeper_playground_rejected" (fun () ->
+    let base_path, _own, other_abs, _outside = make_fixture ~tag:"cross" in
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:other_abs
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected Error, got Ok %S — cross-keeper write not gated"
+             resolved)
+    | Error msg ->
+        assert (contains_substring msg "your own keeper playground");
+        assert (contains_substring msg "Cross-keeper repair loops");
+        assert (contains_substring msg "agent-alpha"))
+
+(* 5. A path completely outside any playground is rejected. *)
+let () =
+  test "outside_playground_rejected" (fun () ->
+    let base_path, _own, _other, outside_abs = make_fixture ~tag:"outside" in
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:outside_abs
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected Error, got Ok %S — outside-playground accepted"
+             resolved)
+    | Error msg ->
+        assert (contains_substring msg "your own keeper playground"))
+
+(* 6. A non-existent [working_dir_arg] returns the "does not exist"
+      error, not the containment error — so the LLM can distinguish
+      "typo in path" from "tried to reach another keeper". *)
+let () =
+  test "nonexistent_working_dir_returns_not_accessible" (fun () ->
+    let base_path, _own, _other, _outside =
+      make_fixture ~tag:"nonexistent"
+    in
+    let bogus = Filename.concat base_path ".masc/playground/agent-alpha/absent-dir" in
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:bogus
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf "expected Error for bogus path, got Ok %S" resolved)
+    | Error msg ->
+        assert (contains_substring msg "does not exist"))
+
+let () = Printf.printf "\n✅ All Tool_repair_loop containment tests passed!\n"

--- a/test/test_tool_repair_loop_containment.ml
+++ b/test/test_tool_repair_loop_containment.ml
@@ -181,4 +181,32 @@ let () =
     | Error msg ->
         assert (contains_substring msg "does not exist"))
 
+(* 7. If the caller's playground bundle does not exist yet, the
+      helper must fail closed with an explicit error naming the
+      playground path and the recovery action. Pre-iter10 code
+      silently fell back to the raw non-realpath'd parent, which
+      on macOS symlink-heavy filesystems could yield a false accept.
+      Regression gate for GLM-5.1 MEDIUM finding on PR #6651. *)
+let () =
+  test "missing_playground_fails_closed" (fun () ->
+    let base_path = fresh_base_path ~tag:"missing_pg" in
+    (* Intentionally do NOT create `.masc/playground/agent-alpha/`.
+       The caller has no playground bundle yet — every request must
+       be rejected with an actionable error, not silently accepted. *)
+    let sibling = Filename.concat base_path "some-dir" in
+    Unix.mkdir sibling 0o755;
+    match
+      Tool_repair_loop.resolve_playground_working_dir
+        ~agent_name:"agent-alpha" ~base_path ~working_dir_arg:sibling
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected fail-closed Error on missing playground, got Ok %S"
+             resolved)
+    | Error msg ->
+        assert (contains_substring msg "playground directory");
+        assert (contains_substring msg "does not exist");
+        assert (contains_substring msg "masc_worktree_create"))
+
 let () = Printf.printf "\n✅ All Tool_repair_loop containment tests passed!\n"


### PR DESCRIPTION
## Summary

Closes #6641. **Iter10** of the #6527 playground containment trilogy — targets the repair loop dispatcher family (`masc_repair_loop_start`, `masc_keeper_repair`) that iter1~iter8 missed. Same fix shape as iter6 #6610 (`validate_writable_path ~agent_name`) applied to a new dispatcher family.

**⚠️ WIP — tests pending.** Base fix and local build are green; tests for the new gate will follow in the same PR before Ready transition.

Discovered by `/loop` tick 17 sweep `rg 'get_string args "cwd"|get_string args "working_dir"' lib/` — the same methodology that found iter9 #6644 in tick 18 and #6637 in tick 16.

## Product impact

`Tool_repair_loop.handle_start` and `Tool_keeper.handle_keeper_repair` both defaulted `working_dir` to `Sys.getcwd ()` and validated against `cwd_root = Sys.getcwd ()`. Any subdirectory of the server repo root passes — including foreign playground clones. Keeper-A could call:

```json
{
  "tool": "masc_repair_loop_start",
  "args": {
    "task_spec": "…anything…",
    "working_dir": ".masc/playground/keeper-B/repos/masc-mcp",
    "target_mode": "repo",
    "target_file": "lib/foo.ml"
  }
}
```

The repair loop would then run its LLM generator + validator on keeper-B's workspace: writing files into keeper-B's playground, building under keeper-B's dune root. Cross-keeper containment violation with the same shape as #6527 iter1 (worktree server-root fallback), iter3 (shell write gate), iter6 (tool_code_write per-agent).

**Importance**: `masc_keeper_repair` is actively used by the repair loop subsystem as a delegated tool. Containment leak here translates directly to cross-keeper code pollution — keeper-A's LLM generations end up in keeper-B's workspace and may be silently committed/pushed as keeper-B's work.

## Evidence

Shared helper `Tool_repair_loop.resolve_playground_working_dir` takes three flat fields (`~agent_name`, `~base_path`, `~working_dir_arg`) so both `Tool_repair_loop_types.context` and `Keeper_types.context` callers can share it without type unification. The two context types have different shapes (`sw/clock` option vs required, `net` only in keeper), so row polymorphism would have been awkward — flat field arguments are the simplest lowest-coupling design.

```ocaml
let resolve_playground_working_dir
    ~agent_name ~base_path ~working_dir_arg =
  let playground_rel =
    Keeper_alerting_path.playground_path_of_keeper agent_name
  in
  let playground_abs =
    try Unix.realpath (Filename.concat base_path playground_rel)
    with Unix.Unix_error _ -> Filename.concat base_path playground_rel
  in
  let effective_arg =
    if String.trim working_dir_arg = "" then playground_abs
    else working_dir_arg
  in
  match (try Ok (Unix.realpath effective_arg)
         with Unix.Unix_error _ -> Error "…") with
  | Error msg -> Error msg
  | Ok wd ->
      if is_safe_subpath ~parent:playground_abs ~child:wd
      then Ok wd
      else Error (cross-keeper rejection with SSOT playground_rel)
```

Both call sites:
1. Default `working_dir` to `""` instead of `Sys.getcwd ()`. Empty resolves to caller's own playground.
2. Delegate resolution + validation to the shared helper.
3. Drop local `cwd_root = Sys.getcwd ()` code entirely.

**Build result (local, worktree root)**:
```
$ opam exec -- dune build --root . @check
(clean, exit 0)
```

No new warnings. `validate_target_file` still called downstream and its error path is preserved via nested `begin ... end match` to avoid OCaml's nested-match pattern ambiguity.

## Review evidence

Cross-model review via `sb glm-text` pending — will post results in a followup comment before adding tests.

**Intended review focus** (for GLM and human reviewers):
1. **Correctness of the per-agent gate**: does `is_safe_subpath ~parent:playground_abs ~child:wd` correctly reject `.masc/playground/<other>/repos/...` paths? Edge cases: symlinks, `..` traversal, case-insensitive filesystems.
2. **Helper signature choice**: is flat field-based the right call vs. a row-polymorphic record or a separate module-level record type?
3. **Default-empty-string behaviour**: is it safe to change the default from `Sys.getcwd ()` to `""`? Any caller today that relies on the `Sys.getcwd ()` default?
4. **Nested match syntax**: `begin match validate_target_file ... end` wrapping is correct but slightly unusual. Could be cleaner with a `let*` ppx or an extraction into a separate function.
5. **Keeper_repair meta handling**: `handle_keeper_repair` uses `ctx.agent_name` rather than `meta.name`/`meta.runtime.keeper_name`. This is intentional — the actual caller identity is the authority, not the meta lookup target. Worth a comment in code or an explicit acknowledgment here.

## Linked issue

Closes #6641.

Parent trilogy: #6527. Prior iterations:
- #6542 iter1 — `tool_worktree` server-root fallback fix
- #6579 iter3 — `keeper_exec_shell` write_outside_playground_blocked
- #6580 iter4 — `effective_allowed_paths` `.worktrees/` removal
- #6610 iter6 — `tool_code_write.validate_writable_path ~agent_name`
- #6617 iter7 — `tool_worktree.ml` agent_name spoof rejection
- #6627 iter8 — `tool_auth` cross-agent gate on initial_admin
- #6648 iter9 — prompt-layer drift fix (merged)
- **this PR — iter10** — `tool_repair_loop` + `tool_keeper.handle_keeper_repair`

Sibling issue also pending approval: #6637 (`tool_code.ml` read-side cross-keeper exfiltration).

Methodology memory: `feedback_structural-bug-class-rg-sweep.md`.
