### PR TITLE
[codex] Split keeper social-model registry modules

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -349,11 +349,15 @@ let weighted_shuffle
     if total_weight <= 0 then entries
     else
       let r = rand_int total_weight in
+      let default_selected, default_remaining =
+        match entries with
+        | first :: rest -> (first, rest)
+        | [] -> assert false
+      in
       (* Find the selected entry via cumulative weight *)
       let rec find_selected cumulative = function
         | [] -> (* fallback: first entry *)
-          (List.hd entries,
-           List.tl entries)
+          (default_selected, default_remaining)
         | (e : Cascade_config_loader.weighted_entry) :: rest ->
           let cumulative' = cumulative + e.weight in
           if r < cumulative' then (e, rest)
@@ -632,4 +636,3 @@ let local_capacity_for_selections ~sw ~net ?config_path selections =
         { empty_capacity with all_discovered = true }
         infos
   end
-

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -639,7 +639,8 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("proactive_cooldown_sec", `Int m.proactive.cooldown_sec);
               ("proactive_count_total", `Int m.runtime.proactive_rt.count_total);
               ("proactive_visible_count_total", `Int m.runtime.proactive_rt.visible_count_total);
-              ("social_model", `String m.social_model);
+              ("social_model",
+                `String (Keeper_social_model.normalize_social_model m.social_model));
               ("autonomous_turn_count", `Int m.runtime.autonomous_turn_count);
               ("autonomous_text_turn_count", `Int m.runtime.autonomous_text_turn_count);
               ("autonomous_tool_turn_count", `Int m.runtime.autonomous_tool_turn_count);

--- a/lib/dune
+++ b/lib/dune
@@ -394,6 +394,10 @@
    ;; Keeper contract
    keeper_schema
    keeper_execution_scope
+   keeper_social_model_types
+   keeper_social_model_protocol
+   keeper_social_model_bdi_speech_v1
+   keeper_social_model_registry
    keeper_social_model
    keeper_cascade_profile
    keeper_cascade_routing

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1279,8 +1279,8 @@ let run_turn
                              Log.Keeper.warn
                                "keeper:%s TopK_llm failed (%s), falling back to \
                                 core+prefilter+discovered"
-                               meta.name
-                               (Printexc.to_string exn);
+                             meta.name
+                             (Printexc.to_string exn);
                              []))
                      | _ ->
                        Log.Keeper.warn

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -1,8 +1,9 @@
-(** Keeper_social_model — keeper-side social routing for unified turns. *)
+(** Keeper_social_model — stable facade over social-model types and dispatch.
 
-open Keeper_types
+    Callers continue to use this module; the actual implementation lives in
+    the split social-model submodules. *)
 
-type speech_act =
+type speech_act = Keeper_social_model_types.speech_act =
   | Stay_silent
   | Inform
   | Request_help
@@ -12,7 +13,7 @@ type speech_act =
   | Broadcast
   | Defer
 
-type delivery_surface =
+type delivery_surface = Keeper_social_model_types.delivery_surface =
   | Silent
   | Visible_reply
   | Board_post
@@ -20,10 +21,10 @@ type delivery_surface =
   | Task_claim_surface
   | Broadcast_surface
 
-type model_id =
+type model_id = Keeper_social_model_types.model_id =
   | Bdi_speech_v1
 
