### PR TITLE
ci(release): smoke-boot binary + catch README/CLI subcommand drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,11 @@ jobs:
       - name: Build
         run: opam exec -- dune build --release bin/main_eio.exe
 
+      - name: Release binary smoke (boot + README drift)
+        run: |
+          chmod +x scripts/release-binary-smoke.sh
+          scripts/release-binary-smoke.sh _build/default/bin/main_eio.exe
+
       - name: Package binary
         run: |
           mkdir -p dist

--- a/scripts/release-binary-smoke.sh
+++ b/scripts/release-binary-smoke.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Verify a release-shaped binary actually boots and does not lie about its
+# CLI surface relative to the repo README.
+#
+# Usage:
+#   scripts/release-binary-smoke.sh [PATH_TO_BINARY]
+#
+# Default binary path: _build/default/bin/main_eio.exe
+#
+# Exit codes:
+#   0  smoke + doc drift OK
+#   2  binary printed FATAL during boot
+#   3  binary did not reach `MASC MCP Server listening` within timeout
+#   4  README references a subcommand that --help does not list
+#   5  argument / setup error
+
+set -euo pipefail
+
+BINARY="${1:-_build/default/bin/main_eio.exe}"
+PORT="${SMOKE_PORT:-18935}"
+BOOT_WAIT_SEC="${BOOT_WAIT_SEC:-5}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+[ -x "$BINARY" ] || { echo "smoke: binary not executable: $BINARY" >&2; exit 5; }
+[ -f config/tool_policy.toml ] || { echo "smoke: config/tool_policy.toml missing" >&2; exit 5; }
+
+tmp=$(mktemp -d -t masc-smoke.XXXXXX)
+trap 'rm -rf "$tmp"; [ -n "${PID:-}" ] && kill "$PID" 2>/dev/null || true' EXIT
+
+mkdir -p "$tmp/.masc/config"
+cp config/tool_policy.toml "$tmp/.masc/config/tool_policy.toml"
+
+log="$tmp/boot.log"
+echo "smoke: booting $BINARY on :$PORT under $tmp"
+"$BINARY" --base-path "$tmp" --port "$PORT" >"$log" 2>&1 &
+PID=$!
+
+# Poll for either a FATAL line or the listening line. Bound by BOOT_WAIT_SEC.
+deadline=$(( $(date +%s) + BOOT_WAIT_SEC ))
+state=pending
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if grep -q '\[FATAL\]\|Fatal ' "$log"; then state=fatal; break; fi
+  if grep -q 'MASC MCP Server listening' "$log"; then state=listening; break; fi
+  sleep 0.2
+done
+kill "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+PID=""
+
+case "$state" in
+  fatal)
+    echo "smoke: FATAL during boot:" >&2
+    grep -B2 -A2 -E 'FATAL|Fatal ' "$log" >&2 || true
+    exit 2
+    ;;
+  pending)
+    echo "smoke: did not reach listening within ${BOOT_WAIT_SEC}s" >&2
+    tail -30 "$log" >&2
+    exit 3
+    ;;
+  listening) echo "smoke: boot OK" ;;
+esac
+
+# --- README ↔ CLI subcommand drift -------------------------------------------
+help_txt="$tmp/help.txt"
+TERM=dumb "$BINARY" --help=plain >"$help_txt" 2>/dev/null || true
+
+# cmdliner Cmd.group prints subcommands under the "COMMANDS" section, with
+# 7-space indent (subcommand name) followed by deeper indent (description).
+# A blank line, an outdented bare-name token, or another ALL-CAPS section
+# header ends the block.
+actual_subcmds=$(awk '
+  /^COMMANDS$/ { in_block=1; next }
+  in_block && /^[A-Z][A-Z ]+$/ { in_block=0; next }
+  in_block && /^       [a-z][a-z0-9_-]*/ {
+    name=$1; sub(/[^a-z0-9_-].*/, "", name); print name
+  }
+' "$help_txt" | sort -u)
+
+# Subcommands the README claims exist (matches `main_eio.exe SUBCMD` and
+# `masc-mcp SUBCMD` where SUBCMD is a bare lowercase token, not a flag).
+readme_subcmds=$(grep -hoE '(main_eio\.exe|masc-mcp) +[a-z][a-z0-9_-]*' README.md \
+  | awk '{print $2}' | sort -u)
+
+drift=0
+for sub in $readme_subcmds; do
+  # ignore obvious noise (config sample words that match the regex by accident)
+  case "$sub" in
+    install|build|run|on|off|via|in|to|of|the|a|an) continue ;;
+  esac
+  if ! echo "$actual_subcmds" | grep -qx "$sub"; then
+    echo "drift: README references '$sub' subcommand but binary --help lists no such command" >&2
+    drift=1
+  fi
+done
+
+if [ "$drift" -ne 0 ]; then
+  echo "" >&2
+  echo "Binary subcommands actually present:" >&2
+  echo "$actual_subcmds" | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "Either the README is ahead of this build (release was cut before merge)," >&2
+  echo "or the README claims a subcommand that no longer exists." >&2
+  exit 4
+fi
+
+echo "smoke: doc drift check OK"
+echo "smoke: release binary contract upheld"

