### PR TITLE
feat(cdal): route review requirements through verification fsm

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -194,6 +194,8 @@ export function actionTypeLabel(value?: string | null): string {
 
 export function targetTypeLabel(value?: string | null): string {
   switch (value) {
+    case 'task':
+      return '작업'
     case 'namespace':
       return '프로젝트 범위'
     case 'room':

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -186,6 +186,51 @@ describe('buildTraceEvents', () => {
     const kinds = events.map(e => e.kind).sort()
     expect(kinds).toEqual(['broadcast', 'tool_call'])
   })
+
+  it('maps keeper contract verdict activity into lifecycle trace events', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [{
+          type: 'keeper.contract_verdict',
+          ts: '2024-04-06T10:00:00Z',
+          detail: {
+            status: 'inconclusive',
+            blocking_gap_artifacts: ['evidence/review_warning.json'],
+          },
+        }],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 1 },
+      },
+      null,
+    )
+    expect(events).toHaveLength(1)
+    expect(events[0]!.kind).toBe('lifecycle')
+    expect(events[0]!.summary).toContain('CDAL inconclusive')
+    expect(events[0]!.summary).toContain('review_warning.json')
+  })
+
+  it('maps keeper friction review tripwires into lifecycle trace events', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [{
+          type: 'keeper.friction',
+          ts: '2024-04-06T10:00:00Z',
+          detail: {
+            review_tripwires: ['review_requirement:submit_for_verification'],
+            evidence_gap_artifacts: ['evidence/review_warning.json'],
+          },
+        }],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 1 },
+      },
+      null,
+    )
+    expect(events).toHaveLength(1)
+    expect(events[0]!.kind).toBe('lifecycle')
+    expect(events[0]!.summary).toContain('submit_for_verification')
+  })
 })
 
 describe('getTraceSummary', () => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -265,6 +265,13 @@ function mergeTraceEvents(
   })
 }
 
+function stringArrayField(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map(item => (typeof item === 'string' ? item.trim() : ''))
+    .filter(Boolean)
+}
+
 function timelineEventToTrace(evt: AgentTimelineEvent, index: number): UnifiedTraceEvent {
   const ts = safeTimestamp(evt.ts)
   const detail = evt.detail ?? {}
@@ -302,6 +309,42 @@ function timelineEventToTrace(evt: AgentTimelineEvent, index: number): UnifiedTr
       sourceLane: 'masc',
       summary: evt.type,
       detail,
+    }
+  }
+
+  if (evt.type === 'keeper.contract_verdict') {
+    const status = typeof detail.status === 'string' ? detail.status : 'unknown'
+    const blockingGaps = stringArrayField(detail.blocking_gap_artifacts)
+    const summary = blockingGaps.length > 0
+      ? `CDAL ${status} · gaps ${blockingGaps.join(', ')}`
+      : `CDAL ${status}`
+    return {
+      id: `tl-${ts}-${evt.type}-${index}`,
+      ts,
+      ts_iso: evt.ts ?? new Date(ts).toISOString(),
+      kind: 'lifecycle',
+      sourceLane: 'masc',
+      summary,
+      detail: { ...detail, type: evt.type },
+    }
+  }
+
+  if (evt.type === 'keeper.friction') {
+    const tripwires = stringArrayField(detail.review_tripwires)
+    const gaps = stringArrayField(detail.evidence_gap_artifacts)
+    const summary = tripwires.length > 0
+      ? `CDAL friction · ${tripwires.join(', ')}`
+      : gaps.length > 0
+        ? `CDAL friction · gaps ${gaps.join(', ')}`
+        : 'CDAL friction'
+    return {
+      id: `tl-${ts}-${evt.type}-${index}`,
+      ts,
+      ts_iso: evt.ts ?? new Date(ts).toISOString(),
+      kind: 'lifecycle',
+      sourceLane: 'masc',
+      summary,
+      detail: { ...detail, type: evt.type },
     }
   }
 

--- a/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
+++ b/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
@@ -131,7 +131,7 @@ Unavailable means `None`, not inference.
 ## 9. Suggested Implementation Order
 
 1. build ref resolution and manifest/contract loading behind a small reader adapter
-2. implement per-check result evaluation for the 4 active checks
+2. implement per-check result evaluation for the 5 active checks
 3. implement run-level verdict derivation
 4. validate new evaluator against known bundles (replay determinism test)
 5. optionally add `Single_run` friction projection

--- a/docs/design/check-evaluation-spec.md
+++ b/docs/design/check-evaluation-spec.md
@@ -74,6 +74,7 @@ Run-level metadata:
 | `runtime.risk_class` | proof faithfully carries the risk class from the contract | `runtime_constraints.risk_class` | `contract_id`, `risk_class` | `contract.json` | load contract snapshot by run convention; require `contract_id` hash match; require `contract.risk_class = proof.risk_class` | Active in v1 | `Violated` on contradiction, `Inconclusive` on missing basis |
 | `proof.contract_snapshot` | the contract snapshot used for replay is the exact immutable input contract referenced by `contract_id` | full contract snapshot | `contract_id` | `contract.json` | load contract snapshot by run convention; recompute content-addressed `contract_id`; require equality with manifest `contract_id` | Active in v1 | `Violated` on hash mismatch, `Inconclusive` on load/parse failure |
 | `proof.required_artifact` | artifacts required by active checks are present and parseable | none directly | `tool_trace_refs`, `raw_evidence_refs`, `checkpoint_ref` | referenced artifacts selected by the active checks | for every artifact selected by phase-1A rules, resolve ref, read file, parse payload; no heuristic fallback | Active in v1 | `Inconclusive` if blocking artifact missing or unreadable |
+| `runtime.review_requirement` | proof bundle v1 does not carry a typed review verdict, so any declared review requirement must route through the verification FSM instead of being silently treated as satisfied | `runtime_constraints.review_requirement` | `raw_evidence_refs` | `evidence/review_warning.json` | if no review requirement is declared, satisfy immediately; if one is declared, emit `Inconclusive` with a blocking gap so downstream uses explicit verification / approval | Active in v1 | `Inconclusive` on any declared review requirement until explicit verification occurs downstream |
 
 ### 4.1 Mode Order Rule
 
@@ -98,7 +99,7 @@ It is limited to the artifacts selected by the active phase-1A checks.
 | `contract.json` | yes | yes | required for contract snapshot integrity and propagation checks |
 | `evidence/mode_violations.json` | no in Phase-1A judge | no | not required by active phase-1A checks; used in Phase-1B friction |
 | `evidence/token_usage.json` | no | no | advisory / annotation only |
-| `evidence/review_warning.json` | no | no | unsupported review semantics in v1 |
+| `evidence/review_warning.json` | conditional | yes when `runtime.review_requirement` is declared | warning-only bridge artifact that routes the run into the verification FSM |
 | `tool_traces/*.jsonl` | no by default | no | only selected when a later active check explicitly consumes them |
 | `checkpoint_ref` target | no by default | no | only selected when a later active check explicitly consumes it |
 
