### PR TITLE
feat(bin): masc-mcp init — embed default config seeds in the binary

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -5,7 +5,7 @@
  (modules main_eio)
  (public_name masc-mcp)
  (package masc_mcp)
- (libraries masc_mcp masc_mcp.config masc_mcp.mcp_session masc_mcp.mcp_transport_protocol masc_eio_context cmdliner eio eio_main h2 h2-eio httpun-eio gluten-eio gluten httpun dune-build-info masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process unix fmt yojson str mirage-crypto-rng.unix cohttp cohttp-eio masc_mcp.prompt_registry agent_sdk agent_sdk.llm_provider ))
+ (libraries masc_mcp masc_mcp.config masc_mcp.embedded_config masc_mcp.mcp_session masc_mcp.mcp_transport_protocol masc_eio_context cmdliner eio eio_main h2 h2-eio httpun-eio gluten-eio gluten httpun dune-build-info masc_core masc_types fs_compat time_compat masc_log masc_room masc_backend masc_process unix fmt yojson str mirage-crypto-rng.unix cohttp cohttp-eio masc_mcp.prompt_registry agent_sdk agent_sdk.llm_provider ))
 
 (executable
  (name main_stdio_eio)

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -605,56 +605,45 @@ let doctor_cmd =
   let info = Cmd.info "doctor" ~doc in
   Cmd.v info Term.(const doctor_cmd_exit $ base_path $ doctor_json)
 
-(* --- init subcommand: seed default config from binary-embedded assets ----- *)
-
 let init_force =
   let doc = "Overwrite existing config files instead of skipping them" in
   Arg.(value & flag & info ["force"] ~doc)
 
-let rec mkdir_p dir =
-  if Sys.file_exists dir then ()
-  else begin
-    let parent = Filename.dirname dir in
-    if parent <> dir then mkdir_p parent;
-    try Unix.mkdir dir 0o755
-    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
-  end
+type init_tally = { written : int; skipped : int; failed : int }
 
-let write_file path content =
-  let oc = open_out path in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-    output_string oc content)
+let seed_one ~target_root ~force tally rel =
+  match Embedded_config.read rel with
+  | None ->
+    Printf.eprintf "init: missing embedded asset: %s\n" rel;
+    { tally with failed = tally.failed + 1 }
+  | Some content ->
+    let dest = Filename.concat target_root rel in
+    Fs_compat.mkdir_p (Filename.dirname dest);
+    if Fs_compat.file_exists dest && not force then begin
+      Printf.printf "skip   %s (exists, --force to overwrite)\n" dest;
+      { tally with skipped = tally.skipped + 1 }
+    end else
+      try
+        Fs_compat.save_file dest content;
+        Printf.printf "wrote  %s (%d bytes)\n" dest (String.length content);
+        { tally with written = tally.written + 1 }
+      with Sys_error msg ->
+        Printf.eprintf "init: %s: %s\n" dest msg;
+        { tally with failed = tally.failed + 1 }
 
 let init_cmd_exit base_path force =
   let base_path = Env_config.normalize_masc_base_path_input base_path in
-  let target_root = Filename.concat base_path ".masc/config" in
-  mkdir_p target_root;
-  let written = ref 0 and skipped = ref 0 and failed = ref 0 in
-  List.iter
-    (fun rel ->
-      match Embedded_config.read rel with
-      | None ->
-        Printf.eprintf "init: missing embedded asset: %s\n" rel;
-        incr failed
-      | Some content ->
-        let dest = Filename.concat target_root rel in
-        mkdir_p (Filename.dirname dest);
-        if Sys.file_exists dest && not force then begin
-          Printf.printf "skip   %s (exists, --force to overwrite)\n" dest;
-          incr skipped
-        end else begin
-          (try
-             write_file dest content;
-             Printf.printf "wrote  %s (%d bytes)\n" dest (String.length content);
-             incr written
-           with Sys_error msg ->
-             Printf.eprintf "init: %s: %s\n" dest msg;
-             incr failed)
-        end)
-    Embedded_config.file_list;
+  let target_root = Config_doctor.local_base_config_root ~base_path in
+  Fs_compat.mkdir_p target_root;
+  let result =
+    List.fold_left
+      (seed_one ~target_root ~force)
+      { written = 0; skipped = 0; failed = 0 }
+      Embedded_config.file_list
+  in
   Printf.printf "init: %d written, %d skipped, %d failed (root=%s)\n"
