### PR TITLE
[codex] Align base-path home fallback and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Other start modes:
 | Loopback | `scripts/start-loopback.sh` | Local dev, fixed port 8935, keepers off |
 | Dir-local | `scripts/run-local.sh --target-dir /path` | Per-project isolation, auto port |
 | Full runtime | `./start-masc-mcp.sh --http` | All transports, keeper autoboot, dashboard |
-| Direct binary | `./_build/default/bin/main_eio.exe --port 8935 --base-path .` | Manual control |
+| Direct binary | `./_build/default/bin/main_eio.exe --port 8935 --base-path "$HOME"` | Manual control |
 
 If you bind to a non-loopback address such as `0.0.0.0`, treat that as a remote exposure path and configure auth first. See [docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md](docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md) and [docs/spec/09-server-transport.md](docs/spec/09-server-transport.md).
 

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -65,6 +65,21 @@ let mcp_protocol_version_default =
 
 let default_base_path = Server_mcp_transport_http.default_base_path
 
+let implicit_base_path_resolution_source () =
+  match Env_config.home_dir_opt () with
+  | Some home ->
+      let normalized_home =
+        Env_config.normalize_masc_base_path_input home
+      in
+      let normalized_default =
+        Env_config.normalize_masc_base_path_input (default_base_path ())
+      in
+      if String.equal normalized_home normalized_default then
+        "implicit_home"
+      else
+        "implicit_repo_root"
+  | None -> "implicit_repo_root"
+
 let is_valid_protocol_version =
   Server_mcp_transport_http.is_valid_protocol_version
 
@@ -320,7 +335,7 @@ let guard_self_repo_base_path base_path =
        (executable: %s)\n\
        Runtime state would pollute the repo. Use a workspace root instead:\n\
        \  --base-path $MASC_BASE_PATH    (recommended)\n\
-       \  --base-path ~/.masc     (alternative)\n\
+       \  --base-path $HOME              (home-scoped runtime)\n\
        Or start via: sb mcp masc start\n"
       base_path abs_exe;
     exit 1
@@ -351,7 +366,7 @@ let run_cmd host port base_path =
             Env_config.normalize_masc_base_path_input (default_base_path ())
           in
           if String.equal default_path normalized_base_path then
-            "implicit_repo_root"
+            implicit_base_path_resolution_source ()
           else
             "explicit_cli"
   in

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -102,16 +102,21 @@ let parse_args () =
     ("--port", Arg.Set_int port, Printf.sprintf "MASC server port (default: %d)" (Env_config_core.masc_http_port_int ()));
     ("--room", Arg.Set_string room, "Room name (default: from base path)");
     ("--refresh", Arg.Set_float refresh, "Refresh interval in seconds (default: 2)");
-    ("--base", Arg.Set_string base_path, "Base path (default: MASC_BASE_PATH or cwd)");
+    ("--base", Arg.Set_string base_path, "Base path (default: MASC_BASE_PATH or HOME)");
   ] in
 
   Arg.parse specs (fun _ -> ()) "masc-tui [OPTIONS]";
 
   (* Resolve base path *)
-  let base = if !base_path <> "" then !base_path
-    else match Sys.getenv_opt "MASC_BASE_PATH" with
-      | Some p -> p
-      | None -> Sys.getcwd ()
+  let base =
+    if !base_path <> "" then !base_path
+    else
+      match Sys.getenv_opt "MASC_BASE_PATH" with
+      | Some p when String.trim p <> "" -> p
+      | _ ->
+          (match Sys.getenv_opt "HOME" with
+           | Some home when String.trim home <> "" -> home
+           | _ -> Sys.getcwd ())
   in
 
   (* Resolve room *)

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -129,6 +129,8 @@ sites work without API change.
 ### 2.1 Root formulas
 
 - Default cluster runtime root: `<base_path>/.masc`
+- When no explicit `base_path` is provided, runtime state falls back to `~/.masc`
+  by treating `HOME` as the implicit base path.
 - Named cluster runtime root: `<base_path>/.masc/clusters/<cluster_name>`
 - Config root: resolved separately by the precedence chain above
 - Personas root: resolved separately from the config root
@@ -296,6 +298,8 @@ Allowed path model:
 Current host note:
 
 - The inspected host also contains auxiliary event and telemetry lanes such as `activity-events/`, `events/`, `telemetry/`, and `data/tool-metrics/`.
