### PR TITLE
refactor(keeper): rename guard_penalty_this_cycle → guard_penalty_total

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -916,7 +916,7 @@ let keeper_config_json (config : Room.config) (name : string)
         Keeper_decision_audit.decision_pipeline_to_mermaid
           ?tool_policy_mode
           ?turn_outcome
-          ~guard_penalty_this_cycle:stats.guard_penalties_total
+          ~guard_penalty_total:stats.guard_penalties_total
           ~phase
           ~thompson_alpha:stats.alpha
           ~thompson_beta:stats.beta

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -198,7 +198,7 @@ let flush_if_needed ~base_path ~keeper_name =
 (* ================================================================ *)
 
 let decision_pipeline_to_mermaid
-    ?(guard_penalty_this_cycle : int option)
+    ?(guard_penalty_total : int option)
     ?(tool_policy_mode : [`Preset of string | `Custom] option)
     ?(turn_outcome : [`Ok | `Failed | `Blocked] option)
     ~(phase : Keeper_state_machine.phase)
@@ -246,7 +246,7 @@ let decision_pipeline_to_mermaid
      p "    class Running off\n";
      p "    class Failing off\n");
   p "\n";
-  let penalty_str = match guard_penalty_this_cycle with
+  let penalty_str = match guard_penalty_total with
     | Some n -> string_of_int n
     | None -> "n/a"
   in

--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -56,13 +56,13 @@ val ring_capacity : unit -> int
     Shows the Guard→Thompson→ToolPolicy feedback loop with current
     phase highlighted and Thompson score annotated.
 
-    Optional parameters surface per-cycle Decision Pipeline state from
-    [KeeperDecisionPipeline.tla] (state variables: guard_penalties_this_cycle,
-    tool_policy selection, turn_outcome). When omitted, the note block
-    shows "n/a" for the missing field — callers can adopt the new
-    parameters incrementally without breaking the render. *)
+    Optional parameters surface Decision Pipeline state from
+    [KeeperDecisionPipeline.tla] and Thompson Sampling stats.
+    [guard_penalty_total] is the cumulative count of heartbeat cycles
+    in which the guardrail fired (1/cycle cap enforced by the caller).
+    When omitted, the note block shows "n/a". *)
 val decision_pipeline_to_mermaid :
-  ?guard_penalty_this_cycle:int ->
+  ?guard_penalty_total:int ->
   ?tool_policy_mode:[`Preset of string | `Custom] ->
   ?turn_outcome:[`Ok | `Failed | `Blocked] ->
   phase:Keeper_state_machine.phase ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -632,7 +632,7 @@ let handle_keeper_get_subroutes state req request reqd =
         Keeper_decision_audit.decision_pipeline_to_mermaid
           ?tool_policy_mode
           ?turn_outcome
-          ~guard_penalty_this_cycle:stats.guard_penalties_total
+          ~guard_penalty_total:stats.guard_penalties_total
           ~phase:current
           ~thompson_alpha:stats.alpha
           ~thompson_beta:stats.beta


### PR DESCRIPTION
## Summary
- `?guard_penalty_this_cycle` → `?guard_penalty_total` (4 files, pure rename)
- OCaml arg는 누적 카운터(Thompson stats), TLA+ var는 per-cycle counter — semantic 정렬
- Docstring에 "cumulative count of heartbeat cycles in which the guardrail fired" 명시

## Test plan
- [x] `dune build @check` pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)