### PR TITLE
feat(tla): add 3 cross-domain boundary specs for audit gaps

### DIFF
--- a/specs/Makefile
+++ b/specs/Makefile
@@ -6,6 +6,7 @@
 #   make check-bug-models   Bug models only
 #   make check-keeper       Keeper state machine only
 #   make check-ecosystem    MASC ecosystem only
+#   make check-boundary     Cross-domain boundary specs only
 #   make list               List all discoverable specs
 
 JAVA      ?= java
@@ -37,7 +38,7 @@ TLC = $(JAVA) $(JAVA_OPTS) \
 CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy.cfg' ! -name '*-ci.cfg' | sort)
 BUGGY_CFGS := $(shell find . -name '*-buggy.cfg' | sort)
 
-.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem list
+.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary list
 
 check-all: check-clean check-buggy
 	@echo "=== All TLA+ specs passed ==="
@@ -97,6 +98,11 @@ check-ecosystem:
 	@$(MAKE) --no-print-directory \
 	  CLEAN_CFGS="$$(find masc-ecosystem/ -name '*.cfg' ! -name '*-buggy.cfg' | sort)" \
 	  BUGGY_CFGS="" check-all
+
+check-boundary:
+	@$(MAKE) --no-print-directory \
+	  CLEAN_CFGS="$$(find boundary/ -name '*.cfg' ! -name '*-buggy.cfg' | sort)" \
+	  BUGGY_CFGS="$$(find boundary/ -name '*-buggy.cfg' | sort)" check-all
 
 list:
 	@echo "Clean specs ($(words $(CLEAN_CFGS))):"; \

--- a/specs/boundary/CascadeKeeperRecovery-buggy.cfg
+++ b/specs/boundary/CascadeKeeperRecovery-buggy.cfg
@@ -1,0 +1,16 @@
+\* Buggy model: no SupervisorRestart action -> keeper stuck in crashed
+\* when providers eventually recover.
+\* Expected: FailingResolves VIOLATED (keeper cannot recover from crash).
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    NumProviders = 2
+    MaxRetries = 2
+    MaxFailures = 3
+    MaxRestarts = 2
+
+INVARIANT SafetyInvariant
+
+PROPERTY FailingResolves
+
+CHECK_DEADLOCK FALSE

--- a/specs/boundary/CascadeKeeperRecovery.cfg
+++ b/specs/boundary/CascadeKeeperRecovery.cfg
@@ -1,0 +1,17 @@
+\* Clean model: cascade exhaustion -> keeper retry -> Failing -> recovery.
+\* 2 providers (GLM + Ollama), 2 retries, 3 failures before crash,
+\* 2 supervisor restarts.
+\* Expected: all safety invariants hold, liveness properties hold.
+SPECIFICATION Spec
+
+CONSTANTS
+    NumProviders = 2
+    MaxRetries = 2
+    MaxFailures = 3
+    MaxRestarts = 2
+
+INVARIANT SafetyInvariant
+
+PROPERTY FailingResolves
+
+CHECK_DEADLOCK FALSE

