### PR TITLE
feat(dashboard): Phase 3 — integrate FSM Hub into agents unified view

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -1,5 +1,5 @@
 // MASC Dashboard — Unified Agents Tab
-// Absorbs: agent-roster + execution + keeper-roster into one view with chip toggle.
+// Absorbs: agent-roster + execution + keeper-roster + FSM hub into one view with chip toggle.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -14,8 +14,9 @@ import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { KeeperFleetOverview } from './keeper-fleet-overview'
+import { FsmHub } from './fsm-hub'
 
-type AgentsView = 'all' | 'agents' | 'keepers'
+type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
 
 const activeView = signal<AgentsView>('all')
 
@@ -23,6 +24,7 @@ const CHIPS: { id: AgentsView; label: string; description: string }[] = [
   { id: 'all', label: '전체 보기', description: '에이전트와 키퍼를 한 목록에서 봅니다.' },
   { id: 'agents', label: '일반 에이전트', description: '키퍼가 연결되지 않은 일반 에이전트만 봅니다.' },
   { id: 'keepers', label: '키퍼', description: '키퍼만 따로 봅니다.' },
+  { id: 'fsm', label: 'FSM', description: '키퍼 composite FSM lifecycle 상태를 봅니다.' },
 ]
 
 export function AgentsUnified() {
@@ -34,7 +36,7 @@ export function AgentsUnified() {
 
   const viewParam = route.value.params.view as string | undefined
   const routeView =
-    viewParam === 'keepers' || viewParam === 'agents'
+    viewParam === 'keepers' || viewParam === 'agents' || viewParam === 'fsm'
       ? viewParam
       : null
   const currentView = routeView ?? activeView.value
@@ -83,17 +85,21 @@ export function AgentsUnified() {
         class="monitor-muted-panel w-fit p-1.5 shadow-[inset_0_1px_0_var(--white-3)]"
       />
 
-      ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
+      ${currentView === 'fsm'
+        ? html`<${FsmHub} />`
+        : html`
+          ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
 
-      ${currentView !== 'agents' && keepers.value.length > 0 ? html`
-        <${KeeperFleetOverview} keepers=${keepers.value} />
-      ` : null}
+          ${currentView !== 'agents' && keepers.value.length > 0 ? html`
+            <${KeeperFleetOverview} keepers=${keepers.value} />
+          ` : null}
 
-      <${AgentRoster}
-        keeperFilter=${currentView === 'keepers' ? 'keeper-only'
-          : currentView === 'agents' ? 'agent-only'
-          : 'all'}
-      />
+          <${AgentRoster}
+            keeperFilter=${currentView === 'keepers' ? 'keeper-only'
+              : currentView === 'agents' ? 'agent-only'
+              : 'all'}
+          />
+        `}
     </div>
   `
 }

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -197,7 +197,7 @@ describe('consolidation redirects (Phase 1)', () => {
     ['telemetry', { operation_id: 'op1' }, 'fleet-health', 'event-log', { operation_id: 'op1' }],
     ['tool-quality', { tool: 'bash' }, 'fleet-health', 'tool-quality', { tool: 'bash' }],
     ['fleet', {}, 'fleet-health', 'comparison', {}],
-    ['fsm-hub', {}, 'agents', undefined, {}],
+    ['fsm-hub', {}, 'agents', 'fsm', {}],
     ['metrics', {}, 'runtime', undefined, {}],
   ])(
     'monitoring:%s → %s (view: %s) preserves params',

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -258,7 +258,7 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'monitoring:fleet':        { section: 'fleet-health', view: 'comparison' },
   'monitoring:tool-quality': { section: 'fleet-health', view: 'tool-quality' },
   'monitoring:governance':   { section: 'fleet-health', view: 'governance' },
-  'monitoring:fsm-hub':      { section: 'agents' },
+  'monitoring:fsm-hub':      { section: 'agents', view: 'fsm' },
   'monitoring:metrics':      { section: 'runtime' },
 
   // Dashboard consolidation Phase 1: command surface


### PR DESCRIPTION
## Summary

- agents-unified의 FilterChips에 FSM view 추가 (4번째 chip)
- 기존 `fsm-hub.ts` 431줄 컴포넌트를 agents section 내 sub-view로 흡수
- legacy `monitoring?section=fsm-hub` redirect가 `agents?view=fsm`으로 정확히 전달

## 변경 파일

| 파일 | 변경 |
|------|------|
| `agents-unified.ts` | AgentsView에 'fsm' 추가, FsmHub import/render |
| `navigation.ts` | fsm-hub redirect에 view: 'fsm' 추가 |
| `navigation.test.ts` | redirect assertion 업데이트 |

## Phase 흐름

| Phase | PR | 상태 |
|-------|-----|------|
| -1 | #7125 | Merged |
| 0 | #7134 | Merged |
| 0-fix | #7145 | Merged |
| 1 | #7152 | Merged |
| 2 | #7165 | Draft |
| **3** | **이 PR** | Draft |

## Test plan

- [x] `tsc --noEmit` — 타입 에러 zero
- [x] `vite build` — 빌드 성공
- [x] navigation.test.ts — 25/25 pass (redirect 포함)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)