### PR TITLE
fix(keeper): read continuity from working_context (RFC-MASC-001 Phase 1 완성)

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -373,15 +373,40 @@ let read_continuity_summary ~(config : Coord.config) ~(meta : keeper_meta)
       max min_keeper_context raw
     in
     let base_dir = session_base_dir config in
-    let _session, ctx_opt =
+    let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+    let session, ctx_opt =
       load_context_from_checkpoint
         ~max_checkpoint_messages:meta.compaction.max_checkpoint_messages
-        ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+        ~trace_id
         ~primary_model_max_tokens:primary_max_context ~base_dir
     in
     match ctx_opt with
     | Some c ->
-        let snapshot = latest_state_snapshot_from_messages c.messages in
+        (* RFC-MASC-001 Phase 1 read-side symmetry: the save path
+           (Keeper_context_core.patch_checkpoint_last_assistant, gated by
+           MASC_STRUCTURED_STATE) writes a typed snapshot to
+           Checkpoint.working_context alongside the text [STATE] block.
+           Prefer that typed snapshot here so the injected continuity
+           reflects the same structured view the save path produced,
+           instead of re-parsing a [STATE] block from message bodies. *)
+        let structured_snapshot =
+          match
+            Keeper_checkpoint_store.load_oas
+              ~session_dir:session.session_dir ~session_id:trace_id
+          with
+          | Ok cp ->
+              (match cp.Agent_sdk.Checkpoint.working_context with
+               | Some json ->
+                   Keeper_memory_policy
+                   .snapshot_of_structured_working_context json
+               | None -> None)
+          | Error _ -> None
+        in
+        let snapshot =
+          match structured_snapshot with
+          | Some _ as s -> s
+          | None -> latest_state_snapshot_from_messages c.messages
+        in
         (match snapshot with
          | Some s -> keeper_state_snapshot_to_summary_text s
          | None ->


### PR DESCRIPTION
## 배경

사용자 관찰: keeper가 매 턴 동일한 상태 narrative(`"DONE: 1.5B+ ep cross-verified ..."` 류)를 반복 생성하며 컨텍스트를 태움. 디버깅 결과 원인은 **save/read 비대칭**.

- **Save 경로** (`keeper_context_core.ml:patch_checkpoint_last_assistant`, RFC-MASC-001 Phase 1): `MASC_STRUCTURED_STATE` 플래그가 켜져 있으면 파싱된 state_snapshot을 `Checkpoint.working_context` JSON에 쓰면서 `[STATE]` 텍스트 블록과 병행 저장.
- **Read 경로** (`keeper_world_observation.ml:read_continuity_summary`): 저장된 `working_context`를 무시하고 message chain에서 `[STATE]` 블록을 regex로 다시 파싱.

결과: keeper 자신이 직전 턴에 board_post로 쓴 `[STATE]` 블록이 assistant tool-use 메시지로 체크포인트에 남아 있고, 다음 턴 read 경로가 그걸 다시 끌어올려 user_message에 주입 → LLM이 같은 narrative를 재생산 → 자가 강화 resonance loop.

## 변경

`keeper_world_observation.ml:read_continuity_summary`의 `ctx_opt = Some c` 분기를 save 경로와 대칭으로:

1. `Keeper_checkpoint_store.load_oas`로 OAS 체크포인트 로드
2. `cp.working_context = Some json`이면 `Keeper_memory_policy.snapshot_of_structured_working_context`로 디코딩
3. 실패/부재 시 기존 `latest_state_snapshot_from_messages` fallback

새 코드/새 타입 없음. 기존 helper만 재사용.

## 호환성

- `MASC_STRUCTURED_STATE`가 꺼져 있으면 `cp.working_context = None` → fallback 경로 실행 (현 동작과 동일)
- `MASC_STRUCTURED_STATE=true` 인 keeper만 즉시 resonance 해소 효과
- `continuity_fallback_summary_text` 경로는 체크포인트 없을 때만 도달 — 그대로 유지

## 테스트

- 기존 `test/test_keeper_state_snapshot_json.ml` 13 tests pass (round_trip/structured_envelope/patch_checkpoint/dual_source) — `snapshot_of_structured_working_context` helper 커버리지가 본 PR 동작을 간접 보장
- 새 구조는 이미 존재하는 helper에 얹은 match-option 배선이라 단위 테스트 가치 제한적. 통합 관찰은 별도 Issue(retro-clean)에서 다룸.

## 빌드

\`\`\`
dune build --root .     # 51s, green
dune exec test/test_keeper_state_snapshot_json.exe  # 13 tests, 0 fail
\`\`\`

## Non-Goals (본 PR 밖)

- `MASC_STRUCTURED_STATE` 기본값 true 전환 — 별도 rollout 결정 필요
- `continuity_fallback_summary_text` 경로 자체 개선(size cap, age gate) — 본 PR은 symmetry만 복구
- 기존 누적된 polluted continuity_summary 필드 retro-clean — 별도 follow-up Issue에서 스크립트 제공 예정
- `keeper_board_post` tool 입력 schema 구조화 — 설계 단계에서 제기했으나 본 echo 증상과 직접 관계 없음

## 참고

- RFC: `docs/rfc/RFC-MASC-001-keeper-checkpoint-boundary-migration.md`
- Save 경로: `lib/keeper/keeper_context_core.ml:1217` (`patch_checkpoint_last_assistant` 주변 `structured_state_enabled` 분기)
- Read helper: `lib/keeper/keeper_memory_policy.ml:394` (`snapshot_of_structured_working_context`)