### PR TITLE
feat(dashboard): eval feed reader — RFC-MASC-005 Phase 1

### DIFF
--- a/lib/dashboard/dashboard_eval_feed.ml
+++ b/lib/dashboard/dashboard_eval_feed.ml
@@ -1,0 +1,180 @@
+(** Dashboard_eval_feed — read-only consumer for OAS eval verdicts.
+
+    Parses swiss-verdict JSON (RFC-OAS-002 schema v1) produced by the OAS
+    harness and exposes eval snapshots for dashboard rendering.
+
+    This module only reads.  It never writes or modifies eval data.
+    Data ownership belongs to OAS. *)
+
+type layer_result_json = {
+  layer_name : string;
+  passed : bool;
+  score : float option;
+  evidence : string list;
+  detail : string option;
+}
+
+type swiss_verdict_json = {
+  schema_version : int;
+  all_passed : bool;
+  coverage : float;
+  layer_results : layer_result_json list;
+}
+
+type eval_snapshot = {
+  agent_name : string;
+  session_id : string option;
+  worker_run_id : string;
+  timestamp : float;
+  verdict : swiss_verdict_json;
+  coverage : float;
+  baseline_status : string option;
+}
+
+(* ── Layer result parsing ────────────────────────────────────────── *)
+
+let read_layer_result_json (json : Yojson.Safe.t)
+    : (layer_result_json, string) result =
+  let layer_name = Safe_ops.json_string ~default:"" "layer_name" json in
+  if layer_name = "" then Error "layer_result: missing layer_name"
+  else
+    let passed = Safe_ops.json_bool ~default:false "passed" json in
+    let score = Safe_ops.json_float_opt "score" json in
+    let evidence = Safe_ops.json_string_list "evidence" json in
+    let detail = Safe_ops.json_string_opt "detail" json in
+    Ok { layer_name; passed; score; evidence; detail }
+
+(* ── Swiss verdict parsing ───────────────────────────────────────── *)
+
+let read_verdict_json (json : Yojson.Safe.t)
+    : (swiss_verdict_json, string) result =
+  let schema_version = Safe_ops.json_int ~default:0 "schema_version" json in
+  if schema_version <> 1 then
+    Error
+      (Printf.sprintf "unsupported schema_version: %d (expected 1)"
+         schema_version)
+  else
+    let all_passed = Safe_ops.json_bool ~default:false "all_passed" json in
+    let coverage = Safe_ops.json_float ~default:0.0 "coverage" json in
+    let layer_jsons = Safe_ops.json_list "layer_results" json in
+    let rec parse_layers acc = function
+      | [] -> Ok (List.rev acc)
+      | hd :: tl -> (
+          match read_layer_result_json hd with
+          | Ok lr -> parse_layers (lr :: acc) tl
+          | Error _ as e -> e)
+    in
+    match parse_layers [] layer_jsons with
+    | Ok layer_results ->
+        Ok { schema_version; all_passed; coverage; layer_results }
+    | Error _ as e -> e
+
+(* ── Eval snapshot parsing ───────────────────────────────────────── *)
+
+let read_snapshot_json ~agent_name (json : Yojson.Safe.t)
+    : eval_snapshot option =
+  let worker_run_id =
+    Safe_ops.json_string ~default:"" "worker_run_id" json
+  in
+  if worker_run_id = "" then None
+  else
+    match Safe_ops.json_member_opt "verdict" json with
+    | None -> None
+    | Some verdict_json -> (
+        match read_verdict_json verdict_json with
+        | Error _ -> None
+        | Ok verdict ->
+            let session_id = Safe_ops.json_string_opt "session_id" json in
+            let timestamp =
+              Safe_ops.json_float ~default:0.0 "timestamp" json
+            in
+            let coverage =
+              Safe_ops.json_float ~default:verdict.coverage "coverage" json
+            in
+            let baseline_status =
+              Safe_ops.json_string_opt "baseline_status" json
+            in
+            Some
+              {
+                agent_name;
+                session_id;
+                worker_run_id;
+                timestamp;
+                verdict;
+                coverage;
+                baseline_status;
+              })
+
+(* ── File system reading ─────────────────────────────────────────── *)
+
+let eval_dir ~base_path ~agent_name =
+  Filename.concat
+    (Filename.concat (Filename.concat base_path ".oas") "eval")
+    agent_name
+
+let read_latest ~base_path ~agent_name ~limit =
+  let dir = eval_dir ~base_path ~agent_name in
+  if not (Sys.file_exists dir && Sys.is_directory dir) then []
+  else
+    let files =
+      try
+        Sys.readdir dir
+        |> Array.to_list
+        |> List.filter (fun f -> Filename.check_suffix f ".json")
+        |> List.sort (fun a b -> String.compare b a)
+      with Sys_error _ -> []
+    in
+    let rec collect acc remaining = function
+      | [] -> List.rev acc
+      | _ when remaining <= 0 -> List.rev acc
+      | filename :: rest ->
+          let path = Filename.concat dir filename in
+          let snapshot =
+            try
+              let content =
+                In_channel.with_open_text path In_channel.input_all
+              in
+              let json = Yojson.Safe.from_string content in
+              read_snapshot_json ~agent_name json
+            with
+            | Sys_error _ | Yojson.Json_error _ -> None
+          in
+          (match snapshot with
+          | Some s -> collect (s :: acc) (remaining - 1) rest
+          | None -> collect acc remaining rest)
+    in
+    collect [] limit files
+
+(* ── JSON serialization ──────────────────────────────────────────── *)
+
+let layer_result_to_json (lr : layer_result_json) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("layer_name", `String lr.layer_name);
+      ("passed", `Bool lr.passed);
+      ("score", Json_util.float_opt_to_json lr.score);
+      ("evidence", `List (List.map (fun s -> `String s) lr.evidence));
+      ("detail", Json_util.string_opt_to_json lr.detail);
+    ]
+
+let verdict_to_json (v : swiss_verdict_json) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("schema_version", `Int v.schema_version);
+      ("all_passed", `Bool v.all_passed);
+      ("coverage", `Float v.coverage);
+      ( "layer_results",
+        `List (List.map layer_result_to_json v.layer_results) );
+    ]
+
+let snapshot_to_json (s : eval_snapshot) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("agent_name", `String s.agent_name);
+      ("session_id", Json_util.string_opt_to_json s.session_id);
+      ("worker_run_id", `String s.worker_run_id);
+      ("timestamp", `Float s.timestamp);
+      ("verdict", verdict_to_json s.verdict);
+      ("coverage", `Float s.coverage);
+      ("baseline_status", Json_util.string_opt_to_json s.baseline_status);
+    ]

