### PR TITLE
refactor(telegram-bot): migrate sidecar runtime paths + add read-fallback (B3c-telegram)

### DIFF
--- a/sidecars/telegram-bot/src/bot.py
+++ b/sidecars/telegram-bot/src/bot.py
@@ -52,10 +52,22 @@ class TelegramGateBot:
         self._last_message_at = ""
 
     def _load_bindings(self) -> None:
-        """Load chat-to-keeper bindings from state file."""
+        """Load chat-to-keeper bindings.
+
+        Read priority: new default (binding_store_path) > legacy
+        (legacy_binding_store_path) > empty. Next _save_bindings always
+        writes to the new default, so the migration is transparent after
+        the .gate/runtime/ rollout (see #7468, #7471).
+        """
         path = Path(self.cfg.binding_store_path)
+        source = "default"
         if not path.exists():
-            return
+            legacy_path = Path(self.cfg.legacy_binding_store_path)
+            if legacy_path.exists():
+                path = legacy_path
+                source = "legacy"
+            else:
+                return
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
@@ -64,9 +76,17 @@ class TelegramGateBot:
                     for k, v in data.items()
                     if isinstance(v, str)
                 }
-                logger.info("Loaded %d binding(s)", len(self._bindings))
+                if source == "legacy":
+                    logger.info(
+                        "Loaded %d binding(s) from legacy store %s; next write goes to %s",
+                        len(self._bindings),
+                        path,
+                        self.cfg.binding_store_path,
+                    )
+                else:
+                    logger.info("Loaded %d binding(s)", len(self._bindings))
         except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load bindings: %s", e)
+            logger.warning("Failed to load bindings from %s: %s", path, e)
 
     def _save_bindings(self) -> None:
         """Persist bindings to disk."""

--- a/sidecars/telegram-bot/src/config.py
+++ b/sidecars/telegram-bot/src/config.py
@@ -13,9 +13,14 @@ from urllib.parse import urlparse
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
 
-DEFAULT_STATE_DIR: Final[str] = ".masc/connectors/telegram"
-DEFAULT_BINDING_STORE_PATH: Final[str] = ".masc/connectors/telegram/bindings.json"
-DEFAULT_STATUS_PATH: Final[str] = ".masc/connectors/telegram/status.json"
+DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/telegram"
+DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/telegram/bindings.json"
+DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/telegram/status.json"
+
+# Legacy read-fallback (pre-v0.9.0 layout). See bot.py _load_bindings —
+# loads from here if the new default is absent, then writes to the new
+# default on next save.
+LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/telegram/bindings.json"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -75,6 +80,8 @@ class BotConfig(BaseSettings):
     # State paths
     binding_store_path: str = Field(default=DEFAULT_BINDING_STORE_PATH)
     status_path: str = Field(default=DEFAULT_STATUS_PATH)
+    # Legacy read-fallback (pre-v0.9.0 layout). Not env-configurable.
+    legacy_binding_store_path: str = Field(default=LEGACY_BINDING_STORE_PATH)
 
     @field_validator("telegram_bot_token")
     @classmethod


### PR DESCRIPTION
## Summary

- Closes the B3c Python sidecar migration triplet. Telegram sidecar's default `TELEGRAM_*_PATH` values move from `.masc/connectors/telegram/*` to `.gate/runtime/telegram/*`, and `bot.py._load_bindings` gains the same 1-tier legacy fallback introduced in #7477 (iMessage) and #7478 (Slack).
- With this PR, all four Python sidecars (`discord-bot`, `imessage-bot`, `slack-bot`, `telegram-bot`) share the same `config.py` + `bot.py` read-fallback pattern.

## Product impact

Transparent. Pre-v0.9.0 `bindings.json` auto-discovered; next save writes to the new default.

## Changes

- `sidecars/telegram-bot/src/config.py`:
  - `DEFAULT_STATE_DIR` + `DEFAULT_BINDING_STORE_PATH` + `DEFAULT_STATUS_PATH` → `.gate/runtime/telegram/*`
  - Added `LEGACY_BINDING_STORE_PATH` + `legacy_binding_store_path` Pydantic field
- `sidecars/telegram-bot/src/bot.py`:
  - `_load_bindings` now checks legacy path; logs migration on fallback

## Evidence

- `python -m py_compile src/config.py src/bot.py` → OK

## Linked issue

Refs #7477 (B3c-imessage), #7478 (B3c-slack), #7470 (B3c-discord), #7471 (v0.9.1 bump). Completes B3c Python half.

## Test plan

- [x] syntax check
- [ ] CI: Build and Test, Lint, Health
- [ ] Post-merge: verify Telegram sidecar first-run log reports legacy fallback

## Follow-ups

- **v0.9.2 bump**: after this merges, B3c is complete. Patch bump covers all four sidecars' legacy fallback + path migration (PRs #7470, #7477, #7478, #7479).
- **B2**: `keeper_name` → `destination_id` in `gate_protocol`. Independent.
- **B4**: standalone `gate-mcp` repo. After B2 lands.
- **Release workflow fix**: Issue #7475 (ocaml/setup-ocaml@v3 upstream regression) still pending — must resolve before v0.9.2 tag push so the binary release succeeds.