### PR TITLE
feat(specs): TLA+ dispatch coverage — data-FSM mismatch bug model

### DIFF
--- a/specs/bug-models/DispatchCoverage-buggy.cfg
+++ b/specs/bug-models/DispatchCoverage-buggy.cfg
@@ -1,0 +1,9 @@
+\* Buggy model: one clearing action omits the FSM event dispatch.
+\* Expected: DataFsmConsistent VIOLATED (and NeverStuckFailing VIOLATED).
+SPECIFICATION SpecBuggy
+CONSTANT Blockers = {reconcile, turn, compact, handoff, guardrail}
+INVARIANT TypeOK
+INVARIANT DataFsmConsistent
+INVARIANT PhaseConsistent
+INVARIANT NeverStuckFailing
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/DispatchCoverage.cfg
+++ b/specs/bug-models/DispatchCoverage.cfg
@@ -1,0 +1,9 @@
+\* Clean model: all clearing actions dispatch both data and FSM updates.
+\* Expected: no error.
+SPECIFICATION Spec
+CONSTANT Blockers = {reconcile, turn, compact, handoff, guardrail}
+INVARIANT TypeOK
+INVARIANT DataFsmConsistent
+INVARIANT PhaseConsistent
+INVARIANT NeverStuckFailing
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/DispatchCoverage.tla
+++ b/specs/bug-models/DispatchCoverage.tla
@@ -1,0 +1,137 @@
+---- MODULE DispatchCoverage ----
+\* Bug Model: FSM Event Dispatch Coverage for Data-Layer Clearing Actions.
+\*
+\* Bug class: "Code clears a blocking condition at the data layer but
+\* forgets to dispatch the corresponding FSM event."
+\*
+\* Real-world instance (Bug #1, #6801): maybe_recover_from_failing() in
+\* keeper_keepalive.ml:812-824 called Keeper_manual_reconcile.clear (data)
+\* but did NOT dispatch Manual_reconcile_cleared to the FSM. Result:
+\* derive_phase() stayed in Failing because conditions.manual_reconcile_required
+\* was never set to FALSE, even though the blocking file was deleted.
+\*
+\* This spec models 5 blocking conditions from the keeper FSM
+\* (keeper_state_machine.ml). Each has a "data layer" boolean and an
+\* "FSM condition" boolean. A clearing action MUST set both to FALSE
+\* atomically (within 1 step). The buggy variant omits the FSM dispatch.
+\*
+\* ── Mapped clearing actions (from OCaml code) ──
+\*
+\*  # | Data clear             | FSM event                  | OCaml location
+\*  --+------------------------+----------------------------+--------------------------------
+\*  1 | manual_reconcile file  | Manual_reconcile_cleared   | keeper_keepalive.ml:813-825
+\*  2 | turn_failures counter  | Turn_succeeded             | keeper_keepalive.ml:804,1447
+\*  3 | compaction_active flag  | Compaction_completed       | keeper_exec_context.ml:150
+\*  4 | handoff_active flag     | Handoff_completed          | keeper_exec_context.ml:166
+\*  5 | guardrail measurement  | Context_measured(stop=F)   | keeper_keepalive.ml:614-627
+\*
+\* ── Abstraction ──
+\* Each blocking condition is modeled as a pair: (data_blocked, fsm_blocked).
+\* Setting a blocker sets both to TRUE. A correct clear sets both to FALSE.
+\* A buggy clear sets data_blocked=FALSE but leaves fsm_blocked=TRUE.
+\* derive_phase uses fsm_blocked, so the keeper stays stuck.
+
+EXTENDS Naturals
+
+CONSTANTS
+    Blockers  \* Set of blocker names, e.g. {"reconcile", "turn", "compact", "handoff", "guardrail"}
+
+VARIABLES
+    data_blocked,   \* [Blockers -> BOOLEAN] : data-layer state
+    fsm_blocked,    \* [Blockers -> BOOLEAN] : FSM conditions record
+    phase           \* "running" | "failing" : simplified derive_phase output
+
+vars == <<data_blocked, fsm_blocked, phase>>
+
+\* ── Type invariant ──
+
+TypeOK ==
+    /\ data_blocked \in [Blockers -> BOOLEAN]
+    /\ fsm_blocked  \in [Blockers -> BOOLEAN]
+    /\ phase \in {"running", "failing"}
+
+\* ── Derived phase (mirrors derive_phase in keeper_state_machine.ml) ──
+\* If ANY fsm_blocked condition is TRUE, phase is "failing".
+\* Otherwise phase is "running".
+
+DerivePhase(fsm) ==
+    IF \E b \in Blockers : fsm[b] = TRUE
+    THEN "failing"
+    ELSE "running"
+
+\* ── Init ──
+
+Init ==
+    /\ data_blocked = [b \in Blockers |-> FALSE]
+    /\ fsm_blocked  = [b \in Blockers |-> FALSE]
+    /\ phase = "running"
+
+\* ── Actions ──
+
+\* Set a blocker: both data and FSM layers agree.
+SetBlocker(b) ==
+    /\ data_blocked[b] = FALSE
+    /\ data_blocked' = [data_blocked EXCEPT ![b] = TRUE]
+    /\ fsm_blocked'  = [fsm_blocked  EXCEPT ![b] = TRUE]
+    /\ phase' = DerivePhase(fsm_blocked')
+
+\* Correct clear: clears BOTH data and FSM in one step.
+CorrectClear(b) ==
+    /\ data_blocked[b] = TRUE
+    /\ data_blocked' = [data_blocked EXCEPT ![b] = FALSE]
+    /\ fsm_blocked'  = [fsm_blocked  EXCEPT ![b] = FALSE]
+    /\ phase' = DerivePhase(fsm_blocked')
+
+\* ── Clean Next (all clears are correct) ──
+
+Next ==
+    \E b \in Blockers :
+        \/ SetBlocker(b)
+        \/ CorrectClear(b)
+
+Spec == Init /\ [][Next]_vars
+
+\* ── Safety Invariants ──
+
+\* CORE INVARIANT: If data says "not blocked" then FSM must also say
+\* "not blocked". This is the dispatch coverage contract.
+\* Violation means: data was cleared but FSM event was not dispatched.
+
+DataFsmConsistent ==
+    \A b \in Blockers :
+        data_blocked[b] = FALSE => fsm_blocked[b] = FALSE
+
+\* DERIVED INVARIANT: Phase must agree with FSM conditions.
+\* (This is a consistency check on DerivePhase.)
+
+PhaseConsistent ==
+    phase = DerivePhase(fsm_blocked)
+
+\* STUCK DETECTION: A keeper is "stuck in Failing" if phase="failing"
+\* but ALL data blockers are cleared. This is the observable symptom
+\* of the bug class.
+
+NeverStuckFailing ==
+    (phase = "failing") =>
+        (\E b \in Blockers : data_blocked[b] = TRUE)
+
+\* ── Bug Model: one blocker omits FSM dispatch ──
+\* The buggy clear sets data_blocked=FALSE but does NOT touch fsm_blocked.
+\* This models the exact bug from keeper_keepalive.ml:812 where
+\* Keeper_manual_reconcile.clear was called without Manual_reconcile_cleared.
+
+BuggyClear(b) ==
+    /\ data_blocked[b] = TRUE
+    /\ data_blocked' = [data_blocked EXCEPT ![b] = FALSE]
+    /\ UNCHANGED fsm_blocked   \* BUG: forgot to dispatch FSM event
+    /\ phase' = DerivePhase(fsm_blocked')
+
+NextBuggy ==
+    \E b \in Blockers :
+        \/ SetBlocker(b)
+        \/ CorrectClear(b)
+        \/ BuggyClear(b)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====


