### PR TITLE
feat(dashboard): session trace improvements — reverse sort, full I/O, structured OAS rendering

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1370,12 +1370,19 @@ export function fetchKeeperTrajectory(
   name: string,
   limit?: number,
   includeThinking = true,
+  fullOutput = false,
 ): Promise<TrajectoryResponse> {
   const params = new URLSearchParams()
   if (limit != null) params.set('limit', String(limit))
   // Always send include_thinking explicitly — backend defaults to false,
   // so omitting the param means "don't include".
   params.set('include_thinking', includeThinking ? 'true' : 'false')
+  // Request full output for session trace detail view.
+  // Backend caps at 10000 for results, 50000 for thinking content.
+  if (fullOutput) {
+    params.set('result_max_len', '10000')
+    params.set('content_max_len', '50000')
+  }
   const qs = params.toString()
   return get<TrajectoryResponse>(
     `/api/v1/keepers/${encodeURIComponent(name)}/trajectory${qs ? `?${qs}` : ''}`,

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -265,20 +265,130 @@ function ThinkingDetail({ event }: { event: UnifiedTraceEvent }) {
 }
 
 function OasDetail({ event }: { event: UnifiedTraceEvent }) {
-  const detailRows = Object.entries(event.detail)
+  const d = event.detail
+
+  // ── OAS tool call ──
+  if (event.kind === 'oas_tool') {
+    const phase = typeof d.phase === 'string' ? d.phase : ''
+    const toolName = typeof d.tool_name === 'string' ? d.tool_name : 'unknown'
+    const phaseLabel = phase === 'called' ? '호출' : phase === 'completed' ? '완료' : phase
+    const phaseColor = phase === 'called' ? 'text-[var(--accent)]' : 'text-[var(--ok)]'
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--white-6)] space-y-1">
+        <div class="flex items-center gap-2 text-[12px]">
+          <span class="text-[var(--text-dim)]">단계:</span>
+          <span class="font-mono font-semibold ${phaseColor}">${phaseLabel}</span>
+        </div>
+        <div class="flex items-center gap-2 text-[12px]">
+          <span class="text-[var(--text-dim)]">도구:</span>
+          <span class="font-mono text-[var(--text-body)]">${toolName}</span>
+        </div>
+      </div>
+    `
+  }
+
+  // ── OAS turn ──
+  if (event.kind === 'oas_turn') {
+    const phase = typeof d.phase === 'string' ? d.phase : ''
+    const turn = d.turn
+    const phaseLabel = phase === 'started' ? '시작' : phase === 'completed' ? '완료' : phase
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--white-6)]">
+        <div class="flex items-center gap-2 text-[12px]">
+          <span class="text-[var(--text-dim)]">턴 ${turn != null ? String(turn) : '-'}:</span>
+          <span class="font-mono font-semibold text-[var(--text-body)]">${phaseLabel}</span>
+        </div>
+      </div>
+    `
+  }
+
+  // ── OAS context compaction ──
+  if (event.kind === 'oas_context') {
+    const before = typeof d.before_tokens === 'number' ? d.before_tokens : null
+    const after = typeof d.after_tokens === 'number' ? d.after_tokens : null
+    const saved = before != null && after != null ? before - after : null
+    const ratio = before != null && after != null && before > 0 ? ((saved ?? 0) / before * 100) : null
+    const compactPhase = typeof d.phase === 'string' ? d.phase : ''
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(56,189,248,0.04)] border border-[rgba(56,189,248,0.15)] space-y-2">
+        <div class="flex items-center gap-3 text-[12px]">
+          ${before != null ? html`<span><span class="text-[var(--text-dim)]">Before:</span> <span class="font-mono">${before.toLocaleString()}</span></span>` : null}
+          <span class="text-[var(--text-dim)]">→</span>
+          ${after != null ? html`<span><span class="text-[var(--text-dim)]">After:</span> <span class="font-mono">${after.toLocaleString()}</span></span>` : null}
+        </div>
+        ${saved != null && saved > 0 ? html`
+          <div class="flex items-center gap-2">
+            <div class="flex-1 h-2 bg-[var(--white-8)] rounded-full overflow-hidden">
+              <div class="h-full bg-[#38bdf8] rounded-full" style="width: ${Math.min(ratio ?? 0, 100).toFixed(1)}%"></div>
+            </div>
+            <span class="text-[10px] font-mono text-[#38bdf8]">-${saved.toLocaleString()}tok (${(ratio ?? 0).toFixed(0)}%)</span>
+          </div>
+        ` : null}
+        ${compactPhase ? html`<div class="text-[10px] text-[var(--text-dim)]">단계: ${compactPhase}</div>` : null}
+      </div>
+    `
+  }
+
+  // ── Lifecycle with durable_kind ──
+  const durableKind = typeof d.durable_kind === 'string' ? d.durable_kind : ''
+
+  if (durableKind === 'llm_request') {
+    const model = typeof d.model === 'string' ? d.model : 'unknown'
+    const inputTokens = typeof d.input_tokens === 'number' ? d.input_tokens : 0
+    const turn = d.turn
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(56,189,248,0.04)] border border-[rgba(56,189,248,0.12)] space-y-1">
+        <div class="flex items-center gap-3 text-[12px]">
+          <span><span class="text-[var(--text-dim)]">모델:</span> <span class="font-mono">${model}</span></span>
+          <span><span class="text-[var(--text-dim)]">입력:</span> <span class="font-mono">${inputTokens.toLocaleString()}tok</span></span>
+          ${turn != null ? html`<span><span class="text-[var(--text-dim)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
+        </div>
+      </div>
+    `
+  }
+
+  if (durableKind === 'llm_response') {
+    const outputTokens = typeof d.output_tokens === 'number' ? d.output_tokens : 0
+    const stopReason = typeof d.stop_reason === 'string' ? d.stop_reason : ''
+    const durationMs = typeof d.duration_ms === 'number' ? d.duration_ms : null
+    const turn = d.turn
+    const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--ok)]' : 'text-[var(--warn)]'
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(34,211,238,0.04)] border border-[rgba(34,211,238,0.12)] space-y-1">
+        <div class="flex items-center gap-3 text-[12px] flex-wrap">
+          <span><span class="text-[var(--text-dim)]">출력:</span> <span class="font-mono">${outputTokens.toLocaleString()}tok</span></span>
+          <span><span class="text-[var(--text-dim)]">종료:</span> <span class="font-mono ${stopColor}">${stopReason}</span></span>
+          ${durationMs != null ? html`<span><span class="text-[var(--text-dim)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span></span>` : null}
+          ${turn != null ? html`<span><span class="text-[var(--text-dim)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
+        </div>
+      </div>
+    `
+  }
+
+  if (durableKind === 'error_occurred') {
+    const domain = typeof d.error_domain === 'string' ? d.error_domain : 'unknown'
+    const errorDetail = typeof d.detail === 'string' ? d.detail : ''
+    return html`
+      <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(239,68,68,0.04)] border border-[rgba(239,68,68,0.15)] space-y-1">
+        <div class="text-[12px]"><span class="text-[var(--text-dim)]">도메인:</span> <span class="font-mono text-[var(--bad)]">${domain}</span></div>
+        ${errorDetail ? html`<div class="text-[11px] font-mono text-[var(--text-body)] break-all">${errorDetail}</div>` : null}
+      </div>
+    `
+  }
+
+  // ── Fallback: generic detail rows ──
+  const detailRows = Object.entries(d)
     .filter(([, value]) => value != null && value !== '')
     .map(([label, value]) => ({ label, value: typeof value === 'string' ? value : JSON.stringify(value) }))
   if (detailRows.length === 0) return null
   return html`
-    <div class="mt-2 grid gap-2">
-      <div class="grid gap-1.5 px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--white-6)]">
-        ${detailRows.map(row => html`
-          <div class="flex items-start gap-2 text-[12px] leading-relaxed">
-            <span class="min-w-[92px] text-[var(--text-dim)] font-mono">${row.label}</span>
-            <span class="text-[var(--text-body)] font-mono break-all">${row.value}</span>
-          </div>
-        `)}
-      </div>
+    <div class="mt-2 grid gap-1.5 px-3 py-2 rounded-lg bg-[var(--white-3)] border border-[var(--white-6)]">
+      ${detailRows.map(row => html`
+        <div class="flex items-start gap-2 text-[12px] leading-relaxed">
+          <span class="min-w-[92px] text-[var(--text-dim)] font-mono">${row.label}</span>
+          <span class="text-[var(--text-body)] font-mono break-all">${row.value}</span>
+        </div>
+      `)}
     </div>
   `
 }
