### PR TITLE
test(dashboard): fleet-telemetry-utils 60 tests

### DIFF
--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PRESSURE_HOT_RATIO,
+  PRESSURE_WARN_RATIO,
+  STALE_ACTIVITY_SEC,
+  normalizeText,
+  isPlaceholderModel,
+  normalizeModelText,
+  firstNonEmptyString,
+  uniqueStrings,
+  successClass,
+  fleetBand,
+  fleetBandScore,
+  rowUrgencyScore,
+  compareFleetRows,
+  pressureClass,
+  statusClass,
+  formatPercent,
+  formatLatency,
+  formatActivity,
+  numericAge,
+  toneForToolSuccess,
+  toneForPressure,
+  toolSummary,
+  summaryCounts,
+  buildToolQualityMap,
+  buildRuntimeWarnings,
+  emptyState,
+  type FleetRow,
+} from './fleet-telemetry-utils'
+
+// --- Helpers ---
+
+function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
+  return {
+    name: 'test-keeper',
+    status: 'active',
+    keepalive_running: true,
+    context_ratio: 0.3,
+    turn_count: 10,
+    last_latency_ms: 500,
+    last_activity_ago_s: 60,
+    model: 'test-model',
+    tool_calls: 5,
+    tool_success_pct: 95,
+    tool_activity_known: true,
+    recent_tools: ['tool_a'],
+    runtime_blocker_class: null,
+    runtime_blocker_summary: null,
+    tool_audit_at: null,
+    budget_source: null,
+    ...overrides,
+  }
+}
+
+// --- Tests ---
+
+describe('normalizeText', () => {
+  it('returns null for null/undefined', () => {
+    expect(normalizeText(null)).toBeNull()
+    expect(normalizeText(undefined)).toBeNull()
+  })
+
+  it('returns null for whitespace-only strings', () => {
+    expect(normalizeText('   ')).toBeNull()
+    expect(normalizeText('')).toBeNull()
+  })
+
+  it('trims and returns non-empty strings', () => {
+    expect(normalizeText('  hello  ')).toBe('hello')
+  })
+})
+
+describe('isPlaceholderModel', () => {
+  it('recognizes placeholder values', () => {
+    expect(isPlaceholderModel('unknown')).toBe(true)
+    expect(isPlaceholderModel('none')).toBe(true)
+    expect(isPlaceholderModel('-')).toBe(true)
+    expect(isPlaceholderModel('n/a')).toBe(true)
+  })
+
+  it('returns false for real model names', () => {
+    expect(isPlaceholderModel('claude-sonnet-4-6')).toBe(false)
+    expect(isPlaceholderModel('gpt-4o')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isPlaceholderModel('Unknown')).toBe(true)
+    expect(isPlaceholderModel('NONE')).toBe(true)
+  })
+})
+
+describe('normalizeModelText', () => {
+  it('returns null for null/undefined/placeholder', () => {
+    expect(normalizeModelText(null)).toBeNull()
+    expect(normalizeModelText(undefined)).toBeNull()
+    expect(normalizeModelText('unknown')).toBeNull()
+    expect(normalizeModelText('n/a')).toBeNull()
+  })
+
+  it('returns trimmed text for valid models', () => {
+    expect(normalizeModelText(' claude-sonnet-4-6 ')).toBe('claude-sonnet-4-6')
+  })
+})
+
+describe('firstNonEmptyString', () => {
+  it('returns first non-null trimmed string', () => {
+    expect(firstNonEmptyString(null, '  ', 'hello', 'world')).toBe('hello')
+  })
+
+  it('returns null when all are empty', () => {
+    expect(firstNonEmptyString(null, undefined, '  ')).toBeNull()
+  })
+})
+
+describe('uniqueStrings', () => {
+  it('deduplicates and trims', () => {
+    expect(uniqueStrings(['a', '  a  ', 'b', null, 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('filters null/undefined/empty', () => {
+    expect(uniqueStrings([null, undefined, '  ', 'x'])).toEqual(['x'])
+  })
+})
+
+describe('successClass', () => {
+  it('returns emerald for >=97', () => {
+    expect(successClass(97)).toContain('emerald')
+    expect(successClass(100)).toContain('emerald')
+  })
+
+  it('returns yellow for 90-96', () => {
+    expect(successClass(90)).toContain('yellow')
+    expect(successClass(96)).toContain('yellow')
+  })
+
+  it('returns red for <90', () => {
+    expect(successClass(89)).toContain('red')
+    expect(successClass(50)).toContain('red')
+  })
+
+  it('returns dim for null/non-finite', () => {
+    expect(successClass(null)).toContain('dim')
+    expect(successClass(NaN)).toContain('dim')
+  })
+})
+
+describe('fleetBand', () => {
+  it('classifies offline when keepalive not running', () => {
+    expect(fleetBand(makeRow({ keepalive_running: false }))).toBe('offline')
+  })
+
+  it('classifies offline for dead/stopped/crashed status', () => {
+    expect(fleetBand(makeRow({ status: 'dead' }))).toBe('offline')
+    expect(fleetBand(makeRow({ status: 'stopped' }))).toBe('offline')
+    expect(fleetBand(makeRow({ status: 'crashed' }))).toBe('offline')
+  })
+
+  it('classifies paused', () => {
+    expect(fleetBand(makeRow({ status: 'paused' }))).toBe('paused')
+  })
+
+  it('classifies attention for runtime blocker', () => {
+    expect(fleetBand(makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' }))).toBe('attention')
+  })
+
+  it('classifies attention for high context ratio', () => {
+    expect(fleetBand(makeRow({ context_ratio: PRESSURE_WARN_RATIO }))).toBe('attention')
+  })
+
+  it('classifies attention for stale activity', () => {
+    expect(fleetBand(makeRow({ last_activity_ago_s: STALE_ACTIVITY_SEC }))).toBe('attention')
+  })
+
+  it('classifies attention for low tool success', () => {
+    expect(fleetBand(makeRow({ tool_success_pct: 85 }))).toBe('attention')
+  })
+
+  it('classifies active for healthy row', () => {
+    expect(fleetBand(makeRow())).toBe('active')
+  })
+})
+
+describe('fleetBandScore', () => {
+  it('orders attention > active > paused > offline', () => {
+    const attention = makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' })
+    const active = makeRow()
+    const paused = makeRow({ status: 'paused' })
+    const offline = makeRow({ keepalive_running: false })
+
+    expect(fleetBandScore(attention)).toBeGreaterThan(fleetBandScore(active))
+    expect(fleetBandScore(active)).toBeGreaterThan(fleetBandScore(paused))
+    expect(fleetBandScore(paused)).toBeGreaterThan(fleetBandScore(offline))
+  })
+})
+
+describe('rowUrgencyScore', () => {
+  it('scores runtime blocker highest', () => {
+    const withBlocker = makeRow({ runtime_blocker_class: 'turn_timeout' })
+    const without = makeRow()
+    expect(rowUrgencyScore(withBlocker)).toBeGreaterThan(rowUrgencyScore(without))
+  })
+
+  it('increases with context ratio', () => {
+    const highCtx = makeRow({ context_ratio: 0.8 })
+    const lowCtx = makeRow({ context_ratio: 0.2 })
+    expect(rowUrgencyScore(highCtx)).toBeGreaterThan(rowUrgencyScore(lowCtx))
+  })
+})
+
+describe('compareFleetRows', () => {
+  it('sorts by band score descending', () => {
+    const a = makeRow({ name: 'a', runtime_blocker_class: 'turn_timeout' })
+    const b = makeRow({ name: 'b' })
+    expect(compareFleetRows(a, b)).toBeLessThan(0) // attention before active
+  })
+
+  it('breaks ties by name ascending', () => {
+    const a = makeRow({ name: 'alpha' })
+    const b = makeRow({ name: 'beta' })
+    expect(compareFleetRows(a, b)).toBeLessThan(0)
+  })
+})
+
+describe('pressureClass', () => {
+  it('returns red for hot ratio', () => {
+    expect(pressureClass(PRESSURE_HOT_RATIO)).toContain('red')
+  })
+
+  it('returns yellow for warn ratio', () => {
+    expect(pressureClass(PRESSURE_WARN_RATIO)).toContain('yellow')
+  })
+
+  it('returns emerald for low ratio', () => {
+    expect(pressureClass(0.1)).toContain('emerald')
+  })
+})
+
+describe('statusClass', () => {
+  it('returns red for offline/stopped', () => {
+    expect(statusClass(makeRow({ keepalive_running: false }))).toContain('red')
+    expect(statusClass(makeRow({ status: 'stopped' }))).toContain('red')
+  })
+
+  it('returns yellow for runtime blocker', () => {
+    expect(statusClass(makeRow({ runtime_blocker_class: 'turn_timeout' }))).toContain('yellow')
+  })
+
+  it('returns emerald for healthy', () => {
+    expect(statusClass(makeRow())).toContain('emerald')
+  })
+})
+
+describe('formatPercent', () => {
+  it('formats valid numbers', () => {
+    expect(formatPercent(95.5, 1)).toBe('95.5%')
+    expect(formatPercent(100)).toBe('100%')
+  })
+
+  it('returns dash for null/non-finite', () => {
+    expect(formatPercent(null)).toBe('-')
+    expect(formatPercent(NaN)).toBe('-')
+  })
+})
+
+describe('formatLatency', () => {
+  it('formats milliseconds', () => {
+    expect(formatLatency(500)).toBe('500ms')
+  })
+
+  it('formats seconds', () => {
+    expect(formatLatency(1500)).toBe('1.5s')
+  })
+
+  it('returns dash for zero/negative/non-finite', () => {
+    expect(formatLatency(0)).toBe('-')
+    expect(formatLatency(-1)).toBe('-')
+    expect(formatLatency(NaN)).toBe('-')
+  })
+})
+
+describe('formatActivity', () => {
+  it('returns dash for null/negative', () => {
+    expect(formatActivity(null)).toBe('-')
+    expect(formatActivity(-1)).toBe('-')
+  })
+})
+
+describe('numericAge', () => {
+  it('returns null for non-finite values', () => {
+    expect(numericAge(null)).toBeNull()
+    expect(numericAge(undefined)).toBeNull()
+    expect(numericAge(NaN)).toBeNull()
+    expect(numericAge(-1)).toBeNull()
+  })
+
+  it('returns valid ages', () => {
+    expect(numericAge(0)).toBe(0)
+    expect(numericAge(300)).toBe(300)
+  })
+})
+
+describe('toneForToolSuccess', () => {
+  it('returns ok for >=97', () => {
+    expect(toneForToolSuccess(97)).toBe('ok')
+    expect(toneForToolSuccess(100)).toBe('ok')
+  })
+
+  it('returns neutral for 90-96', () => {
+    expect(toneForToolSuccess(90)).toBe('neutral')
+    expect(toneForToolSuccess(96)).toBe('neutral')
+  })
+
+  it('returns warn for <90', () => {
+    expect(toneForToolSuccess(89)).toBe('warn')
+  })
+})
+
+describe('toneForPressure', () => {
+  it('returns warn when hot > 0', () => {
+    expect(toneForPressure(1, 0)).toBe('warn')
+  })
+
+  it('returns neutral when warn > 0', () => {
+    expect(toneForPressure(0, 1)).toBe('neutral')
+  })
+
+  it('returns ok when neither', () => {
+    expect(toneForPressure(0, 0)).toBe('ok')
+  })
+})
+
+describe('toolSummary', () => {
+  it('shows recent tools when available', () => {
+    const row = makeRow({ recent_tools: ['bash', 'grep'] })
+    const summary = toolSummary(row)
+    expect(summary.label).toBe('bash, grep')
+  })
+
+  it('shows call count when no tool names', () => {
+    const row = makeRow({ recent_tools: [], tool_calls: 42 })
+    expect(toolSummary(row).label).toContain('42')
+  })
+
+  it('shows no recent tools when activity known but nothing', () => {
+    const row = makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: true })
+    expect(toolSummary(row).label).toContain('No recent tools')
+  })
+
+  it('shows unavailable when activity unknown', () => {
+    const row = makeRow({ recent_tools: [], tool_calls: 0, tool_activity_known: false })
+    expect(toolSummary(row).label).toContain('unavailable')
+  })
+})
+
+describe('summaryCounts', () => {
+  it('counts live, hot, warn, stale correctly', () => {
+    const rows = [
+      makeRow({ name: 'a', keepalive_running: true, context_ratio: 0.1, last_activity_ago_s: 60, tool_calls: 1 }),
+      makeRow({ name: 'b', keepalive_running: true, context_ratio: PRESSURE_HOT_RATIO, last_activity_ago_s: 60, tool_calls: 0, recent_tools: [] }),
+      makeRow({ name: 'c', keepalive_running: false, context_ratio: 0.1, last_activity_ago_s: null, tool_calls: 0, recent_tools: [] }),
+    ]
+    const counts = summaryCounts(rows)
+    expect(counts.live).toBe(2)
+    expect(counts.hot).toBe(1)
+    expect(counts.toolCovered).toBe(1)
+  })
+})
+
+describe('buildToolQualityMap', () => {
+  it('maps keeper names to stats', () => {
+    const map = buildToolQualityMap({
+      total: 10,
+      success: 8,
+      failure: 2,
+      success_rate: 80,
+      by_tool: [],
+      by_keeper: [
+        { name: 'janitor', calls: 5, success_pct: 80 },
+        { name: 'guardian', calls: 5, success_pct: 80 },
+      ],
+      failure_categories: [],
+      hourly_trend: [],
+    })
+    expect(map.get('janitor')!.calls).toBe(5)
+    expect(map.get('guardian')!.success_pct).toBe(80)
+    expect(map.has('unknown')).toBe(false)
+  })
+})
+
+describe('buildRuntimeWarnings', () => {
+  it('warns about admission queue blockage', () => {
+    const rows = [makeRow({ runtime_blocker_class: 'admission_queue_wait_timeout' })]
+    const warnings = buildRuntimeWarnings(rows)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('admission queue')
+  })
+
+  it('warns about slot blockage', () => {
+    const rows = [makeRow({ runtime_blocker_class: 'autonomous_slot_wait_timeout' })]
+    const warnings = buildRuntimeWarnings(rows)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('autonomous cycle')
+  })
+
+  it('warns about other blockers', () => {
+    const rows = [makeRow({ runtime_blocker_class: 'turn_timeout_after_queue_wait' })]
+    const warnings = buildRuntimeWarnings(rows)
+    expect(warnings.length).toBe(1)
+    expect(warnings[0]).toContain('other runtime blockers')
+  })
+
+  it('returns empty for healthy rows', () => {
+    expect(buildRuntimeWarnings([makeRow()])).toEqual([])
+  })
+})
+
+describe('emptyState', () => {
+  it('returns valid initial state', () => {
+    const state = emptyState()
+    expect(state.loading).toBe(false)
+    expect(state.error).toBeNull()
+    expect(state.rows).toEqual([])
+    expect(state.warnings).toEqual([])
+    expect(state.tool_quality.total).toBe(0)
+  })
+})

--- a/dashboard/src/components/memory-state.test.ts
+++ b/dashboard/src/components/memory-state.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  isUpdated,
+  boardPostKind,
+  contentCategory,
+  categoryLabel,
+  authorAvatar,
+  kindLabel,
+  visibilityLabel,
+  filterHint,
+  splitVisiblePosts,
+  type ContentCategory,
+  type VisibleBoardGroups,
+} from './memory-state'
+import type { BoardPost } from '../types'
+
+// Reset module-scope signals between tests
+import { boardHiddenCategories, boardExcludeAutomation } from '../store'
+
+function makePost(overrides: Partial<BoardPost> = {}): BoardPost {
+  return {
+    id: 'p1',
+    author: 'test-agent',
+    title: 'Test post',
+    body: 'Test body content',
+    content: '',
+    meta: null,
+    tags: [],
+    votes: 0,
+    vote_balance: 0,
+    comment_count: 0,
+    created_at: '2026-04-17T00:00:00Z',
+    updated_at: '2026-04-17T00:00:00Z',
+    post_kind: 'direct',
+    flair: undefined,
+    hearth: null,
+    visibility: 'public',
+    expires_at: null,
+    hearth_count: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  boardHiddenCategories.value = new Set()
+  boardExcludeAutomation.value = false
+})
+
+describe('isUpdated', () => {
+  it('returns false when timestamps match', () => {
+    expect(isUpdated(makePost())).toBe(false)
+  })
+
+  it('returns true when updated_at differs', () => {
+    expect(isUpdated(makePost({ updated_at: '2026-04-17T01:00:00Z' }))).toBe(true)
+  })
+})
+
+describe('boardPostKind', () => {
+  it('defaults to direct', () => {
+    expect(boardPostKind(makePost({ post_kind: undefined }))).toBe('direct')
+  })
+
+  it('returns automation when set', () => {
+    expect(boardPostKind(makePost({ post_kind: 'automation' }))).toBe('automation')
+  })
+
+  it('returns system when set', () => {
+    expect(boardPostKind(makePost({ post_kind: 'system' }))).toBe('system')
+  })
+})
+
+describe('contentCategory', () => {
+  it('classifies system posts', () => {
+    expect(contentCategory(makePost({ post_kind: 'system' }))).toBe('system')
+  })
+
+  it('classifies review by title keywords', () => {
+    expect(contentCategory(makePost({ title: 'verdict: 코드 품질 양호' }))).toBe('review')
+    expect(contentCategory(makePost({ title: 'PR 리뷰 완료' }))).toBe('review')
+    expect(contentCategory(makePost({ title: 'Code Review 결과' }))).toBe('review')
+  })
+
+  it('classifies notice by title keywords', () => {
+    expect(contentCategory(makePost({ title: 'alert: 서버 과부하' }))).toBe('notice')
+    expect(contentCategory(makePost({ title: '상태 업데이트' }))).toBe('notice')
+    expect(contentCategory(makePost({ title: 'Warning: CPU 90%' }))).toBe('notice')
+  })
+
+  it('classifies article by title keywords', () => {
+    expect(contentCategory(makePost({ title: '기술 탐색: WebAssembly' }))).toBe('article')
+    expect(contentCategory(makePost({ title: '연구 결과' }))).toBe('article')
+    expect(contentCategory(makePost({ title: 'POC 실험' }))).toBe('article')
+  })
+
+  it('falls back to article for long body content', () => {
+    const longBody = 'x'.repeat(301)
+    expect(contentCategory(makePost({ title: '일반 제목', body: longBody }))).toBe('article')
+  })
+
+  it('falls back to article for default case', () => {
+    expect(contentCategory(makePost({ title: '일반 제목', body: '보통 내용' }))).toBe('article')
+  })
+})
+
+describe('categoryLabel', () => {
+  it('returns label for known categories', () => {
+    expect(categoryLabel('article')).toBe('글/분석')
+    expect(categoryLabel('review')).toBe('리뷰/판정')
+    expect(categoryLabel('notice')).toBe('알림/상태')
+    expect(categoryLabel('system')).toBe('시스템')
+  })
+
+  it('returns raw id for unknown', () => {
+    expect(categoryLabel('unknown' as ContentCategory)).toBe('unknown')
+  })
+})
+
+describe('authorAvatar', () => {
+  it('returns a single emoji for any string', () => {
+    const result = authorAvatar('test-agent')
+    expect(result).toMatch(/\p{Emoji}/u)
+    expect(result.length).toBeLessThanOrEqual(2) // emoji may be 1-2 chars
+  })
+
+  it('returns consistent avatar for same name', () => {
+    expect(authorAvatar('keeper-1')).toBe(authorAvatar('keeper-1'))
+  })
+
+  it('returns different avatars for different names', () => {
+    // Statistically unlikely to collide with different names
+    expect(authorAvatar('keeper-1')).not.toBe(authorAvatar('keeper-2'))
+  })
+})
+
+describe('kindLabel', () => {
+  it('maps known kinds', () => {
+    expect(kindLabel('direct')).toBe('직접')
+    expect(kindLabel('automation')).toBe('자동화')
+    expect(kindLabel('system')).toBe('시스템')
+  })
+
+  it('passes through unknown kinds', () => {
+    expect(kindLabel('custom')).toBe('custom')
+  })
+})
+
+describe('visibilityLabel', () => {
+  it('maps known visibilities', () => {
+    expect(visibilityLabel('internal')).toBe('내부')
+    expect(visibilityLabel('unlisted')).toBe('비공개')
+    expect(visibilityLabel('direct')).toBe('DM')
+  })
+
+  it('returns null for public', () => {
+    expect(visibilityLabel('public')).toBeNull()
+  })
+
+  it('passes through unknown', () => {
+    expect(visibilityLabel('secret')).toBe('secret')
+  })
+})
+
+describe('splitVisiblePosts', () => {
+  it('groups posts by content category', () => {
+    const posts = [
+      makePost({ id: '1', title: '기술 탐색', body: 'x'.repeat(301) }),
+      makePost({ id: '2', title: 'verdict: 양호' }),
+      makePost({ id: '3', post_kind: 'system', title: '알림' }),
+    ]
+    const result = splitVisiblePosts(posts)
+    expect(result.groups.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('hides posts in hidden categories', () => {
+    const posts = [makePost({ id: '1', post_kind: 'system' })]
+    boardHiddenCategories.value = new Set(['system'])
+    const result = splitVisiblePosts(posts)
+    const sysGroup = result.groups.find(g => g.category === 'system')
+    expect(sysGroup!.hidden).toBe(1)
+    expect(sysGroup!.posts.length).toBe(0)
+  })
+
+  it('returns empty groups for empty posts', () => {
+    const result = splitVisiblePosts([])
+    expect(result.groups).toEqual([])
+    expect(result.totalDirect).toBe(0)
+  })
+})
+
+describe('filterHint', () => {
+  it('returns null when nothing hidden', () => {
+    const grouped: VisibleBoardGroups = {
+      groups: [{ category: 'article', posts: [], total: 5, hidden: 0 }],
+      direct: [],
+      automation: [],
+      system: [],
+      totalDirect: 5,
+      totalAutomation: 0,
+      totalSystem: 0,
+      hiddenAutomation: 0,
+      hiddenSystem: 0,
+    }
+    expect(filterHint(grouped)).toBeNull()
+  })
+
+  it('returns hint when posts are hidden', () => {
+    const grouped: VisibleBoardGroups = {
+      groups: [{ category: 'system', posts: [], total: 3, hidden: 3 }],
+      direct: [],
+      automation: [],
+      system: [],
+      totalDirect: 0,
+      totalAutomation: 0,
+      totalSystem: 3,
+      hiddenAutomation: 0,
+      hiddenSystem: 3,
+    }
+    const hint = filterHint(grouped)
+    expect(hint).toContain('숨겨져')
+    expect(hint).toContain('3건')
+  })
+})


### PR DESCRIPTION
## Summary
- `fleet-telemetry-utils.ts` (529줄)의 모든 export 순수 함수에 60개 테스트 추가
- 테스트 범위: 텍스트 정규화, fleet band 분류, 정렬, 포맷팅, tone/color helper, data builder, tool summary, emptyState contract
- UI 렌더링 없이 순수 함수만 테스트 — happy-dom 의존성 없이 빠른 실행 (8ms)

## Test plan
- [x] `npx vitest run src/components/fleet-telemetry-utils.test.ts` 60/60 통과
- [ ] CI Dashboard job 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)