@@ -112,13 +113,18 @@ Rule:
 | check_id | why unsupported in v1 | what is missing | required next step |
 |---|---|---|---|
 | `runtime.allowed_mutations` | OAS enforces it at run time, but proof bundle v1 and evidence v1 do not preserve enough typed post-run evidence to replay it generally | no top-level proof field; no stable typed evidence for mutation class decision; current violation rows do not expose `effect_class` or `decision` | evidence v2 plus mapping update |
-| `runtime.review_requirement` | proof bundle v1 does not encode whether review was satisfied as a typed replayable fact | only ad hoc warning-style evidence exists; no typed review event or verdict input | typed review evidence and check spec expansion |
 
 Rule:
 
 - unsupported checks must not be silently treated as satisfied
 - unsupported checks must not participate in deterministic pass conditions
 - unsupported checks may appear in documentation as contract surface, but not as active phase-1A checks
+
+Note:
+
+- `runtime.review_requirement` is now a bridge check, not a full satisfaction check
+- phase-1A can route declared review requirements into `Inconclusive + blocking gap`
+- phase-1A still cannot prove that review was satisfied from proof bundle v1 alone
 
 ## 6. Blocking vs Annotation Inputs
 

--- a/docs/design/proof-bundle-check-mapping.md
+++ b/docs/design/proof-bundle-check-mapping.md
@@ -27,7 +27,7 @@ Without an explicit mapping table, it is easy to write check logic for fields th
 | `runtime_constraints.requested_execution_mode` | `runtime.requested_execution_mode` | direct top-level field | not needed beyond contract snapshot | Active | propagation / integrity only |
 | `runtime_constraints.risk_class` | `runtime.risk_class` | direct top-level field | not needed beyond contract snapshot | Active | propagation / integrity only |
 | `runtime_constraints.allowed_mutations` | `runtime.allowed_mutations` | no top-level field | insufficient typed replay evidence | Unsupported_in_v1 | enforced at run time, not replayable generally |
-| `runtime_constraints.review_requirement` | `runtime.review_requirement` | no top-level field | insufficient typed replay evidence | Unsupported_in_v1 | warning-style evidence is not enough |
+| `runtime_constraints.review_requirement` | `runtime.review_requirement` | no top-level field | warning-only bridge evidence via `raw_evidence_refs` | Active | routes to `Inconclusive + blocking gap`; explicit review satisfaction is still not replayable |
 | full input contract snapshot | `proof.contract_snapshot` | `contract_id` only | `contract.json` by run convention | Active | integrity only |
 | required refs for active checks | `proof.required_artifact` | refs exist in manifest | referenced artifacts | Active | availability / parseability only |
 
@@ -58,7 +58,7 @@ Without an explicit mapping table, it is easy to write check logic for fields th
 | `contract.json` | OAS | full `runtime_constraints` + opaque `eval_criteria` | yes | no | no |
 | `evidence/mode_violations.json` | OAS | `ts`, `tool_name`, `input_summary`, `effective_mode`, `violation_kind` | no for active checks | yes | insufficient |
 | `evidence/token_usage.json` | OAS | turn token snapshots | no | optional annotation | no |
-| `evidence/review_warning.json` | OAS | warning string + effective mode | no | annotation only | insufficient |
+| `evidence/review_warning.json` | OAS | warning string + effective mode | yes for bridge routing | yes as review tripwire source | still insufficient for full typed review satisfaction |
 | `tool_traces/*.jsonl` | OAS | tool trace rows | only as selected artifact presence | optional | partial, still missing typed join fields |
 
 ## 4.1 Phase-1A Selected Artifact List
@@ -69,7 +69,7 @@ Without an explicit mapping table, it is easy to write check logic for fields th
 | contract snapshot | `{run}/contract.json` | yes | `runtime.requested_execution_mode`, `runtime.risk_class`, `proof.contract_snapshot` |
 | mode violations | `{run}/evidence/mode_violations.json` | no | phase-1B friction only |
 | token usage | `{run}/evidence/token_usage.json` | no | advisory only |
-| review warning | `{run}/evidence/review_warning.json` | no | unsupported review semantics in v1 |
+| review warning | `{run}/evidence/review_warning.json` | conditionally yes | active only when `runtime.review_requirement` is declared |
 | tool traces | `{run}/tool_traces/*.jsonl` | no by default | reserved for future active checks |
 | checkpoint | ref target of `checkpoint_ref` | no by default | reserved for future active checks |
 

--- a/lib/cdal_friction_projection.ml
+++ b/lib/cdal_friction_projection.ml
@@ -40,6 +40,7 @@ type friction_projection = {
 (* ================================================================ *)
 
 let mode_violations_suffix = "evidence/mode_violations.json"
+let review_warning_suffix = "evidence/review_warning.json"
 
 (** Find the first raw_evidence_ref that ends with mode_violations.json. *)
 let find_violations_ref (proof : Agent_sdk.Cdal_proof.t) : string option =
@@ -123,6 +124,18 @@ let compute_tripwires ~threshold (groups : blocked_attempt_group list)
   ) groups
   |> List.sort String.compare
 
+let review_tripwires_of_gaps (gaps : Cdal_types.completeness_gap list)
+    : string list =
+  let has_review_gap =
+    List.exists
+      (fun (g : Cdal_types.completeness_gap) ->
+        g.impact = Cdal_types.Blocks_verdict
+        && String.equal g.artifact review_warning_suffix)
+      gaps
+  in
+  if has_review_gap then [ "review_requirement:submit_for_verification" ]
+  else []
+
 (* ================================================================ *)
 (* Public API                                                        *)
 (* ================================================================ *)
@@ -149,6 +162,11 @@ let project_single_run
           (g, c)
   in
   let gap_groups = compute_gap_groups completeness_gaps in
+  let review_tripwires =
+    List.sort_uniq String.compare
+      (compute_tripwires ~threshold:tripwire_threshold groups
+       @ review_tripwires_of_gaps completeness_gaps)
+  in
   if blocked_attempt_count = 0 && gap_groups = [] then None
   else
     Some {
@@ -159,7 +177,7 @@ let project_single_run
       blocked_tool_counts = compute_tool_counts groups;
       blocked_attempt_groups = groups;
       evidence_gap_groups = gap_groups;
-      review_tripwires = compute_tripwires ~threshold:tripwire_threshold groups;
+      review_tripwires;
     }
 
 (* ================================================================ *)
@@ -271,6 +289,11 @@ let project_window
     let blocked_attempt_count =
       List.fold_left (fun acc (g : blocked_attempt_group) -> acc + g.count) 0 merged in
     let gap_groups = compute_gap_groups completeness_gaps in
+    let review_tripwires =
+      List.sort_uniq String.compare
+        (compute_tripwires ~threshold:tripwire_threshold merged
+         @ review_tripwires_of_gaps completeness_gaps)
+    in
     if blocked_attempt_count = 0 && gap_groups = [] then None
     else
       let run_ids = List.map (fun (p : Agent_sdk.Cdal_proof.t) -> p.run_id) proofs in
@@ -282,7 +305,7 @@ let project_window
         blocked_tool_counts = compute_tool_counts merged;
         blocked_attempt_groups = merged;
         evidence_gap_groups = gap_groups;
-        review_tripwires = compute_tripwires ~threshold:tripwire_threshold merged;
+        review_tripwires;
       }
 
 (* ================================================================ *)

