### PR TITLE
refactor(tool_task): drop Option.get from verifier-gate redirect

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -683,17 +683,17 @@ let handle_transition ctx args =
        && (not force)
     then
       match task_opt with
-      | Some task when Option.is_some task.contract ->
-        let contract = Option.get task.contract in
-        if contract.completion_contract <> [] || contract.required_evidence <> [] then begin
-          Log.Task.info
-            "[verifier-gate] redirecting Done→Submit_for_verification task=%s agent=%s contract_items=%d"
-            task_id ctx.agent_name
-            (List.length contract.completion_contract + List.length contract.required_evidence);
-          Types.Submit_for_verification
-        end else
-          action
-      | _ -> action
+      | Some task ->
+        (match task.contract with
+         | Some contract
+           when contract.completion_contract <> [] || contract.required_evidence <> [] ->
+           Log.Task.info
+             "[verifier-gate] redirecting Done→Submit_for_verification task=%s agent=%s contract_items=%d"
+             task_id ctx.agent_name
+             (List.length contract.completion_contract + List.length contract.required_evidence);
+           Types.Submit_for_verification
+         | _ -> action)
+      | None -> action
     else action
   in
   let default_time = Time_compat.now () -. 60.0 in


### PR DESCRIPTION
## Summary

Follow-up to #7603 (verifier-keeper FSM gate). The Phase 0 patch
introduced `Option.is_some task.contract` + `Option.get task.contract`
in `lib/tool_task.ml`, which crosses the Health ratchet:

```
Ratchet: fail (lib_option_get 0 -> 1)
```

The merged PR was admin-overridden while Health was red, so the
violation now lives on main. This PR folds the two calls into a
single nested `match task.contract with | Some contract when ... ->`
guard so the contract binding stays local to its one use site and
no partial functions are added to `lib/`.

Behaviour is unchanged — same redirect to `Submit_for_verification`,
same log line, same fallback to `action`.

## Test plan

- [x] `dune build --root .` clean
- [x] `dune exec test/test_tool_task_coverage.exe` 39/39 pass
- [x] `dune exec test/test_verification_fsm.exe` 8/8 pass
- [x] `rg "Option\.get" lib/` returns no hits (ratchet baseline will drop back to 0)
- [ ] CI: Health ratchet should go from "fail (lib_option_get 0 -> 1)" to pass

## Context

- Issue #7598 (Phase 0 verifier gate)
- Original regression introduced in #7603 (commit 1236ebfe0, merge a8a6f200b)
- Memory reference: `feedback_ocaml5-mutex-selection.md` is unrelated; the general
  OCaml rule "avoid Option.get / List.hd in lib/" is enforced by
  `scripts/health_snapshot.sh` ratchet against `.ci/health-baseline.json`.