### PR TITLE
fix(admission): make admission queue passthrough — cascade handles throttling

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -64,10 +64,10 @@ let initial_max_concurrent_of_env getenv =
   match parse_int "MASC_ADMISSION_MAX_CONCURRENT" with
   | Some n -> max 1 n
   | None ->
-      (* Default 1: Ollama MLX decode is serial regardless of
-         OLLAMA_NUM_PARALLEL (prefill pipelining, not decode).
-         Override with MASC_ADMISSION_MAX_CONCURRENT for multi-GPU. *)
-      1
+      (* Default 3: with_permit is now passthrough (provider throttle
+         belongs in OAS cascade, not MASC).  This value is only used
+         for snapshot reporting; it does not gate anything. *)
+      3
 
 let global : t = {
   max_slots = initial_max_concurrent_of_env Sys.getenv_opt;
@@ -79,7 +79,7 @@ let global : t = {
 let now_ts () = Unix.gettimeofday ()
 let wait_ms_since enqueue_ts = int_of_float ((now_ts () -. enqueue_ts) *. 1000.0)
 
-let rec acquire ?wait_timeout_sec ~priority ~keeper_name ~cascade_name t =
+let rec _acquire ?wait_timeout_sec ~priority ~keeper_name ~cascade_name t =
   let resolved = Llm_provider.Request_priority.resolve priority in
   let rank = Llm_provider.Request_priority.to_int resolved in
   let action =
@@ -114,7 +114,7 @@ let rec acquire ?wait_timeout_sec ~priority ~keeper_name ~cascade_name t =
       (* If release already resolved our promise, the slot was handed
          to us but we are being cancelled. Release it back. *)
       if Eio.Promise.is_resolved p then
-        release_slot t;
+        _release_slot t;
       raise exn
     in
     (try
@@ -136,7 +136,7 @@ let rec acquire ?wait_timeout_sec ~priority ~keeper_name ~cascade_name t =
      | exn ->
          cancel_wait exn)
 
-and release_slot t =
+and _release_slot t =
   let to_wake =
     Eio.Mutex.use_rw ~protect:true t.mutex (fun () ->
       let rec find_valid acc = function
@@ -160,31 +160,16 @@ and release_slot t =
 
 (* ── Public API ────────────────────────────────────────── *)
 
-let with_permit ?wait_timeout_sec ~priority ~keeper_name ~cascade_name f =
-  acquire ?wait_timeout_sec ~priority ~keeper_name ~cascade_name global;
-  Fun.protect f
-    ~finally:(fun () ->
-      Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
-      release_slot global)
+let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name:_ ~cascade_name:_ f =
+  (* Passthrough: provider-level throttling belongs in OAS (cascade),
+     not in MASC.  The cascade distributes requests across providers
+     and handles 429/timeout by falling to the next provider.
+     Gating here starves cloud-routed keepers behind a serial local
+     decode and cannot express per-provider capacity. *)
+  f ()
 
-let try_with_permit ~priority ~keeper_name ~cascade_name f =
-  let _resolved = Llm_provider.Request_priority.resolve priority in
-  let got =
-    Eio.Mutex.use_rw ~protect:true global.mutex (fun () ->
-      if global.active < global.max_slots then (
-        global.active <- global.active + 1;
-        true
-      ) else
-        false)
-  in
-  if got then (
-    Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
-    Some (Fun.protect f
-      ~finally:(fun () ->
-        Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
-        release_slot global)))
-  else
-    None
+let try_with_permit ~priority:_ ~keeper_name:_ ~cascade_name:_ f =
+  Some (f ())
 
 let snapshot () =
   Eio.Mutex.use_ro global.mutex (fun () ->

--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -1,100 +1,46 @@
 (** Admission Queue Coverage Tests
 
-    Tests for MASC inference admission queue:
-    - Basic acquire/release
-    - Concurrency limit enforcement
-    - Priority ordering
-    - Cancel safety
-    - Exception safety
-    - Snapshot accuracy
-    - try_with_permit behavior
-    - set_max_concurrent validation
-*)
+    Tests for MASC inference admission queue (passthrough mode).
+    Provider-level throttling is handled by OAS cascade, not MASC.
+    These tests verify the passthrough contract: with_permit and
+    try_with_permit always run the callback immediately. *)
 
 open Alcotest
 
 module AQ = Masc_mcp.Admission_queue
 
 (* ============================================================
-   Basic Tests
+   Passthrough Contract
    ============================================================ *)
 
 let test_with_permit_runs () =
   Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:4;
     let result = AQ.with_permit ~priority:Interactive
       ~keeper_name:"test" ~cascade_name:"test" (fun () -> 42) in
     check int "runs and returns" 42 result)
 
-let test_with_permit_releases_on_exception () =
+let test_with_permit_propagates_exception () =
   Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:4;
     (try AQ.with_permit ~priority:Interactive
        ~keeper_name:"test" ~cascade_name:"test"
        (fun () -> failwith "boom")
-     with Failure _ -> ());
-    let s = AQ.snapshot () in
-    check int "active after exception" 0 s.active)
+     with Failure msg -> check string "exception propagates" "boom" msg))
 
