### PR TITLE
[codex] Expose keeper turn runtime knobs via keeper_runtime.toml

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -87,7 +87,8 @@ active-root file at `<active config root>/keeper_runtime.toml`.
 
 ### 1.3 keeper_runtime.toml — per-base-path startup keeper env seeding
 
-All `MASC_KEEPER_*` environment variables can be set declaratively in
+All live startup-scoped `MASC_KEEPER_*` keeper runtime variables wired through
+`Env_config_keeper` / `Keeper_config` can be set declaratively in
 `<active config root>/keeper_runtime.toml`. The TOML file is loaded at server
 startup by `Keeper_runtime_config.load_and_apply` (called from
 `server_runtime_bootstrap.ml`) before any module that reads these env
@@ -107,7 +108,10 @@ Operational contract:
 Missing file is not an error (returns 0 overrides, uses env/defaults).
 Parse errors log a warning and fall back to env defaults.
 
-**Sections** (53 knobs total):
+Legacy compatibility names that are no longer read by the unified turn path
+are intentionally excluded from this TOML surface.
+
+**Sections** (64 knobs total):
 
 | Section | Count | Key examples |
 | --- | --- | --- |
@@ -115,7 +119,7 @@ Parse errors log a warning and fall back to env defaults.
 | `[autonomous]` | 6 | `max_turns_per_call`, `semaphore_wait_timeout_sec`, `concurrency` |
 | `[reactive]` | 2 | `max_turns_per_call`, `max_idle_turns` |
 | `[heartbeat]` | 7 | `interval_sec`, `max_silence_sec`, `smart_heartbeat` |
-| `[turn]` | 5 | `timeout_sec`, `oas_timeout_sec`, `admission_wait_timeout_sec` |
+| `[turn]` | 16 | `timeout_sec`, `tool_cost_max_usd`, `max_tools_per_turn`, `temperature` |
 | `[supervisor]` | 4 | `max_restarts`, `backoff_base_sec`, `backoff_max_sec` |
 | `[lifecycle]` | 4 | `self_preservation_ratio`, `dead_ttl_sec` |
 | `[budget]` | 1 | `daily_usd` |
@@ -135,6 +139,11 @@ max_turns_per_call = 15
 
 [bootstrap]
 max_active_keepers = 12
