### PR TITLE
[codex] Keep social_model off public OAS surface

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -125,6 +125,11 @@ let removed_keeper_input_key_names =
     
   ]
 
+let non_public_keeper_input_key_names =
+  [
+    "social_model";
+  ]
+
 let removed_keeper_msg_input_key_names =
   [
     "goal";
@@ -165,15 +170,24 @@ let present_json_keys (keys : string list) (json : Yojson.Safe.t) : string list 
   | _ -> []
 
 let reject_removed_keeper_input_keys ~tool_name (args : Yojson.Safe.t) =
-  let present = present_json_keys removed_keeper_input_key_names args in
-  match present with
-  | [] -> Ok ()
-  | fields ->
+  let non_public = present_json_keys non_public_keeper_input_key_names args in
+  match non_public with
+  | _ :: _ as fields ->
       Error
         (Printf.sprintf
-           "removed keeper args for %s: %s. Keepers are always-on by definition."
+           "non-public keeper args for %s: %s. These keeper runtime internals are not part of the public MCP/OAS surface."
            tool_name
            (String.concat ", " fields))
+  | [] ->
+      let present = present_json_keys removed_keeper_input_key_names args in
+      match present with
+      | [] -> Ok ()
+      | fields ->
+          Error
+            (Printf.sprintf
+               "removed keeper args for %s: %s. Keepers are always-on by definition."
+               tool_name
+               (String.concat ", " fields))
 
 let reject_removed_keeper_msg_input_keys ~tool_name (args : Yojson.Safe.t) =
   let present = present_json_keys removed_keeper_msg_input_key_names args in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -134,6 +134,11 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         ~preferred:p.tool_denylist_opt
         ~fallback:p.profile_defaults.tool_denylist
     in
+    let social_model =
+      p.profile_defaults.social_model
+      |> Option.value ~default:default_social_model
+      |> Keeper_social_model.normalize_social_model
+    in
     
     let will =
       Option.value
@@ -235,8 +240,8 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
         short_goal;
         mid_goal;
         long_goal;
-        
-        social_model = default_social_model;
+
+        social_model;
         cascade_name = (match p.profile_defaults.cascade_name with
           | Some name -> name
           | None -> Keeper_config.default_cascade_name);

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -65,6 +65,14 @@ let normalize_cascade_name_opt = function
   | None -> None
   | Some raw -> Some (Keeper_cascade_profile.canonicalize raw)
 
+let normalize_social_model_opt = function
+  | None -> None
+  | Some raw -> (
+      match Keeper_social_model_types.model_id_of_string raw with
+      | Some model_id ->
+          Some (Keeper_social_model_types.model_id_to_string model_id)
+      | None -> None)
+
 let lower_string_list_opt = function
   | [] -> None
   | xs -> Some (List.map String.lowercase_ascii xs)
@@ -151,6 +159,7 @@ type keeper_profile_defaults = {
   (* Telemetry Feedback — inject behavioral stats into keeper context *)
   telemetry_feedback_enabled : bool option;
   telemetry_feedback_window_hours : int option;
+  social_model : string option;
   cascade_name : string option;
   models : string list option;
   (* Turn budget overrides. None = inherit env default
@@ -197,6 +206,7 @@ let empty_keeper_profile_defaults = {
   work_discovery_guidance = None;
   telemetry_feedback_enabled = None;
   telemetry_feedback_window_hours = None;
+  social_model = None;
   max_turns_per_call = None;
   max_turns_per_call_scheduled_autonomous = None;
   cascade_name = None;
@@ -278,6 +288,19 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
                      raw))
         | None -> Ok ())
   in
+  let result =
+    Result.bind result (fun () ->
+        match str "social_model" with
+        | Some raw -> (
+            match normalize_social_model_opt (Some raw) with
+            | Some _ -> Ok ()
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "invalid social_model '%s' (allowed: bdi_speech_v1, magentic_ledger_v1)"
+                     raw))
+        | None -> Ok ())
+  in
   Result.map
     (fun () ->
       {
@@ -336,6 +359,7 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
         max_turns_per_call = int_ "max_turns_per_call";
         max_turns_per_call_scheduled_autonomous =
           int_ "max_turns_per_call_scheduled_autonomous";
+        social_model = normalize_social_model_opt (str "social_model");
         cascade_name = normalize_cascade_name_opt (str "cascade_name");
         models =
           (match strs "models" with
@@ -471,6 +495,22 @@ let load_keeper_profile_defaults_from_persona name : keeper_profile_defaults =
                 max_turns_per_call_scheduled_autonomous =
                   Safe_ops.json_int_opt
                     "max_turns_per_call_scheduled_autonomous" keeper_json;
+                social_model =
+                  (match
+                     normalize_social_model_opt
+                       (Safe_ops.json_string_opt "social_model" keeper_json)
+                   with
+                  | Some _ as normalized -> normalized
+                  | None -> (
+                      match
+                        Safe_ops.json_string_opt "social_model" keeper_json
+                      with
+                      | Some raw ->
+                          Log.Keeper.warn
+                            "persona profile %s has invalid social_model '%s'; ignoring"
+                            path raw;
+                          None
+                      | None -> None));
                 cascade_name =
                   normalize_cascade_name_opt
                     (Safe_ops.json_string_opt "cascade_name" keeper_json);
@@ -530,6 +570,7 @@ let merge_keeper_profile_defaults
     telemetry_feedback_window_hours =
       prefer overlay.telemetry_feedback_window_hours
         base.telemetry_feedback_window_hours;
+    social_model = prefer overlay.social_model base.social_model;
     cascade_name = prefer overlay.cascade_name base.cascade_name;
     models = prefer overlay.models base.models;
     max_turns_per_call = prefer overlay.max_turns_per_call base.max_turns_per_call;

--- a/test/test_keeper_runtime_config_ssot.ml
+++ b/test/test_keeper_runtime_config_ssot.ml
@@ -597,6 +597,47 @@ tool_preset = "social"
       check string "cascade_name reset to keeper default"
         Keeper_config.default_cascade_name updated.cascade_name
 
+let test_social_model_not_resynced_from_declarative_defaults () =
+  with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
+  with_config_dir @@ fun config_dir ->
+  Fs_compat.clear_fs ();
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let keeper_name = "social-model-owner-test" in
+  let keepers_toml_dir = Filename.concat config_dir "keepers" in
+  Unix.mkdir keepers_toml_dir 0o755;
+  write_file
+    (Filename.concat keepers_toml_dir (keeper_name ^ ".toml"))
+    {|[keeper]
+goal = "TOML goal"
+social_model = "magentic_ledger_v1"
+|};
+  let config = Coord.default_config room_dir in
+  let initial_meta =
+    match
+      Keeper_types.meta_of_json
+        (`Assoc
+          [
+            ("name", `String keeper_name);
+            ("agent_name", `String keeper_name);
+            ("trace_id", `String "trace-social-model-owner");
+            ("goal", `String "stale goal");
+            ("social_model", `String "bdi_speech_v1");
+          ])
+    with
+    | Ok meta -> meta
+    | Error e -> fail ("meta_of_json failed: " ^ e)
+  in
+  (match Keeper_types.write_meta ~force:true config initial_meta with
+  | Error e -> fail ("write_meta failed: " ^ e)
+  | Ok () -> ());
+  match Keeper_runtime.ensure_keeper_meta config keeper_name with
+  | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
+  | Ok updated ->
+      check string "goal resynced from TOML" "TOML goal" updated.Keeper_types.goal;
+      check string "social_model remains keeper-owned" "bdi_speech_v1"
+        updated.social_model
+
 (** Test: room presence sync updates stale agent capabilities from live keeper meta. *)
 let test_room_presence_syncs_capabilities () =
   with_temp_dir "keeper-config-ssot-room" @@ fun room_dir ->
@@ -755,6 +796,10 @@ let () =
             "declarative keepers reset stale live cascade_name to default"
             `Quick
             test_cascade_defaults_resync;
+          test_case
+            "declarative defaults do not resync social_model"
+            `Quick
+            test_social_model_not_resynced_from_declarative_defaults;
           test_case
             "room presence sync overwrites stale agent capabilities"
             `Quick

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -3,6 +3,16 @@ open Alcotest
 module TL = Masc_mcp.Keeper_toml_loader
 module KTP = Masc_mcp.Keeper_types_profile
 
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
 (* ================================================================ *)
 (* TOML parser tests                                                 *)
 (* ================================================================ *)
@@ -418,6 +428,7 @@ goal = "analyze logs"
 short_goal = "current session"
 mid_goal = "build patterns"
 long_goal = "continuous improvement"
+social_model = "magentic_ledger_v1"
 will = "detect issues"
 needs = "log access"
 desires = "low false positives"
@@ -435,12 +446,35 @@ policy_voice_enabled = false
     | Ok d ->
       check (option string) "persona_name" (Some "analyst") d.persona_name;
       check (option string) "goal" (Some "analyze logs") d.goal;
+      check (option string) "social_model" (Some "magentic_ledger_v1")
+        d.social_model;
       check (option string) "will" (Some "detect issues") d.will;
       check int "mention_targets" 2 (List.length d.mention_targets);
       check (option bool) "proactive" (Some true) d.proactive_enabled;
       check (option bool) "room signal prompt" (Some true)
         d.room_signal_prompt_enabled;
       check (option bool) "policy_voice" (Some false) d.policy_voice_enabled
+
+let test_profile_rejects_invalid_social_model () =
+  let input = {|
+[keeper]
+goal = "test"
+social_model = "experimental_v99"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+      (match KTP.profile_defaults_of_toml doc with
+       | Ok _ -> fail "expected invalid social_model error"
+       | Error msg ->
+           check bool "mentions invalid social_model" true
+             (try
+                ignore
+                  (Str.search_forward
+                     (Str.regexp_string "invalid social_model")
+                     msg 0);
+                true
+              with Not_found -> false))
 
 let test_profile_rejects_removed_model_keys () =
   let input = {|
@@ -770,6 +804,35 @@ let test_persona_resolver_defaults_to_research_tool_preset () =
       check string "persona default tool_preset" "research"
         (Yojson.Safe.Util.to_string tool_preset)
 
+let test_persona_resolver_rejects_non_public_social_model_arg () =
+  with_personas_dir @@ fun personas_dir ->
+  let persona_dir = Filename.concat personas_dir "probe" in
+  mkdir_p persona_dir;
+  write_file
+    (Filename.concat persona_dir "profile.json")
+    {|
+{
+  "name": "Probe",
+  "keeper": {
+    "goal": "test persona keeper"
+  }
+}
+|};
+  match
+    Masc_mcp.Keeper_exec_persona.resolved_keeper_args_from_persona
+      (`Assoc
+        [
+          ("persona_name", `String "probe");
+          ("social_model", `String "magentic_ledger_v1");
+        ])
+  with
+  | Ok _ -> fail "expected non-public social_model rejection"
+  | Error e ->
+      check bool "mentions non-public keeper args" true
+        (Str.string_match (Str.regexp_string "non-public keeper args") e 0
+         || contains_substring e "non-public keeper args");
+      check bool "mentions social_model" true (contains_substring e "social_model")
+
 (* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
@@ -836,6 +899,8 @@ let () =
         [
           test_case "minimal" `Quick test_profile_minimal;
           test_case "full" `Quick test_profile_full;
+          test_case "rejects invalid social_model" `Quick
+            test_profile_rejects_invalid_social_model;
           test_case "musician soul_profile maps to relationship" `Quick
             test_profile_rejects_removed_model_keys;
           test_case "rejects removed initiative keys" `Quick
@@ -865,5 +930,7 @@ let () =
           test_case "skips bad files" `Quick test_discover_skips_bad_files;
           test_case "persona profile canonicalizes soul_profile" `Quick
             test_persona_resolver_defaults_to_research_tool_preset;
+          test_case "persona resolver rejects non-public social_model arg" `Quick
+            test_persona_resolver_rejects_non_public_social_model_arg;
         ] );
     ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -83,6 +83,10 @@ let () =
           Alcotest.test_case "keeper status defaults name to caller" `Quick
             Test_operator_control_keeper
             .test_keeper_status_defaults_name_to_caller;
+          Alcotest.test_case "keeper up rejects non-public social_model arg"
+            `Quick
+            Test_operator_control_keeper
+            .test_keeper_up_rejects_non_public_social_model_arg;
           Alcotest.test_case "keeper status accepts agent alias" `Quick
             Test_operator_control_keeper
             .test_keeper_status_accepts_agent_name_alias;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -157,6 +157,47 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       Alcotest.(check bool) "keepalive running false" false
         Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool))
 
+let test_keeper_up_rejects_non_public_social_model_arg () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_registry.clear ();
+      Keeper_runtime.reset_test_state base_dir;
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+          net = None;
+        }
+      in
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String "social-model-keeper");
+                ("goal", `String "Reject social model override");
+                ("social_model", `String "magentic_ledger_v1");
+                ("proactive_enabled", `Bool false);
+                ("autoboot_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up rejected" false ok;
+      Alcotest.(check bool) "mentions non-public keeper args" true
+        (contains_substring body "non-public keeper args");
+      Alcotest.(check bool) "mentions social_model" true
+        (contains_substring body "social_model"))
+
 let test_keeper_status_defaults_name_to_caller () =
   Eio_main.run @@ fun env ->
   ensure_fs env;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -391,9 +391,19 @@ let test_masc_spawn_schema () =
 
 (* test_masc_runtime_verify_schema removed: tool pruned *)
 
