### PR TITLE
fix(log): demote idle SSE housekeeping info to debug when client_count=0

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -359,8 +359,20 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
             Log.Server.info "Reaped %d stale connections (active: %d)"
               (List.length stale_sids) (Sse.client_count ());
           let evicted_events = Sse.cleanup_expired_events () in
-          if evicted_events > 0 then
-            Log.Server.info "Evicted %d expired SSE buffer events" evicted_events;
+          if evicted_events > 0 then begin
+            (* Same rationale as the namespace-truth broadcast log below:
+               when zero SSE clients are attached, the eviction loop is
+               garbage-collecting events that nobody would ever replay,
+               which is routine housekeeping rather than an
+               operator-actionable signal. Emit at INFO only when at
+               least one client is on the wire — otherwise DEBUG. *)
+            let log_fn =
+              if Sse.client_count () > 0
+              then Log.Server.info
+              else Log.Server.debug
+            in
+            log_fn "Evicted %d expired SSE buffer events" evicted_events
+          end;
           let evicted = Cache_eio.evict_expired state.room_config in
           if evicted > 0 then
             Log.Server.info "Cache: evicted %d expired entries" evicted;

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -226,7 +226,19 @@ let broadcast_namespace_truth_snapshot (state : Mcp_server.server_state) : unit 
       ignore
         (Server_meta_cognition_feedback.maybe_post_digest
            ~config:state.Mcp_server.room_config snapshot);
-      Log.Dashboard.info "namespace-truth snapshot pushed via SSE"
+      (* Demote the "pushed via SSE" log to DEBUG when no SSE client is
+         connected. With zero observers, the broadcast still runs (for
+         the replay buffer and external subscribers) but the log line
+         is pure housekeeping noise — once per minute for 96 minutes
+         straight in a fresh masc-server.log when nothing is tailing
+         /namespace-truth. Operators only care about this signal when
+         there is an actual client on the wire. *)
+      let log_fn =
+        if Sse.client_count () > 0
+        then Log.Dashboard.info
+        else Log.Dashboard.debug
+      in
+      log_fn "namespace-truth snapshot pushed via SSE"
   | Some _ ->
       Log.Dashboard.debug "namespace-truth snapshot unchanged, skipping SSE broadcast"
 


### PR DESCRIPTION
## Summary
/loop on 2026-04-12 observed 180+ INFO lines/hour in `/tmp/masc-min-p-restart.log` from two SSE-housekeeping log sites while `/health` reported `sse_clients: 0` for the entire 96-min uptime window.

| Log site | Rate | Cumulative (96 min) |
|----------|------|---------------------|
| `server_dashboard_http_namespace_truth.ml:229` "namespace-truth snapshot pushed via SSE" | ~1/min | 88 |
| `server_bootstrap_loops.ml:363` "Evicted N expired SSE buffer events" | ~1/min | 94 |

Both fire inside work branches that still have legitimate reasons to run (replay buffer, external subscribers, TTL GC), so the work itself is fine. The logs, however, are pure housekeeping — nothing for an operator to act on unless there's a real client on the wire.

## Fix
Branch each INFO log on `Sse.client_count () > 0`:
- `client_count > 0` → `Log.<Module>.info` (operator wants the signal when someone is actually watching)
- `client_count = 0` → `Log.<Module>.debug` (housekeeping, silent by default)

No behavior change. The broadcast and eviction still run; only the level of the single log line shifts. `Sse.client_count ()` is an `Atomic.get int` — negligible cost.

## Stacking context
Independent of #6661 / #6662 / #6655 merge chain. Can land at any time. The three PRs in flight address orthogonal log-noise / test / classifier issues.

## Test plan
- [x] `dune build` green
- [x] Read both log sites; confirmed each is inside a "non-trivial work happened" guard (`Some snapshot when should_broadcast_namespace_truth_snapshot`, `evicted_events > 0`), so the client_count check only runs when we'd have logged anyway — no new hot path.
- [ ] CI Build and Test green
- [ ] Manual smoke: after rebuild + restart, tail `/tmp/masc-server.log` with no SSE client attached — neither message should appear at INFO. Attach a dashboard client via `/sse` and confirm INFO returns.

## Observability trade-off
The eviction log in particular was a weak "I'm alive" heartbeat for the bootstrap loops subsystem. After this change, `/health` remains the authoritative liveness signal; the log becomes a per-client-activity breadcrumb rather than a per-second heartbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
