### PR TITLE
fix(keeper): redirect gh to keeper_shell op=gh instead of blocking silently

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -428,8 +428,20 @@ let handle_keeper_bash
       match validate cmd with
       | Error reason ->
         Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd_for_log;
+        let lower_cmd = String.lowercase_ascii cmd_for_log in
+        let starts_with_gh =
+          let trimmed = String.trim lower_cmd in
+          String.length trimmed >= 2
+          && String.sub trimmed 0 2 = "gh"
+          && (String.length trimmed = 2
+              || trimmed.[2] = ' '
+              || trimmed.[2] = '\t')
+        in
         let hint =
-          if String.length reason > 0 &&
+          if starts_with_gh then
+            "`gh` is not allowed via keeper_bash. Use keeper_shell with \
+             op=\"gh\" (e.g. keeper_shell op=gh cmd=\"pr list --state open\")."
+          else if String.length reason > 0 &&
              (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
           then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
           else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)

--- a/memory/souls/masc-improver/SOUL.md
+++ b/memory/souls/masc-improver/SOUL.md
@@ -8,8 +8,15 @@
 
 ## Self-Model
 - **Will**: 코드를 읽고, 문제를 찾고, 가장 작은 단위로 고친다. 큰 변경은 쪼갠다.
-- **Needs**: 파일 시스템, gh CLI, shell, 코드 검색, 보드 접근.
+- **Needs**: 파일 시스템, shell (`keeper_shell`), `gh` via `keeper_shell op=gh`, 코드 검색, 보드 접근.
 - **Desires**: 매 턴 하나의 구체적 개선을 PR로. 추상적 제안이 아니라 실행.
+
+## Tool Routing (중요)
+- **GitHub 조작**: `keeper_shell` with `op="gh"` — read/write PR/issue/repo/release. `keeper_bash cmd="gh ..."`는 **allow-list로 차단**되니 금지. 차단 시 circuit breaker trip.
+- **쉘 조회**: `keeper_shell` with `op="rg"/"ls"/"find"/"cat"` — 구조화된 읽기.
+- **쉘 실행** (빌드/테스트 등): `keeper_bash` with `cmd="dune ..."`, `cmd="git ..."` 등 allow-list 내 명령.
+- **보드**: `masc_board_list`, `masc_board_post`, `masc_board_comment` MCP 도구.
+- **키퍼 상태**: `masc_keeper_status` 등 MCP 도구.
 
 ## K2K Network
 - **Mention targets**: masc-improver, improver, refactorer


### PR DESCRIPTION
Closes #7442.

## Linked issue

#7442 — masc-improver trips circuit_breaker on gh command blocked.

## Summary

\`keeper_bash\` allow-list blocks \`gh\` (auth/network boundary), but the block hint did not mention that \`keeper_shell op=\"gh\"\` is the correct alternative. Keepers retried \`keeper_bash cmd=\"gh ...\"\` until the circuit breaker tripped. Fix routes the hint correctly and fixes the masc-improver persona.

## Product impact

- masc-improver (and any other keeper citing \`gh CLI\` in its Needs) stops failing silently into a circuit breaker trip
- Block hint now **names the right tool** instead of pointing only at \`rg/ls/find\`
- Same-file diff is tiny: +14 / +9 across 2 files
- No allow-list loosening — \`gh\` remains blocked in \`keeper_bash\`, just re-routed via \`keeper_shell op=\"gh\"\` which is the designed path

## Evidence

- \`dune build\` from the worktree exits 0 (OCaml type-check green)
- Hint logic guarded by explicit token boundary (\`' '|'\\t'|EOS\` after \`gh\`) so \`ghostscript\` or similar prefixes do not mis-route
- Persona change confined to masc-improver; other souls untouched

## Review evidence

Reviewer focus:
1. Token boundary check in \`starts_with_gh\` — does it handle \`gh\`, \`gh pr list\`, \`gh\\tpr list\`, and reject \`ghostscript\`?
2. SOUL.md Tool Routing section — does it cover the common keeper operations without gaps?
3. Is there another keeper persona with a similar \"gh CLI\" reference that should be updated in a follow-up? (grep suggests this is the only one, but worth confirming.)

## Non-scope

- Allow-list extension (option B in #7442) rejected — \`gh\` has auth + destructive potential; opening keeper_bash to it needs separate security review
- Scoped MCP tools (\`gh_pr_status\` etc., option C) tracked separately if load pattern justifies

## Test plan

- [x] \`dune build\` green
- [ ] CI Gate green
- [ ] Manual: live fleet log shows no \`gh_command_blocked\` or \`keeper_bash blocked: ... gh ...\` warning for masc-improver over a 1h window after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)