### PR TITLE
fix(oas): silence 'no approval callback' WARN via explicit auto_approve

### DIFF
--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -415,6 +415,7 @@ let review
            ~max_turns:1
            ~temperature:Oas_worker_cascade.deterministic_temperature
            ~max_tokens:200
+           ~approval:Approval_callbacks.auto_approve
            ?sw
            ()
        )

--- a/lib/approval_callbacks.ml
+++ b/lib/approval_callbacks.ml
@@ -1,0 +1,23 @@
+(** OAS approval callbacks shared across call sites.
+
+    Kept in a standalone module (not in [Governance_pipeline]) so callers
+    like [Dashboard_operator_judge] or [Tool_deep_review] can reference
+    it without forming a dependency cycle through
+    [Operator_pending_confirm] and the governance approval queue. *)
+
+(** Always-approve callback for system-level OAS runs that are
+    explicitly trusted by MASC: judges (operator/governance),
+    auto_responder, autoresearch codegen, deep_review,
+    anti_rationalization, and the /v1/chat/completions OpenAI-compat
+    bridge.
+
+    OAS emits [WARN] "ApprovalRequired but no approval callback —
+    executing" when a run has [approval=None] and a tool is flagged as
+    ApprovalRequired. For keeper runs the correct callback is
+    [Governance_pipeline.to_oas_approval_callback] (HITL queue +
+    trifecta risk). For system runs there is no human on the other
+    side, so the correct semantics is "always Approve" — passing this
+    callback makes the trust decision explicit at the call site and
+    silences the stray WARN line. *)
+let auto_approve : Oas.Hooks.approval_callback =
+  fun ~tool_name:_ ~input:_ -> Oas.Hooks.Approve

--- a/lib/approval_callbacks.mli
+++ b/lib/approval_callbacks.mli
@@ -1,0 +1,16 @@
+(** OAS approval callbacks shared across call sites.
+
+    Kept in a standalone module (not in [Governance_pipeline]) so
+    callers like [Dashboard_operator_judge] can reference it without
+    forming a dependency cycle through [Operator_pending_confirm] and
+    the governance approval queue. *)
+
+val auto_approve : Oas.Hooks.approval_callback
+(** Always-approve callback for system-level OAS runs that are
+    explicitly trusted by MASC: judges, auto_responder, autoresearch
+    codegen, deep_review, anti_rationalization, and the OpenAI-compat
+    HTTP bridge.
+
+    See the .ml file for the full rationale. TL;DR: keeper runs should
+    use [Governance_pipeline.to_oas_approval_callback]; system runs
+    that have already decided the caller is trusted should use this. *)

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -179,6 +179,7 @@ let call_model_direct_sync ~agent_type ~prompt =
         Oas_worker.run_named ~cascade_name
           ~goal:prompt ~max_turns:1
           ~accept:model_response_is_valid ~max_tokens:500
+          ~approval:Approval_callbacks.auto_approve
           ()
       )
     with

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -147,6 +147,7 @@ let generate_code_change ~goal ~baseline ~lower_is_better ~history ~insights
           ~cascade_name:"autoresearch" ~fallback:(fun () -> 0.7))
         ~max_tokens:(Cascade_inference.resolve_max_tokens
           ~cascade_name:"autoresearch" ~fallback:(fun () -> 4096))
+        ~approval:Approval_callbacks.auto_approve
         ()
     )
   with

--- a/lib/dashboard/dashboard_governance_judge.ml
+++ b/lib/dashboard/dashboard_governance_judge.ml
@@ -311,6 +311,7 @@ let compute_judgments
     Masc_oas_bridge.run_safe ~timeout_s (fun () ->
       Oas_worker.run_named_with_masc_tools ~cascade_name:"governance_judge"
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
+        ~approval:Approval_callbacks.auto_approve
         ()
     )
   with

--- a/lib/dashboard/dashboard_operator_judge.ml
+++ b/lib/dashboard/dashboard_operator_judge.ml
@@ -242,6 +242,7 @@ let compute_judgments
     Masc_oas_bridge.run_safe ~timeout_s (fun () ->
       Oas_worker.run_named_with_masc_tools ~cascade_name:"operator_judge"
         ~goal:prompt ~masc_tools ~dispatch ~max_turns:3
+        ~approval:Approval_callbacks.auto_approve
         ()
     )
   with

--- a/lib/dune
+++ b/lib/dune
@@ -505,6 +505,7 @@
    runtime_params
    governance_registry
    governance_pipeline
