### PR TITLE
refactor(keeper): decompose pre_tool_use guard chain into composed hooks

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -458,6 +458,7 @@
    keeper_post_turn
    keeper_exec_context
    keeper_tools_oas
+   keeper_guards
    keeper_hooks_oas
    keeper_extend_turns
    keeper_llm_bridge
@@ -638,6 +639,7 @@
   keeper_tool_disclosure
   keeper_turn_telemetry
   keeper_exec_context
+  keeper_guards
   keeper_turn_setup
   keeper_turn_up_args
   keeper_turn_up_create

--- a/lib/keeper/keeper_guards.ml
+++ b/lib/keeper/keeper_guards.ml
@@ -1,0 +1,453 @@
+(** Keeper_guards — composable pre_tool_use hooks for keeper agents.
+
+    Decomposes the previously monolithic [pre_tool_use] guard chain
+    (streak / deny / cost / destructive / governance) into standalone
+    OAS [Hooks.hooks] records that stack via
+    [Agent_sdk.Hooks.compose]. Each guard fills only the
+    [pre_tool_use] slot; composition short-circuits on the first
+    non-[Continue] decision.
+
+    Design principles:
+    - Public SDK boundary (C0): OAS is consumed as-is. No OAS-side
+      edits. All keeper-specific state lives in MASC closures.
+    - MASC/OAS boundary (C1): OAS primitives do not learn about
+      keepers. [meta_ref], deny lists, streak thresholds, and cost
+      limits stay on the MASC side.
+    - Observability (C2): every override / approval decision emits a
+      [masc:keeper_gate] Event_bus Custom event in addition to the
+      existing [broadcast_tool_skipped] SSE call. The dual emit lets
+      downstream consumers migrate without coordinating with this
+      change. Payload carries stage/reason/latency so dashboards can
+      chart per-stage firing rates and drift.
+
+    @since T1-A — pre_tool_use guard decomposition *)
+
+(* -------------------------------------------------------------- *)
+(* Shared utilities previously inline in [keeper_hooks_oas]        *)
+(* -------------------------------------------------------------- *)
+
+(** Percent-encode field value for structured [tool_skipped] output.
+    Matches [Keeper_agent_run.escape_field_value]. *)
+let escape_field s =
+  let buf = Buffer.create (String.length s * 3 / 2 + 1) in
+  String.iter (fun ch ->
+    match ch with
+    | ' ' -> Buffer.add_string buf "%20"
+    | '=' -> Buffer.add_string buf "%3D"
+    | '\n' -> Buffer.add_string buf "%0A"
+    | '\r' -> Buffer.add_string buf "%0D"
+    | '\t' -> Buffer.add_string buf "%09"
+    | '%' -> Buffer.add_string buf "%25"
+    | _ -> Buffer.add_char buf ch) s;
+  Buffer.contents buf
+
+(** Render structured skip reason for inline Override injection.
+    The LLM sees this as the ToolResult content immediately within
+    the same turn. *)
+let render_inline_skip_reason ~tool_name ~reason_code ~reason_text : string =
+  let replacement_hint =
+    match (Tool_catalog.metadata tool_name).Tool_catalog.replacement with
+    | Some replacement ->
+      Printf.sprintf " replacement=%s" (escape_field replacement)
+    | None -> ""
+  in
+  Printf.sprintf
+    "[tool_skipped] tool=%s source=keeper_hook code=%s reason=%s%s"
+    (escape_field tool_name)
+    (escape_field reason_code)
+    (escape_field reason_text)
+    replacement_hint
+
+(** Broadcast a tool skip event via SSE for dashboard visibility.
+    Also records in [Dashboard_governance_metrics] for aggregation. *)
+let broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code =
+  Dashboard_governance_metrics.record_tool_skipped
+    ~keeper_name ~tool_name ~reason_code;
+  (try
+    Sse.broadcast
+      (`Assoc [
+        ("type", `String "keeper_tool_skipped");
+        ("name", `String keeper_name);
+        ("tool_name", `String tool_name);
+        ("reason_code", `String reason_code);
+        ("ts_unix", `Float (Unix.gettimeofday ()));
+      ])
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Keeper.warn
+        "tool skip SSE broadcast failed: keeper=%s tool=%s reason=%s err=%s"
+        keeper_name tool_name reason_code (Printexc.to_string exn))
+
+(** Extract command/content string from tool input JSON for screening. *)
+let extract_command_from_input (input : Yojson.Safe.t) : string =
+  let open Yojson.Safe.Util in
+  try
+    match input |> member "command" with
+    | `String s -> s
+    | `Null | _ ->
+      (match input |> member "cmd" with
+       | `String s -> s
+       | `Null | _ ->
+         (match input |> member "content" with
+          | `String s -> s
+          | _ -> ""))
+  with Yojson.Safe.Util.Type_error _ -> ""
+
+(* -------------------------------------------------------------- *)
+(* Telemetry                                                       *)
+(* -------------------------------------------------------------- *)
+
+(** Emit a [masc:keeper_gate] Event_bus Custom event.
+
+    Payload schema:
+    - [stage]               snake_case stage identifier
+    - [decision]            "override" | "continue" | "approval_required"
+    - [reason_code]         machine-classifiable short code
+    - [tool_name]           the tool the gate was evaluating
+    - [agent_name]          keeper name
+    - [turn]                turn index reported by OAS
+    - [accumulated_cost_usd] OAS running cost total
+    - [stage_latency_ms]    measured duration of this guard
+    - [reason_text]         human-readable detail
+    - [source]              "hook" (distinguishes from legacy paths) *)
+let emit_gate_event
+    ~stage ~decision ~reason_code
+    ~tool_name ~agent_name ~turn
+    ~accumulated_cost_usd ~stage_latency_ms ~reason_text =
+  match Keeper_event_bus.get () with
+  | None -> ()
+  | Some bus ->
+    let payload = `Assoc [
+      ("stage", `String stage);
+      ("decision", `String decision);
+      ("reason_code", `String reason_code);
+      ("tool_name", `String tool_name);
+      ("agent_name", `String agent_name);
+      ("turn", `Int turn);
+      ("accumulated_cost_usd", `Float accumulated_cost_usd);
+      ("stage_latency_ms", `Float stage_latency_ms);
+      ("reason_text", `String reason_text);
+      ("source", `String "hook");
+    ] in
+    (try
+      Agent_sdk.Event_bus.publish bus
+        (Agent_sdk.Event_bus.mk_event
+           (Agent_sdk.Event_bus.Custom ("masc:keeper_gate", payload)))
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Keeper.warn
+        "keeper_guards: event emit failed stage=%s tool=%s err=%s"
+        stage tool_name (Printexc.to_string exn))
+
+(* -------------------------------------------------------------- *)
+(* Composition helpers                                             *)
+(* -------------------------------------------------------------- *)
+
+(** Build a [Hooks.hooks] record with only [pre_tool_use] filled. *)
+let hooks_of_pre_tool_use (fn : Agent_sdk.Hooks.hook)
+  : Agent_sdk.Hooks.hooks =
+  { Agent_sdk.Hooks.empty with pre_tool_use = Some fn }
+
+(** Compose a list of hooks via [Hooks.compose], left-to-right.
+    Each slot short-circuits on the first non-[Continue] decision. *)
+let compose_all (hs : Agent_sdk.Hooks.hooks list)
+  : Agent_sdk.Hooks.hooks =
+  List.fold_left
+    (fun acc h -> Agent_sdk.Hooks.compose ~outer:acc ~inner:h)
+    Agent_sdk.Hooks.empty
+    hs
+
+(* -------------------------------------------------------------- *)
+(* Streak state (shared across invocations for one keeper)         *)
+(* -------------------------------------------------------------- *)
+
+(** Mutable streak state captured by [streak_guard]. *)
+type streak_state = { mutable entry : string * int }
+
+let make_streak_state () : streak_state = { entry = ("", 0) }
+
+(* -------------------------------------------------------------- *)
+(* Timing guard — records tool_start_time for post_tool_use use    *)
+(* -------------------------------------------------------------- *)
+
+(** Record the tool start timestamp so [post_tool_use] can compute
+    latency. Returns [Continue] unconditionally. Should be composed
+    FIRST in the chain so the timestamp is set even when a later
+    guard returns [Override]. *)
+let timing_guard ~(tool_start_time : float ref)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse _ ->
+      tool_start_time := Time_compat.now ();
+      Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(* -------------------------------------------------------------- *)
+(* Individual guards                                               *)
+(* -------------------------------------------------------------- *)
+
+(** User-supplied custom guard. Short-circuits via [Override] when
+    the caller's callback returns [Some reason_text]. *)
+let custom_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(guard : tool_name:string -> input:Yojson.Safe.t -> string option)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
+      let t0 = Time_compat.now () in
+      let keeper_name = (!meta_ref).Keeper_types.name in
+      (match guard ~tool_name ~input with
+       | Some reason ->
+         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+         Log.Keeper.info
+           "keeper:%s pre_tool_use guard blocked %s"
+           keeper_name tool_name;
+         broadcast_tool_skipped
+           ~keeper_name ~tool_name ~reason_code:"pre_tool_use_guard";
+         emit_gate_event
+           ~stage:"pre_tool_use_guard" ~decision:"override"
+           ~reason_code:"pre_tool_use_guard"
+           ~tool_name ~agent_name:keeper_name ~turn
+           ~accumulated_cost_usd
+           ~stage_latency_ms:latency_ms
+           ~reason_text:reason;
+         Agent_sdk.Hooks.Override
+           (render_inline_skip_reason
+              ~tool_name ~reason_code:"pre_tool_use_guard"
+              ~reason_text:reason)
+       | None -> Agent_sdk.Hooks.Continue)
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(** Same-name streak gate: block when the same tool name is called
+    [threshold+] times consecutively, regardless of args. OAS idle
+    detection requires exact name+args match, so this catches the
+    "same operation, different targets" pattern (e.g. reading 20
+    board posts one by one). *)
+let streak_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(state : streak_state)
+    ~(threshold : int)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; accumulated_cost_usd; turn; _ } ->
+      let t0 = Time_compat.now () in
+      let keeper_name = (!meta_ref).Keeper_types.name in
+      let prev_name, prev_count = state.entry in
+      let new_count =
+        if prev_name = tool_name then prev_count + 1 else 1
+      in
+      state.entry <- (tool_name, new_count);
+      if new_count >= threshold then begin
+        let reason_text =
+          Printf.sprintf
+            "%s called %d times consecutively. Use a DIFFERENT tool or keeper_stay_silent"
+            tool_name new_count
+        in
+        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+        Log.Keeper.warn
+          "keeper:%s streak_gate: %s called %d times consecutively, blocking"
+          keeper_name tool_name new_count;
+        broadcast_tool_skipped
+          ~keeper_name ~tool_name ~reason_code:"streak_gate";
+        emit_gate_event
+          ~stage:"streak_gate" ~decision:"override"
+          ~reason_code:"streak_gate"
+          ~tool_name ~agent_name:keeper_name ~turn
+          ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms
+          ~reason_text;
+        Agent_sdk.Hooks.Override
+          (render_inline_skip_reason
+             ~tool_name ~reason_code:"streak_gate" ~reason_text)
+      end
+      else Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(** Keeper deny list. Block administrative / destructive tools that
+    should only be invoked by operators or controlled workflows. *)
+let deny_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(denied : string list)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; accumulated_cost_usd; turn; _ } ->
+      let t0 = Time_compat.now () in
+      let keeper_name = (!meta_ref).Keeper_types.name in
+      if List.mem tool_name denied then begin
+        let reason_text = "tool is on the keeper deny list" in
+        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+        Log.Keeper.warn "keeper:%s deny list: blocked %s"
+          keeper_name tool_name;
+        broadcast_tool_skipped
+          ~keeper_name ~tool_name ~reason_code:"keeper_deny";
+        emit_gate_event
+          ~stage:"keeper_deny" ~decision:"override"
+          ~reason_code:"keeper_deny"
+          ~tool_name ~agent_name:keeper_name ~turn
+          ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms
+          ~reason_text;
+        Agent_sdk.Hooks.Override
+          (render_inline_skip_reason
+             ~tool_name ~reason_code:"keeper_deny" ~reason_text)
+      end
+      else Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(** Cost budget gate: reject when the running cost meets or exceeds
+    [limit]. No-op when [max_cost_usd] is [None]. *)
+let cost_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(max_cost_usd : float option)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; accumulated_cost_usd; turn; _ } ->
+      let t0 = Time_compat.now () in
+      let keeper_name = (!meta_ref).Keeper_types.name in
+      (match max_cost_usd with
+       | Some limit when accumulated_cost_usd >= limit ->
+         let reason_text =
+           Printf.sprintf
+             "accumulated_cost_usd=%.4f exceeded limit=%.4f"
+             accumulated_cost_usd limit
+         in
+         let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+         Log.Keeper.warn
+           "keeper:%s cost gate: $%.4f >= $%.4f limit, skipping %s"
+           keeper_name accumulated_cost_usd limit tool_name;
+         broadcast_tool_skipped
+           ~keeper_name ~tool_name ~reason_code:"cost_gate";
+         emit_gate_event
+           ~stage:"cost_gate" ~decision:"override"
+           ~reason_code:"cost_gate"
+           ~tool_name ~agent_name:keeper_name ~turn
+           ~accumulated_cost_usd
+           ~stage_latency_ms:latency_ms
+           ~reason_text;
+         Agent_sdk.Hooks.Override
+           (render_inline_skip_reason
+              ~tool_name ~reason_code:"cost_gate" ~reason_text)
+       | _ -> Agent_sdk.Hooks.Continue)
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(** Destructive pattern detection for bash/edit style tools.
+    Only applies when [enabled] is [true] and the tool is flagged by
+    [Tool_dispatch.is_destructive]. *)
+let destructive_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(enabled : bool)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
+      if not enabled then Agent_sdk.Hooks.Continue
+      else if not (Tool_dispatch.is_destructive tool_name) then
+        Agent_sdk.Hooks.Continue
+      else
+        let t0 = Time_compat.now () in
+        let keeper_name = (!meta_ref).Keeper_types.name in
+        let cmd = extract_command_from_input input in
+        (match Eval_gate.detect_destructive cmd with
+         | None -> Agent_sdk.Hooks.Continue
+         | Some (pattern, desc) ->
+           let reason_text =
+             Printf.sprintf "pattern='%s' (%s)" pattern desc
+           in
+           let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+           Log.Keeper.warn
+             "keeper:%s destructive pattern in %s: '%s' (%s)"
+             keeper_name tool_name pattern desc;
+           broadcast_tool_skipped
+             ~keeper_name ~tool_name ~reason_code:"destructive_guard";
+           emit_gate_event
+             ~stage:"destructive_guard" ~decision:"override"
+             ~reason_code:"destructive_guard"
+             ~tool_name ~agent_name:keeper_name ~turn
+             ~accumulated_cost_usd
+             ~stage_latency_ms:latency_ms
+             ~reason_text;
+           Agent_sdk.Hooks.Override
+             (render_inline_skip_reason
+                ~tool_name ~reason_code:"destructive_guard"
+                ~reason_text))
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(** Governance approval gate. Escalates via [ApprovalRequired] when
+    the assessed risk level meets or exceeds the configured keeper
+    confirm threshold. Relies on an approval callback wired into the
+    agent Builder to resolve the decision. *)
+let governance_approval_guard
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+  : Agent_sdk.Hooks.hooks =
+  hooks_of_pre_tool_use (fun event ->
+    match event with
+    | Agent_sdk.Hooks.PreToolUse
+        { tool_name; input; accumulated_cost_usd; turn; _ } ->
+      let t0 = Time_compat.now () in
+      let keeper_name = (!meta_ref).Keeper_types.name in
+      let governance_level = Env_config_core.governance_level () in
+      let risk = Governance_pipeline.assess_risk ~tool_name ~input in
+      let needs_approval =
+        match Governance_pipeline.keeper_confirm_threshold governance_level with
+        | Some threshold ->
+          Governance_pipeline.risk_level_to_int risk
+          >= Governance_pipeline.risk_level_to_int threshold
+        | None -> false
+      in
+      if needs_approval then begin
+        let latency_ms = (Time_compat.now () -. t0) *. 1000.0 in
+        emit_gate_event
+          ~stage:"governance_approval" ~decision:"approval_required"
+          ~reason_code:"governance_approval"
+          ~tool_name ~agent_name:keeper_name ~turn
+          ~accumulated_cost_usd
+          ~stage_latency_ms:latency_ms
+          ~reason_text:"risk threshold reached; operator approval required";
+        Agent_sdk.Hooks.ApprovalRequired
+      end
+      else Agent_sdk.Hooks.Continue
+    | _ -> Agent_sdk.Hooks.Continue)
+
+(* -------------------------------------------------------------- *)
+(* Chain assembly                                                  *)
+(* -------------------------------------------------------------- *)
+
+(** Build the full keeper pre_tool_use chain.
+
+    Order matters: the first guard to return a non-[Continue]
+    decision wins (short-circuit via [Hooks.compose]). Preserves the
+    ordering of the previous monolithic implementation:
+      timing -> custom -> streak -> deny -> cost -> destructive ->
+      governance_approval *)
+let build_chain
+    ~(meta_ref : Keeper_types.keeper_meta ref)
+    ~(tool_start_time : float ref)
+    ~(streak_state : streak_state)
+    ~(streak_threshold : int)
+    ~(denied : string list)
+    ~(max_cost_usd : float option)
+    ~(destructive_check : bool)
+    ~(pre_tool_use_guard :
+        tool_name:string -> input:Yojson.Safe.t -> string option)
+  : Agent_sdk.Hooks.hooks =
+  compose_all [
+    timing_guard ~tool_start_time;
+    custom_guard ~meta_ref ~guard:pre_tool_use_guard;
+    streak_guard ~meta_ref ~state:streak_state ~threshold:streak_threshold;
+    deny_guard ~meta_ref ~denied;
+    cost_guard ~meta_ref ~max_cost_usd;
+    destructive_guard ~meta_ref ~enabled:destructive_check;
+    governance_approval_guard ~meta_ref;
+  ]

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -22,78 +22,11 @@
 let keeper_denied_tools =
   Tool_catalog.tools_for_surface Tool_catalog.Keeper_denied
 
