### PR TITLE
feat(dashboard): FSM Hub 한국어 레이블 + idle 가시성 개선

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1340,7 +1340,11 @@ function PipelineStep({
   const stalenessCls = (() => {
     if (!heldFor || sinceTs == null) return 'text-[var(--text-dim)]'
     const ageSec = now - sinceTs
-    if (!isActive) return 'text-[var(--text-dim)]'
+    if (!isActive) {
+      // idle 상태에서도 장기 대기를 시각적으로 구분
+      if (ageSec > 600) return 'text-[var(--text-muted)]'   // 10분+ → muted (보임)
+      return 'text-[var(--text-dim)]'                        // 기본 dim
+    }
     if (ageSec > 60) return 'text-[#f59e0b]'
     if (ageSec > 20) return 'text-[#facc15]'
     return 'text-[#818cf8]'
@@ -1676,7 +1680,7 @@ const ALARM_VALUES = new Set([
 
 function swimlaneSegmentColor(value: string): string {
   if (ALARM_VALUES.has(value)) return 'bg-[rgba(239,68,68,0.5)]'
-  if (IDLE_LIKE_VALUES.has(value)) return 'bg-[rgba(255,255,255,0.04)]'
+  if (IDLE_LIKE_VALUES.has(value)) return 'bg-[rgba(255,255,255,0.07)]'
   if (value === 'Compacting' || value === 'compacting') return 'bg-[rgba(245,158,11,0.45)]'
   if (value === 'HandingOff') return 'bg-[rgba(167,139,250,0.5)]'
   return 'bg-[rgba(129,140,248,0.45)]'

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -967,10 +967,15 @@ function StatusBar({
   transitionCount: number
   observationCount: number
 }) {
+  const idleDuration = snapshot && !snapshot.is_live
+    ? fmtDuration(Math.max(0, now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)))
+    : null
+  const idleIsLong = snapshot && !snapshot.is_live && idleDuration != null
+    && (now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)) > 300
   const liveBadge = snapshot
     ? snapshot.is_live
-      ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-emerald-400 border-emerald-500/40 bg-emerald-500/10 animate-pulse">● LIVE</span>`
-      : html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-[var(--text-dim)] border-white/10">○ idle ${fmtDuration(Math.max(0, now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)))}</span>`
+      ? html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono text-emerald-400 border-emerald-500/40 bg-emerald-500/10 animate-pulse">● 실행 중</span>`
+      : html`<span class="px-2 py-0.5 rounded-full border text-[10px] font-mono ${idleIsLong ? 'text-[var(--text-muted)] border-amber-500/30' : 'text-[var(--text-dim)] border-white/10'}">○ 대기 ${idleDuration}${snapshot.last_outcome ? html` <span class="text-[8px] opacity-70">· 턴 #${snapshot.last_outcome.turn_id}</span>` : ''}</span>`
     : null
 
   const staleSec = lastFetchAt > 0 ? Math.max(0, now - lastFetchAt) : 0
@@ -982,9 +987,9 @@ function StatusBar({
           <span class="text-[10px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">FSM Hub</span>
           ${liveBadge}
           ${loading ? html`<span class="inline-block h-2.5 w-2.5 rounded-full border-2 border-[var(--accent)] border-t-transparent animate-spin"></span>` : null}
-          ${staleSec > 60 ? html`<span class="text-[9px] font-mono text-amber-400">${fmtDuration(staleSec)} ago</span>` : null}
+          ${staleSec > 60 ? html`<span class="text-[9px] font-mono text-amber-400">${fmtDuration(staleSec)} 전 갱신</span>` : null}
         </div>
-        <div class="flex items-center gap-1.5 flex-wrap" role="tablist" aria-label="Keeper selection">
+        <div class="flex items-center gap-1.5 flex-wrap" role="tablist" aria-label="Keeper 선택">
           ${keeperNames.map((name, i) => {
             const active = name === selected
             const cls = active
@@ -1023,13 +1028,13 @@ function StatusBar({
         <div class="mt-1.5 flex items-center gap-2 text-[9px] font-mono flex-wrap">
           ${/* KPI micro-metrics */ ''}
           <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--text-body)]">
-            turn ${snapshot.last_outcome ? `#${snapshot.last_outcome.turn_id}` : '—'}
+            턴 ${snapshot.last_outcome ? `#${snapshot.last_outcome.turn_id}` : '—'}
           </span>
           <span class=${`px-1.5 py-0.5 rounded border ${transitionCount > 0 ? 'border-[rgba(129,140,248,0.3)] text-[#818cf8]' : 'border-[var(--white-8)] text-[var(--text-dim)]'}`}>
-            ${transitionCount} transitions
+            ${transitionCount} 전환
           </span>
           <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--text-dim)]">
-            ${observationCount} obs
+            ${observationCount} 관측
           </span>
           ${/* Meta IDs */ ''}
           <span class="text-[var(--text-dim)] opacity-60">corr ${snapshot.correlation_id?.slice(-8) ?? '?'}</span>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -1300,6 +1300,7 @@ function PipelineStep({
   isLast,
   sinceTs,
   now,
+  limited,
 }: {
   label: string
   shortLabel: string
@@ -1307,6 +1308,9 @@ function PipelineStep({
   isLast?: boolean
   sinceTs: number | null
   now: number
+  /** When true, this lane has limited observability — only a subset of
+      states are derivable from the registry. Shown as a subtle indicator. */
+  limited?: boolean
 }) {
   const prevRef = useRef(value)
   const [flash, setFlash] = useState(false)
@@ -1351,14 +1355,15 @@ function PipelineStep({
   })()
 
   return html`
-    <div class="flex items-center gap-0 flex-1 min-w-0" role="listitem" aria-label=${`${label}: ${displayState(value)}${heldFor ? `, ${heldFor}` : ''}`}
-      title=${`${label} (${shortLabel}): ${value} → ${displayState(value)}${heldFor ? ` · ${heldFor}` : ''}\n${STATE_DESCRIPTIONS[value] ?? ''}`}
+    <div class="flex items-center gap-0 flex-1 min-w-0" role="listitem" aria-label=${`${label}: ${displayState(value)}${limited ? ' (관찰 제한)' : ''}${heldFor ? `, ${heldFor}` : ''}`}
+      title=${`${label} (${shortLabel}): ${value} → ${displayState(value)}${heldFor ? ` · ${heldFor}` : ''}${limited ? '\n⚠ 관찰 제한: 일부 상태만 registry에서 파생 가능 (#7122)' : ''}\n${STATE_DESCRIPTIONS[value] ?? ''}`}
     >
-      <div class=${`flex-1 rounded-lg border px-3 py-2 transition-all duration-500 ${borderCls} ${bgCls}`}>
+      <div class=${`flex-1 rounded-lg border px-3 py-2 transition-all duration-500 ${borderCls} ${bgCls} ${limited && !isActive ? 'opacity-60' : ''}`}>
         <div class="flex items-center justify-between gap-1.5">
           <div class="flex items-center gap-1.5 min-w-0">
             ${isActive ? html`<span class="h-1.5 w-1.5 rounded-full bg-[#818cf8] ${activePulse} shrink-0"></span>` : null}
             <span class="text-[9px] font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
+            ${limited ? html`<span class="text-[7px] font-mono text-[var(--text-dim)] border border-[var(--white-10)] rounded px-1" title="Event_bus 구독 미구현으로 일부 상태만 관찰 가능">제한</span>` : null}
           </div>
           ${heldFor ? html`
             <span class=${`text-[9px] font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
@@ -1390,8 +1395,8 @@ function TurnPipelineStrip({
       </div>
       <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="턴 파이프라인 단계">
         <${PipelineStep} shortLabel="KTC" label="턴 주기" value=${snapshot.turn_phase} sinceTs=${stateEntries?.turn ?? null} now=${now} />
-        <${PipelineStep} shortLabel="KDP" label="의사결정" value=${snapshot.decision.stage} sinceTs=${stateEntries?.decision ?? null} now=${now} />
-        <${PipelineStep} shortLabel="KCL" label="캐스케이드" value=${snapshot.cascade.state} sinceTs=${stateEntries?.cascade ?? null} now=${now} />
+        <${PipelineStep} shortLabel="KDP" label="의사결정" value=${snapshot.decision.stage} sinceTs=${stateEntries?.decision ?? null} now=${now} limited />
+        <${PipelineStep} shortLabel="KCL" label="캐스케이드" value=${snapshot.cascade.state} sinceTs=${stateEntries?.cascade ?? null} now=${now} limited />
         <${PipelineStep} shortLabel="KMC" label="컨텍스트 압축" value=${snapshot.compaction.stage} sinceTs=${stateEntries?.compaction ?? null} now=${now} isLast />
       </div>
     </div>

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -92,11 +92,11 @@ const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> = {
 }
 
 const LANE_LABELS: Record<keyof Omit<CompositeObservation, 'ts'>, string> = {
-  phase: 'keeper lifecycle',
-  turn: 'turn cycle',
-  decision: 'decision',
-  cascade: 'cascade',
-  compaction: 'compaction',
+  phase: 'Keeper 생명주기',
+  turn: '턴 주기',
+  decision: '의사결정',
+  cascade: '캐스케이드',
+  compaction: '컨텍스트 압축',
 }
 
 function observeSnapshot(
@@ -898,7 +898,7 @@ export function FsmHub() {
         <${HeroPhase} snapshot=${snapshot} phaseLog=${phaseLog} phaseSince=${stateEntries?.phase ?? null} now=${now} />
 
         ${/* ── Zone 2b: Transition History Trail (collapsible) ── */ ''}
-        <${CollapsibleZone} id="transition-trail" title="Transition History" defaultOpen=${true}>
+        <${CollapsibleZone} id="transition-trail" title="전환 이력" defaultOpen=${true}>
           <${TransitionTrail} history=${history} now=${now} hoveredSegment=${hoveredSegment} />
         <//>
 
@@ -906,7 +906,7 @@ export function FsmHub() {
         <${TurnPipelineStrip} snapshot=${snapshot} stateEntries=${stateEntries} now=${now} />
 
         ${/* ── Zone 3b: Swimlane Timeline (collapsible) ── */ ''}
-        <${CollapsibleZone} id="swimlane" title="Swimlane Timeline" defaultOpen=${true}>
+        <${CollapsibleZone} id="swimlane" title="상태 타임라인" defaultOpen=${true}>
           <${SwimlaneTimeline}
             observations=${view.observations}
             now=${now}
@@ -916,7 +916,7 @@ export function FsmHub() {
         <//>
 
         ${/* ── Zone 4: Health Grid (collapsible) ── */ ''}
-        <${CollapsibleZone} id="health-grid" title="Health Grid" defaultOpen=${true}>
+        <${CollapsibleZone} id="health-grid" title="상태 격자" defaultOpen=${true}>
           <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             <${MeasurementCard} snapshot=${snapshot} />
             <${InvariantsPanel} snapshot=${snapshot} />
@@ -1193,22 +1193,23 @@ function HeroPhase({
 
   return html`
     <div class=${`rounded-xl border p-5 transition-all duration-700 ${flash ? 'border-[var(--accent)] bg-[rgba(71,184,255,0.06)] shadow-[0_0_16px_rgba(71,184,255,0.2)]' : 'border-[var(--white-8)] bg-[var(--white-2)]'}`}
-      role="status" aria-live="polite" aria-label=${`Keeper phase: ${snapshot.phase}${heldFor ? `, held for ${heldFor}` : ''}`}
+      role="status" aria-live="polite" aria-label=${`Keeper 상태: ${displayState(snapshot.phase)}${heldFor ? `, ${heldFor}` : ''}`}
       title=${STATE_DESCRIPTIONS[snapshot.phase] ?? snapshot.phase}
     >
       <div class="flex items-baseline justify-between">
         <div>
-          <div class="text-[10px] font-semibold uppercase tracking-[0.1em] text-[var(--text-muted)]" id="ksm-label">KSM · Keeper Lifecycle</div>
+          <div class="text-[10px] font-semibold tracking-[0.06em] text-[var(--text-muted)]" id="ksm-label">Keeper 생명주기 <span class="font-mono text-[8px] text-[var(--text-dim)]">KSM</span></div>
           <div class=${`mt-1 font-mono text-[32px] font-bold tracking-tight ${color}`} aria-labelledby="ksm-label">
-            ${snapshot.phase}
+            ${displayState(snapshot.phase)}
           </div>
+          <div class="mt-0.5 text-[9px] font-mono text-[var(--text-dim)]">${snapshot.phase}</div>
           ${heldFor ? html`
             <div class="mt-1 text-[10px] font-mono text-[var(--text-dim)]" aria-hidden="true">
-              held for <span class="text-[var(--text-body)]">${heldFor}</span>
+              유지 <span class="text-[var(--text-body)]">${heldFor}</span>
             </div>
           ` : null}
         </div>
-        ${flash ? html`<span class="text-[10px] text-[var(--accent)] animate-pulse font-mono" aria-live="assertive">phase changed</span>` : null}
+        ${flash ? html`<span class="text-[10px] text-[var(--accent)] animate-pulse font-mono" aria-live="assertive">상태 변경</span>` : null}
       </div>
       <${PhaseSparkline} log=${phaseLog} />
     </div>
@@ -1250,6 +1251,46 @@ const STATE_DESCRIPTIONS: Record<string, string> = {
   Draining: 'Finishing current work before shutdown',
   Restarting: 'Shutting down and restarting',
   Dead: 'Permanently terminated',
+}
+
+/** Korean display names for raw FSM state values.
+    Replaces English internals in PipelineStep and Swimlane. */
+const STATE_DISPLAY_NAMES: Record<string, string> = {
+  // KTC
+  idle: '대기',
+  prompting: '프롬프트 구성',
+  executing: '실행 중',
+  compacting: '압축 중',
+  finalizing: '마무리',
+  // KDP
+  undecided: '대기',
+  guard_ok: '가드 통과',
+  gate_rejected: '게이트 거부',
+  tool_policy_selected: '도구 정책 적용',
+  // KCL
+  selecting: '선택 중',
+  trying: '시도 중',
+  done: '완료',
+  exhausted: '소진',
+  // KMC
+  accumulating: '수집 중',
+  // KSM
+  Running: '가동 중',
+  Compacting: '압축 중',
+  HandingOff: '인수인계',
+  Failing: '오류 발생',
+  Crashed: '비정상 종료',
+  Offline: '오프라인',
+  Paused: '일시 중지',
+  Stopped: '정지',
+  Draining: '종료 준비',
+  Restarting: '재시작',
+  Dead: '종료됨',
+}
+
+/** Resolve display name: Korean label for UI, raw value preserved in tooltips. */
+function displayState(value: string): string {
+  return STATE_DISPLAY_NAMES[value] ?? value
 }
 
 function PipelineStep({
@@ -1306,23 +1347,23 @@ function PipelineStep({
   })()
 
   return html`
-    <div class="flex items-center gap-0 flex-1 min-w-0" role="listitem" aria-label=${`${shortLabel}: ${value}${heldFor ? `, held for ${heldFor}` : ''}`}
-      title=${`${label} (${shortLabel}): ${value}${heldFor ? ` · held ${heldFor}` : ''}\n${STATE_DESCRIPTIONS[value] ?? ''}`}
+    <div class="flex items-center gap-0 flex-1 min-w-0" role="listitem" aria-label=${`${label}: ${displayState(value)}${heldFor ? `, ${heldFor}` : ''}`}
+      title=${`${label} (${shortLabel}): ${value} → ${displayState(value)}${heldFor ? ` · ${heldFor}` : ''}\n${STATE_DESCRIPTIONS[value] ?? ''}`}
     >
       <div class=${`flex-1 rounded-lg border px-3 py-2 transition-all duration-500 ${borderCls} ${bgCls}`}>
         <div class="flex items-center justify-between gap-1.5">
           <div class="flex items-center gap-1.5 min-w-0">
             ${isActive ? html`<span class="h-1.5 w-1.5 rounded-full bg-[#818cf8] ${activePulse} shrink-0"></span>` : null}
-            <span class="text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">${shortLabel}</span>
+            <span class="text-[9px] font-semibold tracking-[0.04em] text-[var(--text-muted)]">${label}</span>
           </div>
           ${heldFor ? html`
             <span class=${`text-[9px] font-mono tabular-nums ${stalenessCls}`} aria-hidden="true">${heldFor}</span>
           ` : null}
         </div>
         <div class=${`mt-0.5 font-mono text-[13px] font-semibold ${isActive ? 'text-[var(--text-strong)]' : 'text-[var(--text-muted)]'} ${flash ? 'animate-pulse' : ''}`}>
-          ${value}
+          ${displayState(value)}
         </div>
-        <div class="text-[8px] text-[var(--text-dim)] mt-0.5">${label}</div>
+        <div class="text-[8px] font-mono text-[var(--text-dim)] mt-0.5">${shortLabel} · ${value}</div>
       </div>
       ${!isLast ? html`<div class=${`hidden md:block w-5 shrink-0 ${connectorCls}`}></div>` : null}
     </div>
@@ -1341,13 +1382,13 @@ function TurnPipelineStrip({
   return html`
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
       <div class="mb-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
-        Turn Pipeline
+        턴 파이프라인
       </div>
-      <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="Turn pipeline stages">
-        <${PipelineStep} shortLabel="KTC" label="Turn cycle" value=${snapshot.turn_phase} sinceTs=${stateEntries?.turn ?? null} now=${now} />
-        <${PipelineStep} shortLabel="KDP" label="Decision" value=${snapshot.decision.stage} sinceTs=${stateEntries?.decision ?? null} now=${now} />
-        <${PipelineStep} shortLabel="KCL" label="Cascade" value=${snapshot.cascade.state} sinceTs=${stateEntries?.cascade ?? null} now=${now} />
-        <${PipelineStep} shortLabel="KMC" label="Compaction" value=${snapshot.compaction.stage} sinceTs=${stateEntries?.compaction ?? null} now=${now} isLast />
+      <div class="flex flex-col gap-1 md:flex-row md:gap-0 md:items-stretch" role="list" aria-label="턴 파이프라인 단계">
+        <${PipelineStep} shortLabel="KTC" label="턴 주기" value=${snapshot.turn_phase} sinceTs=${stateEntries?.turn ?? null} now=${now} />
+        <${PipelineStep} shortLabel="KDP" label="의사결정" value=${snapshot.decision.stage} sinceTs=${stateEntries?.decision ?? null} now=${now} />
+        <${PipelineStep} shortLabel="KCL" label="캐스케이드" value=${snapshot.cascade.state} sinceTs=${stateEntries?.cascade ?? null} now=${now} />
+        <${PipelineStep} shortLabel="KMC" label="컨텍스트 압축" value=${snapshot.compaction.stage} sinceTs=${stateEntries?.compaction ?? null} now=${now} isLast />
       </div>
     </div>
   `
@@ -1609,11 +1650,11 @@ const SWIMLANE_LANES: Array<{
   label: string
   short: string
 }> = [
-  { key: 'phase', label: 'Keeper Lifecycle', short: 'KSM' },
-  { key: 'turn', label: 'Turn Cycle', short: 'KTC' },
-  { key: 'decision', label: 'Decision', short: 'KDP' },
-  { key: 'cascade', label: 'Cascade', short: 'KCL' },
-  { key: 'compaction', label: 'Compaction', short: 'KMC' },
+  { key: 'phase', label: 'Keeper 생명주기', short: 'KSM' },
+  { key: 'turn', label: '턴 주기', short: 'KTC' },
+  { key: 'decision', label: '의사결정', short: 'KDP' },
+  { key: 'cascade', label: '캐스케이드', short: 'KCL' },
+  { key: 'compaction', label: '컨텍스트 압축', short: 'KMC' },
 ]
 
 const IDLE_LIKE_VALUES = new Set([
@@ -1743,7 +1784,7 @@ function SwimlaneTimeline({
     <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3" data-fsm-swimlane-root="true">
       <div class="mb-2 flex items-baseline justify-between gap-3 flex-wrap">
         <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
-          Swimlane Timeline
+          상태 타임라인
         </div>
         <div class="flex items-center gap-1 flex-wrap">
           ${SWIMLANE_LANES.map(lane => {
@@ -1789,7 +1830,7 @@ function SwimlaneTimeline({
                     hoveredSegment.from === seg.from &&
                     hoveredSegment.to === seg.to
                   const dimmed = hoveredSegment != null && !isHovered
-                  const ariaLabel = `${lane.label}, ${seg.value}, ${fmtAbs(seg.from)} to ${fmtAbs(seg.to)}, held ${holdFor}`
+                  const ariaLabel = `${lane.label}, ${displayState(seg.value)}, ${fmtAbs(seg.from)} ~ ${fmtAbs(seg.to)}, ${holdFor}`
                   return html`
                     <button
                       type="button"
@@ -1799,7 +1840,7 @@ function SwimlaneTimeline({
                       data-seg-index=${segIndex}
                       class=${`${swimlaneSegmentColor(seg.value)} h-full transition-all duration-200 border-r border-[rgba(0,0,0,0.25)] last:border-r-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-inset ${isHovered ? 'ring-1 ring-[var(--accent)] brightness-125' : ''} ${dimmed ? 'opacity-40' : ''}`}
                       style=${`width: ${pct.toFixed(2)}%`}
-                      title=${`${lane.short} · ${seg.value}\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · held ${holdFor}`}
+                      title=${`${lane.label} (${lane.short}) · ${displayState(seg.value)} (${seg.value})\n${fmtAbs(seg.from)} → ${fmtAbs(seg.to)} · ${holdFor}`}
                       aria-label=${ariaLabel}
                       onmouseenter=${() => onHoverSegment({ field: lane.short, laneKey: lane.key, from: seg.from, to: seg.to, value: seg.value })}
                       onmouseleave=${() => onHoverSegment(null)}


### PR DESCRIPTION
## Summary
- FSM Hub의 암호 같은 약어(KSM/KTC/KDP/KCL/KMC)를 한국어 풀네임으로 교체. 약어는 하단 보조 텍스트로 유지
- 모든 FSM 상태값(idle, undecided, accumulating 등)을 한국어로 표시 (대기, 수집 중 등). 원문은 tooltip에 보존
- 섹션 제목 한국어화: Turn Pipeline→턴 파이프라인, Swimlane Timeline→상태 타임라인 등
- idle 상태에서 10분+ 대기 시 duration 텍스트 가시성 향상 (dim→muted)
- Swimlane idle 구간 opacity 0.04→0.07으로 증가

## 변경 전/후

| 위치 | Before | After |
|------|--------|-------|
| PipelineStep 상단 | `KTC` (9px, 약어) | `턴 주기` (9px, 풀네임) |
| PipelineStep 값 | `idle` | `대기` |
| PipelineStep 하단 | `Turn cycle` (8px) | `KTC · idle` (8px, 약어+원문) |
| Hero | `KSM · Keeper Lifecycle` | `Keeper 생명주기 KSM` |
| Hero 값 | `Running` | `가동 중` + `running` 보조 |
| Swimlane 라벨 | `Keeper Lifecycle` | `Keeper 생명주기` |
| 섹션 제목 | `Turn Pipeline` | `턴 파이프라인` |

## 근거
- Grafana State Timeline / K8s Sloop 패턴: 풀네임 기본, 약어는 필터용
- 사용자 피드백: "ktc 란 무엇? kdp 란 무엇? 이거 뭐임"

## Test plan
- [ ] TypeScript 빌드 에러 없음 (확인 완료)
- [ ] 기존 fsm-hub.test.ts 영향 없음 (데이터 레벨 약어 미변경)
- [ ] 대시보드에서 FSM Hub 패널 시각 확인
- [ ] Hero 카드에 한국어 상태 + 원문 보조 표시 확인
- [ ] Swimlane tooltip에 한국어+원문 병기 확인

Generated with [Claude Code](https://claude.com/claude-code)