### PR TITLE
refactor(dashboard): remove unused config binding in ordered_room_ids

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -241,8 +241,7 @@ let tempo_section (config : Room_utils.config) : section =
   let content = [Tempo.format_state state] in
   { title = "Tempo"; content; empty_msg = "" }
 
-let ordered_room_ids (config : Room_utils.config) =
-  let _ = config in
+let ordered_room_ids (_config : Room_utils.config) =
   let current_room = "default" in
   (current_room, [ current_room ])
 


### PR DESCRIPTION
## Summary

Remove dead code: unused config binding in ordered_room_ids.

## Product impact

No behavioral change. Function signature unchanged (parameter renamed to _config).

## Evidence

- `let _ = config in` removed from ordered_room_ids
- Caller sites (2 places) unchanged — pass config argument as before
- No .mli file — signature not exposed
- Net diff: +1 -2

## Review evidence

Before: `let ordered_room_ids (config : Room_utils.config) = let _ = config in ...`
After: `let ordered_room_ids (_config : Room_utils.config) = ...`

Parameter renamed to `_config` to signal intentional unused parameter. Type annotation preserved.

## Linked issue

Relates task-004
