### PR TITLE
[codex] Clarify tool inventory truth axes

### DIFF
--- a/dashboard/src/components/tools/tool-full-inventory.ts
+++ b/dashboard/src/components/tools/tool-full-inventory.ts
@@ -13,13 +13,13 @@ import {
   type SurfaceFilter,
   searchQuery,
   categoryFilter,
-  enabledOnly,
   directOnly,
   showHidden,
   showDeprecated,
   surfaceFilter,
   SURFACE_MAP,
   SURFACE_LABELS,
+  hasSurface,
   loadTools,
   toolMatchesQuery,
   surfaceCountForFilter,
@@ -65,7 +65,6 @@ export function FullInventoryView({
   const filtered = inventory.filter(item => {
     if (!toolMatchesQuery(item, searchQuery.value)) return false
     if (categoryFilter.value !== 'all' && item.category !== categoryFilter.value) return false
-    if (enabledOnly.value && !item.enabled_in_current_mode) return false
     if (directOnly.value && !item.direct_call_allowed) return false
     if (!showHidden.value && item.visibility === 'hidden') return false
     if (!showDeprecated.value && item.lifecycle === 'deprecated') return false
@@ -77,7 +76,7 @@ export function FullInventoryView({
   })
 
   const totalCount = inventory.length
-  const enabledCount = inventory.filter(item => item.enabled_in_current_mode).length
+  const publicCount = inventory.filter(item => hasSurface(item, 'public_mcp')).length
   const hiddenCount = inventory.filter(item => item.visibility === 'hidden').length
   const deprecatedCount = inventory.filter(item => item.lifecycle === 'deprecated').length
   const directCallCount = inventory.filter(item => item.direct_call_allowed).length
@@ -90,8 +89,8 @@ export function FullInventoryView({
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">전체 도구</span>
         </div>
         <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${enabledCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">활성화됨</span>
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${publicCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
         </div>
         <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
@@ -109,6 +108,10 @@ export function FullInventoryView({
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${filtered.length}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">필터 결과</span>
         </div>
+      </div>
+
+      <div class="text-[12px] text-[var(--text-muted)] mb-4">
+        카드 숫자는 서로 다른 축이다. MCP 공개는 surface, 숨김은 visibility, 직접 호출은 hidden direct-call policy 기준이다.
       </div>
 
       <div class="flex flex-wrap gap-2 mb-4">
@@ -145,18 +148,10 @@ export function FullInventoryView({
           }}
         >
           <option value="all">전체 카테고리</option>
-          ${categories.map(category => html`<option value=${category}>${category}</option>`)}
+          ${categories.map(category => html`
+            <option value=${category}>${category === 'uncategorized' ? '미분류' : category}</option>
+          `)}
         </select>
-        <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
-          <input
-            type="checkbox"
-            checked=${enabledOnly.value}
-            onChange=${(e: Event) => {
-              enabledOnly.value = (e.target as HTMLInputElement).checked
-            }}
-          />
-          <span>활성화만</span>
-        </label>
         <label class="inline-flex items-center gap-2 text-[12px] text-[var(--text-body)]">
           <input
             type="checkbox"

--- a/dashboard/src/components/tools/tool-inventory-row.ts
+++ b/dashboard/src/components/tools/tool-inventory-row.ts
@@ -5,6 +5,9 @@ import type { DashboardToolInventoryItem } from '../../api'
 import { toolBadge } from './tool-state'
 
 export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
+  const categoryLabel = item.category === 'uncategorized' ? '미분류' : item.category
+  const categoryHint = item.category === 'uncategorized' ? ' (서버 미지정)' : ''
+
   return html`
     <article class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
       <div class="flex justify-between gap-3 items-start">
@@ -14,15 +17,13 @@ export function InventoryRow({ item }: { item: DashboardToolInventoryItem }) {
         </div>
         <div class="flex flex-wrap gap-1.5 justify-end">
           ${(item.surfaces ?? []).map(s => toolBadge(s, 'surface'))}
-          ${toolBadge(item.tier, item.tier === 'essential' ? 'ok' : item.tier === 'standard' ? 'warn' : 'default')}
           ${toolBadge(item.visibility)}
           ${toolBadge(item.lifecycle, item.lifecycle === 'deprecated' ? 'warn' : 'default')}
           ${toolBadge(item.implementationStatus)}
         </div>
       </div>
       <div class="flex flex-wrap gap-3 text-[12px] text-[var(--text-muted)] mt-2">
-        <span>카테고리: <strong class="text-[var(--text-body)]">${item.category}</strong></span>
-        <span>모드: <strong class="text-[var(--text-body)]">${item.enabled_in_current_mode ? '활성' : '비활성'}</strong></span>
+        <span>카테고리: <strong class="text-[var(--text-body)]">${categoryLabel}${categoryHint}</strong></span>
         <span>직접 호출: <strong class="text-[var(--text-body)]">${item.direct_call_allowed ? '허용' : '차단'}</strong></span>
         <span>권한: <strong class="text-[var(--text-body)]">${item.required_permission ?? '없음'}</strong></span>
       </div>

--- a/dashboard/src/components/tools/tool-state.ts
+++ b/dashboard/src/components/tools/tool-state.ts
@@ -15,7 +15,6 @@ export const toolsError = computed<string | null>(() => {
 export const toolsLoading = computed(() => toolsResource.state.value.status === 'loading')
 export const searchQuery = signal('')
 export const categoryFilter = signal('all')
-export const enabledOnly = signal(false)
 export const directOnly = signal(false)
 export const showHidden = signal(false)
 export const showDeprecated = signal(true)
@@ -40,6 +39,10 @@ export const SURFACE_LABELS: Record<SurfaceFilter, string> = {
 
 export async function loadTools() {
   await toolsResource.load(() => fetchDashboardTools())
+}
+
+export function hasSurface(item: DashboardToolInventoryItem, surface: string): boolean {
+  return (item.surfaces ?? []).includes(surface)
 }
 
 export function toolMatchesQuery(item: DashboardToolInventoryItem, rawQuery: string): boolean {

--- a/dashboard/src/components/tools/tool-summary-view.ts
+++ b/dashboard/src/components/tools/tool-summary-view.ts
@@ -2,22 +2,23 @@
 
 import { html } from 'htm/preact'
 import type { DashboardToolInventoryItem } from '../../api'
-import { toolBadge } from './tool-state'
+import { hasSurface, toolBadge } from './tool-state'
 
 export function ToolSummaryView({ inventory }: { inventory: DashboardToolInventoryItem[] }) {
-  const essential = inventory
-    .filter(item => item.tier === 'essential' && item.enabled_in_current_mode)
+  const publicTools = inventory
+    .filter(item => hasSurface(item, 'public_mcp'))
     .slice(0, 10)
 
-  const neverUsed = inventory
-    .filter(item => item.lifecycle !== 'deprecated' && item.visibility !== 'hidden')
+  const hiddenDirectCall = inventory
+    .filter(item => item.visibility === 'hidden' && item.direct_call_allowed)
     .slice(-5)
     .reverse()
 
   const visible = inventory.filter(item => item.visibility !== 'hidden')
   const hiddenCount = inventory.length - visible.length
   const visibleCount = visible.length
-  const enabledCount = visible.filter(item => item.enabled_in_current_mode).length
+  const publicCount = inventory.filter(item => hasSurface(item, 'public_mcp')).length
+  const directCallCount = inventory.filter(item => item.direct_call_allowed).length
   const deprecatedCount = visible.filter(item => item.lifecycle === 'deprecated').length
 
   return html`
@@ -28,12 +29,16 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">공개 도구</span>
         </div>
         <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
-          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${enabledCount}</span>
-          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">활성화됨</span>
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${publicCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">MCP 공개</span>
         </div>
         <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${hiddenCount}</span>
           <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">내부 전용</span>
+        </div>
+        <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
+          <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${directCallCount}</span>
+          <span class="text-[11px] text-[var(--text-muted)] uppercase tracking-wider font-medium">직접 호출</span>
         </div>
         <div class="p-4 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] flex flex-col gap-1.5">
           <span class="text-[var(--text-strong)] text-[28px] font-bold leading-none tabular-nums">${deprecatedCount}</span>
@@ -41,11 +46,15 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
         </div>
       </div>
 
-      ${essential.length > 0 ? html`
+      <div class="text-[12px] text-[var(--text-muted)] mb-4">
+        숫자는 서로 다른 축을 본다. MCP 공개는 surface, 내부 전용은 visibility, 직접 호출은 direct-call 정책 기준이다.
+      </div>
+
+      ${publicTools.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">필수 도구 (상위 ${essential.length}개)</h4>
+          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">대표 MCP 공개 도구 (${publicTools.length}개)</h4>
           <div class="flex flex-col">
-            ${essential.map(item => html`
+            ${publicTools.map(item => html`
               <div class="flex items-center gap-3 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
                 <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
                 <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
@@ -56,15 +65,15 @@ export function ToolSummaryView({ inventory }: { inventory: DashboardToolInvento
         </div>
       ` : null}
 
-      ${neverUsed.length > 0 ? html`
+      ${hiddenDirectCall.length > 0 ? html`
         <div class="mt-5">
-          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">미사용 도구 (${neverUsed.length}개)</h4>
+          <h4 class="text-sm font-semibold text-[var(--text-strong)] uppercase tracking-wider mb-3">숨김이지만 직접 호출 가능한 도구 (${hiddenDirectCall.length}개)</h4>
           <div class="flex flex-col">
-            ${neverUsed.map(item => html`
+            ${hiddenDirectCall.map(item => html`
               <div class="flex items-center gap-3 py-2.5 border-b border-[var(--white-4)] hover:bg-[var(--white-3)] transition-colors px-2 rounded" key=${item.name}>
                 <span class="text-[13px] font-medium text-[var(--text-strong)] min-w-[180px] shrink-0">${item.name}</span>
                 <span class="text-[12px] text-[var(--text-muted)] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">${item.description?.slice(0, 60) ?? ''}</span>
-                ${toolBadge(item.category)}
+                ${toolBadge(item.visibility)}
               </div>
             `)}
           </div>

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -53,8 +53,8 @@ export function Tools() {
         <div class="mb-4">
           <p class="text-[12px] text-[var(--text-muted)] leading-relaxed">
             ${showFullInventory.value
-              ? 'hidden/deprecated 포함 전체 도구 surface를 봅니다.'
-              : '필수 도구와 사용 현황 요약입니다.'}
+              ? 'hidden/deprecated 포함 inventory를 surface/visibility/direct-call 축으로 정리해 봅니다.'
+              : '도구 인벤토리의 핵심 surface와 노출 정책을 요약합니다.'}
           </p>
           <${ActionButton}
             variant="ghost"

--- a/docs/research/qwen-function-calling-harness-2026-04-15.md
+++ b/docs/research/qwen-function-calling-harness-2026-04-15.md
@@ -1,0 +1,79 @@
+# Qwen Function Calling Harness Notes
+
+**Date**: 2026-04-15
+**Source**: https://dev.to/samchon/qwen-meetup-function-calling-harness-from-675-to-100-3830
+**Status**: saved for local adoption review
+
+## What mattered
+
+The useful part is not the headline number. The useful part is the harness shape:
+
+1. `parse -> coerce -> validate -> structured feedback -> bounded retry`
+2. keep the validator deterministic and cheap before asking the model to try again
+3. measure `first try` and `final converged` separately
+4. use weaker local models as QA probes because they expose brittle schema and recovery paths faster
+
+The article's concrete examples that map well to `masc-mcp`:
+
+- lenient parse + type coercion before hard rejection
+- field-path feedback instead of generic "bad args"
+- staged validators from cheap to expensive
+- retry only inside the internal autonomous harness, not on the public client-facing path
+
+## What already exists in `masc-mcp`
+
+- Internal OAS-backed keeper/runtime path already opts into structured validation retry. See `lib/keeper/keeper_agent_run.ml`.
+- The repo already documents the public/internal boundary in `docs/design/tool-calling-quality-and-self-healing-rfc.md`.
+- Tool argument validation already has machine-readable field-path errors in `lib/tool_args.ml`.
+
+So the article is mostly confirmation, not a new direction.
+
+## Immediate actions worth adopting
+
+### 1. Keep public MCP one-shot
+
+Do not leak hidden retry into public MCP calls. The article is pro-harness, not pro-silent-retry everywhere.
+
+Applied interpretation for this repo:
+
+- public MCP: deterministic, one-shot, explicit error
+- internal OAS/keeper path: bounded retry with structured feedback
+
+### 2. Make dashboard/tooling distinguish truth axes
+
+If we compare inventory, visibility, direct-call policy, and runtime mode in one panel, the UI must say they are different axes. Otherwise operators read bad numbers and chase fake regressions.
+
+### 3. Prefer exact field-path feedback over prose
+
+When tool validation fails, the most reusable feedback shape is:
+
+- path
+- expected
+- actual or failure reason
+- retryable/non-retryable
+
+This is more important than richer prose.
+
+### 4. Benchmark weakest useful models first
+
+For local harness QA, weaker local models are useful because they reveal:
+
+- ambiguous schema slots
+- over-broad tool contracts
+- missing recovery hints
+- places where "first try" and "converged" diverge too much
+
+### 5. Report `first_try` and `final_converged` separately
+
+The article's strongest operational point is that low first-pass quality can still be acceptable if the repair loop is bounded and deterministic. That should be visible in benchmark outputs rather than collapsed into one success number.
+
+## Concrete `masc-mcp` follow-ups
+
+1. Keep tool inventory/dashboard counts tied to reliable backend truth only.
+2. Extend tool-calling benchmark reporting so `first_try` and `final` are always shown together.
+3. Audit internal validator feedback for cases that still collapse to generic error text instead of field-path diagnostics.
+
+## Related local docs
+
+- `docs/design/tool-calling-quality-and-self-healing-rfc.md`
+- `docs/research/tool-parameter-hallucination-harness.md`

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -110,6 +110,10 @@ let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
     schemas
     |> List.map (fun (schema : Types.tool_schema) ->
            let help_entry = Tool_help_registry.entry_of_schema schema in
+           let metadata_fields =
+             Tool_catalog.metadata_to_fields schema.name
+             |> List.filter (fun (key, _value) -> not (String.equal key "surfaces"))
+           in
            `Assoc
              ([
                 ("name", `String schema.name);
@@ -125,7 +129,7 @@ let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
                    | Some ss -> List.map (fun s -> `String s) (List.rev ss)
                    | None -> []));
               ]
-             @ Tool_catalog.metadata_to_fields schema.name))
+             @ metadata_fields))
   in
   `Assoc
     [

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -126,8 +126,22 @@ let test_dashboard_tools_projection () =
         |> List.find_opt (fun row ->
                row |> member "name" |> to_string = "masc_status")
       in
+      let spawned_agent_tool =
+        inventory_rows
+        |> List.find_opt (fun row ->
+               row |> member "name" |> to_string = "masc_workflow_guide")
+      in
+      let local_worker_tool =
+        inventory_rows
+        |> List.find_opt (fun row ->
+               row |> member "name" |> to_string = "masc_worktree_create")
+      in
       check bool "includes hidden tool" true (Option.is_some hidden_tool);
       check bool "includes public tool" true (Option.is_some public_tool);
+      check bool "includes spawned agent tool" true
+        (Option.is_some spawned_agent_tool);
+      check bool "includes local worker tool" true
+        (Option.is_some local_worker_tool);
       (match public_tool with
       | None -> ()
       | Some row ->
@@ -141,6 +155,22 @@ let test_dashboard_tools_projection () =
           in
           check bool "public tool tagged public_mcp" true (public_surface_count > 0);
           check int "public_mcp not duplicated on public tool" 1 public_surface_count);
+      (match spawned_agent_tool with
+      | None -> ()
+      | Some row ->
+          check bool "spawned agent tool keeps spawned_agent_mcp surface" true
+            (row |> member "surfaces" |> to_list
+             |> List.exists (function
+                  | `String "spawned_agent_mcp" -> true
+                  | _ -> false)));
+      (match local_worker_tool with
+      | None -> ()
+      | Some row ->
+          check bool "local worker tool keeps local_worker surface" true
+            (row |> member "surfaces" |> to_list
+             |> List.exists (function
+                  | `String "local_worker" -> true
+                  | _ -> false)));
       match hidden_tool with
       | None -> ()
       | Some row ->

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -309,7 +309,8 @@ let test_ag_ui_rejects_reconnect_then_recovers () =
   let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
   let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
 
-  let first = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?room=default" () in
+  (* Stay well inside the 1s reconnect guard so the next request is truly immediate. *)
+  let first = run_curl ~headers ~max_time:0.2 ~port ~path:"/ag-ui/events?room=default" () in
   check_status "first /ag-ui/events connect accepted" 200 first;
 
   let second = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?room=default" () in


### PR DESCRIPTION
## What changed
- fix dashboard tool inventory so capability-derived `surfaces` are not overwritten by catalog metadata
- update the tools UI to count and label reliable axes only: total, public MCP surface, hidden, deprecated, direct-call, filtered
- remove the misleading `enabled_in_current_mode` emphasis from the inventory views and render `uncategorized` as `미분류`
- add a saved research note on the Qwen function-calling harness and how it maps onto the current MASC/OAS boundary

## Why
- the previous inventory mixed surface, visibility, and direct-call policy into one screen without telling the operator they were different axes
- the backend projection also duplicated the `surfaces` field, which caused capability surface data such as `spawned_agent_mcp` and `local_worker` to disappear from the dashboard payload

## Impact
- the tools inventory page should now show counts that line up with the active filter tabs instead of collapsing to zeros or mismatched totals
- regression coverage now checks that public, spawned-agent, and local-worker surface tags survive the dashboard projection

## Validation
- `pnpm typecheck`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-tool-inventory-truth-axes test/test_dashboard_tools.exe`
- `./_build/default/test/test_dashboard_tools.exe`