### PR TITLE
chore(cascade): establish SSOT for cascade profile names + drop dead drift

### DIFF
--- a/config/cascade.json
+++ b/config/cascade.json
@@ -1,51 +1,46 @@
 {
+  "_comment": "Known cascade profiles (SSOT: lib/keeper/keeper_cascade_profile.ml). Every <name>_models key here must correspond to a known cascade in that module, and vice versa. Personal/playground-only cascades belong in $MASC_BASE_PATH/.masc/playground/<persona>/.../cascade.json, not in this repo config.",
   "default_models": [
     {"model": "glm-coding:glm-5.1", "weight": 50},
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30},
     {"model": "ollama:gemma4:26b", "weight": 20}
   ],
-  "local_only_models": [
-    "ollama:qwen3.5:35b-a3b-nvfp4"
-  ],
+  "default_temperature": 0.3,
+  "default_max_tokens": 4096,
+  "default_api_key_env": {
+    "glm-coding": "ZAI_API_KEY_SB",
+    "glm": "ZAI_API_KEY_SB"
+  },
+
   "keeper_unified_models": [
     {"model": "glm-coding:glm-5.1", "weight": 50},
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 30},
     {"model": "ollama:gemma4:26b", "weight": 20}
   ],
-  "nick0cave_models": [
-    "glm-coding:glm-5-turbo",
-    "claude:claude-haiku-4-5-20251001",
-    "glm-coding:glm-5.1",
-    "gemini:gemini-2.5-flash",
+  "keeper_unified_temperature": 0.2,
+  "keeper_unified_max_tokens": 16384,
+
+  "local_only_models": [
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
-  "_comment": "Only endpoints the operator actually pays for. glm-coding = Coding Plan subscription (api.z.ai/api/coding/paas/v4). ollama = local MLX fallback. Removed 2026-04-12: (a) glm:glm-5.1 general API — operator has no pay-per-use balance, every call returned HTTP 429 code=1113 'Insufficient balance or no resource package. Please recharge.'. (b) groq:qwen/qwen3-32b — Groq model advertises context_window >= max_tokens, but qwen3-32b caps max_tokens at 40960 while cascade defaults carry 65536, so every call returned HTTP 400 'max_tokens must be less than or equal to 40960'. Both failures committed mutating tools (masc_add_task, keeper_board_vote, keeper_board_comment) before the cascade could fall through to ollama, driving keepers into ambiguous_partial_commit + manual_reconcile. coding_first profile removed 2026-04-12: all keepers now use keeper_unified.",
-  "_comment_nick0cave": "nick0cave is an opt-in implementation-heavy keeper profile. It prefers fast cloud coding models, then gemini, then local ollama fallback.",
+  "local_only_temperature": 0.2,
+  "local_only_max_tokens": 32768,
+
   "local_recovery_models": [
     "ollama:qwen3.5:35b-a3b-nvfp4"
   ],
   "local_recovery_temperature": 0.1,
   "local_recovery_max_tokens": 8192,
+
+  "_comment_tool_rerank": "inference-only override: tool_rerank has no _models of its own; callers reuse the default cascade's models and apply the short max_tokens here. Short responses for rerank scoring.",
+  "tool_rerank_temperature": 0.0,
+  "tool_rerank_max_tokens": 200,
+
   "_comment_sangsu": "sangsu is a persona keeper (홍상수-style 40대 남자) whose conversational turns rarely need tool calls.  Bias heavily toward local ollama to keep cost near zero, but include glm-coding as the second link in the cascade so [require_tool_use] turns auto-failover to a tool-capable cloud model instead of leaving the keeper idle.  Lower temperature (0.1) tightens ollama tool-call obedience per memory/reference_ollama-config-2026-04.  Cascade weight ordering acts as a fallback chain: 90% of orderings put ollama first (then glm), 10% put glm first (then ollama).",
   "sangsu_models": [
     {"model": "ollama:qwen3.5:35b-a3b-nvfp4", "weight": 90, "supports_tool_choice": true},
     {"model": "glm-coding:glm-5.1", "weight": 10}
   ],
   "sangsu_temperature": 0.1,
-  "sangsu_max_tokens": 16384,
-  "tool_rerank_temperature": 0.0,
-  "tool_rerank_max_tokens": 200,
-  "keeper_unified_temperature": 0.2,
-  "keeper_unified_max_tokens": 16384,
-  "nick0cave_temperature": 0.2,
-  "nick0cave_max_tokens": 16384,
-  "keeper_turn_max_tokens": 32768,
-  "local_only_temperature": 0.2,
-  "local_only_max_tokens": 32768,
-  "default_temperature": 0.3,
-  "default_max_tokens": 4096,
-  "default_api_key_env": {
-    "glm-coding": "ZAI_API_KEY_SB",
-    "glm": "ZAI_API_KEY_SB"
-  }
+  "sangsu_max_tokens": 16384
 }

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -33,14 +33,7 @@ let source_to_string = function
     Keepers run through [Keeper_cascade_profile.canonicalize], so any unknown
     keeper [cascade_name] from the registry also shows up below by virtue of
     being included in [keeper_profiles]. *)
