### PR TITLE
docs: define external framework alignment and checkpoint replay rollout

### DIFF
--- a/docs/design/checkpoint-truth-and-replay-rfc.md
+++ b/docs/design/checkpoint-truth-and-replay-rfc.md
@@ -1,0 +1,288 @@
+# Checkpoint Truth and Replay RFC
+
+**Status**: Draft
+**Date**: 2026-04-12
+**Scope**: Keeper runtime checkpoint truth, replay semantics, side-effect boundary
+**One sentence**: Productize keeper continuity as replayable checkpoint-backed runtime state with explicit side-effect boundaries, not as a vague same-trace memory story.
+
+## Related Documents
+
+- `../spec/13-oas-integration.md`
+- `./oas-masc-state-boundary.md`
+- `./delta-checkpoint-read-path.md`
+- `./keeper-continuity-product-rfc.md`
+- `../KEEPER-CONTINUITY-VALIDATION.md`
+
+## Problem
+
+현재 keeper continuity는 "same-trace continuity"라는 제품 언어는 있으나,
+runtime 설계 차원에서 아래가 한 문서로 묶여 있지 않다.
+
+- checkpoint의 SSOT가 무엇인가
+- `resume`, `replay`, `fork`를 어떻게 구분하는가
+- 어떤 step이 deterministic replay 대상인가
+- 어떤 side effect는 replay-safe이고 어떤 것은 아닌가
+- checkpoint truth와 domain truth가 충돌할 때 어느 쪽을 먼저 믿는가
+
+이 공백 때문에 continuity, compaction, handoff, verifier, proof artifact가
+각기 다른 의미로 "replay"를 말하게 된다.
+
+## Goal
+
+이 RFC는 keeper runtime에 대해 아래를 고정한다.
+
+1. checkpoint truth hierarchy
+2. replay semantics vocabulary
+3. deterministic step boundary
+4. side-effect classification
+5. checkpoint write/load contract
+6. rollout order
+
+## Non-goals
+
+- general long-term memory 설계
+- cross-trace recall 설계
+- verifier proof bundle 전면 개편
+- OAS public API에 MASC domain semantics를 추가하는 것
+
+## Terms
+
+### Checkpoint truth
+
+동일 `trace_id` 내에서 다음 turn을 재개하기 위해 필요한 runtime state의 canonical snapshot.
+
+### Resume
+
+현재 trace/session을 이어서 계속하는 것.
+의도는 "이전 runtime state를 이어받아 다음 step으로 간다"이다.
+
+### Replay
+
+저장된 checkpoint를 기준점으로 다시 실행해 동일한 typed fact를 얻는 것.
+목표는 "state reconstruction"이지 "동일한 raw token stream 재생"이 아니다.
+
+### Fork
+
+기존 checkpoint를 읽되, 원본 trace를 덮지 않고 다른 branch/trace로 분기해 실행하는 것.
+
+### Side-effect boundary
+
+replay 시 중복 실행이 허용되지 않는 작업이 시작되는 지점.
+
+## Source of Truth Hierarchy
+
+같은 keeper trace에 대해 충돌이 생기면 아래 순서로 truth를 본다.
+
+1. **OAS checkpoint**
+   - runtime messages
+   - turn count
+   - usage stats
+   - lifecycle state
+2. **Typed post-turn metadata derived from the checkpoint**
+   - generation
+   - compaction outcome
+   - handoff outcome
+   - continuity update timestamp
+3. **Domain surfaces**
+   - keeper meta summary
+   - dashboard read models
+   - continuity summary text
+
+Rule:
+
+- runtime reconstruction은 1번이 우선이다.
+- operator diagnosis는 2번과 3번을 보조로 쓴다.
+- 3번이 1번을 덮어쓰는 설계는 금지한다.
+
+## Replay Semantics
+
+### R1. Resume is the default continuity path
+
+keeper continuity의 기본 경로는 `resume`이다.
+
+- same `trace_id`
+- same checkpoint lineage
+- next turn continues from last saved checkpoint
+
+이 경로는 continuity의 제품 contract와 directly 연결된다.
+
+### R2. Replay is a diagnostic and validation path
+
+`replay`는 operator / verifier / runtime diagnosis 경로다.
+
+목적:
+
+- checkpoint truth 검증
+- deterministic typed fact 재생산
+- continuity drift / artifact drift 분석
+
+비목적:
+
+- identical natural language regeneration
+- exact same provider-side token stream 재현
+
+### R3. Fork must not mutate the source lineage
+
+`fork`는 source checkpoint를 읽을 수는 있지만,
+원본 trace/session lineage를 덮어쓰면 안 된다.
+
+## Deterministic Step Boundary
+
+replay target은 "typed post-step facts"다.
+
+아래는 replay 대상으로 본다.
+
+- checkpoint load success/failure
+- selected tool name
+- tool input/output envelope shape
+- mutation boundary reached 여부
+- compaction decision
+- handoff decision
+- verifier verdict input/output envelope
+
+아래는 replay 대상으로 보지 않는다.
+
+- exact assistant wording
+- exact provider internal retries
+- exact hidden reasoning text
+- exact token-by-token streaming sequence
+
+## Side-effect Classes
+
+### Class A: Pure runtime computation
+
+Examples:
+
+- prompt assembly
+- context reduction
+- tool selection
+- typed verdict derivation
+
+Replay rule:
+
+- always replayable
+
+### Class B: Read-only external observation
+
+Examples:
+
+- search
+- status
+- read-only board/task inspection
+- checkpoint load
+
+Replay rule:
+
+- replayable if output is captured as typed evidence
+- otherwise diagnostic replay only
+
+### Class C: Idempotent domain mutation
+
+Examples:
+
+- duplicate-tolerant board/comment/vote style actions
+- mutation with explicit dedupe key / commit token
+
+Replay rule:
+
+- replayable only through typed mutation evidence or dedupe token
+- raw string inference from trace alone is insufficient
+
+### Class D: Non-replay-safe external mutation
+
+Examples:
+
+- git push
+- external API write
+- deployment
+- filesystem mutation outside a contained sandbox contract
+
+Replay rule:
+
+- do not auto-replay
+- checkpoint may resume after the boundary, but diagnostic replay must treat this as a hard side-effect boundary
+
+## Checkpoint Write / Load Contract
+
+### Write contract
+
+- post-turn checkpoint save happens after runtime state is normalized
+- saved checkpoint must correspond to the continuity/read surfaces emitted for the same turn
+- any sidecar or delta artifact is subordinate to the full checkpoint truth
+
+### Load contract
+
+- restore path loads native OAS checkpoint first
+- fallback paths may exist for compatibility, but they must not redefine truth
+- read surfaces that summarize continuity must clearly indicate when they are derived rather than directly restored
+
+## Invariants
+
+- **INV-OAS-CHK-001**: keeper runtime reconstruction starts from OAS checkpoint truth, not keeper summary text
+- **INV-OAS-CHK-002**: replay judges typed facts, not exact model prose
+- **INV-OAS-CHK-003**: class D side effects are never auto-replayed
+- **INV-OAS-CHK-004**: fork never overwrites the source checkpoint lineage
+- **INV-OAS-CHK-005**: domain read models may summarize checkpoint truth but may not supersede it
+
+## Implementation Landing Points
+
+Primary spec / contract:
+
+- `docs/spec/13-oas-integration.md`
+- `docs/design/oas-masc-state-boundary.md`
+
+Primary code anchors:
+
+- `lib/keeper/keeper_checkpoint_store.ml`
+- `lib/keeper/keeper_agent_run.ml`
+- `lib/keeper/keeper_post_turn.ml`
+
+Secondary design touchpoints:
+
+- `docs/design/delta-checkpoint-read-path.md`
+- `docs/design/keeper-continuity-product-rfc.md`
+- `docs/design/handoff-ssot-adr.md`
+
+## Rollout Order
+
+### Phase 1
+
+- declare checkpoint truth hierarchy
+- declare replay semantics vocabulary
+- wire doc cross-references
+
+### Phase 2
+
+- reduce keeper-owned wrapper state around OAS checkpoint/context
+- move replay-relevant state to typed post-turn facts
+
+### Phase 3
+
+- tighten side-effect classes and mutation boundary evidence
+- make verifier/proof bundle consume the same replay vocabulary
+
+### Phase 4
+
+- optional delta checkpoint restore path, only after full-checkpoint truth is stable
+
+## Open Questions
+
+1. should replayable mutation evidence live with checkpoint metadata, proof bundle, or both?
+2. which current continuity fields should be explicitly marked "derived, not canonical" on keeper status surfaces?
+3. do we need a dedicated typed event for mutation boundary crossing, separate from raw trace/tool call logs?
+
+## Evidence
+
+- [근거] LangGraph durable execution / persistence / time-travel:
+  https://docs.langchain.com/oss/python/langgraph/durable-execution ,
+  https://docs.langchain.com/oss/python/langgraph/persistence ,
+  https://docs.langchain.com/oss/python/langgraph/use-time-travel ;
+  확인일시 2026-04-12 ; 신뢰도 High
+- [근거] current MASC boundary state:
+  `docs/OAS-MASC-BOUNDARY.md` ,
+  `docs/spec/13-oas-integration.md` ;
+  확인일시 2026-04-12 ; 신뢰도 High
+- [근거] current keeper continuity product contract:
+  `docs/design/keeper-continuity-product-rfc.md` ,
+  `docs/KEEPER-CONTINUITY-VALIDATION.md` ;
+  확인일시 2026-04-12 ; 신뢰도 High

