### PR TITLE
fix(logging): promote actionable OAS and keeper failures

### DIFF
--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1893,7 +1893,7 @@ let run_turn
                  Log.Keeper.error "keeper:%s OAS checkpoint save failed: %s" meta.name e);
               Some patched
             | None ->
-              Log.Keeper.warn "keeper:%s missing OAS checkpoint after run" meta.name;
+              Log.Keeper.error "keeper:%s missing OAS checkpoint after run" meta.name;
               None
           in
           (match result.proof with
@@ -1934,7 +1934,7 @@ let run_turn
                  ~kinds_written
            with
            | exn ->
-             Log.Keeper.warn
+             Log.Keeper.error
                "keeper:%s memory_write failed: %s"
                meta.name
                (Printexc.to_string exn));
@@ -1982,7 +1982,7 @@ let run_turn
            with
            | Eio.Cancel.Cancelled _ as e -> raise e
            | exn ->
-               Log.Keeper.warn "keeper:%s episode_create failed: %s"
+               Log.Keeper.error "keeper:%s episode_create failed: %s"
                  meta.name (Printexc.to_string exn));
           (* Memory bank compaction: dedup + consolidate if over threshold. *)
           (try

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -426,14 +426,14 @@ let make_hooks
 
     on_error = Some (function
       | Agent_sdk.Hooks.OnError { detail; context = err_ctx } ->
-        Log.Keeper.warn "keeper:%s on_error: %s (context: %s)"
+        Log.Keeper.error "keeper:%s on_error: %s (context: %s)"
           (!meta_ref).name detail err_ctx;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
 
     on_tool_error = Some (function
       | Agent_sdk.Hooks.OnToolError { tool_name; error } ->
-        Log.Keeper.warn "keeper:%s tool_error: %s — %s"
+        Log.Keeper.error "keeper:%s tool_error: %s — %s"
           (!meta_ref).name tool_name error;
         Agent_sdk.Hooks.Continue
       | _ -> Agent_sdk.Hooks.Continue);
@@ -443,8 +443,8 @@ let make_hooks
         let meta = !meta_ref in
         (* The richer counterpart
              "tool <name> returned error result (n/max): <detail>"
-           is already emitted at WARN by keeper_tools_oas before this hook
-           runs. Emitting a second WARN here with the same error content
+           is already emitted at ERROR by keeper_tools_oas before this hook
+           runs. Emitting a second ERROR here with the same error content
            produces paired duplicate lines per tool failure. Keep a debug
            trace for hook-chain readers; the metric below still records. *)
         Log.Keeper.debug "keeper:%s tool_use_failure: %s — %s"

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1185,11 +1185,11 @@ let run_keepalive_unified_turn
             (match read_meta ctx.config meta_after_observe.name with
              | Ok (Some latest) -> latest
              | Ok None ->
-               Log.Keeper.warn "keeper:%s read_meta returned None after turn failure, using stale meta"
+               Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"
                  meta_after_observe.name;
                meta_after_observe
              | Error e ->
-               Log.Keeper.warn "keeper:%s read_meta failed after turn failure (%s), using stale meta"
+               Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"
                  meta_after_observe.name e;
                meta_after_observe)
           | Ok updated ->

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -247,7 +247,7 @@ let make_tools
                     ("ts_unix", `Float ts);
                   ])
                  with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ());
-                Log.Keeper.warn
+                Log.Keeper.error
                   "tool %s returned error result (%d/%d): %s"
                   td.name count max_consecutive_failures detail;
                 let normalized_error = normalize_tool_result ~success:false result in

--- a/lib/oas_log_bridge.ml
+++ b/lib/oas_log_bridge.ml
@@ -37,6 +37,93 @@ let field_to_json (field : Agent_sdk.Log.field) : string * Yojson.Safe.t =
   | Agent_sdk.Log.B (k, v) -> (k, `Bool v)
   | Agent_sdk.Log.J (k, v) -> (k, v)
 
+let details_of_fields (fields : Agent_sdk.Log.field list)
+    : (string * Yojson.Safe.t) list =
+  List.map field_to_json fields
+
+let json_stringish = function
+  | `String s ->
+      let trimmed = String.trim s in
+      if trimmed = "" then None else Some trimmed
+  | `Int n -> Some (string_of_int n)
+  | `Float f when Float.is_finite f ->
+      Some
+        (if Float.equal f (Float.of_int (int_of_float f)) then
+           string_of_int (int_of_float f)
+         else
+           string_of_float f)
+  | `Bool b -> Some (string_of_bool b)
+  | _ -> None
+
+let first_detail_label details keys =
+  let rec find_key = function
+    | [] -> None
+    | key :: rest -> (
+        match List.assoc_opt key details with
+        | Some value -> (
+            match json_stringish value with
+            | Some _ as label -> label
+            | None -> find_key rest)
+        | None -> find_key rest)
+  in
+  find_key keys
+
+let replace_first_placeholder message value =
+  let len = String.length message in
+  let rec loop idx =
+    if idx + 1 >= len then
+      message
+    else if message.[idx] = '%'
+            && (message.[idx + 1] = 's' || message.[idx + 1] = 'd')
+    then
+      String.sub message 0 idx ^ value
+      ^ String.sub message (idx + 2) (len - idx - 2)
+    else
+      loop (idx + 1)
+  in
+  loop 0
+
+let interpolate_printf_message message details =
+  if not (String.contains message '%') then
+    message
+  else
+    let replacements =
+      [
+        first_detail_label details [ "tool_name"; "tool" ];
+        first_detail_label details [ "fixes" ];
+        first_detail_label details [ "count" ];
+        first_detail_label details [ "client_name" ];
+        first_detail_label details [ "phase" ];
+        first_detail_label details [ "request_id" ];
+        first_detail_label details [ "session_id" ];
+      ]
+      |> List.filter_map Fun.id
+    in
+    List.fold_left replace_first_placeholder message replacements
+
+let render_agent_tools_message ~message ~details =
+  match
+    first_detail_label details [ "tool_name"; "tool" ],
+    first_detail_label details [ "fixes"; "count" ]
+  with
+  | Some tool_name, Some fixes
+    when String.equal message "correction_pipeline fixed tool input fields"
+         || String.equal message
+              "tool %s: correction_pipeline fixed %d field(s)" ->
+      Some
+        (Printf.sprintf "tool %s: correction_pipeline fixed %s field(s)"
+           tool_name fixes)
+  | _ -> None
+
+let render_record_message (record : Agent_sdk.Log.record) : string =
+  let details = details_of_fields record.fields in
+  match record.module_name with
+  | "agent_tools" -> (
+      match render_agent_tools_message ~message:record.message ~details with
+      | Some rendered -> rendered
+      | None -> interpolate_printf_message record.message details)
+  | _ -> interpolate_printf_message record.message details
+
 let level_to_masc (level : Agent_sdk.Log.level) : Log.level =
   match level with
   | Debug -> Log.Debug
@@ -75,11 +162,29 @@ let summarize_fields ~message (fields : Agent_sdk.Log.field list) : string list 
            | Some rendered -> Some (Printf.sprintf "%s=%s" key rendered)
            | None -> None))
 
