### PR TITLE
[codex] Fix keeper keepalive listing regression

### DIFF
--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -139,10 +139,8 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       check (list string) "keeper_names filters sidecars"
         [ "dot.name"; "sangsu" ] names;
       let keepalive_names = Keeper_types.keepalive_keeper_names config in
-      check bool "keepalive includes configured sangsu" true
-        (List.mem "sangsu" keepalive_names);
-      check bool "keepalive excludes json-only dot.name" false
-        (List.mem "dot.name" keepalive_names);
+      check (list string) "keepalive_keeper_names filters sidecars"
+        [ "dot.name"; "sangsu" ] keepalive_names;
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
         Keeper_status.handle_keeper_list ctx (`Assoc [ ("limit", `Int 10) ])


### PR DESCRIPTION
## What changed
- restore `test_keeper_meta_listing` to expect TOML-configured keepers in `keepalive_keeper_names`
- keep the sidecar filtering assertion focused on `.dataset.json` noise instead of excluding a configured keeper

## Why
`#6858` merged the test-only base-path isolation fix, but the keeper-listing test still expected `dot.name` to be absent from `keepalive_keeper_names` even though the test creates `config/keepers/dot.name.toml`. That made the regression reproducible on current `main`.

## Validation
- `env -u MASC_BASE_PATH -u MASC_CONFIG_DIR -u MASC_PERSONAS_DIR dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-meta-listing-regression ./test/test_keeper_meta_listing.exe`
