### PR TITLE
fix(keeper): backlog bypasses idle_gate for task reactivity

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -790,7 +790,16 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
           has_actionable_tasks
           && since_last_scheduled_autonomous >= task_reactive_cooldown
         in
-        let should_run = idle_gate_elapsed && (cooldown_elapsed || backlog_elapsed) in
+        (* Backlog bypass: when actionable tasks exist and task_reactive_cooldown
+           has elapsed, skip the idle_gate check. task_reactive_cooldown is
+           already a (shorter) subdivision of idle_gate; requiring idle_gate_elapsed
+           on top defeats its purpose. Without this bypass, keepers ignore
+           unclaimed work for idle_gate seconds even when the backlog signal
+           is ready to fire. Ref: #7226 claim-first + idle_gate observation. *)
+        let should_run =
+          backlog_elapsed
+          || (idle_gate_elapsed && cooldown_elapsed)
+        in
         let verdict =
           if should_run then
             let run_reasons =
@@ -819,9 +828,8 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
             | first :: rest ->
                 Run { reasons = (first, rest) }
             | [] ->
-                (* Structurally unreachable: idle_gate_elapsed && should_run
-                   and the synthetic Scheduled_autonomous_turn reason
-                   guarantee a non-empty run reason list.
+                (* Structurally unreachable: the synthetic Scheduled_autonomous_turn
+                   tag is always added first, so the list is never empty.
                    Defensive: log warning and fall through to skip so that
                    should_run (derived below) stays consistent with verdict. *)
                 Log.Keeper.warn


### PR DESCRIPTION
## Summary

When actionable tasks exist and task_reactive_cooldown has elapsed, skip the idle_gate check.

## Problem

Observed in server logs:
\`\`\`
keepalive turn not scheduled for sojin: should_run=false
  reasons=[scheduled_autonomous_turn, idle_gate_wait]
  since_last=14 idle_gate=120
\`\`\`

sojin/janitor had idle_sec=120 and unclaimed tasks, but should_run
required \`idle_gate_elapsed\` on top of \`backlog_elapsed\`. This meant
keepers ignored the backlog signal for the full 120s idle_gate even
though task_reactive_cooldown (shorter) had already fired.

## Root Cause

\`\`\`ocaml
(* before *)
let should_run = idle_gate_elapsed && (cooldown_elapsed || backlog_elapsed)
(* after *)
let should_run =
  backlog_elapsed
  || (idle_gate_elapsed && cooldown_elapsed)
\`\`\`

\`task_reactive_cooldown\` is already a subdivision of idle_gate (idle_gate / divisor).
Gating it behind idle_gate_elapsed defeats its purpose.

## Test Plan

- [x] Library build passes
- [x] world_observation tests pass (18 idle/decay tests OK)
- [ ] CI
- [ ] Observe keeper logs: backlog now triggers within task_reactive window