### PR TITLE
feat(keeper): surface guard penalty / tool policy / turn outcome in decision FSM

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -901,6 +901,7 @@ let keeper_config_json (config : Room.config) (name : string)
           ~thompson_beta:stats.beta
           ~tool_count
           ~recovery_floor_count
+          ()
       in
       let tools_access =
         let allowed = Keeper_exec_tools.keeper_allowed_tool_names m in

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -198,11 +198,15 @@ let flush_if_needed ~base_path ~keeper_name =
 (* ================================================================ *)
 
 let decision_pipeline_to_mermaid
+    ?(guard_penalty_this_cycle : int option)
+    ?(tool_policy_mode : [`Preset of string | `Custom] option)
+    ?(turn_outcome : [`Ok | `Failed | `Blocked] option)
     ~(phase : Keeper_state_machine.phase)
     ~(thompson_alpha : float)
     ~(thompson_beta : float)
     ~(tool_count : int)
     ~(recovery_floor_count : int)
+    ()
     : string =
   let b = Buffer.create 512 in
   let p fmt = Printf.bprintf b fmt in
@@ -242,10 +246,28 @@ let decision_pipeline_to_mermaid
      p "    class Running off\n";
      p "    class Failing off\n");
   p "\n";
+  let penalty_str = match guard_penalty_this_cycle with
+    | Some n -> string_of_int n
+    | None -> "n/a"
+  in
+  let policy_str = match tool_policy_mode with
+    | Some (`Preset name) -> Printf.sprintf "preset:%s" name
+    | Some `Custom -> "custom"
+    | None -> "n/a"
+  in
+  let outcome_str = match turn_outcome with
+    | Some `Ok -> "ok"
+    | Some `Failed -> "failed"
+    | Some `Blocked -> "blocked"
+    | None -> "n/a"
+  in
   p "    note right of Running\n";
   p "      Thompson: %.2f (α=%.1f β=%.1f)\n" score thompson_alpha thompson_beta;
   p "      Tools: %d / floor %d\n" tool_count recovery_floor_count;
   p "      Level: %d\n" level;
+  p "      Guard pen this cycle: %s\n" penalty_str;
+  p "      Tool policy: %s\n" policy_str;
+  p "      Turn outcome: %s\n" outcome_str;
   p "    end note\n";
   Buffer.contents b
 

--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -54,13 +54,23 @@ val ring_capacity : unit -> int
 
 (** Generate a Mermaid stateDiagram-v2 for the Decision Pipeline.
     Shows the Guard→Thompson→ToolPolicy feedback loop with current
-    phase highlighted and Thompson score annotated. *)
+    phase highlighted and Thompson score annotated.
+
+    Optional parameters surface per-cycle Decision Pipeline state from
+    [KeeperDecisionPipeline.tla] (state variables: guard_penalties_this_cycle,
+    tool_policy selection, turn_outcome). When omitted, the note block
+    shows "n/a" for the missing field — callers can adopt the new
+    parameters incrementally without breaking the render. *)
 val decision_pipeline_to_mermaid :
