### PR TITLE
feat(dashboard): FSM Hub live indicator + last_outcome (#7122 Phase 2)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -407,6 +407,11 @@ export interface KeeperCompositeMeasurement {
   }
 }
 
+export interface KeeperLastOutcome {
+  turn_id: number
+  ended_at: number
+}
+
 export interface KeeperCompositeSnapshot {
   correlation_id: string
   run_id: string
@@ -419,6 +424,13 @@ export interface KeeperCompositeSnapshot {
   measurement: KeeperCompositeMeasurement
   recovery: { data_record: boolean; fsm_condition: boolean }
   invariants: KeeperCompositeInvariants
+  /** RFC-0003 Phase 2 (#7122): true when a turn is actively
+      executing. Sub-FSM fields reflect live in-turn state only
+      when is_live is true; otherwise they revert to Idle/Undecided. */
+  is_live: boolean
+  /** RFC-0003 Phase 2 (#7122): frozen snapshot of the most recent
+      completed turn. null until the first turn ends. */
+  last_outcome: KeeperLastOutcome | null
 }
 
 export async function fetchKeeperComposite(name: string): Promise<KeeperCompositeSnapshot> {

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -339,11 +339,21 @@ function RecoveryStatePanel({
 
 function SnapshotMeta({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   const date = new Date(snapshot.ts * 1000)
+  const liveClass = snapshot.is_live
+    ? 'text-emerald-400 border-emerald-500/40'
+    : 'text-[var(--text-dim)] border-white/10'
+  const lastOutcomeText = snapshot.last_outcome
+    ? `last turn #${snapshot.last_outcome.turn_id} ended ${new Date(snapshot.last_outcome.ended_at * 1000).toLocaleTimeString()}`
+    : 'no completed turn'
   return html`
-    <div class="flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)] font-mono">
+    <div class="flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)] font-mono items-center">
+      <span class=${`px-1.5 py-0.5 border rounded ${liveClass}`}>
+        ${snapshot.is_live ? '● LIVE' : '○ idle'}
+      </span>
       <span>correlation ${snapshot.correlation_id}</span>
       <span>run ${snapshot.run_id}</span>
       <span>ts ${date.toISOString()}</span>
+      <span class="opacity-70">${lastOutcomeText}</span>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
Dashboard가 #7126의 새 `is_live` + `last_outcome` 필드를 실제로 consume.

FSM Hub `SnapshotMeta`에 추가:
- **LIVE badge** (emerald) — `is_live = true` 시
- **idle badge** (dim) — 유휴 상태
- **last_outcome** 요약 — "last turn #N ended HH:MM:SS"

Live 상태가 시각적으로 명확. Stale 여부가 snapshot header 레벨에서 바로 보임.

## Test plan
- [x] `pnpm tsc --noEmit` pass
- [x] API interface에 `KeeperLastOutcome` + `is_live`/`last_outcome` 필드 추가
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)