### PR TITLE
fix(dashboard): remove 50-task hard cap on planning kanban

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -256,15 +256,20 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
           | _ -> false)
         |> take 20
       in
+      (* Cap removed (2026-04-16): active_tasks is already bounded by
+         how many tasks exist in state, and recent_done is capped at 20
+         above. The previous [take 50] silently truncated the backlog in
+         the dashboard planning view at exactly 50 entries, which surfaced
+         as a "total tasks = 50" bug once the real backlog exceeded that
+         number. The raw list is surfaced instead; frontend paginates. *)
       let all_visible = active_tasks @ recent_done in
-      let limited_tasks = take 50 all_visible in
       let task_fields = [
-        ("tasks", `List (List.map task_json limited_tasks));
+        ("tasks", `List (List.map task_json all_visible));
         ("task_counts", `Assoc [
           ("active", `Int (List.length active_tasks));
           ("done_recent", `Int (List.length recent_done));
           ("total", `Int (List.length tasks));
-          ("shown", `Int (List.length limited_tasks));
+          ("shown", `Int (List.length all_visible));
         ]);
       ] in
       let t_end = Time_compat.now () in


### PR DESCRIPTION
## Why

\`lib/dashboard/dashboard_execution.ml\` truncated the \`active_tasks + recent_done\` list with \`take 50\`:

\`\`\`ocaml
let all_visible = active_tasks @ recent_done in
let limited_tasks = take 50 all_visible in
\`\`\`

This surfaced in the dashboard planning kanban as **\"전체 태스크 50\"** once the real backlog exceeded 50 entries. The \`task_counts.total\` field still reflected the real total (73 in current data), but \`tasks\` array capped at 50 — a silent count bug where operators saw 50 tasks and thought that was the ceiling.

## Fix

Remove the \`take 50\`. Surface \`all_visible\` as-is.

**Safety:**
- \`active_tasks\` is bounded by how many non-done tasks exist in state
- \`recent_done\` is independently capped at 20 above the fix site

If the array ever grows problematic, the right knob is \`governance_registry.dashboard_max_pending_tasks\` applied upstream to filtering, not a post-hoc truncation.

## Verification

- \`dune build @check\` clean
- Planning kanban will show the full backlog (73 todo today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)