### PR TITLE
fix(dashboard): re-surface telemetry summary fetch errors in telemetry-unified

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -119,6 +119,28 @@ describe('TelemetryUnified', () => {
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(2)
   })
 
+  it('surfaces summary fetch errors to the panel error banner (regression: Phase 0 fleet-data-core)', async () => {
+    // Before Phase 0, telemetry-unified awaited fetchTelemetrySummary directly
+    // inside Promise.all, so any rejection flowed to the outer catch and set
+    // state.error. Phase 0 moved the fetch into fleet-data-core which swallows
+    // the rejection into sharedTelemetrySummaryError; the panel must re-surface
+    // that to preserve the prior user-visible failure UI.
+    const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
+    const fetchTelemetrySummary = vi.fn().mockRejectedValue(
+      new Error('GET /api/v1/dashboard/telemetry/summary: 503 Service Unavailable'),
+    )
+    const { TelemetryUnified } = await loadPanel(fetchTelemetry, fetchTelemetrySummary)
+
+    await act(async () => {
+      render(html`<${TelemetryUnified} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetrySummary).toHaveBeenCalled()
+    expect(container.textContent).toContain('503 Service Unavailable')
+  })
+
   it('renders runtime diagnosis metadata for operators', async () => {
     const fetchTelemetry = vi.fn().mockResolvedValue(baseTelemetry)
     const fetchTelemetrySummary = vi.fn().mockResolvedValue(baseSummary)

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -12,7 +12,11 @@ import {
   type TelemetrySource,
   type TelemetrySourceSummary,
 } from '../api/dashboard'
-import { refreshSharedTelemetrySummary, sharedTelemetrySummary } from './fleet-data-core'
+import {
+  refreshSharedTelemetrySummary,
+  sharedTelemetrySummary,
+  sharedTelemetrySummaryError,
+} from './fleet-data-core'
 import { route } from '../router'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { TELEMETRY_SOURCE_META, telemetrySourceMeta } from '../config/telemetry-sources'
@@ -618,6 +622,15 @@ export function TelemetryUnified() {
         storePromise,
       ])
       if (requestId !== latestRequestId.current) return
+      // refreshSharedTelemetrySummary records failures on the shared error
+      // signal rather than throwing (so tool-quality-panel can keep rendering
+      // the last-good value). Telemetry-unified, however, treated a summary
+      // failure as a panel-level error before Phase 0, so re-raise it here
+      // to preserve the user-visible regression surface.
+      const summaryError = sharedTelemetrySummaryError.value
+      if (summaryError !== null) {
+        throw new Error(summaryError)
+      }
       const summary = sharedTelemetrySummary.value ?? { sources: [], total_entries: 0, generated_at: '' }
       state.value = {
         entries: telemetry.entries,


### PR DESCRIPTION
## Summary

Regression hotfix for #7134 (Phase 0 of dashboard consolidation). Summary-
fetch failures are no longer silent in the telemetry-unified panel.

## Product impact

**Bug, introduced in #7134:** when \`/api/v1/dashboard/telemetry/summary\` returns
a 5xx (or any rejection), the telemetry tab silently rendered empty-summary
fallback data without any error indicator. Before Phase 0, the red error
banner appeared with the message.

**Fix:** telemetry-unified reads the shared error signal after the refresh and
re-raises it, restoring the pre-Phase-0 behavior.

tool-quality-panel is intentionally unaffected — it continues to show last-good
values through transient summary errors (that panel's prior behavior too).

## Evidence

- \`npm run test\` — 87 files, **543 passed + 12 skipped** (+1 new regression test)
- \`npm run build\` — clean

## Review evidence

### Change in \`components/telemetry-unified.ts\`
- Add \`sharedTelemetrySummaryError\` import
- After \`Promise.all\`, if the shared error signal is non-null, throw so the
  existing outer catch paints the red banner as it did pre-Phase-0

### New test in \`components/telemetry-unified.test.ts\`
- Mock \`fetchTelemetrySummary\` to reject with "503 Service Unavailable"
- Render TelemetryUnified
- Assert \`container.textContent\` contains the error string

## Not in this PR

- Same pattern for fleet-telemetry-panel (it never migrated in Phase 0, so
  there's nothing to regress — its own Promise.allSettled still handles errors)
- Any new UX for partial summary failures (keeping telemetry but also showing
  an error banner). That would be a Phase 2+ consideration.

## Linked issue

Self-review of Phase 0 (PR #7134). No external tracker.