### PR TITLE
feat(dashboard): add per-lane state dwell time histogram

### DIFF
--- a/dashboard/src/components/fsm-hub-derivations.ts
+++ b/dashboard/src/components/fsm-hub-derivations.ts
@@ -2,6 +2,8 @@ import type { KeeperCompositeSnapshot } from '../api/keeper'
 
 import {
   type CompositeObservation,
+  type DwellEntry,
+  type LaneDwell,
   type LaneKey,
   type StateEntries,
   type SwimlaneSegment,
@@ -257,4 +259,49 @@ export function deriveSwimlaneSegments(
   const tail = segments[segments.length - 1]
   if (tail && boundsEnd > tail.to) tail.to = boundsEnd
   return segments
+}
+
+/** Per-lane dwell histogram. For each sub-FSM lane, sums the time spent in
+    every observed state value across the in-memory observation buffer.
+    [boundsEnd] (typically `Date.now() / 1000`) extends the trailing
+    segment so the *current* state's dwell reflects "how long has it been
+    held" instead of "interval between last two observations".
+
+    Output: lanes in [TRANSITION_FIELDS] order, entries sorted by dwell
+    desc. Empty observation buffer → empty array. */
+export function deriveLaneDwellHistograms(
+  observations: CompositeObservation[],
+  boundsEnd: number,
+): LaneDwell[] {
+  if (observations.length === 0) return []
+  const result: LaneDwell[] = []
+  for (const { field, key } of TRANSITION_FIELDS) {
+    const segments = deriveSwimlaneSegments(observations, key, boundsEnd)
+    const dwellByValue = new Map<string, number>()
+    let total = 0
+    for (const seg of segments) {
+      const seconds = Math.max(0, seg.to - seg.from)
+      if (seconds === 0) continue
+      dwellByValue.set(seg.value, (dwellByValue.get(seg.value) ?? 0) + seconds)
+      total += seconds
+    }
+    const entries: DwellEntry[] = Array.from(dwellByValue.entries())
+      .map(([value, seconds]) => ({
+        value,
+        seconds,
+        pct: total > 0 ? (seconds / total) * 100 : 0,
+      }))
+      .sort((a, b) => {
+        if (b.seconds !== a.seconds) return b.seconds - a.seconds
+        return a.value.localeCompare(b.value)
+      })
+    if (entries.length === 0) continue
+    result.push({
+      field,
+      laneKey: key,
+      totalSeconds: total,
+      entries,
+    })
+  }
+  return result
 }

--- a/dashboard/src/components/fsm-hub-timeline-panels.ts
+++ b/dashboard/src/components/fsm-hub-timeline-panels.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef } from 'preact/hooks'
 import {
   type CompositeObservation,
   type HoveredSegment,
+  type LaneDwell,
   type LaneKey,
   type TopTransition,
   fmtDuration,
@@ -426,6 +427,79 @@ export function TopTransitionsPanel({
                 </span>
                 <span class="w-[18px] text-right text-[var(--text-dim)]">${entry.count}</span>
               </span>
+            </div>
+          `
+        })}
+      </div>
+    </div>
+  `
+}
+
+const BAR_COLOR: Record<string, string> = {
+  KSM: 'bg-[var(--accent)]',
+  KTC: 'bg-[#818cf8]',
+  KDP: 'bg-[#818cf8]',
+  KCL: 'bg-[#818cf8]',
+  KMC: 'bg-[#f59e0b]',
+}
+
+export function DwellHistogramPanel({
+  histograms,
+  hoveredSegment,
+}: {
+  histograms: LaneDwell[]
+  hoveredSegment: HoveredSegment | null
+}) {
+  if (histograms.length === 0) {
+    return html`
+      <div class="rounded-lg border border-dashed border-[var(--white-8)] px-4 py-2 text-center text-[10px] text-[var(--text-dim)]">
+        관측 데이터가 아직 없습니다 — 키퍼가 상태를 유지하면 체류 시간이 표시됩니다
+      </div>
+    `
+  }
+
+  return html`
+    <div class="rounded-xl border border-[var(--white-8)] bg-[var(--white-2)] px-3 py-2">
+      <div class="mb-1.5 text-[9px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+        State Dwell Time
+      </div>
+      <div class="flex flex-col gap-2">
+        ${histograms.map((lane) => {
+          const matchesHover = hoveredSegment != null && hoveredSegment.field === lane.field
+          const dimmed = hoveredSegment != null && !matchesHover
+          const color = FIELD_COLOR[lane.field] ?? 'text-[var(--text-body)]'
+          const barColor = BAR_COLOR[lane.field] ?? 'bg-[var(--accent)]'
+          return html`
+            <div class=${`transition-opacity duration-150 ${dimmed ? 'opacity-40' : ''}`}>
+              <div class="flex items-center gap-1.5 mb-0.5">
+                <span class=${`text-[9px] font-semibold ${color}`}>${lane.field}</span>
+                <span class="text-[9px] text-[var(--text-dim)]">${fmtDuration(lane.totalSeconds)}</span>
+              </div>
+              <div class="flex flex-col gap-px">
+                ${lane.entries.map((entry) => {
+                  const highlighted = hoveredSegment != null
+                    && hoveredSegment.field === lane.field
+                    && hoveredSegment.value === entry.value
+                  const rowCls = highlighted
+                    ? 'bg-[rgba(71,184,255,0.1)] ring-1 ring-[rgba(71,184,255,0.3)] rounded px-0.5'
+                    : ''
+                  return html`
+                    <div
+                      class=${`flex items-center gap-1.5 text-[10px] font-mono leading-tight ${rowCls}`}
+                      title=${`${displayState(entry.value)}: ${fmtDuration(entry.seconds)} (${entry.pct.toFixed(1)}%)`}
+                    >
+                      <span class="w-[60px] shrink-0 text-[var(--text-body)] truncate">${displayState(entry.value)}</span>
+                      <span class="flex-1 h-1.5 rounded-full bg-[var(--white-8)] overflow-hidden">
+                        <span
+                          class=${`block h-full ${barColor}`}
+                          style=${`width: ${Math.max(2, entry.pct)}%`}
+                        ></span>
+                      </span>
+                      <span class="w-[36px] shrink-0 text-right text-[9px] text-[var(--text-dim)]">${entry.pct.toFixed(0)}%</span>
+                    </div>
+                  `
+                })}
+              </div>
             </div>
           `
         })}

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -41,6 +41,19 @@ export type TopTransition = {
   count: number
 }
 
+export type DwellEntry = {
+  value: string
+  seconds: number
+  pct: number
+}
+
+export type LaneDwell = {
+  field: string
+  laneKey: LaneKey
+  totalSeconds: number
+  entries: DwellEntry[]
+}
+
 export type InsightTone = 'ok' | 'info' | 'warn' | 'error'
 
 export type OperationalInsight = {

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   appendCompositeObservation,
+  deriveLaneDwellHistograms,
   deriveObservedLaneSummaries,
   deriveOperationalInsight,
   derivePhaseLog,
@@ -237,6 +238,59 @@ describe('fsm-hub derived state', () => {
 
     expect(result.tone).toBe('info')
     expect(result.headline).toContain('Compaction currently owns the turn')
+  })
+})
+
+describe('deriveLaneDwellHistograms', () => {
+  it('aggregates dwell time per state per lane', () => {
+    const observations = [
+      observation({ ts: 100, phase: 'Running', turn: 'idle' }),
+      observation({ ts: 110, phase: 'Running', turn: 'executing' }),
+      observation({ ts: 130, phase: 'Compacting', turn: 'compacting' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 150)
+
+    const ksm = histograms.find((h) => h.field === 'KSM')
+    expect(ksm).toBeDefined()
+    expect(ksm!.entries).toHaveLength(2)
+    expect(ksm!.entries[0]).toEqual({ value: 'Running', seconds: 30, pct: 60 })
+    expect(ksm!.entries[1]).toEqual({ value: 'Compacting', seconds: 20, pct: 40 })
+
+    const ktc = histograms.find((h) => h.field === 'KTC')
+    expect(ktc).toBeDefined()
+    const idleDwell = ktc!.entries.find((e) => e.value === 'idle')
+    expect(idleDwell?.seconds).toBe(10)
+    const execDwell = ktc!.entries.find((e) => e.value === 'executing')
+    expect(execDwell?.seconds).toBe(20)
+  })
+
+  it('returns empty array for no observations', () => {
+    expect(deriveLaneDwellHistograms([], 100)).toEqual([])
+  })
+
+  it('extends trailing segment to boundsEnd (current state gets live dwell)', () => {
+    const observations = [
+      observation({ ts: 100, phase: 'Running' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 200)
+    const ksm = histograms.find((h) => h.field === 'KSM')
+    expect(ksm!.entries[0]).toEqual({
+      value: 'Running',
+      seconds: 100,
+      pct: 100,
+    })
+  })
+
+  it('pct sums to 100 for each lane', () => {
+    const observations = [
+      observation({ ts: 10, cascade: 'idle' }),
+      observation({ ts: 30, cascade: 'trying' }),
+      observation({ ts: 50, cascade: 'idle' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 60)
+    const kcl = histograms.find((h) => h.field === 'KCL')
+    const totalPct = kcl!.entries.reduce((sum, e) => sum + e.pct, 0)
+    expect(totalPct).toBeCloseTo(100, 5)
   })
 })
 

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -21,12 +21,13 @@ import {
   observeSnapshot,
   appendCompositeObservation,
   deriveTopTransitions,
+  deriveLaneDwellHistograms,
   deriveTransitionHistory,
   derivePhaseLog,
   deriveStateEntries,
 } from './fsm-hub-derivations'
 import { OperationalMeaningPanel, HeroPhase, TurnPipelineStrip, CompositeGraphPanel } from './fsm-hub-pipeline-panels'
-import { SwimlaneTimeline, TopTransitionsPanel, TransitionTrail } from './fsm-hub-timeline-panels'
+import { DwellHistogramPanel, SwimlaneTimeline, TopTransitionsPanel, TransitionTrail } from './fsm-hub-timeline-panels'
 import { MeasurementCard, InvariantsPanel, RecoveryStatePanel } from './fsm-hub-health-panels'
 
 // ── Backward-compatible re-exports ─────────────────────
@@ -35,7 +36,9 @@ import { MeasurementCard, InvariantsPanel, RecoveryStatePanel } from './fsm-hub-
 
 export type {
   CompositeObservation,
+  DwellEntry,
   HoveredSegment,
+  LaneDwell,
   OperationalInsight,
   ObservedLaneSummary,
   StateEntries,
@@ -48,6 +51,7 @@ export { displayState } from './fsm-hub-types'
 
 export {
   appendCompositeObservation,
+  deriveLaneDwellHistograms,
   deriveTransitionHistory,
   deriveTopTransitions,
   derivePhaseLog,
@@ -230,6 +234,10 @@ export function FsmHub() {
     () => deriveStateEntries(view.observations),
     [view.observations],
   )
+  const dwellHistograms = useMemo(
+    () => deriveLaneDwellHistograms(view.observations, now),
+    [view.observations, now],
+  )
   const { snapshot, loading, error, lastFetchAt } = view
 
   return html`
@@ -284,6 +292,11 @@ export function FsmHub() {
             hoveredSegment=${hoveredSegment}
             onHoverSegment=${setHoveredSegment}
           />
+        <//>
+
+        ${/* ── Zone 3c: Dwell Time Histogram (collapsible) ── */ ''}
+        <${CollapsibleZone} id="dwell-histogram" title="상태 체류 시간" defaultOpen=${true}>
+          <${DwellHistogramPanel} histograms=${dwellHistograms} hoveredSegment=${hoveredSegment} />
         <//>
 
         ${/* ── Zone 4: Health Grid (collapsible) ── */ ''}


### PR DESCRIPTION
## Summary

- Aggregate how long a keeper spends in each sub-FSM state value (KSM/KTC/KDP/KCL/KMC)
- Rendered as "상태 체류 시간" panel with horizontal bars + percentage
- Placed between Swimlane Timeline and Health Grid zones

## Why

Transition logs show *what* changed; dwell histograms show *where time is spent*. A keeper bouncing between cascade `idle` and `trying` shows 50/50 dwell — immediate flapping signal. A keeper stuck in `undecided` for 98% of observed time means the decision pipeline rarely fires.

Surveyed Arize Phoenix, LangSmith, AgentOps, W&B Weave, Datadog LLM Observability — **none** provide per-FSM-state dwell analysis. All use span-based tracing (Gantt/waterfall). This is a genuinely novel diagnostic view. Closest academic work: arXiv 1508.02674 (MAS Space-Time Diagrams).

## Changes

- `fsm-hub-types.ts` — `DwellEntry`, `LaneDwell` types
- `fsm-hub-derivations.ts` — `deriveLaneDwellHistograms(observations, boundsEnd)` reuses `deriveSwimlaneSegments`, extends trailing segment for live dwell
- `fsm-hub-timeline-panels.ts` — `DwellHistogramPanel` with per-lane bars, hover dimming
- `fsm-hub.ts` — wires panel as Zone 3c (collapsible "상태 체류 시간")
- `fsm-hub.test.ts` — 4 unit tests

## Verification

- `pnpm test` → 660/660 tests pass (4 new)
- `pnpm typecheck` → clean
- `pnpm lint` → clean

## Test plan

- [ ] Open dashboard, select an active keeper with some observation history
- [ ] Confirm "상태 체류 시간" panel appears below the Swimlane Timeline
- [ ] Each lane shows state values with horizontal bars proportional to dwell %
- [ ] Hover a swimlane segment → corresponding lane in dwell panel highlights, others dim
- [ ] With a fresh keeper (0 observations), confirm empty state message

🤖 Generated with [Claude Code](https://claude.com/claude-code)