### PR TITLE
refactor: remove 15 internal-tuning env vars as constants (Phase A-6/A-7)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -375,9 +375,7 @@ let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) 
 let delegate config ~agent_name ~target ~message
     ?(task_type_str = "async")
     ?(artifacts : artifact list = [])
-    ?(timeout = match Sys.getenv_opt "MASC_A2A_DELEGATION_TIMEOUT_SEC" with
-                | Some s -> (match int_of_string_opt s with Some n -> n | None -> 300)
-                | None -> 300)
+    ?(timeout = 300)
     () : (Yojson.Safe.t, string) result =
   (* BUG: Prevent self-delegation — creates blocking self-portal *)
   if String.equal agent_name target then

--- a/lib/backend/backend_types.ml
+++ b/lib/backend/backend_types.ml
@@ -49,11 +49,7 @@ type config = {
   pubsub_max_messages: int;
 }
 
-(** Get pubsub max messages from env or default *)
-let pubsub_max_messages_from_env () =
-  match Sys.getenv_opt "MASC_PUBSUB_MAX_MESSAGES" with
-  | Some s -> Safe_ops.int_of_string_with_default ~default:1000 s
-  | None -> 1000
+let pubsub_max_messages_from_env () = 1000
 
 let generate_node_id () =
   let hostname = try Unix.gethostname () with Unix.Unix_error _ -> "unknown" in

--- a/lib/channel_gate.ml
+++ b/lib/channel_gate.ml
@@ -56,17 +56,9 @@ type dispatch_fn =
 
 (* ── Configuration ──────────────────────────────────────────── *)
 
-let default_max_content_length = 4000
+let max_content_length () = 4000
 
