### PR TITLE
chore(keeper): promote all keepers to delivery preset

### DIFF
--- a/config/keepers/cheolsu.toml
+++ b/config/keepers/cheolsu.toml
@@ -48,7 +48,7 @@ proactive_enabled = true
 execution_scope = "workspace"
 allowed_paths = ["workspace/yousleepwhen/masc-mcp"]
 
-tool_preset = "coding"
+tool_preset = "delivery"
 
 cascade_name = "keeper_unified"
 

--- a/config/keepers/janitor.toml
+++ b/config/keepers/janitor.toml
@@ -49,7 +49,7 @@ mention_targets = ["janitor", "garbage-keeper", "coder", "masc-improver"]
 proactive_enabled = true
 execution_scope = "workspace"
 
-tool_preset = "social"
+tool_preset = "delivery"
 tool_also_allow = [
   "keeper_board_delete",
   "keeper_board_cleanup",

--- a/config/keepers/sangsu.toml
+++ b/config/keepers/sangsu.toml
@@ -62,7 +62,7 @@ proactive_enabled = true
 # .masc/keepers/<name>.json (live runtime meta). See keeper_types_profile.ml.
 execution_scope = "workspace"
 
-tool_preset = "social"
+tool_preset = "delivery"
 also_allow = ["keeper_voice_speak", "keeper_voice_listen"]
 
 cascade_name = "keeper_unified"


### PR DESCRIPTION
## Summary
- All 4 keepers now have `tool_preset = "delivery"` (was: sangsu=social, cheolsu=coding, janitor=social)
- delivery = coding + autoresearch + coordination masc_groups
- `also_allow` entries (voice for sangsu, board cleanup for janitor) are preserved

## Test plan
- [x] `test_keeper_toml_config_validation` passes
- [ ] CI Build and Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)