### PR TITLE
[codex] reduce dashboard startup and snapshot overhead

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -51,6 +51,20 @@ let messages_safe config =
 let assoc_upsert fields key value =
   (key, value) :: List.remove_assoc key fields
 
+let model_map_of_keeper_rows keepers =
+  let model_map : (string, string) Hashtbl.t = Hashtbl.create 8 in
+  let open Yojson.Safe.Util in
+  List.iter
+    (function
+      | `Assoc _ as keeper_json -> (
+          match member "name" keeper_json, member "active_model" keeper_json with
+          | `String name, `String model when String.trim model <> "" ->
+              Hashtbl.replace model_map name model
+          | _ -> ())
+      | _ -> ())
+    keepers;
+  model_map
+
 
 let task_updated_at (task : Types.task) =
   match task.task_status with
@@ -223,14 +237,7 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
           ("continuity_briefs", `List (List.map (fun (row : continuity_context) -> row.json) continuity_rows));
           ("offline_worker_briefs", `List (List.map (fun (row : worker_context) -> row.json) offline_worker_briefs));
           ("agents",
-           let model_map : (string, string) Hashtbl.t = Hashtbl.create 8 in
-           List.iter (fun name ->
-             match Keeper_types.read_meta config name with
-             | Ok (Some m) ->
-               Hashtbl.replace model_map name
-                 (Keeper_exec_status.active_model_of_meta m)
-             | _ -> ()
-           ) (Keeper_types.keeper_names config);
+           let model_map = model_map_of_keeper_rows keepers in
            `List (List.map (agent_json ~model_map) agents));
           (* pipeline_stage is now included in the snapshot keepers_json,
              so no redundant read_meta + parse_agent_status needed here. *)

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -476,56 +476,110 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
   let rows = Array.to_list results |> List.filter_map Fun.id in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]
 
