### PR TITLE
test(prometheus): remove 3 duplicate metric_type tests

### DIFF
--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -47,22 +47,6 @@ let test_labels_to_string_escaped () =
   check bool "escaped" true (String.length result > 0)
 
 (* ============================================================
-   metric_type Enum Tests
-   ============================================================ *)
-
-let test_metric_type_counter () =
-  let t : Prometheus.metric_type = Prometheus.Counter in
-  check string "counter type" "counter" (Prometheus.type_to_string t)
-
-let test_metric_type_gauge () =
-  let t : Prometheus.metric_type = Prometheus.Gauge in
-  check string "gauge type" "gauge" (Prometheus.type_to_string t)
-
-let test_metric_type_histogram () =
-  let t : Prometheus.metric_type = Prometheus.Histogram in
-  check string "histogram type" "histogram" (Prometheus.type_to_string t)
-
-(* ============================================================
    register_counter Tests
    ============================================================ *)
 
@@ -340,11 +324,6 @@ let () =
       test_case "single" `Quick test_labels_to_string_single;
       test_case "multiple" `Quick test_labels_to_string_multiple;
       test_case "escaped" `Quick test_labels_to_string_escaped;
-    ];
-    "metric_type", [
-      test_case "counter" `Quick test_metric_type_counter;
-      test_case "gauge" `Quick test_metric_type_gauge;
-      test_case "histogram" `Quick test_metric_type_histogram;
     ];
     "register_counter", [
       test_case "basic" `Quick test_register_counter_basic;


### PR DESCRIPTION
## Summary

Delete 3 tests that duplicated existing coverage:
- `test_metric_type_counter` = `test_type_to_string_counter`
- `test_metric_type_gauge` = `test_type_to_string_gauge`
- `test_metric_type_histogram` = `test_type_to_string_histogram`

Same function, same input, same expected output. -21 lines.

## Source

masc-mcp audit Axis E. Remaining Axis E items (50+ sleep-based tests, board_ttl printf runner) tracked in .masc/TODO.md.

## Test plan

- [x] `dune build --root .` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)