### PR TITLE
[codex] Add keeper campaign FSM harness

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -32,6 +32,11 @@
  (modules trace_to_tla)
  (libraries yojson))
 
+(executable
+ (name keeper_campaign_fsm)
+ (modules keeper_campaign_fsm)
+ (libraries masc_mcp yojson))
+
 ;; TUI Dashboard - Terminal interface for multi-agent coordination
 (executable
  (name masc_tui)

--- a/bin/keeper_campaign_fsm.ml
+++ b/bin/keeper_campaign_fsm.ml
@@ -1,0 +1,59 @@
+(** keeper_campaign_fsm — replay keeper campaign event logs into a final FSM snapshot.
+
+    Usage:
+      keeper_campaign_fsm replay <events.jsonl> [output.json]
+*)
+
+module Fsm = Masc_mcp.Keeper_campaign_fsm
+
+let usage () =
+  prerr_endline "Usage: keeper_campaign_fsm replay <events.jsonl> [output.json]";
+  exit 1
+
+let read_events path =
+  let ic = open_in path in
+  let rec loop acc =
+    try
+      let line = input_line ic in
+      let trimmed = String.trim line in
+      if trimmed = "" then loop acc
+      else
+        let json = Yojson.Safe.from_string trimmed in
+        match Fsm.event_of_yojson_result json with
+        | Ok event -> loop (event :: acc)
+        | Error msg ->
+          close_in_noerr ic;
+          failwith (Printf.sprintf "failed to decode %s: %s" path msg)
+    with End_of_file ->
+      close_in ic;
+      List.rev acc
+  in
+  loop []
+
+let write_snapshot path snapshot =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> Yojson.Safe.pretty_to_channel oc (Fsm.snapshot_to_yojson snapshot))
+
+let () =
+  let args = Array.to_list Sys.argv in
+  match args with
+  | [ _; "replay"; events_path ] -> (
+      match Fsm.replay (read_events events_path) with
+      | Ok snapshot ->
+        Yojson.Safe.pretty_to_channel stdout (Fsm.snapshot_to_yojson snapshot);
+        output_char stdout '\n'
+      | Error msg ->
+        prerr_endline msg;
+        exit 2)
+  | [ _; "replay"; events_path; output_path ] -> (
+      match Fsm.replay (read_events events_path) with
+      | Ok snapshot ->
+        write_snapshot output_path snapshot;
+        Yojson.Safe.pretty_to_channel stdout (Fsm.snapshot_to_yojson snapshot);
+        output_char stdout '\n'
+      | Error msg ->
+        prerr_endline msg;
+        exit 2)
+  | _ -> usage ()

--- a/docs/KEEPER-CAMPAIGN-HARNESS.md
+++ b/docs/KEEPER-CAMPAIGN-HARNESS.md
@@ -1,0 +1,129 @@
+# Keeper Campaign Harness
+
+`keeper campaign harness`는 기존 keeper 하나가 장기 goal을 들고 task를 claim한 뒤,
+`masc_autoresearch_*`를 사용해 목표 점수에 도달하고, 이후 compaction 또는 handoff
+압박을 받은 뒤에도 같은 goal/task lineage를 유지하는지를 검증한다.
+
+v1 범위:
+
+- keeper-only
+- hermetic-first
+- `team_session` 비의존
+- verdict는 harness artifact에만 기록
+- 최종 verdict는 `campaign-events.jsonl`을 `keeper_campaign_fsm`으로 replay한 결과가 SSOT
+
+## Entry Point
+
+```bash
+./scripts/harness_keeper_campaign.sh
+```
+
+기본 동작:
+
+1. isolated temp `BASE_PATH`와 server를 띄운다.
+2. harness agent가 room에 join한다.
+3. fixture git repo를 만들고 metric script를 심는다.
+4. keeper를 goal horizons + aggressive compaction/handoff thresholds로 생성한다.
+5. campaign task를 추가한다.
+6. keeper에게 task claim/current_task bind를 시킨다.
+7. keeper에게 fixture repo를 대상으로 autoresearch를 시작시키고 `target_score` 도달을 요구한다.
+8. 큰 prompt로 pressure를 걸어 compaction/handoff를 유도한다.
+9. pressure 이후에도 같은 `goal`과 `current_task_id`를 유지하는지 확인한다.
+10. 최종 verdict를 `reached | stalled | escalated`로 분류한다.
+
+## Verdicts
+
+- `reached`
+  - keeper bootstrap 성공
+  - task bind 성공
+  - autoresearch가 `target_score` 도달
+  - compaction 또는 handoff 증거가 나타남
+  - pressure 이후에도 동일한 `goal`과 `current_task_id` 유지
+
+- `stalled`
+  - keeper lane은 생존했지만 target 또는 continuity proof가 validation window 안에 닫히지 않음
+
+- `escalated`
+  - keeper가 viable goal-reaching lane을 만들지 못했거나 blocker/error 상태로 멈춤
+
+## Artifacts
+
+출력 디렉터리:
+
+```text
+logs/keeper_campaign/<run_id>/
+```
+
+주요 파일:
+
+- `summary.json`
+- `summary.md`
+- `campaign-events.jsonl`
+- `campaign-state.json`
+- `phases.jsonl`
+- `snapshots/*-keeper-status.json`
+- `snapshots/*-autoresearch-status.json`
+- `raw/msg-*.json`
+- `server.log`
+
+## Campaign FSM
+
+하네스는 shell에서 직접 verdict를 계산하지 않는다. 아래 이벤트들을
+`campaign-events.jsonl`로 기록한 뒤, pure OCaml sub-FSM인
+`Keeper_campaign_fsm`으로 replay해서 `campaign-state.json`을 만든다.
+
+핵심 phase:
+
+- `bootstrapping`
+- `claiming_task`
+- `task_bound`
+- `searching`
+- `target_reached`
+- `pressure_testing`
+- `continuity_verified`
+- `stalled`
+- `escalated`
+
+핵심 event:
+
+- `bootstrap_ok`
+- `task_bound_observed`
+- `autoresearch_started`
+- `target_reached`
+- `pressure_started`
+- `compaction_observed`
+- `handoff_observed`
+- `continuity_observed`
+- `window_exhausted`
+- `error_observed`
+
+## Dry Run
+
+runtime 없이 plumbing과 artifact contract만 확인하려면:
+
+```bash
+DRY_RUN=1 START_SERVER=0 ./scripts/harness_keeper_campaign.sh
+```
+
+dry-run은 synthetic `reached` verdict를 만든다. runtime truth proof는 아니다.
+
+## Important Knobs
+
+- `KEEPER_MODELS`
+  - required. example: `KEEPER_MODELS='glm:auto'`
+- `MAX_PRESSURE_TURNS`
+  - compaction/handoff pressure turn count
+- `PRESSURE_BYTES`
+  - per-turn synthetic context pressure size
+- `KEEPER_COMPACTION_RATIO_GATE`
+  - compaction trigger gate
+- `KEEPER_HANDOFF_THRESHOLD`
+  - handoff trigger gate
+- `AUTORESEARCH_WAIT_SEC`
+  - target reach timeout
+
+## Notes
+
+- fixture repo는 isolated `BASE_PATH` 아래에서 생성된다.
+- v1은 subordinate swarm을 증명하지 않는다.
+- success threshold는 `masc_autoresearch_start(target_score=...)`에 의존한다.

--- a/docs/design/keeper-campaign-fsm.md
+++ b/docs/design/keeper-campaign-fsm.md
@@ -1,0 +1,116 @@
+# Keeper Campaign FSM
+
+**Status**: Draft  
+**Date**: 2026-04-15  
+**Scope**: keeper-only goal-reaching campaign harness sub-FSM  
+**One sentence**: separate mission progress from keeper runtime lifecycle, then make the harness verdict replayable and machine-checkable.
+
+## Why This Exists
+
+기존 keeper lifecycle FSM은 keepalive, failure, compaction, handoff 같은
+런타임 생명주기를 설명한다. 하지만 keeper campaign harness가 증명하려는 것은
+다른 축이다.
+
+- goal을 잃지 않고 bootstrap했는가
+- task를 실제로 claim/bind 했는가
+- autoresearch로 target score에 도달했는가
+- 이후 compaction 또는 handoff pressure를 견뎠는가
+- 마지막 continuity check에서 goal/task lineage가 살아 있었는가
+
+이건 runtime FSM에 상태를 더 붙여서 해결할 문제가 아니다.
+
+## Separation Rule
+
+`Keeper_state_machine.phase`는 계속 runtime lifecycle만 소유한다.
+
+`Keeper_campaign_fsm.phase`는 mission progress만 소유한다.
+
+즉 이 둘은 직교한다. 예를 들어 아래 조합이 동시에 가능해야 한다.
+
+- runtime = `Running`, campaign = `Searching`
+- runtime = `Compacting`, campaign = `Pressure_testing`
+- runtime = `HandingOff`, campaign = `Pressure_testing`
+- runtime = `Running`, campaign = `Continuity_verified`
+
+## Campaign Phases
+
+- `bootstrapping`
+  - keeper keepalive/status surface가 살아나기 전
+- `claiming_task`
+  - keeper가 campaign task를 claim/bind 하는 중
+- `task_bound`
+  - `current_task_id`가 확정된 상태
+- `searching`
+  - autoresearch loop가 목표 점수로 수렴 중
+- `target_reached`
+  - score 목표는 달성했지만 continuity pressure 전
+- `pressure_testing`
+  - compaction 또는 handoff evidence를 기다리는 중
+- `continuity_verified`
+  - 최종 성공 terminal
+- `stalled`
+  - timeout/window exhaustion terminal
+- `escalated`
+  - explicit blocker, lineage loss, replay failure 같은 hard-fail terminal
+
+## Event Contract
+
+Replay input은 `campaign-events.jsonl` 한 줄에 이벤트 하나다.
+
+- `bootstrap_ok`
+- `task_bound_observed`
+- `autoresearch_started`
+- `target_reached`
+- `pressure_started`
+- `compaction_observed`
+- `handoff_observed`
+- `continuity_observed`
+- `window_exhausted`
+- `error_observed`
+
+이벤트는 append-only이며 하네스 phase log와 별도다.
+
+## Verdict Rule
+
+verdict는 terminal phase에서만 나온다.
+
+- `continuity_verified` -> `reached`
+- `stalled` -> `stalled`
+- `escalated` -> `escalated`
+
+하네스 summary는 이 verdict를 그대로 사용한다. shell heuristic은 보조 정보로만 남는다.
+
+## Continuity Rule
+
+`continuity_verified`로 들어가려면 모두 참이어야 한다.
+
+- `target_reached = true`
+- `compaction_count > 0` 또는 `handoff_count > 0`
+- `goal_matches = true`
+- `current_task_id == baseline task_id`
+
+이 조건이 깨진 continuity observation은 `escalated`로 간주한다.
+반대로 continuity phase까지 갔지만 lifecycle evidence가 아예 없으면
+`window_exhausted`로 `stalled` 처리한다.
+
+## Harness Mapping
+
+keeper campaign harness는 이제 세 레이어 아티팩트를 남긴다.
+
+- `phases.jsonl`
+  - 사람이 읽는 shell phase timeline
+- `campaign-events.jsonl`
+  - FSM replay용 canonical mission event log
+- `campaign-state.json`
+  - replay 결과 snapshot + verdict
+
+즉 운영자가 보는 phase log와 판정 SSOT를 분리한다.
+
+## Non-Goals
+
+- `team_session` 복구 또는 재도입
+- subordinate swarm orchestration
+- runtime keeper lifecycle 대체
+- multi-keeper campaign
+
+v1은 오직 **leader keeper 하나가 task를 들고 목표에 도달한 뒤 continuity까지 버티는가**만 다룬다.

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -147,7 +147,9 @@ let generate_code_change = Autoresearch_codegen.generate_code_change
 (* Loop State Management                                             *)
 (* ================================================================ *)
 
-let create_state ~goal ~metric_fn ?model_model ~target_file ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn ?(lower_is_better = false) ~workdir () =
+let create_state ~goal ~metric_fn ?model_model ~target_file ?target_score
+    ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn
+    ?(lower_is_better = false) ~workdir () =
   let model_model = match model_model with
     | Some m -> m
     | None -> Provider_adapter.default_model_provider_prefix_result () |> Result.value ~default:"auto"
@@ -163,6 +165,7 @@ let create_state ~goal ~metric_fn ?model_model ~target_file ~cycle_timeout_s ~ma
     metric_fn;
     model_model;
     target_file;
+    target_score;
     status = Running;
     error_message = None;
     current_cycle = 0;
@@ -251,9 +254,42 @@ let record_cycle (state : loop_state) ~hypothesis ~score_before ~score_after
   in
   (state, record)
 
+let target_reached (state : loop_state) =
+  match state.target_score with
+  | None -> false
+  | Some target ->
+      if state.lower_is_better then state.best_score <= target
+      else state.best_score >= target
+
+let completion_reason (state : loop_state) =
+  if target_reached state then
+    Some "target_score reached"
+  else if state.current_cycle >= state.max_cycles then
+    Some "max_cycles reached"
+  else
+    None
+
+let complete_if_finished (state : loop_state) =
+  match state.status, completion_reason state with
+  | Running, Some "target_score reached" ->
+      let target =
+        match state.target_score with
+        | Some value -> Printf.sprintf "%.4f" value
+        | None -> "n/a"
+      in
+      add_insight
+        { state with status = Completed; updated_at = Time_compat.now () }
+        (Printf.sprintf "Target reached at cycle %d (target=%s, best=%.4f)"
+           state.current_cycle target state.best_score)
+  | Running, Some reason ->
+      add_insight
+        { state with status = Completed; updated_at = Time_compat.now () }
+        (Printf.sprintf "Autoresearch completed: %s" reason)
+  | _ -> state
+
 (** Check if the loop should continue. *)
 let should_continue (state : loop_state) =
-  state.status = Running && state.current_cycle < state.max_cycles
+  state.status = Running && Option.is_none (completion_reason state)
 
 (** Stop a running or persisted loop.
     Acquires [loops_mu] write lock internally. *)
@@ -282,6 +318,7 @@ let stop_loop ~base_path ?reason loop_id =
                 metric_fn = persisted.metric_fn;
                 model_model = persisted.model_model;
                 target_file = persisted.target_file;
+                target_score = persisted.target_score;
                 status = persisted.status;
                 error_message = persisted.error_message;
                 current_cycle = persisted.current_cycle;
@@ -312,16 +349,19 @@ let stop_loop ~base_path ?reason loop_id =
 (** Linked loop status JSON for swarm integration.
     Acquires [loops_mu] read lock internally. *)
 let linked_status_json ~base_path (link : swarm_link) =
