### PR TITLE
feat(cascade): Phase B stateful strategies (priority_tier / sticky / round_robin)

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -713,7 +713,19 @@ let resolve_strategy ?config_path ~name () =
                 ~config_path:path ~name in
     let kind = parse_kind_or_default ~name cfg.kind in
     let cycle = cycle_policy_from_loader cfg in
-    { Cascade_strategy.kind; cycle }
+    let tiers =
+      match kind, cfg.tiers with
+      | Cascade_strategy.Priority_tier, Some t -> t
+      | Cascade_strategy.Priority_tier, None -> []  (* misconfig → empty tier *)
+      | _, _ -> []
+    in
+    let sticky_ttl_ms =
+      match kind, cfg.sticky_ttl_ms with
+      | Cascade_strategy.Sticky, Some n -> n
+      | Cascade_strategy.Sticky, None -> Cascade_strategy.default_sticky_ttl_ms
+      | _, _ -> 0
+    in
+    { Cascade_strategy.kind; cycle; tiers; sticky_ttl_ms }
 
 let resolve_ollama_max_concurrent ?config_path ~name () =
   match config_path with

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -215,6 +215,8 @@ type strategy_config = {
   backoff_base_ms : int option;
   backoff_cap_ms : int option;
   ollama_max_concurrent : int option;
+  tiers : string list list option;
+  sticky_ttl_ms : int option;
 }
 
 let read_string_field json key =
