### PR TITLE
feat(dashboard): memory tier saturation + compaction sub-FSM panel

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -342,12 +342,20 @@ export interface KeeperTransitionsResponse {
   transitions: KeeperTransition[]
 }
 
+export interface MemoryKindUsageEntry {
+  kind: string
+  used: number
+  cap: number
+  priority: number
+}
+
 export interface KeeperStateDiagramResponse {
   keeper: string
   current_phase: string
   mermaid: string
   decision_pipeline_mermaid?: string
   cascade_fsm_mermaid?: string
+  compaction_submachine_mermaid?: string | null
   // Structured data for Cytoscape FSM rendering
   thompson_alpha?: number
   thompson_beta?: number
@@ -355,6 +363,7 @@ export interface KeeperStateDiagramResponse {
   recovery_floor_count?: number
   cascade_models?: string[]
   last_provider_result?: string | null
+  memory_kind_usage?: MemoryKindUsageEntry[]
 }
 
 export async function fetchKeeperTransitions(name: string, limit = 20): Promise<KeeperTransitionsResponse> {

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -49,6 +49,7 @@ import {
 import { PipelineStageBar } from './keeper-pipeline-stage'
 import { KeeperPhaseAndStage } from './keeper-phase-indicator'
 import { KeeperStateDiagramPanel } from './keeper-state-diagram'
+import { KeeperMemoryTierPanel } from './keeper-memory-tier-panel'
 import { AgentJournalStream } from './agent-detail-journal'
 import { DialogOverlay } from './common/dialog'
 import { SessionTraceView } from './session-trace/session-trace-view'
@@ -507,6 +508,16 @@ export function KeeperDetailOverlay() {
           </summary>
           <div class="px-4 pb-4 pt-1">
             <${KeeperStateDiagramPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
+          </div>
+        </details>
+
+        <details class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)]">
+          <summary class="cursor-pointer py-2 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] list-none select-none flex items-center gap-2">
+            <span class="w-1.5 h-1.5 rounded-full bg-[rgba(99,102,241,0.5)]"></span>
+            Memory Tier & Compaction
+          </summary>
+          <div class="px-4 pb-4 pt-1">
+            <${KeeperMemoryTierPanel} keeperName=${keeper.name} currentPhase=${keeper.phase} />
           </div>
         </details>
 

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -1,0 +1,132 @@
+import { html } from 'htm/preact'
+import { useEffect, useState } from 'preact/hooks'
+
+import {
+  fetchKeeperStateDiagram,
+  type MemoryKindUsageEntry,
+} from '../api/keeper'
+import { EmptyState } from './common/empty-state'
+import { MermaidGraph } from './common/mermaid-graph'
+
+interface KeeperMemoryTierPanelProps {
+  keeperName: string
+  currentPhase?: string | null
+}
+
+/**
+ * Memory tier saturation bars + optional Compaction sub-FSM.
+ *
+ * Data source: `/api/v1/keepers/:name/state-diagram` — we reuse the same
+ * endpoint the phase diagram consumes so a single round-trip hydrates
+ * both panels. The [memory_kind_usage] field joins
+ * [Keeper_memory_policy.kind_caps] with the live memory bank summary.
+ */
+export function KeeperMemoryTierPanel({
+  keeperName,
+  currentPhase,
+}: KeeperMemoryTierPanelProps) {
+  const [usage, setUsage] = useState<MemoryKindUsageEntry[] | null>(null)
+  const [submachineMermaid, setSubmachineMermaid] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    fetchKeeperStateDiagram(keeperName)
+      .then(data => {
+        if (cancelled) return
+        setUsage(data.memory_kind_usage ?? [])
+        setSubmachineMermaid(data.compaction_submachine_mermaid ?? null)
+        setLoading(false)
+      })
+      .catch(err => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'memory tier fetch failed')
+        setLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [keeperName])
+
+  if (loading) {
+    return html`
+      <div class="flex items-center justify-center gap-2 py-6 text-[11px] text-[var(--text-dim)]">
+        <span class="inline-block h-3 w-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin" aria-hidden="true"></span>
+        메모리 티어 로딩중
+      </div>
+    `
+  }
+
+  if (error || !usage || usage.length === 0) {
+    return html`<${EmptyState} message=${error ?? '메모리 티어 데이터 없음'} compact />`
+  }
+
+  const totalUsed = usage.reduce((sum, row) => sum + row.used, 0)
+  const totalCap = usage.reduce((sum, row) => sum + row.cap, 0)
+  const isCompacting = currentPhase === 'Compacting' || currentPhase === 'compacting'
+
+  return html`
+    <div class="flex flex-col gap-3">
+      <div class="flex flex-wrap items-center gap-2 text-[10px] text-[var(--text-dim)]">
+        <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
+          total ${totalUsed} / ${totalCap}
+        </span>
+        <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">
+          ${usage.length} kinds
+        </span>
+        ${isCompacting ? html`
+          <span class="inline-flex items-center rounded-full border border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.1)] px-2 py-0.5 text-[#f59e0b]">
+            compacting
+          </span>
+        ` : null}
+      </div>
+
+      <div class="flex flex-col gap-1.5">
+        ${usage.map(row => {
+          const pct = row.cap > 0 ? Math.min(100, Math.round((row.used / row.cap) * 100)) : 0
+          const saturated = row.used >= row.cap
+          const barColor = saturated
+            ? 'bg-[rgba(251,191,36,0.7)]'
+            : pct >= 75
+              ? 'bg-[rgba(34,197,94,0.7)]'
+              : 'bg-[rgba(99,102,241,0.6)]'
+          return html`
+            <div class="flex items-center gap-2 text-[11px]">
+              <div class="w-24 truncate text-[var(--text-body)] font-mono" title=${row.kind}>
+                ${row.kind}
+              </div>
+              <div class="relative flex-1 h-4 rounded-full bg-[var(--white-4)] border border-[var(--white-8)] overflow-hidden">
+                <div class=${`absolute inset-y-0 left-0 ${barColor}`} style=${`width: ${pct}%`}></div>
+              </div>
+              <div class="w-16 text-right text-[var(--text-muted)] tabular-nums">
+                ${row.used}/${row.cap}
+              </div>
+              <div class="w-10 text-right text-[10px] text-[var(--text-dim)] tabular-nums">
+                p${row.priority}
+              </div>
+            </div>
+          `
+        })}
+      </div>
+
+      ${submachineMermaid ? html`
+        <div class="mt-2">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
+            Compaction sub-FSM (MemoryCompaction.tla)
+          </div>
+          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+            <${MermaidGraph}
+              source=${submachineMermaid}
+              prefix="compaction-submachine"
+              diagramClass="[&_svg]:max-w-full [&_svg]:mx-auto"
+              minHeightClass="min-h-[120px]"
+            />
+          </div>
+        </div>
+      ` : null}
+    </div>
+  `
+}

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -644,18 +644,68 @@ let handle_keeper_get_subroutes state req request reqd =
           `String m.runtime.usage.last_model_used
         | _ -> `Null
       in
+      (* Memory tier usage: join kind_caps (policy) with kind_counts (bank
+         summary). Each kind reports used / cap so the dashboard tier
+         panel can render saturation without re-reading the memory file. *)
+      let memory_kind_usage : Yojson.Safe.t =
+        let caps = Keeper_memory_policy.kind_caps () in
+        let used_by_kind =
+          match meta with
+          | Ok (Some _) ->
+            (try
+              let summary =
+                Keeper_memory.read_keeper_memory_summary
+                  state.Mcp_server.room_config
+                  ~name ~max_bytes:120_000 ~max_lines:200 ~recent_limit:0
+              in
+              summary.Keeper_memory.kind_counts
+            with _ -> [])
+          | _ -> []
+        in
+        let lookup_used k =
+          try List.assoc k used_by_kind with Not_found -> 0
+        in
+        `List (List.map (fun (kind, cap) ->
+          `Assoc [
+            "kind", `String kind;
+            "used", `Int (lookup_used kind);
+            "cap", `Int cap;
+            "priority", `Int (Keeper_memory_policy.priority_for_kind ~kind);
+          ]) caps)
+      in
+      (* Compaction sub-FSM: only emit a diagram when the keeper is in
+         the [Compacting] phase. The three nodes mirror
+         [specs/bug-models/MemoryCompaction.tla]. *)
+      let compaction_submachine_mermaid =
+        match current with
+        | Keeper_state_machine.Compacting ->
+          let b = Buffer.create 256 in
+          Buffer.add_string b "stateDiagram-v2\n";
+          Buffer.add_string b "    [*] --> Accumulating\n";
+          Buffer.add_string b "    Accumulating --> Compacting: ratio_gate\n";
+          Buffer.add_string b "    Compacting --> Done: Compaction_completed\n";
+          Buffer.add_string b "    Compacting --> Accumulating: Compaction_failed\n";
+          Buffer.add_string b "    Done --> [*]\n";
+          Buffer.add_string b
+            "    classDef active fill:#22c55e,stroke:#16a34a,color:#fff,stroke-width:3px\n";
+          Buffer.add_string b "    class Compacting active\n";
+          `String (Buffer.contents b)
+        | _ -> `Null
+      in
       let json = `Assoc [
         "keeper", `String name;
         "current_phase", `String phase_str;
         "mermaid", `String mermaid;
         "decision_pipeline_mermaid", `String decision_pipeline_mermaid;
         "cascade_fsm_mermaid", `String cascade_fsm_mermaid;
