### PR TITLE
fix(memory_bank): filter [SYNTHETIC] and no-op progress from memory candidates (#7034)

### DIFF
--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -64,6 +64,8 @@ let is_meaningful_memory_text (s : string) : bool =
     "미정";
   ] in
   not (List.mem key placeholders)
+  && not (String_util.contains_substring s "[SYNTHETIC]")
+  && not (String.equal (String.trim s) "No tools used this generation")
 
 let memory_candidates_from_snapshot
     (snapshot : keeper_state_snapshot) : (string * string * int) list =


### PR DESCRIPTION
## Summary

Fixes #7034. Filters `[SYNTHETIC]` placeholder notes and "No tools used this generation" filler from memory bank recall.

## Problem

`synthesize_state_from_run_result` generates `[SYNTHETIC]` decisions and filler progress entries every heartbeat tick when the LLM doesn't produce a STATE block. These passed `is_meaningful_memory_text` and accumulated unbounded — 220+ notes in `masc-improver.memory.jsonl`, top 10 all noise.

## Change

Two conditions added to `is_meaningful_memory_text`:

```ocaml
&& not (String_util.contains_substring s "[SYNTHETIC]")
&& not (String.equal (String.trim s) "No tools used this generation")
```

## What stays

- `[SYNTHETIC]` entries still reach evidence JSON and telemetry
- `synthesize_state_from_run_result` still produces them (needed for generation continuity tracking)
- Hash-based duplicate detection for non-synthetic notes is a follow-up

## Test plan

- [x] `dune build --root . lib` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
