### PR TITLE
[codex] Fix FSM Hub composite render crash on legacy payloads

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -1,6 +1,12 @@
 // MASC Dashboard — Keeper messaging (direct, operator-mediated, SSE streaming)
 
-import { isRecord } from '../components/common/normalize'
+import {
+  asBoolean,
+  asNullableString,
+  asNumber,
+  asString,
+  isRecord,
+} from '../components/common/normalize'
 import {
   formatKeeperVisibleReply,
   normalizeKeeperConversationDetails,
@@ -447,6 +453,101 @@ export interface KeeperCompositeSnapshot {
   last_outcome: KeeperLastOutcome | null
 }
 
+const DEFAULT_KEEPER_COMPOSITE_RECOVERY = {
+  data_record: false,
+  fsm_condition: false,
+} as const
+
+const DEFAULT_KEEPER_COMPOSITE_INVARIANTS = {
+  phase_turn_alignment: true,
+  no_cascade_before_measurement: true,
+  compaction_atomicity: true,
+  event_priority_monotone: true,
+} as const satisfies Omit<KeeperCompositeInvariants, 'recovery_two_store_sync'>
+
+export function normalizeKeeperCompositeSnapshot(data: unknown): KeeperCompositeSnapshot {
+  if (!isRecord(data)) {
+    throw new Error('composite fetch failed: malformed payload')
+  }
+
+  const decision = isRecord(data.decision) ? data.decision : null
+  const cascade = isRecord(data.cascade) ? data.cascade : null
+  const compaction = isRecord(data.compaction) ? data.compaction : null
+  const measurement = isRecord(data.measurement) ? data.measurement : null
+  const autoRules = isRecord(measurement?.auto_rules) ? measurement.auto_rules : null
+  const recovery = isRecord(data.recovery) ? data.recovery : null
+  const dataRecord = asBoolean(recovery?.data_record, DEFAULT_KEEPER_COMPOSITE_RECOVERY.data_record)
+  const fsmCondition = asBoolean(recovery?.fsm_condition, DEFAULT_KEEPER_COMPOSITE_RECOVERY.fsm_condition)
+  const invariants = isRecord(data.invariants) ? data.invariants : null
+  const lastOutcome = isRecord(data.last_outcome) ? data.last_outcome : null
+
+  return {
+    correlation_id: asString(data.correlation_id, ''),
+    run_id: asString(data.run_id, ''),
+    ts: asNumber(data.ts, 0),
+    phase: asString(data.phase, 'Offline'),
+    turn_phase: asString(data.turn_phase, 'idle'),
+    decision: {
+      stage: asString(decision?.stage, 'undecided'),
+    },
+    cascade: {
+      state: asString(cascade?.state, 'idle'),
+    },
+    compaction: {
+      stage: asString(compaction?.stage, 'accumulating'),
+    },
+    measurement: autoRules
+      ? {
+          captured: asBoolean(measurement?.captured, true),
+          auto_rules: {
+            reflect: asBoolean(autoRules.reflect, false),
+            plan: asBoolean(autoRules.plan, false),
+            compact: asBoolean(autoRules.compact, false),
+            handoff: asBoolean(autoRules.handoff, false),
+            guardrail_stop: asBoolean(autoRules.guardrail_stop, false),
+            guardrail_reason: asNullableString(autoRules.guardrail_reason),
+            goal_drift: asNumber(autoRules.goal_drift, 0),
+          },
+        }
+      : {
+          captured: asBoolean(measurement?.captured, false),
+        },
+    recovery: {
+      data_record: dataRecord,
+      fsm_condition: fsmCondition,
+    },
+    invariants: {
+      phase_turn_alignment: asBoolean(
+        invariants?.phase_turn_alignment,
+        DEFAULT_KEEPER_COMPOSITE_INVARIANTS.phase_turn_alignment,
+      ),
+      no_cascade_before_measurement: asBoolean(
+        invariants?.no_cascade_before_measurement,
+        DEFAULT_KEEPER_COMPOSITE_INVARIANTS.no_cascade_before_measurement,
+      ),
+      compaction_atomicity: asBoolean(
+        invariants?.compaction_atomicity,
+        DEFAULT_KEEPER_COMPOSITE_INVARIANTS.compaction_atomicity,
+      ),
+      event_priority_monotone: asBoolean(
+        invariants?.event_priority_monotone,
+        DEFAULT_KEEPER_COMPOSITE_INVARIANTS.event_priority_monotone,
+      ),
+      recovery_two_store_sync: asBoolean(
+        invariants?.recovery_two_store_sync,
+        dataRecord === fsmCondition,
+      ),
+    },
+    is_live: asBoolean(data.is_live, false),
+    last_outcome: lastOutcome
+      ? {
+          turn_id: asNumber(lastOutcome.turn_id, 0),
+          ended_at: asNumber(lastOutcome.ended_at, 0),
+        }
+      : null,
+  }
+}
+
 export async function fetchKeeperComposite(name: string): Promise<KeeperCompositeSnapshot> {
   const resp = await fetchWithTimeout(
     `/api/v1/keepers/${encodeURIComponent(name)}/composite`,
@@ -454,7 +555,7 @@ export async function fetchKeeperComposite(name: string): Promise<KeeperComposit
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`composite fetch failed: ${resp.status}`)
-  return resp.json() as Promise<KeeperCompositeSnapshot>
+  return normalizeKeeperCompositeSnapshot(await resp.json())
 }
 
 // --- Eval Quality (RFC-MASC-005 Phase 3) ---

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -19,17 +19,19 @@
 
 import { describe, expect, it } from 'vitest'
 
-import type { KeeperCompositeSnapshot } from '../api/keeper'
+import {
+  normalizeKeeperCompositeSnapshot,
+  type KeeperCompositeSnapshot,
+} from '../api/keeper'
 import type { GateKeepersData } from '../api/gate'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import { deriveStateEntries, deriveSwimlaneSegments } from './fsm-hub'
 
-/** Server-shaped keeper composite snapshot matching the actual
-    `/api/v1/keepers/:name/composite` response observed from a live
-    MASC v0.8.0 server on 2026-04-15. If the server changes this
-    shape, the parse should fail here, not silently produce undefined
-    in the swimlane. */
-const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
+/** Legacy server-shaped keeper composite snapshot observed from a live
+    `/api/v1/keepers/:name/composite` response before recovery wiring.
+    The dashboard must normalize this shape instead of crashing at
+    `snapshot.recovery.data_record`. */
+const LEGACY_COMPOSITE_PAYLOAD = {
   correlation_id: '10510-64f79d602ce6c-60c',
   run_id: 'r-1776233076-0',
   ts: 1776235685.221697,
@@ -39,17 +41,18 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
   cascade: { state: 'idle' },
   compaction: { stage: 'accumulating' },
   measurement: { captured: false },
-  recovery: { data_record: false, fsm_condition: false },
   invariants: {
     phase_turn_alignment: true,
     no_cascade_before_measurement: true,
     compaction_atomicity: true,
     event_priority_monotone: true,
-    recovery_two_store_sync: true,
   },
   is_live: false,
   last_outcome: { turn_id: 353, ended_at: 1776234638.709722 },
 }
+
+const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot =
+  normalizeKeeperCompositeSnapshot(LEGACY_COMPOSITE_PAYLOAD)
 
 /** Server-shaped gate keepers response. */
 const REAL_GATE_KEEPERS_SHAPE: GateKeepersData = {
@@ -80,6 +83,14 @@ describe('FSM Hub integration — API response shape', () => {
   })
 
   describe('composite snapshot response', () => {
+    it('normalizes legacy payloads that omit recovery wiring', () => {
+      expect(REAL_COMPOSITE_SHAPE.recovery).toEqual({
+        data_record: false,
+        fsm_condition: false,
+      })
+      expect(REAL_COMPOSITE_SHAPE.invariants.recovery_two_store_sync).toBe(true)
+    })
+
     it('carries all 5 sub-FSM fields the FsmHub renders', () => {
       expect(REAL_COMPOSITE_SHAPE.phase).toBeDefined()
       expect(REAL_COMPOSITE_SHAPE.turn_phase).toBeDefined()


### PR DESCRIPTION
## What changed
- normalize `/api/v1/keepers/:name/composite` responses at the dashboard API boundary
- backfill missing `recovery` and `invariants.recovery_two_store_sync` fields when older servers omit them
- add an integration regression test for the legacy payload shape that caused the FSM Hub crash

## Why
The FSM Hub assumed `snapshot.recovery.data_record` always existed, but the current backend `/composite` payload does not emit `recovery` or `recovery_two_store_sync`. That caused `monitoring:agents` / FSM rendering to fail with `Cannot read properties of undefined (reading 'data_record')`.

## Impact
- the FSM view renders again against current/legacy composite payloads
- recovery/invariant panels no longer hard-crash when the backend omits newer fields
- future payload drift is covered by a regression test

## Validation
- `pnpm --dir dashboard test src/components/fsm-hub.test.ts src/components/fsm-hub.integration.test.ts`
- `pnpm --dir dashboard typecheck`

## Notes
This PR restores rendering defensively in the dashboard. It does not add backend recovery truth emission to the composite observer yet.