-type social_state = {
+type social_state = Keeper_social_model_types.social_state = {
   social_model : string;
   belief_summary : string;
   active_desire : string option;
@@ -40,460 +41,21 @@ type accountability_claim = {
   evidence_refs : string list;
 }
 
-let speech_act_to_string = function
-  | Stay_silent -> "stay_silent"
-  | Inform -> "inform"
-  | Request_help -> "request_help"
-  | Claim_task -> "claim_task"
-  | Comment_board -> "comment_board"
-  | Post_board -> "post_board"
-  | Broadcast -> "broadcast"
-  | Defer -> "defer"
+let speech_act_to_string = Keeper_social_model_types.speech_act_to_string
+let delivery_surface_to_string =
+  Keeper_social_model_types.delivery_surface_to_string
 
-let delivery_surface_to_string = function
-  | Silent -> "silent"
-  | Visible_reply -> "visible_reply"
-  | Board_post -> "board_post"
-  | Board_comment -> "board_comment"
-  | Task_claim_surface -> "task_claim"
-  | Broadcast_surface -> "broadcast"
-
-let model_id_to_string = function
-  | Bdi_speech_v1 -> "bdi_speech_v1"
-
-let model_id_of_string value =
-  match String.lowercase_ascii (String.trim value) with
-  | "bdi_speech_v1" -> Some Bdi_speech_v1
-  | _ -> None
-
-let default_model_id = Bdi_speech_v1
-
-let normalize_social_model value =
-  match model_id_of_string value with
-  | Some model_id -> model_id_to_string model_id
-  | None -> model_id_to_string default_model_id
-
-let speech_act_of_string value =
-  match String.lowercase_ascii (String.trim value) with
-  | "stay_silent" -> Some Stay_silent
-  | "inform" -> Some Inform
-  | "request_help" -> Some Request_help
-  | "claim_task" -> Some Claim_task
-  | "comment_board" -> Some Comment_board
-  | "post_board" -> Some Post_board
-  | "broadcast" -> Some Broadcast
-  | "defer" -> Some Defer
-  | _ -> None
-
-let delivery_surface_of_string value =
-  match String.lowercase_ascii (String.trim value) with
-  | "silent" -> Some Silent
-  | "visible_reply" -> Some Visible_reply
-  | "board_post" -> Some Board_post
-  | "board_comment" -> Some Board_comment
-  | "task_claim" -> Some Task_claim_surface
-  | "broadcast" -> Some Broadcast_surface
-  | _ -> None
-
-let parse_header_line line =
-  match String.index_opt line ':' with
-  | None -> None
-  | Some idx ->
-      let key = String.sub line 0 idx |> String.trim in
-      let value =
-        String.sub line (idx + 1) (String.length line - idx - 1) |> String.trim
-      in
-      if key = "" then None else Some (key, value)
-
-let is_social_header_key = function
-  | "SOCIAL_MODEL"
-  | "BELIEF_SUMMARY"
-  | "ACTIVE_DESIRE"
-  | "CURRENT_INTENTION"
-  | "BLOCKER"
-  | "NEED"
-  | "CLAIM_KIND"
-  | "CLAIM_SUBJECT"
-  | "CLAIM_TASK_ID"
-  | "EVIDENCE_REFS"
-  | "SPEECH_ACT"
-  | "DELIVERY_SURFACE" ->
-      true
-  | _ -> false
-
-let parse_header_block raw =
-  let lines = String.split_on_char '\n' raw in
-  let rec consume acc = function
-    | line :: rest -> (
-        match parse_header_line line with
-        | Some (key, value) when is_social_header_key key ->
-            consume ((key, value) :: acc) rest
-        | _ -> (List.rev acc, line :: rest))
-    | [] -> (List.rev acc, [])
-  in
-  let headers, body_lines = consume [] lines in
-  (headers, String.concat "\n" body_lines |> String.trim)
-
-let header_assoc_opt headers key =
-  headers
-  |> List.find_map (fun (header_key, value) ->
-         if String.equal header_key key then Some value else None)
-
-let nonempty_header_opt headers key =
-  match header_assoc_opt headers key with
-  | Some value -> (
-      match String.lowercase_ascii (String.trim value) with
-      | "" | "none" | "null" -> None
-      | _ -> Some (String.trim value))
-  | None -> None
-
-let comma_list_header_opt headers key =
-  match nonempty_header_opt headers key with
-  | Some value ->
-      value
-      |> String.split_on_char ','
-      |> List.map String.trim
-      |> List.filter (fun item -> item <> "")
-      |> List.sort_uniq String.compare
-  | None -> []
-
-let belief_summary_of_observation
-    (observation : Keeper_world_observation.world_observation) : string =
-  let parts =
-    List.filter_map Fun.id [
-      (if observation.pending_mentions <> [] then
-         Some (Printf.sprintf "mentions=%d" (List.length observation.pending_mentions))
-       else None);
-      (if observation.pending_board_events <> [] then
-         Some (Printf.sprintf "board_events=%d"
-                 (List.length observation.pending_board_events))
-       else None);
-      (if observation.pending_scope_messages <> [] then
-         Some
-           (Printf.sprintf "scope_messages=%d"
-              (List.length observation.pending_scope_messages))
-       else None);
-      (if observation.unclaimed_task_count > 0 then
-         Some (Printf.sprintf "unclaimed_tasks=%d" observation.unclaimed_task_count)
-       else None);
-      (if observation.failed_task_count > 0 then
-         Some (Printf.sprintf "failed_tasks=%d" observation.failed_task_count)
-       else None);
-      (if observation.active_goals <> [] then
-         Some (Printf.sprintf "active_goals=%d" (List.length observation.active_goals))
-       else None);
-      (if observation.idle_seconds > 0 then
-         Some (Printf.sprintf "idle=%ds" observation.idle_seconds)
-       else None);
-      (if Option.is_some observation.worktree_change_summary then
-         Some "worktree_delta"
-       else None);
-    ]
-  in
-  match parts with
-  | [] -> "quiet_room"
-  | _ -> String.concat "; " parts
-
-module Bdi_speech_v1 = struct
-  type input = {
-    meta : keeper_meta;
-    observation : Keeper_world_observation.world_observation;
-    result : Keeper_agent_run.run_result;
-    headers : (string * string) list;
-    has_text_reply : bool;
-  }
-
-  type state = {
-    social_model : string;
-    belief_summary : string;
-    active_desire : string option;
-    current_intention : string option;
-    blocker : string option;
-    need : string option;
-  }
-
-  type output = {
-    speech_act : speech_act;
-    delivery_surface : delivery_surface;
-  }
-
-  type request_help_delivery =
-    | Request_help_posted
-    | Request_help_deduped
-    | Request_help_failed
-
-  let to_social_state (state : state) (output : output) : social_state =
-    {
-      social_model = state.social_model;
-      belief_summary = state.belief_summary;
-      active_desire = state.active_desire;
-      current_intention = state.current_intention;
-      blocker = state.blocker;
-      need = state.need;
-      speech_act = output.speech_act;
-      delivery_surface = output.delivery_surface;
-    }
-
-  let make_state ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation)
-      ?active_desire ?current_intention ?blocker ?need ?social_model
-      ?belief_summary () =
-    {
-      social_model =
-        Option.value ~default:(normalize_social_model meta.social_model)
-          social_model;
-      belief_summary =
-        Option.value ~default:(belief_summary_of_observation observation)
-          belief_summary;
-      active_desire;
-      current_intention;
-      blocker;
-      need;
-    }
-
-  let protocol_violation_state ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation)
-      ~(reason : string) =
-    ( make_state ~meta ~observation ?blocker:(Some reason) (),
-      { speech_act = Defer; delivery_surface = Silent } )
-
-  let inferred_text_reply_state ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation) =
-    ( make_state ~meta ~observation (),
-      { speech_act = Inform; delivery_surface = Visible_reply } )
-
-  let inferred_tool_surface tools =
-    if tools = [ "keeper_stay_silent" ] then
-      Some { speech_act = Stay_silent; delivery_surface = Silent }
-    else if List.mem "keeper_board_comment" tools then
-      Some { speech_act = Comment_board; delivery_surface = Board_comment }
-    else if List.mem "keeper_board_post" tools then
-      Some { speech_act = Post_board; delivery_surface = Board_post }
-    else if List.mem "keeper_broadcast" tools then
-      Some { speech_act = Broadcast; delivery_surface = Broadcast_surface }
-    else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
-      Some { speech_act = Claim_task; delivery_surface = Task_claim_surface }
-    else
-      None
-
-  let tool_only_state ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation)
-      ~(result : Keeper_agent_run.run_result) =
-    let output =
-      match inferred_tool_surface result.tools_used with
-      | Some routed -> routed
-      | None -> { speech_act = Inform; delivery_surface = Visible_reply }
-    in
-    (make_state ~meta ~observation (), output)
-
-  let social_state_of_headers ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation) headers =
-    match
-      nonempty_header_opt headers "SPEECH_ACT",
-      header_assoc_opt headers "DELIVERY_SURFACE"
-    with
-    | Some speech_raw, Some delivery_raw -> (
-        match
-          speech_act_of_string speech_raw,
-          delivery_surface_of_string delivery_raw
-        with
-        | Some speech_act, Some delivery_surface ->
-            let belief_summary =
-              let max_len = 200 in
-              let raw =
-                Option.value
-                  ~default:(belief_summary_of_observation observation)
-                  (nonempty_header_opt headers "BELIEF_SUMMARY")
-              in
-              if String.length raw <= max_len then raw
-              else
-                let truncated = String.sub raw 0 max_len in
-                match String.rindex_opt truncated ' ' with
-                | Some i when i > max_len / 2 -> String.sub raw 0 i
-                | _ -> truncated
-            in
-            ( make_state ~meta ~observation
-                ~social_model:
-                  (normalize_social_model
-                     (Option.value
-                        ~default:meta.social_model
-                        (nonempty_header_opt headers "SOCIAL_MODEL")))
-                ~belief_summary
-                ?active_desire:(nonempty_header_opt headers "ACTIVE_DESIRE")
-                ?current_intention:(nonempty_header_opt headers
-                                      "CURRENT_INTENTION")
-                ?blocker:(nonempty_header_opt headers "BLOCKER")
-                ?need:(nonempty_header_opt headers "NEED")
-                (),
-              { speech_act; delivery_surface } )
-        | _ ->
-            protocol_violation_state ~meta ~observation
-              ~reason:"invalid social headers")
-    | _ ->
-        protocol_violation_state ~meta ~observation
-          ~reason:"missing social headers"
-
-  let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option)
-      =
-    match blocker with
-    | None -> false
-    | Some blocker ->
-        String.equal blocker (String.trim meta.runtime.last_blocker)
-        && String.equal meta.runtime.last_speech_act "request_help"
-        && meta.runtime.proactive_rt.last_ts > 0.0
-        && Time_compat.now () -. meta.runtime.proactive_rt.last_ts
-           < float_of_int meta.proactive.cooldown_sec
-
-  let request_help_post_body ~(meta : keeper_meta) ~(state : social_state)
-      blocker =
-    String.concat "\n"
-      [
-        Printf.sprintf "keeper `%s` is blocked." meta.name;
-        Printf.sprintf "goal: %s" meta.goal;
-        Printf.sprintf "beliefs: %s" state.belief_summary;
-        (match state.current_intention with
-        | Some value -> "intended action: " ^ value
-        | None -> "intended action: unspecified");
-        "blocker: " ^ blocker;
-        (match state.need with
-        | Some value -> "need: " ^ value
-        | None -> "need: guidance");
-        "retry condition: external capability or operator guidance becomes available";
-      ]
-
-  let deliver_request_help_post ~(meta : keeper_meta) ~(state : social_state) =
-    match state.blocker with
-    | None -> Request_help_failed
-    | Some blocker when should_dedupe_request_help ~meta ~blocker:(Some blocker)
-      ->
-        Request_help_deduped
-    | Some blocker ->
-        let title = Printf.sprintf "[keeper-blocked] %s needs help" meta.name in
-        let body = request_help_post_body ~meta ~state blocker in
-        let meta_json =
-          Some
-            (`Assoc
-              [
-                ("source", `String "keeper_board_post");
-                ("social_model", `String state.social_model);
-                ("speech_act", `String (speech_act_to_string state.speech_act));
-                ("keeper_name", `String meta.name);
-                ("agent_name", `String meta.agent_name);
-                ("belief_summary", `String state.belief_summary);
-                ("blocker", `String blocker);
-                ( "need",
-                  match state.need with
-                  | Some value -> `String value
-                  | None -> `Null );
-              ])
-        in
-        match
-          Board_dispatch.create_post ~author:meta.name ~title ~body ~content:body
-            ~post_kind:Board.Automation_post ?meta_json
-            ~visibility:Board.Internal ~ttl_hours:24 ~hearth:"keepers" ()
-        with
-        | Ok _ -> Request_help_posted
-        | Error _ -> Request_help_failed
-
-  let transition (_previous_state : state option) (input : input) =
-    let meta = input.meta in
-    let observation = input.observation in
-    let result = input.result in
-    if result.tools_used <> [] then
-      tool_only_state ~meta ~observation ~result
-    else if input.headers <> [] then
-      let state, output =
-        social_state_of_headers ~meta ~observation input.headers
-      in
-      if input.has_text_reply
-         &&
-         match state.blocker with
-         | Some "missing social headers" | Some "invalid social headers" -> true
-         | _ -> false
-      then
-        inferred_text_reply_state ~meta ~observation
-      else
-        (state, output)
-    else if input.has_text_reply then
-      inferred_text_reply_state ~meta ~observation
-    else
-      protocol_violation_state ~meta ~observation
-        ~reason:"no tool calls and no social headers"
-
-  let apply_output_to_result ~(meta : keeper_meta)
-      ~(result : Keeper_agent_run.run_result)
-      ~(visible_response_body : string) (state : social_state) =
-    match state.speech_act, state.delivery_surface with
-    | Request_help, Board_post when result.tools_used = [] ->
-        (match deliver_request_help_post ~meta ~state with
-        | Request_help_posted ->
-            let tools_used =
-              dedupe_keep_order ("keeper_board_post" :: result.tools_used)
-            in
-            ( { result with
-                response_text = "";
-                tools_used;
-                tool_calls_made = List.length tools_used;
-              },
-              state )
-        | Request_help_deduped | Request_help_failed ->
-            ({ result with response_text = "" }, state))
-    | Defer, Silent ->
-        ({ result with response_text = "" }, state)
-    | Stay_silent, Silent when result.tools_used = [] ->
-        ({ result with response_text = "" }, state)
-    | _ ->
-        let response_text =
-          match
-            Keeper_tool_disclosure.normalize_response_text
-              ~text:visible_response_body
-              ~tool_names:result.tools_used ()
-          with
-          | Ok normalized -> normalized
-          | Error _ -> visible_response_body
-        in
-        ({ result with response_text }, state)
-
-  let apply_to_result ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation)
-      (result : Keeper_agent_run.run_result) =
-    let headers, response_body = parse_header_block result.response_text in
-    let visible_response_body =
-      Keeper_text_processing.strip_internal_reply_markup response_body
-    in
-    let input =
-      {
-        meta;
-        observation;
-        result;
-        headers;
-        has_text_reply = String.trim visible_response_body <> "";
-      }
-    in
-    let state, output = transition None input in
-    let social_state = to_social_state state output in
-    apply_output_to_result ~meta ~result ~visible_response_body social_state
-
-  let derive_failure_state ~(meta : keeper_meta)
-      ~(observation : Keeper_world_observation.world_observation)
-      ~(reason : string) =
-    let state =
-      make_state ~meta ~observation
-        ?blocker:
-          (match String.trim reason with
-          | "" -> None
-          | value -> Some (short_preview value))
-        ()
-    in
-    let output = { speech_act = Defer; delivery_surface = Silent } in
-    to_social_state state output
-end
+let model_id_to_string = Keeper_social_model_types.model_id_to_string
+let model_id_of_string = Keeper_social_model_types.model_id_of_string
+let normalize_social_model = Keeper_social_model_types.normalize_social_model
 
 let extract_accountability_claim (result : Keeper_agent_run.run_result) =
