### PR TITLE
chore(oas): bump pin to v0.124.1 (intra-turn truncation + event envelope)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.123.0))
+  (agent_sdk (>= 0.124.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -14,7 +14,7 @@ let publish_broadcast (bus : Agent_sdk.Event_bus.t) ~agent_name ~content =
     ("content", `String content);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:broadcast", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:broadcast", payload)))
 
 (** Publish a heartbeat event to the shared Event_bus. *)
 let publish_heartbeat (bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_pct =
@@ -24,7 +24,7 @@ let publish_heartbeat (bus : Agent_sdk.Event_bus.t) ~agent_name ~turn ~context_p
     ("context_pct", `Float context_pct);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:heartbeat", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:heartbeat", payload)))
 
 (** Publish a board post event to the shared Event_bus. *)
 let publish_board_post (bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
@@ -33,7 +33,7 @@ let publish_board_post (bus : Agent_sdk.Event_bus.t) ~agent_name ~post_id =
     ("post_id", `String post_id);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:board_post", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:board_post", payload)))
 
 (** Publish a task state change event to the shared Event_bus. *)
 let publish_task_transition (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~transition =
@@ -43,7 +43,7 @@ let publish_task_transition (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id ~
     ("transition", `String transition);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:task_transition", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:task_transition", payload)))
 
 (** Publish a heartbeat recovery event to the OAS Event_bus.
     Emitted when a previously timed-out agent re-activates. *)
@@ -53,7 +53,7 @@ let publish_heartbeat_recovered (bus : Agent_sdk.Event_bus.t) ~agent_name ~previ
     ("previous_timeout_s", `Float previous_timeout_s);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:heartbeat_recovered", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:heartbeat_recovered", payload)))
 
 (** {1 Autonomy Agent Lifecycle Events} *)
 
@@ -69,7 +69,7 @@ let publish_agent_selected (bus : Agent_sdk.Event_bus.t) ~agent_name ~trigger
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:autonomy:agent_selected", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_selected", payload)))
 
 (** Publish an agent action decision event (MODEL decision result).
     Emitted after MODEL decides post/comment/upvote/skip. *)
@@ -82,7 +82,7 @@ let publish_agent_decision (bus : Agent_sdk.Event_bus.t) ~agent_name ~action
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:autonomy:agent_decision", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_decision", payload)))
 
 (** Publish an action execution result event.
     Emitted after an agent's action (post/comment/upvote) completes. *)
@@ -95,7 +95,7 @@ let publish_agent_action_executed (bus : Agent_sdk.Event_bus.t) ~agent_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:autonomy:agent_action_executed", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:autonomy:agent_action_executed", payload)))
 
 (** {1 Keeper Snapshot Events} *)
 
@@ -111,7 +111,7 @@ let publish_keeper_snapshot (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:keeper:snapshot", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:keeper:snapshot", payload)))
 
 (** {1 Keeper Lifecycle Events} *)
 
@@ -126,7 +126,7 @@ let publish_keeper_lifecycle (bus : Agent_sdk.Event_bus.t) ~event ~keeper_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:keeper:lifecycle", payload)))
 
 (** {1 Phase 4: Social Events} *)
 
@@ -138,7 +138,7 @@ let publish_trust_updated (bus : Agent_sdk.Event_bus.t) ~agent_a ~agent_b ~trust
     ("trust_score", `Float trust_score);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:trust_updated", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:trust_updated", payload)))
 
 (** Publish a reputation change event. *)
 let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_score ~new_score ~trend =
