### PR TITLE
refactor(discord-bot): migrate sidecar runtime paths to .gate/runtime/ (B3c-discord)

### DIFF
--- a/sidecars/discord-bot/.env.example
+++ b/sidecars/discord-bot/.env.example
@@ -15,19 +15,21 @@ GATE_API_TOKEN=
 DISCORD_KEEPER_MAP={"1234567890": "luna"}
 
 # Durable store for runtime bind/unbind changes.
-# Default runtime root is .masc/connectors/discord/* and should usually share
-# the same MASC_BASE_PATH as the server.
-DISCORD_BINDING_STORE_PATH=.masc/connectors/discord/bindings.json
+# Default runtime root is .gate/runtime/discord/* and should usually share
+# the same MASC_BASE_PATH as the server. (Pre-v0.9.0 layout was
+# .masc/connectors/discord/*; it is still auto-discovered on first read and
+# migrates on the next write.)
+DISCORD_BINDING_STORE_PATH=.gate/runtime/discord/bindings.json
 
 # Append-only operator audit trail for bind/unbind changes.
-DISCORD_BINDING_AUDIT_PATH=.masc/connectors/discord/binding_audit.jsonl
+DISCORD_BINDING_AUDIT_PATH=.gate/runtime/discord/binding_audit.jsonl
 
 # Runtime status heartbeat used by the dashboard's direct Discord panel.
-DISCORD_STATUS_PATH=.masc/connectors/discord/status.json
+DISCORD_STATUS_PATH=.gate/runtime/discord/status.json
 
 # Humanization side-map: guild + channel id-to-name. Written every
 # STATUS_HEARTBEAT_SEC by enumerating discord.py's cached guilds/channels.
-DISCORD_NAMES_PATH=.masc/connectors/discord/names.json
+DISCORD_NAMES_PATH=.gate/runtime/discord/names.json
 STATUS_HEARTBEAT_SEC=10
 
 # Discord role ID for admin commands (optional)

--- a/sidecars/discord-bot/README.md
+++ b/sidecars/discord-bot/README.md
@@ -77,10 +77,10 @@ connector falls back to same-origin auth headers against `127.0.0.1`/`localhost`
 
 By default the bot writes runtime files under:
 
-- `.masc/connectors/discord/bindings.json`
-- `.masc/connectors/discord/binding_audit.jsonl`
-- `.masc/connectors/discord/status.json`
-- `.masc/connectors/discord/names.json` (guild + channel id-to-name humanization)
+- `.gate/runtime/discord/bindings.json`
+- `.gate/runtime/discord/binding_audit.jsonl`
+- `.gate/runtime/discord/status.json`
+- `.gate/runtime/discord/names.json` (guild + channel id-to-name humanization)
 
 Relative paths resolve from `MASC_BASE_PATH` when it is set; otherwise they
 resolve from the bot's current working directory.
@@ -191,7 +191,7 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 
 `/keeper-bind` and `/keeper-unbind` now persist the effective channel map to
 `DISCORD_BINDING_STORE_PATH` (default:
-`.masc/connectors/discord/bindings.json`).
+`.gate/runtime/discord/bindings.json`).
 
 - If the store file does not exist, the bot starts from `DISCORD_KEEPER_MAP`
 - Once an operator persists a runtime bind/unbind, the store file becomes the
@@ -199,9 +199,9 @@ Use the `/keeper-ask` slash command to talk to any keeper from any channel.
 - `/keeper-map` shows the active binding source and store path for operators
 - successful bind/unbind operations also append an audit record to
   `DISCORD_BINDING_AUDIT_PATH` (default:
-  `.masc/connectors/discord/binding_audit.jsonl`)
+  `.gate/runtime/discord/binding_audit.jsonl`)
 - the bot also writes a direct runtime snapshot to `DISCORD_STATUS_PATH`
-  (default: `.masc/connectors/discord/status.json`) every `STATUS_HEARTBEAT_SEC`
+  (default: `.gate/runtime/discord/status.json`) every `STATUS_HEARTBEAT_SEC`
   seconds so the dashboard can show live Discord connection state
 - runtime binding changes written by the dashboard are hot-reloaded by the bot
   without a process restart
@@ -241,7 +241,7 @@ Useful checks:
 
 ```bash
 curl -sfS http://127.0.0.1:8935/api/v1/gate/discord/status
-ls -la "${MASC_BASE_PATH:-$(pwd)}/.masc/connectors/discord"
+ls -la "${MASC_BASE_PATH:-$(pwd)}/.gate/runtime/discord"
 ```
 
 ### Messages are ignored in a channel

