### PR TITLE
feat(fsm-hub): measurement flag tooltips and drift explainer

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -10,6 +10,7 @@ import {
   deriveSwimlaneSegments,
   deriveTimeAxisTicks,
   deriveTransitionHistory,
+  flagTooltip,
   isTransitionInSegment,
   laneTransitionCount,
   type CompositeObservation,
@@ -406,5 +407,31 @@ describe('laneTransitionCount', () => {
     expect(laneTransitionCount(observations, 'turn')).toBe(1)
     expect(laneTransitionCount(observations, 'phase')).toBe(1)
     expect(laneTransitionCount(observations, 'decision')).toBe(0)
+  })
+})
+
+describe('flagTooltip', () => {
+  it('returns the on-description when the flag is active', () => {
+    const tip = flagTooltip('reflect', true)
+    expect(tip).toContain('reflect (active)')
+    expect(tip).toMatch(/self-evaluate|Reflexion/i)
+  })
+
+  it('returns the off-description when the flag is inactive', () => {
+    const tip = flagTooltip('reflect', false)
+    expect(tip).toContain('reflect (inactive)')
+    expect(tip).toMatch(/no reflection pending/i)
+  })
+
+  it('swaps description for guardrail based on state', () => {
+    const on = flagTooltip('guardrail', true)
+    const off = flagTooltip('guardrail', false)
+    expect(on).toMatch(/tripped|halt/i)
+    expect(off).toMatch(/no guardrail active|safety envelope/i)
+  })
+
+  it('falls back to a generic tooltip for unknown labels', () => {
+    expect(flagTooltip('mystery-flag', true)).toBe('mystery-flag: active')
+    expect(flagTooltip('mystery-flag', false)).toBe('mystery-flag: inactive')
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1041,6 +1041,18 @@ const INSIGHT_BADGE_CLS: Record<InsightTone, string> = {
   error: 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]',
 }
 
+/** Panel-level accent — border + subtle tinted overlay — so that the
+    overall tone of the current operator insight is visible from the
+    peripheral visual field. Neutral tones (ok/info) keep the default
+    muted panel frame; warn/error lift the full panel so urgent state
+    does not require reading the small top-right badge. */
+const INSIGHT_PANEL_CLS: Record<InsightTone, string> = {
+  ok: 'border-[var(--white-8)] bg-[var(--white-2)]',
+  info: 'border-[var(--white-8)] bg-[var(--white-2)]',
+  warn: 'border-[rgba(245,158,11,0.45)] bg-[rgba(245,158,11,0.04)] shadow-[0_0_0_1px_rgba(245,158,11,0.15)_inset]',
+  error: 'border-[rgba(239,68,68,0.55)] bg-[rgba(239,68,68,0.05)] shadow-[0_0_0_1px_rgba(239,68,68,0.2)_inset]',
+}
+
 function OperationalMeaningPanel({
   snapshot,
   observations,
@@ -1052,9 +1064,15 @@ function OperationalMeaningPanel({
 }) {
   const insight = deriveOperationalInsight(snapshot, observations, now)
   const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
+  const panelCls = INSIGHT_PANEL_CLS[insight.tone]
+  const isAlarm = insight.tone === 'warn' || insight.tone === 'error'
 
   return html`
-    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-4">
+    <div
+      class=${`rounded-xl border p-4 transition-colors duration-300 ${panelCls}`}
+      role=${isAlarm ? 'alert' : undefined}
+      aria-live=${isAlarm ? 'polite' : undefined}
+    >
       <div class="flex items-start justify-between gap-3 flex-wrap">
         <div class="min-w-0">
           <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]">Operator Meaning</div>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1347,6 +1347,32 @@ function TurnPipelineStrip({
 
 // ── Zone 4: Health Grid ─────────────────────────────────
 
+/** Human-readable descriptions for MeasurementCard auto-rule flags.
+    Indexed by rule name → { on: "this fires next turn", off: "nothing
+    pending" } so the tooltip reflects the active half of the flag. */
+const MEASUREMENT_FLAG_DESCRIPTIONS: Record<string, { on: string; off: string }> = {
+  reflect: {
+    on: 'Keeper will pause before the next turn to self-evaluate its recent output (Reflexion loop).',
+    off: 'No reflection pending — keeper runs its next turn without self-check.',
+  },
+  plan: {
+    on: 'Keeper will re-plan its remaining steps before executing the next action.',
+    off: 'No re-plan scheduled — keeper follows its existing plan.',
+  },
+  compact: {
+    on: 'Context compaction is scheduled — older messages will be summarized to reclaim token budget.',
+    off: 'No compaction pending — the context window still has room.',
+  },
+  handoff: {
+    on: 'Keeper will emit a handover capsule and pass state to the next generation.',
+    off: 'No handoff scheduled — this generation continues running.',
+  },
+  guardrail: {
+    on: 'A guardrail has tripped — the keeper will halt pending operator intervention.',
+    off: 'No guardrail active — keeper runs under its normal safety envelope.',
+  },
+}
+
 function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   const m = snapshot.measurement
   return html`
@@ -1364,7 +1390,10 @@ function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
           </div>
           <div class="flex items-center gap-2 font-mono">
             <${Flag} label="guardrail" on=${m.auto_rules.guardrail_stop} tone="warn" />
-            <span class="text-[10px] text-[var(--text-dim)]">drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
+            <span
+              class="text-[10px] text-[var(--text-dim)] cursor-help"
+              title="Goal drift: 0 = keeper is on-target; higher = keeper output is diverging from its declared goal. Values above ~0.5 typically trigger the guardrail."
+            >drift ${m.auto_rules.goal_drift.toFixed(2)}</span>
           </div>
           ${m.auto_rules.guardrail_reason ? html`
             <div class="text-[9px] text-[#f59e0b] mt-0.5">사유: ${m.auto_rules.guardrail_reason}</div>
@@ -1377,6 +1406,12 @@ function MeasurementCard({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   `
 }
 
+export function flagTooltip(label: string, on: boolean): string {
+  const desc = MEASUREMENT_FLAG_DESCRIPTIONS[label]
+  if (!desc) return `${label}: ${on ? 'active' : 'inactive'}`
+  return `${label} (${on ? 'active' : 'inactive'})\n${on ? desc.on : desc.off}`
+}
+
 function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: 'ok' | 'warn' }) {
   const offCls = 'text-[var(--text-dim)] border-[var(--white-8)]'
   const onCls =
@@ -1384,7 +1419,10 @@ function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: '
       ? 'text-[#f59e0b] border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.08)]'
       : 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]'
   return html`
-    <span class=${`rounded-full border px-2 py-0.5 text-[10px] ${on ? onCls : offCls}`}>
+    <span
+      class=${`rounded-full border px-2 py-0.5 text-[10px] cursor-help ${on ? onCls : offCls}`}
+      title=${flagTooltip(label, on)}
+    >
       ${label}
     </span>
   `


### PR DESCRIPTION
## v16 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

Stacked on #7274 (v15). MeasurementCard 의 auto_rules flag 칩은 세션 초기부터 툴팁이 없어서 새 운영자가 "reflect 는 방금 일어난 건가 다음 턴에 일어날 건가" 를 알 수 없었다. v16 은 각 플래그에 활성/비활성 구분 설명을 붙인다.

## Changes

- `MEASUREMENT_FLAG_DESCRIPTIONS` 테이블 — `{ on, off }` 두 문장을 flag 별로 제공.
- `flagTooltip(label, on)` pure function export — 테스트 가능한 API.
- `Flag` 컴포넌트: `title=\${flagTooltip(...)}` + `cursor-help` — 툴팁 hover hint.
- Drift 숫자에도 별도 툴팁 — 의미 + 가드레일 트리거 임계 설명.
- Unknown label fallback — 나중에 새 flag 가 추가되어도 안전.

## Test

- 신규: `flagTooltip` 4 케이스 (on-copy / off-copy / guardrail-specific / unknown fallback).
- 회귀: vitest 93 files / 630 tests pass.
- typecheck: clean. vite build: clean.

## 의도적 한계

- 설명 문구는 RFC-0003 모델 기반 현재 동작 요약. 구현이 변경되면 업데이트 필요.
- 일부 브라우저(모바일 터치)에서 native `title` 은 hover 가 없어 표시 안 됨. 향후 custom tooltip 컴포넌트 고려 가능.