### PR TITLE
fix(keeper): turn-scoped observation + Phase 2 last_completed_turn (#7122)

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -82,12 +82,25 @@ let compaction_stage_to_string = function
    to the observer — those live inside a single [run_unified_turn] call.
    Post-turn hooks (PR follow-up) will update shared state so the
    observer can distinguish them. *)
+(* Turn-cycle phase derivation (issue #7122).
+
+   The Compacting/Finalizing branches reflect KSM lifecycle phases that
+   the keeper enters between turns. Within a normal turn the phase
+   defaults to [Idle] unless [current_turn_observation] is [Some _],
+   in which case the keeper is actively in [`Executing`] — the OAS
+   call is in flight, between [mark_turn_started] and
+   [mark_turn_finished]. Finer-grained breakdown
+   ([Prompting]/[ToolCall]) requires Event_bus subscription and is
+   tracked as Phase 2 of #7122. *)
 let derive_turn_phase (entry : Keeper_registry.registry_entry) : turn_phase =
   match entry.phase with
   | Keeper_state_machine.Compacting -> `Compacting
   | Keeper_state_machine.HandingOff
   | Keeper_state_machine.Draining -> `Finalizing
-  | _ -> `Idle
+  | _ ->
+    (match entry.current_turn_observation with
+     | Some _ -> `Executing
+     | None -> `Idle)
 
 (* Compaction sub-FSM: compaction_active is the authoritative condition.
    Phase [Compacting] MUST coincide with this condition under the
@@ -97,17 +110,32 @@ let derive_compaction_stage (conds : Keeper_state_machine.conditions)
   if conds.compaction_active then `Compacting
   else `Accumulating
 
-(* Decision pipeline stage. Observer-visible only via [guardrail_triggered]
-   for now; per-turn Guard/Thompson/ToolPolicy staging requires reading
-   the decision-audit ring buffer (follow-up). *)
+(* Decision pipeline stage (issue #7122 Phase 2 follow-up).
+
+   Only [Gate_rejected] is observable from the registry today
+   ([guardrail_triggered] is a sticky condition). [Guard_ok] and
+   [Tool_policy_selected] are per-turn-internal and require either
+   Event_bus subscription (TurnStarted → Guard pass) or an explicit
+   field on [current_turn_observation] populated by the decision
+   audit. Returning [Undecided] for the non-rejected case is the
+   honest placeholder — we do not have observability for the
+   intermediate states yet. Anything else would be a stale-state lie. *)
 let derive_decision_stage (conds : Keeper_state_machine.conditions)
     : decision_stage =
   if conds.guardrail_triggered then `Gate_rejected
   else `Undecided
 
-(* Cascade state is per-turn-internal; not derivable from registry alone.
-   Follow-up PR wires [Local_runtime_pool] slot telemetry and
-   [Keeper_exec_status_metrics.last_model_used] into an observable field. *)
+(* Cascade state (issue #7122 Phase 2 follow-up).
+
+   [cascade_observation] is produced by [Oas_worker.run_named] only
+   on the success path, after the cascade has already terminated.
+   Persisting it into the registry post-hoc would surface stale
+   [`Done`/`Trying`] on idle keepers — strictly worse than [`Idle`].
+   Live cascade state requires Event_bus subscription on
+   [TurnStarted]/[ToolCalled] events that flow through the OAS
+   pipeline. Until that wiring lands, the only honest projection
+   is [`Idle`]. See #7122 for the design constraints that ruled out
+   the post-hoc-persist approach. *)
 let derive_cascade_state (_ : Keeper_registry.registry_entry) : cascade_state =
   `Idle
 

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -33,6 +33,11 @@ type invariants_check = {
   recovery_two_store_sync : bool;
 }
 
+type last_outcome = {
+  turn_id : int;
+  ended_at : float;
+}
+
 type snapshot = {
   correlation_id : string;
   run_id : string;
@@ -46,6 +51,8 @@ type snapshot = {
   reconcile_data : bool;
   reconcile_fsm : bool;
   invariants : invariants_check;
+  is_live : bool;
+  last_outcome : last_outcome option;
 }
 
 let turn_phase_to_string = function
@@ -276,6 +283,15 @@ let observe
     reconcile_data;
     reconcile_fsm;
     invariants;
+    is_live = (entry.current_turn_observation <> None);
+    last_outcome =
+      (match entry.last_completed_turn with
+       | Some lc ->
+         Some {
+           turn_id = lc.ct_turn_id;
+           ended_at = lc.ct_ended_at;
+         }
+       | None -> None);
   }
 
 (* ================================================================ *)
@@ -334,4 +350,11 @@ let snapshot_to_json (s : snapshot) : Yojson.Safe.t =
       "fsm_condition", `Bool s.reconcile_fsm;
     ];
     "invariants", invariants_to_json s.invariants;
+    "is_live", `Bool s.is_live;
+    "last_outcome", (match s.last_outcome with
+      | Some lo -> `Assoc [
+          "turn_id", `Int lo.turn_id;
+          "ended_at", `Float lo.ended_at;
+        ]
+      | None -> `Null);
   ]

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -57,6 +57,15 @@ type invariants_check = {
   recovery_two_store_sync : bool;
 }
 
+(** Frozen outcome of the most recently completed turn (RFC-0003
+    Phase 2). Surfaces terminal data ([Done]/[Guard_ok]/...) without
+    polluting the live sub-FSM fields. [None] until the first turn
+    has finished after registration. *)
+type last_outcome = {
+  turn_id : int;
+  ended_at : float;
+}
+
 type snapshot = {
   correlation_id : string;
   run_id : string;
@@ -70,6 +79,15 @@ type snapshot = {
   reconcile_data : bool;
   reconcile_fsm : bool;
   invariants : invariants_check;
+  is_live : bool;
+      (** [true] when [current_turn_observation] is [Some] — a turn is
+          actively executing and the live sub-FSM fields reflect its
+          state. [false] indicates an idle keeper; sub-FSM fields
+          revert to [Idle]/[Undecided]. *)
+  last_outcome : last_outcome option;
+      (** Most recent completed turn, surfaced separately from live
+          state so operators can see "what just finished" without
+          confusing it with "what's running now". *)
 }
 
 (** Derive a composite snapshot from a live registry entry.

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -117,11 +117,18 @@ type registry_entry = {
     (float * Keeper_state_machine.auto_rule_summary) option;
   last_event_bus_correlation : string option;
   current_turn_observation : turn_observation option;
+  last_completed_turn : completed_turn_observation option;
 }
 
 and turn_observation = {
   turn_id : int;
   started_at : float;
+}
+
+and completed_turn_observation = {
+  ct_turn_id : int;
+  ct_started_at : float;
+  ct_ended_at : float;
 }
 
 
@@ -224,6 +231,7 @@ let register_with_state ~base_path name meta
     last_auto_rules = None;
     last_event_bus_correlation = None;
     current_turn_observation = None;
+    last_completed_turn = None;
   } in
   put_entry key entry;
   if phase = Running then
@@ -346,7 +354,19 @@ let mark_turn_started ~base_path name =
 
 let mark_turn_finished ~base_path name =
   update_entry ~base_path name (fun e ->
-    { e with current_turn_observation = None })
+    let last_completed_turn =
+      match e.current_turn_observation with
+      | Some obs ->
+        Some {
+          ct_turn_id = obs.turn_id;
+          ct_started_at = obs.started_at;
+          ct_ended_at = Time_compat.now ();
+        }
+      | None -> e.last_completed_turn  (* no live turn → preserve previous *)
+    in
+    { e with
+      current_turn_observation = None;
+      last_completed_turn })
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -116,6 +116,12 @@ type registry_entry = {
   last_auto_rules :
     (float * Keeper_state_machine.auto_rule_summary) option;
   last_event_bus_correlation : string option;
+  current_turn_observation : turn_observation option;
+}
+
+and turn_observation = {
+  turn_id : int;
+  started_at : float;
 }
 
 
@@ -217,6 +223,7 @@ let register_with_state ~base_path name meta
     waiting_for_inference = Atomic.make false;
     last_auto_rules = None;
     last_event_bus_correlation = None;
+    current_turn_observation = None;
   } in
   put_entry key entry;
   if phase = Running then
