### PR TITLE
feat(keeper): masc_keeper_compact + masc_keeper_clear MCP tools (MASC-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 ## [Unreleased]
 
+### Added
+- Operator-facing context overflow recovery tools (#7115). Two new MCP
+  tools paired with the `Overflowed` phase introduced in #7083:
+  - `masc_keeper_compact`: dispatches `Operator_compact_requested` to the
+    keeper FSM and runs checkpoint compaction via OAS
+    `recover_latest_checkpoint_for_overflow_retry`. Phase precondition is
+    `Overflowed`/`Paused`/`Compacting`; `force=true` bypasses for
+    `Running`/`Failing`.
+  - `masc_keeper_clear`: last-resort context wipe. Loads the checkpoint,
+    clears non-system messages (system prompt preserved by default), saves
+    a new checkpoint, dispatches `Operator_clear_requested`. Requires an
+    operator-provided `reason` for audit trail.
+- Prometheus counters for the new operator tools:
+  `masc_keeper_operator_compact_total{keeper,result}` (result ∈
+  `ok|no_checkpoint|precondition`) and
+  `masc_keeper_operator_clear_total{keeper,preserve_system}`.
+- `checkpoint_found` field in the `masc_keeper_clear` response so
+  operators can distinguish "no messages to clear" from "no checkpoint
+  on disk".
+
+### Fixed
+- `masc_keeper_compact`/`masc_keeper_clear` now read/write checkpoints
+  from `session_base_dir(config)` (`<masc_root>/.masc/traces`) instead
+  of the incorrect `<base_path>/<keeper_name>`. Previous path would have
+  made the tools always report missing checkpoints.
+- When no valid checkpoint exists, `masc_keeper_compact` now dispatches
+  `Compaction_failed` rather than `Compaction_completed { 0, 0 }`. The
+  latter was a false-success signal that would clear `context_overflow`
+  even though no compaction happened.
+
 ## [0.7.0] - 2026-04-14
 
 ### Added

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -753,6 +753,8 @@ let run_turn
     ; "masc_keeper_list", "키퍼 목록 현황"
     ; "masc_keeper_msg", "키퍼 메시지 전달 대화"
     ; "masc_keeper_status", "키퍼 상태 확인"
+    ; "masc_keeper_compact", "키퍼 컨텍스트 압축 컴팩트 요약"
+    ; "masc_keeper_clear", "키퍼 컨텍스트 초기화 클리어 비우기"
     ; "masc_worktree_create", "워크트리 생성 브랜치"
     ; "masc_worktree_list", "워크트리 목록 현황"
     ; "masc_worktree_remove", "워크트리 삭제 정리"

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -502,8 +502,10 @@ Clears stale data from previous sessions. Does not affect configuration, goals, 
     name = "masc_keeper_compact";
     description = "Trigger operator-initiated context compaction for a keeper. \
 Compacts the keeper's checkpoint to reduce context size. \
-Use when a keeper is in Overflowed or Paused state due to context overflow, \
-or proactively on a Running keeper with force=true.";
+Default precondition: keeper phase is Overflowed, Paused, or Compacting. \
+Pass force=true to allow compaction on Running or Failing keepers. \
+Terminal/transient phases (Offline, Stopped, Dead, Crashed, Restarting, \
+HandingOff, Draining) are always rejected.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -513,7 +515,7 @@ or proactively on a Running keeper with force=true.";
         ]);
         ("force", `Assoc [
           ("type", `String "boolean");
-          ("description", `String "Bypass phase precondition check (allow compaction on Running/Failing keepers).");
+          ("description", `String "Bypass default precondition to allow compaction on Running or Failing keepers. Has no effect on terminal/transient phases.");
         ]);
       ]);
       ("required", `List [`String "name"]);
