### PR TITLE
refactor(command_plane): introduce leader_presence variant (#7239)

### DIFF
--- a/lib/command_plane/cp_lifecycle_policy.ml
+++ b/lib/command_plane/cp_lifecycle_policy.ml
@@ -484,11 +484,12 @@ let policy_deny_json config ~(actor : string) json =
 let detachment_status_detail_json config units agents operations
     (detachment : detachment_record) =
   let now = Time_compat.now () in
-  let leader_status =
+  let leader_presence =
     match detachment.leader_id with
     | Some leader -> agent_status_for (agent_status_map agents) leader
-    | None -> "missing"
+    | None -> Cp_unit.Leader_missing
   in
+  let leader_status = Cp_unit.leader_presence_to_string leader_presence in
   let heartbeat_expired =
     match detachment.heartbeat_deadline with
     | Some deadline -> iso_expired_at now deadline
@@ -525,8 +526,7 @@ let detachment_status_detail_json config units agents operations
       ( "needs_attention",
         `Bool
           (heartbeat_expired
-           || String.equal leader_status "offline"
-           || String.equal leader_status "missing"
+           || Cp_unit.leader_is_unavailable leader_presence
            || detachment.status = Det_stalled
            || detachment.status = Det_awaiting_approval) );
     ]
@@ -696,13 +696,13 @@ let dispatch_tick_json config ~(actor : string) json =
   List.iter
     (fun (detachment : detachment_record) ->
       let is_stalled = stalled_or_quiet_detachment now detachment in
-      let leader_status =
+      let leader_presence =
         match detachment.leader_id with
         | Some leader -> agent_status_for (agent_status_map agents) leader
-        | None -> "missing"
+        | None -> Cp_unit.Leader_missing
       in
       if is_stalled then incr stale_count;
-      if is_stalled || String.equal leader_status "offline" || String.equal leader_status "missing" then
+      if is_stalled || Cp_unit.leader_is_unavailable leader_presence then
         match pick_failover_leader live_agents detachment with
         | Some next_leader ->
             let refreshed =

--- a/lib/command_plane/cp_snapshot_core.ml
+++ b/lib/command_plane/cp_snapshot_core.ml
@@ -475,7 +475,7 @@ let list_alerts_json_from_state _config (state : snapshot_state) =
           ~scope_id:unit.unit_id ~title:(unit.label ^ " has no leader")
           ~detail:"Assign a leader before enabling automatic dispatch.";
       (match unit.leader_id with
-      | Some leader when agent_status_for status_map leader = "offline" ->
+      | Some leader when Cp_unit.leader_is_unavailable (agent_status_for status_map leader) ->
           push_alert ~severity:"bad" ~kind:"leader_offline" ~scope_type:"unit"
             ~scope_id:unit.unit_id ~title:(unit.label ^ " leader is offline")
             ~detail:"Reassign leadership or recall the unit."

--- a/lib/command_plane/cp_unit.ml
+++ b/lib/command_plane/cp_unit.ml
@@ -1,5 +1,22 @@
 include Cp_unit_projection
 
+(** Leader presence: composite of agent_status + existence.
+    Replaces stringly-typed leader_status ("offline"/"missing"/status).
+    @since 7239 *)
+type leader_presence =
+  | Leader_present of Types.agent_status
+  | Leader_offline   (** agent not in live list *)
+  | Leader_missing   (** no leader_id set *)
+
+let leader_presence_to_string = function
+  | Leader_present status -> Types.string_of_agent_status status
+  | Leader_offline -> "offline"
+  | Leader_missing -> "missing"
+
+let leader_is_unavailable = function
+  | Leader_offline | Leader_missing -> true
+  | Leader_present _ -> false
+
 let safe_live_agents config =
   Room.get_active_agents config
   |> List.filter (fun (agent : Types.agent) ->
@@ -333,17 +350,21 @@ let roster_name_is_live live_agents roster_name =
 let agent_status_map agents =
   List.map (fun (agent : Types.agent) -> (agent.name, Types.string_of_agent_status agent.status)) agents
 
-let agent_status_for agents agent_name =
-  match List.assoc_opt agent_name agents with
-  | Some status -> status
-  | None ->
-      agents
-      |> List.find_map (fun (live_name, status) ->
-             if live_agent_name_matches agent_name live_name then
-               Some status
-             else
-               None)
-      |> Option.value ~default:"offline"
+let agent_status_for agents agent_name : leader_presence =
+  let find_status () =
+    match List.assoc_opt agent_name agents with
+    | Some status -> Some status
+    | None ->
+        agents
+        |> List.find_map (fun (live_name, status) ->
+               if live_agent_name_matches agent_name live_name then
+                 Some status
+               else
+                 None)
+  in
+  match find_status () with
+  | Some status -> Leader_present (Types.agent_status_of_string status)
+  | None -> Leader_offline
 
 let active_operation_status = function
   | Active | Planned -> true
@@ -413,14 +434,17 @@ let rec build_tree_json ?(depth = 0) ?(visited = [])
         |> List.filter (roster_name_is_live live_agents)
         |> List.length
       in
-      let leader_status =
+      let leader_presence =
         match unit.leader_id with
         | Some leader -> agent_status_for agent_statuses leader
-        | None -> "missing"
+        | None -> Leader_missing
       in
+      let leader_status = leader_presence_to_string leader_presence in
       let reasons = ref [] in
-      if unit.leader_id = None then reasons := "leader_missing" :: !reasons;
-      if unit.leader_id <> None && leader_status = "offline" then reasons := "leader_offline" :: !reasons;
+      (match leader_presence with
+       | Leader_missing -> reasons := "leader_missing" :: !reasons
+       | Leader_offline -> reasons := "leader_offline" :: !reasons
+       | Leader_present _ -> ());
       if List.length unit.roster > unit.budget.headcount_cap then reasons := "headcount_cap_exceeded" :: !reasons;
       if descendant_op_count > unit.budget.active_operation_cap then
         reasons := "active_operation_cap_exceeded" :: !reasons;
@@ -488,15 +512,20 @@ let rec build_tree_json_indexed ?(depth = 0) ?(visited = [])
         Hashtbl.find_opt tree_idx.live_roster_count unit_id
         |> Option.value ~default:0
       in
-      let leader_status =
+      let leader_presence =
         match unit.leader_id with
-        | Some leader -> Cp_tree_index.agent_status_for_tbl tree_idx leader
-        | None -> "missing"
+        | Some leader ->
+          let s = Cp_tree_index.agent_status_for_tbl tree_idx leader in
+          if s = "offline" then Leader_offline
+          else Leader_present (Types.agent_status_of_string s)
+        | None -> Leader_missing
       in
+      let leader_status = leader_presence_to_string leader_presence in
       let reasons = ref [] in
-      if unit.leader_id = None then reasons := "leader_missing" :: !reasons;
-      if unit.leader_id <> None && leader_status = "offline" then
-        reasons := "leader_offline" :: !reasons;
+      (match leader_presence with
+       | Leader_missing -> reasons := "leader_missing" :: !reasons
+       | Leader_offline -> reasons := "leader_offline" :: !reasons
+       | Leader_present _ -> ());
       if List.length unit.roster > unit.budget.headcount_cap then
         reasons := "headcount_cap_exceeded" :: !reasons;
       if descendant_op_count > unit.budget.active_operation_cap then


### PR DESCRIPTION
## Summary

Replace stringly-typed leader_status with typed leader_presence variant.

Fixes #7239

## Type

\`\`\`ocaml
type leader_presence =
  | Leader_present of Types.agent_status
  | Leader_offline
  | Leader_missing
\`\`\`

## Changes (3 files, 58+/29-)

| File | Change |
|------|--------|
| cp_unit.ml | Type + agent_status_for returns leader_presence |
| cp_lifecycle_policy.ml | 2 call sites: string comparison → leader_is_unavailable |
| cp_snapshot_core.ml | 1 call site: string comparison → leader_is_unavailable |

JSON serialization unchanged (leader_presence_to_string preserves same strings).

## Test Plan

- [x] Library build passes
- [ ] CI