### PR TITLE
refactor(keeper): convert execution_scope from string to typed variant

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -966,7 +966,7 @@ let keeper_config_json (config : Room.config) (name : string)
       (`OK,
        `Assoc [
          ("name", `String m.name);
-         ("execution_scope", `String m.execution_scope);
+         ("execution_scope", `String (Keeper_execution_scope.to_string m.execution_scope));
          ("allowed_paths",
            `List (List.map (fun s -> `String s) m.allowed_paths));
          ("effective_allowed_paths",

--- a/lib/dune
+++ b/lib/dune
@@ -386,6 +386,7 @@
    eval_calibration
    ;; Keeper contract
    keeper_schema
+   keeper_execution_scope
    keeper_social_model
    keeper_cascade_profile
    keeper_cascade_routing

--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -91,7 +91,7 @@ let validate_name name =
   let re = Re.Pcre.re "^[A-Za-z0-9._-]+$" |> Re.compile in
   name <> "" && Re.execp re name
 
-let default_execution_scope = "workspace"
+let default_execution_scope = Keeper_execution_scope.Workspace
 let default_proactive_enabled = true
 let default_proactive_idle_sec = 120
 let default_proactive_cooldown_sec = 300

--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -36,7 +36,7 @@ val alert_reply_preview_max_chars : int
 
 val tool_policy_count_warn_threshold : int
 val tool_first_sentence_max_chars : int
-val default_execution_scope : string
+val default_execution_scope : Keeper_execution_scope.t
 val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int

--- a/lib/keeper/keeper_exec_masc.ml
+++ b/lib/keeper/keeper_exec_masc.ml
@@ -28,9 +28,9 @@ let keeper_masc_path_blocked
       ~(args : Yojson.Safe.t)
   =
   let effective_paths = keeper_effective_write_allowed_paths ~meta in
-  if effective_paths = [] && meta.execution_scope <> "observe_only"
+  if effective_paths = [] && meta.execution_scope <> Keeper_execution_scope.Observe_only
   then None
-  else if meta.execution_scope = "observe_only" && effective_paths = []
+  else if meta.execution_scope = Keeper_execution_scope.Observe_only && effective_paths = []
   then (
     let has_path_arg =
       List.exists

--- a/lib/keeper/keeper_execution_scope.ml
+++ b/lib/keeper/keeper_execution_scope.ml
@@ -1,0 +1,37 @@
+(** Typed execution scope for keeper agents. *)
+
+type t =
+  | Observe_only
+  | Workspace
+  | Local
+
+let default = Workspace
+
+let all = [ Observe_only; Workspace; Local ]
+
+let to_string = function
+  | Observe_only -> "observe_only"
+  | Workspace -> "workspace"
+  | Local -> "local"
+
+let of_string s =
+  match String.lowercase_ascii (String.trim s) with
+  | "observe_only" -> Ok Observe_only
+  | "workspace" -> Ok Workspace
+  | "local" -> Ok Local
+  | _ -> Error (`Unknown_scope s)
+
+let of_string_lossy ?(default = Workspace) s =
+  match of_string s with
+  | Ok v -> v
+  | Error (`Unknown_scope raw) ->
+    Log.Keeper.warn "unknown execution_scope %S, falling back to %s"
+      raw (to_string default);
+    default
+
+let equal a b =
+  match (a, b) with
+  | Observe_only, Observe_only -> true
+  | Workspace, Workspace -> true
+  | Local, Local -> true
+  | _ -> false

--- a/lib/keeper/keeper_execution_scope.mli
+++ b/lib/keeper/keeper_execution_scope.mli
@@ -1,0 +1,28 @@
+(** Typed execution scope for keeper agents.
+
+    Replaces the previous [string] representation to prevent typos and
+    silent fallthrough on unknown values (Parse, Don't Validate). *)
+
+type t =
+  | Observe_only
+  | Workspace
+  | Local
+
+val default : t
+
+(** All valid scopes, in declaration order. *)
+val all : t list
+
+(** Wire-compatible string representation (byte-identical to the legacy
+    string values: ["observe_only"], ["workspace"], ["local"]). *)
+val to_string : t -> string
+
+(** Parse from string.  Returns [Error (`Unknown_scope s)] for
+    unrecognised inputs. *)
+val of_string : string -> (t, [ `Unknown_scope of string ]) result
+
+(** Parse from string with a fallback default (default: {!default}).
+    Logs a warning on unknown input via [Log.Keeper.warn]. *)
+val of_string_lossy : ?default:t -> string -> t
+
+val equal : t -> t -> bool

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -101,7 +101,7 @@ let keeper_schemas : tool_schema list = [
         ("handoff_cooldown_sec", `Assoc [("type", `String "integer")]);
         ("execution_scope", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "observe_only"; `String "workspace"; `String "local"]);
+          ("enum", `List (Keeper_execution_scope.all |> List.map (fun s -> `String (Keeper_execution_scope.to_string s))));
         ]);
         ("allowed_paths", `Assoc [
           ("type", `String "array");
@@ -235,7 +235,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("execution_scope", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "observe_only"; `String "workspace"; `String "local"]);
+          ("enum", `List (Keeper_execution_scope.all |> List.map (fun s -> `String (Keeper_execution_scope.to_string s))));
           ("description", `String "Execution scope. 'observe_only' blocks all writes. 'workspace'/'local' enable writes within playground (.masc/playground/<name>/). Extra paths must be listed explicitly in allowed_paths. Default: workspace.");
         ]);
         ("allowed_paths", `Assoc [

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1063,7 +1063,7 @@ let handle_keeper_status ctx args : tool_result =
            "execution_context", `Assoc [
              ("playground_path", `String playground_rel);
              ("default_cwd", `String playground_abs);
-             ("execution_scope", `String m.execution_scope);
+             ("execution_scope", `String (Keeper_execution_scope.to_string m.execution_scope));
              ("allowed_paths", string_list_to_json m.allowed_paths);
              ("playground_repos",
                let cache_path = Filename.concat playground_abs

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -17,7 +17,7 @@ type parsed_args = {
   policy_voice_enabled_opt : bool option;
   allowed_paths_opt : string list option;
   autoboot_enabled_opt : bool option;
-  execution_scope_opt : string option;
+  execution_scope_opt : Keeper_execution_scope.t option;
   voice_enabled_opt : bool option;
   voice_channel_opt : string option;
   voice_agent_id_opt : string option;
@@ -189,7 +189,15 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
     let long_goal_opt = parse_goal_horizon_opt args "long_goal" in
     let policy_voice_enabled_opt = get_bool_opt args "policy_voice_enabled" in
     let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
-    let execution_scope_opt = get_string_opt args "execution_scope" in
+    let execution_scope_opt =
+      get_string_opt args "execution_scope"
+      |> Option.map (fun s ->
+        match Keeper_execution_scope.of_string s with
+        | Ok v -> v
+        | Error (`Unknown_scope raw) ->
+          Log.Keeper.warn "keeper_up: unknown execution_scope %S, using default" raw;
+          Keeper_execution_scope.default)
+    in
     let voice_enabled_opt = get_bool_opt args "voice_enabled" in
     let voice_channel_opt = get_string_opt args "voice_channel" in
     let voice_agent_id_opt = get_string_opt args "voice_agent_id" in

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -136,7 +136,7 @@ type keeper_meta =
   ; instructions : string
   ; (* -- Policy -- *)
     policy_voice_enabled : bool
-  ; execution_scope : string
+  ; execution_scope : Keeper_execution_scope.t
   ; allowed_paths : string list
   ; tool_access : tool_access
   ; tool_denylist : string list
@@ -670,7 +670,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "desires", `String m.desires
     ; "instructions", `String m.instructions
     ; "policy_voice_enabled", `Bool m.policy_voice_enabled
-    ; "execution_scope", `String m.execution_scope
+    ; "execution_scope", `String (Keeper_execution_scope.to_string m.execution_scope)
     ; "allowed_paths", `List (List.map (fun s -> `String s) m.allowed_paths)
     ; "tool_access", tool_access_to_json m.tool_access
     ; "tool_denylist", `List (List.map (fun s -> `String s) m.tool_denylist)
@@ -777,7 +777,7 @@ type parsed_keeper_identity =
 
 type parsed_keeper_policy =
   { pp_policy_voice_enabled : bool
-  ; pp_execution_scope : string
+  ; pp_execution_scope : Keeper_execution_scope.t
   ; pp_allowed_paths : string list
   ; pp_tool_access : tool_access
   ; pp_tool_denylist : string list
@@ -897,7 +897,8 @@ let parse_keeper_policy (json : Yojson.Safe.t) ~(keeper_name : string)
       Safe_ops.json_bool ~default:voice_enabled_default "policy_voice_enabled" json
     in
     let pp_execution_scope =
-      Safe_ops.json_string ~default:default_execution_scope "execution_scope" json
+      Safe_ops.json_string ~default:(Keeper_execution_scope.to_string default_execution_scope) "execution_scope" json
+      |> Keeper_execution_scope.of_string_lossy
     in
     let pp_allowed_paths = Safe_ops.json_string_list "allowed_paths" json in
     let pp_tool_denylist = Safe_ops.json_string_list "tool_denylist" json in

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -135,7 +135,7 @@ type keeper_meta = {
   desires: string;
   instructions: string;
   policy_voice_enabled: bool;
-  execution_scope: string;
+  execution_scope: Keeper_execution_scope.t;
   allowed_paths: string list;
   tool_access: tool_access;
   tool_denylist: string list;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -139,7 +139,7 @@ type keeper_profile_defaults = {
   room_signal_prompt_enabled : bool option;
   shards : string list option;
   allowed_paths : string list option;
-  execution_scope : string option;
+  execution_scope : Keeper_execution_scope.t option;
   tool_preset : string option;
   tool_also_allow : string list option;
   tool_denylist : string list option;
@@ -310,7 +310,9 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         allowed_paths =
           if has "allowed_paths" then Some (strs "allowed_paths")
           else None;
-        execution_scope = str "execution_scope";
+        execution_scope =
+          Option.map Keeper_execution_scope.of_string_lossy
+            (str "execution_scope");
         tool_preset =
           (match str "tool_preset" with
            | None -> None
@@ -430,7 +432,9 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 (* Persona profiles are not allowed to own execution allowlists.
                    Keep these in keeper TOML / runtime config only. *)
                 allowed_paths = None;
-                execution_scope = Safe_ops.json_string_opt "execution_scope" keeper_json;
+                execution_scope =
+                  Option.map Keeper_execution_scope.of_string_lossy
+                    (Safe_ops.json_string_opt "execution_scope" keeper_json);
                 tool_preset =
                   (match Safe_ops.json_string_opt "tool_preset" keeper_json with
                   | None -> None

--- a/test/dune
+++ b/test/dune
@@ -55,6 +55,7 @@
         test_keeper_registry
         test_keeper_supervisor
         test_keeper_allowed_paths
+        test_keeper_execution_scope
         test_playground_paths
         test_keeper_llama_only
         test_keeper_meta_cwd_resilience
@@ -137,6 +138,7 @@
           test_keeper_registry
           test_keeper_supervisor
           test_keeper_allowed_paths
+          test_keeper_execution_scope
           test_playground_paths
           test_keeper_llama_only
           test_keeper_meta_cwd_resilience

--- a/test/test_keeper_execution_scope.ml
+++ b/test/test_keeper_execution_scope.ml
@@ -1,0 +1,84 @@
+(** Unit tests for Keeper_execution_scope typed variant.
+
+    Verifies round-trip encoding, unknown rejection, case normalization,
+    and wire-compatibility with the legacy string representation. *)
+
+open Alcotest
+module KES = Masc_mcp.Keeper_execution_scope
+
+let scope_testable =
+  testable
+    (fun fmt v -> Format.pp_print_string fmt (KES.to_string v))
+    KES.equal
+
+let test_roundtrip () =
+  List.iter
+    (fun scope ->
+       let s = KES.to_string scope in
+       match KES.of_string s with
+       | Ok back -> check scope_testable ("roundtrip " ^ s) scope back
+       | Error (`Unknown_scope u) ->
+           fail (Printf.sprintf "of_string rejected its own output: %S" u))
+    KES.all
+
+let test_wire_values () =
+  check string "observe_only wire" "observe_only" (KES.to_string Observe_only);
+  check string "workspace wire" "workspace" (KES.to_string Workspace);
+  check string "local wire" "local" (KES.to_string Local)
+
+let test_case_normalization () =
+  check (result scope_testable reject)
+    "OBSERVE_ONLY" (Ok KES.Observe_only) (KES.of_string "OBSERVE_ONLY");
+  check (result scope_testable reject)
+    "Workspace" (Ok KES.Workspace) (KES.of_string "Workspace");
+  check (result scope_testable reject)
+    "  LOCAL  " (Ok KES.Local) (KES.of_string "  LOCAL  ")
+
+let test_unknown_rejected () =
+  match KES.of_string "playground" with
+  | Error (`Unknown_scope _) -> ()
+  | Ok v ->
+      fail
+        (Printf.sprintf "expected Error for 'playground', got Ok %s"
+           (KES.to_string v))
+
+let test_lossy_default () =
+  check scope_testable
+    "lossy unknown → default"
+    KES.Workspace
+    (KES.of_string_lossy "garbage");
+  check scope_testable
+    "lossy unknown → custom default"
+    KES.Local
+    (KES.of_string_lossy ~default:KES.Local "garbage");
+  check scope_testable
+    "lossy valid → parsed"
+    KES.Observe_only
+    (KES.of_string_lossy "observe_only")
+
+let test_default_is_workspace () =
+  check scope_testable "default" KES.Workspace KES.default
+
+let test_all_exhaustive () =
+  check int "all length" 3 (List.length KES.all);
+  List.iter
+    (fun scope ->
+       let found = List.exists (KES.equal scope) KES.all in
+       check bool ("all contains " ^ KES.to_string scope) true found)
+    [ KES.Observe_only; KES.Workspace; KES.Local ]
+
+let () =
+  run "Keeper_execution_scope"
+    [ "roundtrip", [ test_case "to_string -> of_string" `Quick test_roundtrip ]
+    ; "wire", [ test_case "legacy wire values" `Quick test_wire_values ]
+    ; "normalization",
+      [ test_case "case and whitespace" `Quick test_case_normalization ]
+    ; "rejection",
+      [ test_case "unknown scope rejected" `Quick test_unknown_rejected ]
+    ; "lossy",
+      [ test_case "of_string_lossy fallback" `Quick test_lossy_default ]
+    ; "default",
+      [ test_case "default is Workspace" `Quick test_default_is_workspace ]
+    ; "all",
+      [ test_case "all variants present" `Quick test_all_exhaustive ]
+    ]

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -113,7 +113,7 @@ let test_policy_resync () =
     (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
 {|[keeper]
 goal = "test"
-execution_scope = "playground"
+execution_scope = "observe_only"
 policy_voice_enabled = false
 |};
   let config = Room.default_config room_dir in
@@ -125,7 +125,7 @@ policy_voice_enabled = false
             ("name", `String keeper_name);
             ("agent_name", `String keeper_name);
             ("trace_id", `String "trace-policy-resync");
-            ("execution_scope", `String "standard");
+            ("execution_scope", `String "local");
             ("policy_voice_enabled", `Bool true);
           ])
     with
@@ -135,10 +135,15 @@ policy_voice_enabled = false
   (match Keeper_types.write_meta ~force:true config initial_meta with
   | Error e -> fail ("write_meta failed: " ^ e)
   | Ok () -> ());
+  let execution_scope_testable =
+    Alcotest.testable
+      (fun fmt v -> Format.pp_print_string fmt (Keeper_execution_scope.to_string v))
+      Keeper_execution_scope.equal
+  in
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
-      check string "execution_scope" "playground" updated.Keeper_types.execution_scope;
+      check execution_scope_testable "execution_scope" Keeper_execution_scope.Observe_only updated.Keeper_types.execution_scope;
       check bool "policy_voice_enabled" false updated.policy_voice_enabled
 
 (** Test: TOML tool policy and allowed_paths overwrite stale runtime JSON values. *)
@@ -439,7 +444,7 @@ tool_preset = "delivery"
         updated.mention_targets;
       check string "execution_scope from toml"
         "workspace"
-        updated.execution_scope;
+        (Keeper_execution_scope.to_string updated.execution_scope);
       check
         (option string)
         "tool_preset from toml overlay"
@@ -475,7 +480,7 @@ goal = "minimal TOML"
             ("goal", `String "old goal");
             ("will", `String "runtime will");
             ("instructions", `String "runtime instructions");
-            ("execution_scope", `String "playground");
+            ("execution_scope", `String "local");
           ])
     with
     | Ok meta -> meta
@@ -484,6 +489,11 @@ goal = "minimal TOML"
   (match Keeper_types.write_meta ~force:true config initial_meta with
   | Error e -> fail ("write_meta failed: " ^ e)
   | Ok () -> ());
+  let execution_scope_testable =
+    Alcotest.testable
+      (fun fmt v -> Format.pp_print_string fmt (Keeper_execution_scope.to_string v))
+      Keeper_execution_scope.equal
+  in
   match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -494,7 +504,7 @@ goal = "minimal TOML"
       (* instructions was NOT in TOML → preserved from runtime *)
       check string "instructions preserved" "runtime instructions" updated.instructions;
       (* execution_scope was NOT in TOML → preserved from runtime *)
-      check string "execution_scope preserved" "playground" updated.execution_scope
+      check execution_scope_testable "execution_scope preserved" Keeper_execution_scope.Local updated.execution_scope
 
 (** Test: TOML work_discovery fields overwrite stale option-typed meta fields. *)
 let test_discovery_resync () =


### PR DESCRIPTION
## Summary

Keeper의 `execution_scope` 필드를 `string`에서 typed OCaml variant `Keeper_execution_scope.t`로 전환.

- **Parse, Don't Validate 원칙 적용**: 오타나 알 수 없는 값이 런타임에 조용히 통과하는 문제를 컴파일 타임에 차단
- **Wire 호환성 유지**: `to_string` 출력이 기존 string 값(`observe_only`, `workspace`, `local`)과 byte-identical
- **Worker 레벨 미변경**: `Worker_types.execution_scope` (Observe_only | Limited_code_change | Autonomous)는 별도 타입이며 이 PR의 범위 밖

## Product impact

Keeper 운영자/API 클라이언트 관점:
- REST API 호환성 유지 (enum 값 동일)
- Dashboard JSON 출력 동일 (프론트엔드 변경 불필요)
- Unknown scope 값 전송 시 이전: 조용히 무시 → 이제: 경고 로그 + `Workspace` fallback
- TOML/persona profile에서 오타 시 경고 기록

내부 개발자 관점:
- 컴파일러가 exhaustive match 강제
- 새 scope 추가 시 match site 누락이 빌드 에러로 즉시 감지

## Evidence

### 변경 범위

| 영역 | 변경 |
|------|------|
| `Keeper_execution_scope` 모듈 | `.ml` + `.mli` 신규 생성 (variant 정의, `of_string`, `of_string_lossy`, `to_string`) |
| `keeper_config` | `default_execution_scope` 타입을 `Keeper_execution_scope.t`로 변경 |
| `keeper_types` / `.mli` | `keeper_meta.execution_scope` 필드 타입 변경 |
| `keeper_types_profile` | TOML/JSON persona reader에서 `of_string_lossy`로 파싱 |
| `keeper_turn_up_args` | REST boundary에서 `of_string` 파싱 (unknown → 경고 + default) |
| `keeper_exec_masc` | string 비교를 variant 비교로 전환 |
| `keeper_schema` | enum 리스트를 `Keeper_execution_scope.all`에서 생성 |
| `keeper_status_detail` / `dashboard_http_keeper` | JSON emit에서 `to_string` 사용 |

### 건드리지 않은 파일

- `lib/worker_types.ml`, `lib/worker_oas.ml`, `lib/worker_runtime_config.ml` — Worker 레벨 scope
- `lib/operator/operator_digest_types.ml` — operator는 string passthrough 유지

## Review evidence

### 로컬 검증

- [x] `dune build --root .` — clean (0 errors, 0 warnings)
- [x] `dune runtest --root .` — exit 0

### 단위 테스트

- [x] `test_keeper_execution_scope`: 7/7 pass (round-trip, wire 호환성, case 정규화, unknown 거부, lossy fallback, default, exhaustiveness)
- [x] `test_keeper_allowed_paths`: 20/20 pass
- [x] `test_keeper_runtime_config_ssot`: 11/11 pass (rebase 후 타입 업데이트 반영)
- [x] `test_keeper_lifecycle`: 33/33 pass
- [x] `test_keeper_supervisor`: 17/17 pass
- [x] `test_keeper_registry`: 50/50 pass

### CI 상태

Build and Test pass (8m59s), Lint pass (5m11s), Health pass (6m17s).

## Linked issue

Refs #7339 — playground-only allowlist 제거 (병합됨)
Refs #7345 — persona allowed_path 누출 차단 (병합됨)

이 PR은 위 두 PR에 이어지는 keeper 격리 강화 시리즈의 세 번째. Parse Don't Validate 적용으로 scope 필드에서 silent fallthrough 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)