### PR TITLE
[codex] Fix keeper gh normalization and checkpoint orphan repair

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1206,63 +1206,58 @@ let run_turn
                        let rerank_cascade =
                          Keeper_config.keeper_llm_rerank_cascade ()
                        in
-                       (match
-                          Oas_worker_named.resolve_cascade_providers
-                            ~cascade_name:rerank_cascade
+                       let defaults =
+                         Oas_worker.default_model_strings ~cascade_name:rerank_cascade
+                       in
+                       let config_path = Oas_worker.default_config_path () in
+                       let rerank_fn =
+                         Agent_sdk.Tool_selector.default_rerank_fn
+                           ~sw
+                           ~net
+                           ?config_path
+                           ~cascade_name:rerank_cascade
+                           ~defaults
+                           ~k:selection_limit
+                           ()
+                       in
+                       let strategy =
+                         Agent_sdk.Tool_selector.TopK_llm
+                           { k = selection_limit
+                           ; bm25_prefilter_n =
+                               min
+                                 keeper_selection_bm25_prefilter_n
+                                 (List.length preset_tools)
+                           ; always_include = core
+                           ; confidence_threshold = 0.3
+                           ; rerank_fn
+                           }
+                       in
+                       (try
+                          let selected =
+                            Agent_sdk.Tool_selector.select_names
+                              ~strategy
+                              ~context:query_text
+                              ~tools:preset_tools
+                          in
+                          if Keeper_types_profile.keeper_debug
+                          then
+                            Log.Keeper.info
+                              "keeper:%s TopK_llm selected %d tools (query_len=%d, \
+                               candidates=%d)"
+                              meta.name
+                              (List.length selected)
+                              (String.length query_text)
+                              (List.length preset_tools);
+                          selected
                         with
-                        | provider :: _ ->
-                            let rerank_fn =
-                              Agent_sdk.Tool_selector.default_rerank_fn
-                                ~sw
-                                ~net
-                                ~provider
-                                ~k:selection_limit
-                                ()
-                            in
-                            let strategy =
-                              Agent_sdk.Tool_selector.TopK_llm
-                                { k = selection_limit
-                                ; bm25_prefilter_n =
-                                    min
-                                      keeper_selection_bm25_prefilter_n
-                                      (List.length preset_tools)
-                                ; always_include = core
-                                ; confidence_threshold = 0.3
-                                ; rerank_fn
-                                }
-                            in
-                            (try
-                               let selected =
-                                 Agent_sdk.Tool_selector.select_names
-                                   ~strategy
-                                   ~context:query_text
-                                   ~tools:preset_tools
-                               in
-                               if Keeper_types_profile.keeper_debug
-                               then
-                                 Log.Keeper.info
-                                   "keeper:%s TopK_llm selected %d tools (query_len=%d, \
-                                    candidates=%d)"
-                                   meta.name
-                                   (List.length selected)
-                                   (String.length query_text)
-                                   (List.length preset_tools);
-                               selected
-                             with
-                             | Eio.Cancel.Cancelled _ as e -> raise e
-                             | exn ->
-                               Log.Keeper.warn
-                                 "keeper:%s TopK_llm failed (%s), falling back to \
-                                  core+prefilter+discovered"
-                                 meta.name
-                                 (Printexc.to_string exn);
-                               [])
-                        | [] ->
-                            Log.Keeper.warn
-                              "keeper:%s TopK_llm: no rerank provider resolved, falling back \
-                               to core+prefilter+discovered"
-                              meta.name;
-                            [])
+                        | Eio.Cancel.Cancelled _ as e -> raise e
+                        | exn ->
+                          Log.Keeper.warn
+                            "keeper:%s TopK_llm failed (%s), falling back to \
+                             core+prefilter+discovered"
+                            meta.name
+                            (Printexc.to_string exn);
+                          [])
                      | _ ->
                        Log.Keeper.warn
                          "keeper:%s TopK_llm: Eio context unavailable, falling back \

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1206,58 +1206,63 @@ let run_turn
                        let rerank_cascade =
                          Keeper_config.keeper_llm_rerank_cascade ()
                        in
-                       let defaults =
-                         Oas_worker.default_model_strings ~cascade_name:rerank_cascade
-                       in
-                       let config_path = Oas_worker.default_config_path () in
-                       let rerank_fn =
-                         Agent_sdk.Tool_selector.default_rerank_fn
-                           ~sw
-                           ~net
-                           ?config_path
-                           ~cascade_name:rerank_cascade
-                           ~defaults
-                           ~k:selection_limit
-                           ()
-                       in
-                       let strategy =
-                         Agent_sdk.Tool_selector.TopK_llm
-                           { k = selection_limit
-                           ; bm25_prefilter_n =
-                               min
-                                 keeper_selection_bm25_prefilter_n
-                                 (List.length preset_tools)
-                           ; always_include = core
-                           ; confidence_threshold = 0.3
-                           ; rerank_fn
-                           }
-                       in
-                       (try
-                          let selected =
-                            Agent_sdk.Tool_selector.select_names
-                              ~strategy
-                              ~context:query_text
-                              ~tools:preset_tools
-                          in
-                          if Keeper_types_profile.keeper_debug
-                          then
-                            Log.Keeper.info
-                              "keeper:%s TopK_llm selected %d tools (query_len=%d, \
-                               candidates=%d)"
-                              meta.name
-                              (List.length selected)
-                              (String.length query_text)
-                              (List.length preset_tools);
-                          selected
+                       (match
+                          Oas_worker_named.resolve_cascade_providers
+                            ~cascade_name:rerank_cascade
                         with
-                        | Eio.Cancel.Cancelled _ as e -> raise e
-                        | exn ->
-                          Log.Keeper.warn
-                            "keeper:%s TopK_llm failed (%s), falling back to \
-                             core+prefilter+discovered"
-                            meta.name
-                            (Printexc.to_string exn);
-                          [])
+                        | provider :: _ ->
+                            let rerank_fn =
+                              Agent_sdk.Tool_selector.default_rerank_fn
+                                ~sw
+                                ~net
+                                ~provider
+                                ~k:selection_limit
+                                ()
+                            in
+                            let strategy =
+                              Agent_sdk.Tool_selector.TopK_llm
+                                { k = selection_limit
+                                ; bm25_prefilter_n =
+                                    min
+                                      keeper_selection_bm25_prefilter_n
+                                      (List.length preset_tools)
+                                ; always_include = core
+                                ; confidence_threshold = 0.3
+                                ; rerank_fn
+                                }
+                            in
+                            (try
+                               let selected =
+                                 Agent_sdk.Tool_selector.select_names
+                                   ~strategy
+                                   ~context:query_text
+                                   ~tools:preset_tools
+                               in
+                               if Keeper_types_profile.keeper_debug
+                               then
+                                 Log.Keeper.info
+                                   "keeper:%s TopK_llm selected %d tools (query_len=%d, \
+                                    candidates=%d)"
+                                   meta.name
+                                   (List.length selected)
+                                   (String.length query_text)
+                                   (List.length preset_tools);
+                               selected
+                             with
+                             | Eio.Cancel.Cancelled _ as e -> raise e
+                             | exn ->
+                               Log.Keeper.warn
+                                 "keeper:%s TopK_llm failed (%s), falling back to \
+                                  core+prefilter+discovered"
+                                 meta.name
+                                 (Printexc.to_string exn);
+                               [])
+                        | [] ->
+                            Log.Keeper.warn
+                              "keeper:%s TopK_llm: no rerank provider resolved, falling back \
+                               to core+prefilter+discovered"
+                              meta.name;
+                            [])
                      | _ ->
                        Log.Keeper.warn
                          "keeper:%s TopK_llm: Eio context unavailable, falling back \

