### PR TITLE
[codex] improve keeper claim-first prompt guidance

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -177,7 +177,8 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
      Act through tools, not declarations. Call the tool directly.\n\
      - See board activity? Read the full post with keeper_board_get, then comment with \
      keeper_board_comment.\n\
-     - See an unclaimed task matching your skills? Call keeper_task_claim.\n\
+     - See unclaimed work and you do not already hold a task? Call keeper_task_claim with {}. \
+     It auto-claims the next eligible task; you do not need task_id or keeper_tasks_list first.\n\
      - Have a finding or update? Call keeper_board_post.\n\
      - Need to share broadly? Call keeper_broadcast.\n\
      - Nothing genuinely actionable after checking? End your turn with the [STATE] block.\n\
@@ -245,6 +246,14 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf
       (Printf.sprintf "- Active agents: %d\n" observation.active_agent_count);
     Buffer.add_string ubuf "\n");
+  if observation.unclaimed_task_count > 0 && Option.is_none meta.current_task_id then (
+    Buffer.add_string ubuf "### Immediate Task Move\n";
+    Buffer.add_string ubuf
+      "- Call keeper_task_claim with {} to claim the next eligible unclaimed task.\n";
+    Buffer.add_string ubuf
+      "- Do not wait for keeper_tasks_list unless the claim call says no eligible task.\n";
+    Buffer.add_string ubuf
+      "- Prefer keeper_task_claim before keeper_board_list or keeper_github when you have no claimed task.\n\n");
   (* 5. Board activity — reactive trigger *)
   if observation.pending_board_events <> [] then (
     Buffer.add_string ubuf

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -835,6 +835,44 @@ let test_prompt_room_state_section () =
        with Not_found -> false
      in found)
 
+let test_prompt_includes_claim_first_guidance () =
+  let obs =
+    { base_observation with
+      unclaimed_task_count = 3;
+      active_agent_count = 5;
+    }
+  in
+  let sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta:minimal_meta ~observation:obs ()
+  in
+  check bool "system prompt explains auto-claim" true
+    (contains_substring sys "Call keeper_task_claim with {}");
+  check bool "user prompt adds immediate task move section" true
+    (contains_substring user "### Immediate Task Move");
+  check bool "user prompt explains no task_id needed" true
+    (contains_substring user "Do not wait for keeper_tasks_list");
+  check bool "user prompt prefers claim before browsing" true
+    (contains_substring user "Prefer keeper_task_claim before keeper_board_list or keeper_github")
+
+let test_prompt_omits_claim_first_guidance_when_task_claimed () =
+  let current_task_id =
+    match Masc_mcp.Keeper_id.Task_id.of_string "task-123" with
+    | Ok value -> value
+    | Error err -> fail ("task id parse failed: " ^ err)
+  in
+  let meta = { minimal_meta with current_task_id = Some current_task_id } in
+  let obs =
+    { base_observation with
+      unclaimed_task_count = 3;
+      active_agent_count = 5;
+    }
+  in
+  let _sys, user =
+    UP.build_prompt ~base_path:"/test" ~meta ~observation:obs ()
+  in
+  check bool "no immediate task move section once task claimed" false
+    (contains_substring user "### Immediate Task Move")
+
 (* ---------- Config tests ---------- *)
 
 let test_unified_turn_runtime_defaults () =
@@ -2744,6 +2782,10 @@ let () =
           test_case "hustle economy" `Quick test_prompt_hustle_economy;
           test_case "includes worktree delta" `Quick test_prompt_includes_worktree_delta;
           test_case "room state section" `Quick test_prompt_room_state_section;
+          test_case "claim first guidance" `Quick
+            test_prompt_includes_claim_first_guidance;
+          test_case "claim first guidance omitted when task claimed" `Quick
+            test_prompt_omits_claim_first_guidance_when_task_claimed;
           test_case "prefers silence guidance" `Quick
             test_prompt_prefers_silence_guidance;
           test_case "sanitize_text_utf8 replaces control chars" `Quick


### PR DESCRIPTION
## Summary
Bias keepers toward `keeper_task_claim {}` before backlog browsing when unclaimed work is available and they do not already hold a task.

## What changed
- strengthened the unified system prompt so it explicitly says `keeper_task_claim` takes `{}` and auto-claims the next eligible task
- added a user-prompt `Immediate Task Move` section when unclaimed tasks exist and the keeper has no `current_task_id`
- added prompt regression tests for both the positive case and the already-claimed-task case

## Why
After the orphan `ToolResult` checkpoint fix landed, `nick0cave` no longer hit the provider resume error, but recent decisions still showed a separate low-activity pattern:
- `claim_was_available=true`
- `claim_executed=false`
- several autonomous turns ended as `turn_budget_exhausted(...)` after browsing tools such as `keeper_tasks_list` or `keeper_board_list`

The claim tool already auto-claims the next eligible task with an empty object, but the prompt did not make that obvious enough, so keepers were burning turns on discovery instead of starting work.

## Product impact
- keepers should spend fewer autonomous turns on backlog browsing before claiming work
- personas like `nick0cave` should convert backlog pressure into task claims more reliably
- this reduces one common path where autonomous activity looks low even though the namespace still has work available

## Evidence
- recent `nick0cave` decisions in `/Users/dancer/me/.masc/keepers/nick0cave.decisions.jsonl` showed repeated `claim_was_available=true` with `claim_executed=false`
- local prompt tests now verify that claim-first guidance appears only when unclaimed work exists and no task is already claimed

## Review evidence
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-claim-first ./test/test_keeper_unified.exe`

## Linked issue
Refs #7226