+  ?guard_penalty_this_cycle:int ->
+  ?tool_policy_mode:[`Preset of string | `Custom] ->
+  ?turn_outcome:[`Ok | `Failed | `Blocked] ->
   phase:Keeper_state_machine.phase ->
   thompson_alpha:float ->
   thompson_beta:float ->
   tool_count:int ->
   recovery_floor_count:int ->
+  unit ->
   string
 
 (** Generate a Mermaid stateDiagram-v2 for the Cascade FSM.

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -614,6 +614,7 @@ let handle_keeper_get_subroutes state req request reqd =
           ~thompson_beta:stats.beta
           ~tool_count
           ~recovery_floor_count
+          ()
       in
       let cascade_fsm_mermaid =
         match meta with


### PR DESCRIPTION
## Summary

`decision_pipeline_to_mermaid`에 optional labelled args 3개 추가 — `KeeperDecisionPipeline.tla` state 변수와 1:1 대응. RFC-0003 Phase 1b + `docs/design/dashboard-fsm-redesign.md` §3 구현.

## Changes

### `lib/keeper/keeper_decision_audit.mli`
```ocaml
val decision_pipeline_to_mermaid :
  ?guard_penalty_this_cycle:int ->
  ?tool_policy_mode:[`Preset of string | `Custom] ->
  ?turn_outcome:[`Ok | `Failed | `Blocked] ->
  phase:Keeper_state_machine.phase ->
  thompson_alpha:float ->
  thompson_beta:float ->
  tool_count:int ->
  recovery_floor_count:int ->
  unit ->       (* sentinel so optionals are erasable *)
  string
```

| Optional arg | KeeperDecisionPipeline.tla state var |
|--------------|--------------------------------------|
| `guard_penalty_this_cycle` | `guard_penalties_this_cycle` |
| `tool_policy_mode` | `tool_policy` selection |
| `turn_outcome` | `turn_outcome` |

### `lib/keeper/keeper_decision_audit.ml`
- 구현부에 optional args 추가 + 마지막 `()` sentinel
- `note right of Running` 블록에 3개 라인 추가:
  - `Guard pen this cycle: <n>|n/a`
  - `Tool policy: preset:<name>|custom|n/a`
  - `Turn outcome: ok|failed|blocked|n/a`
- 기존 caller는 이들을 넘기지 않아도 되므로 출력은 이전과 동일(세 줄 모두 "n/a")

### Call sites (모두 `()` 추가만)
- `lib/dashboard/dashboard_http_keeper.ml:898`
- `lib/server/server_dashboard_http_keeper_api.ml:611`

## Why

- **Decision FSM을 진짜 dynamic하게**: 현재는 phase / alpha / beta만 runtime을 반영. 나머지 state 변수는 UI에 안 보임.
- **spec ↔ 렌더 1:1**: `KeeperDecisionPipeline.tla` audit(`docs/tla-audit/decision-fsm-gap-2026-04-13.md`)이 지적한 gap을 좁힘.
- **점진 채택 가능**: 기본값은 `None` → "n/a"로 렌더. 새 caller만 값을 넘기면 즉시 visibility 확보.

## Why unit sentinel?

OCaml 경고 16 (`unerasable-optional-argument`). Optional labelled args 뒤에 non-labeled positional arg가 없으면 컴파일러가 erasure 시점을 결정 불가. 유일한 non-breaking fix는 마지막에 `unit ->`를 덧붙이고 caller가 `()` 추가. signature 인간 가독성 trade-off 있지만 OCaml에서는 canonical.

## Test plan

- [x] `dune build --root=. @check` → lib 컴파일 성공, `masc_mcp__Keeper_decision_audit.cmi/.cmo/.cmti` 생성
- [ ] 수동: dashboard에서 Decision FSM 렌더 후 note 블록에 "Guard pen this cycle: n/a / Tool policy: n/a / Turn outcome: n/a" 노출 확인
- [ ] 후속 PR: caller에서 runtime 값 바인딩 (Thompson stats와 같은 경로)

## 빌드 노트

`@check`에서 lib은 통과하지만 **test 바이너리 3개**가 fail:
- `test/test_worker_container_coverage.ml`
- `test/test_worker_safety_gates.ml`
- `test/test_keeper_tool_matrix_cases.ml`

에러는 모두 `agent_sdk.cmi`와 `masc_mcp__*.cmi` 간 `Llm_provider__Types` interface 불일치 — **본 변경과 무관**. 해당 3개 test는 `decision_pipeline_to_mermaid` 호출하지 않음. 환경 수준의 stale (`opam reinstall agent_sdk` + `dune clean`)로 해결 가능. 이 worktree에서는 환경 변경 안 함.

## Related

- RFC-0003 Keeper Composite Lifecycle — #7020
- `docs/design/dashboard-fsm-redesign.md` §Phase 1b
- `docs/tla-audit/decision-fsm-gap-2026-04-13.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)