### PR TITLE
fix(cascade): replace List.hd/List.tl fallback with pattern match

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -349,11 +349,14 @@ let weighted_shuffle
     if total_weight <= 0 then entries
     else
       let r = rand_int total_weight in
-      (* Find the selected entry via cumulative weight *)
+      (* Find the selected entry via cumulative weight. The outer [] | [_]
+         guard means `entries` always has >= 2 elements here; the inner `[]`
+         arm is unreachable and asserts as such. *)
       let rec find_selected cumulative = function
-        | [] -> (* fallback: first entry *)
-          (List.hd entries,
-           List.tl entries)
+        | [] ->
+          (match entries with
+           | first :: rest -> (first, rest)
+           | [] -> assert false)
         | (e : Cascade_config_loader.weighted_entry) :: rest ->
           let cumulative' = cumulative + e.weight in
           if r < cumulative' then (e, rest)


### PR DESCRIPTION
## Summary

Replace the unreachable `List.hd entries, List.tl entries` fallback in `weighted_shuffle.find_selected` with a pattern match on `entries`. No behavior change.

## Why

`scripts/health_snapshot.sh` treats any `List.hd` / `List.tl` occurrence in `lib/` as a ratchet regression — the baseline pins `lib_list_hd=0` and `lib_list_tl=0`. Commits #7382 / #7386 (cascade scaffold) introduced these calls in the fallback arm of `find_selected`. Although the outer `match entries with [] | [_] -> entries` guard makes the fallback unreachable, the text-based ratchet in `health_snapshot.sh` can't see that distinction, so CI `Health` job fails for any downstream PR that gets the `refs/pull/*/merge` commit.

PR #7388 is one such downstream PR — its `Health` check reports `Ratchet: fail (lib_list_hd 0->1; lib_list_tl 0->1)` even though that PR touches only dashboard TypeScript. This fix removes the ratchet regression at the source.

The replacement uses `match entries with | first :: rest -> (first, rest) | [] -> assert false`. The `[]` arm is genuinely unreachable because of the outer guard; an `assert false` documents that invariant without adding new unsafe primitives.

## Test plan

- [x] `dune build --root .` — clean
- [x] `rg -c 'List\.hd' lib -g '*.{ml,mli}'` → 0, `rg -c 'List\.tl' lib -g '*.{ml,mli}'` → 0
- [ ] CI `Health`, `Build and Test`, `TLA+ Model Checking` green
- [ ] Downstream PR #7388 rebases and passes `Health` without further changes