### PR TITLE
ci(tla): recognise multi-variant buggy cfgs (*-buggy-*.cfg)

### DIFF
--- a/specs/Makefile
+++ b/specs/Makefile
@@ -35,8 +35,8 @@ TLC = $(JAVA) $(JAVA_OPTS) \
 	-DTLA2-Library="$(SPEC_DIRS)" \
 	-cp $(TLA2TOOLS) tlc2.TLC $(TLC_FLAGS)
 
-CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy.cfg' ! -name '*-ci.cfg' | sort)
-BUGGY_CFGS := $(shell find . -name '*-buggy.cfg' | sort)
+CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)
+BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
 
 .PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary list
 
@@ -70,13 +70,15 @@ check-buggy:
 	if [ -z "$$cfgs" ]; then echo "(none)"; exit 0; fi; \
 	for cfg in $$cfgs; do \
 	  dir=$$(dirname "$$cfg"); \
-	  bugbase=$$(basename "$$cfg" -buggy.cfg); \
+	  stripped=$${cfg%%-buggy*}; \
+	  bugbase=$$(basename "$$stripped"); \
+	  cfgtag=$$(basename "$$cfg" .cfg); \
 	  tla="$$dir/$$bugbase.tla"; \
 	  if [ ! -f "$$tla" ]; then echo "SKIP $$cfg (no .tla)"; continue; fi; \
 	  skip=0; for kb in $(KNOWN_BUGGY_NO_VIOLATION); do [ "$$bugbase" = "$$kb" ] && skip=1; done; \
 	  if [ $$skip -eq 1 ]; then printf "SKIP %-40s (KNOWN_BUGGY_NO_VIOLATION)\n" "$$bugbase (buggy)"; continue; fi; \
-	  printf "CHECK %-40s " "$$bugbase (buggy)"; \
-	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$bugbase-buggy.log 2>&1; \
+	  printf "CHECK %-40s " "$$cfgtag (buggy)"; \
+	  $(TLC) -config "$$cfg" "$$tla" > /tmp/tlc-$$cfgtag.log 2>&1; \
 	  rc=$$?; \
 	  if [ $$rc -eq 12 ] || [ $$rc -eq 13 ]; then echo "OK (violation exit $$rc)"; \
 	  elif [ $$rc -eq 0 ]; then echo "FAIL (no violation)"; fail=1; \
@@ -86,23 +88,23 @@ check-buggy:
 
 check-bug-models:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find bug-models/ -name '*.cfg' ! -name '*-buggy.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find bug-models/ -name '*-buggy.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find bug-models/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  BUGGY_CFGS="$$(find bug-models/ -name '*-buggy*.cfg' | sort)" check-all
 
 check-keeper:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find keeper-state-machine/ -name '*-buggy.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find keeper-state-machine/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  BUGGY_CFGS="$$(find keeper-state-machine/ -name '*-buggy*.cfg' | sort)" check-all
 
 check-ecosystem:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find masc-ecosystem/ -name '*.cfg' ! -name '*-buggy.cfg' | sort)" \
+	  CLEAN_CFGS="$$(find masc-ecosystem/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
 	  BUGGY_CFGS="" check-all
 
 check-boundary:
 	@$(MAKE) --no-print-directory \
-	  CLEAN_CFGS="$$(find boundary/ -name '*.cfg' ! -name '*-buggy.cfg' | sort)" \
-	  BUGGY_CFGS="$$(find boundary/ -name '*-buggy.cfg' | sort)" check-all
+	  CLEAN_CFGS="$$(find boundary/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  BUGGY_CFGS="$$(find boundary/ -name '*-buggy*.cfg' | sort)" check-all
 
 list:
 	@echo "Clean specs ($(words $(CLEAN_CFGS))):"; \


### PR DESCRIPTION
## Summary

Fixes a silent CI bug where `KeeperCompositeLifecycle.tla`'s three buggy variants (`-buggy-cascade`, `-buggy-compaction`, `-buggy-recovery`) were classified as **clean** specs rather than buggy.

## Root cause

`specs/Makefile` globbed on `*-buggy.cfg` (exact suffix). Multi-variant filenames like `KeeperCompositeLifecycle-buggy-cascade.cfg` don't match that pattern, so the `find ... ! -name '*-buggy.cfg'` filter kept them in `CLEAN_CFGS`. The `check-clean` step then ran them expecting no violation — but the whole point of those cfgs is that each intentionally violates a specific invariant. Result: CI would have failed with `exit 12/13` as "clean" specs.

Additionally, `basename "$cfg" -buggy.cfg` didn't strip the extra suffix, so the resolved `.tla` file name was wrong when a buggy run did happen.

## Fix

- `*-buggy.cfg` → `*-buggy*.cfg` in all clean/buggy find globs (catches both the single-variant and multi-variant forms).
- `basename "$cfg" -buggy.cfg` → `${cfg%%-buggy*}` + `basename`, which correctly strips everything from `-buggy` onward regardless of variant suffix.
- New `cfgtag` variable for unique per-variant log paths so multiple buggy runs in the same spec don't clobber each other's logs.

## Verified locally

```
=== Running clean specs (expect no errors) ===
CHECK KeeperCompositeLifecycle                 OK
=== Running buggy specs (expect violations) ===
CHECK KeeperCompositeLifecycle-buggy-cascade (buggy) OK (violation exit 12)
CHECK KeeperCompositeLifecycle-buggy-compaction (buggy) OK (violation exit 12)
CHECK KeeperCompositeLifecycle-buggy-recovery (buggy) OK (violation exit 12)
=== All TLA+ specs passed ===
```

All three buggy variants fire their distinct safety invariant (per `feedback_tla-spec-audit-outcome-trichotomy` — buggy variants must violate *different* invariants, not the same one).

## Test plan

- [ ] CI `TLA+ Model Checking` job green on this PR.
- [ ] CI picks up composite buggy variants (shown as `(buggy)` entries in the log, not as clean).

## Related

- `specs/keeper-state-machine/KeeperCompositeLifecycle.{tla,cfg,-buggy-*.cfg}` — the spec files this unblocks.
- RFC-0003 §5 / bug models table.
- `feedback_tla-spec-audit-outcome-trichotomy` — drives the multi-buggy-variant convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)