### PR TITLE
chore(telemetry): split silent drops from AfterTurn hook

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -325,14 +325,28 @@ let make_hooks
                "masc_provider_prefix_cache_read_tokens_total"
                ~delta:(Float.of_int cr) ()
          | None -> ());
-        (* Inference latency histogram for /metrics endpoint. *)
+        (* Inference latency histogram for /metrics endpoint.
+           Split observations into three buckets so we can tell "metric is
+           silent because no telemetry" apart from "metric is silent because
+           the hook isn't running". Without this split a histogram sum/count
+           of 0 is ambiguous between the two. *)
+        Prometheus.inc_counter
+          "masc_after_turn_hook_total"
+          ~labels:[("model", model)] ();
         (match response.telemetry with
          | Some t when t.request_latency_ms > 0 ->
            Prometheus.observe_histogram
              "masc_llm_inference_duration_seconds"
              ~labels:[("model", model)]
              (Float.of_int t.request_latency_ms /. 1000.0)
-         | _ -> ());
+         | Some _ ->
+           Prometheus.inc_counter
+             "masc_after_turn_telemetry_zero_latency_total"
+             ~labels:[("model", model)] ()
+         | None ->
+           Prometheus.inc_counter
+             "masc_after_turn_telemetry_missing_total"
+             ~labels:[("model", model)] ());
         Log.Keeper.info "keeper:%s turn=%d total_turns=%d model=%s tokens=%d"
           meta.name turn meta.runtime.usage.total_turns model total_tok;
         (* Emit per-turn cost event for task attribution.

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -168,6 +168,13 @@ let init () =
   in
   add "masc_mcp_requests_total" "Total MCP requests received" Counter;
   add "masc_llm_inference_duration_seconds" "LLM inference request duration in seconds" Histogram;
+  add "masc_after_turn_hook_total"
+    "Times the keeper AfterTurn hook ran (labeled by model). Divergence from \
+     masc_llm_inference_duration_seconds_count identifies missing telemetry." Counter;
+  add "masc_after_turn_telemetry_missing_total"
+    "AfterTurn responses where response.telemetry was None." Counter;
+  add "masc_after_turn_telemetry_zero_latency_total"
+    "AfterTurn responses where telemetry was present but request_latency_ms was 0." Counter;
   add "masc_tasks_total" "Total tasks processed" Counter;
   add "masc_errors_total" "Total errors" Counter;
   add "masc_active_agents" "Currently active agents" Gauge;


### PR DESCRIPTION
## Summary

Log + metric 기반 audit에서 발견한 grey-zone 계측 gap을 defensive하게 보강.

## Observation

서버 uptime 33분 동안:
- Live log: 11 keeper turns 확인 (`keeper:analyst turn=15`, `keeper:ani1999 turn=3`, ...)
- \`masc_llm_inference_duration_seconds_count = 0\`
- 동시에 \`analyst.decisions.jsonl\`에는 \`request_latency_ms: 80200, 12207, 10050\` 값 기록됨

= 같은 \`response.telemetry\` 데이터가 decisions.jsonl에는 도달하지만 Prometheus histogram에는 도달 안 함. 또는 도달하는데 \`request_latency_ms > 0\` 가드를 통과 안 함.

## Why this is a grey-zone bug

keeper_hooks_oas.ml:329-335

\`\`\`ocaml
(match response.telemetry with
 | Some t when t.request_latency_ms > 0 -> observe
 | _ -> ())   (* silent drop *)
\`\`\`

\`| _ -> ()\`는 두 경우를 구분 없이 버림:
1. \`telemetry = None\` (OAS가 telemetry를 안 보냄)
2. \`telemetry = Some _\` but \`latency = 0\` (telemetry는 있으나 측정 안 됨)
3. 또는 hook 자체가 호출 안 됨

히스토그램의 count=0을 봐도 어느 경우인지 진단 불가 → 책임 locus 불분명.

## Fix

3개 labeled counter 추가:
- \`masc_after_turn_hook_total{model}\` — AfterTurn 실행 횟수
- \`masc_after_turn_telemetry_missing_total{model}\` — telemetry=None
- \`masc_after_turn_telemetry_zero_latency_total{model}\` — latency=0

배포 후 divergence 관찰로 root cause locus 특정 가능:
- hook_total ≫ histogram_count, missing=0 → observe path 실패
- missing ≫ 0 → OAS telemetry 전파 문제
- zero_latency ≫ 0 → OAS latency 측정 문제

## Files

| File | Change |
|------|--------|
| \`lib/keeper/keeper_hooks_oas.ml\` | +13/-2 — 3-way match로 확장 |
| \`lib/prometheus.ml\` | +7 — 3 counter register |

## Test plan

- [x] \`dune build\` clean
- [ ] CI green
- [ ] 배포 후 keeper 활동 하에 counter 관찰 (PR merge → server restart → 10분 후 \`/metrics\` 조회)

## Context

Log-based audit + metric probing으로 발견. 이전 PR들 (#6935, #7018)이 "메모리 데이터 흐름을 관찰 가능하게"였다면, 이 PR은 "계측 자체가 작동하는지를 관찰 가능하게". Meta-observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)