-let test_snapshot_empty () =
+let test_try_always_succeeds () =
   Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:4;
-    let s = AQ.snapshot () in
-    check int "max_concurrent" 4 s.max_concurrent;
-    check int "active" 0 s.active;
-    check int "available" 4 s.available;
-    check int "queue_depth" 0 s.queue_depth)
-
-let test_snapshot_during_permit () =
-  Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:2;
-    AQ.with_permit ~priority:Interactive
-      ~keeper_name:"test" ~cascade_name:"test"
-      (fun () ->
-        let s = AQ.snapshot () in
-        check int "active" 1 s.active;
-        check int "available" 1 s.available))
-
-(* ============================================================
-   try_with_permit Tests
-   ============================================================ *)
-
-let test_try_succeeds_when_available () =
-  Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:2;
     let result = AQ.try_with_permit ~priority:Interactive
       ~keeper_name:"test" ~cascade_name:"test" (fun () -> 42) in
-    check (option int) "succeeds" (Some 42) result)
+    check (option int) "always Some" (Some 42) result)
 
-let test_try_returns_none_when_full () =
+let test_concurrent_all_run () =
   Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:1;
-    AQ.with_permit ~priority:Interactive
-      ~keeper_name:"holder" ~cascade_name:"test"
-      (fun () ->
-        let result = AQ.try_with_permit ~priority:Background
-          ~keeper_name:"waiter" ~cascade_name:"test"
-          (fun () -> 99) in
-        check (option int) "returns None" None result))
-
-(* ============================================================
-   Concurrency Limit Tests
-   ============================================================ *)
-
-let test_concurrency_limit () =
-  Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:2;
-    let max_seen = Atomic.make 0 in
-    let current = Atomic.make 0 in
+    let count = Atomic.make 0 in
     let run_one name =
       AQ.with_permit ~priority:Proactive
         ~keeper_name:name ~cascade_name:"test"
         (fun () ->
-          let c = Atomic.fetch_and_add current 1 + 1 in
-          let prev = Atomic.get max_seen in
-          if c > prev then Atomic.set max_seen c;
-          Eio.Fiber.yield ();
-          ignore (Atomic.fetch_and_add current (-1)))
+          ignore (Atomic.fetch_and_add count 1);
+          Eio.Fiber.yield ())
     in
     Eio.Fiber.all [
       (fun () -> run_one "k1");
@@ -102,120 +48,18 @@ let test_concurrency_limit () =
       (fun () -> run_one "k3");
       (fun () -> run_one "k4");
     ];
-    let max_concurrent = Atomic.get max_seen in
-    check bool "max concurrent <= 2" true (max_concurrent <= 2))
+    check int "all 4 ran" 4 (Atomic.get count))
 
 (* ============================================================
-   Priority Ordering Tests
+   Configuration (env parsing still works)
    ============================================================ *)
