### PR TITLE
feat(cascade): client capacity event history (observability)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1892,3 +1892,35 @@ export function fetchCascadeClientCapacity(
     signal: opts?.signal,
   })
 }
+
+export type CascadeCapacityEventKind = 'acquired' | 'released' | 'rejected_full'
+
+export interface CascadeClientCapacityHistoryEvent {
+  ts: number
+  key: string
+  kind: CascadeCapacityEventKind
+  active_after: number
+}
+
+export interface CascadeClientCapacityHistoryResponse {
+  updated_at: string
+  total_events: number
+  events: CascadeClientCapacityHistoryEvent[]
+}
+
+export function fetchCascadeClientCapacityHistory(opts?: {
+  limit?: number
+  kind?: CascadeCapacityKind
+  signal?: AbortSignal
+}): Promise<CascadeClientCapacityHistoryResponse> {
+  const params = new URLSearchParams()
+  if (typeof opts?.limit === 'number' && opts.limit > 0) {
+    params.set('limit', String(opts.limit))
+  }
+  if (opts?.kind) params.set('kind', opts.kind)
+  const qs = params.toString()
+  return get<CascadeClientCapacityHistoryResponse>(
+    `/api/v1/cascade/client_capacity/history${qs ? `?${qs}` : ''}`,
+    { signal: opts?.signal },
+  )
+}

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -11,10 +11,14 @@ import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
 import {
   fetchCascadeClientCapacity,
+  fetchCascadeClientCapacityHistory,
   fetchCascadeConfig,
   fetchCascadeHealth,
   type CascadeCandidate,
+  type CascadeCapacityEventKind,
   type CascadeClientCapacityEntry,
+  type CascadeClientCapacityHistoryEvent,
+  type CascadeClientCapacityHistoryResponse,
   type CascadeClientCapacityResponse,
   type CascadeConfigResponse,
   type CascadeHealthProvider,
@@ -32,16 +36,18 @@ interface CascadeData {
   config: CascadeConfigResponse | null
   health: CascadeHealthResponse | null
   capacity: CascadeClientCapacityResponse | null
+  history: CascadeClientCapacityHistoryResponse | null
 }
 
 async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   await resource.load(async (signal) => {
-    const [config, health, capacity] = await Promise.all([
+    const [config, health, capacity, history] = await Promise.all([
       fetchCascadeConfig({ signal }),
       fetchCascadeHealth({ signal }),
       fetchCascadeClientCapacity({ signal }),
+      fetchCascadeClientCapacityHistory({ limit: 50, signal }),
     ])
-    return { config, health, capacity }
+    return { config, health, capacity, history }
   })
 }
 
@@ -204,12 +210,70 @@ function capacityTone(entry: CascadeClientCapacityEntry): 'ok' | 'warn' | 'bad' 
   return 'ok'
 }
 
+function fmtRelativeTime(tsSec: number): string {
+  const deltaSec = Date.now() / 1000 - tsSec
+  if (!Number.isFinite(deltaSec) || deltaSec < 0) return '방금'
+  if (deltaSec < 1) return '방금'
+  if (deltaSec < 60) return `${Math.floor(deltaSec)}초 전`
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}분 전`
+  if (deltaSec < 86400) return `${Math.floor(deltaSec / 3600)}시간 전`
+  return `${Math.floor(deltaSec / 86400)}일 전`
+}
+
+function eventKindTone(kind: CascadeCapacityEventKind): 'ok' | 'neutral' | 'bad' {
+  switch (kind) {
+    case 'acquired': return 'ok'
+    case 'released': return 'neutral'
+    case 'rejected_full': return 'bad'
+  }
+}
+
+function eventKindLabel(kind: CascadeCapacityEventKind): string {
+  switch (kind) {
+    case 'acquired': return 'acquired'
+    case 'released': return 'released'
+    case 'rejected_full': return 'rejected'
+  }
+}
+
 function capacityKindLabel(kind: CascadeClientCapacityEntry['kind']): string {
   switch (kind) {
     case 'cli': return 'CLI'
     case 'ollama': return 'Ollama'
     case 'other': return 'Other'
   }
+}
+
+function ClientCapacityHistoryTable({
+  history,
+}: { history: CascadeClientCapacityHistoryResponse }) {
+  if (history.events.length === 0) {
+    return html`<${EmptyState}>최근 capacity 이벤트가 없습니다. (acquire/release가 아직 발생하지 않음)<//>`
+  }
+  return html`
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+          <th class="text-left py-1 w-20">시간</th>
+          <th class="text-left py-1">종류</th>
+          <th class="text-left py-1">키</th>
+          <th class="text-right py-1">활성</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${history.events.map((e: CascadeClientCapacityHistoryEvent) => {
+          const tone = eventKindTone(e.kind)
+          return html`
+          <tr class="border-b border-[var(--card-border)] last:border-b-0">
+            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+            <td class="py-1"><${StatusChip} tone=${tone}>${eventKindLabel(e.kind)}<//></td>
+            <td class="py-1"><code class="text-[var(--text-strong)]">${e.key}</code></td>
+            <td class="py-1 text-right tabular-nums">${e.active_after}</td>
+          </tr>
+        `})}
+      </tbody>
+    </table>
+  `
 }
 
 function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResponse }) {
@@ -263,6 +327,7 @@ export function CascadeConfigPanel() {
   const config = current.data?.config ?? null
   const health = current.data?.health ?? null
   const capacity = current.data?.capacity ?? null
+  const history = current.data?.history ?? null
 
   return html`
     <div class="flex flex-col gap-4">
@@ -339,6 +404,12 @@ export function CascadeConfigPanel() {
       <${Card} title="Client Capacity">
         ${capacity
           ? html`<${ClientCapacityTable} capacity=${capacity} />`
+          : null}
+      <//>
+
+      <${Card} title="Client Capacity — 최근 이벤트">
+        ${history
+          ? html`<${ClientCapacityHistoryTable} history=${history} />`
           : null}
       <//>
     </div>

--- a/lib/cascade/cascade_client_capacity.ml
+++ b/lib/cascade/cascade_client_capacity.ml
@@ -76,14 +76,36 @@ let try_acquire url =
        another fiber bumps the count between read and CAS. *)
     let rec attempt () =
       let current = Atomic.get e.active in
-      if current >= e.max_concurrent then None
+      if current >= e.max_concurrent then begin
+        (* Slot full: record for observability before returning. *)
+        Cascade_client_capacity_history.record {
+          ts = Unix.gettimeofday ();
+          key = url;
+          kind = Rejected_full;
+          active_after = current;
+        };
+        None
+      end
       else if Atomic.compare_and_set e.active current (current + 1) then (
+        Cascade_client_capacity_history.record {
+          ts = Unix.gettimeofday ();
+          key = url;
+          kind = Acquired;
+          active_after = current + 1;
+        };
         let released = Atomic.make false in
         let release () =
-          if not (Atomic.exchange released true) then
+          if not (Atomic.exchange released true) then begin
             (* Decrement once, ensure no underflow from double release
                even though the flag guards us. *)
-            ignore (Atomic.fetch_and_add e.active (-1))
+            let prev = Atomic.fetch_and_add e.active (-1) in
+            Cascade_client_capacity_history.record {
+              ts = Unix.gettimeofday ();
+              key = url;
+              kind = Released;
+              active_after = prev - 1;
+            }
+          end
         in
         Some release)
       else attempt ()

--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -1,0 +1,168 @@
+(** See cascade_client_capacity_history.mli for documentation. *)
+
+type event_kind = Acquired | Released | Rejected_full
+
+type event = {
+  ts : float;
+  key : string;
+  kind : event_kind;
+  active_after : int;
+}
+
+(* ── Classifier (copy of Dashboard_cascade.classify_capacity_key) ─
+
+   We copy-paste instead of extracting into a shared helper because:
+   - Both copies are ~12 lines and unlikely to drift meaningfully
+     (the classifier is anchored to two literal substrings).
+   - The dashboard module would otherwise need to depend on this
+     module (for classify_key in JSON projections) or vice versa,
+     and neither direction feels natural.
+   Any drift here will be caught by the [test_snapshot_kind_filter]
+   coverage below + existing Dashboard_cascade tests. *)
+let classify_key url =
+  if String.length url > 4 && String.sub url 0 4 = "cli:" then "cli"
+  else
+    let len = String.length url in
+    let needle = ":11434" in
+    let nlen = String.length needle in
+    let rec scan i =
+      if i + nlen > len then false
+      else if String.sub url i nlen = needle then true
+      else scan (i + 1)
+    in
+    if scan 0 then "ollama" else "other"
+
+(* ── Ring buffer configuration ─────────────────────────────── *)
+
+let min_capacity = 16
+let max_capacity = 65_536
+let default_capacity = 1024
+
+let resolve_capacity () =
+  let from_env =
+    match Sys.getenv_opt "MASC_CAPACITY_HISTORY_SIZE" with
+    | None | Some "" -> default_capacity
+    | Some s ->
+      (match int_of_string_opt (String.trim s) with
+       | Some n -> n
+       | None -> default_capacity)
+  in
+  max min_capacity (min max_capacity from_env)
+
+(* ── Ring buffer state ──────────────────────────────────────
+
+   Invariants (established once, maintained by [record]):
+   - [Array.length !buf = !cap]
+   - [0 <= !head < !cap]
+   - [0 <= !count <= !cap]
+   - The [!count] most recent entries live at indices
+     [ (head - count + cap) mod cap ], …, [ (head - 1 + cap) mod cap ]
+     — that is, [head] points to the *next write slot*, so the most
+     recent entry is at [(head - 1 + cap) mod cap].
+   - Slots [0 .. cap-1] always hold [Some _] once written; we
+     overwrite in place, never resize. *)
+
+let cap_ref = ref 0
+let buf : event option array ref = ref [||]
+let head = ref 0
+let count = ref 0
+let mu = Mutex.create ()
+
+(* Lazy init: resolve capacity + allocate buffer on first use.  We
+   do this outside [record] so [clear] / [capacity] can be called
+   from tests before any event is recorded.  Guarded by [mu]. *)
+let ensure_initialised_locked () =
+  if !cap_ref = 0 then begin
+    let cap = resolve_capacity () in
+    cap_ref := cap;
+    buf := Array.make cap None;
+    head := 0;
+    count := 0
+  end
+
+let record ev =
+  Mutex.protect mu (fun () ->
+      ensure_initialised_locked ();
+      let cap = !cap_ref in
+      (!buf).(!head) <- Some ev;
+      head := (!head + 1) mod cap;
+      if !count < cap then incr count)
+
+let clear () =
+  Mutex.protect mu (fun () ->
+      ensure_initialised_locked ();
+      let cap = !cap_ref in
+      for i = 0 to cap - 1 do (!buf).(i) <- None done;
+      head := 0;
+      count := 0)
+
+let size () = Mutex.protect mu (fun () -> !count)
+
+let capacity () =
+  Mutex.protect mu (fun () ->
+      ensure_initialised_locked ();
+      !cap_ref)
+
+(* ── Snapshot ───────────────────────────────────────────────
+
+   Hot path: copy the live events out under the mutex, then run the
+   (pure) filter / limit pipeline with the lock released.  This keeps
+   the critical section O(count) allocation-light (one intermediate
+   list) and avoids holding the mutex across [List.filter] work. *)
+
+let collect_newest_first_locked () =
+  (* Walk from (head-1) backwards for [count] steps.  Invariant:
+     [0 <= head < cap] and [0 <= i < count <= cap], therefore
+     [head - 1 - i + cap] is in [0, 2*cap - 2], so a single
+     [mod cap] normalises it.  We pattern-match on [Some _] so
+     slots that somehow contain [None] (shouldn't happen once
+     we've written [count] entries, but keeps [collect] safe
+     during the first few acquires) are silently skipped. *)
+  let cap = !cap_ref in
+  let n = !count in
+  let acc = ref [] in
+  (* Walk oldest→newest (i goes from n-1 down to 0) and prepend,
+     so the final list is newest-first without a [List.rev]. *)
+  for i = n - 1 downto 0 do
+    let idx = (!head - 1 - i + cap) mod cap in
+    match (!buf).(idx) with
+    | Some e -> acc := e :: !acc
+    | None -> ()
+  done;
+  !acc
+
+let snapshot ?(limit = 100) ?kind ?since_ts () =
+  let events =
+    Mutex.protect mu (fun () ->
+        ensure_initialised_locked ();
+        collect_newest_first_locked ())
+  in
+  let kind_match =
+    match kind with
+    | None -> fun _ -> true
+    | Some k when k = "cli" || k = "ollama" || k = "other" ->
+      fun e -> classify_key e.key = k
+    | Some _ ->
+      (* Unknown kind filter: return nothing rather than silently
+         matching everything.  Spec-required behaviour per the .mli. *)
+      fun _ -> false
+  in
+  let ts_match =
+    match since_ts with
+    | None -> fun _ -> true
+    | Some t -> fun e -> e.ts >= t
+  in
+  let filtered =
+    List.filter (fun e -> kind_match e && ts_match e) events
+  in
+  let n = max 0 limit in
+  if n = 0 then []
+  else
+    (* [List.filteri] keeps the first [n] elements without building
+       an intermediate list length. *)
+    let rec take k = function
+      | [] -> []
+      | _ when k = 0 -> []
+      | x :: rest -> x :: take (k - 1) rest
+    in
+    take n filtered

--- a/lib/cascade/cascade_client_capacity_history.mli
+++ b/lib/cascade/cascade_client_capacity_history.mli
@@ -1,0 +1,89 @@
+(** Bounded ring buffer of [Cascade_client_capacity] acquire / release /
+    rejected-when-full events, for dashboard observability.
+
+    Phase A ({!Cascade_client_capacity}) introduced the process-local
+    semaphore.  Phase D ({!Dashboard_cascade.client_capacity_json})
+    exposed the *current* snapshot.  Operators still could not answer
+    "how often was the ollama slot full in the last hour?" — this
+    module fills that gap by recording every transition and surfacing
+    recent events via {!snapshot}.
+
+    Contracts:
+    - Size is fixed at init, read from [MASC_CAPACITY_HISTORY_SIZE]
+      (default 1024, clamped to [[16, 65536]]).  Changing the env after
+      first use has no effect; the ring is lazily initialised once.
+    - Drop-oldest on overflow: recording into a full ring overwrites
+      the oldest slot in place, no allocation on steady state.
+    - [record] and [snapshot] are thread-safe via a plain stdlib
+      [Mutex] (matches {!Cascade_client_capacity}'s locking style; see
+      memory/feedback_ocaml5-mutex-selection for the same-domain Eio.Mutex
+      deadlock risk that pushed us to stdlib Mutex here).
+    - [snapshot] returns events newest-first so the dashboard can
+      render without a reverse pass.
+
+    @since 0.9.9 *)
+
+(** Event kind surfaced to the dashboard.  [Acquired] / [Released] are
+    self-explanatory; [Rejected_full] captures the "slot full, caller
+    moved on to the next candidate" case that operators use as the
+    saturation signal. *)
+type event_kind = Acquired | Released | Rejected_full
+
+(** One transition in the capacity semaphore.
+
+    [ts] is a Unix timestamp (seconds).
+    [key] is the registry key (URL or CLI sentinel) as accepted by
+    {!Cascade_client_capacity.register}.
+    [active_after] is the value of the atomic counter *after* the
+    event took effect:
+    - [Acquired]: counter after the successful CAS ([old + 1]).
+    - [Released]: counter after [Atomic.fetch_and_add ... (-1)]
+      completes ([old - 1]).
+    - [Rejected_full]: counter at the moment of rejection (unchanged
+      — the caller did not touch the counter). *)
+type event = {
+  ts : float;
+  key : string;
+  kind : event_kind;
+  active_after : int;
+}
+
+val record : event -> unit
+(** Append [event] to the ring.  Drops the oldest entry if the ring
+    is full.  Safe to call from multiple fibers/domains; serialised
+    via a stdlib [Mutex]. *)
+
+val snapshot : ?limit:int -> ?kind:string -> ?since_ts:float -> unit -> event list
+(** Newest-first snapshot of recorded events.
+
+    @param limit  maximum number of events returned (default 100,
+           clamped to the ring's current count).
+    @param kind   filter by dashboard classification — one of
+           ["cli"], ["ollama"], ["other"].  Unknown values return
+           [[]]; omitting the argument returns every kind.  The
+           classifier matches {!Dashboard_cascade}'s [classify_capacity_key]
+           (copy-paste rather than a shared helper — both are ~12
+           lines and we did not want the new module to depend on
+           [Dashboard_cascade]).
+    @param since_ts  keep only events with [ts >= since_ts].
+           Omitting returns every timestamp.
+
+    The three filters compose: if all three are given, the result
+    is the intersection.  Events are returned newest-first after
+    filtering; the [limit] is applied last. *)
+
+val clear : unit -> unit
+(** Test helper: drop every recorded event and reset the write head. *)
+
+val size : unit -> int
+(** Test helper: current number of recorded events (≤ ring capacity). *)
+
+val capacity : unit -> int
+(** Test helper: the ring's fixed capacity as resolved from
+    [MASC_CAPACITY_HISTORY_SIZE].  Useful for tests that want to
+    overflow the ring without hardcoding the default. *)
+
+val classify_key : string -> string
+(** Same classification as {!Dashboard_cascade.classify_capacity_key}.
+    Exposed for tests that want to assert ["cli"]/["ollama"]/["other"]
+    labels without pulling in the dashboard module. *)

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -170,3 +170,29 @@ let client_capacity_json () =
     ("updated_at", `String (now_iso ()));
     ("entries", `List (List.map client_capacity_entry_to_json sorted));
   ]
+
+(* ── Client capacity history projection ─────────────────── *)
+
+let event_kind_to_string = function
+  | Cascade_client_capacity_history.Acquired -> "acquired"
+  | Released -> "released"
+  | Rejected_full -> "rejected_full"
+
+let history_event_to_json (ev : Cascade_client_capacity_history.event)
+  : Yojson.Safe.t =
+  `Assoc [
+    ("ts", `Float ev.ts);
+    ("key", `String ev.key);
+    ("kind", `String (event_kind_to_string ev.kind));
+    ("active_after", `Int ev.active_after);
+  ]
+
+let client_capacity_history_json ?limit ?kind ?since_ts () =
+  let events =
+    Cascade_client_capacity_history.snapshot ?limit ?kind ?since_ts ()
+  in
+  `Assoc [
+    ("updated_at", `String (now_iso ()));
+    ("total_events", `Int (List.length events));
+    ("events", `List (List.map history_event_to_json events));
+  ]

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -94,3 +94,48 @@ val health_json : unit -> Yojson.Safe.t
 
     @since 0.9.9 *)
 val client_capacity_json : unit -> Yojson.Safe.t