-let persistent_agents_json ?keeper_names config =
-  ignore keeper_names;
-  let names = Keeper_types.persistent_agent_names config in
+let persistent_agents_json ?keeper_names ?keeper_rows config =
+  let rows_from_keeper_rows names rows =
+    let wanted = List.sort_uniq String.compare names in
+    let wanted_tbl = Hashtbl.create (List.length wanted) in
+    List.iter (fun name -> Hashtbl.replace wanted_tbl name ()) wanted;
+    rows
+    |> List.filter_map (function
+         | `Assoc fields -> (
+             match List.assoc_opt "name" fields with
+             | Some (`String name) when Hashtbl.mem wanted_tbl name ->
+                 let field_or_null key =
+                   match List.assoc_opt key fields with
+                   | Some value -> value
+                   | None -> `Null
+                 in
+                 Some
+                   (`Assoc
+                     [
+                       ("runtime_class", `String "keeper");
+                       ("name", field_or_null "name");
+                       ("agent_name", field_or_null "agent_name");
+                       ("trace_id", field_or_null "trace_id");
+                       ("goal", field_or_null "goal");
+                       ("short_goal", field_or_null "short_goal");
+                       ("mid_goal", field_or_null "mid_goal");
+                       ("long_goal", field_or_null "long_goal");
+                       ("status", field_or_null "status");
+                       ("generation", field_or_null "generation");
+                       ("turn_count", field_or_null "turn_count");
+                       ("context_ratio", field_or_null "context_ratio");
+                       ("context_tokens", field_or_null "context_tokens");
+                       ("last_model_used", field_or_null "last_model_used");
+                       ("active_model", field_or_null "active_model");
+                       ("next_model_hint", field_or_null "next_model_hint");
+                       ("active_goal_ids", field_or_null "active_goal_ids");
+                       ("last_autonomous_action_at", field_or_null "last_autonomous_action_at");
+                       ("autonomous_action_count", field_or_null "autonomous_action_count");
+                       ("updated_at", field_or_null "updated_at");
+                       ("created_at", field_or_null "created_at");
+                     ])
+             | _ -> None)
+         | _ -> None)
+  in
   let rows =
-    List.filter_map
-      (fun name ->
-        match Keeper_types.read_meta config name with
-        | Error _ | Ok None -> None
-        | Ok (Some meta) ->
-            let agent_json =
-              Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
-            in
-            let agent_status =
-              match agent_json with
-              | `Assoc _ -> (
-                  match agent_json |> U.member "status" with
-                  | `String status -> status
-                  | _ -> "unknown")
-              | _ -> "unknown"
-            in
-            Some
-              (`Assoc
-                [
-                  ("runtime_class", `String "keeper");
-                  ("name", `String meta.name);
-                  ("agent_name", `String meta.agent_name);
-                  ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
-                  ("goal", `String meta.goal);
-                  ("short_goal", `String meta.short_goal);
-                  ("mid_goal", `String meta.mid_goal);
-                  ("long_goal", `String meta.long_goal);
-                  ("status", `String agent_status);
-                  ("generation", `Int meta.runtime.generation);
-                  ("turn_count", `Int meta.runtime.usage.total_turns);
-                  ("context_ratio",
-                    (match compute_context_ratio meta with
-                     | Some r -> `Float r
-                     | None -> `Null));
-                  ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
-                  ("last_model_used", `String meta.runtime.usage.last_model_used);
-                  ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
-                  ("next_model_hint", string_option_to_json (Keeper_exec_status.next_model_hint_of_meta meta));
-                  ("active_goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
-                  ("last_autonomous_action_at",
-                    if String.trim meta.runtime.last_autonomous_action_at = "" then `Null else `String meta.runtime.last_autonomous_action_at);
-                  ("autonomous_action_count", `Int meta.runtime.autonomous_action_count);
-                  ("updated_at", `String meta.updated_at);
-                  ("created_at", `String meta.created_at);
-                ]))
-      names
+    match keeper_rows with
+    | Some rows ->
+        let names =
+          match keeper_names with
+          | Some names -> names
+          | None -> Keeper_types.persistent_agent_names config
+        in
+        rows_from_keeper_rows names rows
+    | None ->
+        let names =
+          match keeper_names with
+          | Some names -> names
+          | None -> Keeper_types.persistent_agent_names config
+        in
+        List.filter_map
+          (fun name ->
+            match Keeper_types.read_meta config name with
+            | Error _ | Ok None -> None
+            | Ok (Some meta) ->
+                let agent_json =
+                  Keeper_exec_status.parse_agent_status config ~agent_name:meta.agent_name
+                in
+                let agent_status =
+                  match agent_json with
+                  | `Assoc _ -> (
+                      match agent_json |> U.member "status" with
+                      | `String status -> status
+                      | _ -> "unknown")
+                  | _ -> "unknown"
+                in
+                Some
+                  (`Assoc
+                    [
+                      ("runtime_class", `String "keeper");
+                      ("name", `String meta.name);
+                      ("agent_name", `String meta.agent_name);
+                      ("trace_id", `String (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+                      ("goal", `String meta.goal);
+                      ("short_goal", `String meta.short_goal);
+                      ("mid_goal", `String meta.mid_goal);
+                      ("long_goal", `String meta.long_goal);
+                      ("status", `String agent_status);
+                      ("generation", `Int meta.runtime.generation);
+                      ("turn_count", `Int meta.runtime.usage.total_turns);
+                      ("context_ratio",
+                        (match compute_context_ratio meta with
+                         | Some r -> `Float r
+                         | None -> `Null));
+                      ("context_tokens", `Int meta.runtime.usage.last_total_tokens);
+                      ("last_model_used", `String meta.runtime.usage.last_model_used);
+                      ("active_model", `String (Keeper_exec_status.active_model_of_meta meta));
+                      ("next_model_hint", string_option_to_json (Keeper_exec_status.next_model_hint_of_meta meta));
+                      ("active_goal_ids", `List (List.map (fun goal_id -> `String goal_id) meta.active_goal_ids));
+                      ("last_autonomous_action_at",
+                        if String.trim meta.runtime.last_autonomous_action_at = "" then `Null else `String meta.runtime.last_autonomous_action_at);
+                      ("autonomous_action_count", `Int meta.runtime.autonomous_action_count);
+                      ("updated_at", `String meta.updated_at);
+                      ("created_at", `String meta.created_at);
+                    ]))
+          names
   in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]
 
@@ -821,6 +875,11 @@ let snapshot_json ?actor ?view ?(include_messages = true)
       Keeper_types.keeper_names config
     else []
   in
