### PR TITLE
feat(dashboard): per-model timeseries sparklines + cost/cache breakdown

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -561,6 +561,18 @@ export interface DashboardRuntimeProvidersResponse {
   providers: DashboardRuntimeProviderSnapshot[]
 }
 
+export interface BucketMetric {
+  ts_start: number
+  entry_count: number
+  success_count: number
+  error_count: number
+  p50_latency_ms: number
+  p95_latency_ms: number
+  error_rate: number
+  total_cost_usd: number
+  cache_hit_ratio: number
+}
+
 export interface DashboardRuntimeModelMetric {
   model_id: string
   entry_count?: number | null
@@ -589,10 +601,12 @@ export interface DashboardRuntimeModelMetric {
     cost_usd: number
     tools_count: number
   }> | null
+  buckets?: BucketMetric[] | null
 }
 
 export interface DashboardRuntimeModelMetricsResponse {
   window_minutes?: number
+  bucket_minutes?: number
   total_entries?: number
   total_error_entries?: number
   models: DashboardRuntimeModelMetric[]
@@ -691,6 +705,21 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
             tools_count: asNumber(r.tools_count) ?? 0,
           }))
       : null,
+    buckets: Array.isArray(raw.buckets)
+      ? (raw.buckets as unknown[])
+          .filter(isRecord)
+          .map(b => ({
+            ts_start: asNumber(b.ts_start) ?? 0,
+            entry_count: asNumber(b.entry_count) ?? 0,
+            success_count: asNumber(b.success_count) ?? 0,
+            error_count: asNumber(b.error_count) ?? 0,
+            p50_latency_ms: asNumber(b.p50_latency_ms) ?? 0,
+            p95_latency_ms: asNumber(b.p95_latency_ms) ?? 0,
+            error_rate: asNumber(b.error_rate) ?? 0,
+            total_cost_usd: asNumber(b.total_cost_usd) ?? 0,
+            cache_hit_ratio: asNumber(b.cache_hit_ratio) ?? 0,
+          }))
+      : null,
   }
 }
 
