### PR TITLE
fix(lazy): replace Stdlib.Lazy with Eio.Lazy in keeper modules

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -10,9 +10,10 @@
 (* ================================================================ *)
 
 let decision_layer_level_cached =
-  lazy (Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
 
-let decision_layer_level () = Lazy.force decision_layer_level_cached
+let decision_layer_level () = Eio.Lazy.force decision_layer_level_cached
 
 let audit_enabled () = decision_layer_level () >= 1
 
@@ -71,9 +72,10 @@ let to_json (r : decision_record) : Yojson.Safe.t =
 (* ================================================================ *)
 
 let ring_capacity_cached =
-  lazy (Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
 
-let ring_capacity () = max 1 (Lazy.force ring_capacity_cached)
+let ring_capacity () = max 1 (Eio.Lazy.force ring_capacity_cached)
 
 type ring = {
   buf : decision_record option array;
@@ -86,8 +88,6 @@ type ring = {
 let rings : (string, ring) Hashtbl.t = Hashtbl.create 8
 
 let flush_interval_sec_cached =
-  (* Flush cadence is only consulted from keeper runtime fibers, so use
-     Eio.Lazy here to avoid concurrent Stdlib.Lazy.force hazards. *)
   Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
     Env_config_core.get_float ~default:60.0
       "MASC_DECISION_AUDIT_FLUSH_INTERVAL_SEC")

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -5,12 +5,13 @@
 
 module SM = Keeper_state_machine
 
-let enabled_cache : bool Lazy.t =
-  lazy (match Sys.getenv_opt "MASC_TLA_TRACE" with
+let enabled_cache =
+  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
+    match Sys.getenv_opt "MASC_TLA_TRACE" with
     | Some ("1" | "true" | "yes") -> true
     | _ -> false)
 
-let enabled () = Lazy.force enabled_cache
+let enabled () = Eio.Lazy.force enabled_cache
 
 let trace_path ~base_path ~keeper_name =
   Filename.concat
@@ -27,7 +28,7 @@ let emit_transition
     ~(conditions_after : SM.conditions)
     ~(restart_count : int)
   =
-  if not (Lazy.force enabled_cache) then ()
+  if not (Eio.Lazy.force enabled_cache) then ()
   else
     let json = `Assoc [
       "seq", `Int seq;


### PR DESCRIPTION
## Summary

- Convert 3 remaining \`Stdlib.Lazy\` values to \`Eio.Lazy.from_fun ~cancel:\`Protect\`\` in \`keeper_decision_audit.ml\` (2) and \`keeper_trace_emit.ml\` (1).
- Removes partial-refactor drift: the same file had a comment explaining why to use \`Eio.Lazy\`, but applied it to only 2 of 4 lazy values.

## Why

\`Stdlib.Lazy.force\` on OCaml 5.x raises \`Lazy.Undefined\` if two domains (or re-entrant fibers) force concurrently. \`Eio.Lazy.from_fun ~cancel:\`Protect\`\` waits for the first forcer and protects against cancellation during initialization.

## Scope survey

\`rg \"Lazy.force\" lib/\` found 3 \`Stdlib.Lazy.force\` sites vs 18 \`Eio.Lazy.force\` sites. All 3 are converted here. After this PR, lib/ uses \`Eio.Lazy\` exclusively.

## Test plan

- [x] \`dune build --root . @lib/check\` — exit 0
- [x] No test changes needed (env-var reads return same values regardless of Lazy impl)

## Finding source

Cycle 42 of the masc-mcp audit sweep. OCaml best-practice axis — \`Stdlib.Lazy\` should be \`Eio.Lazy\` in Eio server context per established feedback memory.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>