### PR TITLE
feat(dashboard): Turn Budget panel - iteration 1 of visibility loop

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -251,10 +251,10 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
               <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
               <td class="py-1.5 text-center">
                 ${row.budget_source === 'override_invalid'
-                  ? html`<span class="rounded bg-red-500/15 px-1 py-0.5 text-[9px] font-semibold text-red-300" title="잘못된 TOML override">!</span>`
+                  ? html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold text-red-300" title="TOML override가 범위를 벗어남">ERR</span>`
                   : row.budget_source === 'override'
-                    ? html`<span class="rounded bg-amber-500/15 px-1 py-0.5 text-[9px] font-semibold text-amber-300" title="TOML override 적용됨">O</span>`
-                    : html`<span class="text-[9px] text-[var(--text-dim)]">-</span>`}
+                    ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold text-amber-300" title="TOML override 적용됨">OVR</span>`
+                    : html`<span class="text-[9px] text-[var(--text-dim)]">\u2014</span>`}
               </td>
               <td class="py-1.5 text-center">
                 <button
@@ -426,6 +426,7 @@ export function FleetTelemetryPanel() {
         ? 'ok'
         : 'warn'
   const sourcesWithData = value.telemetry_sources.filter(source => source.entry_count > 0).length
+  const budgetOverrideCount = value.rows.filter(r => r.budget_source === 'override' || r.budget_source === 'override_invalid').length
 
   if (value.loading && value.rows.length === 0) {
     return html`<${LoadingState}>Keeper 텔레메트리 불러오는 중...<//>`
@@ -468,6 +469,7 @@ export function FleetTelemetryPanel() {
             ${activeCount > 0 ? html`<span class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-emerald-400">${activeCount} 가동</span>` : null}
             ${attentionCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-amber-400">${attentionCount} 주의</span>` : null}
             ${offlineCount > 0 ? html`<span class="rounded-full bg-[var(--white-8)] px-1.5 py-0.5 text-[var(--text-dim)]">${offlineCount} 오프라인</span>` : null}
+            ${budgetOverrideCount > 0 ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-amber-300">${budgetOverrideCount} 예산 재정의</span>` : null}
           </div>
         </div>
         <div class="flex items-center gap-2">

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -201,6 +201,7 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
             <th class="py-1 text-right font-normal">Ctx</th>
             <th class="py-1 text-right font-normal">Latency</th>
             <th class="py-1 text-right font-normal">Model</th>
+            <th class="py-1 text-center font-normal">Budget</th>
             <th class="w-8 py-1"></th>
           </tr>
         </thead>
@@ -248,6 +249,13 @@ function FleetComparisonTable({ rows, onReset }: { rows: FleetRow[]; onReset: (n
                 valueClass="text-[var(--text-dim)]"
               />
               <td class="py-1.5 text-right text-[10px] text-[var(--text-dim)]">${row.model}</td>
+              <td class="py-1.5 text-center">
+                ${row.budget_source === 'override_invalid'
+                  ? html`<span class="rounded bg-red-500/15 px-1 py-0.5 text-[9px] font-semibold text-red-300" title="잘못된 TOML override">!</span>`
+                  : row.budget_source === 'override'
+                    ? html`<span class="rounded bg-amber-500/15 px-1 py-0.5 text-[9px] font-semibold text-amber-300" title="TOML override 적용됨">O</span>`
+                    : html`<span class="text-[9px] text-[var(--text-dim)]">-</span>`}
+              </td>
               <td class="py-1.5 text-center">
                 <button
                   class="rounded p-0.5 text-[var(--text-dim)] hover:text-red-400 hover:bg-red-400/10 transition-colors"

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -26,6 +26,7 @@ export interface FleetRow {
   runtime_blocker_class: Keeper['runtime_blocker_class'] | null
   runtime_blocker_summary: string | null
   tool_audit_at: string | null
+  budget_source: 'override' | 'override_invalid' | 'env' | null
 }
 
 export interface FleetTelemetryState {
@@ -310,6 +311,16 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             runtime_blocker_summary:
               firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker) ?? null,
             tool_audit_at: keeper.tool_audit_at ?? null,
+            budget_source:
+              keeper.turn_budget?.reactive.source === 'override' ||
+              keeper.turn_budget?.reactive.source === 'override_invalid' ||
+              keeper.turn_budget?.scheduled_autonomous.source === 'override' ||
+              keeper.turn_budget?.scheduled_autonomous.source === 'override_invalid'
+                ? (keeper.turn_budget?.reactive.source === 'override_invalid' ||
+                   keeper.turn_budget?.scheduled_autonomous.source === 'override_invalid'
+                    ? 'override_invalid'
+                    : 'override')
+                : 'env',
           }
         })
       : toolQuality.by_keeper.map((keeper): FleetRow => ({
@@ -328,6 +339,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           runtime_blocker_class: null,
           runtime_blocker_summary: null,
           tool_audit_at: null,
+          budget_source: null,
         }))
 
   return [...rows].sort(compareFleetRows)

--- a/dashboard/src/components/fleet-trend-store.test.ts
+++ b/dashboard/src/components/fleet-trend-store.test.ts
@@ -19,6 +19,7 @@ function makeRow(name: string, overrides: Partial<FleetRow> = {}): FleetRow {
     runtime_blocker_class: null,
     runtime_blocker_summary: null,
     tool_audit_at: null,
+    budget_source: null,
     ...overrides,
   }
 }

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -160,11 +160,23 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
 
 // ── Turn Budget ──────────────────────────────────────────
 
+export function hasTurnBudgetDivergence(keeper: Keeper): boolean {
+  const b = keeper.turn_budget
+  if (!b) return false
+  return (
+    b.reactive.source === 'override' ||
+    b.reactive.source === 'override_invalid' ||
+    b.scheduled_autonomous.source === 'override' ||
+    b.scheduled_autonomous.source === 'override_invalid'
+  )
+}
+
 interface BudgetSlot {
   value: number
-  source: 'override' | 'env'
+  source: 'override' | 'env' | 'override_invalid'
   env_default: number
   env_var: string
+  raw_override: number | null
 }
 
 function buildBudgetTooltip(slot: BudgetSlot, manifest: string | null, clamp: { min: number; max: number }): string {
@@ -173,6 +185,13 @@ function buildBudgetTooltip(slot: BudgetSlot, manifest: string | null, clamp: { 
     lines.push(`Source: TOML override`)
     if (manifest) lines.push(`File:   ${manifest}`)
     lines.push(`Value:  ${slot.value}  (env default was ${slot.env_default})`)
+  } else if (slot.source === 'override_invalid') {
+    lines.push(`Source: env default (override REJECTED)`)
+    if (manifest) lines.push(`File:   ${manifest}`)
+    if (slot.raw_override != null) {
+      lines.push(`Raw:    ${slot.raw_override}  — out of range [${clamp.min}, ${clamp.max}]`)
+    }
+    lines.push(`Value:  ${slot.value}  (fell back to env default)`)
   } else {
     lines.push(`Source: env default`)
     lines.push(`Env:    ${slot.env_var} = ${slot.value}`)
@@ -189,12 +208,26 @@ function BudgetRow({ label, slot, manifest, clamp }: {
   clamp: { min: number; max: number }
 }) {
   const isOverride = slot.source === 'override'
+  const isInvalid = slot.source === 'override_invalid'
   const delta = slot.value - slot.env_default
   const deltaText = delta === 0
     ? null
     : delta > 0
       ? `+${delta} vs env`
       : `${delta} vs env`
+
+  let valueClass: string
+  let pill
+  if (isInvalid) {
+    valueClass = 'text-red-300 underline decoration-wavy decoration-red-400 underline-offset-4 cursor-help'
+    pill = html`<span class="rounded bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-red-300">invalid</span>`
+  } else if (isOverride) {
+    valueClass = 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
+    pill = html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+  } else {
+    valueClass = 'text-[var(--text-muted)] cursor-help'
+    pill = html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`
+  }
 
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
@@ -204,14 +237,10 @@ function BudgetRow({ label, slot, manifest, clamp }: {
           ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">${deltaText}</span>`
           : null}
         <span
-          class="text-xs font-medium tabular-nums ${isOverride
-            ? 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
-            : 'text-[var(--text-muted)] cursor-help'}"
+          class="text-xs font-medium tabular-nums ${valueClass}"
           title=${buildBudgetTooltip(slot, manifest, clamp)}
         >${slot.value}</span>
-        ${isOverride
-          ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
-          : html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`}
+        ${pill}
       </div>
     </div>
   `
@@ -230,6 +259,9 @@ export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
   const hasOverride =
     budget.reactive.source === 'override' ||
     budget.scheduled_autonomous.source === 'override'
+  const hasInvalid =
+    budget.reactive.source === 'override_invalid' ||
+    budget.scheduled_autonomous.source === 'override_invalid'
   const clamp = { min: budget.clamp_min, max: budget.clamp_max }
 
   return html`
@@ -238,9 +270,11 @@ export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
         <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
           턴 예산 (per OAS call)
         </span>
-        ${hasOverride
-          ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">drift</span>`
-          : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
+        ${hasInvalid
+          ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-red-300">invalid override</span>`
+          : hasOverride
+            ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+            : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형 (reactive)"

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -160,26 +160,55 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
 
 // ── Turn Budget ──────────────────────────────────────────
 
-function BudgetRow({ label, value, source, usage }: {
-  label: string
+interface BudgetSlot {
   value: number
   source: 'override' | 'env'
-  usage?: string
+  env_default: number
+  env_var: string
+}
+
+function buildBudgetTooltip(slot: BudgetSlot, manifest: string | null, clamp: { min: number; max: number }): string {
+  const lines: string[] = []
+  if (slot.source === 'override') {
+    lines.push(`Source: TOML override`)
+    if (manifest) lines.push(`File:   ${manifest}`)
+    lines.push(`Value:  ${slot.value}  (env default was ${slot.env_default})`)
+  } else {
+    lines.push(`Source: env default`)
+    lines.push(`Env:    ${slot.env_var} = ${slot.value}`)
+    lines.push(`Note:   no override in TOML`)
+  }
+  lines.push(`Range:  [${clamp.min}, ${clamp.max}]`)
+  return lines.join('\n')
+}
+
+function BudgetRow({ label, slot, manifest, clamp }: {
+  label: string
+  slot: BudgetSlot
+  manifest: string | null
+  clamp: { min: number; max: number }
 }) {
-  const isOverride = source === 'override'
+  const isOverride = slot.source === 'override'
+  const delta = slot.value - slot.env_default
+  const deltaText = delta === 0
+    ? null
+    : delta > 0
+      ? `+${delta} vs env`
+      : `${delta} vs env`
+
   return html`
     <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
       <span class="text-xs text-[var(--text-muted)]">${label}</span>
       <div class="flex items-center gap-2">
-        ${usage ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">${usage}</span>` : null}
+        ${isOverride && deltaText
+          ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">${deltaText}</span>`
+          : null}
         <span
           class="text-xs font-medium tabular-nums ${isOverride
-            ? 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/50 underline-offset-4'
-            : 'text-[var(--text-muted)]'}"
-          title=${isOverride
-            ? `Override: config/keepers/<name>.toml 에 설정됨`
-            : `Env default: MASC_KEEPER_OAS_MAX_TURNS_PER_CALL${label.includes('자율') ? '_SCHEDULED_AUTONOMOUS' : ''}`}
-        >${value}</span>
+            ? 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/60 underline-offset-4 cursor-help'
+            : 'text-[var(--text-muted)] cursor-help'}"
+          title=${buildBudgetTooltip(slot, manifest, clamp)}
+        >${slot.value}</span>
         ${isOverride
           ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
           : html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`}
@@ -198,13 +227,10 @@ export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
     `
   }
 
-  const turnCount = typeof keeper.turn_count === 'number' ? keeper.turn_count : null
-  const reactiveUsage =
-    turnCount != null ? `${turnCount}/${budget.reactive.value}` : undefined
-
   const hasOverride =
     budget.reactive.source === 'override' ||
     budget.scheduled_autonomous.source === 'override'
+  const clamp = { min: budget.clamp_min, max: budget.clamp_max }
 
   return html`
     <div class="flex flex-col gap-1.5">
@@ -214,22 +240,24 @@ export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
         </span>
         ${hasOverride
           ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">drift</span>`
-          : null}
+          : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
       </div>
       <${BudgetRow}
         label="반응형 (reactive)"
-        value=${budget.reactive.value}
-        source=${budget.reactive.source}
-        usage=${reactiveUsage}
+        slot=${budget.reactive}
+        manifest=${budget.manifest_path}
+        clamp=${clamp}
       />
       <${BudgetRow}
         label="예약 자율 (scheduled autonomous)"
-        value=${budget.scheduled_autonomous.value}
-        source=${budget.scheduled_autonomous.source}
+        slot=${budget.scheduled_autonomous}
+        manifest=${budget.manifest_path}
+        clamp=${clamp}
       />
       <span class="text-[11px] text-[var(--text-muted)] leading-snug mt-1">
-        반응형은 보드/멘션 반응 턴, 예약 자율은 idle cycle 턴 예산입니다.
-        Override는 TOML에서 재정의된 값이고, env는 전역 기본값 상속입니다.
+        반응형 = 보드/멘션 반응 턴 예산, 예약 자율 = idle cycle 턴 예산.
+        값에 마우스를 올리면 source path와 env default 비교가 tooltip으로 나타납니다.
+        실제 소비 진행(turn_count/budget)은 현재 backend에 노출되지 않아 표시하지 않습니다.
       </span>
     </div>
   `

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -268,7 +268,7 @@ export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
     <div class="flex flex-col gap-1.5">
       <div class="flex items-center gap-2 mb-1">
         <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          턴 예산 (per OAS call)
+          턴 예산 (OAS 호출당)
         </span>
         ${hasInvalid
           ? html`<span class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-red-300">invalid override</span>`
@@ -277,23 +277,38 @@ export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
             : html`<span class="rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-emerald-400">inherited</span>`}
       </div>
       <${BudgetRow}
-        label="반응형 (reactive)"
+        label="반응형"
         slot=${budget.reactive}
         manifest=${budget.manifest_path}
         clamp=${clamp}
       />
       <${BudgetRow}
-        label="예약 자율 (scheduled autonomous)"
+        label="예약 자율"
         slot=${budget.scheduled_autonomous}
         manifest=${budget.manifest_path}
         clamp=${clamp}
       />
       <span class="text-[11px] text-[var(--text-muted)] leading-snug mt-1">
-        반응형 = 보드/멘션 반응 턴 예산, 예약 자율 = idle cycle 턴 예산.
-        값에 마우스를 올리면 source path와 env default 비교가 tooltip으로 나타납니다.
-        실제 소비 진행(turn_count/budget)은 현재 backend에 노출되지 않아 표시하지 않습니다.
+        반응형 = 보드/멘션 반응 턴 예산, 예약 자율 = 자율 주기 턴 예산.
+        값에 마우스를 올리면 설정 출처와 기본값 비교를 확인할 수 있습니다.
       </span>
     </div>
+  `
+}
+
+export function TurnBudgetSection({ keeper }: { keeper: Keeper }) {
+  const diverges = hasTurnBudgetDivergence(keeper)
+  return html`
+    <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open=${diverges}>
+      <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+        <span class="w-1.5 h-1.5 rounded-full ${diverges ? 'bg-amber-400' : 'bg-accent/50'}"></span>
+        턴 예산
+        ${diverges ? html`<span class="text-[9px] text-amber-300 font-normal normal-case tracking-normal">(재정의됨)</span>` : null}
+      </summary>
+      <div class="mt-3">
+        <${TurnBudgetPanel} keeper=${keeper} />
+      </div>
+    </details>
   `
 }
 

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -158,6 +158,83 @@ function ToolSection({ title, description, tools, fallback }: { title: string; d
   `
 }
 
+// ── Turn Budget ──────────────────────────────────────────
+
+function BudgetRow({ label, value, source, usage }: {
+  label: string
+  value: number
+  source: 'override' | 'env'
+  usage?: string
+}) {
+  const isOverride = source === 'override'
+  return html`
+    <div class="flex items-center justify-between py-2 px-3 rounded-lg bg-[var(--white-3)]">
+      <span class="text-xs text-[var(--text-muted)]">${label}</span>
+      <div class="flex items-center gap-2">
+        ${usage ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums">${usage}</span>` : null}
+        <span
+          class="text-xs font-medium tabular-nums ${isOverride
+            ? 'text-[var(--text-strong)] underline decoration-dotted decoration-amber-300/50 underline-offset-4'
+            : 'text-[var(--text-muted)]'}"
+          title=${isOverride
+            ? `Override: config/keepers/<name>.toml 에 설정됨`
+            : `Env default: MASC_KEEPER_OAS_MAX_TURNS_PER_CALL${label.includes('자율') ? '_SCHEDULED_AUTONOMOUS' : ''}`}
+        >${value}</span>
+        ${isOverride
+          ? html`<span class="rounded bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">override</span>`
+          : html`<span class="rounded bg-[var(--white-6)] px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider text-[var(--text-muted)]">env</span>`}
+      </div>
+    </div>
+  `
+}
+
+export function TurnBudgetPanel({ keeper }: { keeper: Keeper }) {
+  const budget = keeper.turn_budget
+  if (!budget) {
+    return html`
+      <div class="text-[11px] text-[var(--text-muted)] italic">
+        턴 예산 정보를 아직 수신하지 못했습니다. 서버 재시작 후 확인해주세요.
+      </div>
+    `
+  }
+
+  const turnCount = typeof keeper.turn_count === 'number' ? keeper.turn_count : null
+  const reactiveUsage =
+    turnCount != null ? `${turnCount}/${budget.reactive.value}` : undefined
+
+  const hasOverride =
+    budget.reactive.source === 'override' ||
+    budget.scheduled_autonomous.source === 'override'
+
+  return html`
+    <div class="flex flex-col gap-1.5">
+      <div class="flex items-center gap-2 mb-1">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          턴 예산 (per OAS call)
+        </span>
+        ${hasOverride
+          ? html`<span class="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-amber-300">drift</span>`
+          : null}
+      </div>
+      <${BudgetRow}
+        label="반응형 (reactive)"
+        value=${budget.reactive.value}
+        source=${budget.reactive.source}
+        usage=${reactiveUsage}
+      />
+      <${BudgetRow}
+        label="예약 자율 (scheduled autonomous)"
+        value=${budget.scheduled_autonomous.value}
+        source=${budget.scheduled_autonomous.source}
+      />
+      <span class="text-[11px] text-[var(--text-muted)] leading-snug mt-1">
+        반응형은 보드/멘션 반응 턴, 예약 자율은 idle cycle 턴 예산입니다.
+        Override는 TOML에서 재정의된 값이고, env는 전역 기본값 상속입니다.
+      </span>
+    </div>
+  `
+}
+
 // ── Runtime Signals ──────────────────────────────────────
 
 // Helper: format a 0–1 ratio as percentage or '-'

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -41,6 +41,7 @@ import {
   KeeperNeighborhood,
   RuntimeSignals,
   TurnBudgetPanel,
+  hasTurnBudgetDivergence,
 } from './keeper-detail-runtime'
 import {
   KeeperConfigPanel,
@@ -678,10 +679,13 @@ export function KeeperDetailOverlay() {
             <${RuntimeSignals} keeper=${keeper} />
           </details>
 
-          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open>
+          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open=${hasTurnBudgetDivergence(keeper)}>
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
-              <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
+              <span class="w-1.5 h-1.5 rounded-full ${hasTurnBudgetDivergence(keeper) ? 'bg-amber-400' : 'bg-accent/50'}"></span>
               턴 예산
+              ${hasTurnBudgetDivergence(keeper)
+                ? html`<span class="text-[9px] text-amber-300 font-normal normal-case tracking-normal">(override)</span>`
+                : null}
             </summary>
             <div class="mt-3">
               <${TurnBudgetPanel} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -40,6 +40,7 @@ import {
 import {
   KeeperNeighborhood,
   RuntimeSignals,
+  TurnBudgetPanel,
 } from './keeper-detail-runtime'
 import {
   KeeperConfigPanel,
@@ -675,6 +676,16 @@ export function KeeperDetailOverlay() {
             </summary>
             <div class="mt-3 text-[11px] text-[var(--text-muted)] mb-3">폴백 비율, 정렬 품질, 자율 행동 비율 등 metrics_window 기반 런타임 품질 지표</div>
             <${RuntimeSignals} keeper=${keeper} />
+          </details>
+
+          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open>
+            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+              <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
+              턴 예산
+            </summary>
+            <div class="mt-3">
+              <${TurnBudgetPanel} keeper=${keeper} />
+            </div>
           </details>
 
           <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -40,8 +40,7 @@ import {
 import {
   KeeperNeighborhood,
   RuntimeSignals,
-  TurnBudgetPanel,
-  hasTurnBudgetDivergence,
+  TurnBudgetSection,
 } from './keeper-detail-runtime'
 import {
   KeeperConfigPanel,
@@ -679,18 +678,7 @@ export function KeeperDetailOverlay() {
             <${RuntimeSignals} keeper=${keeper} />
           </details>
 
-          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm" open=${hasTurnBudgetDivergence(keeper)}>
-            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
-              <span class="w-1.5 h-1.5 rounded-full ${hasTurnBudgetDivergence(keeper) ? 'bg-amber-400' : 'bg-accent/50'}"></span>
-              턴 예산
-              ${hasTurnBudgetDivergence(keeper)
-                ? html`<span class="text-[9px] text-amber-300 font-normal normal-case tracking-normal">(override)</span>`
-                : null}
-            </summary>
-            <div class="mt-3">
-              <${TurnBudgetPanel} keeper=${keeper} />
-            </div>
-          </details>
+          <${TurnBudgetSection} keeper=${keeper} />
 
           <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
             <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">

--- a/dashboard/src/keeper-store-normalize.test.ts
+++ b/dashboard/src/keeper-store-normalize.test.ts
@@ -344,3 +344,99 @@ describe('normalizeKeepers lifecycle metrics', () => {
     })
   })
 })
+
+describe('normalizeKeepers turn_budget', () => {
+  it('normalizes override reactive + env autonomous with provenance fields', () => {
+    const [k] = normalizeKeepers([
+      {
+        name: 'poe',
+        status: 'active',
+        turn_budget: {
+          reactive: {
+            value: 25,
+            source: 'override',
+            env_default: 15,
+            env_var: 'MASC_KEEPER_OAS_MAX_TURNS_PER_CALL',
+          },
+          scheduled_autonomous: {
+            value: 2,
+            source: 'env',
+            env_default: 2,
+            env_var: 'MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS',
+          },
+          manifest_path: '/abs/config/keepers/poe.toml',
+          clamp_min: 1,
+          clamp_max: 50,
+        },
+      },
+    ])
+    expect(k?.turn_budget).toEqual({
+      reactive: {
+        value: 25,
+        source: 'override',
+        env_default: 15,
+        env_var: 'MASC_KEEPER_OAS_MAX_TURNS_PER_CALL',
+      },
+      scheduled_autonomous: {
+        value: 2,
+        source: 'env',
+        env_default: 2,
+        env_var: 'MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS',
+      },
+      manifest_path: '/abs/config/keepers/poe.toml',
+      clamp_min: 1,
+      clamp_max: 50,
+    })
+  })
+
+  it('returns null when turn_budget is absent', () => {
+    const [k] = normalizeKeepers([{ name: 'no-budget', status: 'active' }])
+    expect(k?.turn_budget).toBeNull()
+  })
+
+  it('returns null when either slot is missing value', () => {
+    const [k] = normalizeKeepers([
+      {
+        name: 'partial',
+        status: 'active',
+        turn_budget: {
+          reactive: { value: 15, source: 'env' },
+          // scheduled_autonomous missing — should reject the whole budget
+        },
+      },
+    ])
+    expect(k?.turn_budget).toBeNull()
+  })
+
+  it('defaults env_default to current value and clamp to [1,50] when backend omits them', () => {
+    const [k] = normalizeKeepers([
+      {
+        name: 'minimal',
+        status: 'active',
+        turn_budget: {
+          reactive: { value: 15, source: 'env' },
+          scheduled_autonomous: { value: 2, source: 'env' },
+        },
+      },
+    ])
+    expect(k?.turn_budget?.reactive.env_default).toBe(15)
+    expect(k?.turn_budget?.clamp_min).toBe(1)
+    expect(k?.turn_budget?.clamp_max).toBe(50)
+    expect(k?.turn_budget?.manifest_path).toBeNull()
+  })
+
+  it('coerces unknown source string to env (safe fallback)', () => {
+    const [k] = normalizeKeepers([
+      {
+        name: 'unknown-source',
+        status: 'active',
+        turn_budget: {
+          reactive: { value: 15, source: 'garbage' },
+          scheduled_autonomous: { value: 2, source: 'override' },
+        },
+      },
+    ])
+    expect(k?.turn_budget?.reactive.source).toBe('env')
+    expect(k?.turn_budget?.scheduled_autonomous.source).toBe('override')
+  })
+})

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -110,10 +110,19 @@ function normalizeTurnBudget(raw: unknown): Keeper['turn_budget'] {
     if (!isRecord(v)) return null
     const value = asNumber(v.value)
     if (value == null) return null
-    const source: 'override' | 'env' = v.source === 'override' ? 'override' : 'env'
+    let source: 'override' | 'env' | 'override_invalid' = 'env'
+    if (v.source === 'override') source = 'override'
+    else if (v.source === 'override_invalid') source = 'override_invalid'
     const envDefault = asNumber(v.env_default) ?? value
     const envVar = asString(v.env_var) ?? ''
-    return { value, source, env_default: envDefault, env_var: envVar }
+    const rawOverride = asNumber(v.raw_override)
+    return {
+      value,
+      source,
+      env_default: envDefault,
+      env_var: envVar,
+      raw_override: rawOverride ?? null,
+    }
   }
   const reactive = readSlot(raw.reactive)
   const scheduled = readSlot(raw.scheduled_autonomous)

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -104,6 +104,21 @@ export function keeperFreshnessTs(keeper: Keeper, heartbeats: Map<string, number
     : null
 }
 
+function normalizeTurnBudget(raw: unknown): Keeper['turn_budget'] {
+  if (!isRecord(raw)) return null
+  const readSlot = (v: unknown): { value: number; source: 'override' | 'env' } | null => {
+    if (!isRecord(v)) return null
+    const value = asNumber(v.value)
+    if (value == null) return null
+    const source = v.source === 'override' ? 'override' : 'env'
+    return { value, source }
+  }
+  const reactive = readSlot(raw.reactive)
+  const scheduled = readSlot(raw.scheduled_autonomous)
+  if (!reactive || !scheduled) return null
+  return { reactive, scheduled_autonomous: scheduled }
+}
+
 function normalizePromptSegments(
   raw: Record<string, unknown> | null,
   excludedKeys: Set<string>,
@@ -402,6 +417,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         latest_tool_call_count: asNumber(row.latest_tool_call_count) ?? null,
         tool_audit_source: asString(row.tool_audit_source) ?? null,
         tool_audit_at: toIsoTimestamp(row.tool_audit_at) ?? asString(row.tool_audit_at) ?? null,
+        turn_budget: normalizeTurnBudget(row.turn_budget),
         conversation_tail_count: asNumber(row.conversation_tail_count),
         k2k_count: asNumber(row.k2k_count),
         handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -106,17 +106,25 @@ export function keeperFreshnessTs(keeper: Keeper, heartbeats: Map<string, number
 
 function normalizeTurnBudget(raw: unknown): Keeper['turn_budget'] {
   if (!isRecord(raw)) return null
-  const readSlot = (v: unknown): { value: number; source: 'override' | 'env' } | null => {
+  const readSlot = (v: unknown) => {
     if (!isRecord(v)) return null
     const value = asNumber(v.value)
     if (value == null) return null
-    const source = v.source === 'override' ? 'override' : 'env'
-    return { value, source }
+    const source: 'override' | 'env' = v.source === 'override' ? 'override' : 'env'
+    const envDefault = asNumber(v.env_default) ?? value
+    const envVar = asString(v.env_var) ?? ''
+    return { value, source, env_default: envDefault, env_var: envVar }
   }
   const reactive = readSlot(raw.reactive)
   const scheduled = readSlot(raw.scheduled_autonomous)
   if (!reactive || !scheduled) return null
-  return { reactive, scheduled_autonomous: scheduled }
+  return {
+    reactive,
+    scheduled_autonomous: scheduled,
+    manifest_path: asString(raw.manifest_path) ?? null,
+    clamp_min: asNumber(raw.clamp_min) ?? 1,
+    clamp_max: asNumber(raw.clamp_max) ?? 50,
+  }
 }
 
 function normalizePromptSegments(

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -654,6 +654,10 @@ export interface Keeper {
   latest_tool_call_count?: number | null
   tool_audit_source?: string | null
   tool_audit_at?: string | null
+  turn_budget?: {
+    reactive: { value: number; source: 'override' | 'env' }
+    scheduled_autonomous: { value: number; source: 'override' | 'env' }
+  } | null
   conversation_tail_count?: number
   k2k_count?: number
   k2k_mentions?: Array<{ keeper: string; count: number }>

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -655,8 +655,21 @@ export interface Keeper {
   tool_audit_source?: string | null
   tool_audit_at?: string | null
   turn_budget?: {
-    reactive: { value: number; source: 'override' | 'env' }
-    scheduled_autonomous: { value: number; source: 'override' | 'env' }
+    reactive: {
+      value: number
+      source: 'override' | 'env'
+      env_default: number
+      env_var: string
+    }
+    scheduled_autonomous: {
+      value: number
+      source: 'override' | 'env'
+      env_default: number
+      env_var: string
+    }
+    manifest_path: string | null
+    clamp_min: number
+    clamp_max: number
   } | null
   conversation_tail_count?: number
   k2k_count?: number

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -657,15 +657,17 @@ export interface Keeper {
   turn_budget?: {
     reactive: {
       value: number
-      source: 'override' | 'env'
+      source: 'override' | 'env' | 'override_invalid'
       env_default: number
       env_var: string
+      raw_override: number | null
     }
     scheduled_autonomous: {
       value: number
-      source: 'override' | 'env'
+      source: 'override' | 'env' | 'override_invalid'
       env_default: number
       env_var: string
+      raw_override: number | null
     }
     manifest_path: string | null
     clamp_min: number

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -446,6 +446,14 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                             Keeper_types_profile.load_keeper_profile_defaults
                               meta.name
                           in
+                          let env_reactive =
+                            Env_config_keeper.KeeperKeepalive
+                            .oas_max_turns_per_call
+                          in
+                          let env_autonomous =
+                            Env_config_keeper.KeeperKeepalive
+                            .oas_max_turns_per_call_scheduled_autonomous
+                          in
                           let reactive_effective =
                             Keeper_types_profile.effective_max_turns_per_call
                               profile
@@ -467,6 +475,11 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                             | Some n when n >= 1 && n <= 50 -> "override"
                             | _ -> "env"
                           in
+                          let manifest_path_json =
+                            match profile.manifest_path with
+                            | Some p -> `String p
+                            | None -> `Null
+                          in
                           `Assoc
                             [
                               ( "reactive",
@@ -474,13 +487,25 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                                   [
                                     ("value", `Int reactive_effective);
                                     ("source", `String reactive_source);
+                                    ("env_default", `Int env_reactive);
+                                    ( "env_var",
+                                      `String
+                                        "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL" );
                                   ] );
                               ( "scheduled_autonomous",
                                 `Assoc
                                   [
                                     ("value", `Int autonomous_effective);
                                     ("source", `String autonomous_source);
+                                    ("env_default", `Int env_autonomous);
+                                    ( "env_var",
+                                      `String
+                                        "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS"
+                                    );
                                   ] );
+                              ("manifest_path", manifest_path_json);
+                              ("clamp_min", `Int 1);
+                              ("clamp_max", `Int 50);
                             ]));
                        ("last_proactive_reason",
                          string_option_to_json

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -441,6 +441,47 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                        ("proactive_enabled", `Bool meta.proactive.enabled);
                        ("proactive_idle_sec", `Int meta.proactive.idle_sec);
                        ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
+                       ("turn_budget",
+                         (let profile =
+                            Keeper_types_profile.load_keeper_profile_defaults
+                              meta.name
+                          in
+                          let reactive_effective =
+                            Keeper_types_profile.effective_max_turns_per_call
+                              profile
+                          in
+                          let reactive_source =
+                            match profile.max_turns_per_call with
+                            | Some n when n >= 1 && n <= 50 -> "override"
+                            | _ -> "env"
+                          in
+                          let autonomous_effective =
+                            Keeper_types_profile
+                            .effective_max_turns_per_call_scheduled_autonomous
+                              profile
+                          in
+                          let autonomous_source =
+                            match
+                              profile.max_turns_per_call_scheduled_autonomous
+                            with
+                            | Some n when n >= 1 && n <= 50 -> "override"
+                            | _ -> "env"
+                          in
+                          `Assoc
+                            [
+                              ( "reactive",
+                                `Assoc
+                                  [
+                                    ("value", `Int reactive_effective);
+                                    ("source", `String reactive_source);
+                                  ] );
+                              ( "scheduled_autonomous",
+                                `Assoc
+                                  [
+                                    ("value", `Int autonomous_effective);
+                                    ("source", `String autonomous_source);
+                                  ] );
+                            ]));
                        ("last_proactive_reason",
                          string_option_to_json
                            (let value = String.trim meta.runtime.proactive_rt.last_reason in

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -458,10 +458,13 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                             Keeper_types_profile.effective_max_turns_per_call
                               profile
                           in
-                          let reactive_source =
-                            match profile.max_turns_per_call with
+                          let classify_source = function
                             | Some n when n >= 1 && n <= 50 -> "override"
-                            | _ -> "env"
+                            | Some _ -> "override_invalid"
+                            | None -> "env"
+                          in
+                          let reactive_source =
+                            classify_source profile.max_turns_per_call
                           in
                           let autonomous_effective =
                             Keeper_types_profile
@@ -469,11 +472,12 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                               profile
                           in
                           let autonomous_source =
-                            match
+                            classify_source
                               profile.max_turns_per_call_scheduled_autonomous
-                            with
-                            | Some n when n >= 1 && n <= 50 -> "override"
-                            | _ -> "env"
+                          in
+                          let raw_override_int = function
+                            | Some n -> `Int n
+                            | None -> `Null
                           in
                           let manifest_path_json =
                             match profile.manifest_path with
@@ -491,6 +495,9 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                                     ( "env_var",
                                       `String
                                         "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL" );
+                                    ( "raw_override",
+                                      raw_override_int
+                                        profile.max_turns_per_call );
                                   ] );
                               ( "scheduled_autonomous",
                                 `Assoc
@@ -502,6 +509,10 @@ let keepers_json ?keeper_names ?(include_recent_activity = false)
                                       `String
                                         "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL_SCHEDULED_AUTONOMOUS"
                                     );
+                                    ( "raw_override",
+                                      raw_override_int
+                                        profile
+                                          .max_turns_per_call_scheduled_autonomous );
                                   ] );
                               ("manifest_path", manifest_path_json);
                               ("clamp_min", `Int 1);


### PR DESCRIPTION
## Summary
키퍼 상세 모달에 **턴 예산** 섹션 추가. Override/Env 구분 명시.

## Iteration 1 / N (scheduled improvement loop)
사용자 요청 — max_turns 가시성 부재를 발견했고, /loop 10m으로 반복 개선 중. 이번은 가장 기본 blocker(백엔드 snapshot에 필드 없음 + frontend 미노출)를 해결.

## Product impact
- 이전: 키퍼가 TOML override를 받았는지 env default인지 **확인 수단 없음**
- 이후: 키퍼 상세 모달 → "턴 예산" 섹션에서 즉시 확인

## Research 기반 design 결정 (외국 베스트 프랙티스)
| 패턴 | 출처 | 적용 |
|------|------|------|
| Override chip + dotted underline | Ant Design ConfigProvider, W3C ARIA tooltip | override value만 강조, default는 dim |
| Section-level DRIFT pill | Evidently AI, Grafana drift dashboard | 헤더에 전체 drift 여부 요약 |
| Monotonic color tier (amber only) | Grafana thresholds (3-tier max) | 과한 색상 금지. override=amber 한 가지 |
| Fixed 2-row budget layout | PatternFly Utilization Bar | reactive / scheduled_autonomous 고정 구조 |

## 변경 파일 (5개)
| 파일 | 변경 |
|------|------|
| `lib/operator/operator_control_snapshot.ml` | keeper JSON에 nested `turn_budget` 추가 |
| `dashboard/src/types/core.ts` | Keeper interface에 `turn_budget` 필드 |
| `dashboard/src/keeper-store-normalize.ts` | `normalizeTurnBudget` helper + 통합 |
| `dashboard/src/components/keeper-detail-runtime.ts` | `TurnBudgetPanel` + `BudgetRow` 컴포넌트 |
| `dashboard/src/components/keeper-detail.ts` | details section 삽입 (open 기본) |

## Evidence
- `dune build`: exit 0 성공
- Backend는 effective_* helper 재사용으로 런타임 동작과 불일치 불가

## Review evidence
단일 모델(Claude Opus 4.6)

## 다음 iteration 예정
- **#2**: turn 실제 사용량 progress bar (`7/15` + bar)
- **#3**: Provenance tooltip (source file path, env var 이름, clamp range)
- **#4**: Fleet 비교 테이블의 drift summary column
- **#5**: 자아 비판 + 미처 포착 안 된 측면 발굴

## Linked issue
Refs: 사용자 요청 — 키퍼별 max_turns를 대시보드에서 확인 가능하도록

🤖 Generated with [Claude Code](https://claude.com/claude-code)