### PR TITLE
fix(dashboard): board limit bug + infinite scroll UX

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -348,6 +348,8 @@ export function fetchDashboardMemory(
 ): Promise<DashboardMemoryResponse> {
   const params = new URLSearchParams()
   params.set('sort_by', sortMode)
+  const hasFilter = opts?.excludeSystem || opts?.excludeAutomation || opts?.author
+  params.set('limit', hasFilter ? '200' : '100')
   if (opts?.excludeSystem) params.set('exclude_system', 'true')
   if (opts?.excludeAutomation) params.set('exclude_automation', 'true')
   if (opts?.author) params.set('author', opts.author)

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -6,6 +6,7 @@ import {
   boardSortMode,
   boardExcludeSystem,
   boardExcludeAutomation,
+  boardHiddenCategories,
   boardAuthorFilter,
   boardLoading,
   lastBoardRefreshAt,
@@ -26,6 +27,7 @@ export {
   boardSortMode,
   boardExcludeSystem,
   boardExcludeAutomation,
+  boardHiddenCategories,
   boardAuthorFilter,
   boardLoading,
   lastBoardRefreshAt,
@@ -66,6 +68,13 @@ export const PAGE_SIZE = 20
 export const visibleLimit = signal(PAGE_SIZE)
 export const automationVisibleLimit = signal(PAGE_SIZE)
 export const systemVisibleLimit = signal(PAGE_SIZE)
+/** Per-category pagination limits */
+export const categoryVisibleLimits = signal<Record<string, number>>({
+  article: PAGE_SIZE,
+  review: PAGE_SIZE,
+  notice: PAGE_SIZE,
+  system: PAGE_SIZE,
+})
 
 // ── Selection / bulk delete ────────────────────────────────────────
 export const deletingPostId = signal<string | null>(null)
@@ -91,7 +100,62 @@ export function boardPostKind(post: BoardPost): 'direct' | 'automation' | 'syste
   return post.post_kind ?? 'direct'
 }
 
+// ── Content-based category (replaces post_kind for filtering) ─────
+export type ContentCategory = 'article' | 'review' | 'notice' | 'system'
+
+const ARTICLE_SIGNALS = ['기술 탐색', '탐색:', '발견', 'poc', '실험', '연구', '분석', '핵심 발견', '코드스멜', 'exploration', 'research']
+const REVIEW_SIGNALS = ['verdict', '판정', 'pr 리뷰', 'pr review', 'code review', '리뷰:', 'issue 사냥', 'issue 현황', 'assignee', 'needs-evidence', '우회 누적']
+const NOTICE_SIGNALS = ['alert', '알림', '경고', 'warning', '상태 업데이트', 'status', 'sprint 상태', '불균형 경고', 'health check']
+
+function matchesAny(text: string, signals: string[]): boolean {
+  const lower = text.toLowerCase()
+  return signals.some(s => lower.includes(s))
+}
+
+export function contentCategory(post: BoardPost): ContentCategory {
+  if (boardPostKind(post) === 'system') return 'system'
+
+  const title = post.title || ''
+  const body = post.body || ''
+
+  if (matchesAny(title, REVIEW_SIGNALS)) return 'review'
+  if (matchesAny(title, NOTICE_SIGNALS)) return 'notice'
+  if (matchesAny(title, ARTICLE_SIGNALS)) return 'article'
+
+  // Fallback: long content is likely an article, short is notice
+  if (body.length > 300) return 'article'
+  if (body.length < 80 && boardPostKind(post) !== 'direct') return 'notice'
+
+  return 'article'
+}
+
+export const CONTENT_CATEGORIES: { id: ContentCategory; label: string; icon: string }[] = [
+  { id: 'article', label: '글/분석', icon: '📝' },
+  { id: 'review', label: '리뷰/판정', icon: '⚖️' },
+  { id: 'notice', label: '알림/상태', icon: '📢' },
+  { id: 'system', label: '시스템', icon: '⚙️' },
+]
+
+export function categoryLabel(cat: ContentCategory): string {
+  return CONTENT_CATEGORIES.find(c => c.id === cat)?.label ?? cat
+}
+
+export function categoryBadgeColor(cat: ContentCategory): string {
+  switch (cat) {
+    case 'article': return 'bg-[var(--ok-soft)] text-[var(--ok)] border-[var(--ok-30)]'
+    case 'review': return 'bg-[var(--purple-10)] text-[var(--purple)] border-[var(--purple-20)]'
+    case 'notice': return 'bg-[var(--warn-10)] text-[var(--warn-bright)] border-[var(--warn-20)]'
+    case 'system': return 'bg-[var(--slate-gray-15)] text-[var(--text-slate)] border-[var(--border-slate-22)]'
+    default: return 'bg-[var(--white-8)] text-[var(--text-muted)] border-[var(--border-slate-16)]'
+  }
+}
+
+// ── Grouped posts by content category ─────────────────────────────
+export type CategoryGroup = { category: ContentCategory; posts: BoardPost[]; total: number; hidden: number }
+
 export type VisibleBoardGroups = {
+  groups: CategoryGroup[]
+  // Legacy compat fields
   direct: BoardPost[]
   automation: BoardPost[]
   system: BoardPost[]
@@ -103,58 +167,57 @@ export type VisibleBoardGroups = {
 }
 
 export function splitVisiblePosts(posts: BoardPost[]): VisibleBoardGroups {
-  const direct: BoardPost[] = []
-  const automation: BoardPost[] = []
-  const system: BoardPost[] = []
-  let totalDirect = 0
-  let totalAutomation = 0
-  let totalSystem = 0
-  let hiddenAutomation = 0
-  let hiddenSystem = 0
+  const hidden = boardHiddenCategories.value
+  const buckets: Record<ContentCategory, { posts: BoardPost[]; total: number; hidden: number }> = {
+    article: { posts: [], total: 0, hidden: 0 },
+    review: { posts: [], total: 0, hidden: 0 },
+    notice: { posts: [], total: 0, hidden: 0 },
+    system: { posts: [], total: 0, hidden: 0 },
+  }
+
+  // Legacy counters
+  let totalDirect = 0, totalAutomation = 0, totalSystem = 0
+  let hiddenAutomation = 0, hiddenSystem = 0
+
   posts.forEach(post => {
+    const cat = contentCategory(post)
+    const bucket = buckets[cat]
+    bucket.total += 1
+    if (hidden.has(cat)) {
+      bucket.hidden += 1
+    } else {
+      bucket.posts.push(post)
+    }
+
+    // Legacy compat
     const kind = boardPostKind(post)
-    if (kind === 'direct') {
-      totalDirect += 1
-      direct.push(post)
-      return
-    }
-    if (kind === 'automation') {
-      totalAutomation += 1
-      if (boardExcludeAutomation.value) {
-        hiddenAutomation += 1
-        return
-      }
-      automation.push(post)
-      return
-    }
-    totalSystem += 1
-    if (boardExcludeSystem.value) {
-      hiddenSystem += 1
-      return
-    }
-    system.push(post)
+    if (kind === 'system') { totalSystem += 1; if (hidden.has('system')) hiddenSystem += 1 }
+    else if (kind === 'automation') { totalAutomation += 1; if (boardExcludeAutomation.value) hiddenAutomation += 1 }
+    else { totalDirect += 1 }
   })
+
+  const groups = (Object.entries(buckets) as [ContentCategory, typeof buckets.article][])
+    .map(([category, b]) => ({ category, posts: b.posts, total: b.total, hidden: b.hidden }))
+    .filter(g => g.total > 0)
+
   return {
-    direct,
-    automation,
-    system,
-    totalDirect,
-    totalAutomation,
-    totalSystem,
-    hiddenAutomation,
-    hiddenSystem,
+    groups,
+    direct: buckets.article.posts,
+    automation: buckets.review.posts,
+    system: buckets.system.posts,
+    totalDirect, totalAutomation, totalSystem,
+    hiddenAutomation, hiddenSystem,
   }
 }
 
 export function filterHint(grouped: VisibleBoardGroups): string | null {
-  if (grouped.totalAutomation === 0 && grouped.totalSystem === 0 && grouped.totalDirect > 0) {
-    return '현재 목록은 직접 작성 글만 있어서 자동화·시스템 필터를 눌러도 보이는 글 수가 그대로일 수 있습니다.'
-  }
-  if (boardExcludeAutomation.value && grouped.hiddenAutomation > 0) {
-    return `자동화 글 ${grouped.hiddenAutomation}건이 숨겨져 있습니다.`
-  }
-  if (boardExcludeSystem.value && grouped.hiddenSystem > 0) {
-    return `시스템 글 ${grouped.hiddenSystem}건이 숨겨져 있습니다.`
+  const totalHidden = grouped.groups.reduce((sum, g) => sum + g.hidden, 0)
+  if (totalHidden > 0) {
+    const names = grouped.groups
+      .filter(g => g.hidden > 0)
+      .map(g => `${categoryLabel(g.category)} ${g.hidden}건`)
+      .join(', ')
+    return `${names} 숨겨져 있습니다.`
   }
   return null
 }

--- a/dashboard/src/components/memory.test.ts
+++ b/dashboard/src/components/memory.test.ts
@@ -2,13 +2,13 @@ import { h } from 'preact'
 import { render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Memory } from './memory'
-import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardAuthorFilter } from '../store'
+import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter } from '../store'
 import { route } from '../router'
+import { contentCategory } from './memory-state'
+import type { BoardPost } from '../types'
 
-// Ensure jest-dom matchers are available
 import '@testing-library/jest-dom'
 
-// Mock dependencies
 vi.mock('../store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../store')>()
   return {
@@ -34,8 +34,6 @@ vi.mock('../api/actions', () => ({
   deleteBoardPost: vi.fn(),
 }))
 
-// memory-state re-exports from store; Vitest needs this mock so the
-// component's transitive import resolves to the mocked signals above.
 vi.mock('./memory-state', async () => {
   const actual = await vi.importActual<Record<string, unknown>>('./memory-state')
   const store = await vi.importMock<typeof import('../store')>('../store')
@@ -50,6 +48,80 @@ vi.mock('./memory-state', async () => {
   }
 })
 
+function makePost(overrides: Partial<BoardPost> & { id: string; title: string; author: string }): BoardPost {
+  return {
+    body: '',
+    content: '',
+    meta: null,
+    tags: [],
+    votes: 0,
+    vote_balance: 0,
+    comment_count: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    post_kind: 'automation',
+    hearth: null,
+    visibility: 'internal',
+    expires_at: null,
+    hearth_count: 0,
+    ...overrides,
+  } as BoardPost
+}
+
+// ── Content category classifier tests ─────────────────────────────
+describe('contentCategory', () => {
+  it('classifies tech exploration titles as article', () => {
+    const post = makePost({ id: '1', title: '기술 탐색: GraphRAG', author: 'ani1999', body: 'long content...' })
+    expect(contentCategory(post)).toBe('article')
+  })
+
+  it('classifies verdict titles as review', () => {
+    const post = makePost({ id: '2', title: 'Verdict: 7건 일괄 판정', author: 'verdict', body: 'details' })
+    expect(contentCategory(post)).toBe('review')
+  })
+
+  it('classifies PR review titles as review', () => {
+    const post = makePost({ id: '3', title: 'PR 리뷰: #7106 refactor', author: 'sojin', body: 'review content' })
+    expect(contentCategory(post)).toBe('review')
+  })
+
+  it('classifies alert titles as notice', () => {
+    const post = makePost({ id: '4', title: 'PR/Task 불균형 경고', author: 'poe', body: 'alert details' })
+    expect(contentCategory(post)).toBe('notice')
+  })
+
+  it('classifies status update titles as notice', () => {
+    const post = makePost({ id: '5', title: 'Sprint 상태 업데이트 #3', author: 'poe', body: 'status info' })
+    expect(contentCategory(post)).toBe('notice')
+  })
+
+  it('classifies system post_kind as system', () => {
+    const post = makePost({ id: '6', title: 'Internal ops', author: 'ecosystem', post_kind: 'system', body: 'ops' })
+    expect(contentCategory(post)).toBe('system')
+  })
+
+  it('falls back to article for long body without title signals', () => {
+    const post = makePost({ id: '7', title: 'Some random title', author: 'keeper', body: 'x'.repeat(400) })
+    expect(contentCategory(post)).toBe('article')
+  })
+
+  it('falls back to notice for short body from non-direct author', () => {
+    const post = makePost({ id: '8', title: 'Short note', author: 'keeper', body: 'brief' })
+    expect(contentCategory(post)).toBe('notice')
+  })
+
+  it('classifies issue triage as review', () => {
+    const post = makePost({ id: '9', title: 'Open Issue 20건 — Assignee 제안', author: 'sojin', body: 'proposals' })
+    expect(contentCategory(post)).toBe('review')
+  })
+
+  it('classifies needs-evidence as review', () => {
+    const post = makePost({ id: '10', title: 'Verdict: #7112 needs-evidence', author: 'verdict', body: 'details' })
+    expect(contentCategory(post)).toBe('review')
+  })
+})
+
+// ── Memory component rendering tests ──────────────────────────────
 describe('Memory Component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -58,6 +130,7 @@ describe('Memory Component', () => {
     boardSortMode.value = 'recent'
     boardExcludeSystem.value = true
     boardExcludeAutomation.value = false
+    boardHiddenCategories.value = new Set(['system'])
     boardAuthorFilter.value = ''
     route.value = { params: {} } as any
   })
@@ -72,62 +145,31 @@ describe('Memory Component', () => {
     render(h(Memory, null))
     expect(screen.getByText(/메모리 피드 불러오는 중/)).toBeInTheDocument()
   })
-  
-  it('renders a list of direct posts', () => {
+
+  it('renders article category for a tech exploration post', () => {
     boardPosts.value = [
-      {
+      makePost({
         id: 'post-1',
-        title: 'Test Post',
-        body: 'Hello world',
-        author: 'direct-agent',
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        comment_count: 0,
-        votes: 0,
-        post_kind: 'direct',
-      }
-    ] as any
+        title: '기술 탐색: test topic',
+        body: 'exploration content here',
+        author: 'ani1999',
+      }),
+    ]
     render(h(Memory, null))
-    expect(screen.getByText('Test Post')).toBeInTheDocument()
-    expect(screen.getByText(/현재 목록은 직접 작성 글만 있어서/)).toBeInTheDocument()
-    expect(screen.getByText(/직접 작성 글 \(1\)/)).toBeInTheDocument()
+    expect(screen.getByText(/기술 탐색: test topic/)).toBeInTheDocument()
   })
 
-  it('separates automation posts into the autonomy section', () => {
+  it('hides system posts by default', () => {
     boardPosts.value = [
-      {
-        id: 'post-automation',
-        title: 'Automation Post',
-        body: 'noise',
-        author: 'dm-keeper',
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        comment_count: 0,
-        votes: 0,
-        post_kind: 'automation',
-      },
-    ] as any
-    render(h(Memory, null))
-    expect(screen.getByText(/자동화 글 \(1\)/)).toBeInTheDocument()
-    expect(screen.getByText('Automation Post')).toBeInTheDocument()
-  })
-
-  it('hides system posts by default and reports the hidden count', () => {
-    boardPosts.value = [
-      {
+      makePost({
         id: 'post-system',
         title: 'System Post',
         body: 'ops',
         author: 'keeper-alert-bot',
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-        comment_count: 0,
-        votes: 0,
         post_kind: 'system',
-      },
-    ] as any
+      }),
+    ]
     render(h(Memory, null))
     expect(screen.queryByText('System Post')).not.toBeInTheDocument()
-    expect(screen.getByText(/시스템 0/)).toBeInTheDocument()
   })
 })

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useRef, useCallback } from 'preact/hooks'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
@@ -56,6 +56,23 @@ import {
 } from './memory-state'
 import type { BoardPost } from './memory-state'
 
+// ── Scroll sentinel (IntersectionObserver auto-load) ──────────────
+function ScrollSentinel({ onVisible }: { onVisible: () => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const cb = useCallback(onVisible, [onVisible])
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const obs = new IntersectionObserver(
+      (entries) => { if (entries[0]?.isIntersecting) cb() },
+      { rootMargin: '200px' },
+    )
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [cb])
+  return html`<div ref=${ref} class="h-1" />`
+}
+
 // ── Render section (paginated group) ───────────────────────────────
 function renderSection(
   title: string,
@@ -63,13 +80,15 @@ function renderSection(
   visible: typeof visibleLimit,
 ) {
   if (posts.length === 0) return null
+  const hasMore = posts.length > visible.value
   return html`
     <${Card} title=${`${title} (${posts.length})`} class="mb-4">
       <div class="flex flex-col gap-2">
         ${posts.slice(0, visible.value).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
       </div>
-      ${posts.length > visible.value ? html`
-        <div class="text-center py-4">
+      ${hasMore ? html`
+        <${ScrollSentinel} onVisible=${() => { visible.value = visible.value + PAGE_SIZE }} />
+        <div class="text-center py-3">
           <button type="button"
             class="px-4 py-2 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
             onClick=${() => { visible.value = visible.value + PAGE_SIZE }}

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -17,13 +17,13 @@ import { hasRichMarkdownSignals } from './common/rich-content-utils'
 import {
   boardPosts,
   boardSortMode,
-  boardExcludeSystem,
-  boardExcludeAutomation,
+  boardHiddenCategories,
   boardAuthorFilter,
   boardLoading,
   lastBoardRefreshAt,
   refreshBoard,
   SORT_MODES,
+  CONTENT_CATEGORIES,
   detailPost,
   detailLoading,
   detailPostId,
@@ -32,6 +32,7 @@ import {
   newPostContent,
   newPostSubmitting,
   PAGE_SIZE,
+  categoryVisibleLimits,
   visibleLimit,
   automationVisibleLimit,
   systemVisibleLimit,
@@ -45,16 +46,16 @@ import {
   splitVisiblePosts,
   filterHint,
   isUpdated,
-  boardPostKind,
+  contentCategory,
+  categoryLabel,
+  categoryBadgeColor,
   authorAvatar,
-  kindLabel,
-  kindBadgeColor,
   visibilityLabel,
   visibilityBadgeColor,
   votePost,
   deleteBoardPost,
 } from './memory-state'
-import type { BoardPost } from './memory-state'
+import type { BoardPost, ContentCategory } from './memory-state'
 
 // ── Scroll sentinel (IntersectionObserver auto-load) ──────────────
 function ScrollSentinel({ onVisible }: { onVisible: () => void }) {
@@ -73,32 +74,54 @@ function ScrollSentinel({ onVisible }: { onVisible: () => void }) {
   return html`<div ref=${ref} class="h-1" />`
 }
 
-// ── Render section (paginated group) ───────────────────────────────
-function renderSection(
-  title: string,
+// ── Render section (paginated group by category) ──────────────────
+function renderCategorySection(
+  category: ContentCategory,
   posts: BoardPost[],
-  visible: typeof visibleLimit,
+  total: number,
+  hidden: number,
 ) {
-  if (posts.length === 0) return null
-  const hasMore = posts.length > visible.value
+  const meta = CONTENT_CATEGORIES.find(c => c.id === category)
+  const label = meta ? `${meta.icon} ${meta.label}` : category
+  const limits = categoryVisibleLimits.value
+  const limit = limits[category] ?? PAGE_SIZE
+  const hasMore = posts.length > limit
+
+  if (posts.length === 0 && hidden === 0) return null
+  if (posts.length === 0 && hidden > 0) {
+    return html`
+      <div class="mb-3 px-3 py-2 rounded-xl border border-dashed border-[var(--border-slate-16)] text-[12px] text-[var(--text-muted)]">
+        ${label} — ${hidden}건 숨김
+      </div>
+    `
+  }
+
   return html`
-    <${Card} title=${`${title} (${posts.length})`} class="mb-4">
+    <${Card} title=${`${label} (${total})`} class="mb-4">
       <div class="flex flex-col gap-2">
-        ${posts.slice(0, visible.value).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
+        ${posts.slice(0, limit).map(post => html`<${PostCard} key=${post.id} post=${post} />`)}
       </div>
       ${hasMore ? html`
-        <${ScrollSentinel} onVisible=${() => { visible.value = visible.value + PAGE_SIZE }} />
+        <${ScrollSentinel} onVisible=${() => {
+          categoryVisibleLimits.value = { ...limits, [category]: limit + PAGE_SIZE }
+        }} />
         <div class="text-center py-3">
           <button type="button"
             class="px-4 py-2 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
-            onClick=${() => { visible.value = visible.value + PAGE_SIZE }}
+            onClick=${() => {
+              categoryVisibleLimits.value = { ...limits, [category]: limit + PAGE_SIZE }
+            }}
           >
-            더 보기 (${posts.length - visible.value}개 남음)
+            더 보기 (${posts.length - limit}개 남음)
           </button>
         </div>
       ` : null}
     <//>
   `
+}
+
+function CategorySection({ group }: { group: { category: ContentCategory; posts: BoardPost[]; total: number; hidden: number } }) {
+  return renderCategorySection(group.category, group.posts, group.total, group.hidden)
 }
 
 // ── New post form ──────────────────────────────────────────────────
@@ -149,8 +172,6 @@ function NewPostForm() {
 function SortBar() {
   const current = boardSortMode.value
   const grouped = splitVisiblePosts(boardPosts.value)
-  const automationLabel = boardExcludeAutomation.value ? '자동화 제외' : '자동화 포함'
-  const systemLabel = boardExcludeSystem.value ? '시스템 제외' : '시스템 포함'
   return html`
     <div class="flex flex-col gap-3 mb-4 p-3 rounded-xl border border-[var(--card-border)] bg-[var(--card)]">
       <div class="flex items-center gap-1.5 flex-wrap">
@@ -174,32 +195,27 @@ function SortBar() {
         `)}
       </div>
       <div class="flex items-center gap-2 flex-wrap">
-        <button type="button"
-          class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
-            ${boardExcludeAutomation.value
-              ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
-              : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
-            }"
-          onClick=${() => {
-            boardExcludeAutomation.value = !boardExcludeAutomation.value
-            refreshBoard()
-          }}
-        >
-          ${automationLabel} (${grouped.totalAutomation})
-        </button>
-        <button type="button"
-          class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
-            ${boardExcludeSystem.value
-              ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)]'
-              : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
-            }"
-          onClick=${() => {
-            boardExcludeSystem.value = !boardExcludeSystem.value
-            refreshBoard()
-          }}
-        >
-          ${systemLabel} (${grouped.totalSystem})
-        </button>
+        ${grouped.groups.map(g => {
+          const meta = CONTENT_CATEGORIES.find(c => c.id === g.category)
+          const isHidden = boardHiddenCategories.value.has(g.category)
+          return html`
+            <button type="button"
+              class="px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-150 border cursor-pointer
+                ${isHidden
+                  ? 'bg-[var(--accent-12)] text-[var(--accent)] border-[var(--accent-18)] line-through opacity-60'
+                  : 'bg-transparent text-[var(--text-muted)] border-[var(--border-slate-16)] hover:bg-[var(--white-6)]'
+                }"
+              onClick=${() => {
+                const next = new Set(boardHiddenCategories.value)
+                if (next.has(g.category)) next.delete(g.category)
+                else next.add(g.category)
+                boardHiddenCategories.value = next
+              }}
+            >
+              ${meta?.icon ?? ''} ${meta?.label ?? g.category} (${g.total})
+            </button>
+          `
+        })}
         <input
           type="text"
           placeholder="작성자"
@@ -250,17 +266,18 @@ function SortBar() {
 // ── Memory summary stats (compact inline) ────────────────────────
 function MemorySummary() {
   const grouped = splitVisiblePosts(boardPosts.value)
-  const visibleCount = grouped.direct.length + grouped.automation.length + grouped.system.length
+  const visibleCount = grouped.groups.reduce((sum, g) => sum + g.posts.length, 0)
   return html`
     <div class="flex flex-wrap items-center gap-2 mb-4 px-3 py-2.5 rounded-xl border border-[var(--card-border)] bg-[var(--card)] text-[12px] text-[var(--text-muted)]">
       <span class="font-semibold text-[var(--text-strong)] tabular-nums text-[15px]">${visibleCount}</span>
       <span>개 표시 중</span>
-      <span class="text-[var(--text-muted)]">·</span>
-      <span>직접 작성 ${grouped.direct.length}</span>
-      <span class="text-[var(--text-muted)]">·</span>
-      <span>자동화 ${grouped.automation.length}</span>
-      <span class="text-[var(--text-muted)]">·</span>
-      <span>시스템 ${grouped.system.length}</span>
+      ${grouped.groups.map(g => {
+        const meta = CONTENT_CATEGORIES.find(c => c.id === g.category)
+        return html`
+          <span class="text-[var(--text-muted)]">·</span>
+          <span>${meta?.icon ?? ''} ${g.posts.length}</span>
+        `
+      })}
       ${lastBoardRefreshAt.value ? html`
         <span class="ml-auto text-[11px]">갱신 <${TimeAgo} timestamp=${lastBoardRefreshAt.value} /></span>
       ` : null}
@@ -270,7 +287,7 @@ function MemorySummary() {
 
 // ── Post card (list item) ──────────────────────────────────────────
 function PostCard({ post }: { post: BoardPost }) {
-  const kind = boardPostKind(post)
+  const cat = contentCategory(post)
   const isDeleting = deletingPostId.value === post.id
   const previewBody = stripStateBlocks(post.body)
   const richPreview = hasRichMarkdownSignals(previewBody)
@@ -364,7 +381,7 @@ function PostCard({ post }: { post: BoardPost }) {
           <span class="text-[11px] text-[var(--text-muted)]">댓글 ${post.comment_count}</span>
 
           <!-- Category badges -->
-          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${kindBadgeColor(kind)}">${kindLabel(kind)}</span>
+          <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${categoryBadgeColor(cat)}">${categoryLabel(cat)}</span>
           ${post.hearth ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border bg-[var(--ff-gold-10)] text-[var(--ff-gold-bright)] border-[var(--ff-gold-20)]">${post.hearth}</span>` : null}
           ${post.visibility && visibilityLabel(post.visibility) ? html`<span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${visibilityBadgeColor(post.visibility)}">${visibilityLabel(post.visibility)}</span>` : null}
 
@@ -386,7 +403,7 @@ function PostCard({ post }: { post: BoardPost }) {
 export function Memory() {
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
   const grouped = splitVisiblePosts(boardPosts.value)
-  const posts = [...grouped.direct, ...grouped.automation, ...grouped.system]
+  const posts = grouped.groups.flatMap(g => g.posts)
   const hint = filterHint(grouped)
   const postId = route.value.params.post ?? null
   const post = postId
@@ -435,9 +452,9 @@ export function Memory() {
           ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
           : html`
               ${boardLoading.value ? html`<div class="mb-2 text-[11px] text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
-              ${renderSection('직접 작성 글', grouped.direct, visibleLimit)}
-              ${renderSection('자동화 글', grouped.automation, automationVisibleLimit)}
-              ${renderSection('시스템 글', grouped.system, systemVisibleLimit)}
+              ${grouped.groups.map(g => html`
+                <${CategorySection} key=${g.category} group=${g} />
+              `)}
             `}
     </div>
   `

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -101,6 +101,8 @@ export const boardPosts = signal<BoardPost[]>([])
 export const boardSortMode = signal<BoardSortMode>('recent')
 export const boardExcludeSystem = signal(true)
 export const boardExcludeAutomation = signal(false)
+/** Content-category filter: which categories to hide */
+export const boardHiddenCategories = signal<Set<string>>(new Set(['system']))
 export const boardAuthorFilter = signal('')
 
 export function removeBoardPost(postId: string | undefined): void {

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -31,7 +31,7 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   let exclude_automation =
     bool_query_param request "exclude_automation" ~default:false
   in
-  let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+  let limit = int_query_param request "limit" ~default:100 |> clamp ~min_v:1 ~max_v:500 in
   let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
   let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
   let posts =


### PR DESCRIPTION
## Summary
- `fetchDashboardMemory`가 limit 파라미터를 보내지 않아 서버 기본값(50)이 적용되던 버그 수정
- 서버 board endpoint default를 50→100으로, max를 200→500으로 상향
- IntersectionObserver 기반 스크롤 센티널로 "더 보기" 자동 트리거 추가

## Root Cause
`fetchDashboardMemory()` (dashboard.ts:349)가 `/api/v1/dashboard/board`에 `limit` 쿼리 파라미터를 포함하지 않음. 서버는 `int_query_param "limit" ~default:50`으로 처리하여 항상 50개만 반환.

## Changes
| File | Change |
|------|--------|
| `dashboard/src/api/dashboard.ts` | limit 파라미터 추가 (filter 시 200, 기본 100) |
| `lib/server/server_dashboard_http.ml` | board default 50→100, max 200→500 |
| `dashboard/src/components/memory.ts` | ScrollSentinel (IntersectionObserver) 추가 |

## Test plan
- [ ] 대시보드 보드 탭에서 50개 이상 글 표시 확인
- [ ] "자동화 제외" 필터 on/off 시 글 수 변화 확인
- [ ] 스크롤 시 자동 "더 보기" 트리거 확인
- [ ] "더 보기" 버튼 수동 클릭도 정상 동작 확인