+   approval_callbacks
    tool_compact
    tool_shard
    tool_shard_limits

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -121,3 +121,4 @@ val to_oas_approval_callback :
     Tools below the threshold are auto-approved.
 
     @since 2.262.0 (#5902, #5907) *)
+

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -183,6 +183,7 @@ val run_named_with_masc_tools :
   ?transport:Masc_grpc_transport.t ->
   ?yield_on_tool:bool ->
   ?compact_ratio:float ->
+  ?approval:Oas.Hooks.approval_callback ->
   ?sw:Eio.Switch.t ->
   ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   unit ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -567,6 +567,7 @@ let run_named_with_masc_tools
     ?transport
     ?(yield_on_tool = false)
     ?compact_ratio
+    ?approval
     ?sw
     ?net
     ()
@@ -582,6 +583,7 @@ let run_named_with_masc_tools
     ?wait_timeout_sec ?guardrails ?hooks ?memory
     ?tool_retry_policy
     ?compact_ratio
+    ?approval
     ?raw_trace ?on_event ?on_yield ?on_resume ?proof_ref
     ?contract
     ?transport ~yield_on_tool ?sw ?net ()

--- a/lib/server/server_openai_compat.ml
+++ b/lib/server/server_openai_compat.ml
@@ -110,6 +110,7 @@ let route_cascade ~message ~system_prompt ~max_tokens ~temperature
         ~max_turns:1
         ~temperature
         ~max_tokens
+        ~approval:Approval_callbacks.auto_approve
         ()
     )
   with

--- a/lib/tool_deep_review.ml
+++ b/lib/tool_deep_review.ml
@@ -111,6 +111,7 @@ let handle_deep_review (config : Coord.config) args : bool * string =
               ~max_turns:1
               ~temperature:0.5
               ~max_tokens:500
+              ~approval:Approval_callbacks.auto_approve
               ()
           )
         with


### PR DESCRIPTION
## Symptom

Live log, ~3 MB window = **36 WARN lines**:

\`\`\`
[WARN] oas:agent_tools: ApprovalRequired but no approval callback — executing
\`\`\`

## Root cause

7 system-level \`Oas_worker.run_named\` call sites pass \`approval=None\`. When an OAS hook flags a tool as \`ApprovalRequired\`, OAS falls through with the WARN line above.

For those callers (judges, autoresearch codegen, deep_review, auto_responder, anti_rationalization, openai-compat bridge) there is no human on the other side — MASC has already decided the call is trusted — but \`None\` misrepresents that decision as a config gap.

## Fix

- **New module \`lib/approval_callbacks.ml\`** with \`auto_approve\`: trivial always-Approve callback. Kept standalone (not in \`Governance_pipeline\`) to avoid the dep cycle \`Dashboard_operator_judge → Governance_pipeline → Operator_pending_confirm → Dashboard_operator_judge\`.
- **Thread \`?approval\` through \`Oas_worker.run_named_with_masc_tools\`** (.ml + .mli) so MASC-tools callers can forward it to the inner \`run_named\`.
- **Inject \`Approval_callbacks.auto_approve\` at 7 call sites**:
  - \`tool_deep_review.ml\`
  - \`autoresearch_codegen.ml\`
  - \`auto_responder.ml\`
  - \`dashboard_operator_judge.ml\`
  - \`dashboard_governance_judge.ml\`
  - \`anti_rationalization.ml\`
  - \`server_openai_compat.ml\`

## What this does NOT change

Keeper runs keep \`Governance_pipeline.to_oas_approval_callback\` (HITL queue + trifecta risk). Only the trusted system paths are auto-approve.

## Evidence

From /loop iteration 1 (WARN/ERROR aggregation across ~611 log entries), this was the #4 highest-frequency pattern and the only top-6 one that's a pure mislabel (not a real failure).

| # | Count | Pattern | Fixable? |
|---|---|---|---|
| 1 | 115 | \`Rate limited\` (external provider) | No |
| 2 | 95 | cascade fallback (result of #1) | No |
| 3 | 50 | \`[MCP] tool call failed\` (mixed) | Partial |
| **4** | **36** | **\`ApprovalRequired but no callback\`** | **This PR** |
| 5 | 30 | janitor \`require_tool_use\` (prompt issue) | Separate |
| 6 | 25 | \`masc_code_edit returned error\` (symptom) | Separate |

## Test plan

- [x] \`dune build --root .\` clean
- [ ] Full \`dune runtest --root .\` — running
- [ ] Deploy + observe: 36/~3MB recurrence drops to 0