### PR TITLE
fix(keeper): gh op timeout floor + --repo org allowlist

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1027,56 +1027,70 @@ let handle_keeper_shell
       Safe_ops.json_string ~default:"" "cmd" args
       |> normalize_gh_command
     in
-    let timeout_sec = clamp_shell_timeout ~default:io_timeout_sec args in
+    (* gh runs against remote network, so 1s floor from shell default is
+       too aggressive (observed: keepers passing timeout_sec=1 kills
+       [gh pr create] mid-TCP). Floor at 5s and default at the configured
+       pr_create timeout (tool_policy.toml, default 30s). *)
+    let gh_default_timeout = Keeper_tool_policy.pr_create_timeout_sec () in
+    let timeout_sec =
+      clamp_shell_timeout ~min_sec:5.0 ~default:gh_default_timeout args
+    in
     if cmd_str = "" then
       error_json ~fields:[ "op", `String op ]
         "cmd is required for gh op. Good: cmd='pr list --state open'. Bad: cmd=''."
     else
-      let gh_dangerous_prefixes =
-        [ "repo delete"; "repo archive"; "repo transfer"
-        ; "auth logout"; "auth token"
-        ; "secret set"; "secret delete"
-        ; "ssh-key delete"
-        ]
-      in
-      let cmd_lower = String.lowercase_ascii cmd_str in
-      let blocked_prefix =
-        List.find_opt (fun prefix ->
-          String.length cmd_lower >= String.length prefix
-          && String.sub cmd_lower 0 (String.length prefix) = prefix
-        ) gh_dangerous_prefixes
-      in
-      (match blocked_prefix with
-      | Some pat ->
-        Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool false
-              ; "op", `String op
-              ; "error", `String "gh_dangerous_blocked"
-              ; "blocked_pattern", `String pat
-              ; "hint", `String "This gh command is blocked for safety."
-              ])
-      | None ->
-        (match cwd_target () with
-         | Error e -> path_error e
-         | Ok cwd ->
-           let full_cmd =
-             Keeper_gh_env.with_env config
-               (Printf.sprintf "gh %s 2>&1" cmd_str)
-           in
-           let st, out =
-             Process_eio.run_argv_with_status ~cwd ~timeout_sec
-               [ "bash"; "-lc"; full_cmd ]
-           in
-           Yojson.Safe.to_string
-             (`Assoc
-                 [ "ok", `Bool (st = Unix.WEXITED 0)
-                 ; "op", `String op
-                 ; "cwd", `String cwd
-                 ; "command", `String (Printf.sprintf "gh %s" cmd_str)
-                 ; "status", Keeper_alerting_path.process_status_to_json st
-                 ; "output", `String out
-                 ])))
+      let allowed_orgs = Keeper_tool_policy.git_clone_allowed_orgs () in
+      (match Worker_dev_tools.validate_gh_command ~allowed_orgs cmd_str with
+       | Error reason ->
+         Yojson.Safe.to_string
+           (`Assoc
+               [ "ok", `Bool false
+               ; "op", `String op
+               ; "error", `String "gh_command_blocked"
+               ; "reason", `String reason
+               ; "hint", `String
+                   "Run `gh --help` shapes: pr/issue/repo/release/label/run/\
+                    workflow/api/project/ruleset/search/status/cache/gist. \
+                    auth/secret/ssh-key are blocked."
+               ])
+       | Ok () ->
+         (match cwd_target () with
+          | Error e -> path_error e
+          | Ok cwd ->
+            let full_cmd =
+              Keeper_gh_env.with_env config
+                (Printf.sprintf "gh %s 2>&1" cmd_str)
+            in
+            let st, out =
+              Process_eio.run_argv_with_status ~cwd ~timeout_sec
+                [ "bash"; "-lc"; full_cmd ]
+            in
+            if process_status_is_timeout st then
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool false
+                    ; "op", `String op
+                    ; "cwd", `String cwd
+                    ; "command", `String (Printf.sprintf "gh %s" cmd_str)
+                    ; "error", `String "gh_command_timed_out"
+                    ; "timeout_sec", `Float timeout_sec
+                    ; "status", Keeper_alerting_path.process_status_to_json st
+                    ; "output", `String out
+                    ; "hint", `String
+                        "gh network call exceeded timeout_sec. Retry with a \
+                         larger value (e.g. timeout_sec=60) or narrow the \
+                         query (--state, --limit, --json)."
+                    ])
+            else
+              Yojson.Safe.to_string
+                (`Assoc
+                    [ "ok", `Bool (st = Unix.WEXITED 0)
+                    ; "op", `String op
+                    ; "cwd", `String cwd
+                    ; "command", `String (Printf.sprintf "gh %s" cmd_str)
+                    ; "status", Keeper_alerting_path.process_status_to_json st
+                    ; "output", `String out
+                    ])))
   | _ ->
     Yojson.Safe.to_string
       (`Assoc

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -597,13 +597,47 @@ let gh_allowed_commands =
   ]
 
 (** Specific (command, subcommand) pairs that are always blocked
-    regardless of allowlist. These are irreversible or catastrophic. *)
+    regardless of allowlist. These are irreversible or catastrophic.
+    Parity with the legacy [gh_dangerous_prefixes] check in
+    [keeper_exec_shell.ml] op=gh, which is being retired in favor of
+    calling [validate_gh_command] as the single source of truth. *)
 let gh_blocked_operations =
   [
     ("repo", "delete");
+    ("repo", "archive");
+    ("repo", "transfer");
     ("gist", "delete");
     ("workflow", "disable");
   ]
+
+(** Extract owner from a [--repo OWNER/NAME], [--repo=OWNER/NAME], or
+    [-R OWNER/NAME] flag in a gh command string. Returns [None] if no
+    such flag is present — in that case gh defaults to the cwd's git
+    origin, which is already org-gated at clone time.
+
+    Only the owner segment is returned; repo/branch names are outside
+    the allowlist scope. *)
+let extract_gh_repo_owner cmd =
+  let tokens =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+  in
+  let owner_of_slug s =
+    match String.split_on_char '/' s with
+    | owner :: _ :: _ when owner <> "" -> Some owner
+    | _ -> None
+  in
+  let rec find = function
+    | [] -> None
+    | "--repo" :: slug :: _ | "-R" :: slug :: _ -> owner_of_slug slug
+    | tok :: rest when String.length tok > 7 && String.sub tok 0 7 = "--repo=" ->
+      let slug = String.sub tok 7 (String.length tok - 7) in
+      (match owner_of_slug slug with
+       | Some _ as o -> o
+       | None -> find rest)
+    | _ :: rest -> find rest
+  in
+  find tokens
 
 (** Extract the top-level command and its first subcommand from a gh
     command string (the portion after "gh ").
@@ -631,10 +665,18 @@ let extract_gh_command_pair cmd =
     (Some x, find_subcmd rest)
 
 (** Validate a gh CLI command string for safety.
-    Checks: (1) shell metacharacters, (2) top-level command allowlist,
-    (3) blocked operation pairs.
+    Checks in order:
+      (1) shell metacharacters,
+      (2) top-level command allowlist,
+      (3) blocked (command, subcommand) operation pairs,
+      (4) [--repo OWNER/NAME] owner against [allowed_orgs] (if non-empty).
+
+    Check 4 is skipped when [allowed_orgs] is [] (policy not configured)
+    or when the command carries no [--repo] flag (gh falls back to
+    cwd's origin, which is already gated at clone time).
+
     [cmd] is the portion after "gh ", e.g. "pr view 123". *)
-let validate_gh_command cmd =
+let validate_gh_command ?(allowed_orgs = []) cmd =
   let trimmed = String.trim cmd in
   if trimmed = "" then Error "gh command must not be empty"
   else if contains_forbidden_shell_chars trimmed then
@@ -660,7 +702,17 @@ let validate_gh_command cmd =
         then
           Error
             (Printf.sprintf "gh %s %s is blocked for safety" command sub)
-        else Ok ()
+        else
+          match allowed_orgs, extract_gh_repo_owner trimmed with
+          | [], _ | _, None -> Ok ()
+          | orgs, Some owner when List.mem owner orgs -> Ok ()
+          | orgs, Some owner ->
+            Error
+              (Printf.sprintf
+                 "gh --repo owner '%s' not in allowed_orgs [%s]. \
+                  Drop --repo to use the current repo, or use an allowed org."
+                 owner
+                 (String.concat ", " orgs))
 
 (** Known destructive API endpoint patterns.
     Each pattern is checked as a substring of the full command.

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -663,4 +663,104 @@ let () =
         Alcotest.(check bool) "placeholder added" true
           (contains_substring redacted "--token [REDACTED]"));
     ];
+    "validate_gh_command", [
+      Alcotest.test_case "accepts allowed subcommand with no repo flag" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "pr list --state open" with
+        | Ok () -> ()
+        | Error msg -> Alcotest.failf "expected ok, got %s" msg);
+      Alcotest.test_case "rejects shell chaining" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "pr list && echo done" with
+        | Ok () -> Alcotest.fail "expected chaining to be blocked"
+        | Error msg ->
+          Alcotest.(check bool) "chaining message" true
+            (contains_substring msg "chaining"));
+      Alcotest.test_case "rejects unknown top-level command" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "auth token" with
+        | Ok () -> Alcotest.fail "expected unknown to be blocked"
+        | Error msg ->
+          Alcotest.(check bool) "not in approved" true
+            (contains_substring msg "not in the approved"));
+      Alcotest.test_case "rejects repo delete" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "repo delete jeong-sik/foo" with
+        | Ok () -> Alcotest.fail "expected repo delete blocked"
+        | Error msg ->
+          Alcotest.(check bool) "blocked for safety" true
+            (contains_substring msg "blocked for safety"));
+      Alcotest.test_case "rejects repo archive (parity with legacy guard)" `Quick (fun () ->
+        match Worker_dev_tools.validate_gh_command "repo archive jeong-sik/foo" with
+        | Ok () -> Alcotest.fail "expected archive blocked"
+        | Error msg ->
+          Alcotest.(check bool) "archive blocked" true
+            (contains_substring msg "blocked for safety"));
+      Alcotest.test_case "skips org check when allowed_orgs empty" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:[]
+            "pr view --repo evil/repo 1"
+        with
+        | Ok () -> ()
+        | Error msg -> Alcotest.failf "expected ok (empty orgs), got %s" msg);
+      Alcotest.test_case "allows repo in allowed_orgs" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
+            "pr view --repo jeong-sik/masc-mcp 123"
+        with
+        | Ok () -> ()
+        | Error msg -> Alcotest.failf "expected ok, got %s" msg);
+      Alcotest.test_case "rejects repo outside allowed_orgs" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
+            "pr view --repo evil-org/payload 1"
+        with
+        | Ok () -> Alcotest.fail "expected org outside allowlist to be blocked"
+        | Error msg ->
+          Alcotest.(check bool) "mentions not in allowed_orgs" true
+            (contains_substring msg "not in allowed_orgs");
+          Alcotest.(check bool) "mentions offending owner" true
+            (contains_substring msg "evil-org"));
+      Alcotest.test_case "rejects --repo=OWNER/NAME form" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
+            "pr view --repo=evil-org/payload 1"
+        with
+        | Ok () -> Alcotest.fail "expected --repo= form to be blocked"
+        | Error msg ->
+          Alcotest.(check bool) "blocked" true
+            (contains_substring msg "not in allowed_orgs"));
+      Alcotest.test_case "rejects -R short flag outside allowlist" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
+            "issue list -R evil-org/payload"
+        with
+        | Ok () -> Alcotest.fail "expected -R form to be blocked"
+        | Error msg ->
+          Alcotest.(check bool) "blocked" true
+            (contains_substring msg "not in allowed_orgs"));
+      Alcotest.test_case "allows no --repo flag with orgs configured" `Quick (fun () ->
+        match
+          Worker_dev_tools.validate_gh_command ~allowed_orgs:["jeong-sik"]
+            "pr list --state open"
+        with
+        | Ok () -> ()
+        | Error msg -> Alcotest.failf "expected ok (no --repo), got %s" msg);
+    ];
+    "extract_gh_repo_owner", [
+      Alcotest.test_case "extracts from --repo flag" `Quick (fun () ->
+        Alcotest.(check (option string)) "owner" (Some "jeong-sik")
+          (Worker_dev_tools.extract_gh_repo_owner
+             "pr view --repo jeong-sik/masc-mcp 1"));
+      Alcotest.test_case "extracts from --repo= form" `Quick (fun () ->
+        Alcotest.(check (option string)) "owner" (Some "jeong-sik")
+          (Worker_dev_tools.extract_gh_repo_owner
+             "pr view --repo=jeong-sik/masc-mcp 1"));
+      Alcotest.test_case "extracts from -R short flag" `Quick (fun () ->
+        Alcotest.(check (option string)) "owner" (Some "jeong-sik")
+          (Worker_dev_tools.extract_gh_repo_owner
+             "issue list -R jeong-sik/masc-mcp"));
+      Alcotest.test_case "returns None without --repo flag" `Quick (fun () ->
+        Alcotest.(check (option string)) "no flag" None
+          (Worker_dev_tools.extract_gh_repo_owner "pr list --state open"));
+      Alcotest.test_case "returns None for malformed slug" `Quick (fun () ->
+        Alcotest.(check (option string)) "no slash" None
+          (Worker_dev_tools.extract_gh_repo_owner "pr view --repo malformed"));
+    ];
   ]


