### PR TITLE
[codex] honor explicit keeper models over cascade defaults

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -448,6 +448,7 @@
    keeper_exec_status_metrics
    keeper_exec_status
    keeper_exec_persona
+   keeper_model_labels
    keeper_fs
    keeper_identity
    keeper_checkpoint_store
@@ -623,6 +624,7 @@
   keeper_exec_status
   keeper_status_detail
   keeper_exec_persona
+  keeper_model_labels
   keeper_fs
   keeper_identity
   keeper_checkpoint_store

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -106,7 +106,11 @@ let compact_if_needed
         "[pre_compact] keeper=%s ratio=%.4f messages=%d tokens=%d trigger=%s"
         meta.name ratio msg_count tok_count reason;
       let model_meta =
-        let model_labels = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
+        let model_labels =
+          match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") meta.models) with
+          | _ :: _ as explicit -> explicit
+          | [] -> Oas_model_resolve.models_of_cascade_name meta.cascade_name
+        in
         let primary_id = match Llm_provider.Cascade_config.parse_model_strings model_labels with
           | c :: _ -> c.Llm_provider.Provider_config.model_id | [] -> "auto" in
         Llm_provider.Model_meta.for_model_id primary_id

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -810,7 +810,7 @@ let context_of_legacy_checkpoint
 let checkpoint_model_of_meta (meta : keeper_meta) =
   let candidates =
     meta.runtime.usage.last_model_used
-    :: Oas_model_resolve.models_of_cascade_name meta.cascade_name
+    :: Keeper_model_labels.configured_model_labels_of_meta meta
   in
   List.find_opt (fun value -> String.trim value <> "") candidates
   |> Option.value ~default:(Provider_adapter.default_local_fallback_label ())

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -199,12 +199,9 @@ let keeper_action_kind_of_tool_names tool_names =
   else if List.mem "keeper_board_vote" tool_names then "vote"
   else "none"
 
-
 let effective_model_labels_for_turn (m : keeper_meta) : string list =
   (* provider filtering now handled by OAS cascade via ~provider_filter *)
-  let configured =
-    Oas_model_resolve.models_of_cascade_name m.cascade_name
-  in
+  let configured = Keeper_model_labels.configured_model_labels_of_meta m in
   let configured_ids =
     try
       Llm_provider.Cascade_config.parse_model_strings configured

--- a/lib/keeper/keeper_exec_status.ml
+++ b/lib/keeper/keeper_exec_status.ml
@@ -7,14 +7,14 @@ open Keeper_types
 let active_model_of_meta (m : keeper_meta) : string =
   if m.runtime.usage.last_model_used <> "" then m.runtime.usage.last_model_used
   else
-    match Oas_model_resolve.models_of_cascade_name m.cascade_name with
+    match Keeper_model_labels.configured_model_labels_of_meta m with
     | model :: _ -> model
     | [] -> ""
 
 let next_model_hint_of_meta (m : keeper_meta) : string option =
   let active = active_model_of_meta m in
   let pool =
-    dedupe_keep_order (Oas_model_resolve.models_of_cascade_name m.cascade_name)
+    Keeper_model_labels.configured_model_labels_of_meta m
   in
   match List.filter (fun model -> model <> active) pool with
   | next_model :: _ -> Some next_model

--- a/lib/keeper/keeper_model_labels.ml
+++ b/lib/keeper/keeper_model_labels.ml
@@ -1,0 +1,6 @@
+open Keeper_types
+
+let configured_model_labels_of_meta (m : keeper_meta) : string list =
+  match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") m.models) with
+  | _ :: _ as explicit -> explicit
+  | [] -> Oas_model_resolve.models_of_cascade_name m.cascade_name

--- a/lib/keeper/keeper_model_labels.mli
+++ b/lib/keeper/keeper_model_labels.mli
@@ -1,0 +1,3 @@
+open Keeper_types
+
+val configured_model_labels_of_meta : keeper_meta -> string list

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -112,7 +112,7 @@ let handle_keeper_status ctx args : tool_result =
       let include_compaction_history =
         get_bool args "include_compaction_history" (not fast)
       in
-      let models = Oas_model_resolve.models_of_cascade_name m.cascade_name in
+      let models = Keeper_model_labels.configured_model_labels_of_meta m in
       let primary_max_context =
         let min_keeper_context = Keeper_config.min_keeper_context_tokens in
         let raw =

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -33,7 +33,7 @@ let resolved_model_id_for_result ~(meta : keeper_meta)
   in
   let used = strip_latest result.model_used in
   let cascade_models =
-    Oas_model_resolve.models_of_cascade_name meta.cascade_name
+    Keeper_model_labels.configured_model_labels_of_meta meta
   in
   let cfgs = Llm_provider.Cascade_config.parse_model_strings cascade_models in
   match

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -663,7 +663,7 @@ let append_decision_record
               (* Partial telemetry for error turns: record what we know.
                  Without this, 90%+ of turns have no telemetry at all. *)
               let cascade_models =
-                Oas_model_resolve.models_of_cascade_name meta.cascade_name
+                Keeper_model_labels.configured_model_labels_of_meta meta
               in
               let error_category =
                 match error with
@@ -723,7 +723,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
       then String.sub s 0 (String.length s - 7) else s
     in
     let used = strip_latest result.model_used in
