### PR TITLE
[codex] Harden HTTP auth and OpenAPI contracts

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -51,6 +51,16 @@ let write_initial_admin config agent_name =
   write_text_file file (String.trim agent_name);
   chmod file 0o600
 
+let save_private_text_file path content =
+  run_blocking_io (fun () ->
+      let oc =
+        open_out_gen [ Open_wronly; Open_creat; Open_trunc; Open_text ] 0o600
+          path
+      in
+      Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+          output_string oc content));
+  chmod path 0o600
+
 (** Read the initial admin agent name, if set. *)
 let read_initial_admin config : string option =
   let file = initial_admin_file config in
@@ -87,7 +97,7 @@ let save_auth_config config (auth_cfg : auth_config) =
   ensure_auth_dirs config;
   let file = auth_config_file config in
   let json = auth_config_to_yojson auth_cfg in
-  write_text_file file (Yojson.Safe.pretty_to_string json)
+  save_private_text_file file (Yojson.Safe.pretty_to_string json)
 
 (* ============================================ *)
 (* Credential management                        *)
@@ -118,7 +128,7 @@ let save_credential config (cred : agent_credential) =
   ensure_auth_dirs config;
   let file = credential_file config cred.agent_name in
   let json = agent_credential_to_yojson cred in
-  write_text_file file (Yojson.Safe.pretty_to_string json)
+  save_private_text_file file (Yojson.Safe.pretty_to_string json)
 
 (** Delete agent credential *)
 let delete_credential config agent_name =
@@ -371,9 +381,7 @@ let init_room_secret config : string =
   ensure_auth_dirs config;
   let secret = generate_token () in
   let hash = sha256_hash secret in
-  Out_channel.with_open_text (room_secret_file config) (fun oc ->
-    output_string oc hash
-  );
+  save_private_text_file (room_secret_file config) hash;
   (* Update auth config with hash *)
   let cfg = load_auth_config config in
   save_auth_config config { cfg with room_secret_hash = Some hash };

--- a/lib/local/worker_container_types.ml
+++ b/lib/local/worker_container_types.ml
@@ -103,14 +103,8 @@ let masc_http_base_url () =
   Env_config.masc_http_base_url ()
 
 let mcp_endpoint_url ~(auth_token : string option) =
-  let base = masc_http_base_url () ^ "/mcp" in
-  match auth_token with
-  | Some token when String.trim token <> "" ->
-      (* Keep auth in the query as a loopback-only fallback for local workers.
-         execute_tool_eio already accepts query token auth, and this avoids
-         header transport edge cases when we self-call through curl. *)
-      base ^ "?token=" ^ token
-  | _ -> base
+  ignore auth_token;
+  masc_http_base_url () ^ "/mcp"
 
 let request_id_matches request_id json =
   let open Yojson.Safe.Util in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -167,7 +167,7 @@ let rec add_routes ~sw ~clock router =
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/dashboard/logs/tool-host-failures" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_tool_auth ~tool_name:"masc_broadcast" (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            let fallback_agent = agent_from_request request in
            let report_result =

--- a/lib/transport.ml
+++ b/lib/transport.ml
@@ -159,6 +159,73 @@ module Rest = struct
   let list_json values =
     `List (List.map (fun value -> `String value) values)
 
