### PR TITLE
simplify: post-merge cleanup of #7315/#7319/#7321

### DIFF
--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 import type { GateKeepersData } from '../api/gate'
+import { normalizeKeepers } from '../keeper-store-normalize'
 import { deriveStateEntries, deriveSwimlaneSegments } from './fsm-hub'
 
 /** Server-shaped keeper composite snapshot matching the actual
@@ -112,8 +113,8 @@ describe('FSM Hub integration — API response shape', () => {
   })
 
   describe('downstream derivers tolerate real-shape observations', () => {
-    const obsFromSnapshot = (snap: KeeperCompositeSnapshot, tsOverride?: number) => ({
-      ts: tsOverride ?? snap.ts,
+    const obsFromSnapshot = (snap: KeeperCompositeSnapshot, ts: number) => ({
+      ts,
       phase: snap.phase,
       turn: snap.turn_phase,
       decision: snap.decision.stage,
@@ -130,9 +131,14 @@ describe('FSM Hub integration — API response shape', () => {
     })
 
     it('deriveSwimlaneSegments handles the full is_live=true projection', () => {
-      // After #7319, is_live with no guardrail yields decision='guard_ok', cascade='trying'
       const obsIdle = obsFromSnapshot(REAL_COMPOSITE_SHAPE, 100)
-      const obsLive = { ...obsIdle, ts: 110, turn: 'executing', decision: 'guard_ok', cascade: 'trying' }
+      const obsLive = {
+        ...obsIdle,
+        ts: 110,
+        turn: 'executing' satisfies KeeperCompositeSnapshot['turn_phase'],
+        decision: 'guard_ok' satisfies KeeperCompositeSnapshot['decision']['stage'],
+        cascade: 'trying' satisfies KeeperCompositeSnapshot['cascade']['state'],
+      }
       const segments = deriveSwimlaneSegments([obsIdle, obsLive], 'decision', 200)
       expect(segments).toHaveLength(2)
       expect(segments[0]?.value).toBe('undecided')
@@ -140,15 +146,15 @@ describe('FSM Hub integration — API response shape', () => {
     })
   })
 
-  describe('known-broken shapes that must still fail loudly', () => {
-    it('a shell response missing the keepers field is the original bug — document the expected shape', () => {
-      const shellWithNullKeepers = { keepers: null as null, configured_keepers: 12 }
-      // Demonstrate: the store reads data.keepers, not data.configured_keepers.
-      // If shell ever returns keepers: null again, the frontend silently renders empty.
-      // FsmHub fix (#7315) works around this via gate fallback — but the test below
-      // pins the failure mode so future refactors don't accidentally regress.
-      expect(shellWithNullKeepers.keepers).toBeNull()
-      expect(shellWithNullKeepers.configured_keepers).toBe(12)
+  describe('store normalizer against the regression shape', () => {
+    it('normalizeKeepers(null) and normalizeKeepers(undefined) yield an empty array — the failure mode that triggered the v8-v22 blind spot', () => {
+      expect(normalizeKeepers(null)).toEqual([])
+      expect(normalizeKeepers(undefined)).toEqual([])
+    })
+
+    it('normalizeKeepers ignores the count-only "configured_keepers" field the shell actually sends', () => {
+      const shellShape: Record<string, unknown> = { configured_keepers: 12 }
+      expect(normalizeKeepers(shellShape.keepers)).toEqual([])
     })
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -135,20 +135,25 @@ export function FsmHub() {
     [storeKeeperList],
   )
   useEffect(() => {
-    if (storeNames.length > 0) return
+    if (storeNames.length > 0 || gateKeeperNames.length > 0) return
     let cancelled = false
     void (async () => {
       try {
         const data = await fetchGateKeepers()
-        if (!cancelled) {
-          setGateKeeperNames(data.keepers.map(k => k.name).sort())
-        }
+        if (cancelled) return
+        const next = data.keepers.map(k => k.name).sort()
+        setGateKeeperNames(prev =>
+          prev.length === next.length && prev.every((v, i) => v === next[i])
+            ? prev
+            : next,
+        )
       } catch {
-        // gate endpoint may require auth — silent fallback
+        // Gate endpoint auth failure or network error — leave names empty
+        // so the primary store path can populate once shell refresh lands.
       }
     })()
     return () => { cancelled = true }
-  }, [storeNames.length, pollTick])
+  }, [storeNames.length, gateKeeperNames.length, pollTick])
 
   const keeperNames = storeNames.length > 0 ? storeNames : gateKeeperNames
   const activeSelected = useMemo(() => {

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -99,15 +99,15 @@ let compaction_stage_to_string = function
    [mark_turn_finished]. Finer-grained breakdown
    ([Prompting]/[ToolCall]) requires Event_bus subscription and is
    tracked as Phase 2 of #7122. *)
-let derive_turn_phase (entry : Keeper_registry.registry_entry) : turn_phase =
+let derive_turn_phase
+    (entry : Keeper_registry.registry_entry)
+    ~(is_live : bool)
+    : turn_phase =
   match entry.phase with
   | Keeper_state_machine.Compacting -> `Compacting
   | Keeper_state_machine.HandingOff
   | Keeper_state_machine.Draining -> `Finalizing
-  | _ ->
-    (match entry.current_turn_observation with
-     | Some _ -> `Executing
-     | None -> `Idle)
+  | _ -> if is_live then `Executing else `Idle
 
 (* Compaction sub-FSM: compaction_active is the authoritative condition.
    Phase [Compacting] MUST coincide with this condition under the
@@ -156,10 +156,8 @@ let derive_decision_stage
    Finer-grained live cascade state ([`Selecting`] vs [`Trying`] vs
    [`Done`]) remains a Phase 2 follow-up (#7122) requiring Event_bus
    subscription. *)
-let derive_cascade_state (entry : Keeper_registry.registry_entry)
-    : cascade_state =
-  if entry.current_turn_observation <> None then `Trying
-  else `Idle
+let derive_cascade_state ~(is_live : bool) : cascade_state =
+  if is_live then `Trying else `Idle
 
 (* Two-store reconcile pair (RFC-0003 §8, absorbed from P4).
    - [reconcile_data]: a prior turn left an ambiguous side-effect record
@@ -265,10 +263,10 @@ let observe
   in
   let conds = entry.conditions in
   let is_live = entry.current_turn_observation <> None in
-  let turn_phase = derive_turn_phase entry in
+  let turn_phase = derive_turn_phase entry ~is_live in
   let compaction_stage = derive_compaction_stage conds in
   let decision_stage = derive_decision_stage conds ~is_live in
-  let cascade_state = derive_cascade_state entry in
+  let cascade_state = derive_cascade_state ~is_live in
   let (reconcile_data, reconcile_fsm) = derive_reconcile entry in
   let invariants =
     compute_invariants


### PR DESCRIPTION
## Context

/simplify 3-parallel-agent review (reuse / quality / efficiency) on the recently merged FSM Hub root-fix trilogy (#7315, #7319, #7321) surfaced 5 actionable findings.

## Fixes

| # | 출처 | 문제 | Fix |
|---|------|------|-----|
| 1 | #7315 | gate fetch 가 seeded 이후에도 30s 마다 재실행 | early-return 에 `gateKeeperNames.length` 포함 |
| 2 | #7315 | setState 매 poll 새 array 참조 → useMemo churn | stable reference updater |
| 3 | #7319 | `derive_turn_phase` + `derive_cascade_state` 가 is_live 를 재계산 | 두 함수에 `~is_live` 파라미터로 통일 |
| 4 | #7321 | stringly-typed literal ('undecided', 'guard_ok' 등) | `satisfies` 로 타입 유니온 검증 |
| 5 | #7321 | tautology test block + dead fallback | `normalizeKeepers` 실행하는 실제 regression 으로 교체 |

## 스킵한 findings

- Store-level fallback (Agent 1의 큰 refactor 제안) — scope 확장, 별도 PR 권장
- Fixture extraction — over-engineering
- Parameter sprawl 전면 통일 — `~is_live` 로 3개 deriver 통일했으므로 이번 PR 에서 해결됨

## Test

- dashboard vitest 95 files / 656 tests pass (+1 new regression case)
- OCaml dune build clean
- Typecheck / vite build clean