### PR TITLE
feat(keeper): add keeper_task_create tool — close producer-consumer loop

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -714,6 +714,7 @@ let run_turn
     ; "keeper_tasks_list", "태스크 목록 할일 백로그"
     ; "keeper_tasks_audit", "태스크 감사 고아 방치"
     ; "keeper_task_claim", "태스크 가져오기 할당"
+    ; "keeper_task_create", "태스크 생성 만들기 일감"
     ; "keeper_task_done", "태스크 완료 마감"
     ; "keeper_task_force_release", "태스크 강제해제 반환"
     ; "keeper_task_force_done", "태스크 강제완료"

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -94,6 +94,19 @@ let handle_keeper_task_tool
         Room.broadcast config ~from_agent:(keeper_agent_sender ~meta) ~content:message
       in
       Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "broadcast", `String message ]))
+  | "keeper_task_create" ->
+    let title = Safe_ops.json_string ~default:"" "title" args |> String.trim in
+    let description = Safe_ops.json_string ~default:"" "description" args |> String.trim in
+    let priority = Safe_ops.json_int ~default:3 "priority" args |> max 1 |> min 5 in
+    if title = ""
+    then error_json "title is required. Provide a clear, actionable task title."
+    else if description = ""
+    then error_json "description is required. Explain what needs to be done and why."
+    else (
+      let result =
+        Room_task.add_task config ~title ~priority ~description
+      in
+      Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "result", `String result ]))
   | "keeper_task_claim" ->
     let preset_name = match Keeper_types.tool_access_preset meta.tool_access with
       | Some p -> Some (Keeper_types.tool_preset_to_string p)

--- a/lib/keeper/keeper_exec_tools.ml
+++ b/lib/keeper/keeper_exec_tools.ml
@@ -179,6 +179,7 @@ let execute_keeper_tool_call
     | "keeper_task_force_done"
     | "keeper_broadcast"
     | "keeper_task_claim"
+    | "keeper_task_create"
     | "keeper_task_done" -> Keeper_exec_task.handle_keeper_task_tool ~config ~meta ~name ~args
     | n when String.starts_with ~prefix:"masc_autoresearch_" n ->
       Keeper_exec_masc.handle_keeper_autoresearch_tool ~config ~meta ~name ~args

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -55,7 +55,7 @@ let core_discovery_tools =
   core_always_tools @
   (* Coordination & awareness *)
   [ "keeper_broadcast"; "keeper_tasks_list";
-    "keeper_task_claim"; "keeper_task_done"; "keeper_tasks_audit";
+    "keeper_task_claim"; "keeper_task_done"; "keeper_task_create"; "keeper_tasks_audit";
     "keeper_memory_search"; "keeper_time_now";
     (* Filesystem: read + write (action symmetry) *)
     "keeper_fs_read"; "keeper_fs_edit";
@@ -259,7 +259,7 @@ let is_main_worktree_boundary_exempt_with_input
   if is_read_only_with_input ~tool_name ~input then true
   else
     match tool_name with
-    | "keeper_task_claim" | "keeper_task_done" | "keeper_tasks_list"
+    | "keeper_task_claim" | "keeper_task_done" | "keeper_task_create" | "keeper_tasks_list"
     | "keeper_board_post" | "keeper_board_comment" | "keeper_board_vote"
     | "keeper_board_list" | "keeper_board_get"
     (* Board delete and cleanup are MASC-state-only mutations (board

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -31,6 +31,7 @@ let keeper_internal_tools =
     "keeper_tasks_list";
     "keeper_tasks_audit";
     "keeper_task_claim";
+    "keeper_task_create";
     "keeper_task_done";
     "keeper_task_force_release";
     "keeper_task_force_done";

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -77,6 +77,9 @@ let synonyms : (string * string list) list =
     ("keeper_tasks_list",
      [ "backlog"; "todo list"; "task list"; "available tasks"; "task board";
        "work items"; "assignee" ]);
+    ("keeper_task_create",
+     [ "create task"; "new task"; "add task"; "make task"; "propose work";
+       "found work"; "needs doing"; "backlog item"; "discovered issue" ]);
     ("keeper_task_claim",
      [ "claim task"; "pick up task"; "assign me task"; "take task";
        "next task"; "give me work" ]);

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -667,6 +667,28 @@ accomplished so other agents can verify.";
       ("required", `List [`String "task_id"]);
     ];
   };