@@ -523,7 +525,10 @@ or proactively on a Running keeper with force=true.";
   {
     name = "masc_keeper_clear";
     description = "Last-resort context clear for a keeper. \
-Drops all conversation messages from the checkpoint, optionally preserving the system prompt. \
+Wipes user/assistant/tool messages from the checkpoint; keeps the system prompt \
+by default (preserve_system_prompt=true). Set preserve_system_prompt=false to \
+drop the system prompt too. Dispatches Operator_clear_requested to the keeper \
+FSM, which resets context_overflow and compact_retry_exhausted. \
 Use only when compaction is insufficient and the keeper cannot recover otherwise. \
 Requires a reason for the audit trail.";
     input_schema = `Assoc [

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -498,6 +498,54 @@ Clears stale data from previous sessions. Does not affect configuration, goals, 
     ];
   };
 
+  {
+    name = "masc_keeper_compact";
+    description = "Trigger operator-initiated context compaction for a keeper. \
+Compacts the keeper's checkpoint to reduce context size. \
+Use when a keeper is in Overflowed or Paused state due to context overflow, \
+or proactively on a Running keeper with force=true.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle");
+        ]);
+        ("force", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Bypass phase precondition check (allow compaction on Running/Failing keepers).");
+        ]);
+      ]);
+      ("required", `List [`String "name"]);
+    ];
+  };
+
+  {
+    name = "masc_keeper_clear";
+    description = "Last-resort context clear for a keeper. \
+Drops all conversation messages from the checkpoint, optionally preserving the system prompt. \
+Use only when compaction is insufficient and the keeper cannot recover otherwise. \
+Requires a reason for the audit trail.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper handle");
+        ]);
+        ("preserve_system_prompt", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Keep the system prompt in the cleared context. Defaults to true.");
+        ]);
+        ("reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Required. Operator explanation for why the context is being cleared (audit trail).");
+        ]);
+      ]);
+      ("required", `List [`String "name"; `String "reason"]);
+    ];
+  };
+
 ]
 
 let schemas : tool_schema list =

