### PR TITLE
harden(agent_registry_eio): serialise session cache mutations

### DIFF
--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -55,18 +55,46 @@ let session_identity_map : (string, string) Hashtbl.t = Hashtbl.create 64
     ~180 lines of identity resolution on 2nd+ calls. *)
 let resolved_names : (string, string) Hashtbl.t = Hashtbl.create 64
 
+(** Mutex serialising multi-step operations on the two session caches
+    above.  Single [Hashtbl] operations are atomic on a single Eio
+    domain, but [get_or_create_identity] interleaves a cache lookup
+    with a [Registry.register] call that yields via [reg.lock], which
+    is a classic check-then-act race window:
+
+    Fiber A                             Fiber B
+    Hashtbl.find_opt sid -> None
+                                        Hashtbl.find_opt sid -> None
+    Registry.register id_a              Registry.register id_b
+    Hashtbl.replace sid id_a.key        Hashtbl.replace sid id_b.key
+
+    Both fibers produce fresh UUID session keys via
+    [Agent_identity.generate_session_key], so [Registry.register] is
+    NOT idempotent here — it installs two distinct identities for the
+    same MCP session, and only the last writer wins in
+    [session_identity_map].  The earlier identity is orphaned in the
+    registry until the zombie sweep collects it.
+
+    Fix: double-checked locking in the create path and a short
+    critical section around all multi-step cache mutations
+    (clear / evict / cleanup / unregister).  Single-entry reads
+    and writes (get_resolved_name / set_resolved_name) also go
+    through the mutex to keep invariants simple. *)
+let session_cache_mu = Eio.Mutex.create ()
+
 (** Maximum session cache entries before forced eviction.
     Prevents unbounded growth when many MCP sessions connect over time. *)
 let max_session_cache_entries = 1024
 
 let clear_session_caches () =
-  Hashtbl.clear session_identity_map;
-  Hashtbl.clear resolved_names
+  Eio_guard.with_mutex session_cache_mu (fun () ->
+    Hashtbl.clear session_identity_map;
+    Hashtbl.clear resolved_names)
 
 (** Evict all session cache entries if either cache exceeds [max_session_cache_entries].
     A simple full-clear is safe because the caches are write-through
-    (identity is reconstructed from params on the next call). *)
-let maybe_evict_session_caches () =
+    (identity is reconstructed from params on the next call).
+    Caller must hold [session_cache_mu]. *)
+let maybe_evict_session_caches_locked () =
   if Hashtbl.length session_identity_map > max_session_cache_entries
      || Hashtbl.length resolved_names > max_session_cache_entries
   then begin
@@ -75,12 +103,15 @@ let maybe_evict_session_caches () =
       (Hashtbl.length session_identity_map)
       (Hashtbl.length resolved_names)
       max_session_cache_entries;
-    clear_session_caches ()
+    Hashtbl.clear session_identity_map;
+    Hashtbl.clear resolved_names
   end
 
 (** Reset registry for testing *)
 let reset_for_testing () =
-  clear_session_caches ();
+  Eio_guard.with_mutex session_cache_mu (fun () ->
+    Hashtbl.clear session_identity_map;
+    Hashtbl.clear resolved_names);
   global_registry := Some (Agent_identity.Registry.create ())
 
 (** {1 Identity Resolution} *)
@@ -99,47 +130,66 @@ let reset_for_testing () =
 let get_or_create_identity ?mcp_session_id params =
   let reg = get_registry_exn () in
 
-  (* Try to find existing identity by MCP session ID *)
+  let touch_and_return identity =
+    let room_id = Yojson.Safe.Util.(
+      try Some (params |> member "room" |> to_string)
+      with Yojson.Safe.Util.Type_error _ -> None
+    ) in
+    Agent_identity.Registry.touch reg identity.Agent_identity.session_key
+      ?room_id ();
+    match Agent_identity.Registry.find_by_session reg identity.session_key with
+    | Some updated -> updated
+    | None -> identity
+  in
+
+  (* Fast path: unlocked lookup is safe because values in
+     [session_identity_map] are immutable [session_key] strings and
+     [Hashtbl.find_opt] is atomic on a single Eio domain.  Registry
+     touches have their own internal lock. *)
   let existing_by_session =
     match mcp_session_id with
     | None -> None
     | Some sid ->
         (match Hashtbl.find_opt session_identity_map sid with
-        | Some session_key -> Agent_identity.Registry.find_by_session reg session_key
-        | None -> None)
+         | Some session_key ->
+             Agent_identity.Registry.find_by_session reg session_key
+         | None -> None)
   in
 
   match existing_by_session with
