### PR TITLE
feat(dashboard): g key toggles Compound Graph

### DIFF
--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -306,6 +306,11 @@ export function FsmHub() {
     [keeperNames],
   )
 
+  useGlobalShortcut(
+    (ev) => ev.key === 'g',
+    () => setGraphOpen(o => !o),
+  )
+
   const view = useMemo(
     () =>
       hub.keeperName === activeSelected
@@ -451,6 +456,7 @@ function ShortcutsOverlay({
   const rows: Array<{ keys: string; desc: string }> = [
     { keys: '1 – 9', desc: 'N번째 키퍼로 이동' },
     { keys: 'r', desc: '강제 새로고침' },
+    { keys: 'g', desc: 'Compound Graph 토글' },
     { keys: '? ', desc: '단축키 목록 토글' },
     { keys: 'Esc', desc: '오버레이 닫기' },
     { keys: '← →', desc: '키퍼 탭 이동 (탭 포커스 시)' },


### PR DESCRIPTION
## Summary

- Press `g` to toggle Compound Graph (Cytoscape) section
- Overlay row added: `g — Compound Graph 토글`

## Why

The graph is at the bottom of the page and operators currently must scroll + click the summary to expand it. `g` removes the friction.

Demonstrates the `useGlobalShortcut` hook (PR #7381) reducing each new shortcut to 4 lines vs the previous 18.

## Verification

- 666/666 tests, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)