### PR TITLE
specs(bug-models): add TLA+ specs for Hebbian and Memory Compaction

### DIFF
--- a/specs/bug-models/HebbianLearning-buggy.cfg
+++ b/specs/bug-models/HebbianLearning-buggy.cfg
@@ -1,0 +1,11 @@
+\* Buggy model: no file lock, consolidate clobbers strengthen.
+\* Expected: NoLostStrengthen VIOLATED (consolidate writes stale snapshot).
+SPECIFICATION SpecBuggy
+INVARIANT WeightBounded NoLostUpdate
+CONSTRAINT VersionBound
+CONSTANTS
+    MaxWeight = 10
+    StrengthenRate = 1
+    DecayAmount = 1
+    MaxVersion = 6
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/HebbianLearning.cfg
+++ b/specs/bug-models/HebbianLearning.cfg
@@ -1,0 +1,11 @@
+\* Clean model: file lock serializes strengthen and consolidate.
+\* Expected: no error (WeightBounded and NoLostStrengthen hold).
+SPECIFICATION Spec
+INVARIANT WeightBounded NoLostUpdate
+CONSTRAINT VersionBound
+CONSTANTS
+    MaxWeight = 10
+    StrengthenRate = 1
+    DecayAmount = 1
+    MaxVersion = 6
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/HebbianLearning.tla
+++ b/specs/bug-models/HebbianLearning.tla
@@ -1,0 +1,222 @@
+---- MODULE HebbianLearning ----
+\* Bug Model: Hebbian read-modify-write without file lock.
+\*
+\* Models hebbian_eio.ml strengthen/consolidate concurrency.
+\* Each operation does: load → compute → save. The file lock
+\* serializes these so no interleaving writes occur between
+\* an operation's load and save.
+\*
+\* Without the lock, operation A can save between B's load and save,
+\* causing B to clobber A's effect (lost update).
+\*
+\* Invariant: when an operation saves, no other write has happened
+\* since that operation loaded (graph_version == load_version + 1).
+\*
+\* Reference: hebbian_eio.ml lines 268-275 (docstring warning).
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxWeight,         \* Upper bound (default 10)
+    StrengthenRate,    \* Increment per strengthen (default 1)
+    DecayAmount,       \* Decrement per consolidate (default 1)
+    MaxVersion         \* State constraint bound on graph_version to keep TLC finite
+
+VARIABLES
+    graph_weight,       \* Current on-disk weight
+    graph_version,      \* Monotonic counter, incremented on each save
+    lock,               \* "free" | "strengthen" | "consolidate"
+    str_phase,          \* "idle" | "loaded" | "computed" | "saved"
+    str_snapshot,       \* Weight that strengthen loaded
+    str_load_ver,       \* graph_version when strengthen loaded
+    str_save_ver,       \* graph_version after strengthen saved (0 if never)
+    con_phase,          \* "idle" | "loaded" | "computed" | "saved"
+    con_snapshot,       \* Weight that consolidate loaded
+    con_load_ver,       \* graph_version when consolidate loaded
+    con_save_ver        \* graph_version after consolidate saved (0 if never)
+
+vars == <<graph_weight, graph_version, lock,
+          str_phase, str_snapshot, str_load_ver, str_save_ver,
+          con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+Init ==
+    /\ graph_weight = 5
+    /\ graph_version = 0
+    /\ lock = "free"
+    /\ str_phase = "idle"
+    /\ str_snapshot = 0
+    /\ str_load_ver = 0
+    /\ str_save_ver = 0
+    /\ con_phase = "idle"
+    /\ con_snapshot = 0
+    /\ con_load_ver = 0
+    /\ con_save_ver = 0
+
+\* ── Safe (locked) strengthen ──────────────────────────
+
+SafeStrAcquire ==
+    /\ str_phase = "idle"
+    /\ lock = "free"
+    /\ lock' = "strengthen"
+    /\ str_phase' = "loaded"
+    /\ str_snapshot' = graph_weight
+    /\ str_load_ver' = graph_version
+    /\ UNCHANGED <<graph_weight, graph_version, str_save_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+SafeStrCompute ==
+    /\ str_phase = "loaded"
+    /\ str_phase' = "computed"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_snapshot, str_load_ver, str_save_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+SafeStrSave ==
+    /\ str_phase = "computed"
+    /\ graph_weight' = IF str_snapshot + StrengthenRate > MaxWeight
+                       THEN MaxWeight
+                       ELSE str_snapshot + StrengthenRate
+    /\ graph_version' = graph_version + 1
+    /\ str_save_ver' = graph_version + 1
+    /\ str_phase' = "saved"
+    /\ lock' = "free"
+    /\ UNCHANGED <<str_snapshot, str_load_ver, con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+SafeStrReset ==
+    /\ str_phase = "saved"
+    /\ str_phase' = "idle"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_snapshot, str_load_ver, str_save_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+\* ── Safe (locked) consolidate ─────────────────────────
+
+SafeConAcquire ==
+    /\ con_phase = "idle"
+    /\ lock = "free"
+    /\ lock' = "consolidate"
+    /\ con_phase' = "loaded"
+    /\ con_snapshot' = graph_weight
+    /\ con_load_ver' = graph_version
+    /\ UNCHANGED <<graph_weight, graph_version, str_phase, str_snapshot, str_load_ver, str_save_ver, con_save_ver>>
+
+SafeConCompute ==
+    /\ con_phase = "loaded"
+    /\ con_phase' = "computed"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_phase, str_snapshot, str_load_ver, str_save_ver,
+                   con_snapshot, con_load_ver, con_save_ver>>
+
+SafeConSave ==
+    /\ con_phase = "computed"
+    /\ graph_weight' = IF con_snapshot < DecayAmount THEN 0
+                       ELSE con_snapshot - DecayAmount
+    /\ graph_version' = graph_version + 1
+    /\ con_save_ver' = graph_version + 1
+    /\ con_phase' = "saved"
+    /\ lock' = "free"
+    /\ UNCHANGED <<str_phase, str_snapshot, str_load_ver, str_save_ver, con_snapshot, con_load_ver>>
+
+SafeConReset ==
+    /\ con_phase = "saved"
+    /\ con_phase' = "idle"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_phase, str_snapshot, str_load_ver, str_save_ver,
+                   con_snapshot, con_load_ver, con_save_ver>>
+
+\* ── Unsafe (no lock) strengthen ───────────────────────
+
+UnsafeStrLoad ==
+    /\ str_phase = "idle"
+    /\ str_phase' = "loaded"
+    /\ str_snapshot' = graph_weight
+    /\ str_load_ver' = graph_version
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_save_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+UnsafeStrCompute ==
+    /\ str_phase = "loaded"
+    /\ str_phase' = "computed"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_snapshot, str_load_ver, str_save_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+UnsafeStrSave ==
+    /\ str_phase = "computed"
+    /\ graph_weight' = IF str_snapshot + StrengthenRate > MaxWeight
+                       THEN MaxWeight
+                       ELSE str_snapshot + StrengthenRate
+    /\ graph_version' = graph_version + 1
+    /\ str_save_ver' = graph_version + 1
+    /\ str_phase' = "saved"
+    /\ UNCHANGED <<lock, str_snapshot, str_load_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+UnsafeStrReset ==
+    /\ str_phase = "saved"
+    /\ str_phase' = "idle"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_snapshot, str_load_ver, str_save_ver,
+                   con_phase, con_snapshot, con_load_ver, con_save_ver>>
+
+\* ── Unsafe (no lock) consolidate ──────────────────────
+
+UnsafeConLoad ==
+    /\ con_phase = "idle"
+    /\ con_phase' = "loaded"
+    /\ con_snapshot' = graph_weight
+    /\ con_load_ver' = graph_version
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_phase, str_snapshot, str_load_ver, str_save_ver, con_save_ver>>
+
+UnsafeConCompute ==
+    /\ con_phase = "loaded"
+    /\ con_phase' = "computed"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_phase, str_snapshot, str_load_ver, str_save_ver,
+                   con_snapshot, con_load_ver, con_save_ver>>
+
+UnsafeConSave ==
+    /\ con_phase = "computed"
+    /\ graph_weight' = IF con_snapshot < DecayAmount THEN 0
+                       ELSE con_snapshot - DecayAmount
+    /\ graph_version' = graph_version + 1
+    /\ con_save_ver' = graph_version + 1
+    /\ con_phase' = "saved"
+    /\ UNCHANGED <<lock, str_phase, str_snapshot, str_load_ver, str_save_ver, con_snapshot, con_load_ver>>
+
+UnsafeConReset ==
+    /\ con_phase = "saved"
+    /\ con_phase' = "idle"
+    /\ UNCHANGED <<graph_weight, graph_version, lock, str_phase, str_snapshot, str_load_ver, str_save_ver,
+                   con_snapshot, con_load_ver, con_save_ver>>
+
+\* ── Specifications ────────────────────────────────────
+
+NextSafe ==
+    \/ SafeStrAcquire \/ SafeStrCompute \/ SafeStrSave \/ SafeStrReset
+    \/ SafeConAcquire \/ SafeConCompute \/ SafeConSave \/ SafeConReset
+
+NextUnsafe ==
+    \/ UnsafeStrLoad \/ UnsafeStrCompute \/ UnsafeStrSave \/ UnsafeStrReset
+    \/ UnsafeConLoad \/ UnsafeConCompute \/ UnsafeConSave \/ UnsafeConReset
+
+Spec == Init /\ [][NextSafe]_vars
+SpecBuggy == Init /\ [][NextUnsafe]_vars
+
+\* ── Safety Invariants ─────────────────────────────────
+
+\* Weight is always bounded.
+WeightBounded == graph_weight >= 0 /\ graph_weight <= MaxWeight
+
+\* No lost update: when an operation saves, no other write has
+\* occurred since that operation loaded.  We capture each save's
+\* version at save-time (str_save_ver / con_save_ver) and check
+\* that save_ver = load_ver + 1, meaning this save was immediately
+\* after the load with no intervening writes.
+\*
+\* Safe model: lock guarantees exclusive load-compute-save, so
+\*   save_ver = load_ver + 1 always.
+\* Buggy model: another operation can save between load and save,
+\*   making save_ver > load_ver + 1 (violation).
+NoLostUpdate ==
+    /\ (str_phase = "saved" => str_save_ver = str_load_ver + 1)
+    /\ (con_phase = "saved" => con_save_ver = con_load_ver + 1)
+
+\* State constraint: keep TLC finite by bounding graph_version.
+\* This is NOT a safety property; it truncates exploration.
+VersionBound == graph_version <= MaxVersion
+
+====

