### PR TITLE
fix(keeper): review findings — subscription leak, mermaid sanitize, dead code

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -289,12 +289,16 @@ type provider_health =
   | `Unknown
   ]
 
+let sanitize_mermaid_note s =
+  String.map (fun c ->
+    if c = ':' || c = '\n' || c = '\r' then ' ' else c) s
+
 let unhealthy_reason_label = function
   | `Saturated -> "saturated"
   | `Unreachable -> "unreachable"
   | `Rate_limited -> "rate_limited"
   | `Timeout -> "timeout"
-  | `Other s -> s
+  | `Other s -> sanitize_mermaid_note s
 
 let cascade_fsm_to_mermaid
     ?(provider_health : (string * provider_health) list option)
@@ -318,25 +322,20 @@ let cascade_fsm_to_mermaid
   (* Provider nodes *)
   let n = List.length models in
   List.iteri (fun i label ->
-    let safe = String.map (fun c ->
-      if c = ':' || c = '/' then '_' else c) label
-    in
-    let display = label in
     let is_last = (i = n - 1) in
     let try_edge = if is_last then "TryLast" else "TryNonLast" in
     if i = 0 then
       p "    SelectProvider --> P%d: %s\n" i try_edge
     else
       p "    P%d --> P%d: CascadableError\n" (i - 1) i;
-    p "    state \"%s\" as P%d\n" display i;
+    p "    state \"%s\" as P%d\n" label i;
     p "    P%d --> Accept: RespondOk\n" i;
     if not is_last then begin
       p "    P%d --> P%d: SlotUnavailable\n" i (i + 1)
     end else begin
       p "    P%d --> AcceptExhaust: LastProviderFail\\n(accept_on_exhaustion)\n" i;
       p "    P%d --> Exhausted: LastProviderFail\n" i
-    end;
-    ignore safe
+    end
   ) models;
   p "    Accept --> [*]\n";
   p "    AcceptExhaust --> [*]\n";

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1336,9 +1336,15 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           ~base_path:config.base_path ~keeper_name:meta.name
         with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None
       in
+      let unsubscribe_event_bus () =
+        match event_bus_sub, Keeper_event_bus.get () with
+        | Some sub, Some bus -> Agent_sdk.Event_bus.unsubscribe bus sub
+        | _ -> ()
+      in
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
-          Keeper_exec_tools.remove_tool_call_observer side_effect_observer)
+          Keeper_exec_tools.remove_tool_call_observer side_effect_observer;
+          unsubscribe_event_bus ())
         (fun () ->
         Keeper_exec_context.timed (fun () ->
           let clock = Eio_context.get_clock () in
@@ -1620,11 +1626,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             end else
               Error (Oas.Error.Internal msg))))
       in
+      (* Drain correlation_id from the subscription created before the
+         turn. Unsubscribe is handled by [unsubscribe_event_bus] in the
+         Fun.protect ~finally above, so this path only drains. *)
       (match event_bus_sub, Keeper_event_bus.get () with
-       | Some sub, Some bus ->
-         let events = Agent_sdk.Event_bus.drain sub in
-         Agent_sdk.Event_bus.unsubscribe bus sub;
-         (match events with
+       | Some sub, Some _bus ->
+         (match Agent_sdk.Event_bus.drain sub with
           | ev :: _ ->
             Keeper_registry.set_last_correlation_id
               ~base_path:config.base_path meta.name

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -172,6 +172,18 @@ let test_cascade_mermaid_renders_other_reason () =
   check bool "other reason string passes through"
     true (substring_present ~haystack:out ~needle:"unhealthy: custom-signal")
 
+let test_cascade_mermaid_other_sanitizes_newline_colon () =
+  let out = DA.cascade_fsm_to_mermaid
+      ~provider_health:[("alpha", `Unhealthy (`Other "line1\nline2:bad"))]
+      ~models:["alpha"]
+      ~last_provider_result:None
+      ()
+  in
+  check bool "sanitized output contains expected string"
+    true (substring_present ~haystack:out ~needle:"unhealthy: line1 line2 bad");
+  check bool "unsanitized colon not present in note"
+    false (substring_present ~haystack:out ~needle:"line2:bad")
+
 let test_cascade_mermaid_healthy_no_reason_note () =
   let out = DA.cascade_fsm_to_mermaid
       ~provider_health:[("alpha", `Healthy)]
@@ -214,6 +226,7 @@ let () =
     "provider_health_reason", [
       test_case "saturated reason in note" `Quick test_cascade_mermaid_renders_saturated_reason;
       test_case "other reason passes through" `Quick test_cascade_mermaid_renders_other_reason;
+      test_case "other reason sanitizes newline and colon" `Quick test_cascade_mermaid_other_sanitizes_newline_colon;
       test_case "healthy has no unhealthy note" `Quick test_cascade_mermaid_healthy_no_reason_note;
     ];
   ]


### PR DESCRIPTION
## Summary
Post-implementation code review (#7097, #7101, #7112) 발견 3건 수정:

1. **Critical — Event_bus subscription leak**: 예외 경로에서 `unsubscribe` 미도달. `Fun.protect ~finally`에 통합.
2. **Important — Mermaid note sanitize**: `Other of string`에 개행/콜론 주입 시 note 구문 깨짐. `sanitize_mermaid_note` 추가.
3. **Important — Dead `safe` variable**: compute → `ignore safe`. Mermaid quoted label은 콜론 허용, P%d ID는 integer. 제거.

## Test plan
- [x] `test_decision_pipeline` 19/19 pass (sanitize 테스트 1개 추가)
- [x] `dune build @check` pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)