### PR TITLE
feat(code-shell): allow pipes in masc_code_shell (allowlist + metachar guard remain)

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -41,8 +41,14 @@ let allowed_shell_commands = [
 ]
 
 let validate_code_shell_command (command : string) : (unit, string) result =
+  (* Pipes (|) are allowed: every segment is independently validated
+     against [allowed_shell_commands], and dangerous metacharacters
+     ([;] [`] [$] [&&] standalone [&]) remain blocked by
+     validate_command_coding_with_allowlist. Without pipes, keepers
+     cannot do common composition like `git log | head` or `rg X | wc`,
+     forcing them into noisy multi-call sequences. *)
   Worker_dev_tools.validate_command_coding_with_allowlist
-    ~allow_pipes:false
+    ~allow_pipes:true
     ~allowed_commands:allowed_shell_commands
     command
 

--- a/test/test_tool_code_write_coverage.ml
+++ b/test/test_tool_code_write_coverage.ml
@@ -179,15 +179,20 @@ let test_mixed_case_org () =
 
 (* ── validate_code_shell_command ─────────────────────────────────── *)
 
-let test_validate_code_shell_command_rejects_pipe () =
+let test_validate_code_shell_command_allows_pipe () =
+  (* Pipes are now allowed: each segment is independently validated
+     against the allowlist; dangerous metacharacters remain blocked. *)
+  check (result unit string) "piped allowlisted commands accepted"
+    (Ok ())
+    (Tool_code_write.validate_code_shell_command "dune build 2>&1 | tail -5")
+
+let test_validate_code_shell_command_rejects_pipe_to_disallowed () =
   match
-    Tool_code_write.validate_code_shell_command
-      "dune build 2>&1 | tail -5"
+    Tool_code_write.validate_code_shell_command "dune build | xargs rm -rf"
   with
-  | Error reason ->
-      check bool "reason mentions pipe restriction" true
-        (String.starts_with ~prefix:"Pipes are not allowed" reason)
-  | Ok () -> fail "expected piped command to be rejected"
+  | Error _ -> ()
+  | Ok () ->
+      fail "expected pipe-to-disallowed-command to be rejected by allowlist"
 
 let test_validate_code_shell_command_allows_direct_build () =
   check (result unit string) "direct build allowed" (Ok ())
@@ -381,8 +386,10 @@ let () =
       test_case "mixed-case org" `Quick test_mixed_case_org;
     ]);
     ("validate_code_shell_command", [
-      test_case "rejects pipe" `Quick
-        test_validate_code_shell_command_rejects_pipe;
+      test_case "allows pipe with allowlisted segments" `Quick
+        test_validate_code_shell_command_allows_pipe;
+      test_case "rejects pipe to disallowed command" `Quick
+        test_validate_code_shell_command_rejects_pipe_to_disallowed;
       test_case "allows direct build" `Quick
         test_validate_code_shell_command_allows_direct_build;
       test_case "rejects semicolon" `Quick


### PR DESCRIPTION
## Why

Keepers (e.g. masc-improver) repeatedly hit:

```
{"error":"Pipes are not allowed. Run one command per call."}
```

…for routine compositions like `git log --oneline | head -10` or `rg X | wc -l`. They're then forced into multi-call sequences that:
- pollute the turn log
- waste tokens
- create observability noise

The rest of the coding-preset shell defaults to `~allow_pipes:true` (`validate_command_coding` in `worker_dev_tools.ml:263`). Only `validate_code_shell_command` was inconsistent, with no comment explaining the intent.

## Safety analysis

`validate_command_coding_with_allowlist` still:
- Rejects dangerous metachars: `;`, `` ` ``, `$`, `&&`, standalone `&`
- Validates **every pipeline segment** independently against `allowed_shell_commands`
- Handles process substitution (`<()`, `>()`) — rejects
- Handles file redirects — rejects (only `2>&1`-style fd redirects allowed)

So `dune build | xargs rm -rf` still fails (`xargs` not in allowlist). New test covers this.

## Changes

- `lib/tool_code_write.ml` — `~allow_pipes:false` → `true`, add comment explaining the safety model
- `test/test_tool_code_write_coverage.ml` — replace `rejects pipe` assertion with `allows pipe with allowlisted segments` + `rejects pipe to disallowed command`

## Verification

- `dune build @check` clean
- 4/4 `validate_code_shell_command` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)