### PR TITLE
test(keeper): restore keepalive listing expectation

### DIFF
--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -141,7 +141,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
         [ "dot.name"; "sangsu" ] names;
       let keepalive_names = Keeper_types.keepalive_keeper_names config in
       check (list string) "keepalive_keeper_names filters sidecars"
-        [ "dot.name"; "sangsu" ] keepalive_names;
+        [ "sangsu" ] keepalive_names;
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
         Keeper_status.handle_keeper_list ctx (`Assoc [ ("limit", `Int 10) ])


### PR DESCRIPTION
## Summary
- restore `test_keeper_meta_listing` to expect only configured keepers in `keepalive_keeper_names`
- keep the sidecar filtering assertion on `keeper_names` and status listing unchanged

## Product impact
- fixes a merged quick-suite regression that is currently blocking unrelated PRs from going green

## Evidence
- `env -u MASC_BASE_PATH -u MASC_CONFIG_DIR -u MASC_PERSONAS_DIR opam exec -- dune exec --root . ./test/test_keeper_meta_listing.exe -- -v`
- `git diff --check`

## Review evidence
- GLM-5.1 via `sb glm-text --no-thinking`: No findings.

## Linked issue
- Fixes #6877