### PR TITLE
chore: simplify session code — trim comments + fix TOCTOU

### DIFF
--- a/lib/gate/channel_gate_discord_names.ml
+++ b/lib/gate/channel_gate_discord_names.ml
@@ -52,11 +52,8 @@ let names_read_path () =
     ~default:default_names_path ~legacy:legacy_names_path
 
 let read_json_file_opt path =
-  if not (Sys.file_exists path) then
-    None
-  else
-    try Some (Yojson.Safe.from_file path) with
-    | _ -> None
+  try Some (Yojson.Safe.from_file path) with
+  | _ -> None
 
 let string_member json key =
   match json |> U.member key with

--- a/lib/gate/channel_gate_discord_state.ml
+++ b/lib/gate/channel_gate_discord_state.ml
@@ -66,11 +66,8 @@ let binding_audit_read_path () =
     ~default:default_binding_audit_path ~legacy:legacy_binding_audit_path
 
 let read_json_file_opt path =
-  if not (Sys.file_exists path) then
-    None
-  else
-    try Some (Yojson.Safe.from_file path) with
-    | Sys_error _ | Yojson.Json_error _ -> None
+  try Some (Yojson.Safe.from_file path) with
+  | Sys_error _ | Yojson.Json_error _ -> None
 
 let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
   match json with

--- a/lib/gate/channel_gate_imessage_state.ml
+++ b/lib/gate/channel_gate_imessage_state.ml
@@ -91,11 +91,8 @@ let binding_audit_read_path () =
     ~default:default_binding_audit_path ~legacy:legacy_binding_audit_path
 
 let read_json_file_opt path =
-  if not (Sys.file_exists path) then
-    None
-  else
-    try Some (Yojson.Safe.from_file path) with
-    | Sys_error _ | Yojson.Json_error _ -> None
+  try Some (Yojson.Safe.from_file path) with
+  | Sys_error _ | Yojson.Json_error _ -> None
 
 let normalize_bindings_json (json : Yojson.Safe.t) : binding list =
   match json with

--- a/lib/gate/gate_protocol.ml
+++ b/lib/gate/gate_protocol.ml
@@ -96,11 +96,7 @@ let inbound_of_json json =
       let raw = str "channel" in
       String.lowercase_ascii (String.trim raw)
     in
-    (* Read priority for the keeper-routing field: accept the new
-       [destination_id] key first and fall back to the legacy [keeper_name]
-       key. Both map onto the same record field for now; emit-side is still
-       [keeper_name] only (B2 Phase 1 — parse-both / emit-legacy). The
-       emit-side rotation happens in Phase 2. *)
+    (* Prefer [destination_id]; fall back to legacy [keeper_name]. *)
     let keeper_name =
       let destination = str "destination_id" in
       if destination <> "" then destination
@@ -138,12 +134,7 @@ let outbound_to_json out =
           ("tokens_used", `Int s.tokens_used);
         ]
   in
-  (* B2 Phase 3: [destination_id] is the sole outbound routing key. The
-     legacy [keeper_name] output was dropped now that all known consumers
-     (sidecars via gate_shared.GateResponse.from_json, #7485) prefer
-     [destination_id] and only fall back to [keeper_name] when the new key
-     is absent. Inbound parse still accepts either key — Phase 4 can
-     retire the [keeper_name] wire form entirely in a future major bump. *)
+  (* Inbound still accepts [keeper_name] for backward compatibility. *)
   let base = [
     ("ok", `Bool true);
     ("destination_id", `String out.keeper_name);

--- a/sidecars/discord-bot/src/config.py
+++ b/sidecars/discord-bot/src/config.py
@@ -39,16 +39,6 @@ LEGACY_NAMES_PATH: Final[str] = ".masc/connectors/discord/names.json"
 
 
 def _runtime_toml_path() -> Path:
-    """Resolve the optional runtime config.toml location.
-
-    The file is not required — when absent, every setting falls back to its
-    Field default. When present, its values override the defaults but are
-    still overridden by env vars (so ephemeral deployment overrides remain
-    unambiguous).
-
-    Location: ``$MASC_BASE_PATH/.gate/runtime/discord/config.toml``.
-    Falls back to cwd-relative when MASC_BASE_PATH is unset.
-    """
     raw = os.getenv("MASC_BASE_PATH", "").strip()
     root = Path(raw).expanduser() if raw else Path.cwd()
     return root / ".gate/runtime/discord/config.toml"
@@ -67,18 +57,7 @@ def _is_loopback_host(raw_host: str | None) -> bool:
 
 
 class BotConfig(BaseSettings):
-    """Bot configuration.
-
-    Resolution priority, highest first:
-      1. Env vars — including ``.env`` file — primary surface for secrets
-         (``DISCORD_BOT_TOKEN``, ``GATE_API_TOKEN``) and for emergency
-         deployment overrides on any field.
-      2. Runtime TOML at ``$MASC_BASE_PATH/.gate/runtime/discord/config.toml``
-         (optional; see :func:`_runtime_toml_path`). Operator-editable, same
-         directory as ``bindings.json``/``status.json``. Not git-tracked.
-      3. Field defaults compiled into this class — the system works
-         end-to-end with no TOML or env var beyond the bot token.
-    """
+    """Bot configuration.  Priority: env > runtime TOML > field defaults."""
 
     model_config = SettingsConfigDict(
         env_prefix="",

--- a/sidecars/shared/gate_shared/bindings_store.py
+++ b/sidecars/shared/gate_shared/bindings_store.py
@@ -1,25 +1,8 @@
 """Shared bindings-store helpers for Channel Gate sidecars.
 
-Slack, iMessage, and Telegram sidecars all need to load a simple
-`{channel_id: keeper_name}` JSON file with 1-tier legacy fallback, and
-Slack + Telegram also need to persist the same shape atomically. This
-module collapses the duplicated 38-line `_load_bindings` /
-`_save_bindings` blocks into a pair of pure functions that take the
-paths as arguments — no base class, no mixin, no state.
-
-Discord's sidecar uses a richer `BindingStore` class with atomic writes
-and audit coupling; it stays separate and is not affected by this
-module.
-
-Read priority in `load_bindings`:
-  1. `default_path` (if the file exists)
-  2. `legacy_path` (if provided, the file exists, and default is absent)
-  3. empty dict
-
-Writes in `save_bindings` always land at the caller's `path`, so the
-one-shot migration introduced in #7477/#7478/#7479 remains transparent
-— next save after a legacy load hits the new default and the legacy
-file becomes dormant.
+Load and persist ``{channel_id: keeper_name}`` JSON with 1-tier legacy
+fallback.  Discord's richer ``BindingStore`` class (audit coupling +
+mtime tracking) is intentionally separate.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Post-session `/simplify` pass. 3 parallel review agents identified 4 actionable items; rest was clean.

**Comment trimming** (-56 LOC):
- `bindings_store.py` module docstring 22→4 lines (task-number refs removed)
- `gate_protocol.ml` two multi-line B2-phase comments → one-line summaries
- `discord-bot/config.py` `_runtime_toml_path` docstring removed + BotConfig docstring 10→1 line

**TOCTOU fix** (-6 LOC):
- `read_json_file_opt` in 3 gate modules dropped the redundant `Sys.file_exists` pre-check. `try/with` already catches `Sys_error` for missing files — the existence check was a wasted syscall + TOCTOU window.

## Evidence

- `dune build --root .` → clean
- Gate tests 34/34 pass
- `python -m py_compile` OK

## Linked issue

Follows the full session's 23-PR connector refactor chain.