### PR TITLE
feat(dashboard): session trace Phase 2 — status filter, search, highlight

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -11,7 +11,7 @@
         "@formkit/auto-animate": "^0.9.0",
         "@preact/signals": "^2.9.0",
         "cytoscape": "^3.33.2",
-        "dompurify": "^3.3.3",
+        "dompurify": "^3.4.0",
         "downshift": "^9.3.2",
         "htm": "^3.1.1",
         "lucide-preact": "^1.8.0",
@@ -20,6 +20,7 @@
         "ninja-keys": "^1.2.2",
         "preact": "^10.29.1",
         "shiki": "^4.0.2",
+        "valibot": "^1.3.1",
         "vis-data": "^8.0.3",
         "vis-network": "^10.0.2",
         "vis-timeline": "^8.5.0"
@@ -4175,9 +4176,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7187,7 +7188,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -7354,6 +7355,20 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.3.1.tgz",
+      "integrity": "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vfile": {

--- a/dashboard/src/components/session-trace/session-trace-entry.ts
+++ b/dashboard/src/components/session-trace/session-trace-entry.ts
@@ -13,6 +13,48 @@ import type { UnifiedTraceEvent, TraceEventKind } from './session-trace-state'
 // ── Constants ──────────────────────────────────────────
 
 const BROADCAST_PREVIEW_MAX = 160
+
+// ── Search highlight ────────────────────────────────────
+
+interface HighlightSegment {
+  text: string
+  match: boolean
+}
+
+function highlightSegments(text: string, query: string): HighlightSegment[] | null {
+  if (!query) return null
+  const lower = text.toLowerCase()
+  const q = query.toLowerCase()
+  if (!lower.includes(q)) return null
+
+  const parts: HighlightSegment[] = []
+  let lastIndex = 0
+  let index = lower.indexOf(q, lastIndex)
+  while (index !== -1) {
+    if (index > lastIndex) {
+      parts.push({ text: text.slice(lastIndex, index), match: false })
+    }
+    parts.push({ text: text.slice(index, index + q.length), match: true })
+    lastIndex = index + q.length
+    index = lower.indexOf(q, lastIndex)
+  }
+  if (lastIndex < text.length) {
+    parts.push({ text: text.slice(lastIndex), match: false })
+  }
+  return parts
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  const segments = highlightSegments(text, query)
+  if (!segments) return html`<span>${text}</span>`
+  return html`
+    <span>${segments.map(seg =>
+      seg.match
+        ? html`<mark class="bg-[rgba(99,102,241,0.25)] text-[var(--text-strong)] px-0.5 rounded">${seg.text}</mark>`
+        : seg.text
+    )}</span>
+  `
+}
 const RESULT_COLLAPSED_MAX_HEIGHT = 200 // px
 const RESULT_LINES_THRESHOLD = 12 // lines above which we collapse
 
@@ -352,6 +394,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
     const stopReason = typeof d.stop_reason === 'string' ? d.stop_reason : ''
     const durationMs = typeof d.duration_ms === 'number' ? d.duration_ms : null
     const turn = d.turn
+    const responseText = typeof d.response_text === 'string' ? d.response_text : ''
     const stopColor = stopReason === 'end_turn' || stopReason === 'stop' ? 'text-[var(--ok)]' : 'text-[var(--warn)]'
     return html`
       <div class="mt-2 px-3 py-2 rounded-lg bg-[rgba(34,211,238,0.04)] border border-[rgba(34,211,238,0.12)] space-y-1">
@@ -361,6 +404,12 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
           ${durationMs != null ? html`<span><span class="text-[var(--text-dim)]">소요:</span> <span class="font-mono ${durationColor(durationMs)}">${formatDuration(durationMs)}</span></span>` : null}
           ${turn != null ? html`<span><span class="text-[var(--text-dim)]">턴:</span> <span class="font-mono">${String(turn)}</span></span>` : null}
         </div>
+        ${responseText ? html`
+          <details class="mt-1">
+            <summary class="text-[10px] text-[var(--text-dim)] cursor-pointer hover:text-[var(--text-body)]">응답 텍스트</summary>
+            <pre class="mt-1 p-2 rounded bg-[var(--white-3)] text-[11px] font-mono text-[var(--text-body)] whitespace-pre-wrap break-all max-h-[300px] overflow-auto">${responseText}</pre>
+          </details>
+        ` : null}
       </div>
     `
   }
