### PR TITLE
[codex] Add magentic ledger social model

### DIFF
--- a/docs/design/keeper-social-model-fsm.md
+++ b/docs/design/keeper-social-model-fsm.md
@@ -21,13 +21,14 @@ Related issue:
 
 - keeper creation persists `social_model` into keeper runtime state
 - unified turn paths propagate `SOCIAL_MODEL`, `BELIEF_SUMMARY`, `ACTIVE_DESIRE`, `CURRENT_INTENTION`, `BLOCKER`, `NEED`, `SPEECH_ACT`, and `DELIVERY_SURFACE`
-- the active baseline is effectively `bdi_speech_v1`
+- the active baseline is `bdi_speech_v1`
+- a first-class `social_model -> implementation` registry dispatches between production modules
+- `magentic_ledger_v1` now exists as a second implementation path to validate the abstraction
 
 ### What is not real yet
 
-- no first-class `social_model -> implementation` registry
-- no per-model `state / input / transition / output` contract
-- no second production social-model implementation to prove the abstraction
+- `social_model` ownership is still runtime-centric rather than persona-default + override + snapshot
+- richer per-model state typing is still hidden behind the shared adapter surface
 
 ## Terminology
 

--- a/docs/design/keeper-social-model-inventory.md
+++ b/docs/design/keeper-social-model-inventory.md
@@ -1,12 +1,12 @@
 # Keeper Social Model Inventory
 
-Status: active baseline + research inventory
+Status: active implementations + research inventory
 
 See also:
 
 - `docs/design/keeper-social-model-fsm.md`
 
-## Active baseline
+## Active implementations
 
 ### `bdi_speech_v1`
 
@@ -27,11 +27,14 @@ See also:
 ### `magentic_ledger_v1`
 
 - Role: progress/stall-oriented planning overlay
-- Implementation status: documented candidate only
+- Implementation status: implemented secondary registry target
 - Best use: detect stuck work, stalled loops, replanning triggers
 - Why not default now:
   - good for task/progress ledgers
   - weaker as the primary social-expression model
+- Implementation note:
+  - tool evidence is treated as progress-ledger state, so tool-only turns can
+    stay silent instead of synthesizing an extra visible reply
 
 Reference:
 - Magentic-One article
@@ -81,9 +84,8 @@ References:
 
 ## Selection rule
 
-Until multiple implementations are production-ready:
+Until `social_model` becomes a richer user-facing axis:
 
 - runtime default stays `bdi_speech_v1`
-- inventory entries are documentation-only
 - `social_model` should not be presented as a rich user-facing strategy selector yet
 - unknown runtime values should fail fast or fall back explicitly to `bdi_speech_v1`

--- a/lib/dune
+++ b/lib/dune
@@ -362,6 +362,7 @@
    keeper_social_model_types
    keeper_social_model_protocol
    keeper_social_model_bdi_speech_v1
+   keeper_social_model_magentic_ledger_v1
    keeper_social_model_registry
    keeper_social_model
    keeper_cascade_profile

--- a/lib/keeper/keeper_social_model.ml
+++ b/lib/keeper/keeper_social_model.ml
@@ -23,6 +23,7 @@ type delivery_surface = Keeper_social_model_types.delivery_surface =
 
 type model_id = Keeper_social_model_types.model_id =
   | Bdi_speech_v1
+  | Magentic_ledger_v1
 
 type transition_reason = Keeper_social_model_types.transition_reason =
   | Tool_only_stay_silent
@@ -31,6 +32,7 @@ type transition_reason = Keeper_social_model_types.transition_reason =
   | Tool_only_broadcast
   | Tool_only_claim_task
   | Tool_only_visible_reply
+  | Tool_only_progress_ledger
   | Explicit_social_headers
   | Missing_headers_fallback_visible_reply
   | Invalid_headers_fallback_visible_reply

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -24,6 +24,7 @@ type delivery_surface = Keeper_social_model_types.delivery_surface =
 
 type model_id = Keeper_social_model_types.model_id =
   | Bdi_speech_v1
+  | Magentic_ledger_v1
 
 type transition_reason = Keeper_social_model_types.transition_reason =
   | Tool_only_stay_silent
