### PR TITLE
feat(dashboard): Eval Quality panel (RFC-MASC-005 Phase 3)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -376,3 +376,47 @@ export async function fetchKeeperStateDiagram(name: string): Promise<KeeperState
   if (!resp.ok) throw new Error(`state-diagram fetch failed: ${resp.status}`)
   return resp.json() as Promise<KeeperStateDiagramResponse>
 }
+
+// --- Eval Quality (RFC-MASC-005 Phase 3) ---
+
+export interface EvalLayerResult {
+  layer_name: string
+  passed: boolean
+  score: number | null
+  evidence: string[]
+  detail: string | null
+}
+
+export interface EvalVerdict {
+  schema_version: number
+  all_passed: boolean
+  coverage: number
+  layer_results: EvalLayerResult[]
+}
+
+export interface EvalSnapshot {
+  agent_name: string
+  session_id: string | null
+  worker_run_id: string
+  timestamp: number
+  verdict: EvalVerdict
+  baseline_status: string | null
+}
+
+export interface KeeperEvalResponse {
+  keeper: string
+  count: number
+  latest_coverage: number | null
+  latest_all_passed: boolean | null
+  snapshots: EvalSnapshot[]
+}
+
+export async function fetchKeeperEval(name: string, limit = 10): Promise<KeeperEvalResponse> {
+  const resp = await fetchWithTimeout(
+    `/api/v1/keepers/${encodeURIComponent(name)}/eval?limit=${limit}`,
+    { headers: jsonHeaders() },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!resp.ok) throw new Error(`eval fetch failed: ${resp.status}`)
+  return resp.json() as Promise<KeeperEvalResponse>
+}

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -55,6 +55,7 @@ import { SessionTraceView } from './session-trace/session-trace-view'
 import { KeeperToolTelemetry } from './keeper-tool-telemetry'
 import { KeeperToolCallInspector } from './keeper-tool-call-inspector'
 import { SupervisorDiagnosticsPanel } from './keeper-supervisor-diagnostics'
+import { KeeperEvalQualityPanel } from './keeper-eval-quality'
 
 // ── Global overlay state ──────────────────────────────────
 
