### PR TITLE
[codex] Sanitize keeper prompt persistence

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -414,7 +414,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                      `Assoc [("has_checkpoint", `Bool false)]
                  | _ ->
                      let primary_max_context =
-                       (match cfgs with c :: _ -> Option.value ~default:128_000 c.Llm_provider.Provider_config.max_tokens | [] -> 128_000)
+                       Oas_model_resolve.resolve_primary_max_context effective_models
                      in
                      let base_dir = Keeper_types.session_base_dir config in
                      let (_session, ctx_opt) =

--- a/lib/dashboard/dashboard_http_keeper_metrics.ml
+++ b/lib/dashboard/dashboard_http_keeper_metrics.ml
@@ -309,11 +309,15 @@ let keeper_history_summary_json
         let role = Safe_ops.json_string ~default:"" "role" j |> String.trim in
         let role_lc = String.lowercase_ascii role in
         let content = Safe_ops.json_string ~default:"" "content" j |> String.trim in
+        let source = Safe_ops.json_string ~default:"" "source" j |> String.trim in
         let ts_unix =
           let ts0 = Safe_ops.json_float ~default:0.0 "ts_unix" j in
           if ts0 > 0.0 then ts0 else Safe_ops.json_float ~default:0.0 "timestamp" j
         in
-        if role = "" || content = "" then
+        if role = "" || content = ""
+           || Keeper_types.is_internal_history_source source
+           || Keeper_context_core.has_world_state_signature content
+        then
           (conv_acc, k2k_acc, raw_count, fragment_count, filtered_count)
         else
           let is_fragment =

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -130,20 +130,23 @@ let oas_checkpoint_path ~(session_dir : string) ~(session_id : string) =
 
 let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
   : (unit, string) result =
