### PR TITLE
feat(dashboard): FSM Hub compound Cytoscape view

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -9,6 +9,8 @@ import {
 import { keepers } from '../store'
 import { compositeTick } from '../composite-signals'
 import { EmptyState } from './common/empty-state'
+import { CytoscapeFsm } from './common/cytoscape-fsm'
+import { buildCompositeFsmSpec } from './keeper-fsm-specs'
 
 /**
  * FSM Hub — architecture audit surface for the composite keeper lifecycle.
@@ -96,6 +98,7 @@ export function FsmHub() {
       ` : error ? html`
         <${EmptyState} message=${error} compact />
       ` : snapshot ? html`
+        <${CompositeGraphPanel} snapshot=${snapshot} />
         <div class="grid gap-4 lg:grid-cols-2">
           <${SubFsmCard} label="KSM · Keeper lifecycle" value=${snapshot.phase} tone="accent" />
           <${SubFsmCard} label="KTC · Turn cycle" value=${snapshot.turn_phase} tone="indigo" />
@@ -111,6 +114,36 @@ export function FsmHub() {
         />
         <${SnapshotMeta} snapshot=${snapshot} />
       ` : null}
+    </div>
+  `
+}
+
+function CompositeGraphPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
+  const spec = useMemo(() => buildCompositeFsmSpec({
+    phase: snapshot.phase,
+    turnPhase: snapshot.turn_phase,
+    decisionStage: snapshot.decision.stage,
+    cascadeState: snapshot.cascade.state,
+    compactionStage: snapshot.compaction.stage,
+  }), [
+    snapshot.phase,
+    snapshot.turn_phase,
+    snapshot.decision.stage,
+    snapshot.cascade.state,
+    snapshot.compaction.stage,
+  ])
+
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+      <div class="mb-2 flex items-center justify-between">
+        <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          Composite compound view — 5 sub-FSMs
+        </div>
+        <span class="text-[10px] text-[var(--text-dim)]">
+          KeeperCompositeLifecycle.tla
+        </span>
+      </div>
+      <${CytoscapeFsm} spec=${spec} height="360px" />
     </div>
   `
 }

--- a/dashboard/src/components/keeper-fsm-specs.ts
+++ b/dashboard/src/components/keeper-fsm-specs.ts
@@ -166,3 +166,80 @@ export function buildCascadeSpec(params: CascadeParams): FsmGraphSpec {
 
   return { nodes, edges, activeNodeId: activeId }
 }
+
+// ================================================================
+// Composite Lifecycle (RFC-0003 KeeperCompositeLifecycle.tla)
+// ================================================================
+//
+// Compound graph: five parent clusters (one per sub-FSM) each containing
+// their possible states. The current state is rendered [active] and the
+// rest [dim], so the viewer reads "where is this keeper in each layer
+// simultaneously". No cross-cluster edges — causal ordering between
+// sub-FSMs is captured by the invariants panel, not the graph edges.
+
+export interface CompositeFsmParams {
+  phase: string            // KSM — keeper lifecycle (11 phases, we show a reduced set)
+  turnPhase: string        // KTC — idle | prompting | executing | compacting | finalizing
+  decisionStage: string    // KDP — undecided | guard_ok | gate_rejected | tool_policy_selected
+  cascadeState: string     // KCL — idle | selecting | trying | done | exhausted
+  compactionStage: string  // KMC — accumulating | compacting | done
+}
+
+const KSM_STATES = [
+  'Offline', 'Running', 'Failing', 'Compacting', 'HandingOff',
+  'Paused', 'Stopped', 'Crashed', 'Dead',
+]
+const KTC_STATES = ['idle', 'prompting', 'executing', 'compacting', 'finalizing']
+const KDP_STATES = ['undecided', 'guard_ok', 'gate_rejected', 'tool_policy_selected']
+const KCL_STATES = ['idle', 'selecting', 'trying', 'done', 'exhausted']
+const KMC_STATES = ['accumulating', 'compacting', 'done']
+
+function nodeType(stateId: string, activeId: string, tone: 'active' | 'warn' | 'err'): FsmNode['type'] {
+  return stateId === activeId ? tone : 'dim'
+}
+
+function clusterNodes(
+  clusterId: string,
+  clusterLabel: string,
+  states: readonly string[],
+  active: string,
+  tone: 'active' | 'warn' | 'err',
+): FsmNode[] {
+  const parent: FsmNode = {
+    id: clusterId,
+    label: clusterLabel,
+    type: 'state',
+  }
+  const children: FsmNode[] = states.map(s => ({
+    id: `${clusterId}:${s}`,
+    label: s,
+    type: nodeType(s, active, tone),
+    parent: clusterId,
+  }))
+  return [parent, ...children]
+}
+
+export function buildCompositeFsmSpec(params: CompositeFsmParams): FsmGraphSpec {
+  const nodes: FsmNode[] = [
+    ...clusterNodes('KSM', 'KSM · keeper lifecycle', KSM_STATES, params.phase, 'active'),
+    ...clusterNodes('KTC', 'KTC · turn cycle', KTC_STATES, params.turnPhase, 'active'),
+    ...clusterNodes('KDP', 'KDP · decision pipeline', KDP_STATES, params.decisionStage,
+      params.decisionStage === 'gate_rejected' ? 'err' : 'active'),
+    ...clusterNodes('KCL', 'KCL · cascade state', KCL_STATES, params.cascadeState,
+      params.cascadeState === 'exhausted' ? 'err' : 'active'),
+    ...clusterNodes('KMC', 'KMC · memory compaction', KMC_STATES, params.compactionStage, 'warn'),
+  ]
+
+  // Edges left empty by design: the compound visual encodes "what sub-FSMs
+  // are simultaneously active". Cross-cluster causality lives in the TLA+
+  // spec (see KeeperCompositeLifecycle.tla join actions) and the invariants
+  // panel — drawing inter-cluster arrows here would overstate the coupling.
+  const edges: FsmEdge[] = []
+
+  return {
+    nodes,
+    edges,
+    layout: 'breadthfirst',
+    direction: 'LR',
+  }
+}


### PR DESCRIPTION
## Summary

Phase 3 §2 of `docs/design/dashboard-fsm-redesign.md`. Replaces the MVP cards grid with a Cytoscape compound graph rendering all five sub-FSMs in one frame.

## Design

- Each sub-FSM → one parent cluster: KSM (lifecycle), KTC (turn cycle), KDP (decision pipeline), KCL (cascade state), KMC (memory compaction).
- Each cluster contains its possible states from `KeeperCompositeLifecycle.tla`. The current state is marked `active` (warn for KMC, err for `gate_rejected` / `exhausted`); others `dim`.
- **No inter-cluster edges.** Cross-FSM causality lives in the spec (join actions in `KeeperCompositeLifecycle.tla`) and the invariants panel. Drawing cross-cluster arrows here would overstate coupling between layers.
- KSM reduced to 9 most-operationally-relevant phases (skipping rare buffer transitions) so the graph stays legible at 360px.

## Kept

The original card grid remains as a textual complement under the graph — useful at narrow widths and for at-a-glance reads.

## Depends on

- #7060 (FSM Hub page) and #7070 (SSE dogfood) merged in as ancestors.

## Test plan

- [ ] `pnpm typecheck` green.
- [ ] Visual: FSM Hub → select a keeper → compound graph renders; current state in each cluster is highlighted; other states dim. Pan/zoom works via Cytoscape.
- [ ] Resize window to narrow → graph shrinks; card grid still readable underneath.

## Related

- `docs/design/dashboard-fsm-redesign.md` Phase 3 §2 — compound view target.
- `specs/keeper-state-machine/KeeperCompositeLifecycle.tla` — source of state sets.
- `dashboard/src/components/keeper-fsm-specs.ts` — existing spec builders (Phase / Decision Pipeline / Cascade) that this extends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)