### PR TITLE
refactor(dashboard): use session_lifecycle and health_level in session_context

### DIFF
--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -8,8 +8,8 @@ type session_context = Dashboard_mission_assembly.session_context = {
   created_by : string option;
   origin_kind : string;
   namespace : string option;
-  status : string;
-  health : string;
+  status : Dashboard_utils.session_lifecycle;
+  health : Dashboard_utils.health_level;
   member_names : string list;
   started_at : string option;
   elapsed_sec : int option;
@@ -212,9 +212,11 @@ let _build_session_context session_json _cards =
       else
         "live=recent_turns · planned=known_members"
     in
-    let status = session_status_string session_json in
-    let status_lc = Dashboard_utils.session_lifecycle_of_string status in
-    let is_terminal = match status_lc with
+    let status =
+      Dashboard_utils.session_lifecycle_of_string
+        (session_status_string session_json)
+    in
+    let is_terminal = match status with
       | Dashboard_utils.SL_completed | SL_interrupted | SL_cancelled | SL_expired -> true
       | SL_active | SL_running | SL_paused | SL_failed | SL_stopped | SL_unknown -> false
     in
@@ -253,15 +255,18 @@ let _build_session_context session_json _cards =
         health =
           (if is_terminal then
              (* Terminal sessions get neutral health — no false alarms *)
-             "ok"
+             Dashboard_utils.HL_ok
            else
-             match session_card with
-             | Some card ->
-                 trim_to_option (string_field "health" card)
-                 |> Option.value ~default:"ok"
-             | None ->
-                 trim_to_option (string_field "status" team_health)
-                 |> Option.value ~default:"ok");
+             let raw =
+               match session_card with
+               | Some card ->
+                   trim_to_option (string_field "health" card)
+                   |> Option.value ~default:"ok"
+               | None ->
+                   trim_to_option (string_field "status" team_health)
+                   |> Option.value ~default:"ok"
+             in
+             Dashboard_utils.health_level_of_string raw);
         member_names;
         started_at = trim_to_option (string_field "created_at_iso" meta);
         elapsed_sec =
@@ -508,8 +513,11 @@ let _build_briefs_from_sessions sessions attention_queue actions =
          in
          let health_tone =
            match top_attention_json with
-           | Some attention -> string_field ~default:session.health "severity" attention
-           | None -> session.health
+           | Some attention ->
+               string_field
+                 ~default:(Dashboard_utils.string_of_health_level session.health)
+                 "severity" attention
+           | None -> Dashboard_utils.string_of_health_level session.health
          in
          let related_attention_count = List.length related_attentions in
          let sort_severity = severity_rank health_tone in
@@ -522,8 +530,8 @@ let _build_briefs_from_sessions sessions attention_queue actions =
                ("goal", `String session.goal);
                ("created_by", json_string_option session.created_by);
                ("namespace", json_string_option session.namespace);
-               ("status", `String session.status);
-               ("health", `String session.health);
+               ("status", `String (Dashboard_utils.string_of_session_lifecycle session.status));
+               ("health", `String (Dashboard_utils.string_of_health_level session.health));
                ("member_names", `List (List.map (fun value -> `String value) session.member_names));
                ("started_at", json_string_option session.started_at);
                ("elapsed_sec", option_to_json (fun value -> `Int value) session.elapsed_sec);

--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -51,8 +51,8 @@ type session_context = {
   created_by : string option;
   origin_kind : string;
   namespace : string option;
-  status : string;
-  health : string;
+  status : Dashboard_utils.session_lifecycle;
+  health : Dashboard_utils.health_level;
   member_names : string list;
   started_at : string option;
   elapsed_sec : int option;
@@ -195,8 +195,8 @@ let read_recent_room_event_lines config ~limit =
       month_dirs;
     List.rev !collected
 
-let is_session_concluded (status : string) =
-  match Dashboard_utils.session_lifecycle_of_string status with
+let is_session_concluded (status : Dashboard_utils.session_lifecycle) =
+  match status with
   | Dashboard_utils.SL_completed | SL_interrupted | SL_cancelled -> true
   | SL_active | SL_running | SL_paused | SL_failed | SL_stopped | SL_expired | SL_unknown -> false
 

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -501,8 +501,11 @@ let build_sessions sessions attention_queue agent_briefs keeper_briefs command_p
          ( attention_count,
            severity_rank
              (match session.top_attention with
-             | Some attention -> string_field ~default:session.health "severity" attention
-             | None -> session.health),
+             | Some attention ->
+                 string_field
+                   ~default:(Dashboard_utils.string_of_health_level session.health)
+                   "severity" attention
+             | None -> Dashboard_utils.string_of_health_level session.health),
            session.last_event_ts,
            `Assoc
              [
@@ -511,8 +514,8 @@ let build_sessions sessions attention_queue agent_briefs keeper_briefs command_p
                ("created_by", json_string_option session.created_by);
                ("origin_kind", `String session.origin_kind);
                ("namespace", json_string_option session.namespace);
-               ("status", `String session.status);
-               ("health", `String session.health);
+               ("status", `String (Dashboard_utils.string_of_session_lifecycle session.status));
+               ("health", `String (Dashboard_utils.string_of_health_level session.health));
                ("member_names", string_list_json session.member_names);
                ("started_at", json_string_option session.started_at);
                ("elapsed_sec", option_to_json (fun value -> `Int value) session.elapsed_sec);


### PR DESCRIPTION
## Summary
- Track C of stringly-typed→variant 전환 (Track A #7249 병렬)
- \`session_context.status\`: string → \`Dashboard_utils.session_lifecycle\`
- \`session_context.health\`: string → \`Dashboard_utils.health_level\`
- \`is_session_concluded\`: 이미 내부에서 parsing하던 걸 외부 variant로 단순화 (double-parsing 제거)

## 설계 근거
두 variant는 PR #7187, #7203에서 이미 정의됨. 지금까지 construction side에서 string을 저장하고 consumer에서 다시 parsing하는 **double-parsing 안티패턴**. 이번 PR로 construction에서 한 번만 파싱, JSON 출력 boundary에서만 string 변환.

## 범위 축소
\`attention_context.severity\` (operator_severity 공유 검토 필요)와 \`operation_context.status/stage/detachment_status\` (open-ended stage)는 별도 PR로 분리. 이번 PR은 **가장 명확한 2개 필드**만 전환.

## Test plan
- [x] \`dune build --root .\` pass
- [ ] CI Build and Test
- [ ] JSON 출력 호환성 (string_of_* 직렬화 유지)

## 관련
- 베이스: main @ 54358c145
- 병렬: #7249 (Track A — dashboard_labels variant 소비)
- Plan: \`/Users/dancer/me/planning/claude-plans/swirling-kindling-corbato.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)