### PR TITLE
feat(cascade): strategy decision trace + dashboard panel

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2008,3 +2008,39 @@ export function fetchTlaSpecs(
     signal: opts?.signal,
   })
 }
+
+export type CascadeStrategyTraceKind = 'ordered' | 'filtered_empty' | 'exhausted'
+
+export interface CascadeStrategyTraceEvent {
+  ts: number
+  cascade_name: string
+  strategy: string
+  cycle: number
+  candidates_in: number
+  candidates_out: number
+  backoff_ms: number
+  kind: CascadeStrategyTraceKind
+}
+
+export interface CascadeStrategyTraceResponse {
+  updated_at: string
+  total_events: number
+  events: CascadeStrategyTraceEvent[]
+}
+
+export function fetchCascadeStrategyTrace(opts?: {
+  limit?: number
+  cascade?: string
+  signal?: AbortSignal
+}): Promise<CascadeStrategyTraceResponse> {
+  const params = new URLSearchParams()
+  if (typeof opts?.limit === 'number' && opts.limit > 0) {
+    params.set('limit', String(opts.limit))
+  }
+  if (opts?.cascade) params.set('cascade', opts.cascade)
+  const qs = params.toString()
+  return get<CascadeStrategyTraceResponse>(
+    `/api/v1/cascade/strategy_trace${qs ? `?${qs}` : ''}`,
+    { signal: opts?.signal },
+  )
+}

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -12,6 +12,7 @@ import { useEffect, useRef } from 'preact/hooks'
 import {
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
+  fetchCascadeStrategyTrace,
   fetchCascadeConfig,
   fetchCascadeHealth,
   type CascadeCandidate,
@@ -24,6 +25,9 @@ import {
   type CascadeHealthProvider,
   type CascadeHealthResponse,
   type CascadeProfile,
+  type CascadeStrategyTraceEvent,
+  type CascadeStrategyTraceKind,
+  type CascadeStrategyTraceResponse,
 } from '../api/dashboard'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
@@ -37,17 +41,19 @@ interface CascadeData {
   health: CascadeHealthResponse | null
   capacity: CascadeClientCapacityResponse | null
   history: CascadeClientCapacityHistoryResponse | null
+  trace: CascadeStrategyTraceResponse | null
 }
 
 async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   await resource.load(async (signal) => {
-    const [config, health, capacity, history] = await Promise.all([
+    const [config, health, capacity, history, trace] = await Promise.all([
       fetchCascadeConfig({ signal }),
       fetchCascadeHealth({ signal }),
       fetchCascadeClientCapacity({ signal }),
       fetchCascadeClientCapacityHistory({ limit: 50, signal }),
+      fetchCascadeStrategyTrace({ limit: 50, signal }),
     ])
-    return { config, health, capacity, history }
+    return { config, health, capacity, history, trace }
   })
 }
 
@@ -244,6 +250,60 @@ function capacityKindLabel(kind: CascadeClientCapacityEntry['kind']): string {
   }
 }
 
+function traceKindTone(k: CascadeStrategyTraceKind): 'ok' | 'warn' | 'bad' {
+  switch (k) {
+    case 'ordered': return 'ok'
+    case 'filtered_empty': return 'warn'
+    case 'exhausted': return 'bad'
+  }
+}
+
+function traceKindLabel(k: CascadeStrategyTraceKind): string {
+  switch (k) {
+    case 'ordered': return '정렬'
+    case 'filtered_empty': return '전부 차단'
+    case 'exhausted': return '소진'
+  }
+}
+
+function StrategyTraceTable({
+  trace,
+}: { trace: CascadeStrategyTraceResponse }) {
+  if (trace.events.length === 0) {
+    return html`<${EmptyState}>최근 strategy decision 이 없습니다. (cascade 호출이 아직 발생하지 않음)<//>`
+  }
+  return html`
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+          <th class="text-left py-1 w-20">시간</th>
+          <th class="text-left py-1">Cascade</th>
+          <th class="text-left py-1">Strategy</th>
+          <th class="text-right py-1">Cycle</th>
+          <th class="text-right py-1">In/Out</th>
+          <th class="text-right py-1">Backoff(ms)</th>
+          <th class="text-left py-1">결과</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${trace.events.map((e: CascadeStrategyTraceEvent) => {
+          const tone = traceKindTone(e.kind)
+          return html`
+          <tr class="border-b border-[var(--card-border)] last:border-b-0">
+            <td class="py-1 text-[var(--text-muted)] tabular-nums">${fmtRelativeTime(e.ts)}</td>
+            <td class="py-1"><code class="text-[var(--text-strong)]">${e.cascade_name}</code></td>
+            <td class="py-1 text-[var(--text-muted)]">${e.strategy}</td>
+            <td class="py-1 text-right tabular-nums">${e.cycle}</td>
+            <td class="py-1 text-right tabular-nums">${e.candidates_in}/${e.candidates_out}</td>
+            <td class="py-1 text-right tabular-nums">${e.backoff_ms > 0 ? e.backoff_ms : '–'}</td>
+            <td class="py-1"><${StatusChip} tone=${tone}>${traceKindLabel(e.kind)}<//></td>
+          </tr>
+        `})}
+      </tbody>
+    </table>
+  `
+}
+
 function ClientCapacityHistoryTable({
   history,
 }: { history: CascadeClientCapacityHistoryResponse }) {
@@ -328,6 +388,7 @@ export function CascadeConfigPanel() {
   const health = current.data?.health ?? null
   const capacity = current.data?.capacity ?? null
   const history = current.data?.history ?? null
+  const trace = current.data?.trace ?? null
 
   return html`
     <div class="flex flex-col gap-4">
@@ -410,6 +471,12 @@ export function CascadeConfigPanel() {
       <${Card} title="Client Capacity — 최근 이벤트">
         ${history
           ? html`<${ClientCapacityHistoryTable} history=${history} />`
+          : null}
+      <//>
+
+      <${Card} title="Strategy Decisions — cycle 추적">
+        ${trace
+          ? html`<${StrategyTraceTable} trace=${trace} />`
           : null}
       <//>
     </div>

--- a/lib/cascade/cascade_strategy_trace.ml
+++ b/lib/cascade/cascade_strategy_trace.ml
@@ -1,0 +1,107 @@
+(** See cascade_strategy_trace.mli for documentation. *)
+
+type event_kind = Ordered | Filtered_empty | Exhausted
+
+type event = {
+  ts : float;
+  cascade_name : string;
+  strategy : string;
+  cycle : int;
+  candidates_in : int;
+  candidates_out : int;
+  backoff_ms : int;
+  kind : event_kind;
+}
+
+let kind_to_string = function
+  | Ordered -> "ordered"
+  | Filtered_empty -> "filtered_empty"
+  | Exhausted -> "exhausted"
+
+let default_capacity = 1024
+let min_capacity = 16
+let max_capacity = 65536
+
+let resolve_capacity () =
+  let from_env =
+    match Sys.getenv_opt "MASC_STRATEGY_TRACE_SIZE" with
+    | None | Some "" -> default_capacity
+    | Some s ->
+      (match int_of_string_opt (String.trim s) with
+       | Some n -> n
+       | None -> default_capacity)
+  in
+  max min_capacity (min max_capacity from_env)
+
+(* Ring buffer: same invariants as Cascade_client_capacity_history. *)
+
+let cap_ref = ref 0
+let buf : event option array ref = ref [||]
+let head = ref 0
+let count = ref 0
+let mu = Mutex.create ()
+
+let ensure_initialised_locked () =
+  if !cap_ref = 0 then begin
+    let cap = resolve_capacity () in
+    cap_ref := cap;
+    buf := Array.make cap None;
+    head := 0;
+    count := 0
+  end
+
+let record ev =
+  Mutex.protect mu (fun () ->
+      ensure_initialised_locked ();
+      let cap = !cap_ref in
+      (!buf).(!head) <- Some ev;
+      head := (!head + 1) mod cap;
+      if !count < cap then incr count)
+
+let clear () =
+  Mutex.protect mu (fun () ->
+      ensure_initialised_locked ();
+      let cap = !cap_ref in
+      for i = 0 to cap - 1 do (!buf).(i) <- None done;
+      head := 0;
+      count := 0)
+
+let size () = Mutex.protect mu (fun () -> !count)
+
+let capacity () =
+  Mutex.protect mu (fun () ->
+      ensure_initialised_locked ();
+      !cap_ref)
+
+let collect_newest_first_locked () =
+  let cap = !cap_ref in
+  let n = !count in
+  let acc = ref [] in
+  for i = n - 1 downto 0 do
+    let idx = (!head - 1 - i + cap) mod cap in
+    match (!buf).(idx) with
+    | Some e -> acc := e :: !acc
+    | None -> ()
+  done;
+  !acc
+
+let snapshot ?(limit = 100) ?cascade () =
+  let events =
+    Mutex.protect mu (fun () ->
+        ensure_initialised_locked ();
+        collect_newest_first_locked ())
+  in
+  let cascade_match =
+    match cascade with
+    | None -> fun _ -> true
+    | Some c -> fun (e : event) -> e.cascade_name = c
+  in
+  let limit = max 0 limit in
+  let rec take n xs =
+    if n <= 0 then []
+    else
+      match xs with
+      | [] -> []
+      | x :: tl -> x :: take (n - 1) tl
+  in
+  events |> List.filter cascade_match |> take limit

--- a/lib/cascade/cascade_strategy_trace.mli
+++ b/lib/cascade/cascade_strategy_trace.mli
@@ -1,0 +1,87 @@
+(** Bounded ring buffer of Cascade {b strategy decisions}, one per cycle.
+
+    {!Cascade_strategy.order_candidates} currently logs cycle-level
+    filtering through {!Log.Misc.info}.  That is useful for tail -f
+    but invisible to the dashboard; operators cannot answer
+    "how often did Phase B Sticky reuse the same provider?" or
+    "how long were Circuit_breaker_cycling retries in the last hour?".
+
+    This module captures the decision outcome of every cycle iteration
+    of {!Oas_worker_named.try_cascade} as a ring event, so the dashboard
+    can surface recent runtime behaviour alongside the TLA+-verified
+    strategy kind.
+
+    Contracts:
+    - Size is fixed at init, read from [MASC_STRATEGY_TRACE_SIZE]
+      (default 1024, clamped to [[16, 65536]]).  Changing the env after
+      first use has no effect; the ring is lazily initialised once.
+    - Drop-oldest on overflow: recording into a full ring overwrites
+      the oldest slot in place, no allocation on steady state.
+    - [record] and [snapshot] are thread-safe via a plain stdlib
+      [Mutex] (same pattern as {!Cascade_client_capacity_history}).
+    - [snapshot] returns events newest-first so the dashboard can
+      render without a reverse pass.
+
+    @since 0.9.10 *)
+
+(** Decision outcome for a single cycle iteration.
+
+    - [Ordered]: strategy returned a non-empty candidate list; the caller
+      proceeded with the FSM.
+    - [Filtered_empty]: strategy filtered every candidate (e.g. every
+      provider in cooldown or slot-full); caller will backoff + retry.
+    - [Exhausted]: [Filtered_empty] on the last cycle, so the cascade
+      gave up and returned the exhaustion error. *)
+type event_kind = Ordered | Filtered_empty | Exhausted
+
+(** One decision event.
+
+    [ts] is a Unix timestamp (seconds).
+    [cascade_name] is the cascade.json profile name.
+    [strategy] is {!Cascade_strategy.kind_to_string} of the active kind.
+    [cycle] is 0-based, matching the [n] in [oas_worker_named.cycle_loop].
+    [candidates_in] is the input list size (post-[resolve_strategy]).
+    [candidates_out] is the list size returned by [order_candidates]
+    for this cycle (same as [candidates_in] for pure [Failover]).
+    [backoff_ms] is the backoff about to be applied for [Filtered_empty];
+    [0] for [Ordered] and [Exhausted]. *)
+type event = {
+  ts : float;
+  cascade_name : string;
+  strategy : string;
+  cycle : int;
+  candidates_in : int;
+  candidates_out : int;
+  backoff_ms : int;
+  kind : event_kind;
+}
+
+val record : event -> unit
+(** Append [event] to the ring.  Drops the oldest entry if the ring
+    is full.  Safe to call from multiple fibers/domains; serialised
+    via a stdlib [Mutex]. *)
+
+val snapshot : ?limit:int -> ?cascade:string -> unit -> event list
+(** Newest-first snapshot of recorded events.
+
+    @param limit  maximum number of events returned (default 100,
+           clamped to the ring's current count).
+    @param cascade  filter by [cascade_name].  Omitting returns
+           events for every cascade.
+
+    Filters compose: both [limit] and [cascade] apply together, with
+    [limit] applied after filtering. *)
+
+val clear : unit -> unit
+(** Test helper: drop every recorded event and reset the write head. *)
+
+val size : unit -> int
+(** Test helper: current number of recorded events (≤ ring capacity). *)
+
+val capacity : unit -> int
+(** Test helper: the ring's fixed capacity as resolved from
+    [MASC_STRATEGY_TRACE_SIZE]. *)
+
+val kind_to_string : event_kind -> string
+(** Serialise [event_kind] as the dashboard-facing label: ["ordered"],
+    ["filtered_empty"], ["exhausted"]. *)

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -196,3 +196,24 @@ let client_capacity_history_json ?limit ?kind ?since_ts () =
     ("total_events", `Int (List.length events));
     ("events", `List (List.map history_event_to_json events));
   ]
+
+let strategy_trace_event_to_json (ev : Cascade_strategy_trace.event)
+  : Yojson.Safe.t =
+  `Assoc [
+    ("ts", `Float ev.ts);
+    ("cascade_name", `String ev.cascade_name);
+    ("strategy", `String ev.strategy);
+    ("cycle", `Int ev.cycle);
+    ("candidates_in", `Int ev.candidates_in);
+    ("candidates_out", `Int ev.candidates_out);
+    ("backoff_ms", `Int ev.backoff_ms);
+    ("kind", `String (Cascade_strategy_trace.kind_to_string ev.kind));
+  ]
+
+let strategy_trace_json ?limit ?cascade () =
+  let events = Cascade_strategy_trace.snapshot ?limit ?cascade () in
+  `Assoc [
+    ("updated_at", `String (now_iso ()));
+    ("total_events", `Int (List.length events));
+    ("events", `List (List.map strategy_trace_event_to_json events));
+  ]

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -139,3 +139,35 @@ val client_capacity_history_json :
   ?kind:string ->
   ?since_ts:float ->
   unit -> Yojson.Safe.t
+
+(** JSON projection of {!Cascade_strategy_trace} — recent per-cycle
+    strategy decisions (candidate in/out counts, backoff, kind).
+
+    Shape:
+    {[
+      {
+        "updated_at": "ISO-8601",
+        "total_events": <int>,
+        "events": [
+          { "ts": <unix seconds>,
+            "cascade_name": "keeper_unified",
+            "strategy": "circuit_breaker_cycling",
+            "cycle": 2,
+            "candidates_in": 3,
+            "candidates_out": 1,
+            "backoff_ms": 2000,
+            "kind": "ordered" | "filtered_empty" | "exhausted" }, ...
+        ]
+      }
+    ]}
+
+    Sorted newest-first (delegated to {!Cascade_strategy_trace.snapshot}).
+
+    @param limit    max events returned (default 100).
+    @param cascade  filter by [cascade_name]; omit to include every cascade.
+
+    @since 0.9.10 *)
+val strategy_trace_json :
+  ?limit:int ->
+  ?cascade:string ->
+  unit -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -40,6 +40,7 @@
    cascade_runtime
    cascade_state
    cascade_strategy
+   cascade_strategy_trace
    cascade_throttle
    cancellation
    gate_keeper_backend

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -636,6 +636,18 @@ let run_named
       (sdk_error_of_masc_internal_error
          (Cascade_exhausted { cascade_name; detail = Some detail }))
   in
+  let record_trace ~cycle ~candidates_out ~backoff_ms ~kind =
+    Cascade_strategy_trace.record {
+      ts = Unix.gettimeofday ();
+      cascade_name;
+      strategy = Cascade_strategy.kind_to_string strategy.kind;
+      cycle;
+      candidates_in = List.length candidate_cfgs;
+      candidates_out;
+      backoff_ms;
+      kind;
+    }
+  in
   let rec cycle_loop n =
     let ordered =
       Cascade_strategy.order_candidates strategy
@@ -643,14 +655,21 @@ let run_named
     in
     let last_cycle = n + 1 >= strategy.cycle.max_cycles in
     match ordered with
-    | [] when last_cycle -> cascade_exhausted_after_filter ~cycle:n
+    | [] when last_cycle ->
+      record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:0 ~kind:Exhausted;
+      cascade_exhausted_after_filter ~cycle:n
     | [] ->
+      let backoff = Cascade_strategy.backoff_ms strategy.cycle ~cycle:(n + 1) in
+      record_trace ~cycle:n ~candidates_out:0 ~backoff_ms:backoff
+        ~kind:Filtered_empty;
       Log.Misc.info
         "cascade %s: cycle %d (%s) filtered all candidates, retrying"
         cascade_name n (Cascade_strategy.kind_to_string strategy.kind);
       do_backoff (n + 1);
       cycle_loop (n + 1)
     | _ ->
+      record_trace ~cycle:n ~candidates_out:(List.length ordered)
+        ~backoff_ms:0 ~kind:Ordered;
       let on_success ~provider_key =
         Cascade_strategy.record_choice strategy ~ctx:signal_ctx ~provider_key
       in

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -56,3 +56,15 @@ let add_routes router =
            Http.Response.json ~compress:true ~request:req
              (Yojson.Safe.to_string json) reqd
          ) request reqd)
