### PR TITLE
feat(keeper): playground-only 격리 — workspace 하드코딩 기본값 제거

### DIFF
--- a/lib/keeper/keeper_alerting_path.ml
+++ b/lib/keeper/keeper_alerting_path.ml
@@ -202,33 +202,6 @@ let resolve_keeper_target_path ~(config : Room.config)
              "path_not_in_allowed_paths: %s (allowed: [%s])"
              raw (String.concat ", " allowed_norms))
 
-(** Workspace-scoped state dirs that remain writable outside the playground.
-    These are keeper-private metadata / trace surfaces under [.masc]. *)
-let workspace_state_defaults (safe_name : string) : string list =
-  [ Printf.sprintf ".masc/keepers/%s/" safe_name;
-    ".masc/traces/" ]
-
-(** Additional workspace-scoped read-only repo roots. Keepers may read these
-    when operating in workspace scope, but write containment should stay inside
-    the playground unless the operator explicitly adds extra allowlist entries. *)
-let workspace_repo_read_defaults : string list =
-  [ "lib/";
-    "test/";
-    "config/";
-    "bin/";
-    "scripts/";
-    "docs/" ]
-
-(** Compute effective read allowed_paths from keeper meta.
-    Always prepends the keeper's playground path and, for workspace scope,
-    the workspace read defaults:
-    - `.masc/keepers/<name>/`
-    - `.masc/traces/`
-    - `lib/`, `test/`, `config/`, `bin/`, `scripts/`, `docs/`
-    (project root `.` is no longer included by default; set
-     [`allowed_paths`] explicitly if needed.)
-    - [`*`] → [] (full access, explicit opt-in bypasses path checks)
-    - other  → playground :: workspace_defaults @ explicit *)
 (* Playground path SSOT lives in [Playground_paths] (masc_config). These
    names preserve the historical keeper-facing API. Do not re-implement
    the literal ".masc/playground" layout here — edit [Playground_paths]
@@ -245,50 +218,29 @@ let ensure_playground_bundle ~(config : Room.config) ~(name : string) : string l
   |> List.map (Filename.concat root)
   |> List.map Keeper_fs.ensure_dir
 
+(** Compute effective read allowed_paths from keeper meta.
+    Returns the playground bundle paths plus any explicit [allowed_paths]
+    entries. [["*"]] means full-access opt-in: the resulting empty list is
+    interpreted by the OAS worker builder as "skip path restriction".
+    Workspace/local scope no longer grants extra hardcoded paths; every
+    additional path must be listed explicitly in [allowed_paths]. *)
 let effective_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   let playground_paths = playground_bundle_paths meta.name in
-  let workspace_defaults =
-    match String.lowercase_ascii meta.execution_scope with
-    | "workspace" ->
-      let safe_name = sanitize_keeper_name meta.name in
-      (* NOTE (#6527 iter 4): `.worktrees/` was previously included
-         here so keepers could read and write worktrees created at the
-         server repository root by the old `worktree_create_r`
-         fallback. That fallback was removed in PR #6542 (iter 2), so
-         new worktrees always land at
-         `.masc/playground/<keeper>/repos/<clone>/.worktrees/<name>/`,
-         which is already inside `playground_paths`. Keeping
-         `.worktrees/` as a workspace default would allow any keeper
-         with workspace scope to read and write into another keeper's
-         server-root worktree or into the MASC repo's own worktrees —
-         exactly the containment leak #6527 is closing. Remove it.
-         Keepers that genuinely need access to a specific worktree can
-         still add it via explicit `allowed_paths` on their keeper
-         meta. *)
-      workspace_state_defaults safe_name @ workspace_repo_read_defaults
-    | _ -> []
-  in
   match meta.allowed_paths with
   | ["*"] -> []
-  | explicit -> playground_paths @ workspace_defaults @ explicit
+  | explicit -> playground_paths @ explicit
 
 (** Compute effective write allowed_paths from keeper meta.
-    This keeps the default write sandbox inside the keeper playground plus
-    keeper-private [.masc] state directories. Workspace repo roots remain
-    read-only by default; operators must opt in explicitly via [allowed_paths]
-    or [`*`] to allow writes there. *)
+    Returns the playground bundle paths plus any explicit [allowed_paths]
+    entries. [["*"]] means full-access opt-in (empty allowlist signals
+    "skip path restriction" to the OAS worker builder). Workspace/local
+    scope no longer grants extra hardcoded paths; every additional path
+    must be listed explicitly in [allowed_paths]. *)
 let effective_write_allowed_paths ~(meta : Keeper_types.keeper_meta) : string list =
   let playground_paths = playground_bundle_paths meta.name in
-  let workspace_defaults =
-    match String.lowercase_ascii meta.execution_scope with
-    | "workspace" ->
-      let safe_name = sanitize_keeper_name meta.name in
-      workspace_state_defaults safe_name
-    | _ -> []
-  in
   match meta.allowed_paths with
   | ["*"] -> []
-  | explicit -> playground_paths @ workspace_defaults @ explicit
+  | explicit -> playground_paths @ explicit
 
 (** Resolve a path for read-only access within the keeper's effective
     allowlist. The allowlist is usually the keeper playground bundle

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -236,12 +236,12 @@ let keeper_schemas : tool_schema list = [
         ("execution_scope", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "observe_only"; `String "workspace"; `String "local"]);
-          ("description", `String "Execution scope: observe_only (read-only), workspace (write to allowed paths), local (full access). Default: workspace.");
+          ("description", `String "Execution scope. 'observe_only' blocks all writes. 'workspace'/'local' enable writes within playground (.masc/playground/<name>/). Extra paths must be listed explicitly in allowed_paths. Default: workspace.");
         ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Restrict file writes to these path prefixes. Empty list uses computed defaults based on execution_scope. Use [\"*\"] for explicit full access.");
+          ("description", `String "Restrict file writes to these path prefixes. Empty list means playground-only (.masc/playground/<name>/). Use [\"*\"] for explicit full access.");
         ]);
         ("tool_access",
           tool_access_schema

--- a/test/test_keeper_allowed_paths.ml
+++ b/test/test_keeper_allowed_paths.ml
@@ -1,5 +1,7 @@
 (** Test suite for Keeper_alerting_path.effective_allowed_paths.
-    Verifies computed defaults, wildcard handling, and scope-based behavior. *)
+    Verifies playground-only defaults, wildcard handling, and explicit
+    allowed_paths behavior. Workspace/local scope no longer grants any
+    hardcoded repo-root or state paths. *)
 
 open Alcotest
 module KAP = Masc_mcp.Keeper_alerting_path
@@ -45,15 +47,6 @@ let with_temp_dir prefix f =
     in
     rm path
   ) (fun () -> f path)
-let workspace_defaults name =
-  [ Printf.sprintf ".masc/keepers/%s/" name;
-    ".masc/traces/";
-    "lib/"; "test/"; "config/"; "bin/"; "scripts/"; "docs/" ]
-
-let workspace_write_defaults name =
-  [ Printf.sprintf ".masc/keepers/%s/" name;
-    ".masc/traces/" ]
-
 (* ── observe_only scope ── *)
 
 let test_observe_only_empty_paths () =
@@ -71,34 +64,33 @@ let test_observe_only_explicit_paths () =
 
 (* ── workspace scope ── *)
 
-let test_workspace_empty_paths_computed_default () =
+let test_workspace_empty_paths_playground_only () =
   let meta = make_meta ~execution_scope:"workspace"
       ~name:"sangsu" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "workspace + [] = playground bundle + computed default"
-    (playground_bundle "sangsu" @ workspace_defaults "sangsu") effective
+  check (list string) "workspace + [] = playground bundle only"
+    (playground_bundle "sangsu") effective
 
 let test_workspace_explicit_paths () =
   let meta = make_meta ~execution_scope:"workspace"
       ~allowed_paths:["src/"; "docs/"] ~name:"t" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "workspace + explicit = playground bundle + ws defaults + explicit"
-    (playground_bundle "t" @ workspace_defaults "t" @ ["src/"; "docs/"]) effective
+  check (list string) "workspace + explicit = playground bundle + explicit"
+    (playground_bundle "t" @ ["src/"; "docs/"]) effective
 
-let test_workspace_write_paths_keep_playground_and_state_only () =
+let test_workspace_write_paths_playground_only () =
   let meta = make_meta ~execution_scope:"workspace"
       ~name:"sangsu" () in
   let effective = KAP.effective_write_allowed_paths ~meta in
-  check (list string) "workspace write defaults exclude repo roots"
-    (playground_bundle "sangsu" @ workspace_write_defaults "sangsu") effective
+  check (list string) "workspace write defaults are playground-only"
+    (playground_bundle "sangsu") effective
 
 let test_workspace_write_paths_preserve_explicit_overrides () =
   let meta = make_meta ~execution_scope:"workspace"
       ~allowed_paths:["workspace/yousleepwhen/oas/"] ~name:"t" () in
   let effective = KAP.effective_write_allowed_paths ~meta in
   check (list string) "explicit write override preserved"
-    (playground_bundle "t" @ workspace_write_defaults "t"
-     @ ["workspace/yousleepwhen/oas/"]) effective
+    (playground_bundle "t" @ ["workspace/yousleepwhen/oas/"]) effective
 
 let test_workspace_star_wildcard () =
   let meta = make_meta ~execution_scope:"workspace"
@@ -126,30 +118,22 @@ let test_star_wildcard_any_scope () =
 
 let test_explicit_paths_any_scope () =
   let paths = ["lib/keeper/"; "test/"] in
-  let non_ws_expected = playground_bundle "t" @ ["lib/keeper/"; "test/"] in
-  (* non-workspace scopes: playground bundle + explicit only *)
+  let expected = playground_bundle "t" @ ["lib/keeper/"; "test/"] in
   List.iter (fun scope ->
     let meta = make_meta ~execution_scope:scope ~allowed_paths:paths ~name:"t" () in
     let effective = KAP.effective_allowed_paths ~meta in
     check (list string) (scope ^ " + explicit = playground bundle + explicit")
-      non_ws_expected effective
-  ) ["observe_only"; "local"];
-  (* workspace scope: playground bundle + workspace defaults + explicit *)
-  let ws_meta = make_meta ~execution_scope:"workspace"
-      ~allowed_paths:paths ~name:"t" () in
-  let ws_effective = KAP.effective_allowed_paths ~meta:ws_meta in
-  check (list string) "workspace + explicit = playground bundle + ws defaults + explicit"
-    (playground_bundle "t" @ workspace_defaults "t" @ ["lib/keeper/"; "test/"]) ws_effective
+      expected effective
+  ) ["observe_only"; "workspace"; "local"]
 
-(* ── keeper name in computed default ── *)
+(* ── keeper name in playground default ── *)
 
-let test_computed_default_uses_keeper_name () =
+let test_playground_default_uses_keeper_name () =
   let meta = make_meta ~execution_scope:"workspace"
       ~name:"cdal-formalist" () in
   let effective = KAP.effective_allowed_paths ~meta in
-  check (list string) "name embedded in path"
-    (playground_bundle "cdal-formalist" @
-     workspace_defaults "cdal-formalist") effective
+  check (list string) "name embedded in playground path"
+    (playground_bundle "cdal-formalist") effective
 
 (* ── playground path ── *)
 
@@ -295,12 +279,12 @@ let () =
             test_observe_only_empty_paths;
           test_case "observe_only + explicit = playground + explicit" `Quick
             test_observe_only_explicit_paths;
-          test_case "workspace + [] = playground + computed default" `Quick
-            test_workspace_empty_paths_computed_default;
+          test_case "workspace + [] = playground only" `Quick
+            test_workspace_empty_paths_playground_only;
           test_case "workspace + explicit = playground + explicit" `Quick
             test_workspace_explicit_paths;
-          test_case "workspace write defaults stay in playground/state only" `Quick
-            test_workspace_write_paths_keep_playground_and_state_only;
+          test_case "workspace write defaults are playground-only" `Quick
+            test_workspace_write_paths_playground_only;
           test_case "workspace write defaults preserve explicit overrides" `Quick
             test_workspace_write_paths_preserve_explicit_overrides;
           test_case "workspace + [*] = full access" `Quick
@@ -311,8 +295,8 @@ let () =
             test_star_wildcard_any_scope;
           test_case "explicit paths any scope" `Quick
             test_explicit_paths_any_scope;
-          test_case "keeper name in computed default" `Quick
-            test_computed_default_uses_keeper_name;
+          test_case "keeper name in playground default" `Quick
+            test_playground_default_uses_keeper_name;
         ] );
       ( "playground",
         [


### PR DESCRIPTION
## Summary
- Keeper tool allowlist를 playground-only로 전환
- `workspace_state_defaults` (`.masc/keepers/<name>/`, `.masc/traces/`) 제거
- `workspace_repo_read_defaults` (`lib/`, `test/`, `config/`, `bin/`, `scripts/`, `docs/`) 제거
- 모든 scope에서 기본 허용 경로 = `.masc/playground/<name>/{mind,repos}/` 뿐
- 추가 경로 필요 시 keeper TOML의 `allowed_paths`에 명시해야 함

## Motivation
4개 keeper(masc-improver, analyst, cheolsu, verdict)가 `~/me` workspace 디렉토리에 대한 공유 하드코딩 접근 권한으로 인해 파일 충돌 발생.
80분 noop-backoff cooldown 유발. 사용자 요구: "딱 playground 말고는 몰라야한다".

## 회귀 감사 결과
`.masc/keepers/`·`.masc/traces/` 쓰기는 전부 서버 내부 경로 (keeper_identity, keeper_checkpoint_store, keeper_chat_store, server_runtime_bootstrap).
Keeper tool (LLM이 호출하는 tool)은 이 디렉토리에 쓰지 않음 — **SAFE**.

## Migration
- 4 keeper TOML은 이미 `execution_scope = "local"` + `allowed_paths` 제거 완료
- 나머지 keeper는 default `workspace` scope → 이 PR 이후 workspace도 playground-only 동작
- 특정 workspace read가 필요한 keeper는 `allowed_paths = ["lib/", ...]` 명시

## 변경 파일
| 파일 | 변경 |
|------|------|
| `lib/keeper/keeper_alerting_path.ml` | `workspace_state_defaults`, `workspace_repo_read_defaults` 삭제, 두 함수 축소 |
| `lib/keeper/keeper_schema.ml` | `execution_scope` + `allowed_paths` description 정직하게 수정 |
| `test/test_keeper_allowed_paths.ml` | 테스트 기대값을 playground-only로 업데이트 |

## Test plan
- [x] `dune build` — clean
- [x] `dune runtest` — 전체 pass
- [ ] Post-merge smoke: keeper가 `lib/` 등을 default scope로 접근 시도하면 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)