### PR TITLE
[codex] Isolate inherited config env in test executables

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -42,6 +42,54 @@ let trim_opt = Env_config_core.trim_opt
 let existing_dir = Env_config_core.existing_dir
 let existing_file = Env_config_core.existing_file
 
+let running_under_test_executable executable_name =
+  executable_name
+  |> Filename.basename
+  |> String.lowercase_ascii
+  |> String.starts_with ~prefix:"test_"
+
+let allow_inherited_test_config_paths () =
+  Env_config_core.get_bool ~default:false
+    "MASC_TEST_ALLOW_INHERITED_CONFIG_PATHS"
+
+let initial_env_config_dir = Env_config_core.config_dir_opt ()
+let initial_env_personas_dir = Env_config_core.personas_dir_opt ()
+let initial_env_home = Sys.getenv_opt "HOME" |> trim_opt
+
+let sanitize_inherited_test_env_opt ~running_under_test_executable ~allow_inherited
+    ~initial ~current =
+  if running_under_test_executable && not allow_inherited then
+    match current, initial with
+    | Some current_value, Some initial_value
+      when String.equal current_value initial_value -> None
+    | _ -> current
+  else
+    current
+
+let current_env_config_dir_opt () =
+  sanitize_inherited_test_env_opt
+    ~running_under_test_executable:
+      (running_under_test_executable Sys.executable_name)
+    ~allow_inherited:(allow_inherited_test_config_paths ())
+    ~initial:initial_env_config_dir
+    ~current:(Env_config_core.config_dir_opt ())
+
+let current_env_personas_dir_opt () =
+  sanitize_inherited_test_env_opt
+    ~running_under_test_executable:
+      (running_under_test_executable Sys.executable_name)
+    ~allow_inherited:(allow_inherited_test_config_paths ())
+    ~initial:initial_env_personas_dir
+    ~current:(Env_config_core.personas_dir_opt ())
+
+let current_env_home_opt () =
+  sanitize_inherited_test_env_opt
+    ~running_under_test_executable:
+      (running_under_test_executable Sys.executable_name)
+    ~allow_inherited:(allow_inherited_test_config_paths ())
+    ~initial:initial_env_home
+    ~current:(Sys.getenv_opt "HOME" |> trim_opt)
+
 let absolute_path path =
   if Filename.is_relative path then Filename.concat (Sys.getcwd ()) path else path
 
@@ -237,9 +285,9 @@ let inputs_from_env () =
     cwd = Sys.getcwd ();
     executable_name = Sys.executable_name;
     env_base_path = Env_config_core.base_path_opt ();
-    env_config_dir = Env_config_core.config_dir_opt ();
-    env_personas_dir = Env_config_core.personas_dir_opt ();
-    env_home = Sys.getenv_opt "HOME";
+    env_config_dir = current_env_config_dir_opt ();
+    env_personas_dir = current_env_personas_dir_opt ();
+    env_home = current_env_home_opt ();
   }
 
 let resolve_with inputs =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -98,7 +98,7 @@ let rec copy_missing_tree ~src ~dst =
 
 let bootstrap_base_path_config_root ~base_path =
   let base_path = Env_config_core.normalize_masc_base_path_input base_path in
-  if Option.is_some (Env_config_core.config_dir_opt ()) then
+  if Option.is_some (Config_dir_resolver.current_env_config_dir_opt ()) then
     ()
   else
     let config_root =
@@ -131,9 +131,9 @@ let startup_config_resolution ~base_path =
         cwd = Sys.getcwd ();
         executable_name = Sys.executable_name;
         env_base_path = Some base_path;
-        env_config_dir = Env_config_core.config_dir_opt ();
-        env_personas_dir = Env_config_core.personas_dir_opt ();
-        env_home = Sys.getenv_opt "HOME";
+        env_config_dir = Config_dir_resolver.current_env_config_dir_opt ();
+        env_personas_dir = Config_dir_resolver.current_env_personas_dir_opt ();
+        env_home = Config_dir_resolver.current_env_home_opt ();
       }
 
 (* GC tuning for long-running server with bursty allocation.

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -75,6 +75,35 @@ let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir
       env_home;
     }
 
+let test_sanitize_inherited_test_env_opt_drops_inherited_value () =
+  let actual =
+    Lib.Config_dir_resolver.sanitize_inherited_test_env_opt
+      ~running_under_test_executable:true ~allow_inherited:false
+      ~initial:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
+      ~current:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
+  in
+  check (option string) "same inherited value ignored" None actual
+
+let test_sanitize_inherited_test_env_opt_keeps_runtime_override () =
+  let actual =
+    Lib.Config_dir_resolver.sanitize_inherited_test_env_opt
+      ~running_under_test_executable:true ~allow_inherited:false
+      ~initial:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
+      ~current:(Some "/tmp/test-config-root")
+  in
+  check (option string) "runtime override preserved"
+    (Some "/tmp/test-config-root") actual
+
+let test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in () =
+  let actual =
+    Lib.Config_dir_resolver.sanitize_inherited_test_env_opt
+      ~running_under_test_executable:true ~allow_inherited:true
+      ~initial:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
+      ~current:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
+  in
+  check (option string) "opt-in preserves inherited value"
+    (Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config") actual
+
 let test_env_override_valid () =
   with_temp_dir "config-dir-env" @@ fun root ->
   let config = make_config_root root in
@@ -307,5 +336,14 @@ let () =
             test_personas_dirs_env_override_is_sole_source;
           test_case "ignores base_path .masc/personas fallback" `Quick
             test_personas_dirs_ignores_base_path_fallback;
+        ] );
+      ( "test_env_sanitization",
+        [
+          test_case "drops inherited config env by default" `Quick
+            test_sanitize_inherited_test_env_opt_drops_inherited_value;
+          test_case "keeps runtime override" `Quick
+            test_sanitize_inherited_test_env_opt_keeps_runtime_override;
+          test_case "opt-in preserves inherited value" `Quick
+            test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in;
         ] );
     ]


### PR DESCRIPTION
## Summary
- ignore inherited `MASC_CONFIG_DIR`, `MASC_PERSONAS_DIR`, and `HOME` in test executables unless the test explicitly opts in
- route server bootstrap config resolution through the same sanitized config env helpers
- keep `test_keeper_meta_listing` hermetic by treating `dot.name` as JSON-only fixture again

## Verification
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_config_dir_resolver.exe`
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_server_runtime_bootstrap.exe`
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_keeper_meta_listing.exe`
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_keeper_runtime_config_ssot.exe`
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_keeper_runtime_denylist.exe`
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_worker_runtime.exe`
- `env MASC_BASE_PATH=/Users/dancer/me MASC_CONFIG_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config MASC_PERSONAS_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config/personas _build/default/test/test_keeper_tool_policy_config.exe`