### PR TITLE
refactor: remove 16 internal tuning env vars (Phase A-2: CP/WARM/SSE/STIG)

### DIFF
--- a/lib/command_plane/cp_snapshot_summaries.ml
+++ b/lib/command_plane/cp_snapshot_summaries.ml
@@ -75,10 +75,7 @@ let traces_json_of_events events =
       ("events", `List events);
     ]
 
-let swarm_slot_samples_tail_lines () =
-  Dashboard_http_helpers.int_of_env_default
-    "MASC_CP_SWARM_SLOT_SAMPLE_TAIL_LINES"
-    ~default:2048 ~min_v:64 ~max_v:20000
+let swarm_slot_samples_tail_lines () = 2048
 
 let read_jsonl_tail_json path ~max_lines =
   read_jsonl_tail_lines path ~max_lines

--- a/lib/level4_config.ml
+++ b/lib/level4_config.ml
@@ -113,13 +113,13 @@ end
 
 module Stigmergy = struct
   (** Pheromone deposit rate per success *)
-  let deposit_rate () = get_env_float "MASC_STIG_DEPOSIT" 0.2
+  let deposit_rate () = 0.2
 
   (** Minimum pheromone strength to follow *)
-  let following_threshold () = get_env_float "MASC_STIG_THRESHOLD" 0.1
+  let following_threshold () = 0.1
 
   (** Number of top trails to consider *)
-  let top_trails_limit () = get_env_int "MASC_STIG_TOP_TRAILS" 5
+  let top_trails_limit () = 5
 end
 
 (** {1 Validation} *)

--- a/lib/server/server_command_plane_http_support.ml
+++ b/lib/server/server_command_plane_http_support.ml
@@ -58,10 +58,7 @@ let tool_command_plane_http_json ~deps ~state request ~name ~args =
 let _cp_summary_ref : Yojson.Safe.t ref =
   ref (`Assoc [("generated_at", `String (Types.now_iso ())); ("status", `String "initializing")])
 
-let _cp_summary_refresh_interval_s =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_CP_SUMMARY_REFRESH_INTERVAL_S"
-    ~default:120.0 ~min_v:30.0 ~max_v:600.0
+let _cp_summary_refresh_interval_s = 120.0
 
 type cp_snapshot_cache = {
   snapshot : Yojson.Safe.t;
@@ -111,15 +108,9 @@ let start_cp_summary_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"cp-summary"
                  ~interval_s:_cp_summary_refresh_interval_s)
-              with timeout_s =
-                     Dashboard_http_helpers.float_of_env_default
-                       "MASC_CP_SUMMARY_TIMEOUT_S"
-                       ~default:90.0 ~min_v:10.0 ~max_v:180.0;
+              with timeout_s = 90.0;
                    max_backoff_s = 300.0;
-                   warm_delay_s =
-                     Dashboard_http_helpers.float_of_env_default
-                       "MASC_WARM_DELAY_CP_SUMMARY_S"
-                       ~default:30.0 ~min_v:0.0 ~max_v:300.0 }
+                   warm_delay_s = 30.0 }
     ~compute:(fun () -> compute_cp_summary ~state)
     ~on_result:(fun json -> _cp_summary_ref := json)
 
@@ -137,14 +128,8 @@ let command_plane_summary_http_json ~state:_ =
    churn while still keeping a warm cached snapshot available. *)
 
 let _cp_snapshot_compute_mu = Eio.Mutex.create ()
-let _cp_snapshot_refresh_interval_s =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_CP_SNAPSHOT_REFRESH_INTERVAL_S"
-    ~default:120.0 ~min_v:30.0 ~max_v:600.0
-let _cp_snapshot_timeout_s =
-  Dashboard_http_helpers.float_of_env_default
-    "MASC_CP_SNAPSHOT_TIMEOUT_S"
-    ~default:60.0 ~min_v:10.0 ~max_v:120.0
+let _cp_snapshot_refresh_interval_s = 120.0
+let _cp_snapshot_timeout_s = 60.0
 
 let compute_cp_snapshot ~state =
   let config = state.Mcp_server.room_config in
@@ -185,10 +170,7 @@ let start_cp_snapshot_refresh_loop ~state ~sw ~clock =
                    ~label:"cp-snapshot"
                    ~interval_s:_cp_snapshot_refresh_interval_s)
                 with timeout_s = _cp_snapshot_timeout_s;
-                     warm_delay_s =
-                       Dashboard_http_helpers.float_of_env_default
-                         "MASC_WARM_DELAY_CP_SNAPSHOT_S"
-                         ~default:90.0 ~min_v:0.0 ~max_v:300.0 }
+                     warm_delay_s = 90.0 }
       ~compute:(fun () -> compute_cp_snapshot ~state)
       ~on_result:store_cp_snapshot
 

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -341,10 +341,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
                  ~label:"operator_snapshot"
                  ~interval_s:_operator_refresh_interval_s)
               with timeout_s = 45.0;
-                   warm_delay_s =
-                     float_of_env_default
-                       "MASC_WARM_DELAY_OPERATOR_SNAPSHOT_S"
-                       ~default:120.0 ~min_v:0.0 ~max_v:300.0 }
+                   warm_delay_s = 120.0 }
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _operator_snapshot_cache json;
@@ -394,10 +391,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
                  ~label:"operator_digest"
                  ~interval_s:_operator_refresh_interval_s)
               with timeout_s = 45.0;
