### PR TITLE
[codex] Fix keeper status tail ordering and continuity fallback provenance

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -239,8 +239,9 @@ let keeper_context_status_json ~(meta : keeper_meta) ~(ctx_work : working_contex
   let continuity_summary =
     match continuity with
     | None ->
-      let trimmed = String.trim meta.continuity_summary in
-      if trimmed = "" then "No continuity snapshot available." else trimmed
+      Keeper_memory_policy.continuity_fallback_summary_text
+        ~continuity_summary:meta.continuity_summary
+        ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
     | Some snapshot -> Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
   in
   let ctx_tokens = count_context_tokens ctx_work in
@@ -285,4 +286,3 @@ let keeper_context_status_json ~(meta : keeper_meta) ~(ctx_work : working_contex
 ;;
 
 (* --- Memory bank search (structured notes from [STATE] blocks) --- *)
-

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -650,8 +650,9 @@ let write_heartbeat_snapshot
       match continuity_snapshot with
       | Some s -> keeper_state_snapshot_to_summary_text s
       | None ->
-        let trimmed = String.trim meta_current.continuity_summary in
-        if trimmed = "" then "No continuity snapshot available." else trimmed
+        continuity_fallback_summary_text
+          ~continuity_summary:meta_current.continuity_summary
+          ~last_continuity_update_ts:meta_current.runtime.last_continuity_update_ts
     in
     let repetition_risk =
       repetition_risk_score ~messages:c_messages ~candidate_reply:None

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -305,6 +305,29 @@ let keeper_state_snapshot_to_summary_text (snapshot : keeper_state_snapshot) : s
   in
   if lines = [] then "No continuity snapshot available." else String.concat "\n" lines
 
+let continuity_fallback_summary_text
+    ~(continuity_summary : string)
+    ~(last_continuity_update_ts : float) : string =
+  let trimmed = String.trim continuity_summary in
+  if trimmed = "" then
+    "No continuity snapshot available."
+  else
+    let freshness_line =
+      if last_continuity_update_ts > 0.0 then
+        let age_s = max 0.0 (Time_compat.now () -. last_continuity_update_ts) in
+        Printf.sprintf "Freshness: %.0fs since last continuity update." age_s
+      else
+        "Freshness: unknown (last continuity update timestamp unavailable)."
+    in
+    String.concat "\n"
+      [
+        "Continuity source: persisted keeper meta fallback.";
+        freshness_line;
+        "Checkpoint note: latest checkpoint [STATE] snapshot unavailable.";
+        "Treat the following as prior context only and re-verify blockers, constraints, and repo state against the live world state before acting.";
+        trimmed;
+      ]
+
 let keeper_state_snapshot_to_json (snapshot : keeper_state_snapshot) : Yojson.Safe.t =
   `Assoc [
     ("goal", Json_util.string_opt_to_json snapshot.goal);

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -297,6 +297,11 @@ let keeper_schemas : tool_schema list = [
           ("type", `String "integer");
           ("description", `String "How many bytes from the end of files to scan for tails (default: 60000).");
         ]);
+        ("tail_order", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "oldest_first"; `String "newest_first"]);
+          ("description", `String "Ordering for metrics/history/compaction tails and recent memory notes. Default: oldest_first (compat).");
+        ]);
         ("fast", `Assoc [
           ("type", `String "boolean");
           ("description", `String "Enable fast mode (skip heavy sections unless explicitly enabled).");

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -64,6 +64,26 @@ let effective_status_name (ctx : _ context) args =
   | "" -> normalize_status_name ctx.agent_name
   | value -> value
 
+type tail_order =
+  | Oldest_first
+  | Newest_first
+
+let tail_order_of_args args =
+  match String.lowercase_ascii (String.trim (get_string args "tail_order" "")) with
+  | "newest_first" | "newest" | "latest_first" | "desc" ->
+      Newest_first
+  | _ ->
+      Oldest_first
+
+let tail_order_to_string = function
+  | Oldest_first -> "oldest_first"
+  | Newest_first -> "newest_first"
+
+let apply_tail_order order items =
+  match order with
+  | Oldest_first -> items
+  | Newest_first -> List.rev items
+
 let resolve_status_target (ctx : _ context) args =
   let requested_name = effective_status_name ctx args in
   if not (validate_name requested_name) then
@@ -95,6 +115,7 @@ let hash_status_args _config resolved_name args =
     string_of_bool (get_bool args "include_compaction_history" false);
     string_of_int (get_int args "tail_turns" 3);
     string_of_int (get_int args "tail_messages" 5);
+    tail_order_to_string (tail_order_of_args args);
   ] in
   Digest.string (String.concat "|" parts) |> Digest.to_hex
 
@@ -435,6 +456,7 @@ let handle_keeper_status ctx args : tool_result =
       let tail_compactions = max 0 (get_int args "tail_compactions" 10) in
       let tail_bytes = max 1_000 (get_int args "tail_bytes" 60_000) in
       let fast = get_bool args "fast" (keeper_status_fast_default ()) in
+      let tail_order = tail_order_of_args args in
       let include_context = get_bool args "include_context" (not fast) in
       let include_metrics_overview =
         get_bool args "include_metrics_overview" (not fast)
@@ -578,7 +600,7 @@ let handle_keeper_status ctx args : tool_result =
            let (parsed, _) =
              Fs_compat.parse_jsonl_lines ~source:"keeper_metrics" lines
            in
-           `List parsed
+           `List (apply_tail_order tail_order parsed)
          in
          let metrics_window_lines =
            if include_metrics_overview then
@@ -637,12 +659,18 @@ let handle_keeper_status ctx args : tool_result =
          in
          let memory_bank_summary =
            if include_memory_bank then
-             read_keeper_memory_summary
-               ctx.config
-               ~name:m.name
-               ~max_bytes:tail_bytes
-               ~max_lines:(max (tail_turns * 10) 400)
-               ~recent_limit:8
+             let summary =
+               read_keeper_memory_summary
+                 ctx.config
+                 ~name:m.name
+                 ~max_bytes:tail_bytes
+                 ~max_lines:(max (tail_turns * 10) 400)
+                 ~recent_limit:8
+             in
+             {
+               summary with
+               recent_notes = apply_tail_order tail_order summary.recent_notes;
+             }
            else
              {
                total_notes = 0;
@@ -735,7 +763,10 @@ let handle_keeper_status ctx args : tool_result =
                    with Yojson.Json_error _ -> (acc, raw_count, fragment_count, filtered_count))
                  ([], 0, 0, 0) lines
              in
-             (`List (List.rev items_rev), raw_count, fragment_count, filtered_count)
+            ( `List (apply_tail_order tail_order (List.rev items_rev)),
+              raw_count,
+              fragment_count,
+              filtered_count )
          in
          let compaction_history_tail =
            if not include_compaction_history then
@@ -818,7 +849,7 @@ let handle_keeper_status ctx args : tool_result =
              let total = List.length events in
              let start = max 0 (total - tail_compactions) in
              let tail = List.filteri (fun i _ -> i >= start) events in
-             (`List tail, total)
+             (`List (apply_tail_order tail_order tail), total)
         in
         let all_internal_tools =
           keeper_model_tools |> List.map (fun tool -> tool.Types.name)
@@ -1018,6 +1049,7 @@ let handle_keeper_status ctx args : tool_result =
              ("include_memory_bank", `Bool include_memory_bank);
              ("include_history_tail", `Bool include_history_tail);
              ("include_compaction_history", `Bool include_compaction_history);
+             ("tail_order", `String (tail_order_to_string tail_order));
            ]);
            ("models_resolved", models_resolved);
            ("model_observability", model_observability);

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -228,8 +228,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   match continuity_snapshot with
                   | Some s -> keeper_state_snapshot_to_summary_text s
                   | None ->