+        "compaction_submachine_mermaid", compaction_submachine_mermaid;
         "thompson_alpha", `Float stats.alpha;
         "thompson_beta", `Float stats.beta;
         "tool_count", `Int tool_count;
         "recovery_floor_count", `Int recovery_floor_count;
         "cascade_models", `List (List.map (fun s -> `String s) cascade_models);
         "last_provider_result", last_provider;
+        "memory_kind_usage", memory_kind_usage;
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd


### PR DESCRIPTION
## Summary

Phase 2 of `docs/design/dashboard-fsm-redesign.md` — expose the memory 5-tier (actually 7-kind) saturation and the Compaction sub-FSM on the keeper detail page. Both signals were previously invisible.

## Backend (`/api/v1/keepers/:name/state-diagram`)

- `memory_kind_usage` — joins `Keeper_memory_policy.kind_caps` with the live bank summary (`Keeper_memory.read_keeper_memory_summary`). Each row reports `{kind, used, cap, priority}`.
- `compaction_submachine_mermaid` — stateDiagram-v2 mirroring `specs/bug-models/MemoryCompaction.tla` (Accumulating / Compacting / Done). Only populated when the keeper is in the `Compacting` phase so the frontend can conditionally hide the panel.

## Frontend

- `dashboard/src/components/keeper-memory-tier-panel.ts` — saturation bars (per kind), totals badge, compaction sub-FSM render. Tailwind-only per `feedback_tailwind-only-dashboard`.
- `dashboard/src/api/keeper.ts` — extend `KeeperStateDiagramResponse` with the two new fields.
- `dashboard/src/components/keeper-detail.ts` — new `details` accordion for the tier panel, placed directly after the phase state machine.

The panel reuses the existing `fetchKeeperStateDiagram` call, so opening it costs zero extra round-trips.

## Test plan

- [ ] Dune lib build green.
- [ ] Dashboard typecheck green (`pnpm typecheck`).
- [ ] Visual check: open keeper detail → Memory Tier panel shows per-kind bars. Compaction sub-FSM appears only when `phase=Compacting`.

## Related

- `docs/design/dashboard-fsm-redesign.md` — Phase 2 contract.
- `specs/bug-models/MemoryCompaction.tla` — sub-machine spec the mermaid mirrors.
- `lib/keeper/keeper_memory_policy.ml:447-451` — `kind_caps` SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)