### PR TITLE
refactor: extract fallback_context_window SSOT, remove 128k magic number

### DIFF
--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -357,11 +357,11 @@ let resolve_strategies
       let obs_val = match obs with
         | Some o -> o
         | None ->
-          (* Fallback: minimal observation when none provided.
-             128_000 matches OAS resolve_primary_max_context fallback. *)
+          (* Fallback: minimal observation when none provided. *)
           { context_ratio = 0.5; active_agent_count = 1;
             unclaimed_task_count = 0; is_single_focused_task = true;
-            context_window = 128_000; is_local_model = false }
+            context_window = Oas_model_resolve.fallback_context_window;
+            is_local_model = false }
       in
       (* Resolve once — no recursive Dynamic *)
       selector obs_val

--- a/lib/dashboard/dashboard_harness_health.ml
+++ b/lib/dashboard/dashboard_harness_health.ml
@@ -184,7 +184,7 @@ let pre_compact_event_of_json json =
         message_count = Safe_ops.json_int ~default:0 "message_count" json;
         token_count = Safe_ops.json_int ~default:0 "token_count" json;
         strategies = Safe_ops.json_string_list "strategies" json;
-        context_window = Safe_ops.json_int ~default:128_000 "context_window" json;
+        context_window = Safe_ops.json_int ~default:Oas_model_resolve.fallback_context_window "context_window" json;
         is_local_model = Safe_ops.json_bool ~default:false "is_local_model" json;
         trigger = string_field json "trigger";
       }

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -8,6 +8,13 @@
 
     @since 2.135.0 — inference-to-oas migration (Phase 1) *)
 
+(** Fallback context window (tokens) when no provider can be resolved.
+    128K matches mid-range cloud models and avoids under-allocating for
+    providers that don't publish their context size.  Referenced as the
+    SSOT fallback across relay, tool_compact, context_compact_oas, and
+    dashboard_harness_health — do not duplicate this literal elsewhere. *)
+let fallback_context_window = 128_000
+
 let default_registry = Llm_provider.Provider_registry.default ()
 
 (** Extract provider name from a "provider:model_id" label string.
@@ -84,15 +91,15 @@ let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
        endpoint lookup for local providers, round-robin fallback).
     2. Apply {!context_floor} guard on the discovered value.
     3. If OAS returns [None], use static registry entry's [max_context].
-    4. Final fallback: [128_000]. *)
+    4. Final fallback: {!fallback_context_window}. *)
 let max_context_of_label (label : string) : int =
   let static_ctx =
     match provider_name_of_label label with
-    | None -> 128_000
+    | None -> fallback_context_window
     | Some pname ->
       match Llm_provider.Provider_registry.find default_registry pname with
       | Some entry -> entry.max_context
-      | None -> 128_000
+      | None -> fallback_context_window
   in
   match Llm_provider.Cascade_config.resolve_label_context label with
   | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
@@ -122,21 +129,21 @@ let context_if_available (label : string) : int option =
     "Available" means the provider's API key env var is set (or not required).
     Per-label context resolved by OAS — no routing guess in MASC.
     Applies {!context_floor} to discovered values.
-    Falls back to 128_000 if no model is available. *)
+    Falls back to {!fallback_context_window} if no model is available. *)
 let resolve_primary_max_context (labels : string list) : int =
   match List.find_map context_if_available labels with
   | Some ctx -> ctx
-  | None -> 128_000
+  | None -> fallback_context_window
 
 (** Maximum context across all available models in a label list.
     Returns the largest context window that any model in the cascade can
     handle.  This is the value MASC should use for [max_input_tokens]:
     OAS cascade will try providers in order — if the primary overflows,
     the cascade fails over to the next provider that can handle the
-    prompt size.  Falls back to [128_000] if no model is available. *)
+    prompt size.  Falls back to {!fallback_context_window} if no model is available. *)
 let resolve_max_cascade_context (labels : string list) : int =
   match List.filter_map context_if_available labels with
-  | [] -> 128_000
+  | [] -> fallback_context_window
   | ctxs -> List.fold_left max 0 ctxs
 
 let labels_are_pure_local (labels : string list) : bool =

--- a/lib/relay.ml
+++ b/lib/relay.ml
@@ -98,8 +98,9 @@ let default_registry = Llm_provider.Provider_registry.default ()
     Resolution order:
     1. Capabilities.for_model_id — per-model override (e.g. "claude-opus-4-6" -> 1M)
     2. Provider_registry.find — provider-level default (e.g. "claude" -> 200K)
-    3. 128_000 fallback (matches Oas_model_resolve.resolve_primary_max_context) *)
+    3. {!Oas_model_resolve.fallback_context_window} *)
 let resolve_max_context model =
+  let fallback = Oas_model_resolve.fallback_context_window in
   (* Layer 1: per-model capabilities (e.g. "claude-opus-4-6" -> 1M) *)
   let from_caps =
     match Llm_provider.Capabilities.for_model_id model with
@@ -126,8 +127,8 @@ let resolve_max_context model =
        if base <> "" then
          match Llm_provider.Provider_registry.find default_registry base with
          | Some entry -> entry.Llm_provider.Provider_registry.max_context
-         | None -> 128_000
-       else 128_000)
+         | None -> fallback
+       else fallback)
 
 (** {1 Token estimation constants}
 

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -60,7 +60,7 @@ Each message has 'role' (system/user/assistant/tool) and 'content' (string).");
         ]);
         ("max_tokens", `Assoc [
           ("type", `String "integer");
-          ("description", `String "Max context window size for ratio calculation (default: 128000)");
+          ("description", `String (Printf.sprintf "Max context window size for ratio calculation (default: %d)" Oas_model_resolve.fallback_context_window));
         ]);
         ("system_prompt", `Assoc [
           ("type", `String "string");
@@ -141,9 +141,9 @@ let handle_compact args : tool_result =
       (try args |> member "max_tokens" |> to_int
        with Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
-         Log.Misc.warn "handle_compact: max_tokens parse failed (%s), using 128000"
-           (Printexc.to_string exn);
-         128_000) in
+         Log.Misc.warn "handle_compact: max_tokens parse failed (%s), using %d"
+           (Printexc.to_string exn) Oas_model_resolve.fallback_context_window;
+         Oas_model_resolve.fallback_context_window) in
     let system_prompt =
       (try args |> member "system_prompt" |> to_string
        with Eio.Cancel.Cancelled _ as e -> raise e


### PR DESCRIPTION
## Summary
- `Oas_model_resolve.fallback_context_window = 128_000` 상수를 SSOT로 정의
- 5개 파일에 산재한 9개 `128_000` 리터럴을 이 상수 참조로 교체

## 영향 파일
| 파일 | 교체 수 | 용도 |
|------|---------|------|
| `oas_model_resolve.ml` | 4 → SSOT 정의 | 모델 context 해석 최종 fallback |
| `relay.ml` | 2 | 모델별 context 해석 fallback |
| `tool_compact.ml` | 2 | 압축 도구 default max_tokens |
| `context_compact_oas.ml` | 1 | 관측 fallback |
| `dashboard_harness_health.ml` | 1 | JSON parse default |

## Why
9곳에 같은 리터럴이 산재하면, 값 변경 시 5파일을 동시에 고쳐야 함. 한 곳이라도 빠지면 context 해석이 파일마다 다르게 동작 (software-development.md S1: Scattered Hardcoded Defaults).

## Test plan
- [x] `dune build --root .` pass
- [x] `rg "128.?000" lib/ --glob "*.ml"` → SSOT 정의 1곳만 남음
- [ ] CI Build and Test

Part of hardcoding removal series.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>