### PR TITLE
fix(dashboard): add 30s polling + idle duration to FSM Hub

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -51,6 +51,14 @@ export function FsmHub() {
   const shouldRefetchForTick =
     selected != null && tick.name === selected ? tick.ts_unix : 0
 
+  // Periodic polling (30s) keeps the hub current even when keepers are idle
+  // and no SSE events fire. Without this the page freezes once activity stops.
+  const [pollTick, setPollTick] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setPollTick(t => t + 1), 30_000)
+    return () => clearInterval(id)
+  }, [])
+
   useEffect(() => {
     if (!selected) return
     let cancelled = false
@@ -77,7 +85,7 @@ export function FsmHub() {
     return () => {
       cancelled = true
     }
-  }, [selected, shouldRefetchForTick])
+  }, [selected, shouldRefetchForTick, pollTick])
 
   return html`
     <div class="flex flex-col gap-5">
@@ -337,18 +345,34 @@ function RecoveryStatePanel({
   `
 }
 
+function formatIdleDuration(seconds: number): string {
+  if (seconds < 60) return `${Math.floor(seconds)}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+}
+
 function SnapshotMeta({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   const date = new Date(snapshot.ts * 1000)
+  const nowSec = Date.now() / 1000
+  const idleSec = snapshot.last_outcome
+    ? nowSec - snapshot.last_outcome.ended_at
+    : nowSec - snapshot.ts
+  const isStale = idleSec > 300
   const liveClass = snapshot.is_live
     ? 'text-emerald-400 border-emerald-500/40'
-    : 'text-[var(--text-dim)] border-white/10'
+    : isStale
+      ? 'text-[#f59e0b] border-[rgba(245,158,11,0.3)]'
+      : 'text-[var(--text-dim)] border-white/10'
+  const liveLabel = snapshot.is_live
+    ? '● LIVE'
+    : `○ idle ${formatIdleDuration(idleSec)}`
   const lastOutcomeText = snapshot.last_outcome
     ? `last turn #${snapshot.last_outcome.turn_id} ended ${new Date(snapshot.last_outcome.ended_at * 1000).toLocaleTimeString()}`
     : 'no completed turn'
   return html`
     <div class="flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)] font-mono items-center">
       <span class=${`px-1.5 py-0.5 border rounded ${liveClass}`}>
-        ${snapshot.is_live ? '● LIVE' : '○ idle'}
+        ${liveLabel}
       </span>
       <span>correlation ${snapshot.correlation_id}</span>
       <span>run ${snapshot.run_id}</span>


### PR DESCRIPTION
## Summary

- FSM Hub가 SSE 이벤트 없으면 화면 갱신 안 되던 문제 수정
- 30초 setInterval polling 추가 (SSE fallback)
- idle 시간 표시 + 5분 이상 시 amber 경고색

## Problem

FSM Hub는 `keeper_composite_changed` SSE 이벤트로만 데이터를 갱신.
키퍼가 idle일 때 state transition이 없으니 SSE 안 오고 화면이 정지.

## Test plan

- [ ] FSM Hub에서 키퍼 선택 후 30초 대기 → 자동 갱신 확인
- [ ] idle 5분 이상 시 amber 색상 확인
- [ ] SSE 이벤트 발생 시 즉시 갱신 (기존 동작 유지)