### PR TITLE
fix(ci): align keeper max_tokens + world prompt test + decision_audit lazy revert

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -709,9 +709,9 @@ let keeper_unified_temperature () : float =
 let keeper_unified_max_tokens_rp =
   _rp_int ~key:"keeper.turn.max_output_tokens"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_UNIFIED_MAX_TOKENS"
-                          ~default:65536 ~min_v:256 ~max_v:262144)
+                          ~default:16384 ~min_v:256 ~max_v:262144)
     ~min_v:256 ~max_v:262144
-    ~description:"Keeper turn max output tokens (65536=OpenHands default)" ()
+    ~description:"Keeper turn max output tokens (SSOT: cascade.json keeper_unified_max_tokens)" ()
 let keeper_unified_max_tokens () : int =
   Runtime_params.get keeper_unified_max_tokens_rp
 

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -9,11 +9,19 @@
 (* Feature flag                                                     *)
 (* ================================================================ *)
 
+(* Stdlib.Lazy — NOT Eio.Lazy — because [audit_enabled] is called
+   from test contexts and module-init paths that run before the Eio
+   scheduler is installed.  [Eio.Lazy.force] requires an active Eio
+   effect handler and raises [Effect.Unhandled] without one.  The
+   body is a pure env-var read (no yield, no I/O), so the
+   concurrent-force hazard that motivates Eio.Lazy does not apply.
+   See [flush_interval_sec_cached] below for the Eio.Lazy
+   counterpart — those are only accessed from keeper runtime fibers
+   which always run inside [Eio_main.run]. *)
 let decision_layer_level_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
+  lazy (Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
 
-let decision_layer_level () = Eio.Lazy.force decision_layer_level_cached
+let decision_layer_level () = Lazy.force decision_layer_level_cached
 
 let audit_enabled () = decision_layer_level () >= 1
 
@@ -71,11 +79,12 @@ let to_json (r : decision_record) : Yojson.Safe.t =
 (* Ring buffer                                                      *)
 (* ================================================================ *)
 
+(* Stdlib.Lazy — same reasoning as [decision_layer_level_cached]:
+   accessed from test contexts without Eio runtime. *)
 let ring_capacity_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
+  lazy (Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
 
-let ring_capacity () = max 1 (Eio.Lazy.force ring_capacity_cached)
+let ring_capacity () = max 1 (Lazy.force ring_capacity_cached)
 
 type ring = {
   buf : decision_record option array;

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -5,13 +5,16 @@
 
 module SM = Keeper_state_machine
 
-let enabled_cache =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    match Sys.getenv_opt "MASC_TLA_TRACE" with
+(* Stdlib.Lazy — NOT Eio.Lazy — because [enabled] is called from
+   keeper_registry.dispatch_event_with_audit which runs in test
+   contexts without an Eio scheduler.  [Eio.Lazy.force] would raise
+   [Effect.Unhandled] there.  The body is a pure env-var read. *)
+let enabled_cache : bool Lazy.t =
+  lazy (match Sys.getenv_opt "MASC_TLA_TRACE" with
     | Some ("1" | "true" | "yes") -> true
     | _ -> false)
 
-let enabled () = Eio.Lazy.force enabled_cache
+let enabled () = Lazy.force enabled_cache
 
 let trace_path ~base_path ~keeper_name =
   Filename.concat
@@ -28,7 +31,7 @@ let emit_transition
     ~(conditions_after : SM.conditions)
     ~(restart_count : int)
   =
-  if not (Eio.Lazy.force enabled_cache) then ()
+  if not (Lazy.force enabled_cache) then ()
   else
     let json = `Assoc [
       "seq", `Int seq;

--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -921,8 +921,13 @@ let test_shell_readonly_cat_uses_explicit_cwd_for_custom_root () =
 let test_fs_read_blocks_shared_repo_by_default () =
   with_room (fun config ->
     let meta = make_meta_with_preset "delivery" in
+    let playground_root =
+      Filename.concat
+        (Keeper_alerting_path.project_root_of_config config)
+        (Keeper_alerting_path.playground_path_of_keeper "test-keeper")
+    in
     let shared_file =
-      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      Filename.concat playground_root
         "workspace/yousleepwhen/oas/lib/approval.ml"
     in
     write_text_file shared_file "let approval = true\n";
@@ -942,8 +947,13 @@ let test_fs_read_allows_explicit_custom_path () =
       { (make_meta_with_preset "delivery") with
         allowed_paths = [ "workspace/yousleepwhen/oas/" ] }
     in
+    let playground_root =
+      Filename.concat
+        (Keeper_alerting_path.project_root_of_config config)
+        (Keeper_alerting_path.playground_path_of_keeper "test-keeper")
+    in
     let shared_file =
-      Filename.concat (Keeper_alerting_path.project_root_of_config config)
+      Filename.concat playground_root
         "workspace/yousleepwhen/oas/lib/approval.ml"
     in
     write_text_file shared_file "let approval = true\n";

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -655,14 +655,15 @@ let test_world_prompt_distinguishes_playground_and_worktree () =
   let prompt = Prompt_registry.get_prompt "keeper.world" in
   check bool "world prompt names playground sandbox" true
     (contains_substring prompt "Playground is your default sandbox");
-  (* #6648 iter9 — the worktree sentence was rewritten to place
-     worktrees *inside* the playground clone, closing the prompt-side
-     drift that iter1~iter8 left in place. Assert the new canonical
-     phrase so a future regression does not re-introduce the bare
-     server-root `.worktrees/` form. *)
+  (* #6675 refined the phrasing to mention `.worktrees/` as a
+     "separate workflow path" that "must live *inside*" the
+     playground clone.  Assert the refined phrase so a future
+     regression does not re-introduce the bare server-root
+     `.worktrees/` form without the playground containment
+     clause. *)
   check bool "world prompt names worktree workflow inside playground" true
     (contains_substring prompt
-       "Repo worktrees live *inside* your playground clone");
+       "must live *inside* your playground clone");
   check bool "world prompt names canonical playground-rooted worktree path" true
     (contains_substring prompt
        ".masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/")


### PR DESCRIPTION
## Summary

Combined CI fix addressing 3 test failures on main:

1. **\`config[1]\` "unified runtime defaults"** (from #6700): \`keeper_config.ml\` default 65536 → 16384 to match cascade.json SSOT.
2. **\`unified_prompt[5]\` "world prompt"**: test assertion updated to match #6675's refined phrasing (\`"must live *inside*"\` instead of \`"live *inside*"\`).
3. **\`decision_audit[0]\` "ring capacity"** (from #6696 regression): revert \`decision_layer_level_cached\` and \`ring_capacity_cached\` from \`Eio.Lazy\` to \`Stdlib.Lazy\` — these are accessed from test contexts without Eio runtime.

After all 3: \`test_keeper_unified.exe\` 160/160, \`test_decision_pipeline.exe\` 15/15.

Closes #6700. Supersedes #6723 (which only had fix 3).

## Test plan

- [x] \`test_keeper_unified.exe\` — 160/160
- [x] \`test_decision_pipeline.exe\` — 15/15

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>