### PR TITLE
feat(dashboard): RFC-MASC-006 Phase 2d — click drill-down detail pane

### DIFF
--- a/dashboard/src/components/observatory/detail-pane.ts
+++ b/dashboard/src/components/observatory/detail-pane.ts
@@ -1,0 +1,108 @@
+// Observatory detail pane (RFC-MASC-006 Phase 2d)
+//
+// Click drill-down: when a track marker is clicked, detailSelection updates
+// and this pane renders the raw TelemetryEntry alongside key metadata
+// (source, timestamp, keeper, outcome).  Close button clears selection.
+
+import { html } from 'htm/preact'
+import type { TelemetryEntry } from '../../api/dashboard'
+import { detailSelection, clearSelection, type DetailSelection } from './detail-selection-store'
+
+function selectionTitle(selection: DetailSelection): string {
+  const source = typeof selection.entry.source === 'string' ? selection.entry.source : '?'
+  const eventType = typeof selection.entry.event_type === 'string' ? selection.entry.event_type : ''
+  if (selection.kind === 'tool_call') {
+    const name = typeof selection.entry.tool_name === 'string'
+      ? selection.entry.tool_name
+      : (typeof selection.entry.name === 'string' ? selection.entry.name : '?')
+    return `도구 · ${name}`
+  }
+  return eventType ? `${source}:${eventType}` : source
+}
+
+function outcomeTag(entry: TelemetryEntry): { label: string; tone: 'ok' | 'bad' | 'neutral' } | null {
+  if (entry.success === true) return { label: 'success', tone: 'ok' }
+  if (entry.success === false) return { label: 'failure', tone: 'bad' }
+  const err = entry.error
+  if (err != null && err !== '') return { label: 'error', tone: 'bad' }
+  return null
+}
+
+function toneClass(tone: 'ok' | 'bad' | 'neutral'): string {
+  if (tone === 'ok') return 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30'
+  if (tone === 'bad') return 'bg-red-500/15 text-red-300 border-red-500/30'
+  return 'bg-white/5 text-text-dim border-card-border'
+}
+
+function keeperOf(entry: TelemetryEntry): string | null {
+  if (typeof entry.keeper === 'string' && entry.keeper !== '') return entry.keeper
+  if (typeof entry.keeper_id === 'string' && entry.keeper_id !== '') return entry.keeper_id
+  return null
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return html`
+    <div class="flex items-baseline gap-2 text-[11px]">
+      <span class="w-20 shrink-0 text-text-dim">${label}</span>
+      <span class="font-mono text-text-strong break-all">${value}</span>
+    </div>
+  `
+}
+
+function formatJson(entry: TelemetryEntry): string {
+  try {
+    return JSON.stringify(entry, null, 2)
+  } catch {
+    return String(entry)
+  }
+}
+
+export function DetailPane() {
+  const selection = detailSelection.value
+  if (selection === null) return null
+
+  const outcome = outcomeTag(selection.entry)
+  const keeper = keeperOf(selection.entry)
+  const source = typeof selection.entry.source === 'string' ? selection.entry.source : null
+
+  return html`
+    <div class="rounded-lg border border-accent/30 bg-bg-0/60 shadow-sm">
+      <div class="flex items-center justify-between border-b border-card-border px-3 py-2">
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] uppercase tracking-widest text-accent font-semibold">상세</span>
+          <span class="text-[12px] font-semibold text-text-strong">${selectionTitle(selection)}</span>
+          ${outcome ? html`
+            <span class="rounded-full border px-2 py-0.5 text-[10px] font-mono ${toneClass(outcome.tone)}">
+              ${outcome.label}
+            </span>
+          ` : null}
+        </div>
+        <button
+          type="button"
+          class="rounded px-2 py-0.5 text-[11px] text-text-dim hover:text-text-strong hover:bg-white/5"
+          onClick=${clearSelection}
+          aria-label="상세 패널 닫기"
+        >
+          ✕
+        </button>
+      </div>
+      <div class="grid grid-cols-1 gap-1.5 px-3 py-2 md:grid-cols-2">
+        <${MetaRow} label="시각" value=${new Date(selection.ts).toLocaleString()} />
+        ${source ? html`<${MetaRow} label="source" value=${source} />` : null}
+        ${keeper ? html`<${MetaRow} label="keeper" value=${keeper} />` : null}
+        ${typeof selection.entry.session_id === 'string' ? html`
+          <${MetaRow} label="session" value=${selection.entry.session_id} />
+        ` : null}
+        ${typeof selection.entry.operation_id === 'string' ? html`
+          <${MetaRow} label="operation" value=${selection.entry.operation_id} />
+        ` : null}
+      </div>
+      <details class="border-t border-card-border">
+        <summary class="cursor-pointer px-3 py-1.5 text-[11px] text-text-dim hover:text-text-strong">
+          raw entry (JSON)
+        </summary>
+        <pre class="max-h-64 overflow-auto px-3 py-2 text-[10px] font-mono text-text-strong bg-black/30">${formatJson(selection.entry)}</pre>
+      </details>
+    </div>
+  `
+}

