### PR TITLE
fix(keeper_pr_review): accept both pr_number and number (schema drift)

### DIFF
--- a/lib/keeper/keeper_tool_pr_review.ml
+++ b/lib/keeper/keeper_tool_pr_review.ml
@@ -10,7 +10,16 @@ let handle_keeper_pr_review_read
       ~(args : Yojson.Safe.t)
   =
   ignore meta;
-  let pr_number = Safe_ops.json_int ~default:0 "pr_number" args in
+  let pr_number =
+  (* Schema-drift compatibility: tool_shard.ml advertises [number]
+     (and most other PR tools also use [number]), but earlier
+     versions of these handlers required [pr_number]. Live log
+     2026-04-16 /loop iter 9 shows 14/3MB failures from keepers
+     sending the schema-canonical key. Read both. *)
+  let from_pr_number = Safe_ops.json_int ~default:0 "pr_number" args in
+  if from_pr_number <> 0 then from_pr_number
+  else Safe_ops.json_int ~default:0 "number" args
+in
   let repo = Safe_ops.json_string ~default:"" "repo" args |> String.trim in
   if pr_number = 0 then
     error_json "pr_number is required. Good: pr_number=123."
@@ -48,7 +57,16 @@ let handle_keeper_pr_review_comment
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   =
-  let pr_number = Safe_ops.json_int ~default:0 "pr_number" args in
+  let pr_number =
+  (* Schema-drift compatibility: tool_shard.ml advertises [number]
+     (and most other PR tools also use [number]), but earlier
+     versions of these handlers required [pr_number]. Live log
+     2026-04-16 /loop iter 9 shows 14/3MB failures from keepers
+     sending the schema-canonical key. Read both. *)
+  let from_pr_number = Safe_ops.json_int ~default:0 "pr_number" args in
+  if from_pr_number <> 0 then from_pr_number
+  else Safe_ops.json_int ~default:0 "number" args
+in
   let body = Safe_ops.json_string ~default:"" "body" args |> String.trim in
   let event = Safe_ops.json_string ~default:"COMMENT" "event" args |> String.trim |> String.uppercase_ascii in
   let repo = Safe_ops.json_string ~default:"" "repo" args |> String.trim in
@@ -104,7 +122,16 @@ let handle_keeper_pr_review_reply
       ~(meta : keeper_meta)
       ~(args : Yojson.Safe.t)
   =