-  let current_cycle, status, best_score, error_message, workdir, source_workdir,
-      program_note, warnings, queued_hypothesis =
+  let current_cycle, status, best_score, target_score, error_message, workdir,
+      lower_is_better, source_workdir, program_note, warnings,
+      queued_hypothesis =
     with_loops_ro (fun () ->
       match Hashtbl.find_opt active_loops link.loop_id with
       | Some state ->
           ( state.current_cycle,
             status_to_string state.status,
             state.best_score,
+            state.target_score,
             state.error_message,
             state.workdir,
+            state.lower_is_better,
             state.source_workdir,
             state.program_note,
             state.warnings,
@@ -332,8 +372,10 @@ let linked_status_json ~base_path (link : swarm_link) =
               ( persisted.current_cycle,
                 status_to_string persisted.status,
                 persisted.best_score,
+                persisted.target_score,
                 persisted.error_message,
                 persisted.workdir,
+                persisted.lower_is_better,
                 persisted.source_workdir,
                 persisted.program_note,
                 persisted.warnings,
@@ -342,8 +384,10 @@ let linked_status_json ~base_path (link : swarm_link) =
               ( 0,
                 "missing",
                 0.0,
+                None,
                 Some "state file missing",
                 managed_worktree_dir ~base_path link.loop_id,
+                false,
                 "",
                 link.program_note,
                 [],
@@ -362,6 +406,14 @@ let linked_status_json ~base_path (link : swarm_link) =
       ("status", `String status);
       ("current_cycle", `Int current_cycle);
       ("best_score", `Float best_score);
+      ("target_score", Json_util.float_opt_to_json target_score);
+      ( "target_reached",
+        `Bool
+          (match target_score with
+           | None -> false
+           | Some target ->
+               if lower_is_better then best_score <= target
+               else best_score >= target) );
       ( "last_decision",
         Json_util.string_opt_to_json last_decision );
       ("target_file", `String link.target_file);

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -132,6 +132,13 @@ let optional_float_field json field =
         (Printf.sprintf "%s: expected float or null, got %s" field
            (yojson_type_name value))
 
+let loop_target_reached (state : loop_state) =
+  match state.target_score with
+  | None -> false
+  | Some target ->
+      if state.lower_is_better then state.best_score <= target
+      else state.best_score >= target
+
 let cycle_to_yojson (r : cycle_record) : Yojson.Safe.t =
   `Assoc [
     ("cycle", `Int r.cycle);
@@ -191,6 +198,8 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
     ("metric_fn", `String s.metric_fn);
     ("model_model", `String s.model_model);
     ("target_file", `String s.target_file);
+    ("target_score", Json_util.float_opt_to_json s.target_score);
+    ("target_reached", `Bool (loop_target_reached s));
     ("status", `String (status_to_string s.status));
     ("current_cycle", `Int s.current_cycle);
     ("baseline", `Float s.baseline);
@@ -238,6 +247,7 @@ let state_of_yojson_result (json : Yojson.Safe.t) : (persisted_summary, string) 
   let* metric_fn = required_string_field kind json "metric_fn" in
   let* model_model = required_string_field kind json "model_model" in
   let* target_file = required_string_field kind json "target_file" in
+  let* target_score = optional_float_field json "target_score" in
   let* workdir = required_string_field kind json "workdir" in
   let* cycle_timeout_s = required_float_field kind json "cycle_timeout_s" in
   let* max_cycles = required_int_field kind json "max_cycles" in
@@ -307,6 +317,7 @@ let state_of_yojson_result (json : Yojson.Safe.t) : (persisted_summary, string) 
       metric_fn;
       model_model;
       target_file;
+      target_score;
       workdir;
       cycle_timeout_s;
       max_cycles;

--- a/lib/autoresearch/autoresearch_types.ml
+++ b/lib/autoresearch/autoresearch_types.ml
@@ -25,6 +25,7 @@ type loop_state = {
   metric_fn : string;
   model_model : string;
   target_file : string;  (** File the MODEL reads and modifies, relative to workdir *)
+  target_score : float option;  (** Optional success threshold for the metric *)
   status : status;
   error_message : string option;
   current_cycle : int;
@@ -75,6 +76,7 @@ type persisted_summary = {
   metric_fn : string;
   model_model : string;
   target_file : string;
+  target_score : float option;
   workdir : string;
   cycle_timeout_s : float;
   max_cycles : int;

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -38,6 +38,8 @@ let loop_summary_json (base_path : string)
       ("baseline", `Float state.baseline);
       ("best_score", `Float state.best_score);
       ("best_cycle", `Int state.best_cycle);
+      ("target_score", Json_util.float_opt_to_json state.target_score);
+      ("target_reached", `Bool (Autoresearch.target_reached state));
       ("total_keeps", `Int state.total_keeps);
       ("total_discards", `Int state.total_discards);
       ("elapsed_s", `Float (Time_compat.now () -. state.start_time));
@@ -83,6 +85,14 @@ let persisted_to_loop_summary_json (base_path : string)
       ("baseline", `Float p.baseline);
       ("best_score", `Float p.best_score);
       ("best_cycle", `Int p.best_cycle);
+      ("target_score", Json_util.float_opt_to_json p.target_score);
+      ( "target_reached",
+        `Bool
+          (match p.target_score with
+           | None -> false
+           | Some target ->
+               if p.lower_is_better then p.best_score <= target
+               else p.best_score >= target) );
       ("total_keeps", `Int p.total_keeps);
       ("total_discards", `Int p.total_discards);
       ("elapsed_s", `Float p.elapsed_s);
@@ -284,6 +294,7 @@ let rehydrate_persisted_loop (persisted : Autoresearch_types.persisted_summary) 
     metric_fn = persisted.metric_fn;
     model_model = persisted.model_model;
     target_file = persisted.target_file;
+    target_score = persisted.target_score;
     status = persisted.status;
     error_message = persisted.error_message;
     current_cycle = persisted.current_cycle;

--- a/lib/dune
+++ b/lib/dune
@@ -445,6 +445,7 @@
    keeper_world_observation
    keeper_decision_audit
    keeper_composite_observer
+   keeper_campaign_fsm
    keeper_unified_prompt
    keeper_unified_turn
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1203,16 +1203,16 @@ let run_turn
                 let llm_selected =
                   if llm_rerank_enabled then
                     (match Eio_context.get_switch_opt (), Eio_context.get_net_opt () with
-                     | Some sw, Some net ->
-                       let rerank_cascade =
-                         Keeper_config.keeper_llm_rerank_cascade ()
-                       in
-                       let defaults =
-                         Oas_worker.default_model_strings ~cascade_name:rerank_cascade
-                       in
-                       let config_path = Oas_worker.default_config_path () in
-                       (* Resolve cascade → first healthy provider. OAS 0.144.0+
-                          no longer owns cascade orchestration — MASC picks one
+	                     | Some sw, Some net ->
+	                       let rerank_cascade =
+	                         Keeper_config.keeper_llm_rerank_cascade ()
+	                       in
+	                       let defaults =
+	                         Oas_worker.default_model_strings ~cascade_name:rerank_cascade
+	                       in
+	                       let config_path = Oas_worker.default_config_path () in
+	                       (* Resolve cascade → first healthy provider. OAS 0.144.0+
+	                          no longer owns cascade orchestration — MASC picks one
                           provider from the cascade and passes it to the
                           single-provider rerank API. Graceful degradation via
                           BM25 fallback lives inside [default_rerank_fn]. *)
@@ -1224,16 +1224,16 @@ let run_turn
                        let providers =
                          Cascade_config.parse_model_strings model_strings
                        in
-                       let healthy =
-                         Cascade_config.filter_healthy ~sw ~net providers
-                       in
-                       (match healthy with
-                        | [] ->
-                          Log.Keeper.warn
-                            "keeper:%s TopK_llm: no healthy provider for cascade \
-                             '%s', falling back to core+prefilter+discovered"
-                            meta.name
-                            rerank_cascade;
+	                       let healthy =
+	                         Cascade_config.filter_healthy ~sw ~net providers
+	                       in
+	                       (match healthy with
+	                        | [] ->
+	                          Log.Keeper.warn
+	                            "keeper:%s TopK_llm: no healthy provider for cascade \
+	                             '%s', falling back to core+prefilter+discovered"
+	                            meta.name
+	                            rerank_cascade;
                           []
                         | first_provider :: _ ->
                           let rerank_fn =
@@ -1275,16 +1275,16 @@ let run_turn
                              selected
                            with
                            | Eio.Cancel.Cancelled _ as e -> raise e
-                           | exn ->
-                             Log.Keeper.warn
-                               "keeper:%s TopK_llm failed (%s), falling back to \
-                                core+prefilter+discovered"
-                             meta.name
-                             (Printexc.to_string exn);
-                             []))
-                     | _ ->
-                       Log.Keeper.warn
-                         "keeper:%s TopK_llm: Eio context unavailable, falling back \
+	                           | exn ->
+	                             Log.Keeper.warn
+	                               "keeper:%s TopK_llm failed (%s), falling back to \
+	                                core+prefilter+discovered"
+	                               meta.name
+	                               (Printexc.to_string exn);
+	                             []))
+	                     | _ ->
+	                       Log.Keeper.warn
+	                         "keeper:%s TopK_llm: Eio context unavailable, falling back \
                           to core+prefilter+discovered"
                          meta.name;
                        [])

--- a/lib/keeper/keeper_campaign_fsm.ml
+++ b/lib/keeper/keeper_campaign_fsm.ml
@@ -1,0 +1,392 @@
+(** Keeper_campaign_fsm — pure campaign goal-reaching sub-FSM.
+
+    This FSM is orthogonal to {!Keeper_state_machine}. It models the keeper
+    campaign harness mission contract only: goal bootstrap, task binding,
+    autoresearch progress, lifecycle pressure, and continuity verification. *)
+
+type phase =
+  | Bootstrapping
+  | Claiming_task
+  | Task_bound
+  | Searching
+  | Target_reached
+  | Pressure_testing
+  | Continuity_verified
+  | Stalled
+  | Escalated
+
+type snapshot = {
+  phase : phase;
+  goal : string option;
+  task_id : string option;
+  current_task_id : string option;
+  loop_id : string option;
+  target_score : float option;
+  target_reached : bool;
+  compaction_count : int;
+  handoff_count : int;
+  continuity_goal_matches : bool option;
+  continuity_task_matches : bool option;
+  reason : string option;
+}
+
+type event =
+  | Bootstrap_ok of { goal : string }
+  | Task_bound_observed of { task_id : string; current_task_id : string }
+  | Autoresearch_started of {
+      loop_id : string;
+      target_score : float option;
+    }
+  | Target_reached_event
+  | Pressure_started
+  | Compaction_observed of { count : int }
+  | Handoff_observed of {
+      count : int;
+      generation : int option;
+      trace_id : string option;
+    }
+  | Continuity_observed of {
+      goal_matches : bool;
+      current_task_id : string option;
+    }
+  | Window_exhausted of { reason : string }
+  | Error_observed of { reason : string }
+
+let initial =
+  {
+    phase = Bootstrapping;
+    goal = None;
+    task_id = None;
+    current_task_id = None;
+    loop_id = None;
+    target_score = None;
+    target_reached = false;
+    compaction_count = 0;
+    handoff_count = 0;
+    continuity_goal_matches = None;
+    continuity_task_matches = None;
+    reason = None;
+  }
+
+let phase_to_string = function
+  | Bootstrapping -> "bootstrapping"
+  | Claiming_task -> "claiming_task"
+  | Task_bound -> "task_bound"
+  | Searching -> "searching"
+  | Target_reached -> "target_reached"
+  | Pressure_testing -> "pressure_testing"
+  | Continuity_verified -> "continuity_verified"
+  | Stalled -> "stalled"
+  | Escalated -> "escalated"
+
+let phase_of_string = function
+  | "bootstrapping" -> Some Bootstrapping
+  | "claiming_task" -> Some Claiming_task
+  | "task_bound" -> Some Task_bound
+  | "searching" -> Some Searching
+  | "target_reached" -> Some Target_reached
+  | "pressure_testing" -> Some Pressure_testing
+  | "continuity_verified" -> Some Continuity_verified
+  | "stalled" -> Some Stalled
+  | "escalated" -> Some Escalated
+  | _ -> None
+
+let phase_terminal = function
+  | Continuity_verified | Stalled | Escalated -> true
+  | Bootstrapping | Claiming_task | Task_bound | Searching
+  | Target_reached | Pressure_testing -> false
+
+let verdict_of_phase = function
+  | Continuity_verified -> Some "reached"
+  | Stalled -> Some "stalled"
+  | Escalated -> Some "escalated"
+  | Bootstrapping | Claiming_task | Task_bound | Searching
+  | Target_reached | Pressure_testing -> None
+
+let event_to_string = function
+  | Bootstrap_ok _ -> "bootstrap_ok"
+  | Task_bound_observed _ -> "task_bound_observed"
+  | Autoresearch_started _ -> "autoresearch_started"
+  | Target_reached_event -> "target_reached"
+  | Pressure_started -> "pressure_started"
+  | Compaction_observed _ -> "compaction_observed"
+  | Handoff_observed _ -> "handoff_observed"
+  | Continuity_observed _ -> "continuity_observed"
+  | Window_exhausted _ -> "window_exhausted"
+  | Error_observed _ -> "error_observed"
+
+let ( let* ) = Result.bind
+
+let continuity_task_matches snapshot current_task_id =
+  match snapshot.task_id, current_task_id with
+  | Some task_id, Some current_task_id -> String.equal task_id current_task_id
+  | _ -> false
+
+let json_of_option f = function
+  | Some value -> f value
+  | None -> `Null
+
+let snapshot_to_yojson snapshot =
+  let fields =
+    [
+      ("phase", `String (phase_to_string snapshot.phase));
+      ("goal", json_of_option (fun x -> `String x) snapshot.goal);
+      ("task_id", json_of_option (fun x -> `String x) snapshot.task_id);
+      ("current_task_id", json_of_option (fun x -> `String x) snapshot.current_task_id);
+      ("loop_id", json_of_option (fun x -> `String x) snapshot.loop_id);
+      ("target_score", json_of_option (fun x -> `Float x) snapshot.target_score);
+      ("target_reached", `Bool snapshot.target_reached);
+      ("compaction_count", `Int snapshot.compaction_count);
+      ("handoff_count", `Int snapshot.handoff_count);
+      ( "continuity_goal_matches",
+        json_of_option (fun x -> `Bool x) snapshot.continuity_goal_matches );
+      ( "continuity_task_matches",
+        json_of_option (fun x -> `Bool x) snapshot.continuity_task_matches );
+      ("reason", json_of_option (fun x -> `String x) snapshot.reason);
+    ]
+  in
+  let fields =
+    match verdict_of_phase snapshot.phase with
+    | Some verdict -> ("verdict", `String verdict) :: fields
+    | None -> fields
+  in
+  `Assoc (List.rev fields)
+
+let event_to_yojson = function
+  | Bootstrap_ok { goal } ->
+    `Assoc [ ("event", `String "bootstrap_ok"); ("goal", `String goal) ]
+  | Task_bound_observed { task_id; current_task_id } ->
+    `Assoc
+      [
+        ("event", `String "task_bound_observed");
+        ("task_id", `String task_id);
+        ("current_task_id", `String current_task_id);
+      ]
+  | Autoresearch_started { loop_id; target_score } ->
+    `Assoc
+      [
+        ("event", `String "autoresearch_started");
+        ("loop_id", `String loop_id);
+        ("target_score", json_of_option (fun x -> `Float x) target_score);
+      ]
+  | Target_reached_event ->
+    `Assoc [ ("event", `String "target_reached") ]
+  | Pressure_started ->
+    `Assoc [ ("event", `String "pressure_started") ]
+  | Compaction_observed { count } ->
+    `Assoc
+      [ ("event", `String "compaction_observed"); ("count", `Int count) ]
+  | Handoff_observed { count; generation; trace_id } ->
+    `Assoc
+      [
+        ("event", `String "handoff_observed");
+        ("count", `Int count);
+        ("generation", json_of_option (fun x -> `Int x) generation);
+        ("trace_id", json_of_option (fun x -> `String x) trace_id);
+      ]
+  | Continuity_observed { goal_matches; current_task_id } ->
+    `Assoc
+      [
+        ("event", `String "continuity_observed");
+        ("goal_matches", `Bool goal_matches);
+        ("current_task_id", json_of_option (fun x -> `String x) current_task_id);
+      ]
+  | Window_exhausted { reason } ->
+    `Assoc
+      [ ("event", `String "window_exhausted"); ("reason", `String reason) ]
+  | Error_observed { reason } ->
+    `Assoc
+      [ ("event", `String "error_observed"); ("reason", `String reason) ]
+
+let get_field name fields =
+  match List.assoc_opt name fields with
+  | Some value -> Ok value
+  | None -> Error ("missing field: " ^ name)
+
+let get_string name fields =
+  match get_field name fields with
+  | Ok (`String value) -> Ok value
+  | Ok _ -> Error ("expected string field: " ^ name)
+  | Error _ as err -> err
+
+let get_string_opt name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> Error ("expected string|null field: " ^ name)
+
+let get_bool name fields =
+  match get_field name fields with
+  | Ok (`Bool value) -> Ok value
+  | Ok _ -> Error ("expected bool field: " ^ name)
+  | Error _ as err -> err
+
+let get_int name fields =
+  match get_field name fields with
+  | Ok (`Int value) -> Ok value
+  | Ok _ -> Error ("expected int field: " ^ name)
+  | Error _ as err -> err
+
+let get_int_opt name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Int value) -> Ok (Some value)
+  | Some _ -> Error ("expected int|null field: " ^ name)
+
+let get_float_opt name fields =
+  match List.assoc_opt name fields with
+  | None | Some `Null -> Ok None
+  | Some (`Float value) -> Ok (Some value)
+  | Some (`Int value) -> Ok (Some (float_of_int value))
+  | Some _ -> Error ("expected number|null field: " ^ name)
+
+let event_of_yojson_result = function
+  | `Assoc fields -> (
+      match get_string "event" fields with
+      | Error _ as err -> err
+      | Ok "bootstrap_ok" ->
+        Result.map (fun goal -> Bootstrap_ok { goal }) (get_string "goal" fields)
+      | Ok "task_bound_observed" ->
+        let* task_id = get_string "task_id" fields in
+        let* current_task_id = get_string "current_task_id" fields in
+        Ok (Task_bound_observed { task_id; current_task_id })
+      | Ok "autoresearch_started" ->
+        let* loop_id = get_string "loop_id" fields in
+        let* target_score = get_float_opt "target_score" fields in
+        Ok (Autoresearch_started { loop_id; target_score })
+      | Ok "target_reached" -> Ok Target_reached_event
+      | Ok "pressure_started" -> Ok Pressure_started
+      | Ok "compaction_observed" ->
+        Result.map (fun count -> Compaction_observed { count }) (get_int "count" fields)
+      | Ok "handoff_observed" ->
+        let* count = get_int "count" fields in
+        let* generation = get_int_opt "generation" fields in
+        let* trace_id = get_string_opt "trace_id" fields in
+        Ok (Handoff_observed { count; generation; trace_id })
+      | Ok "continuity_observed" ->
+        let* goal_matches = get_bool "goal_matches" fields in
+        let* current_task_id = get_string_opt "current_task_id" fields in
+        Ok (Continuity_observed { goal_matches; current_task_id })
+      | Ok "window_exhausted" ->
+        Result.map (fun reason -> Window_exhausted { reason }) (get_string "reason" fields)
+      | Ok "error_observed" ->
+        Result.map (fun reason -> Error_observed { reason }) (get_string "reason" fields)
+      | Ok other -> Error ("unknown event: " ^ other))
+  | _ -> Error "expected JSON object"
+
+let event_of_yojson json =
+  match event_of_yojson_result json with
+  | Ok event -> event
+  | Error msg -> invalid_arg ("Keeper_campaign_fsm.event_of_yojson: " ^ msg)
+
+let invalid snapshot event reason =
+  Error
+    (Printf.sprintf "invalid transition: %s + %s (%s)"
+       (phase_to_string snapshot.phase) (event_to_string event) reason)
+
+let apply_event snapshot event =
+  if phase_terminal snapshot.phase then
+    invalid snapshot event "terminal phase is absorbing"
+  else
+    match snapshot.phase, event with
+    | Bootstrapping, Bootstrap_ok { goal } ->
+      Ok { snapshot with phase = Claiming_task; goal = Some goal; reason = None }
+    | Claiming_task, Task_bound_observed { task_id; current_task_id } ->
+      Ok
+        {
+          snapshot with
+          phase = Task_bound;
+          task_id = Some task_id;
+          current_task_id = Some current_task_id;
+          reason = None;
+        }
+    | Task_bound, Autoresearch_started { loop_id; target_score } ->
+      Ok
+        {
+          snapshot with
+          phase = Searching;
+          loop_id = Some loop_id;
+          target_score;
+          reason = None;
+        }
+    | Searching, Target_reached_event ->
+      Ok
+        {
+          snapshot with
+          phase = Target_reached;
+          target_reached = true;
+          reason = None;
+        }
+    | Target_reached, Pressure_started ->
+      Ok { snapshot with phase = Pressure_testing; reason = None }
+    | Pressure_testing, Compaction_observed { count } ->
+      Ok
+        {
+          snapshot with
+          compaction_count = max snapshot.compaction_count count;
+          reason = None;
+        }
+    | Pressure_testing, Handoff_observed { count; generation = _; trace_id = _ } ->
+      Ok
+        {
+          snapshot with
+          handoff_count = max snapshot.handoff_count count;
+          reason = None;
+        }
+    | Pressure_testing, Continuity_observed { goal_matches; current_task_id } ->
+      let task_matches = continuity_task_matches snapshot current_task_id in
+      let lifecycle_evidence =
+        snapshot.compaction_count > 0 || snapshot.handoff_count > 0
+      in
+      let next_snapshot =
+        {
+          snapshot with
+          current_task_id;
+          continuity_goal_matches = Some goal_matches;
+          continuity_task_matches = Some task_matches;
+        }
+      in
+      if goal_matches && task_matches && lifecycle_evidence && snapshot.target_reached
+      then
+        Ok { next_snapshot with phase = Continuity_verified; reason = None }
+      else
+        let reasons =
+          List.filter_map
+            (fun (ok, msg) -> if ok then None else Some msg)
+            [
+              (goal_matches, "goal mismatch");
+              (task_matches, "task mismatch");
+              (lifecycle_evidence, "missing lifecycle evidence");
+              (snapshot.target_reached, "target not reached");
+            ]
+        in
+        Ok
+          {
+            next_snapshot with
+            phase = Escalated;
+            reason = Some (String.concat ", " reasons);
+          }
+    | (Claiming_task | Task_bound | Searching | Pressure_testing), Window_exhausted { reason } ->
+      Ok { snapshot with phase = Stalled; reason = Some reason }
+    | (Bootstrapping | Claiming_task | Task_bound | Searching | Target_reached
+      | Pressure_testing), Error_observed { reason } ->
+      Ok { snapshot with phase = Escalated; reason = Some reason }
+    | Claiming_task, Bootstrap_ok _ ->
+      invalid snapshot event "bootstrap can only happen once"
+    | Task_bound, Task_bound_observed _ ->
+      invalid snapshot event "task already bound"
+    | Searching, Autoresearch_started _ ->
+      invalid snapshot event "autoresearch already started"
+    | Target_reached, Target_reached_event ->
+      invalid snapshot event "target already reached"
+    | Pressure_testing, Pressure_started ->
+      invalid snapshot event "pressure already started"
+    | _, _ ->
+      invalid snapshot event "event not allowed in this phase"
+
+let replay events =
+  List.fold_left
+    (fun acc event ->
+      let* snapshot = acc in
+      apply_event snapshot event)
+    (Ok initial) events

--- a/lib/keeper/keeper_campaign_fsm.mli
+++ b/lib/keeper/keeper_campaign_fsm.mli
@@ -1,0 +1,68 @@
+(** Keeper_campaign_fsm — pure campaign goal-reaching sub-FSM.
+
+    This FSM tracks mission progress on top of the keeper lifecycle FSM.
+    It deliberately does not own runtime liveness; it only models
+    goal-reaching progress for the keeper-only campaign harness. *)
+
+type phase =
+  | Bootstrapping
+  | Claiming_task
+  | Task_bound
+  | Searching
+  | Target_reached
+  | Pressure_testing
+  | Continuity_verified
+  | Stalled
+  | Escalated
+
+type snapshot = {
+  phase : phase;
+  goal : string option;
+  task_id : string option;
+  current_task_id : string option;
+  loop_id : string option;
+  target_score : float option;
+  target_reached : bool;
+  compaction_count : int;
+  handoff_count : int;
+  continuity_goal_matches : bool option;
+  continuity_task_matches : bool option;
+  reason : string option;
+}
+
+type event =
+  | Bootstrap_ok of { goal : string }
+  | Task_bound_observed of { task_id : string; current_task_id : string }
+  | Autoresearch_started of {
+      loop_id : string;
+      target_score : float option;
+    }
+  | Target_reached_event
+  | Pressure_started
+  | Compaction_observed of { count : int }
+  | Handoff_observed of {
+      count : int;
+      generation : int option;
+      trace_id : string option;
+    }
+  | Continuity_observed of {
+      goal_matches : bool;
+      current_task_id : string option;
+    }
+  | Window_exhausted of { reason : string }
+  | Error_observed of { reason : string }
+
+val initial : snapshot
+val phase_to_string : phase -> string
+val phase_of_string : string -> phase option
+val phase_terminal : phase -> bool
+val verdict_of_phase : phase -> string option
+
+val event_to_string : event -> string
+val snapshot_to_yojson : snapshot -> Yojson.Safe.t
+val event_to_yojson : event -> Yojson.Safe.t
+val event_of_yojson_result : Yojson.Safe.t -> (event, string) result
+val event_of_yojson : Yojson.Safe.t -> event
+
+val apply_event : snapshot -> event -> (snapshot, string) result
+val replay : event list -> (snapshot, string) result

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -25,6 +25,14 @@ let persisted_summary_json (summary : Autoresearch.persisted_summary) =
       ("metric_fn", `String summary.metric_fn);
       ("model_model", `String summary.model_model);
       ("target_file", `String summary.target_file);
+      ("target_score", Json_util.float_opt_to_json summary.target_score);
+      ( "target_reached",
+        `Bool
+          (match summary.target_score with
+           | None -> false
+           | Some target ->
+               if summary.lower_is_better then summary.best_score <= target
+               else summary.best_score >= target) );
       ("status", `String (Autoresearch.status_to_string summary.status));
       ("current_cycle", `Int summary.current_cycle);
       ("baseline", `Float summary.baseline);
@@ -64,6 +72,7 @@ type start_params = {
   cycle_timeout_s : float;
   model_model : string;
   baseline_override : float option;
+  target_score : float option;
   patience : int option;
   build_verify_fn : string option;
   lower_is_better : bool;
@@ -117,6 +126,7 @@ let prepare_start_params (ctx : context) args =
           cycle_timeout_s;
           model_model;
           baseline_override = get_float_opt args "baseline";
+          target_score = get_float_opt args "target_score";
           patience = get_int_opt args "patience";
           build_verify_fn;
           lower_is_better = get_bool args "lower_is_better" false;
@@ -159,6 +169,7 @@ let setup_running_loop (ctx : context) (params : start_params) =
   let state =
     Autoresearch.create_state ~goal:params.goal ~metric_fn:params.metric_fn
       ~model_model:params.model_model ~target_file:params.target_file
+      ?target_score:params.target_score
       ~cycle_timeout_s:params.cycle_timeout_s ~max_cycles:params.max_cycles
       ?patience:params.patience ?build_verify_fn:params.build_verify_fn
       ~lower_is_better:params.lower_is_better
@@ -194,8 +205,10 @@ let setup_running_loop (ctx : context) (params : start_params) =
           match baseline_result with
           | Error message -> Error message
           | Ok baseline ->
-              let state = { state with
-                baseline; best_score = baseline; source_workdir } in
+              let state =
+                Autoresearch.complete_if_finished
+                  { state with baseline; best_score = baseline; source_workdir }
+              in
               Ok (register_loop ctx state))
 
 let status_json (ctx : context) ~loop_id json_fields =
@@ -265,12 +278,14 @@ let handle_start (ctx : context) args =
       broadcast_loop_lifecycle "autoresearch_started" state;
       `Assoc [
         ("loop_id", `String state.loop_id);