-  let headers, _ = parse_header_block result.response_text in
+  let headers, _ =
+    Keeper_social_model_protocol.parse_header_block result.response_text
+  in
   match
-    nonempty_header_opt headers "CLAIM_KIND",
-    nonempty_header_opt headers "CLAIM_SUBJECT"
+    Keeper_social_model_protocol.nonempty_header_opt headers "CLAIM_KIND",
+    Keeper_social_model_protocol.nonempty_header_opt headers "CLAIM_SUBJECT"
   with
   | Some kind, Some subject
     when String.equal (String.lowercase_ascii (String.trim kind))
@@ -501,24 +63,14 @@ let extract_accountability_claim (result : Keeper_agent_run.run_result) =
       Some
         {
           subject = String.trim subject;
-          task_id = nonempty_header_opt headers "CLAIM_TASK_ID";
-          evidence_refs = comma_list_header_opt headers "EVIDENCE_REFS";
+          task_id =
+            Keeper_social_model_protocol.nonempty_header_opt headers
+              "CLAIM_TASK_ID";
+          evidence_refs =
+            Keeper_social_model_protocol.comma_list_header_opt headers
+              "EVIDENCE_REFS";
         }
   | _ -> None
 
-let active_model_of_meta (meta : keeper_meta) =
-  match model_id_of_string meta.social_model with
-  | Some model_id -> model_id
-  | None -> default_model_id
-
-let apply_to_result ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation)
-    (result : Keeper_agent_run.run_result) =
-  match active_model_of_meta meta with
-  | Bdi_speech_v1 -> Bdi_speech_v1.apply_to_result ~meta ~observation result
-
-let derive_failure_state ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation)
-    ~(reason : string) =
-  match active_model_of_meta meta with
-  | Bdi_speech_v1 -> Bdi_speech_v1.derive_failure_state ~meta ~observation ~reason
+let apply_to_result = Keeper_social_model_registry.apply_to_result
+let derive_failure_state = Keeper_social_model_registry.derive_failure_state

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -20,6 +20,9 @@ type delivery_surface =
   | Task_claim_surface
   | Broadcast_surface
 
+type model_id =
+  | Bdi_speech_v1
+
 type social_state = {
   social_model : string;
   belief_summary : string;
@@ -54,6 +57,21 @@ let delivery_surface_to_string = function
   | Board_comment -> "board_comment"
   | Task_claim_surface -> "task_claim"
   | Broadcast_surface -> "broadcast"
+
+let model_id_to_string = function
+  | Bdi_speech_v1 -> "bdi_speech_v1"
+
+let model_id_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "bdi_speech_v1" -> Some Bdi_speech_v1
+  | _ -> None
+
+let default_model_id = Bdi_speech_v1
+
+let normalize_social_model value =
+  match model_id_of_string value with
+  | Some model_id -> model_id_to_string model_id
+  | None -> model_id_to_string default_model_id
 
 let speech_act_of_string value =
   match String.lowercase_ascii (String.trim value) with
@@ -176,190 +194,218 @@ let belief_summary_of_observation
   | [] -> "quiet_room"
   | _ -> String.concat "; " parts
 
-let protocol_violation_state ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation) ~(reason : string)
-    =
-  {
-    social_model = meta.social_model;
-    belief_summary = belief_summary_of_observation observation;
-    active_desire = None;
-    current_intention = None;
-    blocker = Some reason;
-    need = None;
-    speech_act = Defer;
-    delivery_surface = Silent;
+module Bdi_speech_v1 = struct
+  type input = {
+    meta : keeper_meta;
+    observation : Keeper_world_observation.world_observation;
+    result : Keeper_agent_run.run_result;
+    headers : (string * string) list;
+    has_text_reply : bool;
   }
 
-let inferred_text_reply_state ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation) =
-  {
-    social_model = meta.social_model;
-    belief_summary = belief_summary_of_observation observation;
-    active_desire = None;
-    current_intention = None;
-    blocker = None;
-    need = None;
-    speech_act = Inform;
-    delivery_surface = Visible_reply;
+  type state = {
+    social_model : string;
+    belief_summary : string;
+    active_desire : string option;
+    current_intention : string option;
+    blocker : string option;
+    need : string option;
   }
 
-let inferred_tool_surface tools =
-  if tools = [ "keeper_stay_silent" ] then
-    Some (Stay_silent, Silent)
-  else if List.mem "keeper_board_comment" tools then
-    Some (Comment_board, Board_comment)
-  else if List.mem "keeper_board_post" tools then
-    Some (Post_board, Board_post)
-  else if List.mem "keeper_broadcast" tools then
-    Some (Broadcast, Broadcast_surface)
-  else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
-    Some (Claim_task, Task_claim_surface)
-  else
-    None
-
-let tool_only_state ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation)
-    ~(result : Keeper_agent_run.run_result) =
-  let speech_act, delivery_surface =
-    match inferred_tool_surface result.tools_used with
-    | Some routed -> routed
-    | None -> (Inform, Visible_reply)
-  in
-  {
-    social_model = meta.social_model;
-    belief_summary = belief_summary_of_observation observation;
-    active_desire = None;
-    current_intention = None;
-    blocker = None;
-    need = None;
-    speech_act;
-    delivery_surface;
+  type output = {
+    speech_act : speech_act;
+    delivery_surface : delivery_surface;
   }
 
-let social_state_of_headers ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation) headers =
-  match nonempty_header_opt headers "SPEECH_ACT", header_assoc_opt headers "DELIVERY_SURFACE" with
-  | Some speech_raw, Some delivery_raw -> (
-      match
-        speech_act_of_string speech_raw,
-        delivery_surface_of_string delivery_raw
-      with
-      | Some speech_act, Some delivery_surface ->
-          {
-            social_model =
-              Option.value
-                ~default:meta.social_model
-                (nonempty_header_opt headers "SOCIAL_MODEL");
-            belief_summary =
-              (let max_len = 200 in
-               let raw = Option.value
-                ~default:(belief_summary_of_observation observation)
-                (nonempty_header_opt headers "BELIEF_SUMMARY") in
-               if String.length raw <= max_len then raw
-               else
-                 (* Truncate at last space before limit to avoid splitting
-                    multi-byte UTF-8 characters or mid-word cuts. *)
-                 let truncated = String.sub raw 0 max_len in
-                 match String.rindex_opt truncated ' ' with
-                 | Some i when i > max_len / 2 -> String.sub raw 0 i
-                 | _ -> truncated);
-            active_desire = nonempty_header_opt headers "ACTIVE_DESIRE";
-            current_intention = nonempty_header_opt headers "CURRENT_INTENTION";
-            blocker = nonempty_header_opt headers "BLOCKER";
-            need = nonempty_header_opt headers "NEED";
-            speech_act;
-            delivery_surface;
-          }
-      | _ ->
-          protocol_violation_state ~meta ~observation
-            ~reason:"invalid social headers")
-  | _ ->
-      protocol_violation_state ~meta ~observation
-        ~reason:"missing social headers"
+  type request_help_delivery =
+    | Request_help_posted
+    | Request_help_deduped
+    | Request_help_failed
 
-let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option) =
-  match blocker with
-  | None -> false
-  | Some blocker ->
-      String.equal blocker (String.trim meta.runtime.last_blocker)
-      && String.equal meta.runtime.last_speech_act "request_help"
-      && meta.runtime.proactive_rt.last_ts > 0.0
-      && Time_compat.now () -. meta.runtime.proactive_rt.last_ts
-         < float_of_int meta.proactive.cooldown_sec
+  let to_social_state (state : state) (output : output) : social_state =
+    {
+      social_model = state.social_model;
+      belief_summary = state.belief_summary;
+      active_desire = state.active_desire;
+      current_intention = state.current_intention;
+      blocker = state.blocker;
+      need = state.need;
+      speech_act = output.speech_act;
+      delivery_surface = output.delivery_surface;
+    }
 
