### PR TITLE
[codex] Fix autonomous keeper fairness

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -288,11 +288,12 @@ module KeeperKeepalive = struct
 
       When [MASC_KEEPER_OAS_TIMEOUT_SEC] is set, that value is used directly.
       Otherwise, {!oas_timeout_for_context} computes an adaptive timeout:
-        base + ctx/1K × per_1k + min(oas_max_turns_per_call × 4, 40) × per_turn
+        base + ctx/1K × per_1k + min(max_turns, 40) × per_turn
       References {!oas_max_turns_per_call} (default 15) directly to avoid
       default drift.  Previous formula used 4× headroom on a default of 5,
-      producing min(20, 40)=20 effective turns.  With default 15, the 4×
-      multiplier would always saturate the cap, erasing context differentiation.
+      producing min(5, 40)=5 effective turns.  Using the actual per-call
+      turn budget keeps scheduled-autonomous and reactive channels aligned
+      with the timeout heuristic.
 
       At 262K context, 15 turns/call:
         120 + 393 + min(15,40)×30 = 120+393+450 = 963
@@ -319,7 +320,22 @@ module KeeperKeepalive = struct
   let oas_max_turns_per_call =
     max 1 (min 50 (get_int ~default:15 "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL"))
 
-  let oas_timeout_for_context ~(max_context : int) : float =
+  (** Smaller turn budget for scheduled autonomous cycles so one keeper does
+      not monopolize the autonomous semaphore for minutes at a time.
+      Reactive turns keep the general budget because they correspond to
+      explicit external stimuli.
+      Env: [MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS].
+      Default: min(global, 5). Range: [1, global]. *)
+  let oas_max_turns_per_call_scheduled_autonomous =
+    let default = min oas_max_turns_per_call 5 in
+    max 1
+      (min oas_max_turns_per_call
+         (min 50
+            (get_int ~default
+               "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS")))
+
+  let oas_timeout_for_context_with_turn_budget ~(max_context : int)
+      ~(max_turns : int) : float =
     match oas_timeout_sec_override with
     | Some v -> v
     | None ->
@@ -327,16 +343,21 @@ module KeeperKeepalive = struct
       let per_1k = 1.5 in
       let per_turn = 30.0 in
       let context_time = Float.of_int max_context /. 1000.0 *. per_1k in
-      (* Cap at 40 effective turns even if user sets MASC_KEEPER_OAS_MAX_TURNS_PER_CALL
-         higher.  This is a deliberate safety cap: with per_turn=30s, 40 turns alone
-         consume 1200s — the entire turn_timeout_sec budget.  Users pushing beyond
-         40 turns should instead raise turn_timeout_sec or split the work. *)
+      (* Cap at 40 effective turns even if the configured per-call turn
+         budget is higher. This is a deliberate safety cap: with
+         per_turn=30s, 40 turns alone consume 1200s — the entire
+         turn_timeout_sec budget. Users pushing beyond 40 turns should
+         instead raise turn_timeout_sec or split the work. *)
       let effective_turns =
-        Float.of_int (min oas_max_turns_per_call 40)
+        Float.of_int (min max_turns 40)
       in
       let turn_time = effective_turns *. per_turn in
       Float.max 30.0
         (Float.min turn_timeout_sec (base +. context_time +. turn_time))
+
+  let oas_timeout_for_context ~(max_context : int) : float =
+    oas_timeout_for_context_with_turn_budget ~max_context
+      ~max_turns:oas_max_turns_per_call
 
   (** Backward-compatible accessor: returns the env override or 300s default.
       Prefer {!oas_timeout_for_context} when max_context is available. *)

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -53,6 +53,68 @@ let () =
 
 let autonomous_turn_semaphore = Eio.Semaphore.make autonomous_turn_limit
 
