### PR TITLE
refactor(orchestra): rename namespace → root, drop legacy carrier

### DIFF
--- a/lib/command_plane_orchestra.ml
+++ b/lib/command_plane_orchestra.ml
@@ -29,9 +29,9 @@ let by_id rows key_field =
 let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
   let config = ctx.config in
   let actor = ctx.agent_name in
-  let namespace = namespace_json config in
-  let namespace_id =
-    "namespace:" ^ (string_opt namespace "namespace" |> Option.value ~default:"default")
+  let root = root_json config in
+  let root_id =
+    "root:" ^ (string_opt root "project" |> Option.value ~default:"default")
   in
   let operator_snapshot = Operator_control.snapshot_json ~actor ctx in
   let pending_summary =
@@ -115,7 +115,7 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
   let ghost_worker_nodes = [] in
   let keeper_nodes = List.map keeper_node keepers in
   let nodes =
-    namespace_node namespace (List.length sessions) (List.length active_operation_rows)
+    root_node root (List.length sessions) (List.length active_operation_rows)
       (List.length actual_worker_nodes + List.length ghost_worker_nodes)
       (List.length keeper_nodes) (List.length alerts)
       (int_opt pending_summary "total_count" |> Option.value ~default:0)
@@ -150,7 +150,7 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
                match string_opt (assoc_or_empty swarm_json "operation") "operation_id" with
                | Some operation_id when List.mem_assoc operation_id operation_rows_by_id ->
                    "operation:" ^ operation_id
-               | _ -> namespace_id)
+               | _ -> root_id)
          in
          (worker_lanes
          |> List.map (fun (lane_name, _rows) ->
@@ -188,19 +188,19 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
              match string_opt keeper_json "id" with
              | Some keeper_id ->
                  Some
-                   (edge ~id:("edge:namespace-keeper:" ^ keeper_id)
-                      ~source:namespace_id ~target:keeper_id ~kind:"continuity"
+                   (edge ~id:("edge:root-keeper:" ^ keeper_id)
+                      ~source:root_id ~target:keeper_id ~kind:"continuity"
                       ~label:"keeper" ~provenance:"truth" ())
              | None -> None))
   in
   let signals =
     List.filter_map Fun.id
       [
-        signal_for_pending_confirms pending_summary namespace_id;
-        signal_for_runtime_blocker swarm_json namespace_id;
-        signal_for_hot_proof summary_json namespace_id;
+        signal_for_pending_confirms pending_summary root_id;
+        signal_for_runtime_blocker swarm_json root_id;
+        signal_for_hot_proof summary_json root_id;
       ]
-    @ signals_for_alerts alerts namespace_id
+    @ signals_for_alerts alerts root_id
   in
   let focus =
     match List.find_opt (fun signal_json -> string_opt signal_json "tone" = Some "bad") signals with
@@ -239,7 +239,7 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
                 ( "target_id",
                   `String
                     (string_opt node_json "id"
-                    |> Option.value ~default:namespace_id) );
+                    |> Option.value ~default:root_id) );
                 ("label", `String (string_opt node_json "label" |> Option.value ~default:"session"));
                 ("reason", `String "A session needs supervision or is not fully healthy.");
                 ("suggested_surface", `String "intervene");
@@ -249,13 +249,13 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
             `Assoc
               [
                 ("target_kind", `String "node");
-                ("target_id", `String namespace_id);
+                ("target_id", `String root_id);
                 ( "label",
                   `String
-                    (string_opt namespace "namespace" |> Option.value ~default:"default") );
+                    (string_opt root "project" |> Option.value ~default:"default") );
                 ( "reason",
                   `String
-                    "Namespace-wide view is healthy enough; start from the command overview."
+                    "Root view is healthy enough; start from the command overview."
                 );
                 ("suggested_surface", `String "summary");
                 ("suggested_params", `Assoc []);