-let standard_profiles = [
-  "keeper_unified";
-  "default";
-  "local_only";
-  "local_recovery";
-  "nick0cave";
-  "tool_rerank";
-]
+let standard_profiles = Keeper_cascade_profile.known_cascades
 
 let profile_json ~config_path name =
   let defaults = Cascade_runtime.default_model_strings ~cascade_name:name in

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -1,38 +1,65 @@
 (** See {!Keeper_cascade_profile} interface for rationale. *)
 
-let default_name = "keeper_unified"
+(** SSOT variant. Adding a new cascade profile is a compile-time event:
+    add a variant here, then exhaustive [match] sites flag every consumer
+    that needs to handle it. Personal/playground-only cascades must NOT
+    be added here — they live in
+    [$MASC_BASE_PATH/.masc/playground/.../cascade.json] only. *)
+type t =
+  | Default
+  | Keeper_unified
+  | Sangsu
+  | Local_only
+  | Local_recovery
+  | Tool_rerank
 
-(** SSOT for cascade profiles the repo's [config/cascade.json] may define.
-    Adding a new cascade profile requires adding it here AND populating
-    [<name>_models] (and optional [_temperature]/[_max_tokens]) in
-    cascade.json. Personal/playground-only cascades must live in
-    [$MASC_BASE_PATH/.masc/playground/.../cascade.json], not in this list. *)
-let known_cascades =
-  [ "default"
-  ; "keeper_unified"
-  ; "sangsu"
-  ; "local_only"
-  ; "local_recovery"
-  ; "tool_rerank"
-  ]
+let to_string = function
+  | Default -> "default"
+  | Keeper_unified -> "keeper_unified"
+  | Sangsu -> "sangsu"
+  | Local_only -> "local_only"
+  | Local_recovery -> "local_recovery"
+  | Tool_rerank -> "tool_rerank"
 
-let canonicalize (raw : string) : string =
-  let trimmed = String.trim raw in
-  let lc = String.lowercase_ascii trimmed in
-  match lc with
-  | "" -> default_name
+let all = [ Default; Keeper_unified; Sangsu; Local_only; Local_recovery; Tool_rerank ]
+
+(** All known cascade profile names, derived from the variant. Consumers
+    that still operate on strings can use this list; new code should
+    take {!t} directly. *)
+let known_cascades = List.map to_string all
+
+let default = Keeper_unified
+let default_name = to_string default
+
+let of_string_opt (raw : string) : t option =
+  match String.trim raw |> String.lowercase_ascii with
+  | "" -> Some default
+  | "default" -> Some Default
   | "keeper_unified"
   | "oas-keeper_unified"
   | "coding_first"
