### PR TITLE
fix(inventory): deduplicate surfaces field in tool inventory JSON

### DIFF
--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -110,6 +110,10 @@ let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
     schemas
     |> List.map (fun (schema : Types.tool_schema) ->
            let help_entry = Tool_help_registry.entry_of_schema schema in
+           let metadata_fields =
+             Tool_catalog.metadata_to_fields schema.name
+             |> List.filter (fun (key, _value) -> not (String.equal key "surfaces"))
+           in
            `Assoc
              ([
                 ("name", `String schema.name);
@@ -125,7 +129,7 @@ let tool_inventory_json _ctx ~include_hidden ~include_deprecated =
                    | Some ss -> List.map (fun s -> `String s) (List.rev ss)
                    | None -> []));
               ]
-             @ Tool_catalog.metadata_to_fields schema.name))
+             @ metadata_fields))
   in
   `Assoc
     [

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -126,8 +126,22 @@ let test_dashboard_tools_projection () =
         |> List.find_opt (fun row ->
                row |> member "name" |> to_string = "masc_status")
       in
+      let spawned_agent_tool =
+        inventory_rows
+        |> List.find_opt (fun row ->
+               row |> member "name" |> to_string = "masc_workflow_guide")
+      in
+      let local_worker_tool =
+        inventory_rows
+        |> List.find_opt (fun row ->
+               row |> member "name" |> to_string = "masc_worktree_create")
+      in
       check bool "includes hidden tool" true (Option.is_some hidden_tool);
       check bool "includes public tool" true (Option.is_some public_tool);
+      check bool "includes spawned agent tool" true
+        (Option.is_some spawned_agent_tool);
+      check bool "includes local worker tool" true
+        (Option.is_some local_worker_tool);
       (match public_tool with
       | None -> ()
       | Some row ->
@@ -141,6 +155,22 @@ let test_dashboard_tools_projection () =
           in
           check bool "public tool tagged public_mcp" true (public_surface_count > 0);
           check int "public_mcp not duplicated on public tool" 1 public_surface_count);
+      (match spawned_agent_tool with
+      | None -> ()
+      | Some row ->
+          check bool "spawned agent tool keeps spawned_agent_mcp surface" true
+            (row |> member "surfaces" |> to_list
+             |> List.exists (function
+                  | `String "spawned_agent_mcp" -> true
+                  | _ -> false)));
+      (match local_worker_tool with
+      | None -> ()
+      | Some row ->
+          check bool "local worker tool keeps local_worker surface" true
+            (row |> member "surfaces" |> to_list
+             |> List.exists (function
+                  | `String "local_worker" -> true
+                  | _ -> false)));
       match hidden_tool with
       | None -> ()
       | Some row ->


### PR DESCRIPTION
## Summary
- `metadata_to_fields`가 반환하는 `("surfaces", ...)` 필드와 `tool_inventory_json`이 직접 조립하는 `"surfaces"` 배열이 중복 출력되던 버그 수정
- `spawned_agent_mcp`, `local_worker` surface에 대한 inventory projection 테스트 추가

## Changes
- `lib/tool_misc_admin.ml`: `metadata_to_fields` 결과에서 `"surfaces"` 키를 필터링하여 중복 제거
- `test/test_dashboard_tools.ml`: surface별 가시성 검증 테스트 보강

## Test plan
- [x] `dune exec test/test_dashboard_tools.exe` 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)