### PR TITLE
[codex] Scope keeper autoboot to configured keepers

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -601,6 +601,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("next_model_hint", Json_util.string_opt_to_json next_model_hint);
               ("paused", `Bool m.paused);
               ("keepalive_running", `Bool keepalive_running);
+              ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("auto_handoff", `Bool m.auto_handoff);
               ("handoff_threshold", `Float m.handoff_threshold);
               ("agent", agent);
@@ -635,6 +636,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("compaction_ratio_gate", `Float compact_ratio_gate);
               ("compaction_message_gate", `Int compact_message_gate);
               ("compaction_token_gate", `Int compact_token_gate);
+              ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_idle_sec", `Int m.proactive.idle_sec);
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -8,33 +8,13 @@ type boot_meta_resolution = {
   materialized : bool;
 }
 
-let declarative_keeper_names () =
-  Config_dir_resolver.log_warnings ~context:"KeeperRuntime" ();
-  Keeper_types_profile.discover_keepers_toml (Config_dir_resolver.keepers_dir ())
-  |> List.map fst
-
 let bootable_keeper_names config =
-  let json_names = keeper_names config in
-  let toml_names = declarative_keeper_names () in
-  let toml_set =
-    let tbl = Hashtbl.create (List.length toml_names) in
-    List.iter (fun n -> Hashtbl.replace tbl n ()) toml_names;
-    tbl
-  in
-  (* Filter out "phantom" keepers: discovered only from JSON (no TOML config)
-     AND total_turns = 0 (never actually ran).  These are leftover artifacts
-     from old test runs or experiments that waste autoboot fiber slots. *)
-  let filtered_json =
-    List.filter
-      (fun name ->
-        if Hashtbl.mem toml_set name then true
-        else
-          match read_meta config name with
-          | Ok (Some meta) -> meta.runtime.usage.total_turns > 0
-          | Ok None | Error _ -> false)
-      json_names
-  in
-  dedupe_keep_order (filtered_json @ toml_names)
+  configured_keeper_names config
+  |> List.filter (fun name ->
+         match read_meta_file_path (keeper_meta_path config name) with
+         | Ok (Some meta) -> not meta.paused && meta.autoboot_enabled
+         | Ok None -> true
+         | Error _ -> true)
 
 (** Apply a TOML profile default to a runtime meta value.
     [Some v] from TOML overrides; [None] keeps the current runtime value. *)

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -91,6 +91,10 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
         ]);
+        ("autoboot_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If false, persist the keeper but skip auto-start on future server boots.");
+        ]);
         ("proactive_enabled", `Assoc [("type", `String "boolean")]);
         ("auto_handoff", `Assoc [("type", `String "boolean")]);
         ("handoff_threshold", `Assoc [("type", `String "number")]);
