### PR TITLE
perf(memory_oas_bridge): move episode JSONL load outside cache mutex

### DIFF
--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -90,19 +90,56 @@ let episode_ids_of episodes =
    Callers that need fewer use cached_recent_episodes ~limit. *)
 let episode_cache_limit = 500
 
-let load_all_episodes_cached_unlocked () =
-  let path = Institution_eio.episodes_jsonl_path () in
+(* Pure cache construction: stat + JSONL read + build a fresh
+   [episode_file_cache].  Touches no shared state, so safe to run
+   with no lock held. *)
+let build_episode_cache_from_disk path =
   let stamp = file_stamp_opt path in
-  match Hashtbl.find_opt episode_file_cache_tbl path with
-  | Some cache when cache.stamp = stamp -> cache
-  | _ ->
-      let episodes = Institution_eio.load_recent_episodes_jsonl ~limit:episode_cache_limit in
-      let cache = { stamp; episodes; ids = episode_ids_of episodes } in
-      Hashtbl.replace episode_file_cache_tbl path cache;
-      cache
+  let episodes =
+    Institution_eio.load_recent_episodes_jsonl ~limit:episode_cache_limit
+  in
+  { stamp; episodes; ids = episode_ids_of episodes }
 
+(* Cache-aware episode loader.
+
+   Previously held [episode_cache_mu] across
+   [Institution_eio.load_recent_episodes_jsonl] on every cache miss,
+   meaning all concurrent [seed_episodes] / [persisted_episode_ids]
+   / [cached_recent_episodes] callers serialised on a single JSONL
+   read of up to [episode_cache_limit = 500] records.  Same drift
+   class as the [Prompt_registry] / [Discovery_cache] siblings fixed
+   in PRs #6663 / #6668 — an [_unlocked] helper was called from
+   inside the caller's [with_mutex], re-introducing the
+   I/O-under-lock anti-pattern.
+
+   Split into:
+   1. Stamp check under the mutex (pure [Hashtbl.find_opt] +
+      [Unix.stat]).
+   2. Hot path returns the cached record if the stamp still matches.
+   3. On miss, release the lock, build the cache from disk outside
+      the lock, install under a fresh short mutex section.
+
+   Concurrent misses may both run the JSONL read; that is wasteful
+   but correct (the last writer wins on [Hashtbl.replace]).  In
+   practice the stamp check short-circuits the vast majority of
+   calls. *)
 let load_all_episodes_cached () =
-  Eio_guard.with_mutex episode_cache_mu load_all_episodes_cached_unlocked
+  let path = Institution_eio.episodes_jsonl_path () in
+  let cached_opt =
+    Eio_guard.with_mutex episode_cache_mu (fun () ->
+      let current_stamp = file_stamp_opt path in
+      match Hashtbl.find_opt episode_file_cache_tbl path with
+      | Some cache when cache.stamp = current_stamp -> Some cache
+      | _ -> None)
+  in
+  match cached_opt with
+  | Some cache -> cache
+  | None ->
+      (* JSONL read OUTSIDE the mutex. *)
+      let fresh = build_episode_cache_from_disk path in
+      Eio_guard.with_mutex episode_cache_mu (fun () ->
+        Hashtbl.replace episode_file_cache_tbl path fresh);
+      fresh
 
 let cached_recent_episodes ~limit =
   let cache = load_all_episodes_cached () in
@@ -116,33 +153,49 @@ let cached_recent_episodes ~limit =
     in
     drop (total - limit) cache.episodes
 
+(* Record an episode that was just appended to the JSONL file.
+
+   Previously called [load_all_episodes_cached_unlocked] while
+   holding [episode_cache_mu], which meant a cache-miss during
+   flush would block on the same under-mutex JSONL read the main
+   fix addresses above.  Instead, look the cache up in place: if
+   it exists, mutate in place (fast path — no I/O); if it's
+   missing, skip — the next [load_all_episodes_cached] call will
+   populate a fresh cache from disk including the newly-appended
+   episode.
+
+   The [stamp] update keeps the cache in sync with the file's new
+   mtime so subsequent loaders do not trigger a reload purely
+   because [note_episode_flush] just wrote to the file. *)
 let note_episode_flush (episode : Institution_eio.episode) =
