### PR TITLE
feat(memory): wire 4 dead memory subsystems to production

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1754,7 +1754,38 @@ let run_turn
                "keeper:%s memory_write failed: %s"
                meta.name
                (Printexc.to_string exn));
-          (* Phase 2: Post-turn quality metrics — goal alignment + memory recall.
+          (* Episodic memory: create OAS episode from [STATE] snapshot.
+             Populates Memory.t so flush_episodes (AfterTurn hook)
+             persists to institution_episodes.jsonl. *)
+          (try
+             (match
+                Keeper_memory_policy.parse_state_snapshot_from_reply
+                  response_text
+              with
+             | Some snap ->
+               Memory_oas_bridge.store_episode_from_snapshot ~memory
+                 ~keeper_name:meta.name ~turn:result.turns
+                 ~trace_id:
+                   (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                 snap
+             | None -> ())
+           with exn ->
+             Log.Keeper.warn "keeper:%s episode_create failed: %s"
+               meta.name (Printexc.to_string exn));
+          (* Memory bank compaction: dedup + consolidate if over threshold. *)
+          (try
+             let compaction =
+               Keeper_memory_bank.compact_memory_bank_if_needed config meta
+             in
+             if compaction.performed then
+               Log.Keeper.info
+                 "keeper:%s memory_compacted before=%d after=%d dropped=%d"
+                 meta.name compaction.before_notes compaction.after_notes
+                 compaction.dropped_notes
+           with exn ->
+             Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
+               (Printexc.to_string exn));
+          (* Post-turn quality metrics — goal alignment + memory recall.
             Logged to decisions.jsonl for feedback loop analysis. *)
           (try
              let goal_score =

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -397,6 +397,71 @@ let institution_episode_of_oas ~(agent_name : string)
     context;
   }
 
+(** Create an OAS episode from a keeper [STATE] snapshot and store it
+    in [Memory.t].  The episode is later flushed to institution JSONL by
+    the AfterTurn hook's [flush_episodes].
+
+    Metadata keys match what [institution_episode_of_oas] expects, so
+    the round-trip Institution_eio -> OAS -> Institution_eio is lossless. *)
+let store_episode_from_snapshot
+    ~(memory : Agent_sdk.Memory.t)
+    ~(keeper_name : string)
+    ~(turn : int)
+    ~(trace_id : string)
+    (snapshot : Keeper_memory_policy.keeper_state_snapshot) : unit =
+  let parts =
+    List.filter_map Fun.id
+      [
+        Option.map (fun g -> "Goal: " ^ g) snapshot.goal;
+        Option.map (fun p -> "Progress: " ^ p) snapshot.progress;
+        Option.map (fun d -> "Done: " ^ d) snapshot.done_summary;
+      ]
+  in
+  let summary =
+    match parts with
+    | [] -> "keeper turn " ^ string_of_int turn
+    | _ -> String.concat "; " parts
+  in
+  let learnings =
+    (snapshot.decisions @ snapshot.constraints)
+    |> List.filter (fun s -> String.trim s <> "")
+  in
+  let outcome_str, outcome =
+    if snapshot.done_summary <> None then
+      ("success", Agent_sdk.Memory.Success summary)
+    else ("partial", Agent_sdk.Memory.Neutral)
+  in
+  let ts = Time_compat.now () in
+  let episode_id =
+    Printf.sprintf "keeper-%s-t%d-%d" keeper_name turn
+      (int_of_float (ts *. 1000.0) mod 1_000_000)
+  in
+  let episode : Agent_sdk.Memory.episode =
+    {
+      id = episode_id;
+      timestamp = ts;
+      participants = [ keeper_name ];
+      action = summary;
+      outcome;
+      salience = 0.6;
+      metadata =
+        [
+          ("event_type", `String "keeper_turn");
+          ("institution_summary", `String summary);
+          ("institution_outcome", `String outcome_str);
+          ( "learnings",
+            `List (List.map (fun l -> `String l) learnings) );
+          ( "context",
+            `Assoc
+              [
+                ("trace_id", `String trace_id);
+                ("turn", `String (string_of_int turn));
+              ] );
+        ];
+    }
+  in
+  Agent_sdk.Memory.store_episode memory episode
+
 let persisted_episode_ids () =
   Hashtbl.copy (load_all_episodes_cached ()).ids
 

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -183,6 +183,26 @@ let () = Room_hooks.relation_on_leave_fn := Relation_materializer.on_agent_leave
 (* Relation materializer — task done *)
 let () = Room_hooks.relation_on_task_done_fn := Relation_materializer.on_task_done
 
+(* Hebbian learning — strengthen on task completion *)
+let () = Room_hooks.hebbian_on_task_done_fn :=
+  (fun config ~assignee ~active_agents ->
+    List.iter (fun peer ->
+      if peer <> assignee then
+        (try Hebbian_eio.strengthen config ~from_agent:assignee ~to_agent:peer ()
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+           Log.Room.warn "hebbian strengthen failed: %s" (Printexc.to_string exn))
+    ) active_agents)
+
+(* Hebbian learning — weaken on task cancellation *)
+let () = Room_hooks.hebbian_on_task_cancelled_fn :=
+  (fun config ~agent_name ~active_agents ->
+    List.iter (fun peer ->
+      if peer <> agent_name then
+        (try Hebbian_eio.weaken config ~from_agent:agent_name ~to_agent:peer ()
+         with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+           Log.Room.warn "hebbian weaken failed: %s" (Printexc.to_string exn))
+    ) active_agents)
+
 let () = Room_hooks.observe_agent_lifecycle_fn :=
   (fun config ~agent_id ~event_kind ~details ->
     observe_agent_lifecycle config ~agent_id ~event_kind ~details)

--- a/lib/room/room_hooks.ml
+++ b/lib/room/room_hooks.ml
@@ -90,6 +90,18 @@ let relation_on_task_done_fn
   : (assignee:string -> active_agents:string list -> unit) ref
   = ref (fun ~assignee:_ ~active_agents:_ -> ())
 
+(** Hebbian learning: strengthen collaboration on task completion. *)
+let hebbian_on_task_done_fn
+  : (Room_utils_backend_setup.config ->
+     assignee:string -> active_agents:string list -> unit) ref
+  = ref (fun _config ~assignee:_ ~active_agents:_ -> ())
+
+(** Hebbian learning: weaken collaboration on task cancellation. *)
+let hebbian_on_task_cancelled_fn
+  : (Room_utils_backend_setup.config ->
+     agent_name:string -> active_agents:string list -> unit) ref
+  = ref (fun _config ~agent_name:_ ~active_agents:_ -> ())
+
 (** Shared observability hook for join/rejoin/leave events.
     Upper layers can mirror state transitions to audit, telemetry, and logs
     without introducing circular dependencies into room sub-modules. *)

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -908,9 +908,12 @@ let complete_task config ~agent_name ~task_id ~notes =
             (* Record task collaboration via hook (async, non-blocking) *)
             (try
                let active = (Room_state.read_state config).active_agents in
-               !Room_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active
+               !Room_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active;
+               (* Hebbian: strengthen collaboration pattern *)
+               !Room_hooks.hebbian_on_task_done_fn config
+                 ~assignee:agent_name ~active_agents:active
              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-               Log.RoomTask.error "relation-materializer task hook error: %s"
+               Log.RoomTask.error "relation/hebbian task hook error: %s"
                  (Printexc.to_string exn));
             Printf.sprintf "✅ %s completed %s" agent_name task_id
           end
@@ -1096,6 +1099,14 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                               -. task_started_at_unix task.task_status)
                              *. 1000.0)))
                      ());
