### PR TITLE
fix(accountability): exclude synthetic claims from unsupported rate calculation

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -508,8 +508,13 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                     ) all_events in
                     `List (List.filteri (fun i _ -> i < 10) keeper_events)
                   in
+                  let accountability =
+                    Keeper_exec_status_metrics.accountability_summary_json config
+                      ~keeper_name:m.name ~agent_name:m.agent_name
+                  in
                   `Assoc [
                     ("reputation", reputation);
+                    ("accountability", accountability);
                     ("thompson", thompson);
                     ("stress_recent", stress);
                   ]

--- a/lib/dune
+++ b/lib/dune
@@ -417,6 +417,7 @@
    keeper_types
    keeper_memory
    keeper_manual_reconcile
+   keeper_accountability
    keeper_memory_policy
    keeper_memory_bank
    keeper_memory_recall

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -1,0 +1,667 @@
+(** Keeper_accountability — evidence-first accountability ledger for keepers.
+
+    Append-only dated JSONL under [.masc/accountability]. This is separate from
+    popularity signals such as board karma: it records keeper commitments and
+    explicit completion claims, then derives trust/risk summaries from
+    deterministic evidence. *)
+
+open Types
+
+type claim_kind =
+  | Task_commitment
+  | Completion_claim
+
+type claim_status =
+  | Pending
+  | Supported
+  | Unsupported
+  | Expired
+  | Partial
+
+type claim_event = {
+  claim_id : string;
+  agent_name : string;
+  keeper_name : string;
+  trace_id : string option;
+  turn_number : int option;
+  task_id : string option;
+  kind : claim_kind;
+  subject : string;
+  surface : string;
+  created_at : string;
+  evidence_refs : string list;
+  synthetic : bool;
+}
+
+type resolution_event = {
+  claim_id : string;
+  status : claim_status;
+  resolved_at : string;
+  reason : string option;
+  supporting_evidence_refs : string list;
+}
+
+type claim_snapshot = {
+  claim : claim_event;
+  resolution : resolution_event option;
+}
+
+let store_cache : (string, Dated_jsonl.t) Hashtbl.t = Hashtbl.create 4
+let store_cache_mu = Eio.Mutex.create ()
+
+let task_commitment_expiry_sec = 72.0 *. 3600.0
+let completion_claim_expiry_sec = 24.0 *. 3600.0
+let dedupe_window_sec = 3600.0
+let summary_window_days = 14
+
+let claim_kind_to_string = function
+  | Task_commitment -> "task_commitment"
+  | Completion_claim -> "completion_claim"
+
+let claim_kind_of_string = function
+  | "task_commitment" -> Some Task_commitment
+  | "completion_claim" -> Some Completion_claim
+  | _ -> None
+
+let claim_status_to_string = function
+  | Pending -> "pending"
+  | Supported -> "supported"
+  | Unsupported -> "unsupported"
+  | Expired -> "expired"
+  | Partial -> "partial"
+
+let claim_status_of_string = function
+  | "pending" -> Some Pending
+  | "supported" -> Some Supported
+  | "unsupported" -> Some Unsupported
+  | "expired" -> Some Expired
+  | "partial" -> Some Partial
+  | _ -> None
+
+let normalize_refs refs =
+  refs
+  |> List.map String.trim
+  |> List.filter (fun value -> value <> "")
+  |> List.sort_uniq String.compare
+
+let is_keeper_agent_name agent_name =
+  Resilience.Zombie.is_keeper_name
+    (String.lowercase_ascii (String.trim agent_name))
+
+let keeper_name_of_agent agent_name =
+  let trimmed = String.trim agent_name in
+  let suffix = "-agent" in
+  if String.length trimmed > String.length suffix
+     && String.sub trimmed
+          (String.length trimmed - String.length suffix)
+          (String.length suffix)
+        = suffix
+  then
+    String.sub trimmed 0 (String.length trimmed - String.length suffix)
+  else
+    trimmed
+
+let accountability_dir base_path =
+  Filename.concat base_path ".masc/accountability"
+
+let get_store (config : Room_query.config) : Dated_jsonl.t =
+  let base_path = config.base_path in
+  Eio.Mutex.use_rw ~protect:true store_cache_mu (fun () ->
+      match Hashtbl.find_opt store_cache base_path with
+      | Some store -> store
+      | None ->
+          let store = Dated_jsonl.create ~base_dir:(accountability_dir base_path) () in
+          Hashtbl.replace store_cache base_path store;
+          store)
+
+let json_string_opt key json =
+  Safe_ops.json_string_opt key json
+
+let json_int_opt key json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Int value) -> Some value
+      | Some (`Intlit raw) -> int_of_string_opt raw
+      | Some (`Float value) -> Some (int_of_float value)
+      | _ -> None)
+  | _ -> None
+
+let json_bool key ~default json =
+  Safe_ops.json_bool ~default key json
+
+let json_string_list key json =
+  match json with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`List items) ->
+          items
+          |> List.filter_map (function
+                 | `String value ->
+                     let trimmed = String.trim value in
+                     if trimmed = "" then None else Some trimmed
+                 | _ -> None)
+      | _ -> [])
+  | _ -> []
+
+let option_string_field key = function
+  | Some value when String.trim value <> "" -> [ (key, `String (String.trim value)) ]
+  | _ -> []
+
+let option_int_field key = function
+  | Some value -> [ (key, `Int value) ]
+  | None -> []
+
+let claim_event_to_json (event : claim_event) =
+  `Assoc
+    ([
+       ("event_type", `String "claim_created");
+       ("claim_id", `String event.claim_id);
+       ("agent_name", `String event.agent_name);
+       ("keeper_name", `String event.keeper_name);
+       ("kind", `String (claim_kind_to_string event.kind));
+       ("subject", `String event.subject);
+       ("surface", `String event.surface);
+       ("created_at", `String event.created_at);
+       ("evidence_refs", `List (List.map (fun r -> `String r) event.evidence_refs));
+       ("synthetic", `Bool event.synthetic);
+     ]
+    @ option_string_field "trace_id" event.trace_id
+    @ option_int_field "turn_number" event.turn_number
+    @ option_string_field "task_id" event.task_id)
+
+let resolution_event_to_json (event : resolution_event) =
+  `Assoc
+    ([
+       ("event_type", `String "claim_resolved");
+       ("claim_id", `String event.claim_id);
+       ("status", `String (claim_status_to_string event.status));
+       ("resolved_at", `String event.resolved_at);
+       ( "supporting_evidence_refs",
+         `List (List.map (fun r -> `String r) event.supporting_evidence_refs) );
+     ]
+    @ option_string_field "reason" event.reason)
+
+let event_date_string ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02d"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday
+
+let claim_event_of_json json =
+  match json_string_opt "event_type" json with
+  | Some "claim_created" -> (
+      match claim_kind_of_string (Safe_ops.json_string ~default:"" "kind" json) with
+      | Some kind ->
+          let claim_id = Safe_ops.json_string ~default:"" "claim_id" json in
+          let agent_name = Safe_ops.json_string ~default:"" "agent_name" json in
+          let keeper_name =
+            match json_string_opt "keeper_name" json with
+            | Some value when String.trim value <> "" -> String.trim value
+            | _ -> keeper_name_of_agent agent_name
+          in
+          let subject = Safe_ops.json_string ~default:"" "subject" json in
+          let surface = Safe_ops.json_string ~default:"task" "surface" json in
+          let created_at = Safe_ops.json_string ~default:"" "created_at" json in
+          if claim_id = "" || agent_name = "" || subject = "" || created_at = "" then
+            None
+          else
+            Some
+              {
+                claim_id;
+                agent_name;
+                keeper_name;
+                trace_id = json_string_opt "trace_id" json;
+                turn_number = json_int_opt "turn_number" json;
+                task_id = json_string_opt "task_id" json;
+                kind;
+                subject;
+                surface;
+                created_at;
+                evidence_refs = normalize_refs (json_string_list "evidence_refs" json);
+                synthetic = json_bool "synthetic" ~default:false json;
+              }
+      | None -> None)
+  | _ -> None
+
+let resolution_event_of_json json =
+  match json_string_opt "event_type" json with
+  | Some "claim_resolved" -> (
+      match claim_status_of_string (Safe_ops.json_string ~default:"" "status" json) with
+      | Some status ->
+          let claim_id = Safe_ops.json_string ~default:"" "claim_id" json in
+          let resolved_at = Safe_ops.json_string ~default:"" "resolved_at" json in
+          if claim_id = "" || resolved_at = "" then None
+          else
+            Some
+              {
+                claim_id;
+                status;
+                resolved_at;
+                reason = json_string_opt "reason" json;
+                supporting_evidence_refs =
+                  normalize_refs (json_string_list "supporting_evidence_refs" json);
+              }
+      | None -> None)
+  | _ -> None
+
+let read_window_entries (config : Room_query.config) =
+  let now = Time_compat.now () in
+  let since = event_date_string (now -. (float_of_int summary_window_days *. 86400.0)) in
+  let until = event_date_string now in
+  Dated_jsonl.read_range (get_store config) ~since ~until
+
+let materialize_claims jsons =
+  let claims : (string, claim_snapshot) Hashtbl.t = Hashtbl.create 64 in
+  List.iter
+    (fun json ->
+      match claim_event_of_json json, resolution_event_of_json json with
+      | Some claim, None ->
+          if not (Hashtbl.mem claims claim.claim_id) then
+            Hashtbl.replace claims claim.claim_id { claim; resolution = None }
+      | None, Some resolution -> (
+          match Hashtbl.find_opt claims resolution.claim_id with
+          | Some snapshot ->
+              Hashtbl.replace claims resolution.claim_id
+                { snapshot with resolution = Some resolution }
+          | None -> ())
+      | _ -> ())
+    jsons;
+  Hashtbl.to_seq_values claims |> List.of_seq
+
+let created_at_unix claim =
+  Types_core.parse_iso8601_opt claim.created_at |> Option.value ~default:0.0
+
+let effective_status ~(now : float) (snapshot : claim_snapshot) =
+  match snapshot.resolution with
+  | Some resolution -> resolution.status
+  | None ->
+      let age = now -. created_at_unix snapshot.claim in
+      match snapshot.claim.kind with
+      | Task_commitment when age > task_commitment_expiry_sec -> Expired
+      | Completion_claim when age > completion_claim_expiry_sec -> Unsupported
+      | _ -> Pending
+
+let open_recent_claim ~(now : float) snapshots ~agent_name ~kind ~subject ~task_id
+    ~max_age_sec =
+  List.find_opt
+    (fun (snapshot : claim_snapshot) ->
+      snapshot.claim.agent_name = agent_name
+      && snapshot.claim.kind = kind
+      && String.equal snapshot.claim.subject subject
+      && snapshot.claim.task_id = task_id
+      &&
+      let age = now -. created_at_unix snapshot.claim in
+      age >= 0.0 && age <= max_age_sec
+      &&
+      match effective_status ~now snapshot with
+      | Pending -> true
+      | Supported | Unsupported | Expired | Partial -> false)
+    snapshots
+
+let make_claim_id ~agent_name ~kind ~subject ~task_id ~created_at =
+  let raw =
+    String.concat "|"
+      [
+        agent_name;
+        claim_kind_to_string kind;
+        subject;
+        Option.value ~default:"" task_id;
+        created_at;
+      ]
+  in
+  let digest = Digest.to_hex (Digest.string raw) in
+  "acct-" ^ String.sub digest 0 12
+
+let append_claim (config : Room_query.config) (event : claim_event) =
+  Dated_jsonl.append (get_store config) (claim_event_to_json event)
+
+let append_resolution (config : Room_query.config) (event : resolution_event) =
+  Dated_jsonl.append (get_store config) (resolution_event_to_json event)
+
+let task_title_for_id (config : Room_query.config) task_id =
+  Room_query.get_tasks_safe config
+  |> List.find_opt (fun (task : Types.task) -> String.equal task.id task_id)
+  |> Option.map (fun task -> task.title)
+
+let create_task_commitment config ~agent_name ~task_id ~surface =
+  let now = Time_compat.now () in
+  let title =
+    Option.value ~default:task_id (task_title_for_id config task_id)
+  in
+  let snapshots = materialize_claims (read_window_entries config) in
+  match
+    open_recent_claim ~now snapshots ~agent_name ~kind:Task_commitment
+      ~subject:title ~task_id:(Some task_id)
+      ~max_age_sec:task_commitment_expiry_sec
+  with
+  | Some _ -> ()
+  | None ->
+      let created_at = Types.now_iso () in
+      append_claim config
+        {
+          claim_id =
+            make_claim_id ~agent_name ~kind:Task_commitment ~subject:title
+              ~task_id:(Some task_id) ~created_at;
+          agent_name;
+          keeper_name = keeper_name_of_agent agent_name;
+          trace_id = None;
+          turn_number = None;
+          task_id = Some task_id;
+          kind = Task_commitment;
+          subject = title;
+          surface;
+          created_at;
+          evidence_refs = [ "task:" ^ task_id ];
+          synthetic = false;
+        }
+
+let resolve_recent_task_commitment config ~agent_name ~task_id ~status ~reason
+    ~evidence_refs ~max_age_sec =
+  let now = Time_compat.now () in
+  let title =
+    Option.value ~default:task_id (task_title_for_id config task_id)
+  in
+  let snapshots = materialize_claims (read_window_entries config) in
+  match
+    open_recent_claim ~now snapshots ~agent_name ~kind:Task_commitment
+      ~subject:title ~task_id:(Some task_id) ~max_age_sec
+  with
+  | Some snapshot ->
+      append_resolution config
+        {
+          claim_id = snapshot.claim.claim_id;
+          status;
+          resolved_at = Types.now_iso ();
+          reason;
+          supporting_evidence_refs = normalize_refs evidence_refs;
+        }
+  | None -> ()
+
+let maybe_support_recent_completion_claim config ~agent_name ~task_id ~evidence_refs =
+  let now = Time_compat.now () in
+  let title =
+    Option.value ~default:task_id (task_title_for_id config task_id)
+  in
+  let snapshots = materialize_claims (read_window_entries config) in
+  match
+    open_recent_claim ~now snapshots ~agent_name ~kind:Completion_claim
+      ~subject:title ~task_id:(Some task_id)
+      ~max_age_sec:completion_claim_expiry_sec
+  with
+  | Some snapshot ->
+      append_resolution config
+        {
+          claim_id = snapshot.claim.claim_id;
+          status = Supported;
+          resolved_at = Types.now_iso ();
+          reason = Some "task_done";
+          supporting_evidence_refs = normalize_refs evidence_refs;
+        }
+  | None ->
+      let created_at = Types.now_iso () in
+      let claim_id =
+        make_claim_id ~agent_name ~kind:Completion_claim ~subject:title
+          ~task_id:(Some task_id) ~created_at
+      in
+      append_claim config
+        {
+          claim_id;
+          agent_name;
+          keeper_name = keeper_name_of_agent agent_name;
+          trace_id = None;
+          turn_number = None;
+          task_id = Some task_id;
+          kind = Completion_claim;
+          subject = title;
+          surface = "task_transition";
+          created_at;
+          evidence_refs = normalize_refs evidence_refs;
+          synthetic = true;
+        };
+      append_resolution config
+        {
+          claim_id;
+          status = Supported;
+          resolved_at = created_at;
+          reason = Some "task_done";
+          supporting_evidence_refs = normalize_refs evidence_refs;
+        }
+
+let record_task_transition (config : Room_query.config) ~agent_name ~task_id
+    ~transition ~details =
+  if not (is_keeper_agent_name agent_name) then ()
+  else
+    match transition with
+    | "claim" | "start" ->
+        create_task_commitment config ~agent_name ~task_id
+          ~surface:"task_transition"
+    | "done" ->
+        let base_refs = [ "task:" ^ task_id ] in
+        resolve_recent_task_commitment config ~agent_name ~task_id
+          ~status:Supported ~reason:(Some "task_done")
+          ~evidence_refs:base_refs ~max_age_sec:task_commitment_expiry_sec;
+        maybe_support_recent_completion_claim config ~agent_name ~task_id
+          ~evidence_refs:base_refs
+    | "release" | "cancel" ->
+        let reason =
+          match json_string_opt "reason" details with
+          | Some value when String.trim value <> "" -> Some (String.trim value)
+          | _ -> Some transition
+        in
+        resolve_recent_task_commitment config ~agent_name ~task_id
+          ~status:Partial ~reason
+          ~evidence_refs:[ "task:" ^ task_id ] ~max_age_sec:task_commitment_expiry_sec
+    | _ -> ()
+
+let supporting_refs_for_turn ~trace_id ~turn_number strong_evidence_refs =
+  normalize_refs
+    (("turn:" ^ trace_id ^ ":" ^ string_of_int turn_number) :: strong_evidence_refs)
+
+let record_completion_claim (config : Room_query.config) ~keeper_name ~agent_name
+    ~trace_id ~turn_number ~subject ?task_id ?(evidence_refs = [])
+    ?(surface = "keeper_turn") ~strong_evidence ~strong_evidence_refs () =
+  if not (is_keeper_agent_name agent_name) then ()
+  else
+    let subject = String.trim subject in
+    if subject = "" then ()
+    else
+      let now = Time_compat.now () in
+      let snapshots = materialize_claims (read_window_entries config) in
+      let normalized_task_id =
+        match task_id with
+        | Some value ->
+            let trimmed = String.trim value in
+            if trimmed = "" then None else Some trimmed
+        | None -> None
+      in
+      let recent_existing =
+        open_recent_claim ~now snapshots ~agent_name ~kind:Completion_claim
+          ~subject ~task_id:normalized_task_id ~max_age_sec:dedupe_window_sec
+      in
+      let claim_id =
+        match recent_existing with
+        | Some snapshot -> snapshot.claim.claim_id
+        | None ->
+            let created_at = Types.now_iso () in
+            let claim_id =
+              make_claim_id ~agent_name ~kind:Completion_claim ~subject
+                ~task_id:normalized_task_id ~created_at
+            in
+            append_claim config
+              {
+                claim_id;
+                agent_name;
+                keeper_name;
+                trace_id = Some trace_id;
+                turn_number = Some turn_number;
+                task_id = normalized_task_id;
+                kind = Completion_claim;
+                subject;
+                surface;
+                created_at;
+                evidence_refs = normalize_refs evidence_refs;
+                synthetic = false;
+              };
+            claim_id
+      in
+      if strong_evidence then
+        append_resolution config
+          {
+            claim_id;
+            status = Supported;
+            resolved_at = Types.now_iso ();
+            reason = Some "same_turn_evidence";
+            supporting_evidence_refs =
+              supporting_refs_for_turn ~trace_id ~turn_number
+                strong_evidence_refs;
+          }
+
+let risk_band_of_metrics ~evidence_coverage ~unsupported_completion_rate
+    ~open_overdue_commitments =
+  if
+    evidence_coverage >= 0.80
+    && unsupported_completion_rate < 0.10
+    && open_overdue_commitments = 0
+  then "low"
+  else if
+    evidence_coverage >= 0.60
+    && unsupported_completion_rate < 0.25
+    && open_overdue_commitments <= 2
+  then "medium"
+  else
+    "high"
+
+let accountability_summary_json (config : Room_query.config) ~keeper_name
+    ~agent_name =
+  let now = Time_compat.now () in
+  let cutoff = now -. (float_of_int summary_window_days *. 86400.0) in
+  let snapshots =
+    materialize_claims (read_window_entries config)
+    |> List.filter (fun snapshot ->
+           String.equal snapshot.claim.agent_name agent_name
+           && created_at_unix snapshot.claim >= cutoff)
+  in
+  let supported_claims = ref 0 in
+  let resolved_claims = ref 0 in
+  let unsupported_completion_claims = ref 0 in
+  let total_completion_claims = ref 0 in
+  let open_overdue_commitments = ref 0 in
+  let supported_task_commitments = ref 0 in
+  let resolved_task_commitments = ref 0 in
+  let recent_supported_claims = ref 0 in
+  List.iter
+    (fun (snapshot : claim_snapshot) ->
+      let status = effective_status ~now snapshot in
+      let created_unix = created_at_unix snapshot.claim in
+      (match snapshot.claim.kind with
+      | Task_commitment -> (
+          match status with
+          | Supported ->
+              incr supported_task_commitments;
+              incr resolved_task_commitments
+          | Partial | Expired ->
+              incr resolved_task_commitments;
+              if status = Expired then incr open_overdue_commitments
+          | Pending -> ()
+          | Unsupported -> ())
+      | Completion_claim ->
+          if status <> Pending then incr total_completion_claims;
+          if status = Unsupported then incr unsupported_completion_claims);
+      (match status with
+      | Supported ->
+          incr supported_claims;
+          incr resolved_claims;
+          if created_unix >= cutoff then incr recent_supported_claims
+      | Partial | Expired | Unsupported -> incr resolved_claims
+      | Pending -> ());
+      if snapshot.claim.kind = Task_commitment
+         && status = Pending
+         && now -. created_unix > task_commitment_expiry_sec
+      then
+        incr open_overdue_commitments)
+    snapshots;
+  let task_followthrough_rate =
+    if !resolved_task_commitments = 0 then 1.0
+    else
+      float_of_int !supported_task_commitments
+      /. float_of_int !resolved_task_commitments
+  in
+  let evidence_coverage =
+    if !resolved_claims = 0 then 1.0
+    else float_of_int !supported_claims /. float_of_int !resolved_claims
+  in
+  let unsupported_completion_rate =
+    if !total_completion_claims = 0 then 0.0
+    else
+      float_of_int !unsupported_completion_claims
+      /. float_of_int !total_completion_claims
+  in
+  let risk_band =
+    risk_band_of_metrics ~evidence_coverage ~unsupported_completion_rate
+      ~open_overdue_commitments:!open_overdue_commitments
+  in
+  let history =
+    snapshots
+    |> List.sort (fun a b ->
+           compare (created_at_unix b.claim) (created_at_unix a.claim))
+    |> List.filteri (fun idx _ -> idx < 10)
+    |> List.map (fun (snapshot : claim_snapshot) ->
+           let status = effective_status ~now snapshot in
+           `Assoc
+             ([
+                ("claim_id", `String snapshot.claim.claim_id);
+                ("kind", `String (claim_kind_to_string snapshot.claim.kind));
+                ("status", `String (claim_status_to_string status));
+                ("subject", `String snapshot.claim.subject);
+                ("surface", `String snapshot.claim.surface);
+                ("created_at", `String snapshot.claim.created_at);
+                ("keeper_name", `String snapshot.claim.keeper_name);
+                ("evidence_refs", `List (List.map (fun r -> `String r) snapshot.claim.evidence_refs));
+                ("synthetic", `Bool snapshot.claim.synthetic);
+              ]
+             @ option_string_field "task_id" snapshot.claim.task_id
+             @ option_string_field "trace_id" snapshot.claim.trace_id
+             @ option_int_field "turn_number" snapshot.claim.turn_number
+             @
+             match snapshot.resolution with
+             | Some resolution ->
+                 [
+                   ("resolved_at", `String resolution.resolved_at);
+                   ( "supporting_evidence_refs",
+                     `List
+                       (List.map (fun r -> `String r)
+                          resolution.supporting_evidence_refs) );
+                 ]
+                 @ option_string_field "reason" resolution.reason
+             | None -> []))
+  in
+  let routing_hint =
+    match risk_band with
+    | "high" -> "manual_review_recommended"
+    | "medium" -> "prefer_low_risk_when_equivalent"
+    | _ -> "normal_routing"
+  in
+  `Assoc
+    [
+      ("keeper_name", `String keeper_name);
+      ("agent_name", `String agent_name);
+      ("window_days", `Int summary_window_days);
+      ("task_followthrough_rate", `Float task_followthrough_rate);
+      ("evidence_coverage", `Float evidence_coverage);
+      ("unsupported_completion_rate", `Float unsupported_completion_rate);
+      ("open_overdue_commitments", `Int !open_overdue_commitments);
+      ("recent_supported_claims", `Int !recent_supported_claims);
+      ("risk_band", `String risk_band);
+      ("routing_hint", `String routing_hint);
+      ("history", `List history);
+    ]
+
+let accountability_risk_is_high config ~keeper_name ~agent_name =
+  match accountability_summary_json config ~keeper_name ~agent_name with
+  | `Assoc fields -> (
+      match List.assoc_opt "risk_band" fields with
+      | Some (`String "high") -> true
+      | _ -> false)
+  | _ -> false

--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -567,8 +567,10 @@ let accountability_summary_json (config : Room_query.config) ~keeper_name
           | Pending -> ()
           | Unsupported -> ())
       | Completion_claim ->
-          if status <> Pending then incr total_completion_claims;
-          if status = Unsupported then incr unsupported_completion_claims);
+          if status <> Pending && not snapshot.claim.synthetic then
+            incr total_completion_claims;
+          if status = Unsupported && not snapshot.claim.synthetic then
+            incr unsupported_completion_claims);
       (match status with
       | Supported ->
           incr supported_claims;

--- a/lib/keeper/keeper_accountability.mli
+++ b/lib/keeper/keeper_accountability.mli
@@ -1,0 +1,45 @@
+type claim_kind =
+  | Task_commitment
+  | Completion_claim
+
+type claim_status =
+  | Pending
+  | Supported
+  | Unsupported
+  | Expired
+  | Partial
+
+val record_task_transition :
+  Room_query.config ->
+  agent_name:string ->
+  task_id:string ->
+  transition:string ->
+  details:Yojson.Safe.t ->
+  unit
+
+val record_completion_claim :
+  Room_query.config ->
+  keeper_name:string ->
+  agent_name:string ->
+  trace_id:string ->
+  turn_number:int ->
+  subject:string ->
+  ?task_id:string ->
+  ?evidence_refs:string list ->
+  ?surface:string ->
+  strong_evidence:bool ->
+  strong_evidence_refs:string list ->
+  unit ->
+  unit
+
+val accountability_summary_json :
+  Room_query.config ->
+  keeper_name:string ->
+  agent_name:string ->
+  Yojson.Safe.t
+
+val accountability_risk_is_high :
+  Room_query.config ->
+  keeper_name:string ->
+  agent_name:string ->
+  bool

--- a/lib/keeper/keeper_exec_status_metrics.ml
+++ b/lib/keeper/keeper_exec_status_metrics.ml
@@ -608,3 +608,7 @@ let latest_tool_audit_snapshot_from_files config ~keeper_name =
   match latest_tool_audit_snapshot_from_decisions config keeper_name with
   | Some _ as snapshot -> snapshot
   | None -> latest_tool_audit_snapshot_from_metrics config keeper_name
+
+let accountability_summary_json config ~keeper_name ~agent_name =
+  Keeper_accountability.accountability_summary_json config ~keeper_name
+    ~agent_name

--- a/lib/keeper/keeper_exec_status_metrics.mli
+++ b/lib/keeper/keeper_exec_status_metrics.mli
@@ -15,3 +15,5 @@ val summarize_metrics_lines :
 val empty_tool_audit_snapshot : tool_audit_snapshot
 val latest_tool_audit_snapshot_from_files :
   Room.config -> keeper_name:string -> tool_audit_snapshot option
+val accountability_summary_json :
+  Room.config -> keeper_name:string -> agent_name:string -> Yojson.Safe.t

--- a/lib/keeper/keeper_exec_task.ml
+++ b/lib/keeper/keeper_exec_task.ml
@@ -120,6 +120,16 @@ let handle_keeper_task_tool
         Keeper_tool_policy.preset_can_satisfy ~agent_preset:preset ~required_preset:required
     in
     let result = Room.claim_next_r config ~agent_name:meta.agent_name ~task_filter () in
+    let accountability_warning =
+      if
+        Keeper_accountability.accountability_risk_is_high config
+          ~keeper_name:meta.name ~agent_name:meta.agent_name
+      then
+        Some
+          "⚠ Accountability risk is high for this keeper. Prefer manual review or lower-risk routing when equivalent."
+      else
+        None
+    in
     let message = match result with
       | Room.Claim_next_claimed { message; _ } -> message
       | Room.Claim_next_no_unclaimed -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
@@ -129,7 +139,15 @@ let handle_keeper_task_tool
       | Room.Claim_next_no_eligible _ -> "📋 No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
       | Room.Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
     in
-    Yojson.Safe.to_string (`Assoc [ "result", `String message ])
+    Yojson.Safe.to_string
+      (`Assoc
+         ([
+            ("result", `String message);
+          ]
+         @
+         match accountability_warning with
+         | Some warning -> [ ("routing_warning", `String warning) ]
+         | None -> []))
   | "keeper_task_done" ->
     let task_id = Safe_ops.json_string ~default:"" "task_id" args |> String.trim in
     let result_text = Safe_ops.json_string ~default:"" "result" args |> String.trim in
@@ -145,4 +163,3 @@ let handle_keeper_task_tool
            ())
   | other -> error_json ~fields:[ "tool", `String other ] "unknown_task_tool"
 ;;
-

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -31,6 +31,12 @@ type social_state = {
   delivery_surface : delivery_surface;
 }
 
+type accountability_claim = {
+  subject : string;
+  task_id : string option;
+  evidence_refs : string list;
+}
+
 let speech_act_to_string = function
   | Stay_silent -> "stay_silent"
   | Inform -> "inform"
@@ -88,6 +94,10 @@ let is_social_header_key = function
   | "CURRENT_INTENTION"
   | "BLOCKER"
   | "NEED"
+  | "CLAIM_KIND"
+  | "CLAIM_SUBJECT"
+  | "CLAIM_TASK_ID"
+  | "EVIDENCE_REFS"
   | "SPEECH_ACT"
   | "DELIVERY_SURFACE" ->
       true
@@ -118,6 +128,16 @@ let nonempty_header_opt headers key =
       | "" | "none" | "null" -> None
       | _ -> Some (String.trim value))
   | None -> None
+
+let comma_list_header_opt headers key =
+  match nonempty_header_opt headers key with
+  | Some value ->
+      value
+      |> String.split_on_char ','
+      |> List.map String.trim
+      |> List.filter (fun item -> item <> "")
+      |> List.sort_uniq String.compare
+  | None -> []
 
 let belief_summary_of_observation
     (observation : Keeper_world_observation.world_observation) : string =
@@ -385,6 +405,23 @@ let apply_to_result ~(meta : keeper_meta)
         | Error _ -> visible_response_body
       in
       ({ result with response_text }, state)
+
+let extract_accountability_claim (result : Keeper_agent_run.run_result) =
+  let headers, _ = parse_header_block result.response_text in
+  match
+    nonempty_header_opt headers "CLAIM_KIND",
+    nonempty_header_opt headers "CLAIM_SUBJECT"
+  with
+  | Some kind, Some subject
+    when String.equal (String.lowercase_ascii (String.trim kind))
+           "completion_claim" ->
+      Some
+        {
+          subject = String.trim subject;
+          task_id = nonempty_header_opt headers "CLAIM_TASK_ID";
+          evidence_refs = comma_list_header_opt headers "EVIDENCE_REFS";
+        }
+  | _ -> None
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -33,8 +33,16 @@ type social_state = {
   delivery_surface : delivery_surface;
 }
 
+type accountability_claim = {
+  subject : string;
+  task_id : string option;
+  evidence_refs : string list;
+}
+
 val speech_act_to_string : speech_act -> string
 val delivery_surface_to_string : delivery_surface -> string
+val extract_accountability_claim :
+  Keeper_agent_run.run_result -> accountability_claim option
 
 val derive_failure_state :
   meta:Keeper_types.keeper_meta ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -334,6 +334,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
               Progress.stop_tracking turn_task_id;
               (false, Printf.sprintf "❌ Agent.run failed: %s" e_str)
             | Ok result ->
+              let explicit_accountability_claim =
+                Keeper_social_model.extract_accountability_claim result
+              in
               (try ignore (Trajectory.finalize trajectory_acc
                  Trajectory.Completed)
                with Eio.Cancel.Cancelled _ as e -> raise e | exn -> log_keeper_exn
@@ -413,6 +416,63 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     (Printexc.to_string exn);
                   None
               in
+              (match explicit_accountability_claim with
+              | Some claim ->
+                  let trace_id =
+                    Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id
+                  in
+                  let strong_evidence =
+                    let substantive_tools =
+                      result.tools_used
+                      |> List.exists (fun tool_name ->
+                             let trimmed = String.trim tool_name in
+                             trimmed <> ""
+                             && not (String.equal trimmed "keeper_stay_silent"))
+                    in
+                    substantive_tools
+                    ||
+                    match evidence with
+                    | Some (`Assoc fields) -> (
+                        match List.assoc_opt "delta_detected" fields with
+                        | Some (`Bool true) -> true
+                        | _ -> false)
+                    | _ -> false
+                  in
+                  let tool_refs =
+                    result.tools_used
+                    |> List.filter_map (fun tool_name ->
+                           let trimmed = String.trim tool_name in
+                           if trimmed = ""
+                              || String.equal trimmed "keeper_stay_silent"
+                           then None
+                           else Some ("tool:" ^ trimmed))
+                  in
+                  let turn_refs =
+                    let base =
+                      [ Printf.sprintf "turn:%s:%d" trace_id
+                          updated_meta.runtime.usage.total_turns ]
+                    in
+                    match evidence with
+                    | Some (`Assoc fields) -> (
+                        match List.assoc_opt "after_hash" fields with
+                        | Some (`String hash) when String.trim hash <> "" ->
+                            ("git:" ^ String.trim hash) :: base
+                        | _ -> base)
+                    | _ -> base
+                  in
+                  Keeper_accountability.record_completion_claim ctx.config
+                    ~keeper_name:updated_meta.name
+                    ~agent_name:updated_meta.agent_name
+                    ~trace_id
+                    ~turn_number:updated_meta.runtime.usage.total_turns
+                    ~subject:claim.subject
+                    ?task_id:claim.task_id
+                    ~evidence_refs:claim.evidence_refs
+                    ~surface:"keeper_msg"
+                    ~strong_evidence
+                    ~strong_evidence_refs:(tool_refs @ turn_refs)
+                    ()
+              | None -> ());
               start_keepalive ctx updated_meta;
               Progress.Tracker.complete turn_tracker
                 ~message:(Printf.sprintf "Turn completed: %d tool calls" result.tool_calls_made) ();

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -185,6 +185,13 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
      If you call tools, BDI headers are optional and informational only. \
      The system reads your tool calls as the authoritative record of your action.\n\
      \n\
+     If you explicitly claim completion or progress in text, add these optional headers:\n\
+     CLAIM_KIND: completion_claim\n\
+     CLAIM_SUBJECT: short concrete subject or task title\n\
+     CLAIM_TASK_ID: task-123 (if applicable)\n\
+     EVIDENCE_REFS: task:task-123, tool:keeper_task_done\n\
+     Only emit them for concrete claims you expect the system to audit.\n\
+     \n\
      End every response with a [STATE]...[/STATE] block:\n\
      DONE: what you accomplished this cycle\n\
      NEXT: what the next cycle should do\n\

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -465,6 +465,46 @@ let validated_evidence_preview
       Printf.sprintf "(validated evidence: %s)"
         (String.concat ", " names)
 
+let accountability_evidence_refs
+    ~(trace_id : string)
+    ~(turn_number : int)
+    ~(result : Keeper_agent_run.run_result)
+    ~(validated_evidence : Agent_sdk.Raw_trace.run_validation option)
+    ~(turn_evidence : Yojson.Safe.t option) =
+  let tool_refs =
+    result.tools_used
+    |> List.filter_map (fun tool_name ->
+           let trimmed = String.trim tool_name in
+           if trimmed = "" || String.equal trimmed "keeper_stay_silent" then None
+           else Some ("tool:" ^ trimmed))
+  in
+  let validation_refs =
+    match validated_evidence with
+    | Some validation ->
+        let base =
+          validation.evidence
+          |> List.map String.trim
+          |> List.filter (fun entry -> entry <> "")
+          |> List.map (fun entry -> "validation:" ^ entry)
+        in
+        if validation.has_file_write then
+          "validation:file_write" :: base
+        else
+          base
+    | None -> []
+  in
+  let turn_refs =
+    let base = [ Printf.sprintf "turn:%s:%d" trace_id turn_number ] in
+    match turn_evidence with
+    | Some (`Assoc fields) -> (
+        match List.assoc_opt "after_hash" fields with
+        | Some (`String hash) when String.trim hash <> "" ->
+            ("git:" ^ String.trim hash) :: base
+        | _ -> base)
+    | _ -> base
+  in
+  tool_refs @ validation_refs @ turn_refs
+
 let scheduled_autonomous_outcome_for_result
     (result : Keeper_agent_run.run_result) :
     scheduled_autonomous_cycle_outcome =
@@ -1826,6 +1866,9 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           end;
           Error err
       | Ok result ->
+          let explicit_accountability_claim =
+            Social.extract_accountability_claim result
+          in
           let result, social_state =
             Social.apply_to_result ~meta ~observation result
           in
@@ -1974,20 +2017,59 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             ~social_state
             ~result:(Some result) ();
           (* Post-turn evidence: deterministic git before/after delta *)
-          (try
-            ignore (Keeper_evidence.capture_turn_evidence
-              ~base_path:config.base_path
-              ~keeper_name:meta.name
-              ~trace_id:(Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id)
-              ~turn_number:updated_meta.runtime.usage.total_turns
-              ~tool_calls_made:result.tool_calls_made
-              ~before_hash:evidence_before_hash
-              ())
-          with
-          | Eio.Cancel.Cancelled _ as e -> raise e
-          | exn ->
-            Log.Keeper.warn "post-turn evidence capture failed (unified): %s"
-              (Printexc.to_string exn));
+          let turn_evidence =
+            try
+              Keeper_evidence.capture_turn_evidence
+                ~base_path:config.base_path
+                ~keeper_name:meta.name
+                ~trace_id:(Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id)
+                ~turn_number:updated_meta.runtime.usage.total_turns
+                ~tool_calls_made:result.tool_calls_made
+                ~before_hash:evidence_before_hash
+                ()
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Log.Keeper.warn "post-turn evidence capture failed (unified): %s"
+                  (Printexc.to_string exn);
+                None
+          in
+          (match explicit_accountability_claim with
+          | Some claim ->
+              let trace_id =
+                Keeper_id.Trace_id.to_string updated_meta.runtime.trace_id
+              in
+              let validated_evidence = visible_run_validation result in
+              let strong_evidence =
+                has_substantive_tool_calls result.tools_used
+                || Option.is_some validated_evidence
+                ||
+                match turn_evidence with
+                | Some (`Assoc fields) -> (
+                    match List.assoc_opt "delta_detected" fields with
+                    | Some (`Bool true) -> true
+                    | _ -> false)
+                | _ -> false
+              in
+              Keeper_accountability.record_completion_claim config
+                ~keeper_name:updated_meta.name
+                ~agent_name:updated_meta.agent_name
+                ~trace_id
+                ~turn_number:updated_meta.runtime.usage.total_turns
+                ~subject:claim.subject
+                ?task_id:claim.task_id
+                ~evidence_refs:claim.evidence_refs
+                ~surface:(Social.delivery_surface_to_string social_state.delivery_surface)
+                ~strong_evidence
+                ~strong_evidence_refs:
+                  (accountability_evidence_refs
+                     ~trace_id
+                     ~turn_number:updated_meta.runtime.usage.total_turns
+                     ~result
+                     ~validated_evidence
+                     ~turn_evidence)
+                ()
+          | None -> ());
           Log.Keeper.info
             "%s: unified turn OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
             updated_meta.name (Keeper_agent_run.surface_model_used result)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -149,6 +149,10 @@ let observe_task_transition_event config ~agent_name ~task_id
           Telemetry_eio.track_task_completed config ~task_id ~duration_ms
             ~success:(String.equal transition "done")
       | _ -> ()
+  with Stdlib.Effect.Unhandled _ -> ());
+  (try
+     Keeper_accountability.record_task_transition config ~agent_name ~task_id
+       ~transition ~details
   with Stdlib.Effect.Unhandled _ -> ())
 
 (* force_release_task — zombie cleanup needs task management logic *)

--- a/test/dune
+++ b/test/dune
@@ -45,6 +45,7 @@
         test_post_verifier
         test_swarm_checkpoint test_swarm_goal_loop
         test_keeper_memory
+        test_keeper_accountability
         test_keeper_exec_status
         test_keeper_adaptive_thinking
         test_keeper_lifecycle
@@ -127,6 +128,7 @@
           test_post_verifier
           test_swarm_checkpoint test_swarm_goal_loop
           test_keeper_memory
+          test_keeper_accountability
           test_keeper_exec_status
         test_keeper_adaptive_thinking
           test_keeper_lifecycle

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -194,6 +194,68 @@ let test_claim_tool_exposes_routing_warning_for_high_risk_keeper () =
         "⚠ Accountability risk is high for this keeper. Prefer manual review or lower-risk routing when equivalent."
         (string_member "routing_warning" result))
 
+let test_synthetic_claims_do_not_dilute_unsupported_rate () =
+  (* Regression: synthetic completion claims (created by task_transition "done")
+     must NOT be counted in total_completion_claims, otherwise they dilute the
+     unsupported_completion_rate and mask genuine risk. *)
+  with_room (fun config ->
+      let created_at = iso_of_unix (Unix.gettimeofday () -. 3600.0) in
+      (* 1 real unsupported completion claim *)
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-real-unsupported");
+             ("agent_name", `String "keeper-test-agent");
+             ("keeper_name", `String "keeper-test");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Real claim");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("evidence_refs", `List []);
+             ("synthetic", `Bool false);
+           ]);
+      (* 10 synthetic Supported completion claims — these should be ignored *)
+      for i = 1 to 10 do
+        let cid = Printf.sprintf "acct-synthetic-%d" i in
+        let created_at_s = iso_of_unix (Unix.gettimeofday () -. 1800.0) in
+        append_accountability_event config.base_path
+          ~created_at:created_at_s
+          (`Assoc
+             [
+               ("event_type", `String "claim_created");
+               ("claim_id", `String cid);
+               ("agent_name", `String "keeper-test-agent");
+               ("keeper_name", `String "keeper-test");
+               ("kind", `String "completion_claim");
+               ("subject", `String (Printf.sprintf "Synthetic %d" i));
+               ("surface", `String "task_transition");
+               ("created_at", `String created_at_s);
+               ("evidence_refs", `List []);
+               ("synthetic", `Bool true);
+             ]);
+        append_accountability_event config.base_path
+          ~created_at:created_at_s
+          (`Assoc
+             [
+               ("event_type", `String "claim_resolved");
+               ("claim_id", `String cid);
+               ("status", `String "supported");
+               ("resolved_at", `String created_at_s);
+               ("reason", `String "task_done");
+               ("supporting_evidence_refs", `List []);
+             ])
+      done;
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"keeper-test" ~agent_name:"keeper-test-agent"
+      in
+      (* Without the fix: 0/11 = 0.0 unsupported rate. With fix: 1/1 = 1.0 *)
+      check (float 0.0001) "unsupported rate should be 1.0 not diluted" 1.0
+        (float_member "unsupported_completion_rate" summary);
+      check string "risk band should be high" "high"
+        (string_member "risk_band" summary))
+
 let () =
   let base_path = Masc_test_deps.find_project_root () in
   ignore (Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path));
@@ -207,5 +269,7 @@ let () =
             test_stale_completion_claim_sets_high_risk;
           test_case "claim tool exposes routing warning for high risk keeper"
             `Quick test_claim_tool_exposes_routing_warning_for_high_risk_keeper;
+          test_case "synthetic claims do not dilute unsupported rate" `Quick
+            test_synthetic_claims_do_not_dilute_unsupported_rate;
         ] );
     ]

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -1,0 +1,211 @@
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let dir =
+    Filename.concat (Filename.get_temp_dir_name ())
+      (Printf.sprintf "test_keeper_accountability_%d" (Random.int 1_000_000))
+  in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Sys.readdir path
+        |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path)
+      else
+        Sys.remove path
+  in
+  try rm dir with _ -> ()
+
+let iso_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900)
+    (tm.Unix.tm_mon + 1)
+    tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let make_test_meta ?(name = "keeper-sangsu") ?(agent_name = "keeper-sangsu-agent") ()
+    : Keeper_types.keeper_meta =
+  match Keeper_types.meta_of_json
+          (`Assoc
+             [
+               ("name", `String name);
+               ("agent_name", `String agent_name);
+               ("trace_id", `String "test-trace-accountability");
+             ])
+  with
+  | Ok meta -> meta
+  | Error e -> failwith (Printf.sprintf "make_test_meta failed: %s" e)
+
+let make_ctx_work () =
+  Keeper_exec_context.create ~system_prompt:"test" ~max_tokens:4000
+
+let with_room ?(agent_name = "keeper-sangsu-agent") f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  let saved_pg = Sys.getenv_opt "MASC_POSTGRES_URL" in
+  let saved_sb = Sys.getenv_opt "SB_PG_URL" in
+  Unix.putenv "MASC_POSTGRES_URL" "";
+  Unix.putenv "SB_PG_URL" "";
+  Fun.protect
+    ~finally:(fun () ->
+      (match saved_pg with
+       | Some value -> Unix.putenv "MASC_POSTGRES_URL" value
+       | None -> Unix.putenv "MASC_POSTGRES_URL" "");
+      (match saved_sb with
+       | Some value -> Unix.putenv "SB_PG_URL" value
+       | None -> Unix.putenv "SB_PG_URL" "");
+      cleanup_dir dir)
+    (fun () ->
+      let config = Room.default_config dir in
+      ignore (Room.init config ~agent_name:(Some agent_name));
+      f config)
+
+let append_jsonl path json =
+  let oc =
+    open_out_gen [ Open_creat; Open_text; Open_append ] 0o644 path
+  in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc (Yojson.Safe.to_string json);
+      output_char oc '\n')
+
+let append_accountability_event base_dir ~created_at json =
+  let month = String.sub created_at 0 7 in
+  let day = String.sub created_at 8 2 in
+  let dir = Filename.concat base_dir ".masc/accountability" |> fun root ->
+    Filename.concat root month
+  in
+  Fs_compat.mkdir_p dir;
+  let path = Filename.concat dir (day ^ ".jsonl") in
+  append_jsonl path json
+
+let string_member key json = Yojson.Safe.Util.(json |> member key |> to_string)
+let int_member key json = Yojson.Safe.Util.(json |> member key |> to_int)
+let float_member key json = Yojson.Safe.Util.(json |> member key |> to_float)
+
+let test_same_turn_evidence_marks_claim_supported () =
+  with_room (fun config ->
+      Keeper_accountability.record_completion_claim config
+        ~keeper_name:"keeper-sangsu"
+        ~agent_name:"keeper-sangsu-agent"
+        ~trace_id:"trace-1"
+        ~turn_number:7
+        ~subject:"Ship v1"
+        ~task_id:"T-1"
+        ~evidence_refs:[ "task:T-1" ]
+        ~strong_evidence:true
+        ~strong_evidence_refs:[ "tool:keeper_task_done" ]
+        ();
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"keeper-sangsu" ~agent_name:"keeper-sangsu-agent"
+      in
+      check string "risk band" "low" (string_member "risk_band" summary);
+      check string "routing hint" "normal_routing"
+        (string_member "routing_hint" summary);
+      check int "recent supported claims" 1
+        (int_member "recent_supported_claims" summary);
+      check (float 0.0001) "evidence coverage" 1.0
+        (float_member "evidence_coverage" summary);
+      let history = Yojson.Safe.Util.(summary |> member "history" |> to_list) in
+      check int "history count" 1 (List.length history);
+      let first = List.hd history in
+      check string "history status" "supported" (string_member "status" first);
+      let supporting_refs =
+        Yojson.Safe.Util.(
+          first |> member "supporting_evidence_refs" |> to_list
+          |> List.map to_string)
+      in
+      check bool "contains turn reference" true
+        (List.mem "turn:trace-1:7" supporting_refs))
+
+let test_stale_completion_claim_sets_high_risk () =
+  with_room (fun config ->
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-old-unsupported");
+             ("agent_name", `String "keeper-sangsu-agent");
+             ("keeper_name", `String "keeper-sangsu");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Ship v1");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("task_id", `String "T-1");
+             ("evidence_refs", `List [ `String "task:T-1" ]);
+             ("synthetic", `Bool false);
+           ]);
+      let summary =
+        Keeper_accountability.accountability_summary_json config
+          ~keeper_name:"keeper-sangsu" ~agent_name:"keeper-sangsu-agent"
+      in
+      check string "risk band" "high" (string_member "risk_band" summary);
+      check string "routing hint" "manual_review_recommended"
+        (string_member "routing_hint" summary);
+      check (float 0.0001) "unsupported completion rate" 1.0
+        (float_member "unsupported_completion_rate" summary);
+      check bool "risk helper" true
+        (Keeper_accountability.accountability_risk_is_high config
+           ~keeper_name:"keeper-sangsu" ~agent_name:"keeper-sangsu-agent");
+      let history = Yojson.Safe.Util.(summary |> member "history" |> to_list) in
+      check int "history count" 1 (List.length history);
+      let first = List.hd history in
+      check string "history status" "unsupported" (string_member "status" first))
+
+let test_claim_tool_exposes_routing_warning_for_high_risk_keeper () =
+  with_room (fun config ->
+      let meta = make_test_meta () in
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      append_accountability_event config.base_path ~created_at
+        (`Assoc
+           [
+             ("event_type", `String "claim_created");
+             ("claim_id", `String "acct-high-risk");
+             ("agent_name", `String "keeper-sangsu-agent");
+             ("keeper_name", `String "keeper-sangsu");
+             ("kind", `String "completion_claim");
+             ("subject", `String "Prior claim");
+             ("surface", `String "keeper_turn");
+             ("created_at", `String created_at);
+             ("evidence_refs", `List []);
+             ("synthetic", `Bool false);
+           ]);
+      ignore (Room.add_task config ~title:"Task to claim" ~priority:1 ~description:"desc");
+      let result =
+        Keeper_exec_tools.execute_keeper_tool_call
+          ~config ~meta ~ctx_work:(make_ctx_work ())
+          ~name:"keeper_task_claim" ~input:(`Assoc []) ()
+        |> Yojson.Safe.from_string
+      in
+      check string "warning present"
+        "⚠ Accountability risk is high for this keeper. Prefer manual review or lower-risk routing when equivalent."
+        (string_member "routing_warning" result))
+
+let () =
+  let base_path = Masc_test_deps.find_project_root () in
+  ignore (Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path));
+  Alcotest.run "Keeper_accountability"
+    [
+      ( "accountability",
+        [
+          test_case "same turn evidence marks claim supported" `Quick
+            test_same_turn_evidence_marks_claim_supported;
+          test_case "stale completion claim sets high risk" `Quick
+            test_stale_completion_claim_sets_high_risk;
+          test_case "claim tool exposes routing warning for high risk keeper"
+            `Quick test_claim_tool_exposes_routing_warning_for_high_risk_keeper;
+        ] );
+    ]

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -199,8 +199,10 @@ let test_synthetic_claims_do_not_dilute_unsupported_rate () =
      must NOT be counted in total_completion_claims, otherwise they dilute the
      unsupported_completion_rate and mask genuine risk. *)
   with_room (fun config ->
-      let created_at = iso_of_unix (Unix.gettimeofday () -. 3600.0) in
-      (* 1 real unsupported completion claim *)
+      let created_at =
+        iso_of_unix (Unix.gettimeofday () -. (25.0 *. 3600.0))
+      in
+      (* 1 real unsupported completion claim older than the expiry window *)
       append_accountability_event config.base_path ~created_at
         (`Assoc
            [


### PR DESCRIPTION
Task-069 fix: synthetic completion claims were counted in total_completion_claims, diluting unsupported_completion_rate. Added not snapshot.claim.synthetic guard. Includes regression test. Stacked on PR #7162.