### PR TITLE
fix(keeper): stop re-serializing removed models field to break scrub loop

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -652,7 +652,12 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     
     ; "social_model", `String m.social_model
     ; "cascade_name", `String m.cascade_name
-    ; "models", `List (List.map (fun s -> `String s) m.models)
+    (* "models" intentionally omitted from serialization.  The field
+       is in removed_keeper_meta_key_names (via removed_keeper_input_key_names)
+       and scrub_persisted_keeper_meta_json strips it on every load.
+       Re-emitting it here creates a scrub → write → re-scrub loop that
+       fires ~20 INFO log lines per keeper per session.  Models are
+       resolved at runtime from cascade config, not from persisted meta. *)
     ; "will", `String m.will
     ; "needs", `String m.needs
     ; "desires", `String m.desires


### PR DESCRIPTION
## Summary

keeper당 ~20회/세션 반복되는 `[Keeper] scrubbed legacy keeper meta fields for .../X.json: models` 로그의 root cause 수정.

## Root cause

**Scrub-write 무한 루프**:

```
read_meta(X.json)
  → scrub_persisted_keeper_meta_json 발견: "models" 존재
  → 삭제 + save → log "scrubbed ... models"
  → load된 keeper 활동
write_meta(X.json)
  → keeper_meta_to_json → "models" 재직렬화
  → 다음 read_meta에서 다시 발견...
```

`removed_keeper_input_key_names`에 `"models"` 포함 → scrub이 삭제하지만, `keeper_meta_to_json:655`가 `m.models`를 다시 쓰기.

## Fix

`keeper_meta_to_json`에서 `"models"` 직렬화 제거. read path(line 850)는 missing key 시 `[]` fallback 있으므로 안전. models는 런타임에 cascade config에서 resolve됨 — 영속 meta에 저장할 이유 없음.

기존 프로젝트 정책과 일치:
- `feedback_masc-no-model-in-persona-or-metadata.md`
- `feedback_masc-model-agnostic.md`

## Discovery

Iter 8 grey-zone scan — production log frequency analysis. `[Keeper] INFO` 716회 중 상위 반복 패턴의 "scrubbed ... models"가 root cause tracing으로 serialize → scrub 순환 확인.

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 "scrubbed legacy keeper meta fields" 로그가 keeper당 최대 1회(첫 scrub)로 감소

🤖 Generated with [Claude Code](https://claude.com/claude-code)
