### PR TITLE
feat(dashboard): add spec-aware FSM diagnostics

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -169,7 +169,24 @@ describe('fsm-hub derived state', () => {
 
     expect(lanes.find(lane => lane.field === 'KTC')).toMatchObject({
       tone: 'warn',
+      stalled: true,
       value: 'executing',
     })
+  })
+
+  it('keeps active compaction as compaction work before the stall threshold', () => {
+    const result = deriveOperationalInsight(
+      snapshot({
+        is_live: true,
+        phase: 'Compacting',
+        turn_phase: 'compacting',
+        compaction: { stage: 'compacting' },
+      }),
+      [observation({ ts: 10, phase: 'Compacting', turn: 'compacting', compaction: 'compacting' })],
+      20,
+    )
+
+    expect(result.tone).toBe('info')
+    expect(result.headline).toContain('Compaction currently owns the turn')
   })
 })

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -1,7 +1,10 @@
+import type { KeeperCompositeSnapshot } from '../api/keeper'
 import { describe, expect, it } from 'vitest'
 
 import {
   appendCompositeObservation,
+  deriveObservedLaneSummaries,
+  deriveOperationalInsight,
   derivePhaseLog,
   deriveTransitionHistory,
   type CompositeObservation,
@@ -18,6 +21,61 @@ function observation(
     cascade: 'idle',
     compaction: 'idle',
     ...overrides,
+  }
+}
+
+function snapshot(
+  overrides: Partial<KeeperCompositeSnapshot> = {},
+): KeeperCompositeSnapshot {
+  const base: KeeperCompositeSnapshot = {
+    correlation_id: 'corr',
+    run_id: 'run',
+    ts: 100,
+    phase: 'Running',
+    turn_phase: 'idle',
+    decision: { stage: 'undecided' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: false },
+    recovery: { data_record: false, fsm_condition: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_cascade_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+      recovery_two_store_sync: true,
+    },
+    is_live: false,
+    last_outcome: null,
+  }
+
+  return {
+    ...base,
+    ...overrides,
+    decision: {
+      ...base.decision,
+      ...(overrides.decision ?? {}),
+    },
+    cascade: {
+      ...base.cascade,
+      ...(overrides.cascade ?? {}),
+    },
+    compaction: {
+      ...base.compaction,
+      ...(overrides.compaction ?? {}),
+    },
+    measurement: {
+      ...base.measurement,
+      ...(overrides.measurement ?? {}),
+    },
+    recovery: {
+      ...base.recovery,
+      ...(overrides.recovery ?? {}),
+    },
+    invariants: {
+      ...base.invariants,
+      ...(overrides.invariants ?? {}),
+    },
   }
 }
 
@@ -56,5 +114,62 @@ describe('fsm-hub derived state', () => {
       'Running',
       'Failing',
     ])
