### PR TITLE
refactor(slack-bot): migrate sidecar runtime paths + add read-fallback (B3c-slack)

### DIFF
--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -45,9 +45,22 @@ class SlackGateBot:
         self._messages_failed = 0
 
     def _load_bindings(self) -> None:
+        """Load channel-to-keeper bindings.
+
+        Read priority: new default (binding_store_path) > legacy
+        (legacy_binding_store_path) > empty. Next _save_bindings always
+        writes to the new default, so the migration is transparent after
+        the .gate/runtime/ rollout (see #7468, #7471).
+        """
         path = Path(self.cfg.binding_store_path)
+        source = "default"
         if not path.exists():
-            return
+            legacy_path = Path(self.cfg.legacy_binding_store_path)
+            if legacy_path.exists():
+                path = legacy_path
+                source = "legacy"
+            else:
+                return
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
@@ -56,9 +69,17 @@ class SlackGateBot:
                     for k, v in data.items()
                     if isinstance(v, str)
                 }
-                logger.info("Loaded %d binding(s)", len(self._bindings))
+                if source == "legacy":
+                    logger.info(
+                        "Loaded %d binding(s) from legacy store %s; next write goes to %s",
+                        len(self._bindings),
+                        path,
+                        self.cfg.binding_store_path,
+                    )
+                else:
+                    logger.info("Loaded %d binding(s)", len(self._bindings))
         except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load bindings: %s", e)
+            logger.warning("Failed to load bindings from %s: %s", path, e)
 
     def _save_bindings(self) -> None:
         path = Path(self.cfg.binding_store_path)

--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -15,9 +15,14 @@ from urllib.parse import urlparse
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
-DEFAULT_STATE_DIR: Final[str] = ".masc/connectors/slack"
-DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/slack/bindings.json"
-DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/slack/status.json"
+DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/slack"
+DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/slack/bindings.json"
+DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/slack/status.json"
+
+# Legacy read-fallback (pre-v0.9.0 layout). See bot.py _load_bindings —
+# loads from here if the new default is absent, then writes to the new
+# default on next save.
+LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/slack/bindings.json"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -72,6 +77,8 @@ class BotConfig(BaseSettings):
     # State paths
     binding_store_path: str = Field(default=DEFAULT_BINDING_STORE_PATH)
     status_path: str = Field(default=DEFAULT_STATUS_PATH)
+    # Legacy read-fallback (pre-v0.9.0 layout). Not env-configurable.
+    legacy_binding_store_path: str = Field(default=LEGACY_BINDING_STORE_PATH)
 
     @field_validator("slack_bot_token")
     @classmethod


### PR DESCRIPTION
## Summary

- Same migration pattern as #7477 (B3c-imessage). Slack sidecar default `SLACK_BINDING_STORE_PATH` + `SLACK_STATUS_PATH` move from `.masc/connectors/slack/*` to `.gate/runtime/slack/*`.
- Adds 1-tier read-fallback to `bot.py._load_bindings` — Slack's `bot.py` previously had no fallback loop (same gap iMessage had before #7477).

## Product impact

Transparent. Pre-v0.9.0 `bindings.json` auto-discovered on first startup; next save writes to the new default.

## Changes

- `sidecars/slack-bot/src/config.py`:
  - `DEFAULT_STATE_DIR` + `DEFAULT_BINDING_STORE_PATH` + `DEFAULT_STATUS_PATH` → `.gate/runtime/slack/*`
  - Added `LEGACY_BINDING_STORE_PATH` + `legacy_binding_store_path` Pydantic field
- `sidecars/slack-bot/src/bot.py`:
  - `_load_bindings` now checks legacy path; logs migration on fallback

## Evidence

- `python -m py_compile src/config.py src/bot.py` → OK

## Linked issue

Refs #7477 (B3c-imessage), #7470 (B3c-discord), #7471 (v0.9.1 bump).

## Test plan

- [x] syntax check
- [ ] CI: Build and Test, Lint, Health
- [ ] Post-merge: verify Slack sidecar first-run log reports legacy fallback

## Follow-ups

- **B3c-telegram**: last of the Python sidecar migrations. Same pattern.
- **B2** and **B4**: see previous PRs in the chain.