### PR TITLE
fix(dashboard): thread AbortSignal through mission session detail fetch (#7218)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -526,9 +526,12 @@ export function fetchDashboardMission(): Promise<DashboardMissionResponse> {
   return get('/api/v1/dashboard/mission')
 }
 
-export function fetchDashboardMissionSession(sessionId: string): Promise<DashboardMissionSessionDetailResponse> {
+export function fetchDashboardMissionSession(
+  sessionId: string,
+  opts?: { signal?: AbortSignal },
+): Promise<DashboardMissionSessionDetailResponse> {
   const query = `?session_id=${encodeURIComponent(sessionId)}`
-  return get(`/api/v1/dashboard/session${query}`)
+  return get(`/api/v1/dashboard/session${query}`, { signal: opts?.signal })
 }
 
 export interface DashboardRuntimeProviderDiscovery {

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -137,7 +137,9 @@ function MissionLoaded({ mission }: { mission: NonNullable<typeof missionSnapsho
   }
 
   useEffect(() => {
-    void refreshMissionSessionDetail(activeSessionId)
+    const controller = new AbortController()
+    void refreshMissionSessionDetail(activeSessionId, { signal: controller.signal })
+    return () => { controller.abort() }
   }, [activeSessionId])
 
   return html`

--- a/dashboard/src/mission-actions.ts
+++ b/dashboard/src/mission-actions.ts
@@ -3,6 +3,7 @@ import {
   fetchDashboardMissionBriefing,
   fetchDashboardMissionSession,
 } from './api'
+import { isAbortError } from './lib/async-state'
 import {
   missionSnapshot,
   missionLoading,
@@ -72,7 +73,10 @@ export async function refreshMissionSnapshot(
   return inflightMissionSnapshotRefresh
 }
 
-export async function refreshMissionSessionDetail(sessionId: string | null | undefined): Promise<void> {
+export async function refreshMissionSessionDetail(
+  sessionId: string | null | undefined,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
   if (!sessionId) {
     missionSessionDetail.value = null
     missionSessionDetailError.value = null
@@ -82,12 +86,16 @@ export async function refreshMissionSessionDetail(sessionId: string | null | und
   missionSessionDetailLoading.value = true
   missionSessionDetailError.value = null
   try {
-    const raw = await fetchDashboardMissionSession(sessionId)
+    const raw = await fetchDashboardMissionSession(sessionId, { signal: opts?.signal })
+    if (opts?.signal?.aborted) return
     missionSessionDetail.value = normalizeMissionSessionDetail(raw)
   } catch (err) {
+    if (isAbortError(err)) return
     missionSessionDetailError.value = err instanceof Error ? err.message : 'Failed to load session detail'
   } finally {
-    missionSessionDetailLoading.value = false
+    if (!opts?.signal?.aborted) {
+      missionSessionDetailLoading.value = false
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Mission session detail fetch가 AbortSignal을 사용하지 않아 unmount/sessionId 변경 시 in-flight 요청이 orphan으로 남던 문제 수정. 3파일 chain을 통해 signal을 전파.

| 파일:줄 | 변경 |
|---------|------|
| `api/dashboard.ts:529` | `fetchDashboardMissionSession`에 `opts?: { signal?: AbortSignal }` 추가, `get()`에 전달 |
| `mission-actions.ts:76` | `refreshMissionSessionDetail`에 signal 수신, AbortError 분기, race-safe loading 관리 |
| `components/mission.ts:139` | `useEffect` 내부에서 AbortController 생성, cleanup에서 abort |

## Linked issue

Refs #7218 (useEffect 오남용 전수 조사) — **FETCH_NO_LIFECYCLE 1/9 완료**.

## Product impact

**관측 가능 UX 개선**:
- Session 빠르게 전환 시 이전 session의 stale 데이터가 새 session UI에 잠시 flash되는 레이스 제거
- 컴포넌트 unmount 후에도 진행 중이던 fetch가 완료될 때까지 서버 리소스/네트워크를 점유하던 문제 해소

**Race safety 포인트**:
- 이전 invocation이 abort된 후 새 invocation이 시작되면, 이전 invocation의 `finally` 블록은 `signal.aborted` 체크로 `loading=false`를 건들지 않음 (새 invocation의 `loading=true` 유지)
- `AbortError`는 `catch`에서 early return (error signal 오염 방지)

## Evidence

| 검증 | 결과 |
|------|------|
| `tsc --noEmit` | 통과 |
| `vite build` | 통과 (31.39s) |
| vitest (mission 관련) | 21/21 통과 (7 파일) |
| vitest (telemetry-unified) | 10/10 통과 — 전체 실행 시 timeout flake는 pre-existing 5s 기본값 이슈, 내 변경과 무관 |

## Review evidence

- `fetchToolQuality` (api/dashboard.ts:279)의 기존 signal threading 패턴을 따름
- `isAbortError`는 `lib/async-state.ts`에 이미 존재 (telemetry-unified.ts에서 사용 중)
- 다른 caller 존재 여부 grep 결과: `mission.ts`만이 직접 호출, `mission-store`는 re-export만

## Remaining work (#7218)

FETCH_NO_LIFECYCLE 8건 남음:
- `governance.ts:508` (2건 — refreshGovernance + loadParamAudit)
- `keeper-state-diagram.ts:77`
- `connector-status.ts:715` (cleanup은 존재, AbortController만 추가)
- `telemetry-unified.ts:658` (이미 load() 내부 abort 있음 — stylistic 정리만 필요)
- `tools/tool-allowlist-editor.ts:157`
- `mission-briefing-card.ts:233`
- `keeper-tool-telemetry.ts:113`
- `agent-profile.ts:302`

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `vite build` 통과
- [x] mission 관련 테스트 21/21 통과
- [ ] 시각 검증 — session을 빠르게 전환 시 stale flash 제거 확인
- [ ] 시각 검증 — 열린 session 페이지 이탈 시 네트워크 요청 취소 확인 (DevTools Network)

Refs #7218