### PR TITLE
refactor(dashboard): remove 30 MASC_DASHBOARD_* env vars (Phase A-1)

### DIFF
--- a/lib/config/env_config_governance.ml
+++ b/lib/config/env_config_governance.ml
@@ -17,12 +17,10 @@ module Inference = struct
     max 5
       (get_int ~default:timeout_seconds_int "MASC_OPERATOR_JUDGE_TIMEOUT_SEC")
 
-  (** Dashboard governance judge timeout.
-      Falls back to the global inference timeout unless explicitly overridden. *)
+  (** Dashboard governance judge timeout: falls back to the global
+      inference timeout (timeout_seconds_int), floored at 5 seconds. *)
   let dashboard_governance_judge_timeout_seconds =
-    max 5
-      (get_int ~default:timeout_seconds_int
-         "MASC_DASHBOARD_GOVERNANCE_JUDGE_TIMEOUT_SEC")
+    max 5 timeout_seconds_int
 
   (** Enable inference response cache (L1+L2). *)
   let cache_enabled =

--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -77,19 +77,13 @@ let now () = Time_compat.now ()
     Reduced from 10x to 3x — the 10x factor was masking slow compute
     by holding stale data for 22 minutes. With O(n+ops) tree index and
     adaptive refresh intervals, compute is faster so shorter grace is safe. *)
-let stale_factor =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_DASHBOARD_STALE_FACTOR"
-    ~default:3.0 ~min_v:1.0 ~max_v:10.0
+let stale_factor = 3.0
 
 (** Backoff multiplier for stale_grace on bg-revalidation failure.
     Extends the stale window to reduce retry pressure when compute
-    repeatedly fails.  Default 2.0 means the second attempt waits
-    twice the normal stale_grace before retrying.  #5402 *)
-let bg_revalidate_backoff_factor =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_DASHBOARD_BG_REVALIDATE_BACKOFF"
-    ~default:2.0 ~min_v:1.0 ~max_v:10.0
+    repeatedly fails.  2.0 means the second attempt waits twice the
+    normal stale_grace before retrying.  #5402 *)
+let bg_revalidate_backoff_factor = 2.0
 
 exception Compute_timeout of string * bool
 

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -145,10 +145,7 @@ let message_json (message : Types.message) =
 (** Maximum wall-clock time for a single dashboard render.
     Keep a real guard for PG stalls, but allow slow cold-start projections
     to finish at least once so cached surfaces can hydrate. *)
-let render_timeout_s =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_DASHBOARD_EXECUTION_RENDER_TIMEOUT_S"
-    ~default:60.0 ~min_v:10.0 ~max_v:300.0
+let render_timeout_s = 60.0
 
 let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       let ctx : _ Operator_control.context =

--- a/lib/dashboard/dashboard_http_helpers.ml
+++ b/lib/dashboard/dashboard_http_helpers.ml
@@ -35,13 +35,9 @@ let float_of_env_default name ~default ~min_v ~max_v =
   in
   max min_v (min max_v v)
 
-let dashboard_session_list_limit () =
-  int_of_env_default "MASC_DASHBOARD_SESSION_LIST_LIMIT"
-    ~default:20 ~min_v:5 ~max_v:200
+let dashboard_session_list_limit () = 20
 
-let dashboard_session_list_timeout_s () =
-  float_of_env_default "MASC_DASHBOARD_SESSION_LIST_TIMEOUT_S"
-    ~default:5.0 ~min_v:1.0 ~max_v:30.0
+let dashboard_session_list_timeout_s () = 5.0
 
 let operator_snapshot_session_window_seconds () =
   float_of_env_default "MASC_OPERATOR_SNAPSHOT_SESSION_WINDOW_SECONDS"

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -85,7 +85,7 @@ let running_keeper_count (config : Room.config) : int =
        0
 
 let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Safe.t =
-  let include_goals = bool_of_env "MASC_DASHBOARD_INCLUDE_GOALS" in
+  let include_goals = false in
   let history_fragment_filter_enabled =
     bool_default_true_of_env "MASC_KEEPER_HISTORY_FRAGMENT_FILTER"
   in

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -2,8 +2,6 @@
     Extracts the metrics series iteration loop from keepers_dashboard_json. *)
 
 
