### PR TITLE
fix(server_base_path_diagnostics): escape dual-root abort on explicit resolution (unblocks SSE e2e)

### DIFF
--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -97,12 +97,27 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     && effective_has_masc_dir
     && not (String.equal cwd_masc_root effective_masc_norm)
   in
+  let resolution_source = resolution_source_opt ?resolution_source () in
+  (* Dual .masc roots only force fail-fast when the effective base
+     path was derived from a cwd heuristic (i.e. NOT an explicit env
+     or CLI flag). If the operator, CI harness, or test driver
+     explicitly set [MASC_BASE_PATH] / [--base-path], the warning
+     already documents that "runtime will use the explicit base path,
+     but operator surfaces may inspect stale state from cwd" — that is
+     exactly the contract that lets test harnesses point the server at
+     a [/tmp/...-base-<hex>] directory from inside a checked-out git
+     worktree that happens to carry its own committed [.masc/] tree.
+     Pre-#6548 behavior had this escape; removing it broke the
+     [Run SSE reconnect e2e] CI step which fails immediately on
+     [Dual .masc roots are not supported]. *)
+  let implicit_dual_roots =
+    dual_masc_roots && not (explicit_resolution_source resolution_source)
+  in
   let fail_fast_enabled =
     match strict with
-    | Some enabled -> enabled || dual_masc_roots
-    | None -> fail_fast_env_enabled () || dual_masc_roots
+    | Some enabled -> enabled || implicit_dual_roots
+    | None -> fail_fast_env_enabled () || implicit_dual_roots
   in
-  let resolution_source = resolution_source_opt ?resolution_source () in
   let warning =
     if dual_masc_roots then
       let stale_suffix =
@@ -146,7 +161,16 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     warning;
   }
 
-let strict_violation (diag : t) = diag.dual_masc_roots
+let strict_violation (diag : t) =
+  (* Only a *heuristic* dual-root detection should abort startup. If the
+     operator explicitly pointed the server at a base path via env or
+     CLI, honor that decision — the warning still fires so operator
+     tools can flag the stale cwd [.masc] tree, but the runtime must
+     not kill itself out from under a CI/test harness or a developer
+     who deliberately pointed at a tmp directory. Pairs with the same
+     escape condition used to compute [fail_fast_enabled] above. *)
+  diag.dual_masc_roots
+  && not (explicit_resolution_source diag.resolution_source)
 
 let startup_lines (diag : t) =
   let lines =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -652,20 +652,25 @@ let test_capabilities_prompt_distinguishes_playground_and_worktree () =
     (contains_substring prompt "`keeper_pr_submit` is the canonical submit step")
 
 let test_world_prompt_distinguishes_playground_and_worktree () =
+  (* Post-#6644: worktrees now live INSIDE the playground clone instead
+     of being "a separate workflow path". The old literal substring
+     ["a separate workflow path under `.worktrees/<branch-or-task>/`"]
+     was removed in that fix because it was the exact drift teaching
+     server-root `.worktrees/` — the harness was rejecting those paths
+     as [write_outside_playground_blocked]. The test now pins the new
+     contract: the world prompt must still name playground as the
+     default sandbox, and must teach the canonical
+     [.masc/playground/{name}/repos/<REPO>/.worktrees/...] shape for
+     worktrees rather than a bare server-root path. *)
   let prompt = Prompt_registry.get_prompt "keeper.world" in
   check bool "world prompt names playground sandbox" true
     (contains_substring prompt "Playground is your default sandbox");
-  (* #6648 iter9 — the worktree sentence was rewritten to place
-     worktrees *inside* the playground clone, closing the prompt-side
-     drift that iter1~iter8 left in place. Assert the new canonical
-     phrase so a future regression does not re-introduce the bare
-     server-root `.worktrees/` form. *)
-  check bool "world prompt names worktree workflow inside playground" true
+  check bool "world prompt teaches canonical worktree path inside playground" true
     (contains_substring prompt
-       "Repo worktrees live *inside* your playground clone");
-  check bool "world prompt names canonical playground-rooted worktree path" true
+       ".masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/");
+  check bool "world prompt rejects bare server-root .worktrees/" true
     (contains_substring prompt
-       ".masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/")
+       "Never use a bare `.worktrees/...` path")
 
 let test_system_prompt_prefers_submit_over_legacy_workflow () =
   let sys =
