### PR TITLE
fix(eio): serialize tool_metrics and auto_responder Hashtbl access

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -56,27 +56,41 @@ let activity_log ~mode ~from_agent ~mention ~status ~detail =
 
 (** Per-agent-type timestamp list for rate limiting.
     Key = agent_type, Value = recent response timestamps (newest first).
-    O(1) lookup per agent_type — no string prefix scanning. *)
+    O(1) lookup per agent_type — no string prefix scanning.
+
+    [should_throttle] does read-filter-write on [response_times].
+    [maybe_respond] is invoked from the broadcast path for every message
+    and can run concurrently for different mentions; without a mutex the
+    throttle counter silently loses updates.  [Stdlib.Mutex] because the
+    broadcast handler may cross a domain boundary. *)
 let response_times : (string, float list) Hashtbl.t = Hashtbl.create 8
+let response_times_mu = Stdlib.Mutex.create ()
 let chain_limit = 3
 let chain_window_sec = 60.0
 
+let with_throttle_lock f =
+  Stdlib.Mutex.lock response_times_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock response_times_mu)
+    f
+
 let should_throttle ~agent_type =
   let now = Time_compat.now () in
-  let recent =
-    (match Hashtbl.find_opt response_times agent_type with
-     | None -> []
-     | Some times -> List.filter (fun ts -> now -. ts < chain_window_sec) times)
-  in
-  if List.length recent >= chain_limit then (
-    debug_log (Printf.sprintf "THROTTLE: %s has %d responses in last %.0fs"
-      agent_type (List.length recent) chain_window_sec);
-    Hashtbl.replace response_times agent_type recent;
-    true
-  ) else (
-    Hashtbl.replace response_times agent_type (now :: recent);
-    false
-  )
+  with_throttle_lock (fun () ->
+    let recent =
+      (match Hashtbl.find_opt response_times agent_type with
+       | None -> []
+       | Some times -> List.filter (fun ts -> now -. ts < chain_window_sec) times)
+    in
+    if List.length recent >= chain_limit then (
+      debug_log (Printf.sprintf "THROTTLE: %s has %d responses in last %.0fs"
+        agent_type (List.length recent) chain_window_sec);
+      Hashtbl.replace response_times agent_type recent;
+      true
+    ) else (
+      Hashtbl.replace response_times agent_type (now :: recent);
+      false
+    ))
 
 (* --- Mention helpers (re-export) --- *)
 

--- a/lib/tool_metrics.ml
+++ b/lib/tool_metrics.ml
@@ -18,19 +18,32 @@ type accumulator = {
   mutable durations : float list;  (* newest first *)
 }
 
+(** [metrics] is updated from the tool_dispatch post-hook which runs on
+    whichever fiber executed the tool.  Concurrent tool calls would
+    otherwise race on the Hashtbl add and on the mutable accumulator
+    fields (successes/failures/durations).  Stdlib.Mutex because HTTP
+    stats endpoints may run on a different domain. *)
 let metrics : (string, accumulator) Hashtbl.t = Hashtbl.create 32
+let metrics_mu = Stdlib.Mutex.create ()
+
+let with_lock f =
+  Stdlib.Mutex.lock metrics_mu;
+  Fun.protect
+    ~finally:(fun () -> Stdlib.Mutex.unlock metrics_mu)
+    f
 
 let record (result : Tool_result.t) =
-  let acc = match Hashtbl.find_opt metrics result.tool_name with
-    | Some a -> a
-    | None ->
-      let a = { successes = 0; failures = 0; durations = [] } in
-      Hashtbl.replace metrics result.tool_name a;
-      a
-  in
-  if result.success then acc.successes <- acc.successes + 1
-  else acc.failures <- acc.failures + 1;
-  acc.durations <- result.duration_ms :: acc.durations
+  with_lock (fun () ->
+    let acc = match Hashtbl.find_opt metrics result.tool_name with
+      | Some a -> a
+      | None ->
+        let a = { successes = 0; failures = 0; durations = [] } in
+        Hashtbl.replace metrics result.tool_name a;
+        a
+    in
+    if result.success then acc.successes <- acc.successes + 1
+    else acc.failures <- acc.failures + 1;
+    acc.durations <- result.duration_ms :: acc.durations)
 
 let percentile sorted_arr p =
   let n = Array.length sorted_arr in
@@ -57,14 +70,18 @@ let compute_stats tool_name acc =
   }
 
 let stats_for tool_name =
-  match Hashtbl.find_opt metrics tool_name with
-  | Some acc -> Some (compute_stats tool_name acc)
-  | None -> None
+  with_lock (fun () ->
+    match Hashtbl.find_opt metrics tool_name with
+    | Some acc -> Some (compute_stats tool_name acc)
+    | None -> None)
 
 let all_stats () =
-  let all = Hashtbl.fold (fun name acc lst ->
-    compute_stats name acc :: lst
-  ) metrics [] in
+  let all =
+    with_lock (fun () ->
+      Hashtbl.fold (fun name acc lst ->
+        compute_stats name acc :: lst
+      ) metrics [])
+  in
   List.sort (fun a b -> Int.compare b.call_count a.call_count) all
 
 let to_json s =
@@ -82,7 +99,7 @@ let to_json s =
 let all_to_json () =
   `List (List.map to_json (all_stats ()))
 
-let clear () = Hashtbl.clear metrics
+let clear () = with_lock (fun () -> Hashtbl.clear metrics)
 
 let install () =
   Tool_dispatch.register_post_hook (fun result ->


### PR DESCRIPTION
## Problem

Two more global Hashtbls without a mutex, same class as #7003 / #7004:

### \`lib/tool_metrics.ml\`
\`metrics : (string, accumulator) Hashtbl.t\` mutated from the tool_dispatch post-hook which runs on whichever fiber executed the tool. Concurrent tool calls race on:
- \`Hashtbl.replace\` during first-time registration
- Mutable \`acc.successes\`/\`acc.failures\` int increments
- \`acc.durations <- new_list\` head prepend

### \`lib/auto_responder.ml\`
\`response_times\` mutated from \`should_throttle\`, called per incoming broadcast. Parallel mentions race on read-filter-replace — the throttle counter silently loses updates and can admit more than \`chain_limit\` responses.

## Fix

\`Stdlib.Mutex\` around every access. Stdlib over Eio.Mutex because HTTP stats endpoints / broadcast handlers may cross a domain boundary.

## Test plan
- [x] \`dune build --root .\` passes
- [ ] CI

Follow-up to #7003, #7004.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>