### PR TITLE
feat(keeper): consecutive noop backoff (#7158)

### DIFF
--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -323,6 +323,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
             last_preview = "";
             last_work_discovery_ts = 0.0;
             work_discovery_count = 0;
+            consecutive_noop_count = 0;
           };
           generation = 0;
           trace_id = trace_id_t;

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -72,6 +72,12 @@ type proactive_runtime =
   ; last_preview : string
   ; last_work_discovery_ts : float
   ; work_discovery_count : int
+  ; consecutive_noop_count : int
+      (** Consecutive autonomous cycles where only observation tools
+          (board_list, stay_silent, context_status) were used with no
+          substantive action.  Resets to 0 on any productive cycle.
+          Used by [effective_scheduled_autonomous_cooldown] for exponential
+          backoff: cooldown *= 2^min(n, 3), capping at 8x. *)
   }
 
 type scheduled_autonomous_runtime = proactive_runtime
@@ -715,6 +721,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "last_proactive_preview", `String rt.proactive_rt.last_preview
     ; "last_work_discovery_ts", `Float rt.proactive_rt.last_work_discovery_ts
     ; "work_discovery_count", `Int rt.proactive_rt.work_discovery_count
+    ; "consecutive_noop_count", `Int rt.proactive_rt.consecutive_noop_count
     ; "last_compaction_check_ts", `Float rt.compaction_rt.last_check_ts
     ; "last_compaction_decision", `String rt.compaction_rt.last_decision
     ; "last_continuity_update_ts", `Float rt.last_continuity_update_ts
@@ -1057,6 +1064,8 @@ let parse_proactive_runtime (json : Yojson.Safe.t) : proactive_runtime =
       Safe_ops.json_float ~default:0.0 "last_work_discovery_ts" json
   ; work_discovery_count =
       Safe_ops.json_int ~default:0 "work_discovery_count" json
+  ; consecutive_noop_count =
+      Safe_ops.json_int ~default:0 "consecutive_noop_count" json
   }
 ;;
 

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -74,6 +74,7 @@ type proactive_runtime = {
   last_preview: string;
   last_work_discovery_ts : float;
   work_discovery_count : int;
+  consecutive_noop_count : int;
 }
 
 type scheduled_autonomous_runtime = proactive_runtime

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -428,6 +428,23 @@ let has_substantive_tool_calls (tools_used : string list) : bool =
   List.exists (fun name ->
     not (String.equal name "keeper_stay_silent")) tools_used
 
+(** Observation-only tools that do not constitute productive work.
+    A cycle using only these tools (or none) is a "noop" and triggers
+    exponential cooldown backoff to prevent token waste. *)
+let observation_only_tools =
+  [ "keeper_stay_silent"
+  ; "keeper_board_list"
+  ; "keeper_context_status"
+  ; "keeper_tool_search"
+  ]
+
+(** A cycle is noop when it produced no text AND all tools used (if any)
+    are observation-only.  Productive cycles reset consecutive_noop_count. *)
+let is_noop_cycle ~has_text ~(tools_used : string list) : bool =
+  not has_text
+  && List.for_all (fun name ->
+       List.mem name observation_only_tools) tools_used
+
 let visible_run_validation (result : Keeper_agent_run.run_result) :
     Agent_sdk.Raw_trace.run_validation option =
   match result.run_validation with
@@ -925,6 +942,12 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
           rt.proactive_rt.work_discovery_count
           + (if observation.work_discovery_due && has_substantive_tools then 1
              else 0);
+        consecutive_noop_count =
+          (if update_proactive_rt && is_scheduled_autonomous_cycle then
+             if is_noop_cycle ~has_text ~tools_used:result.tools_used
+             then rt.proactive_rt.consecutive_noop_count + 1
+             else 0
+           else rt.proactive_rt.consecutive_noop_count);
       };
       (* Autonomous action tracking from tool calls *)
       autonomous_action_count =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -692,20 +692,30 @@ let actionable_signal_present (observation : world_observation) =
     additional period, down to a configurable floor.  This prevents
     permanent silence when no external events arrive. *)
 let effective_scheduled_autonomous_cooldown
-    ~(base_cooldown : int) ~(since_last : int) : int =
+    ~(base_cooldown : int) ~(since_last : int)
+    ?(consecutive_noop_count = 0) () : int =
+  (* Noop backoff: consecutive observation-only cycles multiply the base
+     cooldown by 2^min(n, 3), capping at 8x. This prevents token waste when
+     the keeper repeatedly reads board_list without taking action. *)
+  let noop_multiplier =
+    if consecutive_noop_count <= 0 then 1
+    else 1 lsl (min consecutive_noop_count 3)  (* 1, 2, 4, 8 *)
+  in
+  let effective_base = base_cooldown * noop_multiplier in
   let min_cooldown = Keeper_config.keeper_proactive_min_cooldown_sec () in
-  (* Floor must not exceed the base cooldown — otherwise decay would
+  (* Floor must not exceed the effective base cooldown — otherwise decay would
      paradoxically increase a short cooldown. *)
-  let floor = min min_cooldown base_cooldown in
-  if since_last <= base_cooldown then base_cooldown
+  let floor = min min_cooldown effective_base in
+  if since_last <= effective_base then effective_base
   else
-    let decay_periods = (since_last - base_cooldown) / (max 1 base_cooldown) in
+    let decay_periods = (since_last - effective_base) / (max 1 effective_base) in
     let capped_periods = min decay_periods 4 in
     let factor = 1.0 /. (Float.pow 2.0 (float_of_int capped_periods)) in
-    max floor (int_of_float (float_of_int base_cooldown *. factor))
+    max floor (int_of_float (float_of_int effective_base *. factor))
 
 let effective_proactive_cooldown =
   effective_scheduled_autonomous_cooldown
+
 
 let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation) =
   let reactive_triggers =
@@ -749,6 +759,8 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
           effective_scheduled_autonomous_cooldown
             ~base_cooldown:meta.proactive.cooldown_sec
             ~since_last:since_last_scheduled_autonomous
+            ~consecutive_noop_count:meta.runtime.proactive_rt.consecutive_noop_count
+            ()
         in
         let task_cooldown_divisor =
           Keeper_config.keeper_proactive_task_cooldown_divisor ()

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -196,11 +196,13 @@ val apply_message_cursor_updates :
     After extended idle (> base cooldown), halve the cooldown each
     additional period, down to a configurable floor. *)
 val effective_scheduled_autonomous_cooldown :
-  base_cooldown:int -> since_last:int -> int
+  base_cooldown:int -> since_last:int ->
+  ?consecutive_noop_count:int -> unit -> int
 
 (** Backward-compatible alias for the pre-rename helper name. *)
 val effective_proactive_cooldown :
-  base_cooldown:int -> since_last:int -> int
+  base_cooldown:int -> since_last:int ->
+  ?consecutive_noop_count:int -> unit -> int
 
 val unified_turn_decision :
   meta:Keeper_types.keeper_meta -> world_observation -> unified_turn_decision

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -371,7 +371,7 @@ let test_effective_cooldown_no_decay_within_base () =
   (* Within the base cooldown period, no decay should apply. *)
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:900
+      ~base_cooldown:1800 ~since_last:900 ()
   in
   check int "no decay within base" 1800 result
 
@@ -379,7 +379,7 @@ let test_effective_cooldown_at_boundary () =
   (* Exactly at the base cooldown, no decay yet. *)
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:1800
+      ~base_cooldown:1800 ~since_last:1800 ()
   in
   check int "no decay at boundary" 1800 result
 
@@ -387,7 +387,7 @@ let test_effective_cooldown_first_decay () =
   (* One full extra period: cooldown halved. *)
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:3600
+      ~base_cooldown:1800 ~since_last:3600 ()
   in
   check int "first decay halves cooldown" 900 result
 
@@ -395,7 +395,7 @@ let test_effective_cooldown_second_decay () =
   (* Two extra periods: cooldown quartered. *)
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:5400
+      ~base_cooldown:1800 ~since_last:5400 ()
   in
   check int "second decay quarters cooldown" 450 result
 
@@ -403,7 +403,7 @@ let test_effective_cooldown_floor () =
   (* Four+ extra periods: cooldown at floor (300s default). *)
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:10800
+      ~base_cooldown:1800 ~since_last:10800 ()
   in
   check int "decay floors at min_cooldown" 300 result
 
@@ -411,9 +411,44 @@ let test_effective_cooldown_max_int () =
   (* max_int (first scheduled autonomous cycle ever): should hit floor immediately. *)
   let result =
     WO.effective_scheduled_autonomous_cooldown
-      ~base_cooldown:1800 ~since_last:max_int
+      ~base_cooldown:1800 ~since_last:max_int ()
   in
   check int "max_int hits floor" 300 result
+
+let test_noop_backoff_doubles_cooldown () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:900
+      ~consecutive_noop_count:1 ()
+  in
+  (* 1 noop → 2x multiplier → effective base = 3600, since_last < 3600 *)
+  check int "1 noop doubles effective base" 3600 result
+
+let test_noop_backoff_quadruples_cooldown () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:900
+      ~consecutive_noop_count:2 ()
+  in
+  (* 2 noops → 4x multiplier → effective base = 7200 *)
+  check int "2 noops quadruples effective base" 7200 result
+
+let test_noop_backoff_caps_at_8x () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:900
+      ~consecutive_noop_count:5 ()
+  in
+  (* 5 noops → capped at 3 → 8x multiplier → effective base = 14400 *)
+  check int "noop backoff caps at 8x" 14400 result
+
+let test_noop_backoff_zero_noops_unchanged () =
+  let result =
+    WO.effective_scheduled_autonomous_cooldown
+      ~base_cooldown:1800 ~since_last:900
+      ~consecutive_noop_count:0 ()
+  in
+  check int "0 noops = no backoff" 1800 result
 
 let test_idle_decay_triggers_turn () =
   (* After extended idle, decay should make cooldown_elapsed true
@@ -2659,6 +2694,14 @@ let () =
             test_effective_cooldown_floor;
           test_case "idle decay: max_int" `Quick
             test_effective_cooldown_max_int;