-  | "oas-coding_first" -> default_name
-  (* Historical drift: these were never defined as separate cascade
-     profiles; calls always fell through to default. Collapse them to
-     [default_name] explicitly so bucket/metric code does not see a
-     ghost value. *)
-  | "keeper_turn" | "keeper_reply" -> default_name
-  | name when List.mem name known_cascades -> trimmed
-  | _ -> default_name
+  | "oas-coding_first" -> Some Keeper_unified
+  (* Historical drift: never defined as separate profiles, always fell
+     through to default. Collapsed here so bucket/metric code does not
+     see a ghost value. *)
+  | "keeper_turn" | "keeper_reply" -> Some default
+  | "sangsu" -> Some Sangsu
+  | "local_only" -> Some Local_only
+  | "local_recovery" -> Some Local_recovery
+  | "tool_rerank" -> Some Tool_rerank
+  | _ -> None
 
-let models_key name = canonicalize name ^ "_models"
-let temperature_key name = canonicalize name ^ "_temperature"
-let max_tokens_key name = canonicalize name ^ "_max_tokens"
+let canonical (raw : string) : t =
+  match of_string_opt raw with
+  | Some t -> t
+  | None -> default
+
+let canonicalize (raw : string) : string = to_string (canonical raw)
+
+let models_key_t t = to_string t ^ "_models"
+let temperature_key_t t = to_string t ^ "_temperature"
+let max_tokens_key_t t = to_string t ^ "_max_tokens"
+
+let models_key name = models_key_t (canonical name)
+let temperature_key name = temperature_key_t (canonical name)
+let max_tokens_key name = max_tokens_key_t (canonical name)

--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -2,15 +2,36 @@
 
 let default_name = "keeper_unified"
 
+(** SSOT for cascade profiles the repo's [config/cascade.json] may define.
+    Adding a new cascade profile requires adding it here AND populating
+    [<name>_models] (and optional [_temperature]/[_max_tokens]) in
+    cascade.json. Personal/playground-only cascades must live in
+    [$MASC_BASE_PATH/.masc/playground/.../cascade.json], not in this list. *)
+let known_cascades =
+  [ "default"
+  ; "keeper_unified"
+  ; "sangsu"
+  ; "local_only"
+  ; "local_recovery"
+  ; "tool_rerank"
+  ]
+
 let canonicalize (raw : string) : string =
   let trimmed = String.trim raw in
-  match String.lowercase_ascii trimmed with
+  let lc = String.lowercase_ascii trimmed in
+  match lc with
   | "" -> default_name
   | "keeper_unified"
   | "oas-keeper_unified"
   | "coding_first"
   | "oas-coding_first" -> default_name
-  | _ -> trimmed
+  (* Historical drift: these were never defined as separate cascade
+     profiles; calls always fell through to default. Collapse them to
+     [default_name] explicitly so bucket/metric code does not see a
+     ghost value. *)
+  | "keeper_turn" | "keeper_reply" -> default_name
+  | name when List.mem name known_cascades -> trimmed
+  | _ -> default_name
 
 let models_key name = canonicalize name ^ "_models"
 let temperature_key name = canonicalize name ^ "_temperature"

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -8,9 +8,18 @@
 (** Canonical cascade profile for keeper turns. *)
 val default_name : string
 
-(** Map known legacy keeper aliases to the canonical cascade profile name.
-    Unknown names are preserved after trimming. Blank names fall back to
-    {!default_name}. *)
+(** SSOT list of cascade profile names valid in the repo [config/cascade.json].
+    Consumers (dashboards, validators, tests) should reference this list
+    rather than hardcoding their own. Personal/playground-only cascades
+    are NOT included here — those belong under
+    [$MASC_BASE_PATH/.masc/playground/.../cascade.json].
+    @since 0.9.5 *)
+val known_cascades : string list
+
+(** Map keeper aliases and historical drift names to the canonical
+    cascade profile name. Unknown names fall back to {!default_name}
+    (previously they passed through unchanged, which let typos and dead
+    profile names silently create ghost metric labels). *)
 val canonicalize : string -> string
 
 (** JSON config key for the cascade's configured model list. *)

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -5,28 +5,64 @@
     SSOT for the active keeper cascade profile and the legacy aliases that must
     continue to resolve to it. *)
 