--- a/docs/design/checkpoint-truth-and-replay-rfc.md
+++ b/docs/design/checkpoint-truth-and-replay-rfc.md
@@ -8,6 +8,7 @@
 ## Related Documents
 
 - `../spec/13-oas-integration.md`
+- `./checkpoint-truth-replay-implementation-checklist.md`
 - `./oas-masc-state-boundary.md`
 - `./delta-checkpoint-read-path.md`
 - `./keeper-continuity-product-rfc.md`

--- a/docs/design/checkpoint-truth-replay-implementation-checklist.md
+++ b/docs/design/checkpoint-truth-replay-implementation-checklist.md
@@ -1,0 +1,146 @@
+# Checkpoint Truth and Replay Implementation Checklist
+
+**Status**: Draft  
+**Date**: 2026-04-12  
+**Scope**: implementation checklist for the checkpoint truth / replay RFC
+
+## Related
+
+- `./checkpoint-truth-and-replay-rfc.md`
+- `../spec/13-oas-integration.md`
+- `./oas-masc-state-boundary.md`
+- `./delta-checkpoint-read-path.md`
+
+## Goal
+
+`checkpoint truth and replay` RFC를 실제 코드 변경 단위로 쪼개어,
+어느 모듈에서 무엇을 바꿔야 하는지와 검증 기준을 고정한다.
+
+## Phase A. Truth Surface Cleanup
+
+### A1. Declare native OAS checkpoint as runtime truth
+
+- [ ] `lib/keeper/keeper_checkpoint_store.ml`
+  - `save_oas` / `load_oas`를 runtime truth path로 유지
+  - legacy checkpoint load path는 compatibility-only로 문서화
+- [ ] `lib/keeper/keeper_agent_run.ml`
+  - checkpoint load/write comments와 variable naming이 truth hierarchy와 일치하는지 정리
+- [ ] `lib/keeper/keeper_post_turn.ml`
+  - post-turn lifecycle가 `Agent_sdk.Checkpoint.t`를 canonical input/output으로 취급하는지 확인
+
+Acceptance:
+
+- restore path 설명에서 native OAS checkpoint가 먼저 나온다
+- legacy path는 fallback 또는 migration wording만 가진다
+
+### A2. Mark derived read surfaces explicitly
+
+- [ ] keeper status / continuity 관련 read surface 문서에서
+  `continuity_summary`, `generation`, `last_continuity_update_ts` 중
+  derived field를 명시
+- [ ] `docs/KEEPER-CONTINUITY-VALIDATION.md`와 wording 일치
+
+Acceptance:
+
+- operator 문서에서 canonical vs derived distinction이 보인다
+
+## Phase B. Replay Semantics and Boundary
+
+### B1. Mutation boundary evidence normalization
+
+- [ ] `lib/keeper/keeper_agent_run.ml`
+  - committed tool 이후 mutation boundary를 typed event/fact로 다룰 수 있는지 점검
+  - 현재 string sentinel에 의존하는 부분을 inventory
+- [ ] `lib/keeper/keeper_post_turn.ml`
+  - compaction / handoff / overflow retry가 replay target typed fact로 충분한지 점검
+
+Acceptance:
+
+- replay target facts 목록이 코드와 문서에서 일치한다
+- mutation boundary가 raw prose가 아니라 typed outcome로 설명된다
+
+### B2. Side-effect class mapping
+
+- [ ] current keeper tools를 RFC의 class A/B/C/D에 임시 매핑
+- [ ] Class D replay 금지 규칙이
+  `keeper_bash`, PR submit, external writes 쪽과 모순 없는지 확인
+
+Implementation anchors:
+
+- `lib/keeper/keeper_agent_run.ml`
+- `lib/keeper/keeper_exec_shell.ml`
+- `lib/tool_code_write.ml`
+
+Acceptance:
+
+- non-replay-safe mutation examples가 실제 write gate와 충돌하지 않는다
+
+## Phase C. Wrapper Reduction
+
+### C1. `working_context` dependency inventory
+
+- [ ] `lib/keeper/keeper_exec_context.ml`
+  - `working_context`가 어디서 필요한지 inventory 작성
+- [ ] `lib/keeper/keeper_post_turn.ml`
+  - `context_of_oas_checkpoint` 결과를 다시 wrapper로 다루는 지점 정리
+- [ ] `lib/keeper/keeper_agent_run.ml`
+  - checkpoint load 후 wrapper가 필요한 이유를 분리
+
+Acceptance:
+
+- wrapper가 truly required인 필드와 historical residue를 구분한 inventory가 있다
+
+### C2. Marker leakage inventory
+
+- [ ] `[STATE]`, `[GOAL]`, memory-summary marker read/write path 수집
+- [ ] checkpoint patching이 marker-preserving trick인지, typed state transport인지 구분
+
+Implementation anchors:
+
+- `lib/keeper/keeper_agent_run.ml`
+- `lib/context_compact_oas.ml`
+- `lib/keeper/keeper_post_turn.ml`
+
+Acceptance:
+
+- marker leakage 제거 backlog가 독립 작업 항목으로 분리된다
+
+## Phase D. Optional Delta Path
+
+### D1. Delta restore stays subordinate
+
+- [ ] `docs/design/delta-checkpoint-read-path.md`
+  - delta는 full checkpoint subordinate임을 계속 유지
+- [ ] restore ordering이 RFC wording과 일치하는지 확인
+
+Acceptance:
+
+- delta path는 optimization이지 truth source가 아님이 명시된다
+
+## Code Anchors
+
+### Primary
+
+- `lib/keeper/keeper_checkpoint_store.ml`
+- `lib/keeper/keeper_agent_run.ml`
+- `lib/keeper/keeper_post_turn.ml`
+- `lib/keeper/keeper_exec_context.ml`
+
+### Secondary
+
+- `lib/keeper/keeper_exec_shell.ml`
+- `lib/tool_code_write.ml`
+- `lib/context_compact_oas.ml`
+
+## Validation Checklist
+
+- [ ] `docs/spec/13-oas-integration.md` open ledger reflects the same phases
+- [ ] `docs/design/checkpoint-truth-and-replay-rfc.md` terminology matches implementation checklist
+- [ ] continuity product RFC does not over-promise beyond replay truth
+- [ ] no code path is described as replay-safe if the current write gate treats it as unsafe
+
+## Deferred Until After Phase A-C
+
+- delta restore implementation
+- generalized time-travel / fork UX
+- proof-bundle level replayable mutation evidence v2