-  | Some identity ->
-      (* Touch to update last_seen and room *)
-      let room_id = Yojson.Safe.Util.(
-        try Some (params |> member "room" |> to_string)
-        with Yojson.Safe.Util.Type_error _ -> None
-      ) in
-      Agent_identity.Registry.touch reg identity.session_key ?room_id ();
-      (* Return fresh identity with updated room *)
-      (match Agent_identity.Registry.find_by_session reg identity.session_key with
-       | Some updated -> updated
-       | None -> identity)
+  | Some identity -> touch_and_return identity
   | None ->
-      (* Create new identity from params *)
-      let identity = Agent_identity.from_mcp_params params in
-      let registered = Agent_identity.Registry.register reg identity in
-
-      (* Link MCP session ID to identity session key *)
-      (match mcp_session_id with
-       | Some sid ->
-           Hashtbl.replace session_identity_map sid registered.session_key
-       | None -> ());
-
-      Log.Session.info "[AgentRegistry] New identity: %s (session=%s, mcp=%s)"
-        registered.agent_name
-        (String.sub registered.session_key 0
-           (min 8 (String.length registered.session_key)))
-        (Option.value mcp_session_id ~default:"none");
-
-      maybe_evict_session_caches ();
-      registered
+      (* Slow path: serialise identity creation so concurrent fibers
+         sharing an [mcp_session_id] cannot both register distinct
+         identities and leak the earlier one into the registry.  The
+         double-check inside the critical section covers the window
+         between the lockless lookup above and lock acquisition. *)
+      Eio_guard.with_mutex session_cache_mu (fun () ->
+        let already =
+          match mcp_session_id with
+          | None -> None
+          | Some sid ->
+              (match Hashtbl.find_opt session_identity_map sid with
+               | Some session_key ->
+                   Agent_identity.Registry.find_by_session reg session_key
+               | None -> None)
+        in
+        match already with
+        | Some identity -> touch_and_return identity
+        | None ->
+            let identity = Agent_identity.from_mcp_params params in
+            let registered = Agent_identity.Registry.register reg identity in
+            (match mcp_session_id with
+             | Some sid ->
+                 Hashtbl.replace session_identity_map sid registered.session_key
+             | None -> ());
+            Log.Session.info "[AgentRegistry] New identity: %s (session=%s, mcp=%s)"
+              registered.agent_name
+              (String.sub registered.session_key 0
+                 (min 8 (String.length registered.session_key)))
+              (Option.value mcp_session_id ~default:"none");
+            maybe_evict_session_caches_locked ();
+            registered)
 
 (** Get identity by agent name (for backward compatibility) *)
 let get_by_name agent_name =
@@ -163,10 +213,12 @@ let get_by_session session_key =
     ~180 lines of identity resolution on 2nd+ calls. *)
 
 let get_resolved_name sid =
-  Hashtbl.find_opt resolved_names sid
+  Eio_guard.with_mutex session_cache_mu (fun () ->
+    Hashtbl.find_opt resolved_names sid)
 
 let set_resolved_name sid name =
-  Hashtbl.replace resolved_names sid name
+  Eio_guard.with_mutex session_cache_mu (fun () ->
+    Hashtbl.replace resolved_names sid name)
 
 (** {1 Statistics} *)
 
@@ -196,24 +248,32 @@ let list_active ?(within_seconds = Env_config.Zombie.threshold_seconds) () =
 
 (** {1 Cleanup} *)
 
