### PR TITLE
fix(keeper): reverse sync stale FSM manual_reconcile_required

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -857,6 +857,17 @@ let sync_manual_reconcile_condition ~(config : Room.config) ~(keeper_name : stri
       ignore (Keeper_registry.dispatch_event
         ~base_path:config.base_path keeper_name
         (Keeper_state_machine.Manual_reconcile_required { reason = detail }))
+  | (`Cleared | `Absent), Some entry
+    when entry.conditions.manual_reconcile_required ->
+      (* Reverse sync: file removed/cleared but FSM condition still true.
+         Without this, keepers whose reconcile file was deleted externally
+         or cleared by a previous server instance stay in Failing forever. *)
+      Log.Keeper.info
+        "sync_reconcile: clearing stale FSM manual_reconcile_required for %s (no file)"
+        keeper_name;
+      ignore (Keeper_registry.dispatch_event
+        ~base_path:config.base_path keeper_name
+        Keeper_state_machine.Manual_reconcile_cleared)
   | _ -> ()
 
 (** Reset stale turn failures so the keeper can exit Failing phase.


### PR DESCRIPTION
## Summary
- When reconcile file is absent but FSM condition `manual_reconcile_required` is true, dispatch `Manual_reconcile_cleared` to unblock keeper
- Fixes edge case where janitor (and potentially other keepers) stay stuck in Failing phase after reconcile file is externally deleted
- Single file, 11-line addition to `sync_manual_reconcile_condition`

## Root cause
`sync_manual_reconcile_condition` only handled file→FSM sync (Pending file → set condition true). The reverse path (Absent file → clear condition) was missing. Keepers whose reconcile file was removed by operator or previous server instance stayed in Failing forever.

## Test plan
- [ ] CI Build and Test pass
- [ ] TLA+ Model Checking pass
- [ ] Verify janitor recovers from stuck state after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)