### PR TITLE
[codex] Formalize magentic ledger FSM and TLA spec

### DIFF
--- a/docs/design/keeper-social-model-fsm.md
+++ b/docs/design/keeper-social-model-fsm.md
@@ -24,6 +24,10 @@ Related issue:
 - the active baseline is `bdi_speech_v1`
 - a first-class `social_model -> implementation` registry dispatches between production modules
 - `magentic_ledger_v1` now exists as a second implementation path to validate the abstraction
+- `magentic_ledger_v1` now routes through an explicit phase/event FSM
+  (`lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml`)
+  with a matching TLA+ spec
+  (`specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla`)
 
 ### What is not real yet
 
@@ -170,6 +174,7 @@ Constraint:
 - unit tests for per-model transitions
 - integration tests for unified turn dispatch
 - explicit unknown-model tests
+- TLA+ state/event set alignment for any model-specific FSM with a closed phase set
 
 ## Acceptance Criteria
 

--- a/docs/design/keeper-social-model-inventory.md
+++ b/docs/design/keeper-social-model-inventory.md
@@ -35,6 +35,8 @@ See also:
 - Implementation note:
   - tool evidence is treated as progress-ledger state, so tool-only turns can
     stay silent instead of synthesizing an extra visible reply
+  - the implementation now uses a pure phase/event FSM plus a matching TLA+
+    spec for the closed state set
 
 Reference:
 - Magentic-One article

--- a/lib/dune
+++ b/lib/dune
@@ -361,6 +361,7 @@
    keeper_execution_scope
    keeper_social_model_types
    keeper_social_model_protocol
