### PR TITLE
[codex] Ignore inherited base-path leaks in tests

### DIFF
--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -125,9 +125,12 @@ let resolve_requested_base_path path =
       requested
 
 (** Resolve base_path with a single authority:
-    - explicit [MASC_BASE_PATH] always wins
+    - in normal executables, explicit [MASC_BASE_PATH] wins
+    - in test executables, inherited [MASC_BASE_PATH] is ignored unless it
+      matches the requested path or the test explicitly opts in
     - otherwise resolve the requested path to its git root *)
 let resolve_masc_base_path path =
+  let requested = resolve_requested_base_path path in
   match Env_config_core.base_path_opt () with
   | Some explicit
     when running_under_test_executable ()
@@ -137,11 +140,21 @@ let resolve_masc_base_path path =
       Log.Room.info
         "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
         explicit path;
-      resolve_requested_base_path path
+      requested
+  | Some explicit
+    when running_under_test_executable ()
+         && not
+              (Env_config_core.get_bool ~default:false
+                 "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
+         && not (String.equal explicit requested) ->
+      Log.Room.info
+        "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
+        explicit path;
+      requested
   | Some explicit ->
       Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
       explicit
-  | None -> resolve_requested_base_path path
+  | None -> requested
 
 let resolve_server_default_base_path path = resolve_masc_base_path path
 

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -13,6 +13,27 @@ let ensure_fs env =
   if not (Fs_compat.has_fs ()) then
     Fs_compat.set_fs (Eio.Stdenv.fs env)
 
+let with_env name value_opt f =
+  let original = Sys.getenv_opt name in
+  let restore () =
+    match original with
+    | Some value -> Unix.putenv name value
+    | None -> Unix.putenv name ""
+  in
+  Fun.protect
+    ~finally:restore
+    (fun () ->
+      (match value_opt with
+       | Some value -> Unix.putenv name value
+       | None -> Unix.putenv name "");
+      f ())
+
+let with_clean_base_path_env f =
+  with_env "MASC_BASE_PATH" None @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
+  with_env "MASC_TEST_SYNCED_BASE_PATH" None @@ fun () ->
+  with_env "MASC_BASE_PATH_RESOLUTION_SOURCE" None f
+
 let cleanup_dir dir =
   let rec rm path =
     if Sys.file_exists path then
@@ -84,6 +105,7 @@ let keeper_ctx env sw config agent_name : _ Tool_keeper.context =
 let test_keeper_listing_ignores_sidecar_json_files () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
@@ -138,6 +160,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
 let test_dashboard_ignores_fileless_manual_reconcile_fallback () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   Fun.protect


### PR DESCRIPTION
## What changed
- make `resolve_masc_base_path` ignore inherited `MASC_BASE_PATH` in test executables unless it matches the requested path or the test explicitly opts in
- keep the existing auto-synced test base-path escape hatch intact
- add a dedicated base-path scrubber to `test_keeper_meta_listing`
- update `test_room_utils_coverage` to lock the new test-only resolution rules

## Why
When `MASC_BASE_PATH=/Users/dancer/me` was present in the parent shell, temp-dir tests that called `Room.default_config base_dir` could silently write keeper metadata into the real `~/me/.masc/keepers` tree instead of their hermetic temp roots. That leaked fixture keepers like `real-test`, `phantom-test`, and `dot.name` into the live workspace.

## Impact
- manual test runs no longer inherit the operator shell's real base path by default
- tests that intentionally want inherited `MASC_BASE_PATH` can still opt in with `MASC_TEST_ALLOW_INHERITED_BASE_PATH=true`
- hermetic keeper-listing tests stop polluting the real keeper registry

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-meta-listing-basepath-leak test/test_room_utils_coverage.exe test/test_keeper_meta_listing.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-meta-listing-basepath-leak/_build/default/test/test_room_utils_coverage.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-meta-listing-basepath-leak/_build/default/test/test_keeper_meta_listing.exe`