@@ -149,7 +149,7 @@ let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_sc
     ("trend", `String trend);
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:reputation_changed", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:reputation_changed", payload)))
 
 (** Publish an institution episode event. *)
 let publish_institution_episode (bus : Agent_sdk.Event_bus.t) ~episode_id ~event_type ~participants =
@@ -159,7 +159,7 @@ let publish_institution_episode (bus : Agent_sdk.Event_bus.t) ~episode_id ~event
     ("participant_count", `Int (List.length participants));
     ("timestamp", `Float (Time_compat.now ()));
   ] in
-  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:institution_episode", payload))
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.mk_event (Custom ("masc:institution_episode", payload)))
 
 (** {1 Harness Observability Events (#3165)} *)
 
@@ -175,7 +175,7 @@ let publish_verdict_recorded (bus : Agent_sdk.Event_bus.t) ~agent_name ~task_id
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:harness:verdict_recorded", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:harness:verdict_recorded", payload)))
 
 (** Publish a pre-compaction observation event.
     Emitted before [Context_compact_oas.compact] runs in keeper. *)
@@ -196,4 +196,4 @@ let publish_pre_compact (bus : Agent_sdk.Event_bus.t) ~keeper_name
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus
-    (Agent_sdk.Event_bus.Custom ("masc:harness:pre_compact", payload))
+    (Agent_sdk.Event_bus.mk_event (Custom ("masc:harness:pre_compact", payload)))

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -59,9 +59,11 @@ let wrap_event ~ts ~event_type ~payload ?agent_name ?session_id ?worker_run_id
 (** Serialize an OAS event to JSON for SSE relay + durable storage. *)
 let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t option =
   let ts = Time_compat.now () in
-  match evt with
+  let session_id = Some evt.meta.correlation_id in
+  let worker_run_id = Some evt.meta.run_id in
+  match evt.payload with
   | Agent_sdk.Event_bus.AgentStarted
-      { agent_name; task_id; session_id; worker_run_id; _ } ->
+      { agent_name; task_id } ->
       let payload =
         `Assoc
           [
@@ -75,7 +77,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         (wrap_event ~ts ~event_type:"agent_started" ~payload ~agent_name
            ~task_id ?session_id ?worker_run_id ())
   | Agent_sdk.Event_bus.AgentCompleted
-      { agent_name; task_id; elapsed; session_id; worker_run_id; _ } ->
+      { agent_name; task_id; elapsed; _ } ->
       let payload =
         `Assoc
           [
@@ -90,7 +92,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         (wrap_event ~ts ~event_type:"agent_completed" ~payload ~agent_name
            ~task_id ?session_id ?worker_run_id ())
   | Agent_sdk.Event_bus.ToolCalled
-      { agent_name; tool_name; session_id; worker_run_id; _ } ->
+      { agent_name; tool_name; _ } ->
       let payload =
         `Assoc
           [
@@ -104,7 +106,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         (wrap_event ~ts ~event_type:"tool_called" ~payload ~agent_name
            ~tool_name ?session_id ?worker_run_id ())
   | Agent_sdk.Event_bus.ToolCompleted
-      { agent_name; tool_name; session_id; worker_run_id; _ } ->
+      { agent_name; tool_name; _ } ->
       let payload =
         `Assoc
           [
@@ -118,7 +120,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         (wrap_event ~ts ~event_type:"tool_completed" ~payload ~agent_name
            ~tool_name ?session_id ?worker_run_id ())
   | Agent_sdk.Event_bus.TurnStarted
-      { agent_name; turn; session_id; worker_run_id; _ } ->
+      { agent_name; turn } ->
       let payload =
         `Assoc
           [
@@ -132,7 +134,7 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         (wrap_event ~ts ~event_type:"turn_started" ~payload ~agent_name ~turn
            ?session_id ?worker_run_id ())
   | Agent_sdk.Event_bus.TurnCompleted
-      { agent_name; turn; session_id; worker_run_id; _ } ->
+      { agent_name; turn } ->
       let payload =
         `Assoc
           [
@@ -151,8 +153,6 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
         before_tokens;
         after_tokens;
         phase;
-        session_id;
-        worker_run_id;
       } ->
       let payload =
         `Assoc

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -158,13 +158,14 @@ let resolve_provider_of_label (label : string) : Oas.Provider.config =
 
 let publish_lifecycle bus ~name ~event ~detail =
   Oas.Event_bus.publish bus
-    (Oas.Event_bus.Custom
-      (Printf.sprintf "masc:oas_worker:%s" event,
-       `Assoc [
-         ("agent", `String name);
-         ("detail", `String detail);
-         ("timestamp", `Float (Time_compat.now ()));
-       ]))
+    (Oas.Event_bus.mk_event
+      (Custom
+        (Printf.sprintf "masc:oas_worker:%s" event,
+         `Assoc [
+           ("agent", `String name);
+           ("detail", `String detail);
+           ("timestamp", `Float (Time_compat.now ()));
+         ])))
 
 (* ================================================================ *)
 (* Internal: checkpoint persistence                                  *)

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -32,7 +32,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   Oas_sse_bridge.start ~sw ~clock ~config:state.room_config ~bus:event_bus;
   let keeper_lifecycle_sub =
     Agent_sdk.Event_bus.subscribe event_bus
