### PR TITLE
feat(keeper): flip MASC_STRUCTURED_STATE default to true (Issue #7613 Part A)

### DIFF
--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -173,8 +173,8 @@ let keeper_entries =
       "Max heartbeat failures before crash";
     entry ~default:"10" "MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES"
       "Max turn failures before crash";
-    entry ~default:"(none)" "MASC_STRUCTURED_STATE"
-      "Enable structured JSON state in checkpoints";
+    entry ~default:"true" "MASC_STRUCTURED_STATE"
+      "Enable structured JSON state in checkpoints (default true; set to \"false\" to opt out)";
     entry ~default:"(none)" "MASC_TLA_TRACE"
       "Enable TLA+ trace emission";
   ]

--- a/lib/keeper/keeper_context_core.ml
+++ b/lib/keeper/keeper_context_core.ml
@@ -1215,11 +1215,14 @@ let load_context_from_checkpoint ~max_checkpoint_messages ~trace_id ~primary_mod
 
 (** Feature flag: when true, store structured JSON in
     [Checkpoint.working_context] alongside the text [STATE] block.
-    Default false — existing behavior preserved. RFC-MASC-001 Phase 1. *)
+    Default TRUE as of RFC-MASC-001 Phase 1 rollout; set
+    [MASC_STRUCTURED_STATE=false] to restore legacy text-only behavior.
+    Accepted false values: [false], [0], [no]. Any other value (or
+    unset) enables the structured path. *)
 let structured_state_enabled () =
   match Sys.getenv_opt "MASC_STRUCTURED_STATE" with
-  | Some ("true" | "1" | "yes") -> true
-  | _ -> false
+  | Some ("false" | "0" | "no") -> false
+  | _ -> true
 
 (** Patch an OAS checkpoint: unify session_id and replace the last
     assistant message's text content with [response_text] (which includes


### PR DESCRIPTION
## 배경

RFC-MASC-001 Phase 1은 `MASC_STRUCTURED_STATE` 플래그 ON을 전제로 save 경로(structured JSON → `Checkpoint.working_context`) + read 경로를 설계함. 실제 코드는 기본값 OFF로 병합되어 Phase 1이 실질적으로 inert 상태였음.

3-PR 체인으로 echo resonance 해소:

| PR | 역할 | 상태 |
|---|---|---|
| #7612 | read/save symmetry (keeper_world_observation) | Draft |
| #7615 | retro-clean 스크립트 (누적 continuity_summary 정리) | Draft |
| **본 PR** | flag 기본값 TRUE 전환 | Draft |

세 PR 머지 후 resonance loop 실질 해소.

## 변경

`lib/keeper/keeper_context_core.ml:1219`

\`\`\`ocaml
(* before *)
let structured_state_enabled () =
  match Sys.getenv_opt "MASC_STRUCTURED_STATE" with
  | Some (\"true\" | \"1\" | \"yes\") -> true
  | _ -> false

(* after *)
let structured_state_enabled () =
  match Sys.getenv_opt "MASC_STRUCTURED_STATE" with
  | Some (\"false\" | \"0\" | \"no\") -> false
  | _ -> true
\`\`\`

+ `lib/config/env_config_snapshot.ml` 기본값 문자열 `\"(none)\"` → `\"true\"`

## 호환성 감사

- `structured_state_enabled()` 참조: 정의(1219) + patch_checkpoint 조건(1257) **2곳뿐**. 다른 경로 영향 없음.
- 기존 체크포인트 35/35 (로컬 측정): `working_context = null`. flip 후 다음 턴에 structured JSON 쓰기 → 그 다음 턴부터 read 활성. 손상 위험 없음.
- 테스트: `test_keeper_state_snapshot_json.ml`이 `Unix.putenv`로 \"true\"/\"false\" 명시 설정. default 변경 불변. 13/13 pass.
- 전체 빌드: `dune build --root .` 75s green.

## Opt-out

\`MASC_STRUCTURED_STATE=false\` (또는 0, no) 설정 시 legacy text-only 경로 복원. 운영 중 문제 발생 시 env var로 즉시 롤백 가능.

## 머지 순서

1. PR #7612 (선결) — read 경로가 structured JSON을 실제로 읽기
2. PR #7615 (권장) — 누적 오염 정리
3. **본 PR** — flag ON으로 전환해서 save 경로 활성

순서 어긋나도 silent degrade (기존 동작 유지), 영구 손상 없음.

## Non-Goals

- Phase 2-5 (RFC-MASC-001의 [STATE] 텍스트 제거 및 flag 삭제) — 별도 PR
- `continuity_fallback_summary_text` 개선 — Issue #7613 Part C
- 운영 대시보드에 flag 상태 표시 — 필요 시 별도 follow-up