-open Dashboard_http_helpers
-
 include Dashboard_http_keeper_metrics
 
 let compute_metrics_window
@@ -574,13 +572,7 @@ let compute_metrics_window
               else float_of_int !guardrail_stop_count /. float_of_int interaction_points_int
             in
             let proactive_previews = List.rev !proactive_previews_rev in
-            let proactive_similarity_warn_threshold =
-              float_of_env_default
-                "MASC_DASHBOARD_PROACTIVE_SIMILARITY_WARN"
-                ~default:0.90
-                ~min_v:0.0
-                ~max_v:1.0
-            in
+            let proactive_similarity_warn_threshold = 0.90 in
             let proactive_similarity_window = 8 in
             let ( proactive_preview_sample_count,
                   proactive_preview_pair_count,

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -12,13 +12,7 @@ open Dashboard_http_helpers
     [~now_ts] is injectable for testing; defaults to wall-clock time. *)
 let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Room.config)
     : Yojson.Safe.t =
-  let window_hours =
-    float_of_env_default
-      "MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS"
-      ~default:1.0
-      ~min_v:0.1
-      ~max_v:168.0
-  in
+  let window_hours = 1.0 in
   let since = now_ts -. (window_hours *. 3600.0) in
   let entries =
     try Audit_log.read_entries ~n:50_000 config
@@ -115,27 +109,9 @@ let tool_call_health_json ?(now_ts = Unix.gettimeofday ()) (config : Room.config
   ]
 
 let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
-  let warn_age_s =
-    int_of_env_default
-      "MASC_DASHBOARD_BOARD_AGE_WARN_SEC"
-      ~default:3600
-      ~min_v:60
-      ~max_v:604800
-  in
-  let bad_age_s =
-    int_of_env_default
-      "MASC_DASHBOARD_BOARD_AGE_BAD_SEC"
-      ~default:21600
-      ~min_v:120
-      ~max_v:1209600
-  in
-  let slo_target_age_s =
-    int_of_env_default
-      "MASC_DASHBOARD_BOARD_SLO_SEC"
-      ~default:900
-      ~min_v:30
-      ~max_v:Masc_time_constants.day_int
-  in
+  let warn_age_s = 3600 in
+  let bad_age_s = 21600 in
+  let slo_target_age_s = 900 in
   try
     let posts = Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:200 () in
     let total_posts = List.length posts in

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -250,10 +250,7 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
 (* Concurrency cap for parallel keeper snapshot fibers.
    Prevents memory bursts when many keepers are processed simultaneously.
    Each keeper fiber does filesystem I/O + heavy JSON construction (~50 fields). *)
-let _keeper_snapshot_max_concurrency =
-  Dashboard_http_helpers.int_of_env_default
-    "MASC_DASHBOARD_KEEPER_SNAPSHOT_MAX_CONCURRENCY"
-    ~default:4 ~min_v:1 ~max_v:32
+let _keeper_snapshot_max_concurrency = 4
 
 let _keeper_sem = Eio.Semaphore.make _keeper_snapshot_max_concurrency
 
