### PR TITLE
feat(sidecars): add env-var aliases to Slack + Telegram config (P1)

### DIFF
--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -67,16 +67,51 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("SLACK_DEFAULT_KEEPER", "default_keeper"),
     )
 
-    # Timeouts
-    gate_timeout_sec: float = Field(default=120.0)
-    gate_breaker_failure_threshold: int = Field(default=3)
-    gate_breaker_reset_sec: int = Field(default=30)
-    status_cache_ttl_sec: int = Field(default=15)
-    keeper_cache_ttl_sec: int = Field(default=30)
+    # Timeouts — common Gate knobs reuse GATE_/STATUS_/KEEPER_ names to match
+    # the other sidecars (see discord-bot and telegram-bot). Field-name aliases
+    # are kept so in-process kwargs still work.
+    gate_timeout_sec: float = Field(
+        default=120.0,
+        validation_alias=AliasChoices("GATE_TIMEOUT_SEC", "gate_timeout_sec"),
+    )
+    gate_breaker_failure_threshold: int = Field(
+        default=3,
+        validation_alias=AliasChoices(
+            "GATE_BREAKER_FAILURE_THRESHOLD", "gate_breaker_failure_threshold"
+        ),
+    )
+    gate_breaker_reset_sec: int = Field(
+        default=30,
+        validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
+    )
+    status_cache_ttl_sec: int = Field(
+        default=15,
+        validation_alias=AliasChoices("STATUS_CACHE_TTL_SEC", "status_cache_ttl_sec"),
+    )
+    keeper_cache_ttl_sec: int = Field(
+        default=30,
+        validation_alias=AliasChoices("KEEPER_CACHE_TTL_SEC", "keeper_cache_ttl_sec"),
+    )
 
-    # State paths
-    binding_store_path: str = Field(default=DEFAULT_BINDING_STORE_PATH)
-    status_path: str = Field(default=DEFAULT_STATUS_PATH)
+    # State paths — SLACK_ prefix matches sidecar-local convention; the
+    # MASC_SLACK_ alias lets OCaml-side env vars (MASC_SLACK_*_PATH) line up
+    # when both halves of the stack are deployed by the same operator.
+    binding_store_path: str = Field(
+        default=DEFAULT_BINDING_STORE_PATH,
+        validation_alias=AliasChoices(
+            "SLACK_BINDING_STORE_PATH",
+            "MASC_SLACK_BINDING_STORE_PATH",
+            "binding_store_path",
+        ),
+    )
+    status_path: str = Field(
+        default=DEFAULT_STATUS_PATH,
+        validation_alias=AliasChoices(
+            "SLACK_STATUS_PATH",
+            "MASC_SLACK_STATUS_PATH",
+            "status_path",
+        ),
+    )
     # Legacy read-fallback (pre-v0.9.0 layout). Not env-configurable.
     legacy_binding_store_path: str = Field(default=LEGACY_BINDING_STORE_PATH)
 

--- a/sidecars/telegram-bot/src/config.py
+++ b/sidecars/telegram-bot/src/config.py
@@ -67,19 +67,50 @@ class BotConfig(BaseSettings):
         validation_alias=AliasChoices("TELEGRAM_ADMIN_USER_IDS", "admin_user_ids"),
     )
 
-    # Timeouts
+    # Timeouts — match discord-bot + slack-bot env var naming so operators
+    # don't need to remember per-sidecar prefixes for the common Gate knobs.
     gate_timeout_sec: float = Field(
         default=120.0,
         validation_alias=AliasChoices("GATE_TIMEOUT_SEC", "gate_timeout_sec"),
     )
-    gate_breaker_failure_threshold: int = Field(default=3)
-    gate_breaker_reset_sec: int = Field(default=30)
-    status_cache_ttl_sec: int = Field(default=15)
-    keeper_cache_ttl_sec: int = Field(default=30)
+    gate_breaker_failure_threshold: int = Field(
+        default=3,
+        validation_alias=AliasChoices(
+            "GATE_BREAKER_FAILURE_THRESHOLD", "gate_breaker_failure_threshold"
+        ),
+    )
+    gate_breaker_reset_sec: int = Field(
+        default=30,
+        validation_alias=AliasChoices("GATE_BREAKER_RESET_SEC", "gate_breaker_reset_sec"),
+    )
+    status_cache_ttl_sec: int = Field(
+        default=15,
+        validation_alias=AliasChoices("STATUS_CACHE_TTL_SEC", "status_cache_ttl_sec"),
+    )
+    keeper_cache_ttl_sec: int = Field(
+        default=30,
+        validation_alias=AliasChoices("KEEPER_CACHE_TTL_SEC", "keeper_cache_ttl_sec"),
+    )
 
-    # State paths
-    binding_store_path: str = Field(default=DEFAULT_BINDING_STORE_PATH)
-    status_path: str = Field(default=DEFAULT_STATUS_PATH)
+    # State paths — TELEGRAM_ prefix matches sidecar-local convention; the
+    # MASC_TELEGRAM_ alias lets OCaml-side env vars line up when both halves
+    # of the stack are deployed by the same operator.
+    binding_store_path: str = Field(
+        default=DEFAULT_BINDING_STORE_PATH,
+        validation_alias=AliasChoices(
+            "TELEGRAM_BINDING_STORE_PATH",
+            "MASC_TELEGRAM_BINDING_STORE_PATH",
+            "binding_store_path",
+        ),
+    )
+    status_path: str = Field(
+        default=DEFAULT_STATUS_PATH,
+        validation_alias=AliasChoices(
+            "TELEGRAM_STATUS_PATH",
+            "MASC_TELEGRAM_STATUS_PATH",
+            "status_path",
+        ),
+    )
     # Legacy read-fallback (pre-v0.9.0 layout). Not env-configurable.
     legacy_binding_store_path: str = Field(default=LEGACY_BINDING_STORE_PATH)
 


