### PR TITLE
[codex] refine dashboard monitoring IA and runtime directory UI

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -92,13 +92,13 @@ export function App() {
 
   return html`
     <div class="flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--bg-0)] bg-[radial-gradient(ellipse_at_top,rgba(25,40,70,0.3)_0%,rgba(11,18,32,1)_80%)] text-[var(--text-body)]">
-      <header class="relative z-10 shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.44)] px-4 py-2 backdrop-blur-xl">
+      <header class="relative z-10 shrink-0 border-b border-[rgba(255,255,255,0.06)] bg-[rgba(8,14,26,0.36)] px-4 py-1.5 backdrop-blur-xl">
         <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[rgba(71,184,255,0.15)] to-transparent"></div>
-        <div class="flex w-full items-center justify-between gap-4 max-[860px]:flex-col max-[860px]:items-stretch">
-          <div class="min-w-0">
-            <div class="flex items-center gap-4">
+        <div class="flex w-full items-center justify-between gap-3 max-[900px]:flex-col max-[900px]:items-stretch">
+          <div class="min-w-0 flex items-center gap-3">
+            <div class="flex shrink-0 items-center gap-2">
               <button type="button"
-                class="hidden max-[768px]:flex size-10 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-5)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+                class="hidden max-[768px]:flex size-9 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-body)] cursor-pointer transition-colors hover:bg-[rgba(255,255,255,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
                 aria-expanded=${mobileMenuOpen.value}
                 aria-label=${mobileMenuOpen.value ? '탐색 메뉴 닫기' : '탐색 메뉴 열기'}
                 aria-controls="dashboard-side-rail"
@@ -106,28 +106,29 @@ export function App() {
               >
                 ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
               </button>
-              <div class="flex size-8 shrink-0 items-center justify-center rounded-lg border border-[rgba(71,184,255,0.3)] bg-[linear-gradient(135deg,rgba(71,184,255,0.2),rgba(10,28,58,0.8))] text-[15px] font-bold text-[var(--text-strong)]">
+              <div class="flex size-7 shrink-0 items-center justify-center rounded-lg border border-[var(--white-10)] bg-[var(--white-4)] text-[13px] text-[var(--text-strong)]">
                 ${currentView?.icon ?? 'M'}
               </div>
-              <div class="min-w-0 flex flex-col justify-center">
-                <div class="flex flex-wrap items-center gap-2 mb-0.5">
-                  <span class="text-[10px] font-bold uppercase tracking-[0.25em] text-[rgba(154,217,255,0.6)]">MASC Control Deck</span>
-                </div>
-                <h1 class="text-[15px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none flex items-center gap-1.5">
-                  ${currentView?.label ?? 'Multi-Agent Namespace Console'}
-                  ${currentSection && currentSection.label !== currentView?.label
-                    ? html`<span class="text-[13px] font-medium text-[var(--text-muted)]">/</span><span class="text-[15px] font-medium text-[rgba(154,217,255,0.8)]">${currentSection.label}</span>`
-                    : null}
-                </h1>
-              </div>
+            </div>
+
+            <div class="min-w-0 flex flex-col justify-center">
+              ${currentSection && currentSection.label !== currentView?.label
+                ? html`
+                    <div class="mb-0.5 flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                      <span>${currentView?.label ?? '홈'}</span>
+                      <span>/</span>
+                    </div>
+                  `
+                : null}
+              <h1 class="min-w-0 text-[18px] font-semibold tracking-[-0.02em] text-[var(--text-strong)] leading-none [overflow-wrap:anywhere]">
+                ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Namespace Console'}
+              </h1>
             </div>
           </div>
 
-          <div class="flex shrink-0 flex-col items-end gap-2">
-            <div class="flex items-center gap-2">
-              <${AuthStatus} />
-              <${ConnectionStatus} />
-            </div>
+          <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            <${AuthStatus} />
+            <${ConnectionStatus} />
             <${BuildIdentityBadge} />
           </div>
         </div>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -37,7 +37,6 @@ import {
   keeperPhaseForDisplay,
   runtimeBandMeta,
   runtimeBandMetaForAgent,
-  summarizeMonitoringEvidence,
   summarizeKeeperMonitoring,
   type RuntimeBand,
 } from '../lib/monitoring-runtime'
@@ -55,6 +54,23 @@ function runtimeBadgeClass(band: RuntimeBand): string {
   if (band === 'attention') return 'border-[rgba(251,191,36,0.2)] bg-[rgba(251,191,36,0.12)] text-[var(--warn)]'
   if (band === 'paused') return 'border-[rgba(167,139,250,0.2)] bg-[rgba(167,139,250,0.12)] text-[#a78bfa]'
   return 'border-[var(--white-8)] bg-[var(--white-4)] text-[var(--text-dim)]'
+}
+
+function stageBadgeClass(stageKey: string): string {
+  if (stageKey === 'tool_use') return 'border-[rgba(71,184,255,0.24)] bg-[rgba(71,184,255,0.12)] text-[var(--accent)]'
+  if (stageKey === 'scheduled_autonomous' || stageKey === 'thinking') return 'border-[rgba(52,211,153,0.22)] bg-[rgba(52,211,153,0.1)] text-[var(--ok)]'
+  if (stageKey === 'handoff' || stageKey === 'compacting') return 'border-[rgba(167,139,250,0.24)] bg-[rgba(167,139,250,0.12)] text-[#c4b5fd]'
+  if (stageKey === 'failing' || stageKey === 'crashed') return 'border-[rgba(239,68,68,0.24)] bg-[rgba(239,68,68,0.12)] text-[var(--bad)]'
+  if (stageKey === 'paused') return 'border-[rgba(167,139,250,0.24)] bg-[rgba(167,139,250,0.12)] text-[#a78bfa]'
+  return 'border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]'
+}
+
+function compactModelLabel(model: string | null | undefined): string | null {
+  const value = model?.trim()
+  if (!value) return null
+  const parts = value.split(':').map(part => part.trim()).filter(Boolean)
+  if (parts.length >= 2) return parts[parts.length - 1] ?? value
+  return value
 }
 
 interface KeeperInfo {
@@ -391,16 +407,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     ),
     [scopedAgents, keeperInfoLookup, keeperList, keeperBriefs],
   )
-  const pageTitle = keeperFilter === 'keeper-only'
-    ? '키퍼 목록'
-    : keeperFilter === 'agent-only'
-      ? '일반 에이전트'
-      : '에이전트 & 키퍼 목록'
   const pageDescription = keeperFilter === 'keeper-only'
-    ? '키퍼만 따로 보고, 런타임 이름은 보조 정보로 확인합니다.'
+    ? '주 이름을 먼저 보고, runtime alias와 FSM 상태는 보조 정보로 확인합니다.'
     : keeperFilter === 'agent-only'
-      ? '키퍼가 연결되지 않은 일반 에이전트만 봅니다.'
-      : '에이전트와 키퍼를 한 목록에서 보고, 운영 상태는 배지로 구분합니다.'
+      ? '키퍼가 연결되지 않은 일반 에이전트만 따로 봅니다.'
+      : '주 이름 기준으로 훑고, 최근 활동과 FSM 상태가 필요한 카드만 열어봅니다.'
 
   const filtered = scopedAgents
     .filter((a: Agent) => {
@@ -479,23 +490,23 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     <div class="agent-page flex w-full flex-col gap-5 px-0 py-1">
       <section class="monitor-surface-card monitor-surface-card-strong p-5">
         <div class="flex flex-col gap-5">
-          <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div class="flex min-w-0 flex-col gap-3">
+          <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
+            <div class="flex min-w-0 flex-col gap-2">
               <div class="flex flex-wrap items-center gap-3">
-                <h2 class="m-0 text-[20px] font-semibold tracking-[-0.02em] text-[var(--text-strong)]">${pageTitle}</h2>
+                <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">디렉터리 필터</span>
                 <span class="inline-flex items-center rounded-full border border-[var(--border-slate-22)] bg-[var(--accent-soft)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-strong)]">${resultCountLabel}</span>
               </div>
               <p class="m-0 max-w-[720px] text-[13px] leading-[1.6] text-[var(--text-body)]">${pageDescription}</p>
             </div>
 
-            <label class="flex w-full max-w-[320px] flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
-              <span>키퍼/런타임 이름으로 찾기</span>
+            <label class="flex w-full flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
+              <span>이름 또는 Runtime Alias</span>
               <${TextInput}
                 class="rounded-2xl bg-[var(--white-3)] px-4 py-3 text-[14px] text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
                 name="agent_search"
                 ariaLabel="키퍼 또는 런타임 이름 검색"
                 autoComplete="off"
-                placeholder="키퍼 또는 런타임 이름으로 찾기"
+                placeholder="키퍼 이름 또는 runtime alias로 찾기"
                 value=${search}
                 onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
               />
@@ -545,7 +556,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           const keeperRuntime = keeperRuntimeLookup.get(agent.name) ?? findKeeperRuntime(agent.name, keeperList)
           const band = bandByAgent.get(agent.name) ?? runtimeBandMeta('attention')
           const keeperMonitoring = keeperRuntime ? summarizeKeeperMonitoring(keeperRuntime) : null
-          const monitoringEvidence = keeperMonitoring ? summarizeMonitoringEvidence(keeperMonitoring) : null
+          const fsmPhase = keeperRuntime ? keeperPhaseForDisplay(keeperRuntime) : null
           const isKeeper = keeper != null
           const currentWork = keeper?.current_work ?? brief?.current_work ?? agent.current_task ?? null
           const lastActivityAge = keeperRuntime?.last_activity_ago_s ?? keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
@@ -579,7 +590,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             keeper?.latest_tool_names,
           )
           const visibleTools = recentTools.slice(0, 2)
-          const hiddenToolCount = Math.max(0, recentTools.length - visibleTools.length)
+          const primaryTool = visibleTools[0] ?? null
+          const extraToolCount = Math.max(0, recentTools.length - (primaryTool ? 1 : 0))
           const toolCallCount =
             brief?.latest_tool_call_count
             ?? keeper?.latest_tool_call_count
@@ -599,8 +611,17 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           const runtimeName = isKeeper
             ? runtimeAgentName(displayName, keeperRuntime?.agent_name ?? keeper?.agent_name ?? agent.name)
             : null
+          const identityLabel = runtimeName ? 'runtime alias' : 'agent runtime'
           const model = keeperRuntime?.model ?? keeper?.model
+          const compactModel = compactModelLabel(model)
           const generation = keeperRuntime?.generation ?? keeper?.generation ?? null
+          const fsmPhaseKey =
+            keeperMonitoring?.phase.key && keeperMonitoring.phase.key !== 'unknown'
+              ? keeperMonitoring.phase.key
+              : fsmPhase
+          const fsmStageKey = keeperMonitoring?.stage.key ?? 'offline'
+          const fsmStageLabel = keeperMonitoring?.stage.label ?? '활동 없음'
+          const fsmStageText = fsmStageLabel === '활동 없음' ? fsmStageLabel : `활동 ${fsmStageLabel}`
           const detailLabel = keeperRuntime ? `${displayName} keeper 상세 보기` : `${displayName} 상세 보기`
           const openDetail = () => {
             if (keeperRuntime) {
@@ -612,92 +633,132 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
           return html`
             <button type="button"
-              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-4 rounded-[var(--radius-xl)] p-5 text-left transition-all duration-200 cursor-pointer hover:border-[var(--border-slate-22)] hover:bg-[var(--bg-1)] hover:-translate-y-0.5"
+              class="monitor-surface-card monitor-surface-card-medium group flex w-full flex-col gap-3.5 rounded-[18px] p-4 text-left transition-all duration-200 cursor-pointer hover:border-[var(--border-slate-22)] hover:bg-[var(--bg-1)] hover:-translate-y-0.5"
               key=${agent.name}
               aria-label=${detailLabel}
               onClick=${openDetail}
             >
-              <div class="flex items-start gap-4">
-                <div class="shrink-0 relative">
-                  <${AgentAvatar}
-                    name=${agent.name}
-                    status=${agent.status}
-                    traits=${agent.traits}
-                    size="xl"
-                    currentWork=${currentWork}
-                    activityAge=${lastActivityAge}
-                  />
-                </div>
-                
-                <div class="flex flex-col min-w-0 flex-1 justify-center py-1">
-                  <strong class="mb-2 min-w-0 overflow-hidden text-[17px] text-[var(--text-strong)] font-semibold leading-[1.3] group-hover:text-[var(--accent)] transition-colors [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${displayName}</strong>
-                  
-                  <div class="flex items-center gap-1.5 flex-wrap mt-1">
-                    <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
-                    <span class="text-[11px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-2 py-0.5 rounded-full">${isKeeper ? '키퍼' : '일반 에이전트'}</span>
-                    ${runtimeName ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${runtimeName}</span>` : null}
-                    ${agent.synthetic ? html`<span class="text-[10px] text-[var(--text-muted)] bg-[var(--white-6)] border border-dashed border-[var(--card-border)] px-1.5 py-px rounded italic" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">파생</span>` : null}
-                    ${monitoringEvidence?.phase && keeperRuntime ? html`<${KeeperPhaseBadge} phase=${keeperPhaseForDisplay(keeperRuntime)} compact />` : null}
-                    ${monitoringEvidence?.stage ? html`<span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]" title=${monitoringEvidence.stage.description}>활동 ${monitoringEvidence.stage.label}</span>` : null}
-                    ${model ? html`<span class="font-mono text-[10px] text-[var(--text-muted)] bg-[var(--white-4)] border border-[var(--card-border)] px-1.5 py-px rounded">${model}</span>` : null}
-                    ${generation != null ? html`<span class="text-[11px] text-[var(--accent)] font-medium bg-[var(--accent-10)] px-1.5 py-px rounded border border-[var(--accent-10)]" title="키퍼 핸드오프가 일어날 때 올라가는 런타임 세대입니다.">세대 ${generation}</span>` : null}
+              <div class="flex items-start justify-between gap-4">
+                <div class="flex min-w-0 flex-1 items-start gap-4">
+                  <div class="shrink-0 relative">
+                    <${AgentAvatar}
+                      name=${agent.name}
+                      status=${agent.status}
+                      traits=${agent.traits}
+                      size="xl"
+                      currentWork=${currentWork}
+                      activityAge=${lastActivityAge}
+                    />
                   </div>
+
+                  <div class="min-w-0 flex-1 py-0.5">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <strong class="min-w-0 overflow-hidden text-[17px] font-semibold leading-[1.3] text-[var(--text-strong)] transition-colors group-hover:text-[var(--accent)] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]">${displayName}</strong>
+                      ${agent.synthetic ? html`
+                        <span class="inline-flex items-center rounded-full border border-dashed border-[var(--card-border)] bg-[var(--white-6)] px-2 py-0.5 text-[10px] italic text-[var(--text-muted)]" title="키퍼 데이터에서 파생된 합성 엔트리입니다.">
+                          파생
+                        </span>
+                      ` : null}
+                    </div>
+
+                    <div class="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                      <span class="uppercase tracking-[0.08em]">${identityLabel}</span>
+                      ${runtimeName ? html`
+                        <span class="text-[var(--text-dim)]">/</span>
+                        <span class="font-mono text-[10px]" translate="no">${runtimeName}</span>
+                      ` : null}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex shrink-0 items-start">
+                  <span class="inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold ${runtimeBadgeClass(band.key)}" title=${band.description}>${band.label}</span>
                 </div>
               </div>
 
-              <div class="flex flex-1 flex-col gap-3 border-t border-[var(--border-slate-12)] pt-3">
-                <p class="m-0 text-[13px] leading-[1.5] text-[var(--text-body)] break-words line-clamp-3" title=${summaryText}>${summaryText}</p>
+              <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)] break-words line-clamp-2" title=${summaryText}>${summaryText}</p>
 
