### PR TITLE
feat(dashboard): surface thinking_fraction per model

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -608,6 +608,14 @@ export interface DashboardRuntimeModelMetric {
   hw_decode_avg_tok_per_sec?: number | null
   hw_decode_p50_tok_per_sec?: number | null
   hw_decode_p95_tok_per_sec?: number | null
+  /**
+   * Fraction [0.0, 1.0] of turns in the window where the model received
+   * think=true. Reflects the Keeper_turn_intent adaptive classifier decision
+   * (Cognitive=true → thinking, Mechanical=false → no thinking). Null when no
+   * entry in the window reported thinking_enabled (older rows or providers
+   * that don't expose the field).
+   */
+  thinking_fraction?: number | null
   avg_latency_ms?: number | null
   p50_latency_ms?: number | null
   p95_latency_ms?: number | null
@@ -707,6 +715,7 @@ function decodeRuntimeModelMetric(raw: unknown): DashboardRuntimeModelMetric | n
     hw_decode_avg_tok_per_sec: asNumber(raw.hw_decode_avg_tok_per_sec) ?? null,
     hw_decode_p50_tok_per_sec: asNumber(raw.hw_decode_p50_tok_per_sec) ?? null,
     hw_decode_p95_tok_per_sec: asNumber(raw.hw_decode_p95_tok_per_sec) ?? null,
+    thinking_fraction: asNumber(raw.thinking_fraction) ?? null,
     avg_latency_ms: asNumber(raw.avg_latency_ms) ?? null,
     p50_latency_ms: asNumber(raw.p50_latency_ms) ?? null,
     p95_latency_ms: asNumber(raw.p95_latency_ms) ?? null,

--- a/dashboard/src/components/runtime-monitor.ts
+++ b/dashboard/src/components/runtime-monitor.ts
@@ -243,6 +243,12 @@ export function RuntimeMonitor() {
                             tone=${'ok'}
                           />`
                         : null}
+                      ${metric.thinking_fraction != null
+                        ? html`<${StatusChip}
+                            label=${`think ${fmtNumber((metric.thinking_fraction ?? 0) * 100, 0)}%`}
+                            tone=${(metric.thinking_fraction ?? 0) > 0.5 ? 'warn' : 'ok'}
+                          />`
+                        : null}
                     </div>
                   </div>
                   <div class="grid grid-cols-3 gap-3 text-[12px] text-text-body">

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -813,6 +813,18 @@ let append_decision_record
           match result with
           | Some r ->
               let surface_model_used = Keeper_agent_run.surface_model_used r in
+              (* Per-turn thinking_enabled read from the same ref that the tool
+                 call log uses; captures the adaptive classifier's decision
+                 (true=Cognitive, false=Mechanical) so the dashboard can surface
+                 thinking fraction per model. *)
+              let (_, _, turn_thinking_enabled, _, _, _, _) =
+                Keeper_tool_call_log.get_turn_context ~keeper_name:meta.name ()
+              in
+              let thinking_enabled_field =
+                match turn_thinking_enabled with
+                | Some b -> [("thinking_enabled", `Bool b)]
+                | None -> []
+              in
               let cascade_fields =
                 match r.cascade_observation with
                 | Some co ->
@@ -880,7 +892,7 @@ let append_decision_record
                   if latency_ms > 0 then
                     `Float (float_of_int r.usage.output_tokens /. (float_of_int latency_ms /. 1000.0))
                   else `Null);
-              ] @ inference_fields @ cascade_fields)
+              ] @ thinking_enabled_field @ inference_fields @ cascade_fields)
           | None ->
               (* Partial telemetry for error turns: record what we know.
                  Without this, 90%+ of turns have no telemetry at all. *)

