### PR TITLE
feat(prometheus): per-keeper turn outcome + token counters (#7495 + #7519 Step 1)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1921,6 +1921,8 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let is_server_parse_rejection = is_server_rejected_parse_error err in
           let is_auto_recoverable = is_auto_recoverable_turn_error err in
           let is_ambiguous_partial = is_ambiguous_side_effect_error err in
+          Prometheus.inc_counter "masc_keeper_turns_total"
+            ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
             meta.name effective_cascade_name max_context latency_ms
@@ -2247,22 +2249,40 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
                      ~turn_evidence)
                 ()
           | None -> ());
+          let model_used = Keeper_agent_run.surface_model_used result in
+          let outcome_str =
+            match result.stop_reason with
+            | Oas_worker.Completed -> "completed"
+            | Oas_worker.TurnBudgetExhausted { turns_used; limit; _ } ->
+                Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit
+            | Oas_worker.MutationBoundaryReached { turns_used; tool_name } ->
+                (match tool_name with
+                 | Some tool ->
+                     Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
+                 | None ->
+                     Printf.sprintf "mutation_boundary(%d)" turns_used)
+          in
+          let outcome_label =
+            match result.stop_reason with
+            | Oas_worker.Completed -> "success"
+            | Oas_worker.TurnBudgetExhausted _ -> "budget_exhausted"
+            | Oas_worker.MutationBoundaryReached _ -> "mutation_boundary"
+          in
+          Prometheus.inc_counter "masc_keeper_turns_total"
+            ~labels:[("keeper_name", updated_meta.name); ("outcome", outcome_label)] ();
+          Prometheus.inc_counter "masc_keeper_input_tokens_total"
+            ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+            ~delta:(float_of_int result.usage.input_tokens) ();
+          Prometheus.inc_counter "masc_keeper_output_tokens_total"
+            ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+            ~delta:(float_of_int result.usage.output_tokens) ();
           Log.Keeper.info
             "%s: keeper cycle OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
-            updated_meta.name (Keeper_agent_run.surface_model_used result)
+            updated_meta.name model_used
             (result.usage.input_tokens + result.usage.output_tokens)
             latency_ms
             selected_mode
-            (match result.stop_reason with
-             | Oas_worker.Completed -> "completed"
-             | Oas_worker.TurnBudgetExhausted { turns_used; limit; _ } ->
-                 Printf.sprintf "budget_exhausted(%d/%d)" turns_used limit
-             | Oas_worker.MutationBoundaryReached { turns_used; tool_name } ->
-                 (match tool_name with
-                  | Some tool ->
-                      Printf.sprintf "mutation_boundary(%d:%s)" turns_used tool
-                  | None ->
-                      Printf.sprintf "mutation_boundary(%d)" turns_used));
+            outcome_str;
           (* 7. Persist updated meta *)
           (match write_meta config updated_meta with
            | Ok () -> ()

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -265,7 +265,19 @@ let init () =
   add fd_threshold
     "Threshold above which open_fds triggers a one-shot WARN log." Gauge;
   set_gauge fd_threshold
-    (float_of_int (Env_config_core.get_int ~default:3000 "MASC_FD_WARN_THRESHOLD" |> max 1))
+    (float_of_int (Env_config_core.get_int ~default:3000 "MASC_FD_WARN_THRESHOLD" |> max 1));
+  (* Per-keeper turn outcome + token counters.  Labels are populated
+     dynamically via inc_counter; no upfront registration needed.
+     Covers issues #7495 (cost/token attribution) and #7519 (SLO). *)
+  add "masc_keeper_turns_total"
+    "Total keeper turns by outcome (labels: keeper_name, outcome=success|failure|budget_exhausted|mutation_boundary)"
+    Counter;
+  add "masc_keeper_input_tokens_total"
+    "Cumulative input tokens per keeper turn (labels: keeper_name, model)"
+    Counter;
+  add "masc_keeper_output_tokens_total"
+    "Cumulative output tokens per keeper turn (labels: keeper_name, model)"
+    Counter
 
 let metric_open_fds = "masc_process_open_fds"
 


### PR DESCRIPTION
## Summary

Per-keeper Prometheus counter 3개 추가. #7495 (cost/token 가시화) + #7519 (SLO success rate) Step 1 동시 해결.

## Linked issues

- Closes Step 1 of #7495 (per-keeper cost/token Prometheus gauge)
- Closes Step 1 of #7519 (keeper turn success rate for SLO)

## New metrics

| Counter | Labels | 용도 |
|---------|--------|------|
| ``masc_keeper_turns_total`` | ``keeper_name``, ``outcome`` | 성공률, error budget, SLO |
| ``masc_keeper_input_tokens_total`` | ``keeper_name``, ``model`` | Token 비용 attribution |
| ``masc_keeper_output_tokens_total`` | ``keeper_name``, ``model`` | Token 비용 attribution |

``outcome`` values: ``success``, ``failure``, ``budget_exhausted``, ``mutation_boundary``.

## PromQL examples

``\`promql
# Per-keeper hourly success rate
rate(masc_keeper_turns_total{outcome="success"}[1h])
  / rate(masc_keeper_turns_total[1h])

# Which keeper is most expensive (output tokens/hr)
sum by (keeper_name) (rate(masc_keeper_output_tokens_total[1h]))

# Error budget: failures this hour vs threshold
sum(increase(masc_keeper_turns_total{outcome="failure"}[1h]))
``\`

## Evidence

``dune build --root .`` clean. +44/-12, 2 files.

## Test plan
- [x] Build clean
- [ ] CI
- [ ] Deploy → ``/metrics`` 에 ``masc_keeper_turns_total`` 노출 확인

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>