+  {
+    name = "keeper_task_create";
+    description = "Create a new task on the MASC backlog. Use when you identify work \
+that should be done — from GitHub issues, board discussions, codebase problems, \
+or your own analysis. Provide a clear title, actionable description, and priority (1=critical, 5=low). \
+The task will appear on the backlog for any keeper to claim.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("title", `Assoc [("type", `String "string"); ("description", `String "Clear, actionable task title (REQUIRED)")]);
+        ("description", `Assoc [("type", `String "string"); ("description", `String "What needs to be done and why. Include enough context for another keeper to pick this up. (REQUIRED)")]);
+        ("priority", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "1=critical, 2=high, 3=medium (default), 4=low, 5=backlog");
+          ("minimum", `Int 1);
+          ("maximum", `Int 5);
+          ("default", `Int 3);
+        ]);
+      ]);
+      ("required", `List [`String "title"; `String "description"]);
+    ];
+  };
 ]
 
 (** Predefined shards *)

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -602,42 +602,37 @@ Use keeper_task_force_release to reassign orphaned tasks.";
   {
     name = "keeper_task_force_release";
     description = "Release a stuck task back to Todo status, removing the current assignee. \
-Use when an agent went offline and left a task claimed. Broadcasts the \
-release to the room. Provide a reason for audit.";
+Applies when the assignee is offline (no heartbeat >10 min). Broadcasts the release to the room.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID from keeper_tasks_list or keeper_tasks_audit (REQUIRED)")]);
-        ("reason", `Assoc [("type", `String "string"); ("description", `String "Reason for force release")]);
+        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID from keeper_tasks_list or keeper_tasks_audit"); ("minLength", `Int 1)]);
+        ("reason", `Assoc [("type", `String "string"); ("description", `String "Why this task is being released (audit trail)"); ("minLength", `Int 1)]);
       ]);
-      ("required", `List [`String "task_id"]);
+      ("required", `List [`String "task_id"; `String "reason"]);
     ];
   };
   {
     name = "keeper_task_force_done";
-    description = "Mark a task Done when the work is confirmed complete but the assignee \
-did not transition it (e.g. they finished but went offline). Requires notes \
-explaining the completion evidence. Broadcasts to room.";
+    description = "Mark a task Done when the assignee completed the work but did not transition it \
+(e.g. went offline after finishing). Broadcasts completion to room.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID from keeper_tasks_list or keeper_tasks_audit (REQUIRED)")]);
-        ("notes", `Assoc [("type", `String "string"); ("description", `String "Evidence that the task is actually complete")]);
+        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID from keeper_tasks_list or keeper_tasks_audit"); ("minLength", `Int 1)]);
+        ("notes", `Assoc [("type", `String "string"); ("description", `String "Completion evidence: PR merged, test output, file diff"); ("minLength", `Int 1)]);
       ]);
-      ("required", `List [`String "task_id"]);
+      ("required", `List [`String "task_id"; `String "notes"]);
     ];
   };
   {
     name = "keeper_broadcast";
     description = "Send a message visible to all agents in the MASC room. \
-message is REQUIRED (non-empty). \
-Good: message='Build complete, all tests pass.'. \
-Bad: message=''. \
 Use for status updates, announcements, warnings, or coordination.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("message", `Assoc [("type", `String "string"); ("description", `String "Message to broadcast")]);
+        ("message", `Assoc [("type", `String "string"); ("description", `String "Message content to broadcast"); ("minLength", `Int 1)]);
       ]);
       ("required", `List [`String "message"]);
     ];
