### PR TITLE
fix(metrics): wire admission queue inflight gauge to passthrough with_permit

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -162,16 +162,31 @@ and _release_slot t =
 
 (* ── Public API ────────────────────────────────────────── *)
 
-let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name:_ ~cascade_name:_ f =
+let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
   (* Passthrough: provider-level throttling belongs in OAS (cascade),
      not in MASC.  The cascade distributes requests across providers
      and handles 429/timeout by falling to the next provider.
      Gating here starves cloud-routed keepers behind a serial local
-     decode and cannot express per-provider capacity. *)
-  f ()
+     decode and cannot express per-provider capacity.
+     Metric observation tracks real inflight even though gating is off. *)
+  Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
+  match f () with
+  | result ->
+    Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
+    result
+  | exception exn ->
+    Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
+    raise exn
 
-let try_with_permit ~priority:_ ~keeper_name:_ ~cascade_name:_ f =
-  Some (f ())
+let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
+  Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
+  match f () with
+  | result ->
+    Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
+    Some result
+  | exception exn ->
+    Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
+    raise exn
 
 let snapshot () =
   Eio.Mutex.use_ro global.mutex (fun () ->


### PR DESCRIPTION
## Summary

\`Admission_queue_metrics.on_release\` 함수가 정의되어 있지만 **호출 site 0개** (grep 검증). 따라서 \`masc_inference_queue_inflight\` gauge가 항상 0 — dashboard에서 inflight load 관측 불가.

## Root Cause

3.0.0에서 admission gating이 OAS cascade로 이동하면서 \`with_permit\`/\`try_with_permit\`가 passthrough \`f ()\`로 단순화됨. 그 과정에서 \`on_acquire\`/\`on_release\` 호출도 함께 빠짐.

\`\`\`bash
$ rg 'Admission_queue_metrics\\.on_release' lib/
# (no output)
\`\`\`

## Fix

passthrough를 그대로 두되 \`on_acquire\`/\`on_release\`로 감싸 inflight 관측 부활. exception path에서도 \`on_release\` 호출 후 re-raise — cancellation/provider error에서도 gauge 균형 유지.

\`\`\`ocaml
let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
  Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
  match f () with
  | result ->
    Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
    result
  | exception exn ->
    Admission_queue_metrics.on_release ~keeper_name ~cascade_name;
    raise exn
\`\`\`

## Discovery method

PR #7089 (telemetry silent drop)의 후속 grey-zone scan에서 발견. transport/SSE/admission queue 레이어의 asymmetric instrumentation 패턴 검색.

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 \`masc_inference_queue_inflight\`가 keeper 활동에 반응하는지 확인 (이전엔 0 고정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)