### PR TITLE
feat(dashboard): prometheus metrics search + tests

### DIFF
--- a/dashboard/src/components/prometheus-metrics.test.ts
+++ b/dashboard/src/components/prometheus-metrics.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parsePrometheusText,
+  categorize,
+  metricMatchesSearch,
+} from './prometheus-metrics'
+
+const SAMPLE = `# HELP masc_uptime_seconds Server uptime in seconds
+# TYPE masc_uptime_seconds gauge
+masc_uptime_seconds 12345.6
+# HELP masc_agent_heartbeat_age_seconds Age of last agent heartbeat
+# TYPE masc_agent_heartbeat_age_seconds gauge
+masc_agent_heartbeat_age_seconds{keeper="janitor"} 5.2
+masc_agent_heartbeat_age_seconds{keeper="guardian"} 120.0
+# HELP masc_keeper_compaction_total Total compaction events
+# TYPE masc_keeper_compaction_total counter
+masc_keeper_compaction_total{keeper="janitor"} 42
+# HELP masc_inference_duration_seconds LLM inference duration
+# TYPE masc_inference_duration_seconds summary
+masc_inference_duration_seconds{quantile="0.5"} 1.23
+masc_inference_duration_seconds{quantile="0.99"} 5.67
+# HELP masc_sse_connections Current SSE connections
+# TYPE masc_sse_connections gauge
+masc_sse_connections 3
+`
+
+describe('parsePrometheusText', () => {
+  it('parses HELP + TYPE + sample lines', () => {
+    const metrics = parsePrometheusText(SAMPLE)
+    expect(metrics.length).toBe(5)
+
+    const uptime = metrics.find(m => m.name === 'masc_uptime_seconds')!
+    expect(uptime.help).toBe('Server uptime in seconds')
+    expect(uptime.type).toBe('gauge')
+    expect(uptime.samples.length).toBe(1)
+    expect(uptime.samples[0]!.value).toBe(12345.6)
+  })
+
+  it('parses labels from samples', () => {
+    const metrics = parsePrometheusText(SAMPLE)
+    const heartbeat = metrics.find(m => m.name === 'masc_agent_heartbeat_age_seconds')!
+    expect(heartbeat.samples.length).toBe(2)
+    expect(heartbeat.samples[0]!.labels).toEqual({ keeper: 'janitor' })
+    expect(heartbeat.samples[1]!.labels).toEqual({ keeper: 'guardian' })
+  })
+
+  it('handles empty input', () => {
+    expect(parsePrometheusText('')).toEqual([])
+    expect(parsePrometheusText('# only comments')).toEqual([])
+  })
+})
+
+describe('categorize', () => {
+  it('classifies keeper metrics', () => {
+    expect(categorize('masc_keeper_compaction_total')).toBe('keeper')
+  })
+
+  it('classifies agent metrics', () => {
+    expect(categorize('masc_agent_heartbeat_age_seconds')).toBe('agent')
+  })
+
+  it('classifies transport metrics', () => {
+    expect(categorize('masc_sse_connections')).toBe('transport')
+    expect(categorize('masc_grpc_requests')).toBe('transport')
+  })
+
+  it('classifies inference metrics', () => {
+    expect(categorize('masc_inference_duration_seconds')).toBe('inference')
+    expect(categorize('masc_llm_tokens')).toBe('inference')
+  })
+
+  it('classifies tool metrics', () => {
+    expect(categorize('masc_tool_call_duration_seconds')).toBe('tool')
+  })
+
+  it('classifies server metrics', () => {
+    expect(categorize('masc_uptime_seconds')).toBe('server')
+    expect(categorize('masc_errors_total')).toBe('server')
+  })
+
+  it('classifies unknown as other', () => {
+    expect(categorize('masc_custom_metric')).toBe('other')
+  })
+})
+
+describe('metricMatchesSearch', () => {
+  const metrics = parsePrometheusText(SAMPLE)
+
+  it('matches by metric name', () => {
+    const heartbeat = metrics.find(m => m.name === 'masc_agent_heartbeat_age_seconds')!
+    expect(metricMatchesSearch(heartbeat, 'heartbeat')).toBe(true)
+    expect(metricMatchesSearch(heartbeat, 'HEARTBEAT')).toBe(true)
+  })
+
+  it('matches by help text', () => {
+    const uptime = metrics.find(m => m.name === 'masc_uptime_seconds')!
+    expect(metricMatchesSearch(uptime, 'uptime')).toBe(true)
+  })
+
+  it('matches by label value', () => {
+    const heartbeat = metrics.find(m => m.name === 'masc_agent_heartbeat_age_seconds')!
+    expect(metricMatchesSearch(heartbeat, 'janitor')).toBe(true)
+    expect(metricMatchesSearch(heartbeat, 'guardian')).toBe(true)
+  })
+
+  it('returns false for non-matching query', () => {
+    const uptime = metrics.find(m => m.name === 'masc_uptime_seconds')!
+    expect(metricMatchesSearch(uptime, 'nonexistent')).toBe(false)
+  })
+
+  it('matches by sample name', () => {
+    const inference = metrics.find(m => m.name === 'masc_inference_duration_seconds')!
+    expect(metricMatchesSearch(inference, 'inference')).toBe(true)
+  })
+
+  it('matches by quantile label value', () => {
+    const inference = metrics.find(m => m.name === 'masc_inference_duration_seconds')!
+    expect(metricMatchesSearch(inference, '0.99')).toBe(true)
+  })
+})

