### PR TITLE
feat(dashboard): Phase 7 — planning FilterChips with goal-tree sub-view

### DIFF
--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -276,7 +276,7 @@ export function Planning() {
           <button
             type="button"
             class="inline-flex items-center gap-1.5 rounded-lg border border-accent/25 bg-[var(--accent-12)] px-3 py-1.5 text-[12px] font-medium text-accent transition-colors hover:border-accent/40 hover:bg-[var(--accent-15)]"
-            onClick=${() => navigate('workspace', { section: 'planning' })}
+            onClick=${() => navigate('workspace', { section: 'planning', view: 'goal-tree' })}
           >
             목표 트리에서 보기
             <span aria-hidden="true">\u2192</span>

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -1,0 +1,59 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const routeSignal = signal<{ tab: string; params: Record<string, string>; postId: string | null }>({
+  tab: 'workspace',
+  params: { section: 'planning' },
+  postId: null,
+})
+
+vi.mock('../router', () => ({
+  get route() { return routeSignal },
+}))
+
+vi.mock('./goals', () => ({
+  Planning: () => html`<div data-testid="planning">Planning</div>`,
+}))
+vi.mock('./goals/goal-tree', () => ({
+  GoalTree: () => html`<div data-testid="goal-tree">GoalTree</div>`,
+}))
+
+import { PlanningPanel } from './planning-panel'
+
+function setRoute(view?: string) {
+  const params: Record<string, string> = { section: 'planning' }
+  if (view) params.view = view
+  routeSignal.value = { tab: 'workspace', params, postId: null }
+}
+
+describe('PlanningPanel', () => {
+  beforeEach(() => setRoute())
+  afterEach(() => cleanup())
+
+  it('renders Planning (kanban) by default', () => {
+    render(html`<${PlanningPanel} />`)
+    expect(screen.getByTestId('planning')).toBeTruthy()
+    expect(screen.queryByTestId('goal-tree')).toBeNull()
+  })
+
+  it('renders GoalTree when view=goal-tree', () => {
+    setRoute('goal-tree')
+    render(html`<${PlanningPanel} />`)
+    expect(screen.getByTestId('goal-tree')).toBeTruthy()
+    expect(screen.queryByTestId('planning')).toBeNull()
+  })
+
+  it('renders FilterChips with 2 options', () => {
+    render(html`<${PlanningPanel} />`)
+    expect(screen.getByText('칸반')).toBeTruthy()
+    expect(screen.getByText('목표 트리')).toBeTruthy()
+  })
+
+  it('falls back to default for unknown view', () => {
+    setRoute('nonexistent')
+    render(html`<${PlanningPanel} />`)
+    expect(screen.getByTestId('planning')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/planning-panel.ts
+++ b/dashboard/src/components/planning-panel.ts
@@ -1,0 +1,56 @@
+// Planning Panel — Phase 7 unified view for planning section.
+// FilterChips toggle between kanban (Planning) and goal-tree (GoalTree).
+// Revives GoalTree which became dead code after Phase 1 removed the
+// standalone goals section.
+
+import { html } from 'htm/preact'
+import { computed } from '@preact/signals'
+import { route } from '../router'
+import { FilterChips } from './common/filter-chips'
+import { Planning } from './goals'
+import { GoalTree } from './goals/goal-tree'
+
+export type PlanningView = 'default' | 'goal-tree'
+
+const PLANNING_VIEWS: PlanningView[] = ['default', 'goal-tree']
+
+function isPlanningView(v: string | undefined): v is PlanningView {
+  return !!v && (PLANNING_VIEWS as string[]).includes(v)
+}
+
+const activeView = computed<PlanningView>(() => {
+  const v = route.value.params.view
+  return isPlanningView(v) ? v : 'default'
+})
+
+const VIEW_CHIPS: Array<{ key: PlanningView; label: string }> = [
+  { key: 'default',   label: '칸반' },
+  { key: 'goal-tree', label: '목표 트리' },
+]
+
+function updateViewParam(view: PlanningView): void {
+  const hash = view === 'default'
+    ? '#workspace?section=planning'
+    : `#workspace?section=planning&view=${view}`
+  history.replaceState(null, '', hash)
+  window.dispatchEvent(new HashChangeEvent('hashchange'))
+}
+
+export function PlanningPanel() {
+  const view = activeView.value
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <${FilterChips}
+        chips=${VIEW_CHIPS}
+        value=${view}
+        onChange=${updateViewParam}
+        size="sm"
+        tone="accent"
+      />
+      ${view === 'goal-tree'
+        ? html`<${GoalTree} />`
+        : html`<${Planning} />`}
+    </div>
+  `
+}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1,10 +1,10 @@
-// MASC Dashboard — Work Tab (Phase 1: goals absorbed into planning)
-// board + planning (includes goal pipeline summary + goals deep-link).
+// MASC Dashboard — Work Tab (Phase 7: planning with goal-tree sub-view)
+// board + planning (FilterChips: kanban / goal-tree).
 
 import { html } from 'htm/preact'
 import { route } from '../router'
 import { Memory } from './memory'
-import { Planning } from './goals'
+import { PlanningPanel } from './planning-panel'
 import { ErrorBoundary } from './common/error-boundary'
 
 type WorkSection = 'board' | 'planning'
@@ -23,7 +23,7 @@ export function Work() {
       <div class="transition-opacity duration-300">
         <${ErrorBoundary} label=${current}>
           ${current === 'board' ? html`<${Memory} />`
-            : html`<${Planning} />`
+            : html`<${PlanningPanel} />`
           }
         </>
       </div>


### PR DESCRIPTION
## Summary

- planning section에 FilterChips 추가: 칸반 (기본) / 목표 트리
- Phase 1에서 dead code가 된 GoalTree 컴포넌트를 sub-view로 부활
- "목표 트리에서 보기" 버튼이 view=goal-tree로 직접 이동

## 변경 파일 (4)

| 파일 | 변경 |
|------|------|
| `planning-panel.ts` | 새 파일: FilterChips wrapper |
| `planning-panel.test.ts` | 새 파일: 4 tests |
| `work.ts` | Planning → PlanningPanel |
| `goals/planning.ts` | 목표 트리 버튼 navigate에 view param 추가 |

## Phase 흐름

| Phase | PR | 상태 |
|-------|-----|------|
| -1~5 | #7125~#7183 | Merged |
| 6 | #7200 | Draft |
| **7** | **이 PR** | Draft |

## Test plan

- [x] `tsc --noEmit` — zero
- [x] `vite build` — success
- [x] planning-panel.test.ts — 4/4 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)