### PR TITLE
Fix keeper post-turn registry base path

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -126,6 +126,53 @@ let apply_post_turn_lifecycle = Keeper_post_turn.apply_post_turn_lifecycle
 let recover_latest_checkpoint_for_overflow_retry =
   Keeper_post_turn.recover_latest_checkpoint_for_overflow_retry
 
+let dispatch_keeper_phase_event ~(config : Room.config) ~keeper_name event =
+  ignore
+    (Keeper_registry.dispatch_event
+       ~base_path:config.base_path
+       keeper_name
+       event)
+
+let dispatch_post_turn_lifecycle_events
+    ~(config : Room.config)
+    ~keeper_name
+    (lifecycle : post_turn_lifecycle) =
+  if lifecycle.compaction.attempted then
+    if lifecycle.compaction.applied then
+      dispatch_keeper_phase_event ~config ~keeper_name
+        (Keeper_state_machine.Compaction_completed
+           {
+             before_tokens = lifecycle.compaction.before_tokens;
+             after_tokens = lifecycle.compaction.after_tokens;
+           })
+    else
+      dispatch_keeper_phase_event ~config ~keeper_name
+        (Keeper_state_machine.Compaction_failed
+           {
+             reason =
+               Option.value lifecycle.compaction.failure_reason
+                 ~default:lifecycle.compaction.decision;
+           });
+  match lifecycle.handoff_attempted, lifecycle.handoff_json with
+  | true, Some _json ->
+      dispatch_keeper_phase_event ~config ~keeper_name
+        (Keeper_state_machine.Handoff_completed
+           {
+             generation = lifecycle.updated_meta.runtime.generation;
+             new_trace_id =
+               Keeper_id.Trace_id.to_string
+                 lifecycle.updated_meta.runtime.trace_id;
+           })
+  | true, None ->
+      dispatch_keeper_phase_event ~config ~keeper_name
+        (Keeper_state_machine.Handoff_failed
+           {
+             reason =
+               Option.value lifecycle.handoff_failure_reason
+                 ~default:"handoff_aborted";
+           })
+  | false, _ -> ()
+
 (* ================================================================ *)
 (* Remaining functions (not extracted — small utilities)              *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -173,6 +173,18 @@ val apply_post_turn_lifecycle :
   checkpoint:Agent_sdk.Checkpoint.t option ->
   post_turn_lifecycle
 
+val dispatch_keeper_phase_event :
+  config:Room.config ->
+  keeper_name:string ->
+  Keeper_state_machine.event ->
+  unit
+
+val dispatch_post_turn_lifecycle_events :
+  config:Room.config ->
+  keeper_name:string ->
+  post_turn_lifecycle ->
+  unit
+
 val recover_latest_checkpoint_for_overflow_retry :
   base_dir:string ->
   meta:keeper_meta ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -336,51 +336,24 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               let lifecycle =
                 Keeper_exec_context.apply_post_turn_lifecycle ~base_dir
                   ~on_compaction_started:(fun () ->
-                    ignore (Keeper_registry.dispatch_event
-                      ~base_path:base_dir meta.name
-                      Keeper_state_machine.Compaction_started))
+                    Keeper_exec_context.dispatch_keeper_phase_event
+                      ~config:ctx.config
+                      ~keeper_name:meta.name
+                      Keeper_state_machine.Compaction_started)
                   ~on_handoff_started:(fun () ->
-                    ignore (Keeper_registry.dispatch_event
-                      ~base_path:base_dir meta.name
-                      Keeper_state_machine.Handoff_started))
+                    Keeper_exec_context.dispatch_keeper_phase_event
+                      ~config:ctx.config
+                      ~keeper_name:meta.name
+                      Keeper_state_machine.Handoff_started)
                   ~meta
                   ~model:result.model_used
                   ~primary_model_max_tokens:max_cascade_context
                   ~checkpoint:result.checkpoint
               in
