### PR TITLE
refactor(keeper): retire boring tool concept — fix keeper silent traps

### DIFF
--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -145,29 +145,14 @@ let latest_tool_name (entries : Yojson.Safe.t list) : string option =
 let prune_boring_tools_after_recent_polling
     ~(visible_tools : string list)
     ~(recent_entries : Yojson.Safe.t list) : string list =
-  let productive_visible =
-    List.exists
-      (fun name -> not (Keeper_tool_registry.is_boring_tool name))
-      visible_tools
-  in
-  let just_polled =
-    match latest_tool_name recent_entries with
-    | Some name ->
-      Keeper_tool_registry.is_boring_tool name
-      && not (String.equal name "keeper_stay_silent")
-    | None -> false
-  in
-  if not just_polled then visible_tools
-  else if not productive_visible then
-    (* All visible tools are boring and we just used one — force silent
-       to break the polling loop instead of offering the same boring tools. *)
-    List.filter (fun name -> String.equal name "keeper_stay_silent") visible_tools
-  else
-    List.filter
-      (fun name ->
-         not (Keeper_tool_registry.is_boring_tool name)
-         || String.equal name "keeper_stay_silent")
-      visible_tools
+  (* Boring concept retired. Previously: when the latest tool call was
+     boring and no visible tool was productive, this collapsed visible
+     tools down to [keeper_stay_silent], forcing silent turns. With the
+     registry's classification empty this becomes an identity transform.
+     The function stays on the public API until the full-removal PR to
+     avoid churn in callers/tests that still import it. *)
+  let _ = latest_tool_name recent_entries in
+  visible_tools
 ;;
 
 let merge_tool_selection_boundary

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -349,10 +349,13 @@ let all_tools_reconcile_safe (names : string list) : bool =
     and should not be treated as productive work.
     Contrast with [keeper_fs_read] which reads new content, or
     [keeper_board_post] which creates artifacts. *)
-let boring_tools =
-  [ "masc_status"; "keeper_tasks_list";
-    "keeper_context_status"; "keeper_tools_list";
-    "keeper_stay_silent"; "keeper_board_list" ]
+(* Boring concept retired. Repeated history: #6199/#6381/#6407 removed it,
+   #6375/#6432/#6872 restored it, #6886 reverted again. Each revival kept
+   widening the list (keeper_board_list, keeper_context_status) which drove
+   keepers into silent-only turns when every visible tool was flagged.
+   Neutralized by leaving the API shape (so callers compile) but treating
+   no tool as boring. Full-source removal tracked in follow-up issue. *)
+let boring_tools : string list = []
 
 let boring_tools_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length boring_tools) in

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -317,6 +317,9 @@ let test_deterministic_prefilter_surfaces_code_tools () =
     true (List.mem "masc_code_search" selected)
 
 let test_prune_boring_tools_after_recent_polling () =
+  (* Boring concept retired. prune_boring_tools_after_recent_polling is now
+     an identity transform — the caller's visible tool set is returned
+     unchanged regardless of recent tool history. *)
   let visible_tools =
     [ "masc_status"; "keeper_tasks_list"; "keeper_context_status";
       "keeper_stay_silent"; "keeper_fs_edit"; "masc_code_search" ]
@@ -329,9 +332,8 @@ let test_prune_boring_tools_after_recent_polling () =
       ~visible_tools ~recent_entries
   in
   Alcotest.(check (list string))
-    "recent polling hides boring tools but keeps productive tools"
-    [ "keeper_stay_silent"; "keeper_fs_edit"; "masc_code_search" ]
-    pruned
+    "visible tools returned unchanged"
+    visible_tools pruned
 
 let test_prune_boring_tools_keeps_set_when_last_tool_productive () =
   let visible_tools =
@@ -345,7 +347,7 @@ let test_prune_boring_tools_keeps_set_when_last_tool_productive () =
       ~visible_tools ~recent_entries
   in
   Alcotest.(check (list string))
-    "productive last tool does not hide boring tools"
+    "productive last tool leaves visible tools unchanged"
     visible_tools pruned
 
 let test_keeper_config_defaults () =

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2624,7 +2624,8 @@ let test_recent_tool_streak_count_ignores_stale_entries () =
        entries)
 
 let test_cross_turn_polling_tool_excludes_stay_silent () =
-  check bool "masc_status is polling tool" true
+  (* Boring concept retired — every tool is non-polling. *)
+  check bool "masc_status no longer flagged as polling" false
     (HK.is_cross_turn_polling_tool "masc_status");
   check bool "stay_silent excluded" false
     (HK.is_cross_turn_polling_tool "keeper_stay_silent");
@@ -2632,10 +2633,11 @@ let test_cross_turn_polling_tool_excludes_stay_silent () =
     (HK.is_cross_turn_polling_tool "keeper_fs_edit")
 
 let test_should_block_cross_turn_polling_on_second_attempt () =
+  (* Boring concept retired — cross-turn polling block is a no-op. *)
   let recent_entries =
     [ tool_log_entry "masc_status" ]
   in
-  check bool "second consecutive polling attempt is blocked" true
+  check bool "cross-turn polling block retired" false
     (HK.should_block_cross_turn_polling ~within_sec:900.0 ~threshold:2
        ~tool_name:"masc_status" ~recent_entries)
 
