### PR TITLE
refactor(dashboard): drop placeholder-heavy review queue UI from Ops

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -32,13 +32,10 @@ async function loadOps() {
     operatorRoomDigest: operatorStore.operatorRoomDigest,
     operatorSnapshot: operatorStore.operatorSnapshot,
     hydratedWorkflowId: helpers.hydratedWorkflowId,
-    reviewDecisionReason: helpers.reviewDecisionReason,
-    selectedReviewItemId: helpers.selectedReviewItemId,
-    selectedReviewTab: helpers.selectedReviewTab,
   }
 }
 
-describe('Ops intervene surface', () => {
+describe('Ops surface', () => {
   let container: HTMLDivElement
 
   beforeEach(() => {
@@ -55,7 +52,7 @@ describe('Ops intervene surface', () => {
     vi.doUnmock('../flow-control/flow-control-panel')
   })
 
-  it('renders a combined activity timeline for healthy mode without legacy KPI cards', async () => {
+  it('renders a combined activity timeline merging recent reviews and interventions', async () => {
     const {
       Ops,
       route,
@@ -65,16 +62,10 @@ describe('Ops intervene surface', () => {
       operatorRoomDigest,
       operatorSnapshot,
       hydratedWorkflowId,
-      reviewDecisionReason,
-      selectedReviewItemId,
-      selectedReviewTab,
     } = await loadOps()
 
     route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
     hydratedWorkflowId.value = null
-    reviewDecisionReason.value = ''
-    selectedReviewItemId.value = ''
-    selectedReviewTab.value = 'active'
     operatorError.value = null
     operatorDigestError.value = null
     operatorSnapshot.value = {
@@ -135,14 +126,15 @@ describe('Ops intervene surface', () => {
     await flushUi()
 
     expect(container.textContent).toContain('최근 운영 활동')
-    expect(container.textContent).toContain('즉시 검토 0')
-    expect(container.textContent).toContain('보류 1')
-    expect(container.textContent).toContain('최근 처리 2')
-    expect(container.textContent).toContain('프로젝트 진행 중')
     expect(container.textContent).toContain('QuickIntervene')
     expect(container.textContent).toContain('FlowControlPanel')
-    expect(container.textContent).not.toContain('Active Queue')
-    expect(container.textContent).not.toContain('Healthy Console')
+
+    // Placeholder-heavy review queue surface is gone — Live Judge + Keeper HITL
+    // handling lives on the Governance page.
+    expect(container.textContent).not.toContain('review_item')
+    expect(container.textContent).not.toContain('큐에서 항목을 고르세요')
+    expect(container.textContent).not.toContain('현재 이 항목에 연결된 operator guidance가 없습니다')
+    expect(container.textContent).not.toContain('실행 작업대')
 
     const items = Array.from(container.querySelectorAll('[data-testid="ops-activity-item"]'))
     expect(items).toHaveLength(3)
@@ -151,7 +143,7 @@ describe('Ops intervene surface', () => {
     expect(items[2]?.textContent).toContain('키퍼 메시지는 잠시 보류')
   }, 120000)
 
-  it('keeps the review workbench while replacing legacy KPI cards with compact badges', async () => {
+  it('renders the same single surface when active review items are present (no 3-column unhealthy branch)', async () => {
     const {
       Ops,
       route,
@@ -161,16 +153,10 @@ describe('Ops intervene surface', () => {
       operatorRoomDigest,
       operatorSnapshot,
       hydratedWorkflowId,
-      reviewDecisionReason,
-      selectedReviewItemId,
-      selectedReviewTab,
     } = await loadOps()
 
     route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
     hydratedWorkflowId.value = null
-    reviewDecisionReason.value = ''
-    selectedReviewItemId.value = ''
-    selectedReviewTab.value = 'active'
     operatorError.value = null
     operatorDigestError.value = null
     operatorSnapshot.value = {
@@ -201,19 +187,9 @@ describe('Ops intervene surface', () => {
       review_summary: {
         active_count: 1,
         deferred_count: 0,
-        recent_count: 1,
+        recent_count: 0,
       },
-      recent_reviews: [
-        {
-          item_id: 'review-1',
-          fingerprint: 'fp-review-1',
-          decision: 'resolved',
-          actor: 'dashboard',
-          reason: '방 상태 확인 완료',
-          at: '2026-03-31T10:10:00Z',
-          target_type: 'namespace',
-        },
-      ],
+      recent_reviews: [],
       worker_cards: [],
     } as unknown as OperatorDigest
     operatorActionLog.value = []
@@ -221,15 +197,15 @@ describe('Ops intervene surface', () => {
     render(html`<${Ops} />`, container)
     await flushUi()
 
-    expect(container.textContent).toContain('즉시 검토 1')
-    expect(container.textContent).toContain('프로젝트 일시정지')
     expect(container.textContent).toContain('QuickIntervene')
     expect(container.textContent).toContain('FlowControlPanel')
-    expect(container.textContent).toContain('실행 작업대')
-    expect(container.textContent).toContain('현재 상태')
-    expect(container.textContent).toContain('마찰 요인')
-    expect(container.textContent).not.toContain('Active Queue')
-    expect(container.textContent).not.toContain('Deferred')
-    expect(container.textContent).not.toContain('Mode')
+    expect(container.textContent).toContain('최근 운영 활동')
+
+    // The placeholder-heavy review queue panel no longer exists regardless of
+    // review_queue contents. review items surface via Governance / Live Judge.
+    expect(container.textContent).not.toContain('방 제어 상태를 재확인하세요')
+    expect(container.textContent).not.toContain('마찰 요인')
+    expect(container.textContent).not.toContain('운영 판단')
+    expect(container.textContent).not.toContain('매뉴얼 처리')
   }, 120000)
 })

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -1,14 +1,11 @@
 import { html } from 'htm/preact'
-import { JsonViewerCard } from '../common/json-viewer'
 import { useEffect } from 'preact/hooks'
 import { CARD_STANDARD } from '../common/card'
 import { EmptyState } from '../common/feedback-state'
-import { ActionButton } from '../common/button'
 import { CountBadge } from '../common/badge'
 import { TimeAgo } from '../common/time-ago'
 import { route } from '../../router'
 import {
-  operatorActionBusy,
   operatorActionLog,
   operatorDigestError,
   operatorError,
@@ -20,74 +17,17 @@ import {
   workflowContextForRoute,
   workflowTargetLabel,
 } from '../../workflow-context'
-import type { OperatorActionLogEntry, OperatorReviewDecision, OperatorReviewItem } from '../../types'
+import type { OperatorActionLogEntry, OperatorReviewDecision } from '../../types'
 import { QuickIntervene } from './quick-intervene'
 import {
   actionTypeLabel,
-  confirmPending,
-  detailDigestForItem,
-  executeRecommendedAction,
   formatMessageContent,
-  guidanceFreshnessLabel,
-  guidanceLayerLabel,
   hydrateOpsWorkflow,
-  hydrateRecommendedAction,
   hydratedWorkflowId,
-  isRootTarget,
-  primaryActionForReviewItem,
-  relativeAge,
-  reviewDecisionReason,
-  runtimeJudgeLabel,
-  selectedReviewItemId,
-  selectedReviewTab,
-  submitReviewDecision,
   targetTypeLabel,
   workflowTargetReady,
 } from './helpers'
 import { FlowControlPanel } from '../flow-control/flow-control-panel'
-import { displayStatus } from '../../lib/status-label'
-
-function severityClass(value?: string | null): string {
-  switch ((value ?? '').trim().toLowerCase()) {
-    case 'bad':
-      return 'border-[var(--bad-30)] bg-[var(--bad-10)]'
-    case 'warn':
-      return 'border-[var(--warn-30)] bg-[var(--warn-10)]'
-    default:
-      return 'border-[var(--card-border)] bg-[var(--white-3)]'
-  }
-}
-
-function severityLabel(value?: string | null): string {
-  switch ((value ?? '').trim().toLowerCase()) {
-    case 'bad':
-      return '즉시 검토'
-    case 'warn':
-      return '주의'
-    default:
-      return '정상'
-  }
-}
-
-function reviewListForTab(
-  tab: 'active' | 'deferred' | 'recent',
-  active: OperatorReviewItem[],
-  deferred: OperatorReviewItem[],
-): OperatorReviewItem[] {
-  return tab === 'deferred' ? deferred : active
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  return value as Record<string, unknown>
-}
-
-function pendingConfirmToken(item: OperatorReviewItem | null): string | null {
-  const friction = asRecord(item?.friction)
-  const pending = asRecord(friction?.pending_confirm)
-  const token = pending?.confirm_token ?? pending?.token
-  return typeof token === 'string' && token.trim() !== '' ? token : null
-}
 
 type ActivityTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
 
@@ -185,27 +125,6 @@ function timelineEntries(limit = 10): OpsActivityTimelineEntry[] {
     .slice(0, limit)
 }
 
-function renderSummaryBadges(activeCount: number, deferredCount: number, recentCount: number) {
-  const roomPaused = operatorSnapshot.value?.root?.paused
-  const roomLabel =
-    typeof roomPaused === 'boolean'
-      ? roomPaused ? '프로젝트 일시정지' : '프로젝트 진행 중'
-      : '프로젝트 상태 확인 필요'
-  const roomTone: ActivityTone =
-    typeof roomPaused !== 'boolean'
-      ? 'default'
-      : roomPaused ? 'warn' : 'ok'
-
-  return html`
-    <section class="${CARD_STANDARD} flex flex-wrap items-center gap-2" data-testid="ops-summary-badges">
-      <${CountBadge} tone=${activeCount > 0 ? 'warn' : 'ok'}>즉시 검토 ${activeCount}<//>
-      <${CountBadge} tone=${deferredCount > 0 ? 'accent' : 'default'}>보류 ${deferredCount}<//>
-      <${CountBadge} tone=${recentCount > 0 ? 'accent' : 'default'}>최근 처리 ${recentCount}<//>
-      <${CountBadge} tone=${roomTone}>${roomLabel}<//>
-    </section>
-  `
-}
-
 function renderActivityTimeline() {
   const entries = timelineEntries()
   if (entries.length === 0) {
@@ -234,153 +153,10 @@ function renderActivityTimeline() {
   `
 }
 
-function renderTruth(item: OperatorReviewItem | null) {
-  const snapshot = operatorSnapshot.value
-  const roomDigest = operatorRoomDigest.value
-  const detailDigest = detailDigestForItem(item, roomDigest)
-
-  if (!item) {
-    return html`<div class="text-[12px] text-[var(--text-muted)]">큐에서 항목을 고르면 truth를 보여줍니다.</div>`
-  }
-
-  if (isRootTarget(item.target_type)) {
-    const room = detailDigest?.root ?? snapshot?.root ?? {}
-    return html`
-      <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Project</div>
-          <strong>${room.project ?? 'default'}</strong>
-          <div class="text-[12px] text-[var(--text-muted)]">${room.project ?? 'project'} · ${room.cluster ?? 'cluster'}</div>
-        </div>
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Gate</div>
-          <strong>${room.paused ? '일시정지' : '열림'}</strong>
-          <div class="text-[12px] text-[var(--text-muted)]">${room.pause_reason ?? '추가 사유 없음'}</div>
-        </div>
-      </div>
-    `
-  }
-
-  if (item.target_type === 'keeper') {
-    const keeper = snapshot?.keepers.find(row => row.name === item.target_id) ?? null
-    return html`
-      <div class="grid grid-cols-2 gap-3 max-[880px]:grid-cols-1">
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Keeper</div>
-          <strong>${keeper?.name ?? item.target_id ?? 'unknown'}</strong>
-          <div class="text-[12px] text-[var(--text-muted)]">${displayStatus(keeper?.status)}${keeper?.model ? ` · ${keeper.model}` : ''}</div>
-        </div>
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Context</div>
-          <strong>${typeof keeper?.context_ratio === 'number' ? `${Math.round(keeper.context_ratio * 100)}%` : 'unknown'}</strong>
-          <div class="text-[12px] text-[var(--text-muted)]">${relativeAge(keeper?.last_turn_ago_s)}</div>
-        </div>
-      </div>
-    `
-  }
-
-  return html`<div class="text-[12px] text-[var(--text-muted)]">지원하지 않는 target입니다.</div>`
-}
-
-function renderAdvice(item: OperatorReviewItem | null) {
-  const roomDigest = operatorRoomDigest.value
-  const detailDigest = detailDigestForItem(item, roomDigest)
-  const summary = detailDigest?.active_summary ?? item?.advice?.active_summary ?? null
-  const guidanceLayer = detailDigest?.active_guidance_layer ?? item?.advice?.active_guidance_layer ?? null
-  const runtime = detailDigest?.operator_judge_runtime ?? roomDigest?.operator_judge_runtime ?? null
-
-  return html`
-    <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-      <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">
-        <span>${guidanceLayerLabel(guidanceLayer)}</span>
-        <span>${runtimeJudgeLabel(runtime)}</span>
-        ${summary?.fresh_until ? html`<span>${guidanceFreshnessLabel(summary)}</span>` : null}
-      </div>
-      <div class="mt-2 text-[13px] leading-[1.55] text-[var(--text-body)]">
-        ${summary?.summary ?? '현재 이 항목에 연결된 operator guidance가 없습니다.'}
-      </div>
-      ${detailDigest?.operator_judge_runtime?.model_used
-        ? html`<div class="mt-2 text-[12px] text-[var(--text-muted)]">${detailDigest.operator_judge_runtime.model_used}</div>`
-        : null}
-    </div>
-  `
-}
-
-function renderFriction(item: OperatorReviewItem | null) {
-  if (!item) {
-    return html`<div class="text-[12px] text-[var(--text-muted)]">큐에서 항목을 고르면 friction을 보여줍니다.</div>`
-  }
-  const friction = asRecord(item.friction)
-  const attentionItems = Array.isArray(friction?.attention_items) ? friction?.attention_items : []
-
-  return html`
-    <div class="grid gap-3">
-      ${attentionItems.length > 0 ? html`
-        <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Attention</div>
-          <div class="mt-2 grid gap-2">
-            ${attentionItems.slice(0, 3).map((row: unknown) => {
-              const record = asRecord(row)
-              return html`
-                <div class="text-[13px] leading-[1.45] text-[var(--text-body)]">
-                  <strong>${typeof record?.severity === 'string' ? record.severity : 'info'}</strong>
-                  <span> ${typeof record?.summary === 'string' ? record.summary : (row)}</span>
-                </div>
-              `
-            })}
-          </div>
-        </div>
-      ` : null}
-      <details class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-        <summary class="cursor-pointer text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">Raw Friction</summary>
-        <${JsonViewerCard} data=${item.friction} />
-      </details>
-    </div>
-  `
-}
-
-function renderRecentReviews() {
-  const roomDigest = operatorRoomDigest.value
-  const recent = roomDigest?.recent_reviews ?? []
-  if (recent.length === 0) {
-    return html`<${EmptyState} message="최근 처리 기록이 없습니다." compact />`
-  }
-  return html`
-    <div class="grid gap-2">
-      ${recent.map(item => html`
-        <article key=${`${item.item_id}:${item.at}`} class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">
-            <span>${reviewDecisionLabel(item.decision)}</span>
-            <span>${targetSummary(item.target_type, item.target_id)}</span>
-            <span>${item.actor}</span>
-          </div>
-          <div class="mt-1 text-[13px] text-[var(--text-body)]">${item.reason}</div>
-          <div class="mt-1 text-[12px] text-[var(--text-muted)]"><${TimeAgo} timestamp=${item.at} /></div>
-        </article>
-      `)}
-    </div>
-  `
-}
-
 export function Ops() {
   const snapshot = operatorSnapshot.value
   const workflowContext = route.value.tab === 'command' ? workflowContextForRoute(route.value) : null
-  const roomDigest = operatorRoomDigest.value
-  const activeQueue = roomDigest?.review_queue ?? []
-  const deferredQueue = roomDigest?.deferred_queue ?? []
   const workflowReady = workflowTargetReady(workflowContext, snapshot?.keepers ?? [])
-  const tab = selectedReviewTab.value
-  const currentQueue = reviewListForTab(tab, activeQueue, deferredQueue)
-  const selectedItem =
-    tab === 'recent'
-      ? null
-      : currentQueue.find(item => item.id === selectedReviewItemId.value) ?? currentQueue[0] ?? null
-  const primaryAction = selectedItem ? primaryActionForReviewItem(selectedItem) : null
-  const activeCount = roomDigest?.review_summary?.active_count ?? activeQueue.length
-  const deferredCount = roomDigest?.review_summary?.deferred_count ?? deferredQueue.length
-  const recentCount = roomDigest?.review_summary?.recent_count ?? (roomDigest?.recent_reviews.length ?? 0)
-  const healthy = activeCount === 0
-  const confirmToken = pendingConfirmToken(selectedItem)
 
   useEffect(() => {
     if (route.value.tab !== 'command' || route.value.params.section !== 'operations') {
@@ -404,20 +180,6 @@ export function Ops() {
     workflowContext?.id,
   ])
 
-  useEffect(() => {
-    if (tab === 'recent') {
-      selectedReviewItemId.value = ''
-      return
-    }
-    if (currentQueue.length === 0) {
-      selectedReviewItemId.value = ''
-      return
-    }
-    if (!currentQueue.some(item => item.id === selectedReviewItemId.value)) {
-      selectedReviewItemId.value = currentQueue[0]?.id ?? ''
-    }
-  }, [tab, currentQueue.map(item => item.id).join('|')])
-
   return html`
     <section class="flex flex-col gap-4">
       ${operatorError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorError.value}</section>` : null}
@@ -440,172 +202,20 @@ export function Ops() {
         </section>
       ` : null}
 
-      ${renderSummaryBadges(activeCount, deferredCount, recentCount)}
-      ${healthy ? html`
-        <section class="grid grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)] gap-4 max-[1200px]:grid-cols-1">
-          <div class="grid gap-4 order-1 max-[1200px]:order-2">
-            <${QuickIntervene} />
-            <${FlowControlPanel} />
-          </div>
-
-          <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1">
-            <div>
-              <h2 class="text-sm font-semibold text-[var(--text-strong)]">최근 운영 활동</h2>
-              <p class="mt-1 text-[12px] text-[var(--text-muted)]">최근 처리와 직접 개입을 시간순으로 함께 보여줍니다.</p>
-            </div>
-            <${renderActivityTimeline} />
-          </section>
-        </section>
-      ` : html`
-        <${FlowControlPanel} />
-        <div class="grid grid-cols-[280px_minmax(0,1fr)_360px] gap-4 max-[1280px]:grid-cols-1">
-          <section class="${CARD_STANDARD} grid gap-3">
-            <div class="flex gap-2 flex-wrap">
-              <${ActionButton} variant=${tab === 'active' ? 'primary' : 'ghost'} size="lg" onClick=${() => { selectedReviewTab.value = 'active' }}>
-                즉시 검토 ${activeCount}
-              <//>
-              <${ActionButton} variant=${tab === 'deferred' ? 'primary' : 'ghost'} size="lg" onClick=${() => { selectedReviewTab.value = 'deferred' }}>
-                보류 ${deferredCount}
-              <//>
-              <${ActionButton} variant=${tab === 'recent' ? 'primary' : 'ghost'} size="lg" onClick=${() => { selectedReviewTab.value = 'recent' }}>
-                최근 처리 ${recentCount}
-              <//>
-            </div>
-
-            ${tab === 'recent'
-              ? html`<${renderRecentReviews} />`
-              : currentQueue.length === 0
-                ? html`<${EmptyState} message="이 탭에는 review item이 없습니다." compact />`
-                : html`
-                    <div class="grid gap-2">
-                      ${currentQueue.map(item => html`
-                        <button
-                          key=${item.id}
-                          type="button"
-                          class="text-left p-3 rounded-xl border ${severityClass(item.severity)} ${selectedItem?.id === item.id ? 'ring-1 ring-[rgba(71,184,255,0.45)]' : ''}"
-                          onClick=${() => { selectedReviewItemId.value = item.id }}
-                        >
-                          <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">
-                            <span>${severityLabel(item.severity)}</span>
-                            <span>${targetTypeLabel(item.target_type)}${item.target_id ? ` · ${item.target_id}` : ''}</span>
-                            <span>${item.urgency}</span>
-                          </div>
-                          <div class="mt-1 text-[14px] font-semibold text-[var(--text-strong)]">${item.summary}</div>
-                          <div class="mt-1 text-[12px] leading-[1.45] text-[var(--text-muted)]">${item.why_now}</div>
-                          ${typeof item.stale_sec === 'number'
-                            ? html`<div class="mt-2 text-[11px] text-[var(--text-muted)]">stale ${relativeAge(item.stale_sec)}</div>`
-                            : null}
-                        </button>
-                      `)}
-                    </div>
-                  `}
-          </section>
-
-          <section class="${CARD_STANDARD} grid gap-4">
-            <div class="p-3 rounded-xl border ${severityClass(selectedItem?.severity)}">
-              <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">
-                <span>${selectedItem?.kind ?? 'review_item'}</span>
-                <span>${selectedItem ? targetTypeLabel(selectedItem.target_type) : '대상 없음'}${selectedItem?.target_id ? ` · ${selectedItem.target_id}` : ''}</span>
-                <span>${selectedItem?.urgency ?? 'soon'}</span>
-              </div>
-              <div class="mt-1 text-[16px] font-semibold text-[var(--text-strong)]">
-                ${selectedItem?.summary ?? '큐에서 항목을 고르세요'}
-              </div>
-              <div class="mt-2 text-[13px] leading-[1.55] text-[var(--text-body)]">
-                ${selectedItem?.why_now ?? '선택한 항목의 why-now 설명이 여기에 나옵니다.'}
-              </div>
-            </div>
-
-            <div class="grid gap-2">
-              <h3 class="text-sm font-semibold text-[var(--text-strong)]">현재 상태</h3>
-              ${renderTruth(selectedItem)}
-            </div>
-
-            <div class="grid gap-2">
-              <h3 class="text-sm font-semibold text-[var(--text-strong)]">마찰 요인</h3>
-              ${renderFriction(selectedItem)}
-            </div>
-
-            <div class="grid gap-2">
-              <h3 class="text-sm font-semibold text-[var(--text-strong)]">운영 판단</h3>
-              ${renderAdvice(selectedItem)}
-            </div>
-          </section>
-
-          <section class="${CARD_STANDARD} grid gap-4">
-            <div>
-              <h3 class="text-sm font-semibold text-[var(--text-strong)]">실행 작업대</h3>
-              <p class="text-[12px] text-[var(--text-muted)] mt-1">가장 작은 다음 행동을 실행하거나, review 상태를 resolve/defer로 닫습니다.</p>
-            </div>
-
-            ${selectedItem == null
-              ? html`<${EmptyState} message="먼저 review item을 고르세요." compact />`
-              : html`
-                  ${primaryAction
-                    ? html`
-                        <article class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] grid gap-2">
-                          <div class="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">
-                            <span>우선 액션</span>
-                            <span>${actionTypeLabel(primaryAction.action_type)}</span>
-                            <span>${targetTypeLabel(primaryAction.target_type)}${primaryAction.target_id ? ` · ${primaryAction.target_id}` : ''}</span>
-                          </div>
-                          <div class="text-[13px] leading-[1.55] text-[var(--text-body)]">${primaryAction.reason}</div>
-                          <div class="flex gap-2 flex-wrap">
-                            <${ActionButton} variant="primary" size="lg" onClick=${() => { void executeRecommendedAction(primaryAction) }} disabled=${operatorActionBusy.value}>
-                              바로 실행
-                            <//>
-                            <${ActionButton} variant="ghost" size="lg" onClick=${() => { hydrateRecommendedAction(primaryAction) }} disabled=${operatorActionBusy.value}>
-                              폼에 채우기
-                            <//>
-                          </div>
-                        </article>
-                      `
-                    : html`<${EmptyState} message="이 항목에는 자동으로 제안된 primary action이 없습니다." compact />`}
-
-                  ${confirmToken
-                    ? html`
-                        <article class="p-3 rounded-xl border border-[var(--warn-30)] bg-[var(--warn-10)] grid gap-2">
-                          <div class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]">승인 대기</div>
-                          <div class="text-[13px] text-[var(--text-body)]">${confirmToken}</div>
-                          <div class="flex gap-2 flex-wrap">
-                            <${ActionButton} variant="primary" size="lg" onClick=${() => { void confirmPending(confirmToken, 'confirm') }} disabled=${operatorActionBusy.value}>
-                              승인 실행
-                            <//>
-                            <${ActionButton} variant="ghost" size="lg" onClick=${() => { void confirmPending(confirmToken, 'deny') }} disabled=${operatorActionBusy.value}>
-                              거부
-                            <//>
-                          </div>
-                        </article>
-                      `
-                    : null}
-
-                  <div class="grid gap-2">
-                    <label class="text-[11px] text-[var(--text-muted)] uppercase tracking-[0.08em]" for="review-reason">처리 이유</label>
-                    <textarea
-                      id="review-reason"
-                      class="control-textarea"
-                      rows=${4}
-                      placeholder="왜 resolve/defer 하는지 남깁니다"
-                      value=${reviewDecisionReason.value}
-                      onInput=${(event: Event) => { reviewDecisionReason.value = (event.target as HTMLTextAreaElement).value }}
-                      disabled=${operatorActionBusy.value}
-                    ></textarea>
-                  </div>
-
-                  <div class="flex gap-2 flex-wrap">
-                    <${ActionButton} variant="primary" size="lg" onClick=${() => { if (selectedItem) void submitReviewDecision(selectedItem, 'review_resolve') }} disabled=${operatorActionBusy.value || !selectedItem || !reviewDecisionReason.value.trim()}>
-                      해결 처리
-                    <//>
-                    <${ActionButton} variant="ghost" size="lg" onClick=${() => { if (selectedItem) void submitReviewDecision(selectedItem, 'review_defer') }} disabled=${operatorActionBusy.value || !selectedItem || !reviewDecisionReason.value.trim()}>
-                      보류 처리
-                    <//>
-                  </div>
-
-                  <${QuickIntervene} />
-                `}
-          </section>
+      <${FlowControlPanel} />
+      <section class="grid grid-cols-2 gap-4 max-[1200px]:grid-cols-1">
+        <div class="grid gap-4 order-1 max-[1200px]:order-2">
+          <${QuickIntervene} />
         </div>
-      `}
+
+        <section class="${CARD_STANDARD} grid gap-3 order-2 max-[1200px]:order-1">
+          <div>
+            <h2 class="text-sm font-semibold text-[var(--text-strong)]">최근 운영 활동</h2>
+            <p class="mt-1 text-[12px] text-[var(--text-muted)]">최근 처리와 직접 개입을 시간순으로 함께 보여줍니다. 검토 큐와 Live Judge 판단은 거버넌스 페이지에서 처리합니다.</p>
+          </div>
+          <${renderActivityTimeline} />
+        </section>
+      </section>
     </section>
   `
 }


### PR DESCRIPTION
## Summary

The Ops (\`운영 행동\`) page carried a 3-column *unhealthy* branch:

- **col 1** — review queue list (즉시 검토 / 보류 / 최근 탭)
- **col 2** — per-item detail (\`현재 상태\` / \`마찰 요인\` / \`운영 판단\`)
- **col 3** — action column (\`실행 작업대\` / \`매뉴얼 처리\`)

Almost every cell rendered as a placeholder when no item was selected:

- \`큐에서 항목을 고르세요\`
- \`선택한 항목의 why-now 설명이 여기에 나옵니다\`
- \`큐에서 항목을 고르면 truth를 보여줍니다\`
- \`큐에서 항목을 고르면 friction을 보여줍니다\`
- \`현재 이 항목에 연결된 operator guidance가 없습니다\`
- \`먼저 review item을 고르세요\`
- \`review_item / 대상 없음 / soon\`

The real thing the user wants to see — **Live Judge + Keeper HITL 승인** — already lives on the Governance page (\`dashboard/src/components/governance.ts\` → \`LiveGovernanceToolbar\`, \`JudgmentsSection\`, \`KeeperApprovalQueueSection\`). The Ops review queue panel was a placeholder-dominant duplicate.

## Change

Collapse Ops to a single surface for every state:

- operator/digest error banners
- workflow-context banner (cross-surface link)
- \`FlowControlPanel\` (pause/resume + maintenance)
- 2-column grid: \`QuickIntervene\` + \`최근 운영 활동\` activity timeline (reviews ∪ interventions, sorted by \`at\`)

Removed:

| Category | Items |
|---|---|
| Render helpers | \`renderTruth\`, \`renderAdvice\`, \`renderFriction\`, \`renderRecentReviews\`, \`renderSummaryBadges\`, \`severityClass\`, \`severityLabel\`, \`reviewListForTab\`, \`asRecord\`, \`pendingConfirmToken\` |
| Local state | \`tab\`, \`currentQueue\`, \`selectedItem\`, \`primaryAction\`, \`confirmToken\`, \`activeCount\`, \`deferredCount\`, \`recentCount\`, \`healthy\` |
| Now-unused imports | \`JsonViewerCard\`, \`ActionButton\`, \`operatorActionBusy\`, \`displayStatus\`, \`relativeAge\`, \`isRootTarget\`, \`detailDigestForItem\`, \`primaryActionForReviewItem\`, \`executeRecommendedAction\`, \`hydrateRecommendedAction\`, \`submitReviewDecision\`, \`confirmPending\`, \`guidanceLayerLabel\`, \`guidanceFreshnessLabel\`, \`runtimeJudgeLabel\`, \`selectedReviewItemId\`, \`selectedReviewTab\`, \`reviewDecisionReason\` |

## Diff

\`\`\`
2 files changed, 33 insertions(+), 447 deletions(-)
\`\`\`

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test src/components/ops\` — 3 test files / 7 tests
- [ ] Manual smoke: Ops 탭에서 placeholder 문구 모두 사라지고 QuickIntervene + 활동 타임라인만 보이는지 확인
- [ ] Manual smoke: Governance 페이지에서 Live Judge + Keeper HITL 승인 대기 카드 정상 렌더링 확인

Tests replace the 2 old cases with 2 invariants of the new surface:
1. activity timeline merges \`recent_reviews\` + \`operatorActionLog\` ordered by timestamp
2. same surface renders regardless of \`review_queue\` contents — no 3-column branch, no placeholder text

## Follow-up candidates (not in this PR)

- \`ops-state.ts\` still exports \`selectedReviewItemId\` / \`selectedReviewTab\` / \`reviewDecisionReason\` signals that are now unused — safe to drop after confirming no regression
- \`ops/helpers.ts\` has stragglers (\`primaryActionForReviewItem\`, \`submitReviewDecision\`, \`executeRecommendedAction\`, \`detailDigestForItem\`, \`confirmPending\`, \`guidanceLayerLabel\`, \`guidanceFreshnessLabel\`, \`runtimeJudgeLabel\`) — each needs individual check against \`ops-room-column.ts\` before deletion