### PR TITLE
refactor(dashboard): fsm-hub self-review cleanup (/simplify)

### DIFF
--- a/dashboard/src/components/fsm-hub-derivations.ts
+++ b/dashboard/src/components/fsm-hub-derivations.ts
@@ -2,6 +2,7 @@ import type { KeeperCompositeSnapshot } from '../api/keeper'
 
 import {
   type CompositeObservation,
+  type LaneKey,
   type StateEntries,
   type SwimlaneSegment,
   type TimeAxisTick,
@@ -83,7 +84,7 @@ export function derivePhaseLog(
 
 export function laneChangedAt(
   observations: CompositeObservation[],
-  key: keyof Omit<CompositeObservation, 'ts'>,
+  key: LaneKey,
 ): number {
   const last = observations[observations.length - 1]
   if (!last) return 0
@@ -98,7 +99,7 @@ export function laneChangedAt(
 
 export function laneTransitionCount(
   observations: CompositeObservation[],
-  key: keyof Omit<CompositeObservation, 'ts'>,
+  key: LaneKey,
 ): number {
   let count = 0
   for (let index = 1; index < observations.length; index += 1) {
@@ -190,7 +191,7 @@ export function deriveTimeAxisTicks(
     at the last observation ts. */
 export function deriveSwimlaneSegments(
   observations: CompositeObservation[],
-  key: keyof Omit<CompositeObservation, 'ts'>,
+  key: LaneKey,
   boundsEnd: number,
 ): SwimlaneSegment[] {
   if (observations.length === 0) return []

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -5,6 +5,7 @@ import type {
 
 import {
   type CompositeObservation,
+  type ObservedLaneSummary,
   type OperationalInsight,
   INVARIANT_LABELS,
   fmtDuration,
@@ -90,6 +91,7 @@ export function deriveOperationalInsight(
   snapshot: KeeperCompositeSnapshot,
   observations: CompositeObservation[],
   now: number,
+  precomputedLanes?: ObservedLaneSummary[],
 ): OperationalInsight {
   const brokenInvariant = brokenInvariantKey(snapshot.invariants)
   if (brokenInvariant) {
@@ -106,7 +108,7 @@ export function deriveOperationalInsight(
     }
   }
 
-  const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
+  const lanes = precomputedLanes ?? deriveObservedLaneSummaries(snapshot, observations, now)
   const stalledLane = lanes.find(lane => lane.stalled)
   if (snapshot.recovery.data_record !== snapshot.recovery.fsm_condition) {
     return {

--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -3,14 +3,16 @@ import type { KeeperCompositeSnapshot } from '../api/keeper'
 import {
   type CompositeObservation,
   type InsightTone,
+  type LaneKey,
   type ObservedLaneSummary,
   LANE_LABELS,
   TRANSITION_FIELDS,
+  extractLaneValue,
 } from './fsm-hub-types'
 import { laneChangedAt, laneTransitionCount } from './fsm-hub-derivations'
 
 export function isObservedStall(
-  key: keyof Omit<CompositeObservation, 'ts'>,
+  key: LaneKey,
   value: string,
   observedForSec: number,
 ): boolean {
@@ -38,19 +40,11 @@ export function isObservedStall(
 }
 
 function laneMeaning(
-  key: keyof Omit<CompositeObservation, 'ts'>,
+  key: LaneKey,
   snapshot: KeeperCompositeSnapshot,
   observedForSec: number,
 ): { tone: InsightTone; meaning: string } {
-  const value = key === 'phase'
-    ? snapshot.phase
-    : key === 'turn'
-      ? snapshot.turn_phase
-      : key === 'decision'
-        ? snapshot.decision.stage
-        : key === 'cascade'
-          ? snapshot.cascade.state
-          : snapshot.compaction.stage
+  const value = extractLaneValue(snapshot, key)
 
   const base: { tone: InsightTone; meaning: string } = (() => {
     switch (key) {
@@ -154,15 +148,7 @@ export function deriveObservedLaneSummaries(
     const observedForSec = changedAt > 0 ? Math.max(0, now - changedAt) : 0
     const transitionCount = laneTransitionCount(observations, key)
     const meaning = laneMeaning(key, snapshot, observedForSec)
-    const value = key === 'phase'
-      ? snapshot.phase
-      : key === 'turn'
-        ? snapshot.turn_phase
-        : key === 'decision'
-          ? snapshot.decision.stage
-          : key === 'cascade'
-            ? snapshot.cascade.state
-            : snapshot.compaction.stage
+    const value = extractLaneValue(snapshot, key)
     const stalled = isObservedStall(key, value, observedForSec)
 
     return {

--- a/dashboard/src/components/fsm-hub-pipeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-pipeline-panels.ts
@@ -41,8 +41,8 @@ export function OperationalMeaningPanel({
   observations: CompositeObservation[]
   now: number
 }) {
-  const insight = deriveOperationalInsight(snapshot, observations, now)
   const lanes = deriveObservedLaneSummaries(snapshot, observations, now)
+  const insight = deriveOperationalInsight(snapshot, observations, now, lanes)
   const panelCls = INSIGHT_PANEL_CLS[insight.tone]
   const isAlarm = insight.tone === 'warn' || insight.tone === 'error'
 
@@ -274,8 +274,8 @@ export function PipelineStep({
     const ageSec = now - sinceTs
     if (!isActive) {
       // idle 상태에서도 장기 대기를 시각적으로 구분
-      if (ageSec > 600) return 'text-[var(--text-muted)]'   // 10분+ → muted (보임)
-      return 'text-[var(--text-dim)]'                        // 기본 dim
+      if (ageSec > 600) return 'text-[var(--text-muted)]'
+      return 'text-[var(--text-dim)]'
     }
     if (ageSec > 60) return 'text-[#f59e0b]'
     if (ageSec > 20) return 'text-[#facc15]'

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef } from 'preact/hooks'
 import {
   type CompositeObservation,
   type HoveredSegment,
+  type LaneKey,
   fmtDuration,
   displayState,
 } from './fsm-hub-types'
@@ -22,7 +23,7 @@ const FIELD_COLOR: Record<string, string> = {
 }
 
 const SWIMLANE_LANES: Array<{
-  key: keyof Omit<CompositeObservation, 'ts'>
+  key: LaneKey
   label: string
   short: string
 }> = [

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -12,6 +12,21 @@ export type CompositeObservation = {
   compaction: string
 }
 
+export type LaneKey = keyof Omit<CompositeObservation, 'ts'>
+
+export function extractLaneValue(
+  snapshot: KeeperCompositeSnapshot,
+  key: LaneKey,
+): string {
+  switch (key) {
+    case 'phase': return snapshot.phase
+    case 'turn': return snapshot.turn_phase
+    case 'decision': return snapshot.decision.stage
+    case 'cascade': return snapshot.cascade.state
+    case 'compaction': return snapshot.compaction.stage
+  }
+}
+
 export type TransitionEntry = {
   ts: number
   from: string
@@ -66,7 +81,7 @@ export const initialHubState: HubState = {
   observations: [],
 }
 
-export const TRANSITION_FIELDS: Array<{ field: string; key: keyof Omit<CompositeObservation, 'ts'> }> = [
+export const TRANSITION_FIELDS: Array<{ field: string; key: LaneKey }> = [
   { field: 'KSM', key: 'phase' },
   { field: 'KTC', key: 'turn' },
   { field: 'KDP', key: 'decision' },
@@ -82,7 +97,7 @@ export const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> =
   recovery_two_store_sync: 'Two-store sync',
 }
 
-export const LANE_LABELS: Record<keyof Omit<CompositeObservation, 'ts'>, string> = {
+export const LANE_LABELS: Record<LaneKey, string> = {
   phase: 'Keeper 생명주기',
   turn: '턴 주기',
   decision: '의사결정',
@@ -152,7 +167,7 @@ export type SwimlaneSegment = {
     PipelineStep) highlight rows that overlap. */
 export type HoveredSegment = {
   field: string  // KSM / KTC / KDP / KCL / KMC
-  laneKey: keyof Omit<CompositeObservation, 'ts'>
+  laneKey: LaneKey
   from: number
   to: number
   value: string

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -430,7 +430,7 @@ function SkeletonLayout() {
         <div class="mt-2"><${SkeletonBar} w="w-40" h="h-8" /></div>
         <div class="mt-2"><${SkeletonBar} w="w-20" h="h-2" /></div>
         <div class="mt-2 flex gap-1">
-          ${[1,2,3,4,5,6,7,8].map(() => html`<${SkeletonBar} w="w-2" h="h-2" />`)}
+          ${[1,2,3,4,5,6,7,8].map(i => html`<${SkeletonBar} key=${i} w="w-2" h="h-2" />`)}
         </div>
       </div>
 
@@ -438,8 +438,8 @@ function SkeletonLayout() {
       <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
         <${SkeletonBar} w="w-24" h="h-2" />
         <div class="mt-2 flex gap-2">
-          ${[1,2,3,4].map(() => html`
-            <div class="flex-1 rounded-lg border border-[var(--white-8)] p-2">
+          ${[1,2,3,4].map(i => html`
+            <div key=${i} class="flex-1 rounded-lg border border-[var(--white-8)] p-2">
               <${SkeletonBar} w="w-10" h="h-2" />
               <div class="mt-1"><${SkeletonBar} w="w-16" h="h-4" /></div>
               <div class="mt-1"><${SkeletonBar} w="w-14" h="h-2" /></div>
@@ -452,8 +452,8 @@ function SkeletonLayout() {
       <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
         <${SkeletonBar} w="w-28" h="h-2" />
         <div class="mt-2 flex flex-col gap-1.5">
-          ${[1,2,3,4,5].map(() => html`
-            <div class="flex items-center gap-2">
+          ${[1,2,3,4,5].map(i => html`
+            <div key=${i} class="flex items-center gap-2">
               <${SkeletonBar} w="w-10" h="h-2" />
               <div class=${`${shimmerCls} flex-1 h-4`}></div>
             </div>
@@ -463,8 +463,8 @@ function SkeletonLayout() {
 
       ${/* Health Grid skeleton */ ''}
       <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-        ${[1,2,3].map(() => html`
-          <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
+        ${[1,2,3].map(i => html`
+          <div key=${i} class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] p-3">
             <${SkeletonBar} w="w-20" h="h-2" />
             <div class="mt-2 flex flex-wrap gap-1.5">
               <${SkeletonBar} w="w-14" h="h-5" />


### PR DESCRIPTION
## Summary
Follow-up to #7317 + #7328 after running /simplify self-review. Three parallel review agents (reuse / quality / efficiency) flagged actionable items — this PR applies the confirmed ones.

### Changes
1. **`LaneKey` type alias + `extractLaneValue` helper** (types.ts)
   - Replaces 9× `keyof Omit<CompositeObservation, 'ts'>` across 5 files
   - Replaces 2× duplicated 5-way ternary in lane-analysis.ts
2. **Fix double-compute of lane summaries in `OperationalMeaningPanel`**
   - Caller computes `lanes` once, passes via new `precomputedLanes?` param
   - Saves one O(n × 5 lanes) scan per 1s `now` tick
3. **Add `key=` props to SkeletonLayout maps** (Preact requirement)
4. **Remove 2 WHAT-comments** (`// 기본 dim`, `// 10분+ → muted`)

### Skipped (reviewed but not applied)
- `fmtDuration` → `formatElapsedCompact` dedup: Math.round vs Math.floor diff causes 0.5s display shift — not behavior-preserving
- Table-drive the 10-case `deriveOperationalInsight`: explicit precedence and unique evidence fields make the if-chain more readable than a rules table
- Remove re-exports in fsm-hub.ts: test file depends on them; re-exports cost nothing at runtime
- SwimlaneTimeline 5×2 scans: n=30 = 300 ops/sec, premature optimization

## Test plan
- [x] \`pnpm typecheck\` — 0 errors
- [x] \`pnpm test\` — 95 files, 655 tests 전부 통과
- [x] No behavior change (순수 정리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)