### PR TITLE
refactor(test): convert test_tool_task_coverage to Alcotest.run (39 tests)

### DIFF
--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -4,8 +4,6 @@ open Masc_mcp
 
 let () = Random.self_init ()
 
-let () = Printf.printf "\n=== Tool_task Coverage Tests ===\n"
-
 let with_env name value_opt f =
   let original = Sys.getenv_opt name in
   let restore () =
@@ -30,16 +28,15 @@ let with_isolated_runtime_env f =
             with_env "SUPABASE_DB_URL" None (fun () ->
               with_env "SB_PG_URL" None f))))))
 
-(* Test helper *)
+(* Test registry — collect via [test] then dispatch with Alcotest.run.
+   Eio scope set up per-test inside the registered thunk. *)
+let test_cases : (string * (unit -> unit)) list ref = ref []
+
 let test name f =
-  try
-    Eio_main.run @@ (fun env ->
-      Fs_compat.set_fs (Eio.Stdenv.fs env);
-      with_isolated_runtime_env f);
-    Printf.printf "✓ %s passed\n" name
-  with e ->
-    Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
-    exit 1
+  test_cases := (name, fun () ->
+    Eio_main.run @@ fun env ->
+    Fs_compat.set_fs (Eio.Stdenv.fs env);
+    with_isolated_runtime_env f) :: !test_cases
 
 (* Create test context *)
 let test_counter = ref 0
@@ -702,4 +699,10 @@ let () = test "build_verdict_sse_payload: fallback_reason serialized" (fun () ->
   assert (payload_member "gate" json = `String "fallback")
 )
 
-let () = Printf.printf "\n✅ All Tool_task tests passed!\n"
+let () =
+  Alcotest.run "Tool_task"
+    [
+      ( "coverage",
+        List.rev !test_cases
+        |> List.map (fun (name, f) -> Alcotest.test_case name `Quick f) );
+    ]


### PR DESCRIPTION
Registry pattern as per #6996/#6997/#6998. Largest coverage file so far at 39 tests.

- [x] 39/39 pass locally
- [ ] CI

Relates to #6992.