### PR TITLE
[codex] tighten keeper runtime limits

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -14,7 +14,7 @@
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,
-  "keeper_unified_max_tokens": 32768,
+  "keeper_unified_max_tokens": 16384,
   "keeper_turn_max_tokens": 32768,
   "local_only_temperature": 0.2,
   "local_only_max_tokens": 32768,

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -7,8 +7,9 @@ open Tool_args
 let default_cascade_name = "keeper_unified"
 
 (** Minimum context window (tokens) for any keeper turn.
-    Prevents running with a context too small for effective reasoning. *)
-let min_keeper_context_tokens = 65_536
+    64k-class local models are valid keeper backends; do not clamp them upward
+    to 65,536, which can exceed the discovered provider ceiling. *)
+let min_keeper_context_tokens = 64_000
 
 (* ── Alert preview truncation lengths ─────────────────────── *)
 (* Invariant: excerpt_min < message_max < reply_max.

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -469,7 +469,9 @@ let build_resume_config ~worker_name ~provider ~model_id ~system_prompt ~tools
       temperature = Some Oas_worker_cascade.worker_temperature;
       top_p = Some Oas_worker_cascade.worker_top_p;
       top_k = Some Oas_worker_cascade.worker_top_k;
-      min_p = Some Oas_worker_cascade.worker_min_p;
+      (* min_p is effectively disabled (0.0) and some cloud providers
+         reject the field itself even when the value is a no-op. *)
+      min_p = None;
       enable_thinking = Some thinking_enabled;
       tool_choice = Some Oas.Types.Auto;
     }

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -989,7 +989,7 @@ let test_unified_turn_runtime_defaults () =
   with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
     check (float 0.01) "unified temp default" 0.4
       (KC.keeper_unified_temperature ());
-    check int "unified max_tokens default" 65536
+    check int "unified max_tokens default" 16384
       (KC.keeper_unified_max_tokens ())
     (* max_turns is set in keeper_agent_run.ml (default: 50) *)))
 

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -535,7 +535,7 @@ let test_worker_build_agent_uses_default_internal_retry_policy () =
 let test_build_resume_config_propagates_retry_policy () =
   with_raw_trace "worker_resume_config_retry" @@ fun raw_trace ->
   let provider = make_local_provider () in
-  let (_config, options) =
+  let (config, options) =
     Worker_container.build_resume_config
       ~worker_name:"resume-worker"
       ~provider
@@ -549,6 +549,7 @@ let test_build_resume_config_propagates_retry_policy () =
       ~tool_retry_policy:Oas.Tool_retry_policy.default_internal
       ()
   in
+  Alcotest.(check (option (float 0.000001))) "resume config omits min_p" None config.min_p;
   let policy = options.tool_retry_policy in
   check_policy_matches_default_internal "resume config" policy
 


### PR DESCRIPTION
## What changed
- lower `coding_first` and `keeper_unified` default output budgets to `16384`
- drop no-op `min_p` from the worker resume path as well as the worker agent config path
- align the keeper minimum context floor with 64k-class local models instead of clamping them up to `65536`

## Why
Keeper turns were failing in two avoidable ways:
- some cloud/provider paths rejected oversized output budgets with `max_tokens must be less than or equal to 40960`
- resume/config paths could still send `min_p` even when the value was effectively disabled, and some providers reject the field itself
- local 64k models were being clamped upward to a 65536 minimum context, which is higher than the discovered provider ceiling

## Impact
- keeps worker and keeper runtime defaults within safer provider limits
- makes the `min_p` disablement consistent across fresh and resumed worker runs
- avoids forcing 64k local backends into an impossible context window

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-runtime-params bin/main_eio.exe test/test_worker_oas_scope_gate.exe test/test_oas_worker.exe test/test_keeper_unified.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-runtime-params ./test/test_worker_oas_scope_gate.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-runtime-params ./test/test_keeper_unified.exe` still has 3 pre-existing baseline failures in unrelated prompt/config cases
- `test_oas_worker.exe` compiled successfully via `dune build`; I did not get a clean standalone completion run for the full executable in this pass
