### PR TITLE
fix(grpc): log non-cancel exceptions in compute_directives instead of silencing

### DIFF
--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -242,7 +242,12 @@ let compute_directives
       (match Yojson.Safe.Util.member "paused" json with
        | `Bool true -> directives := "pause" :: !directives
        | _ -> ())
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Transport.warn
+          "compute_directives: failed to parse agent file %s: %s"
+          agent_file (Printexc.to_string exn));
   (* 2. Task assignment: find first unclaimed task for idle agent *)
   let tasks_dir = Filename.concat masc_dir "tasks" in
   (if Sys.file_exists tasks_dir then
@@ -257,7 +262,13 @@ let compute_directives
               (match Yojson.Safe.Util.member "status" task_json with
                | `String "todo" -> Some (Filename.chop_suffix f ".json")
                | _ -> None)
-            with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Log.Transport.debug
+                  "compute_directives: task parse skip %s: %s"
+                  f (Printexc.to_string exn);
+                None
           else None)
     in
     match unclaimed with


### PR DESCRIPTION
## Summary

`compute_directives` in `lib/grpc/masc_grpc_service.ml` read agent and task JSON files and silently swallowed every non-cancel exception via `| _ -> ()` / `| _ -> None`. Two sites missed a logging pattern already in use in the same file (lines 74, 183).

## Product impact

A corrupted `agents/<name>.json` would make the handler ignore the `"paused": true` field:
- Dashboard pauses the agent via an operator action
- Keeper's directive stream never sees the pause
- Operator has no log line to explain why the pause didn't take effect

The observer sees "nothing happened" with no trace in logs. Common causes (manual JSON edit, truncated write, permission loss) now produce a warn-level log entry naming the file and exception.

Cancellation semantics unchanged.

## Evidence

- `dune build --root .` passes (verified locally).
- CI: 7/7 required checks green.
- Pattern already exists at lines 74 + 183 of the same file; this PR fills the two remaining sites for consistency.

## Review evidence

Axis C (silent-failure) audit initially flagged 7 files as "critical catch-all swallowing Cancelled". Per-site structural verification showed:

- `process_eio.ml:308, 338, 339` — cleanup close inside `Eio.Cancel.Cancelled` handler. Intentional (re-close for cleanup, re-raise outer cancel). **Not a bug.**
- `worker_dev_tools.ml:985` — same pattern. **Not a bug.**
- `dashboard_cache.ml:271` — `Eio.Condition.broadcast` inside Cancelled handler, defensive wake-up. Best-effort. **Not a bug.**
- `grpc_service.ml:281–290`, `grpc_client.ml:111–113` — `with _ -> ()` occurrences are inside **code comments** explaining why that pattern is avoided. **Not code.**
- `grpc_service.ml:245, 260` in `compute_directives` — the only sites where non-cancel exceptions were truly silent. **This PR.**

LLM audit reports surface pattern matches; humans verify each per-site by reading the enclosing context.

## Linked issue

Relates https://github.com/jeong-sik/masc-mcp/issues/6915 (Fiber.fork supervision framework) — this PR applies the same observability principle at the exception-handling layer that the supervision issue applies at the fiber-lifecycle layer.

## Test plan

- [x] `dune build --root .` — passes locally
- [x] CI 7 required checks green
- [ ] CodeRabbit / reviewer feedback
- [ ] Ready transition after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)