### PR TITLE
fix(dashboard): externalize agent status thresholds

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -533,6 +533,10 @@ module InternalTimers = struct
   let label_quiet_threshold_sec =
     get_float ~default:300.0 "MASC_LABEL_QUIET_THRESHOLD_SEC"
 
+  (** Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). *)
+  let label_stuck_threshold_sec =
+    get_float ~default:900.0 "MASC_LABEL_STUCK_THRESHOLD_SEC"
+
   (** Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). *)
   let briefing_cache_ttl_sec =
     get_float ~default:300.0 "MASC_BRIEFING_CACHE_TTL_SEC"

--- a/lib/dashboard/dashboard_labels.ml
+++ b/lib/dashboard/dashboard_labels.ml
@@ -160,15 +160,15 @@ let format_elapsed now timestamp fallback =
 
 (* ===== Agent Status Translation ===== *)
 
-(** Threshold in seconds for considering an agent "stuck" *)
-let stuck_threshold_sec = 900.0 (* 15 minutes *)
-
-(** Threshold in seconds for "quiet" warning *)
-let quiet_threshold_sec = Env_config.InternalTimers.label_quiet_threshold_sec
-
 (** Translate agent status + elapsed time into operator-readable description. *)
 let translate_agent_status ~(now : float) (status : Types.agent_status)
     (last_seen_iso : string) : string =
+  let quiet_threshold_sec =
+    Runtime_params.get Governance_registry.dashboard_agent_quiet_threshold_sec
+  in
+  let stuck_threshold_sec =
+    Runtime_params.get Governance_registry.dashboard_agent_stuck_threshold_sec
+  in
   let elapsed_opt = parse_iso_timestamp last_seen_iso in
   let elapsed_sec =
     match elapsed_opt with Some ts -> now -. ts | None -> 0.0
@@ -192,6 +192,9 @@ let translate_agent_status ~(now : float) (status : Types.agent_status)
 type agent_group = Working | Stuck | Idle | Offline [@@deriving eq]
 
 let classify_agent ~(now : float) (agent : Types.agent) : agent_group =
+  let stuck_threshold_sec =
+    Runtime_params.get Governance_registry.dashboard_agent_stuck_threshold_sec
+  in
   let elapsed_opt = parse_iso_timestamp agent.last_seen in
   let elapsed_sec =
     match elapsed_opt with Some ts -> now -. ts | None -> 0.0

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -144,6 +144,44 @@ let dashboard_min_border_length =
             min_value = Some (`Int 20); max_value = Some (`Int 200) }
     ()
 
+(** Threshold for surfacing a quiet-agent warning in dashboard labels. *)
+let dashboard_agent_quiet_threshold_sec =
+  Runtime_params.register
+    ~key:"dashboard.agent_quiet_threshold_sec"
+    ~default:(fun () -> Env_config_runtime.InternalTimers.label_quiet_threshold_sec)
+    ~validate:
+      (validate_float_range ~min:30.0 ~max:Masc_time_constants.day
+         "dashboard_agent_quiet_threshold_sec")
+    ~serialize:(fun v -> `Float v)
+    ~deserialize:deserialize_float
+    ~meta:
+      {
+        description = "대시보드 quiet 상태 임계값(초)";
+        value_type = "float";
+        min_value = Some (`Float 30.0);
+        max_value = Some (`Float Masc_time_constants.day);
+      }
+    ()
+
+(** Threshold for surfacing a stuck-agent warning in dashboard labels. *)
+let dashboard_agent_stuck_threshold_sec =
+  Runtime_params.register
+    ~key:"dashboard.agent_stuck_threshold_sec"
+    ~default:(fun () -> Env_config_runtime.InternalTimers.label_stuck_threshold_sec)
+    ~validate:
+      (validate_float_range ~min:60.0 ~max:(7.0 *. Masc_time_constants.day)
+         "dashboard_agent_stuck_threshold_sec")
+    ~serialize:(fun v -> `Float v)
+    ~deserialize:deserialize_float
+    ~meta:
+      {
+        description = "대시보드 STUCK 상태 임계값(초)";
+        value_type = "float";
+        min_value = Some (`Float 60.0);
+        max_value = Some (`Float (7.0 *. Masc_time_constants.day));
+      }
+    ()
+
 (* ── cost_policy surface ──────────────────────────────────────── *)
 
 (** Per-session cost ceiling in USD.
@@ -528,7 +566,7 @@ let surfaces =
     };
     {
       id = "dashboard";
-      description = "Dashboard rendering — truncation lengths, row limits, borders";
+      description = "Dashboard rendering — truncation lengths, row limits, borders, status thresholds";
       risk = "low";
       param_keys = [
         "dashboard.max_path_length";
@@ -536,6 +574,8 @@ let surfaces =
         "dashboard.max_pending_tasks";
         "dashboard.max_recent_messages";
         "dashboard.min_border_length";
+        "dashboard.agent_quiet_threshold_sec";
+        "dashboard.agent_stuck_threshold_sec";
       ];
     };
   ]