+- Repo-local `masc-mcp/logs/` directories are non-canonical historical or
+  harness captures. Live runtime service logs belong under `<runtime_root>/logs/`.
 
 ### 3.9 Auth, Connectors, and Voice
 

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -405,7 +405,7 @@ Current log sink observed today:
 
 1. Pick one base-path convention per environment and stick to it.
    - `--base-path /Users/dancer/me` produces `/Users/dancer/me/.masc`
-   - `--base-path /Users/dancer/me/.masc` produces `/Users/dancer/me/.masc/.masc`
+   - `--base-path /Users/dancer/me/.masc` normalizes to `/Users/dancer/me` and warns
 2. Pick one active config root.
    - If `MASC_CONFIG_DIR` is set, that wins.
    - If you want the base-path config root to become active, unset `MASC_CONFIG_DIR` and restart.

--- a/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
+++ b/docs/LOCAL-DASHBOARD-AUTH-RUNBOOK.md
@@ -28,8 +28,10 @@ Truth fields:
 - `effective_masc_root`
 - `cwd_masc_root`
 - `roots_diverge`
+- `strict_mode_requested`
+- `startup_rejected`
 
-If `effective_base_path` is not the repo you expected, fix that first. In shared `~/me` setups, the live auth store may be `~/me/.masc/auth` even when the server process is running from a sub-repo worktree.
+If `effective_base_path` is not the base path you expected, fix that first. In shared `~/me` setups, the live auth store may be `~/me/.masc/auth` even when the server process is running from a sub-repo worktree.
 
 ## 2. Understand the Gate
 
@@ -62,12 +64,13 @@ For dashboard-side keeper lifecycle control, the target shape is:
 When running from a worktree but using a shared local coordination root, start the server with an explicit base path:
 
 ```bash
-MASC_BASE_PATH="$HOME/me" \
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+MASC_BASE_PATH="$BASE_PATH" \
 MASC_ALLOW_INHERITED_BASE_PATH=1 \
 ./_build/default/bin/main_eio.exe \
   --host 127.0.0.1 \
   --port 8935 \
-  --base-path "$HOME/me"
+  --base-path "$BASE_PATH"
 ```
 
 Then re-check `/health` and confirm `effective_base_path` is the same path you intended.
@@ -81,7 +84,8 @@ If you do not, the reliable local fallback is to seed the auth store directly.
 1. Back up the auth config:
 
 ```bash
-cp "$HOME/me/.masc/auth/config.json" "$HOME/me/.masc/auth/config.json.bak"
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+cp "$BASE_PATH/.masc/auth/config.json" "$BASE_PATH/.masc/auth/config.json.bak"
 ```
 
 2. Generate a token and its SHA256 hash:
@@ -199,8 +203,9 @@ If you need to go back to anonymous loopback behavior:
 Example:
 
 ```bash
-mv "$HOME/me/.masc/auth/config.json.bak" "$HOME/me/.masc/auth/config.json"
-rm -f "$HOME/me/.masc/auth/agents/codex-tool-matrix.json"
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+mv "$BASE_PATH/.masc/auth/config.json.bak" "$BASE_PATH/.masc/auth/config.json"
+rm -f "$BASE_PATH/.masc/auth/agents/codex-tool-matrix.json"
 ```
 
 ## 8. Known Failure Modes

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -249,7 +249,7 @@ masc_keeper_up(name: "sangsu")
 전제조건:
 - `PERSONAS_ROOT/<name>/profile.json`이 존재해야 한다 (또는 `CONFIG_ROOT/keepers/<name>.toml`)
 - `PERSONAS_ROOT`는 `MASC_PERSONAS_DIR` 우선, 없으면 resolved `CONFIG_ROOT/personas`를 사용한다.
-- 기본적으로 git repo root를 `MASC_BASE_PATH`로 자동 해석한다.
+- 명시적인 `MASC_BASE_PATH`가 없으면 `HOME`을 implicit base path로 사용한다. 따라서 기본 runtime state는 `~/.masc/` 아래에 놓인다.
 - `start-masc-mcp.sh`는 worktree에서 실행해도 위 규칙을 그대로 따른다.
 - shared keeper 상태 대신 별도 `.masc/`를 쓰고 싶을 때만 `--base-path`를 명시적으로 덮어쓴다.
 - resolved config root는 `MASC_CONFIG_DIR` 우선이며, 없으면 `<MASC_BASE_PATH>/.masc/config`를 먼저 초기화/사용한다. 그 뒤에만 `~/.masc/config`, repo `config/` 자동 탐색이 fallback으로 동작한다. repo `config/`는 체크인된 default/example source이며, 마지막 fallback이다.

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -8,12 +8,19 @@ Terminal UI for monitoring and interacting with MASC keepers.
 # Build
 dune build --root . bin/masc_tui.exe
 