+type autonomous_waiter =
+  {
+    ticket : int;
+    keeper_name : string;
+  }
+
+let autonomous_wait_queue_mutex = Mutex.create ()
+
+let autonomous_wait_queue : autonomous_waiter list ref = ref []
+
+let autonomous_wait_queue_next_ticket = ref 0
+
+let autonomous_queue_poll_sec = 0.05
+
+let with_autonomous_wait_queue f =
+  Mutex.lock autonomous_wait_queue_mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock autonomous_wait_queue_mutex) f
+
+let reset_autonomous_turn_queue_for_test () =
+  with_autonomous_wait_queue (fun () ->
+    autonomous_wait_queue := [];
+    autonomous_wait_queue_next_ticket := 0)
+
+let enqueue_autonomous_waiter ~(keeper_name : string) : int =
+  with_autonomous_wait_queue (fun () ->
+    let ticket = !autonomous_wait_queue_next_ticket in
+    incr autonomous_wait_queue_next_ticket;
+    autonomous_wait_queue :=
+      !autonomous_wait_queue @ [{ ticket; keeper_name }];
+    ticket)
+
+let drop_autonomous_waiter ~(ticket : int) : unit =
+  with_autonomous_wait_queue (fun () ->
+    autonomous_wait_queue :=
+      List.filter (fun waiter -> waiter.ticket <> ticket) !autonomous_wait_queue)
+
+let autonomous_waiter_snapshot_for_test () : string list =
+  with_autonomous_wait_queue (fun () ->
+    List.map (fun waiter -> waiter.keeper_name) !autonomous_wait_queue)
+
+let enqueue_autonomous_waiter_for_test keeper_name =
+  enqueue_autonomous_waiter ~keeper_name
+
+let drop_autonomous_waiter_for_test ticket =
+  drop_autonomous_waiter ~ticket
+
+let autonomous_waiter_head_ticket () : int option =
+  with_autonomous_wait_queue (fun () ->
+    match !autonomous_wait_queue with
+    | head :: _ -> Some head.ticket
+    | [] -> None)
+
+let autonomous_waiter_position ~(ticket : int) : int option =
+  with_autonomous_wait_queue (fun () ->
+    let rec loop idx = function
+      | [] -> None
+      | waiter :: rest ->
+          if waiter.ticket = ticket then Some idx
+          else loop (idx + 1) rest
+    in
+    loop 0 !autonomous_wait_queue)
+
 (** Wall-clock cap on [Eio.Semaphore.acquire] when waiting for a keeper
     turn slot. Without this, a keeper whose peers hold all slots while
     their LLM calls stall for the entire 1200s turn budget would block
@@ -80,17 +142,43 @@ let semaphore_wait_timeout_sec =
     not a keeper failure in the unified-turn sense. *)
 exception Semaphore_wait_timeout of float
 
-let with_keeper_turn_slot ~channel f =
+let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
+    ~(started_at : float) : unit =
+  if Option.equal Int.equal (autonomous_waiter_head_ticket ()) (Some ticket)
+  then ()
+  else
+    let waited_sec = Time_compat.now () -. started_at in
+    if waited_sec >= semaphore_wait_timeout_sec
+    then
+      let ahead =
+        match autonomous_waiter_position ~ticket with
+        | Some idx -> idx
+        | None -> 0
+      in
+      Log.Keeper.warn
+        "semaphore_wait: autonomous fairness queue wait exceeded %.0fs (keeper=%s ahead=%d), skipping turn"
+        semaphore_wait_timeout_sec keeper_name ahead;
+      raise (Semaphore_wait_timeout semaphore_wait_timeout_sec)
+    else (
+      (match Eio_context.get_clock_opt () with
+       | Some clock -> Eio.Time.sleep clock autonomous_queue_poll_sec
+       | None -> Unix.sleepf autonomous_queue_poll_sec);
+      wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at)
+
+let with_keeper_turn_slot ~keeper_name ~channel f =
   let is_autonomous =
     match channel with
     | Keeper_world_observation.Scheduled_autonomous -> true
     | Keeper_world_observation.Reactive -> false
   in
   let t0 = Time_compat.now () in
