### PR TITLE
feat(dashboard): migrate keeper clear action to OAS-only

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -14,7 +14,15 @@ vi.mock('./core', async (importOriginal) => {
   }
 })
 
-import { bootKeeper, sendKeeperMessageDetailed, shutdownKeeper, streamKeeperMessage } from './keeper'
+import {
+  bootKeeper,
+  clearKeeper,
+  deleteKeeperHistorySnapshots,
+  fetchKeeperCheckpoints,
+  sendKeeperMessageDetailed,
+  shutdownKeeper,
+  streamKeeperMessage,
+} from './keeper'
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -130,5 +138,106 @@ describe('keeper lifecycle', () => {
 
     expect(result.ok).toBe(false)
     expect(result.error).toBe('Failed to boot keeper-test (HTTP 502)')
+  })
+
+  it('posts keeper clear payload and returns structured detail', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        action: 'clear',
+        name: 'keeper-test',
+        detail: {
+          cleared_message_count: 12,
+          continuity_cleared: true,
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await clearKeeper('keeper-test', {
+      reason: 'reset stale continuity',
+      preserve_system_prompt: true,
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/keepers/keeper-test/clear')
+    expect(JSON.parse(String(init.body))).toEqual({
+      reason: 'reset stale continuity',
+      preserve_system_prompt: true,
+    })
+    expect(result.ok).toBe(true)
+    expect(result.action).toBe('clear')
+    expect(result.detail).toEqual({
+      cleared_message_count: 12,
+      continuity_cleared: true,
+    })
+  })
+
+  it('fetches keeper checkpoint inventory from the admin route', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        keeper: 'keeper-test',
+        trace_id: 'trace-keeper-test',
+        session_dir: '/tmp/trace-keeper-test',
+        current: null,
+        history: [],
+        legacy_shadow_count: 0,
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperCheckpoints('keeper-test')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/keepers/keeper-test/checkpoints',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    )
+    expect(result.trace_id).toBe('trace-keeper-test')
+    expect(result.history).toEqual([])
+  })
+
+  it('posts selected OAS history snapshot ids for deletion', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        action: 'delete_history',
+        keeper: 'keeper-test',
+        deleted_snapshot_ids: ['oas-snapshot-1.json'],
+        missing_snapshot_ids: [],
+        inventory: {
+          keeper: 'keeper-test',
+          trace_id: 'trace-keeper-test',
+          session_dir: '/tmp/trace-keeper-test',
+          current: null,
+          history: [],
+          legacy_shadow_count: 0,
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await deleteKeeperHistorySnapshots('keeper-test', ['oas-snapshot-1.json'])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/v1/keepers/keeper-test/checkpoints')
+    expect(JSON.parse(String(init.body))).toEqual({
+      action: 'delete_history',
+      snapshot_ids: ['oas-snapshot-1.json'],
+    })
+    expect(result.deleted_snapshot_ids).toEqual(['oas-snapshot-1.json'])
   })
 })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -239,7 +239,7 @@ export async function fetchKeeperChatHistory(
 
 export interface KeeperLifecycleResponse {
   ok: boolean
-  action?: 'boot' | 'shutdown'
+  action?: 'boot' | 'shutdown' | 'reset' | 'clear'
   name?: string
   detail?: unknown
   error?: string
@@ -266,9 +266,17 @@ async function safeJsonResponse<T>(resp: Response, fallbackError: string): Promi
   }
 }
 
-async function safeKeeperLifecycle(url: string, fallbackError: string): Promise<KeeperLifecycleResponse> {
+async function safeKeeperLifecycle(
+  url: string,
+  fallbackError: string,
+  init?: RequestInit,
+): Promise<KeeperLifecycleResponse> {
   try {
-    const resp = await fetch(url, { method: 'POST', headers: jsonHeaders() })
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: jsonHeaders(),
+      ...init,
+    })
     const payload = await safeJsonResponse<KeeperLifecycleResponse>(resp, fallbackError)
     if (resp.ok) return payload
 
@@ -308,6 +316,99 @@ export function resetKeeper(name: string): Promise<KeeperLifecycleResponse> {
     `/api/v1/keepers/${encodeURIComponent(name)}/reset`,
     `Failed to reset ${name}`,
   )
+}
+
+export interface KeeperClearRequest {
+  reason: string
+  preserve_system_prompt?: boolean
+}
+
+export function clearKeeper(
+  name: string,
+  payload: KeeperClearRequest,
+): Promise<KeeperLifecycleResponse> {
+  return safeKeeperLifecycle(
+    `/api/v1/keepers/${encodeURIComponent(name)}/clear`,
+    `Failed to clear ${name}`,
+    {
+      body: JSON.stringify(payload),
+    },
+  )
+}
+
+export interface KeeperCheckpointSummary {
+  snapshot_id: string
+  source_kind: 'oas_current' | 'oas_history' | string
+  is_current: boolean
+  path: string
+  created_at: number
+  generation: number
+  message_count: number
+  system_prompt_present: boolean
+  latest_preview: string | null
+  continuity_summary: string | null
+  file_stat: {
+    size_bytes?: number
+    mtime?: number
+  } | null
+}
+
+export interface KeeperCheckpointInventory {
+  keeper: string
+  trace_id: string
+  session_dir: string
+  current: KeeperCheckpointSummary | null
+  history: KeeperCheckpointSummary[]
+  legacy_shadow_count: number
+}
+
+export interface KeeperCheckpointDeleteResponse {
+  ok: boolean
+  action: 'delete_history' | string
+  keeper: string
+  deleted_snapshot_ids: string[]
+  missing_snapshot_ids: string[]
+  inventory: KeeperCheckpointInventory
+}
+
+export async function fetchKeeperCheckpoints(
+  name: string,
+): Promise<KeeperCheckpointInventory> {
+  const resp = await fetchWithTimeout(
+    `/api/v1/keepers/${encodeURIComponent(name)}/checkpoints`,
+    {
+      method: 'GET',
+      headers: jsonHeaders(),
+    },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => resp.statusText)
+    throw new Error(`Failed to load checkpoints for ${name} (${resp.status}): ${text}`)
+  }
+  return resp.json() as Promise<KeeperCheckpointInventory>
+}
+
+export async function deleteKeeperHistorySnapshots(
+  name: string,
+  snapshotIds: string[],
+): Promise<KeeperCheckpointDeleteResponse> {
+  const resp = await fetch(
+    `/api/v1/keepers/${encodeURIComponent(name)}/checkpoints`,
+    {
+      method: 'POST',
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        action: 'delete_history',
+        snapshot_ids: snapshotIds,
+      }),
+    },
+  )
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => resp.statusText)
+    throw new Error(`Failed to delete checkpoint history for ${name} (${resp.status}): ${text}`)
+  }
+  return resp.json() as Promise<KeeperCheckpointDeleteResponse>
 }
 
 // --- Keeper tool policy editing ---

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -6,11 +6,19 @@ import { html } from 'htm/preact'
 import { isOfflineStatus } from '../lib/status-utils'
 import { keeperDisplayStatus, keeperRuntimeBlockerHint } from '../lib/keeper-runtime-display'
 import { signal } from '@preact/signals'