+
+(** JSON snapshot of the {!Cascade_client_capacity_history} ring
+    buffer — per-event transitions (acquire / release / slot-full
+    rejection) recorded by the client-capacity semaphore.
+
+    Complements {!client_capacity_json}: that one answers "how full
+    is the slot right now?", this one answers "how often did
+    saturation happen in the last hour?" without a separate metrics
+    pipeline.
+
+    Shape:
+    {[
+      {
+        "updated_at": "2026-04-16T22:31:00Z",
+        "total_events": 3,
+        "events": [
+          { "ts": 1713280000.5,
+            "key": "cli:claude_code",
+            "kind": "acquired",
+            "active_after": 1 },
+          { "ts": 1713280001.2,
+            "key": "cli:claude_code",
+            "kind": "rejected_full",
+            "active_after": 1 },
+          ...
+        ]
+      }
+    ]}
+
+    Events are returned newest-first (the ring buffer is walked from
+    write-head backwards).  [kind] strings are ["acquired"],
+    ["released"], ["rejected_full"].
+
+    @param limit   max events returned (default 100).
+    @param kind    dashboard classification filter: one of
+           ["cli"], ["ollama"], ["other"].  Unknown filters return
+           an empty event list; omitting returns every kind.
+    @param since_ts  keep only events with [ts >= since_ts].
+
+    @since 0.9.9 *)
+val client_capacity_history_json :
+  ?limit:int ->
+  ?kind:string ->
+  ?since_ts:float ->
+  unit -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -29,6 +29,7 @@
    cache_eio
    cascade_inference
    cascade_client_capacity
