### PR TITLE
fix(dashboard): real board pagination + SSE refresh for new posts

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -347,14 +347,28 @@ export function fetchDashboardPerf(): Promise<DashboardPerfResponse> {
   return get('/api/v1/dashboard/perf')
 }
 
+export interface FetchDashboardMemoryOptions {
+  excludeSystem?: boolean
+  excludeAutomation?: boolean
+  author?: string
+  /** Page size. Defaults to 200 when any filter is active, else 100. */
+  limit?: number
+  /** Number of posts to skip from the start of the sorted list. Defaults to 0. */
+  offset?: number
+}
+
 export function fetchDashboardMemory(
   sortMode: BoardSortMode,
-  opts?: { excludeSystem?: boolean; excludeAutomation?: boolean; author?: string },
+  opts?: FetchDashboardMemoryOptions,
 ): Promise<DashboardMemoryResponse> {
   const params = new URLSearchParams()
   params.set('sort_by', sortMode)
   const hasFilter = opts?.excludeSystem || opts?.excludeAutomation || opts?.author
-  params.set('limit', hasFilter ? '200' : '100')
+  const defaultLimit = hasFilter ? 200 : 100
+  const limit = Math.max(1, Math.min(500, opts?.limit ?? defaultLimit))
+  const offset = Math.max(0, Math.min(5000, opts?.offset ?? 0))
+  params.set('limit', String(limit))
+  if (offset > 0) params.set('offset', String(offset))
   if (opts?.excludeSystem) params.set('exclude_system', 'true')
   if (opts?.excludeAutomation) params.set('exclude_automation', 'true')
   if (opts?.author) params.set('author', opts.author)

--- a/dashboard/src/components/memory-state.ts
+++ b/dashboard/src/components/memory-state.ts
@@ -9,8 +9,13 @@ import {
   boardHiddenCategories,
   boardAuthorFilter,
   boardLoading,
+  boardLoadingMore,
+  boardHasMore,
+  boardOffset,
+  boardTotal,
   lastBoardRefreshAt,
   refreshBoard,
+  loadMoreBoardPosts,
 } from '../store'
 import {
   votePost,
@@ -30,8 +35,13 @@ export {
   boardHiddenCategories,
   boardAuthorFilter,
   boardLoading,
+  boardLoadingMore,
+  boardHasMore,
+  boardOffset,
+  boardTotal,
   lastBoardRefreshAt,
   refreshBoard,
+  loadMoreBoardPosts,
 }
 export { votePost }
 export { deleteBoardPost }

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -20,8 +20,11 @@ import {
   boardHiddenCategories,
   boardAuthorFilter,
   boardLoading,
+  boardLoadingMore,
+  boardHasMore,
   lastBoardRefreshAt,
   refreshBoard,
+  loadMoreBoardPosts,
   SORT_MODES,
   CONTENT_CATEGORIES,
   detailPost,
@@ -75,6 +78,24 @@ function ScrollSentinel({ onVisible }: { onVisible: () => void }) {
 }
 
 // ── Render section (paginated group by category) ──────────────────
+/** Expand the visible slice for this category by PAGE_SIZE.
+ *  If the category has run out of locally-loaded posts AND the server
+ *  still has more, also trigger a server-side page fetch. */
+function expandCategory(
+  category: ContentCategory,
+  limits: Record<string, number>,
+  currentLimit: number,
+  localPostCount: number,
+) {
+  const nextLimit = currentLimit + PAGE_SIZE
+  categoryVisibleLimits.value = { ...limits, [category]: nextLimit }
+  // Exhausted the locally-loaded slice for this category — ask the server
+  // for more. loadMoreBoardPosts is a noop if already loading or has_more=false.
+  if (nextLimit >= localPostCount && boardHasMore.value) {
+    void loadMoreBoardPosts()
+  }
+}
+
 function renderCategorySection(
   category: ContentCategory,
   posts: BoardPost[],
@@ -85,7 +106,17 @@ function renderCategorySection(
   const label = meta ? `${meta.icon} ${meta.label}` : category
   const limits = categoryVisibleLimits.value
   const limit = limits[category] ?? PAGE_SIZE
-  const hasMore = posts.length > limit
+  // "has more" considers both the locally-loaded posts and the server's
+  // signal. Without boardHasMore, once the category's slice catches up to
+  // the loaded window the button disappears and the next server page is
+  // never requested — that was the #7118 regression.
+  const hasMoreLocal = posts.length > limit
+  const hasMoreRemote = boardHasMore.value
+  const hasMore = hasMoreLocal || hasMoreRemote
+  const loadingMore = boardLoadingMore.value
+  const remainingLabel = hasMoreLocal
+    ? `${posts.length - limit}개 남음`
+    : '다음 페이지 불러오기'
 
   if (posts.length === 0 && hidden === 0) return null
   if (posts.length === 0 && hidden > 0) {
@@ -103,16 +134,18 @@ function renderCategorySection(
       </div>
       ${hasMore ? html`
         <${ScrollSentinel} onVisible=${() => {
-          categoryVisibleLimits.value = { ...limits, [category]: limit + PAGE_SIZE }
+          if (loadingMore) return
+          expandCategory(category, limits, limit, posts.length)
         }} />
         <div class="text-center py-3">
           <button type="button"
-            class="px-4 py-2 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer"
+            class="px-4 py-2 rounded-lg text-[12px] font-medium text-[var(--text-muted)] bg-transparent border border-[var(--border-slate-16)] hover:bg-[var(--white-6)] hover:text-[var(--text-body)] transition-all cursor-pointer disabled:opacity-50"
+            disabled=${loadingMore}
             onClick=${() => {
-              categoryVisibleLimits.value = { ...limits, [category]: limit + PAGE_SIZE }
+              expandCategory(category, limits, limit, posts.length)
             }}
           >
-            더 보기 (${posts.length - limit}개 남음)
+            ${loadingMore ? '불러오는 중...' : `더 보기 (${remainingLabel})`}
           </button>
         </div>
       ` : null}

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -118,7 +118,10 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   'masc/board_post':    { target: 'board' },
   board_comment:        { target: 'board' },
   'masc/board_delete':  { target: 'board' },
-  // Board vote notifications — emitted by lib/server/server_bootstrap_loops.ml
+  // Board notifications — emitted by lib/server/server_bootstrap_loops.ml
+  // via JSON-RPC method="notifications/board" (unwrapped to params.type)
+  post_created:         { target: 'board' },
+  comment_added:        { target: 'board' },
   post_voted:           { target: 'board' },
   comment_voted:        { target: 'board' },
   // Activity graph

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -106,10 +106,22 @@ export const boardExcludeAutomation = signal(false)
 /** Content-category filter: which categories to hide */
 export const boardHiddenCategories = signal<Set<string>>(new Set(['system']))
 export const boardAuthorFilter = signal('')
+/** Number of posts currently loaded — the offset for the next page request. */
+export const boardOffset = signal<number>(0)
+/** true when the server indicates (or we optimistically believe) more posts are available. */
+export const boardHasMore = signal<boolean>(true)
+/** Server-reported total when known; null while has_more=true. */
+export const boardTotal = signal<number | null>(null)
+/** true while a loadMore (append) request is in flight. Distinct from boardLoading (initial/reset). */
+export const boardLoadingMore = signal<boolean>(false)
 
 export function removeBoardPost(postId: string | undefined): void {
   if (!postId) return
-  boardPosts.value = boardPosts.value.filter(p => p.id !== postId)
+  const filtered = boardPosts.value.filter(p => p.id !== postId)
+  if (filtered.length !== boardPosts.value.length) {
+    boardPosts.value = filtered
+    boardOffset.value = filtered.length
+  }
 }
 
 // --- Goals state ---
@@ -562,22 +574,83 @@ export function reconcileBoardPosts(prev: BoardPost[], next: BoardPost[]): Board
   return changed ? merged : prev
 }
 
+/** Append incoming posts to the tail, de-duplicated by id. */
+export function appendBoardPosts(prev: BoardPost[], incoming: BoardPost[]): BoardPost[] {
+  if (incoming.length === 0) return prev
+  if (prev.length === 0) return incoming
+  const existing = new Set(prev.map(p => p.id))
+  const fresh = incoming.filter(p => !existing.has(p.id))
+  if (fresh.length === 0) return prev
+  return prev.concat(fresh)
+}
+
+const BOARD_PAGE_SIZE_DEFAULT = 100
+const BOARD_PAGE_SIZE_FILTERED = 200
+
+function boardPageSize(): number {
+  const hasFilter =
+    boardExcludeAutomation.value
+    || boardExcludeSystem.value
+    || boardAuthorFilter.value.trim() !== ''
+  return hasFilter ? BOARD_PAGE_SIZE_FILTERED : BOARD_PAGE_SIZE_DEFAULT
+}
+
 export async function refreshBoard(): Promise<void> {
   boardLoading.value = true
   try {
+    const limit = boardPageSize()
     const data = await fetchDashboardMemory(boardSortMode.value, {
       excludeSystem: boardExcludeSystem.value,
       excludeAutomation: boardExcludeAutomation.value,
       author: boardAuthorFilter.value || undefined,
+      limit,
+      offset: 0,
     })
     const next = data.posts ?? []
     boardPosts.value = reconcileBoardPosts(boardPosts.value, next)
+    boardOffset.value = next.length
+    boardHasMore.value = typeof data.has_more === 'boolean'
+      ? data.has_more
+      : next.length >= limit
+    boardTotal.value = typeof data.total === 'number' ? data.total : null
     lastBoardRefreshAt.value = new Date().toISOString()
   } catch (err) {
     console.warn('[Board] fetch error:', err)
     showToast('게시판을 불러오지 못했습니다', 'error')
   } finally {
     boardLoading.value = false
+  }
+}
+
+/** Append the next page of board posts onto boardPosts. Noop if a request is
+ *  already in flight or the server indicated no more pages. */
+export async function loadMoreBoardPosts(): Promise<void> {
+  if (boardLoadingMore.value || boardLoading.value) return
+  if (!boardHasMore.value) return
+  boardLoadingMore.value = true
+  try {
+    const limit = boardPageSize()
+    const offset = boardOffset.value
+    const data = await fetchDashboardMemory(boardSortMode.value, {
+      excludeSystem: boardExcludeSystem.value,
+      excludeAutomation: boardExcludeAutomation.value,
+      author: boardAuthorFilter.value || undefined,
+      limit,
+      offset,
+    })
+    const incoming = data.posts ?? []
+    const merged = appendBoardPosts(boardPosts.value, incoming)
+    boardPosts.value = merged
+    boardOffset.value = merged.length
+    boardHasMore.value = typeof data.has_more === 'boolean'
+      ? data.has_more
+      : incoming.length >= limit
+    boardTotal.value = typeof data.total === 'number' ? data.total : null
+  } catch (err) {
+    console.warn('[Board] loadMore error:', err)
+    showToast('다음 페이지를 불러오지 못했습니다', 'error')
+  } finally {
+    boardLoadingMore.value = false
   }
 }
 

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -368,6 +368,10 @@ export interface DashboardMemoryResponse {
   count?: number
   limit?: number
   offset?: number
+  /** true when more posts exist past this page. Use with offset+limit to request the next page. */
+  has_more?: boolean
+  /** Total number of matching posts when the server could determine it; null when has_more=true. */
+  total?: number | null
   sort_by?: string
 }
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -34,13 +34,23 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
   let limit = int_query_param request "limit" ~default:100 |> clamp ~min_v:1 ~max_v:500 in
   let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
   let base_fetch = board_fetch_limit ~exclude_system ~exclude_automation ~limit ~offset in
+  (* Fetch one extra beyond the requested page so we can answer has_more
+     without a second query. total is only emitted when the result fits
+     entirely inside the fetched window — otherwise null (unknown). *)
+  let probe_fetch = base_fetch + 1 in
   let posts =
     Board_dispatch.list_posts ?hearth ~sort_by ~exclude_system
-      ~exclude_automation ?author_filter ~limit:base_fetch ()
+      ~exclude_automation ?author_filter ~limit:probe_fetch ()
   in
   let karma_map = Board_dispatch.get_all_karma () in
   let get_karma author =
     Option.value ~default:0 (List.assoc_opt author karma_map)
+  in
+  let fetched_len = List.length posts in
+  let window_end = offset + limit in
+  let has_more = fetched_len > window_end in
+  let total_json : Yojson.Safe.t =
+    if has_more then `Null else `Int fetched_len
   in
   let paged = posts |> drop offset |> take limit in
   let posts_json =
@@ -65,6 +75,8 @@ let dashboard_memory_http_json request : Yojson.Safe.t =
       ("count", `Int (List.length posts_json));
       ("limit", `Int limit);
       ("offset", `Int offset);
+      ("has_more", `Bool has_more);
+      ("total", total_json);
       ("sort_by", `String (board_sort_label sort_by));
     ]
 


### PR DESCRIPTION
## Summary
- #7118의 "infinite scroll"은 클라이언트 slice 확장만 했고 서버에서 다음 페이지를 요청하지 않아 100/200개 cap에 묶이는 가짜 페이지네이션이었음
- SSE `post_created`/`comment_added` 이벤트가 board refresh로 라우팅되지 않아 새 글이 수동 새로고침 없이는 안 보임
- 서버 응답에 `has_more`/`total` 추가, 클라에 `loadMoreBoardPosts()` (offset 기반 append + id-dedup) 도입, SSE 라우팅 키 2개 추가

## Root Cause
1. `fetchDashboardMemory()`가 limit만 보내고 offset을 안 보냄 → 항상 첫 100개만 fetch
2. `renderCategorySection`의 ScrollSentinel이 `categoryVisibleLimits` slice만 키우고 서버 요청을 안 함 → 기존 fetch 너머 글은 영영 못 봄
3. `server_bootstrap_loops.ml`이 `method="notifications/board", params.type="post_created"` 로 emit하는데 `sse-store.ts` SIMPLE_ROUTES에 `post_created`/`comment_added` 키가 없음 → `refreshBoard()` 미호출

## Changes
| File | Change |
|------|--------|
| `lib/server/server_dashboard_http.ml` | probe-fetch (+1) 기법으로 `has_more`/`total` 응답 필드 추가 |
| `dashboard/src/api/dashboard.ts` | `FetchDashboardMemoryOptions`에 `limit`/`offset` 파라미터 추가 |
| `dashboard/src/types/dashboard-execution.ts` | `DashboardMemoryResponse`에 `has_more`/`total` 타입 추가 |
| `dashboard/src/store.ts` | `boardOffset`/`boardHasMore`/`boardLoadingMore` signals + `loadMoreBoardPosts()` + `appendBoardPosts()` |
| `dashboard/src/components/memory-state.ts` | 새 signals/함수 re-export |
| `dashboard/src/components/memory.ts` | `expandCategory()` — 카테고리 slice 소진 시 서버 loadMore 트리거 |
| `dashboard/src/sse-store.ts` | `post_created`/`comment_added` → board refresh 라우팅 추가 |

## Test plan
- [x] dune build (OCaml) — pass
- [x] pnpm build (dashboard) — pass
- [x] vitest 93 files / 626 tests — all pass
- [ ] 대시보드 보드 탭에서 100+ 글 로드 확인 (스크롤 시 자동 loadMore)
- [ ] SSE: 새 글 작성 후 다른 탭에서 자동 갱신 확인
- [ ] 필터 변경 시 offset 리셋 + 새 결과 표시 확인

Closes regression from #7118