--- a/specs/bug-models/MemoryCompaction-buggy.cfg
+++ b/specs/bug-models/MemoryCompaction-buggy.cfg
@@ -1,0 +1,9 @@
+\* Buggy model: priority-only compaction ignores kind caps.
+\* Expected: ConstraintsPreserved VIOLATED (long_term fills all slots).
+SPECIFICATION SpecBuggy
+INVARIANT ConstraintsPreserved NeverEmpty ResultBounded
+CONSTANTS
+    TargetNotes = 8
+    ConstraintCap = 2
+    LongTermCap = 3
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/MemoryCompaction.cfg
+++ b/specs/bug-models/MemoryCompaction.cfg
@@ -1,0 +1,9 @@
+\* Clean model: compaction respects per-kind caps.
+\* Expected: no error (ConstraintsPreserved, NeverEmpty, ResultBounded hold).
+SPECIFICATION Spec
+INVARIANT ConstraintsPreserved NeverEmpty ResultBounded
+CONSTANTS
+    TargetNotes = 8
+    ConstraintCap = 2
+    LongTermCap = 3
+CHECK_DEADLOCK FALSE

--- a/specs/bug-models/MemoryCompaction.tla
+++ b/specs/bug-models/MemoryCompaction.tla
@@ -1,0 +1,171 @@
+---- MODULE MemoryCompaction ----
+\* Bug Model: Memory bank compaction drops important notes.
+\*
+\* Models keeper_memory_bank.ml compact_memory_bank_if_needed.
+\* Correct code: selection respects kind caps (constraints:2,
+\* decision:2, long_term:4, ...) + recent floor (44 notes).
+\* Bug: priority-only selection lets high-priority long_term notes
+\* fill all slots, starving constraints and other kinds.
+\*
+\* Reference: keeper_memory_bank.ml lines 292-448,
+\*            keeper_memory_policy.ml lines 131-148 (kind_caps).
+
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    TargetNotes,       \* Max notes after compaction (e.g. 8 for small model)
+    ConstraintCap,     \* Max constraint notes to keep (e.g. 2)
+    LongTermCap        \* Max long_term notes to keep (e.g. 3)
+
+VARIABLES
+    bank,              \* Sequence of notes: [kind |-> "...", priority |-> Nat]
+    result,            \* Sequence of notes after compaction
+    phase              \* "accumulating" | "compacting" | "done"
+
+vars == <<bank, result, phase>>
+
+\* Kinds and their priorities (matching OCaml code)
+Kinds == {"constraint", "decision", "progress", "long_term"}
+
+\* Count notes of a given kind in a sequence
+KindCount(seq, kind) ==
+    Cardinality({i \in 1..Len(seq) : seq[i].kind = kind})
+
+TypeOK ==
+    /\ phase \in {"accumulating", "compacting", "done"}
+    /\ \A i \in 1..Len(bank) :
+         /\ bank[i].kind \in Kinds
+         /\ bank[i].priority \in 0..100
+
+Init ==
+    /\ bank = <<>>
+    /\ result = <<>>
+    /\ phase = "accumulating"
+
+\* ── Accumulation (add notes to bank) ──────────────────
+
+AppendConstraint ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2   \* Allow growth beyond target
+    /\ bank' = Append(bank, [kind |-> "constraint", priority |-> 90])
+    /\ UNCHANGED <<result, phase>>
+
+AppendDecision ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2
+    /\ bank' = Append(bank, [kind |-> "decision", priority |-> 86])
+    /\ UNCHANGED <<result, phase>>
+
+AppendProgress ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2
+    /\ bank' = Append(bank, [kind |-> "progress", priority |-> 66])
+    /\ UNCHANGED <<result, phase>>
+
+AppendLongTerm ==
+    /\ phase = "accumulating"
+    /\ Len(bank) < TargetNotes * 2
+    /\ bank' = Append(bank, [kind |-> "long_term", priority |-> 95])
+    /\ UNCHANGED <<result, phase>>
+
+\* ── Trigger compaction (when bank exceeds target) ─────
+
+TriggerCompaction ==
+    /\ phase = "accumulating"
+    /\ Len(bank) > TargetNotes
+    /\ phase' = "compacting"
+    /\ UNCHANGED <<bank, result>>
+
+\* ── Safe compaction (with kind caps) ──────────────────
+
+\* Select notes respecting per-kind caps.
+\* Priority-sorted, but each kind limited to its cap.
+SafeCompact ==
+    /\ phase = "compacting"
+    /\ LET
+         \* Constraint notes: take up to ConstraintCap
+         constraints == SelectSeq(bank, LAMBDA n : n.kind = "constraint")
+         kept_constraints == SubSeq(constraints, 1, IF Len(constraints) > ConstraintCap
+                                                    THEN ConstraintCap
+                                                    ELSE Len(constraints))
+         \* Long-term notes: take up to LongTermCap
+         longtermNotes == SelectSeq(bank, LAMBDA n : n.kind = "long_term")
+         kept_longterm == SubSeq(longtermNotes, 1, IF Len(longtermNotes) > LongTermCap
+                                                   THEN LongTermCap
+                                                   ELSE Len(longtermNotes))
+         \* Decision notes: take up to ConstraintCap (same cap in code)
+         decisions == SelectSeq(bank, LAMBDA n : n.kind = "decision")
+         kept_decisions == SubSeq(decisions, 1, IF Len(decisions) > ConstraintCap
+                                                THEN ConstraintCap
+                                                ELSE Len(decisions))
+         \* Progress notes: fill remaining slots
+         progress == SelectSeq(bank, LAMBDA n : n.kind = "progress")
+         remaining == TargetNotes - Len(kept_constraints)
+                                  - Len(kept_longterm)
+                                  - Len(kept_decisions)
+         kept_progress == SubSeq(progress, 1, IF Len(progress) > remaining
+                                              THEN IF remaining > 0 THEN remaining ELSE 0
+                                              ELSE Len(progress))
+       IN
+         /\ result' = kept_constraints \o kept_longterm \o kept_decisions \o kept_progress
+         /\ phase' = "done"
+         /\ UNCHANGED <<bank>>
+
+\* ── Buggy compaction (priority-only, no kind caps) ────
+
+BugPriorityOnlyCompact ==
+    /\ phase = "compacting"
+    /\ LET
+         \* Just take the first TargetNotes entries (bank is appended
+         \* in priority order: long_term(95) > constraint(90) > decision(86) > progress(66))
+         \* So highest-priority notes fill all slots, starving lower kinds.
+         \*
+         \* Sort by priority descending: long_term first, then constraint,
+         \* then decision, then progress.  If there are more long_term
+         \* notes than TargetNotes, constraints get 0 slots.
+         sortedByPri == SelectSeq(bank, LAMBDA n : n.priority >= 90)
+         lowPri == SelectSeq(bank, LAMBDA n : n.priority < 90)
+         allSorted == sortedByPri \o lowPri
+         taken == SubSeq(allSorted, 1, IF Len(allSorted) > TargetNotes
+                                       THEN TargetNotes
+                                       ELSE Len(allSorted))
+       IN
+         /\ result' = taken
+         /\ phase' = "done"
+         /\ UNCHANGED <<bank>>
+
+\* ── Specifications ────────────────────────────────────
+
+NextSafe ==
+    \/ AppendConstraint \/ AppendDecision \/ AppendProgress \/ AppendLongTerm
+    \/ TriggerCompaction
+    \/ SafeCompact
+
+NextBuggy ==
+    \/ AppendConstraint \/ AppendDecision \/ AppendProgress \/ AppendLongTerm
+    \/ TriggerCompaction
+    \/ BugPriorityOnlyCompact
+
+Spec == Init /\ [][NextSafe]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety Invariants ─────────────────────────────────
+
+\* After compaction, constraint notes are preserved up to their cap.
+\* If the bank had N constraint notes, the result must have min(N, ConstraintCap).
+ConstraintsPreserved ==
+    phase = "done" =>
+        KindCount(result, "constraint") >=
+            IF KindCount(bank, "constraint") > ConstraintCap
+            THEN ConstraintCap
+            ELSE KindCount(bank, "constraint")
+
+\* Compaction never produces an empty result from a non-empty bank.
+NeverEmpty ==
+    (phase = "done" /\ Len(bank) > 0) => Len(result) > 0
+
+\* Result never exceeds target.
+ResultBounded ==
+    phase = "done" => Len(result) <= TargetNotes
+
+====


