### PR TITLE
refactor(dashboard): RFC-MASC-006 Phase 0 — remove sessions stub

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -330,7 +330,7 @@ function renderSessionCard(s: DashboardMissionSessionBrief) {
   return html`
     <${RouteLink}
       tab="monitoring"
-      params=${{ section: 'sessions', session_id: s.session_id }}
+      params=${{ section: 'agents', session_id: s.session_id }}
       class="rounded-xl border bg-card/55 p-4 cursor-pointer transition-[transform,background-color,border-color,box-shadow] duration-200 shadow-sm shadow-black/8 hover:shadow-md hover:bg-card hover:-translate-y-0.5 group ${hasBlocker ? 'border-bad/45' : 'border-card-border hover:border-accent/32'}"
       title=${primary}
     >
@@ -377,7 +377,7 @@ function HotSessions() {
         count=${userSessions.length}
         linkLabel="전체 보기 ->"
         linkTab="monitoring"
-        linkParams=${{ section: 'sessions' }}
+        linkParams=${{ section: 'agents' }}
       />
       ${userSessions.length > 0
         ? html`<div class="grid grid-cols-2 gap-3 max-[960px]:grid-cols-1">${userSessions.map(renderSessionCard)}</div>`

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -1,9 +1,10 @@
 // MASC Dashboard — Status Surface
-// Conventional read-only status area: sessions, agents, activity, runtime, telemetry.
+// Read-only observability surfaces: agents, activity, runtime, telemetry, governance,
+// memory-subsystems, metrics, tool-quality, fleet.
+// (sessions section removed in Phase 0 of RFC-MASC-006 — overlapped with overview.)
 
 import { html } from 'htm/preact'
 import { route } from '../router'
-import { Mission } from './mission'
 import { AgentsUnified } from './agents-unified'
 import { Activity } from './activity'
 import { RuntimeMonitor } from './runtime-monitor'
@@ -15,16 +16,16 @@ import { PrometheusMetrics } from './prometheus-metrics'
 import { ToolQualityPanel } from './tool-quality-panel'
 import { FleetTelemetryPanel } from './fleet-telemetry-panel'
 
-type StatusSection = 'sessions' | 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems' | 'metrics' | 'tool-quality' | 'fleet'
+type StatusSection = 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems' | 'metrics' | 'tool-quality' | 'fleet'
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
   if (
-    section === 'agents' || section === 'activity' || section === 'runtime'
+    section === 'activity' || section === 'runtime'
     || section === 'telemetry' || section === 'governance' || section === 'memory-subsystems'
     || section === 'metrics' || section === 'tool-quality' || section === 'fleet'
   ) return section
-  return 'sessions'
+  return 'agents'
 }
 
 export function Status() {
@@ -33,30 +34,28 @@ export function Status() {
   return html`
     <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
-        ${section === 'agents'
-          ? html`<${AgentsUnified} />`
-          : section === 'activity'
-            ? html`<${Activity} />`
-            : section === 'runtime'
-              ? html`
-                <div class="grid gap-4">
-                  <${OasHealthChip} />
-                  <${RuntimeMonitor} />
-                </div>
-              `
-            : section === 'telemetry'
-              ? html`<${TelemetryUnified} />`
-            : section === 'governance'
-              ? html`<${GovernanceMonitor} />`
-            : section === 'memory-subsystems'
-              ? html`<${MemorySubsystems} />`
-            : section === 'metrics'
-              ? html`<${PrometheusMetrics} />`
-            : section === 'tool-quality'
-              ? html`<${ToolQualityPanel} />`
-            : section === 'fleet'
-              ? html`<${FleetTelemetryPanel} />`
-              : html`<${Mission} />`}
+        ${section === 'activity'
+          ? html`<${Activity} />`
+          : section === 'runtime'
+            ? html`
+              <div class="grid gap-4">
+                <${OasHealthChip} />
+                <${RuntimeMonitor} />
+              </div>
+            `
+          : section === 'telemetry'
+            ? html`<${TelemetryUnified} />`
+          : section === 'governance'
+            ? html`<${GovernanceMonitor} />`
+          : section === 'memory-subsystems'
+            ? html`<${MemorySubsystems} />`
+          : section === 'metrics'
+            ? html`<${PrometheusMetrics} />`
+          : section === 'tool-quality'
+            ? html`<${ToolQualityPanel} />`
+          : section === 'fleet'
+            ? html`<${FleetTelemetryPanel} />`
+            : html`<${AgentsUnified} />`}
       </div>
     </div>
   `

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { defaultParamsForTab, visibleSectionItemsForTab } from './navigation'
+import { defaultParamsForTab, normalizeRouteParams, visibleSectionItemsForTab } from './navigation'
 
 describe('lab navigation', () => {
   it('contains only research surfaces after Phase 1 reorg', () => {
@@ -51,7 +51,14 @@ describe('monitoring navigation labels', () => {
 
     expect(labelFor('governance')).toBe('도구 이벤트')
     expect(labelFor('metrics')).toBe('Prometheus')
-    expect(labelFor('sessions')).toBe('세션')
+    expect(labelFor('agents')).toBe('에이전트 & 키퍼')
+  })
+
+  it('does not expose sessions section (removed in Phase 0 of RFC-MASC-006)', () => {
+    const sections = visibleSectionItemsForTab('monitoring')
+    const ids = sections.map(item => item.id)
+
+    expect(ids).not.toContain('sessions')
   })
 
   it('surfaces tool-quality and fleet alongside telemetry/metrics', () => {
@@ -72,5 +79,18 @@ describe('workspace navigation labels', () => {
 
     expect(labelFor('planning')).toBe('작업 큐')
     expect(labelFor('goals')).toBe('목표 트리')
+  })
+})
+
+describe('normalizeRouteParams backward compat (RFC-MASC-006 Phase 0)', () => {
+  it('redirects legacy ?section=sessions URL to agents and preserves other params', () => {
+    const redirected = normalizeRouteParams('monitoring', { section: 'sessions', session_id: 's-123' })
+    expect(redirected.section).toBe('agents')
+    expect(redirected.session_id).toBe('s-123')
+  })
+
+  it('leaves other valid monitoring sections untouched', () => {
+    const result = normalizeRouteParams('monitoring', { section: 'telemetry' })
+    expect(result.section).toBe('telemetry')
   })
 })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -2,7 +2,6 @@ import type { RouteState, TabId } from '../types'
 
 export type SurfaceId = TabId
 export type SurfaceSectionId =
-  | 'sessions'
   | 'agents'
   | 'activity'
   | 'board'
@@ -64,9 +63,9 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: '모니터링',
     icon: '📡',
-    description: '세션, 에이전트/키퍼 현황 관찰',
+    description: '에이전트/키퍼 현황 및 observability 관찰',
     defaultTab: 'monitoring',
-    defaultParams: { section: 'sessions' },
+    defaultParams: { section: 'agents' },
     tabs: ['monitoring'],
   },
   {
@@ -117,15 +116,9 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   monitoring: [
     {
-      id: 'sessions',
-      label: '세션',
-      description: '읽기 전용 관찰: 세션 상태, 블로커, 주의 큐. 개입은 운영 › 실시간 개입에서.',
-      params: { section: 'sessions' },
-    },
-    {
       id: 'agents',
       label: '에이전트 & 키퍼',
-      description: '이름과 운영 상태를 함께 봅니다.',
+      description: '이름과 운영 상태를 함께 봅니다. 세션 요약은 오버뷰에서.',
       params: { section: 'agents' },
     },
     {
@@ -269,6 +262,11 @@ export function normalizeRouteParams(tabId: TabId, params: Record<string, string
     delete next.section
     delete next.surface
     return next
+  }
+
+  // Phase 0 (RFC-MASC-006): sessions stub removed — redirect to agents
+  if (tabId === 'monitoring' && next.section === 'sessions') {
+    next.section = 'agents'
   }
 
   const typedTabId = tabId as NonHomeTabId


### PR DESCRIPTION
## Summary

RFC-MASC-006 (#7050) Phase 0 — Observatory 구축 전 dead stub 제거.

\`monitoring/sessions\`는 \`Status\` dispatcher가 fallback default로 \`<Mission />\`을 렌더하는 **pure stub**. \`overview\`가 이미 같은 \`mission.sessions\` 데이터를 보여주고 있어 100% 겹침.

## 변경

- \`SurfaceSectionId\` union에서 \`'sessions'\` 제거
- \`monitoring\` tab default: \`sessions\` → \`agents\`
- \`monitoring\` 사이드바에서 \`세션\` entry 삭제
- \`Status\` dispatcher: 기본 렌더 \`Mission\` → \`AgentsUnified\`
- \`normalizeRouteParams\`: \`?section=sessions\` → \`?section=agents\` redirect (session_id 같은 다른 params 유지)
- Overview 세션 카드 링크: 이제 \`agents\` 섹션을 가리킴
- 테스트: sessions 부재 검증 + redirect 동작 검증

## 하위 호환

기존 북마크 \`monitoring?section=sessions&session_id=X\` → \`normalizeRouteParams\`가 \`agents\`로 자동 redirect. 깨짐 없음.

## 남은 정리 (별도 PR)

\`Mission.ts\` 컴포넌트 자체는 이 PR 이후 routing consumer 0. Follow-up에서 orphan 확인 후 삭제 고려.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — zero errors
- [x] \`pnpm exec vitest run navigation\` — 8/8 pass
- [x] \`pnpm exec vitest run mission overview\` — 17/17 pass
- [ ] CI green
- [ ] 로컬 UI 확인: \`/monitoring\` 진입 시 agents 기본, \`/monitoring?section=sessions\` URL 입력 시 agents로 redirect

## Refs

- RFC-MASC-006 (#7050): Observatory unified investigation surface
- Phase 1 (shared filter state) + Phase 2 (Observatory v1)는 후속 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)