### PR TITLE
feat(fsm-hub): absolute time axis on swimlane timeline

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -8,6 +8,7 @@ import {
   derivePhaseLog,
   deriveStateEntries,
   deriveSwimlaneSegments,
+  deriveTimeAxisTicks,
   deriveTransitionHistory,
   type CompositeObservation,
 } from './fsm-hub'
@@ -285,5 +286,44 @@ describe('deriveSwimlaneSegments', () => {
     const segments = deriveSwimlaneSegments(observations, 'turn', 140)
     expect(segments.map(s => s.value)).toEqual(['idle', 'prompting', 'idle', 'prompting'])
     expect(segments[3]).toEqual({ from: 130, to: 140, value: 'prompting' })
+  })
+})
+
+describe('deriveTimeAxisTicks', () => {
+  it('returns no ticks for a zero-width span', () => {
+    expect(deriveTimeAxisTicks(100, 100)).toEqual([])
+  })
+
+  it('returns ticks aligned to round clock moments', () => {
+    // 30s window, step should round up to 10s, firstTick = 110
+    const ticks = deriveTimeAxisTicks(103, 133)
+    expect(ticks.map(t => t.ts)).toEqual([110, 120, 130])
+    for (const tick of ticks) {
+      expect(tick.label).toMatch(/\d{2}:\d{2}:\d{2}/)
+    }
+  })
+
+  it('chooses a minute-scale step for long windows', () => {
+    // 15 min window, step should be 300s (5 min)
+    const ticks = deriveTimeAxisTicks(1_700_000_000, 1_700_000_900)
+    expect(ticks.length).toBeGreaterThanOrEqual(2)
+    expect(ticks.length).toBeLessThanOrEqual(6)
+    const gaps = ticks.slice(1).map((t, i) => t.ts - (ticks[i]?.ts ?? 0))
+    for (const gap of gaps) {
+      expect(gap).toBeGreaterThanOrEqual(60)
+    }
+  })
+
+  it('respects the maxTicks cap', () => {
+    const ticks = deriveTimeAxisTicks(0, 3600, 3)
+    expect(ticks.length).toBeLessThanOrEqual(3)
+  })
+
+  it('emits no ticks strictly-less-than spanStart', () => {
+    const ticks = deriveTimeAxisTicks(100, 200)
+    for (const tick of ticks) {
+      expect(tick.ts).toBeGreaterThan(100)
+      expect(tick.ts).toBeLessThanOrEqual(200)
+    }
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -232,6 +232,43 @@ export function deriveStateEntries(
   return result
 }
 
+export type TimeAxisTick = { ts: number; label: string }
+
+const TIME_AXIS_STEPS_SEC = [1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600, 7200]
+
+/** Compute up to `maxTicks` evenly-spaced absolute-time tick marks that
+    lie strictly inside `[spanStart, spanEnd]`. The step is rounded up
+    to the nearest human-friendly value (1s..2h) so labels align on
+    round clock moments, not arbitrary offsets. Returns empty when the
+    span is too narrow to fit more than a single tick. */
+export function deriveTimeAxisTicks(
+  spanStart: number,
+  spanEnd: number,
+  maxTicks = 6,
+): TimeAxisTick[] {
+  const span = spanEnd - spanStart
+  if (span <= 0 || maxTicks < 2) return []
+  const desiredStep = span / Math.max(1, maxTicks - 1)
+  const step =
+    TIME_AXIS_STEPS_SEC.find(s => s >= desiredStep) ??
+    TIME_AXIS_STEPS_SEC[TIME_AXIS_STEPS_SEC.length - 1] ??
+    desiredStep
+  const showSeconds = step < 60
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(showSeconds ? { second: '2-digit' } : {}),
+    hour12: false,
+  })
+  const firstTick = Math.ceil(spanStart / step) * step
+  const ticks: TimeAxisTick[] = []
+  for (let ts = firstTick; ts <= spanEnd && ticks.length < maxTicks; ts += step) {
+    if (ts <= spanStart) continue
+    ticks.push({ ts, label: formatter.format(new Date(ts * 1000)) })
+  }
+  return ticks
+}
+
 export type SwimlaneSegment = {
   from: number
   to: number
@@ -1480,6 +1517,15 @@ function SwimlaneTimeline({
   const spanEnd = Math.max(now, observations[observations.length - 1]?.ts ?? now)
   const spanWidth = Math.max(1, spanEnd - spanStart)
   const windowDuration = fmtDuration(Math.max(0, spanEnd - spanStart))
+  const ticks = deriveTimeAxisTicks(spanStart, spanEnd)
+  const showSeconds = spanWidth < 600
+  const absFormatter = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(showSeconds ? { second: '2-digit' } : {}),
+    hour12: false,
+  })
+  const fmtAbs = (ts: number) => absFormatter.format(new Date(ts * 1000))
 
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
@@ -1488,7 +1534,10 @@ function SwimlaneTimeline({
           Swimlane Timeline
         </div>
         <div class="text-[9px] font-mono text-[var(--text-dim)]">
-          window <span class="text-[var(--text-body)]">${windowDuration}</span>
+          <span>${fmtAbs(spanStart)}</span>
+          <span class="mx-1 text-[var(--text-muted)]">→</span>
+          <span>${fmtAbs(spanEnd)}</span>
+          · window <span class="text-[var(--text-body)]">${windowDuration}</span>
           · <span class="text-[var(--text-body)]">${observations.length}</span> obs
         </div>
       </div>
@@ -1508,7 +1557,7 @@ function SwimlaneTimeline({
                     <div
                       class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-300 border-r border-[rgba(0,0,0,0.25)] last:border-r-0`}
                       style=${`width: ${pct.toFixed(2)}%`}
-                      title=${`${lane.short} · ${seg.value} · ${holdFor}`}
+                      title=${`${lane.short} · ${seg.value}\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · held ${holdFor}`}
                     ></div>
                   `
                 })}
@@ -1517,6 +1566,25 @@ function SwimlaneTimeline({
           `
         })}
       </div>
+      ${ticks.length > 0 ? html`
+        <div class="mt-1 flex items-center gap-2" aria-hidden="true">
+          <div class="w-[44px] shrink-0"></div>
+          <div class="relative flex-1 h-3">
+            ${ticks.map(tick => {
+              const leftPct = ((tick.ts - spanStart) / spanWidth) * 100
+              return html`
+                <div
+                  class="absolute top-0 flex flex-col items-center text-[var(--text-dim)]"
+                  style=${`left: ${leftPct.toFixed(2)}%; transform: translateX(-50%)`}
+                >
+                  <div class="h-1 w-px bg-[var(--white-10)]"></div>
+                  <div class="text-[8px] font-mono leading-none mt-0.5">${tick.label}</div>
+                </div>
+              `
+            })}
+          </div>
+        </div>
+      ` : null}
       <div class="mt-2 flex flex-wrap items-center gap-2 text-[9px] text-[var(--text-dim)]">
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(129,140,248,0.45)]"></span>active</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(245,158,11,0.45)]"></span>compact</span>


### PR DESCRIPTION
## v10 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

v9 swimlane 이 *상대* 공간 (lane × window proportion) 을 그렸다면, v10 은 거기에 *절대* 시각 앵커를 붙인다.

## Changes

- `deriveTimeAxisTicks(spanStart, spanEnd, maxTicks=6)` — `{1s..2h}` 계단에서 최소 human-friendly step 선택, round-multiple 로 정렬된 ts 리스트 반환.
- `SwimlaneTimeline` 에 tick row 추가 — 각 tick 은 absolute position(%) + `HH:MM[:SS]` label.
- Span header: `12:45:30 → 13:00:00 · window 14m 30s · 18 obs`.
- Segment tooltip 에 절대 시각 구간 + held duration 2줄 표시.
- 10분 이상 window 는 seconds 자동 숨김.

## Test

- 신규: `deriveTimeAxisTicks` 5 케이스.
- 회귀: vitest 93 files / 616 tests pass.
- typecheck: clean. vite build: clean.