### PR TITLE
fix(config): replace critical hardcoded runtime values with env vars

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -372,7 +372,9 @@ let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) 
 let delegate config ~agent_name ~target ~message
     ?(task_type_str = "async")
     ?(artifacts : artifact list = [])
-    ?(timeout = 300)
+    ?(timeout = match Sys.getenv_opt "MASC_A2A_DELEGATION_TIMEOUT_SEC" with
+                | Some s -> (match int_of_string_opt s with Some n -> n | None -> 300)
+                | None -> 300)
     () : (Yojson.Safe.t, string) result =
   (* BUG: Prevent self-delegation — creates blocking self-portal *)
   if String.equal agent_name target then

--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -154,15 +154,20 @@ type comment = {
 (** {1 Limits - Enforced, Not Optional} *)
 
 module Limits = struct
-  let max_posts = 10_000
-  let max_comments_per_post = 1_000
-  let max_content_length = 4_000
+  let env_int name default =
+    match Sys.getenv_opt name with
+    | Some s -> (match int_of_string_opt s with Some n -> n | None -> default)
+    | None -> default
+
+  let max_posts = env_int "MASC_BOARD_MAX_POSTS" 10_000
+  let max_comments_per_post = env_int "MASC_BOARD_MAX_COMMENTS_PER_POST" 1_000
+  let max_content_length = env_int "MASC_BOARD_MAX_CONTENT_LENGTH" 4_000
   let default_ttl_hours = 0    (* 0 = permanent (no expiry) *)
-  let automation_ttl_hours = 168 (* 7 days for Automation_post / System_post *)
-  let max_ttl_hours = 720      (* 30 days max; ignored when ttl=0 *)
-  let sweeper_interval_sec = 10  (* Much more aggressive than OpenClaw's 60s *)
-  let sweeper_batch_size = 100   (* Backpressure: don't delete too many at once *)
-  let author_post_cap = 100     (* Max active posts per author; oldest auto-expired *)
+  let automation_ttl_hours = env_int "MASC_BOARD_AUTOMATION_TTL_HOURS" 168
+  let max_ttl_hours = env_int "MASC_BOARD_MAX_TTL_HOURS" 720
+  let sweeper_interval_sec = env_int "MASC_BOARD_SWEEPER_INTERVAL_SEC" 10
+  let sweeper_batch_size = env_int "MASC_BOARD_SWEEPER_BATCH_SIZE" 100
+  let author_post_cap = env_int "MASC_BOARD_AUTHOR_POST_CAP" 100
 end
 
 (** {1 Vote Direction} *)

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -8,9 +8,14 @@ open Keeper_exec_shared
       (cat, rg, head, tail, find, git_log, tree).
     - [user_timeout_max_sec]: upper bound for user-provided timeout_sec
       in keeper_bash (prevents indefinite blocking). *)
-let io_timeout_sec = 30.0
-let read_timeout_sec = 15.0
-let user_timeout_max_sec = 180.0
+let env_float name default =
+  match Sys.getenv_opt name with
+  | Some s -> (match float_of_string_opt s with Some f -> f | None -> default)
+  | None -> default
+
+let io_timeout_sec = env_float "MASC_KEEPER_IO_TIMEOUT_SEC" 30.0
+let read_timeout_sec = env_float "MASC_KEEPER_READ_TIMEOUT_SEC" 15.0
+let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
 
 let clamp_shell_timeout ?(min_sec = 1.0) ~default args =
   Safe_ops.json_float ~default "timeout_sec" args

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -21,7 +21,10 @@ type context = {
 
 type tool_result = bool * string
 
-let max_write_size = 1024 * 1024 (* 1MB *)
+let max_write_size =
+  match Sys.getenv_opt "MASC_MAX_WRITE_SIZE_BYTES" with
+  | Some s -> (match int_of_string_opt s with Some n -> n | None -> 1024 * 1024)
+  | None -> 1024 * 1024
 
 let normalize_dir_prefix path =
   Tool_code.normalize_path path ^ "/"


### PR DESCRIPTION
## Summary

- Keeper shell timeouts (3 values) → env var override
- Board limits (8 values) → env var override  
- File write size cap (1MB) → env var override
- A2A delegation timeout (300s) → env var override

All: Sys.getenv_opt + parse, bad input keeps default. Zero behavior change without env vars.

## Test plan

- [x] Build clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)