@@ -655,32 +650,28 @@ After claiming, do the work and call keeper_task_done when finished.";
   {
     name = "keeper_task_done";
     description = "Mark your claimed task as complete with a result summary. \
-task_id is REQUIRED. Get task_id from keeper_task_claim response. \
-The task must be claimed by you. Provide a clear summary of what was \
-accomplished so other agents can verify.";
+The task must be claimed by you. Other agents verify completion from the result field.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID from keeper_task_claim (REQUIRED)")]);
-        ("result", `Assoc [("type", `String "string"); ("description", `String "Summary of what was accomplished")]);
+        ("task_id", `Assoc [("type", `String "string"); ("description", `String "Task ID returned by keeper_task_claim"); ("minLength", `Int 1)]);
+        ("result", `Assoc [("type", `String "string"); ("description", `String "What was done: files changed, tests run, outcome observed"); ("minLength", `Int 1)]);
       ]);
-      ("required", `List [`String "task_id"]);
+      ("required", `List [`String "task_id"; `String "result"]);
     ];
   };
   {
     name = "keeper_task_create";
-    description = "Create a new task on the MASC backlog. Use when you identify work \
-that should be done — from GitHub issues, board discussions, codebase problems, \
-or your own analysis. Provide a clear title, actionable description, and priority (1=critical, 5=low). \
-The task will appear on the backlog for any keeper to claim.";
+    description = "Create a new task on the MASC backlog. The task appears for any keeper to claim. \
+Duplicate titles are rejected automatically (dedup by normalized title).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
-        ("title", `Assoc [("type", `String "string"); ("description", `String "Clear, actionable task title (REQUIRED)")]);
-        ("description", `Assoc [("type", `String "string"); ("description", `String "What needs to be done and why. Include enough context for another keeper to pick this up. (REQUIRED)")]);
+        ("title", `Assoc [("type", `String "string"); ("description", `String "Task title: verb + object + scope (e.g. 'Fix CI timeout in keeper_agent_run.ml')"); ("minLength", `Int 5); ("maxLength", `Int 200)]);
+        ("description", `Assoc [("type", `String "string"); ("description", `String "What to do, why, and acceptance criteria. Another keeper reads this to start working."); ("minLength", `Int 10)]);
         ("priority", `Assoc [
           ("type", `String "integer");
-          ("description", `String "1=critical, 2=high, 3=medium (default), 4=low, 5=backlog");
+          ("description", `String "1=critical 2=high 3=medium 4=low 5=backlog");
           ("minimum", `Int 1);
           ("maximum", `Int 5);
           ("default", `Int 3);


### PR DESCRIPTION
## Summary

- 키퍼가 task를 생성할 수 있는 `keeper_task_create` 도구 추가
- 7개 등록 지점 모두 배선 완료 (schema, handler, dispatch, registry, catalog, prefilter, search label)
- `Room_task.add_task`의 기존 dedup guard를 그대로 활용 (동일 제목 task 중복 방지)

## Problem

키퍼 시스템에 **task producer가 없었음**. Task 생성은 외부 `masc_add_task` (사람 세션)으로만 가능. 사람 세션 종료 후 전원 `stay_silent` 루프:

| 시간대 | stay_silent | task 생성/claim |
|--------|-----------|----------------|
| 10-12시 (사람 세션) | 243 | 23 |
| 13-18시 (사람 퇴장) | 429 | 5 |

`keeper_deliberation.ml`에 `CreateTask` action이 설계되어 있었지만 executor가 배선되지 않은 dead code 상태.

## Change

Tool path로 우회: deliberation 경로(dead code) 대신 tool call 경로에 직접 구현.

| 파일 | 변경 |
|------|------|
| `tool_shard.ml` | +22 lines: schema (title, description, priority 1-5) |
| `keeper_exec_task.ml` | +13 lines: handler → `Room_task.add_task` |
| `keeper_exec_tools.ml` | dispatch routing |
| `keeper_tool_registry.ml` | universe + idempotency allowlist |
| `tool_catalog_surfaces.ml` | catalog entry |
| `tool_prefilter.ml` | BM25 search keywords |
| `keeper_agent_run.ml` | Korean search label |

## What is NOT in this PR

- Deliberation `CreateTask` executor wiring (dead code, separate concern)
- Deliberation gate condition fix (catch-22: "needs tasks to create tasks")
- poe keeper config change (`work_discovery_enabled: true`) — config change, not code
- Prompt changes to encourage task creation behavior

## Test plan

- [x] `dune build --root .` — 0 errors (full project)
- [x] `dune build --root . lib` — 0 errors
- [ ] Integration: restart masc-mcp, verify `keeper_task_create` appears in tool search
- [ ] E2E: keeper calls `keeper_task_create`, task appears in backlog

Fixes #7113

## 다음 단계 (follow-up)

1. poe config: `work_discovery_enabled: true`, sources 추가
2. Prompt 업데이트: "일감이 없으면 찾아서 만들어라"
3. Deliberation `CreateTask` executor 배선 또는 deprecation
4. idle_gate 120→300+ 조정 (silent 턴 비용 절감)