-  let pr_number = Safe_ops.json_int ~default:0 "pr_number" args in
+  let pr_number =
+  (* Schema-drift compatibility: tool_shard.ml advertises [number]
+     (and most other PR tools also use [number]), but earlier
+     versions of these handlers required [pr_number]. Live log
+     2026-04-16 /loop iter 9 shows 14/3MB failures from keepers
+     sending the schema-canonical key. Read both. *)
+  let from_pr_number = Safe_ops.json_int ~default:0 "pr_number" args in
+  if from_pr_number <> 0 then from_pr_number
+  else Safe_ops.json_int ~default:0 "number" args
+in
   let comment_id = Safe_ops.json_int ~default:0 "comment_id" args in
   let body = Safe_ops.json_string ~default:"" "body" args |> String.trim in
   let repo = Safe_ops.json_string ~default:"" "repo" args |> String.trim in

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -354,45 +354,55 @@ let keeper_pr_review_tools : Types.tool_schema list = [
   {
     name = "keeper_pr_review_read";
     description = "Read PR metadata, diff, reviews, and comments. \
-Returns title, body, changed files, review threads, and truncated diff (max 64KB). Read-only.";
+Returns title, body, changed files, review threads, and truncated diff (max 64KB). Read-only. \
+Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name)")]);
-        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number")]);
+        ("pr_number", `Assoc [("type", `String "integer"); ("description", `String "PR number (preferred field name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number (legacy alias for pr_number)")]);
       ]);
-      ("required", `List [`String "repo"; `String "number"]);
+      (* No `required` for the number — the handler reads either
+         pr_number or number and emits a clear error if both are
+         missing. Schema-level required=[number] rejected callers
+         that learned the historical pr_number key. *)
+      ("required", `List [`String "repo"]);
     ];
   };
   {
     name = "keeper_pr_review_comment";
     description = "Submit a PR review with optional inline comments. \
-Events: COMMENT, APPROVE, REQUEST_CHANGES. Requires delivery or coding preset.";
+Events: COMMENT, APPROVE, REQUEST_CHANGES. Requires delivery or coding preset. \
+Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name)")]);
-        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number")]);
+        ("pr_number", `Assoc [("type", `String "integer"); ("description", `String "PR number (preferred field name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number (legacy alias for pr_number)")]);
         ("body", `Assoc [("type", `String "string"); ("description", `String "Review body text")]);
         ("event", `Assoc [("type", `String "string"); ("enum", `List [`String "COMMENT"; `String "APPROVE"; `String "REQUEST_CHANGES"]); ("description", `String "Review event type")]);
         ("path", `Assoc [("type", `String "string"); ("description", `String "File path for inline comment (optional)")]);
         ("line", `Assoc [("type", `String "integer"); ("description", `String "Line number for inline comment (optional)")]);
       ]);
-      ("required", `List [`String "repo"; `String "number"; `String "body"; `String "event"]);
+      ("required", `List [`String "repo"; `String "body"; `String "event"]);
     ];
   };
   {
     name = "keeper_pr_review_reply";
-    description = "Reply to a specific PR review comment. Requires delivery or coding preset.";
+    description = "Reply to a specific PR review comment. Requires delivery or coding preset. \
+Pass the PR number as `pr_number` (preferred) or `number` (legacy alias).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("repo", `Assoc [("type", `String "string"); ("description", `String "GitHub repo (owner/name)")]);
-        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number")]);
+        ("pr_number", `Assoc [("type", `String "integer"); ("description", `String "PR number (preferred field name)")]);
+        ("number", `Assoc [("type", `String "integer"); ("description", `String "PR number (legacy alias for pr_number)")]);
         ("comment_id", `Assoc [("type", `String "integer"); ("description", `String "Comment ID to reply to")]);
         ("body", `Assoc [("type", `String "string"); ("description", `String "Reply body text")]);
       ]);
-      ("required", `List [`String "repo"; `String "number"; `String "comment_id"; `String "body"]);
+      ("required", `List [`String "repo"; `String "comment_id"; `String "body"]);
     ];
   };
 ]


### PR DESCRIPTION
## Symptom

Live log, 2026-04-16 /loop iter 9 — \`keeper_pr_review_read\` returned 14 errors per ~3MB window, all identical:

\`\`\`
"pr_number is required. Good: pr_number=123."
\`\`\`

Top offender: \`keeper:verdict\` (8 of 14 \`tool_use_failure\` entries).

## Root cause

Schema drift between \`tool_shard.ml\` and the handler:

- **Schema** advertises: \`required=[repo, number]\` — key is \`number\`
- **Handler** reads: \`Safe_ops.json_int "pr_number"\` — key is \`pr_number\`

When the LLM follows the schema and sends \`{repo, number=123}\`, the handler sees no \`pr_number\` and rejects with the error above. The hint says \`pr_number=123\`, so the LLM may switch keys… only to fail again next call because the schema still says \`number\`. Loop trap.

## Fix

| Layer | Change |
|---|---|
| Handler (\`keeper_tool_pr_review.ml\`) | Reads \`pr_number\` first, falls back to \`number\`. Applied to all 3 handlers (read/comment/reply) for consistency. |
| Schema (\`tool_shard.ml\`) | Lists both keys in \`properties\`. \`pr_number\` marked preferred, \`number\` as legacy alias. \`required\` no longer includes the number — handler enforces. |
| Description | Calls out both names. |

## Related

Same shape as #7445 (\`masc_board_post\` \`body/content\` alias) — required field name in schema drifts from the handler's actual read.

## Loop series

PR #8 in the self-paced /loop:
- #7445 (board_post schema) — **MERGED**
- #7453, #7455, #7459, #7464, #7466, #7472 — Ready
- **this** (pr_review schema)

## Test plan

- [x] \`dune build --root .\` clean
- [ ] \`dune runtest --root .\` — running
- [ ] Deploy + observe: \`pr_number is required\` errors → 0 (\`keeper:verdict\` succeeds on PR review reads)