### PR TITLE
refactor(memory): remove imperative seeding path (RFC-MASC-004 Phase 2)

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -65,7 +65,7 @@ OAS  ──does not know──→ MASC
 |------------------|----------------|-----|
 | `lib/oas_worker*.ml`, `lib/worker_oas.ml`, `lib/verifier_oas.ml` | Correct | OAS is consumed as the runtime contract; MASC chooses prompts, tools, policy, and verification usage |
 | `lib/context_compact_oas.ml` | Acceptable but lossy | Runtime compaction delegates to OAS, but message-importance heuristics still depend on MASC text markers |
-| `lib/memory_oas_bridge.ml` | Acceptable but lossy | Correct consumer-side adapter, but seeding/flushing is still imperative instead of hook-first |
+| `lib/memory_oas_bridge.ml` | Acceptable | Consumer-side adapter; imperative seeding removed in RFC-MASC-004 Phase 2, hook-first injection is now the sole path |
 | `lib/team_session/team_session_oas_bridge.ml` | Acceptable but lossy | OAS Swarm is the substrate, while MASC semantics survive via metadata/projections with known fidelity loss |
 | `lib/keeper/keeper_agent_run.ml` + keeper checkpoint/context path | Boundary violation | Keeper still owns duplicate runtime state via `working_context` and relies on raw text markers such as `[STATE]` |
 
@@ -73,7 +73,7 @@ OAS  ──does not know──→ MASC
 
 - keeper runtime still uses a MASC-owned `working_context` wrapper around OAS context/checkpoint primitives
 - keeper continuity still leaks domain semantics through raw message text (`[STATE]`, goal/memory markers)
-- `memory_oas_bridge.ml` still owns imperative seeding/flushing instead of a hook-first boundary
+- `memory_oas_bridge.ml` imperative seeding removed (RFC-MASC-004 Phase 2); `create_memory_full` and `seed_*` functions remain for Phase 3 dead-code cleanup
 - team-session bridge fidelity and runtime-health signaling are still incomplete
 - proof-store and `oas-runtime` filesystem layout must stay behind thin adapters instead of being reconstructed ad hoc
 
@@ -105,8 +105,8 @@ These stay in MASC:
    - reduce dependence on raw `[STATE]`, `[GOAL]`, and memory-summary markers in runtime-facing paths
 3. **P3 — team-session bridge fidelity**
    - keep MASC semantics in metadata/projections while improving OAS Swarm parity
-4. **P4 — memory bridge hardening**
-   - move from imperative seed/flush toward reusable OAS hook/callback seams where generic
+4. **P4 — memory bridge hardening** — Resolved (2026-04-13, PR #6795 Phase 1 + Phase 2)
+   - imperative seed/flush replaced by hook-first injection via `Memory_hooks` (RFC-MASC-004)
 5. **P5 — doc truth alignment**
    - keep this contract, the implementation spec, and the utilization audit in sync
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -201,12 +201,6 @@ let all_flags : flag list = [
     default = true; category = "runtime";
     lifecycle = Active; since = "2.162.0" };
 
-  (* ── Memory ────────────────────────────────────────────────── *)
-  { env_name = "MASC_MEMORY_HOOK_FIRST";
-    description = "Hook-first memory injection: inject memory via BeforeTurnParams hook instead of imperative OAS Memory.t seeding (RFC-MASC-004)";
-    default = false; category = "runtime";
-    lifecycle = Experimental; since = "2.265.0" };
-
 ]
 
 (** Lookup a flag by env var name. O(n) — acceptable for ~30 flags. *)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1382,45 +1382,27 @@ let run_turn
   in
   let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
   let base_dir = Filename.concat config.base_path ".masc" in
-  let memory_hook_first =
-    Feature_flag_registry.get_bool "MASC_MEMORY_HOOK_FIRST"
-  in
+  (* RFC-MASC-004 Phase 2: Hook-first is now the only path.
+     Create bare memory (no imperative seeding). Memory content is
+     injected via BeforeTurnParams hook; flush is incremental via
+     AfterTurn hook. The memory instance is still needed for flush. *)
   let memory =
