### PR TITLE
fix(keeper): filter phantom keepers from autoboot

### DIFF
--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -14,7 +14,27 @@ let declarative_keeper_names () =
   |> List.map fst
 
 let bootable_keeper_names config =
-  dedupe_keep_order (keeper_names config @ declarative_keeper_names ())
+  let json_names = keeper_names config in
+  let toml_names = declarative_keeper_names () in
+  let toml_set =
+    let tbl = Hashtbl.create (List.length toml_names) in
+    List.iter (fun n -> Hashtbl.replace tbl n ()) toml_names;
+    tbl
+  in
+  (* Filter out "phantom" keepers: discovered only from JSON (no TOML config)
+     AND total_turns = 0 (never actually ran).  These are leftover artifacts
+     from old test runs or experiments that waste autoboot fiber slots. *)
+  let filtered_json =
+    List.filter
+      (fun name ->
+        if Hashtbl.mem toml_set name then true
+        else
+          match read_meta config name with
+          | Ok (Some meta) -> meta.runtime.usage.total_turns > 0
+          | Ok None | Error _ -> false)
+      json_names
+  in
+  dedupe_keep_order (filtered_json @ toml_names)
 
 (** Apply a TOML profile default to a runtime meta value.
     [Some v] from TOML overrides; [None] keeps the current runtime value. *)

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -110,6 +110,51 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check int "status handler count filters sidecars" 2
         Yojson.Safe.Util.(json |> member "count" |> to_int))
 
+(** bootable_keeper_names excludes JSON-only keepers with total_turns=0
+    (phantom keepers from old test runs) but keeps JSON-only keepers
+    that have actually run (total_turns > 0). *)
+let test_bootable_keeper_names_filters_phantom_keepers () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      (* Create a phantom keeper: JSON only, total_turns=0 *)
+      write_keeper_meta_exn config ~name:"phantom-test" ~trace_id:"trace-phantom";
+      (* Create a real keeper: JSON only, total_turns > 0 *)
+      write_keeper_meta_exn config ~name:"real-test" ~trace_id:"trace-real";
+      (match Keeper_types.read_meta config "real-test" with
+       | Ok (Some meta) ->
+         let updated =
+           Keeper_types.map_usage
+             (fun u -> { u with total_turns = 5 })
+             meta
+         in
+         (match Keeper_types.write_meta ~force:true config updated with
+          | Ok () -> ()
+          | Error e -> fail ("write_meta for real-test failed: " ^ e))
+       | Ok None -> fail "real-test meta not found"
+       | Error e -> fail ("read_meta for real-test failed: " ^ e));
+      (* keeper_names should list both (it scans all JSON files in keepers dir) *)
+      let all_names = Keeper_types.keeper_names config in
+      check bool "keeper_names includes phantom-test" true
+        (List.mem "phantom-test" all_names);
+      check bool "keeper_names includes real-test" true
+        (List.mem "real-test" all_names);
+      (* bootable_keeper_names should exclude the phantom but keep real-test *)
+      let bootable = Keeper_runtime.bootable_keeper_names config in
+      check bool "bootable excludes phantom-test (total_turns=0, no TOML)" false
+        (List.mem "phantom-test" bootable);
+      check bool "bootable includes real-test (total_turns>0)" true
+        (List.mem "real-test" bootable))
+
 let () =
   run "keeper_meta_listing"
     [
@@ -117,5 +162,7 @@ let () =
         [
           test_case "keeper_names and keeper_list ignore sidecar json" `Quick
             test_keeper_listing_ignores_sidecar_json_files;
+          test_case "bootable_keeper_names filters phantom keepers" `Quick
+            test_bootable_keeper_names_filters_phantom_keepers;
         ] );
     ]


### PR DESCRIPTION
## Summary
- Deleted 10 phantom keeper JSON files from `~/.masc/keepers/` that had `total_turns=0` (artifacts from old test runs): alpha-scope, audit-keeper-decision, audit-keeper, beta-scope, config-provenance, probe-keeper, remote-scope, resume-keeper, self-probe, shared-scope.
- Added a guard in `bootable_keeper_names` that filters out keepers discovered only from JSON (no TOML config) when `total_turns=0`, preventing future phantom keepers from being auto-booted and wasting fiber slots.
- TOML-configured keepers (cheolsu, janitor, masc-improver, sangsu) and JSON-only keepers that have actually run (`total_turns > 0`) are unaffected.

## Test plan
- [x] New test `bootable_keeper_names filters phantom keepers` verifies phantom (JSON-only, 0 turns) is excluded while real (JSON-only, >0 turns) is included
- [x] `test_keeper_toml.exe` passes (51 tests)
- [x] `test_keeper_runtime_config_ssot.exe` passes (11 tests)
- [x] `dune build` succeeds