### PR TITLE
fix(trace_emit): route TLA trace failures through Log.Keeper.warn

### DIFF
--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -43,6 +43,8 @@ let emit_transition
     ] in
     let path = trace_path ~base_path ~keeper_name in
     try Keeper_types_support.append_jsonl_line path json
-    with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      Printf.eprintf "trace_emit: %s: %s\n%!"
-        keeper_name (Printexc.to_string exn)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+        Log.Keeper.warn "trace_emit: %s: %s"
+          keeper_name (Printexc.to_string exn)


### PR DESCRIPTION
## Summary

`Keeper_trace_emit.emit_transition` caught JSONL-append failures and wrote them via `Printf.eprintf`, bypassing the structured `Log` module used elsewhere in the keeper subsystem. Replace with `Log.Keeper.warn`.

## Product impact

- Structured log output gains the correct `[WARN] [Keeper]` prefix and component tag.
- Downstream log routing (file sinks, stderr mirror, level filter) applies to these messages.
- No change to visibility in interactive debug (operators watching stderr).

## Evidence

- `dune build --root .` passes locally.
- `Log.Keeper.warn` signature matches the existing `Printf.sprintf`-style call: `?ctx:string -> ('a, unit, string, unit) format4 -> 'a`.
- `Log` module is Atomic-based (`log.ml:16 current_level = Atomic.make`) — no Eio scheduler dependency, safe to call from this code path.

## Review evidence

Source: masc-mcp Axis D (telemetry + SSOT drift) sweep. The sweep identified 10 files using `Printf.printf` / `Printf.eprintf` in `lib/`, 38 occurrences total. Per-site classification:

| File | Sites | Classification | This PR |
|------|-------|---------------|---------|
| `keeper_trace_emit.ml` | 1 | Silent bypass | **Fix** |
| `server_bootstrap_http.ml` | 16 | Startup banner (intentional, pre-log-infra) | Skip |
| `masc_log/log.{ml,mli}` | 7 | Log module internals | Skip |
| `opentelemetry_client_cohttp_eio.ml` | 7 | OpenTelemetry exporter internals | Skip |
| `config/env_config_core.ml` | 1 | Deprecation warning at module init — may precede Log init | Follow-up |
| `config/feature_flag_registry.ml` | 1 | Registry miss warning at module init — same caveat | Follow-up |
| `fs_compat/fs_compat.ml` | 1 | JSONL parse warning; called from several places | Follow-up |
| `http_server_eio.ml`, `http_server_h2.ml` | 2+2 | Server startup | Follow-up |

The follow-ups need a module-init-order audit before migration — some of those `Printf.eprintf` calls run before `Masc_log.Log` is ready. The trace_emit case does not have that concern: `emit_transition` runs inside a keeper fiber during state transitions, long after Log is initialized.

## Linked issue

No blocking issue. Part of the masc-mcp audit sweep (2026-04-13).

## Test plan

- [x] `dune build --root .` — passes locally
- [ ] CI required checks
- [ ] Manual: enable `MASC_TLA_TRACE=1`, force a JSONL write failure (read-only trace dir), check stderr shows `[WARN] [Keeper] trace_emit: ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)