### PR TITLE
fix(voice,gate): close dedup race + sanitize channel_session_key

### DIFF
--- a/lib/gate_keeper_backend.ml
+++ b/lib/gate_keeper_backend.ml
@@ -58,6 +58,25 @@ let normalized_or_unknown value =
   | "" -> "unknown"
   | trimmed -> trimmed
 
+(** Sanitize a value for use as a filesystem path component.
+    Replaces everything outside [A-Za-z0-9_-] with '_' so that the resulting
+    string cannot escape its intended parent directory via '/', '\\', or '..'
+    sequences. Empty or fully-stripped values collapse to "unknown". *)
+let filesystem_safe_or_unknown value =
+  let normalized = normalized_context_value value in
+  if normalized = "" then "unknown"
+  else
+    let buf = Buffer.create (String.length normalized) in
+    String.iter
+      (fun ch ->
+        match ch with
+        | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' ->
+          Buffer.add_char buf ch
+        | _ -> Buffer.add_char buf '_')
+      normalized;
+    let s = Buffer.contents buf in
+    if s = "" || String.for_all (fun c -> c = '_') s then "unknown" else s
+
 let agent_name_for_channel_actor ~channel ~channel_room_id ~channel_user_id =
   Printf.sprintf "gate:%s:%s:%s"
     (normalized_or_unknown channel)
@@ -89,10 +108,15 @@ let dispatch ~sw ~clock ~proc_mgr ~net ~config
   let agent_name =
     agent_name_for_channel_actor ~channel ~channel_room_id ~channel_user_id
   in
+  (* Use filesystem-safe sanitizer: this key is later used as a directory
+     component in session_dir. An unsanitized channel_room_id with '..' or '/'
+     would escape the intended traces/channels/ subtree. Discord passes
+     numeric IDs so this is defensive for future integrations (webhooks,
+     custom channels) that could pass attacker-controlled values. *)
   let channel_session_key =
     Printf.sprintf "%s_%s"