--- a/sidecars/discord-bot/run.sh
+++ b/sidecars/discord-bot/run.sh
@@ -29,7 +29,7 @@ export MASC_BASE_PATH="$BASE_PATH"
 
 LOG_DIR="$BASE_PATH/.masc/logs"
 LOG_FILE="$LOG_DIR/discord-sidecar-$(date +%Y%m%d).log"
-STATUS_FILE="$BASE_PATH/.masc/connectors/discord/status.json"
+STATUS_FILE="$BASE_PATH/.gate/runtime/discord/status.json"
 
 cmd="${1:-start}"
 case "$cmd" in

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -16,16 +16,21 @@ from urllib.parse import urlparse
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
-DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/discord/bindings.json"
-DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/discord/binding_audit.jsonl"
-DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
-DEFAULT_NAMES_PATH: Final[str] = ".masc/connectors/discord/names.json"
+DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/discord/bindings.json"
+DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".gate/runtime/discord/binding_audit.jsonl"
+DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/discord/status.json"
+DEFAULT_NAMES_PATH: Final[str] = ".gate/runtime/discord/names.json"
 
-LEGACY_BINDING_STORE_PATH: Final[str] = ".gate/discord_bindings.json"
-LEGACY_BINDING_AUDIT_PATH: Final[str] = ".gate/discord_binding_audit.jsonl"
-LEGACY_STATUS_PATH: Final[str] = ".gate/discord_status.json"
-LEGACY_NAMES_PATH: Final[str] = ".gate/discord_names.json"
-LEGACY_BASE_ROOT: Final[Path] = Path("sidecars/discord-bot")
+# Legacy layout from the pre-v0.9.0 release (OCaml side migrated in
+# #7467/#7468 B3a/B3b). On first startup after upgrade, bot.py's 1-tier
+# fallback picks up data from the legacy location and the next write lands
+# at the new default. The even older `sidecars/discord-bot/.gate/discord_*`
+# cwd-relative layout is no longer auto-discovered; deployments still on it
+# must set explicit DISCORD_*_PATH env vars.
+LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/discord/bindings.json"
+LEGACY_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/discord/binding_audit.jsonl"
+LEGACY_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
+LEGACY_NAMES_PATH: Final[str] = ".masc/connectors/discord/names.json"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -231,15 +236,6 @@ class BotConfig(BaseSettings):
             return base_root / path
         return Path.cwd() / path
 
