### PR TITLE
fix(dashboard/markdown): repair truncated code fences from keeper tool output

### DIFF
--- a/dashboard/src/components/common/markdown.test.ts
+++ b/dashboard/src/components/common/markdown.test.ts
@@ -202,4 +202,32 @@ describe('Markdown', () => {
       expect(container.innerHTML).not.toContain('<script>')
     })
   })
+
+  describe('truncated markdown repair', () => {
+    it('repairs trailing orphan backtick from truncated tool output', () => {
+      // Reproduces the ani1999 board post symptom: LLM output cut at
+      // max_tokens mid-bullet, leaving "- `" as the final line.
+      const md = 'first line\n- `keeper_memory_search`\n- `'
+      render(html`<${Markdown} text=${md} />`, container)
+      // Body is still rendered; the trailing backtick doesn't swallow it.
+      expect(container.textContent).toContain('first line')
+      expect(container.textContent).toContain('keeper_memory_search')
+      // Repair marker is visible so the operator knows it was cut.
+      expect(container.textContent).toContain('[잘림]')
+    })
+
+    it('repairs unclosed triple-backtick code fence', () => {
+      const md = 'before\n```ocaml\nlet x = 1'
+      render(html`<${Markdown} text=${md} />`, container)
+      expect(container.textContent).toContain('before')
+      expect(container.textContent).toContain('let x = 1')
+      expect(container.textContent).toContain('[잘림]')
+    })
+
+    it('leaves balanced markdown untouched', () => {
+      const md = 'plain `inline` and ```\ncode\n```'
+      render(html`<${Markdown} text=${md} />`, container)
+      expect(container.textContent).not.toContain('[잘림]')
+    })
+  })
 })

--- a/dashboard/src/components/common/markdown.ts
+++ b/dashboard/src/components/common/markdown.ts
@@ -112,18 +112,41 @@ function sanitizeMermaidSvg(raw: string): SVGElement | null {
   return document.importNode(svg, true) as unknown as SVGElement
 }
 
+// ── Repair truncated markdown ────────────────────────────────
+// Keeper tool outputs occasionally arrive with an unclosed code fence
+// (```) or an odd count of inline backticks (`) — the LLM ran out of
+// max_tokens mid-write and the `board_post` payload is stored as-is.
+// Marked's parser then "swallows" everything after the opening backtick.
+// Repair: close any dangling fence/inline and append a visible marker
+// so the operator can tell the post was cut, not just strangely rendered.
+function repairTruncatedMarkdown(text: string): string {
+  const fenceCount = (text.match(/```/g) ?? []).length
+  if (fenceCount % 2 === 1) {
+    return `${text}\n…[잘림]\n\`\`\``
+  }
+  // Only count inline backticks OUTSIDE fenced blocks, otherwise
+  // a balanced fence would be miscounted as odd.
+  const outsideFences = text.replace(/```[\s\S]*?```/g, '')
+  const inlineCount = (outsideFences.match(/`/g) ?? []).length
+  if (inlineCount % 2 === 1) {
+    return `${text}…[잘림]\``
+  }
+  return text
+}
+
 // ── Parse markdown with <think> block extraction ─────────────
 // Think blocks are extracted first, their content is parsed
 // separately as markdown, then reassembled as <details>.
 function renderMarkdown(text: string): string {
+  const repaired = repairTruncatedMarkdown(text)
   const parts: string[] = []
   let lastIdx = 0
   const thinkRe = /<think>([\s\S]*?)<\/think\s*>/g
   let m: RegExpExecArray | null
 
-  while ((m = thinkRe.exec(text)) !== null) {
+  while ((m = thinkRe.exec(repaired)) !== null) {
     if (m.index > lastIdx) {
-      parts.push(md.parse(text.slice(lastIdx, m.index)) as string)
+      parts.push(md.parse(repaired.slice(lastIdx, m.index)) as string)
     }
     const innerHtml = md.parse((m[1] as string).trim()) as string
     parts.push(
@@ -132,8 +155,8 @@ function renderMarkdown(text: string): string {
     lastIdx = m.index + m[0].length
   }
 
-  if (lastIdx < text.length) {
-    parts.push(md.parse(text.slice(lastIdx)) as string)
+  if (lastIdx < repaired.length) {
+    parts.push(md.parse(repaired.slice(lastIdx)) as string)
   }
 
   return sanitize(parts.join(''))


### PR DESCRIPTION
Keeper tool outputs occasionally arrive with an unclosed triple-backtick fence or odd inline backtick count when the LLM runs out of max_tokens mid-write. The partial body is stored as-is (e.g. ani1999 board post p-c0494a2e, body_len=467 chars, ending with a lone backtick). Marked then treats the orphan as an open code block and swallows the preceding content.  repairTruncatedMarkdown closes dangling fences/inline backticks and appends a 잘림 marker. 3 new vitest cases, suite 25/25 pass.