### PR TITLE
feat(dashboard): RFC-MASC-006 Phase 2a — Observatory v1 skeleton

### DIFF
--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -1,0 +1,75 @@
+// Observatory Event Track (RFC-MASC-006 Phase 2a)
+// Renders discrete telemetry events as vertical markers on a shared time axis.
+
+import { html } from 'htm/preact'
+import type { TelemetryEntry } from '../../api/dashboard'
+
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  if (typeof entry.ts === 'number') return entry.ts * 1000
+  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
+  if (typeof entry.timestamp === 'number') return entry.timestamp
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+function sourceColor(source: string | undefined): string {
+  switch (source) {
+    case 'oas_event': return 'bg-accent'
+    case 'agent_event': return 'bg-emerald-400'
+    case 'tool_call_io': return 'bg-blue-400'
+    case 'tool_usage': return 'bg-sky-400'
+    case 'keeper_metrics': return 'bg-purple-400'
+    default: return 'bg-text-dim'
+  }
+}
+
+function eventLabel(entry: TelemetryEntry): string {
+  const source = typeof entry.source === 'string' ? entry.source : '?'
+  const eventType = typeof entry.event_type === 'string' ? entry.event_type : ''
+  return eventType ? `${source}:${eventType}` : source
+}
+
+interface Props {
+  events: TelemetryEntry[]
+  windowStart: number
+  windowEnd: number
+}
+
+export function EventTrack({ events, windowStart, windowEnd }: Props) {
+  const span = windowEnd - windowStart
+  if (span <= 0) return null
+
+  const markers = events
+    .map(entry => ({ entry, ts: entryTimestampMs(entry) }))
+    .filter((m): m is { entry: TelemetryEntry; ts: number } =>
+      m.ts !== null && m.ts >= windowStart && m.ts <= windowEnd,
+    )
+
+  return html`
+    <div class="flex items-center gap-3">
+      <div class="w-24 shrink-0 text-[11px] font-semibold text-text-muted">
+        이벤트 (${markers.length})
+      </div>
+      <div class="relative flex-1 h-8 rounded-md bg-bg-1/40 border border-card-border/50">
+        ${markers.length === 0
+          ? html`<div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">이 시간 범위에 이벤트 없음</div>`
+          : markers.map(({ entry, ts }) => {
+              const pct = ((ts - windowStart) / span) * 100
+              const color = sourceColor(typeof entry.source === 'string' ? entry.source : undefined)
+              const label = eventLabel(entry)
+              return html`
+                <span
+                  class="absolute top-1 bottom-1 w-[2px] ${color} hover:w-1 transition-all cursor-pointer"
+                  style="left: ${pct}%;"
+                  title=${`${new Date(ts).toLocaleTimeString()} · ${label}`}
+                ></span>
+              `
+            })
+        }
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -1,0 +1,98 @@
+// Observatory Metric Track (RFC-MASC-006 Phase 2a)
+// Renders tool call success rate over time as an SVG line on shared time axis.
+
+import { html } from 'htm/preact'
+import type { ToolQualityHourlyPoint } from '../../api/dashboard'
+
+interface Props {
+  points: ToolQualityHourlyPoint[]
+  windowStart: number
+  windowEnd: number
+}
+
+function hourToMs(hour: string): number | null {
+  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export function MetricTrack({ points, windowStart, windowEnd }: Props) {
+  const span = windowEnd - windowStart
+  if (span <= 0) return null
+
+  const windowed = points
+    .map(p => ({ point: p, ts: hourToMs(p.hour) }))
+    .filter((m): m is { point: ToolQualityHourlyPoint; ts: number } =>
+      m.ts !== null && m.ts >= windowStart && m.ts <= windowEnd,
+    )
+    .sort((a, b) => a.ts - b.ts)
+
+  const viewBoxWidth = 1000
+  const viewBoxHeight = 60
+
+  const polyline = windowed
+    .map(({ point, ts }) => {
+      const x = ((ts - windowStart) / span) * viewBoxWidth
+      const y = viewBoxHeight - (point.success_rate / 100) * viewBoxHeight
+      return `${x.toFixed(1)},${y.toFixed(1)}`
+    })
+    .join(' ')
+
+  const lastRate = windowed[windowed.length - 1]?.point.success_rate ?? null
+  const lastRateColor =
+    lastRate == null ? 'text-text-dim'
+      : lastRate >= 97 ? 'text-emerald-400'
+      : lastRate >= 90 ? 'text-text-strong'
+      : 'text-red-400'
+
+  return html`
+    <div class="flex items-center gap-3">
+      <div class="w-24 shrink-0">
+        <div class="text-[11px] font-semibold text-text-muted">도구 성공률</div>
+        ${lastRate != null ? html`
+          <div class="text-[13px] font-mono font-semibold ${lastRateColor}">
+            ${lastRate.toFixed(1)}%
+          </div>
+        ` : html`<div class="text-[10px] text-text-dim">데이터 없음</div>`}
+      </div>
+      <div class="relative flex-1 h-12 rounded-md bg-bg-1/40 border border-card-border/50">
+        ${windowed.length === 0 ? html`
+          <div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">
+            hourly_trend 데이터 부족
+          </div>
+        ` : html`
+          <svg
+            viewBox="0 0 ${viewBoxWidth} ${viewBoxHeight}"
+            preserveAspectRatio="none"
+            class="absolute inset-0 w-full h-full"
+          >
+            <line x1="0" y1="${viewBoxHeight * 0.03}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.03}" stroke="currentColor" stroke-dasharray="2 4" class="text-emerald-500/30" stroke-width="0.5" />
+            <line x1="0" y1="${viewBoxHeight * 0.1}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.1}" stroke="currentColor" stroke-dasharray="2 4" class="text-amber-500/30" stroke-width="0.5" />
+            <polyline
+              points=${polyline}
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              class="text-accent"
+              vector-effect="non-scaling-stroke"
+            />
+            ${windowed.map(({ point, ts }) => {
+              const x = ((ts - windowStart) / span) * viewBoxWidth
+              const y = viewBoxHeight - (point.success_rate / 100) * viewBoxHeight
+              return html`
+                <circle
+                  cx="${x.toFixed(1)}"
+                  cy="${y.toFixed(1)}"
+                  r="1.5"
+                  fill="currentColor"
+                  class="text-accent"
+                >
+                  <title>${point.hour} · ${point.success_rate.toFixed(1)}% (${point.calls} calls)</title>
+                </circle>
+              `
+            })}
+          </svg>
+        `}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -1,0 +1,244 @@
+// Observatory — Unified Investigation Surface (RFC-MASC-006 Phase 2a skeleton)
+//
+// v1 scope (this file):
+//   - Shared time axis for 1h / 24h / etc. ranges
+//   - 2 initial tracks: Events (telemetry markers), Metrics (success rate line)
+//   - Global filter integration (keeper / range from observatory-filter-store)
+//
+// Out of scope for Phase 2a (deferred to 2b+):
+//   - Cross-signal hover cursor
+//   - Memory subsystems track (backend snapshot-only)
+//   - Autoresearch cycle track (RFC-MASC-007 hook)
+//   - Tool calls track, drill-down detail pane
+//   - SSE live streaming (current: polling per filter change)
+
+import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
+import { useEffect, useRef } from 'preact/hooks'
+import {
+  currentKeeperFilter,
+  currentTimeRangeFilter,
+  setTimeRangeFilter,
+  timeRangeLabel,
+  TIME_RANGE_PRESETS,
+  type TimeRangePreset,
+} from '../../observatory-filter-store'
+import {
+  fetchTelemetry,
+  fetchToolQuality,
+  type TelemetryEntry,
+  type ToolQualityHourlyPoint,
+} from '../../api/dashboard'
+import { EventTrack } from './event-track'
+import { MetricTrack } from './metric-track'
+import { LoadingState } from '../common/feedback-state'
+
+// --- Time range utilities ---
+
+const RANGE_TO_MS: Record<TimeRangePreset, number> = {
+  '5m': 5 * 60_000,
+  '1h': 60 * 60_000,
+  '24h': 24 * 60 * 60_000,
+  '7d': 7 * 24 * 60 * 60_000,
+}
+
+export function timeRangeToMs(preset: TimeRangePreset): number {
+  return (RANGE_TO_MS[preset] ?? RANGE_TO_MS['1h'] ?? 3_600_000)
+}
+
+const DEFAULT_RANGE: TimeRangePreset = '1h'
+
+// --- Observatory state ---
+
+interface ObservatoryData {
+  loading: boolean
+  error: string | null
+  events: TelemetryEntry[]
+  hourlyTrend: ToolQualityHourlyPoint[]
+  windowStart: number
+  windowEnd: number
+}
+
+function emptyData(): ObservatoryData {
+  const now = Date.now()
+  return {
+    loading: false,
+    error: null,
+    events: [],
+    hourlyTrend: [],
+    windowStart: now - RANGE_TO_MS[DEFAULT_RANGE],
+    windowEnd: now,
+  }
+}
+
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  if (typeof entry.ts === 'number') return entry.ts * 1000
+  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
+  if (typeof entry.timestamp === 'number') return entry.timestamp
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+// --- Time axis header ---
+
+function TimeAxis({ windowStart, windowEnd }: { windowStart: number; windowEnd: number }) {
+  const span = windowEnd - windowStart
+  if (span <= 0) return null
+
+  const tickCount = 6
+  const ticks = Array.from({ length: tickCount + 1 }, (_, i) => {
+    const t = windowStart + (span * i) / tickCount
+    return { t, pct: (i / tickCount) * 100 }
+  })
+
+  const formatTick = (t: number) => {
+    const d = new Date(t)
+    if (span <= 24 * 60 * 60_000) {
+      return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+    }
+    return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}h`
+  }
+
+  return html`
+    <div class="relative h-6 border-b border-card-border text-[10px] text-text-dim font-mono">
+      ${ticks.map(tick => html`
+        <span
+          class="absolute top-0 -translate-x-1/2 whitespace-nowrap"
+          style="left: ${tick.pct}%;"
+        >
+          ${formatTick(tick.t)}
+        </span>
+      `)}
+    </div>
+  `
+}
+
+// --- Range selector ---
+
+function RangeSelector() {
+  const current = currentTimeRangeFilter() ?? DEFAULT_RANGE
+  return html`
+    <div class="inline-flex items-center gap-0.5 rounded-md border border-card-border p-0.5 text-[11px]">
+      ${TIME_RANGE_PRESETS.map((preset: TimeRangePreset) => html`
+        <button
+          type="button"
+          class="rounded px-2 py-0.5 font-medium transition-colors ${
+            current === preset
+              ? 'bg-accent/20 text-accent'
+              : 'text-text-muted hover:text-text-strong hover:bg-white/5'
+          }"
+          onClick=${() => setTimeRangeFilter(preset)}
+          aria-pressed=${current === preset}
+        >
+          ${timeRangeLabel(preset).replace('최근 ', '')}
+        </button>
+      `)}
+    </div>
+  `
+}
+
+// --- Main container ---
+
+export function Observatory() {
+  const state = useSignal<ObservatoryData>(emptyData())
+  const activeController = useRef<AbortController | null>(null)
+  const latestRequestId = useRef(0)
+
+  useEffect(() => {
+    const keeper = currentKeeperFilter() ?? undefined
+    const range = currentTimeRangeFilter() ?? DEFAULT_RANGE
+
+    activeController.current?.abort()
+    const controller = new AbortController()
+    activeController.current = controller
+    const requestId = ++latestRequestId.current
+
+    const now = Date.now()
+    const windowStart = now - RANGE_TO_MS[range]
+    const windowEnd = now
+
+    state.value = { ...state.value, loading: true, error: null }
+
+    Promise.allSettled([
+      fetchTelemetry({ keeper, n: 500, signal: controller.signal }),
+      fetchToolQuality({ n: 2000, signal: controller.signal }),
+    ]).then(([telemetryResult, toolQualityResult]) => {
+      if (controller.signal.aborted || requestId !== latestRequestId.current) return
+
+      const events = telemetryResult.status === 'fulfilled'
+        ? telemetryResult.value.entries.filter(entry => {
+            const ts = entryTimestampMs(entry)
+            return ts !== null && ts >= windowStart && ts <= windowEnd
+          })
+        : []
+
+      const hourlyTrend = toolQualityResult.status === 'fulfilled'
+        ? toolQualityResult.value.hourly_trend ?? []
+        : []
+
+      const errors = [telemetryResult, toolQualityResult]
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+        .map(r => r.reason instanceof Error ? r.reason.message : String(r.reason))
+
+      state.value = {
+        loading: false,
+        error: errors.length > 0 ? errors.join(' · ') : null,
+        events,
+        hourlyTrend,
+        windowStart,
+        windowEnd,
+      }
+    })
+
+    return () => { controller.abort() }
+  }, [currentKeeperFilter(), currentTimeRangeFilter()])
+
+  const data = state.value
+
+  if (data.loading && data.events.length === 0 && data.hourlyTrend.length === 0) {
+    return html`<${LoadingState}>관찰소 데이터 불러오는 중...<//>`
+  }
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <div class="flex flex-col gap-0.5">
+          <h3 class="text-[13px] font-semibold text-text-strong">관찰소 (Observatory)</h3>
+          <p class="text-[11px] text-text-dim">
+            ${currentKeeperFilter() ? `keeper=${currentKeeperFilter()}` : '전체 keeper'}
+            · ${timeRangeLabel(currentTimeRangeFilter() ?? DEFAULT_RANGE)}
+            · ${data.events.length} events
+          </p>
+        </div>
+        <${RangeSelector} />
+      </div>
+
+      ${data.error ? html`
+        <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-200">
+          일부 데이터 불러오기 실패: ${data.error}
+        </div>
+      ` : null}
+
+      <div class="flex flex-col gap-2 rounded-xl border border-card-border bg-card/30 p-4">
+        <${TimeAxis} windowStart=${data.windowStart} windowEnd=${data.windowEnd} />
+        <${EventTrack}
+          events=${data.events}
+          windowStart=${data.windowStart}
+          windowEnd=${data.windowEnd}
+        />
+        <${MetricTrack}
+          points=${data.hourlyTrend}
+          windowStart=${data.windowStart}
+          windowEnd=${data.windowEnd}
+        />
+      </div>
+
+      <p class="text-[10px] text-text-dim italic">
+        Phase 2a 스켈레톤 — 더 많은 track(도구 호출, 메모리, autoresearch)과 cross-signal cursor는 Phase 2b+에서 추가됩니다.
+      </p>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -16,13 +16,15 @@ import { FsmHub } from './fsm-hub'
 import { PrometheusMetrics } from './prometheus-metrics'
 import { ToolQualityPanel } from './tool-quality-panel'
 import { FleetTelemetryPanel } from './fleet-telemetry-panel'
+import { Observatory } from './observatory/observatory'
 
-type StatusSection = 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems' | 'fsm-hub' | 'metrics' | 'tool-quality' | 'fleet'
+type StatusSection = 'observatory' | 'agents' | 'activity' | 'runtime' | 'telemetry' | 'governance' | 'memory-subsystems' | 'fsm-hub' | 'metrics' | 'tool-quality' | 'fleet'
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
   if (
-    section === 'activity' || section === 'runtime'
+    section === 'observatory'
+    || section === 'activity' || section === 'runtime'
     || section === 'telemetry' || section === 'governance' || section === 'memory-subsystems'
     || section === 'fsm-hub' || section === 'metrics' || section === 'tool-quality' || section === 'fleet'
   ) return section
@@ -35,8 +37,10 @@ export function Status() {
   return html`
     <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
-        ${section === 'activity'
-          ? html`<${Activity} />`
+        ${section === 'observatory'
+          ? html`<${Observatory} />`
+          : section === 'activity'
+            ? html`<${Activity} />`
           : section === 'runtime'
             ? html`
               <div class="grid gap-4">

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -2,6 +2,7 @@ import type { RouteState, TabId } from '../types'
 
 export type SurfaceId = TabId
 export type SurfaceSectionId =
+  | 'observatory'
   | 'agents'
   | 'activity'
   | 'board'
@@ -116,6 +117,12 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = DASHBOARD_SURFACES.map(su
 
 export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavItem[]> = {
   monitoring: [
+    {
+      id: 'observatory',
+      label: '관찰소 (beta)',
+      description: '이벤트/메트릭을 단일 timeline에 통합. RFC-MASC-006 Phase 2a.',
+      params: { section: 'observatory' },
+    },
     {
       id: 'agents',
       label: '에이전트 & 키퍼',


### PR DESCRIPTION
RFC-MASC-006 (#7050) Phase 2a — Observatory의 첫 작동 버전. 텔레메트리 이벤트와 도구 품질 시계열을 **단일 time axis**에 통합.

(이 PR은 #7067 대체 — 원본 PR이 base branch 삭제로 자동 닫힘)

## 제공

- 관찰소 surface (\`monitoring/observatory\` sub-section)
- 이벤트 track (텔레메트리 → discrete markers, source별 색상)
- 도구 성공률 track (tool-quality.hourly_trend → SVG polyline)
- Range selector (5m/1h/24h/7d) — Phase 1 setTimeRangeFilter 호출
- Keeper 필터 연동 (Phase 1 currentKeeperFilter)
- "beta" 라벨 + scope 명시

## 의존성

Phase 1 (#7066) merged ✓ — observatory-filter-store 사용

## Out of scope (Phase 2b+)

- Cross-signal cursor, 도구 호출 track, 메모리 track, autoresearch track, drill-down, SSE streaming

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — zero errors
- [x] \`pnpm exec vitest\` — relevant tests pass
- [ ] CI green
- [ ] 로컬 UI 확인

## Refs

- RFC-MASC-006 (#7050), Phase 0 (#7055 merged), Phase 1 (#7066 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)