-import { useRef, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { requestConfirm } from './common/confirm-dialog'
 import { isRecord } from './common/normalize'
 import { currentDashboardActor, runOperatorAction } from '../api'
-import { bootKeeper, shutdownKeeper } from '../api/keeper'
+import {
+  bootKeeper,
+  clearKeeper,
+  deleteKeeperHistorySnapshots,
+  fetchKeeperCheckpoints,
+  shutdownKeeper,
+  type KeeperCheckpointInventory,
+  type KeeperCheckpointSummary,
+} from '../api/keeper'
 import { TimeAgo } from './common/time-ago'
 import type { Keeper } from '../types'
 import { invalidateDashboardCache, refreshDashboard } from '../store'
@@ -247,6 +255,316 @@ function KeeperLifecycleButtons({ keeper, effectiveStatus }: { keeper: Keeper; e
   return null
 }
 
+function KeeperClearContextDialog({
+  keeperName,
+  open,
+  pending,
+  reason,
+  preserveSystemPrompt,
+  onClose,
+  onReasonInput,
+  onPreserveToggle,
+  onSubmit,
+}: {
+  keeperName: string
+  open: boolean
+  pending: boolean
+  reason: string
+  preserveSystemPrompt: boolean
+  onClose: () => void
+  onReasonInput: (next: string) => void
+  onPreserveToggle: (next: boolean) => void
+  onSubmit: () => void
+}) {
+  const reasonRef = useRef<HTMLTextAreaElement>(null)
+  const titleId = `keeper-clear-title-${keeperName}`
+  const descId = `keeper-clear-desc-${keeperName}`
+  if (!open) return null
+
+  return html`
+    <${DialogOverlay}
+      labelledBy=${titleId}
+      describedBy=${descId}
+      onClose=${pending ? () => {} : onClose}
+      initialFocusRef=${reasonRef}
+      overlayClass="fixed inset-0 z-[80] bg-black/70 backdrop-blur-sm isolate flex items-center justify-center p-4"
+      panelClass="w-full max-w-[520px] rounded-2xl border border-[var(--bad-30)] bg-[rgba(13,21,38,0.98)] shadow-[0_24px_64px_rgba(0,0,0,0.6)]"
+    >
+      <div class="p-5 flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <h3 id=${titleId} class="m-0 text-[17px] font-semibold text-[var(--text-strong)]">키퍼 컨텍스트 비우기</h3>
+          <p id=${descId} class="m-0 text-[13px] leading-relaxed text-[var(--text-muted)]">
+            ${keeperName}의 checkpoint 대화와 continuity summary를 비웁니다. 사유는 감사 로그에 남습니다.
+          </p>
+        </div>
+
+        <label class="flex flex-col gap-2">
+          <span class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">사유</span>
+          <textarea
+            ref=${reasonRef}
+            class="min-h-[112px] resize-y rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] px-3 py-2 text-[13px] leading-[1.55] text-[var(--text-body)] outline-none focus:border-[rgba(71,184,255,0.45)] focus:ring-2 focus:ring-[rgba(71,184,255,0.18)]"
+            placeholder="예: stale continuity replay 제거"
+            disabled=${pending}
+            value=${reason}
+            onInput=${(event: Event) => onReasonInput((event.currentTarget as HTMLTextAreaElement).value)}
+          ></textarea>
+        </label>
+
+        <label class="flex items-start gap-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-body)]">
+          <input
+            type="checkbox"
+            class="mt-0.5"
+            checked=${preserveSystemPrompt}
+            disabled=${pending}
+            onChange=${(event: Event) => onPreserveToggle((event.currentTarget as HTMLInputElement).checked)}
+          />
+          <span>
+            system prompt는 보존하고 나머지 메시지만 비웁니다.
+            <span class="block mt-1 text-[var(--text-muted)]">끄면 system prompt까지 같이 제거합니다.</span>
+          </span>
+        </label>
+
+        <div class="rounded-xl border border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">
+          마지막 수단용 액션입니다. 잘못된 continuity가 재주입될 때만 쓰고, 실행 후 즉시 상태를 다시 확인하세요.
+        </div>
+
+        <div class="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg text-[13px] font-medium border border-[var(--card-border)] bg-[var(--white-4)] text-[var(--text-body)] hover:bg-[var(--white-8)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            disabled=${pending}
+            onClick=${onClose}
+          >취소</button>
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg text-[13px] font-medium border border-transparent bg-[var(--bad)] text-white hover:bg-[rgba(239,68,68,0.88)] transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            disabled=${pending || reason.trim() === ''}
+            onClick=${onSubmit}
+          >${pending ? '비우는 중...' : '비우기'}</button>
+        </div>
+      </div>
+    <//>
+  `
+}
+
+function formatCheckpointTime(timestamp: number): string {
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return '-'
+  return new Date(timestamp * 1000).toLocaleString('ko-KR', {
+    hour12: false,
+  })
+}
+
+function CheckpointSummaryCard({
+  title,
+  summary,
+}: {
+  title: string
+  summary: KeeperCheckpointSummary | null
+}) {
+  if (!summary) {
+    return html`
+      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+        ${title}: 저장된 checkpoint 없음
+      </div>
+    `
+  }
+
+  return html`
+    <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-[12px] font-semibold text-[var(--text-strong)]">${title}</span>
+        <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.18)]">
+          gen ${summary.generation}
+        </span>
+        <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
+          ${summary.message_count} msgs
+        </span>
+        ${summary.system_prompt_present
+          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-emerald-400">system kept</span>`
+          : null}
+      </div>
+      <div class="mt-2 text-[11px] text-[var(--text-muted)]">
+        ${formatCheckpointTime(summary.created_at)}
+      </div>
+      ${summary.latest_preview
+        ? html`<div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${summary.latest_preview}</div>`
+        : null}
+      ${summary.continuity_summary
+        ? html`<pre class="mt-2 whitespace-pre-wrap rounded-lg border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${summary.continuity_summary}</pre>`
+        : html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">continuity snapshot 없음</div>`}
+    </div>
+  `
+}
+
+function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: string; refreshToken: number }) {
+  const [inventory, setInventory] = useState<KeeperCheckpointInventory | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  const [deleting, setDeleting] = useState(false)
+
+  const loadInventory = () => {
+    void (async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const next = await fetchKeeperCheckpoints(keeperName)
+        setInventory(next)
+        setSelectedIds(prev =>
+          prev.filter(id => next.history.some(item => item.snapshot_id === id)),
+        )
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'checkpoint inventory load failed')
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }
+
+  useEffect(() => {
+    setInventory(null)
+    setSelectedIds([])
+    loadInventory()
+  }, [keeperName, refreshToken])
+
+  const toggleSnapshot = (snapshotId: string, checked: boolean) => {
+    setSelectedIds(prev =>
+      checked
+        ? (prev.includes(snapshotId) ? prev : [...prev, snapshotId])
+        : prev.filter(id => id !== snapshotId),
+    )
+  }
+
+  const deleteSelected = () => {
+    void (async () => {
+      if (selectedIds.length === 0) {
+        showToast('삭제할 snapshot을 먼저 고르세요', 'warning')
+        return
+      }
+      const confirmed = await requestConfirm({
+        title: 'OAS snapshot 삭제',
+        message: `${selectedIds.length}개 snapshot history를 삭제합니다.\n현재 active checkpoint는 건드리지 않습니다.`,
+        tone: 'danger',
+        confirmText: '삭제',
+      })
+      if (!confirmed) return
+      setDeleting(true)
+      try {
+        const result = await deleteKeeperHistorySnapshots(keeperName, selectedIds)
+        setInventory(result.inventory)
+        setSelectedIds([])
+        const missingSuffix =
+          result.missing_snapshot_ids.length > 0
+            ? ` (누락 ${result.missing_snapshot_ids.length})`
+            : ''
+        showToast(`${result.deleted_snapshot_ids.length}개 snapshot 삭제${missingSuffix}`, 'success')
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : 'snapshot 삭제 실패', 'error')
+      } finally {
+        setDeleting(false)
+      }
+    })()
+  }
+
+  if (loading) {
+    return html`
+      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)] px-3 py-3 text-[12px] text-[var(--text-muted)]">
+        checkpoint inventory 로딩 중...
+      </div>
+    `
+  }
+
+  if (error) {
+    return html`
+      <div class="rounded-xl border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-3 text-[12px] text-[#fda4af]">
+        ${error}
+        <button
+          type="button"
+          class="ml-2 rounded border border-[var(--card-border)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
+          onClick=${loadInventory}
+        >다시 로드</button>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="text-[11px] text-[var(--text-muted)]">
+          current OAS checkpoint와 OAS snapshot history만 노출합니다.
+          ${inventory && inventory.legacy_shadow_count > 0
+            ? html`<span class="block mt-1 text-amber-300">legacy shadow ${inventory.legacy_shadow_count}개는 picker에서 제외됩니다.</span>`
+            : null}
+        </div>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="rounded-lg border border-[var(--card-border)] bg-[var(--white-4)] px-3 py-1.5 text-[11px] font-semibold text-[var(--text-body)] hover:bg-[var(--white-8)] cursor-pointer"
+            onClick=${loadInventory}
+          >새로고침</button>
+          <button
+            type="button"
+            class="rounded-lg border border-[var(--bad-30)] bg-[var(--bad-10)] px-3 py-1.5 text-[11px] font-semibold text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+            disabled=${deleting || selectedIds.length === 0}
+            onClick=${deleteSelected}
+          >${deleting ? '삭제 중...' : `선택 삭제 (${selectedIds.length})`}</button>
+        </div>
+      </div>
+
+      <${CheckpointSummaryCard}
+        title="현재 active checkpoint"
+        summary=${inventory?.current ?? null}
+      />
+
+      <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
+        <div class="border-b border-[var(--card-border)] px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          OAS Snapshot History
+        </div>
+        ${!inventory || inventory.history.length === 0
+          ? html`<div class="px-3 py-3 text-[12px] text-[var(--text-muted)]">저장된 OAS history snapshot이 아직 없습니다.</div>`
+          : html`
+              <div class="flex flex-col">
+                ${inventory.history.map(item => html`
+                  <label class="flex gap-3 border-b border-[var(--card-border)] px-3 py-3 text-[12px] last:border-b-0">
+                    <input
+                      type="checkbox"
+                      class="mt-1"
+                      checked=${selectedIds.includes(item.snapshot_id)}
+                      onChange=${(event: Event) => toggleSnapshot(item.snapshot_id, (event.currentTarget as HTMLInputElement).checked)}
+                    />
+                    <div class="min-w-0 flex-1">
+                      <div class="flex flex-wrap items-center gap-2">
+                        <span class="font-mono text-[var(--text-strong)]">${item.snapshot_id}</span>
+                        <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold bg-[var(--accent-12)] text-[var(--accent)] border border-[rgba(71,184,255,0.18)]">
+                          gen ${item.generation}
+                        </span>
+                        <span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-[var(--white-8)] bg-[var(--white-3)] text-[var(--text-muted)]">
+                          ${item.message_count} msgs
+                        </span>
+                        ${item.system_prompt_present
+                          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border border-emerald-500/20 bg-emerald-500/10 text-emerald-400">system kept</span>`
+                          : null}
+                      </div>
+                      <div class="mt-1 text-[11px] text-[var(--text-muted)]">
+                        ${formatCheckpointTime(item.created_at)}
+                        ${item.file_stat?.size_bytes ? html` · ${(item.file_stat.size_bytes / 1024).toFixed(1)} KB` : null}
+                      </div>
+                      ${item.latest_preview
+                        ? html`<div class="mt-2 text-[12px] leading-relaxed text-[var(--text-body)]">${item.latest_preview}</div>`
+                        : null}
+                      ${item.continuity_summary
+                        ? html`<pre class="mt-2 whitespace-pre-wrap rounded-lg border border-[var(--white-8)] bg-[rgba(255,255,255,0.03)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-muted)]">${item.continuity_summary}</pre>`
+                        : html`<div class="mt-2 text-[11px] text-[var(--text-dim)]">continuity snapshot 없음</div>`}
+                    </div>
+                  </label>
+                `)}
+              </div>
+            `}
+      </div>
+    </div>
+  `
+}
+
 // ── Comms Panel ──────────────────────────────────────────
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
@@ -422,10 +740,52 @@ export function KeeperDetailOverlay() {
   const effectiveStatus = keeperDisplayStatus(keeper)
   const shouldOpenDiagnostics = keeperNeedsDiagnosticAttention(keeper)
   const [diagOpen, setDiagOpen] = useState(shouldOpenDiagnostics)
+  const [clearDialogOpen, setClearDialogOpen] = useState(false)
+  const [clearReason, setClearReason] = useState('')
+  const [preserveSystemPrompt, setPreserveSystemPrompt] = useState(true)
+  const [clearPending, setClearPending] = useState(false)
+  const [checkpointRefreshToken, setCheckpointRefreshToken] = useState(0)
   const prevKeeperRef = useRef(keeper.name)
   if (prevKeeperRef.current !== keeper.name) {
     prevKeeperRef.current = keeper.name
     setDiagOpen(shouldOpenDiagnostics)
+  }
+  useEffect(() => {
+    setClearDialogOpen(false)
+    setClearReason('')
+    setPreserveSystemPrompt(true)
+    setClearPending(false)
+  }, [keeper.name])
+
+  const submitClearContext = () => {
+    void (async () => {
+      const trimmedReason = clearReason.trim()
+      if (!trimmedReason) {
+        showToast('사유를 먼저 적으세요', 'warning')
+        return
+      }
+      setClearPending(true)
+      try {
+        const res = await clearKeeper(keeper.name, {
+          reason: trimmedReason,
+          preserve_system_prompt: preserveSystemPrompt,
+        })
+        if (res.ok) {
+          setClearDialogOpen(false)
+          setClearReason('')
+          setPreserveSystemPrompt(true)
+          setCheckpointRefreshToken(token => token + 1)
+          showToast(`${keeper.name} 컨텍스트를 비웠습니다`, 'success')
+          await refreshAfterRuntimeAction()
+        } else {
+          showToast(res.error ?? '컨텍스트 비우기 실패', 'error')
+        }
+      } catch (err) {
+        showToast(err instanceof Error ? err.message : '컨텍스트 비우기 실패', 'error')
+      } finally {
+        setClearPending(false)
+      }
+    })()
   }
 
   return html`
@@ -504,6 +864,11 @@ export function KeeperDetailOverlay() {
             </div>
           </div>
           <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="py-1 px-3 rounded-lg text-[11px] font-semibold cursor-pointer border border-[var(--bad-30)] bg-[var(--bad-10)] text-[#fb7185] hover:bg-[rgba(239,68,68,0.15)] transition-colors"
+              onClick=${() => setClearDialogOpen(true)}
+            >비우기</button>
             <${KeeperLifecycleButtons} keeper=${keeper} effectiveStatus=${effectiveStatus} />
             <button
               ref=${closeButtonRef}
@@ -735,6 +1100,19 @@ export function KeeperDetailOverlay() {
               <${KeeperConfigPanel} keeperName=${keeper.name} />
             </div>
           </details>
+
+          <details class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm">
+            <summary class="cursor-pointer text-[11px] font-semibold uppercase tracking-widest text-text-muted list-none select-none flex items-center gap-2">
+              <span class="w-1.5 h-1.5 rounded-full bg-accent/50"></span>
+              Checkpoint & Snapshots
+            </summary>
+            <div class="mt-4">
+              <${KeeperCheckpointPanel}
+                keeperName=${keeper.name}
+                refreshToken=${checkpointRefreshToken}
+              />
+            </div>
+          </details>
         </div>
 
         ${'' /* ── Debug (journal + raw data) ── */}
@@ -756,6 +1134,21 @@ export function KeeperDetailOverlay() {
         </details>
 
         </div>
+
+        <${KeeperClearContextDialog}
+          keeperName=${keeper.name}
+          open=${clearDialogOpen}
+          pending=${clearPending}
+          reason=${clearReason}
+          preserveSystemPrompt=${preserveSystemPrompt}
+          onClose=${() => {
+            if (clearPending) return
+            setClearDialogOpen(false)
+          }}
+          onReasonInput=${setClearReason}
+          onPreserveToggle=${setPreserveSystemPrompt}
+          onSubmit=${submitClearContext}
+        />
     <//>
   `
 }

--- a/lib/keeper/keeper_checkpoint_store.ml
+++ b/lib/keeper/keeper_checkpoint_store.ml
@@ -130,12 +130,92 @@ let load_latest ~(session_dir : string) : Keeper_types.checkpoint option =
 let oas_checkpoint_path ~(session_dir : string) ~(session_id : string) =
   Filename.concat session_dir (session_id ^ ".json")
 
+let oas_history_prefix = "oas-snapshot-"
+let oas_history_suffix = ".json"
+
+let is_oas_history_file (filename : string) : bool =
+  let len = String.length filename in
+  len > String.length oas_history_prefix + String.length oas_history_suffix
+  && String.sub filename 0 (String.length oas_history_prefix) = oas_history_prefix
+  && String.sub filename (len - String.length oas_history_suffix)
+       (String.length oas_history_suffix) = oas_history_suffix
+
+let list_oas_history_files ~(session_dir : string) : string list =
+  if not (Fs_compat.file_exists session_dir) then []
+  else
+    Sys.readdir session_dir
+    |> Array.to_list
+    |> List.filter is_oas_history_file
+    |> List.sort (fun a b -> compare b a)
+
+let max_oas_history_retained = 12
+
+let oas_history_path ~(session_dir : string) ~(snapshot_id : string) =
+  Filename.concat session_dir snapshot_id
+
+let oas_history_snapshot_id_of_checkpoint (ckpt : Agent_sdk.Checkpoint.t) : string =
+  let generation =
+    match ckpt.working_context with
+    | Some (`Assoc fields) -> (
+        match List.assoc_opt "keeper_generation" fields with
+        | Some (`Int n) -> n
+        | Some (`Intlit raw) -> (try int_of_string raw with _ -> 0)
+        | _ -> 0)
+    | _ -> 0
+  in
+  let created_ms = max 0 (int_of_float (ckpt.created_at *. 1000.0)) in
+  Printf.sprintf "%s%013d-g%d%s"
+    oas_history_prefix created_ms generation oas_history_suffix
+
+let save_oas_history ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t) : unit =
+  let snapshot_id = oas_history_snapshot_id_of_checkpoint ckpt in
+  Keeper_fs.save_atomic
+    (oas_history_path ~session_dir ~snapshot_id)
+    (Agent_sdk.Checkpoint.to_string ckpt);
+  let files = list_oas_history_files ~session_dir in
+  if List.length files > max_oas_history_retained then
+    files
+    |> List.filteri (fun index _ -> index >= max_oas_history_retained)
+    |> List.iter (fun filename ->
+         let path = oas_history_path ~session_dir ~snapshot_id:filename in
+         try Sys.remove path with
+         | Eio.Cancel.Cancelled _ as e -> raise e
+         | exn ->
+             Log.Keeper.warn "OAS snapshot cleanup failed for %s: %s"
+               path (Printexc.to_string exn))
+
+let delete_oas_history_files ~(session_dir : string) ~(snapshot_ids : string list)
+    : string list * string list =
+  List.fold_left
+    (fun (deleted, missing) snapshot_id ->
+      let path = oas_history_path ~session_dir ~snapshot_id in
+      if Fs_compat.file_exists path then (
+        try
+          Sys.remove path;
+          (snapshot_id :: deleted, missing)
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+            Log.Keeper.warn "OAS snapshot delete failed for %s: %s"
+              path (Printexc.to_string exn);
+            (deleted, snapshot_id :: missing))
+      else
+        (deleted, snapshot_id :: missing))
+    ([], [])
+    snapshot_ids
+  |> fun (deleted, missing) -> (List.rev deleted, List.rev missing)
+
 let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
   : (unit, string) result =
   let fallback () =
     Keeper_fs.save_atomic
       (oas_checkpoint_path ~session_dir ~session_id:ckpt.session_id)
       (Agent_sdk.Checkpoint.to_string ckpt);
+    (try save_oas_history ~session_dir ckpt with
+     | Eio.Cancel.Cancelled _ as e -> raise e
+     | exn ->
+         Log.Keeper.warn "OAS snapshot archive write failed for %s: %s"
+           ckpt.session_id (Printexc.to_string exn));
     Ok ()
   in
   try
@@ -144,8 +224,16 @@ let save_oas ~(session_dir : string) (ckpt : Agent_sdk.Checkpoint.t)
     | Some fs when Eio_guard.is_ready () ->
         let dir = Eio.Path.(fs / session_dir) in
         (match Agent_sdk.Checkpoint_store.create dir with
-         | Ok store -> Agent_sdk.Checkpoint_store.save store ckpt
-             |> Result.map_error Agent_sdk.Error.to_string
+         | Ok store -> (
+             match Agent_sdk.Checkpoint_store.save store ckpt with
+             | Ok () ->
+                 (try save_oas_history ~session_dir ckpt with
+                  | Eio.Cancel.Cancelled _ as e -> raise e
+                  | exn ->
+                      Log.Keeper.warn "OAS snapshot archive write failed for %s: %s"
+                        ckpt.session_id (Printexc.to_string exn));
+                 Ok ()
+             | Error err -> Error (Agent_sdk.Error.to_string err))
          | Error err -> Error (Agent_sdk.Error.to_string err))
     | Some _ | None ->
         fallback ()
@@ -217,6 +305,19 @@ let classify_sdk_error (e : Agent_sdk.Error.sdk_error) : checkpoint_load_error =
   | Serialization (UnknownVariant r) ->
       Parse_error (sprintf "unknown variant %s: %s" r.type_name r.value)
   | _ -> Io_error (Agent_sdk.Error.to_string e)
+
+let load_oas_history_file ~(session_dir : string) ~(snapshot_id : string) :
+    (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =
+  let path = oas_history_path ~session_dir ~snapshot_id in
+  if Fs_compat.file_exists path then
+    try
+      match Agent_sdk.Checkpoint.of_string (Fs_compat.load_file path) with
+      | Ok ckpt -> Ok ckpt
+      | Error e -> Error (classify_sdk_error e)
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn -> Error (Io_error (Printexc.to_string exn))
+  else Error Not_found
 
 let load_oas ~(session_dir : string) ~(session_id : string) :
     (Agent_sdk.Checkpoint.t, checkpoint_load_error) result =

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -14,6 +14,8 @@ let keeper_suffix_config = "/config"
 let keeper_suffix_boot = "/boot"
 let keeper_suffix_shutdown = "/shutdown"
 let keeper_suffix_reset = "/reset"
+let keeper_suffix_clear = "/clear"
+let keeper_suffix_checkpoints = "/checkpoints"
 
 let dedupe_tool_names names =
   Json_util.dedupe_keep_order
@@ -239,6 +241,8 @@ type keeper_post_route_kind =
   | Keeper_post_boot
   | Keeper_post_shutdown
   | Keeper_post_reset
+  | Keeper_post_clear
+  | Keeper_post_checkpoints
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
@@ -256,7 +260,262 @@ let classify_keeper_post_route req_path =
   else if ends_with keeper_suffix_boot then Keeper_post_boot
   else if ends_with keeper_suffix_shutdown then Keeper_post_shutdown
   else if ends_with keeper_suffix_reset then Keeper_post_reset
+  else if ends_with keeper_suffix_clear then Keeper_post_clear
+  else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
   else Keeper_post_unknown
+
+let keeper_path_ends_with req_path suffix =
+  let prefix = keeper_api_prefix in
+  let plen = String.length prefix in
+  let tlen = String.length req_path in
+  let slen = String.length suffix in
+  tlen > plen + slen
+  && String.sub req_path 0 plen = prefix
+  && String.sub req_path (tlen - slen) slen = suffix
+
+let extract_keeper_name_for_suffix req_path suffix =
+  let plen = String.length keeper_api_prefix in
+  let slen = String.length suffix in
+  let raw =
+    String.trim
+      (String.sub req_path plen (String.length req_path - plen - slen))
+  in
+  let valid =
+    String.length raw > 0
+    && String.length raw <= 128
+    && String.to_seq raw
+       |> Seq.for_all (fun c ->
+            (c >= 'a' && c <= 'z')
+            || (c >= 'A' && c <= 'Z')
+            || (c >= '0' && c <= '9')
+            || c = '_' || c = '-')
+  in
+  if valid then raw else ""
+
+let is_keeper_checkpoints_get_path req_path =
+  keeper_path_ends_with req_path keeper_suffix_checkpoints
+
+let trim_to_opt (value : string) =
+  let trimmed = String.trim value in
+  if trimmed = "" then None else Some trimmed
+
+let truncate_text ~max_chars text =
+  let len = String.length text in
+  if len <= max_chars then text
+  else if max_chars <= 1 then String.sub text 0 (max 0 max_chars)
+  else String.sub text 0 (max_chars - 1) ^ "…"
+
+let latest_preview_of_messages (messages : Agent_sdk.Types.message list) =
+  messages
+  |> List.rev
+  |> List.find_map (fun (message : Agent_sdk.Types.message) ->
+       if message.role = Agent_sdk.Types.System then None
+       else
+         Agent_sdk.Types.text_of_message message
+         |> trim_to_opt
+         |> Option.map (truncate_text ~max_chars:180))
+
+let continuity_summary_of_messages (messages : Agent_sdk.Types.message list) =
+  match Keeper_memory_policy.latest_state_snapshot_from_messages messages with
+  | Some snapshot ->
+      Keeper_memory_policy.keeper_state_snapshot_to_summary_text snapshot
+      |> trim_to_opt
+  | None -> None
+
+let stat_json_of_path (path : string) =
+  try
+    let stat = Unix.stat path in
+    `Assoc
+      [
+        ("size_bytes", `Int stat.st_size);
+        ("mtime", `Float stat.st_mtime);
+      ]
+  with
+  | Unix.Unix_error _ -> `Null
+
+let oas_checkpoint_summary_json
+    ~(source_kind : string)
+    ~(snapshot_id : string)
+    ~(path : string)
+    ~(is_current : bool)
+    ~(fallback_generation : int)
+    (checkpoint : Agent_sdk.Checkpoint.t) =
+  let generation =
+    Keeper_context_core.checkpoint_generation checkpoint
+      ~fallback:fallback_generation
+  in
+  let messages = checkpoint.messages in
+  let continuity_summary = continuity_summary_of_messages messages in
+  `Assoc
+    [
+      ("snapshot_id", `String snapshot_id);
+      ("source_kind", `String source_kind);
+      ("is_current", `Bool is_current);
+      ("path", `String path);
+      ("created_at", `Float checkpoint.created_at);
+      ("generation", `Int generation);
+      ("message_count", `Int (List.length messages));
+      ( "system_prompt_present",
+        `Bool
+          (match checkpoint.system_prompt with
+           | Some prompt -> String.trim prompt <> ""
+           | None -> false) );
+      ( "latest_preview",
+        match latest_preview_of_messages messages with
+        | Some preview -> `String preview
+        | None -> `Null );
+      ( "continuity_summary",
+        match continuity_summary with
+        | Some summary -> `String summary
+        | None -> `Null );
+      ("file_stat", stat_json_of_path path);
+    ]
+
+let keeper_checkpoint_inventory_json
+    (config : Coord.config)
+    (name : string) : [ `OK | `Not_found ] * Yojson.Safe.t =
+  match Keeper_types.read_meta_resolved config name with
+  | Error msg ->
+      (`Not_found, `Assoc [("error", `String msg)])
+  | Ok None ->
+      (`Not_found,
+       `Assoc [("error", `String (Printf.sprintf "keeper %S not found" name))])
+  | Ok (Some (_, meta)) ->
+      let trace_id = Keeper_id.Trace_id.to_string meta.runtime.trace_id in
+      let session_dir = Keeper_types.keeper_session_dir config trace_id in
+      let current_path =
+        Keeper_checkpoint_store.oas_checkpoint_path
+          ~session_dir ~session_id:trace_id
+      in
+      let current_json =
+        match
+          Keeper_checkpoint_store.load_oas ~session_dir ~session_id:trace_id
+        with
+        | Ok checkpoint ->
+            let current_history_snapshot_id =
+              Keeper_checkpoint_store.oas_history_snapshot_id_of_checkpoint checkpoint
+            in
+            oas_checkpoint_summary_json
+              ~source_kind:"oas_current"
+              ~snapshot_id:(Filename.basename current_path)
+              ~path:current_path
+              ~is_current:true
+              ~fallback_generation:meta.runtime.generation
+              checkpoint
+            |> fun json -> Some (json, current_history_snapshot_id)
+        | Error _ -> None
+      in
+      let history_json =
+        Keeper_checkpoint_store.list_oas_history_files ~session_dir
+        |> List.filter (fun snapshot_id ->
+             match current_json with
+             | Some (_json, current_history_snapshot_id) ->
+                 snapshot_id <> current_history_snapshot_id
+             | None -> true)
+        |> List.filter_map (fun snapshot_id ->
+             match
+               Keeper_checkpoint_store.load_oas_history_file
+                 ~session_dir ~snapshot_id
+             with
+             | Ok checkpoint ->
+                 Some
+                   (oas_checkpoint_summary_json
+                      ~source_kind:"oas_history"
+                      ~snapshot_id
+                      ~path:
+                        (Keeper_checkpoint_store.oas_history_path
+                           ~session_dir ~snapshot_id)
+                      ~is_current:false
+                      ~fallback_generation:meta.runtime.generation
+                      checkpoint)
+             | Error _ -> None)
+      in
+      ( `OK,
+        `Assoc
+          [
+            ("keeper", `String name);
+            ("trace_id", `String trace_id);
+            ("session_dir", `String session_dir);
+            ("current", match current_json with Some (json, _snapshot_id) -> json | None -> `Null);
+            ("history", `List history_json);
+            ( "legacy_shadow_count",
+              `Int
+                (List.length
+                   (Keeper_checkpoint_store.list_checkpoints ~session_dir)) );
+          ] )
+
+let handle_keeper_checkpoints_post state req reqd body_str =
+  let req_path = Http.Request.path req in
+  let name = extract_keeper_name_for_suffix req_path keeper_suffix_checkpoints in
+  if String.length name = 0 then
+    Http.Response.json ~status:`Bad_request
+      {|{"ok":false,"error":"keeper name is required"}|} reqd
+  else
+    let config = state.Mcp_server.room_config in
+    try
+      let args = Yojson.Safe.from_string body_str in
+      let action = Safe_ops.json_string ~default:"" "action" args in
+      match action with
+      | "delete_history" ->
+          let snapshot_ids =
+            Safe_ops.json_string_list "snapshot_ids" args
+            |> List.map String.trim
+            |> List.filter (fun value -> value <> "")
+            |> Json_util.dedupe_keep_order
+          in
+          if snapshot_ids = [] then
+            Http.Response.json ~status:`Bad_request
+              {|{"ok":false,"error":"snapshot_ids is required"}|} reqd
+          else
+            let trace_id_result =
+              match Keeper_types.read_meta_resolved config name with
+              | Ok (Some (_, meta)) ->
+                  Ok (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+              | Ok None ->
+                  Error (Printf.sprintf "keeper %S not found" name)
+              | Error msg -> Error msg
+            in
+            (match trace_id_result with
+             | Error msg ->
+                 Http.Response.json ~status:`Not_found
+                   (Printf.sprintf {|{"ok":false,"error":"%s"}|}
+                      (String.escaped msg))
+                   reqd
+             | Ok trace_id ->
+                 let session_dir = Keeper_types.keeper_session_dir config trace_id in
+                 let (deleted, missing) =
+                   Keeper_checkpoint_store.delete_oas_history_files
+                     ~session_dir ~snapshot_ids
+                 in
+                 let (_status, inventory) =
+                   keeper_checkpoint_inventory_json config name
+                 in
+                 Http.Response.json ~compress:true ~request:req
+                   (Yojson.Safe.to_string
+                      (`Assoc
+                         [
+                           ("ok", `Bool true);
+                           ("action", `String "delete_history");
+                           ("keeper", `String name);
+                           ("deleted_snapshot_ids", `List (List.map (fun id -> `String id) deleted));
+                           ("missing_snapshot_ids", `List (List.map (fun id -> `String id) missing));
+                           ("inventory", inventory);
+                         ]))
+                   reqd)
+      | "" ->
+          Http.Response.json ~status:`Bad_request
+            {|{"ok":false,"error":"action is required"}|} reqd
+      | other ->
+          Http.Response.json ~status:`Bad_request
+            (Printf.sprintf {|{"ok":false,"error":"unknown action: %s"}|}
+               (String.escaped other))
+            reqd
+    with
+    | Yojson.Json_error e ->
+        Http.Response.json ~status:`Bad_request
+          (Printf.sprintf {|{"ok":false,"error":"invalid json: %s"}|}
+             (String.escaped e))
+          reqd
 
 let is_valid_keeper_name name =
   String.length name > 0
@@ -367,13 +626,15 @@ let handle_keeper_config_post ~sw ~clock state agent_name req reqd body_str =
                 (String.escaped e))
              reqd)
 
-let handle_keeper_lifecycle_post ~sw ~clock ~tool_name ~action state agent_name req reqd =
+let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
+    state agent_name req reqd =
   let req_path = Http.Request.path req in
   let suffix_result =
     match action with
     | "boot" -> Ok keeper_suffix_boot
     | "shutdown" -> Ok keeper_suffix_shutdown
     | "reset" -> Ok keeper_suffix_reset
+    | "clear" -> Ok keeper_suffix_clear
     | unknown ->
         Error (Printf.sprintf "unknown keeper lifecycle action: %s" unknown)
   in
@@ -398,16 +659,43 @@ let handle_keeper_lifecycle_post ~sw ~clock ~tool_name ~action state agent_name 
         net = state.Mcp_server.net;
       }
     in
-    let args = `Assoc [("name", `String name)] in
+    let args_result =
+      match action with
+      | "clear" -> (
+          match body_str with
+          | None ->
+              Error "request body is required for clear"
+          | Some raw -> (
+              try
+                let parsed = Yojson.Safe.from_string raw in
+                match parsed with
+                | `Assoc fields ->
+                    Ok (`Assoc (("name", `String name) :: List.remove_assoc "name" fields))
+                | _ ->
+                    Error "request body must be a JSON object"
+              with
+              | Yojson.Json_error err ->
+                  Error (Printf.sprintf "invalid json: %s" err)))
+      | _ -> Ok (`Assoc [("name", `String name)])
+    in
+    match args_result with
+    | Error msg ->
+        Http.Response.json ~status:`Bad_request
+          (Printf.sprintf {|{"ok":false,"error":"%s"}|} (String.escaped msg))
+          reqd
+    | Ok args ->
     match Tool_keeper.dispatch keeper_ctx ~name:tool_name ~args with
-    | Some (true, body) when String.equal action "boot" ->
+    | Some (true, body) when String.equal action "boot" || String.equal action "clear" ->
         Http.Response.json ~compress:true ~request:req
-          (Printf.sprintf {|{"ok":true,"action":"boot","name":"%s","detail":%s}|}
-             (String.escaped name) body)
+          (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s","detail":%s}|}
+             (String.escaped action)
+             (String.escaped name)
+             body)
           reqd
     | Some (true, _body) ->
         Http.Response.json ~compress:true ~request:req
-          (Printf.sprintf {|{"ok":true,"action":"shutdown","name":"%s"}|}
+          (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
+             (String.escaped action)
              (String.escaped name))
           reqd
     | Some (false, body) ->
@@ -448,6 +736,18 @@ let handle_keeper_get_subroutes state req request reqd =
       in
       Server_auth.respond_json_with_cors ~status:`OK request reqd
         (Yojson.Safe.to_string (Keeper_chat_store.to_json_array messages))
