### PR TITLE
[codex] Expose keeper social transition reasons

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -666,6 +666,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                 if String.trim m.runtime.last_speech_act = ""
                 then `Null
                 else `String m.runtime.last_speech_act);
+              ("last_social_transition_reason",
+                if String.trim m.runtime.last_social_transition_reason = ""
+                then `Null
+                else `String m.runtime.last_social_transition_reason);
               ("last_blocker",
                 if String.trim m.runtime.last_blocker = ""
                 then `Null

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -24,6 +24,22 @@ type delivery_surface = Keeper_social_model_types.delivery_surface =
 type model_id = Keeper_social_model_types.model_id =
   | Bdi_speech_v1
 
+type transition_reason = Keeper_social_model_types.transition_reason =
+  | Tool_only_stay_silent
+  | Tool_only_comment_board
+  | Tool_only_post_board
+  | Tool_only_broadcast
+  | Tool_only_claim_task
+  | Tool_only_visible_reply
+  | Explicit_social_headers
+  | Missing_headers_fallback_visible_reply
+  | Invalid_headers_fallback_visible_reply
+  | Inferred_visible_reply
+  | Protocol_violation_missing_social_headers
+  | Protocol_violation_invalid_social_headers
+  | Protocol_violation_no_tools_no_social_headers
+  | Failure_run_error
+
 type social_state = Keeper_social_model_types.social_state = {
   social_model : string;
   belief_summary : string;
@@ -48,6 +64,8 @@ let delivery_surface_to_string =
 let model_id_to_string = Keeper_social_model_types.model_id_to_string
 let model_id_of_string = Keeper_social_model_types.model_id_of_string
 let normalize_social_model = Keeper_social_model_types.normalize_social_model
+let transition_reason_to_string =
+  Keeper_social_model_types.transition_reason_to_string
 
 let nonempty_opt value =
   let trimmed = String.trim value in

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -25,6 +25,22 @@ type delivery_surface = Keeper_social_model_types.delivery_surface =
 type model_id = Keeper_social_model_types.model_id =
   | Bdi_speech_v1
 
+type transition_reason = Keeper_social_model_types.transition_reason =
+  | Tool_only_stay_silent
+  | Tool_only_comment_board
+  | Tool_only_post_board
+  | Tool_only_broadcast
+  | Tool_only_claim_task
+  | Tool_only_visible_reply
+  | Explicit_social_headers
+  | Missing_headers_fallback_visible_reply
+  | Invalid_headers_fallback_visible_reply
+  | Inferred_visible_reply
+  | Protocol_violation_missing_social_headers
+  | Protocol_violation_invalid_social_headers
+  | Protocol_violation_no_tools_no_social_headers
+  | Failure_run_error
+
 type social_state = Keeper_social_model_types.social_state = {
   social_model : string;
   belief_summary : string;
@@ -47,6 +63,7 @@ val delivery_surface_to_string : delivery_surface -> string
 val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option
 val normalize_social_model : string -> string
+val transition_reason_to_string : transition_reason -> string
 val previous_state_of_meta : Keeper_types.keeper_meta -> social_state option
 val extract_accountability_claim :
   Keeper_agent_run.run_result -> accountability_claim option
@@ -56,11 +73,11 @@ val derive_failure_state :
   observation:Keeper_world_observation.world_observation ->
   previous_state:social_state option ->
   reason:string ->
-  social_state
+  social_state * transition_reason
 
 val apply_to_result :
   meta:Keeper_types.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:social_state option ->
   Keeper_agent_run.run_result ->
-  Keeper_agent_run.run_result * social_state
+  Keeper_agent_run.run_result * social_state * transition_reason

--- a/lib/keeper/keeper_status.ml
+++ b/lib/keeper/keeper_status.ml
@@ -221,6 +221,10 @@ let handle_keeper_list ctx args : tool_result =
                 if String.trim m.runtime.last_speech_act = ""
                 then `Null
                 else `String m.runtime.last_speech_act);
+              ("last_social_transition_reason",
+                if String.trim m.runtime.last_social_transition_reason = ""
+                then `Null
+                else `String m.runtime.last_social_transition_reason);
               ("last_blocker",
                 if String.trim m.runtime.last_blocker = ""
                 then `Null

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -1026,6 +1026,10 @@ let handle_keeper_status ctx args : tool_result =
                if String.trim m.runtime.last_speech_act = ""
                then `Null
                else `String m.runtime.last_speech_act);
