### PR TITLE
[codex] Carry keeper social-model state across turns

### DIFF
--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -49,6 +49,42 @@ let model_id_to_string = Keeper_social_model_types.model_id_to_string
 let model_id_of_string = Keeper_social_model_types.model_id_of_string
 let normalize_social_model = Keeper_social_model_types.normalize_social_model
 
+let nonempty_opt value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+
+let previous_state_of_meta (meta : Keeper_types.keeper_meta) =
+  let runtime = meta.runtime in
+  let speech_act =
+    match model_id_of_string meta.social_model with
+    | None -> None
+    | Some _ -> (
+        match Keeper_social_model_types.speech_act_of_string runtime.last_speech_act with
+        | Some speech_act -> Some speech_act
+        | None -> None)
+  in
+  let active_desire = nonempty_opt runtime.last_active_desire in
+  let current_intention = nonempty_opt runtime.last_current_intention in
+  let blocker = nonempty_opt runtime.last_blocker in
+  let need = nonempty_opt runtime.last_need in
+  match speech_act, active_desire, current_intention, blocker, need with
+  | None, None, None, None, None -> None
+  | _ ->
+      let speech_act = Option.value ~default:Inform speech_act in
+      Some
+        {
+          social_model = normalize_social_model meta.social_model;
+          belief_summary = "runtime_carry";
+          active_desire;
+          current_intention;
+          blocker;
+          need;
+          speech_act;
+          delivery_surface =
+            Keeper_social_model_types.default_delivery_surface_of_speech_act
+              speech_act;
+        }
+
 let extract_accountability_claim (result : Keeper_agent_run.run_result) =
   let headers, _ =
     Keeper_social_model_protocol.parse_header_block result.response_text

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -47,17 +47,20 @@ val delivery_surface_to_string : delivery_surface -> string
 val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option
 val normalize_social_model : string -> string
+val previous_state_of_meta : Keeper_types.keeper_meta -> social_state option
 val extract_accountability_claim :
   Keeper_agent_run.run_result -> accountability_claim option
 
 val derive_failure_state :
   meta:Keeper_types.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
+  previous_state:social_state option ->
   reason:string ->
   social_state
 
 val apply_to_result :
   meta:Keeper_types.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
+  previous_state:social_state option ->
   Keeper_agent_run.run_result ->
   Keeper_agent_run.run_result * social_state

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -342,6 +342,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           noop_turn_count = 0;
           consecutive_noop_count = 0;
           last_speech_act = "";
+          last_active_desire = "";
+          last_current_intention = "";
           last_blocker = "";
           last_need = "";
         };

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -115,6 +115,8 @@ type agent_runtime_state =
   ; noop_turn_count : int
   ; consecutive_noop_count : int
   ; last_speech_act : string
+  ; last_active_desire : string
+  ; last_current_intention : string
   ; last_blocker : string
   ; last_need : string
   }
@@ -738,6 +740,8 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "noop_turn_count", `Int rt.noop_turn_count
     ; "consecutive_noop_count", `Int rt.consecutive_noop_count
     ; "last_speech_act", `String rt.last_speech_act
+    ; "last_active_desire", `String rt.last_active_desire
+    ; "last_current_intention", `String rt.last_current_intention
     ; "last_blocker", `String rt.last_blocker
     ; "last_need", `String rt.last_need
     ; "paused", `Bool m.paused
@@ -1118,6 +1122,12 @@ let parse_keeper_state
   let noop_turn_count = Safe_ops.json_int ~default:0 "noop_turn_count" json in
   let consecutive_noop_count = Safe_ops.json_int ~default:0 "consecutive_noop_count" json in
   let last_speech_act = Safe_ops.json_string ~default:"" "last_speech_act" json in
+  let last_active_desire =
+    Safe_ops.json_string ~default:"" "last_active_desire" json
+  in
+  let last_current_intention =
+    Safe_ops.json_string ~default:"" "last_current_intention" json
+  in
   let last_blocker = Safe_ops.json_string ~default:"" "last_blocker" json in
   let last_need = Safe_ops.json_string ~default:"" "last_need" json in
   let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