--- a/docs/design/external-agent-framework-patterns-rfc.md
+++ b/docs/design/external-agent-framework-patterns-rfc.md
@@ -1,0 +1,234 @@
+# External Agent Framework Patterns RFC
+
+Status: draft
+Updated: 2026-04-12
+
+## Goal
+
+Morph의 agent framework 비교 글을 출발점으로 삼되, `masc-mcp`에 바로 적용 가능한 패턴만 추려서
+설계 우선순위와 landing point를 고정한다.
+
+이 문서의 핵심 질문은 "어느 프레임워크로 갈아탈 것인가"가 아니라
+"현재 `MASC -> OAS` spine 위에서 어떤 추상화를 제품 수준으로 끌어올릴 것인가"다.
+
+## Scope
+
+- 외부 패턴 비교:
+  - LangGraph durable execution / replay
+  - OpenAI Agents SDK workflow / guardrails / tracing
+  - Google ADK + A2A Agent Card / discovery
+  - Morph가 강조한 infra-first execution primitive 관점
+- 내부 적용 축:
+  - keeper checkpoint truth / replay
+  - typed handoff / proof / verifier envelopes
+  - infra primitive SSOT
+  - A2A discovery consolidation
+
+## Non-goals
+
+- Claude Agent SDK, OpenAI Agents SDK, Google ADK, CrewAI, LangGraph를
+  `masc-mcp` core runtime 위에 직접 embedding 하는 것
+- role-play crew abstraction을 coordination core로 채택하는 것
+- code-generating execution model을 keeper default로 바꾸는 것
+
+## Decision Summary
+
+1. `masc-mcp`는 orchestration/control plane으로 유지하고, single-agent runtime은 계속 OAS에 둔다.
+2. 외부 비교에서 가장 먼저 가져올 패턴은 LangGraph류의 `checkpoint truth + replay discipline`이다.
+3. 두 번째는 OpenAI Agents SDK가 보여주는 `typed workflow surface + guardrail/eval-friendly tracing`이다.
+4. 세 번째는 Morph 글이 강조한 `framework보다 infra primitive가 중요하다`는 관점이다.
+5. 네 번째는 Google ADK/A2A 쪽의 `Agent Card based discovery`를 remote interoperability 용도로 다듬는 것이다.
+
+## Comparison
+
+| External pattern | External claim | Current `masc-mcp` state | Decision |
+|---|---|---|---|
+| LangGraph durable execution | checkpoint, resume, replay/fork are first-class | keeper checkpoint는 실재하지만 truth/replay contract가 아직 분산됨 | adopt |
+| OpenAI workflow primitives | handoff, guardrails, traces, evals are workflow-level building blocks | verification/proof/handoff는 있으나 envelope family가 분산됨 | adopt selectively |
+| Google ADK + A2A | Agent Cards and protocol boundary for remote discovery | Agent Card/A2A surface는 이미 존재하나 canonical contract가 흩어져 있음 | adopt selectively |
+| Morph infra-first view | orchestration보다 apply/search/sandbox/compaction primitive quality가 중요 | search/apply/sandbox/compaction이 각각 존재하지만 shared infra model이 없음 | adopt |
+| CrewAI role-based crews | natural-language role composition | `masc-mcp`의 문제는 역할극보다 correctness / observability / state truth | reject for core |
+| Smolagents code agent default | code generation drives tool invocation | keeper write path는 playground containment가 핵심 guardrail | reject for core |
+
+## What to Keep
+
+- `MASC`는 언제/왜/누가 실행되는지를 결정하고,
+  `OAS`는 단일 agent runtime을 담당하는 현재 boundary를 유지한다.
+- repo-local, single-machine, trusted-network coordination이라는 front-door promise를 유지한다.
+- keeper playground containment를 sandbox SSOT로 유지한다.
+
+## What to Change
+
+### 1. Checkpoint Truth and Replay
+
+Priority: P1
+
+What to change:
+
+- keeper continuity를 "same-trace continuity"가 아니라
+  "checkpoint-backed replayable runtime state"로 더 엄격하게 정의한다.
+- replay semantics를 문서에서 먼저 고정한다:
+  - 무엇이 deterministic step인가
+  - 어떤 side effect가 replay-safe 인가
+  - 어떤 operation은 task boundary 뒤로 밀어야 하는가
+
+Primary landing:
+
+- `docs/spec/13-oas-integration.md`
+- `docs/design/oas-masc-state-boundary.md`
+
+Implementation anchors:
+
+- `lib/keeper/keeper_checkpoint_store.ml`
+- `lib/keeper/keeper_agent_run.ml`
+- `lib/keeper/keeper_post_turn.ml`
+
+Expected output:
+
+- canonical checkpoint truth doc
+- replay safety rules
+- keeper read-path / checkpoint ownership cleanup backlog
+
+### 2. Typed Handoff / Proof / Verifier Envelope
+
+Priority: P2
+
+What to change:
+
+- `handoff_context`, proof bundle, verifier verdict, checkpoint evidence를
+  하나의 typed envelope family로 정리한다.
+- 지금처럼 각 subsystem이 비슷한 의미를 다른 JSON shape로 들고 있는 상태를 줄인다.
+
+Primary landing:
+
+- `docs/design/contract-driven-agent-loop-rfc.md`
+- `docs/design/handoff-ssot-adr.md`
+- `docs/design/proof-bundle-check-mapping.md`
+
+Implementation anchors:
+
+- `lib/tool_handover.ml`
+- `lib/verification.ml`
+- `lib/tool_verification.ml`
+- `lib/cdal_loader.ml`
+- `lib/proof_artifact_reader.ml`
+
+Expected output:
+
+- typed envelope vocabulary
+- verifier/proof/handoff compatibility rules
+- replayable evidence contract
+
+### 3. Infra Primitive SSOT
+
+Priority: P3
+
+What to change:
+
+- search, apply/write, sandbox, compaction을 "여러 기능"이 아니라
+  shared execution primitive set으로 문서와 operator surface에서 묶는다.
+- canonical primitive / compatibility-only primitive / experimental primitive를 구분한다.
+
+Primary landing:
+
+- `docs/COMMAND-PLANE-RUNBOOK.md`
+- `docs/design/contract-driven-agent-loop-rfc.md`
+- `docs/SEARCH-FABRIC-V1.md`
+
+Implementation anchors:
+
+- `lib/command_plane/cp_search_fabric.ml`
+- `lib/task_sandbox.ml`
+- `lib/tool_compact.ml`
+- `lib/context_compact_oas.ml`
+- `lib/tool_code_write.ml`
+
+Expected output:
+
+- infra primitive inventory
+- operator-facing composition rules
+- canonical write/apply/search/sandbox language
+
+### 4. A2A Discovery Consolidation
+
+Priority: P4
+
+What to change:
+
+- current A2A/Agent Card surface를 유지하되,
+  `local-only coordination`과 `remote discovery`를 구분해 contract를 정리한다.
+- Agent Card는 capability discovery surface로만 유지하고,
+  memory/tool/state internals를 노출하지 않는다는 원칙을 명문화한다.
+
+Primary landing:
+
+- `docs/SPEC.md`
+- `docs/spec/09-server-transport.md`
+
+Implementation anchors:
+
+- `lib/agent_card.ml`
+- `lib/a2a_tools.ml`
+- `lib/server/server_routes_http_routes_frontend.ml`
+- `lib/transport.ml`
+
+Expected output:
+
+- canonical Agent Card contract
+- local vs remote discovery rules
+- legacy compatibility boundary
+
+## Sequenced Rollout
+
+1. Checkpoint truth / replay RFC
+2. Typed handoff / proof / verifier envelope RFC
+3. Infra primitive SSOT cleanup
+4. A2A discovery consolidation
+
+Reason:
+
+- 지금 코드베이스는 runtime truth가 가장 큰 structural risk다.
+- envelope typing은 proof/verifier/handoff drift를 줄이는 두 번째 축이다.
+- infra primitive는 이미 실체가 있으므로 naming + surface consolidation 성격이 강하다.
+- A2A는 이미 동작하지만 front-door promise가 아니므로 마지막이 맞다.
+
+## Explicit Rejections
+
+- provider-native framework 전체를 `masc-mcp` core로 들여오지 않는다.
+- LangGraph를 orchestration engine으로 통째로 바꾸지 않는다.
+- CrewAI role-play abstraction을 keeper/team-session core로 채택하지 않는다.
+- Smolagents식 code-exec-first runtime을 keeper default로 만들지 않는다.
+
+## Evidence
+
+- [근거] LangGraph durable execution / persistence / time-travel:
+  https://docs.langchain.com/oss/python/langgraph/durable-execution ,
+  https://docs.langchain.com/oss/python/langgraph/persistence ,
+  https://docs.langchain.com/oss/python/langgraph/use-time-travel ;
+  확인일시 2026-04-12 ; 신뢰도 High
+- [근거] OpenAI Agents SDK / Agent Builder / trace grading / agent evals:
+  https://platform.openai.com/docs/guides/agents-sdk/ ,
+  https://platform.openai.com/docs/guides/agent-builder ,
+  https://platform.openai.com/docs/guides/trace-grading ,
+  https://platform.openai.com/docs/guides/agent-evals ;
+  확인일시 2026-04-12 ; 신뢰도 High
+- [근거] Google ADK + A2A:
+  https://google.github.io/adk-docs/ ,
+  https://google.github.io/adk-docs/a2a/intro/ ,
+  https://google.github.io/adk-docs/a2a/ ;
+  확인일시 2026-04-12 ; 신뢰도 High
+- [근거] A2A specification / Agent Card discovery surface:
+  https://a2aproject.github.io/A2A/specification/ ,
+  https://github.com/a2aproject/A2A ;
+  확인일시 2026-04-12 ; 신뢰도 High
+- [근거] Morph framework comparison article:
+  https://www.morphllm.com/ai-agent-framework ;
+  확인일시 2026-04-12 ; 신뢰도 Medium
+
+## Internal References
+
+- `README.md`
+- `docs/OAS-MASC-BOUNDARY.md`
+- `docs/PRODUCT-REVIEW.md`
+- `docs/KEEPER-CONTINUITY-VALIDATION.md`
+- `docs/SEARCH-FABRIC-V1.md`

