### PR TITLE
[codex] streamline observatory views

### DIFF
--- a/dashboard/src/components/live.ts
+++ b/dashboard/src/components/live.ts
@@ -6,33 +6,54 @@ import { PulseStrip } from './live/pulse-strip'
 import { KeeperHealthStrip } from './live/keeper-health-strip'
 import { ActivityStream } from './live/activity-stream'
 import { FocusSidebar } from './live/focus-sidebar'
+import { CollapsibleSection } from './common/collapsible'
 
-export function Live() {
+interface LiveProps {
+  variant?: 'full' | 'observatory'
+}
+
+export function Live({ variant = 'full' }: LiveProps) {
+  const observatoryMode = variant === 'observatory'
+
   return html`
     <div class="flex flex-col gap-5">
-      <section class="monitor-surface-card monitor-surface-card-strong px-5 py-4">
-        <div class="flex flex-col gap-2">
+      ${!observatoryMode ? html`
+        <section class="monitor-surface-card monitor-surface-card-strong px-5 py-4">
           <div class="flex flex-col gap-2">
-            <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
-            <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+            <div class="flex flex-col gap-2">
+              <h2 class="m-0 text-[1.25rem] font-semibold text-[var(--text-strong)]">라이브 모니터</h2>
+              <p class="m-0 text-[13px] leading-[1.55] text-[var(--text-body)]">실시간 이벤트 흐름과 활성 에이전트 상태를 한 화면에서 봅니다.</p>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      ` : null}
 
-      <section class="rounded-[var(--radius-xl)] border border-[var(--border-slate-12)] bg-[var(--white-3)] p-4">
-        <${PulseStrip} />
-      </section>
+      ${!observatoryMode ? html`
+        <section class="rounded-[var(--radius-xl)] border border-[var(--border-slate-12)] bg-[var(--white-3)] p-4">
+          <${PulseStrip} />
+        </section>
+      ` : null}
 
-      <${KeeperHealthStrip} />
+      ${!observatoryMode ? html`<${KeeperHealthStrip} />` : null}
 
-      <div class="live-panels grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
-        <section class="live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
+      ${observatoryMode ? html`
+        <section class="live-panel-main monitor-surface-card monitor-surface-card-medium p-4">
           <${ActivityStream} />
         </section>
-        <section class="live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
-          <${FocusSidebar} />
-        </section>
-      </div>
+
+        <${CollapsibleSection} title="에이전트 상태 상세">
+          <${FocusSidebar} compact=${true} />
+        <//>
+      ` : html`
+        <div class="live-panels grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
+          <section class="live-panel-main monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
+            <${ActivityStream} />
+          </section>
+          <section class="live-panel-side monitor-surface-card monitor-surface-card-medium min-h-[420px] xl:min-h-[520px] p-4">
+            <${FocusSidebar} />
+          </section>
+        </div>
+      `}
     </div>
   `
 }

--- a/dashboard/src/components/live/activity-stream.ts
+++ b/dashboard/src/components/live/activity-stream.ts
@@ -50,7 +50,7 @@ export function ActivityStream() {
         <span class="text-xs text-[var(--text-muted)]">${totalEvents.value} 수신 · ${entries.length} 표시</span>
       </div>
       <${FilterBar} />
-      <div class="activity-stream-list grid gap-2 content-start">
+      <div class="activity-stream-list grid max-h-[52vh] min-h-0 content-start gap-2 overflow-y-auto pr-1">
         ${entries.length === 0
           ? !connected.value
             ? html`<${ErrorState} message="실시간 연결이 끊겨있습니다. 서버 상태를 확인하세요." />`

--- a/dashboard/src/components/live/focus-sidebar.ts
+++ b/dashboard/src/components/live/focus-sidebar.ts
@@ -21,17 +21,25 @@ function pressureLabel(pressure: 'calm' | 'normal' | 'hot'): string {
   }
 }
 
-export function FocusSidebar() {
+interface FocusSidebarProps {
+  compact?: boolean
+}
+
+function FocusSidebarContent({ compact = false }: FocusSidebarProps) {
   const list = focusAgents.value
   const selected = selectedAgentName.value
 
   return html`
     <div class="grid gap-3 grid-rows-[auto_1fr] min-h-0">
-      <div class="focus-sidebar-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
-        <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--text-strong)]">에이전트</h3>
-        <span class="text-xs text-[var(--text-muted)]">${list.length}명 활성</span>
-      </div>
-      <div class="grid gap-1.5 content-start overflow-y-auto max-h-[560px] pr-1">
+      ${compact
+        ? null
+        : html`
+            <div class="focus-sidebar-head flex items-center justify-between gap-3 border-b border-[var(--border-slate-12)] pb-3">
+              <h3 class="m-0 text-[0.95rem] font-semibold text-[var(--text-strong)]">에이전트</h3>
+              <span class="text-xs text-[var(--text-muted)]">${list.length}명 활성</span>
+            </div>
+          `}
+      <div class="grid content-start gap-1.5 overflow-y-auto pr-1 ${compact ? 'max-h-[32vh]' : 'max-h-[560px]'}">
         ${list.length === 0
           ? html`<div class="py-6 text-center text-[var(--text-muted)] text-[13px]">활성 에이전트 없음. masc_join으로 접속하면 여기에 표시됩니다.</div>`
           : list.map(agent => html`
@@ -66,4 +74,8 @@ export function FocusSidebar() {
       </div>
     </div>
   `
+}
+
+export function FocusSidebar(props: FocusSidebarProps) {
+  return html`<${FocusSidebarContent} compact=${props.compact ?? false} />`
 }

--- a/dashboard/src/components/observatory/observatory.test.ts
+++ b/dashboard/src/components/observatory/observatory.test.ts
@@ -91,7 +91,7 @@ describe('Observatory', () => {
     vi.resetModules()
   })
 
-  it('renders live monitoring and activity-derived panels on one surface', async () => {
+  it('shows timeline panels by default', async () => {
     const { Observatory } = await import('./observatory')
 
     await act(async () => {
@@ -102,9 +102,44 @@ describe('Observatory', () => {
 
     expect(fetchTelemetry).toHaveBeenCalledTimes(1)
     expect(fetchToolQuality).toHaveBeenCalledTimes(1)
-    expect(container.textContent).toContain('live-monitor-stub')
     expect(container.textContent).toContain('activity-panels-stub')
+    expect(container.textContent).not.toContain('live-monitor-stub')
     expect(container.textContent).toContain('최근 1시간')
+    expect(container.textContent).toContain('자동 갱신')
     expect(container.textContent).toContain('hover any track for cross-signal readout')
-  })
+  }, 30000)
+
+  it('switches to live tab without rendering timeline panels', async () => {
+    const { Observatory, refreshObservatorySurface } = await import('./observatory')
+
+    await act(async () => {
+      render(html`<${Observatory} />`, container)
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    const liveButton = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.includes('라이브'))
+
+    expect(liveButton).toBeTruthy()
+
+    await act(async () => {
+      liveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(container.textContent).toContain('live-monitor-stub')
+    expect(container.textContent).not.toContain('activity-panels-stub')
+    expect(container.textContent).toContain('실시간 스트림과 에이전트 상태를 한곳에서 봅니다.')
+
+    await act(async () => {
+      refreshObservatorySurface()
+      await Promise.resolve()
+    })
+    await flushUi()
+
+    expect(fetchTelemetry).toHaveBeenCalledTimes(1)
+    expect(fetchToolQuality).toHaveBeenCalledTimes(1)
+  }, 30000)
 })

--- a/dashboard/src/components/observatory/observatory.ts
+++ b/dashboard/src/components/observatory/observatory.ts
@@ -45,6 +45,7 @@ import { ObservatoryActivityPanels } from '../activity-graph'
 
 const DEFAULT_RANGE: TimeRangePreset = '1h'
 const observatoryRefreshVersion = signal(0)
+type ObservatoryView = 'timeline' | 'live'
 
 // --- Observatory state ---
 
@@ -131,6 +132,36 @@ function RangeSelector() {
   `
 }
 
+function ViewSelector({
+  current,
+  onSelect,
+}: {
+  current: ObservatoryView
+  onSelect: (view: ObservatoryView) => void
+}) {
+  return html`
+    <div class="inline-flex items-center gap-0.5 rounded-md border border-card-border p-0.5 text-[11px]">
+      ${([
+        { key: 'timeline', label: '타임라인' },
+        { key: 'live', label: '라이브' },
+      ] as const).map(view => html`
+        <button
+          type="button"
+          class="rounded px-2 py-0.5 font-medium transition-colors ${
+            current === view.key
+              ? 'bg-accent/20 text-accent'
+              : 'text-text-muted hover:text-text-strong hover:bg-white/5'
+          }"
+          onClick=${() => onSelect(view.key)}
+          aria-pressed=${current === view.key}
+        >
+          ${view.label}
+        </button>
+      `)}
+    </div>
+  `
+}
+
 // --- Main container ---
 
 const LIVE_INTERVAL_MS = 30_000
@@ -143,20 +174,27 @@ export function Observatory() {
   const state = useSignal<ObservatoryData>(emptyData())
   const liveMode = useSignal(false)
   const refreshTick = useSignal(0)
+  const activeView = useSignal<ObservatoryView>('timeline')
   const activeController = useRef<AbortController | null>(null)
   const latestRequestId = useRef(0)
 
   useEffect(() => {
-    if (!liveMode.value) return
+    if (activeView.value !== 'timeline' || !liveMode.value) return
     const id = setInterval(() => { refreshTick.value++ }, LIVE_INTERVAL_MS)
     return () => clearInterval(id)
-  }, [liveMode.value])
+  }, [activeView.value, liveMode.value])
 
   useEffect(() => registerActivityRefresh(() => {
     refreshObservatorySurface()
   }), [])
 
   useEffect(() => {
+    if (activeView.value !== 'timeline') {
+      activeController.current?.abort()
+      activeController.current = null
+      return
+    }
+
     const keeper = currentKeeperFilter() ?? undefined
     const range = currentTimeRangeFilter() ?? DEFAULT_RANGE
 
@@ -212,59 +250,69 @@ export function Observatory() {
     })
 
     return () => { controller.abort() }
-  }, [currentKeeperFilter(), currentTimeRangeFilter(), refreshTick.value, observatoryRefreshVersion.value])
+  }, [activeView.value, currentKeeperFilter(), currentTimeRangeFilter(), refreshTick.value, observatoryRefreshVersion.value])
 
   const data = state.value
   const hasTrackData = data.events.length > 0 || data.hourlyTrend.length > 0
 
   return html`
     <div class="flex flex-col gap-5">
-      <${Live} />
-
       <div class="flex items-center justify-between">
         <div class="flex flex-col gap-0.5">
           <h3 class="text-[13px] font-semibold text-text-strong">관찰소 (Observatory)</h3>
           <p class="text-[11px] text-text-dim">
-            ${currentKeeperFilter() ? `keeper=${currentKeeperFilter()}` : '전체 keeper'}
-            · ${timeRangeLabel(currentTimeRangeFilter() ?? DEFAULT_RANGE)}
-            · ${data.totalMatchingEvents} events
-            ${data.truncatedEvents ? ` · showing ${data.events.length}` : ''}
-            ${liveMode.value ? ' · 30s auto-refresh' : ''}
+            ${activeView.value === 'timeline'
+              ? html`
+                  ${currentKeeperFilter() ? `keeper=${currentKeeperFilter()}` : '전체 keeper'}
+                  · ${timeRangeLabel(currentTimeRangeFilter() ?? DEFAULT_RANGE)}
+                  · ${data.totalMatchingEvents} events
+                  ${data.truncatedEvents ? ` · showing ${data.events.length}` : ''}
+                  ${liveMode.value ? ' · 30s 자동 갱신' : ''}
+                `
+              : '실시간 스트림과 에이전트 상태를 한곳에서 봅니다.'}
           </p>
         </div>
         <div class="flex items-center gap-2">
-          <${RangeSelector} />
-          <button
-            type="button"
-            class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
-              liveMode.value
-                ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400'
-                : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
-            }"
-            onClick=${() => {
-              liveMode.value = !liveMode.value
-              if (liveMode.value) refreshTick.value++
-            }}
-            aria-pressed=${liveMode.value}
-          >
-            ${liveMode.value ? html`
-              <span class="relative flex h-2 w-2">
-                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-                <span class="relative inline-flex rounded-full h-2 w-2 bg-emerald-400"></span>
-              </span>
-              Live
-            ` : 'Live'}
-          </button>
+          <${ViewSelector}
+            current=${activeView.value}
+            onSelect=${(view: ObservatoryView) => { activeView.value = view }}
+          />
+          ${activeView.value === 'timeline' ? html`
+            <${RangeSelector} />
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                liveMode.value
+                  ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400'
+                  : 'border-card-border text-text-muted hover:text-text-strong hover:bg-white/5'
+              }"
+              onClick=${() => {
+                liveMode.value = !liveMode.value
+                if (liveMode.value) refreshTick.value++
+              }}
+              aria-pressed=${liveMode.value}
+            >
+              ${liveMode.value ? html`
+                <span class="relative flex h-2 w-2">
+                  <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                  <span class="relative inline-flex rounded-full h-2 w-2 bg-emerald-400"></span>
+                </span>
+                자동 갱신
+              ` : '자동 갱신'}
+            </button>
+          ` : null}
         </div>
       </div>
 
-      ${data.error ? html`
+      ${activeView.value === 'timeline' && data.error ? html`
         <div class="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-200">
           일부 데이터 불러오기 실패: ${data.error}
         </div>
       ` : null}
 