+  else if ends_with keeper_suffix_checkpoints then
+    let name = extract_name keeper_suffix_checkpoints in
+    if String.length name = 0 then
+      Http.Response.json ~status:`Bad_request
+        {|{"error":"keeper name is required"}|} reqd
+    else
+      let (st, json) = keeper_checkpoint_inventory_json state.Mcp_server.room_config name in
+      let status : Httpun.Status.t =
+        match st with `OK -> `OK | `Not_found -> `Not_found
+      in
+      Http.Response.json ~status ~compress:true ~request:req
+        (Yojson.Safe.to_string json) reqd
   else if ends_with "/config" then
     let name = extract_name "/config" in
     if String.length name = 0 then

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -511,9 +511,15 @@ let rec add_routes ~sw ~clock router =
 
   (* Keeper GET sub-routes: /config, /chat/history, /trajectory *)
   |> Http.Router.prefix_get "/api/v1/keepers/" (fun request reqd ->
-       with_public_read (fun state req reqd ->
-         Keeper_api.handle_keeper_get_subroutes state req request reqd
-       ) request reqd)
+       if Keeper_api.is_keeper_checkpoints_get_path (Http.Request.path request) then
+         with_token_permission_auth ~permission:Types.CanAdmin
+           (fun state _agent_name req reqd ->
+             Keeper_api.handle_keeper_get_subroutes state req request reqd
+           ) request reqd
+       else
+         with_public_read (fun state req reqd ->
+           Keeper_api.handle_keeper_get_subroutes state req request reqd
+         ) request reqd)
 
   (* Keeper config or tools update.  This prefix_post catches ALL POST
      /api/v1/keepers/* requests.  We check the suffix BEFORE auth so that
@@ -550,6 +556,22 @@ let rec add_routes ~sw ~clock router =
              (fun state agent_name req reqd ->
                Keeper_api.handle_keeper_lifecycle_post ~sw ~clock ~tool_name:"masc_keeper_reset"
                  ~action:"reset" state agent_name req reqd
+             ) request reqd
+       | Keeper_api.Keeper_post_clear ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_lifecycle_post ~body_str ~sw ~clock
+                   ~tool_name:"masc_keeper_clear" ~action:"clear"
+                   state agent_name req reqd
+               )
+             ) request reqd
+       | Keeper_api.Keeper_post_checkpoints ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state _agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_checkpoints_post state req reqd body_str
+               )
              ) request reqd
        | Keeper_api.Keeper_post_unknown ->
            Http.Response.json ~status:`Not_found

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -797,11 +797,66 @@ let handle_keeper_clear ctx args : tool_result =
             | Some meta -> meta.runtime.generation
             | None -> 0
           in
