### PR TITLE
refactor(test): convert test_cache_eio to Alcotest.run

### DIFF
--- a/test/test_cache_eio.ml
+++ b/test/test_cache_eio.ml
@@ -340,21 +340,38 @@ let test_get_migrates_legacy_entry_and_list_dedupes () =
   print_endline "  test_get_migrates_legacy_entry_and_list_dedupes passed"
 
 let () =
-  print_endline "\n=== Cache_eio Tests (Pure Sync) ===\n";
-  test_set_and_get ();
-  test_set_with_ttl ();
-  test_set_with_tags ();
-  test_large_value_round_trips_without_truncation ();
-  test_get_nonexistent ();
-  test_delete ();
-  test_list ();
-  test_clear ();
-  test_stats ();
-  test_expired_cleanup ();
-  test_evict_expired_batch ();
-  test_maybe_evict_expired_triggers_when_ratio_high ();
-  test_maybe_evict_expired_throttled ();
-  test_distinct_keys_do_not_collide_after_sanitize ();
-  test_overwrite_existing_key_when_cache_is_full ();
-  test_get_migrates_legacy_entry_and_list_dedupes ();
-  print_endline "\n=== All 16 Cache_eio tests passed ===\n"
+  Alcotest.run "Cache_eio"
+    [
+      ( "basic",
+        [
+          Alcotest.test_case "set and get" `Quick test_set_and_get;
+          Alcotest.test_case "set with ttl" `Quick test_set_with_ttl;
+          Alcotest.test_case "set with tags" `Quick test_set_with_tags;
+          Alcotest.test_case "large value round-trips"
+            `Quick test_large_value_round_trips_without_truncation;
+          Alcotest.test_case "get nonexistent" `Quick test_get_nonexistent;
+          Alcotest.test_case "delete" `Quick test_delete;
+          Alcotest.test_case "list" `Quick test_list;
+          Alcotest.test_case "clear" `Quick test_clear;
+          Alcotest.test_case "stats" `Quick test_stats;
+        ] );
+      ( "expiration",
+        [
+          Alcotest.test_case "expired cleanup" `Quick test_expired_cleanup;
+          Alcotest.test_case "evict expired batch" `Quick
+            test_evict_expired_batch;
+          Alcotest.test_case "maybe_evict triggers when ratio high" `Quick
+            test_maybe_evict_expired_triggers_when_ratio_high;
+          Alcotest.test_case "maybe_evict throttled" `Quick
+            test_maybe_evict_expired_throttled;
+        ] );
+      ( "keys_and_eviction",
+        [
+          Alcotest.test_case "distinct keys don't collide after sanitize"
+            `Quick test_distinct_keys_do_not_collide_after_sanitize;
+          Alcotest.test_case "overwrite existing key when full" `Quick
+            test_overwrite_existing_key_when_cache_is_full;
+          Alcotest.test_case "get migrates legacy entry and list dedupes"
+            `Quick test_get_migrates_legacy_entry_and_list_dedupes;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Replaced the sequential \`let () = test_a (); test_b (); ...\` runner with \`Alcotest.run\`, organized into 3 groups:
- \`basic\` (9 tests)
- \`expiration\` (4 tests)
- \`keys_and_eviction\` (3 tests)

## Scope

**Minimal change by design**: the individual \`test_*\` function bodies are untouched — 350 lines of test logic unchanged. Only the top-level runner is swapped.

This works because the existing tests use \`assert\` / \`failwith\` which propagate as test failures through Alcotest. Benefits:
- Alcotest reporting (per-test pass/fail, timing)
- Filter/select tests via command-line args
- Structured exit codes on failure

## Test plan
- [x] \`dune exec ./test/test_cache_eio.exe\` — 16/16 tests pass locally
- [ ] CI green

Part of Axis E (test hygiene) — relates to Issue #6992 which tracks 8 more test files pending similar conversion.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>