### PR TITLE
feat(dashboard): RFC-MASC-006 Phase 2c — cross-signal readout card

### DIFF
--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -1,0 +1,140 @@
+// Cross-signal readout card (RFC-MASC-006 Phase 2c)
+//
+// When the cursor is active, show aligned values across all tracks at the
+// cursor's time — the core "읽기" primitive of Observatory. Reads directly
+// from `cursorPosition` signal + track data passed by parent.
+
+import { html } from 'htm/preact'
+import type { TelemetryEntry, ToolQualityHourlyPoint } from '../../api/dashboard'
+import { cursorPosition } from './cursor-store'
+
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  if (typeof entry.ts === 'number') return entry.ts * 1000
+  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
+  if (typeof entry.timestamp === 'number') return entry.timestamp
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+function hourToMs(hour: string): number | null {
+  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function isToolCall(entry: TelemetryEntry): boolean {
+  const src = typeof entry.source === 'string' ? entry.source : ''
+  return src === 'tool_call_io' || src === 'tool_usage'
+}
+
+interface Props {
+  events: TelemetryEntry[]
+  hourlyTrend: ToolQualityHourlyPoint[]
+  /** Tolerance in ms for "nearby" event (both halves of cursor). */
+  eventWindowMs: number
+}
+
+function countEventsNear(
+  events: TelemetryEntry[],
+  cursorMs: number,
+  windowMs: number,
+  predicate?: (entry: TelemetryEntry) => boolean,
+): number {
+  const half = windowMs / 2
+  return events.filter(entry => {
+    if (predicate && !predicate(entry)) return false
+    const ts = entryTimestampMs(entry)
+    return ts !== null && Math.abs(ts - cursorMs) <= half
+  }).length
+}
+
+function nearestTrendPoint(
+  points: ToolQualityHourlyPoint[],
+  cursorMs: number,
+): ToolQualityHourlyPoint | null {
+  let best: { point: ToolQualityHourlyPoint; dist: number } | null = null
+  for (const point of points) {
+    const ts = hourToMs(point.hour)
+    if (ts === null) continue
+    const dist = Math.abs(ts - cursorMs)
+    if (best === null || dist < best.dist) best = { point, dist }
+  }
+  return best?.point ?? null
+}
+
+function Row({
+  label,
+  value,
+  tone = 'neutral',
+}: {
+  label: string
+  value: string | number
+  tone?: 'neutral' | 'ok' | 'warn' | 'bad'
+}) {
+  const toneClass =
+    tone === 'ok' ? 'text-emerald-400'
+      : tone === 'warn' ? 'text-amber-300'
+      : tone === 'bad' ? 'text-red-400'
+      : 'text-text-strong'
+  return html`
+    <div class="flex items-center justify-between gap-4 text-[11px]">
+      <span class="text-text-dim">${label}</span>
+      <span class="font-mono font-semibold ${toneClass}">${value}</span>
+    </div>
+  `
+}
+
+export function CrossSignalReadout({ events, hourlyTrend, eventWindowMs }: Props) {
+  const cursor = cursorPosition.value
+  if (cursor === null) return null
+
+  const totalEvents = countEventsNear(events, cursor.ts, eventWindowMs)
+  const toolCalls = countEventsNear(events, cursor.ts, eventWindowMs, isToolCall)
+  const toolFailures = countEventsNear(
+    events,
+    cursor.ts,
+    eventWindowMs,
+    entry => isToolCall(entry) && (entry.success === false || Boolean(entry.error)),
+  )
+  const trendPoint = nearestTrendPoint(hourlyTrend, cursor.ts)
+
+  const successRateTone: 'ok' | 'warn' | 'bad' | 'neutral' =
+    trendPoint == null ? 'neutral'
+      : trendPoint.success_rate >= 97 ? 'ok'
+      : trendPoint.success_rate >= 90 ? 'neutral'
+      : 'bad'
+
+  const windowLabel = eventWindowMs >= 60_000
+    ? `±${Math.round(eventWindowMs / 60_000 / 2)}m`
+    : `±${Math.round(eventWindowMs / 1000 / 2)}s`
+
+  return html`
+    <div class="rounded-lg border border-accent/20 bg-accent/5 px-3 py-2 shadow-sm">
+      <div class="mb-1.5 flex items-center justify-between">
+        <span class="text-[10px] uppercase tracking-widest text-accent font-semibold">cursor</span>
+        <span class="text-[11px] font-mono text-text-strong">
+          ${new Date(cursor.ts).toLocaleTimeString()}
+        </span>
+      </div>
+      <div class="grid grid-cols-2 gap-x-4 gap-y-1">
+        <${Row} label=${`이벤트 (${windowLabel})`} value=${totalEvents} />
+        <${Row}
+          label=${`도구 호출 (${windowLabel})`}
+          value=${toolFailures > 0 ? `${toolCalls} / ${toolFailures} 실패` : toolCalls}
+          tone=${toolFailures > 0 ? 'warn' : 'neutral'}
+        />
+        <${Row}
+          label="성공률 (최근 hour)"
+          value=${trendPoint != null ? `${trendPoint.success_rate.toFixed(1)}%` : '-'}
+          tone=${successRateTone}
+        />
+        <${Row}
+          label="최근 호출 건수"
+          value=${trendPoint != null ? trendPoint.calls : '-'}
+        />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -32,6 +32,7 @@ import {
 import { EventTrack } from './event-track'
 import { MetricTrack } from './metric-track'
 import { ToolCallTrack } from './tool-call-track'
+import { CrossSignalReadout } from './cross-signal-readout'
 import { cursorPosition } from './cursor-store'
 import { LoadingState } from '../common/feedback-state'
 
@@ -241,20 +242,21 @@ export function Observatory() {
           windowStart=${data.windowStart}
           windowEnd=${data.windowEnd}
         />
-        ${cursorPosition.value ? html`
-          <div class="mt-1 text-[10px] text-text-dim font-mono">
-            cursor: ${new Date(cursorPosition.value.ts).toLocaleTimeString()}
-            (${(cursorPosition.value.pct * 100).toFixed(1)}%)
-          </div>
-        ` : html`
+        ${cursorPosition.value === null ? html`
           <div class="mt-1 text-[10px] text-text-dim italic">
-            hover any track for cross-signal cursor
+            hover any track for cross-signal readout
           </div>
-        `}
+        ` : null}
       </div>
 
+      <${CrossSignalReadout}
+        events=${data.events}
+        hourlyTrend=${data.hourlyTrend}
+        eventWindowMs=${Math.max(30_000, (data.windowEnd - data.windowStart) * 0.05)}
+      />
+
       <p class="text-[10px] text-text-dim italic">
-        Phase 2b — cross-signal cursor + tool calls track. 추가 track(메모리, autoresearch)과 drill-down은 이후 단계에서.
+        Phase 2c — cross-signal readout card. 추가 track(메모리, autoresearch)과 drill-down은 이후 단계에서.
       </p>
     </div>
   `


### PR DESCRIPTION
RFC-MASC-006 (#7050) Phase 2c — Phase 2b (#7086) 위. Cursor가 활성일 때 **모든 signal 값을 한 카드에** 정렬 표시.

\`\`\`
╭──────────────────────────────────╮
│ cursor              09:47:32     │
│ 이벤트 (±90s)        23            │
│ 도구 호출 (±90s)     14 / 2 실패 🟡│
│ 성공률 (최근 hour)   87.3%     🔴 │
│ 최근 호출 건수       412           │
╰──────────────────────────────────╯
\`\`\`

## 핵심 결정

- **단일 card 접근** — track별 개별 tooltip 대신 하나의 통합 readout. "timeline 전체가 한 순간에 대해 뭘 말하는지"가 투자자 질문
- **Event window = range의 5%** (min 30s) — 좁으면 포착 못함, 넓으면 정보 흐림
- **Tone 자동 계산** — 실패 > 0 warn, success_rate <90% bad 등
- **Hidden when inactive** — cursor 없을 때 렌더 안 함

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — zero errors
- [ ] CI green
- [ ] 로컬 UI: track hover → readout 카드 표시, 시간 따라 값 갱신

## Refs

- RFC-MASC-006 (#7050)
- Phase 2a (#7082 merged), Phase 2b (#7086)

🤖 Generated with [Claude Code](https://claude.com/claude-code)