### PR TITLE
docs: audit OAS observability truth boundaries

### DIFF
--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -13,6 +13,7 @@ consumer → MASC-MCP (coordination/orchestration) → OAS (agent runtime)
 - 이 문서는 **boundary contract SSOT**다.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/spec/13-oas-integration.md`는 구현 세부와 open issue ledger를 유지한다.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md`는 시점별 health snapshot이다.
+- `/home/runner/work/masc-mcp/masc-mcp/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md`는 OAS observability producer -> bridge -> durable store -> dashboard consumer chain과 fixed gaps를 기록한다.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/design/oas-masc-state-boundary.md`는 historical audit + migration backlog로 취급한다.
 
 ## 역할 분리
@@ -53,7 +54,9 @@ OAS  ──does not know──→ MASC
 | Area | Status | Notes |
 |------|--------|-------|
 | Context compaction | Partial complete | `context_compact_oas.ml`는 OAS `Context_reducer`를 사용한다. MASC 전체 context system이 OAS `Context.t`로 통합된 것은 아니다. |
-| Event bus bridge | Complete for current `masc:*` flow | `oas_events.ml` publishes, `oas_sse_bridge.ml` relays to dashboard SSE |
+| Event bus bridge | Complete for current native/custom flow | `oas_sse_bridge.ml` relays both OAS native events and `masc:*` custom events, persists them under `.masc/oas-events/`, and feeds dashboard SSE |
+| Dashboard OAS runtime health | Complete with replay/live split | dashboard health SSOT is `durable oas_event replay + live SSE tail`, not live-only counters |
+| Dashboard runtime counts | Complete with truth split | dashboard `counts` means active runtimes; configured keeper inventory is exposed separately as `configured_keepers` |
 | Checkpoint integration | Partial complete | OAS checkpoint is used in shared worker/runtime paths, and the public OAS worker API now keeps the extra JSON as a neutral checkpoint sidecar. Keeper runtime still persists its own `working_context` / serialized checkpoint path in `lib/keeper/keeper_exec_context.ml` |
 | Memory bridge | Partial complete | long-term + procedural + institution episodic are bridged; broader memory unification is still separate |
 | Team-session swarm | Partial complete | OAS Swarm runner is active; current bridge uses `swarm_config` / `agent_entry` + worker metadata while intentionally omitting `collaboration_context`, so fidelity is still incomplete |
@@ -114,6 +117,8 @@ These stay in MASC:
 
 - “Context integration in progress” now means **broader state unification**, not compaction.
 - “Event_bus bridge planned” is no longer true for the current dashboard/SSE path.
+- dashboard OAS runtime health should be read as **durable replay + live tail**, not as a live-only pulse.
+- dashboard runtime `counts` should be read as **active truth**, while keeper inventory belongs to `configured_keepers`.
 - “team_session pending migration” is no longer true; the correct description is **running on OAS Swarm with an incomplete bridge**.
 
 ## Boundary Review Checklist

--- a/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
+++ b/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
@@ -1,0 +1,88 @@
+# OAS Observability Truth Audit (2026-04-15)
+
+## Scope
+
+This audit records the producer -> bridge -> durable store -> dashboard consumer chain for OAS observability, plus the dashboard truth split that was fixed in the April 2026 cleanup wave.
+
+## Producer To Consumer Chain
+
+### 1. Producers
+
+- OAS native runtime events originate in `agent_sdk` and enter the shared `Agent_sdk.Event_bus`.
+- MASC custom observability events are published by `lib/oas_events.ml` under the `masc:*` namespace.
+
+### 2. Bridge
+
+- `lib/oas_sse_bridge.ml` subscribes to the OAS event bus with `accept_all`.
+- Native events are serialized with an `oas:` prefix.
+- Envelope fields `correlation_id`, `run_id`, and `ts_unix` are emitted for every relayed event.
+
+### 3. Durable Store
+
+- `lib/oas_sse_bridge.ml` appends every relayed OAS event to `.masc/oas-events/` through `Dated_jsonl.append`.
+- This durable JSONL store is the replay source for dashboard recovery and telemetry inspection.
+
+### 4. Server Read Path
+
+- `lib/telemetry_unified.ml` exposes the durable store as telemetry source `oas_event`.
+- Dashboard consumers read it through `/api/v1/dashboard/telemetry?source=oas_event`.
+
+### 5. Dashboard Consumer Path
+
+- `dashboard/src/oas-runtime-store.ts` is the client-side OAS runtime SSOT.
+- Boot and reconnect replay use `replayOasRuntimeTelemetry()` to rebuild runtime state from durable `oas_event` telemetry.
+- Live SSE events flow through `dashboard/src/sse.ts`, but OAS runtime state is updated by the same `applyOasRuntimeEvent()` ingestion path used by replay.
+- `dashboard/src/components/oas-health-chip.ts` renders the replayed + live-combined state.
+
+## Fixed Truth Breaks
+
+### Dashboard OAS Event Wiring
+
+- Keeper lifecycle events were produced with `keeper_name` but the dashboard treated them as `agent_name`.
+- Client dedupe was previously based on weak front-end tuples instead of the OAS envelope.
+- `lastKeeperTick` could drift because the client used local wall-clock time instead of backend event time.
+- A dead `oas:masc:keeper:tick` client-only path existed without a real producer.
+
+### Durable vs Live Split
+
+- Dashboard OAS health used live-only incremental counters, so a reload or reconnect lost the durable truth.
+- Replay and live paths used different logic, which allowed drift between telemetry and runtime chips.
+- The fixed rule is:
+  - OAS runtime health SSOT = `durable oas_event replay + live SSE tail`
+  - live SSE is an overlay, not the only source of truth
+
+### Runtime Count Split
+
+- Dashboard `counts.keepers` used configured keeper inventory in some paths and active runtime counts in others.
+- The fixed rule is:
+  - `counts` = active runtime truth
+  - `configured_keepers` = configured keeper inventory
+  - `counts.total_runtimes` = active agents + active keepers
+
+## Consumer Rules
+
+1. When reading OAS runtime health in the dashboard, trust the replayed `oas_event` ledger first and the live tail second.
+2. When reading runtime counts in the dashboard, use `counts` for active runtime truth and `configured_keepers` for inventory.
+3. When deduping OAS events client-side, prefer the OAS envelope (`event_type`, `correlation_id`, `run_id`, `ts_unix`) over front-end-only tuples.
+
+## Deferred Follow-Up Issue Seeds
+
+These items were intentionally deferred from the April 2026 dashboard cleanup wave because they cross runtime ownership boundaries.
+
+### 1. Keeper checkpoint truth precedence
+
+- Symptom: keeper continuity still spans OAS checkpoint data and MASC-owned runtime wrappers.
+- Suspected owner path: `lib/keeper/keeper_exec_context.ml`, `lib/keeper/keeper_agent_run.ml`, checkpoint replay surfaces.
+- Required outcome: document and enforce one checkpoint truth hierarchy before any more replay logic is added.
+
+### 2. `working_context` ownership reduction
+
+- Symptom: keeper runtime still persists a MASC-owned `working_context` wrapper around OAS context/checkpoint primitives.
+- Suspected owner path: keeper post-turn and restore flows.
+- Required outcome: shrink `working_context` until OAS owns runtime context/checkpoint state and MASC only projects coordination state.
+
+### 3. Raw `[STATE]` marker removal
+
+- Symptom: keeper continuity still depends on raw text markers such as `[STATE]`.
+- Suspected owner path: post-turn continuity writes, context reduction heuristics, replay/read surfaces.
+- Required outcome: replace raw marker coupling with structured metadata or typed replay facts.

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -33,6 +33,7 @@ MASC 전용 요구가 생기면 MASC adapter/bridge로 먼저 해결하고, OAS 
 - `/home/runner/work/masc-mcp/masc-mcp/docs/design/oas-masc-state-boundary.md` is a historical audit / migration backlog, not the primary boundary contract.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/design/checkpoint-truth-and-replay-rfc.md` keeps checkpoint truth hierarchy, replay semantics, and side-effect boundary language.
 - `/home/runner/work/masc-mcp/masc-mcp/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md` is evidence, not contract.
