### PR TITLE
chore(release): bump version to 0.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.5.11] - 2026-04-13
+
+### Changed
+- Replace all `Eio.traceln` in `lib/` with structured `Log` module
+  calls (cascade_inference, autoresearch_codegen, dashboard judges,
+  opentelemetry_client). Zero ad-hoc traceln calls remain.
+- Add relay calibration drift metric: warn on correction_factor
+  outside [0.5, 1.5], debug on shift > 0.1.
+
 ## [0.5.10] - 2026-04-13
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.17)
 
 (name masc_mcp)
-(version 0.5.10)
+(version 0.5.11)
 
 (generate_opam_files true)
 (implicit_transitive_deps false)


### PR DESCRIPTION
## Summary
- Bump dune-project version 0.5.10 -> 0.5.11
- CHANGELOG entry for structured logging migration and relay calibration drift metric

Changes from the previous PR #6860 (Eio.traceln migration + relay calibration) were already merged to main. This PR adds the version bump.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)