@@ -32,6 +33,7 @@ type transition_reason = Keeper_social_model_types.transition_reason =
   | Tool_only_broadcast
   | Tool_only_claim_task
   | Tool_only_visible_reply
+  | Tool_only_progress_ledger
   | Explicit_social_headers
   | Missing_headers_fallback_visible_reply
   | Invalid_headers_fallback_visible_reply

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -1,0 +1,218 @@
+(** Progress/stall-oriented social-model implementation.
+
+    This model reuses the validated header/tool parsing from
+    [bdi_speech_v1], but it interprets tool evidence as progress ledger
+    entries rather than something that always needs an additional visible
+    narration. *)
+
+open Keeper_types
+
+module Types = Keeper_social_model_types
+module Protocol = Keeper_social_model_protocol
+module Bdi = Keeper_social_model_bdi_speech_v1
+
+type progress_phase =
+  | Advancing
+  | Reactive
+  | Stalled
+  | Quiet
+
+let model_name = Types.model_id_to_string Types.Magentic_ledger_v1
+
+let reactive_signal_count
+    (observation : Keeper_world_observation.world_observation) =
+  List.length observation.pending_mentions
+  + List.length observation.pending_board_events
+  + List.length observation.pending_scope_messages
+
+let backlog_count (observation : Keeper_world_observation.world_observation) =
+  observation.unclaimed_task_count + observation.failed_task_count
+
+let phase_of_turn ~(observation : Keeper_world_observation.world_observation)
+    ~(has_progress_evidence : bool) ~(has_text_reply : bool) =
+  if has_progress_evidence || has_text_reply then Advancing
+  else if reactive_signal_count observation > 0 || backlog_count observation > 0
+  then Reactive
+  else if observation.active_goals <> [] && observation.idle_seconds >= 300 then
+    Stalled
+  else Quiet
+
+let phase_to_string = function
+  | Advancing -> "advancing"
+  | Reactive -> "reactive"
+  | Stalled -> "stalled"
+  | Quiet -> "quiet"
+
+let belief_summary_of_phase ~(phase : progress_phase)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(tool_count : int) =
+  let parts =
+    [
+      "phase=" ^ phase_to_string phase;
+      "reactive=" ^ string_of_int (reactive_signal_count observation);
+      "backlog=" ^ string_of_int (backlog_count observation);
+      "goals=" ^ string_of_int (List.length observation.active_goals);
+      "tools=" ^ string_of_int tool_count;
+      "idle=" ^ string_of_int observation.idle_seconds ^ "s";
+    ]
+    @
+    if Option.is_some observation.worktree_change_summary then [ "worktree_delta" ]
+    else []
+  in
+  "ledger:" ^ String.concat "; " parts
+
+let active_desire_of_phase = function
+  | Advancing -> Some "advance_task_progress"
+  | Reactive -> Some "close_open_loop"
+  | Stalled -> Some "recover_forward_motion"
+  | Quiet -> Some "maintain_progress_ledger"
+
+let current_intention_of_phase ~(phase : progress_phase) ~(tools_used : string list)
+    ~(has_text_reply : bool) =
+  if List.mem "keeper_task_claim" tools_used || List.mem "masc_claim_next" tools_used
+  then Some "capture_next_task"
+  else if tools_used <> [] then Some "record_progress_evidence"
+  else if has_text_reply then Some "publish_progress_update"
+  else
+    match phase with
+    | Reactive -> Some "triage_open_signal"
+    | Stalled -> Some "request_replan"
+    | Quiet -> Some "wait_for_delta"
+    | Advancing -> Some "record_progress_evidence"
+
+let blocker_of_phase ~(phase : progress_phase)
+    ~(base_state : Types.social_state) ~(tools_used : string list)
+    ~(has_text_reply : bool) =
+  match base_state.speech_act with
+  | Types.Request_help | Types.Defer when Option.is_some base_state.blocker ->
+      base_state.blocker
+  | _ -> (
+      match phase with
+      | Stalled when tools_used = [] && not has_text_reply ->
+          Some "stalled_without_progress_evidence"
+      | _ -> None)
+
+let need_of_phase ~(phase : progress_phase)
+    ~(base_state : Types.social_state) ~(tools_used : string list)
+    ~(has_text_reply : bool) =
+  match base_state.speech_act with
+  | Types.Request_help when Option.is_some base_state.need -> base_state.need
+  | _ -> (
+      match phase with
+      | Stalled -> Some "fresh_plan_or_external_delta"
+      | Reactive when tools_used = [] && not has_text_reply ->
+          Some "next_actionable_prioritization"
+      | _ -> None)
+
+let should_overlay_ledger = function
+  | Types.Tool_only_stay_silent
+  | Types.Tool_only_comment_board
+  | Types.Tool_only_post_board
+  | Types.Tool_only_broadcast
+  | Types.Tool_only_claim_task
+  | Types.Tool_only_visible_reply
+  | Types.Missing_headers_fallback_visible_reply
+  | Types.Invalid_headers_fallback_visible_reply
+  | Types.Inferred_visible_reply
+  | Types.Protocol_violation_no_tools_no_social_headers ->
+      true
+  | Types.Explicit_social_headers
+  | Types.Protocol_violation_missing_social_headers
+  | Types.Protocol_violation_invalid_social_headers
+  | Types.Tool_only_progress_ledger
+  | Types.Failure_run_error ->
+      false
+
+let overlay_ledger_state ~(observation : Keeper_world_observation.world_observation)
+    ~(result : Keeper_agent_run.run_result) ~(has_text_reply : bool)
+    (base_state : Types.social_state) =
+  let has_progress_evidence =
+    result.tools_used <> [] || Option.is_some observation.worktree_change_summary
+  in
+  let phase =
+    phase_of_turn ~observation ~has_progress_evidence ~has_text_reply
+  in
+  {
+    base_state with
+    social_model = model_name;
+    belief_summary =
+      belief_summary_of_phase ~phase ~observation
+        ~tool_count:(List.length result.tools_used);
+    active_desire = active_desire_of_phase phase;
+    current_intention =
+      current_intention_of_phase ~phase ~tools_used:result.tools_used
+        ~has_text_reply;
+    blocker =
+      blocker_of_phase ~phase ~base_state ~tools_used:result.tools_used
+        ~has_text_reply;
+    need =
+      need_of_phase ~phase ~base_state ~tools_used:result.tools_used
+        ~has_text_reply;
+  }
+
+let adapt_tool_only_turn (state : Types.social_state)
+    (transition_reason : Types.transition_reason) =
+  match transition_reason with
+  | Types.Tool_only_visible_reply ->
+      ( { state with
+          speech_act = Types.Stay_silent;
+          delivery_surface = Types.Silent;
+        },
+        Types.Tool_only_progress_ledger,
+        true )
+  | Types.Tool_only_stay_silent
+  | Types.Tool_only_comment_board
+  | Types.Tool_only_post_board
+  | Types.Tool_only_broadcast
+  | Types.Tool_only_claim_task ->
+      ({ state with social_model = model_name }, transition_reason, true)
+  | _ -> ({ state with social_model = model_name }, transition_reason, false)
+
+let visible_response_body_of_result (result : Keeper_agent_run.run_result) =
+  let _, response_body = Protocol.parse_header_block result.response_text in
+  Keeper_text_processing.strip_internal_reply_markup response_body |> String.trim
+
+let apply_to_result ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : Types.social_state option)
+    (result : Keeper_agent_run.run_result) =
+  let has_text_reply = visible_response_body_of_result result <> "" in
+  let base_result, base_state, base_reason =
+    Bdi.apply_to_result ~meta ~observation ~previous_state result
+  in
+  let state =
+    if should_overlay_ledger base_reason then
+      overlay_ledger_state ~observation ~result ~has_text_reply base_state
+    else { base_state with social_model = model_name }
+  in
+  let state, transition_reason, suppress_visible_text =
+    adapt_tool_only_turn state base_reason
+  in
+  let routed_result =
+    if suppress_visible_text then { base_result with response_text = "" }
+    else base_result
+  in
+  (routed_result, state, transition_reason)
+
+let derive_failure_state ~(meta : keeper_meta)
+    ~(observation : Keeper_world_observation.world_observation)
+    ~(previous_state : Types.social_state option)
+    ~(reason : string) =
+  let base_state, transition_reason =
+    Bdi.derive_failure_state ~meta ~observation ~previous_state ~reason
+  in
+  let phase =
+    phase_of_turn ~observation ~has_progress_evidence:false ~has_text_reply:false
+  in
+  ( { base_state with
+      social_model = model_name;
+      belief_summary = belief_summary_of_phase ~phase ~observation ~tool_count:0;
+      active_desire = Some "recover_forward_motion";
+      current_intention = Some "repair_failed_turn";
+      blocker =
+        (match String.trim reason with
+        | "" -> Some "failed_without_detail"
+        | _ -> base_state.blocker);
+      need = Some "fresh_plan_or_operator_guidance";
+    },
+    transition_reason )

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
@@ -1,0 +1,18 @@
+open Keeper_types
+
+val apply_to_result :
+  meta:keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  previous_state:Keeper_social_model_types.social_state option ->
+  Keeper_agent_run.run_result ->
+  Keeper_agent_run.run_result
+  * Keeper_social_model_types.social_state
+  * Keeper_social_model_types.transition_reason
+
+val derive_failure_state :
+  meta:keeper_meta ->
+  observation:Keeper_world_observation.world_observation ->
+  previous_state:Keeper_social_model_types.social_state option ->
+  reason:string ->
+  Keeper_social_model_types.social_state
+  * Keeper_social_model_types.transition_reason

