### PR TITLE
fix(hebbian): precise signal + close read loop with masc_preferred_partner tool

### DIFF
--- a/lib/room/room_task.ml
+++ b/lib/room/room_task.ml
@@ -26,6 +26,21 @@ let read_backlog_or_raise config =
   | Ok backlog -> backlog
   | Error msg -> raise (Invalid_argument msg)
 
+(** Agents who currently hold a Claimed or InProgress task.
+    Used by the Hebbian hook to strengthen only against agents who are
+    actively working, not everyone who happens to be joined.
+    Falls back to active_agents if the backlog cannot be read. *)
+let working_agents config =
+  match read_backlog_r config with
+  | Error _ -> (Room_state.read_state config).active_agents
+  | Ok backlog ->
+    List.filter_map (fun (t : task) ->
+      match t.task_status with
+      | Claimed { assignee; _ } | InProgress { assignee; _ } -> Some assignee
+      | _ -> None
+    ) backlog.tasks
+    |> List.sort_uniq String.compare
+
 (** Update the on-disk agent state record under its own file lock.
 
     Task transitions ([claim], [complete], [cancel], …) need to
@@ -807,16 +822,19 @@ let transition_task_r config ~agent_name ~task_id ~action
            (try
               let active = (Room_state.read_state config).active_agents in
               !Room_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active;
+              (* Hebbian: strengthen only against agents with active tasks,
+                 not the full room. See working_agents doc for rationale. *)
+              let workers = working_agents config in
               !Room_hooks.hebbian_on_task_done_fn config
-                ~assignee:agent_name ~active_agents:active
+                ~assignee:agent_name ~active_agents:workers
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.RoomTask.error "transition relation/hebbian done hook: %s"
                 (Printexc.to_string exn))
          | Types.Cancel ->
            (try
-              let active = (Room_state.read_state config).active_agents in
+              let workers = working_agents config in
               !Room_hooks.hebbian_on_task_cancelled_fn config
-                ~agent_name ~active_agents:active
+                ~agent_name ~active_agents:workers
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.RoomTask.error "transition hebbian cancel hook: %s"
                 (Printexc.to_string exn))
@@ -928,9 +946,10 @@ let complete_task config ~agent_name ~task_id ~notes =
             (try
                let active = (Room_state.read_state config).active_agents in
                !Room_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active;
-               (* Hebbian: strengthen collaboration pattern *)
+               (* Hebbian: strengthen only against agents with active tasks *)
+               let workers = working_agents config in
                !Room_hooks.hebbian_on_task_done_fn config
-                 ~assignee:agent_name ~active_agents:active
+                 ~assignee:agent_name ~active_agents:workers
              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.RoomTask.error "relation/hebbian task hook error: %s"
                  (Printexc.to_string exn));
@@ -1118,11 +1137,11 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                               -. task_started_at_unix task.task_status)
                              *. 1000.0)))
                      ());
-              (* Hebbian: weaken collaboration pattern on cancellation *)
+              (* Hebbian: weaken only against agents with active tasks *)
               (try
-                 let active = (Room_state.read_state config).active_agents in
+                 let workers = working_agents config in
                  !Room_hooks.hebbian_on_task_cancelled_fn config
-                   ~agent_name ~active_agents:active
+                   ~agent_name ~active_agents:workers
                with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                  Log.RoomTask.error "hebbian task_cancelled hook error: %s"
                    (Printexc.to_string exn));

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -326,6 +326,32 @@ let handle_collaboration_graph ctx args =
     else
       (true, String.concat "\n" lines)
 