+  type auth_mode =
+    | Public
+    | Conditional_bearer
+    | Same_origin_or_bearer
+    | Bearer_required
+
+  let auth_mode_name = function
+    | Public -> "public"
+    | Conditional_bearer -> "conditional_bearer"
+    | Same_origin_or_bearer -> "same_origin_or_bearer"
+    | Bearer_required -> "bearer_required"
+
+  let auth_mode_description = function
+    | Public ->
+        "No bearer token is required for this route."
+    | Conditional_bearer ->
+        "Bearer token auth is required when room auth/token enforcement is active; loopback-local development may allow access without a bearer."
+    | Same_origin_or_bearer ->
+        "Loopback browser requests may use same-origin checks; non-browser clients should use Authorization: Bearer <token>."
+    | Bearer_required ->
+        "Authorization: Bearer <token> is required for this route."
+
+  let openapi_bearer_security =
+    `List [ `Assoc [ ("bearerAuth", `List []) ] ]
+
+  let auth_mode_of_operation = function
+    | "masc_websocket_discovery" -> Public
+    | "masc_webrtc_offer" | "masc_webrtc_answer" -> Same_origin_or_bearer
+    | "masc_broadcast"
+    | "masc_operator_action"
+    | "masc_operator_confirm" -> Bearer_required
+    | "masc_status"
+    | "masc_tasks"
+    | "masc_who"
+    | "masc_messages"
+    | "masc_operator_snapshot"
+    | "masc_operator_digest"
+    | "masc_agent_card" -> Conditional_bearer
+    | _ -> Conditional_bearer
+
+  let auth_mode_of_mcp_path () = Conditional_bearer
+
+  let auth_response_entries mode =
+    match mode with
+    | Public -> []
+    | Same_origin_or_bearer | Conditional_bearer | Bearer_required ->
+        [
+          ( "401",
+            `Assoc
+              [ ("description", `String "Authentication required or invalid bearer token") ] );
+          ( "403",
+            `Assoc
+              [ ("description", `String "Authenticated caller lacks permission") ] );
+        ]
+
+  let auth_fields_for_mode mode =
+    let base =
+      [
+        ("x-auth-mode", `String (auth_mode_name mode));
+        ("x-auth-description", `String (auth_mode_description mode));
+      ]
+    in
+    match mode with
+    | Public | Same_origin_or_bearer -> base
+    | Conditional_bearer | Bearer_required ->
+        ("security", openapi_bearer_security) :: base
+
   let actual_rest_bindings_for_operation = function
     | "masc_status" -> [ (GET, "/api/v1/status") ]
     | "masc_tasks" -> [ (GET, "/api/v1/tasks") ]
@@ -347,6 +414,7 @@ module Rest = struct
 
   let rest_operation_json name method_ (schema : Types.tool_schema) =
     let entry = help_entry name in
+    let auth_mode = auth_mode_of_operation name in
     let base_fields =
       [
         ("summary", `String entry.short_description);
@@ -354,6 +422,7 @@ module Rest = struct
         ("tags", list_json (tags_for_operation name));
         ("x-canonical-operation", `String name);
       ]
+      @ auth_fields_for_mode auth_mode
     in
     let request_fields =
       match method_ with
@@ -381,26 +450,28 @@ module Rest = struct
       (List.rev
          ( ( "responses",
              `Assoc
-               [
-                 ( "200",
-                   `Assoc
-                     [
-                       ("description", `String "Success");
-                       ( "content",
-                         `Assoc
-                           [
-                             ( "application/json",
-                               `Assoc
-                                 [ ("schema", success_response_schema) ] );
-                           ] );
-                     ] );
-               ] )
+               ([
+                  ( "200",
+                    `Assoc
+                      [
+                        ("description", `String "Success");
+                        ( "content",
+                          `Assoc
+                            [
+                              ( "application/json",
+                                `Assoc
+                                  [ ("schema", success_response_schema) ] );
+                            ] );
+                      ] );
+                ]
+                @ auth_response_entries auth_mode) )
          :: request_fields ))
 
   let generate_openapi_document
       ?(host = Env_config_core.masc_host ())
       ?(port = Env_config_core.masc_http_port_int ()) () :
       Yojson.Safe.t =
+    let mcp_auth_mode = auth_mode_of_mcp_path () in
     let operation_entries =
       Sdk_tool_contract.core_remote_operation_names
       |> List.filter_map (fun name ->
@@ -459,20 +530,24 @@ module Rest = struct
               ] );
           ( "responses",
             `Assoc
-              [
-                ( "200",
-                  `Assoc
-                    [
-                      ("description", `String "JSON-RPC response envelope");
-                      ( "content",
-                        `Assoc
-                          [
-                            ( "application/json",
-                              `Assoc
-                                [ ("schema", success_response_schema) ] );
-                          ] );
-                    ] );
-              ] );
+              ([
+                 ( "200",
+                   `Assoc
+                     [
+                       ("description", `String "JSON-RPC response envelope");
+                       ( "content",
+                         `Assoc
+                           [
+                             ( "application/json",
+                               `Assoc
+                                 [ ("schema", success_response_schema) ] );
+                           ] );
+                     ] );
+               ]
+               @ auth_response_entries mcp_auth_mode) );
+          ("x-auth-mode", `String (auth_mode_name mcp_auth_mode));
+          ("x-auth-description", `String (auth_mode_description mcp_auth_mode));
+          ("security", openapi_bearer_security);
           ("x-mcp-operations", `List operation_catalog);
           ("x-agent-sdk-tools", `List sdk_tools);
         ]);
@@ -507,7 +582,25 @@ module Rest = struct
                 ];
             ] );
         ("paths", `Assoc path_entries);
-        ("components", `Assoc [ ("schemas", `Assoc components_schemas) ]);
+        ( "components",
+          `Assoc
+            [
+              ("schemas", `Assoc components_schemas);
+              ( "securitySchemes",
+                `Assoc
+                  [
+                    ( "bearerAuth",
+                      `Assoc
+                        [
+                          ("type", `String "http");
+                          ("scheme", `String "bearer");
+                          ("bearerFormat", `String "opaque-token");
+                          ( "description",
+                            `String
+                              "MASC room bearer token. Some loopback-local routes may additionally permit same-origin browser access." );
+                        ] );
+                  ] );
+            ] );
       ]
 
   (** Compatibility helper. Returns a concrete REST route when one exists;

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -30,6 +30,9 @@ let cleanup_test_room dir =
   in
   try rm_rf dir with _ -> ()
 
+let permission_bits path =
+  (Unix.stat path).Unix.st_perm land 0o777
+
 let with_env name value f =
   let previous = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -106,6 +109,16 @@ let test_save_load_auth_config_in_eio_runtime () =
         check bool "enabled persisted in eio" true loaded.enabled;
         check bool "require_token persisted in eio" true loaded.require_token))
 