### PR DESCRIPTION
## Summary

nick0cave의 2026-04-14 board post와 2026-04-16 서버 로그(\`Timeout after 1s: gh pr create\`)에서 드러난 두 문제를 고칩니다.

- **Problem 1 — gh timeout 1s floor**: \`keeper_shell op=gh\`가 shell 전역 \`min_sec=1.0\`을 쓰면서 LLM이 \`timeout_sec=1\`을 넘기면 gh 네트워크 콜이 mid-TCP에서 죽음. \`gh pr create\`가 4개 이상의 keeper 시도에서 1초 timeout으로 실패.
- **Problem 2 — allowed_orgs 무검증**: \`validate_gh_command\`가 \`--repo OWNER/NAME\`을 \`tool_policy.toml\`의 \`git_clone.allowed_orgs\`와 대조하지 않아서, keeper가 \`git clone\`은 막혀도 \`gh\`로는 임의 org 접근 가능.

## Changes

### \`lib/worker_dev_tools.ml\`
- \`extract_gh_repo_owner\`: \`--repo OWNER/NAME\`, \`--repo=OWNER/NAME\`, \`-R OWNER/NAME\` 파싱. malformed slug는 \`None\`.
- \`validate_gh_command ?(allowed_orgs=[])\`: 빈 리스트 또는 \`--repo\` 없으면 스킵(기존 호출자 behavior 보존). owner가 allowlist 밖이면 \`'X' not in allowed_orgs [...]\` 에러.
- \`gh_blocked_operations\`: \`repo archive\` + \`repo transfer\` 추가 (\`keeper_exec_shell.ml\`에서 제거한 inline \`gh_dangerous_prefixes\` 파리티).

### \`lib/keeper/keeper_exec_shell.ml\` (op=\"gh\")
- Timeout floor: \`min_sec=5.0\`, default는 \`Keeper_tool_policy.pr_create_timeout_sec ()\` (tool_policy.toml, 기본 30s).
- Inline \`gh_dangerous_prefixes\` 제거 → \`validate_gh_command\`가 SSOT.
- Timeout 히트 시 전용 \`gh_command_timed_out\` 응답 + \`timeout_sec\` field + retry hint.
- \`allowed_orgs\`는 \`Keeper_tool_policy.git_clone_allowed_orgs ()\`에서 주입.

### \`test/test_worker_dev_tools.ml\`
+16 케이스:
- \`validate_gh_command\` 11개 (allow/chaining/unknown/delete/archive/org empty/org match/org reject/\`--repo=\` form/\`-R\` form/no-flag)
- \`extract_gh_repo_owner\` 5개 (long flag / \`--repo=\` form / \`-R\` form / no-flag None / malformed None)

## Test plan

- [x] \`dune build\` clean
- [x] \`dune exec test/test_worker_dev_tools.exe\` — 79 tests, 전부 pass (기존 63 + 신규 16)
- [x] \`dune runtest\` — keeper_tool_matrix (104s), mcp_tool_matrix (87s) 포함 green
- [x] \`git rebase origin/main\` 후 재빌드/재테스트 clean (main의 \`Room.config\` → \`Coord.config\` rename과 충돌 없음)
- [ ] CI green 확인 후 ready 전환

## 확인하지 않은 것

- \`keeper_bash\`에서 raw \`gh\` 직접 실행은 **허용하지 않음** — 기존 설계 유지. \`keeper_shell op=gh\`가 gh의 single SSOT validated entry point. bash에서 raw gh를 열면 \`validate_gh_command\`를 우회할 수 있음.
- \`masc_code_shell\`의 allowlist에도 \`gh\` 추가 안 함 (동일 이유).

Fixes symptoms reported in p-61cea9c3267121916e3c7ac67c0e19fa (nick0cave board post, 2026-04-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)