### PR TITLE
docs(specs): mark historical keeper reconcile models

### DIFF
--- a/docs/tla-audit/cascade-fsm-gap-2026-04-13.md
+++ b/docs/tla-audit/cascade-fsm-gap-2026-04-13.md
@@ -1,5 +1,9 @@
 # TLA+ Cascade/Model Selection FSM Gap Analysis
 
+> Status: historical audit only, not a live keeper contract.
+> The current canonical cascade/runtime-truth specs are `KeeperCascadeLifecycle.tla`, `KeeperCompactionLifecycle.tla`, `KeeperCompositeLifecycle.tla`, `KeeperStateMachine.tla`, and `boundary/KeeperContinueGate.tla`.
+> References to `manual_reconcile` below describe the audited 2026-04-13 system, not the current live API/runtime contract.
+
 Date: 2026-04-13
 Auditor: Claude Opus 4.6 (1M context)
 Status: Audit-only (no spec modifications)

--- a/docs/tla-audit/decision-fsm-gap-2026-04-13.md
+++ b/docs/tla-audit/decision-fsm-gap-2026-04-13.md
@@ -1,5 +1,8 @@
 # TLA+ Keeper Decision FSM Gap Analysis
 
+> Status: historical audit only.
+> The current authoritative decision-turn contract is the combination of `KeeperTurnCycle.tla`, `KeeperDecisionPipeline.tla`, `KeeperCompositeLifecycle.tla`, and `boundary/KeeperContinueGate.tla`.
+
 Date: 2026-04-13
 Auditor: Claude Opus 4.6
 Scope: Does the existing TLA+ spec portfolio catch Bug #3 (proactive timer freeze)?

--- a/docs/tla-audit/state-fsm-gap-2026-04-13.md
+++ b/docs/tla-audit/state-fsm-gap-2026-04-13.md
@@ -1,5 +1,9 @@
 # TLA+ Keeper State FSM Gap Analysis — Bug #1 (manual_reconcile one-way trap)
 
+> Status: historical audit only, not a live keeper contract.
+> Current authoritative keeper FSM set is `KeeperStateMachine`, `KeeperCompositeLifecycle`, `KeeperTurnCycle`, `KeeperDecisionPipeline`, `KeeperCascadeLifecycle`, `KeeperCompactionLifecycle`, and `boundary/KeeperContinueGate`.
+> `KeeperReconcileLiveness.tla` and `boundary/KeeperRecoveryOrchestration.tla` are retained here as forensic models for the old two-store reconcile bug.
+
 Date: 2026-04-13
 Auditor: Claude Opus 4.6 (1M context)
 PR: #6834 (fix), this document: audit branch `audit/tla-state-gap`

--- a/specs/boundary/KeeperRecoveryOrchestration-buggy.cfg
+++ b/specs/boundary/KeeperRecoveryOrchestration-buggy.cfg
@@ -1,3 +1,5 @@
+\* HISTORICAL audit model (buggy variant).
+\* The current runtime-owned boundary contract is KeeperContinueGate.tla.
 \* Buggy model: DispatchManualReconcileCleared omitted from recovery sequence.
 \* Expected: ReconcileEventuallyClears VIOLATED (one-way trap).
 SPECIFICATION SpecBuggy

--- a/specs/boundary/KeeperRecoveryOrchestration.cfg
+++ b/specs/boundary/KeeperRecoveryOrchestration.cfg
@@ -1,3 +1,5 @@
+\* HISTORICAL audit model (clean variant).
+\* The current runtime-owned boundary contract is KeeperContinueGate.tla.
 \* Clean model: full recovery sequence including DispatchManualReconcileCleared.
 \* Expected: all safety invariants hold, liveness properties hold.
 SPECIFICATION Spec

--- a/specs/boundary/KeeperRecoveryOrchestration.tla
+++ b/specs/boundary/KeeperRecoveryOrchestration.tla
@@ -1,4 +1,10 @@
 ---- MODULE KeeperRecoveryOrchestration ----
+\* HISTORICAL AUDIT MODEL ONLY — NOT a current runtime-owned boundary contract.
+\*
+\* The live keeper boundary contract for ambiguous post-commit recovery is
+\* boundary/KeeperContinueGate.tla. This module is retained only to document
+\* the old two-store reconcile bookkeeping bug and its cross-store sequencing.
+\*
 \* Cross-domain boundary spec: State (data layer) x FSM (condition layer).
 \*
 \* Models the maybe_recover_from_failing multi-event sequence in

