### PR TITLE
chore(cascade): remove local_only profile — fallback-less cascades are architecturally wrong

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -3,9 +3,6 @@
     "glm-coding:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "local_only_models": [
-    "ollama:qwen3.5:35b-a3b-nvfp4"
-  ],
   "keeper_unified_models": [
     "glm-coding:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
@@ -14,7 +11,7 @@
     "glm-coding:glm-5.1",
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "Only endpoints the operator actually pays for. glm-coding = Coding Plan subscription (api.z.ai/api/coding/paas/v4). ollama = local MLX fallback. Removed 2026-04-12: (a) glm:glm-5.1 general API — operator has no pay-per-use balance, every call returned HTTP 429 code=1113 'Insufficient balance or no resource package. Please recharge.'. (b) groq:qwen/qwen3-32b — Groq model advertises context_window >= max_tokens, but qwen3-32b caps max_tokens at 40960 while cascade defaults carry 65536, so every call returned HTTP 400 'max_tokens must be less than or equal to 40960'. Both failures committed mutating tools (masc_add_task, keeper_board_vote, keeper_board_comment) before the cascade could fall through to ollama, driving keepers into ambiguous_partial_commit + manual_reconcile.",
+  "_comment": "Only endpoints the operator actually pays for. glm-coding = Coding Plan subscription (api.z.ai/api/coding/paas/v4). ollama = local MLX fallback. Removed 2026-04-12: (a) glm:glm-5.1 general API — operator has no pay-per-use balance, every call returned HTTP 429 code=1113 'Insufficient balance or no resource package. Please recharge.'. (b) groq:qwen/qwen3-32b — Groq model advertises context_window >= max_tokens, but qwen3-32b caps max_tokens at 40960 while cascade defaults carry 65536, so every call returned HTTP 400 'max_tokens must be less than or equal to 40960'. Both failures committed mutating tools (masc_add_task, keeper_board_vote, keeper_board_comment) before the cascade could fall through to ollama, driving keepers into ambiguous_partial_commit + manual_reconcile. (c) 'local_only' cascade profile — a cascade without a cloud fallback is architecturally fragile: one Ollama instability (concurrent JSON truncation, model eviction, request parse rejection) takes down every keeper on it with no recovery path. Cascade structure and how keepers consume models are tightly coupled; removing the ability to declare a rung-less cascade forces every keeper profile to inherit defense in depth. The OCaml is_local_only_cascade name-based special case in lib/oas_worker_named.ml becomes dead code after this removal and can be cleaned up in a follow-up.",
   "coding_first_temperature": 0.2,
   "coding_first_max_tokens": 32768,
   "tool_rerank_temperature": 0.0,
@@ -22,8 +19,6 @@
   "keeper_unified_temperature": 0.2,
   "keeper_unified_max_tokens": 32768,
   "keeper_turn_max_tokens": 32768,
-  "local_only_temperature": 0.2,
-  "local_only_max_tokens": 32768,
   "default_temperature": 0.3,
   "default_max_tokens": 4096
 }


### PR DESCRIPTION
## TL;DR

