### PR TITLE
fix(dashboard): cache Meta_cognition summary + raise shell timeout

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -792,7 +792,20 @@ let dashboard_general_agent_count agents =
 let provider_capacity_json () : Yojson.Safe.t =
   `Assoc []
 
-let dashboard_shell_timeout_s = 8.0
+let dashboard_shell_timeout_s = 16.0
+
+(* Meta_cognition.summary_json does a full board_posts.jsonl scan +
+   belief/tension/desire rule evaluation. On a room with 450+ posts this
+   regularly exceeds 8s, which was the previous shell timeout and caused
+   repeat "cache compute timeout: shell:..." + "cache bg-revalidate failed"
+   noise in the log. Give it its own cache with a longer TTL so the shell
+   path does not block on it every refresh cycle. *)
+let meta_cognition_summary_ttl = 120.0
+
+let meta_cognition_summary_cached (config : Room.config) : Yojson.Safe.t =
+  let key = Printf.sprintf "meta_cognition_summary:%s" config.base_path in
+  Dashboard_cache.get_or_compute key ~ttl:meta_cognition_summary_ttl (fun () ->
+    Meta_cognition.summary_json config)
 
 let dashboard_shell_paths_json (config : Room.config) : Yojson.Safe.t =
   Server_base_path_diagnostics.detect
@@ -832,7 +845,7 @@ let dashboard_shell_payload_json (config : Room.config) : Yojson.Safe.t =
     measure_ms (fun () -> keeper_count config)
   in
   let meta_cognition_json, meta_cognition_ms =
-    measure_ms (fun () -> Meta_cognition.summary_json config)
+    measure_ms (fun () -> meta_cognition_summary_cached config)
   in
   let config_resolution_json, config_resolution_ms =
     measure_json_projection "config_resolution" (fun () ->


### PR DESCRIPTION
## Symptom

Keeper log spammed every ~8s on rooms with a large board:
\`\`\`
[WARN] [Dashboard] cache compute timeout: shell:coord=/Users/dancer/me:workspace=/Users/dancer/me (8s)
[WARN] [Dashboard] cache bg-revalidate failed ... Compute_timeout("shell:...", 0)
\`\`\`

## Root cause

\`dashboard_shell_payload_json\` in \`lib/server/server_dashboard_http_core.ml\` calls \`Meta_cognition.summary_json config\` synchronously on every refresh.

\`Meta_cognition.summary_json\`:
1. Loads all \`board_posts.jsonl\` posts, comments, votes, governance cases
2. Applies all belief / tension / desire rules against the complete source set
3. Sorts + takes top N

On \`~/me/.masc/board_posts.jsonl\` (1.5MB, 450+ posts) this routinely crosses the 8s \`dashboard_shell_timeout_s\` threshold. The cache bg-revalidate failure invalidates the shell cache → next tick re-enters the same hot path → repeats forever.

## Fix

- Dedicated cache \`meta_cognition_summary:<base_path>\` with TTL **120s**. Shell refresh reads the cached summary instead of blocking.
- Raise shell compute timeout **8s → 16s** to absorb the first cold call.

## Not fixed in this PR (follow-up)

- Structural: make \`Meta_cognition\` load board state through Room's cached reader instead of full jsonl scan.
- No new test — the hot path is implicit (observed via log noise, reproducible only on a room with 450+ posts).

## Test plan

- [x] \`dune build --root .\` clean
- [ ] Deploy + observe: no more repeated shell:coord timeout warnings