### PR TITLE
feat(dashboard): RFC-MASC-006 Phase 1 — global observatory filter signals

### DIFF
--- a/dashboard/src/components/common/observatory-filter-bar.ts
+++ b/dashboard/src/components/common/observatory-filter-bar.ts
@@ -1,0 +1,98 @@
+// Observatory Global Filter Bar (RFC-MASC-006 Phase 1)
+//
+// Compact chip display shown in dashboard header when any observatory filter
+// is active. Each chip is clearable independently + a "clear all" link.
+//
+// The bar is hidden when no filter is active — zero visual noise.
+
+import { html } from 'htm/preact'
+import { X } from 'lucide-preact'
+import {
+  currentKeeperFilter,
+  currentNamespaceFilter,
+  currentOperationFilter,
+  currentTimeRangeFilter,
+  hasActiveObservatoryFilter,
+  setObservatoryFilter,
+  clearObservatoryFilters,
+  timeRangeLabel,
+} from '../../observatory-filter-store'
+
+function Chip({
+  label,
+  value,
+  onClear,
+}: {
+  label: string
+  value: string
+  onClear: () => void
+}) {
+  return html`
+    <span class="inline-flex items-center gap-1.5 rounded-full border border-card-border bg-card/50 px-2.5 py-1 text-[11px]">
+      <span class="text-text-dim font-medium">${label}:</span>
+      <span class="font-mono text-text-strong">${value}</span>
+      <button
+        type="button"
+        class="ml-0.5 rounded-full p-0.5 text-text-muted hover:bg-white/10 hover:text-text-strong transition-colors"
+        onClick=${onClear}
+        aria-label=${`${label} 필터 제거`}
+      >
+        <${X} size=${10} />
+      </button>
+    </span>
+  `
+}
+
+export function ObservatoryFilterBar() {
+  if (!hasActiveObservatoryFilter()) return null
+
+  const keeper = currentKeeperFilter()
+  const namespace = currentNamespaceFilter()
+  const operation = currentOperationFilter()
+  const range = currentTimeRangeFilter()
+
+  return html`
+    <div
+      class="mb-3 flex flex-wrap items-center gap-2 rounded-xl border border-card-border bg-bg-1/60 px-3 py-2"
+      role="region"
+      aria-label="활성 관찰 필터"
+    >
+      <span class="text-[10px] uppercase tracking-wider text-text-dim font-semibold">필터</span>
+      ${keeper ? html`
+        <${Chip}
+          label="Keeper"
+          value=${keeper}
+          onClear=${() => setObservatoryFilter({ keeper: null })}
+        />
+      ` : null}
+      ${namespace ? html`
+        <${Chip}
+          label="Namespace"
+          value=${namespace}
+          onClear=${() => setObservatoryFilter({ namespace: null })}
+        />
+      ` : null}
+      ${operation ? html`
+        <${Chip}
+          label="Operation"
+          value=${operation}
+          onClear=${() => setObservatoryFilter({ operation: null })}
+        />
+      ` : null}
+      ${range ? html`
+        <${Chip}
+          label="Range"
+          value=${timeRangeLabel(range)}
+          onClear=${() => setObservatoryFilter({ range: null })}
+        />
+      ` : null}
+      <button
+        type="button"
+        class="ml-auto rounded text-[11px] font-medium text-text-muted underline decoration-dotted underline-offset-2 hover:text-text-strong transition-colors"
+        onClick=${() => clearObservatoryFilters()}
+      >
+        모두 해제
+      </button>
+    </div>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -17,6 +17,7 @@ import {
   visibleSectionItemsForTab,
 } from '../config/navigation'
 import { RouteLink } from './common/route-link'
+import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
 
 const buildIdentityOpen = signal(false)
@@ -334,6 +335,7 @@ export function DashboardMain() {
       <div class="mb-3 shrink-0 rounded-xl border border-solid border-[rgba(230,167,0,0.22)] bg-[rgba(230,167,0,0.1)] px-4 py-1.5 text-center text-[0.78rem] text-[#e6a700]">서버 데이터 준비 중 — 잠시 후 자동 갱신됩니다</div>
     ` : null}
     <${SurfaceLead} />
