### PR TITLE
feat(prometheus): surface process open_fds gauge + WARN threshold (root-cause monitoring for EMFILE)

### DIFF
--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -251,12 +251,73 @@ let init () =
   register_histogram ~name:"masc_llm_provider_request_latency_seconds"
     ~help:"Per-HTTP-request LLM latency from OAS on_request_end callback. \
            Independent from masc_llm_inference_duration_seconds (turn-scope) — \
-           this fires per provider HTTP call regardless of keeper hook health." ()
+           this fires per provider HTTP call regardless of keeper hook health." ();
+  (* Process-level resource gauges.  Sampled on every /metrics scrape via
+     [update_fd_gauges] so a monotonic ramp (fd leak) is visible in the
+     time series before it crosses the OS limit and crashes the server.
+     Evidence: 2026-04-16 production incident, 4029 CLOSE_WAIT sockets
+     accumulated before the accept() path started failing. *)
+  add "masc_process_open_fds"
+    "Approximate count of open file descriptors for the server process \
+     (derived from /dev/fd). Ramp indicates a socket/file leak." Gauge;
+  add "masc_process_fd_warn_threshold"
+    "Threshold above which open_fds triggers a one-shot WARN log." Gauge
 
 let start_time = Time_compat.now ()
 
 let update_uptime () =
   set_gauge "masc_uptime_seconds" (Time_compat.now () -. start_time)
+
+(** Warn threshold for open_fds.  Default 3000 leaves headroom below the
+    typical macOS launchd soft limit (256 default but usually raised to
+    ~10k for masc-mcp via launchctl).  Override via
+    [MASC_FD_WARN_THRESHOLD] env var. *)
+let fd_warn_threshold =
+  match Sys.getenv_opt "MASC_FD_WARN_THRESHOLD" with
+  | Some s -> (match int_of_string_opt (String.trim s) with
+               | Some v when v > 0 -> v
+               | _ -> 3000)
+  | None -> 3000
+
+let fd_warned_once = ref false
+
+(** Count approximate open fds by reading [/dev/fd] (macOS + Linux both
+    expose live fd list there). The readdir call itself opens a transient
+    descriptor, so the count is [+1 / +2] off — monotonic behavior still
+    surfaces leaks faithfully.  Returns 0 when the directory is not
+    readable (e.g. non-unix host), which keeps the gauge non-fatal. *)
+let approximate_open_fd_count () =
+  let candidates = ["/dev/fd"; "/proc/self/fd"] in
+  let rec first_readable = function
+    | [] -> None
+    | path :: rest ->
+        (try Some (path, Sys.readdir path)
+         with _ -> first_readable rest)
+  in
+  match first_readable candidates with
+  | None -> 0
+  | Some (_path, entries) ->
+      (* Subtract the self-readdir descriptor when possible. *)
+      max 0 (Array.length entries - 1)
+
+let update_fd_gauges () =
+  let count = approximate_open_fd_count () in
+  set_gauge "masc_process_open_fds" (float_of_int count);
+  set_gauge "masc_process_fd_warn_threshold" (float_of_int fd_warn_threshold);
+  if count >= fd_warn_threshold && not !fd_warned_once then begin
+    fd_warned_once := true;
+    (* Log via Stdlib [prerr_endline] to avoid a Log module dependency
+       cycle (Prometheus is low-level).  The server bootstrap's log sink
+       picks it up and routes through the structured logger. *)
+    Printf.eprintf
+      "[WARN] [Server] process open fd count %d has reached warn \
+       threshold %d — likely socket/file leak, investigate before \
+       accept() starts failing with EMFILE.\n%!"
+      count fd_warn_threshold
+  end else if count < fd_warn_threshold / 2 then
+    (* Reset the one-shot latch once we drop back to comfortable range so
+       a fresh spike re-alerts. *)
+    fd_warned_once := false
 
 (** {1 Prometheus Export} *)
 
@@ -275,6 +336,7 @@ let labels_to_string = function
 
 let to_prometheus_text () =
   update_uptime ();
