### PR TITLE
perf(prompt_registry): move markdown disk reads outside registry mutex

### DIFF
--- a/lib/prompt_registry/prompt_registry.ml
+++ b/lib/prompt_registry/prompt_registry.ml
@@ -528,11 +528,15 @@ let default_prompt_value_unlocked key =
   | Some entry -> Some entry.template
   | None -> None
 
-let resolve_prompt_unlocked key =
-  let override_value = Hashtbl.find_opt override_tbl key in
+(* Pure assembly of a [resolved] record from pre-captured values.
+   Invariant: [file_value] must already be read by the caller — this
+   function never touches the filesystem, so it is safe to call from
+   inside a [with_mutex] block without the contention cost of disk
+   I/O under the lock (the original sin that [resolve_prompt] at the
+   bottom of this file was explicitly refactored to avoid, see #3335). *)
+let build_resolved_from_snapshot
+    ~key ~override_value ~default_value ~file_value =
   let file_path = prompt_markdown_path key in
-  let file_value = Option.bind file_path read_file_if_exists in
-  let default_value = default_prompt_value_unlocked key in
   let source, effective =
     match override_value with
     | Some value -> ("override", value)
@@ -555,6 +559,28 @@ let resolve_prompt_unlocked key =
     has_override = Option.is_some override_value;
   }
 
+(* Aggregate snapshot for batch listing APIs.  [list_prompts] and
+   [validate_prompt_templates] gather these under [with_mutex] and
+   then resolve (with disk reads) outside the lock. *)
+type prompt_snapshot = {
+  snap_key : string;
+  snap_meta : prompt_meta;
+  snap_override_value : string option;
+  snap_default_value : string option;
+}
+
+(* Resolve a single prompt by doing the filesystem read OUTSIDE the
+   mutex.  Intended for batch [list_prompts]/[validate_prompt_templates]
+   call sites that previously held [with_mutex] across [read_file_if_exists]. *)
+let resolved_of_snapshot (s : prompt_snapshot) =
+  let file_path = prompt_markdown_path s.snap_key in
+  let file_value = Option.bind file_path read_file_if_exists in
+  build_resolved_from_snapshot
+    ~key:s.snap_key
+    ~override_value:s.snap_override_value
+    ~default_value:s.snap_default_value
+    ~file_value
+
 let unexpected_template_variables meta template =
   let expected = meta.template_variables in
   if expected = [] then []
@@ -562,8 +588,9 @@ let unexpected_template_variables meta template =
     extract_variables template
     |> List.filter (fun variable -> not (List.mem variable expected))
 
-let prompt_item_json key (meta : prompt_meta) =
-  let resolved = resolve_prompt_unlocked key in
+(* Variant that takes a pre-computed [resolved] record.  Used by the
+   batch listing paths that read files outside the mutex. *)
+let prompt_item_json_of_resolved key (meta : prompt_meta) resolved =
   `Assoc
     [
       ("key", `String key);
@@ -789,27 +816,68 @@ let validate_required_prompt_files () =
             | None -> (key, "<invalid-key>") :: acc)
         meta_tbl [] |> List.sort compare)
 
+(* [validate_prompt_templates] was doing [read_file_if_exists] inside
+   the [with_mutex] fold via [resolve_prompt_unlocked], holding the
+   registry mutex across every markdown file read.  Two-phase:
+   snapshot under the mutex, then read files + build resolved records
+   outside.  Same refactor pattern as [list_prompts] below. *)
 let validate_prompt_templates () =
-  with_mutex (fun () ->
+  let snapshots =
+    with_mutex (fun () ->
       Hashtbl.fold
         (fun key meta acc ->
-          let issues =
-            match resolve_prompt_unlocked key with
-            | { effective = ""; source = "missing"; _ } -> []
-            | resolved ->
-                unexpected_template_variables meta resolved.effective
-                |> List.map (fun variable -> (key, variable))
-          in
-          issues @ acc)
-        meta_tbl [] |> List.sort compare)
+          { snap_key = key;
+            snap_meta = meta;
+            snap_override_value = Hashtbl.find_opt override_tbl key;
+            snap_default_value = default_prompt_value_unlocked key;
+          } :: acc)
+        meta_tbl [])
+  in
+  List.fold_left
+    (fun acc s ->
+      let resolved = resolved_of_snapshot s in
+      let issues =
+        match resolved with
+        | { effective = ""; source = "missing"; _ } -> []
+        | resolved ->
+            unexpected_template_variables s.snap_meta resolved.effective
+            |> List.map (fun variable -> (s.snap_key, variable))
+      in
+      issues @ acc)
+    [] snapshots
+  |> List.sort compare
 
-(** List all registered prompts with metadata, for API/dashboard *)
+(** List all registered prompts with metadata, for API/dashboard.
+
+    Previously held [with_mutex] across every [read_file_if_exists]
+    call (once per registered prompt), blocking all other prompt
+    registry operations for the full disk scan.  Now:
+
+    1. Snapshot (key, meta, override, default) under [with_mutex].
+    2. Release the lock.
+    3. For each snapshot, read the markdown file and build the
+       [resolved] record outside the lock.
+    4. Sort and return.
+
+    Concurrent callers no longer serialize on disk I/O; the only lock
+    hold is the in-memory Hashtbl fold. *)
 let list_prompts () =