--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -227,6 +227,8 @@ let custom_tool_titles : (string * string) list = [
   ("masc_keeper_reconcile", "Keeper Reconcile");
   ("masc_keeper_status", "Keeper Status");
   ("masc_keeper_down", "Stop Keeper");
+  ("masc_keeper_compact", "Compact Keeper Context");
+  ("masc_keeper_clear", "Clear Keeper Context");
   ("masc_keeper_create_from_persona", "Create Keeper from Persona");
   (* SDK aliases *)
   ("masc_list_tasks", "List Tasks");

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -193,7 +193,7 @@ let init () =
     "Context ratio change after compaction (pre - post)" Gauge;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
   add "masc_keeper_operator_compact_total"
-    "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition)" Counter;
+    "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;
   add "masc_keeper_operator_clear_total"
     "Total operator-invoked masc_keeper_clear calls (labels: preserve_system=true|false)" Counter;
   (* Keeper heartbeat metrics — emitted by keeper_keepalive.ml *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -191,6 +191,11 @@ let init () =
     "Total keeper compactions performed" Counter;
   add "masc_keeper_compaction_ratio_change"
     "Context ratio change after compaction (pre - post)" Gauge;
+  (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
+  add "masc_keeper_operator_compact_total"
+    "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition)" Counter;
+  add "masc_keeper_operator_clear_total"
+    "Total operator-invoked masc_keeper_clear calls (labels: preserve_system=true|false)" Counter;
   (* Keeper heartbeat metrics — emitted by keeper_keepalive.ml *)
   add "masc_keeper_heartbeat_successes_total"
     "Total keeper heartbeat successes" Counter;

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -246,6 +246,11 @@ let explicit_metadata : (string * metadata) list =
       { default_metadata with required_permission = Some Types.CanBroadcast } );
     ( "masc_keeper_reset",
       { default_metadata with required_permission = Some Types.CanBroadcast } );
+    ( "masc_keeper_compact",
+      { default_metadata with required_permission = Some Types.CanBroadcast } );
+    ( "masc_keeper_clear",
+      with_semantic_flags ~destructive:true
+        { default_metadata with required_permission = Some Types.CanBroadcast } );
     ( "masc_operation_stop",
       destructive_tool );
     ( "masc_operation_pause",

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -125,6 +125,7 @@ let public_mcp_surface_tools =
     (* Keeper interaction *)
     "masc_keeper_msg"; "masc_keeper_msg_result"; "masc_keeper_list"; "masc_keeper_status";
     "masc_keeper_up"; "masc_keeper_repair"; "masc_keeper_reconcile"; "masc_keeper_reset";
+    "masc_keeper_compact"; "masc_keeper_clear";
     "masc_keeper_down";
     "masc_persona_list";
     (* Board *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -665,7 +665,7 @@ let handle_keeper_compact ctx args : tool_result =
       | Ok None | Error _ ->
         (false, Printf.sprintf "keeper %s: meta unavailable for compaction" name)
       | Ok (Some (_resolved, meta)) ->
-        let base_dir = Filename.concat ctx.config.base_path name in
+        let base_dir = Keeper_types.session_base_dir ctx.config in
         let model = Keeper_exec_context.checkpoint_model_of_meta meta in
         let max_tokens =
           match meta.max_context_override with
@@ -732,7 +732,7 @@ let handle_keeper_clear ctx args : tool_result =
         | Some entry -> Keeper_state_machine.phase_to_string entry.phase
         | None -> "unknown"
       in
-      let base_dir = Filename.concat ctx.config.base_path name in
+      let base_dir = Keeper_types.session_base_dir ctx.config in
       let trace_id = Keeper_exec_context.generate_trace_id () in
       let max_tokens =
         match read_meta_resolved ctx.config name with

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -628,6 +628,179 @@ let handle_keeper_reset ctx args : tool_result =
      | Error err ->
        (false, Printf.sprintf "Failed to write reset meta for %s: %s" meta.name err))
 
+(** Operator-initiated context compaction.
+
+    Dispatches [Operator_compact_requested] to the FSM, then compacts the
+    keeper's latest checkpoint via OAS checkpoint recovery.  Returns
+    before/after token counts on success. *)
+let handle_keeper_compact ctx args : tool_result =
+  match resolve_keeper_name ctx args with
+  | Error err -> (false, err)
+  | Ok name ->
+    let force = get_bool args "force" false in
+    let phase_before =
+      match Keeper_registry.get ~base_path:ctx.config.base_path name with
+      | Some entry -> Keeper_state_machine.phase_to_string entry.phase
+      | None -> "unknown"
+    in
+    (* Phase precondition: Overflowed, Paused, or (Running/Failing with force). *)
+    let allowed =
+      match phase_before with
+      | "overflowed" | "paused" | "compacting" -> true
+      | "running" | "failing" -> force
+      | _ -> false
+    in
+    if not allowed then
+      error_result_typed ~code:Validation_error
+        (Printf.sprintf
+           "keeper %s is in phase %s; compaction requires Overflowed, Paused, or force=true"
+           name phase_before)
+    else begin
+      (* Dispatch FSM event *)
+      Keeper_exec_context.dispatch_keeper_phase_event
+        ~config:ctx.config ~keeper_name:name
+        Keeper_state_machine.Operator_compact_requested;
+      (* Read meta for checkpoint access *)
+      match read_meta_resolved ctx.config name with
+      | Ok None | Error _ ->
+        (false, Printf.sprintf "keeper %s: meta unavailable for compaction" name)
+      | Ok (Some (_resolved, meta)) ->
+        let base_dir = Filename.concat ctx.config.base_path name in
+        let model = Keeper_exec_context.checkpoint_model_of_meta meta in
+        let max_tokens =
+          match meta.max_context_override with
+          | Some n when n > 0 -> n
+          | _ -> 200_000
+        in
+        Keeper_exec_context.dispatch_keeper_phase_event
+          ~config:ctx.config ~keeper_name:name
+          Keeper_state_machine.Compaction_started;
+        match
+          Keeper_exec_context.recover_latest_checkpoint_for_overflow_retry
+            ~base_dir ~meta ~model ~primary_model_max_tokens:max_tokens
+        with
+        | Some recovery ->
+          Keeper_exec_context.dispatch_keeper_phase_event
+            ~config:ctx.config ~keeper_name:name
+            (Keeper_state_machine.Compaction_completed {
+               before_tokens = recovery.compaction.before_tokens;
+               after_tokens = recovery.compaction.after_tokens;
+            });
+          invalidate_status_cache name;
+          (true,
+           Yojson.Safe.to_string
+             (`Assoc [
+               ("name", `String name);
+               ("phase_before", `String phase_before);
+               ("phase_after", `String
+                  (match Keeper_registry.get ~base_path:ctx.config.base_path name with
+                   | Some entry -> Keeper_state_machine.phase_to_string entry.phase
+                   | None -> "unknown"));
+               ("before_tokens", `Int recovery.compaction.before_tokens);
+               ("after_tokens", `Int recovery.compaction.after_tokens);
+             ]))
+        | None ->
+          (* Compaction infrastructure unavailable — checkpoint may be absent. *)
+          Keeper_exec_context.dispatch_keeper_phase_event
+            ~config:ctx.config ~keeper_name:name
+            (Keeper_state_machine.Compaction_completed {
+               before_tokens = 0; after_tokens = 0;
+            });
+          (false,
+           Printf.sprintf
+             "keeper %s: checkpoint compaction unavailable (no valid checkpoint found)"
+             name)
+    end
+
+(** Last-resort context clear.
+
+    Drops all conversation messages from the keeper's checkpoint file,
+    optionally preserving the system prompt.  Dispatches
+    [Operator_clear_requested] to reset overflow-related FSM conditions. *)
+let handle_keeper_clear ctx args : tool_result =
+  match resolve_keeper_name ctx args with
+  | Error err -> (false, err)
+  | Ok name ->
+    let reason = String.trim (get_string args "reason" "") in
+    if reason = "" then
+      error_result_typed ~code:Validation_error
+        "reason is required for masc_keeper_clear (audit trail)"
+    else
+      let preserve_system = get_bool args "preserve_system_prompt" true in
+      let phase_before =
+        match Keeper_registry.get ~base_path:ctx.config.base_path name with
+        | Some entry -> Keeper_state_machine.phase_to_string entry.phase
+        | None -> "unknown"
+      in
+      let base_dir = Filename.concat ctx.config.base_path name in
+      let trace_id = Keeper_exec_context.generate_trace_id () in
+      let max_tokens =
+        match read_meta_resolved ctx.config name with
+        | Ok (Some (_, meta)) ->
+          (match meta.max_context_override with Some n when n > 0 -> n | _ -> 200_000)
+        | _ -> 200_000
+      in
+      let max_checkpoint_messages =
+        match read_meta_resolved ctx.config name with
+        | Ok (Some (_, meta)) -> meta.compaction.max_checkpoint_messages
+        | _ -> 100
+      in
+      let session, ctx_opt =
+        Keeper_exec_context.load_context_from_checkpoint
+          ~max_checkpoint_messages
+          ~trace_id
+          ~primary_model_max_tokens:max_tokens
+          ~base_dir
+      in
+      let cleared_count =
+        match ctx_opt with
+        | None -> 0
+        | Some wctx ->
+          let msg_count = List.length wctx.messages in
+          let cleared_messages =
+            if preserve_system then
+              (* Keep only system-role messages *)
+              List.filter
+                (fun (m : Agent_sdk.Types.message) ->
+                   m.role = Llm_provider.Types.System)
+                wctx.messages
+            else
+              []
+          in
+          let cleared_ctx = { wctx with messages = cleared_messages } in
+          (* Increment generation to signal a new context epoch after clear. *)
+          let generation = 1 in
+          let checkpoint =
+            Keeper_exec_context.create_checkpoint cleared_ctx ~generation:(generation + 1)
+          in
+          Keeper_exec_context.save_session_checkpoint session checkpoint;
+          msg_count - List.length cleared_messages
+      in
+      (* Dispatch FSM event to clear overflow conditions *)
+      Keeper_exec_context.dispatch_keeper_phase_event
+        ~config:ctx.config ~keeper_name:name
+        (Keeper_state_machine.Operator_clear_requested { preserve_system; reason });
+      (* Clear registry failure state *)
+      Keeper_registry.set_failure_reason ~base_path:ctx.config.base_path name None;
+      Keeper_registry.reset_turn_failures ~base_path:ctx.config.base_path name;
+      invalidate_status_cache name;
+      Log.Keeper.warn
+        "%s: context cleared by operator (reason=%s, preserve_system=%b, cleared=%d msgs)"
+        name reason preserve_system cleared_count;
+      (true,
+       Yojson.Safe.to_string
+         (`Assoc [
+           ("name", `String name);
+           ("phase_before", `String phase_before);
+           ("phase_after", `String
+              (match Keeper_registry.get ~base_path:ctx.config.base_path name with
+               | Some entry -> Keeper_state_machine.phase_to_string entry.phase
+               | None -> "unknown"));
+           ("cleared_message_count", `Int cleared_count);
+           ("preserve_system_prompt", `Bool preserve_system);
+           ("reason", `String reason);
+         ]))
+
 let dispatch ctx ~name ~args : tool_result option =
   maybe_bootstrap_existing_keepalives ctx ~name ~args;
   let ctx = resolve_ctx ctx ~name args in
@@ -643,6 +816,8 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_keeper_down" -> Some (handle_keeper_down ctx args)
   | "masc_keeper_list" -> Some (handle_keeper_list ctx args)
   | "masc_keeper_reset" -> Some (handle_keeper_reset ctx args)
+  | "masc_keeper_compact" -> Some (handle_keeper_compact ctx args)
+  | "masc_keeper_clear" -> Some (handle_keeper_clear ctx args)
   | _ -> None
 
 (** Streaming dispatch: only handles keeper_msg with text delta forwarding.
@@ -668,7 +843,8 @@ let tool_required_permission = function
   | "masc_keeper_create_from_persona" | "masc_keeper_up"
   | "masc_keeper_msg" | "masc_keeper_msg_result"
   | "masc_keeper_repair" | "masc_keeper_reconcile"
-  | "masc_keeper_down" | "masc_keeper_reset" ->
+  | "masc_keeper_down" | "masc_keeper_reset"
+  | "masc_keeper_compact" | "masc_keeper_clear" ->
       Some Types.CanBroadcast
   | _ -> None
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -700,11 +700,16 @@ let handle_keeper_compact ctx args : tool_result =
                ("after_tokens", `Int recovery.compaction.after_tokens);
              ]))
         | None ->