--- a/lib/cdal_friction_projection.mli
+++ b/lib/cdal_friction_projection.mli
@@ -45,7 +45,10 @@ type friction_projection = {
     reads [mode_violations.json], parses v1 violation records, groups by
     [(tool_name, violation_kind, effective_mode)], derives tool counts and
     evidence gap groups, and fires review tripwires when any group count
-    exceeds [tripwire_threshold] (default 3).
+    exceeds [tripwire_threshold] (default 3). A blocking
+    [evidence/review_warning.json] gap also emits a
+    [review_requirement:submit_for_verification] tripwire so downstream
+    coordinators can route through their verification FSM.
 
     Returns [None] when no violations and no completeness gaps exist. *)
 val project_single_run :

--- a/lib/cdal_judge.ml
+++ b/lib/cdal_judge.ml
@@ -1,4 +1,4 @@
-(** Cdal_judge -- Phase 1A contract judge with 4 active checks.
+(** Cdal_judge -- Phase 1A contract judge with 5 active checks.
 
     @since CDAL Phase 1A *)
 
@@ -101,6 +101,40 @@ let check_required_artifact (_b : Cdal_loader.loaded_bundle) : Cdal_types.check_
     completeness_gaps = [] }
 
 (* ================================================================ *)
+(* Check 5: Review requirement                                      *)
+(* ================================================================ *)
+
+let review_warning_artifact = "evidence/review_warning.json"
+
+let has_review_warning_ref (proof : Agent_sdk.Cdal_proof.t) : bool =
+  List.exists
+    (fun ref_ -> String.ends_with ~suffix:review_warning_artifact ref_)
+    proof.raw_evidence_refs
+
+let check_review_requirement (b : Cdal_loader.loaded_bundle) : Cdal_types.check_result =
+  let check_id = "runtime.review_requirement" in
+  match b.contract.runtime_constraints.review_requirement with
+  | None ->
+    { check_id; status = Satisfied; findings = []; completeness_gaps = [] }
+  | Some _ ->
+    let reason =
+      if has_review_warning_ref b.proof then
+        "review_requirement present, but OAS only captured warning-style review evidence; use verification FSM for explicit approval"
+      else
+        "review_requirement present, but no review evidence artifact was captured; use verification FSM for explicit approval"
+    in
+    { check_id;
+      status = Inconclusive;
+      findings = [];
+      completeness_gaps = [
+        {
+          Cdal_types.artifact = review_warning_artifact;
+          reason;
+          impact = Blocks_verdict;
+        };
+      ] }
+
+(* ================================================================ *)
 (* Verdict derivation                                               *)
 (* ================================================================ *)
 
@@ -135,6 +169,7 @@ let judge (b : Cdal_loader.loaded_bundle) : Cdal_types.contract_verdict =
     check_risk_class b;
     check_contract_snapshot b;
     check_required_artifact b;
+    check_review_requirement b;
   ] in
   let status = derive_status checks in
   let findings =

