### PR TITLE
fix(dashboard): remove recovery panel after manual_reconcile deletion (#7334)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -405,7 +405,6 @@ export interface KeeperCompositeInvariants {
   no_cascade_before_measurement: boolean
   compaction_atomicity: boolean
   event_priority_monotone: boolean
-  recovery_two_store_sync: boolean
 }
 
 export interface KeeperCompositeMeasurement {
@@ -436,7 +435,6 @@ export interface KeeperCompositeSnapshot {
   cascade: { state: string }
   compaction: { stage: string }
   measurement: KeeperCompositeMeasurement
-  recovery: { data_record: boolean; fsm_condition: boolean }
   invariants: KeeperCompositeInvariants
   /** RFC-0003 Phase 2 (#7122): true when a turn is actively
       executing. Sub-FSM fields reflect live in-turn state only

--- a/dashboard/src/components/fsm-hub-health-panels.ts
+++ b/dashboard/src/components/fsm-hub-health-panels.ts
@@ -96,8 +96,6 @@ const INVARIANT_DESCRIPTIONS: Record<string, string> = {
     'Compaction must be atomic — a turn either sees the old context or the new one, never a half-compacted state. A break corrupts message ordering or duplicates content.',
   event_priority_monotone:
     'Event_bus priorities must be monotone (higher priority delivered first). A break means a critical event was delivered after a lower-priority one, which can skew keeper decisions.',
-  recovery_two_store_sync:
-    'Data-record and FSM-condition stores must agree on the same recovery point. A drift here means a restart would replay from an inconsistent checkpoint.',
 }
 
 export function invariantDescription(key: string): string {
@@ -171,61 +169,3 @@ export function InvariantsPanel({
   `
 }
 
-const RECOVERY_STATE_DESCRIPTIONS: Record<string, string> = {
-  clean:
-    'Both data-record and FSM-condition stores agree — no recovery action needed. A restart from this state will resume cleanly.',
-  reconcile_pending:
-    'Both stores recorded recovery state but have not yet reconciled. The keeper will align them on the next heartbeat cycle.',
-  'drift: data↑ fsm↓':
-    'The data-record store advanced past the FSM-condition store. A restart may replay turns that the FSM already completed, causing duplicate tool calls unless journal idempotency is active.',
-  'drift: fsm↑ data↓':
-    'The FSM-condition store advanced past the data-record. A restart may lose checkpoint data, forcing the keeper to re-derive state from scratch.',
-}
-
-export function recoveryStateDescription(state: string): string {
-  return RECOVERY_STATE_DESCRIPTIONS[state] ?? 'Recovery state defined by the keeper two-store sync contract.'
-}
-
-export function RecoveryStatePanel({
-  dataRecord,
-  fsmCondition,
-}: {
-  dataRecord: boolean
-  fsmCondition: boolean
-}) {
-  const state =
-    !dataRecord && !fsmCondition ? 'clean' :
-    dataRecord && fsmCondition ? 'reconcile_pending' :
-    dataRecord && !fsmCondition ? 'drift: data↑ fsm↓' :
-    'drift: fsm↑ data↓'
-  const isClean = state === 'clean'
-  const isDrift = state.startsWith('drift')
-  const toneCls = isClean ? 'text-[#22c55e]' : isDrift ? 'text-[#ef4444]' : 'text-[#f59e0b]'
-  const panelCls = isClean
-    ? 'border-[var(--white-8)] bg-[var(--white-2)]'
-    : isDrift
-      ? 'border-[rgba(239,68,68,0.55)] bg-[rgba(239,68,68,0.05)] shadow-[0_0_0_1px_rgba(239,68,68,0.2)_inset]'
-      : 'border-[rgba(245,158,11,0.45)] bg-[rgba(245,158,11,0.04)] shadow-[0_0_0_1px_rgba(245,158,11,0.15)_inset]'
-
-  return html`
-    <div
-      class=${`rounded-xl border p-3 transition-colors duration-300 ${panelCls}`}
-      role=${isDrift ? 'alert' : undefined}
-      aria-live=${isDrift ? 'polite' : undefined}
-      title=${recoveryStateDescription(state)}
-    >
-      <div class="text-[10px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)] mb-2">
-        Recovery
-      </div>
-      <div class=${`font-mono text-[13px] font-semibold ${toneCls}`}>${state}</div>
-      <div class="mt-1.5 flex gap-3 text-[9px] text-[var(--text-dim)]">
-        <span class="cursor-help" title="data_record: true means the data store has recorded a recovery point that hasn't been reconciled yet.">
-          data <span class="font-mono">${String(dataRecord)}</span>
-        </span>
-        <span class="cursor-help" title="fsm_condition: true means the FSM store has recorded a recovery condition that hasn't been reconciled yet.">
-          fsm <span class="font-mono">${String(fsmCondition)}</span>
-        </span>
-      </div>
-    </div>
-  `
-}

--- a/dashboard/src/components/fsm-hub-invariant-analysis.ts
+++ b/dashboard/src/components/fsm-hub-invariant-analysis.ts
@@ -42,10 +42,6 @@ function invariantDetail(
       return ok
         ? 'This turn has not emitted competing measurement snapshots.'
         : 'More than one measurement event appears to own the same turn.'
-    case 'recovery_two_store_sync':
-      return ok
-        ? 'Recovery data and FSM condition are synchronized.'
-        : `recovery.data_record=${String(snapshot.recovery.data_record)}, recovery.fsm_condition=${String(snapshot.recovery.fsm_condition)}.`
   }
 }
 
@@ -56,7 +52,7 @@ function nextExpectedStep(snapshot: KeeperCompositeSnapshot): string {
       : 'No turn has completed yet; the first live turn should populate the observer.'
   }
   if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
-    return 'A healthy provider path or manual reconcile must clear Failing before Running can resume.'
+    return 'A healthy provider path must clear Failing before Running can resume.'
   }
   if (snapshot.phase === 'Compacting' || snapshot.compaction.stage === 'compacting') {
     return 'KMC should reach done and then KSM should hand control back to Running.'
@@ -110,30 +106,6 @@ export function deriveOperationalInsight(
 
   const lanes = precomputedLanes ?? deriveObservedLaneSummaries(snapshot, observations, now)
   const stalledLane = lanes.find(lane => lane.stalled)
-  if (snapshot.recovery.data_record !== snapshot.recovery.fsm_condition) {
-    return {
-      tone: 'error',
-      headline: 'Recovery stores diverged',
-      detail: 'The manual-reconcile data record and FSM condition disagree, which should be unreachable under RFC-0003.',
-      nextStep: 'Reconcile the recovery stores before treating the lifecycle as healthy again.',
-      evidence: [
-        `data ${String(snapshot.recovery.data_record)}`,
-        `fsm ${String(snapshot.recovery.fsm_condition)}`,
-      ],
-    }
-  }
-  if (snapshot.recovery.data_record && snapshot.recovery.fsm_condition) {
-    return {
-      tone: 'warn',
-      headline: 'Manual reconcile is pending',
-      detail: 'Both recovery stores agree the keeper is waiting for manual reconcile to clear.',
-      nextStep: 'Resolve the reconcile path before expecting Failing to return to Running.',
-      evidence: [
-        `KSM ${snapshot.phase}`,
-        'manual reconcile required',
-      ],
-    }
-  }
   if (snapshot.phase === 'Failing' && snapshot.cascade.state === 'exhausted') {
     return {
       tone: 'error',

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -101,7 +101,6 @@ const ZERO_VIOLATIONS: InvariantViolationCounts = {
   no_cascade_before_measurement: 0,
   compaction_atomicity: 0,
   event_priority_monotone: 0,
-  recovery_two_store_sync: 0,
 }
 
 export const initialHubState: HubState = {
@@ -128,7 +127,6 @@ export const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> =
   no_cascade_before_measurement: 'Cascade ordering',
   compaction_atomicity: 'Compaction atomic',
   event_priority_monotone: 'Event priority',
-  recovery_two_store_sync: 'Two-store sync',
 }
 
 export const LANE_LABELS: Record<LaneKey, string> = {

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -39,13 +39,11 @@ const REAL_COMPOSITE_SHAPE: KeeperCompositeSnapshot = {
   cascade: { state: 'idle' },
   compaction: { stage: 'accumulating' },
   measurement: { captured: false },
-  recovery: { data_record: false, fsm_condition: false },
   invariants: {
     phase_turn_alignment: true,
     no_cascade_before_measurement: true,
     compaction_atomicity: true,
     event_priority_monotone: true,
-    recovery_two_store_sync: true,
   },
   is_live: false,
   last_outcome: { turn_id: 353, ended_at: 1776234638.709722 },
@@ -97,18 +95,12 @@ describe('FSM Hub integration — API response shape', () => {
       }
     })
 
-    it('all 5 invariants are boolean — InvariantsPanel renders 5/5 or partial', () => {
+    it('all 4 invariants are boolean — InvariantsPanel renders 4/4 or partial', () => {
       const inv = REAL_COMPOSITE_SHAPE.invariants
       expect(typeof inv.phase_turn_alignment).toBe('boolean')
       expect(typeof inv.no_cascade_before_measurement).toBe('boolean')
       expect(typeof inv.compaction_atomicity).toBe('boolean')
       expect(typeof inv.event_priority_monotone).toBe('boolean')
-      expect(typeof inv.recovery_two_store_sync).toBe('boolean')
-    })
-
-    it('recovery.data_record and fsm_condition are boolean — RecoveryStatePanel classifies drift on these', () => {
-      expect(typeof REAL_COMPOSITE_SHAPE.recovery.data_record).toBe('boolean')
-      expect(typeof REAL_COMPOSITE_SHAPE.recovery.fsm_condition).toBe('boolean')
     })
   })
 

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -16,7 +16,6 @@ import {
   inferTransitionReason,
   invariantDescription,
   isTransitionInSegment,
-  recoveryStateDescription,
   laneTransitionCount,
   type CompositeObservation,
   type HoveredSegment,
@@ -49,13 +48,11 @@ function snapshot(
     cascade: { state: 'idle' },
     compaction: { stage: 'accumulating' },
     measurement: { captured: false },
-    recovery: { data_record: false, fsm_condition: false },
     invariants: {
       phase_turn_alignment: true,
       no_cascade_before_measurement: true,
       compaction_atomicity: true,
       event_priority_monotone: true,
-      recovery_two_store_sync: true,
     },
     is_live: false,
     last_outcome: null,
@@ -79,10 +76,6 @@ function snapshot(
     measurement: {
       ...base.measurement,
       ...(overrides.measurement ?? {}),
-    },
-    recovery: {
-      ...base.recovery,
-      ...(overrides.recovery ?? {}),
     },
     invariants: {
       ...base.invariants,
@@ -178,7 +171,6 @@ describe('fsm-hub derived state', () => {
           no_cascade_before_measurement: true,
           compaction_atomicity: true,
           event_priority_monotone: true,
-          recovery_two_store_sync: true,
         },
       }),
       [observation({ ts: 10, phase: 'Compacting', turn: 'executing' })],
@@ -563,7 +555,6 @@ describe('invariantDescription', () => {
       'no_cascade_before_measurement',
       'compaction_atomicity',
       'event_priority_monotone',
-      'recovery_two_store_sync',
     ]
     for (const key of keys) {
       const desc = invariantDescription(key)
@@ -577,30 +568,9 @@ describe('invariantDescription', () => {
     expect(invariantDescription('no_cascade_before_measurement')).toMatch(/cascade|measurement/i)
     expect(invariantDescription('compaction_atomicity')).toMatch(/atomic|half-compacted/i)
     expect(invariantDescription('event_priority_monotone')).toMatch(/priority|priorit/i)
-    expect(invariantDescription('recovery_two_store_sync')).toMatch(/recovery|checkpoint|store/i)
   })
 
   it('falls back to generic text for unknown keys', () => {
     expect(invariantDescription('mystery_invariant')).toMatch(/^Invariant defined by/)
-  })
-})
-
-describe('recoveryStateDescription', () => {
-  it('returns prose for all four recovery states', () => {
-    const states = ['clean', 'reconcile_pending', 'drift: data↑ fsm↓', 'drift: fsm↑ data↓']
-    for (const state of states) {
-      const desc = recoveryStateDescription(state)
-      expect(desc.length).toBeGreaterThan(30)
-      expect(desc).not.toMatch(/^Recovery state defined by/)
-    }
-  })
-
-  it('mentions restart consequence for drift states', () => {
-    expect(recoveryStateDescription('drift: data↑ fsm↓')).toMatch(/restart|replay|duplicate/i)
-    expect(recoveryStateDescription('drift: fsm↑ data↓')).toMatch(/restart|lose|re-derive/i)
-  })
-
-  it('falls back for unknown states', () => {
-    expect(recoveryStateDescription('unknown')).toMatch(/^Recovery state defined by/)
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -30,7 +30,7 @@ import {
 } from './fsm-hub-derivations'
 import { OperationalMeaningPanel, HeroPhase, TurnPipelineStrip, CompositeGraphPanel } from './fsm-hub-pipeline-panels'
 import { DwellHistogramPanel, SwimlaneTimeline, TopTransitionsPanel, TransitionTrail } from './fsm-hub-timeline-panels'
-import { MeasurementCard, InvariantsPanel, RecoveryStatePanel } from './fsm-hub-health-panels'
+import { MeasurementCard, InvariantsPanel } from './fsm-hub-health-panels'
 
 // ── Backward-compatible re-exports ─────────────────────
 // External consumers (agents-unified.ts, fsm-hub.test.ts)
@@ -70,7 +70,6 @@ export { deriveObservedLaneSummaries } from './fsm-hub-lane-analysis'
 export {
   flagTooltip,
   invariantDescription,
-  recoveryStateDescription,
 } from './fsm-hub-health-panels'
 
 export {
@@ -128,7 +127,7 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
  * FSM Hub — architecture audit surface for the composite keeper lifecycle.
  *
  * Layout redesign: Hero (KSM) + Pipeline strip (KTC->KDP->KCL->KMC) +
- * Health grid (measurement/invariants/recovery) + collapsible graph.
+ * Health grid (measurement/invariants) + collapsible graph.
  *
  * Data source: `/api/v1/keepers/:name/composite` (RFC-0003 S7).
  */
@@ -446,16 +445,12 @@ export function FsmHub() {
 
         ${/* ── Zone 4: Health Grid (collapsible) ── */ ''}
         <${CollapsibleZone} id="health-grid" title="상태 격자" defaultOpen=${true}>
-          <div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <div class="grid gap-3 md:grid-cols-2">
             <${MeasurementCard} snapshot=${snapshot} />
             <${InvariantsPanel}
               snapshot=${snapshot}
               violationCounts=${view.invariantViolations}
               sampleCount=${view.invariantSampleCount}
-            />
-            <${RecoveryStatePanel}
-              dataRecord=${snapshot.recovery.data_record}
-              fsmCondition=${snapshot.recovery.fsm_condition}
             />
           </div>
         <//>
@@ -584,14 +579,9 @@ function StatusBar({
         .filter(([_, ok]) => !ok)
         .map(([k]) => k)
     : []
-  const recoveryDrift = snapshot != null
-    && (snapshot.recovery.data_record !== snapshot.recovery.fsm_condition)
-  const hasAnomaly = brokenInvariants.length > 0 || recoveryDrift
+  const hasAnomaly = brokenInvariants.length > 0
   const anomalyTitle = hasAnomaly
-    ? [
-        brokenInvariants.length > 0 ? `깨진 invariant: ${brokenInvariants.join(', ')}` : '',
-        recoveryDrift ? 'recovery 양 store 불일치' : '',
-      ].filter(Boolean).join(' · ')
+    ? `깨진 invariant: ${brokenInvariants.join(', ')}`
     : ''
 
   const containerPadding = density === 'compact' ? 'px-3 py-1.5' : 'px-4 py-2.5'


### PR DESCRIPTION
## Summary
- 대시보드 `monitoring:agents` 렌더가 `Cannot read properties of undefined (reading 'data_record')`로 깨지고 있었음
- 원인: #7334 (Phase B: remove manual_reconcile blocker)에서 백엔드 composite snapshot의 `recovery`/`recovery_two_store_sync`를 제거했지만 dashboard는 그대로 참조
- Dashboard의 dead surface 7개 파일 정리 (-147 / +7)

## Changes
- `api/keeper.ts`: `KeeperCompositeSnapshot.recovery`, `KeeperCompositeInvariants.recovery_two_store_sync` 제거
- `fsm-hub.ts`: `RecoveryStatePanel` 렌더 및 `recoveryDrift` anomaly 제거, health grid 3칸 → 2칸
- `fsm-hub-health-panels.ts`: `RecoveryStatePanel`, `recoveryStateDescription`, 관련 설명 제거
- `fsm-hub-invariant-analysis.ts`: `recovery_two_store_sync` case + recovery store drift branch 제거
- `fsm-hub-types.ts`: invariant 레이블/카운트 정리
- 테스트 픽스처 + `recoveryStateDescription` describe 블록 제거

## Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (no warnings)
- `pnpm build` ✅
- `pnpm exec vitest run src/components/fsm-hub.test.ts src/components/fsm-hub.integration.test.ts` → 58/58 통과

## Not Touching
- 백엔드 (`lib/keeper/keeper_composite_observer.ml`)는 이미 `recovery` 필드를 내보내지 않음 — 이번 PR은 frontend의 관성만 정리
- keeper_bash `gh` 차단 문제와 Dashboard shell cache timeout은 별도 이슈로 분리 권장

## Test plan
- [x] typecheck green
- [x] lint green
- [x] 2 test files 58 tests green
- [x] production build green
- [ ] 머지 후 `http://127.0.0.1:8935/dashboard#monitoring?section=agents&view=fsm`에서 렌더 에러 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)