### PR TITLE
feat(cascade): add coding_plan profile + strict provider allowlist guard

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -20,9 +20,15 @@
     "groq:qwen/qwen3-32b",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "glm-coding = Coding Plan (subscription). glm = general API (pay-per-use). groq = Groq LPU ($0.29/$0.59 per M, GROQ_API_KEY). local last. glm-4.7 dropped 2026-04-11: 100% HTTP 500 on keeper-size bodies (#6567); glm-5.1 succeeds, fallback unchanged.",
+  "coding_plan_models": [
+    "glm-coding:glm-5.1",
+    "ollama:qwen3.5:35b-a3b-nvfp4"
+  ],
+  "_comment": "Profile semantics. glm-coding = Z.AI Coding Plan (subscription, api.z.ai/api/coding/paas/v4, ZAI_API_KEY). glm = Z.AI general API (pay-per-use, api.z.ai/api/paas/v4). groq = Groq LPU ($0.29/$0.59 per M, GROQ_API_KEY). ollama = local MLX. glm-4.7 dropped 2026-04-11: 100% HTTP 500 on keeper-size bodies (#6567); glm-5.1 succeeds. coding_plan profile is the coding-plan-only cascade: no general-API fallback (1113 when the operator has no pay-per-use balance), no paid Groq hop, just coding endpoint then local — use it for keepers whose operator is strictly on the Z.AI Coding Plan subscription. coding_first is the 4-tier safety net that includes paid fallbacks for operators with both plans.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 65536,
+  "coding_plan_temperature": 0.2,
+  "coding_plan_max_tokens": 65536,
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -173,6 +173,76 @@ let test_unknown_provider_is_dropped () =
         true
         (List.length parsed < List.length strings))
 
+(** Semantic contract for the [coding_plan] profile: every entry must
+    resolve to a provider whose endpoint is part of the Z.AI Coding Plan
+    subscription (no pay-per-use general API, no paid Groq hop) or to a
+    free local provider. This keeps the profile honest for operators who
+    are strictly on the Coding Plan — a stray [glm:*] entry would silently
+    bleed into the general API and hit HTTP 429 / code 1113.
+
+    Allowlist is data, not code: the test reads [coding_plan_allowed_providers]
+    from cascade.json if present and falls back to a minimal baseline
+    ({glm-coding, ollama}) otherwise. Adding a new coding-plan-compatible
+    provider is a JSON edit, not an OCaml edit. *)
+let baseline_coding_plan_providers = [ "glm-coding"; "ollama" ]
+
+let load_coding_plan_allowed_providers path : string list =
+  let ic = open_in path in
+  let content =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let len = in_channel_length ic in
+        let buf = Bytes.create len in
+        really_input ic buf 0 len;
+        Bytes.to_string buf)
+  in
+  let json = Yojson.Safe.from_string content in
+  let open Yojson.Safe.Util in
+  match json |> member "coding_plan_allowed_providers" with
+  | `List items ->
+    List.filter_map
+      (function `String s -> Some (String.trim s) | _ -> None)
+      items
+  | _ -> baseline_coding_plan_providers
+
+let split_provider_model s =
+  (* Mirror OAS split_provider_model without re-exporting it: find the
+     first ':' that does not precede a "custom@" tail. cascade.json
+     entries use "provider:model_id" or "provider:model:with:colons"
+     (e.g. "ollama:qwen3.5:35b-a3b-nvfp4"). We only need the provider
+     prefix, so first ':' is enough. *)
+  match String.index_opt s ':' with
+  | None -> None
+  | Some i ->
+    let provider = String.sub s 0 i |> String.lowercase_ascii |> String.trim in
+    let rest = String.sub s (i + 1) (String.length s - i - 1) in
+    Some (provider, rest)
+
+let test_coding_plan_profile_is_strict () =
+  let path = cascade_path () in
+  let strings = load_profile_strings ~path ~profile:"coding_plan" in
+  check bool "coding_plan profile has entries" true (strings <> []);
+  let allowed = load_coding_plan_allowed_providers path in
+  List.iter
+    (fun s ->
+      match split_provider_model s with
+      | None ->
+        Alcotest.fail
+          (Printf.sprintf
+             "coding_plan: %S has no provider prefix (expected \
+              'provider:model_id')"
+             s)
+      | Some (provider, _model) ->
+        check bool
+          (Printf.sprintf
+             "coding_plan: %S uses an allowed provider (%s)"
+             s
+             (String.concat "|" allowed))
+          true
+          (List.mem provider allowed))
+    strings
+
 let () =
   let path = cascade_path () in
   let profiles = discover_profiles path in
@@ -194,5 +264,12 @@ let () =
             "unknown provider dropped (meta-guard)"
             `Quick
             test_unknown_provider_is_dropped;
+        ] );
+      ( "coding_plan",
+        [
+          test_case
+            "coding_plan profile uses only coding-plan-compatible providers"
+            `Quick
+            test_coding_plan_profile_is_strict;
         ] );
     ]


### PR DESCRIPTION
## 요약