-(** Canonical cascade profile for keeper turns. *)
-val default_name : string
+(** SSOT for valid cascade profiles in repo [config/cascade.json].
 
-(** SSOT list of cascade profile names valid in the repo [config/cascade.json].
-    Consumers (dashboards, validators, tests) should reference this list
-    rather than hardcoding their own. Personal/playground-only cascades
-    are NOT included here — those belong under
+    Adding a new profile is a compile-time event: add a variant here
+    and every exhaustive [match] across the codebase flags the consumer
+    sites that need to handle it. Personal/playground-only cascades
+    must NOT be added here — they live in
     [$MASC_BASE_PATH/.masc/playground/.../cascade.json].
+
     @since 0.9.5 *)
+type t =
+  | Default
+  | Keeper_unified
+  | Sangsu
+  | Local_only
+  | Local_recovery
+  | Tool_rerank
+
+val all : t list
+(** [all] is exhaustive: every variant constructor of {!t} appears
+    exactly once. Consumers that need to enumerate profiles should
+    derive from this rather than maintaining a parallel list. *)
+
+val to_string : t -> string
+(** Canonical lowercase-snake-case name, matching the
+    [<name>_models]/[<name>_temperature]/[<name>_max_tokens] convention
+    in [config/cascade.json]. *)
+
+val of_string_opt : string -> t option
+(** Parse a raw cascade name into the variant. Handles legacy aliases
+    ([oas-keeper_unified], [coding_first], [keeper_turn], [keeper_reply])
+    by collapsing them to their canonical variant. Returns [None] for
+    unknown names — use {!canonical} when you want a forced fallback. *)
+
+val canonical : string -> t
+(** [canonical raw] = [of_string_opt raw |> Option.value ~default]. *)
+
+val default : t
+val default_name : string
+(** [default_name = to_string default = "keeper_unified"]. *)
+
 val known_cascades : string list
+(** [known_cascades = List.map to_string all]. Provided for consumers
+    that still operate on strings (cascade.json key prefixes, metric
+    label allow-list); new code should take {!t} directly. *)
 
-(** Map keeper aliases and historical drift names to the canonical
-    cascade profile name. Unknown names fall back to {!default_name}
-    (previously they passed through unchanged, which let typos and dead
-    profile names silently create ghost metric labels). *)
 val canonicalize : string -> string
+(** [canonicalize raw = to_string (canonical raw)]. Existing
+    string-based call sites continue to work; unknown names now fall
+    back to {!default_name} (previously they passed through unchanged,
+    letting typos and dead profile names create ghost metric labels). *)
 
-(** JSON config key for the cascade's configured model list. *)
+(** {1 cascade.json key helpers} *)
+
+val models_key_t : t -> string
+val temperature_key_t : t -> string
+val max_tokens_key_t : t -> string
+
+(** String-based wrappers; first canonicalize, then build the key. *)
 val models_key : string -> string
-
-(** JSON config key for the cascade's configured temperature. *)
 val temperature_key : string -> string
-
-(** JSON config key for the cascade's configured max_tokens. *)
 val max_tokens_key : string -> string

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -163,7 +163,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
           ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
           ~generation:meta.runtime.generation
       in
-      let turn_cascade_name = if direct_reply then "keeper_reply" else "keeper_turn" in
+      (* Historical drift: "keeper_turn" / "keeper_reply" were never defined
+         as separate cascade profiles in cascade.json; they always fell
+         through to default via Keeper_cascade_profile.canonicalize. Using
+         default_name here makes the resolution explicit and keeps metric
+         buckets/Prometheus labels from seeing ghost cascade names. *)
+      let turn_cascade_name = Keeper_cascade_profile.default_name in
       let effective_models =
         if direct_reply then
           Cascade_runtime.models_of_cascade_name turn_cascade_name

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -223,9 +223,12 @@ let test_keeper_direct_reply_contracts () =
   check bool "keeper turn parses direct reply flag" true
     (file_contains_pattern "lib/keeper/keeper_turn.ml"
        "get_bool args \"direct_reply\"");
-  check bool "keeper turn promotes direct replies to reply cascade" true
-    (file_contains_pattern "lib/keeper/keeper_turn.ml"
-       {|let turn_cascade_name = if direct_reply then "keeper_reply" else "keeper_turn"|});
+  (* Historical: direct_reply once forked cascade name into
+     "keeper_reply"/"keeper_turn", but neither was ever defined in
+     cascade.json — the drift collapsed to the default cascade via
+     Keeper_cascade_profile.canonicalize. The fork is gone; the
+     direct_reply flag now only affects persona prompt + skill-route
+     suppression (checked below). *)
   check bool "keeper turn suppresses skill route headers for direct reply" true
     (file_contains_pattern "lib/keeper/keeper_turn.ml"
        "let effective_no_skill_route = no_skill_route || direct_reply");

--- a/test/test_dashboard_harness_health.ml
+++ b/test/test_dashboard_harness_health.ml
@@ -45,7 +45,7 @@ let make_keeper_meta ?(name = "keeper-a") ?(trace_id = "trace-keeper-a") () =
           ("name", `String name);
           ("agent_name", `String name);
           ("trace_id", `String trace_id);
-          ("cascade_name", `String "keeper_unified");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("last_model_used", `String "llama:auto");
         ])
   with

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -281,7 +281,7 @@ let make_keeper_meta_json ?(name = "route-shadow-demo") () =
           ; "agent_name", `String ("keeper-" ^ name ^ "-agent")
           ; "trace_id", `String ("trace-" ^ name ^ "-seed")
           ; "goal", `String "Route shadow regression fixture"
-          ; "cascade_name", `String "keeper_unified"
+          ; "cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name
           ; "updated_at", `String "2026-04-04T00:00:00Z"
           ; "paused", `Bool true
           ])

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -307,7 +307,8 @@ let test_calibration_stats_cross_model_mix () =
   let same_cascade =
     make_result ~cascade:"verifier" ~gen_cascade:"verifier" () in
   let cross_a =
-    make_result ~cascade:"verifier" ~gen_cascade:"keeper_unified" () in
+    make_result ~cascade:"verifier"
+      ~gen_cascade:Masc_mcp.Keeper_config.default_cascade_name () in
   let cross_b =
     make_result ~cascade:"cross_verifier" ~gen_cascade:"local_only" () in
   let no_generator = make_result ~cascade:"verifier" () in

--- a/test/test_keeper_cascade_routing.ml
+++ b/test/test_keeper_cascade_routing.ml
@@ -15,7 +15,7 @@ let routing_t = testable
      Printf.sprintf "{cascade=%s, reason=%s}" r.effective_cascade r.reason))
   (fun a b -> a.effective_cascade = b.effective_cascade)
 
-let base = "keeper_unified"
+let base = Masc_mcp.Keeper_config.default_cascade_name
 
 let select phase =
   Routing.select_cascade ~base_cascade:base ~phase

--- a/test/test_keeper_exec_status.ml
+++ b/test/test_keeper_exec_status.ml
@@ -20,7 +20,7 @@ let make_meta ?(name = "keeper-exec-status-test")
           ("name", `String name);
           ("agent_name", `String name);
           ("trace_id", `String trace_id);
-          ("cascade_name", `String "keeper_unified");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("last_model_used", `String "llama:auto");
         ])
   with

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -114,7 +114,7 @@ let make_keeper_meta ?(name = "keeper-lifecycle-test")
           ("name", `String name);
           ("agent_name", `String name);
           ("trace_id", `String trace_id);
-          ("cascade_name", `String "keeper_unified");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("last_model_used", `String "llama:auto");
         ])
   with

--- a/test/test_keeper_llama_only.ml
+++ b/test/test_keeper_llama_only.ml
@@ -36,7 +36,7 @@ let make_meta ?(last_model_used = "glm-5.1") ?(models = []) () =
           ("name", `String "keeper-llama-only-test");
           ("agent_name", `String "keeper-llama-only-test");
           ("trace_id", `String "trace-keeper-llama-only");
-          ("cascade_name", `String "keeper_unified");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("last_model_used", `String last_model_used);
         ])
     with