--- a/lib/model_inference_metrics.ml
+++ b/lib/model_inference_metrics.ml
@@ -52,6 +52,11 @@ type model_stats = {
   hw_decode_avg_tok_per_sec : float option;
   hw_decode_p50_tok_per_sec : float option;
   hw_decode_p95_tok_per_sec : float option;
+  (* Fraction of turns in window where the model received think=true. Reflects
+     Keeper_turn_intent adaptive classifier (Cognitive=true, Mechanical=false).
+     None when no entry in window reported thinking_enabled (older jsonl rows
+     before the field was emitted, or providers that don't expose it). *)
+  thinking_fraction : float option;
   avg_latency_ms : float;
   p50_latency_ms : float;
   p95_latency_ms : float;
@@ -99,6 +104,9 @@ type raw_entry = {
   (* Hardware decode rate when present in telemetry; None for legacy entries
      and non-Ollama providers whose backend doesn't populate inference_timings. *)
   hw_decode_tok_per_sec : float option;
+  (* Per-turn thinking_enabled as sent to the model (adaptive classifier output).
+     None for entries that predate the field or providers that don't expose it. *)
+  thinking_enabled : bool option;
   latency_ms : float;
   input_tokens : int;
   output_tokens : int;
@@ -152,6 +160,7 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
            in
            Some { model; ts_unix = ts; tok_per_sec = 0.0;
                   hw_decode_tok_per_sec = None;
+                  thinking_enabled = None;
                   latency_ms = 0.0;
                   input_tokens = 0; output_tokens = 0;
                   cache_read_tokens = 0; reasoning_tokens = 0;
@@ -215,8 +224,17 @@ let parse_telemetry_entry (json : Yojson.Safe.t) ~since_unix : raw_entry option 
              match List.assoc_opt "cost_usd" tfields with
              | Some (`Float f) -> f | Some (`Int n) -> Float.of_int n | _ -> 0.0
            in
+           (* Per-turn thinking_enabled — emitted by keeper_unified_turn's
+              append_decision_record under telemetry.thinking_enabled. Treat
+              explicit null or absent as None so backfill stays clean. *)
+           let thinking_enabled =
+             match List.assoc_opt "thinking_enabled" tfields with
+             | Some (`Bool b) -> Some b
+             | _ -> None
+           in
            Some { model; ts_unix = ts; tok_per_sec;
                   hw_decode_tok_per_sec;
+                  thinking_enabled;
                   latency_ms;
                   input_tokens; output_tokens;
                   cache_read_tokens; reasoning_tokens; fallback_applied;
@@ -296,6 +314,19 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
     let error_count = List.length (List.filter (fun e -> e.is_error) entries) in
     let total_tool_calls = List.fold_left (fun acc e -> acc + e.tool_call_count) 0 entries in
     let opt_if_any arr f = if Array.length arr = 0 then None else Some (f arr) in
+    (* thinking_fraction: count of entries with thinking_enabled=true over
+       entries that reported the field. Entries without the field (older jsonl
+       rows, providers that don't expose it) are excluded from denominator —
+       None when no reporter at all. *)
+    let thinking_fraction =
+      let reported = List.filter_map (fun e -> e.thinking_enabled) entries in
+      match reported with
+      | [] -> None
+      | xs ->
+        let total = List.length xs in
+        let on_count = List.length (List.filter (fun x -> x) xs) in
+        Some (float_of_int on_count /. float_of_int total)
+    in
     let stats = {
       model_id;
       entry_count = n;
@@ -305,6 +336,7 @@ let aggregate_by_model (entries : raw_entry list) : model_stats list =
       hw_decode_avg_tok_per_sec = opt_if_any hw_vals avg;
       hw_decode_p50_tok_per_sec = opt_if_any hw_vals (fun a -> percentile a 50.0);
       hw_decode_p95_tok_per_sec = opt_if_any hw_vals (fun a -> percentile a 95.0);
+      thinking_fraction;
       avg_latency_ms = avg lat_vals;
       p50_latency_ms = percentile lat_vals 50.0;
       p95_latency_ms = percentile lat_vals 95.0;
@@ -488,6 +520,7 @@ let model_stats_to_json (s : model_stats) : Yojson.Safe.t =
     ; ("hw_decode_avg_tok_per_sec", opt_float s.hw_decode_avg_tok_per_sec)
     ; ("hw_decode_p50_tok_per_sec", opt_float s.hw_decode_p50_tok_per_sec)
     ; ("hw_decode_p95_tok_per_sec", opt_float s.hw_decode_p95_tok_per_sec)
+    ; ("thinking_fraction", opt_float s.thinking_fraction)
     ; ("avg_latency_ms", `Float s.avg_latency_ms)
     ; ("p50_latency_ms", `Float s.p50_latency_ms)
     ; ("p95_latency_ms", `Float s.p95_latency_ms)

--- a/lib/model_inference_metrics.mli
+++ b/lib/model_inference_metrics.mli
@@ -46,6 +46,12 @@ type model_stats = {
   hw_decode_avg_tok_per_sec : float option;
   hw_decode_p50_tok_per_sec : float option;
   hw_decode_p95_tok_per_sec : float option;
+  thinking_fraction : float option;
+    (** Fraction [0.0, 1.0] of turns in window where the model was sent
+        think=true (Keeper_turn_intent adaptive classifier decision).
+        [None] when no entry in the window reported [thinking_enabled]
+        (older jsonl rows predating the field, or providers that don't
+        expose it). Denominator = count of reporting entries. *)
   avg_latency_ms : float;
   p50_latency_ms : float;
   p95_latency_ms : float;

--- a/test/test_model_inference_metrics.ml
+++ b/test/test_model_inference_metrics.ml
@@ -232,6 +232,94 @@ let test_json_roundtrip () =
     check int "total_error_entries" 0
       (json |> member "total_error_entries" |> to_int))
 
+(* ── thinking_fraction tests ─────────────────────── *)
+
+let success_entry_with_thinking ~model ~ts ~thinking_enabled () =
+  let thinking_field = match thinking_enabled with
+    | Some b -> [("thinking_enabled", `Bool b)]
+    | None -> []
+  in
+  `Assoc [
+    ("ts_unix", `Float ts);
+    ("tool_call_count", `Int 0);
+    ("tools_used", `List []);
+    ("telemetry", `Assoc ([
+      ("model_used", `String model);
+      ("tokens_per_second", `Float 10.0);
+      ("request_latency_ms", `Int 500);
+      ("input_tokens", `Int 100);
+      ("output_tokens", `Int 50);
+      ("cache_read_tokens", `Int 0);
+      ("reasoning_tokens", `Int 0);
+      ("fallback_applied", `Bool false);
+      ("cost_usd", `Float 0.01);
+    ] @ thinking_field));
+  ]
+
+let test_thinking_fraction_mixed () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "thinking_mixed" in
+    let ts = now_unix () in
+    (* 3 true + 5 false reported, 2 missing. fraction = 3 / (3+5) = 0.375 *)
+    let entries =
+      List.init 3 (fun i ->
+        success_entry_with_thinking ~model:"m1"
+          ~ts:(ts -. Float.of_int (i * 5))
+          ~thinking_enabled:(Some true) ())
+      @ List.init 5 (fun i ->
+        success_entry_with_thinking ~model:"m1"
+          ~ts:(ts -. Float.of_int ((i + 3) * 5))
+          ~thinking_enabled:(Some false) ())
+      @ List.init 2 (fun i ->
+        success_entry_with_thinking ~model:"m1"
+          ~ts:(ts -. Float.of_int ((i + 8) * 5))
+          ~thinking_enabled:None ())
+    in
+    write_decisions path entries;
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check int "entry_count" 10 s.entry_count;
+    check bool "thinking_fraction present" true
+      (Option.is_some s.thinking_fraction);
+    let f = Option.get s.thinking_fraction in
+    check (float 0.001) "thinking_fraction = 3/8" 0.375 f)
+
+let test_thinking_fraction_all_missing () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "thinking_missing" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry_with_thinking ~model:"m1" ~ts:(ts -. 5.0)
+        ~thinking_enabled:None ();
+      success_entry_with_thinking ~model:"m1" ~ts:(ts -. 10.0)
+        ~thinking_enabled:None ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let s = List.hd agg.models in
+    check bool "thinking_fraction None" true
+      (Option.is_none s.thinking_fraction))
+
+let test_thinking_fraction_json_serialization () =
+  let base = test_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+    let path = make_keeper_dir base "thinking_json" in
+    let ts = now_unix () in
+    write_decisions path [
+      success_entry_with_thinking ~model:"m1" ~ts:(ts -. 5.0)
+        ~thinking_enabled:(Some true) ();
+      success_entry_with_thinking ~model:"m1" ~ts:(ts -. 10.0)
+        ~thinking_enabled:(Some false) ();
+    ];
+    let agg = M.compute ~base_path:base ~window_minutes:60 in
+    let json = M.to_json agg in
+    let open Yojson.Safe.Util in
+    let models = json |> member "models" |> to_list in
+    let m = List.hd models in
+    check (float 0.001) "thinking_fraction in JSON"
+      0.5 (m |> member "thinking_fraction" |> to_float))
+
 (* ── Bucket tests ───────────────────────────────── *)
 
 let success_entry_with_cache ~model ~ts ?(input_tokens=100) ~cache_read () =
@@ -335,6 +423,11 @@ let () =
       test_case "top tools per model" `Quick test_top_tools_per_model;
       test_case "recent entries capped" `Quick test_recent_entries;
       test_case "json roundtrip" `Quick test_json_roundtrip;
+    ];
+    "thinking_fraction", [
+      test_case "mixed reported yields fraction" `Quick test_thinking_fraction_mixed;
+      test_case "all missing yields None" `Quick test_thinking_fraction_all_missing;
+      test_case "json serialization" `Quick test_thinking_fraction_json_serialization;
     ];
     "buckets", [
       test_case "empty dir → no buckets" `Quick test_buckets_empty_dir;


### PR DESCRIPTION
## Summary

- Add per-model **thinking_fraction** aggregate: fraction of turns in window where `think=true` was sent.
- New dashboard chip \`think N%\` next to existing \`tok/s wall\` / \`tok/s hw\`. Warn tone when > 50% (classifier likely stuck on).
- Wires an existing signal: keeper already tracks \`thinking_enabled_effective\` per turn via \`set_turn_context\`; this PR just persists it to decisions.jsonl and aggregates it into the dashboard API.

## Why

Follow-up to #7624 (flag ON by default). With adaptive mode running for everyone, operators need a real-time signal:
- **Classifier working?** \`think 40%\` on qwen3.5 (mechanical-heavy) vs \`think 85%\` on Claude (cognitive-heavy) = healthy divergence.
- **Classifier stuck?** \`think 100%\` everywhere = Mechanical → Cognitive fallthrough bug (e.g., empty \`last_tool_calls\` taking over).
- **Regression detection**: if a refactor makes every turn Cognitive, the 2× speedup silently disappears — chip would flag it immediately.

## Data flow

\`\`\`
keeper_agent_run.ml:1547
  thinking_enabled_effective = classify(...)
  ↓ Keeper_tool_call_log.set_turn_context ~thinking_enabled
  ↓
keeper_unified_turn.ml:append_decision_record
  get_turn_context → telemetry.thinking_enabled (NEW)
  ↓
model_inference_metrics.ml
  raw_entry.thinking_enabled (NEW) → aggregate_by_model
  → model_stats.thinking_fraction: float option (NEW)
  ↓
dashboard/src/api/dashboard.ts (decoder, NEW field)
  ↓
dashboard/src/components/runtime-monitor.ts (chip, NEW)
\`\`\`

## Backward compat

- \`thinking_enabled\` field in decisions.jsonl is additive; older parsers (external analytics) untouched.
- \`raw_entry.thinking_enabled: bool option\` → None for pre-existing rows.
- \`model_stats.thinking_fraction: float option\` → None when no reporter in window.
- Dashboard chip renders only when fraction is non-null (falls back to invisible on legacy data).

## Test plan
- [x] 3 new unit tests in test_model_inference_metrics.ml (mixed 3/5/2 → 0.375; all-missing → None; JSON roundtrip)
- [x] 16/16 existing tests still green
- [x] OCaml \`dune build --root . @check\` clean
- [x] TypeScript \`pnpm typecheck\` clean
- [ ] Visual verification after PR merge: dashboard renders chip with actual MASC data

## Related
- #7624 (feat: default adaptive thinking ON) — complementary; this PR makes that flag's effect observable.
- OAS #970 + masc-mcp #7616 (merged 2026-04-16) — shipped the adaptive mechanism being surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)