### PR TITLE
feat(dashboard): Keeper 현황 패널 개선 — 트렌드, 리셋, 측정 시점

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -282,6 +282,13 @@ export function shutdownKeeper(name: string): Promise<KeeperLifecycleResponse> {
   )
 }
 
+export function resetKeeper(name: string): Promise<KeeperLifecycleResponse> {
+  return safeKeeperLifecycle(
+    `/api/v1/keepers/${encodeURIComponent(name)}/reset`,
+    `Failed to reset ${name}`,
+  )
+}
+
 // --- Keeper tool policy editing ---
 
 export interface KeeperToolPolicyInput {

--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -92,7 +92,7 @@ describe('FleetHealthPanel', () => {
 
     expect(screen.getByText('개요')).toBeTruthy()
     expect(screen.getByText('이벤트 로그')).toBeTruthy()
-    expect(screen.getByText('Fleet 비교')).toBeTruthy()
+    expect(screen.getByText('Keeper 비교')).toBeTruthy()
     expect(screen.getByText('도구 품질')).toBeTruthy()
     expect(screen.getByText('거버넌스')).toBeTruthy()
   })

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -31,7 +31,7 @@ const activeView = computed<FleetHealthView>(() => {
 const VIEW_CHIPS: Array<{ key: FleetHealthView; label: string }> = [
   { key: 'default',      label: '개요' },
   { key: 'event-log',    label: '이벤트 로그' },
-  { key: 'comparison',   label: 'Fleet 비교' },
+  { key: 'comparison',   label: 'Keeper 비교' },
   { key: 'tool-quality', label: '도구 품질' },
   { key: 'governance',   label: '거버넌스' },
 ]
@@ -63,7 +63,7 @@ export function FleetHealthPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <div class="flex items-center justify-between">
-        <h2 class="text-sm font-medium text-[var(--text-strong)]">Fleet 건강</h2>
+        <h2 class="text-sm font-medium text-[var(--text-strong)]">Keeper 현황</h2>
       </div>
       <${FilterChips}
         chips=${VIEW_CHIPS}

--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -159,7 +159,7 @@ describe('FleetTelemetryPanel', () => {
     expect(fetchDashboardExecution).toHaveBeenCalledTimes(1)
     expect(fetchToolQuality).toHaveBeenCalledTimes(1)
     expect(fetchTelemetrySummary).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('Fleet Coverage')
+    expect(container.textContent).toContain('Keeper 가동률')
     expect(container.textContent).toContain('1/2 keepers surfaced recent tool activity.')
     expect(container.textContent).toContain('keeper-alpha')
     expect(container.textContent).toContain('keeper-beta')

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useSignal } from '@preact/signals'
 import { useEffect, useMemo, useRef } from 'preact/hooks'
+import { RotateCcw } from 'lucide-preact'
 import { LoadingState } from './common/feedback-state'
 import {
   fetchDashboardExecution,
@@ -9,11 +10,15 @@ import {
   type TelemetrySourceSummary,
   type ToolQualityResponse,
 } from '../api/dashboard'
+import { resetKeeper } from '../api/keeper'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import { formatTimeAgo } from '../lib/format-time'
 import { isAbortError } from '../lib/async-state'
+import { requestConfirm } from './common/confirm-dialog'
+import { Sparkline } from './common/sparkline'
+import { pushSnapshot, getTrend, type MetricKey, type TrendDirection } from './fleet-trend-store'
 import {
   EMPTY_TOOL_QUALITY,
   PRESSURE_WARN_RATIO,
@@ -41,6 +46,37 @@ import {
 } from './fleet-telemetry-utils'
 
 export { buildFleetRows }
+
+// Whether "up" is bad for a given metric. context_ratio and latency going up = bad.
+function isUpBad(metric: MetricKey): boolean {
+  return metric === 'context_ratio' || metric === 'last_latency_ms'
+}
+
+function trendArrow(direction: TrendDirection): string {
+  if (direction === 'up') return '\u2191'
+  if (direction === 'down') return '\u2193'
+  return ''
+}
+
+function trendColorClass(direction: TrendDirection, metric: MetricKey): string {
+  if (direction === 'flat') return 'text-[var(--text-dim)]'
+  const bad = (direction === 'up' && isUpBad(metric)) || (direction === 'down' && !isUpBad(metric))
+  return bad ? 'text-red-400' : 'text-emerald-400'
+}
+
+function sparklineColor(metric: MetricKey, direction: TrendDirection): string {
+  if (direction === 'flat') return '#64748b'
+  const bad = (direction === 'up' && isUpBad(metric)) || (direction === 'down' && !isUpBad(metric))
+  return bad ? '#f87171' : '#34d399'
+}
+
+function auditFreshnessClass(isoTimestamp: string | null): string {
+  if (!isoTimestamp) return 'text-[var(--text-dim)]'
+  const ageMs = Date.now() - new Date(isoTimestamp).getTime()
+  if (ageMs < 5 * 60 * 1000) return 'text-[var(--text)]'
+  if (ageMs < 15 * 60 * 1000) return 'text-[var(--text-dim)]'
+  return 'text-amber-300'
+}
 
 function SummaryCard({
   title,
@@ -122,9 +158,33 @@ function PressureWatchlist({ rows }: { rows: FleetRow[] }) {
   `
 }
 
-function FleetComparisonTable({ rows }: { rows: FleetRow[] }) {
+function TrendCell({ name, metric, value, valueClass }: {
+  name: string
+  metric: MetricKey
+  value: string
+  valueClass: string
+}) {
+  const trend = getTrend(name, metric)
+  const arrow = trend ? trendArrow(trend.direction) : ''
+  const colorClass = trend ? trendColorClass(trend.direction, metric) : ''
+  const sColor = trend ? sparklineColor(metric, trend.direction) : '#64748b'
+
+  return html`
+    <td class="py-1.5 text-right">
+      <div class="flex items-center justify-end gap-1">
+        <span class="font-mono ${valueClass}">${value}</span>
+        ${arrow ? html`<span class="text-[9px] ${colorClass}">${arrow}</span>` : null}
+      </div>
+      ${trend && trend.values.length >= 2
+        ? html`<div class="mt-0.5 flex justify-end"><${Sparkline} values=${trend.values} width=${48} height=${14} color=${sColor} /></div>`
+        : null}
+    </td>
+  `
+}
+
+function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (name: string) => void }) {
   if (rows.length === 0) {
-    return html`<div class="text-[11px] text-[var(--text-dim)]">키퍼 fleet 데이터 없음.</div>`
+    return html`<div class="text-[11px] text-[var(--text-dim)]">Keeper 데이터 없음.</div>`
   }
 
   return html`
@@ -135,11 +195,13 @@ function FleetComparisonTable({ rows }: { rows: FleetRow[] }) {
             <th class="py-1 text-left font-normal">Keeper</th>
             <th class="py-1 text-right font-normal">Status</th>
             <th class="py-1 text-right font-normal">Activity</th>
+            <th class="py-1 text-right font-normal">측정</th>
             <th class="py-1 text-right font-normal">Tools</th>
             <th class="py-1 text-right font-normal">Success</th>
             <th class="py-1 text-right font-normal">Ctx</th>
             <th class="py-1 text-right font-normal">Latency</th>
             <th class="py-1 text-right font-normal">Model</th>
+            <th class="w-8 py-1"></th>
           </tr>
         </thead>
         <tbody>
@@ -162,13 +224,40 @@ function FleetComparisonTable({ rows }: { rows: FleetRow[] }) {
               </td>
               <td class="py-1.5 text-right font-mono ${statusClass(row)}">${row.status}</td>
               <td class="py-1.5 text-right text-[var(--text-dim)]">${formatActivity(row.last_activity_ago_s)}</td>
-              <td class="py-1.5 text-right font-mono text-[var(--text)]">${row.tool_calls.toLocaleString()}</td>
-              <td class="py-1.5 text-right font-mono ${successClass(row.tool_success_pct)}">
-                ${formatPercent(row.tool_success_pct, 1)}
+              <td class="py-1.5 text-right text-[10px] ${auditFreshnessClass(row.tool_audit_at)}" title=${row.tool_audit_at ?? ''}>
+                ${row.tool_audit_at ? formatTimeAgo(row.tool_audit_at) : '-'}
               </td>
-              <td class="py-1.5 text-right font-mono ${pressureClass(row.context_ratio)}">${formatPercent(row.context_ratio * 100, 1)}</td>
-              <td class="py-1.5 text-right text-[var(--text-dim)]">${formatLatency(row.last_latency_ms)}</td>
+              <${TrendCell}
+                name=${row.name} metric="tool_calls"
+                value=${row.tool_calls.toLocaleString()}
+                valueClass="text-[var(--text)]"
+              />
+              <${TrendCell}
+                name=${row.name} metric="tool_success_pct"
+                value=${formatPercent(row.tool_success_pct, 1)}
+                valueClass=${successClass(row.tool_success_pct)}
+              />
+              <${TrendCell}
+                name=${row.name} metric="context_ratio"
+                value=${formatPercent(row.context_ratio * 100, 1)}
+                valueClass=${pressureClass(row.context_ratio)}
+              />
+              <${TrendCell}
+                name=${row.name} metric="last_latency_ms"
+                value=${formatLatency(row.last_latency_ms)}
+                valueClass="text-[var(--text-dim)]"
+              />
               <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
+              <td class="py-1.5 text-center">
+                <button
+                  class="rounded p-0.5 text-[var(--text-dim)] hover:text-red-400 hover:bg-red-400/10 transition-colors"
+                  onClick=${() => onReset(row.name)}
+                  title="초기화"
+                  aria-label=${`${row.name} 초기화`}
+                >
+                  <${RotateCcw} size=${12} />
+                </button>
+              </td>
             </tr>
           `})}
         </tbody>
@@ -291,6 +380,8 @@ export function FleetTelemetryPanel() {
         || toolQuality.total > 0
         || telemetrySummary.total_entries > 0
 
+      pushSnapshot(rows)
+
       state.value = {
         loading: false,
         error: hasAnyData ? null : 'No fleet telemetry data available.',
@@ -329,27 +420,56 @@ export function FleetTelemetryPanel() {
   const sourcesWithData = value.telemetry_sources.filter(source => source.entry_count > 0).length
 
   if (value.loading && value.rows.length === 0) {
-    return html`<${LoadingState}>Fleet 텔레메트리 불러오는 중...<//>`
+    return html`<${LoadingState}>Keeper 텔레메트리 불러오는 중...<//>`
   }
 
   if (value.error) {
     return html`<div class="p-4 text-[11px] text-red-400">${value.error}</div>`
   }
 
+  const handleReset = async (name: string) => {
+    const confirmed = await requestConfirm({
+      title: `${name} 초기화`,
+      message: `이 키퍼의 사용량 지표(턴 수, 토큰 수, 비용, 지연시간)가 0으로 초기화됩니다.\n되돌릴 수 없습니다.`,
+      confirmText: '초기화',
+      cancelText: '취소',
+      tone: 'danger',
+    })
+    if (!confirmed) return
+    const result = await resetKeeper(name)
+    if (result.ok) {
+      void loadFleetTelemetry()
+    }
+  }
+
+  const activeCount = counts.live
+  const attentionCount = value.rows.filter(row => row.keepalive_running && (
+    row.runtime_blocker_class != null
+    || row.context_ratio >= PRESSURE_WARN_RATIO
+    || (row.last_activity_ago_s != null && row.last_activity_ago_s >= STALE_ACTIVITY_SEC)
+    || (row.tool_success_pct != null && row.tool_success_pct < 90)
+  )).length
+  const offlineCount = value.rows.length - activeCount
+
   return html`
     <div class="flex flex-col gap-4 p-4">
       <div class="flex items-start justify-between gap-3">
-        <div>
-          <h2 class="text-sm font-medium">Fleet Telemetry</h2>
-          <div class="text-[10px] text-[var(--text-dim)]">
-            ${value.updated_at ? `Updated ${formatTimeAgo(value.updated_at)}` : 'Runtime + telemetry store view'}
+        <div class="flex items-center gap-3">
+          <h2 class="text-sm font-medium">Keeper 텔레메트리</h2>
+          <div class="flex items-center gap-2 text-[10px]">
+            ${activeCount > 0 ? html`<span class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-emerald-400">${activeCount} 가동</span>` : null}
+            ${attentionCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-amber-400">${attentionCount} 주의</span>` : null}
+            ${offlineCount > 0 ? html`<span class="rounded-full bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">
+          <span class="text-[10px] text-[var(--text-dim)]">
+            ${value.updated_at ? `${formatTimeAgo(value.updated_at)} 갱신` : ''}
+          </span>
           <button
             class="rounded bg-[var(--bg-subtle)] px-2 py-0.5 text-[10px] text-[var(--text-dim)] hover:text-[var(--text)]"
             onClick=${() => { void loadFleetTelemetry() }}
-            aria-label="Fleet 텔레메트리 새로고침"
+            aria-label="Keeper 텔레메트리 새로고침"
           >새로고침</button>
           <span class="text-[10px] text-[var(--text-dim)]">${formatAutoRefreshLabel(TELEMETRY_AUTO_REFRESH_MS)}</span>
         </div>
@@ -359,7 +479,7 @@ export function FleetTelemetryPanel() {
 
       <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
         <${SummaryCard}
-          title="Fleet Coverage"
+          title="Keeper 가동률"
           value=${`${counts.live}/${value.rows.length || 0}`}
           detail=${`${counts.toolCovered}/${value.rows.length || 0} keepers surfaced recent tool activity.`}
           tone=${liveTone}
@@ -394,8 +514,8 @@ export function FleetTelemetryPanel() {
       </div>
 
       <div>
-        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Keeper Comparison</div>
-        <${FleetComparisonTable} rows=${value.rows} />
+        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Keeper 비교</div>
+        <${FleetComparisonTable} rows=${value.rows} onReset=${handleReset} />
       </div>
 
       <div>

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -25,6 +25,7 @@ export interface FleetRow {
   recent_tools: string[]
   runtime_blocker_class: Keeper['runtime_blocker_class'] | null
   runtime_blocker_summary: string | null
+  tool_audit_at: string | null
 }
 
 export interface FleetTelemetryState {
@@ -308,6 +309,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             runtime_blocker_class: keeper.runtime_blocker_class ?? null,
             runtime_blocker_summary:
               firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker) ?? null,
+            tool_audit_at: keeper.tool_audit_at ?? null,
           }
         })
       : toolQuality.by_keeper.map((keeper): FleetRow => ({
@@ -325,6 +327,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           recent_tools: [],
           runtime_blocker_class: null,
           runtime_blocker_summary: null,
+          tool_audit_at: null,
         }))
 
   return [...rows].sort(compareFleetRows)

--- a/dashboard/src/components/fleet-trend-store.test.ts
+++ b/dashboard/src/components/fleet-trend-store.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { pushSnapshot, getTrend, resetTrendStore } from './fleet-trend-store'
+import type { FleetRow } from './fleet-telemetry-utils'
+
+function makeRow(name: string, overrides: Partial<FleetRow> = {}): FleetRow {
+  return {
+    name,
+    status: 'active',
+    keepalive_running: true,
+    context_ratio: 0.5,
+    turn_count: 0,
+    last_latency_ms: 100,
+    last_activity_ago_s: 10,
+    model: 'test-model',
+    tool_calls: 5,
+    tool_success_pct: 95,
+    tool_activity_known: true,
+    recent_tools: [],
+    runtime_blocker_class: null,
+    runtime_blocker_summary: null,
+    tool_audit_at: null,
+    ...overrides,
+  }
+}
+
+describe('fleet-trend-store', () => {
+  beforeEach(() => {
+    resetTrendStore()
+  })
+
+  it('returns null when fewer than 3 snapshots exist', () => {
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.1 })])
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.2 })])
+    expect(getTrend('keeper-a', 'context_ratio')).toBeNull()
+  })
+
+  it('detects upward trend', () => {
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.1 })])
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.2 })])
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.3 })])
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.4 })])
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.5 })])
+    pushSnapshot([makeRow('keeper-a', { context_ratio: 0.6 })])
+
+    const trend = getTrend('keeper-a', 'context_ratio')
+    expect(trend?.direction).toBe('up')
+    expect(trend?.delta).toBeGreaterThan(0)
+  })
+
+  it('detects downward trend', () => {
+    for (const v of [100, 90, 80, 70, 60, 50]) {
+      pushSnapshot([makeRow('keeper-a', { last_latency_ms: v })])
+    }
+    const trend = getTrend('keeper-a', 'last_latency_ms')
+    expect(trend?.direction).toBe('down')
+    expect(trend?.delta).toBeLessThan(0)
+  })
+
+  it('detects flat trend when values are stable', () => {
+    for (let i = 0; i < 6; i += 1) {
+      pushSnapshot([makeRow('keeper-a', { tool_calls: 5 })])
+    }
+    const trend = getTrend('keeper-a', 'tool_calls')
+    expect(trend?.direction).toBe('flat')
+  })
+
+  it('caps ring buffer at 10 snapshots', () => {
+    for (let i = 0; i < 20; i += 1) {
+      pushSnapshot([makeRow('keeper-a', { tool_calls: i })])
+    }
+    const trend = getTrend('keeper-a', 'tool_calls')
+    expect(trend?.values.length).toBe(10)
+    expect(trend?.values[0]).toBe(10)
+    expect(trend?.values[9]).toBe(19)
+  })
+
+  it('isolates trends per keeper', () => {
+    for (let i = 0; i < 5; i += 1) {
+      pushSnapshot([
+        makeRow('keeper-a', { context_ratio: 0.1 + i * 0.1 }),
+        makeRow('keeper-b', { context_ratio: 0.9 - i * 0.1 }),
+      ])
+    }
+    expect(getTrend('keeper-a', 'context_ratio')?.direction).toBe('up')
+    expect(getTrend('keeper-b', 'context_ratio')?.direction).toBe('down')
+  })
+
+  it('skips null tool_success_pct values', () => {
+    pushSnapshot([makeRow('keeper-a', { tool_success_pct: null })])
+    pushSnapshot([makeRow('keeper-a', { tool_success_pct: null })])
+    pushSnapshot([makeRow('keeper-a', { tool_success_pct: null })])
+    expect(getTrend('keeper-a', 'tool_success_pct')).toBeNull()
+  })
+
+  it('resetTrendStore clears all data', () => {
+    for (let i = 0; i < 5; i += 1) {
+      pushSnapshot([makeRow('keeper-a', { context_ratio: i * 0.1 })])
+    }
+    expect(getTrend('keeper-a', 'context_ratio')).not.toBeNull()
+    resetTrendStore()
+    expect(getTrend('keeper-a', 'context_ratio')).toBeNull()
+  })
+})

--- a/dashboard/src/components/fleet-trend-store.ts
+++ b/dashboard/src/components/fleet-trend-store.ts
@@ -1,0 +1,91 @@
+// Fleet Trend Store — in-memory ring buffer for per-keeper metric snapshots.
+// Captures 10 snapshots (at 30s refresh = 5 minutes of history) and computes
+// directional trends (up/down/flat) with delta values and sparkline data.
+
+import type { FleetRow } from './fleet-telemetry-utils'
+
+const RING_CAPACITY = 10
+const MIN_SAMPLES_FOR_TREND = 3
+const FLAT_THRESHOLD = 0.02
+
+export type MetricKey = 'context_ratio' | 'tool_success_pct' | 'tool_calls' | 'last_latency_ms'
+
+export type TrendDirection = 'up' | 'down' | 'flat'
+
+export interface TrendInfo {
+  direction: TrendDirection
+  delta: number
+  deltaPercent: number
+  values: number[]
+}
+
+const TRACKED_METRICS: MetricKey[] = ['context_ratio', 'tool_success_pct', 'tool_calls', 'last_latency_ms']
+
+const store = new Map<string, number[]>()
+
+function storeKey(keeperName: string, metric: MetricKey): string {
+  return `${keeperName}:${metric}`
+}
+
+function metricValue(row: FleetRow, metric: MetricKey): number | null {
+  switch (metric) {
+    case 'context_ratio': return row.context_ratio
+    case 'tool_success_pct': return row.tool_success_pct
+    case 'tool_calls': return row.tool_calls
+    case 'last_latency_ms': return row.last_latency_ms
+  }
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0
+  let sum = 0
+  for (const v of values) sum += v
+  return sum / values.length
+}
+
+export function pushSnapshot(rows: FleetRow[]): void {
+  for (const row of rows) {
+    for (const metric of TRACKED_METRICS) {
+      const value = metricValue(row, metric)
+      if (value == null || !Number.isFinite(value)) continue
+      const key = storeKey(row.name, metric)
+      let ring = store.get(key)
+      if (!ring) {
+        ring = []
+        store.set(key, ring)
+      }
+      ring.push(value)
+      if (ring.length > RING_CAPACITY) {
+        ring.splice(0, ring.length - RING_CAPACITY)
+      }
+    }
+  }
+}
+
+export function getTrend(keeperName: string, metric: MetricKey): TrendInfo | null {
+  const key = storeKey(keeperName, metric)
+  const ring = store.get(key)
+  if (!ring || ring.length < MIN_SAMPLES_FOR_TREND) return null
+
+  const recentSlice = ring.slice(-MIN_SAMPLES_FOR_TREND)
+  const oldestSlice = ring.slice(0, MIN_SAMPLES_FOR_TREND)
+  const recentAvg = average(recentSlice)
+  const oldestAvg = average(oldestSlice)
+  const delta = recentAvg - oldestAvg
+  const deltaPercent = oldestAvg !== 0 ? (delta / Math.abs(oldestAvg)) * 100 : 0
+
+  let direction: TrendDirection
+  if (oldestAvg === 0 && recentAvg === 0) {
+    direction = 'flat'
+  } else if (Math.abs(deltaPercent) < FLAT_THRESHOLD * 100) {
+    direction = 'flat'
+  } else {
+    direction = delta > 0 ? 'up' : 'down'
+  }
+
+  return { direction, delta, deltaPercent, values: [...ring] }
+}
+
+export function resetTrendStore(): void {
+  store.clear()
+}

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -43,7 +43,7 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const labelFor = (id: string) => sections.find(item => item.id === id)?.label
 
-    expect(labelFor('fleet-health')).toBe('Fleet 건강')
+    expect(labelFor('fleet-health')).toBe('Keeper 현황')
     expect(labelFor('runtime')).toBe('런타임')
     expect(labelFor('agents')).toBe('에이전트 & 키퍼')
   })

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -139,8 +139,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'fleet-health',
-      label: 'Fleet 건강',
-      description: '텔레메트리 이벤트, Fleet 비교, 도구 품질, 거버넌스 지표를 통합 뷰로.',
+      label: 'Keeper 현황',
+      description: '텔레메트리 이벤트, Keeper 비교, 도구 품질, 거버넌스 지표를 통합 뷰로.',
       params: { section: 'fleet-health' },
     },
     {

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -13,6 +13,7 @@ let keeper_suffix_tools = "/tools"
 let keeper_suffix_config = "/config"
 let keeper_suffix_boot = "/boot"
 let keeper_suffix_shutdown = "/shutdown"
+let keeper_suffix_reset = "/reset"
 
 let dedupe_tool_names names =
   Json_util.dedupe_keep_order
@@ -237,6 +238,7 @@ type keeper_post_route_kind =
   | Keeper_post_config
   | Keeper_post_boot
   | Keeper_post_shutdown
+  | Keeper_post_reset
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
@@ -253,6 +255,7 @@ let classify_keeper_post_route req_path =
   else if ends_with keeper_suffix_config then Keeper_post_config
   else if ends_with keeper_suffix_boot then Keeper_post_boot
   else if ends_with keeper_suffix_shutdown then Keeper_post_shutdown
+  else if ends_with keeper_suffix_reset then Keeper_post_reset
   else Keeper_post_unknown
 
 let is_valid_keeper_name name =
@@ -370,6 +373,7 @@ let handle_keeper_lifecycle_post ~sw ~clock ~tool_name ~action state agent_name 
     match action with
     | "boot" -> Ok keeper_suffix_boot
     | "shutdown" -> Ok keeper_suffix_shutdown
+    | "reset" -> Ok keeper_suffix_reset
     | unknown ->
         Error (Printf.sprintf "unknown keeper lifecycle action: %s" unknown)
   in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -526,6 +526,12 @@ let rec add_routes ~sw ~clock router =
                Keeper_api.handle_keeper_lifecycle_post ~sw ~clock ~tool_name:"masc_keeper_down"
                  ~action:"shutdown" state agent_name req reqd
              ) request reqd
+       | Keeper_api.Keeper_post_reset ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state agent_name req reqd ->
+               Keeper_api.handle_keeper_lifecycle_post ~sw ~clock ~tool_name:"masc_keeper_reset"
+                 ~action:"reset" state agent_name req reqd
+             ) request reqd
        | Keeper_api.Keeper_post_unknown ->
            Http.Response.json ~status:`Not_found
              {|{"error":"not found"}|} reqd)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -385,6 +385,7 @@ let check_route path expected =
        | Keeper_api.Keeper_post_config -> "config"
        | Keeper_api.Keeper_post_boot -> "boot"
        | Keeper_api.Keeper_post_shutdown -> "shutdown"
+       | Keeper_api.Keeper_post_reset -> "reset"
        | Keeper_api.Keeper_post_unknown -> "unknown")
       path
 ;;
@@ -394,6 +395,7 @@ let test_keeper_post_route_classification () =
   check_route "/api/v1/keepers/sangsu/config" Keeper_api.Keeper_post_config;
   check_route "/api/v1/keepers/sangsu/boot" Keeper_api.Keeper_post_boot;
   check_route "/api/v1/keepers/sangsu/shutdown" Keeper_api.Keeper_post_shutdown;
+  check_route "/api/v1/keepers/sangsu/reset" Keeper_api.Keeper_post_reset;
   check_route "/api/v1/keepers/sangsu" Keeper_api.Keeper_post_unknown;
   check_route "/api/v1/keepers//boot" Keeper_api.Keeper_post_unknown
 ;;


### PR DESCRIPTION
## Summary
- "Fleet 건강" → "Keeper 현황"으로 이름 변경 (직관성 개선)
- per-keeper 트렌드 표시: in-memory ring buffer (10 snapshots, 5분) + sparkline + 방향 화살표
- "측정" 컬럼: tool_audit_at 타임스탬프 신선도 색상 코딩 (5분/15분 경계)
- per-keeper 리셋 버튼 + 확인 모달 (requestConfirm 재사용)
- 집계 바: 가동/주의/오프라인 카운트 배지 + 갱신 시점 표시
- 백엔드: POST /api/v1/keepers/:name/reset (기존 lifecycle dispatch 패턴 재사용)

## Product impact
- 사용자가 "Fleet" 용어를 직관적으로 이해하지 못하던 문제 해소
- "지표가 안 변하는 것 같다"는 인지 부담을 트렌드 화살표 + sparkline + 측정 시점 표시로 해결
- 누적 카운터 초기화 가능 (이전: 서버 재시작만이 유일한 리셋 수단)
- 한눈에 보이는 fleet 상태 (가동/주의/오프라인 배지)

## Evidence
- Build: dune build 통과 (boot/shutdown 패턴 정확히 복제)
- Test: 신규 fleet-trend-store.test.ts 8개 케이스 (ring buffer, trend direction, isolation, reset)
- Test: 기존 navigation.test.ts, fleet-health-panel.test.ts, fleet-telemetry-panel.test.ts assertion 업데이트

## Review evidence
- 단일 모델(Claude Opus 4.6) 작성. repo 별 cross-model 정책 미적용.
- 기존 컴포넌트 재사용 우선: confirm-dialog.ts, sparkline.ts, safeKeeperLifecycle, handle_keeper_lifecycle_post

## 변경 파일 (8개 + 1 신규)
| 파일 | 변경 |
|------|------|
| navigation.ts | 라벨 변경 |
| fleet-health-panel.ts | 라벨 변경 |
| fleet-telemetry-panel.ts | TrendCell, 리셋 버튼, 집계 바, 측정 컬럼 |
| fleet-telemetry-utils.ts | FleetRow에 tool_audit_at 추가 |
| fleet-trend-store.ts | 신규 — ring buffer + trend 계산 |
| fleet-trend-store.test.ts | 신규 — 단위 테스트 |
| api/keeper.ts | resetKeeper() 추가 |
| server_dashboard_http_keeper_api.ml | Keeper_post_reset variant |
| server_routes_http_routes_dashboard.ml | reset route dispatch |

## Linked issue
Refs: 사용자 피드백 — Keeper 현황 패널의 직관성, 리셋 기능, 트렌드 표시 개선 요청

## Test plan
- [ ] 대시보드에서 "Keeper 현황" 메뉴 표시 확인
- [ ] Keeper 비교 테이블에 "측정" 컬럼 표시 확인
- [ ] 페이지 로드 후 2-3분 대기 → sparkline/화살표 점진적 등장
- [ ] 리셋 버튼 클릭 → 확인 모달 → 초기화 후 데이터 갱신
- [ ] dune build 성공
- [ ] vitest 통과 (fleet-trend-store + 기존 fleet- 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)