+   cascade_client_capacity_history
    cascade_config
    cascade_config_loader
    cascade_fsm

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -1,6 +1,25 @@
 open Server_auth
+open Server_utils
 
 module Http = Http_server_eio
+
+(* Bounds mirror the .mli contract: dashboard asks for ≤ 1024 events
+   per poll; anything smaller than 1 would produce an empty response. *)
+let clamp_history_limit n = max 1 (min 1024 n)
+
+(* Only forward well-known kind strings.  Unknown values are dropped
+   (passed through as [None]) so the projection returns every kind
+   rather than the "unknown kind → []" behaviour reserved for explicit
+   unknown filters.  Rationale: a typo in a dashboard query param
+   should not silently zero out the response. *)
+let parse_history_kind = function
+  | Some ("cli" | "ollama" | "other") as ok -> ok
+  | _ -> None
+
+let parse_history_since request =
+  match query_param request "since_ts" with
+  | None -> None
+  | Some s -> float_of_string_opt (String.trim s)
 
 let add_routes router =
   router
@@ -22,3 +41,18 @@ let add_routes router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/cascade/client_capacity/history"
+       (fun request reqd ->
+         with_public_read (fun _state req reqd ->
+           let limit =
+             clamp_history_limit (int_query_param req "limit" ~default:100)
+           in
+           let kind = parse_history_kind (query_param req "kind") in
+           let since_ts = parse_history_since req in
+           let json =
+             Dashboard_cascade.client_capacity_history_json
+               ~limit ?kind ?since_ts ()
+           in
+           Http.Response.json ~compress:true ~request:req
+             (Yojson.Safe.to_string json) reqd
+         ) request reqd)

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -12,6 +12,7 @@ open Alcotest
 module S = Masc_mcp.Cascade_strategy
 module H = Masc_mcp.Cascade_health_tracker
 module C = Masc_mcp.Cascade_client_capacity
