### PR TITLE
feat(dashboard): add Top Transitions ranking panel

### DIFF
--- a/dashboard/src/components/fsm-hub-derivations.ts
+++ b/dashboard/src/components/fsm-hub-derivations.ts
@@ -6,6 +6,7 @@ import {
   type StateEntries,
   type SwimlaneSegment,
   type TimeAxisTick,
+  type TopTransition,
   MAX_OBSERVATIONS,
   MAX_TRANSITION_HISTORY,
   TRANSITION_FIELDS,
@@ -67,6 +68,52 @@ export function deriveTransitionHistory(
     }
   }
   return entries.slice(-Math.max(1, maxEntries)).reverse()
+}
+
+/** Aggregate the most frequent (from → to) transitions per lane across the
+    full observation buffer. Unlike [deriveTransitionHistory], which slices
+    to the last N events for the recency log, this counts every adjacent
+    (prev, next) pair in [observations] so the ranking reflects the full
+    window. Ties broken by lane order (TRANSITION_FIELDS), then alphabetical. */
+export function deriveTopTransitions(
+  observations: CompositeObservation[],
+  limit = 5,
+): TopTransition[] {
+  const counts = new Map<string, TopTransition>()
+  for (let index = 1; index < observations.length; index += 1) {
+    const prev = observations[index - 1]
+    const next = observations[index]
+    if (!prev || !next) continue
+    for (const { field, key } of TRANSITION_FIELDS) {
+      if (prev[key] === next[key]) continue
+      const cacheKey = `${field}|${prev[key]}|${next[key]}`
+      const existing = counts.get(cacheKey)
+      if (existing) {
+        existing.count += 1
+      } else {
+        counts.set(cacheKey, {
+          field,
+          from: prev[key],
+          to: next[key],
+          count: 1,
+        })
+      }
+    }
+  }
+  const fieldOrder = new Map(
+    TRANSITION_FIELDS.map(({ field }, idx) => [field, idx]),
+  )
+  return Array.from(counts.values())
+    .sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count
+      const fa = fieldOrder.get(a.field) ?? 99
+      const fb = fieldOrder.get(b.field) ?? 99
+      if (fa !== fb) return fa - fb
+      const fromCmp = a.from.localeCompare(b.from)
+      if (fromCmp !== 0) return fromCmp
+      return a.to.localeCompare(b.to)
+    })
+    .slice(0, Math.max(0, limit))
 }
 
 export function derivePhaseLog(

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -5,6 +5,7 @@ import {
   type CompositeObservation,
   type HoveredSegment,
   type LaneKey,
+  type TopTransition,
   fmtDuration,
   displayState,
 } from './fsm-hub-types'
@@ -363,6 +364,68 @@ export function TransitionTrail({
               <span class="text-[var(--text-dim)]">${entry.from}</span>
               <span class="text-[var(--text-muted)]">→</span>
               <span class="text-[var(--text-strong)]">${entry.to}</span>
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
+}
+
+/** Top-N transition frequency ranking. Surfaces the (from → to) pairs the
+    keeper takes most often inside the in-memory observation window — useful
+    for spotting churn (e.g. KCL idle ↔ trying repeating means cascade is
+    flapping) and for confirming the keeper exercises every lane it owns. */
+export function TopTransitionsPanel({
+  transitions,
+  hoveredSegment,
+}: {
+  transitions: TopTransition[]
+  hoveredSegment: HoveredSegment | null
+}) {
+  if (transitions.length === 0) {
+    return html`
+      <div class="rounded-lg border border-dashed border-[var(--white-8)] px-4 py-2 text-center text-[10px] text-[var(--text-dim)]">
+        반복되는 전이가 없습니다 — 관측이 더 쌓이거나 lane 변화가 발생하면 표시됩니다
+      </div>
+    `
+  }
+
+  const maxCount = transitions[0]?.count ?? 1
+
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
+      <div class="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        Top Transitions (${transitions.length})
+      </div>
+      <div class="flex flex-col gap-0.5">
+        ${transitions.map((entry) => {
+          const color = FIELD_COLOR[entry.field] ?? 'text-[var(--text-body)]'
+          const matchesHover =
+            hoveredSegment != null && hoveredSegment.field === entry.field
+          const dimmed = hoveredSegment != null && !matchesHover
+          const widthPct = Math.max(4, Math.round((entry.count / maxCount) * 100))
+          const rowCls = matchesHover
+            ? 'bg-[rgba(71,184,255,0.1)] ring-1 ring-[rgba(71,184,255,0.3)] rounded px-1'
+            : ''
+          return html`
+            <div
+              class=${`flex items-center gap-2 text-[10px] font-mono leading-tight transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''} ${rowCls}`}
+              title=${`${entry.field}: ${entry.from} → ${entry.to} (관측 ${entry.count}회)`}
+            >
+              <span class=${`w-[28px] shrink-0 font-semibold ${color}`}>${entry.field}</span>
+              <span class="text-[var(--text-dim)]">${displayState(entry.from)}</span>
+              <span class="text-[var(--text-muted)]">→</span>
+              <span class="text-[var(--text-strong)]">${displayState(entry.to)}</span>
+              <span class="ml-auto flex items-center gap-1.5 shrink-0">
+                <span class="h-1 w-12 rounded-full bg-[var(--white-8)] overflow-hidden">
+                  <span
+                    class="block h-full bg-[var(--accent)]"
+                    style=${`width: ${widthPct}%`}
+                  ></span>
+                </span>
+                <span class="w-[18px] text-right text-[var(--text-dim)]">${entry.count}</span>
+              </span>
             </div>
           `
         })}

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -34,6 +34,13 @@ export type TransitionEntry = {
   field: string
 }
 
+export type TopTransition = {
+  field: string
+  from: string
+  to: string
+  count: number
+}
+
 export type InsightTone = 'ok' | 'info' | 'warn' | 'error'
 
 export type OperationalInsight = {

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -9,6 +9,7 @@ import {
   deriveStateEntries,
   deriveSwimlaneSegments,
   deriveTimeAxisTicks,
+  deriveTopTransitions,
   deriveTransitionHistory,
   flagTooltip,
   invariantDescription,
@@ -109,6 +110,45 @@ describe('fsm-hub derived state', () => {
       { ts: 2, from: 'idle', to: 'running', field: 'KTC' },
       { ts: 2, from: 'Running', to: 'Compacting', field: 'KSM' },
     ])
+  })
+
+  it('counts the most frequent (from → to) transitions per lane', () => {
+    const observations = [
+      observation({ ts: 1, turn: 'idle' }),
+      observation({ ts: 2, turn: 'prompting' }),
+      observation({ ts: 3, turn: 'idle' }),
+      observation({ ts: 4, turn: 'prompting' }),
+      observation({ ts: 5, turn: 'executing' }),
+      observation({ ts: 6, phase: 'Compacting', turn: 'compacting' }),
+    ]
+
+    const top = deriveTopTransitions(observations, 5)
+
+    expect(top[0]).toEqual({
+      field: 'KTC',
+      from: 'idle',
+      to: 'prompting',
+      count: 2,
+    })
+    expect(top.find((t) => t.from === 'Running' && t.to === 'Compacting'))
+      .toEqual({ field: 'KSM', from: 'Running', to: 'Compacting', count: 1 })
+    expect(top.length).toBeLessThanOrEqual(5)
+  })
+
+  it('returns an empty list when no transitions occurred', () => {
+    expect(deriveTopTransitions([observation()])).toEqual([])
+    expect(deriveTopTransitions([])).toEqual([])
+  })
+
+  it('respects the limit parameter and breaks ties by lane order then alpha', () => {
+    const observations = [
+      observation({ ts: 1, phase: 'Running', turn: 'idle', decision: 'undecided' }),
+      observation({ ts: 2, phase: 'Compacting', turn: 'prompting', decision: 'guard_ok' }),
+    ]
+
+    const limited = deriveTopTransitions(observations, 2)
+    expect(limited).toHaveLength(2)
+    expect(limited.map((t) => t.field)).toEqual(['KSM', 'KTC'])
   })
 
   it('keeps only distinct consecutive phases in the phase log', () => {

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -20,12 +20,13 @@ import {
 import {
   observeSnapshot,
   appendCompositeObservation,
+  deriveTopTransitions,
   deriveTransitionHistory,
   derivePhaseLog,
   deriveStateEntries,
 } from './fsm-hub-derivations'
 import { OperationalMeaningPanel, HeroPhase, TurnPipelineStrip, CompositeGraphPanel } from './fsm-hub-pipeline-panels'
-import { SwimlaneTimeline, TransitionTrail } from './fsm-hub-timeline-panels'
+import { SwimlaneTimeline, TopTransitionsPanel, TransitionTrail } from './fsm-hub-timeline-panels'
 import { MeasurementCard, InvariantsPanel, RecoveryStatePanel } from './fsm-hub-health-panels'
 
 // ── Backward-compatible re-exports ─────────────────────
@@ -40,6 +41,7 @@ export type {
   StateEntries,
   TimeAxisTick,
   SwimlaneSegment,
+  TopTransition,
 } from './fsm-hub-types'
 
 export { displayState } from './fsm-hub-types'
@@ -47,6 +49,7 @@ export { displayState } from './fsm-hub-types'
 export {
   appendCompositeObservation,
   deriveTransitionHistory,
+  deriveTopTransitions,
   derivePhaseLog,
   deriveStateEntries,
   deriveTimeAxisTicks,
@@ -215,6 +218,10 @@ export function FsmHub() {
     () => deriveTransitionHistory(view.observations),
     [view.observations],
   )
+  const topTransitions = useMemo(
+    () => deriveTopTransitions(view.observations),
+    [view.observations],
+  )
   const phaseLog = useMemo(
     () => derivePhaseLog(view.observations),
     [view.observations],
@@ -258,9 +265,12 @@ export function FsmHub() {
         ${/* ── Zone 2: Hero — KSM Phase ── */ ''}
         <${HeroPhase} snapshot=${snapshot} phaseLog=${phaseLog} phaseSince=${stateEntries?.phase ?? null} now=${now} />
 
-        ${/* ── Zone 2b: Transition History Trail (collapsible) ── */ ''}
+        ${/* ── Zone 2b: Transition History Trail + Top Transitions (collapsible) ── */ ''}
         <${CollapsibleZone} id="transition-trail" title="전환 이력" defaultOpen=${true}>
-          <${TransitionTrail} history=${history} now=${now} hoveredSegment=${hoveredSegment} />
+          <div class="flex flex-col gap-2">
+            <${TransitionTrail} history=${history} now=${now} hoveredSegment=${hoveredSegment} />
+            <${TopTransitionsPanel} transitions=${topTransitions} hoveredSegment=${hoveredSegment} />
+          </div>
         <//>
 
         ${/* ── Zone 3: Turn Pipeline Strip ── */ ''}


### PR DESCRIPTION
## Summary

- Aggregate the most frequent (from → to) transitions per sub-FSM lane across the in-memory observation buffer
- Render under the existing "전환 이력" zone, beside `TransitionTrail`
- Inspired by Arize AX's "most frequently used paths" pattern

## Why

`TransitionTrail` shows the last N events but buries churn — a keeper bouncing between cascade `idle` ↔ `trying` shows up as 20 alternating rows with no signal. Counting each (lane, from, to) pair once and ranking by count exposes flapping immediately, and confirms whether the keeper exercises every lane it owns.

## Changes

- `fsm-hub-types.ts` — `TopTransition` type
- `fsm-hub-derivations.ts` — `deriveTopTransitions(observations, limit=5)` (full-window count, tie-broken by lane order then alpha)
- `fsm-hub-timeline-panels.ts` — `TopTransitionsPanel` with `FIELD_COLOR` + horizontal bar chart scaled to the top entry; participates in hover dimming the same way `TransitionTrail` does
- `fsm-hub.ts` — wires the panel under the existing collapsible "전환 이력" zone
- `fsm-hub.test.ts` — 3 unit tests cover counting, empty input, limit + tie ordering

## Verification

- `pnpm test` → 659/659 tests pass (3 new)
- `pnpm typecheck` → clean
- `pnpm lint` → clean

## Test plan

- [ ] Open dashboard, select an active keeper
- [ ] Confirm "Top Transitions (N)" appears below "Transition History (N)"
- [ ] Hover a swimlane segment for a lane → corresponding rows highlight, others dim
- [ ] If a keeper churns (e.g. cascade idle ↔ trying), confirm it ranks at the top with count > 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)