### PR DESCRIPTION
## Summary

- Adds TLA+ bug model that verifies FSM event dispatch coverage for all data-layer clearing actions
- Models the bug class from #6801: code clears a blocking condition (file delete, counter reset) but omits the FSM event dispatch, leaving `derive_phase` stuck in `Failing`
- Maps 5 blocking conditions: `manual_reconcile`, `turn_failures`, `compaction_active`, `handoff_active`, `guardrail_triggered`

## Dispatch Coverage Table

| # | Clearing Action (code) | Data Layer Change | Required FSM Event | File:Line |
|---|------------------------|-------------------|--------------------|-----------|
| 1 | `Keeper_manual_reconcile.clear` | Deletes `.manual_reconcile.json` | `Manual_reconcile_cleared` | `keeper_keepalive.ml:813-825` |
| 2 | `Keeper_registry.reset_turn_failures` | Sets counter to 0 | `Turn_succeeded` / `Heartbeat_ok` | `keeper_keepalive.ml:804`, `keeper_unified_turn.ml:1761-1772` |
| 3 | Compaction lifecycle dispatch | Resets `compaction_active` | `Compaction_completed` | `keeper_exec_context.ml:150-155` |
| 4 | Handoff lifecycle dispatch | Resets `handoff_active` | `Handoff_completed` | `keeper_exec_context.ml:166-173` |
| 5 | `Context_measured(guardrail_stop=false)` | Clears measurement | `Context_measured{stop=F}` | `keeper_keepalive.ml:614-627` |
| 6 | Post-turn reconcile clear | Clears reconcile after OK turn | `Manual_reconcile_cleared` | `keeper_keepalive.ml:1092-1094` |
| 7 | `reset_turn_failures` in unified turn | Sets failures=0 on Completed/Budget/Mutation | (dispatched by keepalive loop) | `keeper_unified_turn.ml:1761-1772` |

## TLC Results

| Config | States | Distinct | Result |
|--------|--------|----------|--------|
| Clean (`DispatchCoverage.cfg`) | 161 | 32 | No error |
| Buggy (`DispatchCoverage-buggy.cfg`) | 58 | 42 | `DataFsmConsistent` VIOLATED in 3 steps |

Buggy trace: `Init -> SetBlocker(reconcile) -> BuggyClear(reconcile)` — data says cleared, FSM still blocked, keeper stuck in Failing.

## Invariants

- `DataFsmConsistent`: `data_blocked[b] = FALSE => fsm_blocked[b] = FALSE` (core dispatch coverage contract)
- `PhaseConsistent`: `phase = DerivePhase(fsm_blocked)` (sanity check)
- `NeverStuckFailing`: `phase = "failing" => exists blocker with data_blocked = TRUE` (observable symptom detection)

## Test plan

- [x] TLC clean spec: no error (32 distinct states explored)
- [x] TLC buggy spec: invariant violated in 3 steps (reproduces Bug #1 pattern)
- [x] Both configs checked with `CHECK_DEADLOCK FALSE`

Generated with [Claude Code](https://claude.com/claude-code)