### PR TITLE
fix(prompt): restore world prompt contract and sanitize unified prompt

### DIFF
--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -10,7 +10,7 @@ Playground is your default sandbox, relative to the server `base_path`:
 - `.masc/playground/{your-name}/` — bundle root (general workspace)
 - `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
 - `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees live *inside* your playground clone — the canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
+Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`, but in practice they must live *inside* your playground clone. The canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist, never use them):
 - `/repos/...`

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -269,6 +269,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
   in
   let system_prompt =
     Printf.sprintf "%s\n\n## Turn Intent\n%s" base_system_prompt turn_intent_block
+    |> Inference_utils.sanitize_text_utf8
   in
   (* User message: structured world observation *)
   let ubuf = Buffer.create 1024 in
@@ -558,6 +559,6 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
        Buffer.add_string ubuf "\n"
    | _ -> ());
   let user_message =
-    Buffer.contents ubuf
+    Buffer.contents ubuf |> Inference_utils.sanitize_text_utf8
   in
   (system_prompt, user_message)


### PR DESCRIPTION
## Summary
- restore the `keeper.world` wording expected by the unified prompt contract test while keeping the playground-clone path constraint explicit
- sanitize the final unified system prompt and user prompt strings before returning them

## Product impact
- removes a baseline quick-suite blocker that is currently preventing unrelated PR merges
- keeps keeper prompt text safe from embedded control characters in metadata or observation payloads

## Evidence
- local repro before fix: `test_keeper_unified.exe` failed `unified_prompt` cases 5 and 26
- local validation after fix: `env ALCOTEST_QUICK_TESTS=1 opam exec -- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-unified-prompt-ci ./test/test_keeper_unified.exe`
- targeted build: `opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-unified-prompt-ci test/test_keeper_unified.exe`

## Review evidence
- implementation by Codex in dedicated worktree
- follow-up cross-model review pending after PR creation

## Linked issue
- Fixes #6674
