### PR TITLE
chore(drift_guard): register thresholds in Runtime_params

### DIFF
--- a/lib/drift_guard.ml
+++ b/lib/drift_guard.ml
@@ -64,11 +64,16 @@ let default_threshold () = Level2_config.Drift_guard.default_threshold ()
       changed while vocabulary stayed similar.
     - Semantic drift: default when neither structural nor factual patterns match.
 
-    These values are initial estimates, not empirically validated.
-    TODO(RFC-0001 Phase 3): Register in Runtime_params. *)
-let factual_coverage_floor = 0.55
-let factual_size_ratio_floor = 0.6
-let structural_divergence_threshold = 0.18
+    These values are initial estimates and still await empirical
+    calibration against a labelled drift corpus, but are now
+    governable via Runtime_params so operators can tune without a
+    rebuild. *)
+let factual_coverage_floor () =
+  Runtime_params.get Governance_registry.drift_factual_coverage_floor
+let factual_size_ratio_floor () =
+  Runtime_params.get Governance_registry.drift_factual_size_ratio_floor
+let structural_divergence_threshold () =
+  Runtime_params.get Governance_registry.drift_structural_divergence_threshold
 
 let tokenize (s : string) : string list =
   let trimmed = String.trim s in
@@ -176,8 +181,8 @@ let classify_drift ~tokens_a ~tokens_b ~jacc ~cos =
     | 0 -> 1.0
     | max_len -> float_of_int (min len_a len_b) /. float_of_int max_len
   in
-  if coverage < factual_coverage_floor || size_ratio < factual_size_ratio_floor then Factual
-  else if cos -. jacc > structural_divergence_threshold then Structural
+  if coverage < factual_coverage_floor () || size_ratio < factual_size_ratio_floor () then Factual
+  else if cos -. jacc > structural_divergence_threshold () then Structural
   else Semantic
 
 let summarize ~original ~received ~threshold =

--- a/lib/governance_registry.ml
+++ b/lib/governance_registry.ml
@@ -432,6 +432,51 @@ let keeper_stage_timing_ring_size =
     ~deserialize:deserialize_int
     ()
 
