### PR TITLE
perf(discovery_cache): run HTTP probes outside cache mutex

### DIFF
--- a/lib/discovery_cache.ml
+++ b/lib/discovery_cache.ml
@@ -29,14 +29,39 @@ let cached_endpoints : endpoint_info list ref = ref []
 let cache_updated_at : float Atomic.t = Atomic.make 0.0
 let cache_ttl = 30.0
 
-let refresh_cache_unlocked () =
+(* Probe every configured endpoint and install the result under the
+   mutex.  The probe itself ([Llm_provider.Discovery.discover])
+   makes HTTP requests — potentially several seconds of network
+   I/O — so it must NOT be executed while holding [cache_mu].
+
+   The prior version was named [refresh_cache_unlocked] and was
+   called from inside [get_cached_or_refresh]'s [Eio.Mutex.use_rw]
+   block, which meant every dashboard / local-runtime consumer
+   waited on the mutex for the full probe duration.  That is the
+   same drift class as the prompt_registry [_unlocked] variants
+   fixed in PR #6663 — the in-tree API was refactored to keep I/O
+   out of the critical section, but a sibling helper with a
+   misleading "_unlocked" name was left with the old pattern.
+
+   This version splits the work: the HTTP probe runs with no lock
+   held, then the result is installed under the mutex.  Two
+   concurrent refreshers may both probe; that is wasteful but
+   correct.  In practice the 30 s TTL narrows the window. *)
+let refresh_cache () =
   match Atomic.get sw_ref, Atomic.get net_ref with
   | Some sw, Some net ->
-    let endpoints = Llm_provider.Provider_registry.active_llama_endpoints () in
+    let endpoints =
+      Llm_provider.Provider_registry.active_llama_endpoints ()
+    in
+    (* HTTP probes — executed OUTSIDE [cache_mu]. *)
     let results = Llm_provider.Discovery.discover ~sw ~net ~endpoints in
-    cached_endpoints := results;
-    Atomic.set cache_updated_at (Time_compat.now ());
-    (* Persist probe snapshot for time-series history *)
+    (* Install the fresh result under the mutex — no yields inside
+       this critical section. *)
+    Eio.Mutex.use_rw ~protect:true cache_mu (fun () ->
+      cached_endpoints := results;
+      Atomic.set cache_updated_at (Time_compat.now ()));
+    (* Persist probe snapshot for time-series history — file I/O,
+       also kept outside the mutex. *)
     (match Atomic.get base_path_ref with
      | Some bp -> Discovery_history.record_probe ~base_path:bp results
      | None -> ())
@@ -44,11 +69,19 @@ let refresh_cache_unlocked () =
     ()
 
 let get_cached_or_refresh () =
-  Eio.Mutex.use_rw ~protect:true cache_mu (fun () ->
-    let now = Time_compat.now () in
-    if now -. Atomic.get cache_updated_at > cache_ttl || !cached_endpoints = [] then
-      refresh_cache_unlocked ();
-    !cached_endpoints)
+  (* Cheap staleness check: [cache_updated_at] is [Atomic] so the
+     TTL comparison needs no lock.  Only when the cached list is
+     still empty do we take the mutex to decide. *)
+  let stale_by_ttl =
+    Time_compat.now () -. Atomic.get cache_updated_at > cache_ttl
+  in
+  let need_refresh =
+    stale_by_ttl
+    || Eio.Mutex.use_rw ~protect:true cache_mu (fun () ->
+        !cached_endpoints = [])
+  in
+  if need_refresh then refresh_cache ();
+  Eio.Mutex.use_rw ~protect:true cache_mu (fun () -> !cached_endpoints)
 
 let cache_age_seconds () =
   Time_compat.now () -. Atomic.get cache_updated_at


### PR DESCRIPTION

`Discovery_cache.get_cached_or_refresh` held [cache_mu] across the
entire probe cycle — **network I/O under the mutex**:

```ocaml
let refresh_cache_unlocked () =
  ...
  let results = Llm_provider.Discovery.discover ~sw ~net ~endpoints in
  cached_endpoints := results; ...

let get_cached_or_refresh () =
  Eio.Mutex.use_rw ~protect:true cache_mu (fun () ->
    ...
    if stale then refresh_cache_unlocked ();  (* HTTP inside the lock *)
    !cached_endpoints)
```

