### PR TITLE
fix(keeper): align max_tokens SSOT and world prompt wording

### DIFF
--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -10,7 +10,7 @@ Playground is your default sandbox, relative to the server `base_path`:
 - `.masc/playground/{your-name}/` — bundle root (general workspace)
 - `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
 - `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`, but in practice they must live *inside* your playground clone. The canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
+Repo worktrees live *inside* your playground clone. The canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist, never use them):
 - `/repos/...`

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -709,9 +709,9 @@ let keeper_unified_temperature () : float =
 let keeper_unified_max_tokens_rp =
   _rp_int ~key:"keeper.turn.max_output_tokens"
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_UNIFIED_MAX_TOKENS"
-                          ~default:65536 ~min_v:256 ~max_v:262144)
+                          ~default:16384 ~min_v:256 ~max_v:262144)
     ~min_v:256 ~max_v:262144
-    ~description:"Keeper turn max output tokens (65536=OpenHands default)" ()
+    ~description:"Keeper turn max output tokens (aligned with cascade.json SSOT)" ()
 let keeper_unified_max_tokens () : int =
   Runtime_params.get keeper_unified_max_tokens_rp
 


### PR DESCRIPTION
## Summary

- Align `keeper_unified_max_tokens` runtime param default (65536 → 16384) with `cascade.json` SSOT
- Fix world prompt wording to match `unified_prompt[5]` test assertion

## Fixes

| CI Test | Cause | Fix |
|---------|-------|-----|
| `config[1]` unified runtime defaults | Runtime param default (65536) ≠ cascade.json (16384) | Change default to 16384 |
| `unified_prompt[5]` world prompt worktree | Prompt says "they must live" but test expects "Repo worktrees live" | Rewrite to canonical phrase |

## Context

These two test failures have been blocking **every main CI run** since PR #6693 merge (2026-04-12). They also block PR #6722 (model-agnostic Phase 1).

Remaining CI failures (`self_preservation_properties[0]`, `decision_audit[0]`, `bash_branch_guard`) are unrelated — likely Eio.Lazy context issues in test harness.

Closes #6700