### PR TITLE
chore(oas): bump pin v0.124.1 → v0.124.2 (GLM auth fix)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.124.1"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.124.2"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="v0.124.1"
+readonly OAS_AGENT_SDK_SHA="v0.124.2"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.124.0"


### PR DESCRIPTION
## Summary

Bump OAS pin to v0.124.2. Picks up oas#867 — fixes GLM auth failure where `config_of_provider_config` put the resolved API key value into `api_key_env` (env var name field), causing `Sys.getenv "aa9f..."` → None → no Authorization header.

## Test plan

- [x] Local build green
- [ ] CI green  
- [ ] GLM auth passes after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)