--- a/lib/dashboard/dashboard_eval_feed.ml
+++ b/lib/dashboard/dashboard_eval_feed.ml
@@ -102,10 +102,21 @@ let read_snapshot_json ~agent_name (json : Yojson.Safe.t)
 
 (* ── File system reading ─────────────────────────────────────────── *)
 
+let eval_base ~base_path =
+  Filename.concat (Filename.concat base_path ".oas") "eval"
+
 let eval_dir ~base_path ~agent_name =
-  Filename.concat
-    (Filename.concat (Filename.concat base_path ".oas") "eval")
-    agent_name
+  Filename.concat (eval_base ~base_path) agent_name
+
+let list_agents ~base_path =
+  let dir = eval_base ~base_path in
+  try
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter (fun name ->
+         Sys.is_directory (Filename.concat dir name))
+    |> List.sort String.compare
+  with Sys_error _ -> []
 
 let read_latest ~base_path ~agent_name ~limit =
   let dir = eval_dir ~base_path ~agent_name in

--- a/lib/dashboard/dashboard_eval_feed.ml
+++ b/lib/dashboard/dashboard_eval_feed.ml
@@ -27,7 +27,6 @@ type eval_snapshot = {
   worker_run_id : string;
   timestamp : float;
   verdict : swiss_verdict_json;
-  coverage : float;
   baseline_status : string option;
 }
 
@@ -88,9 +87,6 @@ let read_snapshot_json ~agent_name (json : Yojson.Safe.t)
             let timestamp =
               Safe_ops.json_float ~default:0.0 "timestamp" json
             in
-            let coverage =
-              Safe_ops.json_float ~default:verdict.coverage "coverage" json
-            in
             let baseline_status =
               Safe_ops.json_string_opt "baseline_status" json
             in
@@ -101,7 +97,6 @@ let read_snapshot_json ~agent_name (json : Yojson.Safe.t)
                 worker_run_id;
                 timestamp;
                 verdict;
-                coverage;
                 baseline_status;
               })
 
@@ -114,36 +109,29 @@ let eval_dir ~base_path ~agent_name =
 
 let read_latest ~base_path ~agent_name ~limit =
   let dir = eval_dir ~base_path ~agent_name in
