### PR TITLE
fix(release): allow macOS build to fail gracefully (#7475)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,18 @@ concurrency:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-14  # Apple Silicon
             arch: macos-arm64
+            may-fail: true   # upstream opam macOS arm64 binary missing (#7475)
           - os: ubuntu-latest
             arch: linux-x64
+            may-fail: false
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.may-fail }}
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
## Summary

macOS arm64 opam binary is missing upstream — `ocaml/setup-ocaml@v3.6.0` fails. Adds `continue-on-error` + `fail-fast: false` to the release matrix so the Linux build proceeds and creates a release with at least the linux-x64 binary.

When upstream restores macOS binaries, flip `may-fail` back to `false`.

## Changes

`.github/workflows/release.yml`: `fail-fast: false`, `may-fail` matrix flag, `continue-on-error: ${{ matrix.may-fail }}`.

## After merge

Delete v0.9.4 tag, re-tag on new main HEAD, push tag. Linux binary should appear in GitHub Releases.