### PR TITLE
feat(sidecars): add optional runtime config.toml to iMessage/Slack/Telegram

### DIFF
--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -13,7 +13,12 @@ from typing import Final
 from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field, field_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 
 DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/imessage"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/imessage/bindings.json"
@@ -29,6 +34,12 @@ CHAT_DB_PATH: Final[str] = os.path.expanduser("~/Library/Messages/chat.db")
 LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/imessage/bindings.json"
 
 
+def _runtime_toml_path() -> Path:
+    raw = os.getenv("MASC_BASE_PATH", "").strip()
+    root = Path(raw).expanduser() if raw else Path.cwd()
+    return root / ".gate/runtime/imessage/config.toml"
+
+
 def _is_loopback_host(raw_host: str | None) -> bool:
     if raw_host is None:
         return False
@@ -42,9 +53,28 @@ def _is_loopback_host(raw_host: str | None) -> bool:
 
 
 class BotConfig(BaseSettings):
-    """Bot configuration from environment variables."""
+    """Bot configuration.  Priority: env > runtime TOML > field defaults."""
 
-    model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        case_sensitive=True,
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        toml_source = TomlConfigSettingsSource(
+            settings_cls, toml_file=_runtime_toml_path()
+        )
+        return (init_settings, env_settings, dotenv_settings, toml_source, file_secret_settings)
 
     # Gate connection
     gate_base_url: str = Field(

--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -13,7 +13,12 @@ from typing import Final
 from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 
 DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/slack"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/slack/bindings.json"
@@ -23,6 +28,12 @@ DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/slack/status.json"
 # loads from here if the new default is absent, then writes to the new
 # default on next save.
 LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/slack/bindings.json"
+
+
+def _runtime_toml_path() -> Path:
+    raw = os.getenv("MASC_BASE_PATH", "").strip()
+    root = Path(raw).expanduser() if raw else Path.cwd()
+    return root / ".gate/runtime/slack/config.toml"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -38,9 +49,28 @@ def _is_loopback_host(raw_host: str | None) -> bool:
 
 
 class BotConfig(BaseSettings):
-    """Bot configuration from environment variables."""
+    """Bot configuration.  Priority: env > runtime TOML > field defaults."""
 
-    model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        case_sensitive=True,
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        toml_source = TomlConfigSettingsSource(
+            settings_cls, toml_file=_runtime_toml_path()
+        )
+        return (init_settings, env_settings, dotenv_settings, toml_source, file_secret_settings)
 
     # Required: Slack Bot Token (xoxb-...)
     slack_bot_token: str = Field(

--- a/sidecars/telegram-bot/src/config.py
+++ b/sidecars/telegram-bot/src/config.py
@@ -11,7 +11,12 @@ from typing import Final
 from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 
 DEFAULT_STATE_DIR: Final[str] = ".gate/runtime/telegram"
 DEFAULT_BINDING_STORE_PATH: Final[str] = ".gate/runtime/telegram/bindings.json"
@@ -21,6 +26,12 @@ DEFAULT_STATUS_PATH: Final[str] = ".gate/runtime/telegram/status.json"
 # loads from here if the new default is absent, then writes to the new
 # default on next save.
 LEGACY_BINDING_STORE_PATH: Final[str] = ".masc/connectors/telegram/bindings.json"
+
+
+def _runtime_toml_path() -> Path:
+    raw = os.getenv("MASC_BASE_PATH", "").strip()
+    root = Path(raw).expanduser() if raw else Path.cwd()
+    return root / ".gate/runtime/telegram/config.toml"
 
 
 def _is_loopback_host(raw_host: str | None) -> bool:
@@ -36,9 +47,28 @@ def _is_loopback_host(raw_host: str | None) -> bool:
 
 
 class BotConfig(BaseSettings):
-    """Bot configuration from environment variables."""
+    """Bot configuration.  Priority: env > runtime TOML > field defaults."""
 
-    model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
+    model_config = SettingsConfigDict(
+        env_prefix="",
+        case_sensitive=True,
+        env_file=".env",
+        extra="ignore",
+    )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        toml_source = TomlConfigSettingsSource(
+            settings_cls, toml_file=_runtime_toml_path()
+        )
+        return (init_settings, env_settings, dotenv_settings, toml_source, file_secret_settings)
 
     # Required: Telegram Bot API token from @BotFather
     telegram_bot_token: str = Field(


### PR DESCRIPTION
## Summary

- Mirrors #7509 (Discord TOML source). iMessage, Slack, and Telegram sidecars now read an optional `config.toml` from `$MASC_BASE_PATH/.gate/runtime/<kind>/config.toml`.
- All 4 Python sidecars now share the same pydantic TOML source pattern. CI should be green again thanks to #7499.

## Product impact

Zero for existing deployments. Additive surface — operators can create a `config.toml` next to `bindings.json` to tune timeouts/paths without env vars. Secrets stay env-only.

## Changes

Each sidecar (`imessage-bot`, `slack-bot`, `telegram-bot`) gets:
- Import expansion (`TomlConfigSettingsSource`, `SettingsConfigDict`, `PydanticBaseSettingsSource`)
- `_runtime_toml_path()` → resolves `MASC_BASE_PATH/.gate/runtime/<kind>/config.toml`
- `model_config` switched to `SettingsConfigDict(extra="ignore")`
- `settings_customise_sources` overridden with TOML in the priority chain

+99 / -9 across 3 files. Identical pattern per sidecar.

## Evidence

`python -m py_compile` on all 3 → OK.

## Linked issue

Refs #7509 (Discord TOML). Completes 4-sidecar TOML surface.