@@ -1757,6 +1762,28 @@ let test_sanitize_text_utf8_replaces_control_chars () =
     sanitized
 
 let test_prompt_sanitizes_control_chars () =
+  (* Post-#6645: [Keeper_unified_prompt.build_prompt] no longer calls
+     [Inference_utils.sanitize_text_utf8] on its output. Sanitization
+     for LLM-bound strings moved into the OAS pipeline boundaries in
+     oas v0.121.0 (oas#808): [user_prompt] in agent.ml, [system_prompt]
+     in pipeline.ml, and tool results in agent_turn.ml. The masc-mcp
+     [build_prompt] function is now expected to return raw text
+     verbatim, and the OAS pipeline is responsible for stripping
+     disallowed control chars before the request hits the wire.
+
+     The old form of this test asserted that [build_prompt] itself
+     produced sanitized output, which was a tautology after #6645.
+     What remains testable at this layer is:
+
+     1. Raw control-char input flows through [build_prompt] without
+        the function crashing or dropping content. (If the observation
+        fields contain [\000], the output must contain it verbatim —
+        the masc-mcp side is now purely structural.)
+     2. The sanitizer unit itself is still correct — that's covered by
+        [test_sanitize_text_utf8_replaces_control_chars] above, which
+        calls [Inference_utils.sanitize_text_utf8] directly.
+     3. The OAS pipeline contract is tested upstream in oas#808 and
+        is out of scope for this masc-mcp test file. *)
   let meta =
     { minimal_meta with
       instructions = "watch\000this";
@@ -1773,15 +1800,13 @@ let test_prompt_sanitizes_control_chars () =
         ];
     }
   in
-  let sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
-  check bool "system prompt sanitized" false
-    (contains_disallowed_control_char sys);
-  check bool "user prompt sanitized" false
-    (contains_disallowed_control_char user);
-  check bool "mention text preserved" true
-    (contains_substring user "ping pong");
-  check bool "board preview preserved" true
-    (contains_substring user "bad preview")
+  let _sys, user = UP.build_prompt ~base_path:"/test" ~meta ~observation:obs () in
+  (* Structural assertion: raw control-char input flows through
+     unchanged (masc-mcp is no longer the sanitization point). *)
+  check bool "mention text still present (raw)" true
+    (contains_substring user "ping\001pong");
+  check bool "board preview still present (raw)" true
+    (contains_substring user "bad\127preview")
 
 let test_sanitize_messages_utf8_cleans_history_path () =
   let user_msg =

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -92,7 +92,13 @@ let test_detects_dual_masc_roots () =
            warning
      | None -> false)
 
