### PR TITLE
fix(log): demote normal keeper/JSON flows from WARN

### DIFF
--- a/lib/coord/coord_utils_ops.ml
+++ b/lib/coord/coord_utils_ops.ml
@@ -114,11 +114,22 @@ let mkdir_p path =
   Fs_compat.mkdir_p path
 
 let read_json_local path =
-  match Safe_ops.read_json_file_safe path with
-  | Ok json -> json
+  (* Treat blank/empty files as an empty object, consistent with
+     [read_json_root] below. A blank JSON is a legitimate state for
+     placeholders or newly-created agent metadata files, and does not
+     warrant a WARN log line. *)
+  match Safe_ops.read_file_safe path with
   | Error msg ->
     Log.Misc.warn "[read_json_local] %s" msg;
     `Assoc []
+  | Ok content ->
+    let trimmed = String.trim content in
+    if trimmed = "" then `Assoc []
+    else match Safe_ops.parse_json_safe ~context:path trimmed with
+      | Ok json -> json
+      | Error msg ->
+        Log.Misc.warn "[read_json_local] %s" msg;
+        `Assoc []
 
 let read_json_local_result path =
   Safe_ops.read_json_file_safe path

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2266,7 +2266,10 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           (* 8. Handle stop reason *)
           (match result.stop_reason with
            | Oas_worker.TurnBudgetExhausted { turns_used; limit } ->
-             Log.Keeper.warn
+             (* INFO, not WARN: mirrors MutationBoundaryReached below.
+                The keeper made progress and saved a checkpoint; this is
+                a normal pause-and-resume signal, not a failure. *)
+             Log.Keeper.info
                "keeper:%s turn budget exhausted (%d/%d), checkpoint saved — will resume next cycle"
                updated_meta.name turns_used limit;
              (* Do NOT increment turn_failures — this is not a crash.


### PR DESCRIPTION
## 요약

`~/me/logs/masc-mcp-live.log`과 `logs/masc-server-20260413-v5.log`에서 error/warn 스캔 중 발견한 반복 패턴 2건을 정리합니다.

### 1. Keeper `TurnBudgetExhausted` WARN → INFO
- 파일: `lib/keeper/keeper_unified_turn.ml:2268-2276`
- 같은 분기 주석이 이미 "Do NOT increment turn\_failures — this is not a crash. The keeper made progress and saved a checkpoint."로 정상 흐름임을 명시.
- 직후 `MutationBoundaryReached` 분기는 동일한 "checkpoint saved — will resume next cycle" 메시지를 `Log.Keeper.info`로 찍음 → 같은 개념인데 레벨만 달랐음.
- 라이브 로그에서 29개 WARN 중 **13건**이 이 라인이라 시그널/노이즈 비율이 크게 악화되어 있었음.

### 2. `coord_utils_ops.read_json_local` blank 파일 WARN 제거
- 파일: `lib/coord/coord_utils_ops.ml:116-128`
- 빈 keeper agent JSON(`keeper-poe-agent.json`, `keeper-uranium666-agent.json`)이 그냥 존재하는 것만으로 `Blank input data` WARN이 매 사이클 발생.
- 같은 파일의 `read_json_root`(143행)는 이미 `trimmed = ""`이면 조용히 `Assoc []`로 처리.
- 두 헬퍼의 시맨틱을 동일화: blank file → silent `Assoc []`, 진짜 malformed JSON → 기존대로 WARN.

## Dogfooding

`dune build --root .` 통과. 기능 변경 없음(로그 레벨/빈 파일 취급만).

## Test plan
- [ ] CI green
- [ ] 머지 후 라이브 로그에서 해당 두 라인이 INFO 또는 무음으로 내려가는지 확인

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>