### PR TITLE
fix(room): dedupe MASC-base-path resolver logs to kill per-request spam

### DIFF
--- a/lib/room/room_utils_backend_setup.ml
+++ b/lib/room/room_utils_backend_setup.ml
@@ -114,14 +114,43 @@ let sync_test_base_path_env resolved_path =
         Log.Room.info "Synchronized MASC_BASE_PATH=%s for test executable %s"
           resolved_path (Filename.basename Sys.executable_name)
 
+(** Dedupe MASC-base-path log lines across back-to-back identical resolutions.
+
+    [resolve_masc_base_path] is called on every HTTP request (see
+    [server_mcp_transport_http_session.default_base_path]). cwd and
+    [MASC_BASE_PATH] are invariant per server lifetime, so every call
+    produces the same log lines — which used to spam the log every few
+    seconds. The resolver still runs in full (so env changes in tests
+    are honored); only log emission is suppressed when the exact message
+    has been logged before.
+
+    The set is unbounded because the number of distinct log lines the
+    resolver can produce is small and fixed (~4 patterns × realistic
+    input paths). [Stdlib.Mutex] is used instead of [Eio.Mutex] because
+    this resolver is called from both test executables (no Eio context)
+    and the server (with Eio); [Eio.Mutex] raises Unhandled on the
+    former. See feedback: ocaml5-mutex-selection. *)
+let logged_lines : (string, unit) Hashtbl.t = Hashtbl.create 8
+let logged_lines_mutex = Mutex.create ()
+
+let log_once_info fmt =
+  Format.kasprintf (fun msg ->
+    Mutex.lock logged_lines_mutex;
+    let fresh =
+      if Hashtbl.mem logged_lines msg then false
+      else begin Hashtbl.add logged_lines msg (); true end
+    in
+    Mutex.unlock logged_lines_mutex;
+    if fresh then Log.Room.info "%s" msg) fmt
+
 let resolve_requested_base_path path =
   let requested = normalize_base_path path in
   match find_git_root requested with
   | Some git_root ->
-      Log.Room.info "MASC base resolved: %s → %s (git root)" requested git_root;
+      log_once_info "MASC base resolved: %s → %s (git root)" requested git_root;
       git_root
   | None ->
-      Log.Room.info "MASC base: %s (no git root found)" requested;
+      log_once_info "MASC base: %s (no git root found)" requested;
       requested
 
 (** Resolve base_path with a single authority:
@@ -137,7 +166,7 @@ let resolve_masc_base_path path =
          && not
               (Env_config_core.get_bool ~default:false
                  "MASC_TEST_ALLOW_INHERITED_BASE_PATH") ->
-      Log.Room.info
+      log_once_info
         "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
         explicit path;
       requested
@@ -147,12 +176,12 @@ let resolve_masc_base_path path =
               (Env_config_core.get_bool ~default:false
                  "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
          && not (String.equal explicit requested) ->
-      Log.Room.info
+      log_once_info
         "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
         explicit path;
       requested
   | Some explicit ->
-      Log.Room.info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
+      log_once_info "MASC base: %s (explicit MASC_BASE_PATH)" explicit;
       explicit
   | None -> requested
 


### PR DESCRIPTION
## Summary

\`default_base_path()\` runs \`resolve_masc_base_path\` on every HTTP request, which logs 2 INFO lines each time. cwd and \`MASC_BASE_PATH\` don't change mid-lifetime, so the log is literally the same 2 lines every 7–8 seconds — matching MCP heartbeat/polling cadence. Fix is a tiny dedup: log only when the exact message hasn't been logged before.

## Why

Discovered when starting the server for runtime verification of the #7068 Hebbian series. The resolver itself is fast; the log spam was the only symptom. Resolver must keep running in full because tests rely on env-change re-resolution (see \`test_server_base_path_diagnostics\` cases 6–8).

## Product impact

Logs become readable again for operators watching server output. No behavior change: resolution semantics identical, all 9 base-path diagnostic tests pass.

## Changes

\`lib/room/room_utils_backend_setup.ml\` (+34/-5):

- New \`log_once_info\` helper: \`Hashtbl\` set + \`Stdlib.Mutex\` guards emission. If the exact formatted line has been logged before, suppress the \`Log.Room.info\` call.
- 4 log sites in \`resolve_requested_base_path\` and \`resolve_masc_base_path\` converted from \`Log.Room.info\` to \`log_once_info\`.

**Mutex choice**: \`Stdlib.Mutex\`, not \`Eio.Mutex\`. The resolver is called from tests (no Eio scheduler) and from the server (with Eio); \`Eio.Mutex\` raises \`Effect.Unhandled(Get_context)\` outside an Eio fiber. This is exactly the \`ocaml5-mutex-selection\` guidance captured in my local feedback memory.

## Evidence

| Check | Result |
|-------|--------|
| \`dune build\` | clean |
| \`test_server_base_path_diagnostics\` | 9/9 (was 6/9 in first-pass attempt that used \`Eio.Mutex\`) |
| \`test_hebbian_eio\` | 14/14 |
| \`test_tool_surface_ssot\` | 25/25 |
| Runtime on my machine | 2 log lines on startup, silence on subsequent requests |

## Review evidence

First attempt tried to memoize \`default_base_path ()\` with \`Eio.Lazy\` — that broke diagnostic tests 6–8 which depend on env-change re-resolution. Pivoted to "let the resolver run, just dedup the log" — preserves semantics, kills spam.

## Linked

Surfaced during runtime verification of #7128 (Hebbian series). Independent fix.