### PR TITLE
fix(eio): don't swallow Cancelled in 4 more with-exn sites

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1778,9 +1778,11 @@ let run_turn
                    "keeper:%s post-run flush episodes=%d procedures=%d"
                    meta.name ep pr
              | None -> ())
-           with exn ->
-             Log.Keeper.warn "keeper:%s episode_create failed: %s"
-               meta.name (Printexc.to_string exn));
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               Log.Keeper.warn "keeper:%s episode_create failed: %s"
+                 meta.name (Printexc.to_string exn));
           (* Memory bank compaction: dedup + consolidate if over threshold. *)
           (try
              let compaction =
@@ -1791,9 +1793,11 @@ let run_turn
                  "keeper:%s memory_compacted before=%d after=%d dropped=%d"
                  meta.name compaction.before_notes compaction.after_notes
                  compaction.dropped_notes
-           with exn ->
-             Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
-               (Printexc.to_string exn));
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
+               Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
+                 (Printexc.to_string exn));
           (* Post-turn quality metrics — goal alignment + memory recall.
             Logged to decisions.jsonl for feedback loop analysis. *)
           (try

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -949,9 +949,11 @@ let handle_keeper_pr_submit
               "created_at", `String (Printf.sprintf "%.0f" (Unix.gettimeofday ()));
             ] in
             Fs_compat.append_jsonl history_path entry
-          with exn ->
-            Log.Keeper.warn "pr_history append failed: %s (keeper=%s)"
-              (Printexc.to_string exn) meta.name
+          with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+              Log.Keeper.warn "pr_history append failed: %s (keeper=%s)"
+                (Printexc.to_string exn) meta.name
         end;
         Yojson.Safe.to_string
           (`Assoc

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -504,9 +504,13 @@ let atomic_write_file ~(path : string) (content : string) : (unit, string) resul
     Fs_compat.save_file tmp content;
     Fs_compat.rename tmp path;
     Ok ()
-  with exn ->
-    (try Sys.remove tmp with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-    Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+      (try Sys.remove tmp with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+      raise e
+  | exn ->
+      (try Sys.remove tmp with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
+      Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
 
 (** Update a field in a keeper TOML file on disk.
     Uses atomic write (temp file + rename) to prevent corruption


### PR DESCRIPTION
## Problem

Four try-with blocks used \`with exn -> Log.warn ...\` or \`with exn -> Error ...\` — catching \`Eio.Cancel.Cancelled\` silently. All four run inside keeper fibers where cancellation propagation is required for structured concurrency.

| File:Line | Path | Cancel impact |
|---|---|---|
| \`keeper_toml_loader.ml:507\` | \`atomic_write_file\` | Cancelled → Error "atomic write failed", caller unaware |
| \`keeper_exec_github.ml:952\` | pr_history append | Cancelled silently logged, gh workflow continues |
| \`keeper_agent_run.ml:1781\` | post-run episode flush | Cancelled logged, keeper moves to next phase |
| \`keeper_agent_run.ml:1794\` | memory bank compaction | Cancelled logged, keeper continues |

## Fix

Add \`| Eio.Cancel.Cancelled _ as e -> raise e\` before the \`exn\` branch. Log-and-continue semantics preserved for real errors only.

## Test plan
- [x] \`dune build --root .\` passes
- [ ] CI green

Follow-up to #6988, #6990. Part of OCaml Best Practice Audit.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>