-let request_help_post_body ~(meta : keeper_meta) ~(state : social_state) blocker =
-  String.concat "\n"
-    [
-      Printf.sprintf "keeper `%s` is blocked." meta.name;
-      Printf.sprintf "goal: %s" meta.goal;
-      Printf.sprintf "beliefs: %s" state.belief_summary;
-      (match state.current_intention with
-      | Some value -> "intended action: " ^ value
-      | None -> "intended action: unspecified");
-      "blocker: " ^ blocker;
-      (match state.need with
-      | Some value -> "need: " ^ value
-      | None -> "need: guidance");
-      "retry condition: external capability or operator guidance becomes available";
-    ]
+  let make_state ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation)
+      ?active_desire ?current_intention ?blocker ?need ?social_model
+      ?belief_summary () =
+    {
+      social_model =
+        Option.value ~default:(normalize_social_model meta.social_model)
+          social_model;
+      belief_summary =
+        Option.value ~default:(belief_summary_of_observation observation)
+          belief_summary;
+      active_desire;
+      current_intention;
+      blocker;
+      need;
+    }
 
-type request_help_delivery =
-  | Request_help_posted
-  | Request_help_deduped
-  | Request_help_failed
+  let protocol_violation_state ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation)
+      ~(reason : string) =
+    ( make_state ~meta ~observation ?blocker:(Some reason) (),
+      { speech_act = Defer; delivery_surface = Silent } )
 
-let deliver_request_help_post ~(meta : keeper_meta) ~(state : social_state) =
-  match state.blocker with
-  | None -> Request_help_failed
-  | Some blocker when should_dedupe_request_help ~meta ~blocker:(Some blocker) ->
-      Request_help_deduped
-  | Some blocker ->
-      let title = Printf.sprintf "[keeper-blocked] %s needs help" meta.name in
-      let body = request_help_post_body ~meta ~state blocker in
-      let meta_json =
-        Some
-          (`Assoc
-            [
-              ("source", `String "keeper_board_post");
-              ("social_model", `String state.social_model);
-              ("speech_act", `String (speech_act_to_string state.speech_act));
-              ("keeper_name", `String meta.name);
-              ("agent_name", `String meta.agent_name);
-              ("belief_summary", `String state.belief_summary);
-              ("blocker", `String blocker);
-              ( "need",
-                match state.need with
-                | Some value -> `String value
-                | None -> `Null );
-            ])
-      in
-      match
-        Board_dispatch.create_post ~author:meta.name ~title ~body ~content:body
-          ~post_kind:Board.Automation_post ?meta_json ~visibility:Board.Internal
-          ~ttl_hours:24 ~hearth:"keepers" ()
-      with
-      | Ok _ -> Request_help_posted
-      | Error _ -> Request_help_failed
+  let inferred_text_reply_state ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation) =
+    ( make_state ~meta ~observation (),
+      { speech_act = Inform; delivery_surface = Visible_reply } )
 
-let apply_to_result ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation)
-    (result : Keeper_agent_run.run_result) =
-  let headers, response_body = parse_header_block result.response_text in
-  let visible_response_body =
-    Keeper_text_processing.strip_internal_reply_markup response_body
-  in
-  let has_text_reply = String.trim visible_response_body <> "" in
-  let state =
-    (* Tool calls are the authoritative record of action.
-       When tools are present, infer social state from tool calls regardless
-       of whether BDI headers were also emitted. This ensures deterministic
-       observation: the system reads what the agent DID (tool calls), not what
-       it DECLARED (text headers). *)
+  let inferred_tool_surface tools =
+    if tools = [ "keeper_stay_silent" ] then
+      Some { speech_act = Stay_silent; delivery_surface = Silent }
+    else if List.mem "keeper_board_comment" tools then
+      Some { speech_act = Comment_board; delivery_surface = Board_comment }
+    else if List.mem "keeper_board_post" tools then
+      Some { speech_act = Post_board; delivery_surface = Board_post }
+    else if List.mem "keeper_broadcast" tools then
+      Some { speech_act = Broadcast; delivery_surface = Broadcast_surface }
+    else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
+      Some { speech_act = Claim_task; delivery_surface = Task_claim_surface }
+    else
+      None
+
+  let tool_only_state ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation)
+      ~(result : Keeper_agent_run.run_result) =
+    let output =
+      match inferred_tool_surface result.tools_used with
+      | Some routed -> routed
+      | None -> { speech_act = Inform; delivery_surface = Visible_reply }
+    in
+    (make_state ~meta ~observation (), output)
+
+  let social_state_of_headers ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation) headers =
+    match
+      nonempty_header_opt headers "SPEECH_ACT",
+      header_assoc_opt headers "DELIVERY_SURFACE"
+    with
+    | Some speech_raw, Some delivery_raw -> (
+        match
+          speech_act_of_string speech_raw,
+          delivery_surface_of_string delivery_raw
+        with
+        | Some speech_act, Some delivery_surface ->
+            let belief_summary =
+              let max_len = 200 in
+              let raw =
+                Option.value
+                  ~default:(belief_summary_of_observation observation)
+                  (nonempty_header_opt headers "BELIEF_SUMMARY")
+              in
+              if String.length raw <= max_len then raw
+              else
+                let truncated = String.sub raw 0 max_len in
+                match String.rindex_opt truncated ' ' with
+                | Some i when i > max_len / 2 -> String.sub raw 0 i
+                | _ -> truncated
+            in
+            ( make_state ~meta ~observation
+                ~social_model:
+                  (normalize_social_model
+                     (Option.value
+                        ~default:meta.social_model
+                        (nonempty_header_opt headers "SOCIAL_MODEL")))
+                ~belief_summary
+                ?active_desire:(nonempty_header_opt headers "ACTIVE_DESIRE")
+                ?current_intention:(nonempty_header_opt headers
+                                      "CURRENT_INTENTION")
+                ?blocker:(nonempty_header_opt headers "BLOCKER")
+                ?need:(nonempty_header_opt headers "NEED")
+                (),
+              { speech_act; delivery_surface } )
+        | _ ->
+            protocol_violation_state ~meta ~observation
+              ~reason:"invalid social headers")
+    | _ ->
+        protocol_violation_state ~meta ~observation
+          ~reason:"missing social headers"
+
+  let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option)
+      =
+    match blocker with
+    | None -> false
+    | Some blocker ->
+        String.equal blocker (String.trim meta.runtime.last_blocker)
+        && String.equal meta.runtime.last_speech_act "request_help"
+        && meta.runtime.proactive_rt.last_ts > 0.0
+        && Time_compat.now () -. meta.runtime.proactive_rt.last_ts
+           < float_of_int meta.proactive.cooldown_sec
+
+  let request_help_post_body ~(meta : keeper_meta) ~(state : social_state)
+      blocker =
+    String.concat "\n"
+      [
+        Printf.sprintf "keeper `%s` is blocked." meta.name;
+        Printf.sprintf "goal: %s" meta.goal;
+        Printf.sprintf "beliefs: %s" state.belief_summary;
+        (match state.current_intention with
+        | Some value -> "intended action: " ^ value
+        | None -> "intended action: unspecified");
+        "blocker: " ^ blocker;
+        (match state.need with
+        | Some value -> "need: " ^ value
+        | None -> "need: guidance");
+        "retry condition: external capability or operator guidance becomes available";
+      ]
+
+  let deliver_request_help_post ~(meta : keeper_meta) ~(state : social_state) =
+    match state.blocker with
+    | None -> Request_help_failed
+    | Some blocker when should_dedupe_request_help ~meta ~blocker:(Some blocker)
+      ->
+        Request_help_deduped
+    | Some blocker ->
+        let title = Printf.sprintf "[keeper-blocked] %s needs help" meta.name in
+        let body = request_help_post_body ~meta ~state blocker in
+        let meta_json =
+          Some
+            (`Assoc
+              [
+                ("source", `String "keeper_board_post");
+                ("social_model", `String state.social_model);
+                ("speech_act", `String (speech_act_to_string state.speech_act));
+                ("keeper_name", `String meta.name);
+                ("agent_name", `String meta.agent_name);
+                ("belief_summary", `String state.belief_summary);
+                ("blocker", `String blocker);
+                ( "need",
+                  match state.need with
+                  | Some value -> `String value
+                  | None -> `Null );
+              ])
+        in
+        match
+          Board_dispatch.create_post ~author:meta.name ~title ~body ~content:body
+            ~post_kind:Board.Automation_post ?meta_json
+            ~visibility:Board.Internal ~ttl_hours:24 ~hearth:"keepers" ()
+        with
+        | Ok _ -> Request_help_posted
+        | Error _ -> Request_help_failed
+
+  let transition (_previous_state : state option) (input : input) =
+    let meta = input.meta in
+    let observation = input.observation in
+    let result = input.result in
     if result.tools_used <> [] then
       tool_only_state ~meta ~observation ~result
-    else if headers <> [] then
-      let state = social_state_of_headers ~meta ~observation headers in
-      if has_text_reply
+    else if input.headers <> [] then
+      let state, output =
+        social_state_of_headers ~meta ~observation input.headers
+      in
+      if input.has_text_reply
          &&
          match state.blocker with
          | Some "missing social headers" | Some "invalid social headers" -> true
