### PR TITLE
refactor(keeper): rename Heuristic selection_mode to Keyword_scored

### DIFF
--- a/lib/keeper/keeper_alerting.mli
+++ b/lib/keeper/keeper_alerting.mli
@@ -12,7 +12,7 @@ open Keeper_memory
 (** {1 Included: Keeper_skill_routing types} *)
 
 type selection_mode =
-  | Heuristic
+  | Keyword_scored
   | Model_selected of string
   | Model_rejected of string
 

--- a/lib/keeper/keeper_skill_routing.ml
+++ b/lib/keeper/keeper_skill_routing.ml
@@ -3,8 +3,12 @@
     are routed to specific meta-skills (heartbeat, autonomy) based on
     the user's request. *)
 
+(* Keyword_scored: deterministic keyword-count + tie-break scoring over the
+   keeper skill registry. Named explicitly (not "Heuristic") so consumers see
+   it is a Det rule, not an unclassified guess. MEMORY feedback:
+   memory/feedback_no-heuristic-category.md (Det/NonDet/Remove only). *)
 type selection_mode =
-  | Heuristic
+  | Keyword_scored
   | Model_selected of string
   | Model_rejected of string
 
@@ -112,8 +116,8 @@ let route_keeper_skill ~(message : string) : keeper_skill_route =
   in
   { primary_skill
   ; secondary_skill
-  ; reason = "Heuristic match based on message content"
-  ; selection_mode = Heuristic
+  ; reason = "Keyword match score on message content"
+  ; selection_mode = Keyword_scored
   }
 
 let format_skill_route_line (route : keeper_skill_route) : string =
@@ -123,9 +127,9 @@ let format_skill_route_line (route : keeper_skill_route) : string =
 
 let format_skill_route_reason (route : keeper_skill_route) : string =
   match route.selection_mode with
-  | Heuristic -> Printf.sprintf "SKILL_REASON: %s" route.reason
+  | Keyword_scored -> Printf.sprintf "SKILL_REASON: %s" route.reason
   | Model_selected r -> Printf.sprintf "SKILL_REASON: %s" r
-  | Model_rejected r -> Printf.sprintf "SKILL_REASON: %s (heuristic fallback)" r
+  | Model_rejected r -> Printf.sprintf "SKILL_REASON: %s (keyword fallback)" r
 
 let strip_skill_route_lines (raw : string) : string =
   let lines = String.split_on_char '\n' raw in

--- a/test/test_keeper_prompt_metrics.ml
+++ b/test/test_keeper_prompt_metrics.ml
@@ -36,7 +36,7 @@ let skill_route_text =
   let route : KSR.keeper_skill_route =
     { primary_skill = "code_review";
       secondary_skill = None;
-      reason = ""; selection_mode = Heuristic }
+      reason = ""; selection_mode = Keyword_scored }
   in
   KSR.skill_route_context_text
     ~fallback_route:route 


### PR DESCRIPTION
## Summary

Rename `selection_mode` variant `Heuristic` → `Keyword_scored` in `keeper_skill_routing.ml`. The underlying implementation is a deterministic keyword-count + tie-break scoring (Det rule), not a guess.

## Why

MEMORY feedback `memory/feedback_no-heuristic-category.md`:
> "휴리스틱"은 결정론/비결정론 경계의 세 번째 카테고리가 아니다. 아직 분류되지 않은 것일 뿐. 모듈/변수명에 "heuristic"을 쓰지 않는다.

`route_keeper_skill` builds a keyword-count histogram against static keyword lists, tie-breaks by `keeper_skill_priority`, and returns deterministically. Labelling this "Heuristic" hides the Det nature and lets the label propagate to logs/dashboards as if every keeper skill decision is a guess.

## Scope

**In this PR**:
- `lib/keeper/keeper_skill_routing.ml` — variant rename + `reason` string + `format_skill_route_reason` label.
- `lib/keeper/keeper_alerting.mli` — re-exported variant synced.
- `test/test_keeper_prompt_metrics.ml` — call site updated.

**Out of scope** (separate follow-up):
- `lib/heuristic_metrics.ml` and all callers (12+ sites) — systemic, warrants its own PR.
- RFC-0001 `provenance.Heuristic` variant — docs-only until harness code materialises.

## Test plan
- [x] `dune build --root .` clean.
- [x] `dune runtest --root . test/` green (111 tests, 106.974s; `test_keeper_prompt_metrics.exe` 9/9).
- [ ] CI green (awaiting).

## Audit evidence
Plan: `planning/claude-plans/misty-bubbling-music.md` HIGH-1.