-              if lifecycle.compaction.attempted then
-                if lifecycle.compaction.applied then
-                  ignore (Keeper_registry.dispatch_event
-                    ~base_path:base_dir meta.name
-                    (Keeper_state_machine.Compaction_completed {
-                      before_tokens = lifecycle.compaction.before_tokens;
-                      after_tokens = lifecycle.compaction.after_tokens;
-                    }))
-                else
-                  ignore (Keeper_registry.dispatch_event
-                    ~base_path:base_dir meta.name
-                    (Keeper_state_machine.Compaction_failed {
-                      reason =
-                        Option.value lifecycle.compaction.failure_reason
-                          ~default:lifecycle.compaction.decision;
-                    }));
-              (match lifecycle.handoff_attempted, lifecycle.handoff_json with
-               | true, Some _json ->
-                   ignore (Keeper_registry.dispatch_event
-                     ~base_path:base_dir meta.name
-                     (Keeper_state_machine.Handoff_completed {
-                       generation = lifecycle.updated_meta.runtime.generation;
-                       new_trace_id = Keeper_id.Trace_id.to_string lifecycle.updated_meta.runtime.trace_id;
-                     }))
-               | true, None ->
-                   ignore (Keeper_registry.dispatch_event
-                     ~base_path:base_dir meta.name
-                     (Keeper_state_machine.Handoff_failed {
-                       reason =
-                         Option.value lifecycle.handoff_failure_reason
-                           ~default:"handoff_aborted";
-                     }))
-               | false, _ -> ());
+              Keeper_exec_context.dispatch_post_turn_lifecycle_events
+                ~config:ctx.config
+                ~keeper_name:meta.name
+                lifecycle;
               let updated_meta =
                 update_direct_turn_meta lifecycle.updated_meta ~latency_ms result
               in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1565,51 +1565,24 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           let lifecycle =
             apply_post_turn_lifecycle ~base_dir
               ~on_compaction_started:(fun () ->
-                ignore (Keeper_registry.dispatch_event
-                  ~base_path:base_dir meta.name
-                  Keeper_state_machine.Compaction_started))
+                dispatch_keeper_phase_event
+                  ~config
+                  ~keeper_name:meta.name
+                  Keeper_state_machine.Compaction_started)
               ~on_handoff_started:(fun () ->
-                ignore (Keeper_registry.dispatch_event
-                  ~base_path:base_dir meta.name
-                  Keeper_state_machine.Handoff_started))
+                dispatch_keeper_phase_event
+                  ~config
+                  ~keeper_name:meta.name
+                  Keeper_state_machine.Handoff_started)
               ~meta
               ~model:result.model_used
               ~primary_model_max_tokens:max_cascade_context
               ~checkpoint:result.checkpoint
           in
-          if lifecycle.compaction.attempted then
-            if lifecycle.compaction.applied then
-              ignore (Keeper_registry.dispatch_event
-                ~base_path:base_dir meta.name
-                (Keeper_state_machine.Compaction_completed {
-                  before_tokens = lifecycle.compaction.before_tokens;
-                  after_tokens = lifecycle.compaction.after_tokens;
-                }))
-            else
-              ignore (Keeper_registry.dispatch_event
-                ~base_path:base_dir meta.name
-                (Keeper_state_machine.Compaction_failed {
-                  reason =
-                    Option.value lifecycle.compaction.failure_reason
-                      ~default:lifecycle.compaction.decision;
-                }));
-          (match lifecycle.handoff_attempted, lifecycle.handoff_json with
-           | true, Some _json ->
-               ignore (Keeper_registry.dispatch_event
-                 ~base_path:base_dir meta.name
-                 (Keeper_state_machine.Handoff_completed {
-                   generation = lifecycle.updated_meta.runtime.generation;
-                   new_trace_id = Keeper_id.Trace_id.to_string lifecycle.updated_meta.runtime.trace_id;
-                 }))
-           | true, None ->
-               ignore (Keeper_registry.dispatch_event
-                 ~base_path:base_dir meta.name
-                 (Keeper_state_machine.Handoff_failed {
-                   reason =
-                     Option.value lifecycle.handoff_failure_reason
-                       ~default:"handoff_aborted";
-                 }))
-           | false, _ -> ());
+          dispatch_post_turn_lifecycle_events
+            ~config
+            ~keeper_name:meta.name
+            lifecycle;
           let scope_only_reactive =
             observation.pending_scope_messages <> []
             && observation.pending_mentions = []

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -3,6 +3,8 @@ open Alcotest
 module KEC = Masc_mcp.Keeper_exec_context
 module KCC = Masc_mcp.Keeper_context_core
 module KT = Masc_mcp.Keeper_types
