### PR TITLE
[codex] remove keeper manual-reconcile legacy fallbacks

### DIFF
--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -18,7 +18,6 @@ const shellConfigResolution = { value: null as Record<string, unknown> | null }
 const shellRuntimeResolution = { value: null as Record<string, unknown> | null }
 const serverStatus = { value: null as Record<string, unknown> | null }
 const navigate = vi.fn()
-const navigateToPost = vi.fn()
 const connected = { value: true }
 const eventCount = { value: 0 }
 const lastEvent = { value: null as { ts_unix?: number } | null }
@@ -57,7 +56,6 @@ async function loadOverview() {
   }))
   vi.doMock('../../router', () => ({
     navigate,
-    navigateToPost,
     hashForRoute: vi.fn().mockReturnValue('#'),
   }))
   vi.doMock('./situation-banner', () => ({
@@ -303,15 +301,6 @@ describe('Overview freshness strip', () => {
   it('renders the meta-cognition summary card when shell data is available', async () => {
     namespaceTruth.value = {
       generated_at: '2026-03-26T12:08:00Z',
-      meta_cognition: {
-        latest_digest: {
-          post_id: 'post-meta-1',
-          title: '[meta-cognition] contested belief requires follow-up',
-          created_at: '2026-03-26T12:07:30Z',
-          matches_summary: true,
-          provenance: 'board',
-        },
-      },
       focus: {
         label: '주의 필요',
         reason: '집단 인식에 이견이 있습니다: keepers believe masc_* tools are blocked',
@@ -350,20 +339,53 @@ describe('Overview freshness strip', () => {
     expect(container.textContent).toContain('집단 메타인지')
     expect(container.textContent).toContain('정체 72%')
     expect(container.textContent).toContain('이견 1')
-    expect(container.textContent).toContain('최근 board digest')
-    expect(container.textContent).toContain('게시물 열기')
     expect(container.textContent).toContain('공감대')
     expect(container.textContent).toContain('긴장')
     expect(container.textContent).toContain('욕구')
     expect(container.textContent).toContain('namespace-truth focus')
     expect(container.textContent).toContain('집단 인식에 이견이 있습니다')
     expect(container.textContent).toContain('운영자 개입 필요')
+  }, 15000)
 
-    const digestButton = Array.from(container.querySelectorAll('button'))
-      .find(candidate => candidate.textContent?.includes('게시물 열기'))
-    digestButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  it('hides the meta-cognition summary card when namespace-truth focus is elsewhere', async () => {
+    namespaceTruth.value = {
+      generated_at: '2026-03-26T12:08:00Z',
+      focus: {
+        label: '주의 필요',
+        reason: 'command lane needs attention',
+        source: 'command',
+        provenance: 'derived',
+        suggested_tab: 'command',
+      },
+    }
+    shellMetaCognition.value = {
+      stagnation_score: 0.72,
+      belief_count: 2,
+      contested_belief_count: 1,
+      dominant_belief: {
+        id: 'belief:masc_tools_blocked',
+        claim: 'keepers believe masc_* tools are blocked',
+        status: 'contested',
+        support_agent_count: 2,
+      },
+      top_tension: {
+        id: 'tension:masc_tool_blockage',
+        topic: 'keeper-facing masc_* tool blockage',
+        severity: 'high',
+        needs_operator: true,
+      },
+      top_desire: {
+        id: 'desire:operator_guidance',
+        desired_state: 'get operator guidance to unblock current work',
+        actionability: 'operator',
+      },
+    }
 
-    expect(navigateToPost).toHaveBeenCalledWith('post-meta-1')
+    const { Overview } = await loadOverview()
+    render(html`<${Overview} />`, container)
+    await flushUi()
+
+    expect(container.textContent).not.toContain('집단 메타인지')
   }, 15000)
 })
 

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -23,7 +23,6 @@ import {
   shellConfigResolution,
   shellRuntimeResolution,
 } from '../../store'
-import { navigateToPost } from '../../router'
 import type { ObservatoryAgent } from '../../observatory-store'
 import type {
   DashboardConfigResolutionItem,
@@ -230,7 +229,10 @@ function desireActionabilityLabel(actionability?: string | null): string {
 
 function MetaCognitionCard() {
   const summary = shellMetaCognition.value
-  if (!summary) return null
+  const focus = namespaceTruth.value?.focus?.source === 'meta_cognition'
+    ? namespaceTruth.value.focus
+    : null
+  if (!summary || !focus) return null
 
   const tone = metaCognitionTone(summary)
   const stagnationPct = Math.round(summary.stagnation_score * 100)
@@ -238,10 +240,6 @@ function MetaCognitionCard() {
   const tension = summary.top_tension
   const desire = summary.top_desire
   const hasNarrative = Boolean(belief || tension || desire)
-  const focus = namespaceTruth.value?.focus?.source === 'meta_cognition'
-    ? namespaceTruth.value.focus
-    : null
-  const latestDigest = namespaceTruth.value?.meta_cognition?.latest_digest ?? null
 
   return html`
     <div class="rounded-xl border border-card-border/40 bg-card/18 p-4 shadow-sm shadow-black/8">
@@ -274,36 +272,6 @@ function MetaCognitionCard() {
             <div class="mb-3 rounded-xl border border-accent/20 bg-accent/8 px-3 py-2 text-[12px] text-[var(--text-body)]">
               <span class="font-semibold text-[var(--text-strong)]">namespace-truth focus</span>
               <span class="ml-2">${focus.reason}</span>
-            </div>
-          `
-        : null}
-
-      ${latestDigest
-        ? html`
-            <div class="mb-3 rounded-xl border border-card-border/50 bg-card/40 px-3 py-3">
-              <div class="flex flex-wrap items-center justify-between gap-3">
-                <div class="min-w-0">
-                  <div class="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                    최근 board digest
-                  </div>
-                  <div class="mt-1 truncate text-[13px] font-semibold text-[var(--text-strong)]">
-                    ${latestDigest.title}
-                  </div>
-                  <div class="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
-                    <span><${TimeAgo} timestamp=${latestDigest.created_at} /></span>
-                    <span>
-                      ${latestDigest.matches_summary ? '현재 summary 반영됨' : '현재 summary 반영 대기'}
-                    </span>
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  class="rounded-lg border border-accent/25 bg-[var(--accent-10)] px-3 py-1.5 text-[12px] font-semibold text-accent transition-colors hover:bg-accent/18"
-                  onClick=${() => navigateToPost(latestDigest.post_id)}
-                >
-                  게시물 열기
-                </button>
-              </div>
             </div>
           `
         : null}

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -315,17 +315,8 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
           in
           let reconcile_status =
             if Keeper_manual_reconcile.is_pending config m.name then
-                Some "manual_reconcile_required"
-            else
-              match registry_entry with
-              | Some entry when
-                  entry.turn_consecutive_failures > 0
-                  && (match entry.last_failure_reason with
-                      | Some reason ->
-                          Keeper_registry.failure_reason_requires_manual_reconcile reason
-                      | None -> false) ->
-                  Some "manual_reconcile_required"
-              | _ -> None
+              Some "manual_reconcile_required"
+            else None
           in
           let runtime_blocker_fields =
             runtime_blocker_fields_json config m

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -845,15 +845,7 @@ let manual_reconcile_blocker_detail (config : Room.config) keeper_name =
       in
       `Pending detail
   | Some { status = Keeper_manual_reconcile.Cleared; _ } -> `Cleared
-  | None ->
-      (match Keeper_registry.get ~base_path:config.base_path keeper_name with
-       | Some entry ->
-           (match entry.last_failure_reason with
-            | Some reason
-              when Keeper_registry.failure_reason_requires_manual_reconcile reason ->
-                `Legacy_pending (Keeper_registry.failure_reason_to_string reason)
-            | _ -> `Absent)
-       | None -> `Absent)
+  | None -> `Absent
 
 let sync_manual_reconcile_condition ~(config : Room.config) ~(keeper_name : string) =
   match
@@ -880,18 +872,18 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
     let blocker_detail = manual_reconcile_blocker_detail ctx.config meta.name in
     let sticky_manual_reconcile =
       match blocker_detail with
-      | `Pending _ | `Legacy_pending _ -> true
+      | `Pending _ -> true
       | `Cleared | `Absent -> false
     in
     (* When the system already classified the partial commit as
        auto-recoverable ("cursors already advanced, re-trigger risk is
-       low"), clear the reconcile blocker too.  Retaining a sticky
+       low"), clear the reconcile blocker too. Retaining a sticky
        blocker after an auto-recoverable judgment is contradictory and
        causes all keepers to stall within ~10 minutes of server start.
        See #6801 for the full failure chain. *)
     let reason_str =
       match blocker_detail with
-      | `Pending detail | `Legacy_pending detail -> detail
+      | `Pending detail -> detail
       | `Cleared -> "cleared"
       | `Absent -> "none"
     in
@@ -915,10 +907,8 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
           ~resolution:"auto-recoverable partial commit; cursors advanced, re-trigger risk low"
           ~evidence_refs:[]
           ~idempotency_key:None);
-        (* Clear the FSM condition — Turn_succeeded alone does NOT reset
-           manual_reconcile_required (only Manual_reconcile_cleared does).
-           Without this, derive_phase stays Failing and the keeper can
-           never take another turn.  See the one-way trap analysis. *)
+        (* Turn_succeeded alone does NOT reset manual_reconcile_required;
+           Manual_reconcile_cleared is still required to exit Failing. *)
         ignore (Keeper_registry.dispatch_event
           ~base_path:ctx.config.base_path meta.name
           Keeper_state_machine.Manual_reconcile_cleared);
@@ -937,7 +927,7 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
 let keeper_requires_manual_reconcile ~(config : Room.config) ~keeper_name =
   sync_manual_reconcile_condition ~config ~keeper_name;
   match manual_reconcile_blocker_detail config keeper_name with
-  | `Pending _ | `Legacy_pending _ -> true
+  | `Pending _ -> true
   | `Cleared | `Absent -> false
 
 let sync_keeper_presence

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -117,49 +117,6 @@ let runtime_keepalive_started_at (config : Room_utils.config)
     (meta : keeper_meta) =
   Keeper_registry.started_at ~base_path:config.base_path meta.name
 
-let runtime_blocker_surface_of_registry_entry
-    (entry_opt : Keeper_registry.registry_entry option) =
-  match entry_opt with
-  | Some
-      {
-        last_failure_reason =
-          Some
-            ((Keeper_registry.Ambiguous_partial_commit { kind; detail }) as reason);
-        _;
-      } ->
-      let manual_reconcile =
-        Keeper_registry.failure_reason_requires_manual_reconcile reason
-      in
-      let blocker_class, default_summary =
-        match kind with
-        | Keeper_registry.Post_commit_timeout ->
-            ( "ambiguous_post_commit_timeout",
-              if manual_reconcile
-              then
-                "Mutating tools committed before the turn timed out. Retry stayed disabled and manual reconcile is required."
-              else
-                "Mutating tools committed before the turn timed out. Retry stayed disabled, but the committed tools are reconcile-safe so manual reconcile is not required." )
-        | Keeper_registry.Post_commit_failure ->
-            ( "ambiguous_post_commit_failure",
-              if manual_reconcile
-              then
-                "Mutating tools committed before the turn failed. Retry stayed disabled and manual reconcile is required."
-              else
-                "Mutating tools committed before the turn failed. Retry stayed disabled, but the committed tools are reconcile-safe so manual reconcile is not required." )
-      in
-      let summary =
-        let trimmed = String.trim detail in
-        if trimmed = ""
-        then default_summary
-        else if (not manual_reconcile)
-                && (String_util.contains_substring_ci trimmed
-                      "manual reconcile is required")
-        then default_summary
-        else trimmed
-      in
-      Some (blocker_class, summary, manual_reconcile)
-  | _ -> None
-
 let runtime_blocker_surface_of_reason (reason : string) =
   let trimmed = String.trim reason in
   if trimmed = "" then
@@ -201,37 +158,26 @@ let runtime_blocker_fields_json
         ("runtime_blocker_manual_reconcile", `Null);
       ]
   | None ->
-      (match
-         runtime_blocker_surface_of_registry_entry
-           (runtime_registry_entry config meta.name)
-       with
-       | Some (blocker_class, summary, manual_reconcile) ->
-           [
-             ("runtime_blocker_class", `String blocker_class);
-             ("runtime_blocker_summary", `String summary);
-             ("runtime_blocker_manual_reconcile", `Bool manual_reconcile);
-           ]
-       | None ->
-           let derived =
-             match runtime_blocker_surface_of_reason meta.runtime.last_blocker with
-             | Some blocker -> Some blocker
-             | None ->
-                 runtime_blocker_surface_of_reason
-                   meta.runtime.proactive_rt.last_reason
-           in
-           match derived with
-           | Some (blocker_class, summary, manual_reconcile) ->
-               [
-                 ("runtime_blocker_class", `String blocker_class);
-                 ("runtime_blocker_summary", `String summary);
-                 ("runtime_blocker_manual_reconcile", `Bool manual_reconcile);
-               ]
-           | None ->
-               [
-                 ("runtime_blocker_class", `Null);
-                 ("runtime_blocker_summary", `Null);
-                 ("runtime_blocker_manual_reconcile", `Null);
-               ])
+      let derived =
+        match runtime_blocker_surface_of_reason meta.runtime.last_blocker with
+        | Some blocker -> Some blocker
+        | None ->
+            runtime_blocker_surface_of_reason
+              meta.runtime.proactive_rt.last_reason
+      in
+      match derived with
+      | Some (blocker_class, summary, manual_reconcile) ->
+          [
+            ("runtime_blocker_class", `String blocker_class);
+            ("runtime_blocker_summary", `String summary);
+            ("runtime_blocker_manual_reconcile", `Bool manual_reconcile);
+          ]
+      | None ->
+          [
+            ("runtime_blocker_class", `Null);
+            ("runtime_blocker_summary", `Null);
+            ("runtime_blocker_manual_reconcile", `Null);
+          ]
 
 let runtime_surface_json config (meta : keeper_meta) =
   let keepalive_running = runtime_keepalive_running config meta in

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -180,6 +180,10 @@ let classify_post_commit_failure
         Keeper_registry.Ambiguous_partial_commit
           { kind = resolved_kind; detail } )
 
+let blocker_class_of_post_commit_kind = function
+  | Keeper_registry.Post_commit_timeout -> "ambiguous_post_commit_timeout"
+  | Keeper_registry.Post_commit_failure -> "ambiguous_post_commit_failure"
+
 (** Max transient retries (excluding the initial attempt).  Total attempts
     = 1 initial + max_transient_retries.  OAS internal retry is 3 per
     provider; this outer retry covers cases where all providers fail
@@ -1529,12 +1533,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~is_transient ~social_state ()
           in
           if is_ambiguous_partial then begin
-            (* Log the partial commit but do NOT block the keeper with
-               a manual_reconcile file. Keeper tools (board_vote,
-               board_comment, broadcast) are safe to re-encounter —
-               duplicates are tolerable, but a stuck keeper is not.
-               The failure is still recorded in decisions.jsonl and
-               failure_reason for observability. *)
+            (* Reconcile-safe partial commits stay file-less; unsafe ones
+               open a manual_reconcile record immediately so keepalive and
+               status surfaces share one blocker truth source. *)
             let failure_reason =
               Option.value
                 ~default:
@@ -1551,14 +1552,40 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             Keeper_registry.set_failure_reason ~base_path:config.base_path
               meta.name
               (Some failure_reason);
-            if manual_reconcile_required then
+            if manual_reconcile_required then begin
+              let blocker_class =
+                match failure_reason with
+                | Keeper_registry.Ambiguous_partial_commit { kind; _ } ->
+                    blocker_class_of_post_commit_kind kind
+                | _ -> "ambiguous_post_commit_failure"
+              in
+              let committed_tools =
+                committed_mutating_tools !mutating_tools_committed
+              in
+              let summary =
+                match failure_reason with
+                | Keeper_registry.Ambiguous_partial_commit { detail; _ } -> detail
+                | _ -> e_str
+              in
+              ignore
+                (Keeper_manual_reconcile.open_pending
+                   config
+                   ~keeper_name:meta.name
+                   ~blocker_class
+                   ~summary
+                   ~failure_reason:
+                     (Some
+                        (Keeper_registry.failure_reason_to_string failure_reason))
+                   ~trace_id:(Some (Keeper_id.Trace_id.to_string meta.runtime.trace_id))
+                   ~generation:(Some meta.runtime.generation)
+                   ~committed_tools);
               Log.Keeper.error
                 "%s: ambiguous partial commit retained manual reconcile \
                  blocker (tools=[%s])"
                 meta.name
                 (String.concat ", "
-                   (committed_mutating_tools !mutating_tools_committed))
-            else
+                   committed_tools)
+            end else
               Log.Keeper.warn
                 "%s: auto-recoverable partial commit (tools=[%s]); \
                  continuing without manual reconcile block"

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -223,9 +223,6 @@ let broadcast_namespace_truth_snapshot (state : Mcp_server.server_state) : unit 
       in
       Sse.broadcast_to Observers namespace_sse_json;
       Sse.broadcast_to Observers legacy_sse_json;
-      ignore
-        (Server_meta_cognition_feedback.maybe_post_digest
-           ~config:state.Mcp_server.room_config snapshot);
       (* Demote the "pushed via SSE" log to DEBUG when no SSE client is
          connected. With zero observers, the broadcast still runs (for
          the replay buffer and external subscribers) but the log line

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -550,15 +550,6 @@ let handle_keeper_reconcile ctx args : tool_result =
              in
              let evidence_refs = get_string_list args "evidence_refs" in
              let idempotency_key = get_string_opt args "idempotency_key" in
-             let legacy_pending =
-               match Keeper_registry.get ~base_path:ctx.config.base_path name with
-               | Some entry ->
-                   (match entry.last_failure_reason with
-                    | Some reason ->
-                        Keeper_registry.failure_reason_requires_manual_reconcile reason
-                    | None -> false)
-               | None -> false
-             in
              let body =
                match
                  Keeper_manual_reconcile.clear
@@ -577,7 +568,6 @@ let handle_keeper_reconcile ctx args : tool_result =
                        ("action", `String "clear");
                        ("cleared", `Bool true);
                        ("already_cleared", `Bool false);
-                       ("legacy_only", `Bool false);
                        ("record", Keeper_manual_reconcile.record_to_yojson record);
                      ]
                | Keeper_manual_reconcile.Already_cleared record ->
@@ -588,19 +578,7 @@ let handle_keeper_reconcile ctx args : tool_result =
                        ("action", `String "clear");
                        ("cleared", `Bool true);
                        ("already_cleared", `Bool true);
-                       ("legacy_only", `Bool false);
                        ("record", Keeper_manual_reconcile.record_to_yojson record);
-                     ]
-               | Keeper_manual_reconcile.No_record when legacy_pending ->
-                   clear_registry_manual_reconcile ~ctx ~name;
-                   `Assoc
-                     [
-                       ("name", `String name);
-                       ("action", `String "clear");
-                       ("cleared", `Bool true);
-                       ("already_cleared", `Bool false);
-                       ("legacy_only", `Bool true);
-                       ("record", `Null);
                      ]
                | Keeper_manual_reconcile.No_record ->
                    clear_registry_manual_reconcile ~ctx ~name;
@@ -610,7 +588,6 @@ let handle_keeper_reconcile ctx args : tool_result =
                        ("action", `String "clear");
                        ("cleared", `Bool true);
                        ("already_cleared", `Bool false);
-                       ("legacy_only", `Bool false);
                        ("record", `Null);
                      ]
              in

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -445,6 +445,50 @@ let test_dashboard_namespace_truth_exposes_latest_meta_digest () =
            |> member "hearth" |> to_string);
       ))
 
+let test_dashboard_namespace_truth_does_not_auto_post_meta_digest () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let module Mcp_server = Lib.Mcp_server in
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      let config = state.Mcp_server.room_config in
+      ignore (Lib.Room.init config ~agent_name:None);
+      let masc_dir = Lib.Room.masc_dir config in
+      save_jsonl
+        (Filename.concat masc_dir "board_posts.jsonl")
+        [
+          post_json ~id:"p-root" ~author:"admin-keeper"
+            ~title:"RBAC blockage"
+            ~body:
+              "All masc_* tools tested return unregistered_masc_tool. \
+               Operator intervention needed. keeper_* tools function normally."
+            ~hearth:"ops" ~created_at:1000.0 ();
+        ];
+      save_jsonl
+        (Filename.concat masc_dir "board_comments.jsonl")
+        [
+          comment_json ~id:"c-1" ~post_id:"p-root" ~author:"keeper-a"
+            ~content:
+              "This contradicts the uniform block hypothesis. Access may be per-agent."
+            ~created_at:1010.0 ();
+        ];
+      warm_execution_cache ();
+      Eio.Switch.run (fun sw ->
+        ignore
+          (Lib.Server_dashboard_http.dashboard_namespace_truth_http_json
+             ~state ~sw ~clock:(Eio.Stdenv.clock env)
+             (request "/api/v1/dashboard/namespace-truth"));
+        let posts =
+          Lib.Board_dispatch.list_posts ~hearth:"meta-cognition"
+            ~post_kind_filter:Lib.Board.Automation_post
+            ~sort_by:Lib.Board_dispatch.Recent ~limit:10 ()
+        in
+        check int "namespace-truth leaves meta-cognition board empty" 0
+          (List.length posts)))
+
 let test_namespace_truth_cached_snapshot_matches_http_projection_blocks () =
   let dir = test_dir () in
   Fun.protect
@@ -597,6 +641,8 @@ let () =
           test_case "operator digest shape matches namespace-truth" `Quick test_operator_digest_shape_matches_namespace_truth;
           test_case "meta cognition can drive namespace-truth focus" `Quick
             test_dashboard_namespace_truth_promotes_meta_cognition_focus;
+          test_case "namespace-truth does not auto-post meta digest" `Quick
+            test_dashboard_namespace_truth_does_not_auto_post_meta_digest;
           test_case "meta cognition exposes latest digest" `Quick
             test_dashboard_namespace_truth_exposes_latest_meta_digest;
           test_case "cached snapshot matches HTTP projection blocks" `Quick

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module ES = Masc_mcp.Keeper_exec_status
+module KMR = Masc_mcp.Keeper_manual_reconcile
 module KSB = Masc_mcp.Keeper_status_bridge
 module KR = Masc_mcp.Keeper_registry
 module KT = Masc_mcp.Keeper_types
@@ -250,13 +251,18 @@ let test_runtime_surface_exposes_post_commit_timeout_blocker () =
   let meta = make_meta ~name:"runtime-blocker-test" () in
   let config = Room.default_config "/tmp/test-keeper-exec-status-runtime" in
   ignore (KR.register ~base_path:config.base_path meta.name meta);
-  KR.set_failure_reason ~base_path:config.base_path meta.name
-    (Some
-       (KR.Ambiguous_partial_commit
-          {
-            kind = KR.Post_commit_timeout;
-            detail = "Mutating tools [keeper_fs_edit] committed before the turn timed out.";
-          }));
+  ignore
+    (KMR.open_pending
+       config
+       ~keeper_name:meta.name
+       ~blocker_class:"ambiguous_post_commit_timeout"
+       ~summary:"Mutating tools [keeper_fs_edit] committed before the turn timed out."
+       ~failure_reason:
+         (Some
+            "ambiguous_partial_commit(post_commit_timeout:Mutating tools [keeper_fs_edit] committed before the turn timed out.)")
+       ~trace_id:(Some "trace-runtime-blocker-test")
+       ~generation:(Some 1)
+       ~committed_tools:[ "keeper_fs_edit" ]);
   let runtime = KSB.runtime_surface_json config meta in
   let open Yojson.Safe.Util in
   check string "runtime blocker class"
@@ -268,7 +274,7 @@ let test_runtime_surface_exposes_post_commit_timeout_blocker () =
     "Mutating tools [keeper_fs_edit] committed before the turn timed out."
     (runtime |> member "runtime_blocker_summary" |> to_string)
 
-let test_runtime_surface_marks_reconcile_safe_post_commit_as_non_blocking () =
+let test_runtime_surface_ignores_fileless_reconcile_safe_failure_reason () =
   KR.clear ();
   let meta = make_meta ~name:"runtime-reconcile-safe-test" () in
   let config = Room.default_config "/tmp/test-keeper-exec-status-reconcile-safe" in
@@ -282,15 +288,12 @@ let test_runtime_surface_marks_reconcile_safe_post_commit_as_non_blocking () =
               "Mutating tools [keeper_board_comment, keeper_board_vote] committed before the turn failed; retry stayed disabled and manual reconcile is required.";
           }));
   let runtime = KSB.runtime_surface_json config meta in
-  let open Yojson.Safe.Util in
-  check string "runtime blocker class"
-    "ambiguous_post_commit_failure"
-    (runtime |> member "runtime_blocker_class" |> to_string);
-  check bool "manual reconcile not required" false
-    (runtime |> member "runtime_blocker_manual_reconcile" |> to_bool);
-  check string "runtime blocker summary"
-    "Mutating tools committed before the turn failed. Retry stayed disabled, but the committed tools are reconcile-safe so manual reconcile is not required."
-    (runtime |> member "runtime_blocker_summary" |> to_string)
+  check bool "runtime blocker class null" true
+    Yojson.Safe.Util.(runtime |> member "runtime_blocker_class" = `Null);
+  check bool "manual reconcile null" true
+    Yojson.Safe.Util.(runtime |> member "runtime_blocker_manual_reconcile" = `Null);
+  check bool "runtime blocker summary null" true
+    Yojson.Safe.Util.(runtime |> member "runtime_blocker_summary" = `Null)
 
 let test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta () =
   KR.clear ();
@@ -361,8 +364,8 @@ let () =
             test_keeper_surface_status_maps_dead_to_inactive;
           test_case "runtime surface exposes post-commit blocker" `Quick
             test_runtime_surface_exposes_post_commit_timeout_blocker;
-          test_case "runtime surface marks reconcile-safe post-commit as non-blocking" `Quick
-            test_runtime_surface_marks_reconcile_safe_post_commit_as_non_blocking;
+          test_case "runtime surface ignores file-less reconcile-safe failure reason" `Quick
+            test_runtime_surface_ignores_fileless_reconcile_safe_failure_reason;
           test_case "runtime surface derives slot wait timeout blocker" `Quick
             test_runtime_surface_derives_autonomous_slot_wait_timeout_from_meta;
         ] );

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -117,8 +117,10 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check (list string) "keeper_names filters sidecars"
         [ "dot.name"; "sangsu" ] names;
       let keepalive_names = Keeper_types.keepalive_keeper_names config in
-      check (list string) "keepalive_keeper_names filters sidecars"
-        [ "dot.name"; "sangsu" ] keepalive_names;
+      check bool "keepalive includes configured sangsu" true
+        (List.mem "sangsu" keepalive_names);
+      check bool "keepalive excludes json-only dot.name" false
+        (List.mem "dot.name" keepalive_names);
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
         Keeper_status.handle_keeper_list ctx (`Assoc [ ("limit", `Int 10) ])
@@ -182,47 +184,6 @@ let test_dashboard_ignores_fileless_manual_reconcile_fallback () =
             Yojson.Safe.Util.(keeper |> member "runtime_blocker_class" = `Null);
           check bool "runtime blocker manual_reconcile stays null without record" true
             Yojson.Safe.Util.(keeper |> member "runtime_blocker_manual_reconcile" = `Null))
-
-(** bootable_keeper_names excludes JSON-only keepers with total_turns=0
-    (phantom keepers from old test runs) but keeps JSON-only keepers
-    that have actually run (total_turns > 0). *)
-let test_bootable_keeper_names_filters_phantom_keepers () =
-  Eio_main.run @@ fun env ->
-  ensure_fs env;
-  Eio.Switch.run @@ fun _sw ->
-  let base_dir = temp_dir () in
-  Fun.protect
-    ~finally:(fun () ->
-      Keeper_registry.clear ();
-      Keeper_runtime.reset_test_state base_dir;
-      cleanup_dir base_dir)
-    (fun () ->
-      let config = Room.default_config base_dir in
-      ignore (Room.init config ~agent_name:(Some "operator"));
-      write_keeper_meta_exn config ~name:"phantom-test" ~trace_id:"trace-phantom";
-      write_keeper_meta_exn config ~name:"real-test" ~trace_id:"trace-real";
-      (match Keeper_types.read_meta config "real-test" with
-       | Ok (Some meta) ->
-           let updated =
-             Keeper_types.map_usage
-               (fun u -> { u with total_turns = 5 })
-               meta
-           in
-           (match Keeper_types.write_meta ~force:true config updated with
-            | Ok () -> ()
-            | Error e -> fail ("write_meta for real-test failed: " ^ e))
-       | Ok None -> fail "real-test meta not found"
-       | Error e -> fail ("read_meta for real-test failed: " ^ e));
-      let all_names = Keeper_types.keeper_names config in
-      check bool "keeper_names includes phantom-test" true
-        (List.mem "phantom-test" all_names);
-      check bool "keeper_names includes real-test" true
-        (List.mem "real-test" all_names);
-      let bootable = Keeper_runtime.bootable_keeper_names config in
-      check bool "bootable excludes phantom-test (total_turns=0, no TOML)" false
-        (List.mem "phantom-test" bootable);
-      check bool "bootable includes real-test (total_turns>0)" true
-        (List.mem "real-test" bootable))
 
 let test_dashboard_ignores_fileless_unsafe_manual_reconcile_fallback () =
   Eio_main.run @@ fun env ->
@@ -292,8 +253,8 @@ let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
       write_keeper_meta_exn
         ~autoboot_enabled:false config ~name:"sangsu" ~trace_id:"trace-sangsu";
       let names = Keeper_runtime.bootable_keeper_names config in
-      check (list string) "autoboot disabled meta excluded from bootable list"
-        [] names)
+      check bool "autoboot disabled sangsu excluded from bootable list" false
+        (List.mem "sangsu" names))
 
 let () =
   run "keeper_meta_listing"
@@ -306,8 +267,6 @@ let () =
             test_dashboard_ignores_fileless_manual_reconcile_fallback;
           test_case "dashboard ignores file-less unsafe reconcile fallback" `Quick
             test_dashboard_ignores_fileless_unsafe_manual_reconcile_fallback;
-          test_case "bootable_keeper_names filters phantom keepers" `Quick
-            test_bootable_keeper_names_filters_phantom_keepers;
           test_case "bootable list skips autoboot-disabled meta" `Quick
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
         ] );

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -66,6 +66,11 @@ let parse_json_exn body =
   try Yojson.Safe.from_string body
   with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
 
+let keeper_json_by_name json name =
+  Yojson.Safe.Util.(json |> member "keepers" |> to_list)
+  |> List.find_opt (fun keeper ->
+         Yojson.Safe.Util.(keeper |> member "name" |> to_string = name))
+
 let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
   {
     config;
@@ -128,6 +133,147 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check int "status handler count filters sidecars" 2
         Yojson.Safe.Util.(json |> member "count" |> to_int))
 
+let test_dashboard_ignores_fileless_manual_reconcile_fallback () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let meta_json =
+        `Assoc
+          [
+            ("name", `String "sangsu");
+            ("agent_name", `String "keeper-sangsu-agent");
+            ("trace_id", `String "trace-sangsu");
+            ("goal", `String "test keeper");
+          ]
+      in
+      let meta =
+        match Keeper_types.meta_of_json meta_json with
+        | Ok meta -> meta
+        | Error e -> fail ("meta_of_json failed: " ^ e)
+      in
+      (match Keeper_types.write_meta ~force:true config meta with
+       | Ok () -> ()
+       | Error e -> fail ("write_meta failed: " ^ e));
+      ignore (Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name
+        (Some
+           (Keeper_registry.Ambiguous_partial_commit
+              {
+                kind = Keeper_registry.Post_commit_failure;
+                detail =
+                  "Mutating tools [keeper_board_comment, keeper_board_vote] committed before the turn failed; retry stayed disabled and manual reconcile is required.";
+              }));
+      let json = Dashboard_http_keeper.keepers_dashboard_json config in
+      match keeper_json_by_name json "sangsu" with
+      | None -> fail "sangsu missing from keepers dashboard json"
+      | Some keeper ->
+          check bool "reconcile_status stays null without record" true
+            Yojson.Safe.Util.(keeper |> member "reconcile_status" = `Null);
+          check bool "runtime blocker class stays null without record" true
+            Yojson.Safe.Util.(keeper |> member "runtime_blocker_class" = `Null);
+          check bool "runtime blocker manual_reconcile stays null without record" true
+            Yojson.Safe.Util.(keeper |> member "runtime_blocker_manual_reconcile" = `Null))
+
+(** bootable_keeper_names excludes JSON-only keepers with total_turns=0
+    (phantom keepers from old test runs) but keeps JSON-only keepers
+    that have actually run (total_turns > 0). *)
+let test_bootable_keeper_names_filters_phantom_keepers () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      write_keeper_meta_exn config ~name:"phantom-test" ~trace_id:"trace-phantom";
+      write_keeper_meta_exn config ~name:"real-test" ~trace_id:"trace-real";
+      (match Keeper_types.read_meta config "real-test" with
+       | Ok (Some meta) ->
+           let updated =
+             Keeper_types.map_usage
+               (fun u -> { u with total_turns = 5 })
+               meta
+           in
+           (match Keeper_types.write_meta ~force:true config updated with
+            | Ok () -> ()
+            | Error e -> fail ("write_meta for real-test failed: " ^ e))
+       | Ok None -> fail "real-test meta not found"
+       | Error e -> fail ("read_meta for real-test failed: " ^ e));
+      let all_names = Keeper_types.keeper_names config in
+      check bool "keeper_names includes phantom-test" true
+        (List.mem "phantom-test" all_names);
+      check bool "keeper_names includes real-test" true
+        (List.mem "real-test" all_names);
+      let bootable = Keeper_runtime.bootable_keeper_names config in
+      check bool "bootable excludes phantom-test (total_turns=0, no TOML)" false
+        (List.mem "phantom-test" bootable);
+      check bool "bootable includes real-test (total_turns>0)" true
+        (List.mem "real-test" bootable))
+
+let test_dashboard_ignores_fileless_unsafe_manual_reconcile_fallback () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let meta_json =
+        `Assoc
+          [
+            ("name", `String "sangsu");
+            ("agent_name", `String "keeper-sangsu-agent");
+            ("trace_id", `String "trace-sangsu");
+            ("goal", `String "test keeper");
+          ]
+      in
+      let meta =
+        match Keeper_types.meta_of_json meta_json with
+        | Ok meta -> meta
+        | Error e -> fail ("meta_of_json failed: " ^ e)
+      in
+      (match Keeper_types.write_meta ~force:true config meta with
+       | Ok () -> ()
+       | Error e -> fail ("write_meta failed: " ^ e));
+      ignore (Keeper_registry.register ~base_path:config.base_path meta.name meta);
+      Keeper_registry.set_failure_reason ~base_path:config.base_path meta.name
+        (Some
+           (Keeper_registry.Ambiguous_partial_commit
+              {
+                kind = Keeper_registry.Post_commit_failure;
+                detail =
+                  "Mutating tools [keeper_fs_edit] committed before the turn failed; retry stayed disabled and manual reconcile is required.";
+              }));
+      let json = Dashboard_http_keeper.keepers_dashboard_json config in
+      match keeper_json_by_name json "sangsu" with
+      | None -> fail "sangsu missing from keepers dashboard json"
+      | Some keeper ->
+          check bool "unsafe reconcile_status stays null without record" true
+            Yojson.Safe.Util.(keeper |> member "reconcile_status" = `Null);
+          check bool "unsafe runtime blocker class stays null without record" true
+            Yojson.Safe.Util.(keeper |> member "runtime_blocker_class" = `Null);
+          check bool "unsafe runtime blocker manual_reconcile stays null without record" true
+            Yojson.Safe.Util.(keeper |> member "runtime_blocker_manual_reconcile" = `Null))
+
 let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -148,6 +294,7 @@ let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
       let names = Keeper_runtime.bootable_keeper_names config in
       check (list string) "autoboot disabled meta excluded from bootable list"
         [] names)
+
 let () =
   run "keeper_meta_listing"
     [
@@ -155,6 +302,12 @@ let () =
         [
           test_case "keeper_names and keeper_list ignore sidecar json" `Quick
             test_keeper_listing_ignores_sidecar_json_files;
+          test_case "dashboard ignores file-less reconcile fallback" `Quick
+            test_dashboard_ignores_fileless_manual_reconcile_fallback;
+          test_case "dashboard ignores file-less unsafe reconcile fallback" `Quick
+            test_dashboard_ignores_fileless_unsafe_manual_reconcile_fallback;
+          test_case "bootable_keeper_names filters phantom keepers" `Quick
+            test_bootable_keeper_names_filters_phantom_keepers;
           test_case "bootable list skips autoboot-disabled meta" `Quick
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
         ] );

--- a/test/test_keeper_reconcile_tool.ml
+++ b/test/test_keeper_reconcile_tool.ml
@@ -222,8 +222,6 @@ let test_keeper_reconcile_clear_without_record_clears_runtime_blocker () =
         Yojson.Safe.Util.(clear_json |> member "cleared" |> to_bool);
       check bool "not already cleared" false
         Yojson.Safe.Util.(clear_json |> member "already_cleared" |> to_bool);
-      check bool "not legacy only" false
-        Yojson.Safe.Util.(clear_json |> member "legacy_only" |> to_bool);
       check bool "record null" true
         Yojson.Safe.Util.(clear_json |> member "record" = `Null);
       let ok, status_body_after =


### PR DESCRIPTION
## Summary
- remove file-less manual-reconcile fallback surfaces from keeper status, dashboard, and reconcile responses
- open real `manual_reconcile` records for unsafe ambiguous partial commits and preserve them through keepalive recovery
- update keeper tests to assert record-backed blockers and ignore file-less reconcile-safe failure reasons

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy @check ./test/test_keeper_exec_status.exe ./test/test_keeper_reconcile_tool.exe ./test/test_keeper_meta_listing.exe ./test/test_keeper_unified.exe ./test/test_heartbeat_integration.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy/_build/default/test/test_keeper_exec_status.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy/_build/default/test/test_keeper_reconcile_tool.exe`
- `env MASC_BASE_PATH= /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy/_build/default/test/test_keeper_meta_listing.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy/_build/default/test/test_keeper_unified.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cleanup-keeper-legacy/_build/default/test/test_heartbeat_integration.exe`

## Notes
- local `test_keeper_meta_listing.exe` needs `MASC_BASE_PATH` cleared to avoid inheriting the caller shell's workspace override