### PR TITLE
refactor(metrics): all keeper metric names to Prometheus constants

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -168,9 +168,9 @@ let compact_if_needed
           sync_oas_context { ctx with messages }
         in
         let new_ratio = context_ratio compacted_ctx in
-        Prometheus.inc_counter "masc_keeper_compactions_total"
+        Prometheus.inc_counter Prometheus.metric_keeper_compactions
           ~labels:[("keeper", meta.name)] ();
-        Prometheus.set_gauge "masc_keeper_compaction_ratio_change"
+        Prometheus.set_gauge Prometheus.metric_keeper_compaction_ratio_change
           ~labels:[("keeper", meta.name)]
           (ratio -. new_ratio);
         (compacted_ctx, Some reason, "applied:" ^ reason)

--- a/lib/keeper/keeper_evidence.ml
+++ b/lib/keeper/keeper_evidence.ml
@@ -96,7 +96,7 @@ let capture_turn_evidence
   in
   if collision_warnings <> [] then begin
     let n = List.length collision_warnings in
-    Prometheus.inc_counter "masc_keeper_collision_detected_total"
+    Prometheus.inc_counter Prometheus.metric_keeper_collision_detected
       ~labels:[("keeper", keeper_name)] ();
     Log.Keeper.warn
       "evidence: %s has %d file collision(s) with other keeper(s) — \

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -959,7 +959,7 @@ let sync_keeper_presence
           !consecutive_failures
           (max_consecutive_heartbeat_failures ());
         (* RFC-0002: dispatch heartbeat failure *)
-        Prometheus.inc_counter "masc_keeper_heartbeat_failures_total"
+        Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_failures
           ~labels:[("keeper", meta_current.name)] ();
         ignore (Keeper_registry.dispatch_event
           ~base_path:ctx.config.base_path meta_current.name
@@ -974,13 +974,13 @@ let sync_keeper_presence
         ignore (Keeper_registry.dispatch_event
           ~base_path:ctx.config.base_path meta_current.name
           Keeper_state_machine.Heartbeat_ok);
-        Prometheus.inc_counter "masc_keeper_heartbeat_successes_total"
+        Prometheus.inc_counter Prometheus.metric_keeper_heartbeat_successes
           ~labels:[("keeper", meta_current.name)] ();
         maybe_recover_from_failing ~ctx ~meta:meta_current);
       match write_meta ctx.config synced with
       | Ok () -> synced
       | Error e ->
-        Prometheus.inc_counter "masc_keeper_write_meta_failures_total"
+        Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
           ~labels:[("keeper", synced.name); ("phase", "heartbeat")] ();
         Log.Keeper.warn "write_meta failed (heartbeat): %s" e;
         synced
@@ -1140,7 +1140,7 @@ let run_keepalive_unified_turn
         match write_meta ctx.config meta_after_observe with
         | Ok () -> ()
         | Error e ->
-            Prometheus.inc_counter "masc_keeper_write_meta_failures_total"
+            Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
               ~labels:[("keeper", meta_after_observe.name); ("phase", "cursor_update")] ();
             Log.Keeper.warn "write_meta failed (message cursor update): %s" e);
       if Atomic.get stop
@@ -1863,7 +1863,7 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
     (match write_meta ctx.config synced with
      | Ok () -> ()
      | Error e ->
-       Prometheus.inc_counter "masc_keeper_write_meta_failures_total"
+       Prometheus.inc_counter Prometheus.metric_keeper_write_meta_failures
          ~labels:[("keeper", synced.name); ("phase", "bootstrap")] ();
        Log.Keeper.warn "write_meta failed (bootstrap): %s" e);
     synced

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -1921,7 +1921,7 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
           let is_server_parse_rejection = is_server_rejected_parse_error err in
           let is_auto_recoverable = is_auto_recoverable_turn_error err in
           let is_ambiguous_partial = is_ambiguous_side_effect_error err in
-          Prometheus.inc_counter "masc_keeper_turns_total"
+          Prometheus.inc_counter Prometheus.metric_keeper_turns
             ~labels:[("keeper_name", meta.name); ("outcome", "failure")] ();
           Log.Keeper.error
             "%s: keeper cycle FAILED cascade=%s max_context=%d latency=%dms%s error=%s"
