### PR TITLE
feat(gate-protocol): drop keeper_name from outbound JSON (B2 Phase 3)

### DIFF
--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -138,14 +138,14 @@ let outbound_to_json out =
           ("tokens_used", `Int s.tokens_used);
         ]
   in
-  (* B2 Phase 2: emit both [keeper_name] and [destination_id]. Consumers
-     migrating to the new vocabulary can begin reading [destination_id];
-     legacy consumers keep reading [keeper_name]. Phase 3 will drop
-     [keeper_name] from emit (inbound parse will still accept it for one
-     more release cycle). *)
+  (* B2 Phase 3: [destination_id] is the sole outbound routing key. The
+     legacy [keeper_name] output was dropped now that all known consumers
+     (sidecars via gate_shared.GateResponse.from_json, #7485) prefer
+     [destination_id] and only fall back to [keeper_name] when the new key
+     is absent. Inbound parse still accepts either key — Phase 4 can
+     retire the [keeper_name] wire form entirely in a future major bump. *)
   let base = [
     ("ok", `Bool true);
-    ("keeper_name", `String out.keeper_name);
     ("destination_id", `String out.keeper_name);
     ("reply", `String out.content);
     ("turn_stats", stats_json);

--- a/test/test_gate_protocol.ml
+++ b/test/test_gate_protocol.ml
@@ -180,8 +180,11 @@ let test_outbound_emits_destination_id () =
   } in
   let json = Gate_protocol.outbound_to_json out in
   let open Yojson.Safe.Util in
-  check string "keeper_name still emitted" "luna" (json |> member "keeper_name" |> to_string);
-  check string "destination_id mirrors keeper_name" "luna" (json |> member "destination_id" |> to_string)
+  check string "destination_id present" "luna" (json |> member "destination_id" |> to_string);
+  (* B2 Phase 3 — legacy keeper_name key is no longer emitted. *)
+  (match json |> member "keeper_name" with
+   | `Null -> ()
+   | _ -> fail "keeper_name should no longer be emitted")
 
 let test_outbound_to_json_roundtrip () =
   let out : Gate_protocol.outbound_message = {
@@ -194,7 +197,7 @@ let test_outbound_to_json_roundtrip () =
   let open Yojson.Safe.Util in
   check bool "ok" true (json |> member "ok" |> to_bool);
   check string "reply" "reply text" (json |> member "reply" |> to_string);
-  check string "keeper" "luna" (json |> member "keeper_name" |> to_string);
+  check string "destination_id" "luna" (json |> member "destination_id" |> to_string);
   let stats = json |> member "turn_stats" in
   check int "duration" 100 (stats |> member "duration_ms" |> to_int)
 


### PR DESCRIPTION
## Summary

- Track B2 **Phase 3**. `outbound_to_json` now emits `destination_id` only; the legacy `keeper_name` output field is removed.
- Completes the wire-migration cycle on the gate → consumer side: inbound still accepts either key, outbound is canonical.
- Safe to ship now because all known consumers already prefer `destination_id` (#7485 sidecar shared helper).

## Product impact

Zero for sidecars using current `sidecars/shared/gate_shared/gate_response.py` (updated in #7485 which prefers `destination_id` and falls back to `keeper_name`). The removed emit field is no longer consulted by any consumer in this repo.

If any out-of-tree consumer still only parses `keeper_name`, they see `null` / empty now and must read `destination_id` instead. The deprecation path for that was: two releases where both keys were emitted (v0.9.2 code = Phase 2) so consumers had a window.

## Rationale

The full deprecation ladder:

| Phase | Inbound parse | Outbound emit |
|-------|--------------|--------------|
| Phase 1 #7482 | both (prefer `destination_id`) | `keeper_name` |
| Phase 2 #7484 | both | both |
| Phase 2b #7485 | sidecars accept both on the consumer side | — |
| **Phase 3 (this PR)** | both (unchanged) | **`destination_id` only** |
| Phase 4 (future major) | `destination_id` only | `destination_id` only |

## Changes

`lib/gate/gate_protocol.ml` — `outbound_to_json`:

```ocaml
let base = [
  ("ok", `Bool true);
  ("destination_id", `String out.keeper_name);
  ("reply", `String out.content);
  ("turn_stats", stats_json);
] in
```

Comment block updated to describe Phase 3 state and Phase 4 plan.

Tests updated (not added):
- `test_outbound_emits_destination_id` — now asserts `keeper_name` is NOT in the output (`member "keeper_name" = \`Null`)
- `test_outbound_to_json_roundtrip` — `"keeper_name"` check replaced with `"destination_id"`

## Evidence

- `dune build --root .` → clean
- `dune exec test/test_gate_protocol.exe` → **20/20 pass**

## Review evidence

Scanned existing consumers:
- `sidecars/shared/gate_shared/gate_response.py::from_json` — prefers `destination_id`, falls back to `keeper_name`. Pairs with this PR perfectly.
- `sidecars/<bot>/src/formatters.py` → uses `response.keeper_name` which is the dataclass field name (not wire key). No change needed.
- OCaml `outbound_message` record field `keeper_name` unchanged. This PR only affects the JSON decoder/encoder.

No other call site reads the raw JSON `keeper_name` key directly.

## CI note

Upstream `ocaml/setup-ocaml` opam regression (Issue #7475) still blocks Build and Test + Lint. Admin merge consistent with precedent.

## Linked issue

Refs #7482 (B2 Phase 1), #7484 (B2 Phase 2), #7485 (B2 Phase 2b). Completes the B2 wire-vocabulary migration (gate emit side).

## Test plan

- [x] `dune build --root .`
- [x] `dune exec test/test_gate_protocol.exe` → 20/20
- [ ] CI: blocked by upstream

## Follow-ups

- **v0.9.3 bump**: after this merges, B2 Phase 1–3 are all in main. Patch bump. Will include the now-complete wire migration in the release notes.
- **B2 Phase 4 / B4**: rename internal OCaml field + extract `gate-mcp` as standalone repo. Major version, planned for v1.0.