### PR TITLE
fix(board): accept body alias + auto-fill author on masc_board_post

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -671,14 +671,14 @@ let handle_hearth_list _args =
 
 let tool_post_create : Types.tool_schema = {
   name = "masc_board_post";
-  description = "Create a direct/manual post on the MASC internal board for sharing updates, questions, or knowledge with other agents. Keeper and internal automation surfaces use narrower adapters.";
+  description = "Create a post on the MASC internal board. Pass either `body` or `content` (both accepted — `body` wins if both present). `author` is auto-filled from the caller's agent identity when omitted; keepers never need to pass it.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
       ("title", `Assoc [("type", `String "string"); ("description", `String "Optional post title")]);
-      ("body", `Assoc [("type", `String "string"); ("description", `String "Canonical visible body text")]);
-      ("content", `Assoc [("type", `String "string"); ("description", `String "Post content (max 4000 chars)")]);
-      ("author", `Assoc [("type", `String "string"); ("description", `String "Author name")]);
+      ("body", `Assoc [("type", `String "string"); ("description", `String "Post body text (preferred alias for `content`)")]);
+      ("content", `Assoc [("type", `String "string"); ("description", `String "Post body text (alternative to `body`, max 4000 chars)")]);
+      ("author", `Assoc [("type", `String "string"); ("description", `String "Author name. Auto-filled from caller's agent_name when omitted.")]);
       ("meta", `Assoc [("type", `String "object"); ("description", `String "Optional structured operational metadata")]);
       ("classification_reason", `Assoc [("type", `String "string"); ("description", `String "Optional explicit classification rationale; persisted into meta and surfaced by the dashboard")]);
       ("judgment", `Assoc [("type", `String "object"); ("description", `String "Optional structured LLM judgment metadata. Use summary/reason/confidence keys when you want the board to retain your classification rationale")]);
@@ -687,7 +687,10 @@ let tool_post_create : Types.tool_schema = {
       ("hearth", `Assoc [("type", `String "string"); ("description", `String "Topic hearth name (e.g. webrtc, code-review)")]);
       ("thread_id", `Assoc [("type", `String "string"); ("description", `String "Linked conversation thread ID")]);
     ]);
-    ("required", `List [`String "content"; `String "author"]);
+    (* No [required] — handler enforces: body|content must be non-empty,
+       and author is auto-injected via Tool_dispatch pre-hook for keepers.
+       Schema-level required=[content,author] rejected callers who used
+       {title,body} (keeper prompt default) before the handler could run. *)
   ];
 }
 

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -29,8 +29,38 @@ let extract_board_post_id (message : string) =
   | Not_found | Invalid_argument _
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
 
+(** Fill [author] from the caller's agent identity when the arg is absent or
+    blank. Keepers, the HTTP surface, and autonomous callers routinely omit
+    [author] — we used to reject those calls at pre-hook validation, which
+    forced every caller to know about the legacy schema field. Canonical
+    identity lives in [agent_name]; mirror it into the arg object so the
+    downstream [Tool_board.handle_post_create] author check passes. *)
+let ensure_board_post_author ~agent_name arguments =
+  match arguments with
+  | `Assoc fields ->
+    let existing =
+      match List.assoc_opt "author" fields with
+      | Some (`String s) -> String.trim s
+      | _ -> ""
+    in
+    if existing <> "" && existing <> "anonymous" then arguments
+    else
+      let injected = String.trim agent_name in
+      if injected = "" then arguments
+      else
+        let stripped =
+          List.filter (fun (k, _) -> k <> "author") fields
+        in
+        `Assoc (("author", `String injected) :: stripped)
+  | _ -> arguments
+
 let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~sw ~clock ~name =
-  ignore (config, agent_name, state, sw, clock);
+  ignore (config, state, sw, clock);
+  let arguments =
+    match name with
+    | "masc_board_post" -> ensure_board_post_author ~agent_name arguments
+    | _ -> arguments
+  in
   let arg_get_string key default =
     Safe_ops.json_string ~default key arguments in
   let arg_get_int key default =

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -752,6 +752,11 @@ let tool_arguments fixture (schema : Types.tool_schema) =
           [ "source_text"; "max_attempts"; "working_dir" ]
       | "masc_keeper_msg" ->
           [ "timeout_sec" ]
+      | "masc_board_post" ->
+          (* Schema no longer requires content|author (both are validated at
+             the handler layer so body/content aliases both work). Matrix
+             test still needs to supply body so board_core accepts it. *)
+          [ "body" ]
       | _ -> []
     in
     List.sort_uniq String.compare (required @ optional)


### PR DESCRIPTION
## Symptom (observed in live server log)

\`\`\`
[2026-04-16 00:17:52] tool_input_validation rejected masc_board_post: Your call to "masc_board_post":
{"title":"Tool_name Variant 리팩터링 진행 상황 + 후속 작업","body":"..."}

Errors (fix these and call again):
  "content": MISSING (required: string)
  "author": MISSING (required: string)
\`\`\`

Keeper (e.g. masc-improver) tried to post to the board with \`{title, body}\`. The handler actually accepts \`body\` as an alias for \`content\` and auto-injects \`author\` from the agent identity, but the pre-hook validation (driven by the schema's \`required\`) rejected the call before the handler could run.

## Root cause

Two drift points between schema and handler:

1. \`tool_board.ml\` declared \`required: [content, author]\` but the handler logic at \`handle_post_create\` already implements:
   - \`body\` wins over \`content\` (line 317-318)
   - \`author = None / "" / "anonymous"\` → clear error (line 344-345)
2. \`tool_inline_dispatch_extra.ml\` received \`agent_name\` as a dispatch param but never propagated it into the args, so keepers always had to remember to include \`author\`.

## Fix

### \`lib/tool_board.ml\`
- Drop \`required: [content, author]\` from \`masc_board_post\` schema.
- Keep handler's layered checks (body|content non-empty, author non-empty).
- Update property descriptions so both \`body\` and \`content\` are documented as valid primary fields.

### \`lib/tool_inline_dispatch_extra.ml\`
- New \`ensure_board_post_author ~agent_name\` helper. Called before the dispatcher reads args. Injects \`agent_name → author\` when the arg is absent or blank. Leaves explicit non-empty author untouched.
- Pure args-transform, idempotent.

### \`test/test_mcp_tool_matrix_cases.ml\`
- Matrix test was passing \`required_fields schema\` only; with schema \`required\` now empty, masc_board_post got \`{}\` and failed at \`board_core\` \"Content cannot be empty\". Add \"body\" to the optional-args list for this tool so the test still covers the success path.

## Behavior matrix

| Call shape | Before | After |
|---|---|---|
| \`{title, body}\` (keeper default) | ❌ pre-hook rejects | ✅ body→content, author auto-injected |
| \`{content, author}\` (explicit legacy) | ✅ | ✅ |
| \`{}\` (minimal) | ❌ schema reject | ❌ handler: body|content required |
| HTTP POST /api/v1/tools/masc_board_post \`{body}\` | ❌ pre-hook reject | ✅ after caller auth fills agent_name |

## Test plan

- [x] \`dune build --root .\` clean
- [x] \`test_mcp_tool_matrix.exe\` — matrix pass (2/2)
- [ ] Full \`dune runtest --root .\` — running (this is a slow suite; will confirm before Ready)
- [ ] Deploy + observe: keeper board_post calls no longer rejected in log