### PR TITLE
feat(discord-connector): Gate-side hardening + dashboard keeper-first panel

### DIFF
--- a/dashboard/src/api/gate.ts
+++ b/dashboard/src/api/gate.ts
@@ -116,6 +116,14 @@ export interface ConnectorStoragePaths {
   status_path: string
   binding_store_path: string
   audit_path: string
+  names_path: string
+}
+
+export interface ConnectorNames {
+  guild_names: Record<string, string>
+  channel_names: Record<string, string>
+  channel_to_guild: Record<string, string>
+  updated_at: string
 }
 
 export interface ConnectorRuntimeSummary {
@@ -177,6 +185,8 @@ export interface GateConnectorInfo {
   runtime_summary: ConnectorRuntimeSummary
   binding_summary: ConnectorBindingSummary
   observed_channel?: ChannelInfo | null
+  names_path: string
+  names: ConnectorNames
 }
 
 export interface GateConnectorsData {
@@ -352,6 +362,28 @@ function decodeStoragePaths(raw: unknown): ConnectorStoragePaths {
     status_path: asString(record.status_path, ''),
     binding_store_path: asString(record.binding_store_path, ''),
     audit_path: asString(record.audit_path, ''),
+    names_path: asString(record.names_path, ''),
+  }
+}
+
+function decodeStringMap(raw: unknown): Record<string, string> {
+  if (!isRecord(raw)) return {}
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value === 'string' && value.length > 0) {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+function decodeConnectorNames(raw: unknown): ConnectorNames {
+  const record = isRecord(raw) ? raw : {}
+  return {
+    guild_names: decodeStringMap(record.guild_names),
+    channel_names: decodeStringMap(record.channel_names),
+    channel_to_guild: decodeStringMap(record.channel_to_guild),
+    updated_at: asString(record.updated_at, ''),
   }
 }
 
@@ -434,6 +466,8 @@ function decodeGateConnectorInfo(raw: unknown): GateConnectorInfo | null {
     runtime_summary: decodeRuntimeSummary(raw.runtime_summary),
     binding_summary: decodeBindingSummary(raw.binding_summary, configuredBindings.length),
     observed_channel: decodeChannelInfo(raw.observed_channel) ?? null,
+    names_path: asString(raw.names_path, ''),
+    names: decodeConnectorNames(raw.names),
   }
 }
 

--- a/dashboard/src/components/common/button.ts
+++ b/dashboard/src/components/common/button.ts
@@ -29,6 +29,7 @@ interface ActionButtonProps {
   disabled?: boolean
   /** Full width */
   block?: boolean
+  ariaLabel?: string
   onClick?: (e: Event) => void
   children: ComponentChildren
 }
@@ -39,6 +40,7 @@ export function ActionButton({
   class: cx,
   disabled,
   block,
+  ariaLabel,
   onClick,
   children,
 }: ActionButtonProps) {
@@ -52,6 +54,6 @@ export function ActionButton({
   ].filter(Boolean).join(' ')
 
   return html`
-    <button type="button" class=${cls} onClick=${onClick} disabled=${disabled}>${children}</button>
+    <button type="button" class=${cls} onClick=${onClick} disabled=${disabled} aria-label=${ariaLabel}>${children}</button>
   `
 }

--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -239,14 +239,13 @@ describe('ConnectorStatusPanel', () => {
     expect(fetchGateConnectors).toHaveBeenCalled()
     expect(fetchGateKeepers).toHaveBeenCalled()
     expect(text).toContain('Channel Gate Connectors')
-    expect(text).toContain('Gate-Advertised Connector')
     expect(text).toContain('connected')
     expect(text).toContain('Discord')
     expect(text).toContain('sangsu')
-    expect(text).toContain('keeper dir 2')
+    expect(text).toContain('luna')
+    expect(text).toContain('nova')
     expect(text).toContain('keeper-luna-agent')
     expect(text).toContain('Observed room bindings')
-    expect(text).toContain('Recent binding audit')
     expect(text).toContain('Recent gate events')
     expect(text).toContain('keeper_error')
     expect(text).toContain('/tmp/discord_status.json')
@@ -275,7 +274,7 @@ describe('ConnectorStatusPanel', () => {
     await flushUi()
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
 
-    expect(text).toContain('Gate-Advertised Connector')
+    expect(text).toContain('Discord')
     expect(text).toContain('stale')
     expect(text).toContain('Gate metrics unavailable')
     expect(text).toContain('Gate-advertised connector runtime is visible')
@@ -341,7 +340,20 @@ describe('ConnectorStatusPanel', () => {
 
   it('posts bind and unbind actions through the dashboard endpoints', async () => {
     const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
-    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const initialState = sampleConnectorsResponse()
+    const afterBindState = sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        configured_bindings: [
+          { channel_id: '123456', keeper_name: 'luna' },
+          { channel_id: '999999', keeper_name: 'nova' },
+        ],
+        runtime_bindings_count: 2,
+      }],
+    })
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>()
+      .mockResolvedValueOnce(initialState)
+      .mockResolvedValue(afterBindState)
     const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
     const post = vi.fn<(path: string, body: unknown) => Promise<unknown>>().mockResolvedValue({ ok: true })
     const showToast = vi.fn()
@@ -358,24 +370,21 @@ describe('ConnectorStatusPanel', () => {
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
 
+    const addChannelButton = container.querySelector<HTMLButtonElement>('button[aria-label="add channel to nova"]')
+    expect(addChannelButton).not.toBeNull()
+    addChannelButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
     const channelInput = container.querySelector<HTMLInputElement>('input[aria-label="Discord channel id"]')
-    const keeperInput = container.querySelector<HTMLInputElement>('input[aria-label="Keeper name"]')
     expect(channelInput).not.toBeNull()
-    expect(keeperInput).not.toBeNull()
-
-    if (!channelInput || !keeperInput) {
-      throw new Error('expected bind form inputs to exist')
-    }
-
-    channelInput.value = '999999'
-    channelInput.dispatchEvent(new Event('input', { bubbles: true }))
-    keeperInput.value = 'nova'
-    keeperInput.dispatchEvent(new Event('input', { bubbles: true }))
+    channelInput!.value = '999999'
+    channelInput!.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi()
 
     const bindButton = Array.from(container.querySelectorAll('button'))
-      .find(candidate => candidate.textContent?.trim() === 'Bind')
-    bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      .find(candidate => candidate.textContent?.trim() === 'bind')
+    expect(bindButton).toBeDefined()
+    bindButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flushUi()
 
     expect(post).toHaveBeenCalledWith('/api/v1/gate/connector/bind?name=discord', {
@@ -384,9 +393,9 @@ describe('ConnectorStatusPanel', () => {
     })
     expect(showToast).toHaveBeenCalledWith('Bound 999999 -> nova', 'success')
 
-    const unbindButton = Array.from(container.querySelectorAll('button'))
-      .find(candidate => candidate.textContent?.trim() === 'Unbind')
-    unbindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    const unbindButton = container.querySelector<HTMLButtonElement>('button[aria-label="unbind 999999"]')
+    expect(unbindButton).not.toBeNull()
+    unbindButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await flushUi()
 
     expect(post).toHaveBeenCalledWith('/api/v1/gate/connector/unbind?name=discord', {
@@ -395,7 +404,7 @@ describe('ConnectorStatusPanel', () => {
     expect(showToast).toHaveBeenCalledWith('Unbound 999999', 'success')
   })
 
-  it('shows selected keeper runtime metadata from the keeper directory', async () => {
+  it('renders one section per directory keeper (keeper-first grouping)', async () => {
     const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
     const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
     const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
@@ -410,19 +419,153 @@ describe('ConnectorStatusPanel', () => {
     render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
 
-    const keeperSelect = container.querySelector<HTMLSelectElement>('select')
-    expect(keeperSelect).not.toBeNull()
-    if (!keeperSelect) {
-      throw new Error('expected keeper select to exist')
-    }
+    const lunaGroup = container.querySelector('[data-keeper="luna"]')
+    const novaGroup = container.querySelector('[data-keeper="nova"]')
+    expect(lunaGroup).not.toBeNull()
+    expect(novaGroup).not.toBeNull()
+    expect(lunaGroup!.textContent).toContain('luna')
+    expect(lunaGroup!.querySelector('[data-channel-id="123456"]')).not.toBeNull()
+    expect(novaGroup!.textContent).toContain('(no channels)')
+  })
 
-    keeperSelect.value = 'nova'
-    keeperSelect.dispatchEvent(new Event('change', { bubbles: true }))
+  it('groups bindings for unknown keepers under a warning section', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        configured_bindings: [
+          { channel_id: '123456', keeper_name: 'luna' },
+          { channel_id: '999888', keeper_name: 'bob_keeper' },
+        ],
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
     await flushUi()
 
     const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
-    expect(text).toContain('status busy')
-    expect(text).toContain('model gemini-2.5-flash')
-    expect(text).toContain('runtime keeper-nova-agent')
+    expect(text).toContain('⚠')
+    expect(text).toContain('bob_keeper')
+    expect(text).toContain('binding references undefined keeper')
+    const bobGroup = container.querySelector('[data-keeper="bob_keeper"]')
+    expect(bobGroup).not.toBeNull()
+    expect(bobGroup!.querySelector('[data-channel-id="999888"]')).not.toBeNull()
+  })
+
+  it('shows sidecar-off empty state when no bindings and sidecar offline', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        available: false,
+        connected: false,
+        stale: false,
+        status: 'offline',
+        configured_bindings: [],
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    expect(text).toContain('Sidecar not started')
+    expect(text).toContain('cd sidecars/discord-bot && ./run.sh')
+  })
+
+  it('shows no-keepers empty state when keeper directory is empty', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse({
+      connectors: [{
+        ...sampleConnectorsResponse().connectors[0],
+        available: false,
+        connected: false,
+        status: 'offline',
+        configured_bindings: [],
+      }],
+    }))
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue({ count: 0, keepers: [] })
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const text = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    expect(text).toContain('No keepers configured')
+  })
+
+  it('expands [▾] header toggle to show per-dot liveness and metadata', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const beforeText = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    expect(beforeText).not.toContain('Browser → Server')
+    expect(beforeText).not.toContain('keeper dir 2')
+
+    const toggleButton = container.querySelector<HTMLButtonElement>('button[aria-label="toggle header details"]')
+    expect(toggleButton).not.toBeNull()
+    toggleButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const afterText = container.textContent?.replace(/\s+/g, ' ').trim() ?? ''
+    expect(afterText).toContain('Browser → Server')
+    expect(afterText).toContain('Server → Sidecar')
+    expect(afterText).toContain('keeper dir 2')
+  })
+
+  it('shows keeper metadata in each group header', async () => {
+    const fetchGateStatus = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleGateResponse())
+    const fetchGateConnectors = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleConnectorsResponse())
+    const fetchGateKeepers = vi.fn<() => Promise<unknown>>().mockResolvedValue(sampleKeepersResponse())
+
+    const { ConnectorStatusPanel } = await loadComponentWithApi({
+      fetchGateStatus,
+      fetchGateConnectors,
+      fetchGateKeepers,
+      lastEvent: signal(null),
+    })
+
+    render(html`<${ConnectorStatusPanel} />`, container)
+    await flushUi()
+
+    const novaGroup = container.querySelector('[data-keeper="nova"]')
+    expect(novaGroup).not.toBeNull()
+    const novaText = novaGroup!.textContent ?? ''
+    expect(novaText).toContain('status busy')
+    expect(novaText).toContain('model gemini-2.5-flash')
+    expect(novaText).toContain('runtime keeper-nova-agent')
   })
 })

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1,5 +1,5 @@
 // Connector Status — Channel Gate per-channel diagnostics panel.
-// Shows connector health, success rate, duplicates, and latest failure context.
+// Keeper-first layout: each directory keeper is a primary section; bindings nest under.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
@@ -24,13 +24,13 @@ import { lastEvent } from '../sse'
 import { StatCard } from './common/stat-card'
 import { ActionButton } from './common/button'
 import { TextInput } from './common/input'
-import { Select } from './common/select'
 import { showToast } from './common/toast'
 import { createManagedAsyncResource } from '../lib/async-state'
 
 const actionLoading = signal(false)
 const channelDraft = signal('')
-const keeperDraft = signal('')
+const expandedKeeperFor = signal<string | null>(null)
+const headerExpanded = signal(false)
 
 type ConnectorStatusSnapshot = {
   gate: GateStatusData | null
@@ -52,13 +52,8 @@ const EMPTY_SNAPSHOT: ConnectorStatusSnapshot = {
 
 const connectorStatusResource = createManagedAsyncResource<ConnectorStatusSnapshot>(EMPTY_SNAPSHOT)
 
-function preferredConnector(payload: GateConnectorsData | null): GateConnectorInfo | null {
-  if (!payload || payload.connectors.length === 0) return null
-  return payload.connectors.find(connector => connector.capabilities.includes('bindings')) ?? payload.connectors[0] ?? null
-}
-
 async function refresh() {
-  const snapshot = await connectorStatusResource.load(async (signal, previous) => {
+  await connectorStatusResource.load(async (signal, previous) => {
     const next: ConnectorStatusSnapshot = {
       gate: previous?.gate ?? null,
       connectors: previous?.connectors ?? null,
@@ -95,14 +90,6 @@ async function refresh() {
 
     return next
   })
-
-  const primaryConnector = preferredConnector(snapshot?.connectors ?? null)
-  if (!channelDraft.value && (primaryConnector?.configured_bindings.length ?? 0) > 0) {
-    channelDraft.value = primaryConnector?.configured_bindings[0]?.channel_id ?? ''
-  }
-  if (!keeperDraft.value && (primaryConnector?.configured_bindings.length ?? 0) > 0) {
-    keeperDraft.value = primaryConnector?.configured_bindings[0]?.keeper_name ?? ''
-  }
 }
 
 const CHANNEL_ICONS: Record<string, string> = {
@@ -202,6 +189,19 @@ function dotClass(state: LivenessState): string {
   }
 }
 
+function dotClassForLabel(label: string): string {
+  switch (label) {
+    case 'connected':
+      return 'bg-emerald-400'
+    case 'stale':
+      return 'bg-amber-400'
+    case 'disconnected':
+      return 'bg-rose-400'
+    default:
+      return 'bg-[var(--text-dim)]'
+  }
+}
+
 function uniqueStrings(values: string[]): string[] {
   const seen = new Set<string>()
   const ordered: string[] = []
@@ -227,13 +227,6 @@ function runtimeLabelForKeeper(keeper: GateKeeperInfo | null | undefined): strin
   return runtime
 }
 
-function keeperLabel(keeper: GateKeeperInfo): string {
-  const status = keeper.status?.trim() || 'unknown'
-  const model = modelLabelForKeeper(keeper)
-  const runtime = runtimeLabelForKeeper(keeper)
-  return [keeper.name, status, model, runtime].filter(Boolean).join(' · ')
-}
-
 function connectorStateLabel(connector: GateConnectorInfo | null): string {
   const advertised = connector?.status?.trim().toLowerCase()
   if (advertised === 'offline' || advertised === 'stale' || advertised === 'connected' || advertised === 'disconnected') {
@@ -256,19 +249,21 @@ function connectorStateTone(connector: GateConnectorInfo | null): string {
   return 'border-amber-400/30 bg-amber-500/12 text-amber-100'
 }
 
-async function bindConnector(connectorId: string) {
-  const channelId = channelDraft.value.trim()
-  const keeperName = keeperDraft.value.trim()
-  if (!channelId || !keeperName) return
+async function bindConnector(connectorId: string, keeperName: string, channelId: string) {
+  const keeper = keeperName.trim()
+  const channel = channelId.trim()
+  if (!keeper || !channel) return
 
   actionLoading.value = true
   try {
     await post(`/api/v1/gate/connector/bind?name=${encodeURIComponent(connectorId)}`, {
-      channel_id: channelId,
-      keeper_name: keeperName,
+      channel_id: channel,
+      keeper_name: keeper,
     })
+    channelDraft.value = ''
+    expandedKeeperFor.value = null
     await refresh()
-    showToast(`Bound ${channelId} -> ${keeperName}`, 'success')
+    showToast(`Bound ${channel} -> ${keeper}`, 'success')
   } catch (err) {
     showToast(err instanceof Error ? err.message : 'bind failed', 'error')
   } finally {
@@ -276,25 +271,29 @@ async function bindConnector(connectorId: string) {
   }
 }
 
-async function unbindConnector(connectorId: string, channelIdOverride?: string) {
-  const channelId = (channelIdOverride ?? channelDraft.value).trim()
-  if (!channelId) return
+async function unbindConnector(connectorId: string, channelId: string) {
+  const channel = channelId.trim()
+  if (!channel) return
 
   actionLoading.value = true
   try {
     await post(`/api/v1/gate/connector/unbind?name=${encodeURIComponent(connectorId)}`, {
-      channel_id: channelId,
+      channel_id: channel,
     })
-    if (channelDraft.value.trim() === channelId) {
-      channelDraft.value = ''
-    }
     await refresh()
-    showToast(`Unbound ${channelId}`, 'success')
+    showToast(`Unbound ${channel}`, 'success')
   } catch (err) {
     showToast(err instanceof Error ? err.message : 'unbind failed', 'error')
   } finally {
     actionLoading.value = false
   }
+}
+
+type KeeperGroup = {
+  name: string
+  keeper: GateKeeperInfo | null
+  bindings: Array<{ channel_id: string; keeper_name: string }>
+  unknown: boolean
 }
 
 function ConnectorLivePanel({
@@ -312,9 +311,28 @@ function ConnectorLivePanel({
   keeperDirectoryError: string | null
   loading: boolean
 }) {
-  const keeperByName = new Map(keepers.map(keeper => [keeper.name, keeper] as const))
   const configuredBindings = connector?.configured_bindings ?? []
-  const audit = connector?.recent_audit ?? []
+  const names = connector?.names
+  const connectorName = connector?.display_name || 'Connector'
+  const connectorId = connector?.connector_id ?? ''
+  const bindingActionsEnabled = connector != null && connector.capabilities.includes('bindings')
+  const directLabel = connectorStateLabel(connector)
+  const directTone = connectorStateTone(connector)
+
+  let gateHealthLabel = 'unknown'
+  if (connector?.gate_healthy === true) {
+    gateHealthLabel = 'healthy'
+  } else if (connector?.gate_healthy === false) {
+    gateHealthLabel = 'unhealthy'
+  }
+
+  const sidecarLogPath = connector?.names_path
+    ? connector.names_path.replace(
+        /\/\.masc\/connectors\/[^/]+\/names\.json$/,
+        `/.masc/logs/${connectorId}-sidecar-YYYYMMDD.log`,
+      )
+    : ''
+
   const observedRooms = uniqueStrings([
     ...(gate?.bindings ?? [])
       .filter(binding => binding.channel === (connector?.channel ?? ''))
@@ -324,37 +342,28 @@ function ConnectorLivePanel({
       .map(event => event.room_id),
     ...configuredBindings.map(binding => binding.channel_id),
   ])
-  const suggestedKeepers = uniqueStrings([
-    ...(gate?.bindings ?? [])
-      .filter(binding => binding.channel === (connector?.channel ?? ''))
-      .map(binding => binding.keeper),
-    ...(gate?.recent_events ?? [])
-      .filter(event => event.channel === (connector?.channel ?? ''))
-      .map(event => event.keeper),
-    ...configuredBindings.map(binding => binding.keeper_name),
-  ])
-  const selectedKeeper = keeperByName.get(keeperDraft.value.trim()) ?? null
-  const directLabel = connectorStateLabel(connector)
-  const directTone = connectorStateTone(connector)
-  const bindingActionsEnabled =
-    connector != null && connector.capabilities.includes('bindings')
-  const connectorName = connector?.display_name || 'Connector'
-  const connectorId = connector?.connector_id ?? ''
-  const channelInputLabel = `${connectorName} channel id`
-  let gateHealthLabel = 'unknown'
-  if (connector?.gate_healthy === true) {
-    gateHealthLabel = 'healthy'
-  } else if (connector?.gate_healthy === false) {
-    gateHealthLabel = 'unhealthy'
-  }
 
-  const names = connector?.names
-  const sidecarLogPath = connector?.names_path
-    ? connector.names_path.replace(
-        /\/\.masc\/connectors\/[^/]+\/names\.json$/,
-        `/.masc/logs/${connectorId}-sidecar-YYYYMMDD.log`,
-      )
-    : ''
+  const bindingsByKeeper = new Map<string, Array<{ channel_id: string; keeper_name: string }>>()
+  for (const binding of configuredBindings) {
+    const existing = bindingsByKeeper.get(binding.keeper_name)
+    if (existing) {
+      existing.push(binding)
+    } else {
+      bindingsByKeeper.set(binding.keeper_name, [binding])
+    }
+  }
+  const knownNames = new Set(keepers.map(keeper => keeper.name))
+  const knownGroups: KeeperGroup[] = keepers.map(keeper => ({
+    name: keeper.name,
+    keeper,
+    bindings: bindingsByKeeper.get(keeper.name) ?? [],
+    unknown: false,
+  }))
+  const unknownGroups: KeeperGroup[] = []
+  for (const [name, bindings] of bindingsByKeeper) {
+    if (knownNames.has(name)) continue
+    unknownGroups.push({ name, keeper: null, bindings, unknown: true })
+  }
 
   const browserDot: LivenessDot = {
     label: 'Browser → Server',
@@ -421,297 +430,281 @@ function ConnectorLivePanel({
   })()
   const livenessDots: LivenessDot[] = [browserDot, serverDot, sidecarDot]
 
-  const showOnboarding =
-    configuredBindings.length === 0 && !connector?.available && !connectorError
+  const showNoKeeperEmpty =
+    configuredBindings.length === 0 && !connector?.available && keepers.length === 0 && !keeperDirectoryError
+  const showSidecarOffEmpty =
+    !showNoKeeperEmpty && configuredBindings.length === 0 && !connector?.available
 
   return html`
     <div class="mb-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(135deg,rgba(88,101,242,0.16),rgba(88,101,242,0.04))] p-4">
-      <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2 text-[11px] text-[var(--text-body)]">
-        ${livenessDots.map(dot => html`
-          <div class="flex min-w-0 items-center gap-2" title=${dot.hint}>
-            <span class=${`inline-block h-2 w-2 rounded-full ${dotClass(dot.state)}`}></span>
-            <span class="font-medium">${dot.label}</span>
-            <span class="truncate text-[var(--text-dim)]">${dot.detail}</span>
-            ${dot.hint && (dot.state === 'down' || dot.state === 'warn')
-              ? html`<span class="text-[10px] italic text-[var(--text-dim)]">— ${dot.hint}</span>`
-              : null}
-          </div>
-        `)}
+      <div class="flex flex-wrap items-center gap-2 text-[12px]">
+        <span class="text-sm font-semibold text-[var(--text-body)]">${connectorName}</span>
+        ${connector?.bot_user_name
+          ? html`<span class="text-[var(--text-dim)]">· ${connector.bot_user_name}</span>`
+          : null}
+        <span class="text-[var(--text-dim)]">·</span>
+        <span class=${`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] ${directTone}`}>
+          <span class=${`inline-block h-2 w-2 rounded-full ${dotClassForLabel(directLabel)}`}></span>
+          <span>${directLabel}</span>
+        </span>
+        <span class="text-[var(--text-dim)]">· hb ${timeAgo(connector?.updated_at ?? '')}</span>
+        ${connector?.reply_mode
+          ? html`<span class="text-[var(--text-dim)]">· reply ${connector.reply_mode}</span>`
+          : null}
+        ${connector?.self_chat_guid
+          ? html`<span class="text-[var(--text-dim)]">· self-chat ${truncateMiddle(connector.self_chat_guid, 28)}</span>`
+          : null}
+        <span class="ml-auto flex items-center gap-2">
+          ${sidecarLogPath
+            ? html`<span class="cursor-help text-[10px] text-[var(--text-dim)]" title=${sidecarLogPath}>logs↗</span>`
+            : null}
+          <button
+            type="button"
+            class="cursor-pointer rounded border border-[var(--white-8)] px-1.5 text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+            aria-label="toggle header details"
+            onClick=${() => { headerExpanded.value = !headerExpanded.value }}
+          >${headerExpanded.value ? '▴' : '▾'}</button>
+        </span>
       </div>
 
-      ${showOnboarding
+      ${headerExpanded.value
         ? html`
-            <div class="mb-3 rounded-md border border-dashed border-[var(--white-8)] bg-[var(--white-4)] px-3 py-3 text-[12px] text-[var(--text-body)]">
-              <div class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">
-                Connect ${connectorName} in 3 steps
+            <div class="mt-2 rounded-md border border-[var(--white-8)] bg-[var(--white-4)] p-3 text-[11px]">
+              <div class="space-y-1.5">
+                ${livenessDots.map(dot => html`
+                  <div class="flex min-w-0 flex-wrap items-center gap-2">
+                    <span class=${`inline-block h-2 w-2 rounded-full ${dotClass(dot.state)}`}></span>
+                    <span class="font-medium">${dot.label}</span>
+                    <span class="text-[var(--text-dim)]">${dot.detail}</span>
+                    ${dot.hint && (dot.state === 'down' || dot.state === 'warn')
+                      ? html`<span class="italic text-[var(--text-dim)]">— ${dot.hint}</span>`
+                      : null}
+                  </div>
+                `)}
               </div>
-              <ol class="mb-2 list-decimal pl-5 text-[11px] leading-5 text-[var(--text-dim)]">
-                <li>Start the MASC server (the dashboard you're reading confirms it's running).</li>
-                <li>Start the sidecar: <code class="rounded bg-[var(--white-8)] px-1">cd sidecars/${connectorId}-bot && ./run.sh</code></li>
-                <li>Come back to this panel and bind a channel below.</li>
-              </ol>
-              <div class="text-[10px] text-[var(--text-dim)]">
-                Once the sidecar emits its first heartbeat this card disappears.
+              <div class="mt-3 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
+                <span>guilds ${connector?.guild_count ?? 0}</span>
+                <span>gate ${gateHealthLabel}</span>
+                <span>source ${connector?.binding_source || 'unknown'}</span>
+                <span>runtime bindings ${connector?.runtime_bindings_count ?? configuredBindings.length}</span>
+                <span>keeper dir ${keepers.length}</span>
+              </div>
+              <div class="mt-3">
+                <${ActionButton} variant="ghost" size="sm" disabled=${loading || actionLoading.value} onClick=${() => { void refresh() }}>Refresh<//>
               </div>
             </div>
           `
         : null}
-
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="min-w-0">
-          <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">Gate-Advertised Connector</div>
-          <div class="mt-1 flex flex-wrap items-center gap-2">
-            <span class=${`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] ${directTone}`}>
-              ${directLabel}
-            </span>
-            <span class="text-[13px] font-medium text-[var(--text-body)]">
-              ${connector?.bot_user_name
-                ? `${connectorName} · ${connector.bot_user_name} · ${truncateMiddle(connector.bot_user_id, 24)}`
-                : `${connectorName} runtime has not reported identity yet`}
-            </span>
-          </div>
-          <div class="mt-2 flex flex-wrap gap-3 text-[11px] text-[var(--text-dim)]">
-            <span>heartbeat ${timeAgo(connector?.updated_at ?? '')}</span>
-            <span>ready ${timeAgo(connector?.last_ready_at ?? '')}</span>
-            <span>guilds ${connector?.guild_count ?? 0}</span>
-            <span>runtime bindings ${connector?.runtime_bindings_count ?? configuredBindings.length}</span>
-            ${connector?.reply_mode ? html`<span>reply ${connector.reply_mode}</span>` : null}
-            ${connector?.self_chat_guid ? html`<span>self-chat ${truncateMiddle(connector.self_chat_guid, 28)}</span>` : null}
-            <span>source ${connector?.binding_source || 'unknown'}</span>
-            <span>keeper dir ${keepers.length}</span>
-            <span>
-              gate ${gateHealthLabel}
-            </span>
-          </div>
-        </div>
-        <div class="flex flex-wrap gap-2">
-          <${ActionButton} variant="ghost" size="sm" disabled=${loading || actionLoading.value} onClick=${() => { void refresh() }}>Refresh<//>
-          ${bindingActionsEnabled
-            ? html`
-                <${ActionButton}
-                  variant="primary"
-                  size="sm"
-                  disabled=${actionLoading.value || channelDraft.value.trim().length === 0 || keeperDraft.value.trim().length === 0}
-                  onClick=${() => { void bindConnector(connectorId) }}
-                >
-                  ${actionLoading.value ? 'Applying...' : 'Bind'}
-                <//>
-                <${ActionButton}
-                  variant="danger"
-                  size="sm"
-                  disabled=${actionLoading.value || channelDraft.value.trim().length === 0}
-                  onClick=${() => { void unbindConnector(connectorId) }}
-                >
-                  Unbind
-                <//>
-              `
-            : null}
-        </div>
-      </div>
 
       ${connectorError || connector?.error
         ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">${connectorError ?? connector?.error}</div>`
         : null}
 
-      ${connector
+      ${keeperDirectoryError && keepers.length === 0
+        ? html`<div class="mt-3 rounded-md border border-amber-400/20 bg-amber-500/8 px-3 py-2 text-[11px] text-amber-100">keeper directory unavailable, manual entry only</div>`
+        : null}
+
+      ${showNoKeeperEmpty
         ? html`
-            <div class="mt-3 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
-              <span>status ${connector.status_path || '-'}</span>
-              <span>bindings ${connector.binding_store_path || '-'}</span>
-              <span>audit ${connector.audit_path || '-'}</span>
-              <span>names ${connector.names_path || '-'}</span>
-              ${sidecarLogPath
-                ? html`<span>sidecar logs ${sidecarLogPath}</span>`
-                : null}
+            <div class="mt-3 rounded-md border border-dashed border-[var(--white-8)] bg-[var(--white-4)] px-3 py-3 text-[12px]">
+              <div class="font-medium text-[var(--text-body)]">No keepers configured</div>
+              <div class="mt-1 text-[10px] text-[var(--text-dim)]">
+                Add keeper config files under config/keepers/ and restart the server.
+              </div>
             </div>
           `
         : null}
 
-      <div class="mt-4 grid grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] gap-4 max-[980px]:grid-cols-1">
-        <div class="space-y-3 rounded-md border border-dashed border-[var(--white-8)] p-3">
-          <div>
-            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-body)]">Create / replace binding</div>
-            <div class="mt-1 text-[10px] text-[var(--text-dim)]">
-              Existing bindings are listed on the right. Paste a channel ID and pick a keeper here to add or replace a binding.
+      ${showSidecarOffEmpty
+        ? html`
+            <div class="mt-3 rounded-md border border-dashed border-[var(--white-8)] bg-[var(--white-4)] px-3 py-3 text-[12px]">
+              <div class="font-medium text-[var(--text-body)]">Sidecar not started</div>
+              <div class="mt-1 text-[11px] text-[var(--text-dim)]">
+                Start: <code class="rounded bg-[var(--white-8)] px-1">cd sidecars/${connectorId}-bot && ./run.sh</code>
+              </div>
             </div>
-          </div>
-          <div>
-            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Channel ID (draft)</div>
-            <${TextInput}
-              value=${channelDraft.value}
-              placeholder=${`Paste ${connectorName} channel ID — right-click a channel → Copy ID`}
-              ariaLabel=${channelInputLabel}
-              onInput=${(e: Event) => { channelDraft.value = (e.target as HTMLInputElement).value }}
-            />
-            ${channelDraft.value.trim() && humanizeChannel(names, channelDraft.value.trim())
-              ? html`<div class="mt-1 text-[10px] text-[var(--text-dim)]">resolves to ${humanizeChannel(names, channelDraft.value.trim())}</div>`
-              : null}
-          </div>
-          <div>
-            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Keeper</div>
-            ${keepers.length > 0
-              ? html`
-                  <div class="mb-2">
-                    <${Select}
-                      value=${selectedKeeper?.name ?? ''}
-                      options=${keepers.map(keeper => ({ value: keeper.name, label: keeperLabel(keeper) }))}
-                      placeholder="keeper 선택"
-                      onInput=${(value: string) => { keeperDraft.value = value }}
-                    />
-                  </div>
-                `
-              : null}
-            <${TextInput}
-              value=${keeperDraft.value}
-              placeholder="keeper name"
-              ariaLabel="Keeper name"
-              onInput=${(e: Event) => { keeperDraft.value = (e.target as HTMLInputElement).value }}
-            />
-            ${selectedKeeper
-              ? html`
-                  <div class="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-dim)]">
-                    <span>status ${selectedKeeper.status || 'unknown'}</span>
-                    ${modelLabelForKeeper(selectedKeeper) ? html`<span>model ${modelLabelForKeeper(selectedKeeper)}</span>` : null}
-                    ${runtimeLabelForKeeper(selectedKeeper) ? html`<span>runtime ${runtimeLabelForKeeper(selectedKeeper)}</span>` : null}
-                    ${selectedKeeper.keepalive_running ? html`<span>keepalive</span>` : null}
-                  </div>
-                `
-              : null}
-            ${keepers.length === 0 && keeperDirectoryError
-              ? html`
-                  <div class="mt-2 text-[10px] text-[var(--text-dim)]">
-                    keeper directory unavailable, manual entry only
-                  </div>
-                `
-              : null}
-          </div>
-          ${observedRooms.length > 0
-            ? html`
-                <div>
-                  <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Observed rooms</div>
-                  <div class="flex flex-wrap gap-2">
-                    ${observedRooms.slice(0, 8).map(roomId => {
-                      const humanized = humanizeChannel(names, roomId)
-                      return html`
-                      <button
-                        type="button"
-                        class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-1 text-[10px] text-[var(--text-body)] cursor-pointer hover:bg-[var(--white-8)]"
-                        title=${roomId}
-                        onClick=${() => { channelDraft.value = roomId }}
-                      >
-                        ${humanized
-                          ? html`<span>${humanized}</span><span class="ml-1 text-[var(--text-dim)]">· ${truncateMiddle(roomId, 10)}</span>`
-                          : truncateMiddle(roomId, 22)}
-                      </button>
-                    `})}
-                  </div>
-                </div>
-              `
-            : null}
-          ${suggestedKeepers.length > 0
-            ? html`
-                <div>
-                  <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Suggested keepers</div>
-                  <div class="flex flex-wrap gap-2">
-                    ${suggestedKeepers.slice(0, 8).map(name => html`
-                      <button
-                        type="button"
-                        class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-1 text-[10px] text-[var(--text-body)] cursor-pointer hover:bg-[var(--white-8)]"
-                        onClick=${() => { keeperDraft.value = name }}
-                      >
-                        ${name}
-                      </button>
-                    `)}
-                  </div>
-                </div>
-              `
-            : null}
-        </div>
+          `
+        : null}
 
-        <div class="space-y-3">
-          <div>
-            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Configured bindings</div>
-            ${configuredBindings.length === 0
-              ? html`<div class="rounded-md border border-dashed border-[var(--white-8)] px-3 py-4 text-xs text-[var(--text-dim)]">No persisted connector bindings yet</div>`
-              : html`
-                  <div class="space-y-2">
-                    ${configuredBindings.map(binding => html`
-                      ${(() => {
-                        const keeperMeta = keeperByName.get(binding.keeper_name) ?? null
-                        const humanized = humanizeChannel(names, binding.channel_id)
-                        return html`
-                      <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
-                        <div class="flex items-start justify-between gap-3">
-                          <div class="min-w-0">
-                            <div class="text-xs font-medium text-[var(--text-body)]">
-                              <code>${truncateMiddle(binding.channel_id, 26)}</code>
-                              ${humanized
-                                ? html`<span class="ml-2 text-[var(--text-dim)]">— ${humanized}</span>`
-                                : html`<span class="ml-2 text-[var(--text-dim)]">— <span title="sidecar has not sent names yet">names pending</span></span>`}
+      ${knownGroups.length > 0
+        ? html`
+            <div class="mt-3 space-y-2">
+              ${knownGroups.map(group => {
+                const keeper = group.keeper
+                const expanded = expandedKeeperFor.value === group.name
+                const toggleExpand = () => {
+                  if (expanded) {
+                    expandedKeeperFor.value = null
+                  } else {
+                    expandedKeeperFor.value = group.name
+                    channelDraft.value = ''
+                  }
+                }
+                return html`
+                  <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2" data-keeper=${group.name}>
+                    <div class="flex flex-wrap items-baseline gap-3">
+                      <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
+                      ${keeper
+                        ? html`
+                            <div class="text-[10px] text-[var(--text-dim)]">
+                              status ${keeper.status || 'unknown'}
+                              ${modelLabelForKeeper(keeper) ? ` · model ${modelLabelForKeeper(keeper)}` : ''}
+                              ${runtimeLabelForKeeper(keeper) ? ` · runtime ${runtimeLabelForKeeper(keeper)}` : ''}
                             </div>
-                            <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">keeper ${binding.keeper_name}</div>
-                            ${keeperMeta
-                              ? html`
-                                  <div class="mt-1 text-[10px] text-[var(--text-dim)]">
-                                    ${keeperMeta.status || 'unknown'}
-                                    ${modelLabelForKeeper(keeperMeta) ? ` · ${modelLabelForKeeper(keeperMeta)}` : ''}
-                                    ${runtimeLabelForKeeper(keeperMeta) ? ` · ${runtimeLabelForKeeper(keeperMeta)}` : ''}
+                          `
+                        : null}
+                    </div>
+
+                    ${group.bindings.length === 0
+                      ? html`<div class="mt-1 text-[11px] text-[var(--text-dim)]">(no channels)</div>`
+                      : html`
+                          <div class="mt-2 space-y-1">
+                            ${group.bindings.map(binding => {
+                              const humanized = humanizeChannel(names, binding.channel_id)
+                              return html`
+                                <div class="flex items-center justify-between gap-3 text-[12px]" data-channel-id=${binding.channel_id}>
+                                  <div class="min-w-0 text-[var(--text-body)]">
+                                    <span class="mr-1 text-[var(--text-dim)]">·</span>
+                                    ${humanized
+                                      ? html`<span>${humanized}</span>`
+                                      : html`<span class="text-[var(--text-dim)]" title="sidecar has not sent names yet">names pending</span>`}
+                                    <span class="ml-2 text-[10px] text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
                                   </div>
-                                `
-                              : null}
+                                  ${bindingActionsEnabled
+                                    ? html`
+                                        <${ActionButton}
+                                          variant="ghost"
+                                          size="sm"
+                                          disabled=${actionLoading.value}
+                                          ariaLabel=${`unbind ${binding.channel_id}`}
+                                          onClick=${() => { void unbindConnector(connectorId, binding.channel_id) }}
+                                        >unbind<//>
+                                      `
+                                    : null}
+                                </div>
+                              `
+                            })}
                           </div>
-                          <div class="flex gap-2">
-                            <${ActionButton} variant="ghost" size="sm" onClick=${() => {
-                              channelDraft.value = binding.channel_id
-                              keeperDraft.value = binding.keeper_name
-                            }}>Use<//>
-                            ${bindingActionsEnabled
-                              ? html`<${ActionButton} variant="danger" size="sm" disabled=${actionLoading.value} onClick=${() => { void unbindConnector(connectorId, binding.channel_id) }}>Unbind<//>`
-                              : null}
+                        `}
+
+                    ${bindingActionsEnabled
+                      ? html`
+                          <div class="mt-2">
+                            <button
+                              type="button"
+                              class="cursor-pointer text-[11px] text-[var(--text-dim)] hover:text-[var(--text-body)]"
+                              aria-label=${`add channel to ${group.name}`}
+                              onClick=${toggleExpand}
+                            >${expanded ? '− close' : '+ add channel'}</button>
                           </div>
-                        </div>
-                      </div>
+                          ${expanded
+                            ? html`
+                                <div class="mt-2 rounded border border-dashed border-[var(--white-8)] bg-[var(--white-2)] p-2">
+                                  <${TextInput}
+                                    value=${channelDraft.value}
+                                    placeholder=${`Paste ${connectorName} channel ID — right-click a channel → Copy ID`}
+                                    ariaLabel=${`${connectorName} channel id`}
+                                    onInput=${(e: Event) => { channelDraft.value = (e.target as HTMLInputElement).value }}
+                                  />
+                                  ${channelDraft.value.trim() && humanizeChannel(names, channelDraft.value.trim())
+                                    ? html`<div class="mt-1 text-[10px] text-[var(--text-dim)]">resolves to ${humanizeChannel(names, channelDraft.value.trim())}</div>`
+                                    : null}
+                                  ${observedRooms.length > 0
+                                    ? html`
+                                        <div class="mt-2 flex flex-wrap gap-1.5">
+                                          ${observedRooms.slice(0, 8).map(roomId => {
+                                            const humanized = humanizeChannel(names, roomId)
+                                            return html`
+                                              <button
+                                                type="button"
+                                                class="cursor-pointer rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-0.5 text-[10px] text-[var(--text-body)] hover:bg-[var(--white-8)]"
+                                                title=${roomId}
+                                                onClick=${() => { channelDraft.value = roomId }}
+                                              >${humanized
+                                                ? html`<span>${humanized}</span><span class="ml-1 text-[var(--text-dim)]">· ${truncateMiddle(roomId, 10)}</span>`
+                                                : truncateMiddle(roomId, 22)}</button>
+                                            `
+                                          })}
+                                        </div>
+                                      `
+                                    : null}
+                                  <div class="mt-2 flex justify-end">
+                                    <${ActionButton}
+                                      variant="primary"
+                                      size="sm"
+                                      disabled=${actionLoading.value || channelDraft.value.trim().length === 0}
+                                      onClick=${() => { void bindConnector(connectorId, group.name, channelDraft.value.trim()) }}
+                                    >${actionLoading.value ? 'Applying...' : 'bind'}<//>
+                                  </div>
+                                </div>
+                              `
+                            : null}
                         `
-                      })()}
-                    `)}
+                      : null}
                   </div>
-                `}
-          </div>
-          ${audit.length > 0
-            ? html`
-                <div>
-                  <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Recent binding audit</div>
-                  <div class="space-y-2">
-                    ${audit.slice(0, 4).map(entry => html`
-                      ${(() => {
-                        const keeperMeta = keeperByName.get(entry.keeper_name) ?? null
-                        const humanized = humanizeChannel(names, entry.channel_id)
-                        return html`
-                      <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2 text-[11px] text-[var(--text-dim)]">
-                        <div class="font-medium text-[var(--text-body)]">${entry.action} · ${truncateMiddle(entry.channel_id, 22)} · ${entry.keeper_name}</div>
-                        ${humanized
-                          ? html`<div class="mt-0.5 text-[10px] text-[var(--text-dim)]">${humanized}</div>`
-                          : null}
-                        ${keeperMeta && (keeperMeta.status || modelLabelForKeeper(keeperMeta) || runtimeLabelForKeeper(keeperMeta))
-                          ? html`
-                              <div class="mt-1 text-[10px]">
-                                ${keeperMeta.status || 'unknown'}
-                                ${modelLabelForKeeper(keeperMeta) ? ` · ${modelLabelForKeeper(keeperMeta)}` : ''}
-                                ${runtimeLabelForKeeper(keeperMeta) ? ` · ${runtimeLabelForKeeper(keeperMeta)}` : ''}
-                              </div>
-                            `
-                          : null}
-                        <div class="mt-1">${entry.actor_name || 'dashboard'} · ${timeAgo(entry.timestamp)}</div>
-                      </div>
-                        `
-                      })()}
-                    `)}
+                `
+              })}
+            </div>
+          `
+        : null}
+
+      ${unknownGroups.length > 0
+        ? html`
+            <div class="mt-3 space-y-2">
+              ${unknownGroups.map(group => html`
+                <div class="rounded-md border border-amber-400/30 bg-amber-500/8 px-3 py-2" data-keeper=${group.name}>
+                  <div class="flex items-baseline gap-2">
+                    <span class="text-amber-300">⚠</span>
+                    <div class="min-w-0">
+                      <div class="text-sm font-medium text-[var(--text-body)]">${group.name}</div>
+                      <div class="text-[10px] text-amber-200/90">binding references undefined keeper</div>
+                    </div>
+                  </div>
+                  <div class="mt-2 space-y-1">
+                    ${group.bindings.map(binding => {
+                      const humanized = humanizeChannel(names, binding.channel_id)
+                      return html`
+                        <div class="flex items-center justify-between gap-3 text-[12px]" data-channel-id=${binding.channel_id}>
+                          <div class="min-w-0 text-[var(--text-body)]">
+                            <span class="mr-1 text-[var(--text-dim)]">·</span>
+                            ${humanized
+                              ? html`<span>${humanized}</span>`
+                              : html`<span class="text-[var(--text-dim)]">names pending</span>`}
+                            <span class="ml-2 text-[10px] text-[var(--text-dim)]">(${truncateMiddle(binding.channel_id, 14)})</span>
+                          </div>
+                          ${bindingActionsEnabled
+                            ? html`
+                                <${ActionButton}
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled=${actionLoading.value}
+                                  ariaLabel=${`unbind ${binding.channel_id}`}
+                                  onClick=${() => { void unbindConnector(connectorId, binding.channel_id) }}
+                                >unbind<//>
+                              `
+                            : null}
+                        </div>
+                      `
+                    })}
                   </div>
                 </div>
-              `
-            : null}
-        </div>
-      </div>
+              `)}
+            </div>
+          `
+        : null}
+
+      ${connector
+        ? html`
+            <div class="mt-4 flex flex-wrap gap-3 text-[10px] text-[var(--text-dim)]">
+              ${connector.status_path
+                ? html`<span title=${connector.status_path}>runtime ${truncateMiddle(connector.status_path, 50)}</span>`
+                : null}
+              ${sidecarLogPath
+                ? html`<span title=${sidecarLogPath}>logs ${truncateMiddle(sidecarLogPath, 50)}</span>`
+                : null}
+            </div>
+          `
+        : null}
     </div>
   `
 }
@@ -1020,5 +1013,6 @@ export function resetConnectorStatusState() {
   connectorStatusResource.reset(EMPTY_SNAPSHOT)
   actionLoading.value = false
   channelDraft.value = ''
-  keeperDraft.value = ''
+  expandedKeeperFor.value = null
+  headerExpanded.value = false
 }

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -11,6 +11,7 @@ import {
   fetchGateStatus,
   type BindingInfo,
   type ChannelInfo,
+  type ConnectorNames,
   type GateConnectorInfo,
   type GateConnectorsData,
   type GateEventInfo,
@@ -169,6 +170,38 @@ function truncateMiddle(value: string, limit = 18): string {
   return `${trimmed.slice(0, head)}…${trimmed.slice(-tail)}`
 }
 
+function humanizeChannel(names: ConnectorNames | undefined, channelId: string): string {
+  if (!names) return ''
+  const channelName = names.channel_names[channelId]
+  const guildId = names.channel_to_guild[channelId]
+  const guildName = guildId ? names.guild_names[guildId] : undefined
+  if (!channelName && !guildName) return ''
+  if (channelName && guildName) return `${channelName} in "${guildName}"`
+  return channelName || `in "${guildName}"`
+}
+
+type LivenessState = 'ok' | 'warn' | 'down' | 'unknown'
+
+interface LivenessDot {
+  label: string
+  state: LivenessState
+  detail: string
+  hint: string
+}
+
+function dotClass(state: LivenessState): string {
+  switch (state) {
+    case 'ok':
+      return 'bg-emerald-400'
+    case 'warn':
+      return 'bg-amber-400'
+    case 'down':
+      return 'bg-rose-400'
+    default:
+      return 'bg-[var(--text-dim)]'
+  }
+}
+
 function uniqueStrings(values: string[]): string[] {
   const seen = new Set<string>()
   const ordered: string[] = []
@@ -315,8 +348,115 @@ function ConnectorLivePanel({
     gateHealthLabel = 'unhealthy'
   }
 
+  const names = connector?.names
+  const sidecarLogPath = connector?.names_path
+    ? connector.names_path.replace(
+        /\/\.masc\/connectors\/[^/]+\/names\.json$/,
+        `/.masc/logs/${connectorId}-sidecar-YYYYMMDD.log`,
+      )
+    : ''
+
+  const browserDot: LivenessDot = {
+    label: 'Browser → Server',
+    state: connectorError ? 'down' : 'ok',
+    detail: connectorError ? 'gate fetch failed' : 'live',
+    hint: connectorError ? `Check server at ${connector?.gate_base_url || 'localhost:8935'}` : '',
+  }
+  const serverDot: LivenessDot = (() => {
+    if (!connector?.available) {
+      return {
+        label: 'Server → Sidecar',
+        state: 'down',
+        detail: 'no status.json yet',
+        hint: `Run ./run.sh from sidecars/${connectorId}-bot/`,
+      }
+    }
+    if (connector.stale) {
+      return {
+        label: 'Server → Sidecar',
+        state: 'warn',
+        detail: `stale · last heartbeat ${timeAgo(connector.updated_at)}`,
+        hint: 'Sidecar heartbeats stopped — tail its log',
+      }
+    }
+    return {
+      label: 'Server → Sidecar',
+      state: 'ok',
+      detail: `heartbeat ${timeAgo(connector.updated_at)}`,
+      hint: '',
+    }
+  })()
+  const sidecarDot: LivenessDot = (() => {
+    if (!connector?.available) {
+      return {
+        label: `Sidecar → ${connectorName}`,
+        state: 'unknown',
+        detail: 'sidecar offline',
+        hint: '',
+      }
+    }
+    const advertised = connectorStateLabel(connector)
+    if (advertised === 'connected') {
+      return {
+        label: `Sidecar → ${connectorName}`,
+        state: 'ok',
+        detail: connector.bot_user_name ? `as ${connector.bot_user_name}` : 'linked',
+        hint: '',
+      }
+    }
+    if (advertised === 'stale') {
+      return {
+        label: `Sidecar → ${connectorName}`,
+        state: 'warn',
+        detail: 'stale heartbeat',
+        hint: 'Sidecar process may have stopped',
+      }
+    }
+    return {
+      label: `Sidecar → ${connectorName}`,
+      state: 'warn',
+      detail: 'gateway link not yet up',
+      hint: 'Check token and network reachability',
+    }
+  })()
+  const livenessDots: LivenessDot[] = [browserDot, serverDot, sidecarDot]
+
+  const showOnboarding =
+    configuredBindings.length === 0 && !connector?.available && !connectorError
+
   return html`
     <div class="mb-4 rounded-xl border border-[var(--white-8)] bg-[linear-gradient(135deg,rgba(88,101,242,0.16),rgba(88,101,242,0.04))] p-4">
+      <div class="mb-3 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2 text-[11px] text-[var(--text-body)]">
+        ${livenessDots.map(dot => html`
+          <div class="flex min-w-0 items-center gap-2" title=${dot.hint}>
+            <span class=${`inline-block h-2 w-2 rounded-full ${dotClass(dot.state)}`}></span>
+            <span class="font-medium">${dot.label}</span>
+            <span class="truncate text-[var(--text-dim)]">${dot.detail}</span>
+            ${dot.hint && (dot.state === 'down' || dot.state === 'warn')
+              ? html`<span class="text-[10px] italic text-[var(--text-dim)]">— ${dot.hint}</span>`
+              : null}
+          </div>
+        `)}
+      </div>
+
+      ${showOnboarding
+        ? html`
+            <div class="mb-3 rounded-md border border-dashed border-[var(--white-8)] bg-[var(--white-4)] px-3 py-3 text-[12px] text-[var(--text-body)]">
+              <div class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">
+                Connect ${connectorName} in 3 steps
+              </div>
+              <ol class="mb-2 list-decimal pl-5 text-[11px] leading-5 text-[var(--text-dim)]">
+                <li>Start the MASC server (the dashboard you're reading confirms it's running).</li>
+                <li>Start the sidecar: <code class="rounded bg-[var(--white-8)] px-1">cd sidecars/${connectorId}-bot && ./run.sh</code></li>
+                <li>Come back to this panel and bind a channel below.</li>
+              </ol>
+              <div class="text-[10px] text-[var(--text-dim)]">
+                Once the sidecar emits its first heartbeat this card disappears.
+              </div>
+            </div>
+          `
+        : null}
+
       <div class="flex flex-wrap items-start justify-between gap-3">
         <div class="min-w-0">
           <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-dim)]">Gate-Advertised Connector</div>
@@ -379,20 +519,33 @@ function ConnectorLivePanel({
               <span>status ${connector.status_path || '-'}</span>
               <span>bindings ${connector.binding_store_path || '-'}</span>
               <span>audit ${connector.audit_path || '-'}</span>
+              <span>names ${connector.names_path || '-'}</span>
+              ${sidecarLogPath
+                ? html`<span>sidecar logs ${sidecarLogPath}</span>`
+                : null}
             </div>
           `
         : null}
 
       <div class="mt-4 grid grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] gap-4 max-[980px]:grid-cols-1">
-        <div class="space-y-3">
+        <div class="space-y-3 rounded-md border border-dashed border-[var(--white-8)] p-3">
           <div>
-            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Channel ID</div>
+            <div class="text-[11px] font-semibold uppercase tracking-[0.18em] text-[var(--text-body)]">Create / replace binding</div>
+            <div class="mt-1 text-[10px] text-[var(--text-dim)]">
+              Existing bindings are listed on the right. Paste a channel ID and pick a keeper here to add or replace a binding.
+            </div>
+          </div>
+          <div>
+            <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Channel ID (draft)</div>
             <${TextInput}
               value=${channelDraft.value}
-              placeholder=${`${connectorName} channel identifier`}
+              placeholder=${`Paste ${connectorName} channel ID — right-click a channel → Copy ID`}
               ariaLabel=${channelInputLabel}
               onInput=${(e: Event) => { channelDraft.value = (e.target as HTMLInputElement).value }}
             />
+            ${channelDraft.value.trim() && humanizeChannel(names, channelDraft.value.trim())
+              ? html`<div class="mt-1 text-[10px] text-[var(--text-dim)]">resolves to ${humanizeChannel(names, channelDraft.value.trim())}</div>`
+              : null}
           </div>
           <div>
             <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Keeper</div>
@@ -437,15 +590,20 @@ function ConnectorLivePanel({
                 <div>
                   <div class="mb-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">Observed rooms</div>
                   <div class="flex flex-wrap gap-2">
-                    ${observedRooms.slice(0, 8).map(roomId => html`
+                    ${observedRooms.slice(0, 8).map(roomId => {
+                      const humanized = humanizeChannel(names, roomId)
+                      return html`
                       <button
                         type="button"
                         class="rounded-full border border-[var(--white-8)] bg-[var(--white-4)] px-2 py-1 text-[10px] text-[var(--text-body)] cursor-pointer hover:bg-[var(--white-8)]"
+                        title=${roomId}
                         onClick=${() => { channelDraft.value = roomId }}
                       >
-                        ${truncateMiddle(roomId, 22)}
+                        ${humanized
+                          ? html`<span>${humanized}</span><span class="ml-1 text-[var(--text-dim)]">· ${truncateMiddle(roomId, 10)}</span>`
+                          : truncateMiddle(roomId, 22)}
                       </button>
-                    `)}
+                    `})}
                   </div>
                 </div>
               `
@@ -480,11 +638,17 @@ function ConnectorLivePanel({
                     ${configuredBindings.map(binding => html`
                       ${(() => {
                         const keeperMeta = keeperByName.get(binding.keeper_name) ?? null
+                        const humanized = humanizeChannel(names, binding.channel_id)
                         return html`
                       <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2">
                         <div class="flex items-start justify-between gap-3">
                           <div class="min-w-0">
-                            <div class="text-xs font-medium text-[var(--text-body)]">${truncateMiddle(binding.channel_id, 26)}</div>
+                            <div class="text-xs font-medium text-[var(--text-body)]">
+                              <code>${truncateMiddle(binding.channel_id, 26)}</code>
+                              ${humanized
+                                ? html`<span class="ml-2 text-[var(--text-dim)]">— ${humanized}</span>`
+                                : html`<span class="ml-2 text-[var(--text-dim)]">— <span title="sidecar has not sent names yet">names pending</span></span>`}
+                            </div>
                             <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">keeper ${binding.keeper_name}</div>
                             ${keeperMeta
                               ? html`
@@ -521,9 +685,13 @@ function ConnectorLivePanel({
                     ${audit.slice(0, 4).map(entry => html`
                       ${(() => {
                         const keeperMeta = keeperByName.get(entry.keeper_name) ?? null
+                        const humanized = humanizeChannel(names, entry.channel_id)
                         return html`
                       <div class="rounded-md border border-[var(--white-8)] bg-[var(--white-4)] px-3 py-2 text-[11px] text-[var(--text-dim)]">
                         <div class="font-medium text-[var(--text-body)]">${entry.action} · ${truncateMiddle(entry.channel_id, 22)} · ${entry.keeper_name}</div>
+                        ${humanized
+                          ? html`<div class="mt-0.5 text-[10px] text-[var(--text-dim)]">${humanized}</div>`
+                          : null}
                         ${keeperMeta && (keeperMeta.status || modelLabelForKeeper(keeperMeta) || runtimeLabelForKeeper(keeperMeta))
                           ? html`
                               <div class="mt-1 text-[10px]">

--- a/lib/channel_gate_discord_names.ml
+++ b/lib/channel_gate_discord_names.ml
@@ -1,0 +1,121 @@
+(** Discord name_map side-store.
+
+    Names (guild/channel id -> human-readable names) are cosmetic data
+    owned by the sidecar: the bot enumerates guilds/channels every
+    heartbeat and atomically writes {!names_write_path}. Bindings are
+    immutable authority records; names can be renamed at any time. The
+    two concerns have separate lifecycles, so they live in separate
+    files. *)
+
+module U = Yojson.Safe.Util
+
+type name_map = {
+  guild_names : (string * string) list;
+  channel_names : (string * string) list;
+  channel_to_guild : (string * string) list;
+  updated_at : string;
+}
+
+let default_names_path = ".masc/connectors/discord/names.json"
+let legacy_names_path = "sidecars/discord-bot/.gate/discord_names.json"
+
+let resolve_path raw_path =
+  if Filename.is_relative raw_path then
+    Filename.concat (Env_config_core.base_path ()) raw_path
+  else
+    raw_path
+
+let configured_write_path env_name ~default =
+  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
+  | Some raw -> resolve_path raw
+  | None -> resolve_path default
+
+let configured_read_path env_name ~default ~legacy =
+  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
+  | Some raw -> resolve_path raw
+  | None ->
+      let preferred = resolve_path default in
+      let legacy = resolve_path legacy in
+      if Sys.file_exists preferred then preferred
+      else if Sys.file_exists legacy then legacy
+      else preferred
+
+let names_write_path () =
+  configured_write_path "MASC_DISCORD_NAMES_PATH" ~default:default_names_path
+
+let names_read_path () =
+  configured_read_path "MASC_DISCORD_NAMES_PATH"
+    ~default:default_names_path ~legacy:legacy_names_path
+
+let read_json_file_opt path =
+  if not (Sys.file_exists path) then
+    None
+  else
+    try Some (Yojson.Safe.from_file path) with
+    | _ -> None
+
+let string_member json key =
+  match json |> U.member key with
+  | `String s -> s
+  | _ -> ""
+
+let string_assoc_of_member key json =
+  match json |> U.member key with
+  | `Assoc items ->
+      List.filter_map (fun (k, v) ->
+        match v with
+        | `String s -> Some (k, s)
+        | _ -> None)
+        items
+  | _ -> []
+
+let empty =
+  {
+    guild_names = [];
+    channel_names = [];
+    channel_to_guild = [];
+    updated_at = "";
+  }
+
+let read () =
+  match read_json_file_opt (names_read_path ()) with
+  | None -> empty
+  | Some json ->
+      {
+        guild_names = string_assoc_of_member "guild_names" json;
+        channel_names = string_assoc_of_member "channel_names" json;
+        channel_to_guild = string_assoc_of_member "channel_to_guild" json;
+        updated_at = string_member json "updated_at";
+      }
+
+let to_json nm =
+  let to_assoc items =
+    `Assoc (List.map (fun (k, v) -> (k, `String v)) items)
+  in
+  `Assoc
+    [
+      ("guild_names", to_assoc nm.guild_names);
+      ("channel_names", to_assoc nm.channel_names);
+      ("channel_to_guild", to_assoc nm.channel_to_guild);
+      ("updated_at", `String nm.updated_at);
+    ]
+
+let save nm =
+  let path = names_write_path () in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let tmp = path ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        (Yojson.Safe.pretty_to_string (to_json nm) ^ "\n"));
+  Sys.rename tmp path
+
+let resolve_guild_id_for_channel ~channel_id =
+  let channel_id = String.trim channel_id in
+  if channel_id = "" then None
+  else
+    let nm = read () in
+    List.assoc_opt channel_id nm.channel_to_guild

--- a/lib/channel_gate_discord_state.ml
+++ b/lib/channel_gate_discord_state.ml
@@ -16,6 +16,13 @@ type audit_event = {
   previous_keeper : string;
 }
 
+type name_map = {
+  guild_names : (string * string) list;
+  channel_names : (string * string) list;
+  channel_to_guild : (string * string) list;
+  updated_at : string;
+}
+
 let connector_id = "discord"
 let display_name = "Discord"
 let channel = "discord"
@@ -24,11 +31,13 @@ let channel = "discord"
 let default_status_path = ".masc/connectors/discord/status.json"
 let default_binding_store_path = ".masc/connectors/discord/bindings.json"
 let default_binding_audit_path = ".masc/connectors/discord/binding_audit.jsonl"
+let default_names_path = ".masc/connectors/discord/names.json"
 
 let legacy_status_path = "sidecars/discord-bot/.gate/discord_status.json"
 let legacy_binding_store_path = "sidecars/discord-bot/.gate/discord_bindings.json"
 let legacy_binding_audit_path =
   "sidecars/discord-bot/.gate/discord_binding_audit.jsonl"
+let legacy_names_path = "sidecars/discord-bot/.gate/discord_names.json"
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"
@@ -76,6 +85,13 @@ let binding_audit_path () =
 let binding_audit_read_path () =
   configured_read_path "MASC_DISCORD_BINDING_AUDIT_PATH"
     ~default:default_binding_audit_path ~legacy:legacy_binding_audit_path
+
+let names_write_path () =
+  configured_write_path "MASC_DISCORD_NAMES_PATH" ~default:default_names_path
+
+let names_read_path () =
+  configured_read_path "MASC_DISCORD_NAMES_PATH"
+    ~default:default_names_path ~legacy:legacy_names_path
 
 let read_json_file_opt path =
   if not (Sys.file_exists path) then
@@ -209,6 +225,67 @@ let bool_member json key =
 let bool_option_member json key =
   json |> U.member key |> U.to_bool_option
 
+let string_assoc_of_member key json =
+  match json |> U.member key with
+  | `Assoc items ->
+      List.filter_map (fun (k, v) ->
+        match v with
+        | `String s -> Some (k, s)
+        | _ -> None)
+        items
+  | _ -> []
+
+let empty_name_map =
+  {
+    guild_names = [];
+    channel_names = [];
+    channel_to_guild = [];
+    updated_at = "";
+  }
+
+let read_name_map () =
+  match read_json_file_opt (names_read_path ()) with
+  | None -> empty_name_map
+  | Some json ->
+      {
+        guild_names = string_assoc_of_member "guild_names" json;
+        channel_names = string_assoc_of_member "channel_names" json;
+        channel_to_guild = string_assoc_of_member "channel_to_guild" json;
+        updated_at = string_member json "updated_at";
+      }
+
+let name_map_json nm =
+  let to_assoc items =
+    `Assoc (List.map (fun (k, v) -> (k, `String v)) items)
+  in
+  `Assoc
+    [
+      ("guild_names", to_assoc nm.guild_names);
+      ("channel_names", to_assoc nm.channel_names);
+      ("channel_to_guild", to_assoc nm.channel_to_guild);
+      ("updated_at", `String nm.updated_at);
+    ]
+
+let save_name_map nm =
+  let path = names_write_path () in
+  let dir = Filename.dirname path in
+  Fs_compat.mkdir_p dir;
+  let tmp = path ^ ".tmp" in
+  let oc = open_out_bin tmp in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      output_string oc
+        (Yojson.Safe.pretty_to_string (name_map_json nm) ^ "\n"));
+  Sys.rename tmp path
+
+let resolve_guild_id_for_channel ~channel_id =
+  let channel_id = String.trim channel_id in
+  if channel_id = "" then None
+  else
+    let nm = read_name_map () in
+    List.assoc_opt channel_id nm.channel_to_guild
+
 let stale_of_updated_at updated_at =
   match Types.parse_iso8601_opt updated_at with
   | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
@@ -225,6 +302,8 @@ let status_json ?(audit_limit = 10) () =
   let live_status = read_json_file_opt status_path in
   let binding_store_path = binding_store_read_path () in
   let audit_path = binding_audit_read_path () in
+  let names_path = names_read_path () in
+  let name_map = read_name_map () in
   let configured_bindings = read_bindings () in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let channel = "discord" in
@@ -258,6 +337,8 @@ let status_json ?(audit_limit = 10) () =
       ("status_path", `String status_path);
       ("binding_store_path", `String binding_store_path);
       ("audit_path", `String audit_path);
+      ("names_path", `String names_path);
+      ("names", name_map_json name_map);
       ("updated_at", `String updated_at);
       ( "last_ready_at",
         `String (status_field "last_ready_at" string_member "") );
@@ -325,6 +406,7 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
         ( "binding_store_path",
           `String (string_member status "binding_store_path") );
         ("audit_path", `String (string_member status "audit_path"));
+        ("names_path", `String (string_member status "names_path"));
       ]
   in
   let runtime_summary =
@@ -378,6 +460,8 @@ let connector_json ?gate_status_json ?(audit_limit = 10) () =
       ("status_path", `String (string_member status "status_path"));
       ("binding_store_path", `String (string_member status "binding_store_path"));
       ("audit_path", `String (string_member status "audit_path"));
+      ("names_path", `String (string_member status "names_path"));
+      ("names", status |> U.member "names");
       ("updated_at", `String (string_member status "updated_at"));
       ("last_ready_at", `String (string_member status "last_ready_at"));
       ("bot_user_name", `String (string_member status "bot_user_name"));
@@ -434,11 +518,14 @@ let bind ~channel_id ~keeper_name ~actor_name =
     in
     try
       save_bindings updated_bindings;
+      let guild_id =
+        Option.value (resolve_guild_id_for_channel ~channel_id) ~default:""
+      in
       append_audit_event
         {
           timestamp = Server_utils.iso8601_of_unix (Unix.gettimeofday ());
           action = "bind";
-          guild_id = "";
+          guild_id;
           channel_id;
           keeper_name;
           actor_id = actor_name;
@@ -472,11 +559,14 @@ let unbind ~channel_id ~actor_name =
         in
         try
           save_bindings updated_bindings;
+          let guild_id =
+            Option.value (resolve_guild_id_for_channel ~channel_id) ~default:""
+          in
           append_audit_event
             {
               timestamp = Server_utils.iso8601_of_unix (Unix.gettimeofday ());
               action = "unbind";
-              guild_id = "";
+              guild_id;
               channel_id;
               keeper_name = removed_binding.keeper_name;
               actor_id = actor_name;

--- a/lib/channel_gate_discord_state.ml
+++ b/lib/channel_gate_discord_state.ml
@@ -16,12 +16,7 @@ type audit_event = {
   previous_keeper : string;
 }
 
-type name_map = {
-  guild_names : (string * string) list;
-  channel_names : (string * string) list;
-  channel_to_guild : (string * string) list;
-  updated_at : string;
-}
+module Names = Channel_gate_discord_names
 
 let connector_id = "discord"
 let display_name = "Discord"
@@ -31,67 +26,38 @@ let channel = "discord"
 let default_status_path = ".masc/connectors/discord/status.json"
 let default_binding_store_path = ".masc/connectors/discord/bindings.json"
 let default_binding_audit_path = ".masc/connectors/discord/binding_audit.jsonl"
-let default_names_path = ".masc/connectors/discord/names.json"
 
 let legacy_status_path = "sidecars/discord-bot/.gate/discord_status.json"
 let legacy_binding_store_path = "sidecars/discord-bot/.gate/discord_bindings.json"
 let legacy_binding_audit_path =
   "sidecars/discord-bot/.gate/discord_binding_audit.jsonl"
-let legacy_names_path = "sidecars/discord-bot/.gate/discord_names.json"
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"
 
-let resolve_path raw_path =
-  if Filename.is_relative raw_path then
-    Filename.concat (Env_config_core.base_path ()) raw_path
-  else
-    raw_path
-
-let configured_write_path env_name ~default =
-  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
-  | Some raw -> resolve_path raw
-  | None -> resolve_path default
-
-let configured_read_path env_name ~default ~legacy =
-  match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
-  | Some raw -> resolve_path raw
-  | None ->
-      let preferred = resolve_path default in
-      let legacy = resolve_path legacy in
-      if Sys.file_exists preferred then preferred
-      else if Sys.file_exists legacy then legacy
-      else preferred
-
 let status_path () =
-  configured_read_path "MASC_DISCORD_STATUS_PATH" ~default:default_status_path
-    ~legacy:legacy_status_path
+  Names.configured_read_path "MASC_DISCORD_STATUS_PATH"
+    ~default:default_status_path ~legacy:legacy_status_path
 
 let status_write_path () =
-  configured_write_path "MASC_DISCORD_STATUS_PATH" ~default:default_status_path
+  Names.configured_write_path "MASC_DISCORD_STATUS_PATH"
+    ~default:default_status_path
 
 let binding_store_path () =
-  configured_write_path "MASC_DISCORD_BINDING_STORE_PATH"
+  Names.configured_write_path "MASC_DISCORD_BINDING_STORE_PATH"
     ~default:default_binding_store_path
 
 let binding_store_read_path () =
-  configured_read_path "MASC_DISCORD_BINDING_STORE_PATH"
+  Names.configured_read_path "MASC_DISCORD_BINDING_STORE_PATH"
     ~default:default_binding_store_path ~legacy:legacy_binding_store_path
 
 let binding_audit_path () =
-  configured_write_path "MASC_DISCORD_BINDING_AUDIT_PATH"
+  Names.configured_write_path "MASC_DISCORD_BINDING_AUDIT_PATH"
     ~default:default_binding_audit_path
 
 let binding_audit_read_path () =
-  configured_read_path "MASC_DISCORD_BINDING_AUDIT_PATH"
+  Names.configured_read_path "MASC_DISCORD_BINDING_AUDIT_PATH"
     ~default:default_binding_audit_path ~legacy:legacy_binding_audit_path
-
-let names_write_path () =
-  configured_write_path "MASC_DISCORD_NAMES_PATH" ~default:default_names_path
-
-let names_read_path () =
-  configured_read_path "MASC_DISCORD_NAMES_PATH"
-    ~default:default_names_path ~legacy:legacy_names_path
 
 let read_json_file_opt path =
   if not (Sys.file_exists path) then
@@ -225,67 +191,6 @@ let bool_member json key =
 let bool_option_member json key =
   json |> U.member key |> U.to_bool_option
 
-let string_assoc_of_member key json =
-  match json |> U.member key with
-  | `Assoc items ->
-      List.filter_map (fun (k, v) ->
-        match v with
-        | `String s -> Some (k, s)
-        | _ -> None)
-        items
-  | _ -> []
-
-let empty_name_map =
-  {
-    guild_names = [];
-    channel_names = [];
-    channel_to_guild = [];
-    updated_at = "";
-  }
-
-let read_name_map () =
-  match read_json_file_opt (names_read_path ()) with
-  | None -> empty_name_map
-  | Some json ->
-      {
-        guild_names = string_assoc_of_member "guild_names" json;
-        channel_names = string_assoc_of_member "channel_names" json;
-        channel_to_guild = string_assoc_of_member "channel_to_guild" json;
-        updated_at = string_member json "updated_at";
-      }
-
-let name_map_json nm =
-  let to_assoc items =
-    `Assoc (List.map (fun (k, v) -> (k, `String v)) items)
-  in
-  `Assoc
-    [
-      ("guild_names", to_assoc nm.guild_names);
-      ("channel_names", to_assoc nm.channel_names);
-      ("channel_to_guild", to_assoc nm.channel_to_guild);
-      ("updated_at", `String nm.updated_at);
-    ]
-
-let save_name_map nm =
-  let path = names_write_path () in
-  let dir = Filename.dirname path in
-  Fs_compat.mkdir_p dir;
-  let tmp = path ^ ".tmp" in
-  let oc = open_out_bin tmp in
-  Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
-    (fun () ->
-      output_string oc
-        (Yojson.Safe.pretty_to_string (name_map_json nm) ^ "\n"));
-  Sys.rename tmp path
-
-let resolve_guild_id_for_channel ~channel_id =
-  let channel_id = String.trim channel_id in
-  if channel_id = "" then None
-  else
-    let nm = read_name_map () in
-    List.assoc_opt channel_id nm.channel_to_guild
-
 let stale_of_updated_at updated_at =
   match Types.parse_iso8601_opt updated_at with
   | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
@@ -302,8 +207,8 @@ let status_json ?(audit_limit = 10) () =
   let live_status = read_json_file_opt status_path in
   let binding_store_path = binding_store_read_path () in
   let audit_path = binding_audit_read_path () in
-  let names_path = names_read_path () in
-  let name_map = read_name_map () in
+  let names_path = Names.names_read_path () in
+  let name_map = Names.read () in
   let configured_bindings = read_bindings () in
   let recent_audit = read_recent_audit ~limit:audit_limit in
   let channel = "discord" in
@@ -338,7 +243,7 @@ let status_json ?(audit_limit = 10) () =
       ("binding_store_path", `String binding_store_path);
       ("audit_path", `String audit_path);
       ("names_path", `String names_path);
-      ("names", name_map_json name_map);
+      ("names", Names.to_json name_map);
       ("updated_at", `String updated_at);
       ( "last_ready_at",
         `String (status_field "last_ready_at" string_member "") );
@@ -519,7 +424,7 @@ let bind ~channel_id ~keeper_name ~actor_name =
     try
       save_bindings updated_bindings;
       let guild_id =
-        Option.value (resolve_guild_id_for_channel ~channel_id) ~default:""
+        Option.value (Names.resolve_guild_id_for_channel ~channel_id) ~default:""
       in
       append_audit_event
         {
@@ -560,7 +465,7 @@ let unbind ~channel_id ~actor_name =
         try
           save_bindings updated_bindings;
           let guild_id =
-            Option.value (resolve_guild_id_for_channel ~channel_id) ~default:""
+            Option.value (Names.resolve_guild_id_for_channel ~channel_id) ~default:""
           in
           append_audit_event
             {

--- a/lib/dune
+++ b/lib/dune
@@ -39,6 +39,7 @@
    channel_gate
    channel_gate_connector
    channel_gate_metrics
+   channel_gate_discord_names
    channel_gate_discord_state
   channel_gate_imessage_state
    gate_protocol

--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -24,6 +24,10 @@ DISCORD_BINDING_AUDIT_PATH=.masc/connectors/discord/binding_audit.jsonl
 
 # Runtime status heartbeat used by the dashboard's direct Discord panel.
 DISCORD_STATUS_PATH=.masc/connectors/discord/status.json
+
+# Humanization side-map: guild + channel id-to-name. Written every
+# STATUS_HEARTBEAT_SEC by enumerating discord.py's cached guilds/channels.
+DISCORD_NAMES_PATH=.masc/connectors/discord/names.json
 STATUS_HEARTBEAT_SEC=10
 
 # Discord role ID for admin commands (optional)

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -25,23 +25,28 @@ up but the Discord bot has not written its runtime heartbeat yet.
 
 ## Quick Start
 
-Run the bot from `sidecars/discord-bot`, but make sure its runtime root matches
-the server's `MASC_BASE_PATH`.
+One command from a clean clone, once the Discord token is in `.env`:
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel) &&
-cd "$REPO_ROOT/sidecars/discord-bot" &&
-cp .env.example .env
+cd "$(git rev-parse --show-toplevel)/sidecars/discord-bot"
+cp .env.example .env          # edit DISCORD_BOT_TOKEN (and keeper_map)
+uv pip install -e ".[dev]"    # install once
+./run.sh                      # start the bot
+```
 
-# Required for shared connector state with the local MASC server.
-# Match the same runtime root the server uses.
+`run.sh` resolves `MASC_BASE_PATH` from the enclosing git repo root (same root
+the server uses when both live in this checkout), loads `.env`, and tees both
+stdout and stderr to a dated log file at
+`$MASC_BASE_PATH/.masc/logs/discord-sidecar-YYYYMMDD.log`. The script also
+exposes `./run.sh tail` for live log follow and `./run.sh status` for a quick
+dump of the current `status.json`.
+
+If you want the sidecar to share state with a server that runs outside this
+checkout, export `MASC_BASE_PATH` before invoking `./run.sh`:
+
+```bash
 export MASC_BASE_PATH=/path/to/server/runtime/root
-
-# Install dependencies once.
-uv pip install -e ".[dev]"
-
-# Start the bot from this directory so .env is auto-loaded.
-python -m src
+./run.sh
 ```
 
 ## Setup
@@ -75,6 +80,7 @@ By default the bot writes runtime files under:
 - `.masc/connectors/discord/bindings.json`
 - `.masc/connectors/discord/binding_audit.jsonl`
 - `.masc/connectors/discord/status.json`
+- `.masc/connectors/discord/names.json` (guild + channel id-to-name humanization)
 
 Relative paths resolve from `MASC_BASE_PATH` when it is set; otherwise they
 resolve from the bot's current working directory.
@@ -107,9 +113,25 @@ Use that mode only if the server is configured to read the same files via
 # Install dependencies
 uv pip install -e ".[dev]"
 
-# Run the bot
+# Run the bot (preferred entry point — handles MASC_BASE_PATH + logs)
+./run.sh
+
+# Plain invocation (equivalent when MASC_BASE_PATH is already set)
 python -m src
 ```
+
+### Logs
+
+`./run.sh start` writes combined stdout+stderr to
+`$MASC_BASE_PATH/.masc/logs/discord-sidecar-YYYYMMDD.log`. The file is created
+per calendar day and never auto-rotated; prune manually as needed:
+
+```bash
+find "$MASC_BASE_PATH/.masc/logs" -name 'discord-sidecar-*.log' -mtime +14 -delete
+```
+
+Use `./run.sh tail` to follow today's log, or `./run.sh status` to dump the
+latest `status.json` the sidecar has written.
 
 ### 5. Test
 

--- a/sidecars/discord-bot/run.sh
+++ b/sidecars/discord-bot/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Discord Gate Bot runner.
+#
+# Resolves MASC_BASE_PATH from the enclosing git repo root when unset,
+# verifies .env, and streams combined stdout+stderr to a dated log file
+# under $MASC_BASE_PATH/.masc/logs/.
+#
+# Usage:
+#   ./run.sh              start the bot (foreground, tees to today's log)
+#   ./run.sh tail         tail -F today's log file
+#   ./run.sh status       pretty-print the current status.json
+#
+# Designed to be safe to copy-paste: no background launches, no pid files.
+
+set -euo pipefail
+
+script_dir() { cd "$(dirname "$0")" && pwd; }
+
+resolve_base_path() {
+  if [[ -n "${MASC_BASE_PATH:-}" ]]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+    return
+  fi
+  git -C "$(script_dir)" rev-parse --show-toplevel
+}
+
+BASE_PATH="$(resolve_base_path)"
+export MASC_BASE_PATH="$BASE_PATH"
+
+LOG_DIR="$BASE_PATH/.masc/logs"
+LOG_FILE="$LOG_DIR/discord-sidecar-$(date +%Y%m%d).log"
+STATUS_FILE="$BASE_PATH/.masc/connectors/discord/status.json"
+
+cmd="${1:-start}"
+case "$cmd" in
+  start)
+    cd "$(script_dir)"
+    if [[ ! -f .env ]]; then
+      echo "ERROR: .env missing. Copy .env.example and fill DISCORD_BOT_TOKEN." >&2
+      exit 1
+    fi
+    mkdir -p "$LOG_DIR"
+    printf 'Starting Discord sidecar\n  MASC_BASE_PATH=%s\n  log file:      %s\n' \
+      "$BASE_PATH" "$LOG_FILE" >&2
+    python -m src 2>&1 | tee -a "$LOG_FILE"
+    ;;
+  tail)
+    if [[ ! -f "$LOG_FILE" ]]; then
+      echo "No log file yet at $LOG_FILE" >&2
+      echo "Run './run.sh start' first, or check $LOG_DIR for older logs." >&2
+      exit 1
+    fi
+    tail -F "$LOG_FILE"
+    ;;
+  status)
+    if [[ ! -f "$STATUS_FILE" ]]; then
+      echo "No status.json at $STATUS_FILE" >&2
+      echo "The sidecar hasn't started yet or MASC_BASE_PATH points somewhere else." >&2
+      exit 1
+    fi
+    if command -v jq >/dev/null 2>&1; then
+      jq . "$STATUS_FILE"
+    else
+      cat "$STATUS_FILE"
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [start|tail|status]" >&2
+    exit 2
+    ;;
+esac

--- a/sidecars/discord-bot/src/bot.py
+++ b/sidecars/discord-bot/src/bot.py
@@ -33,7 +33,12 @@ from .formatters import (
     strip_state_blocks,
 )
 from .gate_client import BreakerSnapshot, GateClient, GateResponse
-from .status_store import ConnectorRuntimeStatus, StatusStore
+from .status_store import (
+    ConnectorRuntimeStatus,
+    NamesSnapshot,
+    NamesStore,
+    StatusStore,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -83,6 +88,7 @@ class GateBot(discord.Client):
         self.binding_store = BindingStore(self.cfg.binding_store_path())
         self.audit_store = BindingAuditStore(self.cfg.binding_audit_path())
         self.status_store = StatusStore(self.cfg.status_path())
+        self.names_store = NamesStore(self.cfg.names_path())
         persisted_bindings = self.binding_store.load()
         if persisted_bindings is None:
             legacy_binding_store = BindingStore(self.cfg.legacy_binding_store_path())
@@ -159,6 +165,7 @@ class GateBot(discord.Client):
         healthy = await self.gate.health_check()
         self._note_gate_health(healthy)
         self._write_runtime_status()
+        self._write_names_snapshot()
         if healthy:
             logger.info("Gate health check: OK")
         else:
@@ -282,6 +289,45 @@ class GateBot(discord.Client):
         except OSError as exc:
             logger.warning("Failed to write Discord status store %s: %s", self.status_store.path, exc)
 
+    def _write_names_snapshot(self) -> None:
+        """Snapshot guild and channel names for dashboard humanization.
+
+        Only runs when the bot is connected. Offline runs leave the
+        previous names.json in place — the OCaml gate reads last-known
+        state and falls back to empty guild_id when a channel is
+        unknown, so stale names are acceptable.
+        """
+        if self.is_closed() or not self.is_ready():
+            return
+        guild_names: dict[str, str] = {}
+        channel_names: dict[str, str] = {}
+        channel_to_guild: dict[str, str] = {}
+        for guild in self.guilds:
+            guild_id = str(guild.id)
+            guild_names[guild_id] = guild.name
+            for channel in guild.text_channels:
+                channel_id = str(channel.id)
+                channel_names[channel_id] = f"#{channel.name}"
+                channel_to_guild[channel_id] = guild_id
+            for thread in guild.threads:
+                thread_id = str(thread.id)
+                channel_names[thread_id] = f"#{thread.name}"
+                channel_to_guild[thread_id] = guild_id
+        snapshot = NamesSnapshot(
+            updated_at=utc_now_iso(),
+            guild_names=guild_names,
+            channel_names=channel_names,
+            channel_to_guild=channel_to_guild,
+        )
+        try:
+            self.names_store.write(snapshot)
+        except OSError as exc:
+            logger.warning(
+                "Failed to write Discord names store %s: %s",
+                self.names_store.path,
+                exc,
+            )
+
     async def _status_heartbeat_loop(self) -> None:
         interval = max(5, self.cfg.status_heartbeat_sec)
         while True:
@@ -290,6 +336,7 @@ class GateBot(discord.Client):
                 healthy = await self.gate.health_check()
                 self._note_gate_health(healthy)
                 self._write_runtime_status()
+                self._write_names_snapshot()
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -19,10 +19,12 @@ from pydantic_settings import BaseSettings
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/discord/bindings.json"
 DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/discord/binding_audit.jsonl"
 DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
+DEFAULT_NAMES_PATH: Final[str] = ".masc/connectors/discord/names.json"
 
 LEGACY_BINDING_STORE_PATH: Final[str] = ".gate/discord_bindings.json"
 LEGACY_BINDING_AUDIT_PATH: Final[str] = ".gate/discord_binding_audit.jsonl"
 LEGACY_STATUS_PATH: Final[str] = ".gate/discord_status.json"
+LEGACY_NAMES_PATH: Final[str] = ".gate/discord_names.json"
 LEGACY_BASE_ROOT: Final[Path] = Path("sidecars/discord-bot")
 
 
@@ -80,6 +82,13 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices(
             "DISCORD_STATUS_PATH",
             "discord_status_path",
+        ),
+    )
+    discord_names_path: str = Field(
+        default=DEFAULT_NAMES_PATH,
+        validation_alias=AliasChoices(
+            "DISCORD_NAMES_PATH",
+            "discord_names_path",
         ),
     )
 
@@ -166,6 +175,7 @@ class BotConfig(BaseSettings):
         "discord_binding_store_path",
         "discord_binding_audit_path",
         "discord_status_path",
+        "discord_names_path",
     )
     @classmethod
     def validate_non_empty_path(cls, v: str) -> str:
@@ -244,6 +254,9 @@ class BotConfig(BaseSettings):
     def status_path(self) -> Path:
         return self._resolve_storage_path(self.discord_status_path)
 
+    def names_path(self) -> Path:
+        return self._resolve_storage_path(self.discord_names_path)
+
     def legacy_binding_store_path(self) -> Path:
         return self._resolve_legacy_storage_path(LEGACY_BINDING_STORE_PATH)
 
@@ -252,6 +265,9 @@ class BotConfig(BaseSettings):
 
     def legacy_status_path(self) -> Path:
         return self._resolve_legacy_storage_path(LEGACY_STATUS_PATH)
+
+    def legacy_names_path(self) -> Path:
+        return self._resolve_legacy_storage_path(LEGACY_NAMES_PATH)
 
     def gate_message_url(self) -> str:
         base = self.gate_base_url.rstrip("/")

--- a/sidecars/discord-bot/src/status_store.py
+++ b/sidecars/discord-bot/src/status_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -60,6 +60,47 @@ class StatusStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = self.path.with_name(f".{self.path.name}.tmp")
         payload = json.dumps(asdict(status), indent=2, sort_keys=True)
+        try:
+            tmp_path.write_text(f"{payload}\n", encoding="utf-8")
+            os.replace(tmp_path, self.path)
+        except OSError:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
+
+
+@dataclass(frozen=True, slots=True)
+class NamesSnapshot:
+    """Guild and channel id-to-name maps for dashboard humanization.
+
+    The maps use plain dicts for JSON serialization. Callers MUST treat
+    these as read-only — NamesStore.write accepts a snapshot and never
+    mutates it. Produce a new NamesSnapshot to change contents.
+    """
+
+    updated_at: str
+    guild_names: dict[str, str] = field(default_factory=dict)
+    channel_names: dict[str, str] = field(default_factory=dict)
+    channel_to_guild: dict[str, str] = field(default_factory=dict)
+
+
+class NamesStore:
+    """Persist the id-to-name side-map atomically.
+
+    Separate from StatusStore because guild/channel names are cosmetic
+    and mutate on Discord-side renames; bindings and status should not
+    be rewritten when a channel is renamed.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def write(self, snapshot: NamesSnapshot) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_name(f".{self.path.name}.tmp")
+        payload = json.dumps(asdict(snapshot), indent=2, sort_keys=True)
         try:
             tmp_path.write_text(f"{payload}\n", encoding="utf-8")
             os.replace(tmp_path, self.path)

--- a/sidecars/discord-bot/tests/test_status_store.py
+++ b/sidecars/discord-bot/tests/test_status_store.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from src.status_store import ConnectorRuntimeStatus, StatusStore
+from src.status_store import (
+    ConnectorRuntimeStatus,
+    NamesSnapshot,
+    NamesStore,
+    StatusStore,
+)
 
 
 def test_status_store_writes_connector_runtime_snapshot(tmp_path: Path) -> None:
@@ -47,3 +52,36 @@ def test_status_store_writes_connector_runtime_snapshot(tmp_path: Path) -> None:
         "runtime_bindings_count": 2,
         "updated_at": "2026-04-08T13:00:00Z",
     }
+
+
+def test_names_store_writes_humanization_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "state" / "discord_names.json"
+    store = NamesStore(path)
+
+    store.write(
+        NamesSnapshot(
+            updated_at="2026-04-15T00:00:00Z",
+            guild_names={"123": "sangsu-lab"},
+            channel_names={"456": "#general", "457": "#dev"},
+            channel_to_guild={"456": "123", "457": "123"},
+        )
+    )
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "updated_at": "2026-04-15T00:00:00Z",
+        "guild_names": {"123": "sangsu-lab"},
+        "channel_names": {"456": "#general", "457": "#dev"},
+        "channel_to_guild": {"456": "123", "457": "123"},
+    }
+
+
+def test_names_store_empty_snapshot_is_valid(tmp_path: Path) -> None:
+    path = tmp_path / "discord_names.json"
+    store = NamesStore(path)
+
+    store.write(NamesSnapshot(updated_at="2026-04-15T00:00:00Z"))
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["guild_names"] == {}
+    assert data["channel_names"] == {}
+    assert data["channel_to_guild"] == {}

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -41,9 +41,11 @@ let with_discord_paths dir f =
   let status_path = Filename.concat dir "status.json" in
   let binding_path = Filename.concat dir "bindings.json" in
   let audit_path = Filename.concat dir "audit.jsonl" in
+  let names_path = Filename.concat dir "names.json" in
   with_env "MASC_DISCORD_STATUS_PATH" (Some status_path) (fun () ->
     with_env "MASC_DISCORD_BINDING_STORE_PATH" (Some binding_path) (fun () ->
-      with_env "MASC_DISCORD_BINDING_AUDIT_PATH" (Some audit_path) f))
+      with_env "MASC_DISCORD_BINDING_AUDIT_PATH" (Some audit_path) (fun () ->
+        with_env "MASC_DISCORD_NAMES_PATH" (Some names_path) f)))
 
 let test_status_json_reports_missing_live_status () =
   with_temp_dir @@ fun dir ->
@@ -154,6 +156,88 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
       (connector |> U.member "observed_channel" |> U.member "channel"
        |> U.to_string))
 
+let test_name_map_round_trip () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    let nm : Discord_state.name_map =
+      {
+        guild_names = [ ("123", "sangsu-lab") ];
+        channel_names = [ ("456", "#general") ];
+        channel_to_guild = [ ("456", "123") ];
+        updated_at = "2026-04-15T00:00:00Z";
+      }
+    in
+    Discord_state.save_name_map nm;
+    let loaded = Discord_state.read_name_map () in
+    check string "guild name round-trips" "sangsu-lab"
+      (List.assoc "123" loaded.guild_names);
+    check string "channel name round-trips" "#general"
+      (List.assoc "456" loaded.channel_names);
+    check string "channel_to_guild round-trips" "123"
+      (List.assoc "456" loaded.channel_to_guild);
+    check string "updated_at round-trips" "2026-04-15T00:00:00Z"
+      loaded.updated_at)
+
+let test_read_name_map_missing_returns_empty () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    let loaded = Discord_state.read_name_map () in
+    check int "no guild names" 0 (List.length loaded.guild_names);
+    check int "no channel names" 0 (List.length loaded.channel_names);
+    check int "no channel_to_guild entries" 0
+      (List.length loaded.channel_to_guild);
+    check string "empty updated_at" "" loaded.updated_at)
+
+let test_resolve_guild_id_hits_and_misses () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    Discord_state.save_name_map
+      {
+        guild_names = [ ("123", "sangsu-lab") ];
+        channel_names = [ ("456", "#general") ];
+        channel_to_guild = [ ("456", "123") ];
+        updated_at = "2026-04-15T00:00:00Z";
+      };
+    check (option string) "hit returns guild id" (Some "123")
+      (Discord_state.resolve_guild_id_for_channel ~channel_id:"456");
+    check (option string) "miss returns None" None
+      (Discord_state.resolve_guild_id_for_channel ~channel_id:"999");
+    check (option string) "empty channel_id returns None" None
+      (Discord_state.resolve_guild_id_for_channel ~channel_id:""))
+
+let test_bind_populates_guild_id_when_names_available () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    Discord_state.save_name_map
+      {
+        guild_names = [ ("guild-1", "sangsu-lab") ];
+        channel_names = [ ("chan-1", "#general") ];
+        channel_to_guild = [ ("chan-1", "guild-1") ];
+        updated_at = "2026-04-15T00:00:00Z";
+      };
+    match
+      Discord_state.bind ~channel_id:"chan-1" ~keeper_name:"luna"
+        ~actor_name:"dashboard"
+    with
+    | Error err -> fail err
+    | Ok json ->
+        let audit = json |> U.member "recent_audit" |> U.to_list in
+        check string "audit guild_id resolved" "guild-1"
+          (List.hd audit |> U.member "guild_id" |> U.to_string))
+
+let test_bind_accepts_missing_names_with_empty_guild_id () =
+  with_temp_dir @@ fun dir ->
+  with_discord_paths dir (fun () ->
+    match
+      Discord_state.bind ~channel_id:"unknown" ~keeper_name:"luna"
+        ~actor_name:"dashboard"
+    with
+    | Error err -> fail err
+    | Ok json ->
+        let audit = json |> U.member "recent_audit" |> U.to_list in
+        check string "audit guild_id empty when names absent" ""
+          (List.hd audit |> U.member "guild_id" |> U.to_string))
+
 let () =
   run "channel_gate_discord_state"
     [
@@ -167,5 +251,17 @@ let () =
             test_unbind_removes_existing_binding;
           test_case "connectors json advertises connector descriptor" `Quick
             test_connectors_json_advertises_gate_connector_descriptor;
+        ] );
+      ( "name_map",
+        [
+          test_case "round trip" `Quick test_name_map_round_trip;
+          test_case "missing file returns empty" `Quick
+            test_read_name_map_missing_returns_empty;
+          test_case "resolve hits and misses" `Quick
+            test_resolve_guild_id_hits_and_misses;
+          test_case "bind populates guild_id when names available" `Quick
+            test_bind_populates_guild_id_when_names_available;
+          test_case "bind accepts missing names with empty guild_id" `Quick
+            test_bind_accepts_missing_names_with_empty_guild_id;
         ] );
     ]

--- a/test/test_channel_gate_discord_state.ml
+++ b/test/test_channel_gate_discord_state.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Discord_state = Masc_mcp.Channel_gate_discord_state
+module Discord_names = Masc_mcp.Channel_gate_discord_names
 module U = Yojson.Safe.Util
 
 let with_env name value f =
@@ -159,7 +160,7 @@ let test_connectors_json_advertises_gate_connector_descriptor () =
 let test_name_map_round_trip () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
-    let nm : Discord_state.name_map =
+    let nm : Discord_names.name_map =
       {
         guild_names = [ ("123", "sangsu-lab") ];
         channel_names = [ ("456", "#general") ];
@@ -167,8 +168,8 @@ let test_name_map_round_trip () =
         updated_at = "2026-04-15T00:00:00Z";
       }
     in
-    Discord_state.save_name_map nm;
-    let loaded = Discord_state.read_name_map () in
+    Discord_names.save nm;
+    let loaded = Discord_names.read () in
     check string "guild name round-trips" "sangsu-lab"
       (List.assoc "123" loaded.guild_names);
     check string "channel name round-trips" "#general"
@@ -181,7 +182,7 @@ let test_name_map_round_trip () =
 let test_read_name_map_missing_returns_empty () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
-    let loaded = Discord_state.read_name_map () in
+    let loaded = Discord_names.read () in
     check int "no guild names" 0 (List.length loaded.guild_names);
     check int "no channel names" 0 (List.length loaded.channel_names);
     check int "no channel_to_guild entries" 0
@@ -191,7 +192,7 @@ let test_read_name_map_missing_returns_empty () =
 let test_resolve_guild_id_hits_and_misses () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
-    Discord_state.save_name_map
+    Discord_names.save
       {
         guild_names = [ ("123", "sangsu-lab") ];
         channel_names = [ ("456", "#general") ];
@@ -199,16 +200,16 @@ let test_resolve_guild_id_hits_and_misses () =
         updated_at = "2026-04-15T00:00:00Z";
       };
     check (option string) "hit returns guild id" (Some "123")
-      (Discord_state.resolve_guild_id_for_channel ~channel_id:"456");
+      (Discord_names.resolve_guild_id_for_channel ~channel_id:"456");
     check (option string) "miss returns None" None
-      (Discord_state.resolve_guild_id_for_channel ~channel_id:"999");
+      (Discord_names.resolve_guild_id_for_channel ~channel_id:"999");
     check (option string) "empty channel_id returns None" None
-      (Discord_state.resolve_guild_id_for_channel ~channel_id:""))
+      (Discord_names.resolve_guild_id_for_channel ~channel_id:""))
 
 let test_bind_populates_guild_id_when_names_available () =
   with_temp_dir @@ fun dir ->
   with_discord_paths dir (fun () ->
-    Discord_state.save_name_map
+    Discord_names.save
       {
         guild_names = [ ("guild-1", "sangsu-lab") ];
         channel_names = [ ("chan-1", "#general") ];


### PR DESCRIPTION
## Summary

Two-phase rework of the Discord connector so the dashboard actually tells the operator what's bound, who it's bound to, and where the sidecar runs.

### Phase 1 — Gate-side & sidecar hardening (earlier commits)
- `channel_gate_discord_state.ml`: `name_map` side-store (`names.json`), `resolve_guild_id_for_channel`, `bind/unbind` fill `audit_event.guild_id` when resolvable
- Python sidecar: `NamesSnapshot` / `NamesStore` atomic write; heartbeat loop enumerates `self.guilds` → `names.json`
- `sidecars/discord-bot/run.sh`: resolves `MASC_BASE_PATH` from worktree git root, tees stdout/stderr to `${BASE}/.masc/logs/discord-sidecar-YYYYMMDD.log`; subcommands `start|tail|status`
- Dashboard: 3-way liveness banner, channel humanization (`#name in "server"`), onboarding card, sidecar log path footer

### Phase 2 — Dashboard keeper-first rewrite (`7fe83dc38`)
- `ConnectorLivePanel` rebuilt: keeper sections are primary; bindings nest under each keeper with per-keeper `+ add channel` inline form
- Unknown-keeper bindings (binding references a `keeper_name` not in `/gate/keepers`) land in a `⚠` warning group — silent failure forbidden
- 3-way liveness collapses to a single header dot + `[▾]` expand for per-dot detail, guild count, binding source, refresh
- Removed: OBSERVED ROOMS / SUGGESTED KEEPERS / dashed draft form / 3-step onboarding card / Recent binding audit as independent blocks (folded into header or keeper context; audit file untouched, still CLI/tail-accessible)
- `ActionButton` gains `ariaLabel` prop so tests can select buttons without textContent fragility

## Why

User reported "5가지 모두 잘 모르겠음" on the prior Connector view (connection state, binding reality, onboarding flow, sidecar run location, keeper relationship). Phase 1's UI additions landed the signals but kept the binding-first mental model; Phase 2 flips the model so each keeper is a readable unit of responsibility. Validated by Playwright screenshot of the running dev server — sidecar-off empty state shows copy-paste `Start:` hint; binding whose keeper is missing from directory surfaces under `⚠ <name>`.

## Test plan

- [x] `npm test -- --run connector-status` — 11/11 (5 modified, 1 deleted, 6 new)
- [x] `npm test -- --run` full dashboard suite — 660/660
- [x] `npx tsc --noEmit` — clean
- [x] Playwright screenshot of `localhost:5173/dashboard/#command?section=operations&view=connectors` — header/empty-state/unknown group render as designed
- [ ] Happy-path browser verify with live sidecar (bindings show `#channel in "guild"`, `+ add channel` expand submits through `/api/v1/gate/connector/bind`)
- [ ] CodeRabbit review