@@ -313,6 +423,7 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
     || event.kind === 'oas_tool'
     || event.kind === 'oas_turn'
     || event.kind === 'oas_context'
+    || (event.kind === 'lifecycle' && event.detail.durable_kind)
 
   const row = html`
     <div class="flex items-start gap-3 py-2 px-3 rounded-lg ${gateRejected ? 'opacity-50' : ''}">
@@ -384,6 +495,7 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
         ${event.kind === 'task' ? html`<${TaskDetail} event=${event} />` : null}
         ${event.kind === 'thinking' ? html`<${ThinkingDetail} event=${event} />` : null}
         ${event.kind === 'oas_tool' || event.kind === 'oas_turn' || event.kind === 'oas_context'
+          || (event.kind === 'lifecycle' && event.detail.durable_kind)
           ? html`<${OasDetail} event=${event} />`
           : null}
       </div>

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -115,8 +115,9 @@ describe('appendLiveToolCall', () => {
 
     const events = getTraceEvents('keeper-a')
     expect(events).toHaveLength(2)
-    expect(events[0]!.toolName).toBe('keeper_fs_read')
-    expect(events[1]!.toolName).toBe('keeper_edit')
+    // Newest-first: tsUnix=1712400002 (keeper_edit) comes first
+    expect(events[0]!.toolName).toBe('keeper_edit')
+    expect(events[1]!.toolName).toBe('keeper_fs_read')
   })
 
   it('preserves existing events when appending', () => {
@@ -148,8 +149,9 @@ describe('appendLiveToolCall', () => {
 
     const events = getTraceEvents('keeper-a')
     expect(events).toHaveLength(2)
-    expect(events[0]!.kind).toBe('broadcast')
-    expect(events[1]!.kind).toBe('tool_call')
+    // Newest-first: tool_call (tsUnix=1712400000) > broadcast (ts=1712399000000)
+    expect(events[0]!.kind).toBe('tool_call')
+    expect(events[1]!.kind).toBe('broadcast')
   })
 })
 

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -256,7 +256,7 @@ function mergeTraceEvents(
   live: UnifiedTraceEvent[],
 ): UnifiedTraceEvent[] {
   const merged = [...historical, ...live]
-  merged.sort((a, b) => a.ts - b.ts)
+  merged.sort((a, b) => b.ts - a.ts)
   const seen = new Set<string>()
   return merged.filter(event => {
     if (seen.has(event.id)) return false
@@ -433,7 +433,7 @@ export async function loadSessionTrace(agentName: string, isKeeper: boolean): Pr
   try {
     const timelinePromise = fetchAgentTimeline(agentName, TIMELINE_HOURS, TIMELINE_LIMIT)
     const trajectoryPromise = isKeeper
-      ? fetchKeeperTrajectory(agentName, TRAJECTORY_LIMIT)
+      ? fetchKeeperTrajectory(agentName, TRAJECTORY_LIMIT, true, true)
       : Promise.resolve(null)
 
     const [timeline, trajectory] = await Promise.all([timelinePromise, trajectoryPromise])

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -68,7 +68,7 @@ function TraceSummaryBar({ summary }: { summary: TraceSummary }) {
 function LiveIndicator({ events }: { events: readonly { ts: number }[] }) {
   if (events.length === 0) return null
 
-  const lastEvt = events[events.length - 1]
+  const lastEvt = events[0]
   if (!lastEvt) return null
   const isRecent = Date.now() - lastEvt.ts < 60_000
   if (!isRecent) return null
@@ -113,14 +113,14 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
   const events = getFilteredEvents(agentName)
   const summary = getTraceSummary(agentName)
 
-  // Auto-scroll to bottom when new events arrive
+  // Auto-scroll to top when new events arrive (newest-first order)
   const prevCountRef = useRef(0)
   useEffect(() => {
     if (events.length > prevCountRef.current && listRef.current) {
       const el = listRef.current
-      const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 100
-      if (isNearBottom) {
-        el.scrollTop = el.scrollHeight
+      const isNearTop = el.scrollTop < 100
+      if (isNearTop) {
+        el.scrollTop = 0
       }
     }
     prevCountRef.current = events.length

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -557,6 +557,11 @@ let handle_keeper_get_subroutes state req request reqd =
              ~default:2000
            |> max 0 |> min 10000
          in
+         let content_max_len =
+           Server_utils.int_query_param req "content_max_len"
+             ~default:Trajectory.default_thinking_truncation
+           |> max 0 |> min 50000
+         in
          let include_thinking =
            Server_utils.bool_query_param req "include_thinking"
              ~default:false
@@ -593,7 +598,7 @@ let handle_keeper_get_subroutes state req request reqd =
            ("total_entries", `Int total);
            ("showing", `Int (List.length recent));
            ("entries", `List (List.map
-             (Trajectory.trajectory_line_to_json ~result_max_len) recent));
+             (Trajectory.trajectory_line_to_json ~result_max_len ~content_max_len) recent));
          ] in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd)