-                <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
-                  <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
-                    최근 활동 ${lastActivityAt
+              ${isKeeper ? html`
+                <div class="rounded-[16px] border border-[var(--border-slate-12)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.02))] px-3 py-2.5">
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">FSM</span>
+                    ${fsmPhaseKey
+                      ? html`<${KeeperPhaseBadge} phase=${fsmPhaseKey} compact />`
+                      : html`
+                        <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-3)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-muted)]">
+                          생명주기 확인 필요
+                        </span>
+                      `}
+                    <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ${stageBadgeClass(fsmStageKey)}" title=${keeperMonitoring?.stage.description ?? '활동 단계 정보가 없습니다.'}>
+                      ${fsmStageText}
+                    </span>
+                    ${generation != null && generation > 0 ? html`
+                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-3)] px-2 py-0.5 text-[10px] text-[var(--text-muted)]">
+                        세대 ${generation}
+                      </span>
+                    ` : null}
+                  </div>
+                </div>
+              ` : null}
+
+              <div class="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
+                <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
+                  최근 활동
+                  <span class="ml-1 text-[var(--text-body)]">
+                    ${lastActivityAt
                       ? html`<${TimeAgo} timestamp=${lastActivityAt} />`
                       : lastActivityAge != null
                         ? `${formatDuration(lastActivityAge)} 전`
                         : '기록 없음'}
                   </span>
