### PR TITLE
feat(dashboard): add episode filters, search, and JSONL cap

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1736,17 +1736,36 @@ export interface MemorySubsystemsResponse {
   }
   episodes: {
     total: number
+    filtered: number
     shown: number
+    limit: number
     items: MemorySubsystemsEpisode[]
+  }
+  filters: {
+    keepers: string[]
+    outcomes: string[]
   }
 }
 
+export interface MemorySubsystemsQuery {
+  limit?: number
+  keeper?: string
+  outcome?: string
+  q?: string
+  signal?: AbortSignal
+}
+
 export function fetchMemorySubsystems(
-  opts?: { limit?: number; signal?: AbortSignal },
+  opts?: MemorySubsystemsQuery,
 ): Promise<MemorySubsystemsResponse> {
-  const params = opts?.limit ? `?limit=${opts.limit}` : ''
+  const params = new URLSearchParams()
+  if (opts?.limit != null) params.set('limit', String(opts.limit))
+  if (opts?.keeper) params.set('keeper', opts.keeper)
+  if (opts?.outcome) params.set('outcome', opts.outcome)
+  if (opts?.q) params.set('q', opts.q)
+  const qs = params.toString()
   return get<MemorySubsystemsResponse>(
-    `/api/v1/dashboard/memory-subsystems${params}`,
+    `/api/v1/dashboard/memory-subsystems${qs ? `?${qs}` : ''}`,
     { signal: opts?.signal },
   )
 }

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -48,7 +48,7 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
   const outcomeIcon =
     ep.outcome === 'success' ? '●' : ep.outcome === 'partial' ? '◐' : '○'
   return html`
-    <div class="border border-zinc-800 rounded-lg p-3 mb-2">
+    <div class="border border-zinc-800 rounded-lg p-3 mb-2 hover:border-zinc-700 transition-colors">
       <div class="flex items-start justify-between gap-2 mb-1">
         <div class="flex items-center gap-2 min-w-0">
           <span class="${outcomeColor} text-xs">${outcomeIcon}</span>
@@ -56,11 +56,12 @@ function EpisodeCard({ ep }: { ep: MemorySubsystemsEpisode }) {
         </div>
         <span class="text-xs text-zinc-500 shrink-0">${formatTimeAgo(ep.timestamp * 1000)}</span>
       </div>
-      <div class="flex items-center gap-2 text-xs text-zinc-500 mb-1">
+      <div class="flex items-center gap-2 text-xs text-zinc-500 mb-1 flex-wrap">
         <span class="bg-zinc-800 px-1.5 py-0.5 rounded">${ep.event_type}</span>
         ${ep.participants.map(
           (p: string) => html`<span class="font-mono">${p}</span>`,
         )}
+        <span class="text-zinc-600 font-mono text-[10px]">${ep.id}</span>
       </div>
       ${
         ep.learnings.length > 0
@@ -99,9 +100,19 @@ export function MemorySubsystems() {
     data: MemorySubsystemsResponse | null
   }>({ loading: true, error: null, data: null })
 
+  const keeperFilter = useSignal<string>('')
+  const outcomeFilter = useSignal<string>('')
+  const searchQuery = useSignal<string>('')
+
   async function refresh(signal?: AbortSignal) {
     try {
-      const data = await fetchMemorySubsystems({ limit: 50, signal })
+      const data = await fetchMemorySubsystems({
+        limit: 100,
+        keeper: keeperFilter.value || undefined,
+        outcome: outcomeFilter.value || undefined,
+        q: searchQuery.value || undefined,
+        signal,
+      })
       state.value = { loading: false, error: null, data }
     } catch (err) {
       if (isAbortError(err)) return
@@ -121,7 +132,7 @@ export function MemorySubsystems() {
       ac.abort()
       cleanup()
     }
-  }, [])
+  }, [keeperFilter.value, outcomeFilter.value, searchQuery.value])
 
   const { loading, error, data } = state.value
   if (loading && !data) return html`<${LoadingState} label="기억 서브시스템 로드 중..." />`
@@ -132,6 +143,22 @@ export function MemorySubsystems() {
   const lastConsolidation = data?.hebbian?.last_consolidation ?? 0
   const episodes = data?.episodes?.items ?? []
   const totalEpisodes = data?.episodes?.total ?? 0
+  const filteredTotal = data?.episodes?.filtered ?? episodes.length
+  const knownKeepers = data?.filters?.keepers ?? []
+  const knownOutcomes = data?.filters?.outcomes ?? ['success', 'partial', 'failure']
+
+  const onSearchInput = (e: Event) => {
+    const v = (e.target as HTMLInputElement).value
+    searchQuery.value = v
+  }
+
+  const clearFilters = () => {
+    keeperFilter.value = ''
+    outcomeFilter.value = ''
+    searchQuery.value = ''
+  }
+
+  const hasFilter = Boolean(keeperFilter.value || outcomeFilter.value || searchQuery.value)
 
   return html`
     <div class="space-y-6">
