### PR TITLE
fix(tempo): route tempo.json through Room_utils.masc_dir

### DIFF
--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -33,7 +33,7 @@ let default_config = {
 
 (** Get tempo file path *)
 let tempo_file (config : Room_utils.config) =
-  Filename.concat config.base_path ".masc/tempo.json"
+  Filename.concat (Room_utils.masc_dir config) "tempo.json"
 
 (** State to JSON *)
 let state_to_json (state : tempo_state) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary

`lib/tempo.ml`의 tempo.json 저장 경로를 `Room_utils.masc_dir config` 경유로 변경.

Hardcoded `.masc/` 리터럴 concat을 제거하여 cluster namespace를 올바르게 반영하도록 수정.

## Product impact

- **기본 cluster**: 동일한 결과 (`<base>/.masc/tempo.json`). 런타임 의미론 무변경.
- **Non-default cluster** (`MASC_CLUSTER_NAME`이 설정된 경우): 이제 `<base>/.masc/clusters/<name>/tempo.json`으로 resolve. Goal/Task storage와 일치.

## Evidence

### Before

\`\`\`ocaml
let tempo_file (config : Room_utils.config) =
  Filename.concat config.base_path ".masc/tempo.json"
\`\`\`

### After

\`\`\`ocaml
let tempo_file (config : Room_utils.config) =
  Filename.concat (Room_utils.masc_dir config) "tempo.json"
\`\`\`

## Scope

Issue #7340은 3개 파일 bypass를 지적하지만, 이 PR은 **tempo.ml만** 수정.

| 파일 | 이 PR 처리 | 이유 |
|------|---------|------|
| \`lib/tempo.ml\` | ✅ 수정 | 이미 config 인자 받음, 경로 교체만 |
| \`lib/board_core.ml\` | ❌ follow-up | \`Env_config_core.base_path()\` 직접 사용, config 인자 추가해야 함 (API 변경) |
| \`lib/voice/voice_config.ml\` | ❌ follow-up | 동일한 이유, init 시점 호출되어 config 미가용 |

board_core / voice_config은 콜 체인 전반에 \`~config\` 인자 전파가 필요. 후속 PR에서 처리 예정.

## Review evidence

- [x] \`dune build --root .\` — clean
- [x] \`dune runtest\` — all green

## Linked issue

Refs #7340

🤖 Generated with [Claude Code](https://claude.com/claude-code)