@@ -1153,6 +1163,8 @@ let parse_keeper_state
       ; noop_turn_count
       ; consecutive_noop_count
       ; last_speech_act
+      ; last_active_desire
+      ; last_current_intention
       ; last_blocker
       ; last_need
       }
@@ -1336,6 +1348,8 @@ let fallback_canonical_keeper_meta_key_names =
   ; "noop_turn_count"
   ; "consecutive_noop_count"
   ; "last_speech_act"
+  ; "last_active_desire"
+  ; "last_current_intention"
   ; "last_blocker"
   ; "last_need"
   ; "paused"

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -114,6 +114,8 @@ type agent_runtime_state = {
   noop_turn_count: int;
   consecutive_noop_count: int;
   last_speech_act: string;
+  last_active_desire: string;
+  last_current_intention: string;
   last_blocker: string;
   last_need: string;
 }

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1014,6 +1014,10 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
          then now_iso ()
          else rt.last_autonomous_action_at);
       last_speech_act = Social.speech_act_to_string social_state.speech_act;
+      last_active_desire =
+        Option.value ~default:"" social_state.active_desire;
+      last_current_intention =
+        Option.value ~default:"" social_state.current_intention;
       (* A successful turn means the keeper is not blocked.
          Clear unconditionally so stale error strings from previous
          failures do not persist in the runtime JSON and mislead the
@@ -1271,6 +1275,16 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
          | Some (state : Social.social_state) ->
              Social.speech_act_to_string state.speech_act
          | None -> meta.runtime.last_speech_act);
+      last_active_desire =
+        (match social_state with
+         | Some (state : Social.social_state) ->
+             Option.value ~default:"" state.active_desire
+         | None -> meta.runtime.last_active_desire);
+      last_current_intention =
+        (match social_state with
+         | Some (state : Social.social_state) ->
+             Option.value ~default:"" state.current_intention
+         | None -> meta.runtime.last_current_intention);
       last_blocker =
         (match social_state with
          | Some (state : Social.social_state) ->
@@ -1293,6 +1307,7 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
     () : (keeper_meta, Oas.Error.sdk_error) result =
   (* 0. Phase gate + state-aware cascade routing *)
   let registry_base_path = config.base_path in
+  let previous_social_state = Social.previous_state_of_meta meta in
   match Keeper_registry.get_phase ~base_path:registry_base_path meta.name with
   | Some phase when not (Keeper_state_machine.can_execute_turn phase) ->
       Log.Keeper.info
@@ -1760,7 +1775,8 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
              else "")
             (short_preview e_str);
           let social_state =
-            Social.derive_failure_state ~meta ~observation ~reason:e_str
+            Social.derive_failure_state ~meta ~observation
+              ~previous_state:previous_social_state ~reason:e_str
           in
           let failure_meta_base =
             match !paused_meta_override with
@@ -1853,7 +1869,8 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
             Social.extract_accountability_claim result
           in
           let result, social_state =
-            Social.apply_to_result ~meta ~observation result
+            Social.apply_to_result ~meta ~observation
+              ~previous_state:previous_social_state result
           in
           let used_model_id =
             Keeper_agent_run.surface_model_used result

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -35,6 +35,16 @@ type request_help_delivery =
   | Request_help_deduped
   | Request_help_failed
 
+let state_of_social_state (state : Types.social_state) : state =
+  {
+    social_model = state.social_model;
+    belief_summary = state.belief_summary;
+    active_desire = state.active_desire;
+    current_intention = state.current_intention;
+    blocker = state.blocker;
+    need = state.need;
+  }
+
 let to_social_state (state : state) (output : output) : Types.social_state =
   {
     social_model = state.social_model;
@@ -93,8 +103,14 @@ let belief_summary_of_observation
 
 let make_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
+    ?previous_state
     ?active_desire ?current_intention ?blocker ?need ?social_model
     ?belief_summary () =
+  let carry explicit selector =
+    match explicit with
+    | Some _ -> explicit
+    | None -> Option.bind previous_state selector
+  in
   {
     social_model =
       Option.value
@@ -103,21 +119,24 @@ let make_state ~(meta : keeper_meta)
     belief_summary =
       Option.value ~default:(belief_summary_of_observation observation)
         belief_summary;
-    active_desire;
-    current_intention;
+    active_desire = carry active_desire (fun state -> state.active_desire);
+    current_intention =
+      carry current_intention (fun state -> state.current_intention);
     blocker;
-    need;
+    need = carry need (fun state -> state.need);
   }
 
 let protocol_violation_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation) ~(reason : string)
