### PR TITLE
[codex] fix(keeper): require approval for risky operations

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -109,10 +109,14 @@ let assess_trifecta ~active_tool_names =
 (** When trifecta is active (all 3 classes present), escalate risk
     of state_modification tools to at least High.
     This ensures HITL gates fire at lower governance levels. *)
-let combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk =
+let combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk ~input =
   if trifecta_active then
     let caps = tool_capabilities tool_name in
-    if has_capability State_modification caps then
+    let read_only_keeper_github =
+      String.equal tool_name "keeper_github"
+      && Keeper_tool_registry.is_read_only_with_input ~tool_name ~input
+    in
+    if has_capability State_modification caps && not read_only_keeper_github then
       max_risk_level base_risk High
     else
       base_risk
@@ -289,14 +293,27 @@ let baseline_risk ~tool_name ~input =
           else
             classify_name tool_name)
 
+let keeper_mutation_requires_high_floor ~tool_name ~input =
+  match tool_name with
+  | "keeper_fs_edit" | "keeper_write"
+  | "keeper_pr_submit" | "keeper_pr_workflow" -> true
+  | "keeper_github" ->
+    not (Keeper_tool_registry.is_read_only_with_input ~tool_name ~input)
+  | _ -> false
+
 let assess_risk ~tool_name ~input =
-  match classify_with_payload ~tool_name ~input with
-  | Some level -> level
-  | None -> (
+  let base_risk =
+    match classify_with_payload ~tool_name ~input with
+    | Some level -> level
+    | None -> (
       let baseline = baseline_risk ~tool_name ~input in
       match classify_with_contract_risk ~tool_name ~input with
       | Some level -> max_risk_level baseline level
       | None -> baseline)
+  in
+  if keeper_mutation_requires_high_floor ~tool_name ~input
+  then max_risk_level base_risk High
+  else base_risk
 
 (* ── Trace ID generation ────────────────────────────────────── *)
 
@@ -313,6 +330,10 @@ let confirm_threshold = function
   | "enterprise" -> Some High
   | "production" -> Some Critical
   | "development" | _ -> None
+
+let keeper_confirm_threshold = function
+  | "production" -> Some High
+  | other -> confirm_threshold other
 
 (** Minimum risk level that triggers audit logging. *)
 let audit_threshold = function
@@ -446,10 +467,10 @@ let to_oas_approval_callback
     let trifecta_active = trifecta_count >= 3 in
     let base_risk = assess_risk ~tool_name ~input in
     let risk =
-      combinatorial_risk_escalation ~trifecta_active ~tool_name ~base_risk
+      combinatorial_risk_escalation ~trifecta_active ~tool_name ~input ~base_risk
     in
     let needs_approval =
-      match confirm_threshold governance_level with
+      match keeper_confirm_threshold governance_level with
       | Some threshold -> risk_level_to_int risk >= risk_level_to_int threshold
       | None -> false
     in

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -30,11 +30,18 @@ val confirm_threshold : string -> risk_level option
 (** Minimum risk level that requires confirmation for the given governance level.
     Returns [None] for "development" (no confirmation needed). *)
 
+val keeper_confirm_threshold : string -> risk_level option
+(** Keeper-specific confirmation threshold.
+    Keepers are more autonomous than front-door tool dispatch, so production
+    keepers confirm from High upward while the generic production surface
+    confirms only Critical. *)
+
 val assess_risk : tool_name:string -> input:Yojson.Safe.t -> risk_level
 (** Classify tool risk using, in order:
     - tool metadata overrides (readonly/destructive)
     - payload-sensitive destructive semantics for selected mutation fields
     - name/action heuristics as a deterministic fallback
+    - keeper mutation floor: keeper file/PR mutations are elevated to at least High
 
     Result classes:
     - Critical: destructive ops or destructive payload semantics
@@ -91,9 +98,12 @@ val combinatorial_risk_escalation :
   trifecta_active:bool ->
   tool_name:string ->
   base_risk:risk_level ->
+  input:Yojson.Safe.t ->
   risk_level
 (** If trifecta is active and the tool is a state_modification tool,
-    escalate risk to at least High. Otherwise return base_risk unchanged. *)
+    escalate risk to at least High. Read-only keeper_github subcommands remain
+    at [base_risk] even though the top-level tool can mutate. Otherwise return
+    base_risk unchanged. *)
 
 val to_oas_approval_callback :
   governance_level:string ->

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -555,7 +555,7 @@ let make_hooks
                let governance_level = Env_config_core.governance_level () in
                let risk = Governance_pipeline.assess_risk ~tool_name ~input in
                let needs_approval =
-                 match Governance_pipeline.confirm_threshold governance_level with
+                 match Governance_pipeline.keeper_confirm_threshold governance_level with
                  | Some threshold ->
                    Governance_pipeline.risk_level_to_int risk
                    >= Governance_pipeline.risk_level_to_int threshold
@@ -569,7 +569,7 @@ let make_hooks
              let governance_level = Env_config_core.governance_level () in
              let risk = Governance_pipeline.assess_risk ~tool_name ~input in
              let needs_approval =
-               match Governance_pipeline.confirm_threshold governance_level with
+               match Governance_pipeline.keeper_confirm_threshold governance_level with
                | Some threshold ->
                  Governance_pipeline.risk_level_to_int risk
                  >= Governance_pipeline.risk_level_to_int threshold

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -74,7 +74,7 @@ let build_keeper_system_prompt
        - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.\n\
        - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands), keeper_github (PR/issues), keeper_pr_submit (submit staged changes from a playground clone or repo worktree), keeper_pr_workflow (legacy one-shot worktree helper), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit, keeper_bash, or the appropriate PR submit path.\n\
        - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST call keeper_task_done when finished. Claim -> Work -> Done. Every claimed task must be closed. Leaving tasks open creates zombie tasks.\n\
