### PR TITLE
fix(keepalive): autonomous semaphore fairness cooldown

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -142,6 +142,91 @@ let semaphore_wait_timeout_sec =
     not a keeper failure in the unified-turn sense. *)
 exception Semaphore_wait_timeout of float
 
+(** Per-keeper record of the last autonomous turn completion timestamp.
+    Used by the fairness cooldown to prevent a fast-cycling keeper from
+    monopolizing the autonomous slot when peers are waiting.
+
+    Closes #6810: janitor was observed to complete 9 consecutive ~20s
+    turns while cheolsu/sangsu/masc-improver/uranium666 all hit the 60s
+    wait timeout. The queue is FIFO-fair in isolation, but a keeper that
+    re-enters the queue immediately after releasing the semaphore can
+    outpace peers whose heartbeat intervals are longer or whose fibers
+    yield less aggressively. *)
+let last_autonomous_completion : (string, float) Hashtbl.t = Hashtbl.create 16
+
+let last_autonomous_completion_mutex = Mutex.create ()
+
+let with_completion_table f =
+  Mutex.lock last_autonomous_completion_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock last_autonomous_completion_mutex)
+    f
+
+let record_autonomous_completion ~(keeper_name : string) : unit =
+  with_completion_table (fun () ->
+    Hashtbl.replace last_autonomous_completion keeper_name
+      (Time_compat.now ()))
+
+let reset_autonomous_completion_for_test () : unit =
+  with_completion_table (fun () ->
+    Hashtbl.reset last_autonomous_completion)
+
+(** Test-only: stamp a completion time directly without going through
+    [Time_compat.now].  Allows deterministic fairness-cooldown scenarios. *)
+let record_autonomous_completion_at_for_test ~(keeper_name : string) ~(ts : float) : unit =
+  with_completion_table (fun () ->
+    Hashtbl.replace last_autonomous_completion keeper_name ts)
+
+(** Minimum gap between consecutive autonomous turns from the same keeper
+    when other keepers are waiting in the FIFO queue. 0 disables fairness
+    cooldown entirely (pre-#6810 behavior).
+
+    Default 5s gives peers a chance to win head-of-queue after a fast
+    keeper releases the semaphore, even when the fast keeper's heartbeat
+    immediately loops back.
+
+    Env: [MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC]. Range [0, 60]. *)
+let autonomous_fairness_cooldown_sec =
+  Keeper_config.float_of_env_default
+    "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC"
+    ~default:5.0 ~min_v:0.0 ~max_v:60.0
+
+let others_waiting_in_queue ~(keeper_name : string) : bool =
+  with_autonomous_wait_queue (fun () ->
+    List.exists (fun w -> w.keeper_name <> keeper_name)
+      !autonomous_wait_queue)
+
+(** Pure computation: how many seconds [keeper_name] should yield before
+    re-entering the queue at time [now].  Returns [0.0] when no yield is
+    needed.  Extracted so the delay logic is testable without Eio. *)
+let fairness_delay_sec_at ~(now : float) ~(keeper_name : string) : float =
+  if autonomous_fairness_cooldown_sec <= 0.0 then 0.0
+  else if not (others_waiting_in_queue ~keeper_name) then 0.0
+  else
+    match
+      with_completion_table (fun () ->
+        Hashtbl.find_opt last_autonomous_completion keeper_name)
+    with
+    | None -> 0.0
+    | Some last_done ->
+      Float.max 0.0 (autonomous_fairness_cooldown_sec -. (now -. last_done))
+
+(** Enforce fairness cooldown before re-entering the autonomous queue.
+    If this keeper just completed a turn AND other keepers are waiting,
+    yield for the remainder of [autonomous_fairness_cooldown_sec] before
+    appending our ticket. Called from [with_keeper_turn_slot] before
+    [enqueue_autonomous_waiter]. *)
+let maybe_yield_for_fairness ~(keeper_name : string) : unit =
+  let remaining = fairness_delay_sec_at ~now:(Time_compat.now ()) ~keeper_name in
+  if remaining > 0.0 then begin
+    Log.Keeper.info
+      "fairness_cooldown: keeper=%s yielding %.2fs (queue has other waiters)"
+      keeper_name remaining;
+    match Eio_context.get_clock_opt () with
+    | Some clock -> Eio.Time.sleep clock remaining
+    | None -> Eio.Fiber.yield ()
+  end
+
 let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
     ~(started_at : float) : unit =
   if Option.equal Int.equal (autonomous_waiter_head_ticket ()) (Some ticket)
@@ -221,9 +306,20 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
       (* Release exactly what we acquired. Order does not matter because
          these two semaphores do not contend with each other. *)
       if !acquired_turn then Eio.Semaphore.release turn_semaphore;
-      if !acquired_autonomous then Eio.Semaphore.release autonomous_turn_semaphore)
+      if !acquired_autonomous then begin
+        (* Stamp completion time BEFORE releasing the semaphore so that
+           [maybe_yield_for_fairness] can measure the correct interval
+           when this keeper's heartbeat loops back immediately. *)
+        record_autonomous_completion ~keeper_name;
+        Eio.Semaphore.release autonomous_turn_semaphore
+      end)
     (fun () ->
       if is_autonomous then begin
+        (* Fairness cooldown: if this keeper recently completed a turn and
+           other keepers are waiting, yield before re-entering the FIFO
+           queue to give peers a chance to reach head-of-queue first.
+           See [maybe_yield_for_fairness] and #6810. *)
+        maybe_yield_for_fairness ~keeper_name;
         let ticket = enqueue_autonomous_waiter ~keeper_name in
         autonomous_ticket := Some ticket;
         wait_for_autonomous_queue_head ~keeper_name ~ticket ~started_at:t0;

--- a/lib/keeper/keeper_keepalive.mli
+++ b/lib/keeper/keeper_keepalive.mli
@@ -66,6 +66,17 @@ val autonomous_waiter_snapshot_for_test : unit -> string list
 val enqueue_autonomous_waiter_for_test : string -> int
 val drop_autonomous_waiter_for_test : int -> unit
 
+(** Pure computation: seconds keeper should yield before re-entering queue
+    at time [now].  0.0 = no yield needed.  Exposed for unit testing. *)
+val fairness_delay_sec_at : now:float -> keeper_name:string -> float
+
+(** Test-only: stamp a completion time directly (bypasses [Time_compat.now]).
+    Use to set up deterministic fairness-cooldown scenarios. *)
+val record_autonomous_completion_at_for_test : keeper_name:string -> ts:float -> unit
+
+(** Test-only: clear all per-keeper completion timestamps. *)
+val reset_autonomous_completion_for_test : unit -> unit
+
 val wakeup_relevant_keeper_for_board_signal :
   config:Room.config -> Board_dispatch.keeper_board_signal -> unit
 

--- a/test/dune
+++ b/test/dune
@@ -689,6 +689,11 @@
 (test
  (name test_keeper_keepalive_skip_log_throttle)
  (libraries masc_test_deps))
+
+; Keeper autonomous semaphore fairness cooldown (#6810)
+(test
+ (name test_keeper_semaphore_fairness)
+ (libraries masc_test_deps))
 ; Operator Control (7 modules)
 (test
  (name test_operator_control)

--- a/test/test_keeper_semaphore_fairness.ml
+++ b/test/test_keeper_semaphore_fairness.ml
@@ -1,0 +1,134 @@
+(** Regression tests for autonomous semaphore fairness cooldown (#6810).
+
+    Background: janitor completed 9 consecutive ~20s turns while
+    cheolsu/sangsu/masc-improver/uranium666 all hit the 60s autonomous
+    semaphore wait timeout.  The queue is FIFO-fair in isolation, but a
+    fast-cycling keeper that re-enters the queue immediately after
+    releasing the semaphore outruns peers whose heartbeat intervals are
+    longer.
+
+    Fix: [maybe_yield_for_fairness] stamps each autonomous-turn
+    completion, then checks before re-enqueueing: if other keepers are
+    waiting AND this keeper completed within [autonomous_fairness_cooldown_sec]
+    seconds ago, it yields for the remaining cooldown window.
+
+    These tests exercise [fairness_delay_sec_at] — the pure delay-
+    computation extracted from [maybe_yield_for_fairness] — so we never
+    need to actually sleep in a test. *)
+
+module KK = Masc_mcp.Keeper_keepalive
+
+(** Reset both the completion table and the FIFO wait queue between tests. *)
+let with_fresh_state test_body () =
+  KK.reset_autonomous_completion_for_test ();
+  KK.reset_autonomous_turn_queue_for_test ();
+  test_body ()
+
+(* --------------------------------------------------------------------------
+   fairness_delay_sec_at: core logic
+   -------------------------------------------------------------------------- *)
+
+let test_no_completion_no_delay () =
+  (* Keeper has never completed an autonomous turn: no stamp → no delay. *)
+  let delay = KK.fairness_delay_sec_at ~now:1_000_000.0 ~keeper_name:"janitor" in
+  Alcotest.(check (float 0.001)) "no completion → 0.0 delay" 0.0 delay
+
+let test_no_others_waiting_no_delay () =
+  (* No peers in queue: even if cooldown would fire, skip it. *)
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:1_000_000.0;
+  (* janitor is NOT in the queue here; nothing else is either. *)
+  let delay =
+    KK.fairness_delay_sec_at ~now:1_000_000.5 ~keeper_name:"janitor"
+  in
+  Alcotest.(check (float 0.001)) "no queue waiters → 0.0 delay" 0.0 delay
+
+let test_others_waiting_fresh_completion_delays () =
+  (* janitor completed 0.5s ago; peer is waiting; 5s cooldown → ~4.5s remain. *)
+  let t_done = 1_000_000.0 in
+  let now = t_done +. 0.5 in
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:t_done;
+  (* Enqueue a peer so [others_waiting_in_queue] returns true. *)
+  let ticket = KK.enqueue_autonomous_waiter_for_test "cheolsu" in
+  let delay = KK.fairness_delay_sec_at ~now ~keeper_name:"janitor" in
+  KK.drop_autonomous_waiter_for_test ticket;
+  (* Default cooldown is 5s; elapsed 0.5s → remaining ≈ 4.5s.
+     We test with an approximate tolerance. *)
+  Alcotest.(check bool) "delay > 4.0s" true (delay > 4.0);
+  Alcotest.(check bool) "delay <= 5.0s" true (delay <= 5.0)
+
+let test_others_waiting_cooldown_expired_no_delay () =
+  (* Cooldown window already elapsed (6s ago at 5s cooldown). *)
+  let t_done = 1_000_000.0 in
+  let now = t_done +. 6.0 in
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:t_done;
+  let ticket = KK.enqueue_autonomous_waiter_for_test "sangsu" in
+  let delay = KK.fairness_delay_sec_at ~now ~keeper_name:"janitor" in
+  KK.drop_autonomous_waiter_for_test ticket;
+  Alcotest.(check (float 0.001)) "expired cooldown → 0.0 delay" 0.0 delay
+
+let test_others_waiting_exactly_at_boundary_no_delay () =
+  (* Completed exactly cooldown_sec ago → remaining = 0.0. *)
+  let cooldown = 5.0 in
+  let t_done = 1_000_000.0 in
+  let now = t_done +. cooldown in
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:t_done;
+  let ticket = KK.enqueue_autonomous_waiter_for_test "uranium666" in
+  let delay = KK.fairness_delay_sec_at ~now ~keeper_name:"janitor" in
+  KK.drop_autonomous_waiter_for_test ticket;
+  Alcotest.(check (float 0.001)) "exactly at boundary → 0.0" 0.0 delay
+
+let test_per_keeper_isolation () =
+  (* Completing for 'janitor' must not affect 'cheolsu'. *)
+  let t_done = 1_000_000.0 in
+  let now = t_done +. 0.5 in
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:t_done;
+  let ticket = KK.enqueue_autonomous_waiter_for_test "masc-improver" in
+  let delay_cheolsu = KK.fairness_delay_sec_at ~now ~keeper_name:"cheolsu" in
+  KK.drop_autonomous_waiter_for_test ticket;
+  (* cheolsu has no completion stamp → no delay. *)
+  Alcotest.(check (float 0.001)) "unrelated keeper unaffected" 0.0 delay_cheolsu
+
+let test_reset_clears_completion_table () =
+  (* After reset, a previously-stamped keeper sees no delay. *)
+  let t_done = 1_000_000.0 in
+  let now = t_done +. 0.5 in
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:t_done;
+  KK.reset_autonomous_completion_for_test ();
+  let ticket = KK.enqueue_autonomous_waiter_for_test "cheolsu" in
+  let delay = KK.fairness_delay_sec_at ~now ~keeper_name:"janitor" in
+  KK.drop_autonomous_waiter_for_test ticket;
+  Alcotest.(check (float 0.001)) "reset clears stamps → 0.0" 0.0 delay
+
+let test_delay_decreases_with_elapsed_time () =
+  (* delay at t+1s > delay at t+3s. *)
+  let t_done = 1_000_000.0 in
+  KK.record_autonomous_completion_at_for_test ~keeper_name:"janitor" ~ts:t_done;
+  let ticket = KK.enqueue_autonomous_waiter_for_test "sangsu" in
+  let delay_1s = KK.fairness_delay_sec_at ~now:(t_done +. 1.0) ~keeper_name:"janitor" in
+  let delay_3s = KK.fairness_delay_sec_at ~now:(t_done +. 3.0) ~keeper_name:"janitor" in
+  KK.drop_autonomous_waiter_for_test ticket;
+  Alcotest.(check bool) "delay decreases over time" true (delay_1s > delay_3s)
+
+let () =
+  Alcotest.run "Keeper_semaphore_fairness"
+    [
+      ( "fairness_delay_sec_at",
+        [
+          Alcotest.test_case "no completion → no delay" `Quick
+            (with_fresh_state test_no_completion_no_delay);
+          Alcotest.test_case "no others waiting → no delay" `Quick
+            (with_fresh_state test_no_others_waiting_no_delay);
+          Alcotest.test_case "others waiting, fresh completion → delay" `Quick
+            (with_fresh_state test_others_waiting_fresh_completion_delays);
+          Alcotest.test_case "cooldown expired → no delay" `Quick
+            (with_fresh_state test_others_waiting_cooldown_expired_no_delay);
+          Alcotest.test_case "exactly at cooldown boundary → no delay" `Quick
+            (with_fresh_state test_others_waiting_exactly_at_boundary_no_delay);
+          Alcotest.test_case "per-keeper isolation" `Quick
+            (with_fresh_state test_per_keeper_isolation);
+          Alcotest.test_case "reset clears table" `Quick
+            (with_fresh_state test_reset_clears_completion_table);
+          Alcotest.test_case "delay decreases with elapsed time" `Quick
+            (with_fresh_state test_delay_decreases_with_elapsed_time);
+        ] );
+    ]


### PR DESCRIPTION
## Problem

Closes #6810.

`janitor` was completing 9 consecutive autonomous turns while `cheolsu`/`sangsu`/`masc-improver`/`uranium666` all hit the 60s wait timeout. The autonomous FIFO queue is structurally fair, but a fast-cycling keeper (~20s turns) re-enters the queue immediately after releasing the semaphore, outpacing peers with longer heartbeat intervals before they can win head-of-queue.

## Fix

Before appending a new FIFO ticket, `maybe_yield_for_fairness` checks:
1. Other keepers are currently waiting in the queue, AND
2. This keeper completed an autonomous turn within `MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC` seconds ago (default 5s, range [0,60])

If both conditions hold, it sleeps for the remaining cooldown window before enqueueing. Setting the env var to `0` restores pre-fix (no-cooldown) behavior.

## Implementation

- `last_autonomous_completion : (string, float) Hashtbl.t` — per-keeper completion timestamp, protected by `Stdlib.Mutex` (Eio-free, safe across domains)
- `record_autonomous_completion` stamps the table **before** `Eio.Semaphore.release` so peers see the stamp before the releaser can re-enter
- `fairness_delay_sec_at ~now ~keeper_name` — pure function for testability without Eio
- `maybe_yield_for_fairness` calls the pure helper with `Time_compat.now()` and uses `Eio.Time.sleep` (production) or `Eio.Fiber.yield` (no-clock environment)

## Tests

8 new Alcotest cases in `test_keeper_semaphore_fairness.ml`:

| Case | Assert |
|------|--------|
| no completion stamp | delay = 0.0 |
| no peers waiting | delay = 0.0 |
| fresh completion + peers | 4.0s < delay ≤ 5.0s |
| cooldown expired (6s ago) | delay = 0.0 |
| exactly at boundary | delay = 0.0 |
| per-keeper isolation | unrelated keeper unaffected |
| reset clears table | delay = 0.0 after reset |
| delay decreases over time | delay(t+1) > delay(t+3) |

## Checklist

- [x] `dune build` clean
- [x] 8/8 new tests pass
- [x] Existing `test_keeper_keepalive_skip_log_throttle` 6/6 pass
- [x] Env var override documented in code comment
- [x] Zero breaking changes to public API (additive .mli only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)