### PR TITLE
fix(keeper): classify Eio Not_found as checkpoint Not_found, stop error spam

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -157,11 +157,21 @@ type checkpoint_load_error =
   | Parse_error of string
   | Io_error of string
 
+let string_contains_sub ~sub s =
+  let sub_len = String.length sub and s_len = String.length s in
+  if sub_len > s_len then false
+  else
+    let rec loop i =
+      if i > s_len - sub_len then false
+      else if String.sub s i sub_len = sub then true
+      else loop (i + 1)
+    in loop 0
+
 let is_not_found_detail (detail : string) : bool =
   let d = String.lowercase_ascii detail in
-  String.starts_with ~prefix:"no_such_file" d  (* Eio.Fs.Not_found *)
-  || String.starts_with ~prefix:"no such file" d
-  || String.starts_with ~prefix:"unix_error (enoent" d  (* POSIX *)
+  string_contains_sub ~sub:"not_found" d
+  || string_contains_sub ~sub:"no such file" d
+  || string_contains_sub ~sub:"enoent" d
 
 let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   match e with


### PR DESCRIPTION
## Summary
- `is_not_found_detail` used `starts_with` prefix matching, but Eio wraps errors as `"Eio.Io Fs Not_found Unix_error (No such file...)"` which doesn't match
- Switch to substring matching (`contains "not_found"`, `"no such file"`, `"enoent"`)
- First-boot missing checkpoint files are now silently ignored instead of ERROR-logged every ~30s

## Root cause
`Printexc.to_string (Eio.Io ...)` produces `"Eio.Io Fs Not_found Unix_error (No such file or directory, ...)"`.
The old code checked `starts_with "no_such_file"` / `"no such file"` / `"unix_error (enoent"` — none matched because the string starts with `"eio.io"`.

## Test plan
- [x] Library builds clean
- [ ] Deploy and verify error spam stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)