### PR TITLE
feat(dashboard): wire cascade runtime state into FSM render (Phase 1a)

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -619,14 +619,34 @@ let handle_keeper_get_subroutes state req request reqd =
       let cascade_fsm_mermaid =
         match meta with
         | Ok (Some m) ->
+          let routing =
+            Keeper_cascade_routing.select_cascade
+              ~base_cascade:m.cascade_name ~phase:current
+          in
           let models = Oas_worker_named.default_model_strings
-            ~cascade_name:m.cascade_name
+            ~cascade_name:routing.effective_cascade
           in
           let last_model = m.runtime.usage.last_model_used in
           let last_provider_result =
             if last_model <> "" then Some last_model else None
           in
+          (* Provider health derivation: mark the model that served the
+             most recent successful call [`Healthy], everything else
+             [`Unknown]. Full per-provider health tracking is tracked as
+             a follow-up — this surfaces what the runtime already knows. *)
+          let provider_health =
+            List.map (fun model ->
+              let h : Keeper_decision_audit.provider_health =
+                match last_provider_result with
+                | Some p when p = model -> `Healthy
+                | _ -> `Unknown
+              in
+              (model, h))
+              models
+          in
           Keeper_decision_audit.cascade_fsm_to_mermaid
+            ~provider_health
+            ~effective_cascade_reason:routing.reason
             ~models ~last_provider_result ()
         | _ ->
           Keeper_decision_audit.cascade_fsm_to_mermaid


### PR DESCRIPTION
## Summary

Connects the Phase 1a optional labelled args introduced in #7038 (`cascade_fsm_to_mermaid`) to runtime values already observable from the dashboard handler.

## Changes

`lib/server/server_dashboard_http_keeper_api.ml` `/state-diagram` handler:

- `effective_cascade_reason` — pulled from `Keeper_cascade_routing.select_cascade`'s `routing_decision.reason`. Now the Cascade FSM note reads (e.g.) `Reason: phase-gated: failing → local_recovery` instead of being omitted.
- `provider_health` — `Healthy` for the model that served the most recent successful call, `Unknown` for the rest. Full per-provider health tracking is tracked as a follow-up.
- `models` — now sourced from the **effective** cascade (post-routing) rather than `m.cascade_name`, matching what the engine actually executes.

## Deferred

`slot_state` stays unset — `Local_runtime_pool` slot telemetry is not yet plumbed out.

## Test plan

- [ ] `dune build lib/masc_mcp.cma` green.
- [ ] Manual probe: `curl /api/v1/keepers/<name>/state-diagram` → `cascade_fsm_mermaid` contains `Reason:` line.
- [ ] Keeper in `Failing` phase → effective cascade becomes `local_recovery`.

## Related

- #7038 — signature introduction (merged).
- `Keeper_cascade_routing.select_cascade` — reason source.
- `docs/design/dashboard-fsm-redesign.md` — Phase 1a original scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)