### PR TITLE
refactor(context_core): replace Hashtbl dedup with immutable StringSet

### DIFF
--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -10,6 +10,8 @@
 open Printf
 open Keeper_types
 
+module StringSet = Set.Make (String)
+
 (* ================================================================ *)
 (* Constants                                                         *)
 (* ================================================================ *)
@@ -510,14 +512,14 @@ let render_jsonl_lines (lines : string list) : string =
   | _ -> String.concat "\n" lines ^ "\n"
 
 let dedupe_preserve_order (lines : string list) : string list =
-  let seen : (string, unit) Hashtbl.t = Hashtbl.create (List.length lines) in
-  List.filter
-    (fun line ->
-       if Hashtbl.mem seen line then false
-       else (
-         Hashtbl.add seen line ();
-         true))
-    lines
+  let rec go seen acc = function
+    | [] -> List.rev acc
+    | line :: rest ->
+      if StringSet.mem line seen
+      then go seen acc rest
+      else go (StringSet.add line seen) (line :: acc) rest
+  in
+  go StringSet.empty [] lines
 
 let migrate_session_history_logs
     ~(session_dir : string) : history_migration_stats =


### PR DESCRIPTION
## Summary
Replace mutable Hashtbl dedup pattern with immutable StringSet in dedupe_preserve_order (keeper_context_core.ml).

## Changes
- Added module StringSet = Set.Make (String) at module level
- Replaced Hashtbl.create + List.filter + Hashtbl.mem/add with:
  - Recursive go function that threads StringSet accumulator
  - StringSet.mem for membership check, StringSet.add for insert
  - List.rev at base case to preserve input order

## Verification
- dune build @check passed (exit code 0)
- No behavioral change: same dedup semantics, same ordering preserved