### PR TITLE
refactor: replace raise Invalid_argument with typed error returns

### DIFF
--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -219,7 +219,7 @@ let autoresearch_loop_detail_json ~(base_path : string)
     Autoresearch.with_loops_ro (fun () ->
       Hashtbl.find_opt Autoresearch.active_loops loop_id)
   in
-  let base_json, insights_list, full_history =
+  let detail =
     match in_memory with
     | Some state ->
         let json = loop_summary_json base_path state in
@@ -227,7 +227,7 @@ let autoresearch_loop_detail_json ~(base_path : string)
         let history =
           Autoresearch.load_cycle_history ~base_path loop_id
         in
-        (json, insights, history)
+        Ok (json, insights, history)
     | None -> (
         match Autoresearch.load_state ~base_path loop_id with
         | Some summary ->
@@ -235,11 +235,13 @@ let autoresearch_loop_detail_json ~(base_path : string)
             let history =
               Autoresearch.load_cycle_history ~base_path loop_id
             in
-            (json, [], history)
+            Ok (json, [], history)
         | None ->
-            let msg = Printf.sprintf "Loop %s not found" loop_id in
-            raise (Invalid_argument msg))
+            Error (Printf.sprintf "Loop %s not found" loop_id))
   in
+  match detail with
+  | Error msg -> Error msg
+  | Ok (base_json, insights_list, full_history) ->
   (* Replace recent_cycles and insights with full data *)
   let history_json =
     full_history

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -65,10 +65,9 @@ let validate_path config path =
     if String.contains path '\x00' then
       Error (IoError "Path contains null byte")
     else
-    let git_root = match Room_git.git_root ~base_path:config.Room.base_path with
-      | None -> raise (Invalid_argument "Not in a git repository")
-      | Some root -> root
-    in
+    match Room_git.git_root ~base_path:config.Room.base_path with
+    | None -> Error (IoError "Not in a git repository")
+    | Some git_root ->
     let absolute_path =
       if Filename.is_relative path then
         Filename.concat config.Room.base_path path

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -153,7 +153,7 @@ let handle_compact args : tool_result =
          "") in
     let strategies = match strategies_of_string strategy_str with
       | Ok s -> s
-      | Error msg -> raise (Invalid_argument msg)
+      | Error msg -> failwith msg
     in
     let messages = List.map parse_message messages_json in
     (* Build a working_context from the input *)


### PR DESCRIPTION
## Summary

Three sites used `raise (Invalid_argument msg)` to signal errors that should flow through the function's own error channel. Each is replaced with the idiomatic error path.

## Changes

| File | Before | After |
|------|--------|-------|
| `tool_compact.ml:156` | `raise (Invalid_argument msg)` → caught by `| exn ->` (ugly Printexc wrapping) | `failwith msg` → caught by `| Failure msg ->` (clean message) |
| `tool_code.ml:69` | `raise (Invalid_argument ...)` while siblings use `Error (IoError ...)` | `Error (IoError "Not in a git repository")` — consistent Result return |
| `dashboard_http_autoresearch.ml:241` | `raise (Invalid_argument msg)` in a function returning `result` | `Error msg` with restructured 3-tuple binding |

## Product impact

- `tool_compact`: error message changes from `"Invalid_argument(\"bad strategy\")"` to `"bad strategy"`.
- `tool_code`: `validate_path` now returns `Error` for all failure modes instead of mixing raise+Error.
- `autoresearch`: loop detail endpoint returns structured `Error` instead of propagating an uncaught exception.

## Evidence

- `dune build --root .` passes locally.

## Review evidence

- `tool_compact.ml` now stays on the existing `Failure msg` error branch instead of relying on the generic exception fallback.
- `tool_code.ml` no longer mixes exception control flow with a `result` return type inside `validate_path`.
- `dashboard_http_autoresearch.ml` preserves the same message text while returning it through the function's existing `result` channel.

## Sites NOT changed (intentional)

- `keeper_exec_fs.ml:74` — unreachable (mode pre-validated at line 61-63); caught by dedicated handler.
- `eio_context.ml:141` — deep TLS infrastructure.
- `room_task.ml:27` — `read_backlog_or_raise` explicit naming contract.

## Linked issue

Refs #6954

## Test plan

- [x] `dune build --root .` passes
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
