### PR TITLE
[codex] Fix cascade filters and remove dual-root diagnostics

### DIFF
--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -423,6 +423,7 @@ export function normalizeKeepers(raw: unknown): Keeper[] {
         last_speech_act: asString(row.last_speech_act) ?? null,
         last_blocker: asString(row.last_blocker) ?? null,
         last_need: asString(row.last_need) ?? null,
+        runtime_warning_ctx_ratio: asNumber(row.runtime_warning_ctx_ratio) ?? null,
         context_ratio: contextRatio,
         context_tokens: asNumber(row.context_tokens) ?? asNumber(contextRaw?.context_tokens),
         context_max: asNumber(row.context_max) ?? asNumber(contextRaw?.context_max),

--- a/dashboard/src/lib/monitoring-runtime.test.ts
+++ b/dashboard/src/lib/monitoring-runtime.test.ts
@@ -177,6 +177,34 @@ describe('summarizeKeeperMonitoring', () => {
     expect(summary.hint).toContain('slot wait timeout')
   })
 
+  it('uses the server runtime warning threshold instead of the old client hardcode', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        context_ratio: 0.9,
+      }),
+    )
+
+    expect(summary.band.key).toBe('active')
+  })
+
+  it('honors a keeper-specific runtime warning threshold from the payload', () => {
+    const summary = summarizeKeeperMonitoring(
+      makeKeeper({
+        status: 'busy',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        context_ratio: 0.9,
+        runtime_warning_ctx_ratio: 0.85,
+      }),
+    )
+
+    expect(summary.band.key).toBe('attention')
+    expect(summary.hint).toBe('컨텍스트 사용량이 90%입니다.')
+  })
+
   it('keeps never-booted keepers in the offline band', () => {
     const summary = summarizeKeeperMonitoring(
       makeKeeper({

--- a/dashboard/src/lib/monitoring-runtime.ts
+++ b/dashboard/src/lib/monitoring-runtime.ts
@@ -34,7 +34,7 @@ export interface MonitoringEvidence {
 }
 
 const HEARTBEAT_STALE_MS = 5 * 60 * 1000
-const CONTEXT_ATTENTION_RATIO = 0.85
+const DEFAULT_CONTEXT_ATTENTION_RATIO = 0.95
 
 const CANONICAL_PHASE_KEYS = new Set([
   'Offline',
@@ -204,6 +204,13 @@ function isHeartbeatStale(keeper: Keeper): boolean {
   return Date.now() - ts > HEARTBEAT_STALE_MS
 }
 
+function contextAttentionRatio(keeper: Keeper): number {
+  const value = keeper.runtime_warning_ctx_ratio
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : DEFAULT_CONTEXT_ATTENTION_RATIO
+}
+
 function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): RuntimeBand {
   if (keeper.paused || phaseKey === 'Paused' || lifecycleKey === 'paused') return 'paused'
   if (
@@ -221,7 +228,7 @@ function keeperBand(keeper: Keeper, phaseKey: string, lifecycleKey: string): Run
     || keeper.social_model_recognized === false
     || Boolean(keeper.last_blocker?.trim())
     || isHeartbeatStale(keeper)
-    || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= CONTEXT_ATTENTION_RATIO)
+    || (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper))
   ) {
     return 'attention'
   }
@@ -243,7 +250,7 @@ function keeperHint(keeper: Keeper, band: RuntimeBand, stage: StageMeta): string
   if (blocker) return blocker
   if (band === 'paused') return '운영자가 멈춰 둔 상태입니다.'
   if (isHeartbeatStale(keeper)) return '오래 응답이 없어 실제 상태 확인이 필요합니다.'
-  if (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= CONTEXT_ATTENTION_RATIO) {
+  if (typeof keeper.context_ratio === 'number' && keeper.context_ratio >= contextAttentionRatio(keeper)) {
     return `컨텍스트 사용량이 ${Math.round(keeper.context_ratio * 100)}%입니다.`
   }
   if (band === 'attention') return stage.description

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -625,6 +625,7 @@ export interface Keeper {
   last_need?: string | null
   last_drift_reason?: string | null
   drift_count_total?: number
+  runtime_warning_ctx_ratio?: number | null
   generation?: number
   turn_count?: number
   total_turns?: number

--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -263,16 +263,24 @@ let models_of_cascade_name (cascade_name : string) : string list =
 let default_model_strings_from_config () : string list =
   models_of_cascade_name "default"
 
-let resolve_providers_from_model_strings (model_strings : string list)
+let resolve_providers_from_model_strings ?provider_filter
+    (model_strings : string list)
     : Llm_provider.Provider_config.t list =
   let specs = Cascade_config.parse_model_strings model_strings in
-  if specs <> [] then specs
+  let filtered =
+    Cascade_config.apply_provider_filter
+      ~provider_filter
+      ~label:"direct_model_strings"
+      specs
+  in
+  if filtered <> [] then filtered
   else (
     Log.Misc.warn "direct model strings: no callable models from %d entries"
       (List.length model_strings);
     [])
 
-let resolve_named_providers ~cascade_name : Llm_provider.Provider_config.t list =
+let resolve_named_providers ?provider_filter ~cascade_name ()
+    : Llm_provider.Provider_config.t list =
   let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let defaults = default_model_strings ~cascade_name in
   let config_path = cascade_config_path () in
@@ -284,11 +292,12 @@ let resolve_named_providers ~cascade_name : Llm_provider.Provider_config.t list 
     | None -> []
   in
   let specs =
-    if weighted <> [] then
-      Cascade_config.parse_weighted_entries weighted
-    else
-      Cascade_config.parse_model_strings
-        (models_of_cascade_name cascade_name)
+    (if weighted <> [] then
+       Cascade_config.parse_weighted_entries weighted
+     else
+       Cascade_config.parse_model_strings
+         (models_of_cascade_name cascade_name))
+    |> Cascade_config.apply_provider_filter ~provider_filter ~label:cascade_name
   in
   if specs <> [] then specs
   else if models_of_cascade_name cascade_name = defaults then (
@@ -299,4 +308,4 @@ let resolve_named_providers ~cascade_name : Llm_provider.Provider_config.t list 
     Log.Misc.warn
       "cascade %s: configured models unavailable — retrying built-in defaults"
       cascade_name;
-    resolve_providers_from_model_strings defaults)
+    resolve_providers_from_model_strings ?provider_filter defaults)

--- a/lib/cascade/cascade_runtime.mli
+++ b/lib/cascade/cascade_runtime.mli
@@ -34,6 +34,8 @@ val default_model_strings : cascade_name:string -> string list
 val models_of_cascade_name : string -> string list
 val default_model_strings_from_config : unit -> string list
 val resolve_named_providers :
-  cascade_name:string -> Llm_provider.Provider_config.t list
+  ?provider_filter:string list ->
+  cascade_name:string -> unit -> Llm_provider.Provider_config.t list
 val resolve_providers_from_model_strings :
+  ?provider_filter:string list ->
   string list -> Llm_provider.Provider_config.t list

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -18,6 +18,8 @@ let health_ctx_critical = Env_config_keeper.DashboardHealth.ctx_critical
 let health_ctx_warn = Env_config_keeper.DashboardHealth.ctx_warn
 let health_penalty_critical = Env_config_keeper.DashboardHealth.penalty_critical
 let health_penalty_warn = Env_config_keeper.DashboardHealth.penalty_warn
+let runtime_warning_ctx_ratio =
+  Env_config_keeper.DashboardHealth.runtime_warning_ctx_ratio
 
 (** Compute keeper health score (0-100). Pure function.
     Inputs: restart_count, max_restarts, recent_crash_count,
@@ -719,6 +721,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
               ("last_compaction_event", match last_compaction_event with Some j -> j | None -> `Null);
               ("context", context);
               ("context_source", context_source);
+              ("runtime_warning_ctx_ratio", `Float runtime_warning_ctx_ratio);
               (* Eval feed: latest verdict snapshot for this keeper (RFC-MASC-005) *)
               ("eval_latest",
                 let base_path = config.base_path in

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -44,13 +44,15 @@ let admission_wait_timeout_error
 (** Resolve cascade provider configs via MASC Cascade_config.
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
-let resolve_cascade_providers = Cascade_runtime.resolve_named_providers
+let resolve_cascade_providers ?provider_filter ~cascade_name () =
+  Cascade_runtime.resolve_named_providers ?provider_filter ~cascade_name ()
 
 (** Resolve from an explicit model string list (user-declared in keeper TOML).
     MASC parses the strings via its local [Cascade_config] and passes the
     resulting provider configs into OAS execution. *)
-let resolve_providers_from_model_strings =
-  Cascade_runtime.resolve_providers_from_model_strings
+let resolve_providers_from_model_strings ?provider_filter model_strings =
+  Cascade_runtime.resolve_providers_from_model_strings ?provider_filter
+    model_strings
 
 let config_for_label
     ~(name : string)
@@ -157,7 +159,7 @@ let run_named
     ~cascade_name
     ?model_strings
     ~goal
-    ?provider_filter:_provider_filter
+    ?provider_filter
     ?priority
     ?session_id
     ?(system_prompt = "")
@@ -212,10 +214,10 @@ let run_named
     | Some ms when ms <> [] ->
       (* Direct model strings from keeper TOML — skip named preset lookup.
          MASC passes these strings through without interpretation. *)
-      (ms, resolve_providers_from_model_strings ms)
+      (ms, resolve_providers_from_model_strings ?provider_filter ms)
     | _ ->
       let labels = Cascade_runtime.models_of_cascade_name cascade_name in
-      (labels, resolve_cascade_providers ~cascade_name)
+      (labels, resolve_cascade_providers ?provider_filter ~cascade_name ())
   in
   let capture, metrics = Oas_worker_cascade.cascade_metrics_for_candidates ~candidate_cfgs () in
   let name = Printf.sprintf "oas-%s" cascade_name in

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -707,7 +707,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       in
       Server_base_path_diagnostics.log_startup_warning path_diagnostics;
       if Server_base_path_diagnostics.strict_violation path_diagnostics then begin
-        Log.Server.error "%s\nDual .masc roots are not supported. Start the server from the intended base path or remove the stale .masc tree."
+        Log.Server.error "%s\nBase-path strict mode rejected the resolved runtime path configuration."
           (Option.value path_diagnostics.warning
              ~default:
                "strict base-path guard triggered without a diagnostic warning");

--- a/lib/server_base_path_diagnostics.ml
+++ b/lib/server_base_path_diagnostics.ml
@@ -1,5 +1,9 @@
-(** Diagnose runtime base-path mismatches that can make two [.masc] roots
-    look simultaneously authoritative to operators. *)
+(** Diagnose runtime base-path facts with a single authoritative [.masc] root.
+
+    The runtime no longer treats a cwd-local [.masc] tree as a second live
+    authority. Cwd-relative fields remain observational only so health and
+    startup payloads can explain where the process was launched from without
+    reviving stale-path warnings or abort paths. *)
 
 type t = {
   process_cwd : string;
@@ -8,13 +12,9 @@ type t = {
   effective_masc_root : string;
   env_masc_base_path : string option;
   resolution_source : string option;
-  cwd_masc_root : string;
-  cwd_has_masc_dir : bool;
-  cwd_legacy_dirs : string list;
   effective_has_masc_dir : bool;
   effective_legacy_dirs : string list;
   roots_diverge : bool;
-  dual_masc_roots : bool;
   strict_mode_requested : bool;
   startup_rejected : bool;
   startup_abort_eligible : bool;
@@ -73,10 +73,6 @@ let resolution_source_opt ?resolution_source () =
   | Some raw -> trim_opt (Some raw)
   | None -> trim_opt (Sys.getenv_opt "MASC_BASE_PATH_RESOLUTION_SOURCE")
 
-let explicit_resolution_source = function
-  | Some ("explicit_env" | "explicit_cli") -> true
-  | _ -> false
-
 let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     ~effective_base_path ~effective_masc_root () =
   let cwd =
@@ -87,67 +83,18 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
   let cwd_norm = normalize_path ~cwd cwd in
   let effective_base_norm = normalize_path ~cwd effective_base_path in
   let effective_masc_norm = normalize_path ~cwd effective_masc_root in
-  let cwd_masc_root = normalize_path ~cwd (Filename.concat cwd_norm ".masc") in
-  let cwd_has_masc_dir = dir_exists cwd_masc_root in
-  let cwd_legacy_dirs = legacy_dirs_under cwd_masc_root in
   let effective_has_masc_dir = dir_exists effective_masc_norm in
   let effective_legacy_dirs = legacy_dirs_under effective_masc_norm in
   let roots_diverge = not (String.equal cwd_norm effective_base_norm) in
-  let dual_masc_roots =
-    roots_diverge
-    && cwd_has_masc_dir
-    && effective_has_masc_dir
-    && not (String.equal cwd_masc_root effective_masc_norm)
-  in
   let resolution_source = resolution_source_opt ?resolution_source () in
-  (* Dual .masc roots only force fail-fast when the effective base
-     path was derived from a cwd heuristic (i.e. NOT an explicit env
-     or CLI flag). If the operator, CI harness, or test driver
-     explicitly set [MASC_BASE_PATH] / [--base-path], the warning
-     already documents that "runtime will use the explicit base path,
-     but operator surfaces may inspect stale state from cwd" — that is
-     exactly the contract that lets test harnesses point the server at
-     a [/tmp/...-base-<hex>] directory from inside a checked-out git
-     worktree that happens to carry its own committed [.masc/] tree.
-     Pre-#6548 behavior had this escape; removing it broke the
-     [Run SSE reconnect e2e] CI step which fails immediately on
-     [Dual .masc roots are not supported]. *)
-  let startup_rejected =
-    dual_masc_roots && not (explicit_resolution_source resolution_source)
-  in
   let strict_mode_requested =
     match strict with
     | Some enabled -> enabled
     | None -> strict_mode_env_enabled ()
   in
-  let startup_abort_eligible =
-    strict_mode_requested || startup_rejected
-  in
-  let warning =
-    if dual_masc_roots then
-      let stale_suffix =
-        if cwd_legacy_dirs = [] then
-          ""
-        else
-          Printf.sprintf
-            "; ignored cwd .masc still contains legacy dirs (%s)"
-            (format_legacy_dirs cwd_legacy_dirs)
-      in
-      if explicit_resolution_source resolution_source then
-        Some
-          (Printf.sprintf
-             "process cwd (%s) differs from explicit effective base path (%s) and both .masc roots exist (%s vs %s); runtime will use the explicit base path, but operator surfaces may inspect stale state from cwd%s"
-             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm
-             stale_suffix)
-      else
-        Some
-          (Printf.sprintf
-             "process cwd (%s) differs from effective base path (%s) and both .masc roots exist (%s vs %s); operator surfaces may inspect stale state%s"
-             cwd_norm effective_base_norm cwd_masc_root effective_masc_norm
-             stale_suffix)
-    else
-      None
-  in
+  let startup_rejected = false in
+  let startup_abort_eligible = false in
+  let warning = None in
   {
     process_cwd = cwd_norm;
     input_base_path;
@@ -155,13 +102,9 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
     effective_masc_root = effective_masc_norm;
     env_masc_base_path = trim_opt env_masc_base_path;
     resolution_source;
-    cwd_masc_root;
-    cwd_has_masc_dir;
-    cwd_legacy_dirs;
     effective_has_masc_dir;
     effective_legacy_dirs;
     roots_diverge;
-    dual_masc_roots;
     strict_mode_requested;
     startup_rejected;
     startup_abort_eligible;
@@ -169,14 +112,8 @@ let detect ?cwd ?env_masc_base_path ?strict ?input_base_path ?resolution_source
   }
 
 let strict_violation (diag : t) =
-  (* Only a *heuristic* dual-root detection should abort startup. If the
-     operator explicitly pointed the server at a base path via env or
-     CLI, honor that decision — the warning still fires so operator
-     tools can flag the stale cwd [.masc] tree, but the runtime must
-     not kill itself out from under a CI/test harness or a developer
-     who deliberately pointed at a tmp directory. Pairs with the same
-     escape condition used to compute [startup_abort_eligible] above. *)
-  diag.startup_rejected
+  let _ = diag in
+  false
 
 let startup_lines (diag : t) =
   let lines =
@@ -195,12 +132,6 @@ let startup_lines (diag : t) =
       (match diag.warning with
        | Some message -> Some (Printf.sprintf "   Path warning: %s" message)
        | None -> None);
-      (if diag.dual_masc_roots then
-         Some
-           (Printf.sprintf "   Ignored cwd .masc legacy dirs: %s"
-              (format_legacy_dirs diag.cwd_legacy_dirs))
-       else
-         None);
       (if diag.effective_has_masc_dir then
          Some
            (Printf.sprintf "   Active .masc legacy dirs: %s"
@@ -242,14 +173,10 @@ let to_yojson (diag : t) =
        ("cwd", `String diag.process_cwd);
        ("effective_base_path", `String diag.effective_base_path);
        ("effective_masc_root", `String diag.effective_masc_root);
-       ("cwd_masc_root", `String diag.cwd_masc_root);
-       ("cwd_has_masc_dir", `Bool diag.cwd_has_masc_dir);
-       ("cwd_legacy_dirs", `List (List.map (fun dir -> `String dir) diag.cwd_legacy_dirs));
        ("effective_has_masc_dir", `Bool diag.effective_has_masc_dir);
        ( "effective_legacy_dirs",
          `List (List.map (fun dir -> `String dir) diag.effective_legacy_dirs) );
        ("roots_diverge", `Bool diag.roots_diverge);
-       ("dual_masc_roots", `Bool diag.dual_masc_roots);
        ("strict_mode_requested", `Bool diag.strict_mode_requested);
        ("startup_rejected", `Bool diag.startup_rejected);
        ("startup_abort_eligible", `Bool diag.startup_abort_eligible);

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -58,15 +58,20 @@ harness_find_server_exe() {
 
 harness_pick_free_port() {
   local seed start port attempts=2048
+  local tmp_root reservation_file
   seed="${HARNESS_PORT_SEED:-$$}"
   if [[ ! "$seed" =~ ^[0-9]+$ ]]; then
     seed="$$"
   fi
+  tmp_root="$(harness_tmp_root)"
+  reservation_file="${tmp_root%/}/masc-harness-ports.${seed}.txt"
   start=$((9200 + (seed % 1000)))
   port="$start"
 
   while (( attempts > 0 )); do
-    if ! lsof -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if ! lsof -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1 \
+      && ! grep -qx "$port" "$reservation_file" 2>/dev/null; then
+      printf '%s\n' "$port" >>"$reservation_file"
       printf '%s\n' "$port"
       return 0
     fi

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -57,13 +57,28 @@ harness_find_server_exe() {
 }
 
 harness_pick_free_port() {
-  python3 - <<'PY'
-import socket
-s = socket.socket()
-s.bind(("127.0.0.1", 0))
-print(s.getsockname()[1])
-s.close()
-PY
+  local seed start port attempts=2048
+  seed="${HARNESS_PORT_SEED:-$$}"
+  if [[ ! "$seed" =~ ^[0-9]+$ ]]; then
+    seed="$$"
+  fi
+  start=$((9200 + (seed % 1000)))
+  port="$start"
+
+  while (( attempts > 0 )); do
+    if ! lsof -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+      printf '%s\n' "$port"
+      return 0
+    fi
+    port=$((port + 1))
+    if (( port > 65535 )); then
+      port=9200
+    fi
+    attempts=$((attempts - 1))
+  done
+
+  echo "unable to find a free TCP port for harness startup" >&2
+  return 1
 }
 
 harness_tmp_root() {

--- a/scripts/harness/workload/base_path_divergent_cwd.sh
+++ b/scripts/harness/workload/base_path_divergent_cwd.sh
@@ -6,15 +6,15 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
 
-RUN_ID="${RUN_ID:-base-path-dual-root-$(date +%Y%m%d_%H%M%S)-$$}"
-RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/base_path_dual_root/$RUN_ID}"
+RUN_ID="${RUN_ID:-base-path-divergent-cwd-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/base_path_divergent_cwd/$RUN_ID}"
 mkdir -p "$RUN_DIR"
 
 PORT="${PORT:-$(harness_pick_free_port)}"
 SERVER_EXE="${SERVER_EXE:-}"
-CONFIG_DIR="${CONFIG_DIR:-$REPO_ROOT/config}"
+CONFIG_DIR="${CONFIG_DIR:-}"
 CWD_PATH="${CWD_PATH:-$REPO_ROOT}"
-BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-dual-root.${RUN_ID}.XXXXXX")}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-divergent-cwd.${RUN_ID}.XXXXXX")}"
 SERVER_LOG="${SERVER_LOG:-$RUN_DIR/server.log}"
 HEALTH_JSON="${HEALTH_JSON:-$RUN_DIR/health.json}"
 KEEP_SERVER="${KEEP_SERVER:-0}"
@@ -22,10 +22,11 @@ KEEP_PATHS="${KEEP_PATHS:-0}"
 
 TEMP_BASE_PATH=""
 TEMP_CWD_PATH=""
+TEMP_CONFIG_DIR=""
 SERVER_PID=""
 
 log() {
-  printf '[dual-root-guard] %s\n' "$*" >&2
+  printf '[divergent-cwd] %s\n' "$*" >&2
 }
 
 canonical_path() {
@@ -50,9 +51,11 @@ cleanup() {
   if [[ "$KEEP_PATHS" != "1" ]]; then
     [[ -n "$TEMP_BASE_PATH" && -d "$TEMP_BASE_PATH" ]] && rm -rf "$TEMP_BASE_PATH" || true
     [[ -n "$TEMP_CWD_PATH" && -d "$TEMP_CWD_PATH" ]] && rm -rf "$TEMP_CWD_PATH" || true
+    [[ -n "$TEMP_CONFIG_DIR" && -d "$TEMP_CONFIG_DIR" ]] && rm -rf "$TEMP_CONFIG_DIR" || true
   else
     [[ -n "$TEMP_BASE_PATH" ]] && log "keeping base_path fixture: $TEMP_BASE_PATH" || true
     [[ -n "$TEMP_CWD_PATH" ]] && log "keeping cwd fixture: $TEMP_CWD_PATH" || true
+    [[ -n "$TEMP_CONFIG_DIR" ]] && log "keeping config fixture: $TEMP_CONFIG_DIR" || true
   fi
   return 0
 }
@@ -62,7 +65,19 @@ trap cleanup EXIT
 command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
 command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
 
-if [[ ! -d "$CONFIG_DIR" ]]; then
+if [[ -z "$CONFIG_DIR" ]]; then
+  CONFIG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/masc-divergent-config.${RUN_ID}.XXXXXX")"
+  TEMP_CONFIG_DIR="$CONFIG_DIR"
+  mkdir -p "$CONFIG_DIR/prompts" "$CONFIG_DIR/keepers" "$CONFIG_DIR/personas"
+  if [[ -f "$REPO_ROOT/config/cascade.json" ]]; then
+    cp "$REPO_ROOT/config/cascade.json" "$CONFIG_DIR/cascade.json"
+  else
+    printf '{}\n' >"$CONFIG_DIR/cascade.json"
+  fi
+  if [[ -f "$REPO_ROOT/config/tool_policy.toml" ]]; then
+    cp "$REPO_ROOT/config/tool_policy.toml" "$CONFIG_DIR/tool_policy.toml"
+  fi
+elif [[ ! -d "$CONFIG_DIR" ]]; then
   echo "CONFIG_DIR does not exist: $CONFIG_DIR" >&2
   exit 1
 fi
@@ -95,17 +110,19 @@ log "port=$PORT"
   export MASC_CONFIG_DIR="$CONFIG_DIR"
   export MASC_PERSONAS_DIR="$CONFIG_DIR/personas"
   export MASC_STORAGE_TYPE="filesystem"
+  export MASC_BASE_PATH_STRICT="1"
+  export MASC_KEEPER_BOOTSTRAP_ENABLED="0"
   export MASC_AUTONOMY_ENABLED="0"
   export MASC_ORCHESTRATOR_ENABLED="0"
+  export MASC_WS_ENABLED="0"
+  export MASC_WEBRTC_ENABLED="0"
+  export GRAPHQL_API_KEY=""
+  export GRAPHQL_URL="http://127.0.0.1:9/graphql"
   exec "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH"
 ) >"$SERVER_LOG" 2>&1 &
 SERVER_PID="$!"
 
 if ! harness_wait_for_health "$PORT" 20; then
-  if rg -qi 'dual \.masc roots are not supported|dual \.masc roots are unsupported' "$SERVER_LOG"; then
-    log "pass: dual-root startup was rejected"
-    exit 0
-  fi
   log "server did not become healthy"
   harness_print_log_tail "$SERVER_LOG" 120
   exit 1
@@ -113,11 +130,14 @@ fi
 
 curl -fsS "http://127.0.0.1:${PORT}/health" | jq '.' >"$HEALTH_JSON"
 
-DUAL_ROOTS="$(jq -r '.paths.dual_masc_roots // false' "$HEALTH_JSON")"
 ROOTS_DIVERGE="$(jq -r '.paths.roots_diverge // false' "$HEALTH_JSON")"
 HEALTH_CWD="$(jq -r '.paths.cwd // ""' "$HEALTH_JSON")"
 HEALTH_BASE_PATH="$(jq -r '.paths.effective_base_path // ""' "$HEALTH_JSON")"
 HEALTH_WARNING="$(jq -r '.paths.warning // ""' "$HEALTH_JSON")"
+STRICT_MODE_REQUESTED="$(jq -r '.paths.strict_mode_requested // false' "$HEALTH_JSON")"
+STARTUP_REJECTED="$(jq -r '.paths.startup_rejected // false' "$HEALTH_JSON")"
+STARTUP_ABORT_ELIGIBLE="$(jq -r '.paths.startup_abort_eligible // false' "$HEALTH_JSON")"
+STRICT_VIOLATION="$(jq -r '.paths.strict_violation // false' "$HEALTH_JSON")"
 CONFIG_ROOT="$(jq -r '.startup.config_resolution.config_root.path // ""' "$HEALTH_JSON")"
 EXPECTED_CWD="$(canonical_path "$CWD_PATH")"
 EXPECTED_BASE_PATH="$(canonical_path "$BASE_PATH")"
@@ -150,13 +170,34 @@ if [[ "$(canonical_path "$CONFIG_ROOT")" != "$EXPECTED_CONFIG_DIR" ]]; then
   exit 1
 fi
 
-echo "FAIL: server became healthy under a dual-root fixture" >&2
-echo "  cwd=$HEALTH_CWD" >&2
-echo "  effective_base_path=$HEALTH_BASE_PATH" >&2
-echo "  dual_masc_roots=$DUAL_ROOTS" >&2
-echo "  roots_diverge=$ROOTS_DIVERGE" >&2
-if [[ -n "$HEALTH_WARNING" ]]; then
-  echo "  warning=$HEALTH_WARNING" >&2
+if [[ "$ROOTS_DIVERGE" != "true" ]]; then
+  echo "FAIL: expected roots_diverge=true, got $ROOTS_DIVERGE" >&2
+  exit 1
 fi
-echo "  health_json=$HEALTH_JSON" >&2
-exit 1
+
+if [[ "$STRICT_MODE_REQUESTED" != "true" ]]; then
+  echo "FAIL: expected strict_mode_requested=true, got $STRICT_MODE_REQUESTED" >&2
+  exit 1
+fi
+
+if [[ "$STARTUP_REJECTED" != "false" ]]; then
+  echo "FAIL: expected startup_rejected=false, got $STARTUP_REJECTED" >&2
+  exit 1
+fi
+
+if [[ "$STARTUP_ABORT_ELIGIBLE" != "false" ]]; then
+  echo "FAIL: expected startup_abort_eligible=false, got $STARTUP_ABORT_ELIGIBLE" >&2
+  exit 1
+fi
+
+if [[ "$STRICT_VIOLATION" != "false" ]]; then
+  echo "FAIL: expected strict_violation=false, got $STRICT_VIOLATION" >&2
+  exit 1
+fi
+
+if [[ -n "$HEALTH_WARNING" ]]; then
+  echo "FAIL: expected no health warning, got: $HEALTH_WARNING" >&2
+  exit 1
+fi
+
+log "pass: divergent cwd remains observational under strict mode"

--- a/scripts/harness_base_path_divergent_cwd.sh
+++ b/scripts/harness_base_path_divergent_cwd.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$SCRIPT_DIR/harness/workload/base_path_dual_root_guard.sh" "$@"
+exec "$SCRIPT_DIR/harness/workload/base_path_divergent_cwd.sh" "$@"

--- a/test/dune
+++ b/test/dune
@@ -558,6 +558,11 @@
    (run %{test})))
  (libraries masc_test_deps))
 
+(test
+ (name test_cascade_runtime)
+ (modules test_cascade_runtime)
+ (libraries masc_test_deps))
+
 ; ── Tool_name variant roundtrip + coverage ──────────────
 (test
  (name test_tool_name)

--- a/test/test_cascade_runtime.ml
+++ b/test/test_cascade_runtime.ml
@@ -1,0 +1,42 @@
+open Alcotest
+
+let provider_kinds providers =
+  List.map
+    (fun (cfg : Llm_provider.Provider_config.t) ->
+      Llm_provider.Provider_config.string_of_provider_kind cfg.kind)
+    providers
+
+let direct_model_strings =
+  [ "ollama:local-model"
+  ; "custom:remote-model@http://127.0.0.1:18080/v1"
+  ]
+
+let test_provider_filter_is_applied_to_direct_model_strings () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~provider_filter:[ "openai_compat" ]
+      direct_model_strings
+  in
+  check (list string) "filtered to requested provider kind"
+    [ "openai_compat" ] (provider_kinds providers)
+
+let test_provider_filter_falls_back_to_unfiltered_when_no_match () =
+  let providers =
+    Masc_mcp.Cascade_runtime.resolve_providers_from_model_strings
+      ~provider_filter:[ "gemini" ]
+      direct_model_strings
+  in
+  check (list string) "no-match filter falls back to unfiltered providers"
+    [ "ollama"; "openai_compat" ] (provider_kinds providers)
+
+let () =
+  run "Cascade_runtime"
+    [
+      ( "provider_filter",
+        [
+          test_case "applies direct model string filter" `Quick
+            test_provider_filter_is_applied_to_direct_model_strings;
+          test_case "falls back when filter matches nothing" `Quick
+            test_provider_filter_falls_back_to_unfiltered_when_no_match;
+        ] );
+    ]

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -335,7 +335,6 @@ let with_seeded_server f =
       ; "GRAPHQL_API_KEY", ""
       ; "GRAPHQL_URL", "http://127.0.0.1:9/graphql"
       ; "MASC_BASE_PATH", base_path
-      ; "MASC_ALLOW_INHERITED_BASE_PATH", "1"
       ; "MASC_POSTGRES_URL", ""
       ; "DATABASE_URL", ""
       ; "SUPABASE_DB_URL", ""

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -171,9 +171,8 @@ let test_resolve_masc_base_path_ignores_explicit_env_without_opt_in () =
       check string "explicit env ignored without opt-in" requested
         (Coord_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_ignores_explicit_env_with_dual_masc_roots ()
-    =
-  let scratch = Filename.temp_dir "room-utils-dual-roots" "" in
+let test_resolve_masc_base_path_ignores_explicit_env_with_local_masc_dir () =
+  let scratch = Filename.temp_dir "room-utils-local-masc" "" in
   let requested = Filename.concat scratch "repo" in
   let explicit = Filename.concat scratch "parent-root" in
   Unix.mkdir requested 0o755;
@@ -187,11 +186,11 @@ let test_resolve_masc_base_path_ignores_explicit_env_with_dual_masc_roots ()
         [ ("MASC_BASE_PATH", Some explicit);
           ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
         (fun () ->
-          check string "dual roots still honor requested path in tests" requested
+          check string "local .masc still honors requested path in tests" requested
             (Coord_utils.resolve_masc_base_path requested)))
 
-let test_resolve_masc_base_path_dual_root_opt_in_preserves_explicit_env () =
-  let scratch = Filename.temp_dir "room-utils-dual-opt-in" "" in
+let test_resolve_masc_base_path_opt_in_preserves_explicit_env () =
+  let scratch = Filename.temp_dir "room-utils-explicit-opt-in" "" in
   let requested = Filename.concat scratch "repo" in
   let explicit = Filename.concat scratch "parent-root" in
   Unix.mkdir requested 0o755;
@@ -205,7 +204,7 @@ let test_resolve_masc_base_path_dual_root_opt_in_preserves_explicit_env () =
         [ ("MASC_BASE_PATH", Some explicit);
           ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", Some "true") ]
         (fun () ->
-          check string "dual-root opt-in preserves explicit path" explicit
+          check string "opt-in preserves explicit path" explicit
             (Coord_utils.resolve_masc_base_path requested)))
 
 let test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in () =
@@ -623,10 +622,10 @@ let () =
         test_resolve_masc_base_path_collapses_explicit_env_masc_dir;
       test_case "ignores explicit env without opt-in" `Quick
         test_resolve_masc_base_path_ignores_explicit_env_without_opt_in;
-      test_case "ignores explicit env with dual .masc roots" `Quick
-        test_resolve_masc_base_path_ignores_explicit_env_with_dual_masc_roots;
-      test_case "dual-root opt-in preserves explicit env" `Quick
-        test_resolve_masc_base_path_dual_root_opt_in_preserves_explicit_env;
+      test_case "ignores explicit env when requested path has local .masc" `Quick
+        test_resolve_masc_base_path_ignores_explicit_env_with_local_masc_dir;
+      test_case "opt-in preserves explicit env" `Quick
+        test_resolve_masc_base_path_opt_in_preserves_explicit_env;
       test_case "ignores ancestor explicit path without opt-in" `Quick
         test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in;
       test_case "default config syncs test base env" `Quick

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -46,20 +46,7 @@ let canonical_path path =
   try Unix.realpath path with
   | Unix.Unix_error _ -> path
 
-let string_contains ~needle haystack =
-  let needle_len = String.length needle in
-  let hay_len = String.length haystack in
-  let rec loop idx =
-    if idx + needle_len > hay_len then
-      false
-    else if String.sub haystack idx needle_len = needle then
-      true
-    else
-      loop (idx + 1)
-  in
-  if needle_len = 0 then true else loop 0
-
-let test_detects_dual_masc_roots () =
+let test_divergent_cwd_is_observational_only () =
   with_temp_dir "base-path-diag" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -79,26 +66,10 @@ let test_detects_dual_masc_roots () =
       ()
   in
   Alcotest.(check bool) "roots diverge" true diag.roots_diverge;
-  Alcotest.(check bool) "dual roots" true diag.dual_masc_roots;
-  Alcotest.(check bool) "cwd .masc exists" true diag.cwd_has_masc_dir;
   Alcotest.(check bool) "effective .masc exists" true diag.effective_has_masc_dir;
-  Alcotest.(check bool) "warning present" true (Option.is_some diag.warning);
-  Alcotest.(check (list string)) "cwd legacy dirs" [ "perpetual" ]
-    diag.cwd_legacy_dirs;
-  Alcotest.(check bool) "warning mentions ignored legacy dirs" true
-    (match diag.warning with
-     | Some warning ->
-         string_contains ~needle:"ignored cwd .masc still contains legacy dirs (perpetual)"
-           warning
-     | None -> false)
+  Alcotest.(check bool) "warning removed" false (Option.is_some diag.warning)
 
-let test_implicit_dual_roots_are_strict_violation () =
-  (* When [effective_base_path] was derived from a cwd heuristic
-     (no [input_base_path], no [resolution_source] → implicit), a
-     dual-.masc-root situation forces fail-fast even if the operator
-     did not explicitly opt in via [MASC_BASE_PATH_STRICT]. Cwd
-     heuristics are unreliable enough that "start the server next to
-     two different .masc trees" is unambiguously an operator error. *)
+let test_divergent_cwd_is_not_a_strict_violation () =
   with_temp_dir "base-path-strict" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -115,28 +86,14 @@ let test_implicit_dual_roots_are_strict_violation () =
   in
   Alcotest.(check bool) "strict_mode_requested stays false" false
     diag.strict_mode_requested;
-  Alcotest.(check bool) "startup_rejected derived from implicit dual roots" true
+  Alcotest.(check bool) "startup_rejected stays false" false
     diag.startup_rejected;
-  Alcotest.(check bool) "startup_abort_eligible derived from implicit dual roots" true
+  Alcotest.(check bool) "startup_abort_eligible stays false" false
     diag.startup_abort_eligible;
-  Alcotest.(check bool) "implicit dual roots violate" true
+  Alcotest.(check bool) "divergent cwd does not violate" false
     (Server_base_path_diagnostics.strict_violation diag)
 
-let test_explicit_resolution_source_escapes_strict_violation () =
-  (* When the operator/test-harness explicitly set MASC_BASE_PATH (or
-     passed --base-path on the CLI), the runtime trusts that decision
-     and uses the explicit path — the warning still fires so operator
-     tools can flag the stale cwd .masc tree, but strict_violation
-     must return false so the server keeps running.
-
-     Pre-#6548 behavior had this escape via the
-     [not explicit_resolution_source] clause in [strict_violation].
-     #6548 flattened [strict_violation] to just [dual_masc_roots],
-     which broke the [Run SSE reconnect e2e] CI step because the test
-     harness runs from a git worktree (with its own committed
-     .masc/) while pointing at a tmp [/tmp/sse-storm-base-<hex>]
-     MASC_BASE_PATH. The fix restores the escape for explicit
-     resolution sources. *)
+let test_explicit_env_resolution_remains_observational_only () =
   with_temp_dir "base-path-explicit" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -154,25 +111,18 @@ let test_explicit_resolution_source_escapes_strict_violation () =
       ~effective_masc_root:(Filename.concat effective ".masc")
       ()
   in
-  Alcotest.(check bool) "dual roots still detected" true diag.dual_masc_roots;
-  Alcotest.(check bool) "warning still present" true
+  Alcotest.(check bool) "warning removed" false
     (Option.is_some diag.warning);
   Alcotest.(check bool) "strict_mode_requested reflects user STRICT=true" true
     diag.strict_mode_requested;
   Alcotest.(check bool) "startup_rejected false for explicit env source" false
     diag.startup_rejected;
-  Alcotest.(check bool) "startup_abort_eligible remains true under strict mode" true
+  Alcotest.(check bool) "startup_abort_eligible remains false" false
     diag.startup_abort_eligible;
-  Alcotest.(check bool) "explicit env source escapes violation" false
+  Alcotest.(check bool) "explicit env source stays non-violating" false
     (Server_base_path_diagnostics.strict_violation diag)
 
-let test_explicit_cli_resolution_source_also_escapes () =
-  (* Symmetric with [test_explicit_resolution_source_escapes_strict_violation]
-     but drives [resolution_source:"explicit_cli"]. [explicit_resolution_source]
-     pattern-matches on both ["explicit_env"] and ["explicit_cli"], so both
-     must take the escape branch. This test guards against a future
-     refactor that splits those literals into separate code paths and
-     accidentally drops the CLI case. *)
+let test_explicit_cli_resolution_source_remains_observational_only () =
   with_temp_dir "base-path-explicit-cli" @@ fun root ->
   let cwd = Filename.concat root "repo" in
   let effective = Filename.concat root "workspace" in
@@ -189,14 +139,13 @@ let test_explicit_cli_resolution_source_also_escapes () =
       ~effective_masc_root:(Filename.concat effective ".masc")
       ()
   in
-  Alcotest.(check bool) "dual roots still detected" true diag.dual_masc_roots;
   Alcotest.(check bool) "strict_mode_requested false without user STRICT" false
     diag.strict_mode_requested;
   Alcotest.(check bool) "startup_rejected false for explicit cli source" false
     diag.startup_rejected;
   Alcotest.(check bool) "startup_abort_eligible false without user STRICT" false
     diag.startup_abort_eligible;
-  Alcotest.(check bool) "explicit cli source escapes violation" false
+  Alcotest.(check bool) "explicit cli source stays non-violating" false
     (Server_base_path_diagnostics.strict_violation diag)
 
 let test_to_yojson_exposes_effective_paths () =
@@ -216,8 +165,8 @@ let test_to_yojson_exposes_effective_paths () =
     (json |> member "effective_masc_root" |> to_string);
   Alcotest.(check bool) "roots diverge field" true
     (json |> member "roots_diverge" |> to_bool);
-  Alcotest.(check int) "cwd legacy dirs exposed" 0
-    (json |> member "cwd_legacy_dirs" |> to_list |> List.length);
+  Alcotest.(check bool) "cwd legacy dirs removed" true
+    (match json |> member "cwd_legacy_dirs" with `Null -> true | _ -> false);
   Alcotest.(check int) "effective legacy dirs exposed" 0
     (json |> member "effective_legacy_dirs" |> to_list |> List.length)
 
@@ -316,18 +265,18 @@ let () =
     [
       ( "diagnostics",
         [
-          Alcotest.test_case "detects dual .masc roots" `Quick
-            test_detects_dual_masc_roots;
-          Alcotest.test_case "implicit dual roots are strict violation" `Quick
-            test_implicit_dual_roots_are_strict_violation;
+          Alcotest.test_case "divergent cwd is observational only" `Quick
+            test_divergent_cwd_is_observational_only;
+          Alcotest.test_case "divergent cwd is not strict violation" `Quick
+            test_divergent_cwd_is_not_a_strict_violation;
           Alcotest.test_case
-            "explicit env resolution source escapes strict violation"
+            "explicit env resolution remains observational only"
             `Quick
-            test_explicit_resolution_source_escapes_strict_violation;
+            test_explicit_env_resolution_remains_observational_only;
           Alcotest.test_case
-            "explicit cli resolution source also escapes"
+            "explicit cli resolution remains observational only"
             `Quick
-            test_explicit_cli_resolution_source_also_escapes;
+            test_explicit_cli_resolution_source_remains_observational_only;
           Alcotest.test_case "json exposes effective paths" `Quick
             test_to_yojson_exposes_effective_paths;
           Alcotest.test_case "json exposes resolution source" `Quick

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -322,7 +322,7 @@ let test_default_base_path_falls_back_to_home_when_unset () =
         (contains_substring captured
            ("MASC_CONFIG_DIR=" ^ Filename.concat expected_home ".masc/config")))
 
-let test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved () =
+let test_absolute_inherited_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
@@ -340,7 +340,6 @@ let test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved () =
               ("FAKE_CAPTURE_FILE", capture);
               ("HOME", home_dir);
               ("MASC_BASE_PATH", stale_root);
-              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
             ]
           (Printf.sprintf "%s --http --port 9960" (quote script))
       in
@@ -352,7 +351,7 @@ let test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved () =
       check bool "absolute inherited base path preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
-let test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved () =
+let test_absolute_parent_project_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let parent = Filename.concat dir "parent-root" in
       let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
@@ -372,7 +371,6 @@ let test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved () 
               ("FAKE_CAPTURE_FILE", capture);
               ("HOME", home_dir);
               ("MASC_BASE_PATH", parent);
-              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
             ]
           (Printf.sprintf "%s --http --port 9963" (quote script))
       in
@@ -384,7 +382,7 @@ let test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved () 
       check bool "absolute parent root inheritance preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
-let test_zshenv_absolute_base_path_with_dual_roots_is_preserved () =
+let test_zshenv_absolute_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let parent = Filename.concat dir "parent-root" in
       let repo = Filename.concat parent "workspace/yousleepwhen/masc-mcp" in
@@ -405,7 +403,6 @@ let test_zshenv_absolute_base_path_with_dual_roots_is_preserved () =
             [
               ("FAKE_CAPTURE_FILE", capture);
               ("HOME", home_dir);
-              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
             ]
           (Printf.sprintf "%s --http --port 9965" (quote script))
       in
@@ -417,7 +414,7 @@ let test_zshenv_absolute_base_path_with_dual_roots_is_preserved () =
       check bool "zshenv absolute base path preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
-let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
+let test_shared_root_inherited_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
@@ -435,7 +432,6 @@ let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
               ("FAKE_CAPTURE_FILE", capture);
               ("HOME", home_dir);
               ("MASC_BASE_PATH", inherited_root);
-              ("MASC_ALLOW_INHERITED_BASE_PATH", "1");
             ]
           (Printf.sprintf "%s --http --port 9964" (quote script))
       in
@@ -444,7 +440,7 @@ let test_dual_masc_roots_opt_in_preserves_inherited_base_path () =
           stderr;
       let captured = read_file capture in
       let expected_root = canonical_path inherited_root in
-      check bool "opt-in preserves inherited base path" true
+      check bool "shared-root inherited base path preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
@@ -500,7 +496,6 @@ let test_explicit_base_path_execs_from_base_path () =
               ("FAKE_CAPTURE_FILE", capture);
               ("HOME", home_dir);
               ("MASC_BASE_PATH", parent);
-              ("MASC_ALLOW_INHERITED_BASE_PATH", "");
             ]
           (Printf.sprintf "%s --http --port 9966 --base-path %s"
              (quote script) (quote parent))
@@ -704,13 +699,13 @@ let () =
           test_case "default base path falls back to home when unset" `Quick
             test_default_base_path_falls_back_to_home_when_unset;
           test_case
-            "absolute inherited base path with dual .masc roots is preserved"
+            "absolute inherited base path is preserved"
             `Quick
-            test_absolute_inherited_base_path_with_dual_masc_roots_is_preserved;
+            test_absolute_inherited_base_path_is_preserved;
           test_case
             "absolute parent project inherited base path is preserved"
             `Quick
-            test_absolute_parent_project_base_path_with_dual_masc_roots_is_preserved;
+            test_absolute_parent_project_base_path_is_preserved;
           test_case "explicit base path execs from base path" `Quick
             test_explicit_base_path_execs_from_base_path;
           test_case
@@ -726,9 +721,9 @@ let () =
           test_case "grpc-direct banner is preserved in stderr" `Quick
             test_grpc_direct_banner_is_preserved_in_stderr;
           test_case "zshenv absolute base path is preserved" `Quick
-            test_zshenv_absolute_base_path_with_dual_roots_is_preserved;
-          test_case "dual roots opt-in preserves inherited base path" `Quick
-            test_dual_masc_roots_opt_in_preserves_inherited_base_path;
+            test_zshenv_absolute_base_path_is_preserved;
+          test_case "shared-root inherited base path is preserved" `Quick
+            test_shared_root_inherited_base_path_is_preserved;
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
           test_case


### PR DESCRIPTION
## What changed
- apply `provider_filter` during cascade provider resolution so named cascades and direct model-string resolution honor the configured provider allowlist
- remove the dashboard monitor hardcoded context threshold and read `runtime_warning_ctx_ratio` from the server payload instead
- remove the remaining dual-root runtime behavior and rename residual tests and harnesses to `divergent_cwd` / inherited-base-path semantics
- replace the old dual-root workload harness with a divergent-cwd harness and make harness free-port selection shell-only so it works in restricted environments

## Why
- `provider_filter` was passed down from keeper runtime paths but dropped before cascade resolution, so runtime behavior did not match the documented filter semantics
- the dashboard monitor used a client-side hardcoded threshold that could disagree with server health settings
- dual-root support had already been retired, but runtime text, tests, and harness names still assumed it existed

## Impact
- cascade execution now respects the intended provider filter SSOT
- dashboard attention hints now match the server-provided warning threshold
- base-path diagnostics treat divergent cwd as observational only, and the test/harness surface now matches that policy

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/remove-dual-root test/test_room_utils_coverage.exe test/test_start_masc_mcp_script.exe test/test_dashboard_keeper_routes.exe`
- `./_build/default/test/test_room_utils_coverage.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_dashboard_keeper_routes.exe`
- `./scripts/harness_base_path_divergent_cwd.sh`
- previously verified in this worktree: `pnpm tsc --noEmit --pretty false`, dashboard vitest targets, `test_cascade_runtime`, `test_dashboard_cascade`, `test_dashboard_http_core`, `test_server_base_path_diagnostics`, `test_server_runtime_bootstrap`

## Root cause
- filter state and threshold state each had separate client/runtime paths, and the removed dual-root policy still had stale naming and harness assumptions around it.