-      ${!hasTrackData && data.loading
+      ${activeView.value === 'live'
+        ? html`<${Live} variant="observatory" />`
+        : !hasTrackData && data.loading
         ? html`<${LoadingState}>관찰소 데이터 불러오는 중...<//>`
         : html`
             <div class="flex flex-col gap-2 rounded-xl border border-card-border bg-card/30 p-4">
@@ -300,11 +348,13 @@ export function Observatory() {
             <${DetailPane} />
           `}
 
-      <${ObservatoryActivityPanels} />
+      ${activeView.value === 'timeline' ? html`<${ObservatoryActivityPanels} />` : null}
 
-      <p class="text-[10px] text-text-dim italic">
+      ${activeView.value === 'timeline' ? html`
+        <p class="text-[10px] text-text-dim italic">
         Phase 3a — anomaly highlight. 추가 track(메모리, autoresearch)과 compare mode는 이후 단계에서.
-      </p>
+        </p>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -115,7 +115,7 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
     {
       id: 'observatory',
       label: '관찰소 (beta)',
-      description: '실시간 라이브 밴드와 조사형 타임라인을 한 화면에 통합합니다.',
+      description: '조사형 타임라인과 활동 분석을 한 화면에서 빠르게 훑습니다.',
       params: { section: 'observatory' },
     },
     {


### PR DESCRIPTION
## What changed
- split Observatory into `타임라인` and `라이브` modes so the default view stays focused on investigation tracks
- trim duplicated live-monitor chrome in Observatory mode and move agent state into a collapsible detail section
- cap the live activity stream height with internal scrolling instead of extending the full page
- stop timeline polling/fetch work while the `라이브` tab is active and rename the timeline refresh toggle to `자동 갱신`
- update Observatory tests to cover the default timeline view and verify that background refresh does not keep firing in live mode

## Why
The Observatory page had accumulated both timeline analysis and full live-monitor surfaces on one screen. That created excessive vertical scrolling, repeated status signals, and confusing `라이브`/`Live` terminology.

## Impact
- default Observatory entry is shorter and investigation-first
- detailed runtime status is still available on demand
- hidden timeline work no longer keeps refreshing when users are reading the live stream

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run src/components/observatory/observatory.test.ts --no-file-parallelism --maxWorkers=1 --testTimeout=30000`
