### PR TITLE
feat(dashboard): RFC-MASC-006 Phase 3a — z-score anomaly highlight

### DIFF
--- a/dashboard/src/components/observatory/anomaly-utils.ts
+++ b/dashboard/src/components/observatory/anomaly-utils.ts
@@ -1,0 +1,66 @@
+// Observatory anomaly detection (RFC-MASC-006 Phase 3a)
+//
+// Compute z-scores over hourly_trend success_rate values.
+// Points with |z| > threshold are flagged as anomalies.
+// Minimum 3 data points required for meaningful statistics.
+
+import type { ToolQualityHourlyPoint } from '../../api/dashboard'
+
+export interface AnomalyResult {
+  point: ToolQualityHourlyPoint
+  ts: number
+  zScore: number
+  isAnomaly: boolean
+}
+
+const DEFAULT_THRESHOLD = 2.0
+
+export function detectAnomalies(
+  windowed: Array<{ point: ToolQualityHourlyPoint; ts: number }>,
+  threshold: number = DEFAULT_THRESHOLD,
+): AnomalyResult[] {
+  if (windowed.length < 3) {
+    return windowed.map(w => ({
+      point: w.point,
+      ts: w.ts,
+      zScore: 0,
+      isAnomaly: false,
+    }))
+  }
+
+  const rates = windowed.map(w => w.point.success_rate)
+  const mean = rates.reduce((a, b) => a + b, 0) / rates.length
+  const variance = rates.reduce((sum, r) => sum + (r - mean) ** 2, 0) / rates.length
+  const stddev = Math.sqrt(variance)
+
+  if (stddev === 0) {
+    return windowed.map(w => ({
+      point: w.point,
+      ts: w.ts,
+      zScore: 0,
+      isAnomaly: false,
+    }))
+  }
+
+  return windowed.map(w => {
+    const zScore = (w.point.success_rate - mean) / stddev
+    return {
+      point: w.point,
+      ts: w.ts,
+      zScore,
+      isAnomaly: Math.abs(zScore) > threshold,
+    }
+  })
+}
+
+export function anomalySummary(results: AnomalyResult[]): {
+  count: number
+  worstDrop: AnomalyResult | null
+} {
+  const anomalies = results.filter(r => r.isAnomaly)
+  const drops = anomalies.filter(r => r.zScore < 0).sort((a, b) => a.zScore - b.zScore)
+  return {
+    count: anomalies.length,
+    worstDrop: drops[0] ?? null,
+  }
+}

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -1,12 +1,14 @@
-// Observatory Metric Track (RFC-MASC-006 Phase 2a+2b)
+// Observatory Metric Track (RFC-MASC-006 Phase 2a+2b+3a)
 // Renders tool call success rate over time as an SVG line on shared time axis.
 // Phase 2b: mousemove updates cursor-store, CursorLine renders across track.
+// Phase 3a: z-score anomaly detection, red overlay on outlier data points.
 
 import { html } from 'htm/preact'
 import { useRef } from 'preact/hooks'
 import type { ToolQualityHourlyPoint } from '../../api/dashboard'
 import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
