### PR TITLE
feat(dashboard): click Hebbian node → open keeper detail

### DIFF
--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -12,6 +12,7 @@ import {
 import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
 import { setupVisibleAutoRefresh } from '../lib/auto-refresh'
+import { openAgentDetail } from './agent-detail-state'
 
 const REFRESH_MS = 30_000
 
@@ -123,8 +124,22 @@ function HebbianNetwork({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
           const isKeeper = name.startsWith('keeper-')
           const fill = isKeeper ? '#1e293b' : '#0f172a'
           const stroke = isKeeper ? '#3b82f6' : '#64748b'
+          const onNodeClick = () => openAgentDetail(name)
+          const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              openAgentDetail(name)
+            }
+          }
           return html`
-            <g>
+            <g
+              class="cursor-pointer hover:opacity-80 transition-opacity"
+              role="button"
+              tabindex="0"
+              onClick=${onNodeClick}
+              onKeyDown=${onKeyDown}
+              aria-label=${'에이전트 상세 열기: ' + label}
+            >
               <circle
                 cx=${pos.x}
                 cy=${pos.y}
@@ -140,6 +155,7 @@ function HebbianNetwork({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
                 font-size="11"
                 fill="#f1f5f9"
                 font-family="monospace"
+                class="pointer-events-none select-none"
               >
                 ${label}
               </text>
@@ -157,9 +173,19 @@ function SynapseRow({ s }: { s: MemorySubsystemsSynapse }) {
     pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-500' : 'bg-red-400'
   return html`
     <tr class="border-b border-zinc-800">
-      <td class="py-1.5 px-2 text-sm font-mono">${s.from_agent}</td>
+      <td class="py-1.5 px-2 text-sm font-mono">
+        <button
+          class="hover:text-sky-400 hover:underline focus:outline-none focus:text-sky-400"
+          onClick=${() => openAgentDetail(s.from_agent)}
+        >${s.from_agent}</button>
+      </td>
       <td class="py-1.5 px-2 text-sm text-zinc-400 text-center">→</td>
-      <td class="py-1.5 px-2 text-sm font-mono">${s.to_agent}</td>
+      <td class="py-1.5 px-2 text-sm font-mono">
+        <button
+          class="hover:text-sky-400 hover:underline focus:outline-none focus:text-sky-400"
+          onClick=${() => openAgentDetail(s.to_agent)}
+        >${s.to_agent}</button>
+      </td>
       <td class="py-1.5 px-2 text-sm text-right">
         <div class="flex items-center gap-2 justify-end">
           <div class="w-16 bg-zinc-800 rounded h-1.5">


### PR DESCRIPTION
## Summary

PR #7026 (per-keeper memory in detail modal) 위에 cherry — Hebbian 네트워크에서 노드/이름 클릭 시 해당 키퍼의 상세 모달이 열립니다.

## Navigation flow

```
Memory panel → Hebbian network SVG
  └─ node click → openAgentDetail(name) → 상세 모달
                                            └─ 이 키퍼의 시냅스/에피소드 (#7026)
```

혹은 synapse 테이블:
```
Memory panel → 시냅스 테이블 행
  └─ from_agent / to_agent 버튼 → openAgentDetail → 상세 모달
```

## Changes

| File | Change |
|------|--------|
| `dashboard/src/components/memory-subsystems.ts` | SVG `<g>` → role=button + onClick/onKeyDown, SynapseRow cells → inline buttons |

## A11y

- SVG 노드: role=button, tabindex=0, Enter/Space 키 지원, aria-label
- 테이블 셀: \<button\> 태그 + focus 스타일
- `pointer-events-none` on text로 circle 클릭 일관

## Test plan

- [x] `tsc --noEmit` clean
- [ ] CI green
- [ ] 브라우저: 네트워크 노드 클릭 → keeper 모달 열림
- [ ] 브라우저: 시냅스 테이블 이름 클릭 → keeper 모달 열림
- [ ] 키보드: tab으로 노드 포커스 → Enter → 모달 열림

## Depends on

- #7026 (per-keeper memory section in detail modal) — 이 PR과 결합되어야 네트워크 클릭 UX의 payoff가 완성됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)