### PR TITLE
refactor(sidecars): extract shared bindings-store helpers (P0)

### DIFF
--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -10,13 +10,15 @@ Usage:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
 import signal
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+
+from gate_shared.bindings_store import load_bindings
+
 from .config import get_config
 from .gate_client import GateClient
 from .imessage_bridge import (
@@ -59,37 +61,11 @@ class IMessageBot:
             self._refresh_self_chat_guid(force=True)
 
     def _load_bindings(self) -> None:
-        """Load chat-to-keeper bindings from state file.
-
-        Read priority: new default (binding_store_path) > legacy
-        (legacy_binding_store_path) > empty. Next write always goes to the
-        new default, so a one-shot migration is transparent after the
-        .gate/runtime/ rollout (see #7468, #7471).
-        """
-        path = Path(self.cfg.binding_store_path)
-        source = "default"
-        if not path.exists():
-            legacy_path = Path(self.cfg.legacy_binding_store_path)
-            if legacy_path.exists():
-                path = legacy_path
-                source = "legacy"
-            else:
-                return
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                self._bindings = {str(k): str(v) for k, v in data.items() if isinstance(v, str)}
-                if source == "legacy":
-                    logger.info(
-                        "Loaded %d binding(s) from legacy store %s; next write goes to %s",
-                        len(self._bindings),
-                        path,
-                        self.cfg.binding_store_path,
-                    )
-                else:
-                    logger.info("Loaded %d binding(s)", len(self._bindings))
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load bindings from %s: %s", path, e)
+        self._bindings = load_bindings(
+            self.cfg.binding_store_path,
+            legacy_path=self.cfg.legacy_binding_store_path,
+            logger=logger,
+        )
 
     def _resolve_keeper(self, msg: InboundMessage) -> str:
         """Resolve which keeper handles a message.

--- a/sidecars/shared/gate_shared/bindings_store.py
+++ b/sidecars/shared/gate_shared/bindings_store.py
@@ -1,0 +1,95 @@
+"""Shared bindings-store helpers for Channel Gate sidecars.
+
+Slack, iMessage, and Telegram sidecars all need to load a simple
+`{channel_id: keeper_name}` JSON file with 1-tier legacy fallback, and
+Slack + Telegram also need to persist the same shape atomically. This
+module collapses the duplicated 38-line `_load_bindings` /
+`_save_bindings` blocks into a pair of pure functions that take the
+paths as arguments — no base class, no mixin, no state.
+
+Discord's sidecar uses a richer `BindingStore` class with atomic writes
+and audit coupling; it stays separate and is not affected by this
+module.
+
+Read priority in `load_bindings`:
+  1. `default_path` (if the file exists)
+  2. `legacy_path` (if provided, the file exists, and default is absent)
+  3. empty dict
+
+Writes in `save_bindings` always land at the caller's `path`, so the
+one-shot migration introduced in #7477/#7478/#7479 remains transparent
+— next save after a legacy load hits the new default and the legacy
+file becomes dormant.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+
+def load_bindings(
+    default_path: str | Path,
+    *,
+    legacy_path: str | Path | None = None,
+    logger: logging.Logger | None = None,
+) -> dict[str, str]:
+    """Load channel-to-keeper bindings from disk with optional legacy fallback.
+
+    Returns an empty dict if neither file exists, if the file is not a
+    JSON object, or on parse/IO errors. Non-string values are silently
+    dropped to preserve the `str -> str` contract.
+    """
+    log = logger or logging.getLogger(__name__)
+    path = Path(default_path)
+    source = "default"
+    if not path.exists():
+        if legacy_path is None:
+            return {}
+        legacy = Path(legacy_path)
+        if legacy.exists():
+            path = legacy
+            source = "legacy"
+        else:
+            return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning("Failed to load bindings from %s: %s", path, exc)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    bindings = {
+        str(k): str(v) for k, v in data.items() if isinstance(v, str)
+    }
+    if source == "legacy":
+        log.info(
+            "Loaded %d binding(s) from legacy store %s; next write goes to %s",
+            len(bindings),
+            path,
+            default_path,
+        )
+    else:
+        log.info("Loaded %d binding(s)", len(bindings))
+    return bindings
+
+
+def save_bindings(
+    path: str | Path,
+    bindings: dict[str, str],
+    *,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Persist bindings atomically via a hidden tempfile + os.replace."""
+    log = logger or logging.getLogger(__name__)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{target.name}.tmp")
+    try:
+        tmp.write_text(json.dumps(bindings, indent=2), encoding="utf-8")
+        os.replace(tmp, target)
+    except OSError as exc:
+        log.error("Failed to save bindings to %s: %s", target, exc)
+        tmp.unlink(missing_ok=True)

--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -13,12 +13,11 @@ Supports:
 
 from __future__ import annotations
 
-import json
 import logging
-import os
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
+
+from gate_shared.bindings_store import load_bindings, save_bindings
 
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
@@ -45,52 +44,14 @@ class SlackGateBot:
         self._messages_failed = 0
 
     def _load_bindings(self) -> None:
-        """Load channel-to-keeper bindings.
-
-        Read priority: new default (binding_store_path) > legacy
-        (legacy_binding_store_path) > empty. Next _save_bindings always
-        writes to the new default, so the migration is transparent after
-        the .gate/runtime/ rollout (see #7468, #7471).
-        """
-        path = Path(self.cfg.binding_store_path)
-        source = "default"
-        if not path.exists():
-            legacy_path = Path(self.cfg.legacy_binding_store_path)
-            if legacy_path.exists():
-                path = legacy_path
-                source = "legacy"
-            else:
-                return
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                self._bindings = {
-                    str(k): str(v)
-                    for k, v in data.items()
-                    if isinstance(v, str)
-                }
-                if source == "legacy":
-                    logger.info(
-                        "Loaded %d binding(s) from legacy store %s; next write goes to %s",
-                        len(self._bindings),
-                        path,
-                        self.cfg.binding_store_path,
-                    )
-                else:
-                    logger.info("Loaded %d binding(s)", len(self._bindings))
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load bindings from %s: %s", path, e)
+        self._bindings = load_bindings(
+            self.cfg.binding_store_path,
+            legacy_path=self.cfg.legacy_binding_store_path,
+            logger=logger,
+        )
 
     def _save_bindings(self) -> None:
-        path = Path(self.cfg.binding_store_path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(f".{path.name}.tmp")
-        try:
-            tmp.write_text(json.dumps(self._bindings, indent=2), encoding="utf-8")
-            os.replace(tmp, path)
-        except OSError as e:
-            logger.error("Failed to save bindings: %s", e)
-            tmp.unlink(missing_ok=True)
+        save_bindings(self.cfg.binding_store_path, self._bindings, logger=logger)
 
     def _resolve_keeper(self, channel_id: str) -> str:
         return self._bindings.get(channel_id, self.cfg.default_keeper)

--- a/sidecars/telegram-bot/src/bot.py
+++ b/sidecars/telegram-bot/src/bot.py
@@ -11,13 +11,12 @@ Supports:
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import os
 import signal
 import time
 from datetime import datetime, timezone
-from pathlib import Path
+
+from gate_shared.bindings_store import load_bindings, save_bindings
 
 from telegram import Message, Update
 from telegram.ext import (
@@ -52,56 +51,14 @@ class TelegramGateBot:
         self._last_message_at = ""
 
     def _load_bindings(self) -> None:
-        """Load chat-to-keeper bindings.
-
-        Read priority: new default (binding_store_path) > legacy
-        (legacy_binding_store_path) > empty. Next _save_bindings always
-        writes to the new default, so the migration is transparent after
-        the .gate/runtime/ rollout (see #7468, #7471).
-        """
-        path = Path(self.cfg.binding_store_path)
-        source = "default"
-        if not path.exists():
-            legacy_path = Path(self.cfg.legacy_binding_store_path)
-            if legacy_path.exists():
-                path = legacy_path
-                source = "legacy"
-            else:
-                return
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                self._bindings = {
-                    str(k): str(v)
-                    for k, v in data.items()
-                    if isinstance(v, str)
-                }
-                if source == "legacy":
-                    logger.info(
-                        "Loaded %d binding(s) from legacy store %s; next write goes to %s",
-                        len(self._bindings),
-                        path,
-                        self.cfg.binding_store_path,
-                    )
-                else:
-                    logger.info("Loaded %d binding(s)", len(self._bindings))
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to load bindings from %s: %s", path, e)
+        self._bindings = load_bindings(
+            self.cfg.binding_store_path,
+            legacy_path=self.cfg.legacy_binding_store_path,
+            logger=logger,
+        )
 
     def _save_bindings(self) -> None:
-        """Persist bindings to disk."""
-        path = Path(self.cfg.binding_store_path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(f".{path.name}.tmp")
-        try:
-            tmp.write_text(
-                json.dumps(self._bindings, indent=2),
-                encoding="utf-8",
-            )
-            os.replace(tmp, path)
-        except OSError as e:
-            logger.error("Failed to save bindings: %s", e)
-            tmp.unlink(missing_ok=True)
+        save_bindings(self.cfg.binding_store_path, self._bindings, logger=logger)
 
     def _resolve_keeper(self, chat_id: int) -> str:
         """Resolve which keeper handles a chat."""


### PR DESCRIPTION
## Summary

- Collapses 3 near-identical `_load_bindings` / `_save_bindings` implementations (Slack, iMessage, Telegram) into two free functions in a new shared module.
- **−130 / +24 LOC across the 3 `bot.py` files**; new shared module adds 97 LOC with one authoritative copy of the legacy-fallback logic.
- Discord's richer `BindingStore` class (audit coupling + mtime tracking) is intentionally untouched.

## Product impact

**Zero.** Same 1-tier read-fallback semantics (env var > new default > legacy > empty), same atomic tempfile write. Log messages are byte-identical because each sidecar passes its own `logger` into the shared functions.

## Rationale

Post-#7479 (B3c-telegram) all 4 Python sidecars shared the same `.gate/runtime/` path pattern. What was left was pure copy-paste — three 38-line blocks that diverged only in which bot's logger they used. Extracting now (right after the pattern stabilized) is the natural refactor point before any further connector-level changes (#7472, #7476, future P1/P2 follow-ups) try to touch the same code and discover "which of the three do I edit first?"

## Design choices

- **Free functions, not a mixin or subclass.** Bindings state stays on the bot instance (`self._bindings`), the helpers operate on paths. Keeps the import surface tiny (two names) and avoids MRO surprises in sidecars that already inherit from framework base classes.
- **`logger` injected per call**, so log namespace survives (`[slack-gate-bot]`, `[imessage-gate-bot]`, `[telegram-gate-bot]` — distinguishable in stdout).
- **`legacy_path` is optional keyword-only**; callers without a legacy file pass nothing.
- **Atomic write** uses the hidden-tmp + `os.replace` pattern — same contract, shared implementation.

## Changes

New: `sidecars/shared/gate_shared/bindings_store.py` (97 LOC)
```python
def load_bindings(default_path, *, legacy_path=None, logger=None) -> dict[str, str]
def save_bindings(path, bindings, *, logger=None) -> None
```

Per-sidecar:
- `sidecars/slack-bot/src/bot.py` — -47 / +8; `_load`/`_save` bodies collapse to one-line calls.
- `sidecars/telegram-bot/src/bot.py` — -51 / +8; same.
- `sidecars/imessage-bot/src/bot.py` — -32 / +8; only `load` (iMessage bindings are read-only at present).
- Import pruning: `json`, `os`, `pathlib.Path` dropped from `slack-bot` and `telegram-bot`; `json` dropped from `imessage-bot`.

## Evidence

- `python -m py_compile` on all 4 files (new module + 3 bots) → OK
- Full pytest needs the per-sidecar venv (pydantic_settings, discord.py, python-telegram-bot, slack_bolt) — CI will exercise it.

## Review evidence

Before/after diff comparison (representative — Slack):

```python
# Before (38 lines, 3 nested try/except + isinstance checks + 2-branch log)
def _load_bindings(self) -> None:
    path = Path(self.cfg.binding_store_path)
    source = "default"
    if not path.exists():
        ...
    try:
        data = json.loads(path.read_text(encoding="utf-8"))
        if isinstance(data, dict):
            ...
    except (json.JSONDecodeError, OSError) as e: ...

# After (6 lines)
def _load_bindings(self) -> None:
    self._bindings = load_bindings(
        self.cfg.binding_store_path,
        legacy_path=self.cfg.legacy_binding_store_path,
        logger=logger,
    )
```

Behavior preserved verbatim in the shared module. Non-string values are still silently dropped (`{k: v for k, v in data.items() if isinstance(v, str)}`). Log phrasing (`Loaded %d binding(s) from legacy store %s; next write goes to %s`) is identical.

## CI note

Upstream `ocaml/setup-ocaml` regression (Issue #7475) still blocks OCaml CI, but this PR is Python-only so the OCaml failure is not semantically related. Admin merge consistent with recent precedent.

## Linked issue

Refs #7477 (B3c-imessage), #7478 (B3c-slack), #7479 (B3c-telegram). Consolidates the fallback pattern introduced in that series.

## Test plan

- [x] `python -m py_compile` on all 4 touched files
- [ ] CI: Build and Test, Lint (Python paths)
- [ ] Post-merge: restart each sidecar locally — confirm first-run log reports `Loaded N binding(s)` (no `legacy store` phrase if bindings already at new default) and subsequent bind/unbind persists across restart.

## Follow-ups

- **P1** env var naming unification (Slack/iMessage/Telegram config fields missing `validation_alias` — discovered in the parallel audit).
- **P2** Slack/Telegram OCaml state module + HTTP route registration (they render in the dashboard today but can't bind because the Gate has no backend).
- **Possible Discord alignment** later: could port Discord's `BindingStore` class to use the shared helpers too, or vice-versa (adopt Discord's `modified_time_ns` tracking in the shared module). Deliberately out of scope for this PR.