### PR TITLE
feat(dashboard): FSM Hub subscribes to composite SSE tick (drop polling)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -386,6 +386,51 @@ export async function fetchKeeperStateDiagram(name: string): Promise<KeeperState
   return resp.json() as Promise<KeeperStateDiagramResponse>
 }
 
+export interface KeeperCompositeInvariants {
+  phase_turn_alignment: boolean
+  no_cascade_before_measurement: boolean
+  compaction_atomicity: boolean
+  event_priority_monotone: boolean
+  recovery_two_store_sync: boolean
+}
+
+export interface KeeperCompositeMeasurement {
+  captured: boolean
+  auto_rules?: {
+    reflect: boolean
+    plan: boolean
+    compact: boolean
+    handoff: boolean
+    guardrail_stop: boolean
+    guardrail_reason: string | null
+    goal_drift: number
+  }
+}
+
+export interface KeeperCompositeSnapshot {
+  correlation_id: string
+  run_id: string
+  ts: number
+  phase: string
+  turn_phase: string
+  decision: { stage: string }
+  cascade: { state: string }
+  compaction: { stage: string }
+  measurement: KeeperCompositeMeasurement
+  recovery: { data_record: boolean; fsm_condition: boolean }
+  invariants: KeeperCompositeInvariants
+}
+
+export async function fetchKeeperComposite(name: string): Promise<KeeperCompositeSnapshot> {
+  const resp = await fetchWithTimeout(
+    `/api/v1/keepers/${encodeURIComponent(name)}/composite`,
+    { headers: jsonHeaders() },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!resp.ok) throw new Error(`composite fetch failed: ${resp.status}`)
+  return resp.json() as Promise<KeeperCompositeSnapshot>
+}
+
 // --- Eval Quality (RFC-MASC-005 Phase 3) ---
 
 export interface EvalLayerResult {

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -7,6 +7,7 @@ import {
   type KeeperCompositeInvariants,
 } from '../api/keeper'
 import { keepers } from '../store'
+import { compositeTick } from '../composite-signals'
 import { EmptyState } from './common/empty-state'
 
 /**
@@ -40,6 +41,14 @@ export function FsmHub() {
     }
   }, [keeperNames, selected])
 
+  // Re-fetch composite snapshot whenever the selected keeper changes OR the
+  // SSE envelope signals a registry mutation on it. [compositeTick.value.ts_unix]
+  // advances monotonically; the name match guards against unrelated keeper
+  // events triggering refetches.
+  const tick = compositeTick.value
+  const shouldRefetchForTick =
+    selected != null && tick.name === selected ? tick.ts_unix : 0
+
   useEffect(() => {
     if (!selected) return
     let cancelled = false
@@ -63,12 +72,10 @@ export function FsmHub() {
 
     run()
 
-    const interval = window.setInterval(run, 5000)
     return () => {
       cancelled = true
-      window.clearInterval(interval)
     }
-  }, [selected])
+  }, [selected, shouldRefetchForTick])
 
   return html`
     <div class="flex flex-col gap-5">

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1,0 +1,309 @@
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+
+import {
+  fetchKeeperComposite,
+  type KeeperCompositeSnapshot,
+  type KeeperCompositeInvariants,
+} from '../api/keeper'
+import { keepers } from '../store'
+import { EmptyState } from './common/empty-state'
+
+/**
+ * FSM Hub — architecture audit surface for the composite keeper lifecycle.
+ *
+ * Data source: `/api/v1/keepers/:name/composite` (RFC-0003 §7).
+ * Rendered as four sub-FSM badges (KSM / KTC / KDP / KCL / KMC) plus the
+ * five safety invariants from KeeperCompositeLifecycle.tla.
+ *
+ * This MVP shows the composite snapshot as structured rows rather than a
+ * Cytoscape compound graph; the compound view is tracked as a follow-up
+ * (docs/design/dashboard-fsm-redesign.md Phase 3 §2).
+ */
+export function FsmHub() {
+  const [selected, setSelected] = useState<string | null>(null)
+  const [snapshot, setSnapshot] = useState<KeeperCompositeSnapshot | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const keeperList = keepers.value
+  const keeperNames = useMemo(
+    () => keeperList.map(k => k.name).sort(),
+    [keeperList],
+  )
+
+  // Pick the first keeper by default once the list is loaded.
+  useEffect(() => {
+    if (selected == null && keeperNames.length > 0) {
+      const first = keeperNames[0]
+      if (first) setSelected(first)
+    }
+  }, [keeperNames, selected])
+
+  useEffect(() => {
+    if (!selected) return
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+
+    const run = async () => {
+      try {
+        const data = await fetchKeeperComposite(selected)
+        if (!cancelled) {
+          setSnapshot(data)
+          setLoading(false)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'composite fetch failed')
+          setLoading(false)
+        }
+      }
+    }
+
+    run()
+
+    const interval = window.setInterval(run, 5000)
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [selected])
+
+  return html`
+    <div class="flex flex-col gap-5">
+      <${HubHeader} />
+      <${KeeperPicker}
+        names=${keeperNames}
+        selected=${selected}
+        onSelect=${setSelected}
+      />
+
+      ${selected == null ? html`
+        <${EmptyState} message="관찰할 키퍼를 선택하세요" />
+      ` : loading && !snapshot ? html`
+        <div class="flex items-center justify-center gap-2 py-10 text-[11px] text-[var(--text-dim)]">
+          <span class="inline-block h-3 w-3 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin"></span>
+          composite 스냅샷 로딩중
+        </div>
+      ` : error ? html`
+        <${EmptyState} message=${error} compact />
+      ` : snapshot ? html`
+        <div class="grid gap-4 lg:grid-cols-2">
+          <${SubFsmCard} label="KSM · Keeper lifecycle" value=${snapshot.phase} tone="accent" />
+          <${SubFsmCard} label="KTC · Turn cycle" value=${snapshot.turn_phase} tone="indigo" />
+          <${SubFsmCard} label="KDP · Decision pipeline" value=${snapshot.decision.stage} tone="indigo" />
+          <${SubFsmCard} label="KCL · Cascade state" value=${snapshot.cascade.state} tone="indigo" />
+          <${SubFsmCard} label="KMC · Memory compaction" value=${snapshot.compaction.stage} tone="amber" />
+          <${MeasurementCard} snapshot=${snapshot} />
+        </div>
+        <${InvariantsPanel} invariants=${snapshot.invariants} />
+        <${RecoveryStatePanel}
+          dataRecord=${snapshot.recovery.data_record}
+          fsmCondition=${snapshot.recovery.fsm_condition}
+        />
+        <${SnapshotMeta} snapshot=${snapshot} />
+      ` : null}
+    </div>
+  `
+}
+
+function HubHeader() {
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+        FSM Hub — RFC-0003 Composite Lifecycle
+      </div>
+      <div class="mt-1 text-[11px] leading-[1.55] text-[var(--text-body)]">
+        Decision · Cascade · Memory · Compaction 네 서브 FSM을 교차로 관찰합니다.
+        Observer는 <code class="px-1 font-mono text-[var(--accent)]">Keeper_composite_observer.observe</code>
+        를 통해 순수 투영만 수행합니다 — 상태 변경/라우팅은 이 페이지에서 일어나지 않습니다.
+      </div>
+    </div>
+  `
+}
+
+function KeeperPicker({
+  names,
+  selected,
+  onSelect,
+}: {
+  names: string[]
+  selected: string | null
+  onSelect: (n: string) => void
+}) {
+  if (names.length === 0) {
+    return html`<${EmptyState} message="등록된 키퍼가 없습니다" compact />`
+  }
+
+  return html`
+    <div class="flex flex-wrap items-center gap-2">
+      <span class="text-[10px] uppercase tracking-[0.1em] text-[var(--text-muted)]">관찰 대상</span>
+      ${names.map(name => {
+        const active = name === selected
+        const cls = active
+          ? 'bg-[var(--accent-10)] border-[var(--accent-30)] text-[var(--accent)]'
+          : 'bg-[var(--white-3)] border-[var(--white-8)] text-[var(--text-body)] hover:border-[var(--accent-30)]'
+        return html`
+          <button
+            class=${`rounded-full border px-3 py-1 text-[11px] font-mono transition-colors ${cls}`}
+            onClick=${() => onSelect(name)}
+          >
+            ${name}
+          </button>
+        `
+      })}
+    </div>
+  `
+}
+
+function SubFsmCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: string
+  tone: 'accent' | 'indigo' | 'amber'
+}) {
+  const toneCls =
+    tone === 'accent'
+      ? 'text-[var(--accent)]'
+      : tone === 'indigo'
+        ? 'text-[#818cf8]'
+        : 'text-[#f59e0b]'
+
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${label}</div>
+      <div class=${`mt-1.5 font-mono text-[18px] font-semibold ${toneCls}`}>${value}</div>
+    </div>
+  `
+}
+
+function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
+  const m = snapshot.measurement
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        Shared measurement
+      </div>
+      ${m.captured && m.auto_rules ? html`
+        <div class="mt-1.5 flex flex-col gap-1 text-[11px] text-[var(--text-body)]">
+          <div class="flex gap-2 font-mono">
+            <${Flag} label="reflect" on=${m.auto_rules.reflect} />
+            <${Flag} label="plan" on=${m.auto_rules.plan} />
+            <${Flag} label="compact" on=${m.auto_rules.compact} />
+            <${Flag} label="handoff" on=${m.auto_rules.handoff} />
+          </div>
+          <div class="flex gap-2 font-mono">
+            <${Flag} label="guardrail" on=${m.auto_rules.guardrail_stop} tone="warn" />
+            <span class="text-[var(--text-dim)]">drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
+          </div>
+          ${m.auto_rules.guardrail_reason ? html`
+            <div class="text-[10px] text-[#f59e0b]">사유: ${m.auto_rules.guardrail_reason}</div>
+          ` : null}
+        </div>
+      ` : html`
+        <div class="mt-1.5 text-[11px] text-[var(--text-dim)]">
+          아직 관측된 Context_measured 이벤트가 없습니다.
+        </div>
+      `}
+    </div>
+  `
+}
+
+function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: 'ok' | 'warn' }) {
+  const offCls = 'text-[var(--text-dim)] border-[var(--white-8)]'
+  const onCls =
+    tone === 'warn'
+      ? 'text-[#f59e0b] border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.08)]'
+      : 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]'
+  return html`
+    <span class=${`rounded-full border px-2 py-0.5 text-[10px] ${on ? onCls : offCls}`}>
+      ${label}
+    </span>
+  `
+}
+
+const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> = {
+  phase_turn_alignment: 'PhaseTurnAlignment — phase=Compacting ⇔ turn=compacting',
+  no_cascade_before_measurement: 'NoCascadeBeforeMeasurement — measurement 선행',
+  compaction_atomicity: 'CompactionAtomicity — phase=Compacting ⇔ compaction_active',
+  event_priority_monotone: 'EventPriorityMonotone — Compaction < Handoff < Context_measured',
+  recovery_two_store_sync: 'RecoveryTwoStoreSync — data/fsm 저장소 동기',
+}
+
+function InvariantsPanel({ invariants }: { invariants: KeeperCompositeInvariants }) {
+  const entries = Object.entries(invariants) as [keyof KeeperCompositeInvariants, boolean][]
+  const allOk = entries.every(([, ok]) => ok)
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="flex items-center justify-between">
+        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          Safety invariants (KeeperCompositeLifecycle.tla)
+        </div>
+        <span class=${`rounded-full border px-2 py-0.5 text-[10px] font-mono ${
+          allOk
+            ? 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]'
+            : 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'
+        }`}>
+          ${allOk ? 'all green' : 'violation'}
+        </span>
+      </div>
+      <ul class="mt-2 flex flex-col gap-1 text-[11px]">
+        ${entries.map(([key, ok]) => html`
+          <li class="flex items-center gap-2">
+            <span class=${`h-2 w-2 rounded-full ${ok ? 'bg-[#22c55e]' : 'bg-[#ef4444]'}`}></span>
+            <span class=${ok ? 'text-[var(--text-body)]' : 'text-[#f87171]'}>
+              ${INVARIANT_LABELS[key]}
+            </span>
+          </li>
+        `)}
+      </ul>
+    </div>
+  `
+}
+
+function RecoveryStatePanel({
+  dataRecord,
+  fsmCondition,
+}: {
+  dataRecord: boolean
+  fsmCondition: boolean
+}) {
+  const state =
+    !dataRecord && !fsmCondition ? 'clean' :
+    dataRecord && fsmCondition ? 'manual_reconcile_pending' :
+    dataRecord && !fsmCondition ? 'drift: data set, fsm cleared' :
+    'drift: fsm set, data cleared'
+  const toneCls =
+    state === 'clean'
+      ? 'text-[#22c55e]'
+      : state.startsWith('drift')
+        ? 'text-[#ef4444]'
+        : 'text-[#f59e0b]'
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        Recovery two-store (RFC-0003 §8)
+      </div>
+      <div class="mt-1.5 flex flex-wrap items-center gap-3 text-[11px]">
+        <span class=${`font-mono ${toneCls}`}>${state}</span>
+        <span class="text-[var(--text-dim)]">data_record <span class="font-mono text-[var(--text-body)]">${String(dataRecord)}</span></span>
+        <span class="text-[var(--text-dim)]">fsm_condition <span class="font-mono text-[var(--text-body)]">${String(fsmCondition)}</span></span>
+      </div>
+    </div>
+  `
+}
+
+function SnapshotMeta({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
+  const date = new Date(snapshot.ts * 1000)
+  return html`
+    <div class="flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)] font-mono">
+      <span>correlation ${snapshot.correlation_id}</span>
+      <span>run ${snapshot.run_id}</span>
+      <span>ts ${date.toISOString()}</span>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -11,18 +11,19 @@ import { OasHealthChip } from './oas-health-chip'
 import { TelemetryUnified } from './telemetry-unified'
 import { GovernanceMonitor } from './governance-monitor'
 import { MemorySubsystems } from './memory-subsystems'
+import { FsmHub } from './fsm-hub'
 import { PrometheusMetrics } from './prometheus-metrics'
 import { ToolQualityPanel } from './tool-quality-panel'
 import { FleetTelemetryPanel } from './fleet-telemetry-panel'
 
-type StatusSection = 'sessions' | 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems' | 'metrics' | 'tool-quality' | 'fleet'
+type StatusSection = 'sessions' | 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems' | 'fsm-hub' | 'metrics' | 'tool-quality' | 'fleet'
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
   if (
     section === 'agents' || section === 'activity' || section === 'runtime'
     || section === 'telemetry' || section === 'governance' || section === 'memory-subsystems'
-    || section === 'metrics' || section === 'tool-quality' || section === 'fleet'
+    || section === 'fsm-hub' || section === 'metrics' || section === 'tool-quality' || section === 'fleet'
   ) return section
   return 'sessions'
 }
