### PR TITLE
chore(oas): bump pin v0.124.0 → v0.124.1 (intra-turn truncation)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.124.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.124.1"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="v0.124.0"
+readonly OAS_AGENT_SDK_SHA="v0.124.1"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.124.0"


### PR DESCRIPTION
## Summary

Bump OAS pin from v0.124.0 to v0.124.1 to pick up oas#861 (intra-turn truncation).

## What it fixes

When a keeper turn accumulates many tool-call/result rounds, the single turn can exceed the provider's context window. The existing truncation preserves "at least the most recent turn" unchanged — when that turn is 310K tokens, no truncation happens.

v0.124.1 adds intra-turn truncation: groups messages into rounds (Assistant+ToolResult pairs), keeps the preamble + recent rounds within budget.

| Provider | Max Context | Before | After |
|----------|------------|--------|-------|
| GLM-5.1 | 200K | 310K sent → HTTP 400 | ~180K sent → fits |
| ollama 35b-a3b | 262K | 310K sent → HTTP 400 | ~235K sent → fits |

## Scope

1 file changed (pin script only). Event_bus migration already in #6777.

## Test plan

- [x] Local `dune build` green
- [ ] CI green
- [ ] After server restart: uranium666 truncation effective

🤖 Generated with [Claude Code](https://claude.com/claude-code)