### PR TITLE
feat(gate-protocol): accept destination_id alongside keeper_name (B2 Phase 1)

### DIFF
--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -96,6 +96,16 @@ let inbound_of_json json =
       let raw = str "channel" in
       String.lowercase_ascii (String.trim raw)
     in
+    (* Read priority for the keeper-routing field: accept the new
+       [destination_id] key first and fall back to the legacy [keeper_name]
+       key. Both map onto the same record field for now; emit-side is still
+       [keeper_name] only (B2 Phase 1 — parse-both / emit-legacy). The
+       emit-side rotation happens in Phase 2. *)
+    let keeper_name =
+      let destination = str "destination_id" in
+      if destination <> "" then destination
+      else str "keeper_name"
+    in
     let metadata =
       match json |> member "metadata" with
       | `Assoc pairs ->
@@ -109,7 +119,7 @@ let inbound_of_json json =
       channel_user_id = str "channel_user_id";
       channel_user_name = str "channel_user_name";
       channel_room_id = str "channel_room_id";
-      keeper_name = str "keeper_name";
+      keeper_name;
       content = str "content";
       idempotency_key = str "idempotency_key";
       metadata;

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -120,6 +120,57 @@ let test_inbound_of_json_invalid () =
   | Error _ -> ()
   | Ok _ -> fail "expected parse error"
 
+let test_inbound_of_json_accepts_destination_id () =
+  let json =
+    `Assoc [
+      ("channel", `String "discord");
+      ("channel_user_id", `String "u1");
+      ("channel_user_name", `String "alice");
+      ("channel_room_id", `String "r1");
+      ("destination_id", `String "luna");
+      ("content", `String "hi");
+      ("idempotency_key", `String "k-dest");
+    ]
+  in
+  match Gate_protocol.inbound_of_json json with
+  | Ok msg -> check string "destination_id maps to keeper_name" "luna" msg.keeper_name
+  | Error e -> fail e
+
+let test_inbound_of_json_destination_id_wins_over_keeper_name () =
+  let json =
+    `Assoc [
+      ("channel", `String "discord");
+      ("channel_user_id", `String "u1");
+      ("channel_user_name", `String "alice");
+      ("channel_room_id", `String "r1");
+      ("destination_id", `String "new-name");
+      ("keeper_name", `String "legacy-name");
+      ("content", `String "hi");
+      ("idempotency_key", `String "k-both");
+    ]
+  in
+  match Gate_protocol.inbound_of_json json with
+  | Ok msg ->
+      check string "destination_id takes precedence" "new-name" msg.keeper_name
+  | Error e -> fail e
+
+let test_inbound_of_json_keeper_name_still_works () =
+  let json =
+    `Assoc [
+      ("channel", `String "discord");
+      ("channel_user_id", `String "u1");
+      ("channel_user_name", `String "alice");
+      ("channel_room_id", `String "r1");
+      ("keeper_name", `String "legacy-only");
+      ("content", `String "hi");
+      ("idempotency_key", `String "k-legacy");
+    ]
+  in
+  match Gate_protocol.inbound_of_json json with
+  | Ok msg ->
+      check string "keeper_name alone still routes" "legacy-only" msg.keeper_name
+  | Error e -> fail e
+
 let test_outbound_to_json_roundtrip () =
   let out : Gate_protocol.outbound_message = {
     keeper_name = "luna";
@@ -179,6 +230,9 @@ let () =
           test_case "inbound normalizes case" `Quick test_inbound_of_json_normalizes_case;
           test_case "inbound with metadata" `Quick test_inbound_of_json_with_metadata;
           test_case "inbound invalid" `Quick test_inbound_of_json_invalid;
+          test_case "inbound accepts destination_id" `Quick test_inbound_of_json_accepts_destination_id;
+          test_case "destination_id wins over keeper_name" `Quick test_inbound_of_json_destination_id_wins_over_keeper_name;
+          test_case "inbound keeper_name still works" `Quick test_inbound_of_json_keeper_name_still_works;
           test_case "outbound roundtrip" `Quick test_outbound_to_json_roundtrip;
           test_case "error_json" `Quick test_error_json;
         ] );


### PR DESCRIPTION
## Summary

