### PR TITLE
[codex] Make repo config fallback opt-in

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -186,28 +186,29 @@ let config_root_resolution (inputs : inputs) =
       | None ->
           match path_from_home_masc inputs with
           | Some path -> ({ path; exists = true; source = Home_masc }, [])
-          | None when repo_config_fallback_enabled () ->
-              match path_from_cwd inputs.cwd with
-              | Some path -> ({ path; exists = true; source = Cwd }, [])
-              | None ->
-                  match path_from_executable ~cwd:inputs.cwd inputs.executable_name with
-                  | Some path -> ({ path; exists = true; source = Exe_relative }, [])
-                  | None ->
-                      let path = default_missing_root inputs in
-                      missing path
-                        [
-                          Printf.sprintf
-                            "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
-                            path;
-                        ]
           | None ->
-              let path = default_missing_root inputs in
-              missing path
-                [
-                  Printf.sprintf
-                    "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
-                    path;
-                ]
+              if repo_config_fallback_enabled () then
+                match path_from_cwd inputs.cwd with
+                | Some path -> ({ path; exists = true; source = Cwd }, [])
+                | None ->
+                    match path_from_executable ~cwd:inputs.cwd inputs.executable_name with
+                    | Some path -> ({ path; exists = true; source = Exe_relative }, [])
+                    | None ->
+                        let path = default_missing_root inputs in
+                        missing path
+                          [
+                            Printf.sprintf
+                              "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
+                              path;
+                          ]
+              else
+                let path = default_missing_root inputs in
+                missing path
+                  [
+                    Printf.sprintf
+                      "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
+                      path;
+                  ]
 
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -111,6 +111,35 @@ let path_from_cwd cwd =
   let candidate = Filename.concat cwd "config" |> absolute_path_from ~cwd in
   if config_signature_exists candidate then Some candidate else None
 
+let repo_config_fallback_enabled () =
+  Env_config_core.get_bool ~default:false "MASC_ALLOW_REPO_CONFIG_FALLBACK"
+
+let disabled_repo_config_fallback_warnings (inputs : inputs) =
+  if repo_config_fallback_enabled () then
+    []
+  else
+    let candidates =
+      [
+        ("cwd", path_from_cwd inputs.cwd);
+        ("exe_relative", path_from_executable ~cwd:inputs.cwd inputs.executable_name);
+      ]
+      |> List.filter_map (fun (label, path_opt) ->
+             Option.map (fun path -> (label, path)) path_opt)
+    in
+    match candidates with
+    | [] -> []
+    | hits ->
+        let rendered =
+          hits
+          |> List.map (fun (label, path) -> Printf.sprintf "%s:%s" label path)
+          |> String.concat ", "
+        in
+        [
+          Printf.sprintf
+            "Repo config fallback is disabled by default; set MASC_ALLOW_REPO_CONFIG_FALLBACK=true to use %s"
+            rendered;
+        ]
+
 let path_from_home_masc (inputs : inputs) =
   match trim_opt inputs.env_home with
   | None -> None
@@ -136,6 +165,10 @@ let default_missing_root (inputs : inputs) =
   | None -> Filename.concat inputs.cwd "config" |> absolute_path_from ~cwd:inputs.cwd
 
 let config_root_resolution (inputs : inputs) =
+  let missing path warnings =
+    ( { path; exists = false; source = Missing },
+      warnings @ disabled_repo_config_fallback_warnings inputs )
+  in
   match trim_opt inputs.env_config_dir with
   | Some raw ->
       let path = absolute_path_from ~cwd:inputs.cwd raw in
@@ -153,7 +186,7 @@ let config_root_resolution (inputs : inputs) =
       | None ->
           match path_from_home_masc inputs with
           | Some path -> ({ path; exists = true; source = Home_masc }, [])
-          | None ->
+          | None when repo_config_fallback_enabled () ->
               match path_from_cwd inputs.cwd with
               | Some path -> ({ path; exists = true; source = Cwd }, [])
               | None ->
@@ -161,10 +194,20 @@ let config_root_resolution (inputs : inputs) =
                   | Some path -> ({ path; exists = true; source = Exe_relative }, [])
                   | None ->
                       let path = default_missing_root inputs in
-                      ( { path; exists = false; source = Missing },
-                        [ Printf.sprintf
+                      missing path
+                        [
+                          Printf.sprintf
                             "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
-                            path ] )
+                            path;
+                        ]
+          | None ->
+              let path = default_missing_root inputs in
+              missing path
+                [
+                  Printf.sprintf
+                    "Unable to resolve config directory; set MASC_CONFIG_DIR (current fallback candidate: %s)"
+                    path;
+                ]
 
 let child_item (root : path_item) name =
   let path = Filename.concat root.path name in

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -29,6 +29,31 @@ let write_file path content =
   output_string oc content;
   close_out oc
 
+let with_env name value f =
+  let saved = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some prior -> Unix.putenv name prior
+      | None -> Unix.putenv name "")
+    f
+
+let string_contains ~needle haystack =
+  let needle_len = String.length needle in
+  let hay_len = String.length haystack in
+  let rec loop idx =
+    if idx + needle_len > hay_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else
+      loop (idx + 1)
+  in
+  if needle_len = 0 then true else loop 0
+
 let make_config_root root =
   let config = Filename.concat root "config" in
   mkdir_p (Filename.concat config "prompts");
