### PR TITLE
feat(dashboard): TLA+ spec index endpoint + panel

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1982,3 +1982,29 @@ export function fetchVerificationRequests(
     : '/api/v1/verification/requests'
   return get<VerificationRequestsResponse>(path, { signal: opts?.signal })
 }
+
+export type TlaSpecCategory = 'boundary' | 'bug-models' | 'other'
+
+export interface TlaSpecEntry {
+  name: string
+  path: string
+  category: TlaSpecCategory
+  has_clean_cfg: boolean
+  has_buggy_cfg: boolean
+  mtime_iso: string
+}
+
+export interface TlaSpecsResponse {
+  updated_at: string
+  specs_dir: string | null
+  count: number
+  entries: TlaSpecEntry[]
+}
+
+export function fetchTlaSpecs(
+  opts?: AbortableRequestOptions,
+): Promise<TlaSpecsResponse> {
+  return get<TlaSpecsResponse>('/api/v1/verification/specs', {
+    signal: opts?.signal,
+  })
+}

--- a/dashboard/src/components/runtime-panel.test.ts
+++ b/dashboard/src/components/runtime-panel.test.ts
@@ -21,6 +21,12 @@ async function loadRuntimePanel() {
   vi.doMock('./prometheus-metrics', () => ({
     PrometheusMetrics: () => html`<div data-testid="prometheus">PrometheusMetrics</div>`,
   }))
+  vi.doMock('./cascade-config-panel', () => ({
+    CascadeConfigPanel: () => html`<div data-testid="cascade-config">CascadeConfigPanel</div>`,
+  }))
+  vi.doMock('./verification-specs-panel', () => ({
+    VerificationSpecsPanel: () => html`<div data-testid="verification-specs">VerificationSpecsPanel</div>`,
+  }))
   vi.doMock('./common/filter-chips', () => ({
     FilterChips: ({ chips, value }: { chips: { key: string; label: string }[]; value: string }) => html`
       <div data-testid="filter-chips" data-value=${value}>
@@ -52,6 +58,8 @@ describe('RuntimePanel', () => {
     vi.doUnmock('./oas-health-chip')
     vi.doUnmock('./runtime-monitor')
     vi.doUnmock('./prometheus-metrics')
+    vi.doUnmock('./cascade-config-panel')
+    vi.doUnmock('./verification-specs-panel')
     vi.doUnmock('./common/filter-chips')
   })
 
@@ -88,18 +96,19 @@ describe('RuntimePanel', () => {
     expect(container.textContent).toContain('PrometheusMetrics')
   })
 
-  it('renders FilterChips with 4 options', async () => {
+  it('renders FilterChips with 5 options', async () => {
     route.value.params = {}
     const { RuntimePanel } = await loadRuntimePanel()
     render(html`<${RuntimePanel} />`, container)
     await flushUi()
 
     const chips = container.querySelectorAll('[data-testid="chip"]')
-    expect(chips.length).toBe(4)
+    expect(chips.length).toBe(5)
     expect(chips[0]?.textContent).toBe('전체')
     expect(chips[1]?.textContent).toBe('Cascade')
     expect(chips[2]?.textContent).toBe('프로바이더')
     expect(chips[3]?.textContent).toBe('메트릭')
+    expect(chips[4]?.textContent).toBe('형식검증')
   })
 
   it('falls back to default for unknown view param', async () => {

--- a/dashboard/src/components/runtime-panel.ts
+++ b/dashboard/src/components/runtime-panel.ts
@@ -16,10 +16,11 @@ import { OasHealthChip } from './oas-health-chip'
 import { RuntimeMonitor } from './runtime-monitor'
 import { PrometheusMetrics } from './prometheus-metrics'
 import { CascadeConfigPanel } from './cascade-config-panel'
+import { VerificationSpecsPanel } from './verification-specs-panel'
 
-export type RuntimeView = 'default' | 'cascade' | 'providers' | 'prometheus'
+export type RuntimeView = 'default' | 'cascade' | 'providers' | 'prometheus' | 'verification'
 
-const RUNTIME_VIEWS: RuntimeView[] = ['default', 'cascade', 'providers', 'prometheus']
+const RUNTIME_VIEWS: RuntimeView[] = ['default', 'cascade', 'providers', 'prometheus', 'verification']
 
 function isRuntimeView(v: string | undefined): v is RuntimeView {
   return !!v && (RUNTIME_VIEWS as string[]).includes(v)
@@ -35,6 +36,7 @@ const VIEW_CHIPS: Array<{ key: RuntimeView; label: string }> = [
   { key: 'cascade', label: 'Cascade' },
   { key: 'providers', label: '프로바이더' },
   { key: 'prometheus', label: '메트릭' },
+  { key: 'verification', label: '형식검증' },
 ]
 
 function updateViewParam(view: RuntimeView): void {
@@ -65,11 +67,14 @@ export function RuntimePanel() {
           `
         : view === 'prometheus'
           ? html`<${PrometheusMetrics} />`
+        : view === 'verification'
+          ? html`<${VerificationSpecsPanel} />`
         : html`
             <${CascadeConfigPanel} />
             <${OasHealthChip} />
             <${RuntimeMonitor} />
             <${PrometheusMetrics} />
+            <${VerificationSpecsPanel} />
           `}
       </div>
     </div>

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -1,0 +1,154 @@
+// VerificationSpecsPanel — enumerates TLA+ specs with cfg coverage + mtime.
+//
+// Consumes:
+//   GET /api/v1/verification/specs — dashboard_tla_specs.specs_json
+//
+// Surfaces formal verification coverage on the dashboard: which specs exist,
+// which have clean + buggy configs (bug-model pattern), and when they were
+// last modified.  Mirrors the managed-async-resource pattern used by
+// cascade-config-panel.ts.
+
+import { html } from 'htm/preact'
+import { useEffect, useRef } from 'preact/hooks'
+import {
+  fetchTlaSpecs,
+  type TlaSpecEntry,
+  type TlaSpecsResponse,
+} from '../api/dashboard'
+import { Card } from './common/card'
+import { EmptyState } from './common/empty-state'
+import { ErrorState, LoadingState } from './common/feedback-state'
+import { StatusChip } from './common/status-chip'
+import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+
+async function loadSpecs(resource: ManagedAsyncResource<TlaSpecsResponse>) {
+  await resource.load(async (signal) => fetchTlaSpecs({ signal }))
+}
+
+function categoryLabel(cat: TlaSpecEntry['category']): string {
+  switch (cat) {
+    case 'boundary':
+      return '경계'
+    case 'bug-models':
+      return '버그 모델'
+    default:
+      return '기타'
+  }
+}
+
+function categoryTone(cat: TlaSpecEntry['category']): 'ok' | 'warn' | 'neutral' {
+  switch (cat) {
+    case 'boundary':
+      return 'ok'
+    case 'bug-models':
+      return 'warn'
+    default:
+      return 'neutral'
+  }
+}
+
+function cfgCoverage(entry: TlaSpecEntry): { label: string; tone: 'ok' | 'warn' | 'err' } {
+  if (entry.has_clean_cfg && entry.has_buggy_cfg) {
+    return { label: 'clean + buggy', tone: 'ok' }
+  }
+  if (entry.has_clean_cfg) {
+    return { label: 'clean only', tone: 'warn' }
+  }
+  if (entry.has_buggy_cfg) {
+    return { label: 'buggy only', tone: 'warn' }
+  }
+  return { label: 'no cfg', tone: 'err' }
+}
+
+function shortMtime(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+function SpecsTable({ entries }: { entries: TlaSpecEntry[] }) {
+  return html`
+    <div class="overflow-x-auto">
+      <table class="w-full text-xs tabular-nums">
+        <thead class="text-left text-slate-400">
+          <tr>
+            <th class="py-1 pr-4">Spec</th>
+            <th class="py-1 pr-4">Category</th>
+            <th class="py-1 pr-4">Cfg</th>
+            <th class="py-1 pr-4">Path</th>
+            <th class="py-1">Modified</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${entries.map((entry: TlaSpecEntry) => {
+            const cov = cfgCoverage(entry)
+            return html`
+              <tr class="border-t border-slate-800">
+                <td class="py-1 pr-4 font-medium text-slate-100">${entry.name}</td>
+                <td class="py-1 pr-4">
+                  <${StatusChip} tone=${categoryTone(entry.category)} label=${categoryLabel(entry.category)} />
+                </td>
+                <td class="py-1 pr-4">
+                  <${StatusChip} tone=${cov.tone} label=${cov.label} />
+                </td>
+                <td class="py-1 pr-4 font-mono text-slate-400">${entry.path}</td>
+                <td class="py-1 text-slate-400">${shortMtime(entry.mtime_iso)}</td>
+              </tr>
+            `
+          })}
+        </tbody>
+      </table>
+    </div>
+  `
+}
+
+export function VerificationSpecsPanel() {
+  const resourceRef = useRef<ManagedAsyncResource<TlaSpecsResponse> | null>(null)
+  if (resourceRef.current === null) {
+    resourceRef.current = createManagedAsyncResource<TlaSpecsResponse>()
+  }
+  const resource = resourceRef.current
+
+  useEffect(() => {
+    void loadSpecs(resource)
+    const id = setInterval(() => void loadSpecs(resource), 60_000)
+    return () => { clearInterval(id); resource.cancel() }
+  }, [resource])
+
+  const current = resource.state.value
+  const data = current.data
+  const boundaryCount = data?.entries.filter((e: TlaSpecEntry) => e.category === 'boundary').length ?? 0
+  const bugModelCount = data?.entries.filter((e: TlaSpecEntry) => e.category === 'bug-models').length ?? 0
+  const dirLabel = data?.specs_dir ?? '(not found)'
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex items-center gap-3 flex-wrap">
+        <button
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-3 py-1 text-xs text-[var(--text-strong)] hover:bg-[var(--bg-panel-hover)]"
+          onClick=${() => void loadSpecs(resource)}
+        >
+          새로고침
+        </button>
+        ${current.loading ? html`<span class="text-xs text-[var(--text-muted)]">로딩 중...</span>` : null}
+        ${data?.updated_at
+          ? html`<span class="text-xs text-[var(--text-muted)]">specs · ${data.updated_at}</span>`
+          : null}
+      </div>
+
+      ${current.error ? html`<${ErrorState} message=${current.error} />` : null}
+
+      ${current.loading && !data
+        ? html`<${LoadingState}>TLA+ 스펙 목록 불러오는 중...<//>`
+        : null}
+
+      <${Card} title="Formal Specs">
+        <div class="mb-2 text-xs text-slate-400">
+          ${data?.count ?? 0} specs · boundary ${boundaryCount} · bug-models ${bugModelCount}
+          · <span class="font-mono">${dirLabel}</span>
+        </div>
+        ${!data || data.entries.length === 0
+          ? html`<${EmptyState} message="TLA+ 스펙을 찾지 못했습니다 (MASC_SPECS_DIR 확인)" />`
+          : html`<${SpecsTable} entries=${data.entries} />`}
+      <//>
+    </div>
+  `
+}

--- a/lib/dashboard_tla_specs.ml
+++ b/lib/dashboard_tla_specs.ml
@@ -1,0 +1,100 @@
+type spec_entry = {
+  name : string;
+  path : string;
+  category : string;
+  has_clean_cfg : bool;
+  has_buggy_cfg : bool;
+  mtime : float;
+}
+
+let specs_dir () =
+  match Sys.getenv_opt "MASC_SPECS_DIR" with
+  | Some p when p <> "" -> p
+  | _ -> "specs"
+
+let category_of_subdir = function
+  | "boundary" -> "boundary"
+  | "bug-models" -> "bug-models"
+  | _ -> "other"
+
+let is_tla_file name = Filename.check_suffix name ".tla"
+
+let safe_stat_mtime path =
+  try (Unix.stat path).st_mtime
+  with Unix.Unix_error _ -> 0.0
+
+let readdir_safe dir =
+  try Sys.readdir dir |> Array.to_list
+  with Sys_error _ -> []
+
+let is_directory_safe p =
+  try Sys.is_directory p
+  with Sys_error _ -> false
+
+let file_exists_safe p =
+  try Sys.file_exists p
+  with Sys_error _ -> false
+
+let scan_subdir ~root sub =
+  let subpath = Filename.concat root sub in
+  if not (is_directory_safe subpath) then []
+  else
+    readdir_safe subpath
+    |> List.filter is_tla_file
+    |> List.map (fun f ->
+      let name = Filename.chop_suffix f ".tla" in
+      let file_path = Filename.concat subpath f in
+      let clean_cfg = Filename.concat subpath (name ^ ".cfg") in
+      let buggy_cfg = Filename.concat subpath (name ^ "-buggy.cfg") in
+      {
+        name;
+        path = Filename.concat sub f;
+        category = category_of_subdir sub;
+        has_clean_cfg = file_exists_safe clean_cfg;
+        has_buggy_cfg = file_exists_safe buggy_cfg;
+        mtime = safe_stat_mtime file_path;
+      })
+
+let list_specs () =
+  let root = specs_dir () in
+  if not (is_directory_safe root) then []
+  else
+    readdir_safe root
+    |> List.concat_map (fun sub -> scan_subdir ~root sub)
+    |> List.sort (fun a b ->
+      match String.compare a.category b.category with
+      | 0 -> String.compare a.name b.name
+      | c -> c)
+
+let iso_of_unix_time t =
+  let open Unix in
+  let tm = gmtime t in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+    tm.tm_hour tm.tm_min tm.tm_sec
+
+let entry_to_json e : Yojson.Safe.t =
+  `Assoc [
+    "name", `String e.name;
+    "path", `String e.path;
+    "category", `String e.category;
+    "has_clean_cfg", `Bool e.has_clean_cfg;
+    "has_buggy_cfg", `Bool e.has_buggy_cfg;
+    "mtime_iso", `String (iso_of_unix_time e.mtime);
+  ]
+
+let specs_dir_json root =
+  if not (file_exists_safe root) then `Null
+  else
+    try `String (Unix.realpath root)
+    with Unix.Unix_error _ -> `String root
+
+let specs_json () : Yojson.Safe.t =
+  let root = specs_dir () in
+  let entries = list_specs () in
+  `Assoc [
+    "updated_at", `String (iso_of_unix_time (Unix.gettimeofday ()));
+    "specs_dir", specs_dir_json root;
+    "count", `Int (List.length entries);
+    "entries", `List (List.map entry_to_json entries);
+  ]

--- a/lib/dashboard_tla_specs.mli
+++ b/lib/dashboard_tla_specs.mli
@@ -1,0 +1,53 @@
+(** Dashboard projection for TLA+ specs.
+
+    Enumerates [*.tla] files under {!specs_dir} (env [MASC_SPECS_DIR], default
+    ["specs"]) along with their companion [.cfg] files.  Surfaces formal
+    verification coverage in the dashboard without re-running TLC.
+
+    Contracts:
+    - Read-only scan: {!list_specs} walks at most two directory levels under
+      [specs_dir] and performs one [stat] per file.
+    - Returns [[]] when [specs_dir] is missing (runtime deployment without the
+      repo checked out); {!specs_json} then reports [count = 0] and
+      [specs_dir = null].
+    - Entries sorted by [(category, name)] for stable dashboard polling.
+
+    @since 0.9.6 *)
+
+type spec_entry = {
+  name : string;          (** File stem without extension (e.g. ["CascadeStrategy"]). *)
+  path : string;          (** Path relative to [specs_dir] (e.g. ["boundary/CascadeStrategy.tla"]). *)
+  category : string;      (** ["boundary"] | ["bug-models"] | ["other"]. *)
+  has_clean_cfg : bool;   (** [<name>.cfg] is present next to the [.tla]. *)
+  has_buggy_cfg : bool;   (** [<name>-buggy.cfg] is present next to the [.tla]. *)
+  mtime : float;          (** Unix timestamp of the [.tla] file. *)
+}
+
+val specs_dir : unit -> string
+(** Resolved specs directory.  Reads [MASC_SPECS_DIR], falls back to ["specs"]
+    (relative to the current working directory). *)
+
+val list_specs : unit -> spec_entry list
+(** Enumerate all [.tla] files under {!specs_dir}.  Returns [[]] when the
+    directory does not exist.  Sort order: [(category, name)] ascending. *)
+
+val specs_json : unit -> Yojson.Safe.t
+(** JSON bundle suitable for [/api/v1/verification/specs].
+
+    Shape:
+    {[
+      {
+        "updated_at": "2026-04-17T00:00:00Z",
+        "specs_dir": "/abs/path/to/specs" | null,
+        "count": 12,
+        "entries": [
+          { "name": "CascadeStrategy",
+            "path": "boundary/CascadeStrategy.tla",
+            "category": "boundary",
+            "has_clean_cfg": true,
+            "has_buggy_cfg": true,
+            "mtime_iso": "2026-04-15T12:34:56Z" }, ...
+        ]
+      }
+    ]}
+*)

--- a/lib/dune
+++ b/lib/dune
@@ -89,6 +89,7 @@
    dashboard_provider_runs
    dashboard_cascade
    dashboard_verification
+   dashboard_tla_specs
    proactive_refresh
    server_dashboard_http_runtime_support
    server_dashboard_http_runtime_info

--- a/lib/server/server_routes_http_routes_verification.ml
+++ b/lib/server/server_routes_http_routes_verification.ml
@@ -1,8 +1,13 @@
-(** HTTP route for the verification-request dashboard projection.
+(** HTTP routes for the verification domain.
 
     Kept as a dedicated file to avoid bloating
     [server_routes_http_routes_cascade.ml] — the verification domain is
-    independent of cascade. *)
+    independent of cascade.
+
+    - [GET /api/v1/verification/requests] — operator view of pending /
+      approved / rejected verification requests (see {!Dashboard_verification}).
+    - [GET /api/v1/verification/specs] — TLA+ spec index with clean / buggy
+      cfg coverage (see {!Dashboard_tla_specs}). *)
 
 open Server_auth
 
@@ -26,6 +31,12 @@ let add_routes router =
          let json =
            Dashboard_verification.requests_json ?task_id ?limit ()
          in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/verification/specs" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Dashboard_tla_specs.specs_json () in
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)

--- a/test/dune
+++ b/test/dune
@@ -584,6 +584,11 @@
  (libraries masc_test_deps))
 
 (test
+ (name test_dashboard_tla_specs)
+ (modules test_dashboard_tla_specs)
+ (libraries masc_test_deps))
+
+(test
  (name test_cascade_ollama_probe)
  (modules test_cascade_ollama_probe)
  (libraries masc_test_deps))

--- a/test/test_dashboard_tla_specs.ml
+++ b/test/test_dashboard_tla_specs.ml
@@ -1,0 +1,132 @@
+(* Tests for Dashboard_tla_specs: specs directory enumeration + JSON shape. *)
+
+open Alcotest
+
+let make_fixture_dir () =
+  let root = Filename.temp_file "masc-specs-" "" in
+  Unix.unlink root;
+  Unix.mkdir root 0o755;
+  let boundary = Filename.concat root "boundary" in
+  let bugs = Filename.concat root "bug-models" in
+  Unix.mkdir boundary 0o755;
+  Unix.mkdir bugs 0o755;
+  let write path contents =
+    let oc = open_out path in
+    output_string oc contents;
+    close_out oc
+  in
+  write (Filename.concat boundary "CascadeStrategy.tla") "MODULE CascadeStrategy\n";
+  write (Filename.concat boundary "CascadeStrategy.cfg") "SPECIFICATION Spec\n";
+  write (Filename.concat boundary "CascadeStrategy-buggy.cfg") "SPECIFICATION SpecBuggy\n";
+  write (Filename.concat boundary "ZOnlyTla.tla") "MODULE ZOnlyTla\n";
+  write (Filename.concat bugs "Overflow.tla") "MODULE Overflow\n";
+  write (Filename.concat bugs "Overflow.cfg") "SPECIFICATION Spec\n";
+  root
+
+let cleanup root =
+  let rec rm_r p =
+    if Sys.is_directory p then begin
+      Sys.readdir p |> Array.iter (fun c -> rm_r (Filename.concat p c));
+      Unix.rmdir p
+    end else Unix.unlink p
+  in
+  try rm_r root with _ -> ()
+
+let with_specs_dir root f =
+  let saved = Sys.getenv_opt "MASC_SPECS_DIR" in
+  Unix.putenv "MASC_SPECS_DIR" root;
+  Fun.protect
+    ~finally:(fun () ->
+      match saved with
+      | Some v -> Unix.putenv "MASC_SPECS_DIR" v
+      | None -> Unix.putenv "MASC_SPECS_DIR" "")
+    f
+
+let test_list_specs_basic () =
+  let root = make_fixture_dir () in
+  Fun.protect ~finally:(fun () -> cleanup root) (fun () ->
+    with_specs_dir root (fun () ->
+      let entries = Masc_mcp.Dashboard_tla_specs.list_specs () in
+      check int "three specs" 3 (List.length entries);
+      let names = List.map (fun (e : Masc_mcp.Dashboard_tla_specs.spec_entry) -> e.name) entries in
+      check (list string) "sorted by (category, name)"
+        [ "CascadeStrategy"; "ZOnlyTla"; "Overflow" ]
+        names))
+
+let test_cfg_presence_flags () =
+  let root = make_fixture_dir () in
+  Fun.protect ~finally:(fun () -> cleanup root) (fun () ->
+    with_specs_dir root (fun () ->
+      let entries = Masc_mcp.Dashboard_tla_specs.list_specs () in
+      let cascade =
+        List.find (fun (e : Masc_mcp.Dashboard_tla_specs.spec_entry) -> e.name = "CascadeStrategy") entries
+      in
+      check bool "clean cfg present" true cascade.has_clean_cfg;
+      check bool "buggy cfg present" true cascade.has_buggy_cfg;
+      let only_tla =
+        List.find (fun (e : Masc_mcp.Dashboard_tla_specs.spec_entry) -> e.name = "ZOnlyTla") entries
+      in
+      check bool "clean cfg absent" false only_tla.has_clean_cfg;
+      check bool "buggy cfg absent" false only_tla.has_buggy_cfg))
+
+let test_category_mapping () =
+  let root = make_fixture_dir () in
+  Fun.protect ~finally:(fun () -> cleanup root) (fun () ->
+    with_specs_dir root (fun () ->
+      let entries = Masc_mcp.Dashboard_tla_specs.list_specs () in
+      let overflow =
+        List.find (fun (e : Masc_mcp.Dashboard_tla_specs.spec_entry) -> e.name = "Overflow") entries
+      in
+      check string "bug-models category" "bug-models" overflow.category;
+      let cascade =
+        List.find (fun (e : Masc_mcp.Dashboard_tla_specs.spec_entry) -> e.name = "CascadeStrategy") entries
+      in
+      check string "boundary category" "boundary" cascade.category))
+
+let test_missing_dir () =
+  with_specs_dir "/does/not/exist/masc-specs-xyz" (fun () ->
+    let entries = Masc_mcp.Dashboard_tla_specs.list_specs () in
+    check int "empty list when dir missing" 0 (List.length entries);
+    let json = Masc_mcp.Dashboard_tla_specs.specs_json () in
+    match json with
+    | `Assoc fields ->
+      (match List.assoc "specs_dir" fields with
+       | `Null -> ()
+       | _ -> fail "specs_dir should be null when dir missing");
+      (match List.assoc "count" fields with
+       | `Int 0 -> ()
+       | _ -> fail "count should be 0 when dir missing")
+    | _ -> fail "expected assoc")
+
+let test_json_shape () =
+  let root = make_fixture_dir () in
+  Fun.protect ~finally:(fun () -> cleanup root) (fun () ->
+    with_specs_dir root (fun () ->
+      let json = Masc_mcp.Dashboard_tla_specs.specs_json () in
+      match json with
+      | `Assoc fields ->
+        check bool "has updated_at" true (List.mem_assoc "updated_at" fields);
+        check bool "has specs_dir" true (List.mem_assoc "specs_dir" fields);
+        check bool "has count" true (List.mem_assoc "count" fields);
+        check bool "has entries" true (List.mem_assoc "entries" fields);
+        (match List.assoc "count" fields with
+         | `Int 3 -> ()
+         | _ -> fail "count should be 3");
+        (match List.assoc "entries" fields with
+         | `List xs -> check int "entries length" 3 (List.length xs)
+         | _ -> fail "entries should be list")
+      | _ -> fail "expected assoc"))
+
+let () =
+  run "dashboard_tla_specs"
+    [
+      "scan", [
+        test_case "basic list" `Quick test_list_specs_basic;
+        test_case "cfg presence flags" `Quick test_cfg_presence_flags;
+        test_case "category mapping" `Quick test_category_mapping;
+        test_case "missing directory" `Quick test_missing_dir;
+      ];
+      "json", [
+        test_case "shape" `Quick test_json_shape;
+      ];
+    ]


### PR DESCRIPTION
## Summary
Surface formal verification coverage in the dashboard — enumerates `specs/**/*.tla` with clean/buggy `.cfg` presence and `mtime`, and renders a "Formal Specs" card under runtime → 형식검증 view.

## Why
Bug-model spec pattern (clean + buggy cfg pair) is now a first-class asset after LT-1 (#7632) added Phase B stateful spec. Without a runtime index, operators had no way to see which specs exist or whether each carries a buggy cfg.

## Shape
- `lib/dashboard_tla_specs.ml/.mli` (~100 LOC) — read-only scan under `MASC_SPECS_DIR` (default `specs`); returns `{updated_at, specs_dir, count, entries}`. Sort by `(category, name)` stable.
- `lib/server/server_routes_http_routes_verification.ml` — new `/api/v1/verification/specs` route.
- `dashboard/src/components/verification-specs-panel.ts` — managed async resource + Card table, 60s refresh.
- `test/test_dashboard_tla_specs.ml` — 5 alcotest cases (list, cfg flags, category mapping, missing-dir fallback, JSON shape). All green.

## Graceful degradation
- `specs_dir` returns `null` and `count = 0` when directory missing (deployment without `specs/` checked out). Panel shows EmptyState.
- `Unix.realpath` wrapped in try/with — no crash if path resolution fails.

## Test plan
- [x] `dune build` clean
- [x] `dune exec test/test_dashboard_tla_specs.exe` → 5/5
- [x] `pnpm typecheck` clean
- [x] Rebased on LT-1/LT-2/docs (#7629/7630/7632) on main
- [ ] Reviewer: confirm scan performance acceptable for repos with many specs

## Known conflict
Creates same file path `lib/server/server_routes_http_routes_verification.ml` as #7635 (LT-3 verification requests). **If #7635 merges first**, this PR will conflict on that file; resolution is to combine both routes (`/api/v1/verification/specs` + `/api/v1/verification/requests`) in a single `add_routes`.

Related: #7531 (CDAL gate), #7610/#7617 (prior cascade roadmap), #7630/#7632 (Phase D + Phase B).