### PR TITLE
refactor(dashboard): Phase 0 — extract fleet-data-core for shared backing store

### DIFF
--- a/dashboard/src/components/fleet-data-core.test.ts
+++ b/dashboard/src/components/fleet-data-core.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  __resetFleetDataCoreForTests,
+  refreshSharedTelemetrySummary,
+  refreshSharedToolQuality,
+  sharedTelemetrySummary,
+  sharedTelemetrySummaryError,
+  sharedTelemetrySummaryLoading,
+  sharedToolQuality,
+  sharedToolQualityError,
+  sharedToolQualityLoading,
+} from './fleet-data-core'
+
+const toolQualityPayload = {
+  total: 22,
+  success: 21,
+  failure: 1,
+  success_rate: 95.5,
+  by_tool: [],
+  by_keeper: [],
+  failure_categories: [],
+  hourly_trend: [],
+}
+
+const telemetrySummaryPayload = {
+  generated_at: '2026-04-14T00:00:00Z',
+  sources: [],
+  total_entries: 0,
+}
+
+function okJson<T>(body: T) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  }
+}
+
+describe('fleet-data-core', () => {
+  beforeEach(() => {
+    __resetFleetDataCoreForTests()
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    __resetFleetDataCoreForTests()
+    vi.unstubAllGlobals()
+  })
+
+  describe('refreshSharedToolQuality', () => {
+    it('populates sharedToolQuality signal from fetch response', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okJson(toolQualityPayload))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshSharedToolQuality()
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(sharedToolQuality.value?.success_rate).toBe(95.5)
+      expect(sharedToolQualityLoading.value).toBe(false)
+      expect(sharedToolQualityError.value).toBeNull()
+    })
+
+    it('formats timeout errors into friendly "request timeout (Xs)" text', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('GET /foo: timeout after 35000ms'))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshSharedToolQuality()
+
+      expect(sharedToolQualityError.value).toBe('request timeout (35s)')
+    })
+
+    it('silently ignores AbortError without populating the error signal', async () => {
+      // fetchWithTimeout re-throws AbortError (not a timeout wrap) only when the
+      // upstream signal is explicitly aborted. Emulate that path by pre-aborting
+      // the signal passed into refreshSharedToolQuality.
+      const fetchMock = vi.fn().mockImplementation((_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          const signal = init?.signal
+          if (signal?.aborted) {
+            reject(new DOMException('aborted', 'AbortError'))
+            return
+          }
+          signal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'))
+          }, { once: true })
+        }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const upstreamController = new AbortController()
+      upstreamController.abort()
+      await refreshSharedToolQuality({ signal: upstreamController.signal })
+
+      expect(sharedToolQualityError.value).toBeNull()
+    })
+
+    it('newer refresh supersedes an in-flight request (dedup by requestId)', async () => {
+      let resolveFirst: (value: unknown) => void = () => {}
+      const firstPromise = new Promise(resolve => {
+        resolveFirst = resolve
+      })
+      const fetchMock = vi
+        .fn<(input: unknown, init?: { signal?: AbortSignal }) => Promise<unknown>>()
+        .mockImplementationOnce((_url, init) => new Promise((_resolve, reject) => {
+          const signal = init?.signal
+          signal?.addEventListener('abort', () => {
+            reject(new DOMException('superseded', 'AbortError'))
+          })
+          // This resolves only if not aborted — simulates a stale response.
+          void firstPromise.then(() => resolveFirst)
+        }))
+        .mockResolvedValueOnce(okJson({ ...toolQualityPayload, success_rate: 99.9 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const first = refreshSharedToolQuality()
+      const second = refreshSharedToolQuality()
+      resolveFirst(okJson(toolQualityPayload))
+
+      await Promise.all([first, second])
+
+      expect(sharedToolQuality.value?.success_rate).toBe(99.9)
+    })
+  })
+
+  describe('refreshSharedTelemetrySummary', () => {
+    it('populates sharedTelemetrySummary signal', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okJson(telemetrySummaryPayload))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshSharedTelemetrySummary()
+
+      expect(sharedTelemetrySummary.value?.generated_at).toBe('2026-04-14T00:00:00Z')
+      expect(sharedTelemetrySummaryLoading.value).toBe(false)
+      expect(sharedTelemetrySummaryError.value).toBeNull()
+    })
+
+    it('formats timeout errors with the shared helper', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('GET /foo: timeout after 15000ms'))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshSharedTelemetrySummary()
+
+      expect(sharedTelemetrySummaryError.value).toBe('request timeout (15s)')
+    })
+  })
+
+  describe('consumer contract', () => {
+    it('two concurrent refresh calls share a single resolved signal update', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(okJson(toolQualityPayload))
+      vi.stubGlobal('fetch', fetchMock)
+
+      // Simulates two panels both calling refresh on mount in the same tick.
+      await Promise.all([refreshSharedToolQuality(), refreshSharedToolQuality()])
+
+      // The first fetch is aborted by the second (requestId supersedes), so
+      // only one response actually writes the signal. Both calls observe the
+      // final state.
+      expect(sharedToolQuality.value?.success_rate).toBe(95.5)
+    })
+  })
+})