@@ -78,9 +103,27 @@ let test_env_override_invalid_no_fallback () =
   check bool "cascade missing" false resolution.cascade.exists;
   check bool "warnings present" true (resolution.warnings <> [])
 
-let test_cwd_fallback () =
+let test_cwd_fallback_disabled_by_default () =
   with_temp_dir "config-dir-cwd" @@ fun cwd ->
   let _config = make_config_root cwd in
+  with_env "MASC_ALLOW_REPO_CONFIG_FALLBACK" None @@ fun () ->
+  let resolution =
+    Lib.Config_dir_resolver.resolve_with
+      (make_inputs ~cwd ~executable_name:"/tmp/nonexistent-masc" ())
+  in
+  check string "status" "missing"
+    (Lib.Config_dir_resolver.status_to_string resolution.status);
+  check string "root source" "missing"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check bool "warning mentions opt-in" true
+    (List.exists
+       (string_contains ~needle:"MASC_ALLOW_REPO_CONFIG_FALLBACK=true")
+       resolution.warnings)
+
+let test_cwd_fallback_opt_in () =
+  with_temp_dir "config-dir-cwd-opt-in" @@ fun cwd ->
+  let _config = make_config_root cwd in
+  with_env "MASC_ALLOW_REPO_CONFIG_FALLBACK" (Some "true") @@ fun () ->
   let resolution =
     Lib.Config_dir_resolver.resolve_with
       (make_inputs ~cwd ~executable_name:"/tmp/nonexistent-masc" ())
@@ -90,6 +133,25 @@ let test_cwd_fallback () =
   check string "root source" "cwd"
     (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
   check bool "keepers exists" true resolution.keepers.exists
+
+let test_executable_relative_fallback_opt_in () =
+  with_temp_dir "config-dir-exe" @@ fun root ->
+  let repo = Filename.concat root "repo" in
+  let _config = make_config_root repo in
+  let bin_dir = Filename.concat repo "bin" in
+  mkdir_p bin_dir;
+  let executable_name = Filename.concat bin_dir "masc-mcp" in
+  write_file executable_name "#!/bin/sh\n";
+  with_env "MASC_ALLOW_REPO_CONFIG_FALLBACK" (Some "true") @@ fun () ->
+  let resolution =
+    Lib.Config_dir_resolver.resolve_with
+      (make_inputs ~cwd:"/tmp/nonexistent-cwd" ~executable_name ())
+  in
+  check string "status" "ready"
+    (Lib.Config_dir_resolver.status_to_string resolution.status);
+  check string "root source" "exe_relative"
+    (Lib.Config_dir_resolver.source_to_string resolution.config_root.source);
+  check bool "personas exists" true resolution.personas.exists
 
 let test_home_masc_fallback () =
   with_temp_dir "config-dir-home" @@ fun home ->
@@ -221,7 +283,12 @@ let () =
           test_case "env override valid" `Quick test_env_override_valid;
           test_case "env override invalid does not fallback" `Quick
             test_env_override_invalid_no_fallback;
-          test_case "cwd fallback" `Quick test_cwd_fallback;
+          test_case "cwd fallback disabled by default" `Quick
+            test_cwd_fallback_disabled_by_default;
+          test_case "cwd fallback opt-in" `Quick
+            test_cwd_fallback_opt_in;
+          test_case "exe-relative fallback opt-in" `Quick
+            test_executable_relative_fallback_opt_in;
           test_case "local masc fallback precedes home masc" `Quick
             test_local_masc_fallback_precedes_home_masc;
           test_case "local masc fallback collapses explicit .masc dir"


### PR DESCRIPTION
## What changed
- make repo config fallback opt-in instead of default-on
- keep explicit `MASC_CONFIG_DIR`, `MASC_BASE_PATH/.masc/config`, and `~/.masc/config` precedence unchanged
- add resolver tests for default-disabled `cwd/config` and opt-in `cwd` / `exe-relative` fallback

## Why
Current sessions can silently bind to a repo-local `config/` tree when `MASC_CONFIG_DIR` is unset, which is the opposite of the runtime shape we want for `~/me`: `~/.masc/config` should be the normal source of truth, and repo-local config should only be used intentionally.

## Behavior
- default: no implicit fallback to `cwd/config` or `exe-relative config`
- opt-in: set `MASC_ALLOW_REPO_CONFIG_FALLBACK=true` to restore the old repo-config heuristic
- unchanged: explicit `MASC_CONFIG_DIR` still wins, and `MASC_BASE_PATH/.masc/config` / `~/.masc/config` still resolve normally

## Validation
- `git diff --check`
- `env -u MASC_CONFIG_DIR -u MASC_PERSONAS_DIR dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/config-root-optin --build-dir /tmp/dune-config-root-lib lib/config_dir_resolver.pp.ml`
- note: `test_config_dir_resolver.exe` full local build was slow in this environment and timed out under wrapper without surfacing OCaml errors; CI should cover the full executable build