-       - You do not need permission to act. You live here.\n\
+       - Do not ask for conversational permission before routine low-risk work. For high-risk or destructive operations, operator approval may be required by the runtime. Do not assume risky actions are pre-approved.\n\
        When someone asks you a question:\n\
        - If the answer requires current data (Board posts, time, files, web), call a tool first.\n\
        - If you can answer from conversation context alone, respond directly.\n\

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -744,6 +744,7 @@ let test_escalation_state_mod_in_trifecta () =
       ~trifecta_active:true
       ~tool_name:"keeper_fs_edit"
       ~base_risk:Gp.Medium
+      ~input:`Null
   in
   Alcotest.(check string) "escalated to high"
     "high" (Gp.risk_level_to_string escalated)
@@ -755,6 +756,7 @@ let test_escalation_keeps_higher_risk () =
       ~trifecta_active:true
       ~tool_name:"keeper_fs_edit"
       ~base_risk:Gp.Critical
+      ~input:`Null
   in
   Alcotest.(check string) "stays critical"
     "critical" (Gp.risk_level_to_string escalated)
@@ -765,6 +767,7 @@ let test_escalation_no_trifecta_no_change () =
       ~trifecta_active:false
       ~tool_name:"keeper_fs_edit"
       ~base_risk:Gp.Low
+      ~input:`Null
   in
   Alcotest.(check string) "stays low without trifecta"
     "low" (Gp.risk_level_to_string unchanged)
@@ -776,8 +779,20 @@ let test_escalation_non_state_mod_unchanged () =
       ~trifecta_active:true
       ~tool_name:"keeper_fs_read"
       ~base_risk:Gp.Low
+      ~input:`Null
   in
   Alcotest.(check string) "read-only stays low"
+    "low" (Gp.risk_level_to_string unchanged)
+
+let test_escalation_read_only_keeper_github_unchanged () =
+  let unchanged =
+    Gp.combinatorial_risk_escalation
+      ~trifecta_active:true
+      ~tool_name:"keeper_github"
+      ~input:(`Assoc [("cmd", `String "pr view 123")])
+      ~base_risk:Gp.Low
+  in
+  Alcotest.(check string) "read-only keeper_github stays low"
     "low" (Gp.risk_level_to_string unchanged)
 
 let test_tool_capabilities_known () =
