### PR TITLE
feat(keeper): pre-execution hallucination gate for keeper_github

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -435,6 +435,7 @@
    keeper_exec_board
    keeper_exec_fs
    keeper_exec_shell
+   keeper_gh_cache
    keeper_exec_github
    keeper_exec_preflight
    keeper_exec_task
@@ -614,6 +615,7 @@
    keeper_exec_board
    keeper_exec_fs
    keeper_exec_shell
+   keeper_gh_cache
    keeper_exec_github
    keeper_exec_preflight
    keeper_exec_task

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -53,6 +53,83 @@ let gh_not_found_hint ~(st : Unix.process_status) ~(out : string) =
          Use 'issue list' or 'pr list' to find valid targets first." ]
   else []
 
+(** gh subcommands that take a numeric PR/issue target as their first
+    positional argument. We pre-validate the number against the
+    Keeper_gh_cache before dispatching the subprocess.
+
+    [view] is intentionally excluded from the cache check -- list-style
+    [pr view] (with no number) is valid and we don't want to reject it. *)
+let gh_pr_number_subcmds =
+  [ "view"; "close"; "reopen"; "merge"; "comment"; "edit"
+  ; "diff"; "checks"; "review"; "ready"; "status" ]
+
+let gh_issue_number_subcmds =
+  [ "view"; "close"; "reopen"; "comment"; "edit"
+  ; "develop"; "lock"; "unlock"; "pin"; "unpin"; "transfer" ]
+
+(** Parse a gh command string and return [Some (kind, number)] when the
+    command references a specific PR/issue number that we should
+    pre-validate. Returns [None] for list/create/status commands, and
+    for any command whose first positional after the subcommand is not
+    a positive integer (e.g. branch names for [gh pr view my-branch]).
+
+    Examples:
+      "pr view 123"           -> Some (PR, 123)
+      "pr view my-branch"     -> None  (not an integer)
+      "pr list --state open"  -> None
+      "pr create --title foo" -> None
+      "issue comment 456 -b hi" -> Some (Issue, 456)
+      "pr merge 789 --squash" -> Some (PR, 789) *)
+let extract_gh_target_number (cmd : string)
+    : (Keeper_gh_cache.entity_kind * int) option
+  =
+  let parts =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+  in
+  let rec first_positional_int = function
+    | [] -> None
+    | tok :: rest ->
+      if String.length tok > 0 && tok.[0] = '-' then
+        (* Flag: skip over its value too, if this flag takes one.
+           We use a conservative heuristic -- skip the next token only
+           when it doesn't also look like a flag. *)
+        (match rest with
+         | next :: rest' when String.length next > 0 && next.[0] <> '-' ->
+           first_positional_int rest'
+         | _ -> first_positional_int rest)
+      else
+        (match int_of_string_opt tok with
+         | Some n when n > 0 -> Some n
+         | _ -> None)  (* first non-flag positional wasn't a number *)
+  in
+  match parts with
+  | "pr" :: sub :: rest when List.mem (String.lowercase_ascii sub) gh_pr_number_subcmds ->
+    Option.map (fun n -> Keeper_gh_cache.PR, n) (first_positional_int rest)
+  | "issue" :: sub :: rest when List.mem (String.lowercase_ascii sub) gh_issue_number_subcmds ->
+    Option.map (fun n -> Keeper_gh_cache.Issue, n) (first_positional_int rest)
+  | _ -> None
+
+(** Return the kind whose cached number list should be invalidated after
+    this command runs successfully. Covers creation (new number appears),
+    state transitions that close/reopen (membership changes under
+    [state=all] is unchanged, but we still invalidate to resync state
+    filters used elsewhere), and merges. *)
+let gh_mutates_entity (cmd : string) : Keeper_gh_cache.entity_kind option =
+  let parts =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+    |> List.map String.lowercase_ascii
+  in
+  match parts with
+  | "pr" :: sub :: _
+    when List.mem sub [ "create"; "close"; "reopen"; "merge"; "ready"; "edit" ] ->
+    Some Keeper_gh_cache.PR
+  | "issue" :: sub :: _
+    when List.mem sub [ "create"; "close"; "reopen"; "edit"; "transfer"; "delete" ] ->
+    Some Keeper_gh_cache.Issue
+  | _ -> None
+
 (** Truncate gh output to prevent context explosion.
     65KB responses were observed causing 300s timeout via token overflow. *)
 let max_gh_output_bytes = 8192
@@ -255,6 +332,72 @@ let handle_keeper_github
             ; "reason", `String reason
             ])
     | Ok () ->
+      (* Pre-execution hallucination gate. When the command targets a
+         specific PR/issue number, verify that number actually exists in
+         the repo's cached list. On mismatch, return the valid
+         alternatives as a JSON array -- the LLM picks from the list
+         instead of guessing. On `Unknown (cache miss / fetch failure),
+         fallthrough to normal execution (fail-open). See
+         [keeper_gh_cache.ml]. *)
+      let invalid_number =
+        match extract_gh_target_number gh_raw with
+        | None -> None
+        | Some (kind, number) ->
+          let slug =
+            match repo_slug with
+            | Some s -> s
+            | None -> Option.value ~default:"" (project_repo_slug ())
+          in
+          (match
+             Keeper_gh_cache.validate_number ~config ~repo_slug:slug ~kind ~number
+           with
+           | `Valid | `Unknown -> None
+           | `Invalid valids -> Some (kind, number, valids, slug))
+      in
+      (match invalid_number with
+       | Some (kind, number, valids, slug) ->
+         let kind_label =
+           match kind with Keeper_gh_cache.PR -> "PR" | Issue -> "issue"
+         in
+         (* Cap the suggestion list so the tool response doesn't balloon
+            when a repo has 100 PRs -- 20 numbers is enough for the LLM
+            to recognize the range and pick a recent one. *)
+         let shown =
+           let rec take n = function
+             | [] -> []
+             | _ when n <= 0 -> []
+             | x :: rest -> x :: take (n - 1) rest
+           in
+           take 20 valids
+         in
+         let valid_str =
+           shown |> List.map string_of_int |> String.concat ", "
+         in
+         Log.Keeper.warn
+           "keeper_github hallucination-gate: %s #%d not in %s (keeper=%s)"
+           kind_label number slug meta.name;
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool false
+               ; "error", `String "number_not_found"
+               ; ( "reason"
+                 , `String
+                     (Printf.sprintf
+                        "%s #%d does not exist in %s."
+                        kind_label number slug) )
+               ; "valid_numbers", `List (List.map (fun n -> `Int n) shown)
+               ; ( "hint"
+                 , `String
+                     (Printf.sprintf
+                        "Valid %s numbers in %s: [%s]. \
+                         Use one of these instead. \
+                         Do not guess. If you need a number not in this \
+                         list, run '%s list' first to refresh."
+                        kind_label slug valid_str
+                        (match kind with PR -> "pr" | Issue -> "issue")) )
+               ; "cmd", `String ("gh " ^ gh_raw)
+               ])
+       | None ->
       let preset_allows_workflow =
         match Keeper_types.tool_access_preset meta.tool_access with
         | Some preset -> Keeper_tool_policy.allows_workflow_for_preset preset
@@ -351,6 +494,18 @@ let handle_keeper_github
           let shell_cmd = Printf.sprintf "cd %s && %s 2>&1" (Filename.quote root) scoped_cmd in
           let st, raw_out = Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ] in
           let out, trunc_fields = truncate_gh_output raw_out in
+          (* Invalidate cache on successful mutation so the next validation
+             sees the new/removed number. Applies to pr merge explicitly. *)
+          (if st = Unix.WEXITED 0 then
+             match gh_mutates_entity gh_raw with
+             | None -> ()
+             | Some kind ->
+               let slug =
+                 match repo_slug with
+                 | Some s -> s
+                 | None -> Option.value ~default:"" (project_repo_slug ())
+               in
+               if slug <> "" then Keeper_gh_cache.invalidate ~repo_slug:slug ~kind);
           Yojson.Safe.to_string
             (`Assoc
                 ([ "ok", `Bool (st = Unix.WEXITED 0)
@@ -364,12 +519,23 @@ let handle_keeper_github
           Process_eio.run_argv_with_status ~timeout_sec [ "/bin/zsh"; "-lc"; shell_cmd ]
         in
         let out, trunc_fields = truncate_gh_output raw_out in
+        (* See merge-path comment above -- same invalidation rationale. *)
+        (if st = Unix.WEXITED 0 then
+           match gh_mutates_entity gh_raw with
+           | None -> ()
+           | Some kind ->
+             let slug =
+               match repo_slug with
+               | Some s -> s
+               | None -> Option.value ~default:"" (project_repo_slug ())
+             in
+             if slug <> "" then Keeper_gh_cache.invalidate ~repo_slug:slug ~kind);
         Yojson.Safe.to_string
           (`Assoc
               ([ "ok", `Bool (st = Unix.WEXITED 0)
                ; "status", Keeper_alerting_path.process_status_to_json st
                ; "output", `String out
-               ] @ trunc_fields @ gh_not_found_hint ~st ~out))))
+               ] @ trunc_fields @ gh_not_found_hint ~st ~out)))))
 ;;
 
 let handle_keeper_pr_workflow
