### PR TITLE
fix(metrics): forward cascade on_request_end to Prometheus histogram

### DIFF
--- a/lib/llm_metric_bridge.ml
+++ b/lib/llm_metric_bridge.ml
@@ -57,6 +57,17 @@ let emit_http_status ~provider ~model_id ~status =
     observability so a broken hook does not blank out the dashboard. *)
 let request_latency_metric = "masc_llm_provider_request_latency_seconds"
 
+(** Emit a single latency observation to the Prometheus histogram.
+
+    Exposed so that per-call metrics sinks (e.g. the cascade-observation
+    capture in [Oas_worker_cascade]) can forward [on_request_end] to the
+    same histogram without duplicating the label shape.  This is the
+    single source of truth for the label key names. *)
+let emit_request_latency ~model_id ~latency_ms =
+  let seconds = Float.of_int latency_ms /. 1000.0 in
+  Prometheus.observe_histogram request_latency_metric
+    ~labels:[("model", model_id)] seconds
+
 (** Build the OAS Metrics.t sink.
 
     Currently wired through:
@@ -76,9 +87,7 @@ let make_sink () : Llm_provider.Metrics.t =
         emit_http_status ~provider ~model_id ~status);
     on_request_end =
       (fun ~model_id ~latency_ms ->
-        let seconds = Float.of_int latency_ms /. 1000.0 in
-        Prometheus.observe_histogram request_latency_metric
-          ~labels:[("model", model_id)] seconds);
+        emit_request_latency ~model_id ~latency_ms);
   }
 
 (** Install the sink as the process-wide default.  Idempotent — calling

--- a/lib/llm_metric_bridge.mli
+++ b/lib/llm_metric_bridge.mli
@@ -21,6 +21,13 @@ val http_status_metric : string
 val emit_http_status :
   provider:string -> model_id:string -> status:int -> unit
 
+(** Emit a single latency observation to the Prometheus histogram.
+    Called by both the global sink built in {!make_sink} and any
+    per-call OAS [Metrics.t] literal that wants to forward
+    [on_request_end] (e.g. cascade observation captures).  Single
+    source of truth for the label shape. *)
+val emit_request_latency : model_id:string -> latency_ms:int -> unit
+
 (** Construct the OAS Metrics.t sink without installing it.  Useful
     for tests that want to pass [~metrics] explicitly without
     touching global state. *)

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -366,7 +366,16 @@ let cascade_metrics_for_candidates
       on_request_end =
         (fun ~model_id ~latency_ms ->
           ensure_terminal_attempt capture ~candidate_cfgs ~model_id
-            ~latency_ms:(Some latency_ms) ~error:None);
+            ~latency_ms:(Some latency_ms) ~error:None;
+          (* Forward to Prometheus so per-model latency is visible on
+             the dashboard.  Without this, the cascade capture records
+             latency internally but never exports it — the global
+             Llm_metric_bridge sink is not consulted because this
+             per-call metrics object takes precedence. *)
+          Prometheus.observe_histogram
+            Llm_metric_bridge.request_latency_metric
+            ~labels:[("model", model_id)]
+            (Float.of_int latency_ms /. 1000.0));
       on_error =
         (fun ~model_id ~error ->
           ensure_terminal_attempt capture ~candidate_cfgs ~model_id

--- a/lib/oas_worker_cascade.ml
+++ b/lib/oas_worker_cascade.ml
@@ -372,10 +372,7 @@ let cascade_metrics_for_candidates
              latency internally but never exports it — the global
              Llm_metric_bridge sink is not consulted because this
              per-call metrics object takes precedence. *)
-          Prometheus.observe_histogram
-            Llm_metric_bridge.request_latency_metric
-            ~labels:[("model", model_id)]
-            (Float.of_int latency_ms /. 1000.0));
+          Llm_metric_bridge.emit_request_latency ~model_id ~latency_ms);
       on_error =
         (fun ~model_id ~error ->
           ensure_terminal_attempt capture ~candidate_cfgs ~model_id


### PR DESCRIPTION
## Summary

`masc_llm_provider_request_latency_seconds`가 항상 0인 근본 원인 수정.

## Root cause

`cascade_metrics_for_candidates`가 자체 `Metrics.t`를 생성하면서 `on_request_end`를 내부 capture에만 기록. Global `Llm_metric_bridge` sink(PR #7135에서 설치)은 per-call metrics 객체에 의해 override됨 → Prometheus histogram에 절대 도달 안 함.

```
cascade_metrics_for_candidates
  → on_request_end = ensure_terminal_attempt (내부 capture)
  → Prometheus.observe_histogram 호출 없음 ❌
```

live 확인:
```
masc_after_turn_hook_total{model="glm-5.1"} 189   ← 턴은 동작
masc_llm_provider_request_latency_seconds_count 0  ← latency 안 감
```

## Fix

`on_request_end` callback에 `Prometheus.observe_histogram` 1줄 추가. 내부 capture과 Prometheus 양쪽에 기록.

## Companion PR

OAS `jeong-sik/oas` — `fix/transport-http-status`: transport path에서 `on_http_status` 호출 추가. 이 PR과 함께 배포하면 provider/model별 volume + latency 대시보드 가능.

## Test plan

- [ ] CI Build/Lint pass
- [ ] 배포 후 `/metrics`에서 `masc_llm_provider_request_latency_seconds_count > 0` 확인
- [ ] model label 분포 (glm-5.1, qwen3.5 등) 대시보드에서 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)
