### PR TITLE
feat(keeper): per-keeper max_turns override via TOML

### DIFF
--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -152,6 +152,10 @@ type keeper_profile_defaults = {
   telemetry_feedback_window_hours : int option;
   cascade_name : string option;
   models : string list option;
+  (* Turn budget overrides. None = inherit env default
+     (MASC_KEEPER_OAS_MAX_TURNS_PER_CALL / ..._SCHEDULED_AUTONOMOUS). *)
+  max_turns_per_call : int option;
+  max_turns_per_call_scheduled_autonomous : int option;
 }
 
 type persona_summary = {
@@ -191,6 +195,8 @@ let empty_keeper_profile_defaults = {
   work_discovery_guidance = None;
   telemetry_feedback_enabled = None;
   telemetry_feedback_window_hours = None;
+  max_turns_per_call = None;
+  max_turns_per_call_scheduled_autonomous = None;
   cascade_name = None;
   models = None;
 }
@@ -315,6 +321,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         work_discovery_guidance = str "work_discovery_guidance";
         telemetry_feedback_enabled = bool_ "telemetry_feedback_enabled";
         telemetry_feedback_window_hours = int_ "telemetry_feedback_window_hours";
+        max_turns_per_call = int_ "max_turns_per_call";
+        max_turns_per_call_scheduled_autonomous =
+          int_ "max_turns_per_call_scheduled_autonomous";
         cascade_name = normalize_cascade_name_opt (str "cascade_name");
         models =
           (match strs "models" with
@@ -443,6 +452,11 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                   Safe_ops.json_bool_opt "telemetry_feedback_enabled" keeper_json;
                 telemetry_feedback_window_hours =
                   Safe_ops.json_int_opt "telemetry_feedback_window_hours" keeper_json;
+                max_turns_per_call =
+                  Safe_ops.json_int_opt "max_turns_per_call" keeper_json;
+                max_turns_per_call_scheduled_autonomous =
+                  Safe_ops.json_int_opt
+                    "max_turns_per_call_scheduled_autonomous" keeper_json;
                 cascade_name =
                   normalize_cascade_name_opt
                     (Safe_ops.json_string_opt "cascade_name" keeper_json);
@@ -464,6 +478,27 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
        load_keeper_profile_defaults_from_persona name)
   | None ->
     load_keeper_profile_defaults_from_persona name
+
+(** Clamp a profile-provided max-turns override to [1, 50] — the same range
+    enforced by [Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call].
+    Values outside the range are rejected so a typo in TOML cannot silently
+    bypass the budget envelope. *)
+let clamp_max_turns_override : int option -> int option = function
+  | Some n when n >= 1 && n <= 50 -> Some n
+  | _ -> None
+
+let effective_max_turns_per_call (profile : keeper_profile_defaults) : int =
+  match clamp_max_turns_override profile.max_turns_per_call with
+  | Some n -> n
+  | None -> Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call
+
+let effective_max_turns_per_call_scheduled_autonomous
+    (profile : keeper_profile_defaults) : int =
+  let global_cap = Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call in
+  match clamp_max_turns_override profile.max_turns_per_call_scheduled_autonomous with
+  | Some n -> min n global_cap
+  | None ->
+    Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
 
 type keeper_default_source_snapshot = {
   source_kind : string option;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1437,16 +1437,22 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           let remaining_turn_budget_s () =
             Float.max 0.0 (turn_deadline -. Eio.Time.now clock)
           in
+          let keeper_profile =
+            Keeper_types_profile.load_keeper_profile_defaults meta.name
+          in
           let do_run ~run_meta ~max_context ~run_generation ~is_retry
               ~oas_timeout_s =
             let max_idle_turns, max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
                   ( Env_config_keeper.KeeperKeepalive.max_idle_turns_reactive,
-                    Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call )
+                    Keeper_types_profile.effective_max_turns_per_call
+                      keeper_profile )
               | Keeper_world_observation.Scheduled_autonomous ->
                   ( Env_config_keeper.KeeperKeepalive.max_idle_turns_autonomous,
-                    Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous )
+                    Keeper_types_profile
+                    .effective_max_turns_per_call_scheduled_autonomous
+                      keeper_profile )
             in
             Keeper_agent_run.run_turn ~config ~meta:run_meta ~base_dir
               ~max_context ~build_turn_prompt
@@ -1471,9 +1477,12 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             let max_turns =
               match channel with
               | Keeper_world_observation.Reactive ->
-                  Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call
+                  Keeper_types_profile.effective_max_turns_per_call
+                    keeper_profile
               | Keeper_world_observation.Scheduled_autonomous ->
-                  Env_config_keeper.KeeperKeepalive.oas_max_turns_per_call_scheduled_autonomous
+                  Keeper_types_profile
+                  .effective_max_turns_per_call_scheduled_autonomous
+                    keeper_profile
             in
             let attempt_result =
               match

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -666,6 +666,68 @@ cascade_name = "local_only"
        check (option string) "cascade preserved"
          (Some "local_only") d.cascade_name)
 
