### PR TITLE
ci: cache pnpm store for dashboard dependency install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,18 @@ jobs:
       - name: Enable corepack and install pnpm
         run: corepack enable && corepack prepare pnpm@10.31.0 --activate
 
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('dashboard/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
       - name: Install dashboard dependencies
         working-directory: dashboard
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## 목적

Dashboard job의 \`pnpm install --frozen-lockfile\` 이 매번 cold 실행. 1m56s 중 약 45-90s가 npm 패키지 다운로드+압축 해제에 소요.

## 변경 (ci.yml, +12)

Dashboard job 안에 actions/cache@v4 step 삽입:

1. \`pnpm store path\` 로 cache path 해석 (corepack 이후 pnpm CLI 사용 가능).
2. key=\`pnpm-\${runner.os}-\${hashFiles('dashboard/pnpm-lock.yaml')}\`.
3. restore-keys=\`pnpm-\${runner.os}-\` 로 lockfile 업데이트 시에도 기존 store 재활용.

## 예상 효과

- cache hit (같은 lockfile): ~45-90s 절감
- cache miss (lockfile 변경): 0 ~ 10s 저장 오버헤드, 다음 실행부터 절감

Dashboard job 전체 시간이 2분대에서 1분대로 떨어질 것.

## 리스크

- pnpm 버전/OS별 cache dir 다름 → \`pnpm store path\` 로 runtime 해석해 안전.
- actions/cache@v4는 post-step 자동 저장. 실패한 job도 저장 안됨(정상).

## Ref

CI 낭비 감사 2026-04-14 — rank #5 항목.

🤖 Generated with [Claude Code](https://claude.com/claude-code)