### PR TITLE
fix(server): restore /api/v1/operator HTTP routes lost in cp-purge

### DIFF
--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -287,6 +287,63 @@ let rec add_routes ~sw ~clock router =
                   (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
          )
        ) request reqd)
+
+  (* Operator surface restored after cp-purge (#7349): handlers existed in
+     server_dashboard_http_core/.ml but their Router.get/post registrations
+     were deleted together with the Command Plane. Dashboard SSE hydrates
+     the same caches, so this path only services HTTP fallbacks (first load
+     before SSE attaches + explicit tab-refresh). *)
+  |> Http.Router.get "/api/v1/operator" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json = operator_snapshot_http_json ~state ~sw ~clock req in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/operator/digest" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         match operator_digest_http_json ~state ~sw ~clock req with
+         | Ok json ->
+             Http.Response.json ~compress:true ~request:req
+               (Yojson.Safe.to_string json) reqd
+         | Error message ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (operator_error_json message))
+       ) request reqd)
+  |> Http.Router.post "/api/v1/operator/action" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_operator_action" (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             match operator_action_http_json ~state ~sw ~clock req ~args with
+             | Ok json ->
+                 respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+             | Error message ->
+                 respond_json_with_cors ~status:`Bad_request request reqd
+                   (Yojson.Safe.to_string (operator_error_json message))
+           with Yojson.Json_error msg ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string
+                  (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+         )
+       ) request reqd)
+  |> Http.Router.post "/api/v1/operator/confirm" (fun request reqd ->
+       with_tool_auth ~tool_name:"masc_operator_confirm" (fun state req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             match operator_confirm_http_json ~state ~sw ~clock req ~args with
+             | Ok json ->
+                 respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+             | Error message ->
+                 respond_json_with_cors ~status:`Bad_request request reqd
+                   (Yojson.Safe.to_string (operator_error_json message))
+           with Yojson.Json_error msg ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string
+                  (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+         )
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/dashboard/planning" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_planning_http_json ~config:state.Mcp_server.room_config in


### PR DESCRIPTION
## Summary

cp-purge (#7349) co-removed the four `/api/v1/operator*` HTTP route registrations when it deleted the Command Plane surface. The handlers kept existing in `server_dashboard_http_core.ml` / `server_dashboard_http.ml`, but nothing referenced them anymore, so every direct HTTP hit returned **404**.

SSE hydration masked the regression for the common case (dashboard auto-attaches and receives `operator_snapshot` / `operator_digest` events), but the 404 surfaces on:

- explicit tab refresh (`tab-refresh.ts` → `refreshOperatorSnapshot({ force: true })`)
- first load before SSE attaches
- post-action force refresh (`dispatchOperatorAction` → `refreshOperatorRoomDigest`)

## Change

Restore the four route bindings inside `server_routes_http_routes_dashboard.ml`, adjacent to the existing governance approvals endpoint. Auth and error shapes match the pre-purge registrations:

- `GET  /api/v1/operator`          → `with_public_read` + `operator_snapshot_http_json`
- `GET  /api/v1/operator/digest`   → `with_public_read` + `operator_digest_http_json` (Result → 400 on Error)
- `POST /api/v1/operator/action`   → `with_tool_auth ~tool_name:"masc_operator_action"`
- `POST /api/v1/operator/confirm`  → `with_tool_auth ~tool_name:"masc_operator_confirm"`

No handler signatures change. `transport.ml` already declared the same method/path mapping for MCP tool-bindings — this only restores the HTTP router registration.

## Test plan

- [x] `dune build --root .` passes
- [x] `dune build --root . @test/runtest` full suite passes
- [ ] Manual smoke: `curl -s http://127.0.0.1:<port>/api/v1/operator | jq .generated_at` should return a timestamp (no longer 404)
- [ ] Manual smoke: Ops tab refresh in dashboard — verify no console `404 Not Found` for `/api/v1/operator` or `/api/v1/operator/digest?target_type=namespace`

## Root cause note

Transport coverage tests (`test_transport_coverage.ml`) and auth coverage tests (`test_auth_coverage.ml`) still asserted the routes — these pass because they test `Transport.Rest.parse_request`, not whether the HTTP router actually dispatches. A follow-up could add a route-existence integration test so a similar purge-induced removal can't silently land again.