-    def _resolve_legacy_storage_path(self, legacy_cwd_path: str) -> Path:
-        path = Path(legacy_cwd_path).expanduser()
-        if path.is_absolute():
-            return path
-        base_root = self.base_path_root()
-        if base_root is not None:
-            return base_root / LEGACY_BASE_ROOT / path
-        return Path.cwd() / path
-
     def binding_store_path(self) -> Path:
         """Return the durable binding store path.
 
@@ -257,17 +253,20 @@ class BotConfig(BaseSettings):
     def names_path(self) -> Path:
         return self._resolve_storage_path(self.discord_names_path)
 
+    # Legacy paths now resolve under the same base as the new defaults
+    # (MASC_BASE_PATH or cwd), not under sidecars/discord-bot/, because the
+    # pre-v0.9.0 layout was already MASC_BASE_PATH-relative.
     def legacy_binding_store_path(self) -> Path:
-        return self._resolve_legacy_storage_path(LEGACY_BINDING_STORE_PATH)
+        return self._resolve_storage_path(LEGACY_BINDING_STORE_PATH)
 
     def legacy_binding_audit_path(self) -> Path:
-        return self._resolve_legacy_storage_path(LEGACY_BINDING_AUDIT_PATH)
+        return self._resolve_storage_path(LEGACY_BINDING_AUDIT_PATH)
 
     def legacy_status_path(self) -> Path:
-        return self._resolve_legacy_storage_path(LEGACY_STATUS_PATH)
+        return self._resolve_storage_path(LEGACY_STATUS_PATH)
 
     def legacy_names_path(self) -> Path:
-        return self._resolve_legacy_storage_path(LEGACY_NAMES_PATH)
+        return self._resolve_storage_path(LEGACY_NAMES_PATH)
 
     def gate_message_url(self) -> str:
         base = self.gate_base_url.rstrip("/")


### PR DESCRIPTION
## Summary

- Python-side counterpart of #7467 (B3a Discord OCaml migration). Discord sidecar default paths move from `.masc/connectors/discord/*` to `.gate/runtime/discord/*`.
- Pre-v0.9.0 layout demoted to `LEGACY_*` — bot.py's existing 1-tier read-fallback picks up data on first startup and the next write migrates.
- Older still-older `LEGACY_BASE_ROOT = Path(\"sidecars/discord-bot\")` layout cut off (documented in changelog; explicit env var override still supported).

## Product impact

For most operators: **transparent**. bot.py already has the fallback loop:

```python
persisted_bindings = self.binding_store.load()  # reads .gate/runtime/discord/bindings.json
if persisted_bindings is None:
    legacy_binding_store = BindingStore(self.cfg.legacy_binding_store_path())  # .masc/connectors/discord/bindings.json
    legacy_bindings = legacy_binding_store.load()
    ...
```

The sidecar reads from `.gate/runtime/discord/bindings.json`; if the file is absent, it reads from `.masc/connectors/discord/bindings.json` and writes back to the new default on the next change. `keeper_status_tail` status-store writes go straight to the new path.

Cut-off: `sidecars/discord-bot/.gate/discord_*` (a 2026-Q1 cwd-relative layout) is no longer auto-discovered. Deployments on that layout — if any still exist — must set `DISCORD_BINDING_STORE_PATH`, `DISCORD_BINDING_AUDIT_PATH`, `DISCORD_STATUS_PATH`, `DISCORD_NAMES_PATH` env vars explicitly.

## Rationale

B3a (#7467) and B3b (#7468) migrated the OCaml Gate library's Discord + iMessage runtime paths. The Discord sidecar writes its own state files (bindings, status, audit, names), so its defaults must align or a fresh sidecar instance writes to `.masc/connectors/discord/*` while the Gate reads from `.gate/runtime/discord/*` — split-brain.

`LEGACY_BASE_ROOT = Path(\"sidecars/discord-bot\")` removal is a cleanup: the pre-v0.9.0 layout (`.masc/connectors/discord/*`) was already `MASC_BASE_PATH`-relative, so `_resolve_legacy_storage_path` collapses into `_resolve_storage_path`. Keeping the special-case function around would be dead code.

## Changes

- `sidecars/discord-bot/src/config.py`:
  - `DEFAULT_{BINDING_STORE,BINDING_AUDIT,STATUS,NAMES}_PATH` → `.gate/runtime/discord/*`
  - `LEGACY_{BINDING_STORE,BINDING_AUDIT,STATUS,NAMES}_PATH` → `.masc/connectors/discord/*` (previously `.gate/discord_*`)
  - `LEGACY_BASE_ROOT` constant removed
  - `_resolve_legacy_storage_path` method removed
  - `legacy_*_path()` properties now call `_resolve_storage_path` directly
- `sidecars/discord-bot/run.sh`: `STATUS_FILE` watch path updated
- `sidecars/discord-bot/.env.example`: defaults + explanatory comment
- `sidecars/discord-bot/README.md`: 8 path references rewritten

## Evidence

Local:
- `python -m py_compile src/config.py` → OK
- `python -m py_compile src/bot.py` → OK
- `bash -n run.sh` → OK

Full `pytest` needs the sidecar venv (`pydantic_settings`, `discord.py` etc.) which isn't provisioned in this worktree — CI will exercise it in the Build and Test job.

## Review evidence

No test fixture hardcodes the old sidecar path:

```
rg '\\.masc/connectors/discord' sidecars/discord-bot/tests/  # zero hits
rg 'LEGACY_BASE_ROOT'  # zero hits post-removal
```

bot.py's fallback loop is not touched — it calls `self.cfg.legacy_binding_store_path()`, and that method's return value changes shape only in that `LEGACY_BINDING_STORE_PATH` now points at `.masc/connectors/discord/bindings.json` (MASC_BASE_PATH-relative, identical resolution as the new default). Semantics preserved.

## Linked issue

Refs #7467 (B3a Discord OCaml), #7468 (B3b iMessage OCaml), #7462 (v0.9.0 bump).

## Test plan

- [x] `python -m py_compile src/config.py` + `src/bot.py`
- [x] `bash -n run.sh`
- [ ] CI: Build and Test (will run pytest), Lint, Health
- [ ] Post-merge: deploy sidecar locally — confirm `.gate/runtime/discord/bindings.json` appears on first bind/unbind, and any existing `.masc/connectors/discord/bindings.json` is still honored on startup.

## Follow-ups

- **B3c-imessage, -slack, -telegram**: same migration for the remaining 3 Python sidecars. Structure may differ — need to verify each has a fallback loop before applying the same DEFAULT↔LEGACY rotation.
- **B2**: `keeper_name` → `destination_id` in `gate_protocol`. Independent.
- **B4**: standalone `gate-mcp` repo. After B2 + remainder of B3c.