### PR TITLE
feat: rehydrate OAS runtime from durable telemetry

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -5,11 +5,17 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { route, initRouter } from './router'
-import { connectSSE, disconnectSSE } from './sse'
+import {
+  connectSSE,
+  disconnectSSE,
+  pauseQueuedOasRuntimeIngress,
+  resumeQueuedOasRuntimeIngress,
+} from './sse'
 import { requestNamespaceTruthNow, disposeNamespaceTruthScheduler } from './namespace-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshForRoute } from './tab-refresh'
 import { refreshMissionSnapshot } from './mission-store'
+import { replayOasRuntimeTelemetry } from './oas-runtime-store'
 import { refreshShell } from './store'
 import {
   BuildIdentityBadge,
@@ -32,16 +38,27 @@ export const mobileMenuOpen = signal(false)
 
 export function App() {
   useEffect(() => {
+    let cancelled = false
+
     // Initialize hash router and compatible deep links
     initRouter()
-
-    // Connect SSE and start data fetching
-    connectSSE()
 
     // Prime the lightweight shell status first so build/version metadata lands
     // while namespace-truth warms heavier execution/command projections.
     void refreshShell()
     requestNamespaceTruthNow()
+
+    // Replay durable OAS state before opening the live SSE tail.
+    pauseQueuedOasRuntimeIngress()
+    void replayOasRuntimeTelemetry()
+      .catch(err => {
+        console.warn('[app] OAS runtime replay failed', err instanceof Error ? err.message : err)
+      })
+      .finally(() => {
+        if (cancelled) return
+        connectSSE()
+        resumeQueuedOasRuntimeIngress()
+      })
 
     // Register mission refresh for periodic recovery from transient failures.
     // Uses registration pattern to avoid circular imports.
@@ -54,6 +71,7 @@ export function App() {
     startPeriodicRefresh()
 
     return () => {
+      cancelled = true
       disconnectSSE()
       unsubSSE()
       stopPeriodicRefresh()

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -72,7 +72,7 @@ export function OasHealthChip() {
         <${StatCell}
           label="총 이벤트"
           value=${summary.value.totalEvents}
-          detail="live tracked"
+          detail="durable replay + live"
         />
         <${StatCell}
           label="LLM 호출"

--- a/dashboard/src/config/constants.ts
+++ b/dashboard/src/config/constants.ts
@@ -59,6 +59,7 @@ export const KEEPER_REPLY_PREVIEW_MAX = 200
 export const MAX_JOURNAL_ENTRIES = 200
 export const OAS_AGENT_EVENT_BUFFER = 50
 export const OAS_KEEPER_SNAPSHOT_MAX = 20
+export const OAS_TELEMETRY_REPLAY_LIMIT = 500
 
 // --- Text truncation (characters) ---
 export const TRIM_TEXT_DEFAULT = 120

--- a/dashboard/src/oas-runtime-store.test.ts
+++ b/dashboard/src/oas-runtime-store.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./api/dashboard', () => ({
+  fetchTelemetry: vi.fn(),
+}))
+
+import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
+import {
+  applyOasRuntimeEvent,
+  hydrateOasRuntimeFromTelemetryEntries,
+  replayOasRuntimeTelemetry,
+} from './oas-runtime-store'
+import {
+  oasAgentEvents,
+  oasHealthSummary,
+  oasKeeperSnapshots,
+} from './store'
+
+const fetchTelemetryMock = vi.mocked(fetchTelemetry)
+
+function resetRuntimeState() {
+  hydrateOasRuntimeFromTelemetryEntries([])
+}
+
+describe('oas-runtime-store', () => {
+  beforeEach(() => {
+    fetchTelemetryMock.mockReset()
+    resetRuntimeState()
+  })
+
+  it('hydrates durable telemetry into one OAS runtime summary', () => {
+    const entries: TelemetryEntry[] = [
+      {
+        source: 'oas_event',
+        type: 'oas:durable:error_occurred',
+        ts_unix: 400,
+        correlation_id: 'corr-4',
+        run_id: 'run-1',
+        payload: {
+          agent_name: 'alpha',
+          error_domain: 'tool',
+          detail: 'timeout',
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:durable:llm_request',
+        ts_unix: 300,
+        correlation_id: 'corr-3',
+        run_id: 'run-1',
+        payload: {
+          agent_name: 'alpha',
+          model: 'gpt-5',
+          input_tokens: 64,
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:masc:keeper:snapshot',
+        ts_unix: 200,
+        correlation_id: 'corr-2',
+        run_id: 'run-1',
+        payload: {
+          keeper_name: 'keeper-a',
+          generation: 3,
+          context_ratio: 0.42,
+          message_count: 9,
+          timestamp: 200,
+        },
+      },
+      {
+        source: 'oas_event',
+        type: 'oas:masc:autonomy:agent_selected',
+        ts_unix: 100,
+        correlation_id: 'corr-1',
+        run_id: 'run-1',
+        payload: {
+          agent_name: 'alpha',
+          trigger: 'thompson',
+          timestamp: 100,
+        },
+      },
+    ] as TelemetryEntry[]
+
+    hydrateOasRuntimeFromTelemetryEntries(entries)
+
+    expect(oasHealthSummary.value.totalEvents).toBe(4)
+    expect(oasHealthSummary.value.agentEventsCount).toBe(1)
+    expect(oasHealthSummary.value.keeperSnapshotsCount).toBe(1)
+    expect(oasHealthSummary.value.totalLlmCalls).toBe(1)
+    expect(oasHealthSummary.value.totalErrors).toBe(1)
+    expect(oasHealthSummary.value.lastKeeperTick).toBe(200_000)
+    expect(oasHealthSummary.value.lastLlmCallTs).toBe(300_000)
+    expect(oasHealthSummary.value.lastErrorTs).toBe(400_000)
+    expect(oasAgentEvents.value[0]?.agent_name).toBe('alpha')
+    expect(oasKeeperSnapshots.value.get('keeper-a')?.generation).toBe(3)
+  })
+
+  it('dedupes a live event already present in replayed telemetry', () => {
+    const liveEvent = {
+      type: 'oas:masc:autonomy:agent_selected',
+      ts_unix: 123,
+      correlation_id: 'corr-live',
+      run_id: 'run-live',
+      payload: {
+        agent_name: 'beta',
+        trigger: 'thompson',
+        timestamp: 123,
+      },
+    }
+
+    hydrateOasRuntimeFromTelemetryEntries([
+      {
+        source: 'oas_event',
+        ...liveEvent,
+      } as TelemetryEntry,
+    ])
+
+    expect(applyOasRuntimeEvent(liveEvent)).toBe(false)
+    expect(oasHealthSummary.value.totalEvents).toBe(1)
+    expect(oasHealthSummary.value.agentEventsCount).toBe(1)
+  })
+
+  it('replays recent OAS telemetry via the dashboard API', async () => {
+    fetchTelemetryMock.mockResolvedValue({
+      generated_at: '2026-04-15T12:00:00Z',
+      count: 1,
+      entries: [
+        {
+          source: 'oas_event',
+          type: 'oas:masc:reputation_changed',
+          ts_unix: 555,
+          correlation_id: 'corr-r',
+          run_id: 'run-r',
+          payload: {
+            agent_name: 'gamma',
+            old_score: 0.4,
+            new_score: 0.8,
+            trend: 'up',
+            timestamp: 555,
+          },
+        } as TelemetryEntry,
+      ],
+    })
+
+    await replayOasRuntimeTelemetry()
+
+    expect(fetchTelemetryMock).toHaveBeenCalledWith({
+      source: 'oas_event',
+      n: 500,
+      signal: undefined,
+    })
+    expect(oasHealthSummary.value.totalEvents).toBe(1)
+    expect(oasAgentEvents.value[0]?.type).toBe('reputation_changed')
+  })
+})

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -1,0 +1,426 @@
+import { appendLiveOasEvent } from './components/session-trace/session-trace-state'
+import { isRecord, asNumber, asString } from './components/common/normalize'
+import { fetchTelemetry, type TelemetryEntry } from './api/dashboard'
+import { OAS_TELEMETRY_REPLAY_LIMIT } from './config/constants'
+import {
+  oasTotalEvents,
+  pushOasAgentEvent,
+  recordOasError,
+  recordOasLlmCall,
+  resetOasRuntimeSignals,
+  updateOasKeeperSnapshot,
+} from './store'
+import type { OasAgentEvent, OasKeeperSnapshot } from './types/oas'
+
+type OasRuntimeEnvelope = Record<string, unknown> & {
+  type: string
+  payload: Record<string, unknown>
+}
+
+type IngestOptions = {
+  includeLiveTrace?: boolean
+}
+
+const seenOasEventKeys = new Set<string>()
+let replayGeneration = 0
+
+function eventPayload(event: OasRuntimeEnvelope): Record<string, unknown> {
+  return isRecord(event.payload) ? event.payload : {}
+}
+
+function eventUnixSeconds(event: OasRuntimeEnvelope): number {
+  return (
+    asNumber(event.ts_unix)
+    ?? asNumber(event.timestamp)
+    ?? asNumber(event.ts)
+    ?? Date.now() / 1000
+  )
+}
+
+function eventTimestampMs(event: OasRuntimeEnvelope): number {
+  return Math.round(eventUnixSeconds(event) * 1000)
+}
+
+function runtimeEventType(event: OasRuntimeEnvelope): string {
+  return asString(event.event_type) ?? event.type
+}
+
+function runtimeEventKey(event: OasRuntimeEnvelope): string {
+  const payload = eventPayload(event)
+  const type = runtimeEventType(event)
+  const correlationId = asString(event.correlation_id)
+  const runId = asString(event.run_id)
+  const tsUnix = eventUnixSeconds(event)
+  const agentName =
+    asString(event.agent_name)
+    ?? asString(payload.agent_name)
+    ?? asString(payload.agent)
+    ?? asString(payload.keeper_name)
+    ?? ''
+  const taskId = asString(event.task_id) ?? asString(payload.task_id) ?? ''
+  const toolName = asString(event.tool_name) ?? asString(payload.tool_name) ?? ''
+  const turn = asNumber(event.turn) ?? asNumber(payload.turn)
+  if (correlationId || runId || Number.isFinite(tsUnix)) {
+    return [
+      type,
+      agentName,
+      correlationId ?? '',
+      runId ?? '',
+      Number.isFinite(tsUnix) ? String(tsUnix) : '',
+      taskId,
+      toolName,
+      turn != null ? String(turn) : '',
+    ].join('|')
+  }
+  return JSON.stringify({
+    type,
+    agentName,
+    taskId,
+    toolName,
+    turn: turn ?? null,
+    payload,
+  })
+}
+
+function traceDetail(
+  event: OasRuntimeEnvelope,
+  detail: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    event_type: runtimeEventType(event),
+    correlation_id: asString(event.correlation_id) ?? null,
+    run_id: asString(event.run_id) ?? null,
+    ts_unix: eventUnixSeconds(event),
+    ...detail,
+  }
+}
+
+function agentNameFromEnvelope(event: OasRuntimeEnvelope): string {
+  const payload = eventPayload(event)
+  return (
+    asString(payload.agent_name)
+    ?? asString(event.agent_name)
+    ?? asString(payload.agent)
+    ?? ''
+  )
+}
+
+function keeperLifecycleEvent(event: OasRuntimeEnvelope): OasAgentEvent {
+  const payload = eventPayload(event)
+  const keeperName = asString(payload.keeper_name)
+  const actorName = keeperName ?? asString(payload.agent_name) ?? ''
+  return {
+    type: 'keeper_lifecycle',
+    agent_name: actorName,
+    actor_kind: 'keeper',
+    keeper_name: keeperName,
+    event: asString(payload.event),
+    detail: asString(payload.detail),
+    event_type: runtimeEventType(event),
+    correlation_id: asString(event.correlation_id),
+    run_id: asString(event.run_id),
+    event_key: runtimeEventKey(event),
+    timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+  }
+}
+
+function maybeAppendLiveTrace(
+  agentName: string,
+  event: OasRuntimeEnvelope,
+  detail: {
+    idSuffix: string
+    kind: 'lifecycle' | 'oas_tool' | 'oas_turn' | 'oas_context'
+    summary: string
+    data: Record<string, unknown>
+    toolName?: string
+    turn?: number
+    durationMs?: number
+    error?: string
+    costUsd?: number
+  },
+): void {
+  if (!agentName) return
+  const tsMs = eventTimestampMs(event)
+  appendLiveOasEvent(agentName, {
+    id: `${runtimeEventKey(event)}|${detail.idSuffix}`,
+    ts: tsMs,
+    ts_iso: new Date(tsMs).toISOString(),
+    kind: detail.kind,
+    summary: detail.summary,
+    detail: traceDetail(event, detail.data),
+    toolName: detail.toolName,
+    turn: detail.turn,
+    duration_ms: detail.durationMs,
+    error: detail.error,
+    cost_usd: detail.costUsd,
+  })
+}
+
+function ingestRuntimeProjection(
+  event: OasRuntimeEnvelope,
+  opts?: IngestOptions,
+): void {
+  const payload = eventPayload(event)
+  const agentName = agentNameFromEnvelope(event)
+  switch (event.type) {
+    case 'oas:masc:autonomy:agent_selected':
+      pushOasAgentEvent({
+        type: 'selected',
+        agent_name: agentName,
+        actor_kind: 'agent',
+        trigger: asString(payload.trigger),
+        thompson_score: asNumber(payload.thompson_score),
+        final_score: asNumber(payload.final_score),
+        event_type: runtimeEventType(event),
+        correlation_id: asString(event.correlation_id),
+        run_id: asString(event.run_id),
+        event_key: runtimeEventKey(event),
+        timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+      })
+      return
+    case 'oas:masc:autonomy:agent_decision':
+      pushOasAgentEvent({
+        type: 'decision',
+        agent_name: agentName,
+        actor_kind: 'agent',
+        action: asString(payload.action),
+        trigger_reason: asString(payload.trigger_reason),
+        event_type: runtimeEventType(event),
+        correlation_id: asString(event.correlation_id),
+        run_id: asString(event.run_id),
+        event_key: runtimeEventKey(event),
+        timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+      })
+      return
+    case 'oas:masc:autonomy:agent_action_executed':
+      pushOasAgentEvent({
+        type: 'action_executed',
+        agent_name: agentName,
+        actor_kind: 'agent',
+        action: asString(payload.action),
+        success: typeof payload.success === 'boolean' ? payload.success : undefined,
+        event_type: runtimeEventType(event),
+        correlation_id: asString(event.correlation_id),
+        run_id: asString(event.run_id),
+        event_key: runtimeEventKey(event),
+        timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+      })
+      return
+    case 'oas:masc:keeper:snapshot':
+      updateOasKeeperSnapshot({
+        keeper_name: asString(payload.keeper_name) ?? '',
+        generation: asNumber(payload.generation, 0),
+        context_ratio: asNumber(payload.context_ratio, 0),
+        message_count: asNumber(payload.message_count, 0),
+        timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+      } satisfies OasKeeperSnapshot)
+      return
+    case 'oas:masc:keeper:lifecycle':
+      pushOasAgentEvent(keeperLifecycleEvent(event))
+      return
+    case 'oas:masc:trust_updated':
+      pushOasAgentEvent({
+        type: 'trust_updated',
+        agent_name: asString(payload.agent_a) ?? '',
+        actor_kind: 'agent',
+        secondary_agent: asString(payload.agent_b),
+        trust_score: asNumber(payload.trust_score),
+        event_type: runtimeEventType(event),
+        correlation_id: asString(event.correlation_id),
+        run_id: asString(event.run_id),
+        event_key: runtimeEventKey(event),
+        timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+      })
+      return
+    case 'oas:masc:reputation_changed':
+      pushOasAgentEvent({
+        type: 'reputation_changed',
+        agent_name: agentName,
+        actor_kind: 'agent',
+        old_score: asNumber(payload.old_score),
+        new_score: asNumber(payload.new_score),
+        trend: asString(payload.trend),
+        event_type: runtimeEventType(event),
+        correlation_id: asString(event.correlation_id),
+        run_id: asString(event.run_id),
+        event_key: runtimeEventKey(event),
+        timestamp: asNumber(payload.timestamp) ?? eventUnixSeconds(event),
+      })
+      return
+    case 'oas:agent_started':
+    case 'oas:agent_completed':
+      if (opts?.includeLiveTrace) {
+        const phase = event.type === 'oas:agent_started' ? 'started' : 'completed'
+        const inputTokens = asNumber(payload.input_tokens)
+        const outputTokens = asNumber(payload.output_tokens)
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: phase,
+          kind: 'lifecycle',
+          summary: `agent ${phase}${inputTokens != null || outputTokens != null ? ` · ${inputTokens ?? 0}→${outputTokens ?? 0}tok` : ''}`,
+          data: {
+            task_id: asString(payload.task_id) ?? null,
+            elapsed_s: asNumber(payload.elapsed_s) ?? null,
+            input_tokens: inputTokens ?? null,
+            output_tokens: outputTokens ?? null,
+          },
+          costUsd: asNumber(payload.cost_usd) ?? undefined,
+        })
+      }
+      return
+    case 'oas:tool_called':
+    case 'oas:tool_completed':
+      if (opts?.includeLiveTrace) {
+        const phase = event.type === 'oas:tool_called' ? 'called' : 'completed'
+        const toolName = asString(payload.tool_name) ?? 'unknown'
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: `${phase}|${toolName}`,
+          kind: 'oas_tool',
+          summary: `${phase} ${toolName}`,
+          data: { phase, tool_name: toolName },
+          toolName,
+        })
+      }
+      return
+    case 'oas:turn_started':
+    case 'oas:turn_completed':
+      if (opts?.includeLiveTrace) {
+        const phase = event.type === 'oas:turn_started' ? 'started' : 'completed'
+        const turn = asNumber(payload.turn)
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: `${phase}|${turn ?? 'na'}`,
+          kind: 'oas_turn',
+          summary: `${phase} turn${turn != null ? ` ${turn}` : ''}`,
+          data: { phase, turn: turn ?? null },
+          turn: turn ?? undefined,
+        })
+      }
+      return
+    case 'oas:context_compacted':
+      if (opts?.includeLiveTrace) {
+        const before = asNumber(payload.before_tokens)
+        const after = asNumber(payload.after_tokens)
+        const phase = asString(payload.phase)
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: `${phase ?? 'compact'}|${before ?? 'na'}|${after ?? 'na'}`,
+          kind: 'oas_context',
+          summary: `compact${before != null && after != null ? ` ${before}→${after}` : ''}`,
+          data: {
+            before_tokens: before ?? null,
+            after_tokens: after ?? null,
+            phase: phase ?? null,
+          },
+        })
+      }
+      return
+    case 'oas:durable:llm_request':
+      recordOasLlmCall(eventTimestampMs(event))
+      if (opts?.includeLiveTrace) {
+        const turn = asNumber(payload.turn)
+        const model = asString(payload.model) ?? 'unknown'
+        const inputTokens = asNumber(payload.input_tokens) ?? 0
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: `llm_request|${turn ?? 'na'}`,
+          kind: 'lifecycle',
+          summary: `LLM 요청 · ${model} · ${inputTokens}tok${turn != null ? ` · turn ${turn}` : ''}`,
+          data: {
+            durable_kind: 'llm_request',
+            turn: turn ?? null,
+            model,
+            input_tokens: inputTokens,
+          },
+        })
+      }
+      return
+    case 'oas:durable:llm_response':
+      if (opts?.includeLiveTrace) {
+        const turn = asNumber(payload.turn)
+        const outputTokens = asNumber(payload.output_tokens) ?? 0
+        const stopReason = asString(payload.stop_reason) ?? 'unknown'
+        const durationMs = asNumber(payload.duration_ms)
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: `llm_response|${turn ?? 'na'}`,
+          kind: 'lifecycle',
+          summary: `LLM 응답 · ${outputTokens}tok · ${stopReason}${durationMs != null ? ` · ${durationMs.toFixed(0)}ms` : ''}`,
+          data: {
+            durable_kind: 'llm_response',
+            turn: turn ?? null,
+            output_tokens: outputTokens,
+            stop_reason: stopReason,
+            duration_ms: durationMs ?? null,
+          },
+          durationMs: durationMs ?? undefined,
+        })
+      }
+      return
+    case 'oas:durable:error_occurred':
+      recordOasError(eventTimestampMs(event))
+      if (opts?.includeLiveTrace) {
+        const turn = asNumber(payload.turn)
+        const errorDomain = asString(payload.error_domain) ?? 'unknown'
+        const detail = asString(payload.detail) ?? ''
+        maybeAppendLiveTrace(agentName, event, {
+          idSuffix: `error_occurred|${turn ?? 'na'}|${errorDomain}`,
+          kind: 'lifecycle',
+          summary: `OAS 에러 · ${errorDomain}${turn != null ? ` · turn ${turn}` : ''}`,
+          data: {
+            durable_kind: 'error_occurred',
+            turn: turn ?? null,
+            error_domain: errorDomain,
+            detail,
+          },
+          error: detail || errorDomain,
+        })
+      }
+      return
+    default:
+      return
+  }
+}
+
+function coerceOasRuntimeEnvelope(raw: unknown): OasRuntimeEnvelope | null {
+  if (!isRecord(raw)) return null
+  const type = asString(raw.type)
+  if (!type || !type.startsWith('oas:')) return null
+  return {
+    ...raw,
+    type,
+    payload: isRecord(raw.payload) ? raw.payload : {},
+  }
+}
+
+export function applyOasRuntimeEvent(raw: unknown, opts?: IngestOptions): boolean {
+  const event = coerceOasRuntimeEnvelope(raw)
+  if (!event) return false
+  const key = runtimeEventKey(event)
+  if (seenOasEventKeys.has(key)) {
+    return false
+  }
+  seenOasEventKeys.add(key)
+  oasTotalEvents.value = seenOasEventKeys.size
+  ingestRuntimeProjection(event, opts)
+  return true
+}
+
+export function hydrateOasRuntimeFromTelemetryEntries(entries: TelemetryEntry[]): void {
+  resetOasRuntimeSignals()
+  seenOasEventKeys.clear()
+  const ordered = [...entries].sort((a, b) => {
+    const left = coerceOasRuntimeEnvelope(a)
+    const right = coerceOasRuntimeEnvelope(b)
+    return (left ? eventUnixSeconds(left) : 0) - (right ? eventUnixSeconds(right) : 0)
+  })
+  for (const entry of ordered) {
+    applyOasRuntimeEvent(entry)
+  }
+}
+
+export async function replayOasRuntimeTelemetry(signal?: AbortSignal): Promise<void> {
+  const generation = ++replayGeneration
+  const response = await fetchTelemetry({
+    source: 'oas_event',
+    n: OAS_TELEMETRY_REPLAY_LIMIT,
+    signal,
+  })
+  if (generation !== replayGeneration) return
+  hydrateOasRuntimeFromTelemetryEntries(response.entries)
+}

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -5,7 +5,14 @@
 // and named handlers for events with custom logic (conditional hydration,
 // async imports, signal-only updates).
 
