### PR TITLE
fix(coord_task): include current_assignee on Invalid transition errors

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -162,6 +162,21 @@ let task_status_to_string = function
   | Types.Done _ -> "done"
   | Types.Cancelled _ -> "cancelled"
 
+(** Current assignee from the task status, for error messages.
+
+    LLMs that see "Invalid transition: claimed -> release" have no way
+    to tell whether they're trying to release someone else's task vs
+    using the wrong action name. Surfacing the current assignee in the
+    failure lets the LLM see the ownership mismatch and stop retrying.
+
+    Evidence: 2026-04-16 /loop iter 4 — 12+/15 masc_transition failures
+    are "Invalid transition: claimed -> release" from keepers trying to
+    release tasks owned by a different keeper. *)
+let task_assignee_of_status = function
+  | Types.Claimed { assignee; _ } -> Some assignee
+  | Types.InProgress { assignee; _ } -> Some assignee
+  | Types.Todo | Types.Done _ | Types.Cancelled _ -> None
+
 let task_started_at_unix status =
   let default_time = Time_compat.now () in
   match status with
@@ -678,9 +693,16 @@ let transition_task_r config ~agent_name ~task_id ~action
               started_at = now;
             }, None)
         | _ ->
+            let assignee_hint =
+              match task_assignee_of_status task.task_status with
+              | Some a when a <> agent_name ->
+                Printf.sprintf ", current_assignee=%s" a
+              | _ -> ""
+            in
             Error (Types.TaskInvalidState
-              (Printf.sprintf "Invalid transition: %s -> %s (%s, agent=%s)"
-                (task_status_to_string task.task_status) action_s task_id agent_name))
+              (Printf.sprintf "Invalid transition: %s -> %s (%s, agent=%s%s)"
+                (task_status_to_string task.task_status) action_s task_id agent_name
+                assignee_hint))
       in
       if new_status = task.task_status && set_current = None then
         (* Idempotent no-op: status unchanged, skip write/events.


### PR DESCRIPTION
## Symptom

Live log, 2026-04-16 /loop iter 4 — 12 of 15 \`masc_transition\` failures share this error:

\`\`\`
Invalid transition: claimed -> release (task-118, agent=keeper-qa-king-agent)
\`\`\`

The keeper asked to release \`task-118\` but the actual \`Claimed\` state belonged to a different keeper. The error says only \`claimed -> release\`, which doesn't tell the LLM whether the failure is ownership or the action name — so the LLM keeps retrying variations.

## Fix

When the transition fails and the task has an assignee that differs from the calling agent, append:

\`\`\`
, current_assignee=<other_agent>
\`\`\`

**Before:**
\`\`\`
Invalid transition: claimed -> release (task-118, agent=keeper-qa-king-agent)
\`\`\`

**After:**
\`\`\`
Invalid transition: claimed -> release (task-118, agent=keeper-qa-king-agent, current_assignee=keeper-janitor-agent)
\`\`\`

The LLM sees the ownership mismatch and switches tactics (pick a different task, or ask the owner) instead of brute-forcing.

## Guard

Only appended when assignee exists AND differs from caller. Ownership-match failures (e.g. wrong action name with correct owner) keep the terse format — no noise.

## Pattern

Same shape as /loop iter 3 (#7459 — \`masc_code_edit\` hint): tool error messages that actually teach the LLM converge retries, while terse messages drive fruitless retry loops.

## Loop series

PR #5 in the self-paced /loop:
- #7445 (board_post schema) — **MERGED**
- #7453 (auto_approve) — Ready
- #7455 (admin-denied) — Ready
- #7459 (edit hint) — Ready
- **this** (transition assignee hint)

## Test plan

- [x] \`dune build --root .\` clean
- [ ] Full \`dune runtest --root .\` — running
- [ ] Deploy + observe: masc_transition retry loops terminate