### PR TITLE
feat(keeper): failure circuit breaker — corrective hints after repeated errors

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -433,6 +433,7 @@
    keeper_tool_affinity
    keeper_tag_dispatch
    keeper_exec_shared
+   keeper_failure_circuit_breaker
    keeper_exec_board
    keeper_exec_fs
    keeper_exec_shell

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -18,14 +18,15 @@ let tool_result_or_error (ok, msg) = if ok then msg else error_json msg
 let actionable_path_error ~(op : string) ~(keeper_name : string)
       ~(raw_path : string) ~(error : string) =
   let playground = Printf.sprintf ".masc/playground/%s/" keeper_name in
+  let contains sub = String_util.contains_substring error sub in
   let action = match () with
     | () when String.length raw_path = 0 ->
       "Provide a path. Your playground root is " ^ playground
-    | () when try let _ = Str.search_forward (Str.regexp_string "path_not_found") error 0 in true with Not_found -> false ->
+    | () when contains "path_not_found" ->
       Printf.sprintf "File does not exist. Run `keeper_shell op=ls path=%s` first to see available files." playground
-    | () when try let _ = Str.search_forward (Str.regexp_string "path_not_in_allowed") error 0 in true with Not_found -> false ->
+    | () when contains "path_not_in_allowed" ->
       Printf.sprintf "Path is outside your allowed roots. Stay inside %s or use keeper_context_status to see allowed paths." playground
-    | () when try let _ = Str.search_forward (Str.regexp_string "cwd_not_directory") error 0 in true with Not_found -> false ->
+    | () when contains "cwd_not_directory" ->
       "The cwd is not a directory. Omit cwd to use your default playground root."
     | () ->
       Printf.sprintf "Check the path. Your playground: %s" playground

--- a/lib/keeper/keeper_exec_shared.ml
+++ b/lib/keeper/keeper_exec_shared.ml
@@ -11,6 +11,34 @@ let error_json ?(fields = []) (message : string) =
 
 let tool_result_or_error (ok, msg) = if ok then msg else error_json msg
 
