### PR TITLE
chore(cascade): MASC_CASCADE_* env prefix + dashboard SSOT

### DIFF
--- a/lib/cascade/cascade_health_tracker.ml
+++ b/lib/cascade/cascade_health_tracker.ml
@@ -16,24 +16,62 @@
 
 (* ── Configuration ────────────────────────────── *)
 
+(** One-time deprecation warning for legacy OAS_CASCADE_* env vars.
+    The cascade routing layer was migrated from OAS to MASC in v0.149.0
+    (see docs/rfc/RFC-OAS-006-weighted-cascade-routing.md + follow-ups);
+    the env var prefix stayed [OAS_CASCADE_*] by drift.  We accept both
+    during the transition and emit a one-shot warning per deprecated
+    key so operators can update their deployment config. *)
+let deprecation_warned : (string, unit) Hashtbl.t = Hashtbl.create 4
+
+let getenv_with_alias ~primary ~deprecated =
+  match Sys.getenv_opt primary with
+  | Some v -> Some v
+  | None ->
+    (match Sys.getenv_opt deprecated with
+     | Some _ as some ->
+       if not (Hashtbl.mem deprecation_warned deprecated) then begin
+         Hashtbl.add deprecation_warned deprecated ();
+         Printf.eprintf
+           "[warn] env var %s is deprecated; use %s (same semantics)\n%!"
+           deprecated primary
+       end;
+       some
+     | None -> None)
+
 (** Rolling window duration in seconds.  Events older than this are
-    discarded on read.  Default: 300s (5 minutes), matching OpenRouter. *)
+    discarded on read.  Default: 300s (5 minutes), matching OpenRouter's
+    rolling percentile window. *)
 let window_sec =
-  match Sys.getenv_opt "OAS_CASCADE_HEALTH_WINDOW_SEC" with
+  match getenv_with_alias
+          ~primary:"MASC_CASCADE_HEALTH_WINDOW_SEC"
+          ~deprecated:"OAS_CASCADE_HEALTH_WINDOW_SEC" with
   | Some s -> (try Float.of_string s with _ -> 300.0)
   | None -> 300.0
 
 (** Number of consecutive failures before cooldown activates.
     Default: 3, matching LiteLLM's [allowed_fails] concept. *)
 let cooldown_threshold =
-  match Sys.getenv_opt "OAS_CASCADE_COOLDOWN_THRESHOLD" with
+  match getenv_with_alias
+          ~primary:"MASC_CASCADE_COOLDOWN_THRESHOLD"
+          ~deprecated:"OAS_CASCADE_COOLDOWN_THRESHOLD" with
   | Some s -> (try int_of_string s with _ -> 3)
   | None -> 3
 
 (** Cooldown duration in seconds.  During cooldown, the provider is
-    skipped (not attempted).  Default: 60s. *)
+    skipped (not attempted).  Default: 60s.
+
+    Trade-off vs LiteLLM's 30s default: 60s is 2x more conservative,
+    prioritizing hot-loop avoidance over fast recovery.  A flapping
+    provider that recovers within one cooldown window is re-entered on
+    the next selection tick; at 30s, transient errors on the retry
+    boundary can cause the cascade to thrash between providers.
+    Override via [MASC_CASCADE_COOLDOWN_SEC] if recovery latency matters
+    more than thrashing avoidance in your deployment. *)
 let cooldown_sec =
-  match Sys.getenv_opt "OAS_CASCADE_COOLDOWN_SEC" with
+  match getenv_with_alias
+          ~primary:"MASC_CASCADE_COOLDOWN_SEC"
+          ~deprecated:"OAS_CASCADE_COOLDOWN_SEC" with
   | Some s -> (try Float.of_string s with _ -> 60.0)
   | None -> 60.0
 

--- a/lib/cascade/cascade_health_tracker.mli
+++ b/lib/cascade/cascade_health_tracker.mli
@@ -8,6 +8,21 @@
 
     @since 0.137.0 *)
 
