### PR TITLE
fix tool telemetry trust and keeper checkpoint history

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -80,6 +80,9 @@ describe('fetchDashboardTools', () => {
 describe('fetchToolQuality', () => {
   it('passes through the requested sample window', async () => {
     const rawResponse = {
+      generated_at: '2026-04-14T00:00:00Z',
+      sampling_mode: 'recent_n',
+      sample_limit: 250,
       total: 1,
       success: 1,
       failure: 0,
@@ -102,6 +105,38 @@ describe('fetchToolQuality', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?n=250')
     expect(result.total).toBe(1)
+    expect(result.sample_limit).toBe(250)
+  })
+
+  it('passes through the requested time window', async () => {
+    const rawResponse = {
+      generated_at: '2026-04-15T00:00:00Z',
+      sampling_mode: 'window_hours',
+      sample_limit: null,
+      window_hours: 24,
+      total: 3,
+      success: 3,
+      failure: 0,
+      success_rate: 100,
+      by_tool: [],
+      by_keeper: [],
+      failure_categories: [],
+    }
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchToolQuality({ windowHours: 24 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/tool-quality?window_hours=24')
+    expect(result.window_hours).toBe(24)
+    expect(result.sampling_mode).toBe('window_hours')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -262,6 +262,10 @@ export type ToolQualityHourlyPoint = {
 }
 
 export type ToolQualityResponse = {
+  generated_at?: string
+  sampling_mode?: 'recent_n' | 'window_hours' | string
+  sample_limit?: number | null
+  window_hours?: number | null
   total: number
   success: number
   failure: number
@@ -272,9 +276,10 @@ export type ToolQualityResponse = {
   hourly_trend?: ToolQualityHourlyPoint[]
 }
 
-export function fetchToolQuality(opts?: { n?: number; signal?: AbortSignal }): Promise<ToolQualityResponse> {
+export function fetchToolQuality(opts?: { n?: number; windowHours?: number; signal?: AbortSignal }): Promise<ToolQualityResponse> {
   const params = new URLSearchParams()
   if (opts?.n != null) params.set('n', String(opts.n))
+  if (opts?.windowHours != null) params.set('window_hours', String(opts.windowHours))
   const qs = params.toString()
   return get<ToolQualityResponse>(`/api/v1/dashboard/tool-quality${qs ? `?${qs}` : ''}`, { signal: opts?.signal })
 }

--- a/dashboard/src/components/fleet-data-core.ts
+++ b/dashboard/src/components/fleet-data-core.ts
@@ -51,6 +51,8 @@ export interface RefreshSharedOptions {
   signal?: AbortSignal
   /** Override default n=5000 for tool-quality fetches. */
   n?: number
+  /** Use an operational time window instead of a sample tail. */
+  windowHours?: number
 }
 
 export async function refreshSharedToolQuality(opts: RefreshSharedOptions = {}): Promise<void> {
@@ -70,7 +72,11 @@ export async function refreshSharedToolQuality(opts: RefreshSharedOptions = {}):
   sharedToolQualityError.value = null
 
   try {
-    const json = await fetchToolQuality({ n: opts.n ?? 5000, signal: controller.signal })
+    const json = await fetchToolQuality({
+      n: opts.n ?? 5000,
+      windowHours: opts.windowHours,
+      signal: controller.signal,
+    })
     if (requestId !== toolQualityRequestId) return
     sharedToolQuality.value = json
   } catch (e) {

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -102,7 +102,7 @@ function requireResolver<T>(
 
 async function loadPanel(mocks: {
   fetchDashboardExecution: (opts?: { signal?: AbortSignal }) => Promise<DashboardExecutionResponse>
-  fetchToolQuality: (opts?: { n?: number; signal?: AbortSignal }) => Promise<ToolQualityResponse>
+  fetchToolQuality: (opts?: { n?: number; windowHours?: number; signal?: AbortSignal }) => Promise<ToolQualityResponse>
   fetchTelemetrySummary: (opts?: { signal?: AbortSignal }) => Promise<TelemetrySummaryResponse>
 }) {
   vi.resetModules()
@@ -767,7 +767,7 @@ describe('FleetTelemetryPanel', () => {
 
     const fetchDashboardExecution = createAbortableResponse(executionResponse)
     const abortableToolQuality = createAbortableResponse(toolQualityResponse)
-    const fetchToolQuality = vi.fn().mockImplementation((opts?: { n?: number; signal?: AbortSignal }) => (
+    const fetchToolQuality = vi.fn().mockImplementation((opts?: { n?: number; windowHours?: number; signal?: AbortSignal }) => (
       abortableToolQuality(opts)
     ))
     const fetchTelemetrySummary = createAbortableResponse(telemetrySummaryResponse)

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -246,7 +246,7 @@ export function FleetTelemetryPanel() {
     try {
       const [executionResult, toolQualityResult, telemetrySummaryResult] = await Promise.allSettled([
         fetchDashboardExecution({ signal: controller.signal }),
-        fetchToolQuality({ n: 5000, signal: controller.signal }),
+        fetchToolQuality({ n: 5000, windowHours: 24, signal: controller.signal }),
         fetchTelemetrySummary({ signal: controller.signal }),
       ])
 
@@ -374,8 +374,10 @@ export function FleetTelemetryPanel() {
           title="Tool Success"
           value=${value.tool_quality.total > 0 ? formatPercent(value.tool_quality.success_rate, 1) : 'n/a'}
           detail=${value.tool_quality.total > 0
-            ? `${value.tool_quality.failure.toLocaleString()} failures across ${value.tool_quality.total.toLocaleString()} recent calls.`
-            : 'No recent tool quality samples were recorded.'}
+            ? `${value.tool_quality.failure.toLocaleString()} failures across ${value.tool_quality.total.toLocaleString()}${value.tool_quality.sampling_mode === 'window_hours' && value.tool_quality.window_hours != null ? ` calls in the last ${value.tool_quality.window_hours}h.` : ' recent calls.'}`
+            : value.tool_quality.sampling_mode === 'window_hours' && value.tool_quality.window_hours != null
+              ? `No tool quality samples were recorded in the last ${value.tool_quality.window_hours}h.`
+              : 'No recent tool quality samples were recorded.'}
           tone=${value.tool_quality.total > 0 ? toneForToolSuccess(value.tool_quality.success_rate) : 'neutral'}
         />
         <${SummaryCard}

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { LogEntry } from '../api/dashboard'
-import { failureEnvelope, mergeLogEntries } from './logs'
+import { failureEnvelope, mergeLogEntries, renderLogMessage } from './logs'
 
 function entry(seq: number, overrides: Partial<LogEntry> = {}): LogEntry {
   return {
@@ -90,5 +90,22 @@ describe('failureEnvelope', () => {
         }),
       ),
     ).toBeNull()
+  })
+})
+
+describe('renderLogMessage', () => {
+  it('interpolates structured printf-style placeholders from details', () => {
+    expect(
+      renderLogMessage(
+        entry(9, {
+          module: 'oas:agent_tools',
+          message: 'tool %s: correction_pipeline fixed %d field(s)',
+          details: {
+            tool: 'keeper_github',
+            fixes: 2,
+          },
+        }),
+      ),
+    ).toBe('tool keeper_github: correction_pipeline fixed 2 field(s)')
   })
 })

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -99,6 +99,29 @@ function detailLabel(details: Record<string, unknown> | null, key: string): stri
   return null
 }
 
+function interpolateStructuredMessage(
+  message: string,
+  details: Record<string, unknown> | null,
+): string {
+  if (!details || !/%[sd]/.test(message)) return message
+  const replacements = [
+    detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool'),
+    detailLabel(details, 'fixes'),
+    detailLabel(details, 'count'),
+    detailLabel(details, 'client_name'),
+    detailLabel(details, 'phase'),
+    detailLabel(details, 'request_id'),
+    detailLabel(details, 'session_id'),
+  ].filter((value): value is string => !!value)
+
+  let rendered = message
+  for (const value of replacements) {
+    if (!/%[sd]/.test(rendered)) break
+    rendered = rendered.replace(/%[sd]/, value)
+  }
+  return rendered
+}
+
 function nestedRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null
   return value as Record<string, unknown>
@@ -137,6 +160,13 @@ export function failureEnvelope(entry: LogEntry): FailureEnvelope | null {
     operator_action: nestedString(envelope.operator_action),
     evidence_ref: nestedRecord(envelope.evidence_ref),
   }
+}
+
+export function renderLogMessage(entry: LogEntry): string {
+  const details = entryDetails(entry)
+  const message = interpolateStructuredMessage(entry.message, details)
+  const failure = failureEnvelope(entry)
+  return failure ? `${message} (${failure.summary})` : message
 }
 
 function sourceTone(source: string): string {
@@ -197,12 +227,14 @@ function renderLogRow(entry: LogEntry) {
   const source = entry.source || 'structured'
   const details = entryDetails(entry)
   const clientName = detailLabel(details, 'client_name')
-  const toolName = detailLabel(details, 'tool_name')
+  const toolName = detailLabel(details, 'tool_name') ?? detailLabel(details, 'tool')
   const phase = detailLabel(details, 'phase')
   const requestId = detailLabel(details, 'request_id')
   const sessionId = detailLabel(details, 'session_id')
+  const fixes = detailLabel(details, 'fixes')
   const failure = failureEnvelope(entry)
   const sourceClass = sourceTone(source)
+  const renderedMessage = renderLogMessage(entry)
   let backgroundClass = 'bg-[rgba(255,255,255,0.02)]'
   if (level === 'ERROR') {
     backgroundClass = 'bg-[rgba(224,80,80,0.08)]'
@@ -240,6 +272,9 @@ function renderLogRow(entry: LogEntry) {
         ${toolName
           ? html`<span class="inline-flex items-center gap-1 rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px]"><span class="font-mono font-bold ${toolCategory(toolName).color}">${toolCategory(toolName).icon}</span><span class="text-[var(--text-muted)]">${toolName}</span></span>`
           : null}
+        ${fixes
+          ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">fixes ${fixes}</span>`
+          : null}
         ${phase
           ? html`<span class="rounded-full border border-[var(--white-10)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">${phase}</span>`
           : null}
@@ -261,7 +296,7 @@ function renderLogRow(entry: LogEntry) {
       </div>
       <div
         class="text-[12px] leading-relaxed text-[var(--text-body)]"
-        title=${failure ? `${entry.message}\n${failure.summary}` : entry.message}
+        title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}
         style=${{
           display: '-webkit-box',
           overflow: 'hidden',
@@ -269,7 +304,7 @@ function renderLogRow(entry: LogEntry) {
           WebkitLineClamp: 2,
         }}
       >
-        ${failure ? `${entry.message} (${failure.summary})` : entry.message}
+        ${renderedMessage}
       </div>
     </div>
   `

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -473,7 +473,12 @@ function ToolCallHealthPanel() {
 
   return html`
     <div>
-      <${HomeSectionHeader} label="도구 호출" linkLabel="품질 분석 ->" linkTab="monitoring" linkParams=${{ section: 'tool-quality' }} />
+      <${HomeSectionHeader}
+        label="도구 호출"
+        linkLabel="품질 분석 ->"
+        linkTab="monitoring"
+        linkParams=${{ section: 'fleet-health', view: 'tool-quality' }}
+      />
       <div class="grid grid-cols-4 gap-3 max-[640px]:grid-cols-2">
         <${CompactKpi} value=${health.tool_calls.toLocaleString()} label=${`호출 (${health.window_hours}h)`} />
         <${CompactKpi} value=${successRate != null ? `${successRate.toFixed(1)}%` : '-'} valueClass=${successColor} label="성공률" />

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -178,7 +178,7 @@ function labelPills(labels: Record<string, string>): ReturnType<typeof html> | n
         title="View tool quality"
         onClick=${(e: Event) => {
           e.stopPropagation()
-          navigate('monitoring', { section: 'tool-quality', tool: v })
+          navigate('monitoring', { section: 'fleet-health', view: 'tool-quality', tool: v })
         }}
       >${k}=${v}</button>`
     }

--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -2,6 +2,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ToolQualityResponse } from '../api/dashboard'
 
 vi.setConfig({
   testTimeout: 40000,
@@ -9,6 +10,10 @@ vi.setConfig({
 })
 
 const payload = {
+  generated_at: '2026-04-14T00:00:00Z',
+  sampling_mode: 'window_hours',
+  sample_limit: null,
+  window_hours: 24,
   total: 22,
   success: 21,
   failure: 1,
@@ -40,6 +45,22 @@ async function flushUi(): Promise<void> {
   })
 }
 
+async function loadPanel(mocks?: {
+  fetchToolQuality?: (opts?: { n?: number; windowHours?: number; signal?: AbortSignal }) => Promise<ToolQualityResponse>
+}) {
+  vi.resetModules()
+  if (mocks?.fetchToolQuality) {
+    vi.doMock('../api/dashboard', async () => {
+      const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
+      return {
+        ...actual,
+        fetchToolQuality: mocks.fetchToolQuality,
+      }
+    })
+  }
+  return import('./tool-quality-panel')
+}
+
 describe('ToolQualityPanel', () => {
   let container: HTMLDivElement
   const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
@@ -59,7 +80,9 @@ describe('ToolQualityPanel', () => {
     container.remove()
     vi.unstubAllGlobals()
     vi.clearAllMocks()
+    vi.clearAllTimers()
     vi.resetModules()
+    vi.doUnmock('../api/dashboard')
     vi.useRealTimers()
     if (originalVisibility) {
       Object.defineProperty(document, 'visibilityState', originalVisibility)
@@ -67,12 +90,8 @@ describe('ToolQualityPanel', () => {
   })
 
   it('auto-refreshes tool quality while visible', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => payload,
-    })
-    vi.stubGlobal('fetch', fetchMock)
-    const { ToolQualityPanel } = await import('./tool-quality-panel')
+    const fetchToolQuality = vi.fn().mockResolvedValue(payload)
+    const { ToolQualityPanel } = await loadPanel({ fetchToolQuality })
 
     await act(async () => {
       render(html`<${ToolQualityPanel} />`, container)
@@ -80,14 +99,16 @@ describe('ToolQualityPanel', () => {
     })
     await flushUi()
 
-    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(1)
     expect(container.textContent).toContain('30초 자동 갱신')
     expect(container.textContent).toContain('95.5%')
+    expect(container.textContent).toContain('최근 24시간 기준 집계')
+    expect(container.textContent).toContain('Window Calls')
 
-    await vi.advanceTimersByTimeAsync(30_000)
+    vi.advanceTimersByTime(30_000)
     await flushUi()
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(2)
   })
 
   it('normalizes missing tool metric fields before rendering', async () => {
@@ -189,7 +210,7 @@ describe('ToolQualityPanel', () => {
       await Promise.resolve()
     })
 
-    await vi.advanceTimersByTimeAsync(30_000)
+    vi.advanceTimersByTime(30_000)
     await flushUi()
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -246,7 +267,7 @@ describe('ToolQualityPanel', () => {
       get: () => 'hidden',
     })
 
-    await vi.advanceTimersByTimeAsync(35_000)
+    vi.advanceTimersByTime(35_000)
     await flushUi()
 
     expect(container.textContent).toContain('request timeout (35s)')

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -14,6 +14,8 @@ import {
 } from './fleet-data-core'
 import { route } from '../router'
 
+const TOOL_QUALITY_WINDOW_HOURS = 24
+
 interface ToolStat {
   name: string
   calls: number
@@ -41,13 +43,24 @@ interface HourlyPoint {
   success_rate: number
 }
 
-type ToolQualityData = Omit<ToolQualityResponse, 'by_tool'> & {
+type ToolQualityData = Omit<
+  ToolQualityResponse,
+  'by_tool' | 'generated_at' | 'sampling_mode' | 'sample_limit' | 'window_hours'
+> & {
+  generated_at: string | null
+  sampling_mode: string
+  sample_limit: number
+  window_hours: number | null
   by_tool: ToolStat[]
 }
 
 function normalizeToolQualityData(json: ToolQualityResponse): ToolQualityData {
   return {
     ...json,
+    generated_at: json.generated_at ?? null,
+    sampling_mode: json.sampling_mode ?? 'recent_n',
+    sample_limit: json.sample_limit ?? json.total,
+    window_hours: json.window_hours ?? null,
     by_tool: json.by_tool.map(t => ({
       ...t,
       output_truncated_count: t.output_truncated_count ?? 0,
@@ -71,7 +84,7 @@ const error = sharedToolQualityError
  * The underlying fetch is shared across panels via fleet-data-core.
  */
 export async function refreshToolQuality(): Promise<void> {
-  await refreshSharedToolQuality()
+  await refreshSharedToolQuality({ windowHours: TOOL_QUALITY_WINDOW_HOURS })
 }
 
 function handleRefreshToolQualityClick() {
@@ -231,7 +244,11 @@ function FailureList({ categories }: { categories: FailureCategory[] }) {
 export function ToolQualityPanel() {
   useEffect(() => {
     const lifecycleController = new AbortController()
-    const runRefresh = () => refreshSharedToolQuality({ signal: lifecycleController.signal })
+    const runRefresh = () =>
+      refreshSharedToolQuality({
+        signal: lifecycleController.signal,
+        windowHours: TOOL_QUALITY_WINDOW_HOURS,
+      })
 
     void runRefresh()
     const disposeAutoRefresh = setupVisibleAutoRefresh(() => {
@@ -254,7 +271,14 @@ export function ToolQualityPanel() {
   return html`
     <div class="flex flex-col gap-4 p-4">
       <div class="flex items-center justify-between">
-        <h2 class="text-sm font-medium">도구 호출 품질</h2>
+        <div>
+          <h2 class="text-sm font-medium">도구 호출 품질</h2>
+          <div class="text-[10px] text-[var(--text-dim)]">
+            ${d.sampling_mode === 'recent_n'
+              ? `최근 ${d.sample_limit.toLocaleString()}건 기준 집계`
+              : `최근 ${(d.window_hours ?? TOOL_QUALITY_WINDOW_HOURS).toLocaleString()}시간 기준 집계`}
+          </div>
+        </div>
         <button
           class="text-[10px] px-2 py-0.5 rounded bg-[var(--bg-subtle)] text-[var(--text-dim)] hover:text-[var(--text)]"
           onClick=${handleRefreshToolQualityClick}
@@ -270,7 +294,9 @@ export function ToolQualityPanel() {
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-[var(--text)]">${d.total.toLocaleString()}</div>
-          <div class="text-[9px] text-[var(--text-dim)] uppercase">Total Calls</div>
+          <div class="text-[9px] text-[var(--text-dim)] uppercase">
+            ${d.sampling_mode === 'recent_n' ? 'Sampled Calls' : 'Window Calls'}
+          </div>
         </div>
         <div class="text-center">
           <div class="text-lg font-mono text-red-400/80">${d.failure}</div>

--- a/lib/dashboard/dashboard_http_tool_quality.ml
+++ b/lib/dashboard/dashboard_http_tool_quality.ml
@@ -149,15 +149,44 @@ let render_rate_table ~field table =
   |> List.sort (fun (a, _) (b, _) -> Int.compare b a)
   |> List.map snd
 
-let aggregate ?(n = 5000) () : Yojson.Safe.t =
-  let records = Keeper_tool_call_log.read_recent ~n () in
+let empty_summary ~window_hours ~n ~sampling_mode =
+  `Assoc
+    [ ("generated_at", `String (Types.now_iso ()))
+    ; ("sampling_mode", `String sampling_mode)
+    ; ( "sample_limit",
+        match sampling_mode with
+        | "recent_n" -> `Int n
+        | _ -> `Null )
+    ; ( "window_hours",
+        match window_hours with
+        | Some hours -> `Float hours
+        | None -> `Null )
+    ; ("total", `Int 0)
+    ; ("success", `Int 0)
+    ; ("failure", `Int 0)
+    ; ("success_rate", `Float 0.0)
+    ; ("by_tool", `List [])
+    ; ("by_keeper", `List [])
+    ; ("by_model", `List [])
+    ; ("by_lane", `List [])
+    ; ("by_thinking_mode", `List [])
+    ; ("by_tool_choice", `List [])
+    ; ("failure_categories", `List [])
+    ; ("hourly_trend", `List [])
+    ]
+
+let aggregate ?(n = 5000) ?window_hours () : Yojson.Safe.t =
+  let records, sampling_mode, window_hours =
+    match window_hours with
+    | Some hours when hours > 0.0 ->
+      ( Keeper_tool_call_log.read_window ~window_hours:hours ()
+      , "window_hours"
+      , Some hours )
+    | _ ->
+      (Keeper_tool_call_log.read_recent ~n (), "recent_n", None)
+  in
   if records = [] then
-    `Assoc [("total", `Int 0); ("success", `Int 0); ("failure", `Int 0);
-            ("success_rate", `Float 0.0);
-            ("by_tool", `List []); ("by_keeper", `List []);
-            ("by_model", `List []); ("by_lane", `List []);
-            ("by_thinking_mode", `List []); ("by_tool_choice", `List []);
-            ("failure_categories", `List []); ("hourly_trend", `List [])]
+    empty_summary ~window_hours ~n ~sampling_mode
   else
   let total = ref 0 in
   let success = ref 0 in
@@ -345,6 +374,16 @@ let aggregate ?(n = 5000) () : Yojson.Safe.t =
     |> List.map snd
   in
   `Assoc [
+    ("generated_at", `String (Types.now_iso ()));
+    ("sampling_mode", `String sampling_mode);
+    ( "sample_limit",
+      match sampling_mode with
+      | "recent_n" -> `Int n
+      | _ -> `Null );
+    ( "window_hours",
+      match window_hours with
+      | Some hours -> `Float hours
+      | None -> `Null );
     ("total", `Int total_n);
     ("success", `Int success_n);
     ("failure", `Int (total_n - success_n));

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1502,6 +1502,9 @@ let run_turn
                   tool_choice)
                 ~thinking_enabled:(Keeper_config.keeper_enable_thinking ())
                 ?thinking_budget:current_params.thinking_budget
+                ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                ~session_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+                ~turn
                 ();
               (* Tool disclosure telemetry: emitted after all allow-list rewrites
            (last-turn intersect, max_tools cap) so that

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -145,32 +145,83 @@ let role_of_string = function
     Log.Misc.warn "keeper_context_core: unknown role %S, defaulting to User" unknown;
     Agent_sdk.Types.User
 
+let content_blocks_to_json
+    (blocks : Agent_sdk.Types.content_block list) : Yojson.Safe.t =
+  `List (List.map Agent_sdk.Api.content_block_to_json blocks)
+
+let content_blocks_of_json
+    (json : Yojson.Safe.t) : Agent_sdk.Types.content_block list option =
+  let open Yojson.Safe.Util in
+  match json |> member "content_blocks" with
+  | `List blocks ->
+      let parsed =
+        List.filter_map Agent_sdk.Api.content_block_of_json blocks
+      in
+      if List.length parsed = List.length blocks then Some parsed else None
+  | _ -> None
+
+let string_field_opt key value =
+  match value with
+  | Some text -> [ (key, `String text) ]
+  | None -> []
+
 let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
   let m = Inference_utils.sanitize_message_utf8 m in
+  let tool_call_id =
+    match m.tool_call_id with
+    | Some _ as explicit -> explicit
+    | None ->
+        (match m.role with
+         | Agent_sdk.Types.Tool ->
+             List.find_map
+               (function
+                 | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+                 | _ -> None)
+               m.content
+         | _ -> None)
+  in
   let base = [
     ("role", `String (role_to_string m.role));
     ("content", `String (text_of_message m));
+    ("content_blocks", content_blocks_to_json m.content);
   ] in
-  let with_tool_id = match m.role with
-    | Agent_sdk.Types.Tool ->
-      let tool_id = List.find_map (function
-        | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
-        | _ -> None) m.content in
-      (match tool_id with Some id -> ("tool_call_id", `String id) :: base | None -> base)
-    | _ -> base
-  in
-  `Assoc with_tool_id
+  `Assoc
+    (base
+     @ string_field_opt "name" m.name
+     @ string_field_opt "tool_call_id" tool_call_id)
 
 let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
-  let text = json |> member "content" |> to_string |> Inference_utils.sanitize_text_utf8 in
-  match role with
-  | Agent_sdk.Types.Tool ->
-    let tool_use_id = json |> member "tool_call_id" |> to_string_option |> Option.value ~default:"masc-tool" in
-    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id; content = text; is_error = false; json = None }]; name = None; tool_call_id = None }
-  | _ ->
-    { Agent_sdk.Types.role; content = [Agent_sdk.Types.Text text]; name = None; tool_call_id = None }
+  let text =
+    match json |> member "content" |> to_string_option with
+    | Some value -> Inference_utils.sanitize_text_utf8 value
+    | None -> ""
+  in
+  let content =
+    match content_blocks_of_json json with
+    | Some blocks ->
+        if blocks <> [] then blocks else
+        (* Legacy checkpoints stored only flattened text + role. For Tool
+           messages that means the original assistant ToolUse block is gone,
+           so rebuilding a structured ToolResult here creates an invalid
+           orphaned pair on the next Anthropic request. Fall back to plain
+           text so old checkpoints remain readable without breaking turns. *)
+        [ Agent_sdk.Types.Text text ]
+    | None ->
+        [ Agent_sdk.Types.Text text ]
+  in
+  Inference_utils.sanitize_message_utf8
+    {
+      Agent_sdk.Types.role;
+      content;
+      name =
+        (json |> member "name" |> to_string_option
+         |> Option.map Inference_utils.sanitize_text_utf8);
+      tool_call_id =
+        (json |> member "tool_call_id" |> to_string_option
+         |> Option.map Inference_utils.sanitize_text_utf8);
+    }
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -414,7 +414,13 @@ let make_hooks
             ~keeper_name:(!meta_ref).name ()
         in
         let result_bytes = if original_bytes > 0 then original_bytes else out_len in
-        let lane, tool_choice, thinking_enabled, thinking_budget =
+        let ( lane
+            , tool_choice
+            , thinking_enabled
+            , thinking_budget
+            , trace_id
+            , session_id
+            , turn ) =
           Keeper_tool_call_log.get_turn_context
             ~keeper_name:(!meta_ref).name ()
         in
@@ -426,6 +432,7 @@ let make_hooks
              ~model:(let m = (!meta_ref).runtime.usage.last_model_used in
                      if m = "" then (!meta_ref).cascade_name else m)
              ?lane ?tool_choice ?thinking_enabled ?thinking_budget
+             ?trace_id ?session_id ?turn
              ~result_bytes ?truncated_to ()
          with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
         (try

--- a/lib/keeper_tool_call_log.ml
+++ b/lib/keeper_tool_call_log.ml
@@ -27,6 +27,9 @@ type turn_context = {
   tool_choice: string option;
   thinking_enabled: bool option;
   thinking_budget: int option;
+  trace_id: string option;
+  session_id: string option;
+  turn: int option;
 }
 
 let empty_turn_context = {
@@ -34,6 +37,9 @@ let empty_turn_context = {
   tool_choice = None;
   thinking_enabled = None;
   thinking_budget = None;
+  trace_id = None;
+  session_id = None;
+  turn = None;
 }
 
 let pending_turn_context : (string, turn_context) Hashtbl.t = Hashtbl.create 8
@@ -47,9 +53,17 @@ let consume_truncation_info ~keeper_name () =
   | None -> (0, None)
 
 let set_turn_context ~keeper_name ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget () =
+    ?thinking_budget ?trace_id ?session_id ?turn () =
   Hashtbl.replace pending_turn_context keeper_name
-    { lane; tool_choice; thinking_enabled; thinking_budget }
+    {
+      lane;
+      tool_choice;
+      thinking_enabled;
+      thinking_budget;
+      trace_id;
+      session_id;
+      turn;
+    }
 
 let get_turn_context ~keeper_name () =
   let ctx =
@@ -57,7 +71,13 @@ let get_turn_context ~keeper_name () =
     | Some ctx -> ctx
     | None -> empty_turn_context
   in
-  (ctx.lane, ctx.tool_choice, ctx.thinking_enabled, ctx.thinking_budget)
+  ( ctx.lane
+  , ctx.tool_choice
+  , ctx.thinking_enabled
+  , ctx.thinking_budget
+  , ctx.trace_id
+  , ctx.session_id
+  , ctx.turn )
 
 let store_ref : Dated_jsonl.t option ref = ref None
 
@@ -87,13 +107,19 @@ let input_to_json (input : Yojson.Safe.t) : Yojson.Safe.t =
 let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
     ~(output_text : string) ~(success : bool) ~(duration_ms : float)
     ?(model : string = "") ?lane ?tool_choice ?thinking_enabled
-    ?thinking_budget ?result_bytes ?truncated_to () =
+    ?thinking_budget ?trace_id ?session_id ?turn ?result_bytes ?truncated_to () =
   if Observability_redact.is_denied_tool ~tool_name then ()
   else
     match !store_ref with
     | None -> ()
     | Some store ->
-      let ctx_lane, ctx_tool_choice, ctx_thinking_enabled, ctx_thinking_budget =
+      let ( ctx_lane
+          , ctx_tool_choice
+          , ctx_thinking_enabled
+          , ctx_thinking_budget
+          , ctx_trace_id
+          , ctx_session_id
+          , ctx_turn ) =
         get_turn_context ~keeper_name ()
       in
       let lane = match lane with Some _ -> lane | None -> ctx_lane in
@@ -110,6 +136,11 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
         | Some _ -> thinking_budget
         | None -> ctx_thinking_budget
       in
+      let trace_id = match trace_id with Some _ -> trace_id | None -> ctx_trace_id in
+      let session_id =
+        match session_id with Some _ -> session_id | None -> ctx_session_id
+      in
+      let turn = match turn with Some _ -> turn | None -> ctx_turn in
       let model_field =
         if model = "" then [] else [("model", `String model)]
       in
@@ -137,6 +168,18 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
         | Some value -> [("thinking_budget", `Int value)]
         | None -> []
       in
+      let trace_id_field = match trace_id with
+        | Some value -> [("trace_id", `String value)]
+        | None -> []
+      in
+      let session_id_field = match session_id with
+        | Some value -> [("session_id", `String value)]
+        | None -> []
+      in
+      let turn_field = match turn with
+        | Some value -> [("turn", `Int value)]
+        | None -> []
+      in
       let safe_input = input_to_json (Observability_redact.redact_json_value input) in
       let safe_output = Observability_redact.redact_preview ~max_len:max_output_len output_text in
       let json =
@@ -150,6 +193,7 @@ let log_call ~keeper_name ~tool_name ~(input : Yojson.Safe.t)
           ; ("duration_ms", `Float duration_ms)
           ] @ model_field @ lane_field @ tool_choice_field
             @ thinking_enabled_field @ thinking_budget_field
+            @ trace_id_field @ session_id_field @ turn_field
             @ result_bytes_field @ truncated_to_field)
       in
       (* Sanitize UTF-8 before persisting.  Tool output may contain invalid
@@ -194,6 +238,50 @@ let read_recent ?keeper_name ?(n = 100) () : Yojson.Safe.t list =
     else
       let start = if !total <= n then 0 else !pos mod n in
       List.init count (fun i -> buf.((start + i) mod n))
+
+let iso_date_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+
+let ts_of_entry (json : Yojson.Safe.t) : float option =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt "ts" fields with
+      | Some (`Float f) -> Some f
+      | Some (`Int i) -> Some (Float.of_int i)
+      | _ -> None)
+  | _ -> None
+
+let read_window ?keeper_name ~(window_hours : float) () : Yojson.Safe.t list =
+  if window_hours <= 0.0 then []
+  else
+    match !store_ref with
+    | None -> []
+    | Some store ->
+        let now = Time_compat.now () in
+        let since_ts = now -. (window_hours *. 3600.0) in
+        let since_date = iso_date_of_unix since_ts in
+        let until_date = iso_date_of_unix now in
+        let keeper_matches name json =
+          match Safe_ops.json_string_opt "keeper" json with
+          | Some k -> String.equal k name
+          | None -> false
+        in
+        Dated_jsonl.read_range store ~since:since_date ~until:until_date
+        |> List.filter (fun json ->
+               let in_window =
+                 match ts_of_entry json with
+                 | Some ts -> ts >= since_ts
+                 | None -> false
+               in
+               in_window
+               &&
+               match keeper_name with
+               | None -> true
+               | Some name -> keeper_matches name json)
 
 let read_latest ?keeper_name () : Yojson.Safe.t option =
   let keeper_matches name json =

--- a/lib/keeper_tool_call_log.mli
+++ b/lib/keeper_tool_call_log.mli
@@ -32,6 +32,9 @@ val set_turn_context :
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
   ?thinking_budget:int ->
+  ?trace_id:string ->
+  ?session_id:string ->
+  ?turn:int ->
   unit ->
   unit
 (** [set_turn_context ...] stores the current effective turn policy for
@@ -41,8 +44,10 @@ val get_turn_context :
   keeper_name:string ->
   unit ->
   string option * string option * bool option * int option
-(** Returns [(lane, tool_choice, thinking_enabled, thinking_budget)] for
-    the keeper, or [None] values when no turn context has been recorded. *)
+  * string option * string option * int option
+(** Returns [(lane, tool_choice, thinking_enabled, thinking_budget, trace_id,
+    session_id, turn)] for the keeper, or [None] values when no turn context
+    has been recorded. *)
 
 val init : base_path:string -> unit
 (** [init ~base_path] creates the Dated_jsonl store. Call once at startup. *)
@@ -59,6 +64,9 @@ val log_call :
   ?tool_choice:string ->
   ?thinking_enabled:bool ->
   ?thinking_budget:int ->
+  ?trace_id:string ->
+  ?session_id:string ->
+  ?turn:int ->
   ?result_bytes:int ->
   ?truncated_to:int ->
   unit ->
@@ -78,6 +86,14 @@ val read_recent :
   Yojson.Safe.t list
 (** [read_recent ?keeper_name ?n ()] returns the [n] most recent entries,
     optionally filtered by keeper name. Default [n=100]. *)
+
+val read_window :
+  ?keeper_name:string ->
+  window_hours:float ->
+  unit ->
+  Yojson.Safe.t list
+(** [read_window ?keeper_name ~window_hours ()] returns entries within the
+    trailing [window_hours]. Non-positive windows return [[]]. *)
 
 val read_latest :
   ?keeper_name:string ->

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -119,14 +119,7 @@ let () =
   Keeper_exec_tools.on_keeper_tool_call :=
     (fun ~tool_name ~success ~duration_ms ->
        Tool_registry.record_call ~source:Keeper_internal
-         ~tool_name ~success ~duration_ms ();
-       Tool_metrics_persist.enqueue {
-         Tool_result.success; tool_name;
-         duration_ms = Float.of_int duration_ms;
-         data = `Null;
-       };
-       Tool_usage_log.log_call ~tool_name ~success
-         ~caller:(Some "keeper_internal"));
+         ~tool_name ~success ~duration_ms ());
   (* Wire tag-based dispatch for keeper masc_* tools.
      Breaks the same Config dependency cycle as on_keeper_tool_call.
      See #4579: keeper_exec_tools uses handler registry (Tool_Board only),

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -369,8 +369,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      with structured metadata before metrics/OTEL hooks see them. *)
   Tool_output_validation.install ();
   (* Tool metrics JSONL persistence: flush buffered records to disk periodically.
-     Also registers a post-hook so every tool call is enqueued for persistence. *)
+     The shared post-hook is the canonical write path for persisted tool
+     metrics so keeper-internal calls are counted exactly once. *)
   Tool_dispatch.register_post_hook (fun result ->
+    Tool_metrics.record result;
     Tool_metrics_persist.enqueue result;
     result);
   Tool_metrics_persist.start_flush_fiber ~sw ~clock

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -337,7 +337,18 @@ let rec add_routes ~sw ~clock router =
            in
            max 1 (min 50000 raw)
          in
-         let json = Dashboard_http_tool_quality.aggregate ~n () in
+         let window_hours =
+           match Server_utils.query_param req "window_hours" with
+           | Some s ->
+             (try
+                let value = float_of_string s in
+                Some (max 0.1 (min 168.0 value))
+              with
+              | Eio.Cancel.Cancelled _ as e -> raise e
+              | _ -> None)
+           | None -> None
+         in
+         let json = Dashboard_http_tool_quality.aggregate ~n ?window_hours () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/test/test_keeper_tool_call_log.ml
+++ b/test/test_keeper_tool_call_log.ml
@@ -130,6 +130,9 @@ let test_turn_context_fields_stored () =
       ~tool_choice:"required"
       ~thinking_enabled:false
       ~thinking_budget:1024
+      ~trace_id:"trace-k"
+      ~session_id:"trace-k"
+      ~turn:7
       ();
     Keeper_tool_call_log.log_call
       ~keeper_name:"k" ~tool_name:"masc_status"
@@ -149,7 +152,15 @@ let test_turn_context_fields_stored () =
        | `Bool false -> true
        | _ -> false);
     Alcotest.(check int) "thinking_budget field" 1024
-      (Safe_ops.json_int ~default:0 "thinking_budget" entry))
+      (Safe_ops.json_int ~default:0 "thinking_budget" entry);
+    Alcotest.(check (option string)) "trace_id field"
+      (Some "trace-k")
+      (Safe_ops.json_string_opt "trace_id" entry);
+    Alcotest.(check (option string)) "session_id field"
+      (Some "trace-k")
+      (Safe_ops.json_string_opt "session_id" entry);
+    Alcotest.(check int) "turn field" 7
+      (Safe_ops.json_int ~default:0 "turn" entry))
 
 let test_turn_context_fields_absent_without_context () =
   with_tmp_log (fun () ->
@@ -172,6 +183,18 @@ let test_turn_context_fields_absent_without_context () =
        | _ -> false);
     Alcotest.(check bool) "thinking_budget absent" true
       (match Yojson.Safe.Util.member "thinking_budget" entry with
+       | `Null -> true
+       | _ -> false);
+    Alcotest.(check bool) "trace_id absent" true
+      (match Yojson.Safe.Util.member "trace_id" entry with
+       | `Null -> true
+       | _ -> false);
+    Alcotest.(check bool) "session_id absent" true
+      (match Yojson.Safe.Util.member "session_id" entry with
+       | `Null -> true
+       | _ -> false);
+    Alcotest.(check bool) "turn absent" true
+      (match Yojson.Safe.Util.member "turn" entry with
        | `Null -> true
        | _ -> false))
 
@@ -198,6 +221,11 @@ let test_dashboard_aggregate_groups_runtime_fields () =
       ~tool_choice:"auto"
       ~thinking_enabled:true ~thinking_budget:4096 ();
     let summary = Dashboard_http_tool_quality.aggregate ~n:10 () in
+    Alcotest.(check (option string)) "sampling mode present"
+      (Some "recent_n")
+      (Safe_ops.json_string_opt "sampling_mode" summary);
+    Alcotest.(check int) "sample limit echoed" 10
+      (Safe_ops.json_int ~default:0 "sample_limit" summary);
     let by_model = Yojson.Safe.Util.member "by_model" summary in
     let by_lane = Yojson.Safe.Util.member "by_lane" summary in
     let by_thinking = Yojson.Safe.Util.member "by_thinking_mode" summary in
@@ -255,6 +283,49 @@ let test_dashboard_hourly_trend_numeric_ts () =
       (Safe_ops.json_int ~default:0 "calls" bucket);
     Alcotest.(check int) "hour bucket success" 1
       (Safe_ops.json_int ~default:0 "success" bucket))
+
+let test_dashboard_aggregate_window_hours () =
+  with_tmp_log_dir (fun dir ->
+    let store =
+      Dated_jsonl.create
+        ~base_dir:(Filename.concat dir ".masc/tool_calls")
+        ()
+    in
+    let now = Unix.gettimeofday () in
+    let inside = now -. (30.0 *. 60.0) in
+    let outside = now -. (48.0 *. 3600.0) in
+    Dated_jsonl.append store
+      (`Assoc
+         [ ("ts", `Float inside)
+         ; ("keeper", `String "k")
+         ; ("tool", `String "masc_status")
+         ; ("input", `Assoc [])
+         ; ("output", `String "ok")
+         ; ("success", `Bool true)
+         ; ("duration_ms", `Float 2.0)
+         ]);
+    Dated_jsonl.append store
+      (`Assoc
+         [ ("ts", `Float outside)
+         ; ("keeper", `String "k")
+         ; ("tool", `String "masc_status")
+         ; ("input", `Assoc [])
+         ; ("output", `String "error: {\"ok\":false,\"error\":\"stale\"}")
+         ; ("success", `Bool false)
+         ; ("duration_ms", `Float 5.0)
+         ]);
+    let summary = Dashboard_http_tool_quality.aggregate ~n:10 ~window_hours:24.0 () in
+    Alcotest.(check (option string)) "window sampling mode"
+      (Some "window_hours")
+      (Safe_ops.json_string_opt "sampling_mode" summary);
+    Alcotest.(check int) "window total" 1
+      (Safe_ops.json_int ~default:0 "total" summary);
+    Alcotest.(check (option int)) "sample limit omitted"
+      None
+      (Safe_ops.json_int_opt "sample_limit" summary);
+    Alcotest.(check (option (float 0.0001))) "window echoed"
+      (Some 24.0)
+      (Safe_ops.json_float_opt "window_hours" summary))
 
 (* ── UTF-8 sanitization ────────────────────────────── *)
 
@@ -330,6 +401,8 @@ let () =
             test_dashboard_aggregate_groups_runtime_fields
         ; eio_test "dashboard hourly trend buckets numeric ts"
             test_dashboard_hourly_trend_numeric_ts
+        ; eio_test "dashboard aggregate window hours"
+            test_dashboard_aggregate_window_hours
         ] )
     ; ( "utf8_sanitize",
         [ eio_test "invalid UTF-8 bytes scrubbed before persist"

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1043,6 +1043,16 @@ let tool_result_msg ?(id = "tool-1") text : Agent_sdk.Types.message =
     tool_call_id = None;
   }
 
+let tool_use_msg ?(id = "tool-1") ?(name = "keeper_fs_read") input
+    : Agent_sdk.Types.message =
+  {
+    Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
+    content =
+      [ Agent_sdk.Types.ToolUse { id; name; input } ];
+    name = None;
+    tool_call_id = None;
+  }
+
 let test_keeper_checkpoint_store_oas_roundtrip () =
   let base_dir = temp_dir "keeper_oas_store" in
   Fun.protect
@@ -1169,6 +1179,79 @@ let test_keeper_checkpoint_legacy_fallback () =
           Alcotest.(check string) "legacy message restored" "legacy-only"
             (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
       | None -> Alcotest.fail "expected legacy fallback context")
+
+let test_keeper_checkpoint_legacy_roundtrip_preserves_tool_pairs () =
+  let base_dir = temp_dir "keeper_legacy_tool_pair_roundtrip" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-legacy-tool-pair" in
+      let session =
+        Keeper_exec_context.create_session ~session_id:trace_id ~base_dir
+      in
+      let tool_id = "call_legacy_pair" in
+      let legacy_ctx =
+        Keeper_exec_context.create ~system_prompt:"legacy tool history" ~max_tokens:4096
+        |> fun ctx ->
+        Keeper_exec_context.append_many ctx
+          [
+            Agent_sdk.Types.user_msg "read the file";
+            tool_use_msg ~id:tool_id (`Assoc [ ("path", `String "README.md") ]);
+            tool_result_msg ~id:tool_id "contents";
+            Agent_sdk.Types.assistant_msg "done";
+          ]
+      in
+      ignore (Keeper_exec_context.save_checkpoint session legacy_ctx ~generation:2);
+      let (_session, loaded_opt) =
+        Keeper_exec_context.load_context_from_checkpoint
+          ~max_checkpoint_messages:120
+          ~trace_id
+          ~primary_model_max_tokens:1024 ~base_dir
+      in
+      match loaded_opt with
+      | None -> Alcotest.fail "expected legacy structured roundtrip context"
+      | Some loaded ->
+          Alcotest.(check int) "all messages restored" 4
+            (List.length loaded.messages);
+          (match List.nth loaded.messages 1 with
+           | { Agent_sdk.Types.role = Agent_sdk.Types.Assistant;
+               content =
+                 [ Agent_sdk.Types.ToolUse { id; name; input } ];
+               _ } ->
+               Alcotest.(check string) "tool use id preserved" tool_id id;
+               Alcotest.(check string) "tool use name preserved"
+                 "keeper_fs_read" name;
+               Alcotest.(check string) "tool use input preserved"
+                 {|{"path":"README.md"}|}
+                 (Yojson.Safe.to_string input)
+           | _ -> Alcotest.fail "expected assistant tool_use after roundtrip");
+          (match List.nth loaded.messages 2 with
+           | { Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+               content =
+                 [ Agent_sdk.Types.ToolResult { tool_use_id; content; _ } ];
+               _ } ->
+               Alcotest.(check string) "tool result id preserved" tool_id
+                 tool_use_id;
+               Alcotest.(check string) "tool result content preserved"
+                 "contents" content
+           | _ -> Alcotest.fail "expected tool result after roundtrip"))
+
+let test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text () =
+  let json =
+    `Assoc
+      [
+        ("role", `String "tool");
+        ("content", `String "legacy tool output");
+        ("tool_call_id", `String "call_old");
+      ]
+  in
+  match Masc_mcp.Keeper_exec_context.message_of_json json with
+  | { Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+      content = [ Agent_sdk.Types.Text text ];
+      _ } ->
+      Alcotest.(check string) "legacy tool text preserved"
+        "legacy tool output" text
+  | _ -> Alcotest.fail "expected legacy tool message to degrade to plain text"
 
 let test_keeper_checkpoint_prefers_newer_legacy_during_migration () =
   let base_dir = temp_dir "keeper_checkpoint_migration" in
@@ -1755,6 +1838,10 @@ let () =
         test_keeper_checkpoint_prefers_oas_checkpoint;
       Alcotest.test_case "legacy fallback still works" `Quick
         test_keeper_checkpoint_legacy_fallback;
+      Alcotest.test_case "legacy checkpoint roundtrip preserves tool pairs" `Quick
+        test_keeper_checkpoint_legacy_roundtrip_preserves_tool_pairs;
+      Alcotest.test_case "legacy old tool messages degrade to text" `Quick
+        test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text;
       Alcotest.test_case "OAS handoff rollover increments generation" `Quick
         test_keeper_oas_handoff_rollover_increments_generation;
       Alcotest.test_case "OAS handoff rollover noops below threshold" `Quick
@@ -1777,6 +1864,10 @@ let () =
         test_keeper_checkpoint_prefers_oas_checkpoint;
       Alcotest.test_case "legacy fallback still works" `Quick
         test_keeper_checkpoint_legacy_fallback;
+      Alcotest.test_case "legacy checkpoint roundtrip preserves tool pairs" `Quick
+        test_keeper_checkpoint_legacy_roundtrip_preserves_tool_pairs;
+      Alcotest.test_case "legacy old tool messages degrade to text" `Quick
+        test_keeper_checkpoint_legacy_old_tool_messages_degrade_to_text;
       Alcotest.test_case "prefers newer legacy during migration" `Quick
         test_keeper_checkpoint_prefers_newer_legacy_during_migration;
       Alcotest.test_case "OAS handoff rollover increments generation" `Quick


### PR DESCRIPTION
## Summary
- make tool-quality telemetry explicit and more trustworthy by switching dashboard consumers to a 24h window, surfacing sampling metadata, and deduplicating the persisted tool-metrics write path
- thread trace/session/turn join keys into keeper tool-call logs and preserve structured tool history in legacy checkpoints so restored keeper turns do not rebuild orphaned tool_result blocks
- improve dashboard log readability by interpolating structured log fields into printf-style messages such as the OAS correction-pipeline entries

## Verification
- `pnpm run typecheck`
- `pnpm exec vitest run src/components/logs.test.ts src/api/dashboard.test.ts src/components/tool-quality-panel.test.ts src/components/fleet-telemetry-panel.test.ts`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex/tool-quality-telemetry-trust @install`
- `./_build/default/test/test_oas_worker.exe`
- `./_build/default/test/test_keeper_tool_call_log.exe`
- `./_build/default/test/test_tool_metrics_persist.exe`