@@ -367,44 +413,81 @@ let apply_to_result ~(meta : keeper_meta)
       then
         inferred_text_reply_state ~meta ~observation
       else
-        state
-    else if has_text_reply then
+        (state, output)
+    else if input.has_text_reply then
       inferred_text_reply_state ~meta ~observation
     else
       protocol_violation_state ~meta ~observation
         ~reason:"no tool calls and no social headers"
-  in
-  match state.speech_act, state.delivery_surface with
-  | Request_help, Board_post when result.tools_used = [] ->
-      (match deliver_request_help_post ~meta ~state with
-      | Request_help_posted ->
-          let tools_used =
-            dedupe_keep_order ("keeper_board_post" :: result.tools_used)
-          in
-          ( { result with
-              response_text = "";
-              tools_used;
-              tool_calls_made = List.length tools_used;
-            },
-            state )
-      | Request_help_deduped | Request_help_failed ->
-          ({ result with response_text = "" }, state))
-  | Defer, Silent ->
-      ({ result with response_text = "" }, state)
-  | Stay_silent, Silent when result.tools_used = [] ->
-      ({ result with response_text = "" }, state)
-  | _ ->
-      let response_text =
-        match
-          Keeper_tool_disclosure.normalize_response_text
-            ~text:visible_response_body
-            ~tool_names:result.tools_used
-            ()
-        with
-        | Ok normalized -> normalized
-        | Error _ -> visible_response_body
-      in
-      ({ result with response_text }, state)
+
+  let apply_output_to_result ~(meta : keeper_meta)
+      ~(result : Keeper_agent_run.run_result)
+      ~(visible_response_body : string) (state : social_state) =
+    match state.speech_act, state.delivery_surface with
+    | Request_help, Board_post when result.tools_used = [] ->
+        (match deliver_request_help_post ~meta ~state with
+        | Request_help_posted ->
+            let tools_used =
+              dedupe_keep_order ("keeper_board_post" :: result.tools_used)
+            in
+            ( { result with
+                response_text = "";
+                tools_used;
+                tool_calls_made = List.length tools_used;
+              },
+              state )
+        | Request_help_deduped | Request_help_failed ->
+            ({ result with response_text = "" }, state))
+    | Defer, Silent ->
+        ({ result with response_text = "" }, state)
+    | Stay_silent, Silent when result.tools_used = [] ->
+        ({ result with response_text = "" }, state)
+    | _ ->
+        let response_text =
+          match
+            Keeper_tool_disclosure.normalize_response_text
+              ~text:visible_response_body
+              ~tool_names:result.tools_used ()
+          with
+          | Ok normalized -> normalized
+          | Error _ -> visible_response_body
+        in
+        ({ result with response_text }, state)
+
+  let apply_to_result ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation)
+      (result : Keeper_agent_run.run_result) =
+    let headers, response_body = parse_header_block result.response_text in
+    let visible_response_body =
+      Keeper_text_processing.strip_internal_reply_markup response_body
+    in
+    let input =
+      {
+        meta;
+        observation;
+        result;
+        headers;
+        has_text_reply = String.trim visible_response_body <> "";
+      }
+    in
+    let state, output = transition None input in
+    let social_state = to_social_state state output in
+    apply_output_to_result ~meta ~result ~visible_response_body social_state
+
+  let derive_failure_state ~(meta : keeper_meta)
+      ~(observation : Keeper_world_observation.world_observation)
+      ~(reason : string) =
+    let state =
+      make_state ~meta ~observation
+        ?blocker:
+          (match String.trim reason with
+          | "" -> None
+          | value -> Some (short_preview value))
+        ()
+    in
+    let output = { speech_act = Defer; delivery_surface = Silent } in
+    to_social_state state output
+end
 
 let extract_accountability_claim (result : Keeper_agent_run.run_result) =
   let headers, _ = parse_header_block result.response_text in
@@ -423,19 +506,19 @@ let extract_accountability_claim (result : Keeper_agent_run.run_result) =
         }
   | _ -> None
 
+let active_model_of_meta (meta : keeper_meta) =
+  match model_id_of_string meta.social_model with
+  | Some model_id -> model_id
+  | None -> default_model_id
+
+let apply_to_result ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    (result : Keeper_agent_run.run_result) =
+  match active_model_of_meta meta with
+  | Bdi_speech_v1 -> Bdi_speech_v1.apply_to_result ~meta ~observation result
+
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(reason : string) =
-  {
-    social_model = meta.social_model;
-    belief_summary = belief_summary_of_observation observation;
-    active_desire = None;
-    current_intention = None;
-    blocker =
-      (match String.trim reason with
-      | "" -> None
-      | value -> Some (short_preview value));
-    need = None;
-    speech_act = Defer;
-    delivery_surface = Silent;
-  }
+  match active_model_of_meta meta with
+  | Bdi_speech_v1 -> Bdi_speech_v1.derive_failure_state ~meta ~observation ~reason

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -4,7 +4,7 @@
     decision so keepers can stay silent, inform, or ask for help without
     relying on repetitive free-form fallback text. *)
 
-type speech_act =
+type speech_act = Keeper_social_model_types.speech_act =
   | Stay_silent
   | Inform
   | Request_help
@@ -14,7 +14,7 @@ type speech_act =
   | Broadcast
   | Defer
 
-type delivery_surface =
+type delivery_surface = Keeper_social_model_types.delivery_surface =
   | Silent
   | Visible_reply
   | Board_post
@@ -22,10 +22,10 @@ type delivery_surface =
   | Task_claim_surface
   | Broadcast_surface
 
-type model_id =
+type model_id = Keeper_social_model_types.model_id =
   | Bdi_speech_v1
 
