### PR TITLE
fix(concurrency): Atomic.t for cross-domain shell cache + Eio.Mutex for voice sessions

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -5,15 +5,16 @@ open Server_utils
 open Server_dashboard_http_core
 
 (** Track whether shell cache has been populated at least once.
-    Used for adaptive timeout in namespace-truth: cold path gets more time. *)
-let _shell_warmed = ref false
+    Atomic.t for cross-domain visibility: read from executor pool
+    worker domain via [namespace_truth_snapshot_from_caches].
+    Monotonic false→true; stale false just picks the cold timeout. *)
+let _shell_warmed : bool Atomic.t = Atomic.make false
 
 (** Last-known-good shell result for graceful degradation on timeout.
-    When the shell fiber times out (I/O contention), returning the stale
-    shell JSON is strictly better than returning empty [`Assoc []] which
-    zeros out namespace counts and focus data. Updated on every successful
-    shell fetch. *)
-let _last_good_shell : Yojson.Safe.t ref = ref (`Assoc [])
+    Atomic.t for cross-domain visibility (same reason as [_shell_warmed]).
+    Each update swaps a fully-constructed Yojson.Safe.t value;
+    readers always see a complete snapshot. *)
+let _last_good_shell : Yojson.Safe.t Atomic.t = Atomic.make (`Assoc [])
 
 let warm_shell_cache (state : Mcp_server.server_state) =
   let t0 = Time_compat.now () in
@@ -22,8 +23,8 @@ let warm_shell_cache (state : Mcp_server.server_state) =
        dashboard_shell_http_json ?clock:state.Mcp_server.clock
          state.Mcp_server.room_config
      in
-     _shell_warmed := true;
-     _last_good_shell := result;
+     Atomic.set _shell_warmed true;
+     Atomic.set _last_good_shell result;
      Log.Dashboard.info "shell cache pre-warmed (%.1fms)"
        ((Time_compat.now () -. t0) *. 1000.0)
    with

--- a/lib/server/server_dashboard_http_namespace_truth.ml
+++ b/lib/server/server_dashboard_http_namespace_truth.ml
@@ -80,13 +80,13 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
            fiber also fires, discarding even stale data.  Fixes #5090. *)
         let shell_fiber_timeout_s = 12.0 in
         let shell_timeout_s =
-          if !(Execution_surfaces._shell_warmed) then shell_fiber_timeout_s
+          if Atomic.get Execution_surfaces._shell_warmed then shell_fiber_timeout_s
           else Float.max cold_timeout_s (shell_fiber_timeout_s +. 4.0)
         in
         (* Graceful degradation: on timeout fall back to the last successful
            shell result rather than empty JSON, which would zero out namespace
            counts and focus data (61x/day under I/O contention). *)
-        let shell_fallback = !(Execution_surfaces._last_good_shell) in
+        let shell_fallback = Atomic.get Execution_surfaces._last_good_shell in
         (* Sequential fetch to avoid PG connection concurrent usage (#3305). *)
         shell_ref :=
           fiber_with_timeout ~timeout_s:shell_timeout_s "shell"
@@ -99,9 +99,9 @@ let dashboard_namespace_truth_http_json ~state ~sw:_ ~clock _request =
         let shell_json = !shell_ref in
         (* Update last-known-good shell on success. *)
         if shell_json <> `Assoc [] && shell_json <> shell_fallback then
-          Execution_surfaces._last_good_shell := shell_json;
-        if (not !(Execution_surfaces._shell_warmed)) && shell_json <> `Assoc [] then
-          Execution_surfaces._shell_warmed := true;
+          Atomic.set Execution_surfaces._last_good_shell shell_json;
+        if (not (Atomic.get Execution_surfaces._shell_warmed)) && shell_json <> `Assoc [] then
+          Atomic.set Execution_surfaces._shell_warmed true;
         let execution_json = !execution_ref in
         let command_summary_json = !command_ref in
         let parallel_ms = (Time_compat.now () -. t0) *. 1000.0 in
@@ -137,14 +137,14 @@ let namespace_truth_snapshot_from_caches (state : Mcp_server.server_state) :
   else
     let config = state.Mcp_server.room_config in
     let shell_json =
-      if !(Execution_surfaces._shell_warmed) then
+      if Atomic.get Execution_surfaces._shell_warmed then
         (try
            let result = dashboard_shell_http_json ?clock:state.Mcp_server.clock config in
-           Execution_surfaces._last_good_shell := result;
+           Atomic.set Execution_surfaces._last_good_shell result;
            result
          with Eio.Cancel.Cancelled _ as e -> raise e
-            | _ -> !(Execution_surfaces._last_good_shell))
-      else !(Execution_surfaces._last_good_shell)
+            | _ -> Atomic.get Execution_surfaces._last_good_shell)
+      else Atomic.get Execution_surfaces._last_good_shell
     in
     let execution_json = cached_surface_json Execution_surfaces._execution_cache in
     let command_summary_json =

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -28,7 +28,7 @@ type t = {
   sessions: (string, session) Hashtbl.t;  (* agent_id -> session *)
   config_path: string;
   session_dir: string;
-  sessions_mu: Stdlib.Mutex.t;
+  sessions_mu: Eio.Mutex.t;
   (** Serialises every read/write on [sessions] and every mutation of
       the [mutable] fields of a [session] value.  Keeper fibers call
       start_session / heartbeat / end_session / cleanup_zombies from
@@ -36,8 +36,8 @@ type t = {
       races on TOCTOU ([find_opt] + [add]) and the session record's
       mutable [turn_count]/[last_activity]/[status] are non-atomic.
 
-      Stdlib.Mutex so callers on Executor_pool worker domains can
-      still take the lock (Eio.Mutex is single-domain). *)
+      Eio.Mutex via [Eio_guard.with_mutex] so contending fibers
+      suspend instead of blocking the whole domain during file I/O. *)
 }
 
 (** {1 Utilities} *)
