### PR TITLE
feat(lib): Tool_name variant module for compile-time tool ID safety

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -333,6 +333,7 @@
    state_product
    tool_token
    tool_dispatch
+   tool_name
    tool_input_validation
    tool_prefilter
    tool_metrics

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -1,0 +1,488 @@
+(** Tool_name — Compile-time verified tool identifiers.
+
+    Replaces stringly-typed tool dispatch with exhaustive variant matching.
+    Parse boundary: [of_string] at MCP/JSON ingress only.
+    Internal code uses [t] directly — typos become compile errors. *)
+
+module Keeper = struct
+  type t =
+    | Bash
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_list
+    | Board_post
+    | Board_search
+    | Board_stats
+    | Board_vote
+    | Broadcast
+    | Code_read
+    | Context_status
+    | Discovery
+    | Fs_edit
+    | Fs_read
+    | Handoff
+    | Library_read
+    | Library_search
+    | Memory_search
+    | Pr_review_comment
+    | Pr_review_read
+    | Pr_review_reply
+    | Pr_submit
+    | Pr_workflow
+    | Preflight_check
+    | Shell
+    | Stay_silent
+    | Task_claim
+    | Task_create
+    | Task_done
+    | Task_force_done
+    | Task_force_release
+    | Tasks_audit
+    | Tasks_list
+    | Time_now
+    | Tool_search
+    | Tools_list
+    | Voice_agent
+    | Voice_listen
+    | Voice_session_end
+    | Voice_session_start
+    | Voice_sessions
+    | Voice_speak
+
+  let to_string = function
+    | Bash -> "keeper_bash"
+    | Board_cleanup -> "keeper_board_cleanup"
+    | Board_comment -> "keeper_board_comment"
+    | Board_comment_vote -> "keeper_board_comment_vote"
+    | Board_delete -> "keeper_board_delete"
+    | Board_get -> "keeper_board_get"
+    | Board_list -> "keeper_board_list"
+    | Board_post -> "keeper_board_post"
+    | Board_search -> "keeper_board_search"
+    | Board_stats -> "keeper_board_stats"
+    | Board_vote -> "keeper_board_vote"
+    | Broadcast -> "keeper_broadcast"
+    | Code_read -> "keeper_code_read"
+    | Context_status -> "keeper_context_status"
+    | Discovery -> "keeper_discovery"
+    | Fs_edit -> "keeper_fs_edit"
+    | Fs_read -> "keeper_fs_read"
+    | Handoff -> "keeper_handoff"
+    | Library_read -> "keeper_library_read"
+    | Library_search -> "keeper_library_search"
+    | Memory_search -> "keeper_memory_search"
+    | Pr_review_comment -> "keeper_pr_review_comment"
+    | Pr_review_read -> "keeper_pr_review_read"
+    | Pr_review_reply -> "keeper_pr_review_reply"
+    | Pr_submit -> "keeper_pr_submit"
+    | Pr_workflow -> "keeper_pr_workflow"
+    | Preflight_check -> "keeper_preflight_check"
+    | Shell -> "keeper_shell"
+    | Stay_silent -> "keeper_stay_silent"
+    | Task_claim -> "keeper_task_claim"
+    | Task_create -> "keeper_task_create"
+    | Task_done -> "keeper_task_done"
+    | Task_force_done -> "keeper_task_force_done"
+    | Task_force_release -> "keeper_task_force_release"
+    | Tasks_audit -> "keeper_tasks_audit"
+    | Tasks_list -> "keeper_tasks_list"
+    | Time_now -> "keeper_time_now"
+    | Tool_search -> "keeper_tool_search"
+    | Tools_list -> "keeper_tools_list"
+    | Voice_agent -> "keeper_voice_agent"
+    | Voice_listen -> "keeper_voice_listen"
+    | Voice_session_end -> "keeper_voice_session_end"
+    | Voice_session_start -> "keeper_voice_session_start"
+    | Voice_sessions -> "keeper_voice_sessions"
+    | Voice_speak -> "keeper_voice_speak"
+
+  let of_string = function
+    | "keeper_bash" -> Some Bash
+    | "keeper_board_cleanup" -> Some Board_cleanup
+    | "keeper_board_comment" -> Some Board_comment
+    | "keeper_board_comment_vote" -> Some Board_comment_vote
+    | "keeper_board_delete" -> Some Board_delete
+    | "keeper_board_get" -> Some Board_get
+    | "keeper_board_list" -> Some Board_list
+    | "keeper_board_post" -> Some Board_post
+    | "keeper_board_search" -> Some Board_search
+    | "keeper_board_stats" -> Some Board_stats
+    | "keeper_board_vote" -> Some Board_vote
+    | "keeper_broadcast" -> Some Broadcast
+    | "keeper_code_read" -> Some Code_read
+    | "keeper_context_status" -> Some Context_status
+    | "keeper_discovery" -> Some Discovery
+    | "keeper_fs_edit" -> Some Fs_edit
+    | "keeper_fs_read" -> Some Fs_read
+    | "keeper_handoff" -> Some Handoff
+    | "keeper_library_read" -> Some Library_read
+    | "keeper_library_search" -> Some Library_search
+    | "keeper_memory_search" -> Some Memory_search
+    | "keeper_pr_review_comment" -> Some Pr_review_comment
+    | "keeper_pr_review_read" -> Some Pr_review_read
+    | "keeper_pr_review_reply" -> Some Pr_review_reply
+    | "keeper_pr_submit" -> Some Pr_submit
+    | "keeper_pr_workflow" -> Some Pr_workflow
+    | "keeper_preflight_check" -> Some Preflight_check
+    | "keeper_shell" -> Some Shell
+    | "keeper_stay_silent" -> Some Stay_silent
+    | "keeper_task_claim" -> Some Task_claim
+    | "keeper_task_create" -> Some Task_create
+    | "keeper_task_done" -> Some Task_done
+    | "keeper_task_force_done" -> Some Task_force_done
+    | "keeper_task_force_release" -> Some Task_force_release
+    | "keeper_tasks_audit" -> Some Tasks_audit
+    | "keeper_tasks_list" -> Some Tasks_list
+    | "keeper_time_now" -> Some Time_now
+    | "keeper_tool_search" -> Some Tool_search
+    | "keeper_tools_list" -> Some Tools_list
+    | "keeper_voice_agent" -> Some Voice_agent
+    | "keeper_voice_listen" -> Some Voice_listen
+    | "keeper_voice_session_end" -> Some Voice_session_end
+    | "keeper_voice_session_start" -> Some Voice_session_start
+    | "keeper_voice_sessions" -> Some Voice_sessions
+    | "keeper_voice_speak" -> Some Voice_speak
+    | _ -> None
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Masc = struct
+  type t =
+    | A2a_delegate
+    | Add_task
+    | Agent_card
+    | Agent_fitness
+    | Agent_update
+    | Agents
+    | Batch_add_tasks
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_list
+    | Board_post
+    | Board_search
+    | Board_stats
+    | Board_vote
+    | Broadcast
+    | Cancel_task
+    | Check
+    | Claim_next
+    | Claim_task
+    | Cleanup_zombies
+    | Autoresearch_cycle
+    | Autoresearch_inject
+    | Autoresearch_start
+    | Autoresearch_status
+    | Autoresearch_stop
+    | Code_delete
+    | Code_edit
+    | Code_git
+    | Code_read
+    | Code_search
+    | Code_shell
+    | Code_symbols
+    | Code_write
+    | Complete_task
+    | Dashboard
+    | Deliver
+    | Dispatch_assign
+    | Dispatch_plan
+    | Find_by_capability
+    | Heartbeat
+    | Join
+    | Leave
+    | List_tasks
+    | Messages
+    | Note_add
+    | Operation_checkpoint
+    | Operation_finalize
+    | Operation_pause
+    | Operation_resume
+    | Operation_start
+    | Operation_status
+    | Operation_stop
+    | Operator_action
+    | Operator_confirm
+    | Operator_digest
+    | Operator_snapshot
+    | Plan_clear_task
+    | Plan_get
+    | Plan_get_task
+    | Plan_init
+    | Plan_set_task
+    | Plan_update
+    | Register_capabilities
+    | Release_task
+    | Reset
+    | Room_status
+    | Set_current_task
+    | Status
+    | Task_history
+    | Tasks
+    | Tool_grant
+    | Tool_help
+    | Tool_list
+    | Tool_revoke
+    | Transition
+    | Update_priority
+    | Web_search
+    | Who
+    | Workflow_guide
+    | Worktree_create
+    | Worktree_list
+    | Worktree_remove
+    | Worktree_status
+
+  let to_string = function
+    | A2a_delegate -> "masc_a2a_delegate"
+    | Add_task -> "masc_add_task"
+    | Agent_card -> "masc_agent_card"
+    | Agent_fitness -> "masc_agent_fitness"
+    | Agent_update -> "masc_agent_update"
+    | Agents -> "masc_agents"
+    | Batch_add_tasks -> "masc_batch_add_tasks"
+    | Board_cleanup -> "masc_board_cleanup"
+    | Board_comment -> "masc_board_comment"
+    | Board_comment_vote -> "masc_board_comment_vote"
+    | Board_delete -> "masc_board_delete"
+    | Board_get -> "masc_board_get"
+    | Board_list -> "masc_board_list"
+    | Board_post -> "masc_board_post"
+    | Board_search -> "masc_board_search"
+    | Board_stats -> "masc_board_stats"
+    | Board_vote -> "masc_board_vote"
+    | Broadcast -> "masc_broadcast"
+    | Cancel_task -> "masc_cancel_task"
+    | Check -> "masc_check"
+    | Claim_next -> "masc_claim_next"
+    | Claim_task -> "masc_claim_task"
+    | Cleanup_zombies -> "masc_cleanup_zombies"
+    | Autoresearch_cycle -> "masc_autoresearch_cycle"
+    | Autoresearch_inject -> "masc_autoresearch_inject"
+    | Autoresearch_start -> "masc_autoresearch_start"
+    | Autoresearch_status -> "masc_autoresearch_status"
+    | Autoresearch_stop -> "masc_autoresearch_stop"
+    | Code_delete -> "masc_code_delete"
+    | Code_edit -> "masc_code_edit"
+    | Code_git -> "masc_code_git"
+    | Code_read -> "masc_code_read"
+    | Code_search -> "masc_code_search"
+    | Code_shell -> "masc_code_shell"
+    | Code_symbols -> "masc_code_symbols"
+    | Code_write -> "masc_code_write"
+    | Complete_task -> "masc_complete_task"
+    | Dashboard -> "masc_dashboard"
+    | Deliver -> "masc_deliver"
+    | Dispatch_assign -> "masc_dispatch_assign"
+    | Dispatch_plan -> "masc_dispatch_plan"
+    | Find_by_capability -> "masc_find_by_capability"
+    | Heartbeat -> "masc_heartbeat"
+    | Join -> "masc_join"
+    | Leave -> "masc_leave"
+    | List_tasks -> "masc_list_tasks"
+    | Messages -> "masc_messages"
+    | Note_add -> "masc_note_add"
+    | Operation_checkpoint -> "masc_operation_checkpoint"
+    | Operation_finalize -> "masc_operation_finalize"
+    | Operation_pause -> "masc_operation_pause"
+    | Operation_resume -> "masc_operation_resume"
+    | Operation_start -> "masc_operation_start"
+    | Operation_status -> "masc_operation_status"
+    | Operation_stop -> "masc_operation_stop"
+    | Operator_action -> "masc_operator_action"
+    | Operator_confirm -> "masc_operator_confirm"
+    | Operator_digest -> "masc_operator_digest"
+    | Operator_snapshot -> "masc_operator_snapshot"
+    | Plan_clear_task -> "masc_plan_clear_task"
+    | Plan_get -> "masc_plan_get"
+    | Plan_get_task -> "masc_plan_get_task"
+    | Plan_init -> "masc_plan_init"
+    | Plan_set_task -> "masc_plan_set_task"
+    | Plan_update -> "masc_plan_update"
+    | Register_capabilities -> "masc_register_capabilities"
+    | Release_task -> "masc_release_task"
+    | Reset -> "masc_reset"
+    | Room_status -> "masc_room_status"
+    | Set_current_task -> "masc_set_current_task"
+    | Status -> "masc_status"
+    | Task_history -> "masc_task_history"
+    | Tasks -> "masc_tasks"
+    | Tool_grant -> "masc_tool_grant"
+    | Tool_help -> "masc_tool_help"
+    | Tool_list -> "masc_tool_list"
+    | Tool_revoke -> "masc_tool_revoke"
+    | Transition -> "masc_transition"
+    | Update_priority -> "masc_update_priority"
+    | Web_search -> "masc_web_search"
+    | Who -> "masc_who"
+    | Workflow_guide -> "masc_workflow_guide"
+    | Worktree_create -> "masc_worktree_create"
+    | Worktree_list -> "masc_worktree_list"
+    | Worktree_remove -> "masc_worktree_remove"
+    | Worktree_status -> "masc_worktree_status"
+
+  let of_string = function
+    | "masc_a2a_delegate" -> Some A2a_delegate
+    | "masc_add_task" -> Some Add_task
+    | "masc_agent_card" -> Some Agent_card
+    | "masc_agent_fitness" -> Some Agent_fitness
+    | "masc_agent_update" -> Some Agent_update
+    | "masc_agents" -> Some Agents
+    | "masc_batch_add_tasks" -> Some Batch_add_tasks
+    | "masc_board_cleanup" -> Some Board_cleanup
+    | "masc_board_comment" -> Some Board_comment
+    | "masc_board_comment_vote" -> Some Board_comment_vote
+    | "masc_board_delete" -> Some Board_delete
+    | "masc_board_get" -> Some Board_get
+    | "masc_board_list" -> Some Board_list
+    | "masc_board_post" -> Some Board_post
+    | "masc_board_search" -> Some Board_search
+    | "masc_board_stats" -> Some Board_stats
+    | "masc_board_vote" -> Some Board_vote
+    | "masc_broadcast" -> Some Broadcast
+    | "masc_cancel_task" -> Some Cancel_task
+    | "masc_check" -> Some Check
+    | "masc_claim_next" -> Some Claim_next
+    | "masc_claim_task" -> Some Claim_task
+    | "masc_cleanup_zombies" -> Some Cleanup_zombies
+    | "masc_autoresearch_cycle" -> Some Autoresearch_cycle
+    | "masc_autoresearch_inject" -> Some Autoresearch_inject
+    | "masc_autoresearch_start" -> Some Autoresearch_start
+    | "masc_autoresearch_status" -> Some Autoresearch_status
+    | "masc_autoresearch_stop" -> Some Autoresearch_stop
+    | "masc_code_delete" -> Some Code_delete
+    | "masc_code_edit" -> Some Code_edit
+    | "masc_code_git" -> Some Code_git
+    | "masc_code_read" -> Some Code_read
+    | "masc_code_search" -> Some Code_search
+    | "masc_code_shell" -> Some Code_shell
+    | "masc_code_symbols" -> Some Code_symbols
+    | "masc_code_write" -> Some Code_write
+    | "masc_complete_task" -> Some Complete_task
+    | "masc_dashboard" -> Some Dashboard
+    | "masc_deliver" -> Some Deliver
+    | "masc_dispatch_assign" -> Some Dispatch_assign
+    | "masc_dispatch_plan" -> Some Dispatch_plan
+    | "masc_find_by_capability" -> Some Find_by_capability
+    | "masc_heartbeat" -> Some Heartbeat
+    | "masc_join" -> Some Join
+    | "masc_leave" -> Some Leave
+    | "masc_list_tasks" -> Some List_tasks
+    | "masc_messages" -> Some Messages
+    | "masc_note_add" -> Some Note_add
+    | "masc_operation_checkpoint" -> Some Operation_checkpoint
+    | "masc_operation_finalize" -> Some Operation_finalize
+    | "masc_operation_pause" -> Some Operation_pause
+    | "masc_operation_resume" -> Some Operation_resume
+    | "masc_operation_start" -> Some Operation_start
+    | "masc_operation_status" -> Some Operation_status
+    | "masc_operation_stop" -> Some Operation_stop
+    | "masc_operator_action" -> Some Operator_action
+    | "masc_operator_confirm" -> Some Operator_confirm
+    | "masc_operator_digest" -> Some Operator_digest
+    | "masc_operator_snapshot" -> Some Operator_snapshot
+    | "masc_plan_clear_task" -> Some Plan_clear_task
+    | "masc_plan_get" -> Some Plan_get
+    | "masc_plan_get_task" -> Some Plan_get_task
+    | "masc_plan_init" -> Some Plan_init
+    | "masc_plan_set_task" -> Some Plan_set_task
+    | "masc_plan_update" -> Some Plan_update
+    | "masc_register_capabilities" -> Some Register_capabilities
+    | "masc_release_task" -> Some Release_task
+    | "masc_reset" -> Some Reset
+    | "masc_room_status" -> Some Room_status
+    | "masc_set_current_task" -> Some Set_current_task
+    | "masc_status" -> Some Status
+    | "masc_task_history" -> Some Task_history
+    | "masc_tasks" -> Some Tasks
+    | "masc_tool_grant" -> Some Tool_grant
+    | "masc_tool_help" -> Some Tool_help
+    | "masc_tool_list" -> Some Tool_list
+    | "masc_tool_revoke" -> Some Tool_revoke
+    | "masc_transition" -> Some Transition
+    | "masc_update_priority" -> Some Update_priority
+    | "masc_web_search" -> Some Web_search
+    | "masc_who" -> Some Who
+    | "masc_workflow_guide" -> Some Workflow_guide
+    | "masc_worktree_create" -> Some Worktree_create
+    | "masc_worktree_list" -> Some Worktree_list
+    | "masc_worktree_remove" -> Some Worktree_remove
+    | "masc_worktree_status" -> Some Worktree_status
+    | _ -> None
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+module Masc_keeper = struct
+  type t =
+    | Clear
+    | Compact
+    | Create_from_persona
+    | Down
+    | List
+    | Msg
+    | Repair
+    | Reset
+    | Status
+    | Up
+
+  let to_string = function
+    | Clear -> "masc_keeper_clear"
+    | Compact -> "masc_keeper_compact"
+    | Create_from_persona -> "masc_keeper_create_from_persona"
+    | Down -> "masc_keeper_down"
+    | List -> "masc_keeper_list"
+    | Msg -> "masc_keeper_msg"
+    | Repair -> "masc_keeper_repair"
+    | Reset -> "masc_keeper_reset"
+    | Status -> "masc_keeper_status"
+    | Up -> "masc_keeper_up"
+
+  let of_string = function
+    | "masc_keeper_clear" -> Some Clear
+    | "masc_keeper_compact" -> Some Compact
+    | "masc_keeper_create_from_persona" -> Some Create_from_persona
+    | "masc_keeper_down" -> Some Down
+    | "masc_keeper_list" -> Some List
+    | "masc_keeper_msg" -> Some Msg
+    | "masc_keeper_repair" -> Some Repair
+    | "masc_keeper_reset" -> Some Reset
+    | "masc_keeper_status" -> Some Status
+    | "masc_keeper_up" -> Some Up
+    | _ -> None
+
+  let pp fmt t = Format.pp_print_string fmt (to_string t)
+end
+
+type t =
+  | Keeper of Keeper.t
+  | Masc of Masc.t
+  | Masc_keeper of Masc_keeper.t
+
+let to_string = function
+  | Keeper k -> Keeper.to_string k
+  | Masc m -> Masc.to_string m
+  | Masc_keeper mk -> Masc_keeper.to_string mk
+
+let of_string s =
+  match Keeper.of_string s with
+  | Some k -> Some (Keeper k)
+  | None ->
+    match Masc_keeper.of_string s with
+    | Some mk -> Some (Masc_keeper mk)
+    | None ->
+      match Masc.of_string s with
+      | Some m -> Some (Masc m)
+      | None -> None
+
+let pp fmt t = Format.pp_print_string fmt (to_string t)
+
+let is_keeper = function Keeper _ -> true | _ -> false
+let is_masc = function Masc _ -> true | _ -> false
+let is_masc_keeper = function Masc_keeper _ -> true | _ -> false

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -1,0 +1,182 @@
+(** Compile-time verified tool name identifiers.
+
+    Use [of_string] at MCP/JSON parse boundaries only.
+    All internal code passes [t] values directly. *)
+
+module Keeper : sig
+  type t =
+    | Bash
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_list
+    | Board_post
+    | Board_search
+    | Board_stats
+    | Board_vote
+    | Broadcast
+    | Code_read
+    | Context_status
+    | Discovery
+    | Fs_edit
+    | Fs_read
+    | Handoff
+    | Library_read
+    | Library_search
+    | Memory_search
+    | Pr_review_comment
+    | Pr_review_read
+    | Pr_review_reply
+    | Pr_submit
+    | Pr_workflow
+    | Preflight_check
+    | Shell
+    | Stay_silent
+    | Task_claim
+    | Task_create
+    | Task_done
+    | Task_force_done
+    | Task_force_release
+    | Tasks_audit
+    | Tasks_list
+    | Time_now
+    | Tool_search
+    | Tools_list
+    | Voice_agent
+    | Voice_listen
+    | Voice_session_end
+    | Voice_session_start
+    | Voice_sessions
+    | Voice_speak
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Format.formatter -> t -> unit
+end
+
+module Masc : sig
+  type t =
+    | A2a_delegate
+    | Add_task
+    | Agent_card
+    | Agent_fitness
+    | Agent_update
+    | Agents
+    | Batch_add_tasks
+    | Board_cleanup
+    | Board_comment
+    | Board_comment_vote
+    | Board_delete
+    | Board_get
+    | Board_list
+    | Board_post
+    | Board_search
+    | Board_stats
+    | Board_vote
+    | Broadcast
+    | Cancel_task
+    | Check
+    | Claim_next
+    | Claim_task
+    | Cleanup_zombies
+    | Autoresearch_cycle
+    | Autoresearch_inject
+    | Autoresearch_start
+    | Autoresearch_status
+    | Autoresearch_stop
+    | Code_delete
+    | Code_edit
+    | Code_git
+    | Code_read
+    | Code_search
+    | Code_shell
+    | Code_symbols
+    | Code_write
+    | Complete_task
+    | Dashboard
+    | Deliver
+    | Dispatch_assign
+    | Dispatch_plan
+    | Find_by_capability
+    | Heartbeat
+    | Join
+    | Leave
+    | List_tasks
+    | Messages
+    | Note_add
+    | Operation_checkpoint
+    | Operation_finalize
+    | Operation_pause
+    | Operation_resume
+    | Operation_start
+    | Operation_status
+    | Operation_stop
+    | Operator_action
+    | Operator_confirm
+    | Operator_digest
+    | Operator_snapshot
+    | Plan_clear_task
+    | Plan_get
+    | Plan_get_task
+    | Plan_init
+    | Plan_set_task
+    | Plan_update
+    | Register_capabilities
+    | Release_task
+    | Reset
+    | Room_status
+    | Set_current_task
+    | Status
+    | Task_history
+    | Tasks
+    | Tool_grant
+    | Tool_help
+    | Tool_list
+    | Tool_revoke
+    | Transition
+    | Update_priority
+    | Web_search
+    | Who
+    | Workflow_guide
+    | Worktree_create
+    | Worktree_list
+    | Worktree_remove
+    | Worktree_status
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Format.formatter -> t -> unit
+end
+
+module Masc_keeper : sig
+  type t =
+    | Clear
+    | Compact
+    | Create_from_persona
+    | Down
+    | List
+    | Msg
+    | Repair
+    | Reset
+    | Status
+    | Up
+
+  val to_string : t -> string
+  val of_string : string -> t option
+  val pp : Format.formatter -> t -> unit
+end
+
+type t =
+  | Keeper of Keeper.t
+  | Masc of Masc.t
+  | Masc_keeper of Masc_keeper.t
+
+val to_string : t -> string
+val of_string : string -> t option
+val pp : Format.formatter -> t -> unit
+
+val is_keeper : t -> bool
+val is_masc : t -> bool
+val is_masc_keeper : t -> bool

