### PR TITLE
[codex] Make dashboard a live monitor for gRPC truth

### DIFF
--- a/dashboard/src/api/transport-health.ts
+++ b/dashboard/src/api/transport-health.ts
@@ -98,6 +98,15 @@ export interface TransportHealthData {
     stale_total: number
   }
   generated_at: string
+  projection_diagnostics?: {
+    source: string
+    cache_state: string
+    last_success_at: string | null
+    last_attempt_at: string | null
+    last_error_at: string | null
+    stale_reason: string | null
+    stale_age_ms: number | null
+  }
 }
 
 type AbortableRequestOptions = {
@@ -128,6 +137,9 @@ export function decodeTransportHealthData(raw: unknown): TransportHealthData | n
   const http2 = isRecord(raw.http2) ? raw.http2 : null
   const cluster = isRecord(raw.cluster) ? raw.cluster : null
   const agentHealth = isRecord(raw.agent_health) ? raw.agent_health : null
+  const projectionDiagnostics = isRecord(raw.projection_diagnostics)
+    ? raw.projection_diagnostics
+    : null
   const generatedAt = asString(raw.generated_at)
 
   if (!summary || !sse || !grpc || !websocket || !webrtc || !streamableHttp || !http2 || !cluster || !agentHealth || !generatedAt) {
@@ -219,6 +231,17 @@ export function decodeTransportHealthData(raw: unknown): TransportHealthData | n
       stale_total: asNumber(agentHealth.stale_total, 0),
     },
     generated_at: generatedAt,
+    projection_diagnostics: projectionDiagnostics
+      ? {
+          source: asString(projectionDiagnostics.source, 'unknown'),
+          cache_state: asString(projectionDiagnostics.cache_state, 'unknown'),
+          last_success_at: asString(projectionDiagnostics.last_success_at) ?? null,
+          last_attempt_at: asString(projectionDiagnostics.last_attempt_at) ?? null,
+          last_error_at: asString(projectionDiagnostics.last_error_at) ?? null,
+          stale_reason: asString(projectionDiagnostics.stale_reason) ?? null,
+          stale_age_ms: asNumber(projectionDiagnostics.stale_age_ms) ?? null,
+        }
+      : undefined,
   }
 }
 

--- a/dashboard/src/components/transport-health.test.ts
+++ b/dashboard/src/components/transport-health.test.ts
@@ -198,6 +198,34 @@ describe('TransportHealthPanel', () => {
     expect(container.textContent).toContain('prod / namespace default')
   })
 
