### PR TITLE
fix(cascade): add default_api_key_env for GLM providers

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -19,5 +19,9 @@
   "local_only_temperature": 0.2,
   "local_only_max_tokens": 32768,
   "default_temperature": 0.3,
-  "default_max_tokens": 4096
+  "default_max_tokens": 4096,
+  "default_api_key_env": {
+    "glm-coding": "ZAI_API_KEY_SB",
+    "glm": "ZAI_API_KEY_SB"
+  }
 }


### PR DESCRIPTION
## Problem

After OAS pin bump to v0.124.1 (#6781), all GLM cascade calls fail with:
```
Auth error: Authentication parameter not received in Header, unable to authenticate
```

Root cause: `cascade_config_loader.resolve_api_key_env` reads API keys from env vars named in `cascade.json`'s `default_api_key_env` field. Without this field, no Authorization header is sent to GLM.

## Fix

Add `default_api_key_env` to `config/cascade.json`:
```json
"default_api_key_env": {
  "glm-coding": "ZAI_API_KEY_SB",
  "glm": "ZAI_API_KEY_SB"
}
```

`ZAI_API_KEY_SB` is the Coding Plan subscription key (in `~/.zshenv`).

## Scope

1 file, 5 lines. Config-only change.

## Test plan

- [x] JSON valid
- [ ] CI green
- [ ] After merge + server restart: GLM auth passes, cascade works with GLM as primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)