### PR TITLE
ci: add gate aggregator + finalize 0.6.0 release docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -569,3 +569,42 @@ jobs:
 
       - name: Run TLA+ model checking
         run: make -C specs check-all
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [pr-sync-check, changes, build, lint, dashboard, health, tla-specs]
+    if: ${{ !cancelled() }}
+    timeout-minutes: 2
+
+    steps:
+      - name: Aggregate required check status
+        env:
+          PR_SYNC_RESULT: ${{ needs.pr-sync-check.result }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          DASHBOARD_RESULT: ${{ needs.dashboard.result }}
+          HEALTH_RESULT: ${{ needs.health.result }}
+          TLA_RESULT: ${{ needs.tla-specs.result }}
+        run: |
+          set -euo pipefail
+          fail=0
+          check() {
+            local name=$1
+            local result=$2
+            if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+              printf 'PASS  %-20s %s\n' "$name" "$result"
+            else
+              printf 'FAIL  %-20s %s\n' "$name" "$result"
+              fail=1
+            fi
+          }
+          check "pr-sync-check" "$PR_SYNC_RESULT"
+          check "changes"       "$CHANGES_RESULT"
+          check "build"         "$BUILD_RESULT"
+          check "lint"          "$LINT_RESULT"
+          check "dashboard"     "$DASHBOARD_RESULT"
+          check "health"        "$HEALTH_RESULT"
+          check "tla-specs"     "$TLA_RESULT"
+          [ "$fail" -eq 0 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-14
+
+### Added
+- Dashboard OAS telemetry surface (#6978).
+- `oas_sse_bridge` usage relay wiring (#6938).
+
+### Changed
+- Concurrency and observability fixes carried over from the 0.5.x line.
+
+### Notes
+- Version bumped in `dune-project` and `masc_mcp.opam` by #7009. This
+  entry finalizes the release docs that were omitted in that bump, so
+  `scripts/check-version-truth.sh` stops failing on every main-base PR.
+
 ## [0.5.11] - 2026-04-13
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # masc-mcp Roadmap
 
-> Current package version: v0.5.11
-> Latest release: v0.5.11 (2026-04-13)
-> Updated: 2026-04-13
+> Current package version: v0.6.0
+> Latest release: v0.6.0 (2026-04-14)
+> Updated: 2026-04-14
 
 This roadmap is the 6-8 week operating view for `masc-mcp`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,8 +1,8 @@
 # Product Operating Plan
 
-> Current package version: v0.5.11
-> Latest release: v0.5.11 (2026-04-13)
-> Updated: 2026-04-13
+> Current package version: v0.6.0
+> Latest release: v0.6.0 (2026-04-14)
+> Updated: 2026-04-14
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only coordination hardening:

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -3,7 +3,7 @@
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-04-13
-> Snapshot baseline: `dune-project` version `0.5.11`
+> Snapshot baseline: `dune-project` version `0.6.0`
 
 MASC (Multi-Agent Streaming Coordination)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Claude, Gemini, Codex, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Room 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, Command Plane 오케스트레이션을 제공하며, MCP JSON-RPC 프로토콜을 통해 모든 주요 AI IDE/CLI와 통합된다.
 


### PR DESCRIPTION
## 문제

1. branch protection이 `['TLA+ Model Checking', 'Build and Test', 'Lint', 'Health']` 4개를 required_contexts로 강제. 모두 path-filter로 조건부 실행이라 narrow-scope PR에서 **skipping** → `enforce_admins=True` 환경에서 영구 BLOCKED.
2. #7009가 dune-project+opam을 0.6.0으로 올렸지만 ROADMAP/CHANGELOG는 v0.5.11 그대로. 이 드리프트 때문에 `scripts/check-version-truth.sh`가 Health job 초반에 fail → ci-gate PR 자신도 green이 안 됨 → 악순환.

실측 피해: #7006, #7014 둘 다 BLOCKED. #7014 Health job이 `dune-project (0.6.0) != ROADMAP current package version (0.5.11)`로 fail.

## 변경

**커밋 1 — `ci: add ci-gate aggregator`** (`.github/workflows/ci.yml`, +39)
- `ci-gate` job 추가. `needs: [pr-sync-check, changes, build, lint, dashboard, health, tla-specs]`, `if: always()`.
- 각 upstream result가 `success` 또는 `skipped` = PASS, 그 외 = FAIL.
- 기존 per-scope required check는 그대로 남아 실제 실패 표면화 계속. aggregator는 required-gate 역할만 단일화.

**커밋 2 — `docs(release): finalize 0.6.0 entry`** (ROADMAP.md + CHANGELOG.md, +17/-3)
- ROADMAP 헤더: v0.5.11 → v0.6.0 (current + latest), 2026-04-14.
- CHANGELOG: `## [0.6.0] - 2026-04-14` 헤딩 추가. 내용은 #7009 PR body에서 그대로 가져옴 (#6978 dashboard OAS telemetry, #6938 oas_sse_bridge usage relay, 그리고 concurrency/observability carry-over).

## 왜 같은 PR?

별도로 쪼개면 어느 쪽이든 혼자서는 CI green이 안 됨.
- ci-gate만 있는 PR: `ci_core=true`로 Health가 실제 실행되는데 ROADMAP 드리프트로 여전히 fail.
- ROADMAP finalize만 있는 PR: Health는 pass하지만 Build/Lint/TLA가 skipping → BLOCKED.
동일 PR에 묶어서 한 번에 Health + 나머지 required 전부 success 또는 skipped 상태로 만들어야 aggregator가 pass하고 이 PR 자신이 머지 가능.

## 후속 (수동)

머지 직후 branch protection required_contexts를 `['CI Gate']`로 교체:

\`\`\`bash
gh api -X PUT /repos/jeong-sik/masc-mcp/branches/main/protection \\
  --input <(gh api /repos/jeong-sik/masc-mcp/branches/main/protection | \\
    jq '.required_status_checks.contexts = ["CI Gate"] | {required_status_checks, enforce_admins: .enforce_admins.enabled, required_pull_request_reviews, restrictions}')
\`\`\`

그 다음 #7014, #7006 ready + merge.

## 검증

로컬에서:
\`\`\`
$ bash scripts/check-version-truth.sh
Version truth OK: package=0.6.0 latest_release=0.6.0
\`\`\`

YAML 파싱 정상 (ci-gate job 12번째로 등록됨, needs 7개).

🤖 Generated with [Claude Code](https://claude.com/claude-code)