@@ -2268,12 +2268,12 @@ let run_keeper_cycle ~(config : Coord.config) ~(meta : keeper_meta)
             | Oas_worker.TurnBudgetExhausted _ -> "budget_exhausted"
             | Oas_worker.MutationBoundaryReached _ -> "mutation_boundary"
           in
-          Prometheus.inc_counter "masc_keeper_turns_total"
+          Prometheus.inc_counter Prometheus.metric_keeper_turns
             ~labels:[("keeper_name", updated_meta.name); ("outcome", outcome_label)] ();
-          Prometheus.inc_counter "masc_keeper_input_tokens_total"
+          Prometheus.inc_counter Prometheus.metric_keeper_input_tokens
             ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
             ~delta:(float_of_int result.usage.input_tokens) ();
-          Prometheus.inc_counter "masc_keeper_output_tokens_total"
+          Prometheus.inc_counter Prometheus.metric_keeper_output_tokens
             ~labels:[("keeper_name", updated_meta.name); ("model", model_used)]
             ~delta:(float_of_int result.usage.output_tokens) ();
           (* #7469 Step 1: emit prompt-cache usage so Anthropic/Bedrock

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -158,20 +158,50 @@ let observe_histogram name ?(labels=[]) value =
 
 (** {1 Metric Name Constants}
 
-    Exported so registration here and [inc_counter] call-sites in
-    [keeper_unified_turn.ml] share a single source of truth. Without
-    this, a typo on either side produces a dead series with no build
-    error (the counter silently drifts to a new key).
+    Exported so registration here and [inc_counter] / [set_gauge]
+    call-sites in the keeper modules share a single source of truth.
+    Without this, a typo on either side produces a dead series with
+    no build error (the counter silently drifts to a new key).
 
-    Follow-up #7469 Step 1: only the cache counters are covered — the
-    existing input/output/turns counters still use inline strings and
-    should migrate in a separate pass to keep this PR surgical. *)
+    Convention: constant name drops the Prometheus convention suffix
+    ([_total] for counters), full metric name lives on the right-hand
+    side. Consumers import [Prometheus.<constant>] so the compiler
+    catches typos. *)
 
+(* Keeper turn lifecycle (registered in init, incremented in
+   keeper_unified_turn.ml). *)
+let metric_keeper_turns = "masc_keeper_turns_total"
+let metric_keeper_input_tokens = "masc_keeper_input_tokens_total"
+let metric_keeper_output_tokens = "masc_keeper_output_tokens_total"
 let metric_keeper_cache_creation_tokens =
   "masc_keeper_cache_creation_tokens_total"
-
 let metric_keeper_cache_read_tokens =
   "masc_keeper_cache_read_tokens_total"
+
+(* Keeper compaction (keeper_compact_policy.ml, tool_keeper.ml). *)
+let metric_keeper_compactions = "masc_keeper_compactions_total"
+let metric_keeper_compaction_ratio_change =
+  "masc_keeper_compaction_ratio_change"
+let metric_keeper_operator_compact = "masc_keeper_operator_compact_total"
+let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
+
+(* Keeper keepalive (keeper_keepalive.ml). *)
+let metric_keeper_heartbeat_successes =
+  "masc_keeper_heartbeat_successes_total"
+let metric_keeper_heartbeat_failures =
+  "masc_keeper_heartbeat_failures_total"
+let metric_keeper_write_meta_failures =
+  "masc_keeper_write_meta_failures_total"
+
+(* Keeper evidence (keeper_evidence.ml). *)
+let metric_keeper_collision_detected =
+  "masc_keeper_collision_detected_total"
+
+(* MCP tool schema budget (set once at boot from mcp_server_eio.ml
+   via [set_tool_schema_stats]). *)
+let metric_mcp_tool_schema_count = "masc_mcp_tool_schema_count"
+let metric_mcp_tool_schema_tokens_approx =
+  "masc_mcp_tool_schema_tokens_approx"
 
 (** {1 Built-in Metrics} *)
 
