### PR TITLE
fix(decision_audit): revert Eio.Lazy to Stdlib.Lazy for pre-Eio values

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -9,11 +9,19 @@
 (* Feature flag                                                     *)
 (* ================================================================ *)
 
+(* Stdlib.Lazy — NOT Eio.Lazy — because [audit_enabled] is called
+   from test contexts and module-init paths that run before the Eio
+   scheduler is installed.  [Eio.Lazy.force] requires an active Eio
+   effect handler and raises [Effect.Unhandled] without one.  The
+   body is a pure env-var read (no yield, no I/O), so the
+   concurrent-force hazard that motivates Eio.Lazy does not apply.
+   See [flush_interval_sec_cached] below for the Eio.Lazy
+   counterpart — those are only accessed from keeper runtime fibers
+   which always run inside [Eio_main.run]. *)
 let decision_layer_level_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
+  lazy (Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
 
-let decision_layer_level () = Eio.Lazy.force decision_layer_level_cached
+let decision_layer_level () = Lazy.force decision_layer_level_cached
 
 let audit_enabled () = decision_layer_level () >= 1
 
@@ -71,11 +79,12 @@ let to_json (r : decision_record) : Yojson.Safe.t =
 (* Ring buffer                                                      *)
 (* ================================================================ *)
 
+(* Stdlib.Lazy — same reasoning as [decision_layer_level_cached]:
+   accessed from test contexts without Eio runtime. *)
 let ring_capacity_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
+  lazy (Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
 
-let ring_capacity () = max 1 (Eio.Lazy.force ring_capacity_cached)
+let ring_capacity () = max 1 (Lazy.force ring_capacity_cached)
 
 type ring = {
   buf : decision_record option array;


### PR DESCRIPTION
## Summary

Fixes regression from #6696: \`decision_layer_level_cached\` and \`ring_capacity_cached\` were converted to \`Eio.Lazy\` but are accessed from test contexts without Eio runtime, causing \`Effect.Unhandled\` in \`test_decision_pipeline.exe\`.

Reverts these 2 values to \`Stdlib.Lazy\` with explicit comments distinguishing them from the \`Eio.Lazy\` values below (\`flush_interval_sec_cached\`, \`flush_batch_size_cached\`) which are only accessed from keeper runtime fibers.

## Why not all-Eio.Lazy

\`Eio.Lazy.force\` requires an active Eio scheduler. Values read at module init or from tests outside \`Eio_main.run\` must use \`Stdlib.Lazy\`. The rule is: **Eio.Lazy for values accessed only from Eio fibers; Stdlib.Lazy for values accessed before Eio starts or from non-Eio tests**.

## Test plan

- [x] \`dune exec --root . -- ./test/test_decision_pipeline.exe\` — 15/15 pass (was 14/15)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>