### PR TITLE
refactor: Tool_name coverage + prefilter synonym invariant

### DIFF
--- a/lib/tool_name.ml
+++ b/lib/tool_name.ml
@@ -51,6 +51,7 @@ module Keeper = struct
     | Voice_session_start
     | Voice_sessions
     | Voice_speak
+    | Write
 
   let to_string = function
     | Bash -> "keeper_bash"
@@ -98,6 +99,7 @@ module Keeper = struct
     | Voice_session_start -> "keeper_voice_session_start"
     | Voice_sessions -> "keeper_voice_sessions"
     | Voice_speak -> "keeper_voice_speak"
+    | Write -> "keeper_write"
 
   let of_string = function
     | "keeper_bash" -> Some Bash
@@ -145,6 +147,7 @@ module Keeper = struct
     | "keeper_voice_session_start" -> Some Voice_session_start
     | "keeper_voice_sessions" -> Some Voice_sessions
     | "keeper_voice_speak" -> Some Voice_speak
+    | "keeper_write" -> Some Write
     | _ -> None
 
   let pp fmt t = Format.pp_print_string fmt (to_string t)
@@ -196,6 +199,8 @@ module Masc = struct
     | Dispatch_assign
     | Dispatch_plan
     | Find_by_capability
+    | Governance_feed
+    | Governance_status
     | Heartbeat
     | Join
     | Leave
@@ -286,6 +291,8 @@ module Masc = struct
     | Dispatch_assign -> "masc_dispatch_assign"
     | Dispatch_plan -> "masc_dispatch_plan"
     | Find_by_capability -> "masc_find_by_capability"
+    | Governance_feed -> "masc_governance_feed"
+    | Governance_status -> "masc_governance_status"
     | Heartbeat -> "masc_heartbeat"
     | Join -> "masc_join"
     | Leave -> "masc_leave"
@@ -376,6 +383,8 @@ module Masc = struct
     | "masc_dispatch_assign" -> Some Dispatch_assign
     | "masc_dispatch_plan" -> Some Dispatch_plan
     | "masc_find_by_capability" -> Some Find_by_capability
+    | "masc_governance_feed" -> Some Governance_feed
+    | "masc_governance_status" -> Some Governance_status
     | "masc_heartbeat" -> Some Heartbeat
     | "masc_join" -> Some Join
     | "masc_leave" -> Some Leave

--- a/lib/tool_name.mli
+++ b/lib/tool_name.mli
@@ -50,6 +50,7 @@ module Keeper : sig
     | Voice_session_start
     | Voice_sessions
     | Voice_speak
+    | Write
 
   val to_string : t -> string
   val of_string : string -> t option
@@ -102,6 +103,8 @@ module Masc : sig
     | Dispatch_assign
     | Dispatch_plan
     | Find_by_capability
+    | Governance_feed
+    | Governance_status
     | Heartbeat
     | Join
     | Leave

--- a/lib/tool_prefilter.ml
+++ b/lib/tool_prefilter.ml
@@ -419,3 +419,5 @@ let filter ~(tools : Types.tool_schema list) ~(query : string) ~(k : int)
     : Types.tool_schema list =
   filter_with_scores ~tools ~query ~k
   |> List.map fst
+
+let synonym_keys = List.map fst synonyms

--- a/lib/tool_prefilter.mli
+++ b/lib/tool_prefilter.mli
@@ -18,6 +18,10 @@ val filter :
 (** Return top-[k] tools from [tools] most relevant to [query].
     Returns [[]] on zero overlap. *)
 
+val synonym_keys : string list
+(** All tool names registered in the synonym dictionary.
+    Test helper: verify every key maps to a known [Tool_name.t]. *)
+
 val filter_with_scores :
   tools:Types.tool_schema list ->
   query:string ->

--- a/test/test_tool_name.ml
+++ b/test/test_tool_name.ml
@@ -12,7 +12,7 @@ let all_keeper : Tool_name.Keeper.t list =
   ; Task_claim; Task_create; Task_done; Task_force_done; Task_force_release
   ; Tasks_audit; Tasks_list; Time_now; Tool_search; Tools_list
   ; Voice_agent; Voice_listen; Voice_session_end; Voice_session_start
-  ; Voice_sessions; Voice_speak ]
+  ; Voice_sessions; Voice_speak; Write ]
 
 let all_masc : Tool_name.Masc.t list =
   [ A2a_delegate; Add_task; Agent_card; Agent_fitness; Agent_update; Agents
@@ -25,6 +25,7 @@ let all_masc : Tool_name.Masc.t list =
   ; Claim_task; Cleanup_zombies; Code_delete; Code_edit; Code_git; Code_read
   ; Code_search; Code_shell; Code_symbols; Code_write; Complete_task
   ; Dashboard; Deliver; Dispatch_assign; Dispatch_plan; Find_by_capability
+  ; Governance_feed; Governance_status
   ; Heartbeat; Join; Leave; List_tasks; Messages; Note_add
   ; Operation_checkpoint; Operation_finalize; Operation_pause
   ; Operation_resume; Operation_start; Operation_status; Operation_stop
@@ -165,6 +166,15 @@ let test_shard_tools_parse () =
       (Printf.sprintf "Tool_shard names not in Tool_name: [%s]"
          (String.concat "; " unparsed))
 
+let test_prefilter_synonyms_parse () =
+  let unparsed = List.filter (fun name ->
+    Tool_name.of_string name = None
+  ) Tool_prefilter.synonym_keys in
+  if unparsed <> [] then
+    Alcotest.fail
+      (Printf.sprintf "Tool_prefilter synonyms not in Tool_name: [%s]"
+         (String.concat "; " unparsed))
+
 let () =
   Alcotest.run "Tool_name" [
     "roundtrip", [
@@ -183,5 +193,6 @@ let () =
     ];
     "coverage", [
       Alcotest.test_case "shard tools parse" `Quick test_shard_tools_parse;
+      Alcotest.test_case "prefilter synonyms parse" `Quick test_prefilter_synonyms_parse;
     ];
   ]


### PR DESCRIPTION
## Summary

- Tool_name에 3개 variant 추가: `Keeper.Write`, `Masc.Governance_feed`, `Masc.Governance_status`
- `Tool_prefilter.synonym_keys` 노출 + coverage 테스트 추가
- TF-IDF synonym 사전의 모든 key가 `Tool_name.t`로 파싱되는지 검증

## 동기

`tool_prefilter.ml`에는 91개 tool name string literal이 있음. 전체 변환은 큰 PR이 되므로, **invariant 검증**으로 drift를 테스트 시점에 포착.

이 coverage test 덕분에 누락된 3개 도구(`keeper_write`, `masc_governance_*`)를 즉시 발견.

## 발견된 gap (follow-up)

`tool_permission_map.ml`에 Tool_name 미등록 도구 35개 (dispatch_*, observe_*, policy_* 등). 별도 PR에서 처리.

## Test plan

- [x] `test_tool_name.exe` — 12/12 pass (11 기존 + 1 prefilter coverage)
- [x] `dune runtest` — 전체 pass (exit 0)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)