### PR TITLE
fix(observability): track board persist + keeper write_meta errors via counters

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -7,6 +7,18 @@ include Board_core_payload
 (** Flush interval in seconds - configurable via MASC_BOARD_FLUSH_INTERVAL_SEC env var *)
 let flush_interval_sec = Env_config.Board.flush_interval_sec
 
+(** Monotonic counter of persist failures (disk full, permission errors, etc.).
+    Callers of [rewrite_posts]/[rewrite_comments] cannot propagate these
+    errors, but operators need visibility. Surface via [persist_error_count ()]
+    in health dashboards and Prometheus exporters. *)
+let persist_errors = Atomic.make 0
+
+let persist_error_count () = Atomic.get persist_errors
+
+let record_persist_error ~where msg =
+  Atomic.incr persist_errors;
+  Log.BoardLog.error "persist error (%s): %s" where msg
+
 let create_store () = {
   posts = Hashtbl.create 1024;
   comments = Hashtbl.create 4096;
@@ -241,8 +253,8 @@ let rewrite_posts store =
     ) store.posts;
     (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
      | Ok () -> ()
-     | Error msg -> Log.BoardLog.error "persist error (rewrite_posts): %s" msg)
-  with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_posts): %s" msg
+     | Error msg -> record_persist_error ~where:"rewrite_posts" msg)
+  with Sys_error msg -> record_persist_error ~where:"rewrite_posts" msg
 
 let rewrite_comments store =
   try
@@ -254,8 +266,8 @@ let rewrite_comments store =
     ) store.comments;
     (match Fs_compat.save_file_atomic path (Buffer.contents buf) with
      | Ok () -> ()
-     | Error msg -> Log.BoardLog.error "persist error (rewrite_comments): %s" msg)
-  with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_comments): %s" msg
+     | Error msg -> record_persist_error ~where:"rewrite_comments" msg)
+  with Sys_error msg -> record_persist_error ~where:"rewrite_comments" msg
 
 (** {1 Append Helpers} *)
 
@@ -265,7 +277,7 @@ let append_post (p : post) =
     let path = persist_path () in
     Fs_compat.append_file path (Yojson.Safe.to_string (post_to_yojson p) ^ "\n");
     rotate_if_needed path
-  with Sys_error msg -> Log.BoardLog.error "persist error (append_post): %s" msg
+  with Sys_error msg -> record_persist_error ~where:"append_post" msg
 
 let append_comment (c : comment) =
   try
@@ -273,7 +285,7 @@ let append_comment (c : comment) =
     let path = comments_path () in
     Fs_compat.append_file path (Yojson.Safe.to_string (comment_to_yojson c) ^ "\n");
     rotate_if_needed path
-  with Sys_error msg -> Log.BoardLog.error "persist error (append_comment): %s" msg
+  with Sys_error msg -> record_persist_error ~where:"append_comment" msg
 
 (** {1 Post Operations} *)
 

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1096,6 +1096,8 @@ let sync_keeper_presence
       match write_meta ctx.config synced with
       | Ok () -> synced
       | Error e ->
+        Prometheus.inc_counter "masc_keeper_write_meta_failures_total"
+          ~labels:[("keeper", synced.name); ("phase", "heartbeat")] ();
         Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
         synced
     with
@@ -1261,6 +1263,8 @@ let run_keepalive_unified_turn
         match write_meta ctx.config meta_after_observe with
         | Ok () -> ()
         | Error e ->
+            Prometheus.inc_counter "masc_keeper_write_meta_failures_total"
+              ~labels:[("keeper", meta_after_observe.name); ("phase", "cursor_update")] ();
             Log.Keeper.warn "write_meta failed (message cursor update): %s" e);
       if Atomic.get stop
       then meta_after_triage
@@ -1973,7 +1977,10 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
     let synced = ensure_keeper_room_presence ctx.config m in
     (match write_meta ctx.config synced with
      | Ok () -> ()
-     | Error e -> Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
+     | Error e ->
+       Prometheus.inc_counter "masc_keeper_write_meta_failures_total"
+         ~labels:[("keeper", synced.name); ("phase", "bootstrap")] ();
+       Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
     synced
   with
   | Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
## Summary

Part of #6959. Complements #6963 (backend lock/health).

board_core.ml 의 4개 persist 실패 지점과 keeper_keepalive.ml 의 3개 write_meta 실패 지점에 **Prometheus/Atomic 카운터**를 달아 operator 가시성을 확보합니다. Caller signature 는 유지 — 기존 5개 호출처 (board_votes flush/delete 경로)는 unit-returning 그대로 유지.

## Changes

### board_core.ml (4 sites)
- Adds monotonic \`Atomic.t\` counter behind \`persist_error_count ()\` accessor
- Unifies 4 persist-error log sites through \`record_persist_error ~where msg\`
- 기존: \`Log.BoardLog.error \"persist error (rewrite_posts): %s\" msg\` + 누락된 counter
- 변경: \`record_persist_error ~where:\"rewrite_posts\" msg\` → 로그 + Atomic.incr 동시

### keeper_keepalive.ml (3 sites)
- Adds \`masc_keeper_write_meta_failures_total{keeper, phase}\` Prometheus counter next to existing warn log
- phase labels: \`heartbeat\`, \`cursor_update\`, \`bootstrap\`
- Matches existing pattern: \`masc_keeper_heartbeat_successes_total\`

## Rationale

write_meta 실패는 heartbeat/cursor/bootstrap 모든 phase에서 recoverable (다음 tick 에서 meta 재기록). 따라서 warn 로그 레벨은 맞지만, 이전에는 aggregate 지표가 없어 operator 가 disk-full 이나 permission regression 을 탐지할 수 없었음.

## Test plan

- [x] \`dune build @check\` — 통과
- [x] \`test_board_ttl.exe\` — 9 tests pass (regression check)
- [x] 동작 변화 없음 — 기존 log 호출은 유지되고 counter 만 추가됨

## Scope notes

- 남은 #6959 작업: backend.ml (lock/health) 는 **#6963** 에서 진행 중
- Ref-based write_meta failures 는 warn+counter 패턴으로 유지 — caller signature 변경은 \"log or crash\" 선택을 강요하게 되어 스코프 초과

🤖 Generated with [Claude Code](https://claude.com/claude-code)