### PR TITLE
refactor(gate): drop phantom masc_log dependency from lib/gate/dune

### DIFF
--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -20,7 +20,6 @@
    eio.unix
    masc_config
    masc_core
-   masc_log
    masc_pulse
    masc_types
    fs_compat))


### PR DESCRIPTION
## Summary

- Removes `masc_log` from `lib/gate/dune`'s `libraries` stanza. It was declared but never actually referenced by any `lib/gate/*.ml` file.
- One tiny step toward Track B4 (standalone `gate-mcp` repo) — every transitive dep the gate library doesn't need reduces the extraction surface.
- **Not** removing `masc_core` this round: first attempt did, build broke on `Eio_guard.with_mutex` in `channel_gate.ml`. `masc_core` is a real dep (provides `Eio_guard`). Kept.

## Product impact

None. Phantom dep removal.

## Rationale

Investigation for B4 identified `masc_log` and `masc_core` as candidates for removal (zero direct `Log.` / `Masc_log.` / `Masc_core.` references in `lib/gate/*.ml`). Verification revealed:
- `masc_log` — truly unused. `grep -rn 'Log\.\|Masc_log\.' lib/gate/*.ml` → zero hits.
- `masc_core` — provides the `Eio_guard` module used by `channel_gate.ml:71` (`Eio_guard.with_mutex dedup_mutex`). Real dep.

Dep scan on the full gate source (`rg '\b[A-Z][a-zA-Z_]+\.' lib/gate/*.ml | rg -o '\b[A-Z][a-zA-Z_]+' | sort -u`) shows no reference starting with `Log` or `Masc_log`.

## Changes

`lib/gate/dune`:
```
(libraries
  yojson
  unix
  eio
  eio.unix
  masc_config
  masc_core        # retained (Eio_guard)
- masc_log         # phantom, removed
  masc_pulse
  masc_types
  fs_compat)
```

## Evidence

- `dune build --root .` → clean
- `dune exec test/test_gate_protocol.exe` → **20/20 pass**
- `dune exec test/test_channel_gate.exe` → **14/14 pass**

## Review evidence

Scan patterns used:
```
rg '\b[A-Z][a-zA-Z_]+\.' lib/gate/*.ml | rg -o '\b[A-Z][a-zA-Z_]+' | sort -u
```

`Log`, `Masc_log` — absent. `Masc_core` — absent (direct), but `Eio_guard` appears (provided by `masc_core`).

First attempt also removed `masc_core` → build failed with `Unbound module Eio_guard`. Restored. Follow-up for B4 should consider whether `Eio_guard` deserves its own tiny sub-library or whether inlining the one-function wrapper is simpler.

## CI note

Upstream `ocaml/setup-ocaml` opam regression (Issue #7475) continues to block CI Build and Test + Lint. Admin merge consistent with this session's precedent.

## Linked issue

Refs #7475 (upstream blocker). Pre-work for eventual Track B4.

## Test plan

- [x] `dune build --root .`
- [x] Gate tests 34/34 pass
- [ ] CI: blocked by upstream

## Follow-ups

- **masc_config thinning**: only `Env_config_core.{trim_opt, base_path, get_int}` are used. A 3-function extract could let gate depend on a much smaller config base.
- **masc_types thinning**: only `Types.parse_iso8601_opt` is used (discord/imessage state). Duplicating 60 LOC inside gate or sub-splitting to a `time_compat`-like module would drop the last structural tie to MASC domain types.
- **Eio_guard relocation**: if it's a thin wrapper over `Eio.Mutex`, consider inlining so `masc_core` drops out too.