### PR TITLE
fix(storage): route board_core + voice_config through masc_root_dir_from

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -161,13 +161,16 @@ let maybe_sweep store =
 let board_base_path () =
   Env_config_core.base_path ()
 
+let board_masc_dir () =
+  Room_utils.masc_root_dir_from
+    ~base_path:(board_base_path ())
+    ~cluster_name:(Env_config_core.cluster_name ())
+
 let persist_path () =
-  let base = board_base_path () in
-  Filename.concat base ".masc/board_posts.jsonl"
+  Filename.concat (board_masc_dir ()) "board_posts.jsonl"
 
 let comments_path () =
-  let base = board_base_path () in
-  Filename.concat base ".masc/board_comments.jsonl"
+  Filename.concat (board_masc_dir ()) "board_comments.jsonl"
 
 let ensure_dir path =
   if path = "" || path = "." || path = "/" then ()
@@ -175,7 +178,7 @@ let ensure_dir path =
 
 let ensure_masc_dir () =
   let base = board_base_path () in
-  let dir = Filename.concat base ".masc" in
+  let dir = board_masc_dir () in
   ensure_dir base;
   ensure_dir dir
 

--- a/lib/room/room_utils_paths_backend.ml
+++ b/lib/room/room_utils_paths_backend.ml
@@ -1,13 +1,23 @@
 open Room_utils_backend_setup
 
-let masc_root_dir config =
-  let masc_root = Filename.concat config.base_path ".masc" in
-  let cluster_name = config.backend_config.Backend_types.cluster_name in
+(** Pure helper: compute the masc_root directory from primitives.
+
+    Use this when a caller has a [base_path] string (e.g. from
+    [Env_config_core.base_path]) but no [Room.config] value. Semantics
+    match [masc_root_dir] exactly: default cluster -> [<base>/.masc/],
+    non-default -> [<base>/.masc/clusters/<sanitized>/]. *)
+let masc_root_dir_from ~base_path ~cluster_name =
+  let masc_root = Filename.concat base_path ".masc" in
   match cluster_name with
   | "" | "default" -> masc_root
   | other ->
       let seg = sanitize_namespace_segment other in
       Filename.concat (Filename.concat masc_root "clusters") seg
+
+let masc_root_dir config =
+  masc_root_dir_from
+    ~base_path:config.base_path
+    ~cluster_name:config.backend_config.Backend_types.cluster_name
 
 (** Legacy room path helpers — retained for room_multi.ml compat shim. *)
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"

--- a/lib/voice/voice_config.ml
+++ b/lib/voice/voice_config.ml
@@ -68,9 +68,17 @@ let dedupe_keep_order values =
   in
   loop [] [] values
 
+let voice_config_file_in root =
+  let masc_dir =
+    Room_utils.masc_root_dir_from
+      ~base_path:root
+      ~cluster_name:(Env_config_core.cluster_name ())
+  in
+  Filename.concat masc_dir "voice_config.json"
+
 let base_path_voice_config_path_opt () =
   Env_config_core.base_path_opt ()
-  |> Option.map (fun root -> Filename.concat root ".masc/voice_config.json")
+  |> Option.map voice_config_file_in
 
 let repo_voice_config_path_opt () =
   let root =
@@ -82,7 +90,7 @@ let repo_voice_config_path_opt () =
        | Some path -> path
        | None -> cwd)
   in
-  Some (Filename.concat root ".masc/voice_config.json")
+  Some (voice_config_file_in root)
 
 let fallback_voice_config_path () =
   let root =
@@ -90,7 +98,7 @@ let fallback_voice_config_path () =
     | Some bp -> bp
     | None -> Sys.getcwd ()
   in
-  Filename.concat root ".masc/voice_config.json"
+  voice_config_file_in root
 
 let config_path_candidates () =
   [


### PR DESCRIPTION
## Summary

#7370 follow-up. `board_core.ml`과 `voice/voice_config.ml`에 남아있던 `.masc/` hardcoded 경로를 cluster-aware path로 교체.

## Product impact

- **기본 cluster**: 동일한 결과. 런타임 의미론 무변경.
- **Non-default cluster** (`MASC_CLUSTER_NAME`이 설정된 경우):
  - `board_posts.jsonl` / `board_comments.jsonl` → `<base>/.masc/clusters/<name>/`
  - `voice_config.json` → `<base>/.masc/clusters/<name>/`

## Evidence

### 새 pure helper

\`\`\`ocaml
(* lib/room/room_utils_paths_backend.ml *)
let masc_root_dir_from ~base_path ~cluster_name =
  let masc_root = Filename.concat base_path ".masc" in
  match cluster_name with
  | "" | "default" -> masc_root
  | other ->
      let seg = sanitize_namespace_segment other in
      Filename.concat (Filename.concat masc_root "clusters") seg

let masc_root_dir config =
  masc_root_dir_from
    ~base_path:config.base_path
    ~cluster_name:config.backend_config.Backend_types.cluster_name
\`\`\`

기존 `masc_root_dir config` 의미론 보존. 새 `_from`은 config이 없는 init-time 경로에서 사용.

### 소비자

- `board_core.ml`: `persist_path`, `comments_path`, `ensure_masc_dir`가 `board_masc_dir ()` 경유
- `voice_config.ml`: `base_path_*`, `repo_*`, `fallback_*` 3개 함수가 `voice_config_file_in` 콤비네이터 경유

## Review evidence

- [x] \`dune build\` — clean
- [x] \`dune runtest\` — all green
- [x] Config_dir_resolver 의미론 변경 **없음** (feedback \`config-root-scope-discipline\` 준수)

## Linked issue

Resolves #7340 (remaining 2 of 3 bypasses; tempo.ml was covered in #7370).

🤖 Generated with [Claude Code](https://claude.com/claude-code)