### PR TITLE
fix(keeper): dedup tool_use_failure WARN paired with tool error WARN

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -441,7 +441,13 @@ let make_hooks
     post_tool_use_failure = Some (function
       | Agent_sdk.Hooks.PostToolUseFailure { tool_name; error; _ } ->
         let meta = !meta_ref in
-        Log.Keeper.warn "keeper:%s tool_use_failure: %s — %s"
+        (* The richer counterpart
+             "tool <name> returned error result (n/max): <detail>"
+           is already emitted at WARN by keeper_tools_oas before this hook
+           runs. Emitting a second WARN here with the same error content
+           produces paired duplicate lines per tool failure. Keep a debug
+           trace for hook-chain readers; the metric below still records. *)
+        Log.Keeper.debug "keeper:%s tool_use_failure: %s — %s"
           meta.name tool_name error;
         Heuristic_metrics.record {
           module_name = "keeper_hooks_oas";


### PR DESCRIPTION
## 증거 (2026-04-16 system_log JSONL)

모든 keeper 도구 실패가 1-2 seq 간격으로 같은 error content를 두 WARN으로 찍습니다.

``\`
seq 6305  Keeper WARN  tool masc_code_git returned error result (1/3): {...}
seq 6307  Keeper WARN  keeper:masc-improver tool_use_failure: masc_code_git — {...}

seq 6375  Keeper WARN  tool masc_code_git returned error result (1/3): {...}
seq 6377  Keeper WARN  keeper:nick0cave tool_use_failure: masc_code_git — {...}
``\`

- Site A (``lib/keeper/keeper_tools_oas.ml:250``) — 도구 실행 중 WARN, ``n/max`` 연속 실패 카운터 + detail.
- Site B (``lib/keeper/keeper_hooks_oas.ml:444``) — OAS ``post_tool_use_failure`` 훅에서 같은 keeper/tool/error만 다시 WARN.

오늘 로그에서 A/B 쌍이 **1:1로 73쌍** 확인됨 (41 + 32). B는 A의 부분 집합.

## 수정

- B를 ``Log.Keeper.debug``로 강등.
- ``Heuristic_metrics.record`` 는 그대로 유지 → 메트릭 파이프라인 영향 없음.
- 도구 실패 1건당 WARN 2 → 1.

## 이번 루프 누적 효과

이 PR까지 합하면 라이브 로그 노이즈 제거:
- ``turn budget exhausted`` WARN → INFO (#7444)
- ``read_json_local`` blank file WARN 제거 (#7444)
- ``cache bg-revalidate failed`` timeout 중복 WARN 제거 (#7446)
- ``keeper cycle failed`` outer ERROR 중복 제거 (#7451, pending)
- ``tool_use_failure`` WARN 중복 제거 (이 PR)

## Test plan
- [ ] CI green
- [ ] 배포 후 tool failure 1건당 WARN 1줄만 남는지 확인 (``rg 'tool_use_failure' ~/.masc/logs/system_log_*.jsonl`` 와 ``returned error result`` 카운트가 유사해야 함).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>