### PR TITLE
fix(test): align admission queue default 4→1 after #6768

### DIFF
--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -210,7 +210,7 @@ let test_set_max_concurrent_rejects_zero () =
   with Invalid_argument _ -> ()
 
 let test_initial_max_concurrent_default () =
-  check int "default" 4 (AQ.initial_max_concurrent_of_env (fun _ -> None))
+  check int "default" 1 (AQ.initial_max_concurrent_of_env (fun _ -> None))
 
 let test_initial_max_concurrent_prefers_masc_env () =
   let getenv = function
@@ -225,7 +225,7 @@ let test_initial_max_concurrent_ignores_ollama_parallel () =
     | "OLLAMA_NUM_PARALLEL" -> Some "1"
     | _ -> None
   in
-  check int "ollama env ignored" 4 (AQ.initial_max_concurrent_of_env getenv)
+  check int "ollama env ignored" 1 (AQ.initial_max_concurrent_of_env getenv)
 
 let test_initial_max_concurrent_clamps_min_one () =
   let getenv = function


### PR DESCRIPTION
## Summary
- Update test expectations to match #6768's default change (4→1)
- 2 assertions in test_admission_queue_coverage.ml

🤖 Generated with [Claude Code](https://claude.com/claude-code)