### PR TITLE
refactor(gate): migrate Discord runtime paths to .gate/runtime/ (B3a)

### DIFF
--- a/lib/gate/channel_gate_discord_names.ml
+++ b/lib/gate/channel_gate_discord_names.ml
@@ -16,8 +16,12 @@ type name_map = {
   updated_at : string;
 }
 
-let default_names_path = ".masc/connectors/discord/names.json"
-let legacy_names_path = "sidecars/discord-bot/.gate/discord_names.json"
+let default_names_path = ".gate/runtime/discord/names.json"
+(* Legacy path from the pre-v0.9.0 layout. Read-fallback still honours it so
+   that operators who have data there see a transparent migration on the next
+   write. `sidecars/discord-bot/.gate/discord_names.json` (even older layout)
+   is no longer auto-discovered; set MASC_DISCORD_NAMES_PATH if still in use. *)
+let legacy_names_path = ".masc/connectors/discord/names.json"
 
 let resolve_path raw_path =
   if Filename.is_relative raw_path then

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -23,14 +23,20 @@ let display_name = "Discord"
 let channel = "discord"
 
 
-let default_status_path = ".masc/connectors/discord/status.json"
-let default_binding_store_path = ".masc/connectors/discord/bindings.json"
-let default_binding_audit_path = ".masc/connectors/discord/binding_audit.jsonl"
+let default_status_path = ".gate/runtime/discord/status.json"
+let default_binding_store_path = ".gate/runtime/discord/bindings.json"
+let default_binding_audit_path = ".gate/runtime/discord/binding_audit.jsonl"
 
-let legacy_status_path = "sidecars/discord-bot/.gate/discord_status.json"
-let legacy_binding_store_path = "sidecars/discord-bot/.gate/discord_bindings.json"
-let legacy_binding_audit_path =
-  "sidecars/discord-bot/.gate/discord_binding_audit.jsonl"
+(* Legacy paths take the shape used before the gate-runtime migration
+   (masc-mcp #7462 / v0.9.0). On first read after upgrade, data still
+   living at the legacy location is picked up and the next write lands
+   at the new default, so operators see a transparent migration. Older
+   `sidecars/discord-bot/.gate/*` layouts from the 2026-Q1 era are no
+   longer auto-discovered; operators using them must set the explicit
+   MASC_DISCORD_*_PATH env vars. *)
+let legacy_status_path = ".masc/connectors/discord/status.json"
+let legacy_binding_store_path = ".masc/connectors/discord/bindings.json"
+let legacy_binding_audit_path = ".masc/connectors/discord/binding_audit.jsonl"
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_DISCORD_STATUS_STALE_SEC"


### PR DESCRIPTION
## Summary

- Default Discord connector state paths move from `.masc/connectors/discord/*` to `.gate/runtime/discord/*`.
- `legacy_*_path` constants demoted to the former `.masc/connectors/` layout, so existing data is auto-discovered on first read and the next write lands at the new default. Transparent, zero-manual-step migration.
- First step of Track **B3** (Gate runtime path migration).

## Product impact

For most operators: **transparent**. Existing `.masc/connectors/discord/*` files are still read on startup; the next write lands at `.gate/runtime/discord/*`. No intervention required unless:
- Still running the even older `sidecars/discord-bot/.gate/*` layout (2026-Q1 era). Set `MASC_DISCORD_STATUS_PATH`, `MASC_DISCORD_BINDING_STORE_PATH`, `MASC_DISCORD_BINDING_AUDIT_PATH`, `MASC_DISCORD_NAMES_PATH` explicitly.
- Running a custom path via env var — unchanged, env vars take priority.

Engineering value:
- Brings Gate's runtime data layout in line with its sub-library identity (`masc_mcp.gate`, en route to standalone `gate-mcp`). Keeping data under `.masc/` made the library name lie.
- Sets up the convention for B3b (iMessage — needs legacy-fallback wiring first) and B3c (Python sidecars).

## Rationale

Track B has been moving the Gate surface out of `masc_mcp`:
- #7407 (B1a) — pure Gate modules into `lib/gate/`
- #7452 (B1b) — Pulse into `lib/pulse/`
- #7457 (B1c) — `channel_gate` joined `lib/gate/`

Runtime *data* was still under `.masc/connectors/`. This PR moves the defaults to match the library location. `legacy_*_path` already exists as a read-fallback mechanism (see `Channel_gate_discord_names.configured_read_path`), so the migration pattern is just "promote old default to legacy, set new default."

## Changes

- `lib/gate/channel_gate_discord_state.ml`:
  - `default_status_path`         `.masc/connectors/discord/status.json` → `.gate/runtime/discord/status.json`
  - `default_binding_store_path`  `.masc/connectors/discord/bindings.json` → `.gate/runtime/discord/bindings.json`
  - `default_binding_audit_path`  `.masc/connectors/discord/binding_audit.jsonl` → `.gate/runtime/discord/binding_audit.jsonl`
  - `legacy_*_path`: now point at the old `.masc/connectors/discord/*` layout (previously `sidecars/discord-bot/.gate/discord_*`).
- `lib/gate/channel_gate_discord_names.ml`:
  - `default_names_path`          `.masc/connectors/discord/names.json` → `.gate/runtime/discord/names.json`
  - `legacy_names_path`           → `.masc/connectors/discord/names.json`
- Added block comment documenting the layered path priority.

Read priority (unchanged mechanism, new destinations):
1. env var override (`MASC_DISCORD_*_PATH`) if set
2. new default under `.gate/runtime/discord/`
3. legacy under `.masc/connectors/discord/`

Write always goes to #1 or #2 — never to legacy.

## Evidence

- `dune build --root .` → clean.
- `dune exec test/test_channel_gate.exe` → **14/14 pass** (validate + handle_inbound suites).

## Review evidence

- No test fixture hardcodes the old path: `rg '\.masc/connectors/discord' test/` → zero hits.
- No dashboard TS/TSX reference: `rg '\.masc/connectors' dashboard/src/` → zero hits (verified during the earlier B3 investigation).
- Read/write call sites (`status_path`, `binding_store_path`, `names_read_path`, etc.) are unchanged — they always routed through `Names.configured_read_path` / `configured_write_path`, so the fallback chain honors the new defaults automatically.

Pattern reuse: the `~default ~legacy` API in `configured_read_path` was already present. This PR only rotates the constants fed into it.

## Linked issue

Refs #7407, #7452, #7457, #7462 — completes the "Gate lives in its own namespace" portion of Track B by moving runtime data too.

## Test plan

- [x] `dune build --root .` → clean
- [x] `dune exec test/test_channel_gate.exe` → 14/14 pass
- [ ] CI: Build and Test, Lint, Health
- [ ] Post-merge: deploy to local dev — verify `.gate/runtime/discord/bindings.json` gets created on the next write, and existing bindings (from `.masc/connectors/discord/bindings.json`) remain visible on read.

## Follow-ups

- **B3b** — iMessage (`channel_gate_imessage_state.ml`): needs the `~legacy` parameter added to `configured_read_path` (currently Discord-only). Then same default rotation.
- **B3c** — Python sidecars (`sidecars/discord-bot/src/config.py`, `sidecars/imessage-bot/src/config.py`, `sidecars/telegram-bot/src/config.py`): change `DEFAULT_*` constants. Sidecars already honor env vars via Pydantic AliasChoices, so deployments with explicit env vars are unaffected.
- **B2**: `keeper_name` → `destination_id` in `gate_protocol`. Independent of B3. Wire-format deprecation cycle.
- **B4**: standalone `gate-mcp` repo. Depends on B2 + B3 complete.