-    =
-  ( make_state ~meta ~observation ?blocker:(Some reason) (),
+=
+  ( make_state ~meta ~observation ?previous_state:None ?blocker:(Some reason)
+      (),
     { speech_act = Types.Defer; delivery_surface = Types.Silent } )
 
 let inferred_text_reply_state ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation) =
-  ( make_state ~meta ~observation (),
+    ~(observation : Keeper_world_observation.world_observation)
+    ?previous_state () =
+  ( make_state ~meta ~observation ?previous_state (),
     { speech_act = Types.Inform; delivery_surface = Types.Visible_reply } )
 
 let inferred_tool_surface tools =
@@ -148,6 +167,7 @@ let inferred_tool_surface tools =
 
 let tool_only_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : state option)
     ~(result : Keeper_agent_run.run_result) =
   let output =
     match inferred_tool_surface result.tools_used with
@@ -158,10 +178,11 @@ let tool_only_state ~(meta : keeper_meta)
           delivery_surface = Types.Visible_reply;
         }
   in
-  (make_state ~meta ~observation (), output)
+  (make_state ~meta ~observation ?previous_state (), output)
 
 let social_state_of_headers ~(meta : keeper_meta)
-    ~(observation : Keeper_world_observation.world_observation) headers =
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : state option) headers =
   match
     Protocol.nonempty_header_opt headers "SPEECH_ACT",
     Protocol.header_assoc_opt headers "DELIVERY_SURFACE"
@@ -187,6 +208,7 @@ let social_state_of_headers ~(meta : keeper_meta)
               | _ -> truncated
           in
           ( make_state ~meta ~observation
+              ?previous_state
               ~social_model:
                 (Types.normalize_social_model
                    (Option.value
@@ -271,15 +293,15 @@ let deliver_request_help_post ~(meta : keeper_meta)
       | Ok _ -> Request_help_posted
       | Error _ -> Request_help_failed
 
-let transition (_previous_state : state option) (input : input) =
+let transition (previous_state : state option) (input : input) =
   let meta = input.meta in
   let observation = input.observation in
   let result = input.result in
   if result.tools_used <> [] then
-    tool_only_state ~meta ~observation ~result
+    tool_only_state ~meta ~observation ~previous_state ~result
   else if input.headers <> [] then
     let state, output =
-      social_state_of_headers ~meta ~observation input.headers
+      social_state_of_headers ~meta ~observation ~previous_state input.headers
     in
     if input.has_text_reply
        &&
@@ -287,11 +309,11 @@ let transition (_previous_state : state option) (input : input) =
        | Some "missing social headers" | Some "invalid social headers" -> true
        | _ -> false
     then
-      inferred_text_reply_state ~meta ~observation
+      inferred_text_reply_state ~meta ~observation ?previous_state ()
     else
       (state, output)
   else if input.has_text_reply then
-    inferred_text_reply_state ~meta ~observation
+    inferred_text_reply_state ~meta ~observation ?previous_state ()
   else
     protocol_violation_state ~meta ~observation
       ~reason:"no tool calls and no social headers"
@@ -332,6 +354,7 @@ let apply_output_to_result ~(meta : keeper_meta)
 
 let apply_to_result ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : Types.social_state option)
     (result : Keeper_agent_run.run_result) =
   let headers, response_body =
     Protocol.parse_header_block result.response_text
@@ -348,15 +371,18 @@ let apply_to_result ~(meta : keeper_meta)
       has_text_reply = String.trim visible_response_body <> "";
     }
   in
-  let state, output = transition None input in
+  let prior_state = Option.map state_of_social_state previous_state in
+  let state, output = transition prior_state input in
   let social_state = to_social_state state output in
   apply_output_to_result ~meta ~result ~visible_response_body social_state
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : Types.social_state option)
     ~(reason : string) =
   let state =
     make_state ~meta ~observation