-          let checkpoint =
-            Keeper_exec_context.create_checkpoint cleared_ctx ~generation:(current_gen + 1)
-          in
-          Keeper_exec_context.save_session_checkpoint session checkpoint;
+          (match meta_for_trace with
+           | Some meta ->
+               let model = Keeper_exec_context.checkpoint_model_of_meta meta in
+               (match
+                  Keeper_exec_context.save_oas_checkpoint
+                    ~max_checkpoint_messages
+                    ~session
+                    ~agent_name:meta.agent_name
+                    ~model
+                    ~ctx:cleared_ctx
+                    ~generation:(current_gen + 1)
+                with
+                | Ok _ -> ()
+                | Error err ->
+                    Log.Keeper.warn
+                      "%s: failed to save cleared OAS checkpoint: %s"
+                      name err)
+           | None -> ());
           msg_count - List.length cleared_messages
+      in
+      let legacy_shadow_removed_count =
+        let files = Keeper_checkpoint_store.list_checkpoints ~session_dir:session.session_dir in
+        List.fold_left
+          (fun count filename ->
+            let path = Filename.concat session.session_dir filename in
+            try
+              Sys.remove path;
+              count + 1
+            with
+            | Eio.Cancel.Cancelled _ as e -> raise e
+            | exn ->
+                Log.Keeper.warn
+                  "%s: failed to remove legacy checkpoint shadow %s: %s"
+                  name path (Printexc.to_string exn);
+                count)
+          0 files
+      in
+      let continuity_cleared =
+        match meta_for_trace with
+        | Some meta ->
+            let updated_meta =
+              {
+                meta with
+                continuity_summary = "";
+                updated_at = Keeper_types.now_iso ();
+                runtime =
+                  {
+                    meta.runtime with
+                    last_continuity_update_ts = 0.0;
+                  };
+              }
+            in
+            (match Keeper_types.write_meta ~force:true ctx.config updated_meta with
+             | Ok () -> true
+             | Error err ->
+                 Log.Keeper.warn
+                   "%s: failed to clear continuity meta during operator clear: %s"
+                   name err;
+                 false)
+        | None -> false
       in
       (* Dispatch FSM event to clear overflow conditions *)
       Keeper_exec_context.dispatch_keeper_phase_event
