### PR TITLE
[codex] Remove boring tool suppression

### DIFF
--- a/lib/keeper/keeper_exec_tools.mli
+++ b/lib/keeper/keeper_exec_tools.mli
@@ -70,11 +70,6 @@ val injected_masc_tool_names : unit -> string list
 (** [is_core_always_tool name] — true if [name] bypasses policy restrictions. *)
 val is_core_always_tool : string -> bool
 
-(** Drop boring observation tools when a turn already has actionable work.
-    Returns the original set when every tool is boring so callers do not end
-    up with an empty allowlist. *)
-val prune_boring_tools_for_actionable_turn : string list -> string list
-
 (** Deduplicate tool names, preserving order. *)
 val dedupe_tool_names : string list -> string list
 

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -169,11 +169,9 @@ let suggest_alternatives ~(allowed_tools : string list)
     ~(repeated_tools : string list) ~(max_suggestions : int) : string list =
   let repeated_set = Hashtbl.create (List.length repeated_tools) in
   List.iter (fun t -> Hashtbl.replace repeated_set t ()) repeated_tools;
-  (* Exclude boring/meta tools — uses Keeper_tool_registry SSOT *)
   allowed_tools
   |> List.filter (fun t ->
        not (Hashtbl.mem repeated_set t)
-       && not (Keeper_tool_registry.is_boring_tool t)
        && t <> "keeper_stay_silent")
   |> fun candidates ->
      let len = List.length candidates in
@@ -238,10 +236,6 @@ let on_idle_decision ~consecutive_idle_turns ~allowed_tools ~tool_names
   on_idle_decision_with_threshold ~skip_at ~consecutive_idle_turns
     ~allowed_tools ~tool_names
 
-let is_cross_turn_polling_tool (tool_name : string) : bool =
-  Keeper_tool_registry.is_boring_tool tool_name
-  && not (String.equal tool_name "keeper_stay_silent")
-
 let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
     (entries : Yojson.Safe.t list) : int =
   let now = Time_compat.now () in
@@ -256,11 +250,6 @@ let recent_tool_streak_count ?(within_sec = 900.0) ~(tool_name : string)
        | _ -> count)
   in
   loop 0 (List.rev entries)
-
-let should_block_cross_turn_polling ~within_sec ~threshold
-    ~(tool_name : string) ~(recent_entries : Yojson.Safe.t list) : bool =
-  is_cross_turn_polling_tool tool_name
-  && recent_tool_streak_count ~within_sec ~tool_name recent_entries + 1 >= threshold
 
 let make_hooks
     ~config:(_config : Room.config)
@@ -296,7 +285,6 @@ let make_hooks
      At >= streak_threshold, pre_tool_use blocks the call with Override. *)
   let tool_name_streak : (string * int) ref = ref ("", 0) in
   let streak_threshold = 5 in
