### PR TITLE
fix(memory): wire Hebbian hooks into transition_task_r and flush episodes post-run

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1529,10 +1529,9 @@ let run_turn
            Without this, read_continuity_summary finds no [STATE] in the
            checkpoint messages and returns empty — causing keepers to lose
            context across turns.  See #5431. *)
-       (* RFC-MASC-004: AfterTurn hooks flush incrementally on every
-          turn via flush_incremental. No separate final flush needed —
-          the AfterTurn hook already ran for the last turn before
-          Agent.run returned. *)
+       (* RFC-MASC-004: AfterTurn hooks flush incrementally during
+          Agent.run. Post-run episode creation requires an explicit
+          flush_incremental call since AfterTurn already fired. *)
        let text = Agent_sdk.Types.text_of_content result.response.content in
        let model = result.response.model in
        (* Extract and persist thinking blocks to trajectory JSONL.
@@ -1755,8 +1754,10 @@ let run_turn
                meta.name
                (Printexc.to_string exn));
           (* Episodic memory: create OAS episode from [STATE] snapshot.
-             Populates Memory.t so flush_episodes (AfterTurn hook)
-             persists to institution_episodes.jsonl. *)
+             store_episode adds to Memory.t, then flush_incremental
+             persists to institution_episodes.jsonl. The explicit flush
+             is required because this runs AFTER Agent.run returns, so
+             the AfterTurn hook has already fired for the last turn. *)
           (try
              (match
                 Keeper_memory_policy.parse_state_snapshot_from_reply
@@ -1767,7 +1768,15 @@ let run_turn
                  ~keeper_name:meta.name ~turn:result.turns
                  ~trace_id:
                    (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-                 snap
+                 snap;
+               let ep, pr =
+                 Memory_oas_bridge.flush_incremental ~memory
+                   ~agent_name:meta.name
+               in
+               if ep > 0 || pr > 0 then
+                 Log.Keeper.debug
+                   "keeper:%s post-run flush episodes=%d procedures=%d"
+                   meta.name ep pr
              | None -> ())
            with exn ->
              Log.Keeper.warn "keeper:%s episode_create failed: %s"

--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -802,6 +802,25 @@ let transition_task_r config ~agent_name ~task_id ~action
                ?notes:(if notes = "" then None else Some notes)
                ?reason:(if reason = "" then None else Some reason)
                ?duration_ms ~forced:force ());
+        (match action with
+         | Types.Done_action ->
+           (try
+              let active = (Room_state.read_state config).active_agents in
+              !Room_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active;
+              !Room_hooks.hebbian_on_task_done_fn config
+                ~assignee:agent_name ~active_agents:active
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+              Log.RoomTask.error "transition relation/hebbian done hook: %s"
+                (Printexc.to_string exn))
+         | Types.Cancel ->
+           (try
+              let active = (Room_state.read_state config).active_agents in
+              !Room_hooks.hebbian_on_task_cancelled_fn config
+                ~agent_name ~active_agents:active
+            with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
+              Log.RoomTask.error "transition hebbian cancel hook: %s"
+                (Printexc.to_string exn))
+         | Types.Claim | Types.Start | Types.Release -> ());
         Ok (Printf.sprintf "✅ %s %s → %s" task_id
               (task_status_to_string task.task_status)
               (task_status_to_string new_status))


### PR DESCRIPTION
## Summary

Two bugs prevented memory subsystems from firing in production since PR #6889 (merged Apr 4):

- **Hebbian hooks missing on keeper path**: `keeper_task_done → force_done_task_r → transition_task_r` bypasses `complete_task` where Hebbian hooks live. Keepers are the dominant task-completion path (1 `keeper_task_done` vs 0 `masc_done` today). `graph.json` hasn't updated in 9 days.
- **Episode flush timing**: `store_episode_from_snapshot` runs **after** `Agent.run` returns, but `AfterTurn` hook (which calls `flush_incremental`) already fired during the last turn. Episodes stored post-run never get persisted. `institution_episodes.jsonl`: 2 lines, last modified Apr 7.

## Changes

| File | Change |
|------|--------|
| `lib/room/room_task.ml` | Add Hebbian + relation hooks to `transition_task_r` for `Done_action` and `Cancel` |
| `lib/keeper/keeper_agent_run.ml` | Explicit `flush_incremental` after `store_episode_from_snapshot` |

## Evidence

| Artifact | Before | Expected After |
|----------|--------|---------------|
| `graph.json` mtime | Apr 4 (9 days stale) | Updates on every keeper `task_done` |
| `graph.json` synapses | 1 entry | Grows with each task completion |
| `institution_episodes.jsonl` | 2 lines (Apr 7) | Grows on every keeper turn with [STATE] |

## Test plan

- [x] `test_memory_hooks.exe` — 8 tests pass
- [x] `test_memory_oas_5tier.exe` — 18 tests pass
- [x] `test_server_runtime_bootstrap.exe` — 36 tests pass
- [x] `dune build` — compiles clean
- [ ] CI green
- [ ] After deploy: `graph.json` mtime advances on next keeper task completion
- [ ] After deploy: `institution_episodes.jsonl` grows on next keeper turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)