-type social_state = {
+type social_state = Keeper_social_model_types.social_state = {
   social_model : string;
   belief_summary : string;
   active_desire : string option;

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -22,6 +22,9 @@ type delivery_surface =
   | Task_claim_surface
   | Broadcast_surface
 
+type model_id =
+  | Bdi_speech_v1
+
 type social_state = {
   social_model : string;
   belief_summary : string;
@@ -41,6 +44,9 @@ type accountability_claim = {
 
 val speech_act_to_string : speech_act -> string
 val delivery_surface_to_string : delivery_surface -> string
+val model_id_to_string : model_id -> string
+val model_id_of_string : string -> model_id option
+val normalize_social_model : string -> string
 val extract_accountability_claim :
   Keeper_agent_run.run_result -> accountability_claim option
 

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -215,7 +215,8 @@ let handle_keeper_list ctx args : tool_result =
                 if String.trim m.runtime.proactive_rt.last_preview = ""
                 then `Null
                 else `String m.runtime.proactive_rt.last_preview);
-              ("social_model", `String m.social_model);
+              ("social_model",
+                `String (Keeper_social_model.normalize_social_model m.social_model));
               ("last_speech_act",
                 if String.trim m.runtime.last_speech_act = ""
                 then `Null

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -989,7 +989,8 @@ let handle_keeper_status ctx args : tool_result =
              ("tool_action_count", `Int m.runtime.autonomous_action_count);
            ]);
            ("social", `Assoc [
-             ("model", `String m.social_model);
+             ("model",
+               `String (Keeper_social_model.normalize_social_model m.social_model));
              ("last_speech_act",
                if String.trim m.runtime.last_speech_act = ""
                then `Null

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -1,0 +1,369 @@
+(** First concrete social-model implementation for the active baseline.
+
+    This module owns the BDI-flavored transition logic; the registry decides
+    when it is selected. *)
+
+open Keeper_types
+
+module Types = Keeper_social_model_types
+module Protocol = Keeper_social_model_protocol
+
+type input = {
+  meta : keeper_meta;
+  observation : Keeper_world_observation.world_observation;
+  result : Keeper_agent_run.run_result;
+  headers : (string * string) list;
+  has_text_reply : bool;
+}
+
+type state = {
+  social_model : string;
+  belief_summary : string;
+  active_desire : string option;
+  current_intention : string option;
+  blocker : string option;
+  need : string option;
+}
+
+type output = {
+  speech_act : Types.speech_act;
+  delivery_surface : Types.delivery_surface;
+}
+
+type request_help_delivery =
+  | Request_help_posted
+  | Request_help_deduped
+  | Request_help_failed
+
+let to_social_state (state : state) (output : output) : Types.social_state =
+  {
+    social_model = state.social_model;
+    belief_summary = state.belief_summary;
+    active_desire = state.active_desire;
+    current_intention = state.current_intention;
+    blocker = state.blocker;
+    need = state.need;
+    speech_act = output.speech_act;
+    delivery_surface = output.delivery_surface;
+  }
+
+let belief_summary_of_observation
+    (observation : Keeper_world_observation.world_observation) : string =
+  let parts =
+    List.filter_map Fun.id
+      [
+        (if observation.pending_mentions <> [] then
+           Some
+             (Printf.sprintf "mentions=%d"
+                (List.length observation.pending_mentions))
+         else None);
+        (if observation.pending_board_events <> [] then
+           Some
+             (Printf.sprintf "board_events=%d"
+                (List.length observation.pending_board_events))
+         else None);
+        (if observation.pending_scope_messages <> [] then
+           Some
+             (Printf.sprintf "scope_messages=%d"
+                (List.length observation.pending_scope_messages))
+         else None);
+        (if observation.unclaimed_task_count > 0 then
+           Some
+             (Printf.sprintf "unclaimed_tasks=%d" observation.unclaimed_task_count)
+         else None);
+        (if observation.failed_task_count > 0 then
+           Some (Printf.sprintf "failed_tasks=%d" observation.failed_task_count)
+         else None);
+        (if observation.active_goals <> [] then
+           Some
+             (Printf.sprintf "active_goals=%d"
+                (List.length observation.active_goals))
+         else None);
+        (if observation.idle_seconds > 0 then
+           Some (Printf.sprintf "idle=%ds" observation.idle_seconds)
+         else None);
+        (if Option.is_some observation.worktree_change_summary then
+           Some "worktree_delta"
+         else None);
+      ]
+  in
+  match parts with
+  | [] -> "quiet_room"
+  | _ -> String.concat "; " parts
+
+let make_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ?active_desire ?current_intention ?blocker ?need ?social_model
+    ?belief_summary () =
+  {
+    social_model =
+      Option.value
+        ~default:(Types.normalize_social_model meta.social_model)
+        social_model;
+    belief_summary =
+      Option.value ~default:(belief_summary_of_observation observation)
+        belief_summary;
+    active_desire;
+    current_intention;
+    blocker;
+    need;
+  }
+
+let protocol_violation_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation) ~(reason : string)
+    =
+  ( make_state ~meta ~observation ?blocker:(Some reason) (),
+    { speech_act = Types.Defer; delivery_surface = Types.Silent } )
+
+let inferred_text_reply_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation) =
+  ( make_state ~meta ~observation (),
+    { speech_act = Types.Inform; delivery_surface = Types.Visible_reply } )
+
+let inferred_tool_surface tools =
+  if tools = [ "keeper_stay_silent" ] then
+    Some { speech_act = Types.Stay_silent; delivery_surface = Types.Silent }
+  else if List.mem "keeper_board_comment" tools then
+    Some
+      {
+        speech_act = Types.Comment_board;
+        delivery_surface = Types.Board_comment;
+      }
+  else if List.mem "keeper_board_post" tools then
+    Some { speech_act = Types.Post_board; delivery_surface = Types.Board_post }
+  else if List.mem "keeper_broadcast" tools then
+    Some
+      {
+        speech_act = Types.Broadcast;
+        delivery_surface = Types.Broadcast_surface;
+      }
+  else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
+    Some
+      {
+        speech_act = Types.Claim_task;
+        delivery_surface = Types.Task_claim_surface;
+      }
+  else
+    None
+
+let tool_only_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(result : Keeper_agent_run.run_result) =
+  let output =
+    match inferred_tool_surface result.tools_used with
+    | Some routed -> routed
+    | None ->
+        {
+          speech_act = Types.Inform;
+          delivery_surface = Types.Visible_reply;
+        }
+  in
+  (make_state ~meta ~observation (), output)
+
+let social_state_of_headers ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation) headers =
+  match
+    Protocol.nonempty_header_opt headers "SPEECH_ACT",
+    Protocol.header_assoc_opt headers "DELIVERY_SURFACE"
+  with
+  | Some speech_raw, Some delivery_raw -> (
+      match
+        Types.speech_act_of_string speech_raw,
+        Types.delivery_surface_of_string delivery_raw
+      with
+      | Some speech_act, Some delivery_surface ->
+          let belief_summary =
+            let max_len = 200 in
+            let raw =
+              Option.value
+                ~default:(belief_summary_of_observation observation)
+                (Protocol.nonempty_header_opt headers "BELIEF_SUMMARY")
+            in
+            if String.length raw <= max_len then raw
+            else
+              let truncated = String.sub raw 0 max_len in
+              match String.rindex_opt truncated ' ' with
+              | Some i when i > max_len / 2 -> String.sub raw 0 i
+              | _ -> truncated
+          in
+          ( make_state ~meta ~observation
+              ~social_model:
+                (Types.normalize_social_model
+                   (Option.value
+                      ~default:meta.social_model
+                      (Protocol.nonempty_header_opt headers "SOCIAL_MODEL")))
+              ~belief_summary
+              ?active_desire:
+                (Protocol.nonempty_header_opt headers "ACTIVE_DESIRE")
+              ?current_intention:
+                (Protocol.nonempty_header_opt headers "CURRENT_INTENTION")
+              ?blocker:(Protocol.nonempty_header_opt headers "BLOCKER")
+              ?need:(Protocol.nonempty_header_opt headers "NEED")
+              (),
+            { speech_act; delivery_surface } )
+      | _ ->
+          protocol_violation_state ~meta ~observation
+            ~reason:"invalid social headers")
+  | _ ->
+      protocol_violation_state ~meta ~observation
+        ~reason:"missing social headers"
+
+let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option) =
+  match blocker with
+  | None -> false
+  | Some blocker ->
+      String.equal blocker (String.trim meta.runtime.last_blocker)
+      && String.equal meta.runtime.last_speech_act "request_help"
+      && meta.runtime.proactive_rt.last_ts > 0.0
+      && Time_compat.now () -. meta.runtime.proactive_rt.last_ts
+         < float_of_int meta.proactive.cooldown_sec
+
+let request_help_post_body ~(meta : keeper_meta)
+    ~(state : Types.social_state) blocker =
+  String.concat "\n"
+    [
+      Printf.sprintf "keeper `%s` is blocked." meta.name;
+      Printf.sprintf "goal: %s" meta.goal;
+      Printf.sprintf "beliefs: %s" state.belief_summary;
+      (match state.current_intention with
+      | Some value -> "intended action: " ^ value
+      | None -> "intended action: unspecified");
+      "blocker: " ^ blocker;
+      (match state.need with
+      | Some value -> "need: " ^ value
+      | None -> "need: guidance");
+      "retry condition: external capability or operator guidance becomes available";
+    ]
+
+let deliver_request_help_post ~(meta : keeper_meta)
+    ~(state : Types.social_state) =
+  match state.blocker with
+  | None -> Request_help_failed
+  | Some blocker when should_dedupe_request_help ~meta ~blocker:(Some blocker)
+    ->
+      Request_help_deduped
+  | Some blocker ->
+      let title = Printf.sprintf "[keeper-blocked] %s needs help" meta.name in
+      let body = request_help_post_body ~meta ~state blocker in
+      let meta_json =
+        Some
+          (`Assoc
+            [
+              ("source", `String "keeper_board_post");
+              ("social_model", `String state.social_model);
+              ( "speech_act",
+                `String (Types.speech_act_to_string state.speech_act) );
+              ("keeper_name", `String meta.name);
+              ("agent_name", `String meta.agent_name);
+              ("belief_summary", `String state.belief_summary);
+              ("blocker", `String blocker);
+              ( "need",
+                match state.need with
+                | Some value -> `String value
+                | None -> `Null );
+            ])
+      in
+      match
+        Board_dispatch.create_post ~author:meta.name ~title ~body ~content:body
+          ~post_kind:Board.Automation_post ?meta_json
+          ~visibility:Board.Internal ~ttl_hours:24 ~hearth:"keepers" ()
+      with
+      | Ok _ -> Request_help_posted
+      | Error _ -> Request_help_failed
+
+let transition (_previous_state : state option) (input : input) =
+  let meta = input.meta in
+  let observation = input.observation in
+  let result = input.result in
+  if result.tools_used <> [] then
+    tool_only_state ~meta ~observation ~result
+  else if input.headers <> [] then
+    let state, output =
+      social_state_of_headers ~meta ~observation input.headers
+    in
+    if input.has_text_reply
+       &&
+       match state.blocker with
+       | Some "missing social headers" | Some "invalid social headers" -> true
+       | _ -> false
+    then
+      inferred_text_reply_state ~meta ~observation
+    else
+      (state, output)
+  else if input.has_text_reply then
+    inferred_text_reply_state ~meta ~observation
+  else
+    protocol_violation_state ~meta ~observation
+      ~reason:"no tool calls and no social headers"
+
+let apply_output_to_result ~(meta : keeper_meta)
+    ~(result : Keeper_agent_run.run_result)
+    ~(visible_response_body : string) (state : Types.social_state) =
+  match state.speech_act, state.delivery_surface with
+  | Request_help, Board_post when result.tools_used = [] ->
+      (match deliver_request_help_post ~meta ~state with
+      | Request_help_posted ->
+          let tools_used =
+            dedupe_keep_order ("keeper_board_post" :: result.tools_used)
+          in
+          ( { result with
+              response_text = "";
+              tools_used;
+              tool_calls_made = List.length tools_used;
+            },
+            state )
+      | Request_help_deduped | Request_help_failed ->
+          ({ result with response_text = "" }, state))
+  | Defer, Silent ->
+      ({ result with response_text = "" }, state)
+  | Stay_silent, Silent when result.tools_used = [] ->
+      ({ result with response_text = "" }, state)
+  | _ ->
+      let response_text =
+        match
+          Keeper_tool_disclosure.normalize_response_text
+            ~text:visible_response_body
+            ~tool_names:result.tools_used ()
+        with
+        | Ok normalized -> normalized
+        | Error _ -> visible_response_body
+      in
+      ({ result with response_text }, state)
+
+let apply_to_result ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    (result : Keeper_agent_run.run_result) =
+  let headers, response_body =
+    Protocol.parse_header_block result.response_text
+  in
+  let visible_response_body =
+    Keeper_text_processing.strip_internal_reply_markup response_body
+  in
+  let input =
+    {
+      meta;
+      observation;
+      result;
+      headers;
+      has_text_reply = String.trim visible_response_body <> "";
+    }
+  in
+  let state, output = transition None input in
+  let social_state = to_social_state state output in
+  apply_output_to_result ~meta ~result ~visible_response_body social_state
+
+let derive_failure_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(reason : string) =
+  let state =
+    make_state ~meta ~observation
+      ?blocker:
+        (match String.trim reason with
+        | "" -> None
+        | value -> Some (short_preview value))
+      ()
+  in
+  let output =
+    { speech_act = Types.Defer; delivery_surface = Types.Silent }
+  in
+  to_social_state state output

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -1,0 +1,37 @@
+open Keeper_types
+
+type input = {
+  meta : keeper_meta;
+  observation : Keeper_world_observation.world_observation;
+  result : Keeper_agent_run.run_result;
+  headers : (string * string) list;
+  has_text_reply : bool;
+}
+
+type state = {
+  social_model : string;
+  belief_summary : string;
+  active_desire : string option;
+  current_intention : string option;
+  blocker : string option;
+  need : string option;
+}
+
+type output = {
+  speech_act : Keeper_social_model_types.speech_act;
+  delivery_surface : Keeper_social_model_types.delivery_surface;
+}
+
+val transition : state option -> input -> state * output
+
+val apply_to_result :
+  meta:keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  Keeper_agent_run.run_result ->
+  Keeper_agent_run.run_result * Keeper_social_model_types.social_state
+
+val derive_failure_state :
+  meta:keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  reason:string ->
+  Keeper_social_model_types.social_state