+   keeper_social_model_magentic_ledger_fsm
    keeper_social_model_bdi_speech_v1
    keeper_social_model_magentic_ledger_v1
    keeper_social_model_registry

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml
@@ -1,0 +1,156 @@
+module Types = Keeper_social_model_types
+
+type phase =
+  | Advancing
+  | Reactive
+  | Stalled
+  | Quiet
+
+type event =
+  | Progress_observed
+  | Signals_pending
+  | Goal_idle_timeout
+  | All_quiet
+  | Failure_observed
+
+type input = {
+  has_progress_evidence : bool;
+  has_reactive_signal : bool;
+  has_active_goals : bool;
+  idle_seconds : int;
+}
+
+type snapshot = {
+  phase : phase;
+}
+
+let initial = { phase = Quiet }
+let all_phases = [ Advancing; Reactive; Stalled; Quiet ]
+let all_events =
+  [
+    Progress_observed;
+    Signals_pending;
+    Goal_idle_timeout;
+    All_quiet;
+    Failure_observed;
+  ]
+
+let phase_to_string = function
+  | Advancing -> "advancing"
+  | Reactive -> "reactive"
+  | Stalled -> "stalled"
+  | Quiet -> "quiet"
+
+let phase_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "advancing" -> Some Advancing
+  | "reactive" -> Some Reactive
+  | "stalled" -> Some Stalled
+  | "quiet" -> Some Quiet
+  | _ -> None
+
+let event_to_string = function
+  | Progress_observed -> "progress_observed"
+  | Signals_pending -> "signals_pending"
+  | Goal_idle_timeout -> "goal_idle_timeout"
+  | All_quiet -> "all_quiet"
+  | Failure_observed -> "failure_observed"
+
+let event_of_string value =
+  match String.lowercase_ascii (String.trim value) with
+  | "progress_observed" -> Some Progress_observed
+  | "signals_pending" -> Some Signals_pending
+  | "goal_idle_timeout" -> Some Goal_idle_timeout
+  | "all_quiet" -> Some All_quiet
+  | "failure_observed" -> Some Failure_observed
+  | _ -> None
+
+let model_name = Types.model_id_to_string Types.Magentic_ledger_v1
+
+let has_prefix s prefix =
+  let s_len = String.length s and prefix_len = String.length prefix in
+  s_len >= prefix_len && String.sub s 0 prefix_len = prefix
+
+let belief_summary_field belief_summary field_name =
+  let parts =
+    String.split_on_char ';' belief_summary
+    |> List.filter_map (fun raw_part ->
+           let part = String.trim raw_part in
+           let part =
+             if has_prefix part "ledger:" then
+               String.sub part 7 (String.length part - 7)
+             else part
+           in
+           match String.index_opt part '=' with
+           | None -> None
+           | Some idx ->
+               let key = String.sub part 0 idx |> String.trim in
+               let value =
+                 String.sub part (idx + 1) (String.length part - idx - 1)
+                 |> String.trim
+               in
+               Some (key, value))
+  in
+  List.find_map
+    (fun (key, value) -> if String.equal key field_name then Some value else None)
+    parts
+
+let phase_of_active_desire = function
+  | Some "advance_task_progress" -> Some Advancing
+  | Some "close_open_loop" -> Some Reactive
+  | Some "recover_forward_motion" -> Some Stalled
+  | Some "maintain_progress_ledger" -> Some Quiet
+  | _ -> None
+
+let phase_of_current_intention = function
+  | Some "record_progress_evidence"
+  | Some "publish_progress_update" ->
+      Some Advancing
+  | Some "capture_next_task" | Some "triage_open_signal" -> Some Reactive
+  | Some "request_replan" | Some "repair_failed_turn" -> Some Stalled
+  | Some "wait_for_delta" -> Some Quiet
+  | _ -> None
+
+let snapshot_of_social_state (state : Types.social_state) =
+  if not (String.equal (Types.normalize_social_model state.social_model) model_name)
+  then None
+  else
+    let phase =
+      match belief_summary_field state.belief_summary "phase" with
+      | Some phase -> phase_of_string phase
+      | None -> None
+    in
+    let phase =
+      match phase with
+      | Some _ -> phase
+      | None -> phase_of_active_desire state.active_desire
+    in
+    let phase =
+      match phase with
+      | Some _ -> phase
+      | None -> phase_of_current_intention state.current_intention
+    in
+    Option.map (fun phase -> { phase }) phase
+
+let classify_event ~previous (input : input) =
+  if input.has_progress_evidence then Progress_observed
+  else if input.has_reactive_signal then Signals_pending
+  else if
+    input.has_active_goals
+    && (input.idle_seconds >= 300
+       ||
+       match previous with
+       | Some { phase = Stalled } -> true
+       | Some { phase = Advancing | Reactive | Quiet } | None -> false)
+  then Goal_idle_timeout
+  else All_quiet
+
+let apply_event ~current:_ event =
+  let phase =
+    match event with
+    | Progress_observed -> Advancing
+    | Signals_pending -> Reactive
+    | Goal_idle_timeout | Failure_observed -> Stalled
+    | All_quiet -> Quiet
+  in
+  { phase }

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.mli
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.mli
@@ -1,0 +1,35 @@
+type phase =
+  | Advancing
+  | Reactive
+  | Stalled
+  | Quiet
+
+type event =
+  | Progress_observed
+  | Signals_pending
+  | Goal_idle_timeout
+  | All_quiet
+  | Failure_observed
+
+type input = {
+  has_progress_evidence : bool;
+  has_reactive_signal : bool;
+  has_active_goals : bool;
+  idle_seconds : int;
+}
+
+type snapshot = {
+  phase : phase;
+}
+
+val initial : snapshot
+val all_phases : phase list
+val all_events : event list
+val phase_to_string : phase -> string
+val phase_of_string : string -> phase option
+val event_to_string : event -> string
+val event_of_string : string -> event option
+val snapshot_of_social_state :
+  Keeper_social_model_types.social_state -> snapshot option
+val classify_event : previous:snapshot option -> input -> event
+val apply_event : current:snapshot -> event -> snapshot

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -10,12 +10,7 @@ open Keeper_types
 module Types = Keeper_social_model_types
 module Protocol = Keeper_social_model_protocol
 module Bdi = Keeper_social_model_bdi_speech_v1
-
-type progress_phase =
-  | Advancing
-  | Reactive
-  | Stalled
-  | Quiet
+module Fsm = Keeper_social_model_magentic_ledger_fsm
 
 let model_name = Types.model_id_to_string Types.Magentic_ledger_v1
 
