### PR TITLE
feat(dashboard): verification specs category filter + search

### DIFF
--- a/dashboard/src/components/verification-specs-panel.test.ts
+++ b/dashboard/src/components/verification-specs-panel.test.ts
@@ -1,0 +1,202 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { cleanup, render, screen, fireEvent } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  TlaSpecEntry,
+  TlaSpecsResponse,
+} from '../api/dashboard'
+
+// ── Mock async-state ──────────────────────────────────
+
+const mockState = signal({
+  loading: false,
+  error: null as string | null,
+  data: null as TlaSpecsResponse | null,
+})
+
+vi.mock('../lib/async-state', () => ({
+  createManagedAsyncResource: () => ({
+    state: mockState,
+    load: vi.fn(),
+    cancel: vi.fn(),
+  }),
+}))
+
+// ── Mock API ──────────────────────────────────────────
+
+vi.mock('../api/dashboard', () => ({
+  fetchTlaSpecs: vi.fn(),
+}))
+
+// ── Mock UI primitives ────────────────────────────────
+
+vi.mock('./common/card', () => ({
+  Card: ({ title, children }: any) => html`
+    <div data-testid="card"><h3>${title}</h3>${children}</div>
+  `,
+}))
+
+vi.mock('./common/empty-state', () => ({
+  EmptyState: ({ message }: any) => html`
+    <div data-testid="empty-state">${message}</div>
+  `,
+}))
+
+vi.mock('./common/feedback-state', () => ({
+  ErrorState: ({ message }: any) => html`
+    <div data-testid="error-state">${message}</div>
+  `,
+  LoadingState: ({ children }: any) => html`
+    <div data-testid="loading-state">${children}</div>
+  `,
+}))
+
+vi.mock('./common/status-chip', () => ({
+  StatusChip: ({ tone, label, children }: any) => html`
+    <span data-testid="status-chip" data-tone=${tone}>${label ?? children}</span>
+  `,
+}))
+
+vi.mock('./common/filter-chips', () => ({
+  FilterChips: ({ chips, active }: any) => html`
+    <div data-testid="filter-chips">
+      ${chips.map((chip: any) => html`
+        <button
+          key=${chip.key}
+          data-testid="filter-chip-${chip.key}"
+          data-active=${active?.value === chip.key}
+          onClick=${() => { if (active) active.value = chip.key }}
+        >${chip.label} (${chip.count ?? ''})</button>
+      `)}
+    </div>
+  `,
+}))
+
+vi.mock('./common/input', () => ({
+  TextInput: ({ value, onInput, placeholder }: any) => html`
+    <input
+      data-testid="search-input"
+      value=${value}
+      placeholder=${placeholder}
+      onInput=${onInput}
+    />
+  `,
+}))
+
+// ── Import after mocks ────────────────────────────────
+
+import { VerificationSpecsPanel } from './verification-specs-panel'
+
+function makeEntry(overrides: Partial<TlaSpecEntry> = {}): TlaSpecEntry {
+  return {
+    name: 'KeeperOAS.tla',
+    path: 'spec/keeper/KeeperOAS.tla',
+    category: 'boundary',
+    has_clean_cfg: true,
+    has_buggy_cfg: true,
+    mtime_iso: '2026-04-15T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function setData(entries: TlaSpecEntry[]) {
+  mockState.value = {
+    loading: false,
+    error: null,
+    data: {
+      updated_at: '2026-04-16T00:00:00Z',
+      specs_dir: '/specs',
+      count: entries.length,
+      entries,
+    },
+  }
+}
+
+describe('VerificationSpecsPanel', () => {
+  beforeEach(() => {
+    mockState.value = { loading: false, error: null, data: null }
+  })
+  afterEach(() => cleanup())
+
+  it('shows loading state when no data and loading', () => {
+    mockState.value = { loading: true, error: null, data: null }
+    render(html`<${VerificationSpecsPanel} />`)
+    expect(screen.getByTestId('loading-state')).toBeTruthy()
+  })
+
+  it('shows empty state when no specs exist', () => {
+    setData([])
+    render(html`<${VerificationSpecsPanel} />`)
+    expect(screen.getByTestId('empty-state')).toBeTruthy()
+  })
+
+  it('renders spec table with entries', () => {
+    setData([makeEntry()])
+    render(html`<${VerificationSpecsPanel} />`)
+    const card = screen.getByTestId('card')
+    expect(card.innerHTML).toContain('KeeperOAS.tla')
+  })
+
+  it('renders filter chips with counts', () => {
+    setData([
+      makeEntry({ name: 'a.tla', category: 'boundary' }),
+      makeEntry({ name: 'b.tla', category: 'bug-models' }),
+      makeEntry({ name: 'c.tla', category: 'other' }),
+    ])
+    render(html`<${VerificationSpecsPanel} />`)
+    expect(screen.getByTestId('filter-chips')).toBeTruthy()
+    const allChip = screen.getByTestId('filter-chip-all')
+    expect(allChip.textContent).toContain('3')
+  })
+
+  it('shows total count in all filter mode', () => {
+    setData([
+      makeEntry({ name: 'a.tla' }),
+      makeEntry({ name: 'b.tla', category: 'bug-models' }),
+    ])
+    render(html`<${VerificationSpecsPanel} />`)
+    expect(screen.getByText('총 2건')).toBeTruthy()
+  })
+
+  it('shows filtered count when filter is active', () => {
+    setData([
+      makeEntry({ name: 'a.tla', category: 'boundary' }),
+      makeEntry({ name: 'b.tla', category: 'bug-models' }),
+    ])
+    render(html`<${VerificationSpecsPanel} />`)
+
+    const bugChip = screen.getByTestId('filter-chip-bug-models')
+    fireEvent.click(bugChip)
+    expect(screen.getByText('1 / 2건')).toBeTruthy()
+  })
+
+  it('filters by category', () => {
+    const boundary = makeEntry({ name: 'boundary-spec.tla', category: 'boundary' })
+    const bugModel = makeEntry({ name: 'bug-spec.tla', category: 'bug-models' })
+    setData([boundary, bugModel])
+    render(html`<${VerificationSpecsPanel} />`)
+
+    const bugChip = screen.getByTestId('filter-chip-bug-models')
+    fireEvent.click(bugChip)
+    const card = screen.getByTestId('card')
+    expect(card.innerHTML).toContain('bug-spec.tla')
+    expect(card.innerHTML).not.toContain('boundary-spec.tla')
+  })
+
+  it('shows filter-specific empty state when no matches', () => {
+    setData([makeEntry({ category: 'boundary' })])
+    render(html`<${VerificationSpecsPanel} />`)
+
+    const bugChip = screen.getByTestId('filter-chip-bug-models')
+    fireEvent.click(bugChip)
+    expect(screen.getByTestId('empty-state')).toBeTruthy()
+  })
+
+  it('shows error state', () => {
+    mockState.value = { loading: false, error: 'Network error', data: null }
+    render(html`<${VerificationSpecsPanel} />`)
+    expect(screen.getByTestId('error-state')).toBeTruthy()
+  })
+})

--- a/dashboard/src/components/verification-specs-panel.ts
+++ b/dashboard/src/components/verification-specs-panel.ts
@@ -9,9 +9,11 @@
 // cascade-config-panel.ts.
 
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import {
   fetchTlaSpecs,
+  type TlaSpecCategory,
   type TlaSpecEntry,
   type TlaSpecsResponse,
 } from '../api/dashboard'
@@ -19,7 +21,13 @@ import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { StatusChip } from './common/status-chip'
+import { FilterChips } from './common/filter-chips'
+import { TextInput } from './common/input'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
+
+type CategoryFilter = 'all' | TlaSpecCategory
+const categoryFilter = signal<CategoryFilter>('all')
+const searchQuery = signal('')
 
 async function loadSpecs(resource: ManagedAsyncResource<TlaSpecsResponse>) {
   await resource.load(async (signal) => fetchTlaSpecs({ signal }))
@@ -115,9 +123,21 @@ export function VerificationSpecsPanel() {
 
   const current = resource.state.value
   const data = current.data
-  const boundaryCount = data?.entries.filter((e: TlaSpecEntry) => e.category === 'boundary').length ?? 0
-  const bugModelCount = data?.entries.filter((e: TlaSpecEntry) => e.category === 'bug-models').length ?? 0
   const dirLabel = data?.specs_dir ?? '(not found)'
+
+  const allEntries = data?.entries ?? []
+  const filtered = allEntries.filter((e: TlaSpecEntry) => {
+    if (categoryFilter.value !== 'all' && e.category !== categoryFilter.value) return false
+    if (searchQuery.value) {
+      const q = searchQuery.value.toLowerCase()
+      if (!e.name.toLowerCase().includes(q) && !e.path.toLowerCase().includes(q)) return false
+    }
+    return true
+  })
+
+  const boundaryCount = allEntries.filter((e: TlaSpecEntry) => e.category === 'boundary').length
+  const bugModelCount = allEntries.filter((e: TlaSpecEntry) => e.category === 'bug-models').length
+  const otherCount = allEntries.filter((e: TlaSpecEntry) => e.category === 'other').length
 
   return html`
     <div class="flex flex-col gap-4">
@@ -132,6 +152,36 @@ export function VerificationSpecsPanel() {
         ${data?.updated_at
           ? html`<span class="text-xs text-[var(--text-muted)]">specs · ${data.updated_at}</span>`
           : null}
+        ${data
+          ? html`<span class="text-xs text-[var(--text-muted)]">
+              ${categoryFilter.value === 'all' && !searchQuery.value
+                ? `총 ${data.count}건`
+                : `${filtered.length} / ${data.count}건`}
+            </span>`
+          : null}
+      </div>
+
+      <div class="flex flex-wrap gap-3 items-center">
+        <${FilterChips}
+          chips=${[
+            { key: 'all' as CategoryFilter, label: '전체', count: allEntries.length },
+            { key: 'boundary' as CategoryFilter, label: '경계', count: boundaryCount },
+            { key: 'bug-models' as CategoryFilter, label: '버그 모델', count: bugModelCount },
+            { key: 'other' as CategoryFilter, label: '기타', count: otherCount },
+          ]}
+          active=${categoryFilter}
+          size="sm"
+          tone="accent"
+        />
+        <${TextInput}
+          class="max-w-[200px]"
+          name="spec_search"
+          ariaLabel="스펙 검색"
+          autoComplete="off"
+          placeholder="스펙 이름 검색..."
+          value=${searchQuery.value}
+          onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+        />
       </div>
 
       ${current.error ? html`<${ErrorState} message=${current.error} />` : null}
@@ -142,12 +192,13 @@ export function VerificationSpecsPanel() {
 
       <${Card} title="Formal Specs">
         <div class="mb-2 text-xs text-slate-400">
-          ${data?.count ?? 0} specs · boundary ${boundaryCount} · bug-models ${bugModelCount}
-          · <span class="font-mono">${dirLabel}</span>
+          <span class="font-mono">${dirLabel}</span>
         </div>
-        ${!data || data.entries.length === 0
-          ? html`<${EmptyState} message="TLA+ 스펙을 찾지 못했습니다 (MASC_SPECS_DIR 확인)" />`
-          : html`<${SpecsTable} entries=${data.entries} />`}
+        ${filtered.length === 0
+          ? html`<${EmptyState} message=${categoryFilter.value === 'all' && !searchQuery.value
+              ? 'TLA+ 스펙을 찾지 못했습니다 (MASC_SPECS_DIR 확인)'
+              : '조건에 맞는 스펙이 없습니다.'} />`
+          : html`<${SpecsTable} entries=${filtered} />`}
       <//>
     </div>
   `


### PR DESCRIPTION
## Summary
- Add FilterChips-based category filter (all/boundary/bug-models/other) to TLA+ specs panel
- Add TextInput search by spec name/path
- Show filtered count when filter active, filter-specific empty state when no matches
- 9 unit tests for the new functionality

## Test plan
- [x] 9 vitest tests pass (loading, empty, entries, filter chips, count, filter by category, filter empty, error)
- [ ] CI Dashboard job passes
- [ ] Manual: open Workspace > Verification > Formal Specs, verify filter and search work

🤖 Generated with [Claude Code](https://claude.com/claude-code)