-  Log.Keeper.debug "semaphore_acquire: channel=%s autonomous_available=%d turn_available=%d"
+  let queue_depth = List.length (autonomous_waiter_snapshot_for_test ()) in
+  Log.Keeper.debug "semaphore_acquire: keeper=%s channel=%s autonomous_available=%d turn_available=%d queue_depth=%d"
+    keeper_name
     (if is_autonomous then "autonomous" else "reactive")
     (Eio.Semaphore.get_value autonomous_turn_semaphore)
-    (Eio.Semaphore.get_value turn_semaphore);
+    (Eio.Semaphore.get_value turn_semaphore)
+    queue_depth;
   (* Track acquisitions in mutable flags so the outer Fun.protect can
      release exactly the slots we hold — regardless of which exception
      path fires (Semaphore_wait_timeout, Eio.Cancel.Cancelled, or any
@@ -98,6 +186,7 @@ let with_keeper_turn_slot ~channel f =
      internal cancel-race handling. *)
   let acquired_autonomous = ref false in
   let acquired_turn = ref false in
+  let autonomous_ticket = ref None in
   let acquire_bounded ~label sem =
     match Eio_context.get_clock_opt () with
     | Some clock ->
@@ -124,14 +213,20 @@ let with_keeper_turn_slot ~channel f =
   in
   Fun.protect
     ~finally:(fun () ->
+      Option.iter (fun ticket -> drop_autonomous_waiter ~ticket) !autonomous_ticket;
       (* Release exactly what we acquired. Order does not matter because
          these two semaphores do not contend with each other. *)
       if !acquired_turn then Eio.Semaphore.release turn_semaphore;
       if !acquired_autonomous then Eio.Semaphore.release autonomous_turn_semaphore)
     (fun () ->
       if is_autonomous then begin
+        let ticket = enqueue_autonomous_waiter ~keeper_name in
+        autonomous_ticket := Some ticket;
+        wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:t0;
         acquire_bounded ~label:"autonomous" autonomous_turn_semaphore;
-        acquired_autonomous := true
+        acquired_autonomous := true;
+        drop_autonomous_waiter ~ticket;
+        autonomous_ticket := None
       end;
       acquire_bounded ~label:"turn" turn_semaphore;
       acquired_turn := true;
@@ -1053,7 +1148,8 @@ let run_keepalive_unified_turn
       then meta_after_triage
       else if should_run_turn
       then (
-        with_keeper_turn_slot ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
+        with_keeper_turn_slot ~keeper_name:meta_after_triage.name
+          ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
           match
             Keeper_unified_turn.run_unified_turn
               ~config:ctx.config

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -162,7 +162,11 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
     else (
       (match Eio_context.get_clock_opt () with
        | Some clock -> Eio.Time.sleep clock autonomous_queue_poll_sec
-       | None -> Unix.sleepf autonomous_queue_poll_sec);
+       | None ->
+           (* Environment drift: production should always have an Eio clock.
+              Yield cooperatively instead of using a blocking Unix sleep so
+              the Eio convention guard remains satisfied. *)
+           Eio.Fiber.yield ());
       wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at)
 
 let with_keeper_turn_slot ~keeper_name ~channel f =

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -56,6 +56,16 @@ exception Semaphore_wait_timeout of float
     re-reading the env var. Callers should treat this as "skip this
     turn, retry on next heartbeat" rather than a keeper failure. *)
 
+(** Test-only reset for the autonomous FIFO wait queue. *)
+val reset_autonomous_turn_queue_for_test : unit -> unit
+
+(** Test-only snapshot of keeper names currently queued for an autonomous turn. *)
+val autonomous_waiter_snapshot_for_test : unit -> string list
+
+(** Test-only FIFO queue primitives for autonomous fairness regression tests. *)
+val enqueue_autonomous_waiter_for_test : string -> int
+val drop_autonomous_waiter_for_test : int -> unit
+
 val wakeup_relevant_keeper_for_board_signal :
   config:Room.config -> Board_dispatch.keeper_board_signal -> unit
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -195,16 +195,25 @@ let oas_timeout_guard_sec = 1.0
 
 let min_oas_timeout_budget_sec = 30.0
 
-let bounded_oas_timeout_for_turn_budget ~(max_context : int)
+let bounded_oas_timeout_for_turn_budget_with_turn_budget ~(max_context : int)
+    ~(max_turns : int)
     ~(remaining_turn_budget_s : float) : float option =
   let usable_budget = remaining_turn_budget_s -. oas_timeout_guard_sec in
   if usable_budget < min_oas_timeout_budget_sec
   then None
   else
+    let adaptive_timeout =
+      Env_config_keeper.KeeperKeepalive.oas_timeout_for_context_with_turn_budget
+        ~max_context ~max_turns
+    in
     Some
-      (Float.min
-         (Env_config_keeper.KeeperKeepalive.oas_timeout_for_context ~max_context)
-         usable_budget)
+      (Float.min adaptive_timeout usable_budget)
+
+let bounded_oas_timeout_for_turn_budget ~(max_context : int)
+    ~(remaining_turn_budget_s : float) : float option =
+  bounded_oas_timeout_for_turn_budget_with_turn_budget ~max_context
+    ~max_turns:Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call
+    ~remaining_turn_budget_s
 
 (** Detect context overflow errors via structured OAS error types.
     Matches [ContextOverflow] (API-level) and [TokenBudgetExceeded]
@@ -1279,18 +1288,21 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           in
           let do_run ~run_meta ~max_context ~run_generation ~is_retry
               ~oas_timeout_s =
-            let max_idle_turns =
+            let max_idle_turns, max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
-                  Env_config_keeper.KeeperKeepalive.max_idle_turns_reactive
+                  ( Env_config_keeper.KeeperKeepalive.max_idle_turns_reactive,
+                    Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call )
               | Keeper_world_observation.Scheduled_autonomous ->
-                  Env_config_keeper.KeeperKeepalive.max_idle_turns_autonomous
+                  ( Env_config_keeper.KeeperKeepalive.max_idle_turns_autonomous,
+                    Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous )
             in
             Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
               ~user_message ~cascade_name:effective_cascade_name
               ?provider_filter:(Env_config_keeper.KeeperCascade.provider_allowlist ())
               ~generation:run_generation
+              ~max_turns
               ~max_idle_turns
               ~history_user_source:"world_state_prompt"
               ~history_assistant_source:"internal_assistant"
@@ -1305,9 +1317,17 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           let rec retry_loop ~run_meta ~max_context ~run_generation
               ~attempt ~is_retry
               ~overflow_retry_used =
+            let max_turns =
+              match channel with
+              | Keeper_world_observation.Reactive ->
+                  Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call
+              | Keeper_world_observation.Scheduled_autonomous ->
+                  Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
+            in
             let attempt_result =
               match
-                bounded_oas_timeout_for_turn_budget
+                bounded_oas_timeout_for_turn_budget_with_turn_budget
+                  ~max_turns
                   ~max_context
                   ~remaining_turn_budget_s:(remaining_turn_budget_s ())
               with

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -81,6 +81,12 @@ val is_transient_network_error : Oas.Error.sdk_error -> bool
 val bounded_oas_timeout_for_turn_budget :
   max_context:int -> remaining_turn_budget_s:float -> float option
 
+val bounded_oas_timeout_for_turn_budget_with_turn_budget :
+  max_context:int ->
+  max_turns:int ->
+  remaining_turn_budget_s:float ->
+  float option
+
 (** Detect server-side request body parse errors (e.g. Ollama yyjson
     rejecting a malformed request body).  The LLM never
     processed the request, so committed tool results are not at risk

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2152,6 +2152,23 @@ let test_bounded_oas_timeout_caps_to_remaining_turn_budget () =
       check (float 0.01) "remaining budget cap applies" 234.7 timeout_s
   | None -> fail "expected bounded timeout"
 
+let test_bounded_oas_timeout_uses_channel_turn_budget_override () =
+  let max_turns =
+    Env_config.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
+  in
+  let expected =
+    Env_config.KeeperKeepalive.oas_timeout_for_context_with_turn_budget
+      ~max_context:262_144 ~max_turns
+  in
+  match
+    UT.bounded_oas_timeout_for_turn_budget_with_turn_budget
+      ~max_turns ~max_context:262_144 ~remaining_turn_budget_s:1200.0
+  with
+  | Some timeout_s ->
+      check (float 0.01) "scheduled autonomous turn budget lowers adaptive timeout"
+        expected timeout_s
+  | None -> fail "expected bounded timeout"
+
 let test_bounded_oas_timeout_refuses_too_little_budget () =
   check (option (float 0.01)) "insufficient budget returns none" None
     (UT.bounded_oas_timeout_for_turn_budget
@@ -3121,6 +3138,8 @@ let () =
             test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
           test_case "bounded OAS timeout caps to remaining turn budget" `Quick
             test_bounded_oas_timeout_caps_to_remaining_turn_budget;
+          test_case "bounded OAS timeout respects channel turn budget override" `Quick
+            test_bounded_oas_timeout_uses_channel_turn_budget_override;
           test_case "bounded OAS timeout refuses too little remaining budget" `Quick
             test_bounded_oas_timeout_refuses_too_little_budget;
           test_case "pure local label detection" `Quick

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -163,6 +163,28 @@ let test_semaphore_wait_timeout_exception_shape () =
   in
   check (float 0.001) "exception carries wait sec" 42.5 carried
 
+let test_autonomous_queue_fifo_prevents_reentry_cutting () =
+  KK.reset_autonomous_turn_queue_for_test ();
+  let cheolsu_1 = KK.enqueue_autonomous_waiter_for_test "cheolsu" in
+  let sangsu = KK.enqueue_autonomous_waiter_for_test "sangsu" in
+  let janitor = KK.enqueue_autonomous_waiter_for_test "janitor" in
+  check (list string) "initial FIFO order"
+    [ "cheolsu"; "sangsu"; "janitor" ]
+    (KK.autonomous_waiter_snapshot_for_test ());
+  KK.drop_autonomous_waiter_for_test cheolsu_1;
+  let cheolsu_2 = KK.enqueue_autonomous_waiter_for_test "cheolsu" in
+  check (list string) "reentry goes to queue tail"
+    [ "sangsu"; "janitor"; "cheolsu" ]
+    (KK.autonomous_waiter_snapshot_for_test ());
+  KK.drop_autonomous_waiter_for_test sangsu;
+  KK.drop_autonomous_waiter_for_test janitor;
+  check (list string) "older waiters stay ahead of reentry"
+    [ "cheolsu" ]
+    (KK.autonomous_waiter_snapshot_for_test ());
+  KK.drop_autonomous_waiter_for_test cheolsu_2;
+  check (list string) "queue drained" []
+    (KK.autonomous_waiter_snapshot_for_test ())
+
 (* ── KeeperGrpc config defaults ────────────────────────── *)
 
 let test_grpc_max_reconnect_default () =
@@ -345,6 +367,8 @@ let () =
       test_case "default 60s" `Quick test_semaphore_wait_timeout_default;
       test_case "range [5, 600]" `Quick test_semaphore_wait_timeout_range;
       test_case "exception carries wait sec" `Quick test_semaphore_wait_timeout_exception_shape;
+      test_case "autonomous queue FIFO prevents reentry cutting" `Quick
+        test_autonomous_queue_fifo_prevents_reentry_cutting;
     ];
     "grpc_config", [
       test_case "max_reconnect default" `Quick test_grpc_max_reconnect_default;

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -86,6 +86,16 @@ let test_oas_timeout_262k () =
   (* 120 + 262.144*1.5 + min(15,40)*30 = 120+393.216+450 = 963.216 *)
   check bool "262K → [960, 970]" true (v >= 960.0 && v <= 970.0)
 
+let test_oas_timeout_262k_scheduled_autonomous () =
+  let v =
+    Cfg.KeeperKeepalive.oas_timeout_for_context_with_turn_budget
+      ~max_context:262_144
+      ~max_turns:Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
+  in
+  (* 120 + 262.144*1.5 + min(5,40)*30 = 120+393.216+150 = 663.216 *)
+  check bool "262K scheduled autonomous → [660, 670]" true
+    (v >= 660.0 && v <= 670.0)
+
 let test_oas_timeout_zero () =
   let v = adaptive ~max_context:0 in
   (* 120 + 0 + min(15,40)*30 = 570 *)
@@ -110,10 +120,20 @@ let test_max_turns_default () =
   check int "default max_turns_per_call 15" 15
     Cfg.KeeperKeepalive.oas_max_turns_per_call
 
+let test_scheduled_autonomous_max_turns_default () =
+  check int "default scheduled autonomous max_turns_per_call 5" 5
+    Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
+
 let test_max_turns_range () =
   let v = Cfg.KeeperKeepalive.oas_max_turns_per_call in
   check bool "max_turns >= 1" true (v >= 1);
   check bool "max_turns <= 50" true (v <= 50)
+
+let test_scheduled_autonomous_max_turns_range () =
+  let v = Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous in
+  check bool "scheduled autonomous max_turns >= 1" true (v >= 1);
+  check bool "scheduled autonomous max_turns <= global" true
+    (v <= Cfg.KeeperKeepalive.oas_max_turns_per_call)
 
 let test_oas_timeout_sec_compat () =
   (* Without env override, oas_timeout_sec returns 300.0 default *)
@@ -307,12 +327,18 @@ let () =
       test_case "adaptive 32K context" `Quick test_oas_timeout_32k;
       test_case "adaptive 128K context" `Quick test_oas_timeout_128k;
       test_case "adaptive 262K context" `Quick test_oas_timeout_262k;
+      test_case "adaptive 262K scheduled autonomous context" `Quick
+        test_oas_timeout_262k_scheduled_autonomous;
       test_case "adaptive 0 context" `Quick test_oas_timeout_zero;
       test_case "adaptive monotonic" `Quick test_oas_timeout_monotonic;
       test_case "turn timeout default is 1200" `Quick test_turn_timeout_default;
       test_case "adaptive capped at turn timeout" `Quick test_oas_timeout_cap;
-      test_case "max_turns default is 5" `Quick test_max_turns_default;
+      test_case "max_turns default is 15" `Quick test_max_turns_default;
+      test_case "scheduled autonomous max_turns default is 5" `Quick
+        test_scheduled_autonomous_max_turns_default;
       test_case "max_turns range" `Quick test_max_turns_range;
+      test_case "scheduled autonomous max_turns range" `Quick
+        test_scheduled_autonomous_max_turns_range;
       test_case "oas_timeout_sec backward compat" `Quick test_oas_timeout_sec_compat;
     ];
     "semaphore_wait_timeout", [


### PR DESCRIPTION
## Summary
- cap scheduled autonomous keeper turns per `Agent.run` call separately from reactive turns
- add a FIFO wait queue in `keeper_keepalive` so autonomous keepers cannot cut ahead of already-waiting peers
- keep the adaptive OAS timeout math aligned with the channel-specific turn budget and add regression coverage

## Why
After the checkpoint/history fixes landed, local single-slot runs still showed autonomous keepers starving their peers. Lowering admission concurrency alone was not enough because one scheduled autonomous keeper could still dominate the autonomous lane while others aged out on the semaphore wait cap.

## Root Cause
There were two cooperating problems:
- scheduled autonomous and reactive turns shared the same per-call OAS turn budget and timeout heuristic, so autonomous calls could stay alive too long
- autonomous keepers relied on raw semaphore acquisition with no fairness state, so a keeper re-entering the lane could beat peers that had already been waiting

## Product Impact
- scheduled autonomous turns yield earlier instead of holding one `Agent.run` call open for as long as reactive work
- autonomous keepers now queue FIFO before acquiring the autonomous semaphore, so existing waiters stay ahead of re-entry
- reactive turns keep the larger budget they need for explicit external triggers

## Validation
- `./_build/default/test/test_work_as_heartbeat.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/6810-autonomous-fairness ./test/test_keeper_unified.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/6810-autonomous-fairness @check`

## Notes
- I did not run a live shared-base-path server smoke against the existing 8935 runtime because that would require competing with the current local keeper process against the same `.masc` state.

Refs #6810