-  if not (Sys.file_exists dir && Sys.is_directory dir) then []
-  else
-    let files =
-      try
-        Sys.readdir dir
-        |> Array.to_list
-        |> List.filter (fun f -> Filename.check_suffix f ".json")
-        |> List.sort (fun a b -> String.compare b a)
-      with Sys_error _ -> []
-    in
-    let rec collect acc remaining = function
-      | [] -> List.rev acc
-      | _ when remaining <= 0 -> List.rev acc
-      | filename :: rest ->
-          let path = Filename.concat dir filename in
-          let snapshot =
-            try
-              let content =
-                In_channel.with_open_text path In_channel.input_all
-              in
-              let json = Yojson.Safe.from_string content in
-              read_snapshot_json ~agent_name json
-            with
-            | Sys_error _ | Yojson.Json_error _ -> None
-          in
-          (match snapshot with
-          | Some s -> collect (s :: acc) (remaining - 1) rest
-          | None -> collect acc remaining rest)
-    in
-    collect [] limit files
+  let files =
+    try
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (fun f -> Filename.check_suffix f ".json")
+      |> List.sort (fun a b -> String.compare b a)
+    with Sys_error _ -> []
+  in
+  let rec collect acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | filename :: rest ->
+        let path = Filename.concat dir filename in
+        let snapshot =
+          match Safe_ops.read_json_file_safe path with
+          | Error _ -> None
+          | Ok json -> read_snapshot_json ~agent_name json
+        in
+        (match snapshot with
+        | Some s -> collect (s :: acc) (remaining - 1) rest
+        | None -> collect acc remaining rest)
+  in
+  collect [] limit files
 
 (* ── JSON serialization ──────────────────────────────────────────── *)
 
@@ -175,6 +163,5 @@ let snapshot_to_json (s : eval_snapshot) : Yojson.Safe.t =
       ("worker_run_id", `String s.worker_run_id);
       ("timestamp", `Float s.timestamp);
       ("verdict", verdict_to_json s.verdict);
-      ("coverage", `Float s.coverage);
       ("baseline_status", Json_util.string_opt_to_json s.baseline_status);
     ]

--- a/lib/dashboard/dashboard_eval_feed.mli
+++ b/lib/dashboard/dashboard_eval_feed.mli
@@ -36,6 +36,11 @@ val read_verdict_json : Yojson.Safe.t -> (swiss_verdict_json, string) result
     Returns [Error] if [schema_version] is not [1] or required fields are
     missing. *)
 
+val list_agents : base_path:string -> string list
+(** Return sorted agent names that have eval data under
+    [<base_path>/.oas/eval/].  Returns an empty list when the
+    directory does not exist.  Never raises. *)
+
 val read_latest :
   base_path:string -> agent_name:string -> limit:int -> eval_snapshot list
 (** Read the most recent [limit] eval snapshots for [agent_name].

--- a/lib/dashboard/dashboard_eval_feed.mli
+++ b/lib/dashboard/dashboard_eval_feed.mli
@@ -1,0 +1,55 @@
+(** Dashboard_eval_feed — read-only consumer for OAS eval verdicts.
+
+    Parses swiss-verdict JSON (RFC-OAS-002 schema v1) produced by the OAS
+    harness and exposes eval snapshots for dashboard rendering.
+
+    This module only reads.  It never writes or modifies eval data.
+    Data ownership belongs to OAS ({!Agent_sdk.Harness}). *)
+
+type layer_result_json = {
+  layer_name : string;
+  passed : bool;
+  score : float option;
+  evidence : string list;
+  detail : string option;
+}
+
+type swiss_verdict_json = {
+  schema_version : int;
+  all_passed : bool;
+  coverage : float;
+  layer_results : layer_result_json list;
+}
+
+type eval_snapshot = {
+  agent_name : string;
+  session_id : string option;
+  worker_run_id : string;
+  timestamp : float;
+  verdict : swiss_verdict_json;
+  coverage : float;
+  baseline_status : string option;
+      (** ["Improved"] | ["Regressed"] | ["Unchanged"] *)
+}
+
+val read_verdict_json : Yojson.Safe.t -> (swiss_verdict_json, string) result
+(** Parse a swiss-verdict JSON value conforming to RFC-OAS-002 schema v1.
+    Returns [Error] if [schema_version] is not [1] or required fields are
+    missing. *)
+
+val read_latest :
+  base_path:string -> agent_name:string -> limit:int -> eval_snapshot list
+(** Read the most recent [limit] eval snapshots for [agent_name].
+
+    File path convention: [<base_path>/.oas/eval/<agent_name>/*.json].
+    Each JSON file is expected to contain an eval envelope with a
+    [verdict] field conforming to the swiss-verdict schema.
+
+    Returns an empty list when the directory does not exist or contains
+    no parseable files.  Never raises. *)
+
+val snapshot_to_json : eval_snapshot -> Yojson.Safe.t
+(** Serialize an eval snapshot to JSON for HTTP responses. *)
+
+val verdict_to_json : swiss_verdict_json -> Yojson.Safe.t
+(** Serialize a swiss verdict to JSON. *)

--- a/lib/dashboard/dashboard_eval_feed.mli
+++ b/lib/dashboard/dashboard_eval_feed.mli
@@ -27,7 +27,6 @@ type eval_snapshot = {
   worker_run_id : string;
   timestamp : float;
   verdict : swiss_verdict_json;
-  coverage : float;
   baseline_status : string option;
       (** ["Improved"] | ["Regressed"] | ["Unchanged"] *)
 }

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -731,6 +731,36 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("last_compaction_event", match last_compaction_event with Some j -> j | None -> `Null);
               ("context", context);
               ("context_source", context_source);
