### PR TITLE
docs(rfc): RFC-MASC-001, MASC-004, MASC-005

### DIFF
--- a/docs/rfc/RFC-MASC-001-keeper-checkpoint-boundary-migration.md
+++ b/docs/rfc/RFC-MASC-001-keeper-checkpoint-boundary-migration.md
@@ -1,0 +1,229 @@
+# RFC-MASC-001: Keeper Checkpoint Boundary Migration
+
+**Status**: Draft
+**Date**: 2026-04-13
+**Scope**: `lib/keeper/`, `lib/board_core_payload.ml`, `lib/tool_board.ml`, `docs/OAS-MASC-BOUNDARY.md`
+**One sentence**: keeper `working_context` 중복 래퍼를 제거하고 `[STATE]...[/STATE]` text marker를 OAS Checkpoint 구조체로 치환하여, MASC-OAS 경계 violation의 P1(runtime state 이중 소유)과 P2(text marker 누출)를 해소한다.
+
+**Implementation**: 이 RFC의 구현은 **독립 세션/PR로 완전 격리**한다. 다른 RFC와 코드 공유 없음.
+
+## Related Documents
+
+- `docs/OAS-MASC-BOUNDARY.md` — violation 목록: P1(working_context 이중 소유), P2([STATE] text marker 누출)
+- `lib/keeper/keeper_context_core.ml` — `working_context` 타입, checkpoint 생성/복원
+- `lib/keeper/keeper_types.ml` — `working_context = { system_prompt; messages; max_tokens; context }`
+- `lib/board_core_payload.ml` (lines 8-39) — `[STATE]...[/STATE]` 블록 추출
+- `lib/tool_board.ml` (lines 14-41) — `strip_state_blocks_text`
+- OAS `lib/checkpoint.ml` — Checkpoint.t (v4, 23+ fields), delta operations
+- OAS `lib/agent/agent.mli` — `Agent.resume`, `Agent.checkpoint`
+- `feedback_context-identity-on-resume.md` — Agent.resume에 shared_context 전달 필수
+- `feedback_masc-must-use-oas-agent-run.md` — 에이전트 생명주기 자체 재구현 금지
+- `feedback_no-lifecycle-invasion-from-masc.md` — OAS lifecycle/retry/budget/state machine 재구현 금지
+- `feedback_use-oas-context-injector.md` — OAS context_injector 파이프라인 사용 필수
+
+## Problem Statement
+
+### P1: working_context 이중 소유 (Boundary Violation)
+
+MASC keeper는 OAS `Context.t`와 `Checkpoint.t`를 직접 사용하면서도, **자체 `working_context` 래퍼**로 이를 감싸고 있다:
+
+```ocaml
+type working_context = {
+  system_prompt : string;         (* OAS Context.t에도 존재 *)
+  messages : Agent_sdk.Types.message list; (* OAS Checkpoint.t에도 존재 *)
+  max_tokens : int;               (* OAS agent_config에도 존재 *)
+  context : Agent_sdk.Context.t;  (* OAS의 것을 그대로 보유 *)
+}
+```
+
+이 래퍼가 14개 파일(35곳)에서 참조된다. 문제:
+
+1. **상태 불일치**: `working_context.messages`와 `Checkpoint.t.messages`가 동기화되지 않을 수 있다. `sync_oas_context`를 호출해야 하지만 호출 누락 시 silent drift.
+2. **OAS API 회피**: `working_context.system_prompt`를 직접 수정하면 OAS hook chain이 bypass됨.
+3. **Checkpoint 이중 직렬화**: keeper가 자체 checkpoint를 만들면서 OAS checkpoint도 별도로 생성. 디스크에 동일 데이터가 두 번 저장.
+
+### P2: [STATE] Text Marker 누출
+
+keeper는 turn 간 continuity를 위해 `[STATE]...[/STATE]` 텍스트 블록을 LLM 응답에 삽입/추출한다:
+
+```
+[STATE]
+keeper_phase: working
+current_task: PK-12345
+memory_summary: ...
+[/STATE]
+```
+
+이 marker가 12개 파일(35곳)에 분포:
+
+| 파일 | 용도 |
+|------|------|
+| `board_core_payload.ml` | board post에서 [STATE] 추출 후 metadata 저장 |
+| `keeper_context_core.ml` | checkpoint 패칭 시 [STATE] 블록 삽입 |
+| `keeper_agent_run.ml` | [STATE] 합성 + checkpoint 패칭 |
+| `keeper_unified_prompt.ml` | prompt 구성 시 [STATE] 규칙 명시 |
+| `keeper_turn.ml` | output guard에서 [STATE] 규칙 |
+| `keeper_text_processing.ml` | 블록 추출 헬퍼 |
+| `tool_board.ml` | board 저장 전 [STATE] strip |
+| `keeper_exec_memory.ml` | [STATE] 블록 핸들링 |
+| `keeper_handoff_delta.ml` | 핸드오프 시 [STATE] 스냅샷 문서 |
+| `keeper_memory_policy.ml` | 정책 마커 |
+| `keeper_prompt.ml` | prompt emission 규칙 |
+| `keeper_schema.ml` | 스키마 문서 |
+
+문제:
+
+1. **LLM context 오염**: [STATE] 블록이 LLM에게 보이면 LLM이 이를 모방하거나 조작할 수 있다.
+2. **Board 데이터 오염**: strip하지 않으면 board post에 [STATE]가 노출.
+3. **구조화되지 않은 데이터**: 텍스트 파싱에 의존하므로 포맷 변경 시 파서 깨짐. OAS Checkpoint의 structured field로 대체하면 타입 안전.
+
+## Design
+
+### Principle: OAS Checkpoint is the Single Source of Truth
+
+keeper의 turn-to-turn state는 **OAS `Checkpoint.t`의 구조화된 필드에만** 저장한다. `working_context` 래퍼와 `[STATE]` 텍스트는 제거한다.
+
+### Part A: working_context 제거
+
+```
+[현재]
+keeper_context_core.ml
+  └── working_context { system_prompt, messages, max_tokens, context }
+        ↕ sync_oas_context()
+        OAS Context.t / Checkpoint.t
+
+[목표]
+keeper가 OAS Checkpoint.t / Context.t를 직접 사용
+  - system_prompt → Agent.config.system_prompt
+  - messages → Checkpoint.t.messages
+  - max_tokens → Agent.config.max_tokens
+  - context → Context.t (직접 참조)
+```
+
+Migration:
+1. `working_context` 타입을 thin wrapper로 축소: `{ checkpoint: Checkpoint.t; context: Context.t }`
+2. 14개 파일에서 `wc.system_prompt` → `Checkpoint.system_prompt wc.checkpoint` 등으로 전환
+3. 최종적으로 thin wrapper도 제거하고 직접 참조
+
+### Part B: [STATE] → Checkpoint.working_context (structured)
+
+OAS `Checkpoint.t`에는 이미 `working_context: Yojson.Safe.t` 필드가 있다 (line 38). 현재 keeper가 이 필드에 텍스트 블록을 저장하는 대신, **structured JSON**을 저장한다:
+
+```ocaml
+(* 현재: text marker *)
+"[STATE]\nkeeper_phase: working\ncurrent_task: PK-12345\n[/STATE]"
+
+(* 목표: structured JSON in Checkpoint.working_context *)
+{
+  "keeper_phase": "working",
+  "current_task": "PK-12345",
+  "memory_summary_hash": "abc123",
+  "continuity_hints": ["last_tool: git_commit", "pending: review"]
+}
+```
+
+이렇게 하면:
+- LLM에게 [STATE] 텍스트가 보이지 않음
+- 타입 안전한 파싱 (JSON schema)
+- Board post에서 strip 불필요 (텍스트가 아니므로)
+
+### Part C: Board Payload Migration
+
+`board_core_payload.ml`의 [STATE] 추출 로직:
+
+```ocaml
+(* 현재: 텍스트에서 [STATE] 블록을 regex로 추출 *)
+let extract_state_block text = ...
+
+(* 목표: Checkpoint.working_context에서 직접 읽기 *)
+let extract_state checkpoint =
+  checkpoint.Checkpoint.working_context
+  |> Option.bind (fun wc -> Yojson.Safe.Util.member "keeper_phase" wc)
+```
+
+### Part D: Prompt 규칙 변경
+
+`keeper_unified_prompt.ml`에서 "[STATE] 블록으로 상태를 보고하세요" 규칙을 제거하고, 대신 structured tool call이나 OAS hook을 통해 상태를 수집한다.
+
+LLM이 자유텍스트로 상태를 보고하는 것 자체를 폐지하고, keeper의 상태는 **코드 로직으로만** 결정한다 (deterministic boundary).
+
+## Verification
+
+### 완료 기준
+
+```bash
+# 1. [STATE] marker 완전 제거
+rg '\[STATE\]' lib/ | wc -l
+# Expected: 0
+
+# 2. working_context 래퍼 제거 (thin wrapper 이후 최종)
+rg 'type working_context' lib/keeper/ | wc -l
+# Expected: 0
+
+# 3. Checkpoint.working_context structured 사용 확인
+rg 'working_context.*Yojson\|working_context.*json' lib/keeper/ | wc -l
+# Expected: >= 3
+
+# 4. OAS-MASC-BOUNDARY.md P1, P2 해소
+rg 'VIOLATION\|Partial complete.*working_context\|text marker' docs/OAS-MASC-BOUNDARY.md
+# Expected: "Resolved" 또는 해당 항목 제거
+
+# 5. Keeper resume 후 identity 일관성
+# Integration test: checkpoint save → resume → session_id equality
+```
+
+### 테스트
+
+- **Checkpoint round-trip**: structured working_context를 checkpoint에 저장 → resume → 동일 값 복원
+- **Board 클린**: board post에 [STATE] 잔재 없음 (기존 strip 로직 제거 후에도)
+- **LLM context 클린**: LLM에게 전달되는 messages에 [STATE] 없음
+- **Regression**: 기존 keeper 시나리오에서 turn continuity 동등성
+- **OAS identity**: `Agent.resume` 후 `checkpoint.session_id` identity equality (`feedback_context-identity-on-resume.md`)
+
+## Implementation Phases
+
+**모든 Phase는 독립 세션에서 수행. 다른 RFC PR과 merge 순서 무관.**
+
+### Phase 1: Structured working_context (1 PR)
+- Checkpoint.working_context에 structured JSON 저장하는 경로 추가
+- [STATE] 텍스트 → JSON 변환 함수
+- 기존 [STATE] 경로와 병행 (feature flag `MASC_STRUCTURED_STATE=true`)
+
+### Phase 2: [STATE] 제거 — prompt/text_processing (1 PR)
+- `keeper_unified_prompt.ml`에서 [STATE] 규칙 제거
+- `keeper_text_processing.ml`에서 블록 추출 헬퍼 deprecate
+- `keeper_turn.ml` output guard 규칙 변경
+
+### Phase 3: [STATE] 제거 — board/context (1 PR)
+- `board_core_payload.ml` [STATE] 추출 → Checkpoint.working_context 직접 읽기
+- `tool_board.ml` `strip_state_blocks_text` 제거
+- `keeper_context_core.ml` [STATE] 패칭 제거
+
+### Phase 4: working_context 래퍼 축소 (1 PR)
+- `working_context` → thin wrapper `{ checkpoint; context }`
+- 14개 파일에서 접근 패턴 변경
+- `sync_oas_context` 제거 (직접 참조이므로 sync 불필요)
+
+### Phase 5: Thin Wrapper 제거 + 정리 (1 PR)
+- `working_context` 타입 자체 삭제
+- Checkpoint.t / Context.t 직접 사용
+- `docs/OAS-MASC-BOUNDARY.md` P1, P2 "Resolved" 업데이트
+- Feature flag 제거
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| 14개 파일 동시 수정으로 blast radius 큼 | 5 Phase로 분할. 각 Phase는 1 PR, 독립 테스트 |
+| [STATE] 제거 후 keeper continuity 품질 저하 | Phase 1에서 structured JSON이 [STATE]와 동등한 정보를 담는지 검증 후 Phase 2 진행 |
+| OAS Checkpoint.working_context 필드가 변경되면 | OAS Issue #484 Epic과 조율. Checkpoint v4 → v5 migration 필요 시 같이 처리 |
+| Board 기존 데이터에 [STATE]가 남아있음 | 읽기 시 [STATE] 텍스트와 structured JSON 둘 다 파싱 (하위호환) |
+| LLM이 [STATE] 없이 상태를 유지하지 못함 | 상태를 LLM에게 의존하지 않는 설계 (deterministic boundary). keeper 코드가 상태 관리 |
+
+## Scope Exclusion
+
+- Memory bridge hook-first (RFC-MASC-004 범위)
+- OAS Checkpoint 타입 변경 (OAS 측 변경은 최소화, `working_context: Yojson.Safe.t` 이미 존재)
+- Team-session bridge fidelity (OAS-MASC-BOUNDARY P3, 별도 RFC)
+- Dashboard eval 표출 (RFC-MASC-005 범위)
+- Keeper 11-state lifecycle 변경 (이 RFC는 state 저장 방식만 변경, lifecycle 자체는 건드리지 않음)