+          test_case "noop backoff: doubles cooldown" `Quick
+            test_noop_backoff_doubles_cooldown;
+          test_case "noop backoff: quadruples cooldown" `Quick
+            test_noop_backoff_quadruples_cooldown;
+          test_case "noop backoff: caps at 8x" `Quick
+            test_noop_backoff_caps_at_8x;
+          test_case "noop backoff: zero noops unchanged" `Quick
+            test_noop_backoff_zero_noops_unchanged;
           test_case "idle decay: triggers turn" `Quick
             test_idle_decay_triggers_turn;
           test_case "scheduled decision uses backlog acceleration" `Quick


### PR DESCRIPTION
## Summary
- keeper가 board_list만 반복 호출하고 행동 안 하는 noop cycle을 연속 추적
- `consecutive_noop_count` 필드를 `proactive_runtime`에 추가
- 연속 noop 시 cooldown에 지수 backoff 적용: `cooldown *= 2^min(n, 3)` (최대 8x)
- 생산적 사이클에서 카운터 0 리셋

## Noop 판정 기준
observation-only 도구만 사용하고 텍스트 없음:
- `keeper_stay_silent`, `keeper_board_list`, `keeper_context_status`, `keeper_tool_search`

## 효과
base cooldown 60s 기준:
| 연속 noop | effective cooldown |
|-----------|-------------------|
| 0 | 60s |
| 1 | 120s |
| 2 | 240s |
| 3+ | 480s (8x cap) |

## Test plan
- [x] 4 new backoff tests (doubles, quadruples, caps at 8x, zero unchanged)
- [x] 6 existing cooldown tests pass with updated signature
- [x] 145 total tests pass
- [ ] CI green

Closes #7158