### PR TITLE
fix: split active runtime counts from keeper inventory

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -344,7 +344,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     agentsCount: liveRuntimeCounts.agents,
     keepersCount: liveRuntimeCounts.keepers,
     namespaceTruthCounts: namespaceTruth.value?.namespace.counts,
+    namespaceTruthConfiguredKeepers: namespaceTruth.value?.namespace.configured_keepers,
     shellCounts: shellCounts.value,
+    shellConfiguredKeepers: shellCounts.value?.configured_keepers,
   })
   const expectedScopedCount = expectedCountForKeeperFilter(keeperFilter, runtimeCounts)
   const countSourceLabel = runtimeCountSourceLabel(runtimeCounts.source)
@@ -457,6 +459,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     : keeperFilter === 'agent-only'
       ? `일반 에이전트 ${expectedScopedCount}개`
       : `에이전트/키퍼 ${expectedScopedCount}개`
+  const configuredKeeperHint =
+    keeperFilter === 'agent-only' || runtimeCounts.configuredKeepers <= 0
+      ? null
+      : `설정된 keeper ${runtimeCounts.configuredKeepers}개`
   const fallbackStateTitle =
     executionError.value
       ? '상세 상태 불러오기 실패'
@@ -467,8 +473,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     executionError.value
       ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있지만 상세 상태 정보를 아직 가져오지 못했습니다.`
       : executionLoaded.value
-        ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있고 일부만 상세 목록에 반영됐습니다.`
-        : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다. 상세 상태 정보가 올라오면 상태별 분류와 카드가 채워집니다.`
+        ? `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있고 일부만 상세 목록에 반영됐습니다.${configuredKeeperHint ? ` ${configuredKeeperHint}.` : ''}`
+        : `${countSourceLabel} 기준 ${scopeLabel}가 등록되어 있습니다.${configuredKeeperHint ? ` ${configuredKeeperHint}.` : ''} 상세 상태 정보가 올라오면 상태별 분류와 카드가 채워집니다.`
 
   return html`
     <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
@@ -524,6 +530,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-body)]">${fallbackStateMessage}</p>
                     <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
                       <span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">scope ${namespaceName}</span>
+                      ${configuredKeeperHint ? html`<span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">${configuredKeeperHint}</span>` : null}
                       ${namespaceBasePath ? html`<code class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px]">${namespaceBasePath}</code>` : null}
                     </div>
                   </div>

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -49,7 +49,9 @@ export function AgentsUnified() {
     agentsCount: liveRuntimeCounts.agents,
     keepersCount: liveRuntimeCounts.keepers,
     namespaceTruthCounts: namespaceTruth.value?.namespace.counts,
+    namespaceTruthConfiguredKeepers: namespaceTruth.value?.namespace.configured_keepers,
     shellCounts: shellCounts.value,
+    shellConfiguredKeepers: shellCounts.value?.configured_keepers,
   })
   const totalCount = runtimeCounts.totalRuntimes
   const keeperCount = runtimeCounts.keepers

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -143,8 +143,10 @@ export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthRe
             agents: asNumber(namespaceBlock.counts.agents),
             tasks: asNumber(namespaceBlock.counts.tasks),
             keepers: asNumber(namespaceBlock.counts.keepers),
+            total_runtimes: asNumber(namespaceBlock.counts.total_runtimes),
           }
         : undefined,
+      configured_keepers: asNumber(namespaceBlock.configured_keepers),
       provenance: asString(namespaceBlock.provenance) ?? null,
     },
     execution: {

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -12,12 +12,14 @@ describe('resolveRuntimeCounts', () => {
       agentsCount: 0,
       keepersCount: 0,
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
+      namespaceTruthConfiguredKeepers: 5,
       shellCounts: { agents: 1, keepers: 1, tasks: 4 },
     })).toEqual({
       agents: 2,
       keepers: 3,
       tasks: 12,
       totalRuntimes: 5,
+      configuredKeepers: 5,
       source: 'namespace-truth',
     })
   })
@@ -28,11 +30,13 @@ describe('resolveRuntimeCounts', () => {
       agentsCount: 0,
       keepersCount: 0,
       shellCounts: { agents: 4, keepers: 1, tasks: 9 },
+      shellConfiguredKeepers: 3,
     })).toEqual({
       agents: 4,
       keepers: 1,
       tasks: 9,
       totalRuntimes: 5,
+      configuredKeepers: 3,
       source: 'shell',
     })
   })
@@ -44,11 +48,13 @@ describe('resolveRuntimeCounts', () => {
       keepersCount: 3,
       tasksCount: 1,
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
+      namespaceTruthConfiguredKeepers: 5,
     })).toEqual({
       agents: 2,
       keepers: 3,
       tasks: 1,
       totalRuntimes: 5,
+      configuredKeepers: 5,
       source: 'execution',
     })
   })