-                  ${isKeeper && ctxPct != null ? html`
-                    <span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
-                      CTX
-                      <span class="font-mono font-medium ${ctxPct > 85 ? 'text-[var(--bad)]' : ctxPct > 60 ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${ctxPct}%</span>
-                      <span class="inline-block w-12 h-1.5 rounded-full bg-[var(--white-6)] overflow-hidden">
-                        <span class="block h-full rounded-full ${ctxPct > 85 ? 'bg-[var(--bad)]' : ctxPct > 60 ? 'bg-[var(--warn)]' : 'bg-[var(--ok)]'}" style="width:${ctxPct}%"></span>
-                      </span>
+                </span>
+                ${isKeeper && ctxPct != null ? html`
+                  <span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
+                    <span>CTX</span>
+                    <span class="font-mono font-medium ${ctxPct > 85 ? 'text-[var(--bad)]' : ctxPct > 60 ? 'text-[var(--warn)]' : 'text-[var(--text-strong)]'}">${ctxPct}%</span>
+                    <span class="inline-block h-1.5 w-12 overflow-hidden rounded-full bg-[var(--white-6)]">
+                      <span class="block h-full rounded-full ${ctxPct > 85 ? 'bg-[var(--bad)]' : ctxPct > 60 ? 'bg-[var(--warn)]' : 'bg-[var(--ok)]'}" style="width:${ctxPct}%"></span>
+                    </span>
+                  </span>
+                ` : null}
+                ${compactModel ? html`
+                  <span class="inline-flex items-center gap-1.5 rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2.5 py-1">
+                    <span>model</span>
+                    <span class="font-mono text-[10px] text-[var(--text-body)]" translate="no" title=${model ?? undefined}>${compactModel}</span>
+                  </span>
+                ` : null}
+              </div>
+
+              ${(primaryTool || toolCallCount != null || toolAuditAt) ? html`
+                <div class="flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                  <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5">최근 도구</span>
+                  ${primaryTool ? html`
+                    <span class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-[10px] text-[var(--text-body)]" translate="no">
+                      ${primaryTool}
+                    </span>
+                  ` : null}
+                  ${extraToolCount > 0 ? html`
+                    <span class="inline-flex items-center rounded-full border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                      +${extraToolCount}
+                    </span>
+                  ` : null}
+                  ${!primaryTool && toolCallCount === 0 ? html`
+                    <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                      최근 도구 없음
+                    </span>
+                  ` : null}
+                  ${!primaryTool && toolCallCount != null && toolCallCount > 0 ? html`
+                    <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                      ${toolCallCount}회 관찰됨
+                    </span>
+                  ` : null}
+                  ${toolAuditAt ? html`
+                    <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
+                      감사 <${TimeAgo} timestamp=${toolAuditAt} />
                     </span>
                   ` : null}
                 </div>
-
-                ${(visibleTools.length > 0 || toolCallCount != null || toolAuditAt) ? html`
-                  <div class="flex flex-wrap items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
-                    <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5">tool</span>
-                    ${visibleTools.map(name => html`
-                      <span class="inline-flex items-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 font-mono text-[10px] text-[var(--text-body)]">
-                        ${name}
-                      </span>
-                    `)}
-                    ${hiddenToolCount > 0 ? html`
-                      <span class="inline-flex items-center rounded-full border border-dashed border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
-                        +${hiddenToolCount}
-                      </span>
-                    ` : null}
-                    ${visibleTools.length === 0 && toolCallCount === 0 ? html`
-                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
-                        최근 도구 없음
-                      </span>
-                    ` : null}
-                    ${visibleTools.length === 0 && toolCallCount != null && toolCallCount > 0 ? html`
-                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
-                        도구 ${toolCallCount}회
-                      </span>
-                    ` : null}
-                    ${toolAuditAt ? html`
-                      <span class="inline-flex items-center rounded-full border border-[var(--white-8)] bg-[var(--white-2)] px-2 py-0.5 text-[10px]">
-                        감사 <${TimeAgo} timestamp=${toolAuditAt} />
-                      </span>
-                    ` : null}
-                  </div>
-                ` : null}
-              </div>
+              ` : null}
             </button>
           `
         })}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -9,10 +9,10 @@ import { agents, keepers, executionLoaded, shellCounts } from '../store'
 import { missionKeeperBriefs } from '../mission-signals'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
