### PR TITLE
[codex] Reduce CI workflow fan-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: Release Train
     runs-on: ubuntu-latest
     needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && github.base_ref == 'main' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     timeout-minutes: 5
 
     steps:
@@ -53,7 +53,6 @@ jobs:
           fetch-tags: true
 
       - name: Guard pending release tag on main PRs
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
         env:
           BASE_REF: origin/${{ github.base_ref }}
           HEAD_REF: ${{ github.event.pull_request.head.sha }}
@@ -64,16 +63,20 @@ jobs:
             --base "$BASE_REF" \
             --head "$HEAD_REF"
 
-      - name: Skip outside main PRs
-        if: github.event_name != 'pull_request' || github.base_ref != 'main'
-        run: echo "::notice::Release train guard only applies to PRs targeting main"
-
-  health:
-    name: Health
+  changes:
+    name: Detect Changed Surfaces
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: [pr-sync-check, release-train]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && needs.release-train.result == 'success' }}
+    timeout-minutes: 5
+    needs: [pr-sync-check]
+    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    outputs:
+      build: ${{ steps.scope.outputs.build }}
+      lint: ${{ steps.scope.outputs.lint }}
+      dashboard: ${{ steps.scope.outputs.dashboard }}
+      health: ${{ steps.scope.outputs.health }}
+      health_snapshot: ${{ steps.scope.outputs.health_snapshot }}
+      tla: ${{ steps.scope.outputs.tla }}
+      oas_pin: ${{ steps.scope.outputs.oas_pin }}
 
     steps:
       - name: Checkout
@@ -81,19 +84,153 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect scope
+        id: scope
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_BEFORE: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          emit_all_true() {
+            for key in build lint dashboard health health_snapshot tla oas_pin; do
+              echo "${key}=true" >> "$GITHUB_OUTPUT"
+            done
+          }
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            emit_all_true
+            echo "::notice::workflow_dispatch forces every CI surface to run"
+            exit 0
+          fi
+
+          changed_file_list="$(mktemp)"
+          base_ref=""
+          head_ref="${GITHUB_SHA}"
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            git fetch origin "${GITHUB_BASE_REF}" --depth=200
+            base_ref="origin/${GITHUB_BASE_REF}"
+            head_ref="${GITHUB_HEAD_SHA}"
+          elif [ -n "${GITHUB_BEFORE}" ] && [ "${GITHUB_BEFORE}" != "0000000000000000000000000000000000000000" ]; then
+            base_ref="${GITHUB_BEFORE}"
+          fi
+
+          if [ -n "${base_ref}" ]; then
+            git diff --name-only "${base_ref}" "${head_ref}" > "${changed_file_list}"
+          else
+            git ls-files > "${changed_file_list}"
+          fi
+
+          if [ ! -s "${changed_file_list}" ]; then
+            git ls-files > "${changed_file_list}"
+          fi
+
+          echo "Changed files:"
+          sed 's/^/  - /' "${changed_file_list}"
+
+          has_match() {
+            grep -Eq "$1" "${changed_file_list}"
+          }
+
+          ci_core=false
+          build=false
+          lint=false
+          dashboard=false
+          health=false
+          health_snapshot=false
+          tla=false
+          oas_pin=false
+
+          if has_match '^(\.github/workflows/ci\.yml|\.github/actions/)'; then
+            ci_core=true
+          fi
+
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/ci-run-tests\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
+            build=true
+          fi
+
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/check-eio-conventions\.sh$|scripts/check-feature-flag-consistency\.sh$|scripts/check-toml-syntax\.sh$|scripts/validate-prompt-paths\.sh$|scripts/check-boundary-guard\.sh$|scripts/gen-grpc-descriptors\.sh$)'; then
+            lint=true
+          fi
+
+          if has_match '^dashboard/'; then
+            dashboard=true
+          fi
+
+          if has_match '^(bin/|lib/|docs/|README\.md$|CHANGELOG\.md$|\.ci/health-baseline\.json$|dune-project$|.*\.opam$|scripts/check-doc-truth\.sh$|scripts/check-version-truth\.sh$|scripts/health_snapshot\.sh$|scripts/anti-fake-audit\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/sync-oas-pin-docs\.sh$)'; then
+            health=true
+          fi
+
+          if has_match '^(bin/|lib/|test/|proto/|config/|\.ci/health-baseline\.json$|dune-project$|.*\.opam$|scripts/health_snapshot\.sh$|scripts/anti-fake-audit\.sh$)'; then
+            health_snapshot=true
+          fi
+
+          if has_match '^(specs/|lib/keeper/|lib/oas_.*\.ml$|Makefile$)'; then
+            tla=true
+          fi
+
+          if has_match '^(ci/check-oas-pin\.sh$|scripts/check-oas-pin\.sh$|scripts/oas-agent-sdk-pin\.sh$|scripts/sync-oas-pin-docs\.sh$|dune-project$|masc_mcp\.opam$|docs/KEEPER-USER-MANUAL\.md$|docs/OAS-UTILIZATION-AUDIT\.md$)'; then
+            oas_pin=true
+          fi
+
+          if [ "${ci_core}" = true ]; then
+            build=true
+            lint=true
+            dashboard=true
+            health=true
+            health_snapshot=true
+            tla=true
+            oas_pin=true
+          fi
+
+          echo "build=${build}" >> "$GITHUB_OUTPUT"
+          echo "lint=${lint}" >> "$GITHUB_OUTPUT"
+          echo "dashboard=${dashboard}" >> "$GITHUB_OUTPUT"
+          echo "health=${health}" >> "$GITHUB_OUTPUT"
+          echo "health_snapshot=${health_snapshot}" >> "$GITHUB_OUTPUT"
+          echo "tla=${tla}" >> "$GITHUB_OUTPUT"
+          echo "oas_pin=${oas_pin}" >> "$GITHUB_OUTPUT"
+
+          printf 'CI scope => build=%s lint=%s dashboard=%s health=%s health_snapshot=%s tla=%s oas_pin=%s\n' \
+            "${build}" "${lint}" "${dashboard}" "${health}" "${health_snapshot}" "${tla}" "${oas_pin}"
+
+  health:
+    name: Health
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [pr-sync-check, release-train, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.health == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && (needs.release-train.result == 'success' || needs.release-train.result == 'skipped') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install health shell dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ripgrep bc
+
       - name: Setup OCaml toolchain
+        if: needs.changes.outputs.health_snapshot == 'true'
         uses: ./.github/actions/setup-ocaml-toolchain
 
       - name: Pin external OCaml dependencies
+        if: needs.changes.outputs.health_snapshot == 'true'
         uses: ./.github/actions/pin-ocaml-deps
         with:
           pin-flags: --with-bisect
 
       - name: Install system and OCaml dependencies
+        if: needs.changes.outputs.health_snapshot == 'true'
         uses: ./.github/actions/install-ocaml-deps
         with:
           install-flags: --with-test
-          os-packages: ripgrep bc
 
       - name: Verify OAS pin ratchet
         run: |
@@ -107,10 +244,11 @@ jobs:
           scripts/check-version-truth.sh
 
       - name: Fetch base branch for health ratchet
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && needs.changes.outputs.health_snapshot == 'true'
         run: git fetch origin "${{ github.base_ref }}" --depth=1
 
       - name: Run health snapshot
+        if: needs.changes.outputs.health_snapshot == 'true'
         env:
           HEALTH_BASELINE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || '' }}
         run: |
