### PR TITLE
fix(log): demote truncation-only checkpoint sanitize to debug

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -930,7 +930,15 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
     |> Option.map (fun checkpoint ->
       let sanitized, stats = sanitize_oas_checkpoint checkpoint in
       if checkpoint_sanitize_changed stats then begin
-        Log.Keeper.warn
+        let has_data_loss =
+          stats.dropped_blocks > 0
+          || stats.dropped_messages > 0
+          || stats.dropped_chars > 0
+        in
+        (if has_data_loss then
+           Log.Keeper.warn
+         else
+           Log.Keeper.debug)
           "keeper:%s checkpoint migration sanitized messages: dropped_blocks=%d dropped_messages=%d dropped_chars=%d truncated_blocks=%d truncated_chars=%d"
           trace_id
           stats.dropped_blocks


### PR DESCRIPTION
## Summary
- Checkpoint migration `sanitize_oas_checkpoint` runs every turn. OAS overwrites checkpoint with full content after each turn, so truncation repeats indefinitely.
- When `dropped_blocks/messages/chars = 0` (no data loss, only cosmetic truncation), demote WARN → debug.
- WARN only fires on actual data loss (dropped > 0).
- Eliminates ~30% of all WARN lines in production log (40+ repeated identical entries per trace keeper).

## Test plan
- [ ] `dune build` — type checks
- [ ] Verify via server log: trace keeper checkpoint sanitize no longer floods WARN
- [ ] `dropped > 0` case still WARN (manual test: corrupt a checkpoint block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)