### PR TITLE
refactor(cascade): migrate 21 call sites to local Cascade_* (PR 4d-migrate)

### DIFF
--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -116,7 +116,7 @@ let has_background_capacity () =
   | Some sw, Some net -> (
       try
         let capacity =
-          Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+          Cascade_config.local_capacity_for_selections ~sw ~net
             [ "autoresearch" ]
         in
         not

--- a/lib/cascade_inference.ml
+++ b/lib/cascade_inference.ml
@@ -20,7 +20,7 @@ type t = {
 let empty = { temperature = None; max_tokens = None }
 
 (** Convert OAS inference_params to MASC t. *)
-let of_oas (p : Llm_provider.Cascade_config.inference_params) : t =
+let of_oas (p : Cascade_config.inference_params) : t =
   { temperature = p.temperature; max_tokens = p.max_tokens }
 
 (** Extract inference parameters from a parsed JSON value for a named cascade.
@@ -55,7 +55,7 @@ let for_cascade ~(name : string) : t =
   match Oas_worker.default_config_path () with
   | None -> empty
   | Some config_path ->
-      (try of_oas (Llm_provider.Cascade_config.resolve_inference_params ~config_path ~name)
+      (try of_oas (Cascade_config.resolve_inference_params ~config_path ~name)
        with Eio.Cancel.Cancelled _ as e -> raise e
           | exn ->
             Log.warn ~ctx:"cascade"

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -348,7 +348,7 @@ let append_judgments base_path judgments =
 let should_backoff ~sw ~net =
   try
     let capacity =
-      Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+      Cascade_config.local_capacity_for_selections ~sw ~net
         [ "governance_judge" ]
     in
     capacity.all_discovered && capacity.endpoints_found > 0

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -404,7 +404,7 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 (let effective_models =
                    Oas_model_resolve.models_of_cascade_name m.cascade_name
                  in
-                 let cfgs = Llm_provider.Cascade_config.parse_model_strings effective_models in
+                 let cfgs = Cascade_config.parse_model_strings effective_models in
                  match cfgs with
                  | [] when effective_models <> [] ->
                      `Assoc [("has_checkpoint", `Bool false)]

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -259,7 +259,7 @@ let compute_judgments
 let should_backoff ~sw ~net =
   try
     let capacity =
-      Llm_provider.Cascade_config.local_capacity_for_selections ~sw ~net
+      Cascade_config.local_capacity_for_selections ~sw ~net
         [ "operator_judge" ]
     in
     capacity.all_discovered && capacity.endpoints_found > 0

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -1,7 +1,7 @@
 (** Dashboard projection for cascade configuration and runtime health. *)
 
-module CC = Llm_provider.Cascade_config
-module Health = Llm_provider.Cascade_health_tracker
+module CC = Cascade_config
+module Health = Cascade_health_tracker
 
 (* ── Shared helpers ─────────────────────────────────── *)
 

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -1,7 +1,7 @@
 (** Dashboard projection for cascade configuration and runtime health.
 
     Exposes the current cascade.json profiles (raw JSON, parsed with weights)
-    alongside the live {!Llm_provider.Cascade_health_tracker.global} snapshot
+    alongside the live {!Cascade_health_tracker.global} snapshot
     so operators can see *why* a given provider is preferred without
     re-running a turn.
 

--- a/lib/dashboard_provider_runs.ml
+++ b/lib/dashboard_provider_runs.ml
@@ -376,7 +376,7 @@ let resolve_provider_run_request ~provider ~model_opt ~prompt =
 
 (** Check if a model label is runnable (has provider config + auth). *)
 let is_label_runnable (label : string) : bool =
-  match Llm_provider.Cascade_config.parse_model_string label with
+  match Cascade_config.parse_model_string label with
   | None -> false
   | Some _cfg ->
     (* Extract provider prefix from label and check auth detail *)
@@ -401,7 +401,7 @@ let execute_single_agent_run ~sw ~net ~run_id ~provider ~model ~prompt =
         "single-agent run resolved run_id=%s provider=%s requested_model=%s model_label=%s"
         run_id provider model label;
       (* Validate label parses *)
-      match Llm_provider.Cascade_config.parse_model_string label with
+      match Cascade_config.parse_model_string label with
       | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
       | Some _cfg ->
         if not (is_label_runnable label) then

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1217,15 +1217,15 @@ let run_turn
                           single-provider rerank API. Graceful degradation via
                           BM25 fallback lives inside [default_rerank_fn]. *)
                        let model_strings =
-                         Llm_provider.Cascade_config.resolve_model_strings
+                         Cascade_config.resolve_model_strings
                            ?config_path ~name:rerank_cascade ~defaults ()
-                         |> Llm_provider.Cascade_config.expand_model_strings_for_execution
+                         |> Cascade_config.expand_model_strings_for_execution
                        in
                        let providers =
-                         Llm_provider.Cascade_config.parse_model_strings model_strings
+                         Cascade_config.parse_model_strings model_strings
                        in
                        let healthy =
-                         Llm_provider.Cascade_config.filter_healthy ~sw ~net providers
+                         Cascade_config.filter_healthy ~sw ~net providers
                        in
                        (match healthy with
                         | [] ->

--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -111,7 +111,7 @@ let compact_if_needed
           | _ :: _ as explicit -> explicit
           | [] -> Oas_model_resolve.models_of_cascade_name meta.cascade_name
         in
-        let primary_id = match Llm_provider.Cascade_config.parse_model_strings model_labels with
+        let primary_id = match Cascade_config.parse_model_strings model_labels with
           | c :: _ -> c.Llm_provider.Provider_config.model_id | [] -> "auto" in
         Llm_provider.Model_meta.for_model_id primary_id
       in

--- a/lib/keeper/keeper_exec_context.ml
+++ b/lib/keeper/keeper_exec_context.ml
@@ -211,7 +211,7 @@ let effective_model_labels_for_turn (m : keeper_meta) : string list =
   let configured = Keeper_model_labels.configured_model_labels_of_meta m in
   let configured_ids =
     try
-      Llm_provider.Cascade_config.parse_model_strings configured
+      Cascade_config.parse_model_strings configured
       |> List.map (fun (c : Llm_provider.Provider_config.t) -> String.trim c.model_id)
     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> []
   in

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -532,7 +532,7 @@ let handle_keeper_status ctx args : tool_result =
          in
 
          let models_resolved = `List (List.filter_map (fun label ->
-           match Llm_provider.Cascade_config.parse_model_string label with
+           match Cascade_config.parse_model_string label with
            | None -> None
            | Some cfg ->
              let pricing = Llm_provider.Pricing.pricing_for_model cfg.model_id in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -35,7 +35,7 @@ let resolved_model_id_for_result ~(meta : keeper_meta)
   let cascade_models =
     Keeper_model_labels.configured_model_labels_of_meta meta
   in
-  let cfgs = Llm_provider.Cascade_config.parse_model_strings cascade_models in
+  let cfgs = Cascade_config.parse_model_strings cascade_models in
   match
     List.find_opt
       (fun (c : Llm_provider.Provider_config.t) ->

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -388,7 +388,7 @@ let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir 
     Returns Error when the label cannot be parsed. *)
 let oas_provider_of_label (label : string) :
     (Oas.Provider.config, string) result =
-  match Llm_provider.Cascade_config.parse_model_string label with
+  match Cascade_config.parse_model_string label with
   | Some pc -> Ok (Oas.Provider.config_of_provider_config pc)
   | None ->
     let msg = Printf.sprintf "Cannot parse model label: %S (expected provider:model)" label in
@@ -399,7 +399,7 @@ let oas_provider_of_label (label : string) :
     Returns the provider config and model_id on success. *)
 let resolve_oas_provider_of_label (label : string) :
     (Oas.Provider.config * string, string) result =
-  match Llm_provider.Cascade_config.parse_model_string label with
+  match Cascade_config.parse_model_string label with
   | None -> Error (Printf.sprintf "Cannot parse model: %s" label)
   | Some pc ->
     Ok

--- a/lib/oas_model_resolve.ml
+++ b/lib/oas_model_resolve.ml
@@ -1,7 +1,7 @@
 (** OAS model label resolution — resolve model labels to max_context and
     API key availability via OAS Cascade_config and Provider_registry.
 
-    Context resolution delegates to OAS {!Llm_provider.Cascade_config.resolve_label_context}
+    Context resolution delegates to OAS {!Cascade_config.resolve_label_context}
     which uses the same routing logic as cascade execution.
     API key availability is checked via {!Llm_provider.Provider_registry}.
     MASC does NOT guess routing — OAS owns resolution end-to-end.
@@ -82,12 +82,12 @@ let effective_discovered_ctx ~static_ctx ~(discovered : int option) : int =
   | _ -> static_ctx
 
 (** Resolve max_context for a model label.
-    Delegates routing to OAS {!Llm_provider.Cascade_config.resolve_label_context} —
+    Delegates routing to OAS {!Cascade_config.resolve_label_context} —
     MASC does not guess which endpoint serves the request.  Discovered
     values below {!context_floor} fall back to the static registry.
 
     Resolution chain:
-    1. OAS {!Llm_provider.Cascade_config.resolve_label_context} (model-aware
+    1. OAS {!Cascade_config.resolve_label_context} (model-aware
        endpoint lookup for local providers, round-robin fallback).
     2. Apply {!context_floor} guard on the discovered value.
     3. If OAS returns [None], use static registry entry's [max_context].
@@ -101,7 +101,7 @@ let max_context_of_label (label : string) : int =
       | Some entry -> entry.max_context
       | None -> fallback_context_window
   in
-  match Llm_provider.Cascade_config.resolve_label_context label with
+  match Cascade_config.resolve_label_context label with
   | Some ctx -> effective_discovered_ctx ~static_ctx ~discovered:(Some ctx)
   | None -> static_ctx
 
@@ -118,7 +118,7 @@ let context_if_available (label : string) : int option =
       if entry.is_available () then
         let static_ctx = entry.max_context in
         let ctx =
-          match Llm_provider.Cascade_config.resolve_label_context label with
+          match Cascade_config.resolve_label_context label with
           | Some discovered -> effective_discovered_ctx ~static_ctx ~discovered:(Some discovered)
           | None -> static_ctx
         in
@@ -290,7 +290,7 @@ let models_of_cascade_name (cascade_name : string) : string list =
      the first call and Eio.Mutex.Poisoned on subsequent calls.
      Fall back to defaults in both cases. *)
   try
-    Llm_provider.Cascade_config.resolve_model_strings
+    Cascade_config.resolve_model_strings
       ?config_path
       ~name:cascade_name
       ~defaults

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -124,7 +124,7 @@ let proof_result_status_to_string status =
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)
 let resolve_provider_of_label (label : string) : Oas.Provider.config =
-  match Llm_provider.Cascade_config.parse_model_string label with
+  match Cascade_config.parse_model_string label with
   | Some pc -> Oas.Provider.config_of_provider_config pc
   | None ->
       Log.error ~ctx:"oas_worker_exec"

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -90,23 +90,23 @@ let resolve_cascade_providers ~cascade_name : Llm_provider.Provider_config.t lis
   let defaults = default_model_strings ~cascade_name in
   let config_path = default_config_path () in
   let configured =
-    Llm_provider.Cascade_config.resolve_model_strings
+    Cascade_config.resolve_model_strings
       ?config_path ~name:cascade_name ~defaults ()
   in
-  let specs = Llm_provider.Cascade_config.parse_model_strings configured in
+  let specs = Cascade_config.parse_model_strings configured in
   if specs <> [] then specs
   else if configured = defaults then (
       Log.Misc.warn "cascade %s: no callable models from built-in defaults" cascade_name;
       [])
     else (
       Log.Misc.warn "cascade %s: configured models unavailable — retrying built-in defaults" cascade_name;
-      Llm_provider.Cascade_config.parse_model_strings defaults)
+      Cascade_config.parse_model_strings defaults)
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC passes strings through without interpretation — OAS parses them. *)
 let resolve_providers_from_model_strings (model_strings : string list)
     : Llm_provider.Provider_config.t list =
-  let specs = Llm_provider.Cascade_config.parse_model_strings model_strings in
+  let specs = Cascade_config.parse_model_strings model_strings in
   if specs <> [] then specs
   else (
     Log.Misc.warn "direct model strings: no callable models from %d entries"
@@ -170,7 +170,7 @@ let config_for_label
     cascadeable (a different provider may succeed).  Structural agent
     errors (budget, idle, exit) are not — they would recur on any model. *)
 let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
-    : Llm_provider.Cascade_fsm.provider_outcome option =
+    : Cascade_fsm.provider_outcome option =
   match err with
   | Oas.Error.Api api_err ->
     let http_err = match api_err with
@@ -190,17 +190,17 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
       | Llm_provider.Retry.Timeout { message } ->
         Llm_provider.Http_client.NetworkError { message }
     in
-    Some (Llm_provider.Cascade_fsm.Call_err http_err)
+    Some (Cascade_fsm.Call_err http_err)
   (* Model-capability errors: the next provider may handle these.
      CompletionContractViolation: model returned text when tool_use was
      required — a different model with better tool calling may succeed.
      UnrecognizedStopReason: model returned a non-standard stop reason
      that this provider does not map — another provider may not. *)
   | Oas.Error.Agent (Oas.Error.CompletionContractViolation { reason; _ }) ->
-    Some (Llm_provider.Cascade_fsm.Call_err
+    Some (Cascade_fsm.Call_err
       (Llm_provider.Http_client.AcceptRejected { reason }))
   | Oas.Error.Agent (Oas.Error.UnrecognizedStopReason { reason }) ->
-    Some (Llm_provider.Cascade_fsm.Call_err
+    Some (Cascade_fsm.Call_err
       (Llm_provider.Http_client.AcceptRejected { reason }))
   | _ -> None
 
@@ -279,7 +279,7 @@ let run_named
       (* Legacy path: resolve from cascade.json by name *)
       let defaults = default_model_strings ~cascade_name in
       let labels =
-        Llm_provider.Cascade_config.resolve_model_strings
+        Cascade_config.resolve_model_strings
           ?config_path ~name:cascade_name ~defaults ()
       in
       (labels, resolve_cascade_providers ~cascade_name)
@@ -402,10 +402,10 @@ let run_named
       | Ok result ->
         (* FSM: Accept_rejected → decide *)
         let reason = Printf.sprintf "response rejected by accept (model=%s)" result.response.model in
-        let outcome = Llm_provider.Cascade_fsm.Accept_rejected
+        let outcome = Cascade_fsm.Accept_rejected
           { response = result.response; reason } in
-        (match Llm_provider.Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
-         | Llm_provider.Cascade_fsm.Accept_on_exhaustion { response; _ } ->
+        (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
+         | Cascade_fsm.Accept_on_exhaustion { response; _ } ->
            let observation =
              Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some response.model) ~capture
@@ -413,11 +413,11 @@ let run_named
            let result = { result with cascade_observation = Some observation } in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
            Ok result
-         | Llm_provider.Cascade_fsm.Try_next { last_err = new_err } ->
+         | Cascade_fsm.Try_next { last_err = new_err } ->
            Log.Misc.warn "cascade %s: accept rejected %s (%s), trying next" cascade_name provider_cfg.model_id reason;
            metrics.on_cascade_fallback ~from_model:provider_cfg.model_id ~to_model:"next" ~reason;
            try_cascade ?resume_checkpoint:next_resume rest new_err
-         | Llm_provider.Cascade_fsm.Exhausted _ ->
+         | Cascade_fsm.Exhausted _ ->
            let observation =
              Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model) ~capture
@@ -425,7 +425,7 @@ let run_named
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Rejected ~observation:(Some observation);
            Error (Oas.Error.Internal
              (Printf.sprintf "cascade %s: %s" cascade_name reason))
-         | Llm_provider.Cascade_fsm.Accept resp ->
+         | Cascade_fsm.Accept resp ->
            (* Should be unreachable with accept_on_exhaustion:false, but handle gracefully *)
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (model=%s)" cascade_name resp.model;
            let observation =
@@ -439,13 +439,13 @@ let run_named
         (* FSM: Call_err → decide *)
         (match sdk_error_to_cascade_outcome sdk_err with
          | Some outcome ->
-           (match Llm_provider.Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
-            | Llm_provider.Cascade_fsm.Try_next { last_err = new_err } ->
+           (match Cascade_fsm.decide ~accept_on_exhaustion:false ~is_last outcome with
+            | Cascade_fsm.Try_next { last_err = new_err } ->
               Log.Misc.warn "cascade %s: %s failed (%s), trying next" cascade_name provider_cfg.model_id (Oas.Error.to_string sdk_err);
               metrics.on_cascade_fallback ~from_model:provider_cfg.model_id ~to_model:"next"
                 ~reason:(Oas.Error.to_string sdk_err);
               try_cascade ?resume_checkpoint:next_resume rest new_err
-            | Llm_provider.Cascade_fsm.Exhausted _ ->
+            | Cascade_fsm.Exhausted _ ->
               let observation =
                 Oas_worker_cascade.cascade_observation_with_metrics ~cascade_name ~configured_labels
                   ~candidate_cfgs ~selected_model_raw:None ~capture
@@ -500,7 +500,7 @@ let run_model_by_label
     ?net
     ()
   : (Oas_worker_exec.run_result, Oas.Error.sdk_error) result =
-  (match Llm_provider.Cascade_config.parse_model_string model_label with
+  (match Cascade_config.parse_model_string model_label with
   | None ->
     Error (Oas.Error.Internal
       (Printf.sprintf "Cannot parse model label: %s" model_label))

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -200,7 +200,7 @@ let dispatch (ctx : context) ~(name : string) : tool_result option =
               if String.contains raw ':' then raw else Provider_adapter.make_local_label raw
             in
             (* Validate the label parses without retaining model_spec *)
-            (match Llm_provider.Cascade_config.parse_model_string spec_name with Some _ -> Ok () | None -> Error "invalid model spec")
+            (match Cascade_config.parse_model_string spec_name with Some _ -> Ok () | None -> Error "invalid model spec")
         | _ ->
             (match Provider_adapter.preferred_execution_model_labels () with _ :: _ -> Ok () | [] -> Error "no execution model")
       in

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -278,7 +278,7 @@ let oas_completion_at ?runtime_pool ~model_id ~prompt ~max_tokens ~timeout_sec (
       let started = Time_compat.now () in
       let model_label = model_label_for_pool ~model_id runtime_pool in
       match
-        Llm_provider.Cascade_config.parse_model_string ~max_tokens model_label
+        Cascade_config.parse_model_string ~max_tokens model_label
       with
       | None ->
           ( { success = false; latency_ms = 0; error = Some ("invalid model label: " ^ model_label) },

--- a/lib/worker_runtime_docker.ml
+++ b/lib/worker_runtime_docker.ml
@@ -44,7 +44,7 @@ let docker_llama_server_url () =
 
 let rewrite_model_label_for_container model_label =
   if String.starts_with ~prefix:"custom:" model_label then
-    match Llm_provider.Cascade_config.parse_model_string model_label with
+    match Cascade_config.parse_model_string model_label with
     | Some cfg ->
         let rewritten = rewrite_loopback_url cfg.Llm_provider.Provider_config.base_url in
         if String.equal rewritten cfg.Llm_provider.Provider_config.base_url then
@@ -156,7 +156,7 @@ let mount_args (spec : Worker_execution_spec.t) =
   base_mount @ config_mount
 
 let auth_requirements_of_model_label model_label =
-  match Llm_provider.Cascade_config.parse_model_string model_label with
+  match Cascade_config.parse_model_string model_label with
   | None -> Ok []
   | Some cfg ->
     let keys = Provider_adapter.docker_auth_env_keys_of_provider_config cfg in

--- a/test/test_cascade_config_validity.ml
+++ b/test/test_cascade_config_validity.ml
@@ -3,7 +3,7 @@
     Guards every profile's model string list against typos, unknown
     provider names, and unsupported aliases by running them through
     the same parser the server uses at runtime
-    ({!Llm_provider.Cascade_config.parse_model_strings}).
+    ({!Masc_mcp.Cascade_config.parse_model_strings}).
 
     Motivation: 2026-04-11 incident adjacent — masc-mcp#6475 introduced a
     new [glm-coding:*] cascade head, and the only way to know if OAS
@@ -116,11 +116,11 @@ let test_profile_parses_non_empty profile () =
     contains_substring ~needle:"unavailable" msg
   in
   let expanded =
-    Llm_provider.Cascade_config.expand_auto_models strings
+    Masc_mcp.Cascade_config.expand_auto_models strings
   in
   List.iter
     (fun s ->
-      match Llm_provider.Cascade_config.parse_model_string_exn s with
+      match Masc_mcp.Cascade_config.parse_model_string_exn s with
       | Ok (cfg : Llm_provider.Provider_config.t) ->
         check bool
           (Printf.sprintf "%s: %S has non-empty model_id" profile s)
@@ -168,7 +168,7 @@ let test_unknown_provider_is_dropped () =
       in
       check int "fixture has both entries" 2 (List.length strings);
       let parsed =
-        Llm_provider.Cascade_config.parse_model_strings strings
+        Masc_mcp.Cascade_config.parse_model_strings strings
       in
       (* At least one entry must be dropped. Using "<" (not "=") keeps
          the test correct if a future registry happens to also gate the


### PR DESCRIPTION
## Summary

Switches all 21 MASC consumers from \`Llm_provider.Cascade_*\` (OAS) to the MASC-local \`Cascade_*\` scaffolded in #7382.

**Zero behaviour change** — \`Masc_mcp.Cascade_config\` et al are byte-for-byte identical to OAS v0.144.0, with internal refs rewired to \`Llm_provider.*\` for cross-library access.

## Files touched (21)

- \`lib/oas_worker_named.ml\` — \`try_cascade\` FSM driver (20 renames)
- \`lib/keeper/{agent_run,compact_policy,exec_context,status_detail,turn}.ml\`
- \`lib/dashboard/{governance_judge,http_keeper,operator_judge}.ml\`
- \`lib/dashboard_cascade.{ml,mli}\` — \`module CC\` / \`module Health\` aliases
- \`lib/dashboard_provider_runs.ml\`
- \`lib/{autoresearch_codegen,cascade_inference,oas_model_resolve,oas_worker_exec}.ml\`
- \`lib/{tool_inline_dispatch,tool_local_runtime_bench,worker_runtime_docker}.ml\`
- \`lib/local/worker_container.ml\`
- \`test/test_cascade_config_validity.ml\` — uses \`Masc_mcp.Cascade_config\`

## Post-merge invariant

\`\`\`bash
rg "Llm_provider\\.Cascade_" lib/ test/ --type ocaml
# → 0 matches
\`\`\`

MASC no longer depends on OAS's cascade namespace. OAS is free to delete \`cascade_config/fsm/health_tracker/health_filter/throttle/model_resolve\` entirely in the follow-up PR (MAJOR bump).

## Test plan

- [x] \`dune build --root .\` clean
- [ ] CI: \`dune runtest\`
- [ ] After merge + OAS 4e merge: \`rg "Cascade" oas/lib/\` should return 0

## Follow-ups

- **OAS PR 4e**: delete \`cascade_*\` from OAS entirely, MAJOR bump
- MASC: re-author unit tests for \`lib/cascade/\` modules (stripped \`let%test\` blocks during scaffold)

Plan: \`~/me/planning/claude-plans/glimmering-imagining-sphinx.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)