### PR TITLE
chore(oas-pin): bump to 9061c508 (picks up http-client fd-leak fix)

### DIFF
--- a/scripts/oas-agent-sdk-pin.sh
+++ b/scripts/oas-agent-sdk-pin.sh
@@ -3,5 +3,5 @@
 readonly OAS_AGENT_SDK_URL="https://github.com/jeong-sik/oas.git"
 readonly OAS_AGENT_SDK_BASE_VERSION="v0.148.0"
 readonly OAS_AGENT_SDK_TRACK_REF="main"
-readonly OAS_AGENT_SDK_SHA="31e7afef95ef99daed77038cad8022e9015ff630"
+readonly OAS_AGENT_SDK_SHA="9061c50833e45454bbf76d003dc047d177f49f3d"
 readonly OAS_AGENT_SDK_MIN_VERSION="0.148.0"


### PR DESCRIPTION
## Summary

``scripts/oas-agent-sdk-pin.sh`` 의 ``OAS_AGENT_SDK_SHA`` 를 OAS main HEAD (``9061c508``) 로 bump. 다음 rebuild 시 [oas#959](https://github.com/jeong-sik/oas/pull/959) (HTTP client fd-leak fix) 가 masc-mcp 바이너리에 반영됩니다.

## Linked issue

Production incident 2026-04-16 08:42 UTC — pid 37007 EMFILE, 4,029 CLOSE_WAIT to GLM/Zenlayer endpoint. 재시작(pid 17203)만으로는 같은 바이너리이므로 누수 재발.

## Product impact

- **Before**: rebuild 해도 기존 버그 포함, CLOSE_WAIT 재축적.
- **After**: 빌드 → 재시작 → fd leak 차단. 여기에 **같은 세트로 머지된** [masc#7494](https://github.com/jeong-sik/masc-mcp/pull/7494) 의 ``masc_process_open_fds`` gauge 가 재발 시 조기 경보 제공.

## Evidence

``\`diff
-readonly OAS_AGENT_SDK_SHA="31e7afef95ef99daed77038cad8022e9015ff630"
+readonly OAS_AGENT_SDK_SHA="9061c50833e45454bbf76d003dc047d177f49f3d"
``\`

OAS main HEAD 확인 (grep):
``\`
$ cd ~/me/workspace/yousleepwhen/oas && git log origin/main --oneline -1
9061c508 fix(http): close all tracked transports (not just last) + TLS-aware close (#959)
``\`

## Review evidence

Single-line chore change. 수정 파일: ``scripts/oas-agent-sdk-pin.sh`` 1개, 1줄.

## Scope note

``OAS_AGENT_SDK_BASE_VERSION`` (``"v0.148.0"``) 및 ``OAS_AGENT_SDK_MIN_VERSION`` (``"0.148.0"``) 은 **건드리지 않음**. 이 두 값은 이미 실제 OAS 태그 (``v0.139.0`` 가 최신) 와 불일치 상태인데, 본 PR 범위를 "pin SHA bump only" 로 좁혀두기 위함. version floor 정합성 문제는 별도 follow-up 이슈에서 처리 권장.

## Test plan

- [x] Local diff review — 1-line SHA change
- [ ] CI — ``lint`` / ``pin consistency`` / ``ci build-and-test``
- [ ] Post-merge: rebuild + restart → ``lsof -p $(pgrep -f main_eio) | awk '$5=="IPv4"' | grep -c CLOSE_WAIT`` 가 경시간 안에 수백 이하 유지되는지 확인

## Linked PRs

- [masc#7463](https://github.com/jeong-sik/masc-mcp/pull/7463) — prompt externalize step 1 (merged)
- [masc#7494](https://github.com/jeong-sik/masc-mcp/pull/7494) — fd gauge + WARN threshold (merged)
- [oas#959](https://github.com/jeong-sik/oas/pull/959) — HTTP client fd leak fix (merged)
- **This PR** — closes the loop, lets rebuild pick up the fix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>