### PR TITLE
fix(keeper): stop blocking keepers on ambiguous partial commit

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1451,6 +1451,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_transient ~social_state ()
           in
           if is_ambiguous_partial then begin
+            (* Log the partial commit but do NOT block the keeper with
+               a manual_reconcile file. Keeper tools (board_vote,
+               board_comment, broadcast) are safe to re-encounter —
+               duplicates are tolerable, but a stuck keeper is not.
+               The failure is still recorded in decisions.jsonl and
+               failure_reason for observability. *)
             let failure_reason =
               Option.value
                 ~default:
@@ -1463,23 +1469,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             Keeper_registry.set_failure_reason ~base_path:config.base_path
               meta.name
               (Some failure_reason);
-            ignore
-              (Keeper_manual_reconcile.open_pending
-                 config
-                 ~keeper_name:meta.name
-                 ~blocker_class:(blocker_class_of_failure_reason failure_reason)
-                 ~summary:(short_preview e_str)
-                 ~failure_reason:
-                   (Some (Keeper_registry.failure_reason_to_string failure_reason))
-                 ~trace_id:(Some (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
-                 ~generation:(Some meta.runtime.generation)
-                 ~committed_tools:
-                   (committed_mutating_tools !mutating_tools_committed));
-            ignore (Keeper_registry.dispatch_event
-              ~base_path:config.base_path meta.name
-              (Keeper_state_machine.Manual_reconcile_required {
-                reason = short_preview e_str;
-              }))
+            Log.Keeper.warn
+              "%s: auto-recoverable partial commit (tools=[%s]); \
+               continuing without manual reconcile block"
+              meta.name
+              (String.concat ", "
+                 (committed_mutating_tools !mutating_tools_committed))
           end;
           append_decision_record ~config ~meta:updated_meta ~observation
             ~latency_ms ~semaphore_wait_ms


### PR DESCRIPTION
## Problem

mutating tool 실행 후 LLM call 실패 시 `manual_reconcile.json` 파일이 생성되어 keeper가 완전히 멈춘다. 해제하려면 수동으로 파일을 삭제해야 한다. cascade 에러(timeout, JSON parse)가 반복되면 매번 reconcile이 재생성되어 keeper가 영구 정지.

## Fix

reconcile 파일 생성 + state machine block을 **warning 로그**로 대체. failure_reason과 decisions.jsonl에 기록은 유지하되 keeper를 멈추지 않는다.

keeper의 mutating tool들(board_vote, board_comment, broadcast)은 중복 실행해도 치명적이지 않다. 멈추는 것이 더 나쁘다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)