+    <${ObservatoryFilterBar} />
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <div class="animate-in fade-in slide-in-from-bottom-2 duration-300 fill-mode-both">
         <${TabContent} />

--- a/dashboard/src/observatory-filter-store.test.ts
+++ b/dashboard/src/observatory-filter-store.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./router', async () => {
+  const { signal } = await import('@preact/signals')
+  const routeSignal = signal<{ tab: string; params: Record<string, string>; postId: null }>({
+    tab: 'overview',
+    params: {},
+    postId: null,
+  })
+  return {
+    route: routeSignal,
+    navigate: vi.fn((nextTab: string, nextParams?: Record<string, string>) => {
+      routeSignal.value = { tab: nextTab, params: { ...(nextParams ?? {}) }, postId: null }
+    }),
+    __setRoute: (nextTab: string, nextParams: Record<string, string>) => {
+      routeSignal.value = { tab: nextTab, params: { ...nextParams }, postId: null }
+    },
+  }
+})
+
+import * as router from './router'
+import {
+  currentKeeperFilter,
+  currentNamespaceFilter,
+  currentOperationFilter,
+  currentTimeRangeFilter,
+  hasActiveObservatoryFilter,
+  setObservatoryFilter,
+  clearObservatoryFilters,
+  setKeeperFilter,
+  setTimeRangeFilter,
+  timeRangeLabel,
+} from './observatory-filter-store'
+
+const setRoute = (router as unknown as {
+  __setRoute: (t: string, p: Record<string, string>) => void
+}).__setRoute
+
+describe('observatory-filter-store', () => {
+  beforeEach(() => {
+    setRoute('overview', {})
+    vi.clearAllMocks()
+  })
+
+  it('returns null for all filters when URL has no relevant params', () => {
+    expect(currentKeeperFilter()).toBeNull()
+    expect(currentNamespaceFilter()).toBeNull()
+    expect(currentOperationFilter()).toBeNull()
+    expect(currentTimeRangeFilter()).toBeNull()
+    expect(hasActiveObservatoryFilter()).toBe(false)
+  })
+
+  it('reads keeper/ns/op/range from URL params', () => {
+    setRoute('monitoring', { section: 'telemetry', keeper: 'nova', ns: 'team-a', op: 'op-42', range: '1h' })
+
+    expect(currentKeeperFilter()).toBe('nova')
+    expect(currentNamespaceFilter()).toBe('team-a')
+    expect(currentOperationFilter()).toBe('op-42')
+    expect(currentTimeRangeFilter()).toBe('1h')
+    expect(hasActiveObservatoryFilter()).toBe(true)
+  })
+
+  it('rejects invalid time range preset', () => {
+    setRoute('monitoring', { range: 'invalid' })
+    expect(currentTimeRangeFilter()).toBeNull()
+  })
+
+  it('setObservatoryFilter writes to URL via navigate', () => {
+    setObservatoryFilter({ keeper: 'luna', range: '5m' })
+    expect(router.navigate).toHaveBeenCalledWith('overview', { keeper: 'luna', range: '5m' })
+  })
+
+  it('setObservatoryFilter with null value deletes the param', () => {
+    setRoute('monitoring', { keeper: 'nova', range: '1h' })
+    setObservatoryFilter({ keeper: null })
+    expect(router.navigate).toHaveBeenLastCalledWith('monitoring', { range: '1h' })
+  })
+
+  it('setObservatoryFilter preserves unrelated params (section, session_id)', () => {
+    setRoute('monitoring', { section: 'telemetry', session_id: 's-1' })
+    setObservatoryFilter({ keeper: 'nova' })
+    expect(router.navigate).toHaveBeenLastCalledWith('monitoring', {
+      section: 'telemetry',
+      session_id: 's-1',
+      keeper: 'nova',
+    })
+  })
+
+  it('clearObservatoryFilters removes all 4 filter params', () => {
+    setRoute('monitoring', {
+      section: 'telemetry',
+      keeper: 'nova',
+      ns: 'team-a',
+      op: 'op-42',
+      range: '1h',
+    })
+    clearObservatoryFilters()
+    expect(router.navigate).toHaveBeenLastCalledWith('monitoring', { section: 'telemetry' })
+  })
+
+  it('setKeeperFilter is a shortcut for keeper-only update', () => {
+    setKeeperFilter('orion')
+    expect(router.navigate).toHaveBeenCalledWith('overview', { keeper: 'orion' })
+  })
+
+  it('setTimeRangeFilter is a shortcut for range-only update', () => {
+    setTimeRangeFilter('24h')
+    expect(router.navigate).toHaveBeenCalledWith('overview', { range: '24h' })
+  })
+
+  it('timeRangeLabel returns human-readable Korean label', () => {
+    expect(timeRangeLabel('5m')).toBe('최근 5분')
+    expect(timeRangeLabel('1h')).toBe('최근 1시간')
+    expect(timeRangeLabel('24h')).toBe('최근 24시간')
+    expect(timeRangeLabel('7d')).toBe('최근 7일')
+  })
+})

