### PR TITLE
chore: post-reconcile-removal cleanup — dead sidecar filter + stale logs

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1405,13 +1405,13 @@ let read_meta_file_path path : (keeper_meta option, string) result =
 ;;
 
 (** Sidecar stem suffixes (without the trailing .json).
-    A file like [sangsu.manual_reconcile.json] has stem
-    [sangsu.manual_reconcile]; stripping [.json] and checking
-    [String.ends_with ~suffix] on this stem filters sidecars while
-    allowing keeper names that contain dots (e.g. [dot.name.json]).
-    When adding a new sidecar kind, add its dot-prefixed suffix here. *)
+    A file like [sangsu.dataset.json] has stem [sangsu.dataset]; stripping
+    [.json] and checking [String.ends_with ~suffix] on this stem filters
+    sidecars while allowing keeper names that contain dots (e.g.
+    [dot.name.json]). When adding a new sidecar kind, add its dot-prefixed
+    suffix here. *)
 let keeper_sidecar_stem_suffixes =
-  [ ".manual_reconcile"; ".dataset" ]
+  [ ".dataset" ]
 
 let is_keeper_meta_file f =
   if not (Filename.check_suffix f ".json") then false
@@ -1450,8 +1450,7 @@ let keeper_names config =
      JSON files are scoped to the server's base_path, so test isolation works.
      Overlay keepers (from .masc/config/keepers/*.toml) are materialized to
      JSON at boot by load_or_materialize_boot_meta, so they appear here too.
-     Sidecar files (.dataset, .manual_reconcile) are filtered by
-     is_keeper_meta_file. *)
+     Sidecar files (.dataset) are filtered by is_keeper_meta_file. *)
   persisted_keeper_names config
 ;;
 

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -66,7 +66,7 @@ let is_transient_network_error (err : Oas.Error.sdk_error) : bool =
 
     These errors may recur with the same payload, so they are NOT
     eligible for same-turn retry.  They ARE eligible for auto-recovery
-    (skip manual reconcile) when all committed tools are reconcile-safe:
+    when all committed tools are reconcile-safe (idempotent/board-like):
     the keeper's next heartbeat cycle will build a fresh prompt. *)
 let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
   match err with
@@ -1521,7 +1521,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                     else "transient error"
                   in
                   Log.Keeper.warn
-                    "%s: %s after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (error: %s)"
+                    "%s: %s after committed reconcile-safe tool(s) [%s] — auto-recovering (error: %s)"
                     meta.name reason
                     (String.concat ", " committed_tools)
                     err_preview;
@@ -1663,12 +1663,13 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
             then begin
               (* Timeouts are inherently transient — the provider was
                  reachable (tools executed) but took too long.  Board-only
-                 committed tools are duplicate-tolerant, so we skip
-                 manual_reconcile.  Unlike the retry_loop path, no
-                 is_transient check is needed: a wall-clock timeout after
-                 successful tool execution is always transient by nature. *)
+                 committed tools are duplicate-tolerant, so we auto-recover
+                 instead of recording an integrity failure.  Unlike the
+                 retry_loop path, no is_transient check is needed: a
+                 wall-clock timeout after successful tool execution is
+                 always transient by nature. *)
               Log.Keeper.warn
-                "%s: turn wall-clock timeout after committed reconcile-safe tool(s) [%s] — auto-recovering, no manual reconcile (timeout: %s)"
+                "%s: turn wall-clock timeout after committed reconcile-safe tool(s) [%s] — auto-recovering (timeout: %s)"
                 meta.name
                 (String.concat ", " committed_tools)
                 msg;
@@ -1700,7 +1701,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               in
               post_commit_failure_reason := Some failure_reason;
               Log.Keeper.error
-                "%s: turn wall-clock timeout after committed mutating tool call(s) [%s] — treating as integrity failure, manual reconcile required"
+                "%s: turn wall-clock timeout after committed mutating tool call(s) [%s] — treating as integrity failure; evidence recorded for next-turn observation"
                 meta.name
                 (String.concat ", " committed_tools);
               Error reclassified


### PR DESCRIPTION
## Summary
Post-merge cleanup for #7334 (manual_reconcile removal).

- Remove `.manual_reconcile` from `keeper_sidecar_stem_suffixes` in `keeper_types.ml` — no code creates these files anymore
- Update 4 log/comment references in `keeper_unified_turn.ml` that still said "manual reconcile required" — now describe actual behavior (auto-recovery, evidence recording)

## Test plan
- [x] `dune build @check` clean
- [x] Cherry-pick applies cleanly to latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)