### PR TITLE
refactor(keeper): retire cross_turn_polling_gate call-site (#7078 / 2/8)

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -296,7 +296,6 @@ let make_hooks
      At >= streak_threshold, pre_tool_use blocks the call with Override. *)
   let tool_name_streak : (string * int) ref = ref ("", 0) in
   let streak_threshold = 5 in
-  let cross_turn_polling_threshold = 2 in
   { Agent_sdk.Hooks.empty with
 
     after_turn = Some (fun event ->
@@ -469,15 +468,6 @@ let make_hooks
           if prev_name = tool_name then prev_count + 1 else 1
         in
         tool_name_streak := (tool_name, new_count);
-        let recent_entries =
-          if is_cross_turn_polling_tool tool_name then
-            Keeper_tool_call_log.read_recent ~keeper_name ~n:8 ()
-          else []
-        in
-        let cross_turn_streak =
-          if recent_entries = [] then 0
-          else recent_tool_streak_count ~tool_name recent_entries + 1
-        in
         if new_count >= streak_threshold then begin
           Log.Keeper.warn
             "keeper:%s streak_gate: %s called %d times consecutively, blocking"
@@ -491,24 +481,6 @@ let make_hooks
                ~reason_text:(Printf.sprintf
                  "%s called %d times consecutively. Use a DIFFERENT tool or keeper_stay_silent"
                  tool_name new_count))
-        end
-        else if should_block_cross_turn_polling
-                  ~within_sec:900.0
-                  ~threshold:cross_turn_polling_threshold
-                  ~tool_name
-                  ~recent_entries then begin
-          Log.Keeper.warn
-            "keeper:%s cross_turn_polling_gate: %s called %d recent tool calls in a row, blocking"
-            keeper_name tool_name cross_turn_streak;
-          broadcast_tool_skipped ~keeper_name ~tool_name
-            ~reason_code:"cross_turn_polling_gate";
-          Agent_sdk.Hooks.Override
-            (render_inline_skip_reason
-               ~tool_name
-               ~reason_code:"cross_turn_polling_gate"
-               ~reason_text:(Printf.sprintf
-                 "%s was already the last recent polling tool. Do real work with a different tool or use keeper_stay_silent"
-                 tool_name))
         end
         else
         (* Safety gate 0: Keeper deny list *)


### PR DESCRIPTION
## Summary

Part 2/8 of the #7078 workaround catalog. Removes the cross-turn polling gate call-site in \`keeper_hooks_oas.ml\`.

## What the gate did

In \`pre_tool_use\`, after the same-name streak check, it also read the recent tool-call log (last 8 entries, 900s window) and blocked the call if:
- \`is_cross_turn_polling_tool tool_name\` (== boring and not stay_silent), AND
- recent streak + 1 >= 2

It was a second defensive layer behind the \`boring_tools\` classification, trying to catch cross-turn polling that escapes the single-turn streak counter.

## Why retire it now

1. **Same-name streak_gate (5x)** already covers the primary case from within a single turn — running \`masc_status\` 5 times in a row is still blocked.
2. **Boring classifier retirement (#7073)** makes \`is_cross_turn_polling_tool\` constant-false, so the gate is no-op after #7073 lands anyway.
3. The gate's stated purpose — compensating for OAS not persisting idle state across turns — is tracked upstream in #7078. Local duplication adds no value.

## Scope

- Deletes the \`else if should_block_cross_turn_polling ...\` branch from the pre_tool_use gate chain
- Drops the unused \`recent_entries\` / \`cross_turn_streak\` locals  
- Keeps the internal helpers (\`is_cross_turn_polling_tool\`, \`recent_tool_streak_count\`, \`should_block_cross_turn_polling\`) defined so existing tests keep compiling. They become dead code; full removal is tracked by #7075.

## What does NOT change

- Same-name streak gate (5x → Override) — still active
- Denied-tool list
- Idle nudges  
- Boring classifier (handled separately in #7073)

## Test plan

- [x] \`dune build --root . lib\` — 0 errors
- [x] \`test/test_keeper_unified.exe\` — 156/156 pass

Related: #7073 (boring retirement), #7075 (API surface removal), #7078 (catalog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)