@@ -669,9 +666,7 @@ let _snapshot_ttl_s = Env_config.Operator.cache_ttl_sec
 (* Maximum snapshot cache entries.  Each entry holds a full JSON snapshot
    tree which can be several MB.  Unbounded growth caused OOM when the
    dashboard was connected for extended periods (#4795). *)
-let _snapshot_max_entries =
-  Dashboard_http_helpers.int_of_env_default
-    "MASC_DASHBOARD_SNAPSHOT_CACHE_MAX_ENTRIES" ~default:16 ~min_v:4 ~max_v:64
+let _snapshot_max_entries = 16
 
 (* Evict one expired or oldest entry when table reaches _snapshot_max_entries.
    Called inside _snapshot_mu when Eio is ready; pre-Eio callers are

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -41,9 +41,7 @@ include Dashboard_http_helpers
 include Dashboard_http_monitoring
 include Dashboard_http_keeper
 
-let _dashboard_request_timeout_s =
-  float_of_env_default "MASC_DASHBOARD_REQUEST_TIMEOUT_S"
-    ~default:30.0 ~min_v:5.0 ~max_v:120.0
+let _dashboard_request_timeout_s = 30.0
 
 (** Wrap a dashboard computation with a configurable timeout.
     Returns a partial-response JSON on timeout instead of hanging. *)
@@ -64,9 +62,7 @@ let room_scoped_cache_key (config : Room.config) prefix suffix =
   Printf.sprintf "%s:%s:%s:%s" prefix config.base_path
     (room_scope_cache_segment config) suffix
 
-let _dashboard_mission_timeout_s =
-  float_of_env_default "MASC_DASHBOARD_MISSION_TIMEOUT_S"
-    ~default:25.0 ~min_v:10.0 ~max_v:120.0
+let _dashboard_mission_timeout_s = 25.0
 
 let _session_list_timeout_s =
   dashboard_session_list_timeout_s ()
@@ -126,41 +122,11 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
     governance_monitoring_json ~now_ts ~base_path:config.base_path
   in
 
-  let proactive_fallback_warn =
-    float_of_env_default
-      "MASC_DASHBOARD_PROACTIVE_FALLBACK_WARN"
-      ~default:0.20
-      ~min_v:0.0
-      ~max_v:1.0
-  in
-  let proactive_fallback_bad =
-    float_of_env_default
-      "MASC_DASHBOARD_PROACTIVE_FALLBACK_BAD"
-      ~default:0.40
-      ~min_v:0.0
-      ~max_v:1.0
-  in
-  let proactive_similarity_warn =
-    float_of_env_default
-      "MASC_DASHBOARD_PROACTIVE_SIMILARITY_WARN"
-      ~default:0.90
-      ~min_v:0.0
-      ~max_v:1.0
-  in
-  let proactive_similarity_bad =
-    float_of_env_default
-      "MASC_DASHBOARD_PROACTIVE_SIMILARITY_BAD"
-      ~default:0.97
-      ~min_v:0.0
-      ~max_v:1.0
-  in
-  let alert_toast_cooldown_sec =
-    int_of_env_default
-      "MASC_DASHBOARD_ALERT_TOAST_COOLDOWN_SEC"
-      ~default:300
-      ~min_v:10
-      ~max_v:Masc_time_constants.day_int
-  in
+  let proactive_fallback_warn = 0.20 in
+  let proactive_fallback_bad = 0.40 in
+  let proactive_similarity_warn = 0.90 in
+  let proactive_similarity_bad = 0.97 in
+  let alert_toast_cooldown_sec = 300 in
   let cluster = Env_config_core.cluster_name () in
   let status_json =
     `Assoc [
@@ -374,10 +340,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"operator_snapshot"
                  ~interval_s:_operator_refresh_interval_s)
-              with timeout_s =
-                     float_of_env_default
-                       "MASC_DASHBOARD_OPERATOR_SNAPSHOT_TIMEOUT_S"
-                       ~default:45.0 ~min_v:10.0 ~max_v:120.0;
+              with timeout_s = 45.0;
                    warm_delay_s =
                      float_of_env_default
                        "MASC_WARM_DELAY_OPERATOR_SNAPSHOT_S"
@@ -430,10 +393,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"operator_digest"
                  ~interval_s:_operator_refresh_interval_s)
-              with timeout_s =
-                     float_of_env_default
-                       "MASC_DASHBOARD_OPERATOR_DIGEST_TIMEOUT_S"
-                       ~default:45.0 ~min_v:10.0 ~max_v:120.0;
+              with timeout_s = 45.0;
                    warm_delay_s =
                      float_of_env_default
                        "MASC_WARM_DELAY_OPERATOR_DIGEST_S"
@@ -625,10 +585,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
   let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   let net, mono_clock = state_dashboard_runtime_caps state in
-  let mission_refresh_timeout_s =
-    float_of_env_default "MASC_DASHBOARD_MISSION_REFRESH_TIMEOUT_S"
-      ~default:60.0 ~min_v:30.0 ~max_v:300.0
-  in
+  let mission_refresh_timeout_s = 60.0 in
   let compute () =
     mark_cached_surface_attempt _mission_cache;
     let t0_mission = Unix.gettimeofday () in
@@ -856,9 +813,7 @@ let dashboard_general_agent_count agents =
 let provider_capacity_json () : Yojson.Safe.t =
   `Assoc []
 
-let dashboard_shell_timeout_s =
-  float_of_env_default "MASC_DASHBOARD_SHELL_TIMEOUT_S"
-    ~default:8.0 ~min_v:2.0 ~max_v:30.0
+let dashboard_shell_timeout_s = 8.0
 
 let dashboard_shell_paths_json (config : Room.config) : Yojson.Safe.t =
   Server_base_path_diagnostics.detect

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -328,10 +328,7 @@ let start_transport_health_refresh_loop ~state ~sw ~clock =
         mark_cached_surface_error _transport_health_cache exn;
         raise exn
   in
-  let interval_s =
-    float_of_env_default "MASC_DASHBOARD_TRANSPORT_HEALTH_INTERVAL_S"
-      ~default:30.0 ~min_v:5.0 ~max_v:120.0
-  in
+  let interval_s = 30.0 in
   Proactive_refresh.start ~sw ~clock
     ~config:
       { (Proactive_refresh.default_config ~label:"transport_health" ~interval_s)

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -53,18 +53,8 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         let command_ref = ref (`Assoc []) in
         (* Single env var for namespace-truth fiber timeouts.
            Cold start uses higher defaults to allow shell/namespace reads to warm up. *)
-        let warm_timeout_s =
-          float_of_env_default_with_legacy
-            ~canonical:"MASC_DASHBOARD_NAMESPACE_TRUTH_TIMEOUT_S"
-            ~legacy:"MASC_DASHBOARD_ROOM_TRUTH_TIMEOUT_S"
-            ~default:8.0 ~min_v:2.0 ~max_v:25.0
-        in
-        let cold_timeout_s =
-          float_of_env_default_with_legacy
-            ~canonical:"MASC_DASHBOARD_NAMESPACE_TRUTH_COLD_TIMEOUT_S"
-            ~legacy:"MASC_DASHBOARD_ROOM_TRUTH_COLD_TIMEOUT_S"
-            ~default:15.0 ~min_v:5.0 ~max_v:60.0
-        in
+        let warm_timeout_s = 8.0 in
+        let cold_timeout_s = 15.0 in
         let is_cold =
           not (cached_surface_has_success Execution_surfaces._execution_cache)
         in
@@ -88,10 +78,7 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
            (dashboard_shell_timeout_s, default 8s) to avoid the double-timeout
            race where the inner cache returns timeout-error JSON while the outer
            fiber also fires, discarding even stale data.  Fixes #5090. *)
-        let shell_fiber_timeout_s =
-          float_of_env_default "MASC_DASHBOARD_SHELL_FIBER_TIMEOUT_S"
-            ~default:12.0 ~min_v:5.0 ~max_v:30.0
-        in
+        let shell_fiber_timeout_s = 12.0 in
         let shell_timeout_s =
           if !(Execution_surfaces._shell_warmed) then shell_fiber_timeout_s
           else Float.max cold_timeout_s (shell_fiber_timeout_s +. 4.0)

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -237,15 +237,15 @@ let test_dashboard_warm_hydration_contracts () =
   check bool "namespace truth advertises initializing while execution warms" true
     (file_contains_pattern "lib/server/server_dashboard_http_namespace_truth.ml"
        {|("status", `String "initializing")|});
-  check bool "execution render timeout is env-configurable" true
+  check bool "execution render timeout is a named constant" true
     (file_contains_pattern "lib/dashboard/dashboard_execution.ml"
-       "MASC_DASHBOARD_EXECUTION_RENDER_TIMEOUT_S");
+       "let render_timeout_s");
   check bool "execution proactive refresh timeout is extended" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
        "MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S");
   check bool "mission proactive refresh timeout is extended" true
     (file_contains_pattern "lib/server/server_dashboard_http_core.ml"
-       "MASC_DASHBOARD_MISSION_REFRESH_TIMEOUT_S")
+       "let mission_refresh_timeout_s")
 
 let test_http_read_surface_contracts () =
   check bool "room status route now requires read auth" true