-          (* Compaction infrastructure unavailable — checkpoint may be absent. *)
+          (* Compaction infrastructure unavailable — emit [Compaction_failed]
+             so [context_overflow] stays set and [derive_phase] re-projects
+             to Overflowed.  A subsequent [Compact_retry_exhausted] dispatch
+             (owned by the retry-loop caller) will latch the keeper to Paused.
+             Emitting [Compaction_completed] here would be a false success
+             signal. *)
           Keeper_exec_context.dispatch_keeper_phase_event
             ~config:ctx.config ~keeper_name:name
-            (Keeper_state_machine.Compaction_completed {
-               before_tokens = 0; after_tokens = 0;
+            (Keeper_state_machine.Compaction_failed {
+               reason = "no_valid_checkpoint";
             });
           (false,
            Printf.sprintf

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -805,10 +805,17 @@ let handle_keeper_clear ctx args : tool_result =
               []
           in
           let cleared_ctx = { wctx with messages = cleared_messages } in
-          (* Increment generation to signal a new context epoch after clear. *)
-          let generation = 1 in
+          (* Increment generation from meta to signal a new context epoch.
+             Using a hardcoded value would violate generation monotonicity
+             — the keeper_unified_turn retry loop uses meta.runtime.generation
+             to detect stale contexts. *)
+          let current_gen =
+            match meta_for_trace with
+            | Some meta -> meta.runtime.generation
+            | None -> 0
+          in
           let checkpoint =
-            Keeper_exec_context.create_checkpoint cleared_ctx ~generation:(generation + 1)
+            Keeper_exec_context.create_checkpoint cleared_ctx ~generation:(current_gen + 1)
           in
           Keeper_exec_context.save_session_checkpoint session checkpoint;
           msg_count - List.length cleared_messages

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -757,6 +757,7 @@ let handle_keeper_clear ctx args : tool_result =
           ~primary_model_max_tokens:max_tokens
           ~base_dir
       in
+      let checkpoint_found = Option.is_some ctx_opt in
       let cleared_count =
         match ctx_opt with
         | None -> 0
@@ -802,6 +803,7 @@ let handle_keeper_clear ctx args : tool_result =
                | Some entry -> Keeper_state_machine.phase_to_string entry.phase
                | None -> "unknown"));
            ("cleared_message_count", `Int cleared_count);
+           ("checkpoint_found", `Bool checkpoint_found);
            ("preserve_system_prompt", `Bool preserve_system);
            ("reason", `String reason);
          ]))

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -752,25 +752,34 @@ let handle_keeper_clear ctx args : tool_result =
     | None ->
       error_result_typed ~code:Validation_error
         (Printf.sprintf "keeper %s is not in the registry" name)
