### PR TITLE
fix(prompt): reinforce playground containment in keeper capabilities

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -11,6 +11,7 @@ Before any file or path operation, follow this order:
 3. Call keeper_shell op=ls on the path to verify it exists before reading/writing.
 4. Then proceed with the file operation.
 
+NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/YOUR_KEEPER_NAME/`. This includes keeper_bash, masc_code_git, keeper_pr_submit, and masc_code_edit. The server blocks violations, but relying on server rejection wastes your turn budget.
 NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs` — do not invent repos outside that list.
 NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call. Split into separate calls.
 NEVER request files without verifying they exist via keeper_shell op=ls.

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -74,12 +74,24 @@ let keeper_default_read_root ~(config : Room.config) ~(meta : keeper_meta) =
   keeper_playground_root ~config ~meta
 ;;
 
+(* Resolve relative paths against the keeper's playground root.
+   Structural containment: relative paths land inside
+   .masc/playground/<name>/ — escape requires an absolute path which
+   is then checked against allowed_paths. *)
+let playground_relative ~(config : Room.config) ~(meta : keeper_meta)
+    (raw : string) : string =
+  let trimmed = String.trim raw in
+  if trimmed = "" || not (Filename.is_relative trimmed) then trimmed
+  else
+    let pg = keeper_playground_root ~config ~meta in
+    Filename.concat pg trimmed
+
 let resolve_keeper_path ~(config : Room.config) ~(meta : keeper_meta) ~(raw_path : string)
   =
   resolve_keeper_target_path
     ~config
     ~allowed_paths:(keeper_effective_allowed_paths ~meta)
-    ~raw_path
+    ~raw_path:(playground_relative ~config ~meta raw_path)
 ;;
 
 let resolve_keeper_read_path ~(config : Room.config) ~(meta : keeper_meta)
@@ -87,7 +99,7 @@ let resolve_keeper_read_path ~(config : Room.config) ~(meta : keeper_meta)
   Keeper_alerting_path.resolve_keeper_read_path
     ~config
     ~allowed_paths:(keeper_effective_allowed_paths ~meta)
-    ~raw_path
+    ~raw_path:(playground_relative ~config ~meta raw_path)
 ;;
 
 let keeper_agent_sender ~(meta : keeper_meta) =

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -152,12 +152,16 @@ let test_missing_file_error_includes_directory_suggestions () =
         Sys.remove (Filename.concat dir f));
         Unix.rmdir dir with _ -> ()))
     (fun () ->
-      let existing = Filename.concat dir "known.txt" in
-      Out_channel.with_open_text existing
-        (fun oc -> Out_channel.output_string oc "known");
       Eio_main.run @@ fun env ->
       Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
+      let pg_dir = Filename.concat
+        (Keeper_alerting_path.project_root_of_config config)
+        (Keeper_alerting_path.playground_path_of_keeper meta.name) in
+      Fs_compat.mkdir_p pg_dir;
+      let existing = Filename.concat pg_dir "known.txt" in
+      Out_channel.with_open_text existing
+        (fun oc -> Out_channel.output_string oc "known");
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       match Tool.execute tool (`Assoc [("path", `String "missing.txt")]) with
@@ -223,6 +227,10 @@ let test_failure_count_resets_after_success () =
       Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
       let config = Room.default_config dir in
+      let pg_dir = Filename.concat
+        (Keeper_alerting_path.project_root_of_config config)
+        (Keeper_alerting_path.playground_path_of_keeper meta.name) in
+      Fs_compat.mkdir_p pg_dir;
       let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
       let tool = find_tool "keeper_fs_read" tools in
       let path = "reset-after-success.txt" in
@@ -232,7 +240,7 @@ let test_failure_count_resets_after_success () =
         | Error _ -> ()
         | Ok _ -> fail "missing file should fail before reset"
       done;
-      let abs_path = Filename.concat dir path in
+      let abs_path = Filename.concat pg_dir path in
       Out_channel.with_open_text abs_path
         (fun oc -> Out_channel.output_string oc "ok");
       (match Tool.execute tool args with


### PR DESCRIPTION
keeper_bash git 명령 등 cwd 제약이 없던 도구에 대해 playground containment rule 추가. 서버 guard는 이미 있지만 prompt 보강으로 turn budget 낭비 방지.