### PR TITLE
fix(dashboard): merge internal history into session trace

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -18,6 +18,82 @@ let dedupe_tool_names names =
   Json_util.dedupe_keep_order
     (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
 
+let trajectory_line_ts = function
+  | Trajectory.Tool_call entry -> entry.ts
+  | Trajectory.Thinking entry -> entry.ts
+
+let dedupe_thinking_lines (lines : Trajectory.trajectory_line list)
+    : Trajectory.trajectory_line list =
+  let seen = Hashtbl.create 32 in
+  List.filter
+    (function
+      | Trajectory.Tool_call _ -> true
+      | Trajectory.Thinking entry ->
+          let key =
+            Printf.sprintf "%.6f\x1f%b\x1f%s"
+              entry.ts entry.redacted entry.content
+          in
+          if Hashtbl.mem seen key then false
+          else (
+            Hashtbl.add seen key ();
+            true))
+    lines
+
+let internal_history_json_to_trajectory_line (json : Yojson.Safe.t)
+    : Trajectory.trajectory_line option =
+  let source = Safe_ops.json_string ~default:"" "source" json in
+  let content = Safe_ops.json_string ~default:"" "content" json in
+  if source <> "internal_assistant" || String.trim content = "" then None
+  else
+    let ts =
+      match Safe_ops.json_float_opt "ts_unix" json with
+      | Some value when value > 0.0 -> value
+      | _ ->
+          match Safe_ops.json_float_opt "timestamp" json with
+          | Some value when value > 0.0 -> value
+          | _ -> 0.0
+    in
+    if ts <= 0.0 then None
+    else
+      let ts_iso =
+        match Safe_ops.json_string_opt "ts_iso" json with
+        | Some value when String.trim value <> "" -> value
+        | _ ->
+            match Safe_ops.json_string_opt "ts" json with
+            | Some value when String.trim value <> "" -> value
+            | _ -> Dashboard_utils.iso_of_unix ts
+      in
+      Some
+        (Trajectory.Thinking
+           {
+             ts;
+             ts_iso;
+             turn = Safe_ops.json_int ~default:0 "turn" json;
+             content;
+             content_length = String.length content;
+             redacted = Safe_ops.json_bool ~default:false "redacted" json;
+           })
+
+let read_internal_history_lines ~(config : Room.config) ~(trace_id : string)
+    : Trajectory.trajectory_line list =
+  let path = Keeper_types.keeper_internal_history_path config trace_id in
+  Fs_compat.load_jsonl path
+  |> List.filter_map internal_history_json_to_trajectory_line
+
+let merge_keeper_trace_lines ~(config : Room.config) ~(trace_id : string)
+    (trajectory_lines : Trajectory.trajectory_line list)
+    : Trajectory.trajectory_line list =
+  let internal_lines = read_internal_history_lines ~config ~trace_id in
+  dedupe_thinking_lines (trajectory_lines @ internal_lines)
+  |> List.sort (fun left right ->
+         let cmp = Float.compare (trajectory_line_ts left) (trajectory_line_ts right) in
+         if cmp <> 0 then cmp
+         else
+           match left, right with
+           | Trajectory.Thinking _, Trajectory.Tool_call _ -> -1
+           | Trajectory.Tool_call _, Trajectory.Thinking _ -> 1
+           | _ -> 0)
+
 let keeper_tools_response_json (meta : Keeper_types.keeper_meta) =
   let allowed = Keeper_exec_tools.keeper_allowed_tool_names meta in
   let masc_count =
@@ -460,6 +536,9 @@ let handle_keeper_get_subroutes state req request reqd =
        | Ok (Some m) ->
          let trajectory_default_limit = 50 in
          let trajectory_max_limit = 500 in
+         let trace_id =
+           Keeper_id.Trace_id.to_string m.runtime.trace_id
+         in
          let limit =
            Server_utils.int_query_param req "limit"
              ~default:trajectory_default_limit
@@ -479,9 +558,15 @@ let handle_keeper_get_subroutes state req request reqd =
              ~default:false
          in
          let masc_root = Filename.concat config.base_path ".masc" in
-         let all_lines =
+         let trajectory_lines =
            Trajectory.read_all_lines ~masc_root ~keeper_name:m.name
-             ~trace_id:(Keeper_id.Trace_id.to_string m.runtime.trace_id)
+             ~trace_id
+         in
+         let all_lines =
+           if include_thinking then
+             merge_keeper_trace_lines ~config ~trace_id trajectory_lines
+           else
+             trajectory_lines
          in
          (* Filter out thinking entries if not requested *)
          let lines =
@@ -499,7 +584,7 @@ let handle_keeper_get_subroutes state req request reqd =
          in
          let json = `Assoc [
            ("keeper", `String name);
