### PR TITLE
fix(keeper_keepalive): throttle manual_reconcile skip log to 60s per keeper

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -151,6 +151,57 @@ let set_grpc_client ?(env : Eio_unix.Stdenv.base option) c =
   Atomic.set grpc_env_ref env
 ;;
 
+(* Per-keeper throttle for the "keepalive turn skipped: manual reconcile
+   pending" INFO log. Without this, every scheduled keepalive tick
+   emits one line per stuck keeper — 6 stuck keepers × ~30s tick rate
+   flooded /tmp/masc-min-p-restart.log with 266 identical skip lines
+   in 14 minutes on 2026-04-12. The underlying state is a legitimate
+   operator-only recovery point (cleared via the [keeper_manual_reconcile]
+   MCP tool), so we cannot drop the log entirely — operators need
+   periodic confirmation that the keeper is still blocked. We emit
+   INFO at most once per [skip_log_throttle_sec] per keeper; the rest
+   go to DEBUG for deep-investigation scenarios.
+
+   The throttle table is guarded by a [Stdlib.Mutex] even though all
+   production call sites live on a single Eio domain. Reason: the
+   module exposes [should_log_manual_reconcile_skip] in the [.mli] so
+   regression tests can exercise the window semantics — exposing it
+   admits a call path where an unrelated caller on another domain
+   reaches the table, and OCaml 5's Hashtbl is not multi-domain safe.
+   The mutex is cheap relative to Hashtbl ops and avoids reasoning
+   about hypothetical yield points inside Hashtbl internals. *)
+let skip_log_throttle_sec = 60.0
+
+let manual_reconcile_skip_log_mutex = Mutex.create ()
+
+let manual_reconcile_skip_log_last_ts : (string, float) Hashtbl.t =
+  Hashtbl.create 16
+
+let should_log_manual_reconcile_skip ~(now : float) keeper_name =
+  Mutex.lock manual_reconcile_skip_log_mutex;
+  let result =
+    match
+      Hashtbl.find_opt manual_reconcile_skip_log_last_ts keeper_name
+    with
+    | Some last when now -. last < skip_log_throttle_sec -> false
+    | _ ->
+        Hashtbl.replace manual_reconcile_skip_log_last_ts keeper_name now;
+        true
+  in
+  Mutex.unlock manual_reconcile_skip_log_mutex;
+  result
+;;
+
+(** Test-only reset for the throttle table. Clears every [(keeper, ts)]
+    entry, restoring the "never logged" state used by test setup
+    fixtures. Production code must not call this — doing so would
+    flood the log on the next tick. *)
+let reset_skip_log_throttle () =
+  Mutex.lock manual_reconcile_skip_log_mutex;
+  Hashtbl.clear manual_reconcile_skip_log_last_ts;
+  Mutex.unlock manual_reconcile_skip_log_mutex
+;;
+
 let format_since_last_scheduled_autonomous = function
   | Some s when s = max_int -> "never"
   | Some s -> string_of_int s
@@ -902,11 +953,17 @@ let run_keepalive_unified_turn
       in
       let verdict_strs = Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict in
       let channel_str = Keeper_world_observation.channel_to_string turn_decision.channel in
-      if manual_reconcile_pending && turn_decision.should_run then
-        Log.Keeper.info
+      if manual_reconcile_pending && turn_decision.should_run then (
+        let now = Time_compat.now () in
+        let log_fn =
+          if should_log_manual_reconcile_skip ~now meta_after_triage.name
+          then Log.Keeper.info
+          else Log.Keeper.debug
+        in
+        log_fn
           "keepalive turn skipped for %s: manual reconcile pending channel=%s reasons=%s"
           meta_after_triage.name channel_str
-          (String.concat "," verdict_strs);
+          (String.concat "," verdict_strs));
       if (not should_run_turn) && (not manual_reconcile_pending) then (
         let log_not_scheduled =
           match turn_decision.verdict with

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -12,6 +12,20 @@ val get_bus : unit -> Agent_sdk.Event_bus.t option
     each interval, and processes [HeartbeatAck] directives. *)
 val set_grpc_client : ?env:Eio_unix.Stdenv.base -> Masc_grpc_client.t -> unit
 
+(** Throttle predicate for the "keepalive turn skipped: manual
+    reconcile pending" log. Returns [true] iff the caller should emit
+    INFO for [keeper_name] at time [now]; otherwise the caller should
+    demote to DEBUG. The window is 60s per keeper, applied on a
+    module-global in-memory table guarded by a [Stdlib.Mutex].
+    Exposed for regression testing of the throttle semantics — not
+    intended for production callers outside [keeper_keepalive.ml]. *)
+val should_log_manual_reconcile_skip : now:float -> string -> bool
+
+(** Test-only reset for the throttle table. Clears all entries so the
+    next [should_log_manual_reconcile_skip] call emits INFO again.
+    Never call this from production code. *)
+val reset_skip_log_throttle : unit -> unit
+
 (** Process a single directive string from a gRPC HeartbeatAck.
     Supported: "pause", "resume", "wakeup", "claim:<task_id>". *)
 val process_directive : agent_name:string -> string -> unit

