### PR TITLE
fix(keeper): add keeper_board_delete + cleanup to boundary-exempt list

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -262,6 +262,17 @@ let is_main_worktree_boundary_exempt_with_input
     | "keeper_task_claim" | "keeper_task_done" | "keeper_tasks_list"
     | "keeper_board_post" | "keeper_board_comment" | "keeper_board_vote"
     | "keeper_board_list" | "keeper_board_get"
+    (* Board delete and cleanup are MASC-state-only mutations (board
+       post store), not main-worktree writes.  Missing here until #6692
+       caused [janitor] to hit a mutation-boundary block loop at
+       2026-04-12 01:15:25 KST: the first [keeper_board_delete] in a
+       cleanup turn succeeded and opened the boundary, and every
+       subsequent [keeper_board_delete] in the same turn was blocked
+       by the [pre_tool_use_guard], burning the turn budget without
+       progress.  The [masc_board_delete] alias was already exempt at
+       line 283 but its [keeper_*] counterpart had drifted out of this
+       list — same structural gap fixed by #6681 for [masc_claim_next]. *)
+    | "keeper_board_delete" | "keeper_board_cleanup"
     | "keeper_broadcast" -> true
     (* MASC coordination aliases for the [keeper_*] entries above.
        These share the same name with a [masc_] prefix because they are

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -257,6 +257,31 @@ let test_masc_coordination_aliases_bypass_boundary () =
       "masc_board_list"; "masc_board_get"; "masc_board_stats";
       "masc_board_hearths"; "masc_board_profile" ]
 
+(* Regression: [keeper_board_delete] and [keeper_board_cleanup] were
+   missing from the [keeper_*] side of the exempt list even though
+   their [masc_*] coordination alias [masc_board_delete] was already
+   exempt at line 283 of [keeper_tool_registry.ml].  Observed 2026-04-12
+   01:15:25 KST on janitor: the first [keeper_board_delete] of a cleanup
+   turn succeeded and opened the mutation boundary, and every subsequent
+   [keeper_board_delete] in the same turn was blocked by the
+   [pre_tool_use_guard] — burning janitor's turn budget on a repeating
+   "tool skipped" loop instead of progressing through the cleanup queue.
+   Same structural gap class as #6671 / #6681.
+
+   Board delete and cleanup are MASC-state-only mutations (board post
+   store), not main-worktree writes, so multiple deletes per turn are
+   safe.  This test locks the exemption so the next rename does not
+   silently drift the [keeper_*] side out of sync with [masc_*]. *)
+let test_keeper_board_delete_and_cleanup_bypass_boundary () =
+  let check name =
+    Alcotest.(check bool) (name ^ " is mutating") false
+      (is_ro ~tool_name:name ~input:(`Assoc []));
+    Alcotest.(check bool) (name ^ " bypasses boundary") true
+      (is_boundary_exempt ~tool_name:name ~input:(`Assoc []))
+  in
+  List.iter check
+    [ "keeper_board_delete"; "keeper_board_cleanup" ]
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -310,5 +335,7 @@ let () =
             test_keeper_bash_still_opens_boundary;
           Alcotest.test_case "masc_* coordination aliases bypass boundary" `Quick
             test_masc_coordination_aliases_bypass_boundary;
+          Alcotest.test_case "keeper_board_delete and cleanup bypass boundary" `Quick
+            test_keeper_board_delete_and_cleanup_bypass_boundary;
         ] );
     ]


### PR DESCRIPTION
## Summary
Post-restart log on 2026-04-12 01:15:25 KST showed janitor hitting `pre_tool_use guard blocked keeper_board_delete` 6 times in 2 minutes. First `keeper_board_delete` succeeded and opened the mutation boundary; every subsequent one in the same turn was blocked — turn budget burned on a "tool skipped" loop.

Root cause: `keeper_board_delete` and `keeper_board_cleanup` were missing from the `keeper_*` side of `is_main_worktree_boundary_exempt_with_input`. The `masc_board_delete` alias was already exempt (line 283). Same structural gap class as #6681 (which fixed `masc_claim_next`).

## Fix
- Add `"keeper_board_delete" | "keeper_board_cleanup"` to the `keeper_*` branch of the exempt match.
- Add `test_keeper_board_delete_and_cleanup_bypass_boundary` regression test (case 7 in `test_keeper_github_read_only.ml`).

Both tools are board-state-only mutations, not main-worktree writes. Multiple per turn: safe (independent post IDs, idempotent).

## Test plan
- [x] `dune exec test/test_keeper_github_read_only.exe` → 17/17 pass (new case 7 included)
- [x] `dune build lib` green
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