-    | Some _entry ->
+    | Some entry ->
       let preserve_system = get_bool args "preserve_system_prompt" true in
-      let phase_before =
-        match Keeper_registry.get ~base_path:ctx.config.base_path name with
-        | Some entry -> Keeper_state_machine.phase_to_string entry.phase
-        | None -> "unknown"
-      in
+      let phase_before = Keeper_state_machine.phase_to_string entry.phase in
       let base_dir = Keeper_types.session_base_dir ctx.config in
-      let trace_id = Keeper_exec_context.generate_trace_id () in
-      let max_tokens =
+      (* Must use the keeper's OWN trace_id to locate its checkpoint file.
+         Using generate_trace_id () would create a fresh session dir and
+         always report 0 cleared messages, because the existing checkpoint
+         lives under meta.runtime.trace_id. *)
+      let meta_for_trace =
         match read_meta_resolved ctx.config name with
-        | Ok (Some (_, meta)) ->
+        | Ok (Some (_, meta)) -> Some meta
+        | _ -> None
+      in
+      let trace_id =
+        match meta_for_trace with
+        | Some meta -> Keeper_id.Trace_id.to_string meta.runtime.trace_id
+        | None -> Keeper_exec_context.generate_trace_id ()
+      in
+      let max_tokens =
+        match meta_for_trace with
+        | Some meta ->
           (match meta.max_context_override with Some n when n > 0 -> n | _ -> 200_000)
