### PR TITLE
fix(test): prevent integration tests from leaking real PRs to GitHub

### DIFF
--- a/test/test_keeper_pr_workflow.ml
+++ b/test/test_keeper_pr_workflow.ml
@@ -593,6 +593,15 @@ let seed_playground_clone config keeper_name source_repo =
   let clone_path = Filename.concat repos_dir (Filename.basename source_repo) in
   if Sys.file_exists clone_path then rm_rf clone_path;
   run_cmd_exn [ "git"; "clone"; source_repo; clone_path ];
+  (* Replace origin with a local bare repo so git-push succeeds locally
+     but gh-pr-create fails harmlessly — prevents real PRs leaking to GitHub. *)
+  let local_bare = clone_path ^ ".bare" in
+  if Sys.file_exists local_bare then rm_rf local_bare;
+  run_cmd_exn [ "git"; "init"; "--bare"; local_bare ];
+  run_cmd_exn [ "git"; "-C"; clone_path; "remote"; "set-url"; "origin"; local_bare ];
+  (* Ensure main branch exists (clone from worktree may default to another branch) *)
+  ignore (run_cmd [ "git"; "-C"; clone_path; "checkout"; "-B"; "main" ]);
+  run_cmd_exn [ "git"; "-C"; clone_path; "push"; "-u"; "origin"; "main" ];
   clone_path
 
 let cleanup_test_branch repo_root branch =


### PR DESCRIPTION
## Summary
- `seed_playground_clone`이 실제 GitHub remote를 origin으로 유지하면서 `keeper_pr_workflow` 통합 테스트 실행 시 실제 PR이 GitHub에 생성되는 버그 수정
- origin을 로컬 bare repo로 교체하여 `git push`는 로컬에서 성공하고 `gh pr create`는 harmlessly 실패하도록 변경
- 11개 고아 PR(#6734~#6744) 정리 완료

## Changes
- `seed_playground_clone`: clone 후 origin을 로컬 bare repo로 교체
- worktree에서 실행 시 `main` 브랜치가 없는 경우를 대비해 `checkout -B main` 추가

## Test plan
- [x] 전체 52 테스트 통과 (76.9s)
- [x] integration 3개 테스트 모두 OK
- [x] `gh pr create` 단계에서 "none of the git remotes... point to a known GitHub host" 에러로 안전하게 종료 확인
- [x] worktree 환경에서도 동작 확인