### PR TITLE
fix(board): remove duplicate 100-post hard cap that broke pagination

### DIFF
--- a/lib/board_core.ml
+++ b/lib/board_core.ml
@@ -514,7 +514,13 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
           let h_norm = String.lowercase_ascii (String.trim h) in
           List.filter (fun (p : post) -> p.hearth = Some h_norm) filtered
     in
-    take (min limit 100) filtered  (* Hard cap at 100 *)
+    (* Cap at Limits.max_posts (default 10_000) as an OOM guard. The
+       previous inner cap of 100 was a duplicate of Board_dispatch.list_posts's
+       fetch_limit guard (`max limit 200`) and broke offset-based pagination:
+       when the dashboard requested offset=100 limit=100, Board_dispatch
+       passed probe_fetch=201 here but we returned only 100, so fetched_len
+       never exceeded window_end and has_more went stale at ~100-200 posts. *)
+    take (min limit Limits.max_posts) filtered
   )
 
 (** Full-scan search over all posts (no limit on scan, only on results).


### PR DESCRIPTION
## Summary

Board 게시판이 "더 보기"를 눌러도 ~100-200개 근처에서 멈추는 버그. 원인은 \`Board.list_posts\` 안의 \`take (min limit 100) filtered\` 이중 cap.

## Trace

1. Dashboard: \`GET /api/v1/dashboard/board?limit=200&offset=0\`
2. \`server_dashboard_http\`: \`probe_fetch = 201\`, \`Board_dispatch.list_posts ~limit:201\` 호출
3. \`Board_dispatch.list_posts\`: \`fetch_limit = max 201 200 = 201\`, \`Board.list_posts store ~limit:201\` 호출
4. **\`Board.list_posts\`: \`take (min 201 100) filtered\` → 100개만 반환** ← 버그
5. \`server_dashboard_http\`: \`fetched_len=100\`, \`window_end=200\`, \`has_more = (100 > 200) = false\`
6. 프론트: \`boardHasMore.value = false\` → **\`loadMoreBoardPosts\`가 early return** (\`store.ts:629\`)
7. UI: 100개 (또는 filter 켤 때 200개 받아온 후)에서 "더 보기" 비활성

## Why the inner cap existed

역사적으로 \`Board.list_posts\`가 안전 guard를 가졌던 것. 하지만 유일한 caller \`Board_dispatch.list_posts\` (line 227)가 이미 \`max limit 200\` guard + \`Limits.max_posts\` 절대 상한을 가지고 있음. 중복.

## Fix

\`\`\`diff
-    take (min limit 100) filtered  (* Hard cap at 100 *)
+    take (min limit Limits.max_posts) filtered
\`\`\`

\`Limits.max_posts\` 기본값 10,000 (env \`MASC_BOARD_MAX_POSTS\`). OOM guard는 유지, 100 phantom wall만 제거.

## Affected sort modes

Hot sort만 영향. Trending/Recent/Updated/Discussed는 \`needs_full_scan=true\` 경로로 \`Board.search_posts\`를 써서 원래 이 cap을 우회했음.

## Test plan

- [x] \`dune build --root .\` clean
- [x] \`dune exec test/test_board_dispatch.exe\` — 26/26 pass
- [x] \`dune exec test/test_board_ttl.exe\` — 9/9 pass
- [ ] UI 수동 검증: Hot sort + filter + 200개 이상 scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)