### PR TITLE
feat(keeper): strip backward fields from continuity prompt injection

### DIFF
--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -305,6 +305,34 @@ let keeper_state_snapshot_to_summary_text (snapshot : keeper_state_snapshot) : s
   in
   if lines = [] then "No continuity snapshot available." else String.concat "\n" lines
 
+(* RFC-MASC-001 Phase 1 post-mortem (Gen3 2026-04-17):
+   [keeper_state_snapshot_to_summary_text] renders every field for audit/persistence.
+   Injecting it verbatim into the next prompt creates a prose-level echo loop:
+   LLM reads its own past [Done]/[Decisions] narrative and reproduces a
+   near-identical one. Strip backward-looking fields at prompt assembly so the
+   LLM sees only forward-looking context (Goal, Next plan, Next, OpenQuestions,
+   Constraints). Persistence still retains the full summary. *)
+let filter_forward_looking_summary (summary : string) : string =
+  let backward_labels = [ "Done"; "Progress"; "Decisions" ] in
+  let is_backward_line line =
+    let trimmed = String.trim line in
+    List.exists
+      (fun label ->
+        let prefix = label ^ ":" in
+        String.length trimmed >= String.length prefix
+        && String.sub trimmed 0 (String.length prefix) = prefix)
+      backward_labels
+  in
+  let kept =
+    summary
+    |> String.split_on_char '\n'
+    |> List.filter (fun line -> not (is_backward_line line))
+    |> List.filter (fun line -> String.trim line <> "")
+  in
+  match kept with
+  | [] -> ""
+  | _ -> String.concat "\n" kept
+
 let continuity_fallback_summary_text
     ~(continuity_summary : string)
     ~(last_continuity_update_ts : float) : string =

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -289,13 +289,22 @@ let build_prompt ~(meta : Keeper_types.keeper_meta) ~(base_path : string)
     Buffer.add_string ubuf "\n### Autonomous Trigger\n";
     Buffer.add_string ubuf (String.concat "\n" autonomous_trigger);
     Buffer.add_string ubuf "\n");
-  (* 8. Continuity — state across turns *)
+  (* 8. Continuity — state across turns.
+     Inject only forward-looking fields (Goal, Next plan, Next, OpenQuestions,
+     Constraints). Backward-looking fields (Done, Progress, Decisions) are
+     stripped to avoid a prose-level echo loop where the LLM re-reads its own
+     prior narrative and reproduces a near-identical one. The full summary
+     remains persisted in meta.continuity_summary for audit. *)
+  let continuity_for_prompt =
+    Keeper_memory_policy.filter_forward_looking_summary
+      observation.continuity_summary
+  in
   if
-    observation.continuity_summary <> ""
+    continuity_for_prompt <> ""
     && observation.continuity_summary <> "No continuity snapshot available."
   then (
     Buffer.add_string ubuf "\n### Continuity\n";
-    Buffer.add_string ubuf observation.continuity_summary;
+    Buffer.add_string ubuf continuity_for_prompt;
     Buffer.add_string ubuf "\n");
   (* 9. Live worktree delta — actionable change signal *)
   (match observation.worktree_change_summary with

--- a/test/dune
+++ b/test/dune
@@ -695,6 +695,13 @@
  (name test_keeper_state_snapshot_json)
  (libraries masc_test_deps))
 
+; RFC-MASC-001 Phase 1 prose echo guard: prompt-time summary filter
+; strips backward-looking fields (Done, Decisions, Progress) while
+; preserving forward-looking ones (Goal, Next plan, Next, etc.).
+(test
+ (name test_continuity_forward_filter)
+ (libraries masc_test_deps))
+
 ; Keeper_checkpoint_store.is_not_found_detail classifier
 ; regression (observed 334-retry loop on trace-1775487505102-6a347
 ; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)