@@ -176,6 +180,10 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Exact direct-mention tokens that can wake the keeper in room traffic (for example ['sangsu']).");
+        ]);
+        ("autoboot_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If false, persist the keeper but skip auto-start on future server boots.");
         ]);
         ("max_context_override", `Assoc [
           ("type", `String "integer");

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -190,6 +190,7 @@ let handle_keeper_list ctx args : tool_result =
               ("compaction_ratio_gate", `Float compact_ratio_gate);
               ("compaction_message_gate", `Int compact_message_gate);
               ("compaction_token_gate", `Int compact_token_gate);
+              ("autoboot_enabled", `Bool m.autoboot_enabled);
               ("proactive_enabled", `Bool m.proactive.enabled);
               ("proactive_idle_sec", `Int m.proactive.idle_sec);
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -16,6 +16,7 @@ type parsed_args = {
   long_goal_opt : string option;
   policy_voice_enabled_opt : bool option;
   allowed_paths_opt : string list option;
+  autoboot_enabled_opt : bool option;
   execution_scope_opt : string option;
   voice_enabled_opt : bool option;
   voice_channel_opt : string option;
@@ -175,6 +176,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       let raw = get_string_list args "allowed_paths" in
       if raw = [] then None else Some raw
     in
+    let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
     let execution_scope_opt = get_string_opt args "execution_scope" in
     let voice_enabled_opt = get_bool_opt args "voice_enabled" in
     let voice_channel_opt = get_string_opt args "voice_channel" in
@@ -257,6 +259,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       long_goal_opt;
       policy_voice_enabled_opt;
       allowed_paths_opt;
+      autoboot_enabled_opt;
       execution_scope_opt;
       voice_enabled_opt;
       voice_channel_opt;

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -25,6 +25,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         p.profile_defaults.goal |> Option.value ~default:""
         |> normalize_goal_horizon_text
   in
+  let autoboot_enabled = Option.value ~default:true p.autoboot_enabled_opt in
   let policy_voice_enabled =
     first_some
       p.policy_voice_enabled_opt
@@ -282,6 +283,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         continuity_summary = "";
         active_goal_ids = [];
         paused = false;
+        autoboot_enabled;
         current_task_id = None;
         work_discovery_enabled = p.profile_defaults.work_discovery_enabled;
         work_discovery_sources = p.profile_defaults.work_discovery_sources;

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -45,6 +45,9 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
   let allowed_paths =
     Option.value ~default:old.allowed_paths p.allowed_paths_opt
   in
+  let autoboot_enabled =
+    Option.value ~default:old.autoboot_enabled p.autoboot_enabled_opt
+  in
   let mention_targets =
     resolve_mention_targets
       ~mention_targets_in:p.mention_targets_in
@@ -147,6 +150,7 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
       Option.value ~default:old.execution_scope p.execution_scope_opt;
     tool_access;
     tool_denylist;
+    autoboot_enabled;
     voice_enabled =
       Option.value ~default:old.voice_enabled p.voice_enabled_opt;
     voice_channel =

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -155,6 +155,7 @@ type keeper_meta =
     continuity_summary : string
   ; active_goal_ids : string list
   ; paused : bool
+  ; autoboot_enabled : bool
   ; current_task_id : Keeper_id.Task_id.t option
     (** Currently claimed task ID for cost attribution.
       Set when keeper claims a task; cleared on masc_done.
@@ -726,6 +727,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "last_blocker", `String rt.last_blocker
     ; "last_need", `String rt.last_need
     ; "paused", `Bool m.paused
+    ; "autoboot_enabled", `Bool m.autoboot_enabled
     ; "current_task_id", Json_util.string_opt_to_json (Option.map Keeper_id.Task_id.to_string m.current_task_id)
     ; "max_context_override", Json_util.int_opt_to_json m.max_context_override
     ; "work_discovery_enabled", Json_util.bool_opt_to_json m.work_discovery_enabled
@@ -785,6 +787,7 @@ type parsed_keeper_state =
   ; ps_continuity_summary : string
   ; ps_active_goal_ids : string list
   ; ps_paused : bool
+  ; ps_autoboot_enabled : bool
   ; ps_current_task_id : Keeper_id.Task_id.t option
   ; ps_max_context_override : int option
   ; ps_runtime : agent_runtime_state
@@ -1100,6 +1103,9 @@ let parse_keeper_state
   let last_blocker = Safe_ops.json_string ~default:"" "last_blocker" json in
   let last_need = Safe_ops.json_string ~default:"" "last_need" json in
   let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
+  let ps_autoboot_enabled =
+    Safe_ops.json_bool ~default:true "autoboot_enabled" json
+  in
   let ps_current_task_id = match Safe_ops.json_string_opt "current_task_id" json with None -> None | Some s -> (match Keeper_id.Task_id.of_string s with Ok tid -> Some tid | Error _ -> None) in
   let ps_max_context_override = Safe_ops.json_int_opt "max_context_override" json in
   { ps_created_at_raw
@@ -1107,6 +1113,7 @@ let parse_keeper_state
   ; ps_continuity_summary
   ; ps_active_goal_ids
   ; ps_paused
+  ; ps_autoboot_enabled
   ; ps_current_task_id
   ; ps_max_context_override
   ; ps_runtime =
@@ -1203,6 +1210,7 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
              ; continuity_summary = state.ps_continuity_summary
              ; active_goal_ids = state.ps_active_goal_ids
              ; paused = state.ps_paused
+             ; autoboot_enabled = state.ps_autoboot_enabled
              ; current_task_id = state.ps_current_task_id
              ; max_context_override = state.ps_max_context_override
              ; work_discovery_enabled = Safe_ops.json_bool_opt "work_discovery_enabled" json
@@ -1311,6 +1319,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "last_blocker"
   ; "last_need"
   ; "paused"
+  ; "autoboot_enabled"
   ; "current_task_id"
   ; "max_context_override"
   ; "work_discovery_enabled"
@@ -1396,11 +1405,11 @@ let is_keeper_meta_file f =
               String.length stem > String.length suf
               && String.ends_with ~suffix:suf stem)
             keeper_sidecar_stem_suffixes)
-let keeper_names config =
+let persisted_keeper_names config =
   let dir = keeper_dir config in
   match Safe_ops.list_dir_safe dir with
   | Error e ->
-    Log.Keeper.warn "keeper_names: failed to list directory %s: %s" dir e;
+    Log.Keeper.warn "persisted_keeper_names: failed to list directory %s: %s" dir e;
     []
   | Ok files ->
     files
@@ -1410,11 +1419,23 @@ let keeper_names config =
     |> List.sort String.compare
 ;;
 
+let configured_keeper_names _config =
+  Config_dir_resolver.log_warnings ~context:"KeeperTypes" ();
+  Keeper_types_profile.discover_keepers_toml (Config_dir_resolver.keepers_dir ())
+  |> List.map fst
+  |> dedupe_keep_order
+;;
+
+let keeper_names config =
+  persisted_keeper_names config
+;;
+
 let keepalive_keeper_names config =
-  keeper_names config
+  configured_keeper_names config
   |> List.filter_map (fun name ->
     match read_meta_file_path (keeper_meta_path config name) with
-    | Ok (Some meta) when not meta.paused -> Some meta.name
+    | Ok (Some meta) when not meta.paused && meta.autoboot_enabled -> Some meta.name
+    | Ok None -> Some name
     | _ -> None)
 ;;
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -155,6 +155,7 @@ type keeper_meta = {
   continuity_summary: string;
   active_goal_ids: string list;
   paused: bool;
+  autoboot_enabled: bool;
   current_task_id: Keeper_id.Task_id.t option;
   (** Currently claimed task ID for cost attribution. *)
   work_discovery_enabled : bool option;
@@ -223,6 +224,8 @@ val meta_of_json : Yojson.Safe.t -> (keeper_meta, string) result
 (** {1 Meta file I/O} *)
 
 val read_meta_file_path : string -> (keeper_meta option, string) result
+val persisted_keeper_names : Room.config -> string list
+val configured_keeper_names : Room.config -> string list
 val keeper_names : Room.config -> string list
 val keepalive_keeper_names : Room.config -> string list
 val persistent_agent_names : Room.config -> string list

--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -133,12 +133,9 @@ let resolve_masc_base_path path =
     when running_under_test_executable ()
          && not
               (Env_config_core.get_bool ~default:false
-                 "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
-         && Option.equal String.equal
-              (Sys.getenv_opt "MASC_TEST_SYNCED_BASE_PATH")
-              (Some explicit) ->
+                 "MASC_TEST_ALLOW_INHERITED_BASE_PATH") ->
       Log.Room.info
-        "Ignoring auto-synced MASC_BASE_PATH=%s for requested test path %s"
+        "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
         explicit path;
       resolve_requested_base_path path
   | Some explicit ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -184,6 +184,7 @@ let keeper_list_row_json ~runtime_class config name =
             ("agent_name", `String meta.agent_name);
             ("status", `String status);
             ("keepalive_running", `Bool keepalive_running);
+            ("autoboot_enabled", `Bool meta.autoboot_enabled);
             ("proactive_enabled", `Bool meta.proactive.enabled);
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -383,6 +383,7 @@ let create_keeper env sw config name =
             ("name", `String name);
             ("goal", `String "Dashboard keeper fixture");
             ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
           ])
   with
   | Some (true, _) -> ()

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -122,6 +122,7 @@ let create_keeper env sw config name =
             ("name", `String name);
             ("goal", `String "Dashboard keeper fixture");
             ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
           ])
   with
   | Some (true, _) -> ()

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -28,7 +28,21 @@ let write_json path json =
   Out_channel.with_open_bin path (fun oc ->
       output_string oc (Yojson.Safe.pretty_to_string json))
 
-let write_keeper_meta_exn config ~name ~trace_id =
+let write_keeper_toml_exn config ~name =
+  let keepers_dir =
+    Filename.concat (Room.masc_root_dir config) "config/keepers"
+  in
+  Fs_compat.mkdir_p keepers_dir;
+  Fs_compat.save_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|
+[keeper]
+goal = "test keeper"
+room_scope = "current"
+proactive_enabled = false
+|}
+
+let write_keeper_meta_exn ?(autoboot_enabled = true) config ~name ~trace_id =
   let json =
     `Assoc
       [
@@ -36,6 +50,7 @@ let write_keeper_meta_exn config ~name ~trace_id =
         ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
         ("trace_id", `String trace_id);
         ("goal", `String "test keeper");
+        ("autoboot_enabled", `Bool autoboot_enabled);
       ]
   in
   let meta =
@@ -74,6 +89,9 @@ let test_keeper_listing_ignores_sidecar_json_files () =
     (fun () ->
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn config ~name:"sangsu";
+      write_keeper_toml_exn config ~name:"dot.name";
+      Config_dir_resolver.reset ();
       write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu";
       write_keeper_meta_exn config ~name:"dot.name" ~trace_id:"trace-dot-name";
       ignore
@@ -110,10 +128,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check int "status handler count filters sidecars" 2
         Yojson.Safe.Util.(json |> member "count" |> to_int))
 
-(** bootable_keeper_names excludes JSON-only keepers with total_turns=0
-    (phantom keepers from old test runs) but keeps JSON-only keepers
-    that have actually run (total_turns > 0). *)
-let test_bootable_keeper_names_filters_phantom_keepers () =
+let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun _sw ->
@@ -126,35 +141,13 @@ let test_bootable_keeper_names_filters_phantom_keepers () =
     (fun () ->
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
-      (* Create a phantom keeper: JSON only, total_turns=0 *)
-      write_keeper_meta_exn config ~name:"phantom-test" ~trace_id:"trace-phantom";
-      (* Create a real keeper: JSON only, total_turns > 0 *)
-      write_keeper_meta_exn config ~name:"real-test" ~trace_id:"trace-real";
-      (match Keeper_types.read_meta config "real-test" with
-       | Ok (Some meta) ->
-         let updated =
-           Keeper_types.map_usage
-             (fun u -> { u with total_turns = 5 })
-             meta
-         in
-         (match Keeper_types.write_meta ~force:true config updated with
-          | Ok () -> ()
-          | Error e -> fail ("write_meta for real-test failed: " ^ e))
-       | Ok None -> fail "real-test meta not found"
-       | Error e -> fail ("read_meta for real-test failed: " ^ e));
-      (* keeper_names should list both (it scans all JSON files in keepers dir) *)
-      let all_names = Keeper_types.keeper_names config in
-      check bool "keeper_names includes phantom-test" true
-        (List.mem "phantom-test" all_names);
-      check bool "keeper_names includes real-test" true
-        (List.mem "real-test" all_names);
-      (* bootable_keeper_names should exclude the phantom but keep real-test *)
-      let bootable = Keeper_runtime.bootable_keeper_names config in
-      check bool "bootable excludes phantom-test (total_turns=0, no TOML)" false
-        (List.mem "phantom-test" bootable);
-      check bool "bootable includes real-test (total_turns>0)" true
-        (List.mem "real-test" bootable))
-
+      write_keeper_toml_exn config ~name:"sangsu";
+      Config_dir_resolver.reset ();
+      write_keeper_meta_exn
+        ~autoboot_enabled:false config ~name:"sangsu" ~trace_id:"trace-sangsu";
+      let names = Keeper_runtime.bootable_keeper_names config in
+      check (list string) "autoboot disabled meta excluded from bootable list"
+        [] names)
 let () =
   run "keeper_meta_listing"
     [
@@ -162,7 +155,7 @@ let () =
         [
           test_case "keeper_names and keeper_list ignore sidecar json" `Quick
             test_keeper_listing_ignores_sidecar_json_files;
-          test_case "bootable_keeper_names filters phantom keepers" `Quick
-            test_bootable_keeper_names_filters_phantom_keepers;
+          test_case "bootable list skips autoboot-disabled meta" `Quick
+            test_bootable_keeper_names_skip_autoboot_disabled_meta;
         ] );
     ]

--- a/test/test_keeper_reconcile_tool.ml
+++ b/test/test_keeper_reconcile_tool.ml
@@ -71,6 +71,7 @@ let test_keeper_reconcile_inspect_and_clear () =
                 ("name", `String keeper_name);
                 ("goal", `String "Exercise keeper reconcile tool");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       check bool "keeper up ok" true ok;
@@ -195,6 +196,7 @@ let test_keeper_reconcile_clear_without_record_clears_runtime_blocker () =
                 ("name", `String keeper_name);
                 ("goal", `String "Exercise no-record reconcile clear");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       check bool "keeper up ok" true ok;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -107,6 +107,7 @@ let test_keeper_status_exposes_summary_and_recoverable () =
                 ("name", `String keeper_name);
                 ("goal", `String "Probe keeper runtime");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -189,6 +190,7 @@ let test_keeper_status_defaults_name_to_caller () =
                 ("name", `String keeper_name);
                 ("goal", `String "Self inspect");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -235,6 +237,7 @@ let test_keeper_status_accepts_agent_name_alias () =
                 ("name", `String keeper_name);
                 ("goal", `String "Probe keeper runtime");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -281,6 +284,7 @@ let test_keeper_down_accepts_agent_name_alias () =
                 ("name", `String keeper_name);
                 ("goal", `String "Probe keeper runtime");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -332,6 +336,7 @@ let test_operator_keeper_probe_accepts_agent_name_alias () =
                 ("name", `String keeper_name);
                 ("goal", `String "Probe keeper runtime");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -396,6 +401,7 @@ let test_operator_keeper_recover_accepts_agent_name_alias () =
                 ("name", `String keeper_name);
                 ("goal", `String "Probe keeper runtime");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -482,6 +488,7 @@ let test_keeper_list_scoped_to_current_base_path () =
                 ("name", `String keeper_name_a);
                 ("goal", `String "Scoped to base path A");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok in base path A" true ok;
@@ -493,6 +500,7 @@ let test_keeper_list_scoped_to_current_base_path () =
                 ("name", `String keeper_name_b);
                 ("goal", `String "Scoped to base path B");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok in base path B" true ok;
@@ -562,6 +570,7 @@ let test_keeper_status_does_not_cross_base_path () =
                 ("name", `String keeper_name);
                 ("goal", `String "Only exists in base path B");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok in base path B" true ok;
@@ -624,6 +633,7 @@ let test_keeper_down_only_pauses_current_base_path () =
                 ("name", `String keeper_name);
                 ("goal", `String "Shared name in base path A");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok in base path A" true ok;
@@ -635,6 +645,7 @@ let test_keeper_down_only_pauses_current_base_path () =
                 ("name", `String keeper_name);
                 ("goal", `String "Shared name in base path B");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok in base path B" true ok;
@@ -854,6 +865,7 @@ let test_snapshot_keeper_tool_audit_fallback () =
                 ("name", `String keeper_name);
                 ("goal", `String "Expose dashboard fallback keeper audit");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -938,6 +950,7 @@ let test_snapshot_keeper_tool_audit_uses_decision_log () =
                 ("name", `String keeper_name);
                 ("goal", `String "Expose dashboard decision audit");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;
@@ -1036,6 +1049,7 @@ let test_keeper_msg_auto_execution_session_bridge () =
                 ("name", `String keeper_name);
                 ("goal", `String "Start projected team sessions from explicit keeper messages");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       in
       Alcotest.(check bool) "keeper up ok" true ok;

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -93,7 +93,7 @@ let rec rm_rf path =
 
 (* capture_stderr removed — legacy warning tests removed in room flat-path cleanup *)
 
-let test_resolve_masc_base_path_explicit_env_wins_over_git_root_resolution () =
+let test_resolve_masc_base_path_ignores_inherited_env_in_test_by_default () =
   let scratch = Filename.temp_dir "room-utils-worktree" "" in
   let repo_root = Filename.concat scratch "repo" in
   let repo_git = Filename.concat repo_root ".git" in
@@ -111,10 +111,10 @@ let test_resolve_masc_base_path_explicit_env_wins_over_git_root_resolution () =
     [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
       ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
-      check string "explicit env wins over git root" "/Users/dancer/me"
+      check string "requested git root wins in tests" repo_root
         (Room_utils.resolve_masc_base_path worktree_path))
 
-let test_resolve_masc_base_path_preserves_explicit_env_in_test () =
+let test_resolve_masc_base_path_prefers_requested_path_in_test () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-requested"
   in
@@ -122,7 +122,7 @@ let test_resolve_masc_base_path_preserves_explicit_env_in_test () =
     [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
       ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
-      check string "explicit env wins in tests" "/Users/dancer/me"
+      check string "requested path wins in tests" requested
         (Room_utils.resolve_masc_base_path requested))
 
 let test_resolve_masc_base_path_keeps_matching_explicit_env () =
@@ -162,7 +162,7 @@ let test_resolve_masc_base_path_collapses_explicit_env_masc_dir () =
       check string "explicit .masc env collapses to parent" requested
         (Room_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_preserves_explicit_env_without_opt_in () =
+let test_resolve_masc_base_path_ignores_explicit_env_without_opt_in () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-opt-in"
   in
@@ -171,10 +171,10 @@ let test_resolve_masc_base_path_preserves_explicit_env_without_opt_in () =
     [ ("MASC_BASE_PATH", Some explicit);
       ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
     (fun () ->
-      check string "explicit env preserved without opt-in" explicit
+      check string "explicit env ignored without opt-in" requested
         (Room_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_preserves_explicit_env_with_dual_masc_roots ()
+let test_resolve_masc_base_path_ignores_explicit_env_with_dual_masc_roots ()
     =
   let scratch = Filename.temp_dir "room-utils-dual-roots" "" in
   let requested = Filename.concat scratch "repo" in
@@ -188,13 +188,12 @@ let test_resolve_masc_base_path_preserves_explicit_env_with_dual_masc_roots ()
     (fun () ->
       with_envs
         [ ("MASC_BASE_PATH", Some explicit);
-          ("MASC_ALLOW_INHERITED_BASE_PATH", None);
           ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
         (fun () ->
-          check string "dual roots still preserve explicit path" explicit
+          check string "dual roots still honor requested path in tests" requested
             (Room_utils.resolve_masc_base_path requested)))
 
-let test_resolve_masc_base_path_dual_root_opt_in_is_noop () =
+let test_resolve_masc_base_path_dual_root_opt_in_preserves_explicit_env () =
   let scratch = Filename.temp_dir "room-utils-dual-opt-in" "" in
   let requested = Filename.concat scratch "repo" in
   let explicit = Filename.concat scratch "parent-root" in
@@ -207,13 +206,12 @@ let test_resolve_masc_base_path_dual_root_opt_in_is_noop () =
     (fun () ->
       with_envs
         [ ("MASC_BASE_PATH", Some explicit);
-          ("MASC_ALLOW_INHERITED_BASE_PATH", Some "true");
-          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", Some "true") ]
         (fun () ->
-          check string "dual-root opt-in no longer changes result" explicit
+          check string "dual-root opt-in preserves explicit path" explicit
             (Room_utils.resolve_masc_base_path requested)))
 
-let test_resolve_masc_base_path_preserves_ancestor_explicit_path () =
+let test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in () =
   let scratch = Filename.temp_dir "room-utils-ancestor" "" in
   let explicit = scratch in
   let sub_repo = Filename.concat scratch "workspace/sub-repo" in
@@ -231,10 +229,9 @@ let test_resolve_masc_base_path_preserves_ancestor_explicit_path () =
     (fun () ->
       with_envs
         [ ("MASC_BASE_PATH", Some explicit);
-          ("MASC_ALLOW_INHERITED_BASE_PATH", None);
           ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
         (fun () ->
-          check string "ancestor explicit path wins over sub-repo" explicit
+          check string "requested sub-repo wins without opt-in" sub_repo
             (Room_utils.resolve_masc_base_path sub_repo)))
 
 let test_default_config_syncs_test_base_path_env () =
@@ -669,24 +666,24 @@ let () =
       test_case "empty" `Quick test_parse_gitdir_empty;
       test_case "nested" `Quick test_parse_gitdir_nested_worktree;
       test_case "with spaces" `Quick test_parse_gitdir_with_spaces;
-      test_case "explicit env wins over git-root resolution" `Quick
-        test_resolve_masc_base_path_explicit_env_wins_over_git_root_resolution;
-      test_case "preserves explicit base env in tests" `Quick
-        test_resolve_masc_base_path_preserves_explicit_env_in_test;
+      test_case "ignores inherited env in tests by default" `Quick
+        test_resolve_masc_base_path_ignores_inherited_env_in_test_by_default;
+      test_case "prefers requested path in tests" `Quick
+        test_resolve_masc_base_path_prefers_requested_path_in_test;
       test_case "keeps matching explicit env" `Quick
         test_resolve_masc_base_path_keeps_matching_explicit_env;
       test_case "collapses requested .masc path" `Quick
         test_resolve_masc_base_path_collapses_requested_masc_dir;
       test_case "collapses explicit .masc env" `Quick
         test_resolve_masc_base_path_collapses_explicit_env_masc_dir;
-      test_case "preserves explicit env without opt-in" `Quick
-        test_resolve_masc_base_path_preserves_explicit_env_without_opt_in;
-      test_case "preserves explicit env with dual .masc roots" `Quick
-        test_resolve_masc_base_path_preserves_explicit_env_with_dual_masc_roots;
-      test_case "dual-root opt-in is noop" `Quick
-        test_resolve_masc_base_path_dual_root_opt_in_is_noop;
-      test_case "preserves ancestor explicit path" `Quick
-        test_resolve_masc_base_path_preserves_ancestor_explicit_path;
+      test_case "ignores explicit env without opt-in" `Quick
+        test_resolve_masc_base_path_ignores_explicit_env_without_opt_in;
+      test_case "ignores explicit env with dual .masc roots" `Quick
+        test_resolve_masc_base_path_ignores_explicit_env_with_dual_masc_roots;
+      test_case "dual-root opt-in preserves explicit env" `Quick
+        test_resolve_masc_base_path_dual_root_opt_in_preserves_explicit_env;
+      test_case "ignores ancestor explicit path without opt-in" `Quick
+        test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in;
       test_case "default config syncs test base env" `Quick
         test_default_config_syncs_test_base_path_env;
       test_case "auto-synced test base env does not override later requests" `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -89,6 +89,20 @@ let make_config_root root =
   write_file (Filename.concat config "keepers/example.toml") "[keeper]\ngoal = \"example\"\n";
   write_file (Filename.concat config "personas/example.txt") "persona";
   config
+
+let write_basepath_keeper_toml base_path name =
+  let keepers_dir =
+    Filename.concat (Filename.concat (Filename.concat base_path ".masc") "config")
+      "keepers"
+  in
+  mkdir_p keepers_dir;
+  write_file
+    (Filename.concat keepers_dir (name ^ ".toml"))
+    {|[keeper]
+goal = "example"
+room_scope = "current"
+proactive_enabled = false
+|}
 let find_free_port () =
   let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
   Fun.protect
@@ -518,6 +532,7 @@ let test_migrate_resident_keeper_dirs_use_source_scoped_quarantine_path () =
 
 let test_blocking_bootstrap_promotes_legacy_keeper_meta_before_autoboot () =
   with_temp_dir "startup-blocking-legacy-keepers" (fun dir ->
+      write_basepath_keeper_toml dir "sangsu";
       let state = Mcp_server.create_state ~base_path:dir in
       let masc_root = Room.masc_root_dir state.Mcp_server.room_config in
       let legacy_dir = Filename.concat masc_root "resident-keepers" in

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -686,6 +686,7 @@ let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
                 ("name", `String "admin-keeper");
                 ("goal", `String "Admin tool policy test");
                 ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
               ])
       with
       | Some (true, _) -> (

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -480,6 +480,8 @@ let test_masc_keeper_up_schema () =
             (List.mem_assoc "mid_goal" props);
           Alcotest.(check bool) "has long_goal" true
             (List.mem_assoc "long_goal" props);
+          Alcotest.(check bool) "has autoboot_enabled" true
+            (List.mem_assoc "autoboot_enabled" props);
           Alcotest.(check bool) "omits models" false
             (List.mem_assoc "models" props);
           Alcotest.(check bool) "omits allowed_models" false


### PR DESCRIPTION
## Summary
- scope keeper autoboot and keepalive discovery to configured `config/keepers/*.toml` entries instead of every persisted keeper JSON
- keep persisted keeper meta listing separate so dashboard/status surfaces still reflect runtime state without reviving stale fixture keepers
- stop test executables from inheriting shell `MASC_BASE_PATH` by default so they do not write into the real `~/.masc`

## Root Cause
Fixture and test keepers were leaving JSON meta files under `~/.masc/keepers`. Startup discovery treated those persisted files as boot candidates, so unrelated fixture keepers could come back on the next bootstrap. Separately, test executables could inherit a caller `MASC_BASE_PATH` and accidentally operate on the real workspace state.

## What Changed
- added `autoboot_enabled` to keeper meta JSON/state surfaces
- introduced a split between configured keeper discovery and persisted keeper discovery
- switched autoboot/keepalive candidate selection to the configured keeper set only
- updated regression tests to provision explicit TOML keepers where boot behavior matters
- updated room-utils test behavior so inherited `MASC_BASE_PATH` is ignored unless explicitly allowed

## Validation
- `dune build --build-dir /tmp/dune-codex-fixture-pr-check lib/keeper/keeper_types.pp.ml lib/keeper/keeper_runtime.pp.ml lib/keeper/keeper_status.pp.ml lib/dashboard/dashboard_http_keeper.pp.ml lib/tool_keeper.pp.ml lib/room/room_utils_backend_setup.pp.ml`
- `dune exec ./test/test_keeper_meta_listing.exe`

## Notes
- `test_room_utils_coverage.exe` and `test_server_runtime_bootstrap.exe` were not run end-to-end here because those binaries were too heavy in this environment; targeted code paths and the dedicated keeper-meta regression test were run instead.