+  })
+
+  it('derives spec-drift insight from broken invariants', () => {
+    const result = deriveOperationalInsight(
+      snapshot({
+        phase: 'Compacting',
+        turn_phase: 'executing',
+        compaction: { stage: 'accumulating' },
+        invariants: {
+          phase_turn_alignment: false,
+          no_cascade_before_measurement: true,
+          compaction_atomicity: true,
+          event_priority_monotone: true,
+          recovery_two_store_sync: true,
+        },
+      }),
+      [observation({ ts: 10, phase: 'Compacting', turn: 'executing' })],
+      20,
+    )
+
+    expect(result.tone).toBe('error')
+    expect(result.headline).toContain('Spec drift')
+    expect(result.detail).toContain('KSM=Compacting')
+  })
+
+  it('interprets idle snapshots as stable placeholders, not live work', () => {
+    const result = deriveOperationalInsight(
+      snapshot({
+        is_live: false,
+        last_outcome: {
+          turn_id: 42,
+          ended_at: 75,
+        },
+      }),
+      [observation({ ts: 75 })],
+      100,
+    )
+
+    expect(result.tone).toBe('ok')
+    expect(result.headline).toContain('Idle snapshot')
+    expect(result.detail).toContain('25s ago')
+  })
+
+  it('marks long-running observed execution as stalled on screen', () => {
+    const lanes = deriveObservedLaneSummaries(
+      snapshot({
+        is_live: true,
+        turn_phase: 'executing',
+      }),
+      [observation({ ts: 10, turn: 'executing' })],
+      80,
+    )
+
+    expect(lanes.find(lane => lane.field === 'KTC')).toMatchObject({
+      tone: 'warn',
+      value: 'executing',
+    })
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -43,6 +43,7 @@ export type ObservedLaneSummary = {
   label: string
   value: string
   tone: InsightTone
+  stalled: boolean
   meaning: string
   observedForSec: number
   transitionCount: number
@@ -352,14 +353,14 @@ export function deriveObservedLaneSummaries(
           : key === 'cascade'
             ? snapshot.cascade.state
             : snapshot.compaction.stage
+    const stalled = isObservedStall(key, value, observedForSec)
 
     return {
       field,
       label: LANE_LABELS[key],
       value,
-      tone: isObservedStall(key, value, observedForSec) && meaning.tone !== 'error'
-        ? 'warn'
-        : meaning.tone,
+      tone: stalled && meaning.tone !== 'error' ? 'warn' : meaning.tone,
+      stalled,
       meaning: meaning.meaning,
       observedForSec,
       transitionCount,
@@ -463,7 +464,7 @@ export function deriveOperationalInsight(
   }
 
   const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
-  const stalledLane = lanes.find(lane => lane.tone === 'warn' && lane.observedForSec > 0)
+  const stalledLane = lanes.find(lane => lane.stalled)
   if (snapshot.recovery.data_record !== snapshot.recovery.fsm_condition) {
     return {
       tone: 'error',
@@ -738,7 +739,7 @@ export function FsmHub() {
         onSelect=${setSelected}
         loading=${loading}
         transitionCount=${history.length}
-        observationCount=${phaseLog.length}
+        observationCount=${view.observations.length}
       />
 
       ${activeSelected == null ? html`

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -28,6 +28,26 @@ type TransitionEntry = {
   field: string
 }
 
+type InsightTone = 'ok' | 'info' | 'warn' | 'error'
+
+export type OperationalInsight = {
+  tone: InsightTone
+  headline: string
+  detail: string
+  nextStep: string
+  evidence: string[]
+}
+
+export type ObservedLaneSummary = {
+  field: string
+  label: string
+  value: string
+  tone: InsightTone
+  meaning: string
+  observedForSec: number
+  transitionCount: number
+}
+
 type HubState = {
   keeperName: string | null
   snapshot: KeeperCompositeSnapshot | null
@@ -61,6 +81,22 @@ const TRANSITION_FIELDS: Array<{ field: string; key: keyof Omit<CompositeObserva
   { field: 'KCL', key: 'cascade' },
   { field: 'KMC', key: 'compaction' },
 ]
+
+const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> = {
+  phase_turn_alignment: 'Phase ⇔ Turn',
+  no_cascade_before_measurement: 'Cascade ordering',
+  compaction_atomicity: 'Compaction atomic',
+  event_priority_monotone: 'Event priority',
+  recovery_two_store_sync: 'Two-store sync',
+}
+
+const LANE_LABELS: Record<keyof Omit<CompositeObservation, 'ts'>, string> = {
+  phase: 'keeper lifecycle',
+  turn: 'turn cycle',
+  decision: 'decision',
+  cascade: 'cascade',
+  compaction: 'compaction',
+}
 
 function observeSnapshot(
   snapshot: KeeperCompositeSnapshot,
@@ -131,6 +167,441 @@ export function derivePhaseLog(
     }
   }
   return phases.slice(-Math.max(1, maxEntries))
+}
+
+function laneChangedAt(
+  observations: CompositeObservation[],
+  key: keyof Omit<CompositeObservation, 'ts'>,
+): number {
+  const last = observations[observations.length - 1]
+  if (!last) return 0
+  for (let index = observations.length - 1; index > 0; index -= 1) {
+    const prev = observations[index - 1]
+    const next = observations[index]
+    if (!prev || !next) continue
+    if (prev[key] !== next[key]) return next.ts
+  }
+  return observations[0]?.ts ?? last.ts
+}
+
+function laneTransitionCount(
+  observations: CompositeObservation[],
+  key: keyof Omit<CompositeObservation, 'ts'>,
+): number {
+  let count = 0
+  for (let index = 1; index < observations.length; index += 1) {
+    const prev = observations[index - 1]
+    const next = observations[index]
+    if (!prev || !next) continue
+    if (prev[key] !== next[key]) count += 1
+  }
+  return count
+}
+
+function isObservedStall(
+  key: keyof Omit<CompositeObservation, 'ts'>,
+  value: string,
+  observedForSec: number,
+): boolean {
+  if (key === 'phase') {
+    if (value === 'Failing') return observedForSec >= 90
+    if (value === 'Compacting') return observedForSec >= 90
+    if (value === 'HandingOff' || value === 'Draining' || value === 'Restarting') return observedForSec >= 60
+    return false
+  }
+  if (key === 'turn') {
+    if (value === 'prompting' || value === 'executing') return observedForSec >= 45
+    if (value === 'compacting') return observedForSec >= 60
+    if (value === 'finalizing') return observedForSec >= 30
+    return false
+  }
+  if (key === 'cascade') {
+    if (value === 'selecting') return observedForSec >= 30
+    if (value === 'trying') return observedForSec >= 45
+    return false
+  }
+  if (key === 'compaction') {
+    return value === 'compacting' && observedForSec >= 60
+  }
+  return false
+}
+
+function laneMeaning(
+  key: keyof Omit<CompositeObservation, 'ts'>,
+  snapshot: KeeperCompositeSnapshot,
+  observedForSec: number,
+): { tone: InsightTone; meaning: string } {
+  const value = key === 'phase'
+    ? snapshot.phase
+    : key === 'turn'
+      ? snapshot.turn_phase
+      : key === 'decision'
+        ? snapshot.decision.stage
+        : key === 'cascade'
+          ? snapshot.cascade.state
+          : snapshot.compaction.stage
+
+  const base: { tone: InsightTone; meaning: string } = (() => {
+    switch (key) {
+    case 'phase':
+      switch (value) {
+        case 'Running':
+          return snapshot.is_live
+            ? { tone: 'info', meaning: 'parent lifecycle is healthy while the live turn advances' }
+            : { tone: 'ok', meaning: 'no live turn; waiting for the next observation cycle' }
+        case 'Failing':
+          return { tone: 'error', meaning: 'recovery owns the keeper lifecycle until reconcile clears' }
+        case 'Compacting':
+          return { tone: 'warn', meaning: 'post-turn compaction currently owns the lifecycle' }
+        case 'HandingOff':
+          return { tone: 'warn', meaning: 'handoff is draining this keeper toward stop' }
+        case 'Draining':
+          return { tone: 'warn', meaning: 'the keeper is draining in-flight work before stop' }
+        case 'Restarting':
+          return { tone: 'warn', meaning: 'boot path is re-entering Running after restart' }
+        case 'Paused':
+          return { tone: 'info', meaning: 'operator pause keeps the lifecycle intentionally frozen' }
+        case 'Stopped':
+        case 'Offline':
+          return { tone: 'info', meaning: 'no lifecycle activity is currently expected' }
+        case 'Crashed':
+        case 'Dead':
+          return { tone: 'error', meaning: 'the lifecycle is terminal until an external recovery path runs' }
+        default:
+          return { tone: 'info', meaning: 'lifecycle state observed' }
+      }
+    case 'turn':
+      switch (value) {
+        case 'idle':
+          return { tone: snapshot.is_live ? 'info' : 'ok', meaning: snapshot.is_live ? 'turn context exists but work has not advanced yet' : 'no in-flight turn is being observed' }
+        case 'prompting':
+          return { tone: 'info', meaning: 'prompt assembly is still preparing the turn inputs' }
+        case 'executing':
+          return { tone: 'info', meaning: 'the turn is inside model/tool execution work' }
+        case 'compacting':
+          return { tone: 'warn', meaning: 'turn finalization is blocked on compaction finishing' }
+        case 'finalizing':
+          return { tone: 'info', meaning: 'the turn is sealing results and preparing the next idle snapshot' }
+        default:
+          return { tone: 'info', meaning: 'turn-cycle state observed' }
+      }
+    case 'decision':
+      switch (value) {
+        case 'undecided':
+          return { tone: snapshot.is_live ? 'info' : 'ok', meaning: snapshot.is_live ? 'decision work has not committed yet' : 'idle snapshots intentionally clear decision state' }
+        case 'guard_ok':
+          return { tone: 'info', meaning: 'guardrails allowed the turn to continue' }
+        case 'gate_rejected':
+          return { tone: 'warn', meaning: 'guardrails blocked the turn before tool/model work' }
+        case 'tool_policy_selected':
+          return { tone: 'info', meaning: 'tool policy selection has committed and execution can advance' }
+        default:
+          return { tone: 'info', meaning: 'decision state observed' }
+      }
+    case 'cascade':
+      switch (value) {
+        case 'idle':
+          return { tone: 'ok', meaning: 'no provider failover work is active' }
+        case 'selecting':
+          return { tone: 'info', meaning: 'provider routing is selecting the next execution path' }
+        case 'trying':
+          return { tone: 'info', meaning: 'provider execution is in flight' }
+        case 'done':
+          return { tone: 'ok', meaning: 'cascade accepted a provider result for this turn' }
+        case 'exhausted':
+          return { tone: 'error', meaning: 'all cascade options were consumed without a usable path' }
+        default:
+          return { tone: 'info', meaning: 'cascade state observed' }
+      }
+    case 'compaction':
+      switch (value) {
+        case 'accumulating':
+          return { tone: 'ok', meaning: 'memory is collecting compaction candidates, not executing yet' }
+        case 'compacting':
+          return { tone: 'warn', meaning: 'memory compaction is actively rewriting context state' }
+        case 'done':
+          return { tone: 'ok', meaning: 'compaction finished for the observed turn' }
+        default:
+          return { tone: 'info', meaning: 'compaction state observed' }
+      }
+    }
+  })()
+
+  if (base.tone !== 'error' && isObservedStall(key, value, observedForSec)) {
+    return { tone: 'warn', meaning: 'state movement looks stalled on this screen' }
+  }
+  return base
+}
+
+export function deriveObservedLaneSummaries(
+  snapshot: KeeperCompositeSnapshot,
+  observations: CompositeObservation[],
+  now: number,
+): ObservedLaneSummary[] {
+  return TRANSITION_FIELDS.map(({ field, key }) => {
+    const changedAt = laneChangedAt(observations, key)
+    const observedForSec = changedAt > 0 ? Math.max(0, now - changedAt) : 0
+    const transitionCount = laneTransitionCount(observations, key)
+    const meaning = laneMeaning(key, snapshot, observedForSec)
+    const value = key === 'phase'
+      ? snapshot.phase
+      : key === 'turn'
+        ? snapshot.turn_phase
+        : key === 'decision'
+          ? snapshot.decision.stage
+          : key === 'cascade'
+            ? snapshot.cascade.state
+            : snapshot.compaction.stage
+
+    return {
+      field,
+      label: LANE_LABELS[key],
+      value,
+      tone: isObservedStall(key, value, observedForSec) && meaning.tone !== 'error'
+        ? 'warn'
+        : meaning.tone,
+      meaning: meaning.meaning,
+      observedForSec,
+      transitionCount,
+    }
+  })
+}
+
+function brokenInvariantKey(
+  invariants: KeeperCompositeInvariants,
+): keyof KeeperCompositeInvariants | null {
+  const first = (Object.entries(invariants) as Array<[keyof KeeperCompositeInvariants, boolean]>)
+    .find(([, ok]) => !ok)
+  return first?.[0] ?? null
+}
+
+function invariantDetail(
+  snapshot: KeeperCompositeSnapshot,
+  key: keyof KeeperCompositeInvariants,
+  ok: boolean,
+): string {
+  switch (key) {
+    case 'phase_turn_alignment':
+      return ok
+        ? 'KSM/KTC/KMC agree on who owns compaction right now.'
+        : `KSM=${snapshot.phase}, KTC=${snapshot.turn_phase}, KMC=${snapshot.compaction.stage} do not line up.`
+    case 'no_cascade_before_measurement':
+      return ok
+        ? 'Cascade work only advances after measurement is captured.'
+        : `measurement.captured=${String(snapshot.measurement.captured)} while KCL=${snapshot.cascade.state}.`
+    case 'compaction_atomicity':
+      return ok
+        ? 'Compaction does not run outside the parent Compacting phase.'
+        : `KMC=${snapshot.compaction.stage} but KSM=${snapshot.phase}.`
+    case 'event_priority_monotone':
+      return ok
+        ? 'This turn has not emitted competing measurement snapshots.'
+        : 'More than one measurement event appears to own the same turn.'
+    case 'recovery_two_store_sync':
+      return ok
+        ? 'Recovery data and FSM condition are synchronized.'
+        : `recovery.data_record=${String(snapshot.recovery.data_record)}, recovery.fsm_condition=${String(snapshot.recovery.fsm_condition)}.`
+  }
+}
+
+function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
+  if (!snapshot.is_live) {
+    return snapshot.last_outcome
+      ? 'The next live turn should repopulate KTC/KDP/KCL from idle placeholders.'
+      : 'No turn has completed yet; the first live turn should populate the observer.'
+  }
+  if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
+    return 'A healthy provider path or manual reconcile must clear Failing before Running can resume.'
+  }
+  if (snapshot.phase === 'Compacting' || snapshot.compaction.stage === 'compacting') {
+    return 'KMC should reach done and then KSM should hand control back to Running.'
+  }
+  if (snapshot.phase === 'HandingOff') {
+    return 'The current keeper should stop once handoff completion is observed.'
+  }
+  if (snapshot.phase === 'Draining') {
+    return 'Draining should complete before the lifecycle settles into Stopped.'
+  }
+  if (snapshot.decision.stage === 'gate_rejected') {
+    return 'The blocked turn should finalize back to idle without entering cascade/tool execution.'
+  }
+  if (snapshot.cascade.state === 'selecting' || snapshot.cascade.state === 'trying') {
+    return 'KCL should settle into done or exhausted once provider routing returns.'
+  }
+  switch (snapshot.turn_phase) {
+    case 'prompting':
+      return 'KTC should advance into executing once prompt assembly is complete.'
+    case 'executing':
+      return 'Execution should either finalize the turn or drive cascade/compaction transitions.'
+    case 'compacting':
+      return 'Turn finalization is waiting on compaction to finish.'
+    case 'finalizing':
+      return 'The next stable state should be idle with last_outcome updated.'
+    default:
+      return 'The next meaningful edge should come from the next observed lifecycle event.'
+  }
+}
+
+export function deriveOperationalInsight(
+  snapshot: KeeperCompositeSnapshot,
+  observations: CompositeObservation[],
+  now: number,
+): OperationalInsight {
+  const brokenInvariant = brokenInvariantKey(snapshot.invariants)
+  if (brokenInvariant) {
+    return {
+      tone: 'error',
+      headline: `Spec drift on ${INVARIANT_LABELS[brokenInvariant]}`,
+      detail: invariantDetail(snapshot, brokenInvariant, false),
+      nextStep: 'Treat this as an observer-level contract breach before trusting downstream state transitions.',
+      evidence: [
+        `KSM ${snapshot.phase}`,
+        `KTC ${snapshot.turn_phase}`,
+        `KCL ${snapshot.cascade.state}`,
+      ],
+    }
+  }
+
+  const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
+  const stalledLane = lanes.find(lane => lane.tone === 'warn' && lane.observedForSec > 0)
+  if (snapshot.recovery.data_record !== snapshot.recovery.fsm_condition) {
+    return {
+      tone: 'error',
+      headline: 'Recovery stores diverged',
+      detail: 'The manual-reconcile data record and FSM condition disagree, which should be unreachable under RFC-0003.',
+      nextStep: 'Reconcile the recovery stores before treating the lifecycle as healthy again.',
+      evidence: [
+        `data ${String(snapshot.recovery.data_record)}`,
+        `fsm ${String(snapshot.recovery.fsm_condition)}`,
+      ],
+    }
+  }
+  if (snapshot.recovery.data_record && snapshot.recovery.fsm_condition) {
+    return {
+      tone: 'warn',
+      headline: 'Manual reconcile is pending',
+      detail: 'Both recovery stores agree the keeper is waiting for manual reconcile to clear.',
+      nextStep: 'Resolve the reconcile path before expecting Failing to return to Running.',
+      evidence: [
+        `KSM ${snapshot.phase}`,
+        'manual reconcile required',
+      ],
+    }
+  }
+  if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
+    return {
+      tone: 'error',
+      headline: 'Failing after cascade exhaustion',
+      detail: 'The keeper has entered recovery with no remaining cascade path, so the turn cannot self-heal through provider failover.',
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `KSM ${snapshot.phase}`,
+        `KCL ${snapshot.cascade.state}`,
+        snapshot.measurement.captured ? 'measurement captured' : 'measurement missing',
+      ],
+    }
+  }
+  if (snapshot.decision.stage === 'gate_rejected') {
+    return {
+      tone: 'warn',
+      headline: 'Guardrail blocked the turn',
+      detail: 'Decision pipeline reached gate_rejected, so execution should unwind without entering provider work.',
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `KDP ${snapshot.decision.stage}`,
+        `KTC ${snapshot.turn_phase}`,
+        snapshot.measurement.auto_rules?.guardrail_reason ?? 'no guardrail reason',
+      ],
+    }
+  }
+  if (stalledLane) {
+    return {
+      tone: 'warn',
+      headline: `${stalledLane.field} is not moving`,
+      detail: `${stalledLane.value} has been observed for ${fmtDuration(stalledLane.observedForSec)} on this screen without a new edge.`,
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `${stalledLane.field} ${stalledLane.value}`,
+        `${stalledLane.transitionCount} observed changes`,
+      ],
+    }
+  }
+  if (snapshot.phase === 'Compacting' || snapshot.compaction.stage === 'compacting') {
+    return {
+      tone: 'info',
+      headline: 'Compaction currently owns the turn',
+      detail: 'The parent lifecycle and memory lane both indicate that post-turn compaction is the active coordination point.',
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `KSM ${snapshot.phase}`,
+        `KMC ${snapshot.compaction.stage}`,
+      ],
+    }
+  }
+  if (snapshot.phase === 'HandingOff' || snapshot.phase === 'Draining' || snapshot.phase === 'Restarting') {
+    return {
+      tone: 'warn',
+      headline: `${snapshot.phase} is the active lifecycle edge`,
+      detail: 'The keeper is transitioning between stable lifecycle states, so the parent FSM matters more than sub-turn activity right now.',
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `KSM ${snapshot.phase}`,
+        `live ${String(snapshot.is_live)}`,
+      ],
+    }
+  }
+  if (!snapshot.is_live) {
+    const idleSince = snapshot.last_outcome
+      ? fmtDuration(Math.max(0, now - snapshot.last_outcome.ended_at))
+      : 'no completed turn yet'
+    return {
+      tone: 'ok',
+      headline: 'Idle snapshot is consistent',
+      detail: snapshot.last_outcome
+        ? `Sub-FSMs have fallen back to idle placeholders; the last completed turn ended ${idleSince} ago.`
+        : 'The observer is idle and has not captured a completed turn yet.',
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `KSM ${snapshot.phase}`,
+        snapshot.last_outcome ? `turn #${snapshot.last_outcome.turn_id}` : 'no last_outcome',
+      ],
+    }
+  }
+  if (snapshot.cascade.state === 'selecting' || snapshot.cascade.state === 'trying') {
+    return {
+      tone: 'info',
+      headline: 'Provider work is the active frontier',
+      detail: 'Cascade has taken ownership of the live turn, so the important next edge is provider completion or exhaustion.',
+      nextStep: nextExpectedStep(snapshot),
+      evidence: [
+        `KTC ${snapshot.turn_phase}`,
+        `KCL ${snapshot.cascade.state}`,
+      ],
+    }
+  }
+  return {
+    tone: 'info',
+    headline: 'Live turn is progressing normally',
+    detail: 'No invariant drift or recovery issue is visible; the sub-FSMs look aligned for the current live turn.',
+    nextStep: nextExpectedStep(snapshot),
+    evidence: [
+      `KSM ${snapshot.phase}`,
+      `KTC ${snapshot.turn_phase}`,
+      `KDP ${snapshot.decision.stage}`,
+    ],
+  }
+}
+
+function invariantRows(
+  snapshot: KeeperCompositeSnapshot,
+): Array<{ key: keyof KeeperCompositeInvariants; label: string; ok: boolean; detail: string }> {
+  return (Object.entries(snapshot.invariants) as Array<[keyof KeeperCompositeInvariants, boolean]>)
+    .map(([key, ok]) => ({
+      key,
+      label: INVARIANT_LABELS[key],
+      ok,
+      detail: invariantDetail(snapshot, key, ok),
+    }))
 }
 
 function reduceHubState(state: HubState, action: HubAction): HubState {
@@ -280,6 +751,12 @@ export function FsmHub() {
       ` : error ? html`
         <${EmptyState} message=${error} compact />
       ` : snapshot ? html`
+        <${OperationalMeaningPanel}
+          snapshot=${snapshot}
+          observations=${view.observations}
+          now=${now}
+        />
+
         ${/* ── Zone 2: Hero — KSM Phase ── */ ''}
         <${HeroPhase} snapshot=${snapshot} phaseLog=${phaseLog} />
 
@@ -292,7 +769,7 @@ export function FsmHub() {
         ${/* ── Zone 4: Health Grid ── */ ''}
         <div class="grid gap-3 lg:grid-cols-3">
           <${MeasurementCard} snapshot=${snapshot} />
-          <${InvariantsPanel} invariants=${snapshot.invariants} />
+          <${InvariantsPanel} snapshot=${snapshot} />
           <${RecoveryStatePanel}
             dataRecord=${snapshot.recovery.data_record}
             fsmCondition=${snapshot.recovery.fsm_condition}
@@ -395,6 +872,72 @@ function StatusBar({
 }
 
 // ── Zone 2: Hero Phase ──────────────────────────────────
+
+const INSIGHT_BADGE_CLS: Record<InsightTone, string> = {
+  ok: 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]',
+  info: 'text-[var(--accent)] border-[var(--accent-30)] bg-[var(--accent-10)]',
+  warn: 'text-[#f59e0b] border-[rgba(245,158,11,0.3)] bg-[rgba(245,158,11,0.08)]',
+  error: 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]',
+}
+
+function OperationalMeaningPanel({
+  snapshot,
+  observations,
+  now,
+}: {
+  snapshot: KeeperCompositeSnapshot
+  observations: CompositeObservation[]
+  now: number
+}) {
+  const insight = deriveOperationalInsight(snapshot, observations, now)
+  const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
+
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+      <div class="flex items-start justify-between gap-3 flex-wrap">
+        <div class="min-w-0">
+          <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>
+          <div class="mt-1 text-[18px] font-semibold text-[var(--text-strong)]">${insight.headline}</div>
+          <div class="mt-1 text-[11px] text-[var(--text-dim)] leading-relaxed">${insight.detail}</div>
+        </div>
+        <span class=${`rounded-full border px-2.5 py-0.5 text-[10px] font-mono ${INSIGHT_BADGE_CLS[insight.tone]}`}>
+          ${insight.tone}
+        </span>
+      </div>
+
+      <div class="mt-2 text-[10px] text-[var(--text-body)]">
+        <span class="font-semibold text-[var(--text-muted)]">Next:</span> ${insight.nextStep}
+      </div>
+
+      <div class="mt-2 flex flex-wrap gap-1.5">
+        ${insight.evidence.map(item => html`
+          <span class="rounded-full border border-[var(--white-8)] px-2 py-0.5 text-[9px] font-mono text-[var(--text-dim)]">
+            ${item}
+          </span>
+        `)}
+      </div>
+
+      <div class="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-5">
+        ${lanes.map(lane => html`
+          <div class="rounded-lg border border-[var(--white-8)] bg-[var(--white-3)] px-3 py-2">
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${lane.field}</span>
+              <span class=${`rounded-full border px-1.5 py-0.5 text-[8px] font-mono ${INSIGHT_BADGE_CLS[lane.tone]}`}>
+                ${fmtDuration(lane.observedForSec)}
+              </span>
+            </div>
+            <div class="mt-1 font-mono text-[13px] font-semibold text-[var(--text-strong)]">${lane.value}</div>
+            <div class="mt-0.5 text-[9px] text-[var(--text-dim)]">${lane.label}</div>
+            <div class="mt-1.5 text-[9px] leading-relaxed text-[var(--text-body)]">${lane.meaning}</div>
+            <div class="mt-1 text-[8px] font-mono text-[var(--text-dim)]">
+              ${lane.transitionCount} observed edge${lane.transitionCount === 1 ? '' : 's'}
+            </div>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
 
 const PHASE_DOT_COLOR: Record<string, string> = {
   Running: 'bg-emerald-400',
@@ -585,17 +1128,9 @@ function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: '
   `
 }
 
-const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> = {
-  phase_turn_alignment: 'Phase ⇔ Turn',
-  no_cascade_before_measurement: 'Cascade ordering',
-  compaction_atomicity: 'Compaction atomic',
-  event_priority_monotone: 'Event priority',
-  recovery_two_store_sync: 'Two-store sync',
-}
-
-function InvariantsPanel({ invariants }: { invariants: KeeperCompositeInvariants }) {
-  const entries = Object.entries(invariants) as [keyof KeeperCompositeInvariants, boolean][]
-  const allOk = entries.every(([, ok]) => ok)
+function InvariantsPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
+  const entries = invariantRows(snapshot)
+  const allOk = entries.every(entry => entry.ok)
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="flex items-center justify-between mb-2">
@@ -611,12 +1146,17 @@ function InvariantsPanel({ invariants }: { invariants: KeeperCompositeInvariants
         </span>
       </div>
       <ul class="flex flex-col gap-1">
-        ${entries.map(([key, ok]) => html`
-          <li class="flex items-center gap-1.5 text-[10px]">
-            <span class=${`h-1.5 w-1.5 rounded-full shrink-0 ${ok ? 'bg-[#22c55e]' : 'bg-[#ef4444]'}`}></span>
-            <span class=${ok ? 'text-[var(--text-body)]' : 'text-[#f87171] font-semibold'}>
-              ${INVARIANT_LABELS[key]}
-            </span>
+        ${entries.map(entry => html`
+          <li class="flex gap-2 text-[10px]">
+            <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[#22c55e]' : 'bg-[#ef4444]'}`}></span>
+            <div class="min-w-0">
+              <div class=${entry.ok ? 'text-[var(--text-body)]' : 'text-[#f87171] font-semibold'}>
+                ${entry.label}
+              </div>
+              <div class="text-[8px] leading-relaxed text-[var(--text-dim)]">
+                ${entry.detail}
+              </div>
+            </div>
           </li>
         `)}
       </ul>


### PR DESCRIPTION
## Summary

- add an Operator Meaning panel that interprets the current composite snapshot instead of only listing raw FSM states
- derive per-lane observed dwell and transition summaries for KSM/KTC/KDP/KCL/KMC
- make invariant rows explain what each contract means and why a failure matters
- add focused tests for spec-drift, idle snapshots, and on-screen stall detection

## Product impact

- FSM Hub now answers what is wrong, what should happen next, and which lane is not moving
- the surface becomes useful for operator diagnosis instead of only decorative state display
- invariant failures are explained in runtime terms, not just boolean badges

## Evidence

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run src/components/fsm-hub.test.ts`

## Review evidence

- follow-up review requested specifically on whether the new diagnostics meaningfully use RFC-0003 semantics

## Linked issue

- follow-up to PR #7208 and PR #7223