-(** Percent-encode field value for structured [tool_skipped] output.
-    Matches [Keeper_agent_run.escape_field_value] encoding.
-    Local copy to avoid circular dependency. *)
-let escape_field s =
-  let buf = Buffer.create (String.length s * 3 / 2 + 1) in
-  String.iter (fun ch ->
-    match ch with
-    | ' ' -> Buffer.add_string buf "%20"
-    | '=' -> Buffer.add_string buf "%3D"
-    | '\n' -> Buffer.add_string buf "%0A"
-    | '\r' -> Buffer.add_string buf "%0D"
-    | '\t' -> Buffer.add_string buf "%09"
-    | '%' -> Buffer.add_string buf "%25"
-    | _ -> Buffer.add_char buf ch) s;
-  Buffer.contents buf
-
-(** Render structured skip reason for inline Override injection.
-    The LLM sees this as the ToolResult content immediately within
-    the same turn, enabling in-turn reasoning about alternatives.
-    @since Phase 8 — Skip→Override migration *)
-let render_inline_skip_reason ~tool_name ~reason_code ~reason_text : string =
-  let replacement_hint =
-    match (Tool_catalog.metadata tool_name).Tool_catalog.replacement with
-    | Some replacement ->
-      Printf.sprintf " replacement=%s" (escape_field replacement)
-    | None -> ""
-  in
-  Printf.sprintf
-    "[tool_skipped] tool=%s source=keeper_hook code=%s reason=%s%s"
-    (escape_field tool_name)
-    (escape_field reason_code)
-    (escape_field reason_text)
-    replacement_hint
-
-(** Broadcast a tool skip event via SSE for dashboard visibility.
-    Also records the event in [Dashboard_governance_metrics] so the
-    governance monitor endpoint can aggregate (tool, reason) counts
-    without tailing the SSE stream. *)
-let broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code =
-  Dashboard_governance_metrics.record_tool_skipped
-    ~keeper_name ~tool_name ~reason_code;
-  (try
-    Sse.broadcast
-      (`Assoc [
-        ("type", `String "keeper_tool_skipped");
-        ("name", `String keeper_name);
-        ("tool_name", `String tool_name);
-        ("reason_code", `String reason_code);
-        ("ts_unix", `Float (Unix.gettimeofday ()));
-      ])
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | exn ->
-      Log.Keeper.warn
-        "tool skip SSE broadcast failed: keeper=%s tool=%s reason=%s err=%s"
-        keeper_name tool_name reason_code (Printexc.to_string exn))
-
-(** Extract command or content string from tool input JSON for screening.
-    Reads "command", "cmd" (keeper_github), or "content" keys. *)
-let extract_command_from_input (input : Yojson.Safe.t) : string =
-  let open Yojson.Safe.Util in
-  try
-    match input |> member "command" with
-    | `String s -> s
-    | `Null | _ ->
-      (match input |> member "cmd" with
-       | `String s -> s
-       | `Null | _ ->
-         (match input |> member "content" with
-          | `String s -> s
-          | _ -> ""))
-  with Yojson.Safe.Util.Type_error _ -> ""
+(* [escape_field], [render_inline_skip_reason], [broadcast_tool_skipped],
+   and [extract_command_from_input] now live in [Keeper_guards]. They
+   are used only by the decomposed pre_tool_use guard chain, so keeping
+   them there avoids a circular dependency and concentrates the
+   gate-level concerns in one module. *)
 
 (** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
     Schema matches bin/masc_cost.ml with an additional "source" field to
@@ -277,15 +210,27 @@ let make_hooks
   (* Per-turn tool call counter for SSE enrichment.
      Incremented in post_tool_use, reset in after_turn. *)
   let tool_call_count_ref = ref 0 in
-  (* Same-name streak gate: track consecutive calls to the same tool
-     name (regardless of args). OAS idle detection requires exact
-     name+args match, so board_get("a") → board_get("b") is never
-     detected. This catches the "same operation, different targets"
-     pattern (e.g., janitor reading 20 board posts one by one).
-     At >= streak_threshold, pre_tool_use blocks the call with Override. *)
-  let tool_name_streak : (string * int) ref = ref ("", 0) in
+  (* Streak gate state: tracks consecutive calls to the same tool
+     name (regardless of args). Lives across invocations via the
+     [make_hooks] closure — one state per keeper. *)
+  let streak_state = Keeper_guards.make_streak_state () in
   let streak_threshold = 5 in
-  { Agent_sdk.Hooks.empty with
+  (* Build the pre_tool_use guard chain via Hooks.compose. Each guard
+     lives in Keeper_guards and emits its own masc:keeper_gate event
+     on override/approval decisions. *)
+  let guard_chain =
+    Keeper_guards.build_chain
+      ~meta_ref
+      ~tool_start_time
+      ~streak_state
+      ~streak_threshold
+      ~denied:keeper_denied_tools
+      ~max_cost_usd
+      ~destructive_check
+      ~pre_tool_use_guard
+  in
+  let non_gate_hooks =
+    { Agent_sdk.Hooks.empty with
 
     after_turn = Some (fun event ->
       match event with
@@ -375,7 +320,7 @@ let make_hooks
         (* Reset same-name streak at turn boundary so it doesn't
            carry across turns (e.g., 4 calls in turn N + 1 in turn N+1
            should not hit threshold 5). *)
-        tool_name_streak := ("", 0);
+        streak_state.Keeper_guards.entry <- ("", 0);
         tool_call_count_ref := 0;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
@@ -444,122 +389,10 @@ let make_hooks
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 
-    pre_tool_use = Some (fun event ->
-      match event with
-      | Agent_sdk.Hooks.PreToolUse { tool_name; input; accumulated_cost_usd; _ } ->
-        tool_start_time := Time_compat.now ();
-        let keeper_name = (!meta_ref).name in
-        (match pre_tool_use_guard ~tool_name ~input with
-         | Some reason ->
-           Log.Keeper.info
-             "keeper:%s pre_tool_use guard blocked %s"
-             keeper_name tool_name;
-           broadcast_tool_skipped ~keeper_name ~tool_name
-             ~reason_code:"pre_tool_use_guard";
-           Agent_sdk.Hooks.Override
-             (render_inline_skip_reason
-                ~tool_name
-                ~reason_code:"pre_tool_use_guard"
-                ~reason_text:reason)
-         | None ->
-        (* Same-name streak gate: block when the same tool name is called
-           streak_threshold+ times consecutively, regardless of args.
-           Returns Override (tool NOT executed) with a directive to switch tools.
-           Uses >= so EVERY call after the threshold is blocked, not just one. *)
-        let prev_name, prev_count = !tool_name_streak in
-        let new_count =
-          if prev_name = tool_name then prev_count + 1 else 1
-        in
-        tool_name_streak := (tool_name, new_count);
-        if new_count >= streak_threshold then begin
-          Log.Keeper.warn
-            "keeper:%s streak_gate: %s called %d times consecutively, blocking"
-            keeper_name tool_name new_count;
-          broadcast_tool_skipped ~keeper_name ~tool_name
-            ~reason_code:"streak_gate";
-          Agent_sdk.Hooks.Override
-            (render_inline_skip_reason
-               ~tool_name
-               ~reason_code:"streak_gate"
-               ~reason_text:(Printf.sprintf
-                 "%s called %d times consecutively. Use a DIFFERENT tool or keeper_stay_silent"
-                 tool_name new_count))
-        end
-        else
-        (* Safety gate 0: Keeper deny list *)
-        if List.mem tool_name keeper_denied_tools then begin
-          Log.Keeper.warn "keeper:%s deny list: blocked %s"
-            keeper_name tool_name;
-          broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code:"keeper_deny";
-          Agent_sdk.Hooks.Override
-            (render_inline_skip_reason
-               ~tool_name
-               ~reason_code:"keeper_deny"
-               ~reason_text:"tool is on the keeper deny list")
-        end
-        else
-        (* Safety gate 1: Cost budget *)
-        (match max_cost_usd with
-         | Some limit when accumulated_cost_usd >= limit ->
-           let reason_text =
-             Printf.sprintf "accumulated_cost_usd=%.4f exceeded limit=%.4f"
-               accumulated_cost_usd limit
-           in
-           Log.Keeper.warn "keeper:%s cost gate: $%.4f >= $%.4f limit, skipping %s"
-             keeper_name accumulated_cost_usd limit tool_name;
-           broadcast_tool_skipped ~keeper_name ~tool_name ~reason_code:"cost_gate";
-           Agent_sdk.Hooks.Override
-             (render_inline_skip_reason
-                ~tool_name ~reason_code:"cost_gate" ~reason_text)
-         | _ ->
-           (* Safety gate 2: Destructive pattern detection *)
-           if destructive_check && Tool_dispatch.is_destructive tool_name then
-             let cmd = extract_command_from_input input in
-             match Eval_gate.detect_destructive cmd with
-             | Some (pattern, desc) ->
-               let reason_text =
-                 Printf.sprintf "pattern='%s' (%s)" pattern desc
-               in
-               Log.Keeper.warn "keeper:%s destructive pattern in %s: '%s' (%s)"
-                 keeper_name tool_name pattern desc;
-               broadcast_tool_skipped ~keeper_name ~tool_name
-                 ~reason_code:"destructive_guard";
-               Agent_sdk.Hooks.Override
-                 (render_inline_skip_reason
-                    ~tool_name ~reason_code:"destructive_guard" ~reason_text)
-             | None ->
-               (* Governance approval gate: check risk level and request
-                  approval for high-risk tools via OAS ApprovalRequired.
-                  The approval_callback (Keeper_approval_queue) will
-                  suspend the fiber until operator resolves. (#5907) *)
-               let governance_level = Env_config_core.governance_level () in
-               let risk = Governance_pipeline.assess_risk ~tool_name ~input in
-               let needs_approval =
-                 match Governance_pipeline.keeper_confirm_threshold governance_level with
-                 | Some threshold ->
-                   Governance_pipeline.risk_level_to_int risk
-                   >= Governance_pipeline.risk_level_to_int threshold
-                 | None -> false
-               in
-               if needs_approval then
-                 Agent_sdk.Hooks.ApprovalRequired
-               else
-                 Agent_sdk.Hooks.Continue
-           else
-             let governance_level = Env_config_core.governance_level () in
-             let risk = Governance_pipeline.assess_risk ~tool_name ~input in
-             let needs_approval =
-               match Governance_pipeline.keeper_confirm_threshold governance_level with
-               | Some threshold ->
-                 Governance_pipeline.risk_level_to_int risk
-                 >= Governance_pipeline.risk_level_to_int threshold
-               | None -> false
-             in
-             if needs_approval then
-               Agent_sdk.Hooks.ApprovalRequired
-             else
-               Agent_sdk.Hooks.Continue))
-      | _ -> Agent_sdk.Hooks.Continue);
+    (* pre_tool_use is provided by [guard_chain] below via Hooks.compose.
+       The guard chain (timing + custom + streak + deny + cost +
+       destructive + governance_approval) is composed with these
+       non-gate hooks at the end of [make_hooks]. *)
 
     on_idle = Some (fun event ->
       match event with
@@ -613,6 +446,12 @@ let make_hooks
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
   }
+  in
+  (* Guards fire first (outer). If all return Continue, non_gate_hooks
+     fire for the remaining slots (inner). pre_tool_use lives in
+     guard_chain only; non_gate_hooks has it None, so Hooks.compose
+     keeps guard_chain's pre_tool_use verbatim. *)
+  Agent_sdk.Hooks.compose ~outer:guard_chain ~inner:non_gate_hooks
 
 (** Static introspection of hook slot configuration.
     Returns a JSON summary of which hook slots are active, their gates/effects,

--- a/test/dune
+++ b/test/dune
@@ -356,6 +356,7 @@
         test_grpc_client
         test_http_protocol_detect
         test_keeper_safety_gates
+        test_keeper_guards
         test_eval_gate_evasion
         test_prompt_registry_defaults
         test_keeper_recurring
@@ -504,6 +505,7 @@
         test_grpc_client
         test_http_protocol_detect
         test_keeper_safety_gates
+        test_keeper_guards
         test_eval_gate_evasion
         test_prompt_registry_defaults
         test_keeper_recurring

--- a/test/test_keeper_guards.ml
+++ b/test/test_keeper_guards.ml
@@ -1,0 +1,350 @@
+(** Unit tests for [Keeper_guards] — decomposed pre_tool_use chain.
+
+    Verifies:
+    - Each guard's decision logic in isolation
+    - [compose_all] short-circuits on first non-[Continue]
+    - Stateful streak behavior across invocations
+    - Utility helpers moved from [Keeper_hooks_oas]
+      ([extract_command_from_input], [render_inline_skip_reason]) *)
+
+open Alcotest
+module KG = Masc_mcp.Keeper_guards
+
+(* ----------------------------------------------------------------- *)
+(* Helpers                                                             *)
+(* ----------------------------------------------------------------- *)
+
+(** Build a minimal keeper_meta ref for guards that only read [name]. *)
+let make_meta_ref (name : string) : Masc_mcp.Keeper_types.keeper_meta ref =
+  let json : Yojson.Safe.t = `Assoc [
+    ("name", `String name);
+    ("agent_name", `String name);
+    ("trace_id", `String "keeper-guards-test");
+    ("tool_access",
+      Masc_mcp.Keeper_types.tool_access_to_json
+        (Masc_mcp.Keeper_types.Preset
+           { preset = Masc_mcp.Keeper_types.Full; also_allow = [] }));
+  ] in
+  match Masc_mcp.Keeper_types.meta_of_json json with
+  | Ok meta -> ref meta
+  | Error e -> failwith ("make_meta_ref: " ^ e)
+
+let pre_tool_use_event
+    ~(tool_name : string)
+    ?(input = `Assoc [])
+    ?(accumulated_cost_usd = 0.0)
+    ?(turn = 1)
+    ()
+  : Agent_sdk.Hooks.hook_event =
+  Agent_sdk.Hooks.PreToolUse {
+    tool_use_id = "toolu_test_" ^ tool_name;
+    tool_name;
+    input;
+    accumulated_cost_usd;
+    turn;
+    schedule = {
+      planned_index = 0;
+      batch_index = 0;
+      batch_size = 1;
+      concurrency_class = "parallel_read";
+      batch_kind = "parallel";
+    };
+  }
+
+let invoke (hooks : Agent_sdk.Hooks.hooks) (event : Agent_sdk.Hooks.hook_event)
+  : Agent_sdk.Hooks.hook_decision =
+  Agent_sdk.Hooks.invoke hooks.pre_tool_use event
+
+let decision_kind (d : Agent_sdk.Hooks.hook_decision) : string =
+  match d with
+  | Continue -> "Continue"
+  | Skip -> "Skip"
+  | Override _ -> "Override"
+  | ApprovalRequired -> "ApprovalRequired"
+  | AdjustParams _ -> "AdjustParams"
+  | ElicitInput _ -> "ElicitInput"
+  | Nudge _ -> "Nudge"
+
+let override_text (d : Agent_sdk.Hooks.hook_decision) : string =
+  match d with
+  | Override s -> s
+  | _ -> failwith ("expected Override, got " ^ decision_kind d)
+
+(* ----------------------------------------------------------------- *)
+(* Utility tests                                                      *)
+(* ----------------------------------------------------------------- *)
+
+let test_extract_command_from_input () =
+  let j1 = `Assoc [("command", `String "ls -la")] in
+  check string "command key" "ls -la" (KG.extract_command_from_input j1);
+  let j2 = `Assoc [("cmd", `String "git status")] in
+  check string "cmd key" "git status" (KG.extract_command_from_input j2);
+  let j3 = `Assoc [("content", `String "hello")] in
+  check string "content key" "hello" (KG.extract_command_from_input j3);
+  let j4 = `Assoc [] in
+  check string "empty" "" (KG.extract_command_from_input j4)
+
+let contains_substring (haystack : string) (needle : string) : bool =
+  try
+    let _ = Str.search_forward (Str.regexp_string needle) haystack 0 in
+    true
+  with Not_found -> false
+
+let test_render_inline_skip_reason () =
+  let s = KG.render_inline_skip_reason
+    ~tool_name:"keeper_fs_read"
+    ~reason_code:"streak_gate"
+    ~reason_text:"called 5 times"
+  in
+  check bool "contains tool=keeper_fs_read" true
+    (contains_substring s "tool=keeper_fs_read");
+  check bool "contains code=streak_gate" true
+    (contains_substring s "code=streak_gate");
+  check bool "contains source=keeper_hook" true
+    (contains_substring s "source=keeper_hook")
+
+(* ----------------------------------------------------------------- *)
+(* Individual guard tests                                              *)
+(* ----------------------------------------------------------------- *)
+
+let test_deny_guard_blocks () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let hook =
+    KG.deny_guard ~meta_ref ~denied:["dangerous_tool"]
+  in
+  let d = invoke hook (pre_tool_use_event ~tool_name:"dangerous_tool" ()) in
+  check string "denied tool -> Override" "Override" (decision_kind d);
+  let text = override_text d in
+  check bool "override mentions deny list" true
+    (contains_substring text "code=keeper_deny")
+
+let test_deny_guard_continues () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let hook =
+    KG.deny_guard ~meta_ref ~denied:["other_tool"]
+  in
+  let d = invoke hook (pre_tool_use_event ~tool_name:"allowed_tool" ()) in
+  check string "allowed tool -> Continue" "Continue" (decision_kind d)
+
+let test_cost_guard_blocks () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let hook =
+    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10)
+  in
+  let d = invoke hook
+    (pre_tool_use_event ~tool_name:"expensive" ~accumulated_cost_usd:0.15 ())
+  in
+  check string "over limit -> Override" "Override" (decision_kind d)
+
+let test_cost_guard_under_limit () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let hook =
+    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10)
+  in
+  let d = invoke hook
+    (pre_tool_use_event ~tool_name:"cheap" ~accumulated_cost_usd:0.05 ())
+  in
+  check string "under limit -> Continue" "Continue" (decision_kind d)
+
+let test_cost_guard_disabled () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let hook = KG.cost_guard ~meta_ref ~max_cost_usd:None in
+  let d = invoke hook
+    (pre_tool_use_event ~tool_name:"any" ~accumulated_cost_usd:999.0 ())
+  in
+  check string "no budget -> Continue" "Continue" (decision_kind d)
+
+let test_streak_guard_under_threshold () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let state = KG.make_streak_state () in
+  let hook =
+    KG.streak_guard ~meta_ref ~state ~threshold:5
+  in
+  (* 4 consecutive calls — should all Continue *)
+  for _ = 1 to 4 do
+    let d = invoke hook (pre_tool_use_event ~tool_name:"repeat_me" ()) in
+    check string "under threshold -> Continue" "Continue" (decision_kind d)
+  done
+
+let test_streak_guard_at_threshold () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let state = KG.make_streak_state () in
+  let hook =
+    KG.streak_guard ~meta_ref ~state ~threshold:5
+  in
+  (* 4 calls Continue, 5th blocks *)
+  for _ = 1 to 4 do
+    let _ = invoke hook (pre_tool_use_event ~tool_name:"repeat_me" ()) in
+    ()
+  done;
+  let d = invoke hook (pre_tool_use_event ~tool_name:"repeat_me" ()) in
+  check string "5th consecutive -> Override" "Override" (decision_kind d);
+  let text = override_text d in
+  check bool "override mentions streak_gate" true
+    (contains_substring text "code=streak_gate")
+
+let test_streak_guard_resets_on_different_tool () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let state = KG.make_streak_state () in
+  let hook =
+    KG.streak_guard ~meta_ref ~state ~threshold:3
+  in
+  (* 2 calls of tool_a, then tool_b resets counter *)
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"tool_a" ()) in
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"tool_a" ()) in
+  let d_b = invoke hook (pre_tool_use_event ~tool_name:"tool_b" ()) in
+  check string "different tool -> Continue" "Continue" (decision_kind d_b);
+  (* tool_a counter was reset, so another 2 calls won't trigger *)
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"tool_a" ()) in
+  let d_back = invoke hook (pre_tool_use_event ~tool_name:"tool_a" ()) in
+  check string "reset streak -> Continue" "Continue" (decision_kind d_back)
+
+let test_streak_state_manual_reset () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let state = KG.make_streak_state () in
+  let hook =
+    KG.streak_guard ~meta_ref ~state ~threshold:3
+  in
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"t" ()) in
+  let _ = invoke hook (pre_tool_use_event ~tool_name:"t" ()) in
+  (* Emulate after_turn reset: streak_state.entry <- ("", 0) *)
+  state.entry <- ("", 0);
+  let d = invoke hook (pre_tool_use_event ~tool_name:"t" ()) in
+  check string "after reset -> Continue" "Continue" (decision_kind d)
+
+let test_custom_guard_blocks () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let guard ~tool_name ~input:_ =
+    if tool_name = "bad" then Some "user blocked" else None
+  in
+  let hook = KG.custom_guard ~meta_ref ~guard in
+  let d = invoke hook (pre_tool_use_event ~tool_name:"bad" ()) in
+  check string "custom blocked -> Override" "Override" (decision_kind d)
+
+let test_custom_guard_passthrough () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let guard ~tool_name:_ ~input:_ = None in
+  let hook = KG.custom_guard ~meta_ref ~guard in
+  let d = invoke hook (pre_tool_use_event ~tool_name:"ok" ()) in
+  check string "custom None -> Continue" "Continue" (decision_kind d)
+
+let test_timing_guard_sets_time_and_continues () =
+  let tool_start_time = ref 0.0 in
+  let hook = KG.timing_guard ~tool_start_time in
+  let t_before = !tool_start_time in
+  let d = invoke hook (pre_tool_use_event ~tool_name:"any" ()) in
+  check string "timing_guard -> Continue" "Continue" (decision_kind d);
+  check bool "tool_start_time updated" true (!tool_start_time > t_before)
+
+(* ----------------------------------------------------------------- *)
+(* Composition tests                                                   *)
+(* ----------------------------------------------------------------- *)
+
+let test_compose_all_empty () =
+  let hooks = KG.compose_all [] in
+  let d = invoke hooks (pre_tool_use_event ~tool_name:"any" ()) in
+  check string "empty compose -> Continue" "Continue" (decision_kind d)
+
+let test_compose_all_continue_all () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let hooks = KG.compose_all [
+    KG.deny_guard ~meta_ref ~denied:[];
+    KG.cost_guard ~meta_ref ~max_cost_usd:None;
+  ] in
+  let d = invoke hooks (pre_tool_use_event ~tool_name:"anything" ()) in
+  check string "all Continue -> Continue" "Continue" (decision_kind d)
+
+let test_compose_all_short_circuits_at_first_override () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  (* deny_guard blocks first -> cost_guard should not fire *)
+  let hooks = KG.compose_all [
+    KG.deny_guard ~meta_ref ~denied:["blocked_tool"];
+    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10);
+  ] in
+  let d = invoke hooks
+    (pre_tool_use_event ~tool_name:"blocked_tool"
+       ~accumulated_cost_usd:999.0 ())
+  in
+  check string "first Override wins" "Override" (decision_kind d);
+  let text = override_text d in
+  (* The reason should be from deny_guard, not cost_gate *)
+  check bool "short-circuit preserves first reason" true
+    (contains_substring text "code=keeper_deny")
+
+let test_compose_all_preserves_order () =
+  let meta_ref = make_meta_ref "test_keeper" in
+  let streak_state = KG.make_streak_state () in
+  (* streak_guard fires first; after 3 calls it blocks before reaching cost_guard *)
+  let hooks = KG.compose_all [
+    KG.streak_guard ~meta_ref ~state:streak_state ~threshold:3;
+    KG.cost_guard ~meta_ref ~max_cost_usd:(Some 0.10);
+  ] in
+  let _ = invoke hooks (pre_tool_use_event ~tool_name:"x"
+                          ~accumulated_cost_usd:0.05 ()) in
+  let _ = invoke hooks (pre_tool_use_event ~tool_name:"x"
+                          ~accumulated_cost_usd:0.05 ()) in
+  let d = invoke hooks
+    (pre_tool_use_event ~tool_name:"x" ~accumulated_cost_usd:0.05 ())
+  in
+  (* streak triggered, cost would not have *)
+  check string "streak blocks before cost" "Override" (decision_kind d);
+  let text = override_text d in
+  check bool "reason is streak, not cost" true
+    (contains_substring text "code=streak_gate")
+
+(* ----------------------------------------------------------------- *)
+(* hooks_of_pre_tool_use                                              *)
+(* ----------------------------------------------------------------- *)
+
+let test_hooks_of_pre_tool_use_slots () =
+  let hooks =
+    KG.hooks_of_pre_tool_use (fun _ -> Agent_sdk.Hooks.Continue)
+  in
+  check bool "pre_tool_use is Some" true (Option.is_some hooks.pre_tool_use);
+  check bool "after_turn is None" true (Option.is_none hooks.after_turn);
+  check bool "on_idle is None" true (Option.is_none hooks.on_idle);
+  check bool "post_tool_use is None" true (Option.is_none hooks.post_tool_use)
+
+(* ----------------------------------------------------------------- *)
+(* Suite                                                               *)
+(* ----------------------------------------------------------------- *)
+
+let () = run "Keeper_guards" [
+  "utilities", [
+    test_case "extract_command_from_input" `Quick test_extract_command_from_input;
+    test_case "render_inline_skip_reason" `Quick test_render_inline_skip_reason;
+  ];
+  "deny_guard", [
+    test_case "blocks denied tool" `Quick test_deny_guard_blocks;
+    test_case "continues for allowed tool" `Quick test_deny_guard_continues;
+  ];
+  "cost_guard", [
+    test_case "blocks over limit" `Quick test_cost_guard_blocks;
+    test_case "continues under limit" `Quick test_cost_guard_under_limit;
+    test_case "no budget -> continue" `Quick test_cost_guard_disabled;
+  ];
+  "streak_guard", [
+    test_case "under threshold -> continue" `Quick test_streak_guard_under_threshold;
+    test_case "at threshold -> override" `Quick test_streak_guard_at_threshold;
+    test_case "resets on different tool" `Quick test_streak_guard_resets_on_different_tool;
+    test_case "manual state reset" `Quick test_streak_state_manual_reset;
+  ];
+  "custom_guard", [
+    test_case "user blocks" `Quick test_custom_guard_blocks;
+    test_case "user passes through" `Quick test_custom_guard_passthrough;
+  ];
+  "timing_guard", [
+    test_case "sets time and continues" `Quick test_timing_guard_sets_time_and_continues;
+  ];
+  "compose_all", [
+    test_case "empty compose" `Quick test_compose_all_empty;
+    test_case "all Continue" `Quick test_compose_all_continue_all;
+    test_case "short-circuits at first Override" `Quick
+      test_compose_all_short_circuits_at_first_override;
+    test_case "preserves declared order" `Quick test_compose_all_preserves_order;
+  ];
+  "slot_helpers", [
+    test_case "hooks_of_pre_tool_use only fills pre_tool_use" `Quick
+      test_hooks_of_pre_tool_use_slots;
+  ];
+]

