### PR TITLE
chore(dashboard): drop dead Room Strategy panel + state

### DIFF
--- a/dashboard/src/components/flow-control/flow-control-panel.test.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.test.ts
@@ -7,14 +7,11 @@ void vi
 const fetchPauseStatus = vi.fn().mockResolvedValue(undefined)
 const pauseRoom = vi.fn().mockResolvedValue(undefined)
 const resumeRoom = vi.fn().mockResolvedValue(undefined)
-const fetchRoomStrategy = vi.fn().mockResolvedValue(undefined)
 const runGarbageCollection = vi.fn().mockResolvedValue(undefined)
 const cleanupZombies = vi.fn().mockResolvedValue(undefined)
 
 const flowState = { value: 'running' as 'running' | 'paused' | 'initializing' | 'unknown' }
 const flowLoading = { value: false }
-const roomStrategy = { value: null as Record<string, unknown> | null }
-const roomStrategyLoading = { value: false }
 const maintenanceResult = { value: null as string | null }
 const maintenanceLoading = { value: false }
 
@@ -28,15 +25,12 @@ async function loadPanel() {
   vi.doMock('./flow-control-state', () => ({
     cleanupZombies,
     fetchPauseStatus,
-    fetchRoomStrategy,
     flowLoading,
     flowState,
     maintenanceLoading,
     maintenanceResult,
     pauseRoom,
     resumeRoom,
-    roomStrategy,
-    roomStrategyLoading,
     runGarbageCollection,
   }))
   return import('./flow-control-panel')
@@ -50,8 +44,6 @@ describe('FlowControlPanel', () => {
     document.body.appendChild(container)
     flowState.value = 'running'
     flowLoading.value = false
-    roomStrategy.value = null
-    roomStrategyLoading.value = false
     maintenanceResult.value = null
     maintenanceLoading.value = false
   })

--- a/dashboard/src/components/flow-control/flow-control-panel.ts
+++ b/dashboard/src/components/flow-control/flow-control-panel.ts
@@ -6,7 +6,6 @@ import { ActionButton } from '../common/button'
 import { CountBadge } from '../common/badge'
 import {
   flowState, flowLoading, fetchPauseStatus, pauseRoom, resumeRoom,
-  roomStrategy, roomStrategyLoading, fetchRoomStrategy,
   maintenanceResult, maintenanceLoading, runGarbageCollection, cleanupZombies,
 } from './flow-control-state'
 
@@ -43,28 +42,6 @@ export function FlowControlPanel() {
         <${ActionButton} variant="primary" size="md" disabled=${loading || isRunning || isInitializing} onClick=${() => void resumeRoom()}>
           ${loading && isPaused ? '...' : '재개'}<//>
       </div>
-    <//>
-
-    ${'' /* ── Room Strategy ── */}
-    <${SurfaceCard} variant="compact" class="mb-4">
-      <details>
-        <summary class="cursor-pointer text-[13px] text-[var(--text-strong)] font-medium select-none py-1">룸 전략</summary>
-        <div class="mt-3">
-          ${roomStrategy.value ? html`
-            <div class="flex flex-col gap-1.5 mb-3">
-              ${Object.entries(roomStrategy.value).map(([key, val]) => html`
-                <div key=${key} class="flex items-center justify-between py-1.5 px-3 rounded-lg border border-card-border/50 bg-card/20 text-[12px]">
-                  <span class="font-medium text-text-muted">${key}</span>
-                  <span class="font-semibold text-text-strong font-mono">${String(val)}</span>
-                </div>
-              `)}
-            </div>
-          ` : html`<p class="text-[11px] text-text-dim mb-3">조회되지 않았습니다</p>`}
-          <${ActionButton} variant="ghost" size="sm" disabled=${roomStrategyLoading.value}
-            onClick=${() => void fetchRoomStrategy()}>
-            ${roomStrategyLoading.value ? '...' : '조회'}<//>
-        </div>
-      </details>
     <//>
 
     ${'' /* ── Maintenance ── */}

--- a/dashboard/src/components/flow-control/flow-control-state.ts
+++ b/dashboard/src/components/flow-control/flow-control-state.ts
@@ -1,21 +1,12 @@
-import { signal, computed, effect } from '@preact/signals'
+import { signal, effect } from '@preact/signals'
 import { callMcpTool } from '../../api/mcp'
 import { namespaceTruth, namespaceTruthInitializing } from '../../namespace-truth-store'
 import { serverStatus } from '../../store'
 import { showToast } from '../common/toast'
-import { createAsyncResource, getData } from '../../lib/async-state'
 
 export type FlowState = 'unknown' | 'initializing' | 'running' | 'paused'
 export const flowState = signal<FlowState>('unknown')
 export const flowLoading = signal(false)
-
-// Room strategy resource
-const roomStrategyResource = createAsyncResource<Record<string, unknown>>()
-const roomStrategyMutating = signal(false)
-export const roomStrategy = computed(() => getData(roomStrategyResource.state.value) ?? null)
-export const roomStrategyLoading = computed(() =>
-  roomStrategyMutating.value || roomStrategyResource.state.value.status === 'loading',
-)
 
 // Maintenance state
 export const maintenanceResult = signal<string | null>(null)
@@ -72,31 +63,6 @@ export async function resumeRoom(): Promise<void> {
   try { await callMcpTool('masc_resume', {}); flowState.value = 'running'; showToast('프로젝트 재개', 'success') }
   catch (err) { showToast(`재개 실패: ${err instanceof Error ? err.message : String(err)}`, 'error') }
   finally { flowLoading.value = false }
-}
-
-
-// ── Room Strategy ───────────────────────────────
-
-export async function fetchRoomStrategy(): Promise<void> {
-  await roomStrategyResource.load(async () => {
-    const raw = await callMcpTool('masc_room_strategy_get', {})
-    return JSON.parse(raw) as Record<string, unknown>
-  }).catch(() => {
-    showToast('프로젝트 전략 조회 실패', 'error')
-  })
-}
-
-export async function setRoomStrategy(updates: Record<string, unknown>): Promise<void> {
-  roomStrategyMutating.value = true
-  try {
-    await callMcpTool('masc_room_strategy_set', updates)
-    showToast('프로젝트 전략 업데이트 완료', 'success')
-    await fetchRoomStrategy()
-  } catch (err) {
-    showToast(`프로젝트 전략 저장 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
-  } finally {
-    roomStrategyMutating.value = false
-  }
 }
 
 // ── Maintenance ─────────────────────────────────


### PR DESCRIPTION
## Summary

The "룸 전략" `<details>` section in `FlowControlPanel` targets two MCP tools:

- `masc_room_strategy_get`
- `masc_room_strategy_set`

Neither tool is registered anywhere on the OCaml backend (verified by exhaustive `rg` across `lib/` and all `*.ml`/`*.mli`/`*.json`/`*.toml`). Result:

- "조회" button → failing MCP call → red toast "프로젝트 전략 조회 실패"
- Panel body never renders anything except "조회되지 않았습니다"
- `setRoomStrategy` is exported but never imported — pure dead writer next to a dead reader

No handler, no mutation UI, no users. Ghost surface created at some point and never wired up.

## Change

Delete the surface and its dangling state:

- `flow-control-panel.ts` — remove the Room Strategy `<details>` block and its import row
- `flow-control-state.ts` — remove `roomStrategyResource`, `roomStrategyMutating`, `roomStrategy`, `roomStrategyLoading`, `fetchRoomStrategy`, `setRoomStrategy`, plus the now-unused `createAsyncResource`/`getData` imports and the `computed` import
- `flow-control-panel.test.ts` — drop the matching mocks / fixtures

Keep untouched:
- 흐름 제어 (pause/resume) — backed by `masc_pause_status` / `masc_pause` / `masc_resume`
- 유지보수 (GC / 좀비 정리) — backed by `masc_gc` / `masc_cleanup_zombies`

## Diff

```
3 files changed, 1 insertion(+), 66 deletions(-)
```

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test src/components/flow-control` (2 files / 6 tests pass)
- [ ] Manual: Ops 탭에서 흐름 제어 + 유지보수만 렌더되고 "룸 전략" 섹션 사라짐 확인