@@ -59,11 +65,13 @@ describe('resolveRuntimeCounts', () => {
       agentsCount: 0,
       keepersCount: 0,
       namespaceTruthCounts: { agents: 2, keepers: 3, tasks: 12 },
+      namespaceTruthConfiguredKeepers: 4,
     })).toEqual({
       agents: 2,
       keepers: 3,
       tasks: 12,
       totalRuntimes: 5,
+      configuredKeepers: 4,
       source: 'namespace-truth',
     })
   })

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -12,6 +12,7 @@ export interface RuntimeCounts {
   keepers: number
   tasks: number
   totalRuntimes: number
+  configuredKeepers: number
   source: RuntimeCountSource
 }
 
@@ -21,7 +22,9 @@ interface ResolveRuntimeCountsOptions {
   keepersCount: number
   tasksCount?: number
   namespaceTruthCounts?: DashboardNamespaceTruthResponse['namespace']['counts']
+  namespaceTruthConfiguredKeepers?: number
   shellCounts?: DashboardShellResponse['counts'] | null
+  shellConfiguredKeepers?: number
 }
 
 function normalizeCount(value: unknown): number {
@@ -38,6 +41,10 @@ function normalizeCounts(
     agents: normalizeCount(raw.agents),
     keepers: normalizeCount(raw.keepers),
     tasks: normalizeCount(raw.tasks),
+    totalRuntimes:
+      typeof raw.total_runtimes === 'number' && Number.isFinite(raw.total_runtimes)
+        ? Math.max(0, Math.floor(raw.total_runtimes))
+        : normalizeCount(raw.agents) + normalizeCount(raw.keepers),
   }
 }
 
