### PR TITLE
chore(hebbian): correct fabricated research justifications in Phase 1-2 comments

### DIFF
--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -60,15 +60,19 @@ const shortAgentLabel = (name: string) => {
 const weightColor = (w: number) =>
   w >= 0.7 ? '#10b981' : w >= 0.4 ? '#f59e0b' : '#f87171'
 
-// Perceptual linearization: √weight maps linear data to perceived brightness.
-// Ghoniem et al. 2005 — in-cell encoding beats on-edge encoding for weight tasks.
+// √ compresses the high end so differences near 0 remain visible.
+// Floor 0.25 keeps low-weight cells distinguishable from empty (undefined)
+// cells drawn at #1e293b. Floor and range are arbitrary — picked by eye,
+// not derived from a perceptual model. Tune if empty/low contrast is wrong.
 const weightOpacity = (w: number) => 0.25 + 0.75 * Math.sqrt(Math.max(0, Math.min(1, w)))
 
 function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
   if (synapses.length === 0) return null
 
   // Sort by activity total (success + failure on either side) — hubs appear top-left.
-  // Canonical in Hebbian literature (Sadeh & Clopath, PNAS 2024): sort rows by a feature.
+  // Sorting the matrix by some feature is common in Hebbian literature
+  // (e.g. Sadeh & Clopath, PNAS 2024 sorts by stimulus tuning peak); activity
+  // total is a usage-frequency proxy chosen here because MASC has no stimulus.
   const activity = new Map<string, number>()
   synapses.forEach(s => {
     const n = s.success_count + s.failure_count
@@ -215,6 +219,9 @@ function WeightSparkline({ history }: { history?: Array<[number, number]> }) {
     .join(' ')
   const first = chronological[0]?.[1] ?? 0
   const last = chronological[n - 1]?.[1] ?? 0
+  // 0.02 is arbitrary — well under the typical strengthen/weaken step (~0.1
+  // at time of writing), so one learning event produces a decisive color
+  // while sub-threshold drift stays neutral. Not derived from a perceptual law.
   const trendColor = last > first + 0.02 ? '#10b981' : last < first - 0.02 ? '#f87171' : '#94a3b8'
   return html`
     <svg

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -31,7 +31,13 @@ type synapse = {
        vs weakening over time). *)
 }
 
-(** Cap for [weight_history]. Newer entries evict older ones. *)
+(** Cap for [weight_history]. Newer entries evict older ones.
+
+    30 is arbitrary — not derived from any learning-theory argument. It
+    roughly matches the dashboard sparkline pixel budget (80 px wide,
+    ~2.7 px per point) so the polyline renders with legible segments,
+    but the number was picked first and the rationale came after. Raise
+    it if you want longer trajectories; the JSON payload grows linearly. *)
 let history_cap = 30
 
 (** Prepend [(ts, w)] to [history] and trim to [history_cap].


### PR DESCRIPTION
## Summary

Self-audit follow-up to #7068. Three code comments attached academic citations to magic numbers those citations do not actually justify — rewrite them so later readers (human or AI) do not build on a fabricated base.

## Why

Caught during post-merge review of #7068:

- \`weightOpacity\` formula \`0.25 + 0.75·√w\` was labelled "perceptual linearization (Ghoniem et al. 2005)". Ghoniem justifies the *matrix layout* structural choice, not an opacity curve; no perceptual paper derives those specific coefficients.
- The matrix sort comment called activity-total "canonical in Hebbian literature (Sadeh & Clopath, PNAS 2024)". That paper sorts by stimulus tuning peak, not usage frequency. The general principle (sort by *some* feature) is still attributable, but the specific feature is mine.
- Sparkline trend dead-zone \`±0.02\` was described in PR discussion as a "Weber-Fechner practical derivative" — it is not; it was picked by feel.
- \`history_cap = 30\` had no rationale at all in the comment; any sparkline-width rationale came after the pick.

This is the same anti-pattern flagged in my local feedback memory: attaching fake research citations to arbitrary constants. Left in place, it misleads later readers and can be cited as if derived.

## Product impact

No behavior change. Comment-only edits. Matrix, sparkline, ranking, backend all render and compute identically to the state after #7068.

## Changes

### \`dashboard/src/components/memory-subsystems.ts\`

| Location | Before | After |
|----------|--------|-------|
| \`weightOpacity\` | "Perceptual linearization / Ghoniem 2005" | Describes what √ does (compresses high end), why the floor (distinguish from empty cells), and explicitly marks coefficients as eye-picked. |
| \`HebbianMatrix\` sort | "Canonical (Sadeh & Clopath)" | Distinguishes general principle (sort by a feature — cited) from specific choice (activity total — usage-based proxy, chosen here). |
| \`WeightSparkline\` trend | (no comment) | States 0.02 is arbitrary, smaller than the typical strengthen/weaken step so one event produces a decisive color. |

### \`lib/hebbian_eio.ml\`

- \`history_cap = 30\`: states the number is arbitrary, notes it roughly matches the sparkline pixel budget, and acknowledges the rationale came after the pick.

## Evidence

| Check | Result |
|-------|--------|
| \`dune build\` | clean |
| \`dune exec test/test_hebbian_eio.exe\` | 14/14 pass |
| \`pnpm typecheck\` | clean |
| \`pnpm lint\` | clean |
| \`pnpm build\` | not re-run (comment-only in TS; identical output) |

## Review evidence

Self-audit triggered by the user question "가짜 휴리스틱인지 아닌지 체크 괴상한 하드코딩인지 아닌지 체크". Problematic comments enumerated and classified before this PR was opened.

## Linked issue

No issue; follow-up to merged PR #7068.