### PR TITLE
fix(keeper): signal-driven rollover trigger to unstick error loops (#7030)

### DIFF
--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -80,6 +80,13 @@ type handoff_rollover = Keeper_rollover.handoff_rollover = {
 
 let maybe_rollover_oas_handoff = Keeper_rollover.maybe_rollover_oas_handoff
 
+type rollover_gate_decision = Keeper_rollover.rollover_gate_decision =
+  | Skip of string
+  | Go of string
+
+let blocker_indicates_overflow = Keeper_rollover.blocker_indicates_overflow
+let classify_rollover_gate = Keeper_rollover.classify_rollover_gate
+
 (* ================================================================ *)
 (* Re-export from Keeper_compact_policy                              *)
 (* ================================================================ *)

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -126,6 +126,31 @@ val maybe_rollover_oas_handoff :
   checkpoint:Agent_sdk.Checkpoint.t option ->
   handoff_rollover
 
+(** {2 Pure gate helpers (for testing)} *)
+
+type rollover_gate_decision =
+  | Skip of string
+  | Go of string
+
+(** [blocker_indicates_overflow msg] returns true when [msg] matches a
+    provider-agnostic context-overflow wording (GLM / OpenAI / Ollama /
+    Anthropic). Case-insensitive substring match. *)
+val blocker_indicates_overflow : string -> bool
+
+(** [classify_rollover_gate] is the pure decision function used by
+    [maybe_rollover_oas_handoff]. Exposed for unit tests.
+
+    Returns [Go reason] when a handoff should be attempted; [Skip reason]
+    otherwise. The [reason] string is surfaced in logs and [handoff_json]. *)
+val classify_rollover_gate :
+  auto_handoff:bool ->
+  cooldown_elapsed:bool ->
+  ratio:float ->
+  handoff_threshold:float ->
+  last_outcome:proactive_cycle_outcome ->
+  last_blocker:string ->
+  rollover_gate_decision
+
 (** {1 Checkpoint Loading and Saving} *)
 
 val load_context_from_checkpoint :

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -20,6 +20,61 @@ type handoff_rollover = {
   message_count : int;
 }
 
+(** [blocker_indicates_overflow blocker] returns true when [blocker] matches any
+    of the provider-specific context-overflow strings. Provider-agnostic list
+    covers GLM, OpenAI, Ollama, and Anthropic wording.
+
+    Exposed for unit testing. Pure — no runtime dependency. *)
+let blocker_indicates_overflow (blocker : string) : bool =
+  let b = String.lowercase_ascii blocker in
+  let blen = String.length b in
+  let contains needle =
+    let nlen = String.length needle in
+    if nlen = 0 || blen < nlen then false
+    else
+      let rec scan i =
+        if i + nlen > blen then false
+        else if String.sub b i nlen = needle then true
+        else scan (i + 1)
+      in
+      scan 0
+  in
+  contains "exceeds max length"
+  || contains "context_length_exceeded"
+  || contains "prompt is too long"
+  || contains "prompt too long"
+  || contains "maximum context length"
+
+type rollover_gate_decision =
+  | Skip of string
+  | Go of string
+
+(** [classify_rollover_gate] returns the gate verdict without any side effects.
+
+    The ratio gate reflects the *checkpoint* history. The signal gate reflects
+    the *actual* LLM response for the last turn: when a proactive turn errored
+    with an overflow-class blocker, rollover is triggered regardless of the
+    checkpoint ratio — the ratio gate structurally cannot fire once compaction
+    shrinks the checkpoint below the threshold (umbrella #7036). *)
+let classify_rollover_gate
+    ~(auto_handoff : bool) ~(cooldown_elapsed : bool)
+    ~(ratio : float) ~(handoff_threshold : float)
+    ~(last_outcome : proactive_cycle_outcome)
+    ~(last_blocker : string) : rollover_gate_decision =
+  if not auto_handoff then Skip "auto_handoff_disabled"
+  else if not cooldown_elapsed then Skip "cooldown"
+  else
+    let ratio_gate = ratio >= handoff_threshold in
+    let signal_gate =
+      last_outcome = Proactive_error
+      && blocker_indicates_overflow last_blocker
+    in
+    match ratio_gate, signal_gate with
+    | true, true -> Go "ratio+signal"
+    | false, true -> Go "persistent_overflow_blocker"
+    | true, false -> Go "ratio"
+    | false, false -> Skip "below_thresholds"
+
 let maybe_rollover_oas_handoff
     ~(on_started : unit -> unit)
     ~(base_dir : string)
@@ -54,6 +109,15 @@ let maybe_rollover_oas_handoff
         || Time_compat.now () -. base_meta.runtime.last_handoff_ts
            >= float_of_int base_meta.handoff_cooldown_sec
       in
+      let gate_decision =
+        classify_rollover_gate
+          ~auto_handoff:base_meta.auto_handoff
+          ~cooldown_elapsed
+          ~ratio
+          ~handoff_threshold:base_meta.handoff_threshold
+          ~last_outcome:base_meta.runtime.proactive_rt.last_outcome
+          ~last_blocker:base_meta.runtime.last_blocker
+      in
       let rollover_base =
         {
           updated_meta = base_meta;
@@ -66,13 +130,9 @@ let maybe_rollover_oas_handoff
           message_count = message_count ctx;
         }
       in
-      if
-        not base_meta.auto_handoff
-        || ratio < base_meta.handoff_threshold
-        || not cooldown_elapsed
-      then
-        rollover_base
-      else
+      (match gate_decision with
+      | Skip _ -> rollover_base
+      | Go trigger_reason ->
         let now_ts = Time_compat.now () in
         let prev_trace_id = base_meta.runtime.trace_id in
         let new_trace_id = Keeper_identity.generate_trace_id () in
@@ -127,12 +187,13 @@ let maybe_rollover_oas_handoff
                        ("new_trace_id", `String new_trace_id);
                        ("to_model", `String model);
                        ("context_ratio", `Float ratio);
+                       ("trigger_reason", `String trigger_reason);
                      ]
                  in
                  Log.Keeper.info
-                   "keeper:%s OAS handoff rollover trace=%s->%s gen=%d->%d ratio=%.3f"
+                   "keeper:%s OAS handoff rollover trace=%s->%s gen=%d->%d ratio=%.3f trigger=%s"
                    base_meta.name (Keeper_id.Trace_id.to_string prev_trace_id) new_trace_id current_generation
-                   next_generation ratio;
+                   next_generation ratio trigger_reason;
                  { rollover_base with
                    updated_meta;
                    handoff_json = Some handoff_json;
@@ -146,4 +207,4 @@ let maybe_rollover_oas_handoff
             { rollover_base with
               attempted = true;
               failure_reason = Some (Printexc.to_string exn);
-            })
+            }))

--- a/test/dune
+++ b/test/dune
@@ -48,6 +48,7 @@
         test_keeper_adaptive_thinking
         test_keeper_lifecycle
         test_keeper_lifecycle_chaos
+        test_keeper_rollover_gate
         test_keeper_deliberation
         test_keeper_registry
         test_keeper_supervisor
@@ -126,6 +127,7 @@
         test_keeper_adaptive_thinking
           test_keeper_lifecycle
           test_keeper_lifecycle_chaos
+          test_keeper_rollover_gate
           test_keeper_deliberation
           test_keeper_registry
           test_keeper_supervisor

--- a/test/test_keeper_rollover_gate.ml
+++ b/test/test_keeper_rollover_gate.ml
@@ -1,0 +1,174 @@
+(** Tests for the pure rollover gate decision.
+
+    Covers the signal-driven handoff trigger that resolves umbrella #7036
+    (keeper fleet stuck in error loop with compaction_count >> generation). *)
+
+open Alcotest
+
+module KR = Masc_mcp.Keeper_exec_context
+module KT = Masc_mcp.Keeper_types
+
+let decision_testable =
+  let pp fmt = function
+    | KR.Skip reason -> Format.fprintf fmt "Skip(%s)" reason
+    | KR.Go reason -> Format.fprintf fmt "Go(%s)" reason
+  in
+  let eq a b =
+    match a, b with
+    | KR.Skip x, KR.Skip y | KR.Go x, KR.Go y -> String.equal x y
+    | _ -> false
+  in
+  testable pp eq
+
+let overflow_blockers_are_recognized () =
+  let cases = [
+    "Invalid request: Prompt exceeds max length";  (* GLM *)
+    "Error: context_length_exceeded";               (* OpenAI *)
+    "the prompt is too long to fit in the context window";  (* Ollama *)
+    "Anthropic API: prompt too long (200001 > 200000)";     (* Anthropic *)
+    "Model exceeded its maximum context length of 8192";    (* variant *)
+  ] in
+  List.iter
+    (fun msg ->
+      check bool
+        (Printf.sprintf "overflow match: %S" msg)
+        true
+        (KR.blocker_indicates_overflow msg))
+    cases
+
+let non_overflow_blockers_are_not_matched () =
+  let cases = [
+    "";
+    "Internal error: cascade keeper_unified: all models failed";
+    "turn outcome ambiguous after committed message";
+    "network timeout";
+    "rate limited";
+  ] in
+  List.iter
+    (fun msg ->
+      check bool
+        (Printf.sprintf "no false match: %S" msg)
+        false
+        (KR.blocker_indicates_overflow msg))
+    cases
+
+let gate_skips_when_auto_handoff_disabled () =
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:false
+      ~cooldown_elapsed:true
+      ~ratio:0.99
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_error
+      ~last_blocker:"Prompt exceeds max length"
+  in
+  check decision_testable "disabled → Skip"
+    (KR.Skip "auto_handoff_disabled") decision
+
+let gate_skips_when_cooldown_active () =
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:true
+      ~cooldown_elapsed:false
+      ~ratio:0.99
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_error
+      ~last_blocker:"Prompt exceeds max length"
+  in
+  check decision_testable "cooldown → Skip" (KR.Skip "cooldown") decision
+
+let gate_fires_on_ratio () =
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:true
+      ~cooldown_elapsed:true
+      ~ratio:0.90
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_silent
+      ~last_blocker:""
+  in
+  check decision_testable "ratio gate" (KR.Go "ratio") decision
+
+let gate_fires_on_persistent_overflow_despite_low_ratio () =
+  (* This is the umbrella #7036 masc-improver scenario:
+     checkpoint ratio stays at 4.5% because compaction shrinks the snapshot,
+     but the real prompt (context_injector-assembled) exceeds model max.
+     The ratio-only gate structurally cannot fire; the signal gate must. *)
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:true
+      ~cooldown_elapsed:true
+      ~ratio:0.045  (* masc-improver snapshot 2026-04-14 *)
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_error
+      ~last_blocker:"Invalid request: Prompt exceeds max length"
+  in
+  check decision_testable "signal gate fires despite low ratio"
+    (KR.Go "persistent_overflow_blocker") decision
+
+let gate_reports_both_when_both_conditions_true () =
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:true
+      ~cooldown_elapsed:true
+      ~ratio:0.90
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_error
+      ~last_blocker:"context_length_exceeded"
+  in
+  check decision_testable "both → ratio+signal"
+    (KR.Go "ratio+signal") decision
+
+let gate_requires_error_outcome_for_signal_trigger () =
+  (* A blocker string alone isn't enough — the outcome must be Proactive_error.
+     Prevents stale blocker from a resolved turn triggering spurious rollover. *)
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:true
+      ~cooldown_elapsed:true
+      ~ratio:0.2
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_text_response
+      ~last_blocker:"Prompt exceeds max length (stale)"
+  in
+  check decision_testable "stale blocker without error → Skip"
+    (KR.Skip "below_thresholds") decision
+
+let gate_skips_below_all_thresholds () =
+  let decision =
+    KR.classify_rollover_gate
+      ~auto_handoff:true
+      ~cooldown_elapsed:true
+      ~ratio:0.10
+      ~handoff_threshold:0.85
+      ~last_outcome:KT.Proactive_silent
+      ~last_blocker:""
+  in
+  check decision_testable "all quiet → Skip"
+    (KR.Skip "below_thresholds") decision
+
+let () =
+  run "Keeper_rollover.gate" [
+    "blocker classification", [
+      test_case "overflow strings recognized" `Quick
+        overflow_blockers_are_recognized;
+      test_case "non-overflow strings rejected" `Quick
+        non_overflow_blockers_are_not_matched;
+    ];
+    "gate decisions", [
+      test_case "skip when auto_handoff disabled" `Quick
+        gate_skips_when_auto_handoff_disabled;
+      test_case "skip when cooldown active" `Quick
+        gate_skips_when_cooldown_active;
+      test_case "fires on ratio alone" `Quick
+        gate_fires_on_ratio;
+      test_case "fires on persistent overflow despite low ratio (#7036)" `Quick
+        gate_fires_on_persistent_overflow_despite_low_ratio;
+      test_case "reports ratio+signal when both true" `Quick
+        gate_reports_both_when_both_conditions_true;
+      test_case "requires error outcome for signal trigger" `Quick
+        gate_requires_error_outcome_for_signal_trigger;
+      test_case "skip below all thresholds" `Quick
+        gate_skips_below_all_thresholds;
+    ];
+  ]


### PR DESCRIPTION
## Summary

Extends `keeper_rollover` to trigger handoff rollover on a persistent overflow blocker, not only on checkpoint ratio. Resolves the fleet-wide stuck-generation state documented in umbrella #7036 and addresses sub-issue #7030.

## Why

The existing gate (`ratio >= handoff_threshold`) reads the post-compaction checkpoint, which does **not** reflect the real LLM prompt assembled by `context_injector` (system prompt + tool registry + memory bank + board + dynamic context). When the real prompt exceeds the model's `max_context`, the checkpoint stays small and the ratio gate structurally cannot fire.

**Fleet evidence (2026-04-14):**

| keeper | compaction_count | generation |
|--------|------------------|------------|
| poe | 39 | 0 |
| sangsu | 30 | 0 |
| analyst | 17 | 0 |
| ani1999 | 15 | 0 |
| masc-improver | 10 | 5 |

`masc-improver` concrete case: `last_input_tokens=202,730` vs glm-5.1 `max_context=200,000` (**101% overflow**), `last_blocker="Invalid request: Prompt exceeds max length"` persisting 17+ hours across 115 proactive ticks. No rollover, no escalation.

## What changes

- New pure helper `blocker_indicates_overflow : string -> bool` matches provider-agnostic overflow wording (GLM / OpenAI / Ollama / Anthropic) via case-insensitive substring search.
- New pure decision function `classify_rollover_gate` returns `Skip of string | Go of string`. Ratio gate remains, persistent-overflow gate added.
- `maybe_rollover_oas_handoff` consumes the decision and surfaces `trigger_reason` in `handoff_json` and log output.
- 9 unit tests cover provider strings, stale-blocker rejection, and the umbrella #7036 low-ratio + overflow scenario.

## What this does NOT change (follow-ups)

- **#7033** duplicate handoff gate (`keeper_guard` vs `keeper_rollover`) — separate refactor.
- **#7035** cascade-exhaustion blockers — need a different signal + model switch, not rollover. The overflow-class matcher does not match `"cascade keeper_unified: all models"`.
- **#7031 / #7032** — `evidence_chain_valid` and `collision_warnings` still logged but not consumed.

## Test plan

- [x] `dune exec test/test_keeper_rollover_gate.exe` → 9/9 pass
- [x] `dune build --root .` → full build clean
- [ ] CI lifecycle/chaos tests pass
- [ ] Deploy and verify masc-improver transitions generation within one cooldown window

## Trigger reasons emitted in logs and handoff_json

- `ratio` — original behavior
- `persistent_overflow_blocker` — new, umbrella #7036 target
- `ratio+signal` — both conditions true simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)