@@ -965,6 +1131,14 @@ let handle_keeper_pr_submit
               else
                 Ok (Printf.sprintf "PR verified: %s" verified)
         ) in
+        (* Invalidate the PR cache on success so that a keeper issuing
+           [gh pr view <new-number>] on the next turn validates against
+           the refreshed list instead of rejecting the just-created PR. *)
+        if !step_ok then begin
+          let slug = Option.value ~default:"" (project_repo_slug ()) in
+          if slug <> "" then
+            Keeper_gh_cache.invalidate ~repo_slug:slug ~kind:Keeper_gh_cache.PR
+        end;
         (* Record PR in playground history (best-effort, JSONL append) *)
         if !step_ok && !pr_url <> "" then begin
           try

--- a/lib/keeper/keeper_exec_github.ml
+++ b/lib/keeper/keeper_exec_github.ml
@@ -67,19 +67,35 @@ let gh_issue_number_subcmds =
   [ "view"; "close"; "reopen"; "comment"; "edit"
   ; "develop"; "lock"; "unlock"; "pin"; "unpin"; "transfer" ]
 
-(** Parse a gh command string and return [Some (kind, number)] when the
-    command references a specific PR/issue number that we should
-    pre-validate. Returns [None] for list/create/status commands, and
-    for any command whose first positional after the subcommand is not
-    a positive integer (e.g. branch names for [gh pr view my-branch]).
+(** Parse a gh command string and return [Some (kind, number)] ONLY when
+    the number is the immediate positional argument after the
+    subcommand:
+
+        pr <sub> <N> [flags...]
+        issue <sub> <N> [flags...]
+
+    This strict shape is deterministic -- no flag-table heuristic, no
+    guessing which tokens are flag values. For the keeper-hallucination
+    use case the real failures are simple "pr view 99999" strings, so
+    the strict form catches them without risking false rejections on
+    variants like "pr view --web 123" (where we simply fallthrough to
+    normal execution).
+
+    Returns [None] for:
+      - list/create/status subcommands (no target number at all)
+      - commands with flags between the subcommand and the number
+      - commands whose first positional after the subcommand is not a
+        positive integer (branch names, URLs, etc.)
 
     Examples:
-      "pr view 123"           -> Some (PR, 123)
-      "pr view my-branch"     -> None  (not an integer)
-      "pr list --state open"  -> None
-      "pr create --title foo" -> None
-      "issue comment 456 -b hi" -> Some (Issue, 456)
-      "pr merge 789 --squash" -> Some (PR, 789) *)
+      "pr view 123"             -> Some (PR, 123)
+      "pr view 456 --json title" -> Some (PR, 456)
+      "pr merge 789 --squash"   -> Some (PR, 789)
+      "issue comment 42 --body hi" -> Some (Issue, 42)
+      "pr view my-branch"       -> None  (not an integer)
+      "pr view --web 123"       -> None  (flag precedes number)
+      "pr list --state open"    -> None
+      "pr create --title foo"   -> None *)
 let extract_gh_target_number (cmd : string)
     : (Keeper_gh_cache.entity_kind * int) option
   =
