### PR TITLE
fix: remove dead blocker_class_of_failure_reason

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -136,15 +136,6 @@ let summarize_post_commit_failure
         tools
         err_preview
 
-let blocker_class_of_failure_reason = function
-  | Keeper_registry.Ambiguous_partial_commit
-      { kind = Keeper_registry.Post_commit_timeout; _ } ->
-      "ambiguous_post_commit_timeout"
-  | Keeper_registry.Ambiguous_partial_commit
-      { kind = Keeper_registry.Post_commit_failure; _ } ->
-      "ambiguous_post_commit_failure"
-  | _ -> "manual_reconcile_required"
-
 let classify_post_commit_failure
     ~(tool_names : string list)
     ?kind


### PR DESCRIPTION
## Summary
- Remove unused `blocker_class_of_failure_reason` function
- Callers removed in #6764 and #6711 but function definition remained
- Causes CI warning-32 failures on all branches

## Test plan
- [x] 9 lines deleted, no callers exist (`rg blocker_class` returns 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)