-                   warm_delay_s =
-                     float_of_env_default
-                       "MASC_WARM_DELAY_OPERATOR_DIGEST_S"
-                       ~default:150.0 ~min_v:0.0 ~max_v:300.0 }
+                   warm_delay_s = 150.0 }
     ~compute
     ~on_result:(fun json ->
       mark_cached_surface_success _operator_digest_cache json;
@@ -619,10 +613,7 @@ let start_mission_refresh_loop ~state ~sw ~clock =
   Proactive_refresh.start ~sw ~clock
     ~config:{ (Proactive_refresh.default_config ~label:"mission" ~interval_s:120.0)
               with timeout_s = mission_refresh_timeout_s;
-                   warm_delay_s =
-                     float_of_env_default
-                       "MASC_WARM_DELAY_MISSION_S"
-                       ~default:90.0 ~min_v:0.0 ~max_v:300.0 }
+                   warm_delay_s = 90.0 }
     ~compute
     ~on_result:(mark_cached_surface_success _mission_cache)
 

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -38,15 +38,9 @@ let env_int_or ~name ~default =
   | Some raw -> (
       Option.value ~default:default (int_of_string_opt raw))
 
-let sse_reconnect_min_interval_s =
-  env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:1.0
-  |> Float.max 0.0
-
-let sse_connect_window_s =
-  env_float_or ~name:"MASC_SSE_CONNECT_WINDOW_S" ~default:60.0 |> Float.max 0.0
-
-let sse_connect_max_in_window =
-  env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:10 |> max 0
+let sse_reconnect_min_interval_s = 1.0
+let sse_connect_window_s = 60.0
+let sse_connect_max_in_window = 10
 
 (** Register an SSE connection under [sse_registry_mutex].
     All call sites must use this instead of direct [Hashtbl.replace]. *)

--- a/test/test_command_plane_v2_summary.ml
+++ b/test/test_command_plane_v2_summary.ml
@@ -34,7 +34,7 @@ let test_swarm_proof_fallback_reads_slot_samples_from_bounded_tail () =
       let run_dir = Filename.concat (swarm_live_dir config) "run-001" in
       let slot_samples_path = Filename.concat run_dir "slot-samples.jsonl" in
       let noise_rows =
-        List.init 70 (fun idx ->
+        List.init 2200 (fun idx ->
             make_slot_sample
               ~timestamp:(Printf.sprintf "2026-03-23T00:%02d:00Z" idx)
               ~active_slots:1 ~ctx_per_slot:(2048 + idx))
@@ -53,15 +53,14 @@ let test_swarm_proof_fallback_reads_slot_samples_from_bounded_tail () =
           ]
       in
       write_jsonl_rows slot_samples_path rows;
-      with_env "MASC_CP_SWARM_SLOT_SAMPLE_TAIL_LINES" "64" (fun () ->
-        let json = Command_plane_v2.summary_json config in
-        let swarm_proof = Yojson.Safe.Util.member "swarm_proof" json in
-        Alcotest.(check string) "fallback source" "slot_samples"
-          (swarm_proof |> Yojson.Safe.Util.member "source"
-         |> Yojson.Safe.Util.to_string);
-        Alcotest.(check int) "peak_hot_slots uses recent tail only" 9
-          (swarm_proof |> Yojson.Safe.Util.member "peak_hot_slots"
-         |> Yojson.Safe.Util.to_int);
-        Alcotest.(check int) "ctx_per_slot follows latest tail sample" 32768
-          (swarm_proof |> Yojson.Safe.Util.member "ctx_per_slot"
-         |> Yojson.Safe.Util.to_int)))
+      let json = Command_plane_v2.summary_json config in
+      let swarm_proof = Yojson.Safe.Util.member "swarm_proof" json in
+      Alcotest.(check string) "fallback source" "slot_samples"
+        (swarm_proof |> Yojson.Safe.Util.member "source"
+       |> Yojson.Safe.Util.to_string);
+      Alcotest.(check int) "peak_hot_slots uses recent tail only" 9
+        (swarm_proof |> Yojson.Safe.Util.member "peak_hot_slots"
+       |> Yojson.Safe.Util.to_int);
+      Alcotest.(check int) "ctx_per_slot follows latest tail sample" 32768
+        (swarm_proof |> Yojson.Safe.Util.member "ctx_per_slot"
+       |> Yojson.Safe.Util.to_int))


### PR DESCRIPTION
## Summary

**Phase A-2** of env var audit (continuation of #7268).

16개 undeclared 내부 튜닝 env var를 코드 상수로 변환. 전부 Env_config_snapshot에 선언 안 된 invisible env들이라 운영자 조작 불가능한데도 env 외양만 유지하던 상태.

## 제거된 Env (prefix별)
- \`MASC_CP_*\`: **6** (command-plane refresh interval + timeout)
- \`MASC_WARM_DELAY_*\`: **5** (proactive-refresh warm-up delay)
- \`MASC_SSE_*\`: **3** (SSE reconnect/connect rate limit)
- \`MASC_STIG_*\`: **3** (stigmergy 알고리즘 파라미터)

## 파일 (5)
- \`lib/command_plane/cp_snapshot_summaries.ml\` (1)
- \`lib/level4_config.ml\` (3 STIG)
- \`lib/server/server_command_plane_http_support.ml\` (6 CP + WARM)
- \`lib/server/server_dashboard_http_core.ml\` (3 WARM)
- \`lib/server/server_mcp_transport_http_conn.ml\` (3 SSE)

**Net: -36줄**, 각 env는 기존 default 값으로 대체.

## Phase A 누적 현황

| 단계 | Referenced env vars | Undeclared |
|------|---------------------|-----------|
| 시작 | 471 | 154 |
| A-1 (#7268) | 441 | 124 |
| **A-2 (이 PR)** | **425** | **108** |

## 남은 작업
- A-3: 78 declare (operational tunable → snapshot 추가)
- A-4: 16 review (수동 분류)

## Test plan
- [x] 41 keeper tests pass (29 hallucination gate + 12 github hint)
- [x] \`dune build @all\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)