-    if memory_hook_first then
-      (* RFC-MASC-004: Hook-first path. Create bare memory (no seeding).
-         Memory content is injected via BeforeTurnParams hook instead of
-         imperatively pushing into OAS Memory.t tiers.
-         The memory instance is still needed for AfterTurn flush. *)
-      Memory_oas_bridge.create_memory
-        ~agent_name
-        ~base_dir
-        ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-        ()
-    else
-      (* Legacy path: imperative seeding into OAS Memory.t tiers *)
-      Memory_oas_bridge.create_memory_full
-        ~agent_name
-        ~base_dir
-        ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-        ~config
-        ~episode_limit:30
-        ~procedure_limit:10
-        ~global_procedure_limit:5
-        ()
+    Memory_oas_bridge.create_memory
+      ~agent_name
+      ~base_dir
+      ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      ()
   in
-  (* RFC-MASC-004: Compose memory hooks when hook-first is enabled.
-     Memory_hooks provides before_turn_params (text injection) and
-     after_turn (incremental flush). Composed as outermost layer so
+  (* RFC-MASC-004: Memory hooks provide before_turn_params (text injection)
+     and after_turn (incremental flush). Composed as outermost layer so
      memory context is available to all downstream hooks. *)
   let hooks =
-    if memory_hook_first then
-      let mem_hooks =
-        Memory_hooks.make
-          ~agent_name ~config ~memory
-          ~episode_limit:30 ~procedure_limit:10 ()
-      in
-      Agent_sdk.Hooks.compose ~outer:mem_hooks ~inner:hooks
-    else hooks
+    let mem_hooks =
+      Memory_hooks.make
+        ~agent_name ~config ~memory
+        ~episode_limit:30 ~procedure_limit:10 ()
+    in
+    Agent_sdk.Hooks.compose ~outer:mem_hooks ~inner:hooks
   in
   let reducer =
     Agent_sdk.Context_reducer.compose [
@@ -1547,13 +1529,9 @@ let run_turn
            Without this, read_continuity_summary finds no [STATE] in the
            checkpoint messages and returns empty — causing keepers to lose
            context across turns.  See #5431. *)
-       (* When hook-first is enabled, AfterTurn hooks already flush
-          incrementally on every turn. Skip the redundant final flush
-          since flush_incremental is idempotent and the AfterTurn hook
-          already ran for the last turn before Agent.run returned.
-          When hook-first is disabled, this is the only flush point. *)
-       if not memory_hook_first then
-         ignore (Memory_oas_bridge.flush_all ~memory ~agent_name);
+       (* RFC-MASC-004 Phase 2: AfterTurn hooks flush incrementally on
+          every turn. No final flush_all needed — the AfterTurn hook
+          already ran for the last turn before Agent.run returned. *)
        let text = Agent_sdk.Types.text_of_content result.response.content in
        let model = result.response.model in
        (* Extract and persist thinking blocks to trajectory JSONL.

--- a/lib/memory_hooks.ml
+++ b/lib/memory_hooks.ml
@@ -1,7 +1,7 @@
 (** Memory_hooks — OAS hook adapter for hook-first memory injection.
 
-    RFC-MASC-004 Phase 1: Instead of imperatively pushing memory into
-    OAS [Memory.t] tiers before [Agent.run], this module injects memory
+    RFC-MASC-004: Instead of imperatively pushing memory into OAS
+    [Memory.t] tiers before [Agent.run], this module injects memory
     as text via [extra_system_context] in the [BeforeTurnParams] hook
     and flushes incrementally in the [AfterTurn] hook.
 
@@ -11,10 +11,12 @@
     The hook is composed (via [Hooks.compose]) with existing keeper hooks
     so existing safety/cost/tool-disclosure hooks remain untouched.
 
-    Feature flag: [MASC_MEMORY_HOOK_FIRST] (default false).
-    When false, the legacy [create_memory_full] / [flush_all] path is used.
+    Phase 1 introduced this as an opt-in path behind
+    [MASC_MEMORY_HOOK_FIRST]. Phase 2 made it the only path and
+    removed the feature flag and the legacy imperative code path.
 
-    @since v2.265.0 (RFC-MASC-004 Phase 1) *)
+    @since v2.265.0 (RFC-MASC-004 Phase 1)
+    @since v2.266.0 (RFC-MASC-004 Phase 2 — imperative path removed) *)
 
 (** Build an [extra_system_context] string from episodic, procedural,
     and institutional memory.

--- a/lib/memory_hooks.mli
+++ b/lib/memory_hooks.mli
@@ -1,12 +1,12 @@
 (** Memory_hooks — OAS hook adapter for hook-first memory injection.
 
-    RFC-MASC-004 Phase 1: Injects memory as text via
-    [extra_system_context] in [BeforeTurnParams] and flushes
-    incrementally in [AfterTurn].
+    RFC-MASC-004: Injects memory as text via [extra_system_context]
+    in [BeforeTurnParams] and flushes incrementally in [AfterTurn].
 
-    Feature flag: [MASC_MEMORY_HOOK_FIRST] (default false).
+    This is the sole memory injection path since Phase 2 (v2.266.0).
 
-    @since v2.265.0 (RFC-MASC-004 Phase 1) *)
+    @since v2.265.0 (RFC-MASC-004 Phase 1)
+    @since v2.266.0 (RFC-MASC-004 Phase 2 — sole path) *)
 
 (** Create OAS hooks for hook-first memory injection.
 

--- a/test/test_memory_hooks.ml
+++ b/test/test_memory_hooks.ml
@@ -158,20 +158,11 @@ let test_flush_incremental_idempotent () =
   check int "second flush episodes (idempotent)" 0 ep2;
   check int "second flush procedures (idempotent)" 0 pr2
 
-(* ── Feature flag test ─────────────────────────────────────── *)
+(* ── Feature flag removed (RFC-MASC-004 Phase 2) ─────────── *)
 
-let test_feature_flag_registered () =
+let test_feature_flag_removed () =
   let flag = Feature_flag_registry.find_opt "MASC_MEMORY_HOOK_FIRST" in
-  check bool "flag registered" true (Option.is_some flag);
-  match flag with
-  | Some f ->
-    check bool "default is false" false f.default;
-    check string "category is runtime" "runtime" f.category
-  | None -> fail "flag not found"
-
-let test_feature_flag_default_false () =
-  let value = Feature_flag_registry.get_bool "MASC_MEMORY_HOOK_FIRST" in
-  check bool "default runtime value is false" false value
+  check bool "flag removed from registry" true (Option.is_none flag)
 
 (* ── Hook composition test ─────────────────────────────────── *)
 
@@ -209,7 +200,6 @@ let () =
       test_case "flush_incremental idempotent" `Quick test_flush_incremental_idempotent;
     ];
     "feature_flag", [
-      test_case "flag registered" `Quick test_feature_flag_registered;
-      test_case "default is false" `Quick test_feature_flag_default_false;
+      test_case "flag removed (Phase 2)" `Quick test_feature_flag_removed;
     ];
   ]


### PR DESCRIPTION
## Summary

- Phase 1 (#6795)에서 `MASC_MEMORY_HOOK_FIRST` feature flag 뒤에 hook-first 메모리 주입을 도입했다.
- 이 PR은 legacy imperative 경로를 제거하고 hook-first를 유일한 경로로 만든다.
- `keeper_agent_run.ml`에서 `create_memory_full`/`flush_all` 호출부 제거, feature flag 제거, 문서 업데이트.
- `create_memory_full`/`flush_all` 함수 자체는 Phase 3에서 삭제 예정 (이 PR은 호출부만 제거).

## Changes (6 files, -36 lines net)

| File | Change |
|------|--------|
| `lib/keeper/keeper_agent_run.ml` | `MASC_MEMORY_HOOK_FIRST` 분기 제거, 항상 hook-first 경로 사용 |
| `lib/config/feature_flag_registry.ml` | `MASC_MEMORY_HOOK_FIRST` 엔트리 삭제 |
| `lib/memory_hooks.ml` | Phase 2 doc comment 업데이트 |
| `lib/memory_hooks.mli` | Phase 2 doc comment 업데이트 |
| `test/test_memory_hooks.ml` | flag-exists 테스트를 flag-removed 테스트로 교체 |
| `docs/OAS-MASC-BOUNDARY.md` | P4 항목을 "Resolved" 상태로 업데이트 |

## Verification

```bash
# RFC-MASC-004 Phase 2 verification (all pass)
rg 'create_memory_full' lib/keeper/           # 0 hits
rg 'flush_all' lib/keeper/                    # 1 hit (comment only)
rg 'Memory_hooks' lib/keeper/                 # 1 hit (the sole path)
rg 'MASC_MEMORY_HOOK_FIRST' lib/config/       # 0 hits
```

## Test plan

- [x] `dune build --root . lib/` passes (pre-existing `test/test_eval_feed.ml` failure is unrelated)
- [x] `test_memory_hooks.exe` — 7/8 pass; 1 pre-existing env-dependent failure (`load_episodes_text empty` assumes no episode JSONL data on disk)
- [x] `test_feature_flag_removed` confirms flag is gone from registry
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)