+
+[turn]
+tool_cost_max_usd = 1.25
+max_tools_per_turn = 64
+llm_rerank = true
 ```
 
 **Implementation**: `lib/keeper/keeper_runtime_config.ml` maintains a

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -391,7 +391,7 @@ Destructive check 대상 도구: `keeper_bash`, `keeper_fs_edit`, `keeper_edit`,
 
 **Proactive**: `PROACTIVE_TEMP_LOW/MID/HIGH`(0.55/0.75/0.9), `PROACTIVE_SIMILARITY`(0.72), `PROACTIVE_MAX_TOKENS`(1024)
 
-**Cost Gates**: `COST_GATE_USD`(0.10), `TOOL_COST_MAX_USD`(0.50)
+**Cost Gates**: `TOOL_COST_MAX_USD`(0.50, live unified-turn accumulated cost ceiling), `COST_GATE_USD`(0.10, legacy compatibility knob; not used by the unified turn cost guard)
 
 **Unified Turn**: `UNIFIED_TEMP`(0.4), `UNIFIED_MAX_TOKENS`(2048), `UNIFIED_MAX_TURNS`(1000)
 

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -187,9 +187,10 @@ let keeper_execution_entries =
       "Max messages before compaction";
     entry ~default:"4000" "MASC_KEEPER_COMPACT_MAX_TOKENS"
       "Max tokens before compaction (0=disabled)";
-    entry ~default:"0.10" "MASC_KEEPER_COST_GATE_USD" "Per-turn cost gate (USD)";
+    entry ~default:"0.10" "MASC_KEEPER_COST_GATE_USD"
+      "Legacy keeper cost gate (unused by unified turn cost guard)";
     entry ~default:"0.50" "MASC_KEEPER_TOOL_COST_MAX_USD"
-      "Max tool call cost (USD)";
+      "Unified turn accumulated cost ceiling (USD)";
     entry ~default:"0.4" "MASC_KEEPER_UNIFIED_TEMP" "Unified turn temperature";
     entry ~default:"131072" "MASC_KEEPER_UNIFIED_MAX_TOKENS"
       "Unified turn max output tokens";

--- a/lib/keeper/keeper_runtime_config.ml
+++ b/lib/keeper/keeper_runtime_config.ml
@@ -37,6 +37,17 @@ let key_to_env =
     "turn.admission_wait_timeout_sec",  "MASC_KEEPER_ADMISSION_WAIT_TIMEOUT_SEC";
     "turn.max_consecutive_hb_failures", "MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES";
     "turn.max_consecutive_turn_failures", "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES";
+    "turn.batch_limit",                 "MASC_KEEPER_BATCH_LIMIT";
+    "turn.tool_cost_max_usd",           "MASC_KEEPER_TOOL_COST_MAX_USD";
+    "turn.max_tools_per_turn",          "MASC_KEEPER_MAX_TOOLS_PER_TURN";
+    "turn.board_event_limit",           "MASC_KEEPER_BOARD_EVENT_LIMIT";
+    "turn.llm_rerank",                  "MASC_KEEPER_LLM_RERANK";
+    "turn.llm_rerank_cascade",          "MASC_KEEPER_LLM_RERANK_CASCADE";
+    "turn.temperature",                 "MASC_KEEPER_UNIFIED_TEMP";
+    "turn.max_output_tokens",           "MASC_KEEPER_UNIFIED_MAX_TOKENS";
+    "turn.llama_slots",                 "MASC_KEEPER_LLAMA_SLOTS";
+    "turn.enable_thinking",             "MASC_KEEPER_ENABLE_THINKING";
+    "turn.adaptive_thinking",           "MASC_KEEPER_ADAPTIVE_THINKING";
     (* [supervisor] *)
     "supervisor.max_restarts",          "MASC_KEEPER_SUPERVISOR_MAX_RESTARTS";
     "supervisor.backoff_base_sec",      "MASC_KEEPER_SUPERVISOR_BACKOFF_BASE_S";

--- a/lib/keeper/keeper_runtime_config.mli
+++ b/lib/keeper/keeper_runtime_config.mli
@@ -53,6 +53,11 @@ val resolve_overrides :
 
       [reactive]
       max_turns_per_call          = 15
+
+      [turn]
+      tool_cost_max_usd           = 1.25
+      max_tools_per_turn          = 64
+      llm_rerank                  = true
     ]}
 
     Unknown keys are ignored (forward compatibility). *)

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -94,6 +94,39 @@ let test_applies_multiple_overrides () =
     (Some "20")
     (List.assoc_opt "MASC_KEEPER_OAS_MAX_TURNS_PER_CALL" overrides)
 
+let test_applies_turn_execution_overrides () =
+  let doc = parse_or_fail
+    "[turn]\n\
+     tool_cost_max_usd = 1.25\n\
+     max_tools_per_turn = 64\n\
+     llm_rerank = true\n\
+     llm_rerank_cascade = \"tool_rerank_fast\"\n\
+     temperature = 0.65\n\
+     max_output_tokens = 8192\n"
+  in
+  let count, overrides =
+    Keeper_runtime_config.resolve_overrides ~env_lookup:empty_env doc
+  in
+  check int "applied 6" 6 count;
+  check (option string) "tool cost ceiling"
+    (Some "1.25")
+    (List.assoc_opt "MASC_KEEPER_TOOL_COST_MAX_USD" overrides);
+  check (option string) "max tools per turn"
+    (Some "64")
+    (List.assoc_opt "MASC_KEEPER_MAX_TOOLS_PER_TURN" overrides);
+  check (option string) "llm rerank"
+    (Some "true")
+    (List.assoc_opt "MASC_KEEPER_LLM_RERANK" overrides);
+  check (option string) "llm rerank cascade"
+    (Some "tool_rerank_fast")
+    (List.assoc_opt "MASC_KEEPER_LLM_RERANK_CASCADE" overrides);
+  check (option string) "temperature"
+    (Some "0.65")
+    (List.assoc_opt "MASC_KEEPER_UNIFIED_TEMP" overrides);
+  check (option string) "max output tokens"
+    (Some "8192")
+    (List.assoc_opt "MASC_KEEPER_UNIFIED_MAX_TOKENS" overrides)
+
 let test_caller_env_wins_over_toml () =
   let doc = parse_or_fail "[autonomous]\nmax_turns_per_call = 7\n" in
   let fake_env =
@@ -144,6 +177,18 @@ let test_load_and_apply_records_boot_override () =
         0.42
         (Env_config_keeper.KeeperRuntime.deliberation_daily_budget_usd ())
 
+let test_load_and_apply_records_turn_cost_override () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\ntool_cost_max_usd = 1.25\n";
+  match Keeper_runtime_config.load_and_apply ~base_path with
+  | Error msg -> failf "unexpected error: %s" msg
+  | Ok n ->
+    check int "applied count" 1 n;
+    check (option string) "boot override stored"
+      (Some "1.25")
+      (Config_boot_overrides.get_opt "MASC_KEEPER_TOOL_COST_MAX_USD")
+
 let test_float_value_round_trip () =
   let doc = parse_or_fail
     "[autonomous]\nsemaphore_wait_timeout_sec = 120.5\n"
@@ -161,10 +206,12 @@ let () =
       , [ test_case "missing file returns 0 overrides" `Quick test_missing_file_returns_zero
         ; test_case "applies autonomous max_turns_per_call" `Quick test_applies_autonomous_max_turns
         ; test_case "applies multiple overrides" `Quick test_applies_multiple_overrides
