### PR TITLE
fix(cascade_runtime): wire weighted_entry.supports_tool_choice into resolve_named_providers

### DIFF
--- a/lib/cascade/cascade_runtime.ml
+++ b/lib/cascade/cascade_runtime.ml
@@ -275,11 +275,25 @@ let resolve_providers_from_model_strings (model_strings : string list)
 let resolve_named_providers ~cascade_name : Llm_provider.Provider_config.t list =
   let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let defaults = default_model_strings ~cascade_name in
-  let configured = models_of_cascade_name cascade_name in
-  let specs = Cascade_config.parse_model_strings configured in
+  let config_path = cascade_config_path () in
+  let weighted =
+    match config_path with
+    | Some path ->
+      Cascade_config_loader.load_profile_weighted ~config_path:path
+        ~name:cascade_name
+    | None -> []
+  in
+  let specs =
+    if weighted <> [] then
+      Cascade_config.parse_weighted_entries weighted
+    else
+      Cascade_config.parse_model_strings
+        (models_of_cascade_name cascade_name)
+  in
   if specs <> [] then specs
-  else if configured = defaults then (
-    Log.Misc.warn "cascade %s: no callable models from built-in defaults" cascade_name;
+  else if models_of_cascade_name cascade_name = defaults then (
+    Log.Misc.warn "cascade %s: no callable models from built-in defaults"
+      cascade_name;
     [])
   else (
     Log.Misc.warn


### PR DESCRIPTION
## Summary
PR #7493 added the schema (`weighted_entry.supports_tool_choice`) and the wiring helper (`parse_weighted_entries`) but **`resolve_named_providers` still used the string-list path** (`parse_model_strings`), which silently dropped the override.

This PR fixes the dead wire:
- `cascade_runtime.resolve_named_providers` now loads `load_profile_weighted` and pipes through `parse_weighted_entries` when a weighted profile is available
- Falls back to the legacy string-list path only when no weighted profile exists (built-in defaults)

## Why this was missed in #7493
#7493's body explicitly noted "schema reservation only; wiring TBD" but the wiring follow-up was deferred to a separate PR for review-surface separation. This is that PR.

## Real-world impact (sangsu keeper)
Without this PR, sangsu's cascade.json entry:
```json
{"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 90, "supports_tool_choice": true}
```
parses correctly into `weighted_entry { supports_tool_choice = Some true }` but the value never reaches `Provider_config.make`, so OAS still uses the default `ollama_capabilities.supports_tool_choice = false` and `Completion_contract` stays relaxed.

After this PR, sangsu's Qwen3.5+Jinja deployment gets the strict `Require_tool_use` contract it needs.

## Test plan
- [x] `dune build --root .` green
- [ ] CI `dune runtest`
- [ ] sangsu live turn → `gen_ai.request.tool_choice` reaches Ollama as `required`

🤖 Generated with [Claude Code](https://claude.com/claude-code)