### PR TITLE
fix(admission): size queue to actual decode parallelism

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -63,7 +63,11 @@ let initial_max_concurrent_of_env getenv =
   in
   match parse_int "MASC_ADMISSION_MAX_CONCURRENT" with
   | Some n -> max 1 n
-  | None -> 4
+  | None ->
+      (* Default 1: Ollama MLX decode is serial regardless of
+         OLLAMA_NUM_PARALLEL (prefill pipelining, not decode).
+         Override with MASC_ADMISSION_MAX_CONCURRENT for multi-GPU. *)
+      1
 
 let global : t = {
   max_slots = initial_max_concurrent_of_env Sys.getenv_opt;

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -261,13 +261,18 @@ module KeeperKeepalive = struct
       (get_float ~default:1200.0 "MASC_KEEPER_TURN_TIMEOUT_SEC"))
 
   (** Maximum time a proactive keeper will wait in the MASC admission queue
-      before abandoning the current OAS attempt. This prevents background
-      keepers from looking silently stuck behind long-running inference calls.
-      Env: [MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC]. Default: 45.0.
-      Range: [5, 600]. *)
+      before abandoning the current OAS attempt.
+
+      With admission max_concurrent=1 (MLX decode serial), a keeper may wait
+      for the full duration of the preceding keeper's turn. Observed turn
+      durations: 180-963s. Default 180s covers the common case (GLM cascade
+      completes in ~180s) while avoiding indefinite waits.
+
+      Env: [MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC]. Default: 180.0.
+      Range: [5, 1200]. *)
   let admission_wait_timeout_sec =
-    Float.max 5.0 (Float.min 600.0
-      (get_float ~default:45.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
+    Float.max 5.0 (Float.min 1200.0
+      (get_float ~default:180.0 "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC"))
 
   (** Maximum time a scheduled autonomous keeper will wait for the local
       keeper turn gate before skipping the cycle. Reactive turns still wait


### PR DESCRIPTION
## Summary
- Drop `OLLAMA_NUM_PARALLEL` fallback for admission max_slots (default 4→1)
- Raise admission wait timeout 45s→180s (range cap 600→1200)

## Problem
`OLLAMA_NUM_PARALLEL=4` controls Ollama prefill pipelining, not decode concurrency. MLX decode is always serial (1 at a time). Using it as admission max_slots let 4 keepers acquire slots simultaneously, but only 1 made progress. The other 3 stalled on HTTP connections, blocking the queue.

Result: 43 admission timeouts in 50 minutes, 3.6% success rate.

## Fix
- `max_slots` defaults to 1 (match MLX decode=1)
- Override: `MASC_ADMISSION_MAX_CONCURRENT=N` for multi-GPU setups
- Wait timeout 180s covers GLM cascade latency without indefinite waits

## Test plan
- [x] `dune build` passes
- [ ] Server restart → keeper decisions show reduced admission timeouts
- [ ] Multiple keepers take turns sequentially (not 4 simultaneous stalls)

Generated with [Claude Code](https://claude.com/claude-code)