+  |> Http.Router.get "/api/v1/cascade/strategy_trace" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let limit =
+           clamp_history_limit (int_query_param req "limit" ~default:100)
+         in
+         let cascade = query_param req "cascade" in
+         let json =
+           Dashboard_cascade.strategy_trace_json ~limit ?cascade ()
+         in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -13,6 +13,7 @@ module S = Masc_mcp.Cascade_strategy
 module H = Masc_mcp.Cascade_health_tracker
 module C = Masc_mcp.Cascade_client_capacity
 module CH = Masc_mcp.Cascade_client_capacity_history
+module ST = Masc_mcp.Cascade_strategy_trace
 module T = Masc_mcp.Cascade_throttle
 module Cascade_state = Masc_mcp.Cascade_state
 
@@ -702,6 +703,80 @@ let test_history_prometheus_counter_increments () =
   check bool "ollama/rejected_full counter advanced by >= 1"
     true (ollama_rejected >= 1.0)
 
+(* ── Strategy decision trace (LT-5) ─────────────────── *)
+
+let mk_trace_event ?(ts = 0.0) ?(cascade_name = "keeper_unified")
+    ?(strategy = "failover") ?(cycle = 0) ?(candidates_in = 3)
+    ?(candidates_out = 3) ?(backoff_ms = 0) ?(kind = ST.Ordered) () =
+  { ST.ts; cascade_name; strategy; cycle; candidates_in; candidates_out;
+    backoff_ms; kind }
+
+let test_trace_record_snapshot_roundtrip () =
+  ST.clear ();
+  ST.record (mk_trace_event ~ts:1000.0 ~cycle:0 ~kind:ST.Ordered ());
+  ST.record (mk_trace_event ~ts:1001.0 ~cycle:1
+               ~candidates_out:0 ~backoff_ms:500 ~kind:ST.Filtered_empty ());
+  ST.record (mk_trace_event ~ts:1002.0 ~cycle:2
+               ~candidates_out:0 ~kind:ST.Exhausted ());
+  let events = ST.snapshot () in
+  check int "3 events recorded" 3 (List.length events);
+  (match events with
+   | e0 :: e1 :: e2 :: [] ->
+     check (float 0.0) "newest ts" 1002.0 e0.ts;
+     check (float 0.0) "middle ts" 1001.0 e1.ts;
+     check (float 0.0) "oldest ts" 1000.0 e2.ts;
+     check bool "newest kind Exhausted" true (e0.kind = ST.Exhausted);
+     check bool "middle kind Filtered_empty" true (e1.kind = ST.Filtered_empty);
+     check bool "oldest kind Ordered" true (e2.kind = ST.Ordered)
+   | _ -> fail "expected 3 events")
+
+let test_trace_cascade_filter () =
+  ST.clear ();
+  ST.record (mk_trace_event ~cascade_name:"keeper_unified" ~ts:1.0 ());
+  ST.record (mk_trace_event ~cascade_name:"nick0cave" ~ts:2.0 ());
+  ST.record (mk_trace_event ~cascade_name:"keeper_unified" ~ts:3.0 ());
+  let unified = ST.snapshot ~cascade:"keeper_unified" () in
+  check int "keeper_unified → 2 events" 2 (List.length unified);
+  List.iter
+    (fun e -> check string "cascade filter" "keeper_unified" e.ST.cascade_name)
+    unified;
+  let missing = ST.snapshot ~cascade:"does_not_exist" () in
+  check int "missing cascade → empty" 0 (List.length missing)
+
+let test_trace_ring_drops_oldest () =
+  ST.clear ();
+  let cap = ST.capacity () in
+  for i = 0 to cap + 4 do
+    ST.record (mk_trace_event ~ts:(float_of_int i) ~cycle:i ())
+  done;
+  check int "count clamped to capacity" cap (ST.size ());
+  let events = ST.snapshot ~limit:(cap + 10) () in
+  check int "snapshot count = capacity" cap (List.length events);
+  (match events with
+   | newest :: _ ->
+     check (float 0.0) "newest ts = cap+4" (float_of_int (cap + 4)) newest.ts
+   | [] -> fail "expected events");
+  let oldest = List.nth events (cap - 1) in
+  check (float 0.0) "oldest retained ts = 5" 5.0 oldest.ts
+
+let test_trace_limit_clamp () =
+  ST.clear ();
+  for i = 0 to 9 do
+    ST.record (mk_trace_event ~ts:(float_of_int i) ())
+  done;
+  let five = ST.snapshot ~limit:5 () in
+  check int "limit 5" 5 (List.length five);
+  let zero = ST.snapshot ~limit:0 () in
+  check int "limit 0 → empty" 0 (List.length zero);
+  let huge = ST.snapshot ~limit:9999 () in
+  check int "limit>count clamps to count" 10 (List.length huge)
+
+let test_trace_kind_labels () =
+  check string "ordered" "ordered" (ST.kind_to_string ST.Ordered);
+  check string "filtered_empty" "filtered_empty"
+    (ST.kind_to_string ST.Filtered_empty);
+  check string "exhausted" "exhausted" (ST.kind_to_string ST.Exhausted)
+
 let () =
   run "cascade_strategy" [
     "failover", [
@@ -807,5 +882,17 @@ let () =
         test_history_try_acquire_records_events;
       test_case "record bumps Prometheus counter with label" `Quick
         test_history_prometheus_counter_increments;
+    ];
+    "strategy_trace", [
+      test_case "record + snapshot newest-first" `Quick
+        test_trace_record_snapshot_roundtrip;
+      test_case "cascade filter scopes events" `Quick
+        test_trace_cascade_filter;
+      test_case "ring buffer drops oldest" `Quick
+        test_trace_ring_drops_oldest;
+      test_case "limit clamp" `Quick
+        test_trace_limit_clamp;
+      test_case "kind_to_string serialisation" `Quick
+        test_trace_kind_labels;
     ];
   ]


