### PR TITLE
feat(keeper): integrate Cap_message_tokens — Layer 1 uranium666 fix

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.125.0))
+  (agent_sdk (>= 0.126.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1392,6 +1392,7 @@ let run_turn
       Agent_sdk.Context_reducer.drop_thinking;
       Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:3;
       Agent_sdk.Context_reducer.prune_tool_outputs ~max_output_len:4000;
+      Agent_sdk.Context_reducer.cap_message_tokens ~max_tokens:32000 ~keep_recent:3;
       Agent_sdk.Context_reducer.repair_dangling_tool_calls;
       Agent_sdk.Context_reducer.merge_contiguous;
     ]

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.125.0"}
+  "agent_sdk" {>= "0.126.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.125.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.126.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="v0.125.0"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.125.0"
+readonly OAS_AGENT_SDK_SHA="v0.126.0"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.126.0"

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -15,7 +15,11 @@
       limit from the recovery path.
 
     Property 4 (Structural absence):
-      keeper_agent_run source does NOT contain ~max_input_tokens. *)
+      keeper_agent_run source does NOT contain ~max_input_tokens.
+
+    Property 5 (Reducer integration):
+      keeper_agent_run source contains cap_message_tokens in the
+      keeper reducer chain, ordered before repair_dangling_tool_calls. *)
 
 module UT = Masc_mcp.Keeper_unified_turn
 
@@ -129,6 +133,59 @@ let test_structural_absence () =
       false has_max_input_tokens
   end
 
+let test_cap_message_tokens_integration () =
+  let find_substring haystack needle =
+    let hlen = String.length haystack in
+    let nlen = String.length needle in
+    let rec loop i =
+      if i + nlen > hlen then None
+      else if String.sub haystack i nlen = needle then Some i
+      else loop (i + 1)
+    in
+    if nlen = 0 then Some 0 else loop 0
+  in
+  let has_prompt_root path =
+    Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
+  in
+  let repo_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root when has_prompt_root root -> root
+    | _ ->
+        let rec ascend path =
+          if has_prompt_root path then path
+          else
+            let parent = Filename.dirname path in
+            if String.equal parent path then Sys.getcwd () else ascend parent
+        in
+        ascend (Sys.getcwd ())
+  in
+  let target = Filename.concat repo_root "lib/keeper/keeper_agent_run.ml" in
+  if not (Sys.file_exists target) then
+    ()
+  else begin
+    let ic = open_in target in
+    let content = Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () ->
+        let len = in_channel_length ic in
+        let buf = Bytes.create len in
+        really_input ic buf 0 len;
+        Bytes.to_string buf)
+    in
+    let cap_pos =
+      find_substring content "Agent_sdk.Context_reducer.cap_message_tokens"
+    in
+    let repair_pos =
+      find_substring content "Agent_sdk.Context_reducer.repair_dangling_tool_calls"
+    in
+    Alcotest.(check bool)
+      "keeper_agent_run.ml must integrate cap_message_tokens before repair_dangling_tool_calls"
+      true
+      (match cap_pos, repair_pos with
+       | Some cap_pos, Some repair_pos -> cap_pos < repair_pos
+       | _ -> false)
+  end
+
 (* ── Gospel-style specification (documentation) ────────── *)
 (*
    @gospel — formal specification (Ortac runtime not available on 5.4)
@@ -166,5 +223,7 @@ let () =
     ("structural", [
       Alcotest.test_case "absence of max_input_tokens" `Quick
         test_structural_absence;
+      Alcotest.test_case "cap_message_tokens integrated in reducer chain" `Quick
+        test_cap_message_tokens_integration;
     ]);
   ]


### PR DESCRIPTION
## Summary

- Insert `cap_message_tokens ~max_tokens:32000 ~keep_recent:3` into the keeper reducer chain
- Bump the OAS pin to a release that includes `Context_reducer.cap_message_tokens`
- Add a structural regression test that locks the integration into `keeper_agent_run.ml`

## Product impact

- Prevent large single-message keeper turns from overflowing prompt prefill and crashing the MLX-backed keeper path
- Reduce the chance that `uranium666` and similarly large keepers die before completion when one turn accumulates extreme tool-result volume

## Motivation

`max_checkpoint_messages=120` caps message count but not per-message size. A single keeper message can still balloon to hundreds of tool result blocks and exceed the effective prefill budget. `Agent_sdk.Context_reducer.cap_message_tokens` adds the missing per-message safety net.

## Reducer Chain

```ocaml
drop_thinking -> stub_tool_results(3) -> prune_tool_outputs(4000)
  -> cap_message_tokens(32000, 3)
  -> repair_dangling -> merge_contiguous
```

## Evidence

- `opam exec -- dune build --root . lib/keeper/keeper_agent_run.ml`
- `opam exec -- dune build --root . test/test_pbt_context_overflow.exe`
- `_build/default/test/test_pbt_context_overflow.exe`

## Review evidence

- direct ZAI `sb glm-text --no-thinking`
- head `ffec246d0`
- result: `No findings.`

## Linked issue

- Refs #6786

## Test plan

- [x] `opam exec -- dune build --root . lib/keeper/keeper_agent_run.ml`
- [x] `opam exec -- dune build --root . test/test_pbt_context_overflow.exe`
- [x] `_build/default/test/test_pbt_context_overflow.exe`
- [ ] CI checks green
- [ ] Verify uranium666 keeper survives after fix
