### PR TITLE
docs(configuration): replace ghost MASC_*_DEFAULT_MODEL rows with real env vars

### DIFF
--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -142,12 +142,14 @@ contains four sections: `tts`, `stt`, `session`, `local_playback`.
 | `MASC_INFERENCE_CACHE_MAX_TEMP` | float | 0.0 | 캐시 허용 최대 온도 |
 | `MASC_INFERENCE_CACHE_L1_MAX_ENTRIES` | int | 512 | L1 인메모리 캐시 상한 |
 | `MASC_SPAWN_CACHE_POLICY` | string | `"safe_only"` | Spawn 캐시 정책 (`off`/`safe_only`) |
-| `MASC_GLM_DEFAULT_MODEL` | string | `"glm-4.7"` | GLM 기본 모델 |
-| `MASC_GLM_FLASH_MODEL` | string | `"glm-4.7-flash"` | GLM flash 모델 |
-| `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | Gemini 기본 모델 (cascade_model_resolve.ml 이 읽는 실제 env var 이름; 2026-04-16 이전 이 문서는 `MASC_GEMINI_DEFAULT_MODEL` 로 잘못 표기) |
-| `MASC_GEMINI_FLASH_MODEL` | string | `"gemini-2.5-flash"` | Gemini flash 모델 |
-| `MASC_CLAUDE_DEFAULT_MODEL` | string | `"claude-sonnet-4-6"` | Claude 기본 모델 |
-| `MASC_OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | OpenAI 기본 모델 |
+| `ZAI_DEFAULT_MODEL` | string | `"glm-5.1"` | `glm` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:38) |
+| `ZAI_CODING_DEFAULT_MODEL` | string | `"glm-4.7"` | `glm-coding` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:43) |
+| `GEMINI_DEFAULT_MODEL` | string | `"gemini-3-flash-preview"` | `gemini` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:67) |
+| `ANTHROPIC_DEFAULT_MODEL` | string | `"claude-sonnet-4-6-20250514"` | `claude` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:70) |
+| `OPENAI_DEFAULT_MODEL` | string | `"gpt-4.1"` | `openai` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:73) |
+| `OLLAMA_DEFAULT_MODEL` | string | `""` | `ollama` provider `auto` 기본 모델 (lib/config/env_config_runtime.ml:181) |
+| `LLAMA_DEFAULT_MODEL` | string | `"explicit-model-required"` | `llama` provider legacy local runtime 기본 모델 (lib/config/env_config_runtime.ml:150) |
+| `OPENROUTER_DEFAULT_MODEL` | string | (없음) | `openrouter` provider `auto` 기본 모델 (lib/cascade/cascade_model_resolve.ml:76) |
 
 **Keeper Autonomy (자율 에이전트)**: `MASC_AUTONOMY_*` prefix.
 
