### PR TITLE
docs: RFC-0003 Keeper Composite Lifecycle + TLA+ spec + dashboard redesign

### DIFF
--- a/docs/design/dashboard-fsm-redesign.md
+++ b/docs/design/dashboard-fsm-redesign.md
@@ -1,0 +1,197 @@
+# Dashboard FSM Visibility Redesign
+
+**Status**: Design (기획 단계)
+**Date**: 2026-04-14
+**Scope**: `masc-mcp` 대시보드의 FSM/TLA 정보 아키텍처 재구성 + 데이터 파이프라인 dynamic화
+**One sentence**: Keeper detail 한 페이지에 갇혀 있고 Cascade/Decision 그래프가 하드코딩된 현 대시보드를, RFC-0003 composite observer를 소스로 삼는 4-페이지 체계로 재구성한다.
+
+## Related Documents
+
+- `docs/rfc/RFC-0003-keeper-composite-lifecycle.md` — 본 plan의 데이터 계약(composite observer + payload shape)
+- `docs/rfc/RFC-0002-keeper-state-machine.md` — 11-state parent phase FSM
+- `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` — 5 joint invariants + 3 bug models
+- `docs/tla-audit/state-fsm-gap-2026-04-13.md` — Bug #1, P1~P5 제안
+- `docs/design/keeper-detail-source-ownership.md` — Keeper detail 페이지 소유 경계
+
+## 1. 현 상태 분석
+
+### 가시성
+
+| 페이지 | FSM 위젯 | 출처 |
+|--------|----------|------|
+| `dashboard/src/components/keeper-detail.ts:509` | parent phase diagram + Decision FSM + Cascade FSM | `keeper-state-diagram.ts` |
+| `dashboard/src/components/agent-detail.ts` | **없음** | — |
+| Overview / home | **없음** | — |
+| 통합 감사 뷰 | **없음** (존재하지 않음) | — |
+
+### Cascade 하드코딩
+
+`lib/keeper/keeper_decision_audit.ml:256-315` `cascade_fsm_to_mermaid`는 state name, edge label, fallback 조건을 문자열 리터럴로 고정 출력한다. 결과적으로:
+
+- `local_recovery` 와 `keeper_unified` profile이 **같은 그림**으로 표시된다.
+- provider health (healthy/unhealthy/slot_full)는 렌더에 반영되지 않는다.
+- `last_provider_result`가 success든 timeout이든 edge 색이 동일하다.
+
+동시에 model 목록은 `lib/server/server_routes_http_routes_dashboard.ml:618-633`에서 `Oas_worker_named.default_model_strings`로부터 동적으로 읽는다. 즉 **데이터는 흐르는데 렌더가 그것을 쓰지 않는다.**
+
+### Decision FSM 부분 동적
+
+`keeper_decision_audit.mli:55-73` `decision_pipeline_to_mermaid`는 `phase`, `thompson_alpha`, `thompson_beta`만 bind한다. `KeeperDecisionPipeline.tla` state variable 중 `tool_count`, `guard_penalties_this_cycle`, `turn_outcome`은 surfaces에 없다.
+
+### Memory/Compaction 부재
+
+`keeper_memory_policy.ml:447-451` `kind_caps`(`constraints:2, decision:2, next:2, goal:2, progress:2, open_question:2, long_term:4`)와 `keeper_memory_bank.ml`의 compaction snapshot, `tool_compact.ml:24-26` strategy enum은 **어떤 대시보드 페이지에도 표시되지 않는다.**
+
+## 2. 정보 아키텍처 (후속 구현의 기준)
+
+| 페이지 | FSM surface | 근거 | 신규 여부 |
+|--------|------------|------|-----------|
+| `/overview` (기존) | fleet-wide phase histogram + compaction/handoff 카운터 + composite invariants 전체 통과율 | 매크로 상태 한눈 | 확장 |
+| `/keepers/:name` (기존) | parent phase diagram + Decision FSM + Cascade FSM + Memory tier panel + Compaction sub-FSM | 운영자 콘솔 심화 | 확장 |
+| `/agents/:id` (기존) | **mini phase-strip**만 (해당 agent에 연결된 keeper로 링크) | MASC agent ≠ OAS keeper 경계 존중 | 최소 추가 |
+| `/fsm` (신규) | Keeper picker + composite Cytoscape compound graph + 5 invariants panel + event log (composite.tick SSE 구독) | 아키텍처 감사/엔지니어링용 | **신규** |
+
+### 왜 `/fsm`을 분리하는가
+
+`/keepers/:name`은 특정 keeper의 **운영**을 위한 페이지다. 운영자는 pause/resume, logs, last turn을 본다. 이 페이지에 composite FSM 다이어그램을 끼워넣으면 스크롤이 길어지고 맥락이 섞인다. 반면 `/fsm`은 "이 시스템의 상태 머신들이 spec과 일치하는가"를 감사하는 페이지다. 유입 경로와 대상 사용자가 다르다.
+
+### 왜 `/agents/:id`는 mini strip만
+
+MASC `agent`와 OAS `keeper`는 다른 개념이다 (`docs/design/oas-masc-state-boundary.md`). agent detail에 keeper composite FSM 전체를 복제하면 layer boundary를 흐린다. 대신 "이 agent가 연결된 keeper의 현재 parent phase"만 작은 strip으로 보이고 클릭 시 `/keepers/:name`으로 이동.
+
+## 3. Cascade 하드코딩 제거 경로
+
+### 수정 대상
+
+| 파일 | 라인 | 변경 |
+|------|------|------|
+| `lib/keeper/keeper_decision_audit.ml` | 256-315 | `cascade_fsm_to_mermaid` state set을 `CascadeLiveness.tla`의 `{idle, selecting, trying, done, exhausted}` subset으로 제한. 렌더 시점에 받은 실제 profile name, provider health list, last_provider_result로 label/색 bind |
+| `lib/keeper/keeper_decision_audit.mli` | 55-73 | 시그니처 확장 (optional labelled args): `?provider_health:(string * [`Healthy|`Unhealthy|`SlotFull|`Unknown]) list`, `?slot_state:int * int`, `?effective_cascade_reason:string` |
+| `lib/server/server_routes_http_routes_dashboard.ml` | 618-633 | 기존 `Oas_worker_named.default_model_strings` 호출 유지, `Keeper_cascade_routing.select_cascade` 결과와 `Keeper_exec_status_metrics.last_model_used`를 함께 넘긴다 |
+| `lib/dashboard/dashboard_http_keeper.ml` | 147-148 | 이미 phase-aware cascade 리졸브 로직 보유 — `effective_cascade_reason` 노출 경로만 추가 |
+
+### 재사용할 기존 함수 (새 추상화 금지)
+
+- `Keeper_cascade_routing.select_cascade` — phase→cascade 매핑 (`lib/keeper/keeper_cascade_routing.mli`)
+- `Oas_model_resolve.models_of_cascade_name` — cascade 이름 → provider list
+- `Provider_adapter.is_local_provider` — provider 분류
+- `Keeper_exec_status_metrics.last_model_used` — 마지막 사용 provider
+- `Local_runtime_pool` slot telemetry — slot full 판정
+
+MASC 레벨에 새 provider/model 이름이 등장하지 않도록 주의. 값은 OAS가 내려 보낸 opaque 문자열로 대시보드에 전달한다 (`feedback_masc-model-agnostic.md`).
+
+### 출력 불변성
+
+`cascade_fsm_to_mermaid`가 생성하는 state id는 반드시 `CascadeLiveness.tla`의 state 집합 subset. CI에 파일 파싱 단계를 추가해 임의 문자열 유입을 차단한다. Property-based test는 Phase 2의 TLC 통과 여부와 함께 실행한다.
+
+## 4. Decision FSM Dynamic 확장
+
+| 현재 bind | 확장 bind | 출처 |
+|-----------|----------|------|
+| `phase`, `thompson_alpha`, `thompson_beta` | `+ guard_penalty_this_cycle`, `tool_policy_mode`, `turn_outcome` | `KeeperDecisionPipeline.tla` state variables |
+
+`keeper_decision_audit.mli:58-64` 시그니처에 optional labelled args 세 개 추가 (`?guard_penalty_this_cycle:int`, `?tool_policy_mode:[\`Preset of string | \`Custom]`, `?turn_outcome:[\`Ok | \`Failed | \`Blocked]`). default는 `None`이고, None이면 "n/a"로 렌더. 이 방식은 caller가 점진 채택 가능하므로 후방 호환성을 깨지 않는다.
+
+Mermaid `note right of Running` 블록에 세 필드를 한 줄씩 추가한다. Thompson alpha/beta와 나란히.
+
+## 5. Memory Tier Panel + Compaction Sub-FSM
+
+### 신규 컴포넌트
+
+`dashboard/src/components/keeper-memory-tier-panel.ts` 신규. `kind_caps` 7종(`constraints:2, decision:2, next:2, goal:2, progress:2, open_question:2, long_term:4`)을 7개의 vertical bar로 시각화. 각 bar는 `(used/cap)`, `importance_weight`(keeper_memory_policy.ml:401-403)를 tooltip으로 보여준다.
+
+### 백엔드 필드
+
+`/state-diagram` 응답(`server_dashboard_http_keeper_api.ml`)에 다음 필드 추가:
+
+```json
+"memory_kind_usage": [
+  { "kind": "constraints", "used": 1, "cap": 2 },
+  { "kind": "decision",    "used": 2, "cap": 2 },
+  { "kind": "progress",    "used": 0, "cap": 2 }
+  // ...
+]
+```
+
+소스: `Keeper_memory_bank` snapshot에서 kind별 count. 기존 `memory_kind_caps_for_compaction` 헬퍼 재사용.
+
+### Compaction sub-FSM
+
+- 렌더 조건: parent `phase=Compacting`일 때만.
+- State set: `MemoryCompaction.tla`의 `{accumulating, compacting, done}`.
+- Bind: `Keeper_registry.get_conditions`에서 `compaction_active`, `last_compaction_strategy` 읽기.
+- Strategy 이력: `tool_compact.ml:24-26`의 `{prune_tool_outputs | merge_contiguous | drop_low_importance | summarize_old | all}` 중 최근 N개를 기존 `keeper_decision_audit` ring buffer에 **compaction record variant로 얹음** (신규 ring buffer 추가 금지, `feedback_no-derived-tag-when-existing-identifier-suffices.md`).
+
+## 6. API / Cache / Live Updates
+
+### 신규 SSE endpoint
+
+`lib/server/server_routes_http_keeper_stream.ml`에 `/api/v1/keepers/:name/state-diagram/stream` 추가. 기존 SSE 인프라 재사용.
+
+### Cache 재정의
+
+`lib/server/server_dashboard_http_cache.ml`의 기존 캐시는 cold load용으로만 두고, **값의 권위는 SSE 스트림의 last_emitted로 옮긴다**. 단일 writer는 `Keeper_event_bus` 핸들러. 이중 source-of-truth가 생기지 않는다.
+
+### Composite endpoint
+
+`/api/keepers/:name/composite` 신규. payload shape는 RFC-0003 §7에 정의. OAS event_bus envelope(`{correlation_id, run_id, ts}`, OAS PR#845)를 필수 필드로 포함. SSE 토픽: `keeper.composite.tick`.
+
+## 7. Phase 분할 (독립 PR)
+
+| Phase | 산출물 | 의존 | 독립 PR 단위 |
+|-------|--------|------|------------|
+| **1a** | Cascade 하드코딩 제거 + 시그니처 확장 + `cascade_fsm_to_mermaid` state set 제한 | — | 1 PR |
+| **1b** | Decision FSM dynamic 필드 확장 | — | 1 PR |
+| **1c** | `/agents/:id` mini phase-strip (기존 `keeper-phase-strip.ts` 재사용) | — | 1 PR |
+| **2** | Memory tier panel + Compaction sub-FSM + `memory_kind_usage` 필드 | — | 1 PR |
+| **3** | `/fsm` hub 페이지 (composite Cytoscape + invariants panel + event log) | RFC-0003 OCaml observer 구현 선행 | 1 PR |
+| **4** | SSE stream endpoint + EventSource client + cache 강등 | Phase 3 shape 안정화 | 1 PR |
+
+Phase 1a/1b/1c는 서로 직교하므로 **병렬 가능**. Phase 2는 1과 독립. Phase 3은 RFC-0003 observer 모듈(Phase 3 별도 구현 PR)이 머지된 이후.
+
+## 8. 검증 전략
+
+### 단위
+
+- OCaml alcotest: 각 신규/수정된 mermaid builder에 대해 golden output per phase. phase 개수 × cascade profile 개수 조합.
+- Frontend: composite panel 렌더링은 Tailwind-only (`feedback_tailwind-only-dashboard.md`), snapshot test로 DOM 구조 고정.
+
+### 속성 (Property-based)
+
+- 생성된 mermaid state id ⊆ 해당 TLA+ spec의 state 집합. spec 파일을 파싱해 state literal 추출 후 intersection 체크.
+- `memory_kind_usage` 응답의 kind 집합 ⊆ `keeper_memory_policy.ml` `kind_caps` 키 집합.
+
+### E2E (Playwright)
+
+- 시나리오 A — Failing 전이: `masc_keeper_reset`으로 Failing 강제 → cascade 그래프에 `local_recovery` 노출 확인, provider health bar 변경 확인.
+- 시나리오 B — Compaction: context ratio로 compaction 트리거 → sub-FSM `compacting` 렌더 확인 → `done` 전이 후 parent phase `Running` 복귀 확인.
+- 시나리오 C — Invariants violation: 테스트 전용 hook으로 `reconcile_data=false` + `reconcile_fsm=true`를 주입 → `/fsm` 페이지의 `recovery_two_store_sync` invariant가 빨간색으로 표시되는지 확인.
+
+### CI gate
+
+- Phase 2에서 TLC를 4 cfg 모두 실행: clean 통과 + buggy 3개가 각자 다른 invariant 위반 확인. 하나라도 어긋나면 merge 차단.
+- Composite mermaid state-id diff 검사 (spec state 집합 ↔ 런타임 방출 집합).
+
+## 9. Risks / Trade-offs
+
+| Risk | 완화 |
+|------|------|
+| `keeper_decision_audit.mli` 시그니처 확장이 외부 소비자(테스트, 다른 모듈, 다른 서비스)에 파급 | optional labelled args + 기본값 `None` + deprecation note 주석. 한 번에 caller 전환하지 않아도 됨 |
+| SSE stream + 기존 cache 이중 source-of-truth | cache를 stream의 `last_emitted` 값 저장소로 강등. 단일 writer = event_bus handler |
+| `/fsm` 페이지가 "또 하나의 감사 UI"로 방치될 위험 | Phase 3 PR에 운영자 README 섹션 추가: 어떤 invariant violation이 발생하면 어떤 페이지를 본다 |
+| Composite snapshot이 turn 경계에서 stale | `composite_view`를 Lazy로 두고 매 read마다 재계산. SSE `ts` 필드를 필수 |
+| Tailwind-only 제약 vs Cytoscape 사용 | Cytoscape는 자체 canvas라 Tailwind class와 직접 충돌 없음. 컨테이너 레벨만 Tailwind |
+| 신규 페이지 추가로 라우팅 복잡도↑ | 기존 router를 재사용(신규 라우팅 라이브러리 금지), sidebar에 `/fsm` 링크 하나만 추가 |
+
+## 10. Non-goals
+
+- RFC-0003의 OCaml observer 구현 (별도 PR, `feature/composite-observer`)
+- P1(`TurnSucceeded` spec divergence) 수정 — `KeeperStateMachine.tla` 국소 수정이며 본 plan과 직교
+- Fleet-wide composite 뷰(여러 keeper의 composite를 한 번에 비교) — Phase 4 이후로 연기
+- 기존 Keeper detail의 운영자용 섹션 재배치 — 본 plan은 **FSM 가시성**만 다룬다
+
+## 11. Open Questions
+
+1. `/fsm` 페이지에서 Keeper picker를 **URL segment**(`/fsm/:name`)로 둘지 query param으로 둘지. URL segment가 공유/북마크에 유리하지만 라우팅 변경 필요.
+2. Invariants panel에서 위반 알림을 어떤 채널로 escalate할 것인가 — 대시보드 내 배지로만 둘지, Slack webhook까지 연계할지 (RFC-0003 Open Question §3과 동일).
+3. Memory tier panel에서 kind cap 초과 임박(used == cap-1)을 주황색으로 표시할지, 초과 직후(used >= cap)에만 표시할지.

--- a/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
+++ b/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
@@ -1,0 +1,275 @@
+# RFC-0003: Keeper Composite Lifecycle Observer
+
+**Status**: Draft
+**Date**: 2026-04-14
+**Scope**: `masc-mcp` cross-spec joint invariants + dashboard observer contract
+**One sentence**: Decision/Cascade/Memory/Compaction/Recovery의 turn 단위 상호작용을 1급으로 관찰하기 위한 composition observer를 도입하고, 기존 3개의 부분 합성 spec이 커버하지 못하는 joint invariants + `state-fsm-gap-2026-04-13.md` P4(RecoveryOrchestration)를 한 spec에 흡수한다.
+
+## Related Documents
+
+- `RFC-0001-det-nondet-boundary-harness.md` — Det/NonDet 경계 원칙
+- `RFC-0002-keeper-state-machine.md` — 11-state parent phase FSM (이 RFC는 transition을 추가하지 않는다)
+- `docs/tla-audit/state-fsm-gap-2026-04-13.md` — Bug #1, 제안 P1~P5 (여기서 P4를 흡수)
+- `docs/tla-audit/cascade-fsm-gap-2026-04-13.md`
+- `docs/tla-audit/decision-fsm-gap-2026-04-13.md`
+- `docs/design/oas-masc-state-boundary.md` — MASC/OAS SSOT
+- `specs/keeper-state-machine/KeeperStateMachine.tla` — 11-state spec
+- `specs/keeper-state-machine/KeeperCoreTriad.tla` — State × Decision × Cascade (5-phase 투사)
+- `specs/state-product/StateProduct.tla` — Keeper × Turn × Validation 직교 합성
+- `specs/keeper-state-machine/KeeperContextLifecycle.tla` — Context + Compaction + Checkpoint
+- `specs/bug-models/MemoryCompaction.tla`, `CascadeLiveness.tla`
+
+## 1. Context & Motivation
+
+`masc-mcp` 저장소는 이미 세 개의 부분 합성 spec을 가진다.
+
+| Spec | 합성 축 | 커버 | 미커버 |
+|------|---------|------|--------|
+| `KeeperCoreTriad.tla` | State × Decision × Cascade | cascade routing, capability gate, side-effect containment | Memory compaction, turn cycle, recovery orchestration, 11-state 전체 |
+| `StateProduct.tla` | Keeper × Turn × Validation | det/nondet boundary per turn | Decision pipeline, Cascade, Memory |
+| `KeeperContextLifecycle.tla` | Context + Compaction + Checkpoint | context identity on resume, tool pair integrity | State machine의 11-state, Cascade, Decision |
+
+세 spec은 각자 영역에서 유효하지만, **한 turn 안에서 여러 FSM이 순서를 지키며 전이하는 joint property**는 아무도 검사하지 않는다. 근거:
+
+- `Keeper_state_machine.mli:131-136` `Context_measured` 이벤트는 Decision, Compaction, Cascade, Recovery의 분기 조건을 공통으로 공급하지만 이 공유 측정의 존재를 joint spec으로 명시한 곳이 없다.
+- `keeper_post_turn.ml:45-232` `apply_post_turn_lifecycle`는 `Compaction_started/completed`, `Handoff_started/completed`를 한 turn 안에 atomic하게 emit하지만, 이 atomic 경계를 TLC로 검증할 수 있는 spec이 없다.
+- `docs/tla-audit/state-fsm-gap-2026-04-13.md` Bug #1(PR #6834, `keeper_keepalive.ml:774-836`)은 **data record 스토어와 FSM condition 스토어 간 비동기**가 만든 one-way trap이었다. 감사 문서 §5는 P4 `KeeperRecoveryOrchestration.tla` 신규를 제안했으나 아직 spec 파일이 없다.
+- 대시보드 관점에서 각 FSM이 `dashboard/src/components/keeper-*.ts`의 개별 위젯으로 흩어져 있어 "이 keeper의 현재 상태가 invariants를 만족하는가"를 한눈에 볼 수 없다.
+
+이 RFC는 **새 controller를 만들지 않고**, 기존 sub-spec들 사이의 일관성을 관찰하는 composition observer를 spec + OCaml + dashboard payload 계층으로 정의한다.
+
+## 2. Scope
+
+포함:
+
+1. `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` 신규 — projection-style observer spec. state explosion 없이 joint invariants 5개 + liveness 2개 + bug model 3종.
+2. `KeeperCompositeLifecycle.cfg`(clean) + buggy cfg 3개 — clean은 전 invariant 통과, buggy 3개는 서로 다른 invariant를 위반한다 (`feedback_tla-spec-audit-outcome-trichotomy.md`).
+3. `state-fsm-gap-2026-04-13.md` P4(RecoveryOrchestration) 제안을 별도 spec 파일 대신 이 composite 안에 `RecoveryTwoStoreSync` invariant로 흡수.
+4. OCaml observer 모듈 계약(문서만, 구현은 후속 PR): `lib/keeper/keeper_composite_observer.ml{,i}`, `Keeper_registry.registry_entry` 파생 필드, event bus broadcast.
+5. 대시보드 payload shape: `/api/keepers/:name/composite` JSON 스키마.
+
+제외:
+
+- 실제 OCaml observer 구현, dashboard `/fsm` hub 페이지 구현 — 후속 세션의 Phase 1~4 PR에서 순차 진행 (`docs/design/dashboard-fsm-redesign.md` 참조).
+- P1(`TurnSucceeded` spec-code divergence) 수정 — 이 RFC와 직교한 fix로, 별도 PR에서 `KeeperStateMachine.tla`를 OCaml에 정렬한다. 이 RFC는 P1이 수정되었다는 가정 없이도 동작한다.
+- Observer가 sub-FSM의 transition 권한을 획득하는 것.
+
+## 3. Relationship to RFC-0002
+
+RFC-0002는 11-state parent phase FSM을 pure function `derive_phase` + `apply_event`로 1급 구성했다. RFC-0003은 그 위에 **transition을 하나도 추가하지 않는다**. 관계는 다음과 같다:
+
+- RFC-0002: 개별 keeper의 lifecycle ownership (측정 → 이벤트 → 조건 → phase).
+- RFC-0003: 한 turn 안에서 여러 도메인 FSM 간 ordering/atomicity/two-store consistency를 관찰.
+- RFC-0002의 11-state → 6-state projection 규칙은 RFC-0003 spec 서두 `Comment A`에 명시한다. `{Offline, Paused, Stopped, Crashed, Restarting, Dead}`는 모두 `Stable`로 접어 turn cycle 밖에 둔다.
+
+이 RFC의 invariants가 위반된다 해도 RFC-0002의 단일 FSM 동작은 여전히 올바르다. 단, joint property가 깨지면 운영자는 "FSM은 정상이지만 전체 시스템이 turn cycle을 잘못 진행 중"임을 관찰할 수 있어야 한다.
+
+## 4. Meta-FSM Identity
+
+### 세 후보와 선택
+
+| 후보 | 설명 | 채택 여부 |
+|------|------|-----------|
+| **C1 Hierarchical parent** | RFC-0002의 11-state를 parent로 삼고 Decision/Cascade/Memory를 guard로 매다는 HSM | **거절** |
+| **C2 Turn-cycle root** | `KeeperTurnCycle.tla`를 composition root로 하고 나머지를 하위에 위치 | **거절** |
+| **C3 Event-driven projection** | `Context_measured` + OAS envelope를 coordination hub로 보고, 관찰 가능한 projection variables + joint invariants만 선언 | **채택** |
+
+C1을 거절한 구조적 이유: Decision/Cascade/Memory는 turn 내부에서만 의미 있는 상태를 갖는다. 이를 parent-child로 강제하면 `Paused`, `Crashed`, `Restarting` 같은 phase에서도 child FSM의 state를 정의해야 하는데, 현실에서 그 state는 존재하지 않거나 stale하다. 타입이 거짓말하는 spec이 된다.
+
+C2를 거절한 이유: `KeeperTurnCycle.tla`는 turn의 물리적 시퀀스(`prompting/awaiting/tool_call/...`)를 모델링한다. 여기에 Cascade profile이나 Decision tier 같은 상위 개념을 얹으면 spec의 추상화 레벨이 뒤집힌다.
+
+C3 채택 이유: 이미 `Context_measured` + `auto_rules_summary`가 hub 역할을 하고 있고, `Keeper_guard`의 priority ordering(3/4/5)으로 de facto serialization도 성립한다. 새 identifier를 만들지 않고 기존 identifier를 projection으로 재사용한다 (`feedback_no-derived-tag-when-existing-identifier-suffices.md`).
+
+## 5. Spec Summary — `KeeperCompositeLifecycle.tla`
+
+### Projected state variables
+
+| 변수 | 출처 | 값 도메인 | 비고 |
+|------|------|-----------|------|
+| `ksm_phase` | `KeeperStateMachine.tla` 11-state → 6-state 투사 | `{Running, Failing, Compacting, HandingOff, Draining, Stable}` | Lossy projection. Stable은 turn cycle 밖 |
+| `ktc_turn_phase` | `KeeperTurnCycle.tla` / `keeper_unified_turn.ml` | `{idle, prompting, executing, compacting, finalizing}` | |
+| `kdp_decision` | `KeeperDecisionPipeline.tla` | `{undecided, guard_ok, gate_rejected, tool_policy_selected}` | Narrow projection |
+| `kcl_cascade_state` | `CascadeLiveness.tla` | `{idle, selecting, trying, done, exhausted}` | |
+| `kmc_compaction` | `MemoryCompaction.tla` | `{accumulating, compacting, done}` | |
+| `shared_measurement` | `Context_measured` | `Nat` (0 = none, else snapshot id) | **hub** |
+| `measurement_turn` | `turn_tick` at capture | `Nat` | ordering |
+| `reconcile_data` | `Keeper_manual_reconcile` (FS record) | `BOOLEAN` | two-store A |
+| `reconcile_fsm` | `conditions.manual_reconcile_required` | `BOOLEAN` | two-store B |
+| `turn_tick` | monotone counter | `0..MaxTurnTicks` | model bound |
+
+### Actions (narrow abstractions)
+
+`StartTurn`, `MeasurementBroadcast`, `DecideGuard`, `SelectCascade`, `CascadeDone`, `StartCompaction`, `FinishCompaction`, `EnterFailing`, `ClearDataRecord`, `ClearFsmCondition`. 총 10개. 각 action은 sub-FSM transition의 minimum projection이며, 자세한 guard는 원 spec에 위임한다.
+
+### Safety invariants (clean cfg)
+
+| ID | 이름 | 요지 |
+|----|------|------|
+| I1 | `PhaseTurnAlignment` | `ksm_phase = Compacting ⇒ ktc_turn_phase = compacting ∧ kmc_compaction = compacting` |
+| I2 | `NoCascadeBeforeMeasurement` | cascade가 idle/selecting을 떠나려면 현재 turn의 measurement가 있어야 함 |
+| I3 | `CompactionAtomicity` | `kmc_compaction = compacting ⇒ ksm_phase = Compacting` |
+| I4 | `EventPriorityMonotone` | 한 turn에 measurement는 최대 1회 |
+| I5 | `RecoveryTwoStoreSync` | `Failing` 중 `reconcile_data=FALSE ∧ reconcile_fsm=TRUE`인 상태는 unreachable (Bug #1 재구성) |
+
+### Liveness (fairness 필요)
+
+- L1 `EventualMeasurementResolves`: `prompting ~> (shared_measurement ≠ 0 ∨ turn 이동)`
+- L2 `RecoveryEventuallyCompletes`: `Failing ~> Running`
+
+L2는 `WF_vars(ClearDataRecord) + WF_vars(ClearFsmCondition)`이 fairness에 포함되어야만 성립한다. Bug #1의 교훈은 여기에 있다. fairness 하나가 빠지면 liveness가 즉시 무너진다.
+
+### Bug models
+
+| Bug | 행동 | 예상 위반 invariant |
+|-----|------|-------------------|
+| `BugCascadeBeforeMeasurement` | measurement 없이 SelectCascade | I2 |
+| `BugCompactionDesync` | KMC만 compacting으로 진행 | I1, I3 |
+| `BugFsmClearsWithoutData` | data record가 set인데 FSM condition 먼저 clear | I5 |
+
+세 bug는 **서로 다른 invariant를 때린다**. 모두 같은 곳을 치면 invariant 해상도가 낮다는 신호 (`feedback_tla-spec-audit-outcome-trichotomy.md`).
+
+## 6. Observer Contract (OCaml)
+
+### 신규 모듈
+
+- `lib/keeper/keeper_composite_observer.mli`
+  ```ocaml
+  type snapshot = {
+    correlation_id : string;
+    run_id : string;
+    ts : float;
+    ksm_phase : Keeper_state_machine.phase;
+    ktc_turn_phase : [ `Idle | `Prompting | `Executing | `Compacting | `Finalizing ];
+    kdp_decision : [ `Undecided | `Guard_ok | `Gate_rejected | `Tool_policy_selected ];
+    kcl_cascade_state : [ `Idle | `Selecting | `Trying | `Done | `Exhausted ];
+    kmc_compaction : [ `Accumulating | `Compacting | `Done ];
+    shared_measurement : Keeper_state_machine.auto_rules_summary option;
+    reconcile_data : bool;
+    reconcile_fsm : bool;
+    invariants : invariants_check;
+  }
+
+  and invariants_check = {
+    phase_turn_alignment : bool;
+    no_cascade_before_measurement : bool;
+    compaction_atomicity : bool;
+    event_priority_monotone : bool;
+    recovery_two_store_sync : bool;
+  }
+
+  val observe : Keeper_registry.registry_entry -> snapshot
+  (** Pure projection. Reads the registry entry plus the most recent
+      Context_measured event. No mutation, no I/O. *)
+  ```
+
+- `Keeper_registry.registry_entry`에 `composite_view : Keeper_composite_observer.snapshot Lazy.t` 파생 필드 (`:43-75` 확장). **저장되지 않는다**; read 시점에 계산한다. 기존 ref가 stale하지 않도록 lazy + 매 read마다 재평가 옵션을 제공한다.
+
+### 관찰 hook 위치
+
+- `lib/keeper/keeper_post_turn.ml:45-232` `apply_post_turn_lifecycle` — `Compaction_started/completed`, `Handoff_started/completed` 각 emit 직후 `Keeper_event_bus` 브로드캐스트.
+- `lib/keeper/keeper_unified_turn.ml` — phase gate 입출.
+- Topic: `keeper.composite.tick`.
+- Envelope: OAS event_bus envelope `{correlation_id, run_id, ts}` (PR OAS#845, `project_oas-event-bus-envelope-2026-04-12.md`).
+
+### 절대 하지 않는 것
+
+- `Keeper_state_machine.apply_event` 호출.
+- `Keeper_cascade_routing.select_cascade` 호출 변경.
+- `registry_entry` 필드 mutation.
+- 토큰 수, context byte, provider 이름 읽기/저장.
+
+## 7. Dashboard Payload Shape
+
+```json
+GET /api/keepers/:name/composite
+{
+  "correlation_id": "c-2026-04-14-abc123",
+  "run_id": "r-1712834000",
+  "ts": 1712834000.5,
+  "phase": "Running",
+  "turn_phase": "executing",
+  "decision": { "stage": "tool_policy_selected", "cycle_penalty": 0 },
+  "cascade": { "profile": "keeper_unified", "state": "trying" },
+  "compaction": { "stage": "accumulating", "last_saved_tokens": 0 },
+  "measurement": {
+    "captured_this_turn": true,
+    "context_ratio": 0.62,
+    "message_count": 48
+  },
+  "recovery": { "data_record": false, "fsm_condition": false },
+  "invariants": {
+    "phase_turn_alignment": true,
+    "no_cascade_before_measurement": true,
+    "compaction_atomicity": true,
+    "event_priority_monotone": true,
+    "recovery_two_store_sync": true
+  }
+}
+```
+
+Dashboard `/fsm` hub 페이지는 이 payload를 composite Cytoscape + invariants panel + event log로 렌더링한다. 렌더링 설계의 상세는 `docs/design/dashboard-fsm-redesign.md`를 따른다. `/fsm` hub를 선택한 이유는 운영자 콘솔(`/keepers/:name`)과 아키텍처 감사 뷰를 섞지 않기 위함.
+
+## 8. P4 Absorption
+
+`state-fsm-gap-2026-04-13.md` §5 P4는 새 파일 `KeeperRecoveryOrchestration.tla`를 제안했다. 본 RFC는 이를 **별도 spec 파일로 만들지 않는다**. 대신 `KeeperCompositeLifecycle.tla`의 다음 요소가 P4의 의무를 수용한다:
+
+| P4 제안 | 이 RFC의 대응 |
+|---------|---------------|
+| `ClearDataRecord`, `DispatchManualReconcileCleared` 액션 | `ClearDataRecord`, `ClearFsmCondition` actions |
+| `DataRecordCleared ⇒ FSMConditionCleared` safety | `RecoveryTwoStoreSync` invariant |
+| `BugRecoverySequence` (omit dispatch) | `BugFsmClearsWithoutData` bug model + `KeeperCompositeLifecycle-buggy-recovery.cfg` |
+| WF on clearing path | `WF_vars(ClearDataRecord)`, `WF_vars(ClearFsmCondition)` in `Fairness` |
+
+사유: P4의 핵심 요구는 "data record와 FSM condition 두 store가 영구 불일치하지 않는다"이다. 이 요구는 composite spec의 `Failing ~> Running` liveness와 `RecoveryTwoStoreSync` safety에 자연스럽게 들어온다. 별도 파일은 spec fragmentation만 늘린다.
+
+P1(`TurnSucceeded` spec-code divergence)은 여기서 다루지 않는다. P1은 `KeeperStateMachine.tla`의 국소 수정이며, 본 RFC와 직교한다.
+
+## 9. Non-goals & Boundaries
+
+| 규칙 | 근거 | 검사 방법 |
+|------|------|-----------|
+| Observer가 transition 권한을 갖지 않음 | `feedback_no-lifecycle-invasion-from-masc.md` | spec에 `apply_event` 호출 grep |
+| MASC 레벨에 provider/model 이름 노출 금지 | `feedback_masc-model-agnostic.md` | `rg -i 'groq|ollama|claude|gpt' specs/ lib/keeper/keeper_composite_observer.*` |
+| 토큰/예산 추정 금지 | `feedback_budget-belongs-in-oas.md` | spec에 `context_tokens` 같은 양 변수 없음 (audit sub-FSM에 있음) |
+| OAS state mutation 금지 | `feedback_masc-oas-layer-boundary.md`, `feedback_masc-must-use-oas-agent-run.md` | observer 시그니처가 `read-only` 반환 타입 |
+| 새 추상화 발명 최소화 | `feedback_no-derived-tag-when-existing-identifier-suffices.md` | 모든 변수가 기존 spec/모듈에서 1:1 투사 |
+
+이 경계들은 RFC의 "Scope" 항목과 함께 리뷰어가 PR에서 checklist로 확인한다.
+
+## 10. Implementation Phases
+
+| Phase | 산출물 | 의존 | 독립 PR |
+|-------|--------|------|---------|
+| **0** (이번 RFC) | `KeeperCompositeLifecycle.tla` + 4 cfg + RFC-0003 + redesign plan | 없음 | 본 PR |
+| 1 | Dashboard Phase 1 (cascade dehardcode + decision FSM fields + agent mini strip) | Phase 0 승인 | `docs/design/dashboard-fsm-redesign.md` §Phase 1 |
+| 2 | `KeeperCompositeLifecycle` TLC 실행 + buggy cfg 검증 (4개 cfg 모두 pass/fail 확인) | Phase 0 | 독립 |
+| 3 | `lib/keeper/keeper_composite_observer.ml{,i}` + registry 파생 필드 | Phase 2 | 독립 |
+| 4 | `Keeper_event_bus` topic 브로드캐스트 + OAS envelope | Phase 3 | 독립 |
+| 5 | Dashboard `/api/keepers/:name/composite` endpoint + `/fsm` hub | Phase 4 | redesign plan §Phase 3 |
+| 6 | SSE stream + EventSource client | Phase 5 | redesign plan §Phase 4 |
+
+Phase 1과 Phase 2는 병렬 가능하다. Phase 2~6은 이 RFC의 scope를 벗어나며 별도 issue/PR에서 진행한다.
+
+## 11. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Projection의 정보 손실(11→6 phase) | Comment A에 projection 표 명시 + Stable 상태는 turn cycle 밖이라 joint invariant에 영향 없음을 증명 |
+| Sub-spec 변경 시 composite 동기화 지연 | `tla-audit/*-fsm-gap-*.md` 패턴으로 주기적 audit, Phase 2 CI에 TLC 4 cfg 통과 gate 추가 |
+| Observer snapshot stale window | `composite_view`를 Lazy + 매 read마다 재계산, SSE broadcast 시 `ts`를 필수 필드로 둠 |
+| `RecoveryTwoStoreSync`가 과하게 엄격 | "Failing 내에서 data→fsm 순서"만 강제하고, terminal phase(Stopped/Dead)에서는 vacuously hold |
+| SSE + cache 이중 source-of-truth | `server_dashboard_http_cache.ml`를 stream의 last_emitted로 강등, 단일 writer는 event_bus handler |
+
+## 12. Open Questions
+
+1. **Observer snapshot stale window 허용치** — 0ms (매번 재계산) vs 100ms (event_bus tick 주기) 중 어느 쪽이 대시보드에 더 올바른가?
+2. **SSE stream 구독자 limit** — Keeper당 N 클라이언트 이상은 거부? 무제한? 초기 default 값 제안 필요.
+3. **Invariants 위반 시 dashboard 표시 정책** — 단순 경고 배지 vs alert 모달 vs on-call 알람. 운영 impact와 연결.
+4. **P1 수정 타이밍** — RFC-0003 spec 진입 전/후 어느 시점에 `KeeperStateMachine.tla`의 `TurnSucceeded`를 OCaml에 정렬할 것인가? 본 RFC의 buggy cfg 3개와 P1 수정이 독립이지만 CI 순서에 영향이 있다.
+
+## 13. Scope Exclusion
+
+- Dashboard 구현 세부 — `docs/design/dashboard-fsm-redesign.md`에 위임
+- P1(`TurnSucceeded` divergence) 수정 — 별도 PR, 별도 이슈
+- P2, P3(audit가 제안한 다른 항목), P5(OCaml-TLA correspondence test) — 본 RFC 이후 단계로 연기
+- Meta-observer가 여러 keeper를 cross-reference 하는 fleet-level composition — 본 RFC는 keeper 단위만 다룬다

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-cascade.cfg
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-cascade.cfg
@@ -1,0 +1,14 @@
+\* TLC Configuration — Buggy spec (cascade ordering)
+\* Expected outcome: NoCascadeBeforeMeasurement MUST be violated.
+\* If it holds, the invariant is too weak.
+
+SPECIFICATION SpecBuggyCascade
+
+CONSTANTS
+    MaxTurnTicks = 4
+
+INVARIANTS
+    NoCascadeBeforeMeasurement
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-compaction.cfg
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-compaction.cfg
@@ -1,0 +1,16 @@
+\* TLC Configuration — Buggy spec (compaction coupling)
+\* Expected outcome: CompactionAtomicity and/or PhaseTurnAlignment MUST
+\* be violated. Both target the same root: KMC advancing without the
+\* parent phase and turn phase co-advancing.
+
+SPECIFICATION SpecBuggyCompaction
+
+CONSTANTS
+    MaxTurnTicks = 4
+
+INVARIANTS
+    CompactionAtomicity
+    PhaseTurnAlignment
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-recovery.cfg
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle-buggy-recovery.cfg
@@ -1,0 +1,16 @@
+\* TLC Configuration — Buggy spec (recovery two-store desync)
+\* Expected outcome: RecoveryTwoStoreSync MUST be violated.
+\* This reconstructs Bug #1 (masc-mcp PR #6834 / keeper_keepalive.ml:
+\* 774-836) where the FSM condition was cleared before or without the
+\* corresponding data record, leaving the keeper stuck at Failing.
+
+SPECIFICATION SpecBuggyRecovery
+
+CONSTANTS
+    MaxTurnTicks = 4
+
+INVARIANTS
+    RecoveryTwoStoreSync
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.cfg
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.cfg
@@ -1,0 +1,23 @@
+\* TLC Configuration — Clean spec (all invariants hold)
+\* KeeperCompositeLifecycle — cross-spec joint observer
+\*
+\* Run:
+\*   java -jar specs/keeper-state-machine/tla2tools.jar -config \
+\*        specs/keeper-state-machine/KeeperCompositeLifecycle.cfg \
+\*        specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxTurnTicks = 4
+
+INVARIANTS
+    SafetyInvariant
+    RecoveryTwoStoreSync
+
+CHECK_DEADLOCK
+    FALSE
+
+PROPERTIES
+    EventualMeasurementResolves
+    RecoveryEventuallyCompletes

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -185,6 +185,19 @@ CascadeDone ==
                    shared_measurement, measurement_turn, reconcile_data,
                    reconcile_fsm, turn_tick>>
 
+\* FinishTurn — closes the current turn and resets per-turn sub-FSM state.
+\* Without this, the next StartTurn would keep kcl_cascade_state stale
+\* while the measurement is re-cleared, violating NoCascadeBeforeMeasurement.
+FinishTurn ==
+    /\ ktc_turn_phase = "finalizing"
+    /\ ktc_turn_phase' = "idle"
+    /\ kcl_cascade_state' = "idle"
+    /\ kdp_decision' = "undecided"
+    /\ shared_measurement' = 0
+    /\ measurement_turn' = 0
+    /\ UNCHANGED <<ksm_phase, kmc_compaction, reconcile_data,
+                   reconcile_fsm, turn_tick>>
+
 \* Compaction is coupled: parent phase + turn phase + memory phase
 \* must co-advance (CompactionAtomicity).
 StartCompaction ==
@@ -218,8 +231,13 @@ EnterFailing ==
     /\ reconcile_fsm' = TRUE
     /\ ksm_phase' = "Failing"
     /\ ktc_turn_phase' = "idle"
-    /\ UNCHANGED <<kdp_decision, kcl_cascade_state, kmc_compaction,
-                   shared_measurement, measurement_turn, turn_tick>>
+    \* Abort the in-flight turn: reset sub-FSMs so the next StartTurn
+    \* begins from a clean per-turn state.
+    /\ kdp_decision' = "undecided"
+    /\ kcl_cascade_state' = "idle"
+    /\ shared_measurement' = 0
+    /\ measurement_turn' = 0
+    /\ UNCHANGED <<kmc_compaction, turn_tick>>
 
 ClearDataRecord ==
     /\ ksm_phase = "Failing"
@@ -247,6 +265,7 @@ Next ==
     \/ DecideGuard
     \/ SelectCascade
     \/ CascadeDone
+    \/ FinishTurn
     \/ StartCompaction
     \/ FinishCompaction
     \/ EnterFailing
@@ -258,6 +277,7 @@ Fairness ==
     /\ WF_vars(DecideGuard)
     /\ WF_vars(SelectCascade)
     /\ WF_vars(CascadeDone)
+    /\ WF_vars(FinishTurn)
     /\ WF_vars(FinishCompaction)
     /\ WF_vars(ClearDataRecord)
     /\ WF_vars(ClearFsmCondition)
@@ -296,17 +316,18 @@ EventPriorityMonotone ==
     (shared_measurement /= 0) => (measurement_turn <= turn_tick)
 
 \* I5 — RecoveryTwoStoreSync  (absorbs state-fsm-gap-2026-04-13.md P4)
-\* The filesystem reconcile record and the FSM condition must never
-\* reach a permanent disagreement: the FSM condition may only be true
-\* while the data record is also either pending (true) or already
-\* cleared in the same Failing episode. The failure mode is
-\* reconcile_data = FALSE (cleared) but reconcile_fsm still TRUE and
-\* phase stuck at Failing — exactly Bug #1 (PR #6834).
+\* The FSM condition must not be cleared while the filesystem reconcile
+\* record is still set. This is the reverse-order failure: OCaml code
+\* dispatches Manual_reconcile_cleared before Keeper_manual_reconcile.clear.
+\* BugFsmClearsWithoutData reconstructs this pattern.
+\*
+\* Note: the stuck-at (reconcile_data=FALSE, reconcile_fsm=TRUE) pattern
+\* from Bug #1 (PR #6834) is a liveness violation, not a safety one. It is
+\* caught by RecoveryEventuallyCompletes with WF on ClearFsmCondition.
+\* Normal ordering (T,T)->(F,T)->(F,F) does NOT violate this invariant
+\* because reconcile_data=TRUE always implies reconcile_fsm=TRUE here.
 RecoveryTwoStoreSync ==
-    (ksm_phase = "Failing" /\ reconcile_data = FALSE /\ reconcile_fsm)
-        => FALSE                          \* this state is unreachable
-\* Note: this invariant reads as "the bad state must not exist";
-\* TLC will report a violation only via a buggy transition.
+    ~(reconcile_data /\ ~reconcile_fsm)
 
 SafetyInvariant ==
     /\ TypeOK

--- a/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCompositeLifecycle.tla
@@ -1,0 +1,394 @@
+---- MODULE KeeperCompositeLifecycle ----
+\* Keeper Composite Lifecycle — Cross-spec Joint Invariants (Observer)
+\*
+\* Purpose
+\*   The repository already has three partial composition specs:
+\*     - KeeperCoreTriad.tla          State x Decision x Cascade (5-phase projection)
+\*     - StateProduct.tla             Keeper x Turn x Validation
+\*     - KeeperContextLifecycle.tla   Context + Compaction + Checkpoint + Recovery
+\*   None of them check joint invariants that span all four domain FSMs
+\*   (Decision, Cascade, MemoryCompaction, Compaction-phase) together, nor
+\*   does any spec model the keepalive recovery two-store orchestration that
+\*   Bug #1 (keeper_keepalive.ml:774-836, PR #6834) exposed.
+\*
+\*   This spec is an OBSERVER, not a new controller. It declares a minimum
+\*   set of projected variables — each traceable to an OCaml module — and
+\*   asserts joint invariants that no existing spec covers. It does not
+\*   redefine the transitions of any sub-FSM; they are represented only at
+\*   the resolution required for the joint properties.
+\*
+\*   Related audit: docs/tla-audit/state-fsm-gap-2026-04-13.md (proposals
+\*   P1, P3, P4 — this spec absorbs P4 and encodes P3's clearing property).
+\*
+\* Design intent
+\*   1. shared_measurement is the coordination hub (Context_measured event,
+\*      Keeper_state_machine.mli:131-136, auto_rules_summary).
+\*   2. The 11-state parent phase from RFC-0002 is projected to
+\*      {Running, Failing, Compacting, HandingOff, Draining, Stable}
+\*      — exactly the phases that matter for cross-spec ordering.
+\*   3. Recovery orchestration is encoded as a two-store consistency
+\*      invariant between reconcile_data_record and fsm_condition.
+\*   4. Model size kept small on purpose; TLC over this spec should
+\*      complete in seconds, not hours.
+\*
+\* Non-goals (enforced structurally — see Boundary comment at end)
+\*   - No transition of KSM/KTC/KDP/KMC/KCL is redefined here.
+\*   - No provider/model identifier appears at any step.
+\*   - No token counting happens in this spec (OAS owns budget math).
+
+EXTENDS Naturals
+
+CONSTANTS
+    MaxTurnTicks       \* Small bound for model checking (e.g. 4)
+
+ASSUME MaxTurnTicks \in Nat /\ MaxTurnTicks >= 2
+
+\* ── Projected state variables ────────────────────────────
+\* Each variable below is a PROJECTION of state owned by another spec or
+\* OCaml module. The mapping is explicit and one-way; this spec never
+\* writes back.
+
+VARIABLES
+    ksm_phase,          \* KSM projection. KeeperStateMachine.tla phase
+                        \* Reduced to the 6 values that change cross-spec
+                        \* behavior. Mapping from 11-state is in Comment A.
+
+    ktc_turn_phase,     \* KTC projection. KeeperTurnCycle.tla / unified turn
+                        \* Values: idle, prompting, executing, compacting,
+                        \*         finalizing.
+
+    kdp_decision,       \* KDP projection. KeeperDecisionPipeline.tla
+                        \* Values: undecided, guard_ok, gate_rejected,
+                        \*         tool_policy_selected.
+
+    kcl_cascade_state,  \* KCL projection. CascadeLiveness.tla state set
+                        \* Values: idle, selecting, trying, done, exhausted.
+
+    kmc_compaction,     \* KMC projection. MemoryCompaction.tla phase
+                        \* Values: accumulating, compacting, done.
+
+    shared_measurement, \* Coordination hub. auto_rules_summary snapshot id
+                        \* (Nat); 0 means "no measurement yet this turn".
+
+    measurement_turn,   \* Turn tick at which current shared_measurement
+                        \* was captured. Guards "measurement before cascade".
+
+    reconcile_data,     \* Two-store model (P4 absorption)
+                        \* TRUE iff filesystem reconcile record is set.
+
+    reconcile_fsm,      \* Two-store model. TRUE iff FSM condition
+                        \* manual_reconcile_required is set.
+
+    turn_tick           \* Monotone counter used for ordering checks.
+
+vars == <<ksm_phase, ktc_turn_phase, kdp_decision, kcl_cascade_state,
+          kmc_compaction, shared_measurement, measurement_turn,
+          reconcile_data, reconcile_fsm, turn_tick>>
+
+\* ── Enumerated value sets ───────────────────────────────
+
+\* Comment A — 11->6 phase projection (from RFC-0002 Transition Matrix):
+\*   Running     -> Running
+\*   Failing     -> Failing
+\*   Compacting  -> Compacting
+\*   HandingOff  -> HandingOff
+\*   Draining    -> Draining
+\*   Offline, Paused, Stopped, Crashed, Restarting, Dead -> Stable
+\* This is a LOSSY projection; the joint invariants here hold for all
+\* states that collapse to Stable by construction (they are outside the
+\* turn cycle).
+
+PhaseSet       == {"Running", "Failing", "Compacting", "HandingOff",
+                   "Draining", "Stable"}
+TurnPhaseSet   == {"idle", "prompting", "executing", "compacting",
+                   "finalizing"}
+DecisionSet    == {"undecided", "guard_ok", "gate_rejected",
+                   "tool_policy_selected"}
+CascadeSet     == {"idle", "selecting", "trying", "done", "exhausted"}
+CompactionSet  == {"accumulating", "compacting", "done"}
+
+TypeOK ==
+    /\ ksm_phase \in PhaseSet
+    /\ ktc_turn_phase \in TurnPhaseSet
+    /\ kdp_decision \in DecisionSet
+    /\ kcl_cascade_state \in CascadeSet
+    /\ kmc_compaction \in CompactionSet
+    /\ shared_measurement \in Nat
+    /\ measurement_turn \in Nat
+    /\ reconcile_data \in BOOLEAN
+    /\ reconcile_fsm \in BOOLEAN
+    /\ turn_tick \in 0..MaxTurnTicks
+
+\* ── Initial state ────────────────────────────────────────
+
+Init ==
+    /\ ksm_phase = "Running"
+    /\ ktc_turn_phase = "idle"
+    /\ kdp_decision = "undecided"
+    /\ kcl_cascade_state = "idle"
+    /\ kmc_compaction = "accumulating"
+    /\ shared_measurement = 0
+    /\ measurement_turn = 0
+    /\ reconcile_data = FALSE
+    /\ reconcile_fsm = FALSE
+    /\ turn_tick = 0
+
+\* ── Domain actions (abstract) ────────────────────────────
+\* Each action below is a narrow abstraction of a sub-FSM transition.
+\* The sub-FSM's detailed behaviour is verified in its own spec; here
+\* we only move enough state to observe cross-spec properties.
+
+StartTurn ==
+    /\ ksm_phase = "Running"
+    /\ ktc_turn_phase = "idle"
+    /\ turn_tick < MaxTurnTicks
+    /\ ktc_turn_phase' = "prompting"
+    /\ turn_tick' = turn_tick + 1
+    /\ shared_measurement' = 0           \* reset hub at turn start
+    /\ measurement_turn' = 0
+    /\ UNCHANGED <<ksm_phase, kdp_decision, kcl_cascade_state,
+                   kmc_compaction, reconcile_data, reconcile_fsm>>
+
+MeasurementBroadcast ==                  \* Context_measured (priority 5)
+    /\ ktc_turn_phase = "prompting"
+    /\ shared_measurement = 0            \* exactly once per turn (P3-like)
+    /\ shared_measurement' = turn_tick    \* any unique, nonzero value
+    /\ measurement_turn' = turn_tick
+    /\ UNCHANGED <<ksm_phase, ktc_turn_phase, kdp_decision,
+                   kcl_cascade_state, kmc_compaction, reconcile_data,
+                   reconcile_fsm, turn_tick>>
+
+DecideGuard ==
+    /\ ktc_turn_phase = "prompting"
+    /\ shared_measurement /= 0
+    /\ kdp_decision = "undecided"
+    /\ kdp_decision' = "guard_ok"
+    /\ UNCHANGED <<ksm_phase, ktc_turn_phase, kcl_cascade_state,
+                   kmc_compaction, shared_measurement, measurement_turn,
+                   reconcile_data, reconcile_fsm, turn_tick>>
+
+SelectCascade ==                         \* CascadeAfterDecision (abstract)
+    /\ kdp_decision = "guard_ok"
+    /\ shared_measurement /= 0            \* measurement must precede
+    /\ kcl_cascade_state \in {"idle", "selecting"}
+    /\ kcl_cascade_state' = "trying"
+    /\ ktc_turn_phase' = "executing"
+    /\ UNCHANGED <<ksm_phase, kdp_decision, kmc_compaction,
+                   shared_measurement, measurement_turn, reconcile_data,
+                   reconcile_fsm, turn_tick>>
+
+CascadeDone ==
+    /\ kcl_cascade_state = "trying"
+    /\ kcl_cascade_state' = "done"
+    /\ ktc_turn_phase' = "finalizing"
+    /\ UNCHANGED <<ksm_phase, kdp_decision, kmc_compaction,
+                   shared_measurement, measurement_turn, reconcile_data,
+                   reconcile_fsm, turn_tick>>
+
+\* Compaction is coupled: parent phase + turn phase + memory phase
+\* must co-advance (CompactionAtomicity).
+StartCompaction ==
+    /\ ksm_phase = "Running"
+    /\ ktc_turn_phase \in {"idle", "finalizing"}
+    /\ kmc_compaction = "accumulating"
+    /\ ksm_phase' = "Compacting"
+    /\ ktc_turn_phase' = "compacting"
+    /\ kmc_compaction' = "compacting"
+    /\ kcl_cascade_state' = "idle"
+    /\ kdp_decision' = "undecided"
+    /\ UNCHANGED <<shared_measurement, measurement_turn, reconcile_data,
+                   reconcile_fsm, turn_tick>>
+
+FinishCompaction ==
+    /\ ksm_phase = "Compacting"
+    /\ kmc_compaction = "compacting"
+    /\ ksm_phase' = "Running"
+    /\ ktc_turn_phase' = "idle"
+    /\ kmc_compaction' = "done"
+    /\ UNCHANGED <<kdp_decision, kcl_cascade_state, shared_measurement,
+                   measurement_turn, reconcile_data, reconcile_fsm,
+                   turn_tick>>
+
+\* Recovery two-store orchestration (P4 absorption).
+\* Two atomic halves of what keepalive's maybe_recover_from_failing performs.
+
+EnterFailing ==
+    /\ ksm_phase = "Running"
+    /\ reconcile_data' = TRUE
+    /\ reconcile_fsm' = TRUE
+    /\ ksm_phase' = "Failing"
+    /\ ktc_turn_phase' = "idle"
+    /\ UNCHANGED <<kdp_decision, kcl_cascade_state, kmc_compaction,
+                   shared_measurement, measurement_turn, turn_tick>>
+
+ClearDataRecord ==
+    /\ ksm_phase = "Failing"
+    /\ reconcile_data = TRUE
+    /\ reconcile_data' = FALSE
+    /\ UNCHANGED <<ksm_phase, ktc_turn_phase, kdp_decision,
+                   kcl_cascade_state, kmc_compaction, shared_measurement,
+                   measurement_turn, reconcile_fsm, turn_tick>>
+
+ClearFsmCondition ==
+    /\ ksm_phase = "Failing"
+    /\ reconcile_data = FALSE             \* data must be cleared first
+    /\ reconcile_fsm = TRUE
+    /\ reconcile_fsm' = FALSE
+    /\ ksm_phase' = "Running"
+    /\ UNCHANGED <<ktc_turn_phase, kdp_decision, kcl_cascade_state,
+                   kmc_compaction, shared_measurement, measurement_turn,
+                   reconcile_data, turn_tick>>
+
+\* ── Next-state relation ──────────────────────────────────
+
+Next ==
+    \/ StartTurn
+    \/ MeasurementBroadcast
+    \/ DecideGuard
+    \/ SelectCascade
+    \/ CascadeDone
+    \/ StartCompaction
+    \/ FinishCompaction
+    \/ EnterFailing
+    \/ ClearDataRecord
+    \/ ClearFsmCondition
+
+Fairness ==
+    /\ WF_vars(MeasurementBroadcast)
+    /\ WF_vars(DecideGuard)
+    /\ WF_vars(SelectCascade)
+    /\ WF_vars(CascadeDone)
+    /\ WF_vars(FinishCompaction)
+    /\ WF_vars(ClearDataRecord)
+    /\ WF_vars(ClearFsmCondition)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+\* ── Safety invariants (clean cfg must pass) ──────────────
+
+\* I1 — PhaseTurnAlignment
+\* When the parent phase is Compacting, the turn phase and memory phase
+\* must also be in their compacting states. Encodes the post-turn
+\* lifecycle atomicity in keeper_post_turn.ml:45-232.
+PhaseTurnAlignment ==
+    (ksm_phase = "Compacting") =>
+        (ktc_turn_phase = "compacting" /\ kmc_compaction = "compacting")
+
+\* I2 — NoCascadeBeforeMeasurement
+\* Cascade selection cannot advance past idle/selecting without a
+\* measurement having been taken in the current turn.
+NoCascadeBeforeMeasurement ==
+    (kcl_cascade_state \in {"trying", "done"}) =>
+        (shared_measurement /= 0 /\ measurement_turn = turn_tick)
+
+\* I3 — CompactionAtomicity
+\* Memory compaction progress and parent Compacting phase stay consistent:
+\* KMC cannot be in "compacting" while the parent is Running.
+CompactionAtomicity ==
+    (kmc_compaction = "compacting") =>
+        (ksm_phase = "Compacting")
+
+\* I4 — EventPriorityMonotone
+\* At most one measurement per turn (priority 5 cannot fire twice per
+\* turn, keeper_guard.ml). Enforced by the guard in MeasurementBroadcast;
+\* re-asserted as observable invariant for completeness.
+EventPriorityMonotone ==
+    (shared_measurement /= 0) => (measurement_turn <= turn_tick)
+
+\* I5 — RecoveryTwoStoreSync  (absorbs state-fsm-gap-2026-04-13.md P4)
+\* The filesystem reconcile record and the FSM condition must never
+\* reach a permanent disagreement: the FSM condition may only be true
+\* while the data record is also either pending (true) or already
+\* cleared in the same Failing episode. The failure mode is
+\* reconcile_data = FALSE (cleared) but reconcile_fsm still TRUE and
+\* phase stuck at Failing — exactly Bug #1 (PR #6834).
+RecoveryTwoStoreSync ==
+    (ksm_phase = "Failing" /\ reconcile_data = FALSE /\ reconcile_fsm)
+        => FALSE                          \* this state is unreachable
+\* Note: this invariant reads as "the bad state must not exist";
+\* TLC will report a violation only via a buggy transition.
+
+SafetyInvariant ==
+    /\ TypeOK
+    /\ PhaseTurnAlignment
+    /\ NoCascadeBeforeMeasurement
+    /\ CompactionAtomicity
+    /\ EventPriorityMonotone
+
+\* I5 is intentionally NOT bundled into SafetyInvariant because its
+\* shape ("state never reached") is clearer when listed in the cfg as
+\* a separate INVARIANT; see KeeperCompositeLifecycle.cfg.
+
+\* ── Liveness ─────────────────────────────────────────────
+
+\* L1 — EventualMeasurementResolves
+\* Every prompting turn eventually sees a measurement.
+EventualMeasurementResolves ==
+    (ktc_turn_phase = "prompting") ~>
+        (shared_measurement /= 0 \/ ktc_turn_phase /= "prompting")
+
+\* L2 — RecoveryEventuallyCompletes  (absorbs P4 liveness obligation)
+\* A Failing episode must eventually clear both stores and return to
+\* Running. Without WF_vars(ClearDataRecord) + WF_vars(ClearFsmCondition)
+\* this fails, which is the lesson from Bug #1.
+RecoveryEventuallyCompletes ==
+    (ksm_phase = "Failing") ~> (ksm_phase = "Running")
+
+\* ── Bug models (three, each violates a distinct invariant) ──
+
+\* NextBuggyCascade — SelectCascade without measurement
+\* Violates: NoCascadeBeforeMeasurement
+BugCascadeBeforeMeasurement ==
+    /\ kdp_decision = "undecided"         \* skip DecideGuard
+    /\ kcl_cascade_state = "idle"
+    /\ kcl_cascade_state' = "trying"
+    /\ ktc_turn_phase' = "executing"
+    /\ UNCHANGED <<ksm_phase, kdp_decision, kmc_compaction,
+                   shared_measurement, measurement_turn, reconcile_data,
+                   reconcile_fsm, turn_tick>>
+
+NextBuggyCascade == Next \/ BugCascadeBeforeMeasurement
+
+\* NextBuggyCompaction — KMC advances without KSM/KTC coupling
+\* Violates: PhaseTurnAlignment and CompactionAtomicity
+BugCompactionDesync ==
+    /\ ksm_phase = "Running"
+    /\ kmc_compaction = "accumulating"
+    /\ kmc_compaction' = "compacting"     \* BUG: KSM and KTC stay put
+    /\ UNCHANGED <<ksm_phase, ktc_turn_phase, kdp_decision,
+                   kcl_cascade_state, shared_measurement, measurement_turn,
+                   reconcile_data, reconcile_fsm, turn_tick>>
+
+NextBuggyCompaction == Next \/ BugCompactionDesync
+
+\* NextBuggyRecovery — FSM condition cleared without clearing data record
+\* Violates: RecoveryTwoStoreSync (reconstructs Bug #1)
+BugFsmClearsWithoutData ==
+    /\ ksm_phase = "Failing"
+    /\ reconcile_data = TRUE
+    /\ reconcile_fsm = TRUE
+    /\ reconcile_fsm' = FALSE             \* BUG: clears FSM first
+    /\ ksm_phase' = "Running"
+    /\ UNCHANGED <<ktc_turn_phase, kdp_decision, kcl_cascade_state,
+                   kmc_compaction, shared_measurement, measurement_turn,
+                   reconcile_data, turn_tick>>
+
+NextBuggyRecovery == Next \/ BugFsmClearsWithoutData
+
+SpecBuggyCascade    == Init /\ [][NextBuggyCascade]_vars /\ Fairness
+SpecBuggyCompaction == Init /\ [][NextBuggyCompaction]_vars /\ Fairness
+SpecBuggyRecovery   == Init /\ [][NextBuggyRecovery]_vars /\ Fairness
+
+\* ── Boundary comments (reviewer gate) ────────────────────
+\* This spec must NOT introduce any of the following, per:
+\*   memory/feedback_no-lifecycle-invasion-from-masc.md
+\*   memory/feedback_masc-oas-layer-boundary.md
+\*   memory/feedback_masc-model-agnostic.md
+\*   memory/feedback_budget-belongs-in-oas.md
+\* Forbidden in this file (reviewers: grep for these):
+\*   - provider / model identifiers (groq, ollama, claude, ...)
+\*   - token counts or context byte sizes
+\*   - redefinition of transitions owned by sub-specs
+\*   - MASC mutation of OAS-owned state
+
+====


### PR DESCRIPTION
## Summary

**이번 세션은 기획 문서만.** 구현 PR은 이 문서들이 계약으로 고정된 후 별도 세션에서 순차 진행.

- `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` (+ 4 cfg) — projection-style observer spec. 4 도메인 FSM(Decision/Cascade/MemoryCompaction/Compaction-phase) + keepalive two-store recovery를 turn 단위 joint invariants로 관찰. 5 safety + 2 liveness + 3 bug models(서로 다른 invariant 위반).
- `docs/rfc/RFC-0003-keeper-composite-lifecycle.md` (13 sections) — Candidate 3(event-driven projection) 선택 근거, RFC-0002와의 관계, `state-fsm-gap-2026-04-13.md` §5 P4(`KeeperRecoveryOrchestration`)를 별도 spec 대신 `RecoveryTwoStoreSync` invariant로 흡수. Layer boundary(OAS 경계, provider-agnostic, budget in OAS) 명시.
- `docs/design/dashboard-fsm-redesign.md` — 4-페이지 IA(/overview + /keepers/:name + /agents/:id mini strip + 신규 /fsm hub), cascade Mermaid 하드코딩 제거 경로(`keeper_decision_audit.ml:256-315`), Decision FSM dynamic 필드 확장, Memory tier panel + Compaction sub-FSM, SSE + cache 강등, 6-Phase PR 롤아웃 표, 검증 전략.

## Why

- 현재 FSM/TLA 시각화가 `keeper-detail.ts:509`에만 존재. `/agents/:id`, `/overview`, 통합 뷰 부재.
- Cascade Mermaid(`keeper_decision_audit.ml:256-315`)와 Decision FSM 그래프가 부분적으로 하드코딩. 실제 runtime state(provider health, slot, last_provider_result, guard penalty, tool policy mode, turn outcome) 반영 안 됨.
- Memory 5-tier(정확히는 `keeper_memory_policy.ml:447-451` kind_caps)와 Compaction sub-state는 UI에 전혀 없음.
- 기존 composite spec 3개(`KeeperCoreTriad.tla`, `StateProduct.tla`, `KeeperContextLifecycle.tla`)가 각자 부분 영역만 커버. 네 도메인 FSM 사이의 joint invariants + recovery two-store orchestration은 어느 spec도 검증하지 않음 → Bug #1(PR #6834, `keeper_keepalive.ml:774-836`)의 근본.

## 관계 정리

| 축 | 이 PR 커버 |
|----|------------|
| RFC-0002 (11-state parent FSM) | 그대로. transition 추가 없음. RFC-0003은 11→6 phase projection만 수행 |
| `KeeperCoreTriad.tla` (State × Decision × Cascade, 5-phase) | 유지. RFC-0003이 observer로 보완 |
| `StateProduct.tla` (Keeper × Turn × Validation) | 유지. RFC-0003의 `ktc_turn_phase` 축과 정렬 |
| `KeeperContextLifecycle.tla` (Context + Compaction + Checkpoint) | 유지. RFC-0003이 context-level 세부를 재정의하지 않음 |
| `state-fsm-gap-2026-04-13.md` P4 | 흡수(별도 spec 파일 미생성) |
| `state-fsm-gap-2026-04-13.md` P1 (`TurnSucceeded` divergence) | 직교, 별도 PR |

## Test plan

- [ ] 문서 3종 링크가 서로 정확히 참조하는지 수동 확인 (RFC↔Spec↔Redesign)
- [ ] TLA+ spec syntactic 검증: `cd specs/keeper-state-machine && java -jar tla2tools.jar -parse KeeperCompositeLifecycle.tla`
- [ ] Clean cfg TLC 실행: `java -jar tla2tools.jar -config KeeperCompositeLifecycle.cfg KeeperCompositeLifecycle.tla` → "no error"
- [ ] 3개 buggy cfg TLC 실행: 각각 **서로 다른** invariant 위반 확인 (Cascade→NoCascadeBeforeMeasurement, Compaction→CompactionAtomicity+PhaseTurnAlignment, Recovery→RecoveryTwoStoreSync)
- [ ] Layer boundary 수동 검토: provider/model 이름 리터럴, 토큰 추정, MASC에서의 sub-FSM transition 소유권 변경이 없음을 리뷰에서 확인
- [ ] `docs/design/dashboard-fsm-redesign.md` Phase 1~6 테이블이 후속 PR로 분해 가능한 단위인지 검토

## 비고

- TLC 실행 자체는 이번 세션에서 하지 않았음. skeleton이 syntactic하게 맞는지는 다음 세션(redesign plan Phase 2)에서 검증 후 필요시 follow-up PR로 조정.
- `KeeperCompositeLifecycle.tla:389`에 "provider/model identifiers (groq, ollama, claude, ...)" 라인이 있는데, 이는 **금지 대상을 명시한 boundary comment**로 의도된 메타 참조. 향후 CI lint 도입 시 `ALLOW-NOLINT` 토큰 등으로 예외 처리 필요.
- 이 PR은 Draft. 리뷰 완료 + TLC 통과 후 Ready로 전환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)