@@ -47,7 +54,9 @@ export function resolveRuntimeCounts({
   keepersCount,
   tasksCount = 0,
   namespaceTruthCounts,
+  namespaceTruthConfiguredKeepers,
   shellCounts,
+  shellConfiguredKeepers,
 }: ResolveRuntimeCountsOptions): RuntimeCounts {
   const live = {
     agents: normalizeCount(agentsCount),
@@ -57,13 +66,20 @@ export function resolveRuntimeCounts({
   const namespace = normalizeCounts(namespaceTruthCounts)
   const shell = normalizeCounts(shellCounts)
   const liveTotalRuntimes = live.agents + live.keepers
-  const namespaceTotalRuntimes = (namespace?.agents ?? 0) + (namespace?.keepers ?? 0)
-  const shellTotalRuntimes = (shell?.agents ?? 0) + (shell?.keepers ?? 0)
+  const namespaceTotalRuntimes = namespace?.totalRuntimes ?? 0
+  const shellTotalRuntimes = shell?.totalRuntimes ?? 0
+  const configuredKeepers =
+    namespaceTruthConfiguredKeepers != null
+      ? normalizeCount(namespaceTruthConfiguredKeepers)
+      : shellConfiguredKeepers != null
+        ? normalizeCount(shellConfiguredKeepers)
+        : live.keepers
 
   if (executionLoaded && (liveTotalRuntimes > 0 || (namespaceTotalRuntimes === 0 && shellTotalRuntimes === 0))) {
     return {
       ...live,
       totalRuntimes: liveTotalRuntimes,
+      configuredKeepers,
       source: 'execution',
     }
   }
@@ -72,6 +88,7 @@ export function resolveRuntimeCounts({
     return {
       ...namespace!,
       totalRuntimes: namespaceTotalRuntimes,
+      configuredKeepers,
       source: 'namespace-truth',
     }
   }
@@ -80,6 +97,7 @@ export function resolveRuntimeCounts({
     return {
       ...shell!,
       totalRuntimes: shellTotalRuntimes,
+      configuredKeepers,
       source: 'shell',
     }
   }
@@ -88,6 +106,7 @@ export function resolveRuntimeCounts({
     return {
       ...live,
       totalRuntimes: liveTotalRuntimes,
+      configuredKeepers,
       source: executionLoaded ? 'execution' : 'partial',
     }
   }
@@ -95,6 +114,7 @@ export function resolveRuntimeCounts({
   return {
     ...live,
     totalRuntimes: liveTotalRuntimes,
+    configuredKeepers,
     source: executionLoaded ? 'execution' : 'unknown',
   }
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -64,6 +64,8 @@ export interface ShellCounts {
   agents: number
   tasks: number
   keepers: number
+  total_runtimes: number
+  configured_keepers: number
 }
 
 export const shellCounts = signal<ShellCounts | null>(null)
@@ -394,6 +396,8 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
           agents: data.counts.agents ?? 0,
           tasks: data.counts.tasks ?? 0,
           keepers: data.counts.keepers ?? 0,
+          total_runtimes: data.counts.total_runtimes ?? ((data.counts.agents ?? 0) + (data.counts.keepers ?? 0)),
+          configured_keepers: data.configured_keepers ?? 0,
         }
       }
       shellMetaCognition.value = normalizeShellMetaCognitionSummary(data.meta_cognition)

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -97,7 +97,9 @@ export interface DashboardShellResponse {
     agents?: number
     tasks?: number
     keepers?: number
+    total_runtimes?: number
   }
+  configured_keepers?: number
   providers?: Record<string, unknown>
   meta_cognition?: DashboardShellMetaCognitionSummary | null
   auth?: DashboardShellAuthSummary | null
@@ -153,6 +155,7 @@ export interface DashboardNamespaceTruthResponse {
   namespace: {
     status?: ServerStatus | null
     counts?: DashboardShellResponse['counts']
+    configured_keepers?: number
     provenance?: string | null
   }
   execution?: {

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -75,6 +75,15 @@ let keeper_names (config : Room.config) =
 let keeper_count (config : Room.config) : int =
   List.length (keeper_names config)
 
+let running_keeper_count (config : Room.config) : int =
+  keeper_names config
+  |> List.fold_left
+       (fun count name ->
+         match Keeper_types.read_meta config name with
+         | Ok (Some meta) when runtime_keepalive_running config meta -> count + 1
+         | _ -> count)
+       0
+
 let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Safe.t =
   let include_goals = bool_of_env "MASC_DASHBOARD_INCLUDE_GOALS" in
   let history_fragment_filter_enabled =

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -891,7 +891,10 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
   let agents, agents_ms = measure_ms (fun () -> dashboard_agents_safe config) in
   let general_agents = dashboard_general_agent_count agents in
   let tasks, tasks_ms = measure_ms (fun () -> dashboard_tasks_safe config) in
-  let keepers_total, keepers_ms =
+  let active_keepers, keepers_ms =
+    measure_ms (fun () -> running_keeper_count config)
+  in
+  let configured_keepers, configured_keepers_ms =
     measure_ms (fun () -> keeper_count config)
   in
   let meta_cognition_json, meta_cognition_ms =
@@ -915,8 +918,10 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
           [
             ("agents", `Int general_agents);
             ("tasks", `Int (List.length tasks));
-            ("keepers", `Int keepers_total);
+            ("keepers", `Int active_keepers);
+            ("total_runtimes", `Int (general_agents + active_keepers));
           ] );
+      ("configured_keepers", `Int configured_keepers);
       ("providers", provider_capacity_json ());
       ("meta_cognition", meta_cognition_json);
       ("config_resolution", config_resolution_json);
@@ -928,11 +933,13 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
            ("cluster", `String cluster);
            ("coordination_root", `String config.base_path);
            ("workspace_path", `String config.workspace_path);
-           ("keeper_count_source", `String "keeper_meta");
+           ("keeper_count_source", `String "runtime_keepalive");
+           ("configured_keeper_count_source", `String "keeper_meta");
            ("status_ms", `Int status_ms);
            ("agents_ms", `Int agents_ms);
            ("tasks_ms", `Int tasks_ms);
            ("keepers_ms", `Int keepers_ms);
+           ("configured_keepers_ms", `Int configured_keepers_ms);
            ("meta_cognition_ms", `Int meta_cognition_ms);
            ("config_resolution_ms", `Int config_resolution_ms);
            ("runtime_resolution_ms", `Int runtime_resolution_ms);

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -362,9 +362,14 @@ let compose_namespace_truth_snapshot ~(config : Room.config) ~initialized ~shell
   let execution_summary = execution_summary_json execution_json in
   let command_summary = namespace_truth_command_summary_json command_summary_json in
   let shell_counts = json_assoc_field "counts" shell_json in
+  let configured_keepers =
+    Yojson.Safe.Util.member "configured_keepers" shell_json
+  in
   let runtime_count =
-    json_int_field "agents" shell_counts ~default:0
-    + json_int_field "keepers" shell_counts ~default:0
+    json_int_field "total_runtimes" shell_counts
+      ~default:
+        ( json_int_field "agents" shell_counts ~default:0
+        + json_int_field "keepers" shell_counts ~default:0 )
   in
   let focus_json =
     dashboard_namespace_truth_focus_json ~initialized ~runtime_count
@@ -375,6 +380,7 @@ let compose_namespace_truth_snapshot ~(config : Room.config) ~initialized ~shell
       [
         ("status", json_assoc_field "status" shell_json);
         ("counts", json_assoc_field "counts" shell_json);
+        ("configured_keepers", configured_keepers);
         ("provenance", `String "truth");
       ]
   in

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -390,7 +390,7 @@ let create_keeper env sw config name =
   | Some (false, err) -> fail err
   | None -> fail "missing masc_keeper_up dispatch"
 
-let test_dashboard_shell_counts_keepers () =
+let test_dashboard_shell_splits_active_and_configured_keepers () =
   let dir = test_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
@@ -412,8 +412,10 @@ let test_dashboard_shell_counts_keepers () =
             let json = Lib.Server_dashboard_http.dashboard_shell_http_json config in
             let open Yojson.Safe.Util in
             let counts = json |> member "counts" in
-            check int "shell keeper count from keeper meta" 2
-              (counts |> member "keepers" |> to_int))))
+            check int "shell active keeper count uses runtime" 0
+              (counts |> member "keepers" |> to_int);
+            check int "shell configured keeper inventory stays visible" 2
+              (json |> member "configured_keepers" |> to_int))))
 
 let test_dashboard_shell_excludes_keeper_agents_from_general_count () =
   let dir = test_dir () in
@@ -442,8 +444,10 @@ let test_dashboard_shell_excludes_keeper_agents_from_general_count () =
             let counts = json |> member "counts" in
             check int "keeper-backed room has no general agents" 0
               (counts |> member "agents" |> to_int);
-            check int "keeper still counted" 1
-              (counts |> member "keepers" |> to_int))))
+            check int "stopped keeper is not counted as active" 0
+              (counts |> member "keepers" |> to_int);
+            check int "configured keeper inventory remains visible" 1
+              (json |> member "configured_keepers" |> to_int))))
 
 let test_dashboard_execution_fresh_join_not_marked_stale () =
   let dir = test_dir () in
@@ -593,8 +597,8 @@ let () =
             test_dashboard_shell_surfaces_workspace_when_different;
           Alcotest.test_case "shell includes meta cognition summary" `Quick
             test_dashboard_shell_includes_meta_cognition_summary;
-          Alcotest.test_case "shell counts keepers cheaply" `Quick
-            test_dashboard_shell_counts_keepers;
+          Alcotest.test_case "shell splits active and configured keepers" `Quick
+            test_dashboard_shell_splits_active_and_configured_keepers;
           Alcotest.test_case "shell excludes keeper agents from general count" `Quick
             test_dashboard_shell_excludes_keeper_agents_from_general_count;
           Alcotest.test_case "fresh join is not stale" `Quick

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -151,6 +151,12 @@ let test_dashboard_namespace_truth_empty_room () =
         check int "pending confirms zero"
           0
           (json |> member "operator" |> member "pending_confirm_summary" |> member "total_count" |> to_int);
+        check int "configured keepers default to zero"
+          0
+          (json |> member "namespace" |> member "configured_keepers" |> to_int);
+        check int "namespace counts expose total runtimes"
+          0
+          (json |> member "namespace" |> member "counts" |> member "total_runtimes" |> to_int);
         check string "focus source"
           "namespace"
           (json |> member "focus" |> member "source" |> to_string);


### PR DESCRIPTION
## Summary
- expose active keeper/runtime counts separately from configured keeper inventory in dashboard shell and namespace-truth
- update runtime count consumers so the dashboard reads active truth from counts and inventory from configured_keepers
- add OCaml and dashboard tests for the split semantics

## Product impact
- dashboard runtime totals now distinguish active keepers from configured keeper inventory
- roster and namespace-truth views stop mixing inventory counts into active runtime truth
- operator-facing count copy can explain both active runtime load and configured keeper inventory

## Evidence
- server shell and namespace-truth payloads expose `configured_keepers` separately from active `counts`
- dashboard runtime-count consumers now read active truth and inventory from distinct fields
- OCaml regression tests cover stopped keepers remaining in inventory but dropping out of active counts

## Review evidence
- pnpm typecheck
- pnpm exec vitest run src/runtime-counts.test.ts src/components/agent-roster.test.ts
- opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-runtime-count-truth-split
- ./_build/default/test/test_dashboard_execution.exe
- ./_build/default/test/test_dashboard_namespace_truth.exe

## Linked issue
- Refs #7278

## Tests
- pnpm typecheck
- pnpm exec vitest run src/runtime-counts.test.ts src/components/agent-roster.test.ts
- opam exec -- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-runtime-count-truth-split
- ./_build/default/test/test_dashboard_execution.exe
- ./_build/default/test/test_dashboard_namespace_truth.exe