### PR TITLE
fix(keeper): add context compaction to keeper reducer

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1394,6 +1394,8 @@ let run_turn
   in
   let reducer =
     Agent_sdk.Context_reducer.compose [
+      Agent_sdk.Context_reducer.drop_thinking;
+      Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:3;
       Agent_sdk.Context_reducer.repair_dangling_tool_calls;
       Agent_sdk.Context_reducer.merge_contiguous;
     ]

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1396,6 +1396,7 @@ let run_turn
     Agent_sdk.Context_reducer.compose [
       Agent_sdk.Context_reducer.drop_thinking;
       Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:3;
+      Agent_sdk.Context_reducer.prune_tool_outputs ~max_output_len:4000;
       Agent_sdk.Context_reducer.repair_dangling_tool_calls;
       Agent_sdk.Context_reducer.merge_contiguous;
     ]


### PR DESCRIPTION
## Summary

- Keeper의 context_reducer에 `drop_thinking` + `stub_tool_results ~keep_recent:3` 추가
- 기존 reducer는 `repair_dangling_tool_calls` + `merge_contiguous`만 있어 context 크기 감소 효과 없었음
- 175KB+ request body가 Ollama에 그대로 전송되어 JSON parse error 반복 발생

## 변경 내역

```ocaml
(* Before *)
let reducer = compose [
  repair_dangling_tool_calls;
  merge_contiguous;
]

(* After *)
let reducer = compose [
  drop_thinking;                    (* thinking 블록 제거 *)
  stub_tool_results ~keep_recent:3; (* 최근 3개 외 tool result를 stub으로 치환 *)
  repair_dangling_tool_calls;
  merge_contiguous;
]
```

## 연관 PR

- jeong-sik/oas#849 — cascade fallthrough (응급 처치)
- 이 PR — 근본 원인 (context compaction 누락)

## Test plan

- [x] `dune build --root .` 성공
- [ ] keeper turn에서 req_body 크기 감소 확인 (배포 후 로그)
- [ ] thinking block이 이전 turn에서 제거되는지 확인
- [ ] 최근 3개 tool result는 full content 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)