--- a/lib/keeper/social_model/keeper_social_model_protocol.ml
+++ b/lib/keeper/social_model/keeper_social_model_protocol.ml
@@ -1,0 +1,61 @@
+let parse_header_line line =
+  match String.index_opt line ':' with
+  | None -> None
+  | Some idx ->
+      let key = String.sub line 0 idx |> String.trim in
+      let value =
+        String.sub line (idx + 1) (String.length line - idx - 1) |> String.trim
+      in
+      if key = "" then None else Some (key, value)
+
+let is_social_header_key = function
+  | "SOCIAL_MODEL"
+  | "BELIEF_SUMMARY"
+  | "ACTIVE_DESIRE"
+  | "CURRENT_INTENTION"
+  | "BLOCKER"
+  | "NEED"
+  | "CLAIM_KIND"
+  | "CLAIM_SUBJECT"
+  | "CLAIM_TASK_ID"
+  | "EVIDENCE_REFS"
+  | "SPEECH_ACT"
+  | "DELIVERY_SURFACE" ->
+      true
+  | _ -> false
+
+let parse_header_block raw =
+  let lines = String.split_on_char '\n' raw in
+  let rec consume acc = function
+    | line :: rest -> (
+        match parse_header_line line with
+        | Some (key, value) when is_social_header_key key ->
+            consume ((key, value) :: acc) rest
+        | _ -> (List.rev acc, line :: rest))
+    | [] -> (List.rev acc, [])
+  in
+  let headers, body_lines = consume [] lines in
+  (headers, String.concat "\n" body_lines |> String.trim)
+
+let header_assoc_opt headers key =
+  headers
+  |> List.find_map (fun (header_key, value) ->
+         if String.equal header_key key then Some value else None)
+
+let nonempty_header_opt headers key =
+  match header_assoc_opt headers key with
+  | Some value -> (
+      match String.lowercase_ascii (String.trim value) with
+      | "" | "none" | "null" -> None
+      | _ -> Some (String.trim value))
+  | None -> None
+
+let comma_list_header_opt headers key =
+  match nonempty_header_opt headers key with
+  | Some value ->
+      value
+      |> String.split_on_char ','
+      |> List.map String.trim
+      |> List.filter (fun item -> item <> "")
+      |> List.sort_uniq String.compare
+  | None -> []

--- a/lib/keeper/social_model/keeper_social_model_protocol.mli
+++ b/lib/keeper/social_model/keeper_social_model_protocol.mli
@@ -1,0 +1,4 @@
+val parse_header_block : string -> (string * string) list * string
+val header_assoc_opt : (string * string) list -> string -> string option
+val nonempty_header_opt : (string * string) list -> string -> string option
+val comma_list_header_opt : (string * string) list -> string -> string list

--- a/lib/keeper/social_model/keeper_social_model_registry.ml
+++ b/lib/keeper/social_model/keeper_social_model_registry.ml
@@ -1,0 +1,24 @@
+open Keeper_types
+
+module Types = Keeper_social_model_types
+
+let active_model_of_meta (meta : keeper_meta) =
+  match Types.model_id_of_string meta.social_model with
+  | Some model_id -> model_id
+  | None -> Types.default_model_id
+
+let apply_to_result ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    (result : Keeper_agent_run.run_result) =
+  match active_model_of_meta meta with
+  | Types.Bdi_speech_v1 ->
+      Keeper_social_model_bdi_speech_v1.apply_to_result ~meta ~observation
+        result
+
+let derive_failure_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(reason : string) =
+  match active_model_of_meta meta with
+  | Types.Bdi_speech_v1 ->
+      Keeper_social_model_bdi_speech_v1.derive_failure_state ~meta
+        ~observation ~reason

--- a/lib/keeper/social_model/keeper_social_model_registry.mli
+++ b/lib/keeper/social_model/keeper_social_model_registry.mli
@@ -1,0 +1,13 @@
+open Keeper_types
+
+val apply_to_result :
+  meta:keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  Keeper_agent_run.run_result ->
+  Keeper_agent_run.run_result * Keeper_social_model_types.social_state
+
+val derive_failure_state :
+  meta:keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  reason:string ->
+  Keeper_social_model_types.social_state

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -1,0 +1,86 @@
+type speech_act =
+  | Stay_silent
+  | Inform
+  | Request_help
+  | Claim_task
+  | Comment_board
+  | Post_board
+  | Broadcast
+  | Defer
+
+type delivery_surface =
+  | Silent
+  | Visible_reply
+  | Board_post
+  | Board_comment
+  | Task_claim_surface
+  | Broadcast_surface
+
+type model_id =
+  | Bdi_speech_v1
+
+type social_state = {
+  social_model : string;
+  belief_summary : string;
+  active_desire : string option;
+  current_intention : string option;
+  blocker : string option;
+  need : string option;
+  speech_act : speech_act;
+  delivery_surface : delivery_surface;
+}
+
+let speech_act_to_string = function
+  | Stay_silent -> "stay_silent"
+  | Inform -> "inform"
+  | Request_help -> "request_help"
+  | Claim_task -> "claim_task"
+  | Comment_board -> "comment_board"
+  | Post_board -> "post_board"
+  | Broadcast -> "broadcast"
+  | Defer -> "defer"
+
+let speech_act_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "stay_silent" -> Some Stay_silent
+  | "inform" -> Some Inform
+  | "request_help" -> Some Request_help
+  | "claim_task" -> Some Claim_task
+  | "comment_board" -> Some Comment_board
+  | "post_board" -> Some Post_board
+  | "broadcast" -> Some Broadcast
+  | "defer" -> Some Defer
+  | _ -> None
+
+let delivery_surface_to_string = function
+  | Silent -> "silent"
+  | Visible_reply -> "visible_reply"
+  | Board_post -> "board_post"
+  | Board_comment -> "board_comment"
+  | Task_claim_surface -> "task_claim"
+  | Broadcast_surface -> "broadcast"
+
+let delivery_surface_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "silent" -> Some Silent
+  | "visible_reply" -> Some Visible_reply
+  | "board_post" -> Some Board_post
+  | "board_comment" -> Some Board_comment
+  | "task_claim" -> Some Task_claim_surface
+  | "broadcast" -> Some Broadcast_surface
+  | _ -> None
+
+let model_id_to_string = function
+  | Bdi_speech_v1 -> "bdi_speech_v1"
+
+let model_id_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "bdi_speech_v1" -> Some Bdi_speech_v1
+  | _ -> None
+
+let default_model_id = Bdi_speech_v1
+
+let normalize_social_model value =
+  match model_id_of_string value with
+  | Some model_id -> model_id_to_string model_id
+  | None -> model_id_to_string default_model_id

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -1,0 +1,40 @@
+type speech_act =
+  | Stay_silent
+  | Inform
+  | Request_help
+  | Claim_task
+  | Comment_board
+  | Post_board
+  | Broadcast
+  | Defer
+
+type delivery_surface =
+  | Silent
+  | Visible_reply
+  | Board_post
+  | Board_comment
+  | Task_claim_surface
+  | Broadcast_surface
+
+type model_id =
+  | Bdi_speech_v1
+
+type social_state = {
+  social_model : string;
+  belief_summary : string;
+  active_desire : string option;
+  current_intention : string option;
+  blocker : string option;
+  need : string option;
+  speech_act : speech_act;
+  delivery_surface : delivery_surface;
+}
+
+val speech_act_to_string : speech_act -> string
+val speech_act_of_string : string -> speech_act option
+val delivery_surface_to_string : delivery_surface -> string
+val delivery_surface_of_string : string -> delivery_surface option
+val model_id_to_string : model_id -> string
+val model_id_of_string : string -> model_id option
+val default_model_id : model_id
+val normalize_social_model : string -> string

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -188,7 +188,8 @@ let keeper_list_row_json ~runtime_class config name =
             ("proactive_enabled", `Bool meta.proactive.enabled);
             ("proactive_idle_sec", `Int meta.proactive.idle_sec);
             ("proactive_cooldown_sec", `Int meta.proactive.cooldown_sec);
-            ("social_model", `String meta.social_model);
+            ("social_model",
+              `String (Keeper_social_model.normalize_social_model meta.social_model));
             ( "last_speech_act",
               if String.trim meta.runtime.last_speech_act = ""
               then `Null

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -87,6 +87,14 @@ let write_keeper_meta_exn ?(autoboot_enabled = true)
   | Ok () -> ()
   | Error e -> fail ("write_meta failed: " ^ e)
 
+let register_keeper_offline_exn config ~name =
+  match Keeper_types.read_meta config name with
+  | Ok (Some meta) ->
+      ignore
+        (Keeper_registry.register_offline ~base_path:config.base_path name meta)
+  | Ok None -> fail ("expected keeper meta for " ^ name)
+  | Error e -> fail ("read_meta failed: " ^ e)
+
 let parse_json_exn body =
   try Yojson.Safe.from_string body
   with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
@@ -195,6 +203,7 @@ let test_keeper_list_normalizes_unknown_social_model () =
       write_keeper_toml_exn config ~name:"sangsu";
       write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu"
         ~social_model:"experimental_v99";
+      register_keeper_offline_exn config ~name:"sangsu";
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
         match

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -65,7 +65,8 @@ room_scope = "current"
 proactive_enabled = false
 |}
 
