### PR TITLE
feat(cascade): add sangsu profile — local-first ollama + glm fallback

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -26,6 +26,13 @@
   ],
   "local_recovery_temperature": 0.1,
   "local_recovery_max_tokens": 8192,
+  "_comment_sangsu": "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls.  Bias heavily toward local ollama to keep cost near zero, but include glm-coding as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle.  Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04.  Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm), 10% put glm first (then ollama).",
+  "sangsu_models": [
+    {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 90},
+    {"model": "glm-coding:glm-5.1", "weight": 10}
+  ],
+  "sangsu_temperature": 0.1,
+  "sangsu_max_tokens": 16384,
   "tool_rerank_temperature": 0.0,
   "tool_rerank_max_tokens": 200,
   "keeper_unified_temperature": 0.2,


### PR DESCRIPTION
## Why

The sangsu persona keeper has been parking idle with `Completion contract [require_tool_use] violated` errors:

- Keeper was in `keeper_unified` cascade (50% glm / 30% qwen3.5 / 20% gemma4)
- Weighted selection landed on `ollama:qwen3.5:35b-a3b-nvfp4` for a turn that requested `tool_choice = required`
- Qwen3-35B BFCL is ~67% — a double-digit fraction of forced-tool turns return text only
- Contract gate fires → keeper halts (52 min idle in today's incident)

## What

Add a `sangsu` cascade profile:

- `ollama:qwen3.5:35b-a3b-nvfp4` weight 90 + `glm-coding:glm-5.1` weight 10
- `Cascade_config.order_weighted_entries` orders by weighted random; higher weight tends first. On a contract violation OAS falls through to the next link → the tool-required minority auto-escalates to glm-coding instead of leaving the keeper idle
- `sangsu_temperature = 0.1` (vs default 0.2) per `memory/reference_ollama-config-2026-04` — tighter sampling helps qwen obey the function-calling schema when it does try
- `sangsu_max_tokens = 16384` matches `keeper_unified`

## Caller change

This PR only ships the cascade definition. The keeper TOML switch (`cascade_name = "sangsu"`) lives in playground space which is gitignored. After this merges, the operator updates their `config/keepers/sangsu.toml` and restarts the keeper. Cascade JSON is mtime-cached so no rebuild needed — disk edit picks up on the next call.

## Test plan
- [x] `python3 -m json.tool config/cascade.json` valid
- [ ] CI green
- [ ] Manual: switch sangsu keeper to `cascade_name = "sangsu"`, observe idle resolves and most turns served by ollama (tail ollama logs) with occasional glm fallback on tool turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)