### PR TITLE
refactor(gate): inline parse_iso8601_opt + drop masc_types dep (B4 precursor)

### DIFF
--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -198,7 +198,7 @@ let bool_option_member json key =
   json |> U.member key |> U.to_bool_option
 
 let stale_of_updated_at updated_at =
-  match Types.parse_iso8601_opt updated_at with
+  match Gate_time_util.parse_iso8601_opt updated_at with
   | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
   | None -> true
 

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -222,7 +222,7 @@ let bool_option_member json key =
   json |> U.member key |> U.to_bool_option
 
 let stale_of_updated_at updated_at =
-  match Types.parse_iso8601_opt updated_at with
+  match Gate_time_util.parse_iso8601_opt updated_at with
   | Some ts -> Unix.gettimeofday () -. ts > float_of_int (stale_after_sec ())
   | None -> true
 

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -21,5 +21,4 @@
    masc_config
    masc_core
    masc_pulse
-   masc_types
    fs_compat))

--- a/lib/gate/gate_time_util.ml
+++ b/lib/gate/gate_time_util.ml
@@ -1,10 +1,33 @@
-(** ISO-8601 timestamp formatter for Gate audit/status records.
+(** ISO-8601 timestamp helpers kept small and local to [masc_gate] so the
+    library does not depend on [lib/server/server_utils.ml] (HTTP routing
+    types) nor on [lib/types/] (Types.parse_iso8601_opt drags the whole
+    masc_types surface in for a 17-line helper).
 
-    Kept small and local to [masc_gate] so the library does not depend on
-    [lib/server/server_utils.ml] (which pulls in HTTP routing types). *)
+    When Gate moves out of the MASC monolith (Track B4), the remaining
+    external deps reduce to yojson/eio/unix/fs_compat — this file is part
+    of that cleanup. *)
 
 let iso8601_of_unix ts =
   let tm = Unix.gmtime ts in
   Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
     (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
     tm.tm_hour tm.tm_min tm.tm_sec
+
+(** Parse ISO8601 "YYYY-MM-DDTHH:MM:SSZ" to Unix float (UTC). Duplicated
+    locally from [Types.parse_iso8601_opt] to sever the dependency on
+    [masc_types]. Behavior byte-identical to the original. *)
+let parse_iso8601_opt s =
+  try
+    Scanf.sscanf s "%04d-%02d-%02dT%02d:%02d:%02dZ"
+      (fun year mon day hour min sec ->
+        let tm = {
+          Unix.tm_sec = sec; tm_min = min; tm_hour = hour;
+          tm_mday = day; tm_mon = mon - 1; tm_year = year - 1900;
+          tm_wday = 0; tm_yday = 0; tm_isdst = false;
+        } in
+        let local_epoch, _ = Unix.mktime tm in
+        let utc_of_local = Unix.gmtime local_epoch in
+        let utc_as_local, _ = Unix.mktime utc_of_local in
+        let tz_offset = local_epoch -. utc_as_local in
+        Some (local_epoch +. tz_offset))
+  with Scanf.Scan_failure _ | Failure _ | End_of_file -> None


### PR DESCRIPTION
## Summary

- Inlines the 17-line `parse_iso8601_opt` helper from `lib/types/types_core.ml` into `lib/gate/gate_time_util.ml`. That module already owns the reverse direction (`iso8601_of_unix`), so this makes it a cohesive time-helper for gate.
- **`masc_gate` no longer depends on `masc_types`** — the dep declaration is removed from `lib/gate/dune`.
- Second PR in the B4 precursor series (after #7491 which removed the phantom `masc_log` declaration).

## Product impact

None. Behavior byte-identical — same `Scanf.sscanf` + `Unix.mktime` logic.

## Rationale

Gate's only use of `masc_types` was one call: `Types.parse_iso8601_opt updated_at` in `channel_gate_discord_state.ml` and `channel_gate_imessage_state.ml`. Dragging the entire `masc_types` public API into the gate library for a 17-line helper is a poor cost/benefit ratio — especially when Gate is being prepared to extract into a standalone `gate-mcp` repo (Track B4). Net-17-line duplication beats carrying MASC-specific type surfaces that Gate doesn't otherwise need.

## Changes

- `lib/gate/gate_time_util.ml` — adds `parse_iso8601_opt` (copy of `Types.parse_iso8601_opt`, same algorithm). Module docstring updated to describe the new rationale.
- `lib/gate/channel_gate_discord_state.ml` — `Types.parse_iso8601_opt` → `Gate_time_util.parse_iso8601_opt`.
- `lib/gate/channel_gate_imessage_state.ml` — same call site rename.
- `lib/gate/dune` — `masc_types` removed from `libraries`.

## Evidence

- `dune build --root .` → clean
- `dune exec test/test_gate_protocol.exe` → **20/20 pass**
- `dune exec test/test_channel_gate.exe` → **14/14 pass**
- `dune exec test/test_channel_gate_imessage_state.exe` → **2/2 pass**

## Review evidence

- `grep -n 'Types\.' lib/gate/*.ml` — zero hits after this PR (was 2 before: Discord + iMessage state modules).
- `grep -n 'masc_types' lib/gate/dune` — zero hits after this PR.
- Algorithm preserved line-for-line: both original and copy build the `Unix.tm` record, call `Unix.mktime`, then adjust for TZ offset using the same `local_epoch /. utc_as_local` calculation. Unchanged exception handling (`Scanf.Scan_failure | Failure _ | End_of_file → None`).
- The original `Types.parse_iso8601_opt` stays in place for everything else in `masc_mcp` that uses it. No coupling removed outside Gate.

## CI note

Upstream `ocaml/setup-ocaml` opam regression (Issue #7475) still blocks CI Build and Test + Lint. Admin merge consistent with this session's precedent.

## Linked issue

Refs #7491 (phantom `masc_log` removal). Continues Track B4 precursor series.

## Test plan

- [x] `dune build --root .`
- [x] Gate tests 36/36 pass
- [ ] CI: blocked by upstream

## Follow-ups (B4 precursors)

- **masc_config thinning**: `lib/gate/` uses `Env_config_core.{trim_opt, base_path, get_int}` only (3 functions). A 15-LOC extract into a tiny `env_config_base` sub-library would let `masc_gate` drop `masc_config`.
- **masc_core thinning**: provides `Eio_guard.with_mutex` — a 3-line wrapper around `Eio.Mutex.use_rw`. Inlinable so `masc_core` drops out too.
- After both: Gate's deps are `yojson`, `unix`, `eio`, `eio.unix`, `masc_pulse`, `fs_compat`. `masc_pulse` itself is a Gate-only creature (only caller is `channel_gate.ml`). `fs_compat` is a tiny cross-platform helper.
- At that point, B4 extraction becomes a mechanical repo setup.