### PR TITLE
feat(fsm-hub): observation point markers on swimlane (Grafana annotation pattern)

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1908,6 +1908,42 @@ function SwimlaneTimeline({
           </div>
         </div>
       ` : null}
+      ${observations.length > 1 ? html`
+        <div class="mt-0.5 flex items-center gap-2" aria-hidden="true">
+          <div class="w-[44px] shrink-0 text-[8px] text-[var(--text-dim)] text-right">obs</div>
+          <div class="relative flex-1 h-2.5">
+            ${observations.map((obs, obsIndex) => {
+              const leftPct = ((obs.ts - spanStart) / spanWidth) * 100
+              const prev = obsIndex > 0 ? observations[obsIndex - 1] : null
+              const hasTransition = prev != null && (
+                prev.phase !== obs.phase ||
+                prev.turn !== obs.turn ||
+                prev.decision !== obs.decision ||
+                prev.cascade !== obs.cascade ||
+                prev.compaction !== obs.compaction
+              )
+              const dotCls = hasTransition
+                ? 'bg-[#818cf8] ring-1 ring-[rgba(129,140,248,0.4)]'
+                : 'bg-[var(--white-10)]'
+              const changedLanes = prev == null ? [] : [
+                ...(prev.phase !== obs.phase ? ['KSM'] : []),
+                ...(prev.turn !== obs.turn ? ['KTC'] : []),
+                ...(prev.decision !== obs.decision ? ['KDP'] : []),
+                ...(prev.cascade !== obs.cascade ? ['KCL'] : []),
+                ...(prev.compaction !== obs.compaction ? ['KMC'] : []),
+              ]
+              const tip = `${fmtAbs(obs.ts)}${changedLanes.length > 0 ? ` · ${changedLanes.join(', ')} changed` : ' · no change'}`
+              return html`
+                <div
+                  class=${`absolute top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full ${dotCls} transition-all duration-200`}
+                  style=${`left: ${leftPct.toFixed(2)}%`}
+                  title=${tip}
+                ></div>
+              `
+            })}
+          </div>
+        </div>
+      ` : null}
       <div class="mt-2 flex flex-wrap items-center gap-2 text-[9px] text-[var(--text-dim)]">
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(129,140,248,0.45)]"></span>active</span>
         <span class="flex items-center gap-1"><span class="inline-block h-2 w-3 rounded-sm bg-[rgba(245,158,11,0.45)]"></span>compact</span>


### PR DESCRIPTION
## v22 — FSM Hub Iterative Layout Improvements (recurring /loop 30m cycle)

Stacked on #7301 (v21). Grafana annotation 패턴 적용 — swimlane time axis 아래에 observation dot row (rug plot) 추가.

## 제품 사례 참조

| 패턴 | 출처 | 적용 |
|------|------|------|
| Annotation overlay | Grafana | swimlane 아래 obs dot row |
| Rug plot | Tufte (1983) | 1D data point → tick mark |

## Changes

- Swimlane time axis 아래에 "obs" row 추가 — 각 관측 시점에 dot 배치.
- 전이가 있는 관측 = indigo dot + ring, 변화 없음 = dim dot.
- Tooltip: 절대 시각 + 변경된 lane 이름 (e.g. "14:32:10 · KTC, KCL changed").
- Dot 밀도 자체가 폴링 빈도 시각화 — 갭이나 클러스터가 바로 보임.

## 의미

v10 time axis 가 "눈금자" 라면, v22 obs row 는 "눈금자 위의 측정점". Segment 폭의 ambiguity ("오래 유지됨" vs "관측이 드물었음") 해소.

## Test

시각 변경만 — vitest 94 files / 646 tests pass.