### PR TITLE
feat(cascade): mid-turn resume on provider failure

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -262,8 +262,15 @@ let run_named
   let queue_priority =
     Option.value priority ~default:Llm_provider.Request_priority.Proactive
   in
-  (* MASC-driven cascade FSM: try each provider, decide on failure *)
-  let try_provider (provider_cfg : Llm_provider.Provider_config.t) =
+  (* MASC-driven cascade FSM: try each provider, decide on failure.
+     Mid-turn resume: when a provider fails after completing some turns,
+     the next provider resumes from the failed agent's checkpoint instead
+     of restarting from scratch.
+
+     Immutable checkpoint threading: try_provider returns both the result
+     and the agent's checkpoint (if progress was made). try_cascade
+     threads this checkpoint to the next provider without mutable state. *)
+  let try_provider ?resume_checkpoint (provider_cfg : Llm_provider.Provider_config.t) =
     let provider : Agent_sdk.Provider.config =
       Agent_sdk.Provider.config_of_provider_config provider_cfg
     in
@@ -294,10 +301,30 @@ let run_named
         initial_messages; raw_trace; yield_on_tool;
       }
     in
-    Oas_worker_exec.run ~sw ~net ~config ?oas_checkpoint ?on_event
-      ?on_yield ?on_resume ?agent_ref ?proof_ref ?contract goal
+    let effective_checkpoint = match resume_checkpoint with
+      | Some _ -> resume_checkpoint
+      | None -> oas_checkpoint
+    in
+    let local_agent_ref : Oas.Agent.t option ref = ref None in
+    let result =
+      Oas_worker_exec.run ~sw ~net ~config ?oas_checkpoint:effective_checkpoint ?on_event
+        ?on_yield ?on_resume ~agent_ref:local_agent_ref ?proof_ref ?contract goal
+    in
+    (* Extract checkpoint from the agent if it made progress.
+       The agent's mutable state reflects all completed turns even on Error. *)
+    let checkpoint_after = match !local_agent_ref with
+      | Some agent when (Oas.Agent.state agent).turn_count > 0 ->
+        (* Also propagate to caller's agent_ref for final result *)
+        (match agent_ref with Some r -> r := Some agent | None -> ());
+        Some (Oas.Agent.checkpoint agent)
+      | Some agent ->
+        (match agent_ref with Some r -> r := Some agent | None -> ());
+        None
+      | None -> None
+    in
+    (result, checkpoint_after)
   in
-  let rec try_cascade remaining last_err =
+  let rec try_cascade ?resume_checkpoint remaining last_err =
     match remaining with
     | [] ->
       let err_msg = match last_err with
@@ -318,7 +345,14 @@ let run_named
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
       let is_last = rest = [] in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name provider_cfg.model_id is_last;
-      match try_provider provider_cfg with
+      let (result, checkpoint_after) = try_provider ?resume_checkpoint provider_cfg in
+      (* Thread checkpoint forward: if this provider made progress,
+         the next provider can resume from where this one left off. *)
+      let next_resume = match checkpoint_after with
+        | Some _ -> checkpoint_after
+        | None -> resume_checkpoint
+      in
+      (match result with
       | Ok result when accept result.response ->
         (* FSM: Call_ok → Accept *)
         let observation =
@@ -345,7 +379,7 @@ let run_named
          | Llm_provider.Cascade_fsm.Try_next { last_err = new_err } ->
            Log.Misc.warn "cascade %s: accept rejected %s, trying next" cascade_name provider_cfg.model_id;
            metrics.on_cascade_fallback ~from_model:provider_cfg.model_id ~to_model:"next" ~reason;
-           try_cascade rest new_err
+           try_cascade ?resume_checkpoint:next_resume rest new_err
          | Llm_provider.Cascade_fsm.Exhausted _ ->
            let observation =
              Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
@@ -364,7 +398,7 @@ let run_named
               Log.Misc.warn "cascade %s: %s failed, trying next" cascade_name provider_cfg.model_id;
               metrics.on_cascade_fallback ~from_model:provider_cfg.model_id ~to_model:"next"
                 ~reason:(Oas.Error.to_string sdk_err);
-              try_cascade rest new_err
+              try_cascade ?resume_checkpoint:next_resume rest new_err
             | Llm_provider.Cascade_fsm.Exhausted _ ->
               let observation =
                 Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
@@ -380,7 +414,7 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:None ~capture
            in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
-           Error sdk_err)
+           Error sdk_err))
   in
   try
     Admission_queue.with_permit ?wait_timeout_sec


### PR DESCRIPTION
## Summary

Cascade fallback 시 이전 provider에서 완료한 턴을 보존합니다. Provider A가 3턴 후 실패하면, Provider B는 0턴이 아닌 3턴 checkpoint에서 resume합니다.

- `try_provider`가 `(result, checkpoint_after)` 튜플 반환
- checkpoint는 immutable하게 재귀를 통해 threading
- agent의 mutable state에서 추출 (Agent.run 실패 후에도 유효)
- OAS 변경 0줄 — `Agent.t`의 in-place state update + `Agent.checkpoint` 활용

## Product impact

keeper가 cascade fallback 시 이전 provider에서 완료한 대화 턴을 잃지 않음. 3턴 후 provider 장애가 발생해도 다음 provider에서 4턴째부터 이어감.

## Evidence

- OAS `Agent.t`의 mutable state는 `Agent.run` 실패 후에도 유효 (oas/lib/agent/agent.ml:136 `run_turn_core` -> `update_state`)
- `agent_ref`는 `Agent.run` 전에 설정됨 (oas_worker_exec.ml:508)
- `Agent.checkpoint`는 현재 state를 직렬화 (checkpoint.ml)
- `Agent.resume`은 checkpoint에서 agent를 재구성 (agent.ml:269)

## Review evidence

GLM-5.1 cross-review: **Approve**. checkpoint threading 로직 유효, immutable state 요구사항 충족. 제안: zero-turn/error/multi-cascade 테스트 추가 (별도 PR 예정).

## Linked issue

Refs jeong-sik/me#987

## Test plan

- [x] `dune build --root .` green
- [x] `dune runtest --root .` green
- [x] CI checks all green
- [x] GLM-5.1 교차 모델 리뷰 완료