### PR TITLE
feat(keeper): warn on unknown TOML keys (symmetric with JSON)

### DIFF
--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -139,20 +139,64 @@ persona_name = "analyst"
 
 These are still accepted by the loader, but for consistency they should be used only when a basepath-specific override is genuinely necessary.
 
-| Field | Required | Meaning |
+| Field | Type | Meaning |
 | --- | --- | --- |
-| `goal`, `short_goal`, `mid_goal`, `long_goal` | Optional | Override persona goals |
-| `will`, `needs`, `desires`, `instructions` | Optional | Override persona self-model / prompt |
-| `mention_targets` | Optional | Override persona mention aliases |
-| `policy_voice_enabled` | Optional | Override persona voice policy |
-| `proactive_enabled`, `proactive_idle_sec`, `proactive_cooldown_sec` | Optional | Override default proactive behavior |
-| `room_signal_prompt_enabled` | Optional | Override room-signal prompt behavior |
-| `allowed_paths` | Optional | Exceptional path override only; prefer empty and rely on playground default |
-| `tool_also_allow`, `also_allow`, `tool_denylist` | Optional | Policy refinements |
-| `work_discovery_enabled`, `work_discovery_sources`, `work_discovery_interval_sec`, `work_discovery_guidance` | Optional | Work-discovery policy |
-| `telemetry_feedback_enabled`, `telemetry_feedback_window_hours` | Optional | Telemetry feedback policy |
-| `max_turns_per_call`, `max_turns_per_call_scheduled_autonomous` | Optional | Per-keeper turn budget override |
-| `shards` | Optional | Tool shard override |
+| `goal`, `short_goal`, `mid_goal`, `long_goal` | string | Override persona goals |
+| `will`, `needs`, `desires`, `instructions` | string | Override persona self-model / prompt |
+| `mention_targets` | string array | Override persona mention aliases |
+| `policy_voice_enabled` | bool | Override persona voice policy |
+| `proactive_enabled` | bool | Override default proactive scheduling |
+| `proactive_idle_sec`, `proactive_cooldown_sec` | int | Proactive scheduling intervals |
+| `room_signal_prompt_enabled` | bool | Override room-signal prompt behavior |
+| `allowed_paths` | string array | Exceptional path override only; prefer empty and rely on playground default |
+| `tool_also_allow` | string array | Extra tool names added to the preset surface |
+| `also_allow` | string array | Backward-compat alias for `tool_also_allow` (will warn as "unknown key" after deprecation) |
+| `tool_denylist` | string array | Tool names blocked regardless of preset |
+| `work_discovery_enabled` | bool | Enable work discovery loop |
+| `work_discovery_sources` | string array | e.g. `["github_issues", "stale_tasks"]` |
+| `work_discovery_interval_sec` | int | Scan interval |
+| `work_discovery_guidance` | string | Hint string fed into the work-discovery prompt |
+| `telemetry_feedback_enabled` | bool | Surface recent telemetry in the keeper prompt |
+| `telemetry_feedback_window_hours` | int | Window size for telemetry summarization |
+| `max_turns_per_call`, `max_turns_per_call_scheduled_autonomous` | int | Per-keeper turn budget override |
+| `shards` | string array | Tool shard override |
+
+### Allowed value sets
+
+Enumerated fields only accept the values below. The loader rejects invalid input with an explicit error.
+
+| Field | Allowed values |
+| --- | --- |
+| `execution_scope` | `observe_only`, `workspace`, `local` |
+| `tool_preset` | `minimal`, `social`, `messaging`, `coding`, `research`, `delivery`, `full` |
+| `social_model` | `bdi_speech_v1`, `magentic_ledger_v1` (non-public: rejected when passed via tool args; TOML-only) |
+| `cascade_name` | any `<name>` such that `<name>_models` exists in `cascade.json` (e.g. `keeper_unified`, `nick0cave`) |
+
+### Removed / forbidden fields (hard-rejected)
+
+These keys are **rejected at load time** with an `Error`. They are retained only to flag drift from older configs so that stale deployments fail loud instead of silently mis-configuring keepers.
+
+| Field | Replacement / rationale |
+| --- | --- |
+| `models`, `allowed_models`, `active_model` | Models are resolved at runtime from `cascade_name` → `cascade.json`. Do not pin per-keeper. |
+| `presence_keepalive`, `presence_keepalive_sec` | Use `paused` in runtime JSON; keepalive is managed by the keepalive fiber. |
+| `trigger_mode`, `policy_action_budget` | Removed with the legacy policy engine. |
+| `initiative_scope`, `initiative_enabled`, `initiative_idle_sec`, `initiative_cooldown_sec` | Renamed to `proactive_*` (see above). |
+| `policy_mode`, `policy_shell_mode` | Removed with the legacy policy engine. |
+
+Definitive list: `removed_keeper_input_key_names` in [`lib/keeper/keeper_config.ml`](../lib/keeper/keeper_config.ml).
+
+### Unknown-key warning
+
+Keys under `[keeper]` that are neither canonical (above) nor hard-rejected are **silently ignored by the loader, but a warning is emitted**:
+
+```text
+keeper TOML <path> has unknown keys: keeper.room_scope, keeper.scope_kind
+```
+
+Historically, dead config like `room_scope` and `scope_kind` accumulated here. Treat these warnings as drift signals and clean up the TOML. The warning does not block boot.
+
+Definitive canonical list: `canonical_keeper_toml_key_names` in [`lib/keeper/keeper_types_profile.ml`](../lib/keeper/keeper_types_profile.ml).
 
 ## 3. Keeper Runtime State
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -617,6 +617,17 @@ Keeper 설정은 아래 소스에서 공급된다. 상세 우선순위는
 현재 구현에는 compatibility 이유로 authored 필드가 `.masc/keepers/<name>.json`에
 materialize될 수 있지만, 정식 edit surface는 `profile.json`과 `keeper.toml`이다.
 
