### PR TITLE
[codex] Fix repo fallback CI regressions and refresh OAS pin

### DIFF
--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -142,7 +142,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
         [ "dot.name"; "sangsu" ] names;
       let keepalive_names = Keeper_types.keepalive_keeper_names config in
       check (list string) "keepalive_keeper_names filters sidecars"
-        [ "sangsu" ] keepalive_names;
+        [ "dot.name"; "sangsu" ] keepalive_names;
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
         Keeper_status.handle_keeper_list ctx (`Assoc [ ("limit", `Int 10) ])

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -836,7 +836,7 @@ let test_create_server_state_preserves_raw_input_base_path () =
       Alcotest.(check string) "normalized env remains effective workspace root"
         dir (Sys.getenv "MASC_BASE_PATH"))
 
-let test_prompt_markdown_dir_falls_back_to_resolved_config_dir () =
+let test_prompt_markdown_dir_falls_back_to_resolved_config_dir_with_repo_fallback_opt_in () =
   with_temp_dir "startup-prompts" (fun dir ->
       let config_root = Filename.concat dir "config" in
       let expected = Filename.concat config_root "prompts" in
@@ -845,6 +845,7 @@ let test_prompt_markdown_dir_falls_back_to_resolved_config_dir () =
       write_file (Filename.concat config_root "tool_policy.toml")
         "[groups.base]\ntools = [\"keeper_time_now\"]\n[presets.minimal]\ngroups = [\"base\"]\n";
       with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_ALLOW_REPO_CONFIG_FALLBACK" (Some "true") @@ fun () ->
       with_cwd dir @@ fun () ->
       Config_dir_resolver.reset ();
       let resolved =
@@ -1044,8 +1045,10 @@ let () =
           Alcotest.test_case
             "create_server_state preserves raw input base path"
             `Quick test_create_server_state_preserves_raw_input_base_path;
-          Alcotest.test_case "prompt markdown dir falls back to resolved config dir"
-            `Quick test_prompt_markdown_dir_falls_back_to_resolved_config_dir;
+          Alcotest.test_case
+            "prompt markdown dir falls back to resolved config dir with repo fallback opt-in"
+            `Quick
+            test_prompt_markdown_dir_falls_back_to_resolved_config_dir_with_repo_fallback_opt_in;
           Alcotest.test_case "prompt markdown dir honors MASC_CONFIG_DIR override"
             `Quick test_prompt_markdown_dir_honors_masc_config_dir_override;
           Alcotest.test_case

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -858,6 +858,33 @@ let test_prompt_markdown_dir_falls_back_to_resolved_config_dir_with_repo_fallbac
       Alcotest.(check string) "temp room falls back to resolved prompt dir"
         (canonical_path expected) (canonical_path resolved))
 
+let test_prompt_markdown_dir_does_not_use_repo_fallback_without_opt_in () =
+  with_temp_dir "startup-prompts-no-opt-in" (fun dir ->
+      let config_root = Filename.concat dir "config" in
+      let repo_prompts = Filename.concat config_root "prompts" in
+      let home = Filename.concat dir "home" in
+      let expected = Filename.concat home ".masc/config/prompts" in
+      Fs_compat.mkdir_p repo_prompts;
+      write_file (Filename.concat config_root "cascade.json") "{}";
+      write_file (Filename.concat config_root "tool_policy.toml")
+        "[groups.base]\ntools = [\"keeper_time_now\"]\n[presets.minimal]\ngroups = [\"base\"]\n";
+      Fs_compat.mkdir_p home;
+      with_env "HOME" (Some home) @@ fun () ->
+      with_env "MASC_CONFIG_DIR" None @@ fun () ->
+      with_env "MASC_ALLOW_REPO_CONFIG_FALLBACK" None @@ fun () ->
+      with_cwd dir @@ fun () ->
+      Config_dir_resolver.reset ();
+      let resolved =
+        Fun.protect
+          ~finally:(fun () -> Config_dir_resolver.reset ())
+          (fun () ->
+             Prompt_defaults.resolve_prompt_markdown_dir
+               ~workspace_path:dir ~base_path:dir)
+      in
+      Alcotest.(check string)
+        "temp room keeps resolved default prompt dir without repo fallback opt-in"
+        expected resolved)
+
 let test_prompt_markdown_dir_honors_masc_config_dir_override () =
   with_temp_dir "startup-prompts-override" (fun dir ->
       let workspace_prompts = Filename.concat dir "config/prompts" in
@@ -1049,6 +1076,10 @@ let () =
             "prompt markdown dir falls back to resolved config dir with repo fallback opt-in"
             `Quick
             test_prompt_markdown_dir_falls_back_to_resolved_config_dir_with_repo_fallback_opt_in;
+          Alcotest.test_case
+            "prompt markdown dir does not use repo fallback without opt-in"
+            `Quick
+            test_prompt_markdown_dir_does_not_use_repo_fallback_without_opt_in;
           Alcotest.test_case "prompt markdown dir honors MASC_CONFIG_DIR override"
             `Quick test_prompt_markdown_dir_honors_masc_config_dir_override;
           Alcotest.test_case


### PR DESCRIPTION
## What changed
- align `test_keeper_meta_listing` with current `keepalive_keeper_names` behavior for configured dotted keeper names
- update prompt markdown fallback coverage to require `MASC_ALLOW_REPO_CONFIG_FALLBACK=true` for repo-local `config/` resolution
- add an explicit bootstrap regression test proving repo-local prompt fallback stays disabled by default
- refresh `scripts/oas-agent-sdk-pin.sh` to the merged OAS commit that actually publishes `agent_sdk` version `0.131.0`
- sync generated OAS pin doc blocks to the merged runtime pin

## Why
Two separate CI blockers stacked on top of each other:
1. `#6876` changed repo-config fallback behavior, but `Build and Test` still had stale expectations in `test_keeper_meta_listing` and `test_server_runtime_bootstrap`.
2. `#6884` raised the OAS floor to `0.131.0`, but OAS itself was still publishing `agent_sdk.opam` as `0.130.0` until OAS PR `jeong-sik/oas#883` fixed the source of truth. This PR now pins masc-mcp to that merged OAS commit.

## Validation
- `git diff --check origin/main...HEAD`
- `env -u MASC_CONFIG_DIR -u MASC_PERSONAS_DIR dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/config-root-optin --build-dir /tmp/dune-pr6876-fix-bootstrap ./test/test_server_runtime_bootstrap.exe`
- `env -u MASC_CONFIG_DIR -u MASC_PERSONAS_DIR dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/config-root-optin --build-dir /tmp/dune-pr6876-fix-keeper4 ./test/test_keeper_meta_listing.exe`
- `bash scripts/sync-oas-pin-docs.sh --check`
- `bash ci/check-oas-pin.sh`

## Context
- follow-up for merged PR `#6876`
- depends on merged OAS fix `jeong-sik/oas#883`