- First step of **Track B2** wire-vocabulary migration. `gate_protocol.inbound_of_json` now accepts a new `destination_id` JSON field; falls back to legacy `keeper_name` when absent or empty.
- **Parse-both / emit-legacy**: outbound serialization still emits `keeper_name`. Fully backward-compatible — no breaking change for sidecars, dashboard, or external producers.
- Sets up the three-phase deprecation cycle documented in the Track B roadmap.

## Product impact

**None visible yet.** Producers can start emitting `destination_id` immediately and it routes correctly, but no existing producer is required to change.

When Phase 2 lands (next PR), consumers see both keys in outbound JSON and can begin parsing `destination_id` as the canonical field. Phase 3 drops `keeper_name` from emit.

## Rationale

`keeper_name` is MASC-specific vocabulary that baked into the Gate library's public wire format. As `masc_mcp.gate` evolves toward a standalone `gate-mcp` repo (Track B4), this coupling blocks the extraction — "keeper" means "MASC keeper agent", not "generic message recipient."

`destination_id` is channel-agnostic and semantics-free about what the recipient is (a keeper, a tool, a webhook — the Gate doesn't care). Same record field inside OCaml for now, but the wire contract is future-proof.

## Three-phase deprecation cycle

| Phase | Inbound parse | Outbound emit | Purpose |
|-------|--------------|--------------|---------|
| **1 (this PR)** | accept both, prefer `destination_id` | `keeper_name` only | safe rollout of new key |
| **2** (next PR) | accept both | emit both | consumer migration window |
| **3** (after cooling period) | accept both | `destination_id` only | remove legacy emit |
| **4** (future major bump) | `destination_id` only | `destination_id` only | full removal |

## Changes

`lib/gate/gate_protocol.ml`:
```ocaml
(* Read priority: destination_id first, fallback to keeper_name. *)
let keeper_name =
  let destination = str "destination_id" in
  if destination <> "" then destination
  else str "keeper_name"
in
```

Comment block documents the phase.

## Precedence rule

When **both** keys are present on inbound, `destination_id` wins. Rationale:
- Producers that have migrated to the new key should be authoritative.
- Legacy producers that only emit `keeper_name` stay untouched.
- Transition scenarios where a proxy adds `destination_id` are handled atomically.

Alternative (reject when both present) would be over-strict and block gradual migration.

## Evidence

- `dune build --root .` → clean.
- `dune exec test/test_gate_protocol.exe` → **19/19 pass**:
  - 16 existing tests unchanged (keeper_name-only path still validates)
  - 3 new tests:
    - `inbound accepts destination_id`
    - `destination_id wins over keeper_name` (both-present case)
    - `inbound keeper_name still works` (legacy-only path explicit)

## Review evidence

- No external caller reads `keeper_name` off the JSON directly — `gate_protocol.inbound_of_json` is the sole entry point for parsing inbound. `grep -rn '\"keeper_name\"' lib/gate/ test/` shows hits only in the record-field write, comment, and state-persistence JSON (not yet migrated — that's Phase 2's scope).
- Outbound emit path untouched: `outbound_to_json` still writes `(\"keeper_name\", \`String out.keeper_name)`. No consumer breakage.
- Internal `keeper_name` field name inside the `inbound_message` record is kept. Renaming it is a Phase 3+ concern (cross-module refactor; would touch `channel_gate_*` state files).

## Linked issue

Refs #7407, #7452, #7457 (Gate sub-library extraction), #7462 / #7471 / #7481 (version bumps), #7467, #7468, #7470, #7477, #7478, #7479 (B3a/b/c runtime path migrations). Opens Track B2 (vocabulary wire cycle).

## Test plan

- [x] `dune build --root .`
- [x] `dune exec test/test_gate_protocol.exe` → 19/19
- [ ] CI: Build and Test, Lint, Health

## Follow-ups

- **B2 Phase 2**: `outbound_to_json` emits both `keeper_name` AND `destination_id`. Same record field, two keys. Lets consumers migrate.
- **B2 Phase 3**: drop `keeper_name` from emit (inbound parse still accepts it for one more release cycle).
- **B2 Phase 4 + B4**: rename internal record field + extract gate-mcp as standalone repo. Major version bump.