### PR TITLE
[codex] Fix keeper cycle telemetry paths and naming

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -630,7 +630,7 @@ let run_turn
   let affinity_k = Keeper_tool_affinity.configured_max_k () in
   if affinity_k > 0
   then (
-    let masc_root = Filename.concat config.base_path ".masc" in
+    let masc_root = Room.masc_root_dir config in
     let allowed = Keeper_tool_policy.keeper_allowed_tool_names meta in
     let core = Keeper_tool_registry.core_discovery_tools in
     let entries =
@@ -1534,7 +1534,7 @@ let run_turn
     }
   in
   let hooks = Agent_sdk.Hooks.compose ~outer:before_turn_hook ~inner:base_hooks in
-  let base_dir = Filename.concat config.base_path ".masc" in
+  let base_dir = Room.masc_root_dir config in
   (* RFC-MASC-004 Phase 2: Hook-first is now the only path.
      Create bare memory (no imperative seeding). Memory content is
      injected via BeforeTurnParams hook; flush is incremental via

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1042,7 +1042,7 @@ let run_keepalive_unified_turn
         obs.pending_mentions <> [] || obs.pending_scope_messages <> []
       in
       let turn_decision =
-        Keeper_world_observation.unified_turn_decision
+        Keeper_world_observation.keeper_cycle_decision
           ~meta:meta_after_triage
           obs
       in
@@ -1140,7 +1140,7 @@ let run_keepalive_unified_turn
         with_keeper_turn_slot ~keeper_name:meta_after_triage.name
           ~channel:turn_decision.channel (fun ~semaphore_wait_ms ->
           match
-            Keeper_unified_turn.run_unified_turn
+            Keeper_unified_turn.run_keeper_cycle
               ~config:ctx.config
               ~meta:meta_after_observe
               ~observation:obs
@@ -1152,7 +1152,7 @@ let run_keepalive_unified_turn
           with
           | Error err ->
             let e_str = Oas.Error.to_string err in
-            Log.Keeper.error "%s: unified turn failed: %s"
+            Log.Keeper.error "%s: keeper cycle failed: %s"
               meta_after_observe.name e_str;
             if String_util.contains_substring e_str "Eio switch not available"
                || String_util.contains_substring e_str "Eio net not available"
@@ -1192,7 +1192,7 @@ let run_keepalive_unified_turn
         meta_after_triage.name wait_sec;
       meta_after_triage
     | exn ->
-      Log.Keeper.error "%s: unified turn exception: %s"
+      Log.Keeper.error "%s: keeper cycle exception: %s"
         meta_after_triage.name (Printexc.to_string exn);
       meta_after_triage)
 ;;

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -155,7 +155,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
          slots, starving the synchronous run_turn call (Issue #2610). *)
       (* auto execution session interception removed in #2908 *)
       (* === Harness: trajectory accumulator + eval gate config === *)
-      let masc_root = Filename.concat ctx.config.base_path ".masc" in
+      let masc_root = Room.masc_root_dir ctx.config in
       let trajectory_acc =
         Trajectory.create_accumulator
           ~masc_root

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -78,7 +78,7 @@ let line_block label value =
   else Printf.sprintf "%s: %s\n" label value
 
 let autonomous_trigger_lines
-    ~(decision : Keeper_world_observation.unified_turn_decision)
+    ~(decision : Keeper_world_observation.keeper_cycle_decision)
     ~(observation : Keeper_world_observation.world_observation) : string list =
   match decision.channel, decision.should_run with
   | Keeper_world_observation.Scheduled_autonomous, true ->
@@ -280,7 +280,7 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
           "- Economy: Hustle (minimize actions, conserve budget)\n");
   (* 7. Autonomous trigger — why this turn was scheduled *)
   let turn_decision =
-    Keeper_world_observation.unified_turn_decision ~meta observation
+    Keeper_world_observation.keeper_cycle_decision ~meta observation
   in
   let autonomous_trigger =
     autonomous_trigger_lines ~decision:turn_decision ~observation

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1,4 +1,4 @@
-(** Keeper_unified_turn — Single entry point for keeper turns via OAS Agent.run().
+(** Keeper_unified_turn — Single entry point for keeper cycles via OAS Agent.run().
 
     Replaces the 3-path dispatcher (social/proactive/autonomy) with a unified
     observe -> prompt -> Agent.run(tools, guardrails, hooks) loop.
@@ -34,8 +34,18 @@ let string_contains_substring ~(needle : string) (haystack : string) : bool =
 
 let string_contains_substring_ci ~(needle : string) (haystack : string) : bool =
   string_contains_substring
-    ~needle:(String.lowercase_ascii needle)
+      ~needle:(String.lowercase_ascii needle)
     (String.lowercase_ascii haystack)
+
+let finalize_trajectory_acc (trajectory_acc : Trajectory.accumulator)
+    (outcome : Trajectory.trajectory_outcome) : unit =
+  try
+    ignore (Trajectory.finalize trajectory_acc outcome)
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+      Log.Keeper.error "trajectory finalize failed (keeper cycle): %s"
+        (Printexc.to_string exn)
 
 (** {1 Retry & Side-Effect Safety}
 
@@ -1220,7 +1230,7 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
   in
   let preview =
     let trimmed = String.trim reason in
-    if trimmed = "" then "unified turn failed"
+    if trimmed = "" then "keeper cycle failed"
     else short_preview trimmed
   in
   {
@@ -1274,10 +1284,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     };
   }
 
-let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
+let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(generation : int)
-    ?(channel : Keeper_world_observation.unified_turn_channel = Scheduled_autonomous)
+    ?(channel : Keeper_world_observation.keeper_cycle_channel = Scheduled_autonomous)
     ?(semaphore_wait_ms = 0)
     ?shared_context
     () : (keeper_meta, Oas.Error.sdk_error) result =
@@ -1286,7 +1296,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
   match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
   | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
       Log.Keeper.info
-        "%s: unified turn skipped in non-executable phase=%s"
+        "%s: keeper cycle skipped in non-executable phase=%s"
         meta.name (Keeper_state_machine.phase_to_string phase);
       Ok meta
   | phase_opt ->
@@ -1329,6 +1339,14 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
       let base_dir = session_base_dir config in
       (* Ensure session dir tree for filesystem fallback (issue #3019) *)
       Keeper_types.mkdir_p (Filename.concat base_dir (Keeper_id.Trace_id.to_string meta.runtime.trace_id));
+      let masc_root = Room.masc_root_dir config in
+      let trajectory_acc =
+        Trajectory.create_accumulator
+          ~masc_root
+          ~keeper_name:meta.name
+          ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+          ~generation:meta.runtime.generation
+      in
       (* 3. Derive parameters: cascade.json -> keeper env-var fallback *)
       let temperature =
         Cascade_inference.resolve_temperature
@@ -1456,6 +1474,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
               ~temperature ~max_tokens
               ~oas_timeout_s
               ?max_cost_usd
+              ~trajectory_acc
               ~is_retry
               ?shared_context
               ?event_bus:(Keeper_event_bus.get ())
@@ -1722,13 +1741,15 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
        | _ -> ());
       match run_result with
       | Error err ->
+          finalize_trajectory_acc trajectory_acc
+            (Trajectory.Failed (Oas.Error.to_string err));
           let e_str = Oas.Error.to_string err in
           let is_transient = is_transient_network_error err in
           let is_server_parse_rejection = is_server_rejected_parse_error err in
           let is_auto_recoverable = is_auto_recoverable_turn_error err in
           let is_ambiguous_partial = is_ambiguous_side_effect_error err in
           Log.Keeper.error
-            "%s: unified turn FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
+            "%s: keeper cycle FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
             meta.name effective_cascade_name max_context latency_ms
             (if is_ambiguous_partial then
                " (ambiguous partial commit)"
@@ -1797,7 +1818,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            | Ok () -> ()
            | Error msg ->
                Log.Keeper.error
-                 "write_meta failed after unified turn failure: %s" msg);
+                 "write_meta failed after keeper cycle failure: %s" msg);
           let base_path = config.base_path in
           (* Transient errors (429 rate limit, 503 overloaded, network
              timeout) do not count toward the consecutive failure threshold.
@@ -1827,6 +1848,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           end;
           Error err
       | Ok result ->
+          finalize_trajectory_acc trajectory_acc Trajectory.Completed;
           let explicit_accountability_claim =
             Social.extract_accountability_claim result
           in
@@ -1904,7 +1926,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->
                Log.Keeper.error
-                 "write metrics snapshot failed after unified turn: %s"
+                 "write metrics snapshot failed after keeper cycle: %s"
                  (Printexc.to_string exn));
           (* Emit turn-completed event to Activity Graph for timeline token visibility *)
           (try
@@ -2006,7 +2028,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
                 ()
           | None -> ());
           Log.Keeper.info
-            "%s: unified turn OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
+            "%s: keeper cycle OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
             updated_meta.name (Keeper_agent_run.surface_model_used result)
             (result.usage.input_tokens + result.usage.output_tokens)
             latency_ms
@@ -2024,8 +2046,7 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with
            | Ok () -> ()
-           | Error msg ->
-               Log.Keeper.error "write_meta failed after unified turn: %s" msg);
+           | Error msg -> Log.Keeper.error "write_meta failed after keeper cycle: %s" msg);
           (* 8. Handle stop reason *)
           (match result.stop_reason with
            | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
@@ -2048,3 +2069,5 @@ let run_unified_turn ~(config : Room.config) ~(meta : keeper_meta)
              Keeper_registry.reset_turn_failures ~base_path:config.base_path
                updated_meta.name);
           Ok updated_meta
+
+let run_unified_turn = run_keeper_cycle

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -128,12 +128,23 @@ val resolved_max_context_for_turn :
   string list ->
   int
 
+val run_keeper_cycle :
+  config:Room.config ->
+  meta:Keeper_types.keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  generation:int ->
+  ?channel:Keeper_world_observation.keeper_cycle_channel ->
+  ?semaphore_wait_ms:int ->
+  ?shared_context:Agent_sdk.Context.t ->
+  unit ->
+  (Keeper_types.keeper_meta, Oas.Error.sdk_error) result
+
 val run_unified_turn :
   config:Room.config ->
   meta:Keeper_types.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   generation:int ->
-  ?channel:Keeper_world_observation.unified_turn_channel ->
+  ?channel:Keeper_world_observation.keeper_cycle_channel ->
   ?semaphore_wait_ms:int ->
   ?shared_context:Agent_sdk.Context.t ->
   unit ->

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -1,4 +1,4 @@
-(** Keeper_world_observation — Structured world state for unified keeper turns.
+(** Keeper_world_observation — Structured world state for keeper cycles.
 
     Extracts and normalizes observation signals from room state, keeper meta,
     and context so the unified prompt and turn runner consume a single snapshot.
@@ -46,9 +46,11 @@ type world_observation = {
   work_discovery_due : bool;
 }
 
-type unified_turn_channel =
+type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
+
+type unified_turn_channel = keeper_cycle_channel
 
 type turn_reason =
   | Mention_pending
@@ -97,15 +99,17 @@ let verdict_reasons_to_strings = function
       List.map turn_reason_to_string (first :: rest)
   | Skip { reasons = (first, rest) } ->
       List.map skip_reason_to_string (first :: rest)
-type unified_turn_decision = {
+type keeper_cycle_decision = {
   should_run : bool;
-  channel : unified_turn_channel;
+  channel : keeper_cycle_channel;
   verdict : turn_verdict;
   since_last_scheduled_autonomous : int option;
   effective_cooldown : int option;
   task_reactive_cooldown : int option;
   idle_gate_sec : int option;
 }
+
+type unified_turn_decision = keeper_cycle_decision
 
 type board_signal_match = {
   explicit_mention : bool;
@@ -703,7 +707,7 @@ let effective_proactive_cooldown =
   effective_scheduled_autonomous_cooldown
 
 
-let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation) =
+let keeper_cycle_decision ~(meta : keeper_meta) (observation : world_observation) =
   let reactive_triggers =
     [
       (if observation.pending_mentions <> [] then Some Mention_pending else None);
@@ -859,5 +863,9 @@ let unified_turn_decision ~(meta : keeper_meta) (observation : world_observation
           idle_gate_sec = Some idle_gate_sec;
         }
 
-let should_run_unified_turn ~(meta : keeper_meta) (observation : world_observation) =
-  (unified_turn_decision ~meta observation).should_run
+let unified_turn_decision = keeper_cycle_decision
+
+let should_run_keeper_cycle ~(meta : keeper_meta) (observation : world_observation) =
+  (keeper_cycle_decision ~meta observation).should_run
+
+let should_run_unified_turn = should_run_keeper_cycle

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -1,4 +1,4 @@
-(** Keeper_world_observation — Structured world state for unified keeper turns.
+(** Keeper_world_observation — Structured world state for keeper cycles.
 
     Extracts and normalizes observation signals from room state, keeper meta,
     and context so the unified prompt builder and turn runner can consume
@@ -82,12 +82,14 @@ type world_observation = {
   work_discovery_due : bool;
 }
 
-type unified_turn_channel =
+type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
-(** Typed reason for running a keeper turn. Each variant corresponds to
-    exactly one code path in {!unified_turn_decision}. *)
+type unified_turn_channel = keeper_cycle_channel
+
+(** Typed reason for running a keeper cycle. Each variant corresponds to
+    exactly one code path in {!keeper_cycle_decision}. *)
 type turn_reason =
   | Mention_pending
   | Board_event_pending
@@ -106,10 +108,10 @@ type skip_reason =
   | Cooldown_pending of { remaining_sec : int }
   | No_signal
 
-(** Turn decision with non-empty reason list (NEL).
+(** Keeper cycle decision with non-empty reason list (NEL).
     [Run] guarantees at least one trigger reason.
     [Skip] guarantees at least one skip reason.
-    Channel is held by [unified_turn_decision], not duplicated here. *)
+    Channel is held by [keeper_cycle_decision], not duplicated here. *)
 type turn_verdict =
   | Run of { reasons : turn_reason * turn_reason list }
   | Skip of { reasons : skip_reason * skip_reason list }
@@ -125,22 +127,24 @@ val turn_reason_to_string : turn_reason -> string
 val skip_reason_to_string : skip_reason -> string
 
 (** Convert channel to string tag. *)
-val channel_to_string : unified_turn_channel -> string
+val channel_to_string : keeper_cycle_channel -> string
 
 (** Extract all reasons as flat string tags from a verdict.
     Tags map 1:1 to the typed reasons carried by the verdict and do not
     include variant payloads. *)
 val verdict_reasons_to_strings : turn_verdict -> string list
 
-type unified_turn_decision = {
+type keeper_cycle_decision = {
   should_run : bool;
-  channel : unified_turn_channel;
+  channel : keeper_cycle_channel;
   verdict : turn_verdict;
   since_last_scheduled_autonomous : int option;
   effective_cooldown : int option;
   task_reactive_cooldown : int option;
   idle_gate_sec : int option;
 }
+
+type unified_turn_decision = keeper_cycle_decision
 
 type board_signal_match = {
   explicit_mention : bool;
@@ -199,8 +203,14 @@ val effective_proactive_cooldown :
   base_cooldown:int -> since_last:int ->
   ?consecutive_noop_count:int -> unit -> int
 
+val keeper_cycle_decision :
+  meta:Keeper_types.keeper_meta -> world_observation -> keeper_cycle_decision
+
 val unified_turn_decision :
-  meta:Keeper_types.keeper_meta -> world_observation -> unified_turn_decision
+  meta:Keeper_types.keeper_meta -> world_observation -> keeper_cycle_decision
+
+val should_run_keeper_cycle :
+  meta:Keeper_types.keeper_meta -> world_observation -> bool
 
 val should_run_unified_turn :
   meta:Keeper_types.keeper_meta -> world_observation -> bool

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -474,7 +474,7 @@ let handle_keeper_get_subroutes state req request reqd =
            (`Assoc [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])) reqd
     else
       let config = state.Mcp_server.room_config in
-      let masc_root = Filename.concat config.base_path ".masc" in
+      let masc_root = Room.masc_root_dir config in
       let window_hours =
         Server_utils.int_query_param req "window_hours"
           ~default:24
@@ -561,7 +561,7 @@ let handle_keeper_get_subroutes state req request reqd =
            Server_utils.bool_query_param req "include_thinking"
              ~default:false
          in
-         let masc_root = Filename.concat config.base_path ".masc" in
+         let masc_root = Room.masc_root_dir config in
          let trajectory_lines =
            Trajectory.read_all_lines ~masc_root ~keeper_name:m.name
              ~trace_id

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -65,6 +65,13 @@ let contains_substring haystack needle =
   in
   needle_len = 0 || loop 0
 
+let source_file_contains file_rel needle =
+  let path = Filename.concat (repo_root ()) file_rel in
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> contains_substring (In_channel.input_all ic) needle)
+
 let contains_disallowed_control_char s =
   let rec loop i =
     if i >= String.length s then false
@@ -219,7 +226,7 @@ let test_observe_uses_precollected_board_events () =
       check int "precollected board events preserved" (List.length events)
         (List.length obs.pending_board_events);
       check bool "board event schedules turn" true
-        (WO.should_run_unified_turn ~meta:minimal_meta obs))
+        (WO.should_run_keeper_cycle ~meta:minimal_meta obs))
 
 let test_collect_board_events_keeps_non_mentions_as_followup_signal () =
   let base_dir = temp_dir () in
@@ -321,7 +328,7 @@ let test_scheduled_turn_uses_cooldown_only () =
   in
   let obs = { base_observation with idle_seconds = 0 } in
   check bool "cooldown opens scheduled turn without idle heuristic" true
-    (WO.should_run_unified_turn ~meta obs)
+    (WO.should_run_keeper_cycle ~meta obs)
 
 let test_scheduled_turn_respects_cooldown () =
   let meta =
@@ -338,7 +345,7 @@ let test_scheduled_turn_respects_cooldown () =
     }
   in
   check bool "cooldown blocks scheduled turn" false
-    (WO.should_run_unified_turn ~meta base_observation)
+    (WO.should_run_keeper_cycle ~meta base_observation)
 
 let test_scheduled_turn_requires_idle_gate () =
   let meta =
@@ -358,8 +365,8 @@ let test_scheduled_turn_requires_idle_gate () =
   in
   let obs = { base_observation with idle_seconds = 120 } in
   check bool "idle gate blocks scheduled turn" false
-    (WO.should_run_unified_turn ~meta obs);
-  let decision = WO.unified_turn_decision ~meta obs in
+    (WO.should_run_keeper_cycle ~meta obs);
+  let decision = WO.keeper_cycle_decision ~meta obs in
   check bool "decision records idle wait reason" true
     (match decision.verdict with
      | WO.Skip { reasons = (first, rest)} ->
@@ -467,7 +474,7 @@ let test_idle_decay_triggers_turn () =
     }
   in
   check bool "idle decay triggers turn before base cooldown" true
-    (WO.should_run_unified_turn ~meta base_observation)
+    (WO.should_run_keeper_cycle ~meta base_observation)
 
 let test_scheduled_turn_decision_uses_backlog_acceleration () =
   let meta =
@@ -492,7 +499,7 @@ let test_scheduled_turn_decision_uses_backlog_acceleration () =
       failed_task_count = 2;
     }
   in
-  let decision = WO.unified_turn_decision ~meta obs in
+  let decision = WO.keeper_cycle_decision ~meta obs in
   check bool "backlog acceleration opens scheduled turn" true decision.should_run;
   check bool "marks actionable backlog" true
     (match decision.verdict with
@@ -574,7 +581,7 @@ let test_task_reactive_cooldown_floor_never_hits_zero () =
         failed_task_count = 1;
       }
     in
-    let decision = WO.unified_turn_decision ~meta obs in
+    let decision = WO.keeper_cycle_decision ~meta obs in
     check (option int) "task reactive cooldown clamps to positive floor" (Some 300)
       decision.task_reactive_cooldown)
 
@@ -1266,7 +1273,7 @@ let test_silent_proactive_cycle_advances_cooldown_anchor () =
   check bool "silent proactive leaves last_visible_ts untouched" true
     (updated.runtime.proactive_rt.last_visible_ts = 0.0);
   check bool "cooldown blocks immediate rerun after silent cycle" false
-    (WO.should_run_unified_turn ~meta:updated base_observation)
+    (WO.should_run_keeper_cycle ~meta:updated base_observation)
 
 let test_metrics_reactive_failure_does_not_mutate_proactive_runtime () =
   let reactive_observation =
@@ -1566,7 +1573,7 @@ let test_append_metrics_snapshot_treats_validated_evidence_as_tool_use () =
         Yojson.Safe.Util.(
           json |> member "scheduled_autonomous_outcome" |> to_string))
 
-let test_run_unified_turn_skips_non_executable_phase () =
+let test_run_keeper_cycle_skips_non_executable_phase () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_dir = temp_dir () in
@@ -1592,7 +1599,7 @@ let test_run_unified_turn_skips_non_executable_phase () =
         (Option.map KP.phase_to_string
            (KR.get_phase ~base_path:base_dir meta.name));
       match
-        UT.run_unified_turn
+        UT.run_keeper_cycle
           ~config
           ~meta
           ~observation:base_observation
@@ -1609,6 +1616,20 @@ let test_run_unified_turn_skips_non_executable_phase () =
             (Some "paused")
             (Option.map KP.phase_to_string
                (KR.get_phase ~base_path:base_dir meta.name)))
+
+let test_run_keeper_cycle_records_trajectory_source_contract () =
+  check bool "keeper cycle creates trajectory accumulator" true
+    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+       "Trajectory.create_accumulator");
+  check bool "keeper cycle passes trajectory_acc to agent run" true
+    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+       "~trajectory_acc");
+  check bool "keeper cycle resolves masc root via Room.masc_root_dir" true
+    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+       "Room.masc_root_dir config");
+  check bool "keeper cycle finalizes trajectory on completion/failure" true
+    (source_file_contains "lib/keeper/keeper_unified_turn.ml"
+       "Trajectory.finalize trajectory_acc")
 
 (* context_overflow_limit is now in OAS as Retry.extract_context_limit.
    These tests verify the OAS SSOT API is accessible from MASC. *)
@@ -2700,7 +2721,7 @@ let test_recent_tool_streak_count_ignores_stale_entries () =
 (* ---------- Test runner ---------- *)
 
 let () =
-  run "Keeper Unified Turn"
+  run "Keeper Cycle"
     [
       ( "world_observation",
         [
@@ -3013,8 +3034,10 @@ let () =
         ] );
       ( "phase_gate",
         [
-          test_case "run_unified_turn skips paused keeper" `Quick
-            test_run_unified_turn_skips_non_executable_phase;
+          test_case "run_keeper_cycle skips paused keeper" `Quick
+            test_run_keeper_cycle_skips_non_executable_phase;
+          test_case "run_keeper_cycle records trajectory contract" `Quick
+            test_run_keeper_cycle_records_trajectory_source_contract;
         ] );
       ( "tool_classification",
         [


### PR DESCRIPTION
## What changed
- renamed the primary keeper auto/reactive execution terminology from `unified turn` to `keeper cycle`
- kept compatibility aliases for existing `run_unified_turn` / `unified_turn_*` names so downstream callers do not break immediately
- switched keeper trajectory and dashboard telemetry paths to use `Room.masc_root_dir config` instead of manually concatenating `config.base_path/.masc`
- wired keeper cycle trajectory recording into the auto/reactive execution path and updated regression coverage

## Why
The keeper tool usage report reads keeper trajectory data. Manual keeper turns were already recording that data, but the auto/reactive keeper execution path was not. That made dashboard/reporting telemetry incomplete or stale for keepers running through the keepalive loop.

## Root cause
There were two mismatches:
- execution-path mismatch: manual keeper turns recorded trajectory data, keeper auto/reactive cycles did not
- path SSOT mismatch: some keeper telemetry readers/writers used `config.base_path/.masc` directly instead of the canonical `Room.masc_root_dir config`

## Impact
- keeper dashboard telemetry now reflects auto/reactive keeper cycles correctly
- naming is clearer for operators: this path is a keeper cycle, not just a single turn
- clustered or namespaced `.masc` roots follow the canonical path helper consistently in the touched flow

## Validation
- `env DUNE_BUILD_DIR=/tmp/masc-codex-cycle-2 dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-tool-trajectory-report test/test_keeper_unified.exe`
- `env DUNE_BUILD_DIR=/tmp/masc-codex-cycle-2 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-tool-trajectory-report ./test/test_keeper_unified.exe`
- `Keeper Cycle` test suite: 148 tests passed