+      ?previous_state:(Option.map state_of_social_state previous_state)
       ?blocker:
         (match String.trim reason with
         | "" -> None

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -27,11 +27,13 @@ val transition : state option -> input -> state * output
 val apply_to_result :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
+  previous_state:Keeper_social_model_types.social_state option ->
   Keeper_agent_run.run_result ->
   Keeper_agent_run.run_result * Keeper_social_model_types.social_state
 
 val derive_failure_state :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
+  previous_state:Keeper_social_model_types.social_state option ->
   reason:string ->
   Keeper_social_model_types.social_state

--- a/lib/keeper/social_model/keeper_social_model_registry.ml
+++ b/lib/keeper/social_model/keeper_social_model_registry.ml
@@ -9,16 +9,18 @@ let active_model_of_meta (meta : keeper_meta) =
 
 let apply_to_result ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : Types.social_state option)
     (result : Keeper_agent_run.run_result) =
   match active_model_of_meta meta with
   | Types.Bdi_speech_v1 ->
       Keeper_social_model_bdi_speech_v1.apply_to_result ~meta ~observation
-        result
+        ~previous_state result
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : Types.social_state option)
     ~(reason : string) =
   match active_model_of_meta meta with
   | Types.Bdi_speech_v1 ->
       Keeper_social_model_bdi_speech_v1.derive_failure_state ~meta
-        ~observation ~reason
+        ~observation ~previous_state ~reason

--- a/lib/keeper/social_model/keeper_social_model_registry.mli
+++ b/lib/keeper/social_model/keeper_social_model_registry.mli
@@ -3,11 +3,13 @@ open Keeper_types
 val apply_to_result :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
+  previous_state:Keeper_social_model_types.social_state option ->
   Keeper_agent_run.run_result ->
   Keeper_agent_run.run_result * Keeper_social_model_types.social_state
 
 val derive_failure_state :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
+  previous_state:Keeper_social_model_types.social_state option ->
   reason:string ->
   Keeper_social_model_types.social_state

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -60,6 +60,14 @@ let delivery_surface_to_string = function
   | Task_claim_surface -> "task_claim"
   | Broadcast_surface -> "broadcast"
 