### PR DESCRIPTION
## Summary
Ring-buffered audit of every cascade cycle decision — surfaces *why* the strategy picked / skipped / gave up on this iteration, consumed by a new dashboard card.

## Why
After LT-1 (#7632, TLA+ Phase B Sticky/RR spec) and Phase D (#7624, client capacity) the strategy machinery is formally defined but invisible at runtime. Operators had to tail logs for `cycle 2 filtered all candidates, retrying`. This PR turns that log line into structured state so the dashboard shows the decision timeline next to the TLA+-verified kind.

## Shape
- `lib/cascade/cascade_strategy_trace.ml/.mli` (~110 LOC) — bounded ring buffer, drop-oldest, stdlib Mutex (matches `Cascade_client_capacity_history` pattern). Size from `MASC_STRATEGY_TRACE_SIZE` (default 1024, clamp [16, 65536]).
- `lib/oas_worker_named.ml` — single `record_trace` helper wrapped around the existing `cycle_loop` match; zero behaviour change.
- `lib/dashboard_cascade.ml/.mli` — `strategy_trace_json ?limit ?cascade ()`.
- `lib/server/server_routes_http_routes_cascade.ml` — new `GET /api/v1/cascade/strategy_trace` (reuses limit clamp + query param helpers).
- `dashboard/src/components/cascade-config-panel.ts` — new "Strategy Decisions — cycle 추적" card: cascade, strategy kind, cycle, in/out counts, backoff ms, result chip (ordered / filtered_empty / exhausted).
- `test/test_cascade_strategy.ml` — 5 new alcotest cases. Full suite 47/47 pass.

## Observability
- Complements LT-2 client_capacity_history (#7630) which answers "was the slot full?". This answers "did the strategy skip, and why?".
- `kind="exhausted"` is the unambiguous signal that cascade gave up after `max_cycles`; paired with TLA+ Sticky eviction spec from #7632, dashboard + model are now consistent observables.
- Formally verified (TLA+) + runtime-traceable (this) strategy decisions — the spec → code → dashboard triangle.

## Test plan
- [x] `dune build` clean
- [x] `dune exec test/test_cascade_strategy.exe` → 47/47 pass (incl. 5 new strategy_trace cases)
- [x] `pnpm typecheck` clean
- [x] Rebased on latest main (LT-1/LT-2/LT-4 in flight)
- [ ] Reviewer: confirm record_trace location covers all cycle exit paths (Ordered / Filtered_empty / Exhausted)

Related: #7531 (CDAL gate), #7632 (Phase B TLA+), #7630 (capacity history), #7637 (TLA+ spec index).