### PR TITLE
refactor(playground): centralize SSOT for playground paths and worktree naming

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -40,7 +40,7 @@ File operations:
 Workspace:
 - Your playground is `.masc/playground/{your-name}/` with three subdirs:
   - `mind/` — notes, drafts, scratchpads
-  - `repos/` — git clones (one per repo, e.g. `repos/masc-mcp/`)
+  - `repos/` — git clones (one per repo, e.g. `repos/masc-mcp/`) — this is your default coding workspace
   - bundle root — general workspace files
 - All paths come from keeper_context_status: use `playground_bundle`, `playground_mind`, `playground_repos` directly.
 - Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{playground_repos}/{repo}/` automatically.
@@ -54,7 +54,8 @@ PR workflow (Coding/Delivery/Full preset required):
 1. `masc_worktree_create task_id=<id>` — opens isolated branch
 2. `masc_code_read` → `masc_code_edit` — read first, then edit
 3. `masc_code_git action=add` → `action=commit` → `action=push` — all with cwd inside the worktree
-4. `keeper_pr_submit cwd=<worktree-path> commit_message=<msg> pr_title=<title>` — creates draft PR
+4. `keeper_pr_submit` is the canonical submit step after editing. It creates a draft PR from the worktree.
+  NOTE: Do NOT use keeper_pr_workflow — it is deprecated and will error.
 
 Knowledge lookup:
 - Past conversations and messages: keeper_memory_search

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -44,7 +44,7 @@ Workspace:
   - bundle root — general workspace files
 - All paths come from keeper_context_status: use `playground_bundle`, `playground_mind`, `playground_repos` directly.
 - Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{playground_repos}/{repo}/` automatically.
-- Worktrees: live inside clones at `{playground_repos}/{repo}/.worktrees/{your-name}-{task_id}/`. Branch name: `{your-name}/{task_id}`.
+- Worktrees: live inside clones at `.masc/playground/{your-name}/repos/{repo}/.worktrees/{your-name}-{task_id}/`. Branch name: `{your-name}/{task_id}`.
 
 Clone-then-worktree rule (two turns, never one):
 1. If `repos/` is empty, clone first: `keeper_shell op=git_clone url=...`

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -6,14 +6,14 @@ category: keeper
 ## Rules (violating these wastes your turn budget)
 
 Before any file or path operation, follow this order:
-1. Call keeper_context_status. The response gives you `name` plus three ready-made relative paths — `playground_bundle`, `playground_mind`, `playground_repos`. Prefer these over reconstructing `.masc/playground/<name>/...` strings yourself.
-2. If you need a subpath (e.g. a specific repo), append to `playground_repos` — e.g. `<playground_repos>/<repo-name>/<file>`.
+1. Call keeper_context_status. The response gives you `name` plus three ready-made relative paths — `playground_bundle`, `playground_mind`, `playground_repos`. Use these directly instead of reconstructing paths yourself.
+2. If you need a subpath (e.g. a specific repo), append to `playground_repos` — e.g. `{playground_repos}/{repo-name}/{file}`.
 3. Call keeper_shell op=ls on the path to verify it exists before reading/writing.
 4. Then proceed with the file operation.
 
-NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/YOUR_KEEPER_NAME/`. This includes keeper_bash, masc_code_git, keeper_pr_submit, and masc_code_edit. The server blocks violations, but relying on server rejection wastes your turn budget.
-NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs` — do not invent repos outside that list.
-NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call. Split into separate calls.
+NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/{name}/`. The server blocks violations, and each rejection wastes your turn budget.
+NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs`.
+NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call.
 NEVER request files without verifying they exist via keeper_shell op=ls.
 When a tool call fails, read the error message carefully. Do not retry with the same arguments.
 
@@ -21,7 +21,7 @@ keeper_bash examples:
   BAD:  cmd="git log --oneline | head -5"          (pipe blocked)
   GOOD: keeper_shell op=git_log count=5              (use dedicated op)
   BAD:  cmd="cd repos && ls"                         (chaining blocked)
-  GOOD: keeper_shell op=ls path=.masc/playground/<your-name>/repos/  (single op with path)
+  GOOD: keeper_shell op=ls path={playground_repos}    (single op with path from keeper_context_status)
 
 ## What you can do with your tools
 
@@ -33,34 +33,28 @@ File operations:
 - View file (raw): keeper_shell with op=cat, path=<file>
 - Git history: keeper_shell with op=git_log, count=10 (optional: path=<file>, format="%h %s %an")
 - Git status: keeper_shell with op=git_status
-- Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Delivery/Full preset)
-  IMPORTANT: keeper_bash runs ONE command per call. No pipes (|), no chaining (&&, ||, ;), no redirects (>, >>). Split into separate tool calls instead.
-- Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable path: .masc/playground/YOUR_KEEPER_NAME/ (use keeper_context_status to confirm your name).
+- Run shell commands: keeper_bash with cmd=<command> (read-only unless Coding/Delivery/Full preset). ONE command per call — no pipes, chaining, or redirects.
+- Write or create a file: keeper_fs_edit (Coding/Delivery/Full). Writable scope: your playground only.
 - GitHub CLI: keeper_github with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
 
 Workspace:
-- Your writable workspace is `.masc/playground/YOUR_KEEPER_NAME/`. Use keeper_fs_edit to write files there.
-- The playground bundle has three canonical subdirs: `mind/` (notes and scratch), `repos/` (cloned repos for coding), and the bundle root itself for general work.
-- Your clones live under `.masc/playground/YOUR_KEEPER_NAME/repos/<REPO_NAME>/` — this is your default coding workspace. Use `keeper_shell op=ls path=.masc/playground/YOUR_KEEPER_NAME/repos/` to see which clones you currently have.
-- If `repos/` is empty, use `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` to create one. The clone lands at `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/` automatically.
-- playground is your sandbox; worktrees are repo-scoped branch workflows. Use `masc_worktree_create` only for worktrees under a git clone inside your playground `repos/` (alphabetical first clone, or whichever `repo_name` you pass). If `repos/` is empty, do not call it yet; clone first and treat any worktree path outside your playground as invalid.
-- You MUST have a clone under `.masc/playground/YOUR_KEEPER_NAME/repos/` before calling `masc_worktree_create`. If `repos/` is empty, call `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` first, then open the worktree. Do not try to operate on the MASC server repository directly.
-- Refusal pattern when `repos/` is empty — follow these three steps in order and do NOT call `masc_worktree_create` in the same turn:
-  1. Observation: "repos/ is empty, I have no clone yet."
-  2. Action: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git`
-  3. Only on the NEXT turn, after the clone returns ok, call `masc_worktree_create`.
-- If you have multiple clones and want to target a specific one, pass `repo_name=<clone-dir-name>` to `masc_worktree_create`. Example: `repo_name='masc-mcp'` when your repos/ has both `masc-mcp/` and `kirin/`.
-- `keeper_pr_submit` is the canonical submit step after editing.
-- `keeper_pr_workflow` is a legacy one-shot worktree helper. Prefer `keeper_pr_submit`.
-- PR creation workflow (requires Coding, Delivery, or Full preset). Every `cwd` in this sequence MUST resolve under `.masc/playground/YOUR_KEEPER_NAME/repos/<repo>/.worktrees/<worktree-name>/`. Never pass a `cwd` outside your playground.
-  1. masc_worktree_create task_id=<your-task-id>  (creates worktree INSIDE the playground clone that `repos/` resolves to — the returned path starts with `.masc/playground/YOUR_KEEPER_NAME/repos/`)
-  2. masc_code_read path=<file-to-modify>  (read the file first — understand before editing)
-  3. masc_code_edit path=<path> old_string=<before> new_string=<after>  (edit the file)
-  4. masc_code_git action=add cwd=<playground-worktree-path>  (stage changes)
-  5. masc_code_git action=commit cwd=<playground-worktree-path> args=["-m","<commit-message>"]  (commit)
-  6. masc_code_git action=push cwd=<playground-worktree-path>  (push)
-  7. keeper_pr_submit cwd=<playground-worktree-path> commit_message=<commit-message> pr_title=<title>  (create draft PR)
-  NOTE: Do NOT use keeper_pr_workflow — it is deprecated and will error.
+- Your playground is `.masc/playground/{name}/` with three subdirs:
+  - `mind/` — notes, drafts, scratchpads
+  - `repos/` — git clones (one per repo, e.g. `repos/masc-mcp/`)
+  - bundle root — general workspace files
+- All paths come from keeper_context_status: use `playground_bundle`, `playground_mind`, `playground_repos` directly.
+- Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{playground_repos}/{repo}/` automatically.
+- Worktrees: live inside clones at `{playground_repos}/{repo}/.worktrees/{name}-{task_id}/`. Branch name: `{name}/{task_id}`.
+
+Clone-then-worktree rule (two turns, never one):
+1. If `repos/` is empty, clone first: `keeper_shell op=git_clone url=...`
+2. NEXT turn only: `masc_worktree_create task_id=<id>` (targets first clone alphabetically, or pass `repo_name=<dir>` to pick a specific one)
+
+PR workflow (Coding/Delivery/Full preset required):
+1. `masc_worktree_create task_id=<id>` — opens isolated branch
+2. `masc_code_read` → `masc_code_edit` — read first, then edit
+3. `masc_code_git action=add` → `action=commit` → `action=push` — all with cwd inside the worktree
+4. `keeper_pr_submit cwd=<worktree-path> commit_message=<msg> pr_title=<title>` — creates draft PR
 
 Knowledge lookup:
 - Past conversations and messages: keeper_memory_search