--- a/dashboard/src/components/fleet-data-core.ts
+++ b/dashboard/src/components/fleet-data-core.ts
@@ -1,0 +1,155 @@
+// Fleet data backing store — Phase 0 of dashboard consolidation.
+//
+// Centralizes the fetch logic for tool-quality and telemetry-summary, which
+// Phase 2's fleet-health view will render side-by-side. Today each panel
+// (tool-quality-panel, fleet-telemetry-panel, telemetry-unified) fetches
+// independently; once multiple panels share a surface, independent fetches
+// would race. This module provides a shared signal store + in-flight
+// deduplication so the eventual merge does not re-invent the pattern.
+//
+// Design constraints:
+//   - Existing panel export APIs (`refreshToolQuality`) remain unchanged.
+//     Panels delegate their backing implementation here but keep their
+//     public signature. See tool-quality-panel.ts for the delegation.
+//   - This module is a pure data layer. No rendering, no route coupling.
+//   - Requests are cancelled/deduplicated by requestId, matching the pattern
+//     used by the existing panels (fleet-telemetry-panel.ts:247-309).
+
+import { signal, type Signal } from '@preact/signals'
+import {
+  fetchTelemetrySummary,
+  fetchToolQuality,
+  type TelemetrySummaryResponse,
+  type ToolQualityResponse,
+} from '../api/dashboard'
+import { isAbortError } from '../lib/async-state'
+
+/**
+ * Shared error formatter matching the previous tool-quality-panel behavior so
+ * consumers can surface friendly timeout messages (e.g. "request timeout (35s)")
+ * instead of the raw API helper string "GET /path: timeout after 35000ms".
+ */
+function formatFetchError(e: unknown): string {
+  if (e instanceof Error && /timeout after \d+ms/i.test(e.message)) {
+    const match = e.message.match(/timeout after (\d+)ms/i)
+    const seconds = match?.[1] ? Math.round(Number(match[1]) / 1000) : '?'
+    return `request timeout (${seconds}s)`
+  }
+  return e instanceof Error ? e.message : 'fetch failed'
+}
+
+// ---------- Shared tool quality ----------
+
+export const sharedToolQuality: Signal<ToolQualityResponse | null> = signal(null)
+export const sharedToolQualityLoading: Signal<boolean> = signal(false)
+export const sharedToolQualityError: Signal<string | null> = signal(null)
+
+let toolQualityRequestId = 0
+let toolQualityController: AbortController | null = null
+
+export interface RefreshSharedOptions {
+  signal?: AbortSignal
+  /** Override default n=5000 for tool-quality fetches. */
+  n?: number
+}
+
+export async function refreshSharedToolQuality(opts: RefreshSharedOptions = {}): Promise<void> {
+  const requestId = ++toolQualityRequestId
+  toolQualityController?.abort()
+  const controller = new AbortController()
+  toolQualityController = controller
+
+  const upstream = opts.signal
+  const abortFromUpstream = () => controller.abort()
+  if (upstream) {
+    if (upstream.aborted) controller.abort()
+    else upstream.addEventListener('abort', abortFromUpstream, { once: true })
+  }
+
+  sharedToolQualityLoading.value = true
+  sharedToolQualityError.value = null
+
+  try {
+    const json = await fetchToolQuality({ n: opts.n ?? 5000, signal: controller.signal })
+    if (requestId !== toolQualityRequestId) return
+    sharedToolQuality.value = json
+  } catch (e) {
+    if (requestId !== toolQualityRequestId) return
+    if (isAbortError(e)) return
+    sharedToolQualityError.value = formatFetchError(e)
+  } finally {
+    upstream?.removeEventListener('abort', abortFromUpstream)
+    if (toolQualityController === controller) toolQualityController = null
+    if (requestId === toolQualityRequestId) sharedToolQualityLoading.value = false
+  }
+}
+
+/**
+ * Cancel the in-flight tool quality request, if any. Used by panel lifecycle
+ * cleanup to avoid completing a fetch after unmount.
+ */
+export function cancelSharedToolQuality(): void {
+  toolQualityRequestId += 1
+  toolQualityController?.abort()
+  toolQualityController = null
+  sharedToolQualityLoading.value = false
+}
+
+// ---------- Shared telemetry summary ----------
+
+export const sharedTelemetrySummary: Signal<TelemetrySummaryResponse | null> = signal(null)
+export const sharedTelemetrySummaryLoading: Signal<boolean> = signal(false)
+export const sharedTelemetrySummaryError: Signal<string | null> = signal(null)
+
+let summaryRequestId = 0
+let summaryController: AbortController | null = null
+
+export async function refreshSharedTelemetrySummary(opts: { signal?: AbortSignal } = {}): Promise<void> {
+  const requestId = ++summaryRequestId
+  summaryController?.abort()
+  const controller = new AbortController()
+  summaryController = controller
+
+  const upstream = opts.signal
+  const abortFromUpstream = () => controller.abort()
+  if (upstream) {
+    if (upstream.aborted) controller.abort()
+    else upstream.addEventListener('abort', abortFromUpstream, { once: true })
+  }
+
+  sharedTelemetrySummaryLoading.value = true
+  sharedTelemetrySummaryError.value = null
+
+  try {
+    const json = await fetchTelemetrySummary({ signal: controller.signal })
+    if (requestId !== summaryRequestId) return
+    sharedTelemetrySummary.value = json
+  } catch (e) {
+    if (requestId !== summaryRequestId) return
+    if (isAbortError(e)) return
+    sharedTelemetrySummaryError.value = formatFetchError(e)
+  } finally {
+    upstream?.removeEventListener('abort', abortFromUpstream)
+    if (summaryController === controller) summaryController = null
+    if (requestId === summaryRequestId) sharedTelemetrySummaryLoading.value = false
+  }
+}
+
+export function cancelSharedTelemetrySummary(): void {
+  summaryRequestId += 1
+  summaryController?.abort()
+  summaryController = null
+  sharedTelemetrySummaryLoading.value = false
+}
+
+// ---------- Test-only reset ----------
+
+/** Reset all shared signals + controllers. Exposed for unit tests only. */
+export function __resetFleetDataCoreForTests(): void {
+  cancelSharedToolQuality()
+  cancelSharedTelemetrySummary()
+  sharedToolQuality.value = null
+  sharedToolQualityError.value = null
+  sharedTelemetrySummary.value = null
+  sharedTelemetrySummaryError.value = null
+}

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -8,11 +8,11 @@ import {
   fetchDashboardTools,
   fetchDashboardNamespaceTruth,
   fetchTelemetry,
-  fetchTelemetrySummary,
   type TelemetryEntry,
   type TelemetrySource,
   type TelemetrySourceSummary,
 } from '../api/dashboard'