--- a/docs/design/oas-masc-state-boundary.md
+++ b/docs/design/oas-masc-state-boundary.md
@@ -9,6 +9,7 @@ Issue: #1736
 
 ## Related
 
+- [Checkpoint Truth and Replay RFC](./checkpoint-truth-and-replay-rfc.md)
 - [Contract-Driven Agent Loop RFC](./contract-driven-agent-loop-rfc.md)
 - [Labeling and Judging Protocol](./contract-driven-agent-loop-labeling-protocol.md)
 - [Implementation Checklist](./contract-driven-agent-loop-implementation-checklist.md)

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -420,6 +420,30 @@ Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate
 Checkpoint truth / replay semantics for the first three ledger items are
 further constrained by `docs/design/checkpoint-truth-and-replay-rfc.md`.
 
+### 12.1.1 Checkpoint Truth / Replay Phases
+
+Phase ordering follows `docs/design/checkpoint-truth-and-replay-rfc.md`.
+
+| Phase | Scope | Primary modules | Expected output |
+|------|-------|-----------------|-----------------|
+| A | truth surface cleanup | `keeper_checkpoint_store`, `keeper_agent_run`, `keeper_post_turn` | native OAS checkpoint is documented and treated as runtime truth |
+| B | replay semantics + side-effect boundary | `keeper_agent_run`, `keeper_post_turn`, `keeper_exec_shell`, `tool_code_write` | typed replay target facts and mutation-boundary rules |
+| C | wrapper reduction | `keeper_exec_context`, `keeper_agent_run`, `keeper_post_turn`, `context_compact_oas` | `working_context` dependency inventory and marker-leakage backlog |
+| D | optional delta path | `keeper_checkpoint_store`, `delta-checkpoint-read-path` | delta restore remains subordinate to full checkpoint truth |
+
+### 12.1.2 Active Tasks
+
+- **A1** native OAS checkpoint truth wording and fallback ordering
+- **A2** canonical vs derived continuity read-surface labeling
+- **B1** mutation-boundary typed fact inventory
+- **B2** side-effect class mapping against current write-gate behavior
+- **C1** `working_context` dependency inventory
+- **C2** raw marker leakage inventory (`[STATE]`, `[GOAL]`, memory-summary)
+- **D1** delta restore remains optimization-only
+
+Detailed implementation checklist lives in
+`docs/design/checkpoint-truth-replay-implementation-checklist.md`.
+
 ### 12.2 Boundary Audit Snapshot
 
 | Surface | Classification | Notes |

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -31,6 +31,7 @@ MASC 전용 요구가 생기면 MASC adapter/bridge로 먼저 해결하고, OAS 
 - `/home/runner/work/masc-mcp/masc-mcp/docs/OAS-MASC-BOUNDARY.md` is the boundary contract SSOT.
 - This spec keeps the implementation map, bridge inventory, and open structural gaps.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/design/oas-masc-state-boundary.md` is a historical audit / migration backlog, not the primary boundary contract.
+- `/home/runner/work/masc-mcp/masc-mcp/docs/design/checkpoint-truth-and-replay-rfc.md` keeps checkpoint truth hierarchy, replay semantics, and side-effect boundary language.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md` is evidence, not contract.
 
 ---
