### PR TITLE
fix(keeper): repair orphan tool_result before Agent.resume

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -575,7 +575,13 @@ let run_turn
   (* OAS Utf8_sanitize.sanitize handles UTF-8 repair and control char
      stripping at serialization time (backend_openai_serialize.ml,
      backend_anthropic.ml). No pre-sanitize needed here. See OAS #916. *)
-  let history_messages = ctx_work.messages in
+  (* Repair orphaned ToolResult blocks before passing to OAS Agent.run.
+     Stale checkpoints saved before #7237 may contain tool_result blocks
+     whose matching tool_use was trimmed. Anthropic API rejects these.
+     repair_orphan_tool_result_messages downgrades orphans to plain Text. *)
+  let history_messages =
+    Keeper_context_core.repair_orphan_tool_result_messages ctx_work.messages
+  in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   if not is_retry
   then Keeper_exec_context.persist_message ~source:history_user_source session user_msg;


### PR DESCRIPTION
## Summary
- Stale checkpoint의 orphan tool_result가 Anthropic API를 거절시키는 버그 수정
- `history_messages`를 OAS Agent.run에 전달하기 전 `repair_orphan_tool_result_messages` 적용
- 1파일 +7/-1

## Root Cause
- #7237에서 checkpoint trimming 시 ToolUse/ToolResult 쌍 보존 추가
- 하지만 fix 이전에 저장된 stale checkpoint는 이미 쌍이 깨진 상태
- `deserialize_context` 경로는 repair 적용됨, 하지만 **OAS Agent.resume 경로**는 미적용
- `keeper_agent_run.ml:578`에서 `ctx_work.messages`를 직접 전달 → orphan tool_result가 API로 전송

## Fix
```ocaml
(* Before *)
let history_messages = ctx_work.messages in

(* After *)  
let history_messages =
  Keeper_context_core.repair_orphan_tool_result_messages ctx_work.messages
in
```

Orphan ToolResult → Text로 downgrade (semantic content 보존).

## Test plan
- [x] `dune build --root .` 통과
- [ ] CI 통과
- [ ] 서버 재시작 후 sojin keeper의 tool_use_id 에러 소멸 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)