--- a/specs/boundary/CascadeKeeperRecovery.tla
+++ b/specs/boundary/CascadeKeeperRecovery.tla
@@ -1,0 +1,219 @@
+---- MODULE CascadeKeeperRecovery ----
+\* Cross-domain boundary spec: Cascade (OAS) x Keeper lifecycle (MASC).
+\*
+\* Models the end-to-end recovery path from cascade exhaustion through
+\* keeper retry loop, Failing phase, and eventual recovery when providers
+\* come back online.
+\*
+\* Gap identified in cascade-fsm-gap-2026-04-13.md: existing specs model
+\* cascade exhaustion (CascadeExhaustion.tla) and keeper lifecycle
+\* (KeeperStateMachine.tla) in isolation. No spec connects them to verify
+\* that cascade exhaustion -> keeper retry -> Failing -> recovery is live.
+\*
+\* The real code path:
+\*   1. cascade_executor.ml tries providers in order. All fail -> Error.
+\*   2. keeper_unified_turn.ml:retry_loop retries up to MaxRetries times.
+\*   3. If all retries fail, TurnFailed dispatched to FSM -> Failing.
+\*   4. After MaxFailures consecutive failures, keeper crashes.
+\*   5. Supervisor restarts (if budget permits) -> Running.
+\*   6. If providers recover, next turn succeeds -> exit Failing.
+\*
+\* Domain boundary: lib/llm_provider/cascade_executor.ml (OAS cascade) x
+\*                  lib/keeper/keeper_unified_turn.ml (retry loop) x
+\*                  lib/keeper/keeper_state_machine.ml (phase transitions) x
+\*                  lib/keeper/keeper_supervisor.ml (restart budget)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    NumProviders,       \* Number of providers in cascade (e.g. 2: GLM, Ollama)
+    MaxRetries,         \* Retries per turn (e.g. 2, total attempts = 1 + MaxRetries)
+    MaxFailures,        \* Consecutive failures before crash (e.g. 3)
+    MaxRestarts         \* Supervisor restart budget (e.g. 2)
+
+ASSUME NumProviders > 0 /\ MaxRetries >= 0 /\ MaxFailures > 0
+ASSUME MaxRestarts >= 0
+
+P == 1..NumProviders
+
+VARIABLES
+    \* Cascade layer (OAS)
+    provider_health,    \* [P -> {"healthy", "unhealthy"}]
+    \* Keeper turn layer (MASC)
+    keeper_phase,       \* "running" | "failing" | "crashed" | "dead"
+    retry_count,        \* current cascade retry count (0..MaxRetries)
+    fail_count,         \* consecutive turn failures (0..MaxFailures)
+    restart_count       \* supervisor restarts consumed (0..MaxRestarts)
+
+vars == <<provider_health, keeper_phase, retry_count, fail_count,
+          restart_count>>
+
+KeeperPhases == {"running", "failing", "crashed", "dead"}
+
+TypeOK ==
+    /\ provider_health \in [P -> {"healthy", "unhealthy"}]
+    /\ keeper_phase \in KeeperPhases
+    /\ retry_count \in 0..MaxRetries
+    /\ fail_count \in 0..MaxFailures
+    /\ restart_count \in 0..MaxRestarts
+
+\* Derived: at least one provider is healthy.
+SomeProviderHealthy == \E p \in P : provider_health[p] = "healthy"
+
+\* ---- Init ----
+
+Init ==
+    /\ provider_health = [p \in P |-> "healthy"]
+    /\ keeper_phase = "running"
+    /\ retry_count = 0
+    /\ fail_count = 0
+    /\ restart_count = 0
+
+\* ---- Environment Actions ----
+
+\* Provider health can toggle at any time (models network failure,
+\* rate limiting, Ollama crash, etc.).
+ProviderFail(p) ==
+    /\ provider_health[p] = "healthy"
+    /\ provider_health' = [provider_health EXCEPT ![p] = "unhealthy"]
+    /\ UNCHANGED <<keeper_phase, retry_count, fail_count, restart_count>>
+
+ProviderRecover(p) ==
+    /\ provider_health[p] = "unhealthy"
+    /\ provider_health' = [provider_health EXCEPT ![p] = "healthy"]
+    /\ UNCHANGED <<keeper_phase, retry_count, fail_count, restart_count>>
+
+\* ---- Cascade Actions ----
+
+\* Cascade attempt: the keeper tries a turn via the cascade.
+\* If any provider is healthy, the cascade succeeds.
+\* If all providers are unhealthy, the cascade fails.
+CascadeSucceeds ==
+    /\ keeper_phase \in {"running", "failing"}
+    /\ SomeProviderHealthy
+    /\ retry_count' = 0
+    /\ fail_count' = 0
+    /\ keeper_phase' = "running"
+    /\ UNCHANGED <<provider_health, restart_count>>
+
+CascadeFails ==
+    /\ keeper_phase \in {"running", "failing"}
+    /\ ~SomeProviderHealthy
+    /\ IF retry_count < MaxRetries
+       THEN \* Retry (transient error, backoff)
+            /\ retry_count' = retry_count + 1
+            /\ UNCHANGED <<keeper_phase, fail_count, restart_count>>
+       ELSE \* All retries exhausted: turn fails
+            /\ retry_count' = 0
+            /\ fail_count' = fail_count + 1
+            /\ IF fail_count + 1 >= MaxFailures
+               THEN keeper_phase' = "crashed"
+               ELSE keeper_phase' = "failing"
+            /\ UNCHANGED restart_count
+    /\ UNCHANGED provider_health
+
+\* ---- Keeper Lifecycle Actions ----
+
+\* Supervisor restarts a crashed keeper (if budget permits).
+SupervisorRestart ==
+    /\ keeper_phase = "crashed"
+    /\ restart_count < MaxRestarts
+    /\ keeper_phase' = "running"
+    /\ restart_count' = restart_count + 1
+    /\ fail_count' = 0
+    /\ retry_count' = 0
+    /\ UNCHANGED provider_health
+
+\* Supervisor cannot restart: budget exhausted -> Dead.
+BudgetExhausted ==
+    /\ keeper_phase = "crashed"
+    /\ restart_count >= MaxRestarts
+    /\ keeper_phase' = "dead"
+    /\ UNCHANGED <<provider_health, retry_count, fail_count, restart_count>>
+
+\* ---- Clean Next ----
+
+Next ==
+    \/ \E p \in P : ProviderFail(p)
+    \/ \E p \in P : ProviderRecover(p)
+    \/ CascadeSucceeds
+    \/ CascadeFails
+    \/ SupervisorRestart
+    \/ BudgetExhausted
+
+\* Fairness:
+\* - ProviderFail is NOT fair (adversarial environment).
+\* - ProviderRecover: WF (if continuously enabled, eventually fires).
+\* - CascadeSucceeds: SF (if repeatedly enabled, eventually fires).
+\*   WF is too weak because provider health can toggle between cascade
+\*   attempts, making CascadeSucceeds intermittently disabled. SF models
+\*   the real system where a cascade attempt is atomic with respect to
+\*   provider health at invocation time.
+\* - SupervisorRestart: WF (supervisor always attempts restart if budget).
+Fairness ==
+    /\ \A p \in P : WF_vars(ProviderRecover(p))
+    /\ SF_vars(CascadeSucceeds)
+    /\ WF_vars(CascadeFails)
+    /\ WF_vars(SupervisorRestart)
+    /\ WF_vars(BudgetExhausted)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+\* ---- Safety Invariants ----
+
+\* S1: restart_count bounded.
+RestartBounded ==
+    restart_count <= MaxRestarts
+
+\* S2: fail_count bounded.
+FailCountBounded ==
+    fail_count <= MaxFailures
+
+\* S3: retry_count bounded.
+RetryCountBounded ==
+    retry_count <= MaxRetries
+
+\* S4: Dead only when budget is exhausted.
+DeadRequiresNoBudget ==
+    keeper_phase = "dead" => restart_count >= MaxRestarts
+
+\* Combined safety
+SafetyInvariant ==
+    /\ TypeOK
+    /\ RestartBounded
+    /\ FailCountBounded
+    /\ RetryCountBounded
+    /\ DeadRequiresNoBudget
+
+\* ---- Liveness Properties ----
+
+\* L1: If the keeper is Failing, it eventually reaches Running or Dead.
+\* The keeper never stays stuck in Failing indefinitely.
+FailingResolves ==
+    keeper_phase = "failing" ~> keeper_phase \in {"running", "dead"}
+
+\* ---- Bug Model: no SupervisorRestart ----
+\*
+\* Without the supervisor restart mechanism, a keeper that crashes
+\* (all retries exhausted, MaxFailures consecutive failures) has no
+\* recovery path. Even when providers come back, the keeper stays
+\* in "crashed" forever. FailingResolves is violated because the
+\* keeper can go Failing -> Crashed and then get stuck.
+
+NextBuggy ==
+    \/ \E p \in P : ProviderFail(p)
+    \/ \E p \in P : ProviderRecover(p)
+    \/ CascadeSucceeds
+    \/ CascadeFails
+    \* SupervisorRestart OMITTED (the bug)
+    \/ BudgetExhausted
+
+FairnessBuggy ==
+    /\ \A p \in P : WF_vars(ProviderRecover(p))
+    /\ WF_vars(CascadeSucceeds)
+    /\ WF_vars(CascadeFails)
+    /\ WF_vars(BudgetExhausted)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ FairnessBuggy
+
+====