--- a/lib/keeper/social_model/keeper_social_model_registry.ml
+++ b/lib/keeper/social_model/keeper_social_model_registry.ml
@@ -15,6 +15,9 @@ let apply_to_result ~(meta : keeper_meta)
   | Types.Bdi_speech_v1 ->
       Keeper_social_model_bdi_speech_v1.apply_to_result ~meta ~observation
         ~previous_state result
+  | Types.Magentic_ledger_v1 ->
+      Keeper_social_model_magentic_ledger_v1.apply_to_result ~meta
+        ~observation ~previous_state result
 
 let derive_failure_state ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
@@ -23,4 +26,7 @@ let derive_failure_state ~(meta : keeper_meta)
   match active_model_of_meta meta with
   | Types.Bdi_speech_v1 ->
       Keeper_social_model_bdi_speech_v1.derive_failure_state ~meta
+        ~observation ~previous_state ~reason
+  | Types.Magentic_ledger_v1 ->
+      Keeper_social_model_magentic_ledger_v1.derive_failure_state ~meta
         ~observation ~previous_state ~reason

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -18,6 +18,7 @@ type delivery_surface =
 
 type model_id =
   | Bdi_speech_v1
+  | Magentic_ledger_v1
 
 type transition_reason =
   | Tool_only_stay_silent