@@ -204,19 +234,19 @@ let init () =
   add "masc_sse_write_failures_total" "Total SSE write failures by reason" Counter;
   add "masc_sse_rejects_total" "Total SSE connections rejected by storm guard" Counter;
   (* Keeper compaction metrics — emitted by keeper_compact_policy.ml *)
-  add "masc_keeper_compactions_total"
+  add metric_keeper_compactions
     "Total keeper compactions performed" Counter;
-  add "masc_keeper_compaction_ratio_change"
+  add metric_keeper_compaction_ratio_change
     "Context ratio change after compaction (pre - post)" Gauge;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
-  add "masc_keeper_operator_compact_total"
+  add metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;
-  add "masc_keeper_operator_clear_total"
+  add metric_keeper_operator_clear
     "Total operator-invoked masc_keeper_clear calls (labels: preserve_system=true|false)" Counter;
   (* Keeper heartbeat metrics — emitted by keeper_keepalive.ml *)
-  add "masc_keeper_heartbeat_successes_total"
+  add metric_keeper_heartbeat_successes
     "Total keeper heartbeat successes" Counter;
-  add "masc_keeper_heartbeat_failures_total"
+  add metric_keeper_heartbeat_failures
     "Total keeper heartbeat failures" Counter;
   add "masc_provider_prefix_cache_creation_tokens_total"
     "Total provider prefix cache creation tokens (Anthropic)" Counter;
@@ -250,10 +280,10 @@ let init () =
      gives them a HELP description in /metrics output and a zero-value
      baseline so dashboards see "0" instead of "no data" before the
      first observation. *)
-  add "masc_keeper_write_meta_failures_total"
+  add metric_keeper_write_meta_failures
     "Total keeper meta-file write failures, labeled by keeper and phase"
     Counter;
-  add "masc_keeper_collision_detected_total"
+  add metric_keeper_collision_detected
     "Total keeper-name collision detections during evidence assembly"
     Counter;
   add "masc_board_truncated_posts_total"
