### PR TITLE
refactor(tools): replace namespace vocabulary with project in tool descriptions

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -51,7 +51,7 @@ let dedupe_tool_schemas_by_name (schemas : Types.tool_schema list) =
 
 let default_instructions =
   "MASC (Multi-Agent Streaming Coordination) enables AI agent collaboration. \
-NAMESPACE: Agents sharing the same base path (.masc/ folder) coordinate together. \
+PROJECT: Agents sharing the same base path (.masc/ folder) coordinate together. \
 CLUSTER: Set MASC_CLUSTER_NAME for multi-machine coordination (otherwise tool surfaces use the configured cluster/default label). \
 READ: use resources/list + resources/read (status/tasks/agents/events/schema) for snapshots. \
 WRITE: prefer masc_transition (claim/start/done/cancel/release) with expected_version for CAS. \
@@ -161,10 +161,10 @@ let label_words_from_identifier ident =
     Falls back to auto-generated Title Case when absent. *)
 let custom_tool_titles : (string * string) list = [
   (* Room lifecycle *)
-  ("masc_join", "Join Namespace");
-  ("masc_leave", "Leave Namespace");
-  ("masc_status", "Namespace Status");
-  ("masc_reset", "Reset Namespace");
+  ("masc_join", "Join Project");
+  ("masc_leave", "Leave Project");
+  ("masc_status", "Project Status");
+  ("masc_reset", "Reset Project");
   ("masc_who", "List Online Agents");
   ("masc_check", "Check Preconditions");
   ("masc_workflow_guide", "Workflow Guide");
@@ -226,7 +226,7 @@ let custom_tool_titles : (string * string) list = [
   ("masc_keeper_create_from_persona", "Create Keeper from Persona");
   (* SDK aliases *)
   ("masc_list_tasks", "List Tasks");
-  ("masc_room_status", "Namespace Status");
+  ("masc_room_status", "Project Status");
   ("masc_claim_task", "Claim Task");
   ("masc_set_current_task", "Bind Current Task");
   ("masc_complete_task", "Complete Task");

--- a/lib/tool_inline_dispatch_room.ml
+++ b/lib/tool_inline_dispatch_room.ml
@@ -23,14 +23,13 @@ let handle_start (ctx : context) : tool_result option =
     if p = "" then arg_get_string ctx "room" "" else p
   in
   let task_title = arg_get_string ctx "task_title" "" in
-  (* Step 1: set project root / coordination namespace *)
+  (* Step 1: set project root *)
   let room_result =
     if path = "" then begin
-      (* Use current project namespace if already set *)
       if Room.is_initialized state.Mcp_server.room_config then
         Ok config
       else
-        Error "path is required when no project namespace is set. Provide the project directory path."
+        Error "path is required when no project scope is set. Provide the project directory path."
     end else begin
       let expanded =
         if String.length path >= 2 && path.[0] = '~' && path.[1] = '/' then
@@ -116,7 +115,7 @@ let handle_start (ctx : context) : tool_result option =
         end
       end
 
-(** masc_join — join the active MASC project namespace *)
+(** masc_join — join the active MASC project *)
 let handle_join (ctx : context) : tool_result option =
   let config = ctx.config in
   let agent_name = ctx.agent_name in

--- a/lib/tool_schemas/tool_schemas_inline_room.ml
+++ b/lib/tool_schemas/tool_schemas_inline_room.ml
@@ -3,7 +3,7 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_start";
-    description = "One-step onboarding: sets the active project root, joins the default namespace as agent, and optionally creates+claims a task. Prefer this truthful front door over the compatibility alias masc_set_room plus manual follow-up calls.";
+    description = "One-step onboarding: sets the active project root, joins as agent, and optionally creates+claims a task. Prefer this over the compatibility alias masc_set_room plus manual follow-up calls.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -20,7 +20,7 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_join";
-    description = "Join the active MASC namespace as agent_name to collaborate with other AI agents. \
+    description = "Join the active MASC project as agent_name to collaborate with other AI agents. \
 Call at session start or to re-register presence. Other agents can @mention you. \
 Check masc_status after joining to see active agents and available tasks.";
     input_schema = `Assoc [
@@ -41,8 +41,8 @@ Check masc_status after joining to see active agents and available tasks.";
   };
   {
     name = "masc_leave";
-    description = "Leave the active MASC project namespace and mark yourself as offline. \
-Call when: (1) session ends, (2) switching project scopes, (3) work complete. \
+    description = "Leave the active MASC project and mark yourself as offline. \
+Call when: (1) session ends, (2) switching projects, (3) work complete. \
 Side effects: releases all your locks, sets presence to offline. \
 Other agents will see you've left via SSE. \
 Example: masc_leave({agent_name: 'claude-xyz'})";
@@ -84,7 +84,7 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
   {
     name = "masc_messages";
     description = "Get recent broadcast messages from all agents. \
-Use to: catch up after joining, check if someone @mentioned you, see namespace activity. \
+Use to: catch up after joining, check if someone @mentioned you, see project activity. \
 Returns chronological list with sender, timestamp, content. \
 Default: last 20 messages. Use limit param for more/less. \
 Tip: Search for '@your-name' in results to find mentions.";
@@ -106,7 +106,7 @@ Tip: Search for '@your-name' in results to find mentions.";
   };
   {
     name = "masc_who";
-    description = "List all agents currently in the active namespace with their capabilities. \
+    description = "List all agents currently in the active project with their capabilities. \
 Shows: agent name, join time, capabilities (e.g., ['typescript', 'testing']). \
 Use to: find who can help, check if specific agent is online, see team composition. \
 Agents appear after masc_join, disappear after masc_leave. \

--- a/lib/tool_schemas/tool_schemas_room_core.ml
+++ b/lib/tool_schemas/tool_schemas_room_core.ml
@@ -10,7 +10,7 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_status";
-    description = "Get current project namespace/cluster status: active agents, task queue, recent broadcasts, and cluster info. \
+    description = "Get current project status: active agents, task queue, recent broadcasts, and cluster info. \
 Use when you need a snapshot of who is online and what tasks are available. \
 Call after masc_join to orient yourself. Pair with masc_tasks for detailed backlog.";
     input_schema = `Assoc [
@@ -20,7 +20,7 @@ Call after masc_join to orient yourself. Pair with masc_tasks for detailed backl
   };
   {
     name = "masc_reset";
-    description = "DESTRUCTIVE: Reset the active MASC project namespace completely. Deletes ALL data in .masc/ folder. \
+    description = "DESTRUCTIVE: Reset the active MASC project completely. Deletes ALL data in .masc/ folder. \
 Removes: tasks, messages, agents, locks, cache, telemetry. Cannot be undone. \
 Use only for: fresh start, corrupted state recovery, testing. \
 Requires confirm=true to execute. Example: masc_reset({confirm: true})";
@@ -62,7 +62,7 @@ Pair with masc_workflow_guide for next-step recommendations.";
               `String "current_task_set"; `String "worktree_active";
             ]);
           ]);