+             ("last_transition_reason",
+               if String.trim m.runtime.last_social_transition_reason = ""
+               then `Null
+               else `String m.runtime.last_social_transition_reason);
              ("last_blocker",
                if String.trim m.runtime.last_blocker = ""
                then `Null

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -342,6 +342,7 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           noop_turn_count = 0;
           consecutive_noop_count = 0;
           last_speech_act = "";
+          last_social_transition_reason = "";
           last_active_desire = "";
           last_current_intention = "";
           last_blocker = "";

--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -115,6 +115,7 @@ type agent_runtime_state =
   ; noop_turn_count : int
   ; consecutive_noop_count : int
   ; last_speech_act : string
+  ; last_social_transition_reason : string
   ; last_active_desire : string
   ; last_current_intention : string
   ; last_blocker : string
@@ -740,6 +741,7 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ; "noop_turn_count", `Int rt.noop_turn_count
     ; "consecutive_noop_count", `Int rt.consecutive_noop_count
     ; "last_speech_act", `String rt.last_speech_act
+    ; "last_social_transition_reason", `String rt.last_social_transition_reason
     ; "last_active_desire", `String rt.last_active_desire
     ; "last_current_intention", `String rt.last_current_intention
     ; "last_blocker", `String rt.last_blocker
@@ -1122,6 +1124,9 @@ let parse_keeper_state
   let noop_turn_count = Safe_ops.json_int ~default:0 "noop_turn_count" json in
   let consecutive_noop_count = Safe_ops.json_int ~default:0 "consecutive_noop_count" json in
   let last_speech_act = Safe_ops.json_string ~default:"" "last_speech_act" json in
+  let last_social_transition_reason =
+    Safe_ops.json_string ~default:"" "last_social_transition_reason" json
+  in
   let last_active_desire =
     Safe_ops.json_string ~default:"" "last_active_desire" json
   in
@@ -1163,6 +1168,7 @@ let parse_keeper_state
       ; noop_turn_count
       ; consecutive_noop_count
       ; last_speech_act
+      ; last_social_transition_reason
       ; last_active_desire
       ; last_current_intention
       ; last_blocker
@@ -1348,6 +1354,7 @@ let fallback_canonical_keeper_meta_key_names =
   ; "noop_turn_count"
   ; "consecutive_noop_count"
   ; "last_speech_act"
+  ; "last_social_transition_reason"
   ; "last_active_desire"
   ; "last_current_intention"
   ; "last_blocker"

--- a/lib/keeper/keeper_types.mli
+++ b/lib/keeper/keeper_types.mli
@@ -114,6 +114,7 @@ type agent_runtime_state = {
   noop_turn_count: int;
   consecutive_noop_count: int;
   last_speech_act: string;
+  last_social_transition_reason: string;
   last_active_desire: string;
   last_current_intention: string;
   last_blocker: string;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -839,6 +839,7 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
     ?(is_autonomous_turn = true)
     ?(update_proactive_rt = true)
     ?social_state
+    ?social_transition_reason
     (result : Keeper_agent_run.run_result) : keeper_meta =
   let now_ts = Time_compat.now () in
   let surface_model_used = Keeper_agent_run.surface_model_used result in
@@ -1014,6 +1015,10 @@ let update_metrics_from_result (meta : keeper_meta) ~(latency_ms : int)
          then now_iso ()
          else rt.last_autonomous_action_at);
       last_speech_act = Social.speech_act_to_string social_state.speech_act;
+      last_social_transition_reason =
+        (match social_transition_reason with
+         | Some reason -> String.trim reason
+         | None -> rt.last_social_transition_reason);
       last_active_desire =
         Option.value ~default:"" social_state.active_desire;
       last_current_intention =
@@ -1225,7 +1230,8 @@ let broadcast_lifecycle_events ~(name : string)
 
 let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
     ~(observation : Keeper_world_observation.world_observation)
-    ~(reason : string) ?(is_transient = false) ?social_state () : keeper_meta =
+    ~(reason : string) ?(is_transient = false) ?social_state
+    ?social_transition_reason () : keeper_meta =
   ignore is_transient; (* Param retained for caller compatibility; no longer
                           used internally after zombie-fix #5594. *)
   let now_ts = Time_compat.now () in
@@ -1275,6 +1281,10 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
          | Some (state : Social.social_state) ->
              Social.speech_act_to_string state.speech_act
          | None -> meta.runtime.last_speech_act);
+      last_social_transition_reason =
+        (match social_transition_reason with
+         | Some value -> String.trim value
+         | None -> meta.runtime.last_social_transition_reason);
       last_active_desire =
         (match social_state with
          | Some (state : Social.social_state) ->
@@ -1774,7 +1784,7 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
                " (transient, cooldown preserved)"
              else "")
             (short_preview e_str);
-          let social_state =
+          let social_state, social_transition_reason =
             Social.derive_failure_state ~meta ~observation
               ~previous_state:previous_social_state ~reason:e_str
           in
@@ -1789,7 +1799,11 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
               ~latency_ms
               ~observation
               ~reason:e_str
-              ~is_transient ~social_state ()
+              ~is_transient
+              ~social_state
+              ~social_transition_reason:
+                (Social.transition_reason_to_string social_transition_reason)
+              ()
           in
           if is_ambiguous_partial then begin
             (* Manual reconcile blocker removed. Previously, a partial commit
@@ -1868,7 +1882,7 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
           let explicit_accountability_claim =
             Social.extract_accountability_claim result
           in
-          let result, social_state =
+          let result, social_state, social_transition_reason =
             Social.apply_to_result ~meta ~observation
               ~previous_state:previous_social_state result
           in
@@ -1914,6 +1928,8 @@ let run_keeper_cycle ~(config : Room.config) ~(meta : keeper_meta)
             update_metrics_from_result lifecycle.updated_meta ~latency_ms
               ~observation
               ~social_state
+              ~social_transition_reason:
+                (Social.transition_reason_to_string social_transition_reason)
               ~update_proactive_rt:true
               result
           in

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -31,6 +31,7 @@ val update_metrics_from_result :
       autonomous runtime accounting in the unified loop. *)
   ?update_proactive_rt:bool ->
   ?social_state:Keeper_social_model.social_state ->
+  ?social_transition_reason:string ->
   Keeper_agent_run.run_result ->
   Keeper_types.keeper_meta
 
@@ -41,6 +42,7 @@ val update_metrics_from_failure :
   reason:string ->
   ?is_transient:bool ->
   ?social_state:Keeper_social_model.social_state ->
+  ?social_transition_reason:string ->
   unit ->
   Keeper_types.keeper_meta
 

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -141,27 +141,34 @@ let inferred_text_reply_state ~(meta : keeper_meta)
 
 let inferred_tool_surface tools =
   if tools = [ "keeper_stay_silent" ] then
-    Some { speech_act = Types.Stay_silent; delivery_surface = Types.Silent }
+    Some
+      ( { speech_act = Types.Stay_silent; delivery_surface = Types.Silent }
+      , Types.Tool_only_stay_silent )
   else if List.mem "keeper_board_comment" tools then
     Some
-      {
-        speech_act = Types.Comment_board;
-        delivery_surface = Types.Board_comment;
-      }
+      ( {
+          speech_act = Types.Comment_board;
+          delivery_surface = Types.Board_comment;
+        }
+      , Types.Tool_only_comment_board )
   else if List.mem "keeper_board_post" tools then
-    Some { speech_act = Types.Post_board; delivery_surface = Types.Board_post }
+    Some
+      ( { speech_act = Types.Post_board; delivery_surface = Types.Board_post }
+      , Types.Tool_only_post_board )
   else if List.mem "keeper_broadcast" tools then
     Some
-      {
-        speech_act = Types.Broadcast;
-        delivery_surface = Types.Broadcast_surface;
-      }
+      ( {
+          speech_act = Types.Broadcast;
+          delivery_surface = Types.Broadcast_surface;
+        }
+      , Types.Tool_only_broadcast )
   else if List.mem "keeper_task_claim" tools || List.mem "masc_claim_next" tools then
     Some
-      {
-        speech_act = Types.Claim_task;
-        delivery_surface = Types.Task_claim_surface;
-      }
+      ( {
+          speech_act = Types.Claim_task;
+          delivery_surface = Types.Task_claim_surface;
+        }
+      , Types.Tool_only_claim_task )
   else
     None
 
@@ -169,16 +176,17 @@ let tool_only_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : state option)
     ~(result : Keeper_agent_run.run_result) =
