### PR TITLE
fix(dashboard): thread AbortSignal through mission briefing fetch (#7218)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -770,9 +770,12 @@ export interface DashboardVerificationRef {
   value: string
 }
 
-export function fetchDashboardMissionBriefing(force = false): Promise<DashboardMissionBriefingResponse> {
+export function fetchDashboardMissionBriefing(
+  force = false,
+  opts?: { signal?: AbortSignal },
+): Promise<DashboardMissionBriefingResponse> {
   const query = force ? '?force=1' : ''
-  return get(`/api/v1/dashboard/mission/briefing${query}`)
+  return get(`/api/v1/dashboard/mission/briefing${query}`, { signal: opts?.signal })
 }
 
 export function fetchDashboardPlanning(): Promise<DashboardPlanningResponse> {

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -231,9 +231,10 @@ export function MissionBriefingCard() {
     || (briefing?.status === 'unavailable' && !briefing?.cached)
 
   useEffect(() => {
-    if (!briefing && !missionBriefingLoading.value && !missionBriefingError.value) {
-      void refreshMissionBriefing()
-    }
+    if (briefing || missionBriefingLoading.value || missionBriefingError.value) return
+    const controller = new AbortController()
+    void refreshMissionBriefing(false, { signal: controller.signal })
+    return () => { controller.abort() }
   }, [briefing, missionBriefingLoading.value, missionBriefingError.value])
 
   const openLiveJudgeIntervene = () => {

--- a/dashboard/src/mission-actions.ts
+++ b/dashboard/src/mission-actions.ts
@@ -99,11 +99,15 @@ export async function refreshMissionSessionDetail(
   }
 }
 
-export async function refreshMissionBriefing(force = false): Promise<void> {
+export async function refreshMissionBriefing(
+  force = false,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
   missionBriefingLoading.value = true
   missionBriefingError.value = null
   try {
-    const raw = await fetchDashboardMissionBriefing(force)
+    const raw = await fetchDashboardMissionBriefing(force, { signal: opts?.signal })
+    if (opts?.signal?.aborted) return
     const normalized = normalizeMissionBriefing(raw)
     missionBriefing.value = normalized
     if (normalized.refreshing || normalized.status === 'pending') {
@@ -112,9 +116,12 @@ export async function refreshMissionBriefing(force = false): Promise<void> {
       clearMissionBriefingPoll()
     }
   } catch (err) {
+    if (isAbortError(err)) return
     missionBriefingError.value = err instanceof Error ? err.message : 'Failed to load mission briefing'
     clearMissionBriefingPoll()
   } finally {
-    missionBriefingLoading.value = false
+    if (!opts?.signal?.aborted) {
+      missionBriefingLoading.value = false
+    }
   }
 }


### PR DESCRIPTION
## Summary

#7260(mission session detail)의 pattern을 mission briefing에 동일 적용. Component unmount 시 in-flight briefing fetch가 실제로 취소되도록 AbortController 체인 추가.

| 파일 | 변경 |
|------|------|
| `api/dashboard.ts` | `fetchDashboardMissionBriefing`에 `opts?: { signal?: AbortSignal }` 추가 |
| `mission-actions.ts` | `refreshMissionBriefing` signal threading + race-safe loading |
| `components/mission-briefing-card.ts` | useEffect에서 AbortController 생성, cleanup abort |

**User-initiated button 유지**: line 353, 358의 retry 버튼은 사용자 의도적 액션이므로 signal 없이 그대로 `refreshMissionBriefing()` 호출. 이들은 완료까지 실행되어야 함.

## Linked issue

Refs #7218 — FETCH_NO_LIFECYCLE **1건** (`mission-briefing-card.ts:233`). 총 **4/9 완료** (이전: mission-session, keeper-state-diagram, keeper-memory-tier).

## Product impact

- Mission briefing이 느리게 로드되는 동안 사용자가 다른 surface로 이탈해도 fetch가 계속되던 문제 제거
- `scheduleMissionBriefingPoll`의 재귀적 polling이 abort 후에는 재예약되지 않음 (abort 체크가 try 블록의 polling 결정 이전에 위치)

## Evidence

| 검증 | 결과 |
|------|------|
| `tsc --noEmit` | 통과 |
| `vite build` | 통과 (10.29s) |
| vitest (mission) | 7 files, 21 tests 전부 pass |

## Review evidence

- 동일 pattern은 #7260에서 mission session detail에 적용되어 merged됨 — 재사용
- `isAbortError` import는 이미 mission-actions.ts에 존재 (#7260이 추가)
- `refreshMissionBriefing`의 기존 caller 3곳 중 1곳(useEffect)만 signal 전달, 나머지 2곳(retry 버튼)은 optional이므로 영향 없음

## Remaining work (#7218)

FETCH_NO_LIFECYCLE 5건 남음:
- `governance.ts:508` (2건)
- `connector-status.ts:715`
- `telemetry-unified.ts:658` (stylistic)
- `tools/tool-allowlist-editor.ts:157`
- `keeper-tool-telemetry.ts:113`
- `agent-profile.ts:302`

## Test plan

- [x] `tsc --noEmit` 통과
- [x] `vite build` 통과
- [x] mission 관련 7 files, 21 tests 모두 pass
- [ ] 시각 검증 — 브리핑이 로딩 중일 때 다른 surface로 이동 후 DevTools Network에서 요청 `canceled` 상태 확인

Refs #7218