-# Run
+# Run against the same shared runtime root as the server
+MASC_BASE_PATH="$HOME/me" ./_build/default/bin/masc_tui.exe
+
+# Or inspect the implicit home-scoped runtime (~/.masc)
 ./_build/default/bin/masc_tui.exe
 
 # Or, if installed
 masc-tui
 ```
+
+If the server is using a different base path, pass `--base <path>` or export
+`MASC_BASE_PATH` before launching the TUI. The fallback order is
+`MASC_BASE_PATH` -> `HOME` -> `cwd`.
 
 ## Modes
 

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -732,7 +732,7 @@ sequenceDiagram
 |---------|--------|------|
 | `MASC_HOST` | `127.0.0.1` | 바인드 주소 |
 | `--port` / `-p` | `8935` | 리스닝 포트 |
-| `--base-path` | `$MASC_BASE_PATH` or `cwd` | `.masc` 데이터 디렉토리 위치 |
+| `--base-path` | `$MASC_BASE_PATH` or `HOME` (`cwd` only if `HOME` is unavailable) | `.masc` 데이터 디렉토리 위치 |
 
 ### 15.2 트랜스포트 설정
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -371,7 +371,7 @@ masc_set_param(key, value)
 |------|--------|------|
 | `-p`, `--port` | 8935 | HTTP 리스닝 포트 |
 | `--host` | `127.0.0.1` | 바인드 주소 |
-| `--base-path` | `MASC_BASE_PATH` 또는 `cwd` 기반 | `.masc` 폴더 위치 |
+| `--base-path` | `MASC_BASE_PATH` 또는 `HOME` 기반 (`HOME` 없을 때만 `cwd`) | `.masc` 폴더 위치 |
 
 ---
 

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -16,8 +16,18 @@ let session_mutex = Eio.Mutex.create ()
 
 let default_base_path () =
   (* Match the launcher guard: a direct binary launch from a checkout with its
-     own .masc must not silently inherit a stale parent MASC_BASE_PATH. *)
-  Room_utils_backend_setup.resolve_server_default_base_path (Sys.getcwd ())
+     own .masc must not silently inherit a stale parent MASC_BASE_PATH.
+     When no explicit base path is set, prefer HOME so runtime artifacts land
+     under ~/.masc instead of the current checkout. *)
+  let requested_path =
+    match Env_config_core.base_path_opt () with
+    | Some _ -> Sys.getcwd ()
+    | None -> (
+        match Env_config_core.home_dir_opt () with
+        | Some home -> home
+        | None -> Sys.getcwd ())
+  in
+  Room_utils_backend_setup.resolve_server_default_base_path requested_path
 
 let is_valid_protocol_version version =
   List.mem version mcp_protocol_versions

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -15,6 +15,8 @@ type t = {
   effective_legacy_dirs : string list;
   roots_diverge : bool;
   dual_masc_roots : bool;
+  strict_mode_requested : bool;
+  startup_rejected : bool;
   fail_fast_enabled : bool;
   warning : string option;
 }
@@ -110,13 +112,16 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
      Pre-#6548 behavior had this escape; removing it broke the
      [Run SSE reconnect e2e] CI step which fails immediately on
      [Dual .masc roots are not supported]. *)
-  let implicit_dual_roots =
+  let startup_rejected =
     dual_masc_roots && not (explicit_resolution_source resolution_source)
   in
-  let fail_fast_enabled =
+  let strict_mode_requested =
     match strict with
-    | Some enabled -> enabled || implicit_dual_roots
-    | None -> fail_fast_env_enabled () || implicit_dual_roots
+    | Some enabled -> enabled
+    | None -> fail_fast_env_enabled ()
+  in
+  let fail_fast_enabled =
+    strict_mode_requested || startup_rejected
   in
   let warning =
     if dual_masc_roots then
@@ -157,6 +162,8 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     effective_legacy_dirs;
     roots_diverge;
     dual_masc_roots;
+    strict_mode_requested;
+    startup_rejected;
     fail_fast_enabled;
     warning;
   }
@@ -169,8 +176,7 @@ let strict_violation (diag : t) =
      not kill itself out from under a CI/test harness or a developer
      who deliberately pointed at a tmp directory. Pairs with the same
      escape condition used to compute [fail_fast_enabled] above. *)
-  diag.dual_masc_roots
-  && not (explicit_resolution_source diag.resolution_source)
+  diag.startup_rejected
 
 let startup_lines (diag : t) =
   let lines =
@@ -201,8 +207,12 @@ let startup_lines (diag : t) =
               (format_legacy_dirs diag.effective_legacy_dirs))
        else
          None);
-      (if diag.fail_fast_enabled then
+      (if diag.strict_mode_requested then
          Some "   Path strict mode: enabled"
+       else
+         None);
+      (if diag.startup_rejected then
+         Some "   Path startup rejection: enabled"
        else
          None);
     ]
@@ -216,10 +226,10 @@ let log_startup_warning (diag : t) =
   | Some message when not !_logged_once ->
       _logged_once := true;
       Log.Server.warn "%s%s" message
-        (if diag.fail_fast_enabled then " (strict mode enabled)" else "")
+        (if diag.strict_mode_requested then " (strict mode enabled)" else "")
   | Some message ->
       Log.Server.debug "%s%s" message
-        (if diag.fail_fast_enabled then " (strict mode enabled)" else "")
+        (if diag.strict_mode_requested then " (strict mode enabled)" else "")
   | None -> ()
 
 let option_field name = function
@@ -240,6 +250,8 @@ let to_yojson (diag : t) =
          `List (List.map (fun dir -> `String dir) diag.effective_legacy_dirs) );
        ("roots_diverge", `Bool diag.roots_diverge);
        ("dual_masc_roots", `Bool diag.dual_masc_roots);
+       ("strict_mode_requested", `Bool diag.strict_mode_requested);
+       ("startup_rejected", `Bool diag.startup_rejected);
        ("fail_fast_enabled", `Bool diag.fail_fast_enabled);
        ("strict_violation", `Bool (strict_violation diag));
      ]

--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -79,7 +79,7 @@ require_not_contains docs/TUI-GUIDE.md './start-masc-mcp.sh --tui'
 require_contains docs/QUICK-START.md '"method":"initialize"'
 require_contains docs/QUICK-START.md 'Mcp-Session-Id: ${SESSION_ID}'
 require_contains docs/QUICK-START.md 'masc_join(agent_name="codex")'
-require_contains docs/QUICK-START.md '기본적으로 git repo root를 `MASC_BASE_PATH`로 자동 해석한다.'
+require_contains docs/QUICK-START.md '명시적인 `MASC_BASE_PATH`가 없으면 `HOME`을 implicit base path로 사용한다.'
 
 require_contains docs/spec/09-server-transport.md 'GET /api/v1/activity/events'
 require_contains docs/spec/09-server-transport.md '`MASC_USE_H2` | `auto`'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,11 +17,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASE_DIR="$REPO_DIR/releases"
-PID_FILE="$REPO_DIR/masc-prod.pid"
 PROD_PORT=8945
 HEALTH_URL="http://127.0.0.1:$PROD_PORT/health"
-BASE_PATH="${MASC_BASE_PATH:-${HOME}/me}"
-LOG_DIR="${BASE_PATH}/logs"
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+RUNTIME_ROOT="${BASE_PATH}/.masc"
+PID_FILE="${RUNTIME_ROOT}/masc-prod.pid"
+LOG_DIR="${RUNTIME_ROOT}/logs"
 LAUNCHD_LABEL="com.jeong-sik.masc-mcp-prod"
 LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
 
@@ -145,7 +146,7 @@ else
     restore_env_override MASC_CONFIG_DIR
     restore_env_override MASC_PERSONAS_DIR
 
-    mkdir -p "$LOG_DIR"
+    mkdir -p "$RUNTIME_ROOT" "$LOG_DIR"
 
     MASC_ORCHESTRATOR_ENABLED=0 \
     MASC_AUTO_RESPOND=true \

--- a/scripts/harness/self_eval_ratchet.sh
+++ b/scripts/harness/self_eval_ratchet.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 ITERATION="${1:-1}"
 : "${MCP_URL:=http://127.0.0.1:8935/mcp}"
-RESULTS_DIR="${MASC_BASE_PATH:-$HOME/me}/.masc/eval_results"
+RESULTS_DIR="${MASC_BASE_PATH:-${HOME:-$PWD}}/.masc/eval_results"
 RESULT_FILE="${RESULTS_DIR}/iteration_${ITERATION}.json"
 
 mkdir -p "$RESULTS_DIR"

--- a/scripts/logs-follow.sh
+++ b/scripts/logs-follow.sh
@@ -17,11 +17,11 @@ usage() {
   cat <<'EOF'
 Usage: scripts/logs-follow.sh [options]
 
-Follow MASC structured server logs from <base-path>/logs/system_log_YYYY-MM-DD.jsonl.
-When run from a worktree, the script resolves the repo root automatically.
+Follow MASC structured server logs from <base-path>/.masc/logs/system_log_YYYY-MM-DD.jsonl.
+If you pass a repo or worktree path, the script resolves it to the owning repo root automatically.
 
 Options:
-  --base-path <path>    Override MASC base path (default: repo root)
+  --base-path <path>    Override MASC base path (default: MASC_BASE_PATH or HOME)
   --date <YYYY-MM-DD>   Read a specific log file instead of today's rotating file
   --lines <n>           Tail last N lines before following (default: 40, use 0 for only new lines)
   --level <level>       Minimum level: debug|info|warn|error (default: debug)
@@ -185,9 +185,9 @@ require_cmd jq
 require_cmd tail
 validate_args
 
-BASE_PATH_INPUT="${BASE_PATH_OVERRIDE:-$REPO_ROOT}"
+BASE_PATH_INPUT="${BASE_PATH_OVERRIDE:-${MASC_BASE_PATH:-${HOME:-$REPO_ROOT}}}"
 BASE_PATH="$(resolve_base_path "$BASE_PATH_INPUT")"
-LOG_DIR="$BASE_PATH/logs"
+LOG_DIR="$BASE_PATH/.masc/logs"
 
 jq_filter='
   def rank:

--- a/scripts/masc-autonomy-action-stats.py
+++ b/scripts/masc-autonomy-action-stats.py
@@ -115,7 +115,7 @@ def main() -> int:
     parser.add_argument("--format", type=str, default="text", choices=["text", "json"], help="Output format")
     args = parser.parse_args()
 
-    base_path = os.environ.get("MASC_BASE_PATH", os.path.expanduser("~/me"))
+    base_path = (os.environ.get("MASC_BASE_PATH") or os.path.expanduser("~")).strip()
     traces_dir = os.path.join(base_path, ".masc", "traces")
 
     start_ts, end_ts = ts_range_from_args(args.days, args.since, args.until)

--- a/scripts/test_emergent_identity.sh
+++ b/scripts/test_emergent_identity.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 DURATION_HOURS="${1:-24}"
 DURATION_SECS=$((DURATION_HOURS * 3600))
 TEST_AGENTS=("dreamer" "connector" "historian")
-BASE_PATH="${MASC_BASE_PATH:-${HOME}/me}"
-LOG_DIR="${BASE_PATH}/logs/emergent_identity_test"
+BASE_PATH="${MASC_BASE_PATH:-$HOME}"
+LOG_DIR="${BASE_PATH}/.masc/logs/emergent_identity_test"
 METRICS_FILE="$LOG_DIR/metrics_$(date +%Y%m%d_%H%M%S).json"
 
 mkdir -p "$LOG_DIR"

--- a/scripts/viewer-trunk.sh
+++ b/scripts/viewer-trunk.sh
@@ -133,7 +133,8 @@ maybe_prune_trpg_room() {
   fi
 
   local room_id="${MASC_TRPG_PRUNE_ROOM_ID:-default}"
-  local base_path="${MASC_TRPG_PRUNE_BASE_PATH:-${MASC_BASE_PATH:-${HOME}/me}}"
+  local default_base_path="${HOME:-$PWD}"
+  local base_path="${MASC_TRPG_PRUNE_BASE_PATH:-${MASC_BASE_PATH:-$default_base_path}}"
   local keep_sessions="${MASC_TRPG_PRUNE_KEEP_SESSIONS:-1}"
   local -a prune_args=(
     --room-id "$room_id"

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -335,11 +335,19 @@ repo_local_personas_dir_match() {
 
 clear_repo_local_config_for_explicit_base_path() {
     local resolved_base_path="$1"
+    local resolved_repo_env_root="$REPO_ENV_ROOT"
+    local resolved_script_dir="$SCRIPT_DIR"
 
     if [ "$BASE_PATH_EXPLICIT" != "1" ]; then
         return 0
     fi
-    if [ "$resolved_base_path" = "$REPO_ENV_ROOT" ] || [ "$resolved_base_path" = "$SCRIPT_DIR" ]; then
+    if [ -d "$resolved_repo_env_root" ]; then
+        resolved_repo_env_root="$(cd "$resolved_repo_env_root" && pwd -P)"
+    fi
+    if [ -d "$resolved_script_dir" ]; then
+        resolved_script_dir="$(cd "$resolved_script_dir" && pwd -P)"
+    fi
+    if [ "$resolved_base_path" = "$resolved_repo_env_root" ] || [ "$resolved_base_path" = "$resolved_script_dir" ]; then
         return 0
     fi
 
@@ -454,7 +462,7 @@ PORT_EXPLICIT=0
 PRINT_PORT_ONLY=0
 WORKTREE_PORT_HINT=""
 HTTP_MODE="${MASC_MCP_HTTP:-true}"
-BASE_PATH="${MASC_BASE_PATH:-$SCRIPT_DIR}"
+BASE_PATH="${MASC_BASE_PATH:-${HOME:-$SCRIPT_DIR}}"
 HOST="${MASC_HOST:-127.0.0.1}"
 # NOTE: Eio is now the default runtime (Lwt deprecated since 2026-01)
 EIO_MODE="true"
@@ -516,6 +524,8 @@ if [ "$BASE_PATH_EXPLICIT" = "1" ]; then
     BASE_PATH_RESOLUTION_SOURCE="explicit_cli"
 elif [ "$MASC_BASE_PATH_WAS_SET" = "1" ] && is_absolute_path "$BASE_PATH"; then
     BASE_PATH_RESOLUTION_SOURCE="explicit_env"
+elif [ -z "${MASC_BASE_PATH:-}" ] && [ -n "${HOME:-}" ] && [ "$BASE_PATH" = "$HOME" ]; then
+    BASE_PATH_RESOLUTION_SOURCE="implicit_home"
 fi
 
 if [ "$PORT_EXPLICIT" != "1" ]; then

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -125,6 +125,14 @@ let test_dashboard_shell_http_json_includes_paths () =
     (match paths |> member "cwd" with
      | `String value -> String.length value > 0
      | _ -> false);
+  check bool "paths include strict_mode_requested bool" true
+    (match paths |> member "strict_mode_requested" with
+     | `Bool _ -> true
+     | _ -> false);
+  check bool "paths include startup_rejected bool" true
+    (match paths |> member "startup_rejected" with
+     | `Bool _ -> true
+     | _ -> false);
   check bool "shell config resolution is object or null" true
     (match config_resolution with
      | `Assoc _ | `Null -> true

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -113,6 +113,10 @@ let test_implicit_dual_roots_are_strict_violation () =
       ~effective_masc_root:(Filename.concat effective ".masc")
       ()
   in
+  Alcotest.(check bool) "strict_mode_requested stays false" false
+    diag.strict_mode_requested;
+  Alcotest.(check bool) "startup_rejected derived from implicit dual roots" true
+    diag.startup_rejected;
   Alcotest.(check bool) "fail_fast derived from implicit dual roots" true
     diag.fail_fast_enabled;
   Alcotest.(check bool) "implicit dual roots violate" true
@@ -153,13 +157,11 @@ let test_explicit_resolution_source_escapes_strict_violation () =
   Alcotest.(check bool) "dual roots still detected" true diag.dual_masc_roots;
   Alcotest.(check bool) "warning still present" true
     (Option.is_some diag.warning);
-  (* fail_fast_enabled still reflects user intent (STRICT=true is set),
-     but strict_violation short-circuits because the resolution source
-     is explicit. The escape is layered on strict_violation, not on
-     fail_fast_enabled — the user asked for strict mode, honor that
-     signal, just don't kill the runtime when they also told us
-     exactly where to put the base path. *)
-  Alcotest.(check bool) "fail_fast_enabled reflects user STRICT=true" true
+  Alcotest.(check bool) "strict_mode_requested reflects user STRICT=true" true
+    diag.strict_mode_requested;
+  Alcotest.(check bool) "startup_rejected false for explicit env source" false
+    diag.startup_rejected;
+  Alcotest.(check bool) "fail_fast_enabled remains true under strict mode" true
     diag.fail_fast_enabled;
   Alcotest.(check bool) "explicit env source escapes violation" false
     (Server_base_path_diagnostics.strict_violation diag)
@@ -188,6 +190,10 @@ let test_explicit_cli_resolution_source_also_escapes () =
       ()
   in
   Alcotest.(check bool) "dual roots still detected" true diag.dual_masc_roots;
+  Alcotest.(check bool) "strict_mode_requested false without user STRICT" false
+    diag.strict_mode_requested;
+  Alcotest.(check bool) "startup_rejected false for explicit cli source" false
+    diag.startup_rejected;
   Alcotest.(check bool) "fail_fast_enabled false without user STRICT" false
     diag.fail_fast_enabled;
   Alcotest.(check bool) "explicit cli source escapes violation" false
@@ -229,6 +235,22 @@ let test_to_yojson_exposes_resolution_source () =
   let json = Server_base_path_diagnostics.to_yojson diag in
   Alcotest.(check string) "resolution source" "explicit_cli"
     (json |> member "resolution_source" |> to_string)
+
+let test_to_yojson_exposes_gate_fields () =
+  let diag =
+    Server_base_path_diagnostics.detect ~cwd:"/tmp/repo"
+      ~effective_base_path:"/tmp/workspace"
+      ~effective_masc_root:"/tmp/workspace/.masc"
+      ()
+  in
+  let open Yojson.Safe.Util in
+  let json = Server_base_path_diagnostics.to_yojson diag in
+  Alcotest.(check bool) "strict_mode_requested field" false
+    (json |> member "strict_mode_requested" |> to_bool);
+  Alcotest.(check bool) "startup_rejected field" false
+    (json |> member "startup_rejected" |> to_bool);
+  Alcotest.(check bool) "fail_fast_enabled field" false
+    (json |> member "fail_fast_enabled" |> to_bool)
 
 let test_default_base_path_ignores_inherited_parent_root_in_tests () =
   with_temp_dir "base-path-default" @@ fun root ->
@@ -274,6 +296,21 @@ let test_default_base_path_ignores_inherited_root_without_local_masc () =
     (canonical_path repo)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
+let test_default_base_path_falls_back_to_home_when_unset () =
+  with_temp_dir "base-path-default-home-fallback" @@ fun root ->
+  let repo = Filename.concat root "repo" in
+  let home = Filename.concat root "home" in
+  mkdir_p repo;
+  mkdir_p home;
+  with_cwd repo @@ fun () ->
+  with_env "MASC_BASE_PATH" None @@ fun () ->
+  with_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH" None @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
+  with_env "HOME" (Some home) @@ fun () ->
+  Alcotest.(check string) "default base path falls back to home"
+    (canonical_path home)
+    (Server_mcp_transport_http.default_base_path () |> canonical_path)
+
 let () =
   Alcotest.run "Server_base_path_diagnostics"
     [
@@ -295,6 +332,8 @@ let () =
             test_to_yojson_exposes_effective_paths;
           Alcotest.test_case "json exposes resolution source" `Quick
             test_to_yojson_exposes_resolution_source;
+          Alcotest.test_case "json exposes gate fields" `Quick
+            test_to_yojson_exposes_gate_fields;
           Alcotest.test_case "default base path ignores inherited parent root in tests"
             `Quick test_default_base_path_ignores_inherited_parent_root_in_tests;
           Alcotest.test_case
@@ -303,5 +342,8 @@ let () =
           Alcotest.test_case
             "default base path ignores inherited root without local .masc"
             `Quick test_default_base_path_ignores_inherited_root_without_local_masc;
+          Alcotest.test_case
+            "default base path falls back to home when unset"
+            `Quick test_default_base_path_falls_back_to_home_when_unset;
         ] );
     ]

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -291,6 +291,37 @@ let test_bootstraps_base_path_config_from_repo_when_unset () =
       check bool "repo config copied to base path config" true
         (Sys.file_exists (Filename.concat bootstrapped_config "cascade.json")))
 
+let test_default_base_path_falls_back_to_home_when_unset () =
+  with_temp_dir "start-masc-script-home-fallback" (fun dir ->
+      let script = Filename.concat dir "start-masc-mcp.sh" in
+      copy_script (script_path ()) script;
+      ignore (make_config_root dir);
+      make_fake_eio_exe dir;
+      let home_dir = Filename.concat dir "home" in
+      mkdir_p home_dir;
+      let capture = Filename.concat dir "captured-home-fallback.txt" in
+      let code, stdout, stderr =
+        run_shell ~cwd:dir
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("HOME", home_dir);
+              ("MASC_BASE_PATH", "");
+              ("MASC_CONFIG_DIR", "");
+            ]
+          (Printf.sprintf "%s --http --port 9969" (quote script))
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      let captured = read_file capture in
+      let expected_home = canonical_path home_dir in
+      check bool "default base path falls back to home" true
+        (contains_substring captured ("MASC_BASE_PATH=" ^ expected_home));
+      check bool "default config root follows home fallback" true
+        (contains_substring captured
+           ("MASC_CONFIG_DIR=" ^ Filename.concat expected_home ".masc/config")))
+
 let test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
@@ -513,9 +544,10 @@ let test_explicit_base_path_ignores_repo_local_config_from_zshenv () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_parent = canonical_path parent in
       check bool "explicit base path resets config root to base path" true
         (contains_substring captured
-           ("MASC_CONFIG_DIR=" ^ Filename.concat parent ".masc/config"));
+           ("MASC_CONFIG_DIR=" ^ Filename.concat expected_parent ".masc/config"));
       check bool "stderr explains repo-local config ignore" true
         (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR");
       check bool "stderr explains repo-local personas ignore" true
@@ -546,10 +578,11 @@ let test_explicit_base_path_ignores_repo_local_config_from_parent_env () =
         failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
           stderr;
       let captured = read_file capture in
+      let expected_parent = canonical_path parent in
       check bool "parent env repo-local config ignored under external base path"
         true
         (contains_substring captured
-           ("MASC_CONFIG_DIR=" ^ Filename.concat parent ".masc/config"));
+           ("MASC_CONFIG_DIR=" ^ Filename.concat expected_parent ".masc/config"));
       check bool "parent env repo-local config ignore is logged" true
         (contains_substring stderr "Ignoring repo-local MASC_CONFIG_DIR"))
 
@@ -668,6 +701,8 @@ let () =
             test_realtime_transports_default_to_base_path_config_and_preserve_override;
           test_case "bootstraps base path config from repo when unset" `Quick
             test_bootstraps_base_path_config_from_repo_when_unset;
+          test_case "default base path falls back to home when unset" `Quick
+            test_default_base_path_falls_back_to_home_when_unset;
           test_case
             "absolute inherited base path with dual .masc roots is preserved"
             `Quick


### PR DESCRIPTION
## Summary
- make implicit runtime state default to `HOME/.masc` when `MASC_BASE_PATH` is unset
- align launcher/direct-server/TUI/helper/docs wording with the home-scoped base-path rule
- split base-path diagnostics into clearer read-model booleans so strict-mode intent and startup rejection are no longer conflated

## Product impact
- direct server startup from a repo checkout now defaults to home-scoped runtime state instead of repo-local state
- `/health.paths` becomes easier to interpret because `strict_mode_requested` and `startup_rejected` are exposed separately
- operator/help surfaces stop suggesting `--base-path ~/.masc` and consistently point to the workspace root / home-scoped base path

## Evidence
- `dune build --root . bin/main_eio.exe bin/masc_tui.exe test/test_server_base_path_diagnostics.exe test/test_dashboard_http_core.exe test/test_server_runtime_bootstrap.exe test/test_start_masc_mcp_script.exe -j 1`
- `./_build/default/test/test_server_base_path_diagnostics.exe`
- `./_build/default/test/test_dashboard_http_core.exe`
- `./_build/default/test/test_server_runtime_bootstrap.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- `bash -n scripts/logs-follow.sh start-masc-mcp.sh scripts/deploy.sh scripts/harness/self_eval_ratchet.sh scripts/viewer-trunk.sh scripts/test_emergent_identity.sh`
- `bash scripts/check-doc-truth.sh`
- `git diff --check`

## Review evidence
- addressed the remaining follow-up ambiguity from PR #6548 around `fail_fast_enabled` vs actual startup rejection semantics
- re-checked operator-facing wording for the active base-path entrypoints after switching implicit runtime state to `HOME`

## Linked issue
- Refs #6548