### PR TITLE
fix(fsm-hub): wire keeper list from gate endpoint as fallback

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -6,6 +6,7 @@ import {
   type KeeperCompositeSnapshot,
   type KeeperCompositeInvariants,
 } from '../api/keeper'
+import { fetchGateKeepers } from '../api/gate'
 import { keepers } from '../store'
 import { compositeTick } from '../composite-signals'
 import { EmptyState } from './common/empty-state'
@@ -785,13 +786,35 @@ export function FsmHub() {
   const [now, setNow] = useState(() => Date.now() / 1000)
   const [graphOpen, setGraphOpen] = useState(false)
   const [hoveredSegment, setHoveredSegment] = useState<HoveredSegment | null>(null)
+  const [gateKeeperNames, setGateKeeperNames] = useState<string[]>([])
   const requestIdRef = useRef(0)
 
-  const keeperList = keepers.value
-  const keeperNames = useMemo(
-    () => keeperList.map(k => k.name).sort(),
-    [keeperList],
+  // Primary source: store signal (from dashboard/shell polling).
+  // Fallback: direct gate fetch — the shell endpoint omits keeper
+  // details (only sends configured_keepers count), so without this
+  // fallback the FsmHub sees zero keepers and renders empty state.
+  const storeKeeperList = keepers.value
+  const storeNames = useMemo(
+    () => storeKeeperList.map(k => k.name).sort(),
+    [storeKeeperList],
   )
+  useEffect(() => {
+    if (storeNames.length > 0) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const data = await fetchGateKeepers()
+        if (!cancelled) {
+          setGateKeeperNames(data.keepers.map(k => k.name).sort())
+        }
+      } catch {
+        // gate endpoint may require auth — silent fallback
+      }
+    })()
+    return () => { cancelled = true }
+  }, [storeNames.length, pollTick])
+
+  const keeperNames = storeNames.length > 0 ? storeNames : gateKeeperNames
   const activeSelected = useMemo(() => {
     if (selected && keeperNames.includes(selected)) return selected
     return keeperNames[0] ?? null


### PR DESCRIPTION
## Root Cause

FsmHub 가 keeper 이름을 store signal (`keepers.value`) 에서만 읽었는데, 이 signal 은 `/api/v1/dashboard/shell` 응답의 `data.keepers` 에서 채워진다. 하지만 shell endpoint 는 `keepers` 필드를 포함하지 않고 `configured_keepers: 12` (count 만) 를 보낸다. 결과: `normalizeKeepers(null)` → `[]` → FsmHub 에 keeper 0개 → 빈 화면.

## Fix

`storeNames.length === 0` 일 때 `/api/v1/gate/keepers` (connector-status 가 이미 사용중인 endpoint) 에서 keeper 이름을 직접 fetch. 로컬 state `gateKeeperNames` 에 저장. Store 가 나중에 채워지면 자동으로 primary path 로 전환.

## 영향

이 fix 로 v8~v22 의 모든 레이아웃 개선 (swimlane, time axis, hover coordination, skeleton, density chips 등) 이 처음으로 실제 데이터와 함께 동작한다.

## Test plan

- [x] typecheck clean
- [x] vitest 94 files / 646 tests pass
- [x] `curl -s -H "Origin: http://localhost:3000" "http://localhost:8935/api/v1/gate/keepers?limit=5"` → 5 keepers returned
- [ ] 브라우저에서 대시보드 → FSM Hub 열면 keeper 탭이 표시되고 선택 시 composite snapshot 로딩