### PR TITLE
[codex] Remove legacy keeper reason tokens from keepalive logs

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1193,6 +1193,10 @@ let run_keepalive_unified_turn
           meta_after_triage
           obs.message_cursor_updates
       in
+      let format_opt_int = function
+        | Some value -> string_of_int value
+        | None -> "-"
+      in
       let verdict_strs = Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict in
       let channel_str = Keeper_world_observation.channel_to_string turn_decision.channel in
       if manual_reconcile_pending && turn_decision.should_run then (
@@ -1214,14 +1218,16 @@ let run_keepalive_unified_turn
           | _ -> Log.Keeper.info
         in
         log_not_scheduled
-          "keepalive turn not scheduled for %s: should_run=%b channel=%s reasons=[%s] since_last=%s idle_gate=%s"
+          "keepalive turn not scheduled for %s: should_run=%b channel=%s reasons=[%s] idle=%ds since_last=%s idle_gate=%s cooldown=%s task_cooldown=%s"
           meta_after_triage.name
           turn_decision.should_run channel_str
           (String.concat "," verdict_strs)
+          obs.idle_seconds
           (format_since_last_scheduled_autonomous
              turn_decision.since_last_scheduled_autonomous)
-          (match turn_decision.idle_gate_sec with
-           | Some s -> string_of_int s | None -> "-"));
+          (format_opt_int turn_decision.idle_gate_sec)
+          (format_opt_int turn_decision.effective_cooldown)
+          (format_opt_int turn_decision.task_reactive_cooldown));
       if should_run_turn then
         Log.Keeper.info
           "keepalive turn scheduled for %s: channel=%s reasons=%s"

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -72,45 +72,31 @@ type turn_verdict =
   | Skip of { reasons : skip_reason * skip_reason list }
 
 let turn_reason_to_string = function
-  | Mention_pending -> "pending_mentions"
-  | Board_event_pending -> "pending_board_events"
-  | Scope_message_pending -> "pending_scope_messages"
+  | Mention_pending -> "mention_pending"
+  | Board_event_pending -> "board_event_pending"
+  | Scope_message_pending -> "scope_message_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
-  | Idle_cooldown_elapsed _ -> "idle_gate_elapsed"
+  | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
   | Cooldown_elapsed -> "cooldown_elapsed"
-  | Task_backlog _ -> "actionable_backlog"
+  | Task_backlog _ -> "task_backlog"
   | Task_reactive_cooldown_elapsed -> "task_reactive_cooldown_elapsed"
   | Never_started -> "never_started"
 
 let skip_reason_to_string = function
   | Scheduled_autonomous_disabled -> "scheduled_autonomous_disabled"
-  | Idle_gate_pending _ -> "idle_gate_wait"
-  | Cooldown_pending _ -> "cooldown_wait"
+  | Idle_gate_pending _ -> "idle_gate_pending"
+  | Cooldown_pending _ -> "cooldown_pending"
   | No_signal -> "no_signal"
 
 let channel_to_string = function
   | Reactive -> "reactive"
   | Scheduled_autonomous -> "scheduled_autonomous"
 
-let turn_reason_legacy_tokens = function
-  | Task_backlog { unclaimed; failed } ->
-      [ Some "actionable_backlog";
-        (if unclaimed > 0 then Some "unclaimed_tasks" else None);
-        (if failed > 0 then Some "failed_tasks" else None) ]
-      |> List.filter_map Fun.id
-  | reason -> [ turn_reason_to_string reason ]
-
-let skip_reason_legacy_tokens = function
-  | Scheduled_autonomous_disabled -> [ "scheduled_autonomous_disabled" ]
-  | Idle_gate_pending _ -> [ "scheduled_autonomous_turn"; "idle_gate_wait" ]
-  | Cooldown_pending _ -> [ "scheduled_autonomous_turn"; "idle_gate_elapsed" ]
-  | No_signal -> [ "scheduled_autonomous_turn"; "idle_gate_elapsed" ]
-
 let verdict_reasons_to_strings = function
   | Run { reasons = (first, rest) } ->
-      List.concat_map turn_reason_legacy_tokens (first :: rest)
+      List.map turn_reason_to_string (first :: rest)
   | Skip { reasons = (first, rest) } ->
-      List.concat_map skip_reason_legacy_tokens (first :: rest)
+      List.map skip_reason_to_string (first :: rest)
 type unified_turn_decision = {
   should_run : bool;
   channel : unified_turn_channel;

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -115,26 +115,21 @@ type turn_verdict =
   | Skip of { reasons : skip_reason * skip_reason list }
 
 (** Convert a single turn reason to a flat string tag.
-    Encoding is compatibility-oriented: variant payloads
-    (idle_sec, cooldown, unclaimed, failed, remaining_sec) are
-    not included in the output. Returns the same fixed tag
-    regardless of parameter values. *)
+    The tag is a stable snake_case form of the typed variant.
+    Variant payloads are intentionally omitted. *)
 val turn_reason_to_string : turn_reason -> string
 
 (** Convert a single skip reason to a flat string tag.
-    Encoding is compatibility-oriented: variant payloads
-    (remaining_sec) are not included in the output. *)
+    The tag is a stable snake_case form of the typed variant.
+    Variant payloads are intentionally omitted. *)
 val skip_reason_to_string : skip_reason -> string
 
 (** Convert channel to string tag. *)
 val channel_to_string : unified_turn_channel -> string
 
 (** Extract all reasons as flat string tags from a verdict.
-    Tags are compatibility-oriented and do not include variant payloads.
-    Scheduled-autonomous run verdicts preserve the legacy flat tokens
-    that downstream logs and prompts previously consumed, including the
-    synthetic ["scheduled_autonomous_turn"], ["cooldown_elapsed"],
-    ["unclaimed_tasks"], and ["failed_tasks"] tags. *)
+    Tags map 1:1 to the typed reasons carried by the verdict and do not
+    include variant payloads. *)
 val verdict_reasons_to_strings : turn_verdict -> string list
 
 type unified_turn_decision = {

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -506,7 +506,7 @@ let test_scheduled_turn_decision_uses_backlog_acceleration () =
          List.mem WO.Task_reactive_cooldown_elapsed (first :: rest)
      | WO.Skip _ -> false)
 
