### PR TITLE
feat(dashboard): Phase 2 — Fleet Health unified panel with FilterChips

### DIFF
--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -1,0 +1,139 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Writable route signal shared between mock and test helpers.
+const routeSignal = signal<{ tab: string; params: Record<string, string>; postId: string | null }>({
+  tab: 'monitoring',
+  params: { section: 'fleet-health' },
+  postId: null,
+})
+
+vi.mock('../router', () => ({
+  get route() { return routeSignal },
+}))
+
+// Mock child panels to avoid real fetch calls. Each renders a data-testid marker.
+vi.mock('./telemetry-unified', () => ({
+  TelemetryUnified: () => html`<div data-testid="telemetry-unified">TelemetryUnified</div>`,
+}))
+vi.mock('./fleet-telemetry-panel', () => ({
+  FleetTelemetryPanel: () => html`<div data-testid="fleet-telemetry-panel">FleetTelemetryPanel</div>`,
+}))
+vi.mock('./tool-quality-panel', () => ({
+  ToolQualityPanel: () => html`<div data-testid="tool-quality-panel">ToolQualityPanel</div>`,
+}))
+vi.mock('./governance-monitor', () => ({
+  GovernanceMonitor: () => html`<div data-testid="governance-monitor">GovernanceMonitor</div>`,
+}))
+
+// Import after mocks are in place.
+import { FleetHealthPanel } from './fleet-health-panel'
+
+function setRoute(view?: string) {
+  const params: Record<string, string> = { section: 'fleet-health' }
+  if (view) params.view = view
+  routeSignal.value = { tab: 'monitoring', params, postId: null }
+}
+
+describe('FleetHealthPanel', () => {
+  beforeEach(() => {
+    setRoute()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders default dual-panel (TelemetryUnified + ToolQualityPanel) when no view param', () => {
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByTestId('telemetry-unified')).toBeTruthy()
+    expect(screen.getByTestId('tool-quality-panel')).toBeTruthy()
+    expect(screen.queryByTestId('fleet-telemetry-panel')).toBeNull()
+    expect(screen.queryByTestId('governance-monitor')).toBeNull()
+  })
+
+  it('renders TelemetryUnified alone for view=event-log', () => {
+    setRoute('event-log')
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByTestId('telemetry-unified')).toBeTruthy()
+    expect(screen.queryByTestId('tool-quality-panel')).toBeNull()
+  })
+
+  it('renders FleetTelemetryPanel for view=comparison', () => {
+    setRoute('comparison')
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByTestId('fleet-telemetry-panel')).toBeTruthy()
+    expect(screen.queryByTestId('telemetry-unified')).toBeNull()
+  })
+
+  it('renders ToolQualityPanel alone for view=tool-quality', () => {
+    setRoute('tool-quality')
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByTestId('tool-quality-panel')).toBeTruthy()
+    expect(screen.queryByTestId('telemetry-unified')).toBeNull()
+  })
+
+  it('renders GovernanceMonitor for view=governance', () => {
+    setRoute('governance')
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByTestId('governance-monitor')).toBeTruthy()
+    expect(screen.queryByTestId('telemetry-unified')).toBeNull()
+  })
+
+  it('renders FilterChips with 5 view options', () => {
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByText('개요')).toBeTruthy()
+    expect(screen.getByText('이벤트 로그')).toBeTruthy()
+    expect(screen.getByText('Fleet 비교')).toBeTruthy()
+    expect(screen.getByText('도구 품질')).toBeTruthy()
+    expect(screen.getByText('거버넌스')).toBeTruthy()
+  })
+
+  it('marks the default chip as active (aria-pressed)', () => {
+    render(html`<${FleetHealthPanel} />`)
+
+    const defaultChip = screen.getByText('개요').closest('button')
+    expect(defaultChip?.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('clicking a chip dispatches hashchange to switch view', () => {
+    const hashChangeSpy = vi.fn()
+    window.addEventListener('hashchange', hashChangeSpy)
+
+    render(html`<${FleetHealthPanel} />`)
+
+    const toolQualityChip = screen.getByText('도구 품질')
+    fireEvent.click(toolQualityChip)
+
+    expect(hashChangeSpy).toHaveBeenCalledTimes(1)
+    expect(location.hash).toContain('view=tool-quality')
+
+    window.removeEventListener('hashchange', hashChangeSpy)
+  })
+
+  it('clicking 개요 chip removes view param from hash', () => {
+    setRoute('tool-quality')
+    render(html`<${FleetHealthPanel} />`)
+
+    const defaultChip = screen.getByText('개요')
+    fireEvent.click(defaultChip)
+
+    expect(location.hash).not.toContain('view=')
+  })
+
+  it('falls back to default view for unknown view param', () => {
+    setRoute('nonexistent')
+    render(html`<${FleetHealthPanel} />`)
+
+    expect(screen.getByTestId('telemetry-unified')).toBeTruthy()
+    expect(screen.getByTestId('tool-quality-panel')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -1,0 +1,88 @@
+// Fleet Health Panel — Phase 2 unified view for fleet-health section.
+// Replaces the Phase 1 interim FleetHealthRouter with FilterChips-based
+// view switching. Default view shows event-log + tool-quality side-by-side.
+// Deep-link view param (?view=comparison) selects a single sub-view.
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { route } from '../router'
+import { FilterChips } from './common/filter-chips'
+import { TelemetryUnified } from './telemetry-unified'
+import { FleetTelemetryPanel } from './fleet-telemetry-panel'
+import { ToolQualityPanel } from './tool-quality-panel'
+import { GovernanceMonitor } from './governance-monitor'
+
+export type FleetHealthView = 'default' | 'event-log' | 'comparison' | 'tool-quality' | 'governance'
+
+const FLEET_VIEWS: FleetHealthView[] = ['default', 'event-log', 'comparison', 'tool-quality', 'governance']
+
+function isFleetView(v: string | undefined): v is FleetHealthView {
+  return !!v && (FLEET_VIEWS as string[]).includes(v)
+}
+
+// Derive the active view from route params. Single source of truth — no
+// local writable signal needed. FilterChips uses the `value` prop (read-only)
+// + `onChange` to update the URL, which flows back through the route signal.
+const activeView = computed<FleetHealthView>(() => {
+  const v = route.value.params.view
+  return isFleetView(v) ? v : 'default'
+})
+
+const VIEW_CHIPS: Array<{ key: FleetHealthView; label: string }> = [
+  { key: 'default',      label: '개요' },
+  { key: 'event-log',    label: '이벤트 로그' },
+  { key: 'comparison',   label: 'Fleet 비교' },
+  { key: 'tool-quality', label: '도구 품질' },
+  { key: 'governance',   label: '거버넌스' },
+]
+
+function updateViewParam(view: FleetHealthView) {
+  const hash = view === 'default'
+    ? '#monitoring?section=fleet-health'
+    : `#monitoring?section=fleet-health&view=${view}`
+  history.replaceState(null, '', hash)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
+function DefaultDualPanel() {
+  return html`
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <div class="min-w-0 overflow-hidden">
+        <${TelemetryUnified} />
+      </div>
+      <div class="min-w-0 overflow-hidden">
+        <${ToolQualityPanel} />
+      </div>
+    </div>
+  `
+}
+
+export function FleetHealthPanel() {
+  const view = activeView.value
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center justify-between">
+        <h2 class="text-sm font-medium text-[var(--text-strong)]">Fleet 건강</h2>
+      </div>
+      <${FilterChips}
+        chips=${VIEW_CHIPS}
+        value=${view}
+        onChange=${updateViewParam}
+        size="sm"
+        tone="accent"
+      />
+      <div class="transition-opacity duration-200">
+        ${view === 'default'
+          ? html`<${DefaultDualPanel} />`
+        : view === 'event-log'
+          ? html`<${TelemetryUnified} />`
+        : view === 'comparison'
+          ? html`<${FleetTelemetryPanel} />`
+        : view === 'tool-quality'
+          ? html`<${ToolQualityPanel} />`
+        : html`<${GovernanceMonitor} />`}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -1,6 +1,6 @@
-// MASC Dashboard — Status Surface (Phase 1: consolidated)
+// MASC Dashboard — Status Surface (Phase 2: fleet-health unified)
 // Read-only observability surfaces: observatory, agents, activity, runtime,
-// fleet-health (absorbs telemetry + fleet + tool-quality + governance), memory-subsystems.
+// fleet-health (FilterChips unified panel), memory-subsystems.
 
 import { html } from 'htm/preact'
 import { route } from '../router'
@@ -8,12 +8,9 @@ import { AgentsUnified } from './agents-unified'
 import { Activity } from './activity'
 import { RuntimeMonitor } from './runtime-monitor'
 import { OasHealthChip } from './oas-health-chip'
-import { TelemetryUnified } from './telemetry-unified'
-import { GovernanceMonitor } from './governance-monitor'
 import { MemorySubsystems } from './memory-subsystems'
 import { PrometheusMetrics } from './prometheus-metrics'
-import { ToolQualityPanel } from './tool-quality-panel'
-import { FleetTelemetryPanel } from './fleet-telemetry-panel'
+import { FleetHealthPanel } from './fleet-health-panel'
 import { Observatory } from './observatory/observatory'
 
 type StatusSection = 'observatory' | 'agents' | 'activity' | 'runtime' | 'fleet-health' | 'memory-subsystems'
@@ -26,29 +23,6 @@ function currentSection(): StatusSection {
     || section === 'fleet-health' || section === 'memory-subsystems'
   ) return section
   return 'agents'
-}
-
-// Phase 1 interim: routes fleet-health sub-views to existing panel components.
-// Phase 2 replaces this with a unified FleetHealthPanel using FilterChips.
-type FleetHealthView = 'event-log' | 'comparison' | 'tool-quality' | 'governance'
-
-function currentFleetView(): FleetHealthView {
-  const view = route.value.params.view
-  if (view === 'comparison' || view === 'tool-quality' || view === 'governance') return view
-  return 'event-log'
-}
-
-function FleetHealthRouter() {
-  const view = currentFleetView()
-  return html`
-    ${view === 'event-log'
-      ? html`<${TelemetryUnified} />`
-    : view === 'comparison'
-      ? html`<${FleetTelemetryPanel} />`
-    : view === 'tool-quality'
-      ? html`<${ToolQualityPanel} />`
-    : html`<${GovernanceMonitor} />`}
-  `
 }
 
 export function Status() {
@@ -70,7 +44,7 @@ export function Status() {
               </div>
             `
           : section === 'fleet-health'
-            ? html`<${FleetHealthRouter} />`
+            ? html`<${FleetHealthPanel} />`
           : section === 'memory-subsystems'
             ? html`<${MemorySubsystems} />`
             : html`<${AgentsUnified} />`}


### PR DESCRIPTION
## Summary

- Phase 1의 interim `FleetHealthRouter`를 `FleetHealthPanel`로 교체
- FilterChips 기반 5개 view 전환: 개요(2-panel), 이벤트 로그, Fleet 비교, 도구 품질, 거버넌스
- `computed` signal로 route에서 view를 직접 파생 — useEffect sync 불필요
- status.ts 80→54줄 (fleet-health 렌더 위임)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `fleet-health-panel.ts` | 새 파일: FilterChips + view routing |
| `fleet-health-panel.test.ts` | 새 파일: 10 tests (view 전환, chip 클릭, fallback) |
| `status.ts` | FleetHealthRouter 제거, FleetHealthPanel import |

## Phase 흐름

| Phase | PR | 상태 |
|-------|-----|------|
| -1 | #7125 | Merged |
| 0 | #7134 | Merged |
| 0-fix | #7145 | Merged |
| 1 | #7152 | Merged |
| **2** | **이 PR** | Draft |

## Test plan

- [x] `tsc --noEmit` — 타입 에러 zero
- [x] `vite build` — 빌드 성공
- [x] fleet-health-panel.test.ts — 10/10 pass
- [x] navigation.test.ts, tab-refresh.test.ts, fleet-data-core.test.ts — 41/41 pass
- [x] Pre-existing failures만 남음 (main에서도 동일)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)