+let test_auth_config_saved_private () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      let cfg = { Types.default_auth_config with enabled = true } in
+      Auth.save_auth_config dir cfg;
+      check int "auth config mode 0600" 0o600
+        (permission_bits (Auth.auth_config_file dir)))
+
 (* ============================================ *)
 (* Credential management tests                  *)
 (* ============================================ *)
@@ -122,6 +135,29 @@ let test_create_credential () =
       check int "stored token is 64 chars" 64 (String.length cred.token)
   | Error _ ->
       fail "create_token should succeed"
+
+let test_credential_saved_private () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      match Auth.create_token dir ~agent_name:"claude" ~role:Types.Worker with
+      | Ok _ ->
+          check int "credential mode 0600" 0o600
+            (permission_bits (Auth.credential_file dir "claude"))
+      | Error e ->
+          fail
+            (Printf.sprintf "create_token should succeed: %s"
+               (Types.masc_error_to_string e)))
+
+let test_room_secret_saved_private () =
+  let dir = setup_test_room () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_test_room dir)
+    (fun () ->
+      ignore (Auth.init_room_secret dir);
+      check int "room secret mode 0600" 0o600
+        (permission_bits (Auth.room_secret_file dir)))
 
 let test_verify_token () =
   let dir = setup_test_room () in
@@ -432,9 +468,13 @@ let () =
       test_case "save/load config" `Quick test_save_load_auth_config;
       test_case "save/load config in Eio runtime" `Quick
         test_save_load_auth_config_in_eio_runtime;
+      test_case "auth config saved private" `Quick
+        test_auth_config_saved_private;
     ];
     "credentials", [
       test_case "create credential" `Quick test_create_credential;
+      test_case "credential saved private" `Quick
+        test_credential_saved_private;
       test_case "verify token" `Quick test_verify_token;
       test_case "verify wrong token" `Quick test_verify_wrong_token;
       test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
@@ -468,5 +508,6 @@ let () =
     ];
     "enable_disable", [
       test_case "enable/disable auth" `Quick test_enable_disable_auth;
+      test_case "room secret saved private" `Quick test_room_secret_saved_private;
     ];
   ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -169,6 +169,9 @@ let test_http_write_auth_contracts () =
   check bool "board comment route overwrites author from auth identity" true
     (file_contains_pattern "lib/server/server_routes_http_routes_activity.ml"
        {|json_upsert_string_field "author" agent_name|});
+  check bool "tool-host-failures route requires tool auth" true
+    (file_contains_pattern "lib/server/server_routes_http_routes_dashboard.ml"
+       {|with_tool_auth ~tool_name:"masc_broadcast"|});
   check bool "provider runs post requires admin permission" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        {|with_token_permission_auth ~permission:Types.CanAdmin|});

--- a/test/test_transport_coverage.ml
+++ b/test/test_transport_coverage.ml
@@ -635,9 +635,19 @@ let test_rest_generate_openapi_document () =
   check string "openapi version" "3.1.0" (doc |> member "openapi" |> to_string);
   check string "info.version matches repo version" Masc_mcp.Version.version
     (doc |> member "info" |> member "version" |> to_string);
+  check string "bearer security scheme type" "http"
+    (doc |> member "components" |> member "securitySchemes"
+     |> member "bearerAuth" |> member "type" |> to_string);
+  check string "bearer security scheme" "bearer"
+    (doc |> member "components" |> member "securitySchemes"
+     |> member "bearerAuth" |> member "scheme" |> to_string);
   let mcp_post = doc |> member "paths" |> member "/mcp" |> member "post" in
   check string "mcp operation id" "mcp_tools_call"
     (mcp_post |> member "operationId" |> to_string);
+  check string "mcp auth mode" "conditional_bearer"
+    (mcp_post |> member "x-auth-mode" |> to_string);
+  check bool "mcp security present" true
+    (mcp_post |> member "security" <> `Null);
   let operations = mcp_post |> member "x-mcp-operations" |> to_list in
   let status_entry =
     operations
