### PR TITLE
refactor(exec_memory): replace Hashtbl dedup with immutable StringSet

### DIFF
--- a/lib/keeper/keeper_exec_memory.ml
+++ b/lib/keeper/keeper_exec_memory.ml
@@ -1,6 +1,8 @@
 open Keeper_types
 open Keeper_exec_shared
 
+module StringSet = Set.Make (String)
+
 let contains_ci = String_util.contains_substring_ci
 
 type memory_match = {
@@ -116,22 +118,26 @@ let search_history
   let checkpoint_user_msgs =
     Keeper_memory_recall.recent_user_messages ctx_work.messages ~max_n:100
   in
-  let seen : (string, unit) Hashtbl.t = Hashtbl.create 64 in
   let key_of s =
     let len = min 100 (String.length s) in
     String.sub s 0 len
   in
-  List.iter (fun s -> Hashtbl.replace seen (key_of s) ()) checkpoint_user_msgs;
-  let dedup lst =
-    List.filter (fun s ->
+  let seen0 =
+    List.fold_left (fun acc s -> StringSet.add (key_of s) acc)
+      StringSet.empty checkpoint_user_msgs
+  in
+  let dedup seen lst =
+    List.fold_left (fun (acc, seen) s ->
       let k = key_of s in
-      if Hashtbl.mem seen k then false
-      else (Hashtbl.replace seen k (); true)) lst
+      if StringSet.mem k seen then (acc, seen)
+      else (s :: acc, StringSet.add k seen))
+      ([], seen) lst
+    |> fun (acc, seen) -> (List.rev acc, seen)
   in
   let all_candidates =
     checkpoint_user_msgs
-    @ dedup current_history
-    @ dedup prev_history
+    @ fst (dedup seen0 current_history)
+    @ fst (dedup (snd (dedup seen0 current_history)) prev_history)
   in
   all_candidates
   |> List.filter (fun msg -> query <> "" && String_util.contains_substring_ci msg query)


### PR DESCRIPTION
## Summary
Replace mutable Hashtbl dedup pattern with immutable StringSet in keeper_exec_memory.ml.

## Changes
- Added module StringSet = Set.Make (String) at module level
- Replaced Hashtbl.create 64 + List.iter/replace + Hashtbl.mem with:
  - List.fold_left + StringSet.empty + StringSet.add for initial population
  - dedup returns (string list * StringSet.t) to thread accumulator through calls
  - fst/snd to extract deduped list and updated seen set

## Verification
- dune build @check passed (exit code 0)
- No behavioral change: same dedup semantics, same ordering