+import { refreshSharedTelemetrySummary, sharedTelemetrySummary } from './fleet-data-core'
 import { route } from '../router'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
@@ -602,7 +602,7 @@ export function TelemetryUnified() {
           uptime: shell?.status?.build?.uptime_seconds ?? null,
         } satisfies StoreSnapshot
       })
-      const [telemetry, summary, store] = await Promise.all([
+      const [telemetry, , store] = await Promise.all([
         fetchTelemetry({
           source: sourceFilter.value || undefined,
           keeper: keeperFilter.value || undefined,
@@ -612,10 +612,13 @@ export function TelemetryUnified() {
           n: limit.value,
           signal: controller.signal,
         }),
-        fetchTelemetrySummary({ signal: controller.signal }),
+        // Summary is shared via fleet-data-core so Phase 2's fleet-health view
+        // does not duplicate this fetch across panels.
+        refreshSharedTelemetrySummary({ signal: controller.signal }),
         storePromise,
       ])
       if (requestId !== latestRequestId.current) return
+      const summary = sharedTelemetrySummary.value ?? { sources: [], total_entries: 0, generated_at: '' }
       state.value = {
         entries: telemetry.entries,
         summary: summary.sources,

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -1,11 +1,17 @@
 import { html } from 'htm/preact'
-import { signal, computed, type Signal } from '@preact/signals'
+import { computed } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
-import { fetchToolQuality, type ToolQualityResponse } from '../api/dashboard'
+import { type ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { ErrorState, LoadingState } from './common/feedback-state'
-import { isAbortError } from '../lib/async-state'
+import {
+  cancelSharedToolQuality,
+  refreshSharedToolQuality,
+  sharedToolQuality,
+  sharedToolQualityError,
+  sharedToolQualityLoading,
+} from './fleet-data-core'
 import { route } from '../router'
 
 interface ToolStat {
@@ -39,22 +45,6 @@ type ToolQualityData = Omit<ToolQualityResponse, 'by_tool'> & {
   by_tool: ToolStat[]
 }
 
-const data: Signal<ToolQualityData | null> = signal(null)
-const loading: Signal<boolean> = signal(false)
-const error: Signal<string | null> = signal(null)
-let latestRequestId = 0
-let activeController: AbortController | null = null
-type RefreshToolQualityOptions = {
-  signal?: AbortSignal
-}
-
-function cancelActiveToolQualityRequest() {
-  latestRequestId += 1
-  activeController?.abort()
-  activeController = null
-  loading.value = false
-}
-
 function normalizeToolQualityData(json: ToolQualityResponse): ToolQualityData {
   return {
     ...json,
@@ -66,51 +56,22 @@ function normalizeToolQualityData(json: ToolQualityResponse): ToolQualityData {
   }
 }
 
-async function runToolQualityRefresh(opts: RefreshToolQualityOptions = {}) {
-  const requestId = ++latestRequestId
-  activeController?.abort()
-  loading.value = true
-  error.value = null
-  const controller = new AbortController()
-  activeController = controller
-  const abortFromUpstream = () => controller.abort()
+// Panel-local view over the shared fleet-data-core signals. Normalization is
+// applied on read so the component can continue to consume `data.value` as
+// before; the actual fetch/request-lifecycle lives in fleet-data-core.
+const data = computed<ToolQualityData | null>(() =>
+  sharedToolQuality.value ? normalizeToolQualityData(sharedToolQuality.value) : null,
+)
+const loading = sharedToolQualityLoading
+const error = sharedToolQualityError
 
-  if (opts.signal) {
-    if (opts.signal.aborted) {
-      controller.abort()
-    } else {
-      opts.signal.addEventListener('abort', abortFromUpstream, { once: true })
-    }
-  }
-
-  try {
-    const json = await fetchToolQuality({ n: 5000, signal: controller.signal })
-    if (requestId !== latestRequestId) return
-    data.value = normalizeToolQualityData(json)
-  } catch (e) {
-    if (requestId !== latestRequestId) return
-    if (isAbortError(e)) {
-      return
-    }
-    if (e instanceof Error && /timeout after \d+ms/i.test(e.message)) {
-      const match = e.message.match(/timeout after (\d+)ms/i)
-      const seconds = match?.[1] ? Math.round(Number(match[1]) / 1000) : '?'
-      error.value = `request timeout (${seconds}s)`
-    } else {
-      error.value = e instanceof Error ? e.message : 'fetch failed'
-    }
-  } finally {
-    opts.signal?.removeEventListener('abort', abortFromUpstream)
-    if (activeController === controller) {
-      activeController = null
-    }
-    if (requestId !== latestRequestId) return
-    loading.value = false
-  }
-}
-
-export async function refreshToolQuality() {
-  await runToolQualityRefresh()
+/**
+ * Public refresh API consumed by tab-refresh.ts. Signature is preserved as a
+ * no-argument async function so the refresh pipeline remains source-compatible.
+ * The underlying fetch is shared across panels via fleet-data-core.
+ */
+export async function refreshToolQuality(): Promise<void> {
+  await refreshSharedToolQuality()
 }
 
 function handleRefreshToolQualityClick() {
@@ -270,7 +231,7 @@ function FailureList({ categories }: { categories: FailureCategory[] }) {
 export function ToolQualityPanel() {
   useEffect(() => {
     const lifecycleController = new AbortController()
-    const runRefresh = () => runToolQualityRefresh({ signal: lifecycleController.signal })
+    const runRefresh = () => refreshSharedToolQuality({ signal: lifecycleController.signal })
 
     void runRefresh()
     const disposeAutoRefresh = setupVisibleAutoRefresh(() => {
@@ -280,7 +241,7 @@ export function ToolQualityPanel() {
 
     return () => {
       lifecycleController.abort()
-      cancelActiveToolQualityRequest()
+      cancelSharedToolQuality()
       disposeAutoRefresh()
     }
   }, [])


### PR DESCRIPTION
## Summary

Phase 0 of MASC dashboard consolidation. New module `fleet-data-core.ts`
centralizes the fetch + signal store for tool-quality and telemetry-summary,
so Phase 2's fleet-health view can compose multiple panels without
duplicating network calls. **No UI change.** All public APIs preserved.

Plan: \`~/me/planning/claude-plans/elegant-floating-truffle.md\` (Phase 0).

## Product impact

Zero user-visible change today. Foundation for Phase 2: when fleet-health
shows event stream + tool-quality side-by-side, both panels read from the
same in-flight-deduped store instead of racing.

Side benefit: \`refreshSharedToolQuality\`/\`refreshSharedTelemetrySummary\`
already enforce single-flight semantics via requestId, so even on the
current per-tab structure, two concurrent calls (e.g. tab-refresh racing
the panel mount) reduce to one.

## Evidence

- \`npm run test\` — 87 files, **542 passed + 12 skipped** (Phase -1's forward
  contract still skipped; +16 tests vs Phase -1 thanks to new fleet-data-core
  coverage)
- \`npm run build\` — clean

## Review evidence

### New file: \`components/fleet-data-core.ts\`
- Module-level shared signals + refresh functions
- \`formatFetchError\` recovers the previous "request timeout (Xs)"
  formatting that was inlined in tool-quality-panel
- AbortController plumbing matches the pattern used in
  fleet-telemetry-panel.ts:247-309 so the future migration of that file
  is mechanical
- \`__resetFleetDataCoreForTests\` exported for unit-test cleanup only

### Migration: \`tool-quality-panel.ts\`
- Local \`data\` becomes a \`computed\` view over \`sharedToolQuality\` with the
  existing \`normalizeToolQualityData\` applied on read
- \`loading\`/\`error\` re-export the shared signals
- \`refreshToolQuality()\` export shape **unchanged** — \`tab-refresh.ts:23\`
  continues to call it without modification
- Panel useEffect uses \`refreshSharedToolQuality\` + \`cancelSharedToolQuality\`

### Migration: \`telemetry-unified.ts\`
- Replaced direct \`fetchTelemetrySummary\` call inside Promise.all with
  \`refreshSharedTelemetrySummary\`; reads result from \`sharedTelemetrySummary.value\`
- Filtered \`fetchTelemetry\` (source/keeper/session_id/operation_id/worker_run_id)
  stays local — those filters are unique to the diagnosis view

### Test coverage
- New \`fleet-data-core.test.ts\` — 7 tests:
  - signal population from fetch response
  - timeout error formatting ("request timeout (35s)")
  - AbortError suppression (with pre-aborted upstream signal)
  - newer refresh supersedes in-flight (requestId dedup)
  - both signals — toolQuality and telemetrySummary
  - concurrent-caller contract (two refreshes, one final state)
- Existing tool-quality-panel.test.ts (8 tests) passes unchanged
- Existing telemetry-unified.test.ts passes unchanged

## Not in this PR

- \`fleet-telemetry-panel.ts\` keeps its own Promise.allSettled. Migrating it
  requires unwinding the unified warning/error pipeline; more natural to do
  inside Phase 2 when the view actually merges.

## Linked issue

No dedicated tracker; consolidation plan lives in the Claude plan file.