### PR TITLE
feat(keeper): consecutive noop backoff for proactive turns

### DIFF
--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -68,8 +68,8 @@ let build_keeper_system_prompt
       (* ── Shared prefix (identical across all keepers) ────────── *)
       "Autonomous behavior:\n\
        - Every turn you MUST call at least one tool. Do NOT describe actions in text — execute them via tool_call. Saying 'I will post' without calling keeper_board_post is a failure.\n\
-       - On proactive turns: if you need fresh board context, call keeper_board_list first. Otherwise act directly on your current goal and use board tools only when they help.\n\
-       - If no Board activity and no tasks: you may call keeper_board_list to observe, but do not block a productive action on a board scan. Do NOT fabricate activity.\n\
+       - On proactive turns: act directly on your current goal. Only call keeper_board_list if you expect actionable content. If board_list returned no actionable items last turn, do not call it again.\n\
+       - If no Board activity and no tasks: call keeper_stay_silent. Repeated board observation without action wastes tokens. Do NOT fabricate activity.\n\
        - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.\n\
        - ACTION TOOLS: For productive turns, use these: keeper_task_claim (claim work), keeper_fs_read + keeper_fs_edit/keeper_write (read then modify files), keeper_bash (run commands), keeper_github (PR/issues), keeper_pr_submit (submit staged changes from a playground clone or repo worktree), keeper_pr_workflow (legacy one-shot worktree helper), keeper_board_post (share findings), keeper_stay_silent (nothing to do). Reading without acting is not productive — if you read a file, follow up with keeper_fs_edit, keeper_bash, or the appropriate PR submit path.\n\
        - TASK LIFECYCLE: When you claim a task (keeper_task_claim), you MUST call keeper_task_done when finished. Claim -> Work -> Done. Every claimed task must be closed. Leaving tasks open creates zombie tasks.\n\

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -337,6 +337,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           board_reactive_turn_count = 0;
           mention_reactive_turn_count = 0;
           noop_turn_count = 0;
+          consecutive_noop_count = 0;
           last_speech_act = "";
           last_blocker = "";
           last_need = "";

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -107,6 +107,7 @@ type agent_runtime_state =
   ; board_reactive_turn_count : int
   ; mention_reactive_turn_count : int
   ; noop_turn_count : int
+  ; consecutive_noop_count : int
   ; last_speech_act : string
   ; last_blocker : string
   ; last_need : string