@@ -415,6 +416,9 @@ Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate
 | message marker leakage | Open | `[STATE]`, `[GOAL]`, memory-summary markers still carry domain semantics in raw text |
 | memory bridge hooks/callbacks | Open | seeding/flushing remains imperative in `memory_oas_bridge.ml` |
 | team-session bridge fidelity | Open | healthcheck still calls out projection/resource-health gaps |
+
+Checkpoint truth / replay semantics for the first three ledger items are
+further constrained by `docs/design/checkpoint-truth-and-replay-rfc.md`.
 
 ### 12.2 Boundary Audit Snapshot
 

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -2,7 +2,7 @@
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
-> Last Updated: 2026-04-11
+> Last Updated: 2026-04-12
 > Snapshot baseline: `dune-project` version `0.5.9`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.
@@ -73,6 +73,7 @@ graph TB
 |----------|-------------|--------------|
 | `docs/ADR-002-DASHBOARD-OPERATOR-CONTROL-SURFACE.md` | Dashboard operator control surface and review queue UX | `10-dashboard.md` |
 | `docs/design/checkpoint-truth-and-replay-rfc.md` | Checkpoint truth hierarchy, replay semantics, side-effect boundary | `13-oas-integration.md` |
+| `docs/design/checkpoint-truth-replay-implementation-checklist.md` | Implementation checklist for checkpoint truth / replay | `13-oas-integration.md` |
 | `docs/design/keeper-continuity-product-rfc.md` | Keeper continuity contract and promise level | `05-keeper-agent.md` |
 | `docs/design/check-evaluation-spec.md` | Deterministic check evaluation for contract verification | `15-testing.md` |
 | `docs/design/contract-driven-agent-loop-rfc.md` | Contract-driven agent loop (CDAL) framework | `05-keeper-agent.md` |

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -72,6 +72,7 @@ graph TB
 | Document | Description | Related Spec |
 |----------|-------------|--------------|
 | `docs/ADR-002-DASHBOARD-OPERATOR-CONTROL-SURFACE.md` | Dashboard operator control surface and review queue UX | `10-dashboard.md` |
