### PR TITLE
Handle stale keeper composite selection in dashboard

### DIFF
--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -26,7 +26,12 @@ import {
 } from '../api/keeper'
 import type { GateKeepersData } from '../api/gate'
 import { normalizeKeepers } from '../keeper-store-normalize'
-import { deriveStateEntries, deriveSwimlaneSegments } from './fsm-hub'
+import {
+  deriveStateEntries,
+  deriveSwimlaneSegments,
+  isCompositeFetchNotFound,
+  shouldUseGateKeeperFallback,
+} from './fsm-hub'
 import type { CompositeObservation } from './fsm-hub-types'
 
 /** Server-shaped keeper composite snapshot matching the projected
@@ -218,6 +223,21 @@ describe('FSM Hub integration — API response shape', () => {
     it('normalizeKeepers ignores the count-only "configured_keepers" field the shell actually sends', () => {
       const shellShape: Record<string, unknown> = { configured_keepers: 12 }
       expect(normalizeKeepers(shellShape.keepers)).toEqual([])
+    })
+  })
+
+  describe('keeper selection fallback guards', () => {
+    it('uses gate fallback only before execution data has loaded', () => {
+      expect(shouldUseGateKeeperFallback(false, [])).toBe(true)
+      expect(shouldUseGateKeeperFallback(true, [])).toBe(false)
+      expect(shouldUseGateKeeperFallback(true, ['keeper-a'])).toBe(false)
+      expect(shouldUseGateKeeperFallback(false, ['keeper-a'])).toBe(false)
+    })
+
+    it('treats composite 404 as keeper disappearance, not generic schema failure', () => {
+      expect(isCompositeFetchNotFound(new Error('composite fetch failed: 404'))).toBe(true)
+      expect(isCompositeFetchNotFound(new Error('composite fetch failed: 500'))).toBe(false)
+      expect(isCompositeFetchNotFound(new Error('state-diagram fetch failed: 404'))).toBe(false)
     })
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -6,7 +6,7 @@ import {
   type KeeperCompositeSnapshot,
 } from '../api/keeper'
 import { fetchGateKeepers } from '../api/gate'
-import { keepers } from '../store'
+import { executionLoaded, keepers, refreshExecution } from '../store'
 import { compositeTick } from '../composite-signals'
 import { useGlobalShortcut } from '../lib/use-global-shortcut'
 import { EmptyState } from './common/empty-state'
@@ -75,6 +75,17 @@ export {
 export {
   isTransitionInSegment,
 } from './fsm-hub-timeline-panels'
+
+export function shouldUseGateKeeperFallback(
+  executionLoadedValue: boolean,
+  storeNames: string[],
+): boolean {
+  return !executionLoadedValue && storeNames.length === 0
+}
+
+export function isCompositeFetchNotFound(err: unknown): boolean {
+  return err instanceof Error && /composite fetch failed: 404$/.test(err.message)
+}
 
 // ── State Reducer ──────────────────────────────────────
 
@@ -252,12 +263,13 @@ export function FsmHub() {
   // details (only sends configured_keepers count), so without this
   // fallback the FsmHub sees zero keepers and renders empty state.
   const storeKeeperList = keepers.value
+  const executionLoadedValue = executionLoaded.value
   const storeNames = useMemo(
     () => storeKeeperList.map(k => k.name).sort(),
     [storeKeeperList],
   )
   useEffect(() => {
-    if (storeNames.length > 0) return
+    if (!shouldUseGateKeeperFallback(executionLoadedValue, storeNames)) return
     let cancelled = false
     void (async () => {
       try {
@@ -275,9 +287,11 @@ export function FsmHub() {
       }
     })()
     return () => { cancelled = true }
-  }, [storeNames.length, pollTick])
+  }, [executionLoadedValue, storeNames, pollTick])
 
-  const keeperNames = storeNames.length > 0 ? storeNames : gateKeeperNames
+  const keeperNames = shouldUseGateKeeperFallback(executionLoadedValue, storeNames)
+    ? gateKeeperNames
+    : storeNames
   const activeSelected = useMemo(() => {
     if (selected && keeperNames.includes(selected)) return selected
     return keeperNames[0] ?? null
@@ -316,6 +330,17 @@ export function FsmHub() {
         })
       } catch (err) {
         if (requestIdRef.current !== requestId) return
+        if (isCompositeFetchNotFound(err)) {
+          setGateKeeperNames(prev => prev.filter(name => name !== activeSelected))
+          setSelected(prev => (prev === activeSelected ? null : prev))
+          void refreshExecution({ force: true })
+          dispatch({
+            type: 'fetch_failed',
+            keeperName: activeSelected,
+            error: '선택한 keeper가 종료되었거나 등록 해제되었습니다',
+          })
+          return
+        }
         dispatch({
           type: 'fetch_failed',
           keeperName: activeSelected,

--- a/dashboard/src/components/oas-health-chip.test.ts
+++ b/dashboard/src/components/oas-health-chip.test.ts
@@ -48,36 +48,61 @@ describe('topKeepers', () => {
 })
 
 describe('describeAgentEvent', () => {
-  function evt(partial: Partial<OasAgentEvent> & { type: OasAgentEvent['type'] }): OasAgentEvent {
-    return {
-      agent_name: 'a',
-      timestamp: 0,
-      ...partial,
-    }
+  function evt(partial: OasAgentEvent): OasAgentEvent {
+    return partial
   }
 
   it('renders label + action', () => {
-    expect(describeAgentEvent(evt({ type: 'action_executed', action: 'ponder' }))).toBe('실행 · ponder')
+    expect(describeAgentEvent(evt({
+      type: 'action_executed',
+      actor_kind: 'agent',
+      agent_name: 'a',
+      timestamp: 0,
+      action: 'ponder',
+    }))).toBe('실행 · ponder')
   })
 
-  it('falls back to event when action absent', () => {
-    expect(describeAgentEvent(evt({ type: 'decision', event: 'shortlist' }))).toBe('결정 · shortlist')
+  it('falls back to trigger_reason when decision action is absent', () => {
+    expect(describeAgentEvent(evt({
+      type: 'decision',
+      actor_kind: 'agent',
+      agent_name: 'a',
+      timestamp: 0,
+      trigger_reason: 'shortlist',
+    }))).toBe('결정 · shortlist')
   })
 
   it('falls back to trigger when action and event absent', () => {
-    expect(describeAgentEvent(evt({ type: 'selected', trigger: 'heartbeat' }))).toBe('선택 · heartbeat')
+    expect(describeAgentEvent(evt({
+      type: 'selected',
+      actor_kind: 'agent',
+      agent_name: 'a',
+      timestamp: 0,
+      trigger: 'heartbeat',
+    }))).toBe('선택 · heartbeat')
   })
 
   it('includes secondary_agent arrow when present', () => {
     expect(describeAgentEvent(evt({
       type: 'trust_updated',
-      action: 'bump',
+      actor_kind: 'agent',
+      agent_name: 'a',
+      timestamp: 0,
+      trust_score: 0.75,
       secondary_agent: 'b',
-    }))).toBe('신뢰도 · bump → b')
+    }))).toBe('신뢰도 · 0.75 → b')
   })
 
-  it('omits action segment when all three fields missing', () => {
-    expect(describeAgentEvent(evt({ type: 'keeper_lifecycle' }))).toBe('생명주기')
+  it('prefers lifecycle event and phase when present', () => {
+    expect(describeAgentEvent(evt({
+      type: 'keeper_lifecycle',
+      actor_kind: 'keeper',
+      agent_name: 'keeper-a',
+      keeper_name: 'keeper-a',
+      timestamp: 0,
+      event: 'started',
+      phase: 'running',
+    }))).toBe('생명주기 · started')
   })
 
   it('maps all discriminants to Korean labels', () => {
@@ -90,7 +115,19 @@ describe('describeAgentEvent', () => {
       'reputation_changed',
     ]
     for (const t of types) {
-      const rendered = describeAgentEvent(evt({ type: t }))
+      const rendered = describeAgentEvent(
+        t === 'selected'
+          ? evt({ type: t, actor_kind: 'agent', agent_name: 'a', timestamp: 0 })
+          : t === 'decision'
+            ? evt({ type: t, actor_kind: 'agent', agent_name: 'a', timestamp: 0 })
+            : t === 'action_executed'
+              ? evt({ type: t, actor_kind: 'agent', agent_name: 'a', timestamp: 0 })
+              : t === 'keeper_lifecycle'
+                ? evt({ type: t, actor_kind: 'keeper', agent_name: 'a', timestamp: 0 })
+                : t === 'trust_updated'
+                  ? evt({ type: t, actor_kind: 'agent', agent_name: 'a', timestamp: 0 })
+                  : evt({ type: t, actor_kind: 'agent', agent_name: 'a', timestamp: 0 }),
+      )
       // Non-Latin label should be present (Korean)
       expect(rendered.length).toBeGreaterThan(0)
       expect(/^[a-zA-Z]+$/.test(rendered)).toBe(false)

--- a/dashboard/src/components/oas-health-chip.ts
+++ b/dashboard/src/components/oas-health-chip.ts
@@ -33,9 +33,29 @@ const EVENT_TYPE_LABELS: Record<OasAgentEvent['type'], string> = {
  *  Exposed for unit testing. */
 export function describeAgentEvent(evt: OasAgentEvent): string {
   const label = EVENT_TYPE_LABELS[evt.type]
-  const action = evt.action ?? evt.event ?? evt.trigger
-  const target = evt.secondary_agent ? ` → ${evt.secondary_agent}` : ''
-  return `${label}${action ? ` · ${action}` : ''}${target}`
+  switch (evt.type) {
+    case 'selected':
+      return `${label}${evt.trigger ? ` · ${evt.trigger}` : ''}`
+    case 'decision': {
+      const detail = evt.action ?? evt.trigger_reason
+      return `${label}${detail ? ` · ${detail}` : ''}`
+    }
+    case 'action_executed':
+      return `${label}${evt.action ? ` · ${evt.action}` : ''}`
+    case 'keeper_lifecycle': {
+      const detail = evt.event ?? evt.phase ?? evt.detail
+      return `${label}${detail ? ` · ${detail}` : ''}`
+    }
+    case 'trust_updated':
+      return `${label}${evt.trust_score != null ? ` · ${evt.trust_score.toFixed(2)}` : ''}${evt.secondary_agent ? ` → ${evt.secondary_agent}` : ''}`
+    case 'reputation_changed': {
+      const summary =
+        evt.old_score != null && evt.new_score != null
+          ? `${evt.old_score.toFixed(2)} → ${evt.new_score.toFixed(2)}`
+          : evt.trend
+      return `${label}${summary ? ` · ${summary}` : ''}`
+    }
+  }
 }
 
 /** Pick the N most recently updated keepers from a snapshot map.

--- a/dashboard/src/oas-runtime-store.test.ts
+++ b/dashboard/src/oas-runtime-store.test.ts
@@ -121,6 +121,35 @@ describe('oas-runtime-store', () => {
     expect(oasHealthSummary.value.agentEventsCount).toBe(1)
   })
 
+  it('hydrates keeper lifecycle phase from OAS payload', () => {
+    hydrateOasRuntimeFromTelemetryEntries([
+      {
+        source: 'oas_event',
+        type: 'oas:masc:keeper:lifecycle',
+        ts_unix: 210,
+        correlation_id: 'corr-life',
+        run_id: 'run-life',
+        payload: {
+          keeper_name: 'keeper-a',
+          event: 'started',
+          phase: 'running',
+          detail: 'supervised',
+          timestamp: 210,
+        },
+      } as TelemetryEntry,
+    ])
+
+    expect(oasHealthSummary.value.totalEvents).toBe(1)
+    expect(oasHealthSummary.value.agentEventsCount).toBe(1)
+    expect(oasAgentEvents.value[0]).toMatchObject({
+      type: 'keeper_lifecycle',
+      keeper_name: 'keeper-a',
+      phase: 'running',
+      event: 'started',
+      detail: 'supervised',
+    })
+  })
+
   it('dedupes timestamp-less events across replay/live time drift', () => {
     vi.useFakeTimers()
     try {

--- a/dashboard/src/oas-runtime-store.ts
+++ b/dashboard/src/oas-runtime-store.ts
@@ -10,7 +10,10 @@ import {
   resetOasRuntimeSignals,
   updateOasKeeperSnapshot,
 } from './store'
-import type { OasAgentEvent, OasKeeperSnapshot } from './types/oas'
+import type {
+  OasKeeperLifecycleEvent,
+  OasKeeperSnapshot,
+} from './types/oas'
 
 type OasRuntimeEnvelope = Record<string, unknown> & {
   type: string
@@ -109,7 +112,7 @@ function agentNameFromEnvelope(event: OasRuntimeEnvelope): string {
   )
 }
 
-function keeperLifecycleEvent(event: OasRuntimeEnvelope): OasAgentEvent {
+function keeperLifecycleEvent(event: OasRuntimeEnvelope): OasKeeperLifecycleEvent {
   const payload = eventPayload(event)
   const keeperName = asString(payload.keeper_name)
   const actorName = keeperName ?? asString(payload.agent_name) ?? ''
@@ -119,6 +122,7 @@ function keeperLifecycleEvent(event: OasRuntimeEnvelope): OasAgentEvent {
     actor_kind: 'keeper',
     keeper_name: keeperName,
     event: asString(payload.event),
+    phase: asString(payload.phase),
     detail: asString(payload.detail),
     event_type: runtimeEventType(event),
     correlation_id: asString(event.correlation_id),
@@ -220,7 +224,29 @@ function ingestRuntimeProjection(
       } satisfies OasKeeperSnapshot)
       return
     case 'oas:masc:keeper:lifecycle':
-      pushOasAgentEvent(keeperLifecycleEvent(event))
+      {
+        const lifecycle = keeperLifecycleEvent(event)
+        pushOasAgentEvent(lifecycle)
+        if (opts?.includeLiveTrace) {
+          const actorName = lifecycle.keeper_name ?? lifecycle.agent_name
+          const summaryParts = [
+            lifecycle.event,
+            lifecycle.phase,
+            lifecycle.detail,
+          ].filter(Boolean)
+          maybeAppendLiveTrace(actorName, event, {
+            idSuffix: summaryParts.join('|') || 'lifecycle',
+            kind: 'lifecycle',
+            summary: `keeper ${summaryParts.join(' · ') || 'lifecycle'}`,
+            data: {
+              keeper_name: lifecycle.keeper_name ?? null,
+              event: lifecycle.event ?? null,
+              phase: lifecycle.phase ?? null,
+              detail: lifecycle.detail ?? null,
+            },
+          })
+        }
+      }
       return
     case 'oas:masc:trust_updated':
       pushOasAgentEvent({

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -610,27 +610,6 @@ function handleEvent(event: SSEEvent): void {
       break
     }
     case 'oas:masc:keeper:lifecycle': {
-      const p = (event.payload ?? {}) as Record<string, unknown>
-      const keeperName = asString(p.keeper_name) ?? ''
-      const actorName = keeperName || asString(p.agent_name) || ''
-      const lifecycleEvent = (p.event as string) ?? undefined
-      const detail = (p.detail as string) ?? undefined
-      addTypedJournalEntry(
-        actorName,
-        `Keeper ${[lifecycleEvent, detail].filter(Boolean).join(' · ') || 'lifecycle'}`,
-        'oas',
-        'oas_event',
-        {
-          severity: event.severity,
-          source: event.source,
-          narrativeText:
-            `${actorLabel(actorName)} keeper lifecycle 이벤트`
-            + ([lifecycleEvent, detail].filter(Boolean).length > 0
-              ? ` (${[lifecycleEvent, detail].filter(Boolean).join(' · ')})`
-              : ''),
-          ...envelopeFromEvent(event),
-        },
-      )
       break
     }
     case 'oas:masc:trust_updated': {

--- a/dashboard/src/store.test.ts
+++ b/dashboard/src/store.test.ts
@@ -33,10 +33,11 @@ describe('oasHealthSummary', () => {
   it('reflects agent event buffer length', () => {
     const evt = {
       type: 'action_executed',
+      actor_kind: 'agent',
       agent_name: 'dreamer',
       timestamp: 1,
       action: 'ponder',
-    } as unknown as OasAgentEvent
+    } satisfies OasAgentEvent
     pushOasAgentEvent(evt)
     pushOasAgentEvent({ ...evt, timestamp: 2 })
     expect(oasHealthSummary.value.agentEventsCount).toBe(2)
@@ -46,11 +47,12 @@ describe('oasHealthSummary', () => {
   it('dedups identical consecutive agent events', () => {
     const evt = {
       type: 'action_executed',
+      actor_kind: 'agent',
       agent_name: 'dreamer',
       timestamp: 1,
       event_key: 'same-event',
       action: 'ponder',
-    } as unknown as OasAgentEvent
+    } satisfies OasAgentEvent
     pushOasAgentEvent(evt)
     pushOasAgentEvent(evt)
     expect(oasHealthSummary.value.agentEventsCount).toBe(1)
@@ -59,18 +61,21 @@ describe('oasHealthSummary', () => {
   it('keeps distinct events that only share actor and timestamp', () => {
     pushOasAgentEvent({
       type: 'action_executed',
+      actor_kind: 'agent',
       agent_name: 'dreamer',
       timestamp: 1,
       event_key: 'action',
       action: 'ponder',
-    } as unknown as OasAgentEvent)
+    } satisfies OasAgentEvent)
     pushOasAgentEvent({
-      type: 'action_executed',
+      type: 'keeper_lifecycle',
+      actor_kind: 'keeper',
       agent_name: 'dreamer',
       timestamp: 1,
       event_key: 'lifecycle',
+      phase: 'running',
       detail: 'started',
-    } as unknown as OasAgentEvent)
+    } satisfies OasAgentEvent)
     expect(oasHealthSummary.value.agentEventsCount).toBe(2)
   })
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -160,25 +160,64 @@ export function resetOasRuntimeSignals(): void {
   oasLastErrorTs.value = null
 }
 
+function sameOasAgentEvent(left: OasAgentEvent, right: OasAgentEvent): boolean {
+  if (left.event_key != null && right.event_key != null) {
+    return left.event_key === right.event_key
+  }
+  if (
+    left.type !== right.type
+    || left.agent_name !== right.agent_name
+    || left.timestamp !== right.timestamp
+  ) {
+    return false
+  }
+  switch (left.type) {
+    case 'selected':
+      return (
+        right.type === 'selected'
+        && left.trigger === right.trigger
+        && left.thompson_score === right.thompson_score
+        && left.final_score === right.final_score
+      )
+    case 'decision':
+      return (
+        right.type === 'decision'
+        && left.action === right.action
+        && left.trigger_reason === right.trigger_reason
+      )
+    case 'action_executed':
+      return (
+        right.type === 'action_executed'
+        && left.action === right.action
+        && left.success === right.success
+      )
+    case 'keeper_lifecycle':
+      return (
+        right.type === 'keeper_lifecycle'
+        && left.keeper_name === right.keeper_name
+        && left.event === right.event
+        && left.phase === right.phase
+        && left.detail === right.detail
+      )
+    case 'trust_updated':
+      return (
+        right.type === 'trust_updated'
+        && left.secondary_agent === right.secondary_agent
+        && left.trust_score === right.trust_score
+      )
+    case 'reputation_changed':
+      return (
+        right.type === 'reputation_changed'
+        && left.old_score === right.old_score
+        && left.new_score === right.new_score
+        && left.trend === right.trend
+      )
+  }
+}
+
 export function pushOasAgentEvent(event: OasAgentEvent): void {
   const head = oasAgentEvents.value[0]
-  const isDuplicate =
-    head != null
-    && (
-      (head.event_key != null && event.event_key != null && head.event_key === event.event_key)
-      || (
-        head.type === event.type
-        && head.agent_name === event.agent_name
-        && head.keeper_name === event.keeper_name
-        && head.secondary_agent === event.secondary_agent
-        && head.action === event.action
-        && head.event === event.event
-        && head.trigger === event.trigger
-        && head.detail === event.detail
-        && head.timestamp === event.timestamp
-      )
-    )
-  if (isDuplicate) {
+  if (head != null && sameOasAgentEvent(head, event)) {
     return
   }
   oasAgentEvents.value = [event, ...oasAgentEvents.value].slice(0, OAS_AGENT_EVENT_BUFFER)

--- a/dashboard/src/types/oas.ts
+++ b/dashboard/src/types/oas.ts
@@ -1,35 +1,69 @@
-// OAS (Open Agent SDK) Event types for dashboard monitoring
+// OAS (Open Agent SDK) event types for dashboard runtime monitoring.
+// Keep this slice as a discriminated union so each event kind has a stable
+// contract instead of one wide product type with many unrelated optionals.
 
-export interface OasAgentEvent {
-  type:
-    | 'selected'
-    | 'decision'
-    | 'action_executed'
-    | 'keeper_lifecycle'
-    | 'trust_updated'
-    | 'reputation_changed'
+interface OasAgentEventBase {
   agent_name: string
-  actor_kind?: 'agent' | 'keeper'
-  keeper_name?: string
-  secondary_agent?: string
-  action?: string
-  trigger?: string
-  trigger_reason?: string
-  event?: string
   event_type?: string
-  detail?: string
-  thompson_score?: number
-  final_score?: number
-  success?: boolean
-  trust_score?: number
-  old_score?: number
-  new_score?: number
-  trend?: string
   correlation_id?: string
   run_id?: string
   event_key?: string
   timestamp: number
 }
+
+export interface OasAgentSelectedEvent extends OasAgentEventBase {
+  type: 'selected'
+  actor_kind: 'agent'
+  trigger?: string
+  thompson_score?: number
+  final_score?: number
+}
+
+export interface OasAgentDecisionEvent extends OasAgentEventBase {
+  type: 'decision'
+  actor_kind: 'agent'
+  action?: string
+  trigger_reason?: string
+}
+
+export interface OasAgentActionExecutedEvent extends OasAgentEventBase {
+  type: 'action_executed'
+  actor_kind: 'agent'
+  action?: string
+  success?: boolean
+}
+
+export interface OasKeeperLifecycleEvent extends OasAgentEventBase {
+  type: 'keeper_lifecycle'
+  actor_kind: 'keeper'
+  keeper_name?: string
+  event?: string
+  phase?: string
+  detail?: string
+}
+
+export interface OasTrustUpdatedEvent extends OasAgentEventBase {
+  type: 'trust_updated'
+  actor_kind: 'agent'
+  secondary_agent?: string
+  trust_score?: number
+}
+
+export interface OasReputationChangedEvent extends OasAgentEventBase {
+  type: 'reputation_changed'
+  actor_kind: 'agent'
+  old_score?: number
+  new_score?: number
+  trend?: string
+}
+
+export type OasAgentEvent =
+  | OasAgentSelectedEvent
+  | OasAgentDecisionEvent
+  | OasAgentActionExecutedEvent
+  | OasKeeperLifecycleEvent
+  | OasTrustUpdatedEvent
+  | OasReputationChangedEvent
 
 export interface OasKeeperSnapshot {
   keeper_name: string

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -60,6 +60,8 @@ Experimental features such as TRPG live under `lab`.
 ## SSE Expectations
 - Treat SSE as freshness transport, not as the read model.
 - Use projection endpoints for hydration after events.
+- Dashboard observer sessions receive live `oas:*` tail in addition to durable replay; keeper lifecycle detail comes from `oas:masc:keeper:lifecycle`, while primary keeper state transitions remain `keeper_phase_changed`.
+- Full event inventory and timing notes live in `docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md`.
 - Minimum event classes the operator dashboard reacts to:
   - `broadcast`
   - `task_*`

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -180,7 +180,7 @@ Keepalive는 Eio fiber로 구현되어 주기적으로 실행된다.
 |----------|--------|------|
 | heartbeat interval | 30초 | durable keeper의 내부 heartbeat 주기. keeper별 설정값은 없다. |
 | jitter | base * 20% | 주기에 추가되는 랜덤 지연 |
-| snapshot_interval_sec | 60초 | JSONL 메트릭 스냅샷 간격 (환경변수 `MASC_KEEPER_SNAPSHOT_SEC`) |
+| snapshot_interval_sec | 300초 | JSONL 메트릭 스냅샷 간격 (환경변수 `MASC_KEEPER_SNAPSHOT_SEC`, runtime key `keeper.snapshot_sec`) |
 
 Heartbeat fiber가 수행하는 작업 (매 주기):
 1. Room에서 agent 존재 갱신

--- a/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
+++ b/docs/SYSTEM-EVENT-AND-SNAPSHOT-INVENTORY.md
@@ -1,0 +1,343 @@
+# System Event and Snapshot Inventory
+
+Validated against the current code on 2026-04-16.
+
+This document is the operator-facing SSOT for:
+
+- dashboard-visible system events
+- snapshot surfaces and their refresh timing
+- the actual trigger semantics of `keeper_composite_changed`
+- when `operator_digest` is computed versus when it is broadcast
+
+## Scope
+
+- Dashboard event type union: `dashboard/src/types/sse.ts`
+- Keeper composite signal path: `lib/keeper/keeper_registry.ml`
+- Keeper heartbeat snapshot path: `lib/keeper/keeper_keepalive.ml`
+- Server-push snapshot loops: `lib/server/server_dashboard_http_core.ml`, `lib/server/server_dashboard_http_execution_surfaces.ml`
+- OAS Event_bus bridge: `lib/oas_events.ml`, `lib/oas_sse_bridge.ml`
+
+## Read Model Rules
+
+- SSE is freshness transport, not the authoritative read model.
+- `keeper_composite_changed` is signal-only. Consumers re-fetch `/api/v1/keepers/:name/composite`.
+- `operator_snapshot` and `operator_digest` are cached server-push surfaces. Default HTTP reads usually return the cache.
+- OAS bridge events are replayable because `oas_sse_bridge` persists them under `.masc/oas-events/`.
+
+## Timing and Trigger Semantics
+
+| Surface / event | When it happens | Payload model | Notes |
+| --- | --- | --- | --- |
+| `keeper_composite_changed` | After every successful `Keeper_registry.dispatch_event*` application, including no-phase-change updates | Signal-only: `{name, ts_unix}` | Consumers must re-fetch the full composite payload. |
+| `keeper_heartbeat` | When a heartbeat snapshot is actually written | Lightweight SSE envelope | Not emitted on every keepalive cycle. |
+| `oas:masc:keeper:snapshot` | Same moment as `keeper_heartbeat` | OAS Event_bus custom event relayed to SSE | Durable via `.masc/oas-events/`. |
+| `operator_snapshot` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Default root/summary HTTP path returns cache. |
+| `operator_digest` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Default root HTTP path returns cache; non-default requests recompute. |
+| `execution_snapshot` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Used by execution dashboard surfaces. |
+| `transport_health_snapshot` | Background proactive refresh loop | Cached payload wrapped as `{type, payload, ts_unix}` | Used for transport diagnostics. |
+| `namespace_truth_snapshot` | After namespace-truth recomposition from cached surfaces | Cached payload wrapped as `{type, payload, ts_unix}` | `room_truth_snapshot` is the legacy alias. |
+| `room_truth_snapshot` | Emitted together with `namespace_truth_snapshot` | Same payload as namespace truth | Compatibility alias; not a distinct read model. |
+
+## `keeper_composite_changed`
+
+### What it really means
+
+- It means “a keeper registry state-machine event was applied; the composite view may have changed.”
+- It does not carry the composite snapshot itself.
+- It is emitted both when phase changes and when the event updates conditions without a phase change.
+
+### Exact producer
+
+- `Keeper_registry.dispatch_event_with_audit` emits `keeper_composite_changed` after the registry entry is updated.
+- This happens in both the phase-change branch and the no-phase-change success branch.
+
+### Important non-trigger cases
+
+The following direct registry mutation helpers update fields that the composite observer reads, but they do not emit `keeper_composite_changed` by themselves:
+
+- `mark_turn_started`
+- `mark_turn_measurement`
+- `set_turn_decision_stage`
+- `set_turn_cascade_state`
+- `set_turn_phase`
+- `set_turn_selected_model`
+- `mark_turn_finished`
+
+That means `keeper_composite_changed` is not a complete “all composite mutations” stream. It is specifically tied to successful `dispatch_event*` applications.
+
+## Keeper Heartbeat Snapshot Timing
+
+### Base timing
+
+- Keepalive loop base interval: `30s`
+- Keepalive jitter: `base * 20%`
+- Snapshot write interval: runtime param `keeper.snapshot_sec`
+- Current default `keeper.snapshot_sec`: `300s`
+
+### Actual behavior
+
+- The keepalive loop wakes roughly every `30s + jitter`.
+- Snapshot write is gated by `now_ts - last_snapshot_ts >= snapshot_interval_sec`.
+- Smart heartbeat may skip busy or idle cycles, so wall-clock distance between snapshots can exceed the base keepalive interval.
+- When a snapshot is written, three things happen together:
+  - JSONL metrics append
+  - `keeper_heartbeat` SSE broadcast
+  - `masc:keeper:snapshot` OAS custom event publish, later relayed as `oas:masc:keeper:snapshot`
+
+### Practical consequence
+
+If you are watching dashboard freshness:
+
+- `keeper_heartbeat` is a snapshot cadence signal, not a raw “loop tick” signal.
+- absence of `keeper_heartbeat` for under `300s` is not automatically suspicious
+- absence beyond the expected snapshot interval should be interpreted together with smart-heartbeat gating and lifecycle events
+
+## `operator_digest`
+
+### Background refresh path
+
+- Refresh interval source: `MASC_OPERATOR_REFRESH_INTERVAL_S`
+- Default interval: `60s`
+- Warm-cache delay on cold start: `150s`
+- Refresh loop uses `Proactive_refresh`
+
+### HTTP read path
+
+- Default namespace/root request returns `_operator_digest_cache`.
+- Non-default requests recompute immediately:
+  - non-root `target_type`
+  - `target_id`
+  - explicit `include_workers`
+  - explicit actor override
+
+### Broadcast path
+
+- Successful recompute stores the cache first, then calls the operator digest broadcast hook.
+- Broadcast is changed-only.
+- If the JSON payload hash matches the previous payload, SSE broadcast is skipped.
+
+### Practical consequence
+
+- “digest happened” and “`operator_digest` SSE arrived” are different events.
+- The digest may recompute without any outbound SSE if the payload is unchanged.
+- A default HTTP read may return a fresh-enough cached digest even if no recent SSE was emitted.
+
+## Termination Semantics
+
+### Graceful shutdown
+
+- Process-level graceful shutdown handles `SIGTERM` and `SIGINT`.
+- Structured shutdown phases are `Notify -> Drain -> Cleanup -> Exit`.
+- Cleanup closes SSE/WS sessions and flushes in-memory buffers.
+
+### Crash and force-kill
+
+- There is no dedicated `*_shutdown_snapshot` or `*_sigkill_snapshot` event.
+- Keeper crash state is recorded via lifecycle and crash persistence, not via a special shutdown snapshot.
+- Crash persistence uses an in-memory queue drained every `2s`.
+- A hard `SIGKILL` can bypass cleanup and can lose queued-but-not-yet-flushed crash records.
+
+### Operator interpretation
+
+- Graceful stop should show lifecycle transitions and normal cleanup.
+- Abrupt termination should be diagnosed from:
+  - `oas:masc:keeper:lifecycle` / crash detail
+  - registry crash state
+  - `crash-events/` durable records
+  - missing follow-up snapshot traffic
+
+## Event Inventory by Family
+
+### 1. Dashboard typed SSE union
+
+Source of accepted event names on the dashboard side: `dashboard/src/types/sse.ts`.
+
+| Family | Event names |
+| --- | --- |
+| Coordination / room | `agent_joined`, `agent_left`, `broadcast`, `task_update` |
+| Board and notification compatibility | `board_post`, `masc/board_post`, `board_comment`, `masc/board_comment`, `board_delete`, `masc/board_delete`, `post_created`, `comment_added`, `post_voted`, `comment_voted` |
+| Keeper direct SSE | `keeper_heartbeat`, `keeper_handoff`, `masc/keeper_handoff`, `keeper_compaction`, `masc/keeper_compaction`, `keeper_guardrail`, `masc/keeper_guardrail`, `keeper_phase_changed`, `keeper_composite_changed`, `keeper_tool_call`, `masc/keeper_tool_call`, `keeper_tool_skipped`, `keeper_turn_complete`, `masc/keeper_turn_complete` |
+| Approval / governance | `client_input_approved`, `client_input_rejected`, `client_input_updated`, `governance_param_changed`, `approval:pending`, `approval:resolved` |
+| OAS bridge | `oas:masc:autonomy:agent_selected`, `oas:masc:autonomy:agent_decision`, `oas:masc:autonomy:agent_action_executed`, `oas:masc:keeper:snapshot`, `oas:masc:keeper:lifecycle`, `oas:masc:trust_updated`, `oas:masc:reputation_changed`, `oas:agent_started`, `oas:agent_completed`, `oas:tool_called`, `oas:tool_completed`, `oas:turn_started`, `oas:turn_completed`, `oas:context_compacted`, `oas:task_state_changed`, `oas:masc:harness:verdict_recorded`, `oas:masc:harness:pre_compact`, `oas:masc:harness:handoff` |
+| Server-push snapshots | `room_truth_snapshot`, `namespace_truth_snapshot`, `execution_snapshot`, `operator_snapshot`, `operator_digest`, `transport_health_snapshot` |
+
+### 2. OAS custom events published by MASC
+
+These originate in `lib/oas_events.ml` and are later relayed by `oas_sse_bridge`.
+
+| Event name | Meaning |
+| --- | --- |
+| `masc:broadcast` | room broadcast observed via Event_bus |
+| `masc:heartbeat` | generic heartbeat event |
+| `masc:board_post` | board post created |
+| `masc:task_transition` | task state transition |
+| `masc:heartbeat_recovered` | agent recovered from timeout |
+| `masc:autonomy:agent_selected` | autonomy selector chose an agent |
+| `masc:autonomy:agent_decision` | autonomy decision chosen |
+| `masc:autonomy:agent_action_executed` | autonomy action executed |
+| `masc:keeper:snapshot` | keeper heartbeat snapshot |
+| `masc:keeper:lifecycle` | keeper lifecycle update |
+| `masc:trust_updated` | trust score changed |
+| `masc:reputation_changed` | reputation changed |
+| `masc:institution_episode` | institution episode recorded |
+| `masc:harness:verdict_recorded` | harness verdict persisted |
+| `masc:harness:pre_compact` | pre-compaction observation |
+| `masc:harness:handoff` | harness handoff observation |
+
+### 3. Legacy / compatibility cases
+
+| Event name | Status | Notes |
+| --- | --- | --- |
+| `keeper_lifecycle` | removed legacy direct SSE | Replaced by `keeper_phase_changed` for observer-facing FSM transitions and `oas:masc:keeper:lifecycle` for lifecycle detail. |
+| `room_truth_snapshot` | compatibility alias | Emitted together with `namespace_truth_snapshot`; same payload, different name. |
+
+## Representative Messages
+
+These examples are shaped directly from the current producers.
+
+### 1. Direct SSE: `keeper_composite_changed`
+
+```json
+{
+  "type": "keeper_composite_changed",
+  "name": "keeper-a",
+  "ts_unix": 1710000000.123
+}
+```
+
+Meaning:
+
+- signal-only tick
+- downstream must fetch `/api/v1/keepers/keeper-a/composite`
+
+### 2. Direct SSE: `keeper_heartbeat`
+
+```json
+{
+  "type": "keeper_heartbeat",
+  "name": "keeper-a",
+  "generation": 3,
+  "context_ratio": 0.42,
+  "ts_unix": 1710000000.123
+}
+```
+
+Meaning:
+
+- emitted only when heartbeat snapshot write actually happened
+- lightweight envelope, not the full heartbeat snapshot JSONL row
+
+### 3. OAS custom event publish: `masc:keeper:snapshot`
+
+This is the payload published to the shared Event_bus before the SSE bridge wraps it.
+
+```json
+{
+  "keeper_name": "keeper-a",
+  "generation": 3,
+  "context_ratio": 0.42,
+  "message_count": 128,
+  "timestamp": 1710000000.123
+}
+```
+
+### 4. OAS-relayed SSE: `oas:masc:keeper:snapshot`
+
+```json
+{
+  "type": "oas:masc:keeper:snapshot",
+  "event_type": "masc:keeper:snapshot",
+  "ts_unix": 1710000000.123,
+  "correlation_id": "corr-...",
+  "run_id": "run-...",
+  "agent_name": null,
+  "task_id": null,
+  "turn": null,
+  "tool_name": null,
+  "payload": {
+    "keeper_name": "keeper-a",
+    "generation": 3,
+    "context_ratio": 0.42,
+    "message_count": 128,
+    "timestamp": 1710000000.123
+  }
+}
+```
+
+### 5. Server-push snapshot: `operator_digest`
+
+```json
+{
+  "type": "operator_digest",
+  "payload": {
+    "health": "ok",
+    "generated_at": "2026-04-16T12:34:56Z"
+  },
+  "ts_unix": 1710000000.123
+}
+```
+
+Meaning:
+
+- server cache projection
+- changed-only SSE fanout
+- payload body is large and surface-specific; example above is intentionally minimal
+
+### 6. OAS-relayed SSE: `oas:masc:keeper:lifecycle`
+
+```json
+{
+  "type": "oas:masc:keeper:lifecycle",
+  "event_type": "masc:keeper:lifecycle",
+  "ts_unix": 1710000000.123,
+  "correlation_id": "corr-...",
+  "run_id": "run-...",
+  "payload": {
+    "keeper_name": "keeper-a",
+    "event": "started",
+    "phase": "running",
+    "detail": "supervised",
+    "timestamp": 1710000000.123
+  }
+}
+```
+
+Meaning:
+
+- observer and coordinator sessions both receive the live OAS tail
+- lifecycle detail now carries `phase`, so the payload can replace the removed legacy direct SSE
+- dashboard runtime state ingests this as OAS telemetry, while main keeper transition journaling still comes from `keeper_phase_changed`
+
+## Variantization Status
+
+## What is already typed
+
+- Dashboard-side SSE names are modeled as a TypeScript string union in `dashboard/src/types/sse.ts`.
+- Dashboard OAS monitor types are separately modeled in `dashboard/src/types/oas.ts`.
+- Composite observer internals are variantized:
+  - TLA action names mirrored as OCaml variants
+  - invariant keys mirrored as OCaml variants
+  - composite snapshot schema validated on the dashboard side
+
+## What is still stringly typed
+
+- Direct SSE producers emit raw JSON objects with string `"type"` fields.
+- OAS custom events are published as `Agent_sdk.Event_bus.Custom (name, payload)`, where `name` is still a free string.
+- The bridge preserves that string name as `event_type` and prefixes it into `type = "oas:" ^ event_type`.
+
+## Practical conclusion
+
+- This is partially variantized, not end-to-end variantized.
+- Domain contracts inside the composite observer are strongly typed.
+- Dashboard OAS monitor events are now modeled as a discriminated union rather than a wide product type.
+- Transport event names themselves are still mostly string-labeled protocols.
+
+## Source Pointers
+
+- Dashboard event union: `dashboard/src/types/sse.ts`
+- Composite signal router: `dashboard/src/sse-store.ts`, `dashboard/src/composite-signals.ts`
+- Composite producer: `lib/keeper/keeper_registry.ml`
+- Heartbeat snapshot writer: `lib/keeper/keeper_keepalive.ml`
+- OAS custom event publishers: `lib/oas_events.ml`
+- OAS bridge + durable replay: `lib/oas_sse_bridge.ml`
+- Server-push snapshot loops: `lib/server/server_dashboard_http_core.ml`, `lib/server/server_dashboard_http_execution_surfaces.ml`, `lib/server/server_dashboard_http_namespace_truth.ml`

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1874,22 +1874,26 @@ let bootstrap_live_keeper_meta ~(ctx : _ context) (m : keeper_meta) : keeper_met
     m
 ;;
 
-let publish_keeper_lifecycle ~event ~keeper_name ~detail : unit =
+let publish_keeper_lifecycle ?phase ~event ~keeper_name ~detail () : unit =
   match get_bus () with
   | Some bus ->
     Oas_events.publish_keeper_lifecycle
       bus
+      ?phase
       ~event
       ~keeper_name
       ~detail
+      ()
   | None -> ()
 ;;
 
 let publish_keeper_started ~(live_meta : keeper_meta) : unit =
   publish_keeper_lifecycle
+    ~phase:Keeper_state_machine.Running
     ~event:"started"
     ~keeper_name:live_meta.name
     ~detail:"keepalive"
+    ()
 ;;
 
 let dispatch_fiber_started ~base_path keeper_name =
@@ -1928,7 +1932,8 @@ let record_keeper_stopped
       Keeper_state_machine.Stop_requested);
     ignore (Keeper_registry.dispatch_event ~base_path keeper_name
       Keeper_state_machine.Drain_complete);
-    publish_keeper_lifecycle ~event:"stopped" ~keeper_name ~detail;
+    publish_keeper_lifecycle ~phase:Keeper_state_machine.Stopped
+      ~event:"stopped" ~keeper_name ~detail ();
     true)
   else
     false
@@ -1949,7 +1954,8 @@ let record_keeper_crashed
       (Keeper_state_machine.Fiber_terminated { outcome = reason }));
     Keeper_registry.record_crash ~base_path keeper_name (Time_compat.now ()) reason;
     Keeper_registry.record_error ~base_path keeper_name reason;
-    publish_keeper_lifecycle ~event:"crashed" ~keeper_name ~detail:reason)
+    publish_keeper_lifecycle ~phase:Keeper_state_machine.Crashed
+      ~event:"crashed" ~keeper_name ~detail:reason ())
 ;;
 
 let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_meta) : unit
@@ -1973,10 +1979,10 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
      | None -> ());
     let live_meta = bootstrap_live_keeper_meta ~ctx m in
     Keeper_registry.update_meta ~base_path:ctx.config.base_path m.name live_meta;
-    publish_keeper_started ~live_meta;
     (* Telemetry feedback refresh loop removed in #6814:
        behavioral_stats no longer consumed by build_prompt. *)
     dispatch_fiber_started ~base_path:ctx.config.base_path live_meta.name;
+    publish_keeper_started ~live_meta;
     Eio.Fiber.fork ~sw:ctx.sw (fun () ->
       let record_crash failure_reason =
         record_keeper_crashed

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -812,19 +812,8 @@ let execute_entry_action_observability
         (Keeper_state_machine.phase_to_string phase)
         event_name
         detail;
-      (try
-         Sse.broadcast
-           (`Assoc [
-              "type", `String "keeper_lifecycle";
-              "name", `String name;
-              "phase", `String (Keeper_state_machine.phase_to_string phase);
-              "event", `String event_name;
-              "detail", `String detail;
-              "ts_unix", `Float ts_unix;
-            ])
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | _exn -> ())
+      let (_ignore_ts : float) = ts_unix in
+      ()
   | Start_compaction
   | Start_handoff
   | Start_drain

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -46,11 +46,11 @@ let is_stale_paused_meta ~now ~paused_ttl_sec (meta : keeper_meta) =
 
 (* ── Event publishing ────────────────────────────────────── *)
 
-let publish_lifecycle event_name keeper_name detail =
+let publish_lifecycle ?phase event_name keeper_name detail () =
   match Keeper_keepalive.get_bus () with
   | Some bus ->
       Oas_events.publish_keeper_lifecycle bus ~event:event_name
-        ~keeper_name ~detail
+        ?phase ~keeper_name ~detail ()
   | None -> ()
 
 (* ── Supervised fiber launch ─────────────────────────────── *)
@@ -89,7 +89,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
            ignore (Keeper_registry.dispatch_event ~base_path meta.name
              Keeper_state_machine.Drain_complete);
            if resolve_done `Stopped then
-             publish_lifecycle "stopped" meta.name "normal exit"
+             publish_lifecycle ~phase:Keeper_state_machine.Stopped
+               "stopped" meta.name "normal exit" ()
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn ->
@@ -121,7 +122,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
                ~name:meta.name ~ts ~reason ~restart_count:rc;
              Keeper_registry.record_error ~base_path meta.name reason;
              if resolve_done (`Crashed reason) then
-               publish_lifecycle "crashed" meta.name reason))
+               publish_lifecycle ~phase:Keeper_state_machine.Crashed
+                 "crashed" meta.name reason ()))
       ~finally:(fun () ->
         Keeper_registry.cleanup_tracking ~base_path meta.name;
         if not !resolved then begin
@@ -147,7 +149,8 @@ let launch_supervised_fiber ~proactive_warmup_sec ctx (meta : keeper_meta)
             ignore (Keeper_registry.dispatch_event ~base_path meta.name
               (Keeper_state_machine.Fiber_terminated { outcome = reason }));
             if resolve_done (`Crashed reason) then
-              publish_lifecycle "crashed" meta.name reason
+              publish_lifecycle ~phase:Keeper_state_machine.Crashed
+                "crashed" meta.name reason ()
           end
         end))
 
@@ -180,8 +183,9 @@ let supervise_keepalive ~proactive_warmup_sec (ctx : _ context)
     in
     Keeper_registry.update_meta ~base_path:ctx.config.base_path meta.name
       live_meta;
-    publish_lifecycle "started" meta.name "supervised";
-    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg
+    launch_supervised_fiber ~proactive_warmup_sec ctx live_meta reg;
+    publish_lifecycle ~phase:Keeper_state_machine.Running
+      "started" meta.name "supervised" ()
   end
 
 (* ── Sweep and recover ───────────────────────────────────── *)
@@ -219,7 +223,8 @@ let reconcile_keepalive_keepers (ctx : _ context) =
              if not dominated_by_sweep then begin
                supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
                if Keeper_registry.is_running ~base_path meta.name then begin
-                 publish_lifecycle "reconciled" meta.name "durable keeper";
+                 publish_lifecycle ~phase:Keeper_state_machine.Running
+                   "reconciled" meta.name "durable keeper" ();
                  Log.Keeper.info "%s: reconciled durable keeper" meta.name
                end
              end
@@ -248,20 +253,21 @@ let cleanup_dead_tombstone (ctx : _ context)
       in
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
       if persisted_paused then begin
-        publish_lifecycle "dead_cleaned" entry.name "paused meta persisted";
+        publish_lifecycle "dead_cleaned" entry.name "paused meta persisted" ();
         Log.Keeper.info "%s: dead tombstone cleaned up" entry.name
       end else begin
-        publish_lifecycle "dead_cleaned" entry.name "meta write failed, unregistered anyway";
+        publish_lifecycle "dead_cleaned" entry.name
+          "meta write failed, unregistered anyway" ();
         Log.Keeper.warn "%s: dead tombstone unregistered despite meta write failure" entry.name
       end
   | Ok None ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
-      publish_lifecycle "dead_cleaned" entry.name "meta missing";
+      publish_lifecycle "dead_cleaned" entry.name "meta missing" ();
       Log.Keeper.warn "%s: dead tombstone unregistered (meta missing)" entry.name
   | Error err ->
       Keeper_registry.unregister ~base_path:ctx.config.base_path entry.name;
       publish_lifecycle "dead_cleaned" entry.name
-        (Printf.sprintf "meta read error: %s" err);
+        (Printf.sprintf "meta read error: %s" err) ();
       Log.Keeper.warn "%s: dead tombstone unregistered (meta error: %s)"
         entry.name err
 
@@ -304,7 +310,7 @@ let apply_self_preservation ~keepers_dir ~total_keepers to_restart =
         (List.length dominant_entries) n_total ratio dominant_key;
       publish_lifecycle "self_preservation" "supervisor"
         (Printf.sprintf "%d/%d suppressed, cohort=%s"
-           (List.length dominant_entries) n_total dominant_key);
+           (List.length dominant_entries) n_total dominant_key) ();
       Keeper_crash_persistence.enqueue_sp_event
         ~keepers_dir
         ~ts:(Time_compat.now ())
@@ -374,9 +380,9 @@ let sweep_and_recover (ctx : _ context) =
     ignore (Keeper_registry.dispatch_event ~base_path entry.name
       Keeper_state_machine.Restart_budget_exhausted);
     Keeper_registry.mark_dead ~base_path entry.name ~at:now;
-    publish_lifecycle "dead" entry.name
+    publish_lifecycle ~phase:Keeper_state_machine.Dead "dead" entry.name
       (Printf.sprintf "restart budget exhausted (%d), last: %s"
-         max_restarts msg);
+         max_restarts msg) ();
     Log.Keeper.error "%s: restart budget exhausted (%d). Dead."
       entry.name max_restarts
   ) !to_mark_dead;
@@ -405,8 +411,9 @@ let sweep_and_recover (ctx : _ context) =
           ~restart_count:attempt ~last_restart_ts:now
           ~crash_log:(keep_last_n 5 (now, crash_msg) old_crash_log);
         launch_supervised_fiber ~proactive_warmup_sec:0 ctx meta reg;
-        publish_lifecycle "restarted" old_entry.name
-          (Printf.sprintf "attempt %d" attempt);
+        publish_lifecycle ~phase:Keeper_state_machine.Running
+          "restarted" old_entry.name
+          (Printf.sprintf "attempt %d" attempt) ();
         Log.Keeper.info "%s: restarted (attempt %d, backoff %.0fs)"
           old_entry.name attempt (backoff_delay (attempt - 1))
     | _ ->
@@ -426,7 +433,7 @@ let sweep_and_recover (ctx : _ context) =
                (try
                   Sys.remove path;
                   publish_lifecycle "paused_pruned" name
-                    (Printf.sprintf "last_updated=%s" meta.updated_at);
+                    (Printf.sprintf "last_updated=%s" meta.updated_at) ();
                   Log.Keeper.info "%s: stale paused meta pruned" name
                 with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                   Log.Keeper.warn "%s: paused meta prune failed: %s"

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -117,11 +117,18 @@ let publish_keeper_snapshot (bus : Agent_sdk.Event_bus.t) ~keeper_name
 
 (** Publish a keeper keepalive lifecycle event.
     Event names: "started", "stopped", "crashed", "restarted", "dead". *)
-let publish_keeper_lifecycle (bus : Agent_sdk.Event_bus.t) ~event ~keeper_name
-    ~detail =
+let publish_keeper_lifecycle (bus : Agent_sdk.Event_bus.t) ?phase ~event
+    ~keeper_name ~detail () =
+  let phase_json =
+    match phase with
+    | Some phase ->
+      `String (Keeper_state_machine.phase_to_string phase)
+    | None -> `Null
+  in
   let payload = `Assoc [
     ("event", `String event);
     ("keeper_name", `String keeper_name);
+    ("phase", phase_json);
     ("detail", `String detail);
     ("timestamp", `Float (Time_compat.now ()));
   ] in

--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -262,7 +262,7 @@ let relay_event ?store evt =
                 Log.Misc.warn "oas_sse_bridge: durable append failed: %s"
                   (Printexc.to_string exn))
        | None -> ());
-      (try Sse.broadcast_to Coordinators j
+      (try Sse.broadcast_to All j
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->

--- a/test/test_keeper_registry.ml
+++ b/test/test_keeper_registry.ml
@@ -41,13 +41,13 @@ let sse_payload_json (event : string) : Yojson.Safe.t =
   in
   find_data_line (String.split_on_char '\n' event)
 
-let keeper_lifecycle_events received_events =
+let sse_events_of_type event_type received_events =
   received_events
   |> List.rev
   |> List.filter_map (fun raw_event ->
          let payload = sse_payload_json raw_event in
          match Json.member "type" payload |> Json.to_string_option with
-         | Some "keeper_lifecycle" -> Some payload
+         | Some kind when kind = event_type -> Some payload
          | _ -> None)
 
 (* ── Basic registry operations ─────────────────────────── *)
@@ -219,30 +219,30 @@ let test_set_state () =
   | None -> fail "expected k4"
   | Some e -> check string "state" "paused" (KSM.phase_to_string e.phase)
 
-let test_dispatch_event_emits_lifecycle_sse () =
+let test_dispatch_event_emits_phase_sse () =
   R.clear ();
   let received_events = ref [] in
-  Masc_mcp.Sse.subscribe_external ~id:"keeper-registry-lifecycle"
+  Masc_mcp.Sse.subscribe_external ~id:"keeper-registry-phase"
     ~callback:(fun event -> received_events := event :: !received_events) ();
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Sse.unsubscribe_external "keeper-registry-lifecycle")
+      Masc_mcp.Sse.unsubscribe_external "keeper-registry-phase")
     (fun () ->
       ignore (R.register ~base_path:bp "k4-lifecycle" (make_meta "k4-lifecycle"));
       ignore (R.dispatch_event ~base_path:bp "k4-lifecycle" KSM.Operator_pause);
-      match keeper_lifecycle_events !received_events with
-      | [] -> fail "expected keeper_lifecycle SSE event"
+      match sse_events_of_type "keeper_phase_changed" !received_events with
+      | [] -> fail "expected keeper_phase_changed SSE event"
       | payload :: _ ->
-          check string "lifecycle type" "keeper_lifecycle"
+          check string "phase type" "keeper_phase_changed"
             (Json.member "type" payload |> Json.to_string);
           check string "keeper name" "k4-lifecycle"
             (Json.member "name" payload |> Json.to_string);
-          check string "phase" "paused"
-            (Json.member "phase" payload |> Json.to_string);
-          check string "event" "paused"
-            (Json.member "event" payload |> Json.to_string);
-          check string "detail" "operator request"
-            (Json.member "detail" payload |> Json.to_string))
+          check string "prev phase" "running"
+            (Json.member "prev_phase" payload |> Json.to_string);
+          check string "new phase" "paused"
+            (Json.member "new_phase" payload |> Json.to_string);
+          check string "event" "operator_pause"
+            (Json.member "event" payload |> Json.to_string))
 
 let test_extended_states () =
   R.clear ();
@@ -277,15 +277,15 @@ let test_stopped_entry_action_is_observability_only () =
           check string "stopped phase" "stopped"
             (KSM.phase_to_string entry.phase);
           let stopped_payload =
-            keeper_lifecycle_events !received_events
+            sse_events_of_type "keeper_phase_changed" !received_events
             |> List.find_opt (fun payload ->
-                   Json.member "event" payload |> Json.to_string = "stopped")
+                   Json.member "new_phase" payload |> Json.to_string = "stopped")
           in
           (match stopped_payload with
-           | None -> fail "expected stopped lifecycle SSE event"
+           | None -> fail "expected stopped phase SSE event"
            | Some payload ->
-               check string "stopped detail" "drain_complete"
-                 (Json.member "detail" payload |> Json.to_string)))
+               check string "stop event" "drain_complete"
+                 (Json.member "event" payload |> Json.to_string)))
 
 let test_count_running () =
   R.clear ();
@@ -693,8 +693,8 @@ let () =
           eio_test "all" test_all;
           eio_test "update meta" test_update_meta;
           eio_test "set state" test_set_state;
-          eio_test "dispatch event emits lifecycle SSE"
-            test_dispatch_event_emits_lifecycle_sse;
+          eio_test "dispatch event emits phase SSE"
+            test_dispatch_event_emits_phase_sse;
           eio_test "extended states" test_extended_states;
           eio_test "stopped entry action is observability-only"
             test_stopped_entry_action_is_observability_only;

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -83,6 +83,27 @@ let test_event_bus_task_transition () =
     Alcotest.(check string) "task id" "task-1" tid
   | _ -> Alcotest.fail "expected Custom masc:task_transition event"
 
+let test_event_bus_keeper_lifecycle_includes_phase () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let bus = Event_bus.create () in
+  let sub = Event_bus.subscribe bus in
+  Oas_events.publish_keeper_lifecycle bus
+    ~event:"started"
+    ~keeper_name:"keeper-a"
+    ~phase:Masc_mcp.Keeper_state_machine.Running
+    ~detail:"supervised"
+    ();
+  let events = Event_bus.drain sub in
+  Alcotest.(check int) "one event" 1 (List.length events);
+  match (List.hd events : Event_bus.event).payload with
+  | Event_bus.Custom ("masc:keeper:lifecycle", payload) ->
+    let phase = Yojson.Safe.Util.(member "phase" payload |> to_string) in
+    let event = Yojson.Safe.Util.(member "event" payload |> to_string) in
+    Alcotest.(check string) "phase" "running" phase;
+    Alcotest.(check string) "event" "started" event
+  | _ -> Alcotest.fail "expected Custom masc:keeper:lifecycle event"
+
 let test_oas_sse_bridge_persists_native_events () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -129,6 +150,41 @@ let test_oas_sse_bridge_persists_native_events () =
                Alcotest.(check string) "run id" "run-bridge"
                  (field_string "run_id")
            | _ -> Alcotest.fail "expected persisted oas event object");
+          raise Exit)
+      with Exit -> ())
+
+let test_oas_sse_bridge_broadcasts_lifecycle_to_observers () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir "oas_sse_bridge_observer" in
+  Fun.protect
+    ~finally:(fun () ->
+      ignore (Masc_mcp.Sse.close_all_clients ());
+      cleanup_dir dir)
+    (fun () ->
+      let config = Coord.default_config dir in
+      let bus = Event_bus.create () in
+      Masc_mcp.Sse.set_clock (Eio.Stdenv.clock env);
+      try
+        Eio.Switch.run (fun sw ->
+          ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Observer
+                    "observer-lifecycle" ~push:(fun _ -> ()) ~last_event_id:0);
+          ignore (Masc_mcp.Sse.register ~kind:Masc_mcp.Sse.Coordinator
+                    "coordinator-lifecycle" ~push:(fun _ -> ()) ~last_event_id:0);
+          Oas_sse_bridge.start ~sw ~clock:(Eio.Stdenv.clock env) ~config ~bus;
+          Oas_events.publish_keeper_lifecycle bus
+            ~event:"started"
+            ~keeper_name:"keeper-a"
+            ~phase:Masc_mcp.Keeper_state_machine.Running
+            ~detail:"supervised"
+            ();
+          Eio.Time.sleep (Eio.Stdenv.clock env) 2.2;
+          let observer_event = Masc_mcp.Sse.try_pop "observer-lifecycle" in
+          let coordinator_event = Masc_mcp.Sse.try_pop "coordinator-lifecycle" in
+          Alcotest.(check bool) "observer got oas lifecycle" true
+            (observer_event <> None);
+          Alcotest.(check bool) "coordinator got oas lifecycle" true
+            (coordinator_event <> None);
           raise Exit)
       with Exit -> ())
 
@@ -453,8 +509,12 @@ let () =
       Alcotest.test_case "heartbeat event" `Quick test_event_bus_heartbeat;
       Alcotest.test_case "task transition event" `Quick
         test_event_bus_task_transition;
+      Alcotest.test_case "keeper lifecycle includes phase" `Quick
+        test_event_bus_keeper_lifecycle_includes_phase;
       Alcotest.test_case "sse bridge persists native events" `Quick
         test_oas_sse_bridge_persists_native_events;
+      Alcotest.test_case "sse bridge sends lifecycle to observers" `Quick
+        test_oas_sse_bridge_broadcasts_lifecycle_to_observers;
       Alcotest.test_case "agent_completed includes usage" `Quick
         test_agent_completed_includes_usage;
       Alcotest.test_case "agent_completed no usage on error" `Quick


### PR DESCRIPTION
## Summary
- stop using stale gate keeper fallback after execution data has loaded in FSM Hub
- treat composite 404 as a disappeared/unregistered keeper and clear the stale selection instead of leaving the dashboard stuck
- add integration coverage for fallback gating and composite 404 recognition

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty` in `dashboard/`
- `./node_modules/.bin/vitest run --no-file-parallelism --maxWorkers=1 src/components/fsm-hub.integration.test.ts src/store.test.ts src/oas-runtime-store.test.ts src/components/oas-health-chip.test.ts` in `dashboard/`
- `git diff --check`

## Why
`/api/v1/keepers/:name/composite` only works for keepers still present in the registry. FSM Hub could keep showing a stale keeper name from the gate fallback even after execution data had loaded, which made the dashboard repeatedly hit composite 404 and look broken.