+import { detectAnomalies } from './anomaly-utils'
 
 interface Props {
   points: ToolQualityHourlyPoint[]
@@ -34,6 +36,8 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
   const viewBoxWidth = 1000
   const viewBoxHeight = 60
 
+  const anomalyResults = detectAnomalies(windowed)
+
   const polyline = windowed
     .map(({ point, ts }) => {
       const x = ((ts - windowStart) / span) * viewBoxWidth
@@ -42,6 +46,7 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
     })
     .join(' ')
 
+  const anomalyCount = anomalyResults.filter(r => r.isAnomaly).length
   const lastRate = windowed[windowed.length - 1]?.point.success_rate ?? null
   const lastRateColor =
     lastRate == null ? 'text-text-dim'
@@ -58,6 +63,9 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
             ${lastRate.toFixed(1)}%
           </div>
         ` : html`<div class="text-[10px] text-text-dim">데이터 없음</div>`}
+        ${anomalyCount > 0 ? html`
+          <div class="text-[9px] font-mono text-red-400">${anomalyCount} anomaly</div>
+        ` : null}
       </div>
       <div
         ref=${trackRef}
@@ -77,6 +85,22 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
             preserveAspectRatio="none"
             class="absolute inset-0 w-full h-full"
           >
+            ${anomalyResults.filter(r => r.isAnomaly).map((r, i) => {
+              const x = ((r.ts - windowStart) / span) * viewBoxWidth
+              const halfW = viewBoxWidth / Math.max(windowed.length, 1) * 0.5
+              return html`
+                <rect
+                  x="${(x - halfW).toFixed(1)}"
+                  y="0"
+                  width="${(halfW * 2).toFixed(1)}"
+                  height="${viewBoxHeight}"
+                  fill="${r.zScore < 0 ? 'rgba(239,68,68,0.12)' : 'rgba(245,158,11,0.10)'}"
+                  key=${`anomaly-${i}`}
+                >
+                  <title>z=${r.zScore.toFixed(2)} · ${r.point.success_rate.toFixed(1)}%</title>
+                </rect>
+              `
+            })}
             <line x1="0" y1="${viewBoxHeight * 0.03}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.03}" stroke="currentColor" stroke-dasharray="2 4" class="text-emerald-500/30" stroke-width="0.5" />
             <line x1="0" y1="${viewBoxHeight * 0.1}" x2="${viewBoxWidth}" y2="${viewBoxHeight * 0.1}" stroke="currentColor" stroke-dasharray="2 4" class="text-amber-500/30" stroke-width="0.5" />
             <polyline
@@ -87,18 +111,20 @@ export function MetricTrack({ points, windowStart, windowEnd }: Props) {
               class="text-accent"
               vector-effect="non-scaling-stroke"
             />
-            ${windowed.map(({ point, ts }) => {
-              const x = ((ts - windowStart) / span) * viewBoxWidth
-              const y = viewBoxHeight - (point.success_rate / 100) * viewBoxHeight
+            ${anomalyResults.map((r) => {
+              const x = ((r.ts - windowStart) / span) * viewBoxWidth
+              const y = viewBoxHeight - (r.point.success_rate / 100) * viewBoxHeight
               return html`
                 <circle
                   cx="${x.toFixed(1)}"
                   cy="${y.toFixed(1)}"
-                  r="1.5"
+                  r=${r.isAnomaly ? '3' : '1.5'}
                   fill="currentColor"
-                  class="text-accent"
+                  class=${r.isAnomaly ? (r.zScore < 0 ? 'text-red-400' : 'text-amber-400') : 'text-accent'}
+                  stroke=${r.isAnomaly ? 'currentColor' : 'none'}
+                  stroke-width=${r.isAnomaly ? '0.5' : '0'}
                 >
-                  <title>${point.hour} · ${point.success_rate.toFixed(1)}% (${point.calls} calls)</title>
+                  <title>${r.point.hour} · ${r.point.success_rate.toFixed(1)}% (${r.point.calls} calls)${r.isAnomaly ? ` · z=${r.zScore.toFixed(2)}` : ''}</title>
                 </circle>
               `
             })}

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -259,7 +259,7 @@ export function Observatory() {
       <${DetailPane} />
 
       <p class="text-[10px] text-text-dim italic">
-        Phase 2d — click drill-down. 추가 track(메모리, autoresearch)은 이후 단계에서.
+        Phase 3a — anomaly highlight. 추가 track(메모리, autoresearch)과 compare mode는 이후 단계에서.
       </p>
     </div>
   `


### PR DESCRIPTION
## Summary
- 도구 성공률 metric track에 통계 기반 anomaly highlight 추가
- z-score (|z| > 2.0) 기반 — 고정 임계치가 아닌 데이터 자체의 baseline에 적응
- 하락 이상치: 빨간 배경 + 빨간 원 / 상승 이상치: 황색 배경 + 황색 원
- 라벨 컬럼에 anomaly 건수 표시
- Frontend-only (backend 변경 없음)

## 변경 파일
- `anomaly-utils.ts` (신규): `detectAnomalies()`, `anomalySummary()`, z-score 계산
- `metric-track.ts`: SVG anomaly rect overlay + circle 크기/색상 분기
- `observatory.ts`: phase 텍스트 갱신

## Test plan
- [ ] tsc --noEmit: 0 errors
- [ ] 성공률이 일정한 구간 → anomaly 없음 (z=0)
- [ ] 성공률 급락 시점 → 빨간 배경 + 큰 원
- [ ] 데이터 < 3개 → anomaly 표시 없음 (의도적)
- [ ] hover 시 z-score 값 tooltip에 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)