@@ -50,6 +51,8 @@ export function Status() {
               ? html`<${GovernanceMonitor} />`
             : section === 'memory-subsystems'
               ? html`<${MemorySubsystems} />`
+            : section === 'fsm-hub'
+              ? html`<${FsmHub} />`
             : section === 'metrics'
               ? html`<${PrometheusMetrics} />`
             : section === 'tool-quality'

--- a/dashboard/src/composite-signals.ts
+++ b/dashboard/src/composite-signals.ts
@@ -1,0 +1,19 @@
+// Composite lifecycle SSE envelope signal (RFC-0003 §6 / PR#7060).
+//
+// The SSE stream emits [keeper_composite_changed] with a name + wall-clock
+// envelope whenever a registry mutation may have changed the composite
+// snapshot. Subscribers observe [compositeTick] and re-fetch the full
+// payload from [/api/v1/keepers/:name/composite] — keeping the registry
+// as the single writer.
+
+import { signal } from '@preact/signals'
+
+export interface CompositeTickEnvelope {
+  name: string
+  ts_unix: number
+}
+
+export const compositeTick = signal<CompositeTickEnvelope>({
+  name: '',
+  ts_unix: 0,
+})

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -20,6 +20,7 @@ export type SurfaceSectionId =
   | 'fleet'
   | 'connectors'
   | 'memory-subsystems'
+  | 'fsm-hub'
   | 'metrics'
 
 type NonHomeTabId = Exclude<TabId, 'overview' | 'logs'>
@@ -157,6 +158,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '기억 서브시스템',
       description: 'Hebbian 시냅스 그래프, 에피소드 기록, compaction 상태.',
       params: { section: 'memory-subsystems' },
+    },
+    {
+      id: 'fsm-hub',
+      label: 'FSM 허브',
+      description: 'Composite lifecycle — Decision/Cascade/Memory/Compaction FSM 교차 뷰와 invariants.',
+      params: { section: 'fsm-hub' },
     },
     {
       id: 'metrics',

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -25,6 +25,7 @@ import {
 import { mergeServerStatus } from './store-normalizers'
 import { normalizeOperatorSnapshot, normalizeOperatorDigest } from './operator-normalizers'
 import { operatorSnapshot, operatorRoomDigest } from './operator-signals'
+import { compositeTick } from './composite-signals'
 import { hydrateTransportHealthFromSSE } from './components/transport-health'
 import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 import { showToast } from './components/common/toast'
@@ -320,6 +321,16 @@ export function setupSSEReaction(): () => void {
     // 1. Keeper heartbeat — signal-only, zero network calls
     if (event.type === 'keeper_heartbeat') {
       handleKeeperHeartbeat(event)
+      return
+    }
+
+    // Composite lifecycle tick — signal-only; consumers (FSM Hub) re-fetch
+    // /composite themselves. Envelope carries {name, ts_unix} per RFC-0003.
+    if (event.type === 'keeper_composite_changed') {
+      const payload = event as unknown as { name?: string; ts_unix?: number }
+      const name = typeof payload.name === 'string' ? payload.name : ''
+      const ts_unix = typeof payload.ts_unix === 'number' ? payload.ts_unix : Date.now() / 1000
+      compositeTick.value = { name, ts_unix }
       return
     }
 

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -18,6 +18,7 @@ export type SSEEventType =
   | 'keeper_guardrail'
   | 'masc/keeper_guardrail'
   | 'keeper_phase_changed'
+  | 'keeper_composite_changed'
   | 'keeper_tool_call'
   | 'masc/keeper_tool_call'
   | 'keeper_tool_skipped'

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -763,6 +763,21 @@ let dispatch_event_with_audit
             ~phase:tr.new_phase
             ~ts_unix:now)
          tr.entry_actions;
+       (* Composite-lifecycle SSE envelope — RFC-0003 §6.
+          The body carries only the keeper name and observation timestamp;
+          subscribers re-fetch [/api/v1/keepers/:name/composite] for the
+          full snapshot so the spec's "single writer, pull observers"
+          invariant is preserved. *)
+       (try
+          Sse.broadcast
+            (`Assoc [
+               "type", `String "keeper_composite_changed";
+               "name", `String name;
+               "ts_unix", `Float now;
+             ])
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _exn -> ());
        Ok tr
      | Ok tr ->
        (* No phase change — still update conditions *)
@@ -779,6 +794,16 @@ let dispatch_event_with_audit
          conditions = tr.updated_conditions;
          transition_seq = new_seq;
        };
