### PR TITLE
chore(metrics): register 5 orphan Prometheus metrics

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -235,6 +235,26 @@ let init () =
      first observation. *)
   add "masc_llm_provider_http_status_total"
     "Total HTTP responses from LLM providers, labeled by provider, model, and status code"
+    Counter;
+  (* Orphan metrics — used via inc_counter/set_gauge but previously
+     never registered.  Auto-create still works, but registering here
+     gives them a HELP description in /metrics output and a zero-value
+     baseline so dashboards see "0" instead of "no data" before the
+     first observation. *)
+  add "masc_keeper_write_meta_failures_total"
+    "Total keeper meta-file write failures, labeled by keeper and phase"
+    Counter;
+  add "masc_keeper_collision_detected_total"
+    "Total keeper-name collision detections during evidence assembly"
+    Counter;
+  add "masc_board_truncated_posts_total"
+    "Total board posts truncated due to size limits"
+    Counter;
+  add "masc_agent_heartbeat_age_seconds"
+    "Maximum observed heartbeat age across active agents (seconds)"
+    Gauge;
+  add "masc_agent_stale_total"
+    "Total agents marked stale due to missed heartbeats"
     Counter
 
 let start_time = Time_compat.now ()


### PR DESCRIPTION
## Summary

5 metric names are referenced via `inc_counter`/`set_gauge` but never registered in `Prometheus.init`.

| Metric | Type | Call sites |
|--------|------|------------|
| `masc_keeper_write_meta_failures_total` | Counter | keeper_keepalive (3) |
| `masc_keeper_collision_detected_total` | Counter | keeper_evidence |
| `masc_board_truncated_posts_total` | Counter | tool_board |
| `masc_agent_heartbeat_age_seconds` | Gauge | transport_metrics |
| `masc_agent_stale_total` | Counter | transport_metrics |

## Why this matters

`inc_counter` auto-creates the metric on first call, but the auto-created entry has:
- HELP = metric name (no description)
- No `# TYPE` line until first observation
- No zero baseline → dashboards see "no data" instead of "0" before first event

Explicit registration in `init` provides HELP text + zero-value rows from server start.

## Discovery method

```bash
rg 'Prometheus\.(inc_counter|set_gauge|observe_histogram).*"([^"]+)"' lib --no-filename -r '$2' | sort -u > used.txt
rg '(add|register_\w+).*"([^"]+)"' lib/prometheus.ml --no-filename -r '$2' | sort -u > registered.txt
comm -23 used.txt registered.txt
```

Iter 3 of grey-zone scan series (PR #7089, #7120, #7127).

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 `/metrics`에 5개 metric의 `# HELP`/`# TYPE` 라인 + 0 baseline 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
