### PR TITLE
feat(dashboard): keeper pause/resume buttons (#7602)

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -165,7 +165,7 @@ describe('keeper lifecycle', () => {
     })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
     expect(url).toBe('/api/v1/keepers/keeper-test/clear')
     expect(JSON.parse(String(init.body))).toEqual({
       reason: 'reset stale continuity',
@@ -234,7 +234,7 @@ describe('keeper lifecycle', () => {
     const result = await deleteKeeperHistorySnapshots('keeper-test', ['oas-snapshot-1.json'])
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit]
     expect(url).toBe('/api/v1/keepers/keeper-test/checkpoints')
     expect(JSON.parse(String(init.body))).toEqual({
       action: 'delete_history',
@@ -256,7 +256,7 @@ describe('keeper lifecycle', () => {
 
     expect(result.ok).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    const [url, init] = fetchMock.mock.calls[0]
+    const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe('/api/v1/keepers/janitor/directive')
     expect(init.method).toBe('POST')
     expect(JSON.parse(init.body)).toEqual({ action: 'pause' })
@@ -274,7 +274,7 @@ describe('keeper lifecycle', () => {
     const result = await resumeKeeper('janitor')
 
     expect(result.ok).toBe(true)
-    const [url, init] = fetchMock.mock.calls[0]
+    const [url, init] = fetchMock.mock.calls[0]!
     expect(url).toBe('/api/v1/keepers/janitor/directive')
     expect(JSON.parse(init.body)).toEqual({ action: 'resume' })
   })

--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -19,6 +19,8 @@ import {
   clearKeeper,
   deleteKeeperHistorySnapshots,
   fetchKeeperCheckpoints,
+  pauseKeeper,
+  resumeKeeper,
   sendKeeperMessageDetailed,
   shutdownKeeper,
   streamKeeperMessage,
@@ -239,5 +241,56 @@ describe('keeper lifecycle', () => {
       snapshot_ids: ['oas-snapshot-1.json'],
     })
     expect(result.deleted_snapshot_ids).toEqual(['oas-snapshot-1.json'])
+  })
+
+  it('sends POST with action=pause via directive endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, action: 'pause', name: 'janitor' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await pauseKeeper('janitor')
+
+    expect(result.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/keepers/janitor/directive')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ action: 'pause' })
+  })
+
+  it('sends POST with action=resume via directive endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, action: 'resume', name: 'janitor' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resumeKeeper('janitor')
+
+    expect(result.ok).toBe(true)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/keepers/janitor/directive')
+    expect(JSON.parse(init.body)).toEqual({ action: 'resume' })
+  })
+
+  it('returns error when pause directive fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, error: 'Keeper not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await pauseKeeper('nonexistent')
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('Keeper not found')
   })
 })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -297,6 +297,37 @@ async function safeKeeperLifecycle(
   }
 }
 
+async function safeKeeperPostWithBody(
+  url: string,
+  body: Record<string, unknown>,
+  fallbackError: string,
+): Promise<KeeperLifecycleResponse> {
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: jsonHeaders(),
+      body: JSON.stringify(body),
+    })
+    const payload = await safeJsonResponse<KeeperLifecycleResponse>(resp, fallbackError)
+    if (resp.ok) return payload
+
+    const error =
+      isRecord(payload) &&
+      typeof payload.error === 'string' &&
+      payload.error.trim() !== ''
+        ? payload.error
+        : `${fallbackError} (HTTP ${resp.status})`
+
+    if (isRecord(payload)) {
+      return { ...payload, ok: false, error }
+    }
+
+    return { ok: false, error }
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : fallbackError }
+  }
+}
+
 export function bootKeeper(name: string): Promise<KeeperLifecycleResponse> {
   return safeKeeperLifecycle(
     `/api/v1/keepers/${encodeURIComponent(name)}/boot`,
@@ -411,6 +442,21 @@ export async function deleteKeeperHistorySnapshots(
   return resp.json() as Promise<KeeperCheckpointDeleteResponse>
 }
 
+export function pauseKeeper(name: string): Promise<KeeperLifecycleResponse> {
+  return safeKeeperPostWithBody(
+    `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
+    { action: 'pause' },
+    `Failed to pause ${name}`,
+  )
+}
+
+export function resumeKeeper(name: string): Promise<KeeperLifecycleResponse> {
+  return safeKeeperPostWithBody(
+    `/api/v1/keepers/${encodeURIComponent(name)}/directive`,
+    { action: 'resume' },
+    `Failed to resume ${name}`,
+  )
+}
 // --- Keeper tool policy editing ---
 
 export interface KeeperToolPolicyInput {

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -15,6 +15,8 @@ import {
   clearKeeper,
   deleteKeeperHistorySnapshots,
   fetchKeeperCheckpoints,
+  pauseKeeper,
+  resumeKeeper,
   shutdownKeeper,
   type KeeperCheckpointInventory,
   type KeeperCheckpointSummary,
@@ -133,6 +135,25 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const needsAttention = keeperNeedsDiagnosticAttention(keeper)
   if (!needsAttention && !keeper.last_autonomous_action_at) return null
 
+  const directiveLoading = signal(false)
+  const handleDirective = async (action: 'pause' | 'resume') => {
+    directiveLoading.value = true
+    try {
+      const fn = action === 'pause' ? pauseKeeper : resumeKeeper
+      const res = await fn(keeper.name)
+      if (res.ok) {
+        showToast(action === 'pause' ? `${keeper.name} 일시정지됨` : `${keeper.name} 재개됨`, 'success')
+        await refreshAfterRuntimeAction()
+      } else {
+        showToast(res.error ?? '실패', 'error')
+      }
+    } catch {
+      showToast('실패', 'error')
+    } finally {
+      directiveLoading.value = false
+    }
+  }
+
   const toneClass = keeper.paused || socialFallbackActive || runtimeBlocker || blocker || hbStale
     ? 'border-[rgba(251,191,36,0.24)] bg-[rgba(251,191,36,0.08)]'
     : 'border-[var(--card-border)] bg-[var(--white-3)]'
@@ -152,8 +173,17 @@ function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
     <div class="px-6 pt-4">
       <div class="rounded-xl border ${toneClass} px-4 py-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-[12px] text-[var(--text-body)]">
         ${keeper.paused
-          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-[rgba(251,191,36,0.14)] text-[var(--warn)]">일시정지</span>`
-          : null}
+          ? html`<span class="inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold bg-[rgba(251,191,36,0.14)] text-[var(--warn)]">일시정지</span>
+            <button
+              class="inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
+              disabled=${directiveLoading.value}
+              onClick=${() => handleDirective('resume')}
+            >재개</button>`
+          : html`<button
+              class="inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium bg-[var(--white-6)] hover:bg-[var(--white-8)] text-[var(--text-strong)] transition-colors disabled:opacity-50"
+              disabled=${directiveLoading.value}
+              onClick=${() => handleDirective('pause')}
+            >일시정지</button>`}
         ${keeper.paused && keeper.keepalive_running && continueGate
           ? html`<span>하트비트는 유지되지만 승인 전까지 자동 재개하지 않습니다.</span>`
           : keeper.paused && keeper.keepalive_running

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -716,7 +716,7 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     Delegates to [Keeper_keepalive.process_directive] which updates
     registry state, dispatches a state-machine event, and optionally
     wakes up the keeper fiber. *)
-let handle_keeper_directive_post state agent_name req reqd body_str =
+let handle_keeper_directive_post _state _agent_name req reqd body_str =
   let req_path = Http.Request.path req in
   let name = extract_keeper_name_for_post req_path keeper_suffix_directive in
   if String.length name = 0 then

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -16,6 +16,7 @@ let keeper_suffix_shutdown = "/shutdown"
 let keeper_suffix_reset = "/reset"
 let keeper_suffix_clear = "/clear"
 let keeper_suffix_checkpoints = "/checkpoints"
+let keeper_suffix_directive = "/directive"
 
 let dedupe_tool_names names =
   Json_util.dedupe_keep_order
@@ -243,6 +244,7 @@ type keeper_post_route_kind =
   | Keeper_post_reset
   | Keeper_post_clear
   | Keeper_post_checkpoints
+  | Keeper_post_directive
   | Keeper_post_unknown
 
 let classify_keeper_post_route req_path =
@@ -262,6 +264,7 @@ let classify_keeper_post_route req_path =
   else if ends_with keeper_suffix_reset then Keeper_post_reset
   else if ends_with keeper_suffix_clear then Keeper_post_clear
   else if ends_with keeper_suffix_checkpoints then Keeper_post_checkpoints
+  else if ends_with keeper_suffix_directive then Keeper_post_directive
   else Keeper_post_unknown
 
 let keeper_path_ends_with req_path suffix =
@@ -706,6 +709,44 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
     | None ->
         Http.Response.json ~status:`Internal_server_error ~request:req
           {|{"ok":false,"error":"dispatch returned None"}|}
+          reqd
+
+(** POST /api/v1/keepers/:name/directive — pause / resume / wakeup.
+
+    Delegates to [Keeper_keepalive.process_directive] which updates
+    registry state, dispatches a state-machine event, and optionally
+    wakes up the keeper fiber. *)
+let handle_keeper_directive_post state agent_name req reqd body_str =
+  let req_path = Http.Request.path req in
+  let name = extract_keeper_name_for_post req_path keeper_suffix_directive in
+  if String.length name = 0 then
+    Http.Response.json ~status:`Bad_request
+      {|{"error":"keeper name is required"}|} reqd
+  else
+    let action =
+      try
+        let json = Yojson.Safe.from_string body_str in
+        match Safe_ops.json_string_opt "action" json with
+        | Some a when a = "pause" || a = "resume" || a = "wakeup" -> Ok a
+        | Some a ->
+            Error
+              (Printf.sprintf
+                 "invalid action %S: expected pause, resume, or wakeup" a)
+        | None -> Error "missing \"action\" field"
+      with Yojson.Json_error e ->
+        Error (Printf.sprintf "invalid json: %s" (String.escaped e))
+    in
+    match action with
+    | Error msg ->
+        Http.Response.json ~status:`Bad_request
+          (Printf.sprintf {|{"ok":false,"error":%s}|}
+             (Yojson.Safe.to_string (`String msg)))
+          reqd
+    | Ok action_str ->
+        Keeper_keepalive.process_directive ~agent_name:name action_str;
+        Http.Response.json ~compress:true ~request:req
+          (Printf.sprintf {|{"ok":true,"action":"%s","name":"%s"}|}
+             (String.escaped action_str) (String.escaped name))
           reqd
 
 (** Keeper GET sub-routes handler: /config, /chat/history, /trajectory.

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -573,6 +573,13 @@ let rec add_routes ~sw ~clock router =
                  Keeper_api.handle_keeper_checkpoints_post state req reqd body_str
                )
              ) request reqd