@@ -728,6 +729,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "board_reactive_turn_count", `Int rt.board_reactive_turn_count
     ; "mention_reactive_turn_count", `Int rt.mention_reactive_turn_count
     ; "noop_turn_count", `Int rt.noop_turn_count
+    ; "consecutive_noop_count", `Int rt.consecutive_noop_count
     ; "last_speech_act", `String rt.last_speech_act
     ; "last_blocker", `String rt.last_blocker
     ; "last_need", `String rt.last_need
@@ -1104,6 +1106,7 @@ let parse_keeper_state
     Safe_ops.json_int ~default:0 "mention_reactive_turn_count" json
   in
   let noop_turn_count = Safe_ops.json_int ~default:0 "noop_turn_count" json in
+  let consecutive_noop_count = Safe_ops.json_int ~default:0 "consecutive_noop_count" json in
   let last_speech_act = Safe_ops.json_string ~default:"" "last_speech_act" json in
   let last_blocker = Safe_ops.json_string ~default:"" "last_blocker" json in
   let last_need = Safe_ops.json_string ~default:"" "last_need" json in
@@ -1138,6 +1141,7 @@ let parse_keeper_state
       ; board_reactive_turn_count
       ; mention_reactive_turn_count
       ; noop_turn_count
+      ; consecutive_noop_count
       ; last_speech_act
       ; last_blocker
       ; last_need
@@ -1320,6 +1324,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "board_reactive_turn_count"
   ; "mention_reactive_turn_count"
   ; "noop_turn_count"
+  ; "consecutive_noop_count"
   ; "last_speech_act"
   ; "last_blocker"
   ; "last_need"

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -111,6 +111,7 @@ type agent_runtime_state = {
   board_reactive_turn_count: int;
   mention_reactive_turn_count: int;
   noop_turn_count: int;
+  consecutive_noop_count: int;
   last_speech_act: string;
   last_blocker: string;
   last_need: string;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -946,6 +946,11 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
         rt.noop_turn_count
         + (if is_autonomous_turn && not has_text && not has_substantive_tools
               && not has_validated_evidence then 1 else 0);
+      consecutive_noop_count =
+        (if is_autonomous_turn && not has_text && not has_substantive_tools
+            && not has_validated_evidence
+         then rt.consecutive_noop_count + 1
+         else 0);
       (* This timestamp stays scoped to substantive tool actions.
          Validated evidence affects proactive visibility, but it does not
          redefine the autonomous action counter semantics. *)

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -750,6 +750,13 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
             ~base_cooldown:meta.proactive.cooldown_sec
             ~since_last:since_last_scheduled_autonomous
         in
+        (* Exponential backoff for consecutive noop turns: 2^min(n, 3), cap 8x *)
+        let noop_backoff =
+          let n = meta.runtime.consecutive_noop_count in
+          if n <= 0 then 1
+          else Int.min 8 (1 lsl (Int.min n 3))
+        in
+        let effective_cooldown = effective_cooldown * noop_backoff in
         let task_cooldown_divisor =
           Keeper_config.keeper_proactive_task_cooldown_divisor ()
         in


### PR DESCRIPTION
## Summary
- keeper의 반복적 board_list 관찰 턴(noop)에 exponential backoff 적용하여 토큰 낭비 방지
- `consecutive_noop_count` 필드로 연속 noop 추적 (substantive 턴에서 리셋)
- 프롬프트 개선: 반복 관찰 억제, keeper_stay_silent 유도

## Product impact
Keeper가 proactive 턴에서 board_list만 호출하고 아무 action도 안 하는 패턴이 반복되며 토큰을 낭비. base cooldown이 30초인 keeper가 무한 반복 관찰 가능. 이 변경으로 연속 noop 시 cooldown이 최대 8배까지 증가하여 토큰 낭비 자동 억제.

## Evidence
- 관찰: keeper (glm:glm-5-turbo)가 board_list 호출 후 5개 포스트를 읽지만 action 없음
- `noop_turn_count`는 누적값만 — 연속 횟수 추적 불가
- `effective_scheduled_autonomous_cooldown`이 noop 이력을 무시

## Changes
- `lib/keeper/keeper_types.ml` + `.mli`: consecutive_noop_count 필드 추가 (JSON serde + allowed_fields)
- `lib/keeper/keeper_unified_turn.ml`: consecutive noop 추적 로직
- `lib/keeper/keeper_world_observation.ml`: noop backoff 적용 (2^min(n,3), cap 8x)
- `lib/keeper/keeper_prompt.ml`: board observation 프롬프트 개선
- `lib/keeper/keeper_turn_up_create.ml`: 초기값 0

## Review evidence
- `dune build` 통과 (로컬 + CI)
- `dune runtest` 기존 테스트 통과
- Build and Test, Lint, Health CI 모두 green

## Linked issue
Closes #7158

## Backoff effect
| consecutive noops | cooldown multiplier |
|:-:|:-:|
| 0 | 1x (변경 없음) |
| 1 | 2x |
| 2 | 4x |
| 3+ | 8x (cap) |

## Test plan
- [x] `dune build` 통과
- [x] `dune runtest` 기존 테스트 통과
- [ ] keeper runtime JSON에 consecutive_noop_count 필드 확인
- [ ] noop 연속 시 proactive cooldown 증가 확인 (decision_audit 로그)