### PR TITLE
[codex] Require explicit path for code search

### DIFF
--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -243,7 +243,7 @@ let validate_read_path ~agent_name config path =
 (* Handler: masc_code_search - Search code using ripgrep *)
 let handle_code_search ctx args =
   let query = get_string args "query" "" in
-  let path = get_string args "path" "." in
+  let path = get_string args "path" "" in
   let file_pattern = get_string args "file_pattern" "" in
   let case_insensitive = get_bool args "case_insensitive" true in
   let is_regex = get_bool args "is_regex" false in
@@ -251,6 +251,8 @@ let handle_code_search ctx args =
 
   if query = "" then
     (false, "❌ Query required: 'query' parameter")
+  else if String.trim path = "" then
+    (false, "❌ Path required: 'path' parameter")
   else begin
     (* Validate path first *)
     let search_path_result =
@@ -516,8 +518,7 @@ Set is_regex=true only for patterns like 'foo.*bar' or 'class \\w+'.";
         ]);
         ("path", `Assoc [
           ("type", `String "string");
-          ("description", `String "Search path (default: current directory)");
-          ("default", `String ".");
+          ("description", `String "Search path to scope the query (for example 'lib/', 'test/', or 'workspace/yousleepwhen/masc-mcp/lib/')");
         ]);
         ("file_pattern", `Assoc [
           ("type", `String "string");
@@ -535,7 +536,7 @@ Set is_regex=true only for patterns like 'foo.*bar' or 'class \\w+'.";
           ("default", `Int 50);
         ]);
       ]);
-      ("required", `List [`String "query"]);
+      ("required", `List [`String "query"; `String "path"]);
     ];
   };
 

--- a/test/test_tool_code_coverage.ml
+++ b/test/test_tool_code_coverage.ml
@@ -105,9 +105,9 @@ let test_code_search_empty_query () =
 let test_code_search_with_query () =
   let ctx, base_dir = make_ctx () in
   let args = `Assoc [("query", `String "test_pattern")] in
-  let (_, msg) = dispatch_exn ctx ~name:"masc_code_search" ~args in
-  (* May fail (no rg, no git root) but should return a response *)
-  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  let (ok, msg) = dispatch_exn ctx ~name:"masc_code_search" ~args in
+  Alcotest.(check bool) "missing path fails" false ok;
+  Alcotest.(check bool) "mentions path required" true (msg_contains ~needle:"path required" msg);
   cleanup_dir base_dir
 
 let test_code_search_with_options () =
@@ -153,6 +153,23 @@ let test_code_search_with_file_pattern_finds_matches () =
       let matched_path = U.(first |> member "path" |> to_string) in
       Alcotest.(check string) "matched file basename" "match.ml"
         (Filename.basename matched_path))
+
+let test_code_search_schema_requires_path () =
+  let schema =
+    List.find_opt (fun (schema : Types.tool_schema) ->
+      String.equal schema.name "masc_code_search")
+      Tool_code.schemas
+  in
+  match schema with
+  | None -> Alcotest.fail "masc_code_search schema missing"
+  | Some schema ->
+      let module U = Yojson.Safe.Util in
+      let required =
+        schema.input_schema |> U.member "required" |> U.to_list
+        |> List.filter_map (function `String value -> Some value | _ -> None)
+      in
+      Alcotest.(check bool) "query required" true (List.mem "query" required);
+      Alcotest.(check bool) "path required" true (List.mem "path" required)
 
 (* ============================================================
    code_read validation
@@ -255,10 +272,12 @@ let () =
     ]);
     ("code_search", [
       Alcotest.test_case "empty query" `Quick test_code_search_empty_query;
-      Alcotest.test_case "with query" `Quick test_code_search_with_query;
+      Alcotest.test_case "with query requires path" `Quick test_code_search_with_query;
       Alcotest.test_case "with options" `Quick test_code_search_with_options;
       Alcotest.test_case "file pattern matches files" `Quick
         test_code_search_with_file_pattern_finds_matches;
+      Alcotest.test_case "schema requires path" `Quick
+        test_code_search_schema_requires_path;
     ]);
     ("code_read", [
       Alcotest.test_case "no path" `Quick test_code_read_no_path;


### PR DESCRIPTION
## Summary
- stop  from falling back to  when callers omit 
- require  in the tool schema so agents scope code search explicitly
- add coverage for the new runtime and schema contract

## Testing
- dune build --root . test/test_tool_code_coverage.exe test/test_code_navigation_eio.exe
- ./_build/default/test/test_tool_code_coverage.exe
- ./_build/default/test/test_code_navigation_eio.exe