### PR TITLE
refactor(gate): migrate iMessage runtime paths to .gate/runtime/ (B3b)

### DIFF
--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -19,9 +19,16 @@ let connector_id = "imessage"
 let display_name = "iMessage"
 let channel = "imessage"
 
-let default_status_path = ".masc/connectors/imessage/status.json"
-let default_binding_store_path = ".masc/connectors/imessage/bindings.json"
-let default_binding_audit_path = ".masc/connectors/imessage/binding_audit.jsonl"
+let default_status_path = ".gate/runtime/imessage/status.json"
+let default_binding_store_path = ".gate/runtime/imessage/bindings.json"
+let default_binding_audit_path = ".gate/runtime/imessage/binding_audit.jsonl"
+
+(* Legacy paths from the pre-v0.9.0 layout. Read-fallback picks these up
+   once so operators see a transparent migration on the next write — see
+   configured_read_path below. *)
+let legacy_status_path = ".masc/connectors/imessage/status.json"
+let legacy_binding_store_path = ".masc/connectors/imessage/bindings.json"
+let legacy_binding_audit_path = ".masc/connectors/imessage/binding_audit.jsonl"
 
 let stale_after_sec () =
   Env_config_core.get_int ~default:30 "MASC_IMESSAGE_STATUS_STALE_SEC"
@@ -46,13 +53,23 @@ let configured_write_path env_name ~default =
   | Some raw -> resolve_path raw
   | None -> resolve_path default
 
-let configured_read_path env_name ~default =
+(* Read priority: env var > new default (if file exists) > legacy (if file
+   exists) > new default (even if absent, so downstream code sees a stable
+   path for later creation). Matches the Discord resolver in
+   Channel_gate_discord_names.configured_read_path. *)
+let configured_read_path env_name ~default ~legacy =
   match Sys.getenv_opt env_name |> Env_config_core.trim_opt with
   | Some raw -> resolve_path raw
-  | None -> resolve_path default
+  | None ->
+      let default_abs = resolve_path default in
+      if Sys.file_exists default_abs then default_abs
+      else
+        let legacy_abs = resolve_path legacy in
+        if Sys.file_exists legacy_abs then legacy_abs else default_abs
 
 let status_path () =
-  configured_read_path "MASC_IMESSAGE_STATUS_PATH" ~default:default_status_path
+  configured_read_path "MASC_IMESSAGE_STATUS_PATH"
+    ~default:default_status_path ~legacy:legacy_status_path
 
 let status_write_path () =
   configured_write_path "MASC_IMESSAGE_STATUS_PATH" ~default:default_status_path
@@ -63,7 +80,7 @@ let binding_store_path () =
 
 let binding_store_read_path () =
   configured_read_path "MASC_IMESSAGE_BINDING_STORE_PATH"
-    ~default:default_binding_store_path
+    ~default:default_binding_store_path ~legacy:legacy_binding_store_path
 
 let binding_audit_path () =
   configured_write_path "MASC_IMESSAGE_BINDING_AUDIT_PATH"
@@ -71,7 +88,7 @@ let binding_audit_path () =
 
 let binding_audit_read_path () =
   configured_read_path "MASC_IMESSAGE_BINDING_AUDIT_PATH"
-    ~default:default_binding_audit_path
+    ~default:default_binding_audit_path ~legacy:legacy_binding_audit_path
 
 let read_json_file_opt path =
   if not (Sys.file_exists path) then


### PR DESCRIPTION
## Summary

- Mirrors #7467 (B3a) for the iMessage connector. Default state paths move from `.masc/connectors/imessage/*` to `.gate/runtime/imessage/*`.
- Adds `~legacy` parameter to iMessage's `configured_read_path` (Discord already had this via `Channel_gate_discord_names`).
- Closes the OCaml half of **B3** Gate runtime-path migration. Python sidecars follow as **B3c**.

## Product impact

For most operators: **transparent**. Existing `.masc/connectors/imessage/*` files are auto-discovered on first read; the next write lands at `.gate/runtime/imessage/*`.

No intervention needed unless:
- Running a custom path via `MASC_IMESSAGE_*_PATH` env var — unchanged, env vars take priority.

## Rationale

B3a (#7467) handled Discord. iMessage was deferred because its local `configured_read_path` had no `~legacy` parameter — unlike Discord, which already routed through `Channel_gate_discord_names.configured_read_path` with a `~legacy` slot. This PR adds the parameter using the same signature and priority order.

## Changes

`lib/gate/channel_gate_imessage_state.ml`:
- `default_status_path`         `.masc/connectors/imessage/status.json` → `.gate/runtime/imessage/status.json`
- `default_binding_store_path`  `.masc/connectors/imessage/bindings.json` → `.gate/runtime/imessage/bindings.json`
- `default_binding_audit_path`  `.masc/connectors/imessage/binding_audit.jsonl` → `.gate/runtime/imessage/binding_audit.jsonl`
- Added `legacy_status_path`, `legacy_binding_store_path`, `legacy_binding_audit_path` (pre-v0.9.0 `.masc/connectors/imessage/` layout).
- `configured_read_path` signature: `env_name ~default` → `env_name ~default ~legacy`. Read priority:
  1. `MASC_IMESSAGE_*_PATH` env var override
  2. new default (if file exists)
  3. legacy (if file exists)
  4. new default (as a stable path for later creation)
- The three read entry points (`status_path`, `binding_store_read_path`, `binding_audit_read_path`) pass the matching `legacy_*_path`. Write paths unchanged.

Matches the Discord resolver in `Channel_gate_discord_names.configured_read_path` exactly.

## Evidence

- `dune build --root .` → clean.
- `dune exec test/test_channel_gate_imessage_state.exe` → **2/2 pass** (status json redacts self-chat guid, connector json keeps redacted self-chat guid).

## Review evidence

- No test fixture hardcodes the old path: `rg '\.masc/connectors/imessage' test/` → zero hits.
- `resolve_path` unchanged — still treats relative paths as base_path-relative.
- Sys.file_exists check uses resolved absolute path — no TOCTOU window vs later read.

## Linked issue

Refs #7467 (B3a Discord), completes the OCaml half of Track B3.

## Test plan

- [x] `dune build --root .` → clean
- [x] `dune exec test/test_channel_gate_imessage_state.exe` → 2/2 pass
- [ ] CI: Build and Test, Lint, Health
- [ ] Post-merge: deploy to local dev — verify `.gate/runtime/imessage/bindings.json` gets created on the next write, and existing data (from `.masc/connectors/imessage/bindings.json`) remains visible on read.

## Follow-ups

- **B3c** — Python sidecars (`sidecars/{discord,imessage,slack,telegram}-bot/src/config.py`): 15 `DEFAULT_*` constants across 4 sidecars. Pydantic validators can implement the same read-fallback pattern, or rely on operators' explicit env vars during transition.
- **B2** — `keeper_name` → `destination_id` in `gate_protocol`. Independent; wire-format deprecation cycle.
- **B4** — standalone `gate-mcp` repo. After B2 + B3 complete.