### PR TITLE
feat(keeper): composite lifecycle observer — RFC-0003 scaffold

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -468,6 +468,7 @@
    keeper_agent_run
    keeper_world_observation
    keeper_decision_audit
+   keeper_composite_observer
    keeper_unified_prompt
    keeper_unified_turn
 

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -1,0 +1,301 @@
+(** Composite observer — pure projection. See [.mli] for contract. *)
+
+type turn_phase =
+  [ `Idle
+  | `Prompting
+  | `Executing
+  | `Compacting
+  | `Finalizing ]
+
+type decision_stage =
+  [ `Undecided
+  | `Guard_ok
+  | `Gate_rejected
+  | `Tool_policy_selected ]
+
+type cascade_state =
+  [ `Idle
+  | `Selecting
+  | `Trying
+  | `Done
+  | `Exhausted ]
+
+type compaction_stage =
+  [ `Accumulating
+  | `Compacting
+  | `Done ]
+
+type invariants_check = {
+  phase_turn_alignment : bool;
+  no_cascade_before_measurement : bool;
+  compaction_atomicity : bool;
+  event_priority_monotone : bool;
+  recovery_two_store_sync : bool;
+}
+
+type snapshot = {
+  correlation_id : string;
+  run_id : string;
+  ts : float;
+  ksm_phase : Keeper_state_machine.phase;
+  ktc_turn_phase : turn_phase;
+  kdp_decision : decision_stage;
+  kcl_cascade_state : cascade_state;
+  kmc_compaction : compaction_stage;
+  shared_measurement : Keeper_state_machine.auto_rule_summary option;
+  reconcile_data : bool;
+  reconcile_fsm : bool;
+  invariants : invariants_check;
+}
+
+let turn_phase_to_string = function
+  | `Idle -> "idle"
+  | `Prompting -> "prompting"
+  | `Executing -> "executing"
+  | `Compacting -> "compacting"
+  | `Finalizing -> "finalizing"
+
+let decision_stage_to_string = function
+  | `Undecided -> "undecided"
+  | `Guard_ok -> "guard_ok"
+  | `Gate_rejected -> "gate_rejected"
+  | `Tool_policy_selected -> "tool_policy_selected"
+
+let cascade_state_to_string = function
+  | `Idle -> "idle"
+  | `Selecting -> "selecting"
+  | `Trying -> "trying"
+  | `Done -> "done"
+  | `Exhausted -> "exhausted"
+
+let compaction_stage_to_string = function
+  | `Accumulating -> "accumulating"
+  | `Compacting -> "compacting"
+  | `Done -> "done"
+
+(* ================================================================ *)
+(* Derivation from registry entry                                   *)
+(* ================================================================ *)
+
+(* The turn-cycle phase is derived from the keeper lifecycle phase.
+   Per-turn-internal sub-phases (Prompting, Executing) are not visible
+   to the observer — those live inside a single [run_unified_turn] call.
+   Post-turn hooks (PR follow-up) will update shared state so the
+   observer can distinguish them. *)
+let derive_turn_phase (entry : Keeper_registry.registry_entry) : turn_phase =
+  match entry.phase with
+  | Keeper_state_machine.Compacting -> `Compacting
+  | Keeper_state_machine.HandingOff
+  | Keeper_state_machine.Draining -> `Finalizing
+  | _ -> `Idle
+
+(* Compaction sub-FSM: compaction_active is the authoritative condition.
+   Phase [Compacting] MUST coincide with this condition under the
+   [PhaseTurnAlignment] invariant; any drift is a safety signal. *)
+let derive_compaction_stage (conds : Keeper_state_machine.conditions)
+    : compaction_stage =
+  if conds.compaction_active then `Compacting
+  else `Accumulating
+
+(* Decision pipeline stage. Observer-visible only via [guardrail_triggered]
+   for now; per-turn Guard/Thompson/ToolPolicy staging requires reading
+   the decision-audit ring buffer (follow-up). *)
+let derive_decision_stage (conds : Keeper_state_machine.conditions)
+    : decision_stage =
+  if conds.guardrail_triggered then `Gate_rejected
+  else `Undecided
+
+(* Cascade state is per-turn-internal; not derivable from registry alone.
+   Follow-up PR wires [Local_runtime_pool] slot telemetry and
+   [Keeper_exec_status_metrics.last_model_used] into an observable field. *)
+let derive_cascade_state (_ : Keeper_registry.registry_entry) : cascade_state =
+  `Idle
+
+(* Two-store reconcile pair (RFC-0003 §8, absorbed from P4).
+   - [reconcile_data]: a prior turn left an ambiguous side-effect record
+     that still requires operator resolution. Sourced from
+     [last_failure_reason] when the reason is classified as requiring
+     manual reconcile.
+   - [reconcile_fsm]: the keeper's own state machine still carries
+     [manual_reconcile_required] as an observable condition. *)
+let derive_reconcile (entry : Keeper_registry.registry_entry) : bool * bool =
+  let reconcile_data =
+    match entry.last_failure_reason with
+    | None -> false
+    | Some reason ->
+      Keeper_registry.failure_reason_requires_manual_reconcile reason
+  in
+  let reconcile_fsm = entry.conditions.manual_reconcile_required in
+  (reconcile_data, reconcile_fsm)
+
+(* ================================================================ *)
+(* Invariants                                                       *)
+(* ================================================================ *)
+
+let check_phase_turn_alignment
+    (phase : Keeper_state_machine.phase)
+    (turn_phase : turn_phase)
+    : bool =
+  match phase, turn_phase with
+  | Keeper_state_machine.Compacting, `Compacting -> true
+  | Keeper_state_machine.Compacting, _ -> false
+  | _, `Compacting -> false
+  | _ -> true
+
+let check_compaction_atomicity
+    (phase : Keeper_state_machine.phase)
+    (conds : Keeper_state_machine.conditions)
+    : bool =
+  let phase_is_compacting = phase = Keeper_state_machine.Compacting in
+  phase_is_compacting = conds.compaction_active
+
+(* RecoveryTwoStoreSync from KeeperCompositeLifecycle.tla:
+   the dangerous ordering is [reconcile_data cleared /\ reconcile_fsm still set],
+   which indicates a prior clear raced ahead of the FSM condition update.
+   The normal [(T,T) → (F,T) → (F,F)] path passes through [(F,T)] but only
+   as a transient; if observed, it may just be an in-flight reconcile.
+   For the snapshot-level check we flag only the reverse-order anomaly:
+   [reconcile_fsm cleared while reconcile_data still set]. *)
+let check_recovery_two_store_sync
+    ~(reconcile_data : bool)
+    ~(reconcile_fsm : bool)
+    : bool =
+  not (reconcile_data && not reconcile_fsm)
+
+let compute_invariants
+    ~(phase : Keeper_state_machine.phase)
+    ~(conds : Keeper_state_machine.conditions)
+    ~(turn_phase : turn_phase)
+    ~(reconcile_data : bool)
+    ~(reconcile_fsm : bool)
+    : invariants_check =
+  {
+    phase_turn_alignment = check_phase_turn_alignment phase turn_phase;
+    no_cascade_before_measurement = true;
+    (* trivially true until cascade state is observable — see
+       [derive_cascade_state]. *)
+    compaction_atomicity = check_compaction_atomicity phase conds;
+    event_priority_monotone = true;
+    (* per-snapshot view cannot witness event ordering; this invariant
+       becomes checkable when the event-bus broadcast carries priority
+       annotations (follow-up). *)
+    recovery_two_store_sync =
+      check_recovery_two_store_sync ~reconcile_data ~reconcile_fsm;
+  }
+
+(* ================================================================ *)
+(* Public API                                                       *)
+(* ================================================================ *)
+
+let stable_correlation_id (entry : Keeper_registry.registry_entry) : string =
+  Printf.sprintf "keeper:%s:%d" entry.name entry.transition_seq
+
+let stable_run_id (entry : Keeper_registry.registry_entry) : string =
+  Printf.sprintf "r-%.0f-%d" entry.started_at entry.restart_count
+
+let observe
+    ?correlation_id
+    ?run_id
+    ?now
+    (entry : Keeper_registry.registry_entry)
+    : snapshot =
+  let ts = match now with Some t -> t | None -> Time_compat.now () in
+  let correlation_id =
+    match correlation_id with
+    | Some s when String.length s > 0 -> s
+    | _ -> stable_correlation_id entry
+  in
+  let run_id =
+    match run_id with
+    | Some s when String.length s > 0 -> s
+    | _ -> stable_run_id entry
+  in
+  let conds = entry.conditions in
+  let turn_phase = derive_turn_phase entry in
+  let compaction_stage = derive_compaction_stage conds in
+  let decision_stage = derive_decision_stage conds in
+  let cascade_state = derive_cascade_state entry in
+  let (reconcile_data, reconcile_fsm) = derive_reconcile entry in
+  let invariants =
+    compute_invariants
+      ~phase:entry.phase
+      ~conds
+      ~turn_phase
+      ~reconcile_data
+      ~reconcile_fsm
+  in
+  {
+    correlation_id;
+    run_id;
+    ts;
+    ksm_phase = entry.phase;
+    ktc_turn_phase = turn_phase;
+    kdp_decision = decision_stage;
+    kcl_cascade_state = cascade_state;
+    kmc_compaction = compaction_stage;
+    shared_measurement = None;
+    (* Registry does not yet retain the last [Context_measured] summary;
+       the follow-up PR adds [last_auto_rules : (float * auto_rule_summary) option]
+       to [registry_entry] so observers can surface the last measurement. *)
+    reconcile_data;
+    reconcile_fsm;
+    invariants;
+  }
+
+(* ================================================================ *)
+(* JSON serialisation (RFC-0003 §7)                                *)
+(* ================================================================ *)
+
+let invariants_to_json (inv : invariants_check) : Yojson.Safe.t =
+  `Assoc [
+    "phase_turn_alignment", `Bool inv.phase_turn_alignment;
+    "no_cascade_before_measurement", `Bool inv.no_cascade_before_measurement;
+    "compaction_atomicity", `Bool inv.compaction_atomicity;
+    "event_priority_monotone", `Bool inv.event_priority_monotone;
+    "recovery_two_store_sync", `Bool inv.recovery_two_store_sync;
+  ]
+
+let measurement_to_json (m : Keeper_state_machine.auto_rule_summary)
+    : Yojson.Safe.t =
+  `Assoc [
+    "reflect", `Bool m.reflect;
+    "plan", `Bool m.plan;
+    "compact", `Bool m.compact;
+    "handoff", `Bool m.handoff;
+    "guardrail_stop", `Bool m.guardrail_stop;
+    "guardrail_reason", (match m.guardrail_reason with
+      | Some s -> `String s
+      | None -> `Null);
+    "goal_drift", `Float m.goal_drift;
+  ]
+
+let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
+  `Assoc [
+    "correlation_id", `String s.correlation_id;
+    "run_id", `String s.run_id;
+    "ts", `Float s.ts;
+    "phase", `String (Keeper_state_machine.phase_to_string s.ksm_phase);
+    "turn_phase", `String (turn_phase_to_string s.ktc_turn_phase);
+    "decision", `Assoc [
+      "stage", `String (decision_stage_to_string s.kdp_decision);
+    ];
+    "cascade", `Assoc [
+      "state", `String (cascade_state_to_string s.kcl_cascade_state);
+    ];
+    "compaction", `Assoc [
+      "stage", `String (compaction_stage_to_string s.kmc_compaction);
+    ];
+    "measurement", (match s.shared_measurement with
+      | Some m -> `Assoc [
+          "captured", `Bool true;
+          "auto_rules", measurement_to_json m;
+        ]
+      | None -> `Assoc [
+          "captured", `Bool false;
+        ]);
+    "recovery", `Assoc [
+      "data_record", `Bool s.reconcile_data;
+      "fsm_condition", `Bool s.reconcile_fsm;
+    ];
+    "invariants", invariants_to_json s.invariants;
+  ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -1,0 +1,104 @@
+(** Keeper Composite Lifecycle Observer — pure projection.
+
+    Projects a [Keeper_registry.registry_entry] into a composite snapshot
+    spanning Decision / Cascade / Memory / Compaction sub-FSMs as
+    specified in RFC-0003 and
+    [specs/keeper-state-machine/KeeperCompositeLifecycle.tla].
+
+    Contract:
+    - Pure read. No mutation, no I/O, no event emission.
+    - Never calls [Keeper_state_machine.apply_event],
+      [Keeper_cascade_routing.select_cascade], or any routine that would
+      shift keeper lifecycle state.
+    - Does not read provider names, token counts, or context bytes —
+      those belong to OAS (see [feedback_masc-oas-layer-boundary]).
+
+    Initial scope: derives [ksm_phase] and [kmc_compaction] directly from
+    the registry entry. [kdp_decision] / [kcl_cascade_state] remain
+    [`Undecided`] / [`Idle`] until follow-up PRs wire the
+    [Context_measured] / cascade-runtime observation points.
+
+    @since RFC-0003 — Composite observer v0. *)
+
+type turn_phase =
+  [ `Idle
+  | `Prompting
+  | `Executing
+  | `Compacting
+  | `Finalizing ]
+
+type decision_stage =
+  [ `Undecided
+  | `Guard_ok
+  | `Gate_rejected
+  | `Tool_policy_selected ]
+
+type cascade_state =
+  [ `Idle
+  | `Selecting
+  | `Trying
+  | `Done
+  | `Exhausted ]
+
+type compaction_stage =
+  [ `Accumulating
+  | `Compacting
+  | `Done ]
+
+(** Five safety invariants from KeeperCompositeLifecycle.tla.
+    Each field is [true] when the invariant holds for the observed
+    snapshot. A [false] value signals a composite-level safety violation
+    that the dashboard should surface to the operator. *)
+type invariants_check = {
+  phase_turn_alignment : bool;
+  no_cascade_before_measurement : bool;
+  compaction_atomicity : bool;
+  event_priority_monotone : bool;
+  recovery_two_store_sync : bool;
+}
+
+type snapshot = {
+  correlation_id : string;
+  run_id : string;
+  ts : float;
+  ksm_phase : Keeper_state_machine.phase;
+  ktc_turn_phase : turn_phase;
+  kdp_decision : decision_stage;
+  kcl_cascade_state : cascade_state;
+  kmc_compaction : compaction_stage;
+  shared_measurement : Keeper_state_machine.auto_rule_summary option;
+  reconcile_data : bool;
+  reconcile_fsm : bool;
+  invariants : invariants_check;
+}
+
+(** Derive a composite snapshot from a live registry entry.
+
+    [correlation_id] and [run_id] may be supplied by the caller when the
+    observer is driven from a known event envelope (OAS event_bus
+    envelope, PR OAS#845). When absent, the snapshot uses
+    [keeper:<name>:<transition_seq>] as a stable identifier so repeated
+    reads within the same keeper transition return the same id. *)
+val observe :
+  ?correlation_id:string ->
+  ?run_id:string ->
+  ?now:float ->
+  Keeper_registry.registry_entry ->
+  snapshot
+
+(** Stringify [turn_phase] for JSON serialisation. Mirrors the lowercase
+    edge labels used in KeeperTurnCycle.tla. *)
+val turn_phase_to_string : turn_phase -> string
+
+(** Stringify [decision_stage]. Mirrors KeeperDecisionPipeline.tla. *)
+val decision_stage_to_string : decision_stage -> string
+
+(** Stringify [cascade_state]. Mirrors CascadeLiveness.tla action labels. *)
+val cascade_state_to_string : cascade_state -> string
+
+(** Stringify [compaction_stage]. Mirrors MemoryCompaction.tla. *)
+val compaction_stage_to_string : compaction_stage -> string
+
+(** Serialise a snapshot as the [/api/keepers/:name/composite] payload
+    documented in RFC-0003 §7. *)
+val snapshot_to_json : snapshot -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

Introduces `Keeper_composite_observer` — the pure projection module promised by RFC-0003 §6 and scaffolded as the foundation for Phase 3 (`/fsm` hub) and Phase 4 (SSE stream) of `docs/design/dashboard-fsm-redesign.md`.

## Scope

Backend only. Two new files + dune entry:

- `lib/keeper/keeper_composite_observer.mli` — public contract (types, invariants record, `observe`, `snapshot_to_json`).
- `lib/keeper/keeper_composite_observer.ml` — projection implementation.
- `lib/dune` — module registration.

## What the observer does

Reads a live `Keeper_registry.registry_entry` and produces a snapshot with:

- `ksm_phase` — keeper 11-state lifecycle phase (RFC-0002).
- `ktc_turn_phase`, `kmc_compaction` — derived from observable conditions.
- `kdp_decision`, `kcl_cascade_state` — conservative defaults this round; follow-up PRs wire the `Context_measured` retention field and the cascade-runtime observation point.
- `shared_measurement` — `None` until the registry retains the last `auto_rule_summary` (follow-up PR adds `last_auto_rules : (float * auto_rule_summary) option`).
- `reconcile_data` / `reconcile_fsm` — two-store recovery pair from RFC-0003 §8 (absorbs the P4 proposal from `state-fsm-gap-2026-04-13.md`).
- `invariants` — five safety checks from `specs/keeper-state-machine/KeeperCompositeLifecycle.tla`. `RecoveryTwoStoreSync` uses the reverse-order detection agreed in the spec audit.

## What the observer does NOT do

Per the contract in the `.mli` and RFC-0003 §6:

- No `Keeper_state_machine.apply_event` calls.
- No cascade routing mutation.
- No `registry_entry` field writes.
- No access to provider names, token counts, or context bytes (`feedback_masc-oas-layer-boundary`).

## Test plan

- [ ] Dune build: `masc_mcp.cma` green locally; observer `.cmi` / `.cmo` generated.
- [ ] Unit test follow-up (separate PR): golden snapshots per phase + invariants matrix.
- [ ] Wire-up follow-ups:
  - `registry_entry.last_auto_rules` retention so `shared_measurement` becomes non-`None`.
  - Cascade runtime observation hook so `kcl_cascade_state` reflects live state.
  - `/api/keepers/:name/composite` HTTP endpoint + `keeper.composite.tick` event bus topic (RFC-0003 §6).

## Related

- RFC-0003 §6 / §7 — observer contract + payload shape.
- `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` — spec the invariants project.
- `docs/design/dashboard-fsm-redesign.md` Phase 3/4 — downstream consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)