### PR TITLE
fix(dashboard): replace useEffect signal sync with computed in agents-unified

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -2,8 +2,7 @@
 // Absorbs: agent-roster + execution + keeper-roster + FSM hub into one view with chip toggle.
 
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
 import { agents, keepers, executionLoaded, shellCounts } from '../store'
@@ -18,7 +17,14 @@ import { FsmHub } from './fsm-hub'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
 
-const activeView = signal<AgentsView>('all')
+const VALID_VIEWS: AgentsView[] = ['all', 'agents', 'keepers', 'fsm']
+
+// Derive active view from route params. Single source of truth — no
+// useEffect sync needed. Falls back to 'all' when view param is absent.
+const activeView = computed<AgentsView>(() => {
+  const v = route.value.params.view
+  return v && (VALID_VIEWS as string[]).includes(v) ? v as AgentsView : 'all'
+})
 
 const CHIPS: { id: AgentsView; label: string; description: string }[] = [
   { id: 'all', label: '전체 보기', description: '에이전트와 키퍼를 한 목록에서 봅니다.' },
@@ -34,18 +40,7 @@ export function AgentsUnified() {
     return html`<${AgentProfile} name=${agentParam} />`
   }
 
-  const viewParam = route.value.params.view as string | undefined
-  const routeView =
-    viewParam === 'keepers' || viewParam === 'agents' || viewParam === 'fsm'
-      ? viewParam
-      : null
-  const currentView = routeView ?? activeView.value
-
-  useEffect(() => {
-    if (routeView && activeView.value !== routeView) {
-      activeView.value = routeView
-    }
-  }, [routeView])
+  const currentView = activeView.value
 
   // Compute counts for chip badges.
   const liveRuntimeCounts = countRuntimeKinds(agents.value, keepers.value, missionKeeperBriefs.value)
@@ -76,7 +71,7 @@ export function AgentsUnified() {
     <div class="flex flex-col gap-4">
       <${FilterChips}
         chips=${viewChips}
-        active=${activeView}
+        value=${currentView}
         onChange=${(key: AgentsView) => {
           navigate('monitoring', key === 'all' ? { section: 'agents' } : { section: 'agents', view: key })
         }}


### PR DESCRIPTION
## Summary

agents-unified.ts에서 `useEffect`로 route params를 module-level signal에 동기화하던 패턴을 `computed`로 교체.

**Before**: `signal('all')` + `useEffect(() => { activeView.value = routeView }, [routeView])`
**After**: `computed(() => route.value.params.view)`

이 패턴은 fleet-health-panel, runtime-panel, operations-panel에서 이미 사용 중.

## 문제

useEffect는 렌더 후 비동기 실행되므로, route 변경 직후 한 프레임 동안 이전 view가 렌더됨 (stale render).
computed는 읽는 즉시 최신 값을 반환하므로 이 문제가 없음.

## useEffect 감사 결과

| 카테고리 | 건수 | 이 PR | 비고 |
|----------|------|-------|------|
| SIGNAL_SYNC | 6 | **1 수정** | 나머지는 양방향 바인딩/state cleanup으로 정당 |
| FETCH_NO_LIFECYCLE | 9 | 별도 PR | AbortController 추가 필요 (함수 시그니처 변경) |
| DERIVED_STATE | 5 | 별도 평가 | 경계 사례 |

## Test plan

- [x] `tsc --noEmit` — zero
- [x] `vite build` — success
- [x] navigation.test.ts — 27/27 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)