### PR TITLE
refactor(base-path): rename fail_fast_enabled → startup_abort_eligible

### DIFF
--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -17,7 +17,7 @@ type t = {
   dual_masc_roots : bool;
   strict_mode_requested : bool;
   startup_rejected : bool;
-  fail_fast_enabled : bool;
+  startup_abort_eligible : bool;
   warning : string option;
 }
 
@@ -60,7 +60,7 @@ let format_legacy_dirs = function
   | [] -> "none"
   | dirs -> String.concat ", " dirs
 
-let fail_fast_env_enabled () =
+let strict_mode_env_enabled () =
   match Sys.getenv_opt "MASC_BASE_PATH_STRICT" with
   | Some raw -> (
       match String.lowercase_ascii (String.trim raw) with
@@ -118,9 +118,9 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
   let strict_mode_requested =
     match strict with
     | Some enabled -> enabled
-    | None -> fail_fast_env_enabled ()
+    | None -> strict_mode_env_enabled ()
   in
-  let fail_fast_enabled =
+  let startup_abort_eligible =
     strict_mode_requested || startup_rejected
   in
   let warning =
@@ -164,7 +164,7 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     dual_masc_roots;
     strict_mode_requested;
     startup_rejected;
-    fail_fast_enabled;
+    startup_abort_eligible;
     warning;
   }
 
@@ -175,7 +175,7 @@ let strict_violation (diag : t) =
      tools can flag the stale cwd [.masc] tree, but the runtime must
      not kill itself out from under a CI/test harness or a developer
      who deliberately pointed at a tmp directory. Pairs with the same
-     escape condition used to compute [fail_fast_enabled] above. *)
+     escape condition used to compute [startup_abort_eligible] above. *)
   diag.startup_rejected
 
 let startup_lines (diag : t) =
@@ -252,7 +252,7 @@ let to_yojson (diag : t) =
        ("dual_masc_roots", `Bool diag.dual_masc_roots);
        ("strict_mode_requested", `Bool diag.strict_mode_requested);
        ("startup_rejected", `Bool diag.startup_rejected);
-       ("fail_fast_enabled", `Bool diag.fail_fast_enabled);
+       ("startup_abort_eligible", `Bool diag.startup_abort_eligible);
        ("strict_violation", `Bool (strict_violation diag));
      ]
     @ List.filter_map (fun item -> item)

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -117,8 +117,8 @@ let test_implicit_dual_roots_are_strict_violation () =
     diag.strict_mode_requested;
   Alcotest.(check bool) "startup_rejected derived from implicit dual roots" true
     diag.startup_rejected;
-  Alcotest.(check bool) "fail_fast derived from implicit dual roots" true
-    diag.fail_fast_enabled;
+  Alcotest.(check bool) "startup_abort_eligible derived from implicit dual roots" true
+    diag.startup_abort_eligible;
   Alcotest.(check bool) "implicit dual roots violate" true
     (Server_base_path_diagnostics.strict_violation diag)
 
@@ -161,8 +161,8 @@ let test_explicit_resolution_source_escapes_strict_violation () =
     diag.strict_mode_requested;
   Alcotest.(check bool) "startup_rejected false for explicit env source" false
     diag.startup_rejected;
-  Alcotest.(check bool) "fail_fast_enabled remains true under strict mode" true
-    diag.fail_fast_enabled;
+  Alcotest.(check bool) "startup_abort_eligible remains true under strict mode" true
+    diag.startup_abort_eligible;
   Alcotest.(check bool) "explicit env source escapes violation" false
     (Server_base_path_diagnostics.strict_violation diag)
 
@@ -194,8 +194,8 @@ let test_explicit_cli_resolution_source_also_escapes () =
     diag.strict_mode_requested;
   Alcotest.(check bool) "startup_rejected false for explicit cli source" false
     diag.startup_rejected;
-  Alcotest.(check bool) "fail_fast_enabled false without user STRICT" false
-    diag.fail_fast_enabled;
+  Alcotest.(check bool) "startup_abort_eligible false without user STRICT" false
+    diag.startup_abort_eligible;
   Alcotest.(check bool) "explicit cli source escapes violation" false
     (Server_base_path_diagnostics.strict_violation diag)
 
@@ -249,8 +249,8 @@ let test_to_yojson_exposes_gate_fields () =
     (json |> member "strict_mode_requested" |> to_bool);
   Alcotest.(check bool) "startup_rejected field" false
     (json |> member "startup_rejected" |> to_bool);
-  Alcotest.(check bool) "fail_fast_enabled field" false
-    (json |> member "fail_fast_enabled" |> to_bool)
+  Alcotest.(check bool) "startup_abort_eligible field" false
+    (json |> member "startup_abort_eligible" |> to_bool)
 
 let test_default_base_path_ignores_inherited_parent_root_in_tests () =
   with_temp_dir "base-path-default" @@ fun root ->


### PR DESCRIPTION
## Summary

Rename `fail_fast_enabled` → `startup_abort_eligible` in `Server_base_path_diagnostics` to eliminate ambiguous semantics.

## Problem

`fail_fast_enabled` suggests the runtime will "fail fast" on startup, but the actual abort decision is governed by `startup_rejected`. The old name leaked into the JSON read-model (`/health` endpoint), confusing operators and dashboard consumers about what the field actually means.

## Changes

**lib/server_base_path_diagnostics.ml:**
- Record field: `fail_fast_enabled : bool` → `startup_abort_eligible : bool`
- Helper: `fail_fast_env_enabled ()` → `strict_mode_env_enabled ()`
- JSON key: `"fail_fast_enabled"` → `"startup_abort_eligible"`
- All internal references updated (detect, record construction, to_yojson, comment)

**test/test_server_base_path_diagnostics.ml:**
- Field access: `diag.fail_fast_enabled` → `diag.startup_abort_eligible` (4 occurrences)
- JSON key check: `"fail_fast_enabled"` → `"startup_abort_eligible"`
- Test labels updated (4 assertions)

## Breaking change

JSON consumers that depend on `"fail_fast_enabled"` key must migrate to `"startup_abort_eligible"`. This is intentional — the task explicitly asks to migrate human-facing consumers off the ambiguous name.

## No behavioral change

The computed value is identical. Only the name changes.

Closes task-114