-(* test_masc_persona_list_schema and test_masc_keeper_create_from_persona_schema
-   removed: persona concept deleted, schema fields
-   policy_voice_enabled/policy_shell_mode/initiative_* removed in #2607. *)
+(* test_masc_persona_list_schema removed: persona list coverage is trivial. *)
+
+let test_masc_keeper_create_from_persona_schema () =
+  match find_tool "masc_keeper_create_from_persona" with
+  | None -> Alcotest.fail "masc_keeper_create_from_persona not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has persona_name" true
+            (List.mem_assoc "persona_name" props);
+          Alcotest.(check bool) "omits social_model" false
+            (List.mem_assoc "social_model" props)
+      | None -> Alcotest.fail "masc_keeper_create_from_persona missing properties"
 
 let test_masc_keeper_up_schema () =
   match find_tool "masc_keeper_up" with
@@ -407,6 +417,8 @@ let test_masc_keeper_up_schema () =
             (List.mem_assoc "mid_goal" props);
           Alcotest.(check bool) "has long_goal" true
             (List.mem_assoc "long_goal" props);
+          Alcotest.(check bool) "omits social_model" false
+            (List.mem_assoc "social_model" props);
           Alcotest.(check bool) "has autoboot_enabled" true
             (List.mem_assoc "autoboot_enabled" props);
           Alcotest.(check bool) "omits models" false
@@ -683,6 +695,8 @@ let () =
       Alcotest.test_case "spawn" `Quick test_masc_spawn_schema;
     ];
     "keeper_runtime_tools", [
+      Alcotest.test_case "keeper-create-from-persona" `Quick
+        test_masc_keeper_create_from_persona_schema;
       Alcotest.test_case "keeper-up" `Quick
         test_masc_keeper_up_schema;
       Alcotest.test_case "keeper-msg" `Quick


### PR DESCRIPTION
## Summary
- keep `social_model` as keeper-internal metadata seeded from persona/TOML defaults during creation
- remove `social_model` from the public `masc_keeper_up` and `masc_keeper_create_from_persona` schemas
- reject `social_model` when it is passed through public keeper tool inputs, and add regression coverage for that boundary

## Why
`social_model` is an internal keeper runtime concept. The public MCP/OAS surface should not know or configure it directly. This keeps OAS separate from keeper social-model internals while preserving declarative seeding from keeper-owned config.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/social-model-ownership test/test_keeper_toml.exe test/test_keeper_runtime_config_ssot.exe test/test_operator_control.exe test/test_tools_coverage.exe`
- `./_build/default/test/test_keeper_toml.exe`
- `./_build/default/test/test_keeper_runtime_config_ssot.exe`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_tools_coverage.exe`

Refs #7362