### PR TITLE
fix(keeper): TOML cascade_name propagates on boot (#6747)

### DIFF
--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -117,9 +117,15 @@ let update_keeper (ctx : _ context) (p : parsed_args) (old : keeper_meta) : tool
     mid_goal;
     long_goal;
     cascade_name =
-      (if String.trim old.cascade_name <> "" then
-         Keeper_cascade_profile.canonicalize old.cascade_name
-       else Keeper_config.default_cascade_name);
+      (* TOML cascade_name takes precedence over runtime JSON when present.
+         Without this, changing cascade_name in keepers/*.toml has no effect
+         until the runtime JSON is deleted.  See #6747. *)
+      (match p.profile_defaults.cascade_name with
+       | Some name -> Keeper_cascade_profile.canonicalize name
+       | None ->
+         if String.trim old.cascade_name <> "" then
+           Keeper_cascade_profile.canonicalize old.cascade_name
+         else Keeper_config.default_cascade_name);
     will =
       Option.value
         ~default:


### PR DESCRIPTION
## Summary
- `keepers/*.toml`의 `cascade_name` 변경이 서버 재시작 시 runtime JSON에 반영되지 않던 문제 수정
- TOML `profile_defaults.cascade_name` → runtime JSON → `default_cascade_name` 순서로 우선순위 적용

## Root cause
`keeper_turn_up_update.ml`에서 `old.cascade_name`이 비어있지 않으면 무조건 유지, TOML 무시

## Fix
`p.profile_defaults.cascade_name`이 `Some`이면 TOML 값 사용, `None`일 때만 기존 runtime JSON 값 유지

## Test plan
- [x] 145 keeper unified tests pass
- [x] Build success
- [ ] CI green

Closes #6747