### PR TITLE
fix(test): add missing TOML config for dot.name in keeper_meta_listing test

### DIFF
--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -119,6 +119,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
       write_keeper_toml_exn config ~name:"sangsu";
+      write_keeper_toml_exn config ~name:"dot.name";
       Config_dir_resolver.reset ();
       write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu";
       write_keeper_meta_exn config ~name:"dot.name" ~trace_id:"trace-dot-name";


### PR DESCRIPTION
## Summary

- `test_keeper_meta_listing` regressed after #6870 because `keepalive_keeper_names` now sources from `configured_keeper_names` (TOML-based discovery) instead of `persisted_keeper_names` (JSON meta-based)
- The test created a meta JSON for `dot.name` but no corresponding TOML config, so it was invisible to the new implementation
- Added `write_keeper_toml_exn config ~name:"dot.name"` to match the existing `sangsu` fixture pattern

## Test plan

- [x] `dune exec test/test_keeper_meta_listing.exe` — all 4 tests pass
- [x] No production code changes — test fixture only

Closes #6877
Closes #6874

🤖 Generated with [Claude Code](https://claude.com/claude-code)