+let default_delivery_surface_of_speech_act = function
+  | Stay_silent | Defer -> Silent
+  | Inform -> Visible_reply
+  | Request_help | Post_board -> Board_post
+  | Comment_board -> Board_comment
+  | Claim_task -> Task_claim_surface
+  | Broadcast -> Broadcast_surface
+
 let delivery_surface_of_string value =
   match String.lowercase_ascii (String.trim value) with
   | "silent" -> Some Silent

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -33,6 +33,7 @@ type social_state = {
 val speech_act_to_string : speech_act -> string
 val speech_act_of_string : string -> speech_act option
 val delivery_surface_to_string : delivery_surface -> string
+val default_delivery_surface_of_speech_act : speech_act -> delivery_surface
 val delivery_surface_of_string : string -> delivery_surface option
 val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1688,12 +1688,16 @@ let test_metrics_persist_social_state_fields () =
     (fun () ->
       let routed, social_state =
         KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation result
+          ~observation:base_observation ~previous_state:None result
       in
       let updated =
         UT.update_metrics_from_result minimal_meta ~latency_ms:100
           ~observation:base_observation ~social_state routed
       in
+      check string "active desire tracked" "maintain_quiet_readiness"
+        updated.runtime.last_active_desire;
+      check string "current intention tracked" "stay_available_without_noise"
+        updated.runtime.last_current_intention;
       check string "speech act tracked" "stay_silent"
         updated.runtime.last_speech_act;
       check string "no blocker tracked" "" updated.runtime.last_blocker;
@@ -2396,7 +2400,7 @@ let test_social_model_silences_skip_only_turn () =
     (fun () ->
       let routed, state =
         KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation result
+          ~observation:base_observation ~previous_state:None result
       in
       check string "speech act" "stay_silent"
         (KSM.speech_act_to_string state.speech_act);
@@ -2412,7 +2416,8 @@ let test_social_model_unknown_meta_falls_back_to_baseline () =
       ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
   let routed, state =
-    KSM.apply_to_result ~meta ~observation:base_observation result
+    KSM.apply_to_result ~meta ~observation:base_observation
+      ~previous_state:None result
   in
   check string "unknown meta model falls back to baseline"
     "bdi_speech_v1" state.social_model;
@@ -2429,7 +2434,7 @@ let test_social_model_unknown_header_falls_back_to_baseline () =
   in
   let routed, state =
     KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation result
+      ~observation:base_observation ~previous_state:None result
   in
   check string "unknown header model falls back to baseline"
     "bdi_speech_v1" state.social_model;
@@ -2446,7 +2451,7 @@ let test_social_model_infers_visible_reply_without_headers () =
     (fun () ->
       let routed, state =
         KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation result
+          ~observation:base_observation ~previous_state:None result
       in
       check string "speech act" "inform"
         (KSM.speech_act_to_string state.speech_act);
@@ -2464,7 +2469,7 @@ let test_social_model_empty_text_without_headers_stays_silent () =
   in
   let routed, state =
     KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation result
+      ~observation:base_observation ~previous_state:None result
   in
   check string "speech act" "defer"
     (KSM.speech_act_to_string state.speech_act);
@@ -2485,7 +2490,7 @@ let test_social_model_state_only_reply_stays_silent () =
   in
   let routed, state =
     KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation result
+      ~observation:base_observation ~previous_state:None result
   in
   check string "speech act" "defer"
     (KSM.speech_act_to_string state.speech_act);
@@ -2503,7 +2508,7 @@ let test_social_model_strips_state_block_from_visible_reply () =
   in
   let routed, state =
     KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation result
+      ~observation:base_observation ~previous_state:None result
   in
   check string "speech act" "inform"
     (KSM.speech_act_to_string state.speech_act);
@@ -2535,7 +2540,7 @@ let test_social_model_routes_blocker_to_board_post () =
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "observer"));
       let routed, state =
         KSM.apply_to_result ~meta:minimal_meta
-          ~observation:base_observation result
+          ~observation:base_observation ~previous_state:None result
       in
       let posts =
         Masc_mcp.Board_dispatch.list_posts
@@ -2564,7 +2569,7 @@ let test_social_model_tool_only_turn_skips_protocol_violation () =
   in
   let routed, state =
     KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation result
+      ~observation:base_observation ~previous_state:None result
   in
   check string "speech act" "inform"
     (KSM.speech_act_to_string state.speech_act);
@@ -2575,6 +2580,75 @@ let test_social_model_tool_only_turn_skips_protocol_violation () =
     (contains_substring routed.response_text "Tools used: masc_status.");
   check (list string) "tool list preserved" ["masc_status"] routed.tools_used
 
+let test_social_model_previous_state_of_meta_restores_runtime_fields () =
+  let meta =
+    {
+      minimal_meta with
+      runtime =
+        {
+          minimal_meta.runtime with
+          last_speech_act = "request_help";
+          last_active_desire = "seek_help";
+          last_current_intention = "recover_tool_route";
+          last_blocker = "tool route unavailable";
+          last_need = "operator guidance";
+        };
+    }
+  in
+  match KSM.previous_state_of_meta meta with
+  | None -> fail "expected previous social state"
+  | Some state ->
+      check string "social model restored" "bdi_speech_v1" state.social_model;
+      check (option string) "active desire restored"
+        (Some "seek_help") state.active_desire;
+      check (option string) "current intention restored"
+        (Some "recover_tool_route") state.current_intention;
+      check (option string) "blocker restored"
+        (Some "tool route unavailable") state.blocker;
+      check (option string) "need restored"
+        (Some "operator guidance") state.need;
+      check string "speech act restored" "request_help"
+        (KSM.speech_act_to_string state.speech_act);
+      check string "delivery surface inferred from speech act" "board_post"
+        (KSM.delivery_surface_to_string state.delivery_surface)
+
+let test_social_model_tool_only_turn_carries_previous_state () =
+  let result =
+    make_run_result ~text:"" ~tools:["masc_status"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let previous_state =
+    Some
+      KSM.
+        {
+          social_model = "bdi_speech_v1";
+          belief_summary = "mentions=1";
+          active_desire = Some "seek_help";
+          current_intention = Some "recover_tool_route";
+          blocker = Some "tool route unavailable";
+          need = Some "operator guidance";
+          speech_act = Request_help;
+          delivery_surface = Board_post;
+        }
+  in
+  let routed, state =
+    KSM.apply_to_result ~meta:minimal_meta
+      ~observation:base_observation ~previous_state result
+  in
+  check string "speech act becomes inform for tool-only turn" "inform"
+    (KSM.speech_act_to_string state.speech_act);
+  check (option string) "active desire carried"
+    (Some "seek_help") state.active_desire;
+  check (option string) "current intention carried"
+    (Some "recover_tool_route") state.current_intention;
+  check (option string) "need carried"
+    (Some "operator guidance") state.need;
+  check (option string) "blocker not carried into tool-only turn" None
+    state.blocker;
+  check bool "tool-only response still synthesized" true
+    (contains_substring routed.response_text "Tools used: masc_status.");
+  check (list string) "tool list preserved" ["masc_status"] routed.tools_used
+
 let test_social_model_infers_board_comment_from_tool_use () =
   let result =
     make_run_result ~text:"" ~tools:["keeper_board_comment"; "masc_status"]
@@ -2582,7 +2656,7 @@ let test_social_model_infers_board_comment_from_tool_use () =
   in
   let routed, state =
     KSM.apply_to_result ~meta:minimal_meta
-      ~observation:base_observation result
+      ~observation:base_observation ~previous_state:None result
   in
   check string "speech act" "comment_board"
     (KSM.speech_act_to_string state.speech_act);
@@ -2957,6 +3031,10 @@ let () =
             test_social_model_routes_blocker_to_board_post;
           test_case "social model tool-only turn skips protocol violation" `Quick
             test_social_model_tool_only_turn_skips_protocol_violation;
+          test_case "social model restores previous state from runtime" `Quick
+            test_social_model_previous_state_of_meta_restores_runtime_fields;
+          test_case "social model tool-only turn carries previous state" `Quick
+            test_social_model_tool_only_turn_carries_previous_state;
           test_case "social model infers board comment from tool use" `Quick
             test_social_model_infers_board_comment_from_tool_use;
           test_case "render_inline deny" `Quick


### PR DESCRIPTION
## Summary
- persist enough keeper social state in runtime metadata to reconstruct the previous turn's desire/intention context
- thread `previous_state` through the social-model facade, registry, and `bdi_speech_v1` implementation
- carry prior desire/current intention/need through tool-only and no-header turns while keeping blocker semantics explicit
- add regression coverage for runtime restoration and next-turn carry behavior

## Why
The previous PR split the registry and the first model implementation, but the model transition still always started from `None`. This PR makes the first real cross-turn FSM step concrete by restoring prior social state from keeper runtime and passing it into the active model transition.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-state-carry test/test_keeper_unified.exe test/test_keeper_meta_listing.exe`
- `env ALCOTEST_QUICK_TESTS=1 dune exec --build-dir /tmp/masc-social-model-state-carry-build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-state-carry ./test/test_keeper_unified.exe`
- `env ALCOTEST_QUICK_TESTS=1 dune exec --build-dir /tmp/masc-social-model-state-carry-build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-state-carry ./test/test_keeper_meta_listing.exe`
- `bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression`

## Notes
- this slice intentionally persists only the fields needed for durable intent carry (`last_active_desire`, `last_current_intention`) and reuses existing runtime speech/blocker/need fields
- blocker carry remains explicit; successful tool-only turns do not inherit a stale blocker into the next social state
