### PR TITLE
feat(cdal): verdict gate + verification FSM + cross-agent protocol

### DIFF
--- a/dashboard/src/components/common/status-badge.ts
+++ b/dashboard/src/components/common/status-badge.ts
@@ -13,6 +13,8 @@ function statusDotColor(status: string): string {
     case 'in_progress':
     case 'running':
       return 'bg-[var(--warn)]'
+    case 'awaiting_verification':
+      return 'bg-[var(--accent)]'
     case 'interrupted':
     case 'listening':
       return 'bg-[var(--accent)]'

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -41,6 +41,12 @@ function eventBadge(label: string): { icon: any; color: string } {
     case 'completed': return { icon: html`<${Check} size=${14} />`, color: 'text-ok' }
     case 'cancel':
     case 'cancelled': return { icon: html`<${X} size=${14} />`, color: 'text-bad' }
+    case 'submit_for_verification':
+    case 'awaiting_verification': return { icon: html`<${ArrowRight} size=${14} />`, color: 'text-accent' }
+    case 'approve':
+    case 'approved': return { icon: html`<${Check} size=${14} />`, color: 'text-ok' }
+    case 'reject':
+    case 'rejected': return { icon: html`<${X} size=${14} />`, color: 'text-warn' }
     case 'transition': return { icon: html`<${ArrowRight} size=${14} />`, color: 'text-warn' }
     default: return { icon: html`<${Dot} size=${14} />`, color: 'text-text-muted' }
   }

--- a/dashboard/src/lib/status-label.ts
+++ b/dashboard/src/lib/status-label.ts
@@ -85,6 +85,8 @@ export function statusLabel(value?: string | null): string {
       return '점유됨'
     case 'in_progress':
       return '진행 중'
+    case 'awaiting_verification':
+      return '검증 대기'
     case 'todo':
       return '대기'
     case 'preview':

--- a/lib/a2a_types.ml
+++ b/lib/a2a_types.ml
@@ -98,6 +98,7 @@ let masc_status_to_a2a (status : Types.task_status) : a2a_task_state =
   | Types.Todo -> Working            (* pending task = actively in queue *)
   | Types.Claimed _ -> Working       (* claimed = agent working on it *)
   | Types.InProgress _ -> Working    (* explicit in-progress *)
+  | Types.AwaitingVerification _ -> Working (* awaiting verifier action *)
   | Types.Done _ -> Completed        (* done = completed *)
   | Types.Cancelled _ -> Canceled    (* cancelled = canceled *)
 

--- a/lib/cdal_eval_v1.ml
+++ b/lib/cdal_eval_v1.ml
@@ -88,7 +88,15 @@ let default_base_path =
   in
   Filename.concat root "cdal_verdicts"
 
-let persist ?(base_dir = default_base_path)
+let persist ?(base_dir = default_base_path) ?task_id
     (verdict : Cdal_types.contract_verdict) : unit =
   let store = Dated_jsonl.create ~base_dir () in
-  Dated_jsonl.append store (Cdal_types.contract_verdict_to_json verdict)
+  let json = Cdal_types.contract_verdict_to_json verdict in
+  let envelope = match task_id with
+    | None -> json
+    | Some tid ->
+      match json with
+      | `Assoc fields -> `Assoc (("_task_id", `String tid) :: fields)
+      | other -> other
+  in
+  Dated_jsonl.append store envelope

--- a/lib/cdal_eval_v1.mli
+++ b/lib/cdal_eval_v1.mli
@@ -27,4 +27,4 @@ val friction_of_outcome :
 
 (** Persist a verdict to date-split JSONL.
     Defaults to data/cdal_verdicts. Pass [~base_dir] for test isolation. *)
-val persist : ?base_dir:string -> Cdal_types.contract_verdict -> unit
+val persist : ?base_dir:string -> ?task_id:string -> Cdal_types.contract_verdict -> unit

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -1,0 +1,76 @@
+(** Cdal_verdict_gate -- Deterministic gate that blocks task completion
+    when the latest CDAL verdict is Violated or Inconclusive with blocking gaps.
+
+    Reads from cdal_verdicts/*.jsonl (produced by Cdal_eval_v1.persist).
+    Gate logic is pure: Satisfied -> Allow, Violated -> Reject, etc. *)
+
+type gate_result =
+  | Allow
+  | Reject of string
+
+let check_verdict (v : Cdal_types.contract_verdict) : gate_result =
+  match v.status with
+  | Cdal_types.Satisfied -> Allow
+  | Cdal_types.Violated ->
+    let finding_details = List.map (fun (f : Cdal_types.contract_finding) ->
+      Printf.sprintf "check=%s observed=%s expected=%s"
+        f.check_id
+        (Yojson.Safe.to_string f.observed)
+        (Yojson.Safe.to_string f.expected)
+    ) v.findings in
+    let msg = Printf.sprintf
+      "CDAL verdict Violated (run_id=%s, contract=%s). Findings: %s"
+      v.run_id v.contract_id
+      (String.concat "; " finding_details)
+    in
+    Reject msg
+  | Cdal_types.Inconclusive ->
+    let blocking_gaps = List.filter (fun (g : Cdal_types.completeness_gap) ->
+      g.impact = Cdal_types.Blocks_verdict
+    ) v.completeness_gaps in
+    if blocking_gaps = [] then Allow
+    else
+      let gap_details = List.map (fun (g : Cdal_types.completeness_gap) ->
+        Printf.sprintf "%s: %s" g.artifact g.reason
+      ) blocking_gaps in
+      let msg = Printf.sprintf
+        "CDAL verdict Inconclusive with blocking gaps (run_id=%s). Gaps: %s"
+        v.run_id (String.concat "; " gap_details)
+      in
+      Reject msg
+
+let default_base_path =
+  let root =
+    match Sys.getenv_opt "MASC_DATA_DIR" with
+    | Some dir -> dir
+    | None -> Filename.concat (Env_config_core.base_path ()) "data"
+  in
+  Filename.concat root "cdal_verdicts"
+
+let lookup_latest_verdict ?(base_dir = default_base_path) ~task_id () :
+    Cdal_types.contract_verdict option =
+  let store = Dated_jsonl.create ~base_dir () in
+  let recent = Dated_jsonl.read_recent store 200 in
+  List.fold_left (fun acc json ->
+    match json with
+    | `Assoc fields ->
+      (match List.assoc_opt "_task_id" fields with
+       | Some (`String tid) when tid = task_id ->
+         let verdict_fields = List.filter (fun (k, _) -> k <> "_task_id") fields in
+         (match Cdal_types.contract_verdict_of_json (`Assoc verdict_fields) with
+          | Ok v -> Some v
+          | Error _ -> acc)
+       | _ -> acc)
+    | _ -> acc
+  ) None recent
+
+let gate_check ?(base_dir = default_base_path) ~task_id () : string option =
+  match lookup_latest_verdict ~base_dir ~task_id () with
+  | None ->
+    Some (Printf.sprintf
+      "No CDAL verdict found for task %s. Submit evidence before completing."
+      task_id)
+  | Some verdict ->
+    match check_verdict verdict with
+    | Allow -> None
+    | Reject msg -> Some msg

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -47,11 +47,12 @@ let default_base_path =
   in
   Filename.concat root "cdal_verdicts"
 
-let lookup_latest_verdict ?(base_dir = default_base_path) ~task_id () :
-    Cdal_types.contract_verdict option =
+let lookup_latest_verdict ?(base_dir = default_base_path)
+    ?(limit = Env_config_runtime.Cdal.verdict_lookup_limit ())
+    ~task_id () : Cdal_types.contract_verdict option =
   let store = Dated_jsonl.create ~base_dir () in
-  let recent = Dated_jsonl.read_recent store 200 in
-  List.fold_left (fun acc json ->
+  let recent = Dated_jsonl.read_recent store limit in
+  let result = List.fold_left (fun acc json ->
     match json with
     | `Assoc fields ->
       (match List.assoc_opt "_task_id" fields with
@@ -62,7 +63,16 @@ let lookup_latest_verdict ?(base_dir = default_base_path) ~task_id () :
           | Error _ -> acc)
        | _ -> acc)
     | _ -> acc
-  ) None recent
+  ) None recent in
+  (* If we scanned the full limit and still no match, the verdict may exist
+     in older entries outside the scan window. Log a WARN so debugging is
+     possible instead of silent skipping. Issue #7546. *)
+  (if result = None && List.length recent >= limit then
+    Log.Task.warn
+      "[cdal-gate] lookup_latest_verdict: scanned limit=%d without finding task_id=%s; \
+       older verdicts beyond window are silently skipped (MASC_CDAL_VERDICT_LOOKUP_LIMIT)"
+      limit task_id);
+  result
 
 let gate_check ?(base_dir = default_base_path) ~task_id () : string option =
   match lookup_latest_verdict ~base_dir ~task_id () with

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -356,6 +356,15 @@ module Cdal = struct
   let enabled () =
     Feature_flag_registry.get_bool "MASC_CDAL_ENABLED"
 
+  (** Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. *)
+  let gate_enabled () =
+    Feature_flag_registry.get_bool "MASC_CDAL_GATE_ENABLED"
+end
+
+module Verification = struct
+  (** Enable AwaitingVerification state and cross-agent approval. Default: false. *)
+  let fsm_enabled () =
+    Feature_flag_registry.get_bool "MASC_VERIFICATION_FSM_ENABLED"
 end
 
 (** {1 Slot Scheduling} *)

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -359,6 +359,13 @@ module Cdal = struct
   (** Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. *)
   let gate_enabled () =
     Feature_flag_registry.get_bool "MASC_CDAL_GATE_ENABLED"
+
+  (** Max verdicts to scan when looking up the latest verdict by task_id.
+      Beyond this limit, older entries are silently skipped — WARN is logged
+      by the gate when the task_id is not found. Default: 500.
+      Issue #7546. *)
+  let verdict_lookup_limit () =
+    get_int ~default:500 "MASC_CDAL_VERDICT_LOOKUP_LIMIT"
 end
 
 module Verification = struct

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -372,6 +372,11 @@ module Verification = struct
   (** Enable AwaitingVerification state and cross-agent approval. Default: false. *)
   let fsm_enabled () =
     Feature_flag_registry.get_bool "MASC_VERIFICATION_FSM_ENABLED"
+
+  (** Interval for verification timeout check fiber (seconds). Default: 60.
+      Issue #7549. *)
+  let timeout_check_interval_seconds =
+    get_float ~default:60.0 "MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC"
 end
 
 (** {1 Slot Scheduling} *)

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -201,6 +201,16 @@ let all_flags : flag list = [
     default = true; category = "runtime";
     lifecycle = Active; since = "2.162.0" };
 
+  { env_name = "MASC_CDAL_GATE_ENABLED";
+    description = "CDAL verdict gate: block task completion when verdict is Violated/Inconclusive";
+    default = false; category = "runtime";
+    lifecycle = Active; since = "0.9.3" };
+
+  { env_name = "MASC_VERIFICATION_FSM_ENABLED";
+    description = "Task verification FSM: AwaitingVerification state and cross-agent approval";
+    default = false; category = "runtime";
+    lifecycle = Active; since = "0.9.3" };
+
 ]
 
 (** Lookup a flag by env var name. O(n) — acceptable for ~30 flags. *)

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -324,11 +324,13 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
       let status_icon = match task.task_status with
         | Done _ -> "✅"
         | Claimed _ | InProgress _ -> "🔄"
+        | AwaitingVerification _ -> "🔍"
         | Todo -> "📋"
         | Cancelled _ -> "🚫"
       in
       let assignee = match task.task_status with
-        | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } -> assignee
+        | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
+        | AwaitingVerification { assignee; _ } -> assignee
         | Cancelled { cancelled_by; _ } -> cancelled_by
         | Todo -> "unclaimed"
       in
@@ -336,6 +338,7 @@ let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status conf
         | Todo -> "todo"
         | Claimed _ -> "claimed"
         | InProgress _ -> "in_progress"
+        | AwaitingVerification _ -> "awaiting_verification"
         | Done _ -> "done"
         | Cancelled _ -> "cancelled"
       in

--- a/lib/coord/coord_status.ml
+++ b/lib/coord/coord_status.ml
@@ -91,11 +91,13 @@ let status config =
     let status_icon = match task.task_status with
       | Done _ -> "✅"
       | Claimed _ | InProgress _ -> "🔄"
+      | AwaitingVerification _ -> "🔍"
       | Todo -> "📋"
       | Cancelled _ -> "🚫"
     in
     let assignee = match task.task_status with
-      | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } -> assignee
+      | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
+      | AwaitingVerification { assignee; _ } -> assignee
       | Cancelled { cancelled_by; _ } -> cancelled_by
       | Todo -> "unclaimed"
     in

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -757,9 +757,17 @@ let transition_task_r config ~agent_name ~task_id ~action
           when assignee = agent_name
                && Env_config_runtime.Verification.fsm_enabled () ->
             let verification_id =
-              let ts = int_of_float (Time_compat.now () *. 1000.0) in
-              let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF in
-              Printf.sprintf "vrf-%d-%06x" ts hash in
+              (* Cryptographic 128-bit ID (CSPRNG). Issue #7544.
+                 masc_coord cannot depend on masc_mcp (lib dep boundary),
+                 so we use mirage-crypto-rng directly here. *)
+              let rnd = Mirage_crypto_rng.generate 16 in
+              let hex = String.concat "" (
+                List.init (String.length rnd) (fun i ->
+                  Printf.sprintf "%02x" (Char.code (String.get rnd i))
+                )
+              ) in
+              Printf.sprintf "vrf-%s" hex
+            in
             Ok (Types.AwaitingVerification {
               assignee;
               submitted_at = now;

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -184,6 +184,7 @@ let task_status_to_string = function
   | Types.Todo -> "todo"
   | Types.Claimed _ -> "claimed"
   | Types.InProgress _ -> "in_progress"
+  | Types.AwaitingVerification _ -> "awaiting_verification"
   | Types.Done _ -> "done"
   | Types.Cancelled _ -> "cancelled"
 
@@ -200,6 +201,7 @@ let task_status_to_string = function
 let task_assignee_of_status = function
   | Types.Claimed { assignee; _ } -> Some assignee
   | Types.InProgress { assignee; _ } -> Some assignee
+  | Types.AwaitingVerification { assignee; _ } -> Some assignee
   | Types.Todo | Types.Done _ | Types.Cancelled _ -> None
 
 let task_started_at_unix status =
@@ -508,7 +510,8 @@ let claim_task config ~agent_name ~task_id =
           match task.task_status with
           | Todo ->
               { task with task_status = Claimed { assignee = agent_name; claimed_at = now_iso () } }
-          | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } | Cancelled { cancelled_by = assignee; _ } ->
+          | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
+          | AwaitingVerification { assignee; _ } | Cancelled { cancelled_by = assignee; _ } ->
               already_claimed := Some assignee;
               task
         end else task
@@ -606,9 +609,11 @@ let claim_task_r config ~agent_name ~task_id
             | Todo ->
                 let t' = { t with task_status = Claimed { assignee = agent_name; claimed_at = now_iso () } } in
                 (`Claimed_ok, t' :: acc)
-            | Claimed { assignee; _ } | InProgress { assignee; _ } when assignee = agent_name ->
+            | Claimed { assignee; _ } | InProgress { assignee; _ }
+            | AwaitingVerification { assignee; _ } when assignee = agent_name ->
                 (`Already_mine, t :: acc)
             | Claimed { assignee; _ } | InProgress { assignee; _ }
+            | AwaitingVerification { assignee; _ }
             | Done { assignee; _ } | Cancelled { cancelled_by = assignee; _ } ->
                 (`Claimed_by assignee, t :: acc)
           else
@@ -748,6 +753,49 @@ let transition_task_r config ~agent_name ~task_id ~action
               assignee = agent_name;
               started_at = now;
             }, None)
+        | Types.Submit_for_verification, Types.InProgress { assignee; _ }
+          when assignee = agent_name
+               && Env_config_runtime.Verification.fsm_enabled () ->
+            let verification_id =
+              let ts = int_of_float (Time_compat.now () *. 1000.0) in
+              let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF in
+              Printf.sprintf "vrf-%d-%06x" ts hash in
+            Ok (Types.AwaitingVerification {
+              assignee;
+              submitted_at = now;
+              verification_id;
+              required_verifier_role = Reviewer;
+              deadline = None;
+            }, None)
+        | Types.Approve_verification, Types.AwaitingVerification { assignee; verification_id; _ }
+          when agent_name <> assignee
+               && Env_config_runtime.Verification.fsm_enabled () ->
+            Ok (Types.Done {
+              assignee;
+              completed_at = now;
+              notes = Some (Printf.sprintf "Approved by %s (vrf:%s)%s"
+                agent_name verification_id
+                (if notes = "" then "" else " — " ^ notes));
+            }, None)
+        | Types.Reject_verification, Types.AwaitingVerification { assignee; _ }
+          when agent_name <> assignee
+               && Env_config_runtime.Verification.fsm_enabled () ->
+            Ok (Types.InProgress {
+              assignee;
+              started_at = now;
+            }, None)
+        | Types.Approve_verification, Types.AwaitingVerification { assignee; _ }
+          when agent_name = assignee ->
+            Error (Types.TaskInvalidState
+              "Self-approval not allowed: verifier must be a different agent")
+        | Types.Reject_verification, Types.AwaitingVerification { assignee; _ }
+          when agent_name = assignee ->
+            Error (Types.TaskInvalidState
+              "Self-rejection not allowed: verifier must be a different agent")
+        | (Types.Submit_for_verification | Types.Approve_verification
+          | Types.Reject_verification), _
+          when not (Env_config_runtime.Verification.fsm_enabled ()) ->
+            Error (Types.TaskInvalidState "Verification FSM not enabled (MASC_VERIFICATION_FSM_ENABLED=false)")
         | _ ->
             let assignee_hint =
               match task_assignee_of_status task.task_status with
@@ -775,7 +823,9 @@ let transition_task_r config ~agent_name ~task_id ~action
                 (match action with
                 | Types.Release -> handoff_context
                 | Types.Claim | Types.Start | Types.Done_action
-                | Types.Cancel ->
+                | Types.Cancel
+                | Types.Submit_for_verification | Types.Approve_verification
+                | Types.Reject_verification ->
                     None);
             }
           else
@@ -852,7 +902,19 @@ let transition_task_r config ~agent_name ~task_id ~action
                            .task_handoff_context_to_yojson
                              handoff_context );
                        ]
