### PR TITLE
fix(sse): stop double-incrementing event_counter when ~id is passed

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -204,12 +204,33 @@ let cleanup_expired_events () =
   done;
   !count
 
-(** Format SSE event with optional ID and event type *)
+(** Format SSE event with optional ID and event type.
+
+    When [~id] is supplied the caller has already allocated the event
+    ID (typically via {!next_id}); this function must NOT touch the
+    counter, or the caller's allocation + this call's
+    [fetch_and_add] would leave [event_counter] 2× the number of
+    emitted events.  That drift also widens the window for the
+    broadcast_impl / send_to peek-then-format pattern: two fibers
+    that both peek the counter, both get the same value, and then
+    both pass it as [~id] would emit events with the **same** id,
+    breaking MCP SSE resumability (the [last_event_id] filter in
+    [get_events_after] skips by id, so a duplicate would be
+    dropped).
+
+    When [~id] is omitted (external callers in
+    [server_mcp_transport_http] / [server_mcp_transport_http_agui])
+    this function still allocates a fresh id atomically, preserving
+    their contract. *)
 let format_event ?id ?event_type data =
-  (* Atomic fetch_and_add: returns old value, we want new value so +1 *)
-  let new_id = Atomic.fetch_and_add event_counter 1 + 1 in
-  let id_line = Printf.sprintf "id: %d\n"
-    (match id with Some i -> i | None -> new_id) in
+  let effective_id =
+    match id with
+    | Some i -> i
+    | None ->
+        (* Atomic fetch_and_add: returns old value, we want new value so +1 *)
+        Atomic.fetch_and_add event_counter 1 + 1
+  in
+  let id_line = Printf.sprintf "id: %d\n" effective_id in
   let event_line = match event_type with
     | Some e -> Printf.sprintf "event: %s\n" e
     | None -> ""
@@ -455,7 +476,9 @@ let reap_dead_external_subscribers () =
 let broadcast_impl target json =
   let t0 = Time_compat.now () in
   let data = Yojson.Safe.to_string json in
-  let current_event_id = Atomic.get event_counter + 1 in
+  (* Atomically allocate the event id so two concurrent broadcasts
+     cannot observe the same peeked counter value and emit duplicates. *)
+  let current_event_id = next_id () in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
   buffer_event current_event_id event;
   (* Snapshot under read-lock *)
@@ -513,7 +536,8 @@ let broadcast_to target json = broadcast_impl target json
     Enqueues the event in the session's stream for asynchronous delivery. *)
 let send_to session_id json =
   let data = Yojson.Safe.to_string json in
-  let current_event_id = Atomic.get event_counter + 1 in
+  (* Atomic allocation — see [broadcast_impl] for rationale. *)
+  let current_event_id = next_id () in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
   buffer_event current_event_id event;
   let client_opt =


### PR DESCRIPTION

`Sse.format_event` always ran `Atomic.fetch_and_add event_counter 1`
even when the caller passed `~id:already_allocated_id`.  Two
consequences, both latent under the current single-domain Eio
cooperative scheduler but live as soon as a yield lands anywhere
in the broadcast fast path:

## Bug 1 — counter drift

```ocaml
let format_event ?id ?event_type data =
  let new_id = Atomic.fetch_and_add event_counter 1 + 1 in
  let id_line = Printf.sprintf "id: %d\n"
    (match id with Some i -> i | None -> new_id) in
  ...
```

`broadcast_impl` and `send_to` both compute the id themselves:

```ocaml
let current_event_id = Atomic.get event_counter + 1 in
let event = format_event ~id:current_event_id ~event_type:"message" data in
buffer_event current_event_id event;
```

