### PR TITLE
fix(rng): guard module-level Random.State with Eio.Mutex in 3 modules

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -10,8 +10,17 @@
     @since 0.5.0
 *)
 
-(* Fiber-safe random state for UUID generation *)
+(* UUID / random generation.  [Random.State.t] is NOT fiber-safe —
+   concurrent [Random.State.int] or [Uuidm.v4_gen] calls against a
+   shared state can produce duplicate values or corrupt internal
+   state.  The previous doc comment claiming "Fiber-safe" was
+   incorrect.  Guard the shared state with an [Eio.Mutex] and route
+   every RNG access through [with_identity_rng].  Same discipline
+   used by [Lib.A2a_tools] ([a2a_rng] / [a2a_rng_mutex]). *)
 let identity_rng = Random.State.make_self_init ()
+let identity_rng_mutex = Eio.Mutex.create ()
+let with_identity_rng f =
+  Eio.Mutex.use_ro identity_rng_mutex (fun () -> f identity_rng)
 
 (** {1 Core Types} *)
 
@@ -82,7 +91,7 @@ type t = {
 (** Generate a unique agent UUID from name + timestamp hash *)
 let generate_uuid ~agent_name =
   let timestamp = Time_compat.now () in
-  let random_part = Random.State.int identity_rng 0xFFFFFF in
+  let random_part = with_identity_rng (fun rng -> Random.State.int rng 0xFFFFFF) in
   let input = Printf.sprintf "%s-%f-%d" agent_name timestamp random_part in
   (* Simple hash-based UUID: first 8 chars of hex digest *)
   let hash = Digest.string input |> Digest.to_hex in
@@ -92,7 +101,7 @@ let generate_uuid ~agent_name =
 
 (** Generate a unique session key *)
 let generate_session_key () =
-  let uuid = Uuidm.v4_gen identity_rng () in
+  let uuid = with_identity_rng (fun rng -> Uuidm.v4_gen rng ()) in
   Uuidm.to_string uuid
 
 (** Create identity from MCP request params *)

--- a/lib/mention_inbox.ml
+++ b/lib/mention_inbox.ml
@@ -19,12 +19,19 @@ type mention_record = {
 
 (** {1 ID Generation} *)
 
-(* Fiber-safe random state *)
+(* RNG for mention-id generation.  [Random.State.t] is NOT fiber-safe —
+   the previous doc comment claiming otherwise was incorrect.  Guard
+   the shared state with an [Eio.Mutex] and route every RNG access
+   through [with_mention_rng].  Same discipline as [Lib.A2a_tools]
+   ([a2a_rng] / [a2a_rng_mutex]). *)
 let mention_rng = Random.State.make_self_init ()
+let mention_rng_mutex = Eio.Mutex.create ()
+let with_mention_rng f =
+  Eio.Mutex.use_ro mention_rng_mutex (fun () -> f mention_rng)
 
 let generate_mention_id () =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
-  let rand = Random.State.int mention_rng 10000 in
+  let rand = with_mention_rng (fun rng -> Random.State.int rng 10000) in
   Printf.sprintf "m-%d-%04d" ts rand
 
 (** {1 JSON Serialization} *)

--- a/lib/room/nickname.ml
+++ b/lib/room/nickname.ml
@@ -20,19 +20,30 @@ let animals = [|
   "orca"; "rhino"; "sloth"; "tapir"; "zebra";
 |]
 
-(* Fiber-safe random state for nickname generation *)
+(* RNG for nickname generation.  [Random.State.t] is NOT fiber-safe —
+   the previous doc comment claiming otherwise was incorrect.  Guard
+   the shared state with an [Eio.Mutex] and route every RNG access
+   through [with_nickname_rng].  Same discipline as [Lib.A2a_tools]
+   ([a2a_rng] / [a2a_rng_mutex]). *)
 let nickname_rng = Random.State.make_self_init ()
+let nickname_rng_mutex = Eio.Mutex.create ()
+let with_nickname_rng f =
+  Eio.Mutex.use_ro nickname_rng_mutex (fun () -> f nickname_rng)
 
 (** Generate a short random suffix (4 hex chars) for uniqueness *)
 let random_suffix () =
-  Printf.sprintf "%04x" (Random.State.int nickname_rng 0xFFFF)
+  Printf.sprintf "%04x"
+    (with_nickname_rng (fun rng -> Random.State.int rng 0xFFFF))
 
 (** Generate a unique nickname for an agent type.
     Format: {agent_type}-{adjective}-{animal}
     Example: claude-swift-fox, gemini-brave-tiger *)
 let generate agent_type =
-  let adj = adjectives.(Random.State.int nickname_rng (Array.length adjectives)) in
-  let animal = animals.(Random.State.int nickname_rng (Array.length animals)) in
+  let adj, animal =
+    with_nickname_rng (fun rng ->
+      ( adjectives.(Random.State.int rng (Array.length adjectives)),
+        animals.(Random.State.int rng (Array.length animals)) ))
+  in
   Printf.sprintf "%s-%s-%s" agent_type adj animal
 
 (** Generate with suffix for guaranteed uniqueness.


### PR DESCRIPTION

`Random.State.t` is **not** fiber-safe under OCaml 5's memory model
— concurrent `Random.State.int` / `Uuidm.v4_gen` calls against a
shared state can produce duplicate values or corrupt internal state
(stdlib documentation + Jane Street guidance).

Three modules had module-level `Random.State.make_self_init ()` with
doc comments explicitly labelling them "Fiber-safe random state":

| Module | Callers |
|---|---|
| `lib/agent_identity.ml` | `from_mcp_params` on every MCP identity lookup; `from_agent_name` / `anonymous` on fallback paths |
| `lib/room/nickname.ml` | `generate` / `generate_unique` / `random_suffix` on every new keeper / agent registration |
| `lib/mention_inbox.ml` | `generate_mention_id` on every mention insert |

The "Fiber-safe" doc label was wrong on all three.  All three are
called from per-request fibers (MCP tool handlers, gate inbound,
keeper lifecycle) and can race on a busy server.  Symptoms:

- Duplicate agent UUIDs under a burst of `from_mcp_params` calls.
- Duplicate session keys under a burst of `generate_session_key`.
- Duplicate nicknames on a burst keeper spawn.
- Duplicate mention IDs on a burst of mentions (the `ts` prefix
  gives a 1 ms window where `Random.State.int rng 10000` would
  have to not collide).

None of the symptoms are catastrophic individually — downstream
code mostly treats identifiers as opaque — but duplicate session
keys in particular can cause an agent to overwrite another's
registry entry on `Registry.register`, and duplicate UUIDs break
any downstream log correlation or auditing.

## Fix

Pattern cloned from `lib/a2a_tools.ml` (lines 118-125), which
already had the correct discipline:

```ocaml
(* Mutex-protected for fiber safety (Random.State is mutable). *)
let a2a_rng = Random.State.make_self_init ()
let a2a_rng_mutex = Eio.Mutex.create ()
let generate_uuid () =
  Eio.Mutex.use_ro a2a_rng_mutex (fun () ->
    let uuid = Uuidm.v4_gen a2a_rng () in
    Uuidm.to_string uuid)
```

Each of the three modules now has a `<name>_rng_mutex` and a
`with_<name>_rng` helper that wraps every `Random.State.*` /
`Uuidm.v4_gen` call in `Eio.Mutex.use_ro <mutex>`.  The mutex is
held only for the duration of the RNG call (nanoseconds), so
contention is negligible even under burst load.  All other code
in these modules is unchanged.

Updated doc comments to drop the incorrect "Fiber-safe" label and
instead explain the mutex discipline.

## Not touched

- `lib/dashboard/dashboard_governance_judge.ml:281` creates a
  fresh `Random.State.make_self_init ()` on every call.  Expensive
  (re-reads `/dev/urandom` each time) but not racy — each call has
  its own state.  Separate performance cleanup if desired.
- `lib/server/server_routes_http_pages.ml:313` has a local
  `let rng = Random.State.make_self_init ()` inside a single
  function call, not shared across fibers.  Safe as-is.
- All `Mirage_crypto_rng.generate` call sites are already fiber-safe
  (the crypto RNG is internally synchronized) and do not need
  changes.

## Verification

```
dune build --root . @lib/check                          # exit 0
dune exec --root . -- ./test/test_agent_identity.exe    # 32/32 passed
dune exec --root . -- ./test/test_nickname_coverage.exe # 16/16 passed
dune exec --root . -- ./test/test_mention.exe           # 14/14 passed
```

Existing tests cover the happy path for UUID / session-key /
nickname / mention-id generation.  A concurrent-collision
regression test is out of scope for this PR — the fix eliminates a
class of rare race, which the existing test suite cannot provoke
deterministically without a scheduler harness.

## Finding source

Cycle 34 of the masc-mcp audit sweep.  Deep-read target was
`lib/agent_identity.ml`; the `identity_rng` line jumped out
because the doc comment explicitly asserted a property that the
stdlib contract denies.  A cross-module `rg -n "Random\.State"
lib/` then surfaced the two sibling modules with identical
mislabelled comments, and the in-tree `a2a_tools.ml` precedent
confirmed the correct discipline.

Audit heuristic added: when a doc comment makes a concurrency
safety claim ("fiber-safe", "thread-safe", "lock-free"), validate
it against the stdlib contract of the underlying primitive.  If
the primitive is `Random.State.t`, `Hashtbl.t`, `Buffer.t`, `Queue.t`,
or any other mutable stdlib type, the default is NOT safe, and the
doc must be backed by a mutex or a domain-local binding.  Every
"Fiber-safe `Random.State`" in the codebase is a potential bug.