### PR TITLE
feat(dashboard): OAS correlation_id/run_id in journal entries

### DIFF
--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -143,6 +143,23 @@ function addTypedJournalEntry(
   })
 }
 
+/** Extract OAS envelope fields (correlation_id, run_id, ts_unix) from an SSE
+ * event into the shape expected by JournalEntry. Returns an empty object for
+ * non-OAS events so spreading into `extra` stays inert. */
+function envelopeFromEvent(event: SSEEvent): Pick<JournalEntry, 'correlationId' | 'runId' | 'oasTs'> {
+  const out: Pick<JournalEntry, 'correlationId' | 'runId' | 'oasTs'> = {}
+  if (typeof event.correlation_id === 'string' && event.correlation_id.trim() !== '') {
+    out.correlationId = event.correlation_id
+  }
+  if (typeof event.run_id === 'string' && event.run_id.trim() !== '') {
+    out.runId = event.run_id
+  }
+  if (typeof event.ts_unix === 'number' && Number.isFinite(event.ts_unix)) {
+    out.oasTs = event.ts_unix
+  }
+  return out
+}
+
 // --- SSE Manager ---
 
 let source: EventSource | null = null
@@ -541,6 +558,7 @@ function handleEvent(event: SSEEvent): void {
           narrativeText:
             `${actorLabel(snap.keeper_name)}의 keeper snapshot이 갱신되었습니다`
             + ` (gen ${snap.generation}, ctx ${Math.round(snap.context_ratio * 100)}%)`,
+          ...envelopeFromEvent(event),
         },
       )
       break
@@ -573,6 +591,7 @@ function handleEvent(event: SSEEvent): void {
             + ([lifecycleEvent, detail].filter(Boolean).length > 0
               ? ` (${[lifecycleEvent, detail].filter(Boolean).join(' · ')})`
               : ''),
+          ...envelopeFromEvent(event),
         },
       )
       break
@@ -601,6 +620,7 @@ function handleEvent(event: SSEEvent): void {
           narrativeText:
             `${actorLabel(agentA)}와 ${actorLabel(agentB)} 사이 trust score가 갱신되었습니다`
             + (trustScore != null ? ` (${trustScore.toFixed(2)})` : ''),
+          ...envelopeFromEvent(event),
         },
       )
       break
@@ -632,6 +652,7 @@ function handleEvent(event: SSEEvent): void {
             `${actorLabel(agentName)} reputation이 갱신되었습니다`
             + (oldScore != null && newScore != null ? ` (${oldScore.toFixed(2)} → ${newScore.toFixed(2)})` : '')
             + (trend ? `, trend=${trend}` : ''),
+          ...envelopeFromEvent(event),
         },
       )
       break
@@ -661,6 +682,7 @@ function handleEvent(event: SSEEvent): void {
           source: event.source,
           narrativeText: `${actorLabel(agentName)} OAS agent ${phase}${taskId ? ` (${taskId})` : ''}`,
           preview: taskId,
+          ...envelopeFromEvent(event),
         },
       )
       if (agentName) {

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -114,6 +114,11 @@ export interface SSEEvent {
   total_turns?: number
   // OAS bridge payload (generic container for Event_bus events)
   payload?: Record<string, unknown>
+  // OAS envelope — attached to every oas:* event by oas_sse_bridge since 2.260.0.
+  // Used to join events into causal chains in the dashboard journal.
+  correlation_id?: string
+  // OAS envelope per-run identifier (one per Agent.run invocation).
+  run_id?: string
 }
 
 // --- Journal ---
@@ -155,6 +160,13 @@ export interface JournalEntry {
   sessionId?: string
   operationId?: string
   workerRunId?: string
+  // OAS envelope — propagated from oas_sse_bridge so the journal can group
+  // consecutive entries belonging to the same logical run.
+  correlationId?: string
+  // OAS envelope per-run identifier (one per Agent.run invocation).
+  runId?: string
+  // OAS envelope event timestamp (Unix epoch seconds, from envelope, not local clock).
+  oasTs?: number
 }
 
 // --- Sort modes ---


### PR DESCRIPTION
## Summary

Surfaces OAS event_bus envelope fields (correlation_id, run_id, ts_unix) in dashboard journal entries, enabling operators to group events by logical Agent.run invocation.

## Product impact

Journal entries now carry correlation metadata. Future visual grouping (e.g., sidebar filter by run_id) becomes possible without additional backend changes. No behavioral change to existing events.

## Evidence

- `dune build` clean (no OCaml changes)
- `npx tsc --noEmit` clean
- Back-compat: events without correlation_id produce empty spread (no fields added)

## Review evidence

- `envelopeFromEvent()` helper: extracts correlation_id, run_id, oasTs from SSEEvent. Returns empty object for non-OAS events.
- Applied to 5 event handlers: keeper_snapshot, lifecycle, trust, reputation, oas_agent.
- SSEEvent type: additive-only (2 optional fields).
- JournalEntry type: 3 optional fields (correlationId, runId, oasTs).

## Linked issue

Follow-up to oas#845 (event_bus envelope).

## Test plan

- [x] `dune build` clean
- [x] `npx tsc --noEmit` clean
- [ ] SSE observer: verify keeper_snapshot events carry correlation_id in browser devtools
- [ ] Visual grouping deferred to follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)