-          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Historical key 'room_set' now means project namespace configured.");
+          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false. Historical key 'room_set' means project scope configured.");
         ]);
       ]);
       ("required", `List [`String "assertions"]);

--- a/lib/tool_schemas/tool_schemas_room_extra.ml
+++ b/lib/tool_schemas/tool_schemas_room_extra.ml
@@ -1,4 +1,4 @@
-(** MCP tool schemas for namespace management operations (extra). *)
+(** MCP tool schemas for project management operations (extra). *)
 
 open Types
 


### PR DESCRIPTION
## Summary
- Replace "namespace" with "project" in tool schema descriptions, tool profile titles, and doc comments
- No functional/behavioral changes — string-only updates to MCP tool metadata visible to LLM clients

### Files (5, +19 -20)
- `mcp_server_eio_tool_profile.ml`: instruction text + 5 tool titles
- `tool_schemas_inline_room.ml`: 5 description updates (masc_start, join, leave, messages, who)
- `tool_schemas_room_core.ml`: 3 description updates (masc_status, reset, check)
- `tool_schemas_room_extra.ml`: module doc comment
- `tool_inline_dispatch_room.ml`: 2 comments + 1 error message

Part of epic #7261, Step 4.

## Test plan
- [x] `dune build` clean (string-only changes)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)