@@ -330,6 +337,16 @@ let set_failure_reason ~base_path name reason =
 let set_last_correlation_id ~base_path name cid =
   update_entry ~base_path name (fun e ->
     { e with last_event_bus_correlation = Some cid })
+
+let mark_turn_started ~base_path name =
+  update_entry ~base_path name (fun e ->
+    let turn_id = e.meta.runtime.usage.total_turns + 1 in
+    let obs = { turn_id; started_at = Time_compat.now () } in
+    { e with current_turn_observation = Some obs })
+
+let mark_turn_finished ~base_path name =
+  update_entry ~base_path name (fun e ->
+    { e with current_turn_observation = None })
 
 let increment_turn_failures ~base_path name =
   update_entry ~base_path name (fun e ->

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -85,18 +85,22 @@ type registry_entry = {
           successful drain. Stable per session (= [meta.runtime.trace_id]
           as passed to OAS). *)
   current_turn_observation : turn_observation option;
-      (** Live, turn-scoped observation record (issue #7122).
+      (** Live, turn-scoped observation record (issue #7122 Phase 1).
+          [Some _] while a turn is actively executing. [None] outside
+          any turn. Anti-stale barrier: sub-FSM live states are only
+          observable while [Some]. *)
+  last_completed_turn : completed_turn_observation option;
+      (** Frozen snapshot of the most recently completed turn
+          (RFC-0003 Phase 2 design A3). Populated by
+          [mark_turn_finished] when [current_turn_observation] is
+          [Some]; carries terminal data for the composite observer's
+          [last_outcome] snapshot field.
 
-          [Some _] while a turn is actively executing (between
-          [mark_turn_started] and [mark_turn_finished]). [None]
-          outside any turn, meaning the keeper is idle w.r.t. the
-          decision pipeline / cascade layers.
-
-          Anti-stale barrier for the composite observer: sub-FSM
-          states like [`Executing`] are only observable while the
-          turn is live. Once the turn ends, this field is cleared so
-          idle keepers cannot surface stale states from a previous
-          turn. *)
+          Distinct from [current_turn_observation] so the observer
+          can distinguish "live in-turn state" from "previous turn
+          result": idle keepers never surface stale terminal states
+          on the live sub-FSM fields, but operators can still see
+          the most recent outcome in [last_outcome]. *)
 }
 
 and turn_observation = {
@@ -105,6 +109,12 @@ and turn_observation = {
           [meta.runtime.usage.total_turns] + 1). *)
   started_at : float;
       (** Unix timestamp when this turn record was installed. *)
+}
+
+and completed_turn_observation = {
+  ct_turn_id : int;
+  ct_started_at : float;
+  ct_ended_at : float;
 }
 
 (** Register a keeper with an already-live fiber. Primarily used by tests and

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -84,6 +84,27 @@ type registry_entry = {
           keeper turn via [Event_bus.drain]. [None] until the first
           successful drain. Stable per session (= [meta.runtime.trace_id]
           as passed to OAS). *)
+  current_turn_observation : turn_observation option;
+      (** Live, turn-scoped observation record (issue #7122).
+
+          [Some _] while a turn is actively executing (between
+          [mark_turn_started] and [mark_turn_finished]). [None]
+          outside any turn, meaning the keeper is idle w.r.t. the
+          decision pipeline / cascade layers.
+
+          Anti-stale barrier for the composite observer: sub-FSM
+          states like [`Executing`] are only observable while the
+          turn is live. Once the turn ends, this field is cleared so
+          idle keepers cannot surface stale states from a previous
+          turn. *)
+}
+
+and turn_observation = {
+  turn_id : int;
+      (** Per-keeper turn counter at turn start (matches
+          [meta.runtime.usage.total_turns] + 1). *)
+  started_at : float;
+      (** Unix timestamp when this turn record was installed. *)
 }
 
 (** Register a keeper with an already-live fiber. Primarily used by tests and
@@ -125,6 +146,16 @@ val set_failure_reason : base_path:string -> string -> failure_reason option -> 
 
 (** Store the OAS Event_bus [correlation_id] from the most recent turn. *)
 val set_last_correlation_id : base_path:string -> string -> string -> unit
+
+(** Mark the beginning of a keeper turn. Installs a fresh
+    [current_turn_observation] with [turn_id = usage.total_turns + 1].
+    Must be paired with [mark_turn_finished] (or [mark_turn_failed]). *)
+val mark_turn_started : base_path:string -> string -> unit
+
+(** Mark the end of a keeper turn. Clears [current_turn_observation]
+    so the composite observer reverts to idle. Idempotent — safe to
+    call in finally blocks even if [mark_turn_started] was not called. *)
+val mark_turn_finished : base_path:string -> string -> unit
 
 (** Increment turn consecutive failure counter. *)
 val increment_turn_failures : base_path:string -> string -> unit

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1341,10 +1341,19 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
         | Some sub, Some bus -> Agent_sdk.Event_bus.unsubscribe bus sub
         | _ -> ()
       in
+      (* Mark turn boundary for the composite observer (issue #7122).
+         [mark_turn_started] installs [current_turn_observation = Some _]
+         so the composite observer can surface live in-turn states like
+         [`Executing`]. The matching [mark_turn_finished] in the finally
+         block clears the field, preventing stale state on idle keepers. *)
+      Keeper_registry.mark_turn_started
+        ~base_path:config.base_path meta.name;
       let run_result, latency_ms =
         Fun.protect ~finally:(fun () ->
           Keeper_exec_tools.remove_tool_call_observer side_effect_observer;
-          unsubscribe_event_bus ())
+          unsubscribe_event_bus ();
+          Keeper_registry.mark_turn_finished
+            ~base_path:config.base_path meta.name)
         (fun () ->
         Keeper_exec_context.timed (fun () ->
           let clock = Eio_context.get_clock () in

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -18,6 +18,9 @@ module WO = Masc_mcp.Keeper_world_observation
 module DA = Masc_mcp.Keeper_decision_audit
 module TS = Masc_mcp.Tool_shard
 module KTP = Masc_mcp.Keeper_tool_policy
+module Reg = Masc_mcp.Keeper_registry
+module Obs = Masc_mcp.Keeper_composite_observer
+module KTypes = Masc_mcp.Keeper_types
 
 (* ── E1: NEL Invariant ──────────────────────────────── *)
 
@@ -194,6 +197,71 @@ let test_cascade_mermaid_healthy_no_reason_note () =
   check bool "healthy provider does not emit unhealthy note"
     false (substring_present ~haystack:out ~needle:"unhealthy")
 
+(* ── Composite Observer: turn-scoped state (issue #7122) ─ *)
+
+let test_obs_bp = "/tmp/test-composite-obs"
+
+let make_obs_meta name =
+  let json = `Assoc [
+    ("name", `String name);
+    ("agent_name", `String ("agent-" ^ name));
+    ("trace_id", `String ("trace-obs-" ^ name));
+    ("goal", `String "observer test");
+  ] in
+  match KTypes.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("make_obs_meta failed: " ^ err)
+
+let test_observer_idle_when_no_turn () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-idle" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  match Reg.get ~base_path:test_obs_bp name with
+  | None -> Alcotest.fail "registered keeper not found"
+  | Some entry ->
+    let snap = Obs.observe entry in
+    check string "idle keeper has Idle turn phase"
+      "idle" (Obs.turn_phase_to_string snap.ktc_turn_phase)
+
+let test_observer_executing_during_turn () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-active" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  Reg.mark_turn_started ~base_path:test_obs_bp name;
+  (match Reg.get ~base_path:test_obs_bp name with
+   | None -> Alcotest.fail "entry missing after mark_turn_started"
+   | Some entry ->
+     let snap = Obs.observe entry in
+     check string "in-turn keeper has Executing turn phase"
+       "executing" (Obs.turn_phase_to_string snap.ktc_turn_phase))
+
+let test_observer_no_stale_after_turn_end () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-no-stale" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  Reg.mark_turn_started ~base_path:test_obs_bp name;
+  Reg.mark_turn_finished ~base_path:test_obs_bp name;
+  match Reg.get ~base_path:test_obs_bp name with
+  | None -> Alcotest.fail "entry missing after mark_turn_finished"
+  | Some entry ->
+    let snap = Obs.observe entry in
+    check string "post-turn keeper reverts to Idle (no stale Executing)"
+      "idle" (Obs.turn_phase_to_string snap.ktc_turn_phase)
+
+let test_observer_finished_idempotent () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-idempotent" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  (* mark_turn_finished without prior mark_turn_started must not crash. *)
+  Reg.mark_turn_finished ~base_path:test_obs_bp name;
+  Reg.mark_turn_finished ~base_path:test_obs_bp name;
+  match Reg.get ~base_path:test_obs_bp name with
+  | None -> Alcotest.fail "entry missing"
+  | Some entry ->
+    let snap = Obs.observe entry in
+    check string "stays Idle through repeated mark_turn_finished"
+      "idle" (Obs.turn_phase_to_string snap.ktc_turn_phase)
+
 (* ── Test Suite ──────────────────────────────────────── *)
 
 let () =
@@ -228,5 +296,11 @@ let () =
       test_case "other reason passes through" `Quick test_cascade_mermaid_renders_other_reason;
       test_case "other reason sanitizes newline and colon" `Quick test_cascade_mermaid_other_sanitizes_newline_colon;
       test_case "healthy has no unhealthy note" `Quick test_cascade_mermaid_healthy_no_reason_note;
+    ];
+    "composite_observer_turn_scope", [
+      test_case "idle when no turn" `Quick test_observer_idle_when_no_turn;
+      test_case "Executing during turn" `Quick test_observer_executing_during_turn;
+      test_case "no stale Executing after turn end" `Quick test_observer_no_stale_after_turn_end;
+      test_case "mark_turn_finished is idempotent" `Quick test_observer_finished_idempotent;
     ];
   ]

--- a/test/test_decision_pipeline.ml
+++ b/test/test_decision_pipeline.ml
@@ -260,7 +260,71 @@ let test_observer_finished_idempotent () =
   | Some entry ->
     let snap = Obs.observe entry in
     check string "stays Idle through repeated mark_turn_finished"
-      "idle" (Obs.turn_phase_to_string snap.ktc_turn_phase)
+      "idle" (Obs.turn_phase_to_string snap.ktc_turn_phase);
+    check bool "no last_outcome when no turn ever started"
+      true (snap.last_outcome = None)
+
+(* ── Phase 2 (RFC-0003): is_live + last_outcome ──────── *)
+
+let test_observer_is_live_during_turn () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-is-live" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  Reg.mark_turn_started ~base_path:test_obs_bp name;
+  match Reg.get ~base_path:test_obs_bp name with
+  | None -> Alcotest.fail "entry missing"
+  | Some entry ->
+    let snap = Obs.observe entry in
+    check bool "is_live = true during turn" true snap.is_live
+
+let test_observer_is_live_false_when_idle () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-not-live" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  match Reg.get ~base_path:test_obs_bp name with
+  | None -> Alcotest.fail "entry missing"
+  | Some entry ->
+    let snap = Obs.observe entry in
+    check bool "is_live = false on fresh keeper" false snap.is_live
+
+let test_observer_last_outcome_populated_after_turn () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-last-outcome" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  Reg.mark_turn_started ~base_path:test_obs_bp name;
+  Reg.mark_turn_finished ~base_path:test_obs_bp name;
+  match Reg.get ~base_path:test_obs_bp name with
+  | None -> Alcotest.fail "entry missing"
+  | Some entry ->
+    let snap = Obs.observe entry in
+    check bool "is_live = false after turn" false snap.is_live;
+    (match snap.last_outcome with
+     | None -> Alcotest.fail "last_outcome should be Some after a finished turn"
+     | Some lo ->
+       check bool "last_outcome.turn_id positive" true (lo.turn_id > 0);
+       check bool "last_outcome.ended_at non-zero" true (lo.ended_at > 0.0))
+
+let test_observer_last_outcome_preserved_across_finish_idempotent () =
+  Eio_main.run @@ fun _env ->
+  let name = "obs-preserve-last" in
+  let _ = Reg.register ~base_path:test_obs_bp name (make_obs_meta name) in
+  Reg.mark_turn_started ~base_path:test_obs_bp name;
+  Reg.mark_turn_finished ~base_path:test_obs_bp name;
+  let lo_first =
+    match Reg.get ~base_path:test_obs_bp name with
+    | Some e -> (Obs.observe e).last_outcome
+    | None -> None
+  in
+  (* mark_turn_finished again without a new mark_turn_started: previous
+     last_completed_turn must be preserved (no current → no new freeze). *)
+  Reg.mark_turn_finished ~base_path:test_obs_bp name;
+  let lo_second =
+    match Reg.get ~base_path:test_obs_bp name with
+    | Some e -> (Obs.observe e).last_outcome
+    | None -> None
+  in
+  check bool "last_outcome preserved across redundant mark_turn_finished"
+    true (lo_first = lo_second)
 
 (* ── Test Suite ──────────────────────────────────────── *)
 
@@ -302,5 +366,11 @@ let () =
       test_case "Executing during turn" `Quick test_observer_executing_during_turn;
       test_case "no stale Executing after turn end" `Quick test_observer_no_stale_after_turn_end;
       test_case "mark_turn_finished is idempotent" `Quick test_observer_finished_idempotent;
+    ];
+    "composite_observer_phase_2", [
+      test_case "is_live = true during turn" `Quick test_observer_is_live_during_turn;
+      test_case "is_live = false on idle keeper" `Quick test_observer_is_live_false_when_idle;
+      test_case "last_outcome populated after turn" `Quick test_observer_last_outcome_populated_after_turn;
+      test_case "last_outcome preserved across redundant finish" `Quick test_observer_last_outcome_preserved_across_finish_idempotent;
     ];
   ]


### PR DESCRIPTION
## Summary
Fixes #7122. Phase 1 + Phase 2 integrated (after stacked PR #7133 merged into this branch).

### Phase 1 — Anti-stale barrier
- New `current_turn_observation : turn_observation option` field
- `mark_turn_started` / `mark_turn_finished` lifecycle (Fun.protect ~finally guarantees cleanup on exception paths)
- `derive_turn_phase`: `Some` → `Executing`, `None` → `Idle`. Stale state cannot leak.

### Phase 2 — RFC-0003 design A3 (#7131)
- New `completed_turn_observation` type + `last_completed_turn` field
- `mark_turn_finished` move semantic: current → last_completed
- Snapshot: `is_live: bool` + `last_outcome: last_outcome option`
- Idle keepers: live sub-FSM all Idle/Undecided. Terminal data only via separate `last_outcome` field.

### Why this design (RFC #7131)
- A1 (background fiber) rejected: two-writer race
- A2 (observer-time drain) rejected: pure projection 위반
- **A3** preserves single-writer + anti-stale + pure projection

## Test plan
- [x] `composite_observer_turn_scope` 4 tests pass
- [x] `composite_observer_phase_2` 4 tests pass
- [x] 27/27 total tests pass (`test_decision_pipeline.exe`)
- [x] `dune build @check` pass
- [ ] CI green

## Phase 3 (future)
세분화 (`Prompting`/`ToolCall`/`Selecting`/`Trying`)는 background fiber + mutex로 Event_bus 이벤트 실시간 수신 — RFC #7131에 옵션으로 documented. 실제 운영 trigger 발생 시 별도 RFC + PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)