+(** Handle masc_preferred_partner — closes the Hebbian read loop.
+    Returns the agent with the strongest learned collaboration weight
+    for the given agent_id, so keepers can use it when deciding whom
+    to @mention or delegate to. *)
+let handle_preferred_partner ctx args =
+  let agent_id = match get_string_opt args "agent_id" with
+    | Some id when id <> "" -> id
+    | _ -> ctx.agent_name
+  in
+  match Hebbian_eio.get_preferred_partner ctx.config ~agent_id with
+  | None ->
+    (true, Printf.sprintf "No learned partner for %s yet. Complete tasks together to build affinity." agent_id)
+  | Some partner ->
+    let (synapses, _) = Hebbian_eio.get_graph_data ctx.config in
+    let weight = List.find_opt (fun s ->
+      s.Hebbian_eio.from_agent = agent_id && s.Hebbian_eio.to_agent = partner
+    ) synapses in
+    let w = match weight with Some s -> s.Hebbian_eio.weight | None -> 0.0 in
+    let json = `Assoc [
+      ("agent_id", `String agent_id);
+      ("preferred_partner", `String partner);
+      ("affinity_weight", `Float w);
+      ("note", `String "Based on Hebbian learning from shared task completions. Higher weight = more successful past collaboration.");
+    ] in
+    (true, Yojson.Safe.to_string json)
+
 (** Handle masc_consolidate_learning *)
 let handle_consolidate_learning ctx args =
   let decay_after_days = get_int args "decay_after_days" 7 in
@@ -383,6 +409,7 @@ let dispatch ctx ~name ~args =
   | "masc_agent_fitness" -> Some (handle_agent_fitness ctx args)
   | "masc_select_agent" -> Some (handle_select_agent ctx args)
   | "masc_collaboration_graph" -> Some (handle_collaboration_graph ctx args)
+  | "masc_preferred_partner" -> Some (handle_preferred_partner ctx args)
   | "masc_consolidate_learning" -> Some (handle_consolidate_learning ctx args)
   | "masc_agent_card" -> Some (handle_agent_card ctx args)
   | "masc_agent_relations" -> Some (handle_agent_relations ctx args)
@@ -403,6 +430,7 @@ let _tool_spec_requires_join = [ "masc_register_capabilities" ]
 let tool_required_permission = function
   | "masc_agents" | "masc_agent_card" | "masc_agent_fitness"
   | "masc_select_agent" | "masc_collaboration_graph"
+  | "masc_preferred_partner"
   | "masc_get_metrics" | "masc_agent_relations"
   | "masc_meta_cognition_snapshot" ->
       Some Types.CanReadState

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -34,6 +34,9 @@ val handle_select_agent : context -> Yojson.Safe.t -> bool * string
 (** Handle masc_collaboration_graph *)
 val handle_collaboration_graph : context -> Yojson.Safe.t -> bool * string
 
+(** Handle masc_preferred_partner *)
+val handle_preferred_partner : context -> Yojson.Safe.t -> bool * string
+
 (** Handle masc_consolidate_learning *)
 val handle_consolidate_learning : context -> Yojson.Safe.t -> bool * string
 

--- a/lib/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces.ml
@@ -240,6 +240,7 @@ let system_internal_surface_tools =
     (* Agent evaluation — system loop *)
     "masc_agent_fitness"; "masc_agent_relations";
     "masc_meta_cognition_snapshot"; "masc_consolidate_learning";
+    "masc_preferred_partner";
     "masc_select_agent";
     (* Maintenance *)
     "masc_cleanup_zombies"; "masc_gc";

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -41,6 +41,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_dashboard", CanReadState);
     ("masc_check", CanReadState);
     ("masc_collaboration_graph", CanReadState);
+    ("masc_preferred_partner", CanReadState);
     ("masc_feature_flags", CanReadState);
     ("masc_get_metrics", CanReadState);
     ("masc_meta_cognition_snapshot", CanReadState);

--- a/lib/tool_schemas/tool_schemas_agent.ml
+++ b/lib/tool_schemas/tool_schemas_agent.ml
@@ -153,6 +153,20 @@ let schemas : tool_schema list = [
   };
 
   {
+    name = "masc_preferred_partner";
+    description = "Get the agent with the strongest learned collaboration affinity for a given agent. Closes the Hebbian learning loop: strengthened connections from shared task completions become actionable partner suggestions. Use when deciding whom to @mention, delegate to, or collaborate with.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent to find a partner for. Defaults to the calling agent.");
+        ]);
+      ]);
+    ];
+  };
+
+  {
     name = "masc_consolidate_learning";
     description = "Apply decay to old collaboration patterns and prune weak Hebbian connections.";
     input_schema = `Assoc [


### PR DESCRIPTION
## Summary

Two commits that transform Hebbian from a write-only recording system into an actionable feedback loop.

**Commit 1 (D2)**: Narrow the write signal — strengthen/weaken only against agents holding active tasks, not the entire room membership.

**Commit 2 (D1a)**: Close the read loop — expose \`masc_preferred_partner\` as an MCP tool so keepers can query their strongest collaboration partner.

## Why

Session audit found Hebbian was **open-loop**: \`get_preferred_partner\` had zero production callers. The write signal also strengthened every joined agent (room membership noise), not just actual collaborators.

## Changes

### Commit 1: \`lib/room/room_task.ml\` (+27/-8)

\`\`\`
BEFORE: task done → strengthen(assignee, ALL active_agents)
AFTER:  task done → strengthen(assignee, agents with Claimed/InProgress tasks)
\`\`\`

New \`working_agents\` helper reads the backlog and returns only agents currently holding tasks. Falls back to \`active_agents\` if backlog unreadable.

4 call sites changed (transition_task_r Done, transition_task_r Cancel, complete_task, cancel_task_r).

### Commit 2: 4 files (+46)

- **\`tool_agent.ml\`**: \`handle_preferred_partner\` — returns the agent with highest Hebbian weight for a given agent_id.
- **\`tool_agent.mli\`**: export.
- **\`tool_schemas_agent.ml\`**: schema with optional \`agent_id\` param.
- **\`tool_permission_map.ml\`**: \`CanReadState\`.

Response: \`{ agent_id, preferred_partner, affinity_weight, note }\`

## The loop, closed

\`\`\`
[WRITE] task_done → strengthen(assignee, working_agents)
[STORE] .masc/synapses/graph.json
[READ]  masc_preferred_partner tool ← keeper LLM queries this
[ACT]   keeper @mentions or delegates to preferred partner
[LEARN] next task_done → strengthen the pair again (or weaken on cancel)
\`\`\`

## Product impact

- Synapses become meaningful: only agents actively working together build affinity.
- Keepers can discover "who should I collaborate with?" via the tool.
- The dashboard matrix heatmap (#7068) now visualizes a signal that drives behavior, not just room membership noise.

## Evidence

| Check | Result |
|-------|--------|
| \`dune build\` | clean |
| \`dune exec test/test_hebbian_eio.exe\` | 14/14 pass |

## Limitation

\`working_agents\` is coarser than "collaborated on this specific task" — MASC tasks have a single assignee, no co-worker list. A future data model change (task collaborators) would allow finer granularity.

## Linked

Part of Hebbian improvement series:
- [x] #7068 (matrix viz + sparkline)
- [x] #7091 (honest comments)
- [x] #7106 (SSOT constants)
- [ ] A: episode ↔ synapse linking (dashboard, next)