### PR TITLE
[codex] strengthen compaction observability

### DIFF
--- a/lib/keeper/keeper_compact_policy.ml
+++ b/lib/keeper/keeper_compact_policy.ml
@@ -168,9 +168,35 @@ let compact_if_needed
           sync_oas_context { ctx with messages }
         in
         let new_ratio = context_ratio compacted_ctx in
+        let new_msg_count = message_count compacted_ctx in
+        let new_tok_count = token_count compacted_ctx in
+        let saved_tokens = max 0 (tok_count - new_tok_count) in
+        let saved_messages = max 0 (msg_count - new_msg_count) in
         Prometheus.inc_counter Prometheus.metric_keeper_compactions
           ~labels:[("keeper", meta.name)] ();
         Prometheus.set_gauge Prometheus.metric_keeper_compaction_ratio_change
           ~labels:[("keeper", meta.name)]
           (ratio -. new_ratio);
+        Prometheus.inc_counter Prometheus.metric_keeper_compaction_saved_tokens
+          ~labels:[("keeper", meta.name)]
+          ~delta:(float_of_int saved_tokens)
+          ();
+        Log.emit Log.Info ~module_name:"Harness"
+          ~details:
+            (`Assoc
+              [
+                ("keeper_name", `String meta.name);
+                ("trigger", `String reason);
+                ("before_ratio", `Float ratio);
+                ("after_ratio", `Float new_ratio);
+                ("before_messages", `Int msg_count);
+                ("after_messages", `Int new_msg_count);
+                ("before_tokens", `Int tok_count);
+                ("after_tokens", `Int new_tok_count);
+                ("saved_messages", `Int saved_messages);
+                ("saved_tokens", `Int saved_tokens);
+              ])
+          (Printf.sprintf
+             "post_compact keeper=%s trigger=%s saved_tokens=%d"
+             meta.name reason saved_tokens);
         (compacted_ctx, Some reason, "applied:" ^ reason)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -182,6 +182,8 @@ let metric_keeper_cache_read_tokens =
 let metric_keeper_compactions = "masc_keeper_compactions_total"
 let metric_keeper_compaction_ratio_change =
   "masc_keeper_compaction_ratio_change"
+let metric_keeper_compaction_saved_tokens =
+  "masc_keeper_compaction_saved_tokens_total"
 let metric_keeper_operator_compact = "masc_keeper_operator_compact_total"
 let metric_keeper_operator_clear = "masc_keeper_operator_clear_total"
 
@@ -238,6 +240,8 @@ let init () =
     "Total keeper compactions performed" Counter;
   add metric_keeper_compaction_ratio_change
     "Context ratio change after compaction (pre - post)" Gauge;
+  add metric_keeper_compaction_saved_tokens
+    "Total tokens removed by keeper context compaction" Counter;
   (* Operator-initiated overflow recovery — emitted by tool_keeper.ml *)
   add metric_keeper_operator_compact
     "Total operator-invoked masc_keeper_compact calls (labels: result=ok|no_checkpoint|precondition|not_found)" Counter;

--- a/test/test_keeper_lifecycle.ml
+++ b/test/test_keeper_lifecycle.ml
@@ -1726,6 +1726,48 @@ let test_compact_if_needed_emergency_bypass_ignores_cooldown () =
   check bool "compaction was triggered (emergency bypass)" true (Option.is_some trigger);
   check bool "decision starts with applied:" true (String.starts_with ~prefix:"applied:" decision)
 
+let test_compact_if_needed_records_saved_tokens_metric () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let now_ts = 20_000.0 in
+  let meta =
+    make_gate_only_meta
+      ~last_continuity_update_ts:(now_ts -. 60.0)
+      ~cooldown_sec:0
+      ()
+  in
+  let long_text = String.make emergency_test_text_length 'x' in
+  let ctx =
+    KEC.create ~system_prompt:"sp" ~max_tokens:100
+    |> fun c -> KEC.append c (Agent_sdk.Types.user_msg long_text)
+    |> fun c -> KEC.append c (Agent_sdk.Types.assistant_msg long_text)
+    |> KEC.sync_oas_context
+  in
+  let labels = [ ("keeper", meta.name) ] in
+  let before_metric =
+    Masc_mcp.Prometheus.get_metric_value
+      Masc_mcp.Prometheus.metric_keeper_compaction_saved_tokens
+      ~labels
+      ()
+    |> Option.value ~default:0.0
+  in
+  let (compacted_ctx, trigger, decision) =
+    KEC.compact_if_needed ~meta ~now_ts ctx
+  in
+  let after_metric =
+    Masc_mcp.Prometheus.get_metric_value
+      Masc_mcp.Prometheus.metric_keeper_compaction_saved_tokens
+      ~labels
+      ()
+    |> Option.value ~default:0.0
+  in
+  check bool "compaction was triggered" true (Option.is_some trigger);
+  check bool "decision starts with applied:" true
+    (String.starts_with ~prefix:"applied:" decision);
+  check bool "token count reduced" true
+    (KCC.token_count compacted_ctx < KCC.token_count ctx);
+  check bool "saved tokens metric increased" true (after_metric > before_metric)
+
 let test_dispatch_keeper_phase_event_uses_room_base_path () =
   let base_dir = temp_dir "keeper_lifecycle_registry_phase" in
   Fun.protect
@@ -1875,6 +1917,8 @@ let () =
             test_compact_if_needed_ts_zero_bypasses_cooldown;
           test_case "emergency ratio bypasses cooldown gate" `Quick
             test_compact_if_needed_emergency_bypass_ignores_cooldown;
+          test_case "compaction records saved tokens metric" `Quick
+            test_compact_if_needed_records_saved_tokens_metric;
         ] );
       ( "registry_dispatch",
         [

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -211,6 +211,8 @@ let test_keeper_metrics_registered () =
     (has "masc_keeper_compactions_total");
   check bool "has keeper compaction ratio gauge" true
     (has "masc_keeper_compaction_ratio_change");
+  check bool "has keeper compaction saved tokens counter" true
+    (has "masc_keeper_compaction_saved_tokens_total");
   check bool "has keeper heartbeat successes counter" true
     (has "masc_keeper_heartbeat_successes_total");
   check bool "has keeper heartbeat failures counter" true


### PR DESCRIPTION
## Summary
- add a Prometheus counter for context-compaction saved tokens
- emit a structured post-compaction log with before/after ratio, messages, tokens, and trigger
- add regression coverage to verify the new metric is registered and actually increments on compaction

## Why
Recent observability work in the last 100 PRs already covered pre-compaction signals, compaction counts, and ratio deltas, but the post-compaction outcome still lacked a direct saved-token signal.

## Impact
- operators can now see how much token budget compaction actually reclaimed
- post-compaction logs carry the concrete before/after state needed for debugging and tuning thresholds
- dashboards and alerts can consume a monotonic saved-token counter instead of inferring savings indirectly

## Root cause
The compaction path recorded that compaction happened, but not the concrete reclaimed-token total. That left a gap between pre-compaction intent and post-compaction effectiveness.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/pr100-telemetry-audit-2026-04-16 test/test_prometheus_coverage.exe test/test_keeper_lifecycle.exe`
- `./_build/default/test/test_prometheus_coverage.exe`
- `./_build/default/test/test_keeper_lifecycle.exe`