### PR TITLE
feat(oas_sse_bridge): relay AgentCompleted usage to SSE

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -80,14 +80,31 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
           ]
       in
       Some (wrap ~event_type:"agent_started" ~payload ~agent_name ~task_id ())
-  | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; _ } ->
+  | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; result } ->
+      let usage_fields =
+        match result with
+        | Ok resp -> (
+            match resp.usage with
+            | Some u ->
+                [
+                  ("input_tokens", `Int u.input_tokens);
+                  ("output_tokens", `Int u.output_tokens);
+                  ( "cost_usd",
+                    match u.cost_usd with
+                    | Some c -> `Float c
+                    | None -> `Null );
+                ]
+            | None -> [])
+        | Error _ -> []
+      in
       let payload =
         `Assoc
-          [
-            ("agent_name", `String agent_name);
-            ("task_id", `String task_id);
-            ("elapsed_s", `Float elapsed);
-          ]
+          ([
+             ("agent_name", `String agent_name);
+             ("task_id", `String task_id);
+             ("elapsed_s", `Float elapsed);
+           ]
+          @ usage_fields)
       in
       Some (wrap ~event_type:"agent_completed" ~payload ~agent_name ~task_id ())
   | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->

--- a/lib/oas_sse_bridge.mli
+++ b/lib/oas_sse_bridge.mli
@@ -18,3 +18,7 @@ val start :
   config:Room.config ->
   bus:Agent_sdk.Event_bus.t ->
   unit
+
+(** Serialize a single OAS event to SSE JSON.
+    Exposed for unit testing. *)
+val native_event_to_json : Agent_sdk.Event_bus.event -> Yojson.Safe.t option

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -266,7 +266,8 @@ let test_agent_completed_no_usage_on_error () =
       let payload_fields =
         match List.assoc_opt "payload" fields with
         | Some (`Assoc p) -> p
-        | _ -> []
+        | Some _ -> Alcotest.fail "expected payload assoc"
+        | None -> Alcotest.fail "expected payload field"
       in
       Alcotest.(check bool) "no input_tokens on error" true
         (Option.is_none (List.assoc_opt "input_tokens" payload_fields))

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -192,6 +192,86 @@ let test_compact_syncs_oas_context () =
    | _ -> Alcotest.fail "expected context_ratio in oas_context after compact")
 
 (* ================================================================ *)
+let test_agent_completed_includes_usage () =
+  let open Agent_sdk in
+  let usage : Types.api_usage =
+    {
+      input_tokens = 500;
+      output_tokens = 150;
+      cache_creation_input_tokens = 0;
+      cache_read_input_tokens = 0;
+      cost_usd = Some 0.003;
+    }
+  in
+  let resp : Types.api_response =
+    {
+      id = "msg-test";
+      model = "test-model";
+      stop_reason = EndTurn;
+      content = [];
+      usage = Some usage;
+      telemetry = None;
+    }
+  in
+  let evt =
+    Event_bus.mk_event ~correlation_id:"sess-usage" ~run_id:"run-usage"
+      (AgentCompleted
+         {
+           agent_name = "usage-agent";
+           task_id = "task-usage";
+           result = Ok resp;
+           elapsed = 1.5;
+         })
+  in
+  match Oas_sse_bridge.native_event_to_json evt with
+  | None -> Alcotest.fail "expected Some for AgentCompleted"
+  | Some (`Assoc fields) ->
+      let payload_fields =
+        match List.assoc_opt "payload" fields with
+        | Some (`Assoc p) -> p
+        | _ -> Alcotest.failf "expected payload assoc"
+      in
+      let int_field name =
+        match List.assoc_opt name payload_fields with
+        | Some (`Int v) -> v
+        | _ -> -1
+      in
+      Alcotest.(check int) "input_tokens" 500 (int_field "input_tokens");
+      Alcotest.(check int) "output_tokens" 150 (int_field "output_tokens");
+      (match List.assoc_opt "cost_usd" payload_fields with
+       | Some (`Float f) ->
+           Alcotest.(check (float 0.001)) "cost_usd" 0.003 f
+       | _ -> Alcotest.fail "expected cost_usd float");
+      Alcotest.(check string) "event_type" "agent_completed"
+        (match List.assoc_opt "event_type" fields with
+         | Some (`String s) -> s
+         | _ -> "")
+  | Some _ -> Alcotest.fail "expected assoc"
+
+let test_agent_completed_no_usage_on_error () =
+  let open Agent_sdk in
+  let evt =
+    Event_bus.mk_event
+      (AgentCompleted
+         {
+           agent_name = "err-agent";
+           task_id = "task-err";
+           result = Error (Error.Internal "test failure");
+           elapsed = 0.5;
+         })
+  in
+  match Oas_sse_bridge.native_event_to_json evt with
+  | None -> Alcotest.fail "expected Some for AgentCompleted error"
+  | Some (`Assoc fields) ->
+      let payload_fields =
+        match List.assoc_opt "payload" fields with
+        | Some (`Assoc p) -> p
+        | _ -> []
+      in
+      Alcotest.(check bool) "no input_tokens on error" true
+        (Option.is_none (List.assoc_opt "input_tokens" payload_fields))
+  | Some _ -> Alcotest.fail "expected assoc"
+
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -204,6 +284,10 @@ let () =
         test_event_bus_task_transition;
       Alcotest.test_case "sse bridge persists native events" `Quick
         test_oas_sse_bridge_persists_native_events;
+      Alcotest.test_case "agent_completed includes usage" `Quick
+        test_agent_completed_includes_usage;
+      Alcotest.test_case "agent_completed no usage on error" `Quick
+        test_agent_completed_no_usage_on_error;
     ];
     "message_conversion", [
       Alcotest.test_case "message roundtrip" `Quick test_message_roundtrip;


### PR DESCRIPTION
## Summary

- add `input_tokens`, `output_tokens`, and `cost_usd` to `AgentCompleted` SSE payloads
- include usage only when `result = Ok api_response` and `usage = Some _`
- expose `native_event_to_json` for unit tests and add regression coverage

## Product impact

Dashboard SSE consumers can now observe agent token usage and cost directly from `AgentCompleted` events without changing the error-path payload shape.

## Evidence

- local `test_oas_integration.exe` passed after tightening the payload-shape assertion
- `Build and Test`, `Dashboard`, `Health`, `Lint`, and `PR Hygiene` are green; only `TLA+ Model Checking` remains pending
- regression coverage includes both usage-present and error/no-usage cases

## Review evidence

- addressed Copilot feedback by failing the test when `payload` is missing or not an assoc
- replied on the review thread with the validation change and local test result
- no current direct mentions are open on this PR

## Linked issue

Refs #6961
