### PR TITLE
fix(keeper_circuit_breaker): serialize states + RMW + Cancelled re-raise

### DIFF
--- a/lib/keeper/keeper_failure_circuit_breaker.ml
+++ b/lib/keeper/keeper_failure_circuit_breaker.ml
@@ -51,9 +51,23 @@ type breaker_state = {
 
 let states : (string, breaker_state) Hashtbl.t = Hashtbl.create 16
 
+(** Mutex protecting [states] and every per-keeper [breaker_state].
+    Every production path goes through [Keeper_exec_tools.apply_circuit_breaker]
+    which runs on whichever keeper fiber handled the tool call — multiple
+    keepers execute tools concurrently, so [Hashtbl.find_opt] + conditional
+    [Hashtbl.replace] in [get_or_create] is a textbook TOCTOU, and the
+    per-record [consecutive_count] increment in [record_failure] is a
+    read-modify-write racing against [record_success].  [Eio_guard]
+    lets the module still work before the Eio scheduler starts (module
+    init, non-Eio tests). *)
+let states_mu = Eio.Mutex.create ()
+let with_states_rw f = Eio_guard.with_mutex states_mu f
+let with_states_ro f = Eio_guard.with_mutex_ro states_mu f
+
 let threshold = 3
 
-let get_or_create keeper_name =
+(* Caller must hold [states_mu]. *)
+let get_or_create_locked keeper_name =
   match Hashtbl.find_opt states keeper_name with
   | Some s -> s
   | None ->
@@ -67,27 +81,30 @@ let get_or_create keeper_name =
 (* ================================================================ *)
 
 let record_success ~keeper_name =
-  let s = get_or_create keeper_name in
-  s.consecutive_count <- 0
+  with_states_rw (fun () ->
+    let s = get_or_create_locked keeper_name in
+    s.consecutive_count <- 0)
 
 let rec record_failure ~keeper_name ~(error_msg : string) : string option =
   let cls = classify_error error_msg in
-  let s = get_or_create keeper_name in
-  if cls = s.consecutive_class then
-    s.consecutive_count <- s.consecutive_count + 1
-  else begin
-    s.consecutive_class <- cls;
-    s.consecutive_count <- 1
-  end;
-  if s.consecutive_count >= threshold then begin
-    s.total_tripped <- s.total_tripped + 1;
-    s.consecutive_count <- 0;
-    Log.Keeper.warn
-      "circuit_breaker tripped for %s: %d consecutive %s failures (total trips: %d)"
-      keeper_name threshold (error_class_to_string cls) s.total_tripped;
-    Some (corrective_hint cls keeper_name)
-  end else
-    None
+  with_states_rw (fun () ->
+    let s = get_or_create_locked keeper_name in
+    if cls = s.consecutive_class then
+      s.consecutive_count <- s.consecutive_count + 1
+    else begin
+      s.consecutive_class <- cls;
+      s.consecutive_count <- 1
+    end;
+    if s.consecutive_count >= threshold then begin
+      s.total_tripped <- s.total_tripped + 1;
+      s.consecutive_count <- 0;
+      let tripped = s.total_tripped in
+      Log.Keeper.warn
+        "circuit_breaker tripped for %s: %d consecutive %s failures (total trips: %d)"
+        keeper_name threshold (error_class_to_string cls) tripped;
+      Some (corrective_hint cls keeper_name)
+    end else
+      None)
 
 and corrective_hint cls keeper_name =
   let base =
@@ -149,7 +166,9 @@ let maybe_enrich_error ~keeper_name ~(error_msg : string) : string =
          in
          Yojson.Safe.to_string (`Assoc with_breaker)
        | _ -> error_msg ^ hint
-     with _ -> error_msg ^ hint)
+     with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | _ -> error_msg ^ hint)
 
 (* ================================================================ *)
 (* Diagnostics                                                      *)
@@ -157,13 +176,14 @@ let maybe_enrich_error ~keeper_name ~(error_msg : string) : string =
 
 let snapshot_json () : Yojson.Safe.t =
   let entries =
-    Hashtbl.fold (fun name state acc ->
-      `Assoc [
-        "keeper", `String name;
-        "consecutive_class", `String (error_class_to_string state.consecutive_class);
-        "consecutive_count", `Int state.consecutive_count;
-        "total_tripped", `Int state.total_tripped;
-      ] :: acc
-    ) states []
+    with_states_ro (fun () ->
+      Hashtbl.fold (fun name state acc ->
+        `Assoc [
+          "keeper", `String name;
+          "consecutive_class", `String (error_class_to_string state.consecutive_class);
+          "consecutive_count", `Int state.consecutive_count;
+          "total_tripped", `Int state.total_tripped;
+        ] :: acc
+      ) states [])
   in
   `List entries


### PR DESCRIPTION
## Summary

\`Keeper_failure_circuit_breaker\` tracks per-keeper tool-failure state in a module-level \`Hashtbl.t\` with mutable record fields, but had no synchronization at all. Its production callers run on whichever keeper fiber handled the failing tool call (\`Keeper_exec_tools.apply_circuit_breaker\` at \`lib/keeper/keeper_exec_tools.ml:79,82\`), and multiple keepers in the same room execute tools concurrently — so every access path was effectively unprotected against cross-fiber races.

## Races fixed

1. **TOCTOU in \`get_or_create\`** — \`Hashtbl.find_opt states\` followed by conditional \`Hashtbl.replace\`. Two fibers with the same \`keeper_name\` both see \`None\`, both construct a fresh \`breaker_state\`, both \`Hashtbl.replace\`, and the loser's state is orphaned. One of the two subsequent increments lands on a stale record that isn't in the table.

2. **RMW in \`record_failure\`** — the body reads \`s.consecutive_count\`, decides based on it, then writes \`s.consecutive_count <- n+1\`. Two concurrent failures of the same error class can both read \`n\` and both write \`n+1\`, so the counter advances by one instead of two. The trip threshold is consequently reached later than intended, which is exactly the diagnostic this module is supposed to provide.

3. **\`Hashtbl.fold\` in \`snapshot_json\`** — diagnostic snapshot walks the table while writers may be calling \`Hashtbl.replace\` from other fibers. OCaml \`Hashtbl\` does not support concurrent mutate-during-fold; a resize in the middle of the walk corrupts the iteration.

## Bonus: Cancelled swallow

\`maybe_enrich_error\` had \`try ... with _ -> error_msg ^ hint\` wrapping the JSON enrichment — same catch-all bug class as #6990. Added \`| Eio.Cancel.Cancelled _ as e -> raise e\` before the fall-through so cancellation still propagates.

## Change

- Add \`states_mu : Eio.Mutex.t\` + \`with_states_rw\` / \`with_states_ro\` via \`Eio_guard\` (so module init and non-Eio tests still work without \`Effect.Unhandled\`).
- Rename \`get_or_create\` → \`get_or_create_locked\` with a "caller holds \`states_mu\`" contract (same \`_locked\` convention already used in \`agent_registry_eio\`).
- Wrap \`record_success\` / \`record_failure\` / \`snapshot_json\` in the appropriate critical section.
- Move the \`Log.Keeper.warn\` call inside the critical section; the log reads \`s.total_tripped\` immediately after mutating it, so pulling the read inside the lock prevents a stale value being logged when another fiber trips between the mutation and the log line.
- Fix the \`with _\` catch-all to re-raise \`Eio.Cancel.Cancelled\`.

## Test plan

- [x] \`dune build --root . lib/\` — clean
- [ ] CI full suite (runs on PR)
- [ ] Existing \`test/test_circuit_breaker.ml\` should still pass (no API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)