### PR TITLE
[codex] fix keeper broken tool call pairs

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -581,9 +581,10 @@ let run_turn
   (* Repair orphaned ToolResult blocks before passing to OAS Agent.run.
      Stale checkpoints saved before #7237 may contain tool_result blocks
      whose matching tool_use was trimmed. Anthropic API rejects these.
-     repair_orphan_tool_result_messages downgrades orphans to plain Text. *)
+     repair_broken_tool_call_pairs downgrades broken tool_use/tool_result
+     pairs to plain Text before the provider validates adjacency. *)
   let history_messages =
-    Keeper_context_core.repair_orphan_tool_result_messages ctx_work.messages
+    Keeper_context_core.repair_broken_tool_call_pairs ctx_work.messages
   in
   let ctx_work = Keeper_exec_context.append ctx_work user_msg in
   if not is_retry
@@ -1565,6 +1566,11 @@ let run_turn
       Agent_sdk.Context_reducer.prune_tool_outputs ~max_output_len:4000;
       Agent_sdk.Context_reducer.cap_message_tokens ~max_tokens:32000 ~keep_recent:3;
       Agent_sdk.Context_reducer.repair_dangling_tool_calls;
+      {
+        Agent_sdk.Context_reducer.strategy =
+          Agent_sdk.Context_reducer.Custom
+            Keeper_context_core.repair_broken_tool_call_pairs;
+      };
       Agent_sdk.Context_reducer.merge_contiguous;
     ]
   in

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -162,7 +162,7 @@ let compact_if_needed
           let msgs_after_fold =
             Agent_sdk.Context_reducer.reduce fold_reducer msgs_after_compact
           in
-          msgs_after_fold
+          Keeper_context_core.repair_broken_tool_call_pairs msgs_after_fold
         in
         let compacted_ctx =
           sync_oas_context { ctx with messages }

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -230,6 +230,13 @@ let tool_use_ids_of_message (msg : Agent_sdk.Types.message) : string list =
       | _ -> None)
     msg.content
 
