### PR TITLE
fix(ids): close Atomic.incr+get split race in 4 sequence-ID generators

### DIFF
--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -69,9 +69,12 @@ let current_month_file config agent_id =
 let metric_counter = Atomic.make 0
 
 let generate_id () =
-  Atomic.incr metric_counter;
+  (* Use [fetch_and_add] rather than [Atomic.incr; Atomic.get] so the counter
+     read is atomic with the increment. With the split pair, two fibers can
+     both [incr] before either [get], and both observe the same post-increment
+     value, producing duplicate IDs for entries in the same millisecond. *)
+  let sequence = Atomic.fetch_and_add metric_counter 1 + 1 in
   let timestamp_ms = int_of_float (Time_compat.now () *. 1000.) in
-  let sequence = Atomic.get metric_counter in
   Printf.sprintf "metric-%d-%06d" timestamp_ms sequence
 
 (* Async write queue: callers push (file, line) entries into a bounded stream.

--- a/lib/room/heartbeat.ml
+++ b/lib/room/heartbeat.ml
@@ -26,8 +26,11 @@ let with_mu_safe mode f =
   | `RO -> Eio_guard.with_mutex_ro mu f
 
 let generate_id () =
-  Atomic.incr heartbeat_counter;
-  Printf.sprintf "hb-%d-%d" (int_of_float (Time_compat.now ())) (Atomic.get heartbeat_counter)
+  (* [fetch_and_add] instead of [incr; get] pair — the split version lets two
+     fibers both observe the same post-increment counter and produce duplicate
+     heartbeat IDs. *)
+  let seq = Atomic.fetch_and_add heartbeat_counter 1 + 1 in
+  Printf.sprintf "hb-%d-%d" (int_of_float (Time_compat.now ())) seq
 
 let start ~agent_name ~interval ~message =
   with_mu_safe `RW (fun () ->

--- a/lib/types/ids.ml
+++ b/lib/types/ids.ml
@@ -36,8 +36,10 @@ end = struct
   let _id_counter = Atomic.make 0
   let generate () =
     let timestamp = int_of_float (Time_compat.now () *. 1000.0) in
-    Atomic.incr _id_counter;
-    let seq = Atomic.get _id_counter land 0xFFFF in
+    (* [fetch_and_add] atomically returns the pre-increment value, avoiding
+       the [incr; get] split where two fibers can observe the same counter
+       value and produce duplicate task IDs within the same millisecond. *)
+    let seq = (Atomic.fetch_and_add _id_counter 1 + 1) land 0xFFFF in
     Printf.sprintf "task-%d-%04x" timestamp seq
   let to_yojson t = `String t
   let of_yojson = function
@@ -62,8 +64,10 @@ end = struct
   let _id_counter = Atomic.make 0
   let generate () =
     let timestamp = int_of_float (Time_compat.now () *. 1000.0) in
-    Atomic.incr _id_counter;
-    let seq = Atomic.get _id_counter land 0xFFFF in
+    (* See Task_id.generate — [fetch_and_add] closes the split-atomic race
+       so concurrent callers cannot produce duplicate IDs within the same
+       millisecond. *)
+    let seq = (Atomic.fetch_and_add _id_counter 1 + 1) land 0xFFFF in
     Printf.sprintf "thread-%d-%04x" timestamp seq
   let to_yojson t = `String t
   let of_yojson = function


### PR DESCRIPTION
## Summary

Four call sites generate unique IDs using `Atomic.incr counter; Atomic.get counter` — but that pair is **not atomic**. Two concurrent fibers can both increment before either reads, then both read the same post-increment value, producing duplicate IDs.

## Affected IDs

| File:line | ID format | Consumer |
|-----------|-----------|----------|
| `metrics_store_eio.ml:71` | `metric-{ms}-{seq:06d}` | task metric store, dashboards |
| `room/heartbeat.ml:28` | `hb-{ts}-{seq}` | heartbeat tracker |
| `types/ids.ml:37` | `task-{ms}-{seq:04x}` | task IDs throughout MASC |
| `types/ids.ml:63` | `thread-{ms}-{seq:04x}` | thread IDs throughout MASC |

When two callers land in the same millisecond under burst traffic (e.g. keeper turn bursts, fanned-out heartbeats), sequence+timestamp both collide and the full ID is duplicated.

## Fix

Replace `Atomic.incr; Atomic.get` with `Atomic.fetch_and_add counter 1 + 1`, which atomically returns the pre-increment value.

## Sweep discipline

Ran `rg Atomic.incr` across `lib/` to enumerate every site. Other `Atomic.incr` uses (validation counter, room state counters, gRPC stream counters, backoff counter, client counters, hebbian lock stats) are **approximate counters** where read-your-own-write is not required — those remain unchanged. Only ID-generation sites (where uniqueness matters) were fixed.

## Exploit window

Small on single-domain Eio with cooperative scheduling, but real if the read yields (e.g. `Time_compat.now` invoking the Eio clock effect), and wide open under multi-domain Eio. Using the correct atomic primitive removes the foot-gun even before multi-domain ships.

## Test plan

- [x] \`dune build @all\` succeeds
- [ ] Post-merge: sample metric/heartbeat/task logs under concurrent load, confirm unique IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)