### PR TITLE
refactor(keeper): use Tool_name variant in keeper_tool_registry

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -34,9 +34,9 @@ let keeper_voice_tool_schemas =
     wasted on meta-introspection instead of productive action.
     See #4961. *)
 let core_always_tools =
-  [ "keeper_context_status";
-    "keeper_stay_silent"; "keeper_tool_search";
-    "extend_turns" ]
+  List.map Tool_name.to_string
+    Tool_name.[ Keeper Context_status; Keeper Stay_silent; Keeper Tool_search ]
+  @ [ "extend_turns" ] (* OAS SDK-provided, not in Tool_name *)
 
 (** Core tools always visible to the LLM.  All other tools are
     discoverable on demand via [keeper_tool_search].
@@ -57,26 +57,28 @@ let core_always_tools =
     the model repeatedly observes but cannot find tools to act. *)
 let core_discovery_tools =
   core_always_tools @
-  [ (* Coordination *)
-    "keeper_broadcast"; "keeper_tasks_list";
-    "keeper_task_claim"; "keeper_task_done"; "keeper_task_create";
-    "keeper_memory_search";
-    (* Filesystem: read + write (action symmetry) *)
-    "keeper_fs_read"; "keeper_fs_edit";
-    (* Board: core interaction *)
-    "keeper_board_get"; "keeper_board_post";
-    "keeper_board_comment"; "keeper_board_vote"; "keeper_board_list";
-    (* Shell + VCS *)
-    "keeper_shell";
-    "keeper_pr_workflow"; "keeper_pr_submit";
-    "keeper_preflight_check";
-    (* Review *)
-    "keeper_pr_review_read"; "keeper_pr_review_comment"; "keeper_pr_review_reply";
-    (* Discovery fallback for meta/admin tools *)
-    "keeper_tools_list";
-    (* External search *)
-    "masc_web_search";
-  ]
+  List.map Tool_name.to_string
+    Tool_name.[
+      (* Coordination *)
+      Keeper Broadcast; Keeper Tasks_list;
+      Keeper Task_claim; Keeper Task_done; Keeper Task_create;
+      Keeper Memory_search;
+      (* Filesystem: read + write (action symmetry) *)
+      Keeper Fs_read; Keeper Fs_edit;
+      (* Board: core interaction *)
+      Keeper Board_get; Keeper Board_post;
+      Keeper Board_comment; Keeper Board_vote; Keeper Board_list;
+      (* Shell + VCS *)
+      Keeper Shell;
+      Keeper Pr_workflow; Keeper Pr_submit;
+      Keeper Preflight_check;
+      (* Review *)
+      Keeper Pr_review_read; Keeper Pr_review_comment; Keeper Pr_review_reply;
+      (* Discovery fallback for meta/admin tools *)
+      Keeper Tools_list;
+      (* External search *)
+      Masc Web_search;
+    ]
 
 let effective_core_tools () = core_discovery_tools
 
@@ -97,9 +99,9 @@ let is_core_always_tool (name : string) : bool =
 
     Non-shard tools (injected outside Tool_shard, e.g. keeper_tool_search)
     are listed explicitly below. *)
-let non_shard_read_only_tools = [
-  "keeper_tool_search";  (* injected by Keeper_tool_policy, not in any shard *)
-]
+let non_shard_read_only_tools =
+  List.map Tool_name.to_string
+    Tool_name.[ Keeper Tool_search ] (* injected by Keeper_tool_policy, not in any shard *)
 
 let keeper_read_only_tools =
   Tool_shard.all_read_only_keeper_tools () @ non_shard_read_only_tools
@@ -214,10 +216,10 @@ let git_action_of_input (input : Yojson.Safe.t) : string =
   | _ -> ""
 
 let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : bool =
-  (* keeper_shell with op=gh is input-aware: gh commands can mutate state
-     even though the tool itself is marked read-only by default. Check gh
-     op BEFORE the blanket read-only short-circuit. *)
-  if tool_name = "keeper_shell" && is_shell_gh_op input then
+  match Tool_name.of_string tool_name with
+  | Some (Keeper Shell) when is_shell_gh_op input ->
+    (* keeper_shell with op=gh is input-aware: gh commands can mutate state
+       even though the tool itself is marked read-only by default. *)
     let cmd = gh_effective_cmd input in
     let cmd_lower = String.lowercase_ascii cmd in
     if cmd_lower = "" then false
