### PR TITLE
test: session_tracker.ml QA edge cases — escape_string + parse_connection_url + query snapshots

### DIFF
--- a/lib/ocaml/session_tracker/test/dune
+++ b/lib/ocaml/session_tracker/test/dune
@@ -1,6 +1,4 @@
-(test
- (name test_session_tracker)
- (libraries session_tracker alcotest))
+(include_subdirs no)
 
 (test
  (name test_session_tracker_qa)

--- a/lib/ocaml/session_tracker/test/dune
+++ b/lib/ocaml/session_tracker/test/dune
@@ -1,0 +1,7 @@
+(test
+ (name test_session_tracker)
+ (libraries session_tracker alcotest))
+
+(test
+ (name test_session_tracker_qa)
+ (libraries alcotest))

--- a/lib/ocaml/session_tracker/test/test_session_tracker_qa.ml
+++ b/lib/ocaml/session_tracker/test/test_session_tracker_qa.ml
@@ -192,8 +192,8 @@ let test_parse_special_chars_password () =
 (* ============================================ *)
 (* Query generation snapshot tests              *)
 (* These verify the SQL that sprintf produces    *)
-*  so refactoring to parameterized queries can  *
-*  verify equivalence afterward                 *)
+(* so refactoring to parameterized queries can   *)
+(* verify equivalence afterward                  *)
 (* ============================================ *)
 
 let test_register_query_snapshot () =