-      (normalized_or_unknown channel)
-      (normalized_or_unknown channel_room_id)
+      (filesystem_safe_or_unknown channel)
+      (filesystem_safe_or_unknown channel_room_id)
   in
   let args =
     `Assoc [

--- a/lib/voice/voice_bridge.ml
+++ b/lib/voice/voice_bridge.ml
@@ -474,27 +474,39 @@ let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
            ~agent_id ~output_file:audio_file
        with
       | Ok file_size ->
-          let played_seconds = run_local_playback ~sw ~agent_id ~audio_file in
-          record_playback ~agent_id ~message;
-          Ok
-            (append_provider_metadata
-               (`Assoc
-                 (List.concat [
-                   [
-                     ("status", `String "spoken");
-                     ("agent_id", `String agent_id);
-                     ("voice", `String voice);
-                     ("audio_file", `String audio_file);
-                     ("audio_size", `Int file_size);
-                     ( "message_preview",
-                       `String
-                         (String.sub message 0 (min 50 (String.length message))) );
-                   ];
-                   (match played_seconds with
-                    | Some s -> [("played_seconds", `Float s)]
-                    | None -> []);
-                 ]))
-               endpoint)
+          (* run_local_playback now owns the dedup record inside its mutex to
+             close the check-then-act race with [is_dedup_hit]. *)
+          let playback_result =
+            run_local_playback ~sw ~agent_id ~message ~audio_file ()
+          in
+          (match playback_result with
+           | `Dedup_hit ->
+             (try Sys.remove audio_file with Sys_error _ -> ());
+             Ok (`Assoc [
+               ("status", `String "dedup_skipped");
+               ("agent_id", `String agent_id);
+               ("reason", `String "identical message was played recently (mutex)");
+             ])
+           | `Played played_seconds ->
+             Ok
+               (append_provider_metadata
+                  (`Assoc
+                    (List.concat [
+                      [
+                        ("status", `String "spoken");
+                        ("agent_id", `String agent_id);
+                        ("voice", `String voice);
+                        ("audio_file", `String audio_file);
+                        ("audio_size", `Int file_size);
+                        ( "message_preview",
+                          `String
+                            (String.sub message 0 (min 50 (String.length message))) );
+                      ];
+                      (match played_seconds with
+                       | Some s -> [("played_seconds", `Float s)]
+                       | None -> []);
+                    ]))
+                  endpoint))
       | Error error ->
           (try Sys.remove audio_file with Sys_error _ -> ());
           Error error)

--- a/lib/voice/voice_bridge_core.ml
+++ b/lib/voice/voice_bridge_core.ml
@@ -176,64 +176,92 @@ let local_playback_argv ?path_value ~audio_file () =
   in
   pick commands
 
-let run_local_playback ~sw:_ ~agent_id ~audio_file =
+(** Runs local playback with mutex-protected dedup check.
+    Returns:
+    - [`Dedup_hit] if another fiber already played this same message recently
+      (check happens INSIDE the mutex to close the check-then-act race where two
+      fibers both pass the outer [is_dedup_hit] before either records).
+    - [`Played None] if playback was disabled, unavailable, or failed.
+    - [`Played (Some dur)] if playback succeeded with the given duration.
+
+    When [message] is [None] the dedup re-check is skipped (legacy callers that
+    do not propagate the message string). *)
+let run_local_playback ~sw:_ ~agent_id ?message ~audio_file () =
   match load_voice_config () with
   | Error e ->
     Log.Misc.warn "voice config load failed, skipping playback for %s: %s" agent_id e;
-    None
+    `Played None
   | Ok config ->
     if not (Voice_config.local_playback_enabled_for_agent config agent_id) then
-      None
+      `Played None
     else
       match local_playback_argv ~audio_file () with
       | None ->
         log_error
           "local voice playback unavailable: no ffplay/mpg123/play/open executable found";
-        None
+        `Played None
       | Some argv ->
         Eio.Mutex.use_rw ~protect:true playback_mu (fun () ->
-          let t0 = Unix.gettimeofday () in
-          try
-            match Process_eio.run_argv_with_status ~timeout_sec:60.0 argv with
-            | Unix.WEXITED 0, _ ->
-              let dur = Unix.gettimeofday () -. t0 in
-              log_info
-                (Printf.sprintf
-                   "local voice playback finished: agent=%s file=%s via=%s duration=%.1fs"
-                   agent_id audio_file
-                   (match argv with h :: _ -> h | [] -> "unknown")
-                   dur);
-              Some dur
-            | Unix.WEXITED code, output ->
-              log_error
-                (Printf.sprintf
-                   "local voice playback failed (exit=%d): %s%s"
-                   code (String.concat " " argv)
-                   (if String.trim output = "" then "" else " :: " ^ String.trim output));
-              None
-            | Unix.WSTOPPED signal, output ->
-              log_error
-                (Printf.sprintf
-                   "local voice playback stopped (sig=%d): %s%s"
-                   signal (String.concat " " argv)
-                   (if String.trim output = "" then "" else " :: " ^ String.trim output));
-              None
-            | Unix.WSIGNALED signal, output ->
-              log_error
-                (Printf.sprintf
-                   "local voice playback signaled (sig=%d): %s%s"
-                   signal (String.concat " " argv)
-                   (if String.trim output = "" then "" else " :: " ^ String.trim output));
-              None
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            log_error (Printf.sprintf "voice playback exception: %s"
-              (Printexc.to_string exn));
-            None)
+          let dedup_hit =
+            match message with
+            | Some m -> is_dedup_hit ~agent_id ~message:m
+            | None -> false
+          in
+          if dedup_hit then begin
+            log_info (Printf.sprintf
+              "voice dedup skip inside mutex: agent=%s (same message within %.0fs window)"
+              agent_id playback_dedup_window_sec);
+            `Dedup_hit
+          end
+          else begin
+            (* Record BEFORE playing so concurrent callers waiting on this mutex
+               will observe the in-flight playback when they acquire it. *)
+            (match message with
+             | Some m -> record_playback ~agent_id ~message:m
+             | None -> ());
+            let t0 = Unix.gettimeofday () in
+            try
+              match Process_eio.run_argv_with_status ~timeout_sec:60.0 argv with
+              | Unix.WEXITED 0, _ ->
+                let dur = Unix.gettimeofday () -. t0 in
+                log_info
+                  (Printf.sprintf
+                     "local voice playback finished: agent=%s file=%s via=%s duration=%.1fs"
+                     agent_id audio_file
+                     (match argv with h :: _ -> h | [] -> "unknown")
+                     dur);
+                `Played (Some dur)
+              | Unix.WEXITED code, output ->
+                log_error
+                  (Printf.sprintf
+                     "local voice playback failed (exit=%d): %s%s"
+                     code (String.concat " " argv)
+                     (if String.trim output = "" then "" else " :: " ^ String.trim output));
+                `Played None
+              | Unix.WSTOPPED signal, output ->
+                log_error
+                  (Printf.sprintf
+                     "local voice playback stopped (sig=%d): %s%s"
+                     signal (String.concat " " argv)
+                     (if String.trim output = "" then "" else " :: " ^ String.trim output));
+                `Played None
+              | Unix.WSIGNALED signal, output ->
+                log_error
+                  (Printf.sprintf
+                     "local voice playback signaled (sig=%d): %s%s"
+                     signal (String.concat " " argv)
+                     (if String.trim output = "" then "" else " :: " ^ String.trim output));
+                `Played None
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+              log_error (Printf.sprintf "voice playback exception: %s"
+                (Printexc.to_string exn));
+              `Played None
+          end)
 
 let start_local_playback ~sw ~agent_id ~audio_file =
-  ignore (run_local_playback ~sw ~agent_id ~audio_file : float option)
+  ignore (run_local_playback ~sw ~agent_id ~audio_file () : [`Dedup_hit | `Played of float option])
 
 (** Get voice for agent, defaults to "Sarah" if config is unavailable *)
 let get_voice_for_agent agent_id =


### PR DESCRIPTION
## Summary

Two structural bugs found during a bug-sweep audit of PR #6934's voice sync + channel isolation code.

### 1. Voice dedup race (HIGH)

`is_dedup_hit` was called outside any lock, then `run_local_playback` acquired `playback_mu` and blocked for up to 60s, then `record_playback` was called AFTER playback. Two fibers calling `agent_speak` with the same message both passed the outer dedup check before either recorded, so both eventually played. Reachable when the keeper LLM emits two `keeper_voice_speak` tool calls in one response — exactly the \"병렬 목소리\" symptom reported against sangsu.

**Fix**: move `is_dedup_hit` + `record_playback` INSIDE the `playback_mu` block at the top of `run_local_playback`. Record now happens BEFORE playback, so concurrent callers waiting on the mutex observe the in-flight record when they acquire it and skip.

### 2. Path traversal via channel_session_key (MEDIUM, defensive)

`channel_session_key` is built from `normalized_or_unknown` values and used as a directory component under `traces/channels/`. `normalized_or_unknown` strips whitespace but does NOT reject `/`, `\`, or `..`. `Filename.concat` preserves `..`, so an attacker-controlled `channel_room_id` like `../../../evil` would escape the intended subtree.

Not currently exploitable — Discord passes numeric IDs — but defensive for future webhooks / REST channel adapters.

**Fix**: new `filesystem_safe_or_unknown` replaces everything outside `[A-Za-z0-9_-]` with `_`.

## Test plan

- [x] `dune build @all` succeeds
- [x] `dune build @runtest` exits 0 (unrelated keeper_tool_matrix env failures are pre-existing)
- [ ] Manual smoke test after merge: send two rapid identical messages to sangsu in Discord, verify only one plays via voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)