### PR TITLE
refactor(dashboard): unify time range constants + cross-link Observatory

### DIFF
--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -1,7 +1,7 @@
 // Activity graph surface — runtime event graph + timeline
 
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
+import { computed, signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { createAsyncResource } from '../lib/async-state'
 import { Card } from './common/card'
@@ -26,19 +26,38 @@ import {
 } from './activity-graph-groups'
 import { fetchActivityGraph } from '../api'
 import { registerActivityRefresh } from '../sse-store'
+import { route, navigate, hashForRoute } from '../router'
+import {
+  TIME_RANGE_PRESETS,
+  timeRangeShortLabel,
+} from '../observatory-filter-store'
 import type { ActivityGraphResponse, ActivityGraphNode, ActionTimelineGroup } from '../types'
 
 const graphResource = createAsyncResource<ActivityGraphResponse | null>()
-export const selectedTimeRange = signal<string>('all')
+
+// URL-synced time range: reads ?ag_range= param, defaults to 'all'
+const VALID_AG_RANGES = new Set([...TIME_RANGE_PRESETS.filter(p => p !== '5m'), 'all'])
+export const selectedTimeRange = computed(() => {
+  const v = route.value.params.ag_range
+  return v && VALID_AG_RANGES.has(v) ? v : 'all'
+})
+
+function setActivityTimeRange(value: string): void {
+  const next: Record<string, string> = { ...route.value.params }
+  if (value === 'all') {
+    delete next.ag_range
+  } else {
+    next.ag_range = value
+  }
+  navigate(route.value.tab, next)
+}
 const actionFilter = signal<ActionTimelineFilter>('all')
 const showLifecycle = signal(false)
 const expandedActionGroups = signal<Set<string>>(new Set())
 
+// Reuse shared presets + Activity Graph-specific "all" option
 const TIME_RANGES: Array<{ value: string; label: string }> = [
-  { value: '1h', label: '1시간' },
-  { value: '6h', label: '6시간' },
-  { value: '24h', label: '24시간' },
-  { value: '7d', label: '7일' },
+  ...TIME_RANGE_PRESETS.filter(p => p !== '5m').map(p => ({ value: p, label: timeRangeShortLabel(p) })),
   { value: 'all', label: '전체' },
 ]
 
@@ -65,7 +84,7 @@ function TimeRangeSelector() {
               ? 'border-[var(--warn-20)] bg-[var(--warn-10)] text-[var(--warn-bright)]'
               : 'border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)]'
           }"
-          onClick=${() => { selectedTimeRange.value = value; loadGraph() }}
+          onClick=${() => { setActivityTimeRange(value); loadGraph() }}
         >${label}</button>
       `)}
     </div>
@@ -211,13 +230,21 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
                 </div>
                 <div class="mt-3 flex items-center justify-between gap-3 border-t border-[var(--white-6)] pt-3">
                   <span class="text-[11px] text-[var(--text-muted)]">원본 이벤트를 펼쳐서 순서를 확인할 수 있습니다.</span>
-                  <button
-                    type="button"
-                    class="rounded-lg border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-[11px] text-[var(--text-body)] transition-all duration-150 hover:bg-[var(--white-8)]"
-                    onClick=${() => toggleExpandedGroup(group.id)}
-                  >
-                    ${expanded ? '원본 접기' : '원본 보기'}
-                  </button>
+                  <div class="flex items-center gap-2">
+                    ${group.actor ? html`
+                      <a
+                        class="rounded-lg border border-[var(--accent-20)] bg-[var(--accent-soft)] px-3 py-1.5 text-[11px] text-[var(--accent)] no-underline transition-all duration-150 hover:bg-[var(--accent-10)]"
+                        href=${hashForRoute('monitoring', { section: 'observatory', keeper: group.actor, range: selectedTimeRange.value !== 'all' ? selectedTimeRange.value : '1h' })}
+                      >관찰소에서 보기</a>
+                    ` : null}
+                    <button
+                      type="button"
+                      class="rounded-lg border border-[var(--white-10)] bg-[var(--white-4)] px-3 py-1.5 text-[11px] text-[var(--text-body)] transition-all duration-150 hover:bg-[var(--white-8)]"
+                      onClick=${() => toggleExpandedGroup(group.id)}
+                    >
+                      ${expanded ? '원본 접기' : '원본 보기'}
+                    </button>
+                  </div>
                 </div>
                 ${expanded ? html`
                   <div class="mt-3 flex flex-col gap-2 rounded-xl border border-[var(--white-8)] bg-[rgba(15,23,42,0.42)] p-3">

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -20,6 +20,8 @@ import {
   currentTimeRangeFilter,
   setTimeRangeFilter,
   timeRangeLabel,
+  timeRangeShortLabel,
+  timeRangeToMs,
   TIME_RANGE_PRESETS,
   type TimeRangePreset,
 } from '../../observatory-filter-store'
@@ -37,19 +39,6 @@ import { CrossSignalReadout } from './cross-signal-readout'
 import { DetailPane } from './detail-pane'
 import { cursorPosition } from './cursor-store'
 import { LoadingState } from '../common/feedback-state'
-
-// --- Time range utilities ---
-
-const RANGE_TO_MS: Record<TimeRangePreset, number> = {
-  '5m': 5 * 60_000,
-  '1h': 60 * 60_000,
-  '24h': 24 * 60 * 60_000,
-  '7d': 7 * 24 * 60 * 60_000,
-}
-
-export function timeRangeToMs(preset: TimeRangePreset): number {
-  return (RANGE_TO_MS[preset] ?? RANGE_TO_MS['1h'] ?? 3_600_000)
-}
 
 const DEFAULT_RANGE: TimeRangePreset = '1h'
 
@@ -71,7 +60,7 @@ function emptyData(): ObservatoryData {
     error: null,
     events: [],
     hourlyTrend: [],
-    windowStart: now - RANGE_TO_MS[DEFAULT_RANGE],
+    windowStart: now - timeRangeToMs(DEFAULT_RANGE),
     windowEnd: now,
   }
 }