+`keeper.toml`의 **전체 스펙 필드 목록**은
+[`docs/KEEPER-FILE-MODEL.md` §2 Keeper Declaration](./KEEPER-FILE-MODEL.md#2-keeper-declaration)을 참조한다. 요약:
+
+- **Canonical minimal**: `[keeper]` 테이블에 `persona_name`만. 나머지는 persona 기본값에서 해석.
+- **Overlay fields**: `goal`, `tool_preset`, `tool_also_allow`, `cascade_name`, `execution_scope` 등 배치별 override 전용.
+- **Allowed value sets**: `execution_scope ∈ {observe_only, workspace, local}`, `tool_preset ∈ {minimal, social, messaging, coding, research, delivery, full}`, `social_model ∈ {bdi_speech_v1, magentic_ledger_v1}`, `cascade_name`은 `cascade.json`에 `<name>_models` 키로 존재해야 함.
+- **Removed / hard-rejected**: `models`, `allowed_models`, `active_model`, `presence_keepalive*`, `trigger_mode`, `initiative_*`, `policy_mode`, `policy_shell_mode`. 로드 시 에러로 실패한다.
+- **Unknown keys**: canonical/removed 둘 다 아닌 key는 **boot 시 warning** 후 무시된다 (`keeper TOML <path> has unknown keys: ...`). 과거에 `room_scope`/`scope_kind` 같은 dead config가 축적된 적이 있으므로 warning을 발견하면 정리한다.
+
+Definitive source는 코드의 `canonical_keeper_toml_key_names` (`lib/keeper/keeper_types_profile.ml`)와 `removed_keeper_input_key_names` (`lib/keeper/keeper_config.ml`)다.
+
 운영 기준 active config root는 `MASC_CONFIG_DIR`가 있으면 그 디렉토리이고, 없으면 `<MASC_BASE_PATH>/.masc/config`다. `repo/config`는 체크인된 seed source이며 live root가 아니다. 헷갈리면 `main_eio.exe doctor --base-path ...`를 먼저 사용한다. low-level resolver에는 추가 fallback이 있지만, 운영 진단 기준은 `docs/CONFIG-DOCTOR.md`를 따른다.
 
 ### 8.2 Template 변경 반영

--- a/lib/keeper/keeper_types_profile.ml
+++ b/lib/keeper/keeper_types_profile.ml
@@ -368,6 +368,74 @@ let profile_defaults_of_toml (doc : Keeper_toml_loader.toml_doc)
       })
     result
 
