### PR TITLE
refactor(coord_task): variant for transition event_type (#7520 Step 4)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -236,12 +236,26 @@ let observe_task_transition config ~agent_name ~task_id ~transition ~details =
   !Coord_hooks.observe_task_transition_fn config ~agent_name
     ~task_id ~transition ~details
 
+(** Transition log event taxonomy. Variant instead of free-form string
+    (#7520 Step 4) so typos at call-sites fail to compile. The three
+    values correspond to the current fire points in this module — add
+    a variant when a new transition event is introduced. *)
+type transition_event_type =
+  | Task_transition
+  | Task_done
+  | Task_cancelled
+
+let transition_event_type_to_string = function
+  | Task_transition -> "task_transition"
+  | Task_done -> "task_done"
+  | Task_cancelled -> "task_cancelled"
+
 (** SSOT structured event for [log_event] sink. Wraps [task_transition_details]
     with an envelope (type/agent/actor_kind/task/from_status/to_status/ts) so
     every transition log line carries the same schema. Optional [?action]
     preserves the legacy "action" field used by the unified transition path
     so existing dashboard readers do not break. *)
-let transition_log_event ~event_type ~agent_name ~task_id
+let transition_log_event ~(event_type : transition_event_type) ~agent_name ~task_id
     ~from_status ~to_status ?action ?notes ?reason ?duration_ms
     ?handoff_context ?(forced = false) ?(now = now_iso ()) () : Yojson.Safe.t =
   let optional_field name = function
@@ -250,7 +264,7 @@ let transition_log_event ~event_type ~agent_name ~task_id
   in
   `Assoc
     ([
-       ("type", `String event_type);
+       ("type", `String (transition_event_type_to_string event_type));
        ("agent", `String agent_name);
        ("actor_kind", `String (task_actor_kind agent_name));
        ("task", `String task_id);
@@ -851,7 +865,7 @@ let transition_task_r config ~agent_name ~task_id ~action
                 agent);
         log_event config
           (Yojson.Safe.to_string
-             (transition_log_event ~event_type:"task_transition"
+             (transition_log_event ~event_type:Task_transition
                 ~agent_name ~task_id
                 ~from_status:task.task_status ~to_status:new_status
                 ~action:action_s ~forced:force
@@ -1040,7 +1054,7 @@ let complete_task config ~agent_name ~task_id ~notes =
                   ]);
               log_event config
                 (Yojson.Safe.to_string
-                   (transition_log_event ~event_type:"task_done"
+                   (transition_log_event ~event_type:Task_done
                       ~agent_name ~task_id
                       ~from_status:task.task_status
                       ~to_status:
@@ -1159,7 +1173,7 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                     ]);
               log_event config
                 (Yojson.Safe.to_string
-                   (transition_log_event ~event_type:"task_done"
+                   (transition_log_event ~event_type:Task_done
                       ~agent_name ~task_id
                       ~from_status:task.task_status
                       ~to_status:
@@ -1267,7 +1281,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
                     ]);
               log_event config
                 (Yojson.Safe.to_string
-                   (transition_log_event ~event_type:"task_cancelled"
+                   (transition_log_event ~event_type:Task_cancelled
                       ~agent_name ~task_id
                       ~from_status:task.task_status
                       ~to_status:


### PR DESCRIPTION
## Summary
Closes the "event_type → variant" sub-task from #7520. Previously [transition_log_event ~event_type:string] accepted any free-form value at the three call-sites in [lib/coord/coord_task.ml]:

```
~event_type:"task_transition"   # line 854
~event_type:"task_done"         # lines 1043, 1162
~event_type:"task_cancelled"    # line 1270
```

A typo would compile fine but silently drift the dashboard taxonomy. Now:

```ocaml
type transition_event_type = Task_transition | Task_done | Task_cancelled
val transition_event_type_to_string : transition_event_type -> string
```

Call-sites pass the variant; typos fail to compile; new events force an exhaustive update.

## What this does NOT change

The **state transition logic itself** was already type-safe — `from_status` / `to_status` use `Types.task_status` (variant). Only the log-envelope label (the metadata `"type"` field) was stringly-typed. So this PR is a narrow metadata fix, not an FSM redesign.

## Scope boundary

Only `coord_task.ml`'s transition events are in scope. The `oas_sse_bridge.ml` event_type strings (`"agent_started"`, `"tool_called"`, `"turn_started"`, ~10 values) belong to a different taxonomy (agent lifecycle / tool / turn). Separate variant, separate follow-up.

## Test plan
- [x] `dune build --root .` green
- [x] Serialized JSON output byte-identical to prior (values unchanged: `"task_transition"`, `"task_done"`, `"task_cancelled"`)
- [x] Only 3 call-sites + 1 definition updated — no drift risk for dashboard consumers

## Diff stat
```
 lib/coord/coord_task.ml | 26 ++++++++++++++++++++------
```

20 inserts / 6 deletes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)