### PR TITLE
feat(fsm-hub): invariant descriptions and okCount badge

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -11,6 +11,7 @@ import {
   deriveTimeAxisTicks,
   deriveTransitionHistory,
   flagTooltip,
+  invariantDescription,
   isTransitionInSegment,
   laneTransitionCount,
   type CompositeObservation,
@@ -433,5 +434,34 @@ describe('flagTooltip', () => {
   it('falls back to a generic tooltip for unknown labels', () => {
     expect(flagTooltip('mystery-flag', true)).toBe('mystery-flag: active')
     expect(flagTooltip('mystery-flag', false)).toBe('mystery-flag: inactive')
+  })
+})
+
+describe('invariantDescription', () => {
+  it('returns domain-specific prose for each known invariant key', () => {
+    const keys = [
+      'phase_turn_alignment',
+      'no_cascade_before_measurement',
+      'compaction_atomicity',
+      'event_priority_monotone',
+      'recovery_two_store_sync',
+    ]
+    for (const key of keys) {
+      const desc = invariantDescription(key)
+      expect(desc.length).toBeGreaterThan(40)
+      expect(desc).not.toMatch(/^Invariant defined by/)
+    }
+  })
+
+  it('mentions the specific contract each invariant guards', () => {
+    expect(invariantDescription('phase_turn_alignment')).toMatch(/KSM|KTC|drift/i)
+    expect(invariantDescription('no_cascade_before_measurement')).toMatch(/cascade|measurement/i)
+    expect(invariantDescription('compaction_atomicity')).toMatch(/atomic|half-compacted/i)
+    expect(invariantDescription('event_priority_monotone')).toMatch(/priority|priorit/i)
+    expect(invariantDescription('recovery_two_store_sync')).toMatch(/recovery|checkpoint|store/i)
+  })
+
+  it('falls back to generic text for unknown keys', () => {
+    expect(invariantDescription('mystery_invariant')).toMatch(/^Invariant defined by/)
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1428,37 +1428,71 @@ function Flag({ label, on, tone = 'ok' }: { label: string; on: boolean; tone?: '
   `
 }
 
+/** Plain-english safety-property descriptions per invariant key.
+    Each entry names *what* the invariant guards and *what breaks* if
+    it's violated, so an operator reading a red row in the panel
+    understands the blast radius without cross-referencing the keeper
+    RFC. Based on RFC-0003 composite keeper lifecycle contracts. */
+const INVARIANT_DESCRIPTIONS: Record<string, string> = {
+  phase_turn_alignment:
+    'The KSM phase (Running / Compacting / HandingOff / …) must match what the KTC turn lane is doing. A drift means the two state machines disagree on which mode the keeper is in.',
+  no_cascade_before_measurement:
+    'Cascade selection must not begin before the measurement phase captures auto-rules. A violation usually means a provider call fired without the guardrail/drift checks that gate it.',
+  compaction_atomicity:
+    'Compaction must be atomic — a turn either sees the old context or the new one, never a half-compacted state. A break corrupts message ordering or duplicates content.',
+  event_priority_monotone:
+    'Event_bus priorities must be monotone (higher priority delivered first). A break means a critical event was delivered after a lower-priority one, which can skew keeper decisions.',
+  recovery_two_store_sync:
+    'Data-record and FSM-condition stores must agree on the same recovery point. A drift here means a restart would replay from an inconsistent checkpoint.',
+}
+
+export function invariantDescription(key: string): string {
+  return INVARIANT_DESCRIPTIONS[key] ?? 'Invariant defined by the keeper composite contract.'
+}
+
 function InvariantsPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   const entries = invariantRows(snapshot)
-  const allOk = entries.every(entry => entry.ok)
+  const okCount = entries.filter(entry => entry.ok).length
+  const total = entries.length
+  const allOk = okCount === total
+  const badgeText = allOk ? `${total}/${total}` : `${okCount}/${total}`
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="flex items-center justify-between mb-2">
         <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
           Safety
         </div>
-        <span class=${`rounded-full border px-2 py-0.5 text-[9px] font-mono ${
-          allOk
-            ? 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]'
-            : 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'
-        }`}>
-          ${allOk ? '5/5' : 'violation'}
+        <span
+          class=${`rounded-full border px-2 py-0.5 text-[9px] font-mono tabular-nums ${
+            allOk
+              ? 'text-[#22c55e] border-[rgba(34,197,94,0.3)] bg-[rgba(34,197,94,0.08)]'
+              : 'text-[#ef4444] border-[rgba(239,68,68,0.3)] bg-[rgba(239,68,68,0.08)]'
+          }`}
+          title=${allOk
+            ? `All ${total} keeper composite invariants hold.`
+            : `${total - okCount} of ${total} invariants are currently violated.`}
+        >
+          ${badgeText}
         </span>
       </div>
       <ul class="flex flex-col gap-1">
-        ${entries.map(entry => html`
-          <li class="flex gap-2 text-[10px]">
-            <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[#22c55e]' : 'bg-[#ef4444]'}`}></span>
-            <div class="min-w-0">
-              <div class=${entry.ok ? 'text-[var(--text-body)]' : 'text-[#f87171] font-semibold'}>
-                ${entry.label}
+        ${entries.map(entry => {
+          const desc = invariantDescription(entry.key)
+          const tooltip = `${entry.label} — ${entry.ok ? 'holds' : 'BROKEN'}\n${desc}`
+          return html`
+            <li class="flex gap-2 text-[10px] cursor-help" title=${tooltip}>
+              <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[#22c55e]' : 'bg-[#ef4444]'}`}></span>
+              <div class="min-w-0">
+                <div class=${entry.ok ? 'text-[var(--text-body)]' : 'text-[#f87171] font-semibold'}>
+                  ${entry.label}
+                </div>
+                <div class="text-[8px] leading-relaxed text-[var(--text-dim)]">
+                  ${entry.detail}
+                </div>
               </div>
-              <div class="text-[8px] leading-relaxed text-[var(--text-dim)]">
-                ${entry.detail}
-              </div>
-            </div>
-          </li>
-        `)}
+            </li>
+          `
+        })}
       </ul>
     </div>
   `


### PR DESCRIPTION
## v17 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

Stacked on #7280 (v16). InvariantsPanel 은 세션 8 iteration 동안 미개선된 Zone 4 카드. v17 은 각 invariant 에 "무엇을 보장하는가 / 깨지면 무엇이 생기는가" prose 와 okCount 뱃지 도입.

## Changes

- `INVARIANT_DESCRIPTIONS` 테이블 — 5개 keeper composite invariant 각각에 대한 RFC-0003 근거 설명.
- `invariantDescription(key)` pure function export — unknown key fallback.
- InvariantsPanel row 에 `title={label — holds/BROKEN\ndesc}` tooltip.
- Badge `5/5` → `${okCount}/${total}` — 부분 위반(e.g. 4/5) 도 칩에 표시.
- Badge tooltip: 전체/부분 holds 설명.

## Test

- 신규: `invariantDescription` 3 케이스 (known keys prose / contract-specific / unknown fallback).
- 회귀: vitest 93 files / 633 tests pass.
- typecheck: clean. vite build: clean.

## 배경

Lamport 의 safety property 원칙은 "what-could-go-wrong 이 인간에게 읽혀야 한다" — v17 은 이 원칙을 대시보드 레벨에 작게 적용.