### PR TITLE
feat(keeper): default adaptive thinking mode to ON

### DIFF
--- a/lib/keeper/keeper_config.ml
+++ b/lib/keeper/keeper_config.ml
@@ -808,11 +808,12 @@ let keeper_adaptive_thinking_enabled () : bool =
    static base (unchanged legacy behavior). *)
 let keeper_adaptive_thinking_mode_rp =
   _rp_bool ~key:"keeper.turn.adaptive_thinking_mode"
-    ~default:(fun () -> bool_of_env_default "MASC_KEEPER_ADAPTIVE_THINKING_MODE" ~default:false)
+    ~default:(fun () -> bool_of_env_default "MASC_KEEPER_ADAPTIVE_THINKING_MODE" ~default:true)
     ~description:"Enable per-turn boolean enable_thinking override driven by \
                   Keeper_turn_intent classification (Mechanical → false, \
                   Cognitive → true). Independent of adaptive_thinking budget \
-                  flag." ()
+                  flag. Default: on (set MASC_KEEPER_ADAPTIVE_THINKING_MODE=false \
+                  to opt out)." ()
 
 let keeper_adaptive_thinking_mode () : bool =
   Runtime_params.get keeper_adaptive_thinking_mode_rp


### PR DESCRIPTION
## Summary

- **1-line flip**: `MASC_KEEPER_ADAPTIVE_THINKING_MODE` default `false` → `true`.
- Per-turn `Keeper_turn_intent` classification now kicks in out of the box: **Mechanical turns** (task_claim, board_list, shell, fs_read, …) send `think=false` → ~2× faster; **Cognitive turns** (retry, plan/debug keywords, unknown tools, idle) send `think=true`.
- Follow-up from OAS #970 + masc-mcp #7616 (merged 2026-04-16), where the feature was added opt-in.

## Why now

Empirical data from the shipping session:
- qwen3.5:35b-a3b-nvfp4 dashboard p50 tok/s = 1.76 — driven by 356 avg reasoning_tokens/turn (static thinking on all turns).
- Same hardware/model with `think=false` tool-call turn: 0.57s wall / 59 tok/s hw.
- With `think=true`: 1.33s wall / 57 tok/s hw (same correct tool call).

Adaptive mode was validated as opt-in; flipping the default gives all operators the 2× speedup automatically.

## Opt-out preserved

`bool_of_env_default` lets env override code default: users with `export MASC_KEEPER_ADAPTIVE_THINKING_MODE=false` keep the legacy static behavior. No other call sites changed.

## Rollout

1. Merge → `make` (rebuild binary) → restart MASC server.
2. `jq '.thinking_enabled' $ME_ROOT/.masc/keepers/*.decisions.jsonl | sort | uniq -c` should show **both** `true` and `false` (proof adaptive is flipping per turn).

## Test plan
- [ ] CI: existing `test_keeper_turn_intent.ml` already flag-independent; stays green.
- [ ] Smoke: run MASC with no env var set → confirm decisions.jsonl has mixed `thinking_enabled`.
- [ ] Regression: `export MASC_KEEPER_ADAPTIVE_THINKING_MODE=false` → confirm all turns are the static base value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)