### PR TITLE
feat(dashboard): wire tool policy / turn outcome into decision FSM (Phase 1b)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -895,7 +895,27 @@ let keeper_config_json (config : Room.config) (name : string)
         let recovery_floor_count =
           List.length (Keeper_tool_policy.failing_minimum_tool_names ())
         in
+        let tool_policy_mode : [`Preset of string | `Custom] option =
+          match Keeper_types.tool_access_custom_allowlist m.tool_access with
+          | Some _ -> Some `Custom
+          | None ->
+            (match Keeper_types.tool_access_preset m.tool_access with
+             | Some preset ->
+               Some (`Preset (Keeper_types.tool_preset_to_string preset))
+             | None -> None)
+        in
+        let turn_outcome : [`Ok | `Failed | `Blocked] option =
+          match Keeper_registry.get ~base_path:config.base_path m.name with
+          | Some entry when entry.turn_consecutive_failures > 0 ->
+            Some `Failed
+          | Some entry when entry.conditions.manual_reconcile_required ->
+            Some `Blocked
+          | Some _ -> Some `Ok
+          | None -> None
+        in
         Keeper_decision_audit.decision_pipeline_to_mermaid
+          ?tool_policy_mode
+          ?turn_outcome
           ~phase
           ~thompson_alpha:stats.alpha
           ~thompson_beta:stats.beta

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -607,8 +607,31 @@ let handle_keeper_get_subroutes state req request reqd =
       let recovery_floor_count =
         List.length (Keeper_tool_policy.failing_minimum_tool_names ())
       in
+      let tool_policy_mode : [`Preset of string | `Custom] option =
+        match meta with
+        | Ok (Some m) ->
+          (match Keeper_types.tool_access_custom_allowlist m.tool_access with
+           | Some _ -> Some `Custom
+           | None ->
+             (match Keeper_types.tool_access_preset m.tool_access with
+              | Some preset ->
+                Some (`Preset (Keeper_types.tool_preset_to_string preset))
+              | None -> None))
+        | _ -> None
+      in
+      let turn_outcome : [`Ok | `Failed | `Blocked] option =
+        match Keeper_registry.get ~base_path:state.Mcp_server.room_config.base_path name with
+        | Some entry when entry.turn_consecutive_failures > 0 ->
+          Some `Failed
+        | Some entry when entry.conditions.manual_reconcile_required ->
+          Some `Blocked
+        | Some _ -> Some `Ok
+        | None -> None
+      in
       let decision_pipeline_mermaid =
         Keeper_decision_audit.decision_pipeline_to_mermaid
+          ?tool_policy_mode
+          ?turn_outcome
           ~phase:current
           ~thompson_alpha:stats.alpha
           ~thompson_beta:stats.beta


### PR DESCRIPTION
## Summary

Connects the Phase 1b optional labelled args introduced in #7039 (`decision_pipeline_to_mermaid`) to runtime values already observable from the dashboard handlers.

## Changes

Both decision-pipeline renderers updated:

- `lib/server/server_dashboard_http_keeper_api.ml` — `/state-diagram` handler.
- `lib/dashboard/dashboard_http_keeper.ml` — `/keepers/:name/config` handler.

Values wired:

- `tool_policy_mode` — `Custom` if `tool_custom_allowlist` is set; `Preset <name>` otherwise. Plumbs the existing JSON surface into the mermaid note block.
- `turn_outcome` — derived from the registry entry:
  - `Failed` when `turn_consecutive_failures > 0`
  - `Blocked` when `manual_reconcile_required`
  - `Ok` otherwise. Matches the `turn_outcome` state variable in `KeeperDecisionPipeline.tla`.

## Deferred

`guard_penalty_this_cycle` — `Keeper_guard` does not yet expose a per-cycle counter. Follow-up PR.

## Test plan

- [ ] `dune build lib/masc_mcp.cma` green.
- [ ] Manual probe: `/state-diagram` response includes `Tool policy:` and `Turn outcome:` in `decision_pipeline_mermaid`.

## Related

- #7039 — signature introduction (merged).
- `KeeperDecisionPipeline.tla` — `turn_outcome` state variable.
- `docs/design/dashboard-fsm-redesign.md` Phase 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)