-    let cascade_models = Oas_model_resolve.models_of_cascade_name meta.cascade_name in
+    let cascade_models = Keeper_model_labels.configured_model_labels_of_meta meta in
     let cfgs = Llm_provider.Cascade_config.parse_model_strings cascade_models in
     match List.find_opt (fun (c : Llm_provider.Provider_config.t) ->
       c.model_id = result.model_used || c.model_id = used
@@ -1649,7 +1649,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             in
             let used = strip_latest result.model_used in
             let cascade_models =
-              Oas_model_resolve.models_of_cascade_name effective_cascade_name
+              match dedupe_keep_order (List.filter (fun s -> String.trim s <> "") meta.models) with
+              | _ :: _ as explicit -> explicit
+              | [] -> Oas_model_resolve.models_of_cascade_name effective_cascade_name
             in
             let cfgs =
               Llm_provider.Cascade_config.parse_model_strings cascade_models

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -318,7 +318,7 @@ let board_signal_match
 let read_context_ratio ~(config : Room.config) ~(meta : keeper_meta) : float =
   try
     let cascade_models =
-      Oas_model_resolve.models_of_cascade_name meta.cascade_name
+      Keeper_model_labels.configured_model_labels_of_meta meta
     in
     let primary_max_context =
       let min_keeper_context = Keeper_config.min_keeper_context_tokens in
@@ -353,7 +353,7 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
     : string =
   try
     let cascade_models =
-      Oas_model_resolve.models_of_cascade_name meta.cascade_name
+      Keeper_model_labels.configured_model_labels_of_meta meta
     in
     let primary_max_context =
       let min_keeper_context = Keeper_config.min_keeper_context_tokens in

--- a/test/test_keeper_llama_only.ml
+++ b/test/test_keeper_llama_only.ml
@@ -27,8 +27,9 @@ let labels_for_turn meta =
   with_worktree_config_root @@ fun () ->
   Eio_main.run @@ fun _env -> KEC.effective_model_labels_for_turn meta
 
-let make_meta ?(last_model_used = "glm-5.1") () =
-  match
+let make_meta ?(last_model_used = "glm-5.1") ?(models = []) () =
+  let base =
+    match
     KT.meta_of_json
       (`Assoc
         [
@@ -38,9 +39,11 @@ let make_meta ?(last_model_used = "glm-5.1") () =
           ("cascade_name", `String "keeper_unified");
           ("last_model_used", `String last_model_used);
         ])
-  with
+    with
   | Ok meta -> meta
   | Error err -> fail ("meta_of_json failed: " ^ err)
+  in
+  { base with models }
 
 (* Behavioral: stale model from a different provider is excluded from result.
    MASC does not assert specific vendor labels — only cascade behavior.
@@ -48,7 +51,7 @@ let make_meta ?(last_model_used = "glm-5.1") () =
 let test_stale_last_model_is_not_reused_outside_current_cascade () =
   let baseline = labels_for_turn (make_meta ~last_model_used:"" ()) in
   check bool "baseline is non-empty" true (baseline <> []);
-  let labels = labels_for_turn (make_meta ~last_model_used:"glm-5.1" ()) in
+  let labels = labels_for_turn (make_meta ~last_model_used:"glm:glm-5.1" ()) in
   check (list string) "stale pin has no effect on cascade labels" baseline labels
 
 (* Behavioral: when last_model_used matches a configured cascade model,
@@ -64,6 +67,15 @@ let test_matching_last_model_is_preserved_when_still_in_cascade () =
     | actual_first :: _ ->
       check string "matching model stays first" first actual_first
 
+let test_explicit_models_override_cascade_resolution () =
+  let explicit =
+    [ "ollama:qwen3.5:35b-a3b-nvfp4"; "glm-coding:glm-5.1" ]
+  in
+  let labels =
+    labels_for_turn (make_meta ~last_model_used:"" ~models:explicit ())
+  in
+  check (list string) "explicit models are used as configured" explicit labels
+
 let () =
   run "keeper_llama_only"
     [
@@ -73,5 +85,7 @@ let () =
             test_stale_last_model_is_not_reused_outside_current_cascade;
           test_case "keeps llama pin when still allowed" `Quick
             test_matching_last_model_is_preserved_when_still_in_cascade;
+          test_case "prefers explicit models over cascade defaults" `Quick
+            test_explicit_models_override_cascade_resolution;
         ] );
     ]


### PR DESCRIPTION
## What changed

Keepers now treat explicit `models = ["provider:model", ...]` declarations as first-class configuration instead of only using `cascade_name`-derived labels.

## Why

The current keeper UX is split:
- runtime execution already passes `meta.models` into OAS
- several status/context/telemetry paths still derive labels only from `cascade_name`

That makes explicit model routing feel half-wired and keeps abstractions like `local_only` in places where direct `provider:model` configuration is clearer.

## Impact

- status and next-model hints now reflect explicit keeper model lists
- checkpoint/context reads use the configured explicit labels when present
- keeper telemetry and result model resolution no longer ignore explicit labels
- added a small internal helper module to centralize configured-label resolution
- extended `test_keeper_llama_only` with an explicit-model precedence case

## Validation

Ran directly in the worktree:

```bash
dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-keeper-models test/test_keeper_llama_only.exe
./_build/default/test/test_keeper_llama_only.exe
```

Observed result:
- `keeper_llama_only`: 3 tests passed

## Notes

I did not claim a full repo build here. The direct verification attached to this PR is the targeted keeper model-selection test above.