-import { lastEvent, connected, reconnectCount, lastDisconnectedAt } from './sse'
+import {
+  lastEvent,
+  connected,
+  reconnectCount,
+  lastDisconnectedAt,
+  pauseQueuedOasRuntimeIngress,
+  resumeQueuedOasRuntimeIngress,
+} from './sse'
 import type { DashboardExecutionResponse } from './types'
 import {
   keeperHeartbeats,
@@ -39,6 +46,7 @@ import {
   SSE_KEEPER_THREAD_DEBOUNCE_MS,
   SSE_RECONNECT_RETRY_MS,
 } from './config/constants'
+import { replayOasRuntimeTelemetry } from './oas-runtime-store'
 
 // --- Refresh function registration (avoids circular imports) ---
 
@@ -259,10 +267,19 @@ function handleReconnect(): void {
   // If the server is still warming up after restart, the first fetch may fail.
   // Schedule a single retry after 3s to cover the warm-up window.
   invalidateDashboardCache()
+  pauseQueuedOasRuntimeIngress()
   void hydrateAfterReconnect()
+    .finally(() => {
+      resumeQueuedOasRuntimeIngress()
+    })
 }
 
-function hydrateAfterReconnect(): void {
+async function hydrateAfterReconnect(): Promise<void> {
+  try {
+    await replayOasRuntimeTelemetry()
+  } catch (err) {
+    console.warn('[SSE] reconnect OAS replay failed', err instanceof Error ? err.message : err)
+  }
   requestNamespaceTruthNow()
   void refreshActiveRoute().catch(err =>
     console.warn('[SSE] reconnect route refresh failed', err instanceof Error ? err.message : err),

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -4,10 +4,6 @@
 import { signal, type ReadonlySignal } from '@preact/signals'
 import type { JournalEntry, JournalEventType, SSEEvent } from './types'
 import {
-  pushOasAgentEvent,
-  updateOasKeeperSnapshot,
-  recordOasLlmCall,
-  recordOasError,
   removeBoardPost,
 } from './store'
 import {
@@ -15,11 +11,8 @@ import {
   normalizeJournalSeverity,
   normalizeJournalSource,
 } from './journal-entry'
-import type { OasKeeperSnapshot } from './types/oas'
-import {
-  appendLiveOasEvent,
-  appendLiveToolCall,
-} from './components/session-trace/session-trace-state'
+import { appendLiveToolCall } from './components/session-trace/session-trace-state'
+import { applyOasRuntimeEvent } from './oas-runtime-store'
 
 import {
   RECONNECT_BASE_MS,
@@ -160,53 +153,27 @@ function envelopeFromEvent(event: SSEEvent): Pick<JournalEntry, 'correlationId' 
   return out
 }
 
-function eventUnixTs(event: SSEEvent): number {
-  return typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000
-}
-
-function oasEventType(event: SSEEvent): string {
-  return asString(event.event_type) ?? event.type
-}
-
-function oasEventKey(
-  event: SSEEvent,
-  actorName: string,
-  extras: Array<string | number | undefined> = [],
-): string | undefined {
-  const correlationId = asString(event.correlation_id)
-  const runId = asString(event.run_id)
-  const ts = typeof event.ts_unix === 'number' ? event.ts_unix : undefined
-  if (!correlationId && !runId && ts == null) return undefined
-  return [
-    oasEventType(event),
-    actorName,
-    correlationId ?? '',
-    runId ?? '',
-    ts != null ? String(ts) : '',
-    ...extras
-      .filter((value): value is string | number => value != null)
-      .map((value) => String(value)),
-  ].join('|')
-}
-
-function oasTraceDetail(
-  event: SSEEvent,
-  detail: Record<string, unknown>,
-): Record<string, unknown> {
-  return {
-    event_type: oasEventType(event),
-    correlation_id: asString(event.correlation_id) ?? null,
-    run_id: asString(event.run_id) ?? null,
-    ts_unix: typeof event.ts_unix === 'number' ? event.ts_unix : null,
-    ...detail,
-  }
-}
-
 // --- SSE Manager ---
 
 let source: EventSource | null = null
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let reconnectAttempts = 0
+let pauseOasRuntimeIngress = false
+let queuedOasEvents: SSEEvent[] = []
+
+export function pauseQueuedOasRuntimeIngress(): void {
+  pauseOasRuntimeIngress = true
+}
+
+export function resumeQueuedOasRuntimeIngress(): void {
+  pauseOasRuntimeIngress = false
+  if (queuedOasEvents.length === 0) return
+  const pending = queuedOasEvents
+  queuedOasEvents = []
+  for (const event of pending) {
+    handleEvent(event)
+  }
+}
 
 export function buildDashboardSseUrl(sessionId: string, locationSearch = window.location.search): string {
   const urlParams = new URLSearchParams(locationSearch)
@@ -257,6 +224,9 @@ export function connectSSE(): void {
   es.onopen = () => {
     if (source !== es) return
     const wasDisconnected = reconnectAttempts > 0
+    if (wasDisconnected) {
+      pauseOasRuntimeIngress = true
+    }
     reconnectAttempts = 0
     connected.value = true
     if (wasDisconnected) {
@@ -300,6 +270,10 @@ function handleEvent(event: SSEEvent): void {
   // the same switch cases.  Keep the original type for OAS/namespaced events
   // that genuinely use colons or other prefixes.
   const rawType = event.type
+  if (pauseOasRuntimeIngress && rawType.startsWith('oas:')) {
+    queuedOasEvents.push(event)
+    return
+  }
   const MASC_PREFIX = 'masc/'
   const type =
     rawType.startsWith(MASC_PREFIX)
@@ -307,6 +281,9 @@ function handleEvent(event: SSEEvent): void {
       ? rawType.slice(MASC_PREFIX.length)
       : rawType
   const agent = event.agent ?? event.author ?? event.from ?? event.from_agent ?? ''
+  if (rawType.startsWith('oas:')) {
+    applyOasRuntimeEvent(event, { includeLiveTrace: true })
+  }
 
   switch (type) {
     case 'agent_joined':
@@ -536,77 +513,23 @@ function handleEvent(event: SSEEvent): void {
     }
     // OAS bridge events
     case 'oas:masc:autonomy:agent_selected': {
-      const p = (event.payload ?? {}) as Record<string, unknown>
-      const agentName = (p.agent_name as string) ?? ''
-      pushOasAgentEvent({
-        type: 'selected',
-        agent_name: agentName,
-        actor_kind: 'agent',
-        trigger: (p.trigger as string) ?? undefined,
-        thompson_score:
-          typeof p.thompson_score === 'number' ? p.thompson_score : undefined,
-        final_score: typeof p.final_score === 'number' ? p.final_score : undefined,
-        event_type: oasEventType(event),
-        correlation_id: asString(event.correlation_id),
-        run_id: asString(event.run_id),
-        event_key: oasEventKey(event, agentName),
-        timestamp:
-          typeof p.timestamp === 'number'
-            ? p.timestamp
-            : eventUnixTs(event),
-      })
       break
     }
     case 'oas:masc:autonomy:agent_decision': {
-      const p = (event.payload ?? {}) as Record<string, unknown>
-      const agentName = (p.agent_name as string) ?? ''
-      pushOasAgentEvent({
-        type: 'decision',
-        agent_name: agentName,
-        actor_kind: 'agent',
-        action: (p.action as string) ?? undefined,
-        trigger_reason: (p.trigger_reason as string) ?? undefined,
-        event_type: oasEventType(event),
-        correlation_id: asString(event.correlation_id),
-        run_id: asString(event.run_id),
-        event_key: oasEventKey(event, agentName),
-        timestamp:
-          typeof p.timestamp === 'number'
-            ? p.timestamp
-            : eventUnixTs(event),
-      })
       break
     }
     case 'oas:masc:autonomy:agent_action_executed': {
-      const p = (event.payload ?? {}) as Record<string, unknown>
-      const agentName = (p.agent_name as string) ?? ''
-      pushOasAgentEvent({
-        type: 'action_executed',
-        agent_name: agentName,
-        actor_kind: 'agent',
-        action: (p.action as string) ?? undefined,
-        success: typeof p.success === 'boolean' ? p.success : undefined,
-        event_type: oasEventType(event),
-        correlation_id: asString(event.correlation_id),
-        run_id: asString(event.run_id),
-        event_key: oasEventKey(event, agentName, [p.action as string | undefined]),
-        timestamp:
-          typeof p.timestamp === 'number'
-            ? p.timestamp
-            : eventUnixTs(event),
-      })
       break
     }
     case 'oas:masc:keeper:snapshot': {
       const p = (event.payload ?? {}) as Record<string, unknown>
-      const snap: OasKeeperSnapshot = {
+      const snap = {
         keeper_name: (p.keeper_name as string) ?? '',
         generation: (p.generation as number) ?? 0,
         context_ratio: (p.context_ratio as number) ?? 0,
         message_count: (p.message_count as number) ?? 0,
         timestamp: (p.timestamp as number) ?? Date.now() / 1000,
       }
-      updateOasKeeperSnapshot(snap)
       addTypedJournalEntry(
         snap.keeper_name,
         `Keeper snapshot gen=${snap.generation} ctx=${Math.round(snap.context_ratio * 100)}%`,
@@ -629,22 +552,6 @@ function handleEvent(event: SSEEvent): void {
       const actorName = keeperName || asString(p.agent_name) || ''
       const lifecycleEvent = (p.event as string) ?? undefined
       const detail = (p.detail as string) ?? undefined
-      pushOasAgentEvent({
-        type: 'keeper_lifecycle',
-        agent_name: actorName,
-        actor_kind: 'keeper',
-        keeper_name: keeperName || undefined,
-        event: lifecycleEvent,
-        detail,
-        event_type: oasEventType(event),
-        correlation_id: asString(event.correlation_id),
-        run_id: asString(event.run_id),
-        event_key: oasEventKey(event, actorName, [lifecycleEvent, detail]),
-        timestamp:
-          typeof p.timestamp === 'number'
-            ? p.timestamp
-            : eventUnixTs(event),
-      })
       addTypedJournalEntry(
         actorName,
         `Keeper ${[lifecycleEvent, detail].filter(Boolean).join(' · ') || 'lifecycle'}`,
@@ -668,21 +575,6 @@ function handleEvent(event: SSEEvent): void {
       const agentA = (p.agent_a as string) ?? ''
       const agentB = (p.agent_b as string) ?? ''
       const trustScore = typeof p.trust_score === 'number' ? p.trust_score : undefined
-      pushOasAgentEvent({
-        type: 'trust_updated',
-        agent_name: agentA,
-        actor_kind: 'agent',
-        secondary_agent: agentB,
-        trust_score: trustScore,
-        event_type: oasEventType(event),
-        correlation_id: asString(event.correlation_id),
-        run_id: asString(event.run_id),
-        event_key: oasEventKey(event, agentA, [agentB]),
-        timestamp:
-          typeof p.timestamp === 'number'
-            ? p.timestamp
-            : eventUnixTs(event),
-      })
       addTypedJournalEntry(
         agentA,
         `Trust ${agentB}${trustScore != null ? ` · ${trustScore.toFixed(2)}` : ''}`,
@@ -703,22 +595,6 @@ function handleEvent(event: SSEEvent): void {
       const oldScore = typeof p.old_score === 'number' ? p.old_score : undefined
       const newScore = typeof p.new_score === 'number' ? p.new_score : undefined
       const trend = (p.trend as string) ?? undefined
-      pushOasAgentEvent({
-        type: 'reputation_changed',
-        agent_name: agentName,
-        actor_kind: 'agent',
-        old_score: oldScore,
-        new_score: newScore,
-        trend,
-        event_type: oasEventType(event),
-        correlation_id: asString(event.correlation_id),
-        run_id: asString(event.run_id),
-        event_key: oasEventKey(event, agentName, [trend]),
-        timestamp:
-          typeof p.timestamp === 'number'
-            ? p.timestamp
-            : eventUnixTs(event),
-      })
       addTypedJournalEntry(
         agentName,
         `Reputation${oldScore != null && newScore != null ? ` ${oldScore.toFixed(2)} → ${newScore.toFixed(2)}` : ''}${trend ? ` · ${trend}` : ''}`,
@@ -754,26 +630,6 @@ function handleEvent(event: SSEEvent): void {
           ...envelopeFromEvent(event),
         },
       )
-      if (agentName) {
-        const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-        const inputTokens = asNumber(p.input_tokens)
-        const outputTokens = asNumber(p.output_tokens)
-        const costUsd = asNumber(p.cost_usd)
-        appendLiveOasEvent(agentName, {
-          id: oasEventKey(event, agentName, [phase]) ?? `live-oas-agent-${phase}-${tsMs}-${agentName}`,
-          ts: tsMs,
-          ts_iso: new Date(tsMs).toISOString(),
-          kind: 'lifecycle',
-          summary: `agent ${phase}${inputTokens != null || outputTokens != null ? ` · ${inputTokens ?? 0}→${outputTokens ?? 0}tok` : ''}`,
-          detail: oasTraceDetail(event, {
-            task_id: taskId ?? null,
-            elapsed_s: elapsed ?? null,
-            input_tokens: inputTokens ?? null,
-            output_tokens: outputTokens ?? null,
-          }),
-          cost_usd: costUsd ?? undefined,
-        })
-      }
       break
     }
     case 'oas:tool_called':
@@ -793,18 +649,6 @@ function handleEvent(event: SSEEvent): void {
           narrativeText: `${actorLabel(agentName)} OAS 도구 ${phase}: ${toolName}`,
         },
       )
-      if (agentName) {
-        const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-        appendLiveOasEvent(agentName, {
-          id: oasEventKey(event, agentName, [phase, toolName]) ?? `live-oas-tool-${phase}-${tsMs}-${toolName}`,
-          ts: tsMs,
-          ts_iso: new Date(tsMs).toISOString(),
-          kind: 'oas_tool',
-          summary: `${phase} ${toolName}`,
-          detail: oasTraceDetail(event, { phase, tool_name: toolName }),
-          toolName,
-        })
-      }
       break
     }
     case 'oas:turn_started':
@@ -824,18 +668,6 @@ function handleEvent(event: SSEEvent): void {
           narrativeText: `${actorLabel(agentName)} OAS turn ${phase}${turn != null ? ` (T${turn})` : ''}`,
         },
       )
-      if (agentName) {
-        const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-        appendLiveOasEvent(agentName, {
-          id: oasEventKey(event, agentName, [phase, turn]) ?? `live-oas-turn-${phase}-${tsMs}-${turn ?? 'na'}`,
-          ts: tsMs,
-          ts_iso: new Date(tsMs).toISOString(),
-          kind: 'oas_turn',
-          summary: `${phase} turn${turn != null ? ` ${turn}` : ''}`,
-          detail: oasTraceDetail(event, { phase, turn: turn ?? null }),
-          turn,
-        })
-      }
       break
     }
     case 'oas:context_compacted': {
@@ -855,21 +687,6 @@ function handleEvent(event: SSEEvent): void {
           narrativeText: `${actorLabel(agentName)} OAS context compact${phase ? ` (${phase})` : ''}`,
         },
       )
-      if (agentName) {
-        const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-        appendLiveOasEvent(agentName, {
-          id: oasEventKey(event, agentName, [phase, before, after]) ?? `live-oas-context-${tsMs}-${phase ?? 'compact'}`,
-          ts: tsMs,
-          ts_iso: new Date(tsMs).toISOString(),
-          kind: 'oas_context',
-          summary: `compact${before != null && after != null ? ` ${before}→${after}` : ''}`,
-          detail: oasTraceDetail(event, {
-            before_tokens: before ?? null,
-            after_tokens: after ?? null,
-            phase: phase ?? null,
-          }),
-        })
-      }
       break
     }
     case 'oas:task_state_changed': {
@@ -896,21 +713,17 @@ function handleEvent(event: SSEEvent): void {
       const turn = asNumber(p.turn)
       const model = asString(p.model) ?? 'unknown'
       const inputTokens = asNumber(p.input_tokens) ?? 0
-      const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-      recordOasLlmCall(tsMs)
-      appendLiveOasEvent(agentName, {
-        id: oasEventKey(event, agentName, ['llm_request', turn]) ?? `live-oas-durable-llm-req-${tsMs}-${agentName}`,
-        ts: tsMs,
-        ts_iso: new Date(tsMs).toISOString(),
-        kind: 'lifecycle',
-        summary: `LLM 요청 · ${model} · ${inputTokens}tok${turn != null ? ` · turn ${turn}` : ''}`,
-        detail: oasTraceDetail(event, {
-          durable_kind: 'llm_request',
-          turn: turn ?? null,
-          model,
-          input_tokens: inputTokens,
-        }),
-      })
+      addTypedJournalEntry(
+        agentName,
+        `OAS durable llm_request${turn != null ? ` · T${turn}` : ''} · ${model} · ${inputTokens}tok`,
+        'oas',
+        'oas_event',
+        {
+          severity: event.severity,
+          source: event.source,
+          ...envelopeFromEvent(event),
+        },
+      )
       break
     }
     case 'oas:durable:llm_response': {
@@ -920,22 +733,17 @@ function handleEvent(event: SSEEvent): void {
       const outputTokens = asNumber(p.output_tokens) ?? 0
       const stopReason = asString(p.stop_reason) ?? 'unknown'
       const durationMs = asNumber(p.duration_ms)
-      const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-      appendLiveOasEvent(agentName, {
-        id: oasEventKey(event, agentName, ['llm_response', turn]) ?? `live-oas-durable-llm-res-${tsMs}-${agentName}`,
-        ts: tsMs,
-        ts_iso: new Date(tsMs).toISOString(),
-        kind: 'lifecycle',
-        summary: `LLM 응답 · ${outputTokens}tok · ${stopReason}${durationMs != null ? ` · ${durationMs.toFixed(0)}ms` : ''}`,
-        detail: oasTraceDetail(event, {
-          durable_kind: 'llm_response',
-          turn: turn ?? null,
-          output_tokens: outputTokens,
-          stop_reason: stopReason,
-          duration_ms: durationMs ?? null,
-        }),
-        duration_ms: durationMs ?? undefined,
-      })
+      addTypedJournalEntry(
+        agentName,
+        `OAS durable llm_response${turn != null ? ` · T${turn}` : ''} · ${outputTokens}tok · ${stopReason}${durationMs != null ? ` · ${durationMs.toFixed(0)}ms` : ''}`,
+        'oas',
+        'oas_event',
+        {
+          severity: event.severity,
+          source: event.source,
+          ...envelopeFromEvent(event),
+        },
+      )
       break
     }
     case 'oas:durable:error_occurred': {
@@ -944,22 +752,18 @@ function handleEvent(event: SSEEvent): void {
       const turn = asNumber(p.turn)
       const errorDomain = asString(p.error_domain) ?? 'unknown'
       const detail = asString(p.detail) ?? ''
-      const tsMs = (typeof event.ts_unix === 'number' ? event.ts_unix : Date.now() / 1000) * 1000
-      recordOasError(tsMs)
-      appendLiveOasEvent(agentName, {
-        id: oasEventKey(event, agentName, ['error_occurred', turn, errorDomain]) ?? `live-oas-durable-err-${tsMs}-${agentName}`,
-        ts: tsMs,
-        ts_iso: new Date(tsMs).toISOString(),
-        kind: 'lifecycle',
-        summary: `OAS 에러 · ${errorDomain}${turn != null ? ` · turn ${turn}` : ''}`,
-        detail: oasTraceDetail(event, {
-          durable_kind: 'error_occurred',
-          turn: turn ?? null,
-          error_domain: errorDomain,
-          detail,
-        }),
-        error: detail || errorDomain,
-      })
+      addTypedJournalEntry(
+        agentName,
+        `OAS 에러 · ${errorDomain}${turn != null ? ` · T${turn}` : ''}`,
+        'oas',
+        'oas_event',
+        {
+          severity: event.severity,
+          source: event.source,
+          preview: detail || undefined,
+          ...envelopeFromEvent(event),
+        },
+      )
       break
     }
     case 'oas:durable:turn_started':
@@ -987,6 +791,8 @@ export function disconnectSSE(): void {
     source.close()
     source = null
   }
+  pauseOasRuntimeIngress = false
+  queuedOasEvents = []
   connected.value = false
 }
 

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
-  oasAgentEvents,
-  oasKeeperSnapshots,
-  oasLastKeeperTick,
   oasTotalEvents,
   oasTotalLlmCalls,
   oasTotalErrors,
   oasLastLlmCallTs,
   oasLastErrorTs,
   oasHealthSummary,
+  resetOasRuntimeSignals,
   pushOasAgentEvent,
   updateOasKeeperSnapshot,
   recordOasLlmCall,
@@ -17,14 +15,7 @@ import {
 import type { OasAgentEvent, OasKeeperSnapshot } from './types/oas'
 
 function resetOasSignals() {
-  oasAgentEvents.value = []
-  oasKeeperSnapshots.value = new Map()
-  oasLastKeeperTick.value = null
-  oasTotalEvents.value = 0
-  oasTotalLlmCalls.value = 0
-  oasTotalErrors.value = 0
-  oasLastLlmCallTs.value = null
-  oasLastErrorTs.value = null
+  resetOasRuntimeSignals()
 }
 
 describe('oasHealthSummary', () => {
@@ -49,7 +40,7 @@ describe('oasHealthSummary', () => {
     pushOasAgentEvent(evt)
     pushOasAgentEvent({ ...evt, timestamp: 2 })
     expect(oasHealthSummary.value.agentEventsCount).toBe(2)
-    expect(oasHealthSummary.value.totalEvents).toBe(2)
+    expect(oasHealthSummary.value.totalEvents).toBe(0)
   })
 
   it('dedups identical consecutive agent events', () => {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -126,7 +126,6 @@ import {
   OAS_KEEPER_SNAPSHOT_MAX,
   HEARTBEAT_STALE_MS,
   SHELL_TTL_MS,
-
 } from './config/constants'
 
 export const oasAgentEvents = signal<OasAgentEvent[]>([])
@@ -137,6 +136,17 @@ export const oasTotalLlmCalls = signal(0)
 export const oasTotalErrors = signal(0)
 export const oasLastLlmCallTs = signal<number | null>(null)
 export const oasLastErrorTs = signal<number | null>(null)
+
+export function resetOasRuntimeSignals(): void {
+  oasAgentEvents.value = []
+  oasKeeperSnapshots.value = new Map()
+  oasLastKeeperTick.value = null
+  oasTotalEvents.value = 0
+  oasTotalLlmCalls.value = 0
+  oasTotalErrors.value = 0
+  oasLastLlmCallTs.value = null
+  oasLastErrorTs.value = null
+}
 
 export function pushOasAgentEvent(event: OasAgentEvent): void {
   const head = oasAgentEvents.value[0]
@@ -160,7 +170,6 @@ export function pushOasAgentEvent(event: OasAgentEvent): void {
     return
   }
   oasAgentEvents.value = [event, ...oasAgentEvents.value].slice(0, OAS_AGENT_EVENT_BUFFER)
-  oasTotalEvents.value++
 }
 
 /** Record an OAS durable LLM-call event. Increments the global
@@ -168,13 +177,13 @@ export function pushOasAgentEvent(event: OasAgentEvent): void {
  *  surface recency. */
 export function recordOasLlmCall(tsMs: number): void {
   oasTotalLlmCalls.value++
-  oasLastLlmCallTs.value = tsMs
+  oasLastLlmCallTs.value = Math.max(oasLastLlmCallTs.value ?? 0, tsMs)
 }
 
 /** Record an OAS durable error event. */
 export function recordOasError(tsMs: number): void {
   oasTotalErrors.value++
-  oasLastErrorTs.value = tsMs
+  oasLastErrorTs.value = Math.max(oasLastErrorTs.value ?? 0, tsMs)
 }
 
 export function updateOasKeeperSnapshot(snapshot: OasKeeperSnapshot): void {
@@ -197,7 +206,6 @@ export function updateOasKeeperSnapshot(snapshot: OasKeeperSnapshot): void {
     const nextTickMs = Math.round(snapshot.timestamp * 1000)
     oasLastKeeperTick.value = Math.max(oasLastKeeperTick.value ?? 0, nextTickMs)
   }
-  oasTotalEvents.value++
 }
 
 export const oasHealthSummary: ReadonlySignal<OasHealthSummary> = computed(() => ({


### PR DESCRIPTION
## Summary
- rebuild dashboard OAS runtime health from durable oas_event telemetry on boot and reconnect
- route replay and live SSE through one client-side OAS runtime ingestion path
- queue live OAS events during replay so reconnect recovery does not fork the client truth again

## Product impact
- dashboard OAS health survives reloads and reconnects instead of resetting to live-only counters
- replay and live SSE no longer drift because they use the same runtime ingestion path
- reconnect recovery can catch up from durable telemetry before resuming the live OAS tail

## Evidence
- dashboard/src/oas-runtime-store.ts owns the shared replay/live ingestion path
- app boot and SSE reconnect both call durable `oas_event` replay before resuming live ingestion
- targeted tests cover replay hydration and replay/live dedupe behavior

## Review evidence
- pnpm typecheck
- pnpm exec vitest run src/store.test.ts src/sse.test.ts src/components/oas-health-chip.test.ts src/oas-runtime-store.test.ts

## Linked issue
- Refs #7277

## Tests
- pnpm typecheck
- pnpm exec vitest run src/store.test.ts src/sse.test.ts src/components/oas-health-chip.test.ts src/oas-runtime-store.test.ts