### PR TITLE
feat(metrics): wire OAS on_request_end to per-request latency histogram

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -46,13 +46,27 @@ let emit_http_status ~provider ~model_id ~status =
       ]
     ()
 
+(** Per-HTTP-request latency histogram.  Distinct from
+    [masc_llm_inference_duration_seconds] (turn-scope, populated by the
+    keeper AfterTurn hook): this metric is per provider HTTP call, so
+    streaming retries / cascade fallbacks each add an observation.
+
+    Populated unconditionally by the OAS [on_request_end] callback,
+    which fires for every completed HTTP request regardless of whether
+    the AfterTurn hook later runs.  Provides redundant latency
+    observability so a broken hook does not blank out the dashboard. *)
+let request_latency_metric = "masc_llm_provider_request_latency_seconds"
+
 (** Build the OAS Metrics.t sink.
 
-    Currently only [on_http_status] is wired through; the other
-    callbacks inherit the default no-op behaviour from
-    [Llm_provider.Metrics.noop].  Future extensions (error type
-    counters, latency histograms) can add more relays without
-    breaking the signature. *)
+    Currently wired through:
+    - [on_http_status]   → masc_llm_provider_http_status_total
+    - [on_request_end]   → masc_llm_provider_request_latency_seconds
+
+    Other callbacks ([on_cache_hit/miss], [on_request_start], [on_error],
+    [on_cascade_fallback]) inherit the default no-op from
+    [Llm_provider.Metrics.noop].  Add more relays here as their
+    consuming dashboards land. *)
 let make_sink () : Llm_provider.Metrics.t =
   let open Llm_provider.Metrics in
   {
@@ -60,6 +74,11 @@ let make_sink () : Llm_provider.Metrics.t =
     on_http_status =
       (fun ~provider ~model_id ~status ->
         emit_http_status ~provider ~model_id ~status);
+    on_request_end =
+      (fun ~model_id ~latency_ms ->
+        let seconds = Float.of_int latency_ms /. 1000.0 in
+        Prometheus.observe_histogram request_latency_metric
+          ~labels:[("model", model_id)] seconds);
   }
 
 (** Install the sink as the process-wide default.  Idempotent — calling

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -255,7 +255,11 @@ let init () =
     Gauge;
   add "masc_agent_stale_total"
     "Total agents marked stale due to missed heartbeats"
-    Counter
+    Counter;
+  register_histogram ~name:"masc_llm_provider_request_latency_seconds"
+    ~help:"Per-HTTP-request LLM latency from OAS on_request_end callback. \
+           Independent from masc_llm_inference_duration_seconds (turn-scope) — \
+           this fires per provider HTTP call regardless of keeper hook health." ()
 
 let start_time = Time_compat.now ()
 


### PR DESCRIPTION
## Summary

PR #7089는 keeper AfterTurn hook의 silent drop을 진단 가능하게 만들었지만, hook 자체가 죽으면 latency 관측은 여전히 사라짐. **dual-path observability** 추가:

| Metric | Scope | Source |
|--------|-------|--------|
| `masc_llm_inference_duration_seconds` | per-turn | keeper_hooks_oas (AfterTurn) |
| `masc_llm_provider_request_latency_seconds` (NEW) | per-HTTP-request | llm_metric_bridge (OAS callback) |

## Why two metrics

같은 이름에 합치면 의미 혼란 — turn 1개에 LLM HTTP call 여러 개일 수 있음 (cascade fallback, retry). 따라서:
- **turn-scope**: keeper가 1턴 처리하는 데 걸린 LLM 시간 (cascade 합산)
- **request-scope**: 개별 provider HTTP call latency (raw)

두 신호가 보완적. AfterTurn hook이 빠지면 turn-scope는 0이 되지만 request-scope는 OAS callback이 직접 호출하므로 계속 흐름.

## Discovery

Iter 4 grey-zone scan — `llm_metric_bridge.ml`의 `make_sink`가 `on_http_status`만 연결하고 `on_request_end`는 noop으로 둠. OAS API는 이미 `latency_ms`를 직접 전달하므로 1줄로 wire 가능:

```ocaml
on_request_end = (fun ~model_id ~latency_ms ->
  Prometheus.observe_histogram "masc_llm_provider_request_latency_seconds"
    ~labels:[("model", model_id)]
    (Float.of_int latency_ms /. 1000.0));
```

Iter 4 of grey-zone scan series (PR #7089, #7120, #7127, #7132).

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 `/metrics`에서 `masc_llm_provider_request_latency_seconds_{sum,count}` 관찰 — keeper 활동에 비례해 증가하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)
