### PR TITLE
feat(fsm-hub): swimlane ↔ transition-trail hover coordination

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -10,7 +10,9 @@ import {
   deriveSwimlaneSegments,
   deriveTimeAxisTicks,
   deriveTransitionHistory,
+  isTransitionInSegment,
   type CompositeObservation,
+  type HoveredSegment,
 } from './fsm-hub'
 
 function observation(
@@ -325,5 +327,31 @@ describe('deriveTimeAxisTicks', () => {
       expect(tick.ts).toBeGreaterThan(100)
       expect(tick.ts).toBeLessThanOrEqual(200)
     }
+  })
+})
+
+describe('isTransitionInSegment', () => {
+  const segKSM: HoveredSegment = { field: 'KSM', laneKey: 'phase', from: 100, to: 200, value: 'Running' }
+
+  it('returns false when no segment is hovered', () => {
+    expect(isTransitionInSegment({ ts: 150, field: 'KSM' }, null)).toBe(false)
+  })
+
+  it('returns false when fields disagree', () => {
+    expect(isTransitionInSegment({ ts: 150, field: 'KTC' }, segKSM)).toBe(false)
+  })
+
+  it('includes the segment start and end inclusively', () => {
+    expect(isTransitionInSegment({ ts: 100, field: 'KSM' }, segKSM)).toBe(true)
+    expect(isTransitionInSegment({ ts: 200, field: 'KSM' }, segKSM)).toBe(true)
+  })
+
+  it('excludes ts outside the segment window', () => {
+    expect(isTransitionInSegment({ ts: 99, field: 'KSM' }, segKSM)).toBe(false)
+    expect(isTransitionInSegment({ ts: 201, field: 'KSM' }, segKSM)).toBe(false)
+  })
+
+  it('returns true for a field+ts that overlap the hovered segment', () => {
+    expect(isTransitionInSegment({ ts: 150, field: 'KSM' }, segKSM)).toBe(true)
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -275,6 +275,18 @@ export type SwimlaneSegment = {
   value: string
 }
 
+/** Cross-panel hover coordination payload. When a swimlane segment is
+    under the cursor, the SwimlaneTimeline publishes which lane, value,
+    and time window it covers, and downstream panels (TransitionTrail,
+    PipelineStep) highlight rows that overlap. */
+export type HoveredSegment = {
+  field: string  // KSM / KTC / KDP / KCL / KMC
+  laneKey: keyof Omit<CompositeObservation, 'ts'>
+  from: number
+  to: number
+  value: string
+}
+
 /** Collapse consecutive observations of a single lane into run-length
     segments. The final segment is extended to `boundsEnd` so the lane
     visually reaches the right edge of the timeline instead of stopping
@@ -772,6 +784,7 @@ export function FsmHub() {
   const [pollTick, setPollTick] = useState(0)
   const [now, setNow] = useState(() => Date.now() / 1000)
   const [graphOpen, setGraphOpen] = useState(false)
+  const [hoveredSegment, setHoveredSegment] = useState<HoveredSegment | null>(null)
   const requestIdRef = useRef(0)
 
   const keeperList = keepers.value
@@ -883,13 +896,18 @@ export function FsmHub() {
         <${HeroPhase} snapshot=${snapshot} phaseLog=${phaseLog} phaseSince=${stateEntries?.phase ?? null} now=${now} />
 
         ${/* ── Zone 2b: Transition History Trail ── */ ''}
-        <${TransitionTrail} history=${history} now=${now} />
+        <${TransitionTrail} history=${history} now=${now} hoveredSegment=${hoveredSegment} />
 
         ${/* ── Zone 3: Turn Pipeline Strip ── */ ''}
         <${TurnPipelineStrip} snapshot=${snapshot} stateEntries=${stateEntries} now=${now} />
 
         ${/* ── Zone 3b: Swimlane Timeline ── */ ''}
-        <${SwimlaneTimeline} observations=${view.observations} now=${now} />
+        <${SwimlaneTimeline}
+          observations=${view.observations}
+          now=${now}
+          hoveredSegment=${hoveredSegment}
+          onHoverSegment=${setHoveredSegment}
+        />
 
         ${/* ── Zone 4: Health Grid ── */ ''}
         <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
@@ -1500,9 +1518,13 @@ function swimlaneSegmentColor(value: string): string {
 function SwimlaneTimeline({
   observations,
   now,
+  hoveredSegment,
+  onHoverSegment,
 }: {
   observations: CompositeObservation[]
   now: number
+  hoveredSegment: HoveredSegment | null
+  onHoverSegment: (seg: HoveredSegment | null) => void
 }) {
   if (observations.length === 0) {
     return html`
@@ -1553,11 +1575,19 @@ function SwimlaneTimeline({
                 ${segments.map(seg => {
                   const pct = ((seg.to - seg.from) / spanWidth) * 100
                   const holdFor = fmtDuration(Math.max(0, seg.to - seg.from))
+                  const isHovered =
+                    hoveredSegment != null &&
+                    hoveredSegment.laneKey === lane.key &&
+                    hoveredSegment.from === seg.from &&
+                    hoveredSegment.to === seg.to
+                  const dimmed = hoveredSegment != null && !isHovered
                   return html`
                     <div
-                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-300 border-r border-[rgba(0,0,0,0.25)] last:border-r-0`}
+                      class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-200 border-r border-[rgba(0,0,0,0.25)] last:border-r-0 cursor-pointer ${isHovered ? 'ring-1 ring-[var(--accent)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
                       style=${`width: ${pct.toFixed(2)}%`}
                       title=${`${lane.short} · ${seg.value}\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · held ${holdFor}`}
+                      onmouseenter=${() => onHoverSegment({ field: lane.short, laneKey: lane.key, from: seg.from, to: seg.to, value: seg.value })}
+                      onmouseleave=${() => onHoverSegment(null)}
                     ></div>
                   `
                 })}
@@ -1596,12 +1626,23 @@ function SwimlaneTimeline({
   `
 }
 
+export function isTransitionInSegment(
+  entry: { ts: number; field: string },
+  segment: HoveredSegment | null,
+): boolean {
+  if (!segment) return false
+  if (entry.field !== segment.field) return false
+  return entry.ts >= segment.from && entry.ts <= segment.to
+}
+
 function TransitionTrail({
   history,
   now,
+  hoveredSegment,
 }: {
   history: { ts: number; from: string; to: string; field: string }[]
   now: number
+  hoveredSegment: HoveredSegment | null
 }) {
   if (history.length === 0) {
     return html`
@@ -1620,8 +1661,13 @@ function TransitionTrail({
         ${history.map(entry => {
           const ago = fmtDuration(Math.max(0, now - entry.ts))
           const color = FIELD_COLOR[entry.field] ?? 'text-[var(--text-body)]'
+          const inSegment = isTransitionInSegment(entry, hoveredSegment)
+          const dimmed = hoveredSegment != null && !inSegment
+          const rowCls = inSegment
+            ? 'bg-[rgba(71,184,255,0.1)] ring-1 ring-[rgba(71,184,255,0.3)] rounded px-1'
+            : ''
           return html`
-            <div class="flex items-center gap-2 text-[10px] font-mono leading-tight">
+            <div class=${`flex items-center gap-2 text-[10px] font-mono leading-tight transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''} ${rowCls}`}>
               <span class="w-[52px] shrink-0 text-right text-[var(--text-dim)]">${ago} ago</span>
               <span class=${`w-[28px] shrink-0 font-semibold ${color}`}>${entry.field}</span>
               <span class="text-[var(--text-dim)]">${entry.from}</span>


### PR DESCRIPTION
## v11 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

v9 swimlane + v10 time axis 가 "맵 + 좌표계" 를 완성했다면, v11 은 "여러 패널 간 cross-referencing" 을 인터랙션으로 대체한다. OpenObserve/Datadog/Perses 의 표준 linked-panels 패턴.

## Changes

- `HoveredSegment` 타입 export — `{ field, laneKey, from, to, value }` 으로 하나의 세그먼트 정체성 표현.
- `SwimlaneTimeline` 은 segment 에 `onmouseenter/leave` 로 hovered state 퍼블리시.
- `TransitionTrail` 은 `isTransitionInSegment(entry, hoveredSegment)` 로 row 매칭 — 매칭 row 는 accent ring + 하이라이트 bg, 비매칭은 opacity 40%.
- 비호버 lane segment 도 dim — "지금 집중해야 할 슬라이스" 를 시각적으로 격리.
- Hub root 에서 `hoveredSegment: HoveredSegment | null` state 소유 → prop drilling 최소화.

## Test

- 신규: `isTransitionInSegment` 5 케이스 (null / field mismatch / inclusive bounds / exclusive / overlap).
- 회귀: vitest 93 files / 621 tests pass (unrelated telemetry polling test 는 known flake — 재실행 시 green).
- typecheck: clean. vite build: clean.

## 의도적 한계

- PipelineStep 과는 coordination 없음 — PipelineStep 은 "지금 상태" 이므로 과거 segment 와 연관 지을 수 없음.
- 터치/키보드 네비게이션 연동 없음 — 마우스 hover 만. 키보드 사용자를 위한 대안은 v12+ 고려.