### PR TITLE
fix(keeper_recurring): serialize tasks Hashtbl + atomic id_counter

### DIFF
--- a/lib/keeper/keeper_recurring.ml
+++ b/lib/keeper/keeper_recurring.ml
@@ -28,16 +28,33 @@ type recurring_task = {
 
 let tasks : (string, recurring_task) Hashtbl.t = Hashtbl.create 16
 
+(** Mutex protecting [tasks] and [id_counter].  The module header and
+    [.mli] advertise thread-safety, but the previous implementation had
+    no serialisation — [Hashtbl.replace]/[remove]/[fold] ran from every
+    keeper heartbeat loop concurrently, and [id_counter] used the
+    [incr; !] split pattern that lets two fibers observe the same
+    post-increment value and emit duplicate task IDs.  Use
+    [Eio_guard.with_mutex] so code paths that run before [Eio_main.run]
+    (module init, non-Eio tests) still work without triggering
+    [Effect.Unhandled]. *)
+let tasks_mu = Eio.Mutex.create ()
+let with_tasks_rw f = Eio_guard.with_mutex tasks_mu f
+let with_tasks_ro f = Eio_guard.with_mutex_ro tasks_mu f
+
 (* ================================================================ *)
 (* ID generation                                                     *)
 (* ================================================================ *)
 
-let id_counter = ref 0
+let id_counter = Atomic.make 0
 
 let generate_id () =
-  incr id_counter;
+  (* [fetch_and_add] returns the pre-increment value; +1 gives the
+     fresh ticket.  Prevents the [incr; !] race where two fibers read
+     the same post-increment value and produce duplicate IDs within
+     the same millisecond. *)
+  let seq = Atomic.fetch_and_add id_counter 1 + 1 in
   let ts = int_of_float (Unix.gettimeofday () *. 1000.0) mod 100_000 in
-  Printf.sprintf "loop-%d-%d" ts !id_counter
+  Printf.sprintf "loop-%d-%d" ts seq
 
 (* ================================================================ *)
 (* CRUD                                                              *)
@@ -50,35 +67,43 @@ let add ~keeper_name ~label ~interval_sec ?(max_failures = 5) action =
     last_run_ts = 0.0; run_count = 0; failure_count = 0;
     max_failures; enabled = true;
   } in
-  Hashtbl.replace tasks id task;
+  with_tasks_rw (fun () -> Hashtbl.replace tasks id task);
   task
 
 let remove ~id =
-  if Hashtbl.mem tasks id then begin
-    Hashtbl.remove tasks id; true
-  end else false
+  with_tasks_rw (fun () ->
+    if Hashtbl.mem tasks id then begin
+      Hashtbl.remove tasks id; true
+    end else false)
 
 let list ~keeper_name =
-  Hashtbl.fold (fun _id task acc ->
-    if task.keeper_name = keeper_name then task :: acc else acc
-  ) tasks []
+  with_tasks_ro (fun () ->
+    Hashtbl.fold (fun _id task acc ->
+      if task.keeper_name = keeper_name then task :: acc else acc
+    ) tasks [])
 
 let list_all () =
-  Hashtbl.fold (fun _id task acc -> task :: acc) tasks []
+  with_tasks_ro (fun () ->
+    Hashtbl.fold (fun _id task acc -> task :: acc) tasks [])
 
 (* ================================================================ *)
 (* Dispatch                                                          *)
 (* ================================================================ *)
 
 let dispatch_due ~keeper_name ~now_ts ~dispatch =
+  (* Snapshot due tasks under the lock so [add]/[remove] cannot mutate
+     the table while we iterate; then release the lock before invoking
+     [dispatch], which runs arbitrary user code that may yield or call
+     back into this module. *)
   let due_tasks =
-    Hashtbl.fold (fun _id task acc ->
-      if task.keeper_name = keeper_name
-         && task.enabled
-         && now_ts -. task.last_run_ts >= float_of_int task.interval_sec
-      then task :: acc
-      else acc
-    ) tasks []
+    with_tasks_ro (fun () ->
+      Hashtbl.fold (fun _id task acc ->
+        if task.keeper_name = keeper_name
+           && task.enabled
+           && now_ts -. task.last_run_ts >= float_of_int task.interval_sec
+        then task :: acc
+        else acc
+      ) tasks [])
   in
   let count = ref 0 in
   List.iter (fun task ->
@@ -122,4 +147,4 @@ let task_to_json (t : recurring_task) : Yojson.Safe.t =
 (* ================================================================ *)
 
 let clear () =
-  Hashtbl.clear tasks
+  with_tasks_rw (fun () -> Hashtbl.clear tasks)


### PR DESCRIPTION
## Summary

`Keeper_recurring` advertised thread-safety in both its module header (\"Thread-safe via Eio.Mutex guarded by Eio_guard\") and its `.mli` (\"Thread-safe: protected by Eio.Mutex when available\"), but the implementation had neither a mutex nor atomic counters.

Two concrete races:

1. **Duplicate task IDs** — `id_counter = ref 0` + `incr id_counter; ... ; !id_counter` is the split-atomic pattern: two fibers can both run `incr` before either reads, both read the same post-increment value, and `generate_id` produces identical `loop-<ts>-<n>` strings when called within the same millisecond. Same bug class as #6983 (metric/task/thread IDs).

2. **Unsynchronized `tasks` Hashtbl** — `add`/`remove`/`list`/`list_all`/`dispatch_due`/`clear` all hit the same module-level `Hashtbl.t` directly. `Hashtbl.replace` and `Hashtbl.fold` are not safe to interleave. Under multi-keeper deployments every heartbeat loop shares the table.

## Change

- `id_counter` → `Atomic.t` with `fetch_and_add` (same idiom used by PR #6983 for heartbeat/metric/task IDs).
- Add `tasks_mu : Eio.Mutex.t` + `with_tasks_rw` / `with_tasks_ro` helpers wired through `Eio_guard.with_mutex` so module-init and non-Eio test paths still work without `Effect.Unhandled`.
- Wrap every Hashtbl access in the appropriate RW/RO critical section.
- `dispatch_due` snapshots the due list under the lock, then releases before invoking the caller-supplied `dispatch` (which runs arbitrary user code that may yield or re-enter this module).
- Per-task field mutations (`last_run_ts`, `run_count`, `failure_count`, `enabled`) remain lock-free because each recurring task is owned by a single keeper heartbeat loop — no cross-fiber contention on those fields.
- Updated the comment block on `tasks_mu` to record the reason for the lock, matching the style used elsewhere in `lib/keeper` and `lib/room`.

No `.mli` change — the public contract was already correct; the implementation caught up.

## Test plan

- [x] `dune build --root . lib/` — clean
- [ ] CI full suite (runs on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)