+  let path = Institution_eio.episodes_jsonl_path () in
   Eio_guard.with_mutex episode_cache_mu (fun () ->
-    let path = Institution_eio.episodes_jsonl_path () in
-    let cache = load_all_episodes_cached_unlocked () in
-    if not (Hashtbl.mem cache.ids episode.id) then begin
-      let episodes = cache.episodes @ [episode] in
-      (* Trim oldest entries when cache exceeds limit *)
-      let total = List.length episodes in
-      let episodes =
-        if total > episode_cache_limit then
-          let drop_n = total - episode_cache_limit in
-          let rec drop n = function
-            | [] -> []
-            | remaining when n <= 0 -> remaining
-            | (ep : Institution_eio.episode) :: rest ->
-                Hashtbl.remove cache.ids ep.id;
-                drop (n - 1) rest
-          in
-          drop drop_n episodes
-        else
-          episodes
-      in
-      cache.episodes <- episodes;
-      Hashtbl.replace cache.ids episode.id ();
-    end;
-    cache.stamp <- file_stamp_opt path;
-    Hashtbl.replace episode_file_cache_tbl path cache)
+    match Hashtbl.find_opt episode_file_cache_tbl path with
+    | None -> ()  (* No cache to update; next loader will populate fresh *)
+    | Some cache ->
+      if not (Hashtbl.mem cache.ids episode.id) then begin
+        let episodes = cache.episodes @ [episode] in
+        (* Trim oldest entries when cache exceeds limit *)
+        let total = List.length episodes in
+        let episodes =
+          if total > episode_cache_limit then
+            let drop_n = total - episode_cache_limit in
+            let rec drop n = function
+              | [] -> []
+              | remaining when n <= 0 -> remaining
+              | (ep : Institution_eio.episode) :: rest ->
+                  Hashtbl.remove cache.ids ep.id;
+                  drop (n - 1) rest
+            in
+            drop drop_n episodes
+          else
+            episodes
+        in
+        cache.episodes <- episodes;
+        Hashtbl.replace cache.ids episode.id ();
+      end;
+      cache.stamp <- file_stamp_opt path;
+      Hashtbl.replace episode_file_cache_tbl path cache)
 
 type procedure_file_cache = {
   mutable stamp : file_stamp option;


### PR DESCRIPTION

`Memory_oas_bridge.load_all_episodes_cached` held
`episode_cache_mu` across `Institution_eio.load_recent_episodes_jsonl`
on every cache miss — **disk I/O under the mutex** for up to 500
records per read.  Same drift class as the Cycle 36 / 37 siblings:

- Cycle 36 / PR #6663: `prompt_registry.resolve_prompt_unlocked`
- Cycle 37 / PR #6668: `discovery_cache.refresh_cache_unlocked`
- Cycle 38 / **this PR**: `memory_oas_bridge.load_all_episodes_cached_unlocked`

All three shared the pattern: a helper named `_unlocked` whose
caller wrapped it in the module's `with_mutex`, re-introducing the
exact I/O-under-lock anti-pattern a sibling public API had been
refactored to avoid.  Cycle 36 established the audit heuristic
("sibling `_unlocked` variants drift after the public refactor");
this PR closes the last module-level `_unlocked` helper in the
module-level scan.

## Callers of `load_all_episodes_cached`

- `persisted_episode_ids` (line 379) → `flush_episodes` (line 401,
  called from `tool_autoresearch_cycle.ml`,
  `keeper_agent_run.ml:1507`)
- `cached_recent_episodes` (line 107) → `seed_episodes` (line 386,
  called from `tool_autoresearch_cycle.ml`,
  `keeper_agent_run.ml:1384`)
- `note_episode_flush` (line 119) ran
  `load_all_episodes_cached_unlocked` **inside** its own mutex
  section on every flush

On an autoresearch cycle that seeds episodes into a fresh keeper,
every `seed_episodes` call used to serialise on a single JSONL
read of up to 500 episodes under the mutex.  Parallel autoresearch
keepers (each with its own MASC base path, different cache key but
same code path) did not contend directly, but any workflow that
interleaved `seed_episodes` with `flush_episodes` on the same
base path blocked until the flush's `note_episode_flush` finished
its in-lock load too.

## Fix

1. **`build_episode_cache_from_disk path`** — new helper that does
   `file_stamp_opt` + `load_recent_episodes_jsonl` + build cache
   record.  Touches no shared state, so runs with no lock held.

2. **`load_all_episodes_cached`** — split into two phases:
   - Under mutex: `Hashtbl.find_opt episode_file_cache_tbl path`
     + `current_stamp = file_stamp_opt path`.  If cached stamp
     matches, return hot path.
   - Outside mutex: `build_episode_cache_from_disk path` does the
     JSONL read.
   - Under mutex: `Hashtbl.replace` to install.

   Concurrent misses may both run the JSONL read; that is wasteful
   but correct (last writer wins on `Hashtbl.replace`).  In
   practice the stamp check short-circuits almost all calls.

3. **`note_episode_flush`** — previously called
   `load_all_episodes_cached_unlocked` while already holding the
   mutex (nested call), so a miss triggered a JSONL read under
   the lock.  Rewritten to look up the cache in place: if it
   exists, mutate fields (fast path, no I/O); if it is missing,
   skip entirely — the next `load_all_episodes_cached` call will
   populate a fresh cache from disk including the newly-appended
   episode.  The `stamp <- file_stamp_opt path` update still runs
   to keep the existing cache in sync with the file's new mtime
   so subsequent loaders do not re-trigger a reload purely
   because `note_episode_flush` just wrote.

4. **`load_all_episodes_cached_unlocked`** deleted — no remaining
   callers after the refactor, and the "unlocked" name implied
   "caller holds the lock" which the refactor invalidates.

## Verification

```
dune build --root . @lib/check                          # exit 0
dune exec --root . -- ./test/test_memory_oas_5tier.exe  # 22/22 passed
```

The existing `test_memory_oas_5tier.ml` suite covers
`seed_episodes loads recent`, `seed_episodes respects limit`, and
`flush_episodes appends only` — exactly the paths touched by this
refactor.  All 22 tests pass.

## Finding source

Cycle 38 of the masc-mcp audit sweep — carry-over from Cycle 37's
sibling scan.  Cycle 37 closed the `Discovery_cache._unlocked`
variant via PR #6668 and flagged `memory_oas_bridge._unlocked` as
the one remaining module-level `_unlocked` helper from the
`rg -n "^let [a-z_]+_(unlocked|internal|impl|raw|no_lock)\b"`
pass.  Checking it confirmed the same drift shape: disk I/O
re-introduced under the cache mutex via a caller that wrapped
the nominally-unlocked helper in `with_mutex`.

After this PR, every module-level `_unlocked`/`_internal`/`_impl`
helper from the original scan has been either (a) confirmed
legitimate (`with_file_lock_impl`, `search_impl`, `*_raw` in
`room_query.ml` for unfiltered access, `batch_add_tasks_internal`
for reusable internal variant) or (b) refactored (#6663, #6668,
this PR).  The "sibling drift after public refactor" heuristic is
now empirically validated as reproducible — three modules, three
fixes, all matching the same pattern.