### PR TITLE
keeper masc improver agent/task 020

### DIFF
--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -1,3 +1,5 @@
+module StringSet = Set.Make (String)
+
 type source =
   | Env
   | Local_masc
@@ -342,11 +344,13 @@ let personas_dir_opt () =
   if resolution.personas.exists then Some resolution.personas.path else None
 
 let dedupe_paths paths =
-  let seen = Hashtbl.create 8 in
-  List.filter (fun p ->
-      if Hashtbl.mem seen p then false
-      else (Hashtbl.add seen p (); true))
-    paths
+  let rec go seen acc = function
+    | [] -> List.rev acc
+    | p :: rest ->
+      if StringSet.mem p seen then go seen acc rest
+      else go (StringSet.add p seen) (p :: acc) rest
+  in
+  go StringSet.empty [] paths
 
 let personas_dirs_with inputs resolution =
   let primary =


### PR DESCRIPTION
## Summary

Replace mutable Hashtbl with immutable StringSet in dedupe_paths.

## Product impact

No behavioral change. Identical deduplication with order preservation.

## Evidence

- rg Hashtbl lib/config_dir_resolver.ml on branch: 0 matches (before: 3)
- Net diff: +9 -5
- CI pending

## Review evidence

Before: Hashtbl.create + Hashtbl.mem + Hashtbl.add mutable dedup.
After: StringSet tail-recursive fold immutable dedup. Order-preserving.
Module StringSet = Set.Make(String) added at file top.

## Linked issue

Relates task-020