@@ -877,6 +892,8 @@ let () =
         test_escalation_no_trifecta_no_change;
       Alcotest.test_case "escalation: non-state_mod unchanged" `Quick
         test_escalation_non_state_mod_unchanged;
+      Alcotest.test_case "escalation: read-only keeper_github unchanged" `Quick
+        test_escalation_read_only_keeper_github_unchanged;
       Alcotest.test_case "capabilities: known tool" `Quick
         test_tool_capabilities_known;
       Alcotest.test_case "capabilities: unknown tool" `Quick

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -32,6 +32,8 @@ let test_risk_classification_high () =
   let tools = [
     ("masc_code_write", GP.High);
     ("keeper_write", GP.High);
+    ("keeper_fs_edit", GP.High);
+    ("keeper_pr_submit", GP.High);
     ("masc_create_task", GP.High);
   ] in
   List.iter (fun (tool_name, expected) ->
@@ -57,6 +59,26 @@ let test_risk_classification_low () =
       (GP.risk_level_to_string expected)
       (GP.risk_level_to_string actual)
   ) tools
+
+let test_keeper_github_read_only_stays_low () =
+  let actual =
+    GP.assess_risk
+      ~tool_name:"keeper_github"
+      ~input:(`Assoc [("cmd", `String "pr view 123")])
+  in
+  check "keeper_github pr view → low"
+    (GP.risk_level_to_string GP.Low)
+    (GP.risk_level_to_string actual)
+
+let test_keeper_github_mutation_escalates_high () =
+  let actual =
+    GP.assess_risk
+      ~tool_name:"keeper_github"
+      ~input:(`Assoc [("cmd", `String "pr comment 123 --body hi")])
+  in
+  check "keeper_github pr comment → high"
+    (GP.risk_level_to_string GP.High)
+    (GP.risk_level_to_string actual)
 
 (* ── 2. Threshold decisions ──────────────────────────────── *)
 
@@ -245,6 +267,60 @@ let test_callback_approves_low_risk () =
     Alcotest.fail ("expected Approve for low-risk tool, got Reject: " ^ r)
   | _ -> Alcotest.fail "unexpected decision"
 
+let test_callback_production_keeper_write_requires_approval () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let initial_pending = AQ.pending_count () in
+  let result = ref None in
+  Eio.Fiber.fork ~sw (fun () ->
+    let cb =
+      GP.to_oas_approval_callback
+        ~governance_level:"production" ~keeper_name:"test" in
+    let decision =
+      cb
+        ~tool_name:"keeper_fs_edit"
+        ~input:(`Assoc [
+          ("path", `String "lib/example.ml");
+          ("content", `String "let x = 1\n");
+        ])
+    in
+    result := Some decision
+  );
+  Eio.Fiber.yield ();
+  Alcotest.(check int) "one pending approval"
+    (initial_pending + 1) (AQ.pending_count ());
+  let pending_json = AQ.list_pending_json () in
+  let id =
+    match pending_json with
+    | `List (`Assoc kvs :: _) ->
+      (match List.assoc_opt "id" kvs with
+       | Some (`String id) -> id
+       | _ -> Alcotest.fail "missing approval id")
+    | _ -> Alcotest.fail "expected pending approval entry"
+  in
+  (match AQ.resolve ~id ~decision:Agent_sdk.Hooks.Approve with
+   | Ok () -> ()
+   | Error msg -> Alcotest.fail ("resolve failed: " ^ msg));
+  Eio.Fiber.yield ();
+  match !result with
+  | Some Agent_sdk.Hooks.Approve -> ()
+  | Some _ -> Alcotest.fail "expected Approve after operator resolution"
+  | None -> Alcotest.fail "keeper write callback did not suspend for approval"
+
+let test_callback_production_keeper_github_read_only_auto_approved () =
+  let cb =
+    GP.to_oas_approval_callback
+      ~governance_level:"production" ~keeper_name:"test" in
+  let decision =
+    cb ~tool_name:"keeper_github"
+      ~input:(`Assoc [("cmd", `String "pr view 123")])
+  in
+  match decision with
+  | Agent_sdk.Hooks.Approve -> ()
+  | Agent_sdk.Hooks.Reject r ->
+    Alcotest.fail ("expected Approve for read-only keeper_github, got Reject: " ^ r)
+  | _ -> Alcotest.fail "unexpected decision"
+
 (* ── Test runner ──────────────────────────────────────────── *)
 
 let () =
