### PR TITLE
feat(fsm-hub): recovery panel accent + state descriptions

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -13,6 +13,7 @@ import {
   flagTooltip,
   invariantDescription,
   isTransitionInSegment,
+  recoveryStateDescription,
   laneTransitionCount,
   type CompositeObservation,
   type HoveredSegment,
@@ -463,5 +464,25 @@ describe('invariantDescription', () => {
 
   it('falls back to generic text for unknown keys', () => {
     expect(invariantDescription('mystery_invariant')).toMatch(/^Invariant defined by/)
+  })
+})
+
+describe('recoveryStateDescription', () => {
+  it('returns prose for all four recovery states', () => {
+    const states = ['clean', 'reconcile_pending', 'drift: data↑ fsm↓', 'drift: fsm↑ data↓']
+    for (const state of states) {
+      const desc = recoveryStateDescription(state)
+      expect(desc.length).toBeGreaterThan(30)
+      expect(desc).not.toMatch(/^Recovery state defined by/)
+    }
+  })
+
+  it('mentions restart consequence for drift states', () => {
+    expect(recoveryStateDescription('drift: data↑ fsm↓')).toMatch(/restart|replay|duplicate/i)
+    expect(recoveryStateDescription('drift: fsm↑ data↓')).toMatch(/restart|lose|re-derive/i)
+  })
+
+  it('falls back for unknown states', () => {
+    expect(recoveryStateDescription('unknown')).toMatch(/^Recovery state defined by/)
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1498,6 +1498,21 @@ function InvariantsPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
   `
 }
 
+const RECOVERY_STATE_DESCRIPTIONS: Record<string, string> = {
+  clean:
+    'Both data-record and FSM-condition stores agree — no recovery action needed. A restart from this state will resume cleanly.',
+  reconcile_pending:
+    'Both stores recorded recovery state but have not yet reconciled. The keeper will align them on the next heartbeat cycle.',
+  'drift: data↑ fsm↓':
+    'The data-record store advanced past the FSM-condition store. A restart may replay turns that the FSM already completed, causing duplicate tool calls unless journal idempotency is active.',
+  'drift: fsm↑ data↓':
+    'The FSM-condition store advanced past the data-record. A restart may lose checkpoint data, forcing the keeper to re-derive state from scratch.',
+}
+
+export function recoveryStateDescription(state: string): string {
+  return RECOVERY_STATE_DESCRIPTIONS[state] ?? 'Recovery state defined by the keeper two-store sync contract.'
+}
+
 function RecoveryStatePanel({
   dataRecord,
   fsmCondition,
@@ -1513,17 +1528,30 @@ function RecoveryStatePanel({
   const isClean = state === 'clean'
   const isDrift = state.startsWith('drift')
   const toneCls = isClean ? 'text-[#22c55e]' : isDrift ? 'text-[#ef4444]' : 'text-[#f59e0b]'
-  const borderCls = isClean ? 'border-[var(--white-8)]' : isDrift ? 'border-[rgba(239,68,68,0.3)]' : 'border-[rgba(245,158,11,0.3)]'
+  const panelCls = isClean
+    ? 'border-[var(--white-8)] bg-[var(--white-2)]'
+    : isDrift
+      ? 'border-[rgba(239,68,68,0.55)] bg-[rgba(239,68,68,0.05)] shadow-[0_0_0_1px_rgba(239,68,68,0.2)_inset]'
+      : 'border-[rgba(245,158,11,0.45)] bg-[rgba(245,158,11,0.04)] shadow-[0_0_0_1px_rgba(245,158,11,0.15)_inset]'
 
   return html`
-    <div class=${`rounded-xl border bg-[var(--white-2)] p-3 ${borderCls}`}>
+    <div
+      class=${`rounded-xl border p-3 transition-colors duration-300 ${panelCls}`}
+      role=${isDrift ? 'alert' : undefined}
+      aria-live=${isDrift ? 'polite' : undefined}
+      title=${recoveryStateDescription(state)}
+    >
       <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
         Recovery
       </div>
       <div class=${`font-mono text-[13px] font-semibold ${toneCls}`}>${state}</div>
       <div class="mt-1.5 flex gap-3 text-[9px] text-[var(--text-dim)]">
-        <span>data <span class="font-mono">${String(dataRecord)}</span></span>
-        <span>fsm <span class="font-mono">${String(fsmCondition)}</span></span>
+        <span class="cursor-help" title="data_record: true means the data store has recorded a recovery point that hasn't been reconciled yet.">
+          data <span class="font-mono">${String(dataRecord)}</span>
+        </span>
+        <span class="cursor-help" title="fsm_condition: true means the FSM store has recorded a recovery condition that hasn't been reconciled yet.">
+          fsm <span class="font-mono">${String(fsmCondition)}</span>
+        </span>
       </div>
     </div>
   `


### PR DESCRIPTION
## v18 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

Zone 4 마지막 미개선 카드. v15 의 OperationalMeaning panel accent 패턴을 RecoveryStatePanel 에도 적용 + 4 recovery state 설명 + data/fsm flag 툴팁.

## Changes

- `RECOVERY_STATE_DESCRIPTIONS` — 4 state (clean/reconcile_pending/drift ×2) prose.
- `recoveryStateDescription(state)` pure function export.
- Panel accent: clean→neutral, reconcile→amber, drift→red (border+bg+shadow).
- `role="alert"` + `aria-live="polite"` on drift detection.
- data/fsm flag 개별 tooltip.

## Test

- 신규: `recoveryStateDescription` 3 케이스 (all states / restart mention / fallback).
- 회귀: vitest 93 files / 637 tests pass.
- typecheck: clean. vite build: clean.