+  let persistent_keeper_names =
+    if initialized && include_keepers then
+      Keeper_types.persistent_agent_names config
+    else []
+  in
   let result =
     `Assoc
       ([
@@ -850,17 +909,27 @@ let snapshot_json ?actor ?view ?(include_messages = true)
              ignore (lightweight_summary, status_cache);
              sessions_ref := empty_section);
            (fun () ->
-             keepers_ref :=
+             let keepers_json_value =
                timed "keepers_json" (fun () ->
                  if initialized && include_keepers then
                    keepers_json ~keeper_names ~lightweight:lightweight_summary
                      ~include_recent_activity:(not lightweight_summary) config
-                 else empty_section));
-           (fun () ->
+                 else empty_section)
+             in
+             keepers_ref := keepers_json_value;
              persistent_ref :=
                timed "persistent_agents_json" (fun () ->
                  if initialized && include_keepers then
-                   persistent_agents_json ~keeper_names config
+                   let keeper_rows =
+                     match keepers_json_value with
+                     | `Assoc fields -> (
+                         match List.assoc_opt "items" fields with
+                         | Some (`List rows) -> rows
+                         | _ -> [])
+                     | _ -> []
+                   in
+                   persistent_agents_json ~keeper_names:persistent_keeper_names
+                     ~keeper_rows config
                  else empty_section));
            (fun () ->
              let cp = timed "command_plane_json" (fun () ->

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -125,12 +125,46 @@ resolve_base_path() {
 
 build_dashboard_spa() {
     local dashboard_dir="$SCRIPT_DIR/dashboard"
+    local dashboard_index="$SCRIPT_DIR/assets/dashboard/index.html"
     local log_file=""
     local dashboard_pm=()
     local dashboard_pm_label=""
 
     if [ ! -f "$dashboard_dir/package.json" ]; then
         return 0
+    fi
+
+    if is_truthy "${MASC_SKIP_DASHBOARD_BUILD:-0}"; then
+        echo "[dashboard] Skipping SPA build (MASC_SKIP_DASHBOARD_BUILD=1)." >&2
+        return 0
+    fi
+
+    if ! is_truthy "${MASC_DASHBOARD_BUILD_ALWAYS:-0}"; then
+        local stale=0
+        if [ ! -f "$dashboard_index" ]; then
+            stale=1
+        fi
+        for candidate in \
+            "$dashboard_dir/package.json" \
+            "$dashboard_dir/pnpm-lock.yaml" \
+            "$dashboard_dir/tsconfig.json" \
+            "$dashboard_dir/vite.config.ts"
+        do
+            if [ -f "$candidate" ] && [ "$candidate" -nt "$dashboard_index" ]; then
+                stale=1
+                break
+            fi
+        done
+        if [ "$stale" -eq 0 ] && [ -d "$dashboard_dir/src" ] && find "$dashboard_dir/src" -type f -newer "$dashboard_index" | head -n 1 | grep -q .; then
+            stale=1
+        fi
+        if [ "$stale" -eq 0 ] && [ -d "$dashboard_dir/public" ] && find "$dashboard_dir/public" -type f -newer "$dashboard_index" | head -n 1 | grep -q .; then
+            stale=1
+        fi
+        if [ "$stale" -eq 0 ]; then
+            echo "[dashboard] Build output is fresh; skipping SPA build." >&2
+            return 0
+        fi
     fi
 
     echo "[dashboard] Building SPA before server start..." >&2


### PR DESCRIPTION
## Summary
Reduce duplicate keeper read-path work and skip unnecessary dashboard SPA rebuilds so dashboard/operator surfaces stay responsive in keeper-heavy rooms.

## What changed
- reuse snapshot keeper rows when building `persistent_agents`
- derive the dashboard execution agent model map from snapshot keepers instead of rereading keeper metadata
- skip dashboard SPA rebuild on server start when `assets/dashboard/index.html` is already fresh

## Why
With 50+ agents or keepers, the old path paid keeper-meta and runtime-status costs more than once per snapshot/dashboard render. Startup also rebuilt the dashboard SPA even when nothing in the frontend had changed.

## Product impact
- lower duplicate keeper I/O on `/api/v1/operator/snapshot`
- lower duplicate keeper I/O on `/api/v1/dashboard/execution`
- faster server start when dashboard assets are unchanged
- no user-facing API contract changes

## Evidence
- `persistent_agents_json` now accepts already-built keeper rows from the snapshot path
- dashboard execution now builds its model map from snapshot `keepers`
- startup script now checks freshness before rebuilding the SPA

## Review evidence
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-50-agent-readpath ./test/test_dashboard_execution.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-50-agent-readpath ./test/test_operator_control.exe`
- `bash -n /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/dashboard-50-agent-readpath/start-masc-mcp.sh`

## Linked issue
Refs #7197
