### PR TITLE
fix(config): remove deprecated models field from keeper configs

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -51,10 +51,6 @@ allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
 tool_preset = "coding"
 
 cascade_name = "keeper_unified"
-models = [
-  "glm-coding:glm-5.1",
-  "ollama:qwen3.5:35b-a3b-nvfp4",
-]
 
 # Telemetry Feedback
 telemetry_feedback_enabled = true

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -64,12 +64,6 @@ work_discovery_sources = ["stale_tasks", "board_cleanup"]
 work_discovery_interval_sec = 1800
 work_discovery_guidance = "Look for zombie board posts, orphan tasks, and stale data to clean up."
 
-# Model cascade — janitor uses coding plan + local fallback
-models = [
-  "glm-coding:glm-5.1",
-  "ollama:qwen3.5:35b-a3b-nvfp4",
-]
-
 # Telemetry Feedback
 telemetry_feedback_enabled = true
 telemetry_feedback_window_hours = 24

--- a/config/keepers/masc-improver.toml
+++ b/config/keepers/masc-improver.toml
@@ -52,10 +52,6 @@ allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
 tool_preset = "delivery"
 
 cascade_name = "keeper_unified"
-models = [
-  "glm-coding:glm-5.1",
-  "ollama:qwen3.5:35b-a3b-nvfp4",
-]
 
 # Work Discovery
 work_discovery_enabled = true

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -65,12 +65,7 @@ execution_scope = "workspace"
 tool_preset = "social"
 also_allow = ["keeper_voice_speak", "keeper_voice_listen"]
 
-# GLM Coding Plan first, Ollama fallback (oas#786 relaxes tool_choice)
 cascade_name = "keeper_unified"
-models = [
-  "glm-coding:glm-5.1",
-  "ollama:qwen3.5:35b-a3b-nvfp4",
-]
 
 # Telemetry Feedback
 telemetry_feedback_enabled = true


### PR DESCRIPTION
## Summary

PR #6716 replaced per-keeper model lists with `cascade_name` routing but did not remove the `models` field from 4 keeper configs. The TOML parser rejects unknown keys, breaking CI Build and Test.

Removes `models` from: cheolsu, janitor, masc-improver, sangsu.

## Test plan

- [ ] CI Build and Test passes (TOML parse error gone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)