### PR TITLE
refactor(spawn): typed mcp_flag/prompt_flag dispatch (Phase 1)

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -10,6 +10,17 @@ type parsed_output = {
   cost_usd : float option;
 }
 
+(** How MCP tool list is passed on the CLI. *)
+type mcp_flag =
+  | Mcp_joined of string    (** Single flag with comma-joined tools: --flag t1,t2 *)
+  | Mcp_spread of string    (** Server name + spread tools: --server masc --flag t1 t2 *)
+  | Mcp_none                (** No MCP flags emitted *)
+
+(** How the prompt is passed to the CLI. *)
+type prompt_flag =
+  | Prompt_flag of string   (** Prompt passed via CLI flag: -p <prompt> *)
+  | Prompt_stdin             (** Prompt passed via stdin *)
+
 (** Spawn configuration for an agent *)
 type spawn_config = {
   agent_name: string;
@@ -21,7 +32,12 @@ type spawn_config = {
     (** Parse CLI tool's raw output into structured result.
         Each CLI tool has a different JSON schema. *)
   stdin_prompt: bool;
-    (** Whether prompt is passed via stdin (true) or CLI flag (false). *)
+    (** Whether prompt is passed via stdin (true) or CLI flag (false).
+        Deprecated: use [prompt_mode] instead. Kept for backward compat. *)
+  mcp_mode: mcp_flag;
+    (** How MCP tools are passed on the CLI. *)
+  prompt_mode: prompt_flag;
+    (** How the prompt is delivered to the agent. *)
 }
 
 (** Spawn result with token tracking *)
@@ -151,6 +167,8 @@ let default_configs = [
     mcp_tools = masc_mcp_tools;
     parse_output = parse_claude_output;
     stdin_prompt = true;
+    mcp_mode = Mcp_joined "--allowedTools";
+    prompt_mode = Prompt_stdin;
   });
   ("gemini", {
     agent_name = "gemini";
@@ -159,7 +177,9 @@ let default_configs = [
     working_dir = None;
     mcp_tools = masc_mcp_tools;
     parse_output = parse_gemini_output;
-    stdin_prompt = false;  (* Gemini CLI uses -p flag, not stdin *)
+    stdin_prompt = false;
+    mcp_mode = Mcp_spread "--allowed-tools";
+    prompt_mode = Prompt_flag "-p";
   });
   ("codex", {
     agent_name = "codex";
@@ -169,6 +189,8 @@ let default_configs = [
     mcp_tools = masc_mcp_tools;
     parse_output = parse_raw_output;
     stdin_prompt = true;
+    mcp_mode = Mcp_none;
+    prompt_mode = Prompt_stdin;
   });
   ("llama", {
     agent_name = "llama";
@@ -178,6 +200,8 @@ let default_configs = [
     mcp_tools = masc_mcp_tools;
     parse_output = parse_raw_output;
     stdin_prompt = true;
+    mcp_mode = Mcp_none;
+    prompt_mode = Prompt_stdin;
   });
 ]
 
@@ -193,28 +217,37 @@ let get_config agent_name =
     | Some key -> List.assoc_opt key default_configs
     | None -> None
 
+(** Build MCP flags from config's [mcp_mode] field.
+    No agent-name matching — dispatch is config-driven. *)
+let build_mcp_args_from_config (config : spawn_config) tools =
+  if tools = [] then []
+  else
+    match config.mcp_mode with
+    | Mcp_joined flag ->
+      [flag; String.concat "," tools]
+    | Mcp_spread flag ->
+      ["--allowed-mcp-server-names"; "masc"; flag] @ tools
+    | Mcp_none -> []
+
+(** Build prompt flags from config's [prompt_mode] field. *)
+let build_prompt_args_from_config (config : spawn_config) prompt =
+  match config.prompt_mode with
+  | Prompt_flag flag -> [flag; prompt]
+  | Prompt_stdin -> []
+
 (** Build MCP flags as argument list (no shell escaping needed).
-    Uses spawn_key (not canonical_name) to match Spawn.default_configs keys. *)
+    Resolves agent config then dispatches via [mcp_mode]. *)
 let build_mcp_args agent_name tools =
   if tools = [] then []
   else
-    let key = Provider_adapter.resolve_spawn_key agent_name
-              |> Option.value ~default:agent_name in
-    match key with
-    | "claude" ->
-      let tools_str = String.concat "," tools in
-      ["--allowedTools"; tools_str]
-    | "gemini" ->
-      ["--allowed-mcp-server-names"; "masc"; "--allowed-tools"] @ tools
-    | "codex" | "llama" -> []
-    | _ -> []
+    match get_config agent_name with
+    | Some config -> build_mcp_args_from_config config tools
+    | None -> []
 
 let build_prompt_args agent_name prompt =
-  let key = Provider_adapter.resolve_spawn_key agent_name
-            |> Option.value ~default:agent_name in
-  match key with
-  | "gemini" -> ["-p"; prompt]
-  | _ -> []
+  match get_config agent_name with
+  | Some config -> build_prompt_args_from_config config prompt
+  | None -> []
 
 (** Parse command string into executable and arguments *)
 let parse_command cmd =
@@ -344,6 +377,8 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
         mcp_tools = [];
         parse_output = parse_raw_output;
         stdin_prompt = true;
+        mcp_mode = Mcp_none;
+        prompt_mode = Prompt_stdin;
       }
   in
 

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -22,6 +22,7 @@ let test_spawn_config_creation () =
     timeout_seconds = 60;
     working_dir = Some "/tmp";
     mcp_tools = ["tool1"; "tool2"]; parse_output = Spawn.parse_raw_output; stdin_prompt = true;
+    mcp_mode = Spawn.Mcp_none; prompt_mode = Spawn.Prompt_stdin;
   } in
   check string "agent_name" "test-agent" cfg.agent_name;
   check string "command" "claude -p" cfg.command;
