### PR TITLE
fix(checkpoint): add malformed checkpoint detection logging in load_latest

### DIFF
--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -117,7 +117,11 @@ let load_latest ~(session_dir : string) : Keeper_types.checkpoint option =
   | latest :: _ ->
     let path = Filename.concat session_dir latest in
     (try Some (parse_checkpoint_file path)
-     with Eio.Cancel.Cancelled _ as e -> raise e | _ -> None)
+     with Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+       Log.Keeper.warn "malformed checkpoint ignored in %s: %s"
+         path (Printexc.to_string exn);
+       None)
 
 (* ================================================================ *)
 (* OAS Checkpoint Compatibility                                      *)


### PR DESCRIPTION
When checkpoint parsing fails in load_latest, the error is silently swallowed. This adds warn logging to help audit malformed checkpoints after tool-pair fix and other migrations.