--- a/test/test_continuity_forward_filter.ml
+++ b/test/test_continuity_forward_filter.ml
@@ -1,0 +1,87 @@
+(** Verify filter_forward_looking_summary strips backward-looking fields
+    (Done, Progress, Decisions) while preserving forward-looking fields
+    (Goal, Next plan, Next, OpenQuestions, Constraints).
+
+    Motivation: RFC-MASC-001 Phase 1 closed the messages-level [STATE]
+    re-parse loop but the structured snapshot is rendered back to prose
+    and re-injected into the next prompt verbatim, causing the LLM to
+    echo its own prior narrative. Prompt assembly filters at injection
+    time; persistence retains the full summary. *)
+
+let full_summary =
+  {|Goal: verify continuity hygiene
+Done: previous turn reported 5.6B+ ep cross-validated across 30/30 episodes
+Next plan: continue observation
+Next: check retro-clean outcome; monitor keeper idle ratio; verify parse path
+Decisions: 119/119 unclaimed tasks deemed trap cycles; autoboot stable
+OpenQuestions: is Phase 2 needed?
+Constraints: MASC_STRUCTURED_STATE=true|}
+
+let test_strips_backward () =
+  let filtered =
+    Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary full_summary
+  in
+  Alcotest.(check bool) "Done removed"
+    false (String.length filtered >= 5 && Astring.String.is_infix ~affix:"Done:" filtered);
+  Alcotest.(check bool) "Decisions removed"
+    false (Astring.String.is_infix ~affix:"Decisions:" filtered);
+  Alcotest.(check bool) "Progress removed (would be if present)"
+    false (Astring.String.is_infix ~affix:"Progress:" filtered)
+
+let test_keeps_forward () =
+  let filtered =
+    Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary full_summary
+  in
+  Alcotest.(check bool) "Goal kept"
+    true (Astring.String.is_infix ~affix:"Goal:" filtered);
+  Alcotest.(check bool) "Next plan kept"
+    true (Astring.String.is_infix ~affix:"Next plan:" filtered);
+  Alcotest.(check bool) "Next kept"
+    true (Astring.String.is_infix ~affix:"Next:" filtered);
+  Alcotest.(check bool) "OpenQuestions kept"
+    true (Astring.String.is_infix ~affix:"OpenQuestions:" filtered);
+  Alcotest.(check bool) "Constraints kept"
+    true (Astring.String.is_infix ~affix:"Constraints:" filtered)
+
+let test_empty_input () =
+  Alcotest.(check string) "empty stays empty"
+    "" (Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary "");
+  Alcotest.(check string) "all-backward becomes empty"
+    "" (Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary
+          "Done: work\nDecisions: choice\nProgress: 50%")
+
+let test_preserves_line_order () =
+  let filtered =
+    Masc_mcp.Keeper_memory_policy.filter_forward_looking_summary full_summary
+  in
+  let lines = String.split_on_char '\n' filtered in
+  (* Goal comes before Next plan which comes before Next in the original. *)
+  let goal_idx =
+    List.find_index
+      (fun l -> Astring.String.is_prefix ~affix:"Goal:" (String.trim l))
+      lines
+  in
+  let next_plan_idx =
+    List.find_index
+      (fun l -> Astring.String.is_prefix ~affix:"Next plan:" (String.trim l))
+      lines
+  in
+  match (goal_idx, next_plan_idx) with
+  | (Some gi, Some npi) ->
+    Alcotest.(check bool) "Goal precedes Next plan" true (gi < npi)
+  | _ ->
+    Alcotest.fail "Expected Goal and Next plan lines to be present"
+
+let () =
+  Alcotest.run "continuity forward filter"
+    [ ( "filter_forward_looking_summary",
+        [ Alcotest.test_case "strips backward-looking fields" `Quick
+            test_strips_backward;
+          Alcotest.test_case "keeps forward-looking fields" `Quick
+            test_keeps_forward;
+          Alcotest.test_case "empty / all-backward → empty" `Quick
+            test_empty_input;
+          Alcotest.test_case "preserves relative line order" `Quick
+            test_preserves_line_order;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Close the prose-level resonance loop that RFC-MASC-001 Phase 1 left open. Gen3 of `/loop 20m` infinite loop work (handoffs: `memory/handoff-2026-04-17-keeper-resonance-gen2-diagnosis.md`).

## Problem

Phase 1 (PR #7612/#7615/#7618) made `cp.working_context` the typed source of truth, closing the `messages`-level `[STATE]` re-parse loop. But `keeper_post_turn.apply_continuity_summary` still renders the structured snapshot back to prose via `keeper_state_snapshot_to_summary_text`, stores it in `meta.continuity_summary`, and `keeper_unified_prompt.ml:294-298` injects that prose into the next prompt verbatim.

The LLM reads its own prior `Done:` / `Decisions:` narrative and reproduces a near-identical one. Gen2 empirical evidence: `analyst.json` continuity regrew 338→1462 chars after retro-clean, carrying the same `"5.6B+ ep cross-validated"` narrative. `last_continuity_update_ts` fresh.

## Change

| File | Change |
|------|--------|
| `lib/keeper/keeper_memory_policy.ml` | Add `filter_forward_looking_summary : string -> string`. Line-based filter strips `Done:`, `Progress:`, `Decisions:` prefixes |
| `lib/keeper/keeper_unified_prompt.ml` | Call filter before injecting continuity into prompt. Persistence (`meta.continuity_summary`) retains the full summary for audit |
| `test/test_continuity_forward_filter.ml` | 4 tests: strip backward, keep forward, empty/all-backward → empty, relative line order preserved |

## What's preserved vs stripped

| Prompt fields | Persistence |
|---------------|-------------|
| **Kept**: Goal, Next plan, Next, OpenQuestions, Constraints | All fields kept (audit trail) |
| **Stripped**: Done, Progress, Decisions | |

## Verification

```
dune build --root .                                → clean
dune exec --root . test/test_continuity_forward_filter.exe
  → 4 tests pass (strip, keep, empty, order)
```

## Non-goals

- Not touching `keeper_state_snapshot_to_summary_text` itself — persistence still writes all fields.
- Not removing `[STATE]` generation from the LLM prompt. That's RFC-MASC-001 Phase 2, larger generation.
- Not registering a `[STATE]`-aware OAS summarizer. That's the orthogonal Option 3 (OAS compaction hygiene) from the Gen2 handoff — still ship-worthy, separate PR.

## Verification plan after merge

1. Run `scripts/retro-clean-keeper-continuity.sh --apply` once.
2. Let keepers run 1-2h.
3. Re-check `analyst.json` continuity_summary — should stay small, with no `Done:`/`Decisions:` prose that would have triggered the old echo.
4. If re-echo still observed, layer in Option 2 (idle-turn skip) as Gen4.