### PR TITLE
feat(dashboard): Phase 6 — absorb connectors + inspector into operations

### DIFF
--- a/dashboard/src/components/control.test.ts
+++ b/dashboard/src/components/control.test.ts
@@ -51,7 +51,7 @@ describe('Operations control surface', () => {
     vi.doUnmock('./lab-inspector')
   })
 
-  it('renders both Ops and Governance by default when section is not set (falls back to operations)', async () => {
+  it('renders both Ops and Governance by default when section is not set', async () => {
     route.value.params = {}
     const { Operations } = await loadOperations()
     render(html`<${Operations} />`, container)
@@ -62,7 +62,7 @@ describe('Operations control surface', () => {
     expect(container.textContent).not.toContain('Connectors')
   })
 
-  it('renders both Ops and Governance when section is operations (Phase 1 consolidated)', async () => {
+  it('renders both Ops and Governance when section is operations', async () => {
     route.value.params = { section: 'operations' }
     const { Operations } = await loadOperations()
     render(html`<${Operations} />`, container)
@@ -72,8 +72,8 @@ describe('Operations control surface', () => {
     expect(container.textContent).toContain('Governance')
   })
 
-  it('renders ConnectorStatusPanel when section is connectors', async () => {
-    route.value.params = { section: 'connectors' }
+  it('renders ConnectorStatusPanel when view is connectors (Phase 6)', async () => {
+    route.value.params = { section: 'operations', view: 'connectors' }
     const { Operations } = await loadOperations()
     render(html`<${Operations} />`, container)
     await flushUi()
@@ -83,8 +83,8 @@ describe('Operations control surface', () => {
     expect(container.textContent).not.toContain('Governance')
   })
 
-  it('renders LabInspector when section is inspector', async () => {
-    route.value.params = { section: 'inspector' }
+  it('renders LabInspector when view is inspector (Phase 6)', async () => {
+    route.value.params = { section: 'operations', view: 'inspector' }
     const { Operations } = await loadOperations()
     render(html`<${Operations} />`, container)
     await flushUi()
@@ -93,7 +93,7 @@ describe('Operations control surface', () => {
     expect(container.textContent).not.toContain('Ops')
   })
 
-  it('falls back to Ops for unknown section values', async () => {
+  it('falls back to Ops+Governance for unknown section values', async () => {
     route.value.params = { section: 'unknown-section' }
     const { Operations } = await loadOperations()
     render(html`<${Operations} />`, container)

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -1,39 +1,15 @@
-// MASC Dashboard — Operations Surface (Phase 1: consolidated)
-// operations (absorbs intervene + governance) + connectors + inspector.
+// MASC Dashboard — Operations Surface (Phase 6: fully unified)
+// All command sub-views (ops, governance, connectors, inspector) are now
+// FilterChips views inside OperationsPanel.
 
 import { html } from 'htm/preact'
-import { route } from '../router'
 import { OperationsPanel } from './operations-panel'
-import { ConnectorStatusPanel } from './connector-status'
-import { LabInspector } from './lab-inspector'
-
-type OperationsSection = 'operations' | 'connectors' | 'inspector'
-
-function currentSection(): OperationsSection {
-  const section = route.value.params.section
-  if (section === 'connectors') return section
-  if (section === 'inspector') return section
-  return 'operations'
-}
-
-function renderSection(section: OperationsSection) {
-  switch (section) {
-    case 'connectors':
-      return html`<${ConnectorStatusPanel} />`
-    case 'inspector':
-      return html`<${LabInspector} />`
-    case 'operations':
-      return html`<${OperationsPanel} />`
-  }
-}
 
 export function Operations() {
-  const section = currentSection()
-
   return html`
     <div class="flex flex-col gap-5">
       <div class="transition-opacity duration-300">
-        ${renderSection(section)}
+        <${OperationsPanel} />
       </div>
     </div>
   `

--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -20,6 +20,12 @@ async function loadPanel() {
   vi.doMock('./governance', () => ({
     Governance: () => html`<div data-testid="governance">Governance</div>`,
   }))
+  vi.doMock('./connector-status', () => ({
+    ConnectorStatusPanel: () => html`<div data-testid="connectors">Connectors</div>`,
+  }))
+  vi.doMock('./lab-inspector', () => ({
+    LabInspector: () => html`<div data-testid="inspector">Inspector</div>`,
+  }))
   return import('./operations-panel')
 }
 
@@ -41,6 +47,8 @@ describe('OperationsPanel', () => {
     vi.doUnmock('../router')
     vi.doUnmock('./ops')
     vi.doUnmock('./governance')
+    vi.doUnmock('./connector-status')
+    vi.doUnmock('./lab-inspector')
   })
 
   it('renders both Ops and Governance when view is not set (default)', async () => {
@@ -72,17 +80,19 @@ describe('OperationsPanel', () => {
     expect(container.textContent).toContain('Governance')
   })
 
-  it('renders 3 FilterChips options', async () => {
+  it('renders 5 FilterChips options (Phase 6: +connectors +inspector)', async () => {
     const { OperationsPanel } = await loadPanel()
     render(html`<${OperationsPanel} />`, container)
     await flushUi()
 
     const buttons = container.querySelectorAll('button[type="button"]')
-    expect(buttons.length).toBe(3)
+    expect(buttons.length).toBe(5)
     const labels = Array.from(buttons).map(b => b.textContent?.trim())
     expect(labels).toContain('전체')
     expect(labels).toContain('개입')
     expect(labels).toContain('거버넌스')
+    expect(labels).toContain('커넥터')
+    expect(labels).toContain('인스펙터')
   })
 
   it('falls back to default for unknown view param', async () => {

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -1,23 +1,30 @@
-// MASC Dashboard — Operations Panel (Phase 5)
-// FilterChips toggle for ops/governance sub-views within the operations section.
+// MASC Dashboard — Operations Panel (Phase 5+6)
+// FilterChips toggle for ops/governance/connectors/inspector sub-views.
+// Phase 6: connectors and inspector absorbed as sub-views.
 
 import { html } from 'htm/preact'
 import { FilterChips } from './common/filter-chips'
 import { Ops } from './ops'
 import { Governance } from './governance'
+import { ConnectorStatusPanel } from './connector-status'
+import { LabInspector } from './lab-inspector'
 import { route } from '../router'
 
-export type OpsView = 'default' | 'ops' | 'governance'
+export type OpsView = 'default' | 'ops' | 'governance' | 'connectors' | 'inspector'
+
+const VALID_VIEWS: OpsView[] = ['default', 'ops', 'governance', 'connectors', 'inspector']
 
 const VIEW_CHIPS: { key: OpsView; label: string }[] = [
   { key: 'default', label: '전체' },
   { key: 'ops', label: '개입' },
   { key: 'governance', label: '거버넌스' },
+  { key: 'connectors', label: '커넥터' },
+  { key: 'inspector', label: '인스펙터' },
 ]
 
 function currentView(): OpsView {
   const view = route.value.params.view
-  if (view === 'ops' || view === 'governance') return view
+  if (view && (VALID_VIEWS as string[]).includes(view)) return view as OpsView
   return 'default'
 }
 
@@ -43,14 +50,18 @@ export function OperationsPanel() {
       />
       ${view === 'ops'
         ? html`<${Ops} />`
-        : view === 'governance'
-          ? html`<${Governance} />`
-          : html`
-              <${Ops} />
-              <div class="mt-4">
-                <${Governance} />
-              </div>
-            `}
+      : view === 'governance'
+        ? html`<${Governance} />`
+      : view === 'connectors'
+        ? html`<${ConnectorStatusPanel} />`
+      : view === 'inspector'
+        ? html`<${LabInspector} />`
+      : html`
+            <${Ops} />
+            <div class="mt-4">
+              <${Governance} />
+            </div>
+          `}
     </div>
   `
 }

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -713,8 +713,8 @@ function ConfigTruthCard() {
 
         <div class="flex flex-col gap-2">
           <${RouteLink}
-            tab="lab"
-            params=${{ section: 'inspector' }}
+            tab="command"
+            params=${{ section: 'operations', view: 'inspector' }}
             class="rounded-xl border border-accent/25 bg-[var(--accent-10)] px-4 py-3 text-[13px] font-semibold text-accent transition-colors hover:bg-accent/18"
             title="운영 인스펙터 열기"
           >

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -23,21 +23,17 @@ describe('lab navigation', () => {
 })
 
 describe('command navigation', () => {
-  it('includes inspector alongside operations (consolidated) and connectors', () => {
+  it('has only operations section (Phase 6: connectors+inspector absorbed as sub-views)', () => {
     expect(defaultParamsForTab('command')).toEqual({ section: 'operations' })
 
     const commandSections = visibleSectionItemsForTab('command')
 
     expect(commandSections.map(item => item.id)).toEqual([
       'operations',
-      'connectors',
-      'inspector',
     ])
 
     expect(commandSections.map(item => item.label)).toEqual([
       '운영 행동',
-      '커넥터',
-      '운영 인스펙터',
     ])
   })
 })
@@ -225,5 +221,17 @@ describe('consolidation redirects (Phase 1)', () => {
   it('workspace:goals → planning', () => {
     const result = normalizeRouteParams('workspace', { section: 'goals' })
     expect(result.section).toBe('planning')
+  })
+
+  it('command:connectors → operations?view=connectors (Phase 6)', () => {
+    const result = normalizeRouteParams('command', { section: 'connectors' })
+    expect(result.section).toBe('operations')
+    expect(result.view).toBe('connectors')
+  })
+
+  it('command:inspector → operations?view=inspector (Phase 6)', () => {
+    const result = normalizeRouteParams('command', { section: 'inspector' })
+    expect(result.section).toBe('operations')
+    expect(result.view).toBe('inspector')
   })
 })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -10,9 +10,7 @@ export type SurfaceSectionId =
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'memory-subsystems'
   // command
-  | 'operations'     // Phase 1: absorbs intervene + command governance
-  | 'connectors'
-  | 'inspector'
+  | 'operations'     // Phase 1+6: absorbs intervene + governance + connectors + inspector
   // workspace
   | 'board'
   | 'planning'       // Phase 1: absorbs goals
@@ -156,20 +154,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'operations',
       label: '운영 행동',
-      description: '브로드캐스트, 키퍼 메시지, 자율 결정 승인/반려를 한 화면에서.',
+      description: '브로드캐스트, 키퍼 메시지, 자율 결정 승인/반려, 커넥터, 인스펙터를 한 화면에서.',
       params: { section: 'operations' },
-    },
-    {
-      id: 'connectors',
-      label: '커넥터',
-      description: '외부 채널(Discord 등) 연결 상태, 바인딩 관리, 이벤트 로그.',
-      params: { section: 'connectors' },
-    },
-    {
-      id: 'inspector',
-      label: '운영 인스펙터',
-      description: '피처 플래그와 서버 설정을 한 화면으로 묶은 운영 진단/점검 화면.',
-      params: { section: 'inspector' },
     },
   ],
   workspace: [
@@ -261,9 +247,11 @@ export const SECTION_REDIRECTS: Record<TabSectionKey, SectionRedirect> = {
   'monitoring:fsm-hub':      { section: 'agents', view: 'fsm' },
   'monitoring:metrics':      { section: 'runtime' },
 
-  // Dashboard consolidation Phase 1: command surface
-  'command:intervene':  { section: 'operations' },
-  'command:governance': { section: 'operations' },
+  // Dashboard consolidation Phase 1+6: command surface
+  'command:intervene':    { section: 'operations' },
+  'command:governance':   { section: 'operations' },
+  'command:connectors':   { section: 'operations', view: 'connectors' },
+  'command:inspector':    { section: 'operations', view: 'inspector' },
 
   // Dashboard consolidation Phase 1: workspace surface
   'workspace:goals': { section: 'planning' },

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -105,10 +105,10 @@ describe('refreshPlanForRoute', () => {
     })).toEqual([])
   })
 
-  it('refreshes the inspector shell through server config once', async () => {
+  it('refreshes the inspector shell through server config once (Phase 6: view param)', async () => {
     refreshForRoute({
       tab: 'command',
-      params: { section: 'inspector' },
+      params: { section: 'operations', view: 'inspector' },
     })
 
     await waitFor(() => {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -70,7 +70,7 @@ export function refreshPlanForRoute(routeState: Pick<RouteState, 'tab' | 'params
       }
       return ['namespaceTruth', 'missionSnapshot']
     case 'command':
-      if (routeState.params.section === 'inspector') {
+      if (routeState.params.view === 'inspector') {
         return ['inspector']
       }
       return ['namespaceTruth', 'operatorSnapshot', 'operatorRoomDigest']


### PR DESCRIPTION
## Summary

- connectors/inspector를 독립 sidebar section에서 제거
- OperationsPanel의 FilterChips sub-view로 흡수 (5 chips: 전체/개입/거버넌스/커넥터/인스펙터)
- SurfaceSectionId 15 → 13, command sidebar 3 → 1 항목
- control.ts 41 → 17줄

## 변경 파일 (8)

| 파일 | 변경 |
|------|------|
| `navigation.ts` | SurfaceSectionId에서 connectors/inspector 제거, redirect 추가 |
| `navigation.test.ts` | command sections 테스트 업데이트 + redirect 테스트 추가 |
| `operations-panel.ts` | OpsView에 connectors/inspector chip 추가 |
| `control.ts` | connectors/inspector 분기 제거 → pure OperationsPanel |
| `control.test.ts` | section → view param 전환 |
| `tab-refresh.ts` | inspector 감지: section → view param |
| `tab-refresh.test.ts` | inspector 테스트 업데이트 |
| `overview.ts` | inspector 링크 tab=lab → tab=command |

## Phase 흐름

| Phase | PR | 상태 |
|-------|-----|------|
| -1~1 | #7125~#7152 | Merged |
| 2 | #7165 | Merged |
| 3 | #7172 | Merged |
| 4 | #7183 | Merged |
| 5 | #7181 | Merged |
| **6** | **이 PR** | Draft |

## Test plan

- [x] `tsc --noEmit` — zero
- [x] `vite build` — success
- [x] navigation.test.ts — 27/27 pass
- [x] control.test.ts — 5/5 pass
- [x] tab-refresh.test.ts — 9/9 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)