--- a/dashboard/src/observatory-filter-store.ts
+++ b/dashboard/src/observatory-filter-store.ts
@@ -1,0 +1,104 @@
+// Observatory global filter — shared across surfaces (RFC-MASC-006 Phase 1)
+//
+// URL-synced reactive accessors (no separate signal store):
+//   ?keeper=X     — keeper name filter
+//   ?ns=Y         — namespace filter
+//   ?op=Z         — operation_id filter
+//   ?range=1h     — time range preset (5m, 1h, 24h, 7d)
+//
+// Consumers read `currentKeeperFilter()` etc. inside reactive scopes
+// (components, effects, computeds) — the accessor reads `route.value`,
+// which subscribes the enclosing reactive context to route changes.
+
+import { route, navigate } from './router'
+
+export type TimeRangePreset = '5m' | '1h' | '24h' | '7d'
+
+export const TIME_RANGE_PRESETS: ReadonlyArray<TimeRangePreset> = ['5m', '1h', '24h', '7d']
+
+const TIME_RANGE_LABELS: Record<TimeRangePreset, string> = {
+  '5m': '최근 5분',
+  '1h': '최근 1시간',
+  '24h': '최근 24시간',
+  '7d': '최근 7일',
+}
+
+export function timeRangeLabel(preset: TimeRangePreset): string {
+  return TIME_RANGE_LABELS[preset]
+}
+
+// --- Reactive accessors (URL → state) ---
+
+export function currentKeeperFilter(): string | null {
+  const value = route.value.params.keeper
+  return value && value.length > 0 ? value : null
+}
+
+export function currentNamespaceFilter(): string | null {
+  const value = route.value.params.ns
+  return value && value.length > 0 ? value : null
+}
+
+export function currentOperationFilter(): string | null {
+  const value = route.value.params.op
+  return value && value.length > 0 ? value : null
+}
+
+export function currentTimeRangeFilter(): TimeRangePreset | null {
+  const value = route.value.params.range
+  if (!value) return null
+  return TIME_RANGE_PRESETS.includes(value as TimeRangePreset)
+    ? (value as TimeRangePreset)
+    : null
+}
+
+export function hasActiveObservatoryFilter(): boolean {
+  return currentKeeperFilter() !== null
+    || currentNamespaceFilter() !== null
+    || currentOperationFilter() !== null
+    || currentTimeRangeFilter() !== null
+}
+
+// --- Setters (state → URL) ---
+
+type FilterPatch = {
+  keeper?: string | null
+  namespace?: string | null
+  operation?: string | null
+  range?: TimeRangePreset | null
+}
+
+export function setObservatoryFilter(patch: FilterPatch): void {
+  const next: Record<string, string> = { ...route.value.params }
+
+  if (patch.keeper !== undefined) {
+    if (patch.keeper === null || patch.keeper === '') delete next.keeper
+    else next.keeper = patch.keeper
+  }
+  if (patch.namespace !== undefined) {
+    if (patch.namespace === null || patch.namespace === '') delete next.ns
+    else next.ns = patch.namespace
+  }
+  if (patch.operation !== undefined) {
+    if (patch.operation === null || patch.operation === '') delete next.op
+    else next.op = patch.operation
+  }
+  if (patch.range !== undefined) {
+    if (patch.range === null) delete next.range
+    else next.range = patch.range
+  }
+
+  navigate(route.value.tab, next)
+}
+
+export function clearObservatoryFilters(): void {
+  setObservatoryFilter({ keeper: null, namespace: null, operation: null, range: null })
+}
+
+export function setKeeperFilter(keeper: string | null): void {
+  setObservatoryFilter({ keeper })
+}
+
+export function setTimeRangeFilter(range: TimeRangePreset | null): void {
+  setObservatoryFilter({ range })
+}