--- a/docs/rfc/RFC-MASC-001-keeper-checkpoint-boundary-migration.md
+++ b/docs/rfc/RFC-MASC-001-keeper-checkpoint-boundary-migration.md
@@ -147,6 +147,8 @@ let extract_state checkpoint =
 
 LLM이 자유텍스트로 상태를 보고하는 것 자체를 폐지하고, keeper의 상태는 **코드 로직으로만** 결정한다 (deterministic boundary).
 
+**주의**: 현재 11-state lifecycle의 일부 전이가 `[STATE]` 블록 내용에 의존하는지 Phase 1 전에 반드시 확인해야 한다. 만약 LLM이 `[STATE]` 블록으로 `keeper_phase`를 보고하고 이것이 state transition trigger로 사용된다면, 해당 전이 경로를 코드 기반(tool call result, turn outcome, 외부 이벤트)으로 먼저 전환해야 한다. 이 경우 Phase 0(전이 경로 감사)을 추가한다.
+
 ## Verification
 
 ### 완료 기준
@@ -182,7 +184,12 @@ rg 'VIOLATION\|Partial complete.*working_context\|text marker' docs/OAS-MASC-BOU
 
 ## Implementation Phases
 
-**모든 Phase는 독립 세션에서 수행. 다른 RFC PR과 merge 순서 무관.**
+**모든 Phase는 독립 세션에서 수행. `keeper_agent_run.ml` 수정이 RFC-MASC-004와 겹치므로 merge 순서 조율 필요.**
+
+### Phase 0: 전이 경로 감사 (코드 아님, 1일)
+- `rg 'keeper_phase\|state.*transition\|[STATE].*phase' lib/keeper/` 전수 확인
+- 11-state lifecycle 중 [STATE] 텍스트에 의존하는 전이 경로 목록 작성
+- 의존하는 경로가 있으면 code-based trigger 전환 방안 추가 (Phase 1 전제 조건)
 
 ### Phase 1: Structured working_context (1 PR)
 - Checkpoint.working_context에 structured JSON 저장하는 경로 추가
