### PR TITLE
[codex] repair orphan tool results in keeper checkpoints

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -223,6 +223,69 @@ let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
          |> Option.map Inference_utils.sanitize_text_utf8);
     }
 
+let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolUse { id; _ } -> Some id
+      | _ -> None)
+    msg.content
+
+let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
+  List.exists
+    (function
+      | Agent_sdk.Types.ToolResult _ -> true
+      | _ -> false)
+    msg.content
+
+let tool_result_text_of_block
+    ~(tool_use_id : string)
+    ~(content : string)
+    ~(json : Yojson.Safe.t option) : string =
+  let content = Inference_utils.sanitize_text_utf8 (String.trim content) in
+  if content <> "" then content
+  else
+    match json with
+    | Some value -> Yojson.Safe.to_string value
+    | None -> Printf.sprintf "[tool result %s]" tool_use_id
+
+let repair_orphan_tool_result_messages
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let rec loop prev acc = function
+    | [] -> List.rev acc
+    | msg :: rest ->
+        let repaired =
+          if not (has_tool_result_block msg) then msg
+          else
+            let prev_tool_use_ids =
+              match prev with
+              | Some previous -> tool_use_ids_of_message previous
+              | None -> []
+            in
+            let has_orphan =
+              List.exists
+                (function
+                  | Agent_sdk.Types.ToolResult { tool_use_id; _ } ->
+                      not (List.mem tool_use_id prev_tool_use_ids)
+                  | _ -> false)
+                msg.content
+            in
+            if not has_orphan then msg
+            else
+              let content =
+                List.map
+                  (function
+                    | Agent_sdk.Types.ToolResult { tool_use_id; content; json; _ } ->
+                        Agent_sdk.Types.Text
+                          (tool_result_text_of_block ~tool_use_id ~content ~json)
+                    | other -> other)
+                  msg.content
+              in
+              { msg with content }
+        in
+        loop (Some repaired) (repaired :: acc) rest
+  in
+  loop None [] messages
+
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
     ("system_prompt", `String (Inference_utils.sanitize_text_utf8 ctx.system_prompt));
@@ -236,7 +299,10 @@ let deserialize_context (s : string) ~max_tokens : working_context =
   let json = Yojson.Safe.from_string s in
   let open Yojson.Safe.Util in
   let system_prompt = json |> member "system_prompt" |> to_string in
-  let messages = json |> member "messages" |> to_list |> List.map message_of_json in
+  let messages =
+    json |> member "messages" |> to_list |> List.map message_of_json
+    |> repair_orphan_tool_result_messages
+  in
   let _legacy_token_count = json |> member "token_count" |> to_int_option in
   sync_oas_context
     {
@@ -816,7 +882,7 @@ let sanitize_oas_checkpoint
     (cp : Agent_sdk.Checkpoint.t)
   : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
   let messages, stats = sanitize_checkpoint_messages cp.messages in
-  ({ cp with messages }, stats)
+  ({ cp with messages = repair_orphan_tool_result_messages messages }, stats)
 
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in
@@ -844,6 +910,7 @@ let context_of_oas_checkpoint
     else
       let drop = n - max_checkpoint_messages in
       List.filteri (fun i _ -> i >= drop) cp.messages
+    |> repair_orphan_tool_result_messages
   in
   sync_oas_context
     {
@@ -897,6 +964,9 @@ let save_oas_checkpoint
       capped_messages
   in
   let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
+  let capped_messages =
+    repair_orphan_tool_result_messages capped_messages
+  in
   let state =
     {
       Agent_sdk.Types.config =

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -261,6 +261,12 @@ let repair_orphan_tool_result_messages
               | Some previous -> tool_use_ids_of_message previous
               | None -> []
             in
+            (* Anthropic validates ToolResult blocks against ToolUse blocks
+               in the immediately previous message. If checkpoint capping
+               drops that predecessor, the resumed history becomes invalid.
+               Downgrade only the orphaned structured result blocks to
+               plain text so the semantic output survives without replaying
+               provider-specific tool metadata. *)
             let has_orphan =
               List.exists
                 (function

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -885,10 +885,15 @@ let sanitize_checkpoint_messages
     ([], empty_checkpoint_sanitize_stats)
 
 let sanitize_oas_checkpoint
+    ?(repair_orphans = true)
     (cp : Agent_sdk.Checkpoint.t)
   : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
   let messages, stats = sanitize_checkpoint_messages cp.messages in
-  ({ cp with messages = repair_orphan_tool_result_messages messages }, stats)
+  let messages =
+    if repair_orphans then repair_orphan_tool_result_messages messages
+    else messages
+  in
+  ({ cp with messages }, stats)
 
 let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int =
   let open Yojson.Safe.Util in
@@ -902,21 +907,25 @@ let checkpoint_max_tokens (cp : Agent_sdk.Checkpoint.t) ~(fallback : int) : int 
       | _ -> fallback)
 
 let context_of_oas_checkpoint
+    ?(repair_orphans = true)
     ~(max_checkpoint_messages : int)
     (cp : Agent_sdk.Checkpoint.t)
     ~(primary_model_max_tokens : int) : working_context =
-  let cp, _ = sanitize_oas_checkpoint cp in
+  let cp, _ = sanitize_oas_checkpoint ~repair_orphans cp in
   let system_prompt = Option.value ~default:"" cp.system_prompt in
   let max_tokens =
     checkpoint_max_tokens cp ~fallback:primary_model_max_tokens
   in
   let messages =
     let n = List.length cp.messages in
-    if n <= max_checkpoint_messages then cp.messages
-    else
-      let drop = n - max_checkpoint_messages in
-      List.filteri (fun i _ -> i >= drop) cp.messages
-    |> repair_orphan_tool_result_messages
+    let messages =
+      if n <= max_checkpoint_messages then cp.messages
+      else
+        let drop = n - max_checkpoint_messages in
+        List.filteri (fun i _ -> i >= drop) cp.messages
+    in
+    if repair_orphans then repair_orphan_tool_result_messages messages
+    else messages
   in
   sync_oas_context
     {
@@ -960,6 +969,9 @@ let save_oas_checkpoint
       let drop = n - max_checkpoint_messages in
       List.filteri (fun i _ -> i >= drop) ctx.messages
   in
+  let capped_messages_were_truncated =
+    List.length capped_messages < List.length ctx.messages
+  in
   (* Stub old tool results at save time: keep only the most recent turn's
      results in full. During Agent.run the reducer uses keep_recent:3, but
      at checkpoint persistence we are more aggressive — older tool results
@@ -971,7 +983,9 @@ let save_oas_checkpoint
   in
   let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
   let capped_messages =
-    repair_orphan_tool_result_messages capped_messages
+    if capped_messages_were_truncated
+    then repair_orphan_tool_result_messages capped_messages
+    else capped_messages
   in
   let state =
     {

--- a/lib/keeper/keeper_exec_context.mli
+++ b/lib/keeper/keeper_exec_context.mli
@@ -59,6 +59,7 @@ val checkpoint_max_tokens :
   Agent_sdk.Checkpoint.t -> fallback:int -> int
 
 val context_of_oas_checkpoint :
+  ?repair_orphans:bool ->
   max_checkpoint_messages:int ->
   Agent_sdk.Checkpoint.t -> primary_model_max_tokens:int -> working_context
 

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -125,7 +125,13 @@ let apply_post_turn_lifecycle
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx =
+        context_of_oas_checkpoint
+          ~repair_orphans:false
+          ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+          cp
+          ~primary_model_max_tokens
+      in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in
@@ -286,7 +292,9 @@ let recover_latest_checkpoint_for_overflow_retry
   let oas_checkpoint =
     Result.to_option oas_result
     |> Option.map (fun checkpoint ->
-      let sanitized, stats = sanitize_oas_checkpoint checkpoint in
+      let sanitized, stats =
+        sanitize_oas_checkpoint ~repair_orphans:false checkpoint
+      in
       if checkpoint_sanitize_changed stats then begin
         Log.Keeper.warn
           "keeper:%s overflow-retry migration sanitized messages: dropped_blocks=%d dropped_messages=%d dropped_chars=%d truncated_blocks=%d truncated_chars=%d"
@@ -327,7 +335,11 @@ let recover_latest_checkpoint_for_overflow_retry
           checkpoint_generation checkpoint ~fallback:meta.runtime.generation
         in
         Some
-          ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint ~primary_model_max_tokens,
+          ( context_of_oas_checkpoint
+              ~repair_orphans:false
+              ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+              checkpoint
+              ~primary_model_max_tokens,
             turn_generation )
     | _, _, Some checkpoint ->
         (try
@@ -348,7 +360,10 @@ let recover_latest_checkpoint_for_overflow_retry
                       ~fallback:meta.runtime.generation
                   in
                   Some
-                    ( context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages checkpoint
+                    ( context_of_oas_checkpoint
+                        ~repair_orphans:false
+                        ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+                        checkpoint
                         ~primary_model_max_tokens,
                       turn_generation )
               | None -> None))

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -95,7 +95,13 @@ let maybe_rollover_oas_handoff
         message_count = 0;
       }
   | Some cp ->
-      let ctx = context_of_oas_checkpoint ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages cp ~primary_model_max_tokens in
+      let ctx =
+        context_of_oas_checkpoint
+          ~repair_orphans:false
+          ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
+          cp
+          ~primary_model_max_tokens
+      in
       let current_generation =
         checkpoint_generation cp ~fallback:meta.runtime.generation
       in

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -975,6 +975,99 @@ let test_save_oas_checkpoint_stubs_old_tool_results () =
            | Some content ->
                check string "recent tool result stays full" recent_output content))
 
+let test_save_oas_checkpoint_repairs_orphaned_tool_result_after_cap () =
+  let base_dir = temp_dir "keeper_lifecycle_save_orphan_tool_result" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let session =
+        KEC.create_session ~session_id:"trace-save-orphan-tool-result" ~base_dir
+      in
+      let tool_id = "tool-orphan-save" in
+      let tool_output = "saved tool output" in
+      let ctx =
+        KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:64_000
+        |> fun ctx ->
+        KEC.append_many ctx
+          [
+            Agent_sdk.Types.user_msg "inspect file";
+            tool_use_message ~tool_use_id:tool_id ();
+            tool_result_message ~tool_use_id:tool_id tool_output;
+            Agent_sdk.Types.assistant_msg "done";
+          ]
+        |> KEC.sync_oas_context
+      in
+      match
+        KEC.save_oas_checkpoint
+          ~max_checkpoint_messages:2
+          ~session
+          ~agent_name:"keeper-lifecycle"
+          ~model:"glm:glm-5.1"
+          ~ctx
+          ~generation:1
+      with
+      | Error e ->
+          Alcotest.fail
+            (Printf.sprintf "save_oas_checkpoint failed: %s" e)
+      | Ok checkpoint ->
+          check int "save cap still enforced" 2
+            (List.length checkpoint.messages);
+          check (option string) "orphan tool result no longer structured" None
+            (tool_result_content_for_id ~tool_use_id:tool_id checkpoint.messages);
+          (match List.hd checkpoint.messages with
+           | { Agent_sdk.Types.content = [ Agent_sdk.Types.Text text ]; _ } ->
+               check string "orphan tool result downgraded to text"
+                 tool_output text
+           | _ -> fail "expected downgraded text message after save cap"))
+
+let test_load_context_repairs_orphaned_tool_result_after_cap () =
+  let base_dir = temp_dir "keeper_lifecycle_load_orphan_tool_result" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-load-orphan-tool-result" in
+      let session =
+        KEC.create_session ~session_id:trace_id ~base_dir
+      in
+      let tool_id = "tool-orphan-load" in
+      let tool_output = "loaded tool output" in
+      let checkpoint =
+        make_test_checkpoint ~session_id:trace_id
+          [
+            Agent_sdk.Types.user_msg "inspect file";
+            tool_use_message ~tool_use_id:tool_id ();
+            tool_result_message ~tool_use_id:tool_id tool_output;
+            Agent_sdk.Types.assistant_msg "done";
+          ]
+      in
+      (match
+         Masc_mcp.Keeper_checkpoint_store.save_oas
+           ~session_dir:session.session_dir checkpoint
+       with
+       | Ok () -> ()
+       | Error e ->
+           Alcotest.fail
+             (Printf.sprintf "save_oas failed: %s" e));
+      let (_session, loaded_opt) =
+        KEC.load_context_from_checkpoint
+          ~max_checkpoint_messages:2
+          ~trace_id
+          ~primary_model_max_tokens:64_000
+          ~base_dir
+      in
+      match loaded_opt with
+      | None -> fail "expected checkpoint context to load"
+      | Some loaded ->
+          check int "load cap still enforced" 2
+            (List.length loaded.messages);
+          check (option string) "loaded orphan tool result no longer structured" None
+            (tool_result_content_for_id ~tool_use_id:tool_id loaded.messages);
+          (match List.hd loaded.messages with
+           | { Agent_sdk.Types.content = [ Agent_sdk.Types.Text text ]; _ } ->
+               check string "loaded orphan tool result downgraded to text"
+                 tool_output text
+           | _ -> fail "expected downgraded text message after load cap"))
+
 let test_save_oas_checkpoint_strips_summarized_world_state () =
   let base_dir = temp_dir "keeper_lifecycle_save_summary_strip" in
   Fun.protect
@@ -1405,6 +1498,8 @@ let () =
             test_sanitize_checkpoint_message_caps_tool_result_aggregate_budget;
           test_case "save stubs old tool results" `Quick
             test_save_oas_checkpoint_stubs_old_tool_results;
+          test_case "save repairs orphaned tool result after cap" `Quick
+            test_save_oas_checkpoint_repairs_orphaned_tool_result_after_cap;
           test_case "save strips summarized world state" `Quick
             test_save_oas_checkpoint_strips_summarized_world_state;
           test_case "patch replaces last assistant text" `Quick
@@ -1423,6 +1518,8 @@ let () =
             test_load_context_migrates_oversized_text_checkpoint;
           test_case "load migrates summarized world state checkpoint" `Quick
             test_load_context_migrates_summarized_world_state_checkpoint;
+          test_case "load repairs orphaned tool result after cap" `Quick
+            test_load_context_repairs_orphaned_tool_result_after_cap;
         ] );
       ( "compact_policy",
         [

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -1068,6 +1068,58 @@ let test_load_context_repairs_orphaned_tool_result_after_cap () =
                  tool_output text
            | _ -> fail "expected downgraded text message after load cap"))
 
+let test_deserialize_context_repairs_orphan_tool_result () =
+  let ctx =
+    KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:4096
+    |> fun ctx ->
+    KEC.append ctx
+      {
+        Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+        content =
+          [
+            Agent_sdk.Types.ToolResult
+              {
+                tool_use_id = "call-orphan-json";
+                content = "";
+                is_error = false;
+                json = Some (`Assoc [ ("path", `String "README.md") ]);
+              };
+          ];
+        name = None;
+        tool_call_id = None;
+      }
+  in
+  let ctx =
+    KCC.deserialize_context (KEC.serialize_context ctx) ~max_tokens:4096
+  in
+  check (option string) "deserialized orphan tool result downgraded" None
+    (tool_result_content_for_id ~tool_use_id:"call-orphan-json" ctx.messages);
+  match List.hd ctx.messages with
+  | { Agent_sdk.Types.content = [ Agent_sdk.Types.Text text ]; _ } ->
+      check string "deserialized orphan falls back to marker when payload metadata is absent"
+        "[tool result call-orphan-json]" text
+  | _ -> fail "expected orphan tool result to degrade to text on deserialize"
+
+let test_deserialize_context_preserves_valid_tool_pair () =
+  let tool_id = "call-valid-pair" in
+  let ctx =
+    KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:4096
+    |> fun ctx ->
+    KEC.append_many ctx
+      [
+        Agent_sdk.Types.user_msg "read the file";
+        tool_use_message ~tool_use_id:tool_id ();
+        tool_result_message ~tool_use_id:tool_id "paired output";
+        Agent_sdk.Types.assistant_msg "done";
+      ]
+  in
+  let roundtrip =
+    KCC.deserialize_context (KEC.serialize_context ctx) ~max_tokens:4096
+  in
+  check (option string) "paired tool result stays structured"
+    (Some "paired output")
+    (tool_result_content_for_id ~tool_use_id:tool_id roundtrip.messages)
+
 let test_save_oas_checkpoint_strips_summarized_world_state () =
   let base_dir = temp_dir "keeper_lifecycle_save_summary_strip" in
   Fun.protect
@@ -1520,6 +1572,10 @@ let () =
             test_load_context_migrates_summarized_world_state_checkpoint;
           test_case "load repairs orphaned tool result after cap" `Quick
             test_load_context_repairs_orphaned_tool_result_after_cap;
+          test_case "deserialize repairs orphaned tool result" `Quick
+            test_deserialize_context_repairs_orphan_tool_result;
+          test_case "deserialize preserves valid tool pair" `Quick
+            test_deserialize_context_preserves_valid_tool_pair;
         ] );
       ( "compact_policy",
         [


### PR DESCRIPTION
## Summary
Repair orphan `ToolResult` history in keeper checkpoints before resume so capped history no longer breaks the next Anthropic-backed turn.

## What changed
- added checkpoint-history repair logic in `keeper_context_core` that downgrades orphaned `ToolResult` blocks to plain text when their matching `ToolUse` is no longer present in the previous message
- applied that repair on deserialize, OAS checkpoint sanitization, post-cap load, and save-time checkpoint persistence
- added lifecycle tests covering both save-time and load-time cap paths

## Why
Keeper checkpoints were capped by taking the last N messages. That could drop the assistant `ToolUse` while keeping the following `ToolResult`. On the next turn, Anthropic rejected the resumed history with `unexpected \`tool_use_id\``, and mutating keepers escalated into ambiguous partial commit mode because retry stayed disabled after the committed tool call.

## Product impact
- existing corrupted checkpoints self-heal on the next load
- future capped checkpoints stop reintroducing the same orphaned tool-result shape
- keepers that execute mutating tools stop getting stuck behind repeated ambiguous partial commit failures from this specific history-corruption path

## Evidence
- local logs showed `nick0cave` and `janitor` hitting ambiguous partial commit after successful mutating tools, with the underlying provider error `unexpected \`tool_use_id\``
- the root cause is reproducible by capping history across a `ToolUse` / `ToolResult` boundary

## Review evidence
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-orphan-toolresult-checkpoint ./test/test_keeper_lifecycle.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-orphan-toolresult-checkpoint ./test/test_oas_worker.exe`

## Linked issue
Refs #7205
