### PR TITLE
refactor: remove classify_model_family from coordination layer

### DIFF
--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -27,7 +27,6 @@ type pre_compact_event = {
   message_count : int;
   token_count : int;
   strategies : string list;
-  model_family : string;  (** Derived label for backward compat (SSE/dashboard) *)
   context_window : int;
   is_local_model : bool;
   trigger : string;
@@ -154,7 +153,6 @@ let pre_compact_record_json (event : pre_compact_event) =
       ("message_count", `Int event.message_count);
       ("token_count", `Int event.token_count);
       ("strategies", `List (List.map (fun value -> `String value) event.strategies));
-      ("model_family", `String event.model_family);
       ("context_window", `Int event.context_window);
       ("is_local_model", `Bool event.is_local_model);
       ("trigger", `String event.trigger);
@@ -169,7 +167,6 @@ let pre_compact_event_json (event : pre_compact_event) =
       ("message_count", `Int event.message_count);
       ("token_count", `Int event.token_count);
       ("strategies", `List (List.map (fun value -> `String value) event.strategies));
-      ("model_family", `String event.model_family);
       ("context_window", `Int event.context_window);
       ("is_local_model", `Bool event.is_local_model);
       ("trigger", `String event.trigger);
@@ -187,7 +184,6 @@ let pre_compact_event_of_json json =
         message_count = Safe_ops.json_int ~default:0 "message_count" json;
         token_count = Safe_ops.json_int ~default:0 "token_count" json;
         strategies = Safe_ops.json_string_list "strategies" json;
-        model_family = string_field json "model_family";
         context_window = Safe_ops.json_int ~default:128_000 "context_window" json;
         is_local_model = Safe_ops.json_bool ~default:false "is_local_model" json;
         trigger = string_field json "trigger";
@@ -399,9 +395,6 @@ let overview_json
 
 let record_pre_compact_at ~timestamp ~keeper_name ~context_ratio ~message_count
     ~token_count ~strategies ~context_window ~is_local_model ~trigger =
-  let model_family =
-    Provider_adapter.classify_model_family ~is_local:is_local_model ~context_window
-  in
   let event =
     {
       timestamp;
@@ -410,7 +403,6 @@ let record_pre_compact_at ~timestamp ~keeper_name ~context_ratio ~message_count
       message_count;
       token_count;
       strategies;
-      model_family;
       context_window;
       is_local_model;
       trigger;

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -136,7 +136,6 @@ let compact_if_needed
                          (List.map
                             (fun value -> `String value)
                             pre_compact_event.strategies) );
-                     ("model_family", `String pre_compact_event.model_family);
                      ("context_window", `Int pre_compact_event.context_window);
                      ("is_local_model", `Bool pre_compact_event.is_local_model);
                      ("trigger", `String pre_compact_event.trigger);

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -182,15 +182,11 @@ let publish_verdict_recorded (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
 let publish_pre_compact (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ~context_ratio ~strategy_names ~active_agent_count ~context_window
     ~is_local_model =
-  let model_family =
-    Provider_adapter.classify_model_family ~is_local:is_local_model ~context_window
-  in
   let payload = `Assoc [
     ("keeper_name", `String keeper_name);
     ("context_ratio", `Float context_ratio);
     ("strategies", `List (List.map (fun s -> `String s) strategy_names));
     ("active_agent_count", `Int active_agent_count);
-    ("model_family", `String model_family);
     ("context_window", `Int context_window);
     ("is_local_model", `Bool is_local_model);
     ("timestamp", `Float (Time_compat.now ()));

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -966,17 +966,6 @@ let auth_detail_of_provider provider =
         endpoint_url = endpoint_url_of_adapter adapter;
         note = None }
 
-(** Classify a model into a family bucket based on locality and context window.
-    Shared SSOT to avoid duplication across oas_events and dashboard modules. *)
-
-let small_local_context_ceiling = 64_000
-let large_cloud_context_floor = 200_000
-
-let classify_model_family ~is_local ~context_window =
-  if is_local && context_window < small_local_context_ceiling then "small_local"
-  else if context_window >= large_cloud_context_floor then "large_cloud"
-  else "medium_cloud"
-
 let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider_kind) : string list =
   match kind with
   | Llm_provider.Provider_config.Anthropic -> [ "ANTHROPIC_API_KEY" ]

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -275,12 +275,6 @@ val resolve_gemini_direct_auth : unit -> gemini_direct_auth
 (** Compute the Vertex AI OpenAI-compatible endpoint URL. *)
 val gemini_vertex_openai_base_url : project:string -> location:string -> string
 
-(** {1 Model Family Classification} *)
-
-(** Classify a model into a family bucket based on locality and context window.
-    Returns "small_local", "medium_cloud", or "large_cloud". *)
-val classify_model_family : is_local:bool -> context_window:int -> string
-
 (** {1 Misc} *)
 
 val default_cli_agent_name : unit -> string


### PR DESCRIPTION
## Summary

- Remove `classify_model_family` function and associated constants from `Provider_adapter`
- Remove `model_family` string field from `pre_compact_event` record and all JSON serialization
- MASC coordination now uses only numeric constraints (`context_window`, `is_local_model`) — no string categories

## Motivation

Part of Epic #6715 (Model-Agnostic MASC). The `classify_model_family` function converted numeric context_window values into string categories (`small_local`, `medium_cloud`, `large_cloud`). This classification:
1. Lost information (number → string)
2. Created model-dependent branching in downstream consumers
3. Was only used for telemetry/dashboard display, not actual strategy selection

The actual compact strategy selection in `context_compact_oas.ml` already uses direct numeric comparisons. Dashboard frontend confirmed not reading `model_family` field.

## Changes

| File | Change |
|------|--------|
| `provider_adapter.ml/.mli` | Remove `classify_model_family`, `small_local_context_ceiling`, `large_cloud_context_floor` |
| `oas_events.ml` | Remove `model_family` from pre-compact event payload |
| `dashboard_harness_health.ml` | Remove `model_family` from record type, serialization, deserialization |
| `keeper_compact_policy.ml` | Remove `model_family` from compact event JSON |

## Test plan

- [x] `dune build --root .` passes (0 errors)
- [ ] CI Build and Test
- [ ] Verify dashboard still renders pre-compact events correctly

Closes: Part of #6715