### PR DESCRIPTION
## Summary

RFC-MASC-006 (#7050) Phase 1 — Observatory 구축을 위한 **global filter state** 토대 구축. Phase 2 (Observatory v1) 없이도 즉시 가치 있음: 기존 surface 사이를 이동할 때 keeper/namespace/operation/time-range 컨텍스트가 URL에 보존됨.

## URL 파라미터

새로 도입:

| Param | 의미 | 예시 |
|-------|------|------|
| \`keeper\` | keeper 이름 필터 | \`?keeper=nova\` |
| \`ns\` | namespace 필터 | \`?ns=team-a\` |
| \`op\` | operation_id 필터 | \`?op=op-42\` |
| \`range\` | 시간 범위 (\`5m\`/\`1h\`/\`24h\`/\`7d\`) | \`?range=1h\` |

기존 URL param (\`section\`, \`session_id\` 등)과 공존, 덮어쓰지 않음.

## 신규 파일

### \`observatory-filter-store.ts\` (~95줄)

URL ↔ 상태 양방향 반응형 accessor:

\`\`\`typescript
// Read (reactive)
currentKeeperFilter(): string | null
currentNamespaceFilter(): string | null
currentOperationFilter(): string | null
currentTimeRangeFilter(): TimeRangePreset | null
hasActiveObservatoryFilter(): boolean

// Write (URL navigate)
setObservatoryFilter({ keeper?, namespace?, operation?, range? })
clearObservatoryFilters()
setKeeperFilter(keeper: string | null)
setTimeRangeFilter(range: TimeRangePreset | null)
\`\`\`

### \`components/common/observatory-filter-bar.ts\` (~100줄)

Header에 표시되는 chip 위젯:
- 활성 필터가 있을 때만 렌더 (없으면 \`return null\`)
- 각 chip에 X 버튼 — 개별 clear
- 우측 \"모두 해제\" 링크 — bulk clear

## 통합

\`dashboard-shell.ts\` \`DashboardMain\`에 \`<ObservatoryFilterBar />\` 삽입. Filter 없으면 아무것도 안 보임.

## 기존 surface는 미변경

Telemetry-unified 등 기존 surface의 local \`useSignal('')\` 필터는 **그대로 유지**. Phase 2에서 전역으로 migrate 예정. 지금은 토대만.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — zero errors
- [x] \`pnpm exec vitest observatory-filter-store\` — 10/10 pass (10 시나리오: read/write, null 처리, unrelated params 보존, clearAll, shortcut setters, Korean labels)
- [ ] CI green
- [ ] 로컬 UI 확인: URL에 \`?keeper=nova\` 추가 → chip 표시, X 버튼 동작, \"모두 해제\" 동작

## Refs

- RFC-MASC-006 (#7050): Observatory unified investigation surface
- Phase 0 (#7055): sessions stub 제거 ✓ merged
- Phase 2 (다음): Observatory v1 (신규 surface, 5 tracks, cross-signal cursor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)