### PR TITLE
test(keeper_unified): restore code-level default 65536 in unified runtime defaults (#6700)

### DIFF
--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -989,7 +989,13 @@ let test_unified_turn_runtime_defaults () =
   with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
     check (float 0.01) "unified temp default" 0.4
       (KC.keeper_unified_temperature ());
-    check int "unified max_tokens default" 16384
+    (* #6700: the code-level default in keeper_config.ml is 65536.
+       cascade.json overrides it to 16384 at load time, but this test
+       runs with an empty MASC_KEEPER_UNIFIED_MAX_TOKENS env var
+       before cascade loading, so the code default is what surfaces.
+       PR #6693 updated this assertion to 16384 but that's the
+       cascade-loaded value, not the code default. *)
+    check int "unified max_tokens default" 65536
       (KC.keeper_unified_max_tokens ())
     (* max_turns is set in keeper_agent_run.ml (default: 50) *)))
 


### PR DESCRIPTION
Closes #6700. Test-only fix. PR #6693 updated the assertion from 65536 to 16384 (cascade.json override), but the test runs with empty env var before cascade loading, so the code default (65536) is what surfaces. See commit message for full reasoning.