+              (* Eval feed: latest verdict snapshot for this keeper (RFC-MASC-005) *)
+              ("eval_latest",
+                let base_path = config.base_path in
+                let try_name agent_name =
+                  Dashboard_eval_feed.read_latest ~base_path ~agent_name ~limit:1
+                in
+                let snapshots =
+                  match try_name m.name with
+                  | (_ :: _) as ss -> ss
+                  | [] when m.agent_name <> m.name -> try_name m.agent_name
+                  | other -> other
+                in
+                match snapshots with
+                | s :: _ ->
+                    `Assoc [
+                      ("coverage", `Float s.verdict.coverage);
+                      ("all_passed", `Bool s.verdict.all_passed);
+                      ("layer_count", `Int (List.length s.verdict.layer_results));
+                      ("passed_count",
+                        `Int (List.length (List.filter
+                          (fun (lr : Dashboard_eval_feed.layer_result_json) -> lr.passed)
+                          s.verdict.layer_results)));
+                      ("failed_count",
+                        `Int (List.length (List.filter
+                          (fun (lr : Dashboard_eval_feed.layer_result_json) -> not lr.passed)
+                          s.verdict.layer_results)));
+                      ("timestamp", `Float s.timestamp);
+                      ("baseline_status", Json_util.string_opt_to_json s.baseline_status);
+                    ]
+                | [] -> `Null);
             ] @ detail_fields)
           in
           Some summary)

--- a/lib/dune
+++ b/lib/dune
@@ -94,6 +94,7 @@
    dashboard_http_tool_quality
    dashboard_http_autoresearch
    dashboard_harness_health
+   dashboard_eval_feed
    dashboard_goals
    dashboard_feature_health
    dashboard_http_repo_synthesis

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -536,6 +536,55 @@ let handle_keeper_get_subroutes state req request reqd =
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if ends_with "/eval" then
+    let name = extract_name "/eval" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let base_path = state.Mcp_server.room_config.base_path in
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:10
+        |> max 1 |> min 100
+      in
+      (* Use keeper name as agent_name for eval lookup.
+         Keepers may also have a separate agent_name — look up both. *)
+      let config = state.Mcp_server.room_config in
+      let agent_name_opt =
+        match Keeper_types.read_meta config name with
+        | Ok (Some m) when m.agent_name <> name -> Some m.agent_name
+        | _ -> None
+      in
+      let snapshots_by_name =
+        Dashboard_eval_feed.read_latest ~base_path ~agent_name:name ~limit
+      in
+      let snapshots =
+        match agent_name_opt with
+        | Some agent_name when snapshots_by_name = [] ->
+            Dashboard_eval_feed.read_latest ~base_path ~agent_name ~limit
+        | _ -> snapshots_by_name
+      in
+      let latest_verdict =
+        match snapshots with
+        | s :: _ -> Some s.Dashboard_eval_feed.verdict
+        | [] -> None
+      in
+      let json = `Assoc [
+        ("keeper", `String name);
+        ("count", `Int (List.length snapshots));
+        ("latest_coverage",
+          match latest_verdict with
+          | Some v -> `Float v.Dashboard_eval_feed.coverage
+          | None -> `Null);
+        ("latest_all_passed",
+          match latest_verdict with
+          | Some v -> `Bool v.Dashboard_eval_feed.all_passed
+          | None -> `Null);
+        ("snapshots",
+          `List (List.map Dashboard_eval_feed.snapshot_to_json snapshots));
+      ] in
+      Http.Response.json ~compress:true ~request:req
+        (Yojson.Safe.to_string json) reqd
   else if ends_with "/state-diagram" then
     let name = extract_name "/state-diagram" in
     if String.length name = 0 then

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -328,6 +328,57 @@ let rec add_routes ~sw ~clock router =
            (Yojson.Safe.to_string json) reqd
        ) _request reqd)
 
