### PR TITLE
feat(dashboard): add memory subsystems panel (episodes + Hebbian)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1705,6 +1705,52 @@ export function updateExcusePatterns(patterns: ExcusePattern[]): Promise<{ ok: b
   return post<{ ok: boolean }>('/api/v1/dashboard/config/excuse-patterns', patterns)
 }
 
+// --- Memory Subsystems ---
+
+export interface MemorySubsystemsSynapse {
+  from_agent: string
+  to_agent: string
+  weight: number
+  success_count: number
+  failure_count: number
+  last_updated: number
+  created_at: number
+}
+
+export interface MemorySubsystemsEpisode {
+  id: string
+  timestamp: number
+  participants: string[]
+  event_type: string
+  summary: string
+  outcome: string
+  learnings: string[]
+  context: Record<string, string>
+}
+
+export interface MemorySubsystemsResponse {
+  generated_at: string
+  hebbian: {
+    synapses: MemorySubsystemsSynapse[]
+    last_consolidation: number
+  }
+  episodes: {
+    total: number
+    shown: number
+    items: MemorySubsystemsEpisode[]
+  }
+}
+
+export function fetchMemorySubsystems(
+  opts?: { limit?: number; signal?: AbortSignal },
+): Promise<MemorySubsystemsResponse> {
+  const params = opts?.limit ? `?limit=${opts.limit}` : ''
+  return get<MemorySubsystemsResponse>(
+    `/api/v1/dashboard/memory-subsystems${params}`,
+    { signal: opts?.signal },
+  )
+}
+
 // --- Keeper Cascade Config ---
 
 export function fetchCascadeProfiles(): Promise<{ profiles: string[] }> {

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -1,0 +1,213 @@
+import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { LoadingState } from './common/feedback-state'
+import {
+  fetchMemorySubsystems,
+  type MemorySubsystemsResponse,
+  type MemorySubsystemsSynapse,
+  type MemorySubsystemsEpisode,
+} from '../api/dashboard'
+import { formatTimeAgo } from '../lib/format-time'
+import { isAbortError } from '../lib/async-state'
+import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+
+const REFRESH_MS = 30_000
+
+function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
+  const pct = Math.round(s.weight * 100)
+  const barColor =
+    pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-500' : 'bg-red-400'
+  return html`
+    <tr class="border-b border-zinc-800">
+      <td class="py-1.5 px-2 text-sm font-mono">${s.from_agent}</td>
+      <td class="py-1.5 px-2 text-sm text-zinc-400 text-center">→</td>
+      <td class="py-1.5 px-2 text-sm font-mono">${s.to_agent}</td>
+      <td class="py-1.5 px-2 text-sm text-right">
+        <div class="flex items-center gap-2 justify-end">
+          <div class="w-16 bg-zinc-800 rounded h-1.5">
+            <div class="${barColor} rounded h-1.5" style="width:${pct}%"></div>
+          </div>
+          <span class="text-zinc-300 w-10 text-right">${pct}%</span>
+        </div>
+      </td>
+      <td class="py-1.5 px-2 text-sm text-emerald-400 text-center">${s.success_count}</td>
+      <td class="py-1.5 px-2 text-sm text-red-400 text-center">${s.failure_count}</td>
+      <td class="py-1.5 px-2 text-xs text-zinc-500">${formatTimeAgo(s.last_updated * 1000)}</td>
+    </tr>
+  `
+}
+
+function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
+  const outcomeColor =
+    ep.outcome === 'success'
+      ? 'text-emerald-400'
+      : ep.outcome === 'partial'
+        ? 'text-amber-400'
+        : 'text-red-400'
+  const outcomeIcon =
+    ep.outcome === 'success' ? '●' : ep.outcome === 'partial' ? '◐' : '○'
+  return html`
+    <div class="border border-zinc-800 rounded-lg p-3 mb-2">
+      <div class="flex items-start justify-between gap-2 mb-1">
+        <div class="flex items-center gap-2 min-w-0">
+          <span class="${outcomeColor} text-xs">${outcomeIcon}</span>
+          <span class="text-sm font-medium text-zinc-200 truncate">${ep.summary}</span>
+        </div>
+        <span class="text-xs text-zinc-500 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
+      </div>
+      <div class="flex items-center gap-2 text-xs text-zinc-500 mb-1">
+        <span class="bg-zinc-800 px-1.5 py-0.5 rounded">${ep.event_type}</span>
+        ${ep.participants.map(
+          (p: string) => html`<span class="font-mono">${p}</span>`,
+        )}
+      </div>
+      ${
+        ep.learnings.length > 0
+          ? html`
+              <div class="mt-1.5 space-y-0.5">
+                ${ep.learnings.map(
+                  (l: string) =>
+                    html`<div class="text-xs text-zinc-400 pl-3 border-l border-zinc-700">${l}</div>`,
+                )}
+              </div>
+            `
+          : null
+      }
+      ${
+        ep.context && Object.keys(ep.context).length > 0
+          ? html`
+              <div class="mt-1 flex gap-2 flex-wrap">
+                ${Object.entries(ep.context).map(
+                  ([k, v]) =>
+                    html`<span class="text-xs bg-zinc-800/50 px-1.5 py-0.5 rounded text-zinc-500"
+                      >${k}: ${v}</span
+                    >`,
+                )}
+              </div>
+            `
+          : null
+      }
+    </div>
+  `
+}
+
+export function MemorySubsystems() {
+  const state = useSignal<{
+    loading: boolean
+    error: string | null
+    data: MemorySubsystemsResponse | null
+  }>({ loading: true, error: null, data: null })
+
+  async function refresh(signal?: AbortSignal) {
+    try {
+      const data = await fetchMemorySubsystems({ limit: 50, signal })
+      state.value = { loading: false, error: null, data }
+    } catch (err) {
+      if (isAbortError(err)) return
+      state.value = {
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+        data: state.value.data,
+      }
+    }
+  }
+
+  useEffect(() => {
+    const ac = new AbortController()
+    refresh(ac.signal)
+    const cleanup = setupVisibleAutoRefresh(() => refresh(), REFRESH_MS)
+    return () => {
+      ac.abort()
+      cleanup()
+    }
+  }, [])
+
+  const { loading, error, data } = state.value
+  if (loading && !data) return html`<${LoadingState} label="기억 서브시스템 로드 중..." />`
+  if (error && !data)
+    return html`<div class="p-4 text-red-400">Error: ${error}</div>`
+
+  const synapses = data?.hebbian?.synapses ?? []
+  const lastConsolidation = data?.hebbian?.last_consolidation ?? 0
+  const episodes = data?.episodes?.items ?? []
+  const totalEpisodes = data?.episodes?.total ?? 0
+
+  return html`
+    <div class="space-y-6">
+      <!-- Hebbian Synapses -->
+      <section>
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-base font-semibold text-zinc-200">Hebbian 시냅스 그래프</h3>
+          <div class="flex items-center gap-3 text-xs text-zinc-500">
+            <span>${synapses.length}개 시냅스</span>
+            ${
+              lastConsolidation > 0
+                ? html`<span>마지막 통합: ${formatTimeAgo(lastConsolidation * 1000)}</span>`
+                : null
+            }
+          </div>
+        </div>
+        ${
+          synapses.length === 0
+            ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
+                시냅스 데이터 없음. keeper task 완료 시 자동 생성됩니다.
+              </div>`
+            : html`
+                <div class="overflow-x-auto">
+                  <table class="w-full text-left">
+                    <thead>
+                      <tr class="border-b border-zinc-700 text-xs text-zinc-500">
+                        <th class="py-1.5 px-2">From</th>
+                        <th class="py-1.5 px-2"></th>
+                        <th class="py-1.5 px-2">To</th>
+                        <th class="py-1.5 px-2 text-right">Weight</th>
+                        <th class="py-1.5 px-2 text-center">성공</th>
+                        <th class="py-1.5 px-2 text-center">실패</th>
+                        <th class="py-1.5 px-2">마지막</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${synapses.map(
+                        (s: MemorySubsystemsSynapse) => html`<${SynapseRow} s=${s} />`,
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              `
+        }
+      </section>
+
+      <!-- Episodes -->
+      <section>
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-base font-semibold text-zinc-200">에피소드 기록</h3>
+          <span class="text-xs text-zinc-500">${totalEpisodes}개 중 최근 ${episodes.length}개</span>
+        </div>
+        ${
+          episodes.length === 0
+            ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
+                에피소드 없음. keeper [STATE] 출력 시 자동 기록됩니다.
+              </div>`
+            : html`
+                <div class="space-y-1">
+                  ${episodes
+                    .slice()
+                    .reverse()
+                    .map(
+                      (ep: MemorySubsystemsEpisode) =>
+                        html`<${EpisodeCard} ep=${ep} />`,
+                    )}
+                </div>
+              `
+        }
+      </section>
+
+      ${
+        error
+          ? html`<div class="text-xs text-amber-500 mt-2">refresh error: ${error}</div>`
+          : null
+      }
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,12 +9,13 @@ import { Activity } from './activity'
 import { RuntimeMonitor } from './runtime-monitor'
 import { TelemetryUnified } from './telemetry-unified'
 import { GovernanceMonitor } from './governance-monitor'
+import { MemorySubsystems } from './memory-subsystems'
 
-type StatusSection = 'sessions' | 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance'
+type StatusSection = 'sessions' | 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems'
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
-  if (section === 'agents' || section === 'activity' || section === 'runtime' || section === 'telemetry' || section === 'governance') return section
+  if (section === 'agents' || section === 'activity' || section === 'runtime' || section === 'telemetry' || section === 'governance' || section === 'memory-subsystems') return section
   return 'sessions'
 }
 
@@ -34,6 +35,8 @@ export function Status() {
               ? html`<${TelemetryUnified} />`
             : section === 'governance'
               ? html`<${GovernanceMonitor} />`
+            : section === 'memory-subsystems'
+              ? html`<${MemorySubsystems} />`
               : html`<${Mission} />`}
       </div>
     </div>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -19,6 +19,7 @@ export type SurfaceSectionId =
   | 'tool-quality'
   | 'fleet'
   | 'connectors'
+  | 'memory-subsystems'
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
 
@@ -149,6 +150,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: 'tool 이벤트',
       description: 'tool rejection 집계 + approval queue depth/latency.',
       params: { section: 'governance' },
+    },
+    {
+      id: 'memory-subsystems',
+      label: '기억 서브시스템',
+      description: 'Hebbian 시냅스 그래프, 에피소드 기록, compaction 상태.',
+      params: { section: 'memory-subsystems' },
     },
   ],
   command: [

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -68,6 +68,43 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
       ("sort_by", `String (board_sort_label sort_by));
     ]
 