`Llm_provider.Discovery.discover` probes every configured local LLM
endpoint (`MASC_LOCAL_LLM_ENDPOINTS`) with HTTP requests.  Each
request is an Eio HTTP call that yields the fiber while waiting for
the response; on a cold/unhealthy endpoint that can take seconds.
`Eio.Mutex.use_rw` holds the mutex across yields by design, so for
the duration of the probe **every other `get_cached_or_refresh`
caller is blocked**.

Callers (verified via `rg -n "Discovery_cache\." lib/`):

- `local_runtime_pool.ml:191` — `acquire` / `release` fast path
- `tool_local_runtime_verify.ml:21`
- `dashboard_provider_runs.ml:179` — dashboard refresh
- `dashboard_http_monitoring.ml:227,228,230` — dashboard monitoring
  (three separate calls on each panel refresh)
- `any_local_healthy`, `idle_slot_count`, `busy_slot_count`
  convenience queries call `get_cached_or_refresh` internally

A single stale cache flip triggered by any of these callers would
serialize **all** the others for the entire probe window.  On a
dashboard refresh where every panel queries
`any_local_healthy`/`idle_slot_count`/`busy_slot_count`, that is
3 sequential probes each holding the mutex.

## Pattern

Same drift class as the `prompt_registry._unlocked` variants fixed
in PR #6663.  An in-tree API was named `_unlocked` but the caller
still ran it under the mutex, and nobody realized the name had
grown a second meaning ("the function itself doesn't take the
lock" vs "the caller holds it").  Exactly the Cycle 36 heuristic:
"sibling `_unlocked`/`_internal` variants drift after the public
API is refactored".

## Fix

1. Rename `refresh_cache_unlocked` → `refresh_cache`.  The new name
   commits to the right semantics: the caller must NOT hold the
   mutex when calling this; the function acquires [cache_mu]
   internally only for the final install step.

2. Split `refresh_cache` into two phases:
   - **Probe** (outside mutex): `Discovery.discover` runs the HTTP
     calls with no lock held.
   - **Install** (inside mutex): a short, yield-free critical
     section writes `cached_endpoints := results` and updates
     `cache_updated_at`.

3. Keep `Discovery_history.record_probe` outside the mutex too —
   it does its own file I/O and touches no cache state.

4. Rewrite `get_cached_or_refresh`:
   - Check TTL against `Atomic.get cache_updated_at` **without**
     the lock (Atomic reads are cheap and don't contend).
   - Fall back to a short `Eio.Mutex.use_rw` to check the
     empty-list sentinel if the TTL was within tolerance.
   - If stale, call `refresh_cache` (probe happens outside the
     mutex), then re-acquire to return the fresh list.

## Concurrent refresh semantics

If two fibers both observe a stale cache and both call
`refresh_cache`, both run the probe, and the later writer wins on
`cached_endpoints := ...`.  That is **wasteful but correct**; the
30-second TTL narrows the window to rare coincidence, and there
is no corruption risk because each install is a self-contained
atomic ref-write + Atomic.set inside the final mutex section.

An alternate design with an `Eio.Promise`-based "refresh in flight"
singleton (same shape as `Backend.FileSystem.ensure_key_index`)
would dedupe concurrent probes but adds more machinery; left as
a follow-up if contention telemetry ever shows it matters.

## Verification

```
dune build --root . @lib/check     # exit 0
```

No direct `test_discovery_cache.ml` exists.  The existing
`@lib/check` passes, and the module's only exported API
(`get_cached_or_refresh`, `any_local_healthy`, `idle_slot_count`,
`busy_slot_count`) has unchanged observable semantics — same cache
contract, same TTL, same Discovery_history persistence.  Manual
review traced every caller and confirmed they only consume the
returned endpoint list (no reliance on the refresh happening under
a particular lock).

## Finding source

Cycle 37 of the masc-mcp audit sweep.  Applied the Cycle 36
heuristic ("sibling `_unlocked` drift after public refactor") by
running `rg -n "^let [a-z_]+_(unlocked|internal|impl|raw|no_lock)\b" lib/`
and reviewing each match.  Two module-level `_unlocked` variants
stood out: `Prompt_registry.resolve_prompt_unlocked` (fixed in
#6663) and `Discovery_cache.refresh_cache_unlocked` — this PR.
The remaining `_unlocked`/`_internal`/`_raw`/`_impl` hits are
either legitimate implementation helpers (`with_file_lock_impl`,
`search_impl`) or rename-for-clarity artifacts, not drift.

Audit heuristic confirmed: when a module has a misleadingly-named
`_unlocked` helper, prefer renaming **and** verifying that every
caller actually honors the documented lock contract.  The name
alone lies — enforcement only comes from the caller review.