### PR DESCRIPTION
## Summary

- Slack and Telegram sidecar config fields for timeouts, circuit-breaker thresholds, cache TTLs, and state paths now expose `validation_alias` — env-var overrides work for every knob that Discord already exposes.
- Two aliases per state-path field: local (`SLACK_BINDING_STORE_PATH`) + MASC-prefixed (`MASC_SLACK_BINDING_STORE_PATH`) so the OCaml side (`channel_gate_slack_state` once it exists) and the Python sidecar can share one env var.
- Gate-common knobs (`GATE_TIMEOUT_SEC`, `GATE_BREAKER_*`, `STATUS_CACHE_TTL_SEC`, `KEEPER_CACHE_TTL_SEC`) use no sidecar prefix — one variable tunes all sidecars consistently.

## Product impact

**No default behavior change.** Only adds override surfaces that didn't exist before. A deployment that didn't set any env var keeps the same values it had before this PR.

Operators can now tune Slack/Telegram at deploy time the same way they already tune Discord — which the Pydantic audit flagged as an asymmetry.

## Rationale

Parallel audit (4 agents) flagged this as the largest operational gap in the connector config layer. All 4 sidecars had **identical** default numbers but Discord was the only one that let operators override via env vars; Slack/Telegram exposed only the field name as an alias, which Pydantic's default settings do NOT pick up from the environment.

Consequence before this PR: `SLACK_BINDING_STORE_PATH=/custom/path python -m src.bot` had no effect on Slack. After this PR, it behaves as expected.

## Design choices

- **Two aliases for state paths** (local + MASC-prefixed). Matches the OCaml gate library's env-var scheme for when both halves of the stack are deployed together. Deployments can use either name; `AliasChoices` tries them in order.
- **No prefix for Gate-common knobs.** `GATE_TIMEOUT_SEC` intentionally shared — operators tuning the whole stack's tolerance of a slow gate should only need to set it once.
- **iMessage deliberately skipped.** iMessage already uses a `MASC_` prefix convention (`MASC_GATE_URL`, `MASC_IMESSAGE_*_PATH`) that diverges from Discord/Slack/Telegram. Fixing the naming asymmetry is a separate PR with a naming decision attached.

## Changes

`sidecars/slack-bot/src/config.py`:
- 5 timeout/cache fields grow `validation_alias` (common `GATE_*` / `*_CACHE_TTL_SEC` names)
- 2 state-path fields grow two-level alias (`SLACK_*`, `MASC_SLACK_*`, field-name)

`sidecars/telegram-bot/src/config.py`:
- Same 5 timeout/cache fields (except `gate_timeout_sec` which already had `GATE_TIMEOUT_SEC` alias)
- 2 state-path fields with `TELEGRAM_*`, `MASC_TELEGRAM_*`, field-name aliases

Total +85 / -19 across 2 files. No logic change.

## Evidence

- `python -m py_compile sidecars/slack-bot/src/config.py` → OK
- `python -m py_compile sidecars/telegram-bot/src/config.py` → OK
- Full pytest needs each sidecar's venv (pydantic_settings + channel framework) — CI exercises it.

## Review evidence

Alias key ordering deliberately puts the env-var-style uppercase names **first** so Pydantic picks them up during env resolution; field-name aliases are kept last for programmatic-kwargs callers (e.g. unit tests that construct `BotConfig(binding_store_path=...)` directly).

`AliasChoices` returns the first alias that resolves — operators setting both `SLACK_BINDING_STORE_PATH` and `MASC_SLACK_BINDING_STORE_PATH` see the former win, which matches the "sidecar-local convention is more specific" intuition.

No test fixture in `sidecars/slack-bot/tests/` or `sidecars/telegram-bot/tests/` hardcoded the old (alias-less) behavior.

## CI note

Upstream `ocaml/setup-ocaml` regression (Issue #7475) still blocks OCaml CI. This PR touches only Python, so the OCaml failure is not semantically related. Admin merge consistent with recent precedent.

## Linked issue

Refs #7501 (shared bindings-store, previous connector-refactor PR in this session), #7475 (upstream CI blocker).

## Test plan

- [x] `python -m py_compile` on both touched config.py files
- [ ] CI: Python lint + any sidecar-specific pytest
- [ ] Post-merge manual check: `SLACK_BINDING_STORE_PATH=/tmp/s.json python -m src.bot` (Slack) — `get_config().binding_store_path` should return `/tmp/s.json`. Same for Telegram.

## Follow-ups

- **iMessage alignment** — decide on `MASC_` prefix vs no-prefix for the Gate env-var namespace, then apply the same alias expansion to imessage-bot. Also add the reverse alias to discord-bot (`MASC_DISCORD_*`) so the OCaml + Python env vars unify.
- **TOML migration** — the parallel audit suggested moving non-secret config out of env vars entirely into `sidecars/<kind>/config.toml`. This PR is the env-var half; the TOML half is a separate design decision.
- **`channel_gate_slack_state.ml` / `_telegram_state.ml`** — P2 in the audit. Without these, the `MASC_SLACK_*_PATH` aliases are accepted by the sidecar but the Gate has no OCaml consumer.