+let dashboard_memory_subsystems_http_json ~(config : Room_utils.config) request
+    : Yojson.Safe.t =
+  let limit =
+    int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200
+  in
+  let episodes =
+    try Institution_eio.load_recent_episodes_jsonl ~limit
+    with _ -> []
+  in
+  let hebbian =
+    try
+      let g = Hebbian_eio.load_graph config in
+      Hebbian_eio.graph_to_json g
+    with _ -> `Assoc [ ("synapses", `List []); ("last_consolidation", `Float 0.0) ]
+  in
+  let episode_count =
+    try
+      let path = Institution_eio.episodes_jsonl_path () in
+      let jsons = Fs_compat.load_jsonl path in
+      List.length jsons
+    with _ -> 0
+  in
+  `Assoc
+    [
+      ("generated_at", `String (Types.now_iso ()));
+      ( "hebbian", hebbian );
+      ( "episodes",
+        `Assoc
+          [
+            ("total", `Int episode_count);
+            ("shown", `Int (List.length episodes));
+            ( "items",
+              `List
+                (List.map Institution_eio.episode_to_json episodes) );
+          ] );
+    ]
+
 let dashboard_governance_http_json request ~base_path : Yojson.Safe.t =
   let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
   let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -218,6 +218,12 @@ let rec add_routes ~sw ~clock router =
          let json = dashboard_memory_http_json req in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/memory-subsystems" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let config = state.Mcp_server.room_config in
+         let json = dashboard_memory_subsystems_http_json ~config req in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in


### PR DESCRIPTION
## Summary

대시보드 모니터링 탭에 "기억 서브시스템" 섹션 추가. 에피소드와 Hebbian 시냅스를 실시간으로 확인 가능.

- **Hebbian 시냅스 테이블**: agent 쌍, weight bar, 성공/실패 카운트, 마지막 업데이트
- **에피소드 카드**: summary, outcome 표시, learnings, context metadata. 최신순

## Changes

| File | Change |
|------|--------|
| `lib/server/server_dashboard_http.ml` | `dashboard_memory_subsystems_http_json` handler |
| `lib/server/server_routes_http_routes_dashboard.ml` | `/api/v1/dashboard/memory-subsystems` route |
| `dashboard/src/api/dashboard.ts` | `fetchMemorySubsystems` + types |
| `dashboard/src/config/navigation.ts` | `memory-subsystems` section |
| `dashboard/src/components/memory-subsystems.ts` | UI component (SynapseRow, EpisodeCard) |
| `dashboard/src/components/status.ts` | Route `memory-subsystems` to component |

## Context

PR #6935에서 Hebbian + episode wiring을 수정한 후, runtime 검증으로 episodes가 2→14로 증가 확인. 이 패널로 지속적 관찰 가능.

## Test plan

- [x] `dune build` clean
- [x] `tsc --noEmit` clean
- [x] `vite build` success
- [ ] CI green
- [ ] 브라우저에서 모니터링 > 기억 서브시스템 탭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)