@@ -642,12 +642,12 @@ let test_namespace_truth_adaptive_timeout_contracts () =
   check bool "shell fiber uses adaptive timeout" true
     (file_contains_pattern "lib/server/server_dashboard_http_namespace_truth.ml"
        "shell_timeout_s");
-  check bool "namespace-truth timeout configurable via canonical env var" true
+  check bool "namespace-truth warm timeout is a named constant" true
     (file_contains_pattern "lib/server/server_dashboard_http_namespace_truth.ml"
-       "MASC_DASHBOARD_NAMESPACE_TRUTH_TIMEOUT_S");
-  check bool "namespace-truth timeout still honors legacy env fallback" true
+       "let warm_timeout_s");
+  check bool "namespace-truth cold timeout is a named constant" true
     (file_contains_pattern "lib/server/server_dashboard_http_namespace_truth.ml"
-       "MASC_DASHBOARD_ROOM_TRUTH_TIMEOUT_S");
+       "let cold_timeout_s");
   check bool "shell_warmed tracking exists" true
     (file_contains_pattern "lib/server/server_dashboard_http_execution_surfaces.ml"
        "_shell_warmed")


### PR DESCRIPTION
## Summary

**Phase A-1** of env var audit. 사용자 지시 \"너무 많다. 쓰지 않는 건 지우거나 합치자\"에 따라 감사 후 첫 번째 액션.