+| `docs/design/checkpoint-truth-and-replay-rfc.md` | Checkpoint truth hierarchy, replay semantics, side-effect boundary | `13-oas-integration.md` |
 | `docs/design/keeper-continuity-product-rfc.md` | Keeper continuity contract and promise level | `05-keeper-agent.md` |
 | `docs/design/check-evaluation-spec.md` | Deterministic check evaluation for contract verification | `15-testing.md` |
 | `docs/design/contract-driven-agent-loop-rfc.md` | Contract-driven agent loop (CDAL) framework | `05-keeper-agent.md` |


### PR DESCRIPTION
## Summary

- add an RFC comparing adoptable patterns from external agent frameworks against current MASC architecture
- define checkpoint truth hierarchy, replay semantics, and side-effect boundaries for keeper continuity
- break checkpoint truth / replay follow-up work into phased tasks and a module-level implementation checklist

## Product impact

- Promise affected: `none/internal`
- User-visible change: internal architecture and rollout docs only; no runtime behavior change in this PR

## Evidence

- `git diff --check`
- docs updated:
  - `docs/design/external-agent-framework-patterns-rfc.md`
  - `docs/design/checkpoint-truth-and-replay-rfc.md`
  - `docs/design/checkpoint-truth-replay-implementation-checklist.md`
  - `docs/spec/13-oas-integration.md`
  - `docs/spec/SPEC-INDEX.md`

## Review evidence

- Cross-model review comment added on PR: direct `sb glm-text` using `GLM-5.1`, result `No findings.`

## Linked issue

- Closes #
- Relates #1797