--- a/specs/boundary/KeeperRecoveryOrchestration-buggy.cfg
+++ b/specs/boundary/KeeperRecoveryOrchestration-buggy.cfg
@@ -1,0 +1,9 @@
+\* Buggy model: DispatchManualReconcileCleared omitted from recovery sequence.
+\* Expected: ReconcileEventuallyClears VIOLATED (one-way trap).
+SPECIFICATION SpecBuggy
+
+INVARIANT SafetyInvariant
+
+PROPERTY ReconcileEventuallyClears
+
+CHECK_DEADLOCK FALSE

--- a/specs/boundary/KeeperRecoveryOrchestration.cfg
+++ b/specs/boundary/KeeperRecoveryOrchestration.cfg
@@ -1,0 +1,10 @@
+\* Clean model: full recovery sequence including DispatchManualReconcileCleared.
+\* Expected: all safety invariants hold, liveness properties hold.
+SPECIFICATION Spec
+
+INVARIANT SafetyInvariant
+
+PROPERTY ReconcileEventuallyClears
+PROPERTY EventuallyRunning
+
+CHECK_DEADLOCK FALSE

--- a/specs/boundary/KeeperRecoveryOrchestration.tla
+++ b/specs/boundary/KeeperRecoveryOrchestration.tla
@@ -1,0 +1,174 @@
+---- MODULE KeeperRecoveryOrchestration ----
+\* Cross-domain boundary spec: State (data layer) x FSM (condition layer).
+\*
+\* Models the maybe_recover_from_failing multi-event sequence in
+\* keeper_keepalive.ml:774-836. This function clears the filesystem
+\* reconcile record AND dispatches FSM events. Bug #1 (PR #6834) was
+\* caused by clearing the data record without dispatching
+\* Manual_reconcile_cleared to the FSM, leaving the keeper stuck in
+\* Failing indefinitely.
+\*
+\* The spec captures the two-store consistency requirement: the data
+\* layer (filesystem JSON) and the FSM condition layer (in-memory
+\* conditions.manual_reconcile_required) must stay synchronized.
+\*
+\* Domain boundary: lib/keeper/keeper_manual_reconcile.ml (data) x
+\*                  lib/keeper/keeper_state_machine.ml (FSM conditions)
+\* Orchestrator:    lib/keeper/keeper_keepalive.ml (recovery sequence)
+
+EXTENDS Naturals
+
+VARIABLES
+    \* Data layer (filesystem)
+    data_reconcile_pending,     \* TRUE if reconcile record exists on disk
+    \* FSM condition layer (in-memory)
+    fsm_manual_reconcile,       \* TRUE if conditions.manual_reconcile_required
+    fsm_turn_healthy,           \* TRUE if conditions.turn_healthy
+    fsm_heartbeat_healthy       \* TRUE if conditions.heartbeat_healthy
+
+vars == <<data_reconcile_pending, fsm_manual_reconcile, fsm_turn_healthy,
+          fsm_heartbeat_healthy>>
+
+\* Simplified derive_phase: Failing when any condition is unhealthy.
+DerivePhase(mr, th, hh) ==
+    IF mr \/ ~th \/ ~hh THEN "failing" ELSE "running"
+
+Phase == DerivePhase(fsm_manual_reconcile, fsm_turn_healthy, fsm_heartbeat_healthy)
+
+TypeOK ==
+    /\ data_reconcile_pending \in BOOLEAN
+    /\ fsm_manual_reconcile \in BOOLEAN
+    /\ fsm_turn_healthy \in BOOLEAN
+    /\ fsm_heartbeat_healthy \in BOOLEAN
+
+\* ---- Init ----
+
+Init ==
+    /\ data_reconcile_pending = TRUE    \* reconcile record exists
+    /\ fsm_manual_reconcile = TRUE      \* FSM knows about it
+    /\ fsm_turn_healthy = FALSE         \* turn was unhealthy (triggered failing)
+    /\ fsm_heartbeat_healthy = FALSE    \* heartbeat was unhealthy
+
+\* ---- Environment Actions ----
+
+\* A turn fails, setting data_reconcile_pending and fsm conditions.
+TurnFails ==
+    /\ Phase = "running"
+    /\ data_reconcile_pending' = TRUE
+    /\ fsm_manual_reconcile' = TRUE
+    /\ fsm_turn_healthy' = FALSE
+    /\ fsm_heartbeat_healthy' = fsm_heartbeat_healthy
+
+\* ---- Recovery Sequence Actions (the orchestrator) ----
+
+\* Step 1: Clear the filesystem data record.
+\* Maps to: Keeper_manual_reconcile.clear(...)
+ClearDataRecord ==
+    /\ Phase = "failing"
+    /\ data_reconcile_pending = TRUE
+    /\ data_reconcile_pending' = FALSE
+    /\ UNCHANGED <<fsm_manual_reconcile, fsm_turn_healthy, fsm_heartbeat_healthy>>
+
+\* Step 2: Dispatch Heartbeat_ok to FSM.
+\* Maps to: Keeper_state_machine.dispatch ~event:Heartbeat_ok
+DispatchHeartbeatOk ==
+    /\ Phase = "failing"
+    /\ ~fsm_heartbeat_healthy
+    /\ fsm_heartbeat_healthy' = TRUE
+    /\ UNCHANGED <<data_reconcile_pending, fsm_manual_reconcile, fsm_turn_healthy>>
+
+\* Step 3: Dispatch Manual_reconcile_cleared to FSM.
+\* Maps to: Keeper_state_machine.dispatch ~event:Manual_reconcile_cleared
+\* This is the action that was MISSING in the buggy code (PR #6834).
+DispatchManualReconcileCleared ==
+    /\ fsm_manual_reconcile = TRUE
+    /\ fsm_manual_reconcile' = FALSE
+    /\ UNCHANGED <<data_reconcile_pending, fsm_turn_healthy, fsm_heartbeat_healthy>>
+
+\* Step 4: Dispatch Turn_succeeded to FSM.
+\* Maps to: Keeper_state_machine.dispatch ~event:Turn_succeeded
+\* Note: Turn_succeeded clears turn_healthy only, NOT manual_reconcile.
+\* This matches the OCaml code (keeper_state_machine.ml:311-312).
+DispatchTurnSucceeded ==
+    /\ Phase = "failing"
+    /\ ~fsm_turn_healthy
+    /\ fsm_turn_healthy' = TRUE
+    \* Turn_succeeded does NOT clear manual_reconcile (this is the
+    \* correct OCaml behavior, and the divergence from the old TLA+ spec).
+    /\ UNCHANGED <<data_reconcile_pending, fsm_manual_reconcile, fsm_heartbeat_healthy>>
+
+\* ---- Clean Next ----
+
+Next ==
+    \/ TurnFails
+    \/ ClearDataRecord
+    \/ DispatchHeartbeatOk
+    \/ DispatchManualReconcileCleared
+    \/ DispatchTurnSucceeded
+
+\* Fairness: each recovery action individually must eventually fire when
+\* continuously enabled. WF on the disjunction alone is insufficient
+\* because TLC can satisfy it by repeatedly choosing one enabled disjunct
+\* while starving another.
+Fairness ==
+    /\ WF_vars(ClearDataRecord)
+    /\ WF_vars(DispatchHeartbeatOk)
+    /\ WF_vars(DispatchManualReconcileCleared)
+    /\ WF_vars(DispatchTurnSucceeded)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+\* ---- Safety Invariants ----
+
+\* S1: Phase derivation is consistent with conditions.
+PhaseConsistent ==
+    Phase \in {"running", "failing"}
+
+\* S2: If phase is running, no reconcile is pending in FSM.
+RunningMeansNoReconcile ==
+    Phase = "running" => ~fsm_manual_reconcile
+
+\* S3: Data and FSM layers are directionally consistent: if data is
+\* cleared, the FSM clearing path must be available (fsm_manual_reconcile
+\* can still be true temporarily, but the system must not be stuck).
+\* This is captured by liveness, not as an invariant, because the
+\* data clearing and FSM dispatch are separate steps.
+
+\* Combined safety
+SafetyInvariant ==
+    /\ TypeOK
+    /\ RunningMeansNoReconcile
+
+\* ---- Liveness Properties ----
+
+\* L1: manual_reconcile_required eventually clears (the one-way trap
+\* property that Bug #1 violated).
+ReconcileEventuallyClears ==
+    fsm_manual_reconcile ~> ~fsm_manual_reconcile
+
+\* L2: The keeper eventually reaches running.
+EventuallyRunning ==
+    Phase = "failing" ~> Phase = "running"
+
+\* ---- Bug Model: omit DispatchManualReconcileCleared ----
+\*
+\* This models the exact bug from PR #6834: the recovery sequence
+\* clears the data record and dispatches Heartbeat_ok and Turn_succeeded,
+\* but forgets to dispatch Manual_reconcile_cleared. The FSM condition
+\* manual_reconcile_required stays true, phase stays "failing".
+
+NextBuggy ==
+    \/ TurnFails
+    \/ ClearDataRecord
+    \/ DispatchHeartbeatOk
+    \* DispatchManualReconcileCleared is OMITTED (the bug)
+    \/ DispatchTurnSucceeded
+
+FairnessBuggy ==
+    /\ WF_vars(ClearDataRecord)
+    /\ WF_vars(DispatchHeartbeatOk)
+    /\ WF_vars(DispatchTurnSucceeded)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ FairnessBuggy
+
+====

--- a/specs/boundary/KeeperTurnScheduler-buggy.cfg
+++ b/specs/boundary/KeeperTurnScheduler-buggy.cfg
@@ -1,0 +1,14 @@
+\* Buggy model: scope_only_reactive turns skip proactive timer update.
+\* Expected: TimerNeverFrozen VIOLATED (timer frozen after scope-only turn).
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxTime = 8
+    CooldownSec = 3
+    IdleGateSec = 2
+
+INVARIANT SafetyInvariant
+
+PROPERTY TimerNeverFrozen
+
+CHECK_DEADLOCK FALSE

--- a/specs/boundary/KeeperTurnScheduler.cfg
+++ b/specs/boundary/KeeperTurnScheduler.cfg
@@ -1,0 +1,14 @@
+\* Clean model: proactive timer always updated on turn completion.
+\* Expected: all safety invariants hold, TimerNeverFrozen holds.
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxTime = 8
+    CooldownSec = 3
+    IdleGateSec = 2
+
+INVARIANT SafetyInvariant
+
+PROPERTY TimerNeverFrozen
+
+CHECK_DEADLOCK FALSE

--- a/specs/boundary/KeeperTurnScheduler.tla
+++ b/specs/boundary/KeeperTurnScheduler.tla
@@ -1,0 +1,174 @@
+---- MODULE KeeperTurnScheduler ----
+\* Cross-domain boundary spec: Turn completion (side-effect) x Scheduler (timer).
+\*
+\* Models the proactive scheduling decision in
+\* keeper_world_observation.ml:unified_turn_decision and the post-turn
+\* timer update in keeper_unified_turn.ml:update_metrics_from_result.
+\*
+\* Bug #3: scope_only_reactive turns skipped update_proactive_rt, freezing
+\* the proactive cooldown timer. The keeper could never schedule a second
+\* autonomous turn because proactive_last_ts was never refreshed.
+\*
+\* Fix: 355c13fa6 removed scope_only_reactive entirely and always updates
+\* proactive_last_ts on turn completion.
+\*
+\* Domain boundary: keeper_unified_turn.ml (turn result side-effect) x
+\*                  keeper_world_observation.ml (scheduling decision input)
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxTime,            \* upper bound on discretized time (e.g. 8)
+    CooldownSec,        \* proactive cooldown in time units (e.g. 3)
+    IdleGateSec         \* idle gate in time units (e.g. 2)
+
+ASSUME MaxTime > 0 /\ CooldownSec > 0 /\ IdleGateSec > 0
+
+VARIABLES
+    now,                    \* current time (0..MaxTime), monotonically increasing
+    proactive_last_ts,      \* timestamp of last proactive timer update (0..MaxTime)
+    idle_since,             \* timestamp when keeper became idle (0..MaxTime)
+    turn_active,            \* TRUE if a turn is currently executing
+    scope_only_reactive     \* TRUE if current/last turn had scope-only reactive trigger
+
+vars == <<now, proactive_last_ts, idle_since, turn_active, scope_only_reactive>>
+
+TypeOK ==
+    /\ now \in 0..MaxTime
+    /\ proactive_last_ts \in 0..MaxTime
+    /\ idle_since \in 0..MaxTime
+    /\ turn_active \in BOOLEAN
+    /\ scope_only_reactive \in BOOLEAN
+
+\* Derived predicates (match unified_turn_decision logic).
+CooldownElapsed == now - proactive_last_ts >= CooldownSec
+IdleGateElapsed == now - idle_since >= IdleGateSec
+
+\* ---- Init ----
+
+Init ==
+    /\ now = 0
+    /\ proactive_last_ts = 0
+    /\ idle_since = 0
+    /\ turn_active = FALSE
+    /\ scope_only_reactive = FALSE
+
+\* ---- Actions ----
+
+\* Time advances (environment action). Only when no turn is active
+\* (simplification: turns are instantaneous in this model, time
+\* advances between turns).
+TimeTick ==
+    /\ now < MaxTime
+    /\ ~turn_active
+    /\ now' = now + 1
+    /\ UNCHANGED <<proactive_last_ts, idle_since, turn_active, scope_only_reactive>>
+
+\* Scheduled autonomous turn: keeper decides to start a proactive turn.
+\* Guards: cooldown elapsed AND idle gate elapsed AND not currently in turn.
+ScheduledAutonomousTurn ==
+    /\ ~turn_active
+    /\ CooldownElapsed
+    /\ IdleGateElapsed
+    /\ turn_active' = TRUE
+    /\ scope_only_reactive' = FALSE
+    /\ UNCHANGED <<now, proactive_last_ts, idle_since>>
+
+\* Reactive turn triggered by external event (mentions, board events).
+\* No cooldown gate required.
+ReactiveTurn ==
+    /\ ~turn_active
+    /\ turn_active' = TRUE
+    /\ scope_only_reactive' = FALSE
+    /\ UNCHANGED <<now, proactive_last_ts, idle_since>>
+
+\* Scope-only reactive turn: pending_scope_messages present but no
+\* mentions or board events. This is the channel that caused Bug #3.
+ScopeOnlyReactiveTurn ==
+    /\ ~turn_active
+    /\ turn_active' = TRUE
+    /\ scope_only_reactive' = TRUE
+    /\ UNCHANGED <<now, proactive_last_ts, idle_since>>
+
+\* Turn completes and updates the proactive timer.
+\* Clean model: ALWAYS updates proactive_last_ts regardless of channel.
+\* This matches the fix (355c13fa6).
+TurnCompleteClean ==
+    /\ turn_active
+    /\ turn_active' = FALSE
+    \* Always update the proactive timer (the fix).
+    /\ proactive_last_ts' = now
+    /\ idle_since' = now
+    /\ UNCHANGED <<now, scope_only_reactive>>
+
+\* ---- Clean Next ----
+
+Next ==
+    \/ TimeTick
+    \/ ScheduledAutonomousTurn
+    \/ ReactiveTurn
+    \/ ScopeOnlyReactiveTurn
+    \/ TurnCompleteClean
+
+\* Fairness: time must eventually advance and turns must eventually complete.
+Fairness ==
+    /\ WF_vars(TimeTick)
+    /\ WF_vars(TurnCompleteClean)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+\* ---- Safety Invariants ----
+
+\* S1: proactive_last_ts never exceeds current time.
+TimerNotFuture ==
+    proactive_last_ts <= now
+
+\* S2: idle_since never exceeds current time.
+IdleSinceNotFuture ==
+    idle_since <= now
+
+\* Combined safety
+SafetyInvariant ==
+    /\ TypeOK
+    /\ TimerNotFuture
+    /\ IdleSinceNotFuture
+
+\* ---- Liveness Properties ----
+
+\* L1: The proactive timer is never permanently frozen while turns happen.
+\* If a turn completes, the timer is refreshed to the current time.
+\* Formulated as: if a turn is active, it eventually completes and the
+\* timer catches up.
+TimerNeverFrozen ==
+    turn_active ~> (proactive_last_ts >= idle_since)
+
+\* ---- Bug Model: scope_only_reactive skips timer update ----
+\*
+\* Models the exact bug from Bug #3: when scope_only_reactive is true,
+\* update_proactive_rt was set to FALSE, so proactive_last_ts was not
+\* refreshed. After a scope-only turn, the timer is frozen.
+
+TurnCompleteBuggy ==
+    /\ turn_active
+    /\ turn_active' = FALSE
+    \* BUG: only update proactive_last_ts if NOT scope_only_reactive.
+    /\ proactive_last_ts' = IF scope_only_reactive
+                            THEN proactive_last_ts     \* FROZEN
+                            ELSE now
+    /\ idle_since' = now
+    /\ UNCHANGED <<now, scope_only_reactive>>
+
+NextBuggy ==
+    \/ TimeTick
+    \/ ScheduledAutonomousTurn
+    \/ ReactiveTurn
+    \/ ScopeOnlyReactiveTurn
+    \/ TurnCompleteBuggy
+
+FairnessBuggy ==
+    /\ WF_vars(TimeTick)
+    /\ WF_vars(TurnCompleteBuggy)
+
+SpecBuggy == Init /\ [][NextBuggy]_vars /\ FairnessBuggy
+
+====


### PR DESCRIPTION
## Summary

- Add 3 TLA+ specs in `specs/boundary/` that verify cross-domain boundaries identified by the TLA+ audit reports (`docs/tla-audit/*-2026-04-13.md`). The existing 42 specs each verify individual domains but 3 bugs slipped through at domain boundaries.
- Each spec follows the established bug-model pattern: clean config passes (exit 0), buggy config violates a liveness property (exit 12/13).
- Add `check-boundary` target to `specs/Makefile` for targeted boundary spec checking.

### Specs

| Spec | Boundary | Bug | Clean | Buggy |
|------|----------|-----|-------|-------|
| `KeeperRecoveryOrchestration.tla` | State (data layer) x FSM (conditions) | #1: data cleared but FSM event not dispatched | 16 states, no error | `ReconcileEventuallyClears` violated |
| `KeeperTurnScheduler.tla` | Turn completion x Scheduler timer | #3: scope_only_reactive skipped timer update | 180 states, no error | `TimerNeverFrozen` violated |
| `CascadeKeeperRecovery.tla` | Cascade (OAS) x Keeper lifecycle | cascade exhaustion -> stuck in Failing | 124 states, no error | `FailingResolves` violated |

### Key design decisions

- **Per-action fairness** (Recovery Orchestration): WF on individual recovery actions instead of WF on Next disjunction, because the latter allows TLC to starve one disjunct while satisfying the whole.
- **Strong fairness on CascadeSucceeds** (Cascade Recovery): SF models the real system where cascade attempt is atomic with respect to provider health. WF was too weak because provider toggles intermittently disabled CascadeSucceeds.
- **Bounded time model** (Turn Scheduler): MaxTime=8 bounds the state space. `AutonomousEventuallyFires` dropped from cfg because bounded time causes stuttering at horizon; `TimerNeverFrozen` is the primary Bug #3 property.
- **No step counter** (Recovery Orchestration, Cascade Recovery): step counters cause liveness violations at bound by forcing stuttering. Finite domains (boolean conditions, enum phases, bounded integers) naturally bound the state space.

## Test plan

- [x] TLC clean configs: all 3 exit 0 (no error)
- [x] TLC buggy configs: all 3 exit 12 or 13 (liveness violated)
- [x] `make list` discovers all 6 configs
- [ ] CI `make -C specs check-all` passes (boundary specs included in check-all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)