### PR TITLE
fix(test): register orphan test_otel_trace_context in dune runner

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -960,6 +960,12 @@
  (modules test_transport_bridge_seal)
  (libraries masc_test_deps))
 
+; OpenTelemetry trace context (W3C traceparent)
+(test
+ (name test_otel_trace_context)
+ (modules test_otel_trace_context)
+ (libraries masc_test_deps))
+
 (executable
  (name keeper_tool_matrix_case_runner)
  (modules keeper_tool_matrix_case_runner test_keeper_tool_matrix_cases


### PR DESCRIPTION
## Summary

`test/test_otel_trace_context.ml` (262줄, W3C traceparent parsing/generation 검증)이 `test/dune`에 미등록 → CI에서 실행 안 됨.

## Discovery

```bash
# 387 test files vs 62 dune executables
for f in test/test_*.ml; do
  base=$(basename "$f" .ml)
  rg -q "$base" test/dune || echo "$base"
done
# → test_otel_trace_context (유일한 orphan)
```

## Impact

`Otel_trace_context` 모듈의 regression이 production까지 도달할 수 있음. 테스트 파일이 존재하므로 코드 작성자는 보호받고 있다고 생각하지만 실제로는 CI gate 밖.

## Fix

`test/dune`에 test stanza 추가. 기존 패턴(masc_test_deps library) 그대로.

## Test plan

- [ ] CI Build and Test pass (이 test가 실제로 실행되는지 확인)
- [ ] alcotest 로그에서 `test_otel_trace_context` 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
