### PR TITLE
feat(coord_task): add ?correlation_id ?run_id to emit_task_activity

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -140,7 +140,30 @@ let merge_execution_links (existing : Types.task_execution_links) ?session_id
       | None -> trim_opt existing.autoresearch_loop_id);
   }
 
-let emit_task_activity config ~agent_name ~task_id ~kind ~payload =
+(** Merge optional OAS event_bus envelope identifiers (correlation_id,
+    run_id) into the task activity payload. When both ids are absent the
+    original payload is returned untouched, so existing callers compile
+    and behave identically. *)
+let merge_envelope_into_payload ?correlation_id ?run_id payload =
+  let optional name = function
+    | Some v -> [ (name, `String v) ]
+    | None -> []
+  in
+  let extras =
+    optional "correlation_id" correlation_id
+    @ optional "run_id" run_id
+  in
+  if extras = [] then payload
+  else
+    match payload with
+    | `Assoc fields -> `Assoc (fields @ extras)
+    | other -> `Assoc [ ("payload", other); ("envelope", `Assoc extras) ]
+
+let emit_task_activity ?correlation_id ?run_id
+    config ~agent_name ~task_id ~kind ~payload =
+  let payload =
+    merge_envelope_into_payload ?correlation_id ?run_id payload
+  in
   try
     !Coord_hooks.activity_emit_fn config
       ~actor:Coord_hooks.{ kind = task_actor_kind agent_name; id = agent_name }

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -157,7 +157,9 @@ let merge_envelope_into_payload ?correlation_id ?run_id payload =
   else
     match payload with
     | `Assoc fields -> `Assoc (fields @ extras)
-    | other -> `Assoc [ ("payload", other); ("envelope", `Assoc extras) ]
+    | _ ->
+        Log.Misc.warn "emit_task_activity: non-Assoc payload, envelope fields skipped";
+        payload
 
 let emit_task_activity ?correlation_id ?run_id
     config ~agent_name ~task_id ~kind ~payload =

--- a/lib/coord/coord_task.mli
+++ b/lib/coord/coord_task.mli
@@ -29,8 +29,13 @@ val update_local_agent_state :
     the same discipline for its own agent-state writes. *)
 
 val emit_task_activity :
+  ?correlation_id:string -> ?run_id:string ->
   config -> agent_name:string -> task_id:string ->
   kind:string -> payload:Yojson.Safe.t -> unit
+(** Optional [correlation_id] / [run_id] are merged into the activity
+    payload as additional fields when present, so call sites can opt in
+    without breaking existing callers. Backed by
+    [merge_envelope_into_payload]. *)
 
 val task_actor_kind : string -> string
 


### PR DESCRIPTION
## 요약

`emit_task_activity`에 `?correlation_id` `?run_id` optional labeled argument 추가.
OAS event_bus envelope → MASC coordination 레이어 전파 준비.

## 동기

감사 gap #1: OAS event_bus envelope `{correlation_id, run_id, ts}`가 MASC 레이어에 전파 안 됨.
multi-agent 인과 추적(end-to-end trace)이 불가능.

## 변경

- 신규 helper `merge_envelope_into_payload ?correlation_id ?run_id payload` — `Some`일 때만 payload에 merge.
- `emit_task_activity` 시그니처에 `?correlation_id ?run_id` 추가 (기본 None → caller 변경 0).
- `coord_task.mli` 시그니처 동기화.

## 영향 범위

- 기존 caller 모두 변경 없이 컴파일 (optional default None).
- 실제 id wiring (OAS context → MASC caller)은 follow-up PR.

## Test

- `dune build --root .`: exit=0
- `dune runtest --root .`: 116 tests pass

## Related

MASC task-135. 감사 gap #1 시그니처 준비.