-let render_message_with_summary (record : Agent_sdk.Log.record) =
-  match summarize_fields ~message:record.message record.fields with
-  | [] -> record.message
-  | summary -> Printf.sprintf "%s %s" record.message (String.concat " " summary)
+let should_promote_warn_to_error (record : Agent_sdk.Log.record) =
+  match record.level, record.module_name, record.message with
+  | Warn, "agent_config", "MCP server failed" -> true
+  | Warn, "agent_turn", "context_injector raised" -> true
+  | Warn, "agent_tools", "ApprovalRequired but no approval callback — executing" ->
+      true
+  | _ -> false
 
+let effective_level (record : Agent_sdk.Log.record) : Log.level =
+  if should_promote_warn_to_error record then
+    Log.Error
+  else
+    level_to_masc record.level
+
+let render_message_with_summary (record : Agent_sdk.Log.record) =
+  let base_message = render_record_message record in
+  if not (String.equal base_message record.message) then
+    base_message
+  else
+    match summarize_fields ~message:record.message record.fields with
+    | [] -> base_message
+    | summary ->
+        Printf.sprintf "%s %s" base_message (String.concat " " summary)
 (** Build the sink function.  Prefix the module name with ["oas:"] so a
     record emitted by [Agent_sdk.Log.create ~module_name:"agent"] lands
     as ["oas:agent"] in the masc-mcp log stream, distinct from any
@@ -92,7 +197,7 @@ let make_sink () : Agent_sdk.Log.sink =
     | [] -> None
     | fields -> Some (`Assoc (List.map field_to_json fields))
   in
-  Log.emit (level_to_masc record.level)
+  Log.emit (effective_level record)
     ~module_name:("oas:" ^ record.module_name)
     ?details
     message

--- a/lib/oas_log_bridge.mli
+++ b/lib/oas_log_bridge.mli
@@ -9,6 +9,18 @@
 
     Should be called exactly once during server bootstrap. *)
 
+val render_record_message : Agent_sdk.Log.record -> string
+(** Render an OAS log record into the human-readable message string that
+    masc-mcp writes to stderr / the structured ring. This interpolates
+    printf-style templates and normalizes known structured OAS messages
+    into an operator-friendly form. *)
+
+val effective_level : Agent_sdk.Log.record -> Log.level
+(** Normalize the OAS record severity before forwarding it into masc-mcp.
+    This preserves upstream levels by default, but promotes specific
+    operator-actionable warn-level failures on the keeper main path to
+    [Error]. *)
+
 val install : unit -> unit
 (** Register the OAS → masc-mcp log sink as a global OAS sink.  Call
     once before any keeper turn fires an LLM call.  Idempotent via an

--- a/test/test_keeper_tools_oas.ml
+++ b/test/test_keeper_tools_oas.ml
@@ -1,5 +1,7 @@
 (** Tests for Keeper_tools_oas — OAS Tool.t wrapping of keeper tools. *)
 
+module Mlog = Log
+
 open Agent_sdk
 open Alcotest
 open Masc_mcp
@@ -139,6 +141,45 @@ let test_error_json_is_returned_as_tool_error () =
           check bool "detail preserves path" true
             (Option.is_some (Safe_ops.json_string_opt "path" detail))
       | Ok _ -> fail "missing file should be surfaced as tool error")
+
+let latest_log_seq () =
+  match Mlog.Ring.recent ~limit:1 () with
+  | (entry : Mlog.Ring.entry) :: _ -> entry.seq
+  | [] -> -1
+
+let test_error_result_logs_at_error_level () =
+  let meta = make_test_meta () in
+  let ctx_snapshot = make_test_ctx () in
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "test_keeper_tools_log_level_%d" (Random.int 100000)) in
+  (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.readdir dir |> Array.iter (fun f ->
+        Sys.remove (Filename.concat dir f));
+        Unix.rmdir dir with _ -> ()))
+    (fun () ->
+      Eio_main.run @@ fun env ->
+      Fs_compat.set_fs (Eio.Stdenv.fs env);
+      let config = Coord.default_config dir in
+      let tools = Keeper_tools_oas.make_tools ~config ~meta ~ctx_snapshot () in
+      let tool = find_tool "keeper_fs_read" tools in
+      let baseline = latest_log_seq () in
+      (match Tool.execute tool
+               (`Assoc [("path", `String "missing-file-for-keeper-tools-oas.txt")])
+       with
+       | Error _ -> ()
+       | Ok _ -> fail "missing file should be surfaced as tool error");
+      let entry =
+        Mlog.Ring.recent ~limit:50 ~module_filter:"Keeper" ~since_seq:baseline ()
+        |> List.find_opt (fun (entry : Mlog.Ring.entry) ->
+          string_contains ~sub:"returned error result" entry.message)
+      in
+      match entry with
+      | None -> fail "expected keeper error log for failing tool result"
+      | Some (entry : Mlog.Ring.entry) ->
+          check string "failing tool result logs at ERROR" "ERROR"
+            entry.normalized_level)
 
 let test_missing_file_error_includes_directory_suggestions () =
   let meta = make_test_meta () in
@@ -507,6 +548,8 @@ let () =
       test_case "valid schemas" `Quick test_tools_have_valid_schemas;
       test_case "count matches allowed" `Quick test_tool_count_matches_allowed;
       test_case "error json becomes tool error" `Quick test_error_json_is_returned_as_tool_error;
+      test_case "error result logs at error level" `Quick
+        test_error_result_logs_at_error_level;
       test_case "missing file error includes suggestions" `Quick
         test_missing_file_error_includes_directory_suggestions;
       test_case "repeated errors are blocked" `Quick test_repeated_error_results_are_blocked;

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -38,6 +38,83 @@ let test_recent_since_seq_returns_only_new_entries () =
     [ warn_message; info_message ]
     (List.map (fun (entry : Log.Ring.entry) -> entry.message) entries)
 
+let oas_record ?(level = Agent_sdk.Log.Info) ~module_name ~message fields =
+  Agent_sdk.Log.
+    {
+      ts = Unix.gettimeofday ();
+      level;
+      module_name;
+      message;
+      fields;
+      trace_id = None;
+      span_id = None;
+    }
+
+let test_oas_bridge_interpolates_placeholder_messages () =
+  let rendered =
+    Masc_mcp.Oas_log_bridge.render_record_message
+      (oas_record
+         ~module_name:"agent_tools"
+         ~message:"tool %s: correction_pipeline fixed %d field(s)"
+         [ Agent_sdk.Log.S ("tool", "keeper_github");
+           Agent_sdk.Log.I ("fixes", 2) ])
+  in
+  Alcotest.(check string) "placeholder message rendered"
+    "tool keeper_github: correction_pipeline fixed 2 field(s)"
+    rendered
+
+let test_oas_bridge_normalizes_generic_correction_messages () =
+  let rendered =
+    Masc_mcp.Oas_log_bridge.render_record_message
+      (oas_record
+         ~module_name:"agent_tools"
+         ~message:"correction_pipeline fixed tool input fields"
+         [ Agent_sdk.Log.S ("tool", "keeper_github");
+           Agent_sdk.Log.I ("fixes", 2) ])
+  in
+  Alcotest.(check string) "generic correction message normalized"
+    "tool keeper_github: correction_pipeline fixed 2 field(s)"
+    rendered
+
+let test_oas_bridge_promotes_mcp_server_failures_to_error () =
+  let level =
+    Masc_mcp.Oas_log_bridge.effective_level
+      (oas_record
+         ~level:Agent_sdk.Log.Warn
+         ~module_name:"agent_config"
+         ~message:"MCP server failed"
+         [ Agent_sdk.Log.S ("server", "demo");
+           Agent_sdk.Log.S ("error", "connection refused") ])
+  in
+  Alcotest.(check string) "mcp server failure promoted" "ERROR"
+    (Log.level_to_string level)
+
+let test_oas_bridge_promotes_context_injector_failures_to_error () =
+  let level =
+    Masc_mcp.Oas_log_bridge.effective_level
+      (oas_record
+         ~level:Agent_sdk.Log.Warn
+         ~module_name:"agent_turn"
+         ~message:"context_injector raised"
+         [ Agent_sdk.Log.S ("tool", "keeper_fs_read");
+           Agent_sdk.Log.S ("error", "boom") ])
+  in
+  Alcotest.(check string) "context injector failure promoted" "ERROR"
+    (Log.level_to_string level)
+
+let test_oas_bridge_promotes_missing_approval_callback_to_error () =
+  let level =
+    Masc_mcp.Oas_log_bridge.effective_level
+      (oas_record
+         ~level:Agent_sdk.Log.Warn
+         ~module_name:"agent_tools"
+         ~message:"ApprovalRequired but no approval callback — executing"
+         [ Agent_sdk.Log.S ("tool", "keeper_bash");
+           Agent_sdk.Log.S ("agent", "demo") ])
+  in
+  Alcotest.(check string) "approval callback gap promoted" "ERROR"
+    (Log.level_to_string level)
+
 let () =
   Alcotest.run "Masc_log" [
     ( "ring",
@@ -46,5 +123,20 @@ let () =
           test_legacy_traceln_records_metadata;
         Alcotest.test_case "recent since_seq returns only new entries" `Quick
           test_recent_since_seq_returns_only_new_entries;
+        Alcotest.test_case
+          "oas bridge interpolates placeholder messages"
+          `Quick test_oas_bridge_interpolates_placeholder_messages;
+        Alcotest.test_case
+          "oas bridge normalizes generic correction messages"
+          `Quick test_oas_bridge_normalizes_generic_correction_messages;
+        Alcotest.test_case
+          "oas bridge promotes MCP server failures"
+          `Quick test_oas_bridge_promotes_mcp_server_failures_to_error;
+        Alcotest.test_case
+          "oas bridge promotes context injector failures"
+          `Quick test_oas_bridge_promotes_context_injector_failures_to_error;
+        Alcotest.test_case
+          "oas bridge promotes missing approval callback"
+          `Quick test_oas_bridge_promotes_missing_approval_callback_to_error;
       ] );
   ]

--- a/test/test_warn_root_causes.ml
+++ b/test/test_warn_root_causes.ml
@@ -15,6 +15,29 @@ let init_registry () =
   | Ok () -> ()
   | Error e -> failwith (Printf.sprintf "init_policy_config failed: %s" e)
 
+let file_contains_pattern file_rel pattern =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root file_rel in
+  if not (Sys.file_exists path) then false
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let content = In_channel.input_all ic in
+        if String.length pattern = 0 then true
+        else
+          let re = Str.regexp_string pattern in
+          (try ignore (Str.search_forward re content 0); true
+           with Not_found -> false))
+
+let file_not_contains_pattern file_rel pattern =
+  not (file_contains_pattern file_rel pattern)
+
 let make_meta ?(name = "test-keeper") () : Keeper_types.keeper_meta =
   match Keeper_types.meta_of_json
     (`Assoc [("name", `String name); ("agent_name", `String name);
@@ -158,6 +181,43 @@ let test_concurrent_atomic_writes_never_empty () =
   (try Unix.unlink path with _ -> ());
   (try Unix.rmdir dir with _ -> ())
 
+(* ── Test 3: Keeper/OAS failure severities on main path ─────────────── *)
+
+let test_keeper_mainline_failures_log_at_error () =
+  check bool "missing checkpoint after run logs at ERROR" true
+    (file_contains_pattern "lib/keeper/keeper_agent_run.ml"
+       {|Log.Keeper.error "keeper:%s missing OAS checkpoint after run"|});
+  check bool "memory write failures log at ERROR" true
+    (file_contains_pattern "lib/keeper/keeper_agent_run.ml"
+       {|"keeper:%s memory_write failed: %s"|});
+  check bool "memory write failures are no longer WARN" true
+    (file_not_contains_pattern "lib/keeper/keeper_agent_run.ml"
+       {|Log.Keeper.warn
+               "keeper:%s memory_write failed: %s"|});
+  check bool "episode creation failures log at ERROR" true
+    (file_contains_pattern "lib/keeper/keeper_agent_run.ml"
+       {|"keeper:%s episode_create failed: %s"|});
+  check bool "episode creation failures are no longer WARN" true
+    (file_not_contains_pattern "lib/keeper/keeper_agent_run.ml"
+       {|Log.Keeper.warn "keeper:%s episode_create failed: %s"|});
+  check bool "post-failure read_meta None logs at ERROR" true
+    (file_contains_pattern "lib/keeper/keeper_keepalive.ml"
+       {|Log.Keeper.error "keeper:%s read_meta returned None after turn failure, using stale meta"|});
+  check bool "post-failure read_meta Error logs at ERROR" true
+    (file_contains_pattern "lib/keeper/keeper_keepalive.ml"
+       {|Log.Keeper.error "keeper:%s read_meta failed after turn failure (%s), using stale meta"|})
+
+let test_oas_mainline_warns_are_promoted_in_bridge () =
+  check bool "bridge promotes MCP server failure" true
+    (file_contains_pattern "lib/oas_log_bridge.ml"
+       {|Warn, "agent_config", "MCP server failed" -> true|});
+  check bool "bridge promotes context injector failure" true
+    (file_contains_pattern "lib/oas_log_bridge.ml"
+       {|Warn, "agent_turn", "context_injector raised" -> true|});
+  check bool "bridge promotes approval callback gap" true
+    (file_contains_pattern "lib/oas_log_bridge.ml"
+       {|Warn, "agent_tools", "ApprovalRequired but no approval callback — executing"|})
+
 (* ── Runner ───────────────────────────────────────────────────── *)
 
 let () =
@@ -178,5 +238,12 @@ let () =
             test_atomic_write_not_empty;
           test_case "concurrent writes never produce empty reads" `Quick
             test_concurrent_atomic_writes_never_empty;
+        ] );
+      ( "mainline_failure_levels",
+        [
+          test_case "keeper mainline failures log at error" `Quick
+            test_keeper_mainline_failures_log_at_error;
+          test_case "oas mainline warns are promoted in bridge" `Quick
+            test_oas_mainline_warns_are_promoted_in_bridge;
         ] );
     ]


### PR DESCRIPTION
## Summary
- render OAS structured log records into readable messages before they hit stderr/ring logs
- promote actionable OAS warn-level failures and keeper recovery failures to ERROR on the main execution path
- add regression coverage for message rendering and failure severity guards

## Verification
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/log-observability ./test/test_masc_log.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/log-observability/_build/default/test/test_keeper_tools_oas.exe test --color=never 'make_tools' 3,4
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/log-observability/_build/default/test/test_warn_root_causes.exe test --color=never 'mainline_failure_levels'