### PR TITLE
fix(keeper_checkpoint_store): classify Eio.Io Fs Not_found as Not_found

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -157,11 +157,48 @@ type checkpoint_load_error =
   | Parse_error of string
   | Io_error of string
 
+(* Checkpoint-load failures classify as [Not_found] only when the
+   underlying SDK error is genuinely "this file does not exist on first
+   boot" — any other I/O problem should stay [Io_error] so we keep the
+   detail in the error log.
+
+   The matching surface is fragile because [Agent_sdk] serializes
+   filesystem failures via [Printexc.to_string] inside
+   [FileOpFailed.detail] (see oas/lib/fs_result.ml), so we pattern-match
+   on the rendered strings of every exception constructor the OAS
+   wrapper produces:
+
+   - [Eio.Io (Fs Not_found _)] → "Eio.Io Fs Not_found Unix_error ..."
+   - [Unix.Unix_error (ENOENT, _, _)] → "Unix_error(ENOENT, ...)"
+   - [Sys_error "..."] → "No such file or directory: ..."
+   - legacy masc-mcp path that stored just "no_such_file" as detail
+
+   The [has_substring] fallback catches the canonical ENOENT phrase
+   anywhere in the rendered string so that wrapper layers that prepend
+   context (e.g. [sprintf "load %s: %s" path ...]) still classify
+   correctly. *)
 let is_not_found_detail (detail : string) : bool =
   let d = String.lowercase_ascii detail in
-  String.starts_with ~prefix:"no_such_file" d  (* Eio.Fs.Not_found *)
+  (* Local to keep [Keeper_checkpoint_store] surface free of a generic
+     string helper — this module has no .mli so every top-level [let]
+     is exported. *)
+  let has_substring haystack needle =
+    let hl = String.length haystack and nl = String.length needle in
+    if nl = 0 then true
+    else if nl > hl then false
+    else
+      let rec loop i =
+        if i + nl > hl then false
+        else if String.sub haystack i nl = needle then true
+        else loop (i + 1)
+      in
+      loop 0
+  in
+  String.starts_with ~prefix:"no_such_file" d  (* legacy masc-mcp path *)
   || String.starts_with ~prefix:"no such file" d
   || String.starts_with ~prefix:"unix_error (enoent" d  (* POSIX *)
+  || String.starts_with ~prefix:"eio.io fs not_found" d  (* Eio.Io (Fs Not_found _) *)
+  || has_substring d "no such file or directory"
 
 let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   match e with

--- a/test/dune
+++ b/test/dune
@@ -646,6 +646,13 @@
  (name test_cp_unit_descendant_ids)
  (libraries masc_test_deps))
 
