### PR TITLE
refactor(types_profile): replace Hashtbl dedup with immutable StringSet in persona loading

### DIFF
--- a/lib/keeper/keeper_tool_diversity.ml
+++ b/lib/keeper/keeper_tool_diversity.ml
@@ -92,15 +92,17 @@ let compute_diversity ~(available_tools : string list)
     |> List.map (fun s -> s.name)
   in
   (* Underused: available tools never called or called < 1% *)
-  let used_set = Hashtbl.create (List.length stats) in
-  List.iter (fun s ->
-    if s.count > 0 then Hashtbl.replace used_set s.name ()
-  ) stats;
+  let module SS = Set.Make (String) in
+  let used_set =
+    List.fold_left (fun acc s ->
+      if s.count > 0 then SS.add s.name acc else acc)
+      SS.empty stats
+  in
   let threshold = max 1 (total_calls / 100) in
   let underused = available_tools
     |> List.filter (fun tool ->
       not (String.equal tool "keeper_stay_silent")
-      && (not (Hashtbl.mem used_set tool)
+      && (not (SS.mem tool used_set)
           || List.exists (fun s -> s.name = tool && s.count < threshold) stats))
   in
   { total_calls; unique_tools; available_tools = n_available;

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -720,13 +720,14 @@ let list_persona_summaries () : persona_summary list =
     with Sys_error _ -> []
   in
   (* Collect all persona (name, path) from all dirs; later dirs override *)
-  let seen = Hashtbl.create 32 in
+  let module SS = Set.Make (String) in
+  let raw = dirs |> List.concat_map entries_from_dir in
   let all_entries =
-    dirs
-    |> List.concat_map entries_from_dir
-    |> List.filter (fun (name, _) ->
-           if Hashtbl.mem seen name then false
-           else (Hashtbl.add seen name (); true))
+    List.fold_left (fun (acc, seen) (name, path) ->
+      if SS.mem name seen then (acc, seen)
+      else ((name, path) :: acc, SS.add name seen))
+      ([], SS.empty) raw
+    |> fun (acc, _) -> List.rev acc
   in
   all_entries
   |> List.filter_map (fun (name, path) -> load_persona_summary_from_path name path)


### PR DESCRIPTION
## Summary
Replace mutable Hashtbl dedup pattern with immutable StringSet in keeper_types_profile.ml persona loading.

## Changes
- Replaced Hashtbl.create 32 + List.filter + Hashtbl.mem/add with:
  - Local module expression: let module SS = Set.Make (String) in ...
  - List.fold_left with (list * SS.t) accumulator for first-occurrence-wins dedup
  - List.rev at base case to preserve input order

## Verification
- dune build @check passed (exit code 0)
- No behavioral change: same dedup semantics, same first-occurrence-wins ordering