@@ -223,12 +225,38 @@ let read_string_field json key =
   | `String s when String.trim s <> "" -> Some (String.trim s)
   | _ -> None
 
+(* Read a [string list list] from a JSON [list of list of string].
+   Returns [None] when the key is missing or any element has the
+   wrong shape; tier configuration must be all-or-nothing to avoid
+   silent misroutes. *)
+let read_tiers_field json key =
+  let open Yojson.Safe.Util in
+  match json |> member key with
+  | `Null -> None
+  | `List outer ->
+    let parse_tier = function
+      | `List inner ->
+        let strs = List.filter_map (function
+            | `String s when String.trim s <> "" -> Some (String.trim s)
+            | _ -> None) inner
+        in
+        if List.length strs = List.length inner && strs <> [] then Some strs
+        else None
+      | _ -> None
+    in
+    let tiers = List.filter_map parse_tier outer in
+    if List.length tiers = List.length outer && tiers <> [] then Some tiers
+    else None
+  | _ -> None
+
 let empty_strategy_config = {
   kind = None;
   max_cycles = None;
   backoff_base_ms = None;
   backoff_cap_ms = None;
   ollama_max_concurrent = None;
+  tiers = None;
+  sticky_ttl_ms = None;
 }
 
 let resolve_strategy_config ~config_path ~name =
@@ -242,4 +270,6 @@ let resolve_strategy_config ~config_path ~name =
       backoff_cap_ms = read_int_field json (name ^ "_backoff_cap_ms");
       ollama_max_concurrent =
         read_int_field json (name ^ "_ollama_max_concurrent");
+      tiers = read_tiers_field json (name ^ "_tiers");
+      sticky_ttl_ms = read_int_field json (name ^ "_sticky_ttl_ms");
     }

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -108,6 +108,21 @@ type strategy_config = {
   (** ["{name}_ollama_max_concurrent"]. When set, overrides the
       ollama auto-registration default for any ollama-like base URL
       in this cascade's candidate list. *)
+
+  tiers : string list list option;
+  (** ["{name}_tiers"]. Used by the [priority_tier] strategy.  Each
+      inner array is a tier of provider keys (matched against the
+      [model] field in [{name}_models]); outer order is tier order
+      (tier 0 = highest priority).  Example JSON:
+      [\[\["ollama:qwen3-coder:30b"\], \["gemini_cli:gemini-2.5-flash"\]\]].
+      @since 0.9.7 *)
+
+  sticky_ttl_ms : int option;
+  (** ["{name}_sticky_ttl_ms"]. Used by the [sticky] strategy.
+      Defaults to {!Cascade_strategy.default_sticky_ttl_ms}
+      ([300_000]) when [kind] is [sticky] and this field is absent.
+      Values [<= 0] disable affinity entirely.
+      @since 0.9.7 *)
 }
 
 val resolve_strategy_config :

--- a/lib/cascade/cascade_state.ml
+++ b/lib/cascade/cascade_state.ml
@@ -1,0 +1,71 @@
+(** See cascade_state.mli for documentation. *)
+
+(* ── Sticky ─────────────────────────────────────────────────────── *)
+
+type sticky_entry = {
+  provider : string;
+  expires_at : float;
+}
+
+let sticky_table : (string * string, sticky_entry) Hashtbl.t =
+  Hashtbl.create 32
+
+let sticky_mutex = Eio.Mutex.create ()
+
+let record_sticky_choice ~keeper ~cascade ~provider ~ttl_ms ~now =
+  if ttl_ms <= 0 then ()
+  else
+    let expires_at = now +. (float_of_int ttl_ms /. 1000.) in
+    Eio.Mutex.use_rw ~protect:false sticky_mutex (fun () ->
+        Hashtbl.replace sticky_table (keeper, cascade)
+          { provider; expires_at })
+
+let lookup_sticky ~keeper ~cascade ~now =
+  Eio.Mutex.use_ro sticky_mutex (fun () ->
+      match Hashtbl.find_opt sticky_table (keeper, cascade) with
+      | Some entry when now < entry.expires_at -> Some entry.provider
+      | _ -> None)
+
+let clear_sticky () =
+  Eio.Mutex.use_rw ~protect:false sticky_mutex (fun () ->
+      Hashtbl.clear sticky_table)
+
+(* ── Round-robin ────────────────────────────────────────────────── *)
+
+let rr_table : (string, int Atomic.t) Hashtbl.t = Hashtbl.create 16
+let rr_mutex = Eio.Mutex.create ()
+
+let get_or_create_cursor cascade =
+  match Hashtbl.find_opt rr_table cascade with
+  | Some a -> a
+  | None ->
+    Eio.Mutex.use_rw ~protect:false rr_mutex (fun () ->
+        match Hashtbl.find_opt rr_table cascade with
+        | Some a -> a
+        | None ->
+          let a = Atomic.make 0 in
+          Hashtbl.add rr_table cascade a;
+          a)
+
+let rotate_round_robin ~cascade ~bound =
+  if bound <= 0 then 0
+  else
+    let cursor = get_or_create_cursor cascade in
+    let v = Atomic.fetch_and_add cursor 1 in
+    let m = v mod bound in
+    if m < 0 then m + bound else m
+
+let peek_round_robin ~cascade =
+  match Hashtbl.find_opt rr_table cascade with
+  | Some a -> Atomic.get a
+  | None -> 0
+
+let clear_round_robin () =
+  Eio.Mutex.use_rw ~protect:false rr_mutex (fun () ->
+      Hashtbl.clear rr_table)
+
+(* ── Bulk ───────────────────────────────────────────────────────── *)
+
+let clear_all () =
+  clear_sticky ();
+  clear_round_robin ()

--- a/lib/cascade/cascade_state.mli
+++ b/lib/cascade/cascade_state.mli
@@ -1,0 +1,76 @@
+(** Per-cascade-name in-memory state container for stateful strategies.
+
+    Phase A strategies (Failover/Capacity_aware/Weighted_random/
+    Circuit_breaker_cycling) are pure — they read [signal_ctx] and
+    return an ordering.  Phase B introduces three strategies that
+    require external state across calls:
+
+    - [Sticky] remembers each [(keeper, cascade)]'s last successful
+      provider for [sticky_ttl_ms] so subsequent attempts pin to the
+      same backend (warm caches, session affinity).
+    - [Round_robin] maintains a per-cascade rotation cursor so
+      successive cascade calls start from a different candidate,
+      spreading load.
+    - [Priority_tier] is stateless (tier table comes from config) and
+      does not touch this module.
+
+    All entries live in process-local Hashtbls.  Restart resets
+    everything — Phase B is in-memory only.  Persistence to
+    [<base_path>/.masc/cascade_state.json] is deferred to a future
+    PR; the API here is intentionally side-effect-only so a
+    persistence layer can be slotted in without changing callers.
+
+    Concurrency: every operation uses [Atomic.t] or short critical
+    sections under [Eio.Mutex.t].  Safe to call from multiple Eio
+    fibers and (for Atomic-only ops) from multiple OCaml domains.
+
+    @since 0.9.7 *)
+
+(** {1 Sticky state} *)
+
+val record_sticky_choice :
+  keeper:string ->
+  cascade:string ->
+  provider:string ->
+  ttl_ms:int ->
+  now:float ->
+  unit
+(** Record a successful provider for [(keeper, cascade)].  Overwrites
+    any existing entry.  [now] is the wall-clock time used to compute
+    [expires_at = now + ttl_ms / 1000].  No effect when [ttl_ms <= 0]
+    (TTL disabled). *)
+
+val lookup_sticky :
+  keeper:string ->
+  cascade:string ->
+  now:float ->
+  string option
+(** [lookup_sticky ~keeper ~cascade ~now] returns the recorded provider
+    when an entry exists and [now < expires_at]; [None] otherwise.
+    Expired entries are not actively cleaned up here — the strategy's
+    [record_sticky_choice] overwrites stale entries naturally on the
+    next success.  Tests can call {!clear_sticky} for determinism. *)
+
+val clear_sticky : unit -> unit
+(** Remove every sticky entry.  Test helper. *)
+
+(** {1 Round-robin state} *)
+
+val rotate_round_robin : cascade:string -> bound:int -> int
+(** [rotate_round_robin ~cascade ~bound] returns the current cursor
+    value modulo [bound] and atomically advances the cursor by 1.
+    Returns [0] when [bound <= 0] (caller is responsible for
+    treating the empty list as a no-op).  Atomic — safe under
+    contention. *)
+
+val peek_round_robin : cascade:string -> int
+(** Return the current cursor value without advancing.  Test helper. *)
+
+val clear_round_robin : unit -> unit
+(** Reset every cursor to 0.  Test helper. *)
+
+(** {1 Bulk reset} *)
+
+val clear_all : unit -> unit
+(** Equivalent to {!clear_sticky} + {!clear_round_robin}.  Used by
+    tests and by future hot-reload code paths. *)

--- a/lib/cascade/cascade_strategy.ml
+++ b/lib/cascade/cascade_strategy.ml
@@ -5,6 +5,8 @@ type signal_ctx = {
   capacity : string -> Cascade_throttle.capacity_info option;
   now : float;
   rand_int : int -> int;
+  keeper_name : string;
+  cascade_name : string;
 }
 
 type cycle_policy = {
@@ -35,30 +37,49 @@ type kind =
   | Capacity_aware
   | Weighted_random
   | Circuit_breaker_cycling
+  | Priority_tier
+  | Sticky
+  | Round_robin
 
 let kind_to_string = function
   | Failover -> "failover"
   | Capacity_aware -> "capacity_aware"
   | Weighted_random -> "weighted_random"
   | Circuit_breaker_cycling -> "circuit_breaker_cycling"
+  | Priority_tier -> "priority_tier"
+  | Sticky -> "sticky"
+  | Round_robin -> "round_robin"
 
 let parse_kind = function
   | "failover" -> Ok Failover
   | "capacity_aware" -> Ok Capacity_aware
   | "weighted_random" -> Ok Weighted_random
   | "circuit_breaker_cycling" -> Ok Circuit_breaker_cycling
+  | "priority_tier" -> Ok Priority_tier
+  | "sticky" -> Ok Sticky
+  | "round_robin" -> Ok Round_robin
   | other ->
     Error (Printf.sprintf
              "unknown cascade strategy %S (expected one of: \
               failover, capacity_aware, weighted_random, \
-              circuit_breaker_cycling)" other)
+              circuit_breaker_cycling, priority_tier, sticky, \
+              round_robin)" other)
+
+let default_sticky_ttl_ms = 300_000
 
 type t = {
   kind : kind;
   cycle : cycle_policy;
+  tiers : string list list;
+  sticky_ttl_ms : int;
 }
 
-let failover = { kind = Failover; cycle = default_cycle_policy }
+let failover = {
+  kind = Failover;
+  cycle = default_cycle_policy;
+  tiers = [];
+  sticky_ttl_ms = 0;
+}
 
 type 'a adapter = {
   health_key : 'a -> string;
@@ -134,9 +155,78 @@ let weighted_shuffle adapter ctx cands =
   in
   pick [] effective
 
+(* ── Priority tier ──────────────────────────────────────────────── *)
+
+(* Pick the tier for [cycle], clamped to the last tier when [cycle]
+   exceeds [length tiers - 1].  Returns [[]] when [tiers] is empty
+   (no usable configuration → starvation guard handled at caller). *)
+let tier_for_cycle tiers ~cycle =
+  match tiers with
+  | [] -> []
+  | _ ->
+    let n = List.length tiers in
+    let idx = if cycle >= n then n - 1 else max 0 cycle in
+    List.nth tiers idx
+
+let priority_tier_order adapter ctx ~tiers ~cycle cands =
+  let allowed = tier_for_cycle tiers ~cycle in
+  match allowed with
+  | [] -> []
+  | _ ->
+    let in_tier c = List.mem (adapter.health_key c) allowed in
+    cands
+    |> List.filter in_tier
+    |> filter_capacity adapter ctx
+
+(* ── Sticky ─────────────────────────────────────────────────────── *)
+
+let sticky_order adapter ctx cands =
+  match
+    Cascade_state.lookup_sticky
+      ~keeper:ctx.keeper_name
+      ~cascade:ctx.cascade_name
+      ~now:ctx.now
+  with
+  | None -> cands
+  | Some pinned ->
+    (match List.find_opt
+             (fun c -> adapter.health_key c = pinned)
+             cands
+     with
+     | Some c -> [c]
+     | None ->
+       (* Pinned provider no longer in candidate list (config drift,
+          cascade.json reload).  Fall back to plain Failover. *)
+       cands)
+
+(* ── Round-robin ────────────────────────────────────────────────── *)
+
+(* Rotation: take cursor mod len, return [tail @ head] where the
+   first [cursor] elements move to the back.  Cursor advances on
+   every call, even when the cascade ends up using a later element —
+   the goal is cross-call fairness, not per-attempt fairness. *)
+let round_robin_order ctx cands =
+  let n = List.length cands in
+  if n <= 1 then cands
+  else
+    let cursor =
+      Cascade_state.rotate_round_robin
+        ~cascade:ctx.cascade_name
+        ~bound:n
+    in
+    let head, tail =
+      let rec split i acc = function
+        | xs when i <= 0 -> (List.rev acc, xs)
+        | [] -> (List.rev acc, [])
+        | x :: rest -> split (i - 1) (x :: acc) rest
+      in
+      split cursor [] cands
+    in
+    tail @ head
+
 (* ── Public ordering ────────────────────────────────────────────── *)
 
-let order_candidates t ~adapter ~ctx ~cycle:_ cands =
+let order_candidates t ~adapter ~ctx ~cycle cands =
   match t.kind with
   | Failover ->
     cands
@@ -148,3 +238,28 @@ let order_candidates t ~adapter ~ctx ~cycle:_ cands =
     cands
     |> filter_cooldown adapter ctx
     |> filter_capacity adapter ctx
+  | Priority_tier ->
+    priority_tier_order adapter ctx ~tiers:t.tiers ~cycle cands
+  | Sticky ->
+    sticky_order adapter ctx cands
+  | Round_robin ->
+    round_robin_order ctx cands
+
+(* ── Stateful hooks ─────────────────────────────────────────────── *)
+
+let record_choice t ~ctx ~provider_key =
+  match t.kind with
+  | Sticky ->
+    Cascade_state.record_sticky_choice
+      ~keeper:ctx.keeper_name
+      ~cascade:ctx.cascade_name
+      ~provider:provider_key
+      ~ttl_ms:t.sticky_ttl_ms
+      ~now:ctx.now
+  | Failover
+  | Capacity_aware
+  | Weighted_random
+  | Circuit_breaker_cycling
+  | Priority_tier
+  | Round_robin ->
+    ()

--- a/lib/cascade/cascade_strategy.mli
+++ b/lib/cascade/cascade_strategy.mli
@@ -8,10 +8,15 @@
     after a backoff sleep); the strategy can return a different ordering
     because health and capacity signals may have changed.
 
-    S5 (priority_tier), S6 (sticky), S7 (round_robin) require per-cascade
-    external state and are deferred to a follow-up PR.
+    Phase A (S1–S4) is purely stateless.  Phase B introduces three
+    additional kinds — [Priority_tier], [Sticky], [Round_robin] — that
+    consult per-cascade-name state owned by {!Cascade_state}.  The
+    ordering function remains read-only; mutations happen via the
+    explicit {!record_choice} hook the cascade caller invokes after a
+    successful attempt.
 
-    @since 0.9.6 *)
+    @since 0.9.6
+    @since 0.9.7 Phase B (Priority_tier / Sticky / Round_robin) *)
 
 (** {1 Signal context — what the strategy can read} *)
 
@@ -32,6 +37,21 @@ type signal_ctx = {
   rand_int : int -> int;
   (** Random integer generator in [0, n).  Passed in for determinism
       in tests. *)
+
+  keeper_name : string;
+  (** Owning keeper.  Used by [Sticky] to key its state.  Set to ["" ]
+      when the cascade is invoked outside a keeper context (CLI,
+      bootstrap probes); [Sticky] then degrades to a per-cascade-only
+      affinity (still useful), and other kinds ignore the field.
+
+      @since 0.9.7 *)
+
+  cascade_name : string;
+  (** Cascade identifier (the [<name>] in [<name>_models]).  Used by
+      [Sticky] and [Round_robin] to scope their state.  Required for
+      stateful kinds; tolerated as ["" ] for stateless kinds.
+
+      @since 0.9.7 *)
 }
 
 (** {1 Cycle policy — orthogonal to strategy kind} *)
@@ -83,6 +103,33 @@ type kind =
         circuit-breaker semantics live in Cascade_health_tracker; this
         strategy is the policy that reads them. *)
 
+  | Priority_tier
+    (** S5 — providers grouped into ordered tiers via [tiers] in {!t}.
+        Cycle [n] only considers tier [n] (clamped to last tier).
+        Within a tier, capacity-aware filtering is applied; the tier
+        is "active" iff at least one of its providers survives the
+        filter, otherwise the cycle yields the empty list and the
+        caller advances to the next cycle (i.e. next tier).
+        @since 0.9.7 *)
+
+  | Sticky
+    (** S6 — per-[(keeper_name, cascade_name)] affinity.  When a
+        previous successful provider is still within [sticky_ttl_ms],
+        return only that provider as the singleton ordering.  When no
+        sticky entry exists or it has expired, fall back to plain
+        Failover ordering.  The cascade caller is responsible for
+        invoking {!record_choice} after a successful attempt so the
+        affinity is recorded.
+        @since 0.9.7 *)
+
+  | Round_robin
+    (** S7 — per-cascade rotation cursor.  The first attempt of each
+        cascade call rotates the input list by the current cursor
+        value (mod list length), then advances the cursor.  Within a
+        single cycle, the rotated order is preserved (Failover
+        within); cross-call fairness comes from the cursor.
+        @since 0.9.7 *)
+
 val kind_to_string : kind -> string
 val parse_kind : string -> (kind, string) result
 (** [parse_kind s] returns [Ok kind] for known names, [Error msg] for
@@ -94,11 +141,32 @@ val parse_kind : string -> (kind, string) result
 type t = {
   kind : kind;
   cycle : cycle_policy;
+
+  tiers : string list list;
+  (** Used only by [Priority_tier].  Each inner list is the set of
+      provider keys (matched against [adapter.health_key]) that form
+      one tier; outer order is tier order (tier 0 = highest priority).
+      Empty list when the strategy is not [Priority_tier].
+      @since 0.9.7 *)
+
+  sticky_ttl_ms : int;
+  (** Used only by [Sticky].  Time-to-live for a recorded sticky
+      choice in milliseconds.  Defaults to [300_000] (5 minutes) when
+      the strategy is [Sticky]; ignored otherwise.  Values [<= 0]
+      effectively disable affinity (every call is a fresh Failover).
+      @since 0.9.7 *)
 }
 
 val failover : t
-(** [{ kind = Failover; cycle = default_cycle_policy }].  What callers
-    receive when no per-cascade strategy is configured. *)
+(** [{ kind = Failover; cycle = default_cycle_policy; tiers = [];
+       sticky_ttl_ms = 0 }].  What callers receive when no per-cascade
+    strategy is configured. *)
+
+val default_sticky_ttl_ms : int
+(** [300_000] (5 minutes).  The fallback TTL used by config loaders
+    when [Sticky] is selected without an explicit
+    [<name>_sticky_ttl_ms].
+    @since 0.9.7 *)
 
 (** {1 Candidate adapter}
 
@@ -136,4 +204,34 @@ val order_candidates :
     This function is pure and must not perform IO.  [cycle] is
     0-indexed (first cycle = 0).  Some strategies (notably
     Weighted_random) consult [ctx.rand_int]; tests can pass a
-    deterministic RNG. *)
+    deterministic RNG.
+
+    Stateful kinds may consult {!Cascade_state} (which is technically
+    side-effectful for [Round_robin] because it advances a cursor on
+    every call); the function still returns deterministic output for
+    a given state snapshot, and tests can reset the snapshot via
+    {!Cascade_state.clear_all}. *)
+
+(** {1 Stateful hooks}
+
+    Phase B kinds need a write path so the cascade caller can record
+    successful attempts.  Phase A kinds ignore these hooks. *)
+
+val record_choice :
+  t ->
+  ctx:signal_ctx ->
+  provider_key:string ->
+  unit
+(** [record_choice t ~ctx ~provider_key] is invoked by the cascade
+    caller after a successful attempt completes (HTTP 200, FSM
+    [Accept]/[Accept_on_exhaustion]).  For [Sticky], stores
+    [(ctx.keeper_name, ctx.cascade_name) -> provider_key] in
+    {!Cascade_state} with [t.sticky_ttl_ms].  For all other kinds
+    (including [Round_robin], whose cursor was advanced at order
+    time), this is a no-op.
+
+    Idempotent: calling twice for the same attempt simply overwrites
+    the same entry.  Safe under concurrent fibers via
+    {!Cascade_state} mutex.
+
+    @since 0.9.7 *)

--- a/lib/dune
+++ b/lib/dune
@@ -36,6 +36,7 @@
    cascade_health_tracker
    cascade_model_resolve
    cascade_runtime
+   cascade_state
    cascade_strategy
    cascade_throttle
    cancellation

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -78,6 +78,7 @@ val default_model_strings : cascade_name:string -> string list
 
 val run_named :
   cascade_name:string ->
+  ?keeper_name:string ->
   ?model_strings:string list ->
   goal:string ->
   ?provider_filter:string list ->

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -247,6 +247,7 @@ let sdk_error_to_cascade_outcome (err : Oas.Error.sdk_error)
     @since Phase 2 — MASC-driven cascade FSM *)
 let run_named
     ~cascade_name
+    ?(keeper_name = "")
     ?model_strings
     ~goal
     ?provider_filter
@@ -391,7 +392,9 @@ let run_named
     in
     (result, checkpoint_after)
   in
-  let rec try_cascade ?resume_checkpoint remaining last_err =
+  let rec try_cascade
+      ?(on_success = fun ~provider_key:_ -> ())
+      ?resume_checkpoint remaining last_err =
     match remaining with
     | [] ->
       let err_msg = match last_err with
@@ -439,6 +442,7 @@ let run_named
         in
         let result = { result with cascade_observation = Some observation } in
         Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
+        on_success ~provider_key:provider_cfg.model_id;
         Ok result
       | Ok result ->
         Cascade_health_tracker.(record_success global ~provider_key:provider_cfg.model_id);
@@ -454,6 +458,7 @@ let run_named
            in
            let result = { result with cascade_observation = Some observation } in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
+           on_success ~provider_key:provider_cfg.model_id;
            Ok result
          | Cascade_fsm.Try_next { last_err = new_err } ->
            Log.Misc.warn "cascade %s: accept rejected %s (%s), trying next" cascade_name provider_cfg.model_id reason;
@@ -482,6 +487,7 @@ let run_named
            in
            let result = { result with cascade_observation = Some observation } in
            Oas_worker_cascade.record_cascade ~cascade_name ~outcome:`Success ~observation:(Some observation);
+           on_success ~provider_key:provider_cfg.model_id;
            Ok result)
       | Error sdk_err ->
         Cascade_health_tracker.(record_failure global ~provider_key:provider_cfg.model_id);
