### PR TITLE
feat(cascade): scaffold lib/cascade/ with 7 cascade_* modules from OAS (PR 4d-scaffold)

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -1,0 +1,635 @@
+(** Cascade configuration: named provider profiles with JSON hot-reload
+    and discovery-aware health filtering.
+
+    Provider defaults are sourced from {!Provider_registry} (SSOT).
+
+    @since 0.59.0
+    @since 0.92.0 decomposed into Cascade_model_resolve, Cascade_throttle,
+    Cascade_config_loader *)
+
+(* ── Re-exports from extracted modules ─────────────── *)
+
+(* Model resolution *)
+let resolve_glm_model_id = Cascade_model_resolve.resolve_glm_model_id
+let resolve_auto_model_id = Cascade_model_resolve.resolve_auto_model_id
+let parse_custom_model = Cascade_model_resolve.parse_custom_model
+
+(* Throttle — re-exports for future migration consumers. Marked as unused
+   while scaffold lives in parallel with OAS Llm_provider.Cascade_config. *)
+let[@warning "-32"] populate_throttle_table = Cascade_throttle.populate
+let[@warning "-32"] lookup_throttle = Cascade_throttle.lookup
+
+(* Config loader *)
+let load_json = Cascade_config_loader.load_json
+let load_profile = Cascade_config_loader.load_profile
+
+type inference_params = Cascade_config_loader.inference_params = {
+  temperature: float option;
+  max_tokens: int option;
+}
+
+let resolve_inference_params = Cascade_config_loader.resolve_inference_params
+let resolve_api_key_env = Cascade_config_loader.resolve_api_key_env
+
+(* ── Provider registry (SSOT: Provider_registry) ─────── *)
+
+let default_registry = Llm_provider.Provider_registry.default ()
+
+(* Build headers list with Authorization when api_key is present.
+   Anthropic uses x-api-key; OpenAI-compat (including GLM) uses Bearer. *)
+let headers_with_auth ~(kind : Llm_provider.Provider_config.provider_kind) ~api_key =
+  let base = [("Content-Type", "application/json")] in
+  if api_key = "" then base
+  else match kind with
+    | Anthropic ->
+        ("x-api-key", api_key)
+        :: ("anthropic-version", "2023-06-01")
+        :: base
+    | OpenAI_compat | Ollama | Gemini | Glm | Claude_code ->
+        ("Authorization", "Bearer " ^ api_key) :: base
+    | Gemini_cli | Codex_cli -> []
+
+(* ── String splitting helper ──────────────────────────────── *)
+
+(** Split a "provider:model_id" string at the first colon.
+    Returns [None] if the colon is missing, at position 0, or at the end. *)
+let split_provider_model (s : string) : (string * string) option =
+  match String.index_opt s ':' with
+  | None -> None
+  | Some idx ->
+    if idx = 0 || idx >= String.length s - 1 then None
+    else
+      let provider_name =
+        String.sub s 0 idx |> String.trim |> String.lowercase_ascii
+      in
+      let model_id =
+        String.sub s (idx + 1) (String.length s - idx - 1) |> String.trim
+      in
+      if model_id = "" then None
+      else Some (provider_name, model_id)
+
+(* ── Shared config construction helpers ──────────────────── *)
+
+(** Build a {!Llm_provider.Provider_config.t} for "custom:model@url" specs. *)
+let make_custom_config ~temperature ~max_tokens ?system_prompt model_id =
+  let actual_model, base_url = parse_custom_model model_id in
+  if actual_model = "" then None
+  else Some (Llm_provider.Provider_config.make
+               ~kind:OpenAI_compat
+               ~model_id:actual_model
+               ~base_url
+               ~request_path:"/v1/chat/completions"
+               ~temperature
+               ~max_tokens
+               ?system_prompt
+               ())
+
+(** Resolve the effective API key env var name for a provider.
+
+    Checks [api_key_env_overrides] first (exact provider name, then
+    wildcard ["*"]), then falls back to the provider registry default.
+
+    Empty-string entries are treated as absent so a user-provided
+    [{"glm": ""}] falls through to the wildcard and registry default
+    instead of silently disabling auth. *)
+let resolve_effective_api_key_env
+    ~(api_key_env_overrides : (string * string) list)
+    ~(provider_name : string)
+    ~(registry_default : string) =
+  let find_non_empty key =
+    match List.assoc_opt key api_key_env_overrides with
+    | Some v when v <> "" -> Some v
+    | _ -> None
+  in
+  match find_non_empty provider_name with
+  | Some env -> env
+  | None ->
+    match find_non_empty "*" with
+    | Some env -> env
+    | None -> registry_default
+
+(** Build a {!Llm_provider.Provider_config.t} from a registry entry. *)
+let make_registry_config ~temperature ~max_tokens ?system_prompt
+    ?(api_key_env_overrides=[])
+    ~provider_name ~model_id (entry : Llm_provider.Provider_registry.entry) =
+  let defaults = entry.defaults in
+  let effective_api_key_env =
+    resolve_effective_api_key_env
+      ~api_key_env_overrides ~provider_name
+      ~registry_default:defaults.api_key_env
+  in
+  let api_key =
+    if effective_api_key_env = "" then ""
+    else Sys.getenv_opt effective_api_key_env |> Option.value ~default:""
+  in
+  let headers = headers_with_auth ~kind:defaults.kind ~api_key in
+  (* For local providers, resolve "auto" before endpoint selection so that
+     routing uses the concrete model name discovered from the server.
+     Filter by provider's own endpoint to prevent cross-provider
+     contamination (e.g. ollama:auto must not pick up llama-server models). *)
+  let is_local_auto =
+    (provider_name = "llama" || provider_name = "ollama")
+    && model_id = "auto"
+  in
+  let effective_model_id =
+    if is_local_auto then
+      (if provider_name = "ollama" then
+         Llm_provider.Discovery.first_discovered_model_id_for_url defaults.base_url
+       else
+         Llm_provider.Discovery.first_discovered_model_id ())
+      |> Option.value ~default:model_id
+    else model_id
+  in
+  let base_url =
+    if provider_name = "llama" then
+      (* Route to the endpoint that has this model; round-robin fallback *)
+      match Llm_provider.Discovery.endpoint_for_model effective_model_id with
+      | Some url -> url
+      | None -> Llm_provider.Provider_registry.next_llama_endpoint ()
+    else defaults.base_url
+  in
+  let resolved_model_id = resolve_auto_model_id provider_name effective_model_id in
+  (* Resolve max_context: per-model capabilities override registry default *)
+  let max_context =
+    let caps =
+      Option.value ~default:entry.capabilities
+        (Llm_provider.Capabilities.for_model_id resolved_model_id)
+    in
+    match caps.max_context_tokens with
+    | Some n -> n
+    | None -> entry.max_context
+  in
+  Llm_provider.Provider_config.make
+    ~kind:defaults.kind
+    ~model_id:resolved_model_id
+    ~base_url
+    ~api_key ~headers
+    ~request_path:defaults.request_path
+    ~temperature
+    ~max_tokens
+    ~max_context
+    ?system_prompt
+    ()
+
+(* ── Model string parsing ──────────────────────────────── *)
+
+let parse_model_string
+    ?(temperature = Llm_provider.Constants.Inference.default_temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
+    ?system_prompt ?(api_key_env_overrides = [])
+    (s : string) : Llm_provider.Provider_config.t option =
+  match split_provider_model (String.trim s) with
+  | None -> None
+  | Some ("custom", model_id) ->
+    make_custom_config ~temperature ~max_tokens ?system_prompt model_id
+  | Some (provider_name, model_id) ->
+    match Llm_provider.Provider_registry.find default_registry provider_name with
+    | None -> None
+    | Some entry when not (entry.is_available ()) -> None
+    | Some entry ->
+      Some (make_registry_config ~temperature ~max_tokens ?system_prompt
+              ~api_key_env_overrides ~provider_name ~model_id entry)
+
+let parse_model_string_exn
+    ?(temperature = Llm_provider.Constants.Inference.default_temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
+    ?system_prompt (s : string) : (Llm_provider.Provider_config.t, string) result =
+  let s = String.trim s in
+  match split_provider_model s with
+  | None ->
+    Error (Printf.sprintf "invalid model spec %S: expected \"provider:model_id\"" s)
+  | Some ("custom", model_id) ->
+    (match make_custom_config ~temperature ~max_tokens ?system_prompt model_id with
+     | Some cfg -> Ok cfg
+     | None ->
+       Error (Printf.sprintf "invalid custom model spec %S: empty model after @" s))
+  | Some (provider_name, model_id) ->
+    match Llm_provider.Provider_registry.find default_registry provider_name with
+    | None ->
+      Error (Printf.sprintf "unknown provider %S in model spec %S" provider_name s)
+    | Some entry when not (entry.is_available ()) ->
+      Error (Printf.sprintf "provider %S unavailable (missing env var %S)"
+               provider_name entry.defaults.api_key_env)
+    | Some entry ->
+      Ok (make_registry_config ~temperature ~max_tokens ?system_prompt
+            ~provider_name ~model_id entry)
+
+(** Expand provider:auto specs that map to multiple models.
+    "glm:auto" expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
+    Other specs pass through as-is. *)
+let expand_auto_models (strs : string list) : string list =
+  List.concat_map (fun s ->
+    let trimmed = String.trim s in
+    match split_provider_model trimmed with
+    | Some ("glm", model_id)
+      when String.lowercase_ascii model_id = "auto" ->
+      Cascade_model_resolve.glm_auto_models ()
+      |> List.map (fun m -> "glm:" ^ m)
+    | Some ("glm-coding", model_id)
+      when String.lowercase_ascii model_id = "auto" ->
+      Cascade_model_resolve.glm_coding_auto_models ()
+      |> List.map (fun m -> "glm-coding:" ^ m)
+    | _ -> [ trimmed ]
+  ) strs
+
+let parse_model_strings
+    ?(temperature = Llm_provider.Constants.Inference.default_temperature)
+    ?(max_tokens = Llm_provider.Constants.Inference.default_max_tokens)
+    ?system_prompt ?(api_key_env_overrides = [])
+    (strs : string list) : Llm_provider.Provider_config.t list =
+  let expanded = expand_auto_models strs in
+  List.filter_map
+    (parse_model_string ~temperature ~max_tokens ?system_prompt
+       ~api_key_env_overrides)
+    expanded
+
+(* Health filtering (extracted to Cascade_health_filter) *)
+let is_local_provider = Cascade_health_filter.is_local_provider
+let filter_healthy = Cascade_health_filter.filter_healthy
+
+(* ── Context window resolution ──────────────────────────── *)
+
+let effective_max_context (entry : Llm_provider.Provider_registry.entry)
+    (caps : Llm_provider.Capabilities.capabilities) =
+  (* Defensive unwrap: treat [Some 0] / negative as absent rather than
+     handing a broken value to downstream budget arithmetic. Aligns with
+     the same guard in [Pipeline.proactive_context_window_tokens] (#815)
+     and [Provider.resolve_max_context_tokens] (#823). *)
+  match caps.max_context_tokens with
+  | Some n when n > 0 -> n
+  | _ -> entry.max_context
+
+(** Resolve a model label to the per-slot context of the endpoint
+    that would serve it.  Uses the same resolution logic as
+    [make_registry_config]: [current_llama_endpoint] for "llama:*",
+    parsed URL for "custom:*".  Cloud providers return [None].
+
+    Does NOT advance the round-robin counter — safe to call for
+    prompt sizing before the actual cascade request.
+
+    @since 0.100.8 *)
+let resolve_label_context (label : string) : int option =
+  match split_provider_model (String.trim label) with
+  | None -> None
+  | Some ("custom", model_id) ->
+    let _, url = parse_custom_model model_id in
+    Llm_provider.Discovery.discovered_context_for_url url
+  | Some ("llama", model_id) ->
+    (* Model-aware: find the endpoint that has this model loaded *)
+    (match Llm_provider.Discovery.context_for_model model_id with
+     | Some (_url, ctx) -> Some ctx
+     | None ->
+       (* Fallback: round-robin endpoint (backward compat for "auto" etc.) *)
+       let url = Llm_provider.Provider_registry.current_llama_endpoint () in
+       if url = "" then None
+       else Llm_provider.Discovery.discovered_context_for_url url)
+  | Some (_, _) ->
+    (* Cloud providers: no discovery-based per-slot context *)
+    None
+
+(* ── Capability-aware filtering ─────────────────────────── *)
+
+let filter_by_capabilities ~(pred : Llm_provider.Capabilities.capabilities -> bool)
+    (providers : Llm_provider.Provider_config.t list) =
+  let satisfies (cfg : Llm_provider.Provider_config.t) =
+    let caps = match Llm_provider.Capabilities.for_model_id cfg.model_id with
+      | Some c -> c
+      | None ->
+        match Llm_provider.Provider_registry.find default_registry cfg.model_id with
+        | Some entry -> entry.capabilities
+        | None -> Llm_provider.Capabilities.default_capabilities
+    in
+    pred caps
+  in
+  let filtered = List.filter satisfies providers in
+  if filtered = [] then providers
+  else filtered
+
+(* ── Helpers ────────────────────────────────────────────── *)
+
+let text_of_response (resp : Llm_provider.Types.api_response) : string =
+  resp.content
+  |> List.filter_map (function
+    | Llm_provider.Types.Text t -> Some t
+    | _ -> None)
+  |> String.concat ""
+
+(* ── Model resolution: named -> "default" -> hardcoded ─── *)
+
+type cascade_source = Named | Default_fallback | Hardcoded_defaults
+
+(** Weighted shuffle: pick first element by weighted random, then order
+    remaining by descending weight.  This gives probabilistic distribution
+    of first-attempt provider while maintaining a deterministic fallback
+    chain.  Callers preserve backward-compatible fixed ordering by
+    skipping shuffle when every weight is 1.
+
+    Algorithm (LiteLLM simple-shuffle inspired):
+    1. Compute cumulative weights
+    2. Pick random value in [0, total_weight)
+    3. Selected item becomes first; rest sorted by weight desc
+
+    @since 0.137.0 *)
+let weighted_shuffle_rng = lazy (Random.State.make_self_init ())
+
+let weighted_random_int bound =
+  Random.State.int (Lazy.force weighted_shuffle_rng) bound
+
+let weighted_shuffle
+    ?(rand_int = weighted_random_int)
+    (entries : Cascade_config_loader.weighted_entry list)
+    : Cascade_config_loader.weighted_entry list =
+  match entries with
+  | [] | [_] -> entries
+  | _ ->
+    let total_weight =
+      List.fold_left (fun acc (e : Cascade_config_loader.weighted_entry) ->
+          acc + e.weight) 0 entries
+    in
+    if total_weight <= 0 then entries
+    else
+      let r = rand_int total_weight in
+      (* Find the selected entry via cumulative weight *)
+      let rec find_selected cumulative = function
+        | [] -> (* fallback: first entry *)
+          (List.hd entries,
+           List.tl entries)
+        | (e : Cascade_config_loader.weighted_entry) :: rest ->
+          let cumulative' = cumulative + e.weight in
+          if r < cumulative' then (e, rest)
+          else
+            let selected, remaining = find_selected cumulative' rest in
+            (selected, e :: remaining)
+      in
+      let selected, remaining = find_selected 0 entries in
+      (* Sort remaining by descending weight for fallback priority.
+         Use index as tiebreaker to preserve original config order
+         among equal-weight entries (stable sort). *)
+      let indexed = List.mapi (fun i e -> (i, e)) remaining in
+      let sorted_remaining =
+        List.sort (fun (i1, (a : Cascade_config_loader.weighted_entry))
+                       (i2, (b : Cascade_config_loader.weighted_entry)) ->
+            let cmp = compare b.weight a.weight in
+            if cmp <> 0 then cmp else compare i1 i2
+          ) indexed
+        |> List.map snd
+      in
+      selected :: sorted_remaining
+
+let order_weighted_entries
+    ?(rand_int = weighted_random_int)
+    (entries : Cascade_config_loader.weighted_entry list) =
+  let has_weights = List.exists
+      (fun (e : Cascade_config_loader.weighted_entry) -> e.weight <> 1)
+      entries
+  in
+  if not has_weights then entries
+  else
+    let health = Cascade_health_tracker.global in
+    let health_adjusted = List.map
+        (fun (e : Cascade_config_loader.weighted_entry) ->
+           (* Extract model_id from "provider:model_id" to match the key
+              used by cascade_executor (cfg.model_id). *)
+           let provider_key = match String.split_on_char ':' e.model with
+             | _ :: rest when rest <> [] -> String.concat ":" rest
+             | _ -> e.model
+           in
+           let ew = Cascade_health_tracker.effective_weight health
+               ~provider_key ~config_weight:e.weight in
+           { e with weight = ew })
+        entries
+    in
+    (* Filter out zero-weight (cooled-down) providers, but keep at least one *)
+    let active = List.filter
+        (fun (e : Cascade_config_loader.weighted_entry) -> e.weight > 0)
+        health_adjusted
+    in
+    let effective = if active = [] then entries else active in
+    weighted_shuffle ~rand_int effective
+
+let resolve_model_strings_traced_with
+    ~rand_int ?config_path ~name ~defaults () =
+  match config_path with
+  | Some path ->
+    let from_file_weighted =
+      Cascade_config_loader.load_profile_weighted ~config_path:path ~name in
+    if from_file_weighted <> [] then
+      let ordered = order_weighted_entries ~rand_int from_file_weighted in
+      let models = List.map
+          (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
+      (models, Named)
+    else
+      let fallback_weighted =
+        Cascade_config_loader.load_profile_weighted
+          ~config_path:path ~name:"default" in
+      if fallback_weighted <> [] then
+        let ordered = order_weighted_entries ~rand_int fallback_weighted in
+        let models = List.map
+            (fun (e : Cascade_config_loader.weighted_entry) -> e.model)
+            ordered in
+        (models, Default_fallback)
+      else (defaults, Hardcoded_defaults)
+  | None -> (defaults, Hardcoded_defaults)
+
+let resolve_model_strings_traced ?config_path ~name ~defaults () =
+  resolve_model_strings_traced_with
+    ~rand_int:weighted_random_int
+    ?config_path ~name ~defaults ()
+
+let resolve_model_strings ?config_path ~name ~defaults () =
+  fst (resolve_model_strings_traced ?config_path ~name ~defaults ())
+
+(* ── Selection trace (observability) ─────────────────── *)
+
+type candidate_info = {
+  model_string : string;
+  config_weight : int;
+  effective_weight : int;
+  success_rate : float;
+  in_cooldown : bool;
+}
+
+type selection_trace = {
+  candidates : candidate_info list;
+  source : cascade_source;
+}
+
+(** Extract the provider_key the health tracker uses for a "provider:model"
+    string. Mirrors the derivation in {!order_weighted_entries}. *)
+let provider_key_of_model_string s =
+  match String.split_on_char ':' s with
+  | _ :: rest when rest <> [] -> String.concat ":" rest
+  | _ -> s
+
+(** Build a [candidate_info] for a model string given its config weight.
+    Reads current health tracker state for [success_rate] / [in_cooldown]
+    / [effective_weight], so the trace reflects state at call time. *)
+let candidate_info_of_weighted (e : Cascade_config_loader.weighted_entry) =
+  let health = Cascade_health_tracker.global in
+  let key = provider_key_of_model_string e.model in
+  let success_rate = Cascade_health_tracker.success_rate health ~provider_key:key in
+  let in_cooldown = Cascade_health_tracker.is_in_cooldown health ~provider_key:key in
+  let effective_weight =
+    Cascade_health_tracker.effective_weight health
+      ~provider_key:key ~config_weight:e.weight
+  in
+  {
+    model_string = e.model;
+    config_weight = e.weight;
+    effective_weight;
+    success_rate;
+    in_cooldown;
+  }
+
+let resolve_model_strings_with_trace ?config_path ~name ~defaults () =
+  match config_path with
+  | Some path ->
+    let from_file_weighted =
+      Cascade_config_loader.load_profile_weighted ~config_path:path ~name in
+    if from_file_weighted <> [] then
+      let ordered = order_weighted_entries from_file_weighted in
+      let models = List.map
+          (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
+      let candidates = List.map candidate_info_of_weighted ordered in
+      (models, { candidates; source = Named })
+    else
+      let fallback_weighted =
+        Cascade_config_loader.load_profile_weighted
+          ~config_path:path ~name:"default" in
+      if fallback_weighted <> [] then
+        let ordered = order_weighted_entries fallback_weighted in
+        let models = List.map
+            (fun (e : Cascade_config_loader.weighted_entry) -> e.model) ordered in
+        let candidates = List.map candidate_info_of_weighted ordered in
+        (models, { candidates; source = Default_fallback })
+      else
+        let candidates =
+          List.map (fun m ->
+            candidate_info_of_weighted
+              { Cascade_config_loader.model = m; weight = 1 })
+            defaults
+        in
+        (defaults, { candidates; source = Hardcoded_defaults })
+  | None ->
+    let candidates =
+      List.map (fun m ->
+        candidate_info_of_weighted
+          { Cascade_config_loader.model = m; weight = 1 })
+        defaults
+    in
+    (defaults, { candidates; source = Hardcoded_defaults })
+
+let dedupe_stable (items : string list) =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | item :: rest ->
+      if List.mem item seen then loop seen acc rest
+      else loop (item :: seen) (item :: acc) rest
+  in
+  loop [] [] items
+
+let expand_model_strings_for_execution (items : string list) =
+  let expand_one raw =
+    let item = String.trim raw in
+    if item = "" then []
+    else
+      match split_provider_model item with
+      | Some ("glm", model_id)
+        when String.lowercase_ascii model_id = "auto" ->
+        [item; "glm:turbo"; "glm:flash"]
+      | Some ("glm-coding", model_id)
+        when String.lowercase_ascii model_id = "auto" ->
+        [item; "glm-coding:glm-5-turbo"; "glm-coding:glm-5.1";
+         "glm-coding:glm-4.5-air"]
+      | _ -> [item]
+  in
+  items
+  |> List.concat_map expand_one
+  |> dedupe_stable
+
+(* Filter providers by kind name (exact, case-insensitive).
+   Valid filter values: "ollama", "glm", "anthropic", "gemini", "openai_compat", "claude_code".
+   Empty/None filter passes through unchanged. No-match falls back to unfiltered. *)
+let apply_provider_filter ~provider_filter ~label providers =
+  match provider_filter with
+  | None | Some [] -> providers
+  | Some filters ->
+    let lc_filters = List.map String.lowercase_ascii filters in
+    let matches (p : Llm_provider.Provider_config.t) =
+      List.mem (Llm_provider.Provider_config.string_of_provider_kind p.kind) lc_filters
+    in
+    let filtered = List.filter matches providers in
+    if filtered = [] then (
+      Eio.traceln "[CascadeConfig] provider_filter matched no providers (%s); \
+        falling back to unfiltered (filter=[%s] providers=[%s])"
+        label (String.concat "," filters)
+        (String.concat "," (List.map (fun (p : Llm_provider.Provider_config.t) ->
+          Llm_provider.Provider_config.string_of_provider_kind p.kind) providers));
+      providers)
+    else filtered
+
+(* ── Local Capacity Query ──────────────────────────────── *)
+
+type local_capacity = {
+  total : int;
+  process_active : int;
+  process_available : int;
+  process_queue_length : int;
+  all_discovered : bool;
+  endpoints_found : int;
+}
+
+let empty_capacity = {
+  total = 0; process_active = 0; process_available = 0;
+  process_queue_length = 0; all_discovered = true; endpoints_found = 0;
+}
+
+let local_capacity_for_selections ~sw ~net ?config_path selections =
+  (* 1. Resolve each selection through the same path as complete_named *)
+  let model_strings =
+    selections
+    |> List.concat_map (fun s ->
+         resolve_model_strings ?config_path ~name:s ~defaults:[s] ())
+    |> expand_model_strings_for_execution
+    |> List.sort_uniq String.compare
+  in
+  (* 2. Parse to provider configs *)
+  let providers = parse_model_strings model_strings in
+  (* 3. Filter to local providers *)
+  let local_urls =
+    providers
+    |> List.filter is_local_provider
+    |> List.map (fun (cfg : Llm_provider.Provider_config.t) -> cfg.base_url)
+    |> List.sort_uniq String.compare
+  in
+  if local_urls = [] then
+    empty_capacity
+  else begin
+    (* 4. Probe endpoints not yet in throttle table (cold start) *)
+    let need_probe =
+      List.filter (fun url -> Cascade_throttle.lookup url = None) local_urls
+    in
+    if need_probe <> [] then begin
+      let statuses = Llm_provider.Discovery.discover ~sw ~net ~endpoints:need_probe in
+      Cascade_throttle.populate statuses
+    end;
+    (* 5. Aggregate capacity from throttle table *)
+    let infos =
+      List.filter_map (fun url -> Cascade_throttle.capacity url) local_urls
+    in
+    match infos with
+    | [] -> empty_capacity
+    | _ ->
+      List.fold_left (fun acc (info : Cascade_throttle.capacity_info) ->
+        { total = acc.total + info.total;
+          process_active = acc.process_active + info.process_active;
+          process_available = acc.process_available + info.process_available;
+          process_queue_length = acc.process_queue_length + info.process_queue_length;
+          all_discovered = acc.all_discovered
+            && info.source = Llm_provider.Provider_throttle.Discovered;
+          endpoints_found = acc.endpoints_found + 1;
+        })
+        { empty_capacity with all_discovered = true }
+        infos
+  end
+

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -1,0 +1,355 @@
+(** Cascade configuration: named provider profiles with JSON hot-reload
+    and discovery-aware health filtering.
+
+    Consumers define named cascade profiles
+    mapping to ordered lists of providers. This module handles:
+    - Parsing "provider:model" strings into {!Llm_provider.Provider_config.t}
+    - Loading profiles from a JSON config file (mtime-based hot-reload)
+    - Filtering providers by local endpoint health via {!Discovery}
+    - Convenience cascade execution combining the above
+
+    @since 0.59.0
+
+    @stability Internal
+    @since 0.93.1 *)
+
+(** {1 Model Alias Resolution} *)
+
+(** Resolve a GLM model alias to the concrete API model ID.
+    - ["auto"] → env var [ZAI_DEFAULT_MODEL] or ["glm-5.1"]
+    - ["flash"] → ["glm-4.7-flashx"]
+    - ["turbo"] → ["glm-5-turbo"]
+    - ["vision"] → ["glm-4.6v"]
+    - Concrete IDs pass through unchanged.
+    @since 0.89.1 *)
+val resolve_glm_model_id : string -> string
+
+(** Resolve "auto" and aliases to concrete model IDs for any provider.
+    Cloud providers resolve aliases; local providers pass through.
+    @since 0.89.1 *)
+val resolve_auto_model_id : string -> string -> string
+
+(** {1 Model String Parsing} *)
+
+(** Parse a "provider:model_id" string into a {!Llm_provider.Provider_config.t}.
+
+    Supported providers are determined by {!Llm_provider.Provider_registry.default}.
+    Built-in: llama, claude, gemini, glm, openrouter, custom.
+
+    Returns [None] when the provider is unknown or the required API key
+    env var is not set (provider is unavailable). *)
+val parse_model_string :
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?system_prompt:string ->
+  ?api_key_env_overrides:(string * string) list ->
+  string -> Llm_provider.Provider_config.t option
+(** [api_key_env_overrides] defaults to [[]]. When non-empty, it overrides
+    the registry default API key env var for matching providers; see
+    {!parse_model_strings} for format details. Empty-string entries fall
+    through to the next level of the resolution chain.
+
+    @since 0.122.0 api_key_env_overrides parameter added *)
+
+(** Like {!parse_model_string} but returns a [Result] with a diagnostic
+    error message explaining why parsing failed (unknown provider, missing
+    API key, bad format).  Intended for MCP tool boundaries where callers
+    need to report the reason back to the user.
+
+    @since 0.81.0 *)
+val parse_model_string_exn :
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?system_prompt:string ->
+  string -> (Llm_provider.Provider_config.t, string) result
+
+(** Expand provider:auto specs that map to multiple models.
+    ["glm:auto"] expands to ["glm:glm-5.1"; "glm:glm-5-turbo"; ...].
+    Other specs pass through unchanged. *)
+val expand_auto_models : string list -> string list
+
+(** Parse multiple model strings, skipping unavailable ones.
+    Internally calls {!expand_auto_models} before parsing.
+
+    When [api_key_env_overrides] is provided, it overrides the default
+    API key env var for matching providers. The list maps provider names
+    (or ["*"] for all) to env var names. Used by cascade execution paths
+    to apply per-cascade key configuration from cascade.json.
+
+    @since 0.122.0 api_key_env_overrides parameter added *)
+val parse_model_strings :
+  ?temperature:float ->
+  ?max_tokens:int ->
+  ?system_prompt:string ->
+  ?api_key_env_overrides:(string * string) list ->
+  string list -> Llm_provider.Provider_config.t list
+
+(** {1 JSON Config Loading} *)
+
+(** Load a named model list from a JSON config file.
+
+    The JSON file maps "{name}_models" keys to string arrays:
+    {[
+      { "primary_models":    ["llama:qwen3.5", "glm:auto"],
+        "evaluation_models": ["llama:qwen3.5", "glm:glm-4.5"] }
+    ]}
+
+    Results are cached and hot-reloaded when the file mtime changes.
+    Returns an empty list when the file is missing or the key is absent
+    (caller provides defaults). *)
+val load_profile :
+  config_path:string ->
+  name:string ->
+  string list
+
+(** How a cascade name was resolved. *)
+type cascade_source =
+  | Named              (** Found as "{name}_models" in config *)
+  | Default_fallback   (** Name not found; used "default_models" *)
+  | Hardcoded_defaults (** Neither found; used hardcoded [defaults] *)
+
+(** Resolve model strings for a named cascade.
+
+    Resolution order:
+    1. Named profile "{name}_models" from [config_path]
+    2. "default_models" profile from [config_path] (fallback)
+    3. Hardcoded [defaults]
+
+    When [config_path] is [None], returns [defaults] directly. *)
+val resolve_model_strings :
+  ?config_path:string ->
+  name:string ->
+  defaults:string list ->
+  unit ->
+  string list
+
+(** Expand execution-time convenience fallbacks while preserving stable order.
+
+    Currently ["glm:auto"] expands to:
+    {[
+      ["glm:auto"; "glm:turbo"; "glm:flash"]
+    ]}
+
+    Duplicate entries are removed after expansion, keeping the first
+    appearance. This lets callers keep config concise while still
+    getting automatic GLM failover at execution time.
+
+    @since 0.116.2 *)
+val expand_model_strings_for_execution : string list -> string list
+
+(** Like {!resolve_model_strings} but also returns which resolution
+    path was taken. Use this to detect typos: if [source <> Named]
+    when you expected a named profile, the cascade name is likely wrong.
+
+    @since 0.78.0 *)
+val resolve_model_strings_traced :
+  ?config_path:string ->
+  name:string ->
+  defaults:string list ->
+  unit ->
+  string list * cascade_source
+
+(** Per-candidate info in a weighted selection decision.
+
+    Captures the state that influenced a single candidate's ordering
+    at decision time: its declared weight, health-adjusted effective
+    weight, and current health signals.
+
+    @since 0.139.0 *)
+type candidate_info = {
+  model_string : string;        (** "provider:model_id" as written in config *)
+  config_weight : int;          (** Weight from [cascade.json] ([1] when absent) *)
+  effective_weight : int;       (** Weight after health adjustment; [0] = cooled-down *)
+  success_rate : float;         (** Rolling-window success rate, [0.0]–[1.0] *)
+  in_cooldown : bool;           (** Provider currently skipped by cooldown *)
+}
+
+(** Full trace of a cascade selection decision.
+
+    Consumers can use this to surface, in dashboards/telemetry,
+    why a particular provider was attempted first and what signals
+    were considered.
+
+    [candidates] is in final attempt order — the first entry is the
+    provider the cascade will try first.
+
+    When the profile has no weights (every entry is [weight=1]), no
+    probabilistic shuffle happens and [effective_weight = config_weight = 1]
+    for each entry.
+
+    @since 0.139.0 *)
+type selection_trace = {
+  candidates : candidate_info list;
+  source : cascade_source;
+}
+
+(** Like {!resolve_model_strings_traced} but also returns per-candidate
+    health signals that influenced the ordering. Useful for rendering
+    the cascade decision in dashboards without re-deriving state.
+
+    Non-breaking: callers who only need the ordered model list can
+    continue using {!resolve_model_strings} or {!resolve_model_strings_traced}.
+
+    @since 0.139.0 *)
+val resolve_model_strings_with_trace :
+  ?config_path:string ->
+  name:string ->
+  defaults:string list ->
+  unit ->
+  string list * selection_trace
+
+(** {1 Raw JSON Access} *)
+
+(** Load and cache the raw JSON config file.
+    Cached with mtime-based hot-reload.
+    Exposed for consumers needing custom fields beyond model lists
+    (e.g., per-cascade temperature/max_tokens overrides).
+
+    @since 0.89.1 *)
+val load_json : string -> (Yojson.Safe.t, string) result
+
+(** {1 Inference Parameters} *)
+
+(** Per-cascade inference parameter overrides. *)
+type inference_params = {
+  temperature: float option;
+  max_tokens: int option;
+}
+
+(** Resolve inference parameters from cascade.json.
+
+    Resolution order:
+    1. ["{name}_temperature"] / ["{name}_max_tokens"]
+    2. ["default_temperature"] / ["default_max_tokens"]
+    3. [None] (caller uses own defaults)
+
+    @since 0.89.1 *)
+val resolve_inference_params :
+  config_path:string -> name:string -> inference_params
+
+(** Resolve per-cascade API key env var overrides from cascade.json.
+
+    Supports two formats:
+    - String: applies to all providers.
+      [{"{name}_api_key_env": "ZAI_API_KEY_SB"}]
+    - Object: per-provider mapping.
+      [{"{name}_api_key_env": {"glm": "ZAI_API_KEY_SB", "glm-coding": "ZAI_API_KEY_SB"}}]
+
+    Falls back to ["default_api_key_env"], then empty list (use registry defaults).
+
+    @since 0.122.0 *)
+val resolve_api_key_env :
+  config_path:string -> name:string -> (string * string) list
+
+(** {1 Discovery-Aware Health Filtering} *)
+
+(** Filter a provider list by local endpoint health.
+
+    Probes local (llama-server) endpoints via {!Discovery}. When all
+    local endpoints are unhealthy, removes local providers from the list
+    so cloud providers serve as fallback.
+
+    When the list contains only local providers, passes through unchanged
+    (let the provider return a connection error rather than an empty list).
+
+    Cloud providers always pass through unfiltered. *)
+val filter_healthy :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  Llm_provider.Provider_config.t list ->
+  Llm_provider.Provider_config.t list
+
+(** {1 Context Window Resolution} *)
+
+(** Effective max context tokens for a provider entry.
+
+    Returns [caps.max_context_tokens] when known (per-model), otherwise
+    falls back to [entry.max_context] (per-provider default from the registry).
+
+    @since 0.78.0 *)
+val effective_max_context :
+  Llm_provider.Provider_registry.entry -> Llm_provider.Capabilities.capabilities -> int
+
+(** Resolve a model label to the per-slot context of the endpoint
+    that would serve it.
+
+    Uses the same resolution path as [make_registry_config]:
+    - ["llama:*"] → peeks at current round-robin endpoint (no advance)
+    - ["custom:model@url"] → looks up the parsed URL
+    - Cloud providers → [None] (use static {!effective_max_context} instead)
+
+    This is the SSOT for "how much context does this label have?"
+    Consumers should call this instead of guessing from endpoint lists.
+
+    @since 0.100.8 *)
+val resolve_label_context : string -> int option
+
+(** {1 Capability-Aware Filtering} *)
+
+(** Filter providers by a capability predicate.
+
+    Resolves capabilities per-model (via {!Llm_provider.Capabilities.for_model_id})
+    with registry-level fallback. Removes providers that do not satisfy
+    [pred]. If all providers would be removed, returns the original list
+    unchanged (let the provider return an API error).
+
+    Example: filter to providers supporting tools:
+    {[ filter_by_capabilities ~pred:(fun c -> c.supports_tools) providers ]}
+
+    @since 0.78.0 *)
+val filter_by_capabilities :
+  pred:(Llm_provider.Capabilities.capabilities -> bool) ->
+  Llm_provider.Provider_config.t list ->
+  Llm_provider.Provider_config.t list
+
+(** {1 Helpers for Cascade Consumers} *)
+
+(** Extract the concatenated text content from an API response.
+    Joins all {!Llm_provider.Types.Text} blocks. Useful for accept validators. *)
+val text_of_response : Llm_provider.Types.api_response -> string
+
+val apply_provider_filter :
+  provider_filter:string list option ->
+  label:string ->
+  Llm_provider.Provider_config.t list ->
+  Llm_provider.Provider_config.t list
+
+(** {1 Local Capacity Query} *)
+
+(** Point-in-time capacity for local LLM endpoints.
+    All [process_*] counts reflect this OAS process only —
+    other clients sharing the same server are not visible.
+    @since 0.97.0 *)
+type local_capacity = {
+  total : int;
+  (** Server slot count from discovery. *)
+  process_active : int;
+  (** Slots held by this process. *)
+  process_available : int;
+  (** [total - process_active]. May overestimate if other consumers exist. *)
+  process_queue_length : int;
+  (** Fibers waiting for a slot in this process. *)
+  all_discovered : bool;
+  (** [true] only when every contributing endpoint has [Discovered] source.
+      When [false], slot count may be a guessed default. *)
+  endpoints_found : int;
+  (** Number of local endpoints found. 0 means cloud-only selection. *)
+}
+
+val local_capacity_for_selections :
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?config_path:string ->
+  string list ->
+  local_capacity
+(** Query local endpoint capacity for cascade selection strings.
+
+    Each selection string is resolved through the same path as
+    [complete_named]: named profile lookup, then model string parsing.
+    Only local endpoints are considered; cloud providers are ignored.
+
+    Probes endpoints not yet in the throttle table via {!Discovery}
+    (~10ms on localhost), populating the table as a side-effect.
+    Returns [endpoints_found = 0] for cloud-only selections.
+
+    @since 0.97.0 *)

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -1,0 +1,187 @@
+(** JSON config loading with mtime-based hot-reload.
+
+    Loads and caches cascade profile JSON files.  The cache is keyed by
+    file path and invalidated when the file mtime changes.
+
+    @since 0.59.0
+    @since 0.92.0 extracted from Cascade_config *)
+
+let config_cache : (string, float * Yojson.Safe.t) Hashtbl.t =
+  Hashtbl.create 4
+
+(** Stdlib Mutex — no Eio dependency. Keep the critical section limited to
+    cache access so file I/O and JSON parsing do not block unrelated fibers
+    longer than necessary when called from an Eio domain. *)
+let config_cache_mu = Mutex.create ()
+
+let with_cache_lock f =
+  Mutex.lock config_cache_mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock config_cache_mu) f
+
+let read_json_file path =
+  let ic = open_in path in
+  let content =
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         let buf = Bytes.create len in
+         really_input ic buf 0 len;
+         Bytes.to_string buf)
+  in
+  Yojson.Safe.from_string content
+
+let load_json path =
+  let rec load_current () =
+    let mtime = (Unix.stat path).Unix.st_mtime in
+    match with_cache_lock (fun () ->
+        match Hashtbl.find_opt config_cache path with
+        | Some (cached_mtime, json) when Float.equal cached_mtime mtime ->
+          Some json
+        | _ -> None)
+    with
+    | Some json -> Ok json
+    | None ->
+      let json = read_json_file path in
+      let refreshed_mtime = (Unix.stat path).Unix.st_mtime in
+      if not (Float.equal refreshed_mtime mtime) then
+        load_current ()
+      else
+        with_cache_lock (fun () ->
+            match Hashtbl.find_opt config_cache path with
+            | Some (cached_mtime, cached_json)
+              when Float.equal cached_mtime refreshed_mtime ->
+              Ok cached_json
+            | prior ->
+              Hashtbl.replace config_cache path (refreshed_mtime, json);
+              (* Observability: trace first-load vs reload so operators
+                 editing cascade.json can verify their change took effect.
+                 Keeping this at traceln (stderr) matches existing OAS
+                 convention (see Cascade_config.apply_provider_filter). *)
+              (match prior with
+               | None ->
+                 Eio.traceln
+                   "[CascadeConfig] loaded %s mtime=%.0f"
+                   path refreshed_mtime
+               | Some (old_mtime, _) ->
+                 Eio.traceln
+                   "[CascadeConfig] reloaded %s old_mtime=%.0f new_mtime=%.0f"
+                   path old_mtime refreshed_mtime);
+              Ok json)
+  in
+  try load_current () with
+  | Sys_error msg -> Error msg
+  | Unix.Unix_error (err, fn, arg) ->
+    Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
+  | Yojson.Json_error msg -> Error (Printf.sprintf "JSON error: %s" msg)
+  | End_of_file -> Error "unexpected end of file"
+
+(** A model entry with an optional weight for weighted cascade selection.
+    Weight defaults to 1 when not specified (backward compatible). *)
+type weighted_entry = {
+  model: string;
+  weight: int;
+}
+
+let parse_weight_field = function
+  | `Int i when i > 0 -> i
+  | `Float f when f > 0.0 ->
+    let i = int_of_float f in
+    if i > 0 && Float.equal f (float_of_int i) then i else 1
+  | _ -> 1
+
+let parse_weighted_item = function
+  | `String s -> Some { model = String.trim s; weight = 1 }
+  | `Assoc fields ->
+    let open Yojson.Safe.Util in
+    let json = `Assoc fields in
+    (match json |> member "model" with
+     | `String s when String.trim s <> "" ->
+       let w = parse_weight_field (json |> member "weight") in
+       Some { model = String.trim s; weight = w }
+     | _ -> None)
+  | _ -> None
+
+let load_profile_weighted ~config_path ~name =
+  let key = name ^ "_models" in
+  match load_json config_path with
+  | Error _ -> []
+  | Ok json ->
+    let open Yojson.Safe.Util in
+    match json |> member key with
+    | `List items -> List.filter_map parse_weighted_item items
+    | _ -> []
+
+let load_profile ~config_path ~name =
+  load_profile_weighted ~config_path ~name
+  |> List.map (fun e -> e.model)
+
+(* ── Inference parameter resolution ───────────────────── *)
+
+type inference_params = {
+  temperature: float option;
+  max_tokens: int option;
+}
+
+let read_float_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
+
+let read_int_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Int i -> Some i
+  | `Float f -> Some (int_of_float f)
+  | _ -> None
+
+let resolve_inference_params ~config_path ~name =
+  match load_json config_path with
+  | Error _ -> { temperature = None; max_tokens = None }
+  | Ok json ->
+    let temp =
+      match read_float_field json (name ^ "_temperature") with
+      | Some _ as v -> v
+      | None -> read_float_field json "default_temperature"
+    in
+    let max_tok =
+      match read_int_field json (name ^ "_max_tokens") with
+      | Some _ as v -> v
+      | None -> read_int_field json "default_max_tokens"
+    in
+    { temperature = temp; max_tokens = max_tok }
+
+(* ── Per-cascade API key env override ────────────────── *)
+
+(** Read an api_key_env override object from JSON.
+
+    The JSON value can be:
+    - A string: applies to all providers in the cascade.
+      [{"{name}_api_key_env": "ZAI_API_KEY_SB"}]
+    - An object mapping provider names to env var names:
+      [{"{name}_api_key_env": {"glm": "ZAI_API_KEY_SB", "glm-coding": "ZAI_API_KEY_SB"}}]
+
+    Returns an association list of [(provider_name, env_var_name)].
+    The special key ["*"] means "all providers". *)
+let read_api_key_env_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `String s when String.trim s <> "" -> [("*", String.trim s)]
+  | `Assoc pairs ->
+    List.filter_map (fun (k, v) ->
+      match v with
+      | `String s when String.trim s <> "" ->
+        Some (String.lowercase_ascii (String.trim k), String.trim s)
+      | _ -> None
+    ) pairs
+  | _ -> []
+
+let resolve_api_key_env ~config_path ~name =
+  match load_json config_path with
+  | Error _ -> []
+  | Ok json ->
+    match read_api_key_env_field json (name ^ "_api_key_env") with
+    | [] -> read_api_key_env_field json "default_api_key_env"
+    | overrides -> overrides

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -1,0 +1,73 @@
+(** JSON config loading with mtime-based hot-reload.
+
+    @since 0.59.0
+    @since 0.92.0 extracted from Cascade_config
+
+    @stability Internal
+    @since 0.93.1 *)
+
+(** Load and cache a raw JSON config file.
+    Cached with mtime-based hot-reload. *)
+val load_json : string -> (Yojson.Safe.t, string) result
+
+(** A model entry with an optional weight for weighted cascade selection.
+    Weight defaults to 1 when not specified.
+    @since 0.137.0 *)
+type weighted_entry = {
+  model: string;
+  weight: int;
+}
+
+(** Load a named model list from a JSON config file.
+
+    The JSON file maps ["{name}_models"] keys to string arrays.
+    Results are cached and hot-reloaded when the file mtime changes.
+    Returns an empty list when the file is missing or the key is absent. *)
+val load_profile :
+  config_path:string ->
+  name:string ->
+  string list
+
+(** Like {!load_profile} but preserves weight information.
+
+    Supports two JSON formats in the model array:
+    - Plain strings: [{"model": s, "weight": 1}]
+    - Objects: [{"model": "provider:id", "weight": 50}]
+
+    When all weights are 1, the caller should treat the list as unweighted
+    (preserving backward-compatible fixed ordering).
+
+    @since 0.137.0 *)
+val load_profile_weighted :
+  config_path:string ->
+  name:string ->
+  weighted_entry list
+
+(** Per-cascade inference parameter overrides. *)
+type inference_params = {
+  temperature: float option;
+  max_tokens: int option;
+}
+
+(** Resolve inference parameters from cascade.json.
+
+    Resolution order:
+    1. ["{name}_temperature"] / ["{name}_max_tokens"]
+    2. ["default_temperature"] / ["default_max_tokens"]
+    3. [None] (caller uses own defaults) *)
+val resolve_inference_params :
+  config_path:string -> name:string -> inference_params
+
+(** Resolve per-cascade API key env var overrides from cascade.json.
+
+    Resolution order:
+    1. ["{name}_api_key_env"] from [config_path]
+    2. ["default_api_key_env"] from [config_path]
+    3. Empty list (use provider registry defaults)
+
+    The JSON value can be a string (applies to all providers via ["*"] key)
+    or an object mapping provider names to env var names.
+
+    @since 0.122.0 *)
+val resolve_api_key_env :
+  config_path:string -> name:string -> (string * string) list

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -1,0 +1,63 @@
+(** Cascade FSM — pure decision logic for multi-provider failover.
+
+    @since 0.120.0 *)
+
+(* ── Types ──────────────────────────────────────── *)
+
+type provider_outcome =
+  | Call_ok of Llm_provider.Types.api_response
+  | Call_err of Llm_provider.Http_client.http_error
+  | Accept_rejected of { response : Llm_provider.Types.api_response; reason : string }
+  | Slot_full
+
+type decision =
+  | Accept of Llm_provider.Types.api_response
+  | Accept_on_exhaustion of { response : Llm_provider.Types.api_response; reason : string }
+  | Try_next of { last_err : Llm_provider.Http_client.http_error option }
+  | Exhausted of { last_err : Llm_provider.Http_client.http_error option }
+
+(* ── Decision function ──────────────────────────── *)
+
+let decide ~accept_on_exhaustion ~is_last outcome =
+  match outcome with
+  | Call_ok resp ->
+    Accept resp
+  | Slot_full ->
+    Try_next { last_err = Some (Llm_provider.Http_client.NetworkError {
+        message = "slot full, cascading to next provider" }) }
+  | Accept_rejected { response; reason } ->
+    if is_last && accept_on_exhaustion then
+      Accept_on_exhaustion { response; reason }
+    else if is_last then
+      Exhausted { last_err = Some (Llm_provider.Http_client.AcceptRejected { reason }) }
+    else
+      Try_next { last_err = Some (Llm_provider.Http_client.AcceptRejected { reason }) }
+  | Call_err err ->
+    let should_cascade = Cascade_health_filter.should_cascade_to_next err in
+    if should_cascade then
+      Try_next { last_err = Some err }
+    else
+      Exhausted { last_err = Some err }
+
+(* ── Error formatting ───────────────────────────── *)
+
+let format_exhausted_error last_err =
+  let msg = match last_err with
+    | Some (Llm_provider.Http_client.HttpError { code; body }) ->
+      Printf.sprintf "HTTP %d: %s" code
+        (if String.length body > Llm_provider.Constants.Truncation.max_error_body_length
+         then String.sub body 0 Llm_provider.Constants.Truncation.max_error_body_length ^ "..."
+         else body)
+    | Some (Llm_provider.Http_client.AcceptRejected { reason }) -> reason
+    | Some (Llm_provider.Http_client.NetworkError { message }) -> message
+    | None -> "No providers available"
+  in
+  match last_err with
+  | Some (Llm_provider.Http_client.AcceptRejected _ as err) -> err
+  | _ ->
+    Llm_provider.Http_client.NetworkError {
+      message = Printf.sprintf "All models failed: %s" msg
+    }
+
+(* ── Inline tests ───────────────────────────────── *)
+

--- a/lib/cascade/cascade_fsm.mli
+++ b/lib/cascade/cascade_fsm.mli
@@ -1,0 +1,57 @@
+(** Cascade FSM — pure decision logic for multi-provider failover.
+
+    Separates the cascade decision tree from IO (HTTP calls, throttle,
+    timeout). The executor feeds provider outcomes to [decide], which
+    returns the next action without side effects.
+
+    This module owns the "what to do next" logic. The executor owns
+    the "how to do it" (network, slots, diagnostics).
+
+    @stability Evolving
+    @since 0.120.0 *)
+
+(** {1 Provider outcome — result of attempting one provider} *)
+
+type provider_outcome =
+  | Call_ok of Llm_provider.Types.api_response
+  | Call_err of Llm_provider.Http_client.http_error
+  | Accept_rejected of { response : Llm_provider.Types.api_response; reason : string }
+  | Slot_full
+
+(** {1 Cascade decision — what to do next} *)
+
+type decision =
+  | Accept of Llm_provider.Types.api_response
+      (** Provider succeeded and accept predicate passed. Done. *)
+  | Accept_on_exhaustion of { response : Llm_provider.Types.api_response; reason : string }
+      (** All providers rejected by accept, but [accept_on_exhaustion] is true.
+          Return the last valid response as graceful degradation. *)
+  | Try_next of { last_err : Llm_provider.Http_client.http_error option }
+      (** Current provider failed or was rejected. Try the next one. *)
+  | Exhausted of { last_err : Llm_provider.Http_client.http_error option }
+      (** All providers exhausted. Final failure. *)
+
+(** {1 Decision function} *)
+
+val decide :
+  accept_on_exhaustion:bool ->
+  is_last:bool ->
+  provider_outcome ->
+  decision
+(** Pure decision: given the outcome of trying one provider and whether
+    it was the last in the cascade, return the next action.
+
+    - [Call_ok _] → always [Accept] (accept predicate already passed)
+    - [Accept_rejected _] on last + [accept_on_exhaustion] → [Accept_on_exhaustion]
+    - [Accept_rejected _] on last + not exhaustion → [Exhausted]
+    - [Accept_rejected _] on non-last → [Try_next]
+    - [Call_err _] on cascadeable error → [Try_next]
+    - [Call_err _] on non-cascadeable error → [Exhausted]
+    - [Slot_full] → [Try_next] *)
+
+(** {1 Error formatting} *)
+
+val format_exhausted_error :
+  Llm_provider.Http_client.http_error option ->
+  Llm_provider.Http_client.http_error
+(** Format the final error when all providers are exhausted. *)

--- a/lib/cascade/cascade_health_filter.ml
+++ b/lib/cascade/cascade_health_filter.ml
@@ -1,0 +1,117 @@
+(** Cascade health filtering — classify errors and filter provider lists
+    by local health discovery and API key presence.
+
+    Extracted from cascade_config.ml for cohesion.
+
+    @since 0.99.5 *)
+
+(* ── Cascade-level error classification ────────────────── *)
+
+(** Case-insensitive substring check. Scans at most [max_scan] bytes
+    of [haystack] to avoid O(n*m) on very large error bodies. *)
+let contains_ci ?(max_scan = 512) ~haystack ~needle () =
+  let h = String.lowercase_ascii
+    (if String.length haystack > max_scan
+     then String.sub haystack 0 max_scan else haystack)
+  in
+  let n = String.lowercase_ascii needle in
+  let nlen = String.length n in
+  let hlen = String.length h in
+  if nlen = 0 || nlen > hlen then false
+  else
+    let rec scan i =
+      if i > hlen - nlen then false
+      else if String.sub h i nlen = n then true
+      else scan (i + 1)
+    in
+    scan 0
+
+(** Workaround for Ollama failing on large request bodies (~175KB+).
+    Returns 400 with "can't find closing '}'". Root cause is oversized
+    context — the proper fix is context compaction before sending to any
+    provider. This cascade fallthrough is a temporary workaround so
+    keeper turns are not blocked while compaction is implemented. *)
+let is_provider_parse_error (body : string) : bool =
+  contains_ci ~haystack:body ~needle:"can't find closing" ()
+
+(** Decide whether an error should cascade to the next provider.
+    Local resource exhaustion (port/FD limits) stops the cascade
+    because every subsequent provider will hit the same bottleneck. *)
+let should_cascade_to_next err =
+  if Llm_provider.Http_client.is_local_resource_exhaustion err then false
+  else match err with
+  | Llm_provider.Http_client.HttpError { code; body }
+    when List.mem code [400; 422]
+         && (Llm_provider.Retry.is_context_overflow_message body
+             || is_provider_parse_error body) ->
+    true
+  | Llm_provider.Http_client.HttpError { code; _ } ->
+    List.mem code Llm_provider.Constants.Http.cascadable_codes
+  | Llm_provider.Http_client.AcceptRejected _ -> false
+  | Llm_provider.Http_client.NetworkError _ -> true
+
+(* ── Local provider detection ──────────────────────────── *)
+
+let is_local_provider (cfg : Llm_provider.Provider_config.t) =
+  Llm_provider.Provider_config.is_local cfg
+
+(** Check whether a provider has credentials when required. *)
+let has_required_api_key (cfg : Llm_provider.Provider_config.t) =
+  cfg.api_key <> "" || is_local_provider cfg
+
+(* ── Discovery-aware health filtering ──────────────────── *)
+
+(** Internal: filter healthy + return discovery statuses for throttle. *)
+let filter_healthy_internal ~sw ~net (providers : Llm_provider.Provider_config.t list) =
+  let initial_count = List.length providers in
+  (* Step 0: Remove cloud providers missing required API keys *)
+  let providers =
+    let with_keys = List.filter has_required_api_key providers in
+    if with_keys = [] then providers  (* keep all rather than empty *)
+    else begin
+      let dropped = initial_count - List.length with_keys in
+      if dropped > 0 then
+        Llm_provider.Diag.debug "cascade_health_filter" "dropped %d provider(s) missing API keys"
+          dropped;
+      with_keys
+    end
+  in
+  let local_providers =
+    List.filter is_local_provider providers
+  in
+  let cloud_providers =
+    List.filter (fun cfg -> not (is_local_provider cfg)) providers
+  in
+  if local_providers = [] then
+    (providers, [])
+  else
+    let endpoints =
+      local_providers
+      |> List.map (fun (cfg : Llm_provider.Provider_config.t) -> cfg.base_url)
+      |> List.sort_uniq String.compare
+    in
+    (* Use refresh_and_sync instead of discover so that the shared
+       model_endpoints index is populated. Without this, endpoint_for_model
+       always returns None and model-specific routing in
+       make_registry_config falls back to round-robin. See #677. *)
+    let statuses = Llm_provider.Discovery.refresh_and_sync ~sw ~net ~endpoints in
+    if cloud_providers = [] then
+      (providers, statuses)
+    else
+      let any_healthy =
+        List.exists (fun (s : Llm_provider.Discovery.endpoint_status) -> s.healthy) statuses
+      in
+      if any_healthy then
+        (providers, statuses)
+      else begin
+        Llm_provider.Diag.info "cascade_health_filter"
+          "all %d local endpoint(s) unhealthy, falling back to %d cloud provider(s)"
+          (List.length local_providers) (List.length cloud_providers);
+        (cloud_providers, [])
+      end
+
+let filter_healthy ~sw ~net providers =
+  fst (filter_healthy_internal ~sw ~net providers)
+
+(* ── Inline tests ──────────────────────────────────────── *)
+

--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -1,0 +1,225 @@
+(** Reactive health tracking for cascade providers.
+
+    Tracks per-provider success/failure rates using a rolling time window.
+    Providers in cooldown (consecutive failures exceed threshold) are
+    temporarily skipped.  Health data feeds into weighted cascade selection
+    via {!effective_weight}.
+
+    Design: LiteLLM cooldown + OpenRouter rolling-window hybrid.
+    See RFC-OAS-006 Phase 2.
+
+    Thread safety: uses [Stdlib.Mutex] (not Eio.Mutex) for cross-fiber
+    safety without Eio dependency in the hot path.  Critical sections are
+    small (record append + list scan).
+
+    @since 0.137.0 *)
+
+(* ── Configuration ────────────────────────────── *)
+
+(** Rolling window duration in seconds.  Events older than this are
+    discarded on read.  Default: 300s (5 minutes), matching OpenRouter. *)
+let window_sec =
+  match Sys.getenv_opt "OAS_CASCADE_HEALTH_WINDOW_SEC" with
+  | Some s -> (try Float.of_string s with _ -> 300.0)
+  | None -> 300.0
+
+(** Number of consecutive failures before cooldown activates.
+    Default: 3, matching LiteLLM's [allowed_fails] concept. *)
+let cooldown_threshold =
+  match Sys.getenv_opt "OAS_CASCADE_COOLDOWN_THRESHOLD" with
+  | Some s -> (try int_of_string s with _ -> 3)
+  | None -> 3
+
+(** Cooldown duration in seconds.  During cooldown, the provider is
+    skipped (not attempted).  Default: 60s. *)
+let cooldown_sec =
+  match Sys.getenv_opt "OAS_CASCADE_COOLDOWN_SEC" with
+  | Some s -> (try Float.of_string s with _ -> 60.0)
+  | None -> 60.0
+
+(* ── Types ────────────────────────────────────── *)
+
+type outcome = Success | Failure
+
+type event = {
+  time: float;  (* Unix timestamp *)
+  outcome: outcome;
+}
+
+type provider_state = {
+  mutable events: event list;  (* newest first *)
+  mutable consecutive_failures: int;
+  mutable cooldown_until: float;  (* 0.0 = not in cooldown *)
+}
+
+type t = {
+  providers: (string, provider_state) Hashtbl.t;
+  mu: Mutex.t;
+}
+
+(* ── Constructor ──────────────────────────────── *)
+
+let create () : t = {
+  providers = Hashtbl.create 8;
+  mu = Mutex.create ();
+}
+
+let with_lock t f =
+  Mutex.lock t.mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock t.mu) f
+
+let get_or_create_state t key =
+  match Hashtbl.find_opt t.providers key with
+  | Some s -> s
+  | None ->
+    let s = {
+      events = [];
+      consecutive_failures = 0;
+      cooldown_until = 0.0;
+    } in
+    Hashtbl.replace t.providers key s;
+    s
+
+(* ── Recording ────────────────────────────────── *)
+
+let prune_old_events now events =
+  let cutoff = now -. window_sec in
+  List.filter (fun e -> e.time >= cutoff) events
+
+let record t ~provider_key ~outcome ~now =
+  with_lock t (fun () ->
+    let state = get_or_create_state t provider_key in
+    let event = { time = now; outcome } in
+    state.events <- event :: prune_old_events now state.events;
+    match outcome with
+    | Success ->
+      state.consecutive_failures <- 0;
+      (* Clear cooldown on success — provider recovered *)
+      state.cooldown_until <- 0.0
+    | Failure ->
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      if state.consecutive_failures >= cooldown_threshold then
+        state.cooldown_until <- now +. cooldown_sec)
+
+let record_success t ~provider_key =
+  record t ~provider_key ~outcome:Success ~now:(Unix.gettimeofday ())
+
+let record_failure t ~provider_key =
+  record t ~provider_key ~outcome:Failure ~now:(Unix.gettimeofday ())
+
+(* ── Queries ──────────────────────────────────── *)
+
+(** Success rate in the rolling window.  Returns 1.0 for unknown
+    providers (optimistic default — no data means no reason to penalize). *)
+let success_rate t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> 1.0
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      let recent = prune_old_events now state.events in
+      match recent with
+      | [] -> 1.0
+      | _ ->
+        let successes = List.length
+            (List.filter (fun e -> e.outcome = Success) recent) in
+        float_of_int successes /. float_of_int (List.length recent))
+
+(** Whether the provider is currently in cooldown.  A cooled-down provider
+    should be skipped in cascade selection.
+
+    @return [true] if in cooldown AND cooldown has not expired *)
+let is_in_cooldown t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> false
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      if state.cooldown_until > now then true
+      else begin
+        (* Expired cooldown — clear it *)
+        if state.cooldown_until > 0.0 then
+          state.cooldown_until <- 0.0;
+        false
+      end)
+
+(** Compute effective weight for a provider.
+
+    [effective_weight = config_weight * success_rate]
+
+    Providers in cooldown get weight 0 (skipped).  Unknown providers
+    get their full config weight (optimistic). *)
+let effective_weight t ~provider_key ~config_weight =
+  if is_in_cooldown t ~provider_key then 0
+  else
+    let rate = success_rate t ~provider_key in
+    max 1 (int_of_float (float_of_int config_weight *. rate))
+
+(** Summary for debugging/telemetry. *)
+let provider_summary t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> Printf.sprintf "%s: no data" provider_key
+    | Some state ->
+      let now = Unix.gettimeofday () in
+      let recent = prune_old_events now state.events in
+      let total = List.length recent in
+      let successes = List.length
+          (List.filter (fun e -> e.outcome = Success) recent) in
+      let in_cd = state.cooldown_until > now in
+      Printf.sprintf "%s: %d/%d ok (%.0f%%) consec_fail=%d cooldown=%b"
+        provider_key successes total
+        (if total > 0 then 100.0 *. float_of_int successes /. float_of_int total else 100.0)
+        state.consecutive_failures in_cd)
+
+(** Structured provider snapshot — shared by [provider_info] and [all_providers].
+    Built inside the mutex so the snapshot is consistent. *)
+type provider_info = {
+  provider_key : string;
+  success_rate : float;
+  consecutive_failures : int;
+  in_cooldown : bool;
+  cooldown_expires_at : float option;
+  events_in_window : int;
+}
+
+let build_info_locked ~now ~key state =
+  let recent = prune_old_events now state.events in
+  let total = List.length recent in
+  let successes = List.length
+      (List.filter (fun e -> e.outcome = Success) recent) in
+  let rate =
+    if total = 0 then 1.0
+    else float_of_int successes /. float_of_int total
+  in
+  let in_cd = state.cooldown_until > now in
+  {
+    provider_key = key;
+    success_rate = rate;
+    consecutive_failures = state.consecutive_failures;
+    in_cooldown = in_cd;
+    cooldown_expires_at = (if in_cd then Some state.cooldown_until else None);
+    events_in_window = total;
+  }
+
+let provider_info t ~provider_key =
+  with_lock t (fun () ->
+    match Hashtbl.find_opt t.providers provider_key with
+    | None -> None
+    | Some state ->
+      Some (build_info_locked ~now:(Unix.gettimeofday ()) ~key:provider_key state))
+
+let all_providers t =
+  with_lock t (fun () ->
+    let now = Unix.gettimeofday () in
+    Hashtbl.fold
+      (fun key state acc -> build_info_locked ~now ~key state :: acc)
+      t.providers
+      []
+    |> List.sort (fun a b -> String.compare a.provider_key b.provider_key))
+
+(* ── Global singleton ─────────────────────────── *)
+
+(** Global health tracker shared across all cascade calls in this process.
+    Thread-safe via internal Mutex. *)
+let global : t = create ()

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -1,0 +1,66 @@
+(** Reactive health tracking for cascade providers.
+
+    Tracks per-provider success/failure rates using a rolling time window.
+    Providers in cooldown (consecutive failures exceed threshold) are
+    temporarily skipped.
+
+    Thread-safe via internal [Stdlib.Mutex].
+
+    @since 0.137.0 *)
+
+(** Opaque health tracker state. *)
+type t
+
+(** Create a new empty tracker. *)
+val create : unit -> t
+
+(** Record a successful provider call. Clears cooldown and resets
+    consecutive failure counter. *)
+val record_success : t -> provider_key:string -> unit
+
+(** Record a failed provider call. Increments consecutive failure
+    counter; triggers cooldown when threshold is reached. *)
+val record_failure : t -> provider_key:string -> unit
+
+(** Success rate in the rolling window (0.0 to 1.0).
+    Returns 1.0 for unknown providers (optimistic default). *)
+val success_rate : t -> provider_key:string -> float
+
+(** Whether the provider is currently in cooldown (should be skipped). *)
+val is_in_cooldown : t -> provider_key:string -> bool
+
+(** Compute effective weight for weighted cascade selection.
+
+    [effective_weight = config_weight * success_rate]
+
+    Returns 0 for providers in cooldown.
+    Returns full [config_weight] for unknown providers. *)
+val effective_weight : t -> provider_key:string -> config_weight:int -> int
+
+(** Human-readable summary for debugging/telemetry. *)
+val provider_summary : t -> provider_key:string -> string
+
+(** Structured summary for telemetry/dashboard consumption.
+
+    @since 0.139.0 *)
+type provider_info = {
+  provider_key : string;
+  success_rate : float;               (** 0.0 to 1.0, 1.0 if unknown *)
+  consecutive_failures : int;
+  in_cooldown : bool;
+  cooldown_expires_at : float option; (** Unix timestamp, Some iff [in_cooldown] *)
+  events_in_window : int;             (** Events retained in rolling window *)
+}
+
+(** Structured info for a single provider. Returns [None] if untracked.
+    @since 0.139.0 *)
+val provider_info : t -> provider_key:string -> provider_info option
+
+(** Snapshot of all tracked providers.
+    Useful for dashboards and telemetry endpoints.
+    @since 0.139.0 *)
+val all_providers : t -> provider_info list
+
+(** Global singleton tracker shared across all cascade calls.
+    Use this for production; use {!create} for isolated tests. *)
+val global : t

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -1,0 +1,92 @@
+(** Model ID resolution: aliases and auto-detection for cloud providers.
+
+    Pure functions that map user-facing aliases to concrete API model IDs.
+    No side effects beyond reading environment variables.
+
+    @since 0.92.0 extracted from Cascade_config *)
+
+(* ── GLM model catalog ──────────────────────────────── *)
+
+(** Resolve GLM alias to concrete model ID.
+    ZhipuAI serves all models on one endpoint; the "model" field
+    must be an exact ID from their catalog.
+
+    Catalog (2026-03, updated):
+    {b Text}: glm-5.1, glm-5, glm-5-turbo, glm-4.7, glm-4.7-flashx,
+              glm-4.6, glm-4.5, glm-4.5-air, glm-4.5-airx,
+              glm-4.5-flash, glm-4.5-x, glm-4-32b-0414-128k
+    {b Vision}: glm-4.6v, glm-4.6v-flashx, glm-4.6v-flash, glm-4.5v
+    {b Audio}: glm-asr-2512
+    {b Image gen}: cogview-4, glm-image
+
+    All text/vision models support function calling.
+    glm-5.1 supports reasoning (reasoning_content field). *)
+let env_or default var =
+  match Sys.getenv_opt var with
+  | Some v when String.trim v <> "" -> String.trim v
+  | _ -> default
+
+(** Default GLM auto-cascade order: quality-first, then speed.
+    glm-5.1 = best quality (reasoning), glm-5-turbo = fast tool calling,
+    glm-4.7 = stable general, glm-4.7-flashx = fastest/cheapest.
+    Configurable via ZAI_AUTO_MODELS env var (comma-separated). *)
+let glm_auto_models = Llm_provider.Zai_catalog.glm_auto_models
+let glm_coding_auto_models = Llm_provider.Zai_catalog.glm_coding_auto_models
+
+let resolve_glm_model_id model_id =
+  Llm_provider.Zai_catalog.resolve_glm_alias
+    ~default_model:(env_or "glm-5.1" "ZAI_DEFAULT_MODEL")
+    model_id
+
+let resolve_glm_coding_model_id model_id =
+  Llm_provider.Zai_catalog.resolve_glm_coding_alias
+    ~default_model:(env_or "glm-4.7" "ZAI_CODING_DEFAULT_MODEL")
+    model_id
+
+(** Resolve "auto" and aliases to concrete model IDs.
+    Cloud APIs generally require concrete model names, and local
+    providers (llama, ollama) also cannot accept the literal "auto" model ID.
+
+    For local providers, "auto" is resolved via {!Llm_provider.Discovery.first_discovered_model_id}
+    which returns models from the last endpoint probe.  Callers should
+    resolve the model_id before invoking [Llm_provider.Discovery.endpoint_for_model]
+    to avoid routing mismatches. *)
+let resolve_auto_model_id provider_name model_id =
+  match provider_name with
+  | "llama" | "ollama" ->
+    (* Local providers: "auto" resolved earlier via Discovery in
+       cascade_config.ml.  If still "auto" here, try discovery then env var. *)
+    if model_id = "auto" then
+      match Llm_provider.Discovery.first_discovered_model_id () with
+      | Some id -> id
+      | None -> env_or model_id "OLLAMA_DEFAULT_MODEL"
+    else model_id
+  | "glm" -> resolve_glm_model_id model_id
+  | "glm-coding" -> resolve_glm_coding_model_id model_id
+  | "gemini" ->
+    if model_id = "auto" then env_or "gemini-2.5-flash" "GEMINI_DEFAULT_MODEL"
+    else model_id
+  | "claude" ->
+    if model_id = "auto" then env_or "claude-sonnet-4-6-20250514" "ANTHROPIC_DEFAULT_MODEL"
+    else model_id
+  | "openai" ->
+    if model_id = "auto" then env_or "gpt-4.1" "OPENAI_DEFAULT_MODEL"
+    else model_id
+  | "openrouter" ->
+    if model_id = "auto" then env_or model_id "OPENROUTER_DEFAULT_MODEL"
+    else model_id
+  | _ -> model_id
+
+let parse_custom_model model_id =
+  match String.index_opt model_id '@' with
+  | Some at_idx ->
+    let model = String.sub model_id 0 at_idx in
+    let url = String.sub model_id (at_idx + 1) (String.length model_id - at_idx - 1) in
+    (model, url)
+  | None ->
+    let url =
+      match Sys.getenv_opt "CUSTOM_LLM_BASE_URL" with
+      | Some u -> u
+      | None -> Llm_provider.Discovery.default_endpoint
+    in
+    (model_id, url)

--- a/lib/cascade/cascade_model_resolve.mli
+++ b/lib/cascade/cascade_model_resolve.mli
@@ -1,0 +1,34 @@
+(** Model ID resolution: aliases and auto-detection for cloud providers.
+
+    Pure functions that map user-facing aliases to concrete API model IDs.
+
+    @since 0.92.0 extracted from Cascade_config
+
+    @stability Internal
+    @since 0.93.1 *)
+
+(** GLM auto-cascade model list: quality-first, then speed.
+    Returns the ordered list of models to try when [glm:auto] is specified.
+    Configurable via [ZAI_AUTO_MODELS] env var (comma-separated).
+    Default: [\["glm-5.1"; "glm-5-turbo"; "glm-4.7"; "glm-4.7-flashx"\]]. *)
+val glm_auto_models : unit -> string list
+val glm_coding_auto_models : unit -> string list
+
+(** Resolve a GLM model alias to the concrete API model ID.
+    - ["auto"] -> env var [ZAI_DEFAULT_MODEL] or ["glm-5"]
+    - ["flash"] -> ["glm-4.7-flashx"]
+    - ["turbo"] -> ["glm-5-turbo"]
+    - ["vision"] -> ["glm-4.6v"]
+    - Concrete IDs pass through unchanged. *)
+val resolve_glm_model_id : string -> string
+val resolve_glm_coding_model_id : string -> string
+
+(** Resolve "auto" and aliases to concrete model IDs for any provider.
+    Cloud providers resolve aliases; local providers (llama, ollama) resolve
+    "auto" via {!Llm_provider.Discovery.first_discovered_model_id}. *)
+val resolve_auto_model_id : string -> string -> string
+
+(** Parse a "model@url" custom model spec.
+    Returns [(model_id, base_url)].
+    Without [@], uses [CUSTOM_LLM_BASE_URL] env or ["http://127.0.0.1:8080"]. *)
+val parse_custom_model : string -> string * string

--- a/lib/cascade/cascade_throttle.ml
+++ b/lib/cascade/cascade_throttle.ml
@@ -1,0 +1,74 @@
+(** Per-endpoint admission throttle table.
+
+    Shared throttle table: URL -> Llm_provider.Provider_throttle.t.
+    All callers contending for the same local endpoint share one semaphore.
+    Populated lazily from Discovery slot data.
+
+    @since 0.91.0
+    @since 0.92.0 extracted from Cascade_config *)
+
+let throttle_table : (string, Llm_provider.Provider_throttle.t) Hashtbl.t =
+  Hashtbl.create 4
+let throttle_mu = Eio.Mutex.create ()
+
+let has_slot_data (s : Llm_provider.Discovery.endpoint_status) =
+  (match s.slots with Some ss -> ss.total > 0 | None -> false)
+  || (match s.props with Some p -> p.total_slots > 0 | None -> false)
+
+let populate (statuses : Llm_provider.Discovery.endpoint_status list) =
+  Eio.Mutex.use_rw ~protect:true throttle_mu (fun () ->
+    List.iter (fun (s : Llm_provider.Discovery.endpoint_status) ->
+      if not s.healthy then
+        (* Evict stale entry so next healthy probe reinstalls a fresh semaphore. *)
+        Hashtbl.remove throttle_table s.url
+      else
+        let existing = Hashtbl.find_opt throttle_table s.url in
+        let should_install = match existing with
+          | None -> true
+          | Some t ->
+            (* Promote Fallback → Discovered when better data arrives *)
+            Llm_provider.Provider_throttle.source t = Fallback && has_slot_data s
+        in
+        if should_install then
+          let t = match Llm_provider.Provider_throttle.of_discovery_status s with
+            | Some t -> t
+            | None -> Llm_provider.Provider_throttle.default_for_kind Llm_provider.Provider_config.OpenAI_compat
+          in
+          Hashtbl.replace throttle_table s.url t
+    ) statuses)
+
+let lookup url =
+  Eio.Mutex.use_ro throttle_mu (fun () ->
+    Hashtbl.find_opt throttle_table url)
+
+let clear () =
+  Eio.Mutex.use_rw ~protect:true throttle_mu (fun () ->
+    Hashtbl.clear throttle_table)
+
+let length () =
+  Eio.Mutex.use_ro throttle_mu (fun () ->
+    Hashtbl.length throttle_table)
+
+(* ── Capacity Query ────────────────────────────────────── *)
+
+type capacity_info = {
+  total : int;
+  process_active : int;
+  process_available : int;
+  process_queue_length : int;
+  source : Llm_provider.Provider_throttle.capacity_source;
+}
+
+let capacity url =
+  Eio.Mutex.use_ro throttle_mu (fun () ->
+    match Hashtbl.find_opt throttle_table url with
+    | None -> None
+    | Some t ->
+      let snap = Llm_provider.Provider_throttle.snapshot t in
+      Some {
+        total = snap.max_slots;
+        process_active = snap.active;
+        process_available = snap.available;
+        process_queue_length = snap.queue_length;
+        source = Llm_provider.Provider_throttle.source t;
+      })

--- a/lib/cascade/cascade_throttle.mli
+++ b/lib/cascade/cascade_throttle.mli
@@ -1,0 +1,47 @@
+(** Per-endpoint admission throttle table.
+
+    Shared throttle table mapping endpoint URLs to {!Llm_provider.Provider_throttle.t}.
+    Populated lazily from {!Discovery} slot data.
+
+    @since 0.91.0
+    @since 0.92.0 extracted from Cascade_config
+
+    @stability Internal
+    @since 0.93.1 *)
+
+(** Update the throttle table from discovery probe results.
+    Creates entries for healthy endpoints with slot data.
+    Evicts entries for unhealthy endpoints. *)
+val populate : Llm_provider.Discovery.endpoint_status list -> unit
+
+(** Lookup the throttle for a given endpoint URL. *)
+val lookup : string -> Llm_provider.Provider_throttle.t option
+
+(** Clear all throttle entries (for testing). *)
+val clear : unit -> unit
+
+(** Number of throttle entries (for testing). *)
+val length : unit -> int
+
+(** {2 Capacity Query} *)
+
+(** Point-in-time capacity for a single endpoint.
+    All [process_*] counts reflect this OAS process only —
+    other clients sharing the same server are not visible.
+    @since 0.97.0 *)
+type capacity_info = {
+  total : int;
+  (** Server slot count from discovery. *)
+  process_active : int;
+  (** Slots held by this process. *)
+  process_available : int;
+  (** [total - process_active]. May overestimate if other consumers exist. *)
+  process_queue_length : int;
+  (** Fibers waiting for a slot in this process. *)
+  source : Llm_provider.Provider_throttle.capacity_source;
+  (** How the slot count was determined. *)
+}
+
+val capacity : string -> capacity_info option
+(** Capacity for a given endpoint URL. Returns [None] if not in throttle table.
+    @since 0.97.0 *)

--- a/lib/dune
+++ b/lib/dune
@@ -28,6 +28,13 @@
    bounded
    cache_eio
    cascade_inference
+   cascade_config
+   cascade_config_loader
+   cascade_fsm
+   cascade_health_filter
+   cascade_health_tracker
+   cascade_model_resolve
+   cascade_throttle
    cancellation
    channel_gate
    channel_gate_connector


### PR DESCRIPTION
## Summary

Scaffolds MASC's own cascade modules. **No callers yet** — this PR adds 7 modules to the \`masc_mcp\` library so follow-up work can migrate \`Llm_provider.Cascade_*\` references to \`Masc_cascade.Cascade_*\` without a "big-bang" rewrite.

Total: **+2,032 lines** of cascade orchestration imported from OAS v0.144.0.

## What moves

| Module | Role |
|---|---|
| \`cascade_config.ml/mli\` | parser, resolver, filter_healthy, model string parsing |
| \`cascade_config_loader.ml/mli\` | cascade.json JSON load + hot-reload |
| \`cascade_fsm.ml/mli\` | pure decision FSM (\`decide\`) |
| \`cascade_health_filter.ml\` | error classification |
| \`cascade_health_tracker.ml/mli\` | provider success/fail + cooldown tracking |
| \`cascade_model_resolve.ml/mli\` | \`glm:auto\` alias resolution |
| \`cascade_throttle.ml/mli\` | local endpoint slot table |

## What this PR does *not* do

- No call-site changes. All 20+ MASC modules that currently reference \`Llm_provider.Cascade_*\` keep working via the OAS pin (v0.144.0). Migration is the next PR.
- No OAS changes.

## Mechanics

Internal references rewired to \`Llm_provider.*\` for cross-library access (\`Llm_provider.Types\`, \`Llm_provider.Http_client\`, etc.) since the imported code now lives in \`masc_mcp\` instead of OAS's \`llm_provider\` library.

OAS \`ppx_inline_test\` blocks (\`let%test\`) stripped — MASC doesn't carry that ppx. Unit tests will be reauthored in \`test/\` when the migration stabilises.

\`populate_throttle_table\` and \`lookup_throttle\` re-exports in \`cascade_config.ml\` are tagged \`[@warning "-32"]\` because no MASC caller uses them yet — they'll light up when the migrate PR wires call sites through \`Masc_cascade.Cascade_config\`.

## Why

Per user directive (boundary clean-up phase 4):

> cascade_fsm 이 왜 oas 에 있어야함? 마찬가지로 health tracker가. oas 가 왜 cascade 를 알아야함?

Cascade is MASC's responsibility; OAS is a single-provider SDK.

## PR sequence

- **4d-scaffold** (this PR): copy cascade_* into MASC
- **4d-migrate**: swap 20+ call sites \`Llm_provider.Cascade_*\` → \`Masc_cascade.Cascade_*\`
- **OAS PR 4e**: delete cascade_* from OAS entirely (MAJOR bump)

## Test plan

- [x] \`dune build --root .\` clean (masc_mcp library builds with the new modules)
- [ ] CI green
- [ ] migrate PR will exercise the new modules and prove equivalence

Plan: \`~/me/planning/claude-plans/glimmering-imagining-sphinx.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)