### PR TITLE
feat(gate-protocol): emit destination_id in outbound JSON (B2 Phase 2)

### DIFF
--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -138,9 +138,15 @@ let outbound_to_json out =
           ("tokens_used", `Int s.tokens_used);
         ]
   in
+  (* B2 Phase 2: emit both [keeper_name] and [destination_id]. Consumers
+     migrating to the new vocabulary can begin reading [destination_id];
+     legacy consumers keep reading [keeper_name]. Phase 3 will drop
+     [keeper_name] from emit (inbound parse will still accept it for one
+     more release cycle). *)
   let base = [
     ("ok", `Bool true);
     ("keeper_name", `String out.keeper_name);
+    ("destination_id", `String out.keeper_name);
     ("reply", `String out.content);
     ("turn_stats", stats_json);
   ] in

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -171,6 +171,18 @@ let test_inbound_of_json_keeper_name_still_works () =
       check string "keeper_name alone still routes" "legacy-only" msg.keeper_name
   | Error e -> fail e
 
+let test_outbound_emits_destination_id () =
+  let out : Gate_protocol.outbound_message = {
+    keeper_name = "luna";
+    content = "hi";
+    structured = None;
+    turn_stats = None;
+  } in
+  let json = Gate_protocol.outbound_to_json out in
+  let open Yojson.Safe.Util in
+  check string "keeper_name still emitted" "luna" (json |> member "keeper_name" |> to_string);
+  check string "destination_id mirrors keeper_name" "luna" (json |> member "destination_id" |> to_string)
+
 let test_outbound_to_json_roundtrip () =
   let out : Gate_protocol.outbound_message = {
     keeper_name = "luna";
@@ -233,6 +245,7 @@ let () =
           test_case "inbound accepts destination_id" `Quick test_inbound_of_json_accepts_destination_id;
           test_case "destination_id wins over keeper_name" `Quick test_inbound_of_json_destination_id_wins_over_keeper_name;
           test_case "inbound keeper_name still works" `Quick test_inbound_of_json_keeper_name_still_works;
+          test_case "outbound emits destination_id" `Quick test_outbound_emits_destination_id;
           test_case "outbound roundtrip" `Quick test_outbound_to_json_roundtrip;
           test_case "error_json" `Quick test_error_json;
         ] );


### PR DESCRIPTION
## Summary

- Track B2 **Phase 2**. `outbound_to_json` now emits both `keeper_name` and `destination_id` with the same value (the `outbound_message.keeper_name` record field).
- Continues the parse-both / emit-both / emit-new-only cycle started in #7482 (Phase 1).
- No-op for legacy consumers — the wire payload grows by one field per outbound message.

## Product impact

Zero breakage. Consumers can migrate to `destination_id` on their own schedule. Legacy consumers reading `keeper_name` continue working unchanged.

## Changes

`lib/gate/gate_protocol.ml` — `outbound_to_json` base list now includes:
```ocaml
("keeper_name", `String out.keeper_name);
("destination_id", `String out.keeper_name);
```

Both fields always present with identical values during Phase 2.

## Evidence

- `dune build --root .` → clean
- `dune exec test/test_gate_protocol.exe` → **20/20 pass** (+1 test: `outbound emits destination_id`)

## CI note

Upstream `ocaml/setup-ocaml` opam-binary regression (Issue #7475) still blocks Build and Test + Lint. Admin merge planned, consistent with #7481 / #7482 precedent — the change is code-correct and has local test coverage.

## Linked issue

Refs #7482 (B2 Phase 1). Continues Track B2.

## Test plan

- [x] `dune build --root .`
- [x] `dune exec test/test_gate_protocol.exe` → 20/20
- [ ] CI: blocked by upstream (Issue #7475)

## Follow-ups

- **B2 Phase 3**: drop `keeper_name` from emit (inbound parse still accepts it for one more cycle). Separate PR after a cooling period so consumers have time to read both keys.
- **B2 Phase 4 / B4**: rename internal OCaml field `keeper_name` → `destination_id` (cross-module refactor) + extract gate-mcp as standalone repo. Major version.