Removes the \`local_only_models\` / \`local_only_temperature\` / \`local_only_max_tokens\` profile from \`config/cascade.json\`. Acting on the user's architectural critique — **a cascade without a cloud fallback rung is structurally fragile, and cascade structure is tightly coupled to how keepers consume models, so the whole concept of \"local only\" as a cascade policy is wrong**.

## Why now

The loop session has been triaging keeper silent-loop failures for 35+ cycles. The remaining regression vector is isolated to \`sangsu\` (single keeper) experiencing bursts of \`Invalid request: Value looks like object, but can't find closing '}' symbol\` — 20 events in a 30-minute cycle 36 window, all at batch-burst timestamps, all from Ollama on the last rung of sangsu's cascade.

Cycle 36 initially concluded this was a sangsu-specific local_only trade-off (misremembering the cycle-2 \`#6458\` revert). The user corrected:

> \"local-only 라는 정책 자체가 잘못됐음. cascade 구조하고 keeper 가 어떤 모델을 어떤식으로 소비할것인지는 아주 밀접함\"

Re-reading the current state shows sangsu has already moved to \`keeper_unified\`:

\`\`\`bash
$ grep cascade_name config/keepers/*.toml
cheolsu:        cascade_name = \"coding_first\"
janitor:        (default)
masc-improver:  cascade_name = \"coding_first\"
sangsu:         cascade_name = \"keeper_unified\"
\`\`\`

**No keeper currently uses \`local_only\` as its cascade_name.** The profile exists in \`cascade.json\` and the OCaml helper \`lib/oas_worker_named.ml:17-30 is_local_only_cascade\` special-cases it, but it is not reachable from any production keeper right now. It is pure dead config and dead code invitation for future misuse.

## Design rationale

A cascade that only lists local providers and has no cloud fallback is architecturally fragile. A single instability on the local rung takes down every keeper on that cascade with no recovery path. Documented Ollama failure modes from this very loop session:

- **Concurrent JSON truncation** on 27B-NVFP4 under parallel keeper load (cycle-14 runtime-truth finding → the operator added a startup gate script)
- **Model eviction** under idle pressure before OAS #813 (\`feat(ollama): pin keep_alive=-1 by default\`)
- **Malformed request parse rejection** surfacing as \`Invalid request: Value looks like object, but can't find closing '}' symbol\` on specific request shapes — still producing burst failures today

Cascade structure and how keepers consume models are tightly coupled. **Which tool schemas the keeper ships, how much context it packs, which persona-specific instructions it sends — all of that depends on what the cascade can actually serve.** Declaring a \"local_only\" cascade that lacks a cloud rung hides this coupling behind a name-based policy convention and makes the operator opt into fragility.

The correct pattern is defense in depth: every cascade profile should carry at least one cloud rung as backstop, and keeper profiles that want to prefer local for cost/latency reasons should do so via ordering inside a mixed cascade (local first, cloud backstop) — not via a cascade that structurally excludes the backstop.

## Scope

Minimal. Three keys removed from \`config/cascade.json\`:

- \`local_only_models\`
- \`local_only_temperature\`
- \`local_only_max_tokens\`

**No OCaml source change in this PR.** The dead \`is_local_only_cascade\` helper in \`oas_worker_named.ml\` and the \`fallback_policy:\"strict_local_only\"\` harness chaos scripts in \`scripts/harness/workload/team_session_local64_*.sh\` are separate concerns and should not block this config cleanup.

\`\`\`diff
-  \"local_only_models\": [
-    \"ollama:qwen3.5:35b-a3b-nvfp4\"
-  ],
   ...
-  \"local_only_temperature\": 0.2,
-  \"local_only_max_tokens\": 32768,
\`\`\`

JSON remains valid (\`python3 -c 'import json; json.load(open(\"config/cascade.json\"))'\` exit 0).

## Test plan

- [x] JSON validates
- [x] No keeper config references \`local_only\` (\`grep -rn local_only config/keepers/\` returns empty for \`cascade_name\`)
- [ ] CI picks up the config change
- [ ] After merge: no runtime regression — keepers on coding_first / keeper_unified / default cascades unaffected
- [ ] Follow-up PR: delete \`is_local_only_cascade\` helper and simplify \`default_model_strings\` in \`lib/oas_worker_named.ml\`

## Follow-ups (separate PRs, not blocking)

1. \`lib/oas_worker_named.ml\`: delete \`is_local_only_cascade\` + simplify \`default_model_strings\` to always return \`all_labels\`
2. \`scripts/harness/workload/team_session_local64_*.sh\`: audit \`fallback_policy:\"strict_local_only\"\` chaos usage
3. Document the \"every cascade profile needs a cloud backstop\" convention in the cascade.json \`_comment\` or a design doc

🤖 Generated with [Claude Code](https://claude.com/claude-code) (loop cycle 36)