### PR TITLE
fix(keeper): reorder tool merge to preserve BM25-relevant tools on truncation

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -176,8 +176,14 @@ let merge_tool_selection_boundary
     ~(llm_selected : string list)
     ~(discovered : string list) : string list =
   let sorted_discovered = List.sort String.compare discovered in
+  (* BM25-relevant tools first: when downstream truncation caps at
+     max_tools, the tail is dropped.  Placing deterministic_prefilter
+     and discovered before core ensures context-relevant tools survive
+     while generic core tools are truncated first.
+     Core tools that also appear in deterministic_prefilter are deduped
+     (first occurrence wins), so they naturally keep their BM25 rank. *)
   let deterministic_floor =
     Keeper_types.dedupe_keep_order
-      (core @ deterministic_prefilter @ sorted_discovered)
+      (deterministic_prefilter @ sorted_discovered @ core)
   in
   Keeper_types.dedupe_keep_order (deterministic_floor @ llm_selected)

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -224,10 +224,10 @@ let test_selection_boundary_preserves_deterministic_floor () =
     board_post_count;
   Alcotest.(check (list string))
     "deterministic floor survives even when llm omits most tools"
-    [ "keeper_context_status";
-      "keeper_fs_read";
+    [ "keeper_fs_read";
       "keeper_board_post";
       "keeper_tool_search";
+      "keeper_context_status";
     ]
     merged
 
@@ -255,9 +255,9 @@ let test_selection_boundary_appends_llm_only_extras () =
      | _ -> false);
   Alcotest.(check (list string))
     "llm extras append after deterministic floor without duplicates"
-    [ "keeper_context_status";
-      "keeper_fs_read";
+    [ "keeper_fs_read";
       "keeper_tool_search";
+      "keeper_context_status";
       "keeper_bash";
       "keeper_board_post";
     ]
@@ -284,8 +284,8 @@ let test_selection_boundary_sorts_discovered () =
     "discovered order is stable regardless of input order"
     merged_ab merged_ba;
   Alcotest.(check (list string))
-    "discovered is sorted alphabetically after core"
-    ["core_tool"; "tool_a"; "tool_b"]
+    "discovered is sorted alphabetically before core"
+    ["tool_a"; "tool_b"; "core_tool"]
     merged_ab
 
 let test_deterministic_prefilter_surfaces_code_tools () =


### PR DESCRIPTION
## Summary

- Reorder `merge_tool_selection_boundary` concatenation from `core @ prefilter @ discovered` to `prefilter @ discovered @ core`
- When downstream truncation caps at `max_tools`, the tail is dropped — this change ensures BM25-relevant tools survive while generic core tools are truncated first
- Core tools that also appear in BM25 results are deduped by first occurrence, naturally keeping their relevance rank

## Context

When keepers have more tools than the budget allows (>15 after truncation), the overflow guard at `keeper_agent_run.ml:1278` preserves `always_include` tools as essential and fills the remaining budget from `non_essential` in list order. The previous merge order put core tools at the head of non_essential, meaning BM25-ranked context-relevant tools were dropped first.

## Test plan

- [x] `dune build --root .` passes
- [x] `test_keeper_topk_llm.exe` — all 14 tests pass (updated expected order)
- [x] `test_keeper_unified.exe` — all 156 tests pass (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)