+              (* Hebbian: weaken collaboration pattern on cancellation *)
+              (try
+                 let active = (Room_state.read_state config).active_agents in
+                 !Room_hooks.hebbian_on_task_cancelled_fn config
+                   ~agent_name ~active_agents:active
+               with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+                 Log.RoomTask.error "hebbian task_cancelled hook error: %s"
+                   (Printexc.to_string exn));
               Ok (Printf.sprintf "🚫 %s cancelled %s" agent_name task_id)
             end
       with


### PR DESCRIPTION
## Summary

5-Tier 메모리 시스템 중 4개(Hebbian, Episodes, Compaction)가 코드는 완성이지만 프로덕션 wiring이 누락되어 한 번도 데이터를 생성한 적이 없었음. 142줄의 wiring 코드로 연결.

### Phase 1: Hebbian Learning (3 files)
- `Room_hooks` 콜백 패턴으로 `Hebbian_eio.strengthen`/`weaken`을 task 이벤트에 연결
- task.done → strengthen (에이전트 협업 시냅스 강화)
- task.cancelled → weaken (시냅스 약화)
- `.masc/synapses/graph.json` 첫 task 완료 시 생성

### Phase 2: Episode Creation (1 file)
- `Memory_oas_bridge.store_episode_from_snapshot` 추가
- keeper [STATE] 블록을 OAS episode으로 변환 → Memory.t에 저장
- 기존 AfterTurn hook의 `flush_episodes`가 자동으로 `institution_episodes.jsonl`에 영속화

### Phase 3: Compaction Trigger (1 file)  
- 매 턴 `compact_memory_bank_if_needed` 호출 (내부 size guard로 220노트 이하 시 early return)
- 2단계 통합: trace 내 클러스터링 → cross-trace 패턴 탐지 → long_term 승격

### NOT in scope
- Procedural crystallization (evidence 누적 메커니즘 별도 설계 필요)
- graph.json JSONL 전환 (현재 agent 수로 불필요)
- TLA+ spec (wiring 동작 확인 후)

## Test plan
- [x] `dune build` 통과
- [x] `test_hebbian_eio.exe` 9/9 통과
- [x] `test_memory_oas_5tier.exe` 18/18 통과
- [ ] CI 확인
- [ ] keeper 실행 후 `.masc/synapses/graph.json` 생성 확인
- [ ] keeper 턴 후 `.masc/institution_episodes.jsonl` 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)