### PR TITLE
fix(keeper): disable tool cost gate by default

### DIFF
--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -146,6 +146,8 @@ max_tools_per_turn = 64
 llm_rerank = true
 ```
 
+`tool_cost_max_usd = 0` means unlimited and disables the keeper cost gate.
+
 **Implementation**: `lib/keeper/keeper_runtime_config.ml` maintains a
 `key_to_env` table mapping TOML dotted keys to env var names. Values
 are recorded in a process-local boot override store so existing

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -391,7 +391,7 @@ Destructive check 대상 도구: `keeper_bash`, `keeper_fs_edit`, `keeper_edit`,
 
 **Proactive**: `PROACTIVE_TEMP_LOW/MID/HIGH`(0.55/0.75/0.9), `PROACTIVE_SIMILARITY`(0.72), `PROACTIVE_MAX_TOKENS`(1024)
 
-**Cost Gates**: `TOOL_COST_MAX_USD`(0.50, live unified-turn accumulated cost ceiling), `COST_GATE_USD`(0.10, legacy compatibility knob; not used by the unified turn cost guard)
+**Cost Gates**: `TOOL_COST_MAX_USD`(disabled by default; set a positive USD value to enable the live unified-turn accumulated cost ceiling, `0` keeps it disabled), `COST_GATE_USD`(0.10, legacy compatibility knob; not used by the unified turn cost guard)
 
 **Unified Turn**: `UNIFIED_TEMP`(0.4), `UNIFIED_MAX_TOKENS`(2048), `UNIFIED_MAX_TURNS`(1000)
 

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -152,7 +152,7 @@ Tool call -> Cost budget check
 
 | 파라미터 | 기본값 | 설명 |
 |---------|--------|------|
-| `max_cost_usd` | 0.50 | 세션 비용 한도 |
+| `max_cost_usd` | 0 | 세션 비용 한도 (`0`이면 비활성) |
 | `max_tool_calls_per_turn` | 10 | 턴당 도구 호출 상한 |
 | `entropy_threshold` | 3 | 동일 도구 연속 호출 임계값 |
 | `destructive_check_enabled` | true | 파괴적 명령 탐지 |

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -189,8 +189,8 @@ let keeper_execution_entries =
       "Max tokens before compaction (0=disabled)";
     entry ~default:"0.10" "MASC_KEEPER_COST_GATE_USD"
       "Legacy keeper cost gate (unused by unified turn cost guard)";
-    entry ~default:"0.50" "MASC_KEEPER_TOOL_COST_MAX_USD"
-      "Unified turn accumulated cost ceiling (USD)";
+    entry ~default:"0" "MASC_KEEPER_TOOL_COST_MAX_USD"
+      "Unified turn accumulated cost ceiling (USD, 0=disabled)";
     entry ~default:"0.4" "MASC_KEEPER_UNIFIED_TEMP" "Unified turn temperature";
     entry ~default:"131072" "MASC_KEEPER_UNIFIED_MAX_TOKENS"
       "Unified turn max output tokens";

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -590,11 +590,13 @@ let keeper_batch_limit () : int =
 let keeper_tool_cost_max_usd_rp =
   _rp_float ~key:"keeper.turn.tool_cost_max_usd"
     ~default:(fun () -> float_of_env_default "MASC_KEEPER_TOOL_COST_MAX_USD"
-                          ~default:0.50 ~min_v:0.01 ~max_v:50.0)
-    ~min_v:0.01 ~max_v:50.0
-    ~description:"Per-tool cost ceiling (USD)" ()
-let keeper_tool_cost_max_usd () : float =
-  Runtime_params.get keeper_tool_cost_max_usd_rp
+                          ~default:0.0 ~min_v:0.0 ~max_v:50.0)
+    ~min_v:0.0 ~max_v:50.0
+    ~description:"Per-tool cost ceiling (USD, 0=disabled)" ()
+let keeper_tool_cost_max_usd () : float option =
+  match Runtime_params.get keeper_tool_cost_max_usd_rp with
+  | v when Float.compare v 0.0 <= 0 -> None
+  | v -> Some v
 
 let keeper_max_tools_per_turn_rp =
   _rp_int ~key:"keeper.turn.max_tools_per_turn"

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -180,7 +180,7 @@ val keeper_proactive_task_cooldown_divisor : unit -> int
 val keeper_proactive_task_min_cooldown_sec : unit -> int
 
 val keeper_batch_limit : unit -> int
-val keeper_tool_cost_max_usd : unit -> float
+val keeper_tool_cost_max_usd : unit -> float option
 val keeper_max_tools_per_turn : unit -> int
 val keeper_retry_max_tools_per_turn : unit -> int
 val keeper_board_event_limit : unit -> int

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1455,7 +1455,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~history_assistant_source:"internal_assistant"
               ~temperature ~max_tokens
               ~oas_timeout_s
-              ~max_cost_usd
+              ?max_cost_usd
               ~is_retry
               ?shared_context
               ?event_bus:(Keeper_event_bus.get ())

--- a/test/test_keeper_runtime_toml.ml
+++ b/test/test_keeper_runtime_toml.ml
@@ -58,6 +58,16 @@ let test_missing_file_returns_zero () =
   | Ok n -> failf "expected 0 overrides, got %d" n
   | Error msg -> failf "unexpected error: %s" msg
 
+let test_missing_file_keeps_cost_gate_disabled_by_default () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  match Keeper_runtime_config.load_and_apply ~base_path with
+  | Error msg -> failf "unexpected error: %s" msg
+  | Ok _ ->
+    check (option (float 0.0001)) "cost gate disabled by default"
+      None
+      (Keeper_config.keeper_tool_cost_max_usd ())
+
 let test_applies_autonomous_max_turns () =
   let doc = parse_or_fail "[autonomous]\nmax_turns_per_call = 7\n" in
   let count, overrides =
@@ -189,6 +199,21 @@ let test_load_and_apply_records_turn_cost_override () =
       (Some "1.25")
       (Config_boot_overrides.get_opt "MASC_KEEPER_TOOL_COST_MAX_USD")
 
+let test_load_and_apply_records_disabled_turn_cost_override () =
+  with_clean_boot_overrides @@ fun () ->
+  with_base_path @@ fun base_path ->
+  write_toml base_path "[turn]\ntool_cost_max_usd = 0\n";
+  match Keeper_runtime_config.load_and_apply ~base_path with
+  | Error msg -> failf "unexpected error: %s" msg
+  | Ok n ->
+    check int "applied count" 1 n;
+    check (option string) "boot override stored"
+      (Some "0")
+      (Config_boot_overrides.get_opt "MASC_KEEPER_TOOL_COST_MAX_USD");
+    check (option (float 0.0001)) "cost gate disabled"
+      None
+      (Keeper_config.keeper_tool_cost_max_usd ())
+
 let test_float_value_round_trip () =
   let doc = parse_or_fail
     "[autonomous]\nsemaphore_wait_timeout_sec = 120.5\n"
@@ -204,6 +229,7 @@ let () =
   run "keeper_runtime_toml"
     [ ( "resolve_overrides"
       , [ test_case "missing file returns 0 overrides" `Quick test_missing_file_returns_zero