### PR DESCRIPTION
## Summary

Adds formal verification for the two memory subsystems PR #6889 wired up.
Follows the existing clean+buggy dual-cfg pattern used across `specs/bug-models/`.

- `HebbianLearning.tla` — strengthen/consolidate concurrency under file lock
- `MemoryCompaction.tla` — kind-cap compaction selection for keeper memory bank

## Hebbian verification

**Clean model** (`Spec == Init /\ [][NextSafe]_vars`)
- 941 distinct states, depth 27, no error.
- Lock serializes load-compute-save → `save_ver = load_ver + 1` always.

**Buggy model** (`SpecBuggy == Init /\ [][NextUnsafe]_vars`)
- `Invariant NoLostUpdate is violated` at state 7.
- Trace: strengthen loads weight=5 (ver 0) → consolidate loads weight=5 (ver 0) → consolidate saves weight=4 (ver 1) → strengthen computes → strengthen saves weight=6 (ver 2, using stale snapshot 5).
- `str_save_ver=2 ≠ str_load_ver+1=1` → lost update proven.

`save_ver` captures `graph_version` at save-time so the invariant can assert no intervening write between load and save. `VersionBound` state constraint (`MaxVersion=6`) keeps TLC finite.

## Compaction verification

**Clean model**: respects per-kind caps (ConstraintCap=2, LongTermCap=3). `ConstraintsPreserved` holds.

**Buggy model**: priority-only selection. `Invariant ConstraintsPreserved is violated` — long_term (priority 95) fills every slot, starving constraints.

## Files

| File | Purpose |
|------|---------|
| `HebbianLearning.tla` | Hebbian RMW concurrency spec (Safe + Unsafe Next) |
| `HebbianLearning.cfg` | Clean config (lock serializes) |
| `HebbianLearning-buggy.cfg` | Buggy config (no lock, clobber) |
| `MemoryCompaction.tla` | Compaction data preservation spec |
| `MemoryCompaction.cfg` | Clean config (kind caps) |
| `MemoryCompaction-buggy.cfg` | Buggy config (priority-only) |

Makefile auto-discovers via `bug-models/*.cfg` — no build wiring changes.

## Test plan

- [x] `tlc HebbianLearning.cfg` → no error (941 states)
- [x] `tlc HebbianLearning-buggy.cfg` → NoLostUpdate violated
- [x] `tlc MemoryCompaction-buggy.cfg` → ConstraintsPreserved violated
- [ ] CI TLA+ Model Checking job green on this branch
- [ ] MemoryCompaction clean fully explored in CI (local run partial due to state space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)