### PR TITLE
fix(keeper): dedup outer ERROR on keeper cycle failure

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1153,11 +1153,20 @@ let run_keepalive_unified_turn
           with
           | Error err ->
             let e_str = Oas.Error.to_string err in
-            Log.Keeper.error "%s: keeper cycle failed: %s"
+            (* The inner [run_keeper_cycle] already emits a detailed ERROR
+               ("keeper cycle FAILED cascade=... max_context=... error=...")
+               for every Error path, so re-logging at ERROR here duplicates
+               the line for the same event. Keep a debug trace for local
+               readers; escalate to ERROR only on the fatal-environment
+               branch, which is the real signal this layer owns. *)
+            Log.Keeper.debug "%s: keeper cycle failed: %s"
               meta_after_observe.name e_str;
             if String_util.contains_substring e_str "Eio switch not available"
                || String_util.contains_substring e_str "Eio net not available"
             then begin
+              Log.Keeper.error
+                "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
+                meta_after_observe.name e_str;
               Keeper_registry.set_failure_reason
                 ~base_path:ctx.config.base_path meta_after_observe.name
                 (Some (Keeper_registry.Exception


### PR DESCRIPTION
## 증거 (오늘 system_log 2026-04-16)

janitor 단일 실패 이벤트 하나에 ERROR 라인이 2~3개 찍힙니다:

``\`
seq 15631 [ERROR] janitor: keeper cycle FAILED cascade=keeper_unified max_context=200000 latency=8959ms error=Completion contract [require_tool_use] violated...
seq 15632 [ERROR] janitor: keeper cycle failed: Completion contract [require_tool_use] violated...
``\`

- 안쪽 (``lib/keeper/keeper_unified_turn.ml:1921``) — 항상 ERROR + cascade / latency / max_context / preview까지 포함
- 바깥쪽 (``lib/keeper/keeper_keepalive.ml:1156``) — 같은 error string만 다시 ERROR로 찍음

## 수정

- 바깥쪽 passthrough ERROR → ``Log.Keeper.debug`` (정보는 유지, 중복 ERROR만 제거).
- 치명적 Eio 환경 오류(``Eio switch not available`` / ``Eio net not available``) 분기는 **이 레이어 고유의 신호**이므로 ``Log.Keeper.error "promoting to Keeper_fiber_crash: %s"``로 따로 로깅.
- ``Keeper_fiber_crash`` raise, failure reason 태깅, meta 복구 경로 모두 그대로.

## Test plan
- [ ] CI green
- [ ] 배포 후 단일 실패 이벤트에 ERROR 라인 1개만 찍히는지 확인 (``rg '"level":"ERROR".*keeper cycle' ~/.masc/logs/system_log_*.jsonl``)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>