-           ("trace_id", `String (Keeper_id.Trace_id.to_string m.runtime.trace_id));
+           ("trace_id", `String trace_id);
            ("generation", `Int m.runtime.generation);
            ("total_entries", `Int total);
            ("showing", `Int (List.length recent));

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -450,6 +450,76 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
   | Error err -> fail ("failed to read keeper meta after shutdown: " ^ err)
 ;;
 
+let test_merge_keeper_trace_lines_includes_internal_history () =
+  let base_path = Filename.temp_file "dashboard-keeper-trajectory-" "" in
+  (try Sys.remove base_path with
+   | _ -> ());
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+  let config = Masc_mcp.Room.default_config base_path in
+  ignore (Masc_mcp.Room.init config ~agent_name:(Some "bootstrap-admin"));
+  let trace_id = "trace-route-shadow-demo-seed" in
+  let internal_history_path =
+    Masc_mcp.Keeper_types.keeper_internal_history_path config trace_id
+  in
+  Fs_compat.mkdir_p (Filename.dirname internal_history_path);
+  write_file
+    internal_history_path
+    (String.concat
+       "\n"
+       [ {|{"timestamp":1000.0,"ts_unix":1000.0,"source":"internal_assistant","role":"assistant","content":"first internal thought"}|}
+       ; {|{"timestamp":1001.0,"ts_unix":1001.0,"source":"internal_assistant","role":"assistant","content":"second internal thought"}|}
+       ]
+     ^ "\n");
+  let trajectory_lines =
+    [
+      Masc_mcp.Trajectory.Tool_call
+        {
+          Masc_mcp.Trajectory.ts = 1002.0;
+          ts_iso = "1970-01-01T00:16:42Z";
+          turn = 3;
+          round = 1;
+          tool_name = "masc_tasks";
+          args_json = "{}";
+          gate_decision = Masc_mcp.Trajectory.Pass;
+          result = Some {|{"ok":true}|};
+          duration_ms = 12;
+          error = None;
+          cost_usd = 0.0;
+        };
+    ]
+  in
+  let merged =
+    Keeper_api.merge_keeper_trace_lines ~config ~trace_id trajectory_lines
+  in
+  check int "merged entry count" 3 (List.length merged);
+  (match List.nth merged 0 with
+   | Masc_mcp.Trajectory.Thinking entry ->
+     check string "first merged content" "first internal thought" entry.content
+   | Masc_mcp.Trajectory.Tool_call _ ->
+     fail "expected internal history entry first");
+  (match List.nth merged 1 with
+   | Masc_mcp.Trajectory.Thinking entry ->
+     check string "second merged content" "second internal thought" entry.content
+   | Masc_mcp.Trajectory.Tool_call _ ->
+     fail "expected internal history entry second");
+  (match List.nth merged 2 with
+   | Masc_mcp.Trajectory.Tool_call entry ->
+     check string "tool entry remains present" "masc_tasks" entry.tool_name
+   | Masc_mcp.Trajectory.Thinking _ ->
+     fail "expected tool entry last");
+  let tool_only =
+    List.filter
+      (function
+        | Masc_mcp.Trajectory.Tool_call _ -> true
+        | Masc_mcp.Trajectory.Thinking _ -> false)
+      merged
+  in
+  check int "thinking entries can still be filtered out" 1 (List.length tool_only))
+;;
+
 let () =
   run
     "dashboard_keeper_routes"
@@ -462,6 +532,10 @@ let () =
             "lifecycle POST routes do not fall through to generic 404"
             `Slow
             test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404
+        ; test_case
+            "merge keeper trace lines includes internal history"
+            `Quick
+            test_merge_keeper_trace_lines_includes_internal_history
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- merge keeper trajectory entries with `history.internal.jsonl` so session trace surfaces autonomous internal replies
- sort and dedupe merged thinking entries before applying the existing `include_thinking` filter
- add regression coverage for the internal-history merge path in dashboard keeper route tests

## Root cause
`/api/v1/keepers/:name/trajectory` only read trajectory JSONL for the current trace. Unified keeper turns were already persisting `internal_assistant` rows into `history.internal.jsonl`, but those rows never reached the dashboard session trace unless a separate trajectory accumulator path happened to exist.

## Testing
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-session-trace-internal-history ./test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-session-trace-internal-history ./bin/main_eio.exe`
