### PR TITLE
feat(cascade): CLI client-capacity registration (Phase C3, closes #7609)

### DIFF
--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -84,6 +84,9 @@ let int_of_env ?(default = 0) name =
 let ollama_default_max () =
   max 1 (int_of_env ~default:1 "MASC_OLLAMA_MAX_CONCURRENT")
 
+let cli_default_max () =
+  max 1 (int_of_env ~default:1 "MASC_CLI_MAX_CONCURRENT")
+
 (* Parse "url=max,url=max,..." from MASC_CLIENT_CAPACITY. *)
 let parse_capacity_env s =
   String.split_on_char ',' s
@@ -132,6 +135,12 @@ let looks_like_ollama url =
      127.0.0.1, localhost, bare host:port). *)
   contains_substring url ":11434"
 
+let cli_sentinel_prefix = "cli:"
+
+let looks_like_cli_sentinel url =
+  let plen = String.length cli_sentinel_prefix in
+  String.length url > plen && String.sub url 0 plen = cli_sentinel_prefix
+
 let auto_register_for_candidates ~base_urls =
   let max_concurrent = ollama_default_max () in
   List.iter
@@ -146,3 +155,18 @@ let auto_register_ollama_with_override ~base_urls ~max_concurrent =
        if looks_like_ollama url && not (is_registered url) then
          register ~url ~max_concurrent)
     base_urls
+
+let auto_register_cli_for_candidates ~capacity_keys =
+  let max_concurrent = cli_default_max () in
+  List.iter
+    (fun key ->
+       if looks_like_cli_sentinel key && not (is_registered key) then
+         register ~url:key ~max_concurrent)
+    capacity_keys
+
+let auto_register_cli_with_override ~capacity_keys ~max_concurrent =
+  List.iter
+    (fun key ->
+       if looks_like_cli_sentinel key && not (is_registered key) then
+         register ~url:key ~max_concurrent)
+    capacity_keys

--- a/lib/cascade/cascade_client_capacity.mli
+++ b/lib/cascade/cascade_client_capacity.mli
@@ -65,6 +65,35 @@ val auto_register_ollama_with_override :
     Idempotent and only touches URLs that look like ollama and are
     not already registered. *)
 
+val auto_register_cli_for_candidates :
+  capacity_keys:string list ->
+  unit
+(** For each capacity key that looks like a CLI sentinel
+    (heuristic: starts with [cli:]) and is not yet registered,
+    register it with the default CLI concurrency
+    (env [MASC_CLI_MAX_CONCURRENT], fallback [1]).
+
+    Idempotent.  CLI providers (Claude_code / Gemini_cli / Codex_cli)
+    have an empty [base_url] so the cascade caller derives a
+    sentinel like [cli:claude_code] for capacity key purposes;
+    registering that sentinel here gives the strategy a uniform
+    [signal_ctx.capacity] view across HTTP and CLI providers.
+
+    @since 0.9.8 *)
+
+val auto_register_cli_with_override :
+  capacity_keys:string list ->
+  max_concurrent:int ->
+  unit
+(** Like {!auto_register_cli_for_candidates} but with an explicit
+    [max_concurrent] that overrides the env default.  Used by the
+    per-cascade [<name>_cli_max_concurrent] field.
+
+    Idempotent and only touches keys that look like CLI sentinels
+    and are not already registered.
+
+    @since 0.9.8 *)
+
 (** {1 Capacity query} *)
 
 val capacity : string -> Cascade_throttle.capacity_info option

--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -734,3 +734,11 @@ let resolve_ollama_max_concurrent ?config_path ~name () =
     let cfg = Cascade_config_loader.resolve_strategy_config
                 ~config_path:path ~name in
     cfg.ollama_max_concurrent
+
+let resolve_cli_max_concurrent ?config_path ~name () =
+  match config_path with
+  | None -> None
+  | Some path ->
+    let cfg = Cascade_config_loader.resolve_strategy_config
+                ~config_path:path ~name in
+    cfg.cli_max_concurrent