-  let output =
+  let output, transition_reason =
     match inferred_tool_surface result.tools_used with
     | Some routed -> routed
     | None ->
-        {
-          speech_act = Types.Inform;
-          delivery_surface = Types.Visible_reply;
-        }
+        ( {
+            speech_act = Types.Inform;
+            delivery_surface = Types.Visible_reply;
+          }
+        , Types.Tool_only_visible_reply )
   in
-  (make_state ~meta ~observation ?previous_state (), output)
+  (make_state ~meta ~observation ?previous_state (), output, transition_reason)
 
 let social_state_of_headers ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
@@ -222,13 +230,20 @@ let social_state_of_headers ~(meta : keeper_meta)
               ?blocker:(Protocol.nonempty_header_opt headers "BLOCKER")
               ?need:(Protocol.nonempty_header_opt headers "NEED")
               (),
-            { speech_act; delivery_surface } )
+            { speech_act; delivery_surface },
+            Types.Explicit_social_headers )
       | _ ->
-          protocol_violation_state ~meta ~observation
-            ~reason:"invalid social headers")
+          let state, output =
+            protocol_violation_state ~meta ~observation
+              ~reason:"invalid social headers"
+          in
+          (state, output, Types.Protocol_violation_invalid_social_headers))
   | _ ->
