### PR TITLE
feat(dashboard): RFC-MASC-006 Phase 2b — cross-signal cursor + tool calls track

### DIFF
--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -1,0 +1,140 @@
+// Cross-signal readout card (RFC-MASC-006 Phase 2c)
+//
+// When the cursor is active, show aligned values across all tracks at the
+// cursor's time — the core "읽기" primitive of Observatory. Reads directly
+// from `cursorPosition` signal + track data passed by parent.
+
+import { html } from 'htm/preact'
+import type { TelemetryEntry, ToolQualityHourlyPoint } from '../../api/dashboard'
+import { cursorPosition } from './cursor-store'
+
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  if (typeof entry.ts === 'number') return entry.ts * 1000
+  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
+  if (typeof entry.timestamp === 'number') return entry.timestamp
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+function hourToMs(hour: string): number | null {
+  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function isToolCall(entry: TelemetryEntry): boolean {
+  const src = typeof entry.source === 'string' ? entry.source : ''
+  return src === 'tool_call_io' || src === 'tool_usage'
+}
+
+interface Props {
+  events: TelemetryEntry[]
+  hourlyTrend: ToolQualityHourlyPoint[]
+  /** Tolerance in ms for "nearby" event (both halves of cursor). */
+  eventWindowMs: number
+}
+
+function countEventsNear(
+  events: TelemetryEntry[],
+  cursorMs: number,
+  windowMs: number,
+  predicate?: (entry: TelemetryEntry) => boolean,
+): number {
+  const half = windowMs / 2
+  return events.filter(entry => {
+    if (predicate && !predicate(entry)) return false
+    const ts = entryTimestampMs(entry)
+    return ts !== null && Math.abs(ts - cursorMs) <= half
+  }).length
+}
+
+function nearestTrendPoint(
+  points: ToolQualityHourlyPoint[],
+  cursorMs: number,
+): ToolQualityHourlyPoint | null {
+  let best: { point: ToolQualityHourlyPoint; dist: number } | null = null
+  for (const point of points) {
+    const ts = hourToMs(point.hour)
+    if (ts === null) continue
+    const dist = Math.abs(ts - cursorMs)
+    if (best === null || dist < best.dist) best = { point, dist }
+  }
+  return best?.point ?? null
+}
+
+function Row({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string
+  value: string | number
+  tone?: 'neutral' | 'ok' | 'warn' | 'bad'
+}) {
+  const toneClass =
+    tone === 'ok' ? 'text-emerald-400'
+      : tone === 'warn' ? 'text-amber-300'
+      : tone === 'bad' ? 'text-red-400'
+      : 'text-text-strong'
+  return html`
+    <div class="flex items-center justify-between gap-4 text-[11px]">
+      <span class="text-text-dim">${label}</span>
+      <span class="font-mono font-semibold ${toneClass}">${value}</span>
+    </div>
+  `
+}
+
+export function CrossSignalReadout({ events, hourlyTrend, eventWindowMs }: Props) {
+  const cursor = cursorPosition.value
+  if (cursor === null) return null
+
+  const totalEvents = countEventsNear(events, cursor.ts, eventWindowMs)
+  const toolCalls = countEventsNear(events, cursor.ts, eventWindowMs, isToolCall)
+  const toolFailures = countEventsNear(
+    events,
+    cursor.ts,
+    eventWindowMs,
+    entry => isToolCall(entry) && (entry.success === false || Boolean(entry.error)),
+  )
+  const trendPoint = nearestTrendPoint(hourlyTrend, cursor.ts)
+
+  const successRateTone: 'ok' | 'warn' | 'bad' | 'neutral' =
+    trendPoint == null ? 'neutral'
+      : trendPoint.success_rate >= 97 ? 'ok'
+      : trendPoint.success_rate >= 90 ? 'neutral'
+      : 'bad'
+
+  const windowLabel = eventWindowMs >= 60_000
+    ? `±${Math.round(eventWindowMs / 60_000 / 2)}m`
+    : `±${Math.round(eventWindowMs / 1000 / 2)}s`
+
+  return html`
+    <div class="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2 shadow-sm">
+      <div class="mb-1.5 flex items-center justify-between">
+        <span class="text-[10px] uppercase tracking-widest text-accent font-semibold">cursor</span>
+        <span class="text-[11px] font-mono text-text-strong">
+          ${new Date(cursor.ts).toLocaleTimeString()}
+        </span>
+      </div>
+      <div class="grid grid-cols-2 gap-x-4 gap-y-1">
+        <${Row} label=${`이벤트 (${windowLabel})`} value=${totalEvents} />
+        <${Row}
+          label=${`도구 호출 (${windowLabel})`}
+          value=${toolFailures > 0 ? `${toolCalls} / ${toolFailures} 실패` : toolCalls}
+          tone=${toolFailures > 0 ? 'warn' : 'neutral'}
+        />
+        <${Row}
+          label="성공률 (최근 hour)"
+          value=${trendPoint != null ? `${trendPoint.success_rate.toFixed(1)}%` : '-'}
+          tone=${successRateTone}
+        />
+        <${Row}
+          label="최근 호출 건수"
+          value=${trendPoint != null ? trendPoint.calls : '-'}
+        />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/observatory/cursor-line.ts
+++ b/dashboard/src/components/observatory/cursor-line.ts
@@ -1,0 +1,17 @@
+// Vertical cursor line rendered across a track when cursor is active.
+// Reads cursorPosition signal (from cursor-store.ts).
+
+import { html } from 'htm/preact'
+import { cursorPosition } from './cursor-store'
+
+export function CursorLine() {
+  const pos = cursorPosition.value
+  if (pos == null) return null
+  return html`
+    <span
+      class="absolute top-0 bottom-0 w-px bg-text-strong/50 pointer-events-none"
+      style="left: ${(pos.pct * 100).toFixed(3)}%;"
+      aria-hidden="true"
+    ></span>
+  `
+}

--- a/dashboard/src/components/observatory/cursor-store.ts
+++ b/dashboard/src/components/observatory/cursor-store.ts
@@ -1,0 +1,31 @@
+// Observatory cursor state (RFC-MASC-006 Phase 2b)
+// Shared hover cursor across all tracks. Tracks emit mousemove → updates
+// cursorPosition. Tracks render vertical line + tooltip at cursor's time.
+
+import { signal, type Signal } from '@preact/signals'
+
+export interface CursorPosition {
+  /** Cursor's time in ms since epoch. */
+  ts: number
+  /** Normalized x position within track (0.0 - 1.0). */
+  pct: number
+}
+
+export const cursorPosition: Signal<CursorPosition | null> = signal(null)
+
+export function setCursorFromEvent(
+  event: MouseEvent,
+  trackEl: HTMLElement,
+  windowStart: number,
+  windowEnd: number,
+): void {
+  const rect = trackEl.getBoundingClientRect()
+  const x = event.clientX - rect.left
+  const pct = Math.max(0, Math.min(1, x / rect.width))
+  const ts = windowStart + (windowEnd - windowStart) * pct
+  cursorPosition.value = { ts, pct }
+}
+
+export function clearCursor(): void {
+  cursorPosition.value = null
+}

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -1,8 +1,12 @@
-// Observatory Event Track (RFC-MASC-006 Phase 2a)
+// Observatory Event Track (RFC-MASC-006 Phase 2a+2b)
 // Renders discrete telemetry events as vertical markers on a shared time axis.
+// Phase 2b: mousemove updates cursor-store, CursorLine renders across track.
 
 import { html } from 'htm/preact'
+import { useRef } from 'preact/hooks'
 import type { TelemetryEntry } from '../../api/dashboard'
+import { setCursorFromEvent, clearCursor } from './cursor-store'
+import { CursorLine } from './cursor-line'
 
 function entryTimestampMs(entry: TelemetryEntry): number | null {
   if (typeof entry.ts === 'number') return entry.ts * 1000
@@ -39,6 +43,7 @@ interface Props {
 }
 
 export function EventTrack({ events, windowStart, windowEnd }: Props) {
+  const trackRef = useRef<HTMLDivElement | null>(null)
   const span = windowEnd - windowStart
   if (span <= 0) return null
 
@@ -53,7 +58,14 @@ export function EventTrack({ events, windowStart, windowEnd }: Props) {
       <div class="w-24 shrink-0 text-[11px] font-semibold text-text-muted">
         이벤트 (${markers.length})
       </div>
-      <div class="relative flex-1 h-8 rounded-md bg-bg-1/40 border border-card-border/50">
+      <div
+        ref=${trackRef}
+        class="relative flex-1 h-8 rounded-md bg-bg-1/40 border border-card-border/50 cursor-crosshair"
+        onMouseMove=${(e: MouseEvent) => {
+          if (trackRef.current) setCursorFromEvent(e, trackRef.current, windowStart, windowEnd)
+        }}
+        onMouseLeave=${clearCursor}
+      >
         ${markers.length === 0
           ? html`<div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">이 시간 범위에 이벤트 없음</div>`
           : markers.map(({ entry, ts }) => {
@@ -69,6 +81,7 @@ export function EventTrack({ events, windowStart, windowEnd }: Props) {
               `
             })
         }
+        <${CursorLine} />
       </div>
     </div>
   `

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -1,8 +1,12 @@
-// Observatory Metric Track (RFC-MASC-006 Phase 2a)
+// Observatory Metric Track (RFC-MASC-006 Phase 2a+2b)
 // Renders tool call success rate over time as an SVG line on shared time axis.
+// Phase 2b: mousemove updates cursor-store, CursorLine renders across track.
 
 import { html } from 'htm/preact'
+import { useRef } from 'preact/hooks'
 import type { ToolQualityHourlyPoint } from '../../api/dashboard'
+import { setCursorFromEvent, clearCursor } from './cursor-store'
+import { CursorLine } from './cursor-line'
 
 interface Props {
   points: ToolQualityHourlyPoint[]
@@ -16,6 +20,7 @@ function hourToMs(hour: string): number | null {
 }
 
 export function MetricTrack({ points, windowStart, windowEnd }: Props) {
+  const trackRef = useRef<HTMLDivElement | null>(null)
   const span = windowEnd - windowStart
   if (span <= 0) return null
 
@@ -54,7 +59,14 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
           </div>
         ` : html`<div class="text-[10px] text-text-dim">데이터 없음</div>`}
       </div>
-      <div class="relative flex-1 h-12 rounded-md bg-bg-1/40 border border-card-border/50">
+      <div
+        ref=${trackRef}
+        class="relative flex-1 h-12 rounded-md bg-bg-1/40 border border-card-border/50 cursor-crosshair"
+        onMouseMove=${(e: MouseEvent) => {
+          if (trackRef.current) setCursorFromEvent(e, trackRef.current, windowStart, windowEnd)
+        }}
+        onMouseLeave=${clearCursor}
+      >
         ${windowed.length === 0 ? html`
           <div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">
             hourly_trend 데이터 부족
@@ -92,6 +104,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
             })}
           </svg>
         `}
+        <${CursorLine} />
       </div>
     </div>
   `

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -31,6 +31,8 @@ import {
 } from '../../api/dashboard'
 import { EventTrack } from './event-track'
 import { MetricTrack } from './metric-track'
+import { ToolCallTrack } from './tool-call-track'
+import { cursorPosition } from './cursor-store'
 import { LoadingState } from '../common/feedback-state'
 
 // --- Time range utilities ---
@@ -229,15 +231,30 @@ export function Observatory() {
           windowStart=${data.windowStart}
           windowEnd=${data.windowEnd}
         />
+        <${ToolCallTrack}
+          events=${data.events}
+          windowStart=${data.windowStart}
+          windowEnd=${data.windowEnd}
+        />
         <${MetricTrack}
           points=${data.hourlyTrend}
           windowStart=${data.windowStart}
           windowEnd=${data.windowEnd}
         />
+        ${cursorPosition.value ? html`
+          <div class="mt-1 text-[10px] text-text-dim font-mono">
+            cursor: ${new Date(cursorPosition.value.ts).toLocaleTimeString()}
+            (${(cursorPosition.value.pct * 100).toFixed(1)}%)
+          </div>
+        ` : html`
+          <div class="mt-1 text-[10px] text-text-dim italic">
+            hover any track for cross-signal cursor
+          </div>
+        `}
       </div>
 
       <p class="text-[10px] text-text-dim italic">
-        Phase 2a 스켈레톤 — 더 많은 track(도구 호출, 메모리, autoresearch)과 cross-signal cursor는 Phase 2b+에서 추가됩니다.
+        Phase 2b — cross-signal cursor + tool calls track. 추가 track(메모리, autoresearch)과 drill-down은 이후 단계에서.
       </p>
     </div>
   `

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -32,6 +32,7 @@ import {
 import { EventTrack } from './event-track'
 import { MetricTrack } from './metric-track'
 import { ToolCallTrack } from './tool-call-track'
+import { CrossSignalReadout } from './cross-signal-readout'
 import { cursorPosition } from './cursor-store'
 import { LoadingState } from '../common/feedback-state'
 
@@ -241,20 +242,21 @@ export function Observatory() {
           windowStart=${data.windowStart}
           windowEnd=${data.windowEnd}
         />
-        ${cursorPosition.value ? html`
-          <div class="mt-1 text-[10px] text-text-dim font-mono">
-            cursor: ${new Date(cursorPosition.value.ts).toLocaleTimeString()}
-            (${(cursorPosition.value.pct * 100).toFixed(1)}%)
-          </div>
-        ` : html`
+        ${cursorPosition.value === null ? html`
           <div class="mt-1 text-[10px] text-text-dim italic">
-            hover any track for cross-signal cursor
+            hover any track for cross-signal readout
           </div>
-        `}
+        ` : null}
       </div>
 
+      <${CrossSignalReadout}
+        events=${data.events}
+        hourlyTrend=${data.hourlyTrend}
+        eventWindowMs=${Math.max(30_000, (data.windowEnd - data.windowStart) * 0.05)}
+      />
+
       <p class="text-[10px] text-text-dim italic">
-        Phase 2b — cross-signal cursor + tool calls track. 추가 track(메모리, autoresearch)과 drill-down은 이후 단계에서.
+        Phase 2c — cross-signal readout card. 추가 track(메모리, autoresearch)과 drill-down은 이후 단계에서.
       </p>
     </div>
   `

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -1,0 +1,107 @@
+// Observatory Tool Call Track (RFC-MASC-006 Phase 2b)
+// Renders tool call events (from telemetry) as markers, colored by outcome.
+
+import { html } from 'htm/preact'
+import { useRef } from 'preact/hooks'
+import type { TelemetryEntry } from '../../api/dashboard'
+import { setCursorFromEvent, clearCursor } from './cursor-store'
+import { CursorLine } from './cursor-line'
+
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  if (typeof entry.ts === 'number') return entry.ts * 1000
+  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
+  if (typeof entry.timestamp === 'number') return entry.timestamp
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+function isToolCall(entry: TelemetryEntry): boolean {
+  const src = typeof entry.source === 'string' ? entry.source : ''
+  return src === 'tool_call_io' || src === 'tool_usage'
+}
+
+function toolCallOutcome(entry: TelemetryEntry): 'success' | 'failure' | 'unknown' {
+  if (entry.success === true) return 'success'
+  if (entry.success === false) return 'failure'
+  const errorField = entry.error
+  if (errorField != null && errorField !== '') return 'failure'
+  return 'unknown'
+}
+
+function outcomeColor(outcome: ReturnType<typeof toolCallOutcome>): string {
+  switch (outcome) {
+    case 'success': return 'bg-emerald-400'
+    case 'failure': return 'bg-red-400'
+    default: return 'bg-text-dim'
+  }
+}
+
+function toolName(entry: TelemetryEntry): string {
+  if (typeof entry.tool_name === 'string') return entry.tool_name
+  if (typeof entry.name === 'string') return entry.name
+  return '?'
+}
+
+interface Props {
+  events: TelemetryEntry[]
+  windowStart: number
+  windowEnd: number
+}
+
+export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
+  const trackRef = useRef<HTMLDivElement | null>(null)
+  const span = windowEnd - windowStart
+  if (span <= 0) return null
+
+  const markers = events
+    .filter(isToolCall)
+    .map(entry => ({ entry, ts: entryTimestampMs(entry) }))
+    .filter((m): m is { entry: TelemetryEntry; ts: number } =>
+      m.ts !== null && m.ts >= windowStart && m.ts <= windowEnd,
+    )
+
+  const successCount = markers.filter(m => toolCallOutcome(m.entry) === 'success').length
+  const failureCount = markers.filter(m => toolCallOutcome(m.entry) === 'failure').length
+
+  return html`
+    <div class="flex items-center gap-3">
+      <div class="w-24 shrink-0">
+        <div class="text-[11px] font-semibold text-text-muted">도구 호출</div>
+        <div class="text-[10px] text-text-dim">
+          <span class="text-emerald-400">${successCount}</span>
+          <span class="text-text-dim/60 mx-0.5">·</span>
+          <span class="text-red-400">${failureCount}</span>
+        </div>
+      </div>
+      <div
+        ref=${trackRef}
+        class="relative flex-1 h-8 rounded-md bg-bg-1/40 border border-card-border/50 cursor-crosshair"
+        onMouseMove=${(e: MouseEvent) => {
+          if (trackRef.current) setCursorFromEvent(e, trackRef.current, windowStart, windowEnd)
+        }}
+        onMouseLeave=${clearCursor}
+      >
+        ${markers.length === 0
+          ? html`<div class="absolute inset-0 flex items-center justify-center text-[10px] text-text-dim">이 시간 범위에 도구 호출 없음</div>`
+          : markers.map(({ entry, ts }) => {
+              const pct = ((ts - windowStart) / span) * 100
+              const outcome = toolCallOutcome(entry)
+              const color = outcomeColor(outcome)
+              const name = toolName(entry)
+              return html`
+                <span
+                  class="absolute top-1 bottom-1 w-[3px] ${color} rounded-[1px] hover:w-1.5 transition-all"
+                  style="left: ${pct}%;"
+                  title=${`${new Date(ts).toLocaleTimeString()} · ${name} · ${outcome}`}
+                ></span>
+              `
+            })
+        }
+        <${CursorLine} />
+      </div>
+    </div>
+  `
+}


### PR DESCRIPTION
RFC-MASC-006 (#7050) Phase 2b — Observatory의 핵심 investigation primitive. Phase 2a (#7082 merged) 기반.

## 추가 기능

### 1. Cross-signal cursor

트랙 위 마우스가 이동하면 수직선이 **모든 트랙에 동시** 표시.

### 2. Tool Call track (신규)

텔레메트리 중 \`tool_call_io\` / \`tool_usage\` 소스만 필터. 성공/실패 색상 구분.

## 신규 파일

- \`cursor-store.ts\` — shared cursorPosition signal + setter
- \`cursor-line.ts\` — absolute 위치 수직선
- \`tool-call-track.ts\` — 도구 호출 전용 track

## 수정

- \`event-track.ts\` + \`metric-track.ts\`: mousemove 이벤트, CursorLine 삽입
- \`observatory.ts\`: ToolCallTrack 추가

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — zero errors
- [ ] CI green

## Refs

- RFC-MASC-006 (#7050)
- Phase 2a (#7082 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)