### PR TITLE
fix(thompson_sampling): drain pending votes at sampling entry (#7041)

### DIFF
--- a/lib/thompson_sampling.ml
+++ b/lib/thompson_sampling.ml
@@ -444,6 +444,14 @@ let record_quality_signal ~agent_name ~(verdict : Post_verifier.verdict) =
 (** {1 Selection Algorithm} *)
 
 let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
+  (* Drain any pending votes so Beta posteriors reflect recorded feedback
+     before sampling. [record_vote] batches into [pending_votes], and
+     without this flush the batched evidence never reaches [stats_table] —
+     the sampler would read only the initial priors and votes are silently
+     discarded over time. This sampling entry point is the natural "tick
+     end" the .mli refers to. Safe to call under no lock: [flush] acquires
+     [ts_mu] itself. *)
+  flush_pending_votes ();
   (* Initialize stats for all agents *)
   List.iter init_agent agents;
 


### PR DESCRIPTION
## Summary

Fixes #7041. `Thompson_sampling.flush_pending_votes` was documented ("call at tick end") but never called from production — only from tests. Every up/down vote recorded by `tool_task` / `board_votes` accumulated in `pending_votes` and was silently discarded as far as the Beta posterior was concerned.

## Change

One call added at the top of `select_with_feedback`, the sampling entry point invoked on every keeper tick:

```ocaml
let select_with_feedback ~agents ~max_n ~pending_triggers ~tick_interval_s =
  flush_pending_votes ();
  List.iter init_agent agents;
  ...
```

Consumers call `select_with_feedback` on the keeper tick, so everything recorded since the previous tick lands in the posterior before the sampler reads it. This is the natural "tick end" the `.mli` comment already refers to.

## Why this location (vs alternatives from the issue)

| Candidate | Picked? | Reason |
|-----------|---------|--------|
| Keeper heartbeat tick | indirect | Achieved by routing through `select_with_feedback` which is already called per tick — no new coupling from keeper → thompson. |
| Dedicated background fiber | no | Adds a lifecycle to manage (start/stop, error handling). Flushing on read needs no lifecycle. |
| On read path (sample/get_stats) | yes | `select_with_feedback` is the read path. Single-agent `get_stats` is recursive from `flush_pending_votes` itself, so not there. |
| Shutdown hook | no | Loses data on crash per issue description. |

## Test plan

- [x] `dune build --root . lib` — 0 errors
- [x] `test/test_thompson_sampling.exe` — 28/28 pass
- No new test: the issue's defect wasn't a logic bug in `flush_pending_votes` itself but its absence at the call site. Adding coverage would require stubbing the entire sampling pipeline. Existing tests already exercise `flush_pending_votes` end-to-end.

## Concurrency

`flush_pending_votes` acquires `ts_mu` itself. `select_with_feedback` doesn't hold the mutex at this call site (it calls `init_agent` / `get_stats` which each acquire/release independently). No deadlock introduced.

Closes #7041

🤖 Generated with [Claude Code](https://claude.com/claude-code)
