### PR TITLE
feat(metrics): Prometheus counter for cascade capacity events

### DIFF
--- a/lib/cascade/cascade_client_capacity_history.ml
+++ b/lib/cascade/cascade_client_capacity_history.ml
@@ -80,13 +80,30 @@ let ensure_initialised_locked () =
     count := 0
   end
 
+let string_of_kind = function
+  | Acquired -> "acquired"
+  | Released -> "released"
+  | Rejected_full -> "rejected_full"
+
+(* Prometheus counter increment happens *outside* the ring mutex so a slow
+   metrics hashtable mutex never blocks cascade acquire paths.  The counter
+   name + labels match the dashboard projection (classify_key) so Grafana
+   queries can join on the same {kind, key_type} tuple. *)
+let bump_prometheus_counter (ev : event) =
+  Prometheus.inc_counter "masc_cascade_capacity_events_total"
+    ~labels:[
+      "kind", string_of_kind ev.kind;
+      "key_type", classify_key ev.key;
+    ] ()
+
 let record ev =
   Mutex.protect mu (fun () ->
       ensure_initialised_locked ();
       let cap = !cap_ref in
       (!buf).(!head) <- Some ev;
       head := (!head + 1) mod cap;
-      if !count < cap then incr count)
+      if !count < cap then incr count);
+  bump_prometheus_counter ev
 
 let clear () =
   Mutex.protect mu (fun () ->

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -633,6 +633,75 @@ let test_history_try_acquire_records_events () =
           "cli:claude_code" a.key
       | _ -> fail "expected 3 events"))
 
+(* ── Prometheus counter coverage (LT-6) ──────────────────
+
+   The counter increment runs outside the ring-buffer mutex and uses the
+   same (kind, key_type) labels as the JSON projection.  We exercise the
+   full surface in-memory by scraping Masc_mcp.Prometheus.to_prometheus_text
+   after a record() call.  The counter value check is >= rather than = so
+   the test is robust to other cases in the suite touching the same metric. *)
+
+let counter_value_from_text text kind key_type =
+  (* Scan lines of the form:
+       masc_cascade_capacity_events_total{kind="acquired",key_type="cli"} 3.0
+     and return the numeric value for the matching label pair.  Returns
+     [None] when the line is missing. *)
+  let target_kind = Printf.sprintf {|kind="%s"|} kind in
+  let target_key  = Printf.sprintf {|key_type="%s"|} key_type in
+  let lines = String.split_on_char '\n' text in
+  let matching =
+    List.filter (fun line ->
+      String.length line > 0
+      && String.length line >= String.length "masc_cascade_capacity_events_total"
+      && String.sub line 0 (String.length "masc_cascade_capacity_events_total")
+         = "masc_cascade_capacity_events_total"
+      && (let has s =
+            let nlen = String.length s in
+            let llen = String.length line in
+            let rec f i =
+              if i + nlen > llen then false
+              else if String.sub line i nlen = s then true
+              else f (i + 1)
+            in f 0
+          in has target_kind && has target_key))
+      lines
+  in
+  match matching with
+  | [] -> None
+  | line :: _ ->
+    (* Last whitespace-separated token is the value. *)
+    let parts = String.split_on_char ' ' line in
+    (match List.rev parts with
+     | v :: _ -> float_of_string_opt (String.trim v)
+     | [] -> None)
+
+let test_history_prometheus_counter_increments () =
+  CH.clear ();
+  let before =
+    counter_value_from_text
+      (Masc_mcp.Prometheus.to_prometheus_text ()) "acquired" "cli"
+    |> Option.value ~default:0.0
+  in
+  CH.record { ts = 1.0; key = "cli:claude_code";
+              kind = Acquired; active_after = 1 };
+  CH.record { ts = 2.0; key = "cli:gemini_cli";
+              kind = Acquired; active_after = 1 };
+  CH.record { ts = 3.0; key = "http://127.0.0.1:11434";
+              kind = Rejected_full; active_after = 1 };
+  let text = Masc_mcp.Prometheus.to_prometheus_text () in
+  let cli_acquired =
+    counter_value_from_text text "acquired" "cli"
+    |> Option.value ~default:0.0
+  in
+  let ollama_rejected =
+    counter_value_from_text text "rejected_full" "ollama"
+    |> Option.value ~default:0.0
+  in
+  check bool "cli/acquired counter advanced by >= 2"
+    true (cli_acquired >= before +. 2.0);
+  check bool "ollama/rejected_full counter advanced by >= 1"
+    true (ollama_rejected >= 1.0)
+
 let () =
   run "cascade_strategy" [
     "failover", [
@@ -736,5 +805,7 @@ let () =
         test_history_snapshot_kind_filter;
       test_case "try_acquire records events on registered URL" `Quick
         test_history_try_acquire_records_events;
+      test_case "record bumps Prometheus counter with label" `Quick
+        test_history_prometheus_counter_increments;
     ];
   ]


### PR DESCRIPTION
## Summary
Surfaces `Cascade_client_capacity_history.record` events in the existing `/metrics` endpoint as a labelled counter, so Grafana / Alertmanager can chart acquisition rates and alert on rejection spikes.

## Metric shape
\`\`\`
masc_cascade_capacity_events_total{kind, key_type}
\`\`\`
- `kind` ∈ `{acquired, released, rejected_full}` — same labels as the JSON projection + LT-2 dashboard card (#7630).
- `key_type` ∈ `{cli, ollama, other}` — via `classify_key` (already a copy in the history module).

## Why
- Phase D (#7624) → current capacity snapshot.
- LT-2 (#7630) → ring-buffered audit log.
- **Neither** surfaces in Grafana/Prometheus; operators could not alert on *"ollama rejection rate > X per minute"* or chart saturation over 24h.

This completes the observability chain: the events that populate the ring buffer now also increment a labelled counter scraped by `/metrics`.

## Implementation
- One `bump_prometheus_counter` helper in `cascade_client_capacity_history`.
- Counter increment runs *outside* the ring mutex so the Prometheus hashtable mutex cannot block cascade acquire paths (worst case: ring is consistent, counter momentarily behind by 1 — eventually consistent).
- No HTTP changes — `/metrics` already forwards every registered metric.

## Test plan
- [x] New alcotest case scrapes `/metrics` text output and asserts counter advanced for the expected `(kind, key_type)` pair. Uses `>=` rather than `=` so it's robust to other tests touching the metric.
- [x] Full `cascade_strategy` suite 43/43 green.
- [x] `dune build` clean.

## Follow-up
Stacks on LT-5 #7643: `masc_cascade_strategy_decisions_total{cascade, strategy, kind}` counter from `Cascade_strategy_trace.record` — same pattern, needs LT-5 in main first.

Related: #7630 (LT-2 capacity history), #7624 (Phase D snapshot), #7643 (LT-5 strategy trace).