### PR TITLE
feat(dashboard/governance): prominent Keeper HITL approval alert banner

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -181,6 +181,8 @@ describe('Governance surface', () => {
     await flushUi()
 
     expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
+    // No approval queue items → banner must stay hidden so it's not noisy.
+    expect(container.querySelector('[data-testid="keeper-hitl-alert-banner"]')).toBeNull()
   }, 20000)
 
   it('shows retired guidance when case tracking is disabled', async () => {
@@ -400,6 +402,20 @@ describe('Governance surface', () => {
     expect(container.textContent).toContain('새로고침')
     expect(container.textContent).not.toContain('Case Load Visualized')
     expect(container.textContent).not.toContain('청원 콘솔')
+
+    // Prominent top banner must render when approval queue is non-empty.
+    const banner = container.querySelector('[data-testid="keeper-hitl-alert-banner"]')
+    expect(banner).not.toBeNull()
+    expect(banner?.textContent).toContain('1건')
+    expect(banner?.textContent).toContain('지금 검토')
+    expect(banner?.textContent?.toLowerCase()).toContain('critical')
+
+    // Banner precedes the summary strip so it can't be missed.
+    const governanceRoot = container.firstElementChild as HTMLElement | null
+    expect(governanceRoot?.firstElementChild).toBe(banner)
+
+    // Anchor target on the HITL queue card exists so '지금 검토' can scroll to it.
+    expect(container.querySelector('[data-testid="keeper-hitl-approval"]')).not.toBeNull()
 
     const approveButton = Array.from(container.querySelectorAll('button'))
       .find(button => button.textContent?.trim() === '승인')

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -433,16 +433,94 @@ function approvalRiskToneClass(riskLevel: string): string {
   return 'border-white/10 bg-white/5 text-text-muted'
 }
 
+const RISK_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+}
+
+function maxApprovalRisk(items: readonly { risk_level?: string | null }[]): string | null {
+  let topRank = 0
+  let topLabel: string | null = null
+  for (const item of items) {
+    const raw = item.risk_level?.trim().toLowerCase()
+    const rank = raw ? (RISK_RANK[raw] ?? 0) : 0
+    if (rank > topRank) {
+      topRank = rank
+      topLabel = raw ?? null
+    }
+  }
+  return topLabel
+}
+
+function scrollToKeeperApprovalSection(): void {
+  const el = document.getElementById('keeper-hitl-approval')
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function KeeperApprovalAlertBanner() {
+  const items = governanceData.value?.approval_queue ?? []
+  if (items.length === 0) return null
+
+  const maxRisk = maxApprovalRisk(items)
+  const isCritical = maxRisk === 'critical' || maxRisk === 'high'
+  const tone = isCritical
+    ? 'border-bad/40 bg-bad/10 text-bad'
+    : 'border-warn/40 bg-warn/10 text-warn'
+  const ringTone = isCritical ? 'ring-bad/25' : 'ring-warn/25'
+
+  return html`
+    <div
+      class="mb-3.5 flex items-center gap-4 rounded-xl border ${tone} p-4 shadow-sm ring-2 ${ringTone}"
+      data-testid="keeper-hitl-alert-banner"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="shrink-0 flex items-center justify-center w-11 h-11 rounded-full border border-current/30 bg-current/10">
+        <${AlertTriangle} size=${22} aria-hidden="true" />
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-baseline gap-2 flex-wrap">
+          <span class="text-[20px] font-extrabold leading-none">${items.length}건</span>
+          <span class="text-[13px] font-semibold">Keeper HITL 승인 대기</span>
+          ${maxRisk ? html`<span class="text-[11px] font-bold uppercase tracking-wider opacity-80">최고 ${maxRisk}</span>` : null}
+        </div>
+        <div class="mt-1 text-[12px] opacity-85">
+          위험도 threshold를 넘은 keeper tool call이 사용자 판단을 기다리고 있습니다.
+        </div>
+      </div>
+      <${ActionButton}
+        variant=${isCritical ? 'danger' : 'primary'}
+        size="md"
+        class="shrink-0"
+        onClick=${scrollToKeeperApprovalSection}
+      >
+        지금 검토 →
+      <//>
+    </div>
+  `
+}
+
 function KeeperApprovalQueueSection() {
   const items = governanceData.value?.approval_queue ?? []
   const actingId = governanceApprovalActing.value
+  const maxRisk = maxApprovalRisk(items)
+  const hasItems = items.length > 0
+  const countBadgeClass = hasItems
+    ? (maxRisk === 'critical' || maxRisk === 'high'
+        ? 'border-bad/40 bg-bad/15 text-bad text-[13px] px-3 py-1 font-extrabold'
+        : 'border-warn/40 bg-warn/15 text-warn text-[13px] px-3 py-1 font-extrabold')
+    : 'border-white/10 bg-white/5 text-text-muted text-[11px] px-2 py-0.5 font-bold'
   return html`
+    <div id="keeper-hitl-approval" data-testid="keeper-hitl-approval">
     <${Card} title="Keeper HITL 승인 대기" class="section mb-5" variant="compact">
       <div class="mb-3 flex items-center justify-between gap-3">
         <div class="text-[12px] text-text-muted">
           위험도가 threshold를 넘은 keeper tool call이 여기서 대기합니다.
         </div>
-        <span class="rounded-md border border-warn/20 bg-warn/10 px-2 py-0.5 text-[11px] font-bold text-warn">
+        <span class="rounded-md border ${countBadgeClass}">
           ${items.length}건 대기
         </span>
       </div>
@@ -501,6 +579,7 @@ function KeeperApprovalQueueSection() {
             </div>
           `}
     <//>
+    </div>
   `
 }
 
@@ -514,6 +593,7 @@ export function Governance() {
 
   return html`
     <div class="flex flex-col gap-0.5">
+      <${KeeperApprovalAlertBanner} />
       <${GovernanceSummaryStrip} />
       ${caseTrackingRetired
         ? html`


### PR DESCRIPTION
## Summary

The Keeper HITL approval queue card had the same placid visual weight whether 0 or 15 keeper tool calls were waiting for sign-off. A small warn-tone \`\${N}건 대기\` badge buried mid-page does not match the urgency of an approval queue that blocks keeper progress. Users consistently missed the signal.

## Change

Add a **top-of-page attention surface** that only renders when \`approval_queue.length > 0\`:

- `KeeperApprovalAlertBanner` becomes the very first child of the Governance layout (above `GovernanceSummaryStrip`)
- 20px bold count, max risk_level summarized inline, bad tone when any item is critical/high, warn otherwise, ring-2 for visual separation
- `지금 검토 →` button smooth-scrolls to the existing HITL card (anchored via `data-testid="keeper-hitl-approval"` wrapper)
- `role="status"` + `aria-live="polite"` so screen readers announce the count when it first appears

The existing `KeeperApprovalQueueSection` card header also gets a dynamic count badge:
- empty: compact `text-[11px]` muted
- non-empty: `text-[13px] / px-3 / font-extrabold`, bad or warn tone based on max risk

`maxApprovalRisk()` utility ranks `critical > high > medium > low` and is reused by both the banner and the card header.

## Why this design

- Zero approvals → zero extra chrome (no noise)
- Present approvals → top-of-page, color-coded to risk, always presents a scroll target for action
- No animation/pulse: subtle ring + color escalation communicates urgency without being jarring across long sessions

## Diff

\`\`\`
2 files changed, 97 insertions(+), 1 deletion(-)
\`\`\`

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test src/components/governance\` (7 tests)
  - Extended \`renders keeper approval queue ...\` to assert the banner appears with count + risk label, and that it precedes \`GovernanceSummaryStrip\`
  - Extended \`shows keeper guidance when governance feed is empty\` to assert banner is hidden when \`approval_queue\` is empty
- [ ] Manual: inject a synthetic critical approval → red banner at top, \`지금 검토\` scrolls to the card
- [ ] Manual: clear approvals → banner disappears, card header returns to compact state

## Follow-up candidates (not in this PR)

- \`Card\` common component could accept an \`id\` prop so the wrapper \`<div id=...>\` becomes unnecessary
- Banner currently uses `AlertTriangle` from `lucide-preact`; a keeper-specific icon might reinforce context