### PR TITLE
feat(dashboard): Hebbian viz — circular → sorted matrix heatmap + top-5

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1715,6 +1715,9 @@ export interface MemorySubsystemsSynapse {
   failure_count: number
   last_updated: number
   created_at: number
+  /** Newest-first list of (unix ts seconds, weight) points, capped at 30.
+      Missing for graphs produced by pre-sparkline backends. */
+  weight_history?: Array<[number, number]>
 }
 
 export interface MemorySubsystemsEpisode {

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -52,117 +52,182 @@ const ARCHITECTURE_FLOW = `graph LR
     class M1,M3,H1,H2,T2 action
     class UI ui`
 
-function HebbianNetwork({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
+const shortAgentLabel = (name: string) => {
+  const trimmed = name.replace(/^keeper-/, '').replace(/-agent$/, '')
+  return trimmed.length > 12 ? trimmed.slice(0, 11) + '…' : trimmed
+}
+
+const weightColor = (w: number) =>
+  w >= 0.7 ? '#10b981' : w >= 0.4 ? '#f59e0b' : '#f87171'
+
+// Perceptual linearization: √weight maps linear data to perceived brightness.
+// Ghoniem et al. 2005 — in-cell encoding beats on-edge encoding for weight tasks.
+const weightOpacity = (w: number) => 0.25 + 0.75 * Math.sqrt(Math.max(0, Math.min(1, w)))
+
+function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
   if (synapses.length === 0) return null
 
-  const nodes = new Map<string, number>()
+  // Sort by activity total (success + failure on either side) — hubs appear top-left.
+  // Canonical in Hebbian literature (Sadeh & Clopath, PNAS 2024): sort rows by a feature.
+  const activity = new Map<string, number>()
   synapses.forEach(s => {
-    nodes.set(s.from_agent, (nodes.get(s.from_agent) ?? 0) + 1)
-    nodes.set(s.to_agent, (nodes.get(s.to_agent) ?? 0) + 1)
+    const n = s.success_count + s.failure_count
+    activity.set(s.from_agent, (activity.get(s.from_agent) ?? 0) + n)
+    activity.set(s.to_agent, (activity.get(s.to_agent) ?? 0) + n)
   })
+  const agents = Array.from(activity.keys()).sort(
+    (a, b) => (activity.get(b) ?? 0) - (activity.get(a) ?? 0),
+  )
 
-  const nodeNames = Array.from(nodes.keys())
-  const width = 600
-  const height = 360
-  const cx = width / 2
-  const cy = height / 2
-  const radius = Math.min(width, height) / 2 - 60
+  const cellMap = new Map<string, MemorySubsystemsSynapse>()
+  synapses.forEach(s => cellMap.set(`${s.from_agent}|${s.to_agent}`, s))
 
-  const positions = new Map<string, { x: number; y: number }>()
-  nodeNames.forEach((name, i) => {
-    const angle = (i / nodeNames.length) * Math.PI * 2 - Math.PI / 2
-    positions.set(name, {
-      x: cx + radius * Math.cos(angle),
-      y: cy + radius * Math.sin(angle),
-    })
-  })
-
-  const shortLabel = (name: string) => {
-    const trimmed = name.replace(/^keeper-/, '').replace(/-agent$/, '')
-    return trimmed.length > 10 ? trimmed.slice(0, 9) + '…' : trimmed
-  }
+  const n = agents.length
+  const cell = n <= 8 ? 32 : n <= 12 ? 26 : 22
+  const leftPad = 120
+  const topPad = 96
+  const legendW = 70
+  const width = leftPad + n * cell + legendW
+  const height = topPad + n * cell + 30
 
   return html`
-    <div class="bg-zinc-900 rounded-lg p-2 overflow-x-auto">
-      <svg viewBox="0 0 ${width} ${height}" class="w-full h-auto" style="max-height:400px">
-        <defs>
-          <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
-            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" class="text-zinc-600" />
-          </marker>
-        </defs>
-        ${synapses.map(s => {
-          const from = positions.get(s.from_agent)
-          const to = positions.get(s.to_agent)
-          if (!from || !to) return null
-          const pct = Math.round(s.weight * 100)
-          const stroke =
-            pct >= 70 ? '#10b981' : pct >= 40 ? '#f59e0b' : '#f87171'
-          const sw = Math.max(1, s.weight * 4)
-          const dx = to.x - from.x
-          const dy = to.y - from.y
-          const len = Math.sqrt(dx * dx + dy * dy)
-          const ux = dx / len
-          const uy = dy / len
-          const sx = from.x + ux * 22
-          const sy = from.y + uy * 22
-          const ex = to.x - ux * 22
-          const ey = to.y - uy * 22
-          return html`<line
-            x1=${sx}
-            y1=${sy}
-            x2=${ex}
-            y2=${ey}
-            stroke=${stroke}
-            stroke-width=${sw}
-            opacity="0.7"
-            marker-end="url(#arrow)"
-          />`
-        })}
-        ${nodeNames.map(name => {
-          const pos = positions.get(name)!
-          const label = shortLabel(name)
-          const isKeeper = name.startsWith('keeper-')
-          const fill = isKeeper ? '#1e293b' : '#0f172a'
-          const stroke = isKeeper ? '#3b82f6' : '#64748b'
-          const onNodeClick = () => openAgentDetail(name)
-          const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault()
-              openAgentDetail(name)
-            }
-          }
-          return html`
-            <g
-              class="cursor-pointer hover:opacity-80 transition-opacity"
-              role="button"
-              tabindex="0"
-              onClick=${onNodeClick}
-              onKeyDown=${onKeyDown}
-              aria-label=${'에이전트 상세 열기: ' + label}
-            >
-              <circle
-                cx=${pos.x}
-                cy=${pos.y}
-                r="22"
-                fill=${fill}
-                stroke=${stroke}
-                stroke-width="2"
-              />
+    <div class="bg-zinc-900 rounded-lg p-3 overflow-x-auto">
+      <svg viewBox="0 0 ${width} ${height}" class="w-full h-auto" style="max-height:560px">
+        ${agents.map(
+          (name, i) => html`
+            <g transform="translate(${leftPad + i * cell + cell / 2}, ${topPad - 6}) rotate(-45)">
               <text
-                x=${pos.x}
-                y=${pos.y + 4}
-                text-anchor="middle"
-                font-size="11"
-                fill="#f1f5f9"
+                text-anchor="start"
+                font-size="10"
+                fill="#cbd5e1"
                 font-family="monospace"
-                class="pointer-events-none select-none"
-              >
-                ${label}
-              </text>
+                class="cursor-pointer hover:fill-sky-400"
+                onClick=${() => openAgentDetail(name)}
+              >${shortAgentLabel(name)}</text>
             </g>
+          `,
+        )}
+
+        ${agents.map(
+          (name, i) => html`
+            <text
+              x=${leftPad - 6}
+              y=${topPad + i * cell + cell / 2 + 4}
+              text-anchor="end"
+              font-size="10"
+              fill="#cbd5e1"
+              font-family="monospace"
+              class="cursor-pointer hover:fill-sky-400"
+              onClick=${() => openAgentDetail(name)}
+            >${shortAgentLabel(name)}</text>
+          `,
+        )}
+
+        ${agents.flatMap((from, r) =>
+          agents.map((to, c) => {
+            const s = cellMap.get(`${from}|${to}`)
+            const x = leftPad + c * cell
+            const y = topPad + r * cell
+            if (!s) {
+              return html`<rect
+                x=${x}
+                y=${y}
+                width=${cell - 1}
+                height=${cell - 1}
+                fill="#1e293b"
+                stroke="#0f172a"
+                stroke-width="0.5"
+              />`
+            }
+            const pct = Math.round(s.weight * 100)
+            const isDiag = from === to
+            return html`
+              <g>
+                <title>${`${from} → ${to}\nweight ${pct}% · 성공 ${s.success_count} · 실패 ${s.failure_count}`}</title>
+                <rect
+                  x=${x}
+                  y=${y}
+                  width=${cell - 1}
+                  height=${cell - 1}
+                  fill=${weightColor(s.weight)}
+                  opacity=${weightOpacity(s.weight)}
+                  stroke=${isDiag ? '#64748b' : '#0f172a'}
+                  stroke-dasharray=${isDiag ? '2 2' : ''}
+                  stroke-width="0.5"
+                  class="cursor-pointer hover:stroke-zinc-300"
+                  role="button"
+                  aria-label=${`${from} to ${to}: ${pct}%`}
+                  onClick=${() => openAgentDetail(to)}
+                />
+              </g>
+            `
+          }),
+        )}
+
+        <g transform="translate(${leftPad + n * cell + 16}, ${topPad})">
+          <text x="0" y="-8" font-size="9" fill="#94a3b8">weight</text>
+          ${[1.0, 0.75, 0.5, 0.25, 0.05].map(
+            (v, i) => html`
+              <g>
+                <rect
+                  x="0"
+                  y=${i * 16}
+                  width="14"
+                  height="13"
+                  fill=${weightColor(v)}
+                  opacity=${weightOpacity(v)}
+                />
+                <text
+                  x="20"
+                  y=${i * 16 + 10}
+                  font-size="9"
+                  fill="#94a3b8"
+                  font-family="monospace"
+                >${Math.round(v * 100)}%</text>
+              </g>
+            `,
+          )}
+        </g>
+      </svg>
+      <div class="mt-2 text-xs text-zinc-500 text-center">
+        행 = from · 열 = to · 셀 = 시냅스 가중치 · 정렬 = 활동량 내림차순
+      </div>
+    </div>
+  `
+}
+
+function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
+  if (synapses.length === 0) return null
+  const top = [...synapses].sort((a, b) => b.weight - a.weight).slice(0, 5)
+  return html`
+    <div class="bg-zinc-900 rounded-lg p-3 mt-3">
+      <div class="text-xs text-zinc-500 mb-2">강한 연결 Top 5</div>
+      <div class="space-y-1.5">
+        ${top.map(s => {
+          const pct = Math.round(s.weight * 100)
+          const barColor =
+            pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-500' : 'bg-red-400'
+          return html`
+            <div class="flex items-center gap-2 text-xs font-mono">
+              <button
+                class="text-zinc-300 hover:text-sky-400 truncate w-32 text-right"
+                onClick=${() => openAgentDetail(s.from_agent)}
+              >${shortAgentLabel(s.from_agent)}</button>
+              <span class="text-zinc-600">→</span>
+              <button
+                class="text-zinc-300 hover:text-sky-400 truncate w-32 text-left"
+                onClick=${() => openAgentDetail(s.to_agent)}
+              >${shortAgentLabel(s.to_agent)}</button>
+              <div class="flex-1 bg-zinc-800 rounded h-1.5 min-w-[60px]">
+                <div class="${barColor} rounded h-1.5" style="width:${pct}%"></div>
+              </div>
+              <span class="text-zinc-300 w-10 text-right">${pct}%</span>
+              <span class="text-emerald-400 w-8 text-right">${s.success_count}</span>
+              <span class="text-red-400 w-8 text-right">${s.failure_count}</span>
+            </div>
           `
         })}
-      </svg>
+      </div>
     </div>
   `
 }
@@ -371,7 +436,10 @@ export function MemorySubsystems() {
         </div>
         ${
           synapses.length > 0
-            ? html`<div class="mb-3"><${HebbianNetwork} synapses=${synapses} /></div>`
+            ? html`<div class="mb-3">
+                <${HebbianMatrix} synapses=${synapses} />
+                <${HebbianTopLinks} synapses=${synapses} />
+              </div>`
             : null
         }
         ${

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -196,12 +196,45 @@ function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
   `
 }
 
+// Render a tiny polyline of weight history. Input is newest-first from
+// the backend; reverse for chronological left-to-right rendering.
+function WeightSparkline({ history }: { history?: Array<[number, number]> }) {
+  if (!history || history.length < 2) {
+    return html`<span class="text-zinc-700 text-[10px] w-20 text-center">—</span>`
+  }
+  const chronological = [...history].reverse()
+  const w = 80
+  const h = 16
+  const n = chronological.length
+  const points = chronological
+    .map(([, weight], i) => {
+      const x = (i / (n - 1)) * (w - 2) + 1
+      const y = h - 1 - Math.max(0, Math.min(1, weight)) * (h - 2)
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+  const first = chronological[0]?.[1] ?? 0
+  const last = chronological[n - 1]?.[1] ?? 0
+  const trendColor = last > first + 0.02 ? '#10b981' : last < first - 0.02 ? '#f87171' : '#94a3b8'
+  return html`
+    <svg
+      viewBox="0 0 ${w} ${h}"
+      width=${w}
+      height=${h}
+      class="shrink-0"
+      aria-label=${`weight trend: ${n} points`}
+    >
+      <polyline fill="none" stroke=${trendColor} stroke-width="1.25" points=${points} />
+    </svg>
+  `
+}
+
 function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
   if (synapses.length === 0) return null
   const top = [...synapses].sort((a, b) => b.weight - a.weight).slice(0, 5)
   return html`
     <div class="bg-zinc-900 rounded-lg p-3 mt-3">
-      <div class="text-xs text-zinc-500 mb-2">강한 연결 Top 5</div>
+      <div class="text-xs text-zinc-500 mb-2">강한 연결 Top 5 · sparkline = 학습 궤적</div>
       <div class="space-y-1.5">
         ${top.map(s => {
           const pct = Math.round(s.weight * 100)
@@ -222,6 +255,7 @@ function HebbianTopLinks({ synapses }: { synapses: MemorySubsystemsSynapse[] }) 
                 <div class="${barColor} rounded h-1.5" style="width:${pct}%"></div>
               </div>
               <span class="text-zinc-300 w-10 text-right">${pct}%</span>
+              <${WeightSparkline} history=${s.weight_history} />
               <span class="text-emerald-400 w-8 text-right">${s.success_count}</span>
               <span class="text-red-400 w-8 text-right">${s.failure_count}</span>
             </div>

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -25,7 +25,25 @@ type synapse = {
   failure_count: int;   (* Number of failed collaborations *)
   last_updated: float;  (* Unix timestamp *)
   created_at: float;
+  weight_history: (float * float) list;
+    (* (ts, weight) newest first, capped at [history_cap]. Enables
+       sparkline visualization of learning direction (strengthening
+       vs weakening over time). *)
 }
+
+(** Cap for [weight_history]. Newer entries evict older ones. *)
+let history_cap = 30
+
+(** Prepend [(ts, w)] to [history] and trim to [history_cap].
+    Back-to-back writes at the same fractional tick produce separate
+    entries — this preserves trajectory resolution and keeps the
+    append deterministic (no dependence on clock granularity). *)
+let append_history ~ts ~w history =
+  let rec take n xs = match n, xs with
+    | 0, _ | _, [] -> []
+    | n, x :: rest -> x :: take (n - 1) rest
+  in
+  take history_cap ((ts, w) :: history)
 
 (** Synapse graph *)
 type synapse_graph = {
@@ -119,6 +137,9 @@ let with_graph_lock config f =
 
 (** Synapse to JSON *)
 let synapse_to_json (s : synapse) : Yojson.Safe.t =
+  let history_json =
+    `List (List.map (fun (ts, w) -> `List [`Float ts; `Float w]) s.weight_history)
+  in
   `Assoc [
     ("from_agent", `String s.from_agent);
     ("to_agent", `String s.to_agent);
@@ -127,9 +148,26 @@ let synapse_to_json (s : synapse) : Yojson.Safe.t =
     ("failure_count", `Int s.failure_count);
     ("last_updated", `Float s.last_updated);
     ("created_at", `Float s.created_at);
+    ("weight_history", history_json);
   ]
 
-(** Synapse from JSON *)
+(** Parse [weight_history] from JSON, tolerating missing field (backward
+    compat with graph.json files written before this field existed). *)
+let weight_history_of_json json =
+  let open Yojson.Safe.Util in
+  match member "weight_history" json with
+  | `Null -> []
+  | `List items ->
+    List.filter_map (fun item ->
+      match item with
+      | `List [`Float ts; `Float w] -> Some (ts, w)
+      | `List [`Int ts; `Float w] -> Some (float_of_int ts, w)
+      | _ -> None
+    ) items
+  | _ -> []
+
+(** Synapse from JSON. [weight_history] defaults to [] for files written
+    before the field was introduced. *)
 let synapse_of_json json : synapse option =
   let open Yojson.Safe.Util in
   try
@@ -141,6 +179,7 @@ let synapse_of_json json : synapse option =
       failure_count = json |> member "failure_count" |> to_int;
       last_updated = json |> member "last_updated" |> to_float;
       created_at = json |> member "created_at" |> to_float;
+      weight_history = weight_history_of_json json;
     }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Log.Misc.error "Failed to parse synapse: %s" (Printexc.to_string exn);
@@ -193,7 +232,8 @@ let find_synapse graph ~from_agent ~to_agent : synapse option =
     s.from_agent = from_agent && s.to_agent = to_agent
   ) graph.synapses
 
-(** Create new synapse - pure *)
+(** Create new synapse - pure. Seeds [weight_history] with the initial
+    neutral weight so sparklines have a reference point from tick 0. *)
 let create_synapse ~from_agent ~to_agent : synapse =
   let now = Time_compat.now () in
   {
@@ -204,6 +244,7 @@ let create_synapse ~from_agent ~to_agent : synapse =
     failure_count = 0;
     last_updated = now;
     created_at = now;
+    weight_history = [(now, 0.5)];
   }
 
 (** Update synapse in graph - pure *)
@@ -223,11 +264,13 @@ let strengthen config ?params ~from_agent ~to_agent () : unit =
       | None -> create_synapse ~from_agent ~to_agent
     in
     let new_weight = min params.max_weight (synapse.weight +. params.strengthen_rate) in
+    let now = Time_compat.now () in
     let updated = {
       synapse with
       weight = new_weight;
       success_count = synapse.success_count + 1;
-      last_updated = Time_compat.now ();
+      last_updated = now;
+      weight_history = append_history ~ts:now ~w:new_weight synapse.weight_history;
     } in
     let new_graph = update_synapse graph updated in
     save_graph config new_graph
@@ -242,11 +285,13 @@ let weaken config ?params ~from_agent ~to_agent () : unit =
     | None -> ()  (* No synapse to weaken *)
     | Some synapse ->
       let new_weight = max 0.0 (synapse.weight -. params.weaken_rate) in
+      let now = Time_compat.now () in
       let updated = {
         synapse with
         weight = new_weight;
         failure_count = synapse.failure_count + 1;
-        last_updated = Time_compat.now ();
+        last_updated = now;
+        weight_history = append_history ~ts:now ~w:new_weight synapse.weight_history;
       } in
       let new_graph = update_synapse graph updated in
       save_graph config new_graph
@@ -290,7 +335,12 @@ let consolidate config ?params ~decay_after_days () : int =
           (* Prune weak synapse *)
           (acc, count + 1)
         else
-          let updated = { synapse with weight = new_weight; last_updated = now } in
+          let updated = {
+            synapse with
+            weight = new_weight;
+            last_updated = now;
+            weight_history = append_history ~ts:now ~w:new_weight synapse.weight_history;
+          } in
           (updated :: acc, count)
       else
         (synapse :: acc, count)

--- a/test/test_hebbian_eio.ml
+++ b/test/test_hebbian_eio.ml
@@ -180,6 +180,102 @@ let test_weaken_nonexistent () =
   );
   print_endline "✓ test_weaken_nonexistent passed"
 
+let test_weight_history_appends_on_strengthen () =
+  with_temp_masc_dir (fun config ->
+    let params = {
+      Hebbian_eio.strengthen_rate = 0.1;
+      weaken_rate = 0.05;
+      decay_rate = 0.01;
+      min_weight = 0.05;
+      max_weight = 1.0;
+    } in
+    Hebbian_eio.strengthen config ~params ~from_agent:"a" ~to_agent:"b" ();
+    Hebbian_eio.strengthen config ~params ~from_agent:"a" ~to_agent:"b" ();
+    Hebbian_eio.strengthen config ~params ~from_agent:"a" ~to_agent:"b" ();
+
+    let (synapses, _) = Hebbian_eio.get_graph_data config in
+    let s = List.hd synapses in
+    (* Initial (0.5) + 3 strengthen appends = 4 entries, newest first. *)
+    assert (List.length s.Hebbian_eio.weight_history = 4);
+    let (_, newest_w) = List.hd s.Hebbian_eio.weight_history in
+    assert (Float.abs (newest_w -. s.Hebbian_eio.weight) < 1e-9);
+  );
+  print_endline "✓ test_weight_history_appends_on_strengthen passed"
+
+let test_weight_history_caps_at_history_cap () =
+  with_temp_masc_dir (fun config ->
+    for _ = 1 to Hebbian_eio.history_cap + 15 do
+      Hebbian_eio.strengthen config ~from_agent:"a" ~to_agent:"b" ()
+    done;
+    let (synapses, _) = Hebbian_eio.get_graph_data config in
+    let s = List.hd synapses in
+    assert (List.length s.Hebbian_eio.weight_history = Hebbian_eio.history_cap);
+  );
+  print_endline "✓ test_weight_history_caps_at_history_cap passed"
+
+let test_weight_history_backward_compat_missing_field () =
+  (* Simulate a graph.json produced by a pre-sparkline binary: no
+     weight_history field. Loader must default to []. *)
+  let legacy_json = {|
+    {
+      "synapses": [
+        {
+          "from_agent": "legacy_a",
+          "to_agent": "legacy_b",
+          "weight": 0.7,
+          "success_count": 4,
+          "failure_count": 1,
+          "last_updated": 1700000000.0,
+          "created_at": 1699000000.0
+        }
+      ],
+      "last_consolidation": 0.0
+    }
+  |} in
+  let parsed = Hebbian_eio.graph_of_json (Yojson.Safe.from_string legacy_json) in
+  assert (List.length parsed.Hebbian_eio.synapses = 1);
+  let s = List.hd parsed.Hebbian_eio.synapses in
+  assert (s.Hebbian_eio.weight_history = []);
+  assert (Float.abs (s.Hebbian_eio.weight -. 0.7) < 1e-9);
+  print_endline "✓ test_weight_history_backward_compat_missing_field passed"
+
+let test_weight_history_json_roundtrip () =
+  let s : Hebbian_eio.synapse = {
+    from_agent = "rt_a";
+    to_agent = "rt_b";
+    weight = 0.62;
+    success_count = 5;
+    failure_count = 2;
+    last_updated = 1700000100.5;
+    created_at = 1699000000.0;
+    weight_history = [(1700000100.5, 0.62); (1700000050.0, 0.55); (1700000000.0, 0.5)];
+  } in
+  let json = Hebbian_eio.synapse_to_json s in
+  match Hebbian_eio.synapse_of_json json with
+  | None -> assert false
+  | Some s' ->
+    assert (s'.weight_history = s.weight_history);
+    assert (s'.success_count = 5);
+    print_endline "✓ test_weight_history_json_roundtrip passed"
+
+let test_append_history_caps_and_preserves_order () =
+  (* Newest entry is head; overflow evicts the oldest tail. *)
+  let h =
+    let rec fill i h =
+      if i > Hebbian_eio.history_cap + 5 then h
+      else
+        Hebbian_eio.append_history
+          ~ts:(float_of_int i)
+          ~w:(float_of_int i /. 100.0)
+          (fill (i + 1) h)
+    in
+    fill 1 []
+  in
+  assert (List.length h = Hebbian_eio.history_cap);
+  let (head_ts, _) = List.hd h in
+  assert (Float.equal head_ts 1.0);
+  print_endline "✓ test_append_history_caps_and_preserves_order passed"
+
 let () =
   Alcotest.run "Hebbian_eio"
     [
@@ -205,5 +301,18 @@ let () =
           Alcotest.test_case "custom learning params" `Quick
             test_custom_params;
           Alcotest.test_case "lock stats" `Quick test_lock_stats;
+        ] );
+      ( "weight_history",
+        [
+          Alcotest.test_case "appends on strengthen" `Quick
+            test_weight_history_appends_on_strengthen;
+          Alcotest.test_case "caps at history_cap" `Quick
+            test_weight_history_caps_at_history_cap;
+          Alcotest.test_case "backward compat missing field" `Quick
+            test_weight_history_backward_compat_missing_field;
+          Alcotest.test_case "JSON roundtrip" `Quick
+            test_weight_history_json_roundtrip;
+          Alcotest.test_case "caps and preserves order" `Quick
+            test_append_history_caps_and_preserves_order;
         ] );
     ]


### PR DESCRIPTION
## Summary

Replace the circular Hebbian synapse graph with a three-layer research-backed visualization: sorted adjacency-matrix heatmap + top-5 ranked list with sparklines + per-synapse weight history recorded on the backend.

## Why

Circular node-link layout was a poor match for Hebbian synapse data. All nodes at equal distance from center hides direction, hub structure, and weight comparison; the edge color band (4px) was the only weight cue and was hard to read. The reader's eye had to fall back to the table below, so the top visualization carried little signal.

## Research basis

| Source | Insight |
|--------|---------|
| Ghoniem et al. 2005, *Information Visualization* | In-cell encoding on matrices beats on-edge encoding on node-link diagrams for weight-estimation tasks. Matrix results also have lower accuracy variance (stddev 34 vs 92). |
| Sadeh & Clopath, PNAS 2024 (*Synapse-type-specific competitive Hebbian learning*) | Canonical Hebbian weight visualization is a **feature-sorted matrix**. Unsorted matrices hide structure. |
| 2024 connectome literature reviews | Recommend complementary multiple visualizations over a single view. Matrix + ranked list + sparkline matches this. |
| ACM DIS 2025, arXiv 2505.23695 | Multi-agent dashboard UX: **interaction traceability** (time dimension) is the central comprehension bottleneck for LLM agent systems. |

## Changes

### Backend — `lib/hebbian_eio.ml`
- `synapse` gains `weight_history : (float * float) list` (newest first, capped at 30).
- `create_synapse` seeds history with the initial `0.5` reference.
- `strengthen` / `weaken` / `consolidate` append `(now, new_weight)` after mutation. Consolidate records decayed weights too so the trajectory reflects real learning pressure.
- JSON: `synapse_of_json` tolerates files written by pre-sparkline binaries (defaults history to `[]`). `synapse_to_json` always emits the new field.
- Server (`server_dashboard_http.ml`) calls `Hebbian_eio.graph_to_json` directly — pass-through, no server changes required.

### Backend tests — `test/test_hebbian_eio.ml`
5 new cases under `weight_history`: appends on strengthen, caps at `history_cap`, backward-compat load, JSON roundtrip, `append_history` cap/order.

### Dashboard — `dashboard/src/components/memory-subsystems.ts`
- Removed `HebbianNetwork` (circular, 115 lines).
- `HebbianMatrix` (primary): rows/cols sorted by `success_count + failure_count`, cell color tri-bucket, opacity `0.25 + 0.75 · √weight` (Weber-Fechner), diagonal dashed, row/col/cell click → `openAgentDetail`, legend on right.
- `HebbianTopLinks` (secondary): top-5 by weight desc, `from → to · bar · pct · sparkline · ✓ · ✗` per row.
- `WeightSparkline` renders 80×16 SVG polyline; line color green/red/neutral based on first-vs-last trend with ±0.02 dead zone.
- API: `MemorySubsystemsSynapse.weight_history?: Array<[number, number]>`.

### Preserved
- `SynapseRow` detail table, architecture Mermaid diagram, existing auto-refresh + filter infra.

## Product impact

Users investigating MASC agent learning patterns can now see, in a single screen:
1. **Which agents are hubs** (top-left cluster in the matrix).
2. **The strongest flows right now** (Top 5 list).
3. **Whether those flows are strengthening or decaying** (sparkline).

No user-visible regression: detail table and episode panel unchanged. Pre-sparkline `graph.json` loads cleanly (history defaults to empty, em-dash rendered).

## Evidence

| Check | Result |
|-------|--------|
| `dune build` | clean |
| `dune exec test/test_hebbian_eio.exe` | **14/14** (9 prior + 5 new) |
| `pnpm typecheck` | clean |
| `pnpm lint` | clean |
| `pnpm test` | **506/506** |
| `pnpm build` | ✓ 10.3s, no new large chunks |
| New runtime deps | none |

## Review evidence

Self-review over both commits: matrix commit (Phase 1) verified with typecheck+test+build before sparkline commit (Phase 2) was added on top. No external review yet.

## Behavior on mixed backends

- Old backend + new dashboard: `weight_history` is `undefined` → sparkline em-dash. Matrix unaffected.
- New backend + old dashboard: extra field ignored. No regression.
- `graph.json` migration: automatic on first write; no explicit migration step.

## Linked issue

Closes #7069 (weight history sparkline — subsumed into this PR).

## References

- Ghoniem et al., *Visualizing Weighted Networks: A Performance Comparison of Adjacency Matrices versus Node-link Diagrams* — https://www.researchgate.net/publication/258716465
- Sadeh & Clopath, PNAS 2024 — https://www.pnas.org/doi/10.1073/pnas.2305326121
- *Data-to-Dashboard: Multi-Agent LLM Framework* (arXiv 2505.23695) — https://arxiv.org/html/2505.23695v1
- *Graffinity: Visualizing Connectivity in Large Graphs* — https://pmc.ncbi.nlm.nih.gov/articles/PMC5821473/