### PR TITLE
fix(stdio): log board flush failures on shutdown instead of silencing

### DIFF
--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -34,7 +34,12 @@ let run_cmd base_path =
   ignore (Server_bootstrap_loops.start_background_maintenance ~sw ~clock ~env state);
   Fun.protect
     ~finally:(fun () ->
-      (try Board_dispatch.flush () with _ -> ());
+      (try Board_dispatch.flush ()
+       with
+       | Eio.Cancel.Cancelled _ -> ()
+       | exn ->
+           Log.Misc.warn "shutdown: board flush failed: %s"
+             (Printexc.to_string exn));
       Shutdown_hooks.run_all ())
     (fun () -> Mcp_eio.run_stdio ~sw ~env state)
 


### PR DESCRIPTION
## Summary

`bin/main_stdio_eio.ml`'s `Fun.protect ~finally` swallowed all exceptions from `Board_dispatch.flush()` via `with _ -> ()`. If the flush failed on shutdown, the operator had no log trace.

The sibling entry point `bin/main_eio.ml` already handles this correctly with timeout + `Cancelled` re-raise + exception logging.

## Fix

- `Eio.Cancel.Cancelled` → swallow (expected during shutdown teardown)
- Other exceptions → `Log.Misc.warn` with message before continuing

## Product impact

Disk-full, permission-error, or I/O failure during board flush now leaves a warn-level log line. No behavior change on clean shutdown.

## Evidence

- `dune build --root .` passes.
- Behavior now matches the already-correct shutdown handling shape in `bin/main_eio.ml`.

## Review evidence

- `Cancelled` remains ignored so shutdown teardown stays quiet in the expected case.
- Non-cancel exceptions now emit one warn-level log before shutdown continues.
- No flush ordering or shutdown sequencing changed beyond the missing log path.

## Source

masc-mcp audit Axis C (silent failures). Remaining Axis C items (board_core persist, keeper_keepalive write_meta, backend health check) require design-level discussion and are tracked in Issue #6915.

## Linked issue

Refs #6959

## Test plan

- [x] `dune build --root .` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
