### PR TITLE
refactor(dashboard): extract useGlobalShortcut hook

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -8,6 +8,7 @@ import {
 import { fetchGateKeepers } from '../api/gate'
 import { keepers } from '../store'
 import { compositeTick } from '../composite-signals'
+import { useGlobalShortcut } from '../lib/use-global-shortcut'
 import { EmptyState } from './common/empty-state'
 
 import {
@@ -234,26 +235,15 @@ export function FsmHub() {
     })()
   }, [activeSelected, shouldRefetchForTick, pollTick])
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return undefined
-    const handler = (ev: KeyboardEvent) => {
-      if (ev.metaKey || ev.ctrlKey || ev.altKey) return
-      const target = ev.target as HTMLElement | null
-      if (target) {
-        const tag = target.tagName
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
-        if (target.isContentEditable) return
-      }
-      if (ev.key < '1' || ev.key > '9') return
+  useGlobalShortcut(
+    (ev) => ev.key >= '1' && ev.key <= '9',
+    (ev) => {
       const idx = ev.key.charCodeAt(0) - '1'.charCodeAt(0)
-      const target_name = keeperNames[idx]
-      if (!target_name) return
-      ev.preventDefault()
-      setSelected(target_name)
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [keeperNames])
+      const name = keeperNames[idx]
+      if (name) setSelected(name)
+    },
+    [keeperNames],
+  )
 
   const view = useMemo(
     () =>

--- a/dashboard/src/lib/use-global-shortcut.test.ts
+++ b/dashboard/src/lib/use-global-shortcut.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { act } from 'preact/test-utils'
+
+import { useGlobalShortcut } from './use-global-shortcut'
+
+async function mount(node: HTMLDivElement, vnode: ReturnType<typeof html>): Promise<void> {
+  await act(async () => {
+    render(vnode, node)
+    await Promise.resolve()
+  })
+}
+
+function Probe({
+  match,
+  handler,
+}: {
+  match: (ev: KeyboardEvent) => boolean
+  handler: (ev: KeyboardEvent) => void
+}) {
+  useGlobalShortcut(match, handler)
+  return html`<div data-probe />`
+}
+
+function dispatchKey(
+  key: string,
+  init: KeyboardEventInit & { target?: HTMLElement } = {},
+): KeyboardEvent {
+  const { target, ...evInit } = init
+  const ev = new KeyboardEvent('keydown', { key, cancelable: true, bubbles: true, ...evInit })
+  ;(target ?? window).dispatchEvent(ev)
+  return ev
+}
+
+describe('useGlobalShortcut', () => {
+  let host: HTMLDivElement
+
+  beforeEach(() => {
+    host = document.createElement('div')
+    document.body.appendChild(host)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      render(null, host)
+      await Promise.resolve()
+    })
+    host.remove()
+  })
+
+  it('fires handler and preventDefault when match returns true', async () => {
+    const handler = vi.fn()
+    await mount(host, html`<${Probe} match=${(ev: KeyboardEvent) => ev.key === 'r'} handler=${handler} />`)
+    const ev = dispatchKey('r')
+    expect(handler).toHaveBeenCalledOnce()
+    expect(ev.defaultPrevented).toBe(true)
+  })
+
+  it('skips handler while user is typing in INPUT', async () => {
+    const handler = vi.fn()
+    await mount(host, html`<${Probe} match=${(ev: KeyboardEvent) => ev.key === 'r'} handler=${handler} />`)
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    dispatchKey('r', { target: input })
+    expect(handler).not.toHaveBeenCalled()
+    input.remove()
+  })
+
+  it('skips handler when modifier keys are held', async () => {
+    const handler = vi.fn()
+    await mount(host, html`<${Probe} match=${(ev: KeyboardEvent) => ev.key === 'r'} handler=${handler} />`)
+    dispatchKey('r', { metaKey: true })
+    dispatchKey('r', { ctrlKey: true })
+    dispatchKey('r', { altKey: true })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('ignores keys that fail the match predicate', async () => {
+    const handler = vi.fn()
+    await mount(host, html`<${Probe} match=${(ev: KeyboardEvent) => ev.key === 'r'} handler=${handler} />`)
+    const ev = dispatchKey('q')
+    expect(handler).not.toHaveBeenCalled()
+    expect(ev.defaultPrevented).toBe(false)
+  })
+
+  it('removes listener on unmount', async () => {
+    const handler = vi.fn()
+    await mount(host, html`<${Probe} match=${(ev: KeyboardEvent) => ev.key === 'r'} handler=${handler} />`)
+    await act(async () => {
+      render(null, host)
+      await Promise.resolve()
+    })
+    dispatchKey('r')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('skips handler in contenteditable elements', async () => {
+    const handler = vi.fn()
+    await mount(host, html`<${Probe} match=${(ev: KeyboardEvent) => ev.key === 'r'} handler=${handler} />`)
+    const editable = document.createElement('div')
+    editable.contentEditable = 'true'
+    document.body.appendChild(editable)
+    dispatchKey('r', { target: editable })
+    expect(handler).not.toHaveBeenCalled()
+    editable.remove()
+  })
+})

--- a/dashboard/src/lib/use-global-shortcut.ts
+++ b/dashboard/src/lib/use-global-shortcut.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'preact/hooks'
+
+/** Subscribe a handler to window 'keydown' that ignores presses while
+    the user is typing in form fields, contenteditable elements, or
+    holding a modifier (Cmd/Ctrl/Alt). The handler runs only for plain
+    key presses outside text input contexts.
+
+    Pass `match` to filter which key(s) trigger the handler. Return
+    `true` from match to fire `handler`; the hook calls
+    `event.preventDefault()` on a successful match. */
+export function useGlobalShortcut(
+  match: (ev: KeyboardEvent) => boolean,
+  handler: (ev: KeyboardEvent) => void,
+  deps: ReadonlyArray<unknown> = [],
+): void {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.metaKey || ev.ctrlKey || ev.altKey) return
+      const target = ev.target as HTMLElement | null
+      if (target) {
+        const tag = target.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+        if (target.isContentEditable) return
+      }
+      if (!match(ev)) return
+      ev.preventDefault()
+      handler(ev)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps)
+}


### PR DESCRIPTION
## Summary

- New `dashboard/src/lib/use-global-shortcut.ts` Preact hook
- Centralizes the modifier + INPUT/TEXTAREA/SELECT/contentEditable guard pattern
- Converts the 1-9 keeper-jump listener (#7371) as the first user

## Why

The `/simplify` review on PR #7378 flagged 4 copies of the same keyboard-handler boilerplate accumulating in `fsm-hub.ts` across recent feature PRs (#7371 merged, #7375/#7377/#7378 in flight). Each repeats:

- Modifier key bail
- Tag check (INPUT, TEXTAREA, SELECT)
- contentEditable check
- `addEventListener` + cleanup boilerplate

This refactor extracts the pattern. Future PRs adding new shortcuts (?, d, r) can use the hook on rebase, collapsing each call site to 7 lines.

## Changes

- `lib/use-global-shortcut.ts` — 33-line hook with `match` predicate + `handler`
- `lib/use-global-shortcut.test.ts` — 6 tests: fires-on-match, INPUT/contentEditable guard, modifier guard, predicate filtering, listener cleanup
- `components/fsm-hub.ts` — convert 1-9 listener (18 → 7 lines)

## Verification

- 669/669 tests pass (663 baseline + 6 new)
- typecheck/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)