### PR TITLE
fix(cascade): allow CompletionContractViolation to cascade to next provider

### DIFF
--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -166,7 +166,9 @@ let config_for_label
   }
 
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
-    Only API-level errors are cascadeable; agent/config errors are not. *)
+    API-level errors and model-capability-dependent agent errors are
+    cascadeable (a different provider may succeed).  Structural agent
+    errors (budget, idle, exit) are not — they would recur on any model. *)
 let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
     : Llm_provider.Cascade_fsm.provider_outcome option =
   match err with
@@ -189,6 +191,17 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
         Llm_provider.Http_client.NetworkError { message }
     in
     Some (Llm_provider.Cascade_fsm.Call_err http_err)
+  (* Model-capability errors: the next provider may handle these.
+     CompletionContractViolation: model returned text when tool_use was
+     required — a different model with better tool calling may succeed.
+     UnrecognizedStopReason: model returned a non-standard stop reason
+     that this provider does not map — another provider may not. *)
+  | Oas.Error.Agent (Oas.Error.CompletionContractViolation { reason; _ }) ->
+    Some (Llm_provider.Cascade_fsm.Call_err
+      (Llm_provider.Http_client.AcceptRejected { reason }))
+  | Oas.Error.Agent (Oas.Error.UnrecognizedStopReason { reason }) ->
+    Some (Llm_provider.Cascade_fsm.Call_err
+      (Llm_provider.Http_client.AcceptRejected { reason }))
   | _ -> None
 
 (** Run a single Agent.run() call with MASC-driven cascade model fallback.


### PR DESCRIPTION
## Summary
- `sdk_error_to_cascade_outcome`이 `CompletionContractViolation`과 `UnrecognizedStopReason`을 non-cascadeable로 분류하여, GLM text-only 응답 시 Ollama fallthrough가 차단되던 버그 수정
- 두 에러를 `AcceptRejected`로 매핑하여 cascade FSM이 다음 provider를 시도하도록 변경
- 구조적 agent 에러(budget, idle, exit)는 기존대로 non-cascadeable 유지

## Root Cause
Gate 메시지 → keeper → `keeper_unified` cascade에서:
1. GLM-coding이 `supports_tool_choice=true` → contract = `Require_tool_use`
2. GLM이 text만 반환 → `CompletionContractViolation` (Agent error)
3. `sdk_error_to_cascade_outcome`이 Agent error를 `None` 반환 → "not cascadeable"
4. Ollama를 시도하지 않고 즉시 실패

## Change
`lib/oas_worker_named.ml`: `sdk_error_to_cascade_outcome`에 2개 패턴 추가 (+14/-1 lines)

## Test plan
- [ ] `dune build` 성공 (타입 체크 통과)
- [ ] CI 테스트 통과
- [ ] Gate에서 janitor keeper에 메시지 전송 → Ollama fallthrough 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)