--- a/lib/cdal_judge.mli
+++ b/lib/cdal_judge.mli
@@ -1,12 +1,13 @@
-(** Cdal_judge -- Phase 1A contract judge with 4 active checks.
+(** Cdal_judge -- Phase 1A contract judge with 5 active checks.
 
     Evaluates a loaded proof bundle against its contract constraints:
     execution mode propagation and escalation, risk class match,
-    contract snapshot integrity, and required artifact presence.
+    contract snapshot integrity, required artifact presence, and
+    review-requirement bridgeability.
 
     @since CDAL Phase 1A *)
 
-(** Evaluate all 4 checks and derive run-level verdict. *)
+(** Evaluate all 5 checks and derive run-level verdict. *)
 val judge : Cdal_loader.loaded_bundle -> Cdal_types.contract_verdict
 
 (** {2 Individual checks (exposed for testing)} *)
@@ -22,3 +23,8 @@ val check_contract_snapshot : Cdal_loader.loaded_bundle -> Cdal_types.check_resu
 
 (** Check required artifacts are present (always Satisfied post-load). *)
 val check_required_artifact : Cdal_loader.loaded_bundle -> Cdal_types.check_result
+
+(** Check review_requirement is either absent or routed to the verification FSM.
+    Current OAS v1 evidence is warning-only, so review requirements remain
+    [Inconclusive] until explicit verification occurs downstream. *)
+val check_review_requirement : Cdal_loader.loaded_bundle -> Cdal_types.check_result

--- a/lib/cdal_types.ml
+++ b/lib/cdal_types.ml
@@ -55,7 +55,7 @@ type contract_verdict = {
 (* ================================================================ *)
 
 let claim_scope_phase1 = "phase1_scoped_runtime_audit"
-let loader_semantics_version_phase1 = "phase1a_v1"
+let loader_semantics_version_phase1 = "phase1a_v2"
 let schema_compat_mode_v1 = "proof_bundle_v1"
 
 (* ================================================================ *)

--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -33,9 +33,17 @@ let check_verdict (v : Cdal_types.contract_verdict) : gate_result =
       let gap_details = List.map (fun (g : Cdal_types.completeness_gap) ->
         Printf.sprintf "%s: %s" g.artifact g.reason
       ) blocking_gaps in
+      let review_guidance =
+        if List.exists (fun (g : Cdal_types.completeness_gap) ->
+             String.equal g.artifact "evidence/review_warning.json")
+            blocking_gaps
+        then
+          " Submit for verification and approve via the verification FSM before marking done."
+        else ""
+      in
       let msg = Printf.sprintf
-        "CDAL verdict Inconclusive with blocking gaps (run_id=%s). Gaps: %s"
-        v.run_id (String.concat "; " gap_details)
+        "CDAL verdict Inconclusive with blocking gaps (run_id=%s). Gaps: %s%s"
+        v.run_id (String.concat "; " gap_details) review_guidance
       in
       Reject msg
 

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1902,9 +1902,46 @@ let run_turn
              let store = Agent_sdk.Proof_store.default_config in
              let outcome = Cdal_eval_v1.evaluate ~store p in
              let verdict = Cdal_eval_v1.verdict_of_outcome outcome in
+             let task_subject =
+               Option.map
+                 (fun task_id ->
+                   Coord_hooks.
+                     { kind = "task"; id = Keeper_id.Task_id.to_string task_id })
+                 meta.current_task_id
+             in
+             let emit_keeper_activity ~kind ~payload ~tags =
+               try
+                 !Coord_hooks.activity_emit_fn config
+                   ~actor:Coord_hooks.{ kind = "agent"; id = meta.agent_name }
+                   ?subject:task_subject
+                   ~kind ~payload ~tags ()
+               with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.Keeper.warn
+                   "keeper:%s activity emit failed (%s): %s"
+                   meta.name
+                   kind
+                   (Printexc.to_string exn)
+             in
              let task_id = Option.map Keeper_id.Task_id.to_string meta.current_task_id in
              Cdal_eval_v1.persist ?task_id verdict;
              Keeper_turn_telemetry.log_keeper_contract_verdict ~keeper_name:meta.name verdict;
+             emit_keeper_activity
+               ~kind:"keeper.contract_verdict"
+               ~payload:
+                 (Keeper_turn_telemetry.contract_verdict_activity_payload
+                    ~keeper_name:meta.name verdict)
+               ~tags:
+                 ([ "keeper"; "cdal"; "contract_verdict";
+                    Cdal_types.contract_status_to_string verdict.status ]
+                  @
+                  if List.exists
+                       (fun (gap : Cdal_types.completeness_gap) ->
+                         String.equal gap.artifact "evidence/review_warning.json")
+                       verdict.completeness_gaps
+                  then [ "review_requirement" ]
+                  else []);
              (match outcome with
               | Cdal_eval_v1.Load_failure (err, _) ->
                 Log.Keeper.warn
@@ -1913,7 +1950,16 @@ let run_turn
                   (Cdal_loader.load_error_to_string err)
               | Cdal_eval_v1.Verdict (_, _) -> ());
              (match Cdal_eval_v1.friction_of_outcome outcome with
-              | Some fp -> Keeper_turn_telemetry.log_keeper_friction ~keeper_name:meta.name fp
+              | Some fp ->
+                Keeper_turn_telemetry.log_keeper_friction ~keeper_name:meta.name fp;
+                emit_keeper_activity
+                  ~kind:"keeper.friction"
+                  ~payload:
+                    (Keeper_turn_telemetry.friction_activity_payload
+                       ~keeper_name:meta.name fp)
+                  ~tags:
+                    ([ "keeper"; "cdal"; "friction" ]
+                     @ if fp.review_tripwires <> [] then [ "tripwire" ] else [])
               | None -> ())
            | None -> ());
           (* Post-turn deterministic memory write.

--- a/lib/keeper/keeper_turn_telemetry.ml
+++ b/lib/keeper/keeper_turn_telemetry.ml
@@ -4,6 +4,61 @@
     Contains logging helpers for CDAL proofs, contract verdicts, friction
     projections, and memory-bank writes. *)
 
+let string_list_json (items : string list) : Yojson.Safe.t =
+  `List (List.map (fun item -> `String item) items)
+;;
+
+let blocking_gap_artifacts (verdict : Cdal_types.contract_verdict) : string list =
+  verdict.completeness_gaps
+  |> List.filter_map (fun (gap : Cdal_types.completeness_gap) ->
+       if gap.impact = Cdal_types.Blocks_verdict then Some gap.artifact else None)
+  |> List.sort_uniq String.compare
+;;
+
+let friction_gap_artifacts
+      (fp : Cdal_friction_projection.friction_projection) : string list
+  =
+  fp.evidence_gap_groups
+  |> List.map (fun (group : Cdal_friction_projection.evidence_gap_group) ->
+       group.artifact)
+  |> List.sort_uniq String.compare
+;;
+
+let contract_verdict_activity_payload
+      ~(keeper_name : string)
+      (verdict : Cdal_types.contract_verdict)
+  : Yojson.Safe.t
+  =
+  `Assoc
+    [
+      ("keeper_name", `String keeper_name);
+      ("run_id", `String verdict.run_id);
+      ("contract_id", `String verdict.contract_id);
+      ("status", `String (Cdal_types.contract_status_to_string verdict.status));
+      ("claim_scope", `String verdict.claim_scope);
+      ("judgment_hash", `String verdict.judgment_hash);
+      ("finding_count", `Int (List.length verdict.findings));
+      ("blocking_gap_artifacts", string_list_json (blocking_gap_artifacts verdict));
+    ]
+;;
+
+let friction_activity_payload
+      ~(keeper_name : string)
+      (fp : Cdal_friction_projection.friction_projection)
+  : Yojson.Safe.t
+  =
+  `Assoc
+    [
+      ("keeper_name", `String keeper_name);
+      ("window", `String fp.window);
+      ("based_on_run_ids", string_list_json fp.based_on_run_ids);
+      ("blocked_attempt_count", `Int fp.blocked_attempt_count);
+      ("blocked_group_count", `Int (List.length fp.blocked_attempt_groups));
+      ("review_tripwires", string_list_json fp.review_tripwires);
+      ("evidence_gap_artifacts", string_list_json (friction_gap_artifacts fp));
+    ]
+;;
+
 let log_keeper_proof ~(keeper_name : string) (proof : Agent_sdk.Cdal_proof.t) =
   let status_string =
     Agent_sdk.Cdal_proof.show_result_status proof.result_status
@@ -38,23 +93,28 @@ let log_keeper_contract_verdict
       ~(keeper_name : string)
       (verdict : Cdal_types.contract_verdict)
   =
+  let blocking_gaps = blocking_gap_artifacts verdict in
   match verdict.status with
   | Cdal_types.Satisfied ->
     if Keeper_types_profile.keeper_debug
     then
       Log.Keeper.debug
-        "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+        "keeper:%s contract_verdict: status=%s scope=%s hash=%s findings=%d blocking_gaps=[%s]"
         keeper_name
         (Cdal_types.contract_status_to_string verdict.status)
         verdict.claim_scope
         verdict.judgment_hash
+        (List.length verdict.findings)
+        (String.concat "," blocking_gaps)
   | Cdal_types.Violated | Cdal_types.Inconclusive ->
     Log.Keeper.warn
-      "keeper:%s contract_verdict: status=%s scope=%s hash=%s"
+      "keeper:%s contract_verdict: status=%s scope=%s hash=%s findings=%d blocking_gaps=[%s]"
       keeper_name
       (Cdal_types.contract_status_to_string verdict.status)
       verdict.claim_scope
       verdict.judgment_hash
+      (List.length verdict.findings)
+      (String.concat "," blocking_gaps)
 ;;
 
 let log_keeper_friction
@@ -64,30 +124,35 @@ let log_keeper_friction
   let blocked = fp.blocked_attempt_count in
   let groups = List.length fp.blocked_attempt_groups in
   let tripwires = List.length fp.review_tripwires in
+  let gap_artifacts = friction_gap_artifacts fp in
   if tripwires > 0
   then
     Log.Keeper.warn
-      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      "keeper:%s friction: blocked=%d groups=%d tripwires=%d names=[%s] gaps=[%s]"
       keeper_name
       blocked
       groups
       tripwires
+      (String.concat "," fp.review_tripwires)
+      (String.concat "," gap_artifacts)
   else if blocked > 0 || groups > 0
   then
     Log.Keeper.debug
-      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      "keeper:%s friction: blocked=%d groups=%d tripwires=%d gaps=[%s]"
       keeper_name
       blocked
       groups
       tripwires
+      (String.concat "," gap_artifacts)
   else if Keeper_types_profile.keeper_debug
   then
     Log.Keeper.debug
-      "keeper:%s friction: blocked=%d groups=%d tripwires=%d"
+      "keeper:%s friction: blocked=%d groups=%d tripwires=%d gaps=[%s]"
       keeper_name
       blocked
       groups
       tripwires
+      (String.concat "," gap_artifacts)
 ;;
 
 let log_keeper_memory_write

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -148,6 +148,171 @@ let room_state_json config =
         ("pause_reason", string_option_to_json state.pause_reason);
       ]
 
+let cdal_data_root (config : Coord.config) =
+  match Sys.getenv_opt "MASC_DATA_DIR" with
+  | Some dir -> dir
+  | None -> Filename.concat config.base_path "data"
+
+let cdal_verdicts_base_dir config =
+  Filename.concat (cdal_data_root config) "cdal_verdicts"
+
+let recent_cdal_verdicts_by_task (config : Coord.config) =
+  let store = Dated_jsonl.create ~base_dir:(cdal_verdicts_base_dir config) () in
+  let recent =
+    Dated_jsonl.read_recent store (Env_config_runtime.Cdal.verdict_lookup_limit ())
+  in
+  let tbl = Hashtbl.create 32 in
+  List.iter
+    (fun json ->
+      match json with
+      | `Assoc fields -> (
+          match List.assoc_opt "_task_id" fields with
+          | Some (`String tid) when String.trim tid <> "" ->
+              let verdict_fields = List.filter (fun (k, _) -> k <> "_task_id") fields in
+              (match Cdal_types.contract_verdict_of_json (`Assoc verdict_fields) with
+              | Ok verdict -> Hashtbl.replace tbl tid verdict
+              | Error _ -> ())
+          | _ -> ())
+      | _ -> ())
+    recent;
+  tbl
+
+let review_requirement_gaps (verdict : Cdal_types.contract_verdict) =
+  verdict.completeness_gaps
+  |> List.filter (fun (gap : Cdal_types.completeness_gap) ->
+       gap.impact = Cdal_types.Blocks_verdict
+       && String.equal gap.artifact "evidence/review_warning.json")
+
+let task_status_observed_at (task : Types.task) =
+  match task.task_status with
+  | Types.Claimed { claimed_at; _ } -> Some claimed_at
+  | Types.InProgress { started_at; _ } -> Some started_at
+  | Types.AwaitingVerification { submitted_at; _ } -> Some submitted_at
+  | Types.Done { completed_at; _ } -> Some completed_at
+  | Types.Cancelled { cancelled_at; _ } -> Some cancelled_at
+  | Types.Todo -> Some task.created_at
+
+let string_list_json values =
+  `List (List.map (fun value -> `String value) values)
+
+let cdal_review_requirement_item ~now (task : Types.task)
+    (verdict : Cdal_types.contract_verdict) =
+  let review_gaps = review_requirement_gaps verdict in
+  if review_gaps = [] then None
+  else
+    let verify_gate_evidence =
+      match task.contract with
+      | Some contract -> contract.verify_gate_evidence
+      | None -> []
+    in
+    let review_gap_artifacts =
+      review_gaps
+      |> List.map (fun (gap : Cdal_types.completeness_gap) -> gap.artifact)
+      |> List.sort_uniq String.compare
+    in
+    let review_gap_reasons =
+      review_gaps
+      |> List.map (fun (gap : Cdal_types.completeness_gap) -> gap.reason)
+      |> List.sort_uniq String.compare
+    in
+    let stale_sec = stale_sec_of_iso ~now (task_status_observed_at task) in
+    let base_friction route_state status assignee extra_fields =
+      `Assoc
+        ([
+           ("attention_items", `List []);
+           ("risk_digest", `Null);
+           ("pending_confirm", `Null);
+           ( "cdal",
+             `Assoc
+               ([
+                  ("route_state", `String route_state);
+                  ("task_id", `String task.id);
+                  ("task_title", `String task.title);
+                  ("task_status", `String status);
+                  ("assignee", `String assignee);
+                  ("run_id", `String verdict.run_id);
+                  ("contract_id", `String verdict.contract_id);
+                  ("judgment_hash", `String verdict.judgment_hash);
+                  ("review_gap_artifacts", string_list_json review_gap_artifacts);
+                  ("review_gap_reasons", string_list_json review_gap_reasons);
+                  ("verify_gate_evidence", string_list_json verify_gate_evidence);
+                  ("verdict", Cdal_types.contract_verdict_to_json verdict);
+                ]
+                @ extra_fields)) ]
+         : (string * Yojson.Safe.t) list)
+    in
+    match task.task_status with
+    | Types.InProgress { assignee; _ } ->
+        Some
+          {
+            id = "cdal_review_requirement:" ^ task.id;
+            kind = "cdal_review_requirement";
+            target_type = "task";
+            target_id = Some task.id;
+            severity = Sev_bad;
+            urgency = "now";
+            summary = Printf.sprintf "작업 %s 검증 제출 필요" task.title;
+            why_now =
+              "CDAL review_requirement가 발화했고 review_warning 근거만 남아 direct done이 차단되었습니다. verification FSM으로 submit_for_verification 후 승인 경로가 필요합니다.";
+            source = "deterministic";
+            authoritative = true;
+            fingerprint =
+              review_fingerprint
+                [ task.id; verdict.judgment_hash; Types.string_of_task_status task.task_status ];
+            stale_sec;
+            confirm_required = false;
+            recommended_action = None;
+            truth_ref =
+              review_truth_ref_json ~target_type:"task" ~target_id:(Some task.id);
+            friction =
+              base_friction "needs_submit_for_verification" "in_progress" assignee [];
+            advice = review_empty_advice_json;
+          }
+    | Types.AwaitingVerification
+        { assignee; verification_id; required_verifier_role; deadline; _ } ->
+        Some
+          {
+            id = "cdal_review_requirement:" ^ task.id;
+            kind = "cdal_review_requirement";
+            target_type = "task";
+            target_id = Some task.id;
+            severity = Sev_warn;
+            urgency = "soon";
+            summary = Printf.sprintf "작업 %s 검증 승인 대기" task.title;
+            why_now =
+              Printf.sprintf
+                "CDAL review_requirement가 이미 verification FSM으로 라우팅되었고 verification_id=%s 승인을 기다리고 있습니다."
+                verification_id;
+            source = "deterministic";
+            authoritative = true;
+            fingerprint =
+              review_fingerprint
+                [ task.id; verdict.judgment_hash; Types.string_of_task_status task.task_status ];
+            stale_sec;
+            confirm_required = false;
+            recommended_action = None;
+            truth_ref =
+              review_truth_ref_json ~target_type:"task" ~target_id:(Some task.id);
+            friction =
+              base_friction "awaiting_verification" "awaiting_verification" assignee
+                [
+                  ("verification_id", `String verification_id);
+                  ( "required_verifier_role",
+                    `String (Types.role_to_string required_verifier_role) );
+                  ("deadline", string_option_to_json deadline);
+                ];
+            advice = review_empty_advice_json;
+          }
+    | _ -> None
+
+let cdal_review_requirement_items config ~now =
+  let verdicts = recent_cdal_verdicts_by_task config in
+  Coord.get_tasks_safe config
+  |> List.filter_map (fun (task : Types.task) ->
+       match Hashtbl.find_opt verdicts task.id with
+       | Some verdict -> cdal_review_requirement_item ~now task verdict
+       | None -> None)
+
 let keeper_context_ratio (meta : Keeper_types.keeper_meta) =
   let input_tokens = meta.runtime.usage.last_input_tokens in
   if input_tokens = 0 then None
@@ -193,10 +358,12 @@ let urgency_rank = function
 let target_rank value =
   if Operator_digest_types.is_root_alias value then 3
   else match value with
+  | "task" -> 2
   | "keeper" -> 1
   | _ -> 0
 
 let kind_rank = function
+  | "cdal_review_requirement" -> 5
   | "pending_confirm" -> 4
   | "session_risk" -> 3
   | "namespace_gate" -> 2
@@ -565,6 +732,7 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
           @ (match namespace_gate_review_item ~room_json:room_state_json with
             | Some item -> [ item ]
             | None -> [])
+          @ cdal_review_requirement_items config ~now
           @ (keeper_rows |> List.filter_map (keeper_review_item ~now))
         in
         let active_reviews, deferred_reviews =

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -267,6 +267,37 @@ let tool_call_events (config : Coord.config) ~agent_name ~limit :
          })
   |> take limit
 
+let keeper_cdal_events (config : Coord.config) ~agent_name ~limit :
+    timeline_event list =
+  let rec take n xs =
+    match (n, xs) with
+    | n, _ when n <= 0 -> []
+    | _, [] -> []
+    | n, x :: rest -> x :: take (n - 1) rest
+  in
+  let scan_limit =
+    let expanded = if limit <= 0 then 0 else limit * 10 in
+    min 1000 (max limit expanded)
+  in
+  let all_events =
+    Activity_graph.list_events config
+      ~kinds:["keeper.contract_verdict"; "keeper.friction"]
+      ~after_seq:0 ~limit:scan_limit ()
+  in
+  all_events
+  |> List.filter (fun (e : Activity_graph.event) ->
+       match e.actor with
+       | Some a -> String.equal a.id agent_name
+       | None -> false)
+  |> List.map (fun (e : Activity_graph.event) ->
+       {
+         ts = Float.of_int e.ts_ms /. 1000.0;
+         ts_iso = e.ts_iso;
+         event_type = e.kind;
+         detail = e.payload;
+       })
+  |> take limit
+
 (* Collect turn-completed events from Activity Graph *)
 let turn_completed_events (config : Coord.config) ~agent_name ~limit :
     timeline_event list =
@@ -394,10 +425,13 @@ let build_timeline (config : Coord.config) ~agent_name ~since_hours ~limit
       if include_tool_calls then tool_call_events config ~agent_name ~limit:200
       else []
     in
+    let cdal_evts =
+      keeper_cdal_events config ~agent_name ~limit:200
+    in
     let turn_evts =
       turn_completed_events config ~agent_name ~limit:200
     in
-    agent_evts @ task_evts @ msg_evts @ tool_evts @ turn_evts
+    agent_evts @ task_evts @ msg_evts @ tool_evts @ cdal_evts @ turn_evts
   in
   (* Filter by time cutoff and sort chronologically *)
   let filtered =

--- a/test/test_cdal_eval_v1.ml
+++ b/test/test_cdal_eval_v1.ml
@@ -60,6 +60,19 @@ let make_contract () : Agent_sdk.Risk_contract.t =
     ];
   }
 
+let make_contract_with_review_requirement () : Agent_sdk.Risk_contract.t =
+  {
+    runtime_constraints = {
+      requested_execution_mode = Execute;
+      risk_class = Low;
+      allowed_mutations = ["keeper_fs_edit"];
+      review_requirement = Some "human_review";
+    };
+    eval_criteria = `Assoc [
+      ("success_criteria", `List [`String "tests pass"]);
+    ];
+  }
+
 let setup_store () =
   let tmp_dir = Filename.concat
     (Filename.get_temp_dir_name ())