+(** Actionable error for path resolution failures.
+    Follows Samchon harness pattern: field-level diagnostics with
+    exact path, expected constraint, and concrete next action.
+    Claude Code pattern: validateInput returns actionable guidance. *)
+let actionable_path_error ~(op : string) ~(keeper_name : string)
+      ~(raw_path : string) ~(error : string) =
+  let playground = Printf.sprintf ".masc/playground/%s/" keeper_name in
+  let action = match () with
+    | () when String.length raw_path = 0 ->
+      "Provide a path. Your playground root is " ^ playground
+    | () when try let _ = Str.search_forward (Str.regexp_string "path_not_found") error 0 in true with Not_found -> false ->
+      Printf.sprintf "File does not exist. Run `keeper_shell op=ls path=%s` first to see available files." playground
+    | () when try let _ = Str.search_forward (Str.regexp_string "path_not_in_allowed") error 0 in true with Not_found -> false ->
+      Printf.sprintf "Path is outside your allowed roots. Stay inside %s or use keeper_context_status to see allowed paths." playground
+    | () when try let _ = Str.search_forward (Str.regexp_string "cwd_not_directory") error 0 in true with Not_found -> false ->
+      "The cwd is not a directory. Omit cwd to use your default playground root."
+    | () ->
+      Printf.sprintf "Check the path. Your playground: %s" playground
+  in
+  Yojson.Safe.to_string (`Assoc [
+    "ok", `Bool false;
+    "op", `String op;
+    "error", `String error;
+    "tried", `String raw_path;
+    "your_playground", `String playground;
+    "action", `String action;
+  ])
+
 let max_suggested_entries = 12
 
 let file_not_found_prefix = "File not found:"

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -532,8 +532,14 @@ let handle_keeper_shell
     | _ -> raw_op
   in
   let root = Keeper_alerting_path.project_root_of_config config in
+  let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
   let read_target () = resolve_keeper_shell_read_path ~config ~meta ~args in
   let cwd_target () = resolve_keeper_shell_read_cwd ~config ~meta ~args in
+  (* Actionable error: Samchon/Claude Code validateInput pattern.
+     Returns structured JSON with tried path, playground root, and concrete next action. *)
+  let path_error e =
+    actionable_path_error ~op ~keeper_name:meta.name ~raw_path ~error:e
+  in
   let render_process_result ?cwd ~cmd argv =
     let st, out =
       Process_eio.run_argv_with_status ?cwd ~timeout_sec:io_timeout_sec argv
@@ -554,18 +560,18 @@ let handle_keeper_shell
   match op with
   | "pwd" ->
     (match cwd_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok cwd -> render_process_result ~cwd ~cmd:"pwd" [ "/bin/pwd" ])
   | "git_status" ->
     (match cwd_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok cwd ->
        render_process_result ~cwd
          ~cmd:"git -C <cwd> --no-optional-locks status --short --branch"
          [ "git"; "-C"; cwd; "--no-optional-locks"; "status"; "--short"; "--branch" ])
   | "ls" ->
     (match read_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok target ->
        let st, out =
          Process_eio.run_argv_with_status ~timeout_sec:io_timeout_sec [ "/bin/ls"; "-la"; target ]
@@ -581,7 +587,7 @@ let handle_keeper_shell
              ]))
   | "cat" ->
     (match read_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok target ->
        let max_bytes = shell_readonly_cat_max_bytes args in
        let st, out =
@@ -605,7 +611,7 @@ let handle_keeper_shell
     then error_json ~fields:[ "op", `String op ] "pattern is required for rg. Good: pattern='handle_request'. Bad: pattern=''."
     else (
       match read_target () with
-      | Error e -> error_json ~fields:[ "op", `String op ] e
+      | Error e -> path_error e
       | Ok target ->
         let limit = shell_readonly_limit args in
         (* Optional file-type filter (e.g. "ml", "py") *)
@@ -631,7 +637,7 @@ let handle_keeper_shell
               [ "grep"; "-R"; "-n"; "-I"; "-m"; string_of_int limit; "--"; pattern; target ]
         in
         match argv with
-        | Error e -> error_json ~fields:[ "op", `String op ] e
+        | Error e -> path_error e
         | Ok argv ->
         let st, out =
           Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec argv
@@ -650,7 +656,7 @@ let handle_keeper_shell
               ]))
   | "git_log" ->
     (match cwd_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok cwd ->
        let count = max 1 (min 50 (Safe_ops.json_int ~default:10 "count" args)) in
        let format = Safe_ops.json_string ~default:"%h %s" "format" args in
@@ -679,7 +685,7 @@ let handle_keeper_shell
     then error_json ~fields:[ "op", `String op ] "pattern is required for find. Good: pattern='*.ml'. Bad: pattern=''."
     else (
       match read_target () with
-      | Error e -> error_json ~fields:[ "op", `String op ] e
+      | Error e -> path_error e
       | Ok target ->
         let limit = shell_readonly_limit args in
         let st, out =
@@ -700,7 +706,7 @@ let handle_keeper_shell
               ]))
   | "head" ->
     (match read_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
        let st, out =
@@ -718,7 +724,7 @@ let handle_keeper_shell
              ]))
   | "tail" ->
     (match read_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok target ->
        let n = Safe_ops.json_int ~default:20 "lines" args |> fun v -> max 1 (min 200 v) in
        let st, out =
@@ -736,12 +742,12 @@ let handle_keeper_shell
              ]))
   | "wc" ->
     (match read_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok target ->
        render_process_result ~cmd:"wc" [ "/usr/bin/wc"; "-l"; target ])
   | "tree" ->
     (match read_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok target ->
        let st, out =
          Process_eio.run_argv_with_status ~timeout_sec:read_timeout_sec
@@ -760,7 +766,7 @@ let handle_keeper_shell
              ]))
   | "git_diff" ->
     (match cwd_target () with
-     | Error e -> error_json ~fields:[ "op", `String op ] e
+     | Error e -> path_error e
      | Ok cwd ->
        render_process_result ~cwd
          ~cmd:"git diff --stat"
@@ -773,7 +779,7 @@ let handle_keeper_shell
     begin match action with
     | "list" ->
       (match cwd_target () with
-       | Error e -> error_json ~fields:[ "op", `String op ] e
+       | Error e -> path_error e
        | Ok cwd ->
          render_process_result ~cwd ~cmd:"git worktree list"
            [ "git"; "-C"; cwd; "worktree"; "list" ])