--- a/lib/keeper/keeper_evidence.ml
+++ b/lib/keeper/keeper_evidence.ml
@@ -90,7 +90,7 @@ let capture_turn_evidence
   let files_changed = List.length status_lines in
   (* Collision detection *)
   let collision_warnings =
-    if files_changed > 0 then
+    if delta_detected && files_changed > 0 then
       Keeper_file_tracker.record_turn_files ~keeper_name ~files:status_lines
     else []
   in

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -17,6 +17,21 @@ let io_timeout_sec = env_float "MASC_KEEPER_IO_TIMEOUT_SEC" 30.0
 let read_timeout_sec = env_float "MASC_KEEPER_READ_TIMEOUT_SEC" 15.0
 let user_timeout_max_sec = env_float "MASC_KEEPER_USER_TIMEOUT_MAX_SEC" 180.0
 
+let normalize_gh_command (cmd : string) : string =
+  let tokens =
+    cmd
+    |> String.trim
+    |> String.split_on_char ' '
+    |> List.map String.trim
+    |> List.filter (fun token -> token <> "")
+  in
+  let rec drop_leading_gh = function
+    | token :: rest when String.lowercase_ascii token = "gh" ->
+        drop_leading_gh rest
+    | remaining -> remaining
+  in
+  String.concat " " (drop_leading_gh tokens)
+
 let clamp_shell_timeout ?(min_sec = 1.0) ~default args =
   Safe_ops.json_float ~default "timeout_sec" args
   |> fun n -> max min_sec (min user_timeout_max_sec n)
@@ -1008,7 +1023,10 @@ let handle_keeper_shell
                  ; "output", `String out
                  ]))
   | "gh" ->
-    let cmd_str = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
+    let cmd_str =
+      Safe_ops.json_string ~default:"" "cmd" args
+      |> normalize_gh_command
+    in
     let timeout_sec = clamp_shell_timeout ~default:io_timeout_sec args in
     if cmd_str = "" then
       error_json ~fields:[ "op", `String op ]

--- a/lib/keeper/keeper_gh_shared.ml
+++ b/lib/keeper/keeper_gh_shared.ml
@@ -39,6 +39,21 @@ let counter_misses = Atomic.make 0
 let counter_bypasses = Atomic.make 0
 let counter_fetch_errors = Atomic.make 0
 
+let normalize_gh_command (cmd : string) : string =
+  let tokens =
+    cmd
+    |> String.trim
+    |> String.split_on_char ' '
+    |> List.map String.trim
+    |> List.filter (fun token -> token <> "")
+  in
+  let rec drop_leading_gh = function
+    | token :: rest when String.lowercase_ascii token = "gh" ->
+        drop_leading_gh rest
+    | remaining -> remaining
+  in
+  String.concat " " (drop_leading_gh tokens)
+
 let parse_numbers_from_jq_output (out : string) : int list =
   out
   |> String.split_on_char '\n'
@@ -215,6 +230,7 @@ let gh_issue_number_subcmds =
 let extract_gh_target_number (cmd : string)
     : (entity_kind * int) option
   =
+  let cmd = normalize_gh_command cmd in
   let parts =
     String.split_on_char ' ' (String.trim cmd)
     |> List.filter (fun s -> s <> "")
@@ -239,6 +255,7 @@ let extract_gh_target_number (cmd : string)
     [state=all] is unchanged, but we still invalidate to resync state
     filters used elsewhere), and merges. *)
 let gh_mutates_entity (cmd : string) : entity_kind option =
+  let cmd = normalize_gh_command cmd in
   let parts =
     String.split_on_char ' ' (String.trim cmd)
     |> List.filter (fun s -> s <> "")
@@ -388,4 +405,3 @@ let correct_repo_flag ~(correct_slug : string) (cmd : string) : string * bool =
     in
     (corrected, corrected <> cmd)
   else (cmd, false)
-

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -157,6 +157,13 @@ let apply_post_turn_lifecycle
           let session =
             create_session ~session_id:(Keeper_id.Trace_id.to_string base_meta.runtime.trace_id) ~base_dir
           in
