### PR TITLE
feat(keeper): track guard penalties + wire into decision FSM

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -916,6 +916,7 @@ let keeper_config_json (config : Room.config) (name : string)
         Keeper_decision_audit.decision_pipeline_to_mermaid
           ?tool_policy_mode
           ?turn_outcome
+          ~guard_penalty_this_cycle:stats.guard_penalties_total
           ~phase
           ~thompson_alpha:stats.alpha
           ~thompson_beta:stats.beta

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -632,6 +632,7 @@ let handle_keeper_get_subroutes state req request reqd =
         Keeper_decision_audit.decision_pipeline_to_mermaid
           ?tool_policy_mode
           ?turn_outcome
+          ~guard_penalty_this_cycle:stats.guard_penalties_total
           ~phase:current
           ~thompson_alpha:stats.alpha
           ~thompson_beta:stats.beta

--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -24,6 +24,10 @@ type agent_stats = {
   mutable posts_created : int;
   mutable comments_created : int;
   mutable skips : int;
+  (* Guard penalty tracking (Phase B1: Guard → Thompson bridge).
+     Cumulative count of [record_guard_penalty] calls — caller enforces
+     the 1/cycle cap so this approximates "cycles where guardrail fired". *)
+  mutable guard_penalties_total : int;
   (* Timestamp *)
   mutable updated_at : float;
 }
@@ -192,6 +196,7 @@ let make_default_stats name =
     posts_created = 0;
     comments_created = 0;
     skips = 0;
+    guard_penalties_total = 0;
     updated_at = now;
   }
 
@@ -229,6 +234,7 @@ let stats_to_json (s : agent_stats) : Yojson.Safe.t =
     ("posts_created", `Int s.posts_created);
     ("comments_created", `Int s.comments_created);
     ("skips", `Int s.skips);
+    ("guard_penalties_total", `Int s.guard_penalties_total);
     ("updated_at", `Float s.updated_at);
   ]
 
@@ -245,6 +251,7 @@ let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
     let posts_created = json |> member "posts_created" |> to_int_option |> Option.value ~default:0 in
     let comments_created = json |> member "comments_created" |> to_int_option |> Option.value ~default:0 in
     let skips = json |> member "skips" |> to_int_option |> Option.value ~default:0 in
+    let guard_penalties_total = json |> member "guard_penalties_total" |> to_int_option |> Option.value ~default:0 in
     let updated_at = json |> member "updated_at" |> to_float in
     Some {
       name;
@@ -257,6 +264,7 @@ let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
       posts_created;
       comments_created;
       skips;
+      guard_penalties_total;
       updated_at;
     }
   with Yojson.Safe.Util.Type_error _ -> None
@@ -427,6 +435,7 @@ let record_guard_penalty ~agent_name =
   with_ts_rw (fun () ->
     s.beta <- s.beta +. guard_penalty_beta_nudge;
     s.beta <- Float.max min_prior s.beta;
+    s.guard_penalties_total <- s.guard_penalties_total + 1;
     s.updated_at <- Time_compat.now ())
 
 (** Record Post Verifier result into Thompson Sampling priors. *)

--- a/lib/thompson_sampling.mli
+++ b/lib/thompson_sampling.mli
@@ -31,6 +31,11 @@ type agent_stats = {
   mutable posts_created : int;
   mutable comments_created : int;
   mutable skips : int;
+  (* Guard penalty tracking (Phase B1: Guard → Thompson bridge).
+     Incremented on each [record_guard_penalty] call. The caller enforces
+     the 1/cycle cap so this value approximates "cycles in which the
+     guardrail fired" without a separate cycle-boundary state machine. *)
+  mutable guard_penalties_total : int;
   (* Timestamp *)
   mutable updated_at : float;
 }


### PR DESCRIPTION
## Summary

Closes the last open Phase 1b label (`?guard_penalty_this_cycle`) from #7039 by:

1. Adding `guard_penalties_total : int` to `Thompson_sampling.agent_stats`.
2. Incrementing it inside `record_guard_penalty`.
3. Persisting it in the JSONL round-trip (`stats_to_json` / `stats_of_json`).
4. Wiring the value into both decision-pipeline renderers.

## Why total rather than \"this cycle\"

The existing `record_guard_penalty` caller in `keeper_keepalive.ml:830` already enforces the 1/cycle cap. So the cumulative count doubles as a lower bound on \"cycles in which the guardrail fired\" — no separate cycle-boundary state machine is needed to get a useful number on the dashboard.

Renaming the parameter label from `?guard_penalty_this_cycle` to something like `?guard_penalty_total` is deferred to a follow-up, so this PR keeps the existing signature stable.

## Migration

Existing JSONL stats files work unchanged: `stats_of_json` reads `guard_penalties_total` with default `0` when absent.

## Depends on

- #7076 — Phase 1b wiring scaffold (currently auto-merge queued; this branch stacked).
- #7039 — Phase 1b signature (merged).

## Test plan

- [ ] `dune build lib/masc_mcp.cma` green.
- [ ] After a keeper's first guardrail-stop, `/state-diagram` response's `decision_pipeline_mermaid` note block shows `Guard pen this cycle: 1` (incrementing per cycle).
- [ ] `test/test_thompson_sampling.ml` still passes with new field.

## Related

- `lib/thompson_sampling.ml:425` — `record_guard_penalty` site.
- `lib/keeper/keeper_keepalive.ml:830` — 1/cycle cap enforcement.
- `KeeperDecisionPipeline.tla` — `guard_penalties_this_cycle` state variable.
- `docs/design/dashboard-fsm-redesign.md` Phase 1b (final label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)