-
-let test_priority_ordering () =
-  Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:1;
-    let order = ref [] in
-    let hold, release_hold = Eio.Promise.create () in
-    Eio.Fiber.both
-      (fun () ->
-        AQ.with_permit ~priority:Background
-          ~keeper_name:"blocker" ~cascade_name:"test"
-          (fun () -> Eio.Promise.await hold))
-      (fun () ->
-        Eio.Fiber.both
-          (fun () ->
-            Eio.Fiber.both
-              (fun () ->
-                Eio.Fiber.yield ();
-                AQ.with_permit ~priority:Background
-                  ~keeper_name:"bg" ~cascade_name:"test"
-                  (fun () -> order := "bg" :: !order))
-              (fun () ->
-                Eio.Fiber.yield ();
-                AQ.with_permit ~priority:Interactive
-                  ~keeper_name:"int" ~cascade_name:"test"
-                  (fun () -> order := "int" :: !order)))
-          (fun () ->
-            Eio.Fiber.yield ();
-            Eio.Fiber.yield ();
-            Eio.Fiber.yield ();
-            Eio.Promise.resolve release_hold ()));
-    check (list string) "interactive first"
-      ["bg"; "int"] !order)
-
-(* ============================================================
-   Cancel Safety Tests
-   ============================================================ *)
-
-let test_cancel_no_leak () =
-  Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:1;
-    let hold, release_hold = Eio.Promise.create () in
-    Eio.Fiber.both
-      (fun () ->
-        AQ.with_permit ~priority:Interactive
-          ~keeper_name:"blocker" ~cascade_name:"test"
-          (fun () -> Eio.Promise.await hold))
-      (fun () ->
-        Eio.Fiber.both
-          (fun () ->
-            Eio.Fiber.yield ();
-            (try AQ.with_permit ~priority:Background
-               ~keeper_name:"cancelled" ~cascade_name:"test"
-               (fun () -> ())
-             with Eio.Cancel.Cancelled _ -> ()))
-          (fun () ->
-            Eio.Fiber.yield ();
-            Eio.Fiber.yield ();
-            Eio.Promise.resolve release_hold ()));
-    let s = AQ.snapshot () in
-    check int "no leaked slots" 0 s.active)
-
-let test_wait_timeout_no_leak () =
-  Eio_main.run (fun env ->
-    AQ.reset_for_test ~max_slots:1;
-    Eio_context.set_clock (Eio.Stdenv.clock env);
-    let hold, release_hold = Eio.Promise.create () in
-    let timeout_seen = ref None in
-    Eio.Fiber.both
-      (fun () ->
-        AQ.with_permit ~priority:Interactive
-          ~keeper_name:"blocker" ~cascade_name:"test"
-          (fun () -> Eio.Promise.await hold))
-      (fun () ->
-        Eio.Fiber.yield ();
-        (try
-           AQ.with_permit ~wait_timeout_sec:0.01 ~priority:Background
-             ~keeper_name:"timed-out" ~cascade_name:"test"
-             (fun () -> ())
-         with AQ.Wait_timeout wait_ms ->
-           timeout_seen := Some wait_ms);
-        Eio.Promise.resolve release_hold ());
-    check bool "wait timeout raised" true (Option.is_some !timeout_seen);
-    let s = AQ.snapshot () in
-    check int "no leaked slots" 0 s.active;
-    check int "queue cleared" 0 s.queue_depth)
-
-(* ============================================================
-   Configuration Tests
-   ============================================================ *)
-
-let test_set_max_concurrent () =
-  Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:4;
-    AQ.set_max_concurrent 8;
-    check int "updated" 8 (AQ.max_concurrent ());
-    AQ.set_max_concurrent 4)
-
-let test_set_max_concurrent_rejects_zero () =
-  try AQ.set_max_concurrent 0; fail "should raise"
-  with Invalid_argument _ -> ()
 
 let test_initial_max_concurrent_default () =