+- `/home/runner/work/masc-mcp/masc-mcp/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md` records the OAS observability producer -> bridge -> durable store -> dashboard consumer chain.
 
 ---
 
@@ -315,15 +316,33 @@ MASC 조율 이벤트를 OAS `Event_bus`에 `Custom("masc:<type>", json)` 형식
 
 ### 8.2 SSE Relay (oas_sse_bridge.ml)
 
-`oas_sse_bridge.ml`이 Event_bus의 `masc:*` 이벤트를 SSE로 중계한다.
+`oas_sse_bridge.ml`이 Event_bus의 native OAS events와 `masc:*` custom events를 모두 SSE로 중계하고 durable JSONL로도 기록한다.
 
 동작:
-1. `Event_bus.subscribe`로 `masc:` prefix 필터 구독
+1. `Event_bus.subscribe`로 전체 OAS event bus를 구독
 2. 배경 fiber가 `drain_interval_s` (기본 0.25초) 간격으로 poll
-3. `Custom(name, payload)` -> `{"type":"oas:<name>","payload":...,"ts_unix":...}` SSE broadcast
-4. `Sse.broadcast_to Coordinators`로 dashboard 클라이언트에 전달
+3. native/custom event를 `oas:*` envelope JSON으로 직렬화하고 `correlation_id`, `run_id`, `ts_unix`를 포함
+4. `.masc/oas-events/`에 durable append
+5. `Sse.broadcast_to Coordinators`로 dashboard 클라이언트에 전달
 
 환경변수: `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` (범위: 0.05-5.0초)