@@ -828,6 +883,8 @@ let handle_keeper_clear ctx args : tool_result =
                | None -> "unknown"));
            ("cleared_message_count", `Int cleared_count);
            ("checkpoint_found", `Bool checkpoint_found);
+           ("continuity_cleared", `Bool continuity_cleared);
+           ("legacy_shadow_removed_count", `Int legacy_shadow_removed_count);
            ("preserve_system_prompt", `Bool preserve_system);
            ("reason", `String reason);
          ]))

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -385,6 +385,8 @@ let check_route path expected =
        | Keeper_api.Keeper_post_boot -> "boot"
        | Keeper_api.Keeper_post_shutdown -> "shutdown"
        | Keeper_api.Keeper_post_reset -> "reset"
+       | Keeper_api.Keeper_post_clear -> "clear"
+       | Keeper_api.Keeper_post_checkpoints -> "checkpoints"
        | Keeper_api.Keeper_post_unknown -> "unknown")
       path
 ;;
@@ -395,6 +397,8 @@ let test_keeper_post_route_classification () =
   check_route "/api/v1/keepers/sangsu/boot" Keeper_api.Keeper_post_boot;
   check_route "/api/v1/keepers/sangsu/shutdown" Keeper_api.Keeper_post_shutdown;
   check_route "/api/v1/keepers/sangsu/reset" Keeper_api.Keeper_post_reset;