-        | _ -> 200_000
+        | None -> 200_000
       in
       let max_checkpoint_messages =
-        match read_meta_resolved ctx.config name with
-        | Ok (Some (_, meta)) -> meta.compaction.max_checkpoint_messages
-        | _ -> 100
+        match meta_for_trace with
+        | Some meta -> meta.compaction.max_checkpoint_messages
+        | None -> 100
       in
       let session, ctx_opt =
         Keeper_exec_context.load_context_from_checkpoint

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -650,11 +650,14 @@ let handle_keeper_compact ctx args : tool_result =
       | "running" | "failing" -> force
       | _ -> false
     in
-    if not allowed then
+    if not allowed then begin
+      Prometheus.inc_counter "masc_keeper_operator_compact_total"
+        ~labels:[("keeper", name); ("result", "precondition")] ();
       error_result_typed ~code:Validation_error
         (Printf.sprintf
            "keeper %s is in phase %s; compaction requires Overflowed, Paused, or force=true"
            name phase_before)
+    end
     else begin
       (* Dispatch FSM event *)
       Keeper_exec_context.dispatch_keeper_phase_event
@@ -687,6 +690,8 @@ let handle_keeper_compact ctx args : tool_result =
                after_tokens = recovery.compaction.after_tokens;
             });
           invalidate_status_cache name;