-                    let trimmed = String.trim meta.continuity_summary in
-                    if trimmed = "" then "" else trimmed
+                    continuity_fallback_summary_text
+                      ~continuity_summary:meta.continuity_summary
+                      ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
                 in
                 if summary = "" || summary = "No continuity snapshot available."
                 then ""

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -368,17 +368,19 @@ let read_continuity_summary ~(config : Room.config) ~(meta : keeper_meta)
         (match snapshot with
          | Some s -> keeper_state_snapshot_to_summary_text s
          | None ->
-             let trimmed = String.trim meta.continuity_summary in
-             if trimmed = "" then "No continuity snapshot available."
-             else trimmed)
+             continuity_fallback_summary_text
+               ~continuity_summary:meta.continuity_summary
+               ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts)
     | None ->
-        let trimmed = String.trim meta.continuity_summary in
-        if trimmed = "" then "No continuity snapshot available." else trimmed
+        continuity_fallback_summary_text
+          ~continuity_summary:meta.continuity_summary
+          ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | _ ->
-      let trimmed = String.trim meta.continuity_summary in
-      if trimmed = "" then "No continuity snapshot available." else trimmed
+      continuity_fallback_summary_text
+        ~continuity_summary:meta.continuity_summary
+        ~last_continuity_update_ts:meta.runtime.last_continuity_update_ts
 
 (** Board event cursor bootstrap window (seconds). *)
 let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec


### PR DESCRIPTION
## What changed
- added `tail_order` to `masc_keeper_status` so recent tails can be returned in `newest_first` order
- applied that ordering consistently to `metrics_tail`, `history_tail`, `compaction_history_tail`, and recent memory notes
- replaced raw `meta.continuity_summary` fallback usage with a provenance-aware formatter that marks persisted continuity as prior context when the latest checkpoint `[STATE]` snapshot is unavailable

## Why
Keepers were surfacing stale blocker text as if it were live truth, and the status tool showed older tail entries before newer ones. That made diagnosis noisy and encouraged agents to repeat outdated conclusions.

## Impact
- operators can ask for newest-first keeper tails without changing existing default behavior
- fallback continuity now explicitly tells agents to re-verify blockers and repo state against the live world state before acting
- prompt/status/keepalive surfaces use the same continuity fallback wording instead of silently reusing stale text

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-status-tail-order @default`

## Root cause
Status tails were emitted in compatibility order only, and continuity fallback paths reused persisted summary text without marking it as stale or fallback-derived.