+       | Keeper_api.Keeper_post_directive ->
+           with_token_permission_auth ~permission:Types.CanAdmin
+             (fun state agent_name req reqd ->
+               Http.Request.read_body_async reqd (fun body_str ->
+                 Keeper_api.handle_keeper_directive_post state agent_name req reqd body_str
+               )
+             ) request reqd
        | Keeper_api.Keeper_post_unknown ->
            Http.Response.json ~status:`Not_found
              {|{"error":"not found"}|} reqd)

--- a/test/test_dashboard_keeper_routes.ml
+++ b/test/test_dashboard_keeper_routes.ml
@@ -387,6 +387,7 @@ let check_route path expected =
        | Keeper_api.Keeper_post_reset -> "reset"
        | Keeper_api.Keeper_post_clear -> "clear"
        | Keeper_api.Keeper_post_checkpoints -> "checkpoints"
+       | Keeper_api.Keeper_post_directive -> "directive"
        | Keeper_api.Keeper_post_unknown -> "unknown")
       path
 ;;


### PR DESCRIPTION
## Summary
- HTTP POST `/api/v1/keepers/:name/directive` 엔드포인트 추가 (action: pause/resume/wakeup)
- 대시보드 `KeeperRuntimeAlertStrip`에 일시정지/재개 버튼 추가
- `pauseKeeper`/`resumeKeeper` 프론트엔드 API 함수 + 테스트 3건

## Changes
| 파일 | 변경 |
|------|------|
| `lib/server/server_dashboard_http_keeper_api.ml` | directive suffix, variant, classify, handler |
| `lib/server/server_routes_http_routes_dashboard.ml` | Keeper_post_directive 라우트 연결 |
| `dashboard/src/api/keeper.ts` | `safeKeeperPostWithBody`, `pauseKeeper`, `resumeKeeper` |
| `dashboard/src/components/keeper-detail.ts` | paused 배지 옆 Pause/Resume 버튼 |
| `dashboard/src/api/keeper.test.ts` | pause/resume/directive-failure 테스트 3건 |

## Test plan
- [x] `dune build` 통과
- [x] `npx vitest run src/api/keeper.test.ts` — 11 tests passed
- [ ] CI: dune build + dashboard test
- [ ] 수동: keeper paused 상태에서 "재개" 버튼 클릭 → 상태 전환 확인
- [ ] 수동: keeper active 상태에서 "일시정지" 버튼 클릭 → paused 전환 확인

Closes #7602

🤖 Generated with [Claude Code](https://claude.com/claude-code)