-                   | None -> [])));
+                   | None -> []))
+         | Types.Submit_for_verification ->
+             emit_task_activity config ~agent_name ~task_id
+               ~kind:"task.submit_for_verification"
+               ~payload:(`Assoc [ ("task_id", `String task_id) ])
+         | Types.Approve_verification ->
+             emit_task_activity config ~agent_name ~task_id
+               ~kind:"task.approved"
+               ~payload:(`Assoc [ ("task_id", `String task_id) ])
+         | Types.Reject_verification ->
+             emit_task_activity config ~agent_name ~task_id
+               ~kind:"task.rejected"
+               ~payload:(`Assoc [ ("task_id", `String task_id) ]));
         let duration_ms =
           match action with
           | Types.Done_action | Types.Cancel ->
@@ -862,7 +924,9 @@ let transition_task_r config ~agent_name ~task_id ~action
                       ((now_ts
                        -. task_started_at_unix task.task_status)
                       *. 1000.0)))
-          | Types.Claim | Types.Start | Types.Release -> None
+          | Types.Claim | Types.Start | Types.Release
+          | Types.Submit_for_verification | Types.Approve_verification
+          | Types.Reject_verification -> None
         in
         observe_task_transition config ~agent_name ~task_id
           ~transition:action_s
@@ -893,7 +957,9 @@ let transition_task_r config ~agent_name ~task_id ~action
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.RoomTask.error "transition hebbian cancel hook: %s"
                 (Printexc.to_string exn))
-         | Types.Claim | Types.Start | Types.Release -> ());
+         | Types.Claim | Types.Start | Types.Release
+         | Types.Submit_for_verification | Types.Approve_verification
+         | Types.Reject_verification -> ());
         Ok (Printf.sprintf "✅ %s %s → %s" task_id
               (task_status_to_string task.task_status)
               (task_status_to_string new_status))
@@ -933,7 +999,8 @@ let complete_task config ~agent_name ~task_id ~notes =
           Printf.sprintf "❌ Task %s not found" task_id
       | Some task ->
           let can_complete = match task.task_status with
-            | Claimed { assignee; _ } | InProgress { assignee; _ } -> assignee = agent_name
+            | Claimed { assignee; _ } | InProgress { assignee; _ }
+            | AwaitingVerification { assignee; _ } -> assignee = agent_name
             | Todo | Done _ | Cancelled _ -> false
           in
           if not can_complete then
@@ -1054,6 +1121,12 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                        (Printf.sprintf
                           "task %s was cancelled by %s; reopen or create a new task instead of calling masc_transition(action=done)"
                           task_id cancelled_by))
+              | AwaitingVerification { assignee; _ } ->
+                  Some
+                    (Types.TaskInvalidState
+                       (Printf.sprintf
+                          "task %s is awaiting verification by %s; approve or reject before marking done"
+                          task_id assignee))
             in
             match completion_error with
             | Some err -> Error err
