### PR TITLE
fix(worker_oas): stop sending min_p=0.0 to cloud providers

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -72,7 +72,12 @@ let agent_config_of_worker_meta
     temperature = Some Oas_worker_cascade.worker_temperature;
     top_p = Some Oas_worker_cascade.worker_top_p;
     top_k = Some Oas_worker_cascade.worker_top_k;
-    min_p = Some Oas_worker_cascade.worker_min_p;
+    (* min_p intentionally omitted: the constant is 0.0 (no-op) and some
+       cloud providers (Groq, GLM) reject the field itself with
+       "Invalid request: property 'min_p' is unsupported". OAS capability
+       gate in #6653 handles this too, but keeping the send-site explicit
+       avoids ambiguous_partial_commit when the gate has not propagated. *)
+    min_p = None;
     enable_thinking = Some (Option.value ~default:false meta.thinking_enabled);
     tool_choice = Some Oas.Types.Auto;
   }
@@ -257,7 +262,9 @@ let build_agent
     |> Oas.Builder.with_temperature Oas_worker_cascade.worker_temperature
     |> Oas.Builder.with_top_p Oas_worker_cascade.worker_top_p
     |> Oas.Builder.with_top_k Oas_worker_cascade.worker_top_k
-    |> Oas.Builder.with_min_p Oas_worker_cascade.worker_min_p
+    (* with_min_p intentionally omitted — see agent_config_of_worker_meta
+       above for the reason. The worker_min_p constant is 0.0 (a no-op)
+       and cloud providers (Groq, GLM) reject the field itself. *)
     |> Oas.Builder.with_enable_thinking
          (Option.value ~default:false meta.thinking_enabled)
     |> Oas.Builder.with_tool_choice Oas.Types.Auto


### PR DESCRIPTION
## Runtime symptom

Live MASC server at 09:32-09:33 KST:

\`\`\`
registry: phase transition name=analyst old=running new=failing
  event=manual_reconcile_required(
    ambiguous_partial_commit(
      post_commit_failure: Mutating tools [keeper_task_done, keeper_task_claim]
      committed before the turn failed; retry stayed disabled and manual
      reconcile is required (error: Invalid request: property 'min_p' is unsupported)))
\`\`\`

Three keepers (\`analyst\`, \`janitor\`, \`cheolsu\`) got stuck in \`manual_reconcile\` after their mutating tool calls committed and the follow-up turn was rejected by the cloud provider on the \`min_p\` field.

## Root cause

\`lib/worker_oas.ml\` was always sending \`min_p = Some worker_min_p\` where \`worker_min_p = 0.0\`. \`0.0\` is semantically a no-op (no min-p filtering), but cloud providers like Groq and the GLM coding endpoint reject the field itself with \`Invalid request: property 'min_p' is unsupported\`.

OAS capability gate in #6653 is supposed to filter this at the OAS layer, but the live server is still binary-linked to a pre-#6653 build and was still hitting the error. The binary timestamp (\`07:13\`) predates the OAS pin update (\`07:30\`), so a rebuild + restart is needed for that path to take effect.

## Fix

Set \`min_p = None\` at the send site. This gives MASC a safety net that does not depend on OAS version propagation and stays correct even after the OAS gate goes live.

### Call sites updated
1. \`lib/worker_oas.ml:75\` — \`agent_config_of_worker_meta\` record literal
2. \`lib/worker_oas.ml:260\` — Builder pipeline in worker run setup

### Kept
- \`lib/oas_worker_cascade.ml\` constant \`worker_min_p = 0.0\` remains as documentation of the historical default. Removing it would be a wider refactor.

## Test plan
- [x] \`dune build --root . @check\` clean
- [ ] Post-merge: rebuild \`main_eio.exe\`, restart the server, verify no more \`property 'min_p' is unsupported\` errors in \`registry: phase transition\` events.

## Relation to existing work
- Superseded root cause: OAS #6653 (pin bump to \`f075853e\` for capability gate). This PR layers a MASC-level send-site fix on top so the fix is independent of OAS-link status.