@@ -286,13 +316,13 @@ let init () =
   (* Per-keeper turn outcome + token counters.  Labels are populated
      dynamically via inc_counter; no upfront registration needed.
      Covers issues #7495 (cost/token attribution) and #7519 (SLO). *)
-  add "masc_keeper_turns_total"
+  add metric_keeper_turns
     "Total keeper turns by outcome (labels: keeper_name, outcome=success|failure|budget_exhausted|mutation_boundary)"
     Counter;
-  add "masc_keeper_input_tokens_total"
+  add metric_keeper_input_tokens
     "Cumulative input tokens per keeper turn (labels: keeper_name, model)"
     Counter;
-  add "masc_keeper_output_tokens_total"
+  add metric_keeper_output_tokens
     "Cumulative output tokens per keeper turn (labels: keeper_name, model)"
     Counter;
   (* Anthropic / Bedrock prompt caching observability (#7469 Step 1).
@@ -311,9 +341,9 @@ let init () =
     Counter;
   (* Tool schema budget gauges — set once at boot via
      [set_tool_schema_stats]. Covers #7483 Step 1. *)
-  add "masc_mcp_tool_schema_count"
+  add metric_mcp_tool_schema_count
     "Number of tool schemas exposed to MCP clients" Gauge;
-  add "masc_mcp_tool_schema_tokens_approx"
+  add metric_mcp_tool_schema_tokens_approx
     "Approximate token count of all tool schemas combined (chars/4)"
     Gauge
 
@@ -359,8 +389,8 @@ let update_fd_gauges () =
     fd_warned_once := false
 
 let set_tool_schema_stats ~count ~approx_tokens =
-  set_gauge "masc_mcp_tool_schema_count" (float_of_int count);
-  set_gauge "masc_mcp_tool_schema_tokens_approx" (float_of_int approx_tokens)
+  set_gauge metric_mcp_tool_schema_count (float_of_int count);
+  set_gauge metric_mcp_tool_schema_tokens_approx (float_of_int approx_tokens)
 
 (** {1 Prometheus Export} *)
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -634,7 +634,7 @@ let handle_keeper_compact ctx args : tool_result =
        "phase=unknown" precondition failure. *)
     match Keeper_registry.get ~base_path:ctx.config.base_path name with
     | None ->
-      Prometheus.inc_counter "masc_keeper_operator_compact_total"
+      Prometheus.inc_counter Prometheus.metric_keeper_operator_compact
         ~labels:[("keeper", name); ("result", "not_found")] ();
       error_result_typed ~code:Validation_error
         (Printf.sprintf "keeper %s is not in the registry" name)
@@ -650,7 +650,7 @@ let handle_keeper_compact ctx args : tool_result =
       | Offline | Stopped | Dead | Crashed | Restarting | HandingOff | Draining -> false
     in
     if not allowed then begin
-      Prometheus.inc_counter "masc_keeper_operator_compact_total"
+      Prometheus.inc_counter Prometheus.metric_keeper_operator_compact
         ~labels:[("keeper", name); ("result", "precondition")] ();
       error_result_typed ~code:Validation_error
         (Printf.sprintf
@@ -685,7 +685,7 @@ let handle_keeper_compact ctx args : tool_result =
                after_tokens = recovery.compaction.after_tokens;
             });
           invalidate_status_cache name;
-          Prometheus.inc_counter "masc_keeper_operator_compact_total"
+          Prometheus.inc_counter Prometheus.metric_keeper_operator_compact
             ~labels:[("keeper", name); ("result", "ok")] ();
           (true,
            Yojson.Safe.to_string
@@ -711,7 +711,7 @@ let handle_keeper_compact ctx args : tool_result =
             (Keeper_state_machine.Compaction_failed {
                reason = "no_valid_checkpoint";
             });
-          Prometheus.inc_counter "masc_keeper_operator_compact_total"
+          Prometheus.inc_counter Prometheus.metric_keeper_operator_compact
             ~labels:[("keeper", name); ("result", "no_checkpoint")] ();
           (false,
            Printf.sprintf
@@ -814,7 +814,7 @@ let handle_keeper_clear ctx args : tool_result =
       Log.Keeper.warn
         "%s: context cleared by operator (reason=%s, preserve_system=%b, cleared=%d msgs)"
         name reason preserve_system cleared_count;
-      Prometheus.inc_counter "masc_keeper_operator_clear_total"
+      Prometheus.inc_counter Prometheus.metric_keeper_operator_clear
         ~labels:[("keeper", name);
                  ("preserve_system", string_of_bool preserve_system)] ();
       (true,


### PR DESCRIPTION
## Summary
Sweeps the pattern introduced in #7561 across every `masc_keeper_*` counter and the two `masc_mcp_tool_schema_*` gauges.

## Before
`prometheus.ml` registers 11 keeper counters + 2 schema gauges as inline string literals, and 5 files call `Prometheus.inc_counter NAME ...` with the **same literal repeated**. A typo on either side silently creates a dead Hashtbl entry: the registered counter stays at zero while increments land on a different key. No build failure, no test failure — only an empty line in the dashboard.

## After
- 13 module-level `let metric_X = \"...\"` constants in `prometheus.ml`.
- Every registration in `init ()` and every call-site across `keeper_unified_turn.ml` / `tool_keeper.ml` / `keeper_keepalive.ml` / `keeper_compact_policy.ml` / `keeper_evidence.ml` references the constant.
- Typo → fails to compile.

## What's *not* touched
- `test/test_prometheus_coverage.ml` still asserts on literal strings. Those pin the **external Prometheus contract** that dashboards and alerts consume — swapping to constants would make any rename silently pass. Drift between code and external contract should be an explicit, human-reviewed rename.
- Metric values, labels, help text: all unchanged. `/metrics` byte-identical.

## Counters covered
turns, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, compactions, compaction_ratio_change, operator_compact, operator_clear, heartbeat_successes, heartbeat_failures, write_meta_failures, collision_detected

## Gauges covered
tool_schema_count, tool_schema_tokens_approx

## Test plan
- [x] `dune build --root .` green
- [x] `dune exec test/test_prometheus_coverage.exe` — 49 tests pass
- [x] Literal-string contract assertions still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)