### PR TITLE
feat(keeper): reversibility-based gh op classifier (R0/R1/R2)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1040,57 +1040,98 @@ let handle_keeper_shell
         "cmd is required for gh op. Good: cmd='pr list --state open'. Bad: cmd=''."
     else
       let allowed_orgs = Keeper_tool_policy.git_clone_allowed_orgs () in
-      (match Worker_dev_tools.validate_gh_command ~allowed_orgs cmd_str with
-       | Error reason ->
+      (* Reversibility gate (Thariq / Anthropic auto-mode principle):
+         - R0 read / R1 reversible mutation: allowed; R1 is audit-logged.
+         - R2 irreversible: rejected with a structured-tool hint so the
+           LLM can self-recover toward keeper_pr_submit / operator
+           approval without a second round-trip. *)
+      let reversibility = Worker_dev_tools.classify_gh_reversibility cmd_str in
+      (match reversibility with
+       | Worker_dev_tools.R2_Irreversible ->
+         let hint =
+           Option.value
+             (Worker_dev_tools.structured_tool_hint_for_r2 cmd_str)
+             ~default:
+               "This gh command mutates state that gh itself cannot \
+                restore. Route through a structured keeper tool \
+                (keeper_pr_submit for PR ops) or post on the board \
+                for operator approval."
+         in
+         Log.Keeper.warn
+           "keeper_shell op=gh R2 blocked: %s (keeper=%s)"
+           cmd_str meta.name;
          Yojson.Safe.to_string
            (`Assoc
                [ "ok", `Bool false
                ; "op", `String op
-               ; "error", `String "gh_command_blocked"
-               ; "reason", `String reason
-               ; "hint", `String
-                   "Run `gh --help` shapes: pr/issue/repo/release/label/run/\
-                    workflow/api/project/ruleset/search/status/cache/gist. \
-                    auth/secret/ssh-key are blocked."
+               ; "command", `String (Printf.sprintf "gh %s" cmd_str)
+               ; "error", `String "gh_irreversible_blocked"
+               ; "reversibility", `String "R2"
+               ; "hint", `String hint
                ])
-       | Ok () ->
-         (match cwd_target () with
-          | Error e -> path_error e
-          | Ok cwd ->
-            let full_cmd =
-              Keeper_gh_env.with_env config
-                (Printf.sprintf "gh %s 2>&1" cmd_str)
-            in
-            let st, out =
-              Process_eio.run_argv_with_status ~cwd ~timeout_sec
-                [ "bash"; "-lc"; full_cmd ]
-            in
-            if process_status_is_timeout st then
-              Yojson.Safe.to_string
-                (`Assoc
-                    [ "ok", `Bool false
-                    ; "op", `String op
-                    ; "cwd", `String cwd
-                    ; "command", `String (Printf.sprintf "gh %s" cmd_str)
-                    ; "error", `String "gh_command_timed_out"
-                    ; "timeout_sec", `Float timeout_sec
-                    ; "status", Keeper_alerting_path.process_status_to_json st
-                    ; "output", `String out
-                    ; "hint", `String
-                        "gh network call exceeded timeout_sec. Retry with a \
-                         larger value (e.g. timeout_sec=60) or narrow the \
-                         query (--state, --limit, --json)."
-                    ])
-            else
-              Yojson.Safe.to_string
-                (`Assoc
-                    [ "ok", `Bool (st = Unix.WEXITED 0)
-                    ; "op", `String op
-                    ; "cwd", `String cwd
-                    ; "command", `String (Printf.sprintf "gh %s" cmd_str)
-                    ; "status", Keeper_alerting_path.process_status_to_json st
-                    ; "output", `String out
-                    ])))
+       | R0_Read | R1_Reversible ->
+         (match Worker_dev_tools.validate_gh_command ~allowed_orgs cmd_str with
+          | Error reason ->
+            Yojson.Safe.to_string
+              (`Assoc
+                  [ "ok", `Bool false
+                  ; "op", `String op
+                  ; "error", `String "gh_command_blocked"
+                  ; "reason", `String reason
+                  ; "hint", `String
+                      "Run `gh --help` shapes: pr/issue/repo/release/label/run/\
+                       workflow/api/project/ruleset/search/status/cache/gist. \
+                       auth/secret/ssh-key are blocked."
+                  ])
+          | Ok () ->
+            (match cwd_target () with
+             | Error e -> path_error e
+             | Ok cwd ->
+               let reversibility_tag = match reversibility with
+                 | R0_Read -> "R0"
+                 | R1_Reversible -> "R1"
+                 | R2_Irreversible -> "R2"  (* unreachable *)
+               in
+               if reversibility = Worker_dev_tools.R1_Reversible then
+                 Log.Keeper.info
+                   "gh_audit: keeper=%s reversibility=R1 cwd=%s cmd=gh %s"
+                   meta.name cwd cmd_str;
+               let full_cmd =
+                 Keeper_gh_env.with_env config
+                   (Printf.sprintf "gh %s 2>&1" cmd_str)
+               in
+               let st, out =
+                 Process_eio.run_argv_with_status ~cwd ~timeout_sec
+                   [ "bash"; "-lc"; full_cmd ]
+               in
+               if process_status_is_timeout st then
+                 Yojson.Safe.to_string
+                   (`Assoc
+                       [ "ok", `Bool false
+                       ; "op", `String op
+                       ; "cwd", `String cwd
+                       ; "command", `String (Printf.sprintf "gh %s" cmd_str)
+                       ; "reversibility", `String reversibility_tag
+                       ; "error", `String "gh_command_timed_out"
+                       ; "timeout_sec", `Float timeout_sec
+                       ; "status", Keeper_alerting_path.process_status_to_json st
+                       ; "output", `String out
+                       ; "hint", `String
+                           "gh network call exceeded timeout_sec. Retry with a \
+                            larger value (e.g. timeout_sec=60) or narrow the \
+                            query (--state, --limit, --json)."
+                       ])
+               else
+                 Yojson.Safe.to_string
+                   (`Assoc
+                       [ "ok", `Bool (st = Unix.WEXITED 0)
+                       ; "op", `String op
+                       ; "cwd", `String cwd
+                       ; "command", `String (Printf.sprintf "gh %s" cmd_str)
+                       ; "reversibility", `String reversibility_tag
+                       ; "status", Keeper_alerting_path.process_status_to_json st
+                       ; "output", `String out
+                       ]))))
   | _ ->
     Yojson.Safe.to_string
       (`Assoc

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -596,19 +596,149 @@ let gh_allowed_commands =
     "workflow";
   ]
 
-(** Specific (command, subcommand) pairs that are always blocked
-    regardless of allowlist. These are irreversible or catastrophic.
-    Parity with the legacy [gh_dangerous_prefixes] check in
-    [keeper_exec_shell.ml] op=gh, which is being retired in favor of
-    calling [validate_gh_command] as the single source of truth. *)
-let gh_blocked_operations =
+(** Reversibility classification for gh commands.
+    Based on Thariq (Anthropic) Agent SDK workshop principle:
+    "Tools for atomic/irreversible actions; bash for reversible work."
+    + Anthropic Claude Code auto mode pattern:
+    "Safe-tool allowlist = tools that cannot modify state; everything
+    else goes to classifier; irreversible requires approval."
+
+    - [R0_Read]: no state mutation. gh view/list, api GET, status,
+      search. Free to run; only org allowlist gate.
+    - [R1_Reversible]: mutates state but recoverable via inverse op.
+      pr create/close/reopen/merge/ready/comment/edit, issue
+      create/close/reopen, label create/delete, run cancel. Allowed
+      + caller is expected to emit an audit event.
+    - [R2_Irreversible]: cannot be undone via a gh inverse op.
+      repo delete/archive/transfer/rename, release delete, secret
+      delete, auth logout/token, ssh-key delete, workflow disable,
+      api --method DELETE, graphql mutation delete*/remove*/transfer*.
+      Must route through a structured keeper tool (keeper_pr_submit,
+      etc.) that carries operator-approval semantics. *)
+type gh_reversibility =
+  | R0_Read
+  | R1_Reversible
+  | R2_Irreversible
+
+(** (command, subcommand) pairs classified as R2 irreversible.
+    Conservative: when an operation *could* leak/destroy state that
+    gh itself cannot restore, we mark it R2 even if a manual recovery
+    path exists. Examples: repo archive is technically reversible via
+    unarchive but disrupts downstream PRs; ssh-key delete is
+    re-registrable but signing/deploy keys mid-CI break. *)
+let gh_irreversible_ops =
   [
-    ("repo", "delete");
-    ("repo", "archive");
-    ("repo", "transfer");
-    ("gist", "delete");
-    ("workflow", "disable");
+    ("repo",     ["delete"; "archive"; "transfer"; "rename"]);
+    ("release",  ["delete"]);
+    ("secret",   ["delete"; "remove"]);
+    ("ssh-key",  ["delete"]);
+    ("workflow", ["disable"]);
+    ("auth",     ["logout"; "token"]);
+    ("gist",     ["delete"]);
+    ("ruleset",  ["delete"]);
   ]
+
+(** (command, subcommand) pairs classified as R1 reversible mutation.
+    The inverse operation is also a gh subcommand (pr close ↔ reopen,
+    label create ↔ delete, run cancel is always followed by rerun).
+    Allowed via op=gh but callers should audit. *)
+let gh_reversible_mutations =
+  [
+    ("pr",      ["create"; "close"; "reopen"; "merge"; "ready";
+                 "edit"; "comment"; "review"; "lock"; "unlock"]);
+    ("issue",   ["create"; "close"; "reopen"; "edit"; "comment";
+                 "lock"; "unlock"; "develop"; "pin"; "unpin"]);
+    ("label",   ["create"; "edit"; "delete"; "clone"]);
+    ("release", ["create"; "edit"; "upload"; "download"]);
+    ("run",     ["cancel"; "rerun"; "watch"]);
+    ("cache",   ["delete"]);
+    ("gist",    ["create"; "edit"; "clone"; "rename"]);
+    ("repo",    ["create"; "clone"; "fork"; "edit"; "sync"; "set-default"]);
+    ("project", ["create"; "edit"; "close"; "copy"; "link"; "unlink";
+                 "field-create"; "field-delete"; "item-add";
+                 "item-archive"; "item-delete"; "item-edit"]);
+    ("workflow", ["enable"; "run"]);
+    ("ruleset", ["create"; "edit"]);
+  ]
+
+(** Extract the HTTP method from a [gh api] invocation.
+    Returns uppercase method ("GET", "POST", "DELETE", ...) or "GET"
+    as the gh default when no --method flag is present.
+    Recognizes [-X], [--method], [-X=M], [--method=M]. *)
+let extract_gh_api_method cmd =
+  let tokens =
+    String.split_on_char ' ' (String.trim cmd)
+    |> List.filter (fun s -> s <> "")
+  in
+  let rec find = function
+    | [] -> "GET"
+    | "-X" :: m :: _ | "--method" :: m :: _ -> String.uppercase_ascii m
+    | tok :: _ when String.length tok > 9
+                    && String.sub tok 0 9 = "--method=" ->
+      String.uppercase_ascii (String.sub tok 9 (String.length tok - 9))
+    | tok :: _ when String.length tok > 3
+                    && String.sub tok 0 3 = "-X=" ->
+      String.uppercase_ascii (String.sub tok 3 (String.length tok - 3))
+    | _ :: rest -> find rest
+  in
+  find tokens
+
+(** Detect [gh api graphql] invocations that carry a destructive
+    mutation name. Uses substring match on the query body (passed via
+    -f query=... or --raw-field query=...). Conservative: unknown
+    mutation names default to R1 because GraphQL mutation semantics
+    are wide; only the destructive-verb-prefix set is R2. *)
+let gh_api_graphql_is_destructive cmd =
+  let lower = String.lowercase_ascii cmd in
+  let contains needle =
+    let nl = String.length needle in
+    let sl = String.length lower in
+    let rec scan i =
+      if i + nl > sl then false
+      else if String.sub lower i nl = needle then true
+      else scan (i + 1)
+    in
+    nl > 0 && scan 0
+  in
+  contains "graphql"
+  && (contains "deletepullrequest"
+      || contains "deleteissue"
+      || contains "deletebranch"
+      || contains "deleteref"
+      || contains "deleteproject"
+      || contains "deletebranchprotectionrule"
+      || contains "removeouterfromorganization"
+      || contains "transferrepository"
+      || contains "archiverepository")
+
+(** Classify a gh command string by state reversibility.
+    The command is the portion after "gh " — a normalized form
+    without the leading "gh" literal.
+
+    Precedence (first match wins):
+      1. top command + subcommand in [gh_irreversible_ops] → R2
+      2. [api] with [--method DELETE] or a destructive graphql
+         mutation → R2
+      3. top command + subcommand in [gh_reversible_mutations] → R1
+      4. [api] with --method POST/PUT/PATCH (or -f field flags that
+         imply non-GET) → R1
+      5. anything else → R0 (read-only default) *)
+(* [classify_gh_reversibility] is defined after [has_mutating_http_method]
+   below so we can reuse its -f/-F/--field → implicit-POST detection.
+   The forward declaration pattern keeps this section free of an
+   [let rec] cluster that would pull unrelated functions into the same
+   recursive binding. *)
+
+(** Legacy alias: kept so pre-classifier call sites still compile.
+    Equivalent to [classify_gh_reversibility cmd = R2_Irreversible]
+    for the pairs we used to block. *)
+let gh_blocked_operations =
+  List.concat_map
+    (fun (c, subs) -> List.map (fun s -> (c, s)) subs)
+    gh_irreversible_ops
+
+(* [structured_tool_hint_for_r2] is defined after [extract_gh_command_pair]
+   below (see the classifier block near the bottom of this file). *)
 
 (** Extract owner from a [--repo OWNER/NAME], [--repo=OWNER/NAME], or
     [-R OWNER/NAME] flag in a gh command string. Returns [None] if no
@@ -759,6 +889,72 @@ let has_mutating_http_method parts =
         else check rest
   in
   check parts
+
+(** Classify a gh command string by state reversibility.
+    The command is the portion after "gh " — a normalized form
+    without the leading "gh" literal.
+
+    Precedence (first match wins):
+      1. top command + subcommand in [gh_irreversible_ops] → R2
+      2. [api] with [--method DELETE] or a destructive graphql
+         mutation → R2
+      3. [api] with --method POST/PUT/PATCH, or implicit POST via
+         [-f]/[-F]/[--field]/[--raw-field] (gh auto-converts field
+         flags to POST) → R1
+      4. top command + subcommand in [gh_reversible_mutations] → R1
+      5. anything else → R0 (read-only default) *)
+let classify_gh_reversibility cmd =
+  match extract_gh_command_pair cmd with
+  | (None, _) -> R0_Read
+  | (Some command, subcmd_opt) ->
+    let command = String.lowercase_ascii command in
+    let sub =
+      Option.value ~default:"" subcmd_opt |> String.lowercase_ascii
+    in
+    let in_table table =
+      List.exists
+        (fun (c, subs) -> c = command && List.mem sub subs)
+        table
+    in
+    if in_table gh_irreversible_ops then R2_Irreversible
+    else if command = "api" then begin
+      let method_ = extract_gh_api_method cmd in
+      let parts =
+        String.split_on_char ' ' (String.trim cmd)
+        |> List.filter (fun s -> s <> "")
+      in
+      if method_ = "DELETE" then R2_Irreversible
+      else if gh_api_graphql_is_destructive cmd then R2_Irreversible
+      else if List.mem method_ ["POST"; "PUT"; "PATCH"] then R1_Reversible
+      else if has_mutating_http_method parts then R1_Reversible
+      else R0_Read
+    end
+    else if in_table gh_reversible_mutations then R1_Reversible
+    else R0_Read
+
+(** Suggested next-action hint for a rejected R2 command.
+    Returned in the gate response so small LLMs can self-recover
+    without a second operator turn. Conservative: only returns a hint
+    when the mapping is obvious; otherwise None → caller falls back
+    to a generic message. *)
+let structured_tool_hint_for_r2 cmd =
+  match extract_gh_command_pair cmd with
+  | (Some "repo", Some ("delete" | "archive" | "transfer" | "rename")) ->
+    Some "Use an operator-approved path: open a board post describing \
+          the intent and wait for operator action. No keeper tool \
+          performs repo-level destructive ops."
+  | (Some "release", Some "delete") ->
+    Some "Open a board post with release tag + reason. Release deletion \
+          requires operator approval."
+  | (Some "secret", _) | (Some "ssh-key", _) | (Some "auth", _) ->
+    Some "Credential operations are operator-only. Do not attempt via \
+          any keeper tool."
+  | (Some "api", _) ->
+    Some "Destructive gh api calls (DELETE or graphql mutation \
+          delete*/remove*/transfer*) are blocked. Use pr/issue \
+          subcommands for R1 mutations, or open a board post."
+  | _ ->
+    None
 
 (** Filter out flag-like tokens, keeping only positional args.
     Handles boolean flag bypass (e.g. "workflow -q delete"). *)

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -763,4 +763,138 @@ let () =
         Alcotest.(check (option string)) "no slash" None
           (Worker_dev_tools.extract_gh_repo_owner "pr view --repo malformed"));
     ];
+    "classify_gh_reversibility", [
+      (* R0 — read-only *)
+      Alcotest.test_case "R0: pr list" `Quick (fun () ->
+        Alcotest.(check bool) "R0" true
+          (Worker_dev_tools.classify_gh_reversibility "pr list --state open"
+           = Worker_dev_tools.R0_Read));
+      Alcotest.test_case "R0: pr view 123" `Quick (fun () ->
+        Alcotest.(check bool) "R0" true
+          (Worker_dev_tools.classify_gh_reversibility "pr view 123"
+           = Worker_dev_tools.R0_Read));
+      Alcotest.test_case "R0: issue list" `Quick (fun () ->
+        Alcotest.(check bool) "R0" true
+          (Worker_dev_tools.classify_gh_reversibility "issue list --state all"
+           = Worker_dev_tools.R0_Read));
+      Alcotest.test_case "R0: api GET (default)" `Quick (fun () ->
+        Alcotest.(check bool) "R0" true
+          (Worker_dev_tools.classify_gh_reversibility "api repos/jeong-sik/foo"
+           = Worker_dev_tools.R0_Read));
+      Alcotest.test_case "R0: status" `Quick (fun () ->
+        Alcotest.(check bool) "R0" true
+          (Worker_dev_tools.classify_gh_reversibility "status"
+           = Worker_dev_tools.R0_Read));
+      Alcotest.test_case "R0: search issues" `Quick (fun () ->
+        Alcotest.(check bool) "R0" true
+          (Worker_dev_tools.classify_gh_reversibility "search issues --sort created"
+           = Worker_dev_tools.R0_Read));
+
+      (* R1 — reversible mutation *)
+      Alcotest.test_case "R1: pr create" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "pr create --title foo --body bar"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: pr merge" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility "pr merge 123 --squash"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: issue close" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility "issue close 456"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: api --method POST" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "api --method POST repos/jeong-sik/foo/issues"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: api with -f field (implicit POST)" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "api repos/jeong-sik/foo/issues -f title=test"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: label create" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility "label create bug --color red"
+           = Worker_dev_tools.R1_Reversible));
+      Alcotest.test_case "R1: run cancel" `Quick (fun () ->
+        Alcotest.(check bool) "R1" true
+          (Worker_dev_tools.classify_gh_reversibility "run cancel 42"
+           = Worker_dev_tools.R1_Reversible));
+
+      (* R2 — irreversible *)
+      Alcotest.test_case "R2: repo delete" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "repo delete jeong-sik/foo"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: repo archive" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "repo archive jeong-sik/foo"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: repo transfer" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "repo transfer jeong-sik/foo x"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: release delete" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "release delete v1.0"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: secret delete" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "secret delete MY_TOKEN"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: ssh-key delete" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "ssh-key delete 42"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: workflow disable" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "workflow disable ci.yml"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: auth logout" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility "auth logout"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: api --method DELETE" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "api --method DELETE repos/jeong-sik/foo/issues/1"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: graphql mutation deletePullRequest" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "api graphql -f query=mutation{deletePullRequest(input:{pullRequestId:abc}){clientMutationId}}"
+           = Worker_dev_tools.R2_Irreversible));
+      Alcotest.test_case "R2: graphql mutation transferRepository" `Quick (fun () ->
+        Alcotest.(check bool) "R2" true
+          (Worker_dev_tools.classify_gh_reversibility
+             "api graphql -f query=mutation{transferRepository(input:{}){clientMutationId}}"
+           = Worker_dev_tools.R2_Irreversible));
+    ];
+    "structured_tool_hint_for_r2", [
+      Alcotest.test_case "repo delete → board-post hint" `Quick (fun () ->
+        match Worker_dev_tools.structured_tool_hint_for_r2 "repo delete x/y" with
+        | Some msg ->
+          Alcotest.(check bool) "mentions operator" true
+            (contains_substring msg "operator")
+        | None -> Alcotest.fail "expected Some hint");
+      Alcotest.test_case "credential op → operator-only hint" `Quick (fun () ->
+        match Worker_dev_tools.structured_tool_hint_for_r2 "secret delete TOK" with
+        | Some msg ->
+          Alcotest.(check bool) "mentions operator-only" true
+            (contains_substring msg "operator-only")
+        | None -> Alcotest.fail "expected Some hint");
+      Alcotest.test_case "api R2 → generic hint" `Quick (fun () ->
+        match Worker_dev_tools.structured_tool_hint_for_r2
+                "api --method DELETE repos/x/y/releases/1" with
+        | Some msg ->
+          Alcotest.(check bool) "mentions gh api" true
+            (contains_substring msg "gh api")
+        | None -> Alcotest.fail "expected Some hint");
+      Alcotest.test_case "no hint for unmapped R2" `Quick (fun () ->
+        Alcotest.(check (option string)) "none"
+          None
+          (Worker_dev_tools.structured_tool_hint_for_r2 "workflow disable x.yml"));
+    ];
   ]


### PR DESCRIPTION
## Summary

PR #7433 follow-up. gh op gate를 "allow/block" 평면에서 **state-reversibility 3-tier**로 승격.

근거:
- Thariq (Anthropic Agent SDK workshop, 112분): "Tools for atomic/irreversible actions; bash for reversible work"; "How reversible is the work is a really good intuition for what problem domains agents are good at"
- Anthropic Claude Code auto mode: safe-tool allowlist = "state 수정 못 하는 것들", 수정하는 건 classifier, 비가역은 approval
- me#814 (Thariq workshop analysis, 273줄): "tool = atomic/irreversible, bash = composable reversible"

## Classification

| Tier | gh 예시 | 경로 |
|------|---------|------|
| **R0 Read** | pr/issue view·list, api GET, status, search, run view, workflow view | 허용 (기존 org allowlist만) |
| **R1 Reversible** | pr create/close/merge/ready/comment/edit, issue create/close, label create/delete, run cancel, api POST/PUT/PATCH, api -f field (implicit POST) | 허용 + \`gh_audit\` INFO 로그 |
| **R2 Irreversible** | repo delete/archive/transfer/rename, release delete, secret delete, ssh-key delete, workflow disable, auth logout/token, api DELETE, graphql mutation delete*/remove*/transfer* | block + structured next-action hint |

R2 rejection response는 \`structured_tool_hint_for_r2\`가 작동 가능한 next step을 reason에 직접 포함 — small LLM이 같은 턴에 board-post/operator-approval 경로로 전환 가능 (Gate response LLM-readable 원칙).

## Swiss Cheese positioning

이 PR은 **application layer만** 올바르게 만듭니다. 유일한 방어선인 척하지 않음.

- **Credential layer** (가장 load-bearing): \`anyang-keepers\` fine-grained PAT 재발급 — jeong-sik org only, contents+PR+issues write, **no** admin/delete scope. Operator 수동 작업, PR 아님.
- **OS layer**: \`DockerPlayground.enabled = true\` — filesystem/network 격리.
- **Application layer** (이 PR): reversibility classifier.
- **UX layer** (PR #7433에서 merged): timeout floor 5s, allowed_orgs 체크.

## Changes

### \`lib/worker_dev_tools.ml\` (+218/-4)
- \`gh_reversibility\` type: \`R0_Read | R1_Reversible | R2_Irreversible\`
- \`gh_irreversible_ops\`, \`gh_reversible_mutations\` — subcommand tables (data, not heuristic). R0은 default fallthrough.
- \`extract_gh_api_method\` — \`-X\` / \`--method\` / \`-X=\` / \`--method=\` 4 shape 모두 파싱
- \`gh_api_graphql_is_destructive\` — \`api graphql\` + destructive mutation verb 집합(deletePullRequest, deleteIssue, deleteBranch, deleteRef, deleteProject, deleteBranchProtectionRule, removeOuterFromOrganization, transferRepository, archiveRepository) 교집합
- \`classify_gh_reversibility\` — 5단계 precedence (R2 ops → api special-case → R1 mutations → R0)
- \`structured_tool_hint_for_r2\` — 알려진 R2 shape에 다음 행동 hint. 미매핑 R2는 \`None\` → caller가 generic message
- \`gh_blocked_operations\` — \`gh_irreversible_ops\`에서 파생되는 backward-compat alias (validate_gh_command 기존 호출자 보존)

### \`lib/keeper/keeper_exec_shell.ml\` op=\"gh\" (+133/-57)
- Classification 분기:
  - **R2** → \`gh_irreversible_blocked\` error + hint. Keeper log에 WARN.
  - **R0/R1** → 기존 validate_gh_command 경로. R1이면 \`Log.Keeper.info\` 에 \`gh_audit: keeper=NAME reversibility=R1 cwd=... cmd=gh ...\` 기록.
- 모든 응답에 \`reversibility\` 필드 추가 (\"R0\"/\"R1\"/\"R2\") → dashboard 집계 가능.

### \`test/test_worker_dev_tools.ml\` (+134)
- \`classify_gh_reversibility\` — R0 6, R1 7, R2 11 = 24 cases
  - R0: pr list, pr view 123, issue list, api GET, status, search
  - R1: pr create, pr merge, issue close, api POST, api -f field (implicit POST), label create, run cancel
  - R2: repo delete/archive/transfer, release delete, secret delete, ssh-key delete, workflow disable, auth logout, api DELETE, graphql deletePullRequest, graphql transferRepository
- \`structured_tool_hint_for_r2\` — 4 cases (repo, credential, api, unmapped)

## Test plan

- [x] \`dune build\` clean
- [x] \`dune exec test/test_worker_dev_tools.exe\` — 107 tests pass (기존 79 + 신규 28)
- [x] \`dune runtest\` — keeper_tool_matrix (~100s), mcp_tool_matrix (~87s) 포함 green, 기존 case 회귀 없음
- [ ] CI green 확인 후 ready 전환

## 확인하지 않은 것 (follow-up 대상)

- **Operator 수동 작업**: \`anyang-keepers\` fine-grained PAT 재발급 (별도 작업, PR 아님)
- **Structured keeper tool 확장**: 현재 hint는 \"board post로 가라\"이지만, 일부 R2 shape(예: release delete with operator approval)는 structured tool을 추가해 자동화 가능 — 다음 PR 후보
- **Docker playground default true**: 현재 opt-in. 기본화는 별도 설계 필요 (디버깅 flow 영향 검토)

🤖 Generated with [Claude Code](https://claude.com/claude-code)