--- a/test/test_keeper_unified.ml
+++ b/test/test_keeper_unified.ml
@@ -1105,7 +1105,7 @@ let test_metrics_surface_model_prefers_successful_cascade_label () =
       ~model:"qwen3.5:27b-nvfp4" ~input_tok:100 ~output_tok:50
       ~cascade_observation:
         {
-          Masc_mcp.Oas_worker.cascade_name = "keeper_unified";
+          Masc_mcp.Oas_worker.cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
           configured_labels = [ "llama:auto" ];
           candidate_models =
             [ "llama:qwen3.5-35b-a3b-ud-q8-xl"; selected_label ];
@@ -1461,7 +1461,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
           cascade_observation =
             Some
               {
-                Masc_mcp.Oas_worker.cascade_name = "keeper_unified";
+                Masc_mcp.Oas_worker.cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
                 configured_labels = [ "llama:auto" ];
                 candidate_models =
                   [
@@ -1552,7 +1552,7 @@ let test_append_metrics_snapshot_includes_cascade_observation () =
         Yojson.Safe.Util.(json |> member "model_used" |> to_string);
       check bool "cascade field present" true
         Yojson.Safe.Util.(json |> member "cascade" <> `Null);
-      check string "cascade name persisted" "keeper_unified"
+      check string "cascade name persisted" Masc_mcp.Keeper_config.default_cascade_name
         Yojson.Safe.Util.(
           json |> member "cascade" |> member "cascade_name" |> to_string);
       check bool "fallback applied persisted" true
@@ -2190,7 +2190,7 @@ let test_cascade_exhausted_error_detected_from_structured_internal_error () =
     Masc_mcp.Oas_worker_named.sdk_error_of_masc_internal_error
       (Masc_mcp.Oas_worker_named.Cascade_exhausted
          {
-           cascade_name = "keeper_unified";
+           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
            detail = Some "all providers failed";
          })
   in

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -322,7 +322,7 @@ let test_cascade_inference_normalizes_keeper_aliases () =
         ("keeper_unified_max_tokens", `Int 16384);
       ]
   in
-  let canonical = Cascade_inference.for_json ~name:"keeper_unified" json in
+  let canonical = Cascade_inference.for_json ~name:Masc_mcp.Keeper_config.default_cascade_name json in
   let legacy_oas = Cascade_inference.for_json ~name:"oas-keeper_unified" json in
   let legacy_removed = Cascade_inference.for_json ~name:"oas-coding_first" json in
   Alcotest.(check (option (float 0.0001))) "canonical temp"
@@ -337,7 +337,7 @@ let test_cascade_inference_normalizes_keeper_aliases () =
 let test_cascade_observation_json_includes_fallback_fields () =
   let observation : Oas_worker.cascade_observation =
     {
-      cascade_name = "keeper_unified";
+      cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
       configured_labels = [ "glm:auto"; "llama:auto" ];
       candidate_models = [ "glm:glm-5.1"; "openai:qwen3.5-35b" ];
       primary_model = Some "glm:glm-5.1";
@@ -378,7 +378,7 @@ let test_cascade_observation_json_includes_fallback_fields () =
     }
   in
   let json = Oas_worker.cascade_observation_to_json observation in
-  Alcotest.(check string) "cascade name preserved" "keeper_unified"
+  Alcotest.(check string) "cascade name preserved" Masc_mcp.Keeper_config.default_cascade_name
     Yojson.Safe.Util.(json |> member "cascade_name" |> to_string);
   Alcotest.(check bool) "fallback applied preserved" true
     Yojson.Safe.Util.(json |> member "fallback_applied" |> to_bool);
@@ -737,13 +737,13 @@ let test_classify_masc_internal_error_roundtrip () =
     Oas_worker_named.sdk_error_of_masc_internal_error
       (Oas_worker_named.Cascade_exhausted
          {
-           cascade_name = "keeper_unified";
+           cascade_name = Masc_mcp.Keeper_config.default_cascade_name;
            detail = Some "all providers failed";
          })
   in
   (match Oas_worker_named.classify_masc_internal_error cascade_err with
    | Some (Oas_worker_named.Cascade_exhausted { cascade_name; detail }) ->
-       Alcotest.(check string) "cascade name" "keeper_unified" cascade_name;
+       Alcotest.(check string) "cascade name" Masc_mcp.Keeper_config.default_cascade_name cascade_name;
        Alcotest.(check (option string)) "cascade detail"
          (Some "all providers failed") detail
    | _ -> Alcotest.fail "expected structured cascade exhaustion");
@@ -751,14 +751,14 @@ let test_classify_masc_internal_error_roundtrip () =
     Oas_worker_named.sdk_error_of_masc_internal_error
       (Oas_worker_named.Accept_rejected
          {
-           scope = "keeper_unified";
+           scope = Masc_mcp.Keeper_config.default_cascade_name;
            model = Some "mock-model";
            reason = "response rejected by accept (model=mock-model)";
          })
   in
   match Oas_worker_named.classify_masc_internal_error accept_err with
   | Some (Oas_worker_named.Accept_rejected { scope; model; reason }) ->
-      Alcotest.(check string) "accept scope" "keeper_unified" scope;
+      Alcotest.(check string) "accept scope" Masc_mcp.Keeper_config.default_cascade_name scope;
       Alcotest.(check (option string)) "accept model"
         (Some "mock-model") model;
       Alcotest.(check bool) "accept reason preserved" true
@@ -1045,7 +1045,7 @@ let make_keeper_meta ?(name = "keeper-checkpoint-test")
           ("name", `String name);
           ("agent_name", `String name);
           ("trace_id", `String trace_id);
-          ("cascade_name", `String "keeper_unified");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("last_model_used", `String "llama:auto");
         ])
   with

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -337,7 +337,7 @@ let test_keeper_status_exposes_model_observability () =
             ( "cascade",
               `Assoc
                 [
-                  ("cascade_name", `String "keeper_unified");
+                  ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
                   ( "configured_labels",
                     `List [ `String "llama:auto"; `String "glm:auto" ] );
                   ( "candidate_models",
@@ -387,7 +387,7 @@ let test_keeper_status_exposes_model_observability () =
       let status_dump = Yojson.Safe.pretty_to_string status_json in
       Alcotest.(check (option string))
         ("cascade name surfaced\n" ^ status_dump)
-        (Some "keeper_unified")
+        (Some Masc_mcp.Keeper_config.default_cascade_name)
         (observability |> member "cascade_name" |> to_string_option);
       Alcotest.(check bool) "recent turn observation true" true
         (observability |> member "recent_turn_observation" |> to_bool);

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -438,7 +438,7 @@ let make_keeper_meta_json ?(name = "sangsu")
           ("agent_name", `String ("keeper-" ^ name ^ "-agent"));
           ("trace_id", `String trace_id);
           ("goal", `String ("goal-" ^ name));
-          ("cascade_name", `String "keeper_unified");
+          ("cascade_name", `String Masc_mcp.Keeper_config.default_cascade_name);
           ("updated_at", `String updated_at);
           ("last_model_used", `String "llama:auto");
         ])

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -625,12 +625,13 @@ let () = test "build_verdict_sse_payload: distinct cascades = cross_model true" 
   let result =
     make_review_result
       ~evaluator_cascade:"verifier"
-      ~generator_cascade:"keeper_unified"
+      ~generator_cascade:Masc_mcp.Keeper_config.default_cascade_name
       () in
   let json = Tool_task.build_verdict_sse_payload
     ~now:1234567890.0 ~task_id:"t1" ~req ~result in
   assert (payload_member "cross_model" json = `Bool true);
-  assert (payload_member "generator_cascade" json = `String "keeper_unified");
+  assert (payload_member "generator_cascade" json
+          = `String Masc_mcp.Keeper_config.default_cascade_name);
   assert (payload_member "evaluator_cascade" json = `String "verifier");
   assert (payload_member "task_id" json = `String "t1")
 )
@@ -679,7 +680,7 @@ let () = test "build_verdict_sse_payload: empty evaluator string = cross_model f
   let result =
     make_review_result
       ~evaluator_cascade:""
-      ~generator_cascade:"keeper_unified"
+      ~generator_cascade:Masc_mcp.Keeper_config.default_cascade_name
       () in
   let json = Tool_task.build_verdict_sse_payload
     ~now:1234567890.0 ~task_id:"t5" ~req ~result in


### PR DESCRIPTION
## Summary (P0 of cascade SSOT roadmap)

Three coupled cleanups:

1. **nick0cave removed from repo** — personal/playground cascade without a corresponding keeper TOML. Moves to basepath-only.
2. **keeper_turn / keeper_reply drift eliminated** — raw strings in keeper_turn.ml that were never defined as profiles; now resolve explicitly to default via canonicalize.
3. **known_cascades SSOT exposed** — 6 valid profiles listed in one place; canonicalize now fallback-to-default on unknown (no more silent drift).

## Motivation

User audit turned up three symptoms of the same root cause: cascade_name was stringly-typed with no validation, letting drift values (keeper_turn, keeper_reply, nick0cave ghost) leak into cascade.json keys, dashboard lists, admission_queue buckets, and Prometheus metric labels.

This PR fixes the naming SSOT. Follow-up PRs will propagate canonicalize through admission_queue / metrics / TOML load (P1) and add validation invariants (P2).

## Changes

### config/cascade.json
- Removed: `nick0cave_*` keys, `_comment_nick0cave`, orphan `keeper_turn_max_tokens`
- Added: top-level `_comment` documenting the SSOT rule + `_comment_tool_rerank` explaining the inference-only override pattern

### lib/keeper/keeper_cascade_profile.{ml,mli}
- New export: `known_cascades : string list` — authoritative list of profile names valid in repo cascade.json
- `canonicalize` now maps `keeper_turn` / `keeper_reply` to `default_name` (historical drift) and falls back any unknown name to `default_name` (was: pass-through)

### lib/keeper/keeper_turn.ml:166
- Dropped raw `cascade_name = \"keeper_turn\"/\"keeper_reply\"` string; now uses `Keeper_cascade_profile.default_name` directly. `direct_reply` still drives prompt-level behaviour.

### lib/dashboard_cascade.ml
- `standard_profiles` now re-uses `Keeper_cascade_profile.known_cascades` instead of maintaining a parallel list

## Out of scope (follow-up PRs)

- **P1**: canonicalize enforcement at admission_queue / metrics / TOML load boundaries
- **P2**: cascade_config_validity test invariants (orphan key detection, known_cascades cross-check)
- **P3**: docs/CASCADE-CONFIG-SPEC.md, KEEPER-USER-MANUAL.md cascade section
- **P4**: local_only / local_recovery / direct_reply live-usage audit

## Test plan
- [x] dune build --root . green
- [ ] CI runtest
- [ ] Manual: sangsu keeper still resolves to its cascade post-merge (hot-reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)