### PR TITLE
fix(eio): don't swallow Cancelled in 3 more catch-all sites

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1778,7 +1778,9 @@ let run_turn
                    "keeper:%s post-run flush episodes=%d procedures=%d"
                    meta.name ep pr
              | None -> ())
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              Log.Keeper.warn "keeper:%s episode_create failed: %s"
                meta.name (Printexc.to_string exn));
           (* Memory bank compaction: dedup + consolidate if over threshold. *)
@@ -1791,7 +1793,9 @@ let run_turn
                  "keeper:%s memory_compacted before=%d after=%d dropped=%d"
                  meta.name compaction.before_notes compaction.after_notes
                  compaction.dropped_notes
-           with exn ->
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | exn ->
              Log.Keeper.warn "keeper:%s compaction failed: %s" meta.name
                (Printexc.to_string exn));
           (* Post-turn quality metrics — goal alignment + memory recall.

--- a/lib/keeper/keeper_toml_loader.ml
+++ b/lib/keeper/keeper_toml_loader.ml
@@ -504,7 +504,13 @@ let atomic_write_file ~(path : string) (content : string) : (unit, string) resul
     Fs_compat.save_file tmp content;
     Fs_compat.rename tmp path;
     Ok ()
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as e ->
+    (* Fiber cancellation must propagate — never convert it to an Error result.
+       Cleanup is best-effort, itself guarded against swallowing the cancel. *)
+    (try Sys.remove tmp with Eio.Cancel.Cancelled _ as ce -> raise ce | _ -> ());
+    raise e
+  | exn ->
     (try Sys.remove tmp with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
     Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
 


### PR DESCRIPTION
## Summary

Extends the Cancelled re-raise sweep alongside #6988 (keeper_exec_github) and #6990 (server_dashboard_http + tool_board). Three remaining \`with exn ->\` sites were silently swallowing \`Eio.Cancel.Cancelled\`, breaking fiber cancellation semantics.

## Sites fixed

| File:line | Impact |
|-----------|--------|
| \`keeper_toml_loader.ml:507\` (atomic_write_file) | Fiber cancel during save/rename converted to \`Error\` — caller can't distinguish cancel from genuine I/O failure |
| \`keeper_agent_run.ml:1781\` (episode_create flush) | Cancelled turn continues post-run steps (compaction, metrics) as if nothing happened |
| \`keeper_agent_run.ml:1794\` (memory bank compaction) | Same pattern, same impact |

## Sites NOT fixed (verified safe via structural reading)

| File:line | Why safe |
|-----------|----------|
| \`file_lock_eio.ml:103\`, \`:139\` | Handler ends with \`raise exn\` |
| \`spawn.ml:334\` | Handler ends with \`raise exn\` |
| \`tool_command_plane_support.ml:234\` | Handler ends with \`raise exn\` |

## Why this is a real bug (not a theoretical race)

Keeper turns can be cancelled mid-flight when the controlling switch ends (shutdown, timeout, explicit cancel). With Cancelled swallowed at the three fixed sites:
- \`atomic_write_file\`: returns \`Error\` → caller might retry the write or continue with stale config
- \`episode_create\`: warn log, turn proceeds to compaction → compaction runs on cancelled keeper state
- \`compaction\`: warn log, turn proceeds to metrics → metrics recorded for a turn that was cancelled

## Verification

- [x] \`dune build @all\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)