### PR TITLE
feat(metrics): Prometheus counter for cascade strategy decisions

### DIFF
--- a/lib/cascade/cascade_strategy_trace.ml
+++ b/lib/cascade/cascade_strategy_trace.ml
@@ -50,13 +50,26 @@ let ensure_initialised_locked () =
     count := 0
   end
 
+(* Prometheus counter increment happens *outside* the ring mutex so a slow
+   metrics hashtable mutex cannot block cascade strategy paths.  Labels
+   mirror the JSON projection ({cascade, strategy, kind}) so Grafana can
+   join on the same tuple surfaced to the dashboard card. *)
+let bump_prometheus_counter (ev : event) =
+  Prometheus.inc_counter "masc_cascade_strategy_decisions_total"
+    ~labels:[
+      "cascade", ev.cascade_name;
+      "strategy", ev.strategy;
+      "kind", kind_to_string ev.kind;
+    ] ()
+
 let record ev =
   Mutex.protect mu (fun () ->
       ensure_initialised_locked ();
       let cap = !cap_ref in
       (!buf).(!head) <- Some ev;
       head := (!head + 1) mod cap;
-      if !count < cap then incr count)
+      if !count < cap then incr count);
+  bump_prometheus_counter ev
 
 let clear () =
   Mutex.protect mu (fun () ->

--- a/test/test_cascade_strategy.ml
+++ b/test/test_cascade_strategy.ml
@@ -777,6 +777,72 @@ let test_trace_kind_labels () =
     (ST.kind_to_string ST.Filtered_empty);
   check string "exhausted" "exhausted" (ST.kind_to_string ST.Exhausted)
 
+(* ── Prometheus counter coverage (LT-7) ────────────────── *)
+
+let find_strategy_counter_value text ~cascade ~strategy ~kind =
+  let target_cascade = Printf.sprintf {|cascade="%s"|} cascade in
+  let target_strategy = Printf.sprintf {|strategy="%s"|} strategy in
+  let target_kind = Printf.sprintf {|kind="%s"|} kind in
+  let prefix = "masc_cascade_strategy_decisions_total" in
+  let plen = String.length prefix in
+  let has haystack needle =
+    let nlen = String.length needle in
+    let hlen = String.length haystack in
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in loop 0
+  in
+  let lines = String.split_on_char '\n' text in
+  let matching =
+    List.filter (fun line ->
+      String.length line >= plen
+      && String.sub line 0 plen = prefix
+      && has line target_cascade
+      && has line target_strategy
+      && has line target_kind)
+      lines
+  in
+  match matching with
+  | [] -> None
+  | line :: _ ->
+    (match List.rev (String.split_on_char ' ' line) with
+     | v :: _ -> float_of_string_opt (String.trim v)
+     | [] -> None)
+
+let test_trace_prometheus_counter_increments () =
+  ST.clear ();
+  let before =
+    find_strategy_counter_value
+      (Masc_mcp.Prometheus.to_prometheus_text ())
+      ~cascade:"keeper_unified" ~strategy:"failover" ~kind:"ordered"
+    |> Option.value ~default:0.0
+  in
+  ST.record (mk_trace_event ~cascade_name:"keeper_unified"
+               ~strategy:"failover" ~kind:ST.Ordered ());
+  ST.record (mk_trace_event ~cascade_name:"keeper_unified"
+               ~strategy:"failover" ~kind:ST.Ordered ());
+  ST.record (mk_trace_event ~cascade_name:"nick0cave"
+               ~strategy:"circuit_breaker_cycling"
+               ~kind:ST.Filtered_empty ~backoff_ms:500 ());
+  let text = Masc_mcp.Prometheus.to_prometheus_text () in
+  let ordered =
+    find_strategy_counter_value text
+      ~cascade:"keeper_unified" ~strategy:"failover" ~kind:"ordered"
+    |> Option.value ~default:0.0
+  in
+  let filtered =
+    find_strategy_counter_value text
+      ~cascade:"nick0cave" ~strategy:"circuit_breaker_cycling"
+      ~kind:"filtered_empty"
+    |> Option.value ~default:0.0
+  in
+  check bool "keeper_unified/failover/ordered advanced by >= 2"
+    true (ordered >= before +. 2.0);
+  check bool "nick0cave/circuit_breaker_cycling/filtered_empty >= 1"
+    true (filtered >= 1.0)
+
 let () =
   run "cascade_strategy" [
     "failover", [
@@ -894,5 +960,7 @@ let () =
         test_trace_limit_clamp;
       test_case "kind_to_string serialisation" `Quick
         test_trace_kind_labels;
+      test_case "record bumps Prometheus counter with labels" `Quick
+        test_trace_prometheus_counter_increments;
     ];
   ]


### PR DESCRIPTION
## Summary
Completes the 5-surface observability loop for cascade strategy decisions. Stacks on LT-5 (#7643): when that merges, this PR rebases to main and diff reduces to the single record() wiring + one alcotest case.

## Metric shape
\`\`\`
masc_cascade_strategy_decisions_total{cascade, strategy, kind}
\`\`\`
- `cascade` — e.g. `keeper_unified`
- `strategy` — `failover` | `capacity_aware` | `weighted_random` | `circuit_breaker_cycling` | `priority_tier` | `sticky` | `round_robin`
- `kind` — `ordered` | `filtered_empty` | `exhausted`

## Why
- LT-5 (#7643) added ring-buffer events + dashboard card.
- LT-6 (#7645) surfaced *capacity* events in Prometheus.
- This closes the loop: **strategy** events also reach Grafana/Alertmanager.

## 5-surface loop
1. snapshot JSON (LT-5) → current cascade state
2. ring-buffer JSON (LT-5) → recent decisions
3. dashboard card (LT-5) → operator view
4. **Prometheus counter (this PR)** → Grafana/Alertmanager
5. TLA+ spec (Phase B Sticky/RR, #7632) → formal correctness

## Implementation
- Same pattern as LT-6: `bump_prometheus_counter` outside ring mutex, labels mirror JSON projection.
- Eventually consistent — worst case ring is committed, counter lags by 1 event.

## Test plan
- [x] New alcotest scrapes `/metrics` + asserts counter advancement
- [x] Full `cascade_strategy` suite 48/48 green
- [x] `dune build` clean
- [ ] Reviewer: confirm label cardinality acceptable (cascade names × strategies × kinds = bounded)

Related: #7643 (base), #7645 (sister PR), #7632 (TLA+ Phase B), #7630 (capacity history).