@@ -219,6 +226,9 @@ rg 'VIOLATION\|Partial complete.*working_context\|text marker' docs/OAS-MASC-BOU
 | OAS Checkpoint.working_context 필드가 변경되면 | OAS Issue #484 Epic과 조율. Checkpoint v4 → v5 migration 필요 시 같이 처리 |
 | Board 기존 데이터에 [STATE]가 남아있음 | 읽기 시 [STATE] 텍스트와 structured JSON 둘 다 파싱 (하위호환) |
 | LLM이 [STATE] 없이 상태를 유지하지 못함 | 상태를 LLM에게 의존하지 않는 설계 (deterministic boundary). keeper 코드가 상태 관리 |
+| [STATE] 제거 시 11-state lifecycle 전이가 깨짐 | Phase 0에서 전이 경로 감사. LLM 텍스트 기반 전이가 있으면 code-based trigger로 먼저 전환 |
+| Concurrent keeper가 같은 Checkpoint.working_context에 쓰면 last-writer-wins | Checkpoint는 session 단위로 격리(session_id별 파일). 동일 session에 복수 keeper가 쓰는 경우는 MASC task claim CAS로 방지. 추가 보호: checkpoint write 시 base_hash 검증(OAS delta protocol) |
+| Phase 1 dual-source (텍스트+JSON) 충돌 | Feature flag ON 시 structured JSON이 primary, [STATE] 텍스트는 read-only fallback. 쓰기는 JSON만 |
 
 ## Scope Exclusion
 

