### PR TITLE
[codex] Surface keeper admission queue blockers in telemetry

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.sort.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.sort.test.ts
@@ -90,4 +90,35 @@ describe('buildFleetRows sort order', () => {
       'inactive-heavy-tools',
     ])
   })
+
+  it('treats runtime blockers as top-priority attention signals', () => {
+    const keepers = [
+      {
+        name: 'queue-blocked',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.1,
+        total_turns: 12,
+        runtime_blocker_class: 'admission_queue_wait_timeout',
+        runtime_blocker_summary: 'Admission queue wait timeout after 45.0s.',
+      },
+      {
+        name: 'healthy-busy',
+        status: 'active',
+        keepalive_running: true,
+        context_ratio: 0.4,
+        total_turns: 50,
+      },
+    ] satisfies Keeper[]
+
+    const rows = buildFleetRows(
+      keepers,
+      toolQualityByKeeper([
+        { name: 'queue-blocked', calls: 0, success_pct: 100 },
+        { name: 'healthy-busy', calls: 20, success_pct: 100 },
+      ]),
+    )
+
+    expect(rows.map(row => row.name)).toEqual(['queue-blocked', 'healthy-busy'])
+  })
 })

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -211,7 +211,7 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Partial telemetry')
     expect(container.textContent).toContain('keepers are blocked in the admission queue')
     expect(container.textContent).toContain('Admission queue wait timeout after 45.0s.')