-      protocol_violation_state ~meta ~observation
-        ~reason:"missing social headers"
+      let state, output =
+        protocol_violation_state ~meta ~observation
+          ~reason:"missing social headers"
+      in
+      (state, output, Types.Protocol_violation_missing_social_headers)
 
 let should_dedupe_request_help ~(meta : keeper_meta) ~(blocker : string option) =
   match blocker with
@@ -300,7 +315,7 @@ let transition (previous_state : state option) (input : input) =
   if result.tools_used <> [] then
     tool_only_state ~meta ~observation ~previous_state ~result
   else if input.headers <> [] then
-    let state, output =
+    let state, output, transition_reason =
       social_state_of_headers ~meta ~observation ~previous_state input.headers
     in
     if input.has_text_reply
@@ -309,14 +324,32 @@ let transition (previous_state : state option) (input : input) =
        | Some "missing social headers" | Some "invalid social headers" -> true
        | _ -> false
     then
-      inferred_text_reply_state ~meta ~observation ?previous_state ()
+      let state, output =
+        inferred_text_reply_state ~meta ~observation ?previous_state ()
+      in
+      let fallback_reason =
+        match transition_reason with
+        | Types.Protocol_violation_missing_social_headers ->
+            Types.Missing_headers_fallback_visible_reply
+        | Types.Protocol_violation_invalid_social_headers ->
+            Types.Invalid_headers_fallback_visible_reply
+        | _ ->
+            Types.Inferred_visible_reply
+      in
+      (state, output, fallback_reason)
     else
-      (state, output)
+      (state, output, transition_reason)
   else if input.has_text_reply then
-    inferred_text_reply_state ~meta ~observation ?previous_state ()
+    let state, output =
+      inferred_text_reply_state ~meta ~observation ?previous_state ()
+    in
+    (state, output, Types.Inferred_visible_reply)
   else