+        ; test_case "applies turn execution overrides" `Quick test_applies_turn_execution_overrides
         ; test_case "caller env wins over TOML" `Quick test_caller_env_wins_over_toml
         ; test_case "unknown keys ignored" `Quick test_unknown_keys_ignored
         ; test_case "parse error returns Error" `Quick test_parse_error_returns_error
         ; test_case "load_and_apply records boot override" `Quick test_load_and_apply_records_boot_override
+        ; test_case "load_and_apply records turn cost override" `Quick test_load_and_apply_records_turn_cost_override
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ] )
     ]


### PR DESCRIPTION
## What changed
- wire live `keeper.turn.*` runtime knobs into `keeper_runtime.toml` boot override loading
- add runtime TOML tests covering turn cost and execution overrides
- clarify docs/config snapshot text so the live unified-turn blocker is `MASC_KEEPER_TOOL_COST_MAX_USD`, while `MASC_KEEPER_COST_GATE_USD` is legacy compatibility text

## Why
The live keeper cost blocker was effectively stuck at the code default because `keeper_runtime.toml` did not map the unified turn cost/runtime knobs into the boot override store. Operationally that made the `$0.50` ceiling behave like a hardcoded value.

## Impact
- operators can now set the live unified-turn accumulated cost ceiling from `<base_path>/.masc/config/keeper_runtime.toml`
- adjacent keeper turn runtime knobs in the same surface are configurable through the same TOML path
- docs and env snapshot text now reflect the actual live behavior, which should reduce confusion during keeper incidents

## Root cause
`Keeper_runtime_config.key_to_env` did not include the live `keeper.turn.*` knobs used by `Keeper_config`/`keeper_unified_turn`, so startup TOML never reached the runtime path that enforced the cost guard.

## Validation
- `./_build/default/test/test_keeper_runtime_toml.exe`
- `dune build @runtest --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-cost-runtime-surface`