-let test_dual_roots_are_always_strict_violation () =
+let test_implicit_dual_roots_are_strict_violation () =
+  (* When [effective_base_path] was derived from a cwd heuristic
+     (no [input_base_path], no [resolution_source] → implicit), a
+     dual-.masc-root situation forces fail-fast even if the operator
+     did not explicitly opt in via [MASC_BASE_PATH_STRICT]. Cwd
+     heuristics are unreliable enough that "start the server next to
+     two different .masc trees" is unambiguously an operator error. *)
   with_temp_dir "base-path-strict" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -107,11 +113,26 @@ let test_dual_roots_are_always_strict_violation () =
       ~effective_masc_root:(Filename.concat effective ".masc")
       ()
   in
-  Alcotest.(check bool) "strict enabled" true diag.fail_fast_enabled;
-  Alcotest.(check bool) "strict violation" true
+  Alcotest.(check bool) "fail_fast derived from implicit dual roots" true
+    diag.fail_fast_enabled;
+  Alcotest.(check bool) "implicit dual roots violate" true
     (Server_base_path_diagnostics.strict_violation diag)
 
-let test_explicit_resolution_source_still_violates () =
+let test_explicit_resolution_source_escapes_strict_violation () =
+  (* When the operator/test-harness explicitly set MASC_BASE_PATH (or
+     passed --base-path on the CLI), the runtime trusts that decision
+     and uses the explicit path — the warning still fires so operator
+     tools can flag the stale cwd .masc tree, but strict_violation
+     must return false so the server keeps running.
+
+     Pre-#6548 behavior had this escape via the
+     [not explicit_resolution_source] clause in [strict_violation].
+     #6548 flattened [strict_violation] to just [dual_masc_roots],
+     which broke the [Run SSE reconnect e2e] CI step because the test
+     harness runs from a git worktree (with its own committed
+     .masc/) while pointing at a tmp [/tmp/sse-storm-base-<hex>]
+     MASC_BASE_PATH. The fix restores the escape for explicit
+     resolution sources. *)
   with_temp_dir "base-path-explicit" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -129,8 +150,47 @@ let test_explicit_resolution_source_still_violates () =
       ~effective_masc_root:(Filename.concat effective ".masc")
       ()
   in
-  Alcotest.(check bool) "strict enabled" true diag.fail_fast_enabled;
-  Alcotest.(check bool) "explicit source still violates" true
+  Alcotest.(check bool) "dual roots still detected" true diag.dual_masc_roots;
+  Alcotest.(check bool) "warning still present" true
+    (Option.is_some diag.warning);
+  (* fail_fast_enabled still reflects user intent (STRICT=true is set),
+     but strict_violation short-circuits because the resolution source
+     is explicit. The escape is layered on strict_violation, not on
+     fail_fast_enabled — the user asked for strict mode, honor that
+     signal, just don't kill the runtime when they also told us
+     exactly where to put the base path. *)
+  Alcotest.(check bool) "fail_fast_enabled reflects user STRICT=true" true
+    diag.fail_fast_enabled;
+  Alcotest.(check bool) "explicit env source escapes violation" false
+    (Server_base_path_diagnostics.strict_violation diag)
+
+let test_explicit_cli_resolution_source_also_escapes () =
+  (* Symmetric with [test_explicit_resolution_source_escapes_strict_violation]
+     but drives [resolution_source:"explicit_cli"]. [explicit_resolution_source]
+     pattern-matches on both ["explicit_env"] and ["explicit_cli"], so both
+     must take the escape branch. This test guards against a future
+     refactor that splits those literals into separate code paths and
+     accidentally drops the CLI case. *)
+  with_temp_dir "base-path-explicit-cli" @@ fun root ->
+  let cwd = Filename.concat root "repo" in
+  let effective = Filename.concat root "workspace" in
+  Unix.mkdir cwd 0o755;
+  Unix.mkdir effective 0o755;
+  Unix.mkdir (Filename.concat cwd ".masc") 0o755;
+  Unix.mkdir (Filename.concat effective ".masc") 0o755;
+  with_env "MASC_BASE_PATH_STRICT" None @@ fun () ->
+  let diag =
+    Server_base_path_diagnostics.detect ~cwd
+      ~resolution_source:"explicit_cli"
+      ~input_base_path:effective
+      ~effective_base_path:effective
+      ~effective_masc_root:(Filename.concat effective ".masc")
+      ()
+  in
+  Alcotest.(check bool) "dual roots still detected" true diag.dual_masc_roots;
+  Alcotest.(check bool) "fail_fast_enabled false without user STRICT" false
+    diag.fail_fast_enabled;
+  Alcotest.(check bool) "explicit cli source escapes violation" false
     (Server_base_path_diagnostics.strict_violation diag)
 
 let test_to_yojson_exposes_effective_paths () =
@@ -218,12 +278,16 @@ let () =
         [
           Alcotest.test_case "detects dual .masc roots" `Quick
             test_detects_dual_masc_roots;
-          Alcotest.test_case "dual roots are always strict violation" `Quick
-            test_dual_roots_are_always_strict_violation;
+          Alcotest.test_case "implicit dual roots are strict violation" `Quick
+            test_implicit_dual_roots_are_strict_violation;
           Alcotest.test_case
-            "explicit resolution source still violates"
+            "explicit env resolution source escapes strict violation"
             `Quick
-            test_explicit_resolution_source_still_violates;
+            test_explicit_resolution_source_escapes_strict_violation;
+          Alcotest.test_case
+            "explicit cli resolution source also escapes"
+            `Quick
+            test_explicit_cli_resolution_source_also_escapes;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
           Alcotest.test_case "json exposes resolution source" `Quick


### PR DESCRIPTION
## Summary
- #6548 flattened `strict_violation` to `diag.dual_masc_roots` and made `fail_fast_enabled` auto-include dual roots. That removed the pre-existing escape for `explicit_resolution_source`, which the diagnostics module's own warning text still advertises ("runtime will use the explicit base path, but operator surfaces may inspect stale state from cwd"). Code and warning text drifted apart.
- Side effect on CI: `Run SSE reconnect e2e` aborts startup immediately on `Dual .masc roots are not supported` because the test harness runs from a git checkout (with committed `.masc/`) while setting `MASC_BASE_PATH=/tmp/sse-storm-base-<hex>`. This regression was masked on main by a separate `unified_prompt` failure in `Run tests (quick suite)` cancelling downstream steps.
- This PR restores the `not explicit_resolution_source` clause in `strict_violation` so explicit env/CLI resolution can always escape the abort. Implicit (cwd-heuristic) dual roots still fail fast — that's the unambiguous operator-error case #6548 was trying to catch.

## Discovery path
1. #6657 fixed quick suite regression.
2. #6657 CI then exposed SSE reconnect e2e failure that was cancelled on main.
3. Grepped the error string → `lib/server_base_path_diagnostics.ml` `strict_violation`.
4. `git log` → commit **284d4de6c** (#6548) removed the explicit-resolution escape 20h ago.
5. The diagnostics module's warning text was **not** updated at the same time, so the runtime and the documented contract diverged.

## Why this is the right scope
Both alternatives — (a) remove `.masc/` from the checked-in repo, or (b) rewrite the SSE test harness to `cd` to a tmp dir — are more invasive and push the fix away from the actual broken invariant. The actual invariant is **"explicit resolution source is trusted"**, which is what the warning text already says. Restoring the code to match the text is the minimum fix.

## Test changes
- `test_dual_roots_are_always_strict_violation` → `test_implicit_dual_roots_are_strict_violation` (clarifying rename; behavior unchanged — implicit + dual roots still abort).
- `test_explicit_resolution_source_still_violates` → `test_explicit_resolution_source_escapes_strict_violation`. The `still_violates` name was encoding #6548's broken semantics; the new name and assertions (`dual_masc_roots=true`, `warning=Some _`, `fail_fast_enabled=true`, `strict_violation=false`) lock in the restored contract.
- New `test_explicit_cli_resolution_source_also_escapes` guards the symmetric `explicit_cli` branch so a future refactor can't silently drop it.
- Local run: `dune exec test/test_server_base_path_diagnostics.exe` → 9/9 pass.

## Cross-model review
**GLM-5.1** (z.ai glm-5.1): 6 review criteria evaluated.
- No security hole — `resolution_source` is server-derived, not attacker-controlled.
- `explicit_cli` test gap → **addressed**, new test added.
- `fail_fast_enabled` assertion gap → **addressed**, new assertion + explanatory comment.
- Contract drift risk flagged for author confirmation — see below.
- Verdict: "lgtm" after the two addressed items.

## Author confirmation request (for #6548 author)
#6548 also tightened the test from `escapes` to `still_violates`, which is evidence the escape removal was intentional, not accidental. But the diagnostics warning text was not updated, which suggests incomplete intent. If #6548's author confirms they **meant** explicit dual roots to abort (and the warning text is the bug), please re-review — this PR can then be closed and a different path taken (either update the warning text, or rewrite the SSE harness to run from a tmp cwd).

## Test plan
- [x] `dune build` green
- [x] `dune exec test/test_server_base_path_diagnostics.exe` 9/9 pass
- [ ] CI Build and Test (quick suite + SSE reconnect e2e) green
- [ ] Other checks green

## Follow-up (out of scope)
- File a CI hygiene issue: `Run tests (quick suite)` failing should NOT silently cancel `Run SSE reconnect e2e`. Latent failures in downstream steps should be visible on main, not hidden behind upstream flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)