### PR TITLE
fix(tool_code_write): surface nearby lines on 'old_string not found'

### DIFF
--- a/lib/tool_code_write.ml
+++ b/lib/tool_code_write.ml
@@ -388,7 +388,39 @@ let handle_code_edit ctx args =
           done;
 
           if !count = 0 then
-            (false, "old_string not found in file")
+            (* Exact match failed. Look for the first line of old_string
+               (trimmed) inside the file and surface up to 3 matching
+               lines — the LLM almost always got whitespace / indent /
+               trailing newline wrong, and showing the real line(s) it
+               meant to target lets the next attempt succeed without
+               re-reading the whole file.
+
+               Evidence: 2026-04-16 /loop iter 3 — 17/19 masc_code_edit
+               failures are "old_string not found", single root cause. *)
+            let first_line =
+              match String.index_opt old_string '\n' with
+              | Some i -> String.sub old_string 0 i
+              | None -> old_string
+            in
+            let needle = String.trim first_line in
+            if String.length needle < 8 then
+              (false, "old_string not found in file")
+            else
+              let matches =
+                String.split_on_char '\n' content
+                |> List.filter (fun line ->
+                     String_util.contains_substring line needle)
+                |> List.filteri (fun i _ -> i < 3)
+              in
+              let hint =
+                match matches with
+                | [] -> ""
+                | samples ->
+                  "\nLines in file matching the first trimmed line of \
+                   old_string (check whitespace/indent):\n  "
+                  ^ String.concat "\n  " samples
+              in
+              (false, "old_string not found in file." ^ hint)
           else if !count > 1 && not replace_all then
             (false, Printf.sprintf
                "old_string found %d times. Use replace_all=true or provide more context"


### PR DESCRIPTION
## Symptom

Live log, 2026-04-16 /loop iter 3 — \`masc_code_edit\` is the #1 \`tool_use_failure\` offender:

\`\`\`
tool masc_code_edit returned error result — 19/3MB window
```

Drilling in:

| Count | Error detail |
|---|---|
| **17/19** | \`"old_string not found in file"\` |
| 1/19 | \`"old_string found 7 times"\` |
| 1/19 | \`"old_string and new_string are identical"\` |

So 17 of 19 are a **single error class** where the LLM-sent \`old_string\` almost matched file content but with wrong whitespace / indent / trailing newline.

## Root cause

The bare \`"old_string not found in file"\` gives the LLM zero actionable feedback. The next attempt blind-guesses at the whitespace again and usually makes the same mistake. Retry loop without signal.

## Fix

On no-match, take the first line of \`old_string\`, trim it, and surface up to 3 lines from the file whose trimmed content contains that trimmed needle. The LLM sees the actual indent/whitespace it should have matched and succeeds on the next turn without re-reading the file.

**Guard**: if the trimmed needle is <8 chars, fall back to the old terse message — otherwise we'd spam matches for tokens like \`let \`, \`if \`, etc.

Pure additive — success and multi-match paths unchanged.

## Example

**Before:**
\`\`\`
old_string not found in file
\`\`\`

**After (if the line exists with different indent):**
\`\`\`
old_string not found in file.
Lines in file matching the first trimmed line of old_string (check whitespace/indent):
      let needle = String.trim first_line in
\`\`\`

## Test plan

- [x] \`dune build --root .\` clean
- [x] \`test_tool_code_write_coverage\` 29/29 pass
- [ ] Full \`dune runtest --root .\` — running
- [ ] Deploy + observe: masc_code_edit retry convergence (next-turn success rate)

## Loop series context

PR #4 in the self-paced /loop:
- #7445 (board_post schema) — **MERGED**
- #7453 (auto_approve) — Ready
- #7455 (admin tools Keeper_denied) — Ready  
- **this** (edit error hint)