### PR TITLE
feat(fsm-hub): tone-driven panel accent for operator meaning

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1041,6 +1041,18 @@ const INSIGHT_BADGE_CLS: Record<InsightTone, string> = {
   error: 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]',
 }
 
+/** Panel-level accent — border + subtle tinted overlay — so that the
+    overall tone of the current operator insight is visible from the
+    peripheral visual field. Neutral tones (ok/info) keep the default
+    muted panel frame; warn/error lift the full panel so urgent state
+    does not require reading the small top-right badge. */
+const INSIGHT_PANEL_CLS: Record<InsightTone, string> = {
+  ok: 'border-[var(--white-8)] bg-[var(--white-2)]',
+  info: 'border-[var(--white-8)] bg-[var(--white-2)]',
+  warn: 'border-[rgba(245,158,11,0.45)] bg-[rgba(245,158,11,0.04)] shadow-[0_0_0_1px_rgba(245,158,11,0.15)_inset]',
+  error: 'border-[rgba(239,68,68,0.55)] bg-[rgba(239,68,68,0.05)] shadow-[0_0_0_1px_rgba(239,68,68,0.2)_inset]',
+}
+
 function OperationalMeaningPanel({
   snapshot,
   observations,
@@ -1052,9 +1064,15 @@ function OperationalMeaningPanel({
 }) {
   const insight = deriveOperationalInsight(snapshot, observations, now)
   const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
+  const panelCls = INSIGHT_PANEL_CLS[insight.tone]
+  const isAlarm = insight.tone === 'warn' || insight.tone === 'error'
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+    <div
+      class=${`rounded-xl border p-4 transition-colors duration-300 ${panelCls}`}
+      role=${isAlarm ? 'alert' : undefined}
+      aria-live=${isAlarm ? 'polite' : undefined}
+    >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
           <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>


### PR DESCRIPTION
## v15 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

OperationalMeaningPanel 은 세션 8 iteration 동안 내용이 풍부해졌지만 *톤 urgency* 는 우상단 chip 하나에만 의존했다. v15 는 panel 전체 경계 + 배경 tint + 인셋 shadow 로 확장 — 주변시 로도 warn/error 를 감지.

## Changes

- `INSIGHT_PANEL_CLS` 맵: `ok/info` (중립) / `warn` (amber) / `error` (red).
- panel outer `<div>` 가 `INSIGHT_PANEL_CLS[insight.tone]` 적용 + `transition-colors duration-300`.
- warn/error 상태에서 `role="alert" aria-live="polite"` → 스크린리더 톤 변경 알림.
- `ok/info` 는 alert role 없음 — 노이즈 방지.

## Test

- 로직 변경 없음 — vitest 93 files / 626 tests 그대로 pass.
- typecheck: clean. vite build: clean.

## 의도적 한계

- tone 이 ok→warn→error 로 escalation 할 때 전환이 부드럽도록 `duration-300` 적용. 역방향 (error→ok) 도 동일.
- `shadow-[...]` 인라인은 tailwind 임의값 — JIT 이 인식하지만 purge 설정에 따라 주의 필요 (프로젝트 default는 안전).