### PR TITLE
[codex] Isolate keeper meta listing fixture config

### DIFF
--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -31,6 +31,8 @@ let with_env name value_opt f =
 let with_clean_base_path_env f =
   with_env "MASC_BASE_PATH" None @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
+  with_env "MASC_CONFIG_DIR" None @@ fun () ->
+  with_env "MASC_PERSONAS_DIR" None @@ fun () ->
   with_env "MASC_TEST_SYNCED_BASE_PATH" None @@ fun () ->
   with_env "MASC_BASE_PATH_RESOLUTION_SOURCE" None f
 
@@ -117,7 +119,6 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
       write_keeper_toml_exn config ~name:"sangsu";
-      write_keeper_toml_exn config ~name:"dot.name";
       Config_dir_resolver.reset ();
       write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu";
       write_keeper_meta_exn config ~name:"dot.name" ~trace_id:"trace-dot-name";


### PR DESCRIPTION
## What changed
- clear inherited `MASC_CONFIG_DIR` and `MASC_PERSONAS_DIR` in `test_keeper_meta_listing`
- stop creating a `dot.name` TOML fixture for the sidecar-filtering case, so the test keeps `dot.name` as a JSON-only keeper artifact

## Why
PR #6858 merged before the last quick-suite failure was addressed. The failing `keeper_meta_listing` case was mixing repo-level config resolution with temp-root fixture expectations. That let the test observe configured keepers from the repo instead of only the hermetic temp fixture, and it also muddied the `dot.name` keepalive expectation by turning the supposed JSON-only fixture into a configured keeper.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-meta-listing-regression test/test_keeper_meta_listing.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/fix-keeper-meta-listing-regression/_build/default/test/test_keeper_meta_listing.exe`

## Context
- Follow-up to merged PR #6858
- Local cleanup of leaked test keeper artifacts in `~/me/.masc/keepers` is already done