@@ -229,11 +231,11 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
         String.length cmd_lower >= String.length prefix
         && String.sub cmd_lower 0 (String.length prefix) = prefix
       ) gh_read_only_prefixes
-  else if is_effectively_read_only_tool tool_name then true
-  else match tool_name with
-  | "masc_code_git" -> List.mem (git_action_of_input input) git_read_only_actions
-  | "masc_worktree_list" -> true
-  | _ -> false
+  | Some (Masc Code_git) ->
+    if is_effectively_read_only_tool tool_name then true
+    else List.mem (git_action_of_input input) git_read_only_actions
+  | Some (Masc Worktree_list) -> true
+  | _ -> is_effectively_read_only_tool tool_name
 
 (* ── Input-aware mutation-boundary bypass ────────────────────
    Some tools do mutate state, but they should not open the
@@ -261,45 +263,31 @@ let is_main_worktree_boundary_exempt_with_input
     ~(input : Yojson.Safe.t) : bool =
   if is_read_only_with_input ~tool_name ~input then true
   else
-    match tool_name with
-    | "keeper_task_claim" | "keeper_task_done" | "keeper_task_create" | "keeper_tasks_list"
-    | "keeper_board_post" | "keeper_board_comment" | "keeper_board_vote"
-    | "keeper_board_list" | "keeper_board_get"
-    (* Board delete and cleanup are MASC-state-only mutations (board
-       post store), not main-worktree writes.  Missing here until #6692
-       caused [janitor] to hit a mutation-boundary block loop at
-       2026-04-12 01:15:25 KST: the first [keeper_board_delete] in a
-       cleanup turn succeeded and opened the boundary, and every
-       subsequent [keeper_board_delete] in the same turn was blocked
-       by the [pre_tool_use_guard], burning the turn budget without
-       progress.  The [masc_board_delete] alias was already exempt at
-       line 283 but its [keeper_*] counterpart had drifted out of this
-       list — same structural gap fixed by #6681 for [masc_claim_next]. *)
-    | "keeper_board_delete" | "keeper_board_cleanup"
-    | "keeper_broadcast" -> true
-    (* MASC coordination aliases for the [keeper_*] entries above.
-       These share the same name with a [masc_] prefix because they are
-       exposed via the masc-mcp tool surface instead of the per-keeper
-       surface, but their effect is identical: MASC task/board state
-       only, never the main worktree.  Missing here until #6671 caused
-       [masc_improver] to hang after [masc_add_task] opened a boundary:
-       the follow-up [masc_claim_next] was blocked, the LLM looped on
-       text-only responses, and the turn exhausted cascade budget on
-       [max_tokens] — all downstream of this allowlist gap.  See log
-       timestamp 2026-04-12 09:40:58 "pre_tool_use guard blocked
-       masc_claim_next". *)
-    | "masc_tasks" | "masc_add_task" | "masc_claim_next"
-    | "masc_batch_add_tasks" | "masc_plan_init" | "masc_plan_set_task"
-    | "masc_plan_update" | "masc_plan_get" | "masc_transition"
-    | "masc_broadcast" | "masc_messages" | "masc_status"
-    | "masc_dashboard" | "masc_agents" | "masc_agent_card"
-    | "masc_board_post" | "masc_board_comment" | "masc_board_vote"
-    | "masc_board_comment_vote" | "masc_board_delete"
-    | "masc_board_list" | "masc_board_get" | "masc_board_stats"
-    | "masc_board_hearths" | "masc_board_profile" -> true
-    | "masc_code_edit" | "masc_code_write" | "masc_code_delete"
-    | "masc_code_shell" | "masc_code_git" | "masc_worktree_create"
-    | "keeper_pr_submit" | "keeper_fs_edit" -> true
+    match Tool_name.of_string tool_name with
+    (* Keeper coordination: MASC-state-only mutations *)
+    | Some (Keeper Task_claim) | Some (Keeper Task_done)
+    | Some (Keeper Task_create) | Some (Keeper Tasks_list)
+    | Some (Keeper Board_post) | Some (Keeper Board_comment)
+    | Some (Keeper Board_vote) | Some (Keeper Board_list)
+    | Some (Keeper Board_get) | Some (Keeper Board_delete)
+    | Some (Keeper Board_cleanup) | Some (Keeper Broadcast) -> true
+    (* MASC coordination aliases — same effect domain as keeper_* above *)
+    | Some (Masc Tasks) | Some (Masc Add_task) | Some (Masc Claim_next)
+    | Some (Masc Batch_add_tasks) | Some (Masc Plan_init)
+    | Some (Masc Plan_set_task) | Some (Masc Plan_update)
+    | Some (Masc Plan_get) | Some (Masc Transition)
+    | Some (Masc Broadcast) | Some (Masc Messages) | Some (Masc Status)
+    | Some (Masc Dashboard) | Some (Masc Agents) | Some (Masc Agent_card)
+    | Some (Masc Board_post) | Some (Masc Board_comment)
+    | Some (Masc Board_vote) | Some (Masc Board_comment_vote)
+    | Some (Masc Board_delete) | Some (Masc Board_list)
+    | Some (Masc Board_get) | Some (Masc Board_stats)
+    | Some (Masc Board_hearths) | Some (Masc Board_profile) -> true
+    (* Playground-scoped write tools *)
+    | Some (Masc Code_edit) | Some (Masc Code_write)
+    | Some (Masc Code_delete) | Some (Masc Code_shell)
+    | Some (Masc Code_git) | Some (Masc Worktree_create)
+    | Some (Keeper Pr_submit) | Some (Keeper Fs_edit) -> true
     | _ -> false
 
 (* ── Reconcile-safe tools (mutating but idempotent enough) ─── *)
@@ -320,13 +308,16 @@ let is_main_worktree_boundary_exempt_with_input
     appear in [committed_mutating_tools] so including them here would
     be misleading dead entries. *)
 let reconcile_safe_tools =
-  [ "keeper_board_post"; "keeper_board_comment";
-    "keeper_board_vote"; "keeper_board_comment_vote";
-    "keeper_broadcast";
-    "keeper_task_done";
-    "masc_board_post"; "masc_board_comment";
-    "masc_board_vote"; "masc_board_comment_vote";
-    "masc_broadcast" ]
+  List.map Tool_name.to_string
+    Tool_name.[
+      Keeper Board_post; Keeper Board_comment;
+      Keeper Board_vote; Keeper Board_comment_vote;
+      Keeper Broadcast;
+      Keeper Task_done;
+      Masc Board_post; Masc Board_comment;
+      Masc Board_vote; Masc Board_comment_vote;
+      Masc Broadcast;
+    ]
 
 let reconcile_safe_set : (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create (List.length reconcile_safe_tools) in
@@ -354,7 +345,7 @@ let injected_masc_tool_names () =
     metadata.  Consumed by [keeper_tool_policy.keeper_default_model_tools]. *)
 let keeper_tool_search_schema : Types.tool_schema =
   {
-    name = "keeper_tool_search";
+    name = Tool_name.(to_string (Keeper Tool_search));
     description =
       "Search for tools by query describing what you need. \
        Returns tool names, descriptions, and usage guidance. \

--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -158,14 +158,21 @@ module Masc = struct
     | Agent_fitness
     | Agent_update
     | Agents
+    | Autoresearch_cycle
+    | Autoresearch_inject
+    | Autoresearch_start
+    | Autoresearch_status
+    | Autoresearch_stop
     | Batch_add_tasks
     | Board_cleanup
     | Board_comment
     | Board_comment_vote
     | Board_delete
     | Board_get
+    | Board_hearths
     | Board_list
     | Board_post
+    | Board_profile
     | Board_search
     | Board_stats
     | Board_vote
@@ -175,11 +182,6 @@ module Masc = struct
     | Claim_next
     | Claim_task
     | Cleanup_zombies
-    | Autoresearch_cycle
-    | Autoresearch_inject
-    | Autoresearch_start
-    | Autoresearch_status
-    | Autoresearch_stop
     | Code_delete
     | Code_edit
     | Code_git
@@ -252,8 +254,10 @@ module Masc = struct
     | Board_comment_vote -> "masc_board_comment_vote"
     | Board_delete -> "masc_board_delete"
     | Board_get -> "masc_board_get"
+    | Board_hearths -> "masc_board_hearths"
     | Board_list -> "masc_board_list"
     | Board_post -> "masc_board_post"
+    | Board_profile -> "masc_board_profile"
     | Board_search -> "masc_board_search"
     | Board_stats -> "masc_board_stats"
     | Board_vote -> "masc_board_vote"
@@ -340,8 +344,10 @@ module Masc = struct
     | "masc_board_comment_vote" -> Some Board_comment_vote
     | "masc_board_delete" -> Some Board_delete
     | "masc_board_get" -> Some Board_get
+    | "masc_board_hearths" -> Some Board_hearths
     | "masc_board_list" -> Some Board_list
     | "masc_board_post" -> Some Board_post
+    | "masc_board_profile" -> Some Board_profile
     | "masc_board_search" -> Some Board_search
     | "masc_board_stats" -> Some Board_stats
     | "masc_board_vote" -> Some Board_vote

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -64,14 +64,21 @@ module Masc : sig
     | Agent_fitness
     | Agent_update
     | Agents
+    | Autoresearch_cycle
+    | Autoresearch_inject
+    | Autoresearch_start
+    | Autoresearch_status
+    | Autoresearch_stop
     | Batch_add_tasks
     | Board_cleanup
     | Board_comment
     | Board_comment_vote
     | Board_delete
     | Board_get
+    | Board_hearths
     | Board_list
     | Board_post
+    | Board_profile
     | Board_search
     | Board_stats
     | Board_vote
@@ -81,11 +88,6 @@ module Masc : sig
     | Claim_next
     | Claim_task
     | Cleanup_zombies
-    | Autoresearch_cycle
-    | Autoresearch_inject
-    | Autoresearch_start
-    | Autoresearch_status
-    | Autoresearch_stop
     | Code_delete
     | Code_edit
     | Code_git

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -19,7 +19,8 @@ let all_masc : Tool_name.Masc.t list =
   ; Autoresearch_cycle; Autoresearch_inject; Autoresearch_start
   ; Autoresearch_status; Autoresearch_stop
   ; Batch_add_tasks; Board_cleanup; Board_comment; Board_comment_vote
-  ; Board_delete; Board_get; Board_list; Board_post; Board_search
+  ; Board_delete; Board_get; Board_hearths; Board_list; Board_post
+  ; Board_profile; Board_search
   ; Board_stats; Board_vote; Broadcast; Cancel_task; Check; Claim_next
   ; Claim_task; Cleanup_zombies; Code_delete; Code_edit; Code_git; Code_read
   ; Code_search; Code_shell; Code_symbols; Code_write; Complete_task


### PR DESCRIPTION
## Summary

- `keeper_tool_registry.ml`의 tool name 문자열을 `Tool_name.t` variant로 전환
- 6개 리스트(core_always, core_discovery, non_shard_read_only, reconcile_safe) + 2개 match 함수 변환
- `masc_board_hearths`, `masc_board_profile` 2개 도구를 Tool_name에 추가

## 변환 상세

| 대상 | 변환 방식 |
|------|----------|
| `core_always_tools` | `Tool_name.[Keeper Context_status; ...]` → `to_string` |
| `core_discovery_tools` | 22개 도구 variant → `to_string` |
| `reconcile_safe_tools` | 11개 도구 variant → `to_string` |
| `is_read_only_with_input` | `Tool_name.of_string` → variant match |
| `is_main_worktree_boundary_exempt` | 30+ string match → variant match |
| `keeper_tool_search_schema.name` | `Tool_name.(to_string (Keeper Tool_search))` |

## 동기

PR #7323에서 `is_read_only_with_input`의 체크 순서 버그가 3회 CI round-trip 유발.
원인: `"keeper_shell"` string 비교 → `is_effectively_read_only_tool` short-circuit.
Variant match는 이 패턴 자체를 불가능하게 만듦 — `Some (Keeper Shell)` guard가 명시적.

## Test plan

- [x] `test_tool_name.exe` — 11/11 pass (roundtrip + shard coverage)
- [x] `test_keeper_github_read_only.exe` — 19/19 pass (read-only + boundary)
- [x] `dune runtest` — 전체 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)