### PR TITLE
[codex] Clarify test-only base path override env names

### DIFF
--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -103,6 +103,23 @@ Examples:
   [`resolve()`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/config_dir_resolver.ml#L321)
   caches the result, so root changes are boot-static.
 
+### 4. Test-only boot overrides
+
+The following flags exist only to make OCaml test executables deterministic:
+
+| Variable | Default test behavior | Opt-in behavior |
+| --- | --- | --- |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | ignore a shell-provided `MASC_BASE_PATH` override and re-sync to the requested path | preserve an explicit `MASC_BASE_PATH` override for resolver coverage |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | ignore inherited `MASC_CONFIG_DIR` / `MASC_PERSONAS_DIR` values captured from the parent shell | preserve explicit config/personas overrides for config-root coverage |
+
+These are not operator-facing runtime controls and should not be used as
+production launch knobs.
+
+Representative code paths:
+
+- [`coord_utils_backend_setup.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/coord/coord_utils_backend_setup.ml)
+- [`config_dir_resolver.ml`](/Users/dancer/me/workspace/yousleepwhen/masc-mcp/lib/config_dir_resolver.ml)
+
 ## Rules for New Environment Variables
 
 1. New env vars default to `boot_static`.

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -835,8 +835,10 @@ let tempo_entries =
 
 let test_entries =
   [
-    entry ~default:"false" "MASC_TEST_ALLOW_INHERITED_BASE_PATH"
-      "Allow inherited base path in test environments";
+    entry ~default:"false" "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE"
+      "Allow explicit MASC_BASE_PATH override handling in test executables";
+    entry ~default:"false" "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE"
+      "Allow explicit MASC_CONFIG_DIR and MASC_PERSONAS_DIR overrides in test executables";
   ]
 
 let timeout_entries =

--- a/lib/config_dir_resolver.ml
+++ b/lib/config_dir_resolver.ml
@@ -50,9 +50,11 @@ let running_under_test_executable executable_name =
   |> String.lowercase_ascii
   |> String.starts_with ~prefix:"test_"
 
+let test_config_path_override_env = "MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE"
+
 let allow_inherited_test_config_paths () =
   Env_config_core.get_bool ~default:false
-    "MASC_TEST_ALLOW_INHERITED_CONFIG_PATHS"
+    test_config_path_override_env
 
 let initial_env_config_dir = Env_config_core.config_dir_opt ()
 let initial_env_personas_dir = Env_config_core.personas_dir_opt ()

--- a/lib/coord/coord_utils_backend_setup.ml
+++ b/lib/coord/coord_utils_backend_setup.ml
@@ -102,9 +102,14 @@ let running_under_test_executable () =
   in
   String.starts_with ~prefix:"test_" executable
 
+let test_base_path_override_env = "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE"
+
+let test_base_path_override_enabled () =
+  Env_config_core.get_bool ~default:false test_base_path_override_env
+
 let sync_test_base_path_env resolved_path =
   if running_under_test_executable ()
-     && not (Env_config_core.get_bool ~default:false "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
+     && not (test_base_path_override_enabled ())
   then
     match Env_config_core.base_path_opt () with
     | Some current when String.equal current resolved_path -> ()
@@ -155,29 +160,26 @@ let resolve_requested_base_path path =
 
 (** Resolve base_path with a single authority:
     - in normal executables, explicit [MASC_BASE_PATH] wins
-    - in test executables, inherited [MASC_BASE_PATH] is ignored unless it
-      matches the requested path or the test explicitly opts in
+    - in test executables, a shell-provided [MASC_BASE_PATH] override is
+      ignored unless it matches the requested path or the test explicitly opts
+      in via [MASC_TEST_ALLOW_BASE_PATH_OVERRIDE]
     - otherwise resolve the requested path to its git root *)
 let resolve_masc_base_path path =
   let requested = resolve_requested_base_path path in
   match Env_config_core.base_path_opt () with
   | Some explicit
     when running_under_test_executable ()
-         && not
-              (Env_config_core.get_bool ~default:false
-                 "MASC_TEST_ALLOW_INHERITED_BASE_PATH") ->
+         && not (test_base_path_override_enabled ()) ->
       log_once_info
-        "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
+        "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
         explicit path;
       requested
   | Some explicit
     when running_under_test_executable ()
-         && not
-              (Env_config_core.get_bool ~default:false
-                 "MASC_TEST_ALLOW_INHERITED_BASE_PATH")
+         && not (test_base_path_override_enabled ())
          && not (String.equal explicit requested) ->
       log_once_info
-        "Ignoring inherited MASC_BASE_PATH=%s for requested test path %s"
+        "Ignoring test MASC_BASE_PATH override=%s for requested path %s"
         explicit path;
       requested
   | Some explicit ->

--- a/test/test_config_dir_resolver.ml
+++ b/test/test_config_dir_resolver.ml
@@ -75,14 +75,14 @@ let make_inputs ?env_base_path ?env_config_dir ?env_personas_dir
       env_home;
     }
 
-let test_sanitize_inherited_test_env_opt_drops_inherited_value () =
+let test_sanitize_inherited_test_env_opt_drops_captured_parent_shell_value () =
   let actual =
     Lib.Config_dir_resolver.sanitize_inherited_test_env_opt
       ~running_under_test_executable:true ~allow_inherited:false
       ~initial:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
       ~current:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
   in
-  check (option string) "same inherited value ignored" None actual
+  check (option string) "same captured parent-shell value ignored" None actual
 
 let test_sanitize_inherited_test_env_opt_keeps_runtime_override () =
   let actual =
@@ -101,7 +101,7 @@ let test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in () =
       ~initial:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
       ~current:(Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config")
   in
-  check (option string) "opt-in preserves inherited value"
+  check (option string) "opt-in preserves config-path override"
     (Some "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/config") actual
 
 let test_env_override_valid () =
@@ -339,11 +339,11 @@ let () =
         ] );
       ( "test_env_sanitization",
         [
-          test_case "drops inherited config env by default" `Quick
-            test_sanitize_inherited_test_env_opt_drops_inherited_value;
+          test_case "drops captured parent-shell config env by default" `Quick
+            test_sanitize_inherited_test_env_opt_drops_captured_parent_shell_value;
           test_case "keeps runtime override" `Quick
             test_sanitize_inherited_test_env_opt_keeps_runtime_override;
-          test_case "opt-in preserves inherited value" `Quick
+          test_case "opt-in preserves config-path override" `Quick
             test_sanitize_inherited_test_env_opt_keeps_value_with_opt_in;
         ] );
     ]

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -106,7 +106,7 @@ let test_resolve_masc_base_path_ignores_inherited_env_in_test_by_default () =
     (Printf.sprintf "gitdir: %s\n" branch_gitdir);
   with_envs
     [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       check string "requested git root wins in tests" repo_root
         (Coord_utils.resolve_masc_base_path worktree_path))
