### PR TITLE
feat(dashboard): connected keeper phase badge in agent detail

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -38,6 +38,7 @@ import {
   type TaskHistoryRow,
 } from './agent-detail-state'
 import { openKeeperDetail } from './keeper-detail'
+import { KeeperPhaseBadge } from './keeper-phase-indicator'
 import { trimText } from '../lib/truncate'
 import type { Task } from '../types'
 import { DialogOverlay } from './common/dialog'
@@ -149,7 +150,16 @@ export function AgentDetailOverlay() {
               ? html`
                   <div class="mt-1 flex gap-3 flex-wrap text-text-muted text-[13px] font-medium">
                     ${keeper
-                      ? html`<span class="flex items-center gap-1.5">연결된 키퍼: <strong class="text-text-strong">${keeper.name}</strong>${keeperIdentity ? html`<span class="text-text-dim text-xs">· ${keeperIdentity}</span>` : ''}</span>`
+                      ? html`<span class="flex items-center gap-1.5">연결된 키퍼:
+                          <button
+                            type="button"
+                            class="text-text-strong font-semibold hover:text-accent underline underline-offset-2 decoration-dotted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 rounded"
+                            onClick=${() => { closeAgentDetail(); openKeeperDetail(keeper) }}
+                            title="키퍼 상세 페이지 열기"
+                          >${keeper.name}</button>
+                          <${KeeperPhaseBadge} phase=${keeper.phase} compact=${true} />
+                          ${keeperIdentity ? html`<span class="text-text-dim text-xs">· ${keeperIdentity}</span>` : ''}
+                        </span>`
                       : null}
                     ${missionBrief?.related_session_id ? html`<span class="flex items-center gap-1.5">세션: <strong class="font-mono text-text-strong text-xs bg-white/5 px-1.5 rounded">${missionBrief.related_session_id}</strong></span>` : null}
                     ${continuitySummary ? html`<span class="text-accent/90 bg-[var(--accent-10)] px-2 py-0.5 rounded-md border border-accent/10">${continuitySummary}</span>` : null}


### PR DESCRIPTION
## Summary

`/agents/:id` 오버레이의 "연결된 키퍼:" 줄에 **KeeperPhaseBadge(compact)** 를 추가하고, keeper name을 클릭하면 agent overlay가 닫히면서 keeper detail 페이지로 이동하도록 연결. RFC-0003 + `docs/design/dashboard-fsm-redesign.md` §Phase 1c 구현.

## Changes

- `dashboard/src/components/agent-detail.ts`
  - import: `KeeperPhaseBadge` from `./keeper-phase-indicator`
  - "연결된 키퍼" 블록을 수정:
    - keeper name을 `<button>`으로 래핑 → `closeAgentDetail() + openKeeperDetail(keeper)` 호출
    - 이름 옆에 `<KeeperPhaseBadge phase={keeper.phase} compact />` 추가
- 11 insertions / 1 deletion.

## Why

- **가시성**: 운영자가 agent 맥락에서 keeper의 현재 phase(11-state)를 바로 볼 수 있다. 지금은 agent detail에서 keeper의 lifecycle 상태가 전혀 노출되지 않아 keeper 페이지로 다시 들어가야 했다.
- **경계 유지**: 전체 composite FSM/Cascade/Decision 시각화는 **넣지 않는다**. 그건 `/keepers/:name` (운영자 콘솔)과 신규 `/fsm` hub(감사 뷰, Phase 3)의 역할. RFC-0003 §2, `feedback_masc-oas-layer-boundary.md` 원칙 유지.
- **재사용**: 신규 컴포넌트/추상화 없음. 기존 `KeeperPhaseBadge(compact)` + `openKeeperDetail` + `keeperForAgent` 조합 (`feedback_no-derived-tag-when-existing-identifier-suffices.md`).

## Non-goals

- Full FSM 다이어그램, Decision/Cascade sub-widgets — `/fsm` hub에만 존재해야 함.
- Phase transition 타임라인 — `KeeperPhaseTimeline`은 heavy 컴포넌트로 agent detail에 부적합.
- Backend shape 변경 — `keeper.phase` 필드는 이미 존재 (`keeper-store-normalize.ts:307`).

## Test plan

- [x] `pnpm typecheck` (tsc --noEmit) 통과
- [x] 기존 `agent-detail-session-report.test.ts` 9건 통과 (regression 없음)
- [ ] 수동 확인: agent overlay에서 keeper name 클릭 시 agent 닫히고 keeper detail 열림
- [ ] 수동 확인: keeper.phase 값에 따라 badge 색/아이콘/라벨이 올바르게 표시됨 (Running/Failing/Compacting/HandingOff 각각)
- [ ] 수동 확인: keeper가 없는 agent는 badge 렌더 안 됨

## Related

- RFC-0003 Keeper Composite Lifecycle — #7020
- `docs/design/dashboard-fsm-redesign.md` §Phase 1c

🤖 Generated with [Claude Code](https://claude.com/claude-code)