-let test_verdict_reasons_to_strings_preserves_legacy_run_tokens () =
+let test_verdict_reasons_to_strings_uses_structured_run_tags () =
   let verdict =
     WO.Run
       {
@@ -520,17 +520,15 @@ let test_verdict_reasons_to_strings_preserves_legacy_run_tokens () =
             ] );
       }
   in
-  check (list string) "legacy run tokens preserved"
+  check (list string) "structured run tags"
     [ "scheduled_autonomous_turn";
-      "idle_gate_elapsed";
+      "idle_cooldown_elapsed";
       "cooldown_elapsed";
-      "actionable_backlog";
-      "unclaimed_tasks";
-      "failed_tasks";
+      "task_backlog";
       "task_reactive_cooldown_elapsed" ]
     (WO.verdict_reasons_to_strings verdict)
 
-let test_verdict_reasons_to_strings_preserves_legacy_skip_tokens () =
+let test_verdict_reasons_to_strings_uses_structured_skip_tags () =
   let idle_gate_verdict =
     WO.Skip
       {
@@ -545,11 +543,11 @@ let test_verdict_reasons_to_strings_preserves_legacy_skip_tokens () =
           ( WO.Cooldown_pending { remaining_sec = 60 }, [] );
       }
   in
-  check (list string) "legacy idle-gate skip tokens preserved"
-    [ "scheduled_autonomous_turn"; "idle_gate_wait" ]
+  check (list string) "structured idle-gate skip tags"
+    [ "idle_gate_pending" ]
     (WO.verdict_reasons_to_strings idle_gate_verdict);
-  check (list string) "legacy cooldown skip tokens preserved"
-    [ "scheduled_autonomous_turn"; "idle_gate_elapsed" ]
+  check (list string) "structured cooldown skip tags"
+    [ "cooldown_pending" ]
     (WO.verdict_reasons_to_strings cooldown_verdict)
 
 let test_task_reactive_cooldown_floor_never_hits_zero () =
@@ -2744,10 +2742,10 @@ let () =
             test_idle_decay_triggers_turn;
           test_case "scheduled decision uses backlog acceleration" `Quick
             test_scheduled_turn_decision_uses_backlog_acceleration;
-          test_case "verdict reasons preserve legacy run tokens" `Quick
-            test_verdict_reasons_to_strings_preserves_legacy_run_tokens;
-          test_case "verdict reasons preserve legacy skip tokens" `Quick
-            test_verdict_reasons_to_strings_preserves_legacy_skip_tokens;
+          test_case "verdict reasons use structured run tags" `Quick
+            test_verdict_reasons_to_strings_uses_structured_run_tags;
+          test_case "verdict reasons use structured skip tags" `Quick
+            test_verdict_reasons_to_strings_uses_structured_skip_tags;
           test_case "task reactive cooldown floor never hits zero" `Quick
             test_task_reactive_cooldown_floor_never_hits_zero;
           test_case "with goals" `Quick test_observation_with_goals;


### PR DESCRIPTION
## What changed

This PR removes the legacy flattened keeper reason vocabulary from the unified turn decision path.

- `verdict_reasons_to_strings` now emits structured reason tags that map 1:1 to the typed reason variants.
- synthetic legacy tags such as `idle_gate_elapsed`, `idle_gate_wait`, `actionable_backlog`, `unclaimed_tasks`, and `failed_tasks` are no longer injected.
- keepalive skip logs now include the actual scheduling numbers so operators can see why a scheduled autonomous turn did not run.

## Why

The previous log line was misleading during keeper monitoring.

For example, a skip caused by `Cooldown_pending` was rendered as `scheduled_autonomous_turn,idle_gate_elapsed`, which reads like the keeper should have run even though the cooldown gate had not elapsed yet.

That made it hard to distinguish:

- idle gate not met
- cooldown not met
- no signal

## Operator impact

A log like this:

`keepalive turn not scheduled ... reasons=[cooldown_pending] idle=50s since_last=976 idle_gate=120 cooldown=1800 task_cooldown=300`

is now directly interpretable without knowing the legacy token mapping.

## Root cause

`keeper_world_observation.verdict_reasons_to_strings` was still preserving backward-compatible synthetic tokens instead of exposing the actual typed skip/run reasons. The keepalive logger then printed those flattened strings without the scheduling numbers needed for interpretation.

## Validation

- `dune build --root .`
- `dune exec --root . ./test/test_keeper_unified.exe -- test world_observation 20,21`

## Notes

This PR is intentionally separate from the gRPC dashboard truth work so the keeper scheduling vocabulary cleanup can be reviewed on its own.