@@ -92,7 +105,7 @@ let test_full_pipeline () =
       CT.loader_semantics_version_phase1 v.loader_semantics_version;
     Alcotest.(check string) "schema_compat_mode"
       CT.schema_compat_mode_v1 v.schema_compat_mode;
-    Alcotest.(check int) "4 check results" 4
+    Alcotest.(check int) "5 check results" 5
       (List.length v.check_results)
   | Load_failure (err, _) ->
     Alcotest.fail
@@ -155,6 +168,34 @@ let test_verdict_of_outcome () =
   Alcotest.(check string) "failure branch status" "inconclusive"
     (CT.contract_status_to_string v2.status)
 
+let test_review_requirement_yields_inconclusive () =
+  let (store, _tmp) = setup_store () in
+  let run_id = "review-gate-001" in
+  let contract = make_contract_with_review_requirement () in
+  let contract_id = Agent_sdk.Risk_contract.contract_id contract in
+  let proof = make_proof ~run_id ~contract_id () in
+  Agent_sdk.Proof_store.init_run store ~run_id;
+  Agent_sdk.Proof_store.write_manifest store ~run_id proof;
+  Agent_sdk.Proof_store.write_contract store ~run_id contract;
+  match CE.evaluate ~store proof with
+  | Verdict (v, Some fp) ->
+    Alcotest.(check string) "status" "inconclusive"
+      (CT.contract_status_to_string v.status);
+    Alcotest.(check bool) "has review gap" true
+      (List.exists
+         (fun (g : CT.completeness_gap) ->
+           String.equal g.artifact "evidence/review_warning.json")
+         v.completeness_gaps);
+    Alcotest.(check (list string)) "review tripwire"
+      ["review_requirement:submit_for_verification"]
+      fp.review_tripwires
+  | Verdict (_, None) ->
+    Alcotest.fail "expected friction projection for review gap"
+  | Load_failure (err, _) ->
+    Alcotest.fail
+      (Printf.sprintf "expected Verdict, got Load_failure: %s"
+         (CL.load_error_to_string err))
+
 (* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
@@ -167,5 +208,7 @@ let () =
         test_load_failure_inconclusive;
       Alcotest.test_case "verdict_of_outcome" `Quick
         test_verdict_of_outcome;
+      Alcotest.test_case "review requirement yields inconclusive" `Quick
+        test_review_requirement_yields_inconclusive;
     ]);
   ]