@@ -1150,7 +1223,8 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
             (* Can cancel if: Todo, Claimed by me, or InProgress by me *)
             let can_cancel = match task.task_status with
               | Types.Todo -> true
-              | Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ } -> assignee = agent_name
+              | Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ }
+              | Types.AwaitingVerification { assignee; _ } -> assignee = agent_name
               | Types.Done _ | Types.Cancelled _ -> false
             in
             if not can_cancel then

--- a/lib/coord/coord_task_schedule.ml
+++ b/lib/coord/coord_task_schedule.ml
@@ -15,7 +15,8 @@ let agent_current_task_matches_backlog backlog ~agent_name task_id =
   with
   | Some task -> (
       match task.task_status with
-      | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+      | Claimed { assignee; _ } | InProgress { assignee; _ }
+      | AwaitingVerification { assignee; _ } ->
           String.equal assignee agent_name
       | Todo | Done _ | Cancelled _ -> false)
   | None -> false
@@ -81,7 +82,8 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) ?(task_filter=fun (_:
          tasks that permanently block the backlog. *)
       let previous_claim = List.find_opt (fun (t : Types.task) ->
         match t.task_status with
-        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+        | Claimed { assignee; _ } | InProgress { assignee; _ }
+        | AwaitingVerification { assignee; _ } ->
             String.equal assignee agent_name
         | Todo | Done _ | Cancelled _ -> false
       ) backlog.tasks in
@@ -322,6 +324,7 @@ let release_stale_claims config ~ttl_seconds =
                 task.id assignee (now_f -. ts) now_str);
               { task with task_status = Todo }
             end else task
+        | AwaitingVerification _ -> task  (* leave alone; awaiting verifier *)
         | Todo | Done _ | Cancelled _ -> task
       ) backlog.tasks in
       if !stale_tasks <> [] then begin

--- a/lib/coord/dune
+++ b/lib/coord/dune
@@ -50,5 +50,6 @@
   eio.unix
   uri
   uuidm
-  digestif)
+  digestif
+  mirage-crypto-rng)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -110,7 +110,7 @@ let split_tasks (tasks : Types.task list) =
   let active =
     List.filter (fun task ->
       match task.Types.task_status with
-      | Types.InProgress _ | Types.Claimed _ -> true
+      | Types.InProgress _ | Types.Claimed _ | Types.AwaitingVerification _ -> true
       | Types.Todo | Types.Done _ | Types.Cancelled _ -> false
     ) tasks
   in
@@ -126,6 +126,7 @@ let task_lines (tasks : Types.task list) =
         match task.task_status with
         | Types.InProgress { assignee; _ } -> assignee
         | Types.Claimed { assignee; _ } -> assignee
+        | Types.AwaitingVerification { assignee; _ } -> assignee
         | Types.Todo | Types.Done _ | Types.Cancelled _ -> "?"
       in
       Printf.sprintf "[P%d] %s (@%s)" task.priority task.title assignee

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -65,6 +65,7 @@ let task_updated_at (task : Types.task) =
   | Types.Done { completed_at; _ } -> completed_at
   | Types.Cancelled { cancelled_at; _ } -> cancelled_at
   | Types.InProgress { started_at; _ } -> started_at
+  | Types.AwaitingVerification { submitted_at; _ } -> submitted_at
   | Types.Claimed { claimed_at; _ } -> claimed_at
   | Types.Todo -> task.created_at
 
@@ -72,7 +73,8 @@ let task_completed_at (task : Types.task) =
   match task.task_status with
   | Types.Done { completed_at; _ } -> Some completed_at
   | Types.Cancelled { cancelled_at; _ } -> Some cancelled_at
-  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> None
+  | Types.Todo | Types.Claimed _ | Types.InProgress _
+  | Types.AwaitingVerification _ -> None
 
 let task_execution_links_json (task : Types.task) =
   match task.contract with

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -45,7 +45,8 @@ let keeper_action_stale_sec = Env_config.Dashboard.keeper_action_stale_sec
 
 let task_assignee (task : Types.task) =
   match task.task_status with
-  | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } ->
+  | Claimed { assignee; _ } | InProgress { assignee; _ }
+  | AwaitingVerification { assignee; _ } | Done { assignee; _ } ->
       Some assignee
   | Todo | Cancelled _ -> None
 

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -20,6 +20,7 @@ let task_assignee (task : Types.task) : string option =
   match task.task_status with
   | Types.Claimed { assignee; _ } -> Some assignee
   | Types.InProgress { assignee; _ } -> Some assignee
+  | Types.AwaitingVerification { assignee; _ } -> Some assignee
   | Types.Done { assignee; _ } -> Some assignee
   | Types.Todo | Types.Cancelled _ -> None
 
@@ -28,18 +29,21 @@ let task_status_label (task : Types.task) : string =
   | Types.Todo -> "pending"
   | Types.Claimed _ -> "claimed"
   | Types.InProgress _ -> "in_progress"
+  | Types.AwaitingVerification _ -> "awaiting_verification"
   | Types.Done _ -> "completed"
   | Types.Cancelled _ -> "cancelled"
 
 let task_is_terminal (task : Types.task) : bool =
   match task.task_status with
   | Types.Done _ | Types.Cancelled _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> false
+  | Types.Todo | Types.Claimed _ | Types.InProgress _
+  | Types.AwaitingVerification _ -> false
 
 let task_is_done (task : Types.task) : bool =
   match task.task_status with
   | Types.Done _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _ | Types.Cancelled _ -> false
+  | Types.Todo | Types.Claimed _ | Types.InProgress _
+  | Types.AwaitingVerification _ | Types.Cancelled _ -> false
 
 let compute_convergence (goal : Goal_store.goal) linked_tasks children =
   (* Convergence = weighted average of own task completion + child convergence.

--- a/lib/dune
+++ b/lib/dune
@@ -372,6 +372,8 @@
    cdal_judge
    cdal_eval_v1
    cdal_friction_projection
+   cdal_verdict_gate
+   verification_protocol
    artifact_store
    golden_set
    adversarial_eval

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -159,6 +159,7 @@ end
 module Cdal : sig
   val enabled : unit -> bool
   val gate_enabled : unit -> bool
+  val verdict_lookup_limit : unit -> int
 end
 
 module Verification : sig

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -164,6 +164,7 @@ end
 
 module Verification : sig
   val fsm_enabled : unit -> bool
+  val timeout_check_interval_seconds : float
 end
 
 module Board : sig

--- a/lib/env_config_runtime.mli
+++ b/lib/env_config_runtime.mli
@@ -158,6 +158,11 @@ end
 
 module Cdal : sig
   val enabled : unit -> bool
+  val gate_enabled : unit -> bool
+end
+
+module Verification : sig
+  val fsm_enabled : unit -> bool
 end
 
 module Board : sig

--- a/lib/goal/convergence.ml
+++ b/lib/goal/convergence.ml
@@ -53,7 +53,8 @@ let task_matches_goal ~goal_id (task : Types.task) =
 let is_terminal (task : Types.task) =
   match task.task_status with
   | Types.Done _ | Types.Cancelled _ -> true
-  | Types.Todo | Types.Claimed _ | Types.InProgress _ -> false
+  | Types.Todo | Types.Claimed _ | Types.InProgress _
+  | Types.AwaitingVerification _ -> false
 
 (** A task counts as completed (not merely cancelled). *)
 let is_completed (task : Types.task) =

--- a/lib/graphql_api.ml
+++ b/lib/graphql_api.ml
@@ -145,6 +145,18 @@ let task_status_info_of_task (task : Types.task) =
         cancelled_at = Some cancelled_at;
         reason;
       }
+  | Types.AwaitingVerification { assignee; submitted_at; _ } ->
+      {
+        status = "awaiting_verification";
+        assignee = Some assignee;
+        claimed_at = None;
+        started_at = Some submitted_at;
+        completed_at = None;
+        notes = None;
+        cancelled_by = None;
+        cancelled_at = None;
+        reason = None;
+      }
 
 let page_info_typ =
   Schema.obj "PageInfo"

--- a/lib/grpc/masc_grpc_service.ml
+++ b/lib/grpc/masc_grpc_service.ml
@@ -34,6 +34,7 @@ let safe_filename name =
 let task_assignee_of_status = function
   | Types.Claimed { assignee; _ }
   | Types.InProgress { assignee; _ }
+  | Types.AwaitingVerification { assignee; _ }
   | Types.Done { assignee; _ } -> assignee
   | Types.Todo | Types.Cancelled _ -> ""
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1902,7 +1902,8 @@ let run_turn
              let store = Agent_sdk.Proof_store.default_config in
              let outcome = Cdal_eval_v1.evaluate ~store p in
              let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
-             Cdal_eval_v1.persist verdict;
+             let task_id = Option.map Keeper_id.Task_id.to_string meta.current_task_id in
+             Cdal_eval_v1.persist ?task_id verdict;
              Keeper_turn_telemetry.log_keeper_contract_verdict ~keeper_name:meta.name verdict;
              (match outcome with
               | Cdal_eval_v1.Load_failure (err, _) ->

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -103,6 +103,7 @@ let direct_turn_observation (meta : keeper_meta) :
     economic_pressure = Agent_economy.Normal;
     unclaimed_task_count = 0;
     failed_task_count = 0;
+    pending_verification_count = 0;
     active_agent_count = 0;
     last_turn_budget = None;
     last_tools_used = [];

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -621,6 +621,7 @@ let observed_triggers_of_observation
   if observation.pending_scope_messages <> [] then add "scope_message";
   if observation.unclaimed_task_count > 0 then add "new_unclaimed_task";
   if observation.failed_task_count > 0 then add "failed_task";
+  if observation.pending_verification_count > 0 then add "pending_verification";
   if observation.active_goals <> [] && observation.idle_seconds > 0 then
     add "idle_timeout_candidate";
   if Option.is_some observation.worktree_change_summary then add "worktree_change";
@@ -635,6 +636,7 @@ let observed_affordances_of_observation
   if observation.pending_scope_messages <> [] then add "message_sweep";
   if observation.unclaimed_task_count > 0 then add "task_claim";
   if observation.failed_task_count > 0 then add "task_audit";
+  if observation.pending_verification_count > 0 then add "task_verify";
   if Option.is_some observation.worktree_change_summary then add "inspect_worktree_delta";
   List.rev !affordances
 
@@ -749,6 +751,7 @@ let append_decision_record
               ("context_ratio", `Float observation.context_ratio);
               ("unclaimed_task_count", `Int observation.unclaimed_task_count);
               ("failed_task_count", `Int observation.failed_task_count);
+              ("pending_verification_count", `Int observation.pending_verification_count);
               ("active_agent_count", `Int observation.active_agent_count);
               ("worktree_change_detected", `Bool (Option.is_some observation.worktree_change_summary));
             ] );

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -38,6 +38,7 @@ type world_observation = {
   economic_pressure : Agent_economy.pressure_mode;
   unclaimed_task_count : int;
   failed_task_count : int;
+  pending_verification_count : int;
   active_agent_count : int;
   last_turn_budget : (int * int) option;
   last_tools_used : string list;
@@ -203,7 +204,7 @@ let apply_message_cursor_updates (meta : keeper_meta)
     meta updates
 
 (** Read room backlog counts. *)
-let read_backlog_counts ~(config : Coord.config) : int * int =
+let read_backlog_counts ~(config : Coord.config) : int * int * int =
   try
     let backlog = Coord.read_backlog config in
     let unclaimed =
@@ -219,10 +220,18 @@ let read_backlog_counts ~(config : Coord.config) : int * int =
              match t.task_status with Types.Cancelled _ -> true | _ -> false)
            backlog.tasks)
     in
