### PR TITLE
fix(keeper_exec_github): don't swallow Eio.Cancel.Cancelled in PR URL scan

### DIFF
--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -897,7 +897,9 @@ let handle_keeper_pr_submit
                    | Some groups -> found_url := Re.Group.get groups 0
                    | None -> ()
                ) lines
-             with _ -> ());
+             with
+             | Eio.Cancel.Cancelled _ as e -> raise e
+             | _ -> ());
             if !found_url <> "" then begin
               pr_url := !found_url;
               Ok (Printf.sprintf "PR created: %s" !found_url)


### PR DESCRIPTION
## Problem

\`keeper_exec_github.ml:900\` scans stdout for a GitHub PR URL with a bare \`with _ -> ()\`:

\`\`\`ocaml
(try
   List.iter (fun line ->
     match Re.exec_opt url_re trimmed with
     | Some groups -> found_url := Re.Group.get groups 0
     | None -> ()
   ) lines
 with _ -> ());
\`\`\`

**Bug**: catches \`Eio.Cancel.Cancelled\` silently. If the keeper fiber running \`gh pr create\` is cancelled mid-scan, cancellation is absorbed and the code continues as if parsing succeeded.

The intent was to ignore \`Re\` failures (\`Invalid_argument\` on a malformed pattern), not cancellation.

## Fix

Add the standard Cancelled re-raise guard before the wildcard — the pattern used everywhere else in the codebase:

\`\`\`ocaml
with
| Eio.Cancel.Cancelled _ as e -> raise e
| _ -> ());
\`\`\`

## Test plan
- [x] \`dune build --root .\` passes
- [ ] CI green

Part of OCaml Best Practice Audit.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>