### PR TITLE
refactor(dashboard_utils): replace health string predicates with health_level variant

### DIFF
--- a/lib/dashboard/briefing_sections.ml
+++ b/lib/dashboard/briefing_sections.ml
@@ -5,7 +5,7 @@ open Briefing_gaps
 
 let has_operational_signal ~section_id ~room_health ~incident_count ~recommended_action_count =
   let room_risky =
-    Dashboard_utils.is_health_at_risk (String.lowercase_ascii (String.trim room_health))
+    Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string room_health)
   in
   match section_id with
   | "watch" -> room_risky || incident_count > 0 || recommended_action_count > 0
@@ -114,7 +114,7 @@ let build_communication_section ~sessions ~recent_messages ~metadata_gaps
     ("unclear", "Communication metadata is incomplete and no positive activity signal is recorded.", evidence)
   else if known_mode_count = 0 then
     ("unclear", "Communication mode is not recorded for the live sessions.", evidence)
-  else if Dashboard_utils.is_health_at_risk (String.lowercase_ascii (String.trim room_health))
+  else if Dashboard_utils.is_health_at_risk (Dashboard_utils.health_level_of_string room_health)
           || incident_count > 0 || recommended_action_count > 0
   then
     ("watch", "Live sessions exist without recorded communication activity while the namespace still has open operator attention.", evidence)
@@ -172,9 +172,9 @@ let build_alignment_section ~sessions ~agents ~metadata_gaps =
 
 let build_watch_section ~room_health ~incident_count ~recommended_action_count
     ~top_attention_summary =
-  let lowered_room_health = String.lowercase_ascii (String.trim room_health) in
+  let room_health_level = Dashboard_utils.health_level_of_string room_health in
   let risky_room =
-    Dashboard_utils.is_health_at_risk lowered_room_health
+    Dashboard_utils.is_health_at_risk room_health_level
   in
   let evidence =
     []

--- a/lib/dashboard/dashboard_execution_sessions.ml
+++ b/lib/dashboard/dashboard_execution_sessions.ml
@@ -73,7 +73,7 @@ let event_summary event_json =
   | None, None, None, None ->
       String.map (fun ch -> if ch = '_' then ' ' else ch) event_type
 
-let session_severity ~health ~status ~runtime_blocker =
+let session_severity ~(health : Dashboard_utils.health_level) ~status ~runtime_blocker =
   if status = "completed" then
     if is_health_critical health || is_health_warning health then Tone_warn
     else Tone_ok
@@ -241,7 +241,7 @@ let build_session_contexts seeds operation_contexts : session_context list =
            | None -> (None, None)
          in
          let severity =
-           session_severity ~health:seed.health ~status:seed.status
+           session_severity ~health:(Dashboard_utils.health_level_of_string seed.health) ~status:seed.status
              ~runtime_blocker:seed.runtime_blocker
          in
          let intervene_label =

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -107,21 +107,54 @@ let string_list_json values =
 let normalized_text_key text =
   compact_text ~max_len:512 text |> String.trim |> String.lowercase_ascii
 
+(** Health severity level — ordered from worst to best.
+    Parsed from dashboard/operator JSON at the call site via
+    [health_level_of_string], then used in typed predicates below. *)
+type health_level =
+  | HL_critical
+  | HL_bad
+  | HL_risk
+  | HL_warn
+  | HL_degraded
+  | HL_ok
+  | HL_unknown  (** Unparseable or missing health string *)
+
+let health_level_of_string s =
+  match String.lowercase_ascii (String.trim s) with
+  | "critical" -> HL_critical
+  | "bad" -> HL_bad
+  | "risk" -> HL_risk
+  | "warn" -> HL_warn
+  | "degraded" -> HL_degraded
+  | "ok" | "good" | "healthy" -> HL_ok
+  | _ -> HL_unknown
+
+let string_of_health_level = function
+  | HL_critical -> "critical"
+  | HL_bad -> "bad"
+  | HL_risk -> "risk"
+  | HL_warn -> "warn"
+  | HL_degraded -> "degraded"
+  | HL_ok -> "ok"
+  | HL_unknown -> "unknown"
+
 (** Status/health classification predicates — single source of truth.
-    Used across dashboard, briefing, operator, command_plane modules.
-    Adding a new status/health value? Update here, not at each call site. *)
+    Used across dashboard, briefing, operator, command_plane modules. *)
 
 let is_keeper_offline status =
   List.mem status [ "offline"; "inactive"; "error" ]
 
-let is_health_critical health =
-  List.mem health [ "bad"; "critical" ]
+let is_health_critical = function
+  | HL_bad | HL_critical -> true
+  | HL_risk | HL_warn | HL_degraded | HL_ok | HL_unknown -> false
 
-let is_health_warning health =
-  List.mem health [ "warn"; "degraded" ]
+let is_health_warning = function
+  | HL_warn | HL_degraded -> true
+  | HL_critical | HL_bad | HL_risk | HL_ok | HL_unknown -> false
 
-let is_health_at_risk health =
-  List.mem health [ "bad"; "risk"; "critical" ]
+let is_health_at_risk = function
+  | HL_bad | HL_risk | HL_critical -> true
+  | HL_warn | HL_degraded | HL_ok | HL_unknown -> false
 
 let is_session_terminal status =
   List.mem status [ "completed"; "cancelled"; "failed"; "stopped" ]


### PR DESCRIPTION
## Summary
- `dashboard_utils.ml`: `health_level` variant 타입 (7 variants: HL_critical/HL_bad/HL_risk/HL_warn/HL_degraded/HL_ok/HL_unknown)
- `is_health_critical`, `is_health_warning`, `is_health_at_risk` → string `List.mem` 대신 exhaustive variant match
- `health_level_of_string` parser가 lowercase + trim을 내부 처리 → caller 보일러플레이트 제거
- `briefing_sections.ml`, `dashboard_execution_sessions.ml` caller 전환

## Why
Health string predicates는 "bad", "critical" 같은 리터럴을 `List.mem`으로 비교. 새 severity 레벨 추가 시 predicate 누락 위험. Variant match는 exhaustive하므로 새 variant 추가 시 컴파일러가 모든 predicate를 점검.

Part of stringly-typed → variant conversion series (#7150, #7159, #7164, #7180, #7185).

## Test plan
- [x] `dune build --root .` pass
- [x] `test_dashboard_execution.exe` 12/12 pass
- [ ] CI Build and Test

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>