@@ -71,7 +65,7 @@ Board and communication:
 - List recent posts: keeper_board_list
 - When posting to the board, always set hearth to your keeper name (e.g. hearth="sangsu"). Never post without hearth.
 - Broadcast to all agents: keeper_broadcast
-- Speak aloud: keeper_voice_speak (requires MASC_BASE_PATH/.masc/voice_config.json with tts.endpoints configured and ELEVENLABS_API_KEY set)
+- Speak aloud: keeper_voice_speak (requires voice_config.json with tts.endpoints configured)
 
 Task management:
 - View tasks: keeper_tasks_list
@@ -83,4 +77,4 @@ Context:
 - Current time: keeper_time_now
 - Token usage and session state: keeper_context_status
 
-When asked about Board content, room status, files, or any information you do not already know, call the appropriate tool first. Do not guess or fabricate answers. See the Rules section at the top of this document.
+When asked about Board content, room status, files, or any information you do not already know, call the appropriate tool first. Do not guess or fabricate answers.

--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -11,7 +11,7 @@ Before any file or path operation, follow this order:
 3. Call keeper_shell op=ls on the path to verify it exists before reading/writing.
 4. Then proceed with the file operation.
 
-NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/{name}/`. The server blocks violations, and each rejection wastes your turn budget.
+NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/{your-name}/`. The server blocks violations, and each rejection wastes your turn budget.
 NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs`.
 NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call.
 NEVER request files without verifying they exist via keeper_shell op=ls.
@@ -38,13 +38,13 @@ File operations:
 - GitHub CLI: keeper_github with cmd="pr list", cmd="pr view 123", cmd="pr comment 123 --body 'text'", cmd="issue create --title 'bug'"
 
 Workspace:
-- Your playground is `.masc/playground/{name}/` with three subdirs:
+- Your playground is `.masc/playground/{your-name}/` with three subdirs:
   - `mind/` — notes, drafts, scratchpads
   - `repos/` — git clones (one per repo, e.g. `repos/masc-mcp/`)
   - bundle root — general workspace files
 - All paths come from keeper_context_status: use `playground_bundle`, `playground_mind`, `playground_repos` directly.
 - Clones: `keeper_shell op=git_clone url=https://github.com/<allowed_org>/<repo>.git` lands at `{playground_repos}/{repo}/` automatically.
-- Worktrees: live inside clones at `{playground_repos}/{repo}/.worktrees/{name}-{task_id}/`. Branch name: `{name}/{task_id}`.
+- Worktrees: live inside clones at `{playground_repos}/{repo}/.worktrees/{your-name}-{task_id}/`. Branch name: `{your-name}/{task_id}`.
 
 Clone-then-worktree rule (two turns, never one):
 1. If `repos/` is empty, clone first: `keeper_shell op=git_clone url=...`

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -15,7 +15,7 @@ Repo worktrees live *inside* your playground clone at `.masc/playground/{your-na
 - Git branch: `{your-name}/<task_id>` (e.g. `sangsu/fix-bug`)
 - `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), or pass `repo_name=<clone>` to pick a specific one.
 - The returned path always starts with `.masc/playground/{your-name}/repos/`.
-- Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked`.
+- Never use a server-root-relative worktree path — the harness rejects it as `write_outside_playground_blocked`.
 - Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist, never use them):

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -10,7 +10,7 @@ Playground is your default sandbox, relative to the server `base_path`:
 - `.masc/playground/{your-name}/` — bundle root (general workspace)
 - `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
 - `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees live *inside* your playground clone at `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/{your-name}-<task_id>/`.
+Repo worktrees live *inside* your playground clone at `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/` (typically `{your-name}-<task_id>`).
 - Directory name: `{your-name}-<task_id>` (e.g. `sangsu-fix-bug`)
 - Git branch: `{your-name}/<task_id>` (e.g. `sangsu/fix-bug`)
 - `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), or pass `repo_name=<clone>` to pick a specific one.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -10,7 +10,13 @@ Playground is your default sandbox, relative to the server `base_path`:
 - `.masc/playground/{your-name}/` — bundle root (general workspace)
 - `.masc/playground/{your-name}/mind/` — notes, drafts, scratchpads
 - `.masc/playground/{your-name}/repos/` — git clones; each clone lives at `repos/<REPO_NAME>/`
-Repo worktrees live *inside* your playground clone — they are branch-specific working copies under `.worktrees/<branch-or-task>/`. The canonical path is `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/<branch-or-task>/`. `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), and the returned path always starts with `.masc/playground/{your-name}/repos/`. Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked` / `cwd_outside_playground`. Clone the target repo first if `repos/` is empty.
+Repo worktrees live *inside* your playground clone at `.masc/playground/{your-name}/repos/<REPO_NAME>/.worktrees/{your-name}-<task_id>/`.
+- Directory name: `{your-name}-<task_id>` (e.g. `sangsu-fix-bug`)
+- Git branch: `{your-name}/<task_id>` (e.g. `sangsu/fix-bug`)
+- `masc_worktree_create` opens one under the first clone it finds in your `repos/` directory (alphabetical), or pass `repo_name=<clone>` to pick a specific one.
+- The returned path always starts with `.masc/playground/{your-name}/repos/`.
+- Never use a bare `.worktrees/...` path — the harness rejects it as `write_outside_playground_blocked`.
+- Clone the target repo first if `repos/` is empty.
 
 WRONG paths (these do not exist, never use them):
 - `/repos/...`

--- a/lib/config/playground_paths.ml
+++ b/lib/config/playground_paths.ml
@@ -83,3 +83,24 @@ let repos_path (name : string) : string =
 (** All three bundle subdirs in canonical order. *)
 let bundle_paths (name : string) : string list =
   [ bundle_root name; mind_path name; repos_path name ]
+
+(** {1 Worktree Naming}
+
+    Worktree directory names and git branch names for keeper task
+    isolation.  [room_worktree.ml] and [worktree_remove_r] delegate
+    here so the naming convention exists in one place. *)
+
+(** Worktree directory name under [.worktrees/]:
+    ["<agent_name>-<task_id>"].  The caller is responsible for passing
+    either a raw or sanitized agent name — this function formats only.
+
+    Example: [worktree_dir_name "sangsu" "fix-bug"] -> ["sangsu-fix-bug"]. *)
+let worktree_dir_name (agent_name : string) (task_id : string) : string =
+  Printf.sprintf "%s-%s" agent_name task_id
+
+(** Git branch name for a keeper worktree:
+    ["<agent_name>/<task_id>"].
+
+    Example: [worktree_branch_name "sangsu" "fix-bug"] -> ["sangsu/fix-bug"]. *)
+let worktree_branch_name (agent_name : string) (task_id : string) : string =
+  Printf.sprintf "%s/%s" agent_name task_id

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -253,7 +253,7 @@ let auto_correct_path ~(meta : keeper_meta) (raw : string) : string option =
   match try_strip "repos/" (playground ^ "/repos/") with
   | Some _ as r -> r
   | None ->
-  match try_strip "playground/" ".masc/playground/" with
+  match try_strip "playground/" (Playground_paths.all_playgrounds_prefix ^ "/") with
   | Some _ as r -> r
   | None -> None
 
@@ -296,7 +296,7 @@ let resolve_keeper_shell_read_path
            (e.g. ".masc/playground/keeper/repos"), concatenating would
            produce a doubled path.  Detect and resolve against project
            root instead. *)
