### PR TITLE
refactor(keeper): remove dead get_exn + replace EAFP raise with match

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -96,12 +96,10 @@ let parse_checkpoint_file (path : string) : Keeper_types.checkpoint =
   in
   let open Yojson.Safe.Util in
   let serialized =
-    try
-      let ctx = json |> member "context" in
-      if ctx = `Null then raise Not_found;
-      Yojson.Safe.to_string ctx
-    with Eio.Cancel.Cancelled _ as e -> raise e | _ ->
-      json |> member "serialized" |> to_string
+    match json |> member "context" with
+    | `Null | exception Yojson.Safe.Util.Type_error _ ->
+        json |> member "serialized" |> to_string
+    | ctx -> Yojson.Safe.to_string ctx
   in
   {
     Keeper_types.checkpoint_id =

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -229,11 +229,6 @@ let get ~base_path name =
    | Some _ -> ());
   result
 
-let get_exn ~base_path name =
-  match get ~base_path name with
-  | Some e -> e
-  | None -> raise Not_found
-
 let all ?base_path () =
   StringMap.fold
     (fun _k v acc ->

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -94,9 +94,6 @@ val unregister : base_path:string -> string -> unit
 (** Look up a keeper by name. *)
 val get : base_path:string -> string -> registry_entry option
 
-(** Look up a keeper by name, raising [Not_found] if absent. *)
-val get_exn : base_path:string -> string -> registry_entry
-
 (** Return all registered keepers. *)
 val all : ?base_path:string -> unit -> registry_entry list
 

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -347,11 +347,10 @@ let test_record_error () =
   | Some e ->
     check (option string) "error recorded" (Some "something broke") e.last_error
 
-let test_get_exn_not_found () =
+let test_get_returns_none_for_missing () =
   R.clear ();
-  match R.get_exn ~base_path:bp "nonexistent" with
-  | _ -> fail "expected Not_found"
-  | exception Not_found -> ()
+  check (option reject) "nonexistent returns None" None
+    (R.get ~base_path:bp "nonexistent")
 
 let test_noop_on_missing () =
   R.clear ();
@@ -486,7 +485,7 @@ let test_fiber_health_dead_state () =
 let test_shared_refs () =
   R.clear ();
   let entry = R.register ~base_path:bp "ref1" (make_meta "ref1") in
-  let entry_via_get = R.get_exn ~base_path:bp "ref1" in
+  let entry_via_get = match R.get ~base_path:bp "ref1" with Some e -> e | None -> fail "expected ref1" in
   Atomic.set entry.fiber_wakeup true;
   check bool "shared wakeup atomic" true (Atomic.get entry_via_get.fiber_wakeup);
   Atomic.set entry_via_get.fiber_stop true;
@@ -705,7 +704,7 @@ let () =
           eio_test "record restart" test_record_restart;
           eio_test "is_registered" test_is_registered;
           eio_test "record error" test_record_error;
-          eio_test "get_exn not found" test_get_exn_not_found;
+          eio_test "get returns None for missing" test_get_returns_none_for_missing;
           eio_test "noop on missing keys" test_noop_on_missing;
           eio_test "register replaces existing" test_register_replaces;
         ] );


### PR DESCRIPTION
## Summary

1. **keeper_registry**: Delete dead `get_exn` (0 callers). Test replaced with `get` + None assertion.
2. **keeper_checkpoint_store**: Replace `raise Not_found` EAFP with direct match on JSON field.

## Product impact

- No runtime behavior change. Checkpoint parsing still falls back to \"serialized\" field when \"context\" is null/missing.
- API surface reduced: `get_exn` removed from .mli.

## Evidence

- `rg 'Keeper_registry.get_exn'` across repo: 0 matches (before test fix).
- `dune build --root .` passes.

## Source

masc-mcp audit Axis A. Remaining Axis A item: bin/masc_tui.ml List.nth (cosmetic, deferred).

## Test plan

- [x] `dune build --root .` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)