### PR TITLE
fix(checkpoint): ToolResult sanitizer awareness + save-time stub — uranium666 root cause

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -682,16 +682,18 @@ let sanitize_checkpoint_message
                    > default_max_checkpoint_tool_result_total_chars
              then
                (* Over count or aggregate budget: stub the result *)
+               let stub_content = "[tool result cleared]" in
                let stub =
                  Agent_sdk.Types.ToolResult
                    { tool_use_id;
-                     content = "[tool result cleared]";
+                     content = stub_content;
                      is_error;
                      json = None }
                in
                ( stub :: kept_rev,
                  kept_text_blocks, kept_text_chars,
-                 kept_tool_results + 1, kept_tool_result_chars,
+                 kept_tool_results + 1,
+                 kept_tool_result_chars + String.length stub_content,
                  add_checkpoint_sanitize_stats stats
                    { empty_checkpoint_sanitize_stats with
                      dropped_blocks = 1;

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -28,6 +28,15 @@ let default_max_checkpoint_text_blocks_per_message = 32
 let default_max_checkpoint_text_chars_per_message = 16 * 1024
 let checkpoint_text_cap_marker = "\n[capped]"
 
+(** ToolResult block caps — analogous to text block caps above.
+    Without these, a single message with hundreds of ToolResult blocks
+    (e.g. 280 blocks × 7K chars = 1.95M chars) passes through the
+    sanitizer untouched, causing context window overflow on next load.
+    Values aligned with Claude Code: 200K aggregate, per-result 8K. *)
+let default_max_checkpoint_tool_result_chars = 8_000
+let default_max_checkpoint_tool_results_per_message = 20
+let default_max_checkpoint_tool_result_total_chars = 200_000
+
 (* ================================================================ *)
 (* Working Context Types (re-exported from Keeper_types)             *)
 (* ================================================================ *)
@@ -575,9 +584,10 @@ let sanitize_checkpoint_text_block (text : string)
 let sanitize_checkpoint_message
     (msg : Agent_sdk.Types.message)
   : Agent_sdk.Types.message option * checkpoint_sanitize_stats =
-  let kept_rev, _, _, stats =
+  let kept_rev, _, _, _, _, stats =
     List.fold_left
-      (fun (kept_rev, kept_text_blocks, kept_text_chars, stats) block ->
+      (fun (kept_rev, kept_text_blocks, kept_text_chars,
+            kept_tool_results, kept_tool_result_chars, stats) block ->
          match block with
          | Agent_sdk.Types.Text text ->
              let sanitized_text, text_stats =
@@ -588,6 +598,7 @@ let sanitize_checkpoint_message
                   ( kept_rev,
                     kept_text_blocks,
                     kept_text_chars,
+                    kept_tool_results, kept_tool_result_chars,
                     add_checkpoint_sanitize_stats stats text_stats )
               | Some text ->
                   if kept_text_blocks
@@ -596,6 +607,7 @@ let sanitize_checkpoint_message
                     ( kept_rev,
                       kept_text_blocks,
                       kept_text_chars,
+                      kept_tool_results, kept_tool_result_chars,
                       add_checkpoint_sanitize_stats
                         (add_checkpoint_sanitize_stats stats text_stats)
                         {
@@ -612,6 +624,7 @@ let sanitize_checkpoint_message
                       ( kept_rev,
                         kept_text_blocks,
                         kept_text_chars,
+                        kept_tool_results, kept_tool_result_chars,
                         add_checkpoint_sanitize_stats
                           (add_checkpoint_sanitize_stats stats text_stats)
                           {
@@ -635,6 +648,7 @@ let sanitize_checkpoint_message
                       ( Agent_sdk.Types.Text capped_text :: kept_rev,
                         kept_text_blocks + 1,
                         kept_text_chars + String.length capped_text,
+                        kept_tool_results, kept_tool_result_chars,
                         add_checkpoint_sanitize_stats
                           (add_checkpoint_sanitize_stats stats text_stats)
                           block_stats ))
@@ -642,6 +656,7 @@ let sanitize_checkpoint_message
              ( kept_rev,
                kept_text_blocks,
                kept_text_chars,
+               kept_tool_results, kept_tool_result_chars,
                add_checkpoint_sanitize_stats stats
                  {
                    empty_checkpoint_sanitize_stats with
@@ -652,15 +667,71 @@ let sanitize_checkpoint_message
              ( kept_rev,
                kept_text_blocks,
                kept_text_chars,
+               kept_tool_results, kept_tool_result_chars,
                add_checkpoint_sanitize_stats stats
                  {
                    empty_checkpoint_sanitize_stats with
                    dropped_blocks = 1;
                    dropped_chars = String.length text;
                  } )
+         | Agent_sdk.Types.ToolResult { tool_use_id; content; is_error; _ } ->
+             let tool_chars = String.length content in
+             if kept_tool_results
+                >= default_max_checkpoint_tool_results_per_message
+                || kept_tool_result_chars + tool_chars
+                   > default_max_checkpoint_tool_result_total_chars
+             then
+               (* Over count or aggregate budget: stub the result *)
+               let stub =
+                 Agent_sdk.Types.ToolResult
+                   { tool_use_id;
+                     content = "[tool result cleared]";
+                     is_error;
+                     json = None }
+               in
+               ( stub :: kept_rev,
+                 kept_text_blocks, kept_text_chars,
+                 kept_tool_results + 1, kept_tool_result_chars,
+                 add_checkpoint_sanitize_stats stats
+                   { empty_checkpoint_sanitize_stats with
+                     dropped_blocks = 1;
+                     dropped_chars = tool_chars } )
+             else if tool_chars > default_max_checkpoint_tool_result_chars
+             then
+               (* Individual result too large: truncate *)
+               let capped =
+                 String.sub content 0
+                   default_max_checkpoint_tool_result_chars
+                 ^ checkpoint_text_cap_marker
+               in
+               let block =
+                 Agent_sdk.Types.ToolResult
+                   { tool_use_id; content = capped; is_error; json = None }
+               in
+               ( block :: kept_rev,
+                 kept_text_blocks, kept_text_chars,
+                 kept_tool_results + 1,
+                 kept_tool_result_chars
+                 + default_max_checkpoint_tool_result_chars,
+                 add_checkpoint_sanitize_stats stats
+                   { empty_checkpoint_sanitize_stats with
+                     truncated_blocks = 1;
+                     truncated_chars =
+                       tool_chars
+                       - default_max_checkpoint_tool_result_chars } )
+             else
+               (* Within budget: keep as-is *)
+               ( block :: kept_rev,
+                 kept_text_blocks, kept_text_chars,
+                 kept_tool_results + 1,
+                 kept_tool_result_chars + tool_chars,
+                 stats )
          | _ ->
-             (block :: kept_rev, kept_text_blocks, kept_text_chars, stats))
-      ([], 0, 0, empty_checkpoint_sanitize_stats)
+             ( block :: kept_rev,
+               kept_text_blocks, kept_text_chars,
+               kept_tool_results, kept_tool_result_chars,
+               stats ))
+      ([], 0, 0, 0, 0, empty_checkpoint_sanitize_stats)
       msg.content
   in
   let kept = List.rev kept_rev in
@@ -762,6 +833,15 @@ let save_oas_checkpoint
     else
       let drop = n - max_checkpoint_messages in
       List.filteri (fun i _ -> i >= drop) ctx.messages
+  in
+  (* Stub old tool results at save time: keep only the most recent turn's
+     results in full. During Agent.run the reducer uses keep_recent:3, but
+     at checkpoint persistence we are more aggressive — older tool results
+     are unlikely to be useful on resume and bloat disk/memory. *)
+  let capped_messages =
+    Agent_sdk.Context_reducer.reduce
+      (Agent_sdk.Context_reducer.stub_tool_results ~keep_recent:1)
+      capped_messages
   in
   let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
   let state =

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -59,6 +59,41 @@ let contains_substring haystack needle =
   in
   loop 0
 
+let tool_use_message ?(name = "list_files") ~tool_use_id () =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
+    content =
+      [
+        Agent_sdk.Types.ToolUse
+          { id = tool_use_id; name; input = `Assoc [] };
+      ];
+    name = None;
+    tool_call_id = None;
+  }
+
+let tool_result_message ?(is_error = false) ~tool_use_id content =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+    content =
+      [
+        Agent_sdk.Types.ToolResult
+          { tool_use_id; content; is_error; json = None };
+      ];
+    name = None;
+    tool_call_id = None;
+  }
+
+let tool_result_content_for_id ~tool_use_id msgs =
+  List.find_map
+    (fun (msg : Agent_sdk.Types.message) ->
+      List.find_map
+        (function
+          | Agent_sdk.Types.ToolResult { tool_use_id = id; content; _ }
+            when String.equal id tool_use_id -> Some content
+          | _ -> None)
+        msg.content)
+    msgs
+
 let make_keeper_meta ?(name = "keeper-lifecycle-test")
     ?(trace_id = "trace-keeper-lifecycle") () =
   match
@@ -799,6 +834,90 @@ let test_save_oas_checkpoint_caps_oversized_text () =
           check bool "text was compacted" true
             (String.length text < String.length oversized_checkpoint_text))
 
+let test_sanitize_checkpoint_message_caps_oversized_tool_result () =
+  let oversized =
+    String.make
+      (KCC.default_max_checkpoint_tool_result_chars + 1024)
+      'x'
+  in
+  let msg = tool_result_message ~tool_use_id:"tool-cap" oversized in
+  match KCC.sanitize_checkpoint_message msg with
+  | None, _ -> fail "expected oversized tool result to survive as capped output"
+  | Some sanitized, stats ->
+      (match sanitized.content with
+       | [ Agent_sdk.Types.ToolResult { content; _ } ] ->
+           check bool "adds truncation marker" true
+             (contains_substring content KCC.checkpoint_text_cap_marker);
+           check bool "tool result was compacted" true
+             (String.length content < String.length oversized);
+           check bool "tool result stays within configured cap" true
+             (String.length content
+              <= KCC.default_max_checkpoint_tool_result_chars
+                 + String.length KCC.checkpoint_text_cap_marker)
+       | _ -> fail "expected a single capped ToolResult block");
+      check int "tool result truncation recorded" 1 stats.truncated_blocks
+
+let test_save_oas_checkpoint_stubs_old_tool_results () =
+  let base_dir = temp_dir "keeper_lifecycle_save_tool_stub" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-save-tool-stub" ~base_dir
+      in
+      let old_tool_use_id = "tool-old" in
+      let recent_tool_use_id = "tool-recent" in
+      let old_output = String.make 200 'a' in
+      let recent_output = String.make 200 'b' in
+      let ctx =
+        KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:64_000
+        |> fun ctx ->
+        KEC.append_many ctx
+          [
+            Agent_sdk.Types.user_msg "inspect the old turn";
+            tool_use_message ~tool_use_id:old_tool_use_id ();
+            tool_result_message ~tool_use_id:old_tool_use_id old_output;
+            Agent_sdk.Types.assistant_msg "old turn summary";
+            Agent_sdk.Types.user_msg "inspect the recent turn";
+            tool_use_message ~tool_use_id:recent_tool_use_id ~name:"grep_search" ();
+            tool_result_message ~tool_use_id:recent_tool_use_id recent_output;
+            Agent_sdk.Types.assistant_msg "recent turn summary";
+          ]
+        |> KEC.sync_oas_context
+      in
+      match
+        KEC.save_oas_checkpoint
+          ~max_checkpoint_messages:120
+          ~session
+          ~agent_name:"keeper-lifecycle"
+          ~model:"glm:glm-5.1"
+          ~ctx
+          ~generation:1
+      with
+      | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "save_oas_checkpoint failed: %s" e)
+      | Ok checkpoint ->
+          let old_saved =
+            tool_result_content_for_id
+              ~tool_use_id:old_tool_use_id
+              checkpoint.messages
+          in
+          let recent_saved =
+            tool_result_content_for_id
+              ~tool_use_id:recent_tool_use_id
+              checkpoint.messages
+          in
+          (match old_saved with
+           | None -> fail "expected old tool result in saved checkpoint"
+           | Some content ->
+               check bool "old tool result is stubbed" true
+                 (String.starts_with ~prefix:"[tool: list_files," content));
+          (match recent_saved with
+           | None -> fail "expected recent tool result in saved checkpoint"
+           | Some content ->
+               check string "recent tool result stays full" recent_output content))
+
 let test_save_oas_checkpoint_strips_summarized_world_state () =
   let base_dir = temp_dir "keeper_lifecycle_save_summary_strip" in
   Fun.protect
@@ -1223,6 +1342,10 @@ let () =
             test_save_oas_checkpoint_strips_ephemeral_world_state;
           test_case "save caps oversized text" `Quick
             test_save_oas_checkpoint_caps_oversized_text;
+          test_case "save caps oversized tool result" `Quick
+            test_sanitize_checkpoint_message_caps_oversized_tool_result;
+          test_case "save stubs old tool results" `Quick
+            test_save_oas_checkpoint_stubs_old_tool_results;
           test_case "save strips summarized world state" `Quick
             test_save_oas_checkpoint_strips_summarized_world_state;
           test_case "patch replaces last assistant text" `Quick

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -857,6 +857,59 @@ let test_sanitize_checkpoint_message_caps_oversized_tool_result () =
        | _ -> fail "expected a single capped ToolResult block");
       check int "tool result truncation recorded" 1 stats.truncated_blocks
 
+let test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget () =
+  let oversized = String.make 190_000 'z' in
+  let msg =
+    {
+      Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+      content =
+        [
+          Agent_sdk.Types.ToolResult
+            {
+              tool_use_id = "tool-agg-1";
+              content = oversized;
+              is_error = false;
+              json = None;
+            };
+          Agent_sdk.Types.ToolResult
+            {
+              tool_use_id = "tool-agg-2";
+              content = oversized;
+              is_error = false;
+              json = None;
+            };
+          Agent_sdk.Types.ToolResult
+            {
+              tool_use_id = "tool-agg-3";
+              content = oversized;
+              is_error = false;
+              json = None;
+            };
+        ];
+      name = None;
+      tool_call_id = None;
+    }
+  in
+  match KCC.sanitize_checkpoint_message msg with
+  | None, _ -> fail "expected aggregate-budgeted tool results to survive"
+  | Some sanitized, stats ->
+      (match sanitized.content with
+       | [
+           Agent_sdk.Types.ToolResult { content = first; _ };
+           Agent_sdk.Types.ToolResult { content = second; _ };
+           Agent_sdk.Types.ToolResult { content = third; _ };
+         ] ->
+           check bool "first tool result truncated" true
+             (contains_substring first KCC.checkpoint_text_cap_marker);
+           check bool "second tool result truncated" true
+             (contains_substring second KCC.checkpoint_text_cap_marker);
+           check string "aggregate overflow gets stubbed"
+             "[tool result cleared]" third
+       | _ -> fail "expected three ToolResult blocks after aggregate cap");
+      check int "aggregate cap records truncated blocks" 2
+        stats.truncated_blocks;
+      check int "aggregate cap records dropped block" 1 stats.dropped_blocks
+
 let test_save_oas_checkpoint_stubs_old_tool_results () =
   let base_dir = temp_dir "keeper_lifecycle_save_tool_stub" in
   Fun.protect
@@ -911,8 +964,12 @@ let test_save_oas_checkpoint_stubs_old_tool_results () =
           (match old_saved with
            | None -> fail "expected old tool result in saved checkpoint"
            | Some content ->
-               check bool "old tool result is stubbed" true
-                 (String.starts_with ~prefix:"[tool: list_files," content));
+               check bool "old tool result is compacted" true
+                 (not (String.equal old_output content));
+               check bool "old tool result stays structured" true
+                 (String.starts_with ~prefix:"[tool:" content);
+               check bool "old tool result keeps tool name" true
+                 (contains_substring content "list_files"));
           (match recent_saved with
            | None -> fail "expected recent tool result in saved checkpoint"
            | Some content ->
@@ -1344,6 +1401,8 @@ let () =
             test_save_oas_checkpoint_caps_oversized_text;
           test_case "save caps oversized tool result" `Quick
             test_sanitize_checkpoint_message_caps_oversized_tool_result;
+          test_case "save caps aggregate tool result budget" `Quick
+            test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget;
           test_case "save stubs old tool results" `Quick
             test_save_oas_checkpoint_stubs_old_tool_results;
           test_case "save strips summarized world state" `Quick


### PR DESCRIPTION
## Summary

- make checkpoint sanitization ToolResult-aware with per-result, per-message, and aggregate budget guards
- run `stub_tool_results ~keep_recent:1` before checkpoint persistence so older turns do not keep full tool payloads on disk
- add lifecycle regressions for oversized ToolResult truncation, aggregate overflow stubbing, and save-time old-turn stubbing

## Product impact

- reduces checkpoint resume risk when one keeper turn accumulates extremely large ToolResult payloads
- keeps older tool outputs compact on disk while preserving the most recent turn's full result for continuity

## Evidence

- `opam exec -- dune build --root .`
- `opam exec -- dune build --root . lib/keeper/keeper_context_core.ml test/test_keeper_lifecycle.exe`
- `./_build/default/test/test_keeper_lifecycle.exe`
- `git diff --check`

## Review evidence

- direct ZAI `sb glm-text`
- head `e083c5f19`
- result: `No findings.`

## Linked issue

- Refs #6786

## Test plan

- [x] `opam exec -- dune build --root .`
- [x] `opam exec -- dune build --root . lib/keeper/keeper_context_core.ml test/test_keeper_lifecycle.exe`
- [x] `./_build/default/test/test_keeper_lifecycle.exe`
- [x] `git diff --check`
- [ ] CI checks green