-        let pg = ".masc/playground" in
+        let pg = Playground_paths.all_playgrounds_prefix in
         let contains s sub =
           let sl = String.length s and nl = String.length sub in
           if nl > sl then false

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -442,7 +442,7 @@ let handle_keeper_bash
                        Clone into your playground first (keeper_shell op=git_clone), \
                        then set cwd to the cloned repo path." )
                 ; "cmd", `String cmd_for_log
-                ; "hint", `String "Use cwd=.masc/playground/YOUR_KEEPER_NAME/repos/REPO"
+                ; "hint", `String (Printf.sprintf "Use cwd=%srepos/REPO" (Playground_paths.bundle_root meta.name))
                 ]))
         (* Write gate — preset layer *)
         else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
@@ -480,14 +480,16 @@ let handle_keeper_bash
                 ; "error", `String "write_outside_playground_blocked"
                 ; ( "reason"
                   , `String
-                      "Write operations (git push/commit, make deploy, etc.) \
-                       must run with cwd inside your playground \
-                       (.masc/playground/<keeper>/...). Open a worktree under \
-                       your playground clone first via masc_worktree_create, \
-                       then set cwd to the returned worktree path." )
+                      (Printf.sprintf
+                         "Write operations (git push/commit, make deploy, etc.) \
+                          must run with cwd inside your playground \
+                          (%s). Open a worktree under \
+                          your playground clone first via masc_worktree_create, \
+                          then set cwd to the returned worktree path."
+                         (Playground_paths.bundle_root meta.name)) )
                 ; "cmd", `String cmd_for_log
                 ; "cwd", `String cwd
-                ; "hint", `String "cwd must start with .masc/playground/YOUR_KEEPER_NAME/"
+                ; "hint", `String (Printf.sprintf "cwd must start with %s" (Playground_paths.bundle_root meta.name))
                 ]))
         else (
             (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -17,7 +17,7 @@ open Keeper_tool_registry
    Phase B2 / Plan Part 2.5 Axis 4. *)
 
 let keeper_writable_prefixes = [
-  ".masc/playground/";       (* coding workspace *)
+  Playground_paths.all_playgrounds_prefix ^ "/";  (* coding workspace *)
   ".masc/decision_audit/";   (* self audit logs — forensics, not trust input *)
   ".worktrees/";             (* git worktree workspace — repo-root, not .masc/ *)
 ]

--- a/lib/room/room_git.ml
+++ b/lib/room/room_git.ml
@@ -127,9 +127,9 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
     match git_root ~base_path with
     | None -> Error (IoError "Cannot determine git root")
     | Some root ->
-        let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+        let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
         let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
-        let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
+        let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
 
         (* Create .worktrees directory if not exists *)
         let worktrees_dir = Filename.concat root ".worktrees" in
@@ -178,9 +178,9 @@ let remove ~base_path ~agent_name ~task_id : string masc_result =
   match git_root ~base_path with
   | None -> Error (IoError "Cannot determine git root")
   | Some root ->
-      let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+      let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
       let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
-      let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
+      let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
 
       if not (Sys.file_exists worktree_path) then
         Error (IoError (Printf.sprintf "Worktree not found: %s" worktree_path))
@@ -248,7 +248,7 @@ let get_info ~base_path ~agent_name ~task_id =
   match git_root ~base_path with
   | None -> None
   | Some root ->
-      let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+      let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
       let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
-      let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
+      let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
       if Sys.file_exists worktree_path then Some (worktree_path, branch_name) else None

--- a/lib/room/room_worktree.ml
+++ b/lib/room/room_worktree.ml
@@ -209,11 +209,11 @@ let worktree_create_r ?(link_task=true) ?repo_name config ~agent_name ~task_id ~
     match resolve_keeper_repo_root () with
     | Error e -> Error e
     | Ok root -> begin
-        let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+        let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
         match ensure_worktree_path root worktree_name with
         | Error e -> Error e
         | Ok (worktree_path, worktrees_dir) ->
-          let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
+          let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
           let repo_name = Filename.basename root in
 
           (* Build worktree_info for task linking *)
@@ -321,7 +321,7 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
         Filename.concat config.base_path
           (Playground_paths.repos_path agent_name)
       in
-      let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+      let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
       let safe_is_dir path =
         try Sys.file_exists path && Sys.is_directory path
         with Sys_error _ -> false
@@ -363,11 +363,11 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
     match resolve_existing_worktree_root () with
     | Error e -> Error e
     | Ok root ->
-        let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
+        let worktree_name = Playground_paths.worktree_dir_name agent_name task_id in
         match ensure_worktree_path root worktree_name with
         | Error e -> Error e
         | Ok (worktree_path, _) -> begin
-            let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
+            let branch_name = Playground_paths.worktree_branch_name agent_name task_id in
 
             if not (Sys.file_exists worktree_path) then
               Error (IoError (Printf.sprintf "Worktree not found: %s" worktree_path))

--- a/lib/task_sandbox.ml
+++ b/lib/task_sandbox.ml
@@ -83,7 +83,7 @@ let create ~config ~task_id ?(scope = Worker_types.Limited_code_change)
     | Some worktree_path ->
       let branch_name =
         extract_branch_name msg
-        |> Option.value ~default:(Printf.sprintf "%s/%s" agent_name task_id)
+        |> Option.value ~default:(Playground_paths.worktree_branch_name agent_name task_id)
       in
       (* Resolve git root for symlink *)
       let repo_root =

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -136,7 +136,7 @@ let validate_read_path ~agent_name config path =
       with
       | Error e -> Error e
       | Ok canonical ->
-      let playground_tree_rel = ".masc/playground" in
+      let playground_tree_rel = Playground_paths.all_playgrounds_prefix in
       let playground_tree_abs_raw =
         Filename.concat base_path playground_tree_rel
       in

--- a/test/test_playground_paths.ml
+++ b/test/test_playground_paths.ml
@@ -141,6 +141,22 @@ let test_strip_no_traversal () =
   check bool "no backslash in result" true
     (not (String.contains result '\\'))
 
+let test_worktree_dir_name () =
+  check string "basic worktree dir"
+    "sangsu-fix-bug"
+    (PP.worktree_dir_name "sangsu" "fix-bug");
+  check string "hyphenated task id"
+    "cheolsu-PK-123"
+    (PP.worktree_dir_name "cheolsu" "PK-123")
+
+let test_worktree_branch_name () =
+  check string "basic worktree branch"
+    "sangsu/fix-bug"
+    (PP.worktree_branch_name "sangsu" "fix-bug");
+  check string "hyphenated task id"
+    "cheolsu/PK-123"
+    (PP.worktree_branch_name "cheolsu" "PK-123")
+
 let () =
   run "Playground_paths"
     [
@@ -164,5 +180,9 @@ let () =
         test_case "both forms produce identical paths" `Quick test_canonical_short_path_identity;
         test_case "edge cases" `Quick test_strip_edge_cases;
         test_case "strip does not create traversal" `Quick test_strip_no_traversal;
+      ]);
+      ("worktree_naming", [
+        test_case "worktree_dir_name" `Quick test_worktree_dir_name;
+        test_case "worktree_branch_name" `Quick test_worktree_branch_name;
       ]);
     ]


