### PR TITLE
fix(keeper): lower autonomous max_turns default 5→2 (fixes #6810)

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -324,10 +324,18 @@ module KeeperKeepalive = struct
       not monopolize the autonomous semaphore for minutes at a time.
       Reactive turns keep the general budget because they correspond to
       explicit external stimuli.
+
+      Default lowered from 5 to 2 (masc-mcp#6810): with LLM turns at ~22s
+      and [semaphore_wait_timeout_sec] = 60s, a budget of 5 meant one
+      keeper could hold the autonomous slot for 110s+, causing peers
+      queued behind it to time out at 60s.  Budget of 2 caps hold time
+      around 44s (~60s with tools), keeping peers within the wait window.
+      Reactive turns retain the larger budget.
+
       Env: [MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS].
-      Default: min(global, 5). Range: [1, global]. *)
+      Default: min(global, 2). Range: [1, global]. *)
   let oas_max_turns_per_call_scheduled_autonomous =
-    let default = min oas_max_turns_per_call 5 in
+    let default = min oas_max_turns_per_call 2 in
     max 1
       (min oas_max_turns_per_call
          (min 50

--- a/test/test_work_as_heartbeat.ml
+++ b/test/test_work_as_heartbeat.ml
@@ -92,9 +92,10 @@ let test_oas_timeout_262k_scheduled_autonomous () =
       ~max_context:262_144
       ~max_turns:Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
   in
-  (* 120 + 262.144*1.5 + min(5,40)*30 = 120+393.216+150 = 663.216 *)
-  check bool "262K scheduled autonomous → [660, 670]" true
-    (v >= 660.0 && v <= 670.0)
+  (* #6810: default lowered 5→2 to keep semaphore hold under wait timeout.
+     120 + 262.144*1.5 + min(2,40)*30 = 120+393.216+60 = 573.216 *)
+  check bool "262K scheduled autonomous → [570, 580]" true
+    (v >= 570.0 && v <= 580.0)
 
 let test_oas_timeout_zero () =
   let v = adaptive ~max_context:0 in
@@ -121,7 +122,9 @@ let test_max_turns_default () =
     Cfg.KeeperKeepalive.oas_max_turns_per_call
 
 let test_scheduled_autonomous_max_turns_default () =
-  check int "default scheduled autonomous max_turns_per_call 5" 5
+  (* #6810: lowered 5→2 so autonomous semaphore hold
+     (turns × latency) stays under 60s wait timeout. *)
+  check int "default scheduled autonomous max_turns_per_call 2" 2
     Cfg.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
 
 let test_max_turns_range () =
@@ -356,7 +359,7 @@ let () =
       test_case "turn timeout default is 1200" `Quick test_turn_timeout_default;
       test_case "adaptive capped at turn timeout" `Quick test_oas_timeout_cap;
       test_case "max_turns default is 15" `Quick test_max_turns_default;
-      test_case "scheduled autonomous max_turns default is 5" `Quick
+      test_case "scheduled autonomous max_turns default is 2" `Quick
         test_scheduled_autonomous_max_turns_default;
       test_case "max_turns range" `Quick test_max_turns_range;
       test_case "scheduled autonomous max_turns range" `Quick


### PR DESCRIPTION
## Summary
Fixes #6810 autonomous semaphore starvation.

## Root cause
- \`oas_max_turns_per_call_scheduled_autonomous\` default = 5
- LLM turn latency ~22s → semaphore hold up to 110s
- \`semaphore_wait_timeout_sec\` = 60s → queued peers ALWAYS timeout

## Fix
Default 5 → 2. Caps hold time to ~44-60s, keeping peers within wait window.

Operators can restore old behavior via env var:
\`MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS=5\`

## Test plan
- [ ] Build + CI pass
- [ ] Monitor keeper activity with concurrency=1 — no semaphore_wait timeouts

Closes #6810