@@ -180,14 +207,60 @@ export function MemorySubsystems() {
 
       <!-- Episodes -->
       <section>
-        <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
           <h3 class="text-base font-semibold text-zinc-200">에피소드 기록</h3>
-          <span class="text-xs text-zinc-500">${totalEpisodes}개 중 최근 ${episodes.length}개</span>
+          <span class="text-xs text-zinc-500">
+            총 ${totalEpisodes}개 · 필터 ${filteredTotal}개 · 표시 ${episodes.length}개
+          </span>
         </div>
+
+        <!-- Filter Bar -->
+        <div class="flex items-center gap-2 mb-3 flex-wrap">
+          <input
+            type="text"
+            placeholder="검색 (summary, learnings, event_type...)"
+            value=${searchQuery.value}
+            onInput=${onSearchInput}
+            class="flex-1 min-w-[200px] bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+          />
+          <select
+            value=${keeperFilter.value}
+            onChange=${(e: Event) => (keeperFilter.value = (e.target as HTMLSelectElement).value)}
+            class="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+          >
+            <option value="">모든 키퍼</option>
+            ${knownKeepers.map(
+              (k: string) => html`<option value=${k}>${k}</option>`,
+            )}
+          </select>
+          <select
+            value=${outcomeFilter.value}
+            onChange=${(e: Event) => (outcomeFilter.value = (e.target as HTMLSelectElement).value)}
+            class="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+          >
+            <option value="">모든 결과</option>
+            ${knownOutcomes.map(
+              (o: string) => html`<option value=${o}>${o}</option>`,
+            )}
+          </select>
+          ${
+            hasFilter
+              ? html`<button
+                  onClick=${clearFilters}
+                  class="text-xs text-zinc-400 hover:text-zinc-200 px-2 py-1 border border-zinc-700 rounded hover:border-zinc-500"
+                >
+                  필터 해제
+                </button>`
+              : null
+          }
+        </div>
+
         ${
           episodes.length === 0
             ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
-                에피소드 없음. keeper [STATE] 출력 시 자동 기록됩니다.
+                ${hasFilter
+                  ? '필터 조건에 맞는 에피소드가 없습니다.'
+                  : '에피소드 없음. keeper [STATE] 출력 시 자동 기록됩니다.'}
               </div>`
             : html`
                 <div class="space-y-1">

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -672,3 +672,35 @@ let load_recent_episodes_jsonl ~limit : episode list =
       | _ :: rest -> drop (n - 1) rest
     in
     drop (total - limit) all
+
+(** Cap episodes JSONL to at most [max_lines] by keeping the most recent ones.
+    Rewrites the file atomically only if over cap. Returns number of lines
+    dropped (0 when no rewrite was needed).
+
+    Triggered by [flush_episodes] to prevent unbounded growth. *)
+let episodes_jsonl_default_cap = 500
+
+let cap_episodes_jsonl ?(max_lines = episodes_jsonl_default_cap) () : int =
+  let path = episodes_jsonl_path () in
+  if not (Sys.file_exists path) then 0
+  else
+    let lines = Fs_compat.load_jsonl path in
+    let total = List.length lines in
+    if total <= max_lines then 0
+    else begin
+      let rec drop n = function
+        | [] -> []
+        | rest when n <= 0 -> rest
+        | _ :: rest -> drop (n - 1) rest
+      in
+      let keep = drop (total - max_lines) lines in
+      let tmp_path = path ^ ".tmp" in
+      let oc = open_out tmp_path in
+      List.iter (fun line ->
+        output_string oc (Yojson.Safe.to_string line);
+        output_char oc '\n'
+      ) keep;
+      close_out oc;
+      Sys.rename tmp_path path;
+      total - max_lines
+    end

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -473,18 +473,30 @@ let flush_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int =
   let persisted_ids = persisted_episode_ids () in
   let path = Institution_eio.episodes_jsonl_path () in
   Fs_compat.mkdir_p (Filename.dirname path);
-  Agent_sdk.Memory.recall_episodes memory ~limit:max_int ()
-  |> List.fold_left
-       (fun flushed (episode : Agent_sdk.Memory.episode) ->
-         if Hashtbl.mem persisted_ids episode.id then flushed
-         else (
-           let persisted = institution_episode_of_oas ~agent_name episode in
-           Hashtbl.replace persisted_ids episode.id ();
-           Fs_compat.append_jsonl path
-             (Institution_eio.episode_to_json persisted);
-           note_episode_flush persisted;
-           flushed + 1))
-       0
+  let flushed =
+    Agent_sdk.Memory.recall_episodes memory ~limit:max_int ()
+    |> List.fold_left
+         (fun flushed (episode : Agent_sdk.Memory.episode) ->
+           if Hashtbl.mem persisted_ids episode.id then flushed
+           else (
+             let persisted = institution_episode_of_oas ~agent_name episode in
+             Hashtbl.replace persisted_ids episode.id ();
+             Fs_compat.append_jsonl path
+               (Institution_eio.episode_to_json persisted);
+             note_episode_flush persisted;
+             flushed + 1))
+         0
+  in
+  (* Cap file growth. Called after append so we only rewrite when needed. *)
+  if flushed > 0 then begin
+    try
+      let dropped = Institution_eio.cap_episodes_jsonl () in
+      if dropped > 0 then
+        Log.Institution.info "capped institution_episodes.jsonl: dropped %d old entries" dropped
+    with exn ->
+      Log.Institution.warn "episode cap failed: %s" (Printexc.to_string exn)
+  end;
+  flushed
 
 (* ================================================================ *)
 (* Procedural tier: Procedural_memory <-> OAS procedures            *)

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -71,11 +71,22 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
 let dashboard_memory_subsystems_http_json ~(config : Room_utils.config) request
     : Yojson.Safe.t =
   let limit =
-    int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200
+    int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:500
   in
-  let episodes =
-    try Institution_eio.load_recent_episodes_jsonl ~limit
-    with _ -> []
+  let keeper_filter =
+    query_param request "keeper"
+    |> Option.map String.trim
+    |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
+  in
+  let outcome_filter =
+    query_param request "outcome"
+    |> Option.map String.trim
+    |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
+  in
+  let search =
+    query_param request "q"
+    |> Option.map (fun s -> String.trim s |> String.lowercase_ascii)
+    |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
   in
   let hebbian =
     try
@@ -83,12 +94,66 @@ let dashboard_memory_subsystems_http_json ~(config : Room_utils.config) request
       Hebbian_eio.graph_to_json g
     with _ -> `Assoc [ ("synapses", `List []); ("last_consolidation", `Float 0.0) ]
   in
-  let episode_count =
-    try
-      let path = Institution_eio.episodes_jsonl_path () in
-      let jsons = Fs_compat.load_jsonl path in
-      List.length jsons
-    with _ -> 0
+  let all_episodes =
+    try Institution_eio.load_recent_episodes_jsonl ~limit:max_int
+    with _ -> []
+  in
+  let total = List.length all_episodes in
+  let contains_ci haystack needle =
+    let h = String.lowercase_ascii haystack in
+    let hlen = String.length h in
+    let nlen = String.length needle in
+    if nlen = 0 then true
+    else if nlen > hlen then false
+    else
+      let rec scan i =
+        if i + nlen > hlen then false
+        else if String.sub h i nlen = needle then true
+        else scan (i + 1)
+      in
+      scan 0
+  in
+  let filtered =
+    all_episodes
+    |> List.filter (fun (e : Institution_eio.episode) ->
+           let keeper_ok =
+             match keeper_filter with
+             | None -> true
+             | Some k -> List.mem k e.participants
+           in
+           let outcome_ok =
+             match outcome_filter with
+             | None -> true
+             | Some "success" -> e.outcome = `Success
+             | Some "failure" -> e.outcome = `Failure
+             | Some "partial" -> e.outcome = `Partial
+             | Some _ -> true
+           in
+           let search_ok =
+             match search with
+             | None -> true
+             | Some q ->
+               contains_ci e.summary q
+               || contains_ci e.event_type q
+               || List.exists (fun l -> contains_ci l q) e.learnings
+               || List.exists (fun p -> contains_ci p q) e.participants
+           in
+           keeper_ok && outcome_ok && search_ok)
+  in
+  let filtered_total = List.length filtered in
+  let episodes =
+    let rec drop n = function
+      | [] -> []
+      | rest when n <= 0 -> rest
+      | _ :: rest -> drop (n - 1) rest
+    in
+    if filtered_total <= limit then filtered
+    else drop (filtered_total - limit) filtered
+  in
+  let known_keepers =
+    all_episodes
+    |> List.concat_map (fun (e : Institution_eio.episode) -> e.participants)
+    |> List.sort_uniq String.compare
   in
   `Assoc
     [
@@ -97,11 +162,20 @@ let dashboard_memory_subsystems_http_json ~(config : Room_utils.config) request
       ( "episodes",
         `Assoc
           [
-            ("total", `Int episode_count);
+            ("total", `Int total);
+            ("filtered", `Int filtered_total);
             ("shown", `Int (List.length episodes));
+            ("limit", `Int limit);
             ( "items",
               `List
                 (List.map Institution_eio.episode_to_json episodes) );
+          ] );
+      ( "filters",
+        `Assoc
+          [
+            ( "keepers",
+              `List (List.map (fun k -> `String k) known_keepers) );
+            ("outcomes", `List [ `String "success"; `String "partial"; `String "failure" ]);
           ] );
     ]
 


### PR DESCRIPTION
## Summary

PR #6973 (memory subsystems panel) 후속. 3가지 production 우려사항 해결:

1. **파일 크기 보호** — `institution_episodes.jsonl`이 무한 성장하지 않도록 cap
2. **필터** — keeper/outcome으로 서버 레벨 필터링
3. **검색** — summary/learnings/event_type/participants에 대한 case-insensitive 검색

## Changes

| File | Change |
|------|--------|
| `lib/institution_eio.ml` | `cap_episodes_jsonl ?max_lines` (default 500), atomic rewrite |
| `lib/memory_oas_bridge.ml` | `flush_episodes`가 append 후 cap 호출 |
| `lib/server/server_dashboard_http.ml` | `keeper`/`outcome`/`q` query params + filters.keepers 응답 |
| `dashboard/src/api/dashboard.ts` | `MemorySubsystemsQuery` 타입 + params 전송 |
| `dashboard/src/components/memory-subsystems.ts` | 검색 input + keeper/outcome select + "필터 해제" |

## 파일 성장 방지

| 시나리오 | 동작 |
|----------|------|
| `flushed = 0` (new episodes 없음) | cap no-op |
| `total ≤ 500` | cap no-op |
| `total > 500` | atomic rewrite: 오래된 것 drop, 최신 500개 유지 |

Atomic rename via temp file + `Sys.rename`으로 중간 실패에도 파일 일관성 보장.

## UI 상태

- 카운트 3단계: 총 N개 · 필터 M개 · 표시 K개
- Empty state 구분: 필터 적용 중이면 "필터 조건에 맞는 에피소드 없음", 아니면 "keeper [STATE] 출력 시 자동 기록"
- 필터 변경 시 즉시 refetch (useEffect deps)

## Test plan

- [x] `dune build` clean
- [x] `tsc --noEmit` clean
- [x] `vite build` success
- [x] `test_memory_oas_5tier` 18/18 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)