+          Prometheus.inc_counter "masc_keeper_operator_compact_total"
+            ~labels:[("keeper", name); ("result", "ok")] ();
           (true,
            Yojson.Safe.to_string
              (`Assoc [
@@ -711,6 +716,8 @@ let handle_keeper_compact ctx args : tool_result =
             (Keeper_state_machine.Compaction_failed {
                reason = "no_valid_checkpoint";
             });
+          Prometheus.inc_counter "masc_keeper_operator_compact_total"
+            ~labels:[("keeper", name); ("result", "no_checkpoint")] ();
           (false,
            Printf.sprintf
              "keeper %s: checkpoint compaction unavailable (no valid checkpoint found)"
@@ -793,6 +800,9 @@ let handle_keeper_clear ctx args : tool_result =
       Log.Keeper.warn
         "%s: context cleared by operator (reason=%s, preserve_system=%b, cleared=%d msgs)"
         name reason preserve_system cleared_count;
+      Prometheus.inc_counter "masc_keeper_operator_clear_total"
+        ~labels:[("keeper", name);
+                 ("preserve_system", string_of_bool preserve_system)] ();
       (true,
        Yojson.Safe.to_string
          (`Assoc [

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -638,11 +638,18 @@ let handle_keeper_compact ctx args : tool_result =
   | Error err -> (false, err)
   | Ok name ->
     let force = get_bool args "force" false in
-    let phase_before =
-      match Keeper_registry.get ~base_path:ctx.config.base_path name with
-      | Some entry -> Keeper_state_machine.phase_to_string entry.phase
-      | None -> "unknown"
-    in
+    (* Registry race: [resolve_keeper_name] succeeded but the registry entry
+       can still disappear if another fiber unregistered the keeper.  Treat
+       this as a distinct "not found" error rather than an opaque
+       "phase=unknown" precondition failure. *)
+    match Keeper_registry.get ~base_path:ctx.config.base_path name with
+    | None ->
+      Prometheus.inc_counter "masc_keeper_operator_compact_total"
+        ~labels:[("keeper", name); ("result", "not_found")] ();
+      error_result_typed ~code:Validation_error
+        (Printf.sprintf "keeper %s is not in the registry" name)
+    | Some entry ->
+    let phase_before = Keeper_state_machine.phase_to_string entry.phase in
     (* Phase precondition: Overflowed, Paused, or (Running/Failing with force). *)
     let allowed =
       match phase_before with
@@ -738,6 +745,14 @@ let handle_keeper_clear ctx args : tool_result =
       error_result_typed ~code:Validation_error
         "reason is required for masc_keeper_clear (audit trail)"
     else
+    (* Same registry race guard as [handle_keeper_compact]: if the keeper
+       disappeared between [resolve_keeper_name] and [get], abort cleanly
+       rather than silently proceed with a half-applied clear. *)
+    match Keeper_registry.get ~base_path:ctx.config.base_path name with
+    | None ->
+      error_result_typed ~code:Validation_error
+        (Printf.sprintf "keeper %s is not in the registry" name)
+    | Some _entry ->
       let preserve_system = get_bool args "preserve_system_prompt" true in
       let phase_before =
         match Keeper_registry.get ~base_path:ctx.config.base_path name with

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -84,6 +84,8 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_keeper_msg_result", CanBroadcast);
     ("masc_keeper_repair", CanBroadcast);
     ("masc_keeper_reset", CanBroadcast);
+    ("masc_keeper_compact", CanBroadcast);
+    ("masc_keeper_clear", CanBroadcast);
     ("masc_keeper_create_from_persona", CanBroadcast);
     ("masc_operator_confirm", CanBroadcast);
     ("masc_unit_define", CanBroadcast);

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -224,6 +224,10 @@ let synonyms : (string * string list) list =
      [ "send keeper message"; "talk to keeper"; "message keeper"; "keeper chat" ]);
     ("masc_keeper_status",
      [ "keeper health"; "keeper state"; "keeper check"; "keeper info" ]);
+    ("masc_keeper_compact",
+     [ "compact keeper"; "shrink context"; "reduce context"; "context overflow fix" ]);
+    ("masc_keeper_clear",
+     [ "clear keeper"; "reset keeper context"; "wipe keeper history"; "emergency clear" ]);
     (* masc heartbeat — lifecycle tools *)
     ("masc_heartbeat_start",
      [ "start heartbeat"; "begin pinging"; "auto ping"; "keep alive" ]);

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -214,7 +214,11 @@ let test_keeper_metrics_registered () =
   check bool "has keeper heartbeat successes counter" true
     (has "masc_keeper_heartbeat_successes_total");
   check bool "has keeper heartbeat failures counter" true
-    (has "masc_keeper_heartbeat_failures_total")
+    (has "masc_keeper_heartbeat_failures_total");
+  check bool "has operator compact counter" true
+    (has "masc_keeper_operator_compact_total");
+  check bool "has operator clear counter" true
+    (has "masc_keeper_operator_clear_total")
 
 let test_histogram_exported_as_summary () =
   let name = "test_hist_export_fmt" in


### PR DESCRIPTION
## Summary

- Add `masc_keeper_compact` MCP tool — operator-triggered checkpoint compaction via OAS `recover_latest_checkpoint_for_overflow_retry`
- Add `masc_keeper_clear` MCP tool — last-resort context wipe with audit trail (destructive)
- Full 7-point registration: dispatch, permission, catalog, surfaces, prefilter, tool_profile, schema

## Context

Completes the MASC-2 scope from the Keeper Context Overflow plan (PR #7083 = MASC-1). Automatic overflow detection + compact + retry was already wired in `keeper_unified_turn.ml`. These tools provide the **operator manual path** for when auto-recovery fails or proactive intervention is needed.

## MASC-OAS boundary

Both tools inject FSM events (`Operator_compact_requested`, `Operator_clear_requested`) and call OAS checkpoint APIs. No direct token math or context truncation in MASC — budget belongs in OAS.

## Test plan

- [x] `dune build` passes
- [x] `mcp_tool_matrix` inventory + matrix tests pass (schema registration verified)
- [ ] Manual: `masc_keeper_compact` on an Overflowed keeper → phase returns to Running
- [ ] Manual: `masc_keeper_clear` on a stuck keeper → context reset, audit log written

Closes #7104

🤖 Generated with [Claude Code](https://claude.com/claude-code)