### PR TITLE
feat(keeper): typed Unhealthy reasons for provider health

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -275,7 +275,26 @@ let decision_pipeline_to_mermaid
 (* Cascade FSM Mermaid diagram                                      *)
 (* ================================================================ *)
 
-type provider_health = [`Healthy | `Unhealthy | `Unknown]
+type unhealthy_reason =
+  [ `Saturated
+  | `Unreachable
+  | `Rate_limited
+  | `Timeout
+  | `Other of string
+  ]
+
+type provider_health =
+  [ `Healthy
+  | `Unhealthy of unhealthy_reason
+  | `Unknown
+  ]
+
+let unhealthy_reason_label = function
+  | `Saturated -> "saturated"
+  | `Unreachable -> "unreachable"
+  | `Rate_limited -> "rate_limited"
+  | `Timeout -> "timeout"
+  | `Other s -> s
 
 let cascade_fsm_to_mermaid
     ?(provider_health : (string * provider_health) list option)
@@ -330,10 +349,15 @@ let cascade_fsm_to_mermaid
   p "    class Accept ok\n";
   p "    class AcceptExhaust warn\n";
   p "    class Exhausted err\n";
-  (* Provider health styling: unhealthy providers get warn class. *)
+  (* Provider health styling: unhealthy providers get warn class and
+     a note listing the typed reason (Saturated/Unreachable/...) so
+     the operator sees *why* the provider is marked down. *)
   List.iteri (fun i label ->
     match health_for label with
-    | `Unhealthy -> p "    class P%d warn\n" i
+    | `Unhealthy reason ->
+      p "    class P%d warn\n" i;
+      p "    note right of P%d: unhealthy: %s\n" i
+        (unhealthy_reason_label reason)
     | `Unknown -> p "    class P%d dim\n" i
     | `Healthy -> ()
   ) models;

--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -73,10 +73,28 @@ val decision_pipeline_to_mermaid :
   unit ->
   string
 
+(** Reasons a provider may be [Unhealthy].
+    Each constructor corresponds to a distinguishable failure signal
+    the runtime can record against a provider entry. Keep this list
+    closed — new reasons require dashboard+spec updates. *)
+type unhealthy_reason =
+  [ `Saturated       (** slot pool full, no capacity left *)
+  | `Unreachable     (** connect/DNS failure, provider not responding *)
+  | `Rate_limited    (** 429 / quota exhausted *)
+  | `Timeout         (** request did not complete within deadline *)
+  | `Other of string (** free-form reason for signals we do not yet categorise *)
+  ]
+
 (** Provider health surfaced in the Cascade FSM render.
     Mirrors [phealth] in CascadeLiveness.tla. [Unknown] covers the case
-    where the runtime has no recent sample. *)
-type provider_health = [`Healthy | `Unhealthy | `Unknown]
+    where the runtime has no recent sample. [Unhealthy] carries a
+    typed reason so the dashboard can distinguish saturation vs
+    unreachability vs rate limiting without parsing free text. *)
+type provider_health =
+  [ `Healthy
+  | `Unhealthy of unhealthy_reason
+  | `Unknown
+  ]
 
 (** Generate a Mermaid stateDiagram-v2 for the Cascade FSM.
     Shows the provider failover chain with accept/reject/exhaustion

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -138,6 +138,50 @@ let test_audit_ring_and_flag () =
    which lives in masc_room. Test will be added when Heartbeat_smart
    moves to masc_core (room cleanup issue). Verified locally. *)
 
+(* ── Provider Health Reason Rendering ────────────────── *)
+
+let substring_present ~haystack ~needle =
+  let hl = String.length haystack in
+  let nl = String.length needle in
+  if nl > hl then false
+  else
+    let rec loop i =
+      if i + nl > hl then false
+      else if String.sub haystack i nl = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let test_cascade_mermaid_renders_saturated_reason () =
+  let out = DA.cascade_fsm_to_mermaid
+      ~provider_health:[("alpha", `Unhealthy `Saturated)]
+      ~models:["alpha"; "beta"]
+      ~last_provider_result:None
+      ()
+  in
+  check bool "saturated reason appears in note"
+    true (substring_present ~haystack:out ~needle:"unhealthy: saturated")
+
+let test_cascade_mermaid_renders_other_reason () =
+  let out = DA.cascade_fsm_to_mermaid
+      ~provider_health:[("beta", `Unhealthy (`Other "custom-signal"))]
+      ~models:["alpha"; "beta"]
+      ~last_provider_result:None
+      ()
+  in
+  check bool "other reason string passes through"
+    true (substring_present ~haystack:out ~needle:"unhealthy: custom-signal")
+
+let test_cascade_mermaid_healthy_no_reason_note () =
+  let out = DA.cascade_fsm_to_mermaid
+      ~provider_health:[("alpha", `Healthy)]
+      ~models:["alpha"]
+      ~last_provider_result:(Some "alpha")
+      ()
+  in
+  check bool "healthy provider does not emit unhealthy note"
+    false (substring_present ~haystack:out ~needle:"unhealthy")
+
 (* ── Test Suite ──────────────────────────────────────── *)
 
 let () =
@@ -166,5 +210,10 @@ let () =
     ];
     "decision_audit", [
       test_case "ring capacity and feature flag" `Quick test_audit_ring_and_flag;
+    ];
+    "provider_health_reason", [
+      test_case "saturated reason in note" `Quick test_cascade_mermaid_renders_saturated_reason;
+      test_case "other reason passes through" `Quick test_cascade_mermaid_renders_other_reason;
+      test_case "healthy has no unhealthy note" `Quick test_cascade_mermaid_healthy_no_reason_note;
     ];
   ]


### PR DESCRIPTION
## Summary
- `provider_health` 타입을 `[Healthy | Unhealthy of reason | Unknown]`으로 확장 — `Saturated | Unreachable | Rate_limited | Timeout | Other of string` 5종 reason
- Mermaid cascade diagram에 reason label을 `note right of P_i`로 표시
- 기존 wiring site는 `Healthy | Unknown`만 생산 — backward compatible. Detection wiring은 후속 PR

## Test plan
- [x] `test_decision_pipeline` 18/18 pass (신규 3개: saturated note, Other passthrough, healthy no-note)
- [ ] CI green

Part of RFC-0003 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)