### PR TITLE
fix(storage): route 5 eio modules through Room_utils.masc_dir

### DIFF
--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -27,7 +27,7 @@ type cache_entry = {
 
 (** Get cache directory *)
 let cache_dir (config : Room_utils.config) =
-  Filename.concat config.base_path ".masc/cache"
+  Filename.concat (Room_utils.masc_dir config) "cache"
 
 (** Ensure cache directory exists *)
 let ensure_cache_dir config =

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -324,7 +324,7 @@ and institution_of_json json =
 (** {1 Persistence (Eio Native)} *)
 
 let institution_file (config : config) =
-  Filename.concat config.base_path ".masc/institution.json"
+  Filename.concat (Room_utils.masc_dir config) "institution.json"
 
 let load_institution ~fs (config : config) : institution option =
   let file = institution_file config in

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -46,7 +46,7 @@ type config = Room_utils.config
 
 (** Get metrics directory *)
 let metrics_dir (config : config) =
-  Filename.concat config.Room_utils.base_path ".masc/metrics"
+  Filename.concat (Room_utils.masc_dir config) "metrics"
 
 (** Get agent-specific metrics directory *)
 let agent_metrics_dir config agent_id =

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -237,7 +237,7 @@ let set_deliverable (config : Room.config) ~task_id ~content : (planning_context
 (* ===== Session-level Context ===== *)
 
 let current_task_file (config : Room.config) =
-  Filename.concat config.base_path ".masc/current_task"
+  Filename.concat (Room_utils.masc_dir config) "current_task"
 
 (** Get current task_id for session *)
 let get_current_task (config : Room.config) : string option =

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -65,7 +65,7 @@ let log_entry_of_json (json : Yojson.Safe.t) : log_entry option =
     None
 
 let runs_dir (config : config) =
-  Filename.concat config.base_path ".masc/runs"
+  Filename.concat (masc_dir config) "runs"
 
 let run_dir (config : config) task_id =
   Filename.concat (runs_dir config) task_id


### PR DESCRIPTION
## Summary

#7370, #7374 follow-up. 5개 추가 eio storage 모듈의 `.masc/` hardcoded path를 cluster-aware path로 교체.

## Product impact

- **기본 cluster**: 동일한 결과. 런타임 의미론 무변경.
- **Non-default cluster**: 아래 경로들이 `<base>/.masc/clusters/<name>/` 하위로 정확히 들어감.

## Changes

| 파일 | 변경 경로 |
|------|----------|
| `lib/planning_eio.ml` | `current_task` 세션 파일 |
| `lib/run_eio.ml` | `runs/` 디렉토리 |
| `lib/cache_eio.ml` | `cache/` 디렉토리 |
| `lib/metrics_store_eio.ml` | `metrics/` 루트 |
| `lib/institution_eio.ml` | `institution.json` |

모두 1줄 교체 — 각 함수는 이미 `config`를 받고 있어 `Room_utils.masc_dir config` 경유로 변경만.

## Review evidence

- [x] `dune build --root .` — clean (origin/main 기준 #7386 cascade migration 이후 rebase 완료)
- [x] 변경은 기존 패턴 준수 (`masc_dir`은 Room_utils 모듈이 SSOT)

## Linked issue

Refs #7340 (추가 bypass 사이트 — eio 도메인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)