-        ("status", `String "running");
+        ("status", `String (Autoresearch.status_to_string state.status));
         ("goal", `String params.goal);
         ("metric_fn", `String params.metric_fn);
         ("target_file", `String params.target_file);
         ("model_model", `String params.model_model);
         ("baseline", `Float state.baseline);
+        ("target_score", Json_util.float_opt_to_json state.target_score);
+        ("target_reached", `Bool (Autoresearch.target_reached state));
         ("max_cycles", `Int params.max_cycles);
         ("cycle_timeout_s", `Float params.cycle_timeout_s);
         ("workdir", `String state.workdir);

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -257,15 +257,21 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
             if state.status <> Autoresearch.Running then
               Error "Loop is not running"
             else if not (Autoresearch.should_continue state) then begin
-              let state = { state with status = Autoresearch.Completed } in
+              let reason =
+                Option.value ~default:"completed" (Autoresearch.completion_reason state)
+              in
+              let state = Autoresearch.complete_if_finished state in
               Hashtbl.replace active_loops id state;
               Autoresearch.save_state ~base_path:ctx.base_path state;
-              Error "completed"
+              Error ("completed:" ^ reason)
             end else
               Ok state)
     in
     match state_or_error with
-    | Error "completed" ->
+    | Error completed when String.starts_with ~prefix:"completed:" completed ->
+      let reason =
+        String.sub completed 10 (String.length completed - 10)
+      in
       let best_score, best_cycle =
         Autoresearch.with_loops_ro (fun () ->
             match Hashtbl.find_opt active_loops id with
@@ -276,7 +282,7 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
         [
           ("loop_id", `String id);
           ("status", `String "completed");
-          ("reason", `String "max_cycles reached");
+          ("reason", `String reason);
           ("best_score", `Float best_score);
           ("best_cycle", `Int best_cycle);
         ]
@@ -593,8 +599,10 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
                          else state
                        in
                        Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id effective_record;
-                       let state = { state with
-                         current_cycle = state.current_cycle + 1 } in
+                       let state =
+                         Autoresearch.complete_if_finished
+                           { state with current_cycle = state.current_cycle + 1 }
+                       in
                        Autoresearch.with_loops_rw (fun () ->
                          Hashtbl.replace Autoresearch.active_loops id state);
                        Autoresearch.save_state ~base_path:ctx.base_path state;
@@ -620,6 +628,8 @@ let handle_cycle (ctx : Tool_autoresearch_context.t) args =
                              `String
                                (Autoresearch.decision_to_string effective_record.decision) );
                            ("commit_hash", `String commit_hash);
+                           ("status", `String (Autoresearch.status_to_string state.status));
+                           ("target_reached", `Bool (Autoresearch.target_reached state));
                            ("baseline", `Float state.baseline);
                            ("best_score", `Float state.best_score);
                            ( "cycles_remaining",

--- a/lib/tool_autoresearch_schemas.ml
+++ b/lib/tool_autoresearch_schemas.ml
@@ -9,9 +9,10 @@ let schemas : Types.tool_schema list = [
     name = "masc_autoresearch_start";
     description = "Start a solo experiment loop: iteratively modify a target file to optimize \
 a metric. Each cycle: read file -> LLM generates change -> measure -> keep if improved, \
-discard if not. Runs autonomously until max_cycles or stopped. Returns loop_id. \
+discard if not. Runs autonomously until max_cycles, target_score, or stopped. Returns loop_id. \
     Requires: goal, metric_fn (shell command outputting a float), target_file. \
-    Set lower_is_better=true for metrics where lower values are better (e.g., loss, BPB).";
+    Set lower_is_better=true for metrics where lower values are better (e.g., loss, BPB). \
+    Optionally set target_score to stop as soon as the threshold is reached.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -41,6 +42,10 @@ discard if not. Runs autonomously until max_cycles or stopped. Returns loop_id. 
           ("type", `String "number");
           ("description", `String "Initial baseline score. If omitted, measured by running metric_fn once.");
         ]);
+        ("target_score", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Optional success threshold. Higher-or-equal wins by default; with lower_is_better=true, lower-or-equal wins.");
+        ]);
         ("model_model", `Assoc [
           ("type", `String "string");
           ("description", `String "Model label for code change generation (uses cascade default)");
@@ -62,7 +67,8 @@ The MODEL receives the full file, generates a modified version, and writes it ba
   {
     name = "masc_autoresearch_status";
     description = "Get the current status of an autoresearch loop. \
-Returns: loop_id, cycle count, baseline, best score, keep/discard counts, recent history.";
+Returns: loop_id, cycle count, baseline, best score, target_score, target_reached, \
+keep/discard counts, recent history.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/scripts/harness/workload/keeper_campaign.sh
+++ b/scripts/harness/workload/keeper_campaign.sh
@@ -1,0 +1,1036 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+source "$REPO_ROOT/scripts/harness/lib/mcp_jsonrpc.sh"
+source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
+
+RUN_ID="${RUN_ID:-keeper-campaign-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/keeper_campaign/$RUN_ID}"
+SNAP_DIR="$RUN_DIR/snapshots"
+RAW_DIR="$RUN_DIR/raw"
+CAMPAIGN_EVENTS_FILE="$RUN_DIR/campaign-events.jsonl"
+CAMPAIGN_STATE_FILE="$RUN_DIR/campaign-state.json"
+mkdir -p "$RUN_DIR" "$SNAP_DIR" "$RAW_DIR"
+
+DRY_RUN="${DRY_RUN:-0}"
+START_SERVER="${START_SERVER:-1}"
+KEEP_ARTIFACTS="${KEEP_ARTIFACTS:-0}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+PORT="${PORT:-}"
+BASE_PATH="${BASE_PATH:-}"
+SERVER_EXE="${SERVER_EXE:-}"
+MCP_URL="${MCP_URL:-}"
+KEEPER_MODELS="${KEEPER_MODELS:-}"
+KEEPER_NAME="${KEEPER_NAME:-campaign-${RUN_ID}}"
+HARNESS_AGENT_NAME="${HARNESS_AGENT_NAME:-campaign-harness}"
+TARGET_PHASES="${TARGET_PHASES:-bootstrap,task_bind,autoresearch,compaction,handoff,continuity}"
+TURN_TIMEOUT_SEC="${TURN_TIMEOUT_SEC:-90}"
+HEALTH_TIMEOUT_SEC="${HEALTH_TIMEOUT_SEC:-20}"
+BOOTSTRAP_WAIT_SEC="${BOOTSTRAP_WAIT_SEC:-20}"
+TASK_WAIT_SEC="${TASK_WAIT_SEC:-20}"
+AUTORESEARCH_WAIT_SEC="${AUTORESEARCH_WAIT_SEC:-45}"
+PRESSURE_PAUSE_SEC="${PRESSURE_PAUSE_SEC:-1}"
+MAX_PRESSURE_TURNS="${MAX_PRESSURE_TURNS:-4}"
+PRESSURE_BYTES="${PRESSURE_BYTES:-18000}"
+KEEPER_PRESENCE_KEEPALIVE_SEC="${KEEPER_PRESENCE_KEEPALIVE_SEC:-5}"
+KEEPER_COMPACTION_RATIO_GATE="${KEEPER_COMPACTION_RATIO_GATE:-0.10}"
+KEEPER_COMPACTION_MESSAGE_GATE="${KEEPER_COMPACTION_MESSAGE_GATE:-2}"
+KEEPER_CONTINUITY_COOLDOWN_SEC="${KEEPER_CONTINUITY_COOLDOWN_SEC:-0}"
+KEEPER_HANDOFF_THRESHOLD="${KEEPER_HANDOFF_THRESHOLD:-0.01}"
+KEEPER_CONTEXT_BUDGET="${KEEPER_CONTEXT_BUDGET:-0.60}"
+CAMPAIGN_TASK_TITLE="${CAMPAIGN_TASK_TITLE:-Keeper campaign goal reachability validation}"
+CAMPAIGN_GOAL="${CAMPAIGN_GOAL:-Reach the fixture target score through keeper-driven autoresearch, then preserve goal/task lineage across compaction or handoff.}"
+
+SERVER_PID=""
+SERVER_LOG="$RUN_DIR/server.log"
+TEMP_BASE_PATH=""
+FIXTURE_REPO=""
+KEEPER_CREATED=0
+KEEPER_STOPPED=0
+ROOM_JOINED=0
+VALIDATION_EXIT_CODE=1
+
+BOOTSTRAP_PASS=0
+TASK_BIND_PASS=0
+AUTORESEARCH_PASS=0
+COMPACTION_PASS=0
+HANDOFF_PASS=0
+CONTINUITY_PASS=0
+
+TASK_ID=""
+LOOP_ID=""
+CURRENT_TASK_ID=""
+BASELINE_TASK_ID=""
+BASELINE_GOAL=""
+BASELINE_TRACE_ID=""
+BASELINE_GENERATION="0"
+BASELINE_COMPACTIONS="0"
+BASELINE_HANDOFFS="0"
+LATEST_TRACE_ID=""
+LATEST_GENERATION=""
+LATEST_COMPACTIONS=""
+LATEST_HANDOFFS=""
+LATEST_HEALTH=""
+LATEST_INPUT_PREVIEW=""
+LATEST_OUTPUT_PREVIEW=""
+LATEST_LOOP_STATUS=""
+LATEST_TARGET_REACHED="false"
+LATEST_TARGET_SCORE=""
+LAST_TOOL_RAW=""
+LAST_TOOL_ERROR=""
+
+iso_now() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+normalize_bool() {
+  local raw="${1:-0}"
+  case "$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')" in
+    1|true|yes|y|on) printf '1' ;;
+    *) printf '0' ;;
+  esac
+}
+
+trim_preview() {
+  local raw="${1:-}"
+  python3 - "$raw" <<'PY'
+import sys
+text = sys.argv[1].strip().replace("\n", " ")
+limit = 220
+print(text if len(text) <= limit else text[:limit-1] + "…")
+PY
+}
+
+phase_enabled() {
+  case ",$TARGET_PHASES," in
+    *,"$1",*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+write_json_pretty() {
+  local path="$1"
+  local payload="$2"
+  printf '%s' "$payload" | jq '.' >"$path"
+}
+
+write_text() {
+  local path="$1"
+  local payload="$2"
+  printf '%s\n' "$payload" >"$path"
+}
+
+append_phase() {
+  local phase="$1"
+  local status="$2"
+  local summary="$3"
+  local snapshot_file="$4"
+  local aux_file="$5"
+  jq -nc \
+    --arg ts "$(iso_now)" \
+    --arg phase "$phase" \
+    --arg status "$status" \
+    --arg summary "$summary" \
+    --arg snapshot_file "$snapshot_file" \
+    --arg aux_file "$aux_file" \
+    '{
+      timestamp: $ts,
+      phase: $phase,
+      status: $status,
+      summary: $summary,
+      snapshot_file: ($snapshot_file | select(length > 0)),
+      aux_file: ($aux_file | select(length > 0))
+    }' >>"$RUN_DIR/phases.jsonl"
+}
+
+record_campaign_event() {
+  local payload="$1"
+  printf '%s' "$payload" \
+    | jq -c --arg timestamp "$(iso_now)" '. + {timestamp:$timestamp}' \
+    >>"$CAMPAIGN_EVENTS_FILE"
+}
+
+replay_campaign_fsm() {
+  local events_file="$1"
+  local output_file="$2"
+  local bin_path="$REPO_ROOT/_build/default/bin/keeper_campaign_fsm.exe"
+  if [[ -x "$bin_path" ]]; then
+    "$bin_path" replay "$events_file" "$output_file" >/dev/null
+  else
+    dune exec --root "$REPO_ROOT" ./bin/keeper_campaign_fsm.exe -- \
+      replay "$events_file" "$output_file" >/dev/null
+  fi
+}
+
+models_json() {
+  jq -cn --arg csv "$KEEPER_MODELS" '
+    $csv
+    | split(",")
+    | map(gsub("^\\s+|\\s+$"; ""))
+    | map(select(length > 0))
+  '
+}
+
+call_mcp_tool() {
+  local req_id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  local timeout_sec="${4:-$TURN_TIMEOUT_SEC}"
+
+  local saved_timeout="${HTTP_TIMEOUT_SEC:-}"
+  HTTP_TIMEOUT_SEC="$timeout_sec"
+  LAST_TOOL_RAW="$(mcp_call_tool "$req_id" "$tool_name" "$args_json")"
+  HTTP_TIMEOUT_SEC="$saved_timeout"
+
+  if printf '%s' "$LAST_TOOL_RAW" | jq -e '._harness_error? != null' >/dev/null 2>&1; then
+    LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '._harness_error.message // "transport error"')"
+    return 1
+  fi
+
+  LAST_TOOL_ERROR="$(printf '%s' "$LAST_TOOL_RAW" | jq -r '
+    if .error?.message then .error.message
+    elif (.result?.isError // false) == true then
+      ([.result.content[]? | select(.type == "text") | .text] | join(" "))
+    else empty end
+  ' 2>/dev/null | awk 'NF { print; exit }')"
+
+  if [[ -n "$LAST_TOOL_ERROR" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+tool_text() {
+  printf '%s' "$LAST_TOOL_RAW" | jq -r '.result.content[0].text // ""'
+}
+
+tool_json() {
+  local text
+  text="$(tool_text)"
+  printf '%s' "$text" | jq -c '.'
+}
+
+refresh_latest_evidence_from_status() {
+  local status_json="$1"
+  [[ -z "$status_json" ]] && return 0
+  LATEST_TRACE_ID="$(printf '%s' "$status_json" | jq -r '.meta.trace_id // ""')"
+  LATEST_GENERATION="$(printf '%s' "$status_json" | jq -r '.generation // .meta.generation // ""')"
+  LATEST_COMPACTIONS="$(printf '%s' "$status_json" | jq -r '.compaction_count // ""')"
+  LATEST_HANDOFFS="$(printf '%s' "$status_json" | jq -r '.handoff_count_total // ""')"
+  LATEST_HEALTH="$(printf '%s' "$status_json" | jq -r '.diagnostic.health_state // .agent.status // ""')"
+  CURRENT_TASK_ID="$(printf '%s' "$status_json" | jq -r '.meta.current_task_id // ""')"
+}
+
+refresh_latest_loop_state() {
+  local loop_json="$1"
+  [[ -z "$loop_json" ]] && return 0
+  LATEST_LOOP_STATUS="$(printf '%s' "$loop_json" | jq -r '.status // ""')"
+  LATEST_TARGET_REACHED="$(printf '%s' "$loop_json" | jq -r 'if (.target_reached // false) then "true" else "false" end')"
+  LATEST_TARGET_SCORE="$(printf '%s' "$loop_json" | jq -r '.target_score // ""')"
+  if [[ -z "$LOOP_ID" ]]; then
+    LOOP_ID="$(printf '%s' "$loop_json" | jq -r '.loop_id // ""')"
+  fi
+}
+
+join_room() {
+  local args
+  args="$(jq -cn \
+    --arg agent_name "$HARNESS_AGENT_NAME" \
+    '{agent_name:$agent_name,capabilities:["harness","campaign"]}')"
+  call_mcp_tool 100 "masc_join" "$args" 20 || return 1
+  ROOM_JOINED=1
+}
+
+leave_room() {
+  local args
+  args="$(jq -cn --arg agent_name "$HARNESS_AGENT_NAME" '{agent_name:$agent_name}')"
+  call_mcp_tool 101 "masc_leave" "$args" 20 || true
+  ROOM_JOINED=0
+}
+
+create_keeper() {
+  local models_json_payload="$1"
+  local args
+  args="$(jq -cn \
+    --arg name "$KEEPER_NAME" \
+    --arg goal "$CAMPAIGN_GOAL" \
+    --arg short_goal "Claim the campaign task and start autoresearch on the fixture repo." \
+    --arg mid_goal "Reach the target score, then preserve goal/task lineage through pressure." \
+    --arg long_goal "Prove keeper-only goal-reaching continuity without team_session." \
+    --arg instructions "모든 응답은 한국어로 짧게 작성하세요. 목표와 current_task를 잃지 말고, 필요한 경우 masc_claim_next, masc_plan_set_task, masc_autoresearch_* 도구를 사용하세요." \
+    --argjson models "$models_json_payload" \
+    --argjson presence_keepalive_sec "$KEEPER_PRESENCE_KEEPALIVE_SEC" \
+    --argjson compaction_ratio_gate "$KEEPER_COMPACTION_RATIO_GATE" \
+    --argjson compaction_message_gate "$KEEPER_COMPACTION_MESSAGE_GATE" \
+    --argjson continuity_compaction_cooldown_sec "$KEEPER_CONTINUITY_COOLDOWN_SEC" \
+    --argjson handoff_threshold "$KEEPER_HANDOFF_THRESHOLD" \
+    --argjson context_budget "$KEEPER_CONTEXT_BUDGET" \
+    '{
+      name:$name,
+      goal:$goal,
+      short_goal:$short_goal,
+      mid_goal:$mid_goal,
+      long_goal:$long_goal,
+      instructions:$instructions,
+      models:$models,
+      tool_preset:"coding",
+      presence_keepalive:true,
+      presence_keepalive_sec:$presence_keepalive_sec,
+      proactive_enabled:false,
+      auto_handoff:true,
+      compaction_profile:"custom",
+      compaction_ratio_gate:$compaction_ratio_gate,
+      compaction_message_gate:$compaction_message_gate,
+      compaction_token_gate:0,
+      continuity_compaction_cooldown_sec:$continuity_compaction_cooldown_sec,
+      handoff_threshold:$handoff_threshold,
+      handoff_cooldown_sec:30,
+      context_budget:$context_budget,
+      drift_enabled:false
+    }')"
+  call_mcp_tool 110 "masc_keeper_up" "$args" 60 || return 1
+  KEEPER_CREATED=1
+}
+
+stop_keeper() {
+  local args
+  args="$(jq -cn --arg name "$KEEPER_NAME" '{name:$name,remove_meta:false,remove_session:false}')"
+  if call_mcp_tool 111 "masc_keeper_down" "$args" 30; then
+    KEEPER_STOPPED=1
+    return 0
+  fi
+  return 1
+}
+
+keeper_status_json() {
+  local raw_args
+  raw_args="$(jq -cn --arg name "$KEEPER_NAME" '{
+    name:$name,
+    fast:false,
+    include_context:true,
+    include_metrics_overview:true,
+    include_memory_bank:true,
+    include_history_tail:true,
+    include_compaction_history:true,
+    tail_messages:5,
+    tail_turns:3
+  }')"
+  call_mcp_tool 120 "masc_keeper_status" "$raw_args" 60
+  tool_json
+}
+
+autoresearch_status_json() {
+  local raw_args
+  if [[ -n "$LOOP_ID" ]]; then
+    raw_args="$(jq -cn --arg loop_id "$LOOP_ID" '{loop_id:$loop_id}')"
+  else
+    raw_args='{}'
+  fi
+  if call_mcp_tool 121 "masc_autoresearch_status" "$raw_args" 30; then
+    tool_json
+  else
+    jq -nc --arg error "$LAST_TOOL_ERROR" '{error:$error}'
+  fi
+}
+
+capture_snapshot() {
+  local phase="$1"
+  local keeper_file="$SNAP_DIR/${phase}-keeper-status.json"
+  local loop_file="$SNAP_DIR/${phase}-autoresearch-status.json"
+  local keeper_json loop_json
+  keeper_json="$(keeper_status_json)"
+  write_json_pretty "$keeper_file" "$keeper_json"
+  refresh_latest_evidence_from_status "$keeper_json"
+  loop_json="$(autoresearch_status_json)"
+  write_json_pretty "$loop_file" "$loop_json"
+  refresh_latest_loop_state "$loop_json"
+  printf '%s\n%s\n' "$keeper_file" "$loop_file"
+}
+
+wait_for_bootstrap() {
+  local deadline=$(( $(date +%s) + BOOTSTRAP_WAIT_SEC ))
+  local status_json
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    status_json="$(keeper_status_json)"
+    if [[ "$(printf '%s' "$status_json" | jq -r '.keepalive_running // false')" == "true" ]] \
+      && [[ "$(printf '%s' "$status_json" | jq -r '.agent.exists // false')" == "true" ]]; then
+      refresh_latest_evidence_from_status "$status_json"
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_task_binding() {
+  local expected_task_id="$1"
+  local deadline=$(( $(date +%s) + TASK_WAIT_SEC ))
+  local status_json
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    status_json="$(keeper_status_json)"
+    refresh_latest_evidence_from_status "$status_json"
+    if [[ "$CURRENT_TASK_ID" == "$expected_task_id" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+wait_for_target_reached() {
+  local deadline=$(( $(date +%s) + AUTORESEARCH_WAIT_SEC ))
+  local loop_json
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    loop_json="$(autoresearch_status_json)"
+    refresh_latest_loop_state "$loop_json"
+    if [[ "$LATEST_TARGET_REACHED" == "true" ]]; then
+      return 0
+    fi
+    if [[ "$(printf '%s' "$loop_json" | jq -r '.status // ""')" == "error" ]]; then
+      return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+fixture_metric_py() {
+  cat <<'PY'
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+print(1.0 if "GOAL_REACHED" in text else 0.0)
+PY
+}
+
+create_fixture_repo() {
+  FIXTURE_REPO="${BASE_PATH}/keeper-campaign-fixture"
+  mkdir -p "$FIXTURE_REPO"
+  git -C "$FIXTURE_REPO" init -q
+  git -C "$FIXTURE_REPO" config user.email "harness@example.com"
+  git -C "$FIXTURE_REPO" config user.name "Harness User"
+  printf 'TODO\n' >"$FIXTURE_REPO/campaign.txt"
+  fixture_metric_py >"$FIXTURE_REPO/metric.py"
+  git -C "$FIXTURE_REPO" add campaign.txt metric.py
+  git -C "$FIXTURE_REPO" commit -q -m init
+}
+
+create_task() {
+  local description
+  description="$(cat <<EOF
+Claim this task, keep it as current_task, and use keeper-driven autoresearch against:
+- workdir: $FIXTURE_REPO
+- target_file: campaign.txt
+- metric_fn: python3 metric.py campaign.txt
+- success condition: target_score = 1.0
+- required change: replace TODO with GOAL_REACHED
+EOF
+)"
+  local args
+  args="$(jq -cn \
+    --arg title "$CAMPAIGN_TASK_TITLE" \
+    --arg description "$description" \
+    '{title:$title,priority:1,description:$description}')"
+  call_mcp_tool 130 "masc_add_task" "$args" 20 || return 1
+  local output
+  output="$(tool_text)"
+  TASK_ID="$(printf '%s' "$output" | sed -n 's/.*Added \(task-[0-9][0-9][0-9]\):.*/\1/p' | head -n1)"
+  [[ -n "$TASK_ID" ]]
+}
+
+short_prompt() {
+  local label="$1"
+  printf 'Campaign step: %s\n현재 goal과 current_task를 잃지 말고, 상태를 한국어로 2문장 이하로 요약하세요.\n' "$label"
+}
+
+pressure_prompt() {
+  local turn="$1"
+  python3 - "$RUN_ID" "$turn" "$PRESSURE_BYTES" <<'PY'
+import sys
+run_id, turn, target_bytes = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+anchor = f"CAMPAIGN-{run_id}-TURN-{turn}"
+line = (
+    f"Campaign continuity payload {anchor}. "
+    "Keep the same goal and current_task_id. "
+    "Do not start a new task or a new loop. "
+)
+buf = []
+size = 0
+while size < target_bytes:
+    buf.append(line)
+    size += len(line.encode())
+body = "".join(buf)
+print(
+    f"Campaign pressure turn {turn}.\n"
+    f"Current anchor: {anchor}\n"
+    f"{body}\n"
+    "답변은 짧게 하고 마지막 문장에 current_task를 다시 적어주세요."
+)
+PY
+}
+
+send_keeper_message() {
+  local request_id="$1"
+  local message="$2"
+  local raw_args output_json output_text
+  raw_args="$(jq -cn \
+    --arg name "$KEEPER_NAME" \
+    --arg message "$message" \
+    --argjson timeout "$TURN_TIMEOUT_SEC" \
+    '{name:$name,message:$message,timeout_sec:$timeout,require_existing:true}')"
+
+  call_mcp_tool "$request_id" "masc_keeper_msg" "$raw_args" "$((TURN_TIMEOUT_SEC + 30))"
+  output_text="$(tool_text)"
+  output_json="$(jq -nc \
+    --arg timestamp "$(iso_now)" \
+    --arg input_preview "$(trim_preview "$message")" \
+    --arg output_preview "$(trim_preview "$output_text")" \
+    '{timestamp:$timestamp,input_preview:$input_preview,output_preview:$output_preview}')"
+  write_json_pretty "$RAW_DIR/msg-${request_id}.json" "$output_json"
+  LATEST_INPUT_PREVIEW="$(trim_preview "$message")"
+  LATEST_OUTPUT_PREVIEW="$(trim_preview "$output_text")"
+}
+
+claim_and_bind_prompt() {
+  cat <<EOF
+Campaign kickoff.
+1. Use masc_claim_next to claim the highest-priority task.
+2. Keep that task as current_task. If current_task_id is still empty after claim, call masc_plan_set_task with the claimed task id.
+3. Respond with the claimed task id and one short Korean sentence about the next step.
+EOF
+}
+
+start_autoresearch_prompt() {
+  cat <<EOF
+Start keeper-only autoresearch for the claimed campaign task.
+
+Required tool plan:
+1. Use masc_autoresearch_start with:
+   - goal: "Replace TODO with GOAL_REACHED and reach target score 1.0"
+   - workdir: "$FIXTURE_REPO"
+   - target_file: "campaign.txt"
+   - metric_fn: "python3 metric.py campaign.txt"
+   - baseline: 0.0
+   - target_score: 1.0
+   - max_cycles: 4
+   - cycle_timeout_s: 30
+2. Use masc_autoresearch_inject with hypothesis: "Replace TODO with GOAL_REACHED in campaign.txt"
+3. Run masc_autoresearch_cycle until target_reached becomes true or you hit 4 cycles.
+
+Respond with loop_id, current_task_id, and whether target_reached is true.
+EOF
+}
+
+phase_status_string() {
+  local value="$1"
+  case "$value" in
+    1) printf 'pass' ;;
+    2) printf 'simulated' ;;
+    *) printf 'fail' ;;
+  esac
+}
+
+run_dry_run() {
+  local phase keeper_file loop_file
+  write_text "$SERVER_LOG" "dry-run mode: no live MCP calls executed"
+  for phase in bootstrap task_bind autoresearch compaction handoff continuity; do
+    [[ -n "$TARGET_PHASES" ]] && ! phase_enabled "$phase" && continue
+    keeper_file="$SNAP_DIR/${phase}-keeper-status.json"
+    loop_file="$SNAP_DIR/${phase}-autoresearch-status.json"
+    write_json_pretty "$keeper_file" "$(jq -nc --arg phase "$phase" --arg run_id "$RUN_ID" '{
+      simulated:true,
+      dry_run:true,
+      phase:$phase,
+      run_id:$run_id,
+      goal:"dry-run campaign goal",
+      generation:1,
+      compaction_count:1,
+      handoff_count_total:1,
+      keepalive_running:true,
+      agent:{exists:true,status:"alive"},
+      meta:{trace_id:"trace-dry-run",current_task_id:"task-001"}
+    }')"
+    write_json_pretty "$loop_file" "$(jq -nc --arg phase "$phase" --arg run_id "$RUN_ID" '{
+      simulated:true,
+      dry_run:true,
+      phase:$phase,
+      run_id:$run_id,
+      loop_id:"ar-dry-run",
+      status:"completed",
+      target_score:1.0,
+      target_reached:true
+    }')"
+    append_phase "$phase" "simulated" "dry-run synthetic (not runtime proof)" "$keeper_file" "$loop_file"
+  done
+  BOOTSTRAP_PASS=2
+  TASK_BIND_PASS=2
+  AUTORESEARCH_PASS=2
+  COMPACTION_PASS=2
+  HANDOFF_PASS=2
+  CONTINUITY_PASS=2
+  TASK_ID="task-001"
+  LOOP_ID="ar-dry-run"
+  CURRENT_TASK_ID="task-001"
+  BASELINE_TASK_ID="task-001"
+  BASELINE_GOAL="dry-run campaign goal"
+  LATEST_TRACE_ID="trace-dry-run"
+  LATEST_GENERATION="1"
+  LATEST_COMPACTIONS="1"
+  LATEST_HANDOFFS="1"
+  LATEST_HEALTH="simulated"
+  LATEST_LOOP_STATUS="completed"
+  LATEST_TARGET_REACHED="true"
+  LATEST_TARGET_SCORE="1"
+  LATEST_INPUT_PREVIEW="[simulated] dry-run campaign input"
+  LATEST_OUTPUT_PREVIEW="[simulated] dry-run campaign output"
+  record_campaign_event "$(jq -nc --arg goal "$BASELINE_GOAL" '{event:"bootstrap_ok",goal:$goal}')"
+  record_campaign_event "$(jq -nc --arg task_id "$TASK_ID" '{event:"task_bound_observed",task_id:$task_id,current_task_id:$task_id}')"
+  record_campaign_event "$(jq -nc --arg loop_id "$LOOP_ID" '{event:"autoresearch_started",loop_id:$loop_id,target_score:1.0}')"
+  record_campaign_event "$(jq -nc '{event:"target_reached"}')"
+  record_campaign_event "$(jq -nc '{event:"pressure_started"}')"
+  record_campaign_event "$(jq -nc '{event:"compaction_observed",count:1}')"
+  record_campaign_event "$(jq -nc '{event:"handoff_observed",count:1,generation:2,trace_id:"trace-dry-run-2"}')"
+  record_campaign_event "$(jq -nc --arg task_id "$TASK_ID" '{event:"continuity_observed",goal_matches:true,current_task_id:$task_id}')"
+}
+
+cleanup() {
+  if [[ "$(normalize_bool "$DRY_RUN")" != "1" && "$KEEPER_CREATED" == "1" && "$KEEPER_STOPPED" != "1" && -n "${MCP_URL:-}" ]]; then
+    stop_keeper >/dev/null 2>&1 || true
+  fi
+  if [[ "$(normalize_bool "$DRY_RUN")" != "1" && "$ROOM_JOINED" == "1" && -n "${MCP_URL:-}" ]]; then
+    leave_room >/dev/null 2>&1 || true
+  fi
+  if [[ "$(normalize_bool "$KEEP_SERVER")" != "1" ]]; then
+    harness_stop_server "$SERVER_PID" 10
+  fi
+  if [[ "$(normalize_bool "$KEEP_ARTIFACTS")" != "1" && -n "$TEMP_BASE_PATH" && -d "$TEMP_BASE_PATH" ]]; then
+    rm -rf "$TEMP_BASE_PATH"
+  fi
+}
+trap cleanup EXIT
+
+finalize_report() {
+  local verdict="escalated"
+  local campaign_phase="escalated"
+  local classification="FAIL"
+
+  local bootstrap_ok="$BOOTSTRAP_PASS"
+  local task_ok="$TASK_BIND_PASS"
+  local search_ok="$AUTORESEARCH_PASS"
+  local compaction_ok="$COMPACTION_PASS"
+  local handoff_ok="$HANDOFF_PASS"
+  local continuity_ok="$CONTINUITY_PASS"
+
+  if ! phase_enabled bootstrap; then bootstrap_ok=1; fi
+  if ! phase_enabled task_bind; then task_ok=1; fi
+  if ! phase_enabled autoresearch; then search_ok=1; fi
+  if ! phase_enabled compaction; then compaction_ok=1; fi
+  if ! phase_enabled handoff; then handoff_ok=1; fi
+  if ! phase_enabled continuity; then continuity_ok=1; fi
+
+  if [[ -s "$CAMPAIGN_EVENTS_FILE" ]] && replay_campaign_fsm "$CAMPAIGN_EVENTS_FILE" "$CAMPAIGN_STATE_FILE"; then
+    campaign_phase="$(jq -r '.phase // "escalated"' "$CAMPAIGN_STATE_FILE")"
+    verdict="$(jq -r '.verdict // "escalated"' "$CAMPAIGN_STATE_FILE")"
+  else
+    write_json_pretty "$CAMPAIGN_STATE_FILE" "$(jq -nc \
+      --arg phase "escalated" \
+      --arg verdict "escalated" \
+      --arg reason "campaign FSM replay failed or event log was empty" \
+      '{phase:$phase,verdict:$verdict,reason:$reason}')"
+  fi
+
+  if [[ "$(normalize_bool "$DRY_RUN")" == "1" ]]; then
+    classification="DRY_RUN"
+    VALIDATION_EXIT_CODE=2
+  elif [[ "$verdict" == "reached" ]]; then
+    classification="PASS"
+    VALIDATION_EXIT_CODE=0
+  elif [[ "$verdict" == "stalled" ]]; then
+    classification="PARTIAL"
+    VALIDATION_EXIT_CODE=1
+  else
+    classification="FAIL"
+    VALIDATION_EXIT_CODE=1
+  fi
+
+  local continuity_preserved=false
+  if [[ "$CURRENT_TASK_ID" == "$BASELINE_TASK_ID" && -n "$CURRENT_TASK_ID" ]]; then
+    continuity_preserved=true
+  fi
+
+  local summary_json
+  summary_json="$(jq -nc \
+    --arg run_id "$RUN_ID" \
+    --arg run_dir "$RUN_DIR" \
+    --arg classification "$classification" \
+    --arg verdict "$verdict" \
+    --arg campaign_phase "$campaign_phase" \
+    --arg keeper "$KEEPER_NAME" \
+    --arg task_id "$TASK_ID" \
+    --arg current_task_id "$CURRENT_TASK_ID" \
+    --arg loop_id "$LOOP_ID" \
+    --arg trace_id "$LATEST_TRACE_ID" \
+    --arg generation "$LATEST_GENERATION" \
+    --arg compactions "$LATEST_COMPACTIONS" \
+    --arg handoffs "$LATEST_HANDOFFS" \
+    --arg goal "$BASELINE_GOAL" \
+    --arg latest_health "$LATEST_HEALTH" \
+    --arg latest_loop_status "$LATEST_LOOP_STATUS" \
+    --arg latest_target_score "$LATEST_TARGET_SCORE" \
+    --arg latest_input_preview "$LATEST_INPUT_PREVIEW" \
+    --arg latest_output_preview "$LATEST_OUTPUT_PREVIEW" \
+    --argjson bootstrap_pass "$( [[ "$BOOTSTRAP_PASS" != "0" ]] && echo true || echo false )" \
+    --argjson task_bind_pass "$( [[ "$TASK_BIND_PASS" != "0" ]] && echo true || echo false )" \
+    --argjson autoresearch_pass "$( [[ "$AUTORESEARCH_PASS" != "0" ]] && echo true || echo false )" \
+    --argjson compaction_pass "$( [[ "$COMPACTION_PASS" != "0" ]] && echo true || echo false )" \
+    --argjson handoff_pass "$( [[ "$HANDOFF_PASS" != "0" ]] && echo true || echo false )" \
+    --argjson continuity_pass "$( [[ "$CONTINUITY_PASS" != "0" ]] && echo true || echo false )" \
+    --argjson target_reached "$( [[ "$LATEST_TARGET_REACHED" == "true" ]] && echo true || echo false )" \
+    --argjson continuity_preserved "$continuity_preserved" \
+    --argjson dry_run "$( [[ "$(normalize_bool "$DRY_RUN")" == "1" ]] && echo true || echo false )" \
+    '{
+      run_id:$run_id,
+      run_dir:$run_dir,
+      classification:$classification,
+      verdict:$verdict,
+      campaign_phase:$campaign_phase,
+      dry_run:$dry_run,
+      keeper:$keeper,
+      goal:$goal,
+      task_id:$task_id,
+      current_task_id:$current_task_id,
+      loop_id:$loop_id,
+      trace_id:$trace_id,
+      generation:$generation,
+      compaction_count:$compactions,
+      handoff_count_total:$handoffs,
+      latest_health:$latest_health,
+      latest_loop_status:$latest_loop_status,
+      target_score: (if $latest_target_score == "" then null else ($latest_target_score | tonumber?) end),
+      target_reached:$target_reached,
+      continuity_preserved:$continuity_preserved,
+      latest_input_preview:$latest_input_preview,
+      latest_output_preview:$latest_output_preview,
+      phases:{
+        bootstrap:{pass:$bootstrap_pass},
+        task_bind:{pass:$task_bind_pass},
+        autoresearch:{pass:$autoresearch_pass},
+        compaction:{pass:$compaction_pass},
+        handoff:{pass:$handoff_pass},
+        continuity:{pass:$continuity_pass}
+      }
+    }')"
+  write_json_pretty "$RUN_DIR/summary.json" "$summary_json"
+
+  cat >"$RUN_DIR/summary.md" <<EOF
+# Keeper Campaign Harness
+
+- Run ID: \`$RUN_ID\`
+- Classification: **$classification**
+- Verdict: **$verdict**
+- Campaign phase: \`$campaign_phase\`
+- Dry run: $( [[ "$(normalize_bool "$DRY_RUN")" == "1" ]] && echo "yes" || echo "no" )
+- Keeper: \`$KEEPER_NAME\`
+- Models: \`$KEEPER_MODELS\`
+- Goal: $BASELINE_GOAL
+
+## Result
+
+| Phase | Result |
+|---|---|
+| bootstrap | $(phase_status_string "$BOOTSTRAP_PASS") |
+| task_bind | $(phase_status_string "$TASK_BIND_PASS") |
+| autoresearch | $(phase_status_string "$AUTORESEARCH_PASS") |
+| compaction | $(phase_status_string "$COMPACTION_PASS") |
+| handoff | $(phase_status_string "$HANDOFF_PASS") |
+| continuity | $(phase_status_string "$CONTINUITY_PASS") |
+
+## Evidence
+
+- Task ID: \`$TASK_ID\`
+- Current task ID: \`$CURRENT_TASK_ID\`
+- Loop ID: \`$LOOP_ID\`
+- Latest loop status: \`$LATEST_LOOP_STATUS\`
+- Target reached: \`$LATEST_TARGET_REACHED\`
+- Trace ID: \`$LATEST_TRACE_ID\`
+- Generation: \`$LATEST_GENERATION\`
+- Compactions: \`$LATEST_COMPACTIONS\`
+- Handoffs: \`$LATEST_HANDOFFS\`
+- Latest health: \`$LATEST_HEALTH\`
+- Recent input preview: $LATEST_INPUT_PREVIEW
+- Recent output preview: $LATEST_OUTPUT_PREVIEW
+
+## Interpretation
+EOF
+
+  if [[ "$(normalize_bool "$DRY_RUN")" == "1" ]]; then
+    cat >>"$RUN_DIR/summary.md" <<'EOF'
+- **reached**: dry-run synthetic campaign succeeded. This proves the harness contract only.
+- **stalled**: not used in dry-run mode.
+- **escalated**: dry-run harness plumbing failed.
+EOF
+  else
+    cat >>"$RUN_DIR/summary.md" <<'EOF'
+- **reached**: keeper claimed the task, reached target_score through autoresearch, and preserved goal/task lineage after compaction or handoff pressure.
+- **stalled**: the keeper stayed mostly coherent, but target or continuity proof did not finish inside the validation window.
+- **escalated**: the keeper never established a viable goal-reaching lane or surfaced a blocking/error state.
+EOF
+  fi
+
+  cat >>"$RUN_DIR/summary.md" <<EOF
+
+## Artifacts
+
+- Summary JSON: \`$RUN_DIR/summary.json\`
+- Campaign FSM state: \`$CAMPAIGN_STATE_FILE\`
+- Campaign event log: \`$CAMPAIGN_EVENTS_FILE\`
+- Phase log: \`$RUN_DIR/phases.jsonl\`
+- Snapshots: \`$SNAP_DIR\`
+- Raw keeper turns: \`$RAW_DIR\`
+- Server log: \`$SERVER_LOG\`
+EOF
+
+  local manifest_json
+  manifest_json="$(jq -nc \
+    --arg run_id "$RUN_ID" \
+    --arg run_dir "$RUN_DIR" \
+    --arg summary_json "$RUN_DIR/summary.json" \
+    --arg summary_md "$RUN_DIR/summary.md" \
+    --arg campaign_state "$CAMPAIGN_STATE_FILE" \
+    --arg campaign_events "$CAMPAIGN_EVENTS_FILE" \
+    --arg phases "$RUN_DIR/phases.jsonl" \
+    --arg snapshots "$SNAP_DIR" \
+    --arg raw "$RAW_DIR" \
+    '{run_id:$run_id,run_dir:$run_dir,summary_json:$summary_json,summary_md:$summary_md,campaign_state:$campaign_state,campaign_events:$campaign_events,phases:$phases,snapshots:$snapshots,raw:$raw}')"
+  write_json_pretty "$RUN_DIR/manifest.json" "$manifest_json"
+}
+
+real_run() {
+  local models_json_payload snapshot_info keeper_file loop_file keeper_json loop_json
+  local pressure_turn
+
+  require_cmd jq || { echo "jq is required" >&2; return 1; }
+  require_cmd curl || { echo "curl is required" >&2; return 1; }
+  require_cmd python3 || { echo "python3 is required" >&2; return 1; }
+  require_cmd git || { echo "git is required" >&2; return 1; }
+
+  if [[ -z "$KEEPER_MODELS" ]]; then
+    echo "KEEPER_MODELS is required (example: KEEPER_MODELS='glm:auto')" >&2
+    return 1
+  fi
+
+  if [[ "$(normalize_bool "$START_SERVER")" == "1" ]]; then
+    TEMP_BASE_PATH="$(mktemp -d "${TMPDIR:-/tmp}/keeper-campaign.${RUN_ID}.XXXXXX")"
+    BASE_PATH="${BASE_PATH:-$TEMP_BASE_PATH}"
+    PORT="${PORT:-$(harness_pick_free_port)}"
+    MCP_URL="http://127.0.0.1:${PORT}/mcp"
+    local server_exe
+    server_exe="$(harness_find_server_exe "$REPO_ROOT" "$SERVER_EXE")"
+    SERVER_PID="$(harness_start_server "$server_exe" "$PORT" "$BASE_PATH" "$SERVER_LOG")"
+    if ! harness_wait_for_health "$PORT" "$HEALTH_TIMEOUT_SEC"; then
+      echo "failed to start isolated server on port $PORT" >&2
+      harness_print_log_tail "$SERVER_LOG" 120
+      return 1
+    fi
+  elif [[ -z "$MCP_URL" ]]; then
+    echo "MCP_URL is required when START_SERVER=0" >&2
+    return 1
+  fi
+
+  join_room
+  create_fixture_repo
+  models_json_payload="$(models_json)"
+  create_keeper "$models_json_payload"
+
+  if ! wait_for_bootstrap; then
+    record_campaign_event "$(jq -nc '{event:"error_observed",reason:"keeper bootstrap timeout"}')"
+    snapshot_info="$(capture_snapshot bootstrap)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "bootstrap" "fail" "keepalive or room presence did not appear in time" "$keeper_file" "$loop_file"
+    return 1
+  fi
+
+  record_campaign_event "$(jq -nc --arg goal "$CAMPAIGN_GOAL" '{event:"bootstrap_ok",goal:$goal}')"
+  if phase_enabled bootstrap; then
+    snapshot_info="$(capture_snapshot bootstrap)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    BOOTSTRAP_PASS=1
+    append_phase "bootstrap" "pass" "keeper started with active keepalive and status surface" "$keeper_file" "$loop_file"
+  fi
+
+  if ! create_task; then
+    record_campaign_event "$(jq -nc --arg reason "task creation failed: $LAST_TOOL_ERROR" '{event:"error_observed",reason:$reason}')"
+    snapshot_info="$(capture_snapshot task-create)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "task_bind" "fail" "task creation failed: $LAST_TOOL_ERROR" "$keeper_file" "$loop_file"
+    return 1
+  fi
+
+  if ! send_keeper_message 200 "$(claim_and_bind_prompt)"; then
+    record_campaign_event "$(jq -nc --arg reason "keeper claim turn failed: $LAST_TOOL_ERROR" '{event:"error_observed",reason:$reason}')"
+    snapshot_info="$(capture_snapshot task-bind)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "task_bind" "fail" "keeper claim turn failed: $LAST_TOOL_ERROR" "$keeper_file" "$loop_file"
+    return 1
+  fi
+
+  if ! wait_for_task_binding "$TASK_ID"; then
+    record_campaign_event "$(jq -nc '{event:"window_exhausted",reason:"task binding timeout"}')"
+    snapshot_info="$(capture_snapshot task-bind)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "task_bind" "fail" "keeper did not bind current_task_id=$TASK_ID" "$keeper_file" "$loop_file"
+    return 1
+  fi
+
+  BASELINE_TASK_ID="$CURRENT_TASK_ID"
+  keeper_json="$(keeper_status_json)"
+  BASELINE_GOAL="$(printf '%s' "$keeper_json" | jq -r '.goal // ""')"
+  BASELINE_TRACE_ID="$(printf '%s' "$keeper_json" | jq -r '.meta.trace_id // ""')"
+  BASELINE_GENERATION="$(printf '%s' "$keeper_json" | jq -r '(.generation | tonumber?) // 0')"
+  BASELINE_COMPACTIONS="$(printf '%s' "$keeper_json" | jq -r '(.compaction_count | tonumber?) // 0')"
+  BASELINE_HANDOFFS="$(printf '%s' "$keeper_json" | jq -r '(.handoff_count_total | tonumber?) // 0')"
+  record_campaign_event "$(jq -nc --arg task_id "$TASK_ID" --arg current_task_id "$CURRENT_TASK_ID" '{event:"task_bound_observed",task_id:$task_id,current_task_id:$current_task_id}')"
+  if phase_enabled task_bind; then
+    snapshot_info="$(capture_snapshot task-bind)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    TASK_BIND_PASS=1
+    append_phase "task_bind" "pass" "keeper claimed the task and current_task_id is bound" "$keeper_file" "$loop_file"
+  fi
+
+  if ! send_keeper_message 210 "$(start_autoresearch_prompt)"; then
+    record_campaign_event "$(jq -nc --arg reason "keeper autoresearch turn failed: $LAST_TOOL_ERROR" '{event:"error_observed",reason:$reason}')"
+    snapshot_info="$(capture_snapshot autoresearch)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "autoresearch" "fail" "keeper autoresearch turn failed: $LAST_TOOL_ERROR" "$keeper_file" "$loop_file"
+    return 1
+  fi
+
+  if ! wait_for_target_reached; then
+    record_campaign_event "$(jq -nc '{event:"window_exhausted",reason:"autoresearch target timeout"}')"
+    snapshot_info="$(capture_snapshot autoresearch)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "autoresearch" "fail" "autoresearch did not reach target_score within the validation window" "$keeper_file" "$loop_file"
+    return 1
+  fi
+
+  record_campaign_event "$(jq -nc --arg loop_id "$LOOP_ID" --argjson target_score 1.0 '{event:"autoresearch_started",loop_id:$loop_id,target_score:$target_score}')"
+  record_campaign_event "$(jq -nc '{event:"target_reached"}')"
+  record_campaign_event "$(jq -nc '{event:"pressure_started"}')"
+  if phase_enabled autoresearch; then
+    snapshot_info="$(capture_snapshot autoresearch)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    AUTORESEARCH_PASS=1
+    append_phase "autoresearch" "pass" "keeper-driven autoresearch reached target_score" "$keeper_file" "$loop_file"
+  fi
+
+  for pressure_turn in $(seq 1 "$MAX_PRESSURE_TURNS"); do
+    if ! phase_enabled compaction && ! phase_enabled handoff; then
+      break
+    fi
+    if ! send_keeper_message "$((300 + pressure_turn))" "$(pressure_prompt "$pressure_turn")"; then
+      break
+    fi
+    sleep "$PRESSURE_PAUSE_SEC"
+    snapshot_info="$(capture_snapshot "pressure-${pressure_turn}")"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    keeper_json="$(cat "$keeper_file")"
+    if [[ $COMPACTION_PASS -eq 0 ]] \
+      && [[ "$(printf '%s' "$keeper_json" | jq -r '(((.compaction_count | tonumber?) // 0) > (($old | tonumber?) // 0))' --arg old "$BASELINE_COMPACTIONS")" == "true" ]]; then
+      COMPACTION_PASS=1
+      BASELINE_COMPACTIONS="$(printf '%s' "$keeper_json" | jq -r '(.compaction_count | tonumber?) // 0')"
+      record_campaign_event "$(jq -nc --argjson count "$BASELINE_COMPACTIONS" '{event:"compaction_observed",count:$count}')"
+      append_phase "compaction" "pass" "compaction counter increased under campaign pressure" "$keeper_file" "$loop_file"
+    fi
+    if [[ $HANDOFF_PASS -eq 0 ]] \
+      && { [[ "$(printf '%s' "$keeper_json" | jq -r '(((.generation | tonumber?) // 0) > (($old | tonumber?) // 0))' --arg old "$BASELINE_GENERATION")" == "true" ]] \
+        || [[ "$(printf '%s' "$keeper_json" | jq -r '(((.handoff_count_total | tonumber?) // 0) > (($old | tonumber?) // 0))' --arg old "$BASELINE_HANDOFFS")" == "true" ]] \
+        || [[ "$(printf '%s' "$keeper_json" | jq -r '.meta.trace_id != $old' --arg old "$BASELINE_TRACE_ID")" == "true" ]]; }; then
+      HANDOFF_PASS=1
+      BASELINE_GENERATION="$(printf '%s' "$keeper_json" | jq -r '(.generation | tonumber?) // 0')"
+      BASELINE_HANDOFFS="$(printf '%s' "$keeper_json" | jq -r '(.handoff_count_total | tonumber?) // 0')"
+      BASELINE_TRACE_ID="$(printf '%s' "$keeper_json" | jq -r '.meta.trace_id // ""')"
+      record_campaign_event "$(jq -nc --argjson count "$BASELINE_HANDOFFS" --argjson generation "$BASELINE_GENERATION" --arg trace_id "$BASELINE_TRACE_ID" '{event:"handoff_observed",count:$count,generation:$generation,trace_id:$trace_id}')"
+      append_phase "handoff" "pass" "generation or trace evidence changed under campaign pressure" "$keeper_file" "$loop_file"
+    fi
+    if [[ $COMPACTION_PASS -eq 1 || $HANDOFF_PASS -eq 1 ]]; then
+      break
+    fi
+  done
+
+  if phase_enabled compaction && [[ $COMPACTION_PASS -eq 0 ]]; then
+    snapshot_info="$(capture_snapshot compaction-miss)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "compaction" "fail" "compaction evidence did not appear within the validation window" "$keeper_file" "$loop_file"
+  fi
+
+  if phase_enabled handoff && [[ $HANDOFF_PASS -eq 0 ]]; then
+    snapshot_info="$(capture_snapshot handoff-miss)"
+    keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+    loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+    append_phase "handoff" "fail" "handoff evidence did not appear within the validation window" "$keeper_file" "$loop_file"
+  fi
+
+  snapshot_info="$(capture_snapshot continuity)"
+  keeper_file="$(printf '%s' "$snapshot_info" | sed -n '1p')"
+  loop_file="$(printf '%s' "$snapshot_info" | sed -n '2p')"
+  keeper_json="$(cat "$keeper_file")"
+  loop_json="$(cat "$loop_file")"
+  if [[ "$(printf '%s' "$keeper_json" | jq -r '.goal // ""')" == "$BASELINE_GOAL" ]] \
+    && [[ "$(printf '%s' "$keeper_json" | jq -r '.meta.current_task_id // ""')" == "$BASELINE_TASK_ID" ]] \
+    && [[ "$(printf '%s' "$loop_json" | jq -r 'if (.target_reached // false) then "true" else "false" end')" == "true" ]] \
+    && [[ $COMPACTION_PASS -eq 1 || $HANDOFF_PASS -eq 1 ]]; then
+    CONTINUITY_PASS=1
+    record_campaign_event "$(jq -nc --arg task_id "$BASELINE_TASK_ID" '{event:"continuity_observed",goal_matches:true,current_task_id:$task_id}')"
+    append_phase "continuity" "pass" "goal/current_task lineage survived campaign pressure after target reach" "$keeper_file" "$loop_file"
+  else
+    if [[ $COMPACTION_PASS -eq 1 || $HANDOFF_PASS -eq 1 ]]; then
+      record_campaign_event "$(jq -nc \
+        --arg current_task_id "$(printf '%s' "$keeper_json" | jq -r '.meta.current_task_id // empty')" \
+        --argjson goal_matches "$( [[ "$(printf '%s' "$keeper_json" | jq -r '.goal // ""')" == "$BASELINE_GOAL" ]] && echo true || echo false )" \
+        '{event:"continuity_observed",goal_matches:$goal_matches,current_task_id:(if $current_task_id == "" then null else $current_task_id end)}')"
+    else
+      record_campaign_event "$(jq -nc '{event:"window_exhausted",reason:"continuity proof missing lifecycle evidence"}')"
+    fi
+    append_phase "continuity" "fail" "goal/current_task lineage was not preserved after pressure or no lifecycle event occurred" "$keeper_file" "$loop_file"
+  fi
+}
+
+main() {
+  if [[ "$(normalize_bool "$DRY_RUN")" == "1" ]]; then
+    run_dry_run
+    finalize_report
+    printf '%s\n' "$RUN_DIR/summary.json"
+    exit 0
+  fi
+
+  if real_run; then
+    finalize_report
+    printf '%s\n' "$RUN_DIR/summary.json"
+    exit "$VALIDATION_EXIT_CODE"
+  else
+    finalize_report
+    printf '%s\n' "$RUN_DIR/summary.json"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/scripts/harness_keeper_campaign.sh
+++ b/scripts/harness_keeper_campaign.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/keeper_campaign.sh" "$@"

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -14,7 +14,18 @@ JAVA_OPTS := -XX:+UseParallelGC -Xmx2g
 TLC_STOP  := 180
 TLC_FLAGS := -workers auto -cleanup
 
-TLA2TOOLS := keeper-state-machine/tla2tools.jar
+LOCAL_TLA2TOOLS := keeper-state-machine/tla2tools.jar
+HOME_TLA2TOOLS  := $(HOME)/.local/lib/tla/tla2tools-1.8.0.jar
+
+ifeq ($(origin TLA2TOOLS), undefined)
+  ifneq ($(wildcard $(LOCAL_TLA2TOOLS)),)
+    TLA2TOOLS := $(LOCAL_TLA2TOOLS)
+  else ifneq ($(wildcard $(HOME_TLA2TOOLS)),)
+    TLA2TOOLS := $(HOME_TLA2TOOLS)
+  else
+    TLA2TOOLS := $(LOCAL_TLA2TOOLS)
+  endif
+endif
 
 # Specs with known failures (parsing/evaluation errors under CI tla2tools).
 # Remove from this list as specs are fixed. Each entry is a basename (no .cfg).

--- a/specs/keeper-state-machine/KeeperCampaignLifecycle-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperCampaignLifecycle-buggy.cfg
@@ -1,0 +1,13 @@
+\* KeeperCampaignLifecycle — buggy specification
+\* Expected outcome: ContinuityRequiresEvidence MUST be violated.
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    MaxPressureObservations = 2
+
+CHECK_DEADLOCK
+    FALSE
+
+INVARIANTS
+    ContinuityRequiresEvidence

--- a/specs/keeper-state-machine/KeeperCampaignLifecycle.cfg
+++ b/specs/keeper-state-machine/KeeperCampaignLifecycle.cfg
@@ -1,0 +1,20 @@
+\* KeeperCampaignLifecycle — clean specification
+\* Expected: TLC exits 0 (no error)
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MaxPressureObservations = 2
+
+CHECK_DEADLOCK
+    FALSE
+
+INVARIANTS
+    NoSearchBeforeTaskBound
+    NoPressureBeforeTargetReached
+    ContinuityRequiresEvidence
+    TerminalStatesStable
+
+PROPERTIES
+    SearchingEventuallyTerminates
+    PressureEventuallyResolves

--- a/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
+++ b/specs/keeper-state-machine/KeeperCampaignLifecycle.tla
@@ -1,0 +1,224 @@
+---- MODULE KeeperCampaignLifecycle ----
+\* Keeper campaign sub-FSM — pure mission lifecycle for the keeper campaign harness.
+\*
+\* Mirrors: lib/keeper/keeper_campaign_fsm.ml
+\* Goal: prove that campaign verdicts come from a separate mission FSM, not from
+\* runtime keeper lifecycle phases.
+
+EXTENDS Naturals
+
+CONSTANTS MaxPressureObservations
+
+VARIABLES
+    phase,
+    taskBound,
+    searchStarted,
+    targetReached,
+    pressureStarted,
+    compactionCount,
+    handoffCount,
+    continuityGoalMatches,
+    continuityTaskMatches
+
+vars ==
+    << phase, taskBound, searchStarted, targetReached, pressureStarted,
+       compactionCount, handoffCount,
+       continuityGoalMatches, continuityTaskMatches >>
+
+Bootstrapping == "bootstrapping"
+ClaimingTask == "claiming_task"
+TaskBoundPhase == "task_bound"
+Searching == "searching"
+TargetReached == "target_reached"
+PressureTesting == "pressure_testing"
+ContinuityVerified == "continuity_verified"
+Stalled == "stalled"
+Escalated == "escalated"
+
+Terminal == {ContinuityVerified, Stalled, Escalated}
+
+Init ==
+    /\ phase = Bootstrapping
+    /\ taskBound = FALSE
+    /\ searchStarted = FALSE
+    /\ targetReached = FALSE
+    /\ pressureStarted = FALSE
+    /\ compactionCount = 0
+    /\ handoffCount = 0
+    /\ continuityGoalMatches = FALSE
+    /\ continuityTaskMatches = FALSE
+
+BootstrapOk ==
+    /\ phase = Bootstrapping
+    /\ phase' = ClaimingTask
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+TaskBoundObserved ==
+    /\ phase = ClaimingTask
+    /\ phase' = TaskBoundPhase
+    /\ taskBound' = TRUE
+    /\ UNCHANGED << searchStarted, targetReached, pressureStarted,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+AutoresearchStarted ==
+    /\ phase = TaskBoundPhase
+    /\ phase' = Searching
+    /\ searchStarted' = TRUE
+    /\ UNCHANGED << taskBound, targetReached, pressureStarted,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+TargetReachedObserved ==
+    /\ phase = Searching
+    /\ phase' = TargetReached
+    /\ targetReached' = TRUE
+    /\ UNCHANGED << taskBound, searchStarted, pressureStarted,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+PressureStartedObserved ==
+    /\ phase = TargetReached
+    /\ phase' = PressureTesting
+    /\ pressureStarted' = TRUE
+    /\ UNCHANGED << taskBound, searchStarted, targetReached,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+CompactionObserved ==
+    /\ phase = PressureTesting
+    /\ compactionCount + handoffCount < MaxPressureObservations
+    /\ phase' = phase
+    /\ compactionCount' = compactionCount + 1
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    handoffCount, continuityGoalMatches, continuityTaskMatches >>
+
+HandoffObserved ==
+    /\ phase = PressureTesting
+    /\ compactionCount + handoffCount < MaxPressureObservations
+    /\ phase' = phase
+    /\ handoffCount' = handoffCount + 1
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    compactionCount, continuityGoalMatches, continuityTaskMatches >>
+
+ContinuityObserved ==
+    /\ phase = PressureTesting
+    /\ targetReached
+    /\ compactionCount + handoffCount > 0
+    /\ phase' = ContinuityVerified
+    /\ continuityGoalMatches' = TRUE
+    /\ continuityTaskMatches' = TRUE
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    compactionCount, handoffCount >>
+
+WindowExhausted ==
+    /\ phase \in {ClaimingTask, TaskBoundPhase, Searching, PressureTesting}
+    /\ phase' = Stalled
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+ErrorObserved ==
+    /\ phase \notin Terminal
+    /\ phase' = Escalated
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    compactionCount, handoffCount,
+                    continuityGoalMatches, continuityTaskMatches >>
+
+Stutter ==
+    /\ phase \in Terminal
+    /\ UNCHANGED vars
+
+Next ==
+    \/ BootstrapOk
+    \/ TaskBoundObserved
+    \/ AutoresearchStarted
+    \/ TargetReachedObserved
+    \/ PressureStartedObserved
+    \/ CompactionObserved
+    \/ HandoffObserved
+    \/ ContinuityObserved
+    \/ WindowExhausted
+    \/ ErrorObserved
+    \/ Stutter
+
+BootstrapProgress ==
+    \/ BootstrapOk
+    \/ TaskBoundObserved
+    \/ AutoresearchStarted
+    \/ TargetReachedObserved
+    \/ PressureStartedObserved
+
+SearchResolution ==
+    \/ TargetReachedObserved
+    \/ WindowExhausted
+    \/ ErrorObserved
+
+PressureResolution ==
+    \/ ContinuityObserved
+    \/ WindowExhausted
+    \/ ErrorObserved
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(BootstrapProgress)
+    /\ WF_vars(SearchResolution)
+    /\ WF_vars(PressureResolution)
+
+\* Buggy model: continuity can be marked complete without lifecycle evidence
+\* or preserved goal/task lineage.
+ContinuityObservedBuggy ==
+    /\ phase = PressureTesting
+    /\ phase' = ContinuityVerified
+    /\ continuityGoalMatches' = FALSE
+    /\ continuityTaskMatches' = FALSE
+    /\ UNCHANGED << taskBound, searchStarted, targetReached, pressureStarted,
+                    compactionCount, handoffCount >>
+
+NextBuggy ==
+    \/ BootstrapOk
+    \/ TaskBoundObserved
+    \/ AutoresearchStarted
+    \/ TargetReachedObserved
+    \/ PressureStartedObserved
+    \/ CompactionObserved
+    \/ HandoffObserved
+    \/ ContinuityObservedBuggy
+    \/ WindowExhausted
+    \/ ErrorObserved
+    \/ Stutter
+
+SpecBuggy ==
+    /\ Init
+    /\ [][NextBuggy]_vars
+    /\ WF_vars(BootstrapProgress)
+    /\ WF_vars(SearchResolution)
+    /\ WF_vars(PressureResolution)
+
+NoSearchBeforeTaskBound ==
+    searchStarted => taskBound
+
+NoPressureBeforeTargetReached ==
+    pressureStarted => targetReached
+
+ContinuityRequiresEvidence ==
+    phase = ContinuityVerified =>
+      /\ targetReached
+      /\ compactionCount + handoffCount > 0
+      /\ continuityGoalMatches
+      /\ continuityTaskMatches
+
+TerminalStatesStable ==
+    phase \in Terminal =>
+      (phase = ContinuityVerified \/ phase = Stalled \/ phase = Escalated)
+
+SearchingEventuallyTerminates ==
+    [] (phase = Searching => <> (phase \in {TargetReached, Stalled, Escalated}))
+
+PressureEventuallyResolves ==
+    [] (phase = PressureTesting => <> (phase \in Terminal))
+
+====

--- a/test/dune
+++ b/test/dune
@@ -81,6 +81,7 @@
         test_tool_input_validation
         test_autoresearch_codegen
         test_autoresearch_oas_primitives
+        test_autoresearch_target_score
         ; test_contract_risk removed (team session cleanup)
         ; test_contract_composer removed (team session cleanup)
         test_cdal_conformance
@@ -104,6 +105,7 @@
         test_run_local_script
         test_tool_prefilter
         test_keeper_state_machine
+        test_keeper_campaign_fsm
         test_keeper_overflow_recovery
         test_telemetry_unified
         test_keeper_topk_llm
@@ -164,6 +166,7 @@
           test_tool_input_validation
           test_autoresearch_codegen
           test_autoresearch_oas_primitives
+          test_autoresearch_target_score
           ; test_contract_risk removed (team session cleanup)
           ; test_contract_composer removed (team session cleanup)
           test_cdal_conformance
@@ -187,6 +190,7 @@
           test_run_local_script
           test_tool_prefilter
           test_keeper_state_machine
+          test_keeper_campaign_fsm
           test_keeper_overflow_recovery
             test_telemetry_unified
           test_keeper_topk_llm

--- a/test/test_autoresearch_target_score.ml
+++ b/test/test_autoresearch_target_score.ml
@@ -1,0 +1,281 @@
+module Lib = Masc_mcp
+
+open Alcotest
+
+let () = Mirage_crypto_rng_unix.use_default ()
+
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let rec mkdir_p path =
+  if path = "" || path = "/" || Sys.file_exists path then ()
+  else begin
+    mkdir_p (Filename.dirname path);
+    Unix.mkdir path 0o755
+  end
+
+let write_file path contents =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+
+let with_temp_dir prefix f =
+  let dir = temp_dir prefix in
+  Fun.protect ~finally:(fun () -> cleanup_dir dir) (fun () -> f dir)
+
+let with_base_path root f =
+  let previous = Sys.getenv_opt "MASC_BASE_PATH" in
+  Unix.putenv "MASC_BASE_PATH" root;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv "MASC_BASE_PATH" value
+      | None -> Unix.putenv "MASC_BASE_PATH" "")
+    f
+
+let run_in_dir dir cmd =
+  let full = Printf.sprintf "cd %s && %s" (Filename.quote dir) cmd in
+  match Sys.command full with
+  | 0 -> ()
+  | code -> failf "command failed (%d): %s" code full
+
+let init_git_repo repo =
+  run_in_dir repo "git init -q";
+  run_in_dir repo "git config user.email 'test@example.com'";
+  run_in_dir repo "git config user.name 'Test User'";
+  write_file (Filename.concat repo "main.txt") "original\n";
+  run_in_dir repo "git add main.txt";
+  run_in_dir repo "git commit -q -m init"
+
+let clear_autoresearch_state () =
+  Lib.Autoresearch.with_loops_rw (fun () ->
+      Hashtbl.reset Lib.Autoresearch.active_loops;
+      Lib.Autoresearch.latest_loop_id := None);
+  Hashtbl.reset Lib.Tool_autoresearch_registry.pending_hypotheses;
+  Hashtbl.reset Lib.Tool_autoresearch_registry.custom_generators
+
+let with_clean_state f =
+  clear_autoresearch_state ();
+  Fun.protect ~finally:clear_autoresearch_state f
+
+let with_eio f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Process_eio.init
+    ~cwd_default:(Eio.Stdenv.cwd env)
+    ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    ~clock:(Eio.Stdenv.clock env);
+  Eio.Switch.run @@ fun sw ->
+  f ~sw ~clock:(Eio.Stdenv.clock env)
+
+let test_target_score_reaches_completion_higher_is_better () =
+  with_temp_dir "masc_autoresearch_target_high" @@ fun root ->
+  with_base_path root @@ fun () ->
+  with_eio @@ fun ~sw ~clock ->
+  with_clean_state @@ fun () ->
+  let repo = Filename.concat root "repo" in
+  Unix.mkdir repo 0o755;
+  init_git_repo repo;
+  run_in_dir repo "git checkout -q -b target-high";
+  write_file (Filename.concat repo "metric.py")
+    "import pathlib, sys\ntext = pathlib.Path(sys.argv[1]).read_text()\nprint(1.0 if 'GOAL_REACHED' in text else 0.0)\n";
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"Reach target marker"
+      ~metric_fn:"python3 metric.py main.txt"
+      ~model_model:"glm:test"
+      ~target_file:"main.txt"
+      ~target_score:1.0
+      ~cycle_timeout_s:5.0
+      ~max_cycles:3
+      ~workdir:repo
+      ()
+  in
+  let state = { state with baseline = 0.0; best_score = 0.0 } in
+  Lib.Autoresearch.with_loops_rw (fun () ->
+      Hashtbl.replace Lib.Autoresearch.active_loops state.loop_id state;
+      Lib.Autoresearch.latest_loop_id := Some state.loop_id);
+  let ctx : Lib.Tool_autoresearch_context.t =
+    {
+      base_path = root;
+      agent_name = Some "test";
+      start_operation = None;
+      config = None;
+      sw = Some sw;
+      clock = Some clock;
+    }
+  in
+  Lib.Tool_autoresearch_registry.set_generator state.loop_id
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_
+         ~target_file:_ ~file_content:_ ->
+       Ok ("flip marker", "GOAL_REACHED\n"));
+  let result =
+    Lib.Tool_autoresearch_cycle.handle_cycle ctx
+      (`Assoc [ ("loop_id", `String state.loop_id) ])
+  in
+  let open Yojson.Safe.Util in
+  check string "cycle status completed" "completed"
+    (result |> member "status" |> to_string);
+  check bool "target reached in result" true
+    (result |> member "target_reached" |> to_bool);
+  let final_state =
+    Lib.Autoresearch.with_loops_ro (fun () ->
+      match Hashtbl.find_opt Lib.Autoresearch.active_loops state.loop_id with
+      | Some s -> s
+      | None -> fail "loop missing after target completion")
+  in
+  check string "loop marked completed" "completed"
+    (Lib.Autoresearch.status_to_string final_state.status);
+  check bool "target reached in state" true
+    (Lib.Autoresearch.target_reached final_state)
+
+let test_target_score_reaches_completion_lower_is_better () =
+  with_temp_dir "masc_autoresearch_target_low" @@ fun root ->
+  with_base_path root @@ fun () ->
+  with_eio @@ fun ~sw ~clock ->
+  with_clean_state @@ fun () ->
+  let repo = Filename.concat root "repo" in
+  Unix.mkdir repo 0o755;
+  init_git_repo repo;
+  run_in_dir repo "git checkout -q -b target-low";
+  write_file (Filename.concat repo "metric.py")
+    "import pathlib, sys\ntext = pathlib.Path(sys.argv[1]).read_text()\nprint(0.5 if 'LOWER_WINS' in text else 2.0)\n";
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"Lower metric target"
+      ~metric_fn:"python3 metric.py main.txt"
+      ~model_model:"glm:test"
+      ~target_file:"main.txt"
+      ~target_score:1.0
+      ~cycle_timeout_s:5.0
+      ~max_cycles:3
+      ~lower_is_better:true
+      ~workdir:repo
+      ()
+  in
+  let state = { state with baseline = 2.0; best_score = 2.0 } in
+  Lib.Autoresearch.with_loops_rw (fun () ->
+      Hashtbl.replace Lib.Autoresearch.active_loops state.loop_id state;
+      Lib.Autoresearch.latest_loop_id := Some state.loop_id);
+  let ctx : Lib.Tool_autoresearch_context.t =
+    {
+      base_path = root;
+      agent_name = Some "test";
+      start_operation = None;
+      config = None;
+      sw = Some sw;
+      clock = Some clock;
+    }
+  in
+  Lib.Tool_autoresearch_registry.set_generator state.loop_id
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_
+         ~target_file:_ ~file_content:_ ->
+       Ok ("lower wins", "LOWER_WINS\n"));
+  let result =
+    Lib.Tool_autoresearch_cycle.handle_cycle ctx
+      (`Assoc [ ("loop_id", `String state.loop_id) ])
+  in
+  let open Yojson.Safe.Util in
+  check string "cycle status completed" "completed"
+    (result |> member "status" |> to_string);
+  check bool "target reached in result" true
+    (result |> member "target_reached" |> to_bool);
+  let final_state =
+    Lib.Autoresearch.with_loops_ro (fun () ->
+      match Hashtbl.find_opt Lib.Autoresearch.active_loops state.loop_id with
+      | Some s -> s
+      | None -> fail "loop missing after lower target completion")
+  in
+  check string "loop marked completed" "completed"
+    (Lib.Autoresearch.status_to_string final_state.status);
+  check bool "target reached in state" true
+    (Lib.Autoresearch.target_reached final_state)
+
+let test_omitted_target_score_preserves_running_status () =
+  with_temp_dir "masc_autoresearch_target_none" @@ fun root ->
+  with_base_path root @@ fun () ->
+  with_eio @@ fun ~sw ~clock ->
+  with_clean_state @@ fun () ->
+  let repo = Filename.concat root "repo" in
+  Unix.mkdir repo 0o755;
+  init_git_repo repo;
+  run_in_dir repo "git checkout -q -b target-none";
+  write_file (Filename.concat repo "metric.py")
+    "import pathlib, sys\ntext = pathlib.Path(sys.argv[1]).read_text()\nprint(1.0 if 'GOAL_REACHED' in text else 0.0)\n";
+  let state =
+    Lib.Autoresearch.create_state
+      ~goal:"Improve but stay running"
+      ~metric_fn:"python3 metric.py main.txt"
+      ~model_model:"glm:test"
+      ~target_file:"main.txt"
+      ~cycle_timeout_s:5.0
+      ~max_cycles:3
+      ~workdir:repo
+      ()
+  in
+  let state = { state with baseline = 0.0; best_score = 0.0 } in
+  Lib.Autoresearch.with_loops_rw (fun () ->
+      Hashtbl.replace Lib.Autoresearch.active_loops state.loop_id state;
+      Lib.Autoresearch.latest_loop_id := Some state.loop_id);
+  let ctx : Lib.Tool_autoresearch_context.t =
+    {
+      base_path = root;
+      agent_name = Some "test";
+      start_operation = None;
+      config = None;
+      sw = Some sw;
+      clock = Some clock;
+    }
+  in
+  Lib.Tool_autoresearch_registry.set_generator state.loop_id
+    (fun ~goal:_ ~baseline:_ ~lower_is_better:_ ~history:_ ~insights:_
+         ~target_file:_ ~file_content:_ ->
+       Ok ("flip marker", "GOAL_REACHED\n"));
+  let result =
+    Lib.Tool_autoresearch_cycle.handle_cycle ctx
+      (`Assoc [ ("loop_id", `String state.loop_id) ])
+  in
+  let open Yojson.Safe.Util in
+  check string "cycle status remains running" "running"
+    (result |> member "status" |> to_string);
+  check bool "target not reported reached" false
+    (result |> member "target_reached" |> to_bool);
+  let final_state =
+    Lib.Autoresearch.with_loops_ro (fun () ->
+      match Hashtbl.find_opt Lib.Autoresearch.active_loops state.loop_id with
+      | Some s -> s
+      | None -> fail "loop missing after running cycle")
+  in
+  check string "loop remains running" "running"
+    (Lib.Autoresearch.status_to_string final_state.status)
+
+let () =
+  run "autoresearch_target_score"
+    [
+      ( "target_score",
+        [
+          test_case "target score completes higher-is-better loop" `Quick
+            test_target_score_reaches_completion_higher_is_better;
+          test_case "target score completes lower-is-better loop" `Quick
+            test_target_score_reaches_completion_lower_is_better;
+          test_case "omitted target score preserves running status" `Quick
+            test_omitted_target_score_preserves_running_status;
+        ] );
+    ]

--- a/test/test_harness_shell_helpers.ml
+++ b/test/test_harness_shell_helpers.ml
@@ -114,6 +114,81 @@ let test_mcp_jsonrpc_temp_helper () =
       | lines ->
         failf "unexpected helper output:\n%s" (String.concat "\n" lines))
 
+let test_keeper_campaign_harness_dry_run () =
+  with_temp_dir "keeper-campaign-dry-run" (fun dir ->
+      let script =
+        Filename.concat (source_root ()) "scripts/harness_keeper_campaign.sh"
+      in
+      let run_dir = Filename.concat dir "artifacts" in
+      let code, _stdout, stderr =
+        run_bash ~cwd:(source_root ())
+          (Printf.sprintf
+             "DRY_RUN=1 START_SERVER=0 RUN_DIR=%s %s"
+             (quote run_dir) (quote script))
+      in
+      if code <> 0 then
+        failf "keeper campaign dry run failed (%d): %s" code stderr;
+      let summary_path = Filename.concat run_dir "summary.json" in
+      let manifest_path = Filename.concat run_dir "manifest.json" in
+      let campaign_state_path = Filename.concat run_dir "campaign-state.json" in
+      let campaign_events_path = Filename.concat run_dir "campaign-events.jsonl" in
+      check bool "summary.json exists" true (Sys.file_exists summary_path);
+      check bool "manifest.json exists" true (Sys.file_exists manifest_path);
+      check bool "campaign-state.json exists" true (Sys.file_exists campaign_state_path);
+      check bool "campaign-events.jsonl exists" true (Sys.file_exists campaign_events_path);
+      let summary = read_file summary_path in
+      let campaign_state = read_file campaign_state_path in
+      check bool "classification present" true
+        (contains_substring summary "\"classification\": \"DRY_RUN\"");
+      check bool "verdict present" true
+        (contains_substring summary "\"verdict\": \"reached\"");
+      check bool "campaign phase present" true
+        (contains_substring summary "\"campaign_phase\": \"continuity_verified\"");
+      check bool "target reached present" true
+        (contains_substring summary "\"target_reached\": true");
+      check bool "campaign state verdict present" true
+        (contains_substring campaign_state "\"verdict\": \"reached\""))
+
+let test_keeper_campaign_cli_replay () =
+  with_temp_dir "keeper-campaign-cli" (fun dir ->
+      let exe =
+        Filename.concat (source_root ()) "_build/default/bin/keeper_campaign_fsm.exe"
+      in
+      let events_path = Filename.concat dir "events.jsonl" in
+      let output_path = Filename.concat dir "state.json" in
+      let events =
+        String.concat "\n"
+          [
+            {|{"event":"bootstrap_ok","goal":"cli replay goal"}|};
+            {|{"event":"task_bound_observed","task_id":"task-001","current_task_id":"task-001"}|};
+            {|{"event":"autoresearch_started","loop_id":"ar-001","target_score":1.0}|};
+            {|{"event":"target_reached"}|};
+            {|{"event":"pressure_started"}|};
+            {|{"event":"handoff_observed","count":1,"generation":2,"trace_id":"trace-2"}|};
+            {|{"event":"continuity_observed","goal_matches":true,"current_task_id":"task-001"}|};
+            "";
+          ]
+      in
+      let oc = open_out events_path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc events);
+      let code, stdout, stderr =
+        run_bash ~cwd:(source_root ())
+          (Printf.sprintf "%s replay %s %s"
+             (quote exe) (quote events_path) (quote output_path))
+      in
+      if code <> 0 then
+        failf "keeper campaign replay failed (%d): %s" code stderr;
+      check bool "state output exists" true (Sys.file_exists output_path);
+      let output = read_file output_path in
+      check bool "stdout verdict present" true
+        (contains_substring stdout "\"verdict\": \"reached\"");
+      check bool "file verdict present" true
+        (contains_substring output "\"verdict\": \"reached\"");
+      check bool "continuity phase present" true
+        (contains_substring output "\"phase\": \"continuity_verified\""))
+
 let () =
   run "harness_shell_helpers"
     [
@@ -123,5 +198,9 @@ let () =
             test_server_bootstrap_temp_helpers;
           test_case "mcp jsonrpc temp helper" `Quick
             test_mcp_jsonrpc_temp_helper;
+          test_case "keeper campaign dry run" `Quick
+            test_keeper_campaign_harness_dry_run;
+          test_case "keeper campaign cli replay" `Quick
+            test_keeper_campaign_cli_replay;
         ] );
     ]

--- a/test/test_keeper_campaign_fsm.ml
+++ b/test/test_keeper_campaign_fsm.ml
@@ -1,0 +1,170 @@
+open Alcotest
+
+module Fsm = Masc_mcp.Keeper_campaign_fsm
+module Json = Yojson.Safe.Util
+
+let phase_t = testable (Fmt.of_to_string Fsm.phase_to_string) ( = )
+
+let apply_ok snapshot event =
+  match Fsm.apply_event snapshot event with
+  | Ok snapshot -> snapshot
+  | Error msg -> fail msg
+
+let apply_err snapshot event =
+  match Fsm.apply_event snapshot event with
+  | Ok snapshot ->
+    failf "expected transition failure, got %s"
+      (Fsm.phase_to_string snapshot.phase)
+  | Error msg -> msg
+
+let reached_events =
+  [
+    Fsm.Bootstrap_ok { goal = "reach target" };
+    Fsm.Task_bound_observed
+      { task_id = "task-001"; current_task_id = "task-001" };
+    Fsm.Autoresearch_started
+      { loop_id = "ar-001"; target_score = Some 1.0 };
+    Fsm.Target_reached_event;
+    Fsm.Pressure_started;
+    Fsm.Compaction_observed { count = 1 };
+    Fsm.Continuity_observed
+      { goal_matches = true; current_task_id = Some "task-001" };
+  ]
+
+let test_replay_reached () =
+  match Fsm.replay reached_events with
+  | Error msg -> fail msg
+  | Ok snapshot ->
+    check phase_t "terminal reached" Fsm.Continuity_verified snapshot.phase;
+    check (option string) "verdict" (Some "reached")
+      (Fsm.verdict_of_phase snapshot.phase);
+    check bool "target_reached" true snapshot.target_reached;
+    check int "compaction count" 1 snapshot.compaction_count
+
+let test_replay_stalled () =
+  let events =
+    [
+      Fsm.Bootstrap_ok { goal = "reach target" };
+      Fsm.Task_bound_observed
+        { task_id = "task-001"; current_task_id = "task-001" };
+      Fsm.Autoresearch_started
+        { loop_id = "ar-001"; target_score = Some 1.0 };
+      Fsm.Window_exhausted { reason = "autoresearch timeout" };
+    ]
+  in
+  match Fsm.replay events with
+  | Error msg -> fail msg
+  | Ok snapshot ->
+    check phase_t "terminal stalled" Fsm.Stalled snapshot.phase;
+    check (option string) "verdict" (Some "stalled")
+      (Fsm.verdict_of_phase snapshot.phase);
+    check (option string) "reason" (Some "autoresearch timeout") snapshot.reason
+
+let test_replay_escalated_on_continuity_loss () =
+  let events =
+    [
+      Fsm.Bootstrap_ok { goal = "reach target" };
+      Fsm.Task_bound_observed
+        { task_id = "task-001"; current_task_id = "task-001" };
+      Fsm.Autoresearch_started
+        { loop_id = "ar-001"; target_score = Some 1.0 };
+      Fsm.Target_reached_event;
+      Fsm.Pressure_started;
+      Fsm.Handoff_observed { count = 1; generation = Some 2; trace_id = Some "trace-2" };
+      Fsm.Continuity_observed
+        { goal_matches = false; current_task_id = Some "task-002" };
+    ]
+  in
+  match Fsm.replay events with
+  | Error msg -> fail msg
+  | Ok snapshot ->
+    check phase_t "terminal escalated" Fsm.Escalated snapshot.phase;
+    check (option string) "verdict" (Some "escalated")
+      (Fsm.verdict_of_phase snapshot.phase);
+    check bool "goal mismatch stored" true
+      (snapshot.continuity_goal_matches = Some false);
+    check bool "task mismatch stored" true
+      (snapshot.continuity_task_matches = Some false)
+
+let test_invalid_pressure_before_target () =
+  let snapshot =
+    apply_ok Fsm.initial (Fsm.Bootstrap_ok { goal = "reach target" })
+    |> fun snapshot ->
+    apply_ok snapshot
+      (Fsm.Task_bound_observed
+         { task_id = "task-001"; current_task_id = "task-001" })
+    |> fun snapshot ->
+    apply_ok snapshot
+      (Fsm.Autoresearch_started
+         { loop_id = "ar-001"; target_score = Some 1.0 })
+  in
+  let err = apply_err snapshot Fsm.Pressure_started in
+  check bool "pressure rejected before target"
+    true (String.length err > 0)
+
+let test_event_json_roundtrip () =
+  let event =
+    Fsm.Handoff_observed
+      { count = 2; generation = Some 3; trace_id = Some "trace-3" }
+  in
+  match Fsm.event_of_yojson_result (Fsm.event_to_yojson event) with
+  | Error msg -> fail msg
+  | Ok decoded ->
+    check string "event name"
+      (Fsm.event_to_string event) (Fsm.event_to_string decoded)
+
+let test_terminal_phase_is_absorbing () =
+  let snapshot =
+    match Fsm.replay reached_events with
+    | Ok snapshot -> snapshot
+    | Error msg -> fail msg
+  in
+  let err =
+    apply_err snapshot
+      (Fsm.Error_observed { reason = "should not be accepted" })
+  in
+  check bool "terminal rejected"
+    true (String.length err > 0)
+
+let test_snapshot_json_exposes_terminal_verdict () =
+  let terminal =
+    match Fsm.replay reached_events with
+    | Ok snapshot -> snapshot
+    | Error msg -> fail msg
+  in
+  let searching =
+    apply_ok Fsm.initial (Fsm.Bootstrap_ok { goal = "reach target" })
+    |> fun snapshot ->
+    apply_ok snapshot
+      (Fsm.Task_bound_observed
+         { task_id = "task-001"; current_task_id = "task-001" })
+    |> fun snapshot ->
+    apply_ok snapshot
+      (Fsm.Autoresearch_started
+         { loop_id = "ar-001"; target_score = Some 1.0 })
+  in
+  let terminal_json = Fsm.snapshot_to_yojson terminal in
+  let searching_json = Fsm.snapshot_to_yojson searching in
+  check (option string) "terminal verdict present" (Some "reached")
+    (Json.member "verdict" terminal_json |> Json.to_string_option);
+  check (option string) "non-terminal verdict omitted" None
+    (Json.member "verdict" searching_json |> Json.to_string_option)
+
+let () =
+  run "keeper_campaign_fsm"
+    [
+      ( "campaign",
+        [
+          test_case "replay reached path" `Quick test_replay_reached;
+          test_case "replay stalled path" `Quick test_replay_stalled;
+          test_case "replay escalated on continuity loss" `Quick
+            test_replay_escalated_on_continuity_loss;
+          test_case "invalid pressure before target" `Quick
+            test_invalid_pressure_before_target;
+          test_case "event json roundtrip" `Quick test_event_json_roundtrip;
+          test_case "terminal phase is absorbing" `Quick
+            test_terminal_phase_is_absorbing;
+          test_case "snapshot json exposes terminal verdict" `Quick
+            test_snapshot_json_exposes_terminal_verdict;
+        ] );
+    ]