@@ -553,6 +559,8 @@ let run_named
       | None -> Cascade_client_capacity.capacity url);
     now = Unix.gettimeofday ();
     rand_int = Random.int;
+    keeper_name;
+    cascade_name;
   } in
   let cycle_clock = Eio_context.get_clock_opt () in
   let do_backoff cycle =
@@ -600,7 +608,10 @@ let run_named
       do_backoff (n + 1);
       cycle_loop (n + 1)
     | _ ->
-      (match try_cascade ordered None with
+      let on_success ~provider_key =
+        Cascade_strategy.record_choice strategy ~ctx:signal_ctx ~provider_key
+      in
+      (match try_cascade ~on_success ordered None with
        | Ok _ as ok -> ok
        | Error _ as err when last_cycle -> err
        | Error _ ->

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -13,6 +13,7 @@ module S = Masc_mcp.Cascade_strategy
 module H = Masc_mcp.Cascade_health_tracker
 module C = Masc_mcp.Cascade_client_capacity
 module T = Masc_mcp.Cascade_throttle
+module Cascade_state = Masc_mcp.Cascade_state
 
 (* ── Test fixture ────────────────────────────────────────────── *)
 
@@ -49,8 +50,17 @@ let mk_ctx ?(health = H.create ())
            ?(capacity = fun _ -> None)
            ?(now = 0.0)
            ?(rand = fun _ -> 0)
+           ?(keeper_name = "")
+           ?(cascade_name = "")
            () : S.signal_ctx =
-  { health; capacity; now; rand_int = rand }
+  { health; capacity; now; rand_int = rand;
+    keeper_name; cascade_name }
+
+let mk_t ?(cycle = S.default_cycle_policy)
+         ?(tiers = [])
+         ?(sticky_ttl_ms = 0)
+         kind : S.t =
+  { kind; cycle; tiers; sticky_ttl_ms }
 
 (* ── S1 Failover ─────────────────────────────────────────────── *)
 
@@ -71,7 +81,7 @@ let test_capacity_aware_filters_busy () =
     (* "c" has no entry → unknown → kept (fail-open) *)
   ] in
   let ctx = mk_ctx ~capacity:(stub_capacity table) () in
-  let strat = { S.kind = Capacity_aware; cycle = S.default_cycle_policy } in
+  let strat = mk_t S.Capacity_aware in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check (list string) "busy 'a' filtered, 'b' and 'c' (unknown) kept"
     ["b"; "c"] (names ordered)
@@ -83,14 +93,14 @@ let test_capacity_aware_all_busy_yields_empty () =
     (List.nth cands 1).url, mk_capacity_info ~total:1 ~active:1;
   ] in
   let ctx = mk_ctx ~capacity:(stub_capacity table) () in