+  update_fd_gauges ();
   (* Snapshot (name, help, metric_type, value, labels) under the mutex so
      the render phase sees a consistent view even when concurrent fibers
      are still updating [metrics].  [m.value] is mutable so we copy it


### PR DESCRIPTION
## Summary

오늘 EMFILE 장애(pid 37007, CLOSE_WAIT 4029)가 **관측 불가 상태에서 서서히 쌓이다 임계점 넘어선 후 폭발**한 사건에 대해 **재발 시 조기 탐지 계층**을 추가합니다.

FD 누수 자체의 원인 수정은 OAS [oas#959](https://github.com/jeong-sik/oas/pull/959). 이 PR은 MASC 쪽 **보조 방어선**: "누수가 또 생기더라도 서서히 쌓이는 걸 즉시 본다."

## Linked issue

Production incident 2026-04-16 08:42 UTC. 유일한 신호였던 `Too many open files` 에러가 이미 1108건 누적된 후에야 감지. 사전 gauge 없음 → 사용자도 모니터링 불가.

## Product impact

- **Before**: fd 누수는 ``/metrics`` 에 보이지 않음. 4029 CLOSE_WAIT → accept() 실패 → checkpoint 실패 → keeper 전면 마비 순서로 **한 번에 망가짐**.
- **After**:
  - ``masc_process_open_fds`` gauge 가 매 scrape마다 업데이트 → Grafana/Prometheus 시계열에 monotonic ramp가 즉시 보임.
  - 기본 임계 3000 넘어서면 ``[WARN] [Server] process open fd count N has reached warn threshold 3000 — likely socket/file leak`` 1회 로그.
  - Threshold 환경 변수 ``MASC_FD_WARN_THRESHOLD`` 로 튜닝.
  - Hysteresis: 임계의 절반 아래로 떨어지면 latch 리셋 → 다음 spike 때 재alert.

## Evidence

실제 오늘 측정값:
``\`
$ lsof -p 37007 | wc -l
4102        ← 이 시점에 서버 이미 EMFILE 상태
$ lsof -p 37007 | awk '$5=="IPv4"' | grep -c CLOSE_WAIT
4029        ← 4029 개가 GLM / Zenlayer 쪽으로 붙어 있음
$ rg --count-matches 'Too many open files' ~/.masc/logs/system_log_2026-04-16.jsonl
1108
``\`

사전 경고 체계가 있었다면 ``masc_process_open_fds ≥ 3000`` 시점에 이미 WARN 발생 → Vincent 가 4029 되기 전에 재시작/진단 가능.

## Review evidence

### Build
``dune build --root .`` clean, 0 warnings.

### Mechanism
- ``approximate_open_fd_count ()`` — ``/dev/fd`` (macOS) → ``/proc/self/fd`` (Linux) 폴백. readdir 자체가 1 descriptor 만듦 → 보정 위해 -1.
- ``update_fd_gauges ()`` — ``to_prometheus_text`` 안에서 ``update_uptime`` 와 같은 위치에 호출. 별도 fiber 없음(배경 fiber가 자기 fd 릭 생성 리스크 제거).
- ``Printf.eprintf`` 사용 (``Log`` 모듈과 순환 의존 피함).

### 관련 이슈/PR
- **oas#959** (fd leak 근본 수정): 한쪽은 누수를 멈추고 한쪽은 조기 경보 — 이중 방어.
- **#7461** (OTel GenAI semantic convention): 이 gauge 는 그쪽 Prometheus 계측 철학과 일관.
- **#7469** (prompt caching telemetry): "measure first" 원칙 동일 적용.

## Test plan

- [x] local ``dune build`` clean
- [x] ``/dev/fd`` 수기 확인: ``approximate_open_fd_count`` 가 lsof count 와 ±2 이내
- [ ] Staging deploy — /metrics 에 ``masc_process_open_fds`` 노출 확인
- [ ] WARN 임계 테스트: ``MASC_FD_WARN_THRESHOLD=10`` + 10 초과 트리거 시 WARN 1회만 찍히는지 확인 (hysteresis)

## Reason for Draft

oas#959 + 이 PR 을 세트로 머지하는 게 자연스럽습니다. 순서 / threshold 기본값은 Vincent 판단 영역이라 Draft 로 시작합니다.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>