+let test_profile_max_turns_overrides () =
+  let input = {|
+[keeper]
+goal = "test"
+max_turns_per_call = 25
+max_turns_per_call_scheduled_autonomous = 3
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       check (option int) "max_turns_per_call" (Some 25) d.max_turns_per_call;
+       check (option int) "max_turns_per_call_scheduled_autonomous"
+         (Some 3) d.max_turns_per_call_scheduled_autonomous;
+       check int "effective reactive uses override" 25
+         (KTP.effective_max_turns_per_call d);
+       (* autonomous is capped by reactive global cap, but 3 < env default 15 *)
+       check int "effective autonomous uses override" 3
+         (KTP.effective_max_turns_per_call_scheduled_autonomous d))
+
+let test_profile_max_turns_defaults_when_absent () =
+  let input = {|
+[keeper]
+goal = "test"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       check (option int) "max_turns_per_call absent" None d.max_turns_per_call;
+       check (option int) "max_turns_per_call_scheduled_autonomous absent"
+         None d.max_turns_per_call_scheduled_autonomous;
+       (* helpers fall back to env defaults (15 and min(global, 2)=2) *)
+       check int "effective reactive default" 15
+         (KTP.effective_max_turns_per_call d);
+       check int "effective autonomous default" 2
+         (KTP.effective_max_turns_per_call_scheduled_autonomous d))
+
+let test_profile_max_turns_rejects_out_of_range () =
+  let input = {|
+[keeper]
+goal = "test"
+max_turns_per_call = 99
+max_turns_per_call_scheduled_autonomous = 0
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    (match KTP.profile_defaults_of_toml doc with
+     | Error e -> fail e
+     | Ok d ->
+       (* Values are parsed as-is but clamp_max_turns_override rejects them,
+          so helpers fall back to env defaults. *)
+       check int "out-of-range reactive falls back" 15
+         (KTP.effective_max_turns_per_call d);
+       check int "zero autonomous falls back" 2
+         (KTP.effective_max_turns_per_call_scheduled_autonomous d))
+
 let test_profile_normalizes_legacy_keeper_cascade_alias () =
   let input = {|
 [keeper]
@@ -780,6 +842,12 @@ let () =
             test_profile_ignores_legacy_allowed_providers;
           test_case "legacy keeper cascade alias normalized" `Quick
             test_profile_normalizes_legacy_keeper_cascade_alias;
+          test_case "max_turns overrides parsed and applied" `Quick
+            test_profile_max_turns_overrides;
+          test_case "max_turns defaults when absent" `Quick
+            test_profile_max_turns_defaults_when_absent;
+          test_case "max_turns rejects out-of-range values" `Quick
+            test_profile_max_turns_rejects_out_of_range;
         ] );
       ( "file_loading",
         [


### PR DESCRIPTION
## Summary
- `keeper_profile` record에 optional `max_turns_per_call` + `max_turns_per_call_scheduled_autonomous` 필드 추가
- 없으면 기존 env default (`MASC_KEEPER_OAS_MAX_TURNS_PER_CALL`: 15 reactive, 2 autonomous) 상속
- `keeper_unified_turn.ml`의 두 분기점(`do_run`, `retry_loop`)이 `effective_max_turns_per_call[_scheduled_autonomous]` helper를 거침
- 값은 [1, 50] 범위 clamp. autonomous는 global reactive cap에 추가 제한.
- 54 tests pass (기존 51 + 신규 3)

## Product impact
- Keeper별 역할 차이 (간단 반응 vs 복잡 연구)에 맞춰 turn budget tuning 가능
- 기본값 유지 — 기존 keeper는 동작 변화 없음
- env override는 여전히 유효 (profile 값이 없을 때)

## Evidence
- `dune build`: 성공
- `dune exec test/test_keeper_toml.exe`: **54 tests pass** (신규 3개 포함)
  - `max_turns overrides parsed and applied`
  - `max_turns defaults when absent` (env default 확인)
  - `max_turns rejects out-of-range values` (clamp 동작)

## Review evidence
- 단일 모델(Claude Opus 4.6) 작성
- 기존 optional field 패턴 (proactive_enabled, tool_preset 등) 그대로 따름
- Layer boundary: OAS budget은 OAS가 소유. MASC는 override 값만 전달, budget 해석은 OAS가 함

## 변경 파일 (3개)
| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_types_profile.ml` | record 필드 2개 + TOML/JSON parser + helpers + clamp |
| `lib/keeper/keeper_unified_turn.ml` | 2개 분기에서 env 직접 참조 → profile helper 호출로 교체 |
| `test/test_keeper_toml.ml` | 3개 단위 테스트 추가 |

## Linked issue
Refs: 사용자 요청 — keeper별로 max_turn을 TOML에서 override 하고 싶음 (기본값 상속 유지)

## Test plan
- [x] `dune build` 성공
- [x] `dune exec test/test_keeper_toml.exe` 54 tests pass
- [ ] 실제 keeper TOML에 override 넣고 production smoke
- [ ] 기존 keeper (TOML에 필드 없음) 재시작 시 env default 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)