@@ -698,6 +727,7 @@ function decodeRuntimeModelMetricsResponse(raw: unknown): DashboardRuntimeModelM
   if (!isRecord(raw)) return null
   return {
     window_minutes: asNumber(raw.window_minutes),
+    bucket_minutes: asNumber(raw.bucket_minutes),
     total_entries: asNumber(raw.total_entries),
     total_error_entries: asNumber(raw.total_error_entries),
     models: asRecordArray(raw.models)
@@ -715,9 +745,11 @@ export async function fetchRuntimeProviders(opts?: AbortableRequestOptions): Pro
 
 export async function fetchRuntimeModelMetrics(
   windowMinutes = 30,
+  bucketMinutes = 5,
   opts?: AbortableRequestOptions,
 ): Promise<DashboardRuntimeModelMetricsResponse> {
-  const raw = await get<Record<string, unknown>>(`/api/v1/models/metrics?window=${windowMinutes}`, { signal: opts?.signal })
+  const bParam = bucketMinutes > 0 ? `&bucket_min=${bucketMinutes}` : ''
+  const raw = await get<Record<string, unknown>>(`/api/v1/models/metrics?window=${windowMinutes}${bParam}`, { signal: opts?.signal })
   const decoded = decodeRuntimeModelMetricsResponse(raw)
   if (!decoded) throw new Error('invalid runtime model metrics payload')
   return decoded

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -4,6 +4,7 @@ import { useSignal } from '@preact/signals'
 import {
   fetchRuntimeModelMetrics,
   fetchRuntimeProviders,
+  type BucketMetric,
   type DashboardRuntimeModelMetric,
   type DashboardRuntimeModelMetricsResponse,
   type DashboardRuntimeProviderSnapshot,
@@ -25,7 +26,7 @@ async function loadRuntimeData(resource: ManagedAsyncResource<RuntimeData>, wind
   await resource.load(async (signal) => {
     const [providers, metrics] = await Promise.all([
       fetchRuntimeProviders({ signal }),
-      fetchRuntimeModelMetrics(windowMinutes, { signal }),
+      fetchRuntimeModelMetrics(windowMinutes, 5, { signal }),
     ])
     return { providers, metrics }
   })
@@ -80,6 +81,24 @@ function fmtTime(tsUnix: number): string {
   if (tsUnix <= 0) return '--'
   const d = new Date(tsUnix * 1000)
   return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function fmtPct(value: number): string {
+  if (Number.isNaN(value)) return '--'
+  return `${(value * 100).toFixed(1)}%`
+}
+
+function sparklineSvg(values: number[], color: string, w = 80, h = 20): string {
+  if (values.length < 2) return ''
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const points = values.map((v, i) => {
+    const x = (i / (values.length - 1)) * w
+    const y = h - ((v - min) / range) * (h - 2) - 1
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  }).join(' ')
+  return `<svg width="${w}" height="${h}" class="inline-block align-middle" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg"><polyline fill="none" stroke="${color}" stroke-width="1.5" stroke-linejoin="round" points="${points}"/></svg>`
 }
 
 export function RuntimeMonitor() {
@@ -228,6 +247,22 @@ export function RuntimeMonitor() {
                     <div>reasoning/cache · ${fmtNumber(metric.total_reasoning_tokens)} / ${fmtNumber(metric.total_cache_read_tokens)}</div>
                     <div>tools · ${fmtNumber(metric.avg_tool_calls_per_turn, 1)}/turn (${fmtNumber(metric.total_tool_calls)})</div>
                   </div>
+                  ${(metric.buckets ?? []).length >= 2
+                    ? html`<div class="flex items-center gap-4 mt-1 text-[11px] text-[var(--text-muted)]">
+                        <span>p95 latency</span>
+                        <span dangerouslySetInnerHTML=${{ __html: sparklineSvg((metric.buckets as BucketMetric[]).map(b => b.p95_latency_ms), 'var(--status-warn)', 80, 18) }}></span>
+                        <span>error rate</span>
+                        <span dangerouslySetInnerHTML=${{ __html: sparklineSvg((metric.buckets as BucketMetric[]).map(b => b.error_rate), 'var(--status-bad)', 80, 18) }}></span>
+                      </div>`
+                    : null}
+                  ${(() => {
+                    const cacheRead = metric.total_cache_read_tokens ?? 0
+                    const totalIn = cacheRead + (metric.total_input_tokens ?? 0)
+                    const cacheRatio = totalIn > 0 ? cacheRead / totalIn : 0
+                    return html`<div class="text-[11px] text-[var(--text-muted)] mt-1">
+                      cost ${fmtCost(metric.total_cost_usd)} · cache savings ${fmtPct(cacheRatio)} (${fmtNumber(cacheRead)} / ${fmtNumber(totalIn)} tokens)
+                    </div>`
+                  })()}
                   ${(metric.error_count ?? 0) > 0
                     ? html`<div class="text-[11px] text-[var(--status-bad)] mt-1">errors ${fmtNumber(metric.error_count)} / success ${fmtNumber(metric.success_count)}</div>`
                     : null}

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -19,6 +19,23 @@ type recent_entry = {
   re_tools_count : int;
 }
 
+type bucket_metric = {
+  b_ts_start : float;
+  b_entry_count : int;
+  b_success_count : int;
+  b_error_count : int;
+  b_p50_latency_ms : float;
+  b_p95_latency_ms : float;
+  b_error_rate : float;
+  b_total_cost_usd : float;
+  b_cache_hit_ratio : float;
+}
+
+type model_bucketed = {
+  mb_model_id : string;
+  mb_buckets : bucket_metric list;
+}
+
 type model_stats = {
   model_id : string;
   entry_count : int;
@@ -40,10 +57,12 @@ type model_stats = {
   total_tool_calls : int;
   top_tools : (string * int) list;
   recent_entries : recent_entry list;
+  buckets : bucket_metric list;
 }
 
 type aggregate = {
   window_minutes : int;
+  bucket_minutes : int;
   models : model_stats list;
   total_entries : int;
   total_error_entries : int;
@@ -284,10 +303,69 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
           re_cost_usd = e.cost_usd;
           re_tools_count = e.tool_call_count;
         });
+      buckets = [];
     } in
     stats :: acc
   ) tbl []
   |> List.sort (fun a b -> compare b.entry_count a.entry_count)
+
+(* ── Time-bucketed aggregation ──────────────────────────── *)
+
+(** Bucket entries for a single model. Returns oldest-first list of
+    non-empty buckets. *)
+let bucket_entries_for_model (entries : raw_entry list) ~(bucket_sec : int)
+    : bucket_metric list =
+  let bsec = if bucket_sec <= 0 then 60 else bucket_sec in
+  let bsec_f = Float.of_int bsec in
+  let tbl : (int, raw_entry list) Hashtbl.t = Hashtbl.create 16 in
+  List.iter (fun e ->
+    let key = int_of_float (Float.floor (e.ts_unix /. bsec_f)) in
+    let prev = match Hashtbl.find_opt tbl key with Some l -> l | None -> [] in
+    Hashtbl.replace tbl key (e :: prev)
+  ) entries;
+  Hashtbl.fold (fun key bucket_entries acc ->
+    let n = List.length bucket_entries in
+    let lat_vals = List.filter_map (fun e ->
+      if e.latency_ms > 0.0 then Some e.latency_ms else None
+    ) bucket_entries |> Array.of_list in
+    Array.sort Float.compare lat_vals;
+    let success_count = List.length (List.filter (fun e -> not e.is_error) bucket_entries) in
+    let error_count = List.length (List.filter (fun e -> e.is_error) bucket_entries) in
+    let total_cache_read = List.fold_left (fun acc e -> acc + e.cache_read_tokens) 0 bucket_entries in
+    let total_input = List.fold_left (fun acc e -> acc + e.input_tokens) 0 bucket_entries in
+    let denom = total_cache_read + total_input in
+    let cache_hit_ratio =
+      if denom = 0 then 0.0
+      else Float.of_int total_cache_read /. Float.of_int denom
+    in
+    let error_rate =
+      if n = 0 then 0.0
+      else Float.of_int error_count /. Float.of_int n
+    in
+    let bucket = {
+      b_ts_start = Float.of_int key *. bsec_f;
+      b_entry_count = n;
+      b_success_count = success_count;
+      b_error_count = error_count;
+      b_p50_latency_ms = percentile lat_vals 50.0;
+      b_p95_latency_ms = percentile lat_vals 95.0;
+      b_error_rate = error_rate;
+      b_total_cost_usd =
+        List.fold_left (fun acc e -> acc +. e.cost_usd) 0.0 bucket_entries;
+      b_cache_hit_ratio = cache_hit_ratio;
+    } in
+    bucket :: acc
+  ) tbl []
+  |> List.sort (fun a b -> Float.compare a.b_ts_start b.b_ts_start)
+
+let group_entries_by_model (entries : raw_entry list)
+    : (string * raw_entry list) list =
+  let tbl : (string, raw_entry list) Hashtbl.t = Hashtbl.create 8 in
+  List.iter (fun e ->
+    let prev = match Hashtbl.find_opt tbl e.model with Some l -> l | None -> [] in
+    Hashtbl.replace tbl e.model (e :: prev)
+  ) entries;
+  Hashtbl.fold (fun model es acc -> (model, es) :: acc) tbl []
 
 (* ── Public API ─────────────────────────────────────────── *)
 
@@ -298,10 +376,62 @@ let compute ~base_path ~window_minutes : aggregate =
   let total_error_entries =
     List.length (List.filter (fun e -> e.is_error) entries)
   in
-  { window_minutes; models; total_entries = List.length entries;
+  { window_minutes; bucket_minutes = 0; models;
+    total_entries = List.length entries;
     total_error_entries }
 
+let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate =
+  let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
+  let entries = read_all_decisions ~base_path ~since_unix in
+  let models = aggregate_by_model entries in
+  let bucket_sec =
+    if bucket_minutes <= 0 then 60 else bucket_minutes * 60
+  in
+  (* Reuse parsed entries: re-group per model and bucketize without re-reading. *)
+  let by_model = group_entries_by_model entries in
+  let models_with_buckets =
+    List.map (fun (s : model_stats) ->
+      let model_entries =
+        match List.assoc_opt s.model_id by_model with
+        | Some es -> es
+        | None -> []
+      in
+      { s with buckets = bucket_entries_for_model model_entries ~bucket_sec }
+    ) models
+  in
+  let total_error_entries =
+    List.length (List.filter (fun e -> e.is_error) entries)
+  in
+  { window_minutes; bucket_minutes;
+    models = models_with_buckets;
+    total_entries = List.length entries;
+    total_error_entries }
+
+let aggregate_buckets ~base_path ~window_min ~bucket_min : model_bucketed list =
+  let since_unix = Time_compat.now () -. (Float.of_int window_min *. 60.0) in
+  let entries = read_all_decisions ~base_path ~since_unix in
+  let bucket_sec = if bucket_min <= 0 then 60 else bucket_min * 60 in
+  let by_model = group_entries_by_model entries in
+  List.map (fun (model_id, es) ->
+    { mb_model_id = model_id;
+      mb_buckets = bucket_entries_for_model es ~bucket_sec }
+  ) by_model
+  |> List.sort (fun a b -> compare a.mb_model_id b.mb_model_id)
+
 (* ── JSON serialization ─────────────────────────────────── *)
+
+let bucket_metric_to_json (b : bucket_metric) : Yojson.Safe.t =
+  `Assoc
+    [ ("ts_start", `Float b.b_ts_start)
+    ; ("entry_count", `Int b.b_entry_count)
+    ; ("success_count", `Int b.b_success_count)
+    ; ("error_count", `Int b.b_error_count)
+    ; ("p50_latency_ms", `Float b.b_p50_latency_ms)
+    ; ("p95_latency_ms", `Float b.b_p95_latency_ms)
+    ; ("error_rate", `Float b.b_error_rate)
+    ; ("total_cost_usd", `Float b.b_total_cost_usd)
+    ; ("cache_hit_ratio", `Float b.b_cache_hit_ratio)
+    ]
 
 let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
   `Assoc
@@ -336,11 +466,13 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
           ("tools_count", `Int r.re_tools_count);
         ]
       ) s.recent_entries))