@@ -330,9 +332,12 @@ JSON 파일로 CASCADE별 모델 순서를 정의한다. 키 패턴: `{cascade_n
 |----------|----------------|----------|
 | `ollama` | `Local_runtime` | `OLLAMA_DEFAULT_MODEL` (port 11434, 262k context) |
 | `llama` | `Local_runtime` | `LLAMA_DEFAULT_MODEL` (legacy local OpenAI-compatible runtime) |
-| `glm` | `Glm` | `MASC_GLM_DEFAULT_MODEL` |
+| `glm` | `Glm` | `ZAI_DEFAULT_MODEL` |
+| `glm-coding` | `Glm` | `ZAI_CODING_DEFAULT_MODEL` |
 | `gemini` | `Gemini` | `GEMINI_DEFAULT_MODEL` |
-| `claude` | `Claude` | `MASC_CLAUDE_DEFAULT_MODEL` |
+| `claude` | `Claude` | `ANTHROPIC_DEFAULT_MODEL` |
+| `openai` | `OpenAI` | `OPENAI_DEFAULT_MODEL` |
+| `openrouter` | `OpenRouter` | `OPENROUTER_DEFAULT_MODEL` |
 
 ### 7.3 Per-cascade 추론 파라미터
 


### PR DESCRIPTION
## Context

\`docs/spec/14-configuration.md\` 의 Env_config_governance 섹션 (라인 145-150) 이 6 개의 \`MASC_*_DEFAULT_MODEL\` env var 을 문서화해왔다. 그러나 **이 중 어떤 것도 코드에서 읽지 않는다**:

\`\`\`
$ rg 'MASC_GLM_DEFAULT_MODEL|MASC_GEMINI_DEFAULT_MODEL|MASC_CLAUDE_DEFAULT_MODEL|MASC_OPENAI_DEFAULT_MODEL|MASC_GLM_FLASH_MODEL|MASC_GEMINI_FLASH_MODEL' lib/
# (no matches)
\`\`\`

실제로 코드가 \`env_or\` 로 읽는 env var 이름은 다르다:

| 표기 | 실제 코드 | 출처 |
|------|----------|------|
| \`MASC_GLM_DEFAULT_MODEL\` | \`ZAI_DEFAULT_MODEL\` | lib/cascade/cascade_model_resolve.ml:38 |
| \`MASC_GLM_FLASH_MODEL\` | \`ZAI_CODING_DEFAULT_MODEL\` | cascade_model_resolve.ml:43 (glm-coding provider) |
| \`MASC_GEMINI_DEFAULT_MODEL\` | \`GEMINI_DEFAULT_MODEL\` | cascade_model_resolve.ml:67 |
| \`MASC_CLAUDE_DEFAULT_MODEL\` | \`ANTHROPIC_DEFAULT_MODEL\` | cascade_model_resolve.ml:70 |
| \`MASC_OPENAI_DEFAULT_MODEL\` | \`OPENAI_DEFAULT_MODEL\` | cascade_model_resolve.ml:73 |
| — | \`OPENROUTER_DEFAULT_MODEL\` | cascade_model_resolve.ml:76 |
| — | \`OLLAMA_DEFAULT_MODEL\` | env_config_runtime.ml:181 |
| — | \`LLAMA_DEFAULT_MODEL\` | env_config_runtime.ml:150 |

기본값도 밀려있었다. 예: 문서는 \`MASC_GLM_DEFAULT_MODEL = "glm-4.7"\`, 코드는 \`ZAI_DEFAULT_MODEL = "glm-5.1"\`.

## Changes

**Section 3.3 Governance (라인 145-150 → 145-152, 8 rows)**: 6 개 ghost row 를 **code-verified 8 개 row** 로 교체. 각 row 에 file:line 출처를 주석으로 박아 앞으로 drift 발견이 쉽게.

**Section 7.2 Provider mapping (라인 335-337 → 335-340)**: 같은 정정. \`glm-coding\` / \`openai\` / \`openrouter\` row 추가.

## Overlap with #7610

[#7610](https://github.com/jeong-sik/masc-mcp/pull/7610) 도 Gemini row 에서 \`MASC_GEMINI_DEFAULT_MODEL\` → \`GEMINI_DEFAULT_MODEL\` 정정. **Content 는 동일**하므로 merge 순서 무관 — 두 번째 PR 가 trivial rebase 한 번만 하면 됨.

## Verification

Docs-only, 빌드/테스트 영향 없음. 각 env var 이름을 \`rg\` 로 lib/ 에서 확인:

- \`rg ZAI_DEFAULT_MODEL lib/\` → cascade_model_resolve.ml:38
- \`rg GEMINI_DEFAULT_MODEL lib/\` → cascade_model_resolve.ml:67
- \`rg ANTHROPIC_DEFAULT_MODEL lib/\` → cascade_model_resolve.ml:70
- ... (all 8 rows traced to concrete file:line)

## Follow-ups (별도 PR)

- \`MASC_CHAIN_JUDGE_MODEL\` (라인 128) 동일 검증 — \`rg MASC_CHAIN_JUDGE_MODEL lib/\` 결과 확인 필요
- 섹션 5 의 다른 model config table (briefing_models, keeper_unified_models 등) 실제 코드 정렬 확인
- \`MASC_DEFAULT_PROVIDER\` / \`MASC_DEFAULT_MODEL\` / \`MASC_DEFAULT_CASCADE\` — provider_adapter.ml:728/748/877 에서 읽음, 별도 row 로 문서화 고려