@@ -87,27 +103,18 @@ let extract_gh_target_number (cmd : string)
     String.split_on_char ' ' (String.trim cmd)
     |> List.filter (fun s -> s <> "")
   in
-  let rec first_positional_int = function
-    | [] -> None
-    | tok :: rest ->
-      if String.length tok > 0 && tok.[0] = '-' then
-        (* Flag: skip over its value too, if this flag takes one.
-           We use a conservative heuristic -- skip the next token only
-           when it doesn't also look like a flag. *)
-        (match rest with
-         | next :: rest' when String.length next > 0 && next.[0] <> '-' ->
-           first_positional_int rest'
-         | _ -> first_positional_int rest)
-      else
-        (match int_of_string_opt tok with
-         | Some n when n > 0 -> Some n
-         | _ -> None)  (* first non-flag positional wasn't a number *)
+  let positive_int s =
+    match int_of_string_opt s with
+    | Some n when n > 0 -> Some n
+    | _ -> None
   in
   match parts with
-  | "pr" :: sub :: rest when List.mem (String.lowercase_ascii sub) gh_pr_number_subcmds ->
-    Option.map (fun n -> Keeper_gh_cache.PR, n) (first_positional_int rest)
-  | "issue" :: sub :: rest when List.mem (String.lowercase_ascii sub) gh_issue_number_subcmds ->
-    Option.map (fun n -> Keeper_gh_cache.Issue, n) (first_positional_int rest)
+  | "pr" :: sub :: num_str :: _
+    when List.mem (String.lowercase_ascii sub) gh_pr_number_subcmds ->
+    Option.map (fun n -> Keeper_gh_cache.PR, n) (positive_int num_str)
+  | "issue" :: sub :: num_str :: _
+    when List.mem (String.lowercase_ascii sub) gh_issue_number_subcmds ->
+    Option.map (fun n -> Keeper_gh_cache.Issue, n) (positive_int num_str)
   | _ -> None
 
 (** Return the kind whose cached number list should be invalidated after

--- a/lib/keeper/keeper_exec_github.mli
+++ b/lib/keeper/keeper_exec_github.mli
@@ -15,6 +15,20 @@ val truncate_gh_output :
   string ->
   string * (string * Yojson.Safe.t) list
 
+(** Pure parser: return the target [(kind, number)] when [cmd] is a gh
+    subcommand that references a specific PR/issue number. Returns
+    [None] for list/create/status commands and for branch-name-style
+    targets (e.g. "pr view my-branch"). Exposed for unit testing. *)
+val extract_gh_target_number :
+  string -> (Keeper_gh_cache.entity_kind * int) option
+
+(** Pure classifier: return [Some kind] when [cmd] is a mutation that
+    changes the set of PRs/issues (create/close/reopen/merge/etc.).
+    Used to invalidate the gh cache after a successful mutation.
+    Exposed for unit testing. *)
+val gh_mutates_entity :
+  string -> Keeper_gh_cache.entity_kind option
+
 val handle_keeper_github :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_gh_cache.ml
+++ b/lib/keeper/keeper_gh_cache.ml
@@ -1,0 +1,166 @@
+(** See [keeper_gh_cache.mli] for the public interface rationale. *)
+
+type entity_kind = PR | Issue
+
+type validation_result =
+  [ `Valid
+  | `Invalid of int list
+  | `Unknown
+  ]
+
+type cache_entry = {
+  numbers : int list;
+  fetched_at : float;
+  populated : bool;
+      (** [true] when a fetch succeeded and returned a list (possibly empty).
+          [false] marks a failed fetch so the caller can fallthrough without
+          caching the failure forever. *)
+}
+
+(** TTL keeps entries fresh enough to pick up new PRs within ~2 minutes,
+    while avoiding per-call subprocess overhead for repeated validations. *)
+let cache_ttl_sec = 120.0
+
+(** Page size for the REST list call. Matches the default keeper repo
+    working set; large repos (>100 open PRs) will fall back to [`Unknown]
+    for older numbers, which is safer than a hard rejection. *)
+let fetch_page_size = 100
+
+let kind_path = function PR -> "pulls" | Issue -> "issues"
+
+(** Cache keyed by (repo_slug, entity_kind). Module-level so all keepers
+    share a single table -- one keeper's populate benefits all of them. *)
+let cache : (string * entity_kind, cache_entry) Hashtbl.t = Hashtbl.create 8
+
+let cache_lock = Eio.Mutex.create ()
+
+(* Metrics counters. Atomic.int used instead of ref-with-mutex so callers
+   of [metrics] don't need to grab the cache lock. *)
+let counter_hits = Atomic.make 0
+let counter_misses = Atomic.make 0
+let counter_bypasses = Atomic.make 0
+let counter_fetch_errors = Atomic.make 0
+
+(* ------------------------------------------------------------------ *)
+(* gh config dir detection -- duplicated from Keeper_exec_github to keep
+   this module self-contained (no upward dependency). *)
+(* ------------------------------------------------------------------ *)
+
+let keeper_gh_config_dir (config : Room.config) : string option =
+  let dir = Filename.concat config.Room_utils.base_path ".masc/gh-auth" in
+  if Sys.file_exists dir && Sys.is_directory dir then Some dir else None
+
+let with_keeper_gh_env (config : Room.config) (gh_cmd : string) : string =
+  match keeper_gh_config_dir config with
+  | None -> gh_cmd
+  | Some dir ->
+    Printf.sprintf "GH_CONFIG_DIR=%s %s" (Filename.quote dir) gh_cmd
+
+(* ------------------------------------------------------------------ *)
+(* REST-based number fetch. qa-king observed that [gh pr view] via
+   GraphQL returns false negatives ("Could not resolve" for real PRs),
+   so we use the REST endpoint directly: it returns exactly what exists. *)
+(* ------------------------------------------------------------------ *)
+
+let parse_numbers_from_jq_output (out : string) : int list =
+  (* Output is one integer per line, possibly trailing newline. *)
+  out
+  |> String.split_on_char '\n'
+  |> List.filter_map (fun line ->
+         let s = String.trim line in
+         if s = "" then None
+         else
+           match int_of_string_opt s with
+           | Some n when n > 0 -> Some n
+           | _ -> None)
+
+(** GitHub's [/repos/{slug}/issues] endpoint returns both issues AND PRs
+    (PRs are a subtype of issues in the REST API). For the Issue kind
+    we filter out entries where [pull_request] is set, leaving only
+    genuine issues. For PR kind the [/pulls] endpoint needs no filter. *)
+let jq_filter = function
+  | PR -> ".[] | .number"
+  | Issue -> ".[] | select(.pull_request == null) | .number"
+
+let fetch_numbers ~(config : Room.config) ~(repo_slug : string) ~(kind : entity_kind)
+    : int list option
+  =
+  let endpoint =
+    Printf.sprintf "repos/%s/%s?state=all&per_page=%d"
+      repo_slug (kind_path kind) fetch_page_size
+  in
+  let raw =
+    Printf.sprintf "gh api %s --jq %s"
+      (Filename.quote endpoint)
+      (Filename.quote (jq_filter kind))
+  in
+  let scoped = with_keeper_gh_env config raw in
+  let shell = Printf.sprintf "%s 2>/dev/null" scoped in
+  match
+    Process_eio.run_argv_with_status
+      ~timeout_sec:10.0
+      [ "/bin/zsh"; "-lc"; shell ]
+  with
+  | Unix.WEXITED 0, out -> Some (parse_numbers_from_jq_output out)
+  | _ ->
+    Atomic.incr counter_fetch_errors;
+    None
+
+(* ------------------------------------------------------------------ *)
+(* Cache lookup with TTL + lazy population *)
+(* ------------------------------------------------------------------ *)
+
+let now () = Unix.gettimeofday ()
+
+let entry_is_fresh entry =
+  entry.populated && now () -. entry.fetched_at < cache_ttl_sec
+
+(** Read or populate the entry for [(repo_slug, kind)].
+    Returns the entry; [populated=false] means fetch failed. *)
+let get_or_populate ~config ~repo_slug ~kind : cache_entry =
+  Eio.Mutex.use_rw ~protect:true cache_lock (fun () ->
+    let key = (repo_slug, kind) in
+    match Hashtbl.find_opt cache key with
+    | Some entry when entry_is_fresh entry -> entry
+    | _ ->
+      let entry =
+        match fetch_numbers ~config ~repo_slug ~kind with
+        | Some numbers ->
+          { numbers; fetched_at = now (); populated = true }
+        | None ->
+          (* Fetch failed: record a short-lived empty entry so we don't
+             retry the subprocess on every validation call in a burst. *)
+          { numbers = []; fetched_at = now (); populated = false }
+      in
+      Hashtbl.replace cache key entry;
+      entry)
+
+let validate_number ~config ~repo_slug ~kind ~number : validation_result =
+  if number <= 0 then `Unknown
+  else if repo_slug = "" then `Unknown
+  else
+    let entry = get_or_populate ~config ~repo_slug ~kind in
+    if not entry.populated then begin
+      Atomic.incr counter_bypasses;
+      `Unknown
+    end
+    else if List.mem number entry.numbers then begin
+      Atomic.incr counter_hits;
+      `Valid
+    end
+    else begin
+      Atomic.incr counter_misses;
+      `Invalid entry.numbers
+    end
+
+let invalidate ~repo_slug ~kind =
+  Eio.Mutex.use_rw ~protect:true cache_lock (fun () ->
+    Hashtbl.remove cache (repo_slug, kind))
+
+let metrics () : (string * int) list =
+  [ "hits", Atomic.get counter_hits
+  ; "misses", Atomic.get counter_misses
+  ; "bypasses", Atomic.get counter_bypasses
+  ; "fetch_errors", Atomic.get counter_fetch_errors
+  ]
+

--- a/lib/keeper/keeper_gh_cache.mli
+++ b/lib/keeper/keeper_gh_cache.mli
@@ -1,0 +1,49 @@
+(** In-memory cache of valid GH PR/issue numbers per repo.
+
+    Populated lazily via [gh api repos/{slug}/pulls|issues?state=all]
+    (REST, not GraphQL -- GraphQL has known false negatives, see
+    masc-mcp board post p-10f3f0914beeb9e0d22f80e0b0e107a8).
+
+    Used by [handle_keeper_github] to reject hallucinated PR/issue
+    numbers BEFORE invoking gh, and return the valid number list as
+    alternatives. Works regardless of LLM instruction-following quality.
+
+    Thread-safety: mutex-protected, shared across all keepers.
+
+    Fail-open: cache fetch failures return [`Unknown], which the caller
+    interprets as "proceed with normal execution". *)
+
+type entity_kind = PR | Issue
+
+type validation_result =
+  [ `Valid
+  | `Invalid of int list
+    (** number not in cache; caller SHOULD return valid alternatives *)
+  | `Unknown
+    (** cache fetch failed or returned empty; caller SHOULD fallthrough *)
+  ]
+
+val validate_number :
+  config:Room.config ->
+  repo_slug:string ->
+  kind:entity_kind ->
+  number:int ->
+  validation_result
+(** Check whether [number] is a known-valid PR/issue for [repo_slug].
+
+    On first call for a given [(repo_slug, kind)] the cache is populated
+    via a subprocess [gh api] call. Subsequent calls within the TTL
+    window (120 s) are served from memory. *)
+
+val invalidate : repo_slug:string -> kind:entity_kind -> unit
+(** Clear the cache entry for [(repo_slug, kind)]. Call this after a
+    successful mutation (pr create, issue create, pr close) so the next
+    validation picks up the new/removed number. *)
+
+val metrics : unit -> (string * int) list
+(** Return [("hits", n); ("misses", n); ("bypasses", n); ("fetch_errors", n)].
+
+    [hits]          number was in cache and valid
+    [misses]        number was NOT in cache (hallucination detected)
+    [bypasses]      cache empty or fetch failed (command proceeded normally)
+    [fetch_errors]  gh api subprocess failed *)

--- a/test/dune
+++ b/test/dune
@@ -370,6 +370,7 @@
         test_goal_janitor
         test_keeper_pr_workflow
         test_keeper_github_hint
+        test_keeper_gh_hallucination_gate
         test_voice_config)
  (modules
         test_runtime_params
@@ -518,6 +519,7 @@
         test_goal_janitor
         test_keeper_pr_workflow
         test_keeper_github_hint
+        test_keeper_gh_hallucination_gate
         test_voice_config)
  (libraries masc_test_deps))
 

--- a/test/test_keeper_gh_hallucination_gate.ml
+++ b/test/test_keeper_gh_hallucination_gate.ml
@@ -1,0 +1,240 @@
+(** Tests for the keeper_github hallucination gate.
+
+    Covers:
+    1. [extract_gh_target_number]: pure parser correctness for the
+       commands that should/shouldn't trigger pre-validation.
+    2. [gh_mutates_entity]: pure classifier covering the cache
+       invalidation triggers.
+    3. [Keeper_gh_cache.validate_number]: fast-path returns ([`Unknown]
+       on empty repo_slug, zero number) that don't require subprocess. *)
+
+open Alcotest
+
+module Room = Masc_mcp.Room
+
+let extract = Masc_mcp.Keeper_exec_github.extract_gh_target_number
+let mutates = Masc_mcp.Keeper_exec_github.gh_mutates_entity
+
+(* The entity_kind variants need a testable for Alcotest option checks.
+   Pretty-print and equality are trivial. *)
+let entity_kind_testable =
+  let pp fmt = function
+    | Masc_mcp.Keeper_gh_cache.PR -> Format.fprintf fmt "PR"
+    | Masc_mcp.Keeper_gh_cache.Issue -> Format.fprintf fmt "Issue"
+  in
+  testable pp ( = )
+
+let target_testable = option (pair entity_kind_testable int)
+
+(* ====================================================================== *)
+(* extract_gh_target_number                                                  *)
+(* ====================================================================== *)
+
+let test_extract_pr_view_number () =
+  check target_testable "pr view 123"
+    (Some (Masc_mcp.Keeper_gh_cache.PR, 123))
+    (extract "pr view 123")
+
+let test_extract_pr_view_with_flags () =
+  check target_testable "pr view 456 --json title,body"
+    (Some (Masc_mcp.Keeper_gh_cache.PR, 456))
+    (extract "pr view 456 --json title,body")
+
+let test_extract_pr_merge_number () =
+  check target_testable "pr merge 789 --squash"
+    (Some (Masc_mcp.Keeper_gh_cache.PR, 789))
+    (extract "pr merge 789 --squash")
+
+let test_extract_pr_comment_number () =
+  check target_testable "pr comment 42 --body 'hi'"
+    (Some (Masc_mcp.Keeper_gh_cache.PR, 42))
+    (extract "pr comment 42 --body hi")
+
+let test_extract_issue_view_number () =
+  check target_testable "issue view 100"
+    (Some (Masc_mcp.Keeper_gh_cache.Issue, 100))
+    (extract "issue view 100")
+
+let test_extract_issue_close_number () =
+  check target_testable "issue close 17 --reason completed"
+    (Some (Masc_mcp.Keeper_gh_cache.Issue, 17))
+    (extract "issue close 17 --reason completed")
+
+let test_extract_pr_list_returns_none () =
+  (* List commands don't target a specific number — must not trigger validation. *)
+  check target_testable "pr list --state open" None (extract "pr list --state open")
+
+let test_extract_pr_create_returns_none () =
+  (* Creation is a mutation, not a reference to an existing number. *)
+  check target_testable "pr create --title foo --body bar"
+    None
+    (extract "pr create --title foo --body bar")
+
+let test_extract_issue_list_returns_none () =
+  check target_testable "issue list" None (extract "issue list")
+
+let test_extract_issue_create_returns_none () =
+  check target_testable "issue create --title foo"
+    None
+    (extract "issue create --title foo")
+
+let test_extract_pr_view_branch_returns_none () =
+  (* [gh pr view my-branch] is valid; first positional is not an integer. *)
+  check target_testable "pr view my-feature-branch"
+    None
+    (extract "pr view my-feature-branch")
+
+let test_extract_unknown_command_returns_none () =
+  check target_testable "repo view" None (extract "repo view");
+  check target_testable "workflow list" None (extract "workflow list");
+  check target_testable "" None (extract "")
+
+let test_extract_extra_whitespace () =
+  check target_testable "multiple spaces around 'pr view 55'"
+    (Some (Masc_mcp.Keeper_gh_cache.PR, 55))
+    (extract "   pr   view    55   ")
+
+let test_extract_zero_is_none () =
+  (* 0 is not a valid PR/issue number. *)
+  check target_testable "pr view 0" None (extract "pr view 0")
+
+let test_extract_negative_is_none () =
+  (* Negative ints fail parsing (leading - looks like a flag and is skipped). *)
+  check target_testable "pr view -5" None (extract "pr view -5")
+
+(* ====================================================================== *)
+(* gh_mutates_entity                                                        *)
+(* ====================================================================== *)
+
+let test_mutates_pr_create () =
+  check (option entity_kind_testable) "pr create"
+    (Some Masc_mcp.Keeper_gh_cache.PR)
+    (mutates "pr create --title foo")
+
+let test_mutates_pr_close () =
+  check (option entity_kind_testable) "pr close"
+    (Some Masc_mcp.Keeper_gh_cache.PR)
+    (mutates "pr close 123")
+
+let test_mutates_pr_merge () =
+  check (option entity_kind_testable) "pr merge"
+    (Some Masc_mcp.Keeper_gh_cache.PR)
+    (mutates "pr merge 456 --squash")
+
+let test_mutates_issue_create () =
+  check (option entity_kind_testable) "issue create"
+    (Some Masc_mcp.Keeper_gh_cache.Issue)
+    (mutates "issue create --title bug")
+
+let test_mutates_issue_close () =
+  check (option entity_kind_testable) "issue close"
+    (Some Masc_mcp.Keeper_gh_cache.Issue)
+    (mutates "issue close 17")
+
+let test_mutates_pr_list_returns_none () =
+  (* Read commands must NOT trigger invalidation. *)
+  check (option entity_kind_testable) "pr list" None (mutates "pr list")
+
+let test_mutates_pr_view_returns_none () =
+  check (option entity_kind_testable) "pr view" None (mutates "pr view 100")
+
+let test_mutates_issue_list_returns_none () =
+  check (option entity_kind_testable) "issue list"
+    None
+    (mutates "issue list")
+
+let test_mutates_unknown_command_returns_none () =
+  check (option entity_kind_testable) "repo view" None (mutates "repo view");
+  check (option entity_kind_testable) "workflow list" None (mutates "workflow list")
+
+(* ====================================================================== *)
+(* Keeper_gh_cache.validate_number fast-path                                *)
+(* ====================================================================== *)
+
+(* These tests only exercise the guard clauses that short-circuit before
+   any subprocess. Full cache behavior requires a real [gh api] call,
+   which is integration-level rather than unit-level. *)
+
+let dummy_config () : Room.config =
+  let tmp = Printf.sprintf "/tmp/test-gh-cache-%d" (Random.bits ()) in
+  (try Unix.mkdir tmp 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  (try Unix.mkdir (Filename.concat tmp ".masc") 0o755
+   with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Room.default_config tmp
+
+let test_validate_empty_slug_returns_unknown () =
+  let config = dummy_config () in
+  let result =
+    Masc_mcp.Keeper_gh_cache.validate_number
+      ~config ~repo_slug:"" ~kind:Masc_mcp.Keeper_gh_cache.PR ~number:42
+  in
+  check bool "empty slug -> Unknown" true
+    (match result with `Unknown -> true | _ -> false)
+
+let test_validate_zero_number_returns_unknown () =
+  let config = dummy_config () in
+  let result =
+    Masc_mcp.Keeper_gh_cache.validate_number
+      ~config ~repo_slug:"owner/repo" ~kind:Masc_mcp.Keeper_gh_cache.PR ~number:0
+  in
+  check bool "zero number -> Unknown" true
+    (match result with `Unknown -> true | _ -> false)
+
+let test_validate_negative_number_returns_unknown () =
+  let config = dummy_config () in
+  let result =
+    Masc_mcp.Keeper_gh_cache.validate_number
+      ~config ~repo_slug:"owner/repo" ~kind:Masc_mcp.Keeper_gh_cache.Issue ~number:(-1)
+  in
+  check bool "negative number -> Unknown" true
+    (match result with `Unknown -> true | _ -> false)
+
+let test_metrics_initial () =
+  let m = Masc_mcp.Keeper_gh_cache.metrics () in
+  (* Keys must exist even before any call. *)
+  check bool "has hits" true (List.mem_assoc "hits" m);
+  check bool "has misses" true (List.mem_assoc "misses" m);
+  check bool "has bypasses" true (List.mem_assoc "bypasses" m);
+  check bool "has fetch_errors" true (List.mem_assoc "fetch_errors" m)
+
+(* ====================================================================== *)
+(* Test runner                                                              *)
+(* ====================================================================== *)
+
+let () =
+  run "keeper_gh_hallucination_gate"
+    [ "extract_gh_target_number",
+      [ test_case "pr view 123" `Quick test_extract_pr_view_number
+      ; test_case "pr view 456 --json" `Quick test_extract_pr_view_with_flags
+      ; test_case "pr merge 789" `Quick test_extract_pr_merge_number
+      ; test_case "pr comment 42" `Quick test_extract_pr_comment_number
+      ; test_case "issue view 100" `Quick test_extract_issue_view_number
+      ; test_case "issue close 17" `Quick test_extract_issue_close_number
+      ; test_case "pr list -> None" `Quick test_extract_pr_list_returns_none
+      ; test_case "pr create -> None" `Quick test_extract_pr_create_returns_none
+      ; test_case "issue list -> None" `Quick test_extract_issue_list_returns_none
+      ; test_case "issue create -> None" `Quick test_extract_issue_create_returns_none
+      ; test_case "pr view branch -> None" `Quick test_extract_pr_view_branch_returns_none
+      ; test_case "unknown command -> None" `Quick test_extract_unknown_command_returns_none
+      ; test_case "extra whitespace" `Quick test_extract_extra_whitespace
+      ; test_case "number 0 -> None" `Quick test_extract_zero_is_none
+      ; test_case "negative number -> None" `Quick test_extract_negative_is_none
+      ]
+    ; "gh_mutates_entity",
+      [ test_case "pr create" `Quick test_mutates_pr_create
+      ; test_case "pr close" `Quick test_mutates_pr_close
+      ; test_case "pr merge" `Quick test_mutates_pr_merge
+      ; test_case "issue create" `Quick test_mutates_issue_create
+      ; test_case "issue close" `Quick test_mutates_issue_close
+      ; test_case "pr list -> None" `Quick test_mutates_pr_list_returns_none
+      ; test_case "pr view -> None" `Quick test_mutates_pr_view_returns_none
+      ; test_case "issue list -> None" `Quick test_mutates_issue_list_returns_none
+      ; test_case "unknown command -> None" `Quick test_mutates_unknown_command_returns_none
+      ]
+    ; "cache_validate_fast_paths",
+      [ test_case "empty slug -> Unknown" `Quick test_validate_empty_slug_returns_unknown
+      ; test_case "zero number -> Unknown" `Quick test_validate_zero_number_returns_unknown
+      ; test_case "negative number -> Unknown" `Quick test_validate_negative_number_returns_unknown
+      ; test_case "metrics keys present" `Quick test_metrics_initial
+      ]
+    ]

--- a/test/test_keeper_gh_hallucination_gate.ml
+++ b/test/test_keeper_gh_hallucination_gate.ml
@@ -102,6 +102,19 @@ let test_extract_negative_is_none () =
   (* Negative ints fail parsing (leading - looks like a flag and is skipped). *)
   check target_testable "pr view -5" None (extract "pr view -5")
 
+let test_extract_flag_before_number_is_none () =
+  (* The parser is strict: it only recognizes `<kind> <sub> <N>` with
+     the integer as the immediate third token. If the caller puts a
+     flag between [sub] and [N] we fallthrough (Unknown), letting gh
+     process the command normally. This keeps the parser sound without
+     a gh-flag-table heuristic. *)
+  check target_testable "pr view --web 42 (flag precedes number)"
+    None
+    (extract "pr view --web 42");
+  check target_testable "issue view --json title 7"
+    None
+    (extract "issue view --json title 7")
+
 (* ====================================================================== *)
 (* gh_mutates_entity                                                        *)
 (* ====================================================================== *)
@@ -219,6 +232,8 @@ let () =
       ; test_case "extra whitespace" `Quick test_extract_extra_whitespace
       ; test_case "number 0 -> None" `Quick test_extract_zero_is_none
       ; test_case "negative number -> None" `Quick test_extract_negative_is_none
+      ; test_case "flag before number -> None (strict)" `Quick
+          test_extract_flag_before_number_is_none
       ]
     ; "gh_mutates_entity",
       [ test_case "pr create" `Quick test_mutates_pr_create


### PR DESCRIPTION
## Context

cheolsu keeper가 `keeper_github` 호출 시 존재하지 않는 PR/issue 번호를 계속 지어낸다 (87연속 `ok:false` in decisions.jsonl). 현재 대응은:

1. **프롬프트**: `config/prompts/keeper.capabilities.md:15` "NEVER guess or invent PR numbers"
2. **사후 hint**: `gh_not_found_hint` "Do not guess numbers. Use 'issue list' or 'pr list' first"

둘 다 GLM-5-turbo 같은 소형 LLM에 무시된다. **Harness > Model** 원칙에 따라 구조적 해결이 필요했다.

## Approach

실행 **전** pre-validation gate:

1. **`keeper_gh_cache.ml/.mli`** (NEW): per-repo PR/issue 번호 in-memory 캐시
   - `gh api repos/.../{pulls,issues}?state=all` (REST, GraphQL 회피 — qa-king의 p-10f3f0914beeb9e0d22f80e0b0e107a8 관찰대로)
   - TTL 120s, `Eio.Mutex`로 동시성 보호, 전체 keeper 공유
   - fail-open: fetch 실패 시 `\`Unknown` 반환 → 정상 실행으로 fallthrough
2. **`extract_gh_target_number`**: 순수 파서. `pr view/merge/comment/...`와 `issue view/close/...`에서 정수 target 추출. `pr list`, `pr create`, branch-name 등은 `None`
3. **`handle_keeper_github` validation gate**: `validate_gh_command` 이후, execution 직전에 삽입. Invalid 번호면 `valid_numbers` JSON array와 함께 거부
4. **`gh_mutates_entity` + 자동 invalidation**: `pr create/close/merge/...` 성공 후 캐시 무효화
5. **`handle_keeper_pr_submit` invalidation**: PR 생성 성공 후 즉시 PR 캐시 refresh

## 핵심 설계 결정

"추측하지 마라" 대신 **"이 중에서 골라라"**. 거부 응답에 `valid_numbers: [7110, 7111, 7112]`를 배열로 넣어 LLM이 **선택만** 하게 한다. 소형 모델에도 결정론적으로 작동.

## Board ideas 반영

| Idea | Post | 반영 |
|------|------|------|
| Schema enforcement | `p-2b53cfeeb76e3436a0b97b66a5bb7cee` (ani1999) | pre-validation으로 구현 |
| REST > GraphQL | `p-10f3f0914beeb9e0d22f80e0b0e107a8` (qa-king) | `gh api` REST 사용 |
| Access vs param validation gap | `c-bb62dad395866e8fbf7bec22acd0451e` (cheolsu) | param validation 추가로 gap 해소 |

## Files

- `lib/keeper/keeper_gh_cache.{ml,mli}` (NEW): 166 + 49 lines
- `lib/keeper/keeper_exec_github.{ml,mli}`: +176 / +14 lines (pre-validation gate, cache invalidation)
- `test/test_keeper_gh_hallucination_gate.ml` (NEW): 240 lines, 28 tests
- `lib/dune`, `test/dune`: +2 / +2 lines (module registration)

## Verification

- **New tests**: 28/28 pass (`extract_gh_target_number` 15, `gh_mutates_entity` 9, cache fast-paths 4)
- **Regression**: 기존 gh 테스트 44/44 pass (`test_keeper_github_safety` 13, `test_keeper_github_read_only` 19, `test_keeper_github_hint` 12)
- **Full build**: `dune build` clean

## Runtime verification (post-merge)

Metrics via `Keeper_gh_cache.metrics ()` 노출:
- `hits`: 번호가 캐시에 있고 유효
- `misses`: hallucination 탐지 (실행 차단됨)
- `bypasses`: 캐시 비어있음 (fallthrough)
- `fetch_errors`: gh api 서브프로세스 실패

Post-merge KPI: `misses / (hits + misses)` 비율로 hallucination 감지율 측정 가능. 배포 후 cheolsu의 `keeper_github` 성공률이 0% → >50%로 오르는지 추적.

## Plan

See `~/me/planning/claude-plans/peaceful-sauteeing-stearns.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)