+    ; ("buckets", `List (List.map bucket_metric_to_json s.buckets))
     ]
 
 let to_json (agg : aggregate) : Yojson.Safe.t =
   `Assoc
     [ ("window_minutes", `Int agg.window_minutes)
+    ; ("bucket_minutes", `Int agg.bucket_minutes)
     ; ("total_entries", `Int agg.total_entries)
     ; ("total_error_entries", `Int agg.total_error_entries)
     ; ("models", `List (List.map model_stats_to_json agg.models))

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -381,18 +381,18 @@ let compute ~base_path ~window_minutes : aggregate =
     total_error_entries }
 
 let compute_with_buckets ~base_path ~window_minutes ~bucket_minutes : aggregate =
+  let bucket_minutes = max 1 bucket_minutes in
   let since_unix = Time_compat.now () -. (Float.of_int window_minutes *. 60.0) in
   let entries = read_all_decisions ~base_path ~since_unix in
   let models = aggregate_by_model entries in
-  let bucket_sec =
-    if bucket_minutes <= 0 then 60 else bucket_minutes * 60
-  in
-  (* Reuse parsed entries: re-group per model and bucketize without re-reading. *)
-  let by_model = group_entries_by_model entries in
+  let bucket_sec = bucket_minutes * 60 in
+  let by_model_tbl : (string, raw_entry list) Hashtbl.t = Hashtbl.create 8 in
+  List.iter (fun (model, es) -> Hashtbl.replace by_model_tbl model es)
+    (group_entries_by_model entries);
   let models_with_buckets =
     List.map (fun (s : model_stats) ->
       let model_entries =
-        match List.assoc_opt s.model_id by_model with
+        match Hashtbl.find_opt by_model_tbl s.model_id with
         | Some es -> es
         | None -> []
       in

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -15,6 +15,28 @@ type recent_entry = {
   re_tools_count : int;
 }
 
+type bucket_metric = {
+  b_ts_start : float;
+    (** Unix seconds at the floor of the bucket (inclusive start). *)
+  b_entry_count : int;
+  b_success_count : int;
+  b_error_count : int;
+  b_p50_latency_ms : float;
+  b_p95_latency_ms : float;
+  b_error_rate : float;
+    (** error_count / entry_count; 0.0 when bucket is empty. *)
+  b_total_cost_usd : float;
+  b_cache_hit_ratio : float;
+    (** cache_read_tokens / (cache_read_tokens + input_tokens); 0.0 when
+        denominator is zero (do not return NaN). *)
+}
+
+type model_bucketed = {
+  mb_model_id : string;
+  mb_buckets : bucket_metric list;
+    (** Ordered oldest-first; only non-empty buckets are emitted. *)
+}
+
 type model_stats = {
   model_id : string;
   entry_count : int;
@@ -36,10 +58,12 @@ type model_stats = {
   total_tool_calls : int;
   top_tools : (string * int) list;
   recent_entries : recent_entry list;
+  buckets : bucket_metric list;
 }
 
 type aggregate = {
   window_minutes : int;
+  bucket_minutes : int;
   models : model_stats list;
   total_entries : int;
   total_error_entries : int;
@@ -49,7 +73,35 @@ val compute : base_path:string -> window_minutes:int -> aggregate
 (** [compute ~base_path ~window_minutes] reads all keeper decisions.jsonl
     files, filters entries within the last [window_minutes], and returns
     per-model aggregate statistics sorted by entry count descending.
-    Error turns (outcome="error") are counted separately per model. *)
+    Error turns (outcome="error") are counted separately per model.
+
+    The returned [model_stats] record carries an empty [buckets] list and
+    the enclosing [aggregate.bucket_minutes] is [0]. To include a
+    time-bucketed series, call {!compute_with_buckets} instead. *)
+
+val compute_with_buckets :
+  base_path:string ->
+  window_minutes:int ->
+  bucket_minutes:int ->
+  aggregate
+(** Same as {!compute} but each returned [model_stats] additionally carries
+    a [buckets] list produced by {!aggregate_buckets}. *)
+
+val aggregate_buckets :
+  base_path:string ->
+  window_min:int ->
+  bucket_min:int ->
+  model_bucketed list
+(** [aggregate_buckets ~base_path ~window_min ~bucket_min] splits the last
+    [window_min] minutes into [bucket_min]-minute buckets, groups entries
+    per model, and for each non-empty bucket computes:
+    p50/p95 latency, error_rate, total_cost_usd, cache_hit_ratio.
+
+    - Buckets are keyed by [floor(ts_unix / (bucket_min * 60))].
+    - Only buckets with at least one entry are emitted.
+    - Buckets are returned oldest-first within each model.
+    - [cache_hit_ratio] is [0.0] when the denominator is zero (never NaN).
+    - A non-positive [bucket_min] is treated as [1]. *)
 
 val to_json : aggregate -> Yojson.Safe.t
 (** Serialize [aggregate] to JSON for API responses. *)

--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -15,9 +15,16 @@ let add_routes ~sw router =
   |> Http.Router.get "/api/v1/models/metrics" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let window = int_query_param req "window" ~default:30 in
-         let agg = Model_inference_metrics.compute
-           ~base_path:state.Mcp_server.room_config.base_path
-           ~window_minutes:window in
+         let bucket_min = int_query_param req "bucket_min" ~default:0 in
+         let base_path = state.Mcp_server.room_config.base_path in
+         let agg =
+           if bucket_min > 0 then
+             Model_inference_metrics.compute_with_buckets
+               ~base_path ~window_minutes:window ~bucket_minutes:bucket_min
+           else
+             Model_inference_metrics.compute
+               ~base_path ~window_minutes:window
+         in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string (Model_inference_metrics.to_json agg)) reqd
        ) request reqd)

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -232,6 +232,94 @@ let test_json_roundtrip () =
     check int "total_error_entries" 0
       (json |> member "total_error_entries" |> to_int))
 
+(* ── Bucket tests ───────────────────────────────── *)
+
+let success_entry_with_cache ~model ~ts ~cache_read () =
+  `Assoc [
+    ("ts_unix", `Float ts);
+    ("tool_call_count", `Int 0);
+    ("tools_used", `List []);
+    ("telemetry", `Assoc [
+      ("model_used", `String model);
+      ("tokens_per_second", `Float 10.0);
+      ("request_latency_ms", `Int 500);
+      ("input_tokens", `Int 100);
+      ("output_tokens", `Int 50);
+      ("cache_read_tokens", `Int cache_read);
+      ("reasoning_tokens", `Int 0);
+      ("fallback_applied", `Bool false);
+      ("cost_usd", `Float 0.01);
+    ]);
+  ]
+
+let test_buckets_empty_dir () =
+  let dir = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:5 in
+    check int "empty → no models" 0 (List.length result))
+
+let test_buckets_single_bucket () =
+  let dir = test_dir () in
+  let path = make_keeper_dir dir "single_bucket" in
+  let now = now_unix () in
+  write_decisions path [
+    success_entry ~model:"model-a" ~ts:now ();
+    success_entry ~model:"model-a" ~ts:(now -. 30.0) ();
+  ];
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60 in
+    check int "one model" 1 (List.length result);
+    let m = List.hd result in
+    check string "model_id" "model-a" m.mb_model_id;
+    check int "one bucket (60min window, 60min bucket)" 1 (List.length m.mb_buckets))
+
+let test_buckets_sparse () =
+  let dir = test_dir () in
+  let path = make_keeper_dir dir "sparse" in
+  let now = now_unix () in
+  write_decisions path [
+    success_entry ~model:"model-b" ~ts:now ();
+    success_entry ~model:"model-b" ~ts:(now -. 600.0) ();
+  ];
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:5 in
+    check int "one model" 1 (List.length result);
+    let m = List.hd result in
+    check bool "sparse → 2 distinct buckets (10min apart, 5min width)"
+      true (List.length m.mb_buckets >= 2))
+
+let test_buckets_cache_hit_ratio_zero_denom () =
+  let dir = test_dir () in
+  let path = make_keeper_dir dir "cache_zero" in
+  let now = now_unix () in
+  write_decisions path [
+    success_entry_with_cache ~model:"model-c" ~ts:now ~cache_read:0 ();
+  ];
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60 in
+    check int "one model" 1 (List.length result);
+    let m = List.hd result in
+    let b = List.hd m.mb_buckets in
+    check bool "cache_hit_ratio not NaN" true
+      (not (Float.is_nan b.b_cache_hit_ratio));
+    check bool "cache_hit_ratio = 0.0 when input=100, cache=0"
+      true (b.b_cache_hit_ratio < 0.01))
+
+let test_buckets_with_compute () =
+  let dir = test_dir () in
+  let path = make_keeper_dir dir "bucketed_compute" in
+  let now = now_unix () in
+  write_decisions path [
+    success_entry ~model:"model-x" ~ts:now ();
+  ];
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
+    let agg = M.compute_with_buckets ~base_path:dir ~window_minutes:60 ~bucket_minutes:5 in
+    check int "bucket_minutes populated" 5 agg.bucket_minutes;
+    let m = List.hd agg.models in
+    check bool "model_stats.buckets non-empty" true (List.length m.buckets > 0);
+    let b = List.hd m.buckets in
+    check int "bucket entry_count" 1 b.b_entry_count)
+
 (* ── Runner ──────────────────────────────────────── *)
 
 let () =
@@ -247,5 +335,12 @@ let () =
       test_case "top tools per model" `Quick test_top_tools_per_model;
       test_case "recent entries capped" `Quick test_recent_entries;
       test_case "json roundtrip" `Quick test_json_roundtrip;
+    ];
+    "buckets", [
+      test_case "empty dir → no buckets" `Quick test_buckets_empty_dir;
+      test_case "single bucket window" `Quick test_buckets_single_bucket;
+      test_case "sparse entries → distinct buckets" `Quick test_buckets_sparse;
+      test_case "cache_hit_ratio zero denom" `Quick test_buckets_cache_hit_ratio_zero_denom;
+      test_case "compute_with_buckets integration" `Quick test_buckets_with_compute;
     ];
   ]

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -234,7 +234,7 @@ let test_json_roundtrip () =
 
 (* ── Bucket tests ───────────────────────────────── *)
 
-let success_entry_with_cache ~model ~ts ~cache_read () =
+let success_entry_with_cache ~model ~ts ?(input_tokens=100) ~cache_read () =
   `Assoc [
     ("ts_unix", `Float ts);
     ("tool_call_count", `Int 0);
@@ -243,7 +243,7 @@ let success_entry_with_cache ~model ~ts ~cache_read () =
       ("model_used", `String model);
       ("tokens_per_second", `Float 10.0);
       ("request_latency_ms", `Int 500);
-      ("input_tokens", `Int 100);
+      ("input_tokens", `Int input_tokens);
       ("output_tokens", `Int 50);
       ("cache_read_tokens", `Int cache_read);
       ("reasoning_tokens", `Int 0);
@@ -293,7 +293,7 @@ let test_buckets_cache_hit_ratio_zero_denom () =
   let path = make_keeper_dir dir "cache_zero" in
   let now = now_unix () in
   write_decisions path [
-    success_entry_with_cache ~model:"model-c" ~ts:now ~cache_read:0 ();
+    success_entry_with_cache ~model:"model-c" ~ts:now ~input_tokens:0 ~cache_read:0 ();
   ];
   Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () ->
     let result = M.aggregate_buckets ~base_path:dir ~window_min:60 ~bucket_min:60 in
@@ -302,8 +302,8 @@ let test_buckets_cache_hit_ratio_zero_denom () =
     let b = List.hd m.mb_buckets in
     check bool "cache_hit_ratio not NaN" true
       (not (Float.is_nan b.b_cache_hit_ratio));
-    check bool "cache_hit_ratio = 0.0 when input=100, cache=0"
-      true (b.b_cache_hit_ratio < 0.01))
+    check (float 0.001) "cache_hit_ratio = 0.0 when both tokens=0"
+      0.0 b.b_cache_hit_ratio)
 
 let test_buckets_with_compute () =
   let dir = test_dir () in


### PR DESCRIPTION
## Summary

- Time-bucketed per-model metrics (p50/p95 latency, error rate, cost, cache hit ratio) via aggregate_buckets
- Inline SVG sparklines in RuntimeMonitor for latency regression + error rate detection
- Cost breakdown with cache savings % per model

## Product impact

Operators can now detect model performance regressions visually (sparkline spikes) and compare cache efficiency across models without tailing JSONL. No behavioral change to existing data flow.

## Evidence

- `dune build` clean
- 13/13 alcotest cases pass (8 existing + 5 new bucket tests)
- `npx tsc --noEmit` clean on dashboard
- API backward-compatible: `?bucket_min=0` (or omitted) returns existing flat response

## Review evidence

Backend (OCaml):
- `bucket_entries_for_model`: Hashtbl bucketing by floor(ts/bucket_sec), per-bucket p50/p95 via sorted array, safe cache_hit_ratio (denom=0 → 0.0)
- `compute_with_buckets`: reuses parsed entries (no double I/O), groups by model, attaches buckets per model_stats
- `aggregate_buckets`: standalone entry point returning model_bucketed list sorted by model_id
- HTTP route: `?bucket_min=5` triggers compute_with_buckets; `=0` or omitted stays on compute()

Frontend (TS):
- BucketMetric type + decoder follows existing asNumber/isRecord pattern
- sparklineSvg: pure SVG polyline, no deps, color parameterized via CSS vars
- Cache savings: computed client-side from total_cache_read_tokens / (cache + input)

## Linked issue

Relates #6883 (model inference observability phase 1).

## Test plan

- [x] `dune build` clean
- [x] 13/13 alcotest pass
- [x] `npx tsc --noEmit` clean
- [x] API: `curl localhost:8935/api/v1/models/metrics?window=60&bucket_min=5` returns buckets array
- [ ] Visual: dev server → RuntimeMonitor → sparklines render with ≥2 data points

🤖 Generated with [Claude Code](https://claude.com/claude-code)