--- a/lib/cascade/cascade_config.mli
+++ b/lib/cascade/cascade_config.mli
@@ -426,3 +426,14 @@ val resolve_ollama_max_concurrent :
     default ({!Cascade_client_capacity.auto_register_for_candidates}).
     [None] means "use the env-var default
     ([MASC_OLLAMA_MAX_CONCURRENT] or 1)". *)
+
+val resolve_cli_max_concurrent :
+  ?config_path:string ->
+  name:string ->
+  unit ->
+  int option
+(** Per-cascade override for the CLI client-capacity registration
+    default ({!Cascade_client_capacity.auto_register_cli_for_candidates}).
+    [None] means "use the env-var default
+    ([MASC_CLI_MAX_CONCURRENT] or 1)".
+    @since 0.9.8 *)

--- a/lib/cascade/cascade_config_loader.ml
+++ b/lib/cascade/cascade_config_loader.ml
@@ -215,6 +215,7 @@ type strategy_config = {
   backoff_base_ms : int option;
   backoff_cap_ms : int option;
   ollama_max_concurrent : int option;
+  cli_max_concurrent : int option;
   tiers : string list list option;
   sticky_ttl_ms : int option;
 }
@@ -255,6 +256,7 @@ let empty_strategy_config = {
   backoff_base_ms = None;
   backoff_cap_ms = None;
   ollama_max_concurrent = None;
+  cli_max_concurrent = None;
   tiers = None;
   sticky_ttl_ms = None;
 }
@@ -270,6 +272,8 @@ let resolve_strategy_config ~config_path ~name =
       backoff_cap_ms = read_int_field json (name ^ "_backoff_cap_ms");
       ollama_max_concurrent =
         read_int_field json (name ^ "_ollama_max_concurrent");
+      cli_max_concurrent =
+        read_int_field json (name ^ "_cli_max_concurrent");
       tiers = read_tiers_field json (name ^ "_tiers");
       sticky_ttl_ms = read_int_field json (name ^ "_sticky_ttl_ms");
     }

