### PR TITLE
fix(keeper-audit): re-raise Cancelled from Fun.protect finally

### DIFF
--- a/lib/keeper/keeper_transition_audit.ml
+++ b/lib/keeper/keeper_transition_audit.ml
@@ -81,7 +81,11 @@ let append_to_sink ~keeper_name (rec_ : transition_record) =
          open_out_gen [ Open_wronly; Open_append; Open_creat ] 0o644 path
        in
        Fun.protect
-         ~finally:(fun () -> try close_out oc with _ -> ())
+         ~finally:(fun () ->
+           try close_out oc
+           with
+           | Eio.Cancel.Cancelled _ as e -> raise e
+           | _ -> ())
          (fun () -> output_string oc (line ^ "\n"))
      with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
 


### PR DESCRIPTION
## Summary

Fix a silent-cancel regression in `lib/keeper/keeper_transition_audit.ml:append_to_sink`. The `Fun.protect` finally block's bare `with _ -> ()` swallowed `Eio.Cancel.Cancelled` raised during `close_out`.

## Before

\`\`\`ocaml
Fun.protect
  ~finally:(fun () -> try close_out oc with _ -> ())
  (fun () -> output_string oc (line ^ "\n"))
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
\`\`\`

The outer `try ... with Cancelled _ as e -> raise e` only catches cancels from the body fn (`output_string`). A cancel surfacing in the finally's `close_out` hits the inner `with _ -> ()` first and is dropped.

## After

\`\`\`ocaml
Fun.protect
  ~finally:(fun () ->
    try close_out oc
    with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | _ -> ())
  (fun () -> output_string oc (line ^ "\n"))
with Eio.Cancel.Cancelled _ as e -> raise e | _ -> ())
\`\`\`

## Why

The keeper transition audit JSONL sink runs inside an Eio domain as part of `record_transition`. A lost cancel means the parent switch thinks the append succeeded normally while the fiber was actually torn down — state-machine observability diverges silently.

## Test plan
- [x] `dune build --root .` clean.
- [ ] CI green (awaiting).

## Audit evidence
Plan: `planning/claude-plans/misty-bubbling-music.md` HIGH-2.