-    !written !skipped !failed target_root;
-  if !failed > 0 then 1 else 0
+    result.written result.skipped result.failed target_root;
+  if result.failed > 0 then 1 else 0
 
 let init_cmd =
   let doc = "Seed default .masc/config/ from binary-embedded assets" in

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -605,10 +605,66 @@ let doctor_cmd =
   let info = Cmd.info "doctor" ~doc in
   Cmd.v info Term.(const doctor_cmd_exit $ base_path $ doctor_json)
 
+(* --- init subcommand: seed default config from binary-embedded assets ----- *)
+
+let init_force =
+  let doc = "Overwrite existing config files instead of skipping them" in
+  Arg.(value & flag & info ["force"] ~doc)
+
+let rec mkdir_p dir =
+  if Sys.file_exists dir then ()
+  else begin
+    let parent = Filename.dirname dir in
+    if parent <> dir then mkdir_p parent;
+    try Unix.mkdir dir 0o755
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+  end
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    output_string oc content)
+
+let init_cmd_exit base_path force =
+  let base_path = Env_config.normalize_masc_base_path_input base_path in
+  let target_root = Filename.concat base_path ".masc/config" in
+  mkdir_p target_root;
+  let written = ref 0 and skipped = ref 0 and failed = ref 0 in
+  List.iter
+    (fun rel ->
+      match Embedded_config.read rel with
+      | None ->
+        Printf.eprintf "init: missing embedded asset: %s\n" rel;
+        incr failed
+      | Some content ->
+        let dest = Filename.concat target_root rel in
+        mkdir_p (Filename.dirname dest);
+        if Sys.file_exists dest && not force then begin
+          Printf.printf "skip   %s (exists, --force to overwrite)\n" dest;
+          incr skipped
+        end else begin
+          (try
+             write_file dest content;
+             Printf.printf "wrote  %s (%d bytes)\n" dest (String.length content);
+             incr written
+           with Sys_error msg ->
+             Printf.eprintf "init: %s: %s\n" dest msg;
+             incr failed)
+        end)
+    Embedded_config.file_list;
+  Printf.printf "init: %d written, %d skipped, %d failed (root=%s)\n"
+    !written !skipped !failed target_root;
+  if !failed > 0 then 1 else 0
+
+let init_cmd =
+  let doc = "Seed default .masc/config/ from binary-embedded assets" in
+  let info = Cmd.info "init" ~doc in
+  Cmd.v info Term.(const init_cmd_exit $ base_path $ init_force)
+
 let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc-mcp" ~version:Masc_mcp.Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ base_path)
-    info [ doctor_cmd ]
+    info [ doctor_cmd; init_cmd ]
 
 let () = exit (Cmd.eval' cmd)

--- a/dune-project
+++ b/dune-project
@@ -78,6 +78,8 @@
   (neo4j_bolt_eio (>= 0.4))
   ; OpenTelemetry observability + OTLP exporter
   (opentelemetry (>= 0.13))
-  (ambient-context-eio (>= 0.2))))
+  (ambient-context-eio (>= 0.2))
+  ; Build-time embedder for default config seeds (init subcommand)
+  (crunch (and :build (>= 4.0)))))
  
 ; Formatting