### PR DESCRIPTION
## Summary
- `Playground_paths`에 `worktree_dir_name`, `worktree_branch_name` 함수 추가 — worktree 네이밍 패턴의 SSOT
- `room_worktree.ml`, `room_git.ml`, `task_sandbox.ml`의 inline `Printf.sprintf "%s-%s"/%s/%s"` 패턴을 SSOT 호출로 전환
- `keeper_exec_shell.ml`, `keeper_tool_policy.ml`의 하드코딩 `".masc/playground"` 문자열을 `Playground_paths.all_playgrounds_prefix`로 교체
- `keeper.capabilities.md` 프롬프트 개선: Workspace 섹션 중복 6회 반복 제거, `YOUR_KEEPER_NAME` → `{name}` 통일, deprecated 도구 참조 삭제, PR 워크플로우 7단계→4단계 압축
- `keeper.world.md`에 worktree 네이밍 컨벤션 (`{name}-{task_id}`, `{name}/{task_id}`) 명시

## Changes
| File | Change |
|------|--------|
| `lib/config/playground_paths.ml` | `worktree_dir_name`, `worktree_branch_name` 추가 |
| `lib/room/room_worktree.ml` | inline format → SSOT (3곳) |
| `lib/room/room_git.ml` | inline format → SSOT (6곳) |
| `lib/task_sandbox.ml` | inline format → SSOT (1곳) |
| `lib/keeper/keeper_exec_shell.ml` | hardcoded string → SSOT (2곳) |
| `lib/keeper/keeper_tool_policy.ml` | hardcoded string → SSOT (1곳) |
| `config/prompts/keeper.capabilities.md` | 프롬프트 압축 및 개선 |
| `config/prompts/keeper.world.md` | worktree naming convention 추가 |

## Test plan
- [x] `dune build lib/ bin/` 통과
- [x] 기존 `test_playground_paths` 테스트 통과
- [ ] keeper 실제 worktree create/remove 동작 확인 (keeper 기동 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)