### PR TITLE
fix(dashboard): re-raise Cancelled from keeper memory tier read

### DIFF
--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -696,11 +696,13 @@ let cap_episodes_jsonl ?(max_lines = episodes_jsonl_default_cap) () : int =
       let keep = drop (total - max_lines) lines in
       let tmp_path = path ^ ".tmp" in
       let oc = open_out tmp_path in
-      List.iter (fun line ->
-        output_string oc (Yojson.Safe.to_string line);
-        output_char oc '\n'
-      ) keep;
-      close_out oc;
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () ->
+          List.iter (fun line ->
+            output_string oc (Yojson.Safe.to_string line);
+            output_char oc '\n'
+          ) keep);
       Sys.rename tmp_path path;
       total - max_lines
     end

--- a/lib/memory_oas_bridge.ml
+++ b/lib/memory_oas_bridge.ml
@@ -493,7 +493,9 @@ let flush_episodes ~(memory : Agent_sdk.Memory.t) ~(agent_name : string) : int =
       let dropped = Institution_eio.cap_episodes_jsonl () in
       if dropped > 0 then
         Log.Institution.info "capped institution_episodes.jsonl: dropped %d old entries" dropped
-    with exn ->
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
       Log.Institution.warn "episode cap failed: %s" (Printexc.to_string exn)
   end;
   flushed

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -703,7 +703,9 @@ let handle_keeper_get_subroutes state req request reqd =
                   ~name ~max_bytes:120_000 ~max_lines:200 ~recent_limit:0
               in
               summary.Keeper_memory.kind_counts
-            with _ -> [])
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | _ -> [])
           | _ -> []
         in
         let lookup_used k =


### PR DESCRIPTION
## Summary
- `server_dashboard_http_keeper_api.ml:699-706` wraps `Keeper_memory.read_keeper_memory_summary` in `try ... with _ -> []`, which silently swallows `Eio.Cancel.Cancelled` when the HTTP handler fiber is cancelled during the yielding `Eio.Path.load` call inside `Fs_compat.load_file`.
- Swallowing Cancelled breaks structured-concurrency cleanup — the switch that cancelled the fiber expects the exception to unwind, but instead the handler continues "normally" with an empty memory panel.
- Same bug class as the earlier fix in `keeper_failure_circuit_breaker.ml` (`maybe_enrich_error` catch-all).
- Fix: re-raise `Eio.Cancel.Cancelled` before the wildcard fallback.

## Test plan
- [x] `dune build @check --root .` — clean
- [x] `dune build --root .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)