Z.AI Coding Plan 구독자를 위한 전용 cascade 프로필 `coding_plan`을 추가합니다. 기존 4-tier `coding_first` 는 glm-coding → glm → groq → ollama 순서라 Coding Plan만 쓰는 운영자에게는 2순위 `glm:glm-5.1` 이 매 호출마다 HTTP 429 / code 1113 ("Insufficient balance")로 실패하면서 Ollama 도달까지 한 홉을 낭비합니다. `coding_plan` 은 그 낭비를 제거합니다.

```json
"coding_plan_models": [
  "glm-coding:glm-5.1",
  "ollama:qwen3.5:35b-a3b-nvfp4"
]
```

## 왜 이 형태인가

- **No hardcoding, no heuristic, configuration-driven**. Coding-plan 호환 공급자 목록을 `coding_plan_allowed_providers` JSON 필드로 override 할 수 있게 했고, 기본 baseline은 `{glm-coding, ollama}` 만 하드코딩으로 남깁니다. 새로운 coding-plan 공급자가 생기면 JSON 편집만으로 추가 가능.
- **OAS 변경 불필요**. OAS `Cascade_config_loader.load_profile ~name` 이 임의 `<name>_models` 키를 읽는 generic interface 라 cascade.json 추가만으로 동작. 현재 pinned OAS SHA는 이미 `glm-coding` 을 first-class provider 로 인식 (`provider_registry.ml` `glm_coding_defaults`, base URL `api.z.ai/api/coding/paas/v4`).
- **기존 프로필 무변화**. `default`, `local_only`, `keeper_unified`, `coding_first` 는 건드리지 않아 기존 keeper 동작이 바뀌지 않습니다. `coding_plan` 은 opt-in 프로필로, 운영자가 명시적으로 `cascade_name = "coding_plan"` 으로 키퍼 설정을 전환할 때만 활성화됩니다.

## 테스트

`test/test_cascade_config_validity.ml` 에 2가지 보강을 넣었습니다.

1. **자동 profile 발견**. 기존 `discover_profiles` 가 `_models` 접미사 스캔으로 새 프로필을 자동 감지 → `coding_plan` 은 자동으로 parse 검증을 받습니다. OCaml 편집 없이 JSON 편집만으로 커버리지 확보되는 게 원래 의도였습니다 (#6478 iter 5 패턴 유지).
2. **Strictness 가드** (`test_coding_plan_profile_is_strict`). 모든 `coding_plan_models` 항목이 allowlist 공급자(`glm-coding`, `ollama`)에 속하는지 assert. 실수로 `glm:*` 또는 `groq:*` 가 끼면 테스트가 loud fail:

```
FAIL coding_plan: "glm:glm-5.1" uses an allowed provider (glm-coding|ollama)
```

Negative fixture 로컬 검증 완료 (일시적으로 `glm:glm-5.1` 삽입 → 실패 재현 → 복원).

### 로컬 실행 결과

```
Testing `Cascade config validity'.
  [OK]  profiles    0  default parses cleanly.
  [OK]  profiles    1  local_only parses cleanly.
  [OK]  profiles    2  keeper_unified parses cleanly.
  [OK]  profiles    3  coding_first parses cleanly.
  [OK]  profiles    4  coding_plan parses cleanly.
  [OK]  regression  0  unknown provider dropped (meta-guard).
  [OK]  coding_plan 0  coding_plan profile uses only coding-plan-compatible providers.

Test Successful in 0.005s. 7 tests run.
```

## 관련

- masc-mcp #6475 — `glm-coding` 을 `glm` 앞에 배치한 원래 routing fix. 이 PR은 그 전략을 "Coding Plan 전용" 이라는 **의도의 명시** 로 발전시킵니다.
- masc-mcp #6478 (merged) — `MASC_KEEPER_CASCADE_PROVIDER_ALLOWLIST` env knob + static validity test 프레임워크. 이 PR은 그 테스트 프레임워크의 discover_profiles 패턴을 그대로 활용합니다.
- oas #801 (merged) — `OAS_OLLAMA_SUPPORTS_TOOL_CHOICE` env override + `parse_model_string_exn` error contract. 이 PR은 OAS 변경 없이 동일 contract 위에서 동작합니다.

## Files

- `config/cascade.json` (+8/-1): 새 프로필 + 업데이트된 `_comment` (플랜 의미 명시).
- `test/test_cascade_config_validity.ml` (+77): strictness 테스트 + allowlist 로더.

## Test plan

- [x] `dune build --root . test/test_cascade_config_validity.exe` — clean.
- [x] `MASC_CASCADE_JSON_PATH=config/cascade.json _build/default/test/test_cascade_config_validity.exe` — 7/7 pass, 0.005s.
- [x] Negative fixture (forbidden `glm:glm-5.1` 삽입) — 예상대로 loud fail, 정확한 offending entry 메시지.
- [ ] CI: Build & Test (OCaml 5.4.1), Lint, Version Consistency.
- [ ] Optional follow-up: specific keeper configs opt-in 전환 (별도 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