--- a/dashboard/src/components/observatory/detail-selection-store.ts
+++ b/dashboard/src/components/observatory/detail-selection-store.ts
@@ -1,0 +1,25 @@
+// Observatory drill-down selection store (RFC-MASC-006 Phase 2d)
+//
+// Separate from cursor-store on purpose:
+//   - cursor = ephemeral (hover, clears on mouseleave) → "overview"
+//   - selection = persistent (click, clears on explicit close/next click) → "deep dive"
+//
+// Tracks dispatch entity selections here; DetailPane reads this signal and
+// renders raw entry plus metadata for the selected point.
+
+import { signal, type Signal } from '@preact/signals'
+import type { TelemetryEntry } from '../../api/dashboard'
+
+export type DetailSelection =
+  | { kind: 'event'; entry: TelemetryEntry; ts: number }
+  | { kind: 'tool_call'; entry: TelemetryEntry; ts: number }
+
+export const detailSelection: Signal<DetailSelection | null> = signal(null)
+
+export function selectEntity(selection: DetailSelection): void {
+  detailSelection.value = selection
+}
+
+export function clearSelection(): void {
+  detailSelection.value = null
+}

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -1,12 +1,14 @@
-// Observatory Event Track (RFC-MASC-006 Phase 2a+2b)
+// Observatory Event Track (RFC-MASC-006 Phase 2a+2b+2d)
 // Renders discrete telemetry events as vertical markers on a shared time axis.
 // Phase 2b: mousemove updates cursor-store, CursorLine renders across track.
+// Phase 2d: click marker → selectEntity → DetailPane opens.
 
 import { html } from 'htm/preact'
 import { useRef } from 'preact/hooks'
 import type { TelemetryEntry } from '../../api/dashboard'
 import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
+import { selectEntity, detailSelection } from './detail-selection-store'
 
 function entryTimestampMs(entry: TelemetryEntry): number | null {
   if (typeof entry.ts === 'number') return entry.ts * 1000
@@ -72,11 +74,20 @@ export function EventTrack({ events, windowStart, windowEnd }: Props) {
               const pct = ((ts - windowStart) / span) * 100
               const color = sourceColor(typeof entry.source === 'string' ? entry.source : undefined)
               const label = eventLabel(entry)
+              const selected = detailSelection.value
+              const isSelected = selected !== null
+                && selected.kind === 'event'
+                && selected.entry === entry
+              const ringClass = isSelected ? 'ring-2 ring-accent ring-offset-1 ring-offset-bg-1' : ''
               return html`
                 <span
-                  class="absolute top-1 bottom-1 w-[2px] ${color} hover:w-1 transition-all cursor-pointer"
+                  class="absolute top-1 bottom-1 w-[2px] ${color} hover:w-1 transition-all cursor-pointer ${ringClass}"
                   style="left: ${pct}%;"
                   title=${`${new Date(ts).toLocaleTimeString()} · ${label}`}
+                  onClick=${(e: MouseEvent) => {
+                    e.stopPropagation()
+                    selectEntity({ kind: 'event', entry, ts })
+                  }}
                 ></span>
               `
             })

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -33,6 +33,7 @@ import { EventTrack } from './event-track'
 import { MetricTrack } from './metric-track'
 import { ToolCallTrack } from './tool-call-track'
 import { CrossSignalReadout } from './cross-signal-readout'
