### PR TITLE
refactor(worker_dev_tools): extract file_read byte limit to SSOT constants

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -534,6 +534,7 @@
    governance_pipeline
    tool_compact
    tool_shard
+   tool_shard_limits
    tool_keeper
    ;; Autoresearch — Karpathy-inspired autonomous experiment loop
    autoresearch

--- a/lib/keeper/keeper_exec_fs.ml
+++ b/lib/keeper/keeper_exec_fs.ml
@@ -1,6 +1,14 @@
 open Keeper_types
 open Keeper_exec_shared
 
+(** keeper_fs_read max_bytes clamp. [fs_read_default_max_bytes] is the
+    canonical default; [Tool_shard_limits.keeper_fs_read_default_max_bytes]
+    re-exports it at a leaf module so the tool schema in tool_shard.ml
+    can reference the same value without creating a dependency cycle. *)
+let fs_read_default_max_bytes = Tool_shard_limits.keeper_fs_read_default_max_bytes
+let fs_read_min_max_bytes = 512
+let fs_read_max_max_bytes = 200_000
+
 let is_missing_read_path_error (e : string) =
   String.starts_with ~prefix:"path_not_found:" e
   || String.starts_with ~prefix:"path_not_found_under_allowed_roots:" e
@@ -12,7 +20,8 @@ let handle_keeper_fs_read
   =
   let path = Safe_ops.json_string ~default:"" "path" args in
   let max_bytes =
-    Safe_ops.json_int ~default:20000 "max_bytes" args |> fun n -> max 512 (min 200000 n)
+    Safe_ops.json_int ~default:fs_read_default_max_bytes "max_bytes" args
+    |> fun n -> max fs_read_min_max_bytes (min fs_read_max_max_bytes n)
   in
   let fallback_dir = keeper_default_read_root ~config ~meta in
   match resolve_keeper_read_path ~config ~meta ~raw_path:path with

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -128,7 +128,8 @@ let allowed_git_actions = [
   "clone";
 ]
 
-let max_output_bytes = 10 * 1024 (* 10KB output limit *)
+let max_output_bytes = 10 * 1024
+let max_output_label = "10KB"
 
 let truncate_output s =
   if String.length s > max_output_bytes then
@@ -730,7 +731,7 @@ Use when removing generated, obsolete, or conflicting files during code work.";
 Allowed: dune, make, npm, npx, node, git, ls, cat, head, tail, wc, rg, find, \
 diff, patch, mkdir, opam, ocamlfind, tsc. Use for building and testing code \
 in isolated worktrees. For unrestricted shell at project root, use keeper_bash. \
-Returns exit_code and stdout (truncated at 10KB).";
+Returns exit_code and stdout (truncated at " ^ max_output_label ^ ").";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -21,10 +21,12 @@ type context = {
 
 type tool_result = bool * string
 
+let default_max_write_size = 1024 * 1024  (* 1 MiB *)
+
 let max_write_size =
   match Sys.getenv_opt "MASC_MAX_WRITE_SIZE_BYTES" with
-  | Some s -> (match int_of_string_opt s with Some n -> n | None -> 1024 * 1024)
-  | None -> 1024 * 1024
+  | Some s -> Option.value (int_of_string_opt s) ~default:default_max_write_size
+  | None -> default_max_write_size
 
 let normalize_dir_prefix path =
   Tool_code.normalize_path path ^ "/"

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -250,7 +250,7 @@ For multi-file search, use keeper_shell with op=rg.";
       ("type", `String "object");
       ("properties", `Assoc [
         ("path", `Assoc [("type", `String "string"); ("description", `String "Relative or absolute file path")]);
-        ("max_bytes", `Assoc [("type", `String "integer"); ("description", `String "Max bytes to return (default: 20000)")]);
+        ("max_bytes", `Assoc [("type", `String "integer"); ("description", `String ("Max bytes to return (default: " ^ Tool_shard_limits.keeper_fs_read_default_max_bytes_string ^ ")"))]);
       ]);
       ("required", `List [`String "path"]);
     ];

--- a/lib/tool_shard_limits.ml
+++ b/lib/tool_shard_limits.ml
@@ -1,0 +1,9 @@
+(** SSOT constants for tool schemas and runtime handlers that would
+    otherwise form a dependency cycle (Tool_shard ↔ Keeper_exec_fs).
+
+    These integers live in a leaf module with no dependencies so both
+    sides can import the same value. *)
+
+let keeper_fs_read_default_max_bytes = 20_000
+let keeper_fs_read_default_max_bytes_string =
+  string_of_int keeper_fs_read_default_max_bytes

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -823,12 +823,23 @@ type tool_exec_observer =
 
 (* --- Tool implementations --- *)
 
+(** [file_read] byte cap. Reads longer than this are truncated to prevent
+    context overflow. SSOT for the limit, its display label, and the
+    tool description shown to agents. *)
+let file_read_max_bytes = 100_000
+let file_read_max_label = "100KB"
+
+let file_read_description =
+  Printf.sprintf
+    "Read file contents by absolute path. Returns file text. \
+     Use shell_exec with 'ls' instead if you need directory listing. \
+     Maximum %s per read to prevent context overflow."
+    file_read_max_label
+
 let make_file_read ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_read"
-    ~description:"Read file contents by absolute path. Returns file text. \
-      Use shell_exec with 'ls' instead if you need directory listing. \
-      Maximum 100KB per read to prevent context overflow."
+    ~description:file_read_description
     ~parameters:[
       { name = "path";
         description = "Absolute file path to read";
@@ -861,9 +872,10 @@ let make_file_read ?workdir ?on_exec () =
              Option.iter
                (fun f -> f ~tool_name:"file_read" ~success:true ~duration_ms)
                on_exec;
-             if String.length content > 100_000 then
+             if String.length content > file_read_max_bytes then
                Ok { Agent_sdk.Types.content =
-                 String.sub content 0 100_000 ^ "\n[TRUNCATED at 100KB]" }
+                 String.sub content 0 file_read_max_bytes
+                 ^ Printf.sprintf "\n[TRUNCATED at %s]" file_read_max_label }
              else Ok { Agent_sdk.Types.content = content }
            with Sys_error msg ->
              let duration_ms =


### PR DESCRIPTION
## Summary
worker_dev_tools의 \`file_read\` 툴에서 동일한 100KB 제한이 **3곳에 중복**되어 독립적으로 drift 가능했음:
1. 툴 description: \`Maximum 100KB per read\`
2. 조건문 임계값: \`String.length content > 100_000\`
3. truncation 접미사: \`[TRUNCATED at 100KB]\`

## 설계 근거
**Scattered Hardcoded Defaults** 안티패턴 (CLAUDE.md S1). 만일 한 곳만 200KB로 바꾸면 description과 실제 동작이 어긋남. SSOT 상수 2개로 통합 — byte limit과 label만 정의하면 description이 Printf로 합성됨.

- \`file_read_max_bytes = 100_000\` — 실제 cutoff
- \`file_read_max_label = "100KB"\` — 사람이 읽는 label
- \`file_read_description\`은 위 label을 이용해 Printf로 구성

## Test plan
- [x] \`dune build --root .\` pass
- [ ] CI Build and Test

## 관련
- 베이스: main @ 9379db827
- Plan: \`/Users/dancer/me/planning/claude-plans/swirling-kindling-corbato.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)