### PR TITLE
fix(test): resolve Config_dir_resolver global state leak in keeper_meta_listing

### DIFF
--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -112,6 +112,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
+      Config_dir_resolver.reset ();
       Keeper_registry.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
@@ -120,6 +121,8 @@ let test_keeper_listing_ignores_sidecar_json_files () =
       ignore (Room.init config ~agent_name:(Some "operator"));
       write_keeper_toml_exn config ~name:"sangsu";
       write_keeper_toml_exn config ~name:"dot.name";
+      let config_root = Filename.concat (Room.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
       Config_dir_resolver.reset ();
       write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu";
       write_keeper_meta_exn config ~name:"dot.name" ~trace_id:"trace-dot-name";
@@ -142,7 +145,7 @@ let test_keeper_listing_ignores_sidecar_json_files () =
         [ "dot.name"; "sangsu" ] names;
       let keepalive_names = Keeper_types.keepalive_keeper_names config in
       check (list string) "keepalive_keeper_names filters sidecars"
-        [ "sangsu" ] keepalive_names;
+        [ "dot.name"; "sangsu" ] keepalive_names;
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
         Keeper_status.handle_keeper_list ctx (`Assoc [ ("limit", `Int 10) ])
@@ -261,10 +264,12 @@ let test_dashboard_ignores_fileless_unsafe_manual_reconcile_fallback () =
 let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
   Eio.Switch.run @@ fun _sw ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
+      Config_dir_resolver.reset ();
       Keeper_registry.clear ();
       Keeper_runtime.reset_test_state base_dir;
       cleanup_dir base_dir)
@@ -272,6 +277,8 @@ let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
       write_keeper_toml_exn config ~name:"sangsu";
+      let config_root = Filename.concat (Room.masc_root_dir config) "config" in
+      Unix.putenv "MASC_CONFIG_DIR" config_root;
       Config_dir_resolver.reset ();
       write_keeper_meta_exn
         ~autoboot_enabled:false config ~name:"sangsu" ~trace_id:"trace-sangsu";


### PR DESCRIPTION
## Summary

- `keepalive_keeper_names` 및 `bootable_keeper_names` 테스트의 flaky 근본 원인 수정
- `configured_keeper_names`가 `Config_dir_resolver.keepers_dir()` (전역 싱글톤)을 사용해서 테스트 temp dir가 아닌 실제 `config/keepers/`를 읽는 문제
- PR #6885의 surface-level fix (dot.name TOML 추가)로는 해결되지 않았고, 오히려 현재 main에서 새로운 assertion failure 발생

## Changes

| 변경 | 이유 |
|------|------|
| `MASC_CONFIG_DIR` → test config root 설정 | Config_dir_resolver가 test temp dir를 사용하도록 |
| `Config_dir_resolver.reset()` finally 추가 | 테스트 간 global cache 오염 방지 |
| `with_clean_base_path_env` bootable test에 추가 | env var 격리 누락 보완 |
| 기대값 `["sangsu"]` → `["dot.name"; "sangsu"]` | 양쪽 모두 valid TOML + autoboot-enabled meta |

## Root Cause

```
configured_keeper_names _config =
  Config_dir_resolver.keepers_dir ()  (* ← config 인자 무시, 전역 싱글톤 사용 *)
```

테스트에서 `Config_dir_resolver.reset()` 호출 후, resolver가 CWD/HOME 기반으로 재해석 → 실제 `config/keepers/*.toml` (qa-king, ani1999 등)을 발견하거나, 반대로 아무것도 못 찾아서 빈 리스트 반환. 두 경우 모두 기대값과 불일치.

## Verification

- 수정 전 (main): test 0 FAIL (`Expected: ["sangsu"]`, `Received: ["dot.name"; "sangsu"]`)
- 수정 후: 4/4 PASS
- 전체 테스트 스위트: 유일한 failure는 `test_keeper_tool_matrix` (pre-existing, 무관)

Refs: #6870, #6871, #6862, #6877

## Test plan

- [x] `dune exec test/test_keeper_meta_listing.exe` — 4/4 pass
- [x] `dune runtest` — no regression from this change
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)