@@ -36,6 +37,7 @@ let test_spawn_config_no_working_dir () =
     timeout_seconds = 30;
     working_dir = None;
     mcp_tools = []; parse_output = Spawn.parse_raw_output; stdin_prompt = true;
+    mcp_mode = Spawn.Mcp_none; prompt_mode = Spawn.Prompt_stdin;
   } in
   match cfg.working_dir with
   | None -> ()
@@ -48,6 +50,7 @@ let test_spawn_config_empty_tools () =
     timeout_seconds = 1;
     working_dir = None;
     mcp_tools = []; parse_output = Spawn.parse_raw_output; stdin_prompt = true;
+    mcp_mode = Spawn.Mcp_none; prompt_mode = Spawn.Prompt_stdin;
   } in
   check int "empty tools" 0 (List.length cfg.mcp_tools)
 


### PR DESCRIPTION
## Summary

Phase 1 of spawn config externalization (Epic #6715, Model-Agnostic MASC Phase 3).

- Add `mcp_flag` type: `Mcp_joined | Mcp_spread | Mcp_none`
- Add `prompt_flag` type: `Prompt_flag | Prompt_stdin`
- Replace agent-name match tables with config-field dispatch
- All 10 spawn tests pass, no behavior change

## Motivation

`build_mcp_args` and `build_prompt_args` matched on agent name strings (`"claude"`, `"gemini"`, etc.) to determine CLI flag format. This couples MASC to specific agent identities.

Now each `spawn_config` entry declares its own flag format, and dispatch is config-driven. Adding a new agent requires only a new config entry (or TOML file in Phase 2), not a code change.

## Next phases

- Phase 2: TOML file loader (`config/spawn/<key>.toml`)
- Phase 3: Ship TOML files, default_configs becomes compile-time fallback

## Test plan

- [x] `test_spawn.exe`: 10/10 pass
- [x] `dune build --root .`: exit 0
- [ ] CI Build and Test