### PR TITLE
fix(keeper): dispatch Manual_reconcile_cleared + fix proactive timer freeze

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -816,8 +816,15 @@ let maybe_recover_from_failing ~(ctx : _ context) ~(meta : keeper_meta) =
           ~resolution:"auto-recoverable partial commit; cursors advanced, re-trigger risk low"
           ~evidence_refs:[]
           ~idempotency_key:None);
+        (* Clear the FSM condition — Turn_succeeded alone does NOT reset
+           manual_reconcile_required (only Manual_reconcile_cleared does).
+           Without this, derive_phase stays Failing and the keeper can
+           never take another turn.  See the one-way trap analysis. *)
+        ignore (Keeper_registry.dispatch_event
+          ~base_path:ctx.config.base_path meta.name
+          Keeper_state_machine.Manual_reconcile_cleared);
         Log.Keeper.info
-          "heartbeat recovery: cleared reconcile blocker for %s (auto-recoverable, re-trigger risk low)"
+          "heartbeat recovery: cleared reconcile blocker + FSM condition for %s (auto-recoverable, re-trigger risk low)"
           meta.name
       end;
       dispatch_keepalive_event ~ctx ~keeper_name:meta.name

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1656,17 +1656,17 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             ~config
             ~keeper_name:meta.name
             lifecycle;
-          let scope_only_reactive =
-            observation.pending_scope_messages <> []
-            && observation.pending_mentions = []
-            && observation.pending_board_events = []
-          in
-          (* 6. Observe result and update metrics *)
+          (* 6. Observe result and update metrics.
+             Always update proactive_rt regardless of turn type.
+             Previously, scope-only reactive turns (pending_scope but no
+             mentions/board) skipped the timestamp update, freezing the
+             proactive cooldown timer so the second autonomous turn never
+             fired.  See Bug #3 in the root-cause analysis. *)
           let updated_meta =
             update_metrics_from_result lifecycle.updated_meta ~latency_ms
               ~observation
               ~social_state
-              ~update_proactive_rt:(not scope_only_reactive)
+              ~update_proactive_rt:true
               result
           in
           (try


### PR DESCRIPTION
## Summary

Two root-cause bugs that combined to make keepers stop after 1 heartbeat:

**Bug 1 — FSM one-way trap** (`keeper_keepalive.ml:812-822`):
- `maybe_recover_from_failing` cleared the data record but never dispatched `Manual_reconcile_cleared` to the FSM
- `Turn_succeeded` alone does NOT reset `manual_reconcile_required` (test-verified)
- Result: keeper enters `Failing` phase → can't take turns → can't exit → permanent stall
- Fix: dispatch `Manual_reconcile_cleared` after clearing the record

**Bug 3 — Proactive timer freeze** (`keeper_unified_turn.ml:1659-1669`):
- `scope_only_reactive` turns skipped `proactive_rt.last_ts` update
- Cooldown timer froze → second autonomous turn never scheduled
- Fix: always update `proactive_rt` regardless of turn type

## Evidence

- 12 parallel agent analysis identified 3 root causes
- FSM trap confirmed by existing test: `test_apply_turn_succeeded_does_not_clear_manual_reconcile`
- Proactive freeze confirmed by tracing `update_proactive_rt` call path

## Test plan

- [x] `dune build` passes
- [x] FSM tests: 108 pass
- [x] Unified turn tests: 164 pass
- [x] Heartbeat integration: 19 pass
- [x] Keeper exec status: 18 pass
- [ ] Server restart verification: keepers should maintain proactive turns beyond first heartbeat
- [ ] Reconcile recovery: keeper should exit Failing phase after auto-clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)