--- a/specs/keeper-state-machine/KeeperCoreTriad.tla
+++ b/specs/keeper-state-machine/KeeperCoreTriad.tla
@@ -379,9 +379,9 @@ RunningEventuallyCompletes ==
         (turn_status = "done" \/ phase /= "Running")
 
 \* L2: Failing phase eventually resolves — DELEGATED to KeeperStateMachine.tla.
-\* This property requires operator intervention (manual_reconcile_clear) which
-\* is outside cascade routing scope. The counterexample: partial_commit in
-\* Failing creates a cycle only breakable by operator action + next success.
+\* This property may require external operator approval/recovery clearance,
+\* which is outside cascade routing scope. The counterexample: partial_commit
+\* in Failing creates a cycle only breakable by external action + next success.
 \* Retained as definition for documentation; removed from cfg PROPERTIES.
 FailingResolves ==
     phase = "Failing" ~> phase /= "Failing"

--- a/specs/keeper-state-machine/KeeperReconcileLiveness-buggy.cfg
+++ b/specs/keeper-state-machine/KeeperReconcileLiveness-buggy.cfg
@@ -1,4 +1,5 @@
-\* KeeperReconcileLiveness — Buggy specification (OLD code)
+\* KeeperReconcileLiveness — HISTORICAL audit model (buggy variant)
+\* NOT part of the canonical runtime-truth keeper spec set.
 \* Expected: TLC exits 12 or 13 (liveness violation)
 \*
 \* Models the pre-fix heartbeat recovery that only dispatched

--- a/specs/keeper-state-machine/KeeperReconcileLiveness.cfg
+++ b/specs/keeper-state-machine/KeeperReconcileLiveness.cfg
@@ -1,4 +1,5 @@
-\* KeeperReconcileLiveness — Clean specification (FIXED code)
+\* KeeperReconcileLiveness — HISTORICAL audit model (clean variant)
+\* NOT part of the canonical runtime-truth keeper spec set.
 \* Expected: TLC exits 0 (no error)
 \*
 \* Verifies that manual_reconcile_required is NOT a one-way trap

--- a/specs/keeper-state-machine/KeeperReconcileLiveness.tla
+++ b/specs/keeper-state-machine/KeeperReconcileLiveness.tla
@@ -1,4 +1,20 @@
 ---- MODULE KeeperReconcileLiveness ----
+\* HISTORICAL AUDIT MODEL ONLY — NOT part of the canonical keeper runtime set.
+\*
+\* Current authoritative keeper FSM set:
+\*   - KeeperStateMachine.tla
+\*   - KeeperCompositeLifecycle.tla
+\*   - KeeperTurnCycle.tla
+\*   - KeeperDecisionPipeline.tla
+\*   - KeeperCascadeLifecycle.tla
+\*   - KeeperCompactionLifecycle.tla
+\*   - boundary/KeeperContinueGate.tla
+\*
+\* This module is retained as a forensic model for the old two-store
+\* manual_reconcile one-way trap. It does not describe the current
+\* runtime-owned contract and should not be used as the SSOT for live
+\* keeper behavior.
+\*
 \* Keeper Reconcile Liveness — TLA+ Specification
 \*
 \* Verifies that manual_reconcile_required is not a one-way trap:


### PR DESCRIPTION
## Summary
- mark `KeeperReconcileLiveness` and `KeeperRecoveryOrchestration` as historical audit models rather than current runtime-truth contracts
- add explicit canonical-set pointers in the 2026-04-13 TLA audit docs so readers land on the current keeper FSM set first
- soften one stale `manual_reconcile_clear` wording in `KeeperCoreTriad.tla` so it no longer reads like the current live approval path

## Verification
- `make -C specs check-all CLEAN_CFGS='keeper-state-machine/KeeperReconcileLiveness.cfg boundary/KeeperRecoveryOrchestration.cfg' BUGGY_CFGS='keeper-state-machine/KeeperReconcileLiveness-buggy.cfg boundary/KeeperRecoveryOrchestration-buggy.cfg'`
- `git diff --check`

## Notes
- This PR is documentation/spec authority cleanup only. It does not change keeper runtime behavior.
- Follow-up PR will wire `KeeperCompositeLifecycle` into the default sweep and finish migrating dashboard legacy `/state-diagram` panels toward the composite/runtime-truth surface.