### PR TITLE
feat(admission): host-resource fd gate — reject turns at 90% threshold (#7500 Step 1)

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -54,6 +54,8 @@ let insert_sorted entry ws =
   in
   go [] ws
 
+exception Host_resource_saturated of string
+
 (* ── Core Queue ────────────────────────────────────────── *)
 
 let initial_max_concurrent_of_env getenv =
@@ -162,7 +164,19 @@ and _release_slot t =
 
 (* ── Public API ────────────────────────────────────────── *)
 
+let check_host_resources ~keeper_name =
+  let fd_count = Prometheus.approximate_open_fd_count () in
+  let threshold = Prometheus.fd_warn_threshold in
+  if fd_count >= threshold * 9 / 10 then begin
+    let msg =
+      Printf.sprintf "fd count %d >= 90%% of threshold %d" fd_count threshold
+    in
+    Log.Misc.warn "admission rejected for %s: %s" keeper_name msg;
+    raise (Host_resource_saturated msg)
+  end
+
 let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
+  check_host_resources ~keeper_name;
   (* Passthrough: provider-level throttling belongs in OAS (cascade),
      not in MASC.  The cascade distributes requests across providers
      and handles 429/timeout by falling to the next provider.
@@ -179,6 +193,7 @@ let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
     raise exn
 
 let try_with_permit ~priority:_ ~keeper_name ~cascade_name f =
+  check_host_resources ~keeper_name;
   Admission_queue_metrics.on_acquire ~keeper_name ~cascade_name ~wait_ms:0;
   match f () with
   | result ->


### PR DESCRIPTION
## Summary

#7500 Step 1: admission_queue 에 fd 기반 host-resource gate 추가. fd count >= warn_threshold × 90% 이면 새 keeper turn 거부.

## Linked issue

Closes Step 1 of #7500.

## Product impact

- **Before**: fd 누수 시 admission queue 가 계속 keeper turn 허용 → HTTP 연결 추가 → 악순환 → EMFILE.
- **After**: fd 임계 90% 도달 시 ``Host_resource_saturated`` 예외 → keeper turn 거부 → 기존 연결만 정리 → 서버 생존.

## Evidence

``dune build --root .`` clean. 1 file, ~15 lines added.

## Test plan
- [x] Build clean
- [ ] ``MASC_FD_WARN_THRESHOLD=50`` 로 낮춰서 gate trigger 확인
- [ ] CI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>