+let tool_result_ids_of_message (msg : Agent_sdk.Types.message) : string list =
+  List.filter_map
+    (function
+      | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+      | _ -> None)
+    msg.content
+
 let has_tool_result_block (msg : Agent_sdk.Types.message) : bool =
   List.exists
     (function
@@ -276,6 +283,61 @@ let tool_result_text_of_block
     | Some value -> Yojson.Safe.to_string value
     | None -> Printf.sprintf "[tool result %s]" tool_use_id
 
+let tool_use_text_of_block
+    ~(tool_use_id : string)
+    ~(tool_name : string)
+    ~(input : Yojson.Safe.t) : string =
+  let tool_name = Inference_utils.sanitize_text_utf8 (String.trim tool_name) in
+  let tool_use_id = Inference_utils.sanitize_text_utf8 (String.trim tool_use_id) in
+  let tool_name =
+    if tool_name = "" then "unknown_tool" else tool_name
+  in
+  let input_json = Yojson.Safe.to_string input |> Inference_utils.sanitize_text_utf8 in
+  Printf.sprintf "[tool use %s %s input=%s]" tool_name tool_use_id input_json
+
+let repair_dangling_tool_use_messages
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  let repair_with_next
+      (current : Agent_sdk.Types.message)
+      (next_opt : Agent_sdk.Types.message option) =
+    let next_tool_result_ids =
+      match next_opt with
+      | Some next -> tool_result_ids_of_message next
+      | None -> []
+    in
+    let has_dangling =
+      List.exists
+        (function
+          | Agent_sdk.Types.ToolUse { id; _ } ->
+              not (List.mem id next_tool_result_ids)
+          | _ -> false)
+        current.content
+    in
+    if not has_dangling then current
+    else
+      let content =
+        List.map
+          (function
+            | Agent_sdk.Types.ToolUse { id; name; input }
+              when not (List.mem id next_tool_result_ids) ->
+                Agent_sdk.Types.Text
+                  (tool_use_text_of_block
+                     ~tool_use_id:id ~tool_name:name ~input)
+            | other -> other)
+          current.content
+      in
+      { current with content }
+  in
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | [ current ] ->
+        List.rev (repair_with_next current None :: acc)
+    | current :: ((next :: _) as rest) ->
+        let repaired = repair_with_next current (Some next) in
+        loop (repaired :: acc) rest
+  in
+  loop [] messages
+
 let repair_orphan_tool_result_messages
     (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
   let rec loop prev acc = function
@@ -320,6 +382,12 @@ let repair_orphan_tool_result_messages
   in
   loop None [] messages
 
+let repair_broken_tool_call_pairs
+    (messages : Agent_sdk.Types.message list) : Agent_sdk.Types.message list =
+  messages
+  |> repair_dangling_tool_use_messages
+  |> repair_orphan_tool_result_messages
+
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
     ("system_prompt", `String (Inference_utils.sanitize_text_utf8 ctx.system_prompt));
@@ -335,7 +403,7 @@ let deserialize_context (s : string) ~max_tokens : working_context =
   let system_prompt = json |> member "system_prompt" |> to_string in
   let messages =
     json |> member "messages" |> to_list |> List.map message_of_json
-    |> repair_orphan_tool_result_messages
+    |> repair_broken_tool_call_pairs
   in
   let _legacy_token_count = json |> member "token_count" |> to_int_option in
   sync_oas_context
@@ -918,7 +986,7 @@ let sanitize_oas_checkpoint
   : Agent_sdk.Checkpoint.t * checkpoint_sanitize_stats =
   let messages, stats = sanitize_checkpoint_messages cp.messages in
   let messages =
-    if repair_orphans then repair_orphan_tool_result_messages messages
+    if repair_orphans then repair_broken_tool_call_pairs messages
     else messages
   in
   ({ cp with messages }, stats)
@@ -949,7 +1017,7 @@ let context_of_oas_checkpoint
       trim_messages_preserving_pairs cp.messages
         ~max_count:max_checkpoint_messages
     in
-    if repair_orphans then repair_orphan_tool_result_messages messages
+    if repair_orphans then repair_broken_tool_call_pairs messages
     else messages
   in
   sync_oas_context
@@ -1006,7 +1074,7 @@ let save_oas_checkpoint
   let capped_messages, _ = sanitize_checkpoint_messages capped_messages in
   let capped_messages =
     if capped_messages_were_truncated
-    then repair_orphan_tool_result_messages capped_messages
+    then repair_broken_tool_call_pairs capped_messages
     else capped_messages
   in
   let state =

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -94,6 +94,17 @@ let tool_result_content_for_id ~tool_use_id msgs =
         msg.content)
     msgs
 
+let has_tool_use_id ~tool_use_id msgs =
+  List.exists
+    (fun (msg : Agent_sdk.Types.message) ->
+      List.exists
+        (function
+          | Agent_sdk.Types.ToolUse { id; _ } ->
+              String.equal id tool_use_id
+          | _ -> false)
+        msg.content)
+    msgs
+
 let make_keeper_meta ?(name = "keeper-lifecycle-test")
     ?(trace_id = "trace-keeper-lifecycle") () =
   match
@@ -1115,6 +1126,78 @@ let test_deserialize_context_preserves_valid_tool_pair () =
     (Some "paired output")
     (tool_result_content_for_id ~tool_use_id:tool_id roundtrip.messages)
 
+let test_deserialize_context_repairs_dangling_tool_use () =
+  let tool_id = "call-dangling-use-json" in
+  let ctx =
+    KEC.create ~system_prompt:"keeper lifecycle" ~max_tokens:4096
+    |> fun ctx ->
+    KEC.append_many ctx
+      [
+        Agent_sdk.Types.user_msg "read the file";
+        tool_use_message ~tool_use_id:tool_id ~name:"keeper_board_comment" ();
+        Agent_sdk.Types.assistant_msg "done";
+      ]
+  in
+  let roundtrip =
+    KCC.deserialize_context (KEC.serialize_context ctx) ~max_tokens:4096
+  in
+  check bool "dangling tool use removed on deserialize" false
+    (has_tool_use_id ~tool_use_id:tool_id roundtrip.messages);
+  match List.nth_opt roundtrip.messages 1 with
+  | Some { Agent_sdk.Types.content = [ Agent_sdk.Types.Text text ]; _ } ->
+      check bool "dangling tool use downgraded to text on deserialize" true
+        (contains_substring text "tool use keeper_board_comment");
+      check bool "dangling tool use id retained on deserialize" true
+        (contains_substring text tool_id)
+  | _ -> fail "expected dangling tool use to downgrade to text on deserialize"
+
+let test_load_context_repairs_dangling_tool_use_after_cap () =
+  let base_dir = temp_dir "keeper_lifecycle_load_dangling_tool_use" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let trace_id = "trace-load-dangling-tool-use" in
+      let session =
+        KEC.create_session ~session_id:trace_id ~base_dir
+      in
+      let tool_id = "tool-dangling-load" in
+      let checkpoint =
+        make_test_checkpoint ~session_id:trace_id
+          [
+            Agent_sdk.Types.user_msg "inspect file";
+            tool_use_message ~tool_use_id:tool_id ~name:"keeper_board_comment" ();
+            Agent_sdk.Types.assistant_msg "done";
+          ]
+      in
+      (match
+         Masc_mcp.Keeper_checkpoint_store.save_oas
+           ~session_dir:session.session_dir checkpoint
+       with
+       | Ok () -> ()
+       | Error e ->
+           Alcotest.fail
+             (Printf.sprintf "save_oas failed: %s" e));
+      let (_session, loaded_opt) =
+        KEC.load_context_from_checkpoint
+          ~max_checkpoint_messages:8
+          ~trace_id
+          ~primary_model_max_tokens:64_000
+          ~base_dir
+      in
+      match loaded_opt with
+      | None -> fail "expected checkpoint context to load"
+      | Some loaded ->
+          check bool "dangling tool use removed on load" false
+            (has_tool_use_id ~tool_use_id:tool_id loaded.messages);
+          match List.nth_opt loaded.messages 1 with
+          | Some { Agent_sdk.Types.content = [ Agent_sdk.Types.Text text ]; _ } ->
+              check bool "dangling tool use downgraded to text on load" true
+                (contains_substring text "tool use keeper_board_comment");
+              check bool "dangling tool use id retained on load" true
+                (contains_substring text tool_id)
+          | _ ->
+              fail "expected dangling tool use to downgrade to text on load")
+
 let test_save_oas_checkpoint_strips_summarized_world_state () =
   let base_dir = temp_dir "keeper_lifecycle_save_summary_strip" in
   Fun.protect
@@ -1571,6 +1654,10 @@ let () =
             test_deserialize_context_repairs_orphan_tool_result;
           test_case "deserialize preserves valid tool pair" `Quick
             test_deserialize_context_preserves_valid_tool_pair;
+          test_case "deserialize repairs dangling tool use" `Quick
+            test_deserialize_context_repairs_dangling_tool_use;
+          test_case "load repairs dangling tool use after cap" `Quick
+            test_load_context_repairs_dangling_tool_use_after_cap;
         ] );
       ( "compact_policy",
         [

--- a/test/test_pbt_context_overflow.ml
+++ b/test/test_pbt_context_overflow.ml
@@ -19,7 +19,11 @@
 
     Property 5 (Reducer integration):
       keeper_agent_run source contains cap_message_tokens in the
-      keeper reducer chain, ordered before repair_dangling_tool_calls. *)
+      keeper reducer chain, ordered before repair_dangling_tool_calls.
+
+    Property 6 (Reducer hardening):
+      keeper_agent_run source contains the keeper-local
+      repair_broken_tool_call_pairs reducer after repair_dangling_tool_calls. *)
 
 module UT = Masc_mcp.Keeper_unified_turn
 
@@ -186,6 +190,63 @@ let test_cap_message_tokens_integration () =
        | _ -> false)
   end
 
