### PR TITLE
fix(dashboard): AbortController for keeper state diagram fetches (#7218)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -373,20 +373,27 @@ export interface KeeperStateDiagramResponse {
   memory_kind_usage?: MemoryKindUsageEntry[]
 }
 
-export async function fetchKeeperTransitions(name: string, limit = 20): Promise<KeeperTransitionsResponse> {
+export async function fetchKeeperTransitions(
+  name: string,
+  limit = 20,
+  opts?: { signal?: AbortSignal },
+): Promise<KeeperTransitionsResponse> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/transitions?limit=${limit}`,
-    { headers: jsonHeaders() },
+    { headers: jsonHeaders(), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`transitions fetch failed: ${resp.status}`)
   return resp.json() as Promise<KeeperTransitionsResponse>
 }
 
-export async function fetchKeeperStateDiagram(name: string): Promise<KeeperStateDiagramResponse> {
+export async function fetchKeeperStateDiagram(
+  name: string,
+  opts?: { signal?: AbortSignal },
+): Promise<KeeperStateDiagramResponse> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/state-diagram`,
-    { headers: jsonHeaders() },
+    { headers: jsonHeaders(), signal: opts?.signal },
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`state-diagram fetch failed: ${resp.status}`)

--- a/dashboard/src/components/keeper-memory-tier-panel.ts
+++ b/dashboard/src/components/keeper-memory-tier-panel.ts
@@ -31,24 +31,24 @@ export function KeeperMemoryTierPanel({
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     setLoading(true)
     setError(null)
 
-    fetchKeeperStateDiagram(keeperName)
+    fetchKeeperStateDiagram(keeperName, { signal: controller.signal })
       .then(data => {
-        if (cancelled) return
+        if (controller.signal.aborted) return
         setUsage(data.memory_kind_usage ?? [])
         setSubmachineMermaid(data.compaction_submachine_mermaid ?? null)
         setLoading(false)
       })
       .catch(err => {
-        if (cancelled) return
+        if (controller.signal.aborted) return
         setError(err instanceof Error ? err.message : 'memory tier fetch failed')
         setLoading(false)
       })
 
-    return () => { cancelled = true }
+    return () => { controller.abort() }
   }, [keeperName])
 
   if (loading) {

--- a/dashboard/src/components/keeper-state-diagram.ts
+++ b/dashboard/src/components/keeper-state-diagram.ts
@@ -75,16 +75,16 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    let cancelled = false
+    const controller = new AbortController()
     setLoading(true)
     setError(null)
 
     Promise.allSettled([
-      fetchKeeperStateDiagram(keeperName),
-      fetchKeeperTransitions(keeperName, 5),
+      fetchKeeperStateDiagram(keeperName, { signal: controller.signal }),
+      fetchKeeperTransitions(keeperName, 5, { signal: controller.signal }),
     ])
       .then(([diagramResult, transitionsResult]) => {
-        if (cancelled) return
+        if (controller.signal.aborted) return
         if (diagramResult.status === 'fulfilled') {
           setDiagramData(diagramResult.value)
         } else {
@@ -101,12 +101,12 @@ export function KeeperStateDiagramPanel({ keeperName, currentPhase }: KeeperStat
         setLoading(false)
       })
       .catch(err => {
-        if (cancelled) return
+        if (controller.signal.aborted) return
         setError(err instanceof Error ? err.message : 'state diagram fetch failed')
         setLoading(false)
       })
 
-    return () => { cancelled = true }
+    return () => { controller.abort() }
   }, [keeperName])
 
   const livePhase = normalizePhase(currentPhase) ?? normalizePhase(diagramData?.current_phase)


### PR DESCRIPTION
## Summary

키퍼 state diagram 관련 2개 컴포넌트에서 `cancelled` flag 기반 cleanup을 AbortController로 교체. 두 컴포넌트가 공유하는 API 레이어(`api/keeper.ts`)에 signal 파라미터를 추가하여 fetch 자체가 abort되도록 수정.

| 파일 | 변경 |
|------|------|
| `api/keeper.ts` | `fetchKeeperStateDiagram`, `fetchKeeperTransitions`에 `opts?: { signal?: AbortSignal }` 추가. `fetchWithTimeout`이 이미 upstream signal linking 지원 |
| `components/keeper-state-diagram.ts` | `cancelled` flag → `AbortController`. Promise.allSettled 내부 두 fetch 모두 signal 전달 |
| `components/keeper-memory-tier-panel.ts` | 동일한 fetchKeeperStateDiagram 사용자 — 같은 패턴 적용 |

## Linked issue

Refs #7218 — FETCH_NO_LIFECYCLE **2/9 처리** (`keeper-state-diagram.ts:77` + bonus `keeper-memory-tier-panel.ts:38` 동일 패턴).

## Product impact

**관측 가능한 개선**:
- 키퍼 전환이 빠른 사용자 시나리오에서 in-flight HTTP 요청이 실제로 abort됨 (이전: flag만 체크, 네트워크/서버 리소스는 계속 점유)
- 컴포넌트 unmount 후에도 fetch 완료까지 대기하던 서버 부하 감소

## Evidence

| 검증 | 결과 |
|------|------|
| `tsc --noEmit` | 통과 |
| `vite build` | 통과 (7.89s) |
| vitest (keeper 관련) | 15 files, 93 tests 전부 pass |

## Review evidence

- `fetchWithTimeout` (api/core.ts:125)는 이미 `init.signal`을 받아 내부 timeout controller와 linking — 추가 로직 불필요
- `fetchKeeperStateDiagram` / `fetchKeeperTransitions`의 다른 caller는 `keeper-phase-strip.ts`와 `keeper-memory-tier-panel.ts` — 옵션 파라미터이므로 backward compatible (변경 불필요)
- `keeper-memory-tier-panel.ts`는 원래 이슈 리스트에 없지만 동일 API를 쓰고 동일 패턴(cancelled flag)이므로 함께 수정

## Remaining work (#7218)

FETCH_NO_LIFECYCLE 6건 남음 (mission PR #7260 + 이 PR 이후):
- `governance.ts:508` (2건)
- `connector-status.ts:715`
- `telemetry-unified.ts:658` (stylistic)
- `tools/tool-allowlist-editor.ts:157`
- `mission-briefing-card.ts:233`
- `keeper-tool-telemetry.ts:113`
- `agent-profile.ts:302`

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `vite build` 통과
- [x] 15 keeper test files, 93 tests 모두 pass
- [ ] 시각 검증 — 키퍼를 빠르게 전환할 때 DevTools Network 탭에서 이전 요청이 `canceled` 상태로 변하는지 확인

Refs #7218