-    protocol_violation_state ~meta ~observation
-      ~reason:"no tool calls and no social headers"
+    let state, output =
+      protocol_violation_state ~meta ~observation
+        ~reason:"no tool calls and no social headers"
+    in
+    (state, output, Types.Protocol_violation_no_tools_no_social_headers)
 
 let apply_output_to_result ~(meta : keeper_meta)
     ~(result : Keeper_agent_run.run_result)
@@ -372,9 +405,12 @@ let apply_to_result ~(meta : keeper_meta)
     }
   in
   let prior_state = Option.map state_of_social_state previous_state in
-  let state, output = transition prior_state input in
+  let state, output, transition_reason = transition prior_state input in
   let social_state = to_social_state state output in
-  apply_output_to_result ~meta ~result ~visible_response_body social_state
+  let result, social_state =
+    apply_output_to_result ~meta ~result ~visible_response_body social_state
+  in
+  (result, social_state, transition_reason)
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
@@ -392,4 +428,4 @@ let derive_failure_state ~(meta : keeper_meta)
   let output =
     { speech_act = Types.Defer; delivery_surface = Types.Silent }
   in
-  to_social_state state output
+  (to_social_state state output, Types.Failure_run_error)

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -22,14 +22,19 @@ type output = {
   delivery_surface : Keeper_social_model_types.delivery_surface;
 }
 
-val transition : state option -> input -> state * output
+val transition :
+  state option ->
+  input ->
+  state * output * Keeper_social_model_types.transition_reason
 
 val apply_to_result :
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
   Keeper_agent_run.run_result ->
-  Keeper_agent_run.run_result * Keeper_social_model_types.social_state
+  Keeper_agent_run.run_result
+  * Keeper_social_model_types.social_state
+  * Keeper_social_model_types.transition_reason
 
 val derive_failure_state :
   meta:keeper_meta ->
@@ -37,3 +42,4 @@ val derive_failure_state :
   previous_state:Keeper_social_model_types.social_state option ->
   reason:string ->
   Keeper_social_model_types.social_state
+  * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_registry.mli
+++ b/lib/keeper/social_model/keeper_social_model_registry.mli
@@ -5,7 +5,9 @@ val apply_to_result :
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->
   Keeper_agent_run.run_result ->
-  Keeper_agent_run.run_result * Keeper_social_model_types.social_state
+  Keeper_agent_run.run_result
+  * Keeper_social_model_types.social_state
+  * Keeper_social_model_types.transition_reason
 
 val derive_failure_state :
   meta:keeper_meta ->
@@ -13,3 +15,4 @@ val derive_failure_state :
   previous_state:Keeper_social_model_types.social_state option ->
   reason:string ->
   Keeper_social_model_types.social_state
+  * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -19,6 +19,22 @@ type delivery_surface =
 type model_id =
   | Bdi_speech_v1
 
