### PR TITLE
[codex] Tighten admin snapshot permissions

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -137,13 +137,12 @@ let _tool_spec_read_only =
 
 let tool_required_permission = function
   | "masc_config" | "masc_dashboard"
-  | "masc_tool_stats" | "masc_tool_help" | "masc_web_search"
-  | "masc_tool_admin_snapshot" ->
+  | "masc_tool_stats" | "masc_tool_help" | "masc_web_search" ->
       Some Types.CanReadState
+  | "masc_tool_admin_snapshot" | "masc_tool_admin_update" ->
+      Some Types.CanAdmin
   | "masc_webrtc_offer" | "masc_webrtc_answer" | "masc_cleanup_zombies" ->
       Some Types.CanBroadcast
-  | "masc_tool_admin_update" ->
-      Some Types.CanAdmin
   | _ -> None
 
 let () =

--- a/lib/tool_permission_map.ml
+++ b/lib/tool_permission_map.ml
@@ -86,7 +86,7 @@ let legacy_permission_entries : (string * permission) list =
     ("masc_tool_list", CanReadState);
     ("masc_tool_grant", CanAdmin);
     ("masc_tool_revoke", CanAdmin);
-    ("masc_tool_admin_snapshot", CanReadState);
+    ("masc_tool_admin_snapshot", CanAdmin);
     ("masc_tool_admin_update", CanAdmin);
     ("masc_portal_open", CanOpenPortal);
     ("masc_portal_close", CanOpenPortal);

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -441,8 +441,8 @@ let test_permission_for_tool_stats () =
 
 let test_permission_for_tool_admin_snapshot () =
   match Auth.permission_for_tool "masc_tool_admin_snapshot" with
-  | Some Types.CanReadState -> ()
-  | _ -> fail "expected CanReadState"
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
 
 let test_permission_for_tool_admin_update () =
   match Auth.permission_for_tool "masc_tool_admin_update" with

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -179,6 +179,15 @@ let test_http_write_auth_contracts () =
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
        "~net:state.Mcp_server.net")
 
+let test_tool_admin_snapshot_auth_contracts () =
+  check bool "tool admin snapshot metadata requires admin permission" true
+    (file_contains_pattern "lib/tool_misc.ml"
+       {|"masc_tool_admin_snapshot" | "masc_tool_admin_update" ->
+      Some Types.CanAdmin|});
+  check bool "tool admin snapshot legacy permission map requires admin" true
+    (file_contains_pattern "lib/tool_permission_map.ml"
+       {|("masc_tool_admin_snapshot", CanAdmin)|})
+
 let test_keeper_direct_reply_contracts () =
   check bool "dashboard keeper direct messages request direct reply" true
     (file_contains_pattern "dashboard/src/api/keeper.ts"
@@ -644,6 +653,8 @@ let () =
            test_case "health and ci diagnostics" `Quick test_health_and_ci_runner_diagnostics;
            test_case "route auth contracts" `Quick test_route_auth_contracts;
            test_case "http write auth contracts" `Quick test_http_write_auth_contracts;
+           test_case "tool admin snapshot auth contracts" `Quick
+             test_tool_admin_snapshot_auth_contracts;
            test_case "keeper direct reply contracts" `Quick
              test_keeper_direct_reply_contracts;
            test_case "dashboard warm hydration contracts" `Quick

--- a/test/test_tool_access_role.ml
+++ b/test/test_tool_access_role.ml
@@ -199,6 +199,7 @@ let test_permissions_promoted_to_metadata_ssot () =
       ("masc_heartbeat", Types.CanBroadcast);
       ("masc_config", Types.CanReadState);
       ("masc_tool_list", Types.CanReadState);
+      ("masc_tool_admin_snapshot", Types.CanAdmin);
       ("masc_runtime_verify", Types.CanReadState);
       ("masc_persona_list", Types.CanReadState);
       ("masc_keeper_reset", Types.CanBroadcast);


### PR DESCRIPTION
## Summary
- require CanAdmin for masc_tool_admin_snapshot in the declared permission SSOT
- align the legacy permission map and metadata coverage expectations
- add a source guard so the snapshot does not drift back to reader-grade access

## Testing
- dune build --root . test/test_auth_coverage.exe test/test_tool_access_role.exe test/test_ci_hardening_source.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_tool_access_role.exe
- ./_build/default/test/test_ci_hardening_source.exe