@@ -117,7 +117,7 @@ let test_resolve_masc_base_path_prefers_requested_path_in_test () =
   in
   with_envs
     [ ("MASC_BASE_PATH", Some "/Users/dancer/me");
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       check string "requested path wins in tests" requested
         (Coord_utils.resolve_masc_base_path requested))
@@ -128,7 +128,7 @@ let test_resolve_masc_base_path_keeps_matching_explicit_env () =
   in
   with_envs
     [ ("MASC_BASE_PATH", Some requested);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       check string "matching explicit env preserved" requested
         (Coord_utils.resolve_masc_base_path requested))
@@ -141,7 +141,7 @@ let test_resolve_masc_base_path_collapses_requested_masc_dir () =
   in
   with_envs
     [ ("MASC_BASE_PATH", None);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       check string "requested .masc input collapses to parent"
         (Filename.dirname requested)
@@ -154,24 +154,25 @@ let test_resolve_masc_base_path_collapses_explicit_env_masc_dir () =
   let explicit = Filename.concat requested ".masc" in
   with_envs
     [ ("MASC_BASE_PATH", Some explicit);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       check string "explicit .masc env collapses to parent" requested
         (Coord_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_ignores_explicit_env_without_opt_in () =
+let test_resolve_masc_base_path_ignores_base_path_override_without_opt_in () =
   let requested =
     Filename.concat (Filename.get_temp_dir_name ()) "room-utils-opt-in"
   in
   let explicit = "/Users/dancer/me" in
   with_envs
     [ ("MASC_BASE_PATH", Some explicit);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
-      check string "explicit env ignored without opt-in" requested
+      check string "base path override ignored without opt-in" requested
         (Coord_utils.resolve_masc_base_path requested))
 
-let test_resolve_masc_base_path_ignores_explicit_env_with_local_masc_dir () =
+let test_resolve_masc_base_path_ignores_base_path_override_with_local_masc_dir ()
+    =
   let scratch = Filename.temp_dir "room-utils-local-masc" "" in
   let requested = Filename.concat scratch "repo" in
   let explicit = Filename.concat scratch "parent-root" in
@@ -184,12 +185,13 @@ let test_resolve_masc_base_path_ignores_explicit_env_with_local_masc_dir () =
     (fun () ->
       with_envs
         [ ("MASC_BASE_PATH", Some explicit);
-          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+          ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
         (fun () ->
-          check string "local .masc still honors requested path in tests" requested
+          check string "local .masc still ignores base path override in tests"
+            requested
             (Coord_utils.resolve_masc_base_path requested)))
 
-let test_resolve_masc_base_path_opt_in_preserves_explicit_env () =
+let test_resolve_masc_base_path_opt_in_preserves_base_path_override () =
   let scratch = Filename.temp_dir "room-utils-explicit-opt-in" "" in
   let requested = Filename.concat scratch "repo" in
   let explicit = Filename.concat scratch "parent-root" in
@@ -202,12 +204,13 @@ let test_resolve_masc_base_path_opt_in_preserves_explicit_env () =
     (fun () ->
       with_envs
         [ ("MASC_BASE_PATH", Some explicit);
-          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", Some "true") ]
+          ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", Some "true") ]
         (fun () ->
-          check string "opt-in preserves explicit path" explicit
+          check string "opt-in preserves base path override" explicit
             (Coord_utils.resolve_masc_base_path requested)))
 
-let test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in () =
+let test_resolve_masc_base_path_ignores_ancestor_base_path_override_without_opt_in ()
+    =
   let scratch = Filename.temp_dir "room-utils-ancestor" "" in
   let explicit = scratch in
   let sub_repo = Filename.concat scratch "workspace/sub-repo" in
@@ -225,9 +228,10 @@ let test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in ()
     (fun () ->
       with_envs
         [ ("MASC_BASE_PATH", Some explicit);
-          ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+          ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
         (fun () ->
-          check string "requested sub-repo wins without opt-in" sub_repo
+          check string "requested sub-repo wins without base path override opt-in"
+            sub_repo
             (Coord_utils.resolve_masc_base_path sub_repo)))
 
 let test_default_config_syncs_test_base_path_env () =
@@ -237,7 +241,7 @@ let test_default_config_syncs_test_base_path_env () =
   with_envs
     [ ("MASC_BASE_PATH", None);
       ("MASC_TEST_SYNCED_BASE_PATH", None);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       ignore (Coord_utils.default_config requested);
       check (option string) "env synced to requested path" (Some requested)
@@ -253,7 +257,7 @@ let test_auto_synced_test_base_path_does_not_override_later_requests () =
   with_envs
     [ ("MASC_BASE_PATH", None);
       ("MASC_TEST_SYNCED_BASE_PATH", None);
-      ("MASC_TEST_ALLOW_INHERITED_BASE_PATH", None) ]
+      ("MASC_TEST_ALLOW_BASE_PATH_OVERRIDE", None) ]
     (fun () ->
       ignore (Coord_utils.default_config first);
       check string "later requested path wins over auto-synced env" second
@@ -620,14 +624,15 @@ let () =
         test_resolve_masc_base_path_collapses_requested_masc_dir;
       test_case "collapses explicit .masc env" `Quick
         test_resolve_masc_base_path_collapses_explicit_env_masc_dir;
-      test_case "ignores explicit env without opt-in" `Quick
-        test_resolve_masc_base_path_ignores_explicit_env_without_opt_in;
-      test_case "ignores explicit env when requested path has local .masc" `Quick
-        test_resolve_masc_base_path_ignores_explicit_env_with_local_masc_dir;
-      test_case "opt-in preserves explicit env" `Quick
-        test_resolve_masc_base_path_opt_in_preserves_explicit_env;
-      test_case "ignores ancestor explicit path without opt-in" `Quick
-        test_resolve_masc_base_path_ignores_ancestor_explicit_path_without_opt_in;
+      test_case "ignores base path override without opt-in" `Quick
+        test_resolve_masc_base_path_ignores_base_path_override_without_opt_in;
+      test_case "ignores base path override when requested path has local .masc"
+        `Quick
+        test_resolve_masc_base_path_ignores_base_path_override_with_local_masc_dir;
+      test_case "opt-in preserves base path override" `Quick
+        test_resolve_masc_base_path_opt_in_preserves_base_path_override;
+      test_case "ignores ancestor base path override without opt-in" `Quick
+        test_resolve_masc_base_path_ignores_ancestor_base_path_override_without_opt_in;
       test_case "default config syncs test base env" `Quick
         test_default_config_syncs_test_base_path_env;
       test_case "auto-synced test base env does not override later requests" `Quick

--- a/test/test_server_base_path_diagnostics.ml
+++ b/test/test_server_base_path_diagnostics.ml
@@ -201,7 +201,7 @@ let test_to_yojson_exposes_gate_fields () =
   Alcotest.(check bool) "startup_abort_eligible field" false
     (json |> member "startup_abort_eligible" |> to_bool)
 
-let test_default_base_path_ignores_inherited_parent_root_in_tests () =
+let test_default_base_path_ignores_parent_base_path_override_in_tests () =
   with_temp_dir "base-path-default" @@ fun root ->
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
@@ -210,13 +210,14 @@ let test_default_base_path_ignores_inherited_parent_root_in_tests () =
   Unix.mkdir (Filename.concat repo ".masc") 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
-  with_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH" None @@ fun () ->
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" None @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
-  Alcotest.(check string) "default base path ignores inherited parent root in tests"
+  Alcotest.(check string)
+    "default base path ignores parent base path override in tests"
     (canonical_path repo)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
-let test_default_base_path_preserves_explicit_root_with_opt_in () =
+let test_default_base_path_preserves_base_path_override_with_opt_in () =
   with_temp_dir "base-path-default-optin" @@ fun root ->
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
@@ -225,13 +226,13 @@ let test_default_base_path_preserves_explicit_root_with_opt_in () =
   Unix.mkdir (Filename.concat repo ".masc") 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
-  with_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH" (Some "true") @@ fun () ->
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" (Some "true") @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
-  Alcotest.(check string) "explicit root preserved with opt-in"
+  Alcotest.(check string) "base path override preserved with opt-in"
     (canonical_path base_path)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
-let test_default_base_path_ignores_inherited_root_without_local_masc () =
+let test_default_base_path_ignores_base_path_override_without_local_masc () =
   with_temp_dir "base-path-default-no-local-masc" @@ fun root ->
   let base_path = Filename.concat root "base" in
   let repo = Filename.concat base_path "workspace/yousleepwhen/masc-mcp" in
@@ -239,9 +240,10 @@ let test_default_base_path_ignores_inherited_root_without_local_masc () =
   Unix.mkdir (Filename.concat base_path ".masc") 0o755;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" (Some base_path) @@ fun () ->
-  with_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH" None @@ fun () ->
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" None @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
-  Alcotest.(check string) "default base path ignores inherited root without local .masc"
+  Alcotest.(check string)
+    "default base path ignores base path override without local .masc"
     (canonical_path repo)
     (Server_mcp_transport_http.default_base_path () |> canonical_path)
 
@@ -253,7 +255,7 @@ let test_default_base_path_falls_back_to_home_when_unset () =
   mkdir_p home;
   with_cwd repo @@ fun () ->
   with_env "MASC_BASE_PATH" None @@ fun () ->
-  with_env "MASC_TEST_ALLOW_INHERITED_BASE_PATH" None @@ fun () ->
+  with_env "MASC_TEST_ALLOW_BASE_PATH_OVERRIDE" None @@ fun () ->
   with_env "MASC_BASE_PATH_INPUT" None @@ fun () ->
   with_env "HOME" (Some home) @@ fun () ->
   Alcotest.(check string) "default base path falls back to home"
@@ -283,14 +285,15 @@ let () =
             test_to_yojson_exposes_resolution_source;
           Alcotest.test_case "json exposes gate fields" `Quick
             test_to_yojson_exposes_gate_fields;
-          Alcotest.test_case "default base path ignores inherited parent root in tests"
-            `Quick test_default_base_path_ignores_inherited_parent_root_in_tests;
           Alcotest.test_case
-            "default base path preserves explicit root with opt-in"
-            `Quick test_default_base_path_preserves_explicit_root_with_opt_in;
+            "default base path ignores parent base path override in tests"
+            `Quick test_default_base_path_ignores_parent_base_path_override_in_tests;
           Alcotest.test_case
-            "default base path ignores inherited root without local .masc"
-            `Quick test_default_base_path_ignores_inherited_root_without_local_masc;
+            "default base path preserves base path override with opt-in"
+            `Quick test_default_base_path_preserves_base_path_override_with_opt_in;
+          Alcotest.test_case
+            "default base path ignores base path override without local .masc"
+            `Quick test_default_base_path_ignores_base_path_override_without_local_masc;
           Alcotest.test_case
             "default base path falls back to home when unset"
             `Quick test_default_base_path_falls_back_to_home_when_unset;

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -322,7 +322,7 @@ let test_default_base_path_falls_back_to_home_when_unset () =
         (contains_substring captured
            ("MASC_CONFIG_DIR=" ^ Filename.concat expected_home ".masc/config")))
 
-let test_absolute_inherited_base_path_is_preserved () =
+let test_absolute_env_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
@@ -348,7 +348,7 @@ let test_absolute_inherited_base_path_is_preserved () =
           stderr;
       let captured = read_file capture in
       let expected_root = canonical_path stale_root in
-      check bool "absolute inherited base path preserved" true
+      check bool "absolute env base path preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_absolute_parent_project_base_path_is_preserved () =
@@ -414,7 +414,7 @@ let test_zshenv_absolute_base_path_is_preserved () =
       check bool "zshenv absolute base path preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
-let test_shared_root_inherited_base_path_is_preserved () =
+let test_shared_root_env_base_path_is_preserved () =
   with_temp_dir "start-masc-script" (fun dir ->
       let script = Filename.concat dir "start-masc-mcp.sh" in
       copy_script (script_path ()) script;
@@ -440,7 +440,7 @@ let test_shared_root_inherited_base_path_is_preserved () =
           stderr;
       let captured = read_file capture in
       let expected_root = canonical_path inherited_root in
-      check bool "shared-root inherited base path preserved" true
+      check bool "shared-root env base path preserved" true
         (contains_substring captured ("MASC_BASE_PATH=" ^ expected_root)))
 
 let test_worktree_prefers_local_build_over_workspace_build () =
@@ -699,11 +699,11 @@ let () =
           test_case "default base path falls back to home when unset" `Quick
             test_default_base_path_falls_back_to_home_when_unset;
           test_case
-            "absolute inherited base path is preserved"
+            "absolute env base path is preserved"
             `Quick
-            test_absolute_inherited_base_path_is_preserved;
+            test_absolute_env_base_path_is_preserved;
           test_case
-            "absolute parent project inherited base path is preserved"
+            "absolute parent project env base path is preserved"
             `Quick
             test_absolute_parent_project_base_path_is_preserved;
           test_case "explicit base path execs from base path" `Quick
@@ -722,8 +722,8 @@ let () =
             test_grpc_direct_banner_is_preserved_in_stderr;
           test_case "zshenv absolute base path is preserved" `Quick
             test_zshenv_absolute_base_path_is_preserved;
-          test_case "shared-root inherited base path is preserved" `Quick
-            test_shared_root_inherited_base_path_is_preserved;
+          test_case "shared-root env base path is preserved" `Quick
+            test_shared_root_env_base_path_is_preserved;
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
           test_case


### PR DESCRIPTION
## What changed
- rename the test-only base-path override env from `MASC_TEST_ALLOW_INHERITED_BASE_PATH` to `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE`
- rename the related config-path test env from `MASC_TEST_ALLOW_INHERITED_CONFIG_PATHS` to `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE`
- update resolver comments, log wording, and test names to describe explicit test overrides instead of "inherited" paths
- document both test-only envs in `docs/ENV-CONTRACT.md` and refresh the env snapshot descriptions

## Why
- the old names still reflected the removed dual-root / inherited-path framing even though the actual behavior is now "test-only explicit override opt-in"
- leaving the old names in place would keep test-only control knobs semantically out of sync with the single-root runtime policy

## Impact
- test-only base-path and config-path knobs now read consistently with current runtime policy
- resolver code, env inventory, and test output all use the same terminology
- no production runtime behavior changes are intended; this is naming and documentation cleanup around test-only controls

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/chore/base-path-override-terminology test/test_room_utils_coverage.exe test/test_server_base_path_diagnostics.exe test/test_start_masc_mcp_script.exe`
- `./_build/default/test/test_room_utils_coverage.exe`
- `./_build/default/test/test_server_base_path_diagnostics.exe`
- `./_build/default/test/test_start_masc_mcp_script.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/chore/base-path-override-terminology test/test_config_dir_resolver.exe`
- `./_build/default/test/test_config_dir_resolver.exe`

## Root cause
- earlier cleanup removed dual-root behavior but left test-only env names and assertions using older "inherited path" language, so code, docs, and test output no longer described the same concept precisely.