-(** Clean up stale session mappings and resolved-name cache entries *)
+(** Clean up stale session mappings and resolved-name cache entries.
+
+    Two-phase under [session_cache_mu]: snapshot the [(sid, session_key)]
+    pairs inside the lock, look them up against the registry while still
+    holding the lock (Registry has its own lock but does not depend on
+    ours), then remove stale entries.  Holding the mutex across the
+    scan prevents a concurrent [get_or_create_identity] from installing
+    a fresh entry that this scan would then incorrectly remove. *)
 let cleanup_stale_sessions () =
   match get_registry () with
   | Error e ->
       Log.Identity.warn "cleanup_stale_sessions: registry unavailable: %s" e;
       0
   | Ok reg ->
-    let to_remove = ref [] in
-    Hashtbl.iter (fun sid session_key ->
-      match Agent_identity.Registry.find_by_session reg session_key with
-      | None -> to_remove := sid :: !to_remove
-      | Some _ -> ()
-    ) session_identity_map;
-    List.iter (fun sid ->
-      Hashtbl.remove session_identity_map sid;
-      Hashtbl.remove resolved_names sid
-    ) !to_remove;
-    List.length !to_remove
+    Eio_guard.with_mutex session_cache_mu (fun () ->
+      let to_remove = ref [] in
+      Hashtbl.iter (fun sid session_key ->
+        match Agent_identity.Registry.find_by_session reg session_key with
+        | None -> to_remove := sid :: !to_remove
+        | Some _ -> ()
+      ) session_identity_map;
+      List.iter (fun sid ->
+        Hashtbl.remove session_identity_map sid;
+        Hashtbl.remove resolved_names sid
+      ) !to_remove;
+      List.length !to_remove)
 
 (** Unregister an identity *)
 let unregister session_key =
@@ -223,11 +283,12 @@ let unregister session_key =
         (String.sub session_key 0 (min 8 (String.length session_key))) e
   | Ok reg ->
     Agent_identity.Registry.unregister reg session_key;
-    let to_remove = ref [] in
-    Hashtbl.iter (fun sid sk ->
-      if sk = session_key then to_remove := sid :: !to_remove
-    ) session_identity_map;
-    List.iter (fun sid ->
-      Hashtbl.remove session_identity_map sid;
-      Hashtbl.remove resolved_names sid
-    ) !to_remove
+    Eio_guard.with_mutex session_cache_mu (fun () ->
+      let to_remove = ref [] in
+      Hashtbl.iter (fun sid sk ->
+        if sk = session_key then to_remove := sid :: !to_remove
+      ) session_identity_map;
+      List.iter (fun sid ->
+        Hashtbl.remove session_identity_map sid;
+        Hashtbl.remove resolved_names sid
+      ) !to_remove)

