### PR TITLE
test(cancellation_coverage): delete 5 zero-assertion type-stub tests

### DIFF
--- a/test/test_cancellation_coverage.ml
+++ b/test/test_cancellation_coverage.ml
@@ -14,31 +14,6 @@ open Alcotest
 module Cancellation = Masc_mcp.Cancellation
 
 (* ============================================================
-   token Type Tests
-   ============================================================ *)
-
-let test_token_type_id () =
-  (* Token has id field *)
-  let _ : string = "token_id" in
-  ()
-
-let test_token_type_cancelled () =
-  let _ : bool = false in
-  ()
-
-let test_token_type_reason () =
-  let _ : string option = None in
-  ()
-
-let test_token_type_callbacks () =
-  let _ : (unit -> unit) list = [] in
-  ()
-
-let test_token_type_created_at () =
-  let _ : float = 0.0 in
-  ()
-
-(* ============================================================
    TokenStore.create_with_id Tests
    ============================================================ *)
 
@@ -138,13 +113,6 @@ let test_cancel_nonexistent () =
 
 let () =
   run "Cancellation Coverage" [
-    "token_type", [
-      test_case "id" `Quick test_token_type_id;
-      test_case "cancelled" `Quick test_token_type_cancelled;
-      test_case "reason" `Quick test_token_type_reason;
-      test_case "callbacks" `Quick test_token_type_callbacks;
-      test_case "created_at" `Quick test_token_type_created_at;
-    ];
     "create_with_id", [
       test_case "creates" `Quick test_create_with_id_creates;
       test_case "not cancelled" `Quick test_create_with_id_not_cancelled;


### PR DESCRIPTION
## Summary

Delete 5 tests from `test/test_cancellation_coverage.ml` whose bodies bind a literal value to a typed binding and return unit. They exercise no code and assert nothing — passing unconditionally.

```ocaml
let test_token_type_id () =
  let _ : string = "token_id" in
  ()
```

All five follow this shape (id / cancelled / reason / callbacks / created_at).

## Product impact

- **Test runtime**: marginal reduction (5 no-op tests).
- **Signal**: no loss — these tests catch exactly zero regressions.
- **Coverage**: unchanged — they don't invoke `Cancellation.*`.
- **CI output**: cleaner test run; the empty `token_type` group is dropped entirely.

Sibling groups (`create_with_id`, `get`, `remove`, `list_all`) remain — those exercise `TokenStore` operations and assert results.

## Evidence

- `dune build --root .` passes locally.
- Per-test inspection confirms no assertion, no function call.
- Audit classification: **zero-assertion type stub** (not a weak test that could be strengthened — the whole premise is \"this literal typechecks as T\").

## Review evidence

Audit source: Axis E (fake-test detection) sweep of 388 test files. Found 170 candidate zero-assertion functions across 55 files. Per-file verification revealed three categories:

1. **Type stubs** — literal → typed binding → unit. Zero runtime signal. (**This PR.**)
2. **Smoke tests** — call a production function but don't check the result. Weak but catches crashes. **Keep** (e.g. `test_is_enabled_type` in `test_auto_responder_coverage.ml:186`).
3. **Internal-assertion delegators** — call a helper that itself contains assertions. **Keep.**

The Axis E \"TOP 10 to delete\" list had overlaps with all three categories. This PR intentionally takes only the unambiguous cluster from a single file. Follow-up PRs will propose per-file deletions after similar verification.

## Linked issue

No blocking issue. Part of the masc-mcp audit sweep (2026-04-13).

## Test plan

- [x] `dune build --root .` — passes locally
- [ ] CI required checks
- [ ] Remaining Alcotest groups (`create_with_id`, `get`, `remove`, `list_all`) unchanged — verified by diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)