--- a/test/test_cdal_friction_projection.ml
+++ b/test/test_cdal_friction_projection.ml
@@ -314,6 +314,21 @@ let test_evidence_gap_groups () =
     Alcotest.(check string) "gap artifact" "manifest.json" g0.artifact;
     Alcotest.(check string) "gap impact" "blocks_verdict" g0.impact
 
+let test_review_gap_emits_tripwire () =
+  let (store, _tmp) = setup_store () in
+  let proof = make_proof ~run_id:"review-gap-001" () in
+  let gaps : Masc_mcp.Cdal_types.completeness_gap list = [
+    { artifact = "evidence/review_warning.json";
+      reason = "review_requirement present but no review evidence artifact was captured";
+      impact = Blocks_verdict };
+  ] in
+  match CFP.project_single_run ~store ~completeness_gaps:gaps proof with
+  | None -> Alcotest.fail "expected Some (has review gap)"
+  | Some fp ->
+    Alcotest.(check (list string)) "review tripwire"
+      ["review_requirement:submit_for_verification"]
+      fp.review_tripwires
+
 let test_tripwire_fires () =
   let (store, _tmp) = setup_store () in
   let run_id = "tw-test-001" in
@@ -529,6 +544,8 @@ let () =
          test_blocked_tool_counts;
        Alcotest.test_case "evidence gap groups" `Quick
          test_evidence_gap_groups;
+       Alcotest.test_case "review gap emits tripwire" `Quick
+         test_review_gap_emits_tripwire;
        Alcotest.test_case "tripwire fires" `Quick
          test_tripwire_fires;
        Alcotest.test_case "tripwire below threshold" `Quick