+let test_pair_repair_integration () =
+  let find_substring ?(start = 0) haystack needle =
+    let hlen = String.length haystack in
+    let nlen = String.length needle in
+    let rec loop i =
+      if i + nlen > hlen then None
+      else if String.sub haystack i nlen = needle then Some i
+      else loop (i + 1)
+    in
+    if nlen = 0 then Some start else loop start
+  in
+  let has_prompt_root path =
+    Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
+  in
+  let repo_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root when has_prompt_root root -> root
+    | _ ->
+        let rec ascend path =
+          if has_prompt_root path then path
+          else
+            let parent = Filename.dirname path in
+            if String.equal parent path then Sys.getcwd () else ascend parent
+        in
+        ascend (Sys.getcwd ())
+  in
+  let target = Filename.concat repo_root "lib/keeper/keeper_agent_run.ml" in
+  if not (Sys.file_exists target) then
+    ()
+  else begin
+    let ic = open_in target in
+    let content = Fun.protect
+      ~finally:(fun () -> close_in ic)
+      (fun () ->
+        let len = in_channel_length ic in
+        let buf = Bytes.create len in
+        really_input ic buf 0 len;
+        Bytes.to_string buf)
+    in
+    let repair_pos =
+      find_substring content "Agent_sdk.Context_reducer.repair_dangling_tool_calls"
+    in
+    let local_pos =
+      match repair_pos with
+      | Some repair_pos ->
+          find_substring ~start:repair_pos content
+            "Keeper_context_core.repair_broken_tool_call_pairs"
+      | None -> None
+    in
+    Alcotest.(check bool)
+      "keeper_agent_run.ml must integrate local pair repair after repair_dangling_tool_calls"
+      true
+      (match repair_pos, local_pos with
+       | Some repair_pos, Some local_pos -> repair_pos < local_pos
+       | _ -> false)
+  end
+
 (* ── Gospel-style specification (documentation) ────────── *)
 (*
    @gospel — formal specification (Ortac runtime not available on 5.4)
@@ -225,5 +286,7 @@ let () =
         test_structural_absence;
       Alcotest.test_case "cap_message_tokens integrated in reducer chain" `Quick
         test_cap_message_tokens_integration;
+      Alcotest.test_case "local pair repair integrated in reducer chain" `Quick
+        test_pair_repair_integration;
     ]);
   ]


### PR DESCRIPTION
## Summary
- repair broken `tool_use`/`tool_result` pairs before keeper history is sent back to the provider
- apply the same normalization during checkpoint deserialize/load/save, reducer compaction, and keeper compaction
- add lifecycle and structural tests covering dangling `tool_use` recovery and reducer integration

## Root Cause
Anthropic rejected resumed/reduced keeper history when an assistant `tool_use` block no longer had the required immediate `tool_result` pair. We only repaired orphan `tool_result` blocks, so broken `tool_use` pairs could still leak through after checkpoint trimming or reducer passes.

## Impact
This hardens keeper turn recovery at the MASC boundary instead of relying on prompt or hook behavior. Providers should no longer see malformed tool-call history for this class of resumed-turn failures, which avoids ambiguous partial-commit loops after reconcile-safe tool calls like `keeper_board_comment`.

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-tool-pair-repair ./test/test_keeper_lifecycle.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-tool-pair-repair ./test/test_pbt_context_overflow.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-tool-pair-repair @default`