@@ -785,7 +791,7 @@ let handle_keeper_shell
           "branch is required. Good: action='add', branch='feature/my-task'. Bad: branch=''."
       else (
         match cwd_target () with
-        | Error e -> error_json ~fields:[ "op", `String op ] e
+        | Error e -> path_error e
         | Ok cwd ->
           let _st, wt_out =
             Process_eio.run_argv_with_status ~timeout_sec:5.0
@@ -869,10 +875,10 @@ let handle_keeper_shell
               ])
       | None ->
         (match cwd_target () with
-         | Error e -> error_json ~fields:[ "op", `String op ] e
+         | Error e -> path_error e
          | Ok cwd ->
            (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd_str with
-            | Error e -> error_json ~fields:[ "op", `String op ] e
+            | Error e -> path_error e
             | Ok () ->
               let st, out =
                 Process_eio.run_argv_with_status ~cwd ~timeout_sec

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -62,7 +62,29 @@ let execute_keeper_tool_call
   =
   let args = input in
   let now_ts = Time_compat.now () in
+  let apply_circuit_breaker result =
+    (* Detect error in JSON result and enrich with corrective hint
+       if the same error class has repeated [threshold] times. *)
+    let is_error =
+      try
+        match Yojson.Safe.from_string result with
+        | `Assoc fields ->
+          (match List.assoc_opt "ok" fields with
+           | Some (`Bool false) -> true
+           | _ -> List.mem_assoc "error" fields)
+        | _ -> false
+      with _ -> false
+    in
+    if is_error then
+      Keeper_failure_circuit_breaker.maybe_enrich_error
+        ~keeper_name:meta.name ~error_msg:result
+    else begin
+      Keeper_failure_circuit_breaker.record_success ~keeper_name:meta.name;
+      result
+    end
+  in
   let lookup = tool_access_lookup_of_meta meta in
+  apply_circuit_breaker (
   if not (can_execute ~lookup name)
   then
     let reason, hint =
@@ -216,4 +238,4 @@ let execute_keeper_tool_call
              [ ("did_you_mean", `List (List.map enrich_suggestion names));
                ("hint", `String "Call one of these tools with the correct parameters.") ])
       in
-      Yojson.Safe.to_string (`Assoc fields))
+      Yojson.Safe.to_string (`Assoc fields)))

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -135,7 +135,25 @@ and corrective_hint cls keeper_name =
 let maybe_enrich_error ~keeper_name ~(error_msg : string) : string =
   match record_failure ~keeper_name ~error_msg with
   | None -> error_msg
-  | Some hint -> error_msg ^ hint
+  | Some hint ->
+    (* Try to enrich JSON responses by adding circuit_breaker field.
+       If error_msg is valid JSON with an "action" field, replace it.
+       Otherwise append as text (fallback for non-JSON errors). *)
+    (try
+       match Yojson.Safe.from_string error_msg with
+       | `Assoc fields ->
+         let enriched =
+           List.map (fun (k, v) ->
+             if k = "action" then (k, `String hint)
+             else (k, v)
+           ) fields
+         in
+         let with_breaker =
+           ("circuit_breaker", `Bool true) :: enriched
+         in
+         Yojson.Safe.to_string (`Assoc with_breaker)
+       | _ -> error_msg ^ hint
+     with _ -> error_msg ^ hint)
 
 (* ================================================================ *)
 (* Diagnostics                                                      *)

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -1,0 +1,155 @@
+(** Keeper Failure Circuit Breaker — detect repeated tool failures and
+    inject corrective hints into error responses.
+
+    Tracks consecutive failures per keeper by error class. After
+    [threshold] consecutive failures of the same class, appends a
+    corrective hint to the error message so the LLM adjusts its
+    next tool call.
+
+    Error classes are coarse categories (path_not_found, cwd_not_directory,
+    path_not_in_allowed_paths) — not exact error strings. This prevents
+    near-miss variants from resetting the counter. *)
+
+(* ================================================================ *)
+(* Error classification                                             *)
+(* ================================================================ *)
+
+type error_class =
+  | Path_not_found
+  | Path_not_allowed
+  | Cwd_not_directory
+  | Shell_exit_nonzero
+  | Other
+
+let classify_error (error_msg : string) : error_class =
+  if String.length error_msg = 0 then Other
+  else
+    let contains sub = try
+      let _ = Str.search_forward (Str.regexp_string sub) error_msg 0 in
+      true
+    with Not_found -> false
+    in
+    if contains "path_not_found" then Path_not_found
+    else if contains "path_not_in_allowed" then Path_not_allowed
+    else if contains "cwd_not_directory" then Cwd_not_directory
+    else if contains "No such file or directory" then Path_not_found
+    else if contains "exit" && contains "code" then Shell_exit_nonzero
+    else Other
+
+let error_class_to_string = function
+  | Path_not_found -> "path_not_found"
+  | Path_not_allowed -> "path_not_allowed"
+  | Cwd_not_directory -> "cwd_not_directory"
+  | Shell_exit_nonzero -> "shell_exit_nonzero"
+  | Other -> "other"
+
+(* ================================================================ *)
+(* Per-keeper state                                                  *)
+(* ================================================================ *)
+
+type breaker_state = {
+  mutable consecutive_class : error_class;
+  mutable consecutive_count : int;
+  mutable total_tripped : int;
+}
+
+let states : (string, breaker_state) Hashtbl.t = Hashtbl.create 16
+
+let threshold = 3
+
+let get_or_create keeper_name =
+  match Hashtbl.find_opt states keeper_name with
+  | Some s -> s
+  | None ->
+    let s = { consecutive_class = Other; consecutive_count = 0;
+              total_tripped = 0 } in
+    Hashtbl.replace states keeper_name s;
+    s
+
+(* ================================================================ *)
+(* Record + hint generation                                         *)
+(* ================================================================ *)
+
+let record_success ~keeper_name =
+  let s = get_or_create keeper_name in
+  s.consecutive_count <- 0
+
+let record_failure ~keeper_name ~(error_msg : string) : string option =
+  let cls = classify_error error_msg in
+  let s = get_or_create keeper_name in
+  if cls = s.consecutive_class then
+    s.consecutive_count <- s.consecutive_count + 1
+  else begin
+    s.consecutive_class <- cls;
+    s.consecutive_count <- 1
+  end;
+  if s.consecutive_count >= threshold then begin
+    s.total_tripped <- s.total_tripped + 1;
+    s.consecutive_count <- 0;
+    Log.Keeper.warn
+      "circuit_breaker tripped for %s: %d consecutive %s failures (total trips: %d)"
+      keeper_name threshold (error_class_to_string cls) s.total_tripped;
+    Some (corrective_hint cls keeper_name)
+  end else
+    None
+
+and corrective_hint cls keeper_name =
+  let base =
+    Printf.sprintf
+      "\n\n[CIRCUIT BREAKER] You have failed %d times with the same error class (%s). STOP and change your approach:\n"
+      threshold (error_class_to_string cls)
+  in
+  let specific = match cls with
+    | Path_not_found ->
+      Printf.sprintf
+        "- The file you are looking for does NOT exist. Do NOT guess paths.\n\
+         - Run `keeper_shell op=ls` on your playground root first to see what actually exists.\n\
+         - Your playground: .masc/playground/%s/\n\
+         - Your repos: .masc/playground/%s/repos/ (clone a repo first if empty)\n\
+         - NEVER fabricate file paths like lib/ocaml/... — check with ls first."
+        keeper_name keeper_name
+    | Path_not_allowed ->
+      Printf.sprintf
+        "- You are trying to access a path outside your allowed roots.\n\
+         - Stay inside: .masc/playground/%s/ or allowed workspace paths.\n\
+         - Do NOT access the server root or arbitrary directories.\n\
+         - Run `keeper_context_status` to see your allowed paths."
+        keeper_name
+    | Cwd_not_directory ->
+      "- The cwd you specified is not a directory. Use `keeper_shell op=ls` to find valid directories.\n\
+       - Leave the cwd parameter empty to use your default playground root."
+    | Shell_exit_nonzero ->
+      "- Your shell command is failing repeatedly. Check the command syntax.\n\
+       - Try a simpler command first to verify the tool works.\n\
+       - Do NOT retry the exact same failing command."
+    | Other ->
+      "- You are repeating the same failing action. Try a completely different approach.\n\
+       - If stuck, use `keeper_stay_silent` and wait for new context."
+  in
+  base ^ specific
+
+(* ================================================================ *)
+(* Append hint to error message                                     *)
+(* ================================================================ *)
+
+let maybe_enrich_error ~keeper_name ~(error_msg : string) : string =
+  match record_failure ~keeper_name ~error_msg with
+  | None -> error_msg
+  | Some hint -> error_msg ^ hint
+
+(* ================================================================ *)
+(* Diagnostics                                                      *)
+(* ================================================================ *)
+
+let snapshot_json () : Yojson.Safe.t =
+  let entries =
+    Hashtbl.fold (fun name state acc ->
+      `Assoc [
+        "keeper", `String name;
+        "consecutive_class", `String (error_class_to_string state.consecutive_class);
+        "consecutive_count", `Int state.consecutive_count;
+        "total_tripped", `Int state.total_tripped;
+      ] :: acc
+    ) states []
+  in
+  `List entries

--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -24,11 +24,7 @@ type error_class =
 let classify_error (error_msg : string) : error_class =
   if String.length error_msg = 0 then Other
   else
-    let contains sub = try
-      let _ = Str.search_forward (Str.regexp_string sub) error_msg 0 in
-      true
-    with Not_found -> false
-    in
+    let contains sub = String_util.contains_substring error_msg sub in
     if contains "path_not_found" then Path_not_found
     else if contains "path_not_in_allowed" then Path_not_allowed
     else if contains "cwd_not_directory" then Cwd_not_directory
@@ -74,7 +70,7 @@ let record_success ~keeper_name =
   let s = get_or_create keeper_name in
   s.consecutive_count <- 0
 
-let record_failure ~keeper_name ~(error_msg : string) : string option =
+let rec record_failure ~keeper_name ~(error_msg : string) : string option =
   let cls = classify_error error_msg in
   let s = get_or_create keeper_name in
   if cls = s.consecutive_class then

--- a/lib/keeper/keeper_failure_circuit_breaker.mli
+++ b/lib/keeper/keeper_failure_circuit_breaker.mli
@@ -1,0 +1,29 @@
+(** Keeper Failure Circuit Breaker — detect repeated tool failures and
+    inject corrective hints into error responses.
+
+    After [threshold] consecutive failures of the same error class,
+    appends a corrective hint to the error message. Resets on success.
+
+    @since v0.5.11 *)
+
+(** Coarse error categories for grouping failures. *)
+type error_class =
+  | Path_not_found
+  | Path_not_allowed
+  | Cwd_not_directory
+  | Shell_exit_nonzero
+  | Other
+
+(** Classify an error message string into an error class. *)
+val classify_error : string -> error_class
+
+(** Record a successful tool call (resets consecutive counter). *)
+val record_success : keeper_name:string -> unit
+
+(** Enrich an error message with a corrective hint if the circuit
+    breaker threshold has been reached. Returns the original message
+    unchanged if under threshold, or message + hint if tripped. *)
+val maybe_enrich_error : keeper_name:string -> error_msg:string -> string
+
+(** JSON snapshot of all breaker states for diagnostics. *)
+val snapshot_json : unit -> Yojson.Safe.t

--- a/specs/KeeperCircuitBreaker-buggy.cfg
+++ b/specs/KeeperCircuitBreaker-buggy.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Threshold = 3
+    ErrorClasses = {"path_not_found", "path_not_allowed", "other"}
+    MaxSteps = 12
+
+INVARIANT TripOnlyWithStreak

--- a/specs/KeeperCircuitBreaker-buggy.cfg
+++ b/specs/KeeperCircuitBreaker-buggy.cfg
@@ -6,3 +6,5 @@ CONSTANTS
     MaxSteps = 12
 
 INVARIANT TripOnlyWithStreak
+
+CHECK_DEADLOCK FALSE

--- a/specs/KeeperCircuitBreaker.cfg
+++ b/specs/KeeperCircuitBreaker.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Threshold = 3
+    ErrorClasses = {"path_not_found", "path_not_allowed", "other"}
+    MaxSteps = 12
+
+INVARIANT SafetyInvariant

--- a/specs/KeeperCircuitBreaker.cfg
+++ b/specs/KeeperCircuitBreaker.cfg
@@ -6,3 +6,5 @@ CONSTANTS
     MaxSteps = 12
 
 INVARIANT SafetyInvariant
+
+CHECK_DEADLOCK FALSE

--- a/specs/KeeperCircuitBreaker.tla
+++ b/specs/KeeperCircuitBreaker.tla
@@ -1,0 +1,129 @@
+---- MODULE KeeperCircuitBreaker ----
+\* Circuit Breaker state machine for keeper tool failure recovery.
+\* Verifies safety (no false trips) and mutation-tests the class isolation property.
+
+EXTENDS Integers, Sequences, FiniteSets
+
+CONSTANTS
+    Threshold,       \* consecutive failures before trip (3 in production)
+    ErrorClasses,    \* set of error classes
+    MaxSteps         \* bound model checking
+
+VARIABLES
+    count,           \* consecutive failure count (0..Threshold)
+    currentClass,    \* current error class being tracked
+    tripped,         \* whether hint was injected on THIS step
+    totalTrips,      \* cumulative trip count
+    classStreak,     \* TRUE iff all counted failures are same class (ghost variable)
+    step             \* step counter for bounded checking
+
+vars == <<count, currentClass, tripped, totalTrips, classStreak, step>>
+
+TypeOK ==
+    /\ count \in 0..Threshold
+    /\ currentClass \in ErrorClasses \cup {"none"}
+    /\ tripped \in BOOLEAN
+    /\ totalTrips \in Nat
+    /\ classStreak \in BOOLEAN
+    /\ step \in 0..MaxSteps
+
+Init ==
+    /\ count = 0
+    /\ currentClass = "none"
+    /\ tripped = FALSE
+    /\ totalTrips = 0
+    /\ classStreak = TRUE
+    /\ step = 0
+
+\* --- Clean Actions ---
+
+RecordSuccess ==
+    /\ step < MaxSteps
+    /\ count' = 0
+    /\ currentClass' = currentClass
+    /\ tripped' = FALSE
+    /\ totalTrips' = totalTrips
+    /\ classStreak' = TRUE
+    /\ step' = step + 1
+
+RecordFailure(cls) ==
+    /\ step < MaxSteps
+    /\ cls \in ErrorClasses
+    /\ IF cls = currentClass
+       THEN \* same class: increment
+            IF count + 1 >= Threshold
+            THEN \* TRIP
+                 /\ count' = 0
+                 /\ tripped' = TRUE
+                 /\ totalTrips' = totalTrips + 1
+                 /\ currentClass' = currentClass
+                 /\ classStreak' = TRUE
+            ELSE
+                 /\ count' = count + 1
+                 /\ tripped' = FALSE
+                 /\ totalTrips' = totalTrips
+                 /\ currentClass' = currentClass
+                 /\ classStreak' = TRUE  \* still same class
+       ELSE \* different class: reset to 1
+            /\ count' = 1
+            /\ currentClass' = cls
+            /\ tripped' = FALSE
+            /\ totalTrips' = totalTrips
+            /\ classStreak' = TRUE  \* fresh streak of new class
+    /\ step' = step + 1
+
+Next ==
+    \/ RecordSuccess
+    \/ \E cls \in ErrorClasses : RecordFailure(cls)
+
+Spec == Init /\ [][Next]_vars
+
+\* --- Safety Invariants ---
+
+\* S1: count is always bounded
+CountBounded ==
+    count >= 0 /\ count < Threshold
+
+\* S2: trip only with class streak
+TripOnlyWithStreak ==
+    tripped = TRUE => classStreak = TRUE
+
+\* S3: totalTrips monotonic
+TotalTripsMonotonic ==
+    totalTrips >= 0
+
+\* Combined
+SafetyInvariant ==
+    /\ TypeOK
+    /\ CountBounded
+    /\ TripOnlyWithStreak
+    /\ TotalTripsMonotonic
+
+\* --- Buggy model: class change does NOT reset count ---
+
+RecordFailureBuggy(cls) ==
+    /\ step < MaxSteps
+    /\ cls \in ErrorClasses
+    \* BUG: no class-change branch — always increment
+    /\ LET newCount == count + 1 IN
+       LET classChanged == cls # currentClass /\ currentClass # "none" IN
+       IF newCount >= Threshold
+       THEN /\ count' = 0
+            /\ tripped' = TRUE
+            /\ totalTrips' = totalTrips + 1
+            /\ currentClass' = cls
+            /\ classStreak' = IF classChanged THEN FALSE ELSE classStreak
+       ELSE /\ count' = newCount
+            /\ tripped' = FALSE
+            /\ totalTrips' = totalTrips
+            /\ currentClass' = cls
+            /\ classStreak' = IF classChanged THEN FALSE ELSE classStreak
+    /\ step' = step + 1
+
+NextBuggy ==
+    \/ RecordSuccess
+    \/ \E cls \in ErrorClasses : RecordFailureBuggy(cls)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====

--- a/test/dune
+++ b/test/dune
@@ -604,7 +604,8 @@
         test_tool_code_read_containment
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
-        test_anti_rationalization_coverage test_field_validation)
+        test_anti_rationalization_coverage test_field_validation
+        test_circuit_breaker)
  (modules test_admission_queue_coverage
         test_backend_coverage test_tools_coverage test_types_utils_coverage
         test_agent_card_coverage test_misc_coverage test_relay_coverage
@@ -641,7 +642,8 @@
         test_tool_code_read_containment
         test_tool_library_coverage test_tool_shard_coverage
         test_context_compact_oas_coverage test_keeper_masc_bridge
-        test_anti_rationalization_coverage test_field_validation)
+        test_anti_rationalization_coverage test_field_validation
+        test_circuit_breaker)
  (libraries masc_test_deps))
 
 ; ============================================================

--- a/test/test_circuit_breaker.ml
+++ b/test/test_circuit_breaker.ml
@@ -1,0 +1,82 @@
+open Alcotest
+
+module CB = Masc_mcp.Keeper_failure_circuit_breaker
+
+let contains haystack needle =
+  let nl = String.length needle and hl = String.length haystack in
+  if nl > hl then false
+  else
+    let rec scan i =
+      if i + nl > hl then false
+      else if String.sub haystack i nl = needle then true
+      else scan (i + 1)
+    in scan 0
+
+let test_classify_path_not_found () =
+  check bool "path_not_found from prefix" true
+    (CB.classify_error "path_not_found_under_allowed_roots: /foo" = CB.Path_not_found);
+  check bool "path_not_found from NSFD" true
+    (CB.classify_error "No such file or directory" = CB.Path_not_found)
+
+let test_classify_path_not_allowed () =
+  check bool "path_not_allowed" true
+    (CB.classify_error "path_not_in_allowed_paths: /x" = CB.Path_not_allowed)
+
+let test_classify_other () =
+  check bool "other" true
+    (CB.classify_error "random error" = CB.Other)
+
+let test_no_hint_under_threshold () =
+  CB.record_success ~keeper_name:"t1";
+  let r1 = CB.maybe_enrich_error ~keeper_name:"t1" ~error_msg:"path_not_found: /a" in
+  check bool "1st: no hint" true (not (contains r1 "CIRCUIT BREAKER"));
+  let r2 = CB.maybe_enrich_error ~keeper_name:"t1" ~error_msg:"path_not_found: /b" in
+  check bool "2nd: no hint" true (not (contains r2 "CIRCUIT BREAKER"))
+
+let test_hint_at_threshold () =
+  CB.record_success ~keeper_name:"t2";
+  ignore (CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /a");
+  ignore (CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /b");
+  let r3 = CB.maybe_enrich_error ~keeper_name:"t2" ~error_msg:"path_not_found: /c" in
+  check bool "3rd: HAS hint" true (contains r3 "CIRCUIT BREAKER");
+  check bool "mentions playground" true (contains r3 "playground");
+  check bool "mentions ls" true (contains r3 "keeper_shell op=ls")
+
+let test_reset_on_success () =
+  CB.record_success ~keeper_name:"t3";
+  ignore (CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:"path_not_found: /a");
+  ignore (CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:"path_not_found: /b");
+  CB.record_success ~keeper_name:"t3";
+  let r = CB.maybe_enrich_error ~keeper_name:"t3" ~error_msg:"path_not_found: /c" in
+  check bool "after reset: no hint" true (not (contains r "CIRCUIT BREAKER"))
+
+let test_class_change_resets () =
+  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_found: /a");
+  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_found: /b");
+  ignore (CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_in_allowed_paths: /x");
+  let r = CB.maybe_enrich_error ~keeper_name:"t4" ~error_msg:"path_not_in_allowed_paths: /y" in
+  check bool "class switch: no hint at 2nd" true (not (contains r "CIRCUIT BREAKER"))
+
+let test_snapshot () =
+  ignore (CB.maybe_enrich_error ~keeper_name:"t5" ~error_msg:"path_not_found: /a");
+  match CB.snapshot_json () with
+  | `List entries -> check bool "has entries" true (List.length entries > 0)
+  | _ -> Alcotest.fail "expected list"
+
+let () =
+  run "Circuit_breaker" [
+    "classify", [
+      test_case "path_not_found" `Quick test_classify_path_not_found;
+      test_case "path_not_allowed" `Quick test_classify_path_not_allowed;
+      test_case "other" `Quick test_classify_other;
+    ];
+    "threshold", [
+      test_case "no hint under threshold" `Quick test_no_hint_under_threshold;
+      test_case "hint at threshold" `Quick test_hint_at_threshold;
+      test_case "reset on success" `Quick test_reset_on_success;
+      test_case "class change resets" `Quick test_class_change_resets;
+    ];
+    "diagnostics", [
+      test_case "snapshot" `Quick test_snapshot;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Keeper가 같은 error class를 3회 연속 반복하면 에러 응답에 `[CIRCUIT BREAKER]` corrective hint를 자동 주입.

**문제**: 97턴 analyst가 존재하지 않는 `lib/ocaml/slack_client.ml`을 반복 접근 → `path_not_found` 에러 반복 → meta-cognition이 "tool blockage"로 오분류 → room stagnation 75%.

**해결**: tool result에 구체적 교정 안내를 주입하여 LLM이 다음 tool call에서 올바른 행동을 하도록 유도.

### Error classes
| Class | Corrective hint |
|-------|----------------|
| `path_not_found` | ls로 먼저 확인하라, playground root 안내, 환각 경로 금지 |
| `path_not_allowed` | allowed roots 안내, context_status 사용 유도 |
| `cwd_not_directory` | cwd 비우고 기본 playground 사용 |
| `shell_exit_nonzero` | 명령어 문법 확인, 단순 명령 먼저 |
| `other` | 다른 접근 시도 또는 stay_silent |

### Architecture
```
keeper tool call → execute_keeper_tool_call
                     ↓
              apply_circuit_breaker(result)
                     ↓
              is_error? → record_failure → threshold? → enrich message
              is_ok?   → record_success → reset counter
```

## Test plan
- [ ] `dune build` passes
- [ ] keeper가 같은 에러 3회 반복 후 `[CIRCUIT BREAKER]` hint가 에러 메시지에 나타남
- [ ] 성공 시 카운터 리셋 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)