### PR TITLE
chore(deps): bump OAS pin v0.122.2 → v0.123.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.122.1))
+  (agent_sdk (>= 0.123.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -136,15 +136,6 @@ let summarize_post_commit_failure
         tools
         err_preview
 
-let blocker_class_of_failure_reason = function
-  | Keeper_registry.Ambiguous_partial_commit
-      { kind = Keeper_registry.Post_commit_timeout; _ } ->
-      "ambiguous_post_commit_timeout"
-  | Keeper_registry.Ambiguous_partial_commit
-      { kind = Keeper_registry.Post_commit_failure; _ } ->
-      "ambiguous_post_commit_failure"
-  | _ -> "manual_reconcile_required"
-
 let classify_post_commit_failure
     ~(tool_names : string list)
     ?kind

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -14,7 +14,7 @@ let publish_broadcast (bus : Agent_sdk.Event_bus.t) ~agent_name ~content =
     ("content", `String content);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:broadcast", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:broadcast", payload)))
 
 (** Publish a heartbeat event to the shared Event_bus. *)
 let publish_heartbeat (bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_pct =
@@ -24,7 +24,7 @@ let publish_heartbeat (bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_p
     ("context_pct", `Float context_pct);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:heartbeat", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:heartbeat", payload)))
 
 (** Publish a board post event to the shared Event_bus. *)
 let publish_board_post (bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
@@ -33,7 +33,7 @@ let publish_board_post (bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
     ("post_id", `String post_id);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:board_post", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:board_post", payload)))
 
 (** Publish a task state change event to the shared Event_bus. *)
 let publish_task_transition (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~transition =
@@ -43,7 +43,7 @@ let publish_task_transition (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~
     ("transition", `String transition);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:task_transition", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:task_transition", payload)))
 
 (** Publish a heartbeat recovery event to the OAS Event_bus.
     Emitted when a previously timed-out agent re-activates. *)
@@ -53,7 +53,7 @@ let publish_heartbeat_recovered (bus : Agent_sdk.Event_bus.t) ~agent_name ~previ
     ("previous_timeout_s", `Float previous_timeout_s);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:heartbeat_recovered", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:heartbeat_recovered", payload)))
 
 (** {1 Autonomy Agent Lifecycle Events} *)
 
@@ -69,7 +69,7 @@ let publish_agent_selected (bus : Agent_sdk.Event_bus.t) ~agent_name ~trigger
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:autonomy:agent_selected", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_selected", payload)))
 
 (** Publish an agent action decision event (MODEL decision result).
     Emitted after MODEL decides post/comment/upvote/skip. *)
@@ -82,7 +82,7 @@ let publish_agent_decision (bus : Agent_sdk.Event_bus.t) ~agent_name ~action
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:autonomy:agent_decision", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_decision", payload)))
 
 (** Publish an action execution result event.
     Emitted after an agent's action (post/comment/upvote) completes. *)
@@ -95,7 +95,7 @@ let publish_agent_action_executed (bus : Agent_sdk.Event_bus.t) ~agent_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:autonomy:agent_action_executed", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_action_executed", payload)))
 
 (** {1 Keeper Snapshot Events} *)
 
@@ -111,7 +111,7 @@ let publish_keeper_snapshot (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:keeper:snapshot", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:keeper:snapshot", payload)))
 
 (** {1 Keeper Lifecycle Events} *)
 
@@ -126,7 +126,7 @@ let publish_keeper_lifecycle (bus : Agent_sdk.Event_bus.t) ~event ~keeper_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:keeper:lifecycle", payload)))
 
 (** {1 Phase 4: Social Events} *)
 
@@ -138,7 +138,7 @@ let publish_trust_updated (bus : Agent_sdk.Event_bus.t) ~agent_a ~agent_b ~trust
     ("trust_score", `Float trust_score);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:trust_updated", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:trust_updated", payload)))
 
 (** Publish a reputation change event. *)
 let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_score ~new_score ~trend =
@@ -149,7 +149,7 @@ let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_sc
     ("trend", `String trend);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:reputation_changed", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:reputation_changed", payload)))
 
 (** Publish an institution episode event. *)
 let publish_institution_episode (bus : Agent_sdk.Event_bus.t) ~episode_id ~event_type ~participants =
@@ -159,7 +159,7 @@ let publish_institution_episode (bus : Agent_sdk.Event_bus.t) ~episode_id ~event
     ("participant_count", `Int (List.length participants));
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:institution_episode", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:institution_episode", payload)))
 
 (** {1 Harness Observability Events (#3165)} *)
 
@@ -175,7 +175,7 @@ let publish_verdict_recorded (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:harness:verdict_recorded", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:harness:verdict_recorded", payload)))
 
 (** Publish a pre-compaction observation event.
     Emitted before [Context_compact_oas.compact] runs in keeper. *)
@@ -196,4 +196,4 @@ let publish_pre_compact (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:harness:pre_compact", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:harness:pre_compact", payload)))

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -60,8 +60,8 @@ let wrap_event ~ts ~event_type ~payload ?agent_name ?session_id ?worker_run_id
 let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t option =
   let ts = Time_compat.now () in
   match evt with
