### PR TITLE
feat: add keeper accountability reputation ledger

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -223,6 +223,75 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
          |> Option.map Inference_utils.sanitize_text_utf8);
     }
 
+let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+      | _ -> None)
+    msg.content
+
+let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
+  List.exists
+    (function
+      | Agent_sdk.Types.ToolResult _ -> true
+      | _ -> false)
+    msg.content
+
+let tool_result_text_of_block
+    ~(tool_use_id : string)
+    ~(content : string)
+    ~(json : Yojson.Safe.t option) : string =
+  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
+  if content <> "" then content
+  else
+    match json with
+    | Some value -> Yojson.Safe.to_string value
+    | None -> Printf.sprintf "[tool result %s]" tool_use_id
+
+let repair_orphan_tool_result_messages
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let rec loop prev acc = function
+    | [] -> List.rev acc
+    | msg :: rest ->
+        let repaired =
+          if not (has_tool_result_block msg) then msg
+          else
+            let prev_tool_use_ids =
+              match prev with
+              | Some previous -> tool_use_ids_of_message previous
+              | None -> []
+            in
+            (* Anthropic validates ToolResult blocks against ToolUse blocks
+               in the immediately previous message. If checkpoint capping
+               drops that predecessor, the resumed history becomes invalid.
+               Downgrade only the orphaned structured result blocks to
+               plain text so the semantic output survives without replaying
+               provider-specific tool metadata. *)
+            let has_orphan =
+              List.exists
+                (function
+                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                      not (List.mem tool_use_id prev_tool_use_ids)
+                  | _ -> false)
+                msg.content
+            in
+            if not has_orphan then msg
+            else
+              let content =
+                List.map
+                  (function
+                    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
+                        Agent_sdk.Types.Text
+                          (tool_result_text_of_block ~tool_use_id ~content ~json)
+                    | other -> other)
+                  msg.content
+              in
+              { msg with content }
+        in
+        loop (Some repaired) (repaired :: acc) rest
+  in
+  loop None [] messages
+
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
     ("system_prompt", `String (Inference_utils.sanitize_text_utf8 ctx.system_prompt));
@@ -236,7 +305,10 @@ let deserialize_context (s : string) ~max_tokens : working_context =
   let json = Yojson.Safe.from_string s in
   let open Yojson.Safe.Util in
   let system_prompt = json |> member "system_prompt" |> to_string in
-  let messages = json |> member "messages" |> to_list |> List.map message_of_json in
+  let messages =
+    json |> member "messages" |> to_list |> List.map message_of_json
+    |> repair_orphan_tool_result_messages
+  in
   let _legacy_token_count = json |> member "token_count" |> to_int_option in
   sync_oas_context
     {
@@ -813,9 +885,14 @@ let sanitize_checkpoint_messages
     ([], empty_checkpoint_sanitize_stats)
 
 let sanitize_oas_checkpoint
+    ?(repair_orphans = true)
     (cp : Agent_sdk.Checkpoint.t)
   : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
   let messages, stats = sanitize_checkpoint_messages cp.messages in
+  let messages =
+    if repair_orphans then repair_orphan_tool_result_messages messages
+    else messages
+  in
   ({ cp with messages }, stats)
 
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
@@ -830,20 +907,25 @@ let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
       | _ -> fallback)
 
 let context_of_oas_checkpoint
+    ?(repair_orphans = true)
     ~(max_checkpoint_messages : int)
     (cp : Agent_sdk.Checkpoint.t)
     ~(primary_model_max_tokens : int) : working_context =
-  let cp, _ = sanitize_oas_checkpoint cp in
+  let cp, _ = sanitize_oas_checkpoint ~repair_orphans cp in
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
     checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
   in
   let messages =
     let n = List.length cp.messages in
-    if n <= max_checkpoint_messages then cp.messages
-    else
-      let drop = n - max_checkpoint_messages in
-      List.filteri (fun i _ -> i >= drop) cp.messages
+    let messages =
+      if n <= max_checkpoint_messages then cp.messages
+      else
+        let drop = n - max_checkpoint_messages in
+        List.filteri (fun i _ -> i >= drop) cp.messages
+    in
+    if repair_orphans then repair_orphan_tool_result_messages messages
+    else messages
   in
   sync_oas_context
     {
@@ -887,6 +969,9 @@ let save_oas_checkpoint
       let drop = n - max_checkpoint_messages in
       List.filteri (fun i _ -> i >= drop) ctx.messages
   in
+  let capped_messages_were_truncated =
+    List.length capped_messages < List.length ctx.messages
+  in
   (* Stub old tool results at save time: keep only the most recent turn's
      results in full. During Agent.run the reducer uses keep_recent:3, but
      at checkpoint persistence we are more aggressive — older tool results
@@ -897,6 +982,11 @@ let save_oas_checkpoint
       capped_messages
   in
   let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
+  let capped_messages =
+    if capped_messages_were_truncated
+    then repair_orphan_tool_result_messages capped_messages
+    else capped_messages
+  in
   let state =
     {
       Agent_sdk.Types.config =

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -59,6 +59,7 @@ val checkpoint_max_tokens :
   Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 val context_of_oas_checkpoint :
+  ?repair_orphans:bool ->
   max_checkpoint_messages:int ->
   Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -125,7 +125,13 @@ let apply_post_turn_lifecycle
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx =
+        context_of_oas_checkpoint
+          ~repair_orphans:false
+          ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+          cp
+          ~primary_model_max_tokens
+      in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -286,7 +292,9 @@ let recover_latest_checkpoint_for_overflow_retry
   let oas_checkpoint =
     Result.to_option oas_result
     |> Option.map (fun checkpoint ->
-      let sanitized, stats = sanitize_oas_checkpoint checkpoint in
+      let sanitized, stats =
+        sanitize_oas_checkpoint ~repair_orphans:false checkpoint
+      in
       if checkpoint_sanitize_changed stats then begin
         Log.Keeper.warn
           "keeper:%s overflow-retry migration sanitized messages: dropped_blocks=%d dropped_messages=%d dropped_chars=%d truncated_blocks=%d truncated_chars=%d"
@@ -327,7 +335,11 @@ let recover_latest_checkpoint_for_overflow_retry
           checkpoint_generation checkpoint ~fallback:meta.runtime.generation
         in
         Some
-          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint ~primary_model_max_tokens,
+          ( context_of_oas_checkpoint
+              ~repair_orphans:false
+              ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+              checkpoint
+              ~primary_model_max_tokens,
             turn_generation )
     | _, _, Some checkpoint ->
         (try
@@ -348,7 +360,10 @@ let recover_latest_checkpoint_for_overflow_retry
                       ~fallback:meta.runtime.generation
                   in
                   Some
-                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint
+                    ( context_of_oas_checkpoint
+                        ~repair_orphans:false
+                        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+                        checkpoint
                         ~primary_model_max_tokens,
                       turn_generation )
               | None -> None))

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -95,7 +95,13 @@ let maybe_rollover_oas_handoff
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx =
+        context_of_oas_checkpoint
+          ~repair_orphans:false
+          ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+          cp
+          ~primary_model_max_tokens
+      in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -588,6 +588,115 @@ let test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_
           fail
             "expected overflow retry recovery to keep message history within budget even with a large checkpoint system prompt")
 
+let test_legacy_checkpoint_roundtrip_preserves_tool_pairing () =
+  let base_dir = temp_dir "keeper_lifecycle_legacy_tool_pairing" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let meta = make_keeper_meta ~trace_id:"trace-legacy-tool-pairing" () in
+      let session =
+        KEC.create_session
+          ~session_id:(Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~base_dir
+      in
+      let tool_use_id = "call-legacy-1" in
+      let legacy_ctx =
+        KEC.create ~system_prompt:"legacy structured" ~max_tokens:2048
+        |> fun ctx ->
+        KEC.append_many ctx
+          [
+            Agent_sdk.Types.user_msg "run the search";
+            tool_use_message ~name:"grep_search" ~tool_use_id ();
+            tool_result_message ~tool_use_id "3 hits";
+          ]
+      in
+      ignore (KEC.save_checkpoint session legacy_ctx ~generation:4);
+      let loaded_opt =
+        load_context ~base_dir
+          ~trace_id:(Masc_mcp.Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~max_tokens:1024
+      in
+      match loaded_opt with
+      | Some loaded ->
+          let has_tool_use =
+            List.exists
+              (fun (msg : Agent_sdk.Types.message) ->
+                List.exists
+                  (function
+                    | Agent_sdk.Types.ToolUse { id; name; _ } ->
+                        String.equal id tool_use_id
+                        && String.equal name "grep_search"
+                    | _ -> false)
+                  msg.content)
+              loaded.messages
+          in
+          let has_tool_result =
+            List.exists
+              (fun (msg : Agent_sdk.Types.message) ->
+                List.exists
+                  (function
+                    | Agent_sdk.Types.ToolResult { tool_use_id = id; content; _ } ->
+                        String.equal id tool_use_id
+                        && String.equal content "3 hits"
+                    | _ -> false)
+                  msg.content)
+              loaded.messages
+          in
+          check bool "tool use restored" true has_tool_use;
+          check bool "tool result restored" true has_tool_result
+      | None -> Alcotest.fail "expected legacy checkpoint context")
+
+let test_context_of_oas_checkpoint_drops_orphan_tool_result () =
+  let checkpoint =
+    {
+      Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
+      session_id = "trace-oas-orphan-tool-result";
+      agent_name = "keeper-lifecycle";
+      model = "llama:auto";
+      system_prompt = Some "oas malformed";
+      messages =
+        [
+          Agent_sdk.Types.assistant_msg "flattened legacy tool call text";
+          tool_result_message ~tool_use_id:"orphan-call" "orphan output";
+        ];
+      usage = Agent_sdk.Types.empty_usage;
+      turn_count = 2;
+      created_at = 0.0;
+      tools = [];
+      tool_choice = None;
+      disable_parallel_tool_use = false;
+      temperature = None;
+      top_p = None;
+      top_k = None;
+      min_p = None;
+      enable_thinking = None;
+      response_format_json = false;
+      thinking_budget = None;
+      cache_system_prompt = false;
+      max_input_tokens = None;
+      max_total_tokens = Some 4096;
+      context = Agent_sdk.Context.create ();
+      mcp_sessions = [];
+      working_context = None;
+    }
+  in
+  let loaded =
+    KEC.context_of_oas_checkpoint ~max_checkpoint_messages:120 checkpoint
+      ~primary_model_max_tokens:1024
+  in
+  let has_orphan_tool_result =
+    List.exists
+      (fun (msg : Agent_sdk.Types.message) ->
+        List.exists
+          (function
+            | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                String.equal tool_use_id "orphan-call"
+            | _ -> false)
+          msg.content)
+      loaded.messages
+  in
+  check bool "orphan tool result dropped" false has_orphan_tool_result
+
 (* --- patch_checkpoint_last_assistant tests (#5431) --- *)
 
 let make_test_checkpoint ?(session_id = "old-session")
@@ -1382,6 +1491,10 @@ let () =
             test_recover_latest_checkpoint_for_overflow_retry_compacts_oas_checkpoint;
           test_case "overflow retry falls back to legacy checkpoint" `Quick
             test_recover_latest_checkpoint_for_overflow_retry_uses_legacy_checkpoint;
+          test_case "legacy checkpoint roundtrip preserves tool pairing" `Quick
+            test_legacy_checkpoint_roundtrip_preserves_tool_pairing;
+          test_case "OAS checkpoint drops orphan tool result" `Quick
+            test_context_of_oas_checkpoint_drops_orphan_tool_result;
           test_case
             "overflow retry history budget ignores checkpoint system prompt"
             `Quick


### PR DESCRIPTION
## Summary
- add an evidence-first keeper accountability ledger under `.masc/accountability`
- record keeper task transitions and explicit completion claims, then derive private risk/routing signals
- expose accountability in the keeper trust observatory and add a claim-time routing warning for high-risk keepers
- keep existing public reputation and karma behavior unchanged

## Testing
- `dune build --root . @install`
- `dune exec --root . ./test/test_keeper_accountability.exe`
- `dune exec --root . ./test/test_keeper_task_dispatch.exe`
- `dune exec --root . ./test/test_keeper_unified.exe`