### PR TITLE
feat(mcp): emit openWorldHint tool annotation (#7480 Step 1)

### DIFF
--- a/lib/mcp_server_eio_tool_profile.ml
+++ b/lib/mcp_server_eio_tool_profile.ml
@@ -132,10 +132,27 @@ let tool_annotations_for_profile _profile tool_name =
     | None -> Tool_dispatch.is_idempotent tool_name || read_only
   in
   let is_deprecated = meta.lifecycle = Tool_catalog.Deprecated in
+  (* MCP 2025-03-26: [openWorldHint] signals whether the tool can
+     interact with systems outside the server's closed world.
+     Default per spec is [true]. We emit an explicit value when we
+     are confident:
+     - destructive shell/git tools → open world (external side effects)
+     - pure MASC read-only tools   → closed world (server state only)
+     Otherwise we omit the hint so the spec default applies. This is
+     intentionally coarse (see #7480 Step 1); refinement comes as more
+     tools register explicit metadata. *)
+  let open_world_hint =
+    if destructive then Some true
+    else if read_only then Some false
+    else None
+  in
   let fields =
     [ ("readOnlyHint", `Bool read_only) ]
     @ (if destructive then [ ("destructiveHint", `Bool true) ] else [])
     @ (if idempotent then [ ("idempotentHint", `Bool true) ] else [])
+    @ (match open_world_hint with
+       | Some v -> [ ("openWorldHint", `Bool v) ]
+       | None -> [])
     @ (if is_deprecated then [ ("deprecated", `Bool true) ] else [])
     @ (match meta.replacement with
        | Some r when is_deprecated -> [ ("successor", `String r) ]

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -726,6 +726,17 @@ let test_handle_request_tools_list_operator_profile () =
                  Alcotest.(check bool) "action readonly hint" false
                    (action_tool |> Yojson.Safe.Util.member "annotations"
                     |> Yojson.Safe.Util.member "readOnlyHint"
+                    |> Yojson.Safe.Util.to_bool);
+                 (* #7480 Step 1: read-only tools advertise
+                    openWorldHint=false so MCP clients know they do not
+                    reach outside MASC's own state. *)
+                 Alcotest.(check bool) "snapshot openWorld=false" false
+                   (snapshot_tool |> Yojson.Safe.Util.member "annotations"
+                    |> Yojson.Safe.Util.member "openWorldHint"
+                    |> Yojson.Safe.Util.to_bool);
+                 Alcotest.(check bool) "digest openWorld=false" false
+                   (digest_tool |> Yojson.Safe.Util.member "annotations"
+                    |> Yojson.Safe.Util.member "openWorldHint"
                     |> Yojson.Safe.Util.to_bool)
              | _ -> Alcotest.fail "tools not a list")
         | _ -> Alcotest.fail "result not an object")


### PR DESCRIPTION
## Summary
Adds the fourth MCP 2025-03-26 tool annotation that was missing from our `tools/list` response: `openWorldHint`.

Three hints already travel back via `tool_annotations_for_profile`:
- `readOnlyHint`
- `destructiveHint`
- `idempotentHint`

This PR emits `openWorldHint` so MCP clients have a complete signal set for gating decisions (e.g. Claude Code can distinguish "this tool only reads MASC state" from "this tool shells out to git").

## Heuristic (Step 1, intentionally coarse)

| Tool property | `openWorldHint` |
|---|---|
| destructive (shell/git/edit) | `true` |
| read-only (MASC state queries) | `false` |
| otherwise | omitted (MCP default = `true`) |

Tools that are read-only yet still hit external services (e.g. future GitHub/JIRA read APIs) would be mis-classified as closed-world under this pass. Refinement is deferred until enough explicit `metadata.readonly/destructive` entries exist in `tool_catalog.ml` to override the heuristic per tool — fits the Step 1 scope in #7480.

## Why this matters

Per MCP spec the default value is `true`, so omitting the hint keeps the server spec-compliant. The value-add is the `false` signal for clients that gate on outbound side effects — they can skip extra confirmation dialogs for tools we've vouched for as closed-world.

## Test plan
- [x] `dune build --root .` green
- [x] New regression test in `test/test_mcp_server_eio.ml`: operator `snapshot` + `digest` tools must advertise `openWorldHint=false`
- [x] `handle tools/list operator profile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)