+  it('renders live-vs-cache truth line when projection diagnostics exist', async () => {
+    const fetchTransportHealth = vi.fn<() => Promise<unknown>>().mockResolvedValue(
+      sampleResponse({
+        projection_diagnostics: {
+          source: 'live_metrics',
+          cache_state: 'fresh',
+          last_success_at: '2026-04-15T10:00:00Z',
+          last_attempt_at: '2026-04-15T10:00:01Z',
+          last_error_at: null,
+          stale_reason: null,
+          stale_age_ms: null,
+        },
+      }),
+    )
+
+    const { TransportHealthPanel } = await loadComponentWithApi({
+      fetchTransportHealth,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${TransportHealthPanel} />`, container)
+    await flushUi()
+
+    expect(container.textContent).toContain('live_metrics')
+    expect(container.textContent).toContain('cache fresh')
+    expect(container.textContent).toContain('last ok 2026-04-15T10:00:00Z')
+  })
+
   it('debounces SSE-driven transport refreshes through FetchScheduler', async () => {
     const lastEvent = signal<unknown>(null)
     const fetchTransportHealth = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleResponse())

--- a/dashboard/src/components/transport-health.ts
+++ b/dashboard/src/components/transport-health.ts
@@ -196,6 +196,21 @@ function formatMetricValue(value: number | null): string | number {
   return value === null ? 'n/a' : value
 }
 
+function transportTruthLine(data: TransportHealthData): string | null {
+  const diagnostics = data.projection_diagnostics
+  if (!diagnostics) return null
+  const parts = [
+    diagnostics.source,
+    `cache ${diagnostics.cache_state}`,
+  ]
+  if (diagnostics.stale_age_ms !== null) {
+    parts.push(`stale ${diagnostics.stale_age_ms}ms`)
+  } else if (diagnostics.last_success_at) {
+    parts.push(`last ok ${diagnostics.last_success_at}`)
+  }
+  return parts.join(' · ')
+}
+
 function MetricRow({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
   return html`
     <div class="flex items-center justify-between gap-3 py-1.5">
@@ -317,6 +332,7 @@ export function TransportHealthPanel() {
     data.cluster.cluster && data.cluster.cluster !== 'unknown' && data.cluster.cluster !== 'default'
       ? `${data.cluster.cluster} / namespace ${data.cluster.room_id}`
       : `namespace ${data.cluster.room_id}`
+  const truthLine = transportTruthLine(data)
 
   return html`
     <div class="space-y-4">
@@ -330,6 +346,9 @@ export function TransportHealthPanel() {
             primary path: <span class="font-mono text-text-strong">${data.summary.primary_path}</span>
             <span class=${`ml-2 text-[11px] uppercase tracking-wider ${toneClass(sseStatus)}`}>${data.summary.queue_pressure}</span>
           </div>
+          ${truthLine
+            ? html`<div class="mt-1 text-[11px] text-text-muted">${truthLine}</div>`
+            : null}
         </div>
         <button
           class="text-[10px] text-text-muted hover:text-text-body transition-colors"

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -31,6 +31,21 @@ let safe_filename name =
     then c
     else '_') name
 
+let task_assignee_of_status = function
+  | Types.Claimed { assignee; _ }
+  | Types.InProgress { assignee; _ }
+  | Types.Done { assignee; _ } -> assignee
+  | Types.Todo | Types.Cancelled _ -> ""
+
+let task_info_of_task (task : Types.task) : T.task_info =
+  {
+    T.id = task.id;
+    title = task.title;
+    status = Types.string_of_task_status task.task_status;
+    assigned_to = task_assignee_of_status task.task_status;
+    priority = task.priority;
+  }
+
 (** {1 Unary Handlers} *)
 
 (** Join handler: agent joins the coordination room. *)
@@ -162,27 +177,7 @@ let handle_get_status (room_config : Room_utils_backend_setup.config) (_bytes : 
           None)
     else []
   in
-  let tasks =
-    let tasks_dir = Filename.concat masc_dir "tasks" in
-    if Sys.file_exists tasks_dir && Sys.is_directory tasks_dir then
-      Sys.readdir tasks_dir
-      |> Array.to_list
-      |> List.filter (fun f -> Filename.check_suffix f ".json")
-      |> List.filter_map (fun f ->
-        let path = Filename.concat tasks_dir f in
-        try
-          let json = Yojson.Safe.from_string (read_file_safe path) in
-          let open Yojson.Safe.Util in
-          Some ({
-            T.id = json |> member "id" |> to_string_option |> Option.value ~default:"";
-            title = json |> member "title" |> to_string_option |> Option.value ~default:"";
-            status = json |> member "status" |> to_string_option |> Option.value ~default:"";
-            assigned_to = json |> member "assigned_to" |> to_string_option |> Option.value ~default:"";
-            priority = (try json |> member "priority" |> to_int with Yojson.Safe.Util.Type_error _ -> 0);
-          } : T.task_info)
-        with Eio.Cancel.Cancelled _ as e -> raise e | exn -> Log.Transport.debug "task parse skip: %s" (Printexc.to_string exn); None)
-    else []
-  in
+  let tasks = Room.get_tasks_safe room_config |> List.map task_info_of_task in
   T.StatusResponse.(to_bytes {
     agents;
     tasks;
@@ -249,27 +244,13 @@ let compute_directives
           "compute_directives: failed to parse agent file %s: %s"
           agent_file (Printexc.to_string exn));
   (* 2. Task assignment: find first unclaimed task for idle agent *)
-  let tasks_dir = Filename.concat masc_dir "tasks" in
-  (if Sys.file_exists tasks_dir then
+  (if Room.root_is_initialized room_config then
     let unclaimed =
-      Sys.readdir tasks_dir
-      |> Array.to_list
-      |> List.filter_map (fun f ->
-          if Filename.check_suffix f ".json" then
-            try
-              let path = Filename.concat tasks_dir f in
-              let task_json = Yojson.Safe.from_string (read_file_safe path) in
-              (match Yojson.Safe.Util.member "status" task_json with
-               | `String "todo" -> Some (Filename.chop_suffix f ".json")
-               | _ -> None)
-            with
-            | Eio.Cancel.Cancelled _ as e -> raise e
-            | exn ->
-                Log.Transport.debug
-                  "compute_directives: task parse skip %s: %s"
-                  f (Printexc.to_string exn);
-                None
-          else None)
+      Room.get_tasks_safe room_config
+      |> List.filter_map (fun (task : Types.task) ->
+           match task.task_status with
+           | Types.Todo -> Some task.id
+           | _ -> None)
     in
     match unclaimed with
     | task_id :: _ -> directives := ("claim:" ^ task_id) :: !directives
@@ -400,6 +381,23 @@ let handle_subscribe
   Atomic.incr active_subscribe_streams;
   Transport_metrics.set_grpc_subscribers (Atomic.get active_subscribe_streams);
   let events_count = ref 0 in
+  let stream_closed = Atomic.make false in
+  let sub_id = Printf.sprintf "grpc-subscribe-%s-%Ld"
+    req.agent_name (now_ms ()) in
+  let cleanup_subscriber ?exn () =
+    if Atomic.compare_and_set stream_closed false true then begin
+      Sse.unsubscribe_external sub_id;
+      Atomic.decr active_subscribe_streams;
+      Transport_metrics.set_grpc_subscribers
+        (Atomic.get active_subscribe_streams);
+      Option.iter
+        (fun err ->
+          Log.Misc.warn "gRPC subscriber %s failed: %s" sub_id
+            (Printexc.to_string err))
+        exn;
+      Log.Misc.info "gRPC subscriber %s cleaned up" sub_id
+    end
+  in
   (* Send initial event confirming subscription *)
   let init_event = T.Event.{
     seq = 0L;
@@ -453,10 +451,7 @@ let handle_subscribe
      so it MUST NOT block. We use Grpc_eio.Stream.length to check
      capacity before adding. If the stream is full or closed, the event
      is dropped and the subscriber auto-unregisters. *)
-  let sub_id = Printf.sprintf "grpc-subscribe-%s-%Ld"
-    req.agent_name (now_ms ()) in
   let seq_counter = Atomic.make (Int64.to_int req.since_seq + 1) in
-  let stream_closed = Atomic.make false in
   let max_buffer = 48 in (* stream capacity is 64; leave headroom *)
   Sse.subscribe_external ~id:sub_id
     ~is_alive:(fun () ->
@@ -464,11 +459,7 @@ let handle_subscribe
     ~callback:(fun sse_event ->
     if Atomic.get stream_closed || Grpc_eio.Stream.is_closed stream then begin
       (* Stream already gone — auto-cleanup *)
-      if not (Atomic.get stream_closed) then begin
-        Atomic.set stream_closed true;
-        Sse.unsubscribe_external sub_id;
-        Log.Misc.info "gRPC subscriber %s auto-cleaned (stream closed)" sub_id
-      end
+      cleanup_subscriber ()
     end else if Grpc_eio.Stream.length stream >= max_buffer then
       (* Stream buffer near-full — drop event to avoid blocking broadcast *)
       Log.Misc.warn "gRPC subscriber %s: buffer full (%d), dropping event"
@@ -485,14 +476,10 @@ let handle_subscribe
       try Grpc_eio.Stream.add stream (T.Event.to_bytes event)
       with
       | Eio.Cancel.Cancelled _ as e ->
-        Atomic.set stream_closed true;
-        Sse.unsubscribe_external sub_id;
+        cleanup_subscriber ();
         raise e
       | exn ->
-        Atomic.set stream_closed true;
-        Sse.unsubscribe_external sub_id;
-        Log.Misc.warn "gRPC subscriber %s failed: %s" sub_id
-          (Printexc.to_string exn)
+        cleanup_subscriber ~exn ()
     end
   ) ();
   (* Stream stays open; will be closed when the gRPC connection drops

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -430,6 +430,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
             Log.Server.info "reaped %d SSE guards + %d HTTP guards + %d stale sessions"
               sse_guards_reaped http_guards_reaped sessions_reaped;
           let ext_reaped = Sse.reap_dead_external_subscribers () in
+          Transport_metrics.set_grpc_subscribers
+            (Sse.external_subscriber_count_with_prefix "grpc-subscribe-");
           if ext_reaped > 0 then
             Log.Server.info "reaped %d dead external subscribers" ext_reaped;
           if Server_webrtc_transport.is_enabled () then begin

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -385,5 +385,17 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
         ~clock ~timeout_sec:120.0 (compute ?actor ?fixture ~light)
 
-let dashboard_transport_health_http_json ~state:_ =
-  cached_surface_json _transport_health_cache
+let transport_health_cache_diagnostics () =
+  match cached_surface_json _transport_health_cache with
+  | `Assoc fields -> (
+      match List.assoc_opt "projection_diagnostics" fields with
+      | Some (`Assoc diagnostics) -> diagnostics
+      | _ -> [])
+  | _ -> []
+
+let dashboard_transport_health_http_json ~state =
+  let live_json =
+    Transport_metrics.transport_health_json ~config:state.Mcp_server.room_config
+  in
+  extend_projection_diagnostics live_json
+    (("source", `String "live_metrics") :: transport_health_cache_diagnostics ())

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -402,6 +402,13 @@ let with_ext_sub_ro f = Eio_guard.with_mutex_ro ext_sub_mutex f
 let current_external_subscriber_count () =
   with_ext_sub_ro (fun () -> Hashtbl.length external_subscribers)
 
+let current_external_subscriber_count_with_prefix prefix =
+  with_ext_sub_ro (fun () ->
+    Hashtbl.fold
+      (fun sub_id _ acc ->
+        if String.starts_with ~prefix sub_id then acc + 1 else acc)
+      external_subscribers 0)
+
 (** Register an external subscriber that receives formatted SSE events
     on every broadcast.  The [callback] must not block (use best-effort).
 
@@ -424,6 +431,9 @@ let unsubscribe_external id =
 (** Number of external subscribers (for diagnostics). *)
 let external_subscriber_count () =
   current_external_subscriber_count ()
+
+let external_subscriber_count_with_prefix prefix =
+  current_external_subscriber_count_with_prefix prefix
 
 (** Fan out an event string to all external subscribers.
     Dead subscribers (where [is_alive] returns [false]) are automatically

--- a/test/test_grpc_coordination.ml
+++ b/test/test_grpc_coordination.ml
@@ -276,6 +276,34 @@ let test_grpc_server_registers_health_service () =
           Alcotest.(check bool) "health service registered" true
             (List.mem "grpc.health.v1.Health" services)))
 
+let test_get_status_projects_backlog_tasks () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_temp_dir "masc-grpc-status" (fun dir ->
+      let room_config = Room_utils.default_config dir in
+      ignore (Masc_mcp.Room.init room_config ~agent_name:(Some "alpha"));
+      ignore
+        (Masc_mcp.Room.add_task room_config
+           ~title:"Fix stale projection" ~priority:1
+           ~description:"Use backlog SSOT for gRPC status");
+      ignore (Masc_mcp.Room.claim_next room_config ~agent_name:"alpha");
+      let service =
+        Masc_mcp.Masc_grpc_service.create_service
+          ~room_config
+          ~tool_dispatcher:(fun _tool _payload -> Ok "{}")
+      in
+      match Grpc_eio.Service.get_method service "GetStatus" with
+      | Some { handler = `Unary handler; _ } ->
+          let resp = T.StatusResponse.of_bytes (handler "") in
+          Alcotest.(check int) "tasks count" 1 (List.length resp.tasks);
+          let task = List.hd resp.tasks in
+          Alcotest.(check string) "task id" "task-001" task.T.id;
+          Alcotest.(check string) "task title" "Fix stale projection" task.T.title;
+          Alcotest.(check string) "task status" "claimed" task.T.status;
+          Alcotest.(check string) "task assignee" "alpha" task.T.assigned_to;
+          Alcotest.(check int) "task priority" 1 task.T.priority
+      | _ -> Alcotest.fail "GetStatus unary handler missing")
+
 let test_empty_request_handling () =
   (* Verify graceful handling of empty protobuf message (all defaults). *)
   let bytes = T.JoinRequest.to_bytes {
@@ -325,6 +353,8 @@ let () =
       ( "service",
         [
           Alcotest.test_case "service_name" `Quick test_service_name;
+          Alcotest.test_case "get_status_projects_backlog_tasks" `Quick
+            test_get_status_projects_backlog_tasks;
         ] );
       ( "server_config",
         [


### PR DESCRIPTION
## What changed

This PR makes the dashboard transport panel behave like a live monitor for gRPC transport state instead of a delayed cached snapshot.

It also fixes gRPC status/task projection so the wire response reflects the room backlog SSOT instead of guessing from per-file task JSON.

## Why

Real-world probing showed two concrete issues:

- `/api/v1/dashboard/transport-health` could report stale gRPC counts because it served only the cached transport-health surface.
- `MascCoordination/GetStatus` projected tasks incorrectly because it read `.masc/tasks/*.json` directly even though current task storage is backlog-based.

That meant the dashboard could disagree with the real runtime state, and gRPC status consumers could receive empty or malformed task objects.

## User impact

- The dashboard now exposes live transport truth for gRPC and still includes cache diagnostics so operators can see whether the cache is fresh or stale.
- The transport panel now shows a truth line (`live_metrics`, cache state, last success) so it is usable as a monitor instead of just a decorative snapshot.
- gRPC `GetStatus` now returns real task ids, titles, statuses, assignees, and priorities from the backlog SSOT.
- Heartbeat directive calculation now reads the same backlog SSOT, so remote workers and status queries are aligned.

## Root cause

- Transport health mixed two concerns: cached background refresh and operator-facing truth. The route returned only the cached payload.
- gRPC status and directive logic had drifted from the canonical room storage model.
- gRPC subscriber cleanup updated some close/error paths, and background maintenance now re-derives the subscriber gauge from the SSE bridge registry.

## Validation

- `dune build --root .`
- `dune exec --root . ./test/test_grpc_coordination.exe`
- `dune exec --root . ./test/test_transport_metrics.exe -- test json`
- `dune exec --root . ./test/test_ci_hardening_source.exe -- test source_guard 19`
- `dune exec --root . ./test/test_ci_hardening_source.exe -- test source_guard 24`
- `node_modules/.bin/vitest run --no-file-parallelism --maxWorkers=1 src/components/transport-health.test.ts`
- reran the gRPC real-world probe against this branch and confirmed:
  - dashboard transport-health reports `source=live_metrics`
  - live gRPC counts show `active_streams=1`, `subscribers=1` during the run
  - `GetStatus` returns real task objects instead of `[{}]`

## Follow-up

One gap remains outside this PR's full closure: on a quiet client disconnect, `grpc_subscribers_total` can still lag behind because the underlying server-streaming path does not always surface a close event immediately. The dashboard truth and status projection are fixed here, but fully closing silent-disconnect cleanup likely needs a lower-level stream close hook or an explicit lease/heartbeat path for subscribe streams.