@@ -253,6 +329,10 @@ let () =
       Alcotest.test_case "critical tools" `Quick test_risk_classification_critical;
       Alcotest.test_case "high-risk tools" `Quick test_risk_classification_high;
       Alcotest.test_case "low-risk tools" `Quick test_risk_classification_low;
+      Alcotest.test_case "keeper_github read-only stays low" `Quick
+        test_keeper_github_read_only_stays_low;
+      Alcotest.test_case "keeper_github mutation escalates high" `Quick
+        test_keeper_github_mutation_escalates_high;
     ]);
     ("threshold_decisions", [
       Alcotest.test_case "development allows all" `Quick test_development_allows_all;
@@ -269,5 +349,9 @@ let () =
     ]);
     ("callback_integration", [
       Alcotest.test_case "low risk auto-approved" `Quick test_callback_approves_low_risk;
+      Alcotest.test_case "production keeper write requires approval" `Quick
+        test_callback_production_keeper_write_requires_approval;
+      Alcotest.test_case "production keeper_github read-only auto-approved" `Quick
+        test_callback_production_keeper_github_read_only_auto_approved;
     ]);
   ]

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -187,6 +187,28 @@ let test_direct_reply_prompt_matches_server_managed_heartbeat_policy () =
   check bool "does not mention masc_heartbeat" false
     (has_in prompt "masc_heartbeat")
 
+let test_prompt_mentions_runtime_operator_approval_for_risky_actions () =
+  let prompt =
+    KP.build_keeper_system_prompt
+      ~goal:"Keep keeper guidance aligned with runtime behavior"
+      ~short_goal:"verify approval wording"
+      ~mid_goal:"ship coherent keeper guidance"
+      ~long_goal:"avoid approval-policy drift"
+      ~will:"maintain coherent identity"
+      ~needs:"factual grounding"
+      ~desires:"safe execution"
+      ~instructions:""
+      ()
+  in
+  let has_in s needle =
+    try ignore (Str.search_forward (Str.regexp_string needle) s 0); true
+    with Not_found -> false
+  in
+  check bool "mentions operator approval" true
+    (has_in prompt "operator approval may be required by the runtime");
+  check bool "does not claim no permission is needed" false
+    (has_in prompt "You do not need permission to act")
+
 let test_token_report () =
   (* Emit a structured report for A/B comparison *)
   let tp = build_separated () in
@@ -232,6 +254,8 @@ let () =
             test_soft_context_in_dynamic_only;
           test_case "direct reply prompt matches server-managed heartbeat policy" `Quick
             test_direct_reply_prompt_matches_server_managed_heartbeat_policy;
+          test_case "prompt mentions runtime operator approval for risky actions" `Quick
+            test_prompt_mentions_runtime_operator_approval_for_risky_actions;
         ] );
       ( "metrics_report",
         [


### PR DESCRIPTION
## What changed
- align keeper system prompt with runtime governance so it no longer claims risky actions never need permission
- raise keeper-side risk classification for mutating file/PR operations to at least `High`
- use a keeper-specific confirmation threshold so production keepers require operator approval for high-risk mutations
- keep read-only `keeper_github` subcommands auto-approved
- add regression coverage for governance escalation, HITL callback behavior, and prompt wording

## Why
Keeper runtime already had an approval queue and approval callback, but two gaps made keepers act as if operator approval was unnecessary:
1. the keeper prompt explicitly said `You do not need permission to act`
2. production keeper approval only triggered at `Critical`, while common keeper mutations such as file edits and PR submission were classified below that threshold

That mismatch meant keepers often performed risky write paths without surfacing an approval boundary.

## Impact
- risky keeper file/PR operations now suspend on operator approval more often in production
- read-only keeper GitHub commands like `pr view` stay friction-free
- prompt guidance now matches the actual runtime policy instead of teaching the model to ignore approvals

## Validation
- `opam exec -- dune build --root . test/test_hitl_approval.exe test/test_governance_pipeline.exe test/test_keeper_prompt_metrics.exe`
- `./_build/default/test/test_hitl_approval.exe`
- `./_build/default/test/test_governance_pipeline.exe`
- `./_build/default/test/test_keeper_prompt_metrics.exe`
- `git diff --check`

## Root cause
The system prompt and runtime governance policy had drifted apart. In addition, keeper mutation tools were not conservatively classified enough for the production approval threshold to catch them.
