### PR TITLE
refactor(dashboard): convert remaining List.mem session/operation checks to variant

### DIFF
--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -392,13 +392,12 @@ let detachment_index command_plane_json =
     detachments;
   table
 
-let operation_severity ~status ~blocker_summary =
-  if List.mem status [ "failed"; "cancelled" ] then
-    Tone_bad
-  else if status = "paused" || Option.is_some blocker_summary then
-    Tone_warn
-  else
-    Tone_ok
+let operation_severity ~(status : Cp_types.operation_status) ~blocker_summary =
+  match status with
+  | Cp_types.Failed | Cancelled -> Tone_bad
+  | Paused -> Tone_warn
+  | _ when Option.is_some blocker_summary -> Tone_warn
+  | Planned | Active | Completed -> Tone_ok
 
 let build_operation_contexts command_plane_json =
   let operations =
@@ -427,8 +426,9 @@ let build_operation_contexts command_plane_json =
                  else
                    None
            in
-           let status = string_field ~default:"active" "status" operation in
-           let severity = operation_severity ~status ~blocker_summary in
+           let status_str = string_field ~default:"active" "status" operation in
+           let op_status = Option.value ~default:Cp_types.Active (Cp_serde.operation_status_of_string status_str) in
+           let severity = operation_severity ~status:op_status ~blocker_summary in
            let linked_session_id, linked_detachment_id =
              match Hashtbl.find_opt detachments operation_id with
              | Some (session_id, detachment_id) -> (session_id, detachment_id)
@@ -463,7 +463,7 @@ let build_operation_contexts command_plane_json =
                    [
                      ("operation_id", `String operation_id);
                      ("objective", member_assoc "objective" operation);
-                     ("status", `String status);
+                     ("status", `String status_str);
                      ("stage", member_assoc "stage" operation);
                      ("assigned_unit_id", member_assoc "assigned_unit_id" operation);
                      ("assigned_unit_label", member_assoc "assigned_unit_label" operation_card);

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -213,7 +213,11 @@ let _build_session_context session_json _cards =
         "live=recent_turns · planned=known_members"
     in
     let status = session_status_string session_json in
-    let is_terminal = List.mem status [ "completed"; "interrupted"; "cancelled"; "expired" ] in
+    let status_lc = Dashboard_utils.session_lifecycle_of_string status in
+    let is_terminal = match status_lc with
+      | Dashboard_utils.SL_completed | SL_interrupted | SL_cancelled | SL_expired -> true
+      | SL_active | SL_running | SL_paused | SL_failed | SL_stopped | SL_unknown -> false
+    in
     let blocker_summary =
       if is_terminal then
         (* Terminal sessions cannot be blocked — suppress stale blockers *)

--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -195,19 +195,22 @@ let read_recent_room_event_lines config ~limit =
       month_dirs;
     List.rev !collected
 
+let is_session_concluded (status : string) =
+  match Dashboard_utils.session_lifecycle_of_string status with
+  | Dashboard_utils.SL_completed | SL_interrupted | SL_cancelled -> true
+  | SL_active | SL_running | SL_paused | SL_failed | SL_stopped | SL_expired | SL_unknown -> false
+
 let status_of_archived_session (session : session_context option) =
   match session with
   | Some session ->
-      if List.mem session.status [ "completed"; "interrupted"; "cancelled" ]
-      then "inactive"
-      else "offline"
+      if is_session_concluded session.status then "inactive" else "offline"
   | None -> "unknown"
 
 let archived_reason_for_session (session : session_context option) =
   match session with
   | Some session ->
       Some
-        (if List.mem session.status [ "completed"; "interrupted"; "cancelled" ]
+        (if is_session_concluded session.status
          then "not in current namespace state"
          else "missing from current namespace state")
   | None -> None


### PR DESCRIPTION
## Summary
#7203 squash merge에서 누락된 3파일 변경 보완:

- `dashboard_mission.ml`: `List.mem status ["completed"; "interrupted"; "cancelled"; "expired"]` → `session_lifecycle` exhaustive match
- `dashboard_mission_agents.ml`: `List.mem session.status [...]` → `is_session_concluded` + `session_lifecycle` variant
- `dashboard_execution_builders.ml`: `operation_severity` `List.mem status ["failed"; "cancelled"]` → `Cp_types.operation_status` exhaustive match

## Why
#7203에서 `session_lifecycle` variant를 도입했지만, 마지막 커밋(3파일)이 squash merge에 포함되지 않아 main에 반영 안 됨. 더블 체크 스캔에서 발견.

## Test plan
- [x] `dune build --root . lib/` pass
- [ ] CI Build and Test

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>