--- a/lib/trajectory.mli
+++ b/lib/trajectory.mli
@@ -75,6 +75,7 @@ val gate_decision_to_json : gate_decision -> Yojson.Safe.t
 val outcome_to_json : trajectory_outcome -> Yojson.Safe.t
 val outcome_to_string : trajectory_outcome -> string
 val default_result_truncation : int
+val default_thinking_truncation : int
 val entry_to_json : ?result_max_len:int -> tool_call_entry -> Yojson.Safe.t
 val thinking_entry_to_json : ?content_max_len:int -> thinking_entry -> Yojson.Safe.t
 val trajectory_line_to_json : ?result_max_len:int -> ?content_max_len:int -> trajectory_line -> Yojson.Safe.t


### PR DESCRIPTION
## Summary

- **정렬 순서 변경**: 세션 트레이스 이벤트를 최신순(newest-first)으로 정렬, auto-scroll도 top 방향으로 변경
- **Full I/O 가시성**: tool call result truncation을 500→10000자, thinking content를 2000→50000자로 확대
  - Backend에 `content_max_len` 쿼리 파라미터 추가 (0~50000 범위)
  - `Trajectory.default_thinking_truncation`을 `.mli`에 노출
- **OAS 이벤트 구조화 렌더링**: raw key-value dump를 이벤트 타입별 구조화된 뷰로 교체
  - `oas_tool`: phase(called/completed) + tool_name
  - `oas_turn`: phase(started/completed) + turn number
  - `oas_context`: before/after tokens + compaction ratio progress bar
  - `lifecycle` + `llm_request`: model + input_tokens + turn
  - `lifecycle` + `llm_response`: output_tokens + stop_reason + duration
  - `lifecycle` + `error_occurred`: error_domain + detail
- **Lifecycle detail 확장**: `durable_kind`이 있는 lifecycle 이벤트의 detail expansion 활성화

## Test plan

- [ ] 대시보드 접속 → keeper 선택 → session trace 확인
- [ ] 최신 이벤트가 상단에 표시되는지 확인
- [ ] tool_call expand → 500자 이상 결과가 잘리지 않고 표시되는지 확인
- [ ] OAS 이벤트 (oas_tool, oas_turn, oas_context) 구조화되어 표시되는지 확인
- [ ] thinking expand → 전체 내용 표시되는지 확인
- [ ] 필터 동작 확인 (기존 카테고리 필터)
- [ ] `dune build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)