### PR TITLE
chore(deps): bump OAS agent_sdk pin to v0.132.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,7 +38,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (>= 6.0))
-  (agent_sdk (>= 0.131.0))
+  (agent_sdk (>= 0.132.0))
   (uri (>= 4.4))
   (tls (>= 2.0))
   (tls-eio (>= 2.0))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0"}
-  "agent_sdk" {>= "0.131.0"}
+  "agent_sdk" {>= "0.132.0"}
   "uri" {>= "4.4"}
   "tls" {>= "2.0"}
   "tls-eio" {>= "2.0"}

--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
-readonly OAS_AGENT_SDK_BASE_VERSION="v0.131.0"
+readonly OAS_AGENT_SDK_BASE_VERSION="v0.132.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="9993f11206b37a3eb867bd4db51812d104aeed44"
-readonly OAS_AGENT_SDK_MIN_VERSION="0.131.0"
+readonly OAS_AGENT_SDK_SHA="v0.132.0"
+readonly OAS_AGENT_SDK_MIN_VERSION="0.132.0"


### PR DESCRIPTION
## Summary
- dune-project: `agent_sdk >= 0.131.0` -> `>= 0.132.0`
- scripts/oas-agent-sdk-pin.sh: BASE_VERSION, SHA, MIN_VERSION -> v0.132.0

OAS v0.132.0 adds the `Diag` module for structured llm_provider logging.

## Test plan
- [x] `dune build` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)