### PR TITLE
refactor(dashboard): use Cp_types variants in operation_context

### DIFF
--- a/lib/dashboard/dashboard_mission_agents.ml
+++ b/lib/dashboard/dashboard_mission_agents.ml
@@ -96,9 +96,11 @@ type keeper_context = {
 type operation_context = {
   operation_id : string;
   linked_session_id : string option;
-  status : string;
+  (** [None] when status field missing or unparseable ("unknown" in source). *)
+  status : Cp_types.operation_status option;
   stage : string option;
-  detachment_status : string option;
+  (** [None] when no detachment attached, or detachment status missing. *)
+  detachment_status : Cp_types.detachment_status option;
   objective : string option;
   updated_at : string option;
 }

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -374,15 +374,20 @@ let build_operation_contexts command_plane_json =
          else
            let linked_session_id, detachment_status =
              match Hashtbl.find_opt detachments operation_id with
-             | Some (session_id, status) -> (session_id, status)
+             | Some (session_id, status_str) ->
+                 (session_id, Option.map Cp_serde.detachment_status_of_string status_str)
              | None ->
                  (trim_to_option (string_field "detachment_session_id" operation), None)
+           in
+           let status =
+             Option.bind (trim_to_option (string_field "status" operation))
+               Cp_serde.operation_status_of_string
            in
            Some
              {
                operation_id;
                linked_session_id;
-               status = string_field ~default:"unknown" "status" operation;
+               status;
                stage = trim_to_option (string_field "stage" operation);
                detachment_status;
                objective = trim_to_option (string_field "objective" operation);
@@ -390,12 +395,20 @@ let build_operation_contexts command_plane_json =
              })
 
 let operation_badge_json (operation : operation_context) =
+  let status_str =
+    match operation.status with
+    | Some s -> Cp_serde.string_of_operation_status s
+    | None -> "unknown"
+  in
+  let detachment_status_str =
+    Option.map Cp_serde.detachment_status_to_string operation.detachment_status
+  in
   `Assoc
     [
       ("operation_id", `String operation.operation_id);
-      ("status", `String operation.status);
+      ("status", `String status_str);
       ("stage", json_string_option operation.stage);
-      ("detachment_status", json_string_option operation.detachment_status);
+      ("detachment_status", json_string_option detachment_status_str);
       ("objective", json_string_option operation.objective);
       ("updated_at", json_string_option operation.updated_at);
     ]


### PR DESCRIPTION
## Summary
- operation_context.status: string → Cp_types.operation_status option
- operation_context.detachment_status: string option → Cp_types.detachment_status option
- stage: 변경 없음 (open-ended taxonomy)

## 설계 근거
- "unknown" 기본값이 있던 status는 이제 None으로 명시적 표현
- detachment_status의 None은 "no detachment attached"를 의미
- Cp_types variant를 통해 값 정합성 보장 (같은 Cp domain)
- JSON 출력 시 None → "unknown" (status) / null (detachment)

## Test plan
- [x] \`dune build --root .\` pass
- [ ] CI Build and Test
- [ ] JSON 호환성 (unknown 매핑 유지)

## 관련
- 베이스: main @ ce2af9be8
- 계열: #7249 (Track A), #7250 (Track C session_context)
- Plan: \`/Users/dancer/me/planning/claude-plans/swirling-kindling-corbato.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)