@@ -265,7 +265,7 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
     [
       ("version", `String "orchestra.v1");
       ("generated_at", `String (Types.now_iso ()));
-      ("namespace", namespace);
+      ("root", root);
       ( "summary",
         `Assoc
           [
@@ -289,7 +289,7 @@ let json ?run_id:_ ?operation_id:_ (ctx : _ Operator_control.context) =
         `List
           [
             `String
-              "namespace-wide orchestra map is composed from command-plane truth, swarm live state, and operator read models.";
+              "root-wide orchestra map is composed from command-plane truth, swarm live state, and operator read models.";
             `String
               "provenance marks whether a node or signal is truth, derived, or fallback.";
           ] );

--- a/lib/cp_orchestra_nodes.ml
+++ b/lib/cp_orchestra_nodes.ml
@@ -1,19 +1,16 @@
 (** Cp_orchestra_nodes — Entity node renderers for CP orchestra graph.
 
-    Each function renders a specific CP entity (namespace, session, operation,
+    Each function renders a specific CP entity (root, session, operation,
     worker, keeper, etc.) as a graph node with facts and edges.
 
     @since God file decomposition — extracted from command_plane_orchestra.ml *)
 
 open Cp_orchestra_helpers
 
-let namespace_json config =
+let root_json config =
   if not (Room.is_initialized config) then
     `Assoc
       [
-        ("namespace_id", `String "default");
-        ("namespace", `String "default");
-        ("namespace_mode", `String "flattened");
         ("project", `String (Filename.basename config.base_path));
         ("cluster", `String (Env_config_core.cluster_name ()));
         ("paused", `Bool false);
@@ -28,9 +25,6 @@ let namespace_json config =
     let tasks = Room.get_tasks_raw config in
     `Assoc
       [
-        ("namespace_id", `String "default");
-        ("namespace", `String "default");
-        ("namespace_mode", `String "flattened");
         ("project", `String state.project);
         ("cluster", `String (Env_config_core.cluster_name ()));
         ("paused", `Bool state.paused);
@@ -40,25 +34,22 @@ let namespace_json config =
         ("message_count", `Int state.message_seq);
       ]
 
-let namespace_node namespace_json session_count operation_count worker_count keeper_count
+let root_node root_json session_count operation_count worker_count keeper_count
     alert_count pending_confirm_count =
-  let namespace_id =
-    first_some (string_opt namespace_json "namespace_id")
-      (string_opt namespace_json "namespace")
-    |> Option.value ~default:"default"
+  let label =
+    string_opt root_json "project" |> Option.value ~default:"root"
   in
-  let paused = bool_opt namespace_json "paused" |> Option.value ~default:false in
+  let paused = bool_opt root_json "paused" |> Option.value ~default:false in
   let tone = if paused || pending_confirm_count > 0 || alert_count > 0 then "warn" else "ok" in
-  node ~id:("namespace:" ^ namespace_id) ~kind:"namespace" ~label:namespace_id
-    ?subtitle:(string_opt namespace_json "project")
-    ~tone ~provenance:"truth" ~visual_class:"namespace-core" ~glyph:"◎"
+  node ~id:("root:" ^ label) ~kind:"root" ~label
+    ?subtitle:(string_opt root_json "project")
+    ~tone ~provenance:"truth" ~visual_class:"root-core" ~glyph:"◎"
     ?pulse:(pulse_of_tone tone)
     ~facts:
       [
-        fact "project"
-          (string_opt namespace_json "project" |> Option.value ~default:"n/a");
+        fact "project" label;
         fact "cluster"
-          (string_opt namespace_json "cluster" |> Option.value ~default:"default");
+          (string_opt root_json "cluster" |> Option.value ~default:"default");
         fact "sessions" (string_of_int session_count);
         fact "operations" (string_of_int operation_count);
         fact "workers" (string_of_int worker_count);

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -319,13 +319,13 @@ let test_orchestra_room_core_shape () =
       ignore (Room.broadcast config ~from_agent:"owner" ~content:"orchestra seed");
       let json = Command_plane_orchestra.json (operator_ctx env sw config "owner") in
       let nodes = Yojson.Safe.Util.(json |> member "nodes" |> to_list) in
-      Alcotest.(check bool) "namespace node exists" true
+      Alcotest.(check bool) "root node exists" true
         (List.exists
            (fun row ->
-             Yojson.Safe.Util.(row |> member "kind" |> to_string) = "namespace")
+             Yojson.Safe.Util.(row |> member "kind" |> to_string) = "root")
            nodes);
-      Alcotest.(check bool) "namespace block present" true
-        (Yojson.Safe.Util.member "namespace" json <> `Null);
+      Alcotest.(check bool) "root block present" true
+        (Yojson.Safe.Util.member "root" json <> `Null);
       Alcotest.(check int) "session count" 0
         Yojson.Safe.Util.(json |> member "summary" |> member "session_count" |> to_int);
       Alcotest.(check string) "focus kind" "node"


### PR DESCRIPTION
## Summary

Command-plane orchestra graph에서 \`namespace\` entity를 \`root\`로 rename하고 legacy carrier field(\`namespace_id\`/\`namespace\`/\`namespace_mode\`)를 제거. namespace axis는 이미 #6308에서 retired됐고 값이 base_path 기반의 project 이름으로 고정되어 있었음.

## Product impact

**Backend response 변경** (\`GET /api/v1/command-plane/orchestra\`):
- Top-level \`"namespace"\` object → \`"root"\` object
- root object에서 \`namespace_id\`, \`namespace\`, \`namespace_mode\` 3개 field 제거
- Node \`kind="namespace"\` → \`kind="root"\`, id prefix \`namespace:X\` → \`root:X\`, visual_class \`namespace-core\` → \`root-core\`
- Edge id prefix \`edge:namespace-keeper:\` → \`edge:root-keeper:\`
- Truth note 문구 \`"namespace-wide ..."\` → \`"root-wide ..."\`

**Dashboard consumer 없음**. \`dashboard/src/types/command-plane-orchestra.ts\`는 선언만 되어 있고 실제 fetch/render는 없음 (확인: \`rg command-plane/orchestra dashboard/src\` 매치 0건).

## Evidence

- \`opam exec -- dune build --root .\` → 0 errors
- test_operator_control (39 tests including snapshot/actions/judgment/keeper/swarm): **39/39 PASS**
  - "root node exists" + "root block present" assertion 업데이트된 버전 통과

## Review evidence

Self-reviewed. \`Cp_orchestra_nodes\`는 \`command_plane_orchestra\`에서만 \`include\`로 사용되고 외부 모듈 참조 0건 (확인: \`rg Cp_orchestra_nodes lib/\` — 선언 + include 1건). 함수명 rename이 backward compatibility 이슈 없음.

\`operator_control_snapshot.ml\`와 \`operator_digest.ml\`도 각자 \`namespace_id\` 필드를 내보내지만 **별개 code path**로, 이 PR scope 밖. 후속 PR에서 dashboard mission/operator normalizer와 함께 처리.

## Linked issue

Refs #7261 — Step 3b of Room/namespace → basePath 단일화 epic.

## Changes

| 파일 | 변경 |
|------|------|
| \`lib/cp_orchestra_nodes.ml\` | \`namespace_json\`/\`namespace_node\` → \`root_json\`/\`root_node\`; legacy 3개 field 삭제; label derived from \`project\` |
| \`lib/command_plane_orchestra.ml\` | local variables rename, edge/response/focus label/truth note 문구 업데이트 |
| \`test/test_operator_control_snapshot.ml\` | orchestra assertion: \`kind="namespace"\` → \`kind="root"\`, top-level \`"namespace"\` block → \`"root"\` |

+32 -41 (-9 net)

## Test plan

- [x] \`dune build\` pass
- [x] Operator control suite (39 tests) green
- [ ] CI Build and Test
- [ ] Dashboard runtime 영향 0 (endpoint 안 씀)

🤖 Generated with [Claude Code](https://claude.com/claude-code)