### PR TITLE
ci: don't force TLA+ on ci_core=true (save ~14min per CI-config PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,13 @@ jobs:
             dashboard=true
             health=true
             health_snapshot=true
-            tla=true
             oas_pin=true
+            # Note: tla is intentionally NOT forced on by ci_core. TLA+ model
+            # checking takes ~14 min and only meaningfully depends on specs/,
+            # lib/keeper/, lib/oas_*.ml, or Makefile. A pure workflow/action
+            # change has no effect on TLA spec correctness, so forcing it here
+            # spent ~14 min per unrelated CI-config PR. tla stays driven by its
+            # narrow path filter only.
           fi
 
           echo "build=${build}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 문제

\`ci.yml\`의 \`changes\` job에 \`ci_core=true\` 분기(180-188)가 있다. \`.github/workflows/ci.yml\` 또는 \`.github/actions/\` 변경 감지 시 모든 scope 플래그를 true로 일괄 설정 — 그 중 **\`tla=true\`가 포함되어 있어 TLA+ 모델 체커가 강제 실행됨** (~14분 소요).

그러나 TLA+ spec verification의 실제 입력은:
- \`specs/\`
- \`lib/keeper/\`
- \`lib/oas_*.ml\`
- \`Makefile\`

**workflow YAML이나 composite action 변경은 spec 결과를 바꿀 수 없음**. ci-gate 추가 PR 자체(\`#7015\`)가 좋은 예시 — \`tla-specs\`가 14m5s 돌았지만 검증 내용은 이전 main과 동일.

## 변경 (1 파일, +6/-1)

\`\`\`diff
           if [ "\${ci_core}" = true ]; then
             build=true
             lint=true
             dashboard=true
             health=true
             health_snapshot=true
-            tla=true
             oas_pin=true
+            # Note: tla is intentionally NOT forced on by ci_core.
+            # ... (설명)
           fi
\`\`\`

tla scope는 기존 path filter(\`specs/|lib/keeper/|lib/oas_.*\\.ml$|Makefile$\`)에 의해서만 true가 된다 — 정확히 TLA 결과에 영향 주는 경로들.

## 효과

- **이 PR 자체가 첫 수혜자**: ci.yml만 변경하므로 ci_core=true지만 tla는 skipping. CI Gate도 즉시 통과.
- 향후 CI 설정/workflow 손질 PR이 매번 14분씩 아껴짐.
- spec 수정 PR의 TLA 실행은 영향 없음 (narrow path filter가 그대로 동작).

## 검증

- YAML parse OK (12 jobs 정상).
- ci-gate aggregator는 \`tla=skipped\`를 PASS로 간주 → BLOCKED 트랩 없음.

## Ref

CI 낭비 감사 2026-04-14 — rank #1 절감 항목 (총 5개 중).

🤖 Generated with [Claude Code](https://claude.com/claude-code)