--- a/test/test_keeper_safety_gates.ml
+++ b/test/test_keeper_safety_gates.ml
@@ -3,7 +3,7 @@
     Covers three safety layers:
     1. Eval_gate.detect_destructive — all 19 patterns + safe commands
     2. Keeper_exec_tools.keeper_allowed_tool_names — policy mode tool grants
-    3. Keeper_hooks_oas.extract_command_from_input — JSON command extraction
+    3. Keeper_guards.extract_command_from_input — JSON command extraction
 
     Closes the P1 test gap from the keeper safety audit. *)
 
@@ -242,17 +242,17 @@ let test_all_modes_produce_same_tools () =
 
 let test_extract_command_key () =
   let input = `Assoc [("command", `String "rm -rf /tmp")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "command key" "rm -rf /tmp" cmd
 
 let test_extract_cmd_key () =
   let input = `Assoc [("cmd", `String "gh pr list")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "cmd key" "gh pr list" cmd
 
 let test_extract_content_key () =
   let input = `Assoc [("content", `String "DROP TABLE foo")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "content key" "DROP TABLE foo" cmd
 
 let test_extract_priority_order () =
@@ -262,7 +262,7 @@ let test_extract_priority_order () =
     ("cmd", `String "second");
     ("content", `String "third");
   ] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "command wins" "first" cmd
 
 let test_extract_cmd_over_content () =