-  let cross_turn_polling_threshold = 2 in
   { Agent_sdk.Hooks.empty with
 
     after_turn = Some (fun event ->
@@ -469,15 +457,6 @@ let make_hooks
           if prev_name = tool_name then prev_count + 1 else 1
         in
         tool_name_streak := (tool_name, new_count);
-        let recent_entries =
-          if is_cross_turn_polling_tool tool_name then
-            Keeper_tool_call_log.read_recent ~keeper_name ~n:8 ()
-          else []
-        in
-        let cross_turn_streak =
-          if recent_entries = [] then 0
-          else recent_tool_streak_count ~tool_name recent_entries + 1
-        in
         if new_count >= streak_threshold then begin
           Log.Keeper.warn
             "keeper:%s streak_gate: %s called %d times consecutively, blocking"
@@ -491,24 +470,6 @@ let make_hooks
                ~reason_text:(Printf.sprintf
                  "%s called %d times consecutively. Use a DIFFERENT tool or keeper_stay_silent"
                  tool_name new_count))
-        end
-        else if should_block_cross_turn_polling
-                  ~within_sec:900.0
-                  ~threshold:cross_turn_polling_threshold
-                  ~tool_name
-                  ~recent_entries then begin
-          Log.Keeper.warn
-            "keeper:%s cross_turn_polling_gate: %s called %d recent tool calls in a row, blocking"
-            keeper_name tool_name cross_turn_streak;
-          broadcast_tool_skipped ~keeper_name ~tool_name
-            ~reason_code:"cross_turn_polling_gate";
-          Agent_sdk.Hooks.Override
-            (render_inline_skip_reason
-               ~tool_name
-               ~reason_code:"cross_turn_polling_gate"
-               ~reason_text:(Printf.sprintf
-                 "%s was already the last recent polling tool. Do real work with a different tool or use keeper_stay_silent"
-                 tool_name))
         end
         else
         (* Safety gate 0: Keeper deny list *)

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -200,15 +200,10 @@ let inferred_tool_surface tools =
 let tool_only_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(result : Keeper_agent_run.run_result) =
-  let visible_reply =
-    Keeper_text_processing.strip_internal_reply_markup result.response_text
-  in
   let speech_act, delivery_surface =
     match inferred_tool_surface result.tools_used with
     | Some routed -> routed
-    | None ->
-        if String.trim visible_reply <> "" then (Inform, Visible_reply)
-        else (Defer, Silent)
+    | None -> (Inform, Visible_reply)
   in
   {
     social_model = meta.social_model;
@@ -379,7 +374,17 @@ let apply_to_result ~(meta : keeper_meta)
   | Stay_silent, Silent when result.tools_used = [] ->
       ({ result with response_text = "" }, state)
   | _ ->
-      ({ result with response_text = visible_response_body }, state)
+      let response_text =
+        match
+          Keeper_tool_disclosure.normalize_response_text
+            ~text:visible_response_body
+            ~tool_names:result.tools_used
+            ()
+        with
+        | Ok normalized -> normalized
+        | Error _ -> visible_response_body
+      in
+      ({ result with response_text }, state)
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)

--- a/lib/keeper/keeper_tool_disclosure.ml
+++ b/lib/keeper/keeper_tool_disclosure.ml
@@ -136,25 +136,6 @@ let deterministic_prefilter_names
     |> List.filteri (fun i _ -> i < selection_limit)
 ;;
 
-let latest_tool_name (entries : Yojson.Safe.t list) : string option =
-  entries
-  |> List.rev
-  |> List.find_map (Safe_ops.json_string_opt "tool")
-;;
-
-let prune_boring_tools_after_recent_polling
-    ~(visible_tools : string list)
-    ~(recent_entries : Yojson.Safe.t list) : string list =
-  (* Boring concept retired. Previously: when the latest tool call was
-     boring and no visible tool was productive, this collapsed visible
-     tools down to [keeper_stay_silent], forcing silent turns. With the
-     registry's classification empty this becomes an identity transform.
-     The function stays on the public API until the full-removal PR to
-     avoid churn in callers/tests that still import it. *)
-  let _ = latest_tool_name recent_entries in
-  visible_tools
-;;
-
 let merge_tool_selection_boundary
     ~(core : string list)
     ~(deterministic_prefilter : string list)

--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -99,7 +99,7 @@ let compute_diversity ~(available_tools : string list)
   let threshold = max 1 (total_calls / 100) in
   let underused = available_tools
     |> List.filter (fun tool ->
-      not (Keeper_tool_registry.is_boring_tool tool)
+      not (String.equal tool "keeper_stay_silent")
       && (not (Hashtbl.mem used_set tool)
           || List.exists (fun s -> s.name = tool && s.count < threshold) stats))
   in

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -336,42 +336,6 @@ let is_reconcile_safe_tool (name : string) : bool =
 let all_tools_reconcile_safe (names : string list) : bool =
   names <> [] && List.for_all is_reconcile_safe_tool names
 
-(* ── Boring tools (non-productive observation/polling) ─────── *)
-
-(** Tools that gather status but produce no side effects.
-    Calling only these tools across consecutive turns indicates a
-    polling loop. This shared classification is still useful for
-    prompt shaping, telemetry, and tool-diversity heuristics.
-
-    A tool is "boring" if calling it N times yields the same
-    information as calling it once, and it mutates nothing.
-    [keeper_stay_silent] is included: it is a no-op by design
-    and should not be treated as productive work.
-    Contrast with [keeper_fs_read] which reads new content, or
-    [keeper_board_post] which creates artifacts. *)
-(* Boring concept retired. Repeated history: #6199/#6381/#6407 removed it,
-   #6375/#6432/#6872 restored it, #6886 reverted again. Each revival kept
-   widening the list (keeper_board_list, keeper_context_status) which drove
-   keepers into silent-only turns when every visible tool was flagged.
-   Neutralized by leaving the API shape (so callers compile) but treating
-   no tool as boring. Full-source removal tracked in follow-up issue. *)
-let boring_tools : string list = []
-
-let boring_tools_set : (string, unit) Hashtbl.t =
-  let tbl = Hashtbl.create (List.length boring_tools) in
-  List.iter (fun name -> Hashtbl.replace tbl name ()) boring_tools;
-  tbl
-
-let is_boring_tool (name : string) : bool =
-  Hashtbl.mem boring_tools_set name
-
-let prune_boring_tools_for_actionable_turn (tool_names : string list) :
-    string list =
-  let actionable =
-    List.filter (fun name -> not (is_boring_tool name)) tool_names
-  in
-  if actionable = [] then tool_names else actionable
-
 (* ── Dynamic schema injection (masc_* tools) ──────────────────── *)
 
 let masc_schemas_ref : Types.tool_schema list ref = ref []

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -358,7 +358,7 @@ let scheduled_autonomous_outcome_of_result
 
 let has_substantive_tool_calls (tools_used : string list) : bool =
   List.exists (fun name ->
-    not (Keeper_tool_registry.is_boring_tool name)) tools_used
+    not (String.equal name "keeper_stay_silent")) tools_used
 
 let visible_run_validation (result : Keeper_agent_run.run_result) :
     Agent_sdk.Raw_trace.run_validation option =
