### PR TITLE
fix(log): dedupe 'mixed cascade context budget' log per keeper

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -346,6 +346,14 @@ let pause_keeper_for_overflow
     meta.name reason;
   paused_meta
 
+(* Dedupe "mixed cascade context budget" log: the values are constant
+   per (keeper_name, model_labels) because cascade config is static at
+   startup.  Logging per turn produces 15-20 duplicates per keeper per
+   minute under load. Track (name, primary, cascade_max) tuples we've
+   already announced and skip subsequent identical log lines. *)
+let cascade_budget_logged : (string * int * int, unit) Hashtbl.t =
+  Hashtbl.create 16
+
 let resolved_max_context_for_turn
     ~(meta : keeper_meta)
     (model_labels : string list) : int =
@@ -370,10 +378,15 @@ let resolved_max_context_for_turn
           Oas_model_resolve.clamp_context_for_pure_local_labels
             ~labels:model_labels ~max_context:resolved
         in
-        if primary < cascade_max then
-          Log.Keeper.info
-            "%s: mixed cascade context budget primary=%d cascade_max=%d; using primary for initial turn budget"
-            meta.name primary cascade_max;
+        if primary < cascade_max then begin
+          let key = (meta.name, primary, cascade_max) in
+          if not (Hashtbl.mem cascade_budget_logged key) then begin
+            Hashtbl.add cascade_budget_logged key ();
+            Log.Keeper.info
+              "%s: mixed cascade context budget primary=%d cascade_max=%d; using primary for initial turn budget"
+              meta.name primary cascade_max
+          end
+        end;
         primary
   in
   if raw < min_keeper_context then begin


### PR DESCRIPTION
## Summary

서버 로그에서 아래 INFO가 keeper당 15-20회/분 반복:

```
[Keeper] poe: mixed cascade context budget primary=200000 cascade_max=262144; using primary for initial turn budget
```

## Root cause

`resolved_max_context_for_turn`이 매 턴 호출되며, `primary < cascade_max` (mixed-provider cascade 구성)일 때마다 INFO 로그. cascade config는 startup에 정적이므로 `(keeper_name, primary, cascade_max)` 튜플이 keeper당 상수 → 반복 메시지가 noise.

```ocaml
(* 매 턴 호출 *)
if primary < cascade_max then
  Log.Keeper.info
    "%s: mixed cascade context budget primary=%d cascade_max=%d..."
    meta.name primary cascade_max;
```

## Fix

module-level `Hashtbl` dedup — `(name, primary, cascade_max)` 튜플 단위로 한 번만 로그. 단일 Eio domain이라 plain Hashtbl 안전.

## Discovery

Iter 7 grey-zone scan: production log sample(`/Users/dancer/me/logs/masc-server-restart.log`)에서 [Keeper] INFO 716회 중 상위 반복 패턴 추출. PR #7142(`default_base_path` Lazy memoize)과 같은 계열이지만 dynamic label이라 Hashtbl dedup 사용.

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 keeper당 해당 INFO가 첫 턴 1회만 출력되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
