### PR TITLE
refactor: remove 7 review-bucket env vars as constants (Phase A-4)

### DIFF
--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -93,19 +93,9 @@ type ring = {
 
 let rings : (string, ring) Hashtbl.t = Hashtbl.create 8
 
-let flush_interval_sec_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_float ~default:60.0
-      "MASC_DECISION_AUDIT_FLUSH_INTERVAL_SEC")
+let flush_interval_sec () = 60.0
 
-let flush_interval_sec () = Eio.Lazy.force flush_interval_sec_cached
-
-let flush_batch_size_cached =
-  Eio.Lazy.from_fun ~cancel:`Protect (fun () ->
-    Env_config_core.get_int ~default:10
-      "MASC_DECISION_AUDIT_FLUSH_BATCH_SIZE")
-
-let flush_batch_size () = Eio.Lazy.force flush_batch_size_cached
+let flush_batch_size () = 10
 
 let get_or_create_ring name =
   match Hashtbl.find_opt rings name with

--- a/lib/level2_config.ml
+++ b/lib/level2_config.ml
@@ -35,8 +35,8 @@ end
 module Hebbian = struct
   let learning_rate () = get_env_float "MASC_HEBBIAN_RATE" 0.075
   let decay_rate () = get_env_float "MASC_HEBBIAN_DECAY" 0.01
-  let min_weight () = get_env_float "MASC_HEBBIAN_MIN_WEIGHT" 0.05
-  let max_weight () = get_env_float "MASC_HEBBIAN_MAX_WEIGHT" 1.0
+  let min_weight () = 0.05
+  let max_weight () = 1.0
 end
 
 (** Get all config as JSON for debugging *)

--- a/lib/level4_config.ml
+++ b/lib/level4_config.ml
@@ -106,7 +106,7 @@ end
 
 module Foraging = struct
   (** Default exploration rate (epsilon for epsilon-greedy) *)
-  let exploration_rate () = get_env_float "MASC_FORAGE_EXPLORATION" 0.3
+  let exploration_rate () = 0.3
 end
 
 (** {1 Stigmergy Configuration} *)

--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -23,18 +23,13 @@ include Server_mcp_transport_http_conn
 include Server_mcp_transport_http_respond
 include Server_mcp_transport_http_agui
 
-let env_float_or = Server_mcp_transport_http_conn.env_float_or
-
 let body_jsonrpc_method = Server_mcp_transport_http_headers.body_jsonrpc_method
 
 let sse_prime_event = Server_mcp_transport_http_headers.sse_prime_event
 
 let sse_ping_interval_s = Server_mcp_transport_http_headers.sse_ping_interval_s
 
-let post_sse_keepalive_interval_s =
-  env_float_or ~name:"MASC_POST_SSE_KEEPALIVE_SEC"
-    ~default:sse_ping_interval_s
-  |> Float.max 0.1
+let post_sse_keepalive_interval_s = Float.max 0.1 sse_ping_interval_s
 
 let get_last_event_id = Server_mcp_transport_http_headers.get_last_event_id
 

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -40,8 +40,7 @@ let cache_ttl_seconds env_var ~default =
       | _ -> default)
   | None -> default
 
-let status_cache_ttl_s () =
-  cache_ttl_seconds "MASC_STATUS_CACHE_TTL_S" ~default:2.0
+let status_cache_ttl_s () = 2.0
 
 let invalidate_status_cache () =
   _status_cache.key <- None;


### PR DESCRIPTION
## Summary

**Phase A-4** of env audit (review bucket 16개 수동 분류).

## 분류 결과
| 분류 | 수 | 처리 |
|------|---|------|
| constant | 7 | **이 PR** |
| declare | 8 | 후속 PR (snapshot 등록) |
| **false positive** | **1** | \`MASC_EVENT\` — AG-UI event **name** literal, env var 아님 |

## 제거 (7)
- \`MASC_DECISION_AUDIT_FLUSH_INTERVAL_SEC\` (60s)
- \`MASC_DECISION_AUDIT_FLUSH_BATCH_SIZE\` (10)
- \`MASC_FORAGE_EXPLORATION\` (level4 epsilon, 0.3)
- \`MASC_HEBBIAN_MIN_WEIGHT\` (0.05)
- \`MASC_HEBBIAN_MAX_WEIGHT\` (1.0)
- \`MASC_POST_SSE_KEEPALIVE_SEC\` → \`sse_ping_interval_s\` fallback 사용
- \`MASC_STATUS_CACHE_TTL_S\` (2s)

**유지된 operational env**: \`MASC_HEBBIAN_RATE\`, \`MASC_HEBBIAN_DECAY\` (이미 declared). MIN/MAX weight는 algorithm bound지 operational knob이 아니라 제거.

## Phase A 누적

| 단계 | Referenced | Undeclared |
|------|-----------|-----------|
| 시작 | 471 | 154 |
| A-1 (#7268) | 441 | 124 |
| A-2 (#7270) | 425 | 108 |
| **A-4 (이 PR)** | **418** | **101** |

## 남은 작업
- A-3: 78 declare operational → snapshot 등록
- A-5: 8 remaining declare (review bucket에서)

## Test plan
- [x] 41 keeper tests pass
- [x] \`dune build @all\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)