### PR TITLE
chore(keeper): retro-clean script for stale continuity_summary (Issue #7613 Part B)

### DIFF
--- a/scripts/retro-clean-keeper-continuity.sh
+++ b/scripts/retro-clean-keeper-continuity.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# retro-clean-keeper-continuity.sh — one-shot cleanup of stale
+# continuity_summary fields in .masc/keepers/*.json.
+#
+# Context: Issue #7613. PR #7612 restored RFC-MASC-001 Phase 1
+# read/save symmetry for Checkpoint.working_context, but existing
+# keeper.json files still carry 370–1039 char accumulated narrative in
+# continuity_summary. That text survives the checkpoint-less fallback
+# path and feeds the resonance loop.
+#
+# This script:
+#   1. Scans .masc/keepers/*.json, reports continuity_summary size
+#      per keeper.
+#   2. With --apply, backs up each file to
+#      .masc/keepers/_backup-retro-clean-<ts>/ and sets
+#      continuity_summary = "". All other fields (including
+#      last_continuity_update_ts and runtime) are preserved.
+#
+# Usage:
+#   scripts/retro-clean-keeper-continuity.sh                # dry-run
+#   scripts/retro-clean-keeper-continuity.sh --apply        # write
+#   scripts/retro-clean-keeper-continuity.sh --base-path /path/to/me --apply
+#
+# Restore:
+#   cp .masc/keepers/_backup-retro-clean-<ts>/*.json .masc/keepers/
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+APPLY=0
+BASE_PATH="${PWD}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1 ;;
+    --base-path) shift; BASE_PATH="${1:?}" ;;
+    --base-path=*) BASE_PATH="${1#--base-path=}" ;;
+    -h|--help)
+      sed -n '2,26p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+KEEPER_DIR="${BASE_PATH}/.masc/keepers"
+if [ ! -d "$KEEPER_DIR" ]; then
+  echo "ERROR: $KEEPER_DIR not found" >&2
+  exit 1
+fi
+
+TS=$(date +%Y%m%d-%H%M%S)
+BACKUP_DIR="${KEEPER_DIR}/_backup-retro-clean-${TS}"
+
+if [ "$APPLY" -eq 1 ]; then
+  mkdir -p "$BACKUP_DIR"
+  echo "Backup dir: $BACKUP_DIR"
+fi
+
+total=0
+nonempty=0
+cleared=0
+chars_freed=0
+
+shopt -s nullglob
+for f in "$KEEPER_DIR"/*.json; do
+  [ -f "$f" ] || continue
+  name=$(basename "$f" .json)
+  case "$name" in
+    _backup*) continue ;;
+  esac
+
+  # wc -c counts a trailing newline that jq adds to -r output;
+  # subtract 1 to get the actual string length.
+  raw_len=$(jq -r '.continuity_summary // ""' "$f" | wc -c | tr -d ' ')
+  len=$(( raw_len > 0 ? raw_len - 1 : 0 ))
+
+  total=$((total + 1))
+
+  if [ "$len" -le 0 ]; then
+    printf "  skip  %-24s (empty)\n" "$name"
+    continue
+  fi
+
+  nonempty=$((nonempty + 1))
+  printf "  clear %-24s %5d chars\n" "$name" "$len"
+
+  if [ "$APPLY" -eq 1 ]; then
+    cp "$f" "$BACKUP_DIR/$name.json"
+    tmp=$(mktemp)
+    jq '.continuity_summary = ""' "$f" > "$tmp"
+    mv "$tmp" "$f"
+    cleared=$((cleared + 1))
+    chars_freed=$((chars_freed + len))
+  fi
+done
+
+echo ""
+echo "Total keepers:         $total"
+echo "With non-empty summary: $nonempty"
+if [ "$APPLY" -eq 1 ]; then
+  echo "Cleared:                $cleared"
+  echo "Chars freed:            $chars_freed"
+  echo "Backup:                 $BACKUP_DIR"
+else
+  echo "Would clear:            $nonempty"
+  echo "Run with --apply to modify files."
+fi


### PR DESCRIPTION
## 배경

Issue #7613 Part B. PR #7612 가 `Checkpoint.working_context` save/read 비대칭을 해소했지만, 기존 `.masc/keepers/*.json` 의 `continuity_summary` 필드에 누적된 narrative 텍스트는 그대로 남아있음. 체크포인트-부재 fallback 경로에서 여전히 주입되어 resonance loop 유지.

로컬 측정(2026-04-16): 12 keeper 모두 370~1038 chars 누적. 합계 ~7.9k chars.

## 변경

신규: `scripts/retro-clean-keeper-continuity.sh`

- `.masc/keepers/*.json` 의 `continuity_summary` 를 안전하게 비우는 one-shot 정리 스크립트
- 기본 dry-run, `--apply` 플래그로만 실제 쓰기
- `--apply` 시 타임스탬프 backup 디렉토리 생성 후 파일별 백업
- 다른 필드(`last_continuity_update_ts`, `runtime`, 기타)는 전부 보존 → keeper가 다음 턴에 자연 재도출

## Dry-run 출력 (로컬)

\`\`\`
  clear analyst                    462 chars
  clear ani1999                    371 chars
  clear cheolsu                    857 chars
  clear janitor                    379 chars
  clear masc-improver              781 chars
  clear minjae                     825 chars
  clear nick0cave                  518 chars
  clear poe                        370 chars
  clear qa-king                    855 chars
  clear sangsu                     609 chars
  clear sojin                     1038 chars
  clear verdict                    854 chars

Total keepers:         12
With non-empty summary: 12
Would clear:            12
\`\`\`

## 사용 예

\`\`\`bash
# 1) dry-run (기본)
scripts/retro-clean-keeper-continuity.sh

# 2) 다른 MASC 루트를 대상으로
scripts/retro-clean-keeper-continuity.sh --base-path ~/me

# 3) 실제 적용
scripts/retro-clean-keeper-continuity.sh --apply

# 4) 복원
cp .masc/keepers/_backup-retro-clean-<ts>/*.json .masc/keepers/
\`\`\`

## 안전성

- Dry-run default
- Per-file backup에 timestamp 붙임 → 같은 날 여러 번 실행해도 덮어쓰기 없음
- jq 이용한 atomic read→write (tmp + mv)
- `set -euo pipefail` + `case` 로 파일명 sanity
- shellcheck pass

## Non-Goals

- `MASC_STRUCTURED_STATE` 기본값 전환 — Issue #7613 Part A, 별도 결정
- `continuity_fallback_summary_text` 경로 자체 개선 — Issue #7613 Part C
- PR #7612 (save/read symmetry) — 선행 PR, 본 스크립트는 그 위에 쌓음

## 머지 순서 권장

1. PR #7612 머지 (symmetry 복구)
2. 본 PR 머지 (스크립트 추가)
3. 운영자 수동 실행: `scripts/retro-clean-keeper-continuity.sh --apply`
4. (선택) Issue #7613 Part A — 플래그 기본값 전환