+  check_route "/api/v1/keepers/sangsu/clear" Keeper_api.Keeper_post_clear;
+  check_route "/api/v1/keepers/sangsu/checkpoints" Keeper_api.Keeper_post_checkpoints;
   check_route "/api/v1/keepers/sangsu" Keeper_api.Keeper_post_unknown;
   check_route "/api/v1/keepers//boot" Keeper_api.Keeper_post_unknown
 ;;
@@ -417,6 +421,7 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
   @@ fun ~port ~config ~admin_token ~keeper_name ->
   let boot_path = Printf.sprintf "/api/v1/keepers/%s/boot" keeper_name in
   let shutdown_path = Printf.sprintf "/api/v1/keepers/%s/shutdown" keeper_name in
+  let clear_path = Printf.sprintf "/api/v1/keepers/%s/clear" keeper_name in
   let boot_result =
     run_curl_post ~body:"{}" ~token:admin_token ~port ~path:boot_path ()
   in
@@ -445,6 +450,56 @@ let test_keeper_lifecycle_routes_do_not_fall_through_to_generic_404 () =
     "shutdown route reaches lifecycle handler"
     true
     (contains_substr {|"action":"shutdown"|} shutdown_result.body);
+  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+   | Ok (Some meta) ->
+       let updated_meta =
+         {
+           meta with
+           continuity_summary = "stale continuity snapshot";
+           updated_at = Masc_mcp.Keeper_types.now_iso ();
+           runtime =
+             {
+               meta.runtime with
+               last_continuity_update_ts = 1234.0;
+             };
+         }
+       in
+       (match Masc_mcp.Keeper_types.write_meta ~force:true config updated_meta with
+        | Ok () -> ()
+        | Error err -> fail ("failed to seed continuity summary: " ^ err))
+   | Ok None -> fail "keeper meta missing before clear route"
+   | Error err -> fail ("failed to read keeper meta before clear: " ^ err));
+  let clear_result =
+    run_curl_post
+      ~body:{|{"reason":"reset stale continuity","preserve_system_prompt":true}|}
+      ~token:admin_token
+      ~port
+      ~path:clear_path
+      ()
+  in
+  require_status "clear route returns 200" 200 clear_result;
+  check
+    bool
+    "clear route is not generic 404"
+    false
+    (contains_substr {|{"error":"not found"}|} clear_result.body);
+  check
+    bool
+    "clear route reaches lifecycle handler"
+    true
+    (contains_substr {|"action":"clear"|} clear_result.body);
+  check
+    bool
+    "clear route reports continuity cleanup"
+    true
+    (contains_substr {|"continuity_cleared":true|} clear_result.body);
+  (match Masc_mcp.Keeper_types.read_meta config keeper_name with
+   | Ok (Some meta) ->
+       check string "clear resets continuity summary" "" meta.continuity_summary;
+       check (float 0.0001) "clear resets continuity freshness" 0.0
+         meta.runtime.last_continuity_update_ts
+   | Ok None -> fail "keeper meta missing after clear route"
+   | Error err -> fail ("failed to read keeper meta after clear: " ^ err));
   match Masc_mcp.Keeper_types.read_meta config keeper_name with
   | Ok (Some meta) -> check bool "shutdown persists paused keeper meta" true meta.paused
   | Ok None -> fail "keeper meta missing after shutdown route"