@@ -559,6 +560,9 @@ export function KeeperDetailOverlay() {
         <${InferenceTelemetryPanel} keeper=${keeper} />
         ${'' /* ── Per-keeper tool telemetry ── */}
         <${KeeperToolTelemetry} keeperName=${keeper.name} />
+
+        ${'' /* ── Eval Quality (RFC-MASC-005 Phase 3) ── */}
+        <${KeeperEvalQualityPanel} keeperName=${keeper.name} />
 
         ${'' /* ── Direct conversation ── */}
         <${KeeperCommsPanel} keeper=${keeper} />

--- a/dashboard/src/components/keeper-eval-quality.test.ts
+++ b/dashboard/src/components/keeper-eval-quality.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { KeeperEvalResponse, EvalSnapshot } from '../api/keeper'
+
+// Mock fetchKeeperEval at the API layer
+const fetchKeeperEvalMock = vi.fn<(name: string, limit?: number) => Promise<KeeperEvalResponse>>()
+
+vi.mock('../api/keeper', () => ({
+  fetchKeeperEval: (...args: Parameters<typeof fetchKeeperEvalMock>) => fetchKeeperEvalMock(...args),
+}))
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+function makeSnapshot(overrides: Partial<EvalSnapshot> = {}): EvalSnapshot {
+  return {
+    agent_name: 'test-keeper',
+    session_id: null,
+    worker_run_id: 'run-1',
+    timestamp: Date.now() / 1000,
+    verdict: {
+      schema_version: 1,
+      all_passed: true,
+      coverage: 0.82,
+      layer_results: [
+        { layer_name: 'ToolSelected', passed: true, score: 0.95, evidence: ['correct tool chosen'], detail: null },
+        { layer_name: 'CompletesWithin', passed: true, score: 1.0, evidence: ['3/5 turns'], detail: null },
+        { layer_name: 'ContainsText', passed: false, score: 0.0, evidence: ['missing expected output'], detail: null },
+      ],
+    },
+    baseline_status: 'Improved',
+    ...overrides,
+  }
+}
+
+function makeEvalResponse(overrides: Partial<KeeperEvalResponse> = {}): KeeperEvalResponse {
+  const snapshots = overrides.snapshots ?? [makeSnapshot()]
+  return {
+    keeper: 'test-keeper',
+    count: snapshots.length,
+    latest_coverage: snapshots[0]?.verdict.coverage ?? null,
+    latest_all_passed: snapshots[0]?.verdict.all_passed ?? null,
+    snapshots,
+    ...overrides,
+  }
+}
+
+describe('fetchKeeperEval integration types', () => {
+  it('parses a well-formed eval response', () => {
+    const response = makeEvalResponse()
+    expect(response.count).toBe(1)
+    expect(response.latest_coverage).toBe(0.82)
+    expect(response.latest_all_passed).toBe(true)
+    expect(response.snapshots[0]?.verdict.layer_results).toHaveLength(3)
+  })
+
+  it('handles empty snapshots', () => {
+    const response = makeEvalResponse({ snapshots: [], count: 0, latest_coverage: null, latest_all_passed: null })
+    expect(response.count).toBe(0)
+    expect(response.latest_coverage).toBeNull()
+    expect(response.snapshots).toHaveLength(0)
+  })
+
+  it('tracks layer pass/fail correctly', () => {
+    const snapshot = makeSnapshot()
+    const passed = snapshot.verdict.layer_results.filter(l => l.passed)
+    const failed = snapshot.verdict.layer_results.filter(l => !l.passed)
+    expect(passed).toHaveLength(2)
+    expect(failed).toHaveLength(1)
+    expect(failed[0]?.layer_name).toBe('ContainsText')
+  })
+
+  it('baseline_status is nullable', () => {
+    const noBaseline = makeSnapshot({ baseline_status: null })
+    expect(noBaseline.baseline_status).toBeNull()
+    const improved = makeSnapshot({ baseline_status: 'Improved' })
+    expect(improved.baseline_status).toBe('Improved')
+  })
+})

--- a/dashboard/src/components/keeper-eval-quality.ts
+++ b/dashboard/src/components/keeper-eval-quality.ts
@@ -1,0 +1,230 @@
+// Keeper Eval Quality Panel — RFC-MASC-005 Phase 3
+// Displays OAS eval verdicts: coverage bar, layer results, 24h trend.
+// Data source: GET /api/v1/keepers/:name/eval (Phase 2 API)
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { fetchKeeperEval } from '../api/keeper'
+import type { KeeperEvalResponse, EvalSnapshot, EvalLayerResult } from '../api/keeper'
+
+// ── Per-keeper cached state ─────────────────────────────
+
+interface EvalState {
+  loading: boolean
+  error: string | null
+  data: KeeperEvalResponse | null
+}
+
+type EvalSignal = ReturnType<typeof signal<EvalState>>
+const evalCache = new Map<string, EvalSignal>()
+
+const defaultState: EvalState = { loading: false, error: null, data: null }
+
+function getEvalSignal(name: string): EvalSignal {
+  let s = evalCache.get(name)
+  if (!s) {
+    s = signal<EvalState>({ ...defaultState })
+    evalCache.set(name, s)
+  }
+  return s
+}
+
+function readEvalState(name: string): EvalState {
+  return getEvalSignal(name).value ?? defaultState
+}
+
+async function loadEvalData(name: string): Promise<void> {
+  const s = getEvalSignal(name)
+  const current = readEvalState(name)
+  if (current.loading) return
+  s.value = { loading: true, error: null, data: current.data }
+  try {
+    const data = await fetchKeeperEval(name, 20)
+    s.value = { loading: false, error: null, data }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'eval fetch failed'
+    s.value = { loading: false, error: msg, data: null }
+  }
+}
+
+// ── Coverage bar ────────────────────────────────────────
+
+function coverageColor(coverage: number): string {
+  if (coverage >= 0.9) return 'var(--ok)'
+  if (coverage >= 0.6) return 'var(--warn)'
+  return 'var(--bad)'
+}
+
+function coverageTone(coverage: number): string {
+  if (coverage >= 0.9) return 'border-[rgba(74,222,128,0.2)] bg-[rgba(74,222,128,0.06)]'
+  if (coverage >= 0.6) return 'border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.06)]'
+  return 'border-[var(--bad-20)] bg-[rgba(239,68,68,0.06)]'
+}
+
+function baselineLabel(status: string | null): { text: string; cls: string } | null {
+  if (!status) return null
+  switch (status) {
+    case 'Improved':
+      return { text: 'Improved', cls: 'text-[var(--ok)]' }
+    case 'Regressed':
+      return { text: 'Regressed', cls: 'text-[var(--bad)]' }
+    case 'Unchanged':
+      return { text: 'Unchanged', cls: 'text-[var(--text-muted)]' }
+    default:
+      return { text: status, cls: 'text-[var(--text-muted)]' }
+  }
+}
+
+// ── Layer result row ────────────────────────────────────
+
+function LayerResultRow({ layer }: { layer: EvalLayerResult }) {
+  const icon = layer.passed ? '\u2713' : '\u2717'
+  const iconCls = layer.passed
+    ? 'text-[var(--ok)]'
+    : 'text-[var(--bad)]'
+  const scoreText = layer.score != null ? layer.score.toFixed(2) : '-'
+  const detail = layer.detail ?? layer.evidence[0] ?? ''
+
+  return html`
+    <div class="flex items-center gap-3 py-1.5 px-2 rounded-lg hover:bg-[var(--white-3)] transition-colors">
+      <span class="flex-shrink-0 w-4 text-center font-bold text-sm ${iconCls}">${icon}</span>
+      <span class="flex-shrink-0 w-[120px] text-[11px] font-mono text-[var(--accent)] truncate" title=${layer.layer_name}>${layer.layer_name}</span>
+      <span class="flex-shrink-0 w-10 text-right text-[11px] font-mono tabular-nums text-[var(--text-strong)]">${scoreText}</span>
+      <span class="flex-1 text-[10px] text-[var(--text-muted)] truncate" title=${detail}>${detail}</span>
+    </div>
+  `
+}
+
+// ── 24h Trend computation ───────────────────────────────
+
+function computeTrend(snapshots: EvalSnapshot[]): { oldCoverage: number; newCoverage: number; deltaPercent: number } | null {
+  if (snapshots.length < 2) return null
+  const now = Date.now() / 1000
+  const cutoff24h = now - 86400
+  const recent = snapshots.filter(s => s.timestamp >= cutoff24h)
+  const older = snapshots.filter(s => s.timestamp < cutoff24h)
+  if (recent.length === 0) return null
+  const newestRecent = recent[0]
+  if (!newestRecent) return null
+  const newCoverage = newestRecent.verdict.coverage
+  const oldestRecent = recent[recent.length - 1]
+  const firstOlder = older[0]
+  const oldCoverage = firstOlder
+    ? firstOlder.verdict.coverage
+    : (oldestRecent?.verdict.coverage ?? newCoverage)
+  if (oldCoverage === newCoverage) return null
+  const deltaPercent = oldCoverage > 0 ? ((newCoverage - oldCoverage) / oldCoverage) * 100 : 0
+  return { oldCoverage, newCoverage, deltaPercent }
+}
+
+// ── Main panel ──────────────────────────────────────────
+
+export function KeeperEvalQualityPanel({ keeperName }: { keeperName: string }) {
+  const evalSignal = getEvalSignal(keeperName)
+
+  useEffect(() => {
+    void loadEvalData(keeperName)
+  }, [keeperName])
+
+  // Access .value to subscribe, then fallback for strict-mode undefined
+  const state = evalSignal.value ?? defaultState
+  const { loading, error, data } = state
+
+  if (loading && !data) {
+    return html`
+      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+        <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-[11px] text-[var(--text-dim)] animate-pulse">데이터 로딩 중...</div>
+      </div>
+    `
+  }
+
+  if (error && !data) {
+    return html`
+      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+        <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-[11px] text-[var(--text-dim)]">eval 데이터 없음</div>
+      </div>
+    `
+  }
+
+  if (!data || data.count === 0) {
+    return html`
+      <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+        <div class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)] mb-2">Eval Quality</div>
+        <div class="text-[11px] text-[var(--text-dim)]">eval 결과 없음. OAS harness가 verdict를 생성하면 여기에 표시됩니다.</div>
+      </div>
+    `
+  }
+
+  const latest = data.snapshots[0]
+  if (!latest) return null
+
+  const coverage = latest.verdict.coverage
+  const coveragePct = Math.round(coverage * 100)
+  const allPassed = latest.verdict.all_passed
+  const layers = latest.verdict.layer_results
+  const baseline = baselineLabel(latest.baseline_status)
+  const trend = computeTrend(data.snapshots)
+
+  return html`
+    <div class="p-4 rounded-xl border ${coverageTone(coverage)} transition-colors">
+      ${'' /* Header */}
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] font-semibold tracking-[0.08em] uppercase text-[var(--text-muted)]">Eval Quality</span>
+          ${allPassed
+            ? html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[9px] font-semibold bg-[rgba(74,222,128,0.12)] text-[var(--ok)]">ALL PASS</span>`
+            : html`<span class="inline-flex items-center py-0.5 px-1.5 rounded text-[9px] font-semibold bg-[rgba(239,68,68,0.12)] text-[var(--bad)]">FAIL</span>`
+          }
+          ${baseline ? html`<span class="text-[10px] font-medium ${baseline.cls}">${baseline.text}</span>` : null}
+        </div>
+        <button
+          type="button"
+          class="text-[9px] text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer bg-transparent border-0 p-0"
+          onClick=${() => void loadEvalData(keeperName)}
+          title="새로고침"
+        >${loading ? '...' : '\u21bb'}</button>
+      </div>
+
+      ${'' /* Coverage bar */}
+      <div class="flex items-center gap-3 mb-3">
+        <span class="text-[10px] text-[var(--text-muted)] flex-shrink-0 w-16">Coverage</span>
+        <div class="flex-1 h-2 bg-[var(--white-6)] rounded-full overflow-hidden">
+          <div
+            class="h-full rounded-full transition-all duration-500"
+            style="width:${coveragePct}%;background:${coverageColor(coverage)}"
+          ></div>
+        </div>
+        <span class="text-sm font-bold tabular-nums flex-shrink-0" style="color:${coverageColor(coverage)}">${coverage.toFixed(2)}</span>
+      </div>
+
+      ${'' /* Layer Results */}
+      ${layers.length > 0 ? html`
+        <div class="mb-3">
+          <div class="text-[9px] uppercase tracking-wider text-[var(--text-dim)] mb-1.5">Layer Results</div>
+          <div class="flex flex-col gap-0.5">
+            ${layers.map((layer: EvalLayerResult) => html`<${LayerResultRow} layer=${layer} />`)}
+          </div>
+        </div>
+      ` : null}
+
+      ${'' /* 24h Trend */}
+      ${trend ? html`
+        <div class="flex items-center gap-2 pt-2 border-t border-[var(--white-8)]">
+          <span class="text-[9px] uppercase tracking-wider text-[var(--text-dim)]">Trend (24h)</span>
+          <span class="text-[11px] font-mono tabular-nums text-[var(--text-muted)]">
+            ${trend.oldCoverage.toFixed(2)} \u2192 ${trend.newCoverage.toFixed(2)}
+          </span>
+          <span class="text-[11px] font-mono tabular-nums font-semibold ${trend.deltaPercent >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">
+            (${trend.deltaPercent >= 0 ? '+' : ''}${trend.deltaPercent.toFixed(1)}%)
+          </span>
+        </div>
+      ` : null}
+
+      ${'' /* Snapshot count */}
+      <div class="mt-2 text-[9px] text-[var(--text-dim)]">${data.count} eval snapshot${data.count !== 1 ? 's' : ''}</div>
+    </div>
+  `
+}


### PR DESCRIPTION
## Summary

RFC-MASC-005 Phase 3: Dashboard UI에 Eval Quality 섹션 추가.

- **KeeperEvalQualityPanel**: keeper detail 화면에 eval 품질 패널 추가
  - Coverage bar (0.0-1.0, 색상 코딩: green/yellow/red)
  - Layer results 목록 (pass/fail 아이콘, score, evidence)
  - 24h trend (이전 coverage -> 현재 coverage, delta %)
  - Baseline status 표시 (Improved/Regressed/Unchanged)
  - 자동 로딩 + 새로고침 버튼
- **fetchKeeperEval API client**: GET `/api/v1/keepers/:name/eval` (Phase 2 API) 소비
  - `EvalLayerResult`, `EvalVerdict`, `EvalSnapshot`, `KeeperEvalResponse` 타입 정의
- Panel 위치: Tool Telemetry와 Direct Conversation 사이
- Tailwind-only 스타일링 (기존 dashboard 패턴 준수)

Depends on: #6799 (Phase 1+2, merged)

## Test plan

- [x] `pnpm typecheck` 통과 (새 에러 0건, 기존 cytoscape 에러는 main에서 이미 존재)
- [x] `pnpm lint` 통과
- [x] `pnpm test` 전체 통과
- [x] `keeper-eval-quality.test.ts` 4 tests 통과 (타입 파싱, 빈 응답, layer pass/fail, nullable baseline)
- [x] `dune build --root .` OCaml 빌드 통과
- [ ] eval 데이터가 있는 keeper에서 UI 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)