+
+### 8.3 Dashboard Observability Read Path
+
+Dashboard OAS runtime health is not a live-only counter.
+
+Read path:
+
+1. durable replay source: `/api/v1/dashboard/telemetry?source=oas_event`
+2. client runtime ledger: `dashboard/src/oas-runtime-store.ts`
+3. live overlay: `dashboard/src/sse.ts` -> same `applyOasRuntimeEvent()` ingestion path
+4. UI consumer: `dashboard/src/components/oas-health-chip.ts`
+
+SSOT rules:
+
+- OAS runtime health = `durable oas_event replay + live SSE tail`
+- dashboard `counts` = active runtime truth
+- dashboard `configured_keepers` = configured keeper inventory
 
 ---
 
@@ -397,7 +416,9 @@ Static pre-filtering은 OAS Guardrails가, stateful per-call checks는 Eval_gate
 |------|------|------|
 | Agent 실행 | Complete | `oas_worker.ml`이 모든 MODEL 호출을 Agent.run으로 라우팅 |
 | Context compaction | Complete | OAS Context_reducer 직접 위임, MASC Custom closure 주입 |
-| Event_bus bridge | Complete | `masc:*` 이벤트 13종 publish + SSE relay |
+| Event_bus bridge | Complete | OAS native/custom events are relayed to SSE and persisted under `.masc/oas-events/` |
+| Dashboard OAS runtime health | Complete | dashboard health uses `durable replay + live tail`, not live-only counters |
+| Dashboard runtime counts | Complete | dashboard `counts` carries active runtimes and `configured_keepers` carries inventory |
 | Checkpoint | Partial | shared worker/runtime paths는 OAS Checkpoint를 사용한다. Public `Oas_worker` surface의 extra checkpoint JSON은 neutral `checkpoint_sidecar` 이름을 쓰지만 keeper 경로는 여전히 `lib/keeper/keeper_exec_context.ml`의 wrapper + serialized context를 유지 |
 | Memory bridge | Partial | Long_term + Episodic + Procedural bridged. Working/Scratchpad는 OAS 내부. 전체 통합은 미완 |
 | Team-session swarm | Partial | OAS Swarm runner 활성, bridge fidelity 불완전 |


### PR DESCRIPTION
## Summary
- document the producer -> bridge -> durable store -> dashboard consumer chain for OAS observability
- update OAS boundary/spec docs to state that dashboard OAS runtime health is durable replay plus live tail
- record the deferred follow-up items for checkpoint truth, working_context ownership, and raw state markers

## Product impact
- reviewers now have one written SSOT for OAS observability truth instead of inferring it from server and dashboard code
- future dashboard/runtime work can distinguish active truth from configured inventory without rediscovering the split
- deferred checkpoint and continuity work now has explicit follow-up issue anchors

## Evidence
- docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md records the full producer -> consumer chain
- boundary/spec docs now state the replay-plus-live dashboard rule and count split rule
- follow-up issues #7277, #7278, and #7279 capture the deferred runtime boundary work

## Review evidence
- git diff --check

## Linked issue
- Refs #7277
- Refs #7278
- Refs #7279

## Tests
- git diff --check