-      ~filter:(function
+      ~filter:(fun (evt : Agent_sdk.Event_bus.event) ->
+        match evt.payload with
         | Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", _) -> true
         | _ -> false)
   in
@@ -41,7 +42,8 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       (try
         let events = Agent_sdk.Event_bus.drain keeper_lifecycle_sub in
         List.iter
-          (function
+          (fun (evt : Agent_sdk.Event_bus.event) ->
+            match evt.payload with
             | Agent_sdk.Event_bus.Custom ("masc:keeper:lifecycle", payload) ->
                 (match
                    ( Safe_ops.json_string_opt "event" payload,

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.123.0"}
+  "agent_sdk" {>= "0.124.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.123.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.124.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="v0.123.0"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.123.0"
+readonly OAS_AGENT_SDK_SHA="v0.124.1"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.124.0"

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -36,11 +36,11 @@ let test_event_bus_broadcast () =
   Oas_events.publish_broadcast bus ~agent_name:"test-agent" ~content:"hello";
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
-  match List.hd events with
+  (match (List.hd events).payload with
   | Event_bus.Custom ("masc:broadcast", payload) ->
     let agent = Yojson.Safe.Util.(member "agent_name" payload |> to_string) in
     Alcotest.(check string) "agent name" "test-agent" agent
-  | _ -> Alcotest.fail "expected Custom masc:broadcast event"
+  | _ -> Alcotest.fail "expected Custom masc:broadcast event")
 
 let test_event_bus_heartbeat () =
   Eio_main.run @@ fun env ->
@@ -50,11 +50,11 @@ let test_event_bus_heartbeat () =
   Oas_events.publish_heartbeat bus ~agent_name:"keeper-runtime" ~turn:5 ~context_pct:0.42;
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
-  match List.hd events with
+  (match (List.hd events).payload with
   | Event_bus.Custom ("masc:heartbeat", payload) ->
     let turn = Yojson.Safe.Util.(member "turn" payload |> to_int) in
     Alcotest.(check int) "turn" 5 turn
-  | _ -> Alcotest.fail "expected Custom masc:heartbeat event"
+  | _ -> Alcotest.fail "expected Custom masc:heartbeat event")
 
 let test_event_bus_task_transition () =
   Eio_main.run @@ fun env ->
@@ -65,11 +65,11 @@ let test_event_bus_task_transition () =
     ~task_id:"task-1" ~transition:"done";
   let events = Event_bus.drain sub in
   Alcotest.(check int) "one event" 1 (List.length events);
-  match List.hd events with
+  (match (List.hd events).payload with
   | Event_bus.Custom ("masc:task_transition", payload) ->
     let tid = Yojson.Safe.Util.(member "task_id" payload |> to_string) in
     Alcotest.(check string) "task id" "task-1" tid
-  | _ -> Alcotest.fail "expected Custom masc:task_transition event"
+  | _ -> Alcotest.fail "expected Custom masc:task_transition event")
 
 let test_oas_sse_bridge_persists_native_events () =
   Eio_main.run @@ fun env ->
@@ -85,14 +85,15 @@ let test_oas_sse_bridge_persists_native_events () =
         Eio.Switch.run (fun sw ->
           Oas_sse_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
           Event_bus.publish bus
-            (Event_bus.ToolCalled
-               {
-                 agent_name = "bridge-agent";
-                 tool_name = "masc_status";
-                 input = `Assoc [];
-                 session_id = Some "sess-bridge";
-                 worker_run_id = Some "run-bridge";
-               });
+            (Event_bus.mk_event
+               ~correlation_id:"sess-bridge"
+               ~run_id:"run-bridge"
+               (ToolCalled
+                  {
+                    agent_name = "bridge-agent";
+                    tool_name = "masc_status";
+                    input = `Assoc [];
+                  }));
           Eio.Time.sleep (Eio.Stdenv.clock env) 2.2;
           let store =
             Dated_jsonl.create


### PR DESCRIPTION
## Summary

- Bump OAS agent_sdk pin from v0.122.2 to v0.124.1
- Migrate Event_bus API: flat variant → envelope record (`{meta; payload}`)
- Version floor: `agent_sdk >= 0.124.0`

## OAS changes picked up

1. **oas#861** — intra-turn truncation: when a single keeper turn exceeds the provider context budget (observed 276K tokens vs GLM 200K max), older tool-call/result rounds are dropped while preserving the preamble and ToolUse/ToolResult pairing
2. **oas#845** — Event_bus envelope: `session_id` → `correlation_id`, `worker_run_id` → `run_id`, wrapped in `{meta; payload}` record

## MASC migration

| File | Change |
|------|--------|
| `lib/oas_sse_bridge.ml` | Destructure `evt.payload` + extract meta fields |
| `lib/oas_events.ml` | 15x `publish` → `mk_event (Custom (...))` |
| `lib/oas_worker_exec.ml` | `publish_lifecycle` → `mk_event` |
| `lib/server/server_bootstrap_loops.ml` | Filter/drain lambdas �� `evt.payload` match |
| `test/test_oas_integration.ml` | Pattern match + ToolCalled publish migration |

## Test plan

- [x] `dune build` green
- [x] 8/9 tests pass (1 pre-existing flaky: SSE bridge env leak)
- [ ] CI green
- [ ] After rebuild + server restart: uranium666 context truncation effective, GLM/ollama 400 errors eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)