### PR TITLE
fix(config): remove dead MASC_TEAM_SESSION_MODEL_* + register A2A timeout

### DIFF
--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -290,15 +290,6 @@ module Transport = struct
 end
 
 module TeamSession = struct
-  let model_35b_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_35B" |> trim_opt
-
-  let model_27b_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_27B" |> trim_opt
-
-  let model_9b_opt () =
-    Sys.getenv_opt "MASC_TEAM_SESSION_MODEL_9B" |> trim_opt
-
   (** Enable routing judge in team session dispatch. Default: true. *)
   let router_judge_enabled () =
     Feature_flag_registry.get_bool "MASC_TEAM_SESSION_ROUTER_JUDGE"

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -840,6 +840,8 @@ let test_entries =
 
 let timeout_entries =
   [
+    entry ~default:"300" "MASC_A2A_DELEGATION_TIMEOUT_SEC"
+      "A2A task delegation timeout (seconds)";
     entry ~default:"100" "MASC_EVENT_BUFFER_SIZE"
       "A2A event buffer size per subscription";
     entry ~default:"30.0" "MASC_SSE_KEEPALIVE_SEC"

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -49,9 +49,6 @@ module Orchestrator : sig
 end
 
 module TeamSession : sig
-  val model_35b_opt : unit -> string option
-  val model_27b_opt : unit -> string option
-  val model_9b_opt : unit -> string option
   val router_judge_enabled : unit -> bool
   val router_judge_timeout_sec : unit -> int
   val router_judge_confidence_threshold : unit -> float


### PR DESCRIPTION
## Summary

1. **Remove dead code**: `model_35b_opt`, `model_27b_opt`, `model_9b_opt` from `Env_config_runtime.TeamSession` — zero callers. Model selection moved to `cascade_config`.
2. **Register missing env var**: `MASC_A2A_DELEGATION_TIMEOUT_SEC` (default 300s) in `env_config_snapshot.timeout_entries` — was invisible on the dashboard config page.

## Product impact

- Dashboard config introspection now shows A2A delegation timeout.
- 3 dead functions removed from the API surface.

## Evidence

- `rg 'model_35b_opt\|model_27b_opt\|model_9b_opt'` in `lib/`: only definitions, zero callers.
- `dune build --root .` passes.

## Review evidence

- The deleted TeamSession helpers were read-only accessors with no remaining call sites after model selection moved to cascade config.
- The snapshot change is additive only: one missing timeout entry is registered under the existing timeout surface.
- No runtime config parsing semantics changed.

## Source

masc-mcp audit Axis D.

## Linked issue

Refs #6964

## Test plan

- [x] `dune build --root .` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