@@ -271,27 +271,27 @@ let test_extract_cmd_over_content () =
     ("cmd", `String "second");
     ("content", `String "third");
   ] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "cmd wins over content" "second" cmd
 
 let test_extract_no_keys () =
   let input = `Assoc [("path", `String "/tmp/file")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "no matching key" "" cmd
 
 let test_extract_null_values () =
   let input = `Assoc [("command", `Null); ("cmd", `Null); ("content", `Null)] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "all null" "" cmd
 
 let test_extract_empty_object () =
   let input = `Assoc [] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   check string "empty object" "" cmd
 
 let test_extract_non_string_command () =
   let input = `Assoc [("command", `Int 42)] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   (* Non-string "command" falls through to "cmd"/"content" *)
   check string "non-string command" "" cmd
 
@@ -312,21 +312,21 @@ let test_destructive_check_tools_membership () =
 
 let test_integration_dangerous_bash () =
   let input = `Assoc [("command", `String "rm -rf /")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   match Eval_gate.detect_destructive cmd with
   | Some (pat, _) -> check string "detected rm -rf" "rm -rf" pat
   | None -> fail "Should detect rm -rf through extract+detect pipeline"
 
 let test_integration_safe_bash () =
   let input = `Assoc [("command", `String "ls -la /tmp")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   match Eval_gate.detect_destructive cmd with
   | None -> ()
   | Some (pat, _) -> fail (Printf.sprintf "Should be safe, matched %S" pat)
 
 let test_integration_github_force_push () =
   let input = `Assoc [("cmd", `String "push --force origin main")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   (* The actual command seen by the gate would be "push --force origin main",
      but detect_destructive looks for "git push --force" which requires "git" prefix.
      The keeper_github tool prepends "gh" not "git", so this would NOT match
@@ -337,7 +337,7 @@ let test_integration_github_force_push () =
 
 let test_integration_edit_destructive_content () =
   let input = `Assoc [("content", `String "DROP TABLE production_users")] in
-  let cmd = Keeper_hooks_oas.extract_command_from_input input in
+  let cmd = Keeper_guards.extract_command_from_input input in
   match Eval_gate.detect_destructive cmd with
   | Some (pat, _) -> check string "detected drop table" "drop table" pat
   | None -> fail "Should detect DROP TABLE through content key"

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -13,6 +13,7 @@ module KD = Masc_mcp.Keeper_deliberation
 module AE = Masc_mcp.Agent_economy
 module KC = Masc_mcp.Keeper_config
 module HK = Masc_mcp.Keeper_hooks_oas
+module KG = Masc_mcp.Keeper_guards
 module OMR = Masc_mcp.Oas_model_resolve
 
 let has_prompt_root path =
@@ -2476,7 +2477,7 @@ let str_contains s sub =
   with Not_found -> false
 
 let test_render_inline_skip_reason_deny () =
-  let result = HK.render_inline_skip_reason
+  let result = KG.render_inline_skip_reason
     ~tool_name:"keeper_bash"
     ~reason_code:"keeper_deny"
     ~reason_text:"tool is on the keeper deny list"
@@ -2487,7 +2488,7 @@ let test_render_inline_skip_reason_deny () =
   check bool "reason encoded" true (str_contains result "reason=tool%20is%20on")
 
 let test_render_inline_skip_reason_cost () =
-  let result = HK.render_inline_skip_reason
+  let result = KG.render_inline_skip_reason
     ~tool_name:"keeper_bash"
     ~reason_code:"cost_gate"
     ~reason_text:"accumulated_cost_usd=0.5100 exceeded limit=0.5000"
@@ -2497,7 +2498,7 @@ let test_render_inline_skip_reason_cost () =
   check bool "reason encoded equals" true (str_contains result "0.5100%20exceeded")
 
 let test_render_inline_skip_reason_destructive () =
-  let result = HK.render_inline_skip_reason
+  let result = KG.render_inline_skip_reason
     ~tool_name:"keeper_bash"
     ~reason_code:"destructive_guard"
     ~reason_text:"pattern='rm -rf' (recursive forced deletion)"
@@ -2508,17 +2509,17 @@ let test_render_inline_skip_reason_destructive () =
 
 let test_render_inline_escape_edge_cases () =
   (* Empty reason text *)
-  let empty = HK.render_inline_skip_reason
+  let empty = KG.render_inline_skip_reason
     ~tool_name:"t" ~reason_code:"c" ~reason_text:"" in
   check bool "empty reason" true (str_contains empty "reason=");
   (* Percent sign in reason *)
-  let pct = HK.render_inline_skip_reason
+  let pct = KG.render_inline_skip_reason
     ~tool_name:"t" ~reason_code:"c" ~reason_text:"CPU at 90%" in
   check bool "percent encoded" true (str_contains pct "90%25")
 
 let test_render_inline_with_replacement () =
   (* keeper_board_post has replacement=masc_board_post in Tool_catalog *)
-  let result = HK.render_inline_skip_reason
+  let result = KG.render_inline_skip_reason
     ~tool_name:"keeper_board_post"
     ~reason_code:"keeper_deny"
     ~reason_text:"denied"


### PR DESCRIPTION
## Summary

Extract the monolithic `pre_tool_use` callback in `keeper_hooks_oas.ml` into seven standalone guards composed via `Agent_sdk.Hooks.compose`:

```
timing -> custom -> streak -> deny -> cost -> destructive -> governance_approval
```

Each guard lives in the new `lib/keeper/keeper_guards.ml` module and fills only the `pre_tool_use` slot; `Hooks.compose` handles short-circuit on the first non-`Continue` decision. The outer composed chain is then merged with the non-gate hooks (`after_turn`, `post_tool_use`, `on_idle`, `on_error`, `on_tool_error`, `post_tool_use_failure`) via a single `Hooks.compose` call.

## Motivation

This is **Phase 1 T1-A** from the MASC ⟷ OAS integration gap analysis (`planning/claude-plans/glowing-splashing-hanrahan.md`). The existing monolithic `pre_tool_use` chain was a 116-line `if/else` tree embedded in `keeper_hooks_oas.ml`, which:

- hid the composable structure that OAS `Hooks.compose` already provides
- conflated timing/logging/decision logic across six semantic gates
- made new gate additions risky without clear reason-code partitioning

By contrast, `operator_approval.ml` was already using OAS `Approval.create` + stages for operator action gating. This refactor brings the keeper-side tool gating into the same compositional idiom, but via `Hooks.compose` (the correct primitive for `PreToolUse` events) rather than `Approval.pipeline` (which remains in place for non-tool operator actions).

## Design constraints

- **C0 (Public SDK)**: zero changes to OAS. `Hooks.compose` is consumed as-is, no MASC-specific extensions proposed upstream. Verified via `git diff HEAD` in `workspace/yousleepwhen/oas`: empty for tracked files.
- **C1 (OAS is MASC-agnostic)**: keeper-specific concepts (streak state, deny list, cost limit, `meta_ref`) stay in MASC closures. OAS primitives remain general-purpose.
- **C2 (observability)**: each override / approval emits **both**
  1. the legacy `broadcast_tool_skipped` SSE event (backward compatibility)
  2. a new `masc:keeper_gate` `Event_bus.Custom` event carrying `stage`, `decision`, `reason_code`, `stage_latency_ms`, `reason_text`.
  Dual emit lets dashboard consumers migrate without coordinating with this refactor.

## Moved utilities

`broadcast_tool_skipped`, `render_inline_skip_reason`, `extract_command_from_input`, and `escape_field` move from `keeper_hooks_oas` to `keeper_guards` since they are now only consumed by the decomposed guards. This avoids circular dependency and concentrates the gate-level concerns in one module. Existing test call sites in `test_keeper_safety_gates` and `test_keeper_unified` are retargeted to the new module.

## Test plan

- [x] `dune build --root .` green
- [x] `test_keeper_guards` — 19 new unit tests (each guard in isolation, compose_all short-circuit / order preservation, stateful streak behavior)
- [x] `test_keeper_safety_gates` — 52 tests pass against relocated `extract_command_from_input`
- [x] `test_keeper_unified` — 141 tests pass against relocated `render_inline_skip_reason`
- [x] Confirmed OAS repo diff is empty (C1 verification)
- [x] Rebase onto latest `origin/main` clean, all tests still pass

## Telemetry schema

New `masc:keeper_gate` Event_bus.Custom event payload:

```json
{
  "stage": "streak_gate | keeper_deny | cost_gate | destructive_guard | pre_tool_use_guard | governance_approval",
  "decision": "override | continue | approval_required",
  "reason_code": "<stage identifier>",
  "tool_name": "<tool>",
  "agent_name": "<keeper>",
  "turn": <int>,
  "accumulated_cost_usd": <float>,
  "stage_latency_ms": <float>,
  "reason_text": "<human-readable>",
  "source": "hook"
}
```

Dashboard consumers can subscribe to this event to chart per-stage firing rates, reason-code distribution, and latency drift. The `source: "hook"` field distinguishes new-path events from any future legacy-path shims.

## Rollback

If a regression surfaces:
- Legacy `broadcast_tool_skipped` path still fires, so existing dashboard widgets and alert rules keep working.
- The new `masc:keeper_gate` events can be ignored without operational impact.
- Full revert is a single commit revert; worktree leaves `main` untouched.

## Part of

Tier 1 / T1-A in `planning/claude-plans/glowing-splashing-hanrahan.md`. Next planned steps (separate PRs): T1-B (MASC stub/truncate → `Context_reducer.Stub_tool_results`), T2 telemetry-driven checkpoint / event-bus filter experiments, T4 upstream OAS gaps (`Tool_selector.select_with_index`, `Builder.with_policy_channel`).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>