### PR TITLE
fix: re-raise Eio.Cancel.Cancelled in 5 catch-all handlers

### DIFF
--- a/lib/agent_economy.ml
+++ b/lib/agent_economy.ml
@@ -175,7 +175,9 @@ let append_transaction base_path (txn : transaction) : (unit, string) result =
     let line = Yojson.Safe.to_string (transaction_to_json txn) ^ "\n" in
     Fs_compat.append_file path line;
     Ok ()
-  with e ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | e ->
     Error (Printf.sprintf "[agent_economy] ledger write failed: %s"
              (Printexc.to_string e))
 

--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -326,7 +326,9 @@ let bounded_run ~constraints ~goal ~agents ~prompt ~spawn_fn =
             let rec try_spawn attempt =
               let result =
                 try Ok (spawn_fn agent prompt)
-                with e -> Error (Printexc.to_string e)
+                with
+                | Eio.Cancel.Cancelled _ as e -> raise e
+                | e -> Error (Printexc.to_string e)
               in
               match result with
               | Ok spawn_result when spawn_result.success ->

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -442,8 +442,9 @@ let handle_keeper_pr_workflow
                 worktree_path (String.trim out_prune);
             Ok ()
           end
-        with exn ->
-          Error (Printexc.to_string exn)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn -> Error (Printexc.to_string exn)
       in
       let branch_exists_locally branch_name =
         let st, out = run_sh ~cwd:repo_root ~timeout_sec:5.0

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -134,7 +134,9 @@ let update_playground_repo_cache
     ] in
     ignore (Fs_compat.save_file_atomic cache_path
       (Yojson.Safe.pretty_to_string json ^ "\n"))
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
     Logs.warn (fun f -> f "playground cache update failed: %s"
       (Printexc.to_string exn))
 

--- a/lib/opentelemetry_client_cohttp_eio.ml
+++ b/lib/opentelemetry_client_cohttp_eio.ml
@@ -144,7 +144,9 @@ end = struct
       try
         let r = Httpc.post client ~sw ~headers ~body uri in
         Ok r
-      with e -> Error e
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | e -> Error e
     in
     match r with
     | Error e ->


### PR DESCRIPTION
## Summary

- 5 catch-all exception handlers silently converted \`Eio.Cancel.Cancelled\` into \`Error\`/\`Logs.warn\`, preventing cancellation from propagating during switch teardown.
- Fix: add \`| Eio.Cancel.Cancelled _ as e -> raise e\` before each catch-all.
- All 5 try-blocks contain yielding Eio operations (HTTP, shell exec, Eio FS), so Cancelled can legitimately arrive.

## Affected sites

| File | Yields via |
|------|-----------|
| \`opentelemetry_client_cohttp_eio.ml:147\` | \`Httpc.post\` (cohttp-eio) |
| \`keeper_exec_github.ml:445\` | \`run_sh\` (Process_eio) |
| \`agent_economy.ml:178\` | \`Fs_compat.append_file\` (Eio.Path) |
| \`bounded.ml:329\` | \`spawn_fn\` (agent spawn) |
| \`keeper_exec_shell.ml:137\` | \`Fs_compat.save_file_atomic\` (Eio.Path) |

## Verified safe (no change needed)

- \`types/types_core.ml\` (10 hits), \`types/types_auth.ml\` (3 hits): pure Yojson parsing, non-yielding.
- \`prompt_registry.ml\` (2 hits): Buffer/Printf template rendering, non-yielding.

## Test plan

- [x] \`dune build --root . @lib/check\` — exit 0
- [x] No test changes: the fix only affects cancellation propagation path, which existing tests do not exercise.

## Finding source

Cycle 43 of the masc-mcp audit sweep. Scanned \`with (exn|e|_) ->\` across lib/, filtered by yield potential of try-block.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>