### PR TITLE
feat(dashboard): wire Local_runtime_pool slot state into cascade FSM

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -667,8 +667,19 @@ let handle_keeper_get_subroutes state req request reqd =
               (model, h))
               models
           in
+          (* Slot occupancy from the local runtime pool. The cascade FSM
+             shares these slots across all keepers, so rendering the
+             fleet-global (used, capacity) is the honest value — a
+             per-cascade split would claim an isolation the runtime does
+             not actually provide. *)
+          let slot_state =
+            let used = Local_runtime_pool.allocated_slots () in
+            let max = Local_runtime_pool.configured_capacity () in
+            if max > 0 then Some (used, max) else None
+          in
           Keeper_decision_audit.cascade_fsm_to_mermaid
             ~provider_health
+            ?slot_state
             ~effective_cascade_reason:routing.reason
             ~models ~last_provider_result ()
         | _ ->


### PR DESCRIPTION
## Summary

Final Phase 1a optional label. Populates `?slot_state` on `cascade_fsm_to_mermaid` so the cascade note block now reads `Slots: 3 / 8` alongside the existing provider health and effective-cascade reason from #7077.

## Change

```ocaml
let slot_state =
  let used = Local_runtime_pool.allocated_slots () in
  let max = Local_runtime_pool.configured_capacity () in
  if max > 0 then Some (used, max) else None
in
Keeper_decision_audit.cascade_fsm_to_mermaid
  ~provider_health
  ?slot_state                       (* NEW *)
  ~effective_cascade_reason:routing.reason
  ~models ~last_provider_result ()
```

## Why fleet-global, not per-cascade

The local runtime pool slots are **shared across all keepers** regardless of which cascade profile they selected. A per-cascade split would claim an isolation the runtime doesn't provide — honest surfacing of the shared resource is spec-aligned.

## Depends on

- #7077 — Phase 1a wiring scaffold (currently auto-merge queued; this branch is stacked on it).
- #7038 — Phase 1a signature introduction (merged).

## Test plan

- [ ] `dune build lib/masc_mcp.cma` green.
- [ ] Manual probe: `/state-diagram` response's `cascade_fsm_mermaid` note block contains `Slots: N / M`.
- [ ] With `Local_runtime_pool` disabled/unused → `slot_state=None`, note block skips the line cleanly (no "Slots: 0 / 0").

## Related

- `lib/local/local_runtime_pool.ml` — source of slot accessors.
- `docs/design/dashboard-fsm-redesign.md` — Phase 1a scope (final label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)