+        ; test_case "missing file keeps cost gate disabled by default" `Quick test_missing_file_keeps_cost_gate_disabled_by_default
         ; test_case "applies autonomous max_turns_per_call" `Quick test_applies_autonomous_max_turns
         ; test_case "applies multiple overrides" `Quick test_applies_multiple_overrides
         ; test_case "applies turn execution overrides" `Quick test_applies_turn_execution_overrides
@@ -212,6 +238,7 @@ let () =
         ; test_case "parse error returns Error" `Quick test_parse_error_returns_error
         ; test_case "load_and_apply records boot override" `Quick test_load_and_apply_records_boot_override
         ; test_case "load_and_apply records turn cost override" `Quick test_load_and_apply_records_turn_cost_override
+        ; test_case "load_and_apply records disabled turn cost override" `Quick test_load_and_apply_records_disabled_turn_cost_override
         ; test_case "float value round trip" `Quick test_float_value_round_trip
         ] )
     ]


### PR DESCRIPTION
## Summary
- disable the keeper tool cost gate by default when no runtime value is configured
- treat `tool_cost_max_usd = 0` as an explicit "off" setting
- thread the optional budget into the unified keeper run path and document the new behavior
- add runtime config tests covering both the default-disabled case and the explicit-disabled case

## Why
The live `~/me` base-path deployment currently falls back to `$0.50` when `[turn].tool_cost_max_usd` is unset, which causes keepers to enter a system-wide cost-gated idle loop. The desired behavior is the inverse: no cost gate unless an operator explicitly configures one.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-cost-unlimited`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-cost-unlimited/_build/default/test/test_keeper_runtime_toml.exe`
- `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/keeper-cost-unlimited/_build/default/test/test_keeper_guards.exe`

## Operator note
On the current live binary, `tool_cost_max_usd = 0` is not safe yet because the old code clamps the value. This PR makes `0` and "unset" both resolve to cost-budget disabled.