### PR TITLE
chore(metrics): remove 6 dead delta-checkpoint metric registrations

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -202,19 +202,6 @@ let init () =
     "Total provider prefix cache read tokens (Anthropic)" Counter;
   register_histogram ~name:"masc_tool_call_duration_seconds"
     ~help:"Tool call latency in seconds" ();
-  (* Delta checkpoint metrics *)
-  add "masc_delta_shadow_match_total"
-    "Shadow-apply delta: rebuilt hash matches current checkpoint" Counter;
-  add "masc_delta_shadow_mismatch_total"
-    "Shadow-apply delta: rebuilt hash differs from current checkpoint" Counter;
-  add "masc_delta_shadow_error_total"
-    "Shadow-apply delta: compute or apply raised an error" Counter;
-  register_histogram ~name:"masc_delta_checkpoint_size_bytes"
-    ~help:"Size in bytes of serialized delta checkpoint" ();
-  register_histogram ~name:"masc_full_checkpoint_size_bytes"
-    ~help:"Size in bytes of serialized full checkpoint" ();
-  register_gauge ~name:"masc_delta_size_ratio"
-    ~help:"Ratio of delta size to full checkpoint size (last observation)" ();
   (* Inference admission queue metrics *)
   add "masc_inference_queue_inflight"
     "Concurrent inference calls holding an admission permit" Gauge;


### PR DESCRIPTION
## Summary

6개 delta-checkpoint metric이 `Prometheus.init`에 등록되어 있지만 **관측자 0개** — feature가 현재 코드베이스에 없음.

| 삭제된 metric | Type |
|--------------|:----:|
| `masc_delta_shadow_match_total` | Counter |
| `masc_delta_shadow_mismatch_total` | Counter |
| `masc_delta_shadow_error_total` | Counter |
| `masc_delta_checkpoint_size_bytes` | Histogram |
| `masc_full_checkpoint_size_bytes` | Histogram |
| `masc_delta_size_ratio` | Gauge |

## Verification

```bash
$ rg 'masc_delta_shadow|masc_delta_checkpoint|masc_full_checkpoint|masc_delta_size' lib/ --files-with-matches
lib/prometheus.ml   # <-- 등록만, observe 없음
```

다른 어떤 `.ml`/`.mli`에서도 참조되지 않음. delta checkpoint feature는 code base에서 제거된 상태.

## Why remove

등록만 남아있으면 `/metrics` 응답에 6개의 permanent zero 행을 남김 — 스크레이프당 cardinality + I/O 낭비. feature 재도입 시 registration은 관측 call site와 함께 되돌아오면 됨.

## Relation to other PRs

- **PR #7132** (반대 방향): observe되지만 registration 없는 5개 orphan metric 등록
- **PR #7135** (새 metric): 실제 observer와 함께 registration 추가

이 PR은 **registration만 있고 observer 없는** 반대 패턴 정리. iter 6 of grey-zone scan series.

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 `/metrics`에서 6개 metric 사라짐 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
