### PR TITLE
refactor(cascade-loader): move Eio.traceln outside cache mutex

### DIFF
--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -47,27 +47,38 @@ let load_json path =
       if not (Float.equal refreshed_mtime mtime) then
         load_current ()
       else
-        with_cache_lock (fun () ->
-            match Hashtbl.find_opt config_cache path with
-            | Some (cached_mtime, cached_json)
-              when Float.equal cached_mtime refreshed_mtime ->
-              Ok cached_json
-            | prior ->
-              Hashtbl.replace config_cache path (refreshed_mtime, json);
-              (* Observability: trace first-load vs reload so operators
-                 editing cascade.json can verify their change took effect.
-                 Keeping this at traceln (stderr) matches existing OAS
-                 convention (see Cascade_config.apply_provider_filter). *)
-              (match prior with
-               | None ->
-                 Eio.traceln
-                   "[CascadeConfig] loaded %s mtime=%.0f"
-                   path refreshed_mtime
-               | Some (old_mtime, _) ->
-                 Eio.traceln
-                   "[CascadeConfig] reloaded %s old_mtime=%.0f new_mtime=%.0f"
-                   path old_mtime refreshed_mtime);
-              Ok json)
+        (* Keep the critical section to Hashtbl access only. Any Eio-aware
+           work (traceln in particular) must run OUTSIDE the Stdlib.Mutex
+           because traceln can suspend the fiber while the lock is held,
+           blocking unrelated fibers on the domain.
+           Ref: memory/feedback_eio-traceln-outside-critical-section.md *)
+        let outcome =
+          with_cache_lock (fun () ->
+              match Hashtbl.find_opt config_cache path with
+              | Some (cached_mtime, cached_json)
+                when Float.equal cached_mtime refreshed_mtime ->
+                `Returning_cached cached_json
+              | prior ->
+                Hashtbl.replace config_cache path (refreshed_mtime, json);
+                `Installed_new (Option.map fst prior))
+        in
+        (match outcome with
+         | `Returning_cached cached_json -> Ok cached_json
+         | `Installed_new prior_mtime ->
+           (* Observability: trace first-load vs reload so operators
+              editing cascade.json can verify their change took effect.
+              Keeping this at traceln (stderr) matches existing OAS
+              convention (see Cascade_config.apply_provider_filter). *)
+           (match prior_mtime with
+            | None ->
+              Eio.traceln
+                "[CascadeConfig] loaded %s mtime=%.0f"
+                path refreshed_mtime
+            | Some old_mtime ->
+              Eio.traceln
+                "[CascadeConfig] reloaded %s old_mtime=%.0f new_mtime=%.0f"
+                path old_mtime refreshed_mtime);
+           Ok json)
   in
   try load_current () with
   | Sys_error msg -> Error msg


### PR DESCRIPTION
## Summary

`cascade_config_loader.load_json` was calling `Eio.traceln` while holding the cache's `Stdlib.Mutex`. Split the critical section so traceln runs after the lock is released.

## Why

`Eio.traceln` writes to stderr via the Eio scheduler and can suspend the current fiber. Holding a `Stdlib.Mutex` across a suspension blocks every other fiber on the same domain until the trace completes — and this is a hot-path cache loader, so bisect / cold-cache runs paid the cost repeatedly.

MEMORY: `memory/feedback_eio-traceln-outside-critical-section.md` — "hot-path 로더의 mutex 안에서 Eio.traceln 금지. lock 해제 후 captured locals로 trace."

## Approach

Inside the lock: check the cache, install the new entry, return a polymorphic variant:
- `Returning_cached cached_json` → another fiber installed the same mtime first, reuse it.
- `Installed_new prior_mtime` → we installed; log `loaded` or `reloaded` (with old mtime) outside the lock.

Outside the lock: pattern-match, emit `Eio.traceln`, build the `Result`.

## Test plan
- [x] `dune build --root .` clean.
- [x] `dune exec test/test_cascade_runtime.exe` green (2/2).
- [ ] CI green (awaiting).

## Audit evidence
Plan: `planning/claude-plans/misty-bubbling-music.md` MEDIUM-1.