### PR TITLE
fix(evidence): surface collision_warnings as counter + warn log (#7031)

### DIFF
--- a/lib/keeper/keeper_evidence.ml
+++ b/lib/keeper/keeper_evidence.ml
@@ -94,6 +94,15 @@ let capture_turn_evidence
       Keeper_file_tracker.record_turn_files ~keeper_name ~files:status_lines
     else []
   in
+  if collision_warnings <> [] then begin
+    let n = List.length collision_warnings in
+    Prometheus.inc_counter "masc_keeper_collision_detected_total"
+      ~labels:[("keeper", keeper_name)] ();
+    Log.Keeper.warn
+      "evidence: %s has %d file collision(s) with other keeper(s) — \
+       overlapping writes may corrupt shared state"
+      keeper_name n
+  end;
   let prev_evidence_hash = get_prev_hash ~keeper_name ~trace_id in
   let ts = Types.now_iso () in
   let evidence_body = `Assoc ([


### PR DESCRIPTION
## Summary

Fixes #7031. Promotes `collision_warnings` from silent JSON evidence to observable Prometheus counter + warn-level log.

## Problem

`collision_warnings` were computed by `Keeper_file_tracker.record_turn_files` and embedded in evidence JSON (`evidence/turn_NNN.json`), but no gate, policy, counter, or log line ever read them. Operators had no visibility into keepers writing to the same files simultaneously.

## Change

In `keeper_evidence.ml`, after `collision_warnings` is computed:

```ocaml
if collision_warnings <> [] then begin
  Prometheus.inc_counter "masc_keeper_collision_detected_total"
    ~labels:[("keeper", keeper_name)] ();
  Log.Keeper.warn
    "evidence: %s has %d file collision(s) with other keeper(s)"
    keeper_name n
end;
```

## What is NOT in this PR

Write-blocking policy (force worktree, pause the colliding keeper, or conflict resolution). That is a design decision tracked in #7032 as a follow-up.

## Test plan

- [x] `dune build --root . lib` — 0 errors
- No new test: the change is a 2-line counter+log emit in a function that already has integration tests covering evidence capture. Adding a unit test would require mocking the file tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
