### PR TITLE
feat(cascade): bump gemini auto default to gemini-3-flash-preview

### DIFF
--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -144,7 +144,7 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `MASC_SPAWN_CACHE_POLICY` | string | `"safe_only"` | Spawn 캐시 정책 (`off`/`safe_only`) |
 | `MASC_GLM_DEFAULT_MODEL` | string | `"glm-4.7"` | GLM 기본 모델 |
 | `MASC_GLM_FLASH_MODEL` | string | `"glm-4.7-flash"` | GLM flash 모델 |
-| `MASC_GEMINI_DEFAULT_MODEL` | string | `"gemini-2.5-pro"` | Gemini 기본 모델 |
+| `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | Gemini 기본 모델 (cascade_model_resolve.ml 이 읽는 실제 env var 이름; 2026-04-16 이전 이 문서는 `MASC_GEMINI_DEFAULT_MODEL` 로 잘못 표기) |
 | `MASC_GEMINI_FLASH_MODEL` | string | `"gemini-2.5-flash"` | Gemini flash 모델 |
 | `MASC_CLAUDE_DEFAULT_MODEL` | string | `"claude-sonnet-4-6"` | Claude 기본 모델 |
 | `MASC_OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | OpenAI 기본 모델 |
@@ -331,7 +331,7 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
 | `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
 | `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
-| `gemini` | `Gemini` | `MASC_GEMINI_DEFAULT_MODEL` |
+| `gemini` | `Gemini` | `GEMINI_DEFAULT_MODEL` |
 | `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |
 
 ### 7.3 Per-cascade 추론 파라미터

--- a/lib/cascade/cascade_model_resolve.ml
+++ b/lib/cascade/cascade_model_resolve.ml
@@ -64,7 +64,13 @@ let resolve_auto_model_id provider_name model_id =
   | "glm" -> resolve_glm_model_id model_id
   | "glm-coding" -> resolve_glm_coding_model_id model_id
   | "gemini" ->
-    if model_id = "auto" then env_or "gemini-2.5-flash" "GEMINI_DEFAULT_MODEL"
+    (* Default bumped from gemini-2.5-flash to gemini-3-flash-preview on
+       2026-04-16 (PR C Cadd follow-up). Capabilities are inherited via
+       the `starts_with "gemini-3"` prefix matcher in
+       oas/lib/llm_provider/capabilities.ml:269 (1M context, tools,
+       parallel tool calls). Override with GEMINI_DEFAULT_MODEL if you
+       still need the 2.5 line. *)
+    if model_id = "auto" then env_or "gemini-3-flash-preview" "GEMINI_DEFAULT_MODEL"
     else model_id
   | "claude" ->
     if model_id = "auto" then env_or "claude-sonnet-4-6-20250514" "ANTHROPIC_DEFAULT_MODEL"


### PR DESCRIPTION
## Context

OAS PR [#968](https://github.com/jeong-sik/oas/pull/968) (PR C Cadd) 이 `gemini-3-*` preview IDs를 OAS capability 인벤토리에 명시적으로 등록했다. 그 follow-up으로 masc-mcp cascade 의 `gemini:auto` 해석 기본값도 3-계로 승격한다.

## Changes

**`lib/cascade/cascade_model_resolve.ml:66-76`**

```diff
 | "gemini" ->
-    if model_id = "auto" then env_or "gemini-2.5-flash" "GEMINI_DEFAULT_MODEL"
+    (* Default bumped from gemini-2.5-flash to gemini-3-flash-preview ... *)
+    if model_id = "auto" then env_or "gemini-3-flash-preview" "GEMINI_DEFAULT_MODEL"
     else model_id
```

## Scope / 영향 분석

| 경로 | 영향 |
|------|------|
| `config/cascade.json` production cascade | **없음**. glm-coding/ollama 만 사용, gemini 참조 0건. |
| 명시적 \`gemini:<model>\` 지정 | **없음**. 정확한 model_id를 넘기는 경우 resolver 가 그대로 통과. |
| \`gemini:auto\` 해석 경로 | **변경**. lib/ 와 test/ 에 grep 결과 명시적 소비자 0건 (playground/ad-hoc 스크립트만 영향 가능). |
| \`GEMINI_DEFAULT_MODEL\` env var | **보존**. 2.5 필요 시 env 로 override. |

Capabilities 는 OAS \`capabilities.ml:269\` 의 \`starts_with "gemini-3"\` prefix matcher 로 상속 (1M context, tools, parallel tool calls) — OAS #968 의 inline 테스트로 contract 입증.

## Pre-existing Drift (이 PR 에서 안 고침)

- \`docs/spec/14-configuration.md:147\` 가 \`MASC_GEMINI_DEFAULT_MODEL\` 이란 env var 을 문서화하지만 **코드 어디에서도 읽지 않는다** (\`rg MASC_GEMINI_DEFAULT_MODEL lib/\` 매치 0건). 실제 읽히는 변수명은 \`GEMINI_DEFAULT_MODEL\` (라인 67).
- 이 env-var-name drift 는 pre-existing 이며 문서 정리만으로 해결 가능. 본 PR 의 scope 가 아님 — 별도 docs cleanup PR 로 분리.

## Verification

- \`dune build --root .\` → exit 0
- \`dune runtest --root . lib/cascade\` → exit 0
- \`rg -n "gemini:auto\\|gemini.*auto" test/\` → 매치 0 건 (breaking 없음)

## Follow-ups

- **OAS 쪽 Gemini pricing** — pricing.ml 에 Gemini 계열 (2.5 및 3) 가격이 전무. cost 계산이 $0 으로 떨어짐. 별도 PR.
- **docs env-var 이름 정정** — \`MASC_GEMINI_DEFAULT_MODEL\` → \`GEMINI_DEFAULT_MODEL\` 로 docs/spec/14-configuration.md 라인 147, 334 정정.
- **Cdeprecate** — gemini-2.5-* 사용 시 \`Eio.traceln\` one-shot warn, 1주 뒤.
- **Cremove** — production gemini-2.5 참조 전면 제거, 2주 뒤.