@@ -670,7 +680,18 @@ let test_rest_generate_openapi_document () =
     (List.exists
        (fun row ->
          row |> member "path" |> to_string = "/api/v1/broadcast")
-       (broadcast_entry |> member "x-rest-bindings" |> to_list))
+       (broadcast_entry |> member "x-rest-bindings" |> to_list));
+  let broadcast_post =
+    doc |> member "paths" |> member "/api/v1/broadcast" |> member "post"
+  in
+  check string "broadcast auth mode" "bearer_required"
+    (broadcast_post |> member "x-auth-mode" |> to_string);
+  check bool "broadcast security present" true
+    (broadcast_post |> member "security" <> `Null);
+  check bool "broadcast 401 documented" true
+    (broadcast_post |> member "responses" |> member "401" <> `Null);
+  check bool "broadcast 403 documented" true
+    (broadcast_post |> member "responses" |> member "403" <> `Null)
 
 let test_rest_generate_openapi_document_relative_server_fallback () =
   let open Yojson.Safe.Util in

--- a/test/test_worker_container_coverage.ml
+++ b/test/test_worker_container_coverage.ml
@@ -1,6 +1,16 @@
 open Alcotest
 open Masc_mcp
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some old -> Unix.putenv name old
+      | None -> Unix.putenv name "")
+    f
+
 let worker_usage ?cost_usd ~input_tokens ~output_tokens () :
     Agent_sdk.Types.api_usage =
   {
@@ -62,6 +72,13 @@ let test_merge_usage_sums_costs_when_both_present () =
   check (option (float 0.000001)) "costs summed" (Some 0.15)
     merged.cost_usd
 
+let test_mcp_endpoint_url_does_not_leak_token () =
+  with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" (fun () ->
+    let url =
+      Worker_container_types.mcp_endpoint_url ~auth_token:(Some "secret-token")
+    in
+    check string "mcp url stays clean" "http://127.0.0.1:8935/mcp" url)
+
 let () =
   run "Worker_runtime"
     [
@@ -75,5 +92,7 @@ let () =
             test_merge_usage_preserves_present_cost;
           test_case "merge usage sums costs" `Quick
             test_merge_usage_sums_costs_when_both_present;
+          test_case "mcp endpoint url does not leak token" `Quick
+            test_mcp_endpoint_url_does_not_leak_token;
         ] );
     ]


### PR DESCRIPTION
## Summary

This PR hardens a few HTTP/OAS surfaces that were still weaker than the runtime auth model.

- add explicit auth metadata to the generated OpenAPI document
- move dashboard `tool-host-failures` ingestion behind tool auth instead of public read
- stop local worker MCP self-calls from leaking bearer tokens in URL query strings
- save auth config, credentials, and room secret files with `0600` permissions

## Root Cause

The generated OpenAPI contract under-described runtime auth requirements, one dashboard write route was still treated like a read path, and a local worker fallback path still carried bearer tokens in URLs. Auth file writes also relied on default file creation modes instead of explicitly tightening permissions.

## Validation

- `dune build test/test_transport_coverage.exe test/test_auth.exe test/test_auth_coverage.exe test/test_worker_container_coverage.exe test/test_ci_hardening_source.exe test/test_openapi_api_e2e.exe`
- `./_build/default/test/test_transport_coverage.exe`
- `./_build/default/test/test_auth.exe`
- `./_build/default/test/test_auth_coverage.exe`
- `./_build/default/test/test_worker_container_coverage.exe`
- `./_build/default/test/test_ci_hardening_source.exe`
- `./_build/default/test/test_openapi_api_e2e.exe`

## Notes

I did not change the existing loopback cross-port browser mutation policy in this PR because that can affect local dev flows and should be handled as a separate hardening step.