### PR TITLE
refactor(dashboard): remove namespace carrier fields from TS types and normalizers

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -181,8 +181,6 @@ function isNotInitializedEnvelope(raw: unknown): boolean {
 
 function bootstrapStatusEnvelope(generatedAt: string): Record<string, unknown> {
   return {
-    namespace_id: 'default',
-    namespace: 'default',
     project: 'initializing',
     generated_at: generatedAt,
   }

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -351,8 +351,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const expectedScopedCount = expectedCountForKeeperFilter(keeperFilter, runtimeCounts)
   const countSourceLabel = runtimeCountSourceLabel(runtimeCounts.source)
   const namespaceStatus = namespaceTruth.value?.namespace.status ?? serverStatus.value
-  const namespaceName = namespaceStatus?.namespace ?? 'default'
-  const namespaceBasePath = namespaceStatus?.namespace_base_path ?? null
+  const namespaceName = namespaceStatus?.project ?? 'default'
 
   const briefMap = useMemo(
     () => new Map<string, DashboardMissionAgentBrief>(
@@ -531,7 +530,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
                       <span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">scope ${namespaceName}</span>
                       ${configuredKeeperHint ? html`<span class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5">${configuredKeeperHint}</span>` : null}
-                      ${namespaceBasePath ? html`<code class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px]">${namespaceBasePath}</code>` : null}
                     </div>
                   </div>
                 </div>

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -497,7 +497,7 @@ export function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
   const auditSource = observedAudit.toolAuditSource
   const auditAt = observedAudit.toolAuditAt
   const namespaceName =
-    namespaceStatus.namespace ?? namespaceStatus.namespace_id ?? serverStatus.value?.namespace ?? 'default'
+    namespaceStatus.project ?? serverStatus.value?.project ?? 'default'
   const project = namespaceStatus.project ?? serverStatus.value?.project ?? 'N/A'
   const clusterRaw = namespaceStatus.cluster ?? serverStatus.value?.cluster ?? null
   const clusterVisible = clusterRaw && clusterRaw !== 'unknown' && clusterRaw !== 'default' && clusterRaw !== 'N/A'

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -155,7 +155,7 @@ export function buildLiveJudgeSituationReport({
   briefing: DashboardMissionBriefingResponse | null | undefined
   target: LiveJudgeTarget
 }): string {
-  const namespace = mission?.summary.namespace ?? mission?.summary.namespace_id ?? 'default'
+  const namespace = mission?.summary.project ?? 'default'
   const roomHealth = mission?.summary.room_health ?? 'unknown'
   const sessionCount = mission?.sessions.length ?? 0
   const attentionCount = mission?.attention_queue.length ?? 0
@@ -196,7 +196,7 @@ function createLiveJudgeWorkflowContext(
     focus_kind: 'live_judgment',
     operation_id: null,
     summary: `${target.name}에게 상황판 요약을 보내 live 판단을 받습니다.`,
-    payload_preview: `scope ${mission?.summary.namespace ?? mission?.summary.namespace_id ?? 'default'} · attention ${mission?.attention_queue.length ?? 0} · gaps ${metadataGapCount}`,
+    payload_preview: `scope ${mission?.summary.project ?? 'default'} · attention ${mission?.attention_queue.length ?? 0} · gaps ${metadataGapCount}`,
     suggested_payload: { message },
     preview: {
       keeper_name: target.name,

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -249,7 +249,7 @@ function renderTruth(item: OperatorReviewItem | null) {
       <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
           <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Project</div>
-          <strong>${room.namespace ?? room.namespace_id ?? 'default'}</strong>
+          <strong>${room.project ?? 'default'}</strong>
           <div class="text-[12px] text-[var(--text-muted)]">${room.project ?? 'project'} · ${room.cluster ?? 'cluster'}</div>
         </div>
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -228,7 +228,7 @@ export function OpsRoomColumn() {
         <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>기본 범위</span>
-            <strong>${room.namespace ?? room.namespace_id ?? 'default'}</strong>
+            <strong>${room.project ?? 'default'}</strong>
           </div>
           <div class="ops-stat p-3 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] flex flex-col gap-1">
             <span>프로젝트</span>

--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -224,8 +224,6 @@ function normalizeSummary(raw: unknown): DashboardMissionSummary {
     room_health: asString(root.room_health),
     cluster: asString(root.cluster),
     project: asString(root.project),
-    namespace_id: asString(root.namespace_id) ?? null,
-    namespace: asString(root.namespace) ?? null,
     paused: asBoolean(root.paused),
     tempo_interval_s: asNumber(root.tempo_interval_s),
     active_agents: asNumber(root.active_agents),

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -20,9 +20,6 @@ import type {
 function normalizeServerStatus(raw: unknown): ServerStatus | null {
   if (!isRecord(raw)) return null
   return {
-    namespace_id: asString(raw.namespace_id),
-    namespace: asString(raw.namespace),
-    namespace_base_path: asString(raw.namespace_base_path),
     coordination_root: asString(raw.coordination_root),
     workspace_path: asString(raw.workspace_path),
     workspace_differs: asBoolean(raw.workspace_differs),

--- a/dashboard/src/namespace-truth-store.test.ts
+++ b/dashboard/src/namespace-truth-store.test.ts
@@ -21,8 +21,7 @@ describe('refreshNamespaceTruth', () => {
       generated_at: '2026-03-25T08:16:21Z',
       namespace: {
         status: {
-          namespace_id: 'default',
-          namespace: 'default',
+          project: 'default',
           version: '2.148.0',
           build: {
             release_version: '2.148.0',
@@ -73,8 +72,7 @@ describe('refreshNamespaceTruth', () => {
       generated_at: '2026-03-25T08:16:21Z',
       namespace: {
         status: {
-          namespace_id: 'default',
-          namespace: 'default',
+          project: 'default',
           version: '2.148.0',
         },
       },

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -41,8 +41,6 @@ function normalizeMessage(raw: unknown): Message | null {
 function normalizeNamespace(raw: unknown): OperatorNamespaceSnapshot {
   if (!isRecord(raw)) return {}
   return {
-    namespace_id: asString(raw.namespace_id),
-    namespace: asString(raw.namespace),
     project: asString(raw.project),
     cluster: asString(raw.cluster),
     paused: asBoolean(raw.paused),

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -578,9 +578,6 @@ export function normalizeServerStatus(raw: unknown, generatedAt?: string): Serve
   if (!isRecord(raw)) return null
   return {
     ...(raw as ServerStatus),
-    namespace_id: asString(raw.namespace_id) ?? undefined,
-    namespace: asString(raw.namespace) ?? undefined,
-    namespace_base_path: asString(raw.namespace_base_path) ?? undefined,
     generated_at: generatedAt ?? toIsoTimestamp(raw.generated_at) ?? undefined,
     build: normalizeBuildIdentity(raw.build),
   }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -449,14 +449,14 @@ export async function refreshShell(opts?: RefreshOptions): Promise<void> {
  *  Shared by doFetchExecution (HTTP) and SSE execution_snapshot handler. */
 export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void {
   const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
-  const previousNamespace = serverStatus.value?.namespace
+  const previousProject = serverStatus.value?.project
   if (normalizedStatus) {
     serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
   }
   const roomChanged =
-    previousNamespace != null
-    && normalizedStatus?.namespace != null
-    && previousNamespace !== normalizedStatus.namespace
+    previousProject != null
+    && normalizedStatus?.project != null
+    && previousProject !== normalizedStatus.project
   const normalizedAgents = (Array.isArray(data.agents) ? data.agents : [])
     .map(normalizeAgent)
     .filter((row): row is Agent => row !== null)

--- a/dashboard/src/types/command-plane-orchestra.ts
+++ b/dashboard/src/types/command-plane-orchestra.ts
@@ -255,8 +255,6 @@ export interface CommandPlaneOrchestraResponse {
   version?: string
   generated_at?: string
   namespace: {
-    namespace_id?: string
-    namespace?: string
     project?: string
     cluster?: string
     paused?: boolean

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -465,9 +465,6 @@ export interface DashboardGoalsTreeResponse {
 
 
 export interface ServerStatus {
-  namespace_id?: string
-  namespace?: string
-  namespace_base_path?: string
   coordination_root?: string
   workspace_path?: string
   workspace_differs?: boolean

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -6,8 +6,6 @@ export interface DashboardMissionSummary {
   room_health?: string
   cluster?: string
   project?: string
-  namespace_id?: string | null
-  namespace?: string | null
   paused?: boolean
   tempo_interval_s?: number
   active_agents?: number
@@ -330,8 +328,6 @@ export interface DashboardProofWorkerRunEvidence {
 }
 
 export interface OperatorNamespaceSnapshot {
-  namespace_id?: string
-  namespace?: string
   project?: string
   cluster?: string
   paused?: boolean


### PR DESCRIPTION
## Summary
- Remove `namespace_id`, `namespace`, `namespace_base_path`, `namespace_mode` from `ServerStatus` interface and all related TS types
- Remove corresponding normalizer mappings in 5 normalizer files
- Replace UI fallback chains `x.namespace ?? x.namespace_id ?? 'default'` with `x.project ?? 'default'` in 4 consumer components
- Clean API bootstrap payload and test fixtures

### Files changed (15, +12 -37)
| Category | Files |
|----------|-------|
| Types | `dashboard-execution.ts`, `dashboard-mission.ts`, `command-plane-orchestra.ts` |
| Normalizers | `namespace-truth-normalizers.ts`, `store-normalizers.ts`, `mission-normalizers.ts`, `operator-normalizers.ts` |
| API | `api/core.ts` |
| Consumers | `mission-briefing-card.ts`, `keeper-detail-runtime.ts`, `ops-room-column.ts`, `ops/index.ts`, `agent-roster.ts`, `store.ts` |
| Tests | `namespace-truth-store.test.ts` |

### Preserved
- `target_type: 'namespace'` semantic discriminators (different axis)
- File/function names containing "namespace" (separate rename step)

Part of epic #7261, companion to backend PR #7295.

## Test plan
- [x] `tsc --noEmit` zero errors
- [ ] CI green (Dashboard check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)