### PR TITLE
feat(metrics): prompt-cache Prometheus counters (#7469 Step 1)

### DIFF
--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2279,13 +2279,16 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock
              hit rate is observable. Skip when both are zero — non-caching
              providers (GLM/local-llama) would otherwise register a series
-             per keeper+model combination that never moves off zero. *)
+             per keeper+model combination that never moves off zero.
+             Metric names pulled from [Prometheus] constants so a typo
+             here would fail to compile instead of silently creating a
+             dead series. *)
           (if result.usage.cache_creation_input_tokens > 0 then
-             Prometheus.inc_counter "masc_keeper_cache_creation_tokens_total"
+             Prometheus.inc_counter Prometheus.metric_keeper_cache_creation_tokens
                ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
                ~delta:(float_of_int result.usage.cache_creation_input_tokens) ());
           (if result.usage.cache_read_input_tokens > 0 then
-             Prometheus.inc_counter "masc_keeper_cache_read_tokens_total"
+             Prometheus.inc_counter Prometheus.metric_keeper_cache_read_tokens
                ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
                ~delta:(float_of_int result.usage.cache_read_input_tokens) ());
           Log.Keeper.info

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -2276,6 +2276,18 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           Prometheus.inc_counter "masc_keeper_output_tokens_total"
             ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
             ~delta:(float_of_int result.usage.output_tokens) ();
+          (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock
+             hit rate is observable. Skip when both are zero — non-caching
+             providers (GLM/local-llama) would otherwise register a series
+             per keeper+model combination that never moves off zero. *)
+          (if result.usage.cache_creation_input_tokens > 0 then
+             Prometheus.inc_counter "masc_keeper_cache_creation_tokens_total"
+               ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+               ~delta:(float_of_int result.usage.cache_creation_input_tokens) ());
+          (if result.usage.cache_read_input_tokens > 0 then
+             Prometheus.inc_counter "masc_keeper_cache_read_tokens_total"
+               ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
+               ~delta:(float_of_int result.usage.cache_read_input_tokens) ());
           Log.Keeper.info
             "%s: keeper cycle OK model=%s tokens=%d latency=%dms mode=%s stop=%s"
             updated_meta.name model_used

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -278,6 +278,19 @@ let init () =
   add "masc_keeper_output_tokens_total"
     "Cumulative output tokens per keeper turn (labels: keeper_name, model)"
     Counter;
+  (* Anthropic / Bedrock prompt caching observability (#7469 Step 1).
+     OAS already receives [cache_creation_input_tokens] and
+     [cache_read_input_tokens] in every [api_usage]; these counters
+     expose them to Prometheus so cache hit-rate and write cost are
+     attributable per keeper + model. Populated dynamically via
+     [inc_counter]; tools that never emit cache data (e.g. non-Anthropic
+     providers) simply leave these at 0. *)
+  add "masc_keeper_cache_creation_tokens_total"
+    "Cumulative prompt-cache creation tokens per keeper turn (labels: keeper_name, model)"
+    Counter;
+  add "masc_keeper_cache_read_tokens_total"
+    "Cumulative prompt-cache read tokens per keeper turn (labels: keeper_name, model)"
+    Counter;
   (* Tool schema budget gauges — set once at boot via
      [set_tool_schema_stats]. Covers #7483 Step 1. *)
   add "masc_mcp_tool_schema_count"

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -156,6 +156,23 @@ let observe_histogram name ?(labels=[]) value =
            metric_type = Counter; value = 1.0; labels;
          }))
 
+(** {1 Metric Name Constants}
+
+    Exported so registration here and [inc_counter] call-sites in
+    [keeper_unified_turn.ml] share a single source of truth. Without
+    this, a typo on either side produces a dead series with no build
+    error (the counter silently drifts to a new key).
+
+    Follow-up #7469 Step 1: only the cache counters are covered — the
+    existing input/output/turns counters still use inline strings and
+    should migrate in a separate pass to keep this PR surgical. *)
+
+let metric_keeper_cache_creation_tokens =
+  "masc_keeper_cache_creation_tokens_total"
+
+let metric_keeper_cache_read_tokens =
+  "masc_keeper_cache_read_tokens_total"
+
 (** {1 Built-in Metrics} *)
 
 let init () =
@@ -284,11 +301,12 @@ let init () =
      expose them to Prometheus so cache hit-rate and write cost are
      attributable per keeper + model. Populated dynamically via
      [inc_counter]; tools that never emit cache data (e.g. non-Anthropic
-     providers) simply leave these at 0. *)
-  add "masc_keeper_cache_creation_tokens_total"
+     providers) simply leave these at 0. Names are exported as module
+     constants below so registration and call-sites cannot drift. *)
+  add metric_keeper_cache_creation_tokens
     "Cumulative prompt-cache creation tokens per keeper turn (labels: keeper_name, model)"
     Counter;
-  add "masc_keeper_cache_read_tokens_total"
+  add metric_keeper_cache_read_tokens
     "Cumulative prompt-cache read tokens per keeper turn (labels: keeper_name, model)"
     Counter;
   (* Tool schema budget gauges — set once at boot via


### PR DESCRIPTION
## Summary
Exposes the prompt-cache token fields OAS already reports (`cache_creation_input_tokens`, `cache_read_input_tokens`) as two new Prometheus counters:

- `masc_keeper_cache_creation_tokens_total`
- `masc_keeper_cache_read_tokens_total`

Labels are `(keeper_name, model)` — identical to the existing `masc_keeper_input_tokens_total` / `masc_keeper_output_tokens_total` series, so dashboards aggregate them together.

## Why (per #7469)

The issue's ask is **measure before policy change**. Today:
- OAS already sends cache token counts in `api_usage`.
- MASC logs/dashboard/Prometheus all drop them.
- Zero visibility into whether turning `cache_system_prompt=true` would be an improvement for a given keeper.

Step 1 plugs that observability gap; Step 2 (opt-in cascade toggle) and Step 3 (default flip) stay gated on what these counters show.

## Design notes
- `inc_counter` is guarded by `value > 0`. Non-caching providers (GLM, local-llama) always send 0 for these fields; without the guard we'd register a dead series per keeper+model pair every turn.
- No new dependencies, no schema changes, no provider-specific code — pure observer.

## Test plan
- [x] `dune build --root .` green
- [ ] Deploy → scrape `/metrics` on a keeper that uses Anthropic → confirm both series appear with non-zero values
- [ ] Confirm GLM-only keeper shows no series for these counters (guard works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)