### PR TITLE
[codex] Add context to OAS native lifecycle logs

### DIFF
--- a/lib/oas_log_bridge.ml
+++ b/lib/oas_log_bridge.ml
@@ -44,12 +44,49 @@ let level_to_masc (level : Agent_sdk.Log.level) : Log.level =
   | Warn -> Log.Warn
   | Error -> Log.Error
 
+let field_value_to_human (json : Yojson.Safe.t) : string option =
+  match json with
+  | `String value when String.trim value <> "" -> Some value
+  | `Int value -> Some (string_of_int value)
+  | `Intlit value -> Some value
+  | `Float value -> Some (Printf.sprintf "%.3f" value)
+  | `Bool value -> Some (string_of_bool value)
+  | _ -> None
+
+let preferred_summary_keys message =
+  match message with
+  | "turn completed" | "turn started" ->
+      [ "turn"; "max_turns"; "turn_duration_sec"; "elapsed_run_sec"; "model"; "stop" ]
+  | "agent completed" | "agent started" ->
+      [ "agent_name"; "agent"; "task_id"; "elapsed_s"; "input_tokens"; "output_tokens" ]
+  | "tool completed" | "tool called" ->
+      [ "agent_name"; "agent"; "tool_name"; "turn" ]
+  | _ ->
+      [ "agent_name"; "agent"; "task_id"; "turn"; "tool_name"; "model"; "stop" ]
+
+let summarize_fields ~message (fields : Agent_sdk.Log.field list) : string list =
+  let assoc = List.map field_to_json fields in
+  preferred_summary_keys message
+  |> List.filter_map (fun key ->
+       match List.assoc_opt key assoc with
+       | None -> None
+       | Some value -> (
+           match field_value_to_human value with
+           | Some rendered -> Some (Printf.sprintf "%s=%s" key rendered)
+           | None -> None))
+
+let render_message_with_summary (record : Agent_sdk.Log.record) =
+  match summarize_fields ~message:record.message record.fields with
+  | [] -> record.message
+  | summary -> Printf.sprintf "%s %s" record.message (String.concat " " summary)
+
 (** Build the sink function.  Prefix the module name with ["oas:"] so a
     record emitted by [Agent_sdk.Log.create ~module_name:"agent"] lands
     as ["oas:agent"] in the masc-mcp log stream, distinct from any
     masc-mcp module called "agent". *)
 let make_sink () : Agent_sdk.Log.sink =
  fun record ->
+  let message = render_message_with_summary record in
   let details =
     match record.fields with
     | [] -> None
@@ -58,7 +95,7 @@ let make_sink () : Agent_sdk.Log.sink =
   Log.emit (level_to_masc record.level)
     ~module_name:("oas:" ^ record.module_name)
     ?details
-    record.message
+    message
 
 (** Process-wide latch to make [install] idempotent.  Unlike
     [Llm_metric_bridge] which uses [set_global] (replacement semantics),

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -46,6 +46,50 @@ let payload_agent_name payload =
   | Some _ as value -> value
   | None -> payload_string_opt "agent" payload
 
+let emit_native_event_log (evt : Agent_sdk.Event_bus.event) (json : Yojson.Safe.t) =
+  let log message =
+    Log.emit Log.Info ~module_name:"oas:event" ~details:json message
+  in
+  match evt.payload with
+  | Agent_sdk.Event_bus.AgentStarted { agent_name; task_id } ->
+      log
+        (Printf.sprintf "agent started agent=%s task_id=%s" agent_name task_id)
+  | Agent_sdk.Event_bus.AgentCompleted { agent_name; task_id; elapsed; _ } ->
+      log
+        (Printf.sprintf
+           "agent completed agent=%s task_id=%s elapsed_s=%.3f"
+           agent_name task_id elapsed)
+  | Agent_sdk.Event_bus.TurnStarted { agent_name; turn } ->
+      log (Printf.sprintf "turn started agent=%s turn=%d" agent_name turn)
+  | Agent_sdk.Event_bus.TurnCompleted { agent_name; turn } ->
+      log (Printf.sprintf "turn completed agent=%s turn=%d" agent_name turn)
+  | Agent_sdk.Event_bus.ToolCalled { agent_name; tool_name; _ } ->
+      log
+        (Printf.sprintf "tool called agent=%s tool_name=%s" agent_name tool_name)
+  | Agent_sdk.Event_bus.ToolCompleted { agent_name; tool_name; _ } ->
+      log
+        (Printf.sprintf
+           "tool completed agent=%s tool_name=%s"
+           agent_name tool_name)
+  | Agent_sdk.Event_bus.ContextCompacted
+      { agent_name; before_tokens; after_tokens; phase } ->
+      log
+        (Printf.sprintf
+           "context compacted agent=%s before_tokens=%d after_tokens=%d phase=%s"
+           agent_name before_tokens after_tokens phase)
+  | Agent_sdk.Event_bus.ContextOverflowImminent
+      { agent_name; estimated_tokens; limit_tokens; ratio } ->
+      log
+        (Printf.sprintf
+           "context overflow imminent agent=%s estimated_tokens=%d limit_tokens=%d ratio=%.3f"
+           agent_name estimated_tokens limit_tokens ratio)
+  | Agent_sdk.Event_bus.ContextCompactStarted { agent_name; trigger } ->
+      log
+        (Printf.sprintf
+           "context compact started agent=%s trigger=%s"
+           agent_name trigger)
+  | _ -> ()
+
 (** Build the SSE JSON wrapper. [correlation_id] and [run_id] are
     mandatory (from the envelope); all other fields are optional. *)
 let wrap_event ~ts ~correlation_id ~run_id ~event_type ~payload
@@ -208,6 +252,7 @@ let relay_event ?store evt =
          from subprocess captures).  Scrub before persisting or broadcasting
          so that JSONL consumers and SSE clients receive well-formed UTF-8. *)
       let j = Inference_utils.sanitize_json_utf8 j in
+      emit_native_event_log evt j;
       (match store with
        | Some store ->
            (try Dated_jsonl.append store j

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -1,5 +1,7 @@
 (** Tests for OAS integration modules: oas_events, message conversion. *)
 
+module Masc_log = Log
+
 open Agent_sdk
 open Masc_mcp
 
@@ -23,6 +25,16 @@ let rec cleanup_dir path =
       Unix.rmdir path
     end else
       Unix.unlink path
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
 
 (* ================================================================ *)
 (* Oas_events tests                                                  *)
@@ -273,6 +285,164 @@ let test_agent_completed_no_usage_on_error () =
         (Option.is_none (List.assoc_opt "input_tokens" payload_fields))
   | Some _ -> Alcotest.fail "expected assoc"
 
+let test_oas_log_bridge_turn_completed_summary () =
+  Oas_log_bridge.install ();
+  let before_seq =
+    match Masc_log.Ring.recent ~module_filter:"oas:agent" ~limit:1 () with
+    | [] -> None
+    | entry :: _ -> Some entry.seq
+  in
+  let logger = Agent_sdk.Log.create ~module_name:"agent" () in
+  Agent_sdk.Log.info logger "turn completed"
+    [
+      Agent_sdk.Log.I ("turn", 72);
+      Agent_sdk.Log.I ("max_turns", 120);
+      Agent_sdk.Log.F ("turn_duration_sec", 1.25);
+      Agent_sdk.Log.S ("model", "glm-5-turbo");
+      Agent_sdk.Log.S ("stop", "end_turn");
+    ];
+  let entries =
+    Masc_log.Ring.recent ~module_filter:"oas:agent" ?since_seq:before_seq
+      ~order:`Oldest_first ()
+  in
+  match List.rev entries with
+  | [] -> Alcotest.fail "expected bridged oas:agent log entry"
+  | entry :: _ ->
+      Alcotest.(check bool) "message includes turn" true
+        (contains_substring entry.message "turn=72");
+      Alcotest.(check bool) "message includes model" true
+        (contains_substring entry.message "model=glm-5-turbo");
+      Alcotest.(check bool) "message includes stop" true
+        (contains_substring entry.message "stop=end_turn");
+      (match entry.details with
+       | `Assoc fields ->
+           Alcotest.(check bool) "details preserve turn" true
+             (List.mem_assoc "turn" fields)
+       | _ -> Alcotest.fail "expected structured details")
+
+let test_oas_sse_bridge_logs_turn_completed_with_agent_name () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "oas_turn_log" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let bus = Event_bus.create () in
+      let before_seq =
+        match Masc_log.Ring.recent ~module_filter:"oas:event" ~limit:1 () with
+        | [] -> None
+        | entry :: _ -> Some entry.seq
+      in
+      Sse.set_clock (Eio.Stdenv.clock env);
+      try
+        Eio.Switch.run (fun sw ->
+          Oas_sse_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
+          Event_bus.publish bus
+            (Event_bus.mk_event
+               ~correlation_id:"sess-turn" ~run_id:"run-turn"
+               (TurnCompleted { agent_name = "bridge-agent"; turn = 72 }));
+          Eio.Time.sleep (Eio.Stdenv.clock env) 2.2;
+          let entries =
+            Masc_log.Ring.recent ~module_filter:"oas:event" ?since_seq:before_seq
+              ~order:`Oldest_first ()
+          in
+          let entry =
+            match
+              List.find_opt
+                (fun (entry : Masc_log.Ring.entry) ->
+                  contains_substring entry.message
+                    "turn completed agent=bridge-agent turn=72")
+                entries
+            with
+            | Some entry -> entry
+            | None -> Alcotest.fail "expected oas:event turn completed log"
+          in
+          (match entry.details with
+           | `Assoc fields ->
+               let event_type =
+                 match List.assoc_opt "event_type" fields with
+                 | Some (`String value) -> value
+                 | _ -> ""
+               in
+               let agent_name =
+                 match List.assoc_opt "agent_name" fields with
+                 | Some (`String value) -> value
+                 | _ -> ""
+               in
+               let turn =
+                 match List.assoc_opt "turn" fields with
+                 | Some (`Int value) -> value
+                 | _ -> -1
+               in
+               Alcotest.(check string) "event type" "turn_completed" event_type;
+               Alcotest.(check string) "agent name" "bridge-agent" agent_name;
+               Alcotest.(check int) "turn" 72 turn
+           | _ -> Alcotest.fail "expected structured oas:event details");
+          raise Exit)
+      with Exit -> ())
+
+let test_oas_sse_bridge_logs_tool_completed_with_agent_name () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "oas_tool_log" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let bus = Event_bus.create () in
+      let before_seq =
+        match Masc_log.Ring.recent ~module_filter:"oas:event" ~limit:1 () with
+        | [] -> None
+        | entry :: _ -> Some entry.seq
+      in
+      Sse.set_clock (Eio.Stdenv.clock env);
+      try
+        Eio.Switch.run (fun sw ->
+          Oas_sse_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
+          Event_bus.publish bus
+            (Event_bus.mk_event
+               ~correlation_id:"sess-tool" ~run_id:"run-tool"
+               (ToolCompleted
+                  {
+                    agent_name = "bridge-agent";
+                    tool_name = "masc_board_list";
+                    output = Ok { Agent_sdk.Types.content = "ok" };
+                  }));
+          Eio.Time.sleep (Eio.Stdenv.clock env) 2.2;
+          let entries =
+            Masc_log.Ring.recent ~module_filter:"oas:event" ?since_seq:before_seq
+              ~order:`Oldest_first ()
+          in
+          let entry =
+            match
+              List.find_opt
+                (fun (entry : Masc_log.Ring.entry) ->
+                  contains_substring entry.message
+                    "tool completed agent=bridge-agent tool_name=masc_board_list")
+                entries
+            with
+            | Some entry -> entry
+            | None -> Alcotest.fail "expected oas:event tool completed log"
+          in
+          (match entry.details with
+           | `Assoc fields ->
+               let event_type =
+                 match List.assoc_opt "event_type" fields with
+                 | Some (`String value) -> value
+                 | _ -> ""
+               in
+               let tool_name =
+                 match List.assoc_opt "tool_name" fields with
+                 | Some (`String value) -> value
+                 | _ -> ""
+               in
+               Alcotest.(check string) "event type" "tool_completed" event_type;
+               Alcotest.(check string) "tool name" "masc_board_list" tool_name
+           | _ -> Alcotest.fail "expected structured oas:event details");
+          raise Exit)
+      with Exit -> ())
+
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -289,6 +459,12 @@ let () =
         test_agent_completed_includes_usage;
       Alcotest.test_case "agent_completed no usage on error" `Quick
         test_agent_completed_no_usage_on_error;
+      Alcotest.test_case "oas log bridge adds turn completed summary" `Quick
+        test_oas_log_bridge_turn_completed_summary;
+      Alcotest.test_case "sse bridge logs turn completed with agent name" `Quick
+        test_oas_sse_bridge_logs_turn_completed_with_agent_name;
+      Alcotest.test_case "sse bridge logs tool completed with agent name" `Quick
+        test_oas_sse_bridge_logs_tool_completed_with_agent_name;
     ];
     "message_conversion", [
       Alcotest.test_case "message roundtrip" `Quick test_message_roundtrip;


### PR DESCRIPTION
## Summary
- add human-readable field summaries to bridged `oas:*` log lines so generic OAS messages like `turn completed` expose turn/model/stop context in the terminal log stream
- emit companion `oas:event` log entries for native OAS lifecycle events that already carry identifying context on the event bus, including agent, turn, tool, and compaction-related events
- cover the new log behavior with OAS integration tests

## Why
The existing `[oas:agent] turn completed` line preserved structured details in JSON, but the terminal log line only showed the bare message. In practice that made it hard to tell which agent produced the line. The same ambiguity can show up across other native OAS lifecycle events.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-oas-turn-completed-context test/test_oas_integration.exe`
- `./_build/default/test/test_oas_integration.exe`