### PR TITLE
refactor(activity_graph): node_status string → variant (#7182)

### DIFF
--- a/lib/activity_graph.mli
+++ b/lib/activity_graph.mli
@@ -6,6 +6,30 @@
 
 (** {1 Types} *)
 
+(** Node status variant. Replaces stringly-typed status.
+    @since 7182 *)
+type node_status =
+  | Active | Offline | Spawned | Retired | Compacting | Handoff
+  | Autonomy | Guardrail
+  | Todo | Claimed | In_progress | Done | Cancelled
+  | Posted | Discussed
+  | Open | Resolved
+  | Approved | Denied
+  | Running | Paused | Stopped | Finalized
+  | Observed | Room | Unset
+
+val node_status_to_string : node_status -> string
+val node_status_of_string : string -> node_status
+
+(** Span status variant (separate lifecycle from node status).
+    @since 7182 *)
+type span_status =
+  | Span_open | Span_completed | Span_released | Span_cancelled
+  | Span_left | Span_retired | Span_finalized | Span_stopped | Span_ended
+
+val span_status_to_string : span_status -> string
+val span_status_of_string : string -> span_status
+
 type entity_ref = {
   kind : string;
   id : string;
@@ -27,7 +51,7 @@ type graph_node = {
   id : string;
   kind : string;
   label : string;
-  status : string;
+  status : node_status;
   weight : int;
   semantic_weight : float;
   last_event_at : string;
@@ -131,7 +155,7 @@ type agent_span = {
   end_ms : int;
   span_kind : string;
   label : string;
-  span_status : string;
+  span_status : span_status;
 }
 
 val agent_span_to_yojson : agent_span -> Yojson.Safe.t

--- a/lib/activity_graph/activity_graph.ml
+++ b/lib/activity_graph/activity_graph.ml
@@ -393,15 +393,15 @@ let span_end_kind = function
   | _ -> None
 
 let span_end_status = function
-  | "task.done" -> "completed"
-  | "task.released" -> "released"
-  | "task.cancelled" -> "cancelled"
-  | "agent.left" -> "left"
-  | "agent.retired" -> "retired"
-  | "operation.finalized" -> "finalized"
-  | "operation.stopped" -> "stopped"
-  | "keeper.autonomy_completed" -> "completed"
-  | _ -> "ended"
+  | "task.done" -> Span_completed
+  | "task.released" -> Span_released
+  | "task.cancelled" -> Span_cancelled
+  | "agent.left" -> Span_left
+  | "agent.retired" -> Span_retired
+  | "operation.finalized" -> Span_finalized
+  | "operation.stopped" -> Span_stopped
+  | "keeper.autonomy_completed" -> Span_completed
+  | _ -> Span_ended
 
 let agent_spans_json config ?(limit = 500) ?since_ms () =
   let events = list_events config ~kinds:[] ~after_seq:0 ~limit () in
@@ -460,7 +460,7 @@ let agent_spans_json config ?(limit = 500) ?since_ms () =
       end_ms = now_ms;
       span_kind = sk;
       label;
-      span_status = "open";
+      span_status = Span_open;
     } :: !closed_spans
   ) open_spans;
   let all_spans = List.rev !closed_spans in

--- a/lib/activity_graph/activity_graph_reducer.ml
+++ b/lib/activity_graph/activity_graph_reducer.ml
@@ -6,7 +6,7 @@ type node_acc = {
   node_id : string;
   node_kind : string;
   mutable label : string;
-  mutable status : string;
+  mutable status : node_status;
   mutable weight : int;
   mutable semantic_weight : float;
   mutable last_event_at : string;
@@ -32,7 +32,7 @@ let payload_string field json =
   | _ -> None
 
 let is_generic_status = function
-  | "" | "active" | "observed" -> true
+  | Unset | Active | Observed -> true
   | _ -> false
 
 (* Semantic weight multiplier by event kind.
@@ -59,7 +59,7 @@ let semantic_multiplier = function
 
 let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
     ~(kind : string) ~(label : string)
-    ~(status : string) ~(ts_iso : string) ~(meta : Yojson.Safe.t)
+    ~(status : node_status) ~(ts_iso : string) ~(meta : Yojson.Safe.t)
     ~(sw_delta : float) =
   match Hashtbl.find_opt nodes id with
   | Some node ->
@@ -67,7 +67,7 @@ let ensure_node (nodes : (string, node_acc) Hashtbl.t) ~(id : string)
       node.semantic_weight <- node.semantic_weight +. sw_delta;
       node.last_event_at <- ts_iso;
       if node.label = id || node.label = "" then node.label <- label;
-      if status <> ""
+      if status <> Unset
          && (not (is_generic_status status) || is_generic_status node.status)
       then
         node.status <- status;
@@ -123,12 +123,12 @@ let reduce_event ~nodes ~edges (value : event) =
   let sw = semantic_multiplier value.kind in
   let room_node_id = "room:" ^ value.room_id in
   ensure_node nodes ~id:room_node_id ~kind:"room" ~label:value.room_id
-    ~status:"room" ~ts_iso:value.ts_iso ~meta:default_meta ~sw_delta:sw;
+    ~status:Room ~ts_iso:value.ts_iso ~meta:default_meta ~sw_delta:sw;
   let actor_id =
     match value.actor with
     | Some actor ->
         let id =
-          ensure_entity_node nodes actor ~fallback_status:"active"
+          ensure_entity_node nodes actor ~fallback_status:Active
             ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
         in
         ensure_edge edges ~source:id ~target:room_node_id ~kind:"belongs_to"
@@ -140,7 +140,7 @@ let reduce_event ~nodes ~edges (value : event) =
     match value.subject with
     | Some subject ->
         let id =
-          ensure_entity_node nodes subject ~fallback_status:"observed"
+          ensure_entity_node nodes subject ~fallback_status:Observed
             ~ts_iso:value.ts_iso ~meta:value.payload ~sw_delta:sw
         in
         ensure_edge edges ~source:id ~target:room_node_id ~kind:"belongs_to"
@@ -165,56 +165,56 @@ let reduce_event ~nodes ~edges (value : event) =
     | None -> ()
   in
   (match value.kind with
-  | "agent.joined" -> set_subject_status "active"
-  | "agent.left" -> set_subject_status "offline"
-  | "agent.spawned" -> set_subject_status "spawned"
-  | "agent.retired" -> set_subject_status "retired"
-  | "agent.compacted" -> set_subject_status "compacting"
+  | "agent.joined" -> set_subject_status Active
+  | "agent.left" -> set_subject_status Offline
+  | "agent.spawned" -> set_subject_status Spawned
+  | "agent.retired" -> set_subject_status Retired
+  | "agent.compacted" -> set_subject_status Compacting
   | "agent.handoff" ->
-      set_actor_status "handoff";
-      set_subject_status "active";
+      set_actor_status Handoff;
+      set_subject_status Active;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"hands_off_to" ~active:true
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "task.created" ->
-      set_subject_status "todo";
+      set_subject_status Todo;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"creates" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "task.claimed" ->
-      set_subject_status "claimed";
+      set_subject_status Claimed;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"works_on" ~active:true
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "task.started" ->
-      set_subject_status "in_progress";
+      set_subject_status In_progress;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"works_on" ~active:true
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "task.released" ->
-      set_subject_status "todo";
+      set_subject_status Todo;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"works_on" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "task.done" ->
-      set_subject_status "done";
+      set_subject_status Done;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"works_on" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "task.cancelled" ->
-      set_subject_status "cancelled";
+      set_subject_status Cancelled;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"works_on" ~active:false
@@ -233,14 +233,14 @@ let reduce_event ~nodes ~edges (value : event) =
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "board.posted" ->
-      set_subject_status "posted";
+      set_subject_status Posted;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"posts" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "board.commented" ->
-      set_subject_status "discussed";
+      set_subject_status Discussed;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"comments_on" ~active:false
@@ -253,7 +253,7 @@ let reduce_event ~nodes ~edges (value : event) =
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "decision.opened" ->
-      set_subject_status "open";
+      set_subject_status Open;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"opens" ~active:false
@@ -265,32 +265,32 @@ let reduce_event ~nodes ~edges (value : event) =
           ensure_edge edges ~source ~target ~kind:"votes_on" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
-  | "decision.resolved" -> set_subject_status "resolved"
+  | "decision.resolved" -> set_subject_status Resolved
   | "policy.approved" ->
-      set_subject_status "approved";
+      set_subject_status Approved;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"governs" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "policy.denied" ->
-      set_subject_status "denied";
+      set_subject_status Denied;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"governs" ~active:false
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
   | "operation.started" ->
-      set_subject_status "running";
+      set_subject_status Running;
       (match (actor_id, subject_id) with
       | Some source, Some target ->
           ensure_edge edges ~source ~target ~kind:"operates_on" ~active:true
             ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
-  | "operation.paused" -> set_subject_status "paused"
-  | "operation.resumed" -> set_subject_status "running"
-  | "operation.stopped" -> set_subject_status "stopped"
-  | "operation.finalized" -> set_subject_status "finalized"
+  | "operation.paused" -> set_subject_status Paused
+  | "operation.resumed" -> set_subject_status Running
+  | "operation.stopped" -> set_subject_status Stopped
+  | "operation.finalized" -> set_subject_status Finalized
   | "team.turn" ->
       (match (actor_id, subject_id) with
       | Some source, Some target ->
@@ -303,10 +303,10 @@ let reduce_event ~nodes ~edges (value : event) =
           ensure_edge edges ~source ~target ~kind:"participates_in"
             ~active:false ~ts_iso:value.ts_iso ~meta:value.payload
       | _ -> ())
-  | "keeper.autonomy_started" -> set_actor_status "autonomy"
-  | "keeper.autonomy_completed" -> set_actor_status "active"
-  | "keeper.guardrail" -> set_actor_status "guardrail"
-  | "keeper.compaction" -> set_actor_status "compacting"
+  | "keeper.autonomy_started" -> set_actor_status Autonomy
+  | "keeper.autonomy_completed" -> set_actor_status Active
+  | "keeper.guardrail" -> set_actor_status Guardrail
+  | "keeper.compaction" -> set_actor_status Compacting
   | "tool.called" ->
       (match (actor_id, subject_id) with
       | Some source, Some target ->

--- a/lib/activity_graph/activity_graph_types.ml
+++ b/lib/activity_graph/activity_graph_types.ml
@@ -1,5 +1,73 @@
 (** Activity_graph_types — type definitions and JSON serde for activity graph. *)
 
+(** Node status: type-safe variant replacing stringly-typed status.
+    Flat variant — node [kind] field already carries the category.
+    @since 7182 *)
+type node_status =
+  (* Agent lifecycle *)
+  | Active | Offline | Spawned | Retired | Compacting | Handoff
+  | Autonomy | Guardrail
+  (* Task lifecycle *)
+  | Todo | Claimed | In_progress | Done | Cancelled
+  (* Board *)
+  | Posted | Discussed
+  (* Decision *)
+  | Open | Resolved
+  (* Policy *)
+  | Approved | Denied
+  (* Operation lifecycle *)
+  | Running | Paused | Stopped | Finalized
+  (* Generic / fallback *)
+  | Observed | Room | Unset
+
+let node_status_to_string = function
+  | Active -> "active" | Offline -> "offline" | Spawned -> "spawned"
+  | Retired -> "retired" | Compacting -> "compacting" | Handoff -> "handoff"
+  | Autonomy -> "autonomy" | Guardrail -> "guardrail"
+  | Todo -> "todo" | Claimed -> "claimed" | In_progress -> "in_progress"
+  | Done -> "done" | Cancelled -> "cancelled"
+  | Posted -> "posted" | Discussed -> "discussed"
+  | Open -> "open" | Resolved -> "resolved"
+  | Approved -> "approved" | Denied -> "denied"
+  | Running -> "running" | Paused -> "paused"
+  | Stopped -> "stopped" | Finalized -> "finalized"
+  | Observed -> "observed" | Room -> "room" | Unset -> ""
+
+let node_status_of_string = function
+  | "active" -> Active | "offline" -> Offline | "spawned" -> Spawned
+  | "retired" -> Retired | "compacting" -> Compacting | "handoff" -> Handoff
+  | "autonomy" -> Autonomy | "guardrail" -> Guardrail
+  | "todo" -> Todo | "claimed" -> Claimed | "in_progress" -> In_progress
+  | "done" -> Done | "cancelled" -> Cancelled
+  | "posted" -> Posted | "discussed" -> Discussed
+  | "open" -> Open | "resolved" -> Resolved
+  | "approved" -> Approved | "denied" -> Denied
+  | "running" -> Running | "paused" -> Paused
+  | "stopped" -> Stopped | "finalized" -> Finalized
+  | "observed" -> Observed | "room" -> Room
+  | "" -> Unset
+  | _ -> Observed  (* fail-open: unknown status treated as generic *)
+
+(** Span status: separate from node_status (different lifecycle).
+    @since 7182 *)
+type span_status =
+  | Span_open | Span_completed | Span_released | Span_cancelled
+  | Span_left | Span_retired | Span_finalized | Span_stopped | Span_ended
+
+let span_status_to_string = function
+  | Span_open -> "open" | Span_completed -> "completed"
+  | Span_released -> "released" | Span_cancelled -> "cancelled"
+  | Span_left -> "left" | Span_retired -> "retired"
+  | Span_finalized -> "finalized" | Span_stopped -> "stopped"
+  | Span_ended -> "ended"
+
+let span_status_of_string = function
+  | "open" -> Span_open | "completed" -> Span_completed
+  | "released" -> Span_released | "cancelled" -> Span_cancelled
+  | "left" -> Span_left | "retired" -> Span_retired
+  | "finalized" -> Span_finalized | "stopped" -> Span_stopped
+  | _ -> Span_ended
+
 type entity_ref = {
   kind : string;
   id : string;
@@ -21,7 +89,7 @@ type graph_node = {
   id : string;
   kind : string;
   label : string;
-  status : string;
+  status : node_status;
   weight : int;
   semantic_weight : float;
   last_event_at : string;
@@ -45,7 +113,7 @@ type agent_span = {
   end_ms : int;
   span_kind : string;
   label : string;
-  span_status : string;
+  span_status : span_status;
 }
 
 let entity ~kind id = { kind; id }
@@ -101,7 +169,7 @@ let graph_node_to_yojson (value : graph_node) =
       ("id", `String value.id);
       ("kind", `String value.kind);
       ("label", `String value.label);
-      ("status", `String value.status);
+      ("status", `String (node_status_to_string value.status));
       ("weight", `Int value.weight);
       ("semantic_weight", `Float value.semantic_weight);
       ("last_event_at", `String value.last_event_at);
@@ -128,7 +196,7 @@ let agent_span_to_yojson (s : agent_span) =
     ("end_ms", `Int s.end_ms);
     ("kind", `String s.span_kind);
     ("label", `String s.label);
-    ("status", `String s.span_status);
+    ("status", `String (span_status_to_string s.span_status));
   ]
 
 let now_ts_ms () = int_of_float (Time_compat.now () *. 1000.0)


### PR DESCRIPTION
## Summary

Convert 26 stringly-typed status values into flat OCaml variant types.
Final item in the stringly-typed to variant conversion series (#7150, #7159, #7164, #7180).

Fixes #7182

## Design Decision

**Flat variant** over category-nested. Rationale:
- \`graph_node.kind\` already carries the category (agent/task/board/etc.)
- Reducer uses a single match expression for all 27 status transitions
- Category nesting would require 2-level match, added complexity with no benefit

## Types

\`\`\`ocaml
type node_status =
  | Active | Offline | Spawned | Retired | Compacting | Handoff
  | Autonomy | Guardrail
  | Todo | Claimed | In_progress | Done | Cancelled
  | Posted | Discussed | Open | Resolved | Approved | Denied
  | Running | Paused | Stopped | Finalized
  | Observed | Room | Unset

type span_status =
  | Span_open | Span_completed | Span_released | Span_cancelled
  | Span_left | Span_retired | Span_finalized | Span_stopped | Span_ended
\`\`\`

## Files Changed (4 files, 143+/51-)

| File | Change |
|------|--------|
| activity_graph_types.ml | node_status + span_status variants, to/of_string |
| activity_graph_reducer.ml | 27 set_*_status calls: string → variant |
| activity_graph.ml | span_end_status returns span_status variant |
| activity_graph.mli | Export types + converters |

## Test Plan

- [x] \`dune build\` passes (0 errors)
- [x] No activity_graph test failures
- [ ] CI