### PR TITLE
feat(dashboard): Phase 4 — runtime FilterChips toggle

### DIFF
--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -1,0 +1,124 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const route = { value: { tab: 'monitoring' as string, params: {} as Record<string, string> } }
+
+async function flushUi(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadRuntimePanel() {
+  vi.resetModules()
+  vi.doMock('../router', () => ({ route }))
+  vi.doMock('./oas-health-chip', () => ({
+    OasHealthChip: () => html`<div data-testid="oas-health">OasHealthChip</div>`,
+  }))
+  vi.doMock('./runtime-monitor', () => ({
+    RuntimeMonitor: () => html`<div data-testid="runtime-monitor">RuntimeMonitor</div>`,
+  }))
+  vi.doMock('./prometheus-metrics', () => ({
+    PrometheusMetrics: () => html`<div data-testid="prometheus">PrometheusMetrics</div>`,
+  }))
+  vi.doMock('./common/filter-chips', () => ({
+    FilterChips: ({ chips, value }: { chips: { key: string; label: string }[]; value: string }) => html`
+      <div data-testid="filter-chips" data-value=${value}>
+        ${chips.map((c: { key: string; label: string }) =>
+          html`<span data-testid="chip" data-key=${c.key}>${c.label}</span>`,
+        )}
+      </div>
+    `,
+  }))
+  return import('./runtime-panel')
+}
+
+describe('RuntimePanel', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    route.value = { tab: 'monitoring', params: {} }
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../router')
+    vi.doUnmock('./oas-health-chip')
+    vi.doUnmock('./runtime-monitor')
+    vi.doUnmock('./prometheus-metrics')
+    vi.doUnmock('./common/filter-chips')
+  })
+
+  it('renders all 3 panels by default', async () => {
+    route.value.params = {}
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('OasHealthChip')
+    expect(container.textContent).toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('PrometheusMetrics')
+  })
+
+  it('renders only OasHealthChip and RuntimeMonitor for providers view', async () => {
+    route.value.params = { view: 'providers' }
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('OasHealthChip')
+    expect(container.textContent).toContain('RuntimeMonitor')
+    expect(container.textContent).not.toContain('PrometheusMetrics')
+  })
+
+  it('renders only PrometheusMetrics for prometheus view', async () => {
+    route.value.params = { view: 'prometheus' }
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).not.toContain('OasHealthChip')
+    expect(container.textContent).not.toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('PrometheusMetrics')
+  })
+
+  it('renders FilterChips with 3 options', async () => {
+    route.value.params = {}
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    const chips = container.querySelectorAll('[data-testid="chip"]')
+    expect(chips.length).toBe(3)
+    expect(chips[0]?.textContent).toBe('전체')
+    expect(chips[1]?.textContent).toBe('프로바이더')
+    expect(chips[2]?.textContent).toBe('메트릭')
+  })
+
+  it('falls back to default for unknown view param', async () => {
+    route.value.params = { view: 'unknown-view' }
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('OasHealthChip')
+    expect(container.textContent).toContain('RuntimeMonitor')
+    expect(container.textContent).toContain('PrometheusMetrics')
+  })
+
+  it('passes current view value to FilterChips', async () => {
+    route.value.params = { view: 'providers' }
+    const { RuntimePanel } = await loadRuntimePanel()
+    render(html`<${RuntimePanel} />`, container)
+    await flushUi()
+
+    const filterChips = container.querySelector('[data-testid="filter-chips"]')
+    expect(filterChips?.getAttribute('data-value')).toBe('providers')
+  })
+})

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -1,0 +1,67 @@
+// RuntimePanel — Phase 4 runtime section with FilterChips toggle.
+// Wraps OasHealthChip, RuntimeMonitor, PrometheusMetrics with view switching.
+// Views: default (all), providers (health + monitor), prometheus (metrics only).
+// Pattern: mirrors fleet-health-panel.ts (unidirectional flow via URL).
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { route } from '../router'
+import { FilterChips } from './common/filter-chips'
+import { OasHealthChip } from './oas-health-chip'
+import { RuntimeMonitor } from './runtime-monitor'
+import { PrometheusMetrics } from './prometheus-metrics'
+
+export type RuntimeView = 'default' | 'providers' | 'prometheus'
+
+const RUNTIME_VIEWS: RuntimeView[] = ['default', 'providers', 'prometheus']
+
+function isRuntimeView(v: string | undefined): v is RuntimeView {
+  return !!v && (RUNTIME_VIEWS as string[]).includes(v)
+}
+
+const activeView = computed<RuntimeView>(() => {
+  const v = route.value.params.view
+  return isRuntimeView(v) ? v : 'default'
+})
+
+const VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
+  { key: 'default', label: '전체' },
+  { key: 'providers', label: '프로바이더' },
+  { key: 'prometheus', label: '메트릭' },
+]
+
+function updateViewParam(view: RuntimeView): void {
+  const hash = view === 'default'
+    ? '#monitoring?section=runtime'
+    : `#monitoring?section=runtime&view=${view}`
+  history.replaceState(null, '', hash)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
+export function RuntimePanel() {
+  const view = activeView.value
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <${FilterChips}
+        chips=${VIEW_CHIPS}
+        value=${view}
+        onChange=${updateViewParam}
+      />
+      <div class="grid gap-4">
+        ${view === 'providers'
+          ? html`
+            <${OasHealthChip} />
+            <${RuntimeMonitor} />
+          `
+        : view === 'prometheus'
+          ? html`<${PrometheusMetrics} />`
+        : html`
+            <${OasHealthChip} />
+            <${RuntimeMonitor} />
+            <${PrometheusMetrics} />
+          `}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -1,4 +1,4 @@
-// MASC Dashboard — Status Surface (Phase 2: fleet-health unified)
+// MASC Dashboard — Status Surface (Phase 2+4: fleet-health + runtime unified)
 // Read-only observability surfaces: observatory, agents, activity, runtime,
 // fleet-health (FilterChips unified panel), memory-subsystems.
 
@@ -6,10 +6,8 @@ import { html } from 'htm/preact'
 import { route } from '../router'
 import { AgentsUnified } from './agents-unified'
 import { Activity } from './activity'
-import { RuntimeMonitor } from './runtime-monitor'
-import { OasHealthChip } from './oas-health-chip'
+import { RuntimePanel } from './runtime-panel'
 import { MemorySubsystems } from './memory-subsystems'
-import { PrometheusMetrics } from './prometheus-metrics'
 import { FleetHealthPanel } from './fleet-health-panel'
 import { Observatory } from './observatory/observatory'
 
@@ -36,13 +34,7 @@ export function Status() {
           : section === 'activity'
             ? html`<${Activity} />`
           : section === 'runtime'
-            ? html`
-              <div class="grid gap-4">
-                <${OasHealthChip} />
-                <${RuntimeMonitor} />
-                <${PrometheusMetrics} />
-              </div>
-            `
+            ? html`<${RuntimePanel} />`
           : section === 'fleet-health'
             ? html`<${FleetHealthPanel} />`
           : section === 'memory-subsystems'


### PR DESCRIPTION
## Summary
- Add `RuntimePanel` component with FilterChips-based view switching for the runtime section
- Three views: **전체** (all 3 panels), **프로바이더** (OasHealthChip + RuntimeMonitor), **메트릭** (PrometheusMetrics only)
- Pattern mirrors `fleet-health-panel.ts` (Phase 2): computed signal from route params, unidirectional flow via URL
- Removes direct imports of OasHealthChip/RuntimeMonitor/PrometheusMetrics from `status.ts`

## Phase chain
- Phase 2: `fleet-health-panel.ts` (merged in main)
- **Phase 4**: `runtime-panel.ts` (this PR)

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] `vite build` — success
- [x] `vitest run runtime-panel.test.ts` — 6/6 pass
  - Default view shows all 3 panels
  - `providers` view shows OasHealthChip + RuntimeMonitor only
  - `prometheus` view shows PrometheusMetrics only
  - FilterChips renders 3 options (전체/프로바이더/메트릭)
  - Unknown view param falls back to default
  - Active value passed correctly to FilterChips

🤖 Generated with [Claude Code](https://claude.com/claude-code)