### PR TITLE
feat(metrics): tool schema budget gauges (#7483 Step 1)

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -113,6 +113,14 @@ let () =
      Uses Config.raw_all_tool_schemas which includes Board schemas
      not present in Tools.all_schemas_extended. *)
   Keeper_exec_tools.inject_masc_schemas Config.raw_all_tool_schemas;
+  (* Report tool schema budget to Prometheus (#7483 Step 1). *)
+  (let schemas = Config.visible_tool_schemas () in
+   let count = List.length schemas in
+   let chars = List.fold_left (fun acc (s : Types.tool_schema) ->
+     acc + String.length s.name + String.length s.description
+     + String.length (Yojson.Safe.to_string s.input_schema)
+   ) 0 schemas in
+   Prometheus.set_tool_schema_stats ~count ~approx_tokens:(chars / 4));
   (* Wire keeper-internal tool call recording to break Config dependency cycle.
      keeper_exec_tools cannot reference Tool_registry directly. *)
   Keeper_exec_tools.on_keeper_tool_call :=

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -277,7 +277,14 @@ let init () =
     Counter;
   add "masc_keeper_output_tokens_total"
     "Cumulative output tokens per keeper turn (labels: keeper_name, model)"
-    Counter
+    Counter;
+  (* Tool schema budget gauges — set once at boot via
+     [set_tool_schema_stats]. Covers #7483 Step 1. *)
+  add "masc_mcp_tool_schema_count"
+    "Number of tool schemas exposed to MCP clients" Gauge;
+  add "masc_mcp_tool_schema_tokens_approx"
+    "Approximate token count of all tool schemas combined (chars/4)"
+    Gauge
 
 let metric_open_fds = "masc_process_open_fds"
 
@@ -319,6 +326,10 @@ let update_fd_gauges () =
       count fd_warn_threshold
   end else if count < fd_warn_threshold / 2 then
     fd_warned_once := false
+
+let set_tool_schema_stats ~count ~approx_tokens =
+  set_gauge "masc_mcp_tool_schema_count" (float_of_int count);
+  set_gauge "masc_mcp_tool_schema_tokens_approx" (float_of_int approx_tokens)
 
 (** {1 Prometheus Export} *)
 


### PR DESCRIPTION
## Summary
- Registers two Prometheus gauges that record the tool-catalog footprint every keeper turn pays for:
  - `masc_mcp_tool_schema_count`
  - `masc_mcp_tool_schema_tokens_approx` (sum of `name + description + input_schema` chars / 4)
- Both are set once at server init from `Config.visible_tool_schemas ()` — matches what MCP clients actually see (post hidden/deprecated filter).

## Why
Issue #7483 Step 1. Schema-bloat complaints currently have no metric to confirm whether a PR that added/removed tools actually shifted the budget. chars/4 is a deliberately coarse tokenizer proxy — goal is **change detection over time**, not a precise count. Boot-time only, so zero hot-path cost.

## Out of scope
- Per-tool breakdown (Step 2+)
- Tokenizer-accurate counts (would require pulling model-specific BPE)

## Test plan
- [x] `dune build --root .` green
- [ ] After deploy: scrape `/metrics` and confirm both gauges appear with non-zero values
- [ ] Sanity check: `tokens_approx ≈ count * avg_schema_chars / 4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)