### PR TITLE
feat(dashboard): verification status filter

### DIFF
--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -1,0 +1,172 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { cleanup, render, screen, fireEvent } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  VerificationRequest,
+  VerificationRequestsResponse,
+} from '../api/dashboard'
+
+// ── Mock async-state ──────────────────────────────────
+
+const mockState = signal({
+  loading: false,
+  error: null as string | null,
+  data: null as VerificationRequestsResponse | null,
+})
+
+vi.mock('../lib/async-state', () => ({
+  createManagedAsyncResource: () => ({
+    state: mockState,
+    load: vi.fn(),
+    cancel: vi.fn(),
+  }),
+}))
+
+// ── Mock API ──────────────────────────────────────────
+
+vi.mock('../api/dashboard', () => ({
+  fetchVerificationRequests: vi.fn(),
+}))
+
+// ── Mock UI primitives (real Preact components) ───────
+
+vi.mock('./common/card', () => ({
+  Card: ({ title, children }: any) => html`
+    <div data-testid="card"><h3>${title}</h3>${children}</div>
+  `,
+}))
+
+vi.mock('./common/empty-state', () => ({
+  EmptyState: ({ children }: any) => html`
+    <div data-testid="empty-state">${children}</div>
+  `,
+}))
+
+vi.mock('./common/feedback-state', () => ({
+  ErrorState: ({ message }: any) => html`
+    <div data-testid="error-state">${message}</div>
+  `,
+  LoadingState: ({ children }: any) => html`
+    <div data-testid="loading-state">${children}</div>
+  `,
+}))
+
+vi.mock('./common/status-chip', () => ({
+  StatusChip: ({ tone, children }: any) => html`
+    <span data-testid="status-chip" data-tone=${tone}>${children}</span>
+  `,
+}))
+
+// ── Import after mocks ────────────────────────────────
+
+import { VerificationRequestsPanel } from './verification-requests-panel'
+
+function makeRequest(overrides: Partial<VerificationRequest> = {}): VerificationRequest {
+  return {
+    request_id: 'req-001',
+    task_id: 'task-001',
+    keeper: null,
+    status: 'pending',
+    created_at: new Date().toISOString(),
+    submitted_by: 'agent-a',
+    approved_by: null,
+    completion_contract: [],
+    required_evidence: [],
+    verdict: null,
+    verdict_reason: '',
+    ...overrides,
+  }
+}
+
+function setData(requests: VerificationRequest[]) {
+  mockState.value = {
+    loading: false,
+    error: null,
+    data: {
+      updated_at: new Date().toISOString(),
+      total: requests.length,
+      requests,
+    },
+  }
+}
+
+describe('VerificationRequestsPanel', () => {
+  beforeEach(() => {
+    mockState.value = { loading: false, error: null, data: null }
+  })
+  afterEach(() => cleanup())
+
+  it('shows loading state when no data and loading', () => {
+    mockState.value = { loading: true, error: null, data: null }
+    render(html`<${VerificationRequestsPanel} />`)
+    expect(screen.getByTestId('loading-state')).toBeTruthy()
+  })
+
+  it('shows empty state when no requests exist', () => {
+    setData([])
+    render(html`<${VerificationRequestsPanel} />`)
+    expect(screen.getByTestId('empty-state')).toBeTruthy()
+  })
+
+  it('renders filter buttons for all statuses', () => {
+    setData([makeRequest()])
+    render(html`<${VerificationRequestsPanel} />`)
+    // Filter buttons always present; table content may duplicate labels
+    expect(screen.getAllByText('전체').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('검증 대기').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('승인').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('반려').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('시간 초과').length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows total count in all filter mode', () => {
+    setData([makeRequest(), makeRequest({ request_id: 'req-002', status: 'approved' })])
+    render(html`<${VerificationRequestsPanel} />`)
+    expect(screen.getByText('총 2건')).toBeTruthy()
+  })
+
+  it('filters by pending status', () => {
+    const pending = makeRequest({ request_id: 'req-p', status: 'pending' })
+    const approved = makeRequest({ request_id: 'req-a', status: 'approved' })
+    setData([pending, approved])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    // Filter button is the first element with "검증 대기" text
+    const pendingButtons = screen.getAllByText('검증 대기')
+    fireEvent.click(pendingButtons[0])
+    const card = screen.getByTestId('card')
+    expect(card.innerHTML).toContain('req-p')
+    expect(card.innerHTML).not.toContain('req-a')
+    expect(screen.getByText('1 / 2건')).toBeTruthy()
+  })
+
+  it('filters by approved status', () => {
+    const pending = makeRequest({ request_id: 'req-p', status: 'pending' })
+    const approved = makeRequest({ request_id: 'req-a', status: 'approved' })
+    setData([pending, approved])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    const approvedButtons = screen.getAllByText('승인')
+    fireEvent.click(approvedButtons[0])
+    const card = screen.getByTestId('card')
+    expect(card.innerHTML).toContain('req-a')
+    expect(card.innerHTML).not.toContain('req-p')
+  })
+
+  it('shows filter-specific empty state when no matches', () => {
+    setData([makeRequest({ status: 'approved' })])
+    render(html`<${VerificationRequestsPanel} />`)
+
+    const rejectedButtons = screen.getAllByText('반려')
+    fireEvent.click(rejectedButtons[0])
+    expect(screen.getByTestId('empty-state')).toBeTruthy()
+  })
+
+  it('shows error state', () => {
+    mockState.value = { loading: false, error: 'Network error', data: null }
+    render(html`<${VerificationRequestsPanel} />`)
+    expect(screen.getByTestId('error-state')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -135,7 +135,7 @@ describe('VerificationRequestsPanel', () => {
 
     // Filter button is the first element with "검증 대기" text
     const pendingButtons = screen.getAllByText('검증 대기')
-    fireEvent.click(pendingButtons[0])
+    fireEvent.click(pendingButtons[0]!)
     const card = screen.getByTestId('card')
     expect(card.innerHTML).toContain('req-p')
     expect(card.innerHTML).not.toContain('req-a')
@@ -149,7 +149,7 @@ describe('VerificationRequestsPanel', () => {
     render(html`<${VerificationRequestsPanel} />`)
 
     const approvedButtons = screen.getAllByText('승인')
-    fireEvent.click(approvedButtons[0])
+    fireEvent.click(approvedButtons[0]!)
     const card = screen.getByTestId('card')
     expect(card.innerHTML).toContain('req-a')
     expect(card.innerHTML).not.toContain('req-p')
@@ -160,7 +160,7 @@ describe('VerificationRequestsPanel', () => {
     render(html`<${VerificationRequestsPanel} />`)
 
     const rejectedButtons = screen.getAllByText('반려')
-    fireEvent.click(rejectedButtons[0])
+    fireEvent.click(rejectedButtons[0]!)
     expect(screen.getByTestId('empty-state')).toBeTruthy()
   })
 

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -10,6 +10,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
+import { signal } from '@preact/signals'
 import {
   fetchVerificationRequests,
   type VerificationRequest,
@@ -28,6 +29,18 @@ import {
 
 const AUTO_REFRESH_MS = 15_000
 const DEFAULT_LIMIT = 100
+
+type StatusFilter = VerificationRequestStatus | 'all'
+
+const statusFilter = signal<StatusFilter>('all')
+
+const FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: 'pending', label: '검증 대기' },
+  { value: 'approved', label: '승인' },
+  { value: 'rejected', label: '반려' },
+  { value: 'timed_out', label: '시간 초과' },
+]
 
 async function loadData(
   resource: ManagedAsyncResource<VerificationRequestsResponse>,
@@ -187,11 +200,13 @@ function VerificationRow({ row }: { row: VerificationRequest }) {
 
 // ── Table ─────────────────────────────────────────────
 
-function RequestsTable({ data }: { data: VerificationRequestsResponse }) {
-  if (data.requests.length === 0) {
+function RequestsTable({ requests }: { requests: VerificationRequest[] }) {
+  if (requests.length === 0) {
     return html`
       <${EmptyState}>
-        현재 대기중이거나 완료된 검증 요청이 없습니다.
+        ${statusFilter.value === 'all'
+          ? '현재 대기중이거나 완료된 검증 요청이 없습니다.'
+          : `"${STATUS_LABEL[statusFilter.value as VerificationRequestStatus]}" 상태의 요청이 없습니다.`}
       <//>
     `
   }
@@ -211,7 +226,7 @@ function RequestsTable({ data }: { data: VerificationRequestsResponse }) {
           </tr>
         </thead>
         <tbody>
-          ${data.requests.map(
+          ${requests.map(
             (row) => html`<${VerificationRow} key=${row.request_id} row=${row} />`,
           )}
         </tbody>
@@ -242,6 +257,11 @@ export function VerificationRequestsPanel() {
 
   const current = resource.state.value
   const data = current.data ?? null
+  const filtered = data
+    ? statusFilter.value === 'all'
+      ? data.requests
+      : data.requests.filter((r) => r.status === statusFilter.value)
+    : []
 
   return html`
     <div class="flex flex-col gap-4">
@@ -262,9 +282,24 @@ export function VerificationRequestsPanel() {
           : null}
         ${data
           ? html`<span class="text-xs text-[var(--text-muted)]">
-              총 ${data.total}건
+              ${statusFilter.value === 'all'
+                ? `총 ${data.total}건`
+                : `${filtered.length} / ${data.total}건`}
             </span>`
           : null}
+      </div>
+
+      <div class="flex items-center gap-1.5 flex-wrap">
+        ${FILTER_OPTIONS.map((opt) => html`
+          <button
+            class=${`rounded px-2 py-0.5 text-[11px] border transition-colors ${
+              statusFilter.value === opt.value
+                ? 'bg-[var(--text-strong)] text-[var(--bg-0)] border-[var(--text-strong)]'
+                : 'bg-[var(--bg-0)] text-[var(--text-muted)] border-[var(--card-border)] hover:text-[var(--text-body)]'
+            }`}
+            onClick=${() => { statusFilter.value = opt.value }}
+          >${opt.label}</button>
+        `)}
       </div>
 
       ${current.error ? html`<${ErrorState} message=${current.error} />` : null}
@@ -274,7 +309,7 @@ export function VerificationRequestsPanel() {
         : null}
 
       <${Card} title="검증 요청">
-        ${data ? html`<${RequestsTable} data=${data} />` : null}
+        ${data ? html`<${RequestsTable} requests=${filtered} />` : null}
       <//>
     </div>
   `


### PR DESCRIPTION
## Summary
- Add client-side status filter buttons (전체/검증 대기/승인/반려/시간 초과) to the verification requests panel
- Uses Preact signal for reactive filtering — no re-fetch needed
- Shows filtered count alongside total (e.g., "3 / 47건")
- Empty state message adapts to selected filter

## Test plan
- [ ] Open dashboard → workspace → 검증 tab
- [ ] Verify filter buttons render and toggle correctly
- [ ] Verify table filters by status in real-time
- [ ] Verify count updates (filtered / total)
- [ ] Verify empty state message changes per filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)