### PR TITLE
refactor(dashboard): clarify IA labels and resolve user-reported overlaps

### DIFF
--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -47,3 +47,24 @@ describe('command navigation', () => {
     ])
   })
 })
+
+describe('monitoring navigation labels', () => {
+  it('uses Korean label for 도구 이벤트 and keeps Prometheus naming', () => {
+    const sections = visibleSectionItemsForTab('monitoring')
+    const labelFor = (id: string) => sections.find(item => item.id === id)?.label
+
+    expect(labelFor('governance')).toBe('도구 이벤트')
+    expect(labelFor('metrics')).toBe('Prometheus')
+    expect(labelFor('sessions')).toBe('세션')
+  })
+})
+
+describe('workspace navigation labels', () => {
+  it('renames planning to 작업 큐 and keeps 목표 트리', () => {
+    const sections = visibleSectionItemsForTab('workspace')
+    const labelFor = (id: string) => sections.find(item => item.id === id)?.label
+
+    expect(labelFor('planning')).toBe('작업 큐')
+    expect(labelFor('goals')).toBe('목표 트리')
+  })
+})

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -119,7 +119,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'sessions',
       label: '세션',
-      description: '실시간 세션 상태, 블로커, 내부 신호, 주의 큐를 한 화면에서 봅니다.',
+      description: '읽기 전용 관찰: 세션 상태, 블로커, 주의 큐. 개입은 운영 › 실시간 개입에서.',
       params: { section: 'sessions' },
     },
     {
@@ -148,8 +148,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'governance',
-      label: 'tool 이벤트',
-      description: 'tool rejection 집계 + approval queue depth/latency.',
+      label: '도구 이벤트',
+      description: '읽기 전용: 도구 거부 집계, 승인 큐 깊이/지연. 승인 액션은 운영 › 거버넌스에서.',
       params: { section: 'governance' },
     },
     {
@@ -161,7 +161,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'metrics',
       label: 'Prometheus',
-      description: 'counter, gauge, summary 원시 메트릭 (/metrics endpoint).',
+      description: '저수준 raw 지표(/metrics): counter·gauge·summary. 디버깅과 알림 소스용.',
       params: { section: 'metrics' },
     },
   ],
@@ -169,13 +169,13 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'intervene',
       label: '실시간 개입',
-      description: '네임스페이스 브로드캐스트, 키퍼 개별 메시지 발송 등 운영 메시지 개입.',
+      description: '쓰기 액션: 네임스페이스 브로드캐스트, 키퍼에게 직접 메시지 발송. 세션 읽기는 모니터링 › 세션에서.',
       params: { section: 'intervene' },
     },
     {
       id: 'governance',
       label: '거버넌스',
-      description: '에이전트 자율 결정의 검토/승인 기록. 위험 행동 방지 레이어.',
+      description: '쓰기 액션: 자율 결정 검토·승인·반려. 추이 관찰은 모니터링 › 도구 이벤트에서.',
       params: { section: 'governance' },
     },
     {
@@ -194,14 +194,14 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'planning',
-      label: '계획 및 메트릭',
-      description: '태스크 kanban과 backlog 관리. 목표 계층은 별도 탭에서 봅니다.',
+      label: '작업 큐',
+      description: '실행 단위의 칸반과 백로그. 상위 의도 구조는 목표 트리에서.',
       params: { section: 'planning' },
     },
     {
       id: 'goals',
       label: '목표 트리',
-      description: '목표의 부모-자식 계층 구조와 수렴도. 태스크 연결, 에이전트 배정 상태 시각화.',
+      description: '의도의 부모-자식 계층과 수렴도. 실행 단위 태스크는 작업 큐에서.',
       params: { section: 'goals' },
     },
   ],

--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -236,7 +236,7 @@ let all_entries =
     };
     {
       id = "workspace.planning";
-      label = "계획 및 메트릭";
+      label = "작업 큐";
       exposure_status = "main";
       hidden_from_nav = false;
       meets_main_gate = true;


### PR DESCRIPTION
## 배경

사용자가 대시보드 관찰 중 네 가지 중복 의심과 Prometheus 역할 불명을 제기.

1. 세션 ↔ 실시간 개입 — 같아 보임
2. 런타임 ↔ Tool 이벤트 — 비슷해 보임
3. 계획·메트릭 ↔ 목표 트리 — 같은 말처럼 읽힘
4. Prometheus — 뭘 보여주는지 불명
5. "tool 이벤트" 라벨이 한/영 혼용

## 조사 결과 (증거 기반)

| 의심 쌍 | 판정 | 근거 |
|--------|------|------|
| 세션 ↔ 실시간 개입 | **별개** | `missionSnapshot` (read) vs `Ops.broadcast` (write) |
| 런타임 ↔ 도구 이벤트 | **부분 중복** | 양쪽 다 observation. 단, Prometheus와 데이터 소스 다름 |
| 계획·메트릭 ↔ 목표 트리 | **별개** | kanban(execution) vs hierarchy(intent). 라벨만 헷갈림 |
| Prometheus ↔ 기타 관찰 | **독립** | `/metrics` raw vs `/api/dashboard` 가공 |
| 거버넌스 이중 배치 | **실제 중복** (향후 PR 후속) | 이번에는 라벨·성격으로 분리, 코드 통폐합은 별도 PR |

결론: 4쌍 중 대부분은 **데이터 중복이 아니라 라벨·IA 혼동**. 섣부른 통폐합은 HITL(쓰기) ↔ 관찰(읽기) 경계를 무너뜨릴 위험. 이번 PR은 **라벨·설명 명확화**에 집중.

## 변경 (파일 3개, +31/-10)

`dashboard/src/config/navigation.ts`
- `monitoring.sessions` → description에 '읽기 전용', 운영 › 실시간 개입 교차링크
- `monitoring.governance` 라벨: `tool 이벤트` → `도구 이벤트` (영한혼용 해소)
  + description에 '읽기 전용, 승인은 운영 › 거버넌스' 명시
- `monitoring.metrics` (Prometheus) → description을 '저수준 raw 메트릭, 디버깅·알림 소스' 로 명확화
- `command.intervene` → description에 '쓰기 액션' 명시, 세션 읽기 교차링크
- `command.governance` → description에 '쓰기 액션' 명시, 도구 이벤트 추이 교차링크
- `workspace.planning` 라벨: `계획 및 메트릭` → `작업 큐`
- `workspace.goals` → description을 '의도 vs 실행' 경계로 재서술

`dashboard/src/config/navigation.test.ts`
- monitoring/workspace 라벨 계약 테스트 추가 (기존 lab/command만 커버됨)

`lib/dashboard/dashboard_surface_readiness.ml`
- `workspace.planning.label`을 `작업 큐`로 동기화

## 섹션 ID 변경 없음

라우트 `#monitoring?section=governance`, `#workspace?section=planning` 등은 그대로 유지. **북마크·외부 링크 안전**.

## 후속 PR

- B안: 모니터링 4섹션(세션/런타임/텔레메트리/Prometheus) Observatory 통합 레이아웃
- C안: Control Deck (키퍼/세션 단위 관찰+액션 단일 탭)
- 거버넌스 이중 배치(`monitoring.governance` vs `command.governance`)의 코드 레벨 분리 또는 단일화

## 테스트

- `pnpm test` (dashboard): **493 passed / 493** (추가 2 테스트 포함)
- `pnpm typecheck`: 에러 없음
- OCaml 테스트는 `workspace.planning` id만 검사 — 라벨 변경 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)