### PR TITLE
fix(keeper_bash): redirect gh commands to keeper_shell op=gh (#7442)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -428,12 +428,23 @@ let handle_keeper_bash
       match validate cmd with
       | Error reason ->
         Log.Keeper.warn "keeper_bash blocked: %s (cmd=%s)" reason cmd_for_log;
+        let lower_cmd = String.lowercase_ascii (String.trim cmd) in
+        let starts_with_gh =
+          String.length lower_cmd >= 2
+          && String.sub lower_cmd 0 2 = "gh"
+          && (String.length lower_cmd = 2 || lower_cmd.[2] = ' ')
+        in
         let hint =
           if String.length reason > 0 &&
              (Re.execp (Re.Pcre.re "chain|redirect|pipe|semicolon" |> Re.compile) (String.lowercase_ascii reason))
           then "Use separate tool calls instead of chaining. Call keeper_bash once per command."
           else if Re.execp (Re.Pcre.re "inject|symbol" |> Re.compile) (String.lowercase_ascii reason)
           then "Avoid shell metacharacters. Use keeper_shell with a specific op (rg, find, ls) instead."
+          else if starts_with_gh
+          then "Use keeper_shell op='gh' for GitHub CLI commands. \
+                The keeper_bash allow-list intentionally excludes gh — \
+                the keeper_shell path carries the auth/audit hooks. \
+                Example: keeper_shell(op='gh', cmd='pr list')."
           else "Check the command for blocked patterns. Use keeper_shell for structured ops (rg, ls, find)."
         in
         Yojson.Safe.to_string


### PR DESCRIPTION
## Summary

Fixes #7442. masc-improver was retrying `gh` commands on `keeper_bash` even though the bash allow-list intentionally excludes `gh`, eventually tripping the circuit breaker.

The existing `command_blocked` hint had a 3-branch cascade (chain/pipe → separate calls, inject/symbol → keeper_shell with op, default → structured ops). None of these tells the LLM that `gh` has its own dedicated `keeper_shell op='gh'` path with auth and audit hooks.

## Change

`lib/keeper/keeper_exec_shell.ml` — add a 4th branch detecting commands starting with `gh` (with word boundary to avoid matching `ghost`), returning a hint that points to `keeper_shell op='gh'` with a concrete example.

```ocaml
else if starts_with_gh
then "Use keeper_shell op='gh' for GitHub CLI commands. \
      The keeper_bash allow-list intentionally excludes gh — \
      the keeper_shell path carries the auth/audit hooks. \
      Example: keeper_shell(op='gh', cmd='pr list')."
```

The redirect target is real — `keeper_shell` `"gh"` op is implemented at `lib/keeper/keeper_exec_shell.ml:1036` and validated via `Worker_dev_tools.validate_gh_command`.

## Why this fix vs. prompt/persona

User-recommended Option (a) was prompt/persona update. I went with the runtime hint instead because:
- The hint reaches every keeper, not just personas that get refreshed
- It's where the LLM actually sees the failure (immediate feedback loop)
- It survives prompt drift across keeper restarts/refactors

The persona update is still worth doing as a follow-up, but the runtime hint is the load-bearing fix.

## Pattern reference

\"Tool error messages teach LLM\" pattern — terse \"X not allowed\" causes retry loops; a redirect hint converges in ≤1 retry. Recent precedents in this loop session:
- #7459 (masc_code_edit hint surfaces near-match lines)
- #7464 (masc_transition error includes current_assignee)
- #7466 (shell command_blocked hint redirects OCaml syntax)

## Test plan

- [x] `dune build lib/keeper` succeeds
- [ ] `dune runtest lib/keeper` (CI)
- [ ] Manual: feed a blocked `gh pr list` to keeper_bash and confirm hint mentions `keeper_shell op='gh'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)