### PR TITLE
fix(keeper): evidence capture filters operator-local dirty state

### DIFF
--- a/lib/worktree_live_context.ml
+++ b/lib/worktree_live_context.ml
@@ -31,16 +31,56 @@ let repo_root_for ~base_path =
       if root = "" then None else Some root
   | _ -> None
 
-let current_status_lines ~repo_root =
+(** Paths that pollute cross-keeper evidence with operator-local dirty state.
+    These are never meaningfully "modified by a keeper turn" — they are
+    operator-local artifacts (runtime data dumps, handoff notes, temp
+    scratch, CI build tmp) that sit in the main repo root. Without this
+    filter, every keeper's evidence turn recorded the entire polluted
+    working tree as its own modifications, firing 34+ false-positive
+    cross-keeper collision warnings per evidence capture. *)
+let evidence_excluded_path_substrings =
+  [ ".masc/"
+  ; "data/"
+  ; "memory/"
+  ; "tmp_edit"
+  ; ".ci_"
+  ; "node_modules/"
+  ; "package-lock.json"
+  ]
+
+(** File-name patterns (root-level operator junk) that never belong to a
+    keeper turn: PR/issue dumps, CR snapshot files, comment snapshots. *)
+let evidence_excluded_filename_prefixes =
+  [ "pr_"; "cr_"; "comments_"; "all_comments_" ]
+
+(** Strip the leading `XY ` porcelain status prefix from a status line.
+    `git status --porcelain` emits lines like ` M lib/foo.ml`, `?? data/`,
+    `R  old -> new`. After trimming leading whitespace we still carry
+    e.g. `M sample.ml` or `?? pr_430.json` — the filename starts after
+    the first space in the trimmed line. *)
+let path_after_porcelain_prefix trimmed_line =
+  match String.index_opt trimmed_line ' ' with
+  | Some idx when idx + 1 < String.length trimmed_line ->
+      String.sub trimmed_line (idx + 1) (String.length trimmed_line - idx - 1)
+  | _ -> trimmed_line
+
+let path_is_operator_noise trimmed_line =
+  let path = path_after_porcelain_prefix trimmed_line in
   let contains_substring text ~substring =
     String_util.contains_substring text substring
   in
+  let starts_with_prefix prefix = String.starts_with ~prefix path in
+  List.exists
+    (fun substring -> contains_substring path ~substring)
+    evidence_excluded_path_substrings
+  || List.exists starts_with_prefix evidence_excluded_filename_prefixes
+
+let current_status_lines ~repo_root =
   run_git_capture_lines ~workdir:repo_root [ "status"; "--porcelain" ]
   |> Option.value ~default:[]
   |> List.map String.trim
-  |> List.filter (fun line ->
-         not (contains_substring line ~substring:".masc/"))
   |> List.filter (fun line -> line <> "")
+  |> List.filter (fun line -> not (path_is_operator_noise line))
 
 let state_dir ~repo_root =
   Filename.concat (Filename.concat repo_root ".masc") "live-context"

--- a/test/test_worktree_live_context.ml
+++ b/test/test_worktree_live_context.ml
@@ -98,6 +98,45 @@ let test_capture_change_block_in_eio_runtime () =
         check (option string) "same change not repeated in eio" None
           (Wlc.capture_change_block ~base_path:dir ~actor_key:"keeper-a")))
 
