### PR TITLE
[codex] Type OAS worker boundary failures

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -101,13 +101,7 @@ let is_required_tool_contract_violation (err : Oas.Error.sdk_error) : bool =
            ~needle:"tool_choice requested tool use"
            lower
          && string_contains_substring ~needle:"no tooluse block" lower
-  | _ ->
-      let lower = String.lowercase_ascii (Oas.Error.to_string err) in
-      string_contains_substring
-        ~needle:"completion contract [require_tool_use] violated"
-        lower
-      || ( string_contains_substring ~needle:"tool_choice requested tool use" lower
-           && string_contains_substring ~needle:"no tooluse block" lower )
+  | _ -> false
 
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err
@@ -244,14 +238,7 @@ let is_cascade_exhausted_error (err : Oas.Error.sdk_error) : bool =
   match Oas_worker_named.classify_masc_internal_error err with
   | Some (Oas_worker_named.Cascade_exhausted _)
   | Some (Oas_worker_named.Accept_rejected _) -> true
-  | None ->
-      match err with
-      | Oas.Error.Internal msg ->
-          string_contains_substring_ci
-            ~needle:"all models failed" msg
-          || string_contains_substring_ci
-               ~needle:"response rejected by accept" msg
-      | _ -> false
+  | None -> false
 
 type overflow_retry_plan = {
   retry_max_context : int;

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -93,12 +93,21 @@ let is_server_rejected_parse_error (err : Oas.Error.sdk_error) : bool =
   | _ -> false
 
 let is_required_tool_contract_violation (err : Oas.Error.sdk_error) : bool =
-  let lower = String.lowercase_ascii (Oas.Error.to_string err) in
-  string_contains_substring
-    ~needle:"completion contract [require_tool_use] violated"
-    lower
-  || ( string_contains_substring ~needle:"tool_choice requested tool use" lower
-       && string_contains_substring ~needle:"no tooluse block" lower )
+  match err with
+  | Oas.Error.Agent (Oas.Error.CompletionContractViolation { contract; reason }) ->
+      String.equal contract "require_tool_use"
+      || let lower = String.lowercase_ascii reason in
+         string_contains_substring
+           ~needle:"tool_choice requested tool use"
+           lower
+         && string_contains_substring ~needle:"no tooluse block" lower
+  | _ ->
+      let lower = String.lowercase_ascii (Oas.Error.to_string err) in
+      string_contains_substring
+        ~needle:"completion contract [require_tool_use] violated"
+        lower
+      || ( string_contains_substring ~needle:"tool_choice requested tool use" lower
+           && string_contains_substring ~needle:"no tooluse block" lower )
 
 let is_auto_recoverable_turn_error (err : Oas.Error.sdk_error) : bool =
   is_transient_network_error err
@@ -232,13 +241,17 @@ let is_context_overflow (err : Oas.Error.sdk_error) : bool =
   | _ -> false
 
 let is_cascade_exhausted_error (err : Oas.Error.sdk_error) : bool =
-  match err with
-  | Oas.Error.Internal msg ->
-      string_contains_substring_ci
-        ~needle:"all models failed" msg
-      || string_contains_substring_ci
-           ~needle:"response rejected by accept" msg
-  | _ -> false
+  match Oas_worker_named.classify_masc_internal_error err with
+  | Some (Oas_worker_named.Cascade_exhausted _)
+  | Some (Oas_worker_named.Accept_rejected _) -> true
+  | None ->
+      match err with
+      | Oas.Error.Internal msg ->
+          string_contains_substring_ci
+            ~needle:"all models failed" msg
+          || string_contains_substring_ci
+               ~needle:"response rejected by accept" msg
+      | _ -> false
 
 type overflow_retry_plan = {
   retry_max_context : int;

--- a/lib/keeper/keeper_unified_turn.mli
+++ b/lib/keeper/keeper_unified_turn.mli
@@ -121,6 +121,10 @@ val is_ambiguous_side_effect_error : Oas.Error.sdk_error -> bool
 (** [true] when a structured error indicates context overflow. *)
 val is_context_overflow : Oas.Error.sdk_error -> bool
 
+(** [true] when an error represents terminal cascade exhaustion or a
+    final accept-rejected result from the MASC OAS boundary. *)
+val is_cascade_exhausted_error : Oas.Error.sdk_error -> bool
+
 (** Resolve the initial keeper turn context budget.
     Uses the first available model in the cascade rather than the largest
     fallback model, so lifecycle context math matches the provider that will

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -123,17 +123,30 @@ let proof_result_status_to_string status =
     Explicit model-label execution must never silently substitute a
     discovery-only model. Callers are expected to validate labels
     before reaching this helper. *)
-let resolve_provider_of_label (label : string) : Oas.Provider.config =
+type label_resolution_error =
+  | Invalid_model_label of string
+
+let label_resolution_error_to_string = function
+  | Invalid_model_label label ->
+    Printf.sprintf "invalid model label %S" label
+
+let label_resolution_error_to_sdk_error err =
+  Oas.Error.Config
+    (Oas.Error.InvalidConfig
+       {
+         field = "model_label";
+         detail = label_resolution_error_to_string err;
+       })
+
+let resolve_provider_of_label (label : string) :
+    (Oas.Provider.config, label_resolution_error) result =
   match Cascade_config.parse_model_string label with
-  | Some pc -> Oas.Provider.config_of_provider_config pc
+  | Some pc -> Ok (Oas.Provider.config_of_provider_config pc)
   | None ->
       Log.error ~ctx:"oas_worker_exec"
         "refusing unresolved explicit model label=%S; execution never falls back to discovery-only models"
         label;
-      invalid_arg
-        (Printf.sprintf
-           "Oas_worker_exec.resolve_provider_of_label: invalid model label %S"
-           label)
+      Error (Invalid_model_label label)
 
 (* ================================================================ *)
 (* Internal: event publishing                                        *)

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -7,6 +7,8 @@
 
     @since God file decomposition — extracted from oas_worker.ml *)
 
+open Result_syntax
+
 (* ================================================================ *)
 (* Cascade profile defaults (moved from Cascade module)              *)
 (* ================================================================ *)
@@ -41,6 +43,10 @@ let admission_wait_timeout_error
   Log.Misc.warn "%s" msg;
   Error (Oas.Error.Internal msg)
 
+let eio_context_error_to_sdk_error detail =
+  Oas.Error.Config
+    (Oas.Error.InvalidConfig { field = "eio_context"; detail })
+
 (** Resolve cascade provider configs via MASC Cascade_config.
     Returns Provider_config.t list for the downstream OAS runtime,
     bypassing the old Model_spec facade. *)
@@ -51,6 +57,86 @@ let resolve_cascade_providers = Cascade_runtime.resolve_named_providers
     resulting provider configs into OAS execution. *)
 let resolve_providers_from_model_strings =
   Cascade_runtime.resolve_providers_from_model_strings
