### PR TITLE
refactor(imessage-bot): migrate sidecar runtime paths + add read-fallback (B3c-imessage)

### DIFF
--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -59,17 +59,37 @@ class IMessageBot:
             self._refresh_self_chat_guid(force=True)
 
     def _load_bindings(self) -> None:
-        """Load chat-to-keeper bindings from state file."""
+        """Load chat-to-keeper bindings from state file.
+
+        Read priority: new default (binding_store_path) > legacy
+        (legacy_binding_store_path) > empty. Next write always goes to the
+        new default, so a one-shot migration is transparent after the
+        .gate/runtime/ rollout (see #7468, #7471).
+        """
         path = Path(self.cfg.binding_store_path)
+        source = "default"
         if not path.exists():
-            return
+            legacy_path = Path(self.cfg.legacy_binding_store_path)
+            if legacy_path.exists():
+                path = legacy_path
+                source = "legacy"
+            else:
+                return
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
                 self._bindings = {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
-                logger.info("Loaded %d binding(s)", len(self._bindings))
+                if source == "legacy":
+                    logger.info(
+                        "Loaded %d binding(s) from legacy store %s; next write goes to %s",
+                        len(self._bindings),
+                        path,
+                        self.cfg.binding_store_path,
+                    )
+                else:
+                    logger.info("Loaded %d binding(s)", len(self._bindings))
         except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load bindings: %s", e)
+            logger.warning("Failed to load bindings from %s: %s", path, e)
 
     def _resolve_keeper(self, msg: InboundMessage) -> str:
         """Resolve which keeper handles a message.

--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -15,12 +15,18 @@ from urllib.parse import urlparse
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 
-DEFAULT_STATE_DIR: Final[str] = ".masc/connectors/imessage"
-DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/imessage/bindings.json"
-DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".masc/connectors/imessage/binding_audit.jsonl"
-DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/imessage/status.json"
-DEFAULT_CURSOR_PATH: Final[str] = ".masc/connectors/imessage/cursor.json"
+DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/imessage"
+DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/imessage/bindings.json"
+DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".gate/runtime/imessage/binding_audit.jsonl"
+DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/imessage/status.json"
+DEFAULT_CURSOR_PATH: Final[str] = ".gate/runtime/imessage/cursor.json"
 CHAT_DB_PATH: Final[str] = os.path.expanduser("~/Library/Messages/chat.db")
+
+# Legacy layout from the pre-v0.9.0 release (OCaml side migrated in #7468 B3b).
+# bot.py's _load_bindings uses this as a read-fallback — if the new
+# binding_store_path does not exist and the legacy one does, the legacy file
+# is loaded and the next write lands at the new default.
+LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/imessage/bindings.json"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -82,6 +88,10 @@ class BotConfig(BaseSettings):
     binding_audit_path: str = Field(default=DEFAULT_BINDING_AUDIT_PATH)
     status_path: str = Field(default=DEFAULT_STATUS_PATH)
     cursor_path: str = Field(default=DEFAULT_CURSOR_PATH)
+    # Legacy read-fallback (pre-v0.9.0 layout). Not env-configurable — intended
+    # to be a stable constant; operators still on an even older layout should
+    # set IMESSAGE_BINDING_STORE_PATH explicitly.
+    legacy_binding_store_path: str = Field(default=LEGACY_BINDING_STORE_PATH)
 
     # chat.db
     chat_db_path: str = Field(default=CHAT_DB_PATH)


### PR DESCRIPTION
## Summary

- Python-side counterpart of #7468 (B3b iMessage OCaml migration). Default `IMESSAGE_*_PATH` values move from `.masc/connectors/imessage/*` to `.gate/runtime/imessage/*`.
- **Adds read-fallback plumbing to `bot.py`** — iMessage sidecar previously had no fallback loop (unlike Discord), so this PR introduces one. Matches the behavior pattern Discord uses since #7470.
- Scope minimized: only `bindings.json` is fallback-aware. `status.json`, `cursor.json`, `binding_audit.jsonl` are write-only from the sidecar's perspective.

## Product impact

**Transparent** for operators using default paths or `IMESSAGE_BINDING_STORE_PATH` env var.

On first startup after upgrade:
1. `.gate/runtime/imessage/bindings.json` doesn't exist yet.
2. `_load_bindings` falls back to `.masc/connectors/imessage/bindings.json` (old default) and loads from there.
3. Logs `Loaded N binding(s) from legacy store ...; next write goes to .gate/runtime/imessage/bindings.json`.
4. Next `save_bindings` write lands at the new default. Legacy file becomes dormant but unharmed.

## Rationale

B3b (#7468) migrated the OCaml Gate's iMessage runtime paths. The sidecar writes its own `bindings.json`, so unless the sidecar's default matches, a fresh instance ends up with split-brain data (Gate reads `.gate/runtime/imessage/bindings.json`, sidecar writes `.masc/connectors/imessage/bindings.json`).

Unlike Discord's `bot.py`, iMessage's `_load_bindings` had a single path check (no legacy branch). This PR adds the 1-tier fallback pattern, keeping it deliberately minimal — no Pydantic `AliasChoices` for the legacy field (it's a stable constant, not env-configurable).

## Changes

- `sidecars/imessage-bot/src/config.py`:
  - `DEFAULT_STATE_DIR` + `DEFAULT_{BINDING_STORE,BINDING_AUDIT,STATUS,CURSOR}_PATH` → `.gate/runtime/imessage/*`
  - Added `LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/imessage/bindings.json"`
  - Added `legacy_binding_store_path: str = Field(default=LEGACY_BINDING_STORE_PATH)` (non-env-configurable; operators on an older-still layout should set `IMESSAGE_BINDING_STORE_PATH` explicitly)
- `sidecars/imessage-bot/src/bot.py`:
  - `_load_bindings` now checks `legacy_binding_store_path` when the new default is absent; logs the migration on fallback

## Evidence

- `python -m py_compile src/config.py src/bot.py` → OK (syntax clean)
- Full `pytest` requires the sidecar venv (`pydantic_settings`, `AppKit`/`objc` for AppleScript bridging) — not available in this worktree. CI will run it.

## Review evidence

- Only `_load_bindings` reads a sidecar-owned state file at startup. `StatusStore`, `advance_cursor`, and audit writes are all write-side. Confirmed with `grep -n 'binding_store\|status_path\|cursor_path\|binding_audit' sidecars/imessage-bot/src/bot.py` — 3 occurrences, all distinguishable:
  - `self.status_store = StatusStore(Path(self.cfg.status_path))` — writes only
  - `path = Path(self.cfg.binding_store_path)` — in `_load_bindings`, now fallback-aware
  - `advance_cursor(Path(self.cfg.cursor_path), last_ok_rowid)` — writes only
- Status file cold-start is fine: the Gate's own `status_read_path` from #7468 already has OCaml-side legacy fallback, and a heartbeat rewrites the status file within seconds. No data loss during the transition.

## Linked issue

Refs #7468 (B3b OCaml iMessage), #7470 (B3c-discord Python sidecar), #7471 (v0.9.1 bump).

## Test plan

- [x] `python -m py_compile src/config.py src/bot.py`
- [ ] CI: Build and Test (will run pytest), Lint, Health
- [ ] Post-merge: deploy iMessage sidecar locally — verify first-run log reports `legacy store` path, next `/bind` edit writes to `.gate/runtime/imessage/bindings.json`, old file remains for rollback safety.

## Follow-ups

- **B3c-slack / -telegram**: same pattern — add 1-tier fallback in each `bot.py` + rotate `DEFAULT_*` → `LEGACY_*`. Slack and Telegram sidecars have the same "no fallback loop" gap as iMessage did before this PR.
- **B2**: `keeper_name` → `destination_id` in `gate_protocol`. Independent wire-format deprecation cycle.
- **B4**: standalone `gate-mcp` repo. After remainder of B3c + B2 lands.