-  let strat = { S.kind = Capacity_aware; cycle = S.default_cycle_policy } in
+  let strat = mk_t S.Capacity_aware in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check (list string) "all busy → empty list" [] (names ordered)
 
 let test_capacity_aware_unknown_passes () =
   let cands = [mk_cand "a"; mk_cand "b"] in
   let ctx = mk_ctx ~capacity:(fun _ -> None) () in
-  let strat = { S.kind = Capacity_aware; cycle = S.default_cycle_policy } in
+  let strat = mk_t S.Capacity_aware in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check (list string) "unknown capacity → all kept (fail-open)"
     ["a"; "b"] (names ordered)
@@ -107,7 +117,7 @@ let test_weighted_random_deterministic_with_rand0 () =
     mk_cand ~w:20 "c";
   ] in
   let ctx = mk_ctx ~rand:(fun _ -> 0) () in
-  let strat = { S.kind = Weighted_random; cycle = S.default_cycle_policy } in
+  let strat = mk_t S.Weighted_random in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check (list string) "rand=0 picks left-to-right"
     ["a"; "b"; "c"] (names ordered)
@@ -125,7 +135,7 @@ let test_weighted_random_starvation_guard () =
   cool_down "a"; cool_down "b";
   let cands = [mk_cand ~w:50 "a"; mk_cand ~w:30 "b"] in
   let ctx = mk_ctx ~health:h ~rand:(fun _ -> 0) () in