--- a/docs/rfc/RFC-MASC-004-memory-bridge-hook-first.md
+++ b/docs/rfc/RFC-MASC-004-memory-bridge-hook-first.md
@@ -1,0 +1,196 @@
+# RFC-MASC-004: Memory Bridge Hook-First Migration
+
+**Status**: Draft
+**Date**: 2026-04-13
+**Scope**: `lib/memory_oas_bridge.ml`, `lib/keeper/keeper_agent_run.ml`
+**One sentence**: `memory_oas_bridge.ml`의 imperative seeding 5개 함수를 OAS `BeforeTurnParams` hook 경유로 전환하여 MASC↔OAS 경계 violation을 제거하고, keeper_agent_run.ml의 명시적 호출 의존성을 끊는다.
+
+## Related Documents
+
+- `lib/memory_oas_bridge.ml` (679줄) — 현재 imperative seeding/flushing 어댑터
+- `lib/keeper/keeper_agent_run.ml` (~line 1385, ~1518) — seeding/flushing call site
+- `docs/OAS-MASC-BOUNDARY.md` (lines 68, 72-78) — "Acceptable but lossy" 평가, P4 우선순위
+- OAS `lib/hooks.mli` — `BeforeTurnParams`, `AfterTurn` hook events
+- OAS `lib/context.ml` — Context.t, context injection pipeline
+- `feedback_use-oas-context-injector.md` — OAS context_injector 파이프라인 사용 필수
+- `feedback_no-lifecycle-invasion-from-masc.md` — OAS lifecycle 재구현 금지
+- RFC-MASC-001 — Keeper Checkpoint Boundary Migration (선행 권장이나 병행 가능)
+
+## Problem Statement
+
+### 현재 구조: Imperative Seeding
+
+```
+keeper_agent_run.ml (line ~1385)
+  └── memory_oas_bridge.create_memory_full()
+        ├── seed_episodes()        → OAS Episodic tier에 직접 push
+        ├── seed_procedures_as_oas() → OAS Procedural tier에 직접 push
+        ├── seed_institution()     → Long_term에 JSON 직접 저장
+        └── (optional) seed_all_procedures_as_oas()
+
+keeper_agent_run.ml (line ~1518, turn 종료 후)
+  └── memory_oas_bridge.flush_all()
+        ├── flush episodes → JSONL
+        └── flush procedures → JSONL
+```
+
+문제:
+
+1. **OAS lifecycle invasion**: MASC가 OAS의 context/memory를 직접 조작한다. OAS 관점에서 이 seeding은 "외부에서 나도 모르게 context가 변경되는" 상황.
+2. **Hook 우회**: OAS는 `BeforeTurnParams`에서 context injection을 제공한다. MASC가 이를 무시하고 직접 push하면 OAS의 context flow invariant가 깨짐.
+3. **순서 의존성**: `create_memory_full()`이 `Agent.run()` 직전에 호출되어야 한다. 호출 순서가 바뀌면 silent failure.
+4. **테스트 불가**: imperative seeding은 OAS agent 테스트에서 mock하기 어려움. Hook이면 OAS harness에서 자연스럽게 테스트 가능.
+5. **Flushing 누락 위험**: agent가 crash로 종료하면 `flush_all()`이 호출되지 않아 memory 유실.
+
+### Boundary Violation 카운트
+
+`docs/OAS-MASC-BOUNDARY.md` 기준:
+- Memory bridge imperative seeding → **P4** (현재)
+- 이 RFC 완료 후 → P4 해소, violation count -1
+
+## Design
+
+### Principle: Hook-Mediated, Not Direct-Push
+
+MASC는 OAS hook을 통해 memory를 주입한다. OAS가 제공하는 `BeforeTurnParams` hook에서 context를 조정하고, `AfterTurn` hook에서 flush를 수행한다.
+
+### Architecture: Before vs After
+
+```
+[현재] MASC → direct push → OAS memory tiers
+[목표] MASC → hook registration → OAS invokes hook → MASC provides memory
+```
+
+### Part A: Hook Registration
+
+keeper가 OAS agent를 생성할 때 hook을 등록한다:
+
+```ocaml
+(* keeper_hooks_oas.ml에서 *)
+
+let memory_hooks ~bridge =
+  let before_turn_params = fun event ->
+    (* OAS가 turn 시작 전 호출 *)
+    let episodes = Memory_oas_bridge.load_episodes bridge in
+    let procedures = Memory_oas_bridge.load_procedures bridge in
+    (* AdjustParams로 context에 memory 주입 *)
+    AdjustParams {
+      event with
+      context = Context.inject_memory event.context
+        ~episodes ~procedures
+    }
+  in
+  let after_turn = fun event ->
+    (* OAS가 turn 완료 후 호출 *)
+    Memory_oas_bridge.flush_incremental bridge event.response;
+    Continue
+  in
+  Hooks.{ before_turn_params; after_turn; ... }
+```
+
+### Part B: memory_oas_bridge.ml 리팩토링
+
+현재 679줄의 `memory_oas_bridge.ml`에서:
+
+| 현재 함수 | 전환 후 | 호출 주체 |
+|-----------|---------|----------|
+| `create_memory_full` | 삭제. 개별 load 함수로 분해 | OAS hook |
+| `seed_episodes` | `load_episodes` (순수 읽기, push 없음) | OAS hook |
+| `seed_procedures_as_oas` | `load_procedures` (순수 읽기) | OAS hook |
+| `seed_institution` | `load_institution` (순수 읽기) | OAS hook |
+| `flush_all` | `flush_incremental` (turn 단위) | OAS hook |
+| 캐시 로직 (file_stamp) | 유지. 내부 최적화 | 변경 없음 |
+
+핵심 변경: **push 함수(side effect) → load 함수(pure read) + OAS가 주입**.
+
+### Part C: Flush 안전성 개선
+
+현재 `flush_all()`은 agent 종료 후 1회 호출. Crash 시 유실.
+
+Hook-first 전환 후:
+- `AfterTurn` hook에서 **매 turn 종료마다** incremental flush
+- OAS의 `Eio.Switch.on_release`에서 final flush (crash safety)
+- JSONL append-only이므로 중복 flush는 idempotent
+
+### Part D: Migration Path
+
+```
+Phase 1: Hook adapter 추가 (기존 imperative 경로와 병행)
+  ├── memory_hooks.ml 생성
+  ├── keeper_hooks_oas.ml에 memory hook 등록
+  └── 기존 create_memory_full/flush_all 유지 (fallback)
+
+Phase 2: 기존 imperative 경로 제거
+  ├── keeper_agent_run.ml에서 create_memory_full 호출 삭제
+  ├── keeper_agent_run.ml에서 flush_all 호출 삭제
+  └── memory_oas_bridge.ml에서 seed_* 함수 deprecate
+
+Phase 3: Dead code 정리
+  ├── seed_episodes, seed_procedures_as_oas, seed_institution 삭제
+  ├── create_memory_full 삭제
+  └── flush_all → flush_incremental로 완전 전환
+```
+
+## Verification
+
+### 완료 기준
+
+```bash
+# 1. Imperative seeding call site 제거 확인
+rg 'create_memory_full\|seed_episodes\|seed_procedures_as_oas\|seed_institution' lib/keeper/ | wc -l
+# Expected: 0
+
+# 2. flush_all call site 제거 확인
+rg 'flush_all' lib/keeper/ | wc -l
+# Expected: 0
+
+# 3. Hook registration 확인
+rg 'memory_hooks\|before_turn_params.*memory\|after_turn.*flush' lib/keeper/ | wc -l
+# Expected: >= 2
+
+# 4. OAS-MASC-BOUNDARY.md 업데이트
+rg 'Imperative seeding' docs/OAS-MASC-BOUNDARY.md
+# Expected: "Resolved" 또는 해당 항목 제거
+```
+
+### 테스트
+
+- Unit test: `load_episodes`/`load_procedures` 순수성 검증 (side effect 없음)
+- Integration test: mock OAS agent에 memory hook 등록 → turn 실행 → memory 주입 확인
+- Crash test: agent turn 중 cancel → JSONL에 이전 turn 데이터 보존 확인
+- Regression: 기존 keeper 시나리오에서 memory 정확도 동등성 확인
+
+## Implementation Phases
+
+### Phase 1: Hook Adapter (병행 운영, 1 PR)
+- `memory_hooks.ml` 생성 (hook registration)
+- `memory_oas_bridge.ml`에 `load_*` pure read 함수 추가
+- `keeper_hooks_oas.ml`에서 hook 등록 통합
+- Feature flag: `MASC_MEMORY_HOOK_FIRST=true` (기본 false)
+
+### Phase 2: Imperative 경로 제거 (1 PR)
+- `MASC_MEMORY_HOOK_FIRST` 기본 true
+- `keeper_agent_run.ml`에서 `create_memory_full`/`flush_all` 호출 제거
+- `docs/OAS-MASC-BOUNDARY.md` P4 항목 업데이트
+
+### Phase 3: Dead Code 정리 (1 PR)
+- `MASC_MEMORY_HOOK_FIRST` flag 제거
+- `seed_*` 함수 삭제, `create_memory_full` 삭제
+- `memory_oas_bridge.ml` 크기 목표: 679줄 → ~400줄
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Hook 순서가 memory seeding 시점과 맞지 않음 | OAS `BeforeTurnParams`는 turn 시작 직전이므로 현재 `create_memory_full` 호출 시점과 동등 |
+| Incremental flush가 JSONL 파일을 과도하게 open/close | Append-only + buffered write. 매 turn이 아닌 dirty flag 기반 |
+| RFC-MASC-001과의 충돌 | MASC-001은 working_context/[STATE] 경계, 이 RFC는 memory bridge. 파일 겹침은 `keeper_agent_run.ml`만. 병행 가능하되 merge 순서 주의 |
+| 캐시 무효화 로직이 hook context에서 동작하지 않음 | file_stamp 로직은 memory_oas_bridge 내부. hook은 load 결과만 소비하므로 캐시는 투명 |
+
+## Scope Exclusion
+
+- OAS hooks.ml 변경 (OAS 측 hook은 이미 충분)
+- working_context 제거 (RFC-MASC-001 범위)
+- [STATE] text marker 제거 (RFC-MASC-001 범위)
+- 5-tier memory 모델 자체의 재설계 (Long_term/Episodic/Procedural 구조 유지)
+- PG backend 추가 (filesystem-first 원칙 유지)

