### PR TITLE
fix(prometheus): export histogram metrics as summary with _sum/_count

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -224,18 +224,61 @@ let to_prometheus_text () =
     let existing = Hashtbl.find_opt by_name m.name |> Option.value ~default:[] in
     Hashtbl.replace by_name m.name (m :: existing)
   ) metrics;
+  (* Collect histogram parent names.  observe_histogram stores the
+     cumulative sum under the original name and the observation count
+     under "<name>_count".  We suppress standalone export of the
+     _count companion and instead emit it inline as part of the
+     summary stanza for the parent. *)
+  let histogram_parents = Hashtbl.create 8 in
   Hashtbl.iter (fun name ms ->
+    List.iter (fun (m : metric) ->
+      if m.metric_type = Histogram then
+        Hashtbl.replace histogram_parents name true
+    ) ms
+  ) by_name;
+  let label_key labels =
+    String.concat "" (List.map (fun (k, v) -> k ^ v) labels)
+  in
+  Hashtbl.iter (fun name ms ->
+    let is_histogram_count =
+      let suf = "_count" in
+      let slen = String.length suf in
+      String.length name > slen
+      && String.sub name (String.length name - slen) slen = suf
+      && Hashtbl.mem histogram_parents
+           (String.sub name 0 (String.length name - slen))
+    in
+    if is_histogram_count then ()
+    else
     match ms with
     | [] -> ()
     | m :: _ ->
-        Buffer.add_string buf (Printf.sprintf "# HELP %s %s\n" name m.help);
-        Buffer.add_string buf (Printf.sprintf "# TYPE %s %s\n" name (type_to_string m.metric_type));
-        List.iter (fun metric ->
-          Buffer.add_string buf (Printf.sprintf "%s%s %g\n"
-            metric.name
-            (labels_to_string metric.labels)
-            metric.value)
-        ) ms
+      Buffer.add_string buf (Printf.sprintf "# HELP %s %s\n" name m.help);
+      (match m.metric_type with
+       | Histogram ->
+         (* No bucket distribution is tracked, so emit as summary
+            (sum + count) which is the closest valid Prometheus type. *)
+         Buffer.add_string buf (Printf.sprintf "# TYPE %s summary\n" name);
+         List.iter (fun (metric : metric) ->
+           let ls = labels_to_string metric.labels in
+           Buffer.add_string buf
+             (Printf.sprintf "%s_sum%s %g\n" name ls metric.value);
+           let count_key = name ^ "_count" ^ label_key metric.labels in
+           let count_val =
+             match Hashtbl.find_opt metrics count_key with
+             | Some cm -> cm.value
+             | None -> 0.0
+           in
+           Buffer.add_string buf
+             (Printf.sprintf "%s_count%s %g\n" name ls count_val)
+         ) ms
+       | _ ->
+         Buffer.add_string buf
+           (Printf.sprintf "# TYPE %s %s\n" name (type_to_string m.metric_type));
+         List.iter (fun (metric : metric) ->
+           Buffer.add_string buf (Printf.sprintf "%s%s %g\n"
+             metric.name (labels_to_string metric.labels) metric.value)
+         ) ms)
   ) by_name;
   Buffer.contents buf
 

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -232,6 +232,25 @@ let test_keeper_metrics_registered () =
   check bool "has keeper heartbeat failures counter" true
     (has "masc_keeper_heartbeat_failures_total")
 
+let test_histogram_exported_as_summary () =
+  let name = "test_hist_export_fmt" in
+  Prometheus.register_histogram ~name ~help:"export format test" ();
+  Prometheus.observe_histogram name 1.5;
+  Prometheus.observe_histogram name 2.5;
+  let text = Prometheus.to_prometheus_text () in
+  let has pat =
+    try ignore (Str.search_forward (Str.regexp_string pat) text 0); true
+    with Not_found -> false
+  in
+  check bool "TYPE summary" true
+    (has (Printf.sprintf "# TYPE %s summary" name));
+  check bool "has _sum" true
+    (has (Printf.sprintf "%s_sum" name));
+  check bool "has _count" true
+    (has (Printf.sprintf "%s_count" name));
+  check bool "no standalone _count TYPE" false
+    (has (Printf.sprintf "# TYPE %s_count" name))
+
 (* ============================================================
    Convenience Functions Tests
    ============================================================ *)
@@ -383,6 +402,8 @@ let () =
       test_case "has uptime" `Quick test_to_prometheus_text_has_uptime;
       test_case "has sse metrics" `Quick test_to_prometheus_text_has_sse_metrics;
       test_case "keeper metrics registered" `Quick test_keeper_metrics_registered;
+      test_case "histogram exported as summary with _sum/_count"
+        `Quick test_histogram_exported_as_summary;
     ];
     "convenience", [
       test_case "record_request" `Quick test_record_request;


### PR DESCRIPTION
## Summary

- Prometheus `/metrics` endpoint에서 histogram 타입이 단일 값(`metric_name 0`)으로만 출력되던 문제 수정
- `observe_histogram`은 이미 sum + count를 두 개의 hashtable entry로 관리하지만, `to_prometheus_text`가 둘을 flat 라인으로 export하여 Prometheus parser가 해석 불가
- bucket 분포를 추적하지 않으므로 **summary** type (`_sum` + `_count`)으로 re-type하여 export
- auto-created `_count` companion metric의 standalone export를 suppress하여 중복 series 방지

## 영향 받는 histogram (5개)

- `masc_tool_call_duration_seconds`
- `masc_llm_inference_duration_seconds`
- `masc_delta_checkpoint_size_bytes`
- `masc_full_checkpoint_size_bytes`
- `masc_inference_queue_wait_seconds`

## Before/After

```
# Before
# TYPE masc_llm_inference_duration_seconds histogram
masc_llm_inference_duration_seconds 0

# After
# TYPE masc_llm_inference_duration_seconds summary
masc_llm_inference_duration_seconds_sum 4.5
masc_llm_inference_duration_seconds_count 3
```

## Test plan

- [x] 기존 51 tests 통과 (regression 없음)
- [x] 신규 test: `histogram exported as summary with _sum/_count` — TYPE summary, _sum/_count 포함, standalone _count TYPE 부재 확인
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)