--- a/test/test_oas_worker.ml
+++ b/test/test_oas_worker.ml
@@ -1165,6 +1165,50 @@ let test_keeper_checkpoint_store_oas_missing_returns_none () =
               | Io_error d -> "io:" ^ d
               | Not_found -> "not_found"))))
 
+let test_keeper_checkpoint_store_writes_oas_history () =
+  let base_dir = temp_dir "keeper_oas_history_store" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      Fs_compat.clear_fs ();
+      let session_dir = Filename.concat base_dir "trace-history" in
+      let checkpoint1 =
+        make_oas_checkpoint ~session_id:"trace-history"
+          ~messages:[Agent_sdk.Types.user_msg "first"]
+          ~created_at:1711234500.0 ()
+      in
+      let checkpoint2 =
+        make_oas_checkpoint ~session_id:"trace-history"
+          ~messages:[Agent_sdk.Types.user_msg "second"]
+          ~created_at:1711234560.0 ()
+      in
+      (match Keeper_checkpoint_store.save_oas ~session_dir checkpoint1 with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail (Printf.sprintf "save_oas #1 failed: %s" e));
+      (match Keeper_checkpoint_store.save_oas ~session_dir checkpoint2 with
+       | Ok () -> ()
+       | Error e -> Alcotest.fail (Printf.sprintf "save_oas #2 failed: %s" e));
+      let history_files =
+        Keeper_checkpoint_store.list_oas_history_files ~session_dir
+      in
+      Alcotest.(check int) "history file count" 2 (List.length history_files);
+      let latest_snapshot_id =
+        match history_files with
+        | latest :: _ -> latest
+        | [] -> Alcotest.fail "expected OAS snapshot history file"
+      in
+      match
+        Keeper_checkpoint_store.load_oas_history_file
+          ~session_dir ~snapshot_id:latest_snapshot_id
+      with
+      | Ok loaded ->
+          Alcotest.(check (float 0.000001)) "history created_at preserved"
+            checkpoint2.created_at
+            loaded.created_at;
+          Alcotest.(check string) "latest history message" "second"
+            (Agent_sdk.Types.text_of_message (List.hd loaded.messages))
+      | Error _ -> Alcotest.fail "expected OAS history checkpoint load to succeed")
+
 let test_keeper_checkpoint_prefers_oas_checkpoint () =
   let base_dir = temp_dir "keeper_oas_checkpoint" in
   Fun.protect
