### PR TITLE
feat(dashboard): Phase 5 — operations FilterChips toggle

### DIFF
--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -3,8 +3,7 @@
 
 import { html } from 'htm/preact'
 import { route } from '../router'
-import { Ops } from './ops'
-import { Governance } from './governance'
+import { OperationsPanel } from './operations-panel'
 import { ConnectorStatusPanel } from './connector-status'
 import { LabInspector } from './lab-inspector'
 
@@ -24,15 +23,7 @@ function renderSection(section: OperationsSection) {
     case 'inspector':
       return html`<${LabInspector} />`
     case 'operations':
-      // Phase 1 interim: render Ops (intervention) and Governance (approval
-      // queue) vertically. Phase 5 merges them into a unified operations-panel
-      // with broadcast/message/approve sections.
-      return html`
-        <${Ops} />
-        <div class="mt-4">
-          <${Governance} />
-        </div>
-      `
+      return html`<${OperationsPanel} />`
   }
 }
 

--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -1,0 +1,111 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+void vi
+
+const route = { value: { tab: 'command' as string, params: {} as Record<string, string> } }
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadPanel() {
+  vi.resetModules()
+  vi.doMock('../router', () => ({ route }))
+  vi.doMock('./ops', () => ({
+    Ops: () => html`<div data-testid="ops">Ops</div>`,
+  }))
+  vi.doMock('./governance', () => ({
+    Governance: () => html`<div data-testid="governance">Governance</div>`,
+  }))
+  return import('./operations-panel')
+}
+
+describe('OperationsPanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    route.value = { tab: 'command', params: { section: 'operations' } }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../router')
+    vi.doUnmock('./ops')
+    vi.doUnmock('./governance')
+  })
+
+  it('renders both Ops and Governance when view is not set (default)', async () => {
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Ops')
+    expect(container.textContent).toContain('Governance')
+  })
+
+  it('renders only Ops when view is ops', async () => {
+    route.value.params = { section: 'operations', view: 'ops' }
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Ops')
+    expect(container.textContent).not.toContain('Governance')
+  })
+
+  it('renders only Governance when view is governance', async () => {
+    route.value.params = { section: 'operations', view: 'governance' }
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).not.toContain('Ops')
+    expect(container.textContent).toContain('Governance')
+  })
+
+  it('renders 3 FilterChips options', async () => {
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    const buttons = container.querySelectorAll('button[type="button"]')
+    expect(buttons.length).toBe(3)
+    const labels = Array.from(buttons).map(b => b.textContent?.trim())
+    expect(labels).toContain('전체')
+    expect(labels).toContain('개입')
+    expect(labels).toContain('거버넌스')
+  })
+
+  it('falls back to default for unknown view param', async () => {
+    route.value.params = { section: 'operations', view: 'unknown' }
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('Ops')
+    expect(container.textContent).toContain('Governance')
+  })
+
+  it('marks the active chip with aria-pressed=true', async () => {
+    route.value.params = { section: 'operations', view: 'governance' }
+    const { OperationsPanel } = await loadPanel()
+    render(html`<${OperationsPanel} />`, container)
+    await flushUi()
+
+    const buttons = container.querySelectorAll('button[type="button"]')
+    const governanceBtn = Array.from(buttons).find(b => b.textContent?.trim() === '거버넌스')
+    expect(governanceBtn?.getAttribute('aria-pressed')).toBe('true')
+
+    const defaultBtn = Array.from(buttons).find(b => b.textContent?.trim() === '전체')
+    expect(defaultBtn?.getAttribute('aria-pressed')).toBe('false')
+  })
+})

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -1,0 +1,56 @@
+// MASC Dashboard — Operations Panel (Phase 5)
+// FilterChips toggle for ops/governance sub-views within the operations section.
+
+import { html } from 'htm/preact'
+import { FilterChips } from './common/filter-chips'
+import { Ops } from './ops'
+import { Governance } from './governance'
+import { route } from '../router'
+
+export type OpsView = 'default' | 'ops' | 'governance'
+
+const VIEW_CHIPS: { key: OpsView; label: string }[] = [
+  { key: 'default', label: '전체' },
+  { key: 'ops', label: '개입' },
+  { key: 'governance', label: '거버넌스' },
+]
+
+function currentView(): OpsView {
+  const view = route.value.params.view
+  if (view === 'ops' || view === 'governance') return view
+  return 'default'
+}
+
+function updateViewParam(next: OpsView): void {
+  const base = '#command?section=operations'
+  const hash = next === 'default' ? base : `${base}&view=${next}`
+  window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
+export function OperationsPanel() {
+  const view = currentView()
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <${FilterChips}
+        chips=${VIEW_CHIPS}
+        value=${view}
+        onChange=${updateViewParam}
+        size="md"
+        tone="accent"
+        class="w-fit"
+      />
+      ${view === 'ops'
+        ? html`<${Ops} />`
+        : view === 'governance'
+          ? html`<${Governance} />`
+          : html`
+              <${Ops} />
+              <div class="mt-4">
+                <${Governance} />
+              </div>
+            `}
+    </div>
+  `
+}


### PR DESCRIPTION
## Summary
- Add `OperationsPanel` component with `FilterChips` for switching between combined (전체), ops-only (개입), and governance-only (거버넌스) views.
- URL-driven via `route.params.view` with `history.replaceState` + `hashchange` dispatch (unidirectional flow, no internal signal).
- Update `control.ts` to delegate to `OperationsPanel` instead of inline Ops + Governance rendering.

## Changed files
- `dashboard/src/components/operations-panel.ts` — new component
- `dashboard/src/components/operations-panel.test.ts` — 6 tests (default/ops/governance views, chip count, unknown fallback, aria-pressed)
- `dashboard/src/components/control.ts` — replace inline rendering with `<OperationsPanel />`

## Verification
- `tsc --noEmit` — zero errors
- `vite build` — success
- `vitest run operations-panel.test.ts` — 6/6 pass
- `vitest run control.test.ts` — 5/5 pass (existing tests unaffected)

## Test plan
- [ ] Verify FilterChips renders 3 options in dashboard UI
- [ ] Verify default view shows both Ops and Governance
- [ ] Verify clicking "개입" shows only Ops
- [ ] Verify clicking "거버넌스" shows only Governance
- [ ] Verify URL updates with `view=ops` / `view=governance` param
- [ ] Verify browser back/forward navigates between views

🤖 Generated with [Claude Code](https://claude.com/claude-code)