### PR TITLE
fix(keeper): wire boring-tool pruning to reduce keeper_stay_silent waste

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1296,6 +1296,18 @@ let run_turn
                   essential @ List.filteri (fun i _ -> i < budget) non_essential)
                 else all_allowed
               in
+              (* Boring-tool pruning: hide status-polling tools when the
+                 keeper has been repeatedly calling them without productive
+                 work.  Single boring calls are fine (first board_list is
+                 normal); only consecutive boring streaks get pruned.
+                 Applied after the overflow cap so the pruned set is
+                 already within budget. *)
+              let all_allowed =
+                Keeper_tool_disclosure.prune_boring_tools_from_messages
+                  ~visible_tools:all_allowed
+                  ~messages
+                  ()
+              in
               let tool_filter = Agent_sdk.Guardrails.AllowList all_allowed in
               (* Tool choice: Auto on all turns.
            Previous design forced tool_choice=Any on non-last turns

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -170,6 +170,80 @@ let prune_boring_tools_after_recent_polling
       visible_tools
 ;;
 
+(** Extract tool names from recent assistant messages (most recent last).
+    Scans content blocks for [ToolUse] entries and returns tool names
+    in chronological order.  Only looks at the last [n] assistant messages
+    to bound the scan. *)
+let recent_tool_names_from_messages
+    ?(max_messages = 3)
+    (messages : Agent_sdk.Types.message list)
+  : string list =
+  messages
+  |> List.rev
+  |> List.filter (fun (m : Agent_sdk.Types.message) ->
+       m.role = Agent_sdk.Types.Assistant)
+  |> List.filteri (fun i _ -> i < max_messages)
+  |> List.rev
+  |> List.concat_map (fun (m : Agent_sdk.Types.message) ->
+       List.filter_map
+         (function
+           | Agent_sdk.Types.ToolUse { name; _ } -> Some name
+           | _ -> None)
+         m.content)
+;;
+
+(** Prune boring tools from the visible set based on recent tool call
+    history extracted from messages.  Delegates to
+    [prune_boring_tools_after_recent_polling] for single-call pruning,
+    then applies a consecutive boring streak detector:
+
+    If the last [consecutive_boring_threshold] tool calls are ALL boring
+    (excluding [keeper_stay_silent] itself), force [keeper_stay_silent]
+    as the only visible tool to break the polling loop.
+
+    A single boring call is normal (first board_list check is expected);
+    only repeated boring-only turns trigger forced silence. *)
+let prune_boring_tools_from_messages
+    ~(visible_tools : string list)
+    ~(messages : Agent_sdk.Types.message list)
+    ?(consecutive_boring_threshold = 3)
+    ()
+  : string list =
+  let recent_names = recent_tool_names_from_messages ~max_messages:4 messages in
+  (* Build JSON entries for the existing prune function *)
+  let recent_entries =
+    List.map
+      (fun name -> `Assoc [ ("tool", `String name) ])
+      recent_names
+  in
+  let after_single_prune =
+    prune_boring_tools_after_recent_polling ~visible_tools ~recent_entries
+  in
+  (* Consecutive boring streak detection: if the last N tool calls
+     (excluding keeper_stay_silent) are all boring, force silence.
+     This catches loops where the keeper alternates between status
+     checks without doing productive work. *)
+  let non_silent_recent =
+    List.filter
+      (fun name -> not (String.equal name "keeper_stay_silent"))
+      recent_names
+  in
+  let streak_len = min consecutive_boring_threshold (List.length non_silent_recent) in
+  if streak_len >= consecutive_boring_threshold then
+    let last_n =
+      let rev = List.rev non_silent_recent in
+      List.filteri (fun i _ -> i < consecutive_boring_threshold) rev
+    in
+    let all_boring = List.for_all Keeper_tool_registry.is_boring_tool last_n in
+    if all_boring then
+      (* Force keeper_stay_silent only to break the loop *)
+      List.filter (fun name -> String.equal name "keeper_stay_silent") after_single_prune
+    else
+      after_single_prune
+  else
+    after_single_prune
+;;
+
 let merge_tool_selection_boundary
     ~(core : string list)
     ~(deterministic_prefilter : string list)

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -352,7 +352,8 @@ let all_tools_reconcile_safe (names : string list) : bool =
 let boring_tools =
   [ "masc_status"; "keeper_tasks_list";
     "keeper_context_status"; "keeper_tools_list";
-    "keeper_stay_silent"; "keeper_board_list" ]
+    "keeper_stay_silent"; "keeper_board_list";
+    "masc_board_list" ]
 
 let boring_tools_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length boring_tools) in

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -348,6 +348,105 @@ let test_prune_boring_tools_keeps_set_when_last_tool_productive () =
     "productive last tool does not hide boring tools"
     visible_tools pruned
 
