### PR TITLE
fix(ci): repin setup-ocaml to published release

### DIFF
--- a/.github/actions/setup-ocaml-toolchain/action.yml
+++ b/.github/actions/setup-ocaml-toolchain/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Setup OCaml
-      uses: ocaml/setup-ocaml@v3.6.0
+      uses: ocaml/setup-ocaml@v3.5.1
       with:
         ocaml-compiler: ${{ inputs.ocaml-compiler }}
         dune-cache: ${{ inputs.dune-cache }}

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3.6.0
+        uses: ocaml/setup-ocaml@v3.5.1
         with:
           ocaml-compiler: 5.4.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3.6.0
+        uses: ocaml/setup-ocaml@v3.5.1
         with:
           ocaml-compiler: 5.4.x
 

--- a/.github/workflows/webrtc-live-interop.yml
+++ b/.github/workflows/webrtc-live-interop.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup OCaml
-        uses: ocaml/setup-ocaml@v3.6.0
+        uses: ocaml/setup-ocaml@v3.5.1
         with:
           ocaml-compiler: 5.4.x
           dune-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,12 @@ had the full Phase 2 release to migrate.
 
 ### Fixed
 
-- **Release workflow GitHub Action pinned**. `ocaml/setup-ocaml@v3`
-  floating tag regressed between v0.9.0 (2026-04-15) and v0.9.1
-  (2026-04-16) — opam binary resolution fails on `ubuntu-latest` + `x86_64`.
-  Pinned to `ocaml/setup-ocaml@v3.6.0` (latest release as of 2026-03-30)
-  across `release.yml`, `webrtc-live-interop.yml`, `deploy-railway.yml`.
+- **OCaml setup action pin corrected**. The floating `ocaml/setup-ocaml@v3`
+  tag regressed between v0.9.0 (2026-04-15) and v0.9.1 (2026-04-16), and
+  the follow-up `v3.6.0` pin was not a published setup-ocaml release.
+  Re-pinned the shared setup action plus `release.yml`,
+  `webrtc-live-interop.yml`, and `deploy-railway.yml` to the latest
+  published `ocaml/setup-ocaml@v3.5.1` release verified on 2026-04-16.
   Closes #7475.
 
 ## [0.9.1] - 2026-04-16


### PR DESCRIPTION
## Summary

- repin the shared `setup-ocaml-toolchain` composite action from `ocaml/setup-ocaml@v3.6.0` to the published `v3.5.1` release
- align the direct `deploy-railway`, `release`, and `webrtc-live-interop` workflows with the same working pin
- correct the changelog note so future CI triage points at the actual published release

## Product impact

- Promise affected: `repo coordination`
- User-visible change: blocked PR CI should stop failing during the shared OCaml/opam bootstrap step

## Evidence

- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/actions/setup-ocaml-toolchain/action.yml .github/workflows/ci.yml .github/workflows/deploy-railway.yml .github/workflows/release.yml .github/workflows/webrtc-live-interop.yml`
- upstream release page check on 2026-04-16 shows `ocaml/setup-ocaml` latest published release is `v3.5.1`

## Review evidence

- direct CI triage on failing PRs `#7424`, `#7472`, and `#7476` showed the common error: `Failed to find opam binary for 'linux' and 'x86_64'`
- no cross-model review requested for this small workflow-only fix

## Linked issue

- Closes #7475
- Relates #7424, #7455, #7472, #7474, #7476, #7493