--- a/scripts/release-binary-smoke.sh
+++ b/scripts/release-binary-smoke.sh
@@ -16,6 +16,11 @@
 
 set -euo pipefail
 
+readonly EXIT_FATAL=2
+readonly EXIT_TIMEOUT=3
+readonly EXIT_DRIFT=4
+readonly EXIT_SETUP=5
+
 BINARY="${1:-_build/default/bin/main_eio.exe}"
 PORT="${SMOKE_PORT:-18935}"
 BOOT_WAIT_SEC="${BOOT_WAIT_SEC:-5}"
@@ -23,8 +28,8 @@ BOOT_WAIT_SEC="${BOOT_WAIT_SEC:-5}"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-[ -x "$BINARY" ] || { echo "smoke: binary not executable: $BINARY" >&2; exit 5; }
-[ -f config/tool_policy.toml ] || { echo "smoke: config/tool_policy.toml missing" >&2; exit 5; }
+[ -x "$BINARY" ] || { echo "smoke: binary not executable: $BINARY" >&2; exit "$EXIT_SETUP"; }
+[ -f config/tool_policy.toml ] || { echo "smoke: config/tool_policy.toml missing" >&2; exit "$EXIT_SETUP"; }
 
 tmp=$(mktemp -d -t masc-smoke.XXXXXX)
 trap 'rm -rf "$tmp"; [ -n "${PID:-}" ] && kill "$PID" 2>/dev/null || true' EXIT
@@ -53,12 +58,12 @@ case "$state" in
   fatal)
     echo "smoke: FATAL during boot:" >&2
     grep -B2 -A2 -E 'FATAL|Fatal ' "$log" >&2 || true
-    exit 2
+    exit "$EXIT_FATAL"
     ;;
   pending)
     echo "smoke: did not reach listening within ${BOOT_WAIT_SEC}s" >&2
     tail -30 "$log" >&2
-    exit 3
+    exit "$EXIT_TIMEOUT"
     ;;
   listening) echo "smoke: boot OK" ;;
 esac
@@ -79,17 +84,25 @@ actual_subcmds=$(awk '
   }
 ' "$help_txt" | sort -u)
 
