### PR TITLE
refactor: consolidate board visibility + health level variant dispatch (#7525)

### DIFF
--- a/lib/board_votes.ml
+++ b/lib/board_votes.ml
@@ -202,12 +202,7 @@ let stats store =
     ]
   )
 
-let visibility_of_string = function
-  | "public" -> Some Public
-  | "unlisted" -> Some Unlisted
-  | "internal" -> Some Internal
-  | "direct" -> Some Direct
-  | _ -> None
+let visibility_of_string = Board_core_classify.visibility_of_string
 
 let post_of_yojson (json : Yojson.Safe.t) : post option =
   match

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -73,7 +73,8 @@ let list_field key json =
   | `List items -> items
   | _ -> []
 
-let severity_rank = function
+let severity_rank s =
+  match String.lowercase_ascii s with
   | "bad" | "risk" | "critical" -> 2
   | "warn" | "watch" | "interrupted" | "degraded" -> 1
   | _ -> 0
@@ -124,8 +125,8 @@ let health_level_of_string s =
   | "critical" -> HL_critical
   | "bad" -> HL_bad
   | "risk" -> HL_risk
-  | "warn" -> HL_warn
-  | "degraded" -> HL_degraded
+  | "warn" | "watch" -> HL_warn
+  | "degraded" | "interrupted" -> HL_degraded
   | "ok" | "good" | "healthy" -> HL_ok
   | _ -> HL_unknown
 
@@ -137,6 +138,11 @@ let string_of_health_level = function
   | HL_degraded -> "degraded"
   | HL_ok -> "ok"
   | HL_unknown -> "unknown"
+
+let severity_rank_of_health_level = function
+  | HL_critical | HL_bad | HL_risk -> 2
+  | HL_warn | HL_degraded -> 1
+  | HL_ok | HL_unknown -> 0
 
 (** Session lifecycle — parsed from session JSON at call sites.
     The variant makes the different terminal sets visible:

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -109,12 +109,7 @@ let board_error_to_string = function
   | Board.Validation_error s -> Printf.sprintf "Validation error: %s" s
   | Board.Already_voted s -> Printf.sprintf "Already voted: %s" s
 
-let visibility_of_string = function
-  | "public" -> Some Board.Public
-  | "unlisted" -> Some Board.Unlisted
-  | "internal" -> Some Board.Internal
-  | "direct" -> Some Board.Direct
-  | _ -> None
+let visibility_of_string = Board.visibility_of_string
 
 (** Agent lookup callback — set once at server startup with the real
     Coord.is_agent_joined check so that board posts are auto-classified


### PR DESCRIPTION
## Summary

Issue #7525 (variant 통합 7곳) 중 가장 위험한 2곳 수정.

## Changes

### Board Visibility SSOT (#5, MEDIUM+CONSISTENCY)
- `Board_types.visibility` + `Board_core_classify.visibility_of_string/to_string`이 SSOT
- `tool_board.ml`: 중복 `visibility_of_string` 제거 → `Board.visibility_of_string` 참조
- `board_votes.ml`: 중복 `visibility_of_string` 제거 → `Board_core_classify.visibility_of_string` 참조
- 3파일 독립 정의 → 1 SSOT + 2 alias

### Health Level variant coverage (#1, HIGH)
- `health_level_of_string`: "watch" → `HL_warn`, "interrupted" → `HL_degraded` 추가
- `severity_rank_of_health_level`: variant 기반 새 함수 (기존 `severity_rank` string 버전 유지)
- Caller 점진 전환 가능 (string → variant migration path)

## Remaining (#7525)

3. Agent Archetype, 4. Claim Status, 6. Feature Flag Lifecycle, 7. Keeper Lifecycle — 다음 PR

## Test plan

- [x] `dune build` clean
- [x] `dune runtest` — 전체 pass (mcp/keeper tool matrix 포함)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)