@@ -740,7 +740,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
   let substantive_tool_call_count =
     result.tools_used
     |> List.filter (fun name ->
-         not (Keeper_tool_registry.is_boring_tool name))
+         not (String.equal name "keeper_stay_silent"))
     |> List.length
   in
   let has_substantive_tools = has_substantive_tool_calls result.tools_used in

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -315,41 +315,6 @@ let test_deterministic_prefilter_surfaces_code_tools () =
   in
   Alcotest.(check bool) "code search appears without llm rerank"
     true (List.mem "masc_code_search" selected)
-
-let test_prune_boring_tools_after_recent_polling () =
-  (* Boring concept retired. prune_boring_tools_after_recent_polling is now
-     an identity transform — the caller's visible tool set is returned
-     unchanged regardless of recent tool history. *)
-  let visible_tools =
-    [ "masc_status"; "keeper_tasks_list"; "keeper_context_status";
-      "keeper_stay_silent"; "keeper_fs_edit"; "masc_code_search" ]
-  in
-  let recent_entries =
-    [ `Assoc [ ("tool", `String "masc_status") ] ]
-  in
-  let pruned =
-    Keeper_tool_disclosure.prune_boring_tools_after_recent_polling
-      ~visible_tools ~recent_entries
-  in
-  Alcotest.(check (list string))
-    "visible tools returned unchanged"
-    visible_tools pruned
-
-let test_prune_boring_tools_keeps_set_when_last_tool_productive () =
-  let visible_tools =
-    [ "masc_status"; "keeper_tasks_list"; "keeper_stay_silent"; "keeper_fs_edit" ]
-  in
-  let recent_entries =
-    [ `Assoc [ ("tool", `String "keeper_fs_edit") ] ]
-  in
-  let pruned =
-    Keeper_tool_disclosure.prune_boring_tools_after_recent_polling
-      ~visible_tools ~recent_entries
-  in
-  Alcotest.(check (list string))
-    "productive last tool leaves visible tools unchanged"
-    visible_tools pruned
-
 let test_keeper_config_defaults () =
   (* Default: LLM rerank disabled *)
   Alcotest.(check bool) "llm_rerank disabled by default"
@@ -386,10 +351,6 @@ let () =
         test_selection_boundary_sorts_discovered;
       Alcotest.test_case "deterministic prefilter surfaces code tools" `Quick
         test_deterministic_prefilter_surfaces_code_tools;
-      Alcotest.test_case "recent polling prunes boring tools" `Quick
-        test_prune_boring_tools_after_recent_polling;
-      Alcotest.test_case "productive last tool keeps boring tools visible" `Quick
-        test_prune_boring_tools_keeps_set_when_last_tool_productive;
     ];
     "keeper_config", [
       Alcotest.test_case "config defaults" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2433,12 +2433,13 @@ let test_social_model_tool_only_turn_skips_protocol_violation () =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation result
   in
-  check string "speech act" "defer"
+  check string "speech act" "inform"
     (KSM.speech_act_to_string state.speech_act);
-  check string "delivery surface" "silent"
+  check string "delivery surface" "visible_reply"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "no protocol violation blocker" None state.blocker;
-  check string "visible response suppressed" "" routed.response_text;
+  check bool "tool-only turn synthesizes visible response" true
+    (contains_substring routed.response_text "Tools used: masc_status.");
   check (list string) "tool list preserved" ["masc_status"] routed.tools_used
 
 let test_social_model_infers_board_comment_from_tool_use () =
@@ -2455,7 +2456,9 @@ let test_social_model_infers_board_comment_from_tool_use () =
   check string "delivery surface" "board_comment"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "no protocol violation blocker" None state.blocker;
-  check string "visible response empty" "" routed.response_text;
+  check bool "tool turn keeps synthesized visible response" true
+    (contains_substring routed.response_text
+       "Tools used: keeper_board_comment, masc_status.");
   check (list string) "tool list preserved"
     ["keeper_board_comment"; "masc_status"] routed.tools_used
 
@@ -2622,33 +2625,6 @@ let test_recent_tool_streak_count_ignores_stale_entries () =
   check int "stale entry does not extend streak" 1
     (HK.recent_tool_streak_count ~within_sec:60.0 ~tool_name:"masc_status"
        entries)
-
-let test_cross_turn_polling_tool_excludes_stay_silent () =
-  (* Boring concept retired — every tool is non-polling. *)
-  check bool "masc_status no longer flagged as polling" false
-    (HK.is_cross_turn_polling_tool "masc_status");
-  check bool "stay_silent excluded" false
-    (HK.is_cross_turn_polling_tool "keeper_stay_silent");
-  check bool "productive tool excluded" false
-    (HK.is_cross_turn_polling_tool "keeper_fs_edit")
-
-let test_should_block_cross_turn_polling_on_second_attempt () =
-  (* Boring concept retired — cross-turn polling block is a no-op. *)
-  let recent_entries =
-    [ tool_log_entry "masc_status" ]
-  in
-  check bool "cross-turn polling block retired" false
-    (HK.should_block_cross_turn_polling ~within_sec:900.0 ~threshold:2
-       ~tool_name:"masc_status" ~recent_entries)
-
-let test_should_not_block_cross_turn_polling_without_prior_match () =
-  let recent_entries =
-    [ tool_log_entry "keeper_fs_edit" ]
-  in
-  check bool "no prior polling match means no block" false
-    (HK.should_block_cross_turn_polling ~within_sec:900.0 ~threshold:2
-       ~tool_name:"masc_status" ~recent_entries)
-
 (* ---------- Test runner ---------- *)
 
 let () =
@@ -2749,12 +2725,6 @@ let () =
             test_recent_tool_streak_count_counts_tail_matches;
           test_case "recent tool streak ignores stale entries" `Quick
             test_recent_tool_streak_count_ignores_stale_entries;
