### PR TITLE
test(admission_queue): regression tests for inflight gauge balance

### DIFF
--- a/test/test_admission_queue_coverage.ml
+++ b/test/test_admission_queue_coverage.ml
@@ -134,6 +134,79 @@ let test_snapshot_json_shape () =
     | _ -> fail "expected Assoc")
 
 (* ============================================================
+   Metric Regression — locks in PR #7127 fix.
+
+   with_permit / try_with_permit are passthrough wrappers, but they
+   MUST still call on_acquire/on_release so the inflight gauge is
+   meaningful.  Without this, masc_inference_queue_inflight stays at 0
+   and dashboards see no load even when keepers are active.  Easy to
+   regress because the queue body is a one-line passthrough.
+   ============================================================ *)
+
+let test_with_permit_releases_inflight_gauge () =
+  Eio_main.run (fun _env ->
+    let before =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_inflight" ()
+    in
+    AQ.with_permit ~priority:Interactive
+      ~keeper_name:"metric-test" ~cascade_name:"test"
+      (fun () -> ());
+    let after =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_inflight" ()
+    in
+    check (float 0.1) "inflight balanced after success" before after)
+
+let test_with_permit_releases_on_exception () =
+  Eio_main.run (fun _env ->
+    let before =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_inflight" ()
+    in
+    (try
+       AQ.with_permit ~priority:Interactive
+         ~keeper_name:"metric-test-exn" ~cascade_name:"test"
+         (fun () -> failwith "boom")
+     with Failure _ -> ());
+    let after =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_inflight" ()
+    in
+    check (float 0.1) "inflight balanced after exception" before after)
+
+let test_with_permit_increments_acquired_counter () =
+  Eio_main.run (fun _env ->
+    let before =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_acquired_total" ()
+    in
+    AQ.with_permit ~priority:Interactive
+      ~keeper_name:"counter-test" ~cascade_name:"test"
+      (fun () -> ());
+    let after =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_acquired_total" ()
+    in
+    check (float 0.1) "acquired counter incremented" (before +. 1.0) after)
+
+let test_try_with_permit_releases_inflight_gauge () =
+  Eio_main.run (fun _env ->
+    let before =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_inflight" ()
+    in
+    let _ : int option = AQ.try_with_permit ~priority:Interactive
+      ~keeper_name:"try-metric" ~cascade_name:"test"
+      (fun () -> 1)
+    in
+    let after =
+      Masc_mcp.Prometheus.metric_value_or_zero
+        "masc_inference_queue_inflight" ()
+    in
+    check (float 0.1) "try_with_permit balanced" before after)
+
+(* ============================================================
    Runner
    ============================================================ *)
 
@@ -160,5 +233,15 @@ let () =
         test_max_concurrent_metric_tracks_capacity;
       test_case "rejects zero" `Quick test_set_max_concurrent_rejects_zero;
       test_case "snapshot_json shape" `Quick test_snapshot_json_shape;
+    ];
+    "metric_regression", [
+      test_case "with_permit balances inflight gauge" `Quick
+        test_with_permit_releases_inflight_gauge;
+      test_case "with_permit releases on exception" `Quick
+        test_with_permit_releases_on_exception;
+      test_case "with_permit increments acquired counter" `Quick
+        test_with_permit_increments_acquired_counter;
+      test_case "try_with_permit balances inflight gauge" `Quick
+        test_try_with_permit_releases_inflight_gauge;
     ];
   ]


### PR DESCRIPTION
## Summary

PR #7127이 `with_permit`/`try_with_permit`에 `on_acquire`/`on_release` 호출을 추가했지만, **회귀 테스트 0개**. passthrough 한 줄로 단순한 함수라 누군가 "정리"하면서 다시 vanish 가능.

## What's tested

| 테스트 | 검증 |
|--------|------|
| `with_permit balances inflight gauge` | 정상 종료 후 `masc_inference_queue_inflight` 증감 균형 |
| `with_permit releases on exception` | 예외 발생 후에도 `on_release` 호출 (re-raise path) |
| `with_permit increments acquired counter` | `masc_inference_queue_acquired_total` += 1 |
| `try_with_permit balances inflight gauge` | passthrough variant도 동일하게 균형 유지 |

기존 `max_concurrent_metric_tracks_capacity` 테스트(line 104)와 같은 `Prometheus.metric_value_or_zero` 패턴 사용.

## Why a separate PR

PR #7127 본체는 이미 머지됨. 회귀 테스트는 별도 PR이 더 명확 — fix와 test의 lineage가 분리되어 후속 작업자가 "이 테스트는 왜?" 추적 시 cause/effect가 분명해짐.

## Discovery

Iter 5 grey-zone scan에서 PR #7089/#7127/#7132/#7135의 코드가 test에서 reference되는지 검색 → admission_queue 외에 0건. PR #7127이 가장 회귀 위험이 큼(단 1줄 변경으로 metric drift 재발).

## Test plan

- [ ] Build and Test — 4개 새 테스트 모두 PASS
- [ ] alcotest log에서 `metric_regression` 그룹 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