-let max_content_length () =
-  match Sys.getenv_opt "MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH" with
-  | Some s -> (try max 100 (min 16000 (int_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> default_max_content_length)
-  | None -> default_max_content_length
-
-let dedup_ttl_sec () =
-  match Sys.getenv_opt "MASC_CHANNEL_GATE_DEDUP_TTL_SEC" with
-  | Some s -> (try max 10.0 (min 3600.0 (float_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 300.0)
-  | None -> 300.0
+let dedup_ttl_sec () = 300.0
 
 (* ── Deduplication (TTL hashtable, Eio-guarded mutex) ───────── *)
 
@@ -74,10 +66,7 @@ let dedup_table : (string, float) Hashtbl.t = Hashtbl.create 256
 
 let dedup_mutex = Eio.Mutex.create ()
 
-let dedup_max_entries =
-  match Sys.getenv_opt "MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES" with
-  | Some s -> (try max 100 (min 100_000 (int_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 10_000)
-  | None -> 10_000
+let dedup_max_entries = 10_000
 
 let with_dedup_lock f = Eio_guard.with_mutex dedup_mutex f
 

--- a/lib/channel_gate_metrics.ml
+++ b/lib/channel_gate_metrics.ml
@@ -109,16 +109,7 @@ type stats_acc = {
   binding_order : string Queue.t;
 }
 
-let parse_slow_threshold_ms value =
-  match int_of_string_opt (String.trim value) with Some v -> max 250 (min 120_000 v) | None -> 10_000
-
-let cached_slow_threshold_ms =
-  match Sys.getenv_opt "MASC_CHANNEL_GATE_SLOW_MS" with
-  | Some value -> parse_slow_threshold_ms value
-  | None -> 10_000
-
-let slow_threshold_ms () =
-  cached_slow_threshold_ms
+let slow_threshold_ms () = 10_000
 
 let max_tracked_rooms = 256
 let max_recent_events = 128

--- a/lib/core/circuit_breaker.ml
+++ b/lib/core/circuit_breaker.ml
@@ -48,36 +48,11 @@ type t = {
   cooldown_sec: float;        (** How long to stay open (default: 300s) *)
 }
 
-(** {1 Configuration}
-
-    SSOT for circuit breaker parameters.  This module lives in [masc_core],
-    which is below [masc_config] in the dependency graph, so env var reading
-    is self-contained here.  Do not duplicate these defaults in [env_config]. *)
+(** {1 Configuration} *)
 
 let default_failure_threshold = 3
 let default_failure_window = 60.0    (* 1 minute *)
 let default_cooldown = 300.0         (* 5 minutes *)
-
-let failure_threshold_from_env () =
-  Sys.getenv_opt "MASC_CIRCUIT_THRESHOLD"
-  |> Option.map int_of_string
-  |> Option.value ~default:default_failure_threshold
-
-let failure_window_from_env () =
-  let v =
-    Sys.getenv_opt "MASC_CIRCUIT_FAILURE_WINDOW_SEC"
-    |> Option.map float_of_string
-    |> Option.value ~default:default_failure_window
-  in
-  Float.max 1.0 v  (* prevent zero-window disabling the breaker *)
-
-let cooldown_from_env () =
-  let v =
-    Sys.getenv_opt "MASC_CIRCUIT_COOLDOWN"
-    |> Option.map float_of_string
-    |> Option.value ~default:default_cooldown
-  in
-  Float.max 1.0 v  (* prevent zero-cooldown instant retry loops *)
 
 (** {1 Creation} *)
 
@@ -94,11 +69,7 @@ let create
     cooldown_sec = cooldown;
   }
 
-let create_from_env () =
-  create
-    ~failure_threshold:(failure_threshold_from_env ())
-    ~cooldown:(cooldown_from_env ())
-    ()
+let create_from_env () = create ()
 
 (** {1 Internal Helpers} *)
 

--- a/lib/process/file_lock_eio.ml
+++ b/lib/process/file_lock_eio.ml
@@ -17,16 +17,8 @@ type lock_entry = {
   mutable active : int;   (** Number of fibers currently holding or waiting on this mutex *)
 }
 
-(** Self-contained config. [masc_process] is below [masc_config] in the
-    dependency graph, so env var reading is local. *)
-let max_lock_entries =
-  (match Sys.getenv_opt "MASC_FILE_LOCK_MAX_ENTRIES" with
-   | Some s -> (try max 64 (min 4096 (int_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 512)
-   | None -> 512)
-let stale_lock_seconds =
-  (match Sys.getenv_opt "MASC_FILE_LOCK_STALE_SEC" with
-   | Some s -> (try Float.max 60.0 (Float.min 7200.0 (float_of_string s)) with Eio.Cancel.Cancelled _ as e -> raise e | _ -> 600.0)
-   | None -> 600.0)
+let max_lock_entries = 512
+let stale_lock_seconds = 600.0
 
 let table : (string, lock_entry) Hashtbl.t = Hashtbl.create 64
 let table_mu = Eio.Mutex.create ()

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -42,10 +42,7 @@ let max_clients = 200
     (Eio.Stream.create 0 blocks add until a matching take).
     64 events at 3-10s intervals covers 3-10 minutes of buffering.
     A client that falls this far behind should reconnect. *)
-let stream_capacity =
-  match Sys.getenv_opt "MASC_SSE_STREAM_CAPACITY" with
-  | Some s -> (match int_of_string_opt (String.trim s) with Some v -> max 8 (min 1024 v) | None -> 64)
-  | None -> 64
+let stream_capacity = 64
 
 (** SSE client state.
     [event_stream] is the per-session mailbox.  [broadcast] pushes here;

--- a/lib/swarm_status/swarm_status_types.ml
+++ b/lib/swarm_status/swarm_status_types.ml
@@ -173,10 +173,7 @@ type session_info = {
     accommodates 2-3 consecutive round trips without false "stalled" signals.
     If no event occurs within this window, the lane transitions to "waiting".
     Self-contained config (masc_swarm_status is below masc_config). *)
-let moving_window_sec =
-  match Sys.getenv_opt "MASC_SWARM_MOVING_WINDOW_SEC" with
-  | Some s -> (try Float.max 30.0 (float_of_string s) with _ -> 300.0)
-  | None -> 300.0
+let moving_window_sec = 300.0
 
 (** Time window for "stalled" (no activity, likely stuck) status.
     900s (15 min) = 3x moving_window. The 1:3 ratio mirrors common

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -26,13 +26,7 @@ type board_list_cache = {
 let _board_list_cache : board_list_cache =
   { key = None; value = None; expires_at = 0.0 }
 
-let board_list_cache_ttl_s () =
-  match Sys.getenv_opt "MASC_KEEPER_BOARD_LIST_CACHE_TTL_S" with
-  | Some raw ->
-    (match Float.of_string_opt (String.trim raw) with
-     | Some v when v >= 0.0 -> v
-     | _ -> 30.0)
-  | None -> 30.0
+let board_list_cache_ttl_s () = 30.0
 
 let invalidate_board_list_cache () =
   _board_list_cache.key <- None;

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -21,12 +21,7 @@ type context = {
 
 type tool_result = bool * string
 
-let default_max_write_size = 1024 * 1024  (* 1 MiB *)
-
-let max_write_size =
-  match Sys.getenv_opt "MASC_MAX_WRITE_SIZE_BYTES" with
-  | Some s -> Option.value (int_of_string_opt s) ~default:default_max_write_size
-  | None -> default_max_write_size
+let max_write_size = 1024 * 1024  (* 1 MiB *)
 
 let normalize_dir_prefix path =
   Tool_code.normalize_path path ^ "/"

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -251,9 +251,6 @@ let with_server f =
   let env =
     merge_env_overrides
       [
-        ("MASC_SSE_RECONNECT_MIN_INTERVAL_S", "1.5");
-        ("MASC_SSE_CONNECT_WINDOW_S", "5.0");
-        ("MASC_SSE_CONNECT_MAX_IN_WINDOW", "1000");
         ("MASC_AUTONOMY_ENABLED", "0");
         ("GRAPHQL_API_KEY", "");
         ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
@@ -312,10 +309,10 @@ let test_ag_ui_rejects_reconnect_then_recovers () =
   let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
   let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
 
-  let first = run_curl ~headers ~max_time:1.0 ~port ~path:"/ag-ui/events?room=default" () in
+  let first = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?room=default" () in
   check_status "first /ag-ui/events connect accepted" 200 first;
 
-  let second = run_curl ~headers ~max_time:1.0 ~port ~path:"/ag-ui/events?room=default" () in
+  let second = run_curl ~headers ~max_time:0.5 ~port ~path:"/ag-ui/events?room=default" () in
   check_status "immediate /ag-ui/events reconnect rejected" 429 second;
 
   Unix.sleepf 2.0;


### PR DESCRIPTION
## Summary
2 commits: Phase A-6 (9 vars) + Phase A-7 (6 vars) = 15 env var overrides → code constants.
All are internal tuning parameters that were never changed at runtime.

## Phase A-6: circuit/gate/lock (9 vars, -57 lines)
| Env Var | Default | File |
|---------|---------|------|
| MASC_CIRCUIT_THRESHOLD | 3 | circuit_breaker.ml |
| MASC_CIRCUIT_FAILURE_WINDOW_SEC | 60.0 | circuit_breaker.ml |
| MASC_CIRCUIT_COOLDOWN | 300.0 | circuit_breaker.ml |
| MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH | 4000 | channel_gate.ml |
| MASC_CHANNEL_GATE_DEDUP_TTL_SEC | 300.0 | channel_gate.ml |
| MASC_CHANNEL_GATE_DEDUP_MAX_ENTRIES | 10000 | channel_gate.ml |
| MASC_CHANNEL_GATE_SLOW_MS | 10000 | channel_gate_metrics.ml |
| MASC_FILE_LOCK_MAX_ENTRIES | 512 | file_lock_eio.ml |
| MASC_FILE_LOCK_STALE_SEC | 600.0 | file_lock_eio.ml |

## Phase A-7: scattered inline vars (6 vars, -23 lines)
| Env Var | Default | File |
|---------|---------|------|
| MASC_KEEPER_BOARD_LIST_CACHE_TTL_S | 30.0 | tool_board.ml |
| MASC_MAX_WRITE_SIZE_BYTES | 1MiB | tool_code_write.ml |
| MASC_A2A_DELEGATION_TIMEOUT_SEC | 300 | a2a_tools.ml |
| MASC_SSE_STREAM_CAPACITY | 64 | sse.ml |
| MASC_PUBSUB_MAX_MESSAGES | 1000 | backend_types.ml |
| MASC_SWARM_MOVING_WINDOW_SEC | 300.0 | swarm_status_types.ml |

**Net: -80 lines across 10 files. 15 env vars removed.**

## Phase A 누적
| Stage | Env vars removed | Lines saved |
|-------|-----------------|-------------|
| A-1 (#7268) | 30 DASHBOARD | -113 |
| A-2 (#7270) | 16 CP/WARM/SSE/STIG | -36 |
| A-4 (#7288) | 7 review bucket | -16 |
| **A-6/A-7 (this)** | **15 circuit/gate/lock/misc** | **-80** |
| **Total** | **68** | **-245** |

## Test plan
- [x] `dune build` — success
- [x] `dune runtest` — all pass (A-6)
- [ ] `dune runtest` — A-7 (running)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)