@@ -128,6 +266,7 @@ jobs:
           fi
 
       - name: Upload health snapshot
+        if: needs.changes.outputs.health_snapshot == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: health-snapshot
@@ -136,8 +275,8 @@ jobs:
   oas-pin-check:
     name: OAS Pin Consistency
     runs-on: ubuntu-latest
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.oas_pin == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
     timeout-minutes: 3
 
     steps:
@@ -178,8 +317,8 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [pr-sync-check, release-train]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && needs.release-train.result == 'success' }}
+    needs: [pr-sync-check, release-train, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.build == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') && (needs.release-train.result == 'success' || needs.release-train.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -283,8 +422,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.lint == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -342,8 +481,8 @@ jobs:
     name: Dashboard
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [pr-sync-check]
-    if: ${{ !cancelled() && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
+    needs: [pr-sync-check, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.dashboard == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout
@@ -410,6 +549,8 @@ jobs:
     name: TLA+ Model Checking
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [pr-sync-check, changes]
+    if: ${{ !cancelled() && needs.changes.outputs.tla == 'true' && (needs.pr-sync-check.result == 'success' || needs.pr-sync-check.result == 'skipped') }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/planning-hygiene.yml
+++ b/.github/workflows/planning-hygiene.yml
@@ -2,7 +2,7 @@ name: Planning Hygiene
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/planning-hygiene.yml
+++ b/.github/workflows/planning-hygiene.yml
@@ -2,7 +2,7 @@ name: Planning Hygiene
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/sweep-supersede-check.yml
+++ b/.github/workflows/sweep-supersede-check.yml
@@ -5,7 +5,7 @@ name: Sweep Supersede Check
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/sweep-supersede-check.yml
+++ b/.github/workflows/sweep-supersede-check.yml
@@ -5,7 +5,7 @@ name: Sweep Supersede Check
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Reduce PR-time CI fan-out so unrelated changes stop triggering the full workflow matrix.

## Product impact

- Promise affected: `delivery swarm`
- User-visible change: docs-only or PR-metadata-only changes now skip unrelated heavy CI jobs, while code-path changes still run the relevant gates.

## Evidence

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/ci.yml .github/workflows/planning-hygiene.yml .github/workflows/sweep-supersede-check.yml`
- `git diff --check`
- scope simulation:
  - `docs/KEEPER-USER-MANUAL.md` => `build=false lint=false dashboard=false health=true health_snapshot=false tla=false oas_pin=true`
  - `.github/workflows/planning-hygiene.yml` => all heavy CI surfaces `false`
- recent GitHub run evidence showed each PR spawning CI plus four PR-target workflows, and CI itself fan-outing into `Build and Test`, `Lint`, `Health`, `Dashboard`, and `TLA+ Model Checking` even for unrelated changes.

## Review evidence

- `GLM-5` direct review on `main...codex/reduce-ci-fanout` workflow diff
- Result: `No findings.`
- One earlier review raised a valid concern about dropping `synchronize` from PR-meta workflows; that was patched in follow-up commit `d934d8c79`.

## Linked issue

- Relates #3551
