### PR TITLE
fix(dashboard): prevent operator refresh timeout cascade

### DIFF
--- a/lib/server/proactive_refresh.ml
+++ b/lib/server/proactive_refresh.ml
@@ -56,7 +56,20 @@ let notify_error config exn =
   | Some f -> Safe_ops.protect ~default:() (fun () -> f exn)
   | None -> ()
 
-let start ~sw ~clock ~config ~compute ~on_result =
+let start ~sw ~clock ~config:raw_config ~compute ~on_result =
+  (* Clamp timeout below interval to prevent overlapping refreshes.
+     When timeout >= interval, a timed-out compute runs past the next
+     scheduled refresh, causing cascading failures (#7164). *)
+  let config =
+    if raw_config.timeout_s >= raw_config.interval_s then begin
+      let clamped = raw_config.interval_s *. 0.8 in
+      Log.Dashboard.warn
+        "%s: timeout_s (%.0f) >= interval_s (%.0f), clamping to %.0fs"
+        raw_config.label raw_config.timeout_s raw_config.interval_s clamped;
+      { raw_config with timeout_s = clamped }
+    end else
+      raw_config
+  in
   Eio.Fiber.fork ~sw (fun () ->
     if config.warm_delay_s > 0.0 then begin
       Log.Dashboard.debug "%s warm cache delayed %.0fs" config.label config.warm_delay_s;

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -316,8 +316,8 @@ let _operator_digest_cache =
 let _operator_refresh_interval_s =
   float_of_env_default
     "MASC_OPERATOR_REFRESH_INTERVAL_S"
-    ~default:30.0
-    ~min_v:5.0
+    ~default:60.0
+    ~min_v:10.0
     ~max_v:600.0
 
 let operator_snapshot_extra () =


### PR DESCRIPTION
## Summary
- operator_snapshot/digest refresh interval (30s) was shorter than timeout (45s), causing cascading failures when compute exceeded the interval
- Raised default interval from 30s to 60s
- Added timeout >= interval clamp in proactive_refresh.ml to prevent this class of misconfiguration at the framework level

## Evidence
systemlog showed repeated patterns:
```
[WARN] operator_digest refresh failed (4 consecutive, next in 30s, 45.0s): Failure("timeout")
[WARN] operator_snapshot refresh failed (2 consecutive, next in 60s, 45.2s): Failure("timeout")
```

## Test plan
- [ ] Build passes
- [ ] Server starts without clamp warning (interval > timeout)
- [ ] Dashboard refresh logs show no cascading failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)