+let test_masc_board_list_is_boring () =
+  Alcotest.(check bool) "masc_board_list is boring"
+    true (Keeper_tool_registry.is_boring_tool "masc_board_list")
+
+(** Build a minimal assistant message with ToolUse content blocks. *)
+let assistant_msg_with_tools (tool_names : string list) : Agent_sdk.Types.message =
+  let content =
+    List.map
+      (fun name ->
+        Agent_sdk.Types.ToolUse { id = "id_" ^ name; name; input = `Assoc [] })
+      tool_names
+  in
+  { role = Agent_sdk.Types.Assistant; content; name = None; tool_call_id = None }
+
+let test_prune_boring_tools_from_messages_single_boring () =
+  (* A single boring tool call should not trigger forced silence *)
+  let messages = [ assistant_msg_with_tools [ "keeper_board_list" ] ] in
+  let visible_tools =
+    [ "masc_status"; "keeper_stay_silent"; "keeper_fs_edit"; "keeper_board_list" ]
+  in
+  let pruned =
+    Keeper_tool_disclosure.prune_boring_tools_from_messages
+      ~visible_tools ~messages ()
+  in
+  (* Single boring call prunes boring tools but keeps productive ones *)
+  Alcotest.(check bool) "productive tools still visible"
+    true (List.mem "keeper_fs_edit" pruned);
+  Alcotest.(check bool) "keeper_stay_silent still visible"
+    true (List.mem "keeper_stay_silent" pruned)
+
+let test_prune_boring_tools_from_messages_consecutive_streak () =
+  (* 3 consecutive boring-only turns should force keeper_stay_silent *)
+  let messages = [
+    assistant_msg_with_tools [ "keeper_board_list" ];
+    assistant_msg_with_tools [ "masc_status" ];
+    assistant_msg_with_tools [ "keeper_tasks_list" ];
+  ] in
+  let visible_tools =
+    [ "masc_status"; "keeper_stay_silent"; "keeper_fs_edit";
+      "keeper_board_list"; "keeper_tasks_list" ]
+  in
+  let pruned =
+    Keeper_tool_disclosure.prune_boring_tools_from_messages
+      ~visible_tools ~messages ()
+  in
+  Alcotest.(check (list string))
+    "consecutive boring streak forces silence-only"
+    [ "keeper_stay_silent" ] pruned
+
+let test_prune_boring_tools_from_messages_mixed_breaks_streak () =
+  (* A productive tool in the middle breaks the streak *)
+  let messages = [
+    assistant_msg_with_tools [ "keeper_board_list" ];
+    assistant_msg_with_tools [ "keeper_fs_edit" ];
+    assistant_msg_with_tools [ "masc_status" ];
+  ] in
+  let visible_tools =
+    [ "masc_status"; "keeper_stay_silent"; "keeper_fs_edit";
+      "keeper_board_list" ]
+  in
+  let pruned =
+    Keeper_tool_disclosure.prune_boring_tools_from_messages
+      ~visible_tools ~messages ()
+  in
+  (* Last tool is boring so single-call pruning fires, but streak is
+     broken by keeper_fs_edit so forced-silence does NOT apply *)
+  Alcotest.(check bool) "productive tools still visible after broken streak"
+    true (List.mem "keeper_fs_edit" pruned);
+  Alcotest.(check bool) "keeper_stay_silent visible"
+    true (List.mem "keeper_stay_silent" pruned)
+
+let test_prune_boring_tools_from_messages_no_history () =
+  (* No messages: no pruning *)
+  let visible_tools =
+    [ "masc_status"; "keeper_stay_silent"; "keeper_fs_edit" ]
+  in
+  let pruned =
+    Keeper_tool_disclosure.prune_boring_tools_from_messages
+      ~visible_tools ~messages:[] ()
+  in
+  Alcotest.(check (list string))
+    "no message history means no pruning"
+    visible_tools pruned
+
+let test_recent_tool_names_from_messages () =
+  let messages = [
+    assistant_msg_with_tools [ "keeper_board_list"; "keeper_fs_edit" ];
+    { role = Agent_sdk.Types.User;
+      content = [ Agent_sdk.Types.Text "hello" ];
+      name = None; tool_call_id = None };
+    assistant_msg_with_tools [ "masc_status" ];
+  ] in
+  let names =
+    Keeper_tool_disclosure.recent_tool_names_from_messages ~max_messages:3 messages
+  in
+  Alcotest.(check (list string))
+    "extracts tool names from assistant messages in order"
+    [ "keeper_board_list"; "keeper_fs_edit"; "masc_status" ] names
+
 let test_keeper_config_defaults () =
   (* Default: LLM rerank disabled *)
   Alcotest.(check bool) "llm_rerank disabled by default"
@@ -388,6 +487,20 @@ let () =
         test_prune_boring_tools_after_recent_polling;
       Alcotest.test_case "productive last tool keeps boring tools visible" `Quick
         test_prune_boring_tools_keeps_set_when_last_tool_productive;
+      Alcotest.test_case "masc_board_list is boring" `Quick
+        test_masc_board_list_is_boring;
+    ];
+    "boring_tools_from_messages", [
+      Alcotest.test_case "single boring call prunes but keeps productive" `Quick
+        test_prune_boring_tools_from_messages_single_boring;
+      Alcotest.test_case "consecutive boring streak forces silence" `Quick
+        test_prune_boring_tools_from_messages_consecutive_streak;
+      Alcotest.test_case "mixed history breaks streak" `Quick
+        test_prune_boring_tools_from_messages_mixed_breaks_streak;
+      Alcotest.test_case "no history means no pruning" `Quick
+        test_prune_boring_tools_from_messages_no_history;
+      Alcotest.test_case "recent_tool_names_from_messages extracts correctly" `Quick
+        test_recent_tool_names_from_messages;
     ];
     "keeper_config", [
       Alcotest.test_case "config defaults" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2977,6 +2977,12 @@ let () =
           test_case "keeper_bash is NOT boring" `Quick (fun () ->
             check bool "keeper_bash"
               false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_bash"));
+          test_case "masc_board_list IS boring" `Quick (fun () ->
+            check bool "masc_board_list"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_board_list"));
+          test_case "keeper_board_list IS boring" `Quick (fun () ->
+            check bool "keeper_board_list"
+              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_board_list"));
           test_case "keeper allowed tools exclude heartbeat" `Quick
             test_keeper_allowed_tools_exclude_heartbeat;
         ] );


### PR DESCRIPTION
## Summary
- Wire the dead-code `prune_boring_tools_after_recent_polling` into `keeper_agent_run.ml` via a new message-based adapter (`prune_boring_tools_from_messages`)
- Add `masc_board_list` to the boring_tools set (consecutive calls return identical data)
- Add consecutive boring streak detection: when the last 3 non-silent tool calls are all boring, force `keeper_stay_silent` as the only visible tool to break the polling loop
- Single boring calls are not affected (first `board_list` check is normal behavior)

## Motivation
Analysis showed `keeper_stay_silent` accounted for 12.3% of all tool calls (19 calls), and `keeper_board_list` had 21 consecutive calls. The pruning logic existed but was never wired into the turn lifecycle.

## Changes
| File | Change |
|------|--------|
| `lib/keeper/keeper_tool_registry.ml` | Add `masc_board_list` to boring_tools |
| `lib/keeper/keeper_tool_disclosure.ml` | Add `recent_tool_names_from_messages` + `prune_boring_tools_from_messages` |
| `lib/keeper/keeper_agent_run.ml` | Wire pruning into before_turn_params hook (after overflow cap, before tool_filter) |
| `test/test_keeper_topk_llm.ml` | 6 new tests: boring classification, message extraction, streak detection |
| `test/test_keeper_unified.ml` | 2 new tests: masc_board_list + keeper_board_list boring assertions |

## Test plan
- [x] `dune build` passes
- [x] `dune exec test/test_keeper_topk_llm.exe` — 20 tests pass (6 new)
- [x] `dune exec test/test_keeper_unified.exe -- test boring_tools` — 15 tests pass (2 new)
- [x] Full `dune runtest` passes
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)