+(** Regression: pre-filter rejects paths that operators leave dirty in
+    the repo root (data/*.jsonl, memory/*.md, tmp_edit/, pr_*.json, etc).
+    Without this filter, every keeper's evidence turn recorded the full
+    operator-local working tree as its own "modifications", producing
+    34+ cross-keeper collision warnings per turn. *)
+let test_current_status_lines_filters_operator_noise () =
+  with_temp_dir "status-exclude" (fun dir ->
+    init_repo dir;
+    (* Create untracked operator junk in the excluded roots. *)
+    Unix.mkdir (Filename.concat dir "data") 0o755;
+    write_file (Filename.concat dir "data/run.jsonl") "row\n";
+    Unix.mkdir (Filename.concat dir "memory") 0o755;
+    write_file (Filename.concat dir "memory/note.md") "hi\n";
+    Unix.mkdir (Filename.concat dir "tmp_edit") 0o755;
+    write_file (Filename.concat dir "tmp_edit/scratch.txt") "x\n";
+    write_file (Filename.concat dir "pr_430.json") "{}\n";
+    write_file (Filename.concat dir "cr_latest.txt") "..\n";
+    write_file (Filename.concat dir "comments_430.txt") "..\n";
+    (* Plus one legitimate keeper-modified tracked file. *)
+    write_file (Filename.concat dir "sample.ml") "let value = 2\n";
+    let lines = Wlc.current_status_lines ~repo_root:dir in
+    check int "only the real keeper change surfaces" 1 (List.length lines);
+    let only = List.hd lines in
+    check bool "returned line mentions sample.ml" true
+      (try
+         ignore
+           (Str.search_forward (Str.regexp_string "sample.ml") only 0);
+         true
+       with Not_found -> false))
+
+(** Keeper-created source files (untracked at first) MUST still surface
+    in evidence — that's the whole point of tracking new files. *)
+let test_current_status_lines_keeps_keeper_new_files () =
+  with_temp_dir "status-new" (fun dir ->
+    init_repo dir;
+    write_file (Filename.concat dir "new_module.ml") "let x = 1\n";
+    let lines = Wlc.current_status_lines ~repo_root:dir in
+    check int "untracked keeper file surfaces" 1 (List.length lines))
+
 let () =
   run "Worktree_live_context"
     [
@@ -108,5 +147,12 @@ let () =
             test_capture_distinguishes_new_changes;
           test_case "works in Eio runtime" `Quick
             test_capture_change_block_in_eio_runtime;
+        ] );
+      ( "current_status_lines",
+        [
+          test_case "filters operator-noise paths (data/, memory/, pr_*.json, etc.)"
+            `Quick test_current_status_lines_filters_operator_noise;
+          test_case "keeps keeper-created new files"
+            `Quick test_current_status_lines_keeps_keeper_new_files;
         ] );
     ]


### PR DESCRIPTION
## Summary

사용자 관찰 (로그):
\`\`\`
[WARN] [Keeper] evidence: janitor has 34 file collision(s) with other keeper(s)
       — overlapping writes may corrupt shared state
\`\`\`

## 정체

\`keeper_evidence\`가 \`git status --porcelain\`을 **공유 repo 루트**에서 읽는다.
루트에 operator-local 어지러운 상태가 있으면 (data/JSONL dump, memory/handoff 노트, tmp_edit/, pr_*.json, cr_*.txt 같은 scratch 파일) 모든 keeper가 같은 34개 파일을 자기 "변경"으로 기록 → 300s 윈도우 내 짝짝마다 **34 false-positive collision** fire.

경고 자체는 설계대로 작동. 입력이 거짓말한 것: keeper들은 실제로 그 파일을 안 건드렸고 **공유 dirty 트리를 같이 읽었을 뿐**.

## Fix

\`Worktree_live_context.current_status_lines\`의 기존 \`.masc/\` 필터를 확장:

**Path-substring 제외:**
- \`data/\` — runtime JSONL dump
- \`memory/\` — operator handoff/recall 노트
- \`tmp_edit\` — scratch edit 디렉토리
- \`.ci_\` — CI build artifact
- \`node_modules/\`, \`package-lock.json\`

**Root-filename-prefix 제외:**
- \`pr_*\` (pr_430.json 등)
- \`cr_*\` (cr_latest.txt 등)
- \`comments_*\`, \`all_comments_*\`

## 보존되는 동작

Keeper가 새로 만든 untracked source 파일 (\`new_module.ml\` 같은)은 **여전히 감지됨**. 기존 \`capture_change_block\` 3개 테스트 변경 없이 pass.

## Test plan
- [x] 5/5 Worktree_live_context tests pass (2 신규 + 3 기존)
- [x] 41 keeper tests pass (hallucination gate + github hint)
- [x] \`dune build @all\` clean
- [ ] CI green

## 실측 영향
루트에 ~34 dirty operator 파일이 있을 때, keeper turn당 cross-keeper collision warning이 **34+ → 0** (실제 공유 경로 write가 발생할 때까지).

## 한계 (후속 PR)

이 fix는 증상을 줄이지만 근본 문제 — 모든 keeper가 공유 repo 루트의 status를 봄 — 은 남아있다. 더 정직한 fix는 \"delivery\" preset keeper의 경우 자기 playground worktree의 status만 보도록 wiring하는 것. 별도 이슈로 트래킹.

🤖 Generated with [Claude Code](https://claude.com/claude-code)