+import { DetailPane } from './detail-pane'
 import { cursorPosition } from './cursor-store'
 import { LoadingState } from '../common/feedback-state'
 
@@ -255,8 +256,10 @@ export function Observatory() {
         eventWindowMs=${Math.max(30_000, (data.windowEnd - data.windowStart) * 0.05)}
       />
 
+      <${DetailPane} />
+
       <p class="text-[10px] text-text-dim italic">
-        Phase 2c — cross-signal readout card. 추가 track(메모리, autoresearch)과 drill-down은 이후 단계에서.
+        Phase 2d — click drill-down. 추가 track(메모리, autoresearch)은 이후 단계에서.
       </p>
     </div>
   `

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -1,11 +1,13 @@
-// Observatory Tool Call Track (RFC-MASC-006 Phase 2b)
+// Observatory Tool Call Track (RFC-MASC-006 Phase 2b+2d)
 // Renders tool call events (from telemetry) as markers, colored by outcome.
+// Phase 2d: click marker → selectEntity → DetailPane opens.
 
 import { html } from 'htm/preact'
 import { useRef } from 'preact/hooks'
 import type { TelemetryEntry } from '../../api/dashboard'
 import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
+import { selectEntity, detailSelection } from './detail-selection-store'
 
 function entryTimestampMs(entry: TelemetryEntry): number | null {
   if (typeof entry.ts === 'number') return entry.ts * 1000
@@ -91,11 +93,20 @@ export function ToolCallTrack({ events, windowStart, windowEnd }: Props) {
               const outcome = toolCallOutcome(entry)
               const color = outcomeColor(outcome)
               const name = toolName(entry)
+              const selected = detailSelection.value
+              const isSelected = selected !== null
+                && selected.kind === 'tool_call'
+                && selected.entry === entry
+              const ringClass = isSelected ? 'ring-2 ring-accent ring-offset-1 ring-offset-bg-1' : ''
               return html`
                 <span
-                  class="absolute top-1 bottom-1 w-[3px] ${color} rounded-[1px] hover:w-1.5 transition-all"
+                  class="absolute top-1 bottom-1 w-[3px] ${color} rounded-[1px] hover:w-1.5 transition-all cursor-pointer ${ringClass}"
                   style="left: ${pct}%;"
                   title=${`${new Date(ts).toLocaleTimeString()} · ${name} · ${outcome}`}
+                  onClick=${(e: MouseEvent) => {
+                    e.stopPropagation()
+                    selectEntity({ kind: 'tool_call', entry, ts })
+                  }}
                 ></span>
               `
             })


### PR DESCRIPTION
## Summary
- Observatory에 click drill-down 기능 추가 (Phase 2d)
- event-track / tool-call-track 마커 클릭 → 상세 패널(DetailPane) 표시
- 선택 상태는 cursor(hover, ephemeral)와 분리된 persistent signal
- 상세 패널: metadata grid + success/failure badge + 접이식 raw JSON

## 변경 파일
- `detail-selection-store.ts` (신규): DetailSelection union + signal
- `detail-pane.ts` (신규): 선택 entity의 metadata + raw JSON 뷰
- `event-track.ts`: click handler + selection ring highlight
- `tool-call-track.ts`: click handler + selection ring highlight
- `observatory.ts`: DetailPane 렌더링 추가

## Investigation primitive chain
- **Phase 2b**: hover → cross-signal cursor
- **Phase 2c**: cursor snapshot → aligned readout card
- **Phase 2d**: click → drill-down detail pane (raw entry)

## Test plan
- [ ] tsc --noEmit: 0 errors
- [ ] event-track marker 클릭 시 DetailPane 표시 확인
- [ ] tool-call-track marker 클릭 시 DetailPane 표시 확인
- [ ] 선택된 marker에 ring highlight 표시
- [ ] ✕ 닫기 버튼으로 DetailPane dismiss
- [ ] hover cursor와 selection이 독립 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)