### PR TITLE
[codex] Add rich board and task content previews

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -276,13 +276,14 @@ export function sanitizeBoardTitle(title: string, fallbackBody = ''): string {
 
 function normalizeBoardMeta(raw: unknown): BoardPost['meta'] {
   if (!isRecord(raw)) return null
-  const source = asString(raw.source, '').trim() || null
-  const stateBlock = asString(raw.state_block, '').trim() || null
-  if (!source && !stateBlock) return null
-  return {
-    source,
-    state_block: stateBlock,
-  }
+  const next: Record<string, unknown> = { ...raw }
+  const source = asString(raw.source, '').trim()
+  const stateBlock = asString(raw.state_block, '').trim()
+  const classificationReason = asString(raw.classification_reason, '').trim()
+  if (source) next.source = source
+  if (stateBlock) next.state_block = stateBlock
+  if (classificationReason) next.classification_reason = classificationReason
+  return Object.keys(next).length > 0 ? next : null
 }
 
 function normalizeBoardPost(raw: unknown): BoardPost | null {

--- a/dashboard/src/api/link-previews.ts
+++ b/dashboard/src/api/link-previews.ts
@@ -1,0 +1,94 @@
+import { post } from './core'
+import { isRecord, asString } from '../components/common/normalize'
+
+export type LinkPreviewKind = 'link' | 'image'
+
+export interface LinkPreview {
+  url: string
+  kind: LinkPreviewKind
+  canonical_url?: string | null
+  title?: string | null
+  description?: string | null
+  site_name?: string | null
+  image_url?: string | null
+  favicon_url?: string | null
+  content_type?: string | null
+  fetched_at?: string | null
+  cache_state?: string | null
+}
+
+interface LinkPreviewResponse {
+  previews?: Record<string, unknown>
+  errors?: Record<string, unknown>
+}
+
+interface CacheEntry {
+  preview: LinkPreview | null
+  expiresAt: number
+}
+
+const LOCAL_PREVIEW_TTL_MS = 15 * 60 * 1000
+const LOCAL_ERROR_TTL_MS = 5 * 60 * 1000
+const previewCache = new Map<string, CacheEntry>()
+
+function normalizeLinkPreview(raw: unknown): LinkPreview | null {
+  if (!isRecord(raw)) return null
+  const url = asString(raw.url)
+  const kind = asString(raw.kind)
+  if (!url || (kind !== 'link' && kind !== 'image')) return null
+  return {
+    url,
+    kind,
+    canonical_url: asString(raw.canonical_url) ?? null,
+    title: asString(raw.title) ?? null,
+    description: asString(raw.description) ?? null,
+    site_name: asString(raw.site_name) ?? null,
+    image_url: asString(raw.image_url) ?? null,
+    favicon_url: asString(raw.favicon_url) ?? null,
+    content_type: asString(raw.content_type) ?? null,
+    fetched_at: asString(raw.fetched_at) ?? null,
+    cache_state: asString(raw.cache_state) ?? null,
+  }
+}
+
+function shouldUseCached(entry: CacheEntry | undefined): entry is CacheEntry {
+  return Boolean(entry && entry.expiresAt > Date.now())
+}
+
+export async function fetchLinkPreviews(urls: string[]): Promise<Record<string, LinkPreview>> {
+  const uniqueUrls = [...new Set(urls.map(url => url.trim()).filter(Boolean))].slice(0, 8)
+  if (uniqueUrls.length === 0) return {}
+
+  const result: Record<string, LinkPreview> = {}
+  const missing: string[] = []
+
+  for (const url of uniqueUrls) {
+    const cached = previewCache.get(url)
+    if (shouldUseCached(cached)) {
+      if (cached.preview) result[url] = cached.preview
+      continue
+    }
+    missing.push(url)
+  }
+
+  if (missing.length === 0) return result
+
+  const raw = await post<LinkPreviewResponse>('/api/v1/dashboard/link-previews', { urls: missing })
+  const previews = isRecord(raw.previews) ? raw.previews : {}
+  const errors = isRecord(raw.errors) ? raw.errors : {}
+
+  for (const url of missing) {
+    const preview = normalizeLinkPreview(previews[url])
+    if (preview) {
+      previewCache.set(url, { preview, expiresAt: Date.now() + LOCAL_PREVIEW_TTL_MS })
+      result[url] = preview
+      continue
+    }
+
+    if (errors[url] !== undefined) {
+      previewCache.set(url, { preview: null, expiresAt: Date.now() + LOCAL_ERROR_TTL_MS })
+    }
+  }
+
+  return result
+}

--- a/dashboard/src/components/common/rich-composer.ts
+++ b/dashboard/src/components/common/rich-composer.ts
@@ -1,0 +1,81 @@
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { TextArea } from './input'
+import { RichContent } from './rich-content'
+
+type ComposerMode = 'write' | 'preview'
+
+export function RichComposer({
+  value,
+  onValueChange,
+  placeholder,
+  rows = 6,
+  disabled,
+  helpText,
+  previewLimit = 2,
+}: {
+  value: string
+  onValueChange: (next: string) => void
+  placeholder?: string
+  rows?: number
+  disabled?: boolean
+  helpText?: string
+  previewLimit?: number
+}) {
+  const [mode, setMode] = useState<ComposerMode>('write')
+
+  return html`
+    <div class="rounded-xl border border-[var(--card-border)] bg-[rgba(8,13,22,0.88)]">
+      <div class="flex items-center justify-between gap-3 border-b border-[var(--card-border)] px-3 py-2">
+        <div class="flex items-center gap-1.5">
+          ${(['write', 'preview'] as ComposerMode[]).map(tab => html`
+            <button
+              key=${tab}
+              type="button"
+              class=${`rounded-lg border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                mode === tab
+                  ? 'border-[rgba(71,184,255,0.35)] bg-[var(--accent-12)] text-[var(--accent)]'
+                  : 'border-transparent bg-transparent text-[var(--text-muted)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)]'
+              }`}
+              onClick=${() => setMode(tab)}
+              disabled=${disabled}
+            >
+              ${tab === 'write' ? 'Write' : 'Preview'}
+            </button>
+          `)}
+        </div>
+        <div class="text-[10px] text-[var(--text-muted)]">
+          Markdown, code fence, URL, image link
+        </div>
+      </div>
+
+      <div class="p-3">
+        ${mode === 'write'
+          ? html`
+              <${TextArea}
+                value=${value}
+                placeholder=${placeholder}
+                rows=${rows}
+                disabled=${disabled}
+                class="min-h-[140px]"
+                onInput=${(event: Event) => onValueChange((event.target as HTMLTextAreaElement).value)}
+              />
+            `
+          : value.trim()
+            ? html`
+                <div class="max-h-[320px] overflow-auto rounded-lg border border-[var(--card-border)] bg-[var(--bg-0)] p-3 custom-scrollbar">
+                  <${RichContent} text=${value} previewLimit=${previewLimit} />
+                </div>
+              `
+            : html`
+                <div class="rounded-lg border border-dashed border-[var(--card-border)] bg-[var(--white-3)] px-3 py-6 text-center text-[12px] text-[var(--text-muted)]">
+                  미리볼 내용이 아직 없습니다.
+                </div>
+              `}
+        ${helpText
+          ? html`<div class="mt-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${helpText}</div>`
+          : null}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/common/rich-content-utils.test.ts
+++ b/dashboard/src/components/common/rich-content-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  convertStandaloneImageUrlsToMarkdown,
+  extractPreviewUrls,
+  extractStandaloneImageUrls,
+  prepareRichContent,
+} from './rich-content-utils'
+
+describe('rich-content-utils', () => {
+  it('converts standalone image URLs into markdown images', () => {
+    const source = 'before\nhttps://example.com/cat.png\nafter'
+    const output = convertStandaloneImageUrlsToMarkdown(source)
+    expect(output).toContain('![](<https://example.com/cat.png>)')
+  })
+
+  it('extracts standalone image URLs separately', () => {
+    const source = 'https://example.com/cat.png\nhello'
+    expect(extractStandaloneImageUrls(source)).toEqual(['https://example.com/cat.png'])
+  })
+
+  it('does not create preview cards for standalone image URLs', () => {
+    const source = 'https://example.com/cat.png\nhttps://example.com/post'
+    expect(extractPreviewUrls(source)).toEqual(['https://example.com/post'])
+  })
+
+  it('ignores markdown image URLs when collecting preview cards', () => {
+    const source = '![alt](https://example.com/cat.png)\nhttps://example.com/post'
+    expect(extractPreviewUrls(source)).toEqual(['https://example.com/post'])
+  })
+
+  it('prepares markdown text and previews together', () => {
+    const prepared = prepareRichContent(
+      '```ts\nconst x = 1\n```\nhttps://example.com/card',
+      2,
+    )
+    expect(prepared.markdownText).toContain('```ts')
+    expect(prepared.previewUrls).toEqual(['https://example.com/card'])
+  })
+})

--- a/dashboard/src/components/common/rich-content-utils.ts
+++ b/dashboard/src/components/common/rich-content-utils.ts
@@ -1,0 +1,68 @@
+const URL_PATTERN = /https?:\/\/[^\s<>"')\]]+[^\s<>"'.,;:!?)]/gi
+const MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*]\((https?:\/\/[^)\s]+)\)/gi
+const STANDALONE_URL_PATTERN = /^<?(https?:\/\/\S+)>?$/
+
+const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.avif']
+
+export function isImageUrl(url: string): boolean {
+  const normalized = url.toLowerCase()
+  return IMAGE_EXTENSIONS.some(ext => normalized.endsWith(ext))
+}
+
+function cleanUrl(url: string): string {
+  return url.replace(/[)>.,;:!?]+$/g, '')
+}
+
+export function convertStandaloneImageUrlsToMarkdown(text: string): string {
+  return text
+    .split('\n')
+    .map(line => {
+      const trimmed = line.trim()
+      const match = trimmed.match(STANDALONE_URL_PATTERN)
+      if (!match) return line
+      const url = cleanUrl(match[1] ?? '')
+      if (!url || !isImageUrl(url)) return line
+      return line.replace(trimmed, `![](<${url}>)`)
+    })
+    .join('\n')
+}
+
+export function extractStandaloneImageUrls(text: string): string[] {
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .map(line => line.match(STANDALONE_URL_PATTERN)?.[1] ?? '')
+    .map(cleanUrl)
+    .filter(url => url !== '' && isImageUrl(url))
+}
+
+export function extractPreviewUrls(text: string, maxCount = 4): string[] {
+  if (maxCount <= 0) return []
+  const excluded = new Set<string>(extractStandaloneImageUrls(text))
+  const withoutMarkdownImages = text.replace(MARKDOWN_IMAGE_PATTERN, '')
+  const urls = withoutMarkdownImages.match(URL_PATTERN) ?? []
+  const deduped: string[] = []
+
+  for (const raw of urls) {
+    const url = cleanUrl(raw)
+    if (!url || excluded.has(url) || isImageUrl(url)) continue
+    if (!deduped.includes(url)) deduped.push(url)
+    if (deduped.length >= maxCount) break
+  }
+
+  return deduped
+}
+
+export function prepareRichContent(text: string, previewLimit = 4): {
+  markdownText: string
+  previewUrls: string[]
+} {
+  return {
+    markdownText: convertStandaloneImageUrlsToMarkdown(text),
+    previewUrls: extractPreviewUrls(text, previewLimit),
+  }
+}
+
+export function hasRichMarkdownSignals(text: string): boolean {
+  return /(^|\n)(`{3,}|~{3,}|#{1,6}\s+|[-*+]\s+|\d+\.\s+|>\s+|!\[[^\]]*]\(|https?:\/\/\S+)/m.test(text)
+}

--- a/dashboard/src/components/common/rich-content.ts
+++ b/dashboard/src/components/common/rich-content.ts
@@ -1,0 +1,90 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+import { Markdown } from './markdown'
+import { fetchLinkPreviews, type LinkPreview } from '../../api/link-previews'
+import { prepareRichContent } from './rich-content-utils'
+
+function previewCard(preview: LinkPreview) {
+  const href = preview.canonical_url || preview.url
+  const title = preview.title || preview.site_name || preview.url
+  const description = preview.description || ''
+  const imageUrl = preview.image_url || null
+  const faviconUrl = preview.favicon_url || null
+  const hostLabel = (() => {
+    try {
+      return new URL(href).hostname
+    } catch {
+      return preview.site_name || preview.url
+    }
+  })()
+
+  return html`
+    <a
+      key=${preview.url}
+      href=${href}
+      target="_blank"
+      rel="noreferrer"
+      class="group flex overflow-hidden rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] text-inherit no-underline transition-colors hover:border-[var(--accent-20)] hover:bg-[var(--white-5)]"
+    >
+      ${imageUrl
+        ? html`
+            <div class="w-[112px] shrink-0 bg-[var(--white-5)]">
+              <img src=${imageUrl} alt=${title} class="block h-full w-full object-cover" loading="lazy" />
+            </div>
+          `
+        : null}
+      <div class="min-w-0 flex-1 px-3 py-2.5">
+        <div class="flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
+          ${faviconUrl ? html`<img src=${faviconUrl} alt="" class="h-3.5 w-3.5 rounded-sm" loading="lazy" />` : null}
+          <span class="truncate">${preview.site_name || hostLabel}</span>
+        </div>
+        <div class="mt-1 text-[12px] font-semibold leading-snug text-[var(--text-strong)] group-hover:text-[var(--accent)]">
+          ${title}
+        </div>
+        ${description
+          ? html`<div class="mt-1 line-clamp-3 text-[11px] leading-relaxed text-[var(--text-muted)]">${description}</div>`
+          : null}
+      </div>
+    </a>
+  `
+}
+
+export function RichContent({
+  text,
+  class: className,
+  previewLimit = 4,
+}: {
+  text: string
+  class?: string
+  previewLimit?: number
+}) {
+  const prepared = useMemo(() => prepareRichContent(text, previewLimit), [text, previewLimit])
+  const [previews, setPreviews] = useState<Record<string, LinkPreview>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    if (prepared.previewUrls.length === 0) {
+      setPreviews({})
+      return
+    }
+    void fetchLinkPreviews(prepared.previewUrls)
+      .then(next => { if (!cancelled) setPreviews(next) })
+      .catch(() => { if (!cancelled) setPreviews({}) })
+    return () => { cancelled = true }
+  }, [prepared.previewUrls.join('|')])
+
+  if (!text) return null
+
+  const cards = prepared.previewUrls
+    .map(url => previews[url])
+    .filter((preview): preview is LinkPreview => Boolean(preview))
+
+  return html`
+    <div class="flex flex-col gap-3">
+      <${Markdown} text=${prepared.markdownText} class=${className} />
+      ${cards.length > 0
+        ? html`<div class="grid gap-2">${cards.map(card => previewCard(card))}</div>`
+        : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -9,12 +9,12 @@ import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
 import { TimeAgo } from '../common/time-ago'
+import { RichContent } from '../common/rich-content'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
 import { tasksByStatus, refreshExecution, executionLoading, executionLoaded, executionError } from '../../store'
 import { deleteTask } from '../../api/actions'
 import type { Task } from '../../types'
-import { truncate } from '../../lib/truncate'
 import {
   expandedTasks,
   toggleTaskExpand,
@@ -65,8 +65,7 @@ export function KanbanCard({ task }: { task: Task }) {
   const hasDescription = Boolean(task.description)
   const isDeleting = deletingTaskId.value === task.id
   const description = task.description ?? ''
-  const canExpand = description.length > 140
-  const preview = isExpanded || !canExpand ? description : truncate(description, 140)
+  const canExpand = description.length > 160
   const scope = taskScope(task)
   const link = taskLink(task)
 
@@ -115,7 +114,9 @@ export function KanbanCard({ task }: { task: Task }) {
 
       ${hasDescription ? html`
         <div class="flex flex-col gap-2">
-          <div class="text-[13px] leading-relaxed text-text-body whitespace-pre-wrap break-words">${preview}</div>
+          <div class=${`overflow-hidden text-[13px] leading-relaxed text-text-body ${isExpanded || !canExpand ? '' : 'max-h-[9rem]'}`}>
+            <${RichContent} text=${description} previewLimit=${1} />
+          </div>
           ${canExpand ? html`
             <button
               type="button"

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -7,6 +7,7 @@ import { DialogOverlay } from '../common/dialog'
 import { StatusBadge } from '../common/status-badge'
 import { EmptyState } from '../common/empty-state'
 import { ErrorState, LoadingState } from '../common/feedback-state'
+import { RichContent } from '../common/rich-content'
 import { TimeAgo } from '../common/time-ago'
 import { findKeeper } from '../../lib/keeper-utils'
 import {
@@ -68,7 +69,7 @@ function TaskEventsSection() {
                 <span class="text-[12px] font-medium text-text-strong">${evt.label}</span>
                 ${evt.agent ? html`<span class="text-[10px] text-accent">@${evt.agent}${evt.actorKind ? ` · ${evt.actorKind}` : ''}</span>` : null}
               </div>
-              ${evt.notes ? html`<div class="mt-0.5 text-[11px] text-text-muted whitespace-pre-wrap">${evt.notes}</div>` : null}
+              ${evt.notes ? html`<div class="mt-1 text-[11px] text-text-muted"><${RichContent} text=${evt.notes} previewLimit=${1} /></div>` : null}
             </div>
             ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} class="text-[10px] text-text-dim shrink-0" />` : null}
           </div>
@@ -191,7 +192,7 @@ function HandoffSection({ task }: { task: Task }) {
     <div>
       <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">최근 Handoff</div>
       <div class="rounded-xl border border-warn/20 bg-warn/8 px-4 py-3">
-        <div class="text-[13px] leading-relaxed text-text-body whitespace-pre-wrap">${handoff.summary}</div>
+        <div class="text-[13px] leading-relaxed text-text-body"><${RichContent} text=${handoff.summary} previewLimit=${2} /></div>
         ${handoff.reason ? html`<div class="mt-2 text-[11px] text-text-muted">reason: ${handoff.reason}</div>` : null}
         ${handoff.next_step ? html`<div class="mt-1 text-[11px] text-text-muted">next: ${handoff.next_step}</div>` : null}
         ${handoff.failure_mode ? html`<div class="mt-1 text-[11px] text-text-muted">failure: ${handoff.failure_mode}</div>` : null}
@@ -295,7 +296,9 @@ export function TaskDetailOverlay() {
           ${task.description ? html`
             <div>
               <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted mb-2">설명</div>
-              <div class="text-[13px] leading-relaxed text-text-body whitespace-pre-wrap break-words">${task.description}</div>
+              <div class="rounded-xl border border-[var(--white-10)] bg-[var(--white-3)] px-4 py-3 text-[13px] leading-relaxed text-text-body">
+                <${RichContent} text=${task.description} previewLimit=${2} />
+              </div>
             </div>
           ` : null}
 

--- a/dashboard/src/components/memory-post-detail.test.ts
+++ b/dashboard/src/components/memory-post-detail.test.ts
@@ -33,6 +33,7 @@ vi.mock('./common/empty-state', () => ({
 
 vi.mock('./common/input', () => ({
   TextInput: (props: Record<string, unknown>) => h('input', props),
+  TextArea: (props: Record<string, unknown>) => h('textarea', props),
 }))
 
 vi.mock('./memory-state', () => ({

--- a/dashboard/src/components/memory-post-detail.ts
+++ b/dashboard/src/components/memory-post-detail.ts
@@ -2,11 +2,11 @@ import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
-import { Markdown } from './common/markdown'
 import { showToast } from './common/toast'
 import { EmptyState } from './common/empty-state'
 import { LoadingState } from './common/feedback-state'
-import { TextInput } from './common/input'
+import { RichComposer } from './common/rich-composer'
+import { RichContent } from './common/rich-content'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate } from '../router'
 import { navigateToAuthor } from '../lib/board-utils'
@@ -90,7 +90,7 @@ function CommentItem({
             onClick=${() => { replyingTo.value = isReplying ? null : comment.id; commentText.value = '' }}
           >${isReplying ? '취소' : '답글'}</button>
         </div>
-        <div class="text-[13px] text-[var(--text-body)] leading-[1.55]"><${Markdown} text=${displayText} /></div>
+        <div class="text-[13px] text-[var(--text-body)] leading-[1.55]"><${RichContent} text=${displayText} previewLimit=${1} /></div>
         ${needsTruncation ? html`
           <button type="button"
             class="mt-1 text-[11px] text-[var(--accent)] hover:underline cursor-pointer bg-transparent border-0"
@@ -98,26 +98,29 @@ function CommentItem({
           >${expanded ? '접기' : '더 보기...'}</button>
         ` : null}
         ${isReplying ? html`
-          <div class="mt-2 flex gap-2">
-            <${TextInput}
-              class="flex-1"
-              placeholder="답글 작성..."
+          <div class="mt-2">
+            <${RichComposer}
               value=${commentText.value}
-              onInput=${(event: Event) => { commentText.value = (event.target as HTMLInputElement).value }}
-              onKeyDown=${(event: KeyboardEvent) => { if (event.key === 'Enter') submitComment(postId, comment.id) }}
+              placeholder="답글 작성..."
+              rows=${4}
               disabled=${commentSubmitting.value}
+              onValueChange=${(next: string) => { commentText.value = next }}
+              helpText="Markdown과 코드 스니펫을 그대로 붙일 수 있습니다."
+              previewLimit=${1}
             />
-            <button type="button"
-              class="py-1.5 px-3 rounded-lg text-[12px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
-                ${commentSubmitting.value || commentText.value.trim() === ''
-                  ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
-                  : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
-                }"
-              onClick=${() => submitComment(postId, comment.id)}
-              disabled=${commentSubmitting.value || commentText.value.trim() === ''}
-            >
-              ${commentSubmitting.value ? '...' : '등록'}
-            </button>
+            <div class="mt-2 flex justify-end">
+              <button type="button"
+                class="py-1.5 px-3 rounded-lg text-[12px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
+                  ${commentSubmitting.value || commentText.value.trim() === ''
+                    ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
+                    : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
+                  }"
+                onClick=${() => submitComment(postId, comment.id)}
+                disabled=${commentSubmitting.value || commentText.value.trim() === ''}
+              >
+                ${commentSubmitting.value ? '...' : '등록'}
+              </button>
+            </div>
           </div>
         ` : null}
       </div>
@@ -163,26 +166,29 @@ export function CommentThread({ comments, postId }: { comments: BoardComment[]; 
 // ── Comment form ───────────────────────────────────────────────────
 function CommentForm({ postId }: { postId: string }) {
   return html`
-    <div class="mt-4 flex gap-2">
-      <${TextInput}
-        class="flex-1"
-        placeholder="댓글 추가..."
+    <div class="mt-4">
+      <${RichComposer}
         value=${commentText.value}
-        onInput=${(event: Event) => { commentText.value = (event.target as HTMLInputElement).value }}
-        onKeyDown=${(event: KeyboardEvent) => { if (event.key === 'Enter') submitComment(postId) }}
+        placeholder="댓글 추가..."
+        rows=${5}
         disabled=${commentSubmitting.value}
+        onValueChange=${(next: string) => { commentText.value = next }}
+        helpText="Markdown, 코드 스니펫, URL 링크 카드를 지원합니다."
+        previewLimit=${1}
       />
-      <button type="button"
-        class="py-2 px-4 rounded-lg text-[13px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
-          ${commentSubmitting.value || commentText.value.trim() === ''
-            ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
-            : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
-          }"
-        onClick=${() => submitComment(postId)}
-        disabled=${commentSubmitting.value || commentText.value.trim() === ''}
-      >
-        ${commentSubmitting.value ? '...' : '등록'}
-      </button>
+      <div class="mt-2 flex justify-end">
+        <button type="button"
+          class="py-2 px-4 rounded-lg text-[13px] font-medium font-[inherit] cursor-pointer transition-all duration-150 border
+            ${commentSubmitting.value || commentText.value.trim() === ''
+              ? 'bg-[var(--white-5)] text-[var(--text-muted)] border-[var(--border-slate-12)] opacity-50 cursor-not-allowed'
+              : 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)] hover:bg-[var(--ok-22)]'
+            }"
+          onClick=${() => submitComment(postId)}
+          disabled=${commentSubmitting.value || commentText.value.trim() === ''}
+        >
+          ${commentSubmitting.value ? '...' : '등록'}
+        </button>
+      </div>
     </div>
   `
 }
@@ -219,7 +225,7 @@ export function PostDetail({ post }: { post: BoardPost }) {
           </div>
 
           <div class="text-[13px] text-[var(--text-body)] leading-[1.65]">
-            <${Markdown} text=${stripStateBlocks(post.body)} />
+            <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
           </div>
 
           <!-- Author and meta -->

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -6,12 +6,14 @@ import { showToast } from './common/toast'
 import { requestConfirm } from './common/confirm-dialog'
 import { EmptyState } from './common/empty-state'
 import { LoadingState } from './common/feedback-state'
-import { Markdown } from './common/markdown'
-import { TextInput, TextArea } from './common/input'
+import { TextInput } from './common/input'
+import { RichComposer } from './common/rich-composer'
+import { RichContent } from './common/rich-content'
 import { stripStateBlocks } from '../keeper-message'
 import { navigate, navigateToPost, route } from '../router'
 import { PostDetail } from './memory-post-detail'
 import { stripInlineMarkdown, navigateToAuthor } from '../lib/board-utils'
+import { hasRichMarkdownSignals } from './common/rich-content-utils'
 import {
   boardPosts,
   boardSortMode,
@@ -53,10 +55,6 @@ import {
   deleteBoardPost,
 } from './memory-state'
 import type { BoardPost } from './memory-state'
-
-function hasRichMarkdownPreview(text: string): boolean {
-  return /(^|\n)(`{3,}|~{3,}|#{1,6}\s+|[-*+]\s+|\d+\.\s+|>\s+)/m.test(text)
-}
 
 // ── Render section (paginated group) ───────────────────────────────
 function renderSection(
@@ -105,10 +103,13 @@ function NewPostForm() {
         value=${newPostTitle.value}
         onInput=${(e: Event) => { newPostTitle.value = (e.target as HTMLInputElement).value }}
       />
-      <${TextArea}
-        placeholder="내용을 입력하세요..."
+      <${RichComposer}
         value=${newPostContent.value}
-        onInput=${(e: Event) => { newPostContent.value = (e.target as HTMLTextAreaElement).value }}
+        onValueChange=${(next: string) => { newPostContent.value = next }}
+        rows=${8}
+        placeholder="내용을 입력하세요. Markdown, 코드 스니펫, URL, 이미지 링크를 그대로 붙일 수 있습니다."
+        helpText="예: ts 코드펜스, 일반 URL 링크 카드, 단독 이미지 URL 자동 인라인"
+        previewLimit=${2}
       />
       <div class="flex gap-2 justify-end">
         <button type="button"
@@ -253,7 +254,7 @@ function PostCard({ post }: { post: BoardPost }) {
   const kind = boardPostKind(post)
   const isDeleting = deletingPostId.value === post.id
   const previewBody = stripStateBlocks(post.body)
-  const richPreview = hasRichMarkdownPreview(previewBody)
+  const richPreview = hasRichMarkdownSignals(previewBody)
 
   const handleVote = async (dir: 'up' | 'down', event: Event) => {
     event.stopPropagation()
@@ -322,7 +323,7 @@ function PostCard({ post }: { post: BoardPost }) {
 
         <!-- Content preview: rendered markdown, height-capped -->
         <div class="board-post-preview text-[13px] text-[var(--text-body)] leading-[1.55] mb-2.5 overflow-hidden relative ${richPreview ? 'max-h-[12rem]' : 'max-h-[4.8em]'}">
-          <${Markdown} text=${previewBody} class="board-post-preview__content" />
+          <${RichContent} text=${previewBody} class="board-post-preview__content" previewLimit=${1} />
           <div class="absolute bottom-0 left-0 right-0 ${richPreview ? 'h-10' : 'h-6'} bg-gradient-to-t from-[var(--card)] to-transparent pointer-events-none" />
         </div>
 

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -5,6 +5,7 @@ import { JsonViewerCard } from '../common/json-viewer'
 import { signal } from '@preact/signals'
 import { CARD_STANDARD } from '../common/card'
 import { ActionButton } from '../common/button'
+import { RichComposer } from '../common/rich-composer'
 import { useRef } from 'preact/hooks'
 import { EmptyState, LoadingState } from '../common/feedback-state'
 import {
@@ -303,14 +304,15 @@ export function OpsRoomColumn() {
               onInput=${(event: Event) => { taskTitle.value = (event.target as HTMLInputElement).value }}
               disabled=${operatorActionBusy.value}
             />
-            <textarea
-              class="control-textarea"
-              rows=${3}
-              placeholder="작업 설명"
+            <${RichComposer}
               value=${taskDescription.value}
-              onInput=${(event: Event) => { taskDescription.value = (event.target as HTMLTextAreaElement).value }}
+              rows=${5}
+              placeholder="작업 설명"
               disabled=${operatorActionBusy.value}
-            ></textarea>
+              onValueChange=${(next: string) => { taskDescription.value = next }}
+              helpText="개입 화면에서도 Markdown, 코드 스니펫, URL 링크 카드를 그대로 기록할 수 있습니다."
+              previewLimit=${1}
+            />
             <div class="control-row items-stretch">
               <select
                 class="control-input min-w-[92px]"

--- a/dashboard/src/components/task-manage/task-create-form.ts
+++ b/dashboard/src/components/task-manage/task-create-form.ts
@@ -1,8 +1,9 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { TextInput, TextArea } from '../common/input'
+import { TextInput } from '../common/input'
 import { Select } from '../common/select'
 import { ActionButton } from '../common/button'
+import { RichComposer } from '../common/rich-composer'
 import { showTaskCreate, taskCreating, createTask } from './task-manage-state'
 
 const title = signal('')
@@ -60,11 +61,13 @@ export function TaskCreateForm() {
         <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_180px]">
           <div class="flex flex-col gap-1.5">
             <label class="text-[11px] font-medium text-text-muted">설명</label>
-            <${TextArea}
+            <${RichComposer}
               value=${description.value}
-              placeholder="배경, 재현 조건, 원하는 결과를 적으면 backlog 카드에서 바로 보입니다."
+              placeholder="배경, 재현 조건, 원하는 결과를 적으면 backlog 카드와 Task 상세에서 그대로 렌더링됩니다."
               rows=${4}
-              onInput=${(e: Event) => { description.value = (e.target as HTMLTextAreaElement).value }}
+              onValueChange=${(next: string) => { description.value = next }}
+              helpText="Markdown, fenced code block, URL 링크 카드, 단독 이미지 URL을 지원합니다."
+              previewLimit=${2}
             />
           </div>
 

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -71,15 +71,54 @@ export function normalizeTask(raw: unknown): Task | null {
   const id = asString(raw.id)
   const title = asString(raw.title)
   if (!id || !title) return null
+  const contract = isRecord(raw.contract)
+    ? {
+        strict: asBoolean(raw.contract.strict),
+        completion_contract: asStringArray(raw.contract.completion_contract),
+        required_evidence: asStringArray(raw.contract.required_evidence),
+        inspect_gate_evidence: asStringArray(raw.contract.inspect_gate_evidence),
+        verify_gate_evidence: asStringArray(raw.contract.verify_gate_evidence),
+        links: isRecord(raw.contract.links)
+          ? {
+              operation_id: asString(raw.contract.links.operation_id) ?? null,
+              session_id: asString(raw.contract.links.session_id) ?? null,
+              autoresearch_loop_id: asString(raw.contract.links.autoresearch_loop_id) ?? null,
+            }
+          : null,
+      }
+    : null
+  const handoffContext = isRecord(raw.handoff_context)
+    ? {
+        summary: asString(raw.handoff_context.summary, ''),
+        reason: asString(raw.handoff_context.reason) ?? null,
+        next_step: asString(raw.handoff_context.next_step) ?? null,
+        failure_mode: asString(raw.handoff_context.failure_mode) ?? null,
+        evidence_refs: asStringArray(raw.handoff_context.evidence_refs),
+        updated_at: asString(raw.handoff_context.updated_at) ?? null,
+        updated_by: asString(raw.handoff_context.updated_by) ?? null,
+      }
+    : null
+  const executionLinks = isRecord(raw.execution_links)
+    ? {
+        operation_id: asString(raw.execution_links.operation_id) ?? null,
+        session_id: asString(raw.execution_links.session_id) ?? null,
+        autoresearch_loop_id: asString(raw.execution_links.autoresearch_loop_id) ?? null,
+      }
+    : null
   return {
     id,
     title,
     status: normalizeTaskStatus(raw.status),
     priority: asNumber(raw.priority),
     assignee: asString(raw.assignee),
+    assignee_kind: asString(raw.assignee_kind) ?? null,
     description: asString(raw.description),
     created_at: asString(raw.created_at),
     updated_at: asString(raw.updated_at),
+    completed_at: asString(raw.completed_at),
+    contract,
+    handoff_context: handoffContext,
+    execution_links: executionLinks,
   }
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -98,6 +98,13 @@ export interface Message {
 
 // --- Board ---
 
+export type BoardPostMeta = Record<string, unknown> & {
+  source?: string | null
+  state_block?: string | null
+  classification_reason?: string | null
+  judgment?: unknown
+}
+
 export interface BoardPost {
   id: string
   author: string
@@ -106,10 +113,7 @@ export interface BoardPost {
   title: string
   body: string
   content: string
-  meta?: {
-    source?: string | null
-    state_block?: string | null
-  } | null
+  meta?: BoardPostMeta | null
   tags: string[]
   votes: number
   vote_balance?: number

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -48,27 +48,51 @@ let messages_safe config =
     Room.get_messages_raw config ~since_seq:0 ~limit:50
   else []
 
+let assoc_upsert fields key value =
+  (key, value) :: List.remove_assoc key fields
+
+
+let task_updated_at (task : Types.task) =
+  match task.task_status with
+  | Types.Done { completed_at; _ } -> completed_at
+  | Types.Cancelled { cancelled_at; _ } -> cancelled_at
+  | Types.InProgress { started_at; _ } -> started_at
+  | Types.Claimed { claimed_at; _ } -> claimed_at
+  | Types.Todo -> task.created_at
+
+let task_completed_at (task : Types.task) =
+  match task.task_status with
+  | Types.Done { completed_at; _ } -> Some completed_at
+  | Types.Cancelled { cancelled_at; _ } -> Some cancelled_at
+  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> None
+
+let task_execution_links_json (task : Types.task) =
+  match task.contract with
+  | Some contract -> Types.task_execution_links_to_yojson contract.links
+  | None -> `Null
 
 let task_json (task : Types.task) =
-  let base =
-    [
-      ("id", `String task.id);
-      ("title", `String task.title);
-      ("description", `String task.description);
-      ("status", `String (Types.string_of_task_status task.task_status));
-      ("priority", `Int task.priority);
-      ("assignee", Json_util.string_opt_to_json (task_assignee task));
-      ("created_at", `String task.created_at);
-    ]
-  in
-  let extra = match task.task_status with
-    | Types.Done { completed_at; _ } ->
-      [("completed_at", `String completed_at)]
-    | Types.Cancelled { cancelled_at; _ } ->
-      [("completed_at", `String cancelled_at)]
+  let fields =
+    match Types.task_to_yojson task with
+    | `Assoc assoc -> assoc
     | _ -> []
   in
-  `Assoc (base @ extra)
+  let fields =
+    assoc_upsert fields "assignee"
+      (Json_util.string_opt_to_json (task_assignee task))
+  in
+  let fields =
+    assoc_upsert fields "updated_at" (`String (task_updated_at task))
+  in
+  let fields =
+    assoc_upsert fields "execution_links" (task_execution_links_json task)
+  in
+  let fields =
+    match task_completed_at task with
+    | Some timestamp -> assoc_upsert fields "completed_at" (`String timestamp)
+    | None -> List.remove_assoc "completed_at" fields
+  in
+  `Assoc fields
 
 let agent_json ~(model_map : (string, string) Hashtbl.t) (agent : Types.agent) =
   let (emoji, korean_name) = get_agent_identity agent.name in

--- a/lib/dune
+++ b/lib/dune
@@ -108,6 +108,7 @@
    server_meta_cognition_feedback
    server_dashboard_http
    server_dashboard_http_cache
+   server_dashboard_http_link_preview
    server_dashboard_http_core
    server_routes_http
    server_routes_http_common

--- a/lib/masc_http_client/masc_http_client.ml
+++ b/lib/masc_http_client/masc_http_client.ml
@@ -53,6 +53,12 @@ let make_closing_client ~sw ~net ~https =
 
 (** POST with structured error handling.
     DNS resolution, TLS, and I/O errors return Error instead of crashing the fiber. *)
+type response = {
+  status : int;
+  headers : (string * string) list;
+  body : string;
+}
+
 let post_sync ~net ?(https = None) ~url ~headers ~body () =
   try
     Eio.Switch.run @@ fun sw ->
@@ -77,7 +83,7 @@ let post_sync ~net ?(https = None) ~url ~headers ~body () =
   | exn -> Error (Printexc.to_string exn)
 
 (** GET with structured error handling. *)
-let get_sync ~net ?(https = None) ~url ~headers () =
+let get_response_sync ~net ?(https = None) ~url ~headers () =
   try
     Eio.Switch.run @@ fun sw ->
     let client = make_closing_client ~sw ~net ~https in
@@ -91,10 +97,19 @@ let get_sync ~net ?(https = None) ~url ~headers () =
     let code =
       Cohttp.Response.status resp |> Cohttp.Code.code_of_status
     in
+    let response_headers =
+      Cohttp.Response.headers resp |> Cohttp.Header.to_list
+    in
     let body_str =
       Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024)
     in
-    Ok (code, body_str)
+    Ok { status = code; headers = response_headers; body = body_str }
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn -> Error (Printexc.to_string exn)
+
+(** GET with structured error handling. *)
+let get_sync ~net ?(https = None) ~url ~headers () =
+  match get_response_sync ~net ~https ~url ~headers () with
+  | Ok response -> Ok (response.status, response.body)
+  | Error _ as error -> error

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -386,10 +386,11 @@ let fetch_preview ~clock ~net url =
                       Option.value ~default:false
                         (Option.map
                            (fun value ->
-                             String.starts_with ~prefix:"image/"
-                               (lower_trim
-                                  (List.hd
-                                     (String.split_on_char ';' value))))
+                             match String.split_on_char ';' value with
+                             | head :: _ ->
+                                 String.starts_with ~prefix:"image/"
+                                   (lower_trim head)
+                             | [] -> false)
                            content_type)
                     then
                       Ok

--- a/lib/server/server_dashboard_http_link_preview.ml
+++ b/lib/server/server_dashboard_http_link_preview.ml
@@ -1,0 +1,493 @@
+open Yojson.Safe.Util
+
+type preview_extract = {
+  title : string option;
+  description : string option;
+  site_name : string option;
+  image_url : string option;
+  canonical_url : string option;
+  favicon_url : string option;
+}
+
+type cache_payload = {
+  preview : Yojson.Safe.t;
+  expires_at : float;
+}
+
+let cache_ttl_sec = 3600.0
+let error_ttl_sec = 300.0
+let max_preview_urls = 8
+let preview_timeout_sec = 5.0
+let max_html_chars = 262_144
+
+let preview_cache_mu = Eio.Mutex.create ()
+let preview_cache : (string, cache_payload) Hashtbl.t = Hashtbl.create 128
+
+let trim_to_option value =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let lower_trim value = String.lowercase_ascii (String.trim value)
+
+let cache_lookup key =
+  Eio.Mutex.use_rw ~protect:true preview_cache_mu (fun () ->
+      match Hashtbl.find_opt preview_cache key with
+      | Some entry when entry.expires_at > Time_compat.now () -> Some entry.preview
+      | Some _ ->
+          Hashtbl.remove preview_cache key;
+          None
+      | None -> None)
+
+let cache_store ~ttl key preview =
+  Eio.Mutex.use_rw ~protect:true preview_cache_mu (fun () ->
+      Hashtbl.replace preview_cache key
+        { preview; expires_at = Time_compat.now () +. ttl })
+
+let json_string_opt_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> trim_to_option value
+  | _ -> None
+
+let error_reason_of_json = function
+  | `Assoc fields -> json_string_opt_field fields "error"
+  | _ -> None
+
+let assoc_upsert fields key value =
+  (key, value) :: List.remove_assoc key fields
+
+let with_cache_state preview cache_state =
+  match preview with
+  | `Assoc fields -> `Assoc (assoc_upsert fields "cache_state" (`String cache_state))
+  | _ -> preview
+
+let decode_html_entities value =
+  let replacements =
+    [
+      ("&amp;", "&");
+      ("&quot;", "\"");
+      ("&#39;", "'");
+      ("&apos;", "'");
+      ("&lt;", "<");
+      ("&gt;", ">");
+      ("&nbsp;", " ");
+    ]
+  in
+  List.fold_left
+    (fun acc (needle, replacement) ->
+      Re.replace_string (Re.compile (Re.str needle)) ~all:true ~by:replacement acc)
+    value replacements
+
+let collapse_whitespace value =
+  value
+  |> Re.replace_string (Re.Pcre.re "[ \t\r\n]+" |> Re.compile) ~all:true ~by:" "
+  |> String.trim
+
+let normalize_text value =
+  value |> decode_html_entities |> collapse_whitespace |> trim_to_option
+
+let is_http_scheme = function
+  | Some "http" | Some "https" -> true
+  | _ -> false
+
+let is_loopback_or_unspecified_host host =
+  Server_auth.is_loopback_host host || Server_auth.is_unspecified_host host
+
+let ipaddr_is_private_or_reserved = function
+  | Ipaddr.V4 addr ->
+      let octets = Ipaddr.V4.to_octets addr in
+      let byte idx = Char.code octets.[idx] in
+      let b0 = byte 0 and b1 = byte 1 in
+      b0 = 0
+      || b0 = 10
+      || b0 = 127
+      || (b0 = 169 && b1 = 254)
+      || (b0 = 172 && b1 >= 16 && b1 <= 31)
+      || (b0 = 192 && b1 = 168)
+      || (b0 = 100 && b1 >= 64 && b1 <= 127)
+      || (b0 = 192 && b1 = 0)
+      || (b0 = 198 && (b1 = 18 || b1 = 19))
+      || (b0 = 198 && b1 = 51)
+      || (b0 = 203 && b1 = 0)
+      || b0 >= 224
+  | Ipaddr.V6 addr ->
+      let text = Ipaddr.V6.to_string addr |> String.lowercase_ascii in
+      Ipaddr.V6.compare addr Ipaddr.V6.localhost = 0
+      || Ipaddr.V6.compare addr Ipaddr.V6.unspecified = 0
+      || String.starts_with ~prefix:"fc" text
+      || String.starts_with ~prefix:"fd" text
+      || String.starts_with ~prefix:"fe8" text
+      || String.starts_with ~prefix:"fe9" text
+      || String.starts_with ~prefix:"fea" text
+      || String.starts_with ~prefix:"feb" text
+      || String.starts_with ~prefix:"ff" text
+      || String.starts_with ~prefix:"2001:db8" text
+
+let eio_ipaddr_is_private_or_reserved ip =
+  let rendered = Fmt.str "%a" Eio.Net.Ipaddr.pp ip in
+  match Ipaddr.of_string rendered with
+  | Ok parsed -> ipaddr_is_private_or_reserved parsed
+  | Error _ -> true
+
+let validate_resolved_host ~net (uri : Uri.t) =
+  try
+    match Uri.host uri with
+    | None -> Error "missing host"
+    | Some host when is_loopback_or_unspecified_host host ->
+        Error "host is not allowed"
+    | Some host ->
+        let service =
+          match Uri.port uri with
+          | Some port -> Int.to_string port
+          | None ->
+              if Uri.scheme uri = Some "https" then "443" else "80"
+        in
+        let addrs = Eio.Net.getaddrinfo_stream ~service net host in
+        match addrs with
+        | [] -> Error "dns resolution returned no addresses"
+        | items ->
+            let blocked =
+              List.exists
+                (function
+                  | `Tcp (ip, _) -> eio_ipaddr_is_private_or_reserved ip
+                  | `Unix _ -> true)
+                items
+            in
+            if blocked then Error "resolved address is not allowed" else Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn -> Error (Printf.sprintf "dns failure: %s" (Printexc.to_string exn))
+
+let normalize_request_url raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then Error "url is empty"
+  else
+    let uri = Uri.of_string trimmed in
+    if not (is_http_scheme (Uri.scheme uri)) then
+      Error "only http/https URLs are allowed"
+    else if Uri.userinfo uri <> None then
+      Error "userinfo in URL is not allowed"
+    else if Uri.host uri = None then
+      Error "missing host"
+    else
+      Ok (Uri.with_fragment uri None |> Uri.to_string)
+
+let image_extensions =
+  [ ".png"; ".jpg"; ".jpeg"; ".gif"; ".webp"; ".svg"; ".avif"; ".bmp" ]
+
+let infer_image_url url =
+  let lower = String.lowercase_ascii url in
+  List.exists (fun ext -> Filename.check_suffix lower ext) image_extensions
+
+let first_head_fragment body =
+  let re =
+    Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] "<head[^>]*>(.*?)</head>"
+    |> Re.compile
+  in
+  match Re.exec_opt re body with
+  | Some groups ->
+      Re.Group.get groups 1
+  | None ->
+      String.sub body 0 (min (String.length body) max_html_chars)
+
+let first_match body pattern =
+  let re =
+    Re.Pcre.re ~flags:[ `CASELESS; `DOTALL ] pattern |> Re.compile
+  in
+  match Re.exec_opt re body with
+  | Some groups -> normalize_text (Re.Group.get groups 1)
+  | None -> None
+
+let meta_content head attr key =
+  let quoted value =
+    Printf.sprintf
+      "<meta[^>]+%s\\s*=\\s*['\"]%s['\"][^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
+      attr value
+  in
+  let reversed value =
+    Printf.sprintf
+      "<meta[^>]+content\\s*=\\s*['\"]([^'\"]+)['\"][^>]+%s\\s*=\\s*['\"]%s['\"][^>]*>"
+      attr value
+  in
+  match first_match head (quoted key) with
+  | Some _ as value -> value
+  | None -> first_match head (reversed key)
+
+let link_href head rel_value =
+  let pattern =
+    Printf.sprintf
+      "<link[^>]+rel\\s*=\\s*['\"][^'\"]*%s[^'\"]*['\"][^>]+href\\s*=\\s*['\"]([^'\"]+)['\"][^>]*>"
+      rel_value
+  in
+  let reversed =
+    Printf.sprintf
+      "<link[^>]+href\\s*=\\s*['\"]([^'\"]+)['\"][^>]+rel\\s*=\\s*['\"][^'\"]*%s[^'\"]*['\"][^>]*>"
+      rel_value
+  in
+  match first_match head pattern with
+  | Some _ as value -> value
+  | None -> first_match head reversed
+
+let title_tag head =
+  first_match head "<title[^>]*>(.*?)</title>"
+
+let resolve_relative_url ~base_url value =
+  let base_uri = Uri.of_string base_url in
+  Uri.resolve "" base_uri (Uri.of_string value) |> Uri.to_string
+
+let default_favicon_url url =
+  let uri = Uri.of_string url in
+  Uri.make ?scheme:(Uri.scheme uri) ?host:(Uri.host uri) ?port:(Uri.port uri)
+    ~path:"/favicon.ico" ()
+  |> Uri.to_string
+
+let extract_html_preview_fields ~url body =
+  let head = first_head_fragment body in
+  let title =
+    match meta_content head "property" "og:title" with
+    | Some _ as value -> value
+    | None -> (
+        match meta_content head "name" "twitter:title" with
+        | Some _ as value -> value
+        | None -> title_tag head)
+  in
+  let description =
+    match meta_content head "property" "og:description" with
+    | Some _ as value -> value
+    | None -> (
+        match meta_content head "name" "twitter:description" with
+        | Some _ as value -> value
+        | None -> meta_content head "name" "description")
+  in
+  let site_name =
+    match meta_content head "property" "og:site_name" with
+    | Some _ as value -> value
+    | None -> Uri.host (Uri.of_string url)
+  in
+  let image_url =
+    match meta_content head "property" "og:image" with
+    | Some raw -> Some (resolve_relative_url ~base_url:url raw)
+    | None -> (
+        match meta_content head "name" "twitter:image" with
+        | Some raw -> Some (resolve_relative_url ~base_url:url raw)
+        | None -> None)
+  in
+  let canonical_url =
+    match link_href head "canonical" with
+    | Some raw -> Some (resolve_relative_url ~base_url:url raw)
+    | None -> None
+  in
+  let favicon_url =
+    match link_href head "icon" with
+    | Some raw -> Some (resolve_relative_url ~base_url:url raw)
+    | None -> Some (default_favicon_url url)
+  in
+  { title; description; site_name; image_url; canonical_url; favicon_url }
+
+let list_header_ci headers name =
+  let target = String.lowercase_ascii name in
+  headers
+  |> List.find_map (fun (key, value) ->
+         if String.equal (String.lowercase_ascii key) target then Some value
+         else None)
+
+let is_success_status code = code >= 200 && code < 300
+
+let is_redirect_status code =
+  code = 301 || code = 302 || code = 303 || code = 307 || code = 308
+
+let https_connector_result () =
+  match Eio_context.get_https_connector_result () with
+  | Ok connector -> Ok (Some connector)
+  | Error message -> Error message
+
+let fetch_response ~net ~url =
+  let uri = Uri.of_string url in
+  let https_result =
+    if Uri.scheme uri = Some "https" then https_connector_result () else Ok None
+  in
+  match https_result with
+  | Error _ as error -> error
+  | Ok https ->
+      Masc_http_client.get_response_sync ~net ~https ~url
+        ~headers:
+          [
+            ("Accept", "text/html,application/xhtml+xml,image/*;q=0.9,*/*;q=0.1");
+            ("Accept-Encoding", "identity");
+            ("User-Agent", "MASC-Dashboard-LinkPreview/1.0");
+          ]
+        ()
+
+let rec fetch_response_following_redirects ~net ~url ~remaining_redirects =
+  match fetch_response ~net ~url with
+  | Error _ as error -> error
+  | Ok response when is_redirect_status response.status && remaining_redirects > 0
+    ->
+      (match list_header_ci response.headers "location" with
+       | Some location when String.trim location <> "" ->
+           let next_url = resolve_relative_url ~base_url:url location in
+           fetch_response_following_redirects ~net ~url:next_url
+             ~remaining_redirects:(remaining_redirects - 1)
+       | _ -> Ok response)
+  | Ok response -> Ok response
+
+let build_preview_json ~url ~kind ?canonical_url ?title ?description ?site_name
+    ?image_url ?favicon_url ?content_type ~cache_state () =
+  let fields =
+    [
+      ("url", `String url);
+      ("kind", `String kind);
+      ("canonical_url", Json_util.string_opt_to_json canonical_url);
+      ("title", Json_util.string_opt_to_json title);
+      ("description", Json_util.string_opt_to_json description);
+      ("site_name", Json_util.string_opt_to_json site_name);
+      ("image_url", Json_util.string_opt_to_json image_url);
+      ("favicon_url", Json_util.string_opt_to_json favicon_url);
+      ("content_type", Json_util.string_opt_to_json content_type);
+      ("fetched_at", `String (Types.now_iso ()));
+      ("cache_state", `String cache_state);
+    ]
+  in
+  `Assoc fields
+
+let error_json ~url ~reason ~cache_state () =
+  `Assoc
+    [
+      ("url", `String url);
+      ("error", `String reason);
+      ("cache_state", `String cache_state);
+    ]
+
+let fetch_preview ~clock ~net url =
+  match normalize_request_url url with
+  | Error reason -> Error reason
+  | Ok normalized_url -> (
+      match validate_resolved_host ~net (Uri.of_string normalized_url) with
+      | Error reason -> Error reason
+      | Ok () ->
+          if infer_image_url normalized_url then
+            Ok
+              (build_preview_json ~url:normalized_url ~kind:"image"
+                 ~image_url:normalized_url
+                 ~favicon_url:(default_favicon_url normalized_url)
+                 ~cache_state:"miss" ())
+          else
+            let run () =
+              match
+                fetch_response_following_redirects ~net ~url:normalized_url
+                  ~remaining_redirects:2
+              with
+              | Error message -> Error message
+              | Ok response ->
+                  if not (is_success_status response.status) then
+                    Error (Printf.sprintf "HTTP %d" response.status)
+                  else
+                    let content_type = list_header_ci response.headers "content-type" in
+                    if
+                      Option.value ~default:false
+                        (Option.map
+                           (fun value ->
+                             String.starts_with ~prefix:"image/"
+                               (lower_trim
+                                  (List.hd
+                                     (String.split_on_char ';' value))))
+                           content_type)
+                    then
+                      Ok
+                        (build_preview_json ~url:normalized_url ~kind:"image"
+                           ~image_url:normalized_url
+                           ?content_type
+                           ~favicon_url:(default_favicon_url normalized_url)
+                           ~cache_state:"miss" ())
+                    else
+                      let body =
+                        if String.length response.body > max_html_chars then
+                          String.sub response.body 0 max_html_chars
+                        else response.body
+                      in
+                      let extracted =
+                        extract_html_preview_fields ~url:normalized_url body
+                      in
+                      let canonical_url =
+                        match extracted.canonical_url with
+                        | Some value -> Some value
+                        | None -> Some normalized_url
+                      in
+                      Ok
+                        (build_preview_json ~url:normalized_url ~kind:"link"
+                           ?canonical_url
+                           ?title:extracted.title
+                           ?description:extracted.description
+                           ?site_name:extracted.site_name
+                           ?image_url:extracted.image_url
+                           ?favicon_url:extracted.favicon_url
+                           ?content_type
+                           ~cache_state:"miss" ())
+            in
+            try Eio.Time.with_timeout_exn clock preview_timeout_sec run
+            with Eio.Cancel.Cancelled _ as e -> raise e
+               | exn -> Error (Printexc.to_string exn))
+
+let urls_of_request args =
+  match args |> member "urls" with
+  | `List items ->
+      let urls =
+        items
+        |> List.filter_map (function
+             | `String value ->
+                 let trimmed = String.trim value in
+                 if trimmed = "" then None else Some trimmed
+             | _ -> None)
+        |> List.sort_uniq String.compare
+      in
+      if urls = [] then Error "urls must contain at least one non-empty string"
+      else Ok (List.take max_preview_urls urls)
+  | _ -> Error "urls must be an array of strings"
+
+let dashboard_link_previews_http_json ~state ~(args : Yojson.Safe.t) :
+    (Yojson.Safe.t, string) result =
+  let clock_opt =
+    match state.Mcp_server.clock with
+    | Some _ as clock -> clock
+    | None -> Eio_context.get_clock_opt ()
+  in
+  let net_opt =
+    match state.Mcp_server.net with
+    | Some _ as net -> net
+    | None -> Eio_context.get_net_opt ()
+  in
+  match clock_opt, net_opt, urls_of_request args with
+  | None, _, _ -> Error "dashboard link preview clock unavailable"
+  | _, None, _ -> Error "dashboard link preview net unavailable"
+  | _, _, (Error _ as error) -> error
+  | Some clock, Some net, Ok urls ->
+      let preview_fields = ref [] in
+      let error_fields = ref [] in
+      List.iter
+        (fun url ->
+          match cache_lookup url with
+          | Some cached ->
+              (match error_reason_of_json cached with
+               | Some reason ->
+                   error_fields := (url, `String reason) :: !error_fields
+               | None ->
+                preview_fields :=
+                  (url, with_cache_state cached "hit") :: !preview_fields)
+          | None -> (
+              match fetch_preview ~clock ~net url with
+              | Ok preview ->
+                  let persisted = with_cache_state preview "miss" in
+                  cache_store ~ttl:cache_ttl_sec url persisted;
+                  preview_fields := (url, persisted) :: !preview_fields
+              | Error reason ->
+                  let error_preview =
+                    error_json ~url ~reason ~cache_state:"miss" ()
+                  in
+                  cache_store ~ttl:error_ttl_sec url error_preview;
+                  error_fields := (url, `String reason) :: !error_fields))
+        urls;
+      Ok
+        (`Assoc
+          [
+            ("previews", `Assoc (List.rev !preview_fields));
+            ("errors", `Assoc (List.rev !error_fields));
+          ])

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -66,6 +66,30 @@ let handle_broadcast state agent_name reqd body_str =
   | Yojson.Json_error msg -> reply false (Some ("invalid JSON: " ^ msg))
   | e -> reply false (Some (Printexc.to_string e))
 
+let handle_dashboard_link_previews state req reqd body_str =
+  let respond_error message =
+    Http.Response.json ~status:`Bad_request ~request:req
+      (Yojson.Safe.to_string
+         (`Assoc
+           [
+             ("ok", `Bool false);
+             ("error", `String message);
+           ]))
+      reqd
+  in
+  try
+    let args = Yojson.Safe.from_string body_str in
+    match
+      Server_dashboard_http_link_preview.dashboard_link_previews_http_json
+        ~state ~args
+    with
+    | Ok json ->
+        Http.Response.json ~compress:true ~request:req
+          (Yojson.Safe.to_string json) reqd
+    | Error message -> respond_error message
+  with Yojson.Json_error message ->
+    respond_error ("invalid json: " ^ message)
+
 let rec add_routes ~sw ~clock router =
   router
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
@@ -222,6 +246,12 @@ let rec add_routes ~sw ~clock router =
          let json = dashboard_memory_http_json req in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.post "/api/v1/dashboard/link-previews" (fun request reqd ->
+       with_permission_auth ~permission:Types.CanReadState
+         (fun state req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             handle_dashboard_link_previews state req reqd body_str))
+         request reqd)
   |> Http.Router.get "/api/v1/dashboard/memory-subsystems" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let config = state.Mcp_server.room_config in

--- a/test/dune
+++ b/test/dune
@@ -37,6 +37,7 @@
         test_dashboard
         test_dashboard_perf
         test_dashboard_tool_host_events
+        test_dashboard_link_preview
         test_gate_keeper_backend
         test_transport_read_model
         test_multi_room test_worktree_detection test_bounded test_mention
@@ -115,6 +116,7 @@
           test_dashboard
           test_dashboard_perf
           test_dashboard_tool_host_events
+          test_dashboard_link_preview
           test_gate_keeper_backend
           test_transport_read_model
           test_multi_room test_worktree_detection test_bounded test_mention

--- a/test/test_dashboard_link_preview.ml
+++ b/test/test_dashboard_link_preview.ml
@@ -1,0 +1,64 @@
+open Alcotest
+
+module Lib = Masc_mcp
+
+let test_extract_html_preview_fields () =
+  let html =
+    {|
+      <html>
+        <head>
+          <title>Fallback Title</title>
+          <meta property="og:title" content="OG Title">
+          <meta property="og:description" content="OG description here">
+          <meta property="og:site_name" content="Example Site">
+          <meta property="og:image" content="/cover.png">
+          <link rel="canonical" href="/entry">
+          <link rel="icon" href="/favicon.ico">
+        </head>
+      </html>
+    |}
+  in
+  let extracted =
+    Lib.Server_dashboard_http_link_preview.extract_html_preview_fields
+      ~url:"https://example.com/blog/post" html
+  in
+  check (option string) "title" (Some "OG Title") extracted.title;
+  check (option string) "description" (Some "OG description here")
+    extracted.description;
+  check (option string) "site_name" (Some "Example Site") extracted.site_name;
+  check (option string) "image_url" (Some "https://example.com/cover.png")
+    extracted.image_url;
+  check (option string) "canonical_url" (Some "https://example.com/entry")
+    extracted.canonical_url;
+  check (option string) "favicon_url"
+    (Some "https://example.com/favicon.ico") extracted.favicon_url
+
+let test_image_url_detection () =
+  check bool "png is image" true
+    (Lib.Server_dashboard_http_link_preview.infer_image_url
+       "https://example.com/demo.png");
+  check bool "html is not image" false
+    (Lib.Server_dashboard_http_link_preview.infer_image_url
+       "https://example.com/page.html")
+
+let test_normalize_request_url_rejects_non_http () =
+  match
+    Lib.Server_dashboard_http_link_preview.normalize_request_url
+      "file:///tmp/example.html"
+  with
+  | Error _ -> ()
+  | Ok value ->
+      failf "expected non-http URL to be rejected, got %s" value
+
+let () =
+  Alcotest.run "dashboard_link_preview"
+    [
+      ( "preview",
+        [
+          test_case "extract html preview fields" `Quick
+            test_extract_html_preview_fields;
+          test_case "image url detection" `Quick test_image_url_detection;
+          test_case "normalize rejects non-http" `Quick
+            test_normalize_request_url_rejects_non_http;
+        ] );
+    ]


### PR DESCRIPTION
## What changed
- add shared rich content rendering/composer support for dashboard markdown, code fences, standalone image URLs, and URL preview cards
- wire Board post list/detail/comments and Task create/detail/inject surfaces to the rich renderer/composer
- add a dashboard link preview API with HTML metadata extraction, SSRF-safe URL validation, redirect handling, and TTL caching
- preserve richer task projection fields in the execution payload, including contract, handoff context, execution links, and completed timestamps
- add frontend utility tests and OCaml link preview tests

## Why
Board and Task content were still effectively plain text in key flows, which made longer operational notes, code snippets, linked references, and image context hard to use in the dashboard.

## Impact
Operators and keepers can now leave richer records directly in the dashboard without changing existing board/task write APIs.

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-rich-content-preview ./test/test_dashboard_link_preview.exe`
- `dune build --display short --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-rich-content-preview`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin/tsc --noEmit --pretty`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/.bin/vitest run src/components/common/rich-content-utils.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm build`
