### PR TITLE
fix(keeper_status_detail): serialize _cache Hashtbl under Eio.Mutex

### DIFF
--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -27,20 +27,33 @@ type cache_entry = {
 
 let _cache : (string, cache_entry) Hashtbl.t = Hashtbl.create 8
 
+(** Mutex protecting [_cache].  [handle_keeper_status] runs from an MCP
+    tool-dispatch fiber, one per concurrent [masc_keeper_status]
+    request, and [invalidate_status_cache_{for,all}] is called from
+    keeper state-change paths on different fibers — so every access
+    path competes for the same module-level [Hashtbl.t] with no
+    serialisation.  The dangerous pair is [Hashtbl.filter_map_inplace]
+    (eviction) interleaving with [Hashtbl.find_opt] / [Hashtbl.replace]
+    from another fiber, which can segfault or return torn values: OCaml
+    [Hashtbl] is explicitly unsafe for concurrent mutate-during-read. *)
+let cache_mu = Eio.Mutex.create ()
+
 let invalidate_status_cache_for name =
-  Hashtbl.filter_map_inplace
-    (fun key entry ->
-      match String.rindex_opt key ':' with
-      | Some idx ->
-          let cached_name =
-            String.sub key (idx + 1) (String.length key - idx - 1)
-          in
-          if String.equal cached_name name then None else Some entry
-      | None -> Some entry)
-    _cache
+  Eio_guard.with_mutex cache_mu (fun () ->
+    Hashtbl.filter_map_inplace
+      (fun key entry ->
+        match String.rindex_opt key ':' with
+        | Some idx ->
+            let cached_name =
+              String.sub key (idx + 1) (String.length key - idx - 1)
+            in
+            if String.equal cached_name name then None else Some entry
+        | None -> Some entry)
+      _cache)
 
 let invalidate_status_cache_all () =
-  Hashtbl.clear _cache
+  Eio_guard.with_mutex cache_mu (fun () ->
+    Hashtbl.clear _cache)
 
 let status_cache_key ~base_path ~name = base_path ^ ":" ^ name
 
@@ -91,8 +104,13 @@ let handle_keeper_status ctx args : tool_result =
   | Ok (name, m) ->
       let cache_key = status_cache_key ~base_path:ctx.config.base_path ~name in
       let args_hash = hash_status_args ctx.config name args in
-      (* Cache hit: same updated_at + same args → return cached response *)
-      (match Hashtbl.find_opt _cache cache_key with
+      (* Cache hit: same updated_at + same args → return cached response.
+         The read is taken under [cache_mu] so it cannot interleave with
+         an eviction from [invalidate_status_cache_{for,all}]. *)
+      (match
+         Eio_guard.with_mutex_ro cache_mu (fun () ->
+           Hashtbl.find_opt _cache cache_key)
+       with
        | Some entry
          when entry.updated_at = m.updated_at
            && entry.args_hash = args_hash ->
@@ -776,6 +794,7 @@ let handle_keeper_status ctx args : tool_result =
            ]);
          ]) in
          let response = Yojson.Safe.pretty_to_string json in
-         Hashtbl.replace _cache cache_key
-           { updated_at = m.updated_at; args_hash; response };
+         Eio_guard.with_mutex cache_mu (fun () ->
+           Hashtbl.replace _cache cache_key
+             { updated_at = m.updated_at; args_hash; response });
          (true, response))


### PR DESCRIPTION
## Summary

\`handle_keeper_status\` runs from an MCP tool-dispatch fiber on every \`masc_keeper_status\` request, and \`invalidate_status_cache_{for,all}\` is called from keeper state-change paths on different fibers. The module-level \`_cache : (string, cache_entry) Hashtbl.t\` had no lock — every access path was racing.

## Concrete race

The dangerous interleaving is \`Hashtbl.filter_map_inplace\` (eviction inside \`invalidate_status_cache_for\`) running concurrently with \`Hashtbl.find_opt\` / \`Hashtbl.replace\` from a status handler. OCaml \`Hashtbl\` is explicitly unsafe for concurrent mutate-during-read — a bucket resize mid-fold can segfault or return a torn \`cache_entry\`.

Even without eviction the \`find_opt + replace\` pair from two concurrent \`masc_keeper_status\` requests on the same keeper is a mild lost-update (both miss, both build the response, both \`replace\`) — benign but indicates the invariant was never enforced.

## Change

- Add \`cache_mu : Eio.Mutex.t\`.
- \`invalidate_status_cache_for\` / \`invalidate_status_cache_all\` run under \`Eio_guard.with_mutex\` so the \`filter_map_inplace\` / \`clear\` cannot interleave with reads.
- \`handle_keeper_status\` cache read uses \`use_ro\`, and the write uses \`use_rw\` (scoped narrowly — only the \`Hashtbl.replace\`, not the whole response construction, because that spans many yield points).

Same template as #6987 (\`keeper_registry\`), #7022 (\`keeper_recurring\`), #7043 (\`keeper_failure_circuit_breaker\`), #7052 (\`keeper_alerting\`).

## Test plan

- [x] \`dune build --root . lib/\` — clean
- [ ] CI full suite (runs on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)