### PR TITLE
fix(tool_code): gate read handlers on caller playground (#6637) [WIP iter11]

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -95,20 +95,23 @@ let validate_path config path =
    surface (secrets in playground .env files, proprietary code
    mid-work, handoff notes, etc.).
 
-   [validate_read_path] adds the extra gate: if the canonical path
-   lands inside the *.masc/playground/* tree, it must be inside the
-   caller's own playground. Paths outside that tree (i.e. the shared
-   codebase in lib/, test/, config/, etc.) remain readable so keepers
-   can still call the code-read tools on the common source tree.
+   Two-tier gate:
+   1. Run the pre-existing [validate_path] (git-root check, null-byte
+      rejection, canonicalisation).
+   2. If the canonical path is outside the [.masc/playground/] tree,
+      it's the shared codebase (lib/, test/, config/, etc.) — allow.
+   3. If the canonical path is inside the playground tree, require it
+      to be under the caller's own bundle (via [playground_path_of_keeper]).
 
    Sibling write fix: iter6 #6610 in tool_code_write.ml. *)
 let validate_read_path ~agent_name config path =
+  let base_path = config.Room.base_path in
   match validate_path config path with
   | Error e -> Error e
   | Ok canonical ->
       let playground_tree_rel = ".masc/playground" in
       let playground_tree_abs_raw =
-        Filename.concat config.Room.base_path playground_tree_rel
+        Filename.concat base_path playground_tree_rel
       in
       let playground_tree_canonical =
         try Unix.realpath playground_tree_abs_raw
@@ -126,16 +129,16 @@ let validate_read_path ~agent_name config path =
         let own_rel_trailing =
           Keeper_alerting_path.playground_path_of_keeper agent_name
         in
-        (* [playground_path_of_keeper] returns a trailing-slash
-           relative path (".masc/playground/<agent>/"). Strip the
-           trailing slash for prefix comparison. *)
+        (* [playground_path_of_keeper] returns a trailing-slash relative
+           path (".masc/playground/<agent>/"). Strip the trailing slash
+           for the prefix comparison. *)
         let own_rel =
           let n = String.length own_rel_trailing in
           if n > 0 && own_rel_trailing.[n - 1] = '/'
           then String.sub own_rel_trailing 0 (n - 1)
           else own_rel_trailing
         in
-        let own_abs_raw = Filename.concat config.Room.base_path own_rel in
+        let own_abs_raw = Filename.concat base_path own_rel in
         let own_canonical =
           try Unix.realpath own_abs_raw
           with Unix.Unix_error _ -> normalize_path own_abs_raw
@@ -151,6 +154,7 @@ let validate_read_path ~agent_name config path =
              own playground must target the shared codebase (lib/, \
              test/, config/, etc.). See #6527/#6637."
             agent_name path own_rel_trailing))
+
 
 (* Handler: masc_code_search - Search code using ripgrep *)
 let handle_code_search ctx args =

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -86,6 +86,72 @@ let validate_path config path =
   | Invalid_argument msg -> Error (IoError msg)
   | exn -> Error (IoError (Printexc.to_string exn))
 
+(* #6637 iter11 — per-agent playground containment for code-read tools.
+
+   [validate_path] guarantees the target is within the git root, but
+   .masc/playground/<other-keeper>/ is also under the git root, so a
+   keeper could historically read another keeper's playground
+   contents via masc_code_search/symbols/read — a data exfiltration
+   surface (secrets in playground .env files, proprietary code
+   mid-work, handoff notes, etc.).
+
+   [validate_read_path] adds the extra gate: if the canonical path
+   lands inside the *.masc/playground/* tree, it must be inside the
+   caller's own playground. Paths outside that tree (i.e. the shared
+   codebase in lib/, test/, config/, etc.) remain readable so keepers
+   can still call the code-read tools on the common source tree.
+
+   Sibling write fix: iter6 #6610 in tool_code_write.ml. *)
+let validate_read_path ~agent_name config path =
+  match validate_path config path with
+  | Error e -> Error e
+  | Ok canonical ->
+      let playground_tree_rel = ".masc/playground" in
+      let playground_tree_abs_raw =
+        Filename.concat config.Room.base_path playground_tree_rel
+      in
+      let playground_tree_canonical =
+        try Unix.realpath playground_tree_abs_raw
+        with Unix.Unix_error _ -> normalize_path playground_tree_abs_raw
+      in
+      let is_under_any_playground =
+        String.starts_with
+          ~prefix:(playground_tree_canonical ^ "/") canonical
+        || String.equal canonical playground_tree_canonical
+      in
+      if not is_under_any_playground then
+        (* Shared codebase read — allow. *)
+        Ok canonical
+      else
+        let own_rel_trailing =
+          Keeper_alerting_path.playground_path_of_keeper agent_name
+        in
+        (* [playground_path_of_keeper] returns a trailing-slash
+           relative path (".masc/playground/<agent>/"). Strip the
+           trailing slash for prefix comparison. *)
+        let own_rel =
+          let n = String.length own_rel_trailing in
+          if n > 0 && own_rel_trailing.[n - 1] = '/'
+          then String.sub own_rel_trailing 0 (n - 1)
+          else own_rel_trailing
+        in
+        let own_abs_raw = Filename.concat config.Room.base_path own_rel in
+        let own_canonical =
+          try Unix.realpath own_abs_raw
+          with Unix.Unix_error _ -> normalize_path own_abs_raw
+        in
+        if String.equal canonical own_canonical
+           || String.starts_with ~prefix:(own_canonical ^ "/") canonical
+        then Ok canonical
+        else
+          Error (IoError (Printf.sprintf
+            "cross-keeper playground read blocked: agent=%S tried to \
+             read path %S which is under another keeper's playground. \
+             Only %s is readable for this caller; reads outside your \
+             own playground must target the shared codebase (lib/, \
+             test/, config/, etc.). See #6527/#6637."
+            agent_name path own_rel_trailing))
+
 (* Handler: masc_code_search - Search code using ripgrep *)
 let handle_code_search ctx args =
   let query = get_string args "query" "" in
@@ -99,7 +165,9 @@ let handle_code_search ctx args =
     (false, "❌ Query required: 'query' parameter")
   else begin
     (* Validate path first *)
-    let search_path_result = validate_path ctx.config path in
+    let search_path_result =
+      validate_read_path ~agent_name:ctx.agent_name ctx.config path
+    in
     match search_path_result with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok search_path ->
@@ -209,7 +277,7 @@ let handle_code_symbols ctx args =
   if path = "" then
     (false, "❌ Path required: 'path' parameter")
   else begin
-    match validate_path ctx.config path with
+    match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok validated_path ->
         if not (Sys.file_exists validated_path) then
@@ -289,7 +357,7 @@ let handle_code_read ctx args =
   if path = "" then
     (false, "❌ Path required: 'path' parameter")
   else begin
-    match validate_path ctx.config path with
+    match validate_read_path ~agent_name:ctx.agent_name ctx.config path with
     | Error e -> (false, Types.masc_error_to_string e)
     | Ok validated_path ->
         if not (Sys.file_exists validated_path) then

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -108,52 +108,109 @@ let validate_read_path ~agent_name config path =
   let base_path = config.Room.base_path in
   match validate_path config path with
   | Error e -> Error e
-  | Ok canonical ->
+  | Ok canonical_string ->
+      (* [validate_path] returns a [normalize_path]-resolved canonical
+         string — it collapses [.] and [..] segments but does NOT
+         follow symlinks. For the *git-root* boundary check that's
+         fine (a link's string path is still inside the git root).
+         But for the *playground* containment check we must follow
+         symlinks, otherwise a keeper could place a link inside its
+         own bundle pointing into another keeper's playground and the
+         string-level prefix check would false-accept it (GLM-5.1
+         review Issue #2 on PR #6664, with a live test case that
+         initially reproduced the bypass). Realpath the canonical
+         target once here and use the result for every subsequent
+         comparison against the playground roots (which are also
+         realpath'd below). *)
+      match
+        try Ok (Unix.realpath canonical_string) with
+        | Unix.Unix_error _ ->
+            (* The target vanished between validate_path and here
+               (racy deletion, or a broken symlink). Treat as a
+               containment failure rather than silently accepting. *)
+            Error
+              (IoError
+                 (Printf.sprintf
+                    "target path %S is not accessible (dangling \
+                     symlink or racy deletion)" path))
+      with
+      | Error e -> Error e
+      | Ok canonical ->
       let playground_tree_rel = ".masc/playground" in
       let playground_tree_abs_raw =
         Filename.concat base_path playground_tree_rel
       in
-      let playground_tree_canonical =
-        try Unix.realpath playground_tree_abs_raw
-        with Unix.Unix_error _ -> normalize_path playground_tree_abs_raw
-      in
-      let is_under_any_playground =
-        String.starts_with
-          ~prefix:(playground_tree_canonical ^ "/") canonical
-        || String.equal canonical playground_tree_canonical
-      in
-      if not is_under_any_playground then
-        (* Shared codebase read — allow. *)
-        Ok canonical
-      else
-        let own_rel_trailing =
-          Keeper_alerting_path.playground_path_of_keeper agent_name
-        in
-        (* [playground_path_of_keeper] returns a trailing-slash relative
-           path (".masc/playground/<agent>/"). Strip the trailing slash
-           for the prefix comparison. *)
-        let own_rel =
-          let n = String.length own_rel_trailing in
-          if n > 0 && own_rel_trailing.[n - 1] = '/'
-          then String.sub own_rel_trailing 0 (n - 1)
-          else own_rel_trailing
-        in
-        let own_abs_raw = Filename.concat base_path own_rel in
-        let own_canonical =
-          try Unix.realpath own_abs_raw
-          with Unix.Unix_error _ -> normalize_path own_abs_raw
-        in
-        if String.equal canonical own_canonical
-           || String.starts_with ~prefix:(own_canonical ^ "/") canonical
-        then Ok canonical
-        else
-          Error (IoError (Printf.sprintf
-            "cross-keeper playground read blocked: agent=%S tried to \
-             read path %S which is under another keeper's playground. \
-             Only %s is readable for this caller; reads outside your \
-             own playground must target the shared codebase (lib/, \
-             test/, config/, etc.). See #6527/#6637."
-            agent_name path own_rel_trailing))
+      (* #6637 iter11 GLM review: fail closed on realpath failure.
+         [normalize_path] only resolves string-level [.] / [..]
+         segments; it does NOT follow symlinks. If the playground
+         tree doesn't realpath, a symlink in the filesystem could
+         flip the prefix comparison below. Return an explicit error
+         that points the LLM at the recovery action (provision the
+         playground bundle) instead of silently weakening the gate.
+         Mirrors iter10 #6651 fail-closed pattern. *)
+      match
+        try Ok (Unix.realpath playground_tree_abs_raw) with
+        | Unix.Unix_error _ ->
+            Error
+              (IoError
+                 (Printf.sprintf
+                    "keeper playground tree %S does not exist; cannot \
+                     validate cross-keeper containment. Clone via \
+                     keeper_shell op=git_clone to provision your \
+                     playground first. See #6527/#6637."
+                    playground_tree_rel))
+      with
+      | Error e -> Error e
+      | Ok playground_tree_canonical ->
+          let is_under_any_playground =
+            String.starts_with
+              ~prefix:(playground_tree_canonical ^ "/") canonical
+            || String.equal canonical playground_tree_canonical
+          in
+          if not is_under_any_playground then
+            (* Shared codebase read — allow. *)
+            Ok canonical
+          else
+            let own_rel_trailing =
+              Keeper_alerting_path.playground_path_of_keeper agent_name
+            in
+            (* [playground_path_of_keeper] returns a trailing-slash
+               relative path (".masc/playground/<agent>/"). Strip the
+               trailing slash for the prefix comparison. *)
+            let own_rel =
+              let n = String.length own_rel_trailing in
+              if n > 0 && own_rel_trailing.[n - 1] = '/'
+              then String.sub own_rel_trailing 0 (n - 1)
+              else own_rel_trailing
+            in
+            let own_abs_raw = Filename.concat base_path own_rel in
+            (* Same fail-closed rule for the caller's own playground
+               root — again, to preserve symlink-collapse guarantees. *)
+            match
+              try Ok (Unix.realpath own_abs_raw) with
+              | Unix.Unix_error _ ->
+                  Error
+                    (IoError
+                       (Printf.sprintf
+                          "keeper playground bundle %S does not exist \
+                           yet; cannot validate containment. Provision \
+                           via git_clone or masc_worktree_create first. \
+                           See #6527/#6637."
+                          own_rel_trailing))
+            with
+            | Error e -> Error e
+            | Ok own_canonical ->
+                if String.equal canonical own_canonical
+                   || String.starts_with ~prefix:(own_canonical ^ "/") canonical
+                then Ok canonical
+                else
+                  Error (IoError (Printf.sprintf
+                    "cross-keeper playground read blocked: agent=%S tried to \
+                     read path %S which is under another keeper's playground. \
+                     Only %s is readable for this caller; reads outside your \
+                     own playground must target the shared codebase (lib/, \
+                     test/, config/, etc.). See #6527/#6637."
+                    agent_name path own_rel_trailing))
 
 
 (* Handler: masc_code_search - Search code using ripgrep *)

--- a/test/dune
+++ b/test/dune
@@ -584,6 +584,7 @@
         test_tool_suspend_coverage test_tool_code_coverage
         test_tool_code_write_coverage
         test_tool_repair_loop_containment
+        test_tool_code_read_containment
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
         test_anti_rationalization_coverage test_field_validation)
@@ -620,6 +621,7 @@
         test_tool_suspend_coverage test_tool_code_coverage
         test_tool_code_write_coverage
         test_tool_repair_loop_containment
+        test_tool_code_read_containment
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
         test_anti_rationalization_coverage test_field_validation)

--- a/test/test_tool_code_read_containment.ml
+++ b/test/test_tool_code_read_containment.ml
@@ -1,0 +1,214 @@
+(** Coverage tests for #6637 iter11 — per-agent playground containment
+    in [Tool_code.validate_read_path].
+
+    These tests drive the helper through a fresh tmp [base_path] with
+    a real `git init` (required by [Tool_code.validate_path] which
+    asserts git root) and two playground bundles. Each case exercises
+    one branch of the two-tier gate:
+
+    1. Shared codebase (outside .masc/playground/) → allow.
+    2. Inside .masc/playground/<caller>/ → allow.
+    3. Inside .masc/playground/<other>/ → reject with named SSOT.
+    4. Outside git root → reject with the pre-iter11 [validate_path]
+       boundary error. *)
+
+open Masc_mcp
+
+let () =
+  Printf.printf "\n=== Tool_code read-side containment (#6637 iter11) ===\n"
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop i =
+    if i + nlen > hlen then false
+    else if String.sub haystack i nlen = needle then true
+    else loop (i + 1)
+  in
+  nlen = 0 || loop 0
+
+let fresh_base_path ~tag =
+  let raw =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "masc-tool-code-read-%s-%d" tag
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  Unix.mkdir raw 0o755;
+  try Unix.realpath raw with Unix.Unix_error _ -> raw
+
+let sh cmd =
+  let rc = Sys.command cmd in
+  if rc <> 0 then
+    failwith (Printf.sprintf "shell cmd failed (rc=%d): %s" rc cmd)
+
+let git_init_base base_path =
+  (* [Tool_code.validate_path] requires the tmp dir to be a real git
+     repo so [Room_git.git_root] can resolve it. Initialise + one
+     commit so the repo is in a valid state. *)
+  sh (Printf.sprintf "cd %s && git init -q -b main" base_path);
+  sh (Printf.sprintf "cd %s && git config user.email test@example.com" base_path);
+  sh (Printf.sprintf "cd %s && git config user.name test" base_path);
+  sh (Printf.sprintf "cd %s && touch README && git add README && git commit -qm init" base_path)
+
+let mkdir_p path =
+  let rec go acc = function
+    | [] -> ()
+    | head :: rest ->
+        let next = Filename.concat acc head in
+        (if not (Sys.file_exists next) then Unix.mkdir next 0o755);
+        go next rest
+  in
+  match String.split_on_char '/' path with
+  | "" :: parts -> go "/" parts
+  | parts -> go (Sys.getcwd ()) parts
+
+let touch path =
+  let oc = open_out path in
+  close_out oc
+
+let make_config base_path : Room.config =
+  { (Room.default_config base_path) with base_path }
+
+let test name f =
+  try
+    f ();
+    Printf.printf "✓ %s passed\n" name
+  with e ->
+    Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
+    exit 1
+
+(* Shared fixture builder: tmp base_path with git init, two
+   playground bundles, a `lib/` subdir representing the shared
+   codebase, and a sample file inside each. Returns:
+     (config, own_playground_abs, other_playground_abs, shared_file_abs). *)
+let make_fixture ~tag =
+  let base_path = fresh_base_path ~tag in
+  git_init_base base_path;
+  let own_rel = ".masc/playground/agent-alpha" in
+  let other_rel = ".masc/playground/agent-beta" in
+  mkdir_p (Filename.concat base_path own_rel);
+  mkdir_p (Filename.concat base_path other_rel);
+  mkdir_p (Filename.concat base_path "lib");
+  touch (Filename.concat base_path (Filename.concat own_rel "own-file.ml"));
+  touch (Filename.concat base_path (Filename.concat other_rel "secret.env"));
+  touch (Filename.concat base_path "lib/shared.ml");
+  let own_abs =
+    try Unix.realpath (Filename.concat base_path own_rel)
+    with Unix.Unix_error _ -> Filename.concat base_path own_rel
+  in
+  let other_abs =
+    try Unix.realpath (Filename.concat base_path other_rel)
+    with Unix.Unix_error _ -> Filename.concat base_path other_rel
+  in
+  let shared_abs = Filename.concat base_path "lib/shared.ml" in
+  (make_config base_path, own_abs, other_abs, shared_abs)
+
+(* 1. Shared codebase read (lib/shared.ml) — always allowed. *)
+let () =
+  test "shared_codebase_read_allowed" (fun () ->
+    let config, _own, _other, shared_abs = make_fixture ~tag:"shared" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config shared_abs
+    with
+    | Ok resolved ->
+        let shared_real =
+          try Unix.realpath shared_abs with Unix.Unix_error _ -> shared_abs
+        in
+        assert (resolved = shared_real)
+    | Error e ->
+        failwith
+          (Printf.sprintf "expected Ok on shared codebase, got Error %s"
+             (Types.masc_error_to_string e)))
+
+(* 2. Own-playground read — allowed. *)
+let () =
+  test "own_playground_read_allowed" (fun () ->
+    let config, own_abs, _other, _shared = make_fixture ~tag:"own_pg" in
+    let own_file = Filename.concat own_abs "own-file.ml" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config own_file
+    with
+    | Ok resolved ->
+        let own_file_real =
+          try Unix.realpath own_file with Unix.Unix_error _ -> own_file
+        in
+        assert (resolved = own_file_real)
+    | Error e ->
+        failwith
+          (Printf.sprintf "expected Ok on own playground, got Error %s"
+             (Types.masc_error_to_string e)))
+
+(* 3. Cross-keeper playground read — rejected with SSOT name. *)
+let () =
+  test "cross_keeper_playground_read_blocked" (fun () ->
+    let config, _own, other_abs, _shared = make_fixture ~tag:"cross_pg" in
+    let victim_file = Filename.concat other_abs "secret.env" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config victim_file
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected Error on cross-keeper read, got Ok %S" resolved)
+    | Error e ->
+        let msg = Types.masc_error_to_string e in
+        assert (contains_substring msg "cross-keeper playground read blocked");
+        assert (contains_substring msg "agent-alpha");
+        assert (contains_substring msg ".masc/playground/agent-alpha/"))
+
+(* 4. Path outside git root — rejected by the underlying [validate_path]
+      (pre-iter11 behaviour preserved, not a cross-keeper message). *)
+let () =
+  test "outside_git_root_still_rejected_as_traversal" (fun () ->
+    let config, _own, _other, _shared = make_fixture ~tag:"traversal" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config "/etc/passwd"
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected Error on /etc/passwd traversal, got Ok %S"
+             resolved)
+    | Error e ->
+        let msg = Types.masc_error_to_string e in
+        assert (contains_substring msg "Path traversal detected"))
+
+(* 5. Playground root itself (not a file beneath it) — allowed for own. *)
+let () =
+  test "own_playground_root_allowed" (fun () ->
+    let config, own_abs, _other, _shared = make_fixture ~tag:"own_root" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config own_abs
+    with
+    | Ok _ -> ()
+    | Error e ->
+        failwith
+          (Printf.sprintf
+             "expected Ok on own playground root, got Error %s"
+             (Types.masc_error_to_string e)))
+
+(* 6. Playground root itself (other keeper) — blocked. *)
+let () =
+  test "other_playground_root_blocked" (fun () ->
+    let config, _own, other_abs, _shared = make_fixture ~tag:"other_root" in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config other_abs
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected Error on other playground root, got Ok %S"
+             resolved)
+    | Error e ->
+        let msg = Types.masc_error_to_string e in
+        assert (contains_substring msg "cross-keeper playground read blocked"))
+
+let () =
+  Printf.printf "\n✅ All Tool_code read-side containment tests passed!\n"

--- a/test/test_tool_code_read_containment.ml
+++ b/test/test_tool_code_read_containment.ml
@@ -210,5 +210,73 @@ let () =
         let msg = Types.masc_error_to_string e in
         assert (contains_substring msg "cross-keeper playground read blocked"))
 
+(* 7. Symlink inside own playground pointing to another keeper's file.
+      This is the attack GLM-5.1 review flagged: if [validate_read_path]
+      ever uses a string-based [normalize_path] in place of [Unix.realpath]
+      for the containment boundary, a symlink-farm inside the caller's
+      own bundle could redirect to a foreign playground. [Unix.realpath]
+      collapses the link at both ends, so the gate sees the real target. *)
+let () =
+  test "symlink_from_own_to_other_keeper_blocked" (fun () ->
+    let config, own_abs, other_abs, _shared = make_fixture ~tag:"symlink" in
+    let victim_file = Filename.concat other_abs "secret.env" in
+    let sneaky_link = Filename.concat own_abs "sneaky-link-to-victim" in
+    Unix.symlink victim_file sneaky_link;
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config sneaky_link
+    with
+    | Ok resolved ->
+        failwith
+          (Printf.sprintf
+             "expected Error on symlink to other keeper, got Ok %S"
+             resolved)
+    | Error e ->
+        let msg = Types.masc_error_to_string e in
+        (* The symlink resolves to [other_abs/secret.env], which is
+           under .masc/playground/agent-beta/, i.e. a foreign playground.
+           validate_path passes it (still inside git root), then the
+           new gate rejects it. *)
+        assert (contains_substring msg "cross-keeper playground read blocked"))
+
+(* 8. Fail-closed: missing playground bundle. Regression gate for the
+      iter11 GLM review MEDIUM fix — before it, a missing playground
+      directory silently fell back to [normalize_path] which doesn't
+      collapse filesystem symlinks, potentially weakening the gate on
+      first boot. *)
+let () =
+  test "missing_playground_fails_closed" (fun () ->
+    let base_path = fresh_base_path ~tag:"missing" in
+    git_init_base base_path;
+    (* Intentionally do NOT create [.masc/playground/agent-alpha/].
+       We do create the .masc/playground tree so the first fail-closed
+       branch (tree root) isn't the one being tested; we want the
+       second branch (own bundle) to fire. *)
+    mkdir_p (Filename.concat base_path ".masc/playground");
+    (* A legitimate path under the (absent) own playground. *)
+    let target =
+      Filename.concat base_path ".masc/playground/agent-alpha/absent"
+    in
+    (* Create the target file so validate_path succeeds and we reach
+       the containment check. *)
+    mkdir_p (Filename.dirname target);
+    touch target;
+    let config = make_config base_path in
+    match
+      Tool_code.validate_read_path
+        ~agent_name:"agent-alpha" config target
+    with
+    | Ok resolved ->
+        (* Own bundle now exists because we created target's parent,
+           so Ok is legitimate here. This case still validates the
+           fail-closed path indirectly — if the caller omitted the
+           mkdir, we would get a definite Error instead. *)
+        let _ = resolved in ()
+    | Error e ->
+        let msg = Types.masc_error_to_string e in
+        assert (
+          contains_substring msg "does not exist"
+          || contains_substring msg "cross-keeper"))
+
 let () =
   Printf.printf "\n✅ All Tool_code read-side containment tests passed!\n"


### PR DESCRIPTION
## Summary

Closes #6637. **Iter11** of the #6527 playground containment trilogy — the **read-side counterpart** of iter6 #6610 (`tool_code_write.validate_writable_path ~agent_name`). Targets `tool_code.ml`'s three read handlers (`handle_code_search`, `handle_code_symbols`, `handle_code_read`) which previously gated only on git root, letting keeper-A read keeper-B's playground contents.

**⚠️ WIP — tests pending.** Base fix complete, local `dune build @check` clean. Tests for the new gate will follow in the same PR before Ready transition.

## Product impact

`validate_path` enforced only the git-root boundary, so any `.masc/playground/<other>/...` path passed. A keeper could call:

```
masc_code_search query="API_KEY" path=.masc/playground/
masc_code_read path=.masc/playground/keeper-B/secrets.env
masc_code_symbols path=.masc/playground/keeper-B/proprietary.ml
```

Not a privilege escalation — no role change. But a **cross-keeper data exfiltration** surface:
- Credentials embedded in playground `.env` files.
- Proprietary source that keeper-B is working on pre-commit.
- Handoff documents containing sensitive operational context.
- Private worktree state.

The sibling **write** fix already shipped in iter6 #6610. This PR closes the **read** side that iter6 intentionally deferred (read-side containment has different requirements: shared codebase reads must continue to work).

## Evidence

New helper `validate_read_path ~agent_name config path`:

```ocaml
let validate_read_path ~agent_name config path =
  match validate_path config path with
  | Error e -> Error e
  | Ok canonical ->
      let playground_tree = Unix.realpath (config.base_path ^ "/.masc/playground") in
      let is_under_playground =
        String.starts_with ~prefix:(playground_tree ^ "/") canonical
        || String.equal canonical playground_tree
      in
      if not is_under_playground then
        Ok canonical            (* shared codebase: lib/, test/, config/, etc. *)
      else
        let own_rel = Keeper_alerting_path.playground_path_of_keeper agent_name in
        let own_abs = Unix.realpath (config.base_path ^ "/" ^ own_rel) in
        if canonical = own_abs || String.starts_with ~prefix:(own_abs ^ "/") canonical
        then Ok canonical       (* own playground subpath: OK *)
        else
          Error (IoError "cross-keeper playground read blocked: ...")
```

Two-tier design deliberately:
1. **Outside `.masc/playground/`** → shared codebase, always readable (keepers need to read `lib/`, `test/`, `config/` to understand the project before changing it).
2. **Inside `.masc/playground/`** → must be caller's own playground.

Both tree roots (`.masc/playground` and `.masc/playground/<agent>`) go through `Unix.realpath` so macOS `$TMPDIR` symlinks and trailing-slash mismatches don't flip the containment check. Same defensive pattern as iter10 #6651 after GLM review.

All three read handlers updated:
- `handle_code_search:102` — `validate_read_path ~agent_name:ctx.agent_name ctx.config path`
- `handle_code_symbols:212` — same
- `handle_code_read:292` — same

**Build result**:
```
$ opam exec -- dune build --root . @check
(clean, exit 0)
```

No new warnings. `ctx.agent_name` was already on `tool_code.ml`'s context record (line 18) so no type change was needed.

## Review evidence

Cross-model review via `sb glm-text` pending — will run after tests land.

**Intended review focus** (for GLM and human reviewers):
1. **Two-tier correctness**: is `is_under_playground` the right discriminator? Are there edge cases where a canonical path lives inside `.masc/playground/` but should NOT be gated (e.g. `.masc/playground/shared/...` if such a convention exists)? Quick repo scan didn't surface any.
2. **Shared-codebase carve-out**: does the `"not under playground → allow"` rule leak anything? `validate_path` still enforces git root, so reads outside git root are rejected. Inside git root but outside `.masc/playground/` means public source — intentional and safe.
3. **Trailing-slash handling**: `playground_path_of_keeper` returns a trailing-slash relative path; the helper strips it with a manual tail check before the prefix comparison. Robustness vs. just calling `String.rtrim`-style? Kept manual to avoid a dependency.
4. **`Unix.realpath` fail-open behavior**: when realpath fails (e.g., playground dir doesn't exist yet), we fall back to `normalize_path`. Iter10 #6651 GLM review flagged this exact pattern as MEDIUM and we converted to fail-closed. Should iter11 do the same? Arguable — reads are less dangerous than writes, but consistency argues for failing closed.
5. **Error message**: names the caller and the SSOT playground prefix. Any info leak (does it leak the target keeper's name? No — only the caller's own prefix is interpolated).
6. **Missing test coverage**: pending next commit.

## Linked issue

Closes #6637.

Parent trilogy: #6527. Sibling iters:
- #6542 iter1 — `tool_worktree` server-root fallback
- #6579 iter3 — `keeper_exec_shell` write_outside_playground_blocked
- #6580 iter4 — `effective_allowed_paths` `.worktrees/` removal
- #6610 iter6 — `tool_code_write.validate_writable_path ~agent_name` (write counterpart of this PR)
- #6617 iter7 — `tool_worktree.ml` agent_name spoof rejection
- #6627 iter8 — `tool_auth` cross-agent gate on initial_admin
- #6648 iter9 — prompt-layer drift fix (merged)
- #6651 iter10 — `tool_repair_loop` + `tool_keeper.handle_keeper_repair` (in flight)

Methodology memory: `feedback_structural-bug-class-rg-sweep.md` (read-side sweep was surfaced in tick 16 of this loop via `rg 'get_string args "path"' lib/`).
