### PR TITLE
fix(keeper_alerting): serialize alert_dedup_table under Eio.Mutex

### DIFF
--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -103,6 +103,18 @@ let alert_dedup_window_sec = Env_config.AlertDedup.window_sec
 
 let alert_dedup_table : (string, float) Hashtbl.t = Hashtbl.create 32
 
+(** Mutex protecting [alert_dedup_table].  [is_alert_deduplicated] runs
+    from every keeper's alert scoring path, and keepers execute
+    concurrently in the same room — so the previous implementation
+    interleaved [Hashtbl.length] / [Hashtbl.filter_map_inplace] /
+    [Hashtbl.find_opt] / [Hashtbl.replace] from multiple fibers with
+    no serialisation.  The [find_opt + replace] pair is a TOCTOU that
+    can let the same alert fire twice even within the dedup window,
+    and [filter_map_inplace] concurrent with [find_opt] invalidates
+    the iteration (OCaml [Hashtbl] does not support mutate-during-
+    fold). *)
+let alert_dedup_mu = Eio.Mutex.create ()
+
 let alert_dedup_key ~(keeper_name : string) ~(reasons : string list) : string =
   let sorted = List.sort String.compare reasons in
   keeper_name ^ ":" ^ String.concat "," sorted
@@ -110,17 +122,18 @@ let alert_dedup_key ~(keeper_name : string) ~(reasons : string list) : string =
 let is_alert_deduplicated ~(keeper_name : string) ~(reasons : string list) : bool =
   let key = alert_dedup_key ~keeper_name ~reasons in
   let now = Time_compat.now () in
-  if Hashtbl.length alert_dedup_table > 64 then begin
-    let stale_threshold = alert_dedup_window_sec *. 2.0 in
-    Hashtbl.filter_map_inplace (fun _k ts ->
-      if now -. ts > stale_threshold then None else Some ts
-    ) alert_dedup_table
-  end;
-  match Hashtbl.find_opt alert_dedup_table key with
-  | Some last_ts when now -. last_ts < alert_dedup_window_sec -> true
-  | _ ->
-    Hashtbl.replace alert_dedup_table key now;
-    false
+  Eio_guard.with_mutex alert_dedup_mu (fun () ->
+    if Hashtbl.length alert_dedup_table > 64 then begin
+      let stale_threshold = alert_dedup_window_sec *. 2.0 in
+      Hashtbl.filter_map_inplace (fun _k ts ->
+        if now -. ts > stale_threshold then None else Some ts
+      ) alert_dedup_table
+    end;
+    match Hashtbl.find_opt alert_dedup_table key with
+    | Some last_ts when now -. last_ts < alert_dedup_window_sec -> true
+    | _ ->
+      Hashtbl.replace alert_dedup_table key now;
+      false)
 
 (** {1 Alert Signal Weights}
 


### PR DESCRIPTION
## Summary

\`Keeper_alerting.is_alert_deduplicated\` runs from every keeper's interesting-alert scoring path (\`lib/keeper/keeper_alerting.ml:480\`). Multiple keepers execute turns concurrently in the same MASC room, and the module-level \`alert_dedup_table : (string, float) Hashtbl.t\` had no serialisation.

Two concrete races:

1. **TOCTOU on \`find_opt + replace\`.** The function reads \`Hashtbl.find_opt alert_dedup_table key\`, and on miss (or expired entry) writes \`Hashtbl.replace alert_dedup_table key now\`. Two fibers with the same dedup key both see \`None\` and both \`replace\` — the dedup window is not enforced and the same alert fires twice.

2. **\`Hashtbl.filter_map_inplace\` during \`find_opt\`.** When the table exceeds 64 entries, the function runs an in-place eviction. A concurrent fiber calling \`Hashtbl.find_opt\` during that iteration can observe a resized bucket array mid-fold; OCaml \`Hashtbl\` is explicitly unsafe for mutate-during-read.

## Change

- Add \`alert_dedup_mu : Eio.Mutex.t\`.
- Wrap the whole body of \`is_alert_deduplicated\` — the size check, eviction, \`find_opt\`, and \`replace\` must be one critical section (serialising the individual calls would leave the RMW window open).
- Uses \`Eio_guard.with_mutex\` so module init / non-Eio tests continue to work.

Same pattern applied in the recent hardening sweep (\`keeper_evidence\`, \`keeper_file_tracker\`, \`keeper_approval_queue\`, #6987 \`keeper_registry\`, #7022 \`keeper_recurring\`, #7043 \`keeper_failure_circuit_breaker\`).

## Test plan

- [x] \`dune build --root . lib/\` — clean
- [ ] CI full suite (runs on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)