+       (try
+          Sse.broadcast
+            (`Assoc [
+               "type", `String "keeper_composite_changed";
+               "name", `String name;
+               "ts_unix", `Float now;
+             ])
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | _exn -> ());
        Ok tr
      | Error e ->
        Log.Keeper.warn "registry: dispatch_event rejected name=%s error=%s"

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -710,6 +710,25 @@ let handle_keeper_get_subroutes state req request reqd =
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if ends_with "/composite" then
+    (* RFC-0003 §7: composite lifecycle snapshot derived from the
+       registry entry via the [Keeper_composite_observer] pure
+       projection. No mutation, no I/O, no provider/token access. *)
+    let name = extract_name "/composite" in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let base_path = state.Mcp_server.room_config.base_path in
+      (match Keeper_registry.get ~base_path name with
+       | None ->
+         Http.Response.json ~status:`Not_found
+           (Printf.sprintf {|{"error":"keeper %S not registered"}|} name) reqd
+       | Some entry ->
+         let snapshot = Keeper_composite_observer.observe entry in
+         let json = Keeper_composite_observer.snapshot_to_json snapshot in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd)
   else
     Http.Response.json ~status:`Not_found
       {|{"error":"not found"}|} reqd


### PR DESCRIPTION
## Summary

Dogfood #7065's `compositeTick` signal from inside #7060's FSM Hub page. Drops the 5s `setInterval` polling in favour of push-based refresh driven by the `keeper_composite_changed` SSE envelope.

## Change

```ts
// removed
const interval = window.setInterval(run, 5000)

// added
const tick = compositeTick.value
const shouldRefetchForTick =
  selected != null && tick.name === selected ? tick.ts_unix : 0

useEffect(() => { run() }, [selected, shouldRefetchForTick])
```

Guard `tick.name === selected` filters unrelated keeper events so switching hubs doesn't stampede the endpoint. `ts_unix` in the useEffect deps ensures each advancing envelope triggers exactly one fetch.

## Behavioural delta

- **Before**: each open FSM Hub page calls `/composite` once every 5s regardless of whether anything changed.
- **After**: one fetch per `keeper_composite_changed` envelope for the selected keeper. Initial fetch still fires on selection.

This preserves the RFC-0003 §6 "single writer, pull observers" contract — subscribers never mutate registry state.

## Depends on

- #7060 — FSM Hub page (unmerged; this branch contains its commits via merge).
- #7065 — SSE envelope + `compositeTick` signal (unmerged; merged in).

Both dependency branches were merged in to produce this follow-up. Once #7060 and #7065 both merge to main, a clean rebase should reduce this PR to the single `fsm-hub.ts` diff.

## Test plan

- [ ] `pnpm typecheck` green.
- [ ] Visual: open FSM Hub → select a keeper → trigger a keeper turn elsewhere → observe snapshot refresh without the 5s delay.
- [ ] Network panel: `/composite` fires on each keeper event rather than every 5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)