### PR TITLE
feat(fsm-hub): sticky status bar with backdrop blur

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -968,7 +968,7 @@ function StatusBar({
   const staleSec = lastFetchAt > 0 ? Math.max(0, now - lastFetchAt) : 0
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-4 py-2.5">
+    <div class="sticky top-0 z-20 rounded-xl border border-[var(--white-8)] bg-[var(--panel-dark-60)] backdrop-blur-md px-4 py-2.5 shadow-[0_4px_12px_rgba(0,0,0,0.25)]">
       <div class="flex items-center justify-between gap-3 flex-wrap">
         <div class="flex items-center gap-3">
           <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">FSM Hub</span>


### PR DESCRIPTION
## v14 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

v8~v13 이 대시보드 *컨텐츠* 를 밀도 있게 만든 결과, 스크롤하면 keeper 선택기/liveness 배지가 사라진다. v14 는 StatusBar 를 sticky pin 하고 backdrop blur 를 적용해 orientation 을 유지한다.

## Changes

- StatusBar outer `div` 에 `sticky top-0 z-20` 추가.
- 배경 `bg-[var(--panel-dark-60)]` + `backdrop-blur-md` → 스크롤되는 컨텐츠가 은은하게 비침.
- `shadow-[0_4px_12px_rgba(0,0,0,0.25)]` 로 sticky ↔ 스크롤 컨텐츠 경계 시각화.
- z-20: zone 3b (swimlane focus ring z-index) 와 충돌 없도록 높게.

## Test

- 로직 변경 없음 — vitest 93 files / 626 tests 그대로 pass.
- typecheck: clean. vite build: clean.

## 의도적 한계

- Sticky 동작은 가장 가까운 scrollable ancestor 에 대해 상대적. 페이지 level scroll 이 일반적인 경우라 viewport 에 고정됨.
- `backdrop-blur-md` 는 일부 구형 브라우저 (Safari 9-15) 에서 완전히 지원 안 됨 — fallback 은 반투명 배경만 표시.