--- a/dashboard/src/components/prometheus-metrics.ts
+++ b/dashboard/src/components/prometheus-metrics.ts
@@ -7,6 +7,7 @@ import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { TextInput } from './common/input'
 import { fetchWithTimeout, authHeaders } from '../api/core'
 import { navigate } from '../router'
 
@@ -25,7 +26,7 @@ interface MetricSample {
   value: number
 }
 
-function parsePrometheusText(text: string): ParsedMetric[] {
+export function parsePrometheusText(text: string): ParsedMetric[] {
   const metrics: ParsedMetric[] = []
   const lines = text.split('\n')
   let current: ParsedMetric | null = null
@@ -103,7 +104,7 @@ function parseLabels(raw: string): Record<string, string> {
 
 type MetricCategory = 'server' | 'agent' | 'keeper' | 'transport' | 'inference' | 'tool' | 'delta' | 'provider' | 'other'
 
-function categorize(name: string): MetricCategory {
+export function categorize(name: string): MetricCategory {
   if (name.startsWith('masc_keeper_')) return 'keeper'
   if (name.startsWith('masc_agent_')) return 'agent'
   if (name.startsWith('masc_sse_') || name.startsWith('masc_grpc_') || name.startsWith('masc_ws_')) return 'transport'
@@ -198,6 +199,18 @@ async function fetchPrometheusText(signal?: AbortSignal): Promise<string> {
   return res.text()
 }
 
+// --- Search helpers ---
+
+export function metricMatchesSearch(m: ParsedMetric, q: string): boolean {
+  const lower = q.toLowerCase()
+  if (m.name.toLowerCase().includes(lower)) return true
+  if (m.help.toLowerCase().includes(lower)) return true
+  return m.samples.some(s =>
+    s.name.toLowerCase().includes(lower) ||
+    Object.values(s.labels).some(v => v.toLowerCase().includes(lower)),
+  )
+}
+
 // --- Component ---
 
 export function PrometheusMetrics() {
@@ -205,6 +218,7 @@ export function PrometheusMetrics() {
   const error = useSignal<string | null>(null)
   const metrics = useSignal<ParsedMetric[]>([])
   const lastUpdated = useSignal<string | null>(null)
+  const searchQuery = useSignal('')
   const expandedCategories = useSignal<Set<MetricCategory>>(new Set(['server', 'agent', 'keeper', 'inference']))
 
   async function refresh() {
@@ -235,19 +249,31 @@ export function PrometheusMetrics() {
     return html`<${EmptyState} message="No metrics available" />`
   }
 
-  // Group by category
+  // Group by category (filtered if search active)
+  const query = searchQuery.value.trim().toLowerCase()
+  const filteredMetrics = query
+    ? metrics.value.filter(m => metricMatchesSearch(m, query))
+    : metrics.value
+
   const grouped = new Map<MetricCategory, ParsedMetric[]>()
-  for (const m of metrics.value) {
+  for (const m of filteredMetrics) {
     const cat = categorize(m.name)
     const list = grouped.get(cat) ?? []
     list.push(m)
     grouped.set(cat, list)
   }
 
+  // Auto-expand categories when searching
+  if (query) {
+    const expanded = new Set<MetricCategory>()
+    for (const cat of grouped.keys()) expanded.add(cat)
+    if (expandedCategories.value !== expanded) expandedCategories.value = expanded
+  }
+
   // Summary stats
-  const totalMetrics = metrics.value.length
-  const totalSamples = metrics.value.reduce((sum, m) => sum + m.samples.length, 0)
-  const nonZeroSamples = metrics.value.reduce(
+  const totalMetrics = filteredMetrics.length
+  const totalSamples = filteredMetrics.reduce((sum, m) => sum + m.samples.length, 0)
+  const nonZeroSamples = filteredMetrics.reduce(
     (sum, m) => sum + m.samples.filter(s => s.value !== 0).length,
     0,
   )
@@ -287,6 +313,24 @@ export function PrometheusMetrics() {
           ${error.value}
         </div>
       `}
+
+      <${TextInput}
+        class="max-w-[300px]"
+        placeholder="검색 (메트릭 이름, 라벨...)"
+        ariaLabel="메트릭 검색"
+        value=${searchQuery.value}
+        onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+      />
+
+      ${query && html`
+        <span class="text-xs text-[var(--text-muted)]">
+          ${totalMetrics} / ${metrics.value.length} 메트릭 일치
+        </span>
+      `}
+
+      ${totalMetrics === 0 && query ? html`
+        <${EmptyState} message="조건에 맞는 메트릭이 없습니다." />
+      ` : null}
 
       ${categoryOrder.filter(cat => grouped.has(cat)).map(cat => {
         const catMetrics = grouped.get(cat)!


### PR DESCRIPTION
## Summary
- Prometheus /metrics 패널에 텍스트 검색 기능 추가
- 메트릭 이름, help text, label 값, quantile 값으로 검색 가능
- 검색 시 카테고리 자동 확장
- 순수 함수(`parsePrometheusText`, `categorize`, `metricMatchesSearch`) export 후 16개 테스트 작성

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run src/components/prometheus-metrics.test.ts` 16/16 통과
- [ ] CI Detect Changed Surfaces 통과
- [ ] 대시보드에서 검색 UI 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)