### PR TITLE
fix(verification): mirage-crypto verification_id (#7544)

### DIFF
--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -196,11 +196,22 @@ let request_of_yojson = function
        | _ -> Error "verification request requires 'id', 'task_id', 'worker' fields")
   | _ -> Error "verification request must be a JSON object"
 
-(** ID generation *)
+(** ID generation — cryptographic random, 128-bit space.
+
+    Prior implementation (#7544) combined [Time_compat.now ()] with
+    [Hashtbl.hash (Unix.gettimeofday ())], which collided inside the
+    same millisecond and relied on OCaml's process-specific structural
+    hash seed. Using [Mirage_crypto_rng] matches [Board.Post_id] and
+    [Autoresearch_knowledge.generate_finding_id] — 16 random bytes
+    (~2^128 collision space), no wallclock dependency. *)
 let generate_id () =
-  let ts = int_of_float (Time_compat.now () *. 1000.0) in
-  let hash = Hashtbl.hash (Unix.gettimeofday ()) land 0xFFFFFF in
-  Printf.sprintf "vrf-%d-%06x" ts hash
+  let rnd = Mirage_crypto_rng.generate 16 in
+  let hex = String.concat "" (
+    List.init (String.length rnd) (fun i ->
+      Printf.sprintf "%02x" (Char.code (String.get rnd i))
+    )
+  ) in
+  "vrf-" ^ hex
 
 (** Automated criterion evaluation *)
 let evaluate_criterion output criterion =

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -1,5 +1,8 @@
 (** Tests for Verification module *)
 
+(* Mirage_crypto_rng is consumed by V.generate_id (#7544). *)
+let () = Mirage_crypto_rng_unix.use_default ()
+
 module V = Masc_mcp.Verification
 
 (** Use a temporary directory for each test *)
@@ -208,6 +211,26 @@ let test_auto_verify_with_custom_fails () =
         | Error _ -> ()
         | Ok _ -> Alcotest.fail "auto-verify with custom should fail")
 
+(* --- ID generation property test (#7544) --- *)
+
+module StringSet = Set.Make (String)
+
+let test_generate_id_prefix () =
+  let id = V.generate_id () in
+  Alcotest.(check bool) "vrf- prefix" true
+    (String.length id > 4 && String.sub id 0 4 = "vrf-")
+
+let test_generate_id_no_collisions () =
+  (* 10000 consecutive ids must be unique — the old Hashtbl.hash-based
+     generator collided within the same millisecond. *)
+  let n = 10_000 in
+  let seen = ref StringSet.empty in
+  for _ = 1 to n do
+    let id = V.generate_id () in
+    seen := StringSet.add id !seen
+  done;
+  Alcotest.(check int) "all 10k ids unique" n (StringSet.cardinal !seen)
+
 let test_pending_for_agent () =
   with_temp_dir (fun base_path ->
     let _ = V.create_request ~base_path ~task_id:"t1"
@@ -242,6 +265,10 @@ let () =
     "cross_agent", [
       Alcotest.test_case "same agent rejected" `Quick test_cross_agent_same;
       Alcotest.test_case "different agents ok" `Quick test_cross_agent_different;
+    ];
+    "id_generation", [
+      Alcotest.test_case "vrf- prefix" `Quick test_generate_id_prefix;
+      Alcotest.test_case "10k ids collision-free" `Quick test_generate_id_no_collisions;
     ];
     "storage", [
       Alcotest.test_case "create and load" `Quick test_create_and_load;


### PR DESCRIPTION
## Summary
Replaces the collision-prone `Verification.generate_id` — `Time_compat.now () + Hashtbl.hash (Unix.gettimeofday ())` — with a 128-bit cryptographic random id via `Mirage_crypto_rng.generate 16`, matching `Board.Post_id.generate` and `Autoresearch_knowledge.generate_finding_id`.

## Why (per #7544)

The old generator has two real issues:

1. **Process-local hash seed** — OCaml's structural hash seeds itself per process, so "deterministic" ID formation across restarts was a lie.
2. **Same-ms collisions** — CDAL verdict gate creates verifications in rapid bursts. A collision inside a single ms was reachable in practice.

No new dependencies — `mirage-crypto-rng` is already vendored and initialised at server boot (`bin/main_eio.ml:415`).

## Scope note

The parent issue's listing of `lib/coord/coord_task.ml:703-706` was stale — that duplicate block had already been removed before this PR. Only one generator site remained (`lib/verification.ml:200`), so the acceptance criterion "single implementation" is met without additional moves.

## Test plan
- [x] `dune build --root .` green
- [x] New `id_generation` group in `test/test_verification.ml`:
  - `vrf-` prefix invariant
  - 10,000 consecutive ids → 10,000 unique (property test from issue acceptance)
- [x] All 22 verification tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)