-  })
+  }, 30_000)
 
   it('falls back to runtime model and tool audit data when quality rows are sparse', async () => {
     const { buildFleetRows } = await loadPanel({

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -167,6 +167,52 @@ describe('FleetTelemetryPanel', () => {
     expect(container.textContent).toContain('Failure Categories')
   }, 60_000)
 
+  it('warns when keepers are stuck before reaching tool execution', async () => {
+    const fetchDashboardExecution = vi.fn().mockResolvedValue({
+      ...executionResponse,
+      keepers: [
+        {
+          name: 'keeper-alpha',
+          status: 'active',
+          keepalive_running: true,
+          context_ratio: 0.22,
+          total_turns: 48,
+          last_latency_ms: 45_000,
+          last_activity_ago_s: 20,
+          last_model_used: 'gpt-5.4',
+          runtime_blocker_class: 'admission_queue_wait_timeout',
+          runtime_blocker_summary: 'Admission queue wait timeout after 45.0s.',
+          recent_tool_names: [],
+        },
+      ],
+    } satisfies DashboardExecutionResponse)
+    const fetchToolQuality = vi.fn().mockResolvedValue({
+      ...toolQualityResponse,
+      total: 0,
+      success: 0,
+      failure: 0,
+      success_rate: 0,
+      by_keeper: [],
+      failure_categories: [],
+    })
+    const fetchTelemetrySummary = vi.fn().mockResolvedValue(telemetrySummaryResponse)
+    const { FleetTelemetryPanel } = await loadPanel({
+      fetchDashboardExecution,
+      fetchToolQuality,
+      fetchTelemetrySummary,
+    })
+
+    await act(async () => {
+      render(html`<${FleetTelemetryPanel} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('Partial telemetry')
+    expect(container.textContent).toContain('keepers are blocked in the admission queue')
+    expect(container.textContent).toContain('Admission queue wait timeout after 45.0s.')
+  })
+
   it('falls back to runtime model and tool audit data when quality rows are sparse', async () => {
     const { buildFleetRows } = await loadPanel({
       fetchDashboardExecution: vi.fn().mockResolvedValue(executionResponse),

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -39,6 +39,8 @@ interface FleetRow {
   tool_success_pct: number | null
   tool_activity_known: boolean
   recent_tools: string[]
+  runtime_blocker_class: Keeper['runtime_blocker_class'] | null
+  runtime_blocker_summary: string | null
 }
 
 interface FleetTelemetryState {
@@ -235,7 +237,8 @@ function fleetBand(row: FleetRow): FleetBand {
   }
   if (normalizedStatus === 'paused') return 'paused'
   if (
-    row.context_ratio >= PRESSURE_WARN_RATIO
+    row.runtime_blocker_class != null
+    || row.context_ratio >= PRESSURE_WARN_RATIO
     || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
     || (row.tool_success_pct != null && row.tool_success_pct < 90)
   ) {
@@ -254,6 +257,7 @@ function fleetBandScore(row: FleetRow): number {
 
 function rowUrgencyScore(row: FleetRow): number {
   let score = 0
+  if (row.runtime_blocker_class != null) score += 100
   if (row.context_ratio >= PRESSURE_WARN_RATIO) score += row.context_ratio * 100
   if (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC) {
     score += Math.min(row.last_activity_ago_s / STALE_ACTIVITY_SEC, 5)
@@ -317,6 +321,9 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             tool_success_pct: toolQualityForKeeper?.success_pct ?? null,
             tool_activity_known: keeperHasToolTelemetry(keeper, toolCalls, recentTools),
             recent_tools: recentTools,
+            runtime_blocker_class: keeper.runtime_blocker_class ?? null,
+            runtime_blocker_summary:
+              firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker) ?? null,
           }
         })
       : toolQuality.by_keeper.map((keeper): FleetRow => ({
@@ -332,6 +339,8 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           tool_success_pct: keeper.success_pct,
           tool_activity_known: keeper.calls > 0,
           recent_tools: [],
+          runtime_blocker_class: null,
+          runtime_blocker_summary: null,
         }))
 
   return [...rows].sort(compareFleetRows)
@@ -357,6 +366,7 @@ function pressureClass(ratio: number): string {
 
 function statusClass(row: FleetRow): string {
   if (!row.keepalive_running || row.status === 'offline' || row.status === 'stopped') return 'text-red-400'
+  if (row.runtime_blocker_class != null) return 'text-yellow-400'
   if (row.context_ratio >= PRESSURE_HOT_RATIO) return 'text-yellow-400'
   return 'text-emerald-400'
 }
@@ -443,6 +453,25 @@ function buildTelemetryWarnings(sources: TelemetrySourceSummary[]): string[] {
     if (agentAge == null || agentAge <= TELEMETRY_ACTIVITY_FRESH_SEC) {
       warnings.push(`OAS event relay stale: last durable event ${formatElapsedCompact(oasAge)} ago.`)
     }
+  }
+
+  return warnings
+}
+
+function buildRuntimeWarnings(rows: FleetRow[]): string[] {
+  const warnings: string[] = []
+  const admissionBlocked = rows.filter(row => row.runtime_blocker_class === 'admission_queue_wait_timeout')
+  if (admissionBlocked.length > 0) {
+    warnings.push(
+      `${admissionBlocked.length} keepers are blocked in the admission queue; tool telemetry can look stale because turns never reached tool execution.`,
+    )
+  }
+
+  const slotBlocked = rows.filter(row => row.runtime_blocker_class === 'autonomous_slot_wait_timeout')
+  if (slotBlocked.length > 0) {
+    warnings.push(
+      `${slotBlocked.length} keepers skipped their autonomous cycle while waiting for a local keeper slot.`,
+    )
   }
 
   return warnings
@@ -596,6 +625,13 @@ function FleetComparisonTable({ rows }: { rows: FleetRow[] }) {
             <tr class="border-b border-[var(--card-border)] border-opacity-30 align-top">
               <td class="py-1.5">
                 <div class="font-mono text-[var(--text)]">${row.name}</div>
+                ${row.runtime_blocker_summary
+                  ? html`
+                    <div class="max-w-[240px] truncate text-[10px] text-amber-300" title=${row.runtime_blocker_summary}>
+                      ${row.runtime_blocker_summary}
+                    </div>
+                  `
+                  : null}
                 <div class="max-w-[240px] truncate text-[10px] text-[var(--text-dim)]" title=${toolInfo.title}>
                   ${toolInfo.label}
                 </div>
@@ -720,6 +756,7 @@ export function FleetTelemetryPanel() {
       warnings.push(...buildTelemetryWarnings(telemetrySummary.sources))
 
       const rows = buildFleetRows(keepers, toolQuality)
+      warnings.push(...buildRuntimeWarnings(rows))
       const updatedAt =
         (executionResult.status === 'fulfilled' ? executionResult.value.generated_at : null)
         || telemetrySummary.generated_at

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -474,6 +474,17 @@ function buildRuntimeWarnings(rows: FleetRow[]): string[] {
     )
   }
 
+  const otherBlocked = rows.filter(row =>
+    row.runtime_blocker_class != null
+    && row.runtime_blocker_class !== 'admission_queue_wait_timeout'
+    && row.runtime_blocker_class !== 'autonomous_slot_wait_timeout',
+  )
+  if (otherBlocked.length > 0) {
+    warnings.push(
+      `${otherBlocked.length} keepers have other runtime blockers; inspect the row-level blocker hints for details.`,
+    )
+  }
+
   return warnings
 }
 

--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -76,6 +76,8 @@ let global : t = {
   mutex = Eio.Mutex.create ();
 }
 
+let () = Admission_queue_metrics.set_max_concurrent global.max_slots
+
 let now_ts () = Unix.gettimeofday ()
 let wait_ms_since enqueue_ts = int_of_float ((now_ts () -. enqueue_ts) *. 1000.0)
 
@@ -201,7 +203,8 @@ let set_max_concurrent n =
     invalid_arg
       (Printf.sprintf "Admission_queue.set_max_concurrent: must be >= 1, got %d" n);
   Eio.Mutex.use_rw ~protect:true global.mutex (fun () ->
-    global.max_slots <- n)
+    global.max_slots <- n);
+  Admission_queue_metrics.set_max_concurrent n
 
 let max_concurrent () = global.max_slots
 
@@ -210,4 +213,5 @@ let reset_for_test ~max_slots =
   Eio.Mutex.use_rw ~protect:true global.mutex (fun () ->
     global.max_slots <- max_slots;
     global.active <- 0;
-    global.waiters <- [])
+    global.waiters <- []);
+  Admission_queue_metrics.set_max_concurrent max_slots

--- a/lib/admission_queue_metrics.ml
+++ b/lib/admission_queue_metrics.ml
@@ -19,3 +19,7 @@ let on_release ~keeper_name:_ ~cascade_name:_ =
 
 let on_cancelled ~keeper_name:_ ~cascade_name:_ =
   Prometheus.inc_counter "masc_inference_queue_cancelled_total" ()
+
+let set_max_concurrent value =
+  Prometheus.set_gauge "masc_inference_queue_max_concurrent"
+    (float_of_int (max 0 value))

--- a/lib/admission_queue_metrics.ml
+++ b/lib/admission_queue_metrics.ml
@@ -22,4 +22,4 @@ let on_cancelled ~keeper_name:_ ~cascade_name:_ =
 
 let set_max_concurrent value =
   Prometheus.set_gauge "masc_inference_queue_max_concurrent"
-    (float_of_int (max 0 value))
+    (float_of_int value)

--- a/lib/admission_queue_metrics.mli
+++ b/lib/admission_queue_metrics.mli
@@ -22,3 +22,6 @@ val on_release : keeper_name:string -> cascade_name:string -> unit
 val on_cancelled : keeper_name:string -> cascade_name:string -> unit
 (** Called when a wait is cancelled by fiber cancellation.
     Increments cancelled counter. *)
+
+val set_max_concurrent : int -> unit
+(** Syncs the configured admission queue capacity into Prometheus. *)

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -312,6 +312,40 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                  let keepalive_started_at =
                    Keeper_status_bridge.runtime_keepalive_started_at config meta
                  in
+                 let created_ts =
+                   Resilience.Time.parse_iso8601_opt meta.created_at
+                   |> Option.value ~default:0.0
+                 in
+                 let last_turn_ago_s =
+                   if meta.runtime.usage.last_turn_ts <= 0.0 then 0.0
+                   else now_ts -. meta.runtime.usage.last_turn_ts
+                 in
+                 let last_handoff_ago_s =
+                   if meta.runtime.last_handoff_ts <= 0.0 then 0.0
+                   else now_ts -. meta.runtime.last_handoff_ts
+                 in
+                 let last_compaction_ago_s =
+                   if meta.runtime.compaction_rt.last_ts <= 0.0 then 0.0
+                   else now_ts -. meta.runtime.compaction_rt.last_ts
+                 in
+                 let last_proactive_ago_s =
+                   if meta.runtime.proactive_rt.last_ts <= 0.0 then 0.0
+                   else now_ts -. meta.runtime.proactive_rt.last_ts
+                 in
+                 let last_activity_ts =
+                   List.fold_left max 0.0
+                     [
+                       meta.runtime.usage.last_turn_ts;
+                       meta.runtime.proactive_rt.last_ts;
+                       meta.runtime.last_handoff_ts;
+                       meta.runtime.compaction_rt.last_ts;
+                       created_ts;
+                     ]
+                 in
+                 let last_activity_ago_s =
+                   if last_activity_ts <= 0.0 then 0.0
+                   else now_ts -. last_activity_ts
+                 in
                  let diagnostic =
                    Keeper_exec_status.keeper_diagnostic_json ~meta
                      ~agent_status:agent_json ~keepalive_running ~history_items:[]
@@ -348,7 +382,7 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                  in
                  Some
                    (`Assoc
-                     [
+                     ([
                        ("runtime_class", `String "keeper");
                        ("pipeline_stage", `String pipeline_stage);
                        ("phase", phase_str);
@@ -368,6 +402,11 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                           | Some r -> `Float r
                           | None -> `Null));
                        ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
+                       ("last_turn_ago_s", `Float last_turn_ago_s);
+                       ("last_handoff_ago_s", `Float last_handoff_ago_s);
+                       ("last_compaction_ago_s", `Float last_compaction_ago_s);
+                       ("last_proactive_ago_s", `Float last_proactive_ago_s);
+                       ("last_activity_ago_s", `Float last_activity_ago_s);
                        ("last_model_used", `String meta.runtime.usage.last_model_used);
                        ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
                        ("keepalive_running", `Bool keepalive_running);
@@ -397,6 +436,18 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        ("proactive_enabled", `Bool meta.proactive.enabled);
                        ("proactive_idle_sec", `Int meta.proactive.idle_sec);
                        ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
+                       ("last_proactive_reason",
+                         string_option_to_json
+                           (let value = String.trim meta.runtime.proactive_rt.last_reason in
+                            if value = "" then None else Some value));
+                       ("last_proactive_preview",
+                         string_option_to_json
+                           (let value = String.trim meta.runtime.proactive_rt.last_preview in
+                            if value = "" then None else Some value));
+                       ("last_blocker",
+                         string_option_to_json
+                           (let value = String.trim meta.runtime.last_blocker in
+                            if value = "" then None else Some value));
                        ("updated_at", `String meta.updated_at);
                        ("created_at", `String meta.created_at);
                        ("recent_activity",
@@ -415,7 +466,8 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                              with Yojson.Json_error _ -> None) lines)
                          else
                            `List []);
-                     ])
+                     ]
+                     @ Keeper_status_bridge.runtime_blocker_fields_json config meta))
            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
              Log.Dashboard.error "keepers_json fiber error (%s): %s"
                name (Printexc.to_string exn);

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -78,6 +78,61 @@ let test_initial_max_concurrent_clamps_min_one () =
   in
   check int "clamped" 1 (AQ.initial_max_concurrent_of_env getenv)
 
+let test_wait_timeout_no_leak () =
+  Eio_main.run (fun env ->
+    AQ.reset_for_test ~max_slots:1;
+    Eio_context.set_clock (Eio.Stdenv.clock env);
+    let hold, release_hold = Eio.Promise.create () in
+    let timeout_seen = ref None in
+    Eio.Fiber.both
+      (fun () ->
+        AQ.with_permit ~priority:Interactive
+          ~keeper_name:"blocker" ~cascade_name:"test"
+          (fun () -> Eio.Promise.await hold))
+      (fun () ->
+        Eio.Fiber.yield ();
+        (try
+           AQ.with_permit ~wait_timeout_sec:0.01 ~priority:Background
+             ~keeper_name:"timed-out" ~cascade_name:"test"
+             (fun () -> ())
+         with AQ.Wait_timeout wait_ms ->
+           timeout_seen := Some wait_ms);
+        Eio.Promise.resolve release_hold ());
+    check bool "wait timeout raised" true (Option.is_some !timeout_seen);
+    let s = AQ.snapshot () in
+    check int "no leaked slots" 0 s.active;
+    check int "queue cleared" 0 s.queue_depth)
+
+(* ============================================================
+   Configuration Tests
+   ============================================================ *)
+
+let test_set_max_concurrent () =
+  Eio_main.run (fun _env ->
+    AQ.reset_for_test ~max_slots:4;
+    AQ.set_max_concurrent 8;
+    check int "updated" 8 (AQ.max_concurrent ());
+    AQ.set_max_concurrent 4)
+
+let test_max_concurrent_metric_tracks_capacity () =
+  Eio_main.run (fun _env ->
+    AQ.reset_for_test ~max_slots:3;
+    let initial =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_max_concurrent" ()
+    in
+    check (float 0.1) "metric initialized" 3.0 initial;
+    AQ.set_max_concurrent 5;
+    let updated =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_max_concurrent" ()
+    in
+    check (float 0.1) "metric updated" 5.0 updated)
+
+let test_set_max_concurrent_rejects_zero () =
+  try AQ.set_max_concurrent 0; fail "should raise"
+  with Invalid_argument _ -> ()
+
 let test_snapshot_json_shape () =
   Eio_main.run (fun _env ->
     let json = AQ.snapshot_json () in
@@ -102,6 +157,7 @@ let () =
       test_case "propagates exception" `Quick test_with_permit_propagates_exception;
       test_case "try always succeeds" `Quick test_try_always_succeeds;
       test_case "concurrent all run" `Quick test_concurrent_all_run;
+      test_case "wait timeout no leak" `Quick test_wait_timeout_no_leak;
     ];
     "config", [
       test_case "initial default" `Quick test_initial_max_concurrent_default;
@@ -111,6 +167,10 @@ let () =
         test_initial_max_concurrent_ignores_ollama_parallel;
       test_case "initial clamps min one" `Quick
         test_initial_max_concurrent_clamps_min_one;
+      test_case "set_max_concurrent" `Quick test_set_max_concurrent;
+      test_case "max_concurrent metric tracks capacity" `Quick
+        test_max_concurrent_metric_tracks_capacity;
+      test_case "rejects zero" `Quick test_set_max_concurrent_rejects_zero;
       test_case "snapshot_json shape" `Quick test_snapshot_json_shape;
     ];
   ]


### PR DESCRIPTION
## Summary
- surface keeper admission-queue blockers in telemetry so operators can distinguish true idleness from proactive turns that timed out before tool execution

## What changed
- publish the admission queue max-concurrency gauge so Prometheus and monitoring surfaces expose the real queue capacity
- enrich lightweight keeper execution snapshots with recent activity ages and runtime blocker fields
- teach Fleet Telemetry to elevate admission-queue blockers, show blocker hints inline, and explain why tool telemetry may appear stale when turns never reached tool execution
- add focused OCaml and dashboard tests for the new telemetry and blocker behavior

## Why
Keepers looked like they were simply idle, but the real failure mode was proactive turns timing out in the admission queue before any tool execution happened. The dashboard exposed too little runtime truth to make that obvious.

## Product impact
- operators can now see configured admission queue capacity in Prometheus
- execution and fleet surfaces carry blocker context instead of flattening everything into `idle`
- fleet telemetry warns when stale tool telemetry is a consequence of queue contention rather than missing ingestion

## Evidence
- reproduced the observed local failure mode with a single effective admission slot and concurrent proactive keepers, which left heartbeat telemetry moving while tool telemetry stopped advancing
- local validation:
  - `dune build --root . @check`
  - `_build/default/test/test_admission_queue_coverage.exe`
  - `pnpm --dir dashboard typecheck`
  - `/opt/homebrew/bin/node dashboard/node_modules/vitest/vitest.mjs run src/components/fleet-telemetry-panel.sort.test.ts --pool=threads --testTimeout=5000 --hookTimeout=5000 --teardownTimeout=5000`
  - `/opt/homebrew/bin/node dashboard/node_modules/vitest/vitest.mjs run src/components/fleet-telemetry-panel.test.ts -t "warns when keepers are stuck before reaching tool execution" --pool=threads --testTimeout=30000 --hookTimeout=10000 --teardownTimeout=10000`

## Review evidence
- reviewer: direct `sb glm-text` (`GLM-5.1`)
- timestamp: `2026-04-12T17:29:27Z`
- result: no high or critical findings
- follow-up: patched the reported low-severity observability gaps in commit `a99572b50`

## Root cause
The runtime was configured with a single effective admission slot while multiple autonomous keepers were attempting proactive turns. Those turns timed out in the queue, so tool telemetry stopped advancing even though heartbeat telemetry kept moving.

## Linked issue
- Refs #6210
