### PR TITLE
chore(cascade): canonicalize at every admission/metrics boundary (P1)

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -84,6 +84,10 @@ let now_ts () = Unix.gettimeofday ()
 let wait_ms_since enqueue_ts = int_of_float ((now_ts () -. enqueue_ts) *. 1000.0)
 
 let rec _acquire ?wait_timeout_sec ~priority ~keeper_name ~cascade_name t =
+  (* Normalize at the gate: any cascade name stored in the admission info
+     record or forwarded to metrics passes through the SSOT canonicalizer,
+     so downstream consumers never see drift/ghost values. *)
+  let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   let resolved = Llm_provider.Request_priority.resolve priority in
   let rank = Llm_provider.Request_priority.to_int resolved in
   let action =
@@ -176,6 +180,9 @@ let check_host_resources ~keeper_name =
   end
 
 let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~cascade_name f =
+  (* SSOT: every admission_queue entry point canonicalizes cascade_name
+     so metrics/structs never see drift values. *)
+  let cascade_name = Keeper_cascade_profile.canonicalize cascade_name in
   check_host_resources ~keeper_name;
   (* Passthrough: provider-level throttling belongs in OAS (cascade),
      not in MASC.  The cascade distributes requests across providers

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -134,7 +134,10 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              | Some (`List ((`String m) :: _)) -> m
              | _ ->
                match List.assoc_opt "cascade_name" tfields with
-               | Some (`String s) -> s ^ " (cascade)"
+               | Some (`String s) ->
+                 (* Canonicalize so error attribution buckets match the
+                    SSOT profile names instead of drift/ghost values. *)
+                 Keeper_cascade_profile.canonicalize s ^ " (cascade)"
                | _ -> "__error__"
            in
            Some { model; ts_unix = ts; tok_per_sec = 0.0; latency_ms = 0.0;


### PR DESCRIPTION
## Summary (P1 of cascade SSOT roadmap, stacked on #7562)

Enforces `Keeper_cascade_profile.canonicalize` at two call sites where cascade_name previously flowed through as a raw string:

1. **admission_queue.ml** — `_acquire` and `with_permit` entry points normalize on the way in
2. **model_inference_metrics.ml** — error-turn attribution canonicalizes before bucketing

## Stacking

Base: `chore/cascade-ssot-cleanup` (#7562). Reviewing against #7562 gives the minimal diff; against `main` it shows both PRs combined.

After #7562 merges, this PR rebases to main automatically via GitHub's update-branch.

## Real-world impact

admission_queue stored cascade_name in its info struct. If a caller passed a drift string (e.g. pre-P0 "keeper_turn"), it would survive as-is and appear in admin dashboards. Now any such drift is collapsed to default at the gate.

model_inference_metrics bucketizes error turns by cascade_name. Without canonicalization, errors attributed to a legacy/drift name would split from the same cascade's other errors.

## Not covered (follow-up)

- admission_queue_metrics.ml: all params are `~cascade_name:_` (unused). No Prometheus label cardinality issue, so no change needed.
- keeper_config.ml TOML load: covered implicitly via canonicalize on read; dedicated validator is P2.

## Test plan
- [x] `dune build --root .` green
- [ ] CI runtest
- [ ] P2 (#7562 follow-up): cascade_config_validity test invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)