+module CH = Masc_mcp.Cascade_client_capacity_history
 module T = Masc_mcp.Cascade_throttle
 module Cascade_state = Masc_mcp.Cascade_state
 
@@ -526,6 +527,112 @@ let test_cascade_state_round_robin_negative_bound () =
   let v2 = Cascade_state.rotate_round_robin ~cascade:"x" ~bound:(-3) in
   check int "negative bound → returns 0" 0 v2
 
+(* ── Client capacity history (Phase D follow-up) ─────────── *)
+
+let test_history_record_snapshot_roundtrip () =
+  CH.clear ();
+  CH.record { ts = 1000.0; key = "cli:claude_code";
+              kind = Acquired; active_after = 1 };
+  CH.record { ts = 1001.0; key = "cli:claude_code";
+              kind = Released; active_after = 0 };
+  CH.record { ts = 1002.0; key = "http://127.0.0.1:11434";
+              kind = Rejected_full; active_after = 1 };
+  let events = CH.snapshot () in
+  check int "3 events recorded" 3 (List.length events);
+  (* Newest-first ordering: ts=1002 must come first. *)
+  (match events with
+   | e0 :: e1 :: e2 :: [] ->
+     check (float 0.0) "newest ts=1002" 1002.0 e0.ts;
+     check (float 0.0) "middle ts=1001" 1001.0 e1.ts;
+     check (float 0.0) "oldest ts=1000" 1000.0 e2.ts;
+     check bool "newest kind = Rejected_full"
+       true (e0.kind = CH.Rejected_full);
+     check bool "middle kind = Released"
+       true (e1.kind = CH.Released);
+     check bool "oldest kind = Acquired"
+       true (e2.kind = CH.Acquired)
+   | _ -> fail "expected exactly 3 events")
+
+let test_history_ring_buffer_drops_oldest () =
+  CH.clear ();
+  let cap = CH.capacity () in
+  (* Record cap+5 events; oldest 5 must be dropped. *)
+  for i = 0 to cap + 4 do
+    CH.record { ts = float_of_int i;
+                key = "cli:x";
+                kind = Acquired;
+                active_after = i }
+  done;
+  check int "count clamped to capacity" cap (CH.size ());
+  let events = CH.snapshot ~limit:(cap + 10) () in
+  check int "snapshot count = capacity" cap (List.length events);
+  (* Newest must be ts=cap+4.  Oldest retained must be ts=5
+     (i.e. the first 5 inserts at ts=0..4 were overwritten). *)
+  (match events with
+   | [] -> fail "expected at least one event"
+   | newest :: _ ->
+     check (float 0.0) "newest ts = cap+4"
+       (float_of_int (cap + 4)) newest.ts);
+  let oldest = List.nth events (cap - 1) in
+  check (float 0.0) "oldest retained ts = 5 (earlier 5 dropped)"
+    5.0 oldest.ts
+
+let test_history_snapshot_kind_filter () =
+  CH.clear ();
+  CH.record { ts = 1.0; key = "cli:claude_code";
+              kind = Acquired; active_after = 1 };
+  CH.record { ts = 2.0; key = "http://127.0.0.1:11434";
+              kind = Acquired; active_after = 1 };
+  CH.record { ts = 3.0; key = "http://other.example/api";
+              kind = Rejected_full; active_after = 0 };
+  CH.record { ts = 4.0; key = "cli:gemini_cli";
+              kind = Released; active_after = 0 };
+  (* cli filter → 2 events, both cli:* keys *)
+  let cli_events = CH.snapshot ~kind:"cli" () in
+  check int "cli filter → 2 events" 2 (List.length cli_events);
+  List.iter
+    (fun e ->
+       check string "cli filter matches classify_key"
+         "cli" (CH.classify_key e.CH.key))
+    cli_events;
+  (* ollama filter → 1 event for :11434 *)
+  let ollama_events = CH.snapshot ~kind:"ollama" () in
+  check int "ollama filter → 1 event" 1 (List.length ollama_events);
+  (* other filter → 1 event for http://other *)
+  let other_events = CH.snapshot ~kind:"other" () in
+  check int "other filter → 1 event" 1 (List.length other_events);
+  (* Unknown kind → empty list *)
+  let unknown = CH.snapshot ~kind:"no_such_kind" () in
+  check int "unknown kind → empty" 0 (List.length unknown)
+
+let test_history_try_acquire_records_events () =
+  CH.clear ();
+  C.unregister_all ();
+  C.register ~url:"cli:claude_code" ~max_concurrent:1;
+  (* First acquire → Acquired recorded *)
+  (match C.try_acquire "cli:claude_code" with
+   | None -> fail "first acquire should succeed"
+   | Some release ->
+     (* Second acquire → Rejected_full recorded *)
+     check bool "second acquire hits cap"
+       true (C.try_acquire "cli:claude_code" = None);
+     release ();
+     let events = CH.snapshot () in
+     (* Expected newest-first: Released, Rejected_full, Acquired. *)
+     check int "3 events recorded" 3 (List.length events);
+     (match events with
+      | r :: f :: a :: [] ->
+        check bool "newest = Released" true (r.kind = CH.Released);
+        check int "released active_after = 0" 0 r.active_after;
+        check bool "middle = Rejected_full"
+          true (f.kind = CH.Rejected_full);
+        check int "rejected active_after = 1" 1 f.active_after;
+        check bool "oldest = Acquired" true (a.kind = CH.Acquired);
+        check int "acquired active_after = 1" 1 a.active_after;
+        check string "all keys = cli:claude_code"
+          "cli:claude_code" a.key
+      | _ -> fail "expected 3 events"))
+
 let () =
   run "cascade_strategy" [
     "failover", [
@@ -619,5 +726,15 @@ let () =
         test_cascade_state_sticky_zero_ttl_no_record;
       test_case "round_robin bound<=0 returns 0" `Quick
         test_cascade_state_round_robin_negative_bound;
+    ];
+    "client_capacity_history", [
+      test_case "record + snapshot roundtrip newest-first" `Quick
+        test_history_record_snapshot_roundtrip;
+      test_case "ring buffer drops oldest when full" `Quick
+        test_history_ring_buffer_drops_oldest;
+      test_case "snapshot kind filter" `Quick
+        test_history_snapshot_kind_filter;
+      test_case "try_acquire records events on registered URL" `Quick
+        test_history_try_acquire_records_events;
     ];
   ]


### PR DESCRIPTION
## Summary

Long-term item LT-2 from the post-Phase-D backlog. Adds an in-memory ring buffer recording \`Acquired\` / \`Released\` / \`Rejected_full\` events for every slot transition in \`Cascade_client_capacity\`, plus a dashboard panel to visualise recent events.

Answers the operator question Phase D left unanswered: "how often was ollama/CLI slot full in the last hour?"

## Backend (~257 LOC)

- \`lib/cascade/cascade_client_capacity_history.ml\` (168) + \`.mli\` (89) — ring buffer, default 1024, env \`MASC_CAPACITY_HISTORY_SIZE\` clamped to \`[16, 65536]\`. Stdlib \`Mutex.protect\`, lazy ring init.
- \`lib/cascade/cascade_client_capacity.ml\` — \`try_acquire\` records \`Acquired\` on success, \`Rejected_full\` at cap. Release closure records \`Released\`. No record on unregistered URL.
- \`lib/dashboard_cascade.ml\` + \`.mli\` — \`client_capacity_history_json ?limit ?kind ?since_ts\` projection.
- \`lib/server/server_routes_http_routes_cascade.ml\` — new \`GET /api/v1/cascade/client_capacity/history\` (limit clamped \`[1, 1024]\`, unknown \`kind\` silently dropped to avoid dashboard typos zeroing the response).
- \`lib/dune\` — register new module.

## Frontend

- \`dashboard/src/api/dashboard.ts\` — types + \`fetchCascadeClientCapacityHistory\`.
- \`dashboard/src/components/cascade-config-panel.ts\` — relative-time helper + \`ClientCapacityHistoryTable\` + second \"Client Capacity — 최근 이벤트\" card. Auto-refreshes with the existing 30s poll.

## Tests

\`test_cascade_strategy.ml\` 38 → 42 cases (+4 under \`client_capacity_history\` subgroup):
- \`record + snapshot roundtrip\` — newest-first ordering.
- \`ring buffer drops oldest when full\` — size+1 insert → oldest gone.
- \`snapshot kind filter\` — cli/ollama/other separation.
- \`try_acquire records events on registered URL\` — integration: Acquired → Rejected_full → Released sequence.

## Design notes (from agent report)

- Classifier: copy-pasted \`classify_capacity_key\` into the new module rather than extracting shared helper. Both copies are ~12 lines; drift caught by kind-filter test. Extraction would force an artificial cross-module dep.
- Event type: no \`ppx_deriving_yojson\` — manual JSON projection in \`Dashboard_cascade.history_event_to_json\` keeps the new module dependency-free and gives explicit control over \`kind\` string encoding.
- Snapshot unknown-kind returns \`[]\` (spec-required for pure API); HTTP route silently drops unknown \`kind\` query params to avoid a dashboard typo blanking the response.
- Stdlib \`Mutex.protect\` (not Eio) — matches \`cascade_client_capacity.ml\` style; lazy ring init so \`clear\`/\`capacity\` test helpers work before first \`record\`.

## Backward compat

All-additive. Ring buffer drop-oldest is silent. No behavior change when nothing calls the new route.

## Test plan

- [x] \`dune build --root .\` clean
- [x] \`dune exec --root . test/test_cascade_strategy.exe\` — 42/42 pass
- [x] \`pnpm typecheck\` clean
- [ ] CI: Build / Lint / Dashboard / Health / TLA+ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)