-let write_keeper_meta_exn ?(autoboot_enabled = true) config ~name ~trace_id =
+let write_keeper_meta_exn ?(autoboot_enabled = true)
+    ?(social_model = "bdi_speech_v1") config ~name ~trace_id =
   let json =
     `Assoc
       [
@@ -73,6 +74,7 @@ let write_keeper_meta_exn ?(autoboot_enabled = true) config ~name ~trace_id =
         ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
         ("trace_id", `String trace_id);
         ("goal", `String "test keeper");
+        ("social_model", `String social_model);
         ("autoboot_enabled", `Bool autoboot_enabled);
       ]
   in
@@ -175,6 +177,37 @@ let test_bootable_keeper_names_skip_autoboot_disabled_meta () =
       check bool "autoboot disabled sangsu excluded from bootable list" false
         (List.mem "sangsu" names))
 
+let test_keeper_list_normalizes_unknown_social_model () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn config ~name:"sangsu";
+      write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu"
+        ~social_model:"experimental_v99";
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        Tool_keeper.handle_keeper_list ctx
+          (`Assoc [ ("limit", `Int 10); ("detailed", `Bool true) ])
+      in
+      check bool "tool keeper list ok" true ok;
+      let json = parse_json_exn body in
+      match keeper_json_by_name json "sangsu" with
+      | Some keeper ->
+          check string "social_model normalized" "bdi_speech_v1"
+            Yojson.Safe.Util.(keeper |> member "social_model" |> to_string)
+      | None -> fail "expected sangsu row in keeper list")
+
 let () =
   run "keeper_meta_listing"
     [
@@ -184,5 +217,7 @@ let () =
             test_keeper_listing_ignores_sidecar_json_files;
           test_case "bootable list skips autoboot-disabled meta" `Quick
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
+          test_case "tool keeper list normalizes unknown social model" `Quick
+            test_keeper_list_normalizes_unknown_social_model;
         ] );
     ]

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -197,8 +197,12 @@ let test_keeper_list_normalizes_unknown_social_model () =
         ~social_model:"experimental_v99";
       let ctx = keeper_ctx env sw config "operator" in
       let ok, body =
-        Tool_keeper.handle_keeper_list ctx
-          (`Assoc [ ("limit", `Int 10); ("detailed", `Bool true) ])
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_list"
+            ~args:(`Assoc [ ("limit", `Int 10); ("detailed", `Bool true) ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_list dispatch"
       in
       check bool "tool keeper list ok" true ok;
       let json = parse_json_exn body in

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -896,6 +896,16 @@ let test_meta_defaults_social_model () =
   check string "default social model" "bdi_speech_v1"
     minimal_meta.social_model
 
+let test_social_model_registry_round_trip () =
+  check (option string) "known model id resolves"
+    (Some "bdi_speech_v1")
+    (KSM.model_id_of_string "bdi_speech_v1"
+    |> Option.map KSM.model_id_to_string);
+  check bool "unknown model id rejected" true
+    (Option.is_none (KSM.model_id_of_string "experimental_v99"));
+  check string "unknown model normalized to baseline" "bdi_speech_v1"
+    (KSM.normalize_social_model "experimental_v99")
+
 (* ---------- Metrics observation tests ---------- *)
 
 let sample_prompt_metrics ?(system_prompt = "You are a keeper.")
@@ -2395,6 +2405,36 @@ let test_social_model_silences_skip_only_turn () =
       check string "visible response suppressed" "" routed.response_text;
       check (list string) "no synthetic tools" [] routed.tools_used)
 
+let test_social_model_unknown_meta_falls_back_to_baseline () =
+  let meta = { minimal_meta with social_model = "experimental_v99" } in
+  let result =
+    make_run_result ~text:"I can respond normally." ~tools:[]
+      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta ~observation:base_observation result
+  in
+  check string "unknown meta model falls back to baseline"
+    "bdi_speech_v1" state.social_model;
+  check string "visible response preserved"
+    "I can respond normally." routed.response_text
+
+let test_social_model_unknown_header_falls_back_to_baseline () =
+  let result =
+    make_run_result
+      ~text:
+        "SOCIAL_MODEL: experimental_v99\nBELIEF_SUMMARY: quiet_room\nACTIVE_DESIRE: maintain_quiet_readiness\nCURRENT_INTENTION: stay_available_without_noise\nBLOCKER: none\nNEED: none\nSPEECH_ACT: stay_silent\nDELIVERY_SURFACE: silent"
+      ~tools:[]
+      ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation result
+  in
+  check string "unknown header model falls back to baseline"
+    "bdi_speech_v1" state.social_model;
+  check string "visible response suppressed" "" routed.response_text
+
 let test_social_model_infers_visible_reply_without_headers () =
   let result =
     make_run_result ~text:"I think I should ask for help." ~tools:[]
@@ -2897,8 +2937,14 @@ let () =
             test_tool_query_text_of_user_message_strips_continuity_noise;
           test_case "tool query keeps counted headers" `Quick
             test_tool_query_text_of_user_message_keeps_counted_headers;
+          test_case "social model registry round trip" `Quick
+            test_social_model_registry_round_trip;
           test_case "social model silences skip-only turn" `Quick
             test_social_model_silences_skip_only_turn;
+          test_case "social model unknown meta falls back to baseline" `Quick
+            test_social_model_unknown_meta_falls_back_to_baseline;
+          test_case "social model unknown header falls back to baseline" `Quick
+            test_social_model_unknown_header_falls_back_to_baseline;
           test_case "social model infers visible reply without headers" `Quick
             test_social_model_infers_visible_reply_without_headers;
           test_case "social model empty text without headers stays silent" `Quick


### PR DESCRIPTION
## Summary
- extract the current `bdi_speech_v1` transition core behind an explicit social-model dispatch boundary
- split social-model code into shared types/protocol helpers, a `bdi_speech_v1` implementation module, a registry module, and a thin `Keeper_social_model` facade
- normalize unknown `social_model` values to the active baseline before exposing them via keeper status, dashboard, and tool surfaces
- add regression coverage for model-id normalization and unknown-model fallback in unified social-model tests

## Why
`social_model` had a design contract and an internal dispatch boundary, but the implementation was still physically collapsed into one file. This PR makes the first implementation boundary real so follow-up work can add state carry and additional models without mixing facade, registry, protocol parsing, and BDI behavior in one module.

## Validation
- `env ALCOTEST_QUICK_TESTS=1 dune exec --build-dir /tmp/masc-social-model-fsm-build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-fsm-registry ./test/test_keeper_unified.exe`
  - result: `150 tests run`, `Test Successful`

## Notes
- I added a keeper-list surface normalization test in `test_keeper_meta_listing.ml`, but running that target currently hits an unrelated compile error in `lib/keeper/keeper_agent_run.ml` around `Agent_sdk.Tool_selector.default_rerank_fn ?config_path`.
- I did not patch that call in this PR because it is outside the social-model refactor slice; the failure appears pre-existing relative to these changes.