@@ -551,6 +591,8 @@ let ensure_init () =
   ignore (Runtime_params.get dashboard_max_pending_tasks);
   ignore (Runtime_params.get dashboard_max_recent_messages);
   ignore (Runtime_params.get dashboard_min_border_length);
+  ignore (Runtime_params.get dashboard_agent_quiet_threshold_sec);
+  ignore (Runtime_params.get dashboard_agent_stuck_threshold_sec);
   Keeper_config.ensure_runtime_params_init ()
 
 let surfaces_json () =

--- a/test/test_dashboard_labels.ml
+++ b/test/test_dashboard_labels.ml
@@ -29,6 +29,33 @@ let make_timestamp_pair seconds_ago =
   in
   (now, past_iso)
 
+let with_dashboard_label_thresholds ?quiet ?stuck f =
+  let set_or_fail param value =
+    match Lib.Runtime_params.set param value with
+    | Ok () -> ()
+    | Error msg -> Alcotest.fail msg
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      Option.iter
+        (fun _ ->
+          Lib.Runtime_params.clear
+            Lib.Governance_registry.dashboard_agent_quiet_threshold_sec)
+        quiet;
+      Option.iter
+        (fun _ ->
+          Lib.Runtime_params.clear
+            Lib.Governance_registry.dashboard_agent_stuck_threshold_sec)
+        stuck)
+    (fun () ->
+      Option.iter
+        (set_or_fail Lib.Governance_registry.dashboard_agent_quiet_threshold_sec)
+        quiet;
+      Option.iter
+        (set_or_fail Lib.Governance_registry.dashboard_agent_stuck_threshold_sec)
+        stuck;
+      f ())
+
 let test_working_agent () =
   let (now, recent_iso) = make_timestamp_pair 60.0 in
   let result =
@@ -36,12 +63,36 @@ let test_working_agent () =
   in
   Alcotest.(check string) "active+recent = working" "working" result
 
+let test_quiet_threshold_override () =
+  with_dashboard_label_thresholds ~quiet:30.0 ~stuck:900.0 @@ fun () ->
+  let (now, quiet_iso) = make_timestamp_pair 60.0 in
+  let result =
+    Lib.Dashboard_labels.translate_agent_status ~now Types.Active quiet_iso
+  in
+  Alcotest.(check bool) "override surfaces quiet warning" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "quiet") result 0);
+       true
+     with Not_found -> false)
+
 let test_stuck_agent () =
   let (now, old_iso) = make_timestamp_pair 1200.0 in (* 20 minutes ago *)
   let result =
     Lib.Dashboard_labels.translate_agent_status ~now Types.Active old_iso
   in
   Alcotest.(check bool) "stuck agent contains STUCK" true