--- a/test/test_agent_registry_eio.ml
+++ b/test/test_agent_registry_eio.ml
@@ -120,7 +120,7 @@ let test_concurrent_access () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Agent_registry_eio.reset_for_testing ();
-  
+
   (* Simulate concurrent access *)
   Eio.Fiber.all (List.init 5 (fun i () ->
     let params = `Assoc [
@@ -131,8 +131,53 @@ let test_concurrent_access () =
       Eio.Fiber.yield ()
     done
   ));
-  
+
   ()
+
+(** Contract: N fibers racing to create an identity for the same
+    [mcp_session_id] must converge to a single [session_key].  This
+    is asserted even though under single-domain Eio with uncontended
+    Registry locks, [get_or_create_identity] currently executes
+    atomically and the race would not fire without the
+    double-checked locking fix.  The test defends the invariant
+    against future changes — a migration to multi-domain, a refactor
+    that introduces a yield between [Hashtbl.find_opt] and
+    [Hashtbl.replace], or Registry contention that forces
+    [reg.lock] to suspend — any of which would otherwise orphan the
+    first-seen identity because both fibers would observe [None] in
+    [session_identity_map], both [Registry.register] with a fresh
+    UUID [session_key], and only the last [Hashtbl.replace] would
+    win.  See lib/agent_registry_eio.ml [session_cache_mu] comment. *)
+let test_concurrent_same_mcp_session_id () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Agent_registry_eio.reset_for_testing ();
+  let mcp_sid =
+    Printf.sprintf "race-session-%d" (Random.int 1_000_000)
+  in
+  let collected : Agent_identity.t list ref = ref [] in
+  let collect_mu = Eio.Mutex.create () in
+  Eio.Fiber.all (List.init 8 (fun _i () ->
+    let params =
+      `Assoc [("_agent_name", `String "racing-agent")]
+    in
+    let id =
+      Agent_registry_eio.get_or_create_identity ~mcp_session_id:mcp_sid params
+    in
+    Eio.Mutex.use_rw ~protect:true collect_mu (fun () ->
+      collected := id :: !collected)));
+  let keys =
+    List.sort_uniq compare (List.map (fun id -> id.Agent_identity.session_key)
+                              !collected)
+  in
+  check int "all fibers converged to a single session_key" 1 (List.length keys);
+  (* And the map-resolved identity is the same key. *)
+  (match
+     Agent_registry_eio.get_or_create_identity ~mcp_session_id:mcp_sid
+       (`Assoc [])
+   with
+   | id -> check (list string) "re-lookup returns the shared key" keys
+             [id.session_key])
 
 let () =
   run "Agent_registry_eio" [
@@ -152,5 +197,7 @@ let () =
     ];
     "concurrency", [
       test_case "concurrent_access" `Quick test_concurrent_access;
+      test_case "concurrent_same_mcp_session_id" `Quick
+        test_concurrent_same_mcp_session_id;
     ];
   ]


### PR DESCRIPTION
## Summary

- Adds `session_cache_mu : Eio.Mutex.t` to `agent_registry_eio.ml` and serialises all multi-step operations on `session_identity_map` / `resolved_names`.
- `get_or_create_identity` keeps a lockless fast path (existing session) and uses double-checked locking on the create path to prevent two concurrent fibers sharing an `mcp_session_id` from registering distinct UUID `session_key`s and orphaning the earlier identity.
- `cleanup_stale_sessions` / `unregister` / `get_resolved_name` / `set_resolved_name` / `clear_session_caches` go through the same mutex for a uniform, locally-checkable contract.
- Adds `test_concurrent_same_mcp_session_id` as a contract assertion.

## Race timeline (theoretical under single-domain, real under contention)

```
Fiber A                             Fiber B
find_opt sid       -> None
                                    find_opt sid       -> None
from_mcp_params    (fresh UUID_A)   from_mcp_params    (fresh UUID_B)
Registry.register  identity_A       Registry.register  identity_B
replace sid UUID_A                  replace sid UUID_B   (last writer wins)
```

Because `Agent_identity.generate_session_key` mints a fresh UUID, `Registry.register` is **not** idempotent for the "same MCP session" case — the earlier identity is orphaned in `reg.identities` until the zombie sweep collects it, and the caller that lost the race keeps operating with the now-orphaned key.

Under today's single-domain Eio with uncontended `Registry` locks the race is theoretical (`get_or_create_identity` runs atomically because nothing on its hot path yields). The fix is defensive: the moment another fiber contends `reg.lock`, a refactor adds a yield to `from_mcp_params`, or masc-mcp migrates to multi-domain, the race becomes active.

## Finding source

Cycle 39 of the masc-mcp audit sweep. After Cycles 36-38 exhausted the `_unlocked` sibling drift scan (#6663, #6668, #6671), the sweep moved to lockless module-level `Hashtbl`s. Triage result:

- `lib/tool_metrics.ml` / `lib/prometheus.ml` — safe under single-domain (no yields on hot path); noted for defensive hardening later.
- `lib/tool_catalog.ml` — init-only populate then read-only; safe by construction.
- `lib/agent_registry_eio.ml` — **this PR**. The only remaining module where the check-then-act pattern spans a potential yield and where the stored key is a fresh UUID, making `Registry.register` non-idempotent across concurrent callers for the same MCP session.

## Test plan

- [x] `dune build --root . @lib/check` — exit 0
- [x] `dune exec --root . -- ./test/test_agent_registry_eio.exe` — 11/11 (new `concurrent_same_mcp_session_id`)
- [x] `dune exec --root . -- ./test/test_agent_identity.exe` — 32/32

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>