-          test_case "cross-turn polling tool excludes stay_silent" `Quick
-            test_cross_turn_polling_tool_excludes_stay_silent;
-          test_case "cross-turn polling blocks second attempt" `Quick
-            test_should_block_cross_turn_polling_on_second_attempt;
-          test_case "cross-turn polling allows non-matching history" `Quick
-            test_should_not_block_cross_turn_polling_without_prior_match;
         ] );
       ( "config",
         [
@@ -2962,34 +2932,8 @@ let () =
           test_case "run_unified_turn skips paused keeper" `Quick
             test_run_unified_turn_skips_non_executable_phase;
         ] );
-      ( "boring_tools",
+      ( "tool_classification",
         [
-          (* Boring concept retired — these tests previously asserted
-             particular tools were classified boring. After neutralization,
-             the classification is empty and [is_boring_tool] is constant
-             false. The suite is retained as a regression guard against
-             accidental reintroduction of the classification. *)
-          test_case "no tool is classified boring" `Quick (fun () ->
-            List.iter
-              (fun name ->
-                check bool
-                  (Printf.sprintf "%s not boring" name)
-                  false
-                  (Masc_mcp.Keeper_tool_registry.is_boring_tool name))
-              [ "masc_status"; "keeper_tasks_list"; "keeper_tools_list";
-                "keeper_context_status"; "keeper_stay_silent";
-                "keeper_board_list"; "keeper_fs_read"; "keeper_board_post";
-                "keeper_task_claim"; "keeper_bash"; "masc_heartbeat" ]);
-          test_case "prune_boring_tools_for_actionable_turn is identity"
-            `Quick (fun () ->
-              let input =
-                [ "masc_status"; "keeper_tasks_list"; "keeper_board_post" ]
-              in
-              let pruned =
-                Masc_mcp.Keeper_tool_registry
-                  .prune_boring_tools_for_actionable_turn input
-              in
-              check (list string) "no tools removed" input pruned);
           test_case "keeper allowed tools exclude heartbeat" `Quick
             test_keeper_allowed_tools_exclude_heartbeat;
         ] );


### PR DESCRIPTION
## Summary
- remove the remaining keeper boring-tool shim API and pruning helpers instead of leaving them as dead compatibility paths
- delete the cross-turn polling gate so status-style tools are no longer treated as a special silent-suppression class
- keep tool-only turns visible by synthesizing a reply instead of collapsing them into `silent`

## Why
- `#7073` neutralized the boring classifier, but left dead APIs and tests behind
- that leftover surface kept the runtime and test suite harder to reason about, and it obscured why productive tool turns still looked silent

## Product impact
- keepers stop hiding productive tool-only turns behind silent outcomes
- operator/debugging behavior becomes easier to interpret because the boring/polling special case is fully removed rather than half-neutralized

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/ctx-breakdown-panel`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_topk_llm.exe`

## Review evidence
- rebased onto current `main` so the PR no longer reintroduces already-merged `#7062` CTX composition changes
- updated the stale review note about `keeper_agent_run.ml` / `keeper_registry.ml` drift after the rebase
- checked thread-aware review data for `#7081`; there are no unresolved inline review threads, only top-level PR hygiene feedback

## Linked issue
- Refs #7073
- Refs #7085
- Refs #7075
- Refs #7087