-  check int "default" 1 (AQ.initial_max_concurrent_of_env (fun _ -> None))
+  check int "default" 3 (AQ.initial_max_concurrent_of_env (fun _ -> None))
 
 let test_initial_max_concurrent_prefers_masc_env () =
   let getenv = function
     | "MASC_ADMISSION_MAX_CONCURRENT" -> Some "8"
-    | "OLLAMA_NUM_PARALLEL" -> Some "1"
     | _ -> None
   in
   check int "uses explicit MASC env" 8 (AQ.initial_max_concurrent_of_env getenv)
@@ -225,7 +69,7 @@ let test_initial_max_concurrent_ignores_ollama_parallel () =
     | "OLLAMA_NUM_PARALLEL" -> Some "1"
     | _ -> None
   in
-  check int "ollama env ignored" 1 (AQ.initial_max_concurrent_of_env getenv)
+  check int "ollama env ignored" 3 (AQ.initial_max_concurrent_of_env getenv)
 
 let test_initial_max_concurrent_clamps_min_one () =
   let getenv = function
@@ -236,7 +80,6 @@ let test_initial_max_concurrent_clamps_min_one () =
 
 let test_snapshot_json_shape () =
   Eio_main.run (fun _env ->
-    AQ.reset_for_test ~max_slots:4;
     let json = AQ.snapshot_json () in
     match json with
     | `Assoc fields ->
@@ -254,29 +97,13 @@ let test_snapshot_json_shape () =
 
 let () =
   run "Admission_queue" [
-    "basic", [
+    "passthrough", [
       test_case "with_permit runs" `Quick test_with_permit_runs;
-      test_case "releases on exception" `Quick test_with_permit_releases_on_exception;
-      test_case "snapshot empty" `Quick test_snapshot_empty;
-      test_case "snapshot during permit" `Quick test_snapshot_during_permit;
-    ];
-    "try_with_permit", [
-      test_case "succeeds when available" `Quick test_try_succeeds_when_available;
-      test_case "returns None when full" `Quick test_try_returns_none_when_full;
-    ];
-    "concurrency", [
-      test_case "enforces limit" `Quick test_concurrency_limit;
-    ];
-    "priority", [
-      test_case "ordering" `Quick test_priority_ordering;
-    ];
-    "cancel", [
-      test_case "no slot leak" `Quick test_cancel_no_leak;
-      test_case "wait timeout no leak" `Quick test_wait_timeout_no_leak;
+      test_case "propagates exception" `Quick test_with_permit_propagates_exception;
+      test_case "try always succeeds" `Quick test_try_always_succeeds;
+      test_case "concurrent all run" `Quick test_concurrent_all_run;
     ];
     "config", [
-      test_case "set_max_concurrent" `Quick test_set_max_concurrent;
-      test_case "rejects zero" `Quick test_set_max_concurrent_rejects_zero;
       test_case "initial default" `Quick test_initial_max_concurrent_default;
       test_case "initial prefers masc env" `Quick
         test_initial_max_concurrent_prefers_masc_env;


### PR DESCRIPTION
## Summary
- `with_permit` and `try_with_permit` now run the callback immediately (passthrough)
- Provider-level throttling belongs in OAS cascade, not MASC
- -226/+38 lines

## Problem
Admission queue `max_slots=1` starved 6/7 keepers. They waited 60s for a semaphore slot, then skipped their turn. The queue cannot express per-provider capacity (GLM cloud=3, Ollama local=1 are different).

## Why passthrough
- Providers enforce their own rate limits (429)
- OAS cascade handles 429 by falling to next provider
- MASC guessing provider capacity is a boundary violation
- The cascade IS the distribution mechanism

## Test plan
- [x] 9 passthrough contract tests pass
- [ ] CI build + full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)