+
+type masc_internal_error =
+  | Cascade_exhausted of {
+      cascade_name : string;
+      detail : string option;
+    }
+  | Accept_rejected of {
+      scope : string;
+      model : string option;
+      reason : string;
+    }
+
+let masc_internal_error_prefix = "[masc_oas_error] "
+
+let string_opt_of_assoc key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`String value) -> Some value
+      | _ -> None)
+  | _ -> None
+
+let masc_internal_error_to_json = function
+  | Cascade_exhausted { cascade_name; detail } ->
+    `Assoc
+      [
+        ("kind", `String "cascade_exhausted");
+        ("cascade_name", `String cascade_name);
+        ("detail", Json_util.string_opt_to_json detail);
+      ]
+  | Accept_rejected { scope; model; reason } ->
+    `Assoc
+      [
+        ("kind", `String "accept_rejected");
+        ("scope", `String scope);
+        ("model", Json_util.string_opt_to_json model);
+        ("reason", `String reason);
+      ]
+
+let sdk_error_of_masc_internal_error err =
+  Oas.Error.Internal
+    (masc_internal_error_prefix ^ Yojson.Safe.to_string (masc_internal_error_to_json err))
+
+let classify_masc_internal_error (err : Oas.Error.sdk_error) :
+    masc_internal_error option =
+  match err with
+  | Oas.Error.Internal msg when String.starts_with ~prefix:masc_internal_error_prefix msg ->
+    let payload =
+      String.sub msg
+        (String.length masc_internal_error_prefix)
+        (String.length msg - String.length masc_internal_error_prefix)
+    in
+    (try
+       match Yojson.Safe.from_string payload with
+       | `Assoc fields as json -> (
+           match List.assoc_opt "kind" fields with
+           | Some (`String "cascade_exhausted") -> (
+               match string_opt_of_assoc "cascade_name" json with
+               | Some cascade_name ->
+                 Some
+                   (Cascade_exhausted
+                      {
+                        cascade_name;
+                        detail = string_opt_of_assoc "detail" json;
+                      })
+               | None -> None)
+           | Some (`String "accept_rejected") -> (
+               match string_opt_of_assoc "scope" json, string_opt_of_assoc "reason" json with
+               | Some scope, Some reason ->
+                 Some
+                   (Accept_rejected
+                      {
+                        scope;
+                        model = string_opt_of_assoc "model" json;
+                        reason;
+                      })
+               | _ -> None)
+           | _ -> None)
+       | _ -> None
+     with Yojson.Json_error _ -> None)
+  | _ -> None
 
 let config_for_label
     ~(name : string)
@@ -73,8 +159,11 @@ let config_for_label
     ?contract
     ?approval
     ~(description : string option)
-    () : Oas_worker_exec.config =
-  let provider = Oas_worker_exec.resolve_provider_of_label model_label in
+    () : (Oas_worker_exec.config, Oas.Error.sdk_error) result =
+  let* provider =
+    Oas_worker_exec.resolve_provider_of_label model_label
+    |> Result.map_error Oas_worker_exec.label_resolution_error_to_sdk_error
+  in
   let model_id = match Cascade_runtime.provider_name_of_label model_label with
     | Some _ ->
       (match String.index_opt model_label ':' with
@@ -82,27 +171,28 @@ let config_for_label
        | None -> model_label)
     | None -> model_label
   in
-  {
-    (Oas_worker_exec.default_config ~name ~provider ~model_id
-       ~system_prompt ~tools)
-    with
-    max_turns;
-    max_tokens;
-    max_input_tokens;
-    max_cost_usd;
-    temperature;
-    max_idle_turns;
-    guardrails;
-    hooks;
-    context_reducer;
-    memory;
-    tool_retry_policy;
-    enable_thinking;
-    contract;
-    description;
-    compact_ratio;
-    approval;
-  }
+  Ok
+    {
+      (Oas_worker_exec.default_config ~name ~provider ~model_id
+         ~system_prompt ~tools)
+      with
+      max_turns;
+      max_tokens;
+      max_input_tokens;
+      max_cost_usd;
+      temperature;
+      max_idle_turns;
+      guardrails;
+      hooks;
+      context_reducer;
+      memory;
+      tool_retry_policy;
+      enable_thinking;
+      contract;
+      description;
+      compact_ratio;
+      approval;
+    }
 
 (** Convert an OAS sdk_error into a Cascade_fsm provider_outcome.
     API-level errors and model-capability-dependent agent errors are
@@ -204,7 +294,7 @@ let run_named
     ()
   : (Oas_worker_exec.run_result, Oas.Error.sdk_error) result =
   match require_eio ?sw ?net () with
-  | Error e -> Error (Oas.Error.Internal e)
+  | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
   let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let configured_labels, candidate_cfgs =
@@ -222,8 +312,13 @@ let run_named
   match candidate_cfgs with
   | [] ->
     Log.Misc.error "cascade %s: no callable models available" cascade_name;
-    Error (Oas.Error.Internal
-      (Printf.sprintf "cascade %s: no callable models available" cascade_name))
+    Error
+      (sdk_error_of_masc_internal_error
+         (Cascade_exhausted
+            {
+              cascade_name;
+              detail = Some "no callable models available";
+            }))
   | _ ->
   let transport_resolved = match transport with
     | Some t -> t
@@ -310,8 +405,13 @@ let run_named
           ~candidate_cfgs ~selected_model_raw:None ~capture
       in
       Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Failure ~observation:(Some observation);
-      Error (Oas.Error.Internal
-        (Printf.sprintf "cascade %s: all models failed: %s" cascade_name err_msg))
+      Error
+        (sdk_error_of_masc_internal_error
+           (Cascade_exhausted
+              {
+                cascade_name;
+                detail = Some err_msg;
+              }))
     | (provider_cfg : Llm_provider.Provider_config.t) :: rest ->
       let is_last = rest = [] in
       Log.Misc.debug "cascade %s: trying %s (is_last=%b)" cascade_name provider_cfg.model_id is_last;
@@ -356,8 +456,14 @@ let run_named
                ~candidate_cfgs ~selected_model_raw:(Some result.response.model) ~capture
            in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Rejected ~observation:(Some observation);
-           Error (Oas.Error.Internal
-             (Printf.sprintf "cascade %s: %s" cascade_name reason))
+           Error
+             (sdk_error_of_masc_internal_error
+                (Accept_rejected
+                   {
+                     scope = cascade_name;
+                     model = Some result.response.model;
+                     reason;
+                   }))
          | Cascade_fsm.Accept resp ->
            (* Should be unreachable with accept_on_exhaustion:false, but handle gracefully *)
            Log.Misc.warn "cascade %s: unexpected Accept in Accept_rejected branch (model=%s)" cascade_name resp.model;
@@ -433,46 +539,50 @@ let run_model_by_label
     ?net
     ()
   : (Oas_worker_exec.run_result, Oas.Error.sdk_error) result =
-  (match Cascade_config.parse_model_string model_label with
-  | None ->
-    Error (Oas.Error.Internal
-      (Printf.sprintf "Cannot parse model label: %s" model_label))
-  | Some _pc ->
-    match require_eio ?sw ?net () with
-    | Error e -> Error (Oas.Error.Internal e)
-    | Ok (sw, net) ->
-        let transport_resolved = match transport with
-          | Some t -> t
-          | None -> Masc_grpc_transport.from_env ()
-        in
-        let config =
-          config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
-            ~tools ~max_turns ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature
-            ~max_idle_turns ?guardrails ?hooks ?context_reducer ?memory
-            ?tool_retry_policy
-            ?enable_thinking
-            ?compact_ratio
-            ~description:(Some (Printf.sprintf "model_label:%s" model_label))
-            ()
-        in
-        let config = { config with transport = transport_resolved } in
-        try
-          Admission_queue.with_permit ?wait_timeout_sec
-            ~priority:Llm_provider.Request_priority.Proactive
-            ~keeper_name:"oas-label-model"
+  let* config =
+    config_for_label ~name:"oas-label-model" ~model_label ~system_prompt
+      ~tools ~max_turns ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature
+      ~max_idle_turns ?guardrails ?hooks ?context_reducer ?memory
+      ?tool_retry_policy
+      ?enable_thinking
+      ?compact_ratio
+      ~description:(Some (Printf.sprintf "model_label:%s" model_label))
+      ()
+  in
+  match require_eio ?sw ?net () with
+  | Error e -> Error (eio_context_error_to_sdk_error e)
+  | Ok (sw, net) ->
+      let transport_resolved = match transport with
+        | Some t -> t
+        | None -> Masc_grpc_transport.from_env ()
+      in
+      let config = { config with transport = transport_resolved } in
+      try
+        Admission_queue.with_permit ?wait_timeout_sec
+          ~priority:Llm_provider.Request_priority.Proactive
+          ~keeper_name:"oas-label-model"
+          ~cascade_name:model_label
+          (fun () ->
+            match Oas_worker_exec.run ~sw ~net ~config ?on_event ?contract goal with
+            | Ok result when accept result.response -> Ok result
+            | Ok result ->
+                Error
+                  (sdk_error_of_masc_internal_error
+                     (Accept_rejected
+                        {
+                          scope = model_label;
+                          model = Some result.response.model;
+                          reason =
+                            Printf.sprintf
+                              "response rejected by accept (model=%s)"
+                              result.response.model;
+                        }))
+            | Error e -> Error e)
+      with
+      | Admission_queue.Wait_timeout wait_ms ->
+          admission_wait_timeout_error ~keeper_name:"oas-label-model"
             ~cascade_name:model_label
-            (fun () ->
-              match Oas_worker_exec.run ~sw ~net ~config ?on_event ?contract goal with
-              | Ok result when accept result.response -> Ok result
-              | Ok _ ->
-                  Error (Oas.Error.Internal
-                    (Printf.sprintf "response rejected by accept from %s" model_label))
-              | Error e -> Error e)
-        with
-        | Admission_queue.Wait_timeout wait_ms ->
-            admission_wait_timeout_error ~keeper_name:"oas-label-model"
-              ~cascade_name:model_label
-              ~priority:Llm_provider.Request_priority.Proactive wait_ms)
+            ~priority:Llm_provider.Request_priority.Proactive wait_ms
 
 let run_named_with_masc_tools
     ~cascade_name
@@ -547,20 +657,20 @@ let run_model_with_masc_tools
     ?net
     ()
   : (Oas_worker_exec.run_result, Oas.Error.sdk_error) result =
+  let* config =
+    config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
+      ~tools:[] ~max_turns ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature
+      ?guardrails ?hooks ?memory ?tool_retry_policy ?enable_thinking
+      ?compact_ratio
+      ~description:(Some (Printf.sprintf "model_label:%s" model_label))
+      ()
+  in
   match require_eio ?sw ?net () with
-  | Error e -> Error (Oas.Error.Internal e)
+  | Error e -> Error (eio_context_error_to_sdk_error e)
   | Ok (sw, net) ->
       let transport_resolved = match transport with
         | Some t -> t
         | None -> Masc_grpc_transport.from_env ()
-      in
-        let config =
-          config_for_label ~name:"oas-explicit-model" ~model_label ~system_prompt
-          ~tools:[] ~max_turns ~max_tokens ?max_input_tokens ?max_cost_usd ~temperature ?guardrails ?hooks
-          ?memory ?tool_retry_policy ?enable_thinking
-          ?compact_ratio
-          ~description:(Some (Printf.sprintf "model_label:%s" model_label))
-          ()
       in
       let config = { config with raw_trace; transport = transport_resolved } in
       try

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2177,12 +2177,12 @@ let test_required_tool_contract_violation_detected () =
   check bool "tool-choice contract violation detected" true
     (UT.is_required_tool_contract_violation err)
 
-let test_required_tool_contract_violation_detected_from_legacy_internal_error () =
+let test_required_tool_contract_violation_ignores_legacy_internal_error () =
   let err =
     Agent_sdk.Error.Internal
       "Completion contract [require_tool_use] violated: required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block"
   in
-  check bool "tool-choice contract violation detected" true
+  check bool "legacy internal contract violation ignored" false
     (UT.is_required_tool_contract_violation err)
 
 let test_cascade_exhausted_error_detected_from_structured_internal_error () =
@@ -2197,10 +2197,23 @@ let test_cascade_exhausted_error_detected_from_structured_internal_error () =
   check bool "structured cascade exhausted error detected" true
     (UT.is_cascade_exhausted_error err)
 
-let test_auto_recoverable_turn_error_excludes_required_tool_contract_violation () =
+let test_cascade_exhausted_error_ignores_legacy_internal_error () =
   let err =
     Agent_sdk.Error.Internal
-      "Completion contract [require_tool_use] violated: required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block"
+      "cascade keeper_unified: all models failed: no providers available"
+  in
+  check bool "legacy internal cascade exhaustion ignored" false
+    (UT.is_cascade_exhausted_error err)
+
+let test_auto_recoverable_turn_error_excludes_required_tool_contract_violation () =
+  let err =
+    Agent_sdk.Error.Agent
+      (CompletionContractViolation
+         {
+           contract = "require_tool_use";
+           reason =
+             "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+         })
   in
   check bool "tool-choice contract violation is not globally auto-recoverable" false
     (UT.is_auto_recoverable_turn_error err)
@@ -3408,10 +3421,12 @@ let () =
             test_auto_recoverable_turn_error_includes_server_parse_rejection;
           test_case "required tool contract violation detected from structured error" `Quick
             test_required_tool_contract_violation_detected;
-          test_case "required tool contract violation detected from legacy internal error" `Quick
-            test_required_tool_contract_violation_detected_from_legacy_internal_error;
+          test_case "legacy internal contract violation is ignored" `Quick
+            test_required_tool_contract_violation_ignores_legacy_internal_error;
           test_case "structured cascade exhausted error detected" `Quick
             test_cascade_exhausted_error_detected_from_structured_internal_error;
+          test_case "legacy internal cascade exhaustion is ignored" `Quick
+            test_cascade_exhausted_error_ignores_legacy_internal_error;
           test_case "auto-recoverable excludes tool-choice contract violation" `Quick
             test_auto_recoverable_turn_error_excludes_required_tool_contract_violation;
           test_case "auto-recoverable excludes persistent errors" `Quick

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -2166,11 +2166,36 @@ let test_auto_recoverable_turn_error_includes_server_parse_rejection () =
 
 let test_required_tool_contract_violation_detected () =
   let err =
+    Agent_sdk.Error.Agent
+      (CompletionContractViolation
+         {
+           contract = "require_tool_use";
+           reason =
+             "required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block";
+         })
+  in
+  check bool "tool-choice contract violation detected" true
+    (UT.is_required_tool_contract_violation err)
+
+let test_required_tool_contract_violation_detected_from_legacy_internal_error () =
+  let err =
     Agent_sdk.Error.Internal
       "Completion contract [require_tool_use] violated: required tool contract unsatisfied: tool_choice requested tool use, but the model returned no ToolUse block"
   in
   check bool "tool-choice contract violation detected" true
     (UT.is_required_tool_contract_violation err)
+
+let test_cascade_exhausted_error_detected_from_structured_internal_error () =
+  let err =
+    Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
+      (Masc_mcp.Oas_worker_named.Cascade_exhausted
+         {
+           cascade_name = "keeper_unified";
+           detail = Some "all providers failed";
+         })
+  in
+  check bool "structured cascade exhausted error detected" true
+    (UT.is_cascade_exhausted_error err)
 
 let test_auto_recoverable_turn_error_excludes_required_tool_contract_violation () =
   let err =
@@ -3379,14 +3404,18 @@ let () =
             test_server_rejected_parse_error_network_error;
           test_case "auto-recoverable includes transient network" `Quick
             test_auto_recoverable_turn_error_includes_transient_network;
-            test_case "auto-recoverable includes server parse rejection" `Quick
-              test_auto_recoverable_turn_error_includes_server_parse_rejection;
-            test_case "required tool contract violation detected" `Quick
-              test_required_tool_contract_violation_detected;
-            test_case "auto-recoverable excludes tool-choice contract violation" `Quick
-              test_auto_recoverable_turn_error_excludes_required_tool_contract_violation;
-            test_case "auto-recoverable excludes persistent errors" `Quick
-              test_auto_recoverable_turn_error_excludes_persistent_errors;
+          test_case "auto-recoverable includes server parse rejection" `Quick
+            test_auto_recoverable_turn_error_includes_server_parse_rejection;
+          test_case "required tool contract violation detected from structured error" `Quick
+            test_required_tool_contract_violation_detected;
+          test_case "required tool contract violation detected from legacy internal error" `Quick
+            test_required_tool_contract_violation_detected_from_legacy_internal_error;
+          test_case "structured cascade exhausted error detected" `Quick
+            test_cascade_exhausted_error_detected_from_structured_internal_error;
+          test_case "auto-recoverable excludes tool-choice contract violation" `Quick
+            test_auto_recoverable_turn_error_excludes_required_tool_contract_violation;
+          test_case "auto-recoverable excludes persistent errors" `Quick
+            test_auto_recoverable_turn_error_excludes_persistent_errors;
           test_case "bounded OAS timeout keeps adaptive timeout under full budget" `Quick
             test_bounded_oas_timeout_uses_adaptive_when_budget_is_large;
           test_case "bounded OAS timeout caps to remaining turn budget" `Quick

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -703,20 +703,67 @@ let test_oas_worker_exec_build_applies_priority () =
   | Error err -> Alcotest.fail (Oas.Error.to_string err)
 
 let test_resolve_provider_of_label_rejects_invalid_explicit_label () =
-  match
-    try
-      ignore (Oas_worker_exec.resolve_provider_of_label "not-a-model-label");
-      Ok ()
-    with Invalid_argument msg -> Error msg
-  with
-  | Ok () ->
+  match Oas_worker_exec.resolve_provider_of_label "not-a-model-label" with
+  | Ok _ ->
       Alcotest.fail
         "expected invalid explicit model label to be rejected without fallback"
-  | Error msg ->
+  | Error err ->
+      let msg = Oas_worker_exec.label_resolution_error_to_string err in
       Alcotest.(check bool) "mentions invalid model label" true
         (contains_substring ~needle:"invalid model label" msg);
       Alcotest.(check bool) "mentions rejected label" true
         (contains_substring ~needle:"not-a-model-label" msg)
+
+let test_run_model_with_masc_tools_rejects_invalid_explicit_label () =
+  match
+    Oas_worker.run_model_with_masc_tools
+      ~model_label:"not-a-model-label"
+      ~goal:"test goal"
+      ~masc_tools:[]
+      ~dispatch:(fun ~name:_ ~args:_ -> (true, "ok"))
+      ()
+  with
+  | Ok _ ->
+      Alcotest.fail "expected invalid explicit model label to fail before execution"
+  | Error (Oas.Error.Config (Oas.Error.InvalidConfig { field; detail })) ->
+      Alcotest.(check string) "invalid field" "model_label" field;
+      Alcotest.(check bool) "detail mentions rejected label" true
+        (contains_substring ~needle:"not-a-model-label" detail)
+  | Error err ->
+      Alcotest.failf "unexpected error shape: %s" (Oas.Error.to_string err)
+
+let test_classify_masc_internal_error_roundtrip () =
+  let cascade_err =
+    Oas_worker_named.sdk_error_of_masc_internal_error
+      (Oas_worker_named.Cascade_exhausted
+         {
+           cascade_name = "keeper_unified";
+           detail = Some "all providers failed";
+         })
+  in
+  (match Oas_worker_named.classify_masc_internal_error cascade_err with
+   | Some (Oas_worker_named.Cascade_exhausted { cascade_name; detail }) ->
+       Alcotest.(check string) "cascade name" "keeper_unified" cascade_name;
+       Alcotest.(check (option string)) "cascade detail"
+         (Some "all providers failed") detail
+   | _ -> Alcotest.fail "expected structured cascade exhaustion");
+  let accept_err =
+    Oas_worker_named.sdk_error_of_masc_internal_error
+      (Oas_worker_named.Accept_rejected
+         {
+           scope = "keeper_unified";
+           model = Some "mock-model";
+           reason = "response rejected by accept (model=mock-model)";
+         })
+  in
+  match Oas_worker_named.classify_masc_internal_error accept_err with
+  | Some (Oas_worker_named.Accept_rejected { scope; model; reason }) ->
+      Alcotest.(check string) "accept scope" "keeper_unified" scope;
+      Alcotest.(check (option string)) "accept model"
+        (Some "mock-model") model;
+      Alcotest.(check bool) "accept reason preserved" true
+        (contains_substring ~needle:"response rejected by accept" reason)
+  | _ -> Alcotest.fail "expected structured accept rejection"
 
 let test_worker_build_agent_uses_default_internal_retry_policy () =
   with_raw_trace "worker_build_agent_retry" @@ fun raw_trace ->
@@ -1837,6 +1884,10 @@ let () =
         test_oas_worker_exec_build_applies_priority;
       Alcotest.test_case "invalid explicit model label is rejected" `Quick
         test_resolve_provider_of_label_rejects_invalid_explicit_label;
+      Alcotest.test_case "run_model_with_masc_tools rejects invalid explicit model label" `Quick
+        test_run_model_with_masc_tools_rejects_invalid_explicit_label;
+      Alcotest.test_case "structured MASC internal errors roundtrip through classifier" `Quick
+        test_classify_masc_internal_error_roundtrip;
       Alcotest.test_case "worker build_agent installs retry policy" `Quick
         test_worker_build_agent_uses_default_internal_retry_policy;
       Alcotest.test_case "resume config propagates retry policy" `Quick


### PR DESCRIPTION
## Summary
- remove the raising invalid-model-label path from the OAS worker execution boundary
- tag MASC-owned OAS internal failures so keeper recovery logic can classify them structurally
- remove the remaining legacy string fallback from keeper contract/cascade detection so the boundary is fully typed

## Why
Keeper-side recovery and rollover code was already trying to reason over `Oas.Error.sdk_error`, but several OAS worker boundary failures were still being collapsed into free-form `Internal` strings or `Invalid_argument`. That made downstream classification brittle and left one explicit-model path able to escape the `Result` contract entirely.

## What changed
- changed `Oas_worker_exec.resolve_provider_of_label` to return a typed result instead of raising
- added structured MASC internal error tagging/classification helpers in `Oas_worker_named`
- updated `run_named` / `run_model_by_label` / `run_model_with_masc_tools` to use the typed label-resolution path and emit tagged internal errors for cascade exhaustion and accept rejection
- updated `Keeper_unified_turn` to detect completion-contract violations only from structured `Agent (CompletionContractViolation _)` errors and to classify cascade exhaustion only through the new tagged helper
- added regression coverage for invalid explicit labels, internal-error roundtrips, structured contract violations, structured cascade exhaustion, and explicit non-support for the removed legacy string path

## Product impact
- keeper recovery and rollover decisions no longer silently depend on free-form `Internal` strings for these OAS boundary failures
- invalid explicit model labels now stay inside the `Result` contract instead of escaping through `Invalid_argument`
- future regressions in typed error propagation should fail fast instead of being masked by fallback matching

## Evidence
- `Oas.Error.Agent` is not introduced by this PR; it already exists in the current `agent_sdk` dependency surface and is matched directly here
- linked keeper failure-signal umbrella: `Refs #7036`

## Review evidence
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/oas-result-health test/test_oas_worker.exe`
- `./_build/default/test/test_oas_worker.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/oas-result-health test/test_keeper_unified.exe`
- `./_build/default/test/test_keeper_unified.exe`

## Linked issue
- Refs #7036
