### PR TITLE
feat(keeper): wire OAS Event_bus correlation_id into composite snapshot

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -203,7 +203,10 @@ let observe
   let correlation_id =
     match correlation_id with
     | Some s when String.length s > 0 -> s
-    | _ -> stable_correlation_id entry
+    | _ ->
+      match entry.last_event_bus_correlation with
+      | Some cid -> cid
+      | None -> stable_correlation_id entry
   in
   let run_id =
     match run_id with

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -115,11 +115,7 @@ type registry_entry = {
           Does not affect state machine phase derivation. *)
   last_auto_rules :
     (float * Keeper_state_machine.auto_rule_summary) option;
-      (** Snapshot of the most recent [Context_measured] auto-rule summary.
-          Stored as [(wall_clock, summary)] so the composite observer
-          (RFC-0003 §6) can surface the last measurement without reading
-          history files. [None] until the first [Context_measured] event
-          has been dispatched. *)
+  last_event_bus_correlation : string option;
 }
 
 
@@ -220,6 +216,7 @@ let register_with_state ~base_path name meta
     transition_seq = 0;
     waiting_for_inference = Atomic.make false;
     last_auto_rules = None;
+    last_event_bus_correlation = None;
   } in
   put_entry key entry;
   if phase = Running then
@@ -329,6 +326,10 @@ let record_error ~base_path name err =
 
 let set_failure_reason ~base_path name reason =
   update_entry ~base_path name (fun e -> { e with last_failure_reason = reason })
+
+let set_last_correlation_id ~base_path name cid =
+  update_entry ~base_path name (fun e ->
+    { e with last_event_bus_correlation = Some cid })
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -79,6 +79,11 @@ type registry_entry = {
           (RFC-0003 §6) can surface the last measurement without reading
           history files. [None] until the first [Context_measured] event
           has been dispatched. *)
+  last_event_bus_correlation : string option;
+      (** Most recent OAS Event_bus [correlation_id] extracted after a
+          keeper turn via [Event_bus.drain]. [None] until the first
+          successful drain. Stable per session (= [meta.runtime.trace_id]
+          as passed to OAS). *)
 }
 
 (** Register a keeper with an already-live fiber. Primarily used by tests and
@@ -117,6 +122,9 @@ val record_error : base_path:string -> string -> string -> unit
 
 (** Set the structured failure reason for cohort detection. *)
 val set_failure_reason : base_path:string -> string -> failure_reason option -> unit
+
+(** Store the OAS Event_bus [correlation_id] from the most recent turn. *)
+val set_last_correlation_id : base_path:string -> string -> string -> unit
 
 (** Increment turn consecutive failure counter. *)
 val increment_turn_failures : base_path:string -> string -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1324,6 +1324,13 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
         paused_meta_override := Some paused_meta
       in
       Keeper_exec_tools.add_tool_call_observer side_effect_observer;
+      let event_bus_sub =
+        match Keeper_event_bus.get () with
+        | Some bus ->
+          Some (Agent_sdk.Event_bus.subscribe
+                  ~filter:(Agent_sdk.Event_bus.filter_agent meta.name) bus)
+        | None -> None
+      in
       let evidence_before_hash =
         try Keeper_evidence.snapshot_before_turn
           ~base_path:config.base_path ~keeper_name:meta.name
@@ -1613,6 +1620,17 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             end else
               Error (Oas.Error.Internal msg))))
       in
+      (match event_bus_sub, Keeper_event_bus.get () with
+       | Some sub, Some bus ->
+         let events = Agent_sdk.Event_bus.drain sub in
+         Agent_sdk.Event_bus.unsubscribe bus sub;
+         (match events with
+          | ev :: _ ->
+            Keeper_registry.set_last_correlation_id
+              ~base_path:config.base_path meta.name
+              ev.Agent_sdk.Event_bus.meta.correlation_id
+          | [] -> ())
+       | _ -> ());
       match run_result with
       | Error err ->
           let e_str = Oas.Error.to_string err in


### PR DESCRIPTION
## Summary
- OAS Event_bus에서 `correlation_id`를 turn 단위로 subscribe/drain → registry에 저장
- Composite observer fallback: explicit arg > registry(real OAS) > synthetic `keeper:<name>:<seq>`
- OAS 변경 없음, dashboard 변경 없음 (이미 `correlation_id` 렌더 중)
- 4파일 36줄 추가

## Data flow
```
OAS pipeline → Event_bus.publish({correlation_id, ...})
  → keeper_unified_turn subscribe(filter_agent) / drain / unsubscribe
  → keeper_registry.set_last_correlation_id
  → keeper_composite_observer.observe reads from registry
  → GET /composite returns real OAS correlation_id
```

## Test plan
- [x] `test_decision_pipeline` 18/18 pass
- [x] `test_keeper_registry` 50/50 pass
- [x] `dune build @check` pass
- [ ] CI green

Part of RFC-0003 Route B (correlation_id trail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)