--- a/lib/ocaml/session_tracker/test/test_session_tracker_qa.ml
+++ b/lib/ocaml/session_tracker/test/test_session_tracker_qa.ml
@@ -1,0 +1,286 @@
+(** QA Tests for session_tracker.ml — edge cases and boundary conditions
+    Author: qa-king
+    Purpose: Cover escape_string, parse_connection_url edge cases
+    These tests target the ~71% of functions that had ZERO test coverage.
+
+    NOTE: escape_string is reproduced locally because it's not exported.
+    When cheolsu's parameterized query patch lands, these escape_string tests
+    serve as a regression baseline — the old behavior is documented here. *)
+
+open Alcotest
+
+(* Helper: substring search — because String.contains only works for single chars *)
+let string_contains ~substring ~string =
+  let sub_len = String.length substring in
+  let str_len = String.length string in
+  if sub_len = 0 then true
+  else if sub_len > str_len then false
+  else
+    let rec loop i =
+      if i + sub_len > str_len then false
+      else if String.sub string i sub_len = substring then true
+      else loop (i + 1)
+    in
+    loop 0
+
+(* ============================================ *)
+(* Local types and functions for testing        *)
+(* These mirror session_tracker.ml internals    *)
+(* ============================================ *)
+
+type connection_info = {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+  database: string;
+}
+
+let escape_string s =
+  let buf = Buffer.create (String.length s * 2) in
+  String.iter (fun c ->
+    match c with
+    | '\'' -> Buffer.add_string buf "''"
+    | '\\' -> Buffer.add_string buf "\\\\"
+    | _ -> Buffer.add_char buf c
+  ) s;
+  Buffer.contents buf
+
+let parse_connection_url url =
+  let url =
+    if String.length url > 13 && String.sub url 0 13 = "postgresql://" then
+      String.sub url 13 (String.length url - 13)
+    else if String.length url > 11 && String.sub url 0 11 = "postgres://" then
+      String.sub url 11 (String.length url - 11)
+    else
+      url
+  in
+  let at_pos = String.index url '@' in
+  let user_pass = String.sub url 0 at_pos in
+  let host_rest = String.sub url (at_pos + 1) (String.length url - at_pos - 1) in
+  let colon_pos = String.index user_pass ':' in
+  let user = String.sub user_pass 0 colon_pos in
+  let password = String.sub user_pass (colon_pos + 1) (String.length user_pass - colon_pos - 1) in
+  let slash_pos = String.index host_rest '/' in
+  let host_port = String.sub host_rest 0 slash_pos in
+  let database = String.sub host_rest (slash_pos + 1) (String.length host_rest - slash_pos - 1) in
+  let colon_pos = String.index host_port ':' in
+  let host = String.sub host_port 0 colon_pos in
+  let port = String.sub host_port (colon_pos + 1) (String.length host_port - colon_pos - 1) in
+  { host; port; user; password; database }
+
+(* ============================================ *)
+(* escape_string tests                          *)
+(* ============================================ *)
+
+let test_escape_normal_string () =
+  check string "normal string unchanged" "hello world" (escape_string "hello world")
+
+let test_escape_single_quote () =
+  (* Classic SQL injection: Robert'); DROP TABLE students; -- *)
+  check string "single quote doubled" "it''s" (escape_string "it's")
+
+let test_escape_backslash () =
+  check string "backslash doubled" "C:\\\\Users" (escape_string "C:\\Users")
+
+let test_escape_multiple_quotes () =
+  check string "multiple quotes" "a''b''c" (escape_string "a'b'c")
+
+let test_escape_mixed () =
+  check string "mixed quotes and backslashes" "a''b\\\\c''d" (escape_string "a'b\\c'd")
+
+let test_escape_empty_string () =
+  check string "empty string stays empty" "" (escape_string "")
+
+let test_escape_only_quotes () =
+  check string "all quotes" "''''" (escape_string "''")
+
+let test_escape_only_backslashes () =
+  check string "all backslashes" "\\\\\\\\" (escape_string "\\\\")
+
+let test_escape_long_string () =
+  (* Stress test: 10000 single quotes *)
+  let input = String.make 10000 '\'' in
+  let result = escape_string input in
+  check int "long string escaped length" 20000 (String.length result)
+
+(* ============================================ *)
+(* BUG documentation tests                      *)
+(* These DOCUMENT known weaknesses in           *)
+(* escape_string — they will BREAK if the       *)
+(* function is fixed to handle these cases      *)
+(* ============================================ *)
+
+let test_escape_null_byte_passthrough () =
+  (* BUG: NULL byte passes through unescaped!
+     In PostgreSQL, \x00 in a string literal can cause truncation or errors.
+     This test DOCUMENTS the current (wrong) behavior.
+     FIX: parameterized queries eliminate this entire class of bugs. *)
+  let result = escape_string "hello\x00world" in
+  check bool "null byte passes through (BUG)" true (String.contains result '\x00')
+
+let test_escape_double_dollar_passthrough () =
+  (* BUG: $$ is a PostgreSQL dollar-quoted string delimiter.
+     escape_string doesn't touch $ at all.
+     This is safe ONLY if parameterized queries are used. *)
+  let result = escape_string "$$" in
+  check string "dollar signs pass through (known gap)" "$$" result
+
+let test_escape_semicolon_passthrough () =
+  (* SQL injection vectors use semicolons for statement termination.
+     escape_string doesn't escape semicolons — that's fine WITH parameterized
+     queries, but lethal WITH sprintf. *)
+  let result = escape_string "'; DROP TABLE session_tracker; --" in
+  check string "semicolon passes through" "''; DROP TABLE session_tracker; --" result
+
+let test_escape_unicode_null () =
+  (* BUG: U+0000 (NULL) in UTF-8 is \x00, passes through *)
+  let result = escape_string "\x00" in
+  check bool "unicode null passes through (BUG)" true (String.length result = 1)
+
+(* ============================================ *)
+(* parse_connection_url — boundary tests        *)
+(* ============================================ *)
+
+let test_parse_valid_postgresql_scheme () =
+  let result = parse_connection_url "postgresql://admin:secret@db.example.com:5432/myapp" in
+  check string "host" "db.example.com" result.host;
+  check string "port" "5432" result.port;
+  check string "user" "admin" result.user;
+  check string "password" "secret" result.password;
+  check string "database" "myapp" result.database
+
+let test_parse_valid_postgres_scheme () =
+  let result = parse_connection_url "postgres://admin:secret@db.example.com:5432/myapp" in
+  check string "host via postgres://" "db.example.com" result.host
+
+let test_parse_no_at_sign () =
+  (* Missing @ should raise Not_found from String.index *)
+  check_raises "no @ raises" Not_found (fun () ->
+    ignore (parse_connection_url "postgresql://user:passhost/db"))
+
+let test_parse_no_colon_userpass () =
+  (* Missing : in user:pass should raise Not_found *)
+  check_raises "no colon in userpass raises" Not_found (fun () ->
+    ignore (parse_connection_url "postgresql://userpass@host:5432/db"))
+
+let test_parse_no_slash_hostport () =
+  (* Missing / before database should raise Not_found *)
+  check_raises "no slash in hostport raises" Not_found (fun () ->
+    ignore (parse_connection_url "postgresql://user:pass@host:5432"))
+
+let test_parse_empty_string () =
+  (* Empty string should raise on String.index *)
+  check_raises "empty string raises" Not_found (fun () ->
+    ignore (parse_connection_url ""))
+
+let test_parse_special_chars_password () =
+  (* Password with @ in it — this is a REAL edge case
+     The parser will break because it finds @ in password first.
+     DOCUMENTED BUG: URL-encoded passwords (%40) are not decoded. *)
+  let result = parse_connection_url "postgresql://user:p@ss@host:5432/db" in
+  (* Parser grabs "user:p" as user_pass, "ss@host:5432/db" as host_rest
+     Then "ss@host" will fail to parse because there's no colon for port.
+     Actually: host_port would be... let's trace:
+     at_pos = 7 (first @ after "user:p")
+     user_pass = "user:p", host_rest = "ss@host:5432/db"
+     Then slash_pos finds / at 13, host_port = "ss@host:5432"
+     colon_pos finds : at 6, host = "ss@host", port = "5432"
+     So password = "p", host = "ss@host" — WRONG *)
+  check string "broken password parse" "p" result.password
+
+(* ============================================ *)
+(* Query generation snapshot tests              *)
+(* These verify the SQL that sprintf produces    *)
+*  so refactoring to parameterized queries can  *
+*  verify equivalence afterward                 *)
+(* ============================================ *)
+
+let test_register_query_snapshot () =
+  let session_id = "test-session" in
+  let segment = "default" in
+  let pid = 12345 in
+  let now = 1000.0 in
+  let query = Printf.sprintf
+    "INSERT INTO session_tracker (session_id, segment, pid, status, last_seen, started_at) \
+     VALUES ('%s', '%s', %d, 'active', to_timestamp(%.3f), to_timestamp(%.3f)) \
+     ON CONFLICT (session_id, segment) DO UPDATE SET \
+       pid = %d, status = 'active', last_seen = to_timestamp(%.3f))"
+    (escape_string session_id)
+    (escape_string segment)
+    pid now now pid now
+  in
+  check bool "query contains INSERT" true (string_contains ~substring:"INSERT" ~string:query);
+  check bool "query contains VALUES" true (string_contains ~substring:"VALUES" ~string:query);
+  check bool "query contains session_id value" true (string_contains ~substring:"test-session" ~string:query);
+  check bool "query contains ON CONFLICT" true (string_contains ~substring:"ON CONFLICT" ~string:query)
+
+let test_heartbeat_query_snapshot () =
+  let now = 2000.0 in
+  let query = Printf.sprintf
+    "UPDATE session_tracker SET last_seen = to_timestamp(%.3f) \
+     WHERE session_id = '%s' AND segment = '%s'"
+    now (escape_string "sess-1") (escape_string "seg-1")
+  in
+  check bool "query is UPDATE" true (string_contains ~substring:"update" ~string:(String.lowercase_ascii query));
+  check bool "query contains WHERE" true (string_contains ~substring:"WHERE" ~string:query);
+  check bool "query contains session" true (string_contains ~substring:"sess-1" ~string:query)
+
+let test_query_with_injection_attempt () =
+  (* Simulate SQL injection in session_id — with current escape_string,
+     semicolons pass through. This demonstrates WHY parameterized queries
+     are needed. *)
+  let malicious_id = "'; DELETE FROM session_tracker; --" in
+  let query = Printf.sprintf
+    "UPDATE session_tracker SET last_seen = to_timestamp(%.3f) \
+     WHERE session_id = '%s'"
+    1000.0 (escape_string malicious_id)
+  in
+  (* After escaping: quotes are doubled, but semicolons and -- pass through *)
+  check bool "injection query still contains semicolons" true (string_contains ~substring:";" ~string:query);
+  check bool "quotes are properly escaped" true (string_contains ~substring:"''" ~string:query)
+
+(* ============================================ *)
+(* Test suite registration                      *)
+(* ============================================ *)
+
+let escape_string_tests = [
+  test_case "normal string" `Quick test_escape_normal_string;
+  test_case "single quote" `Quick test_escape_single_quote;
+  test_case "backslash" `Quick test_escape_backslash;
+  test_case "multiple quotes" `Quick test_escape_multiple_quotes;
+  test_case "mixed" `Quick test_escape_mixed;
+  test_case "empty string" `Quick test_escape_empty_string;
+  test_case "only quotes" `Quick test_escape_only_quotes;
+  test_case "only backslashes" `Quick test_escape_only_backslashes;
+  test_case "long string (10000 quotes)" `Quick test_escape_long_string;
+  (* BUG documentation tests *)
+  test_case "NULL byte passes through (BUG)" `Quick test_escape_null_byte_passthrough;
+  test_case "$$ passes through (known gap)" `Quick test_escape_double_dollar_passthrough;
+  test_case "semicolon passes through" `Quick test_escape_semicolon_passthrough;
+  test_case "unicode null passes through (BUG)" `Quick test_escape_unicode_null;
+]
+
+let parse_url_tests = [
+  test_case "valid postgresql:// URL" `Quick test_parse_valid_postgresql_scheme;
+  test_case "valid postgres:// URL" `Quick test_parse_valid_postgres_scheme;
+  (* Boundary / error cases *)
+  test_case "no @ raises exception" `Quick test_parse_no_at_sign;
+  test_case "no colon in userpass raises" `Quick test_parse_no_colon_userpass;
+  test_case "no slash in hostport raises" `Quick test_parse_no_slash_hostport;
+  test_case "empty string raises" `Quick test_parse_empty_string;
+  test_case "@ in password (parsing bug)" `Quick test_parse_special_chars_password;
+]
+
+let query_snapshot_tests = [
+  test_case "register query format" `Quick test_register_query_snapshot;
+  test_case "heartbeat query format" `Quick test_heartbeat_query_snapshot;
+  test_case "injection attempt in query" `Quick test_query_with_injection_attempt;
+]
+
+let () =
+  run "session_tracker QA tests" [
+    "escape_string", escape_string_tests;
+    "parse_connection_url", parse_url_tests;
+    "query_snapshots", query_snapshot_tests;
+  ]

--- a/session_tracker_qa_tests.md
+++ b/session_tracker_qa_tests.md
@@ -1,0 +1,164 @@
+# QA 테스트 제안: session_tracker.ml escape_string + parse_connection_url Edge Cases
+
+**작성자**: qa-king  
+**대상**: `/Users/dancer/me/lib/ocaml/session_tracker/test/test_session_tracker.ml`
+
+> ⚠️ session_tracker는 masc-mcp 레포가 아닌 별도 프로젝트(`lib/ocaml/session_tracker/`)에 있음.
+> 이 파일은 테스트 코드 제안서. 담당자가 직접 `test_session_tracker.ml`에 반영 바람.
+
+---
+
+## 1. `escape_string` 테스트 (SQL Injection 방어 핵심 함수)
+
+```ocaml
+(* ============================================ *)
+(* escape_string edge case tests — qa-king      *)
+(* ============================================ *)
+
+(* 기본 케이스: 작은따옴표 이스케이프 *)
+let test_escape_single_quote () =
+  let result = Session_tracker.escape_string "it's" in
+  check string "single quote escaped" "it''s" result
+
+(* 기본 케이스: 백슬래시 이스케이프 *)
+let test_escape_backslash () =
+  let result = Session_tracker.escape_string "path\\to\\file" in
+  check string "backslash escaped" "path\\\\to\\\\file" result
+
+(* 빈 문자열 *)
+let test_escape_empty () =
+  let result = Session_tracker.escape_string "" in
+  check string "empty string unchanged" "" result
+
+(* 이스케이프 불필요한 문자열 *)
+let test_escape_no_special () =
+  let result = Session_tracker.escape_string "normal text 123" in
+  check string "normal text unchanged" "normal text 123" result
+
+(* 혼합 특수문자 *)
+let test_escape_mixed () =
+  let result = Session_tracker.escape_string "it's a \\path\\ here" in
+  check string "mixed escaped" "it''s a \\\\path\\\\ here" result
+
+(* 연속 작은따옴표 *)
+let test_escape_consecutive_quotes () =
+  let result = Session_tracker.escape_string "'''" in
+  check string "consecutive quotes" "''''''" result
+
+(* 연속 백슬래시 *)
+let test_escape_consecutive_backslashes () =
+  let result = Session_tracker.escape_string "\\\\" in
+  check string "consecutive backslashes" "\\\\\\\\" result
+
+(* ⚠️ NULL 바이트 — 현재 구현은 통과시킴 (보안 이슈) *)
+let test_escape_null_byte () =
+  let result = Session_tracker.escape_string "before\000after" in
+  (* 현재 동작: NULL 바이트가 그대로 통과 → SQL injection 벡터 가능 *)
+  (* 이 테스트는 현재 동작을 기록하는 것. 파라미터화된 쿼리 전환 후에는 무의미해짐 *)
+  check string "null byte passes through (KNOWN ISSUE)" "before\000after" result
+
+(* ⚠️ PostgreSQL 특수 시퀀스 $$ — 현재 구현은 통과시킴 *)
+let test_escape_dollar_quote () =
+  let result = Session_tracker.escape_string "$$drop table$$" in
+  (* $$...$$ 는 PostgreSQL의 다른 인용 방식. escape_string은 처리 안 함 *)
+  check string "dollar quote passes through (KNOWN ISSUE)" "$$drop table$$" result
+
+(* SQL injection 시도 패턴 *)
+let test_escape_sql_injection_attempt () =
+  let result = Session_tracker.escape_string "'; DROP TABLE sessions;--" in
+  check string "sql injection escaped" "''; DROP TABLE sessions;--" result
+
+(* 이미 이스케이프된 입력 — double escape 발생 *)
+let test_escape_already_escaped () =
+  let result = Session_tracker.escape_string "it''s" in
+  (* 주의: 이미 이스케이프된 ''가 ''''''로 다시 이스케이프됨 → double escape 버그 *)
+  check string "double escape bug" "it''''''s" result
+
+(* 매우 긴 문자열 *)
+let test_escape_long_string () =
+  let long = String.make 10000 'A' in
+  let result = Session_tracker.escape_string long in
+  check int "long string length preserved" 10000 (String.length result)
+```
+
+## 2. `parse_connection_url` Edge Case 테스트
+
+```ocaml
+(* ============================================ *)
+(* parse_connection_url edge cases — qa-king     *)
+(* ============================================ *)
+
+(* 특수문자 포함 password — @ 문자가 password에 있으면 파싱 깨짐 *)
+let test_parse_url_special_password () =
+  (* 현재 구현: String.index url '@'로 첫 @를 찾음
+     password에 @가 있으면 host를 잘못 파싱함 *)
+  let url = "postgresql://user:p@ss@host:5432/db" in
+  (* 이건 Not_found 예외를 던지거나 잘못된 결과를 반환할 것 *)
+  (* 현재 동작을 확인하는 테스트 — 버그 리포트 목적 *)
+  (try
+    let _ = Session_tracker.parse_connection_url url in
+    (* 파싱이 성공하면 host가 "ss@host"가 아닌지 확인 *)
+    assert false (* 예외가 없으면 이 테스트가 실패해야 함 *)
+  with Not_found ->
+    () (* 예상된 실패: @가 여러 개면 첫 번째 @에서 자르므로 host 파싱 오류 *)
+  )
+
+(* 포트 없는 URL *)
+let test_parse_url_no_port () =
+  (* 현재 구현: String.index host_rest ':'로 포트를 찾음
+     포트가 없으면 Not_found *)
+  let url = "postgresql://user:pass@host/db" in
+  (try
+    let _ = Session_tracker.parse_connection_url url in
+    assert false (* 포트 없으면 실패해야 함 *)
+  with Not_found ->
+    ()
+  )
+
+(* 빈 문자열 *)
+let test_parse_url_empty () =
+  (try
+    let _ = Session_tracker.parse_connection_url "" in
+    assert false
+  with Not_found ->
+    ()
+  )
+
+(* 프로토콜만 있는 URL *)
+let test_parse_url_protocol_only () =
+  (try
+    let _ = Session_tracker.parse_connection_url "postgresql://" in
+    assert false
+  with Not_found ->
+    ()
+  )
+
+(* user:pass 없는 URL *)
+let test_parse_url_no_credentials () =
+  let url = "postgresql://host:5432/db" in
+  (try
+    let _ = Session_tracker.parse_connection_url url in
+    assert false
+  with Not_found ->
+    ()
+  )
+```
+
+## 3. 커버리지 요약
+
+| 추가 테스트 | 수량 | 목적 |
+|---|---|---|
+| `escape_string` edge cases | 11개 | SQL injection 방어 검증 + 알려진 이슈 기록 |
+| `parse_connection_url` edge cases | 5개 | 입력 검증 + 예외 처리 검증 |
+| **총 추가** | **16개** | |
+
+### 기대 효과
+- 파라미터화된 쿼리 전환 전 **현재 동작 고정** → 회귀 방지
+- `escape_string`의 알려진 취약점(NULL byte, $$, double escape)을 테스트로 명시
+- `parse_connection_url`의 입력 검증 부재를 테스트로 증명
+
+### 우선순위
+1. 🔴 `escape_string` SQL injection 시도 패턴 테스트 — 즉시
+2. 🔴 `escape_string` NULL byte / $$ 테스트 — 즉시  
+3. 🟡 `parse_connection_url` 예외 케이스 — 중기
+4. 🟢 `is_pid_alive` boundary 테스트 — 장기 (DB 없이 테스트 어려움)


### PR DESCRIPTION
## Summary

QA tests for `session_tracker.ml` — escape_string, parse_connection_url, query snapshots. Coverage was 29% (4/14 functions). Adds 23 tests covering edge cases and known bugs as a regression baseline.

## Product impact

No runtime behavior change.  Test-only addition.  Tests reimplement `escape_string` and `parse_connection_url` locally because the production `session_tracker` library has not landed yet — these tests serve as the regression baseline for cheolsu's parameterized-query patch.

## Evidence

- `dune build` clean
- `dune exec lib/ocaml/session_tracker/test/test_session_tracker_qa.exe` → 23/23 tests pass
- After rebase onto main: Lint, Release Train, Health, Build & Test, TLA+ all pass

## Review evidence

23 alcotest cases:

- escape_string (13): normal/quote/backslash/mixed/empty/long-stress + 4 documented bugs (NULL byte, `$$`, semicolon, unicode null all pass through)
- parse_connection_url (7): valid postgresql:// + postgres:// schemes, missing-`@`/`:`/`/` raises, empty raises, `@` in password parses incorrectly (documented bug)
- query_snapshots (3): register query format, heartbeat query format, semicolon injection scenario

Fix commits on top of qa-king's original work:

1. `fix(test): drop phantom test_session_tracker stanza, fix comment syntax` — original `test/dune` referenced `(libraries session_tracker alcotest)` and a non-existent `test_session_tracker.ml`.  Removed phantom stanza, kept only `test_session_tracker_qa` with `alcotest`.  Added `(include_subdirs no)` to satisfy `lib/dune`'s `(include_subdirs unqualified)` parent.  Fixed malformed comment block at lines 192-197 (mixed `(*` opener with bare `*` continuation).

## Linked issue

Relates task-005.  No explicit issue number — this is preemptive QA coverage for cheolsu's pending parameterized-query work.

## Test plan

- [x] `dune runtest` standalone (no DB connection needed)
- [x] All 23 alcotest cases pass
- [x] Build & Test CI passes after rebase
- [x] Lint passes after rebase (was failing on stale `agent_sdk >= 0.131.0` floor)
- [x] Release Train passes after rebase (was failing on stale `0.5.10` vs main's `0.5.11`)