### PR TITLE
perf: reorder system prompt for LLM KV cache prefix sharing

### DIFF
--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -29,7 +29,7 @@ type keeper_board_signal = {
 }
 
 type board_sse_event =
-  | Post_created of { post_id : string; author : string; title : string; hearth : string option }
+  | Post_created of { post_id : string; author : string; title : string; content : string; hearth : string option }
   | Comment_added of { post_id : string; comment_id : string; author : string }
   | Post_voted of { post_id : string; voter : string; direction : Board.vote_direction }
   | Comment_voted of { comment_id : string; voter : string; direction : Board.vote_direction }
@@ -172,7 +172,8 @@ let create_post ~author ~content ?title ?body ~post_kind ?meta_json
             };
           emit_board_sse_event
             (Post_created
-               { post_id = pid; author = auth; title = post.title; hearth = post.hearth });
+               { post_id = pid; author = auth; title = post.title;
+                 content = post.content; hearth = post.hearth });
           ok
       | Error _ as err -> err)
 

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -59,14 +59,48 @@ let build_keeper_system_prompt
     if s = "" then ""
     else Printf.sprintf "<persona>\n%s\n</persona>\n\n" s
   in
+  (* Prefix ordering: common blocks first for LLM KV cache sharing.
+     All keepers share the same autonomous-behavior, policy, continuity,
+     and most of <world>/<capabilities> text.  Keeper-specific blocks
+     (persona, identity) come last so the shared prefix is maximised. *)
   String.concat ""
     [
-      persona_block;
-      "<world>\n";
+      (* ── Shared prefix (identical across all keepers) ────────── *)
+      "Autonomous behavior:\n\
+       - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
+       - On proactive turns: if you need fresh board context, call keeper_board_list first. Otherwise act directly on your current goal and use board tools only when they help.\n\
+       - If no Board activity and no tasks: you may call keeper_board_list to observe, but do not block a productive action on a board scan. Do NOT fabricate activity.\n\
+       - ANTI-POLLING: Do NOT call masc_status or keeper_tasks_list more than once per session unless you received genuinely new information. These are observation tools, not work.\n\
+       - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.\n\
+       - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands), keeper_github (PR/issues), keeper_pr_submit (submit staged changes from a playground clone or repo worktree), keeper_pr_workflow (legacy one-shot worktree helper), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit, keeper_bash, or the appropriate PR submit path.\n\
+       - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST call keeper_task_done when finished. Claim -> Work -> Done. Every claimed task must be closed. Leaving tasks open creates zombie tasks.\n\
+       - You do not need permission to act. You live here.\n\
+       When someone asks you a question:\n\
+       - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\
+       - If you can answer from conversation context alone, respond directly.\n\
+       \n\
+       ";
+      profile_policy;
+      "\n\
+       \n\
+       <continuity>\n\
+       Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.\n\
+       When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE].\n";
+      keeper_constitution ();
+      "\n\
+       </continuity>\n\
+       \n\
+       <world>\n";
       substitute_keeper_name (Prompt_registry.get_prompt Keeper_prompt_names.world);
       "\n</world>\n\
        \n\
-       <identity>\n\
+       <capabilities>\n";
+      substitute_keeper_name (Prompt_registry.get_prompt Keeper_prompt_names.capabilities);
+      "\n</capabilities>\n\
+       \n\
+       ";
+      persona_block;
+      "<identity>\n\
        Goal: ";
       goal;
       "\n\
@@ -91,35 +125,7 @@ let build_keeper_system_prompt
        ";
       custom;
       "\n\
-       </identity>\n\
-       \n\
-       Autonomous behavior:\n\
-       - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
-       - On proactive turns: if you need fresh board context, call keeper_board_list first. Otherwise act directly on your current goal and use board tools only when they help.\n\
-       - If no Board activity and no tasks: you may call keeper_board_list to observe, but do not block a productive action on a board scan. Do NOT fabricate activity.\n\
-       - ANTI-POLLING: Do NOT call masc_status or keeper_tasks_list more than once per session unless you received genuinely new information. These are observation tools, not work.\n\
-       - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.\n\
-       - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands), keeper_github (PR/issues), keeper_pr_submit (submit staged changes from a playground clone or repo worktree), keeper_pr_workflow (legacy one-shot worktree helper), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit, keeper_bash, or the appropriate PR submit path.\n\
-       - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST call keeper_task_done when finished. Claim -> Work -> Done. Every claimed task must be closed. Leaving tasks open creates zombie tasks.\n\
-       - You do not need permission to act. You live here.\n\
-       When someone asks you a question:\n\
-       - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\
-       - If you can answer from conversation context alone, respond directly.\n\
-       \n\
-       <capabilities>\n";
-      substitute_keeper_name (Prompt_registry.get_prompt Keeper_prompt_names.capabilities);
-      "\n</capabilities>\n\
-       \n\
-       ";
-      profile_policy;
-      "\n\
-       \n\
-       <continuity>\n\
-       Continuity and any end-of-reply STATE formatting requirements apply unless a more specific turn-level mode or output guard disables them.\n\
-       When <direct_reply_mode> is present, follow it instead: do not emit SKILL:, SKILL_REASON:, or [STATE].\n";
-      keeper_constitution ();
-      "\n\
-       </continuity>";
+       </identity>";
     ]
 
 let append_direct_reply_mode_prompt ~(base_prompt : string) : string =

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -78,7 +78,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       signal);
   Board_dispatch.set_board_sse_hook (fun event ->
     let params = match event with
-      | Board_dispatch.Post_created { post_id; author; title; hearth } ->
+      | Board_dispatch.Post_created { post_id; author; title; hearth; _ } ->
           let base = [("type", `String "post_created");
                       ("post_id", `String post_id);
                       ("author", `String author);
@@ -108,7 +108,43 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       ("jsonrpc", `String "2.0");
       ("method", `String "notifications/board");
       ("params", params)
-    ]));
+    ]);
+    (* Emit activity event so Discord/external connectors can detect board posts *)
+    let activity_kind, activity_actor, activity_subject, activity_payload = match event with
+      | Board_dispatch.Post_created { post_id; author; title; content; hearth } ->
+          let base = [("post_id", `String post_id); ("title", `String title);
+                      ("content", `String content); ("author", `String author)] in
+          let payload_fields = match hearth with
+            | Some h -> ("hearth", `String h) :: base
+            | None -> base
+          in
+          ("board.posted",
+           Activity_graph.entity ~kind:"agent" author,
+           Some (Activity_graph.entity ~kind:"post" post_id),
+           `Assoc payload_fields)
+      | Board_dispatch.Comment_added { post_id; comment_id; author } ->
+          ("board.commented",
+           Activity_graph.entity ~kind:"agent" author,
+           Some (Activity_graph.entity ~kind:"post" post_id),
+           `Assoc [("post_id", `String post_id); ("comment_id", `String comment_id);
+                   ("author", `String author)])
+      | Board_dispatch.Post_voted { post_id; voter; direction } ->
+          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          ("board.voted",
+           Activity_graph.entity ~kind:"agent" voter,
+           Some (Activity_graph.entity ~kind:"post" post_id),
+           `Assoc [("post_id", `String post_id); ("direction", `String dir)])
+      | Board_dispatch.Comment_voted { comment_id; voter; direction } ->
+          let dir = match direction with Board.Up -> "up" | Board.Down -> "down" in
+          ("board.voted",
+           Activity_graph.entity ~kind:"agent" voter,
+           Some (Activity_graph.entity ~kind:"comment" comment_id),
+           `Assoc [("comment_id", `String comment_id); ("direction", `String dir)])
+    in
+    ignore (Activity_graph.emit state.room_config
+      ~actor:activity_actor ?subject:activity_subject
+      ~kind:activity_kind ~payload:activity_payload
+      ~tags:["board"; activity_kind] ()));
   (* Wire broadcast → keeper wakeup: any broadcast wakes keepers so they
      can react to new tasks, mentions, or room activity immediately.
      Room_state.on_broadcast_mention is the active path (Room.broadcast uses

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -107,6 +107,7 @@ class GateBot(discord.Client):
         self._last_gate_health_at = ""
         self._last_ready_at = ""
         self._status_task: asyncio.Task[None] | None = None
+        self._activity_task: asyncio.Task[None] | None = None
         self._write_runtime_status(connected_override=False)
 
     async def setup_hook(self) -> None:
@@ -119,11 +120,19 @@ class GateBot(discord.Client):
         self.tree.add_command(keeper_audit)  # pyright: ignore[reportUnknownArgumentType]
         await self.tree.sync()
         self._status_task = asyncio.create_task(self._status_heartbeat_loop())
+        self._activity_task = asyncio.create_task(self._activity_subscriber_loop())
         self._write_runtime_status()
         logger.info("Slash commands synced")
 
     async def close(self) -> None:
         """Release resources on shutdown."""
+        if self._activity_task is not None:
+            self._activity_task.cancel()
+            try:
+                await self._activity_task
+            except asyncio.CancelledError:
+                pass
+            self._activity_task = None
         if self._status_task is not None:
             self._status_task.cancel()
             try:
@@ -286,6 +295,102 @@ class GateBot(discord.Client):
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.warning("Discord status heartbeat failed: %s", exc)
             await asyncio.sleep(interval)
+
+    def _channels_for_keeper(self, keeper_name: str) -> list[int]:
+        """Return Discord channel IDs bound to the given keeper."""
+        self._maybe_reload_bindings()
+        return [
+            int(ch_id)
+            for ch_id, name in self.keeper_bindings.items()
+            if name == keeper_name
+        ]
+
+    async def _activity_subscriber_loop(self) -> None:
+        """Poll MASC activity events and push keeper board posts to Discord."""
+        poll_interval = 10  # seconds
+        last_seq = 0
+        # Start from current high-water mark to avoid replaying old events
+        try:
+            events = await self.gate.poll_activity(
+                kinds=["board.commented"],
+                limit=1,
+            )
+            if events:
+                last_seq = max(int(e.get("seq", 0)) for e in events)
+                logger.info("Activity poller starting from seq %d", last_seq)
+        except Exception:  # pragma: no cover
+            pass
+
+        while True:
+            try:
+                events = await self.gate.poll_activity(
+                    after_seq=last_seq,
+                    kinds=["board.commented"],
+                    limit=50,
+                )
+                for event in events:
+                    seq = int(event.get("seq", 0))
+                    if seq > last_seq:
+                        last_seq = seq
+                    await self._handle_activity_event(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Activity poller error: %s", exc)
+            await asyncio.sleep(poll_interval)
+
+    async def _handle_activity_event(self, event: dict[str, Any]) -> None:
+        """Forward a board event to bound Discord channels."""
+        kind = str(event.get("kind", ""))
+        actor_info = event.get("actor", {})
+        if not isinstance(actor_info, dict):
+            return
+        actor_id = str(actor_info.get("id", ""))
+
+        payload = event.get("payload", {})
+        if not isinstance(payload, dict):
+            return
+
+        # Only forward keeper-originated board events
+        if not actor_id.startswith("keeper-"):
+            return
+
+        # Extract keeper name from actor id (e.g., "keeper-sangsu-agent" -> "sangsu")
+        keeper_name = actor_id
+
+        channels = self._channels_for_keeper(keeper_name)
+        if not channels:
+            return
+
+        # Build a concise message from the event
+        text = self._format_board_event(kind, keeper_name, payload)
+        if not text:
+            return
+
+        for ch_id in channels:
+            channel = self.get_channel(ch_id)
+            if channel is None:
+                try:
+                    channel = await self.fetch_channel(ch_id)
+                except discord.HTTPException:
+                    continue
+            if isinstance(channel, discord.abc.Messageable):
+                try:
+                    await channel.send(text[:2000])
+                except discord.HTTPException as exc:
+                    logger.warning("Failed to push to channel %s: %s", ch_id, exc)
+
+    def _format_board_event(
+        self,
+        kind: str,
+        keeper_name: str,
+        payload: dict[str, Any],
+    ) -> str:
+        """Format a board event as a Discord message."""
+        content = str(payload.get("content", ""))
+        if not content:
+            return ""
+        return strip_state_blocks(content)
 
     def is_admin(self, interaction: discord.Interaction) -> bool:
         member = interaction.user

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -296,13 +296,29 @@ class GateBot(discord.Client):
                 logger.warning("Discord status heartbeat failed: %s", exc)
             await asyncio.sleep(interval)
 
+    @staticmethod
+    def _normalize_keeper_name(raw: str) -> str:
+        """Normalize keeper name for matching.
+
+        Board authors use 'keeper-sangsu', bindings use 'keeper-sangsu-agent'.
+        Strip the '-agent' suffix and 'keeper-' prefix to get the bare name,
+        then compare bare names.
+        """
+        name = raw.strip().lower()
+        if name.endswith("-agent"):
+            name = name[: -len("-agent")]
+        if name.startswith("keeper-"):
+            name = name[len("keeper-") :]
+        return name
+
     def _channels_for_keeper(self, keeper_name: str) -> list[int]:
         """Return Discord channel IDs bound to the given keeper."""
         self._maybe_reload_bindings()
+        normalized = self._normalize_keeper_name(keeper_name)
         return [
             int(ch_id)
             for ch_id, name in self.keeper_bindings.items()
-            if name == keeper_name
+            if self._normalize_keeper_name(name) == normalized
         ]
 
     async def _activity_subscriber_loop(self) -> None:

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -312,7 +312,7 @@ class GateBot(discord.Client):
         # Start from current high-water mark to avoid replaying old events
         try:
             events = await self.gate.poll_activity(
-                kinds=["board.commented"],
+                kinds=["board.posted", "board.commented"],
                 limit=1,
             )
             if events:
@@ -325,7 +325,7 @@ class GateBot(discord.Client):
             try:
                 events = await self.gate.poll_activity(
                     after_seq=last_seq,
-                    kinds=["board.commented"],
+                    kinds=["board.posted", "board.commented"],
                     limit=50,
                 )
                 for event in events:

--- a/sidecars/shared/gate_shared/gate_client_base.py
+++ b/sidecars/shared/gate_shared/gate_client_base.py
@@ -417,3 +417,45 @@ class GateClientBase:
             self._note_transport_failure(f"stream http error: {e}")
         except Exception as e:  # pragma: no cover
             self._note_transport_failure(f"stream error: {e}")
+
+    # ── Activity Polling ─────────────────────────────────
+
+    async def poll_activity(
+        self,
+        *,
+        after_seq: int = 0,
+        kinds: list[str] | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Poll recent activity events from the replay API.
+
+        Returns events with seq > after_seq.  Caller tracks the
+        high-water seq for incremental polling.
+        """
+        client = self._get_client()
+        base = self._message_url.rsplit("/api/", 1)[0]
+        url = f"{base}/api/v1/activity/events"
+
+        params: dict[str, str | int] = {
+            "after_seq": after_seq,
+            "limit": limit,
+        }
+        if kinds:
+            params["kinds"] = ",".join(kinds)
+
+        try:
+            resp = await client.get(
+                url,
+                params=params,
+                timeout=httpx.Timeout(timeout=10.0, connect=5.0),
+            )
+            if resp.status_code >= 400:
+                return []
+            data: object = resp.json()
+            if isinstance(data, dict):
+                events = data.get("events", [])
+                if isinstance(events, list):
+                    return [cast(dict[str, Any], e) for e in events if isinstance(e, dict)]
+        except Exception as e:  # pragma: no cover
+            logger.warning("Activity poll error: %s", e)
+        return []


### PR DESCRIPTION
## Summary
- keeper system prompt에서 공통 블록(autonomous behavior, policy, continuity, constitution)을 앞으로, keeper별 블록(persona, identity)을 뒤로 재배치
- Ollama가 10개 keeper를 동시 서빙할 때 공유 prefix(~800+ tokens)의 KV cache를 재사용 가능
- 기존에는 persona_block이 맨 앞이라 첫 토큰부터 keeper마다 달라 매번 full prefill

## Before / After
```
Before: <persona>(다름) → <world> → <identity>(다름) → autonomous(공통) → ...
After:  autonomous(공통) → policy(공통) → <continuity>(공통) → <world> → ... → <persona>(다름) → <identity>(다름)
```

## Test plan
- [x] `dune build --root .` 성공
- [x] `test_keeper_unified.exe` 158 tests pass
- [x] `test_prompt_registry_defaults.exe` 11 tests pass
- [ ] Ollama KV cache hit rate 실측 비교 (deploy 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)