+(** Canonical TOML key names recognized by [profile_defaults_of_toml].
+    Keys outside this set under [[keeper]] (or any other table) are silently
+    ignored by the loader, which historically let dead config accumulate
+    (e.g. legacy [room_scope], [scope_kind]).  [warn_unknown_keeper_toml_keys]
+    uses this list to surface drift on boot, symmetric with
+    [warn_unknown_keeper_meta_keys] on the JSON side.
+
+    [also_allow] is retained as a backward-compat alias for
+    [tool_also_allow] — see the fallback in [profile_defaults_of_toml]. *)
+let canonical_keeper_toml_key_names =
+  [ "name"
+  ; "persona_name"
+  ; "goal"
+  ; "short_goal"
+  ; "mid_goal"
+  ; "long_goal"
+  ; "will"
+  ; "needs"
+  ; "desires"
+  ; "instructions"
+  ; "policy_voice_enabled"
+  ; "mention_targets"
+  ; "proactive_enabled"
+  ; "proactive_idle_sec"
+  ; "proactive_cooldown_sec"
+  ; "room_signal_prompt_enabled"
+  ; "shards"
+  ; "allowed_paths"
+  ; "execution_scope"
+  ; "tool_preset"
+  ; "tool_also_allow"
+  ; "also_allow"
+  ; "tool_denylist"
+  ; "work_discovery_enabled"
+  ; "work_discovery_sources"
+  ; "work_discovery_interval_sec"
+  ; "work_discovery_guidance"
+  ; "telemetry_feedback_enabled"
+  ; "telemetry_feedback_window_hours"
+  ; "max_turns_per_call"
+  ; "max_turns_per_call_scheduled_autonomous"
+  ; "social_model"
+  ; "cascade_name"
+  ; "models"
+  ]
+
+(** Pure detector: returns TOML keys that [profile_defaults_of_toml] does not
+    consume.  Exposed separately from the logging wrapper so tests can
+    assert on the key list without mocking the Log subsystem. *)
+let detect_unknown_keeper_toml_keys (doc : Keeper_toml_loader.toml_doc) =
+  let known =
+    canonical_keeper_toml_key_names
+    |> List.map (fun k -> "keeper." ^ k)
+  in
+  doc
+  |> List.map fst
+  |> List.filter (fun key -> not (List.mem key known))
+  |> dedupe_keep_order
+
+let warn_unknown_keeper_toml_keys ~path (doc : Keeper_toml_loader.toml_doc) =
+  match detect_unknown_keeper_toml_keys doc with
+  | [] -> ()
+  | unknown ->
+    Log.Keeper.warn
+      "keeper TOML %s has unknown keys: %s"
+      path
+      (String.concat ", " unknown)
+
 let load_keeper_toml (path : string)
     : (string * keeper_profile_defaults, string) result =
   match Safe_ops.read_file_safe path with
@@ -379,6 +447,7 @@ let load_keeper_toml (path : string)
       match profile_defaults_of_toml doc with
       | Error e -> Error (Printf.sprintf "%s: %s" path e)
       | Ok defaults ->
+        warn_unknown_keeper_toml_keys ~path doc;
         let name =
           match Keeper_toml_loader.toml_string_opt doc "keeper.name" with
           | Some n when n <> "" -> n

--- a/test/test_keeper_toml.ml
+++ b/test/test_keeper_toml.ml
@@ -834,6 +834,52 @@ let test_persona_resolver_rejects_non_public_social_model_arg () =
       check bool "mentions social_model" true (contains_substring e "social_model")
 
 (* ================================================================ *)