+type transition_reason =
+  | Tool_only_stay_silent
+  | Tool_only_comment_board
+  | Tool_only_post_board
+  | Tool_only_broadcast
+  | Tool_only_claim_task
+  | Tool_only_visible_reply
+  | Explicit_social_headers
+  | Missing_headers_fallback_visible_reply
+  | Invalid_headers_fallback_visible_reply
+  | Inferred_visible_reply
+  | Protocol_violation_missing_social_headers
+  | Protocol_violation_invalid_social_headers
+  | Protocol_violation_no_tools_no_social_headers
+  | Failure_run_error
+
 type social_state = {
   social_model : string;
   belief_summary : string;
@@ -92,3 +108,24 @@ let normalize_social_model value =
   match model_id_of_string value with
   | Some model_id -> model_id_to_string model_id
   | None -> model_id_to_string default_model_id
+
+let transition_reason_to_string = function
+  | Tool_only_stay_silent -> "tool_only:stay_silent"
+  | Tool_only_comment_board -> "tool_only:comment_board"
+  | Tool_only_post_board -> "tool_only:post_board"
+  | Tool_only_broadcast -> "tool_only:broadcast"
+  | Tool_only_claim_task -> "tool_only:claim_task"
+  | Tool_only_visible_reply -> "tool_only:visible_reply"
+  | Explicit_social_headers -> "headers:explicit_social_headers"
+  | Missing_headers_fallback_visible_reply ->
+      "headers_missing:fallback_visible_reply"
+  | Invalid_headers_fallback_visible_reply ->
+      "headers_invalid:fallback_visible_reply"
+  | Inferred_visible_reply -> "text_reply:inferred_visible_reply"
+  | Protocol_violation_missing_social_headers ->
+      "protocol_violation:missing_social_headers"
+  | Protocol_violation_invalid_social_headers ->
+      "protocol_violation:invalid_social_headers"
+  | Protocol_violation_no_tools_no_social_headers ->
+      "protocol_violation:no_tool_calls_and_no_social_headers"
+  | Failure_run_error -> "failure:run_error"

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -19,6 +19,22 @@ type delivery_surface =
 type model_id =
   | Bdi_speech_v1
 
+type transition_reason =
+  | Tool_only_stay_silent
+  | Tool_only_comment_board
+  | Tool_only_post_board
+  | Tool_only_broadcast
+  | Tool_only_claim_task
+  | Tool_only_visible_reply
+  | Explicit_social_headers
+  | Missing_headers_fallback_visible_reply
+  | Invalid_headers_fallback_visible_reply
+  | Inferred_visible_reply
+  | Protocol_violation_missing_social_headers
+  | Protocol_violation_invalid_social_headers
+  | Protocol_violation_no_tools_no_social_headers
+  | Failure_run_error
+
 type social_state = {
   social_model : string;
   belief_summary : string;
@@ -39,3 +55,4 @@ val model_id_to_string : model_id -> string
 val model_id_of_string : string -> model_id option
 val default_model_id : model_id
 val normalize_social_model : string -> string
+val transition_reason_to_string : transition_reason -> string

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -194,6 +194,10 @@ let keeper_list_row_json ~runtime_class config name =
               if String.trim meta.runtime.last_speech_act = ""
               then `Null
               else `String meta.runtime.last_speech_act );
+            ( "last_social_transition_reason",
+              if String.trim meta.runtime.last_social_transition_reason = ""
+              then `Null
+              else `String meta.runtime.last_social_transition_reason );
             ("skill_route", keeper_list_skill_route_json config meta);
             ("cascade_name", `String meta.cascade_name);
             ("created_at", `String meta.created_at);

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -66,7 +66,8 @@ proactive_enabled = false
 |}
 
 let write_keeper_meta_exn ?(autoboot_enabled = true)
-    ?(social_model = "bdi_speech_v1") config ~name ~trace_id =
+    ?(social_model = "bdi_speech_v1")
+    ?(last_social_transition_reason = "") config ~name ~trace_id =
   let json =
     `Assoc
       [
@@ -75,6 +76,7 @@ let write_keeper_meta_exn ?(autoboot_enabled = true)
         ("trace_id", `String trace_id);
         ("goal", `String "test keeper");
         ("social_model", `String social_model);
+        ("last_social_transition_reason", `String last_social_transition_reason);
         ("autoboot_enabled", `Bool autoboot_enabled);
       ]
   in
@@ -221,6 +223,43 @@ let test_keeper_list_normalizes_unknown_social_model () =
             Yojson.Safe.Util.(keeper |> member "social_model" |> to_string)
       | None -> fail "expected sangsu row in keeper list")
 
