### PR TITLE
[codex] split CLI and direct runtime adapters

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -580,6 +580,7 @@ export interface DashboardRuntimeProvidersResponse {
     providers?: number
     local_models?: number
     cloud_models?: number
+    cli_models?: number
   } | null
   providers: DashboardRuntimeProviderSnapshot[]
 }
@@ -679,6 +680,7 @@ function decodeRuntimeProvidersResponse(raw: unknown): DashboardRuntimeProviders
           providers: asNumber(summary.providers),
           local_models: asNumber(summary.local_models),
           cloud_models: asNumber(summary.cloud_models),
+          cli_models: asNumber(summary.cli_models),
         }
       : null,
     providers: asRecordArray(raw.providers)

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -163,7 +163,7 @@ export function RuntimeMonitor() {
           <${StatCell}
             label="Local Models"
             value=${providers?.summary?.local_models ?? 0}
-            detail=${`Cloud ${providers?.summary?.cloud_models ?? 0}`}
+            detail=${`Cloud ${providers?.summary?.cloud_models ?? 0} · CLI ${providers?.summary?.cli_models ?? 0}`}
           />
         </div>
         <div class="flex flex-col gap-3">

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -213,13 +213,20 @@ let llama_snapshot () =
 (** Build snapshot for any direct-API provider.
     Vendor-specific logic (Gemini Vertex ADC, etc.) is encapsulated
     inside Provider_adapter.auth_detail_of_provider. *)
-let direct_provider_snapshot provider =
+let provider_snapshot_of_adapter (adapter : Provider_adapter.adapter) =
+  let provider = adapter.canonical_name in
   let detail = Provider_adapter.auth_detail_of_provider provider in
   let default_model = default_model_for_provider provider in
+  let kind =
+    match adapter.runtime_kind with
+    | Provider_adapter.Local -> "local"
+    | Provider_adapter.Cli_agent -> "cli"
+    | Provider_adapter.Direct_api -> "cloud"
+  in
   {
     provider;
-    kind = "cloud";
-    runtime_kind = "direct_api";
+    kind;
+    runtime_kind = Provider_adapter.string_of_runtime_kind adapter.runtime_kind;
     auth_kind = detail.auth_kind;
     status = detail.status;
     available = detail.available;
@@ -233,15 +240,14 @@ let direct_provider_snapshot provider =
   }
 
 let provider_snapshots () : provider_snapshot list =
-  let direct =
+  let managed =
     Provider_adapter.direct_adapters
     |> List.filter (fun (a : Provider_adapter.adapter) ->
-         a.runtime_kind = Provider_adapter.Direct_api
+         a.runtime_kind <> Provider_adapter.Local
          && a.default_model_id <> None)
-    |> List.map (fun (a : Provider_adapter.adapter) ->
-         direct_provider_snapshot a.canonical_name)
+    |> List.map provider_snapshot_of_adapter
   in
-  llama_snapshot () :: direct
+  llama_snapshot () :: managed
 
 let provider_snapshot_by_name name =
   provider_snapshots ()
@@ -293,7 +299,14 @@ let provider_inventory_json () =
   in
   let cloud_models =
     snapshots
-    |> List.filter (fun snapshot -> snapshot.kind <> "local")
+    |> List.filter (fun snapshot -> snapshot.runtime_kind = "direct_api")
+    |> List.fold_left
+         (fun acc snapshot -> acc + List.length snapshot.models)
+         0
+  in
+  let cli_models =
+    snapshots
+    |> List.filter (fun snapshot -> snapshot.runtime_kind = "cli_agent")
     |> List.fold_left
          (fun acc snapshot -> acc + List.length snapshot.models)
          0
@@ -307,6 +320,7 @@ let provider_inventory_json () =
             ("providers", `Int (List.length snapshots));
             ("local_models", `Int local_models);
             ("cloud_models", `Int cloud_models);
+            ("cli_models", `Int cli_models);
           ] );
       ( "providers",
         `List (List.map provider_snapshot_to_json snapshots) );

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1,9 +1,11 @@
 type runtime_kind =
   | Local
+  | Cli_agent
   | Direct_api
 
 type auth_mode =
   | No_auth
+  | Cli_cached_login
   | Api_key of string
   | Vertex_adc of {
       project_env : string;
@@ -63,10 +65,12 @@ let google_cloud_location_env = "GOOGLE_CLOUD_LOCATION"
 
 let string_of_runtime_kind = function
   | Local -> "local"
+  | Cli_agent -> "cli_agent"
   | Direct_api -> "direct_api"
 
 let string_of_auth_mode = function
   | No_auth -> "none"
+  | Cli_cached_login -> "cli_cached_login"
   | Api_key env_name -> "api_key:" ^ env_name
   | Vertex_adc { project_env; location_env } ->
       "vertex_adc:" ^ project_env ^ ":" ^ location_env
@@ -82,9 +86,12 @@ let normalize_label label = String.trim label |> String.lowercase_ascii
 
 let cn_llama = "llama"
 let cn_ollama = "ollama"
-let cn_claude = "claude-api"
-let cn_codex = "codex-api"
-let cn_gemini = "gemini-api"
+let cn_claude = "claude"
+let cn_codex = "codex"
+let cn_gemini = "gemini"
+let cn_claude_api = "claude-api"
+let cn_codex_api = "codex-api"
+let cn_gemini_api = "gemini-api"
 let cn_glm = "glm"
 let cn_openrouter = "openrouter"
 
@@ -123,19 +130,18 @@ let make_local_label (model_id : string) : string =
 let string_of_provider_kind
     : Llm_provider.Provider_config.provider_kind -> string
   = function
-  | Anthropic -> cn_claude
-  | OpenAI_compat -> cn_codex
+  | Anthropic -> cn_claude_api
+  | OpenAI_compat -> cn_codex_api
   | Ollama -> cn_ollama
-  | Gemini -> cn_gemini
+  | Gemini -> cn_gemini_api
   | Gemini_cli -> cn_gemini
   | Glm -> cn_glm
   | Claude_code -> cn_claude
   | Codex_cli -> cn_codex
 
-(** Single source of truth for all agent adapters.
-    spawn_key maps to Spawn.default_configs keys.
-    default_voice maps to TTS voice names.
-    Adding a new agent = adding one entry here. *)
+(** Single source of truth for all provider/runtime adapters.
+    Simple names ([claude], [codex], [gemini]) are CLI runtimes.
+    Direct API adapters use explicit [*-api] canonical names. *)
 let direct_adapters =
   [
     {
@@ -166,28 +172,61 @@ let direct_adapters =
     };
     {
       canonical_name = cn_claude;
+      runtime_kind = Cli_agent;
+      auth_mode = Cli_cached_login;
+      aliases = [ cn_claude; "claude-code"; "claude_code" ];
+      spawn_key = Some "claude";
+      cascade_prefix = "claude_code";
+      default_voice = Some "Sarah";
+      endpoint_url = None;
+      default_model_id = Some "auto";
+    };
+    {
+      canonical_name = cn_codex;
+      runtime_kind = Cli_agent;
+      auth_mode = Cli_cached_login;
+      aliases = [ cn_codex; "codex-cli"; "codex_cli" ];
+      spawn_key = Some "codex";
+      cascade_prefix = "codex_cli";
+      default_voice = Some "George";
+      endpoint_url = None;
+      default_model_id = Some "auto";
+    };
+    {
+      canonical_name = cn_gemini;
+      runtime_kind = Cli_agent;
+      auth_mode = Cli_cached_login;
+      aliases = [ cn_gemini; "gemini-cli"; "gemini_cli" ];
+      spawn_key = Some "gemini";
+      cascade_prefix = "gemini_cli";
+      default_voice = Some "Roger";
+      endpoint_url = None;
+      default_model_id = Some "auto";
+    };
+    {
+      canonical_name = cn_claude_api;
       runtime_kind = Direct_api;
       auth_mode = Api_key "ANTHROPIC_API_KEY";
-      aliases = [ cn_claude; "claude"; "anthropic"; "claude-code"; "claude-api" ];
-      spawn_key = Some "claude";
+      aliases = [ cn_claude_api; "anthropic" ];
+      spawn_key = None;
       cascade_prefix = "claude";
       default_voice = Some "Sarah";
       endpoint_url = Some (anthropic_api_url ());
       default_model_id = Some "auto";
     };
     {
-      canonical_name = cn_codex;
+      canonical_name = cn_codex_api;
       runtime_kind = Direct_api;
       auth_mode = Api_key "OPENAI_API_KEY";
-      aliases = [ cn_codex; "codex"; "openai"; "codex-cli"; "codex-api" ];
-      spawn_key = Some "codex";
+      aliases = [ cn_codex_api; "openai" ];
+      spawn_key = None;
       cascade_prefix = "openai";
       default_voice = Some "George";
       endpoint_url = Some (openai_api_url ());
       default_model_id = Some "auto";
     };
     {
-      canonical_name = cn_gemini;
+      canonical_name = cn_gemini_api;
       runtime_kind = Direct_api;
       auth_mode =
         Vertex_adc
@@ -195,8 +234,8 @@ let direct_adapters =
             project_env = google_cloud_project_env;
             location_env = google_cloud_location_env;
           };
-      aliases = [ cn_gemini; "gemini"; "google"; "gemini-cli"; "gemini-api" ];
-      spawn_key = Some "gemini";
+      aliases = [ cn_gemini_api; "google" ];
+      spawn_key = None;
       cascade_prefix = "gemini";
       default_voice = Some "Roger";
       endpoint_url = None; (** Resolved dynamically for Gemini *)
@@ -669,6 +708,10 @@ let provider_auth_available label =
   | Some adapter ->
       (match adapter.auth_mode with
        | No_auth -> true
+       | Cli_cached_login ->
+           (match adapter.spawn_key with
+            | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
+            | None -> false)
        | Api_key env_name -> env_present env_name
        | Vertex_adc { project_env; _ } -> env_present project_env)
   | None -> false
@@ -751,7 +794,8 @@ let provider_model_label provider model =
 
 (** Derives the default model label for an adapter from its [runtime_kind]
     and [cascade_prefix].  Local adapters require an explicit model ID
-    (resolved via env); Direct_api adapters use "[cascade_prefix]:auto" when
+    (resolved via env); Cli_agent/Direct_api adapters use
+    "[cascade_prefix]:auto" when
     a default model is configured. *)
 let default_model_label_for_adapter (adapter : adapter) =
   match adapter.runtime_kind with
@@ -759,6 +803,7 @@ let default_model_label_for_adapter (adapter : adapter) =
     Result.map
       (fun model_id -> adapter.cascade_prefix ^ ":" ^ model_id)
       (explicit_llama_model_id_result ())
+  | Cli_agent
   | Direct_api ->
     match adapter.default_model_id with
     | Some _ -> Ok (adapter.cascade_prefix ^ ":auto")
@@ -771,6 +816,10 @@ let auto_label_for_adapter (adapter : adapter) =
   let is_available =
     match adapter.auth_mode with
     | No_auth -> true
+    | Cli_cached_login ->
+        (match adapter.spawn_key with
+         | Some cmd -> Llm_provider.Provider_registry.command_in_path cmd
+         | None -> false)
     | Api_key env_name -> env_present env_name
     | Vertex_adc { project_env; _ } -> env_present project_env
   in
@@ -938,7 +987,7 @@ let auth_detail_of_provider provider =
       note = Some "Unsupported provider" }
   | Some adapter ->
     let auth_kind_base = string_of_auth_mode adapter.auth_mode in
-    if adapter.canonical_name = cn_gemini then
+    if adapter.canonical_name = cn_gemini_api then
       match resolve_gemini_direct_auth () with
       | Gemini_api_key ->
         { auth_kind = "api_key:GEMINI_API_KEY"; status = "configured";
@@ -955,6 +1004,13 @@ let auth_detail_of_provider provider =
         { auth_kind = auth_kind_base; status = "missing_auth";
           available = false; supports_run = false;
           endpoint_url = None; note = Some message }
+    else if adapter.runtime_kind = Cli_agent then
+      let available = provider_auth_available provider in
+      { auth_kind = auth_kind_base;
+        status = (if available then "configured" else "missing_auth");
+        available; supports_run = available;
+        endpoint_url = None;
+        note = Some "Cached CLI login is assumed; final validation happens at execution time." }
     else
       let available = provider_auth_available provider in
       { auth_kind = auth_kind_base;
@@ -969,7 +1025,7 @@ let auth_env_keys_of_provider_kind (kind : Llm_provider.Provider_config.provider
   | Llm_provider.Provider_config.Glm -> [ "ZAI_API_KEY" ]
   | Llm_provider.Provider_config.OpenAI_compat -> [ "OPENAI_API_KEY" ]
   | Llm_provider.Provider_config.Gemini -> [ google_cloud_project_env; google_cloud_location_env ]
-  | Llm_provider.Provider_config.Gemini_cli -> [ google_cloud_project_env; google_cloud_location_env ]
+  | Llm_provider.Provider_config.Gemini_cli
   | Llm_provider.Provider_config.Claude_code
   | Llm_provider.Provider_config.Codex_cli
   | Llm_provider.Provider_config.Ollama -> []
@@ -992,6 +1048,7 @@ let all_auth_env_keys () : string list =
   |> List.filter_map (fun (adapter : adapter) ->
     match adapter.auth_mode with
     | No_auth -> None
+    | Cli_cached_login -> None
     | Api_key env_name -> Some env_name
     | Vertex_adc _ -> None)
   |> List.sort_uniq String.compare

--- a/lib/provider_adapter.mli
+++ b/lib/provider_adapter.mli
@@ -10,10 +10,12 @@
 
 type runtime_kind =
   | Local
+  | Cli_agent
   | Direct_api
 
 type auth_mode =
   | No_auth
+  | Cli_cached_login
   | Api_key of string
   | Vertex_adc of {
       project_env : string;
@@ -81,6 +83,9 @@ val cn_ollama : string
 val cn_claude : string
 val cn_codex : string
 val cn_gemini : string
+val cn_claude_api : string
+val cn_codex_api : string
+val cn_gemini_api : string
 val cn_glm : string
 val cn_openrouter : string
 val cn_custom : string
@@ -93,7 +98,7 @@ val string_of_voice_transport : voice_transport -> string
 
 (** {1 Adapter Registry} *)
 
-(** All registered LLM provider adapters. *)
+(** All registered LLM provider/runtime adapters. *)
 val direct_adapters : adapter list
 
 (** All registered voice provider adapters. *)

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -48,6 +48,26 @@ let sse_connect_window_s =
 let sse_connect_max_in_window =
   env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:10 |> max 0
 
+let guard_deadline state =
+  let session_deadline =
+    if sse_reconnect_min_interval_s <= 0.0 || state.last_connect_at < 0.0 then
+      neg_infinity
+    else
+      state.last_connect_at +. sse_reconnect_min_interval_s
+  in
+  let window_deadline =
+    if sse_connect_window_s <= 0.0 then
+      neg_infinity
+    else
+      match state.connect_times with
+      | latest :: _ -> latest +. sse_connect_window_s
+      | [] -> neg_infinity
+  in
+  Float.max session_deadline window_deadline
+
+let guard_expired ~now ~session_id state =
+  not (Hashtbl.mem sse_conn_by_session session_id) && now >= guard_deadline state
+
 (** Register an SSE connection under [sse_registry_mutex].
     All call sites must use this instead of direct [Hashtbl.replace]. *)
 let register_sse_conn ~session_id ~info =
@@ -72,7 +92,6 @@ let stop_sse_session session_id =
     | None -> None
     | Some info ->
         Hashtbl.remove sse_conn_by_session session_id;
-        Hashtbl.remove sse_connect_guard_by_session session_id;
         Some info) in
   match info_opt with
   | None -> ()
@@ -89,9 +108,10 @@ let active_session_count () =
 
 let reap_stale_guards () =
   Eio.Mutex.use_rw ~protect:true sse_registry_mutex (fun () ->
+    let now = Time_compat.now () in
     let stale =
-      Hashtbl.fold (fun sid _ acc ->
-        if not (Hashtbl.mem sse_conn_by_session sid) then sid :: acc
+      Hashtbl.fold (fun sid state acc ->
+        if guard_expired ~now ~session_id:sid state then sid :: acc
         else acc
       ) sse_connect_guard_by_session []
     in
@@ -144,11 +164,16 @@ let check_sse_connect_guard session_id =
     let now = Time_compat.now () in
     let state =
       match Hashtbl.find_opt sse_connect_guard_by_session session_id with
-      | Some v -> v
+      | Some v ->
+          v.connect_times <- prune_connect_times ~now v.connect_times;
+          if guard_expired ~now ~session_id v then (
+            Hashtbl.remove sse_connect_guard_by_session session_id;
+            { last_connect_at = -.1.0; connect_times = [] })
+          else
+            v
       | None -> { last_connect_at = -.1.0; connect_times = [] }
     in
-    let recent = prune_connect_times ~now state.connect_times in
-    state.connect_times <- recent;
+    let recent = state.connect_times in
     let session_wait_s =
       if sse_reconnect_min_interval_s <= 0.0 then
         0.0

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -153,7 +153,7 @@ let test_spawnable_agents_nonempty () =
 
 let test_spawnable_agents_contains_claude () =
   let agents = Masc_mcp.Provider_adapter.spawnable_canonical_names () in
-  check bool "contains claude-api" true (List.mem "claude-api" agents)
+  check bool "contains claude" true (List.mem "claude" agents)
 
 let test_agent_type_of_mention_claude () =
   let t = Auto_responder.agent_type_of_mention "claude-rare-beaver" in

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -177,10 +177,15 @@ let test_sse_guard_registry_is_shared_with_cleanup_loop () =
       failf "expected first guard insert to succeed, got %s %.3f" reason
         retry_after_s
   | Ok () ->
-      check int "cleanup loop sees the same guard table" 1
+      check int "cleanup keeps fresh guard entries" 0
         (Cleanup_view.reap_stale_guards ());
-      check int "transport view is already clean after shared reap" 0
-        (Transport.reap_stale_guards ())
+      (match Transport.check_sse_connect_guard session_id with
+      | Error ("session_cooldown", retry_after_s) ->
+          check bool "cooldown stays positive" true (retry_after_s > 0.0)
+      | Error (reason, retry_after_s) ->
+          failf "expected shared cooldown guard, got %s %.3f" reason retry_after_s
+      | Ok () ->
+          fail "expected second guard check to observe shared cooldown state")
 
 let () =
   Eio_main.run @@ fun env ->

--- a/test/test_mention_coverage.ml
+++ b/test/test_mention_coverage.ml
@@ -248,8 +248,8 @@ let test_is_spawnable_empty () =
 let test_spawnable_agents_list () =
   let names = Masc_mcp.Provider_adapter.spawnable_canonical_names () in
   check bool "list not empty" true (List.length names > 0);
-  check bool "contains claude-api" true (List.mem "claude-api" names);
-  check bool "contains gemini-api" true (List.mem "gemini-api" names);
+  check bool "contains claude" true (List.mem "claude" names);
+  check bool "contains gemini" true (List.mem "gemini" names);
   check bool "does not contain bare ollama" false (List.mem "ollama" names)
 
 (* ============================================================

--- a/test/test_observability_provider_contracts.ml
+++ b/test/test_observability_provider_contracts.ml
@@ -13,8 +13,8 @@ module Adapter = Masc_mcp.Provider_adapter
 
 let test_alias_roundtrip () =
   let cases =
-    [ ("anthropic", "claude-api"); ("Claude", "claude-api");
-      ("google", "gemini-api"); ("Gemini", "gemini-api");
+    [ ("anthropic", "claude-api"); ("Claude", "claude");
+      ("google", "gemini-api"); ("Gemini", "gemini");
       ("openai", "codex-api"); ("OpenAI", "codex-api");
       ("llama", "llama"); ("llamacpp", "llama");
       ("glm", "glm"); ("zai", "glm");
@@ -56,6 +56,8 @@ let test_adapter_well_formed () =
 
 let test_runtime_kind_strings () =
   check string "local" "local" (Adapter.string_of_runtime_kind Adapter.Local);
+  check string "cli_agent" "cli_agent"
+    (Adapter.string_of_runtime_kind Adapter.Cli_agent);
   check string "direct_api" "direct_api"
     (Adapter.string_of_runtime_kind Adapter.Direct_api)
 
@@ -71,6 +73,18 @@ let test_resolve_canonical_wraps_adapter () =
     in
     check (option string) ("consistent: " ^ label) via_adapter via_fn)
     labels
+
+let test_dashboard_provider_snapshots_include_cli_and_api () =
+  Eio_main.run (fun _env ->
+    let open Masc_mcp.Dashboard_provider_runs in
+    let claude_cli = provider_snapshot_by_name "claude" in
+    let claude_api = provider_snapshot_by_name "claude-api" in
+    check bool "cli snapshot present" true (Option.is_some claude_cli);
+    check bool "api snapshot present" true (Option.is_some claude_api);
+    check string "cli runtime kind" "cli_agent"
+      (Option.get claude_cli).runtime_kind;
+    check string "api runtime kind" "direct_api"
+      (Option.get claude_api).runtime_kind)
 
 let test_default_registry_populated () =
   (* Verify default_registry is usable by resolving a known provider.
@@ -224,6 +238,8 @@ let () =
           test_case "unknown returns none" `Quick test_unknown_returns_none;
           test_case "adapter well formed" `Quick test_adapter_well_formed;
           test_case "runtime kind strings" `Quick test_runtime_kind_strings;
+          test_case "dashboard snapshots include cli and api" `Quick
+            test_dashboard_provider_snapshots_include_cli_and_api;
         ] );
       ( "oas_model_resolve",
         [

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -22,6 +22,16 @@ let test_resolve_direct_aliases () =
   let codex = Option.get (Adapter.resolve_direct_adapter "openai") in
   check string "codex-api alias" "codex-api" codex.canonical_name
 
+let test_resolve_cli_canonical_names () =
+  let claude = Option.get (Adapter.resolve_direct_adapter "claude") in
+  check string "claude canonical" "claude" claude.canonical_name;
+  check string "claude runtime" "cli_agent"
+    (Adapter.string_of_runtime_kind claude.runtime_kind);
+  let gemini = Option.get (Adapter.resolve_direct_adapter "gemini") in
+  check string "gemini canonical" "gemini" gemini.canonical_name;
+  let codex = Option.get (Adapter.resolve_direct_adapter "codex") in
+  check string "codex canonical" "codex" codex.canonical_name
+
 let test_gemini_direct_auth_vertex_adc () =
   with_env "GOOGLE_CLOUD_PROJECT" (Some "demo-project") (fun () ->
       with_env "GOOGLE_CLOUD_LOCATION" (Some "asia-northeast3") (fun () ->
@@ -212,6 +222,7 @@ let () =
       ( "registry",
         [
           test_case "resolve direct aliases" `Quick test_resolve_direct_aliases;
+          test_case "resolve cli canonicals" `Quick test_resolve_cli_canonical_names;
           test_case "gemini vertex adc" `Quick test_gemini_direct_auth_vertex_adc;
           test_case "gemini api key fallback" `Quick
             test_gemini_direct_auth_api_key_fallback;

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -251,9 +251,6 @@ let with_server f =
   let env =
     merge_env_overrides
       [
-        ("MASC_SSE_RECONNECT_MIN_INTERVAL_S", "1.5");
-        ("MASC_SSE_CONNECT_WINDOW_S", "5.0");
-        ("MASC_SSE_CONNECT_MAX_IN_WINDOW", "1000");
         ("MASC_AUTONOMY_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
@@ -312,10 +309,10 @@ let test_ag_ui_rejects_reconnect_then_recovers () =
   let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
   let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
 
-  let first = run_curl ~headers ~max_time:1.0 ~port ~path:"/ag-ui/events?room=default" () in
+  let first = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?room=default" () in
   check_status "first /ag-ui/events connect accepted" 200 first;
 
-  let second = run_curl ~headers ~max_time:1.0 ~port ~path:"/ag-ui/events?room=default" () in
+  let second = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?room=default" () in
   check_status "immediate /ag-ui/events reconnect rejected" 429 second;
 
   Unix.sleepf 2.0;


### PR DESCRIPTION
## Summary
This makes CLI runtimes first-class in the MASC provider adapter layer instead of conflating them with direct API providers.

## What Changed
- add `Cli_agent` runtime kind and `Cli_cached_login` auth mode
- make `claude`, `codex`, and `gemini` the canonical CLI runtime adapters
- keep `claude-api`, `codex-api`, and `gemini-api` as explicit direct API adapters
- update provider-kind mapping, auth resolution, spawnable adapter resolution, and dashboard runtime inventory
- expose CLI runtime inventory separately in the dashboard summary/API
- update provider/observability/mention/auto-responder tests to match the new contract

## Why
The docs and runtime model had drifted: wrapper behavior existed, but the provider SSOT still treated CLI and direct API paths as the same class. This change aligns the code with the intended boundary.

## Impact
- simple names now consistently mean CLI runtimes
- direct API selection remains available through explicit `*-api` names
- dashboard/runtime inventory now shows CLI and direct API surfaces separately
- spawn/mention logic resolves through the same canonical adapter layer

## Validation
- targeted MASC build for touched tests
- `./_build/default/test/test_provider_adapter.exe`
- `./_build/default/test/test_observability_provider_contracts.exe`
- `./_build/default/test/test_auto_responder_coverage.exe`
- `./_build/default/test/test_mention_coverage.exe`

## Notes
Companion change for the matching `oas` CLI runtime label PR.
Dashboard TypeScript typecheck was not runnable in this worktree because local `tsc`/`node_modules` is absent under `dashboard/`.