### PR TITLE
feat(discord-bot): load optional runtime config.toml

### DIFF
--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -14,7 +14,12 @@ from typing import Final, cast
 from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/discord/bindings.json"
 DEFAULT_BINDING_AUDIT_PATH: Final[str] = ".gate/runtime/discord/binding_audit.jsonl"
@@ -33,6 +38,22 @@ LEGACY_STATUS_PATH: Final[str] = ".masc/connectors/discord/status.json"
 LEGACY_NAMES_PATH: Final[str] = ".masc/connectors/discord/names.json"
 
 
+def _runtime_toml_path() -> Path:
+    """Resolve the optional runtime config.toml location.
+
+    The file is not required — when absent, every setting falls back to its
+    Field default. When present, its values override the defaults but are
+    still overridden by env vars (so ephemeral deployment overrides remain
+    unambiguous).
+
+    Location: ``$MASC_BASE_PATH/.gate/runtime/discord/config.toml``.
+    Falls back to cwd-relative when MASC_BASE_PATH is unset.
+    """
+    raw = os.getenv("MASC_BASE_PATH", "").strip()
+    root = Path(raw).expanduser() if raw else Path.cwd()
+    return root / ".gate/runtime/discord/config.toml"
+
+
 def _is_loopback_host(raw_host: str | None) -> bool:
     if raw_host is None:
         return False
@@ -46,9 +67,45 @@ def _is_loopback_host(raw_host: str | None) -> bool:
 
 
 class BotConfig(BaseSettings):
-    """Bot configuration from environment variables."""
+    """Bot configuration.
 
-    model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
+    Resolution priority, highest first:
+      1. Env vars — including ``.env`` file — primary surface for secrets
+         (``DISCORD_BOT_TOKEN``, ``GATE_API_TOKEN``) and for emergency
+         deployment overrides on any field.
+      2. Runtime TOML at ``$MASC_BASE_PATH/.gate/runtime/discord/config.toml``
+         (optional; see :func:`_runtime_toml_path`). Operator-editable, same
+         directory as ``bindings.json``/``status.json``. Not git-tracked.
+      3. Field defaults compiled into this class — the system works
+         end-to-end with no TOML or env var beyond the bot token.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        case_sensitive=True,
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        toml_source = TomlConfigSettingsSource(
+            settings_cls, toml_file=_runtime_toml_path()
+        )
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            toml_source,
+            file_secret_settings,
+        )
 
     # Required
     discord_bot_token: str = Field(


### PR DESCRIPTION
## Summary

- Discord sidecar now reads an optional `config.toml` from `$MASC_BASE_PATH/.gate/runtime/discord/config.toml`.
- **File absent = everything works with field defaults.** No action required for fresh deployments.
- Pydantic `TomlConfigSettingsSource` (pydantic-settings >=2.6, already pinned) provides the loader.

## Product impact

Zero for existing deployments. Additive surface: operators who want to tune timeouts/paths/breaker thresholds without env-var sprawl can create a `config.toml` next to `bindings.json`. Example:

```toml
gate_timeout_sec = 60
status_heartbeat_sec = 5
```

Secrets (`DISCORD_BOT_TOKEN`, `GATE_API_TOKEN`) stay in env vars. TOML never holds secrets.

## Resolution priority

```
init kwargs > env vars + .env > runtime TOML > field defaults
```

Env var aliases from #7506 are preserved — existing `DISCORD_BINDING_STORE_PATH` deployments unaffected.

## Changes

`sidecars/discord-bot/src/config.py`:
- Import `TomlConfigSettingsSource`, `PydanticBaseSettingsSource`, `SettingsConfigDict`
- `_runtime_toml_path()` — resolves `MASC_BASE_PATH/.gate/runtime/discord/config.toml` (cwd fallback)
- `model_config` switched to `SettingsConfigDict(extra="ignore")` so unknown TOML keys don't crash
- `settings_customise_sources` overridden to insert TOML source in the priority chain

+60 / -3 in 1 file.

## Evidence

`python -m py_compile` → OK. Full pytest needs sidecar venv.

## Follow-ups

- Same pattern for iMessage, Slack, Telegram sidecars
- Optionally trim env-var alias overweight (keep secrets-only env, rest goes to TOML)