--- a/test/test_cdal_judge.ml
+++ b/test/test_cdal_judge.ml
@@ -1,6 +1,6 @@
 (** test_cdal_judge -- Unit tests for Cdal_judge module.
 
-    Tests 4 active checks and run-level verdict derivation
+    Tests 5 active checks and run-level verdict derivation
     with determinism and findings population verification. *)
 
 module CJ = Masc_mcp.Cdal_judge
@@ -51,13 +51,14 @@ let make_proof
 let make_contract
     ?(requested = Agent_sdk.Execution_mode.Execute)
     ?(risk_class = Agent_sdk.Risk_class.Low)
+    ?review_requirement
     () : Agent_sdk.Risk_contract.t =
   {
     runtime_constraints = {
       requested_execution_mode = requested;
       risk_class;
       allowed_mutations = ["keeper_fs_edit"];
-      review_requirement = None;
+      review_requirement;
     };
     eval_criteria = `Assoc [
       ("success_criteria", `List [`String "tests pass"]);
@@ -71,10 +72,13 @@ let make_bundle
     ?(proof_risk = Agent_sdk.Risk_class.Low)
     ?(contract_requested = Agent_sdk.Execution_mode.Execute)
     ?(contract_risk = Agent_sdk.Risk_class.Low)
+    ?contract_review_requirement
+    ?(proof_raw_evidence_refs = [])
     ?(contract_id_match = true)
     () : CL.loaded_bundle =
   let contract = make_contract ~requested:contract_requested
-      ~risk_class:contract_risk () in
+      ~risk_class:contract_risk
+      ?review_requirement:contract_review_requirement () in
   let recomputed_contract_id =
     Agent_sdk.Risk_contract.contract_id contract in
   let proof_contract_id =
@@ -83,6 +87,7 @@ let make_bundle
   let proof = make_proof ~run_id ~contract_id:proof_contract_id
       ~requested:proof_requested ~effective:proof_effective
       ~risk_class:proof_risk () in
+  let proof = { proof with raw_evidence_refs = proof_raw_evidence_refs } in
   {
     proof;
     manifest_json = `Assoc [];
@@ -101,7 +106,7 @@ let test_all_satisfied () =
   Alcotest.(check string) "status" "satisfied"
     (CT.contract_status_to_string verdict.status);
   Alcotest.(check int) "no findings" 0 (List.length verdict.findings);
-  Alcotest.(check int) "4 check results" 4
+  Alcotest.(check int) "5 check results" 5
     (List.length verdict.check_results);
   List.iter (fun (cr : CT.check_result) ->
     Alcotest.(check string) (cr.check_id ^ " satisfied") "satisfied"
@@ -176,6 +181,38 @@ let test_required_artifact_satisfied () =
   Alcotest.(check string) "status" "satisfied"
     (CT.contract_status_to_string cr.status);
   Alcotest.(check int) "no findings" 0 (List.length cr.findings)
+
+(* ================================================================ *)
+(* test_review_requirement_inconclusive_missing_evidence             *)
+(* ================================================================ *)
+
+let test_review_requirement_inconclusive_missing_evidence () =
+  let bundle = make_bundle
+      ?contract_review_requirement:(Some "human_review") () in
+  let cr = CJ.check_review_requirement bundle in
+  Alcotest.(check string) "status" "inconclusive"
+    (CT.contract_status_to_string cr.status);
+  Alcotest.(check int) "1 completeness gap" 1 (List.length cr.completeness_gaps);
+  let gap = List.hd cr.completeness_gaps in
+  Alcotest.(check string) "gap artifact" "evidence/review_warning.json" gap.artifact;
+  Alcotest.(check string) "gap impact" "blocks_verdict"
+    (CT.completeness_impact_to_string gap.impact)
+
+(* ================================================================ *)
+(* test_review_requirement_inconclusive_warning_only                 *)
+(* ================================================================ *)
+
+let test_review_requirement_inconclusive_warning_only () =
+  let bundle = make_bundle
+      ?contract_review_requirement:(Some "human_review")
+      ~proof_raw_evidence_refs:["proof-store://judge-test-001/evidence/review_warning.json"]
+      () in
+  let cr = CJ.check_review_requirement bundle in
+  Alcotest.(check string) "status" "inconclusive"
+    (CT.contract_status_to_string cr.status);
+  let gap = List.hd cr.completeness_gaps in
+  Alcotest.(check bool) "mentions warning-style evidence" true
+    (Astring.String.is_infix ~affix:"warning-style review evidence" gap.reason)
 
 (* ================================================================ *)
 (* test_verdict_priority_violated_wins                               *)
@@ -280,6 +317,10 @@ let () =
         test_contract_snapshot_violated;
       Alcotest.test_case "required artifact satisfied" `Quick
         test_required_artifact_satisfied;
+      Alcotest.test_case "review requirement missing evidence" `Quick
+        test_review_requirement_inconclusive_missing_evidence;
+      Alcotest.test_case "review requirement warning only" `Quick
+        test_review_requirement_inconclusive_warning_only;
     ]);
     ("verdict", [
       Alcotest.test_case "violated wins" `Quick

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -90,6 +90,22 @@ let test_inconclusive_blocking_gap_rejects () =
   | CVG.Allow ->
     Alcotest.fail "Inconclusive with blocking gap should Reject"
 
+let test_review_gap_mentions_verification_fsm () =
+  let gap =
+    make_gap
+      ~artifact:"evidence/review_warning.json"
+      ~reason:"review_requirement present but only warning-style review evidence exists"
+      ~impact:CT.Blocks_verdict
+      ()
+  in
+  let v = make_verdict ~status:CT.Inconclusive ~gaps:[gap] () in
+  match CVG.check_verdict v with
+  | CVG.Reject msg ->
+    Alcotest.(check bool) "mentions submit_for_verification" true
+      (Astring.String.is_infix ~affix:"Submit for verification" msg)
+  | CVG.Allow ->
+    Alcotest.fail "Review gap should Reject"
+
 let test_inconclusive_annotation_only_allows () =
   let gap = make_gap ~impact:CT.Annotation_only () in
   let v = make_verdict ~status:CT.Inconclusive ~gaps:[gap] () in
@@ -204,6 +220,7 @@ let () =
       Alcotest.test_case "violated rejects" `Quick test_violated_rejects;
       Alcotest.test_case "violated no findings rejects" `Quick test_violated_no_findings_still_rejects;
       Alcotest.test_case "inconclusive blocking gap rejects" `Quick test_inconclusive_blocking_gap_rejects;
+      Alcotest.test_case "review gap mentions verification fsm" `Quick test_review_gap_mentions_verification_fsm;
       Alcotest.test_case "inconclusive annotation only allows" `Quick test_inconclusive_annotation_only_allows;
       Alcotest.test_case "inconclusive no gaps allows" `Quick test_inconclusive_no_gaps_allows;
       Alcotest.test_case "inconclusive mixed gaps rejects" `Quick test_inconclusive_mixed_gaps_rejects;

--- a/test/test_golden_set_eval.ml
+++ b/test/test_golden_set_eval.ml
@@ -179,10 +179,10 @@ let test_calibration_baseline () =
   ) results
 
 let test_structural_checks_pass_for_valid_proofs () =
-  (* Verify that structurally valid proofs always get 4/4 satisfied checks *)
+  (* Verify that structurally valid proofs always get 5/5 satisfied checks *)
   let bundle = bundle_of_golden_case (List.hd GS.positive_cases) in
   let verdict = CJ.judge bundle in
-  Alcotest.(check int) "4 check results" 4
+  Alcotest.(check int) "5 check results" 5
     (List.length verdict.check_results);
   List.iter (fun (cr : CT.check_result) ->
     Alcotest.(check string) (cr.check_id ^ " satisfied") "satisfied"

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -63,6 +63,10 @@ let () =
           Alcotest.test_case "digest defaults to namespace target" `Quick
             Test_operator_control_actions
             .test_digest_defaults_to_namespace_target;
+          Alcotest.test_case "cdal review requirement appears in review queue"
+            `Quick
+            Test_operator_control_actions
+            .test_cdal_review_requirement_appears_in_review_queue;
           Alcotest.test_case "review resolve hides matching item" `Quick
             Test_operator_control_actions
             .test_review_resolve_hides_matching_item;

--- a/test/test_operator_control_actions.ml
+++ b/test/test_operator_control_actions.ml
@@ -1,6 +1,55 @@
 open Masc_mcp
 open Test_operator_control_support
 
+module CT = Masc_mcp.Cdal_types
+
+let make_review_required_verdict ?(run_id = "review-run-001") () :
+    CT.contract_verdict =
+  let gap : CT.completeness_gap =
+    {
+      artifact = "evidence/review_warning.json";
+      reason =
+        "review_requirement present but only warning-style review evidence exists";
+      impact = CT.Blocks_verdict;
+    }
+  in
+  let basis_input =
+    Printf.sprintf "%s|%s|%s"
+      "md5:review-contract"
+      CT.loader_semantics_version_phase1
+      CT.schema_compat_mode_v1
+  in
+  let basis_hash = "md5:" ^ (Digest.string basis_input |> Digest.to_hex) in
+  let verdict_without_hash : CT.contract_verdict =
+    {
+      run_id;
+      contract_id = "md5:review-contract";
+      claim_scope = CT.claim_scope_phase1;
+      judgment_basis_hash = basis_hash;
+      judgment_hash = "";
+      loader_semantics_version = CT.loader_semantics_version_phase1;
+      schema_compat_mode = CT.schema_compat_mode_v1;
+      status = CT.Inconclusive;
+      findings = [];
+      completeness_gaps = [ gap ];
+      check_results = [];
+    }
+  in
+  let judgment_hash = CT.compute_judgment_hash verdict_without_hash in
+  { verdict_without_hash with judgment_hash }
+
+let claim_and_start config ~agent_name ~task_id =
+  (match
+     Coord.transition_task_r config ~agent_name ~task_id ~action:Types.Claim ()
+   with
+  | Ok _ -> ()
+  | Error err -> Alcotest.fail (Types.show_masc_error err));
+  match
+    Coord.transition_task_r config ~agent_name ~task_id ~action:Types.Start ()
+  with
+  | Ok _ -> ()
+  | Error err -> Alcotest.fail (Types.show_masc_error err)
+
 let test_task_inject_executes_immediately () =
   Eio_main.run @@ fun env ->
   ensure_fs env;
@@ -76,6 +125,52 @@ let review_item_from_room_digest ctx =
   match Yojson.Safe.Util.(digest |> member "review_queue" |> to_list) with
   | item :: _ -> item
   | [] -> Alcotest.fail "expected review_queue item"
+
+let test_cdal_review_requirement_appears_in_review_queue () =
+  Eio_main.run @@ fun env ->
+  ensure_fs env;
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Coord.default_config base_dir in
+      ignore (Coord.init config ~agent_name:(Some "dashboard"));
+      ignore (Coord.join config ~agent_name:"worker" ~capabilities:[] ());
+      let ctx = operator_ctx env sw config "dashboard" in
+      let task_id =
+        let _ =
+          Coord.add_task config ~title:"Review required task" ~priority:2
+            ~description:"needs verification routing"
+        in
+        match Coord.read_backlog config |> fun backlog -> backlog.tasks with
+        | task :: _ -> task.id
+        | [] -> Alcotest.fail "expected task"
+      in
+      claim_and_start config ~agent_name:"worker" ~task_id;
+      Cdal_eval_v1.persist
+        ~base_dir:(Filename.concat base_dir "data/cdal_verdicts")
+        ~task_id
+        (make_review_required_verdict ());
+      let item = review_item_from_room_digest ctx in
+      Alcotest.(check string) "kind" "cdal_review_requirement"
+        Yojson.Safe.Util.(item |> member "kind" |> to_string);
+      Alcotest.(check string) "target_type" "task"
+        Yojson.Safe.Util.(item |> member "target_type" |> to_string);
+      Alcotest.(check string) "target_id" task_id
+        Yojson.Safe.Util.(item |> member "target_id" |> to_string);
+      Alcotest.(check string) "severity" "bad"
+        Yojson.Safe.Util.(item |> member "severity" |> to_string);
+      Alcotest.(check bool) "summary mentions submit" true
+        (Astring.String.is_infix
+           ~affix:"검증 제출 필요"
+           Yojson.Safe.Util.(item |> member "summary" |> to_string));
+      Alcotest.(check bool) "friction includes review gap" true
+        (List.mem
+           (`String "evidence/review_warning.json")
+           Yojson.Safe.Util.
+             (item |> member "friction" |> member "cdal"
+              |> member "review_gap_artifacts" |> to_list)))
 
 let test_review_resolve_hides_matching_item () =
   Eio_main.run @@ fun env ->


### PR DESCRIPTION
## Summary
- route OAS `review_requirement` warning evidence into the existing verification FSM instead of treating it as a silent pass
- add keeper-side logging and activity telemetry for CDAL verdict/friction so review routing is visible operationally
- surface `keeper.contract_verdict` and `keeper.friction` events in the dashboard trace view

## Scope
- no OAS reimplementation in `masc-mcp`
- `masc-mcp` only consumes existing OAS `review_warning.json` evidence and turns it into deterministic gate/telemetry/dashboard signals

## Validation
- `dune build --root . _build/default/test/test_cdal_judge.exe _build/default/test/test_cdal_eval_v1.exe _build/default/test/test_cdal_friction_projection.exe _build/default/test/test_cdal_verdict_gate.exe _build/default/test/test_golden_set_eval.exe`
- `./_build/default/test/test_cdal_judge.exe`
- `./_build/default/test/test_cdal_eval_v1.exe`
- `./_build/default/test/test_cdal_friction_projection.exe`
- `./_build/default/test/test_cdal_verdict_gate.exe`
- `./_build/default/test/test_golden_set_eval.exe`
- `dashboard`: `vitest run src/components/session-trace/session-trace-state.test.ts --no-file-parallelism --maxWorkers=1`
- `dashboard`: `tsc --noEmit --pretty false`
- `git diff --check`