+; Keeper_checkpoint_store.is_not_found_detail classifier
+; regression (observed 334-retry loop on trace-1775487505102-6a347
+; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)
+(test
+ (name test_keeper_checkpoint_classify)
+ (libraries masc_test_deps))
+
 ; Operator Control (7 modules)
 (test
  (name test_operator_control)

--- a/test/test_keeper_checkpoint_classify.ml
+++ b/test/test_keeper_checkpoint_classify.ml
@@ -1,0 +1,102 @@
+(** Regression tests for [Keeper_checkpoint_store.is_not_found_detail]
+    and [classify_sdk_error] (#6654 follow-up).
+
+    Background: on 2026-04-12 /loop observed a keeper logging 334
+    copies of [OAS checkpoint I/O error: file load failed on
+    trace-1775487505102-6a347: Eio.Io Fs Not_found Unix_error (No such
+    file or directory, "openat", ...)] in a tight retry loop. The
+    expected behavior for a missing trace checkpoint is a silent
+    [Not_found] classification so the keeper either takes a cold boot
+    path or moves on. Instead the classifier fell through to
+    [Io_error], which [keeper_context_core.ml] treats as a non-trivial
+    failure worth logging at every retry.
+
+    Root cause: [Agent_sdk.Error.FileOpFailed.detail] is populated by
+    [Printexc.to_string] in [oas/lib/fs_result.ml], so an Eio filesystem
+    ENOENT renders as literally [Eio.Io Fs Not_found Unix_error ...].
+    [is_not_found_detail] only matched three legacy prefixes
+    ([no_such_file], [no such file], [unix_error (enoent]) and never
+    recognized the rendered Eio exception string.
+
+    These tests lock the classifier to:
+    - the three legacy prefixes (regression guard)
+    - the Eio.Io rendered form observed in production
+    - a canonical "no such file or directory" substring anywhere in
+      the detail (robust against wrapper layers prepending context) *)
+
+module Store = Masc_mcp.Keeper_checkpoint_store
+
+let check_not_found name detail =
+  Alcotest.(check bool) name true (Store.is_not_found_detail detail)
+
+let check_not_classified_as_not_found name detail =
+  Alcotest.(check bool) name false (Store.is_not_found_detail detail)
+
+(* ─── Legacy prefixes (regression guard) ─────────────────────── *)
+
+let test_legacy_no_such_file_prefix () =
+  check_not_found "no_such_file underscore prefix (legacy)"
+    "no_such_file: trace-xyz"
+
+let test_legacy_no_such_file_space_prefix () =
+  check_not_found "no such file prefix"
+    "No such file or directory"
+
+let test_legacy_unix_error_prefix () =
+  check_not_found "unix_error(enoent prefix (POSIX)"
+    "Unix_error (ENOENT, \"openat\", \"/tmp/x\")"
+
+(* ─── Regression: Eio.Io rendered form from Printexc ─────────── *)
+
+let test_eio_io_fs_not_found_rendered () =
+  (* Exact detail string observed in /tmp/masc-6647-restart2.log for
+     trace-1775487505102-6a347 — the keeper looping fix target. *)
+  check_not_found
+    "Eio.Io Fs Not_found Unix_error rendered by Printexc.to_string"
+    "Eio.Io Fs Not_found Unix_error (No such file or directory, \
+     \"openat\", \"/Users/dancer/me/.masc/traces/trace-123/trace-123.json\"), \
+     \n  opening <fs:/Users/dancer/me/.masc/traces/trace-123/trace-123.json>"
+
+(* ─── Substring fallback: wrapper layers may prepend context ──── *)
+
+let test_substring_embedded_no_such_file () =
+  check_not_found
+    "substring match for 'no such file or directory' anywhere in detail"
+    "load trace-abc: wrapped error: Sys_error \
+     \"/path/trace.json: No such file or directory\""
+
+(* ─── Negative cases ─────────────────────────────────────────── *)
+
+let test_parse_error_not_misclassified () =
+  check_not_classified_as_not_found
+    "JSON parse error must stay classified as Parse_error"
+    "JSON error: Unexpected end of input"
+
+let test_permission_denied_not_misclassified () =
+  check_not_classified_as_not_found
+    "permission denied must stay classified as Io_error"
+    "Unix_error (EACCES, \"openat\", \"/path/trace.json\")"
+
+let () =
+  Alcotest.run "Keeper_checkpoint_classify"
+    [
+      ( "is_not_found_detail",
+        [
+          Alcotest.test_case "legacy no_such_file underscore prefix" `Quick
+            test_legacy_no_such_file_prefix;
+          Alcotest.test_case "legacy 'No such file' prefix" `Quick
+            test_legacy_no_such_file_space_prefix;
+          Alcotest.test_case "legacy Unix_error(ENOENT prefix" `Quick
+            test_legacy_unix_error_prefix;
+          Alcotest.test_case
+            "Eio.Io Fs Not_found Unix_error rendered (regression)"
+            `Quick test_eio_io_fs_not_found_rendered;
+          Alcotest.test_case
+            "'no such file or directory' substring match" `Quick
+            test_substring_embedded_no_such_file;
+          Alcotest.test_case "JSON parse error not misclassified" `Quick
+            test_parse_error_not_misclassified;
+          Alcotest.test_case "EACCES not misclassified" `Quick
+            test_permission_denied_not_misclassified;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- /loop on 2026-04-12 observed a keeper spamming **334** copies of the same checkpoint-not-found ERROR for `trace-1775487505102-6a347` in `/tmp/masc-6647-restart2.log`. Trace dir existed but was empty (first-boot).
- Root cause: `Keeper_checkpoint_store.is_not_found_detail` only matched three legacy prefixes and missed the `Eio.Io Fs Not_found Unix_error (...)` form that `Agent_sdk.Error.FileOpFailed.detail` actually contains — the detail is populated by `Printexc.to_string` in `oas/lib/fs_result.ml:11`, so every filesystem ENOENT comes through as a string starting with `Eio.Io Fs Not_found ...`.
- Because the classifier returned `Io_error` instead of `Not_found`, `keeper_context_core.ml:389` logged an error every retry, drowning signal. The fix makes the classifier recognize both the Eio-rendered form and a canonical `"no such file or directory"` substring anywhere in the detail.

## Before / after on production log
Before: 334 `[ERROR] [Keeper] ... OAS checkpoint I/O error: file load failed on ...: Eio.Io Fs Not_found Unix_error (...)` lines.
After (local test): first-boot keeper with no checkpoint logs nothing at ERROR level (per `keeper_context_core.ml:390` which suppresses the `Not_found` branch explicitly).

## Details
`is_not_found_detail` now checks four prefixes (three legacy + `eio.io fs not_found`) plus a substring fallback for `"no such file or directory"` anywhere in the detail. The substring fallback is defensive against wrapper layers that prepend context (e.g. `sprintf "load %s: %s" path detail`). `has_substring` is a local binding inside `is_not_found_detail` to avoid polluting the module's public API (there is no `.mli` gate on this module).

## Scope note
This is a string-based workaround. The root cause is OAS serializing filesystem failures through `Printexc.to_string` rather than exposing a typed `Not_found` variant in `Error.sdk_error`. The long-term fix belongs upstream in OAS; this PR stops the log spam immediately.

## Test plan
- [x] Added `test/test_keeper_checkpoint_classify.ml` with 7 cases:
  - three legacy prefixes (regression guard — don't break existing paths)
  - the exact Eio.Io rendered string observed in the production log
  - `"no such file or directory"` substring embedded in a wrapper message
  - JSON parse error negative case (must stay `Parse_error`)
  - EACCES negative case (must stay `Io_error`)
- [x] `dune exec test/test_keeper_checkpoint_classify.exe` → 7/7 PASS
- [x] `dune build bin/main_eio.exe` green
- [x] Cross-model review: **GLM-5.1 → "Clean, ship it"** (7 review criteria, all resolved; `has_substring` moved to local binding per reviewer feedback)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)