30개 undeclared \`MASC_DASHBOARD_*\` env var를 코드 상수로 변환.

## 배경 (감사 결과)

| 지표 | 값 |
|------|---|
| 코드에서 참조되는 MASC_* env var | 471 |
| Env_config_snapshot에 선언된 것 | 317 |
| **선언 없이 사용되는 것** (dashboard에 invisible) | **154** |

154개 undeclared를 분류:
- 78 declare (운영 tunable → snapshot 추가 대상)
- **46 constant (내부 튜닝 → 코드 상수화 대상, 이 PR이 30개 처리)**
- 2 delete
- 16 review
- 11 false positive

## 이 PR 대상

30개 MASC_DASHBOARD_* 전부 내부 dashboard 튜닝 (narrow min/max clamp):
- PROACTIVE_{FALLBACK,SIMILARITY}_{WARN,BAD} 같은 임계값
- {MISSION,OPERATOR_SNAPSHOT,OPERATOR_DIGEST,SHELL,NAMESPACE_TRUTH}_TIMEOUT_S
- BOARD_{AGE_WARN,AGE_BAD,SLO}_SEC
- STALE_FACTOR, BG_REVALIDATE_BACKOFF
- 기타 내부 값

운영자가 건드릴 일 없는 튜닝 값이라 코드 상수로 inline.

## 변경
- 11 파일, **net -113줄**
- 각 env var는 기존 default 값으로 대체
- min/max clamp 제거 (상수는 이미 범위 내)

## After
| 지표 | Before | After |
|------|-------|-------|
| Referenced env vars | 471 | **441** |
| Declared | 317 | 317 |
| Undeclared | 154 | 124 |

## Test plan
- [x] 41 keeper tests pass (29 hallucination gate + 12 github hint)
- [x] \`dune build @all\` clean (\`DUNE_CACHE=disabled\`)
- [ ] CI green

## 후속 PR
- **A-2**: 16 나머지 MASC_* 상수화 (CP, STIG, WARM, SSE)
- **A-3**: 78 운영 env var → snapshot 추가
- **A-4**: 16 review-bucket 수동 분류

🤖 Generated with [Claude Code](https://claude.com/claude-code)