-  | Agent_sdk.Event_bus.AgentStarted
-      { agent_name; task_id; session_id; worker_run_id; _ } ->
+  | { Agent_sdk.Event_bus.payload = Agent_sdk.Event_bus.AgentStarted
+      { agent_name; task_id; session_id; worker_run_id; _ }; _ } ->
       let payload =
         `Assoc
           [
@@ -74,8 +74,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"agent_started" ~payload ~agent_name
            ~task_id ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.AgentCompleted
-      { agent_name; task_id; elapsed; session_id; worker_run_id; _ } ->
+  | { payload = Agent_sdk.Event_bus.AgentCompleted
+      { agent_name; task_id; elapsed; session_id; worker_run_id; _ }; _ } ->
       let payload =
         `Assoc
           [
@@ -89,8 +89,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"agent_completed" ~payload ~agent_name
            ~task_id ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.ToolCalled
-      { agent_name; tool_name; session_id; worker_run_id; _ } ->
+  | { payload = Agent_sdk.Event_bus.ToolCalled
+      { agent_name; tool_name; session_id; worker_run_id; _ }; _ } ->
       let payload =
         `Assoc
           [
@@ -103,8 +103,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"tool_called" ~payload ~agent_name
            ~tool_name ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.ToolCompleted
-      { agent_name; tool_name; session_id; worker_run_id; _ } ->
+  | { payload = Agent_sdk.Event_bus.ToolCompleted
+      { agent_name; tool_name; session_id; worker_run_id; _ }; _ } ->
       let payload =
         `Assoc
           [
@@ -117,8 +117,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"tool_completed" ~payload ~agent_name
            ~tool_name ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.TurnStarted
-      { agent_name; turn; session_id; worker_run_id; _ } ->
+  | { payload = Agent_sdk.Event_bus.TurnStarted
+      { agent_name; turn; session_id; worker_run_id; _ }; _ } ->
       let payload =
         `Assoc
           [
@@ -131,8 +131,8 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"turn_started" ~payload ~agent_name ~turn
            ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.TurnCompleted
-      { agent_name; turn; session_id; worker_run_id; _ } ->
+  | { payload = Agent_sdk.Event_bus.TurnCompleted
+      { agent_name; turn; session_id; worker_run_id; _ }; _ } ->
       let payload =
         `Assoc
           [
@@ -145,7 +145,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"turn_completed" ~payload ~agent_name ~turn
            ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.ContextCompacted
+  | { payload = Agent_sdk.Event_bus.ContextCompacted
       {
         agent_name;
         before_tokens;
@@ -153,7 +153,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         phase;
         session_id;
         worker_run_id;
-      } ->
+      }; _ } ->
       let payload =
         `Assoc
           [
@@ -168,7 +168,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
       Some
         (wrap_event ~ts ~event_type:"context_compacted" ~payload ~agent_name
            ?session_id ?worker_run_id ())
-  | Agent_sdk.Event_bus.TaskStateChanged { task_id; from_state; to_state } ->
+  | { payload = Agent_sdk.Event_bus.TaskStateChanged { task_id; from_state; to_state }; _ } ->
       let payload =
         `Assoc
           [
@@ -178,9 +178,9 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
           ]
       in
       Some (wrap_event ~ts ~event_type:"task_state_changed" ~payload ~task_id ())
-  | Agent_sdk.Event_bus.ElicitationCompleted _ ->
+  | { payload = Agent_sdk.Event_bus.ElicitationCompleted _; _ } ->
     None  (* Internal; no SSE relay needed *)
-  | Agent_sdk.Event_bus.Custom (name, payload) ->
+  | { payload = Agent_sdk.Event_bus.Custom (name, payload); _ } ->
       Some
         (wrap_event ~ts ~event_type:name ~payload
            ?agent_name:(payload_agent_name payload)

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -158,13 +158,14 @@ let resolve_provider_of_label (label : string) : Oas.Provider.config =
 
 let publish_lifecycle bus ~name ~event ~detail =
   Oas.Event_bus.publish bus
-    (Oas.Event_bus.Custom
-      (Printf.sprintf "masc:oas_worker:%s" event,
-       `Assoc [
-         ("agent", `String name);
-         ("detail", `String detail);
-         ("timestamp", `Float (Time_compat.now ()));
-       ]))
+    (Oas.Event_bus.mk_event
+      (Custom
+        (Printf.sprintf "masc:oas_worker:%s" event,
+         `Assoc [
+           ("agent", `String name);
+           ("detail", `String detail);
+           ("timestamp", `Float (Time_compat.now ()));
+         ])))
 
 (* ================================================================ *)
 (* Internal: checkpoint persistence                                  *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -33,7 +33,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   let keeper_lifecycle_sub =
     Agent_sdk.Event_bus.subscribe event_bus
       ~filter:(function
-        | Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", _) -> true
+        | { Agent_sdk.Event_bus.payload = Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", _); _ } -> true
         | _ -> false)
   in
   Eio.Fiber.fork ~sw (fun () ->
@@ -42,7 +42,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         let events = Agent_sdk.Event_bus.drain keeper_lifecycle_sub in
         List.iter
           (function
-            | Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", payload) ->
+            | { Agent_sdk.Event_bus.payload = Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", payload); _ } ->
                 (match
                    ( Safe_ops.json_string_opt "event" payload,
                      Safe_ops.json_string_opt "keeper_name" payload )

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.122.1"}
+  "agent_sdk" {>= "0.123.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.122.2"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.123.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="v0.122.2"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.122.1"
+readonly OAS_AGENT_SDK_SHA="v0.123.0"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.123.0"

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -37,7 +37,7 @@ let test_event_bus_broadcast () =
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match List.hd events with
-  | Event_bus.Custom ("masc:broadcast", payload) ->
+  | { Event_bus.payload = Event_bus.Custom ("masc:broadcast", payload); _ } ->
     let agent = Yojson.Safe.Util.(member "agent_name" payload |> to_string) in
     Alcotest.(check string) "agent name" "test-agent" agent
   | _ -> Alcotest.fail "expected Custom masc:broadcast event"
@@ -51,7 +51,7 @@ let test_event_bus_heartbeat () =
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match List.hd events with
-  | Event_bus.Custom ("masc:heartbeat", payload) ->
+  | { Event_bus.payload = Event_bus.Custom ("masc:heartbeat", payload); _ } ->
     let turn = Yojson.Safe.Util.(member "turn" payload |> to_int) in
     Alcotest.(check int) "turn" 5 turn
   | _ -> Alcotest.fail "expected Custom masc:heartbeat event"
@@ -66,7 +66,7 @@ let test_event_bus_task_transition () =
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
   match List.hd events with
-  | Event_bus.Custom ("masc:task_transition", payload) ->
+  | { Event_bus.payload = Event_bus.Custom ("masc:task_transition", payload); _ } ->
     let tid = Yojson.Safe.Util.(member "task_id" payload |> to_string) in
     Alcotest.(check string) "task id" "task-1" tid
   | _ -> Alcotest.fail "expected Custom masc:task_transition event"
@@ -85,14 +85,15 @@ let test_oas_sse_bridge_persists_native_events () =
         Eio.Switch.run (fun sw ->
           Oas_sse_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
           Event_bus.publish bus
-            (Event_bus.ToolCalled
-               {
-                 agent_name = "bridge-agent";
-                 tool_name = "masc_status";
-                 input = `Assoc [];
-                 session_id = Some "sess-bridge";
-                 worker_run_id = Some "run-bridge";
-               });
+            (Event_bus.mk_event
+               (ToolCalled
+                  {
+                    agent_name = "bridge-agent";
+                    tool_name = "masc_status";
+                    input = `Assoc [];
+                    session_id = Some "sess-bridge";
+                    worker_run_id = Some "run-bridge";
+                  }));
           Eio.Time.sleep (Eio.Stdenv.clock env) 2.2;
           let store =
             Dated_jsonl.create


### PR DESCRIPTION
## Summary
- Bump OAS pin from v0.122.2 to v0.123.0
- Update version floor in dune-project and opam

## Changes in OAS v0.123.0
- Ollama JSON parse errors classified as cascadeable (#849)
- Coding Plan concurrency raised 1→3 (#854)
- Cascade boundary analysis docs (#855)
- Pure FSM decision logic extraction (#856)
- Request body observability (#857)
- TLA+ spec for cascade FSM (#858)

## Test plan
- [ ] CI build passes with new pin
- [ ] opam install resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)