### PR TITLE
feat(tla): CascadeStrategy boundary spec + BoundedCycle bug model (Phase C part 1)

### DIFF
--- a/specs/boundary/CascadeStrategy-buggy.cfg
+++ b/specs/boundary/CascadeStrategy-buggy.cfg
@@ -1,0 +1,15 @@
+\* Buggy model: AdvanceCycle without an upper guard lets [cycle]
+\* exceed [MaxCycles - 1].
+\* Expected: BoundedCycle MUST be violated.
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Candidates = {"a", "b"}
+    MaxCycles = 2
+
+INVARIANTS
+    BoundedCycle
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/boundary/CascadeStrategy.cfg
+++ b/specs/boundary/CascadeStrategy.cfg
@@ -1,0 +1,14 @@
+\* Cascade strategy boundary contract — clean model.
+\* Verifies: TypeOK, BoundedCycle, TerminationConsistency.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Candidates = {"a", "b", "c"}
+    MaxCycles = 3
+
+INVARIANTS
+    Safety
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/boundary/CascadeStrategy.tla
+++ b/specs/boundary/CascadeStrategy.tla
@@ -1,0 +1,177 @@
+---- MODULE CascadeStrategy ----
+\* Boundary spec for the pluggable cascade strategy system
+\* (lib/cascade/cascade_strategy.{ml,mli} from Phase A #7606 +
+\* Phase B #7611).
+\*
+\* Runtime truth being modelled:
+\*   - A cascade call ranges over [Candidates] in a strategy-defined
+\*     order; each candidate is attempted at most once per cycle.
+\*   - When a cycle exhausts (either filtered to empty or every
+\*     candidate failed), the caller advances to [cycle + 1] after
+\*     [backoff_ms]; bounded by [max_cycles].
+\*   - On success, the loop returns immediately.  On
+\*     [cycle = max_cycles - 1] failure, it returns [Cascade_exhausted].
+\*
+\* What this spec deliberately abstracts away:
+\*   - The actual HTTP / IO of the provider call (modelled as a
+\*     non-deterministic Success/Failure choice).
+\*   - The exact backoff value (the policy's monotonicity is
+\*     verified in OCaml unit tests; here we only model the *fact*
+\*     that some non-zero delay happens between cycles).
+\*   - Sticky TTL expiry as a separate event (modelled as: the
+\*     pinned provider is either available or "expired").
+\*
+\* The spec exists so that the safety properties below are not
+\* preserved by accident — i.e. so that buggy variants of the
+\* runtime would visibly violate them, per the masc-mcp Bug Model
+\* convention (memory feedback_tla-spec-audit-outcome-trichotomy +
+\* the BugAction / SpecBuggy pattern in software-development.md).
+
+EXTENDS Naturals, TLC
+
+CONSTANTS
+    Candidates,        \* Set of provider keys, e.g. {"a", "b", "c"}
+    MaxCycles          \* Upper bound on cycle counter
+
+ASSUME MaxCyclesIsPos == MaxCycles \in Nat /\ MaxCycles >= 1
+ASSUME CandidatesNonEmpty == Candidates # {}
+
+VARIABLES
+    cycle,             \* 0..MaxCycles  (MaxCycles == "exhausted")
+    attempted,         \* set of (cycle, candidate) pairs already tried
+    outcome,           \* "in_progress" | "accepted" | "exhausted"
+    accepted_provider  \* the candidate that produced "accepted", or "none"
+
+vars == << cycle, attempted, outcome, accepted_provider >>
+
+OutcomeSet == {"in_progress", "accepted", "exhausted"}
+NoneProvider == "_none_"
+ASSUME NoneProvider \notin Candidates
+
+(* ── Type invariant ─────────────────────────────────────── *)
+
+TypeOK ==
+    /\ cycle \in 0..MaxCycles
+    /\ outcome \in OutcomeSet
+    /\ accepted_provider \in (Candidates \cup {NoneProvider})
+
+(* ── Initial state ──────────────────────────────────────── *)
+
+Init ==
+    /\ cycle = 0
+    /\ attempted = {}
+    /\ outcome = "in_progress"
+    /\ accepted_provider = NoneProvider
+
+(* ── Helpers ────────────────────────────────────────────── *)
+
+\* Candidates not yet tried in the current cycle.
+RemainingThisCycle ==
+    { c \in Candidates : << cycle, c >> \notin attempted }
+
+(* ── Actions ────────────────────────────────────────────── *)
+
+\* Try a candidate this cycle and accept the result.  Models the
+\* "Accept" branch in cascade_fsm.decide.
+Accept(c) ==
+    /\ outcome = "in_progress"
+    /\ c \in RemainingThisCycle
+    /\ outcome' = "accepted"
+    /\ accepted_provider' = c
+    /\ attempted' = attempted \cup { << cycle, c >> }
+    /\ UNCHANGED cycle
+
+\* Try a candidate this cycle and fail; cascade falls through.
+Fail(c) ==
+    /\ outcome = "in_progress"
+    /\ c \in RemainingThisCycle
+    /\ outcome' = outcome
+    /\ accepted_provider' = accepted_provider
+    /\ attempted' = attempted \cup { << cycle, c >> }
+    /\ UNCHANGED cycle
+
+\* Cycle exhausted (no candidate left this cycle).  Either advance
+\* to next cycle (after backoff, modelled as pure transition) or
+\* terminate with Cascade_exhausted on the last cycle.
+AdvanceCycle ==
+    /\ outcome = "in_progress"
+    /\ RemainingThisCycle = {}
+    /\ cycle + 1 < MaxCycles
+    /\ cycle' = cycle + 1
+    /\ UNCHANGED << attempted, outcome, accepted_provider >>
+
+Exhaust ==
+    /\ outcome = "in_progress"
+    /\ RemainingThisCycle = {}
+    /\ cycle + 1 >= MaxCycles
+    /\ outcome' = "exhausted"
+    /\ UNCHANGED << cycle, attempted, accepted_provider >>
+
+Next ==
+    \/ \E c \in Candidates : Accept(c)
+    \/ \E c \in Candidates : Fail(c)
+    \/ AdvanceCycle
+    \/ Exhaust
+
+\* No fairness modelled.  EventuallyTerminates would require an
+\* environmental assumption that providers eventually respond for
+\* every (cycle, candidate) pair, which the strategy module does
+\* not own — it is enforced by per-call timeouts upstream.  We
+\* therefore verify safety invariants only; liveness of the cascade
+\* loop is covered by the OCaml unit tests' bounded-iteration check.
+
+Spec == Init /\ [][Next]_vars
+
+(* ── Safety properties ──────────────────────────────────── *)
+
+\* The cycle counter never exceeds the configured bound.  The
+\* runtime translation: cycle_loop's [n + 1 >= strategy.cycle.max_cycles]
+\* check fires before we recurse, so [cycle = max_cycles] is only
+\* reachable when [outcome = "exhausted"].
+BoundedCycle ==
+    cycle <= MaxCycles - 1
+
+\* Once the cascade settles, attempted is non-empty (we tried
+\* something) and the result is consistent.
+TerminationConsistency ==
+    \/ outcome = "in_progress"
+    \/ /\ outcome = "accepted"
+       /\ accepted_provider \in Candidates
+       /\ \E c \in attempted : c[2] = accepted_provider
+    \/ /\ outcome = "exhausted"
+       /\ accepted_provider = NoneProvider
+
+\* Aggregate safety invariant referenced by the .cfg INVARIANTS.
+\* (NoDoubleAttempt is vacuous because [attempted] is a set, so
+\* duplicate adds are absorbed at the model level.  The runtime
+\* truth is that [try_cascade] consumes the remaining list by
+\* recursion — verified by the OCaml unit tests, not the spec.)
+Safety ==
+    /\ TypeOK
+    /\ BoundedCycle
+    /\ TerminationConsistency
+
+(* ──────────────────────────────────────────────────────── *)
+(* Bug Model — variants that introduce a regression.         *)
+(* ──────────────────────────────────────────────────────── *)
+
+\* Bug 1 — UnboundedCycleAdvance: cycle wrap-around / off-by-one
+\* would let the loop advance past MaxCycles.  Models a regression
+\* where the [cycle + 1 >= max_cycles] guard is misimplemented as
+\* [cycle >= max_cycles] (off-by-one), letting the loop run one
+\* extra cycle.
+AdvanceCycleBuggy ==
+    /\ outcome = "in_progress"
+    /\ RemainingThisCycle = {}
+    /\ cycle' = cycle + 1                  \* no upper guard
+    /\ UNCHANGED << attempted, outcome, accepted_provider >>
+
+NextBuggy ==
+    \/ \E c \in Candidates : Accept(c)
+    \/ \E c \in Candidates : Fail(c)
+    \/ AdvanceCycleBuggy
+    \/ Exhaust
+
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+====


### PR DESCRIPTION
## Summary

First slice of Phase C (#7609): TLA+ boundary contract for the pluggable cascade strategy system (#7606 + #7611). Code-free — only `specs/boundary/` additions.

## What's modelled

| Concept | Runtime | Spec |
|---------|---------|------|
| Cycle counter | `cycle_loop n` in `oas_worker_named.ml` | `cycle \in 0..MaxCycles` |
| Remaining candidates | list consumed by `try_cascade` recursion | `{c \in Candidates : <<cycle, c>> \notin attempted}` |
| Accept | FSM `Accept` / `Accept_on_exhaustion` | `outcome' = "accepted"` |
| AdvanceCycle guard | `n + 1 >= strategy.cycle.max_cycles` | `cycle + 1 < MaxCycles` |
| Exhaust | `Cascade_exhausted` | `outcome' = "exhausted"` |

## Properties (clean cfg)

- **TypeOK** — variable domains.
- **BoundedCycle** — `cycle ≤ MaxCycles - 1`. The runtime relies on the `cycle + 1 >= max_cycles` check firing before recursion.
- **TerminationConsistency** — `accepted ⇒ accepted_provider ∈ Candidates ∧ attempted contains that pair`; `exhausted ⇒ no provider`.

TLC result: 76 states, 61 distinct, depth 13 — no error.

## Bug model (`-buggy.cfg`)

`AdvanceCycleBuggy` drops the upper-bound guard (models an off-by-one regression where `cycle >= max_cycles` replaces `cycle + 1 >= max_cycles`). Expected: BoundedCycle **must** violate.

TLC result: 19 states, **BoundedCycle violated at depth 7** — pair is healthy.

## Why no liveness

`EventuallyTerminates` would require a fairness assumption that every (cycle, candidate) pair gets a provider response in finite time. That assumption lives at the call-timeout layer upstream, not inside the cascade strategy module. Bounded-iteration behaviour is covered directly by `test_cascade_strategy.ml` OCaml unit tests.

## Why no NoDoubleAttempt

`attempted` is modelled as a set, which absorbs duplicate adds. The runtime guarantee (one try per `(cycle, candidate)` from `try_cascade` recursion consuming `remaining`) is covered by the OCaml tests instead of the spec — keeping the state space tractable.

## Out of scope (separate PRs, also part of #7609)

- Ollama `/api/ps` Discovery probe (replaces the Phase A client semaphore for ollama URLs).
- CLI provider capacity (gemini_cli / claude) — generalisation of `<name>_ollama_max_concurrent`.
- Sticky liveness spec (requires explicit TTL event modelling).

## Verification

```
cd specs && make check-clean  # CascadeStrategy.cfg → no error
cd specs && make check-buggy  # CascadeStrategy-buggy.cfg → violation expected
```

Both auto-picked up by `find . -name '*.cfg'` in the existing Makefile (no Makefile changes needed).

## References

- Phase A: #7606 — `c6cd5167c`
- Phase B: #7611 — `33e9002ad`
- Phase C tracking: #7609

🤖 Generated with [Claude Code](https://claude.com/claude-code)