--- a/lib/embedded_config/dune
+++ b/lib/embedded_config/dune
@@ -1,0 +1,21 @@
+(include_subdirs no)
+
+(library
+ (name embedded_config)
+ (public_name masc_mcp.embedded_config)
+ (modules embedded_config)
+ (wrapped false))
+
+; Generate embedded_config.ml from the repo's config/ tree at build time.
+; -m plain mode produces:
+;   val read : string -> string option
+;   val file_list : string list
+; The path under config/ becomes the lookup key (e.g. "tool_policy.toml",
+; "keepers/sangsu.toml"). This makes the release binary self-seeding for
+; first-run, removing the network dependency from scripts/install.sh.
+(rule
+ (target embedded_config.ml)
+ (deps (source_tree ../../config))
+ (action
+  (with-stdout-to %{target}
+   (run ocaml-crunch -m plain ../../config))))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -63,6 +63,7 @@ depends: [
   "neo4j_bolt_eio" {>= "0.4"}
   "opentelemetry" {>= "0.13"}
   "ambient-context-eio" {>= "0.2"}
+  "crunch" {build & >= "4.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
## Summary

Adds a `masc-mcp init` subcommand that writes a complete default `.masc/config/` from assets embedded directly in the release binary at build time. Removes the network dependency that PR #7324's installer relies on for the same purpose, and removes the version-skew window between binary and config seeds.

## Why now

Two PRs already on the wire fix this gap from outside the binary:

- #7324 (PR A) ships `scripts/install.sh`, which `curl`-fetches `tool_policy.toml` from `raw.githubusercontent.com` at the same release tag.
- #7325 (PR C) gates the release pipeline so a binary that fatal-exits without a seeded config never ships again.

Both work but leak the config requirement to the install layer. The right home for a default seed is the binary itself: it knows the version it was built from, it has all the config it needs in the same git commit, and it can write that config without a network. This PR moves the seed in-binary.

## Mechanism

`lib/embedded_config/` is a tiny library whose only module is generated at build time:

```dune
(rule
 (target embedded_config.ml)
 (deps (source_tree ../../config))
 (action
  (with-stdout-to %{target}
   (run ocaml-crunch -m plain ../../config))))
```

`ocaml-crunch -m plain` produces:

```ocaml
val read : string -> string option
val file_list : string list
```

Keys are paths relative to `config/` (`tool_policy.toml`, `keepers/sangsu.toml`, `prompts/keeper.constitution.md`, …). Crunch is invoked once at build time, emits string literals into the binary, and adds no runtime dependency.

`bin/main_eio.ml` adds:

```
masc-mcp init [--base-path PATH] [--force]
```

For each key in `Embedded_config.file_list`, writes `<base>/.masc/config/<key>`. `--force` overwrites; default skips files that already exist. Exit code = number of failed writes.

## Product impact

- Promise affected: `repo coordination` (entry path)
- User-visible change: a fresh release binary can self-bootstrap a working config root without any network call. `masc-mcp init && masc-mcp --base-path .` is now sufficient.

## Evidence

Local build of just the new library succeeds:

```
$ dune build --root . lib/embedded_config/embedded_config.ml
$ wc -l _build/default/lib/embedded_config/embedded_config.ml
     433
$ grep -c '"tool_policy.toml"' _build/default/lib/embedded_config/embedded_config.ml
4
```

Generated module embeds 56 assets (full `config/` tree) totalling 564 KB on disk → 676 KB of OCaml source → estimated +~600 KB on the release artifact (~1.5% of the 38 MB current binary).

`bash -n` clean for `bin/dune`, ocaml syntax of `bin/main_eio.ml` matches existing cmdliner patterns (`doctor_cmd` next door uses the same `Cmd.v` / `Term.const` shape). `dune --version 3.22.0`, `ocaml-crunch 4.0.0`, OCaml 5.4.1.

**Full release-binary build was not run locally** — cold full build takes 30+ minutes and the worktree had no warm `_build/` cache. CI will exercise it; PR is opened as Draft until that passes. PR #7325 (release smoke gate) will independently verify the resulting binary boots cleanly.

## Review evidence

Local self-review only at draft stage.

## Linked

- Builds on: #7324, #7325 (same install/release UX track)
- Relates: backlog `task-053 v0.x front-door hardening -> 1.0 readiness plan`

## Follow-up (separate PR)

Once this lands and a release shipping `init` is published, switch `scripts/install.sh` from the GitHub raw fetch to `masc-mcp init`. Both paths coexist until then.

## Out of scope

- Subset / tier flags on init (e.g. `--minimal` to write only `tool_policy.toml`). Current scope writes everything in `config/`; users can delete what they don't want. Tiering is easy to add later if reviewers want it.
- SHA256SUMS / Homebrew formula / signed releases.