### PR TITLE
fix(playground): normalize keeper-X-agent to X in path SSOT

### DIFF
--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -16,21 +16,52 @@
     server's [base_path]. *)
 let all_playgrounds_prefix : string = ".masc/playground"
 
-(** Sanitize a keeper name into a filesystem-safe component. Allows
+(** Strip the [keeper-...-agent] canonical wrapper when present,
+    returning the inner short name.  E.g.
+    ["keeper-masc-improver-agent"] -> ["masc-improver"].
+
+    The MCP session resolver generates canonical names via
+    [keeper_agent_name] in [keeper_types_profile.ml], but playground
+    directories on disk use the short form ([meta.name]).  Without
+    stripping, path lookups produce
+    [.masc/playground/keeper-X-agent/repos/] which does not exist;
+    the actual directory is [.masc/playground/X/repos/].
+
+    A name that does not match the wrapper pattern is returned
+    unchanged.  The function is idempotent:
+    [strip (strip x) = strip x].
+
+    The length guard [nlen > plen + slen] (i.e., > 13) ensures we
+    never produce an empty string from stripping — ["keeper-agent"]
+    (12 chars) passes through unchanged because its inner part would
+    be empty. *)
+let strip_keeper_agent_wrapper (name : string) : string =
+  let prefix = "keeper-" and suffix = "-agent" in
+  let plen = String.length prefix and slen = String.length suffix in
+  let nlen = String.length name in
+  if nlen > plen + slen
+     && String.starts_with ~prefix name
+     && String.ends_with ~suffix name
+  then String.sub name plen (nlen - plen - slen)
+  else name
+
+(** Sanitize a keeper name into a filesystem-safe component.
+
+    First strips the [keeper-...-agent] canonical wrapper (see
+    {!strip_keeper_agent_wrapper}) so that both ["keeper-X-agent"]
+    and ["X"] resolve to the same directory.  Then allows
     [A-Za-z0-9._-] and replaces everything else with [_]. An empty
     input or the special path components [.] / [..] are replaced with
     [_], so [sanitize_keeper_name ".."] returns ["__"] rather than
     returning a traversal segment as a directory name. *)
 let sanitize_keeper_name (name : string) : string =
+  let name = strip_keeper_agent_wrapper name in
   let mapped =
     String.map (fun c ->
       if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
          || (c >= '0' && c <= '9') || c = '-' || c = '_' || c = '.'
       then c else '_') name
   in
-  (* Reject empty, "." and ".." explicitly — these are filesystem
-     special directory references, not real keeper names, and would
-     let a poisoned [meta.name] escape the playground bundle. *)
   match mapped with
   | "" -> "_"
   | "." -> "_"

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -29,12 +29,20 @@ let handle_worktree_create ctx args =
     if from_args = "" then Ok ctx.agent_name
     else if from_args = ctx.agent_name then Ok ctx.agent_name
     else
-      Error (Printf.sprintf
-        "agent_name mismatch: arg=%S but context agent is %S. \
-         Cross-agent worktree creation is blocked — omit agent_name \
-         (or pass your own) so the worktree lands in your own \
-         playground."
-        from_args ctx.agent_name)
+      (* Normalize both forms via Playground_paths so "masc-improver"
+         and "keeper-masc-improver-agent" compare equal — they are the
+         same keeper, just different name forms (short vs canonical).
+         The security invariant is preserved: different keepers still
+         have different normalized names. *)
+      let normalize = Playground_paths.sanitize_keeper_name in
+      if normalize from_args = normalize ctx.agent_name then Ok ctx.agent_name
+      else
+        Error (Printf.sprintf
+          "agent_name mismatch: arg=%S but context agent is %S. \
+           Cross-agent worktree creation is blocked — omit agent_name \
+           (or pass your own) so the worktree lands in your own \
+           playground."
+          from_args ctx.agent_name)
   in
   match agent_name_result with
   | Error msg -> (false, msg)

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -88,6 +88,59 @@ let test_no_path_escape () =
     ".masc/playground/_/"
     (PP.bundle_root "")
 
+(* Canonical/short name normalization — keeper-X-agent strips to X *)
+
+let test_strip_canonical_to_short () =
+  check string "canonical stripped to short"
+    "masc-improver"
+    (PP.sanitize_keeper_name "keeper-masc-improver-agent");
+  check string "short stays short"
+    "masc-improver"
+    (PP.sanitize_keeper_name "masc-improver");
+  check string "cheolsu canonical"
+    "cheolsu"
+    (PP.sanitize_keeper_name "keeper-cheolsu-agent");
+  check string "sangsu canonical"
+    "sangsu"
+    (PP.sanitize_keeper_name "keeper-sangsu-agent")
+
+let test_canonical_short_path_identity () =
+  check string "repos path identity"
+    (PP.repos_path "masc-improver")
+    (PP.repos_path "keeper-masc-improver-agent");
+  check string "bundle_root identity"
+    (PP.bundle_root "cheolsu")
+    (PP.bundle_root "keeper-cheolsu-agent");
+  check string "mind_path identity"
+    (PP.mind_path "sangsu")
+    (PP.mind_path "keeper-sangsu-agent")
+
+let test_strip_edge_cases () =
+  check string "keeper-agent not stripped (inner would be empty)"
+    "keeper-agent"
+    (PP.sanitize_keeper_name "keeper-agent");
+  check string "single-char inner name"
+    "x"
+    (PP.sanitize_keeper_name "keeper-x-agent");
+  check string "idempotent"
+    (PP.sanitize_keeper_name "masc-improver")
+    (PP.sanitize_keeper_name
+       (PP.sanitize_keeper_name "keeper-masc-improver-agent"));
+  check string "different keepers stay different"
+    "sangsu"
+    (PP.sanitize_keeper_name "keeper-sangsu-agent");
+  check bool "sangsu != cheolsu after normalize"
+    true
+    (PP.sanitize_keeper_name "keeper-sangsu-agent"
+     <> PP.sanitize_keeper_name "keeper-cheolsu-agent")
+
+let test_strip_no_traversal () =
+  let result = PP.sanitize_keeper_name "keeper-../../etc-agent" in
+  check bool "no slash in result" true
+    (not (String.contains result '/'));
+  check bool "no backslash in result" true
+    (not (String.contains result '\\'))
+
 let () =
   run "Playground_paths"
     [
@@ -105,5 +158,11 @@ let () =
       ]);
       ("security", [
         test_case "no path escape" `Quick test_no_path_escape;
+      ]);
+      ("canonical_normalize", [
+        test_case "canonical stripped to short" `Quick test_strip_canonical_to_short;
+        test_case "both forms produce identical paths" `Quick test_canonical_short_path_identity;
+        test_case "edge cases" `Quick test_strip_edge_cases;
+        test_case "strip does not create traversal" `Quick test_strip_no_traversal;
       ]);
     ]


### PR DESCRIPTION
## Root cause

Playground directories are created with keeper short name (\`meta.name = \"masc-improver\"\`) but runtime resolves \`ctx.agent_name\` to canonical MCP form (\`\"keeper-masc-improver-agent\"\`). \`Playground_paths.sanitize_keeper_name\` did character-level sanitization only, so canonical names passed through unchanged — producing paths to directories that do not exist.

\`\`\`
Expected: .masc/playground/keeper-masc-improver-agent/repos/  (NOT FOUND)
Actual:   .masc/playground/masc-improver/repos/masc-mcp       (EXISTS)
\`\`\`

This caused 3 cascading failures in keeper playground operations:
- **Layer 8**: \`tool_worktree.ml\` agent_name strict equality — LLM sends short form, ctx has canonical
- **Layer 9**: \`room_worktree.ml\` repos_path(canonical) — directory not found
- **Layer 11**: \`worker_dev_tools.ml\` validate_path workdir — wrong playground path

## Fix

\`strip_keeper_agent_wrapper\` in \`playground_paths.ml\` strips \`keeper-\` prefix and \`-agent\` suffix when both present. Applied inside \`sanitize_keeper_name\` (the SSOT for all path derivation) so every downstream function automatically normalizes.

Also normalize the agent_name comparison in \`tool_worktree.ml\` so both name forms compare equal.

## Properties
- Idempotent: \`strip("masc-improver") = "masc-improver"\`
- No traversal: stripped result passes through char sanitization
- Backward compatible: short form input unchanged
- Security preserved: different keepers still mismatch after normalize

## Test plan
- [x] \`test_playground_paths.exe\`: 11/11 pass (4 new canonical_normalize tests)
- [ ] Runtime: keeper passes \`masc_worktree_create\` with short name without \`agent_name mismatch\` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)