+  (* ── Eval feed (RFC-MASC-005 Phase 2) ── *)
+  |> Http.Router.get "/api/v1/dashboard/eval-feed" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         let agent_name = Server_utils.query_param req "agent_name" in
+         let limit =
+           Server_utils.int_query_param req "limit" ~default:10
+           |> max 1 |> min 100
+         in
+         let json =
+           match agent_name with
+           | Some name when String.trim name <> "" ->
+               let snapshots =
+                 Dashboard_eval_feed.read_latest ~base_path
+                   ~agent_name:(String.trim name) ~limit
+               in
+               `Assoc [
+                 ("generated_at", `String (Types.now_iso ()));
+                 ("agent_name", `String (String.trim name));
+                 ("count", `Int (List.length snapshots));
+                 ("snapshots", `List (List.map Dashboard_eval_feed.snapshot_to_json snapshots));
+               ]
+           | _ ->
+               let agents = Dashboard_eval_feed.list_agents ~base_path in
+               let per_agent =
+                 List.map (fun name ->
+                   let snapshots =
+                     Dashboard_eval_feed.read_latest ~base_path
+                       ~agent_name:name ~limit:1
+                   in
+                   let latest =
+                     match snapshots with
+                     | s :: _ -> Dashboard_eval_feed.snapshot_to_json s
+                     | [] -> `Null
+                   in
+                   `Assoc [
+                     ("agent_name", `String name);
+                     ("latest", latest);
+                   ]
+                 ) agents
+               in
+               `Assoc [
+                 ("generated_at", `String (Types.now_iso ()));
+                 ("agent_count", `Int (List.length agents));
+                 ("agents", `List per_agent);
+               ]
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   (* ── Telemetry unified view ── *)
   |> Http.Router.get "/api/v1/dashboard/telemetry" (fun request reqd ->
        with_public_read (fun state req reqd ->

--- a/test/dune
+++ b/test/dune
@@ -234,6 +234,7 @@
         test_dashboard_http_core
         test_dashboard_autoresearch
         test_dashboard_harness_health
+        test_eval_feed
         test_dashboard_repo_synthesis
         test_dashboard_tools
         test_tool_quality_classify
@@ -382,6 +383,7 @@
         test_dashboard_http_core
         test_dashboard_autoresearch
         test_dashboard_harness_health
+        test_eval_feed
         test_dashboard_repo_synthesis
         test_dashboard_tools
         test_tool_quality_classify

--- a/test/test_eval_feed.ml
+++ b/test/test_eval_feed.ml
@@ -218,7 +218,7 @@ let test_read_latest_with_files () =
   let first = List.nth results 0 in
   check string "first worker_run_id" "run-002" first.worker_run_id;
   check string "first agent_name" "keeper-a" first.agent_name;
-  check (float 0.001) "first coverage" 0.90 first.coverage;
+  check (float 0.001) "first coverage" 0.85 first.verdict.coverage;
   (match first.session_id with
   | Some sid -> check string "first session_id" "sess-002" sid
   | None -> fail "expected session_id for first snapshot");
@@ -227,7 +227,7 @@ let test_read_latest_with_files () =
   | None -> fail "expected baseline_status for first snapshot");
   let second = List.nth results 1 in
   check string "second worker_run_id" "run-001" second.worker_run_id;
-  check (float 0.001) "second coverage" 0.80 second.coverage
+  check (float 0.001) "second coverage" 0.85 second.verdict.coverage
 
 let test_read_latest_with_limit () =
   let base = tmpdir "eval_limit" in
@@ -270,7 +270,6 @@ let test_snapshot_json_roundtrip () =
           worker_run_id = "run-abc-123";
           timestamp = 1700000000.0;
           verdict;
-          coverage = 0.85;
           baseline_status = Some "Improved";
         }
       in
@@ -279,10 +278,6 @@ let test_snapshot_json_roundtrip () =
         Masc_mcp.Safe_ops.json_string ~default:"" "agent_name" json_out
       in
       check string "agent_name roundtrip" "keeper-a" agent;
-      let cov =
-        Masc_mcp.Safe_ops.json_float ~default:0.0 "coverage" json_out
-      in
-      check (float 0.001) "coverage roundtrip" 0.85 cov;
       let verdict_j = Yojson.Safe.Util.member "verdict" json_out in
       let sv =
         Masc_mcp.Safe_ops.json_int ~default:0 "schema_version" verdict_j