@@ -26,6 +27,7 @@ type transition_reason =
   | Tool_only_broadcast
   | Tool_only_claim_task
   | Tool_only_visible_reply
+  | Tool_only_progress_ledger
   | Explicit_social_headers
   | Missing_headers_fallback_visible_reply
   | Invalid_headers_fallback_visible_reply
@@ -96,10 +98,12 @@ let delivery_surface_of_string value =
 
 let model_id_to_string = function
   | Bdi_speech_v1 -> "bdi_speech_v1"
+  | Magentic_ledger_v1 -> "magentic_ledger_v1"
 
 let model_id_of_string value =
   match String.lowercase_ascii (String.trim value) with
   | "bdi_speech_v1" -> Some Bdi_speech_v1
+  | "magentic_ledger_v1" -> Some Magentic_ledger_v1
   | _ -> None
 
 let default_model_id = Bdi_speech_v1
@@ -116,6 +120,7 @@ let transition_reason_to_string = function
   | Tool_only_broadcast -> "tool_only:broadcast"
   | Tool_only_claim_task -> "tool_only:claim_task"
   | Tool_only_visible_reply -> "tool_only:visible_reply"
+  | Tool_only_progress_ledger -> "tool_only:progress_ledger"
   | Explicit_social_headers -> "headers:explicit_social_headers"
   | Missing_headers_fallback_visible_reply ->
       "headers_missing:fallback_visible_reply"

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -18,6 +18,7 @@ type delivery_surface =
 
 type model_id =
   | Bdi_speech_v1
+  | Magentic_ledger_v1
 
 type transition_reason =
   | Tool_only_stay_silent
@@ -26,6 +27,7 @@ type transition_reason =
   | Tool_only_broadcast
   | Tool_only_claim_task
   | Tool_only_visible_reply