+(* Unknown-key detection                                             *)
+(* ================================================================ *)
+
+let test_detect_unknown_keys_empty_when_all_canonical () =
+  let input = {|
+[keeper]
+goal = "canonical"
+mention_targets = ["a", "b"]
+tool_preset = "coding"
+tool_also_allow = ["x"]
+cascade_name = "keeper_unified"
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "no unknown keys" [] unknown
+
+let test_detect_unknown_keys_flags_legacy_dead_config () =
+  let input = {|
+[keeper]
+goal = "g"
+room_scope = "current"
+scope_kind = "local"
+mention_targets = ["a"]
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "surfaces dead config"
+      ["keeper.room_scope"; "keeper.scope_kind"] unknown
+
+let test_detect_unknown_keys_accepts_also_allow_alias () =
+  let input = {|
+[keeper]
+goal = "g"
+also_allow = ["x"]
+|} in
+  match TL.parse_toml input with
+  | Error e -> fail e
+  | Ok doc ->
+    let unknown = KTP.detect_unknown_keeper_toml_keys doc in
+    check (list string) "also_allow is recognized alias" [] unknown
+
+(* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
 
@@ -915,6 +961,15 @@ let () =
             test_profile_max_turns_defaults_when_absent;
           test_case "max_turns rejects out-of-range values" `Quick
             test_profile_max_turns_rejects_out_of_range;
+        ] );
+      ( "unknown_keys",
+        [
+          test_case "empty when all canonical" `Quick
+            test_detect_unknown_keys_empty_when_all_canonical;
+          test_case "flags legacy dead config" `Quick
+            test_detect_unknown_keys_flags_legacy_dead_config;
+          test_case "also_allow alias accepted" `Quick
+            test_detect_unknown_keys_accepts_also_allow_alias;
         ] );
       ( "file_loading",
         [


### PR DESCRIPTION
## 왜 (Why)

`profile_defaults_of_toml`은 인식 key만 `List.assoc_opt`로 개별 조회하고, **알 수 없는 key는 조용히 무시**한다. JSON 쪽은 `warn_unknown_keeper_meta_keys`로 경고하지만 TOML 쪽에는 없었다. 이 비대칭성 때문에 live keeper TOML 에 legacy dead config가 축적:

- `room_scope = "current"` — 11/12 파일
- `scope_kind = "local"|"global"` — 4/12 파일
- `also_allow` alias/`tool_also_allow` canonical 혼재

`~/me/.masc/config/keepers/` 의 로컬 파일들은 별도로 정리 완료. 재발 방지를 위해 loader에 경고를 추가한다.

## 무엇을 (What)

- `canonical_keeper_toml_key_names`: SSOT 리스트 (`profile_defaults_of_toml`이 실제로 소비하는 key + `also_allow` backward-compat alias)
- `detect_unknown_keeper_toml_keys`: 순수 함수 — `[keeper.X]` 중 canonical 에 없는 key 반환
- `warn_unknown_keeper_toml_keys`: `Log.Keeper.warn` wrapper
- `load_keeper_toml`에서 `profile_defaults_of_toml` 성공 후 호출 (Error 는 기존 경로 그대로 reject)

## 영향 (Scope)

- 기존 동작: **변화 없음**. Warning 만 추가.
- `removed_keeper_input_key_names` (models/initiative_*/presence_*/policy_* 등) 은 여전히 hard-reject (변경 없음).
- `also_allow` alias 는 canonical에 포함되어 경고 안 남. 제거는 별도 PR로 단계 분리.

## 테스트

\`\`\`
dune exec test/test_keeper_toml.exe
...
[OK] unknown_keys 0  empty when all canonical.
[OK] unknown_keys 1  flags legacy dead config.
[OK] unknown_keys 2  also_allow alias accepted.
...
Test Successful in 0.011s. 59 tests run.
\`\`\`

## 검증 계획

- [x] `dune build` clean
- [x] `dune exec test/test_keeper_toml.exe` 59/59 pass
- [ ] CI green
- [ ] 실제 부팅 시 clean TOML 에서 warn 0건, dirty TOML 주입 시 warn 1건 수동 확인

## 후속

- 6개월 후 `also_allow` backward-compat alias 제거 고려 (breaking change 전 warning period 확보).

🤖 Generated with [Claude Code](https://claude.com/claude-code)