### PR TITLE
fix(keeper): clear last_blocker on successful turn

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -873,7 +873,13 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
          then now_iso ()
          else rt.last_autonomous_action_at);
       last_speech_act = Social.speech_act_to_string social_state.speech_act;
-      last_blocker = Option.value ~default:"" social_state.blocker;
+      (* A successful turn means the keeper is not blocked.
+         Clear unconditionally so stale error strings from previous
+         failures do not persist in the runtime JSON and mislead the
+         dashboard into showing BLOCKED status.  The social model's
+         blocker field is a protocol-level signal; runtime last_blocker
+         tracks whether the keeper can make progress. *)
+      last_blocker = "";
       last_need = Option.value ~default:"" social_state.need;
     };
   }


### PR DESCRIPTION
## Summary

- Unconditionally set `last_blocker = ""` in `update_metrics_from_result` (success path) instead of deriving it from `social_state.blocker`
- Prevents stale error strings from prior failures (e.g. "cascade all models failed") from persisting in the runtime JSON across successful turns
- The dashboard reads `last_blocker` to derive BLOCKED status, so stale values caused false positives for active keepers with 100+ successful turns

## Root cause

`update_metrics_from_failure` sets `last_blocker` to the error reason string. On the next successful turn, `update_metrics_from_result` derived `last_blocker` from `social_state.blocker` via `Option.value ~default:""`. In most cases this correctly cleared to `""`, but the field was not unconditionally reset — a successful OAS turn means the keeper is not blocked, period.

## Test plan

- [x] `dune build` passes
- [x] `dune exec ./test/test_keeper_unified.exe` — 164 tests pass
- [x] Existing test `"no blocker tracked"` confirms `last_blocker = ""` after success


🤖 Generated with [Claude Code](https://claude.com/claude-code)