### PR TITLE
[codex] Retire command and swarm compat read surfaces

### DIFF
--- a/dashboard/src/mission-normalizers.ts
+++ b/dashboard/src/mission-normalizers.ts
@@ -239,18 +239,10 @@ function normalizeSummary(raw: unknown): DashboardMissionSummary {
 
 function normalizeCommandFocus(raw: unknown): DashboardMissionCommandFocus {
   const root = isRecord(raw) ? raw : {}
-  const swarm = isRecord(root.swarm_overview) ? root.swarm_overview : {}
   return {
     health: asString(root.health),
     active_operations: asNumber(root.active_operations),
     pending_approvals: asNumber(root.pending_approvals),
-    swarm_overview: {
-      active_lanes: asNumber(swarm.active_lanes),
-      moving_lanes: asNumber(swarm.moving_lanes),
-      stalled_lanes: asNumber(swarm.stalled_lanes),
-      projected_lanes: asNumber(swarm.projected_lanes),
-      last_movement_at: asString(swarm.last_movement_at) ?? null,
-    },
     top_attention: normalizeAttentionItem(root.top_attention),
     top_action: normalizeRecommendedAction(root.top_action),
   }

--- a/dashboard/src/namespace-truth-normalizers.ts
+++ b/dashboard/src/namespace-truth-normalizers.ts
@@ -157,8 +157,6 @@ export function normalizeNamespaceTruth(raw: unknown): DashboardNamespaceTruthRe
       pending_approvals: asNumber(commandBlock.pending_approvals),
       bad_alerts: asNumber(commandBlock.bad_alerts),
       warn_alerts: asNumber(commandBlock.warn_alerts),
-      moving_lanes: asNumber(commandBlock.moving_lanes),
-      active_lanes: asNumber(commandBlock.active_lanes),
       provenance: asString(commandBlock.provenance) ?? null,
     },
     meta_cognition: {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -303,9 +303,6 @@ export function normalizeOperatorDigest(raw: unknown): OperatorDigest {
       .filter((item): item is OperatorRecommendedAction => item !== null),
     recommendation_summary: normalizeGuidanceSummary(root.recommendation_summary),
     root: normalizeNamespace(root.root),
-    swarm_status: isRecord(root.swarm_status)
-      ? (root.swarm_status as unknown as OperatorDigest['swarm_status'])
-      : undefined,
     attention_items: extractArray(root.attention_items)
       .map(normalizeAttentionItem)
       .filter((item): item is OperatorAttentionItem => item !== null),

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -168,8 +168,6 @@ export interface DashboardNamespaceTruthResponse {
     pending_approvals?: number
     bad_alerts?: number
     warn_alerts?: number
-    moving_lanes?: number
-    active_lanes?: number
     provenance?: string | null
   }
   meta_cognition?: DashboardNamespaceTruthMetaCognition | null

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -21,7 +21,6 @@ export interface DashboardMissionCommandFocus {
   health?: string
   active_operations?: number
   pending_approvals?: number
-  swarm_overview?: Record<string, unknown>
   top_attention?: OperatorAttentionItem | null
   top_action?: OperatorRecommendedAction | null
 }
@@ -354,8 +353,6 @@ export interface OperatorLinkedAutoresearch {
 
 export interface OperatorSessionSnapshot {
   session_id: string
-  command_plane_operation_id?: string
-  command_plane_detachment_id?: string
   status?: string
   progress_pct?: number
   elapsed_sec?: number
@@ -566,7 +563,6 @@ export interface OperatorDigest {
   active_recommendation_summary?: OperatorGuidanceSummary | null
   fallback_recommended_actions?: OperatorRecommendedAction[]
   recommendation_summary?: OperatorGuidanceSummary | null
-  swarm_status?: Record<string, unknown>
   root?: OperatorNamespaceSnapshot
   attention_items: OperatorAttentionItem[]
   recommended_actions: OperatorRecommendedAction[]
@@ -597,8 +593,6 @@ export interface OperatorSnapshot {
   keepers: OperatorKeeperSnapshot[]
   operator_judge_runtime?: OperatorJudgeRuntime | null
   persistent_agents?: OperatorKeeperSnapshot[]
-  command_plane?: Record<string, unknown>
-  swarm_status?: Record<string, unknown>
   recent_messages: Message[]
   pending_confirms: PendingConfirmation[]
   pending_confirm_envelope?: PendingConfirmEnvelope | null

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -166,19 +166,15 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
           ~include_messages:false
           ~include_keepers:true
           ~include_summary_fields:false
-          ~include_command_plane:false
           ~lightweight_summary:true
           ctx
       in
       Eio.Fiber.yield ();
-      let command_plane_json =
-        `Assoc []
-      in
       (* Yield between heavy computation phases to prevent fiber starvation.
          Eio's cooperative scheduler needs explicit yields in CPU-bound paths
          so other fibers (SSE, health checks) can progress. *)
       Eio.Fiber.yield ();
-      let operation_contexts = build_operation_contexts command_plane_json in
+      let operation_contexts = build_operation_contexts () in
       let session_contexts = [] in
       let execution_queue =
         build_execution_queue session_contexts operation_contexts

--- a/lib/dashboard/dashboard_execution_builders.ml
+++ b/lib/dashboard/dashboard_execution_builders.ml
@@ -368,30 +368,6 @@ let continuity_row_of_keeper ~(now_ts : float) ?related_session_id keeper :
           ]);
   }
 
-let detachment_index command_plane_json =
-  let table = Hashtbl.create 32 in
-  let detachments =
-    member_assoc "detachments" command_plane_json
-    |> member_assoc "detachments"
-    |> function
-    | `List items -> items
-    | _ -> []
-  in
-  List.iter
-    (fun detachment_card ->
-      let detachment = member_assoc "detachment" detachment_card in
-      let operation_id = string_field "operation_id" detachment in
-      if operation_id <> "" then
-        let session_id =
-          trim_to_option (string_field "session_id" detachment)
-        in
-        let detachment_id =
-          trim_to_option (string_field "detachment_id" detachment)
-        in
-        Hashtbl.replace table operation_id (session_id, detachment_id))
-    detachments;
-  table
-
 let operation_severity ~(status : string) ~blocker_summary =
   match status with
   | "failed" | "cancelled" -> Tone_bad
@@ -399,94 +375,8 @@ let operation_severity ~(status : string) ~blocker_summary =
   | _ when Option.is_some blocker_summary -> Tone_warn
   | _ -> Tone_ok
 
-let build_operation_contexts command_plane_json =
-  let operations =
-    member_assoc "operations" command_plane_json
-    |> member_assoc "operations"
-    |> function
-    | `List items -> items
-    | _ -> []
-  in
-  let detachments = detachment_index command_plane_json in
-  operations
-  |> List.filter_map (fun operation_card ->
-         let operation = member_assoc "operation" operation_card in
-         let operation_id = string_field "operation_id" operation in
-         if operation_id = "" then None
-         else
-           let search = member_assoc "search" operation_card in
-           let blockers = list_field "dependency_blockers" search in
-           let blocker_summary =
-             match blockers with
-             | blocker :: _ ->
-                 trim_to_option (string_field "reason" blocker)
-             | [] ->
-                 if string_field "readiness" search = "blocked" then
-                   Some "operation search is blocked"
-                 else
-                   None
-           in
-           let status_str = string_field ~default:"active" "status" operation in
-           let op_status = status_str in
-           let severity = operation_severity ~status:op_status ~blocker_summary in
-           let linked_session_id, linked_detachment_id =
-             match Hashtbl.find_opt detachments operation_id with
-             | Some (session_id, detachment_id) -> (session_id, detachment_id)
-             | None ->
-                 ( trim_to_option (string_field "detachment_session_id" operation),
-                   None )
-           in
-           let command_handoff =
-             handoff_json
-               ~surface:"command"
-               ~command_surface:"operations"
-               ~operation_id
-               ~label:"작전 원인 보기"
-               ~target_type:"operation"
-               ~target_id:operation_id
-               ~focus_kind:"operation"
-               ()
-           in
-           let updated_at =
-             trim_to_option (string_field "updated_at" operation)
-           in
-           Some
-             {
-               operation_id;
-               severity;
-               last_seen_ts =
-                 parse_iso_opt updated_at |> Option.value ~default:0.0;
-               linked_session_id;
-               linked_detachment_id;
-               json =
-                 `Assoc
-                   [
-                     ("operation_id", `String operation_id);
-                     ("objective", member_assoc "objective" operation);
-                     ("status", `String status_str);
-                     ("stage", member_assoc "stage" operation);
-                     ("assigned_unit_id", member_assoc "assigned_unit_id" operation);
-                     ("assigned_unit_label", member_assoc "assigned_unit_label" operation_card);
-                     ("linked_session_id", json_string_option linked_session_id);
-                     ("linked_detachment_id", json_string_option linked_detachment_id);
-                     ("blocker_summary", json_string_option blocker_summary);
-                     ("search_status", member_assoc "readiness" search);
-                     ( "next_tool",
-                       if Option.is_some blocker_summary then `String "masc_operation_status"
-                       else `String "masc_observe_operations" );
-                     ("updated_at", json_string_option updated_at);
-                     ("top_handoff", command_handoff);
-                     ("command_handoff", command_handoff);
-                   ];
-             })
-  |> List.sort (fun left right ->
-         let by_severity =
-           Int.compare
-             (tone_rank right.severity)
-             (tone_rank left.severity)
-         in
-         if by_severity <> 0 then by_severity
-         else Float.compare right.last_seen_ts left.last_seen_ts)
+let build_operation_contexts () =
+  []
 
 let build_worker_support_briefs ~(now_ts : float) ~(tasks : Types.task list)
     ~(agents : Types.agent list) ~(messages : Types.message list) session_contexts :

--- a/lib/dashboard/dashboard_mission.ml
+++ b/lib/dashboard/dashboard_mission.ml
@@ -562,7 +562,6 @@ type mission_projection = {
   snapshot_json : Yojson.Safe.t;
   digest_json : Yojson.Safe.t;
   namespace_json : Yojson.Safe.t;
-  command_json : Yojson.Safe.t;
   incidents : Yojson.Safe.t list;
   recommended_actions : Yojson.Safe.t list;
   attention_queue : attention_context list;
@@ -572,7 +571,7 @@ type mission_projection = {
   internal_signals : Yojson.Safe.t list;
 }
 
-let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~clock
+let build_projection ?actor ~config ~sw ~clock
     ~proc_mgr () =
   let actor_name =
     match actor with
@@ -601,25 +600,15 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
           ~include_messages:false
           ~include_keepers:true
           ~include_summary_fields:false
-          ~include_command_plane:false
           ~lightweight_summary:true
           ctx)
-  in
-  let command_json =
-    Dashboard_cache.get_or_compute
-      (room_scoped_cache_key config "command_projection" actor_name)
-      ~ttl:3.0
-      (fun () -> `Assoc [])
   in
   let digest_json =
     Dashboard_cache.get_or_compute
       (room_scoped_cache_key config "digest" actor_name)
       ~ttl:5.0
       (fun () ->
-        match
-          Operator_control.digest_json ~actor:actor_name ?command_plane_summary
-            ?swarm_status ctx
-        with
+        match Operator_control.digest_json ~actor:actor_name ctx with
         | Ok json -> json
         | Error message ->
             `Assoc
@@ -627,8 +616,6 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
                 ("health", `String "warn");
                 ("attention_items", `List []);
                 ("recommended_actions", `List []);
-                ("swarm_status", Swarm_status.empty_json);
-                ("command_plane", `Assoc []);
                 ("error", `String message);
               ])
   in
@@ -662,7 +649,6 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
     snapshot_json;
     digest_json;
     namespace_json;
-    command_json;
     incidents;
     recommended_actions;
     attention_queue;
@@ -670,19 +656,13 @@ let build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw ~cl
     agent_briefs;
     keeper_briefs;
     internal_signals;
-  }
+}
 
-let json ?actor ?command_plane_summary ?swarm_status ~config ~sw ~clock ~proc_mgr
+let json ?actor ~config ~sw ~clock ~proc_mgr
     () =
   let projection =
-    build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw
+    build_projection ?actor ~config ~sw
       ~clock ~proc_mgr ()
-  in
-  let operations_summary =
-    member_assoc "operations" projection.command_json |> member_assoc "summary"
-  in
-  let decisions_summary =
-    member_assoc "decisions" projection.command_json |> member_assoc "summary"
   in
   let summary_json =
     `Assoc
@@ -696,9 +676,8 @@ let json ?actor ?command_plane_summary ?swarm_status ~config ~sw ~clock ~proc_mg
     `Assoc
       [
         ("health", `String (string_field ~default:"ok" "health" projection.digest_json));
-        ("active_operations", `Int (int_field "active" operations_summary));
-        ("pending_approvals", `Int (int_field "pending" decisions_summary));
-        ("swarm_overview", member_assoc "swarm_status" projection.digest_json |> member_assoc "overview");
+        ("active_operations", `Int 0);
+        ("pending_approvals", `Int 0);
         ("top_attention", top_item projection.incidents);
         ("top_action", top_item projection.recommended_actions);
       ]
@@ -727,15 +706,15 @@ let json ?actor ?command_plane_summary ?swarm_status ~config ~sw ~clock ~proc_mg
       ("internal_signals", `List projection.internal_signals);
     ]
 
-let session_json ?actor ?command_plane_summary ?swarm_status ~session_id ~config ~sw
+let session_json ?actor ~session_id ~config ~sw
     ~clock ~proc_mgr () =
   let projection =
-    build_projection ?actor ?command_plane_summary ?swarm_status ~config ~sw
+    build_projection ?actor ~config ~sw
       ~clock ~proc_mgr ()
   in
   let session_row_json =
     Dashboard_mission_assembly.build_sessions projection.sessions projection.attention_queue projection.agent_briefs
-      projection.keeper_briefs projection.command_json
+      projection.keeper_briefs
     |> List.find_opt (fun json ->
            String.equal (string_field "session_id" json) session_id)
   in
@@ -758,7 +737,7 @@ let session_json ?actor ?command_plane_summary ?swarm_status ~session_id ~config
     ignore (config, session_id);
     `Null
   in
-  let operation_contexts = Dashboard_mission_assembly.build_operation_contexts projection.command_json in
+  let operation_contexts = Dashboard_mission_assembly.build_operation_contexts () in
   let operations_json =
     match session_context with
     | None -> []

--- a/lib/dashboard/dashboard_mission.mli
+++ b/lib/dashboard/dashboard_mission.mli
@@ -1,7 +1,5 @@
 val json :
   ?actor:string ->
-  ?command_plane_summary:Yojson.Safe.t ->
-  ?swarm_status:Yojson.Safe.t ->
   config:Coord.config ->
   sw:Eio.Switch.t ->
   clock:'a Eio.Time.clock ->
@@ -11,8 +9,6 @@ val json :
 
 val session_json :
   ?actor:string ->
-  ?command_plane_summary:Yojson.Safe.t ->
-  ?swarm_status:Yojson.Safe.t ->
   session_id:string ->
   config:Coord.config ->
   sw:Eio.Switch.t ->

--- a/lib/dashboard/dashboard_mission_assembly.ml
+++ b/lib/dashboard/dashboard_mission_assembly.ml
@@ -335,59 +335,8 @@ let build_internal_signals incidents actions =
   |> List.sort (fun left right -> Int.compare right.pressure_rank left.pressure_rank)
   |> List.map (fun (row : keeper_context) -> row.json)
 
-let detachment_index command_plane_json =
-  let table = Hashtbl.create 16 in
-  let detachments =
-    member_assoc "detachments" command_plane_json
-    |> member_assoc "detachments"
-    |> function
-    | `List items -> items
-    | _ -> []
-  in
-  List.iter
-    (fun detachment_card ->
-      let detachment = member_assoc "detachment" detachment_card in
-      let operation_id = string_field "operation_id" detachment in
-      if operation_id <> "" then
-        Hashtbl.replace table operation_id
-          ( trim_to_option (string_field "session_id" detachment),
-            trim_to_option (string_field "status" detachment) ))
-    detachments;
-  table
-
-let build_operation_contexts command_plane_json =
-  let operations =
-    member_assoc "operations" command_plane_json
-    |> member_assoc "operations"
-    |> function
-    | `List items -> items
-    | _ -> []
-  in
-  let detachments = detachment_index command_plane_json in
-  operations
-  |> List.filter_map (fun operation_card ->
-         let operation = member_assoc "operation" operation_card in
-         let operation_id = string_field "operation_id" operation in
-         if operation_id = "" then None
-         else
-           let linked_session_id, detachment_status =
-             match Hashtbl.find_opt detachments operation_id with
-             | Some (session_id, status_str) ->
-                 (session_id, status_str)
-             | None ->
-                 (trim_to_option (string_field "detachment_session_id" operation), None)
-           in
-           let status = trim_to_option (string_field "status" operation) in
-           Some
-             {
-               operation_id;
-               linked_session_id;
-               status;
-               stage = trim_to_option (string_field "stage" operation);
-               detachment_status;
-               objective = trim_to_option (string_field "objective" operation);
-               updated_at = trim_to_option (string_field "updated_at" operation);
-             })
+let build_operation_contexts () =
+  []
 
 let operation_badge_json (operation : operation_context) =
   let status_str =
@@ -490,7 +439,7 @@ let keeper_refs_for_session member_names keeper_briefs =
                  ("current_work", member_assoc "current_work" row);
                ]))
 
-let build_sessions sessions attention_queue agent_briefs keeper_briefs command_plane_json =
+let build_sessions sessions attention_queue agent_briefs keeper_briefs =
   let related_attention_count session_id =
     attention_queue
     |> List.fold_left
@@ -498,7 +447,7 @@ let build_sessions sessions attention_queue agent_briefs keeper_briefs command_p
            if List.mem session_id attention.related_session_ids then acc + 1 else acc)
          0
   in
-  let operation_contexts = build_operation_contexts command_plane_json in
+  let operation_contexts = build_operation_contexts () in
   sessions
   |> List.map (fun (session : session_context) ->
          let attention_count = related_attention_count session.session_id in

--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -141,7 +141,7 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
          snapshot path and can spike memory on rooms with many keepers. *)
       Operator_control.snapshot_json ~actor:actor_name ~view:"summary"
         ~include_messages:false ~include_keepers:false
-        ~include_summary_fields:false ~include_command_plane:false
+        ~include_summary_fields:false
         ~lightweight_summary:true ctx
     in
     let scope_json =

--- a/lib/operator/operator_control.mli
+++ b/lib/operator/operator_control.mli
@@ -9,7 +9,6 @@ val snapshot_json :
   ?include_messages:bool ->
   ?include_keepers:bool ->
   ?include_summary_fields:bool ->
-  ?include_command_plane:bool ->
   ?lightweight_summary:bool ->
   'a context ->
   Yojson.Safe.t

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -796,16 +796,16 @@ let namespace_scope_cache_segment (_config : Coord_utils.config) = "default"
 
 let snapshot_json ?actor ?view ?(include_messages = true)
     ?(include_keepers = true) ?(include_summary_fields = true)
-    ?(include_command_plane = true) ?(lightweight_summary = false)
+    ?(lightweight_summary = false)
     (ctx : 'a context) : Yojson.Safe.t =
   let cache_key =
-    Printf.sprintf "%s|%s|%s|%s|%b|%b|%b|%b|%b"
+    Printf.sprintf "%s|%s|%s|%s|%b|%b|%b|%b"
       ctx.config.base_path
       (namespace_scope_cache_segment ctx.config)
       (Option.value ~default:"" actor)
       (Option.value ~default:"" view)
       include_messages include_keepers include_summary_fields
-      include_command_plane lightweight_summary
+      lightweight_summary
   in
   (* Singleflight cache lookup: check for fresh hit, in-flight compute,
      or start a new compute.  Uses Eio.Mutex for safe Hashtbl access.
@@ -916,23 +916,17 @@ let snapshot_json ?actor ?view ?(include_messages = true)
   in
   (* Team sessions removed — status_cache and session digests no longer needed. *)
   let status_cache : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 0 in
-  let command_plane_summary =
-    if include_summary_fields && initialized then
-      timed "command_plane_summary" (fun () ->
-        Some (`Assoc []))
-    else None
-  in
   let summary_fields = timed "summary_fields" (fun () ->
     if include_summary_fields
        && initialized
        && (match view with Summary | Full -> true | _ -> false)
     then
       let room_attention =
-        build_room_attention_items ?command_plane_summary config
+        build_room_attention_items config
         |> List.sort compare_attention
       in
       let room_recommendation_items =
-        room_recommendations ?command_plane_summary config
+        room_recommendations config
       in
       [
         ("attention_summary", summary_of_attention_items room_attention);
@@ -963,17 +957,11 @@ let snapshot_json ?actor ?view ?(include_messages = true)
          ("root", room_json config);
        ]
       @ (
-         (* Parallelize independent I/O: sessions, keepers, persistent_agents,
-            and command_plane + swarm_status.  command_plane_json was previously
-            computed sequentially before the fiber block, blocking the entire
-            snapshot when command plane generation was slow.  Now it runs as
-            a 4th fiber, overlapping with sessions/keepers I/O. *)
+         (* Parallelize independent I/O: sessions, keepers, and persistent_agents. *)
          let empty_section = `Assoc [ ("count", `Int 0); ("items", `List []) ] in
          let sessions_ref = ref empty_section in
          let keepers_ref = ref empty_section in
          let persistent_ref = ref empty_section in
-         let command_plane_ref = ref `Null in
-         let swarm_status_ref = ref `Null in
          Eio.Fiber.all [
            (fun () ->
              (* Team sessions removed — always empty *)
@@ -1002,20 +990,11 @@ let snapshot_json ?actor ?view ?(include_messages = true)
                    persistent_agents_json ~keeper_names:persistent_keeper_names
                      ~keeper_rows config
                  else empty_section));
-           (fun () ->
-             let cp = timed "command_plane_json" (fun () ->
-               let _ = initialized && include_command_plane in
-               `Null)
-             in
-             command_plane_ref := cp;
-             swarm_status_ref := `Null);
          ];
          [
            ("sessions", !sessions_ref);
            ("keepers", !keepers_ref);
            ("persistent_agents", !persistent_ref);
-           ("command_plane", !command_plane_ref);
-           ("swarm_status", !swarm_status_ref);
          ]
       )
       (* Team sessions removed — aggregate metrics are always empty. *)

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -73,7 +73,7 @@ let recent_tool_host_failures ~now () =
   Log.Ring.recent ~limit:12 ~module_filter:Failure_envelope.tool_host_log_module_name ()
   |> dedup [] []
 
-let build_room_attention_items ?command_plane_summary:_ config =
+let build_room_attention_items config =
   let pending_confirms = read_pending_confirms config in
   let pending_items =
     if pending_confirms = [] then []
@@ -96,7 +96,7 @@ let build_room_attention_items ?command_plane_summary:_ config =
     (recent_tool_host_failures ~now:(Time_compat.now ()) ()
     @ pending_items)
 
-let room_recommendations ?command_plane_summary:_ _config =
+let room_recommendations _config =
   dedup_recommendations []
 
 (* Re-export from Operator_digest_review_types without [include] to
@@ -487,7 +487,7 @@ let review_queue_json ~actor active deferred recent_json =
   ]
 
 let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_include_workers
-    ?command_plane_summary ?swarm_status (ctx : 'a context) :
+    (ctx : 'a context) :
     (Yojson.Safe.t, string) result =
   let config = ctx.config in
   if not (Coord.is_initialized config) then
@@ -504,8 +504,6 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
           ("provenance_summary", operator_surface_contract_json);
           ("judgment", `Null);
           ("operator_judge_runtime", operator_judge_runtime_json config);
-          ("command_plane", `Assoc []);
-          ("swarm_status", Swarm_status.empty_json);
           ("attention_items", `List []);
           ("attention_summary", summary_of_attention_items []);
           ("pending_confirm_summary", pending_confirm_summary_json_of_scope (pending_confirm_scope_of_entries ?actor []));
@@ -528,27 +526,16 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
     let* target_type = normalize_digest_target_type target_type in
     let now = Time_compat.now () in
     let room_state_json = room_state_json config in
-    let command_plane_digest_json =
-      match command_plane_summary with
-      | Some summary -> summary
-      | None -> `Assoc []
-    in
-    let swarm_status_json =
-      match swarm_status with
-      | Some json -> json
-      | None ->
-          Swarm_status.build_json ~timeline_limit_override:6 config
-    in
     match target_type with
     | "root" ->
         let confirm_scope = pending_confirm_scope ?actor config in
         let attention_items =
-          build_room_attention_items ~command_plane_summary:command_plane_digest_json config
+          build_room_attention_items config
           |> List.sort compare_attention
         in
         let recommended_actions =
           dedup_recommendations
-            (room_recommendations ~command_plane_summary:command_plane_digest_json config)
+            (room_recommendations config)
         in
         let fallback_recommendation_summary =
           summary_of_recommendations ~actor:actor_name recommended_actions
@@ -582,8 +569,6 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
               ("health", `String (health_from_attention_items attention_items));
               ("provenance_summary", operator_surface_contract_json);
               ("operator_judge_runtime", operator_judge_runtime_json config);
-              ("command_plane", command_plane_digest_json);
-              ("swarm_status", swarm_status_json);
               ("role_census", `Assoc []);
               ("runtime_pools", `Assoc []);
               ("lane_census", `Assoc []);

--- a/lib/operator/operator_digest.mli
+++ b/lib/operator/operator_digest.mli
@@ -72,15 +72,9 @@ val summary_of_recommendations : actor:string -> recommended_action list -> Yojs
 val health_from_attention_items : attention_item list -> string
 val normalize_team_health : string -> string
 
-val build_room_attention_items :
-  ?command_plane_summary:Yojson.Safe.t ->
-  Coord.config ->
-  attention_item list
+val build_room_attention_items : Coord.config -> attention_item list
 
-val room_recommendations :
-  ?command_plane_summary:Yojson.Safe.t ->
-  Coord.config ->
-  recommended_action list
+val room_recommendations : Coord.config -> recommended_action list
 
 val normalize_digest_target_type :
   string option -> (string, string) result
@@ -90,7 +84,5 @@ val digest_json :
   ?target_type:string ->
   ?target_id:string ->
   ?include_workers:bool ->
-  ?command_plane_summary:Yojson.Safe.t ->
-  ?swarm_status:Yojson.Safe.t ->
   'a Operator_pending_confirm.context ->
   (Yojson.Safe.t, string) result

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -39,9 +39,7 @@ let normalized_actor ~context_actor = function
 let operator_surface_contract_json =
   `Assoc
     [
-      ("command_plane", `String "truth");
       ("judgment", `String "judgment");
-      ("swarm_status", `String "derived");
       ("attention_items", `String "derived");
       ("recommended_actions", `String "fallback");
       ("active_recommended_actions", `String "judgment_or_fallback");

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -95,9 +95,6 @@ let initialized_json_opt ?(allow_initializing = false) = function
       | _ -> Some json)
   | _ -> None
 
-let command_plane_summary_cache_parts ~allow_initializing:_ ~state:_ =
-  (None, None)
-
 let dashboard_batch_json ?(compact = false) (config : Coord.config) : Yojson.Safe.t =
   let room_state = Coord.read_state config in
   let tempo = Tempo.get_tempo config in
@@ -307,7 +304,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
               ~include_messages:true ~include_keepers:true
               ~include_summary_fields:false
               ~lightweight_summary:true
-              ~include_command_plane:false ctx
+              ctx
           in
           let dt_snapshot = Unix.gettimeofday () -. t_snapshot in
           let dt_total = Unix.gettimeofday () -. started_at in
@@ -343,9 +340,6 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
     mark_cached_surface_attempt _operator_digest_cache;
     let started_at = Unix.gettimeofday () in
     try
-      let command_plane_summary, swarm_status =
-        command_plane_summary_cache_parts ~allow_initializing:false ~state
-      in
       run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw
         ~clock ~config
         (fun ~config ~sw ->
@@ -362,7 +356,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
           in
           match
             Operator_control.digest_json ~actor:"dashboard" ~target_type:"root"
-              ?command_plane_summary ?swarm_status ctx
+              ctx
           with
           | Ok json ->
               with_projection_diagnostics ~surface:"operator_digest" ~started_at
@@ -412,13 +406,13 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
       | Some ("0" | "false" | "no") -> false
       | _ -> true
     in
-    let include_command_plane =
+    let lightweight_summary =
       match view with
-      | Some raw -> not (String.equal (String.lowercase_ascii (String.trim raw)) "summary")
-      | None -> true
+      | Some raw -> String.equal (String.lowercase_ascii (String.trim raw)) "summary"
+      | None -> false
     in
     let mode =
-      if include_command_plane then Offloaded_readonly else Inline_shared
+      if lightweight_summary then Inline_shared else Offloaded_readonly
     in
     match Eio.Time.with_timeout clock _dashboard_request_timeout_s (fun () ->
       Ok
@@ -438,9 +432,9 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
              in
             Operator_control.snapshot_json ?actor ?view
                ~include_messages ~include_keepers
-               ~include_summary_fields:include_command_plane
-               ~lightweight_summary:(not include_command_plane)
-               ~include_command_plane ctx))
+               ~include_summary_fields:(not lightweight_summary)
+               ~lightweight_summary
+               ctx))
     ) with
     | Ok json ->
         with_projection_diagnostics ~surface:"operator_snapshot" ~started_at
@@ -504,15 +498,9 @@ let operator_digest_http_json ~state ~sw ~clock request =
                  mcp_session_id = None;
                }
              in
-             let command_plane_summary, swarm_status =
-               if namespace_target_type (Some effective_target_type) then
-                 command_plane_summary_cache_parts ~allow_initializing:false ~state
-               else
-                 (None, None)
-             in
              match
                Operator_control.digest_json ?actor ~target_type:effective_target_type
-                 ?target_id ?include_workers ?command_plane_summary ?swarm_status
+                 ?target_id ?include_workers
                  ctx
              with
              | Ok json -> json
@@ -572,25 +560,20 @@ let start_mission_refresh_loop ~state ~sw ~clock =
     mark_cached_surface_attempt _mission_cache;
     let t0_mission = Unix.gettimeofday () in
     try
-      let t_cp = Unix.gettimeofday () in
-      let command_plane_summary, swarm_status =
-        command_plane_summary_cache_parts ~allow_initializing:false ~state
-      in
       run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw
         ~clock ~config:room_config
         |> fun run_compute ->
-        let dt_cp = Unix.gettimeofday () -. t_cp in
         let result =
           run_compute
           (fun ~config ~sw ->
-            Dashboard_mission.json ?command_plane_summary ?swarm_status ~config ~sw
+            Dashboard_mission.json ~config ~sw
               ~clock ~proc_mgr ())
         in
       let dt_total = Unix.gettimeofday () -. t0_mission in
       if dt_total >= 5.0 then
         Log.Dashboard.warn
-          "[mission profile] total=%.1fs cp_summary=%.1fs compute=%.1fs"
-          dt_total dt_cp (dt_total -. dt_cp);
+          "[mission profile] total=%.1fs"
+          dt_total;
       result
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -610,28 +593,15 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
   let actor = operator_actor_hint request in
   let compute ?actor () =
     let started_at = Unix.gettimeofday () in
-    let command_plane_started_at = Unix.gettimeofday () in
-    let command_plane_summary, swarm_status =
-      command_plane_summary_cache_parts ~allow_initializing:false ~state
-    in
-    let command_plane_summary_ms =
-      int_of_float
-        ((Unix.gettimeofday () -. command_plane_started_at) *. 1000.0)
-    in
     run_dashboard_compute ~mode:Offloaded_readonly ?net ?mono_clock ~sw
       ~clock
       ~config:state.Mcp_server.room_config
       (fun ~config ~sw ->
-        Dashboard_mission.json ?actor ?command_plane_summary ?swarm_status
+        Dashboard_mission.json ?actor
           ~config ~sw ~clock
           ~proc_mgr:state.Mcp_server.proc_mgr ())
     |> with_projection_diagnostics ~surface:"mission" ~started_at
-         ~extra:
-           [
-             ("command_plane_summary_ms", `Int command_plane_summary_ms);
-             ("has_command_plane_summary", `Bool (Option.is_some command_plane_summary));
-             ("has_swarm_status", `Bool (Option.is_some swarm_status));
-           ]
+         ~extra:[]
   in
   let full_json =
     match actor with
@@ -657,11 +627,7 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
 let dashboard_session_http_json ~state ~sw ~clock request =
   match query_param request "session_id" with
   | Some session_id when String.trim session_id <> "" ->
-      let command_plane_summary, swarm_status =
-        command_plane_summary_cache_parts ~allow_initializing:false ~state
-      in
       Dashboard_mission.session_json ?actor:(operator_actor_hint request)
-        ?command_plane_summary ?swarm_status
         ~session_id:(String.trim session_id)
         ~config:state.Mcp_server.room_config ~sw ~clock
         ~proc_mgr:state.Mcp_server.proc_mgr ()

--- a/lib/server/server_dashboard_http_core.mli
+++ b/lib/server/server_dashboard_http_core.mli
@@ -62,13 +62,6 @@ val with_projection_diagnostics :
   Yojson.Safe.t ->
   Yojson.Safe.t
 
-(** {1 Command Plane Support} *)
-
-val command_plane_summary_cache_parts :
-  allow_initializing:bool ->
-  state:Mcp_server.server_state ->
-  Yojson.Safe.t option * Yojson.Safe.t option
-
 (** {1 Sanitization and Request Helpers} *)
 
 val operator_actor_hint : Httpun.Request.t -> string option

--- a/lib/server/server_dashboard_http_namespace_truth_support.ml
+++ b/lib/server/server_dashboard_http_namespace_truth_support.ml
@@ -310,8 +310,6 @@ let namespace_truth_command_summary_json command_summary_json =
   let command_detachments = json_assoc_field "detachments" command_summary_json in
   let command_alerts = json_assoc_field "alerts" command_summary_json in
   let command_decisions = json_assoc_field "decisions" command_summary_json in
-  let swarm_status = json_assoc_field "swarm_status" command_summary_json in
-  let swarm_overview = json_assoc_field "overview" swarm_status in
   `Assoc
     [
       ( "active_operations",
@@ -334,8 +332,6 @@ let namespace_truth_command_summary_json command_summary_json =
         `Int
           (json_int_field "warn" (json_assoc_field "summary" command_alerts)
              ~default:0) );
-      ("moving_lanes", `Int (json_int_field "moving_lanes" swarm_overview ~default:0));
-      ("active_lanes", `Int (json_int_field "active_lanes" swarm_overview ~default:0));
       ("provenance", `String "truth");
     ]
 

--- a/lib/swarm_status/swarm_status_json.ml
+++ b/lib/swarm_status/swarm_status_json.ml
@@ -114,7 +114,7 @@ let lane_kind_string = function
   | Supervised -> "supervised"
 
 let source_of_truth = function
-  | Managed -> "managed_command_plane"
+  | Managed -> "managed"
   | Projected -> "projected_swarm_json"
   | Supervised -> "execution_session_operator"
 

--- a/lib/swarm_status/swarm_status_parse.ml
+++ b/lib/swarm_status/swarm_status_parse.ml
@@ -67,7 +67,7 @@ let trace_of_json json =
   {
     event_id = get_string_default json "event_id" "";
     event_type = get_string_default json "event_type" "trace";
-    source = get_string_default json "source" "command_plane";
+    source = get_string_default json "source" "managed";
     trace_id = get_string_default json "trace_id" "";
     operation_id = get_string_opt json "operation_id";
     actor = get_string_opt json "actor";

--- a/lib/tool_misc_admin.ml
+++ b/lib/tool_misc_admin.ml
@@ -248,12 +248,6 @@ let handle_tool_admin_snapshot ctx args =
         ("status", `String "ok");
         ("generated_at", `String (Types.now_iso ()));
         ("auth", auth_snapshot_json ctx);
-        ( "command_plane",
-          `Assoc
-            [
-              ("policy_status", `Assoc []);
-              ("enforcement_summary", enforcement_summary_json ());
-            ] );
         ( "tool_inventory",
           tool_inventory_json ctx ~include_hidden ~include_deprecated );
       ]

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -360,9 +360,12 @@ let test_mission_briefing_memory_guard_contracts () =
   check bool "mission briefing snapshot disables keeper payload" true
     (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
        "~include_keepers:false");
+  check bool "mission briefing snapshot no longer references command plane" true
+    (file_not_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
+       "include_command_plane");
   check bool "mission briefing snapshot stays off command plane" true
     (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
-       "~include_command_plane:false");
+       "~include_summary_fields:false");
   check bool "mission briefing snapshot stays lightweight" true
     (file_contains_pattern "lib/dashboard/dashboard_mission_briefing.ml"
        "~lightweight_summary:true");

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -23,10 +23,10 @@ let () =
             `Quick
             Test_operator_control_snapshot
             .test_snapshot_pending_confirm_summary_tracks_actor_scope;
-          Alcotest.test_case "snapshot summary view can omit command plane"
+          Alcotest.test_case "snapshot summary view excludes retired command plane"
             `Quick
             Test_operator_control_snapshot
-            .test_snapshot_summary_view_can_omit_command_plane;
+            .test_snapshot_summary_view_excludes_retired_command_plane;
           Alcotest.test_case "snapshot lightweight summary omits heavy activity"
             `Quick
             Test_operator_control_snapshot

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -164,7 +164,7 @@ let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
              Yojson.Safe.Util.(row |> member "action_type" |> to_string) = "task_inject")
            confirm_required_actions))
 
-let test_snapshot_summary_view_can_omit_command_plane () =
+let test_snapshot_summary_view_excludes_retired_command_plane () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
   Eio.Switch.run @@ fun sw ->
@@ -177,11 +177,12 @@ let test_snapshot_summary_view_can_omit_command_plane () =
       ignore (Coord.join config ~agent_name:"owner" ~capabilities:[] ());
       let json =
         Operator_control.snapshot_json ~view:"summary"
-          ~include_messages:false ~include_command_plane:false
+          ~include_messages:false
           (operator_ctx env sw config "owner")
       in
-      Alcotest.(check bool) "command_plane omitted" true
-        (Yojson.Safe.Util.member "command_plane" json = `Null);
+      Alcotest.(check bool) "command_plane field absent" true
+        (not (List.mem_assoc "command_plane"
+           Yojson.Safe.Util.(to_assoc json)));
       Alcotest.(check bool) "swarm_status omitted" true
         (Yojson.Safe.Util.member "swarm_status" json = `Null);
       Alcotest.(check bool) "attention summary still present" true
@@ -202,7 +203,7 @@ let test_snapshot_lightweight_summary_omits_heavy_activity () =
       ignore (Coord.join config ~agent_name:"owner" ~capabilities:[] ());
       let json =
         Operator_control.snapshot_json ~view:"summary"
-          ~include_keepers:true ~include_messages:true ~include_command_plane:false
+          ~include_keepers:true ~include_messages:true
           ~lightweight_summary:true
           (operator_ctx env sw config "owner")
       in

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -556,7 +556,7 @@ let () = test "dispatch_tool_admin_snapshot" (fun () ->
       assert (Yojson.Safe.Util.member "mode" json = `Null);
       (* keeper_policies removed with policy_mode purge *)
       assert (Yojson.Safe.Util.member "keeper_policies" json = `Null);
-      assert (Yojson.Safe.Util.member "command_plane" json <> `Null)
+      assert (Yojson.Safe.Util.member "command_plane" json = `Null)
   | None -> failwith "dispatch returned None"
 )
 


### PR DESCRIPTION
## What changed
- removed retired `command_plane` compatibility plumbing from operator, dashboard mission, dashboard execution builders, server dashboard HTTP core, and admin snapshot surfaces
- removed retired `swarm_status` / `swarm_overview` fields from operator digest, mission payloads, namespace truth summaries, and dashboard TypeScript normalizers/types
- simplified the now-dead dashboard mission assembly and execution builder paths that were only threading empty command/swarm summaries
- updated source-guard and operator coverage tests to assert those retired fields are absent

## Why
`command_plane` was already a removed implementation surface, but several read models still carried compatibility fields and empty summaries. `swarm_status` was in a similar state for these operator/mission payloads, which kept dead JSON structure alive and made the health model less truthful.

This change narrows those read surfaces to the fields that are still actually authoritative.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/remove-command-plane-compat`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_dashboard_mission.exe`
- `./_build/default/test/test_ci_hardening_source.exe`

## Notes
- full dashboard TypeScript typecheck was not run because `dashboard/node_modules` is absent in this worktree, so `tsc` is unavailable
- remaining broader swarm cleanup is tracked separately in `#7572`