### PR TITLE
harden(store_cache): mutex-protect Dated_jsonl store caches

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -183,17 +183,29 @@ let legacy_audit_path (config : config) =
   Filename.concat masc_dir "audit.jsonl"
 
 (** Date-split store: [.masc/audit/YYYY-MM/DD.jsonl].
-    Cached per base_dir so all callers share the same Eio.Mutex. *)
+    Cached per base_dir so all callers share the same Eio.Mutex.
+
+    The cache itself is protected by [audit_store_cache_mu] so that
+    two concurrent [get_audit_store] calls for the same base dir
+    cannot install two [Dated_jsonl.t] records with different inner
+    [Eio.Mutex] instances — otherwise file I/O to the same
+    [YYYY-MM/DD.jsonl] path would serialise through two different
+    mutexes and racing appends could interleave on disk.  Under the
+    current single-domain Eio with a non-yielding [Dated_jsonl.create]
+    this race does not fire today, but the fix is cheap and removes a
+    fragile implicit invariant. *)
 let audit_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+let audit_store_cache_mu = Eio.Mutex.create ()
 
 let get_audit_store (config : config) : Dated_jsonl.t =
   let base = Filename.concat (Room_utils.masc_dir config) "audit" in
-  match Hashtbl.find_opt audit_store_cache base with
-  | Some store -> store
-  | None ->
-    let store = Dated_jsonl.create ~base_dir:base () in
-    Hashtbl.replace audit_store_cache base store;
-    store
+  Eio_guard.with_mutex audit_store_cache_mu (fun () ->
+    match Hashtbl.find_opt audit_store_cache base with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:base () in
+      Hashtbl.replace audit_store_cache base store;
+      store)
 
 (** Parse JSON list into audit entries. Logs first 5 failures individually,
     then a summary. Returns only successfully parsed entries. *)

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -84,17 +84,20 @@ let telemetry_file config =
   Filename.concat (Room_utils.masc_dir config) "telemetry.jsonl"
 
 (** Date-split store: [.masc/telemetry/YYYY-MM/DD.jsonl].
-    Cached per base_dir so all callers share the same Eio.Mutex. *)
+    Cached per base_dir so all callers share the same Eio.Mutex.
+    See audit_log.ml get_audit_store for the invariant rationale. *)
 let telemetry_store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+let telemetry_store_cache_mu = Eio.Mutex.create ()
 
 let get_telemetry_store config : Dated_jsonl.t =
   let base = Filename.concat (Room_utils.masc_dir config) "telemetry" in
-  match Hashtbl.find_opt telemetry_store_cache base with
-  | Some store -> store
-  | None ->
-    let store = Dated_jsonl.create ~base_dir:base () in
-    Hashtbl.replace telemetry_store_cache base store;
-    store
+  Eio_guard.with_mutex telemetry_store_cache_mu (fun () ->
+    match Hashtbl.find_opt telemetry_store_cache base with
+    | Some store -> store
+    | None ->
+      let store = Dated_jsonl.create ~base_dir:base () in
+      Hashtbl.replace telemetry_store_cache base store;
+      store)
 
 let parse_event_records (jsons : Yojson.Safe.t list) : event_record list =
   List.filter_map (fun json ->


### PR DESCRIPTION
## Summary

- Adds `audit_store_cache_mu` / `telemetry_store_cache_mu` to `audit_log.ml` / `telemetry_eio.ml` and wraps the respective `get_*_store` functions in `Eio_guard.with_mutex`.
- Brings two outliers into conformance with the already-locked exemplars: `keeper_types_support.metrics_store_cache`, `keeper_crash_persistence.store_cache` / `sp_store_cache`, and `dashboard_governance_judge.judgments_store_cache`.

## Why

The cache contract is \"every caller for a given base_dir gets the **same** `Dated_jsonl.t`, which owns the **same** `Eio.Mutex.t`, which is the only serialisation on concurrent appends to the same `YYYY-MM/DD.jsonl`\". Two distinct stores for the same dir would own two distinct mutexes, and writes to the same file would race at the byte level.

Under today's single-domain Eio with a non-yielding `Dated_jsonl.create`, the lockless get-or-create is atomic and the race does not fire. But the fix is cheap and closes a fragile-by-implicit-invariant contract the type system cannot enforce.

Same drift class as PR #6682 (`agent_registry_eio`): a module-level Hashtbl whose safety depends on nothing yielding between `find_opt` and `replace`.

## Scope survey

| Module | Cache | Before |
|---|---|---|
| `audit_log.ml` | `audit_store_cache` | no mutex → fixed |
| `telemetry_eio.ml` | `telemetry_store_cache` | no mutex → fixed |
| `keeper_types_support.ml` | `metrics_store_cache` | already has `metrics_store_mu` |
| `keeper_crash_persistence.ml` | `store_cache` | already has `store_mu` |
| `keeper_crash_persistence.ml` | `sp_store_cache` | already has `sp_store_mu` |
| `dashboard_governance_judge.ml` | `judgments_store_cache` | already has `outer_mu` |

## Test plan

- [x] \`dune build --root . @lib/check\` — exit 0
- [x] No new tests — observable semantics are unchanged; the fix is a no-op on single-domain Eio today.
- [x] Verified `test_audit_log` and `test_telemetry_eio_coverage` failures are pre-existing on origin/main (stashed the fix and re-ran to confirm).

## Finding source

Cycle 40 of the masc-mcp audit sweep. Continuation of Cycle 39's \"lockless module-level Hashtbl\" axis, focused on the cache-of-locks sub-class.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>