@@ -2962,50 +2964,32 @@ let () =
         ] );
       ( "boring_tools",
         [
-          test_case "masc_status is boring" `Quick (fun () ->
-            check bool "masc_status"
-              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_status"));
-          test_case "masc_heartbeat is NOT boring (removed from keeper)" `Quick (fun () ->
-            check bool "masc_heartbeat"
-              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "masc_heartbeat"));
-          test_case "keeper_tasks_list is boring" `Quick (fun () ->
-            check bool "keeper_tasks_list"
-              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_tasks_list"));
-          test_case "keeper_tools_list is boring" `Quick (fun () ->
-            check bool "keeper_tools_list"
-              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_tools_list"));
-          test_case "keeper_context_status is boring" `Quick (fun () ->
-            check bool "keeper_context_status"
-              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_context_status"));
-          test_case "actionable turns prune boring tools when alternatives exist" `Quick (fun () ->
-            let pruned =
-              Masc_mcp.Keeper_tool_registry.prune_boring_tools_for_actionable_turn
+          (* Boring concept retired — these tests previously asserted
+             particular tools were classified boring. After neutralization,
+             the classification is empty and [is_boring_tool] is constant
+             false. The suite is retained as a regression guard against
+             accidental reintroduction of the classification. *)
+          test_case "no tool is classified boring" `Quick (fun () ->
+            List.iter
+              (fun name ->
+                check bool
+                  (Printf.sprintf "%s not boring" name)
+                  false
+                  (Masc_mcp.Keeper_tool_registry.is_boring_tool name))
+              [ "masc_status"; "keeper_tasks_list"; "keeper_tools_list";
+                "keeper_context_status"; "keeper_stay_silent";
+                "keeper_board_list"; "keeper_fs_read"; "keeper_board_post";
+                "keeper_task_claim"; "keeper_bash"; "masc_heartbeat" ]);
+          test_case "prune_boring_tools_for_actionable_turn is identity"
+            `Quick (fun () ->
+              let input =
                 [ "masc_status"; "keeper_tasks_list"; "keeper_board_post" ]
-            in
-            check (list string) "boring tools removed"
-              [ "keeper_board_post" ] pruned);
-          test_case "actionable turns keep boring tools when nothing else exists" `Quick (fun () ->
-            let pruned =
-              Masc_mcp.Keeper_tool_registry.prune_boring_tools_for_actionable_turn
-                [ "masc_status"; "keeper_tasks_list" ]
-            in
-            check (list string) "boring-only set preserved"
-              [ "masc_status"; "keeper_tasks_list" ] pruned);
-          test_case "keeper_fs_read is NOT boring" `Quick (fun () ->
-            check bool "keeper_fs_read"
-              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_fs_read"));
-          test_case "keeper_board_post is NOT boring" `Quick (fun () ->
-            check bool "keeper_board_post"
-              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_board_post"));
-          test_case "keeper_task_claim is NOT boring" `Quick (fun () ->
-            check bool "keeper_task_claim"
-              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_task_claim"));
-          test_case "keeper_stay_silent IS boring (no-op)" `Quick (fun () ->
-            check bool "keeper_stay_silent"
-              true (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_stay_silent"));
-          test_case "keeper_bash is NOT boring" `Quick (fun () ->
-            check bool "keeper_bash"
-              false (Masc_mcp.Keeper_tool_registry.is_boring_tool "keeper_bash"));
+              in
+              let pruned =
+                Masc_mcp.Keeper_tool_registry
+                  .prune_boring_tools_for_actionable_turn input
+              in
+              check (list string) "no tools removed" input pruned);
           test_case "keeper allowed tools exclude heartbeat" `Quick
             test_keeper_allowed_tools_exclude_heartbeat;
         ] );


### PR DESCRIPTION
## Summary

User-reported symptom: keepers falling into silent loops, suspected the
**boring tool classification** as the driver.

Neutralizes the `boring` concept without ripping out the API surface so
call-sites continue to compile unchanged.

## History (why this keeps returning)

| PR | Action |
|----|--------|
| #6199 / #6381 / #6407 | Removed boring gate/pruning |
| #6375 / #6432 / #6872 | Restored boring gate + force-silent |
| #6886 | Revert #6872 |

Each revival widened the list (`keeper_board_list`,
`keeper_context_status` added) which drove the observed silent-only turns.

## Changes

1. `lib/keeper/keeper_tool_registry.ml`: `boring_tools = []`. `is_boring_tool` now constant `false`; `prune_boring_tools_for_actionable_turn` becomes identity.
2. `lib/keeper/keeper_tool_disclosure.ml`: `prune_boring_tools_after_recent_polling` becomes identity. The previous "all tools boring → keep only `keeper_stay_silent`" branch (the direct silent trap) is removed.
3. Tests (`test_keeper_topk_llm.ml`, `test_keeper_unified.ml`): re-expressed to document the retired state and regression-guard against accidental revival.

## What is NOT in this PR

- Full source-level removal of `boring_tools` / `is_boring_tool` / `prune_*` definitions and their call-sites in `keeper_hooks_oas.ml`, `keeper_tool_diversity.ml`, `keeper_unified_turn.ml`, `keeper_exec_tools.mli`. These compile against the neutralized API and behave as "no tool boring". Follow-up issue will remove the API surface.
- Cross-turn polling gate (`should_block_cross_turn_polling`) is now a no-op for every tool because `is_cross_turn_polling_tool` returns false. If we need to protect against infinite polling on specific tools, that should be expressed explicitly in a per-tool policy, not a shared "boring" classification.

## Test plan

- [x] `dune build --root . lib` (full lib green)
- [x] `test/test_keeper_topk_llm.exe` — 14/14 pass
- [x] `test/test_keeper_unified.exe` — 146/146 pass (boring suite rewritten)

🤖 Generated with [Claude Code](https://claude.com/claude-code)