### PR DESCRIPTION
## What changed

- added a keeper-only `Keeper_campaign_fsm` sub-FSM plus a replay CLI for campaign event logs
- wired the keeper campaign harness to emit `campaign-events.jsonl` and derive `campaign-state.json`/verdicts from FSM replay instead of shell-only heuristics
- extended autoresearch with `target_score` / `target_reached` so the harness can machine-check goal completion
- added design docs and a TLA+ spec pair for the campaign lifecycle, plus Makefile fallback for `tla2tools.jar` lookup in worktrees
- added focused tests for FSM behavior, CLI replay, shell dry-run artifacts, and autoresearch threshold handling
- adapted keeper rerank callsites to the current single-provider `Tool_selector.default_rerank_fn` API

## Why

The repo already had keeper lifecycle machinery, compaction/handoff continuity, and autoresearch primitives, but it did not have a machine-checkable mission model for a long-running keeper campaign. The harness could exercise pieces of the flow, but there was no explicit keeper-only campaign FSM or end-to-end replayable verdict source.

## Impact

- keeper campaign validation is now modeled as an orthogonal mission FSM instead of being mixed into the runtime keeper lifecycle
- harness artifacts are stronger: operators can inspect both the human-readable phase log and the canonical campaign replay state
- campaign verdicts (`reached` / `stalled` / `escalated`) are now replay-derived and testable

## Validation

- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/keeper-campaign-harness _build/default/test/test_keeper_campaign_fsm.exe _build/default/test/test_harness_shell_helpers.exe _build/default/bin/keeper_campaign_fsm.exe`
- `./_build/default/test/test_keeper_campaign_fsm.exe`
- `./_build/default/test/test_harness_shell_helpers.exe`
- `make -C specs --no-print-directory CLEAN_CFGS='keeper-state-machine/KeeperCampaignLifecycle.cfg' BUGGY_CFGS='keeper-state-machine/KeeperCampaignLifecycle-buggy.cfg' check-all`
