### PR TITLE
refactor(keeper): remove dead Blocked variant from turn_outcome

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -910,7 +910,7 @@ let keeper_config_json (config : Room.config) (name : string)
                Some (`Preset (Keeper_types.tool_preset_to_string preset))
              | None -> None)
         in
-        let turn_outcome : [`Ok | `Failed | `Blocked] option =
+        let turn_outcome : [`Ok | `Failed] option =
           match Keeper_registry.get ~base_path:config.base_path m.name with
           | Some entry when entry.turn_consecutive_failures > 0 ->
             Some `Failed

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -190,7 +190,7 @@ let flush_if_needed ~base_path ~keeper_name =
 let decision_pipeline_to_mermaid
     ?(guard_penalty_total : int option)
     ?(tool_policy_mode : [`Preset of string | `Custom] option)
-    ?(turn_outcome : [`Ok | `Failed | `Blocked] option)
+    ?(turn_outcome : [`Ok | `Failed] option)
     ~(phase : Keeper_state_machine.phase)
     ~(thompson_alpha : float)
     ~(thompson_beta : float)
@@ -248,7 +248,6 @@ let decision_pipeline_to_mermaid
   let outcome_str = match turn_outcome with
     | Some `Ok -> "ok"
     | Some `Failed -> "failed"
-    | Some `Blocked -> "blocked"
     | None -> "n/a"
   in
   p "    note right of Running\n";

--- a/lib/keeper/keeper_decision_audit.mli
+++ b/lib/keeper/keeper_decision_audit.mli
@@ -64,7 +64,7 @@ val ring_capacity : unit -> int
 val decision_pipeline_to_mermaid :
   ?guard_penalty_total:int ->
   ?tool_policy_mode:[`Preset of string | `Custom] ->
-  ?turn_outcome:[`Ok | `Failed | `Blocked] ->
+  ?turn_outcome:[`Ok | `Failed] ->
   phase:Keeper_state_machine.phase ->
   thompson_alpha:float ->
   thompson_beta:float ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -708,7 +708,7 @@ let handle_keeper_get_subroutes state req request reqd =
               | None -> None))
         | _ -> None
       in
-      let turn_outcome : [`Ok | `Failed | `Blocked] option =
+      let turn_outcome : [`Ok | `Failed] option =
         match Keeper_registry.get ~base_path:state.Mcp_server.room_config.base_path name with
         | Some entry when entry.turn_consecutive_failures > 0 ->
           Some `Failed


### PR DESCRIPTION
## Summary
Post-reconcile dead code cleanup. The `Blocked` variant in `turn_outcome` type was never constructed after manual_reconcile removal (#7334). Remove the dead variant and its unreachable match arm.

4 files, -1 line net.

## Test plan
- [x] `dune build @check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)