+    (try
+       ignore (Str.search_forward (Str.regexp_string "STUCK") result 0);
+       true
+     with Not_found -> false)
+
+let test_stuck_threshold_override () =
+  with_dashboard_label_thresholds ~quiet:300.0 ~stuck:60.0 @@ fun () ->
+  let (now, stuck_iso) = make_timestamp_pair 120.0 in
+  let result =
+    Lib.Dashboard_labels.translate_agent_status ~now Types.Busy stuck_iso
+  in
+  Alcotest.(check bool) "override surfaces stuck warning" true
     (try
        ignore (Str.search_forward (Str.regexp_string "STUCK") result 0);
        true
@@ -306,6 +357,25 @@ let test_classify_listening_is_idle () =
   Alcotest.(check bool) "listening = Idle" true
     (Lib.Dashboard_labels.equal_agent_group group Lib.Dashboard_labels.Idle)
 
+let test_classify_uses_stuck_threshold_override () =
+  with_dashboard_label_thresholds ~stuck:60.0 @@ fun () ->
+  let (now, stuck_iso) = make_timestamp_pair 120.0 in
+  let agent : Types.agent =
+    {
+      name = "test-agent";
+      agent_type = "test";
+      status = Types.Active;
+      capabilities = [];
+      current_task = None;
+      joined_at = "2026-01-01T00:00:00Z";
+      last_seen = stuck_iso;
+      meta = None;
+    }
+  in
+  let group = Lib.Dashboard_labels.classify_agent ~now agent in
+  Alcotest.(check bool) "active can classify as Stuck via override" true
+    (Lib.Dashboard_labels.equal_agent_group group Lib.Dashboard_labels.Stuck)
+
 (* ===== Attention Items ===== *)
 
 let test_attention_empty () =
@@ -328,7 +398,9 @@ let () =
       ( "Agent Status",
         [
           ("working agent", `Quick, test_working_agent);
+          ("quiet threshold override", `Quick, test_quiet_threshold_override);
           ("stuck agent", `Quick, test_stuck_agent);
+          ("stuck threshold override", `Quick, test_stuck_threshold_override);
           ("utc parser matches canonical", `Quick, test_parse_iso_timestamp_matches_canonical_utc);
           ("fractional utc normalizes", `Quick, test_parse_iso_timestamp_fractional_utc_normalizes);
           ("numeric offset normalizes", `Quick, test_parse_iso_timestamp_offset_matches_utc);
@@ -369,6 +441,7 @@ let () =
         [
           ("inactive is Offline", `Quick, test_classify_inactive_is_offline);
           ("listening is Idle", `Quick, test_classify_listening_is_idle);
+          ("stuck override applied", `Quick, test_classify_uses_stuck_threshold_override);
         ] );
       ( "Attention",
         [

--- a/test/test_runtime_params.ml
+++ b/test/test_runtime_params.ml
@@ -214,6 +214,34 @@ let () =
      | Ok () -> Alcotest.fail "should reject empty model name")
   in
 
+  let test_dashboard_params_registered () =
+    Governance_registry.ensure_init ();
+    let entries = Runtime_params.registry () in
+    let has key = List.exists (fun (k, _, _, _, _) -> k = key) entries in
+    Alcotest.(check bool) "dashboard.agent_quiet_threshold_sec"
+      true (has "dashboard.agent_quiet_threshold_sec");
+    Alcotest.(check bool) "dashboard.agent_stuck_threshold_sec"
+      true (has "dashboard.agent_stuck_threshold_sec")
+  in
+
+  let test_dashboard_surface () =
+    let surfaces = Governance_registry.surfaces in
+    let dashboard_surface =
+      List.find_opt
+        (fun (s : Governance_registry.surface) -> s.id = "dashboard")
+        surfaces
+    in
+    match dashboard_surface with
+    | None -> Alcotest.fail "dashboard surface not found"
+    | Some s ->
+        Alcotest.(check string) "risk" "low" s.risk;
+        Alcotest.(check int) "param count" 7 (List.length s.param_keys);
+        Alcotest.(check bool) "has quiet threshold"
+          true (List.mem "dashboard.agent_quiet_threshold_sec" s.param_keys);
+        Alcotest.(check bool) "has stuck threshold"
+          true (List.mem "dashboard.agent_stuck_threshold_sec" s.param_keys)
+  in
+
   (* ── clear_by_key ────────────────────────────────────────── *)
 
   let test_clear_by_key () =
@@ -419,6 +447,9 @@ let () =
         [
           Alcotest.test_case "registration" `Quick test_governance_registry;
           Alcotest.test_case "validation" `Quick test_governance_registry_validation;
+          Alcotest.test_case "dashboard params registered" `Quick
+            test_dashboard_params_registered;
+          Alcotest.test_case "dashboard surface" `Quick test_dashboard_surface;
         ] );
       ( "keeper_lifecycle",
         [


### PR DESCRIPTION
## Summary
- move dashboard `quiet` / `STUCK` agent label thresholds onto the governable runtime-params surface
- add `MASC_LABEL_STUCK_THRESHOLD_SEC` so the env-layer also has an SSOT default
- cover the new dashboard surface keys and override behavior in unit tests

## Why
`dashboard_labels.ml` still had a hardcoded `900s` stuck threshold and only half of the label logic was tunable. This left operator-facing status classification outside the existing `Runtime_params > env > default` config path that the rest of the dashboard rendering already uses.

## Changes
- `lib/config/env_config_runtime.ml`
  - add `InternalTimers.label_stuck_threshold_sec`
- `lib/governance_registry.ml`
  - register `dashboard.agent_quiet_threshold_sec`
  - register `dashboard.agent_stuck_threshold_sec`
  - expose both on the `dashboard` governance surface
- `lib/dashboard/dashboard_labels.ml`
  - read quiet/stuck thresholds from `Runtime_params`
- tests
  - verify override behavior in `test_dashboard_labels.ml`
  - verify governance registration/surface membership in `test_runtime_params.ml`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-label-thresholds test/test_dashboard_labels.exe test/test_runtime_params.exe`
- `./_build/default/test/test_dashboard_labels.exe`
- `./_build/default/test/test_runtime_params.exe`

## Notes
Cross-model review will be added in a follow-up comment per repo workflow.