+import { RouteLink } from './common/route-link'
 import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
-import { KeeperFleetOverview } from './keeper-fleet-overview'
 import { FsmHub } from './fsm-hub'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
@@ -27,8 +27,8 @@ const activeView = computed<AgentsView>(() => {
 })
 
 const CHIPS: { id: AgentsView; label: string; description: string }[] = [
-  { id: 'all', label: '전체 보기', description: '에이전트와 키퍼를 한 목록에서 봅니다.' },
-  { id: 'agents', label: '일반 에이전트', description: '키퍼가 연결되지 않은 일반 에이전트만 봅니다.' },
+  { id: 'all', label: '전체', description: '에이전트와 키퍼를 한 목록에서 봅니다.' },
+  { id: 'agents', label: '에이전트', description: '키퍼가 연결되지 않은 일반 에이전트만 봅니다.' },
   { id: 'keepers', label: '키퍼', description: '키퍼만 따로 봅니다.' },
   { id: 'fsm', label: 'FSM', description: '키퍼 composite FSM lifecycle 상태를 봅니다.' },
 ]
@@ -82,14 +82,24 @@ export function AgentsUnified() {
         class="monitor-muted-panel w-fit p-1.5 shadow-[inset_0_1px_0_var(--white-3)]"
       />
 
+      ${currentView !== 'fsm' ? html`
+        <div class="monitor-muted-panel flex flex-wrap items-center gap-2 px-4 py-3 text-[12px] text-[var(--text-muted)]">
+          <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">이 화면 밖</span>
+          <span>이벤트 로그, 도구 품질, 거버넌스</span>
+          <${RouteLink}
+            tab="monitoring"
+            params=${{ section: 'fleet-health' }}
+            class="inline-flex shrink-0 items-center justify-center rounded-full border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-strong)] transition-colors hover:bg-[var(--accent-20)]"
+          >
+            플릿 텔레메트리 열기
+          <//>
+        </div>
+      ` : null}
+
       ${currentView === 'fsm'
         ? html`<${FsmHub} />`
         : html`
           ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
-
-          ${currentView !== 'agents' && keepers.value.length > 0 ? html`
-            <${KeeperFleetOverview} keepers=${keepers.value} />
-          ` : null}
 
           <${AgentRoster}
             keeperFilter=${currentView === 'keepers' ? 'keeper-only'

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -52,13 +52,13 @@ export function ConnectionStatus() {
     : `재연결 중...${formatDisconnectDuration()}`
 
   return html`
-    <div class="flex items-center gap-2 text-[length:var(--fs-sm)] whitespace-nowrap ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}">
-      <span class="size-[9px] rounded-full inline-block ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_9px_rgba(74,222,128,0.8)]' : 'bg-[var(--bad)]'}"></span>
+    <div class="flex items-center gap-1.5 whitespace-nowrap text-[12px] ${isConnected ? 'text-[#9af3ba]' : 'text-[#f7b7b7]'}">
+      <span class="inline-block size-[8px] rounded-full ${isConnected ? 'bg-[var(--ok)] shadow-[0_0_7px_rgba(74,222,128,0.75)]' : 'bg-[var(--bad)]'}"></span>
       <span class="status-text">${statusLabel}</span>
       ${attentionCount > 0 ? html`
         <${RouteLink}
           tab="overview"
-          class="inline-flex items-center justify-center py-0.5 px-2 min-w-[80px] border border-solid border-[var(--card-border)] bg-[var(--white-4)] tabular-nums rounded-full attention-badge"
+          class="inline-flex items-center justify-center rounded-full border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-0.5 tabular-nums attention-badge"
         >주의 ${attentionCount}건<//>
       ` : null}
     </div>
@@ -83,13 +83,15 @@ export function BuildIdentityBadge() {
   return html`
     <div class="relative">
       <button type="button"
-        class="text-[11px] py-[6px] px-[11px] rounded-md border border-solid border-[var(--accent-30)] bg-[var(--accent-10)] text-[var(--text-strong)] cursor-pointer font-[inherit] transition-colors duration-150 hover:bg-[var(--accent-20)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
+        class="cursor-pointer rounded-full border border-[var(--white-10)] bg-[var(--white-4)] px-[10px] py-[5px] text-[10px] text-[var(--text-muted)] transition-colors duration-150 hover:border-[var(--accent-20)] hover:text-[var(--text-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(71,184,255,0.45)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg-0)]"
         aria-expanded=${buildIdentityOpen.value}
+        aria-label=${`서버 빌드 정보 ${label}`}
+        title="서버 빌드 정보"
         onClick=${() => {
           buildIdentityOpen.value = !buildIdentityOpen.value
         }}
       >
-        서버 빌드 · ${label}
+        ${label}
       </button>
       ${buildIdentityOpen.value
         ? html`

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -62,9 +62,12 @@ export function FleetHealthPanel() {
 
   return html`
     <div class="flex flex-col gap-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-sm font-medium text-[var(--text-strong)]">Keeper 현황</h2>
-      </div>
+        <div class="flex flex-col gap-1">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">운영 신호 묶음</div>
+          <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-muted)]">
+            이 화면은 roster가 아니라 이벤트, 비교, 도구 품질, 거버넌스 같은 플릿 신호를 보는 곳입니다.
+          </p>
+        </div>
       <${FilterChips}
         chips=${VIEW_CHIPS}
         value=${view}

--- a/dashboard/src/config/navigation.test.ts
+++ b/dashboard/src/config/navigation.test.ts
@@ -43,9 +43,9 @@ describe('monitoring navigation labels', () => {
     const sections = visibleSectionItemsForTab('monitoring')
     const labelFor = (id: string) => sections.find(item => item.id === id)?.label
 
-    expect(labelFor('fleet-health')).toBe('Keeper 현황')
+    expect(labelFor('fleet-health')).toBe('플릿 텔레메트리')
     expect(labelFor('runtime')).toBe('런타임')
-    expect(labelFor('agents')).toBe('에이전트 & 키퍼')
+    expect(labelFor('agents')).toBe('런타임 디렉터리')
   })
 
   it('does not expose sessions section (removed in Phase 0 of RFC-MASC-006)', () => {

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -61,7 +61,7 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     id: 'monitoring',
     label: '모니터링',
     icon: '📡',
-    description: '에이전트/키퍼 현황 및 observability 관찰',
+    description: '런타임 디렉터리와 플릿 신호 관찰',
     defaultTab: 'monitoring',
     defaultParams: { section: 'agents' },
     tabs: ['monitoring'],
@@ -121,8 +121,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'agents',
-      label: '에이전트 & 키퍼',
-      description: '이름과 운영 상태를 함께 봅니다. 세션 요약은 오버뷰에서.',
+      label: '런타임 디렉터리',
+      description: '누가 살아 있고 어떤 런타임인지 빠르게 훑어봅니다. 이벤트, 도구, 거버넌스는 플릿 텔레메트리에서 봅니다.',
       params: { section: 'agents' },
     },
     {
@@ -139,8 +139,8 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     },
     {
       id: 'fleet-health',
-      label: 'Keeper 현황',
-      description: '텔레메트리 이벤트, Keeper 비교, 도구 품질, 거버넌스 지표를 통합 뷰로.',
+      label: '플릿 텔레메트리',
+      description: '이벤트 로그, Keeper 비교, 도구 품질, 거버넌스 신호를 한 화면에서 봅니다.',
       params: { section: 'fleet-health' },
     },
     {

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -45,7 +45,7 @@ let handle_ag_ui_events ~deps request reqd =
       respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version
         ~reason ~retry_after_s reqd
   | Ok () ->
-      stop_sse_session session_id;
+      stop_sse_session_preserve_guard session_id;
       let headers =
         Httpun.Headers.of_list
           (sse_stream_headers ~deps session_id protocol_version origin)
@@ -103,7 +103,7 @@ let handle_ag_ui_events ~deps request reqd =
                 with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                   Log.Server.error "ag-ui drain write error: %s"
                     (Printexc.to_string exn);
-                  stop_sse_session info.session_id);
+                  stop_sse_session_preserve_guard info.session_id);
                 if not !(info.stop) then drain ()
               in
               try drain ()
@@ -120,19 +120,19 @@ let handle_ag_ui_events ~deps request reqd =
                       | exn -> Log.Server.debug "SSE ping sleep interrupted: %s" (Printexc.to_string exn));
                   (try
                      if info.closed then
-                       stop_sse_session info.session_id
+                       stop_sse_session_preserve_guard info.session_id
                      else if not !(info.stop) then
                        ignore (send_raw info ": ping\n\n")
                    with Eio.Cancel.Cancelled _ as exn -> raise exn
                       | exn ->
                           Log.Server.warn "SSE ping send failed for session %s: %s" info.session_id (Printexc.to_string exn);
-                          stop_sse_session info.session_id);
+                          stop_sse_session_preserve_guard info.session_id);
                   loop ())
               in
               try loop () with Eio.Cancel.Cancelled _ as exn -> raise exn
                 | exn ->
                     Log.Server.error "SSE ping loop exited for session %s: %s" info.session_id (Printexc.to_string exn);
-                    stop_sse_session info.session_id)
+                    stop_sse_session_preserve_guard info.session_id)
       | Error msg ->
           Log.Server.debug "ag-ui SSE runtime unavailable for session %s: %s"
             session_id msg)

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -85,16 +85,23 @@ let close_sse_conn info =
          (Printexc.to_string exn));
     Sse.unregister_if_current info.session_id info.client_id)
 
-let stop_sse_session session_id =
+let stop_sse_session_impl ~clear_guard session_id =
   let info_opt = Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
     match Hashtbl.find_opt sse_conn_by_session session_id with
     | None -> None
     | Some info ->
         Hashtbl.remove sse_conn_by_session session_id;
+        if clear_guard then Hashtbl.remove sse_connect_guard_by_session session_id;
         Some info) in
   match info_opt with
   | None -> ()
   | Some info -> close_sse_conn info
+
+let stop_sse_session session_id =
+  stop_sse_session_impl ~clear_guard:true session_id
+
+let stop_sse_session_preserve_guard session_id =
+  stop_sse_session_impl ~clear_guard:false session_id
 
 let is_active_sse_session session_id =
   Eio.Mutex.use_ro sse_registry_mutex (fun () ->

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -187,6 +187,23 @@ let test_sse_guard_registry_is_shared_with_cleanup_loop () =
       | Ok () ->
           fail "expected second guard check to observe shared cooldown state")
 
+let test_preserve_guard_keeps_ag_ui_cooldown () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let module Cleanup_view = Masc_mcp.Server_mcp_transport_http_sse in
+  let session_id = "ag-ui-preserve-guard" in
+  match Transport.check_sse_connect_guard session_id with
+  | Error (reason, retry_after_s) ->
+      failf "expected first guard insert to succeed, got %s %.3f" reason
+        retry_after_s
+  | Ok () ->
+      Cleanup_view.stop_sse_session_preserve_guard session_id;
+      (match Transport.check_sse_connect_guard session_id with
+      | Ok () -> fail "expected preserved guard to enforce reconnect cooldown"
+      | Error (reason, retry_after_s) ->
+          check string "preserves session cooldown reason" "session_cooldown" reason;
+          check bool "preserved retry-after is positive" true (retry_after_s > 0.0));
+      ignore (Cleanup_view.reap_stale_guards ())
+
 let () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -208,5 +225,7 @@ let () =
         test_case "initialize disables sse" `Quick test_initialize_never_uses_sse;
         test_case "sse guard registry is shared" `Quick
           test_sse_guard_registry_is_shared_with_cleanup_loop;
+        test_case "preserve guard keeps cooldown" `Quick
+          test_preserve_guard_keeps_ag_ui_cooldown;
       ]);
     ]


### PR DESCRIPTION
## Summary
- rename the monitoring sections to separate runtime directory from fleet telemetry
- remove duplicated fleet-summary widgets from the runtime directory and quiet the card metadata
- add visible FSM context to keeper cards and slim down the global dashboard header

## Testing
- `pnpm run build`
- `pnpm exec vitest run src/config/navigation.test.ts src/components/agent-roster.test.ts --no-file-parallelism --maxWorkers=1`