@@ -1924,6 +1968,8 @@ let () =
     "keeper_checkpoint_store", [
       Alcotest.test_case "OAS store roundtrip" `Quick
         test_keeper_checkpoint_store_oas_roundtrip;
+      Alcotest.test_case "OAS store writes history snapshots" `Quick
+        test_keeper_checkpoint_store_writes_oas_history;
       Alcotest.test_case "OAS store missing returns none" `Quick
         test_keeper_checkpoint_store_oas_missing_returns_none;
       Alcotest.test_case "prefers OAS checkpoint over legacy" `Quick


### PR DESCRIPTION
- Dashboard UI: `keeper-detail.ts` 헤더 비우기 동작을 active OAS checkpoint만 비우도록 변경
- Checkpoint & Snapshots 섹션 신설 (current OAS checkpoint + OAS-native snapshot history 표출 및 선택 삭제 지원)
- API: `api/keeper.ts` 프론트엔드 연동 및 `server_dashboard_http_keeper_api.ml`, `server_routes_http_routes_dashboard.ml`에 `/api/v1/keepers/:name/checkpoints` 어드민 라우트 추가
- Store: `keeper_checkpoint_store.ml`에 OAS snapshot history archive 추가
- Core: `tool_keeper.ml`의 `masc_keeper_clear`가 더 이상 legacy shadow를 만들지 않고 OAS current만 갱신하며, 현재 세션의 남은 legacy `ckpt-*`도 정리하도록 개선
- Note: Legacy 지원 코드를 완전히 삭제하지는 않았으나, 신규 surface에서는 legacy 생성을 중단함