--- a/docs/rfc/RFC-MASC-004-memory-bridge-hook-first.md
+++ b/docs/rfc/RFC-MASC-004-memory-bridge-hook-first.md
@@ -182,7 +182,7 @@ rg 'Imperative seeding' docs/OAS-MASC-BOUNDARY.md
 
 | Risk | Mitigation |
 |------|------------|
-| Hook 순서가 memory seeding 시점과 맞지 않음 | OAS `BeforeTurnParams`는 turn 시작 직전이므로 현재 `create_memory_full` 호출 시점과 동등 |
+| Hook 순서가 memory seeding 시점과 맞지 않음 | Phase 1에서 trace-level 검증 필수: (1) `BeforeTurnParams` hook이 context 구성 이전/이후 어느 시점에 호출되는지 OAS 코드에서 확인, (2) hook에서 주입한 memory가 downstream hook(safety filter 등)에 보이는지 확인. 동등성이 증명되지 않으면 OAS에 hook 순서 보장 API 요청 |
 | Incremental flush가 JSONL 파일을 과도하게 open/close | Append-only + buffered write. 매 turn이 아닌 dirty flag 기반 |
 | RFC-MASC-001과의 충돌 | MASC-001은 working_context/[STATE] 경계, 이 RFC는 memory bridge. 파일 겹침은 `keeper_agent_run.ml`만. 병행 가능하되 merge 순서 주의 |
 | 캐시 무효화 로직이 hook context에서 동작하지 않음 | file_stamp 로직은 memory_oas_bridge 내부. hook은 load 결과만 소비하므로 캐시는 투명 |

