### PR TITLE
feat(dashboard): cumulative invariant violation counts

### DIFF
--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -1,8 +1,9 @@
 import { html } from 'htm/preact'
 
-import type { KeeperCompositeSnapshot } from '../api/keeper'
+import type { KeeperCompositeSnapshot, KeeperCompositeInvariants } from '../api/keeper'
 
 import { invariantRows } from './fsm-hub-invariant-analysis'
+import type { InvariantViolationCounts } from './fsm-hub-types'
 
 /** Human-readable descriptions for MeasurementCard auto-rule flags.
     Indexed by rule name -> { on: "this fires next turn", off: "nothing
@@ -103,7 +104,15 @@ export function invariantDescription(key: string): string {
   return INVARIANT_DESCRIPTIONS[key] ?? 'Invariant defined by the keeper composite contract.'
 }
 
-export function InvariantsPanel({ snapshot }: { snapshot: KeeperCompositeSnapshot }) {
+export function InvariantsPanel({
+  snapshot,
+  violationCounts,
+  sampleCount,
+}: {
+  snapshot: KeeperCompositeSnapshot
+  violationCounts: InvariantViolationCounts
+  sampleCount: number
+}) {
   const entries = invariantRows(snapshot)
   const okCount = entries.filter(entry => entry.ok).length
   const total = entries.length
@@ -131,13 +140,24 @@ export function InvariantsPanel({ snapshot }: { snapshot: KeeperCompositeSnapsho
       <ul class="flex flex-col gap-1">
         ${entries.map(entry => {
           const desc = invariantDescription(entry.key)
-          const tooltip = `${entry.label} — ${entry.ok ? 'holds' : 'BROKEN'}\n${desc}`
+          const vCount = violationCounts[entry.key as keyof KeeperCompositeInvariants] ?? 0
+          const rate = sampleCount > 0
+            ? `${vCount}/${sampleCount} 위반`
+            : ''
+          const tooltip = `${entry.label} — ${entry.ok ? 'holds' : 'BROKEN'}\n${desc}${rate ? `\n누적: ${rate}` : ''}`
           return html`
             <li class="flex gap-2 text-[10px] cursor-help" title=${tooltip}>
               <span class=${`mt-[5px] h-1.5 w-1.5 rounded-full shrink-0 ${entry.ok ? 'bg-[#22c55e]' : 'bg-[#ef4444]'}`}></span>
-              <div class="min-w-0">
-                <div class=${entry.ok ? 'text-[var(--text-body)]' : 'text-[#f87171] font-semibold'}>
-                  ${entry.label}
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-1.5">
+                  <span class=${entry.ok ? 'text-[var(--text-body)]' : 'text-[#f87171] font-semibold'}>
+                    ${entry.label}
+                  </span>
+                  ${vCount > 0 ? html`
+                    <span class="ml-auto text-[8px] font-mono tabular-nums text-[#f87171]">
+                      ${vCount}/${sampleCount}
+                    </span>
+                  ` : null}
                 </div>
                 <div class="text-[8px] leading-relaxed text-[var(--text-dim)]">
                   ${entry.detail}

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -75,6 +75,8 @@ export type ObservedLaneSummary = {
   transitionCount: number
 }
 
+export type InvariantViolationCounts = Record<keyof KeeperCompositeInvariants, number>
+
 export type HubState = {
   keeperName: string | null
   snapshot: KeeperCompositeSnapshot | null
@@ -82,6 +84,8 @@ export type HubState = {
   error: string | null
   lastFetchAt: number
   observations: CompositeObservation[]
+  invariantSampleCount: number
+  invariantViolations: InvariantViolationCounts
 }
 
 export type HubAction =
@@ -92,6 +96,14 @@ export type HubAction =
 export const MAX_OBSERVATIONS = 30
 export const MAX_TRANSITION_HISTORY = 20
 
+const ZERO_VIOLATIONS: InvariantViolationCounts = {
+  phase_turn_alignment: 0,
+  no_cascade_before_measurement: 0,
+  compaction_atomicity: 0,
+  event_priority_monotone: 0,
+  recovery_two_store_sync: 0,
+}
+
 export const initialHubState: HubState = {
   keeperName: null,
   snapshot: null,
@@ -99,6 +111,8 @@ export const initialHubState: HubState = {
   error: null,
   lastFetchAt: 0,
   observations: [],
+  invariantSampleCount: 0,
+  invariantViolations: { ...ZERO_VIOLATIONS },
 }
 
 export const TRANSITION_FIELDS: Array<{ field: string; key: LaneKey }> = [

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -94,6 +94,11 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
       }
     case 'fetch_succeeded': {
       const observation = observeSnapshot(action.snapshot, action.fetchedAt)
+      const inv = action.snapshot.invariants
+      const violations = { ...current.invariantViolations }
+      for (const key of Object.keys(violations) as Array<keyof typeof violations>) {
+        if (!inv[key]) violations[key] += 1
+      }
       return {
         keeperName: action.keeperName,
         snapshot: action.snapshot,
@@ -101,6 +106,8 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
         error: null,
         lastFetchAt: action.fetchedAt,
         observations: appendCompositeObservation(current.observations, observation),
+        invariantSampleCount: current.invariantSampleCount + 1,
+        invariantViolations: violations,
       }
     }
     case 'fetch_failed':
@@ -303,7 +310,11 @@ export function FsmHub() {
         <${CollapsibleZone} id="health-grid" title="상태 격자" defaultOpen=${true}>
           <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
             <${MeasurementCard} snapshot=${snapshot} />
-            <${InvariantsPanel} snapshot=${snapshot} />
+            <${InvariantsPanel}
+              snapshot=${snapshot}
+              violationCounts=${view.invariantViolations}
+              sampleCount=${view.invariantSampleCount}
+            />
             <${RecoveryStatePanel}
               dataRecord=${snapshot.recovery.data_record}
               fsmCondition=${snapshot.recovery.fsm_condition}


### PR DESCRIPTION
## Summary

- Track per-invariant violation frequency across the observation session
- Display "N/M" (violated/sampled) red counter next to each invariant row
- Tooltip includes cumulative count in Korean ("누적: N/M 위반")

## Why

Boolean snapshot shows only *current* state — a transient violation that appeared once in 50 samples looks identical to a persistent one that fires every sample. The violation counter differentiates:
- **1/50** — rare, likely transient race condition during compaction
- **47/50** — persistent, indicates a real invariant drift needing investigation

## Changes

- `fsm-hub-types.ts` — `InvariantViolationCounts` type, HubState fields
- `fsm-hub.ts` — reducer increments counts on each `fetch_succeeded`
- `fsm-hub-health-panels.ts` — InvariantsPanel accepts + renders counts

## Verification

- `pnpm typecheck` → clean
- `pnpm test` → 663/663 pass
- `pnpm lint` → clean

## Test plan

- [ ] Select a keeper, verify invariant rows show no counter initially (all 0)
- [ ] After multiple polling cycles, counters remain 0 if all invariants hold
- [ ] Simulate broken invariant (e.g. Compacting phase + executing turn) → red "N/M" appears
- [ ] Hover invariant row → tooltip shows "누적: N/M 위반"

🤖 Generated with [Claude Code](https://claude.com/claude-code)