@@ -94,14 +94,11 @@ let create ~config_path =
     sessions = Hashtbl.create 16;
     config_path;
     session_dir;
-    sessions_mu = Stdlib.Mutex.create ();
+    sessions_mu = Eio.Mutex.create ();
   }
 
 let with_lock t f =
-  Stdlib.Mutex.lock t.sessions_mu;
-  Fun.protect
-    ~finally:(fun () -> Stdlib.Mutex.unlock t.sessions_mu)
-    f
+  Eio_guard.with_mutex t.sessions_mu f
 
 (** {1 Internal Helpers} *)
 

--- a/test/test_dashboard_namespace_truth.ml
+++ b/test/test_dashboard_namespace_truth.ml
@@ -570,7 +570,7 @@ let test_last_good_shell_fallback_preserves_counts () =
       warm_execution_cache ();
       (* Warm the shell cache so _last_good_shell gets populated. *)
       Lib.Server_dashboard_http.warm_shell_cache state;
-      let last_good = !(Lib.Server_dashboard_http._last_good_shell) in
+      let last_good = Atomic.get Lib.Server_dashboard_http._last_good_shell in
       check bool "last good shell is non-empty after warm"
         true
         (last_good <> `Assoc []);
@@ -582,7 +582,7 @@ let test_last_good_shell_fallback_preserves_counts () =
         (counts <> `Null);
       (* Verify namespace-truth snapshot_from_caches uses the stale shell data
          even when the warmed flag is false (cold path, simulating timeout). *)
-      Lib.Server_dashboard_http._shell_warmed := false;
+      Atomic.set Lib.Server_dashboard_http._shell_warmed false;
       let snapshot =
         match Lib.Server_dashboard_http.namespace_truth_snapshot_from_caches state with
         | Some json -> json
@@ -595,7 +595,7 @@ let test_last_good_shell_fallback_preserves_counts () =
         true
         (ns_counts <> `Null);
       (* Restore warmed state for subsequent tests. *)
-      Lib.Server_dashboard_http._shell_warmed := true)
+      Atomic.set Lib.Server_dashboard_http._shell_warmed true)
 
 let test_namespace_truth_snapshot_hash_ignores_generated_at () =
   Fun.protect


### PR DESCRIPTION
## Summary
- **execution_surfaces**: `_shell_warmed` and `_last_good_shell` were bare `ref`s read/written from executor pool worker domains (via `namespace_truth_snapshot_from_caches`) without memory barriers. Converted to `Atomic.t` — lock-free, cross-domain visible, no hot-path overhead.
- **voice_session_manager**: `Stdlib.Mutex` held across `save_session` file I/O (6 call sites). Replaced with `Eio.Mutex` via `Eio_guard.with_mutex` — fiber-suspending instead of domain-freezing. Also corrected stale docstring claiming "Eio.Mutex is single-domain" (incorrect).

## Evidence path
Traced from `run_dashboard_compute` (only multi-domain entry point, `Executor_pool.create ~domain_count:2`) through its closure call graph to find mutable state accessed without barriers.

## Test plan
- [x] `dune build` (full)
- [x] `test_dashboard_execution` — 12/12 OK
- [x] `test_dashboard_namespace_truth` — 13/13 OK (test updated to use Atomic API)
- [ ] CI green