--- a/docs/rfc/RFC-MASC-005-dashboard-oas-eval-consumer.md
+++ b/docs/rfc/RFC-MASC-005-dashboard-oas-eval-consumer.md
@@ -1,0 +1,169 @@
+# RFC-MASC-005: Dashboard as OAS Eval Consumer
+
+**Status**: Draft
+**Date**: 2026-04-13
+**Scope**: `lib/dashboard/`, `lib/server_dashboard_http.ml`
+**One sentence**: MASC dashboard가 자체 eval store를 만들지 않고 OAS의 `raw_trace.ml`, `harness.ml`, `eval_baseline.ml` 결과를 read-only로 소비하여, keeper 실행 품질을 관측 가능하게 한다.
+
+## Related Documents
+
+- RFC-OAS-002 (OTel Metric Naming & Eval Feed Schema) — `oas.*` metric + swiss_verdict JSON schema. **이 RFC의 전제**.
+- `lib/dashboard/dashboard_harness_health.ml` — 현재 harness health 집계 (evaluator stale 탐지)
+- `lib/dashboard/dashboard_http_keeper_detail.ml` — keeper 상세 페이지 (trace_id 파싱 존재)
+- `lib/dashboard/dashboard_http_keeper_metrics.ml` — keeper 24h 메트릭 버킷
+- OAS `lib/raw_trace.ml` — JSONL trace format (v1, 6 record types)
+- OAS `lib/harness.ml` — swiss_verdict, verdict
+- OAS `lib/eval.ml` — run_metrics, metric_value
+- OAS `docs/schemas/swiss-verdict.schema.json` (RFC-OAS-002에서 생성 예정)
+- `feedback_tailwind-only-dashboard.md` — Tailwind utility만 사용
+- `feedback_dashboard-observation-focus.md` — 설명 최소화, 핵심은 누가/어디서/뭘/왜
+- `feedback_masc-oas-layer-boundary.md` — MASC는 추상 신호만, OAS가 raw 인프라 소유
+
+## Problem Statement
+
+### 현재 상태
+
+MASC dashboard는 keeper 실행 메트릭(turn count, tool calls, duration)을 자체 수집하지만, **OAS 수준의 eval 메트릭은 전혀 표시하지 않는다**:
+
+- Swiss cheese verdict (layer별 passed/failed, coverage)
+- Eval baseline regression (Improved/Regressed/Unchanged)
+- Raw trace 기반 tool 정확도, turn 효율성
+- OTel metric 시계열
+
+`dashboard_harness_health.ml`이 evaluator stale 탐지는 하지만, 실제 verdict 내용을 파싱하거나 표시하지 않는다.
+
+### 왜 자체 eval store를 만들지 않는가
+
+1. **MASC-OAS Layer Boundary** (`feedback_masc-oas-layer-boundary.md`): OAS가 eval 인프라를 소유. MASC가 eval store를 별도로 만들면 동기화 문제 + 이중 진실 원천.
+2. **OAS가 이미 제공**: `raw_trace.ml` JSONL + `harness.ml` verdict + `eval.ml` run_metrics. Consumer가 파싱만 하면 된다.
+3. **Dashboard observation focus** (`feedback_dashboard-observation-focus.md`): dashboard는 관찰 도구. 데이터 생성은 OAS 책임.
+
+## Design
+
+### Architecture: Read-Only Consumer
+
+```
+OAS (data producer)              MASC Dashboard (consumer)
+─────────────────                ─────────────────────────
+raw_trace.ml → JSONL files   →  dashboard reads JSONL
+harness.ml → swiss_verdict   →  dashboard parses JSON schema
+eval.ml → run_metrics        →  dashboard renders metrics
+otel_tracer → oas.* metrics  →  dashboard queries OTel endpoint
+```
+
+MASC dashboard는 **읽기만** 한다. 쓰기/수정/변환은 하지 않는다.
+
+### Part A: Eval Feed Reader Module
+
+```ocaml
+(* dashboard_eval_feed.ml — 신규 *)
+
+type eval_snapshot = {
+  agent_name: string;
+  session_id: string option;
+  worker_run_id: string;
+  timestamp: float;
+  verdict: swiss_verdict_json;    (** RFC-OAS-002 schema v1 *)
+  coverage: float;
+  baseline_status: string option; (** "Improved" | "Regressed" | "Unchanged" *)
+}
+
+val read_latest : base_path:string -> agent_name:string -> limit:int -> eval_snapshot list
+(** OAS raw_trace JSONL + eval output 디렉토리에서 최근 N개 eval snapshot 읽기.
+    파일 탐색 경로: <base_path>/.oas/traces/<agent_name>/*.jsonl
+                    <base_path>/.oas/eval/<agent_name>/*.json *)
+
+val read_verdict_json : Yojson.Safe.t -> (swiss_verdict_json, string) result
+(** RFC-OAS-002 swiss-verdict.schema.json v1 파싱.
+    schema_version != 1이면 Error. *)
+```
+
+### Part B: Dashboard HTTP Routes
+
+`server_dashboard_http.ml`에 eval 관련 route 추가:
+
+| Route | Method | Response |
+|-------|--------|----------|
+| `/api/v1/dashboard/eval/:agent_name` | GET | 최근 eval snapshot list (JSON) |
+| `/api/v1/dashboard/eval/:agent_name/latest` | GET | 가장 최근 1건 |
+| `/api/v1/dashboard/eval/:agent_name/trend` | GET | 최근 24h coverage trend |
+
+모든 route는 read-only. 캐시: `dashboard_cache.ml`의 기존 캐시 인프라 활용 (TTL 60s).
+
+### Part C: Dashboard UI (Tailwind-only)
+
+Keeper detail 페이지에 eval 섹션 추가:
+
+```
+┌─── Eval Quality ──────────────────────────────────┐
+│ Coverage: ████████░░ 0.82  [Improved ↑]           │
+│                                                    │
+│ Layer Results:                                     │
+│  ✓ ToolSelected    0.95  "correct tool chosen"     │
+│  ✓ CompletesWithin 1.00  "3/5 turns"              │
+│  ✗ ContainsText    0.00  "missing expected output" │
+│                                                    │
+│ Trend (24h): 0.78 → 0.82 (+5.1%)                  │
+└────────────────────────────────────────────────────┘
+```
+
+원칙:
+- Tailwind utility만 사용 (`feedback_tailwind-only-dashboard.md`)
+- 설명 최소화, 숫자 중심 (`feedback_dashboard-observation-focus.md`)
+- 영한혼용 금지
+
+### Part D: OTel Metric 시계열 (선택적)
+
+RFC-OAS-002의 `oas.*` metric이 OTel endpoint에 emit되면, dashboard가 이를 쿼리하여 시계열 그래프를 렌더링할 수 있다. 단, OTel collector가 MASC 환경에 배포되어 있어야 함.
+
+현재 MASC는 OTel collector를 내장하지 않으므로 이 기능은 **optional**:
+- OTel endpoint 설정이 있으면 시계열 표시
+- 없으면 JSONL 기반 snapshot만 표시
+
+## Implementation Phases
+
+### Phase 1: Eval Feed Reader (1 PR)
+- `dashboard_eval_feed.ml` 생성
+- Swiss verdict JSON 파서 (RFC-OAS-002 schema v1 기준)
+- Unit test: 샘플 JSONL/JSON 파싱 검증
+
+### Phase 2: HTTP Routes (1 PR)
+- `/api/v1/dashboard/eval/:agent_name` 3개 route
+- `dashboard_cache.ml` 통합
+- Integration test: mock eval data → route 응답 검증
+
+### Phase 3: Dashboard UI (1 PR)
+- Keeper detail 페이지에 eval 섹션 추가
+- Tailwind-only 렌더링
+- Coverage trend 24h 그래프 (SVG inline 또는 CSS bar)
+
+### Phase 4: OTel 시계열 (선택적, 1 PR)
+- OTel endpoint 설정 탐지
+- Metric query + 시계열 렌더링
+- 설정 없으면 graceful skip
+
+## Dependencies
+
+| 의존 대상 | 상태 | 차단 여부 |
+|-----------|------|----------|
+| RFC-OAS-002 (swiss_verdict JSON schema) | Draft | Phase 1 차단: schema 확정 필요 |
+| RFC-OAS-002 (OTel `oas.*` metric naming) | Draft | Phase 4 차단 (Phase 1-3은 비차단) |
+| OAS raw_trace JSONL 경로 convention | 구현됨 | 비차단 |
+| Issue #484 (Delta-Context Epic) | Open | 비차단 (checkpoint replay는 이 RFC 범위 밖) |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| OAS eval output 경로가 변경되면 dashboard 깨짐 | Path convention을 config로 외부화. 기본값은 `.oas/` 하위 |
+| Swiss verdict schema v1이 빠르게 v2로 변경 | `schema_version` 필드 체크. v2 추가 시 v1 파서 유지 (하위호환) |
+| Eval data가 없는 keeper (eval 미실행) | "No eval data" 표시. Empty state UI 처리 |
+| JSONL 파일이 커서 읽기 느림 | `limit` 파라미터로 최근 N건만. tail -N 방식 읽기 |
+
+## Scope Exclusion
+
+- Eval data 생성/수정 (OAS 책임)
+- OTel collector 배포 (인프라 별도)
+- Eval 기반 자동 keeper 조정 (관측만, 제어 없음)
+- Board/team-session eval 집계 (keeper 단위만)
+- Swiss verdict 외 커스텀 eval format 지원


### PR DESCRIPTION
## Summary

- **RFC-MASC-001**: keeper checkpoint boundary migration — working_context 래퍼 + [STATE] text marker 제거 (독립 세션 격리)
- **RFC-MASC-004**: memory bridge hook-first — imperative seeding → OAS BeforeTurnParams/AfterTurn hook 전환
- **RFC-MASC-005**: dashboard as OAS eval consumer — swiss_verdict + OTel metric read-only 소비

## RFC Files

- `docs/rfc/RFC-MASC-001-keeper-checkpoint-boundary-migration.md` → #6771
- `docs/rfc/RFC-MASC-004-memory-bridge-hook-first.md` → #6769
- `docs/rfc/RFC-MASC-005-dashboard-oas-eval-consumer.md` → #6770

## Test plan

- [ ] RFC 내용 검토
- [ ] 교차 모델 리뷰 (GLM-5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)