### PR TITLE
feat(fsm-hub): per-lane transition count chips in swimlane header

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -11,6 +11,7 @@ import {
   deriveTimeAxisTicks,
   deriveTransitionHistory,
   isTransitionInSegment,
+  laneTransitionCount,
   type CompositeObservation,
   type HoveredSegment,
 } from './fsm-hub'
@@ -372,5 +373,38 @@ describe('isTransitionInSegment', () => {
     ]
     const index = history.findIndex(e => isTransitionInSegment(e, segKSM))
     expect(index).toBe(-1)
+  })
+})
+
+describe('laneTransitionCount', () => {
+  it('returns zero when the lane never changed', () => {
+    const observations = [
+      observation({ ts: 100, turn: 'idle' }),
+      observation({ ts: 110, turn: 'idle' }),
+      observation({ ts: 120, turn: 'idle' }),
+    ]
+    expect(laneTransitionCount(observations, 'turn')).toBe(0)
+  })
+
+  it('counts each value change between adjacent observations', () => {
+    const observations = [
+      observation({ ts: 100, turn: 'idle' }),
+      observation({ ts: 110, turn: 'prompting' }),
+      observation({ ts: 120, turn: 'executing' }),
+      observation({ ts: 130, turn: 'executing' }),
+      observation({ ts: 140, turn: 'idle' }),
+    ]
+    expect(laneTransitionCount(observations, 'turn')).toBe(3)
+  })
+
+  it('is lane-independent — different lanes count independently', () => {
+    const observations = [
+      observation({ ts: 100, turn: 'idle', phase: 'Running' }),
+      observation({ ts: 110, turn: 'prompting', phase: 'Running' }),
+      observation({ ts: 120, turn: 'prompting', phase: 'Compacting' }),
+    ]
+    expect(laneTransitionCount(observations, 'turn')).toBe(1)
+    expect(laneTransitionCount(observations, 'phase')).toBe(1)
+    expect(laneTransitionCount(observations, 'decision')).toBe(0)
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -314,7 +314,7 @@ export function deriveSwimlaneSegments(
   return segments
 }
 
-function laneTransitionCount(
+export function laneTransitionCount(
   observations: CompositeObservation[],
   key: keyof Omit<CompositeObservation, 'ts'>,
 ): number {
@@ -1601,12 +1601,41 @@ function SwimlaneTimeline({
     hour12: false,
   })
   const fmtAbs = (ts: number) => absFormatter.format(new Date(ts * 1000))
+  const laneDensity: Record<string, number> = {}
+  let busiestLane = ''
+  let busiestCount = 0
+  for (const lane of SWIMLANE_LANES) {
+    const count = laneTransitionCount(observations, lane.key)
+    laneDensity[lane.short] = count
+    if (count > busiestCount) {
+      busiestLane = lane.short
+      busiestCount = count
+    }
+  }
 
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
-      <div class="mb-2 flex items-baseline justify-between">
+      <div class="mb-2 flex items-baseline justify-between gap-3 flex-wrap">
         <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Swimlane Timeline
+        </div>
+        <div class="flex items-center gap-1 flex-wrap">
+          ${SWIMLANE_LANES.map(lane => {
+            const count = laneDensity[lane.short] ?? 0
+            const isBusiest = busiestLane === lane.short && count > 0
+            return html`
+              <span
+                class=${`rounded-full border px-1.5 py-0.5 text-[9px] font-mono tabular-nums ${
+                  count === 0
+                    ? 'text-[var(--text-dim)] border-[var(--white-8)]'
+                    : isBusiest
+                      ? 'text-[#818cf8] border-[rgba(129,140,248,0.4)] bg-[rgba(129,140,248,0.08)]'
+                      : 'text-[var(--text-body)] border-[var(--white-10)]'
+                }`}
+                title=${`${lane.label} · ${count} transition${count === 1 ? '' : 's'} in this window`}
+              >${lane.short} ${count}</span>
+            `
+          })}
         </div>
         <div class="text-[9px] font-mono text-[var(--text-dim)]">
           <span>${fmtAbs(spanStart)}</span>


### PR DESCRIPTION
## v13 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

v12 까지 상세 표시를 강화했다면 v13 은 반대로 *요약* 을 전면에. lane 별 transition 수를 작은 chip 행으로 헤더에 배치 — 운영자가 "어느 레인이 바쁜가" 를 한 눈에 포착.

## Changes

- `laneTransitionCount` export — 기존 내부 헬퍼를 퍼블릭 API 로 승격 (테스트 포함).
- `SwimlaneTimeline` 헤더에 chip row 추가 — 각 lane 당 `{short} {count}` 형태.
- Busiest lane 은 indigo 강조 (count > 0 조건), zero-count 는 dim.
- Chip tooltip: 풀 레이블 + count.
- 헤더는 `flex-wrap` — 좁은 화면에서 자동 줄바꿈.

## Test

- 신규: `laneTransitionCount` 3 케이스 (no-change / multiple / lane-independence).
- 회귀: vitest 93 files / 626 tests pass.
- typecheck: clean. vite build: clean.

## 의도적 한계

- Count 는 observations 버퍼 윈도우 기준 — 영속 집계 아님.
- "busiest" 선정은 단순 max — tie 발생 시 첫 매칭 lane 이 선택되는 deterministic 순서.