-    (unclaimed, failed)
+    let pending_verification =
+      List.length
+        (List.filter
+           (fun (t : Types.task) ->
+             match t.task_status with
+             | Types.AwaitingVerification _ -> true | _ -> false)
+           backlog.tasks)
+    in
+    (unclaimed, failed, pending_verification)
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> (0, 0)
+  | _ -> (0, 0, 0)
 
 (** Count active agents in room. *)
 let count_active_agents ~(config : Coord.config) : int =
@@ -619,7 +628,7 @@ let observe ~(pending_board_events : pending_board_event list option)
   let pending_mentions, pending_scope_messages, message_cursor_updates =
     collect_message_scope ~config ~meta
   in
-  let unclaimed_task_count, failed_task_count =
+  let unclaimed_task_count, failed_task_count, pending_verification_count =
     read_backlog_counts ~config
   in
   let active_agent_count = count_active_agents ~config in
@@ -669,6 +678,7 @@ let observe ~(pending_board_events : pending_board_event list option)
     economic_pressure;
     unclaimed_task_count;
     failed_task_count;
+    pending_verification_count;
     active_agent_count;
     last_turn_budget = None;
     last_tools_used = [];
@@ -682,6 +692,7 @@ let actionable_signal_present (observation : world_observation) =
   || Option.is_some observation.worktree_change_summary
   || observation.unclaimed_task_count > 0
   || observation.failed_task_count > 0
+  || observation.pending_verification_count > 0
   || observation.work_discovery_due
 
 let proactive_work_signal_present ~(meta : keeper_meta)

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -69,6 +69,9 @@ type world_observation = {
   failed_task_count : int;
   (** Number of failed/cancelled tasks in the room backlog. *)
 
+  pending_verification_count : int;
+  (** Number of tasks awaiting cross-agent verification. *)
+
   active_agent_count : int;
   (** Number of agents currently active in the room. *)
 

--- a/lib/meta_cognition_snapshot.ml
+++ b/lib/meta_cognition_snapshot.ml
@@ -385,7 +385,8 @@ let active_task_count tasks =
        (fun acc (task : Types.task) ->
          match task.task_status with
          | Types.Done _ | Types.Cancelled _ -> acc
-         | Types.Todo | Types.Claimed _ | Types.InProgress _ -> acc + 1)
+         | Types.Todo | Types.Claimed _ | Types.InProgress _
+         | Types.AwaitingVerification _ -> acc + 1)
        0
 
 let stagnation_score ~active_agents ~active_tasks ~idle_signal_count

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -268,8 +268,9 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   fork_subsystem "session_cleanup" (fun () ->
     Session.start_mcp_session_cleanup_loop ~sw ~clock ());
   fork_subsystem "verification_timeout" (fun () ->
+    let interval = Env_config_runtime.Verification.timeout_check_interval_seconds in
     let rec loop () =
-      Eio.Time.sleep clock 60.0;
+      Eio.Time.sleep clock interval;
       Verification_protocol.check_timeouts ~config:state.room_config;
       loop ()
     in

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -267,6 +267,13 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       ());
   fork_subsystem "session_cleanup" (fun () ->
     Session.start_mcp_session_cleanup_loop ~sw ~clock ());
+  fork_subsystem "verification_timeout" (fun () ->
+    let rec loop () =
+      Eio.Time.sleep clock 60.0;
+      Verification_protocol.check_timeouts ~config:state.room_config;
+      loop ()
+    in
+    loop ());
   (* Auto-boot keepers from keeper meta and start keepalive loops.
      Retries unbooted keepers up to [max_retries] times so transient
      failures (model resolution, discovery timing) don't permanently

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -260,7 +260,7 @@ let dashboard_planning_http_json ~(config : Coord.config) : Yojson.Safe.t =
            match task.task_status with
            | Todo -> (todo + 1, claimed, running, done_count, cancelled)
            | Claimed _ -> (todo, claimed + 1, running, done_count, cancelled)
-           | InProgress _ -> (todo, claimed, running + 1, done_count, cancelled)
+           | InProgress _ | AwaitingVerification _ -> (todo, claimed, running + 1, done_count, cancelled)
            | Done _ -> (todo, claimed, running, done_count + 1, cancelled)
            | Cancelled _ -> (todo, claimed, running, done_count, cancelled + 1))
          (0, 0, 0, 0, 0)

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -717,7 +717,8 @@ let dashboard_shell_status_json (config : Coord.config) : Yojson.Safe.t =
 
 let dashboard_task_assignee (task : Types.task) =
   match task.task_status with
-  | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } ->
+  | Claimed { assignee; _ } | InProgress { assignee; _ }
+  | AwaitingVerification { assignee; _ } | Done { assignee; _ } ->
       Some assignee
   | Todo | Cancelled _ -> None
 

--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -105,6 +105,7 @@ let is_pending_task (task : Types.task) : bool =
   | Types.Todo -> true
   | Types.Claimed _ -> true
   | Types.InProgress _ -> true
+  | Types.AwaitingVerification _ -> true
   | Types.Done _ -> false
   | Types.Cancelled _ -> false
 

--- a/lib/tool_coord.ml
+++ b/lib/tool_coord.ml
@@ -129,12 +129,14 @@ let task_status_badge = function
   | Types.Todo -> ("📋", "todo")
   | Types.Claimed _ -> ("🟡", "claimed")
   | Types.InProgress _ -> ("🟢", "in_progress")
+  | Types.AwaitingVerification _ -> ("🔍", "awaiting_verification")
   | Types.Done _ -> ("✅", "done")
   | Types.Cancelled _ -> ("🚫", "cancelled")
 
 let task_assignee = function
   | Types.Claimed { assignee; _ }
   | Types.InProgress { assignee; _ }
+  | Types.AwaitingVerification { assignee; _ }
   | Types.Done { assignee; _ } -> assignee
   | Types.Cancelled { cancelled_by; _ } -> cancelled_by
   | Types.Todo -> "unclaimed"
@@ -212,6 +214,9 @@ let status_summary_string (ctx : context) =
         | Types.Done _ ->
             (active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt + 1,
              cancelled_cnt)
+        | Types.AwaitingVerification _ ->
+            (task :: active, todo_cnt, claimed_cnt, in_progress_cnt + 1,
+             done_cnt, cancelled_cnt)
         | Types.Cancelled _ ->
             (active, todo_cnt, claimed_cnt, in_progress_cnt, done_cnt,
              cancelled_cnt + 1))
@@ -386,7 +391,8 @@ let inspect_state ctx =
       Coord.get_tasks_raw ctx.config
       |> List.exists (fun (task : Types.task) ->
              match task.task_status with
-             | Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ } ->
+             | Types.Claimed { assignee; _ } | Types.InProgress { assignee; _ }
+             | Types.AwaitingVerification { assignee; _ } ->
                  assignee = ctx.agent_name || assignee = actual_name
              | Types.Todo | Types.Done _ | Types.Cancelled _ -> false)
     else false

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -746,9 +746,9 @@ let handle_transition ctx args =
                | Some c -> c.verify_gate_evidence
                | None -> [] in
              (match task.task_status with
-              | Types.AwaitingVerification { verification_id; _ } ->
+              | Types.AwaitingVerification { verification_id; assignee; _ } ->
                 Verification_protocol.on_submit_for_verification
-                  ~config:ctx.config ~task ~verification_id ~evidence_refs
+                  ~config:ctx.config ~task ~assignee ~verification_id ~evidence_refs
               | _ -> ())
            | None -> ())
         | Types.Approve_verification ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -707,6 +707,16 @@ let handle_transition ctx args =
     end else
       r
   in
+  (* Capture verification_id from AwaitingVerification state BEFORE transition.
+     approve/reject transitions change state, destroying the verification_id.
+     Issue #7543. *)
+  let verification_id_before =
+    match task_opt with
+    | Some t -> (match t.task_status with
+        | Types.AwaitingVerification { verification_id; _ } -> Some verification_id
+        | _ -> None)
+    | None -> None
+  in
   let result = try_transition 0 in
   (* Notify A2A subscribers on successful transition *)
   (match result with
@@ -742,14 +752,16 @@ let handle_transition ctx args =
               | _ -> ())
            | None -> ())
         | Types.Approve_verification ->
+          let verification_id = Option.value ~default:"" verification_id_before in
           Verification_protocol.on_approve_verification
             ~config:ctx.config ~task_id ~verifier:ctx.agent_name
-            ~verification_id:"" ~notes
+            ~verification_id ~notes
         | Types.Reject_verification ->
           let reason = if notes <> "" then notes else reason in
+          let verification_id = Option.value ~default:"" verification_id_before in
           Verification_protocol.on_reject_verification
             ~config:ctx.config ~task_id ~verifier:ctx.agent_name
-            ~verification_id:"" ~reason
+            ~verification_id ~reason
         | _ -> ())
    | Error err ->
        Log.Task.error "task transition failed: %s" (Types.masc_error_to_string err));

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -186,15 +186,24 @@ let strict_release_requires_handoff = function
   | Some ({ contract = Some contract; _ } : Types.task) -> contract.strict
   | _ -> false
 
-let _contract_gate_rejection_message _reasons =
-  (* Task_contract_gate removed — always allow completion *)
-  "task contract gate is not available"
-
 let persisted_contract_rejection ~(ctx : context)
     ~(task_opt : Types.task option) ~(notes : string) =
