### PR TITLE
fix(keeper): demote semaphore_wait fail-safe logs to INFO

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -247,7 +247,13 @@ let rec wait_for_autonomous_queue_head ~(keeper_name : string) ~(ticket : int)
         | Some idx -> idx
         | None -> 0
       in
-      Log.Keeper.warn
+      (* INFO not WARN: this is a fail-safe — the keeper is voluntarily
+         skipping its slot in the queue and will retry on the next
+         cycle. WARN-level here produced ~38 entries per ~3MB log
+         window with 12 keepers contending on a 60s wait budget. The
+         operator only needs to know if these dominate; per-event
+         noise is harmful. Live log evidence: 2026-04-16 /loop iter 8. *)
+      Log.Keeper.info
         "semaphore_wait: autonomous fairness queue wait exceeded %.0fs (keeper=%s ahead=%d), skipping turn"
         semaphore_wait_timeout_sec keeper_name ahead;
       raise (Semaphore_wait_timeout semaphore_wait_timeout_sec)
@@ -290,7 +296,10 @@ let with_keeper_turn_slot ~keeper_name ~channel f =
         Eio.Time.with_timeout_exn clock semaphore_wait_timeout_sec (fun () ->
           Eio.Semaphore.acquire sem)
       with Eio.Time.Timeout ->
-        Log.Keeper.warn
+        (* INFO not WARN: see commentary above — keeper skips this turn
+           and the next heartbeat re-queues it. Per-event noise hurts
+           operator signal more than it helps. *)
+        Log.Keeper.info
           "semaphore_wait: %s semaphore wait exceeded %.0fs (channel=%s), \
            skipping turn"
           label semaphore_wait_timeout_sec


### PR DESCRIPTION
## Symptom

Live log, 2026-04-16 /loop iter 8 — \`semaphore_wait\` is now the **#1 WARN** in a ~3MB window: **38 entries**. Two sub-patterns:

| Count | Message |
|---|---|
| 12 | \`semaphore_wait: autonomous semaphore wait exceeded 60s (channel=autonomous), skipping turn\` |
| 9+ | \`semaphore_wait: autonomous fairness queue wait exceeded 60s (keeper=<name> ahead=N), skipping turn\` |

## Root cause

Both lines are **fail-safe paths**, not failures:

- The keeper voluntarily skips its turn slot when the queue takes too long.
- The next heartbeat re-queues it.
- The runtime is working as designed — 12 keepers × 60s wait budget on a small autonomous concurrency naturally produces queue contention under load.

WARN-level here floods the operator log with normal scheduling behavior, drowning out real problems (the next 6 entries below it dropped from 70+ in earlier iterations to ≤16).

## Fix

Demote both call sites in \`lib/keeper/keeper_keepalive.ml\` from \`Log.Keeper.warn\` → \`Log.Keeper.info\`.

**No behavior change**: \`Semaphore_wait_timeout\` is still raised, the turn is still skipped, retry path is unchanged. Only severity moves.

## Why not a counter-based throttle?

Considered (only WARN every Nth event in a window) but ruled out: the events are **expected and routine** under normal load. INFO is the correct semantic — operators who want to track saturation rate should aggregate per-minute counts via the metrics path, not the per-event log.

## Loop series

PR #7 in the self-paced /loop:
- #7445 (board_post schema) — **MERGED**
- #7453, #7455, #7459, #7464, #7466 — Ready
- **this** (semaphore_wait → INFO)

## Test plan

- [x] \`dune build --root .\` clean
- [x] \`test_keeper_semaphore_fairness\` 8/8 pass
- [ ] Full \`dune runtest --root .\` — running
- [ ] Deploy + observe: \`semaphore_wait\` WARN line drops to 0 (still visible at INFO level)