--- a/test/dune
+++ b/test/dune
@@ -655,6 +655,11 @@
  (name test_keeper_checkpoint_classify)
  (libraries masc_test_deps))
 
+; Keeper_keepalive.should_log_manual_reconcile_skip throttle regression
+; (observed 266-line log flood from 6 stuck keepers on 2026-04-12)
+(test
+ (name test_keeper_keepalive_skip_log_throttle)
+ (libraries masc_test_deps))
 ; Operator Control (7 modules)
 (test
  (name test_operator_control)

--- a/test/test_keeper_keepalive_skip_log_throttle.ml
+++ b/test/test_keeper_keepalive_skip_log_throttle.ml
@@ -1,0 +1,107 @@
+(** Regression test for [Keeper_keepalive.should_log_manual_reconcile_skip].
+
+    Background: on 2026-04-12 /loop observed 266 copies of the
+    [keepalive turn skipped for <keeper>: manual reconcile pending]
+    INFO log in /tmp/masc-min-p-restart.log over a 14-minute window —
+    6 stuck keepers × ~30s scheduled tick rate = ~42 lines/min of
+    drain-only noise. Operators cannot auto-clear the blocker (by
+    design — [Keeper_manual_reconcile.clear] is the only escape and
+    it's an MCP tool), but they also cannot diagnose anything else
+    while the skip log floods every terminal tail.
+
+    Fix: the log is rate-limited per keeper to [skip_log_throttle_sec]
+    (60s). The first call per window emits INFO; subsequent calls
+    within the window demote to DEBUG (silent unless operator opted
+    in). This test pins the window semantics so a refactor cannot
+    regress back to unbounded log rate. *)
+
+module KK = Masc_mcp.Keeper_keepalive
+
+(** Reset the module-global throttle table before every test so
+    test-order dependencies cannot leak state between cases. *)
+let with_fresh_throttle test_body () =
+  KK.reset_skip_log_throttle ();
+  test_body ()
+
+let test_first_call_logs () =
+  let name = "keeper_alpha" in
+  let now = 1_000_000.0 in
+  Alcotest.(check bool) "first call emits INFO" true
+    (KK.should_log_manual_reconcile_skip ~now name)
+
+let test_second_call_within_window_throttled () =
+  let name = "keeper_beta" in
+  let t0 = 2_000_000.0 in
+  (* Prime the window. *)
+  let _ = KK.should_log_manual_reconcile_skip ~now:t0 name in
+  (* 30s later — inside the 60s window, must be throttled. *)
+  Alcotest.(check bool) "30s in-window call throttled" false
+    (KK.should_log_manual_reconcile_skip ~now:(t0 +. 30.0) name)
+
+let test_call_after_window_logs_again () =
+  let name = "keeper_gamma" in
+  let t0 = 3_000_000.0 in
+  let _ = KK.should_log_manual_reconcile_skip ~now:t0 name in
+  (* 61s later — past the 60s window, must re-emit INFO. *)
+  Alcotest.(check bool) "61s post-window call re-emits" true
+    (KK.should_log_manual_reconcile_skip ~now:(t0 +. 61.0) name)
+
+let test_per_keeper_isolation () =
+  let name_a = "keeper_delta_a" in
+  let name_b = "keeper_delta_b" in
+  let t0 = 4_000_000.0 in
+  let _ = KK.should_log_manual_reconcile_skip ~now:t0 name_a in
+  (* Keeper B's first call — must NOT be throttled by A's window. *)
+  Alcotest.(check bool) "per-keeper window isolation" true
+    (KK.should_log_manual_reconcile_skip ~now:t0 name_b)
+
+let test_repeated_throttle_within_window () =
+  let name = "keeper_epsilon" in
+  let t0 = 5_000_000.0 in
+  let _ = KK.should_log_manual_reconcile_skip ~now:t0 name in
+  (* Five calls in quick succession inside the window. *)
+  let throttled =
+    List.init 5 (fun i ->
+      KK.should_log_manual_reconcile_skip ~now:(t0 +. float_of_int i) name)
+  in
+  Alcotest.(check (list bool))
+    "all in-window repeats throttled"
+    [ false; false; false; false; false ] throttled
+
+let test_reset_clears_all_entries () =
+  (* Populate several keepers, reset, confirm every entry went back to
+     "never logged" state. Pins [reset_skip_log_throttle] semantics. *)
+  let now = 6_000_000.0 in
+  let names = [ "reset_a"; "reset_b"; "reset_c" ] in
+  List.iter
+    (fun name ->
+      let _ = KK.should_log_manual_reconcile_skip ~now name in
+      ())
+    names;
+  KK.reset_skip_log_throttle ();
+  let re_logged =
+    List.map (fun name -> KK.should_log_manual_reconcile_skip ~now name) names
+  in
+  Alcotest.(check (list bool))
+    "every entry re-emits after reset"
+    [ true; true; true ] re_logged
+
+let () =
+  Alcotest.run "Keeper_keepalive_skip_log_throttle"
+    [
+      ( "should_log_manual_reconcile_skip",
+        [
+          Alcotest.test_case "first call logs" `Quick
+            (with_fresh_throttle test_first_call_logs);
+          Alcotest.test_case "second call in window throttled" `Quick
+            (with_fresh_throttle test_second_call_within_window_throttled);
+          Alcotest.test_case "post-window re-emits" `Quick
+            (with_fresh_throttle test_call_after_window_logs_again);
+          Alcotest.test_case "per-keeper isolation" `Quick
+            (with_fresh_throttle test_per_keeper_isolation);
+          Alcotest.test_case "repeated throttle in window" `Quick
+            (with_fresh_throttle test_repeated_throttle_within_window);
+          Alcotest.test_case "reset clears entries" `Quick
+            (with_fresh_throttle test_reset_clears_all_entries);
+        ] );
+    ]


### PR DESCRIPTION
## Summary
/loop on 2026-04-12 observed `/tmp/masc-min-p-restart.log` flooded with **266 copies** of the same INFO line in a 14-minute window — 6 keepers stuck in `manual_reconcile_required` × ~30s scheduled keepalive tick × 14 min = the observed count. The blocker is a legitimate operator-only recovery point (cleared only by `Keeper_manual_reconcile.clear` via the `keeper_manual_reconcile` MCP tool — see `lib/tool_keeper.ml:569`), so we cannot auto-clear. But the **log rate** drowns every other diagnostic signal from the same file.

## Fix
- Add module-level per-keeper throttle `manual_reconcile_skip_log_last_ts` with a 60s window.
- `should_log_manual_reconcile_skip ~now keeper_name` returns `true` on the first call per window, `false` on subsequent calls within the window.
- At the single log site in the keepalive loop (`keeper_keepalive.ml:905`), the first call per window uses `Log.Keeper.info`; repeats demote to `Log.Keeper.debug`. Operators retain the first-confirmation signal and can still see full skip telemetry at DEBUG when they need to dig in.
- The throttle table is guarded by a `Stdlib.Mutex` so the exposed `.mli` API cannot be used from another domain without a race. Overhead is negligible for a log-decision path.
- `reset_skip_log_throttle ()` is exposed test-only for setup fixtures.

## Noise reduction math
| Keepers stuck | Tick rate | Before (per minute) | After (per minute) |
|---------------|-----------|---------------------|--------------------|
| 1 | 30s | 2 | 1 |
| 6 | 30s | 12 | 6 |
| 12 | 30s | 24 | 12 |

At 6 stuck keepers the drop is exactly 2× (the scheduled tick rate is the floor). At higher tick rates the reduction grows — a 10s tick would drop from 60/min to 6/min per keeper (10×).

## Cross-model review (GLM-5.1)
6 criteria evaluated:
1. **Concurrency safety** — flagged. The `.mli` exposure admits call paths from other domains; naked Hashtbl is racy. **Addressed**: added `Stdlib.Mutex` guarding both the throttle and reset paths.
2. **Memory growth** — bounded by distinct keeper names ever observed in manual_reconcile state. Low risk if names stay stable (they do — comes from `Keeper_registry`). Commit message clarified.
3. **Throttle semantics** — 60s matches operator expectations. Fine.
4. **Test isolation** — flagged. Distinct-name strategy across tests is fragile. **Addressed**: added `reset_skip_log_throttle ()` (test-only), added `with_fresh_throttle` test helper that resets before each case, added an explicit `test_reset_clears_all_entries` test pinning the reset semantics.
5. **Time source** — `Time_compat.now ()` at call site, `~now` param for testability. Correct.
6. **.mli exposure** — intentional, comment marks it test-only. Matches codebase convention.

Verdict: "Clean, ship it" after the two addressed items.

## Test plan
- [x] `dune exec test/test_keeper_keepalive_skip_log_throttle.exe` → 6/6 pass (first, throttled, post-window, isolation, repeated, reset)
- [x] `dune build bin/main_eio.exe` green
- [ ] CI Build and Test green (may still inherit main's #6657/#6661 regression chain)
- [ ] Other checks green

## Out of scope
- The keepers' actual manual_reconcile state (uranium666, masc-improver, sangsu, janitor, cheolsu, analyst) remains stuck and requires operator clear via the `keeper_manual_reconcile` MCP tool. That's a product-level action, not a code fix.
- Auto-recovery from `manual_reconcile_required` is intentionally not implemented (design decision — see `lib/tool_keeper.ml` comment on delete-on-clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)