+          let compacted_ctx =
+            {
+              compacted_ctx with
+              messages =
+                repair_orphan_tool_result_messages compacted_ctx.messages;
+            }
+          in
           (match save_oas_checkpoint
                ~max_checkpoint_messages:base_meta.compaction.max_checkpoint_messages
                ~session
@@ -292,7 +299,7 @@ let recover_latest_checkpoint_for_overflow_retry
     Result.to_option oas_result
     |> Option.map (fun checkpoint ->
       let sanitized, stats =
-        sanitize_oas_checkpoint checkpoint
+        sanitize_oas_checkpoint ~repair_orphans:false checkpoint
       in
       if checkpoint_sanitize_changed stats then begin
         Log.Keeper.warn
@@ -335,6 +342,7 @@ let recover_latest_checkpoint_for_overflow_retry
         in
         Some
           ( context_of_oas_checkpoint
+              ~repair_orphans:false
               ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
               checkpoint
               ~primary_model_max_tokens,
@@ -359,6 +367,7 @@ let recover_latest_checkpoint_for_overflow_retry
                   in
                   Some
                     ( context_of_oas_checkpoint
+                        ~repair_orphans:false
                         ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
                         checkpoint
                         ~primary_model_max_tokens,
@@ -398,6 +407,13 @@ let recover_latest_checkpoint_for_overflow_retry
             before_tokens;
             after_tokens;
             saved_tokens = max 0 (before_tokens - after_tokens);
+          }
+        in
+        let compacted_ctx =
+          {
+            compacted_ctx with
+            messages =
+              repair_orphan_tool_result_messages compacted_ctx.messages;
           }
         in
         try

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -127,7 +127,6 @@ let apply_post_turn_lifecycle
   | Some cp ->
       let ctx =
         context_of_oas_checkpoint
-          ~repair_orphans:false
           ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
           cp
           ~primary_model_max_tokens
@@ -293,7 +292,7 @@ let recover_latest_checkpoint_for_overflow_retry
     Result.to_option oas_result
     |> Option.map (fun checkpoint ->
       let sanitized, stats =
-        sanitize_oas_checkpoint ~repair_orphans:false checkpoint
+        sanitize_oas_checkpoint checkpoint
       in
       if checkpoint_sanitize_changed stats then begin
         Log.Keeper.warn
@@ -336,7 +335,6 @@ let recover_latest_checkpoint_for_overflow_retry
         in
         Some
           ( context_of_oas_checkpoint
-              ~repair_orphans:false
               ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
               checkpoint
               ~primary_model_max_tokens,
@@ -361,7 +359,6 @@ let recover_latest_checkpoint_for_overflow_retry
                   in
                   Some
                     ( context_of_oas_checkpoint
-                        ~repair_orphans:false
                         ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
                         checkpoint
                         ~primary_model_max_tokens,

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -97,6 +97,7 @@ let maybe_rollover_oas_handoff
   | Some cp ->
       let ctx =
         context_of_oas_checkpoint
+          ~repair_orphans:false
           ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
           cp
           ~primary_model_max_tokens
@@ -147,11 +148,18 @@ let maybe_rollover_oas_handoff
           let new_session =
             create_session ~session_id:new_trace_id ~base_dir
           in
+          let save_ctx =
+            {
+              ctx with
+              messages =
+                repair_orphan_tool_result_messages ctx.messages;
+            }
+          in
           match save_oas_checkpoint
                   ~max_checkpoint_messages:base_meta.compaction.max_checkpoint_messages
                   ~session:new_session
                   ~agent_name:base_meta.agent_name
-                  ~model ~ctx ~generation:next_generation with
+                  ~model ~ctx:save_ctx ~generation:next_generation with
           | Error e ->
               Log.Keeper.error
                 "keeper:%s OAS handoff rollover ABORTED — checkpoint save failed: %s"

--- a/lib/keeper/keeper_rollover.ml
+++ b/lib/keeper/keeper_rollover.ml
@@ -97,7 +97,6 @@ let maybe_rollover_oas_handoff
   | Some cp ->
       let ctx =
         context_of_oas_checkpoint
-          ~repair_orphans:false
           ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
           cp
           ~primary_model_max_tokens

--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -187,11 +187,26 @@ let is_gh_api_read_only (cmd_lower : string) : bool =
 
 (** Extract the effective gh command string from keeper_shell op=gh input.
     [keeper_exec_shell] uses the [cmd] field. *)
+let normalize_gh_command (cmd : string) : string =
+  let tokens =
+    cmd
+    |> String.trim
+    |> String.split_on_char ' '
+    |> List.map String.trim
+    |> List.filter (fun token -> token <> "")
+  in
+  let rec drop_leading_gh = function
+    | token :: rest when String.lowercase_ascii token = "gh" ->
+        drop_leading_gh rest
+    | remaining -> remaining
+  in
+  String.concat " " (drop_leading_gh tokens)
+
 let gh_effective_cmd (input : Yojson.Safe.t) : string =
   match input with
   | `Assoc fields ->
     (match List.assoc_opt "cmd" fields with
-     | Some (`String s) -> String.trim s
+     | Some (`String s) -> normalize_gh_command s
      | _ -> "")
   | _ -> ""
 

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -41,27 +41,10 @@ let allowed_shell_commands = [
 ]
 
 let validate_code_shell_command (command : string) : (unit, string) result =
-  let trimmed = String.trim command in
-  if trimmed = "" then Error "command must not be empty"
-  else if Worker_dev_tools.contains_forbidden_shell_chars_coding trimmed then
-    Error "Shell injection syntax (;, &&, standalone &, `, $) not allowed."
-  else if Worker_dev_tools.has_process_substitution trimmed then
-    Error "Process substitution (<(...) or >(...)) is not allowed."
-  else if Worker_dev_tools.has_unsafe_redirection trimmed then
-    Error "File redirects are not allowed. Only fd redirects like 2>&1 are permitted."
-  else
-    match Worker_dev_tools.split_pipeline_segments trimmed with
-    | Error _ as err -> err
-    | Ok [_segment] -> (
-        match Worker_dev_tools.extract_command_name trimmed with
-        | None -> Error "command must not be empty"
-        | Some name when List.mem name allowed_shell_commands -> Ok ()
-        | Some name ->
-            Error
-              (Printf.sprintf "Command '%s' not in allowlist: %s"
-                 name (String.concat ", " allowed_shell_commands)))
-    | Ok _ ->
-        Error "Pipes are not allowed in masc_code_shell. Run one command per call."
+  Worker_dev_tools.validate_command_coding_with_allowlist
+    ~allow_pipes:false
+    ~allowed_commands:allowed_shell_commands
+    command
 
 let git_common_root path =
   try

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -32,6 +32,53 @@ let first_nonempty_line output =
   |> List.map String.trim
   |> List.find_opt (fun s -> s <> "")
 
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  if nlen = 0 then true
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+let masked_build_pipeline_reason (command : string) : string option =
+  let normalized =
+    command
+    |> String.trim
+    |> String.lowercase_ascii
+  in
+  let starts_with_build_or_test =
+    List.exists
+      (fun prefix -> String.starts_with ~prefix normalized)
+      [
+        "dune build";
+        "dune runtest";
+        "make";
+        "npm test";
+        "npm run test";
+        "npm run build";
+        "pnpm test";
+        "pnpm run test";
+        "pnpm run build";
+        "yarn test";
+        "yarn build";
+        "cargo test";
+        "cargo check";
+        "pytest";
+        "go test";
+        "tsc";
+      ]
+  in
+  if starts_with_build_or_test && contains_substring normalized "|" then
+    Some
+      "Build/test commands must run directly in masc_code_shell. \
+       Do not pipe them through tail/head/grep; this tool already truncates \
+       output, and piping hides progress until EOF which can trigger timeouts."
+  else None
+
 let git_common_root path =
   try
     match
@@ -469,6 +516,10 @@ let handle_code_shell ctx args =
 
   if command = "" then (false, "command parameter required")
   else begin
+    match masked_build_pipeline_reason command with
+    | Some reason -> (false, reason)
+    | None ->
+      begin
     (* Parse first token to check allowlist *)
     let tokens = String.split_on_char ' ' (String.trim command) in
     let executable = match tokens with
@@ -510,6 +561,7 @@ let handle_code_shell ctx args =
         | _, output ->
           (false, Printf.sprintf "Command failed: %s" (truncate_output output))
     end
+  end
   end
 
 (* Handler: masc_code_git — Git operations *)

--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -32,52 +32,36 @@ let first_nonempty_line output =
   |> List.map String.trim
   |> List.find_opt (fun s -> s <> "")
 
-let contains_substring haystack needle =
-  let hlen = String.length haystack in
-  let nlen = String.length needle in
-  if nlen = 0 then true
-  else
-    let rec loop i =
-      if i + nlen > hlen then false
-      else if String.sub haystack i nlen = needle then true
-      else loop (i + 1)
-    in
-    loop 0
+(* Shell command allowlist *)
+let allowed_shell_commands = [
+  "dune"; "make"; "npm"; "npx"; "node";
+  "git"; "ls"; "cat"; "head"; "tail"; "wc";
+  "rg"; "find"; "diff"; "patch"; "mkdir";
+  "opam"; "ocamlfind"; "tsc";
+]
 
-let masked_build_pipeline_reason (command : string) : string option =
-  let normalized =
-    command
-    |> String.trim
-    |> String.lowercase_ascii
-  in
-  let starts_with_build_or_test =
-    List.exists
-      (fun prefix -> String.starts_with ~prefix normalized)
-      [
-        "dune build";
-        "dune runtest";
-        "make";
-        "npm test";
-        "npm run test";
-        "npm run build";
-        "pnpm test";
-        "pnpm run test";
-        "pnpm run build";
-        "yarn test";
-        "yarn build";
-        "cargo test";
-        "cargo check";
-        "pytest";
-        "go test";
-        "tsc";
-      ]
-  in
-  if starts_with_build_or_test && contains_substring normalized "|" then
-    Some
-      "Build/test commands must run directly in masc_code_shell. \
-       Do not pipe them through tail/head/grep; this tool already truncates \
-       output, and piping hides progress until EOF which can trigger timeouts."
-  else None
+let validate_code_shell_command (command : string) : (unit, string) result =
+  let trimmed = String.trim command in
+  if trimmed = "" then Error "command must not be empty"
+  else if Worker_dev_tools.contains_forbidden_shell_chars_coding trimmed then
+    Error "Shell injection syntax (;, &&, standalone &, `, $) not allowed."
+  else if Worker_dev_tools.has_process_substitution trimmed then
+    Error "Process substitution (<(...) or >(...)) is not allowed."
+  else if Worker_dev_tools.has_unsafe_redirection trimmed then
+    Error "File redirects are not allowed. Only fd redirects like 2>&1 are permitted."
+  else
+    match Worker_dev_tools.split_pipeline_segments trimmed with
+    | Error _ as err -> err
+    | Ok [_segment] -> (
+        match Worker_dev_tools.extract_command_name trimmed with
+        | None -> Error "command must not be empty"
+        | Some name when List.mem name allowed_shell_commands -> Ok ()
+        | Some name ->
+            Error
+              (Printf.sprintf "Command '%s' not in allowlist: %s"
+                 name (String.concat ", " allowed_shell_commands)))
+    | Ok _ ->
+        Error "Pipes are not allowed in masc_code_shell. Run one command per call."
 
 let git_common_root path =
   try
@@ -156,14 +140,6 @@ let validate_writable_path ~(agent_name : string) config path =
         agent_name
         agent_playground_prefix
         canonical_path))
-
-(* Shell command allowlist *)
-let allowed_shell_commands = [
-  "dune"; "make"; "npm"; "npx"; "node";
-  "git"; "ls"; "cat"; "head"; "tail"; "wc";
-  "rg"; "find"; "diff"; "patch"; "mkdir";
-  "opam"; "ocamlfind"; "tsc";
-]
 
 (* Git action allowlist *)
 let allowed_git_actions = [
@@ -515,54 +491,42 @@ let handle_code_shell ctx args =
   let timeout = get_int args "timeout" 30 in
 
   if command = "" then (false, "command parameter required")
-  else begin
-    match masked_build_pipeline_reason command with
-    | Some reason -> (false, reason)
-    | None ->
-      begin
-    (* Parse first token to check allowlist *)
-    let tokens = String.split_on_char ' ' (String.trim command) in
-    let executable = match tokens with
-      | [] -> ""
-      | exe :: _ -> Filename.basename exe
-    in
-
-    if not (List.mem executable allowed_shell_commands) then
-      (false, Printf.sprintf "Command '%s' not in allowlist: %s"
-         executable (String.concat ", " allowed_shell_commands))
-    else begin
-      (* Validate cwd if provided *)
-      let cwd_result =
-        if cwd = "" then Ok None
-        else match validate_writable_path ~agent_name:ctx.agent_name ctx.config cwd with
-          | Ok abs_cwd -> Ok (Some abs_cwd)
-          | Error e -> Error e
-      in
-      match cwd_result with
-      | Error e -> (false, Types.masc_error_to_string e)
-      | Ok cwd_opt ->
-        let safe_timeout = Float.of_int (max 5 (min 120 timeout)) in
-        let cmd_parts = ["sh"; "-c"; command] in
-        let full_cmd = match cwd_opt with
-          | None -> cmd_parts
-          | Some dir -> ["sh"; "-c"; Printf.sprintf "cd %s && %s"
-                           (Filename.quote dir) command]
+  else
+    match validate_code_shell_command command with
+    | Error reason -> (false, reason)
+    | Ok () ->
+        (* Validate cwd if provided *)
+        let cwd_result =
+          if cwd = "" then Ok None
+          else
+            match validate_writable_path ~agent_name:ctx.agent_name ctx.config cwd with
+            | Ok abs_cwd -> Ok (Some abs_cwd)
+            | Error e -> Error e
         in
-        match Process_eio.run_argv_with_status ~timeout_sec:safe_timeout full_cmd with
-        | Unix.WEXITED code, output ->
-          let response = `Assoc [
-            ("status", `String (if code = 0 then "ok" else "error"));
-            ("exit_code", `Int code);
-            ("output", `String (truncate_output output));
-            ("command", `String command);
-            ("agent", `String ctx.agent_name);
-          ] in
-          (code = 0, Yojson.Safe.pretty_to_string response)
-        | _, output ->
-          (false, Printf.sprintf "Command failed: %s" (truncate_output output))
-    end
-  end
-  end
+        (match cwd_result with
+         | Error e -> (false, Types.masc_error_to_string e)
+         | Ok cwd_opt ->
+             let safe_timeout = Float.of_int (max 5 (min 120 timeout)) in
+             let cmd_parts = ["sh"; "-c"; command] in
+             let full_cmd =
+               match cwd_opt with
+               | None -> cmd_parts
+               | Some dir ->
+                   [ "sh"; "-c"; Printf.sprintf "cd %s && %s"
+                       (Filename.quote dir) command ]
+             in
+             match Process_eio.run_argv_with_status ~timeout_sec:safe_timeout full_cmd with
+             | Unix.WEXITED code, output ->
+                 let response = `Assoc [
+                   ("status", `String (if code = 0 then "ok" else "error"));
+                   ("exit_code", `Int code);
+                   ("output", `String (truncate_output output));
+                   ("command", `String command);
+                   ("agent", `String ctx.agent_name);
+                 ] in
+                 (code = 0, Yojson.Safe.pretty_to_string response)
+             | _, output ->
+                 (false, Printf.sprintf "Command failed: %s" (truncate_output output)))
 
 (* Handler: masc_code_git — Git operations *)
 let handle_code_git ctx args =
