### PR TITLE
refactor(dashboard): extract duplicated Observatory utils to shared module

### DIFF
--- a/dashboard/src/components/observatory/cross-signal-readout.ts
+++ b/dashboard/src/components/observatory/cross-signal-readout.ts
@@ -7,27 +7,7 @@
 import { html } from 'htm/preact'
 import type { TelemetryEntry, ToolQualityHourlyPoint } from '../../api/dashboard'
 import { cursorPosition } from './cursor-store'
-
-function entryTimestampMs(entry: TelemetryEntry): number | null {
-  if (typeof entry.ts === 'number') return entry.ts * 1000
-  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
-  if (typeof entry.timestamp === 'number') return entry.timestamp
-  if (typeof entry.ts_iso === 'string') {
-    const parsed = Date.parse(entry.ts_iso)
-    return Number.isNaN(parsed) ? null : parsed
-  }
-  return null
-}
-
-function hourToMs(hour: string): number | null {
-  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
-  return Number.isNaN(parsed) ? null : parsed
-}
-
-function isToolCall(entry: TelemetryEntry): boolean {
-  const src = typeof entry.source === 'string' ? entry.source : ''
-  return src === 'tool_call_io' || src === 'tool_usage'
-}
+import { entryTimestampMs, hourToMs, isToolCall } from './observatory-utils'
 
 interface Props {
   events: TelemetryEntry[]

--- a/dashboard/src/components/observatory/event-track.ts
+++ b/dashboard/src/components/observatory/event-track.ts
@@ -9,17 +9,7 @@ import type { TelemetryEntry } from '../../api/dashboard'
 import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
 import { selectEntity, detailSelection } from './detail-selection-store'
-
-function entryTimestampMs(entry: TelemetryEntry): number | null {
-  if (typeof entry.ts === 'number') return entry.ts * 1000
-  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
-  if (typeof entry.timestamp === 'number') return entry.timestamp
-  if (typeof entry.ts_iso === 'string') {
-    const parsed = Date.parse(entry.ts_iso)
-    return Number.isNaN(parsed) ? null : parsed
-  }
-  return null
-}
+import { entryTimestampMs } from './observatory-utils'
 
 function sourceColor(source: string | undefined): string {
   switch (source) {

--- a/dashboard/src/components/observatory/metric-track.ts
+++ b/dashboard/src/components/observatory/metric-track.ts
@@ -9,16 +9,12 @@ import type { ToolQualityHourlyPoint } from '../../api/dashboard'
 import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
 import { detectAnomalies } from './anomaly-utils'
+import { hourToMs } from './observatory-utils'
 
 interface Props {
   points: ToolQualityHourlyPoint[]
   windowStart: number
   windowEnd: number
-}
-
-function hourToMs(hour: string): number | null {
-  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
-  return Number.isNaN(parsed) ? null : parsed
 }
 
 export function MetricTrack({ points, windowStart, windowEnd }: Props) {

--- a/dashboard/src/components/observatory/observatory-utils.ts
+++ b/dashboard/src/components/observatory/observatory-utils.ts
@@ -1,0 +1,25 @@
+// Shared utility functions for Observatory components.
+// Extracted to eliminate 8 duplicated definitions across 4+ files.
+
+import type { TelemetryEntry } from '../../api/dashboard'
+
+export function entryTimestampMs(entry: TelemetryEntry): number | null {
+  if (typeof entry.ts === 'number') return entry.ts * 1000
+  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
+  if (typeof entry.timestamp === 'number') return entry.timestamp
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isNaN(parsed) ? null : parsed
+  }
+  return null
+}
+
+export function hourToMs(hour: string): number | null {
+  const parsed = Date.parse(hour.includes('T') ? hour : `${hour}:00:00Z`)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export function isToolCall(entry: TelemetryEntry): boolean {
+  const src = typeof entry.source === 'string' ? entry.source : ''
+  return src === 'tool_call_io' || src === 'tool_usage'
+}

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -29,6 +29,7 @@ import {
   type TelemetryEntry,
   type ToolQualityHourlyPoint,
 } from '../../api/dashboard'
+import { entryTimestampMs } from './observatory-utils'
 import { EventTrack } from './event-track'
 import { MetricTrack } from './metric-track'
 import { ToolCallTrack } from './tool-call-track'
@@ -73,17 +74,6 @@ function emptyData(): ObservatoryData {
     windowStart: now - RANGE_TO_MS[DEFAULT_RANGE],
     windowEnd: now,
   }
-}
-
-function entryTimestampMs(entry: TelemetryEntry): number | null {
-  if (typeof entry.ts === 'number') return entry.ts * 1000
-  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
-  if (typeof entry.timestamp === 'number') return entry.timestamp
-  if (typeof entry.ts_iso === 'string') {
-    const parsed = Date.parse(entry.ts_iso)
-    return Number.isNaN(parsed) ? null : parsed
-  }
-  return null
 }
 
 // --- Time axis header ---

--- a/dashboard/src/components/observatory/tool-call-track.ts
+++ b/dashboard/src/components/observatory/tool-call-track.ts
@@ -8,22 +8,7 @@ import type { TelemetryEntry } from '../../api/dashboard'
 import { setCursorFromEvent, clearCursor } from './cursor-store'
 import { CursorLine } from './cursor-line'
 import { selectEntity, detailSelection } from './detail-selection-store'
-
-function entryTimestampMs(entry: TelemetryEntry): number | null {
-  if (typeof entry.ts === 'number') return entry.ts * 1000
-  if (typeof entry.ts_unix === 'number') return entry.ts_unix * 1000
-  if (typeof entry.timestamp === 'number') return entry.timestamp
-  if (typeof entry.ts_iso === 'string') {
-    const parsed = Date.parse(entry.ts_iso)
-    return Number.isNaN(parsed) ? null : parsed
-  }
-  return null
-}
-
-function isToolCall(entry: TelemetryEntry): boolean {
-  const src = typeof entry.source === 'string' ? entry.source : ''
-  return src === 'tool_call_io' || src === 'tool_usage'
-}
+import { entryTimestampMs, isToolCall } from './observatory-utils'
 
 function toolCallOutcome(entry: TelemetryEntry): 'success' | 'failure' | 'unknown' {
   if (entry.success === true) return 'success'


### PR DESCRIPTION
## Summary
- `entryTimestampMs` (4 copies), `hourToMs` (2 copies), `isToolCall` (2 copies) 통합
- 신규 `observatory-utils.ts`에 3개 함수 추출
- 5개 소비자 파일에서 로컬 정의 제거 + import 전환
- 순감소 -34줄, 향후 copy drift 방지

## 변경 파일
- `observatory-utils.ts` (신규): 공유 유틸리티
- `observatory.ts`: 로컬 `entryTimestampMs` 제거
- `event-track.ts`: 로컬 `entryTimestampMs` 제거
- `tool-call-track.ts`: 로컬 `entryTimestampMs` + `isToolCall` 제거
- `cross-signal-readout.ts`: 로컬 3개 함수 모두 제거
- `metric-track.ts`: 로컬 `hourToMs` 제거

## Test plan
- [ ] tsc --noEmit: 0 errors
- [ ] 기능 동작 변경 없음 (pure mechanical extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)