--- a/lib/cascade/cascade_config_loader.mli
+++ b/lib/cascade/cascade_config_loader.mli
@@ -109,6 +109,15 @@ type strategy_config = {
       ollama auto-registration default for any ollama-like base URL
       in this cascade's candidate list. *)
 
+  cli_max_concurrent : int option;
+  (** ["{name}_cli_max_concurrent"]. When set, overrides the CLI
+      auto-registration default ([MASC_CLI_MAX_CONCURRENT] or 1)
+      for every CLI provider (Claude_code / Gemini_cli / Codex_cli)
+      in this cascade's candidate list.  CLI providers share a
+      single concurrency cap because each CLI binary is typically
+      limited to one in-flight subprocess.
+      @since 0.9.8 *)
+
   tiers : string list list option;
   (** ["{name}_tiers"]. Used by the [priority_tier] strategy.  Each
       inner array is a tier of provider keys (matched against the

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -536,9 +536,36 @@ let run_named
       ~name:cascade_name
       ()
   in
+  let cli_max =
+    Cascade_config.resolve_cli_max_concurrent
+      ?config_path:(default_config_path ())
+      ~name:cascade_name
+      ()
+  in
   let candidate_base_urls =
     List.map (fun (c : Llm_provider.Provider_config.t) -> c.base_url) candidate_cfgs
   in
+  (* CLI providers (Claude_code / Gemini_cli / Codex_cli) have an
+     empty [base_url].  Map them to a stable per-kind sentinel so the
+     strategy's capacity probe and the client-capacity registry share
+     the same lookup key.  Any new CLI kind added to OAS will fall
+     through this match and get an empty key (capacity treated as
+     "unknown → optimistically available"), preserving Phase A
+     fail-open semantics until the entry is added explicitly. *)
+  let cli_sentinel_of_kind = function
+    | Llm_provider.Provider_config.Claude_code -> Some "cli:claude_code"
+    | Gemini_cli -> Some "cli:gemini_cli"
+    | Codex_cli -> Some "cli:codex_cli"
+    | _ -> None
+  in
+  let capacity_key_of (c : Llm_provider.Provider_config.t) =
+    if c.base_url <> "" then c.base_url
+    else
+      match cli_sentinel_of_kind c.kind with
+      | Some s -> s
+      | None -> ""
+  in
+  let candidate_capacity_keys = List.map capacity_key_of candidate_cfgs in
   (match ollama_max with
    | None ->
      Cascade_client_capacity.auto_register_for_candidates
@@ -552,9 +579,16 @@ let run_named
      probe never breaks the cascade — it just denies the cache
      optimisation for this attempt. *)
   Cascade_ollama_probe.refresh_many ~sw ~net candidate_base_urls;
+  (match cli_max with
+   | None ->
+     Cascade_client_capacity.auto_register_cli_for_candidates
+       ~capacity_keys:candidate_capacity_keys
+   | Some n ->
+     Cascade_client_capacity.auto_register_cli_with_override
+       ~capacity_keys:candidate_capacity_keys ~max_concurrent:n);
   let adapter : Llm_provider.Provider_config.t Cascade_strategy.adapter = {
     health_key = (fun (c : Llm_provider.Provider_config.t) -> c.model_id);
-    capacity_key = (fun (c : Llm_provider.Provider_config.t) -> c.base_url);
+    capacity_key = capacity_key_of;
     weight = (fun _ -> 1);
   } in
   let signal_ctx : Cascade_strategy.signal_ctx = {

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -296,6 +296,61 @@ let test_ollama_register_with_override () =
   | Some info ->
     check int "override max=4" 4 info.total
 
+(* ── Phase C3: CLI sentinel auto-registration ──────────────── *)
+
+let test_cli_auto_register_filters_sentinels () =
+  C.unregister_all ();
+  C.auto_register_cli_for_candidates ~capacity_keys:[
+    "cli:claude_code";
+    "cli:gemini_cli";
+    "http://127.0.0.1:8085";  (* HTTP, not CLI *)
+    "";                       (* unknown / empty *)
+  ];
+  let urls = C.registered_urls () in
+  check bool "cli:claude_code registered"
+    true (List.mem "cli:claude_code" urls);
+  check bool "cli:gemini_cli registered"
+    true (List.mem "cli:gemini_cli" urls);
+  check bool "http URL NOT registered as CLI"
+    false (List.mem "http://127.0.0.1:8085" urls);
+  check bool "empty key NOT registered"
+    false (List.mem "" urls)
+
+let test_cli_register_with_override () =
+  C.unregister_all ();
+  C.auto_register_cli_with_override
+    ~capacity_keys:["cli:codex_cli"]
+    ~max_concurrent:3;
+  match C.capacity "cli:codex_cli" with
+  | None -> fail "expected CLI registration"
+  | Some info ->
+    check int "CLI override max=3" 3 info.total
+
+let test_cli_acquire_blocks_at_cap () =
+  C.unregister_all ();
+  C.auto_register_cli_with_override
+    ~capacity_keys:["cli:claude_code"]
+    ~max_concurrent:1;
+  match C.try_acquire "cli:claude_code" with
+  | None -> fail "first acquire should succeed"
+  | Some release ->
+    check bool "second acquire returns None at cap"
+      true (C.try_acquire "cli:claude_code" = None);
+    release ();
+    check bool "after release: capacity available again"
+      true (C.try_acquire "cli:claude_code" <> None)
+
+let test_cli_idempotent_registration () =
+  C.unregister_all ();
+  C.auto_register_cli_with_override
+    ~capacity_keys:["cli:gemini_cli"] ~max_concurrent:5;
+  C.auto_register_cli_for_candidates
+    ~capacity_keys:["cli:gemini_cli"];  (* should be no-op *)
+  match C.capacity "cli:gemini_cli" with
+  | None -> fail "expected registration"
+  | Some info ->
+    check int "first override preserved (idempotent)" 5 info.total
+
 (* ── Phase B: Priority_tier (S5) ───────────────────────────── *)
 
 let test_priority_tier_picks_first_tier () =
@@ -488,6 +543,14 @@ let () =
         test_ollama_auto_register;
       test_case "auto_register override sets max" `Quick
         test_ollama_register_with_override;
+      test_case "cli sentinel auto-register filters non-CLI" `Quick
+        test_cli_auto_register_filters_sentinels;
+      test_case "cli auto_register override sets max" `Quick
+        test_cli_register_with_override;
+      test_case "cli acquire blocks at cap, releases freely" `Quick
+        test_cli_acquire_blocks_at_cap;
+      test_case "cli registration is idempotent" `Quick
+        test_cli_idempotent_registration;
     ];
     "priority_tier", [
       test_case "cycle 0 picks first tier" `Quick


### PR DESCRIPTION
## Summary

Phase C3 of the pluggable cascade strategy roadmap.  CLI providers (Claude_code / Gemini_cli / Codex_cli) carry an empty \`base_url\`, so the URL-keyed Phase A \`Cascade_client_capacity\` mechanism could not throttle them.  This PR closes that gap with a small, symmetric extension that mirrors the existing ollama path.

## Approach

- **Per-kind sentinel**: \`oas_worker_named.ml\` derives \`cli:claude_code\` / \`cli:gemini_cli\` / \`cli:codex_cli\` for any candidate whose \`base_url\` is empty, and uses the same string as both the strategy's \`capacity_key\` and the registry key for \`auto_register_cli_*\`.
- **Symmetric helpers** in \`Cascade_client_capacity\`: \`looks_like_cli_sentinel\`, \`auto_register_cli_for_candidates\`, \`auto_register_cli_with_override\`.  Reuses the existing \`Hashtbl\` + \`Atomic\` + \`try_acquire\` loop unchanged.
- **Config schema**: \`<name>_cli_max_concurrent : int option\` (default 1, env override \`MASC_CLI_MAX_CONCURRENT\`).  Added to \`Cascade_config_loader.strategy_config\` and \`Cascade_config.resolve_cli_max_concurrent\`, parallel to the ollama field.
- **Wiring**: \`oas_worker_named.ml\` derives sentinels alongside \`candidate_base_urls\`, calls \`auto_register_cli_*\` with the same per-cascade-override > env > 1 precedence, and swaps \`capacity_key\` over to the new helper.  The Phase C2 capacity chain (throttle → ollama_probe → client_capacity) routes by string key, so CLI sentinels resolve through the existing branch with no chain edit.

## Backward compatibility

Cascades that omit \`<name>_cli_max_concurrent\` hit the env-default branch.  \`MASC_CLI_MAX_CONCURRENT\` defaults to 1, which throttles concurrent CLI subprocess invocations — the explicit design goal.  Cascades with no CLI providers receive an empty \`candidate_capacity_keys\` list and the auto-register helpers no-op.

## Tests

\`test/test_cascade_strategy.ml\` adds 4 cases under the \`client_capacity\` group (32 → 36 pass in 0.003s):
- \`cli sentinel auto-register filters non-CLI\` — only \`cli:*\` keys are registered; HTTP URLs and empty strings are ignored.
- \`cli auto_register override sets max\` — explicit cap overrides env default.
- \`cli acquire blocks at cap, releases freely\` — single-slot semantics + release roundtrip.
- \`cli registration is idempotent\` — repeated registration preserves the first cap.

## Test plan

- [x] \`dune build\` clean
- [x] \`dune exec test/test_cascade_strategy.exe\` — 36/36 pass
- [ ] CI: Build / Lint / Health / TLA+ green
- [ ] Manual smoke (post-merge): cascade with two CLI providers + \`<name>_cli_max_concurrent: 1\` → second call sees the slot taken and falls through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)