@@ -786,7 +750,7 @@ Returns exit_code and stdout (truncated at " ^ max_output_label ^ ").";
       ("properties", `Assoc [
         ("command", `Assoc [
           ("type", `String "string");
-          ("description", `String "Shell command to run (first token must be in allowlist)");
+          ("description", `String "Single shell command to run (no pipes/chaining; first token must be in allowlist)");
         ]);
         ("cwd", `Assoc [
           ("type", `String "string");

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -221,10 +221,10 @@ let validate_command_with_allowlist ~allowed_commands cmd =
 let validate_command cmd =
   validate_command_with_allowlist ~allowed_commands:dev_allowed_commands cmd
 
-(** Relaxed command validation for Coding/Full preset keepers.
-    Allows pipes and redirects; validates every command in the pipeline
-    against [dev_allowed_commands]. *)
-let validate_command_coding cmd =
+let validate_command_coding_with_allowlist
+    ?(allow_pipes = true)
+    ~(allowed_commands : string list)
+    cmd =
   let trimmed = String.trim cmd in
   if trimmed = "" then Error "command must not be empty"
   else if contains_forbidden_shell_chars_coding trimmed then
@@ -237,12 +237,15 @@ let validate_command_coding cmd =
     match split_pipeline_segments trimmed with
     | Error _ as err -> err
     | Ok segments ->
+      if (not allow_pipes) && List.length segments > 1 then
+        Error "Pipes are not allowed. Run one command per call."
+      else
       let rec validate_segments = function
         | [] -> Ok ()
         | segment :: rest -> (
             match extract_command_name segment with
             | None -> Error "command must not be empty"
-            | Some name when List.mem name dev_allowed_commands ->
+            | Some name when List.mem name allowed_commands ->
               validate_segments rest
             | Some name ->
               Error
@@ -251,6 +254,15 @@ let validate_command_coding cmd =
                    name))
       in
       validate_segments segments
+
+(** Relaxed command validation for Coding/Full preset keepers.
+    Allows pipes and redirects; validates every command in the pipeline
+    against [dev_allowed_commands]. *)
+let validate_command_coding cmd =
+  validate_command_coding_with_allowlist
+    ~allow_pipes:true
+    ~allowed_commands:dev_allowed_commands
+    cmd
 
 let strip_wrapping_quotes token =
   let len = String.length token in

--- a/test/test_keeper_github_read_only.ml
+++ b/test/test_keeper_github_read_only.ml
@@ -61,6 +61,25 @@ let test_read_only_case_insensitive () =
   Alcotest.(check bool) "Pr View mixed"
     true (is_ro ~tool_name:"keeper_shell" ~input:(mk_cmd "Pr View 123"))
 
+let test_prefixed_gh_command_normalization () =
+  Alcotest.(check (option int)) "prefixed gh parser still finds PR number"
+    (Some 123)
+    (match Keeper_gh_shared.extract_gh_target_number "gh pr view 123" with
+     | Some (Keeper_gh_shared.PR, n) -> Some n
+     | _ -> None);
+  Alcotest.(check (option string)) "prefixed gh parser still finds mutation"
+    (Some "pr")
+    (match Keeper_gh_shared.gh_mutates_entity "gh pr merge 123" with
+     | Some Keeper_gh_shared.PR -> Some "pr"
+     | Some Keeper_gh_shared.Issue -> Some "issue"
+     | None -> None);
+  Alcotest.(check bool) "prefixed gh command stays read-only"
+    true
+    (is_ro ~tool_name:"keeper_shell" ~input:(mk_cmd "gh pr list --state open"));
+  Alcotest.(check bool) "prefixed gh merge stays mutating"
+    true
+    (has_side_effect ~tool_name:"keeper_shell" ~input:(mk_cmd "gh pr merge 123"))
+
 (* ================================================================ *)
 (* Read-only subcommands via args                                    *)
 (* ================================================================ *)
@@ -344,6 +363,8 @@ let () =
             test_read_only_cmd_prefixes;
           Alcotest.test_case "case insensitive" `Quick
             test_read_only_case_insensitive;
+          Alcotest.test_case "prefixed gh command normalization" `Quick
+            test_prefixed_gh_command_normalization;
         ] );
       ( "read_only_args",
         [

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -588,6 +588,153 @@ let test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_
           fail
             "expected overflow retry recovery to keep message history within budget even with a large checkpoint system prompt")
 
+let test_recover_latest_checkpoint_for_overflow_retry_repairs_orphan_tool_result () =
+  let base_dir = temp_dir "keeper_lifecycle_overflow_retry_orphan" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let trace_id = "trace-overflow-retry-orphan" in
+      let meta = make_keeper_meta ~trace_id () in
+      let orphan_id = "call-overflow-orphan" in
+      let dense_ctx =
+        build_dense_context ~turns:22 ~max_tokens:4096
+          ~state_reply:
+            "done\n\n[STATE]\nGoal: repair orphan on overflow retry\nProgress: ready\n[/STATE]"
+      in
+      let checkpoint = save_checkpoint ~base_dir ~meta ~ctx:dense_ctx in
+      let checkpoint =
+        { checkpoint with
+          messages =
+            {
+              Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+              content =
+                [
+                  Agent_sdk.Types.ToolResult
+                    {
+                      tool_use_id = orphan_id;
+                      content = "";
+                      is_error = false;
+                      json = Some (`Assoc [ ("path", `String "README.md") ]);
+                    };
+                ];
+              name = None;
+              tool_call_id = None;
+            }
+            :: checkpoint.messages;
+        }
+      in
+      let session = KEC.create_session ~session_id:trace_id ~base_dir in
+      (match
+         Masc_mcp.Keeper_checkpoint_store.save_oas
+           ~session_dir:session.session_dir checkpoint
+       with
+       | Ok () -> ()
+       | Error _ -> Alcotest.fail "save_oas raw orphan checkpoint failed");
+      match
+        KEC.recover_latest_checkpoint_for_overflow_retry ~base_dir ~meta
+          ~model:"llama:auto" ~primary_model_max_tokens:256
+      with
+      | Some recovery ->
+          check (option string)
+            "overflow retry drops structured orphan tool result" None
+            (tool_result_content_for_id ~tool_use_id:orphan_id
+               recovery.checkpoint.messages)
+      | None -> fail "expected overflow retry recovery from orphan checkpoint")
+
+let test_rollover_repairs_orphan_tool_result () =
+  let base_dir = temp_dir "keeper_lifecycle_rollover_orphan" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let trace_id = "trace-rollover-orphan" in
+      let meta =
+        {
+          (make_keeper_meta ~trace_id ()) with
+          auto_handoff = true;
+          handoff_threshold = 0.0;
+          handoff_cooldown_sec = 0;
+        }
+      in
+      let orphan_id = "call-rollover-orphan" in
+      let checkpoint =
+        {
+          Agent_sdk.Checkpoint.version = Agent_sdk.Checkpoint.checkpoint_version;
+          session_id = trace_id;
+          agent_name = "patch-test";
+          model = "test-model";
+          system_prompt = None;
+          messages =
+            [
+              {
+                Agent_sdk.Types.role = Agent_sdk.Types.Tool;
+                content =
+                  [
+                    Agent_sdk.Types.ToolResult
+                      {
+                        tool_use_id = orphan_id;
+                        content = "";
+                        is_error = false;
+                        json = Some (`Assoc [ ("path", `String "lib/keeper.ml") ]);
+                      };
+                  ];
+                name = None;
+                tool_call_id = None;
+              };
+              Agent_sdk.Types.assistant_msg
+                "done\n\n[STATE]\nGoal: rollover orphan repair\nProgress: ready\n[/STATE]";
+            ];
+          usage = Agent_sdk.Types.empty_usage;
+          turn_count = 2;
+          created_at = 0.0;
+          tools = [];
+          tool_choice = None;
+          disable_parallel_tool_use = false;
+          temperature = None;
+          top_p = None;
+          top_k = None;
+          min_p = None;
+          enable_thinking = None;
+          response_format_json = false;
+          thinking_budget = None;
+          cache_system_prompt = false;
+          max_input_tokens = None;
+          max_total_tokens = Some 4096;
+          context = Agent_sdk.Context.create ();
+          mcp_sessions = [];
+          working_context = None;
+        }
+      in
+      let rollover =
+        KEC.maybe_rollover_oas_handoff
+          ~on_started:(fun () -> ())
+          ~base_dir
+          ~meta
+          ~model:"llama:auto"
+          ~primary_model_max_tokens:256
+          ~checkpoint:(Some checkpoint)
+      in
+      check bool "rollover attempted" true rollover.attempted;
+      let next_trace_id =
+        Masc_mcp.Keeper_id.Trace_id.to_string rollover.updated_meta.runtime.trace_id
+      in
+      let next_session = KEC.create_session ~session_id:next_trace_id ~base_dir in
+      match
+        Masc_mcp.Keeper_checkpoint_store.load_oas
+          ~session_dir:next_session.session_dir
+          ~session_id:next_trace_id
+      with
+      | Ok saved ->
+          check (option string)
+            "rollover drops structured orphan tool result" None
+            (tool_result_content_for_id ~tool_use_id:orphan_id saved.messages)
+      | Error _ -> Alcotest.fail "load_oas rollover checkpoint failed")
+
 (* --- patch_checkpoint_last_assistant tests (#5431) --- *)
 
 let make_test_checkpoint ?(session_id = "old-session")
@@ -1526,6 +1673,10 @@ let () =
             "overflow retry history budget ignores checkpoint system prompt"
             `Quick
             test_recover_latest_checkpoint_for_overflow_retry_ignores_checkpoint_system_prompt_in_history_budget;
+          test_case "overflow retry repairs orphan tool result" `Quick
+            test_recover_latest_checkpoint_for_overflow_retry_repairs_orphan_tool_result;
+          test_case "rollover repairs orphan tool result" `Quick
+            test_rollover_repairs_orphan_tool_result;
         ] );
       ( "checkpoint_patch",
         [

--- a/test/test_keeper_mutex_coverage.ml
+++ b/test/test_keeper_mutex_coverage.ml
@@ -116,6 +116,45 @@ let test_keeper_evidence_chain_verifies () =
         (Printf.sprintf "evidence chain mismatch at turn %d: %s <> %s" turn
            expected actual)
 
+let collision_count (json : Yojson.Safe.t option) =
+  match json with
+  | Some (`Assoc fields) ->
+      (match List.assoc_opt "collision_warnings" fields with
+       | Some (`List warnings) -> List.length warnings
+       | _ -> 0)
+  | _ -> 0
+
+let test_keeper_evidence_ignores_preexisting_dirty_state_without_delta () =
+  with_eio_env @@ fun _env ->
+  with_temp_dir "keeper-evidence-preexisting-dirty" @@ fun base_path ->
+  init_git_repo base_path;
+  let gitignore = Filename.concat base_path ".gitignore" in
+  let tracked = Filename.concat base_path "shared.ml" in
+  Out_channel.with_open_bin gitignore (fun oc -> output_string oc ".masc/\n");
+  Out_channel.with_open_bin tracked (fun oc -> output_string oc "let shared = 1\n");
+  run_in_dir base_path "git add .gitignore shared.ml && git commit -q -m init";
+  Out_channel.with_open_bin tracked (fun oc -> output_string oc "let shared = 2\n");
+  let before_alpha =
+    Keeper_evidence.snapshot_before_turn ~base_path ~keeper_name:"alpha"
+  in
+  let before_beta =
+    Keeper_evidence.snapshot_before_turn ~base_path ~keeper_name:"beta"
+  in
+  let ev1 =
+    Keeper_evidence.capture_turn_evidence ~base_path ~keeper_name:"alpha"
+      ~trace_id:"trace-a" ~turn_number:1 ~tool_calls_made:0
+      ~before_hash:before_alpha ()
+  in
+  let ev2 =
+    Keeper_evidence.capture_turn_evidence ~base_path ~keeper_name:"beta"
+      ~trace_id:"trace-b" ~turn_number:1 ~tool_calls_made:0
+      ~before_hash:before_beta ()
+  in
+  Alcotest.(check int) "first keeper sees no collision without new delta" 0
+    (collision_count ev1);
+  Alcotest.(check int) "second keeper also sees no collision without new delta" 0
+    (collision_count ev2)
+
 let () =
   run "keeper_mutex_coverage"
     [
@@ -129,5 +168,7 @@ let () =
       "keeper_evidence", [
         test_case "hash chain verifies in git repo" `Quick
           test_keeper_evidence_chain_verifies;
+        test_case "ignores preexisting dirty state without delta" `Quick
+          test_keeper_evidence_ignores_preexisting_dirty_state_without_delta;
       ];
     ]

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -177,6 +177,36 @@ let test_mixed_case_org () =
     (Tool_code_write.validate_clone_url ~base_path:bp
        "https://github.com/Jeong-Sik/repo.git")
 
+(* ── masked_build_pipeline_reason ─────────────────────────────────── *)
+
+let test_masked_build_pipeline_rejected () =
+  let reason_contains needle haystack =
+    let hlen = String.length haystack in
+    let nlen = String.length needle in
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    if nlen = 0 then true else loop 0
+  in
+  match
+    Tool_code_write.masked_build_pipeline_reason
+      "dune build 2>&1 | tail -5"
+  with
+  | Some reason ->
+      check bool "reason mentions piping" true
+        (reason_contains "Do not pipe" reason)
+  | None -> fail "expected build pipeline to be rejected"
+
+let test_masked_build_pipeline_allows_direct_build () =
+  check (option string) "direct build allowed" None
+    (Tool_code_write.masked_build_pipeline_reason "dune build 2>&1")
+
+let test_masked_build_pipeline_allows_non_build_pipe () =
+  check (option string) "non-build pipe allowed" None
+    (Tool_code_write.masked_build_pipeline_reason "git diff | tail -5")
+
 (* ── Per-agent containment (#6527 iter 6) ───────────────────────────
    Regression tests for PR #6610 — verify that validate_writable_path
    and validate_clone_cwd refuse cross-agent playground writes even
@@ -353,6 +383,14 @@ let () =
       test_case "missing config fails closed" `Quick test_missing_base_path_without_config_fails_closed;
       test_case "explicit config dir override still validates" `Quick test_explicit_config_dir_override_still_validates;
       test_case "mixed-case org" `Quick test_mixed_case_org;
+    ]);
+    ("masked_build_pipeline_reason", [
+      test_case "rejects build pipeline" `Quick
+        test_masked_build_pipeline_rejected;
+      test_case "allows direct build" `Quick
+        test_masked_build_pipeline_allows_direct_build;
+      test_case "allows non-build pipe" `Quick
+        test_masked_build_pipeline_allows_non_build_pipe;
     ]);
     ("per_agent_containment_6527_iter6", [
       test_case "writable_path allows own playground" `Quick

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -177,35 +177,31 @@ let test_mixed_case_org () =
     (Tool_code_write.validate_clone_url ~base_path:bp
        "https://github.com/Jeong-Sik/repo.git")
 
-(* ── masked_build_pipeline_reason ─────────────────────────────────── *)
+(* ── validate_code_shell_command ─────────────────────────────────── *)
 
-let test_masked_build_pipeline_rejected () =
-  let reason_contains needle haystack =
-    let hlen = String.length haystack in
-    let nlen = String.length needle in
-    let rec loop i =
-      if i + nlen > hlen then false
-      else if String.sub haystack i nlen = needle then true
-      else loop (i + 1)
-    in
-    if nlen = 0 then true else loop 0
-  in
+let test_validate_code_shell_command_rejects_pipe () =
   match
-    Tool_code_write.masked_build_pipeline_reason
+    Tool_code_write.validate_code_shell_command
       "dune build 2>&1 | tail -5"
   with
-  | Some reason ->
-      check bool "reason mentions piping" true
-        (reason_contains "Do not pipe" reason)
-  | None -> fail "expected build pipeline to be rejected"
+  | Error reason ->
+      check bool "reason mentions pipe restriction" true
+        (String.starts_with ~prefix:"Pipes are not allowed" reason)
+  | Ok () -> fail "expected piped command to be rejected"
 
-let test_masked_build_pipeline_allows_direct_build () =
-  check (option string) "direct build allowed" None
-    (Tool_code_write.masked_build_pipeline_reason "dune build 2>&1")
+let test_validate_code_shell_command_allows_direct_build () =
+  check (result unit string) "direct build allowed" (Ok ())
+    (Tool_code_write.validate_code_shell_command "dune build 2>&1")
 
-let test_masked_build_pipeline_allows_non_build_pipe () =
-  check (option string) "non-build pipe allowed" None
-    (Tool_code_write.masked_build_pipeline_reason "git diff | tail -5")
+let test_validate_code_shell_command_rejects_semicolon () =
+  match
+    Tool_code_write.validate_code_shell_command
+      "dune build; tail -5"
+  with
+  | Error reason ->
+      check bool "reason mentions shell injection" true
+        (String.starts_with ~prefix:"Shell injection syntax" reason)
+  | Ok () -> fail "expected semicolon chaining to be rejected"
 
 (* ── Per-agent containment (#6527 iter 6) ───────────────────────────
    Regression tests for PR #6610 — verify that validate_writable_path
@@ -384,13 +380,13 @@ let () =
       test_case "explicit config dir override still validates" `Quick test_explicit_config_dir_override_still_validates;
       test_case "mixed-case org" `Quick test_mixed_case_org;
     ]);
-    ("masked_build_pipeline_reason", [
-      test_case "rejects build pipeline" `Quick
-        test_masked_build_pipeline_rejected;
+    ("validate_code_shell_command", [
+      test_case "rejects pipe" `Quick
+        test_validate_code_shell_command_rejects_pipe;
       test_case "allows direct build" `Quick
-        test_masked_build_pipeline_allows_direct_build;
-      test_case "allows non-build pipe" `Quick
-        test_masked_build_pipeline_allows_non_build_pipe;
+        test_validate_code_shell_command_allows_direct_build;
+      test_case "rejects semicolon" `Quick
+        test_validate_code_shell_command_rejects_semicolon;
     ]);
     ("per_agent_containment_6527_iter6", [
       test_case "writable_path allows own playground" `Quick

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -531,6 +531,34 @@ let () =
         match Worker_dev_tools.validate_command_coding "dune test 2>&1" with
         | Ok () -> ()
         | Error e -> Alcotest.fail ("should allow 2>&1: " ^ e));
+      Alcotest.test_case "single-command contract rejects pipe" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding_with_allowlist
+            ~allow_pipes:false
+            ~allowed_commands:["dune"; "git"; "head"]
+            "dune build 2>&1 | tail -5"
+        with
+        | Error reason when String.starts_with ~prefix:"Pipes are not allowed" reason -> ()
+        | Error reason -> Alcotest.fail ("wrong rejection: " ^ reason)
+        | Ok () -> Alcotest.fail "should reject pipe under single-command contract");
+      Alcotest.test_case "single-command contract keeps redirect" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding_with_allowlist
+            ~allow_pipes:false
+            ~allowed_commands:["dune"; "git"; "head"]
+            "dune build 2>&1"
+        with
+        | Ok () -> ()
+        | Error e -> Alcotest.fail ("should allow direct build with fd redirect: " ^ e));
+      Alcotest.test_case "single-command contract enforces custom allowlist" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_command_coding_with_allowlist
+            ~allow_pipes:false
+            ~allowed_commands:["git"]
+            "dune build"
+        with
+        | Error _ -> ()
+        | Ok () -> Alcotest.fail "should reject command outside custom allowlist");
     ];
     "is_destructive_bash_operation", [
       Alcotest.test_case "blocks force push" `Quick (fun () ->


### PR DESCRIPTION
## Summary
- normalize `keeper_shell op=gh` commands so accidental `gh gh ...` prefixes do not break execution
- repair orphaned checkpoint `ToolResult` blocks during overflow retry and rollover recovery
- suppress cross-keeper collision warnings when the worktree was already dirty and no new delta was introduced this turn
- move `masc_code_shell` onto the shared structural command validator and enforce a single-command contract without string-prefix heuristics
- restore the keeper rerank call to the repo's pinned `agent_sdk 0.141.x` interface so CI and local truth match again

## Root Cause
- keepers sometimes passed `cmd` values that already included the `gh` binary name, while the shell executor always prepended `gh`, producing `gh gh ...`
- overflow retry and rollover paths explicitly disabled orphan repair, allowing stale `tool_result` blocks to survive into the next provider request and trigger `unexpected tool_use_id` errors
- evidence collision tracking recorded every dirty file on every turn, even when the turn itself did not create a new delta, so pre-existing dirty state caused repeated false-positive keeper collision warnings
- `masc_code_shell` accepted shell pipelines and chained commands as raw strings, which let keepers hide long-running build output behind `| tail -5`
- this branch briefly mixed a newer `agent_sdk` rerank API into code that still targets the repo's pinned `0.141.x` interface

## Product Impact
- keeper GitHub CLI calls are resilient to duplicated `gh` prefixes
- stale checkpoint history no longer reintroduces invalid tool-result pairs during recovery paths
- collision logs are quieter and better aligned with actual overlapping writes
- `masc_code_shell` now rejects pipes/chaining structurally while still allowing a single allowed command with safe fd redirection like `2>&1`
- the rerank path stays compatible with the SDK version CI actually installs

## Evidence
- keeper logs showed `gh gh pr list --head ...` failures from duplicated prefixes
- keeper logs showed Anthropic request failures with `unexpected tool_use_id found in tool_result blocks`
- keeper logs showed repeated cross-keeper collision warnings from pre-existing dirty state
- keeper logs showed `masc_code_shell` timeouts on `dune build 2>&1 | tail -5`
- GitHub Actions on this PR failed in `Lint`, `Health`, and `Build and Test` with `keeper_agent_run.ml` calling `default_rerank_fn` using unsupported `~provider` against the pinned SDK interface

## Review Evidence
- focused regression tests cover gh normalization, orphan repair, collision noise suppression, and structural command validation
- CI failures were inspected directly from the PR's GitHub Actions logs before the rerank compatibility fix was pushed
- local pin drift was confirmed with `scripts/check-oas-pin.sh`, which reported the switch was pinned to a newer OAS SHA than the repo expects

## Linked Issue
- Refs #7205

## Validation
- `dune build --root . -j 1 test/test_keeper_github_read_only.exe test/test_keeper_lifecycle.exe test/test_keeper_mutex_coverage.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH='' GRAPHQL_API_KEY='' ZAI_API_KEY='' _build/default/test/test_keeper_github_read_only.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH='' GRAPHQL_API_KEY='' ZAI_API_KEY='' _build/default/test/test_keeper_lifecycle.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH='' GRAPHQL_API_KEY='' ZAI_API_KEY='' _build/default/test/test_keeper_mutex_coverage.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH='' GRAPHQL_API_KEY='' ZAI_API_KEY='' _build/default/test/test_worker_dev_tools.exe`
- `env MASC_STORAGE_TYPE=filesystem MASC_BASE_PATH='' GRAPHQL_API_KEY='' ZAI_API_KEY='' _build/default/test/test_tool_code_write_coverage.exe`
- `scripts/check-oas-pin.sh` (reported local pin drift to a newer OAS SHA than the repo's pinned truth)