+  | Tool_only_progress_ledger
   | Explicit_social_headers
   | Missing_headers_fallback_visible_reply
   | Invalid_headers_fallback_visible_reply

--- a/test/test_keeper_meta_listing.ml
+++ b/test/test_keeper_meta_listing.ml
@@ -260,6 +260,42 @@ let test_keeper_list_exposes_last_social_transition_reason () =
               keeper |> member "last_social_transition_reason" |> to_string)
       | None -> fail "expected sangsu row in keeper list")
 
+let test_keeper_list_preserves_known_social_model () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  with_clean_base_path_env @@ fun () ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Config_dir_resolver.reset ();
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      write_keeper_toml_exn config ~name:"sangsu";
+      write_keeper_meta_exn config ~name:"sangsu" ~trace_id:"trace-sangsu"
+        ~social_model:"magentic_ledger_v1";
+      register_keeper_offline_exn config ~name:"sangsu";
+      let ctx = keeper_ctx env sw config "operator" in
+      let ok, body =
+        match
+          Tool_keeper.dispatch ctx ~name:"masc_keeper_list"
+            ~args:(`Assoc [ ("limit", `Int 10); ("detailed", `Bool true) ])
+        with
+        | Some result -> result
+        | None -> fail "expected masc_keeper_list dispatch"
+      in
+      check bool "tool keeper list ok" true ok;
+      let json = parse_json_exn body in
+      match keeper_json_by_name json "sangsu" with
+      | Some keeper ->
+          check string "known model preserved" "magentic_ledger_v1"
+            Yojson.Safe.Util.(keeper |> member "social_model" |> to_string)
+      | None -> fail "expected sangsu row in keeper list")
+
 let () =
   run "keeper_meta_listing"
     [
@@ -271,6 +307,8 @@ let () =
             test_bootable_keeper_names_skip_autoboot_disabled_meta;
           test_case "tool keeper list normalizes unknown social model" `Quick
             test_keeper_list_normalizes_unknown_social_model;
+          test_case "tool keeper list preserves known social model" `Quick
+            test_keeper_list_preserves_known_social_model;
           test_case "tool keeper list exposes last social transition reason"
             `Quick test_keeper_list_exposes_last_social_transition_reason;
         ] );

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -901,6 +901,10 @@ let test_social_model_registry_round_trip () =
     (Some "bdi_speech_v1")
     (KSM.model_id_of_string "bdi_speech_v1"
     |> Option.map KSM.model_id_to_string);
+  check (option string) "second model id resolves"
+    (Some "magentic_ledger_v1")
+    (KSM.model_id_of_string "magentic_ledger_v1"
+    |> Option.map KSM.model_id_to_string);
   check bool "unknown model id rejected" true
     (Option.is_none (KSM.model_id_of_string "experimental_v99"));
   check string "unknown model normalized to baseline" "bdi_speech_v1"
@@ -2685,6 +2689,77 @@ let test_social_model_infers_board_comment_from_tool_use () =
   check (list string) "tool list preserved"
     ["keeper_board_comment"; "masc_status"] routed.tools_used
 