-  with_mutex (fun () ->
+  let snapshots =
+    with_mutex (fun () ->
       Hashtbl.fold
-        (fun key meta acc -> prompt_item_json key meta :: acc)
-        meta_tbl []
-      |> List.sort compare_prompt_items)
+        (fun key meta acc ->
+          { snap_key = key;
+            snap_meta = meta;
+            snap_override_value = Hashtbl.find_opt override_tbl key;
+            snap_default_value = default_prompt_value_unlocked key;
+          } :: acc)
+        meta_tbl [])
+  in
+  snapshots
+  |> List.map (fun s ->
+    let resolved = resolved_of_snapshot s in
+    prompt_item_json_of_resolved s.snap_key s.snap_meta resolved)
+  |> List.sort compare_prompt_items
 
 (** JSON export of all prompts for API *)
 let prompts_json () =


### PR DESCRIPTION

`Prompt_registry.list_prompts` and `Prompt_registry.validate_prompt_templates`
both held `with_mutex` while calling `resolve_prompt_unlocked` for
every registered prompt inside a `Hashtbl.fold`.
`resolve_prompt_unlocked` in turn called `read_file_if_exists`,
which does `In_channel.with_open_text path …` — **file I/O under
the registry mutex**, for every prompt in the meta_tbl, in series.

This is the exact anti-pattern the public `resolve_prompt` (line
704) was refactored to avoid in #3335:

```
(** Resolve a prompt with file I/O performed outside the mutex.
    Reads the markdown file first, then acquires the mutex for
    hashtbl lookups only. Prevents Eio.Mutex contention when
    file I/O blocks a fiber (#3335). *)
```

The `_unlocked` variant was left behind because it was an
"under-the-lock" helper and at the time no batch caller needed the
discipline — `list_prompts` / `validate_prompt_templates` were added
later and silently inherited the contention.

## Impact

`list_prompts` is on the hot dashboard path (every prompt panel
refresh).  `validate_prompt_templates` runs at startup and from
dashboard validation endpoints.  Both fold over `meta_tbl` and touch
disk for every entry.  With N prompts registered and per-read cost
T, the registry mutex is held for ≈ N·T even when all callers just
want to read in-memory metadata.  Every other `Prompt_registry`
operation (`get_prompt`, `set_override`, `register`, `restore`,
`persist_overrides`) blocks on the same mutex while that disk scan
runs.

On a hot reload where 20+ prompts exist and the `.md` files live on
an NFS or cold disk, this is easy to observe as 100+ ms mutex hold
times while the dashboard refresh is in flight.

## Fix

Two-phase pattern, same as the public `resolve_prompt` (#3335):

1. **Snapshot under the mutex.** Fold `meta_tbl` once, capturing
   `(key, meta, override_value, default_value)` tuples for every
   entry.  This is pure in-memory work and no disk touches the
   critical section.

2. **Release the mutex and read markdown files outside.** For each
   snapshot, call a new `resolved_of_snapshot` helper that does
   `prompt_markdown_path` + `read_file_if_exists` and assembles a
   `resolved` record via the existing projection logic.

3. **Build the JSON / issue list outside the lock** from the
   resolved records.

The existing `resolve_prompt_unlocked` is deleted — it had two
callers (`prompt_item_json`, `validate_prompt_templates`), both
replaced by the snapshot path.  `prompt_item_json` is renamed to
`prompt_item_json_of_resolved` (takes a pre-computed `resolved`
record) to make the "receives pre-resolved data" contract explicit.

A new `build_resolved_from_snapshot` helper centralizes the pure
projection logic; both `resolved_of_snapshot` (batch listing path)
and the public `resolve_prompt` (single-lookup path, unchanged)
share the same assembly shape.

## Verification

```
dune build --root . @lib/check                            # exit 0
dune exec --root . -- ./test/test_prompt_registry_defaults.exe
# 11/11 passed — including prompts_json / integration / render
```

The existing test suite covers `prompts_json` (which calls
`list_prompts`), override semantics, markdown-file reading, and
render_prompt_template.  No behavior change — the refactor
preserves `resolved` record content identically, only moves the
disk reads out of the critical section.

## Finding source

Cycle 36 of the masc-mcp audit sweep.  Queue#3 carry-over — Cycle 31
flagged this as "doc only" but a closer read found that the
anti-pattern is not just documentation drift: the `_unlocked`
variant was structurally identical to the pre-#3335 `resolve_prompt`
and had the same contention cost.  The fact that the public
`resolve_prompt` already solved this in-tree, with an explicit doc
comment pointing at the ticket, made the drift unambiguous.

Audit heuristic added: when an audit finds a public API that was
refactored to fix a specific contention bug (e.g. "file I/O outside
mutex"), grep for sibling `_unlocked` / `_internal` / `_impl`
variants of the same function and verify they apply the same
discipline.  The refactor pattern almost never propagates
automatically — someone fixed `foo` and left `foo_internal` alone.