### PR TITLE
feat(dashboard): /api/v1/keepers/:name/composite endpoint — RFC-0003 §7

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -710,6 +710,25 @@ let handle_keeper_get_subroutes state req request reqd =
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if ends_with "/composite" then
+    (* RFC-0003 §7: composite lifecycle snapshot derived from the
+       registry entry via the [Keeper_composite_observer] pure
+       projection. No mutation, no I/O, no provider/token access. *)
+    let name = extract_name "/composite" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let base_path = state.Mcp_server.room_config.base_path in
+      (match Keeper_registry.get ~base_path name with
+       | None ->
+         Http.Response.json ~status:`Not_found
+           (Printf.sprintf {|{"error":"keeper %S not registered"}|} name) reqd
+       | Some entry ->
+         let snapshot = Keeper_composite_observer.observe entry in
+         let json = Keeper_composite_observer.snapshot_to_json snapshot in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd)
   else
     Http.Response.json ~status:`Not_found
       {|{"error":"not found"}|} reqd


### PR DESCRIPTION
## Summary

Wire the RFC-0003 composite observer (#7046) into the HTTP surface. Adds `/api/v1/keepers/:name/composite` alongside the existing `/state-diagram` branch so Phase 3 (the `/fsm` hub page) and Phase 4 (SSE stream) can consume the composite payload.

## Behaviour

- Handler looks up the registry entry via `Keeper_registry.get`, projects it through `Keeper_composite_observer.observe`, and serialises with `Keeper_composite_observer.snapshot_to_json`. The response shape matches RFC-0003 §7.
- Unknown keeper → 404. Missing `:name` → 400. Mirrors the adjacent `/state-diagram` branch.
- No mutation, no I/O beyond the response write.

## Test plan

- [ ] `dune build lib/masc_mcp.cma` green.
- [ ] Manual probe: `curl /api/v1/keepers/<name>/composite` returns the documented JSON shape.
- [ ] Follow-up PR wires `Keeper_composite_observer` to read `entry.last_auto_rules` (after #7057 merges) so `shared_measurement` becomes non-`None`.

## Related

- #7046 — observer scaffold (merged).
- #7057 — `registry_entry.last_auto_rules` data field (enables `shared_measurement`).
- `docs/design/dashboard-fsm-redesign.md` Phase 3 — downstream consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)