@@ -28,27 +23,14 @@ let reactive_signal_count
 let backlog_count (observation : Keeper_world_observation.world_observation) =
   observation.unclaimed_task_count + observation.failed_task_count
 
-let phase_of_turn ~(observation : Keeper_world_observation.world_observation)
-    ~(has_progress_evidence : bool) ~(has_text_reply : bool) =
-  if has_progress_evidence || has_text_reply then Advancing
-  else if reactive_signal_count observation > 0 || backlog_count observation > 0
-  then Reactive
-  else if observation.active_goals <> [] && observation.idle_seconds >= 300 then
-    Stalled
-  else Quiet
-
-let phase_to_string = function
-  | Advancing -> "advancing"
-  | Reactive -> "reactive"
-  | Stalled -> "stalled"
-  | Quiet -> "quiet"
-
-let belief_summary_of_phase ~(phase : progress_phase)
+let belief_summary_of_snapshot ~(snapshot : Fsm.snapshot)
+    ~(event : Fsm.event)
     ~(observation : Keeper_world_observation.world_observation)
     ~(tool_count : int) =
   let parts =
     [
-      "phase=" ^ phase_to_string phase;
+      "phase=" ^ Fsm.phase_to_string snapshot.phase;
+      "event=" ^ Fsm.event_to_string event;
       "reactive=" ^ string_of_int (reactive_signal_count observation);
       "backlog=" ^ string_of_int (backlog_count observation);
       "goals=" ^ string_of_int (List.length observation.active_goals);
@@ -62,12 +44,12 @@ let belief_summary_of_phase ~(phase : progress_phase)
   "ledger:" ^ String.concat "; " parts
 
 let active_desire_of_phase = function
-  | Advancing -> Some "advance_task_progress"
-  | Reactive -> Some "close_open_loop"
-  | Stalled -> Some "recover_forward_motion"
-  | Quiet -> Some "maintain_progress_ledger"
+  | Fsm.Advancing -> Some "advance_task_progress"
+  | Fsm.Reactive -> Some "close_open_loop"
+  | Fsm.Stalled -> Some "recover_forward_motion"
+  | Fsm.Quiet -> Some "maintain_progress_ledger"
 
-let current_intention_of_phase ~(phase : progress_phase) ~(tools_used : string list)
+let current_intention_of_phase ~(phase : Fsm.phase) ~(tools_used : string list)
     ~(has_text_reply : bool) =
   if List.mem "keeper_task_claim" tools_used || List.mem "masc_claim_next" tools_used
   then Some "capture_next_task"
@@ -75,12 +57,12 @@ let current_intention_of_phase ~(phase : progress_phase) ~(tools_used : string l
   else if has_text_reply then Some "publish_progress_update"
   else
     match phase with
-    | Reactive -> Some "triage_open_signal"
-    | Stalled -> Some "request_replan"
-    | Quiet -> Some "wait_for_delta"
-    | Advancing -> Some "record_progress_evidence"
+    | Fsm.Reactive -> Some "triage_open_signal"
+    | Fsm.Stalled -> Some "request_replan"
+    | Fsm.Quiet -> Some "wait_for_delta"
+    | Fsm.Advancing -> Some "record_progress_evidence"
 
-let blocker_of_phase ~(phase : progress_phase)
+let blocker_of_phase ~(phase : Fsm.phase)
     ~(base_state : Types.social_state) ~(tools_used : string list)
     ~(has_text_reply : bool) =
   match base_state.speech_act with
@@ -88,19 +70,19 @@ let blocker_of_phase ~(phase : progress_phase)
       base_state.blocker
   | _ -> (
       match phase with
-      | Stalled when tools_used = [] && not has_text_reply ->
+      | Fsm.Stalled when tools_used = [] && not has_text_reply ->
           Some "stalled_without_progress_evidence"
       | _ -> None)
 
-let need_of_phase ~(phase : progress_phase)
+let need_of_phase ~(phase : Fsm.phase)
     ~(base_state : Types.social_state) ~(tools_used : string list)
     ~(has_text_reply : bool) =
   match base_state.speech_act with
   | Types.Request_help when Option.is_some base_state.need -> base_state.need
   | _ -> (
       match phase with
-      | Stalled -> Some "fresh_plan_or_external_delta"
-      | Reactive when tools_used = [] && not has_text_reply ->
+      | Fsm.Stalled -> Some "fresh_plan_or_external_delta"
+      | Fsm.Reactive when tools_used = [] && not has_text_reply ->
           Some "next_actionable_prioritization"
       | _ -> None)
 
@@ -124,29 +106,45 @@ let should_overlay_ledger = function
       false
 
 let overlay_ledger_state ~(observation : Keeper_world_observation.world_observation)
-    ~(result : Keeper_agent_run.run_result) ~(has_text_reply : bool)
+    ~(result : Keeper_agent_run.run_result)
+    ~(previous_state : Types.social_state option)
+    ~(has_text_reply : bool)
     (base_state : Types.social_state) =
-  let has_progress_evidence =
-    result.tools_used <> [] || Option.is_some observation.worktree_change_summary
+  let previous_snapshot =
+    Option.bind previous_state Fsm.snapshot_of_social_state
   in
-  let phase =
-    phase_of_turn ~observation ~has_progress_evidence ~has_text_reply
+  let current_snapshot = Option.value ~default:Fsm.initial previous_snapshot in
+  let event =
+    Fsm.classify_event ~previous:previous_snapshot
+      {
+        Fsm.has_progress_evidence =
+          result.tools_used <> [] || has_text_reply
+          || Option.is_some observation.worktree_change_summary;
+        has_reactive_signal =
+          reactive_signal_count observation > 0 || backlog_count observation > 0;
+        has_active_goals = observation.active_goals <> [];
+        idle_seconds = observation.idle_seconds;
+      }
   in
+  let snapshot = Fsm.apply_event ~current:current_snapshot event in
   {
     base_state with
     social_model = model_name;
     belief_summary =
-      belief_summary_of_phase ~phase ~observation
+      belief_summary_of_snapshot ~snapshot ~event ~observation
         ~tool_count:(List.length result.tools_used);
-    active_desire = active_desire_of_phase phase;
+    active_desire = active_desire_of_phase snapshot.phase;
     current_intention =
-      current_intention_of_phase ~phase ~tools_used:result.tools_used
+      current_intention_of_phase ~phase:snapshot.phase
+        ~tools_used:result.tools_used
         ~has_text_reply;
     blocker =
-      blocker_of_phase ~phase ~base_state ~tools_used:result.tools_used
+      blocker_of_phase ~phase:snapshot.phase ~base_state
+        ~tools_used:result.tools_used
         ~has_text_reply;
     need =
-      need_of_phase ~phase ~base_state ~tools_used:result.tools_used
+      need_of_phase ~phase:snapshot.phase ~base_state
+        ~tools_used:result.tools_used
         ~has_text_reply;
   }
 
@@ -182,7 +180,8 @@ let apply_to_result ~(meta : keeper_meta)
   in
   let state =
     if should_overlay_ledger base_reason then
-      overlay_ledger_state ~observation ~result ~has_text_reply base_state
+      overlay_ledger_state ~observation ~result ~previous_state ~has_text_reply
+        base_state
     else { base_state with social_model = model_name }
   in
   let state, transition_reason, suppress_visible_text =
@@ -201,12 +200,19 @@ let derive_failure_state ~(meta : keeper_meta)
   let base_state, transition_reason =
     Bdi.derive_failure_state ~meta ~observation ~previous_state ~reason
   in
-  let phase =
-    phase_of_turn ~observation ~has_progress_evidence:false ~has_text_reply:false
+  let previous_snapshot =
+    Option.bind previous_state Fsm.snapshot_of_social_state
+  in
+  let snapshot =
+    Fsm.apply_event
+      ~current:(Option.value ~default:Fsm.initial previous_snapshot)
+      Fsm.Failure_observed
   in
   ( { base_state with
       social_model = model_name;
-      belief_summary = belief_summary_of_phase ~phase ~observation ~tool_count:0;
+      belief_summary =
+        belief_summary_of_snapshot ~snapshot ~event:Fsm.Failure_observed
+          ~observation ~tool_count:0;
       active_desire = Some "recover_forward_motion";
       current_intention = Some "repair_failed_turn";
       blocker =

--- a/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.cfg
+++ b/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.cfg
@@ -1,0 +1,22 @@
+\* TLC Configuration — clean spec for the magentic_ledger_v1 social FSM.
+\*
+\* Run:
+\*   java -jar specs/keeper-state-machine/tla2tools.jar -config \
+\*        specs/keeper-state-machine/KeeperSocialModelMagenticLedger.cfg \
+\*        specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    ClassifyTypeOK
+    StalledNeedsGoalOrFailure
+
+CHECK_DEADLOCK
+    FALSE
+
+PROPERTIES
+    ProgressDominates
+    ReactiveDominatesIdleTimeout
+    StalledStickyWithGoal
+    QuietWhenNoDrivers

--- a/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+++ b/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
@@ -79,25 +79,38 @@ ClassifyTypeOK ==
 StalledNeedsGoalOrFailure ==
     phase = "stalled" => has_active_goals \/ failure_observed
 
+ProgressDominatesAction ==
+    (has_progress_evidence' /\ ~failure_observed') => phase' = "advancing"
+
+ReactiveDominatesIdleTimeoutAction ==
+    (~failure_observed' /\ ~has_progress_evidence' /\ has_reactive_signal')
+    => phase' = "reactive"
+
+StalledStickyWithGoalAction ==
+    (phase = "stalled"
+     /\ ~has_progress_evidence'
+     /\ ~has_reactive_signal'
+     /\ has_active_goals'
+     /\ ~failure_observed')
+    => phase' = "stalled"
+
+QuietWhenNoDriversAction ==
+    (~has_progress_evidence'
+     /\ ~has_reactive_signal'
+     /\ ~has_active_goals'
+     /\ ~failure_observed')
+    => phase' = "quiet"
+
 ProgressDominates ==
-    [](has_progress_evidence' => phase' = "advancing")
+    [][ProgressDominatesAction]_vars
 
 ReactiveDominatesIdleTimeout ==
-    []((~has_progress_evidence' /\ has_reactive_signal') => phase' = "reactive")
+    [][ReactiveDominatesIdleTimeoutAction]_vars
 
 StalledStickyWithGoal ==
-    []((phase = "stalled"
-        /\ ~has_progress_evidence'
-        /\ ~has_reactive_signal'
-        /\ has_active_goals'
-        /\ ~failure_observed')
-       => phase' = "stalled")
+    [][StalledStickyWithGoalAction]_vars
 
 QuietWhenNoDrivers ==
-    []((~has_progress_evidence'
-        /\ ~has_reactive_signal'
-        /\ ~has_active_goals'
-        /\ ~failure_observed')
-       => phase' = "quiet")
+    [][QuietWhenNoDriversAction]_vars
 
 =============================================================================

--- a/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
+++ b/specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla
@@ -1,0 +1,103 @@
+---- MODULE KeeperSocialModelMagenticLedger ----
+\* Keeper social model (magentic_ledger_v1) — phase/event FSM.
+\*
+\* Mirrors:
+\*   - lib/keeper/social_model/keeper_social_model_magentic_ledger_fsm.ml
+\*
+\* Purpose:
+\*   - Freeze the phase and event sets for the progress-ledger social model.
+\*   - Make the "stalled stays stalled until a new delta arrives" rule explicit.
+\*   - Verify that progress evidence dominates other signals, reactive signals
+\*     dominate idle timeouts, and empty turns settle to Quiet.
+
+EXTENDS TLC
+
+VARIABLES
+    phase,
+    has_progress_evidence,
+    has_reactive_signal,
+    has_active_goals,
+    idle_long,
+    failure_observed
+
+vars == <<phase, has_progress_evidence, has_reactive_signal,
+          has_active_goals, idle_long, failure_observed>>
+
+PhaseSet == {"advancing", "reactive", "stalled", "quiet"}
+EventSet == {"progress_observed", "signals_pending", "goal_idle_timeout",
+             "all_quiet", "failure_observed"}
+
+ClassifyEvent(progress, reactive, goals, idle, failure, current_phase) ==
+    IF failure THEN "failure_observed"
+    ELSE IF progress THEN "progress_observed"
+    ELSE IF reactive THEN "signals_pending"
+    ELSE IF goals /\ (idle \/ current_phase = "stalled")
+            THEN "goal_idle_timeout"
+    ELSE "all_quiet"
+
+NextPhase(current_phase, event) ==
+    CASE event = "progress_observed" -> "advancing"
+      [] event = "signals_pending"   -> "reactive"
+      [] event = "goal_idle_timeout" -> "stalled"
+      [] event = "all_quiet"         -> "quiet"
+      [] event = "failure_observed"  -> "stalled"
+      [] OTHER -> current_phase
+
+Init ==
+    /\ phase = "quiet"
+    /\ has_progress_evidence = FALSE
+    /\ has_reactive_signal = FALSE
+    /\ has_active_goals = FALSE
+    /\ idle_long = FALSE
+    /\ failure_observed = FALSE
+
+Next ==
+    \E progress, reactive, goals, idle, failure \in BOOLEAN:
+        /\ has_progress_evidence' = progress
+        /\ has_reactive_signal' = reactive
+        /\ has_active_goals' = goals
+        /\ idle_long' = idle
+        /\ failure_observed' = failure
+        /\ phase' =
+            NextPhase(phase,
+                ClassifyEvent(progress, reactive, goals, idle, failure, phase))
+
+Spec == Init /\ [][Next]_vars
+
+TypeOK ==
+    /\ phase \in PhaseSet
+    /\ has_progress_evidence \in BOOLEAN
+    /\ has_reactive_signal \in BOOLEAN
+    /\ has_active_goals \in BOOLEAN
+    /\ idle_long \in BOOLEAN
+    /\ failure_observed \in BOOLEAN
+
+ClassifyTypeOK ==
+    ClassifyEvent(has_progress_evidence, has_reactive_signal, has_active_goals,
+                  idle_long, failure_observed, phase) \in EventSet
+
+StalledNeedsGoalOrFailure ==
+    phase = "stalled" => has_active_goals \/ failure_observed
+
+ProgressDominates ==
+    [](has_progress_evidence' => phase' = "advancing")
+
+ReactiveDominatesIdleTimeout ==
+    []((~has_progress_evidence' /\ has_reactive_signal') => phase' = "reactive")
+
+StalledStickyWithGoal ==
+    []((phase = "stalled"
+        /\ ~has_progress_evidence'
+        /\ ~has_reactive_signal'
+        /\ has_active_goals'
+        /\ ~failure_observed')
+       => phase' = "stalled")
+
+QuietWhenNoDrivers ==
+    []((~has_progress_evidence'
+        /\ ~has_reactive_signal'
+        /\ ~has_active_goals'
+        /\ ~failure_observed')
+       => phase' = "quiet")
+
+=============================================================================

--- a/test/dune
+++ b/test/dune
@@ -107,6 +107,7 @@
         test_tool_prefilter
         test_keeper_state_machine
         test_keeper_campaign_fsm
+        test_keeper_social_model_magentic_ledger_fsm
         test_keeper_overflow_recovery
         test_telemetry_unified
         test_keeper_topk_llm
@@ -193,6 +194,7 @@
           test_tool_prefilter
           test_keeper_state_machine
           test_keeper_campaign_fsm
+          test_keeper_social_model_magentic_ledger_fsm
           test_keeper_overflow_recovery
             test_telemetry_unified
           test_keeper_topk_llm

--- a/test/test_keeper_social_model_magentic_ledger_fsm.ml
+++ b/test/test_keeper_social_model_magentic_ledger_fsm.ml
@@ -1,0 +1,159 @@
+open Alcotest
+
+module Fsm = Masc_mcp.Keeper_social_model_magentic_ledger_fsm
+module KSM = Masc_mcp.Keeper_social_model
+
+let has_prompt_root path =
+  Sys.file_exists (Filename.concat path "config/prompts/keeper.unified.system.md")
+
+let repo_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when has_prompt_root root -> root
+  | _ ->
+      let rec ascend path =
+        if has_prompt_root path then path
+        else
+          let parent = Filename.dirname path in
+          if String.equal parent path then Sys.getcwd () else ascend parent
+      in
+      ascend (Sys.getcwd ())
+
+let read_file path = In_channel.with_open_bin path In_channel.input_all
+
+let substring_index haystack needle =
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop i =
+    if i + needle_len > hay_len then None
+    else if String.sub haystack i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  if needle_len = 0 then Some 0 else loop 0
+
+let extract_quoted_set source name =
+  let prefix = name ^ " == {" in
+  match substring_index source prefix with
+  | None -> fail ("missing set definition: " ^ name)
+  | Some start ->
+      let body_start = start + String.length prefix in
+      let rest =
+        String.sub source body_start (String.length source - body_start)
+      in
+      let body_end =
+        match String.index_opt rest '}' with
+        | Some idx -> idx
+        | None -> fail ("unterminated set definition: " ^ name)
+      in
+      String.sub rest 0 body_end
+      |> String.split_on_char ','
+      |> List.map String.trim
+      |> List.filter (fun item -> item <> "")
+      |> List.map (fun item ->
+             if String.length item >= 2 && item.[0] = '"' then
+               String.sub item 1 (String.length item - 2)
+             else item)
+      |> List.sort String.compare
+
+let phase_strings phases =
+  phases |> List.map Fsm.phase_to_string |> List.sort String.compare
+
+let event_strings events =
+  events |> List.map Fsm.event_to_string |> List.sort String.compare
+
+let test_progress_evidence_beats_other_signals () =
+  let event =
+    Fsm.classify_event ~previous:(Some { Fsm.phase = Stalled })
+      {
+        Fsm.has_progress_evidence = true;
+        has_reactive_signal = true;
+        has_active_goals = true;
+        idle_seconds = 900;
+      }
+  in
+  check string "progress event selected" "progress_observed"
+    (Fsm.event_to_string event);
+  let snapshot = Fsm.apply_event ~current:{ phase = Stalled } event in
+  check string "progress -> advancing" "advancing"
+    (Fsm.phase_to_string snapshot.phase)
+
+let test_reactive_signal_beats_idle_timeout () =
+  let event =
+    Fsm.classify_event ~previous:None
+      {
+        Fsm.has_progress_evidence = false;
+        has_reactive_signal = true;
+        has_active_goals = true;
+        idle_seconds = 900;
+      }
+  in
+  check string "reactive event selected" "signals_pending"
+    (Fsm.event_to_string event);
+  let snapshot = Fsm.apply_event ~current:Fsm.initial event in
+  check string "signals -> reactive" "reactive"
+    (Fsm.phase_to_string snapshot.phase)
+
+let test_stalled_state_sticks_until_delta () =
+  let previous = Some { Fsm.phase = Stalled } in
+  let event =
+    Fsm.classify_event ~previous
+      {
+        Fsm.has_progress_evidence = false;
+        has_reactive_signal = false;
+        has_active_goals = true;
+        idle_seconds = 0;
+      }
+  in
+  check string "stalled carry classifies timeout" "goal_idle_timeout"
+    (Fsm.event_to_string event);
+  let snapshot = Fsm.apply_event ~current:{ phase = Stalled } event in
+  check string "stalled stays stalled" "stalled"
+    (Fsm.phase_to_string snapshot.phase)
+
+let test_snapshot_restored_from_social_state () =
+  let state =
+    {
+      KSM.social_model = "magentic_ledger_v1";
+      belief_summary = "ledger:phase=stalled; event=goal_idle_timeout";
+      active_desire = Some "recover_forward_motion";
+      current_intention = Some "request_replan";
+      blocker = Some "stalled_without_progress_evidence";
+      need = Some "fresh_plan_or_external_delta";
+      speech_act = KSM.Stay_silent;
+      delivery_surface = KSM.Silent;
+    }
+  in
+  match Fsm.snapshot_of_social_state state with
+  | None -> fail "expected snapshot"
+  | Some snapshot ->
+      check string "phase restored" "stalled"
+        (Fsm.phase_to_string snapshot.phase)
+
+let test_tla_sets_match_ocaml () =
+  let tla_path =
+    Filename.concat (repo_root ())
+      "specs/keeper-state-machine/KeeperSocialModelMagenticLedger.tla"
+  in
+  let source = read_file tla_path in
+  check (list string) "phase set matches"
+    (extract_quoted_set source "PhaseSet")
+    (phase_strings Fsm.all_phases);
+  check (list string) "event set matches"
+    (extract_quoted_set source "EventSet")
+    (event_strings Fsm.all_events)
+
+let () =
+  run "keeper_social_model_magentic_ledger_fsm"
+    [
+      ( "fsm",
+        [
+          test_case "progress evidence beats other signals" `Quick
+            test_progress_evidence_beats_other_signals;
+          test_case "reactive signal beats idle timeout" `Quick
+            test_reactive_signal_beats_idle_timeout;
+          test_case "stalled state sticks until delta" `Quick
+            test_stalled_state_sticks_until_delta;
+          test_case "snapshot restored from social state" `Quick
+            test_snapshot_restored_from_social_state;
+          test_case "tla sets match ocaml" `Quick test_tla_sets_match_ocaml;
+        ] );
+    ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2803,6 +2803,38 @@ let test_social_model_magentic_ledger_previous_state_of_meta_restores_model ()
       check string "speech act restored" "inform"
         (KSM.speech_act_to_string state.speech_act)
 
+let test_social_model_magentic_ledger_stalled_state_carries_until_delta () =
+  let meta = { minimal_meta with social_model = "magentic_ledger_v1" } in
+  let previous_state =
+    Some
+      {
+        KSM.social_model = "magentic_ledger_v1";
+        belief_summary = "ledger:phase=stalled; event=goal_idle_timeout";
+        active_desire = Some "recover_forward_motion";
+        current_intention = Some "request_replan";
+        blocker = Some "stalled_without_progress_evidence";
+        need = Some "fresh_plan_or_external_delta";
+        speech_act = KSM.Stay_silent;
+        delivery_surface = KSM.Silent;
+      }
+  in
+  let observation =
+    { base_observation with active_goals = [ "goal-1" ]; idle_seconds = 0 }
+  in
+  let result =
+    make_run_result ~text:"" ~tools:[]
+      ~model:"test-model" ~input_tok:10 ~output_tok:1 ()
+  in
+  let _, state, _ =
+    KSM.apply_to_result ~meta ~observation ~previous_state result
+  in
+  check (option string) "stalled desire carried" (Some "recover_forward_motion")
+    state.active_desire;
+  check (option string) "stalled intention carried" (Some "request_replan")
+    state.current_intention;
+  check bool "belief summary remains stalled" true
+    (contains_substring state.belief_summary "ledger:phase=stalled")
+
 let test_keeper_allowed_tools_exclude_heartbeat () =
   let allowed =
     Masc_mcp.Keeper_exec_tools.keeper_allowed_tool_names minimal_policy_meta
@@ -3181,6 +3213,8 @@ let () =
             test_social_model_magentic_ledger_hides_nonvisible_tool_text;
           test_case "magentic ledger restores previous state model" `Quick
             test_social_model_magentic_ledger_previous_state_of_meta_restores_model;
+          test_case "magentic ledger stalled state carries until delta" `Quick
+            test_social_model_magentic_ledger_stalled_state_carries_until_delta;
           test_case "render_inline deny" `Quick
             test_render_inline_skip_reason_deny;
           test_case "render_inline cost" `Quick


### PR DESCRIPTION
## Summary
- extract magentic_ledger_v1 into an explicit phase/event FSM module instead of ad-hoc per-turn phase branching
- make stalled ledger state sticky until a real delta arrives, and drive the social-model overlay from that FSM
- add a matching TLA+ spec/cfg plus a dedicated OCaml test that asserts the spec's closed phase/event sets match the implementation

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/social-model-second-fsm test/test_keeper_social_model_magentic_ledger_fsm.exe test/test_keeper_unified.exe test/test_keeper_meta_listing.exe
- env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_keeper_social_model_magentic_ledger_fsm.exe
- env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_keeper_unified.exe
- env ALCOTEST_QUICK_TESTS=1 _build/default/test/test_keeper_meta_listing.exe