### PR TITLE
chore(dashboard): remove orphaned dashboard_proof.mli

### DIFF
--- a/lib/dashboard/dashboard_proof.mli
+++ b/lib/dashboard/dashboard_proof.mli
@@ -1,7 +1,0 @@
-val json :
-  ?actor:string ->
-  ?session_id:string ->
-  ?operation_id:string ->
-  config:Room.config ->
-  unit ->
-  Yojson.Safe.t


### PR DESCRIPTION
## Summary

Delete `lib/dashboard/dashboard_proof.mli` (7 lines). The file declares `val json : ... -> Yojson.Safe.t` but has no `.ml` implementation and is not listed in `lib/dune`'s `(modules ...)` allow-list. Dune never built it; no .ml source references it.

## Product impact

None. The file was never compiled.

## Evidence

- `find lib -name 'dashboard_proof*'` returns only the orphan `.mli`.
- `rg 'Dashboard_proof'` across `.ml` sources: 0 matches. The dep-graph JSON (`reports/lib-dependency-graph.json`) does reference `Dashboard_proof*`, but that report is stale — it also lists `Dashboard_proof_actors`, `_events`, `_helpers`, `_verdict` as modules that don't exist on disk either.
- `grep dashboard_proof lib/dune` returns 0 matches. Dune's `(modules ...)` allow-list omits it, so dune silently ignores it.
- `dune build --root .` passes with the file deleted. Also passed before the deletion — dune never built it in either case.

## Review evidence

Audit source: masc-mcp dune-modules consistency sweep. Process: enumerate all `.ml` and `.mli` files under `lib/` (expanding subdirectories), group by basename, report mismatches. 646 `.ml`, 233 `.mli`. One orphaned `.mli` (this file). 412 `.ml` without `.mli` (normal — private implementations).

The sweep also surfaced the stale dep-graph report; regenerating that is out of scope for this PR (it's a build artifact, not hand-edited).

## Linked issue

No blocking issue. Part of the masc-mcp audit sweep (2026-04-13).

## Test plan

- [x] `dune build --root .` — passes locally (both before and after deletion; the file was never part of the build).
- [ ] CI required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)