@@ -127,7 +116,7 @@ function RangeSelector() {
           onClick=${() => setTimeRangeFilter(preset)}
           aria-pressed=${current === preset}
         >
-          ${timeRangeLabel(preset).replace('최근 ', '')}
+          ${timeRangeShortLabel(preset)}
         </button>
       `)}
     </div>
@@ -161,7 +150,7 @@ export function Observatory() {
     const requestId = ++latestRequestId.current
 
     const now = Date.now()
-    const windowStart = now - RANGE_TO_MS[range]
+    const windowStart = now - timeRangeToMs(range)
     const windowEnd = now
 
     state.value = { ...state.value, loading: true, error: null }

--- a/dashboard/src/observatory-filter-store.test.ts
+++ b/dashboard/src/observatory-filter-store.test.ts
@@ -30,6 +30,8 @@ import {
   setKeeperFilter,
   setTimeRangeFilter,
   timeRangeLabel,
+  timeRangeShortLabel,
+  timeRangeToMs,
 } from './observatory-filter-store'
 
 const setRoute = (router as unknown as {
@@ -111,7 +113,29 @@ describe('observatory-filter-store', () => {
   it('timeRangeLabel returns human-readable Korean label', () => {
     expect(timeRangeLabel('5m')).toBe('최근 5분')
     expect(timeRangeLabel('1h')).toBe('최근 1시간')
+    expect(timeRangeLabel('6h')).toBe('최근 6시간')
     expect(timeRangeLabel('24h')).toBe('최근 24시간')
     expect(timeRangeLabel('7d')).toBe('최근 7일')
+  })
+
+  it('timeRangeShortLabel returns short label without prefix', () => {
+    expect(timeRangeShortLabel('5m')).toBe('5분')
+    expect(timeRangeShortLabel('1h')).toBe('1시간')
+    expect(timeRangeShortLabel('6h')).toBe('6시간')
+    expect(timeRangeShortLabel('24h')).toBe('24시간')
+    expect(timeRangeShortLabel('7d')).toBe('7일')
+  })
+
+  it('timeRangeToMs converts presets to milliseconds', () => {
+    expect(timeRangeToMs('5m')).toBe(5 * 60_000)
+    expect(timeRangeToMs('1h')).toBe(60 * 60_000)
+    expect(timeRangeToMs('6h')).toBe(6 * 60 * 60_000)
+    expect(timeRangeToMs('24h')).toBe(24 * 60 * 60_000)
+    expect(timeRangeToMs('7d')).toBe(7 * 24 * 60 * 60_000)
+  })
+
+  it('accepts 6h as valid time range preset', () => {
+    setRoute('monitoring', { range: '6h' })
+    expect(currentTimeRangeFilter()).toBe('6h')
   })
 })

--- a/dashboard/src/observatory-filter-store.ts
+++ b/dashboard/src/observatory-filter-store.ts
@@ -12,19 +12,46 @@
 
 import { route, navigate } from './router'
 
-export type TimeRangePreset = '5m' | '1h' | '24h' | '7d'
+export type TimeRangePreset = '5m' | '1h' | '6h' | '24h' | '7d'
 
-export const TIME_RANGE_PRESETS: ReadonlyArray<TimeRangePreset> = ['5m', '1h', '24h', '7d']
+export const TIME_RANGE_PRESETS: ReadonlyArray<TimeRangePreset> = ['5m', '1h', '6h', '24h', '7d']
+
+const TIME_RANGE_SHORT_LABELS: Record<TimeRangePreset, string> = {
+  '5m': '5분',
+  '1h': '1시간',
+  '6h': '6시간',
+  '24h': '24시간',
+  '7d': '7일',
+}
 
 const TIME_RANGE_LABELS: Record<TimeRangePreset, string> = {
   '5m': '최근 5분',
   '1h': '최근 1시간',
+  '6h': '최근 6시간',
   '24h': '최근 24시간',
   '7d': '최근 7일',
 }
 
 export function timeRangeLabel(preset: TimeRangePreset): string {
   return TIME_RANGE_LABELS[preset]
+}
+
+export function timeRangeShortLabel(preset: TimeRangePreset): string {
+  return TIME_RANGE_SHORT_LABELS[preset]
+}
+
+// --- Time range → milliseconds conversion (shared across Observatory & Activity Graph) ---
+
+const RANGE_TO_MS: Record<TimeRangePreset, number> = {
+  '5m': 5 * 60_000,
+  '1h': 60 * 60_000,
+  '6h': 6 * 60 * 60_000,
+  '24h': 24 * 60 * 60_000,
+  '7d': 7 * 24 * 60 * 60_000,
+}
+
+export function timeRangeToMs(preset: TimeRangePreset): number {
+  return RANGE_TO_MS[preset] ?? RANGE_TO_MS['1h']
 }
 
 // --- Reactive accessors (URL → state) ---


### PR DESCRIPTION
## Summary
- Observatory와 Activity Graph의 시간 범위 상수(presets, labels, ms 변환)를 `observatory-filter-store.ts`로 통합
- Activity Graph 시간 범위를 URL params(`?ag_range=`)에 동기화 (새로고침 시 필터 유지)
- Activity Graph action group에서 "관찰소에서 보기" cross-link 추가 (keeper + range 전달)
- `timeRangeShortLabel()` 추가로 `.replace('최근 ', '')` 패턴 제거
- `TimeRangePreset`에 `'6h'` 추가 (Activity Graph에서만 사용하던 것을 공유 타입으로 승격)

## Product impact
대시보드 내부 리팩토링. 외부 동작 변경: Activity Graph 시간 필터가 URL에 반영되어 새로고침 시 유지됨. action group에서 Observatory로 이동하는 cross-link 추가.

## Evidence
- `tsc --noEmit` 통과
- `vitest run` 관련 15개 테스트 통과
- `vite build` 성공
- CI Dashboard job pass (2m0s)

## Review evidence
Self-reviewed. Dashboard-only 변경, OCaml/backend 영향 없음.

## Linked issue
Refs RFC-MASC-006

## Changes
| 파일 | 변경 |
|------|------|
| `observatory-filter-store.ts` | `RANGE_TO_MS`, `timeRangeToMs`, `timeRangeShortLabel` 추가, `'6h'` preset 추가 |
| `observatory.ts` | 로컬 `RANGE_TO_MS` 제거, filter-store import로 전환 |
| `activity-graph.ts` | 로컬 `TIME_RANGES` → 공유 상수 파생, URL 동기화, cross-link 버튼 |
| `observatory-filter-store.test.ts` | `6h`, `timeRangeShortLabel`, `timeRangeToMs` 테스트 추가 |

## Test plan
- [x] `tsc --noEmit` 통과
- [x] `vitest run observatory-filter-store.test.ts activity-graph.test.ts` 15개 통과
- [x] `vite build` 성공
- [ ] 대시보드에서 Activity Graph 시간 범위 변경 → URL에 `ag_range` 반영 확인
- [ ] "관찰소에서 보기" 링크 클릭 → Observatory로 keeper/range 전달 확인
- [ ] Observatory `6h` 프리셋 버튼 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)