### PR TITLE
feat(otel): dual-emit GenAI semconv on tool span (#7461 Step 1)

### DIFF
--- a/lib/otel/otel_dispatch_hook.ml
+++ b/lib/otel/otel_dispatch_hook.ml
@@ -3,6 +3,17 @@
     Creates an OTel span for each tool call using data from [Tool_result.t].
     Also records a Prometheus histogram observation for tool call duration.
 
+    Span attributes are dual-emitted: the legacy [tool.*] keys stay so
+    existing custom dashboards keep working, and the OpenTelemetry GenAI
+    semantic-convention keys ([gen_ai.tool.name],
+    [gen_ai.operation.name]) are added so vendors that auto-categorise
+    on [gen_ai.*] (Datadog v1.37+, Grafana, etc.) classify these spans
+    as AI/LLM activity instead of generic tool calls. See #7461 Step 1.
+
+    Note: as of 2026-04 most GenAI semconv attributes are
+    Stability.Experimental, so dual-emit also acts as a hedge against
+    spec changes — only the legacy keys would survive a rename event.
+
     @since 2.103.0 *)
 
 module OT = Opentelemetry
@@ -21,12 +32,22 @@ let on_tool_result (result : Tool_result.t) : Tool_result.t =
       else
         [("otel.status_code", `String "ERROR")]
     in
-    let attrs =
+    let legacy_attrs =
       [ ("tool.name", `String result.tool_name);
         ("tool.success", `Bool result.success);
         ("tool.duration_ms", `Int (int_of_float result.duration_ms)) ]
-      @ status_attrs
     in
+    (* OpenTelemetry GenAI semantic conventions
+       (https://opentelemetry.io/docs/specs/semconv/gen-ai/). Tool execution
+       within an agent run is the [execute_tool] operation per the spec.
+       [gen_ai.system] / [gen_ai.request.model] are intentionally omitted —
+       those belong on the parent agent / chat span (Step 2 of #7461),
+       not on the inner tool span which is provider-agnostic. *)
+    let gen_ai_attrs =
+      [ ("gen_ai.operation.name", `String "execute_tool");
+        ("gen_ai.tool.name", `String result.tool_name) ]
+    in
+    let attrs = legacy_attrs @ gen_ai_attrs @ status_attrs in
     ignore (OT.Trace.with_ ("tool/" ^ result.tool_name) ~attrs
       (fun _scope -> ()))
   end;


### PR DESCRIPTION
## Summary
Adds OpenTelemetry GenAI semantic-convention attributes alongside the existing custom `tool.*` keys on the per-tool-call span emitted from `Tool_dispatch` post-hook:

```diff
  ("tool.name", `String result.tool_name);          # legacy
  ("tool.success", `Bool result.success);            # legacy
  ("tool.duration_ms", `Int (...));                  # legacy
+ ("gen_ai.operation.name", `String "execute_tool"); # OTel GenAI semconv
+ ("gen_ai.tool.name", `String result.tool_name);    # OTel GenAI semconv
  ("otel.status_code", `String "OK"|"ERROR")         # OTel core
```

## Why dual-emit instead of swap

1. **Vendor categorisation**: Datadog OTel v1.37+, Grafana, and similar auto-categorise spans on the `gen_ai.*` namespace. Today MASC tool calls land in generic span buckets — after this PR they show up as AI/LLM activity automatically.
2. **Spec stability hedge**: as of 2026-04 most GenAI semconv attributes are `Stability.Experimental`. Keeping the legacy keys means a spec rename event ([spec history shows several](https://opentelemetry.io/docs/specs/semconv/gen-ai/)) doesn't break existing dashboards.
3. **Zero-downtime**: no consumer breaks today; new consumers pick up the standard names immediately.

## Scope boundary

`gen_ai.system` / `gen_ai.request.model` / `gen_ai.response.model` and the keeper-turn-level `chat` span belong on the parent (#7461 Step 2). Adding them to the inner tool span would be misleading — the tool itself is provider-agnostic.

## References
- [OpenTelemetry GenAI semconv (operation.name + tool.name)](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/)
- Issue #7461 (audit of MASC OTel attribute drift vs 2026 semconv)

## Test plan
- [x] `dune build --root .` green
- [x] OTel disabled (default): hook falls through `if Otel_config.enabled` check — zero behavior change
- [ ] OTel enabled (manual): scrape OTLP backend, confirm `gen_ai.tool.name` and `gen_ai.operation.name` appear on `tool/<name>` spans

## Diff stat
```
 lib/otel/otel_dispatch_hook.ml | 25 +++++++++++++++++++++++--
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)