### PR TITLE
[codex] Restrict loopback dev mutation origins

### DIFF
--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -272,6 +272,9 @@ cd dashboard && pnpm run build
 # Dev server (Vite dev mode, HMR, proxy)
 cd dashboard && MASC_DASHBOARD_PROXY_TARGET="http://127.0.0.1:8935" pnpm run dev
 
+# Vite port를 5173이 아닌 값으로 바꾸면 서버 쪽 allowlist도 같이 맞춘다.
+MASC_HTTP_DEV_MUTATION_ORIGINS="http://localhost:4173" ./start-masc-mcp.sh
+
 # Production build (static assets in dist/)
 cd dashboard && pnpm run build
 ```
@@ -400,4 +403,3 @@ cd dashboard && pnpm run build  # TypeScript type check
 - [ ] Registry-like file 수정했는가? → Section #13 체크
 
 **마지막 업데이트**: 2026-03-30 (ADR-003 추가, Section #8-#13 신규)
-

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -500,6 +500,7 @@ Vite 설정:
 - `outDir: '../assets/dashboard'` (OCaml 서버가 서빙하는 위치)
 - `manualChunks: { vendor: ['preact', 'preact/hooks', 'htm', '@preact/signals'] }`
 - Dev proxy: `MASC_DASHBOARD_PROXY_TARGET` -> `/api/*`, `/sse/*` 프록시
+- 무토큰 loopback mutation은 기본적으로 `http://localhost:5173`, `http://127.0.0.1:5173`, `http://[::1]:5173`만 허용. 다른 dev origin/port를 쓰면 서버 프로세스에 `MASC_HTTP_DEV_MUTATION_ORIGINS`를 설정
 
 ## 5. HTTP API Endpoints
 
@@ -620,6 +621,7 @@ Vite 설정:
 |------|--------|------|
 | `MASC_ASSETS_ROOT` / `MASC_ASSETS_DIR` | `{exe_dir}/assets` | Static asset 루트 |
 | `MASC_DASHBOARD_PROXY_TARGET` | (필수, dev only) | Vite dev server API proxy 대상 |
+| `MASC_HTTP_DEV_MUTATION_ORIGINS` | `http://localhost:5173,http://127.0.0.1:5173,http://[::1]:5173` | 무토큰 loopback cross-port mutation을 허용할 dev origin 목록 (comma-separated) |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_ENABLED` | `true` | Governance judge daemon 활성화 |
 | `MASC_DASHBOARD_GOVERNANCE_JUDGE_INTERVAL_SEC` | `60` | Judge 갱신 간격 (최소 15s) |
 | `MASC_DASHBOARD_TOOL_CALL_WINDOW_HOURS` | `1.0` | Tool call health window (0.1~168h) |

--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -146,7 +146,15 @@ let default_port_of_scheme = function
 let normalize_loopback_host host =
   match String.lowercase_ascii (String.trim host) with
   | "127.0.0.1" -> "localhost"
+  | "::1" | "0:0:0:0:0:0:0:1" -> "localhost"
   | other -> other
+
+let trim_nonempty raw =
+  let value = String.trim raw in
+  if String.equal value "" then None else Some value
+
+let split_csv_nonempty raw =
+  raw |> String.split_on_char ',' |> List.filter_map trim_nonempty
 
 (** Returns (host, explicit_port, scheme). *)
 let host_port_scheme_of_origin origin =
@@ -185,6 +193,36 @@ let allow_anonymous_mutations =
   | Some ("1" | "true") -> true
   | _ -> false
 
+let default_loopback_dev_mutation_origins =
+  [
+    "http://127.0.0.1:5173";
+    "http://localhost:5173";
+    "http://[::1]:5173";
+  ]
+
+let configured_loopback_dev_mutation_origins () =
+  match Sys.getenv_opt "MASC_HTTP_DEV_MUTATION_ORIGINS" with
+  | Some raw -> split_csv_nonempty raw
+  | None -> default_loopback_dev_mutation_origins
+
+let normalized_origin_key origin =
+  match host_port_scheme_of_origin origin with
+  | Some (host, port, scheme) ->
+      let default = default_port_of_scheme scheme in
+      Some
+        ( normalize_loopback_host host,
+          (match port with Some _ -> port | None -> default),
+          Option.map String.lowercase_ascii scheme )
+  | None -> None
+
+let is_allowlisted_loopback_dev_origin origin =
+  match normalized_origin_key origin with
+  | Some ((host, _, _) as candidate) when is_loopback_host host ->
+      configured_loopback_dev_mutation_origins ()
+      |> List.filter_map normalized_origin_key
+      |> List.exists (fun allowed -> allowed = candidate)
+  | _ -> false
+
 let ensure_same_origin_browser_request request :
     (unit, Types.masc_error) result =
   match Httpun.Headers.get request.Httpun.Request.headers "origin" with
@@ -203,17 +241,17 @@ let ensure_same_origin_browser_request request :
                (normalize_loopback_host request_host) ->
           let default = default_port_of_scheme scheme in
           let norm p = match p with Some _ -> p | None -> default in
-          (* Loopback relaxation: when both origin and host resolve to a
-             loopback address (localhost / 127.0.0.1 / ::1), cross-port
-             mutations are allowed. The dev proxy (vite 5173 → backend
-             8935) relies on this, and remote attackers cannot forge a
-             loopback Origin. For public hosts we still require an
-             exact port match. Restores the behaviour that
-             test_auth_coverage.test_same_origin_allows_different_
-             explicit_port_on_loopback expects after #6449. *)
-          if is_loopback_host (normalize_loopback_host origin_host) then
+          (* Loopback same-port remains allowed, but cross-port mutations now
+             require an explicit dev-origin allowlist instead of trusting any
+             localhost page. This preserves the default Vite dashboard proxy
+             flow (5173 -> backend) while shrinking the browser trust boundary. *)
+          if norm origin_port = norm request_port then
             Ok ()
-          else if norm origin_port = norm request_port then Ok ()
+          else if
+            is_loopback_host (normalize_loopback_host origin_host)
+            && is_allowlisted_loopback_dev_origin origin
+          then
+            Ok ()
           else (
             Log.Auth.debug
               "same-origin port mismatch: origin=%S host=%s"

--- a/lib/server/server_routes_http_routes_activity.ml
+++ b/lib/server/server_routes_http_routes_activity.ml
@@ -238,7 +238,8 @@ let add_routes ~sw ~clock router =
        ) request reqd)
 
   (* Board write APIs — used by dashboard + Bevy Viewer.
-     Uses with_tool_auth to allow localhost browser requests without token. *)
+     Uses with_tool_auth to allow same-origin or allowlisted local dev browser
+     requests without a bearer token. *)
   |> Http.Router.post "/api/v1/tools/masc_board_vote" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_board_vote"
          (fun _state _req reqd ->

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -338,7 +338,21 @@ let test_same_origin_allows_loopback_alias_same_port () =
   | Ok () -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
-let test_same_origin_allows_different_explicit_port_on_loopback () =
+let test_same_origin_allows_allowlisted_dashboard_dev_origin () =
+  let module Server_auth = Masc_mcp.Server_auth in
+  let headers =
+    Httpun.Headers.of_list
+      [
+        ("host", "localhost:8935");
+        ("origin", "http://localhost:5173");
+      ]
+  in
+  let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+  match Server_auth.ensure_same_origin_browser_request request with
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_same_origin_rejects_non_allowlisted_loopback_cross_port () =
   let module Server_auth = Masc_mcp.Server_auth in
   let headers =
     Httpun.Headers.of_list
@@ -349,7 +363,8 @@ let test_same_origin_allows_different_explicit_port_on_loopback () =
   in
   let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
   match Server_auth.ensure_same_origin_browser_request request with
-  | Ok () -> ()
+  | Ok () -> fail "expected non-allowlisted loopback cross-port request to be rejected"
+  | Error (Types.Forbidden _) -> ()
   | Error e -> fail (Types.masc_error_to_string e)
 
 let test_same_origin_rejects_different_explicit_port_on_public_host () =
@@ -586,6 +601,21 @@ let test_env_flag_overrides_all () =
         check bool "env flag forces strict regardless" true
           (SA.http_auth_strict_enabled ()))))
 
+let test_custom_dev_origin_allows_loopback_cross_port () =
+  let module SA = Masc_mcp.Server_auth in
+  with_env "MASC_HTTP_DEV_MUTATION_ORIGINS" "http://localhost:4317" (fun () ->
+    let headers =
+      Httpun.Headers.of_list
+        [
+          ("host", "localhost:9000");
+          ("origin", "http://localhost:4317");
+        ]
+    in
+    let request = Httpun.Request.create ~headers `POST "/api/v1/operator/action" in
+    match SA.ensure_same_origin_browser_request request with
+    | Ok () -> ()
+    | Error e -> fail (Types.masc_error_to_string e))
+
 let test_public_read_path_allows_generic_connector_status () =
   let module SA = Masc_mcp.Server_auth in
   check bool "generic connector status is public read" true
@@ -772,8 +802,10 @@ let () =
         test_same_origin_https_tunnel_same_host;
       test_case "same-origin allows loopback alias same port" `Quick
         test_same_origin_allows_loopback_alias_same_port;
-      test_case "same-origin allows different explicit port on loopback" `Quick
-        test_same_origin_allows_different_explicit_port_on_loopback;
+      test_case "same-origin allows allowlisted dashboard dev origin" `Quick
+        test_same_origin_allows_allowlisted_dashboard_dev_origin;
+      test_case "same-origin rejects non-allowlisted loopback cross-port" `Quick
+        test_same_origin_rejects_non_allowlisted_loopback_cross_port;
       test_case "same-origin rejects different explicit port on public host" `Quick
         test_same_origin_rejects_different_explicit_port_on_public_host;
       test_case "same-origin allows explicit default port https" `Quick
@@ -790,6 +822,8 @@ let () =
         test_base_url_unset_loopback_no_strict;
       test_case "env flag overrides all" `Quick
         test_env_flag_overrides_all;
+      test_case "custom dev origin allows loopback cross-port" `Quick
+        test_custom_dev_origin_allows_loopback_cross_port;
       test_case "generic connector status is public read" `Quick
         test_public_read_path_allows_generic_connector_status;
       test_case "generic connector bind is not public read" `Quick

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -208,7 +208,14 @@ let test_http_write_auth_contracts () =
        {|with_token_permission_auth ~permission:Types.CanAdmin|});
   check bool "provider runs route threads state net into dashboard single-run" true
     (file_contains_pattern "lib/server/server_routes_http_routes_provider_runs.ml"
-       "~net:state.Mcp_server.net")
+       "~net:state.Mcp_server.net");
+  check bool "loopback cross-port auth uses explicit dev origin allowlist" true
+    (file_contains_pattern "lib/server/server_auth.ml"
+       "configured_loopback_dev_mutation_origins");
+  check bool "loopback cross-port auth no longer trusts any loopback origin" true
+    (not
+       (file_contains_pattern "lib/server/server_auth.ml"
+          "if is_loopback_host (normalize_loopback_host origin_host) then"))
 
 let test_keeper_direct_reply_contracts () =
   check bool "dashboard keeper direct messages request direct reply" true


### PR DESCRIPTION
## Summary
- stop trusting arbitrary loopback cross-port browser origins for tokenless HTTP mutations
- keep the default dashboard Vite dev proxy flow by allowlisting the standard 5173 origins
- add an env override for custom dev origins and cover the contract in auth/source tests

## Testing
- dune build --root . test/test_auth_coverage.exe test/test_ci_hardening_source.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_ci_hardening_source.exe