### PR TITLE
refactor(dashboard_utils): dedup_strings Hashtbl to Base.String.Set

### DIFF
--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -25,14 +25,13 @@ let trim_to_option text =
   if trimmed = "" then None else Some trimmed
 
 let dedup_strings (xs : string list) : string list =
-  let seen = Hashtbl.create (List.length xs) in
-  List.filter
-    (fun x ->
-      if Hashtbl.mem seen x then false
-      else (
-        Hashtbl.add seen x ();
-        true))
-    xs
+  let rec go seen acc = function
+    | [] -> List.rev acc
+    | x :: rest ->
+      if Base.String.Set.mem x seen then go seen acc rest
+      else go (Base.String.Set.add x seen) (x :: acc) rest
+  in
+  go Base.String.Set.empty [] xs
 
 let string_list_of_json json =
   match json with

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -28,10 +28,10 @@ let dedup_strings (xs : string list) : string list =
   let rec go seen acc = function
     | [] -> List.rev acc
     | x :: rest ->
-      if Base.String.Set.mem x seen then go seen acc rest
-      else go (Base.String.Set.add x seen) (x :: acc) rest
+      if Base.Set.mem seen x then go seen acc rest
+      else go (Base.Set.add seen x) (x :: acc) rest
   in
-  go Base.String.Set.empty [] xs
+  go (Base.Set.empty (module Base.String)) [] xs
 
 let string_list_of_json json =
   match json with


### PR DESCRIPTION
## Summary

Replace mutable Hashtbl with immutable Base.String.Set in dedup_strings.

## Product impact

No behavioral change. Identical deduplication results with identical ordering. Data structure internal optimization only.

## Evidence

- Code change: Hashtbl.create + Hashtbl.mem + Hashtbl.add → Base.String.Set tail-recursive fold
- Net diff: -1 line (same string list signature)
- CI: PR Sync Check, pr-hygiene, label-and-review all SUCCESS. Health/Build/InProgress.

## Review evidence

Before: Hashtbl-based dedup with mutable state during construction.
After: Base.String.Set with immutable tail-recursive fold, O(n log n) with order preservation.
Module interface unchanged, backward compatible.

## Linked issue

Relates #task-015