-  let strat = { S.kind = Weighted_random; cycle = S.default_cycle_policy } in
+  let strat = mk_t S.Weighted_random in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check int "all-cooldown → fallback picks at least 1"
     2 (List.length ordered)
@@ -143,10 +153,9 @@ let test_cb_cycling_excludes_cooldown_and_busy () =
     (* "c" unknown → kept *)
   ] in
   let ctx = mk_ctx ~health:h ~capacity:(stub_capacity table) () in
-  let strat = {
-    S.kind = Circuit_breaker_cycling;
-    cycle = { max_cycles = 3; backoff_base_ms = 100; backoff_cap_ms = 1000 };
-  } in
+  let strat = mk_t S.Circuit_breaker_cycling
+      ~cycle:{ max_cycles = 3; backoff_base_ms = 100; backoff_cap_ms = 1000 }
+  in
   let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
   check (list string) "cooldown 'a' + busy 'b' filtered, 'c' (unknown) kept"
     ["c"] (names ordered)
@@ -287,6 +296,151 @@ let test_ollama_register_with_override () =
   | Some info ->
     check int "override max=4" 4 info.total
 
+(* ── Phase B: Priority_tier (S5) ───────────────────────────── *)
+
+let test_priority_tier_picks_first_tier () =
+  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
+  let strat = mk_t S.Priority_tier
+      ~tiers:[["a"]; ["b"; "c"]]
+  in
+  let ctx = mk_ctx () in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "cycle 0 → tier 0 (a only)" ["a"] (names ordered)
+
+let test_priority_tier_advances_with_cycle () =
+  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
+  let strat = mk_t S.Priority_tier
+      ~tiers:[["a"]; ["b"; "c"]]
+  in
+  let ctx = mk_ctx () in
+  let cycle1 = S.order_candidates strat ~adapter ~ctx ~cycle:1 cands in
+  check (list string) "cycle 1 → tier 1 (b, c)" ["b"; "c"] (names cycle1)
+
+let test_priority_tier_clamps_overflow () =
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let strat = mk_t S.Priority_tier ~tiers:[["a"]; ["b"]] in
+  let ctx = mk_ctx () in
+  let cycle99 = S.order_candidates strat ~adapter ~ctx ~cycle:99 cands in
+  check (list string) "cycle ≥ tiers count → last tier" ["b"] (names cycle99)
+
+let test_priority_tier_capacity_filter () =
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let table = [
+    (List.nth cands 0).url, mk_capacity_info ~total:1 ~active:1;
+  ] in
+  let strat = mk_t S.Priority_tier ~tiers:[["a"; "b"]] in
+  let ctx = mk_ctx ~capacity:(stub_capacity table) () in
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "tier 0 with 'a' busy → only 'b'" ["b"] (names ordered)
+
+(* ── Phase B: Sticky (S6) ──────────────────────────────────── *)
+
+let test_sticky_records_and_pins () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
+  let strat = mk_t S.Sticky ~sticky_ttl_ms:60_000 in
+  let ctx = mk_ctx ~now:1000.0 ~keeper_name:"k1" ~cascade_name:"cas" () in
+  (* First call: no entry → returns full list *)
+  let first = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "no sticky → full list" ["a"; "b"; "c"] (names first);
+  (* Record success on 'b' *)
+  S.record_choice strat ~ctx ~provider_key:"b";
+  (* Second call: pinned to 'b' *)
+  let second = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "after record → pinned to 'b'" ["b"] (names second)
+
+let test_sticky_expires_after_ttl () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let strat = mk_t S.Sticky ~sticky_ttl_ms:60_000 in
+  let ctx_now = mk_ctx ~now:0.0 ~keeper_name:"k" ~cascade_name:"cas" () in
+  S.record_choice strat ~ctx:ctx_now ~provider_key:"a";
+  (* 60s + 1ms past expiry *)
+  let ctx_later = mk_ctx ~now:60.001 ~keeper_name:"k" ~cascade_name:"cas" () in
+  let ordered = S.order_candidates strat ~adapter ~ctx:ctx_later ~cycle:0 cands in
+  check (list string) "expired → fall back to full list"
+    ["a"; "b"] (names ordered)
+
+let test_sticky_pinned_provider_missing_falls_back () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let strat = mk_t S.Sticky ~sticky_ttl_ms:60_000 in
+  let ctx = mk_ctx ~now:0.0 ~keeper_name:"k" ~cascade_name:"cas" () in
+  (* Pin 'c' which doesn't exist in the candidate list *)
+  S.record_choice strat ~ctx ~provider_key:"c";
+  let ordered = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "missing pin → fall back to full list"
+    ["a"; "b"] (names ordered)
+
+let test_sticky_per_keeper_isolation () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let strat = mk_t S.Sticky ~sticky_ttl_ms:60_000 in
+  let k1 = mk_ctx ~now:0.0 ~keeper_name:"k1" ~cascade_name:"cas" () in
+  let k2 = mk_ctx ~now:0.0 ~keeper_name:"k2" ~cascade_name:"cas" () in
+  S.record_choice strat ~ctx:k1 ~provider_key:"a";
+  S.record_choice strat ~ctx:k2 ~provider_key:"b";
+  let ordered_k1 = S.order_candidates strat ~adapter ~ctx:k1 ~cycle:0 cands in
+  let ordered_k2 = S.order_candidates strat ~adapter ~ctx:k2 ~cycle:0 cands in
+  check (list string) "k1 → 'a'" ["a"] (names ordered_k1);
+  check (list string) "k2 → 'b'" ["b"] (names ordered_k2)
+
+(* ── Phase B: Round_robin (S7) ─────────────────────────────── *)
+
+let test_round_robin_rotates_each_call () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "a"; mk_cand "b"; mk_cand "c"] in
+  let strat = mk_t S.Round_robin in
+  let ctx = mk_ctx ~cascade_name:"rr-test" () in
+  let r0 = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  let r1 = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  let r2 = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  let r3 = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "call 0: cursor 0 → abc" ["a"; "b"; "c"] (names r0);
+  check (list string) "call 1: cursor 1 → bca" ["b"; "c"; "a"] (names r1);
+  check (list string) "call 2: cursor 2 → cab" ["c"; "a"; "b"] (names r2);
+  check (list string) "call 3: cursor 3 mod 3 = 0 → abc" ["a"; "b"; "c"] (names r3)
+
+let test_round_robin_singleton_no_op () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "only"] in
+  let strat = mk_t S.Round_robin in
+  let ctx = mk_ctx ~cascade_name:"singleton" () in
+  let r = S.order_candidates strat ~adapter ~ctx ~cycle:0 cands in
+  check (list string) "singleton → unchanged" ["only"] (names r);
+  (* Cursor not advanced for singleton *)
+  check int "cursor stays at 0" 0
+    (Cascade_state.peek_round_robin ~cascade:"singleton")
+
+let test_round_robin_per_cascade_cursor () =
+  Cascade_state.clear_all ();
+  let cands = [mk_cand "a"; mk_cand "b"] in
+  let strat = mk_t S.Round_robin in
+  let ctx_x = mk_ctx ~cascade_name:"cas-x" () in
+  let ctx_y = mk_ctx ~cascade_name:"cas-y" () in
+  let _ = S.order_candidates strat ~adapter ~ctx:ctx_x ~cycle:0 cands in
+  let _ = S.order_candidates strat ~adapter ~ctx:ctx_x ~cycle:0 cands in
+  let r_y = S.order_candidates strat ~adapter ~ctx:ctx_y ~cycle:0 cands in
+  check (list string) "cas-y has its own cursor (still 0)"
+    ["a"; "b"] (names r_y)
+
+(* ── Phase B: cascade_state primitives ─────────────────────── *)
+
+let test_cascade_state_sticky_zero_ttl_no_record () =
+  Cascade_state.clear_all ();
+  Cascade_state.record_sticky_choice ~keeper:"k" ~cascade:"c"
+    ~provider:"p" ~ttl_ms:0 ~now:0.0;
+  match Cascade_state.lookup_sticky ~keeper:"k" ~cascade:"c" ~now:0.0 with
+  | None -> ()
+  | Some _ -> fail "ttl_ms=0 should not record"
+
+let test_cascade_state_round_robin_negative_bound () =
+  Cascade_state.clear_all ();
+  let v = Cascade_state.rotate_round_robin ~cascade:"x" ~bound:0 in
+  check int "bound<=0 → returns 0" 0 v;
+  let v2 = Cascade_state.rotate_round_robin ~cascade:"x" ~bound:(-3) in
+  check int "negative bound → returns 0" 0 v2
+
 let () =
   run "cascade_strategy" [
     "failover", [
@@ -334,5 +488,39 @@ let () =
         test_ollama_auto_register;
       test_case "auto_register override sets max" `Quick
         test_ollama_register_with_override;
+    ];
+    "priority_tier", [
+      test_case "cycle 0 picks first tier" `Quick
+        test_priority_tier_picks_first_tier;
+      test_case "cycle advances with tier index" `Quick
+        test_priority_tier_advances_with_cycle;
+      test_case "cycle overflow clamps to last tier" `Quick
+        test_priority_tier_clamps_overflow;
+      test_case "tier respects capacity filter" `Quick
+        test_priority_tier_capacity_filter;
+    ];
+    "sticky", [
+      test_case "record_choice → pinned on next call" `Quick
+        test_sticky_records_and_pins;
+      test_case "expires after ttl" `Quick
+        test_sticky_expires_after_ttl;
+      test_case "missing pinned provider falls back" `Quick
+        test_sticky_pinned_provider_missing_falls_back;
+      test_case "per-keeper isolation" `Quick
+        test_sticky_per_keeper_isolation;
+    ];
+    "round_robin", [
+      test_case "rotates each call" `Quick
+        test_round_robin_rotates_each_call;
+      test_case "singleton list is no-op" `Quick
+        test_round_robin_singleton_no_op;
+      test_case "per-cascade cursor isolation" `Quick
+        test_round_robin_per_cascade_cursor;
+    ];
+    "cascade_state", [
+      test_case "sticky ttl_ms=0 does not record" `Quick
+        test_cascade_state_sticky_zero_ttl_no_record;
+      test_case "round_robin bound<=0 returns 0" `Quick
+        test_cascade_state_round_robin_negative_bound;
     ];
   ]