@@ -393,7 +442,7 @@ function OasDetail({ event }: { event: UnifiedTraceEvent }) {
   `
 }
 
-export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
+export function SessionTraceEntry({ event, searchQuery }: { event: UnifiedTraceEvent; searchQuery?: string }) {
   const kindStyle = KIND_STYLES[event.kind]
   // For tool_call, use tool-specific icon/color
   // For lifecycle + durable_kind, use durable-specific icon/color
@@ -463,7 +512,7 @@ export function SessionTraceEntry({ event }: { event: UnifiedTraceEvent }) {
                 : null}
         </div>
         <div class="mt-0.5 text-[11px] text-[var(--text-muted)] font-mono truncate max-w-full" title=${event.summary}>
-          ${summaryText}
+          <${HighlightedText} text=${summaryText} query=${searchQuery ?? ''} />
         </div>
       </div>
 

--- a/dashboard/src/components/session-trace/session-trace-filter.ts
+++ b/dashboard/src/components/session-trace/session-trace-filter.ts
@@ -1,14 +1,20 @@
-// Session trace filter — FilterChips wrapper for trace event kinds.
+// Session trace filter — category chips, status chips, and search input.
 // Receives agentName as prop to avoid global activeTraceAgent dependency.
 
 import { html } from 'htm/preact'
 import { FilterChips } from '../common/filter-chips'
-import { getKindCounts, getTraceFilter, setTraceFilter, _traceSlots } from './session-trace-state'
-import type { TraceEventKind } from './session-trace-state'
+import {
+  getKindCounts, getTraceFilter, setTraceFilter,
+  getStatusCounts, getTraceStatusFilter, setTraceStatusFilter,
+  getTraceSearchQuery, setTraceSearchQuery,
+  _traceSlots,
+} from './session-trace-state'
+import type { TraceEventKind, TraceStatus } from './session-trace-state'
 
 type FilterKey = TraceEventKind | 'all'
+type StatusKey = TraceStatus | 'all'
 
-const CHIP_DEFS: Array<{ key: FilterKey; label: string }> = [
+const CATEGORY_CHIPS: Array<{ key: FilterKey; label: string }> = [
   { key: 'all',        label: '전체' },
   { key: 'tool_call',  label: '도구 호출' },
   { key: 'oas_tool',   label: 'OAS 도구' },
@@ -21,6 +27,13 @@ const CHIP_DEFS: Array<{ key: FilterKey; label: string }> = [
   { key: 'lifecycle',  label: '생명주기' },
 ]
 
+const STATUS_CHIPS: Array<{ key: StatusKey; label: string }> = [
+  { key: 'all',           label: '전체' },
+  { key: 'success',       label: '성공' },
+  { key: 'failure',       label: '실패' },
+  { key: 'gate_rejected', label: '게이트 거부' },
+]
+
 export function SessionTraceFilter({ agentName }: { agentName: string }) {
   // Read _traceSlots.value to subscribe to slot changes
   void _traceSlots.value
@@ -28,17 +41,63 @@ export function SessionTraceFilter({ agentName }: { agentName: string }) {
   const counts = getKindCounts(agentName)
   const currentFilter = getTraceFilter(agentName)
 
-  const chips = CHIP_DEFS
+  const categoryChips = CATEGORY_CHIPS
     .filter(c => c.key === 'all' || (counts[c.key] ?? 0) > 0)
     .map(c => ({ ...c, count: counts[c.key] || null }))
 
+  const statusCounts = getStatusCounts(agentName)
+  const currentStatus = getTraceStatusFilter(agentName)
+
+  const statusChips = STATUS_CHIPS
+    .filter(c => c.key === 'all' || (statusCounts[c.key] ?? 0) > 0)
+    .map(c => ({ ...c, count: statusCounts[c.key] || null }))
+
+  const searchQuery = getTraceSearchQuery(agentName)
+
   return html`
-    <${FilterChips}
-      chips=${chips}
-      value=${currentFilter}
-      onChange=${(key: FilterKey) => { setTraceFilter(agentName, key) }}
-      size="sm"
-      tone="accent"
-    />
+    <div class="space-y-2">
+      <!-- Search -->
+      <div class="relative">
+        <input
+          type="text"
+          placeholder="이벤트 검색..."
+          value=${searchQuery}
+          onInput=${(e: Event) => {
+            const v = (e.target as HTMLInputElement).value
+            setTraceSearchQuery(agentName, v)
+          }}
+          class="w-full px-3 py-1.5 text-[12px] rounded-lg bg-[var(--white-3)] border border-[var(--white-6)] text-[var(--text-body)] placeholder:text-[var(--text-dim)] outline-none focus:border-[var(--accent)]"
+        />
+        ${searchQuery ? html`
+          <button
+            onClick=${() => setTraceSearchQuery(agentName, '')}
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-dim)] hover:text-[var(--text-body)] text-[14px] leading-none"
+          >\u00d7</button>
+        ` : null}
+      </div>
+
+      <!-- Category chips -->
+      <${FilterChips}
+        chips=${categoryChips}
+        value=${currentFilter}
+        onChange=${(key: FilterKey) => { setTraceFilter(agentName, key) }}
+        size="sm"
+        tone="accent"
+      />
+
+      <!-- Status chips -->
+      ${statusCounts.all > 0 ? html`
+        <div>
+          <div class="text-[10px] text-[var(--text-dim)] mb-1">상태</div>
+          <${FilterChips}
+            chips=${statusChips}
+            value=${currentStatus}
+            onChange=${(key: StatusKey) => { setTraceStatusFilter(agentName, key) }}
+            size="sm"
+            tone="neutral"
+          />
+        </div>
+      ` : null}
+    </div>
   `
 }

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -8,6 +8,10 @@ import {
   getKindCounts,
   setTraceFilter,
   getTraceFilter,
+  setTraceStatusFilter,
+  getTraceStatusFilter,
+  setTraceSearchQuery,
+  getStatusCounts,
   getTraceLoading,
   getTraceError,
   buildTraceEvents,
@@ -40,6 +44,8 @@ describe('appendLiveToolCall', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -70,6 +76,8 @@ describe('appendLiveToolCall', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -94,6 +102,8 @@ describe('appendLiveToolCall', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -135,6 +145,8 @@ describe('appendLiveToolCall', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -247,6 +259,8 @@ describe('getTraceSummary', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -285,6 +299,8 @@ describe('getTraceSummary', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -331,6 +347,8 @@ describe('getTraceSummary', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -375,6 +393,8 @@ describe('getTraceSummary', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -397,6 +417,8 @@ describe('getKindCounts', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -420,6 +442,8 @@ describe('filter', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -440,6 +464,8 @@ describe('closeSessionTrace', () => {
         loading: false,
         error: null,
         filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
         fetchToken: 0,
       },
     }
@@ -448,5 +474,165 @@ describe('closeSessionTrace', () => {
     expect(getTraceEvents('keeper-a')).toEqual([])
     expect(getTraceLoading('keeper-a')).toBe(false)
     expect(getTraceError('keeper-a')).toBeNull()
+  })
+})
+
+describe('status filter', () => {
+  it('classifies tool_call as success and events with error as failure', () => {
+    traceSlots.value = {
+      'keeper-a': {
+        events: [
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'read', detail: {} },
+          { id: '2', ts: 2000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'fail', detail: {}, error: 'timeout' },
+          { id: '3', ts: 3000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'rejected', detail: {}, gate: { status: 'reject', reason: 'unsafe' } },
+          { id: '4', ts: 4000, ts_iso: '', kind: 'broadcast', sourceLane: 'masc', summary: 'hello', detail: {} },
+        ],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+
+    const counts = getStatusCounts('keeper-a')
+    expect(counts.success).toBe(1)
+    expect(counts.failure).toBe(1)
+    expect(counts.gate_rejected).toBe(1)
+    expect(counts.all).toBe(3) // broadcast has no status
+  })
+
+  it('filters events by status', () => {
+    traceSlots.value = {
+      'keeper-a': {
+        events: [
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'ok', detail: {} },
+          { id: '2', ts: 2000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'fail', detail: {}, error: 'err' },
+        ],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+
+    setTraceStatusFilter('keeper-a', 'failure')
+    expect(getTraceStatusFilter('keeper-a')).toBe('failure')
+    const filtered = getFilteredEvents('keeper-a')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]!.error).toBe('err')
+  })
+
+  it('combines category filter and status filter', () => {
+    traceSlots.value = {
+      'keeper-a': {
+        events: [
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'ok', detail: {} },
+          { id: '2', ts: 2000, ts_iso: '', kind: 'oas_tool', sourceLane: 'oas', summary: 'oas-ok', detail: {} },
+          { id: '3', ts: 3000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'fail', detail: {}, error: 'err' },
+        ],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+
+    setTraceFilter('keeper-a', 'tool_call')
+    setTraceStatusFilter('keeper-a', 'success')
+    const filtered = getFilteredEvents('keeper-a')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]!.id).toBe('1')
+  })
+})
+
+describe('search filter', () => {
+  it('matches against summary, toolName, and error fields', () => {
+    traceSlots.value = {
+      'keeper-a': {
+        events: [
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'read file', detail: {}, toolName: 'fs_read' },
+          { id: '2', ts: 2000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'edit code', detail: {}, toolName: 'edit_file' },
+          { id: '3', ts: 3000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'bash error', detail: {}, error: 'command not found' },
+        ],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+
+    // Match by summary
+    setTraceSearchQuery('keeper-a', 'read')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(1)
+
+    // Match by toolName
+    setTraceSearchQuery('keeper-a', 'edit')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(1)
+
+    // Match by error
+    setTraceSearchQuery('keeper-a', 'not found')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(1)
+
+    // No match
+    setTraceSearchQuery('keeper-a', 'nonexistent')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(0)
+  })
+
+  it('is case-insensitive', () => {
+    traceSlots.value = {
+      'keeper-a': {
+        events: [
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'Read File', detail: {} },
+        ],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+
+    setTraceSearchQuery('keeper-a', 'read')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(1)
+
+    setTraceSearchQuery('keeper-a', 'FILE')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(1)
+  })
+
+  it('combines with category and status filters', () => {
+    traceSlots.value = {
+      'keeper-a': {
+        events: [
+          { id: '1', ts: 1000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'read config', detail: {}, toolName: 'fs_read' },
+          { id: '2', ts: 2000, ts_iso: '', kind: 'tool_call', sourceLane: 'masc', summary: 'read config', detail: {}, toolName: 'fs_read', error: 'denied' },
+          { id: '3', ts: 3000, ts_iso: '', kind: 'broadcast', sourceLane: 'masc', summary: 'read this message', detail: {} },
+        ],
+        loading: false,
+        error: null,
+        filter: 'all',
+        statusFilter: 'all',
+        searchQuery: '',
+        fetchToken: 0,
+      },
+    }
+
+    // Search + category filter
+    setTraceFilter('keeper-a', 'tool_call')
+    setTraceSearchQuery('keeper-a', 'config')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(2)
+
+    // Search + category + status filter
+    setTraceStatusFilter('keeper-a', 'success')
+    expect(getFilteredEvents('keeper-a')).toHaveLength(1)
+    expect(getFilteredEvents('keeper-a')[0]!.id).toBe('1')
   })
 })

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -21,6 +21,8 @@ export type TraceEventKind =
   | 'oas_turn'
   | 'oas_context'
 
+export type TraceStatus = 'success' | 'failure' | 'gate_rejected'
+
 export type TraceSourceLane = 'masc' | 'oas'
 
 export interface UnifiedTraceEvent {
@@ -74,6 +76,8 @@ interface TraceSlot {
   loading: boolean
   error: string | null
   filter: TraceEventKind | 'all'
+  statusFilter: TraceStatus | 'all'
+  searchQuery: string
   /** Monotonic fetch token — used to discard stale in-flight responses. */
   fetchToken: number
 }
@@ -83,7 +87,7 @@ interface TraceSlot {
 const traceSlots = signal<Record<string, TraceSlot>>({})
 const liveTraceFeeds = signal<Record<string, UnifiedTraceEvent[]>>({})
 
-const EMPTY_SLOT: TraceSlot = { events: [], loading: false, error: null, filter: 'all', fetchToken: 0 }
+const EMPTY_SLOT: TraceSlot = { events: [], loading: false, error: null, filter: 'all', statusFilter: 'all', searchQuery: '', fetchToken: 0 }
 
 const LIVE_TRACE_LIMIT = 120
 let liveTraceSeq = 0
@@ -117,11 +121,65 @@ export function getTraceFilter(agent: string): TraceEventKind | 'all' {
   return getSlot(agent).filter
 }
 
+export function getTraceStatusFilter(agent: string): TraceStatus | 'all' {
+  return getSlot(agent).statusFilter
+}
+
+export function getTraceSearchQuery(agent: string): string {
+  return getSlot(agent).searchQuery
+}
+
+// ── Status classification ────────────────────────────────
+
+export function getEventStatus(e: UnifiedTraceEvent): TraceStatus | null {
+  if (e.gate?.status === 'reject') return 'gate_rejected'
+  if (e.error) return 'failure'
+  if (e.kind === 'tool_call' || e.kind === 'oas_tool') return 'success'
+  return null
+}
+
+// ── Search matching ──────────────────────────────────────
+
+function eventMatchesSearch(e: UnifiedTraceEvent, query: string): boolean {
+  const q = query.toLowerCase()
+  const fields = [
+    e.summary,
+    e.toolName,
+    e.error,
+    e.thinkingContent,
+    e.toolResult?.slice(0, 500),
+    ...Object.values(e.detail).map(v => typeof v === 'string' ? v : ''),
+  ]
+  return fields.some(f => f != null && f.toLowerCase().includes(q))
+}
+
 export function getFilteredEvents(agent: string): UnifiedTraceEvent[] {
-  const filter = getTraceFilter(agent)
+  const slot = getSlot(agent)
+  let events = getTraceEvents(agent)
+  if (slot.filter !== 'all') {
+    events = events.filter(e => e.kind === slot.filter)
+  }
+  if (slot.statusFilter !== 'all') {
+    events = events.filter(e => getEventStatus(e) === slot.statusFilter)
+  }
+  if (slot.searchQuery) {
+    events = events.filter(e => eventMatchesSearch(e, slot.searchQuery))
+  }
+  return events
+}
+
+export function getStatusCounts(agent: string): Record<TraceStatus | 'all', number> {
   const events = getTraceEvents(agent)
-  if (filter === 'all') return events
-  return events.filter(e => e.kind === filter)
+  let success = 0
+  let failure = 0
+  let gate_rejected = 0
+  for (const e of events) {
+    const s = getEventStatus(e)
+    if (s === 'success') success++
+    else if (s === 'failure') failure++
+    else if (s === 'gate_rejected') gate_rejected++
+  }
+  return { all: success + failure + gate_rejected, success, failure, gate_rejected }
 }
 
 export function getTraceSummary(agent: string): TraceSummary {
@@ -241,6 +299,14 @@ export { liveTraceFeeds as _liveTraceFeeds }
 
 export function setTraceFilter(agent: string, filter: TraceEventKind | 'all'): void {
   patchSlot(agent, { filter })
+}
+
+export function setTraceStatusFilter(agent: string, statusFilter: TraceStatus | 'all'): void {
+  patchSlot(agent, { statusFilter })
+}
+
+export function setTraceSearchQuery(agent: string, searchQuery: string): void {
+  patchSlot(agent, { searchQuery })
 }
 
 // ── Converters ─────────────────────────────────────────

--- a/dashboard/src/components/session-trace/session-trace-view.ts
+++ b/dashboard/src/components/session-trace/session-trace-view.ts
@@ -13,6 +13,7 @@ import {
   getTraceError,
   getFilteredEvents,
   getTraceSummary,
+  getTraceSearchQuery,
   loadSessionTrace,
   closeSessionTrace,
   _traceSlots,
@@ -112,6 +113,7 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
   const error = getTraceError(agentName)
   const events = getFilteredEvents(agentName)
   const summary = getTraceSummary(agentName)
+  const searchQuery = getTraceSearchQuery(agentName)
 
   // Auto-scroll to top when new events arrive (newest-first order)
   const prevCountRef = useRef(0)
@@ -183,7 +185,7 @@ export function SessionTraceView({ agentName, isKeeper, keeperStatus, keeperGene
         ref=${listRef}
         class="flex flex-col gap-0.5 max-h-[500px] overflow-y-auto rounded-lg border border-[var(--card-border)] bg-[var(--white-2)]"
       >
-        ${events.map(evt => html`<${SessionTraceEntry} key=${evt.id} event=${evt} />`)}
+        ${events.map(evt => html`<${SessionTraceEntry} key=${evt.id} event=${evt} searchQuery=${searchQuery} />`)}
         <${LiveIndicator} events=${events} />
       </div>
 


### PR DESCRIPTION
## Summary

- **상태 필터**: `TraceStatus`(success/failure/gate_rejected) 타입 + `getEventStatus` 분류기. 상태 chip으로 필터링.
- **텍스트 검색**: summary, toolName, error, thinkingContent, toolResult, detail 필드 대소문자 무시 검색.
- **검색 하이라이트**: `highlightSegments` 순수 함수 + `HighlightedText` 컴포넌트로 `<mark>` 렌더링.
- **3-way 필터 체인**: category → status → search 순차 적용.
- **LLM 응답 텍스트**: `response_text` 필드가 SSE 이벤트에 추가되면 자동 표시 (`<details>` 블록). 현재 백엔드는 메타데이터만 전송.
- **검색어 prop drilling**: view → entry로 `searchQuery` 전달하여 전역 상태 의존 없이 테스트 격리.

Phase 1 (#7605) 후속.

## Test plan

- [x] `vitest run src/components/session-trace/` — 26 tests passed (6 new)
- [x] `tsc --noEmit` — clean
- [x] `dune build` — clean
- [ ] 카테고리 필터 + 상태 필터 조합 동작 확인
- [ ] 검색어 입력 → 필터링 + 하이라이트 동작
- [ ] 검색 초기화 → 전체 이벤트 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)