--- a/test/test_eval_feed.ml
+++ b/test/test_eval_feed.ml
@@ -1,0 +1,345 @@
+open Alcotest
+
+module Eval_feed = Masc_mcp.Dashboard_eval_feed
+
+let test_counter = ref 0
+
+let tmpdir prefix =
+  incr test_counter;
+  let dir =
+    Filename.concat
+      (Filename.get_temp_dir_name ())
+      (Printf.sprintf "%s_%d_%d_%d" prefix (Unix.getpid ()) !test_counter
+         (int_of_float (Unix.gettimeofday () *. 1000.0)))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let mkdir_p path =
+  let rec aux current = function
+    | [] -> ()
+    | seg :: rest ->
+        let next = Filename.concat current seg in
+        (try Unix.mkdir next 0o755
+         with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+        aux next rest
+  in
+  let segments = String.split_on_char '/' path in
+  match segments with
+  | "" :: rest -> aux "/" rest
+  | _ -> aux "." segments
+
+let write_file path content =
+  let oc = open_out path in
+  output_string oc content;
+  close_out oc
+
+(* ── Sample JSON fixtures ────────────────────────────────────────── *)
+
+let valid_verdict_json =
+  {|{
+    "schema_version": 1,
+    "all_passed": true,
+    "coverage": 0.85,
+    "layer_results": [
+      {
+        "layer_name": "ToolSelected",
+        "passed": true,
+        "score": 0.95,
+        "evidence": ["correct tool chosen"],
+        "detail": null
+      },
+      {
+        "layer_name": "CompletesWithin",
+        "passed": true,
+        "score": 1.0,
+        "evidence": ["3/5 turns"],
+        "detail": "within budget"
+      },
+      {
+        "layer_name": "ContainsText",
+        "passed": false,
+        "score": null,
+        "evidence": ["missing expected output", "partial match"],
+        "detail": null
+      }
+    ]
+  }|}
+
+let valid_snapshot_json =
+  Printf.sprintf
+    {|{
+    "agent_name": "keeper-a",
+    "session_id": "sess-001",
+    "worker_run_id": "run-abc-123",
+    "timestamp": 1700000000.0,
+    "coverage": 0.85,
+    "baseline_status": "Improved",
+    "verdict": %s
+  }|}
+    valid_verdict_json
+
+(* ── Verdict parsing tests ───────────────────────────────────────── *)
+
+let test_parse_valid_verdict () =
+  let json = Yojson.Safe.from_string valid_verdict_json in
+  match Eval_feed.read_verdict_json json with
+  | Error msg -> fail ("unexpected error: " ^ msg)
+  | Ok verdict ->
+      check int "schema_version" 1 verdict.schema_version;
+      check bool "all_passed" true verdict.all_passed;
+      check (float 0.001) "coverage" 0.85 verdict.coverage;
+      check int "layer count" 3 (List.length verdict.layer_results);
+      let first = List.nth verdict.layer_results 0 in
+      check string "first layer name" "ToolSelected" first.layer_name;
+      check bool "first passed" true first.passed;
+      (match first.score with
+      | Some s -> check (float 0.001) "first score" 0.95 s
+      | None -> fail "expected score for first layer");
+      check (list string) "first evidence" [ "correct tool chosen" ]
+        first.evidence;
+      let third = List.nth verdict.layer_results 2 in
+      check string "third layer name" "ContainsText" third.layer_name;
+      check bool "third passed" false third.passed;
+      check bool "third score is none" true (Option.is_none third.score);
+      check (list string) "third evidence"
+        [ "missing expected output"; "partial match" ]
+        third.evidence
+
+let test_parse_wrong_schema_version () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version": 2, "all_passed": true, "coverage": 0.5, "layer_results": []}|}
+  in
+  match Eval_feed.read_verdict_json json with
+  | Ok _ -> fail "expected error for schema_version 2"
+  | Error msg ->
+      check bool "error mentions schema_version" true
+        (String.length msg > 0);
+      check bool "error mentions version 2" true
+        (try
+           ignore (Str.search_forward (Str.regexp_string "2") msg 0);
+           true
+         with Not_found -> false)
+
+let test_parse_missing_schema_version () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"all_passed": true, "coverage": 0.5, "layer_results": []}|}
+  in
+  match Eval_feed.read_verdict_json json with
+  | Ok _ -> fail "expected error for missing schema_version"
+  | Error _ -> ()
+
+let test_parse_empty_layer_results () =
+  let json =
+    Yojson.Safe.from_string
+      {|{"schema_version": 1, "all_passed": true, "coverage": 1.0, "layer_results": []}|}
+  in
+  match Eval_feed.read_verdict_json json with
+  | Error msg -> fail ("unexpected error: " ^ msg)
+  | Ok verdict ->
+      check bool "all_passed" true verdict.all_passed;
+      check int "layer count" 0 (List.length verdict.layer_results)
+
+let test_parse_layer_missing_name () =
+  let json =
+    Yojson.Safe.from_string
+      {|{
+        "schema_version": 1, "all_passed": false, "coverage": 0.0,
+        "layer_results": [{"passed": true, "evidence": []}]
+      }|}
+  in
+  match Eval_feed.read_verdict_json json with
+  | Ok _ -> fail "expected error for missing layer_name"
+  | Error msg ->
+      check bool "error mentions layer_name" true
+        (try
+           ignore
+             (Str.search_forward (Str.regexp_string "layer_name") msg 0);
+           true
+         with Not_found -> false)
+
+(* ── read_latest tests ───────────────────────────────────────────── *)
+
+let test_read_latest_empty_dir () =
+  let base = tmpdir "eval_empty" in
+  let result = Eval_feed.read_latest ~base_path:base ~agent_name:"keeper-a" ~limit:10 in
+  check int "empty result" 0 (List.length result)
+
+let test_read_latest_nonexistent_dir () =
+  let result =
+    Eval_feed.read_latest ~base_path:"/nonexistent/path"
+      ~agent_name:"keeper-a" ~limit:10
+  in
+  check int "empty result" 0 (List.length result)
+
+let test_read_latest_with_files () =
+  let base = tmpdir "eval_files" in
+  let eval_dir =
+    Filename.concat
+      (Filename.concat (Filename.concat base ".oas") "eval")
+      "keeper-a"
+  in
+  mkdir_p eval_dir;
+  (* Write two valid snapshot files *)
+  write_file
+    (Filename.concat eval_dir "001.json")
+    (Printf.sprintf
+       {|{
+         "worker_run_id": "run-001",
+         "timestamp": 1700000001.0,
+         "coverage": 0.80,
+         "baseline_status": "Unchanged",
+         "verdict": %s
+       }|}
+       valid_verdict_json);
+  write_file
+    (Filename.concat eval_dir "002.json")
+    (Printf.sprintf
+       {|{
+         "worker_run_id": "run-002",
+         "session_id": "sess-002",
+         "timestamp": 1700000002.0,
+         "coverage": 0.90,
+         "baseline_status": "Improved",
+         "verdict": %s
+       }|}
+       valid_verdict_json);
+  (* Write one invalid file *)
+  write_file (Filename.concat eval_dir "003.json") {|{"invalid": true}|};
+  (* Write a non-json file that should be ignored *)
+  write_file (Filename.concat eval_dir "readme.txt") "ignore me";
+  let results =
+    Eval_feed.read_latest ~base_path:base ~agent_name:"keeper-a" ~limit:10
+  in
+  check int "two valid snapshots" 2 (List.length results);
+  (* Sorted by filename descending, so 002 comes first *)
+  let first = List.nth results 0 in
+  check string "first worker_run_id" "run-002" first.worker_run_id;
+  check string "first agent_name" "keeper-a" first.agent_name;
+  check (float 0.001) "first coverage" 0.90 first.coverage;
+  (match first.session_id with
+  | Some sid -> check string "first session_id" "sess-002" sid
+  | None -> fail "expected session_id for first snapshot");
+  (match first.baseline_status with
+  | Some bs -> check string "first baseline_status" "Improved" bs
+  | None -> fail "expected baseline_status for first snapshot");
+  let second = List.nth results 1 in
+  check string "second worker_run_id" "run-001" second.worker_run_id;
+  check (float 0.001) "second coverage" 0.80 second.coverage
+
+let test_read_latest_with_limit () =
+  let base = tmpdir "eval_limit" in
+  let eval_dir =
+    Filename.concat
+      (Filename.concat (Filename.concat base ".oas") "eval")
+      "keeper-b"
+  in
+  mkdir_p eval_dir;
+  for i = 1 to 5 do
+    write_file
+      (Filename.concat eval_dir (Printf.sprintf "%03d.json" i))
+      (Printf.sprintf
+         {|{
+           "worker_run_id": "run-%03d",
+           "timestamp": %f,
+           "coverage": 0.5,
+           "verdict": %s
+         }|}
+         i
+         (1700000000.0 +. float_of_int i)
+         valid_verdict_json)
+  done;
+  let results =
+    Eval_feed.read_latest ~base_path:base ~agent_name:"keeper-b" ~limit:2
+  in
+  check int "limited to 2" 2 (List.length results)
+
+(* ── Serialization roundtrip ─────────────────────────────────────── *)
+
+let test_snapshot_json_roundtrip () =
+  let json = Yojson.Safe.from_string valid_snapshot_json in
+  match Eval_feed.read_verdict_json (Yojson.Safe.Util.member "verdict" json) with
+  | Error msg -> fail ("verdict parse failed: " ^ msg)
+  | Ok verdict ->
+      let snapshot : Eval_feed.eval_snapshot =
+        {
+          agent_name = "keeper-a";
+          session_id = Some "sess-001";
+          worker_run_id = "run-abc-123";
+          timestamp = 1700000000.0;
+          verdict;
+          coverage = 0.85;
+          baseline_status = Some "Improved";
+        }
+      in
+      let json_out = Eval_feed.snapshot_to_json snapshot in
+      let agent =
+        Masc_mcp.Safe_ops.json_string ~default:"" "agent_name" json_out
+      in
+      check string "agent_name roundtrip" "keeper-a" agent;
+      let cov =
+        Masc_mcp.Safe_ops.json_float ~default:0.0 "coverage" json_out
+      in
+      check (float 0.001) "coverage roundtrip" 0.85 cov;
+      let verdict_j = Yojson.Safe.Util.member "verdict" json_out in
+      let sv =
+        Masc_mcp.Safe_ops.json_int ~default:0 "schema_version" verdict_j
+      in
+      check int "schema_version in output" 1 sv
+
+let test_verdict_to_json () =
+  let verdict : Eval_feed.swiss_verdict_json =
+    {
+      schema_version = 1;
+      all_passed = false;
+      coverage = 0.42;
+      layer_results =
+        [
+          {
+            layer_name = "L1";
+            passed = true;
+            score = Some 0.9;
+            evidence = [ "ok" ];
+            detail = None;
+          };
+        ];
+    }
+  in
+  let json = Eval_feed.verdict_to_json verdict in
+  let ap = Masc_mcp.Safe_ops.json_bool ~default:true "all_passed" json in
+  check bool "all_passed false" false ap;
+  let cov = Masc_mcp.Safe_ops.json_float ~default:0.0 "coverage" json in
+  check (float 0.001) "coverage" 0.42 cov
+
+(* ── Test suite ──────────────────────────────────────────────────── *)
+
+let () =
+  run "Dashboard_eval_feed"
+    [
+      ( "verdict_parsing",
+        [
+          test_case "valid verdict" `Quick test_parse_valid_verdict;
+          test_case "wrong schema_version" `Quick
+            test_parse_wrong_schema_version;
+          test_case "missing schema_version" `Quick
+            test_parse_missing_schema_version;
+          test_case "empty layer_results" `Quick
+            test_parse_empty_layer_results;
+          test_case "layer missing name" `Quick test_parse_layer_missing_name;
+        ] );
+      ( "read_latest",
+        [
+          test_case "empty directory" `Quick test_read_latest_empty_dir;
+          test_case "nonexistent directory" `Quick
+            test_read_latest_nonexistent_dir;
+          test_case "with files" `Quick test_read_latest_with_files;
+          test_case "with limit" `Quick test_read_latest_with_limit;
+        ] );
+      ( "serialization",
+        [
+          test_case "snapshot roundtrip" `Quick test_snapshot_json_roundtrip;
+          test_case "verdict_to_json" `Quick test_verdict_to_json;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- RFC-MASC-005 Phase 1: Eval Feed Reader Module
- Read-only consumer for OAS swiss-verdict JSON (RFC-OAS-002 schema v1)
- Parses verdict files from `.oas/eval/<agent_name>/*.json`
- Types: `swiss_verdict_json`, `layer_result_json`, `eval_snapshot`
- Functions: `read_verdict_json`, `read_latest`, `snapshot_to_json`, `verdict_to_json`

## Files

| File | Description |
|------|-------------|
| `lib/dashboard/dashboard_eval_feed.ml` | Implementation (read-only parser + filesystem reader) |
| `lib/dashboard/dashboard_eval_feed.mli` | Public interface |
| `test/test_eval_feed.ml` | 11 tests (parsing, error cases, filesystem, serialization) |
| `lib/dune` | Module registration |
| `test/dune` | Test registration |

## Design decisions

- Follows existing `dashboard_harness_health.ml` patterns: `Safe_ops.json_*` for parsing, `Json_util.*_opt_to_json` for serialization
- `schema_version != 1` returns `Error` (forward-compatible gate per RFC)
- `read_latest` never raises; returns empty list on missing dir or parse failures
- Public module (not private) — Phase 2 HTTP routes will consume this from `server_dashboard_http.ml`

## Known: pre-existing build errors

`dune build` fails on 5 files (`oas_worker_exec.ml`, `keeper_agent_run.ml`, `worker_container.ml`, `keeper_status_detail.ml`, `dashboard_http_keeper.ml`) due to OAS pin v0.124.2 API changes (`named_cascade` removal, `max_tokens` now `int option`). These are pre-existing on `main` and unrelated to this PR.

## Test plan

- [ ] Verify `dune build` passes after OAS pin alignment PR
- [ ] Run `dune exec test/test_eval_feed.exe` — 11 tests covering verdict parsing, schema version gate, empty/nonexistent dirs, limit, JSON roundtrip

## References

- RFC: `docs/rfc/RFC-MASC-005-dashboard-oas-eval-consumer.md`
- OAS schema: `docs/schemas/swiss-verdict.schema.json` (OAS repo, PR #869)
- Next: Phase 2 (HTTP routes), Phase 3 (UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)