### PR TITLE
fix: tail-recursive list helpers for cp-summary stack overflow (#6633)

### DIFF
--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -291,7 +291,7 @@ let list_detachments_json_from_state ?operation_id ?detachment_id
   in
   let rows =
     detachments
-    |> List.map (fun (detachment : detachment_record) ->
+    |> Safe_ops.map_safe (fun (detachment : detachment_record) ->
            let operation =
              operation_by_id operations detachment.operation_id
              |> Option.map operation_to_json
@@ -529,7 +529,7 @@ let list_alerts_json_from_state _config (state : snapshot_state) =
                | Some reason -> reason
                | None -> "Pending policy gate approval"));
   (* Add occurrences count to deduped alerts *)
-  let enriched = List.rev !alerts |> List.map (fun (key, json) ->
+  let enriched = List.rev !alerts |> Safe_ops.map_safe (fun (key, json) ->
     let occurrences =
       Hashtbl.find_opt seen key |> Option.map (fun count -> !count) |> Option.value ~default:1
     in

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -256,6 +256,22 @@ let json_member_opt key json =
   | `Null -> None
   | v -> Some v
 
+(** {1 Tail-recursive list helpers} *)
+
+(** Tail-recursive replacement for [Stdlib.List.concat_map].
+    [Stdlib.List.concat_map f l] is implemented as [concat (map f l)] —
+    neither [map] nor [concat] is tail-recursive, so a list of N elements
+    where [f] returns M-element sub-lists uses O(N + N*M) stack frames.
+    This version uses [fold_left] + [rev_append] — constant stack. *)
+let concat_map_safe (f : 'a -> 'b list) (l : 'a list) : 'b list =
+  List.rev (List.fold_left (fun acc x -> List.rev_append (f x) acc) [] l)
+
+(** Tail-recursive replacement for [Stdlib.List.map].
+    [Stdlib.List.map] builds the result on the stack — O(N) frames.
+    For lists that may exceed ~10K elements, use this instead. *)
+let map_safe (f : 'a -> 'b) (l : 'a list) : 'b list =
+  List.rev (List.rev_map f l)
+
 (** {1 Safe Process Execution} *)
 
 (* Intentionally empty: process execution lives in Process_eio (argv-only). *)

--- a/lib/core/safe_ops.mli
+++ b/lib/core/safe_ops.mli
@@ -105,3 +105,11 @@ val json_assoc : string -> Yojson.Safe.t -> (string * Yojson.Safe.t) list
 
 val json_member_opt : string -> Yojson.Safe.t -> Yojson.Safe.t option
 (** Extract any non-null JSON value by key. Returns [None] for [`Null] or missing key. *)
+
+(** {1 Tail-recursive list helpers} *)
+
+val concat_map_safe : ('a -> 'b list) -> 'a list -> 'b list
+(** Tail-recursive [List.concat_map].  Stdlib's version uses O(N) stack. *)
+
+val map_safe : ('a -> 'b) -> 'a list -> 'b list
+(** Tail-recursive [List.map].  Stdlib's version uses O(N) stack. *)

--- a/lib/swarm_status/swarm_status_build.ml
+++ b/lib/swarm_status/swarm_status_build.ml
@@ -4,6 +4,11 @@ open Swarm_status_json
 open Swarm_status_classify
 open Swarm_status_lanes
 
+(* Tail-recursive List.concat_map — avoids Stack_overflow on long
+   lane event lists.  Stdlib's version uses O(N) stack frames. *)
+let concat_map_safe f l =
+  List.rev (List.fold_left (fun acc x -> List.rev_append (f x) acc) [] l)
+
 let build_json_from_inputs ~timeline_limit_override ~now
     ~operations ~detachments ~alerts ~decisions ~traces ~sessions =
   let operation_kinds =
@@ -98,7 +103,7 @@ let build_json_from_inputs ~timeline_limit_override ~now
                   | "managed" -> Managed
                   | "supervised" -> Supervised
                   | _ -> Projected)))
-      |> List.concat_map (fun (lane : lane) ->
+      |> concat_map_safe (fun (lane : lane) ->
              let kind =
                match lane.lane_id with
                | "managed" -> Managed


### PR DESCRIPTION
## Summary

Adds \`Safe_ops.concat_map_safe\` / \`Safe_ops.map_safe\` (tail-recursive) and applies to 3 hottest sites in the cp-summary code path reported in #6633.

\`Stdlib.List.map\` / \`List.concat_map\` build results on the stack — O(N) frames. For the cp-summary path that chains multiple map/concat_map on potentially unbounded lists (detachments, alerts, lane events), accumulated data post-restart can overflow.

## Changes

| File | Site | Change |
|------|------|--------|
| \`safe_ops.ml/mli\` | new | \`concat_map_safe\`, \`map_safe\` using fold_left+rev_append |
| \`swarm_status_build.ml:101\` | concat_map on lane events | inline tail-recursive helper |
| \`cp_snapshot_core.ml:294\` | map on detachments | \`Safe_ops.map_safe\` |
| \`cp_snapshot_core.ml:532\` | map on enriched alerts | \`Safe_ops.map_safe\` |

Does NOT fully close #6633 (overflow may be deeper), but removes the most obvious non-tail-recursive hotspots.

## Test plan

- [x] \`dune build --root . @lib/check\` — exit 0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>