### PR DESCRIPTION
## Summary

Phase B of the pluggable cascade strategy system (continuation of #7606), implementing the three deferred kinds tracked in #7608.

| Strategy | Behaviour | State |
|----------|-----------|-------|
| `priority_tier` | Cycle N considers tier N (clamped to last tier); capacity-filtered within tier | None (config-driven) |
| `sticky` | Returns singleton for the recorded provider while non-expired; falls back to Failover otherwise | `(keeper, cascade) → {provider, expires_at}` |
| `round_robin` | Rotates input by per-cascade cursor (Atomic fetch-and-add) | `cascade → int Atomic.t` |

All three integrate with the existing cascade.json schema and degrade silently when their fields are absent — every existing cascade remains bit-identical to Failover.

## Schema (cascade.json)

```jsonc
"keeper_unified_strategy": "priority_tier",
"keeper_unified_tiers": [
  ["ollama:qwen3-coder:30b"],
  ["gemini_cli:gemini-2.5-flash", "glm:glm-4.5"]
],
"keeper_unified_sticky_ttl_ms": 300000  // only consumed when strategy == "sticky"
```

Tier parsing is all-or-nothing: any malformed inner list discards the whole field, avoiding silent misroutes.

## Boundary preservation

- `Cascade_fsm.decide` — untouched (still pure).
- `try_cascade` body — only addition is one `on_success` callback at three Accept branches; recursion structure unchanged.
- New state lives entirely in `Cascade_state`; mutations behind `Eio.Mutex`, lock-free reads via `Atomic`.
- `signal_ctx` gained `keeper_name` + `cascade_name`; `run_named` gained `?keeper_name = \"\"`. Backward-compat: existing callers degrade Sticky to per-cascade-only key.

## Tests

`test/test_cascade_strategy.ml` 19 → 32 cases, all pass:
- priority_tier (4): tier picking / cycle advance / overflow clamp / capacity filter
- sticky (4): record + pin / TTL expiry / missing pin fallback / per-keeper isolation
- round_robin (3): rotation / singleton no-op / per-cascade cursor isolation
- cascade_state (2): ttl_ms<=0 ignored / bound<=0 returns 0

\`\`\`
$ dune exec test/test_cascade_strategy.exe
Test Successful in 0.003s. 32 tests run.
\`\`\`

Full \`dune runtest\` green (no regressions in 111-case keeper_tool_matrix etc.).

## Backward compatibility

- New \`kind\` variants are opt-in via cascade.json; absent → Failover with max_cycles=1.
- New record fields default to empty (\`tiers = []\`, \`sticky_ttl_ms = 0\`).
- New \`signal_ctx\` fields are \`\"\"\` for callers that don't care.
- \`run_named\`'s \`?keeper_name\` is optional; existing call-sites unchanged.

## Out of scope (Phase C — #7609)

- TLA+ spec for cycle/backoff invariants and sticky liveness.
- Ollama \`/api/ps\` Discovery probe (replaces client semaphore for ollama).
- CLI provider capacity (gemini_cli/claude).

## Production rollout note

Sticky and round_robin are stateful in-memory only; restart resets affinities and cursors. Persistence to \`<base_path>/.masc/cascade_state.json\` is intentionally deferred — current MASC restarts already invalidate provider warm-state, so the loss is acceptable for Phase B.

## References

- Phase A: #7606 (\`c6cd5167c\`)
- Phase B tracking: #7608
- Phase C tracking: #7609

🤖 Generated with [Claude Code](https://claude.com/claude-code)