### PR TITLE
feat(dashboard): observation buffer fill-level gauge

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -16,6 +16,7 @@ import {
   type HubState,
   initialHubState,
   fmtDuration,
+  MAX_OBSERVATIONS,
 } from './fsm-hub-types'
 import {
   observeSnapshot,
@@ -404,8 +405,23 @@ function StatusBar({
           <span class=${`px-1.5 py-0.5 rounded border ${transitionCount > 0 ? 'border-[rgba(129,140,248,0.3)] text-[#818cf8]' : 'border-[var(--white-8)] text-[var(--text-dim)]'}`}>
             ${transitionCount} 전환
           </span>
-          <span class="px-1.5 py-0.5 rounded border border-[var(--white-8)] text-[var(--text-dim)]">
-            ${observationCount} 관측
+          <span
+            class=${`relative px-1.5 py-0.5 rounded border overflow-hidden ${
+              observationCount >= MAX_OBSERVATIONS
+                ? 'border-[rgba(245,158,11,0.4)] text-[#f59e0b]'
+                : 'border-[var(--white-8)] text-[var(--text-dim)]'
+            }`}
+            title=${`관측 버퍼 ${observationCount}/${MAX_OBSERVATIONS} — 가득 차면 오래된 관측부터 순환 교체됩니다`}
+          >
+            <span
+              class=${`absolute inset-0 ${
+                observationCount >= MAX_OBSERVATIONS
+                  ? 'bg-[rgba(245,158,11,0.08)]'
+                  : 'bg-[rgba(255,255,255,0.03)]'
+              }`}
+              style=${`width: ${Math.round((observationCount / MAX_OBSERVATIONS) * 100)}%`}
+            ></span>
+            <span class="relative">${observationCount}/${MAX_OBSERVATIONS} 관측</span>
           </span>
           ${/* Meta IDs */ ''}
           <span class="text-[var(--text-dim)] opacity-60">corr ${snapshot.correlation_id?.slice(-8) ?? '?'}</span>


### PR DESCRIPTION
## Summary

- Upgrade plain "N 관측" badge to "N/30 관측" with background fill bar
- Amber shift at buffer full (30/30) — signals observation eviction
- Tooltip explains ring buffer cycling

## Why

Operators need to know whether the observation window has enough data for meaningful dwell/transition analysis. A freshly selected keeper shows "2/30" — the dwell histogram is based on ~60 seconds of data. At "30/30" the window is saturated and old samples are cycling out.

Pattern follows Grafana stat panels / Datadog host map capacity indicators: inline fraction text with CSS width% background fill.

## Changes

- `fsm-hub.ts` — StatusBar badge upgrade (18 lines added, 2 removed)
- No new types, derivers, or test files needed (pure presentation change)

## Verification

- `pnpm typecheck` → clean
- `pnpm test` → 659/659 pass
- `pnpm lint` → clean

## Test plan

- [ ] Select a keeper, confirm badge shows "N/30 관측"
- [ ] Background fill width proportional to N
- [ ] At 30/30, border turns amber and fill is visible
- [ ] Hover shows Korean tooltip about cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)