### PR TITLE
chore(prompts): drop hardcoded jeong-sik/masc-mcp primary-repo metadata

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -12,7 +12,7 @@ Before any file or path operation, follow this order:
 4. Then proceed with the file operation.
 
 NEVER operate outside your playground. ALL tool calls that accept `cwd` or `path` MUST resolve under `.masc/playground/{your-name}/`. The server blocks violations, and each rejection wastes your turn budget.
-NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). The primary repo is jeong-sik/masc-mcp; the full allow-list lives in `config/tool_policy.toml` under `[git_clone] allowed_orgs`.
+NEVER guess or invent PR numbers, issue numbers, task IDs, or repository names. Always query first (keeper_github, keeper_tasks_list). Allowed orgs/repos live in `config/tool_policy.toml` under `[git_clone]`.
 NEVER use pipes (|), chaining (&&, ||, ;), or redirects (>, >>) in keeper_bash. ONE command per call.
 NEVER request files without verifying they exist via keeper_shell op=ls.
 When a tool call fails, read the error message carefully. Do not retry with the same arguments.

--- a/config/prompts/keeper.world.md
+++ b/config/prompts/keeper.world.md
@@ -38,10 +38,8 @@ Including the playground prefix causes path doubling errors. The tool adds the p
 
 ## Project
 
-- Primary GitHub repository: jeong-sik/masc-mcp. Additional repos may be allowed via `config/tool_policy.toml` under `[git_clone] allowed_orgs` — never invent an org/repo outside that list.
-- To clone the primary project: keeper_shell with op=git_clone, url=https://github.com/jeong-sik/masc-mcp
-- To check open PRs: keeper_github with cmd="pr list --repo jeong-sik/masc-mcp"
-- To check issues: keeper_github with cmd="issue list --repo jeong-sik/masc-mcp"
+- Allowed GitHub orgs/repos come from `config/tool_policy.toml` `[git_clone]` (`allowed_orgs`, `denied_repos`). Query that file before cloning; never invent an org/repo outside the list.
+- The task you claim tells you which repo to work in. If unclear, ask on the board before cloning.
 
 ## Environment
 


### PR DESCRIPTION
## Why

`config/prompts/keeper.world.md`의 `## Project` 섹션은 **jeong-sik/masc-mcp을 유일한 primary repo**로 선언하고 clone URL, PR list, issue list gh 명령을 하드코딩하고 있었습니다. `keeper.capabilities.md`도 같은 주장을 반복합니다.

두 가지 문제:
1. `[git_clone] allowed_orgs`가 확장되어도 프롬프트는 masc-mcp만 가리켜 keeper 선택 편향이 고정됩니다.
2. SSOT가 둘(프롬프트 문구 ↔ tool_policy.toml)이라 drift가 필연.

## What

- `keeper.world.md` `## Project`: 4줄 하드코딩 → "allowed orgs/repos는 tool_policy.toml을 참조" + "task가 repo를 알려준다"
- `keeper.capabilities.md`: "primary repo is jeong-sik/masc-mcp" 제거, tool_policy.toml 참조만 남김

예시 경로(`repos/masc-mcp/lib/foo.ml`)는 path-doubling 규칙의 구체적 예로만 남김 — metadata 주장이 아닌 형식 설명.

## Follow-up

후속 PR(B)에서 `[git_clone] allowed_orgs`/`denied_repos`를 런타임에 읽어 system prompt에 inject하는 구조 변경을 제안합니다. 이 PR은 하드코딩 제거까지만.

## Test plan
- [ ] keeper autoboot 후 `keeper.world.md` / `keeper.capabilities.md` system prompt에 drift 없음
- [ ] CI markdown lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)