### PR TITLE
fix(test): sync unified_prompt tests to post-#6644/#6645 contract

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -652,12 +652,25 @@ let test_capabilities_prompt_distinguishes_playground_and_worktree () =
     (contains_substring prompt "`keeper_pr_submit` is the canonical submit step")
 
 let test_world_prompt_distinguishes_playground_and_worktree () =
+  (* Post-#6644: worktrees now live INSIDE the playground clone instead
+     of being "a separate workflow path". The old literal substring
+     ["a separate workflow path under `.worktrees/<branch-or-task>/`"]
+     was removed in that fix because it was the exact drift teaching
+     server-root `.worktrees/` — the harness was rejecting those paths
+     as [write_outside_playground_blocked]. The test now pins the new
+     contract: the world prompt must still name playground as the
+     default sandbox, and must teach the canonical
+     [.masc/playground/{name}/repos/<REPO>/.worktrees/...] shape for
+     worktrees rather than a bare server-root path. *)
   let prompt = Prompt_registry.get_prompt "keeper.world" in
   check bool "world prompt names playground sandbox" true
     (contains_substring prompt "Playground is your default sandbox");
-  check bool "world prompt names worktree workflow" true
+  check bool "world prompt teaches canonical worktree path inside playground" true
     (contains_substring prompt
-       "Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`")
+       ".masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/");
+  check bool "world prompt rejects bare server-root .worktrees/" true
+    (contains_substring prompt
+       "Never use a bare `.worktrees/...` path")
 
 let test_system_prompt_prefers_submit_over_legacy_workflow () =
   let sys =
@@ -1749,6 +1762,28 @@ let test_sanitize_text_utf8_replaces_control_chars () =
     sanitized
 
 let test_prompt_sanitizes_control_chars () =
+  (* Post-#6645: [Keeper_unified_prompt.build_prompt] no longer calls
+     [Inference_utils.sanitize_text_utf8] on its output. Sanitization
+     for LLM-bound strings moved into the OAS pipeline boundaries in
+     oas v0.121.0 (oas#808): [user_prompt] in agent.ml, [system_prompt]
+     in pipeline.ml, and tool results in agent_turn.ml. The masc-mcp
+     [build_prompt] function is now expected to return raw text
+     verbatim, and the OAS pipeline is responsible for stripping
+     disallowed control chars before the request hits the wire.
+
+     The old form of this test asserted that [build_prompt] itself
+     produced sanitized output, which was a tautology after #6645.
+     What remains testable at this layer is:
+
+     1. Raw control-char input flows through [build_prompt] without
+        the function crashing or dropping content. (If the observation
+        fields contain [\000], the output must contain it verbatim —
+        the masc-mcp side is now purely structural.)
+     2. The sanitizer unit itself is still correct — that's covered by
+        [test_sanitize_text_utf8_replaces_control_chars] above, which
+        calls [Inference_utils.sanitize_text_utf8] directly.
+     3. The OAS pipeline contract is tested upstream in oas#808 and
+        is out of scope for this masc-mcp test file. *)
   let meta =
     { minimal_meta with
       instructions = "watch\000this";
@@ -1765,15 +1800,13 @@ let test_prompt_sanitizes_control_chars () =
         ];
     }
   in
-  let sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
-  check bool "system prompt sanitized" false
-    (contains_disallowed_control_char sys);
-  check bool "user prompt sanitized" false
-    (contains_disallowed_control_char user);
-  check bool "mention text preserved" true
-    (contains_substring user "ping pong");
-  check bool "board preview preserved" true
-    (contains_substring user "bad preview")
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
+  (* Structural assertion: raw control-char input flows through
+     unchanged (masc-mcp is no longer the sanitization point). *)
+  check bool "mention text still present (raw)" true
+    (contains_substring user "ping\001pong");
+  check bool "board preview still present (raw)" true
+    (contains_substring user "bad\127preview")
 
 let test_sanitize_messages_utf8_cleans_history_path () =
   let user_msg =


### PR DESCRIPTION
## Summary
main's Build and Test CI has been red since the #6644/#6645 merges yesterday (run 24291348412 and every PR CI inherited thereafter, including #6655). Two unified_prompt cases fail because the tests were not updated when intentional behavior changes landed:

- **case 5** (`world prompt distinguishes playground and worktree`) asserted a literal substring that #6644 intentionally removed — it was the exact drift teaching server-root `.worktrees/`.
- **case 26** (`prompt sanitizes control chars`) asserted that `Keeper_unified_prompt.build_prompt` output was sanitized, but #6645 removed those sanitize calls because OAS v0.121.0 (oas#808) centralizes UTF-8 sanitization at pipeline boundaries. The check became a tautology on removed code.

## Fixes
- **case 5** now pins the new contract: world prompt must (a) name playground as default sandbox, (b) teach the canonical `.masc/playground/{name}/repos/<REPO>/.worktrees/…` shape, (c) reject bare server-root `.worktrees/`. These directly reflect `config/prompts/keeper.world.md` post-#6644.
- **case 26** removes the `build_prompt`-level sanitize assertions (redundant after #6645), adds a block comment explaining the sanitization contract moved to OAS, and asserts the structural invariant that raw control-char input flows through `build_prompt` verbatim. The sanitizer itself is still covered by `test_sanitize_text_utf8_replaces_control_chars` immediately above.

## Scope
Test-only. No lib/ or prompt changes. No behavior change.

## Why not revert #6644/#6645
Both PRs landed correct product intent:
- #6644 fixed the harness-rejection drift where keepers were being taught bare `.worktrees/` paths and then hitting `write_outside_playground_blocked`.
- #6645 removed masc-mcp sanitize calls that were redundant after OAS v0.121.0 centralized sanitization at the pipeline boundaries. Reverting would re-introduce double-sanitization.

## Test plan
- [x] `dune exec test/test_keeper_unified.exe` → 160/160 pass locally, including the two previously-red cases
- [x] `dune build` green
- [ ] CI Build and Test green (primary blocking check)
- [ ] Other checks green

## Follow-ups (out of scope)
- File a note on oas#808 to confirm the pipeline-layer sanitize contract has an upstream regression test in OAS. If not, the masc-mcp side loses its end-to-end guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)