Every successful broadcast increments `event_counter` **twice**:
once by the caller's `Atomic.get + 1` pattern (well, it peeks — no
increment yet), then once by `format_event`'s `fetch_and_add`.  The
caller's value (which is what ends up in `buffer_event`) is the
peeked `+1`, but the counter has advanced by 1.  Over N broadcasts
the counter ends up at N (peek doesn't mutate), the **last buffered
id is N**, and both `current_id ()` and `last_event_id` queries
against the counter agree with the buffered state — so the happy
path looks consistent.

That's the happy **sequential** path.

## Bug 2 — duplicate ids under concurrent broadcasts

The real bug only triggers when two fibers concurrently enter
`broadcast_impl` with no yield between the peek and
`format_event`:

- counter = 5
- T1: `Atomic.get + 1` → 6, stores in `current_event_id`
- T2: `Atomic.get + 1` → 6, stores in `current_event_id`  (same!)
- T1: `format_event ~id:6` — fetch_and_add gives 5, counter = 6, uses the passed id = 6
- T2: `format_event ~id:6` — fetch_and_add gives 6, counter = 7, uses the passed id = 6
- T1: `buffer_event 6 …`
- T2: `buffer_event 6 …` ← **duplicate id** in the buffer

Both events are appended to `event_buffer` with id = 6.  MCP SSE
resumability ([get_events_after last_id]) filters by `id > last_id`,
so on reconnect with `last_event_id = 5` both events are returned
(OK).  But on reconnect with `last_event_id = 6` **both are
dropped**, even though only one is actually "already delivered" to
the client — the client loses one event silently.

Under today's single-domain Eio scheduler there is no yield point
between the `Atomic.get` and the `format_event` call in either
`broadcast_impl` or `send_to` (both bodies are pure computation up
to that point), so the race does not fire in practice.  But any
future refactor that adds a `Log` call, a `debug_log`, or any
`Eio.*` call between those two lines makes it live, and the
behaviour is already incorrect under any future multi-domain
rollout.

## Fix

1. `format_event`: only `fetch_and_add` when `~id` is omitted.
   When the caller passes an id, use it as-is and leave the counter
   alone.  This preserves the external call sites in
   `server_mcp_transport_http` / `server_mcp_transport_http_agui`
   (all `format_event data` without `~id`) which still get the
   atomic allocation they rely on.

2. `broadcast_impl` and `send_to`: replace
   `Atomic.get event_counter + 1` with `next_id ()`, the existing
   helper that does a single `Atomic.fetch_and_add`.  Each event
   now has exactly one counter bump, allocated atomically, and
   `buffer_event` is called with the same id the counter was
   advanced to.

Doc comment on `format_event` now spells out the "caller owns the
id → do not touch the counter" contract so a future reader
doesn't re-introduce the double-increment.

## Verification

```
dune build --root . @lib/check                   # exit 0
dune exec --root . -- ./test/test_sse_coverage.exe # 29/29 passed
```

The existing SSE test suite covers `current_id` / `next_id` /
`buffer_event` / `get_events_after` / `broadcast` / `send_to`
sequentially, which is the happy path this fix keeps stable.  A
concurrent-duplicate-id regression test is out of scope — the
bug only reproduces under a deliberate two-fiber schedule, which
the current test harness doesn't provide.

## Finding source

Cycle 35 of the masc-mcp audit sweep, continuing the Cycle 34
heuristic "doc comment vs stdlib contract ↔ concurrency claim".
Scanning `sse.ml` for a module-level `Queue.t` without a mutex
(the original target) turned up the `event_buffer` Queue, which
is actually safe under single-domain cooperative scheduling.  The
sharper finding was in the adjacent `format_event` function: the
`?id` option parameter interacts with the unconditional
`fetch_and_add` to create a latent counter-drift / duplicate-id
bug whose severity depends entirely on the scheduler not yielding
in the wrong place.

Audit heuristic added: when a function takes an **optional**
parameter whose value overrides a computed internal value, check
whether the internal computation still has side effects when the
parameter is supplied.  An unconditional side effect paired with
a conditional use of its result is a "wasted increment" at best
and a correctness drift at worst.