### PR TITLE
fix(keeper): align CI test failures — config, prompt, Eio context

### DIFF
--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -10,7 +10,7 @@ Playground is your default sandbox, relative to the server `base_path`:
 - `.masc/playground/{your-name}/` — bundle root (general workspace)
 - `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
 - `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees are a separate workflow path under `.worktrees/<branch-or-task>/`, but in practice they must live *inside* your playground clone. The canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
+Repo worktrees live *inside* your playground clone — they are branch-specific working copies under `.worktrees/<branch-or-task>/`. The canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist, never use them):
 - `/repos/...`

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -711,7 +711,7 @@ let keeper_unified_max_tokens_rp =
     ~default:(fun () -> int_of_env_default "MASC_KEEPER_UNIFIED_MAX_TOKENS"
                           ~default:65536 ~min_v:256 ~max_v:262144)
     ~min_v:256 ~max_v:262144
-    ~description:"Keeper turn max output tokens (65536=OpenHands default)" ()
+    ~description:"Keeper turn max output tokens fallback (cascade.json overrides to 16384 in production)" ()
 let keeper_unified_max_tokens () : int =
   Runtime_params.get keeper_unified_max_tokens_rp
 

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -127,6 +127,7 @@ let test_masc_whitelist_blocks_traversal () =
 (* ── E2: Decision Audit ─────────────────────────────── *)
 
 let test_audit_ring_and_flag () =
+  Eio_main.run @@ fun _env ->
   (* Verify audit module is accessible and configured *)
   let cap = DA.ring_capacity () in
   check bool "ring capacity >= 1" true (cap >= 1);

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -150,6 +150,7 @@ let make_meta name =
   | Error err -> fail ("make_meta: " ^ err)
 
 let test_self_preservation_subset () =
+  Eio_main.run @@ fun _env ->
   Reg.clear ();
   let names = ["a"; "b"; "c"; "d"; "e"] in
   let entries = List.map (fun name ->

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -987,10 +987,11 @@ let test_unified_turn_runtime_defaults () =
   with_env "MASC_KEEPER_UNIFIED_MAX_TOKENS" "" (fun () ->
     check (float 0.01) "unified temp default" 0.4
       (KC.keeper_unified_temperature ());
-    (* This unit test does not run Runtime_params.restore, so an empty env var
-       falls back to the code-level default rather than config/cascade.json. *)
+    (* Runtime param default is 65536 (safe fallback).
+       In production, cascade.json overrides to 16384.
+       This test verifies the runtime default, not cascade-resolved value. *)
     check int "unified max_tokens default" 65536
-    (KC.keeper_unified_max_tokens ())
+      (KC.keeper_unified_max_tokens ())
     (* max_turns is set in keeper_agent_run.ml (default: 50) *)))
 
 let test_meta_defaults_social_model () =


### PR DESCRIPTION
## Summary

Fix 4 persistent CI test failures (re-creation of #6732 after GitHub sync issue).

### Changes (5 files, +8/-3):
1. `keeper_config.ml` — description documents cascade.json override (default stays 65536)
2. `test_keeper_unified.ml` — expect 65536 (runtime default), not 16384 (cascade-resolved)
3. `keeper.world.md` — canonical phrase "Repo worktrees live *inside* your playground clone"
4. `test_keeper_supervisor.ml` — `Eio_main.run` wrapper for Eio.Lazy.force
5. `test_decision_pipeline.ml` — `Eio_main.run` wrapper for Eio.Lazy.force

### Verification
- config[1]: pass locally
- unified_prompt[5]: pass locally
- self_preservation_properties[0]: pass locally
- decision_audit[0]: pass locally
- No new regressions in full test suites
- GLM-5.1 cross-model review: Approve

Closes #6700