+let test_social_model_magentic_ledger_silences_tool_only_turn () =
+  let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
+  let result =
+    make_run_result ~text:"" ~tools:["masc_status"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let routed, state, transition_reason =
+    KSM.apply_to_result ~meta ~observation:base_observation
+      ~previous_state:None result
+  in
+  check string "social model" "magentic_ledger_v1" state.social_model;
+  check string "speech act" "stay_silent"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "silent"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check (option string) "active desire reflects progress ledger"
+    (Some "advance_task_progress") state.active_desire;
+  check (option string) "current intention tracks evidence"
+    (Some "record_progress_evidence") state.current_intention;
+  check string "transition reason" "tool_only:progress_ledger"
+    (KSM.transition_reason_to_string transition_reason);
+  check bool "belief summary is ledger shaped" true
+    (contains_substring state.belief_summary "ledger:phase=advancing");
+  check string "visible response suppressed" "" routed.response_text;
+  check (list string) "tool list preserved" ["masc_status"] routed.tools_used
+
+let test_social_model_magentic_ledger_hides_nonvisible_tool_text () =
+  let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
+  let result =
+    make_run_result ~text:"" ~tools:["keeper_board_comment"; "masc_status"]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let routed, state, transition_reason =
+    KSM.apply_to_result ~meta ~observation:base_observation
+      ~previous_state:None result
+  in
+  check string "social model" "magentic_ledger_v1" state.social_model;
+  check string "speech act" "comment_board"
+    (KSM.speech_act_to_string state.speech_act);
+  check string "delivery surface" "board_comment"
+    (KSM.delivery_surface_to_string state.delivery_surface);
+  check string "transition reason preserved" "tool_only:comment_board"
+    (KSM.transition_reason_to_string transition_reason);
+  check string "non-visible tool turn does not synthesize text" ""
+    routed.response_text;
+  check (list string) "tool list preserved"
+    ["keeper_board_comment"; "masc_status"] routed.tools_used
+
+let test_social_model_magentic_ledger_previous_state_of_meta_restores_model ()
+    =
+  let meta =
+    {
+      minimal_meta with
+      social_model = "magentic_ledger_v1";
+      runtime =
+        {
+          minimal_meta.runtime with
+          last_speech_act = "inform";
+          last_active_desire = "advance_task_progress";
+          last_current_intention = "record_progress_evidence";
+        };
+    }
+  in
+  match KSM.previous_state_of_meta meta with
+  | None -> fail "expected previous social state"
+  | Some state ->
+      check string "social model restored" "magentic_ledger_v1"
+        state.social_model;
+      check string "speech act restored" "inform"
+        (KSM.speech_act_to_string state.speech_act)
+
 let test_keeper_allowed_tools_exclude_heartbeat () =
   let allowed =
     Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names minimal_policy_meta
@@ -3053,6 +3128,12 @@ let () =
             test_social_model_tool_only_turn_carries_previous_state;
           test_case "social model infers board comment from tool use" `Quick
             test_social_model_infers_board_comment_from_tool_use;
+          test_case "magentic ledger silences tool-only turn" `Quick
+            test_social_model_magentic_ledger_silences_tool_only_turn;
+          test_case "magentic ledger hides non-visible tool text" `Quick
+            test_social_model_magentic_ledger_hides_nonvisible_tool_text;
+          test_case "magentic ledger restores previous state model" `Quick
+            test_social_model_magentic_ledger_previous_state_of_meta_restores_model;
           test_case "render_inline deny" `Quick
             test_render_inline_skip_reason_deny;
           test_case "render_inline cost" `Quick


### PR DESCRIPTION
## Summary
- add `magentic_ledger_v1` as a second keeper social-model implementation
- extract the model's phase/event FSM into a dedicated module with a matching TLA+ spec/config
- route dashboard composite-observer and keeper FSM surfaces through the new model/runtime states, including recovery payload and `Overflowed` phase support
- cover silent tool-only progress turns, stalled-state carry behavior, recovery contract exposure, and known-model dashboard normalization with focused tests

## Why
- validate that `social_model` is a real implementation boundary instead of a runtime tag that always collapses to `bdi_speech_v1`
- make the progress-ledger model's state machine explicit and auditable instead of encoding the transition rules inline in one implementation file
- keep dashboard/runtime observability aligned with the richer keeper lifecycle surface and the RFC-0003 recovery payload contract

## Product impact
- keepers can now opt into `magentic_ledger_v1` without falling back to the baseline implementation path
- tool-only progress turns in `magentic_ledger_v1` stay silent while still persisting social state and transition-reason observability
- stalled progress-ledger state now carries until a real delta arrives, which avoids spurious quiet-state resets between turns
- dashboard normalization/visualization now understands `Overflowed` and the recovery payload shape emitted by the composite observer

## Evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/social-model-second-fsm`
- `./_build/default/test/test_keeper_unified.exe`
- `./_build/default/test/test_decision_pipeline.exe`
- `./_build/default/test/test_keeper_social_model_magentic_ledger_fsm.exe`
- `pnpm exec vitest run src/keeper-store-normalize.test.ts`
- `npx tsc --noEmit --pretty`

## Review evidence
- no unresolved review threads on PR #7426 as of 2026-04-16 02:08 KST
- GitHub checks were green before the latest push, and a fresh CI run is expected after commit `1e13c1909`
- local verification passed for build, OCaml test coverage, and dashboard type/test coverage before push

## Linked issue
- Refs #7362