+let test_keeper_list_exposes_last_social_transition_reason () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn config ~name:"sangsu";
+      write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu"
+        ~last_social_transition_reason:"tool_only:visible_reply";
+      register_keeper_offline_exn config ~name:"sangsu";
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_list"
+            ~args:(`Assoc [ ("limit", `Int 10); ("detailed", `Bool true) ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_list dispatch"
+      in
+      check bool "tool keeper list ok" true ok;
+      let json = parse_json_exn body in
+      match keeper_json_by_name json "sangsu" with
+      | Some keeper ->
+          check string "transition reason surfaced" "tool_only:visible_reply"
+            Yojson.Safe.Util.(
+              keeper |> member "last_social_transition_reason" |> to_string)
+      | None -> fail "expected sangsu row in keeper list")
+
 let () =
   run "keeper_meta_listing"
     [
@@ -232,5 +271,7 @@ let () =
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
           test_case "tool keeper list normalizes unknown social model" `Quick
             test_keeper_list_normalizes_unknown_social_model;
+          test_case "tool keeper list exposes last social transition reason"
+            `Quick test_keeper_list_exposes_last_social_transition_reason;
         ] );
     ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1686,13 +1686,16 @@ let test_metrics_persist_social_state_fields () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let routed, social_state =
+      let routed, social_state, transition_reason =
         KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation ~previous_state:None result
       in
       let updated =
         UT.update_metrics_from_result minimal_meta ~latency_ms:100
-          ~observation:base_observation ~social_state routed
+          ~observation:base_observation ~social_state
+          ~social_transition_reason:
+            (KSM.transition_reason_to_string transition_reason)
+          routed
       in
       check string "active desire tracked" "maintain_quiet_readiness"
         updated.runtime.last_active_desire;
@@ -1700,6 +1703,8 @@ let test_metrics_persist_social_state_fields () =
         updated.runtime.last_current_intention;
       check string "speech act tracked" "stay_silent"
         updated.runtime.last_speech_act;
+      check string "transition reason tracked" "headers:explicit_social_headers"
+        updated.runtime.last_social_transition_reason;
       check string "no blocker tracked" "" updated.runtime.last_blocker;
       check string "no need tracked" "" updated.runtime.last_need)
 
@@ -1707,7 +1712,8 @@ let test_metrics_failure_response () =
   let reason = "Agent run failed: Max turns exceeded (turn 10, limit 10)" in
   let updated =
     UT.update_metrics_from_failure minimal_meta ~latency_ms:250
-      ~observation:base_observation ~reason ()
+      ~observation:base_observation ~reason
+      ~social_transition_reason:"failure:run_error" ()
   in
   check int "total_turns +1" (minimal_meta.runtime.usage.total_turns + 1) updated.runtime.usage.total_turns;
   check int "latency recorded" 250 updated.runtime.usage.last_latency_ms;
@@ -1738,7 +1744,9 @@ let test_metrics_failure_response () =
          true
        with Not_found -> false
      in
-     found)
+     found);
+  check string "failure transition reason tracked" "failure:run_error"
+    updated.runtime.last_social_transition_reason
 
 let test_prompt_includes_board_activity_section () =
   let obs =
@@ -2398,7 +2406,7 @@ let test_social_model_silences_skip_only_turn () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let routed, state =
+      let routed, state, _ =
         KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation ~previous_state:None result
       in
@@ -2415,7 +2423,7 @@ let test_social_model_unknown_meta_falls_back_to_baseline () =
     make_run_result ~text:"I can respond normally." ~tools:[]
       ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
-  let routed, state =
+  let routed, state, _ =
     KSM.apply_to_result ~meta ~observation:base_observation
       ~previous_state:None result
   in
@@ -2432,7 +2440,7 @@ let test_social_model_unknown_header_falls_back_to_baseline () =
       ~tools:[]
       ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
-  let routed, state =
+  let routed, state, _ =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state:None result
   in
@@ -2449,7 +2457,7 @@ let test_social_model_infers_visible_reply_without_headers () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)
     (fun () ->
-      let routed, state =
+      let routed, state, _ =
         KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation ~previous_state:None result
       in
@@ -2467,7 +2475,7 @@ let test_social_model_empty_text_without_headers_stays_silent () =
     make_run_result ~text:"" ~tools:[]
       ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
-  let routed, state =
+  let routed, state, transition_reason =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state:None result
   in
@@ -2477,6 +2485,9 @@ let test_social_model_empty_text_without_headers_stays_silent () =
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "blocker notes empty protocol violation"
     (Some "no tool calls and no social headers") state.blocker;
+  check string "transition reason"
+    "protocol_violation:no_tool_calls_and_no_social_headers"
+    (KSM.transition_reason_to_string transition_reason);
   check string "visible response suppressed" "" routed.response_text;
   check (list string) "no synthetic tools" [] routed.tools_used
 
@@ -2488,7 +2499,7 @@ let test_social_model_state_only_reply_stays_silent () =
       ~tools:[]
       ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
-  let routed, state =
+  let routed, state, _ =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state:None result
   in
@@ -2506,7 +2517,7 @@ let test_social_model_strips_state_block_from_visible_reply () =
       ~tools:[]
       ~model:"test-model" ~input_tok:20 ~output_tok:5 ()
   in
-  let routed, state =
+  let routed, state, _ =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state:None result
   in
@@ -2538,7 +2549,7 @@ let test_social_model_routes_blocker_to_board_post () =
       Masc_mcp.Board_dispatch.init_jsonl ();
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "observer"));
-      let routed, state =
+      let routed, state, _ =
         KSM.apply_to_result ~meta:minimal_meta
           ~observation:base_observation ~previous_state:None result
       in
@@ -2567,7 +2578,7 @@ let test_social_model_tool_only_turn_skips_protocol_violation () =
     make_run_result ~text:"" ~tools:["masc_status"]
       ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
   in
-  let routed, state =
+  let routed, state, transition_reason =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state:None result
   in
@@ -2576,6 +2587,8 @@ let test_social_model_tool_only_turn_skips_protocol_violation () =
   check string "delivery surface" "visible_reply"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "no protocol violation blocker" None state.blocker;
+  check string "transition reason" "tool_only:visible_reply"
+    (KSM.transition_reason_to_string transition_reason);
   check bool "tool-only turn synthesizes visible response" true
     (contains_substring routed.response_text "Tools used: masc_status.");
   check (list string) "tool list preserved" ["masc_status"] routed.tools_used
@@ -2588,6 +2601,7 @@ let test_social_model_previous_state_of_meta_restores_runtime_fields () =
         {
           minimal_meta.runtime with
           last_speech_act = "request_help";
+          last_social_transition_reason = "headers:explicit_social_headers";
           last_active_desire = "seek_help";
           last_current_intention = "recover_tool_route";
           last_blocker = "tool route unavailable";
@@ -2631,7 +2645,7 @@ let test_social_model_tool_only_turn_carries_previous_state () =
           delivery_surface = Board_post;
         }
   in
-  let routed, state =
+  let routed, state, _ =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state result
   in
@@ -2654,7 +2668,7 @@ let test_social_model_infers_board_comment_from_tool_use () =
     make_run_result ~text:"" ~tools:["keeper_board_comment"; "masc_status"]
       ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
   in
-  let routed, state =
+  let routed, state, transition_reason =
     KSM.apply_to_result ~meta:minimal_meta
       ~observation:base_observation ~previous_state:None result
   in
@@ -2663,6 +2677,8 @@ let test_social_model_infers_board_comment_from_tool_use () =
   check string "delivery surface" "board_comment"
     (KSM.delivery_surface_to_string state.delivery_surface);
   check (option string) "no protocol violation blocker" None state.blocker;
+  check string "transition reason" "tool_only:comment_board"
+    (KSM.transition_reason_to_string transition_reason);
   check bool "tool turn keeps synthesized visible response" true
     (contains_substring routed.response_text
        "Tools used: keeper_board_comment, masc_status.");


### PR DESCRIPTION
## Summary
- add canonical social-model transition reason tags and thread them through registry/bdi dispatch
- persist last_social_transition_reason in keeper runtime state
- expose the latest social transition reason in keeper list/status/detail/dashboard surfaces

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-transition-reason test/test_keeper_unified.exe test/test_keeper_meta_listing.exe
- env ALCOTEST_QUICK_TESTS=1 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-transition-reason/_build/default/test/test_keeper_unified.exe
- env ALCOTEST_QUICK_TESTS=1 dune exec --build-dir /tmp/masc-social-transition-reason-build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/social-model-transition-reason ./test/test_keeper_meta_listing.exe
- bash scripts/health_snapshot.sh --skip-build --baseline-ref origin/main --fail-on-lib-regression