### PR TITLE
fix(build_identity): probe exe_dir before cwd for git commit

### DIFF
--- a/lib/build_identity.ml
+++ b/lib/build_identity.ml
@@ -75,9 +75,23 @@ let git_probe_from_root repo_root =
   in
   Eio_guard.run_in_systhread f
 
+(** Pick the ordered list of directories to probe for a git repo,
+    executable_dir first so the binary's own source tree wins over
+    whatever cwd the user started the process from.
+
+    Rationale: running `cd ~/me && ~/.../masc-mcp/_build/.../main_eio.exe`
+    used to report ~/me's git HEAD instead of masc-mcp's because the old
+    implementation sorted candidates with [List.sort_uniq String.compare]
+    and cwd happened to sort first alphabetically.
+
+    Pure — exposed for unit testing. *)
+let pick_repo_candidates ~exe_dir ~cwd =
+  if String.equal exe_dir cwd then [ exe_dir ] else [ exe_dir; cwd ]
+
 let probe_git_commit () =
-  [ Sys.getcwd (); executable_dir () ]
-  |> List.sort_uniq String.compare
+  pick_repo_candidates
+    ~exe_dir:(executable_dir ())
+    ~cwd:(Sys.getcwd ())
   |> List.find_map (fun dir ->
          match find_git_root dir with
          | Some root -> git_probe_from_root root

--- a/lib/build_identity.mli
+++ b/lib/build_identity.mli
@@ -24,3 +24,10 @@ val resolve_commit :
   env_value:string option -> probe:(unit -> string option) -> string option
 (** Resolve commit hash from env var or probe function.
     Exposed for testing. *)
+
+val pick_repo_candidates :
+  exe_dir:string -> cwd:string -> string list
+(** Ordered list of directories to probe for a git repo. Places [exe_dir]
+    before [cwd] so the binary's own source tree wins when the process is
+    launched from an unrelated cwd. Returns a single entry when both
+    arguments are equal. Pure — exposed for unit testing. *)

--- a/test/test_build_identity.ml
+++ b/test/test_build_identity.ml
@@ -28,6 +28,49 @@ let test_current_started_at_is_stable () =
   Alcotest.(check bool) "uptime monotonic" true
     (second.uptime_seconds >= first.uptime_seconds)
 
+let test_pick_repo_candidates_exe_first_when_distinct () =
+  (* Regression for the bug where running `cd ~/me && .../masc-mcp/main_eio.exe`
+     reported ~/me's commit instead of masc-mcp's. exe_dir must come first. *)
+  let result =
+    Build_identity.pick_repo_candidates
+      ~exe_dir:"/Users/dev/masc-mcp/_build/default/bin"
+      ~cwd:"/Users/dev/me"
+  in
+  Alcotest.(check (list string))
+    "exe_dir before cwd"
+    [ "/Users/dev/masc-mcp/_build/default/bin"; "/Users/dev/me" ]
+    result
+
+let test_pick_repo_candidates_dedups_equal () =
+  let result =
+    Build_identity.pick_repo_candidates
+      ~exe_dir:"/Users/dev/masc-mcp"
+      ~cwd:"/Users/dev/masc-mcp"
+  in
+  Alcotest.(check (list string))
+    "single entry when equal"
+    [ "/Users/dev/masc-mcp" ]
+    result
+
+let test_pick_repo_candidates_not_sorted_alphabetically () =
+  (* The old implementation used List.sort_uniq String.compare which
+     sorted alphabetically, causing /Users/dancer/me to win over
+     /Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/bin
+     because the shorter prefix is lexicographically smaller. Assert
+     that we now preserve the logical order instead. *)
+  let result =
+    Build_identity.pick_repo_candidates
+      ~exe_dir:"/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/bin"
+      ~cwd:"/Users/dancer/me"
+  in
+  match result with
+  | first :: _ ->
+      Alcotest.(check string)
+        "exe_dir wins over shorter cwd prefix"
+        "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/default/bin"
+        first
+  | [] -> Alcotest.fail "pick_repo_candidates returned empty list"
+
 let () =
   Alcotest.run "build_identity"
     [
@@ -39,5 +82,14 @@ let () =
             test_resolve_commit_uses_probe_when_env_missing;
           Alcotest.test_case "current started_at stable" `Quick
             test_current_started_at_is_stable;
+          Alcotest.test_case
+            "pick_repo_candidates exe first when distinct" `Quick
+            test_pick_repo_candidates_exe_first_when_distinct;
+          Alcotest.test_case
+            "pick_repo_candidates dedups equal" `Quick
+            test_pick_repo_candidates_dedups_equal;
+          Alcotest.test_case
+            "pick_repo_candidates not sorted alphabetically" `Quick
+            test_pick_repo_candidates_not_sorted_alphabetically;
         ] );
     ]


### PR DESCRIPTION
## 증상

대시보드 `status.build.commit`이 실행 중인 masc-mcp 바이너리의 HEAD 대신 부모 디렉토리(`~/me`)의 HEAD를 표시. `MASC_BUILD_GIT_COMMIT` env 우회는 됐지만 기본 probe 경로가 틀렸음.

## 원인

`probe_git_commit`이 `[Sys.getcwd (); executable_dir ()]`를 `List.sort_uniq String.compare`로 정렬. 실행 형태가
```
cd ~/me && ~/me/workspace/yousleepwhen/masc-mcp/_build/default/bin/main_eio.exe --base-path=~/me
```
일 때 `/Users/dancer/me` < `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_build/...` 로 cwd가 lexicographic하게 먼저 오고, `find_git_root`가 cwd의 `.git`을 먼저 찾아 `~/me`의 커밋이 보고됨.

## 수정

`pick_repo_candidates ~exe_dir ~cwd`를 순수 헬퍼로 추출하고 exe_dir을 앞에 둠. 바이너리의 소스 트리가 항상 승리.

## 테스트

`test_build_identity.ml`에 3 케이스 추가 (모두 pass):
1. `pick_repo_candidates exe_first_when_distinct` — exe_dir 먼저
2. `pick_repo_candidates_dedups_equal` — equal인 경우 single entry
3. `pick_repo_candidates_not_sorted_alphabetically` — 실제 버그 재현 경로로 회귀 고정

```
Testing `build_identity'.
  [OK]  identity  0   resolve commit prefers env.
  [OK]  identity  1   resolve commit falls back to probe.
  [OK]  identity  2   current started_at stable.
  [OK]  identity  3   pick_repo_candidates exe first when distinct.
  [OK]  identity  4   pick_repo_candidates dedups equal.
  [OK]  identity  5   pick_repo_candidates not sorted alphabetically.
Test Successful in 0.013s. 6 tests run.
```

## 검증 계획 (머지 후)

1. 바이너리 재빌드
2. `MASC_BUILD_GIT_COMMIT` env 없이 `cd ~/me && .../main_eio.exe --base-path=~/me` 재시작
3. `sb masc status`에서 `build.commit`이 masc-mcp HEAD와 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)