### PR TITLE
fix(cascade): replace List.hd/tl with safe match in weighted selector

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -351,9 +351,13 @@ let weighted_shuffle
       let r = rand_int total_weight in
       (* Find the selected entry via cumulative weight *)
       let rec find_selected cumulative = function
-        | [] -> (* fallback: first entry *)
-          (List.hd entries,
-           List.tl entries)
+        | [] ->
+          (* fallback: first entry. Unreachable when total_weight > 0
+             since [entries] is non-empty in that branch, but match
+             must be exhaustive. *)
+          (match entries with
+           | first :: rest -> (first, rest)
+           | [] -> assert false)
         | (e : Cascade_config_loader.weighted_entry) :: rest ->
           let cumulative' = cumulative + e.weight in
           if r < cumulative' then (e, rest)


### PR DESCRIPTION
## Why

#7382 (cascade scaffold) imported a weighted-selector fallback using `List.hd` / `List.tl` on entries:

```ocaml
| [] -> (List.hd entries, List.tl entries)
```

Both are partial functions and trip the `lib_list_hd` / `lib_list_tl` ratchet in the Health CI step.

`.ci/health-baseline.json` was not updated when #7382 merged, so every subsequent PR is blocked at Health with:

```
Ratchet: fail (lib_list_hd 0->1; lib_list_tl 0->1)
```

This is an environment regression unrelated to PR contents — currently blocking #7347, #7377, #7378, #7383 etc.

## Fix

Replace the fallback with an explicit pattern match. Logic identical (the `[]` branch is unreachable when `total_weight > 0`, but the match must remain exhaustive — so `assert false`).

## Verification

- `dune build @check --root .` — clean
- `grep -rn 'List\.hd\|List\.tl' lib/` — 0 hits
- Ratchet stays at 0/0; downstream PRs unblock once this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)