+(* ── drift_guard heuristics (Low risk, detection tuning) ───── *)
+
+(** Token-coverage floor below which a handoff is classified as
+    factual drift. Initial estimate from drift_guard.ml; not
+    empirically calibrated against a labelled corpus. *)
+let drift_factual_coverage_floor =
+  Runtime_params.register
+    ~key:"drift.factual_coverage_floor"
+    ~default:(fun () -> 0.55)
+    ~validate:(validate_float_range ~min:0.0 ~max:1.0 "drift_factual_coverage_floor")
+    ~serialize:(fun v -> `Float v)
+    ~deserialize:deserialize_float
+    ~meta:{ description = "drift_guard factual drift 판정 — 토큰 커버리지 하한";
+            value_type = "float";
+            min_value = Some (`Float 0.0); max_value = Some (`Float 1.0) }
+    ()
+
+(** Size-ratio floor (handoff / original) below which the handoff is
+    factual drift. Captures "content replaced" vs "content edited". *)
+let drift_factual_size_ratio_floor =
+  Runtime_params.register
+    ~key:"drift.factual_size_ratio_floor"
+    ~default:(fun () -> 0.6)
+    ~validate:(validate_float_range ~min:0.0 ~max:1.0 "drift_factual_size_ratio_floor")
+    ~serialize:(fun v -> `Float v)
+    ~deserialize:deserialize_float
+    ~meta:{ description = "drift_guard factual drift 판정 — 크기 비율 하한";
+            value_type = "float";
+            min_value = Some (`Float 0.0); max_value = Some (`Float 1.0) }
+    ()
+
+(** Cosine-jaccard divergence threshold for structural drift. Above
+    this, vocabulary overlap is high but word-order/phrasing shifted. *)
+let drift_structural_divergence_threshold =
+  Runtime_params.register
+    ~key:"drift.structural_divergence_threshold"
+    ~default:(fun () -> 0.18)
+    ~validate:(validate_float_range ~min:0.0 ~max:1.0 "drift_structural_divergence_threshold")
+    ~serialize:(fun v -> `Float v)
+    ~deserialize:deserialize_float
+    ~meta:{ description = "drift_guard structural drift 판정 — cosine-jaccard 발산 임계치";
+            value_type = "float";
+            min_value = Some (`Float 0.0); max_value = Some (`Float 1.0) }
+    ()
+
 (* ── surface catalog ─────────────────────────────────────────── *)
 
 type surface = {
@@ -509,6 +554,16 @@ let surfaces =
         "relay.tokens_per_tool_call"; "relay.tokens_per_tool_result";
         "relay.cost_large_file_read"; "relay.cost_per_file_edit";
         "relay.cost_long_running"; "relay.cost_exploration"; "relay.cost_simple";
+      ];
+    };
+    {
+      id = "drift_guard";
+      description = "Handoff drift classification thresholds (initial estimates, not corpus-calibrated)";
+      risk = "low";
+      param_keys = [
+        "drift.factual_coverage_floor";
+        "drift.factual_size_ratio_floor";
+        "drift.structural_divergence_threshold";
       ];
     };
     {
@@ -593,6 +648,9 @@ let ensure_init () =
   ignore (Runtime_params.get dashboard_min_border_length);
   ignore (Runtime_params.get dashboard_agent_quiet_threshold_sec);
   ignore (Runtime_params.get dashboard_agent_stuck_threshold_sec);
+  ignore (Runtime_params.get drift_factual_coverage_floor);
+  ignore (Runtime_params.get drift_factual_size_ratio_floor);
+  ignore (Runtime_params.get drift_structural_divergence_threshold);
   Keeper_config.ensure_runtime_params_init ()
 
 let surfaces_json () =


### PR DESCRIPTION
## Summary

PR 2/2 — audit의 magic-number 항목 처리. drift_guard가 이미 달아두었던 \`TODO(RFC-0001 Phase 3): Register in Runtime_params\`를 완수.

### Before (module-level constants)

\`\`\`ocaml
(* lib/drift_guard.ml:69-71 *)
let factual_coverage_floor = 0.55
let factual_size_ratio_floor = 0.6
let structural_divergence_threshold = 0.18
\`\`\`

- 숫자 근거 없음, 주석에 "not empirically validated"만 표시
- 런타임에서 조정 불가 → rebuild 필요
- Het heuristic이 런타임 내부에 숨어있음

### After (Runtime_params + Governance surface)

\`\`\`ocaml
let factual_coverage_floor () =
  Runtime_params.get Governance_registry.drift_factual_coverage_floor
\`\`\`

- \`drift.factual_coverage_floor\` (default 0.55, range [0, 1])
- \`drift.factual_size_ratio_floor\` (default 0.6, range [0, 1])
- \`drift.structural_divergence_threshold\` (default 0.18, range [0, 1])
- 새 governance surface "drift_guard" (risk=low) 등록
- Dashboard/운영 도구에서 조정 가능

## Why just drift_guard

Audit Top 10 중 동일 패턴(module-level threshold):
- metacognition_threshold (0.7/0.3/0.6/0.5)
- keeper_compact_policy (keep_recent:3/2)
- credits_dashboard (70/30/50/20)

이들은 drift_guard 패턴 복제로 같은 PR에 넣을 수 있으나, 각각 callsite 수정이 커서 **1 heuristic domain = 1 PR**로 분리하는 것이 안전. drift_guard는 TODO 주석으로 가장 명시적이었고 자체 테스트가 있어 low-risk.

## Files

| File | Change |
|------|--------|
| \`lib/governance_registry.ml\` | +60 — 3 param 등록, drift_guard surface, ensure_init 업데이트 |
| \`lib/drift_guard.ml\` | +12/-7 — constants → accessor functions, 주석 업데이트 |

## Test plan

- [x] \`dune build\` clean
- [x] \`test_drift_guard_core\` 5/5 pass
- [ ] CI green
- [ ] Default 유지 → 기존 동작 동일 (mechanical refactor, behavior-preserving)

## Context

PR 1/2 (#7061)가 stub 제거. 이 PR이 threshold 외부화. 후속 PR에서 다른 heuristic domain (metacognition, compaction) 동일 패턴 적용 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)