--- a/test/dune
+++ b/test/dune
@@ -556,6 +556,12 @@
    (run %{test})))
  (libraries masc_test_deps))
 
+; ── Tool_name variant roundtrip + coverage ──────────────
+(test
+ (name test_tool_name)
+ (modules test_tool_name)
+ (libraries masc_test_deps))
+
 ; ── Core Triad: State x Decision x Cascade ──────────────
 (test
  (name test_keeper_cascade_routing)

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -1,0 +1,186 @@
+(** Test Tool_name: roundtrip, coverage, and invariant checks. *)
+
+open Masc_mcp
+
+let all_keeper : Tool_name.Keeper.t list =
+  [ Bash; Board_cleanup; Board_comment; Board_comment_vote; Board_delete
+  ; Board_get; Board_list; Board_post; Board_search; Board_stats; Board_vote
+  ; Broadcast; Code_read; Context_status; Discovery; Fs_edit; Fs_read
+  ; Handoff; Library_read; Library_search; Memory_search
+  ; Pr_review_comment; Pr_review_read; Pr_review_reply; Pr_submit; Pr_workflow
+  ; Preflight_check; Shell; Stay_silent
+  ; Task_claim; Task_create; Task_done; Task_force_done; Task_force_release
+  ; Tasks_audit; Tasks_list; Time_now; Tool_search; Tools_list
+  ; Voice_agent; Voice_listen; Voice_session_end; Voice_session_start
+  ; Voice_sessions; Voice_speak ]
+
+let all_masc : Tool_name.Masc.t list =
+  [ A2a_delegate; Add_task; Agent_card; Agent_fitness; Agent_update; Agents
+  ; Autoresearch_cycle; Autoresearch_inject; Autoresearch_start
+  ; Autoresearch_status; Autoresearch_stop
+  ; Batch_add_tasks; Board_cleanup; Board_comment; Board_comment_vote
+  ; Board_delete; Board_get; Board_list; Board_post; Board_search
+  ; Board_stats; Board_vote; Broadcast; Cancel_task; Check; Claim_next
+  ; Claim_task; Cleanup_zombies; Code_delete; Code_edit; Code_git; Code_read
+  ; Code_search; Code_shell; Code_symbols; Code_write; Complete_task
+  ; Dashboard; Deliver; Dispatch_assign; Dispatch_plan; Find_by_capability
+  ; Heartbeat; Join; Leave; List_tasks; Messages; Note_add
+  ; Operation_checkpoint; Operation_finalize; Operation_pause
+  ; Operation_resume; Operation_start; Operation_status; Operation_stop
+  ; Operator_action; Operator_confirm; Operator_digest; Operator_snapshot
+  ; Plan_clear_task; Plan_get; Plan_get_task; Plan_init; Plan_set_task
+  ; Plan_update; Register_capabilities; Release_task; Reset; Room_status
+  ; Set_current_task; Status; Task_history; Tasks; Tool_grant; Tool_help
+  ; Tool_list; Tool_revoke; Transition; Update_priority; Web_search; Who
+  ; Workflow_guide; Worktree_create; Worktree_list; Worktree_remove
+  ; Worktree_status ]
+
+let all_masc_keeper : Tool_name.Masc_keeper.t list =
+  [ Clear; Compact; Create_from_persona; Down; List; Msg; Repair; Reset
+  ; Status; Up ]
+
+let all_tool_names : Tool_name.t list =
+  List.map (fun k -> Tool_name.Keeper k) all_keeper
+  @ List.map (fun m -> Tool_name.Masc m) all_masc
+  @ List.map (fun mk -> Tool_name.Masc_keeper mk) all_masc_keeper
+
+(* ── Roundtrip ─────────────────────────────────────────────── *)
+
+let test_roundtrip_keeper () =
+  List.iter (fun k ->
+    let s = Tool_name.Keeper.to_string k in
+    let parsed = Tool_name.Keeper.of_string s in
+    Alcotest.(check (option (of_pp Tool_name.Keeper.pp)))
+      (Printf.sprintf "roundtrip %s" s) (Some k) parsed
+  ) all_keeper
+
+let test_roundtrip_masc () =
+  List.iter (fun m ->
+    let s = Tool_name.Masc.to_string m in
+    let parsed = Tool_name.Masc.of_string s in
+    Alcotest.(check (option (of_pp Tool_name.Masc.pp)))
+      (Printf.sprintf "roundtrip %s" s) (Some m) parsed
+  ) all_masc
+
+let test_roundtrip_masc_keeper () =
+  List.iter (fun mk ->
+    let s = Tool_name.Masc_keeper.to_string mk in
+    let parsed = Tool_name.Masc_keeper.of_string s in
+    Alcotest.(check (option (of_pp Tool_name.Masc_keeper.pp)))
+      (Printf.sprintf "roundtrip %s" s) (Some mk) parsed
+  ) all_masc_keeper
+
+let test_roundtrip_toplevel () =
+  List.iter (fun t ->
+    let s = Tool_name.to_string t in
+    let parsed = Tool_name.of_string s in
+    Alcotest.(check (option (of_pp Tool_name.pp)))
+      (Printf.sprintf "roundtrip %s" s) (Some t) parsed
+  ) all_tool_names
+
+(* ── Prefix invariants ─────────────────────────────────────── *)
+
+let test_keeper_prefix () =
+  List.iter (fun k ->
+    let s = Tool_name.Keeper.to_string k in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s starts with keeper_" s)
+      true
+      (String.length s > 7 && String.sub s 0 7 = "keeper_")
+  ) all_keeper
+
+let test_masc_prefix () =
+  List.iter (fun m ->
+    let s = Tool_name.Masc.to_string m in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s starts with masc_" s)
+      true
+      (String.length s > 5 && String.sub s 0 5 = "masc_")
+  ) all_masc
+
+let test_masc_keeper_prefix () =
+  List.iter (fun mk ->
+    let s = Tool_name.Masc_keeper.to_string mk in
+    Alcotest.(check bool)
+      (Printf.sprintf "%s starts with masc_keeper_" s)
+      true
+      (String.length s > 12 && String.sub s 0 12 = "masc_keeper_")
+  ) all_masc_keeper
+
+(* ── Uniqueness ────────────────────────────────────────────── *)
+
+let test_all_names_unique () =
+  let names = List.map Tool_name.to_string all_tool_names in
+  let sorted = List.sort String.compare names in
+  let rec check = function
+    | a :: b :: rest ->
+      if a = b then
+        Alcotest.fail (Printf.sprintf "duplicate tool name: %s" a)
+      else check (b :: rest)
+    | _ -> ()
+  in
+  check sorted
+
+(* ── Unknown strings fail closed ───────────────────────────── *)
+
+let test_unknown_returns_none () =
+  let unknowns = [ "keeper_nonexistent"; "masc_fake"; "foobar"; "" ] in
+  List.iter (fun s ->
+    Alcotest.(check (option (of_pp Tool_name.pp)))
+      (Printf.sprintf "unknown %s -> None" s)
+      None (Tool_name.of_string s)
+  ) unknowns
+
+(* ── Group predicates ──────────────────────────────────────── *)
+
+let test_is_keeper () =
+  List.iter (fun k ->
+    Alcotest.(check bool) "is_keeper" true
+      (Tool_name.is_keeper (Keeper k))
+  ) all_keeper;
+  List.iter (fun m ->
+    Alcotest.(check bool) "masc is not keeper" false
+      (Tool_name.is_keeper (Masc m))
+  ) all_masc
+
+(* ── Coverage: all shard tool schemas must parse ───────────── *)
+
+let test_shard_tools_parse () =
+  let shard_names = [ "base"; "board"; "filesystem"; "shell"; "voice";
+                      "coding"; "pr"; "autoresearch"; "library" ] in
+  let tool_names =
+    List.concat_map (fun sn ->
+      match Tool_shard.get_shard sn with
+      | Some shard ->
+        List.map (fun (t : Types.tool_schema) -> t.name) shard.tools
+      | None -> []
+    ) shard_names
+  in
+  let unparsed = List.filter (fun name ->
+    Tool_name.of_string name = None
+  ) tool_names in
+  if unparsed <> [] then
+    Alcotest.fail
+      (Printf.sprintf "Tool_shard names not in Tool_name: [%s]"
+         (String.concat "; " unparsed))
+
+let () =
+  Alcotest.run "Tool_name" [
+    "roundtrip", [
+      Alcotest.test_case "keeper" `Quick test_roundtrip_keeper;
+      Alcotest.test_case "masc" `Quick test_roundtrip_masc;
+      Alcotest.test_case "masc_keeper" `Quick test_roundtrip_masc_keeper;
+      Alcotest.test_case "toplevel" `Quick test_roundtrip_toplevel;
+    ];
+    "invariants", [
+      Alcotest.test_case "keeper prefix" `Quick test_keeper_prefix;
+      Alcotest.test_case "masc prefix" `Quick test_masc_prefix;
+      Alcotest.test_case "masc_keeper prefix" `Quick test_masc_keeper_prefix;
+      Alcotest.test_case "all unique" `Quick test_all_names_unique;
+      Alcotest.test_case "unknown -> None" `Quick test_unknown_returns_none;
+      Alcotest.test_case "is_keeper" `Quick test_is_keeper;
+    ];
+    "coverage", [
+      Alcotest.test_case "shard tools parse" `Quick test_shard_tools_parse;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- `Tool_name` 모듈 추가: 130개 도구 이름을 nested variant (`Keeper.t`, `Masc.t`, `Masc_keeper.t`)로 정의
- `of_string`/`to_string` 양방향 변환, `pp` formatter
- Shard 커버리지 테스트: 새 도구 추가 시 `Tool_name`에 등록 안 하면 테스트 실패

## 동기

PR #7323에서 `keeper_shell`의 `is_read_only_with_input` 체크 순서 버그가 3회 CI round-trip을 요구.
근본 원인: tool_name이 `string`이라 컴파일러가 검증 불가. Variant라면 exhaustive match 누락이 컴파일 에러.

## 구조

```
Tool_name.t
├── Keeper of Keeper.t   (45 variants: Shell, Bash, Fs_edit, ...)
├── Masc of Masc.t       (85 variants: Status, Join, Code_git, ...)
└── Masc_keeper of Masc_keeper.t  (10 variants: Msg, Up, Down, ...)
```

## 테스트

- Roundtrip: `of_string (to_string t) = Some t` 전체 130개
- Prefix invariant: `keeper_*`, `masc_*`, `masc_keeper_*` prefix 검증
- Uniqueness: 중복 이름 없음
- Shard coverage: `Tool_shard` 스키마의 모든 도구가 `of_string`으로 파싱 가능
- Unknown fail-closed: 미등록 문자열 → `None`

## 마이그레이션 로드맵

| Phase | 대상 | 예상 |
|-------|------|------|
| **1 (이 PR)** | 모듈 정의 + 테스트 | 0 breaking change |
| 2 | `keeper_tool_registry.ml` dispatch 변환 | 1 파일 |
| 3 | governance, prefilter, catalog 변환 | 5 파일 |
| 4 | 나머지 lib/ + test/ | ~20 파일 |

## Test plan

- [x] `dune exec test/test_tool_name.exe` — 11/11 pass
- [x] `dune runtest` — 전체 pass (exit 0)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)