### PR TITLE
chore(cascade): drop unused populate_throttle_table / lookup_throttle re-exports

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -14,11 +14,6 @@ let resolve_glm_model_id = Cascade_model_resolve.resolve_glm_model_id
 let resolve_auto_model_id = Cascade_model_resolve.resolve_auto_model_id
 let parse_custom_model = Cascade_model_resolve.parse_custom_model
 
-(* Throttle — re-exports for future migration consumers. Marked as unused
-   while some callers still depend on the consolidated Cascade_config surface. *)
-let[@warning "-32"] populate_throttle_table = Cascade_throttle.populate
-let[@warning "-32"] lookup_throttle = Cascade_throttle.lookup
-
 (* Config loader *)
 let load_json = Cascade_config_loader.load_json
 let load_profile = Cascade_config_loader.load_profile


### PR DESCRIPTION
## Summary

Two throttle re-exports carried \`[@warning \"-32\"]\` since #7382 (4d-scaffold) to silence unused-value warnings while call sites were expected to migrate over. After #7386 (4d-migrate) moved 21 call sites, these two never grew any consumers.

```bash
$ rg 'populate_throttle_table|lookup_throttle' . --glob '!.git'
./lib/cascade/cascade_config.ml:19:let[@warning "-32"] populate_throttle_table = Cascade_throttle.populate
./lib/cascade/cascade_config.ml:20:let[@warning "-32"] lookup_throttle = Cascade_throttle.lookup
```

Only the two `let`-definitions themselves — **zero callers** across `lib/` + `test/` + `scripts/` + `harness/`.

The surrounding comment also claimed "some callers still depend on the consolidated `Cascade_config` surface", but grep proves that's stale. Consumers needing throttle ops go through `Cascade_throttle` directly.

## Change
```diff
-(* Throttle — re-exports for future migration consumers. Marked as unused
-   while some callers still depend on the consolidated Cascade_config surface. *)
-let[@warning "-32"] populate_throttle_table = Cascade_throttle.populate
-let[@warning "-32"] lookup_throttle = Cascade_throttle.lookup
-
 (* Config loader *)
```

1 file, 5 lines removed.

## Test plan

- [x] `dune build @lib/all --root .` clean
- [x] `rg 'populate_throttle_table|lookup_throttle' . --glob '!.git'` post-edit: 0 matches

## Related

- #7382 (scaffold that introduced the re-exports)
- #7386 (migrate that was supposed to wire them)