-  (* Task_contract_gate removed — always allow completion *)
-  ignore (ctx, task_opt, notes);
-  None
+  ignore notes;
+  match task_opt with
+  | None -> None
+  | Some task ->
+    if not (Env_config_runtime.Cdal.gate_enabled ()) then begin
+      Log.Task.info "[cdal-gate] disabled, skipping for task=%s agent=%s"
+        task.id ctx.agent_name;
+      None
+    end else
+      match task.contract with
+      | None -> None
+      | Some contract when not contract.strict -> None
+      | Some _contract ->
+        Log.Task.info "[cdal-gate] checking verdict for task=%s agent=%s"
+          task.id ctx.agent_name;
+        Cdal_verdict_gate.gate_check ~task_id:task.id ()
 
 (* Handlers *)
 
@@ -717,7 +726,31 @@ let handle_transition ctx args =
          ("action", `String action_s);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (match action with
+        | Types.Submit_for_verification ->
+          let tasks = Coord.get_tasks_raw ctx.config in
+          (match List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks with
+           | Some task ->
+             let evidence_refs = match task.contract with
+               | Some c -> c.verify_gate_evidence
+               | None -> [] in
+             (match task.task_status with
+              | Types.AwaitingVerification { verification_id; _ } ->
+                Verification_protocol.on_submit_for_verification
+                  ~config:ctx.config ~task ~verification_id ~evidence_refs
+              | _ -> ())
+           | None -> ())
+        | Types.Approve_verification ->
+          Verification_protocol.on_approve_verification
+            ~config:ctx.config ~task_id ~verifier:ctx.agent_name
+            ~verification_id:"" ~notes
+        | Types.Reject_verification ->
+          let reason = if notes <> "" then notes else reason in
+          Verification_protocol.on_reject_verification
+            ~config:ctx.config ~task_id ~verifier:ctx.agent_name
+            ~verification_id:"" ~reason
+        | _ -> ())
    | Error err ->
        Log.Task.error "task transition failed: %s" (Types.masc_error_to_string err));
   (* Record metrics *)

--- a/lib/tool_task_schemas.ml
+++ b/lib/tool_task_schemas.ml
@@ -184,9 +184,11 @@ Tip: Look for status='todo' tasks to claim.";
   };
   {
     name = "masc_transition";
-    description = "Move a task through its lifecycle: claim, start, done, cancel, or release. \
+    description = "Move a task through its lifecycle: claim, start, done, cancel, release, \
+submit_for_verification, approve, or reject. \
 Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
-After masc_add_task or masc_claim_next; pair with masc_deliver before action='done'.";
+After masc_add_task or masc_claim_next; pair with masc_deliver before action='done'. \
+Use submit_for_verification to request cross-agent review; approve/reject for verifier actions.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -200,7 +202,7 @@ After masc_add_task or masc_claim_next; pair with masc_deliver before action='do
         ]);
         ("action", `Assoc [
           ("type", `String "string");
-          ("description", `String "Transition action: claim | start | done | cancel | release");
+          ("description", `String "Transition action: claim | start | done | cancel | release | submit_for_verification | approve | reject");
         ]);
         ("expected_version", `Assoc [
           ("type", `String "integer");

--- a/lib/types/typed_state.ml
+++ b/lib/types/typed_state.ml
@@ -81,6 +81,10 @@ let of_wire : Types_core.task_status -> any_task_status = function
     Terminal (PDone { assignee; completed_at; notes })
   | Types_core.Cancelled { cancelled_by; cancelled_at; reason } ->
     Terminal (PCancelled { cancelled_by; cancelled_at; reason })
+  | Types_core.AwaitingVerification { assignee; submitted_at; _ } ->
+    (* No PAwaitingVerification variant yet; map to Active PInProgress as
+       fallback — the assignee is still working until a verifier acts. *)
+    Active (PInProgress { assignee; started_at = submitted_at })
 
 let status_name : type p. p task_status_t -> string = function
   | PTodo -> "todo"

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -229,6 +229,9 @@ type task_action =
   | Done_action
   | Cancel
   | Release
+  | Submit_for_verification
+  | Approve_verification
+  | Reject_verification
 [@@deriving show]
 
 let task_action_of_string s =
@@ -238,6 +241,9 @@ let task_action_of_string s =
   | "done" -> Ok Done_action
   | "cancel" -> Ok Cancel
   | "release" -> Ok Release
+  | "submit_for_verification" -> Ok Submit_for_verification
+  | "approve" -> Ok Approve_verification
+  | "reject" -> Ok Reject_verification
   | other -> Error (Printf.sprintf "Unknown task action: %s" other)
 
 let task_action_to_string = function
@@ -246,15 +252,27 @@ let task_action_to_string = function
   | Done_action -> "done"
   | Cancel -> "cancel"
   | Release -> "release"
+  | Submit_for_verification -> "submit_for_verification"
+  | Approve_verification -> "approve"
+  | Reject_verification -> "reject"
 
 (** All valid task actions, derived from the ADT (single source of truth). *)
-let all_task_actions = [Claim; Start; Done_action; Cancel; Release]
+let all_task_actions =
+  [ Claim; Start; Done_action; Cancel; Release;
+    Submit_for_verification; Approve_verification; Reject_verification ]
 let valid_task_action_strings = List.map task_action_to_string all_task_actions
 
 type task_status =
   | Todo
   | Claimed of { assignee: string; claimed_at: string }
   | InProgress of { assignee: string; started_at: string }
+  | AwaitingVerification of {
+      assignee: string;
+      submitted_at: string;
+      verification_id: string;
+      required_verifier_role: role;
+      deadline: string option;
+    }
   | Done of { assignee: string; completed_at: string; notes: string option }
   | Cancelled of { cancelled_by: string; cancelled_at: string; reason: string option }
 [@@deriving show]
@@ -264,6 +282,7 @@ let task_status_to_string = function
   | Todo -> "todo"
   | Claimed _ -> "claimed"
   | InProgress _ -> "in_progress"
+  | AwaitingVerification _ -> "awaiting_verification"
   | Done _ -> "done"
   | Cancelled _ -> "cancelled"
 
@@ -290,6 +309,16 @@ let task_status_to_yojson = function
         ("assignee", `String assignee);
         ("completed_at", `String completed_at);
         ("notes", Json_util.string_opt_to_json notes);
+      ]
+  | AwaitingVerification { assignee; submitted_at; verification_id;
+                           required_verifier_role; deadline } ->
+      `Assoc [
+        ("status", `String "awaiting_verification");
+        ("assignee", `String assignee);
+        ("submitted_at", `String submitted_at);
+        ("verification_id", `String verification_id);
+        ("required_verifier_role", `String (role_to_string required_verifier_role));
+        ("deadline", Json_util.string_opt_to_json deadline);
       ]
   | Cancelled { cancelled_by; cancelled_at; reason } ->
       `Assoc [
@@ -318,6 +347,17 @@ let task_status_of_yojson json =
         let completed_at = json |> member "completed_at" |> to_string in
         let notes = json |> member "notes" |> to_string_option in
         Ok (Done { assignee; completed_at; notes })
+    | "awaiting_verification" ->
+        let assignee = json |> member "assignee" |> to_string in
+        let submitted_at = json |> member "submitted_at" |> to_string in
+        let verification_id = json |> member "verification_id" |> to_string in
+        let required_verifier_role =
+          match json |> member "required_verifier_role" |> to_string_option with
+          | Some s -> role_of_string s
+          | None -> Reviewer in
+        let deadline = json |> member "deadline" |> to_string_option in
+        Ok (AwaitingVerification { assignee; submitted_at; verification_id;
+                                   required_verifier_role; deadline })
     | "cancelled" ->
         let cancelled_by = json |> member "cancelled_by" |> to_string in
         let cancelled_at = json |> member "cancelled_at" |> to_string in

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -1,0 +1,109 @@
+(** Verification_protocol -- Cross-agent verification workflow orchestration.
+
+    Bridges task FSM transitions (AwaitingVerification state) with:
+    - Board system (Direct visibility posts to verifiers)
+    - SSE events (masc:verification:requested, :verdict, :rejected)
+    - Verification storage (.masc/verifications/)
+
+    @since Phase B+C *)
+
+let on_submit_for_verification ~(config : Coord.config)
+    ~(task : Types.task) ~verification_id ~evidence_refs =
+  let base_path = config.Coord.base_path in
+  let criteria = List.map (fun s -> Verification.Custom s)
+    (match task.contract with
+     | Some c -> c.verify_gate_evidence
+     | None -> []) in
+  let worker = match task.task_status with
+    | AwaitingVerification { assignee; _ } -> assignee
+    | _ -> "unknown" in
+  let _req =
+    Verification.create_request ~base_path ~task_id:task.id
+      ~output:(`Assoc [
+        ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+        ("task_title", `String task.title);
+      ])
+      ~criteria ~worker () in
+  let meta_json = `Assoc [
+    ("type", `String "verification_request");
+    ("task_id", `String task.id);
+    ("verification_id", `String verification_id);
+    ("worker", `String worker);
+    ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+    ("criteria", `List (List.map Verification.criterion_to_yojson criteria));
+  ] in
+  let _post = Board_dispatch.create_post
+    ~author:"system"
+    ~content:(Printf.sprintf "Verification requested for task %s (%s) by %s"
+      task.id task.title worker)
+    ~title:(Printf.sprintf "Verify: %s" task.title)
+    ~post_kind:Board.System_post
+    ~meta_json
+    ~visibility:Board.Internal
+    ~hearth:"verification"
+    () in
+  Subscriptions.push_event_to_sessions (`Assoc [
+    ("type", `String "masc/verification/requested");
+    ("task_id", `String task.id);
+    ("verification_id", `String verification_id);
+    ("worker", `String worker);
+    ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
+    ("timestamp", `Float (Time_compat.now ()));
+  ]);
+  ignore base_path
+
+let on_approve_verification ~(config : Coord.config)
+    ~task_id ~verifier ~verification_id ~notes =
+  ignore config;
+  let meta_json = `Assoc [
+    ("type", `String "verification_verdict");
+    ("task_id", `String task_id);
+    ("verification_id", `String verification_id);
+    ("verdict", `String "approved");
+  ] in
+  let _post = Board_dispatch.create_post
+    ~author:verifier
+    ~content:(Printf.sprintf "Approved task %s (vrf:%s)%s"
+      task_id verification_id
+      (if notes = "" then "" else " — " ^ notes))
+    ~post_kind:Board.System_post
+    ~meta_json
+    ~visibility:Board.Internal
+    ~hearth:"verification"
+    () in
+  Subscriptions.push_event_to_sessions (`Assoc [
+    ("type", `String "masc/verification/verdict");
+    ("task_id", `String task_id);
+    ("verification_id", `String verification_id);
+    ("verifier", `String verifier);
+    ("verdict", `String "approved");
+    ("notes", `String notes);
+    ("timestamp", `Float (Time_compat.now ()));
+  ])
+
+let on_reject_verification ~(config : Coord.config)
+    ~task_id ~verifier ~verification_id ~reason =
+  ignore config;
+  let meta_json = `Assoc [
+    ("type", `String "verification_verdict");
+    ("task_id", `String task_id);
+    ("verification_id", `String verification_id);
+    ("verdict", `String "rejected");
+  ] in
+  let _post = Board_dispatch.create_post
+    ~author:verifier
+    ~content:(Printf.sprintf "Rejected task %s (vrf:%s): %s"
+      task_id verification_id reason)
+    ~post_kind:Board.System_post
+    ~meta_json
+    ~visibility:Board.Internal
+    ~hearth:"verification"
+    () in
+  Subscriptions.push_event_to_sessions (`Assoc [
+    ("type", `String "masc/verification/rejected");
+    ("task_id", `String task_id);
+    ("verification_id", `String verification_id);
+    ("verifier", `String verifier);
+    ("reason", `String reason);
+    ("timestamp", `Float (Time_compat.now ()));
+  ])

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -107,3 +107,47 @@ let on_reject_verification ~(config : Coord.config)
     ("reason", `String reason);
     ("timestamp", `Float (Time_compat.now ()));
   ])
+
+let check_timeouts ~(config : Coord.config) =
+  if not (Env_config_runtime.Verification.fsm_enabled ()) then ()
+  else
+    try
+      let backlog = Coord.read_backlog config in
+      let now = Time_compat.now () in
+      List.iter (fun (task : Types.task) ->
+        match task.task_status with
+        | Types.AwaitingVerification { assignee; verification_id; deadline = Some dl; _ } ->
+          (match Types.parse_iso8601_opt dl with
+           | Some deadline_ts when now > deadline_ts ->
+             let _post = Board_dispatch.create_post
+               ~author:"system"
+               ~content:(Printf.sprintf
+                 "Verification timeout: task %s (%s) by %s — no verifier responded within deadline %s"
+                 task.id task.title assignee dl)
+               ~title:(Printf.sprintf "Timeout: %s" task.title)
+               ~post_kind:Board.System_post
+               ~meta_json:(`Assoc [
+                 ("type", `String "verification_timeout");
+                 ("task_id", `String task.id);
+                 ("verification_id", `String verification_id);
+                 ("assignee", `String assignee);
+                 ("deadline", `String dl);
+               ])
+               ~visibility:Board.Internal
+               ~hearth:"verification"
+               () in
+             Subscriptions.push_event_to_sessions (`Assoc [
+               ("type", `String "masc/verification/timeout");
+               ("task_id", `String task.id);
+               ("verification_id", `String verification_id);
+               ("assignee", `String assignee);
+               ("timestamp", `Float now);
+             ])
+           | _ -> ())
+        | _ -> ()
+      ) backlog.tasks
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Task.error "verification timeout check failed: %s"
+        (Printexc.to_string exn)

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -54,7 +54,18 @@ let on_submit_for_verification ~(config : Coord.config)
 
 let on_approve_verification ~(config : Coord.config)
     ~task_id ~verifier ~verification_id ~notes =
-  ignore config;
+  let base_path = config.Coord.base_path in
+  (* Update Verification.ml state machine: Pending -> Completed Pass.
+     Issue #7544. *)
+  (if verification_id <> "" then
+    match Verification.submit_verdict ~base_path
+            ~req_id:verification_id ~verifier
+            ~verdict:Verification.Pass with
+    | Ok _ -> ()
+    | Error e ->
+      Log.Task.error
+        "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
+        task_id verification_id verifier e);
   let meta_json = `Assoc [
     ("type", `String "verification_verdict");
     ("task_id", `String task_id);
@@ -83,7 +94,18 @@ let on_approve_verification ~(config : Coord.config)
 
 let on_reject_verification ~(config : Coord.config)
     ~task_id ~verifier ~verification_id ~reason =
-  ignore config;
+  let base_path = config.Coord.base_path in
+  (* Update Verification.ml state machine: Pending -> Completed (Fail reason).
+     Issue #7544. *)
+  (if verification_id <> "" then
+    match Verification.submit_verdict ~base_path
+            ~req_id:verification_id ~verifier
+            ~verdict:(Verification.Fail reason) with
+    | Ok _ -> ()
+    | Error e ->
+      Log.Task.error
+        "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
+        task_id verification_id verifier e);
   let meta_json = `Assoc [
     ("type", `String "verification_verdict");
     ("task_id", `String task_id);

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -7,35 +7,35 @@
 
     @since Phase B+C *)
 
+(* Fail-closed by types: [~assignee] is passed directly by the caller,
+   which already destructures [AwaitingVerification { assignee; _ }]. Removes
+   the prior "unknown" fallback that violated Silent Failure 금지. Issue #7547. *)
 let on_submit_for_verification ~(config : Coord.config)
-    ~(task : Types.task) ~verification_id ~evidence_refs =
+    ~(task : Types.task) ~assignee ~verification_id ~evidence_refs =
   let base_path = config.Coord.base_path in
   let criteria = List.map (fun s -> Verification.Custom s)
     (match task.contract with
      | Some c -> c.verify_gate_evidence
      | None -> []) in
-  let worker = match task.task_status with
-    | AwaitingVerification { assignee; _ } -> assignee
-    | _ -> "unknown" in
   let _req =
     Verification.create_request ~base_path ~task_id:task.id
       ~output:(`Assoc [
         ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
         ("task_title", `String task.title);
       ])
-      ~criteria ~worker () in
+      ~criteria ~worker:assignee () in
   let meta_json = `Assoc [
     ("type", `String "verification_request");
     ("task_id", `String task.id);
     ("verification_id", `String verification_id);
-    ("worker", `String worker);
+    ("worker", `String assignee);
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
     ("criteria", `List (List.map Verification.criterion_to_yojson criteria));
   ] in
   let _post = Board_dispatch.create_post
     ~author:"system"
     ~content:(Printf.sprintf "Verification requested for task %s (%s) by %s"
-      task.id task.title worker)
+      task.id task.title assignee)
     ~title:(Printf.sprintf "Verify: %s" task.title)
     ~post_kind:Board.System_post
     ~meta_json
@@ -46,7 +46,7 @@ let on_submit_for_verification ~(config : Coord.config)
     ("type", `String "masc/verification/requested");
     ("task_id", `String task.id);
     ("verification_id", `String verification_id);
-    ("worker", `String worker);
+    ("worker", `String assignee);
     ("evidence_refs", `List (List.map (fun s -> `String s) evidence_refs));
     ("timestamp", `Float (Time_compat.now ()));
   ]);

--- a/test/dune
+++ b/test/dune
@@ -376,6 +376,7 @@
         test_cdal_eval_v1
         test_cdal_friction_projection
         test_cdal_verdict_gate
+        test_verification_fsm
         test_task_sandbox
         test_governance_yojson_roundtrip
         test_eval_calibration
@@ -522,6 +523,7 @@
         test_cdal_eval_v1
         test_cdal_friction_projection
         test_cdal_verdict_gate
+        test_verification_fsm
         test_task_sandbox
         test_governance_yojson_roundtrip
         test_eval_calibration

--- a/test/dune
+++ b/test/dune
@@ -375,6 +375,7 @@
         test_cdal_judge
         test_cdal_eval_v1
         test_cdal_friction_projection
+        test_cdal_verdict_gate
         test_task_sandbox
         test_governance_yojson_roundtrip
         test_eval_calibration
@@ -520,6 +521,7 @@
         test_cdal_judge
         test_cdal_eval_v1
         test_cdal_friction_projection
+        test_cdal_verdict_gate
         test_task_sandbox
         test_governance_yojson_roundtrip
         test_eval_calibration

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -1,0 +1,218 @@
+(** test_cdal_verdict_gate -- Unit tests for CDAL verdict gate logic.
+
+    Tests the deterministic gate that blocks task completion
+    based on CDAL verdict status. *)
+
+module CVG = Masc_mcp.Cdal_verdict_gate
+module CT = Masc_mcp.Cdal_types
+
+let make_verdict
+    ?(run_id = "test-run-001")
+    ?(contract_id = "md5:test-contract")
+    ?(status = CT.Satisfied)
+    ?(findings = [])
+    ?(gaps = [])
+    () : CT.contract_verdict =
+  let basis_input =
+    Printf.sprintf "%s|%s|%s"
+      contract_id
+      CT.loader_semantics_version_phase1
+      CT.schema_compat_mode_v1 in
+  let basis_hash =
+    "md5:" ^ (Digest.string basis_input |> Digest.to_hex) in
+  let v_no_hash : CT.contract_verdict = {
+    run_id;
+    contract_id;
+    claim_scope = CT.claim_scope_phase1;
+    judgment_basis_hash = basis_hash;
+    judgment_hash = "";
+    loader_semantics_version = CT.loader_semantics_version_phase1;
+    schema_compat_mode = CT.schema_compat_mode_v1;
+    status;
+    findings;
+    completeness_gaps = gaps;
+    check_results = [];
+  } in
+  let judgment_hash = CT.compute_judgment_hash v_no_hash in
+  { v_no_hash with judgment_hash }
+
+let make_finding
+    ?(check_id = "test_check")
+    ?(observed = `String "bad")
+    ?(expected = `String "good")
+    () : CT.contract_finding =
+  { check_id; event_id = None; observed; expected; trace_ref = None }
+
+let make_gap
+    ?(artifact = "test.json")
+    ?(reason = "missing")
+    ?(impact = CT.Blocks_verdict)
+    () : CT.completeness_gap =
+  { artifact; reason; impact }
+
+(* ================================================================ *)
+(* check_verdict tests                                               *)
+(* ================================================================ *)
+
+let test_satisfied_allows () =
+  let v = make_verdict ~status:CT.Satisfied () in
+  match CVG.check_verdict v with
+  | CVG.Allow -> ()
+  | CVG.Reject msg ->
+    Alcotest.fail (Printf.sprintf "Satisfied should Allow, got Reject: %s" msg)
+
+let test_violated_rejects () =
+  let finding = make_finding ~check_id:"execution_mode" () in
+  let v = make_verdict ~status:CT.Violated ~findings:[finding] () in
+  match CVG.check_verdict v with
+  | CVG.Reject msg ->
+    Alcotest.(check bool) "contains check_id" true
+      (Astring.String.is_infix ~affix:"execution_mode" msg);
+    Alcotest.(check bool) "contains Violated" true
+      (Astring.String.is_infix ~affix:"Violated" msg)
+  | CVG.Allow ->
+    Alcotest.fail "Violated should Reject"
+
+let test_violated_no_findings_still_rejects () =
+  let v = make_verdict ~status:CT.Violated () in
+  match CVG.check_verdict v with
+  | CVG.Reject _ -> ()
+  | CVG.Allow ->
+    Alcotest.fail "Violated with no findings should still Reject"
+
+let test_inconclusive_blocking_gap_rejects () =
+  let gap = make_gap ~artifact:"evidence.json" ~impact:CT.Blocks_verdict () in
+  let v = make_verdict ~status:CT.Inconclusive ~gaps:[gap] () in
+  match CVG.check_verdict v with
+  | CVG.Reject msg ->
+    Alcotest.(check bool) "contains artifact" true
+      (Astring.String.is_infix ~affix:"evidence.json" msg)
+  | CVG.Allow ->
+    Alcotest.fail "Inconclusive with blocking gap should Reject"
+
+let test_inconclusive_annotation_only_allows () =
+  let gap = make_gap ~impact:CT.Annotation_only () in
+  let v = make_verdict ~status:CT.Inconclusive ~gaps:[gap] () in
+  match CVG.check_verdict v with
+  | CVG.Allow -> ()
+  | CVG.Reject msg ->
+    Alcotest.fail (Printf.sprintf "Annotation_only gap should Allow, got: %s" msg)
+
+let test_inconclusive_no_gaps_allows () =
+  let v = make_verdict ~status:CT.Inconclusive () in
+  match CVG.check_verdict v with
+  | CVG.Allow -> ()
+  | CVG.Reject msg ->
+    Alcotest.fail (Printf.sprintf "Inconclusive with no gaps should Allow, got: %s" msg)
+
+let test_inconclusive_mixed_gaps_rejects () =
+  let blocking = make_gap ~artifact:"a.json" ~impact:CT.Blocks_verdict () in
+  let annotation = make_gap ~artifact:"b.json" ~impact:CT.Annotation_only () in
+  let v = make_verdict ~status:CT.Inconclusive ~gaps:[blocking; annotation] () in
+  match CVG.check_verdict v with
+  | CVG.Reject _ -> ()
+  | CVG.Allow ->
+    Alcotest.fail "Mixed gaps with at least one blocking should Reject"
+
+(* ================================================================ *)
+(* gate_check with persistence (integration)                         *)
+(* ================================================================ *)
+
+let with_temp_dir f =
+  let dir = Filename.temp_dir "cdal_gate_test" "" in
+  Fun.protect ~finally:(fun () ->
+    ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
+  ) (fun () -> f dir)
+
+let write_verdict_jsonl ~base_dir ?task_id (verdict : CT.contract_verdict) =
+  let today = Unix.gmtime (Unix.gettimeofday ()) in
+  let date_dir = Printf.sprintf "%04d-%02d"
+    (today.tm_year + 1900) (today.tm_mon + 1) in
+  let dir = Filename.concat base_dir date_dir in
+  ignore (Sys.command (Printf.sprintf "mkdir -p %s" (Filename.quote dir)));
+  let day_file = Printf.sprintf "%02d.jsonl" today.tm_mday in
+  let path = Filename.concat dir day_file in
+  let json = CT.contract_verdict_to_json verdict in
+  let envelope = match task_id with
+    | None -> json
+    | Some tid ->
+      match json with
+      | `Assoc fields -> `Assoc (("_task_id", `String tid) :: fields)
+      | other -> other
+  in
+  let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
+  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+    output_string oc (Yojson.Safe.to_string envelope);
+    output_char oc '\n')
+
+let test_gate_no_verdict_rejects () =
+  with_temp_dir (fun base_dir ->
+    match CVG.gate_check ~base_dir ~task_id:"task-missing" () with
+    | Some msg ->
+      Alcotest.(check bool) "mentions task id" true
+        (Astring.String.is_infix ~affix:"task-missing" msg)
+    | None ->
+      Alcotest.fail "No verdict should reject")
+
+let test_gate_satisfied_verdict_allows () =
+  with_temp_dir (fun base_dir ->
+    let verdict = make_verdict ~status:CT.Satisfied () in
+    write_verdict_jsonl ~base_dir ~task_id:"task-001" verdict;
+    match CVG.gate_check ~base_dir ~task_id:"task-001" () with
+    | None -> ()
+    | Some msg ->
+      Alcotest.fail (Printf.sprintf "Satisfied verdict should allow, got: %s" msg))
+
+let test_gate_violated_verdict_rejects () =
+  with_temp_dir (fun base_dir ->
+    let finding = make_finding () in
+    let verdict = make_verdict ~status:CT.Violated ~findings:[finding] () in
+    write_verdict_jsonl ~base_dir ~task_id:"task-002" verdict;
+    match CVG.gate_check ~base_dir ~task_id:"task-002" () with
+    | Some _ -> ()
+    | None ->
+      Alcotest.fail "Violated verdict should reject")
+
+let test_gate_different_task_id_not_found () =
+  with_temp_dir (fun base_dir ->
+    let verdict = make_verdict ~status:CT.Satisfied () in
+    write_verdict_jsonl ~base_dir ~task_id:"task-other" verdict;
+    match CVG.gate_check ~base_dir ~task_id:"task-mine" () with
+    | Some _ -> ()
+    | None ->
+      Alcotest.fail "Different task_id should not match")
+
+let test_gate_latest_verdict_wins () =
+  with_temp_dir (fun base_dir ->
+    let v1 = make_verdict ~run_id:"run-old" ~status:CT.Violated () in
+    write_verdict_jsonl ~base_dir ~task_id:"task-003" v1;
+    let v2 = make_verdict ~run_id:"run-new" ~status:CT.Satisfied () in
+    write_verdict_jsonl ~base_dir ~task_id:"task-003" v2;
+    match CVG.gate_check ~base_dir ~task_id:"task-003" () with
+    | None -> ()
+    | Some msg ->
+      Alcotest.fail (Printf.sprintf "Latest Satisfied should allow, got: %s" msg))
+
+(* ================================================================ *)
+(* Test suite                                                        *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "cdal_verdict_gate" [
+    ("check_verdict", [
+      Alcotest.test_case "satisfied allows" `Quick test_satisfied_allows;
+      Alcotest.test_case "violated rejects" `Quick test_violated_rejects;
+      Alcotest.test_case "violated no findings rejects" `Quick test_violated_no_findings_still_rejects;
+      Alcotest.test_case "inconclusive blocking gap rejects" `Quick test_inconclusive_blocking_gap_rejects;
+      Alcotest.test_case "inconclusive annotation only allows" `Quick test_inconclusive_annotation_only_allows;
+      Alcotest.test_case "inconclusive no gaps allows" `Quick test_inconclusive_no_gaps_allows;
+      Alcotest.test_case "inconclusive mixed gaps rejects" `Quick test_inconclusive_mixed_gaps_rejects;
+    ]);
+    ("gate_check_integration", [
+      Alcotest.test_case "no verdict rejects" `Quick test_gate_no_verdict_rejects;
+      Alcotest.test_case "satisfied verdict allows" `Quick test_gate_satisfied_verdict_allows;
+      Alcotest.test_case "violated verdict rejects" `Quick test_gate_violated_verdict_rejects;
+      Alcotest.test_case "different task_id not found" `Quick test_gate_different_task_id_not_found;
+      Alcotest.test_case "latest verdict wins" `Quick test_gate_latest_verdict_wins;
+    ]);
+  ]

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -113,6 +113,7 @@ let base_observation : WO.world_observation =
     economic_pressure = AE.Normal;
     unclaimed_task_count = 0;
     failed_task_count = 0;
+    pending_verification_count = 0;
     active_agent_count = 0;
     last_turn_budget = None;
     last_tools_used = [];

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -5,6 +5,9 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 module V = Masc_mcp.Verification
 
+(* Initialize mirage-crypto-rng once (needed by Verification.generate_id). *)
+let () = Mirage_crypto_rng_unix.use_default ()
+
 (** Use a temporary directory for each test *)
 let with_temp_dir f =
   let dir = Filename.temp_dir "masc_verify_test" "" in

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -132,6 +132,60 @@ let test_self_rejection_blocked () =
     | Error _ -> ())
 
 (* ================================================================ *)
+(* Verification.ml state sync (P0 #7544)                             *)
+(* ================================================================ *)
+
+(* Directly exercises Verification.submit_verdict — the state-sync primitive
+   that verification_protocol.on_approve/reject calls internally.
+   Full protocol (board + SSE) is tested e2e. *)
+let test_submit_verdict_pass () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let base_path = config.Coord.base_path in
+    let req = match Verification.create_request
+      ~base_path ~task_id:"task-x" ~output:(`Assoc [])
+      ~criteria:[Verification.Custom "tests pass"] ~worker:"worker" () with
+      | Ok r -> r
+      | Error e -> Alcotest.fail e
+    in
+    Alcotest.(check bool) "initial pending" true
+      (match req.status with Pending -> true | _ -> false);
+    let _ = match Verification.submit_verdict ~base_path
+      ~req_id:req.id ~verifier:"verifier-agent"
+      ~verdict:Verification.Pass with
+      | Ok _ -> ()
+      | Error e -> Alcotest.fail ("submit_verdict failed: " ^ e)
+    in
+    match Verification.load_request base_path req.id with
+    | Error e -> Alcotest.fail ("load_request failed: " ^ e)
+    | Ok updated ->
+      Alcotest.(check bool) "completed pass" true
+        (match updated.status with Completed Pass -> true | _ -> false))
+
+let test_submit_verdict_fail () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let base_path = config.Coord.base_path in
+    let req = match Verification.create_request
+      ~base_path ~task_id:"task-y" ~output:(`Assoc [])
+      ~criteria:[Verification.Custom "tests pass"] ~worker:"worker" () with
+      | Ok r -> r
+      | Error e -> Alcotest.fail e
+    in
+    let _ = match Verification.submit_verdict ~base_path
+      ~req_id:req.id ~verifier:"verifier-agent"
+      ~verdict:(Verification.Fail "missing evidence") with
+      | Ok _ -> ()
+      | Error e -> Alcotest.fail ("submit_verdict failed: " ^ e)
+    in
+    match Verification.load_request base_path req.id with
+    | Error e -> Alcotest.fail ("load_request failed: " ^ e)
+    | Ok updated ->
+      Alcotest.(check bool) "completed fail" true
+        (match updated.status with
+         | Completed (Fail r) ->
+           Astring.String.is_infix ~affix:"missing evidence" r
+         | _ -> false))
+
+(* ================================================================ *)
 (* FSM disabled                                                      *)
 (* ================================================================ *)
 
@@ -168,5 +222,11 @@ let () =
     ("fsm_disabled", [
       Alcotest.test_case "submit fails when FSM disabled" `Quick
         test_fsm_disabled_submit_fails;
+    ]);
+    ("verification_state_sync", [
+      Alcotest.test_case "submit_verdict Pass updates state" `Quick
+        test_submit_verdict_pass;
+      Alcotest.test_case "submit_verdict Fail preserves reason" `Quick
+        test_submit_verdict_fail;
     ]);
   ]

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -1,0 +1,172 @@
+(** test_verification_fsm -- FSM transition tests for AwaitingVerification state.
+
+    Tests Phase B+C transitions with MASC_VERIFICATION_FSM_ENABLED=true:
+    - InProgress -> AwaitingVerification (submit_for_verification)
+    - AwaitingVerification -> Done (cross-agent approve)
+    - AwaitingVerification -> InProgress (cross-agent reject)
+    - Self-approval/rejection blocked
+    - FSM disabled path: error message *)
+
+open Masc_mcp
+
+let with_temp_config ~fsm_enabled f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Unix.putenv "MASC_VERIFICATION_FSM_ENABLED" (if fsm_enabled then "true" else "false");
+  let dir = Filename.temp_file "verification_fsm_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  let config = Coord.default_config dir in
+  ignore (Coord.init config ~agent_name:(Some "worker"));
+  Task_dispatch.reset_for_test ();
+  Task_dispatch.init_jsonl ();
+  Fun.protect ~finally:(fun () ->
+      let rec rm path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then (
+            Sys.readdir path
+            |> Array.iter (fun name -> rm (Filename.concat path name));
+            Unix.rmdir path)
+          else
+            Unix.unlink path
+      in
+      rm dir) (fun () -> f config)
+
+(* Add a task with strict contract requiring verification *)
+let add_strict_task config =
+  let contract : Types.task_contract = {
+    strict = true;
+    completion_contract = ["tests pass"];
+    required_evidence = [];
+    inspect_gate_evidence = [];
+    verify_gate_evidence = ["output.json"];
+    links = { operation_id = None; session_id = None; autoresearch_loop_id = None };
+  } in
+  let _msg = Coord.add_task ~contract config ~title:"strict task"
+    ~priority:3 ~description:"needs verification" in
+  let backlog = Coord.read_backlog config in
+  match List.nth_opt backlog.tasks 0 with
+  | None -> Alcotest.fail "no task added"
+  | Some t -> t.id
+
+let claim_and_start config agent_name task_id =
+  let _ = Coord.transition_task_r config ~agent_name ~task_id
+    ~action:Types.Claim () in
+  let _ = Coord.transition_task_r config ~agent_name ~task_id
+    ~action:Types.Start () in
+  ()
+
+let get_task config task_id =
+  let backlog = Coord.read_backlog config in
+  List.find_opt (fun (t : Types.task) -> t.id = task_id) backlog.tasks
+
+let status_string config task_id =
+  match get_task config task_id with
+  | None -> "not_found"
+  | Some t -> Types.string_of_task_status t.task_status
+
+(* ================================================================ *)
+(* FSM transitions (enabled)                                         *)
+(* ================================================================ *)
+
+let test_submit_for_verification_moves_to_awaiting () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    match Coord.transition_task_r config ~agent_name:"worker"
+            ~task_id ~action:Types.Submit_for_verification () with
+    | Error e -> Alcotest.fail ("submit failed: " ^ Types.show_masc_error e)
+    | Ok _ ->
+      Alcotest.(check string) "status" "awaiting_verification"
+        (status_string config task_id))
+
+let test_approve_by_other_agent_moves_to_done () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    let _ = Coord.transition_task_r config ~agent_name:"worker"
+      ~task_id ~action:Types.Submit_for_verification () in
+    match Coord.transition_task_r config ~agent_name:"verifier"
+            ~task_id ~action:Types.Approve_verification () with
+    | Error e -> Alcotest.fail ("approve failed: " ^ Types.show_masc_error e)
+    | Ok _ ->
+      Alcotest.(check string) "status" "done"
+        (status_string config task_id))
+
+let test_reject_by_other_agent_moves_to_in_progress () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    let _ = Coord.transition_task_r config ~agent_name:"worker"
+      ~task_id ~action:Types.Submit_for_verification () in
+    match Coord.transition_task_r config ~agent_name:"verifier"
+            ~task_id ~action:Types.Reject_verification ~reason:"test reject" () with
+    | Error e -> Alcotest.fail ("reject failed: " ^ Types.show_masc_error e)
+    | Ok _ ->
+      Alcotest.(check string) "status" "in_progress"
+        (status_string config task_id))
+
+let test_self_approval_blocked () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    let _ = Coord.transition_task_r config ~agent_name:"worker"
+      ~task_id ~action:Types.Submit_for_verification () in
+    match Coord.transition_task_r config ~agent_name:"worker"
+            ~task_id ~action:Types.Approve_verification () with
+    | Ok _ -> Alcotest.fail "self-approval should be blocked"
+    | Error e ->
+      let msg = Types.show_masc_error e in
+      Alcotest.(check bool) "error mentions self-approval" true
+        (Astring.String.is_infix ~affix:"Self-approval" msg))
+
+let test_self_rejection_blocked () =
+  with_temp_config ~fsm_enabled:true (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    let _ = Coord.transition_task_r config ~agent_name:"worker"
+      ~task_id ~action:Types.Submit_for_verification () in
+    match Coord.transition_task_r config ~agent_name:"worker"
+            ~task_id ~action:Types.Reject_verification () with
+    | Ok _ -> Alcotest.fail "self-rejection should be blocked"
+    | Error _ -> ())
+
+(* ================================================================ *)
+(* FSM disabled                                                      *)
+(* ================================================================ *)
+
+let test_fsm_disabled_submit_fails () =
+  with_temp_config ~fsm_enabled:false (fun config ->
+    let task_id = add_strict_task config in
+    claim_and_start config "worker" task_id;
+    match Coord.transition_task_r config ~agent_name:"worker"
+            ~task_id ~action:Types.Submit_for_verification () with
+    | Ok _ -> Alcotest.fail "submit should fail when FSM disabled"
+    | Error e ->
+      let msg = Types.show_masc_error e in
+      Alcotest.(check bool) "error mentions FSM disabled" true
+        (Astring.String.is_infix ~affix:"not enabled" msg))
+
+(* ================================================================ *)
+(* Test suite                                                        *)
+(* ================================================================ *)
+
+let () =
+  Alcotest.run "verification_fsm" [
+    ("transitions_enabled", [
+      Alcotest.test_case "submit moves to awaiting_verification" `Quick
+        test_submit_for_verification_moves_to_awaiting;
+      Alcotest.test_case "cross-agent approve moves to done" `Quick
+        test_approve_by_other_agent_moves_to_done;
+      Alcotest.test_case "cross-agent reject moves to in_progress" `Quick
+        test_reject_by_other_agent_moves_to_in_progress;
+      Alcotest.test_case "self-approval blocked" `Quick
+        test_self_approval_blocked;
+      Alcotest.test_case "self-rejection blocked" `Quick
+        test_self_rejection_blocked;
+    ]);
+    ("fsm_disabled", [
+      Alcotest.test_case "submit fails when FSM disabled" `Quick
+        test_fsm_disabled_submit_fails;
+    ]);
+  ]

--- a/test/test_verification_fsm.ml
+++ b/test/test_verification_fsm.ml
@@ -9,9 +9,17 @@
 
 open Masc_mcp
 
+let rng_initialized = ref false
+
 let with_temp_config ~fsm_enabled f =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
+  (* Initialize mirage-crypto-rng for verification_id generation.
+     Production initializes this at server startup; tests must do it explicitly. *)
+  if not !rng_initialized then begin
+    Mirage_crypto_rng_unix.use_default ();
+    rng_initialized := true
+  end;
   Unix.putenv "MASC_VERIFICATION_FSM_ENABLED" (if fsm_enabled then "true" else "false");
   let dir = Filename.temp_file "verification_fsm_" "" in
   Unix.unlink dir;


### PR DESCRIPTION
## Summary

CDAL(Contract-Driven Agent Loop) verdict를 task 완료 게이트로 재활성화하고, Task FSM에 `AwaitingVerification` 상태를 추가하여 cross-agent 검증 워크플로우를 구축.

## Phases

### Phase A: CDAL Verdict Gate
`cdal_verdict_gate.ml`이 JSONL에서 task_id로 verdict를 조회하여 Violated/Inconclusive(blocking) 시 done 전이를 차단. 결정론적(JSON 조회 + status 매칭).

### Phase B: Task FSM 확장
`AwaitingVerification` 상태 + 3개 새 action(`submit_for_verification`/`approve`/`reject`). 전이 규칙: `InProgress` → `AwaitingVerification` → `Done`(cross-agent) 또는 `InProgress`(거절). Self-approval 차단.

### Phase C: Verification Protocol
`verification_protocol.ml`이 board post(visibility=Internal, hearth=verification) + SSE 이벤트(`masc:verification:requested`/`:verdict`/`:rejected`/`:timeout`)를 방출. Timeout fiber(60s)가 deadline 초과한 태스크에 대해 escalation.

### Keeper-as-Verifier 경로
`world_observation`에 `pending_verification_count` 추가 → keeper가 검증 대기 태스크를 context에서 인식 → LLM이 `masc_transition(action=approve/reject)` 호출 가능.

### Dashboard UI
- `status-label`: `'검증 대기'` for `awaiting_verification`
- `status-badge`: accent 색상
- `task-detail-overlay`: submit/approve/reject 이벤트 뱃지

## Feature Flags (모두 default=false)

| Flag | 기능 |
|------|------|
| `MASC_CDAL_GATE_ENABLED` | verdict gate |
| `MASC_VERIFICATION_FSM_ENABLED` | AwaitingVerification FSM |
| `MASC_CDAL_ENABLED` | proof 캡처 (기존, default=true) |

3개 독립 — 각각 단계적 활성화 가능.

## Changes
- 3 new OCaml files: `cdal_verdict_gate.ml`, `verification_protocol.ml`, `test_cdal_verdict_gate.ml`, `test_verification_fsm.ml`
- 34+ modified files (exhaustiveness fixes for new variant across 16+ files)
- 18 new tests (7 unit + 5 verdict integration + 6 FSM transition)

## Test Plan
- [x] `dune build` — clean build, 0 warnings
- [x] `test_cdal_verdict_gate` — 12/12 pass
- [x] `test_verification_fsm` — 6/6 pass
- [x] `test_keeper_unified` — 161/161 pass
- [x] `dune runtest` — full suite pass (gRPC pre-existing env issue only)
- [ ] E2E 수동: strict task → claim → start → submit → SSE → approve(diff agent) → Done
- [ ] Feature flag off 회귀 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)