+module KR = Masc_mcp.Keeper_registry
+module KST = Masc_mcp.Keeper_state_machine
 
 let temp_dir prefix =
   let dir = Filename.temp_file prefix "" in
@@ -20,6 +22,31 @@ let cleanup_dir dir =
         Unix.unlink path
   in
   try rm dir with _ -> ()
+
+let base_lifecycle ~(meta : KT.keeper_meta) : KEC.post_turn_lifecycle =
+  {
+    updated_meta = meta;
+    checkpoint = None;
+    handoff_json = None;
+    handoff_attempted = false;
+    handoff_failure_reason = None;
+    compaction =
+      {
+        attempted = false;
+        applied = false;
+        failure_reason = None;
+        trigger = None;
+        decision = "skipped:test";
+        before_tokens = 0;
+        after_tokens = 0;
+        saved_tokens = 0;
+      };
+    turn_generation = meta.runtime.generation;
+    context_ratio = 0.0;
+    context_tokens = 0;
+    context_max = 0;
+    message_count = 0;
+  }
 
 let contains_substring haystack needle =
   let hay_len = String.length haystack in
@@ -682,6 +709,68 @@ let test_compact_if_needed_emergency_bypass_ignores_cooldown () =
   check bool "compaction was triggered (emergency bypass)" true (Option.is_some trigger);
   check bool "decision starts with applied:" true (String.starts_with ~prefix:"applied:" decision)
 
