### PR TITLE
fix(dispatch): return graceful errors instead of raising Not_found on missing JSON fields

### DIFF
--- a/lib/tool_inline_dispatch_comm.ml
+++ b/lib/tool_inline_dispatch_comm.ml
@@ -139,10 +139,11 @@ let handle_listen (ctx : context) : tool_result option =
   let msg_opt = ctx.wait_for_message registry ~agent_name ~timeout in
   (match msg_opt with
    | Some msg ->
-       let from = match Json_util.get_string msg "from" with Some v -> v | None -> raise Not_found in
-       let content = match Json_util.get_string msg "content" with Some v -> v | None -> raise Not_found in
-       let timestamp = match Json_util.get_string msg "timestamp" with Some v -> v | None -> raise Not_found in
-       Some (true, Printf.sprintf {|
+       (match Json_util.get_string msg "from",
+              Json_util.get_string msg "content",
+              Json_util.get_string msg "timestamp" with
+        | Some from, Some content, Some timestamp ->
+            Some (true, Printf.sprintf {|
 MESSAGE RECEIVED
 From: %s
 Time: %s
@@ -151,6 +152,12 @@ Time: %s
 
 Call masc_listen again to continue listening.
 |} from timestamp content)
+        | _ ->
+            Log.Mcp.warn
+              "masc_listen received malformed message (missing from/content/timestamp) for agent %s"
+              agent_name;
+            Some (Tool_args.error_result
+                    "received malformed message (missing from/content/timestamp)"))
    | None ->
        Some (true, Printf.sprintf "Listening timed out after %.0fs. No messages received." timeout))
 

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -51,7 +51,13 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
   match (name : string) with
   | "masc_recall_search" ->
       let module U = Yojson.Safe.Util in
-      let query = match Json_util.get_string arguments "query" with Some v -> v | None -> raise Not_found in
+      let query =
+        Option.value ~default:""
+          (Json_util.get_string arguments "query")
+      in
+      if String.trim query = "" then
+        Some (Tool_args.error_result "query is required")
+      else begin
       let limit = arguments |> U.member "limit" |> U.to_int_option |> Option.value ~default:5 in
       (* PR#814 Gap 3: format=grep returns compact grep-like output for LLM parsing *)
       let format = arguments |> U.member "format" |> U.to_string_option
@@ -96,6 +102,7 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
             (List.length result.items) query));
         ] in
         Some (true, Yojson.Safe.to_string response)
+      end
 
   | "masc_board_post" ->
       let (success, message) as result = Tool_board.handle_tool name arguments in


### PR DESCRIPTION
## Summary

Two tool dispatch handlers raised `Not_found` on missing JSON fields, causing silent panics:

- **`handle_listen`** (`lib/tool_inline_dispatch_comm.ml`): malformed message from `masc_listen` (missing `from`/`content`/`timestamp`) → `raise Not_found`. Now logs warn + returns `Tool_args.error_result`.
- **`masc_recall_search`** (`lib/tool_inline_dispatch_extra.ml`): missing/empty `query` param → `raise Not_found`. Now returns a validation error.

## Product impact

When a malformed broadcast reached an agent via `masc_listen`, or when an LLM called `masc_recall_search` without a `query` field, the handler raised `Not_found` and the MCP dispatcher surfaced an opaque exception. The LLM client received a transport-level error instead of a structured tool error, and the logs showed no explanation. After this PR, the caller gets a `{"status":"error","message":"..."}` response and the operator gets a `Log.Mcp.warn` line with the agent name.

No behavior change on well-formed input.

## Evidence

- `dune build --root .` passes (verified in worktree `.worktrees/fix/json-notfound-dispatch`).
- Full `dune test` runs 186s; pre-existing failures in `keeper_tool_matrix` (TTS/audio/network env-dependent) unrelated to this PR.
- GitHub Actions CI: 9/9 required checks pass.

## Review evidence

- Audit source: masc-mcp Axis A sweep (`failwith` / partial functions / `raise Not_found`) across `lib/` + `bin/` + `test/`.
- Scanned 880 lib files + 388 test files. `lib/` had 7 `raise Not_found` sites; this PR addresses the Top-2.
- The remaining 5 sites were verified as either intentional EAFP control flow (`keeper_checkpoint_store.ml:101` — raise caught by same `with`) or design decisions that need a separate discussion (registry lookup API).

## Linked issue

Relates to audit axes documented in https://github.com/jeong-sik/masc-mcp/issues/6915 (supervision) and the broader `Parse, Don't Validate` principle applied across the dispatch layer.

## Test plan

- [x] `dune build --root .` — passes locally
- [x] CI 9 required checks green
- [ ] CodeRabbit / reviewer feedback
- [ ] Ready transition after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)