### PR TITLE
fix(dashboard): dedup cache timeout WARN in bg-revalidate path

### DIFF
--- a/lib/dashboard/dashboard_cache.ml
+++ b/lib/dashboard/dashboard_cache.ml
@@ -209,8 +209,15 @@ let get_or_compute_eio ?wait_timeout_sec key ~ttl compute =
                 key);
           Eio.Condition.broadcast cond
         | exception exn ->
-          Log.Dashboard.warn "cache bg-revalidate failed (%s): %s"
-            key (Printexc.to_string exn);
+          (* Compute_timeout was already logged by
+             [get_or_compute_with_timeout] at WARN; suppress the outer
+             duplicate so one timeout does not produce two WARN lines.
+             Other exceptions still surface here. *)
+          (match exn with
+           | Compute_timeout _ -> ()
+           | _ ->
+             Log.Dashboard.warn "cache bg-revalidate failed (%s): %s"
+               key (Printexc.to_string exn));
           Eio.Mutex.use_rw ~protect:true mu (fun () ->
             match Hashtbl.find_opt table key with
             | Some (Computing { cond = c; _ }) when c == cond ->


### PR DESCRIPTION
## 요약

라이브 로그에서 발견한 대시보드 캐시 timeout 이벤트가 한 번의 timeout에 WARN 두 줄을 찍는 중복 로그를 제거합니다.

## 현상

```text
[WARN] [Dashboard] cache compute timeout: shell:coord=/Users/.../me:workspace=/Users/.../me (8s)
[WARN] [Dashboard] cache bg-revalidate failed (shell:coord=/Users/.../me:workspace=/Users/.../me): Masc_mcp.Dashboard_cache.Compute_timeout("shell:coord=...", 0)
```

- 안쪽: ``get_or_compute_with_timeout``(lib/dashboard/dashboard_cache.ml:362/372)가 timeout을 감지하고 WARN 찍고 ``Compute_timeout`` 예외 raise.
- 바깥쪽: ``get_or_compute_eio`` 의 bg-revalidate ``exception exn`` 핸들러(209-213)가 같은 예외를 잡고 ``bg-revalidate failed`` WARN을 다시 찍음. 메시지는 새로운 정보 없음.

## 수정

``Compute_timeout`` 예외만 pattern match로 분기해서 바깥 WARN을 생략. 다른 모든 예외는 그대로 WARN 유지.

stale entry 복구, backoff grace 계산, ``Eio.Condition.broadcast`` 는 전부 그대로 수행.

## 참고

``lib/server/server_dashboard_http_core.ml:800`` 주석에 이미 이 노이즈 패턴이 known issue로 기록되어 있고 ``meta_cognition_summary_ttl`` 로 부분 완화된 상태. 이 PR은 TTL 조정으로 덮지 못한 잔여 케이스(``shell:coord=...``)를 로그 레벨에서 닫습니다.

## Test plan
- [ ] CI green
- [ ] 머지 후 라이브 로그에서 ``cache bg-revalidate failed`` WARN이 ``Compute_timeout`` 케이스에선 사라지고 ``cache compute timeout`` WARN만 남는지 확인.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>