+(** {1 Runtime configuration (env-driven, read once at module load)}
+
+    The env var prefix is [MASC_CASCADE_*]; [OAS_CASCADE_*] is accepted
+    as a deprecated alias (legacy of the v0.149.0 OAS→MASC migration)
+    and emits a one-time warning. *)
+
+val window_sec : float
+(** Rolling window duration in seconds.  Default 300.0 (5 min). *)
+
+val cooldown_threshold : int
+(** Consecutive failures before cooldown activates.  Default 3. *)
+
+val cooldown_sec : float
+(** Cooldown duration in seconds.  Default 60.0. *)
+
 (** Opaque health tracker state. *)
 type t
 

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -94,16 +94,6 @@ let config_json () =
 
 (* ── Health projection ──────────────────────────────── *)
 
-let float_env ~default key =
-  match Sys.getenv_opt key with
-  | Some s -> (try Float.of_string s with _ -> default)
-  | None -> default
-
-let int_env ~default key =
-  match Sys.getenv_opt key with
-  | Some s -> (try int_of_string s with _ -> default)
-  | None -> default
-
 let provider_info_to_json (info : Health.provider_info) : Yojson.Safe.t =
   `Assoc [
     ("provider_key", `String info.provider_key);
@@ -121,11 +111,13 @@ let health_json () =
   let providers = Health.all_providers Health.global in
   `Assoc [
     ("updated_at", `String (now_iso ()));
-    ("window_sec",
-     `Float (float_env ~default:300.0 "OAS_CASCADE_HEALTH_WINDOW_SEC"));
-    ("cooldown_threshold",
-     `Int (int_env ~default:3 "OAS_CASCADE_COOLDOWN_THRESHOLD"));
-    ("cooldown_sec",
-     `Float (float_env ~default:60.0 "OAS_CASCADE_COOLDOWN_SEC"));
+    (* Health tracker is the SSOT for these values; reading env here would
+       diverge from what the tracker actually applied (e.g. if the operator
+       sets a malformed value that falls back to the default, the tracker
+       has the fallback but a second env read would pick up the malformed
+       string). *)
+    ("window_sec", `Float Health.window_sec);
+    ("cooldown_threshold", `Int Health.cooldown_threshold);
+    ("cooldown_sec", `Float Health.cooldown_sec);
     ("providers", `List (List.map provider_info_to_json providers));
   ]


### PR DESCRIPTION
## Summary

Three drifts in [lib/cascade/cascade_health_tracker.ml] + [lib/dashboard_cascade.ml] fixed in one pass:

1. **Env prefix drift** — `cascade_config.ml` was migrated OAS→MASC in v0.149.0, but env vars stayed `OAS_CASCADE_*`. Added `MASC_CASCADE_*` as primary, keep `OAS_CASCADE_*` as deprecated alias with one-shot stderr warning.
2. **Config SSOT** — Dashboard re-read env vars separately with `float_env`/`int_env` helpers; values could diverge from what the tracker actually applied. Dashboard now reads `Cascade_health_tracker.{window_sec, cooldown_threshold, cooldown_sec}`. Env parsed in **exactly one place**.
3. **cooldown_sec rationale** — 60s default (vs LiteLLM's 30s) lacked a trade-off comment. Added it: 60s prioritizes hot-loop avoidance over fast recovery.

## Evidence basis

Industry comparison researched this session:

| Param | MASC | LiteLLM | OpenRouter |
|------|------|---------|------------|
| window_sec | **300s** | 60s | 300s (OpenRouter-aligned ✅) |
| cooldown_threshold | **3** | 3 (allowed_fails) | — (LiteLLM-aligned ✅) |
| cooldown_sec | **60s** | 30s | — (2× conservative, now documented) |

Sources: [LiteLLM Cooldown](https://deepwiki.com/BerriAI/litellm/7.2-cooldown-management), [OpenRouter Latency rolling window](https://openrouter.ai/docs/guides/best-practices/latency-and-performance).

## Test plan

- [x] `dune build @install` clean (warn-as-error strict mode).
- [ ] Manual: set `OAS_CASCADE_COOLDOWN_SEC=45` and verify one-shot deprecation warning on stderr, value applies.
- [ ] Manual: set `MASC_CASCADE_COOLDOWN_SEC=45` (no OAS_* set), verify no warning.
- [ ] Dashboard `health_json` endpoint shows tracker's actual applied values (not freshly-parsed env).

## Why one PR (not three)

All three drifts share the same code surface (`cascade_health_tracker.ml` config block + its sole dashboard consumer). Splitting would force the second PR to re-touch the same lines. Review cost is one read pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)