-# Subcommands the README claims exist (matches `main_eio.exe SUBCMD` and
-# `masc-mcp SUBCMD` where SUBCMD is a bare lowercase token, not a flag).
-readme_subcmds=$(grep -hoE '(main_eio\.exe|masc-mcp) +[a-z][a-z0-9_-]*' README.md \
+# Subcommands the README claims exist. Restrict to lines/segments inside
+# backticks (inline `code` or ``` fenced blocks ```), so prose like
+# "use masc-mcp in Claude" never trips the gate.
+readme_subcmds=$(awk '
+  /^```/        { in_fence = !in_fence; next }
+  in_fence      { print; next }
+  /`/ {
+    s = $0
+    while (match(s, /`[^`]+`/)) {
+      print substr(s, RSTART + 1, RLENGTH - 2)
+      s = substr(s, RSTART + RLENGTH)
+    }
+  }
+' README.md \
+  | grep -hoE '(main_eio\.exe|masc-mcp) +[a-z][a-z0-9_-]*' \
   | awk '{print $2}' | sort -u)
 
 drift=0
 for sub in $readme_subcmds; do
-  # ignore obvious noise (config sample words that match the regex by accident)
-  case "$sub" in
-    install|build|run|on|off|via|in|to|of|the|a|an) continue ;;
-  esac
   if ! echo "$actual_subcmds" | grep -qx "$sub"; then
     echo "drift: README references '$sub' subcommand but binary --help lists no such command" >&2
     drift=1
@@ -103,7 +116,7 @@ if [ "$drift" -ne 0 ]; then
   echo "" >&2
   echo "Either the README is ahead of this build (release was cut before merge)," >&2
   echo "or the README claims a subcommand that no longer exists." >&2
-  exit 4
+  exit "$EXIT_DRIFT"
 fi
 
 echo "smoke: doc drift check OK"


### PR DESCRIPTION
## Summary

Adds a release-time smoke gate that (a) actually boots the freshly built binary in a temporary base path, and (b) cross-checks every subcommand the README claims against what `--help` actually lists. The gate runs in `release.yml` after `dune build` and before artifact upload, so a regression like v0.8.0 cannot ship.

## Why now

The same first-run smoke that motivated #7324 also surfaced this:

- v0.8.0 binary fatal-exits without `tool_policy.toml` seeded — never tested at release time.
- v0.8.0 README references `main_eio.exe doctor`, but the v0.8.0 binary's `--help` does not list any `doctor` subcommand. PR #7314 added it after the release was cut. The release pipeline had no way to notice.

`scripts/check-version-truth.sh` already polices `dune-project ↔ tag ↔ ROADMAP`. This PR adds the missing axis: `binary ↔ README`.

## Design

`scripts/release-binary-smoke.sh [BINARY]` (default `_build/default/bin/main_eio.exe`).

1. Boot smoke
   - mktemp base path, copy repo's `config/tool_policy.toml` (empirically the only file required for clean boot — see #7324 for the data).
   - Spawn binary on `:18935`, poll for `[FATAL]` / `Fatal ` / `MASC MCP Server listening`.
   - Bound by `BOOT_WAIT_SEC` (default 5s).
   - Exit 2 on FATAL, 3 on timeout.

2. Drift check
   - `--help=plain` → awk extracts cmdliner `COMMANDS` section (7-space indent).
   - `grep -hoE '(main_eio\\.exe|masc-mcp) +[a-z][a-z0-9_-]*' README.md` collects claimed subcommands.
   - Any claimed subcommand absent from `--help` → exit 4 with both sides printed.

Wired into `.github/workflows/release.yml` as a new step between Build and Package, on both macos-14 and ubuntu-latest matrix legs. ~5s per arch.

## Product impact

- Promise affected: `repo coordination` (release reliability)
- User-visible change: none directly. Breakage class blocked at gate.

## Evidence

Tested locally on macOS arm64 against the actual v0.8.0 release binary downloaded from GitHub Releases (`/tmp/masc-installer-e2e-1776238282/prefix/masc-mcp`):

```
$ scripts/release-binary-smoke.sh /tmp/.../masc-mcp
smoke: booting /tmp/.../masc-mcp on :18935 under /var/folders/.../masc-smoke.XXXXXX
smoke: boot OK
drift: README references 'doctor' subcommand but binary --help lists no such command

Binary subcommands actually present:
  
Either the README is ahead of this build (release was cut before merge),
or the README claims a subcommand that no longer exists.
exit=4
```

Exactly the regression we want to catch.

Awk parser independently fixture-tested against a synthetic cmdliner help with two subcommands — both extracted. `bash -n` clean. `python3 -c 'import yaml; yaml.safe_load(open(...))'` clean for the workflow file.

## Review evidence

Local self-review only at draft stage.

## Linked issue

- Relates: #7324 (PR A — installer that motivated this gate)
- Relates: backlog `task-053 v0.x front-door hardening -> 1.0 readiness plan`

## Out of scope

- Snapshot-style golden file for the full --help text (heavier, more churn). The current scope is the actual bug class observed.
- Full `init` subcommand to remove the `cp config/tool_policy.toml` step (PR B — coming next).
- SHA256SUMS / signed releases / Homebrew formula.