### PR TITLE
feat(launchers): opt-in MASC_LOG_FILE tee for run-local + start-masc-mcp

### DIFF
--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -198,4 +198,11 @@ echo "  Port: $PORT" >&2
 echo "  Dashboard build: $(if [ "$BUILD_DASHBOARD" = "1" ]; then echo enabled; else echo skipped; fi)" >&2
 echo "  Transports: http=on grpc=${MASC_GRPC_ENABLED} ws=${MASC_WS_ENABLED} webrtc=${MASC_WEBRTC_ENABLED}" >&2
 
-exec "$EXE" --host="$HOST" --port="$PORT" --base-path="$TARGET_DIR"
+if [ -n "${MASC_LOG_FILE:-}" ]; then
+  mkdir -p "$(dirname "$MASC_LOG_FILE")"
+  echo "  Log file: $MASC_LOG_FILE (stdout+stderr tee'd)" >&2
+  set -o pipefail
+  exec "$EXE" --host="$HOST" --port="$PORT" --base-path="$TARGET_DIR" 2>&1 | tee -a "$MASC_LOG_FILE"
+else
+  exec "$EXE" --host="$HOST" --port="$PORT" --base-path="$TARGET_DIR"
+fi

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -779,7 +779,14 @@ launch_from_base_path() {
         echo "Error: failed to chdir to base path: $RESOLVED_BASE_PATH" >&2
         exit 1
     fi
-    exec "$@"
+    if [ -n "${MASC_LOG_FILE:-}" ]; then
+        mkdir -p "$(dirname "$MASC_LOG_FILE")"
+        echo "  Log file: $MASC_LOG_FILE (stdout+stderr tee'd)" >&2
+        set -o pipefail
+        exec "$@" 2>&1 | tee -a "$MASC_LOG_FILE"
+    else
+        exec "$@"
+    fi
 }
 
 # Eio server has different CLI format and is HTTP-only


### PR DESCRIPTION
## Summary

Both `scripts/run-local.sh` and `start-masc-mcp.sh` end in `exec "$@"` with no stdout/stderr redirection. The server's structured log stream disappears into the controlling terminal and cannot be tailed after the fact — this blocks external log-based monitoring from catching issues that happened minutes earlier (e.g. `[ERROR] [Keeper] janitor: keeper cycle failed: Completion contract [require_tool_use] violated ...`, `keeper_bash` command_blocked warnings).

## Change

Opt-in tee: when `MASC_LOG_FILE` is set, redirect `2>&1` into `tee -a "$MASC_LOG_FILE"`. Default behaviour (env unset) unchanged — `exec` replaces the shell directly as before.

```bash
# Before
exec "$EXE" --host="$HOST" --port="$PORT" --base-path="$TARGET_DIR"

# After
if [ -n "${MASC_LOG_FILE:-}" ]; then
  mkdir -p "$(dirname "$MASC_LOG_FILE")"
  set -o pipefail
  exec "$EXE" ... 2>&1 | tee -a "$MASC_LOG_FILE"
else
  exec "$EXE" ...
fi
```

Same pattern applied to `launch_from_base_path` in `start-masc-mcp.sh`.

## Why

Operators running the server in the foreground still get live output. Anyone running a log-based automation can now invoke:

```bash
MASC_LOG_FILE=logs/masc-server-$(date +%Y%m%d).log ./start-masc-mcp.sh --http
```

Previously the only way to tail was to wrap the launcher with another tee externally, which most users don't do — as evidenced by zero masc-server-*.log files in `logs/` newer than 2026-04-13 despite the server running continuously.

## `set -o pipefail`

Without it, tee's 0 exit would mask non-zero binary exit. Only triggers in the opt-in branch.

## Test plan

- [x] `bash -n scripts/run-local.sh` — syntax OK
- [x] `bash -n start-masc-mcp.sh` — syntax OK
- [x] `MASC_LOG_FILE= scripts/run-local.sh --help` — help path prints as before
- [ ] Manual smoke: `MASC_LOG_FILE=/tmp/masc-smoke.log scripts/run-local.sh --port 9999`, stop, verify file exists and has content