### PR TITLE
fix(session): add mutex to McpSessionStore (closes #6629)

### DIFF
--- a/lib/session.ml
+++ b/lib/session.ml
@@ -453,6 +453,20 @@ module McpSessionStore = struct
   let sessions : (string, mcp_session) Hashtbl.t = Hashtbl.create 64
   let max_age = ref Env_config.Session.max_age_seconds
 
+  (** Mutex protecting all reads and writes to [sessions].
+
+      The background [start_mcp_session_cleanup_loop] fiber runs
+      [cleanup_stale] concurrently with HTTP handler fibers that call
+      [create]/[get]/[remove].  Without the mutex, [Hashtbl.fold] inside
+      [cleanup_stale] can race with [Hashtbl.add] in [create] (rehash
+      under iterator) or with [get]'s mutable field writes on a shared
+      record.  Under single-domain Eio none of the Hashtbl operations
+      yield, so the race is theoretical today; the mutex closes the
+      contract gap documented in issue #6629 and matches the discipline
+      already established by the sibling [registry.lock] in this file. *)
+  let mu = Eio.Mutex.create ()
+  let with_lock f = Eio_guard.with_mutex mu f
+
   (** Generate MCP session ID *)
   let generate_id () : string =
     let bytes = Mirage_crypto_rng.generate 16 in
@@ -464,37 +478,42 @@ module McpSessionStore = struct
 
   (** Create new MCP session *)
   let create ?agent_name () : mcp_session =
-    let now = Time_compat.now () in
-    let session = {
-      id = generate_id ();
-      created_at = now;
-      last_activity = now;
-      agent_name;
-      metadata = [];
-      request_count = 0;
-    } in
-    Hashtbl.add sessions session.id session;
-    session
+    with_lock (fun () ->
+      let now = Time_compat.now () in
+      let session = {
+        id = generate_id ();
+        created_at = now;
+        last_activity = now;
+        agent_name;
+        metadata = [];
+        request_count = 0;
+      } in
+      Hashtbl.add sessions session.id session;
+      session)
 
-  (** Get MCP session by ID *)
+  (** Get MCP session by ID, updating last_activity and request_count. *)
   let get (session_id : string) : mcp_session option =
-    match Hashtbl.find_opt sessions session_id with
-    | None -> None
-    | Some session ->
-      session.last_activity <- Time_compat.now ();
-      session.request_count <- session.request_count + 1;
-      Some session
+    with_lock (fun () ->
+      match Hashtbl.find_opt sessions session_id with
+      | None -> None
+      | Some session ->
+        session.last_activity <- Time_compat.now ();
+        session.request_count <- session.request_count + 1;
+        Some session)
 
   (** Cleanup stale MCP sessions *)
   let cleanup_stale () : int =
-    let now = Time_compat.now () in
-    let stale = Hashtbl.fold (fun id session acc ->
-      if now -. session.last_activity > !max_age then id :: acc else acc
-    ) sessions [] in
-    List.iter (Hashtbl.remove sessions) stale;
-    List.length stale
+    with_lock (fun () ->
+      let now = Time_compat.now () in
+      let stale = Hashtbl.fold (fun id session acc ->
+        if now -. session.last_activity > !max_age then id :: acc else acc
+      ) sessions [] in
+      List.iter (Hashtbl.remove sessions) stale;
+      List.length stale)
 
-  (** Convert MCP session to JSON *)
+  (** Convert MCP session to JSON.
+      Reads immutable fields of the record — no lock needed because
+      the caller owns the value returned by [get]. *)
   let to_json (s : mcp_session) : Yojson.Safe.t =
     `Assoc [
       ("id", `String s.id);
@@ -507,14 +526,16 @@ module McpSessionStore = struct
 
   (** List all MCP sessions *)
   let list_all () : mcp_session list =
-    Hashtbl.fold (fun _ s acc -> s :: acc) sessions []
+    with_lock (fun () ->
+      Hashtbl.fold (fun _ s acc -> s :: acc) sessions [])
 
   (** Remove session *)
   let remove (id : string) : bool =
-    if Hashtbl.mem sessions id then begin
-      Hashtbl.remove sessions id;
-      true
-    end else false
+    with_lock (fun () ->
+      if Hashtbl.mem sessions id then begin
+        Hashtbl.remove sessions id;
+        true
+      end else false)
 end
 
 (** Start a background fiber that periodically cleans up stale MCP sessions.


### PR DESCRIPTION
## Summary

Adds \`Eio.Mutex.t\` to \`McpSessionStore\`, wrapping all \`Hashtbl\` operations in \`Eio_guard.with_mutex\`. Closes #6629.

## Problem

Background cleanup loop (\`start_mcp_session_cleanup_loop\`) runs \`Hashtbl.fold\` + \`Hashtbl.remove\` concurrently with HTTP handler fibers calling \`create\`/\`get\`/\`remove\`. Three documented race classes:

1. **Rehash under iterator**: \`Hashtbl.fold\` (cleanup) + \`Hashtbl.add\` (create) → UB under OCaml 5 memory model
2. **Torn mutable writes**: \`get\` mutates \`last_activity\`/\`request_count\` without sync
3. **TOCTOU in remove**: \`Hashtbl.mem\` then \`Hashtbl.remove\` — two removers both return \`true\`

Theoretical under single-domain Eio today (no yields in Hashtbl ops), but the sibling \`registry\` type in the same file already uses a lock — this was an undocumented contract gap.

## Fix

- \`let mu = Eio.Mutex.create ()\` + \`let with_lock f = Eio_guard.with_mutex mu f\`
- \`create\`, \`get\`, \`cleanup_stale\`, \`list_all\`, \`remove\` wrapped
- \`to_json\` left unlocked (reads immutable fields of caller-owned value)
- No caller changes needed

## Test plan

- [x] \`dune build --root . @lib/check\` — exit 0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>