### PR TITLE
fix(config): route Printf.eprintf warnings through Log.Misc.warn

### DIFF
--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -98,8 +98,7 @@ let deprecation_warned = Hashtbl.create 8
 let warn_deprecated ~old_name ~new_name =
   if not (Hashtbl.mem deprecation_warned old_name) then begin
     Hashtbl.replace deprecation_warned old_name true;
-    Printf.eprintf
-      "[WARN] env %s is deprecated; use %s instead. Support will be removed in a future release.\n%!"
+    Log.Misc.warn "env %s is deprecated; use %s instead. Support will be removed in a future release."
       old_name new_name
   end
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -223,7 +223,7 @@ let get_bool env_name =
   match find_opt env_name with
   | Some flag -> runtime_value flag
   | None ->
-      Printf.eprintf "WARNING: feature flag %s not found in registry\n%!" env_name;
+      Log.Misc.warn "feature flag %s not found in registry" env_name;
       Env_config_core.get_bool ~default:false env_name
 
 let lifecycle_to_string = function


### PR DESCRIPTION
## Summary

Migrate 2 `Printf.eprintf` warning sites in config layer to `Log.Misc.warn`:
- `env_config_core.ml:101` — deprecated env var warning
- `feature_flag_registry.ml:226` — unregistered flag warning

`fs_compat/fs_compat.ml` NOT changed — separate sub-library without Log access.

## Product impact

Config warnings now appear with structured `[WARN] [Misc]` prefix and are routable through log filtering. No behavior change.

## Evidence

- `dune build --root .` passes. Log module is Atomic-based (no Eio dependency).

## Source

masc-mcp audit Axis D.

## Test plan

- [x] `dune build --root .` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)