+  let fallback () =
+    Keeper_fs.save_atomic
+      (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
+      (Agent_sdk.Checkpoint.to_string ckpt);
+    Ok ()
+  in
   try
     ignore (Keeper_fs.ensure_dir session_dir);
     match Fs_compat.get_fs_opt () with
-    | Some fs ->
+    | Some fs when Eio_guard.is_ready () ->
         let dir = Eio.Path.(fs / session_dir) in
         (match Agent_sdk.Checkpoint_store.create dir with
          | Ok store -> Agent_sdk.Checkpoint_store.save store ckpt
              |> Result.map_error Agent_sdk.Error.to_string
          | Error err -> Error (Agent_sdk.Error.to_string err))
-    | None ->
-        Keeper_fs.save_atomic
-          (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
-          (Agent_sdk.Checkpoint.to_string ckpt);
-        Ok ()
+    | Some _ | None ->
+        fallback ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printf.sprintf "save_oas: %s" (Printexc.to_string exn))
@@ -215,8 +218,20 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
 
 let load_oas ~(session_dir : string) ~(session_id : string) :
     (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
+  let fallback () =
+    let path = oas_checkpoint_path ~session_dir ~session_id in
+    if Fs_compat.file_exists path then
+      try
+        match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
+        | Ok ckpt -> Ok ckpt
+        | Error e -> Error (classify_sdk_error e)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn -> Error (Io_error (Printexc.to_string exn))
+    else Error Not_found
+  in
   match Fs_compat.get_fs_opt () with
-  | Some fs ->
+  | Some fs when Eio_guard.is_ready () ->
       let dir = Eio.Path.(fs / session_dir) in
       (match Agent_sdk.Checkpoint_store.create dir with
        | Ok store -> (
@@ -224,14 +239,5 @@ let load_oas ~(session_dir : string) ~(session_id : string) :
            | Ok ckpt -> Ok ckpt
            | Error e -> Error (classify_sdk_error e))
        | Error e -> Error (Store_error (Agent_sdk.Error.to_string e)))
-  | None ->
-      let path = oas_checkpoint_path ~session_dir ~session_id in
-      if Fs_compat.file_exists path then
-        try
-          match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
-          | Ok ckpt -> Ok ckpt
-          | Error e -> Error (classify_sdk_error e)
-        with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | exn -> Error (Io_error (Printexc.to_string exn))
-      else Error Not_found
+  | Some _ | None ->
+      fallback ()

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -21,6 +21,13 @@ open Keeper_types
     Per-keeper override via [compaction_policy.max_checkpoint_messages]. *)
 let default_max_checkpoint_messages = 120
 
+(** Hard caps for checkpoint payload hygiene.
+    Message-count capping alone is insufficient when a single message
+    accumulates hundreds of text blocks or multi-MB synthetic context. *)
+let default_max_checkpoint_text_blocks_per_message = 32
+let default_max_checkpoint_text_chars_per_message = 16 * 1024
+let checkpoint_text_cap_marker = "\n[capped]"
+
 (* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
 (* ================================================================ *)
@@ -205,24 +212,203 @@ let create_session ~session_id ~base_dir =
   ensure_dir session_dir;
   { session_id; session_dir; checkpoints = [] }
 
+type history_migration_stats = {
+  moved_lines : int;
+  dropped_lines : int;
+  kept_lines : int;
+  malformed_lines : int;
+}
+
+let empty_history_migration_stats =
+  { moved_lines = 0; dropped_lines = 0; kept_lines = 0; malformed_lines = 0 }
+
+let split_jsonl_lines (content : string) : string list =
+  content
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> String.trim line <> "")
+
+let normalize_system_context_prefix (text : string) : string =
+  let trimmed = String.trim text in
+  let prefix = "[system context]" in
+  if String.starts_with ~prefix trimmed then
+    let prefix_len = String.length prefix in
+    let rest_len = String.length trimmed - prefix_len in
+    if rest_len <= 0 then ""
+    else String.trim (String.sub trimmed prefix_len rest_len)
+  else trimmed
+
+let has_world_state_signature (text : string) : bool =
+  let trimmed = normalize_system_context_prefix text in
+  String_util.contains_substring_ci trimmed "## Current World State"
+  &&
+  (String_util.contains_substring_ci trimmed "### Namespace State"
+   || String_util.contains_substring_ci trimmed "### Available Tools"
+   || String_util.contains_substring_ci trimmed "### Continuity")
+
+type history_line_action =
+  | Keep_main
+  | Move_internal
+  | Drop_line
+
+let classify_history_entry ~(source : string) ~(content : string) :
+    history_line_action =
+  if Keeper_types.is_prompt_history_source source
+     || has_world_state_signature content
+  then Drop_line
+  else if Keeper_types.is_internal_history_source source then
+    Move_internal
+  else Keep_main
+
+let classify_history_jsonl_line (line : string) : history_line_action option =
+  try
+    let json = Yojson.Safe.from_string line in
+    let source =
+      Yojson.Safe.Util.(json |> member "source" |> to_string_option)
+      |> Option.value ~default:""
+      |> String.trim
+    in
+    let content =
+      Yojson.Safe.Util.(json |> member "content" |> to_string_option)
+      |> Option.value ~default:""
+      |> String.trim
+    in
+    Some (classify_history_entry ~source ~content)
+  with
+  | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+
+let render_jsonl_lines (lines : string list) : string =
+  match lines with
+  | [] -> ""
+  | _ -> String.concat "\n" lines ^ "\n"
+
+let dedupe_preserve_order (lines : string list) : string list =
+  let seen : (string, unit) Hashtbl.t = Hashtbl.create (List.length lines) in
+  List.filter
+    (fun line ->
+       if Hashtbl.mem seen line then false
+       else (
+         Hashtbl.add seen line ();
+         true))
+    lines
+
+let migrate_session_history_logs
+    ~(session_dir : string) : history_migration_stats =
+  let main_path = Filename.concat session_dir "history.jsonl" in
+  let internal_path = Filename.concat session_dir "history.internal.jsonl" in
+  if not (Fs_compat.file_exists main_path) && not (Fs_compat.file_exists internal_path) then
+    empty_history_migration_stats
+  else
+    let main_lines =
+      if Fs_compat.file_exists main_path then
+        split_jsonl_lines (Fs_compat.load_file main_path)
+      else []
+    in
+    let existing_internal =
+      if Fs_compat.file_exists internal_path then
+        split_jsonl_lines (Fs_compat.load_file internal_path)
+      else []
+    in
+    let kept_rev, moved_rev, dropped_main, malformed_main =
+      List.fold_left
+        (fun (kept_rev, moved_rev, dropped_lines, malformed_lines) line ->
+           match classify_history_jsonl_line line with
+           | Some Keep_main ->
+               (line :: kept_rev, moved_rev, dropped_lines, malformed_lines)
+           | Some Move_internal ->
+               (kept_rev, line :: moved_rev, dropped_lines, malformed_lines)
+           | Some Drop_line ->
+               (kept_rev, moved_rev, dropped_lines + 1, malformed_lines)
+           | None ->
+               (line :: kept_rev, moved_rev, dropped_lines, malformed_lines + 1))
+        ([], [], 0, 0)
+        main_lines
+    in
+    let kept_lines = List.rev kept_rev in
+    let moved_lines = List.rev moved_rev in
+    let internal_kept_rev, dropped_internal, malformed_internal =
+      List.fold_left
+        (fun (kept_rev, dropped_lines, malformed_lines) line ->
+           match classify_history_jsonl_line line with
+           | Some Drop_line -> (kept_rev, dropped_lines + 1, malformed_lines)
+           | Some _ -> (line :: kept_rev, dropped_lines, malformed_lines)
+           | None -> (line :: kept_rev, dropped_lines, malformed_lines + 1))
+        ([], 0, 0)
+        existing_internal
+    in
+    let sanitized_internal = List.rev internal_kept_rev in
+    let total_dropped = dropped_main + dropped_internal in
+    let malformed_lines = malformed_main + malformed_internal in
+    if moved_lines = [] && total_dropped = 0 then
+      {
+        moved_lines = 0;
+        dropped_lines = 0;
+        kept_lines = List.length kept_lines;
+        malformed_lines;
+      }
+    else
+      let merged_internal =
+        dedupe_preserve_order (sanitized_internal @ moved_lines)
+      in
+      (match Fs_compat.save_file_atomic main_path (render_jsonl_lines kept_lines) with
+       | Ok () -> ()
+       | Error detail ->
+           raise (Failure (Printf.sprintf "save main history failed: %s" detail)));
+      (match
+         Fs_compat.save_file_atomic internal_path
+           (render_jsonl_lines merged_internal)
+       with
+       | Ok () -> ()
+       | Error detail ->
+           raise (Failure
+                    (Printf.sprintf "save internal history failed: %s" detail)));
+      {
+        moved_lines = List.length moved_lines;
+        dropped_lines = total_dropped;
+        kept_lines = List.length kept_lines;
+        malformed_lines;
+      }
+
+let history_path_for_source
+    ~(session_dir : string)
+    ~(source : string option) : string =
+  match source with
+  | Some source when Keeper_types.is_internal_history_source source ->
+      Filename.concat session_dir "history.internal.jsonl"
+  | _ ->
+      Filename.concat session_dir "history.jsonl"
+
 let persist_message ?source session msg =
   let msg = Inference_utils.sanitize_message_utf8 msg in
-  let path = Filename.concat session.session_dir "history.jsonl" in
-  let now_ts = Time_compat.now () in
-  let payload =
-    match message_to_json msg with
-    | `Assoc fields ->
-      let fields =
-        match source with
-        | Some source when String.trim source <> "" ->
-            ("source", `String source) :: fields
-        | _ -> fields
-      in
-      `Assoc (("timestamp", `Float now_ts) :: ("ts_unix", `Float now_ts) :: fields)
-    | j -> j
+  let source_text =
+    source |> Option.value ~default:"" |> String.trim
   in
-  let line = Yojson.Safe.to_string payload ^ "\n" in
-  Fs_compat.append_file path line
+  let content_text =
+    msg.content
+    |> List.filter_map (function
+         | Agent_sdk.Types.Text text -> Some text
+         | _ -> None)
+    |> String.concat "\n"
+  in
+  if classify_history_entry ~source:source_text ~content:content_text = Drop_line then
+    ()
+  else
+    let path = history_path_for_source ~session_dir:session.session_dir ~source in
+    let now_ts = Time_compat.now () in
+    let payload =
+      match message_to_json msg with
+      | `Assoc fields ->
+        let fields =
+          match source with
+          | Some source when String.trim source <> "" ->
+              ("source", `String source) :: fields
+          | _ -> fields
+        in
+        `Assoc
+          (("timestamp", `Float now_ts) :: ("ts_unix", `Float now_ts) :: fields)
+      | j -> j
+    in
+    let line = Yojson.Safe.to_string payload ^ "\n" in
+    Fs_compat.append_file path line
 
 (* ================================================================ *)
 (* End of inlined Keeper_working_context operations                  *)
@@ -258,6 +444,256 @@ let log_keeper_exn ~label exn =
 
 let checkpoint_generation_key = "keeper_generation"
 
+type checkpoint_sanitize_stats = {
+  dropped_messages : int;
+  dropped_blocks : int;
+  dropped_chars : int;
+  truncated_blocks : int;
+  truncated_chars : int;
+}
+
+let empty_checkpoint_sanitize_stats =
+  {
+    dropped_messages = 0;
+    dropped_blocks = 0;
+    dropped_chars = 0;
+    truncated_blocks = 0;
+    truncated_chars = 0;
+  }
+
+let checkpoint_sanitize_changed (stats : checkpoint_sanitize_stats) : bool =
+  stats.dropped_messages > 0
+  || stats.dropped_blocks > 0
+  || stats.dropped_chars > 0
+  || stats.truncated_blocks > 0
+  || stats.truncated_chars > 0
+
+let add_checkpoint_sanitize_stats
+    (a : checkpoint_sanitize_stats)
+    (b : checkpoint_sanitize_stats) : checkpoint_sanitize_stats =
+  {
+    dropped_messages = a.dropped_messages + b.dropped_messages;
+    dropped_blocks = a.dropped_blocks + b.dropped_blocks;
+    dropped_chars = a.dropped_chars + b.dropped_chars;
+    truncated_blocks = a.truncated_blocks + b.truncated_blocks;
+    truncated_chars = a.truncated_chars + b.truncated_chars;
+  }
+
+let truncate_checkpoint_text ~max_chars (text : string) : string * int =
+  let len = String.length text in
+  if len <= max_chars then (text, 0)
+  else if max_chars <= 0 then ("", len)
+  else
+    let marker_len = String.length checkpoint_text_cap_marker in
+    if max_chars <= marker_len then
+      (String.sub checkpoint_text_cap_marker 0 max_chars, len)
+    else
+      let kept = max_chars - marker_len in
+      ( String.sub text 0 kept ^ checkpoint_text_cap_marker,
+        len - kept )
+
+let find_substring_from
+    ~(haystack : string)
+    ~(needle : string)
+    ~(start : int) : int option =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 || start < 0 || start >= hay_len || needle_len > hay_len
+  then None
+  else
+    let rec loop idx =
+      if idx + needle_len > hay_len then None
+      else if String.sub haystack idx needle_len = needle then Some idx
+      else loop (idx + 1)
+    in
+    loop start
+
+let strip_world_state_segments (text : string) : string =
+  let needle = "## Current World State" in
+  let rec loop current =
+    match find_substring_from ~haystack:current ~needle ~start:0 with
+    | None -> String.trim current
+    | Some idx ->
+        let seg_start =
+          match String.rindex_from_opt current idx '\n' with
+          | Some newline_idx -> newline_idx + 1
+          | None -> 0
+        in
+        let current_len = String.length current in
+        let seg_end =
+          let rec scan i =
+            if i >= current_len - 1 then current_len
+            else if current.[i] = '\n' && current.[i + 1] = '[' then i + 1
+            else scan (i + 1)
+          in
+          scan idx
+        in
+        let before = String.sub current 0 seg_start in
+        let after = String.sub current seg_end (current_len - seg_end) in
+        let combined =
+          if before = "" then after
+          else if after = "" then before
+          else before ^ "\n" ^ after
+        in
+        loop combined
+  in
+  loop text
+
+let is_ephemeral_system_context_text (text : string) : bool =
+  let trimmed = String.trim text in
+  String.starts_with ~prefix:"[system context]" trimmed
+
+let sanitize_checkpoint_text_block (text : string)
+  : string option * checkpoint_sanitize_stats =
+  if is_ephemeral_system_context_text text then
+    ( None,
+      {
+        empty_checkpoint_sanitize_stats with
+        dropped_blocks = 1;
+        dropped_chars = String.length text;
+      } )
+  else if has_world_state_signature text then
+    let stripped = strip_world_state_segments text in
+    if stripped = "" then
+      ( None,
+        {
+          empty_checkpoint_sanitize_stats with
+          dropped_blocks = 1;
+          dropped_chars = String.length text;
+        } )
+    else if String.equal stripped text then
+      (Some text, empty_checkpoint_sanitize_stats)
+    else
+      ( Some stripped,
+        {
+          empty_checkpoint_sanitize_stats with
+          truncated_blocks = 1;
+          truncated_chars = String.length text - String.length stripped;
+        } )
+  else (Some text, empty_checkpoint_sanitize_stats)
+
+let sanitize_checkpoint_message
+    (msg : Agent_sdk.Types.message)
+  : Agent_sdk.Types.message option * checkpoint_sanitize_stats =
+  let kept_rev, _, _, stats =
+    List.fold_left
+      (fun (kept_rev, kept_text_blocks, kept_text_chars, stats) block ->
+         match block with
+         | Agent_sdk.Types.Text text ->
+             let sanitized_text, text_stats =
+               sanitize_checkpoint_text_block text
+             in
+             (match sanitized_text with
+              | None ->
+                  ( kept_rev,
+                    kept_text_blocks,
+                    kept_text_chars,
+                    add_checkpoint_sanitize_stats stats text_stats )
+              | Some text ->
+                  if kept_text_blocks
+                     >= default_max_checkpoint_text_blocks_per_message
+                  then
+                    ( kept_rev,
+                      kept_text_blocks,
+                      kept_text_chars,
+                      add_checkpoint_sanitize_stats
+                        (add_checkpoint_sanitize_stats stats text_stats)
+                        {
+                          empty_checkpoint_sanitize_stats with
+                          dropped_blocks = 1;
+                          dropped_chars = String.length text;
+                        } )
+                  else
+                    let remaining =
+                      default_max_checkpoint_text_chars_per_message
+                      - kept_text_chars
+                    in
+                    if remaining <= 0 then
+                      ( kept_rev,
+                        kept_text_blocks,
+                        kept_text_chars,
+                        add_checkpoint_sanitize_stats
+                          (add_checkpoint_sanitize_stats stats text_stats)
+                          {
+                            empty_checkpoint_sanitize_stats with
+                            dropped_blocks = 1;
+                            dropped_chars = String.length text;
+                          } )
+                    else
+                      let capped_text, truncated_chars =
+                        truncate_checkpoint_text ~max_chars:remaining text
+                      in
+                      let block_stats =
+                        if truncated_chars > 0 then
+                          {
+                            empty_checkpoint_sanitize_stats with
+                            truncated_blocks = 1;
+                            truncated_chars;
+                          }
+                        else empty_checkpoint_sanitize_stats
+                      in
+                      ( Agent_sdk.Types.Text capped_text :: kept_rev,
+                        kept_text_blocks + 1,
+                        kept_text_chars + String.length capped_text,
+                        add_checkpoint_sanitize_stats
+                          (add_checkpoint_sanitize_stats stats text_stats)
+                          block_stats ))
+         | Agent_sdk.Types.Thinking { content; _ } ->
+             ( kept_rev,
+               kept_text_blocks,
+               kept_text_chars,
+               add_checkpoint_sanitize_stats stats
+                 {
+                   empty_checkpoint_sanitize_stats with
+                   dropped_blocks = 1;
+                   dropped_chars = String.length content;
+                 } )
+         | Agent_sdk.Types.RedactedThinking text ->
+             ( kept_rev,
+               kept_text_blocks,
+               kept_text_chars,
+               add_checkpoint_sanitize_stats stats
+                 {
+                   empty_checkpoint_sanitize_stats with
+                   dropped_blocks = 1;
+                   dropped_chars = String.length text;
+                 } )
+         | _ ->
+             (block :: kept_rev, kept_text_blocks, kept_text_chars, stats))
+      ([], 0, 0, empty_checkpoint_sanitize_stats)
+      msg.content
+  in
+  let kept = List.rev kept_rev in
+  if kept = [] then
+    ( None,
+      add_checkpoint_sanitize_stats stats
+        { empty_checkpoint_sanitize_stats with dropped_messages = 1 } )
+  else (Some { msg with content = kept }, stats)
+
+let sanitize_checkpoint_messages
+    (messages : Agent_sdk.Types.message list)
+  : Agent_sdk.Types.message list * checkpoint_sanitize_stats =
+  List.fold_right
+    (fun msg (acc, stats) ->
+       let sanitized_opt, msg_stats = sanitize_checkpoint_message msg in
+       let acc =
+         match sanitized_opt with
+         | Some sanitized -> sanitized :: acc
+         | None -> acc
+       in
+       let stats =
+         add_checkpoint_sanitize_stats stats msg_stats
+       in
+       (acc, stats))
+    messages
+    ([], empty_checkpoint_sanitize_stats)
+
+let sanitize_oas_checkpoint
+    (cp : Agent_sdk.Checkpoint.t)
+  : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
+  let messages, stats = sanitize_checkpoint_messages cp.messages in
+  ({ cp with messages }, stats)
+
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in
   match cp.max_total_tokens with
@@ -273,6 +709,7 @@ let context_of_oas_checkpoint
     ~(max_checkpoint_messages : int)
     (cp : Agent_sdk.Checkpoint.t)
     ~(primary_model_max_tokens : int) : working_context =
+  let cp, _ = sanitize_oas_checkpoint cp in
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
     checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
@@ -326,6 +763,7 @@ let save_oas_checkpoint
       let drop = n - max_checkpoint_messages in
       List.filteri (fun i _ -> i >= drop) ctx.messages
   in
+  let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
   let state =
     {
       Agent_sdk.Types.config =
@@ -402,9 +840,31 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     | _ -> false
   in
   if prefer_legacy then
-    Log.Keeper.info
+       Log.Keeper.info
       "keeper:%s checkpoint migration fallback: legacy newer than OAS"
       trace_id;
+  let oas_checkpoint =
+    Result.to_option oas_result
+    |> Option.map (fun checkpoint ->
+      let sanitized, stats = sanitize_oas_checkpoint checkpoint in
+      if checkpoint_sanitize_changed stats then begin
+        Log.Keeper.warn
+          "keeper:%s checkpoint migration sanitized messages: dropped_blocks=%d dropped_messages=%d dropped_chars=%d truncated_blocks=%d truncated_chars=%d"
+          trace_id
+          stats.dropped_blocks
+          stats.dropped_messages
+          stats.dropped_chars
+          stats.truncated_blocks
+          stats.truncated_chars;
+        (match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir sanitized with
+         | Ok () -> ()
+         | Error detail ->
+             Log.Keeper.error
+               "keeper:%s checkpoint migration save failed: %s"
+               trace_id detail)
+      end;
+      sanitized)
+  in
   match (prefer_legacy, oas_checkpoint, legacy_checkpoint) with
   | (false, Some checkpoint, _) ->
       let ctx =
@@ -453,7 +913,8 @@ let patch_checkpoint_last_assistant
           else msg)
         cp.messages
   in
-  { cp with Agent_sdk.Checkpoint.session_id; messages }
+  let sanitized_messages, _ = sanitize_checkpoint_messages messages in
+  { cp with Agent_sdk.Checkpoint.session_id; messages = sanitized_messages }
 
 let save_checkpoint session (ctx : working_context) ~generation =
   let ckpt = create_checkpoint ctx ~generation in

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -436,18 +436,34 @@ let write_heartbeat_snapshot
     | Some c -> c.messages
     | None ->
       let history_path =
-        Filename.concat
-          (Filename.concat base_dir (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id))
-          "history.jsonl"
+        Keeper_types.keeper_history_path ctx.config
+          (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
+      in
+      let internal_history_path =
+        Keeper_types.keeper_internal_history_path ctx.config
+          (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
       in
       (let parse_errors = ref 0 in
        let messages =
          try
-           read_file_tail_lines history_path ~max_bytes:max_history_read_bytes ~max_lines:max_history_read_lines
+           [ history_path; internal_history_path ]
+           |> List.concat_map (fun path ->
+                read_file_tail_lines path
+                  ~max_bytes:max_history_read_bytes
+                  ~max_lines:max_history_read_lines)
            |> List.filter_map (fun line ->
              try
                let json = Yojson.Safe.from_string line in
-               Some (Keeper_context_core.message_of_json json)
+               let source =
+                 Safe_ops.json_string ~default:"" "source" json |> String.trim
+               in
+               let content =
+                 Safe_ops.json_string ~default:"" "content" json |> String.trim
+               in
+               if Keeper_types.is_prompt_history_source source
+                  || Keeper_context_core.has_world_state_signature content
+               then None
+               else Some (Keeper_context_core.message_of_json json)
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | _exn ->
@@ -462,8 +478,10 @@ let write_heartbeat_snapshot
        in
        if !parse_errors > 0 then
          Log.Keeper.warn
-           "write_heartbeat_snapshot: failed to parse %d message(s) from history.jsonl for keeper=%s trace_id=%s path=%s"
-           !parse_errors meta_current.name (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id) history_path;
+           "write_heartbeat_snapshot: failed to parse %d message(s) from history logs for keeper=%s trace_id=%s path=%s"
+           !parse_errors meta_current.name
+           (Keeper_id.Trace_id.to_string meta_current.runtime.trace_id)
+           history_path;
        messages)
   in
   let c_messages = messages_for_continuity in

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -554,12 +554,21 @@ let load_history_user_messages ~(path : string) ~(max_n : int) : string list =
        try
          let json = Yojson.Safe.from_string line in
          let role = Yojson.Safe.Util.(json |> member "role" |> to_string) in
+         let source =
+           Yojson.Safe.Util.(json |> member "source" |> to_string_option)
+           |> Option.value ~default:""
+           |> String.trim
+         in
          if role = "user" then
            let content =
              Yojson.Safe.Util.(json |> member "content" |> to_string)
              |> String.trim
            in
-           if content = "" then None else Some content
+           if content = ""
+              || Keeper_types.is_internal_history_source source
+              || Keeper_context_core.has_world_state_signature content
+           then None
+           else Some content
          else None
        with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
   |> take max_n

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -265,7 +265,29 @@ let recover_latest_checkpoint_for_overflow_retry
        Log.Keeper.error "keeper:%s overflow retry OAS load error: %s"
          (Keeper_id.Trace_id.to_string meta.runtime.trace_id) d
    | Error Not_found | Ok _ -> ());
-  let oas_checkpoint = Result.to_option oas_result in
+  let oas_checkpoint =
+    Result.to_option oas_result
+    |> Option.map (fun checkpoint ->
+      let sanitized, stats = sanitize_oas_checkpoint checkpoint in
+      if checkpoint_sanitize_changed stats then begin
+        Log.Keeper.warn
+          "keeper:%s overflow-retry migration sanitized messages: dropped_blocks=%d dropped_messages=%d dropped_chars=%d truncated_blocks=%d truncated_chars=%d"
+          (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          stats.dropped_blocks
+          stats.dropped_messages
+          stats.dropped_chars
+          stats.truncated_blocks
+          stats.truncated_chars;
+        (match Keeper_checkpoint_store.save_oas ~session_dir:session.session_dir sanitized with
+         | Ok () -> ()
+         | Error detail ->
+             Log.Keeper.error
+               "keeper:%s overflow-retry migration save failed: %s"
+               (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+               detail)
+      end;
+      sanitized)
+  in
   let legacy_checkpoint =
     (try load_latest_checkpoint session
      with

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -261,6 +261,7 @@ let handle_keeper_list ctx args : tool_result =
                 ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));
                 ("session_dir", `String (keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
                 ("history", `String (keeper_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
+                ("history_internal", `String (keeper_internal_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id)));
               ]);
             ]))
         ) keeper_names

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -216,6 +216,9 @@ let handle_keeper_status ctx args : tool_result =
                ("provider", `String provider_name);
                ("model_id", `String cfg.model_id);
                ("max_context", `Int (Oas_model_resolve.max_context_of_label label));
+               ( "max_output_tokens",
+                 Option.fold ~none:`Null ~some:(fun tokens -> `Int tokens)
+                   cfg.max_tokens );
                ("max_output_tokens", match cfg.max_tokens with Some n -> `Int n | None -> `Null);
                ("api_key_env", if cfg.api_key <> "" then `String "(set)" else `Null);
                ("cost_per_million_input", `Float pricing.input_per_million);
@@ -228,6 +231,10 @@ let handle_keeper_status ctx args : tool_result =
          let memory_bank_path = keeper_memory_bank_path ctx.config m.name in
          let session_dir = keeper_session_dir ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
          let history_path = keeper_history_path ctx.config (Keeper_id.Trace_id.to_string m.runtime.trace_id) in
+         let internal_history_path =
+           keeper_internal_history_path ctx.config
+             (Keeper_id.Trace_id.to_string m.runtime.trace_id)
+         in
 
          let metrics_tail =
            let lines =
@@ -344,6 +351,10 @@ let handle_keeper_status ctx args : tool_result =
                        else None
                      in
                      let role_lc = String.lowercase_ascii role in
+                     let is_internal =
+                       Keeper_types.is_internal_history_source source
+                       || Keeper_context_core.has_world_state_signature content
+                     in
                      let entry_kind =
                        match source, role_lc with
                        | "direct_user", _ | "direct_assistant", _ ->
@@ -362,7 +373,9 @@ let handle_keeper_status ctx args : tool_result =
                        role_lc = "assistant"
                        && looks_fragmentary_history_text content
                      in
-                     let should_filter = history_filter_fragments && is_fragment in
+                     let should_filter =
+                       is_internal || (history_filter_fragments && is_fragment)
+                     in
                      let preview =
                        if String.length content > 200 then
                          utf8_safe_prefix_bytes content ~max_bytes:200 ^ "..."
@@ -699,6 +712,7 @@ let handle_keeper_status ctx args : tool_result =
              ("dataset_export", `String (keeper_dataset_export_path ctx.config m.name));
              ("session_dir", `String session_dir);
              ("history", `String history_path);
+             ("history_internal", `String internal_history_path);
              ("evidence_dir", `String
                (Filename.concat ctx.config.base_path
                  (Printf.sprintf ".masc/evidence/%s/%s"

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -57,6 +57,20 @@ let keeper_session_dir config trace_id =
 let keeper_history_path config trace_id =
   Filename.concat (keeper_session_dir config trace_id) "history.jsonl"
 
+let keeper_internal_history_path config trace_id =
+  Filename.concat (keeper_session_dir config trace_id) "history.internal.jsonl"
+
+let normalize_history_source (source : string) =
+  source |> String.trim |> String.lowercase_ascii
+
+let is_prompt_history_source (source : string) =
+  String.equal (normalize_history_source source) "world_state_prompt"
+
+let is_internal_history_source (source : string) =
+  match normalize_history_source source with
+  | "world_state_prompt" | "internal_assistant" -> true
+  | _ -> false
+
 let keeper_policy_log_path config name =
   Filename.concat (keeper_dir_ config) (name ^ ".policy.jsonl")
 

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -573,6 +573,49 @@ let startup_prune_keeper_checkpoints (state : Mcp_server.server_state) =
      Log.Misc.error "startup checkpoint prune failed: %s"
        (Printexc.to_string exn))
 
+let startup_migrate_keeper_histories (state : Mcp_server.server_state) =
+  (try
+     let traces_dir =
+       Filename.concat (Room.masc_root_dir state.room_config) "traces"
+     in
+     if Sys.file_exists traces_dir then begin
+       let moved_total = ref 0 in
+       let dropped_total = ref 0 in
+       let sessions_migrated = ref 0 in
+       Array.iter
+         (fun trace_name ->
+            let trace_dir = Filename.concat traces_dir trace_name in
+            if Sys.is_directory trace_dir then
+              let stats =
+                Keeper_context_core.migrate_session_history_logs
+                  ~session_dir:trace_dir
+              in
+              if stats.moved_lines > 0 || stats.dropped_lines > 0 then begin
+                incr sessions_migrated;
+                moved_total := !moved_total + stats.moved_lines;
+                dropped_total := !dropped_total + stats.dropped_lines;
+                Log.Misc.info
+                  "startup history migration: trace=%s moved=%d dropped=%d kept=%d malformed=%d"
+                  trace_name
+                  stats.moved_lines
+                  stats.dropped_lines
+                  stats.kept_lines
+                  stats.malformed_lines
+              end)
+         (Sys.readdir traces_dir);
+       if !sessions_migrated > 0 then
+         Log.Misc.info
+           "startup history migration: migrated %d session(s), moved %d internal line(s), dropped %d prompt line(s)"
+           !sessions_migrated
+           !moved_total
+           !dropped_total
+     end
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Misc.error "startup history migration failed: %s"
+         (Printexc.to_string exn))
+
 (* bootstrap_keepers removed: the keeper_autoboot subsystem in
    start_keeper_loops now handles keeper startup in a dedicated
    fiber with a 5-second delay, avoiding PG pool contention with
@@ -710,6 +753,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
           ("prompt_bootstrap", fun () -> bootstrap_prompt_state state);
           ("telemetry_warmup", fun () -> warm_tool_registry_from_telemetry state);
           ("tool_metrics_restore", fun () -> restore_tool_metrics_from_disk state);
+          ("keeper_history_migration", fun () -> startup_migrate_keeper_histories state);
         ]
         @ (if has_legacy_traces then
              [("legacy_trace_dir_migration", fun () ->

--- a/lib/server/server_runtime_bootstrap.mli
+++ b/lib/server/server_runtime_bootstrap.mli
@@ -56,6 +56,7 @@ val warm_tool_registry_from_telemetry : Mcp_server.server_state -> unit
 val migrate_legacy_dirs : Mcp_server.server_state -> unit
 val startup_prune_jsonl : Mcp_server.server_state -> unit
 val startup_prune_keeper_checkpoints : Mcp_server.server_state -> unit
+val startup_migrate_keeper_histories : Mcp_server.server_state -> unit
 
 (** {1 Main Entry Point} *)
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -67,7 +67,7 @@ let agent_config_of_worker_meta
     name = meta.worker_name;
     model = oas_model_of_effective_model meta.effective_model;
     system_prompt = Some system_prompt;
-    max_tokens;
+    max_tokens = Some max_tokens;
     max_turns = effective_max_turns meta;
     temperature = Some Oas_worker_cascade.worker_temperature;
     top_p = Some Oas_worker_cascade.worker_top_p;

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -61,7 +61,7 @@ let effective_max_turns (meta : Worker_container_types.worker_container_meta) : 
 let agent_config_of_worker_meta
     (meta : Worker_container_types.worker_container_meta)
     ~(system_prompt : string) : Oas.Types.agent_config =
-  let max_tokens = Some (Worker_container_types.local_worker_max_tokens ()) in
+  let max_tokens = Worker_container_types.local_worker_max_tokens () in
   {
     Oas.Types.default_config with
     name = meta.worker_name;

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -585,6 +585,254 @@ let make_test_checkpoint ?(session_id = "old-session")
     working_context = None;
   }
 
+let contaminated_world_state_text =
+  "## Current World State\n\n\
+   ### Namespace State\n- Unclaimed tasks: 22\n- Active agents: 6\n\n\
+   ### Available Tools\n- keeper_board_list\n- keeper_task_claim\n\n\
+   ### Continuity\nGoal: keep going\nDone: none\n"
+
+let contaminated_user_message ?(prompt = "짧게 ping만 해봐") () :
+    Agent_sdk.Types.message =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.User;
+    content =
+      [
+        Agent_sdk.Types.Text prompt;
+        Agent_sdk.Types.Text contaminated_world_state_text;
+        Agent_sdk.Types.Text ("[system context] " ^ contaminated_world_state_text);
+      ];
+    name = None;
+    tool_call_id = None;
+  }
+
+let oversized_checkpoint_text =
+  String.make 20_000 'x'
+
+let oversized_user_message ?(prompt = "긴 텍스트도 저장되면 안 돼") () :
+    Agent_sdk.Types.message =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.User;
+    content =
+      [
+        Agent_sdk.Types.Text prompt;
+        Agent_sdk.Types.Text oversized_checkpoint_text;
+      ];
+    name = None;
+    tool_call_id = None;
+  }
+
+let summarized_contaminated_text =
+  "[Summary of 2 earlier messages]\n\
+   [User] ## Current World State\n\n\
+   ### Namespace State\n- Unclaimed tasks: 22\n\n\
+   ### Available Tools\n- keeper_board_list\n\n\
+   ### Continuity\nGoal: keep going\nDone: none\n\
+   [Assistant] 이 줄은 남아야 한다.\n"
+
+let summarized_contaminated_message () : Agent_sdk.Types.message =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.User;
+    content = [Agent_sdk.Types.Text summarized_contaminated_text];
+    name = None;
+    tool_call_id = None;
+  }
+
+let test_persist_message_drops_world_state_and_separates_internal_history () =
+  let base_dir = temp_dir "keeper_lifecycle_history_split" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-history-split" ~base_dir
+      in
+      KEC.persist_message
+        ~source:"direct_user"
+        session
+        (Agent_sdk.Types.user_msg "real conversation");
+      KEC.persist_message
+        ~source:"world_state_prompt"
+        session
+        (Agent_sdk.Types.user_msg contaminated_world_state_text);
+      KEC.persist_message
+        ~source:"internal_assistant"
+        session
+        (Agent_sdk.Types.assistant_msg "internal reply");
+      let main_history =
+        Fs_compat.load_file
+          (Filename.concat session.session_dir "history.jsonl")
+      in
+      let internal_history =
+        Fs_compat.load_file
+          (Filename.concat session.session_dir "history.internal.jsonl")
+      in
+      check bool "main history keeps direct conversation" true
+        (contains_substring main_history "real conversation");
+      check bool "main history excludes world state prompt" false
+        (contains_substring main_history "Current World State");
+      check bool "main history excludes internal assistant" false
+        (contains_substring main_history "internal reply");
+      check bool "internal history drops world state prompt" false
+        (contains_substring internal_history "Current World State");
+      check bool "internal history stores internal assistant" true
+        (contains_substring internal_history "internal reply"))
+
+let test_migrate_session_history_logs_moves_internal_entries () =
+  let base_dir = temp_dir "keeper_lifecycle_history_migrate" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-history-migrate" ~base_dir
+      in
+      let history_path = Filename.concat session.session_dir "history.jsonl" in
+      let internal_history_path =
+        Filename.concat session.session_dir "history.internal.jsonl"
+      in
+      let payload =
+        String.concat "\n"
+          [
+            {|{"role":"user","content":"real conversation"}|};
+            {|{"role":"user","source":"world_state_prompt","content":"## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
+            {|{"role":"assistant","source":"internal_assistant","content":"internal reply"}|};
+            {|{"role":"user","content":"[Summary]\n[User] ## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
+          ]
+        ^ "\n"
+      in
+      Fs_compat.save_file history_path payload;
+      Fs_compat.save_file
+        internal_history_path
+        (String.concat "\n"
+           [
+             {|{"role":"user","source":"world_state_prompt","content":"## Current World State\n\n### Namespace State\n- Unclaimed tasks: 9\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
+             {|{"role":"assistant","source":"internal_assistant","content":"existing internal reply"}|};
+           ]
+         ^ "\n");
+      let stats =
+        KCC.migrate_session_history_logs ~session_dir:session.session_dir
+      in
+      check int "moved internal lines" 1 stats.moved_lines;
+      check int "dropped prompt lines" 3 stats.dropped_lines;
+      let main_history = Fs_compat.load_file history_path in
+      let internal_history =
+        Fs_compat.load_file internal_history_path
+      in
+      check bool "main history keeps real conversation" true
+        (contains_substring main_history "real conversation");
+      check bool "main history excludes world state" false
+        (contains_substring main_history "Current World State");
+      check bool "main history excludes internal assistant" false
+        (contains_substring main_history "internal reply");
+      check bool "internal history drops world state" false
+        (contains_substring internal_history "Current World State");
+      check bool "internal history keeps moved internal assistant" true
+        (contains_substring internal_history "internal reply"))
+
+let test_save_oas_checkpoint_strips_ephemeral_world_state () =
+  let base_dir = temp_dir "keeper_lifecycle_save_strip" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-save-strip" ~base_dir
+      in
+      let ctx =
+        KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:64_000
+        |> fun ctx -> KEC.append ctx (contaminated_user_message ())
+        |> KEC.sync_oas_context
+      in
+      match
+        KEC.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
+          ~agent_name:"keeper-lifecycle"
+          ~model:"glm:glm-5.1"
+          ~ctx
+          ~generation:1
+      with
+      | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "save_oas_checkpoint failed: %s" e)
+      | Ok checkpoint ->
+          check int "saved message count" 1
+            (List.length checkpoint.messages);
+          let text =
+            Agent_sdk.Types.text_of_message (List.hd checkpoint.messages)
+          in
+          check bool "preserves actual prompt" true
+            (contains_substring text "짧게 ping만 해봐");
+          check bool "drops world state snapshot" false
+            (contains_substring text "Current World State"))
+
+let test_save_oas_checkpoint_caps_oversized_text () =
+  let base_dir = temp_dir "keeper_lifecycle_save_cap" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-save-cap" ~base_dir
+      in
+      let ctx =
+        KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:64_000
+        |> fun ctx -> KEC.append ctx (oversized_user_message ())
+        |> KEC.sync_oas_context
+      in
+      match
+        KEC.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
+          ~agent_name:"keeper-lifecycle"
+          ~model:"glm:glm-5.1"
+          ~ctx
+          ~generation:1
+      with
+      | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "save_oas_checkpoint failed: %s" e)
+      | Ok checkpoint ->
+          let text =
+            Agent_sdk.Types.text_of_message (List.hd checkpoint.messages)
+          in
+          check bool "keeps prompt prefix" true
+            (contains_substring text "긴 텍스트도 저장되면 안 돼");
+          check bool "adds truncation marker" true
+            (contains_substring text "[capped]");
+          check bool "text was compacted" true
+            (String.length text < String.length oversized_checkpoint_text))
+
+let test_save_oas_checkpoint_strips_summarized_world_state () =
+  let base_dir = temp_dir "keeper_lifecycle_save_summary_strip" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-save-summary-strip" ~base_dir
+      in
+      let ctx =
+        KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:64_000
+        |> fun ctx -> KEC.append ctx (summarized_contaminated_message ())
+        |> KEC.sync_oas_context
+      in
+      match
+        KEC.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
+          ~agent_name:"keeper-lifecycle"
+          ~model:"glm:glm-5.1"
+          ~ctx
+          ~generation:1
+      with
+      | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "save_oas_checkpoint failed: %s" e)
+      | Ok checkpoint ->
+          let text =
+            Agent_sdk.Types.text_of_message (List.hd checkpoint.messages)
+          in
+          check bool "drops embedded world state from summary" false
+            (contains_substring text "Current World State");
+          check bool "preserves assistant summary text" true
+            (contains_substring text "이 줄은 남아야 한다."))
+
 let test_patch_checkpoint_replaces_last_assistant () =
   let msgs =
     [ Agent_sdk.Types.user_msg "hello";
@@ -643,6 +891,172 @@ let test_patch_checkpoint_no_assistant_noop () =
   check int "message count unchanged" 1 (List.length patched.messages);
   let text = Agent_sdk.Types.text_of_message (List.hd patched.messages) in
   check string "user msg unchanged" "only user" text
+
+let test_patch_checkpoint_strips_ephemeral_world_state () =
+  let msgs =
+    [
+      contaminated_user_message ~prompt:"지금 상태 한 줄로만 말해." ();
+      Agent_sdk.Types.assistant_msg "raw response";
+    ]
+  in
+  let cp = make_test_checkpoint msgs in
+  let patched =
+    KCC.patch_checkpoint_last_assistant cp
+      ~session_id:"patched-session"
+      ~response_text:"clean response"
+  in
+  let first_text = Agent_sdk.Types.text_of_message (List.hd patched.messages) in
+  check bool "keeps user prompt" true
+    (contains_substring first_text "지금 상태 한 줄로만 말해.");
+  check bool "removes world state from prior user message" false
+    (contains_substring first_text "Current World State")
+
+let test_load_context_migrates_ephemeral_world_state_checkpoint () =
+  let base_dir = temp_dir "keeper_lifecycle_load_migrate" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-load-migrate" in
+      let session = KEC.create_session ~session_id:trace_id ~base_dir in
+      let checkpoint =
+        make_test_checkpoint ~session_id:trace_id
+          [ contaminated_user_message ~prompt:"짧게 ping만 해봐" () ]
+      in
+      (match
+         Masc_mcp.Keeper_checkpoint_store.save_oas
+           ~session_dir:session.session_dir checkpoint
+       with
+       | Ok () -> ()
+       | Error e ->
+           Alcotest.fail
+             (Printf.sprintf "seed save_oas failed: %s" e));
+      let loaded_opt = load_context ~base_dir ~trace_id ~max_tokens:64_000 in
+      let loaded =
+        match loaded_opt with
+        | Some ctx -> ctx
+        | None -> Alcotest.fail "expected migrated context"
+      in
+      let loaded_text =
+        String.concat "\n"
+          (List.map Agent_sdk.Types.text_of_message loaded.messages)
+      in
+      check bool "loaded prompt preserved" true
+        (contains_substring loaded_text "짧게 ping만 해봐");
+      check bool "loaded world state removed" false
+        (contains_substring loaded_text "Current World State");
+      match
+        Masc_mcp.Keeper_checkpoint_store.load_oas
+          ~session_dir:session.session_dir
+          ~session_id:trace_id
+      with
+      | Error _ -> Alcotest.fail "expected migrated checkpoint on disk"
+      | Ok migrated ->
+          let migrated_text =
+            String.concat "\n"
+              (List.map Agent_sdk.Types.text_of_message migrated.messages)
+          in
+          check bool "migrated checkpoint persists cleanup" false
+            (contains_substring migrated_text "Current World State"))
+
+let test_load_context_migrates_oversized_text_checkpoint () =
+  let base_dir = temp_dir "keeper_lifecycle_load_cap" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-load-cap" in
+      let session = KEC.create_session ~session_id:trace_id ~base_dir in
+      let checkpoint =
+        make_test_checkpoint ~session_id:trace_id
+          [ oversized_user_message ~prompt:"짧게 요약해" () ]
+      in
+      (match
+         Masc_mcp.Keeper_checkpoint_store.save_oas
+           ~session_dir:session.session_dir checkpoint
+       with
+       | Ok () -> ()
+       | Error e ->
+           Alcotest.fail
+             (Printf.sprintf "seed save_oas failed: %s" e));
+      let loaded_opt = load_context ~base_dir ~trace_id ~max_tokens:64_000 in
+      let loaded =
+        match loaded_opt with
+        | Some ctx -> ctx
+        | None -> Alcotest.fail "expected migrated capped context"
+      in
+      let loaded_text =
+        String.concat "\n"
+          (List.map Agent_sdk.Types.text_of_message loaded.messages)
+      in
+      check bool "loaded prompt preserved" true
+        (contains_substring loaded_text "짧게 요약해");
+      check bool "loaded checkpoint capped" true
+        (contains_substring loaded_text "[capped]");
+      check bool "loaded text reduced" true
+        (String.length loaded_text < String.length oversized_checkpoint_text);
+      match
+        Masc_mcp.Keeper_checkpoint_store.load_oas
+          ~session_dir:session.session_dir
+          ~session_id:trace_id
+      with
+      | Error _ -> Alcotest.fail "expected capped checkpoint on disk"
+      | Ok migrated ->
+          let migrated_text =
+            String.concat "\n"
+              (List.map Agent_sdk.Types.text_of_message migrated.messages)
+          in
+          check bool "migrated checkpoint persists cap" true
+            (contains_substring migrated_text "[capped]");
+          check bool "migrated text reduced" true
+            (String.length migrated_text < String.length oversized_checkpoint_text))
+
+let test_load_context_migrates_summarized_world_state_checkpoint () =
+  let base_dir = temp_dir "keeper_lifecycle_load_summary_strip" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-load-summary-strip" in
+      let session = KEC.create_session ~session_id:trace_id ~base_dir in
+      let checkpoint =
+        make_test_checkpoint ~session_id:trace_id
+          [ summarized_contaminated_message () ]
+      in
+      (match
+         Masc_mcp.Keeper_checkpoint_store.save_oas
+           ~session_dir:session.session_dir checkpoint
+       with
+       | Ok () -> ()
+       | Error e ->
+           Alcotest.fail
+             (Printf.sprintf "seed save_oas failed: %s" e));
+      let loaded_opt = load_context ~base_dir ~trace_id ~max_tokens:64_000 in
+      let loaded =
+        match loaded_opt with
+        | Some ctx -> ctx
+        | None -> Alcotest.fail "expected migrated summarized context"
+      in
+      let loaded_text =
+        String.concat "\n"
+          (List.map Agent_sdk.Types.text_of_message loaded.messages)
+      in
+      check bool "loaded summary drops world state" false
+        (contains_substring loaded_text "Current World State");
+      check bool "loaded summary keeps assistant text" true
+        (contains_substring loaded_text "이 줄은 남아야 한다.");
+      match
+        Masc_mcp.Keeper_checkpoint_store.load_oas
+          ~session_dir:session.session_dir
+          ~session_id:trace_id
+      with
+      | Error _ -> Alcotest.fail "expected migrated summary checkpoint on disk"
+      | Ok migrated ->
+          let migrated_text =
+            String.concat "\n"
+              (List.map Agent_sdk.Types.text_of_message migrated.messages)
+          in
+          check bool "migrated summary strips world state" false
+            (contains_substring migrated_text "Current World State");
+          check bool "migrated summary keeps assistant text" true
+            (contains_substring migrated_text "이 줄은 남아야 한다."))
 
 (* Regression tests for compaction gate fixes introduced in #5599:
    - ts=0.0 must not block compaction via the cooldown gate
@@ -799,6 +1213,18 @@ let () =
         ] );
       ( "checkpoint_patch",
         [
+          test_case
+            "persist_message drops world state and separates internal history"
+            `Quick
+            test_persist_message_drops_world_state_and_separates_internal_history;
+          test_case "migrate_session_history_logs moves internal entries" `Quick
+            test_migrate_session_history_logs_moves_internal_entries;
+          test_case "save strips ephemeral world state" `Quick
+            test_save_oas_checkpoint_strips_ephemeral_world_state;
+          test_case "save caps oversized text" `Quick
+            test_save_oas_checkpoint_caps_oversized_text;
+          test_case "save strips summarized world state" `Quick
+            test_save_oas_checkpoint_strips_summarized_world_state;
           test_case "patch replaces last assistant text" `Quick
             test_patch_checkpoint_replaces_last_assistant;
           test_case "patch preserves non-assistant messages" `Quick
@@ -807,6 +1233,14 @@ let () =
             test_patch_checkpoint_updates_session_id;
           test_case "patch with no assistant is noop" `Quick
             test_patch_checkpoint_no_assistant_noop;
+          test_case "patch strips ephemeral world state" `Quick
+            test_patch_checkpoint_strips_ephemeral_world_state;
+          test_case "load migrates ephemeral world state checkpoint" `Quick
+            test_load_context_migrates_ephemeral_world_state_checkpoint;
+          test_case "load migrates oversized text checkpoint" `Quick
+            test_load_context_migrates_oversized_text_checkpoint;
+          test_case "load migrates summarized world state checkpoint" `Quick
+            test_load_context_migrates_summarized_world_state_checkpoint;
         ] );
       ( "compact_policy",
         [

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -306,6 +306,24 @@ let test_load_history_user_messages () =
     check string "first" "hello world" (List.hd result);
     check string "last" "third question" (List.nth result 2))
 
+let test_load_history_user_messages_ignores_internal_prompt_entries () =
+  let dir = test_tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
+    let path = Filename.concat dir "history.jsonl" in
+    let lines = [
+      {|{"role":"user","source":"world_state_prompt","content":"## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
+      {|{"role":"user","content":"real user question"}|};
+      {|{"role":"user","content":"[Summary]\n[User] ## Current World State\n\n### Namespace State\n- Unclaimed tasks: 1\n\n### Available Tools\n- keeper_board_list\n\n### Continuity\nGoal: keep going"}|};
+      {|{"role":"user","content":"second real question"}|};
+    ] in
+    let oc = open_out path in
+    List.iter (fun l -> output_string oc (l ^ "\n")) lines;
+    close_out oc;
+    let result = Keeper_memory_recall.load_history_user_messages ~path ~max_n:10 in
+    check int "only real user messages kept" 2 (List.length result);
+    check string "first real" "real user question" (List.hd result);
+    check string "second real" "second real question" (List.nth result 1))
+
 let test_recall_candidates_with_history_dedup () =
   let dir = test_tmpdir () in
   Fun.protect ~finally:(fun () -> cleanup_tmpdir dir) (fun () ->
@@ -775,6 +793,8 @@ let () =
         [
           test_case "load_history_user_messages from jsonl" `Quick
             test_load_history_user_messages;
+          test_case "load_history_user_messages ignores internal prompt entries" `Quick
+            test_load_history_user_messages_ignores_internal_prompt_entries;
           test_case "recall_candidates_with_history deduplicates" `Quick
             test_recall_candidates_with_history_dedup;
           test_case "recall_candidates_with_history appends history" `Quick


### PR DESCRIPTION
## Summary
- stop persisting `world_state_prompt` content into keeper durable history
- split and sanitize legacy keeper history/checkpoint data so `Current World State / Available Tools / Continuity` prompt payloads are removed from durable state
- keep `internal_assistant` history separate while filtering prompt-only contamination from recall, status, dashboard, and keepalive fallback paths
- add startup migration for existing traces and tighten checkpoint store fallback behavior outside `Eio_main.run`
- fix adjacent SDK type drift (`max_tokens` option fields and removed `named_cascade` path) so `@check` stays green on the current branch

## Why
Keeper runtime state was being polluted by ephemeral prompt material that should never have been durable. In practice that left very large repeated prompt fragments inside checkpoints and `history.jsonl`, which inflated context, confused telemetry, and made keepers look idle or broken for the wrong reasons.

## Impact
- durable keeper history keeps real conversation state instead of repeated synthetic world snapshots
- startup migration cleans existing traces without keeping the prompt payload in `history.internal.jsonl`
- checkpoint save/load remains safe in non-Eio test contexts
- dashboard and status views stop surfacing prompt contamination as user-visible history

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-checkpoint-sanitize ./test/test_keeper_lifecycle.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-checkpoint-sanitize ./test/test_keeper_memory.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-checkpoint-sanitize @check`
- live verification on a worktree server at `http://127.0.0.1:8945`:
  - startup migration logged `migrated 8 session(s), moved 1 internal line(s), dropped 1076 prompt line(s)`
  - `trace-1775482986825-dd636/history.jsonl` reduced to 5 real lines and `history.internal.jsonl` to 0 lines
  - `trace-1775485604090-c6ad8/history.jsonl` reduced to 3 real lines and `history.internal.jsonl` retained 5 non-prompt lines

## Root Cause
The keeper pipeline rendered structured runtime state into markdown prompt sections and then treated those synthetic prompt messages as ordinary durable history/checkpoint content. That broke the boundary between ephemeral turn context and persisted keeper memory.