### PR TITLE
chore(dashboard_cache): remove dead cleanup_expired function

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -70,19 +70,6 @@ let maybe_evict () =
     | None -> ()
   end
 
-(** Remove all fully expired entries (past stale_until).
-    Returns the number of entries removed. *)
-let [@warning "-32"] cleanup_expired () =
-  let now_ts = Time_compat.now () in
-  Eio.Mutex.use_rw ~protect:true mu (fun () ->
-    let victims = Hashtbl.fold (fun key slot acc ->
-      match slot with
-      | Ready entry when entry.stale_until <= now_ts -> key :: acc
-      | _ -> acc
-    ) table [] in
-    List.iter (fun key -> Hashtbl.remove table key) victims;
-    List.length victims)
-
 let now () = Time_compat.now ()
 
 (** Default stale grace multiplier: stale data is served for [ttl * stale_factor]


### PR DESCRIPTION
## Summary

Remove `Dashboard_cache.cleanup_expired` — a 13-line function that was never called anywhere in the repo. The `[@warning \"-32\"]` attribute confirmed \"unused value\" at compile time and the code was left behind.

## Product impact

No runtime behavior change. Cache eviction continues via `maybe_evict` (reactive, on-insert).

## Evidence

- `rg 'Dashboard_cache.cleanup_expired' $(repo)` returns **zero matches** outside the definition.
- Function is NOT exposed in `lib/dashboard/dashboard_cache.mli`.
- Reactive eviction in `maybe_evict` (lines 48-71) handles overflow — see inline docstring.
- `dune build --root .` passes locally.

## Review evidence

Audit source: masc-mcp sweep of `[@warning \"-...\"]` suppressions in `lib/`. Only one `[@warning \"-32\"]` (unused-value) in `lib/`. The two `[@warning \"-69\"]` (unused-field) sites found were verified as intentional:

- `lib/runtime_params.ml:43` `clear_override` — docstring at lines 34-36 explains \"set-only from this module's perspective; used internally by typed `clear`\". **Keep.**
- `lib/keeper/keeper_post_turn.ml:43` `overflow_retry_recovery` — all three fields (`checkpoint`, `compaction`, `turn_generation`) read by `keeper_unified_turn.ml` + tests. Warning suppression is for cross-module usage. **Keep.**

This PR is the narrow, clearly-dead case.

## Linked issue

Part of the masc-mcp audit sweep (2026-04-13). No direct issue tracker entry; the audit reports are session-local.

## Test plan

- [x] `dune build --root .` — passes locally
- [ ] CI required checks
- [ ] No behavior change expected — only a function deletion + its docstring + one attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)