### PR TITLE
feat(dashboard): 1-9 number-key keeper shortcuts

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -216,6 +216,27 @@ export function FsmHub() {
     })()
   }, [activeSelected, shouldRefetchForTick, pollTick])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.metaKey || ev.ctrlKey || ev.altKey) return
+      const target = ev.target as HTMLElement | null
+      if (target) {
+        const tag = target.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+        if (target.isContentEditable) return
+      }
+      if (ev.key < '1' || ev.key > '9') return
+      const idx = ev.key.charCodeAt(0) - '1'.charCodeAt(0)
+      const target_name = keeperNames[idx]
+      if (!target_name) return
+      ev.preventDefault()
+      setSelected(target_name)
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [keeperNames])
+
   const view = useMemo(
     () =>
       hub.keeperName === activeSelected
@@ -412,6 +433,7 @@ function StatusBar({
                 tabindex=${active ? 0 : -1}
                 class=${`rounded-full border px-2.5 py-0.5 text-[10px] font-mono transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--bg-0)] ${cls}`}
                 onClick=${() => onSelect(name)}
+                title=${i < 9 ? `${name} — 단축키 ${i + 1}` : name}
                 onKeyDown=${(e: KeyboardEvent) => {
                   let next = -1
                   if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (i + 1) % keeperNames.length
@@ -428,7 +450,7 @@ function StatusBar({
                   }
                 }}
               >
-                ${name.replace(/^keeper-|-agent$/g, '')}
+                ${i < 9 ? html`<span class="opacity-50 mr-0.5">${i + 1}</span>` : null}${name.replace(/^keeper-|-agent$/g, '')}
               </button>
             `
           })}


### PR DESCRIPTION
## Summary

- Press 1-9 to jump to the Nth keeper tab
- Tab labels show small digit prefix as visual hint
- Modifier keys + input focus disable the shortcut

## Why

For 5-10 keeper deployments, Cmd+K command palette is overkill. Direct number-key shortcuts:
- 1 keystroke vs 3-4 (Cmd+K, type, enter)
- Visible digit prefix = self-documenting
- Familiar pattern (browser tab pinning, Slack/Discord channel switching)

Inspired by research showing Cmd+K pays off only at 50+ navigable entities (Linear, Slack with hundreds of channels).

## Changes

- `fsm-hub.ts` — global `keydown` listener for `1`-`9`, dimmed digit prefix in tab label, updated `title` attribute

## Verification

- 663/663 tests pass
- typecheck/lint clean
- Modifier keys ignored, input/textarea focus respects user typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)