+let test_dispatch_keeper_phase_event_uses_room_base_path () =
+  let base_dir = temp_dir "keeper_lifecycle_registry_phase" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      KR.clear ();
+      let config = Masc_mcp.Room.default_config base_dir in
+      let meta = make_keeper_meta ~name:"keeper-phase-regression" () in
+      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      KEC.dispatch_keeper_phase_event
+        ~config
+        ~keeper_name:meta.name
+        KST.Compaction_started;
+      match KR.get ~base_path:config.base_path meta.name with
+      | Some entry ->
+          check string "compaction start reaches registry" "compacting"
+            (KST.phase_to_string entry.phase)
+      | None -> fail "expected registered keeper after compaction dispatch")
+
+let test_dispatch_post_turn_lifecycle_events_uses_room_base_path () =
+  let base_dir = temp_dir "keeper_lifecycle_registry_outcome" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      KR.clear ();
+      let config = Masc_mcp.Room.default_config base_dir in
+      let meta = make_keeper_meta ~name:"keeper-outcome-regression" () in
+      ignore (KR.register ~base_path:config.base_path meta.name meta);
+      KEC.dispatch_keeper_phase_event
+        ~config
+        ~keeper_name:meta.name
+        KST.Compaction_started;
+      let lifecycle =
+        {
+          (base_lifecycle ~meta) with
+          compaction =
+            {
+              attempted = true;
+              applied = true;
+              failure_reason = None;
+              trigger = Some "test";
+              decision = "applied:test";
+              before_tokens = 42;
+              after_tokens = 21;
+              saved_tokens = 21;
+            };
+        }
+      in
+      KEC.dispatch_post_turn_lifecycle_events
+        ~config
+        ~keeper_name:meta.name
+        lifecycle;
+      match KR.get ~base_path:config.base_path meta.name with
+      | Some entry ->
+          check string "compaction completion reaches registry" "running"
+            (KST.phase_to_string entry.phase)
+      | None -> fail "expected registered keeper after lifecycle dispatch")
+
 let () =
   run "keeper_lifecycle"
     [
@@ -725,5 +814,12 @@ let () =
             test_compact_if_needed_ts_zero_bypasses_cooldown;
           test_case "emergency ratio bypasses cooldown gate" `Quick
             test_compact_if_needed_emergency_bypass_ignores_cooldown;
+        ] );
+      ( "registry_dispatch",
+        [
+          test_case "phase event uses room base_path" `Quick
+            test_dispatch_keeper_phase_event_uses_room_base_path;
+          test_case "post-turn lifecycle events use room base_path" `Quick
+            test_dispatch_post_turn_lifecycle_events_uses_room_base_path;
         ] );
     ]

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -768,7 +768,7 @@ let assert_branch_switch_blocked config cmd label =
   let args =
     `Assoc
       [ "cmd", `String cmd
-      ; "cwd", `String shared_repo_rel
+      ; "cwd", `String shared_repo_abs
       ]
   in
   let result = call_tool config meta "keeper_bash" args in
@@ -928,7 +928,7 @@ let test_fs_read_blocks_shared_repo_by_default () =
     write_text_file shared_file "let approval = true\n";
     let result =
       call_tool config meta "keeper_fs_read"
-        (`Assoc [ "path", `String "workspace/yousleepwhen/oas/lib/approval.ml" ])
+        (`Assoc [ "path", `String shared_file ])
     in
     let json = parse_json result in
     check bool "returns error payload" true
@@ -949,7 +949,7 @@ let test_fs_read_allows_explicit_custom_path () =
     write_text_file shared_file "let approval = true\n";
     let result =
       call_tool config meta "keeper_fs_read"
-        (`Assoc [ "path", `String "workspace/yousleepwhen/oas/lib/approval.ml" ])
+        (`Assoc [ "path", `String shared_file ])
     in
     let json = parse_json result in
     check bool "explicit custom path read ok" true (json_bool "ok" json);

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -990,7 +990,7 @@ let test_unified_turn_runtime_defaults () =
     (* This unit test does not run Runtime_params.restore, so an empty env var
        falls back to the code-level default rather than config/cascade.json. *)
     check int "unified max_tokens default" 65536
-      (KC.keeper_unified_max_tokens ())
+    (KC.keeper_unified_max_tokens ())
     (* max_turns is set in keeper_agent_run.ml (default: 50) *)))
 
 let test_meta_defaults_social_model () =


### PR DESCRIPTION
## Summary
- route post-turn keeper registry lifecycle dispatch through shared helpers that always use `Room.config.base_path`
- update both legacy `keeper_turn` and unified `keeper_unified_turn` post-turn paths to use the shared dispatch helpers
- add lifecycle regression coverage and align stale keeper prompt/path test expectations with current runtime invariants so CI reflects actual behavior

## Product impact
- fixes keeper post-turn lifecycle bookkeeping so compaction and handoff phase transitions are recorded against the actual room registry entry
- prevents silent registry misses caused by dispatching `Compaction_*` / `Handoff_*` events with `session_base_dir` instead of the keeper room base path
- keeps CI signal clean by updating stale test expectations that had drifted from current prompt text and path-resolution defaults

## Evidence
- `opam exec -- dune exec --root . ./test/test_keeper_lifecycle.exe`
- `opam exec -- dune exec --root . ./test/test_keeper_pr_workflow.exe`
- `opam exec -- dune exec --root . ./test/test_keeper_unified.exe`
- GitHub Actions run `24311767954` passed required checks: `Build and Test`, `Dashboard`, `Health`, `Lint`, `PR Hygiene`, `PR Sync Check`, `Release Train`, `TLA+ Model Checking`

## Review evidence
- Cross-model review: direct ZAI `sb glm-text`
- Timestamp: 2026-04-13 02:01 KST
- Scope: rebased head `e8667d32c`
- Result: `No findings.`

## Linked issue
- Refs #6592

## Notes
- current head: `e8667d32c`
- PR review thread sweep found no unresolved review threads or review submissions at the time of update
