### PR TITLE
feat(dashboard): cascade strategy trace search + pure function tests

### DIFF
--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  traceEventMatchesSearch,
+  fmtPct,
+  candidateTone,
+  sourceLabel,
+  sourceTone,
+  providerTone,
+  capacityTone,
+  eventKindTone,
+  eventKindLabel,
+  capacityKindLabel,
+  traceKindTone,
+  traceKindLabel,
+} from './cascade-config-panel'
+import type {
+  CascadeCandidate,
+  CascadeClientCapacityEntry,
+  CascadeHealthProvider,
+  CascadeStrategyTraceEvent,
+} from '../api/dashboard'
+
+// --- Helpers ---
+
+function makeTraceEvent(overrides: Partial<CascadeStrategyTraceEvent> = {}): CascadeStrategyTraceEvent {
+  return {
+    ts: Date.now() / 1000 - 60,
+    cascade_name: 'default',
+    strategy: 'weighted',
+    cycle: 1,
+    candidates_in: 3,
+    candidates_out: 1,
+    backoff_ms: 0,
+    kind: 'ordered',
+    ...overrides,
+  }
+}
+
+function makeCandidate(overrides: Partial<CascadeCandidate> = {}): CascadeCandidate {
+  return {
+    model: 'test-model',
+    config_weight: 1,
+    effective_weight: 1,
+    success_rate: 0.95,
+    in_cooldown: false,
+    ...overrides,
+  }
+}
+
+function makeProvider(overrides: Partial<CascadeHealthProvider> = {}): CascadeHealthProvider {
+  return {
+    provider_key: 'test-provider',
+    success_rate: 0.95,
+    consecutive_failures: 0,
+    events_in_window: 10,
+    in_cooldown: false,
+    cooldown_expires_at: null,
+    ...overrides,
+  }
+}
+
+function makeCapacityEntry(overrides: Partial<CascadeClientCapacityEntry> = {}): CascadeClientCapacityEntry {
+  return {
+    kind: 'cli',
+    key: 'test-key',
+    active: 1,
+    available: 2,
+    total: 3,
+    ...overrides,
+  }
+}
+
+// --- Tests ---
+
+describe('fmtPct', () => {
+  it('formats ratio as percentage string', () => {
+    expect(fmtPct(0.955)).toBe('95.5%')
+    expect(fmtPct(1.0)).toBe('100.0%')
+  })
+
+  it('returns -- for NaN', () => {
+    expect(fmtPct(NaN)).toBe('--')
+  })
+})
+
+describe('candidateTone', () => {
+  it('returns bad for cooldown', () => {
+    expect(candidateTone(makeCandidate({ in_cooldown: true }))).toBe('bad')
+  })
+
+  it('returns bad for zero effective weight', () => {
+    expect(candidateTone(makeCandidate({ effective_weight: 0 }))).toBe('bad')
+  })
+
+  it('returns bad for very low success rate', () => {
+    expect(candidateTone(makeCandidate({ success_rate: 0.3 }))).toBe('bad')
+  })
+
+  it('returns warn for moderate success rate', () => {
+    expect(candidateTone(makeCandidate({ success_rate: 0.8 }))).toBe('warn')
+  })
+
+  it('returns ok for healthy candidate', () => {
+    expect(candidateTone(makeCandidate())).toBe('ok')
+  })
+})
+
+describe('sourceLabel', () => {
+  it('maps source kinds', () => {
+    expect(sourceLabel('named')).toBe('named')
+    expect(sourceLabel('default_fallback')).toBe('default')
+    expect(sourceLabel('hardcoded_defaults')).toBe('hardcoded')
+  })
+})
+
+describe('sourceTone', () => {
+  it('returns ok for named', () => {
+    expect(sourceTone('named')).toBe('ok')
+  })
+
+  it('returns warn for fallbacks', () => {
+    expect(sourceTone('default_fallback')).toBe('warn')
+    expect(sourceTone('hardcoded_defaults')).toBe('warn')
+  })
+})
+
+describe('providerTone', () => {
+  it('returns bad for cooldown', () => {
+    expect(providerTone(makeProvider({ in_cooldown: true }))).toBe('bad')
+  })
+
+  it('returns bad for low success rate', () => {
+    expect(providerTone(makeProvider({ success_rate: 0.5 }))).toBe('bad')
+  })
+
+  it('returns warn for moderate success rate', () => {
+    expect(providerTone(makeProvider({ success_rate: 0.8 }))).toBe('warn')
+  })
+
+  it('returns ok for healthy provider', () => {
+    expect(providerTone(makeProvider())).toBe('ok')
+  })
+})
+
+describe('capacityTone', () => {
+  it('returns bad for zero total', () => {
+    expect(capacityTone(makeCapacityEntry({ total: 0 }))).toBe('bad')
+  })
+
+  it('returns warn for zero available', () => {
+    expect(capacityTone(makeCapacityEntry({ available: 0 }))).toBe('warn')
+  })
+
+  it('returns ok for healthy entry', () => {
+    expect(capacityTone(makeCapacityEntry())).toBe('ok')
+  })
+})
+
+describe('eventKindTone', () => {
+  it('maps event kinds to tones', () => {
+    expect(eventKindTone('acquired')).toBe('ok')
+    expect(eventKindTone('released')).toBe('neutral')
+    expect(eventKindTone('rejected_full')).toBe('bad')
+  })
+})
+
+describe('eventKindLabel', () => {
+  it('maps event kinds to labels', () => {
+    expect(eventKindLabel('acquired')).toBe('acquired')
+    expect(eventKindLabel('released')).toBe('released')
+    expect(eventKindLabel('rejected_full')).toBe('rejected')
+  })
+})
+
+describe('capacityKindLabel', () => {
+  it('maps capacity kinds to labels', () => {
+    expect(capacityKindLabel('cli')).toBe('CLI')
+    expect(capacityKindLabel('ollama')).toBe('Ollama')
+    expect(capacityKindLabel('other')).toBe('Other')
+  })
+})
+
+describe('traceKindTone', () => {
+  it('maps trace kinds to tones', () => {
+    expect(traceKindTone('ordered')).toBe('ok')
+    expect(traceKindTone('filtered_empty')).toBe('warn')
+    expect(traceKindTone('exhausted')).toBe('bad')
+  })
+})
+
+describe('traceKindLabel', () => {
+  it('maps trace kinds to Korean labels', () => {
+    expect(traceKindLabel('ordered')).toBe('정렬')
+    expect(traceKindLabel('filtered_empty')).toBe('전부 차단')
+    expect(traceKindLabel('exhausted')).toBe('소진')
+  })
+})
+
+describe('traceEventMatchesSearch', () => {
+  it('matches cascade_name', () => {
+    const e = makeTraceEvent({ cascade_name: 'production-v2' })
+    expect(traceEventMatchesSearch(e, 'production')).toBe(true)
+    expect(traceEventMatchesSearch(e, 'v2')).toBe(true)
+  })
+
+  it('matches strategy', () => {
+    const e = makeTraceEvent({ strategy: 'round-robin' })
+    expect(traceEventMatchesSearch(e, 'round')).toBe(true)
+    expect(traceEventMatchesSearch(e, 'robin')).toBe(true)
+  })
+
+  it('matches kind label (Korean)', () => {
+    const e = makeTraceEvent({ kind: 'exhausted' })
+    expect(traceEventMatchesSearch(e, '소진')).toBe(true)
+  })
+
+  it('matches kind value (English)', () => {
+    const e = makeTraceEvent({ kind: 'filtered_empty' })
+    expect(traceEventMatchesSearch(e, 'filtered')).toBe(true)
+  })
+
+  it('matches cycle number', () => {
+    const e = makeTraceEvent({ cycle: 42 })
+    expect(traceEventMatchesSearch(e, '42')).toBe(true)
+  })
+
+  it('matches candidates_in/out numbers', () => {
+    const e = makeTraceEvent({ candidates_in: 5, candidates_out: 2 })
+    expect(traceEventMatchesSearch(e, '5')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    const e = makeTraceEvent({ cascade_name: 'Production' })
+    expect(traceEventMatchesSearch(e, 'production')).toBe(true)
+    expect(traceEventMatchesSearch(e, 'PRODUCTION')).toBe(true)
+  })
+
+  it('returns false when nothing matches', () => {
+    const e = makeTraceEvent()
+    expect(traceEventMatchesSearch(e, 'nonexistent-xyz')).toBe(false)
+  })
+
+  it('returns true for empty query (no filtering)', () => {
+    const e = makeTraceEvent()
+    expect(traceEventMatchesSearch(e, '')).toBe(true)
+  })
+})

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -9,6 +9,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useRef } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
 import {
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
@@ -32,6 +33,7 @@ import {
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { TextInput } from './common/input'
 import { StatCell } from './common/stat-cell'
 import { StatusChip } from './common/status-chip'
 import { createManagedAsyncResource, type ManagedAsyncResource } from '../lib/async-state'
@@ -57,12 +59,12 @@ async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   })
 }
 
-function fmtPct(value: number): string {
+export function fmtPct(value: number): string {
   if (Number.isNaN(value)) return '--'
   return `${(value * 100).toFixed(1)}%`
 }
 
-function candidateTone(c: CascadeCandidate): string {
+export function candidateTone(c: CascadeCandidate): string {
   if (c.in_cooldown) return 'bad'
   if (c.effective_weight === 0) return 'bad'
   if (c.success_rate < 0.5) return 'bad'
@@ -70,7 +72,7 @@ function candidateTone(c: CascadeCandidate): string {
   return 'ok'
 }
 
-function sourceLabel(source: CascadeProfile['source']): string {
+export function sourceLabel(source: CascadeProfile['source']): string {
   switch (source) {
     case 'named': return 'named'
     case 'default_fallback': return 'default'
@@ -78,7 +80,7 @@ function sourceLabel(source: CascadeProfile['source']): string {
   }
 }
 
-function sourceTone(source: CascadeProfile['source']): string {
+export function sourceTone(source: CascadeProfile['source']): string {
   switch (source) {
     case 'named': return 'ok'
     case 'default_fallback': return 'warn'
@@ -159,7 +161,7 @@ function KeeperMapping({ config }: { config: CascadeConfigResponse }) {
   `
 }
 
-function providerTone(p: CascadeHealthProvider): 'ok' | 'warn' | 'bad' {
+export function providerTone(p: CascadeHealthProvider): 'ok' | 'warn' | 'bad' {
   if (p.in_cooldown) return 'bad'
   if (p.success_rate < 0.7) return 'bad'
   if (p.success_rate < 0.9) return 'warn'
@@ -210,7 +212,7 @@ function HealthTable({ health }: { health: CascadeHealthResponse }) {
   `
 }
 
-function capacityTone(entry: CascadeClientCapacityEntry): 'ok' | 'warn' | 'bad' {
+export function capacityTone(entry: CascadeClientCapacityEntry): 'ok' | 'warn' | 'bad' {
   if (entry.total === 0) return 'bad'
   if (entry.available === 0) return 'warn'
   return 'ok'
@@ -226,7 +228,7 @@ function fmtRelativeTime(tsSec: number): string {
   return `${Math.floor(deltaSec / 86400)}일 전`
 }
 
-function eventKindTone(kind: CascadeCapacityEventKind): 'ok' | 'neutral' | 'bad' {
+export function eventKindTone(kind: CascadeCapacityEventKind): 'ok' | 'neutral' | 'bad' {
   switch (kind) {
     case 'acquired': return 'ok'
     case 'released': return 'neutral'
@@ -234,7 +236,7 @@ function eventKindTone(kind: CascadeCapacityEventKind): 'ok' | 'neutral' | 'bad'
   }
 }
 
-function eventKindLabel(kind: CascadeCapacityEventKind): string {
+export function eventKindLabel(kind: CascadeCapacityEventKind): string {
   switch (kind) {
     case 'acquired': return 'acquired'
     case 'released': return 'released'
@@ -242,7 +244,7 @@ function eventKindLabel(kind: CascadeCapacityEventKind): string {
   }
 }
 
-function capacityKindLabel(kind: CascadeClientCapacityEntry['kind']): string {
+export function capacityKindLabel(kind: CascadeClientCapacityEntry['kind']): string {
   switch (kind) {
     case 'cli': return 'CLI'
     case 'ollama': return 'Ollama'
@@ -250,7 +252,7 @@ function capacityKindLabel(kind: CascadeClientCapacityEntry['kind']): string {
   }
 }
 
-function traceKindTone(k: CascadeStrategyTraceKind): 'ok' | 'warn' | 'bad' {
+export function traceKindTone(k: CascadeStrategyTraceKind): 'ok' | 'warn' | 'bad' {
   switch (k) {
     case 'ordered': return 'ok'
     case 'filtered_empty': return 'warn'
@@ -258,7 +260,7 @@ function traceKindTone(k: CascadeStrategyTraceKind): 'ok' | 'warn' | 'bad' {
   }
 }
 
-function traceKindLabel(k: CascadeStrategyTraceKind): string {
+export function traceKindLabel(k: CascadeStrategyTraceKind): string {
   switch (k) {
     case 'ordered': return '정렬'
     case 'filtered_empty': return '전부 차단'
@@ -266,13 +268,34 @@ function traceKindLabel(k: CascadeStrategyTraceKind): string {
   }
 }
 
+export function traceEventMatchesSearch(
+  e: CascadeStrategyTraceEvent,
+  query: string,
+): boolean {
+  const q = query.toLowerCase()
+  if (e.cascade_name.toLowerCase().includes(q)) return true
+  if (e.strategy.toLowerCase().includes(q)) return true
+  if (e.kind.toLowerCase().includes(q)) return true
+  if (traceKindLabel(e.kind).toLowerCase().includes(q)) return true
+  if (String(e.cycle).includes(q)) return true
+  if (String(e.candidates_in).includes(q)) return true
+  if (String(e.candidates_out).includes(q)) return true
+  return false
+}
+
 function StrategyTraceTable({
   trace,
-}: { trace: CascadeStrategyTraceResponse }) {
+  searchQuery,
+}: { trace: CascadeStrategyTraceResponse; searchQuery: { value: string } }) {
   if (trace.events.length === 0) {
     return html`<${EmptyState}>최근 strategy decision 이 없습니다. (cascade 호출이 아직 발생하지 않음)<//>`
   }
+  const query = searchQuery.value.trim().toLowerCase()
+  const filtered = query
+    ? trace.events.filter(e => traceEventMatchesSearch(e, query))
+    : trace.events
   return html`
+    ${query ? html`<div class="text-xs text-[var(--text-muted)] mb-2">${filtered.length}/${trace.events.length}건</div>` : null}
     <table class="w-full text-xs">
       <thead>
         <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
@@ -286,7 +309,7 @@ function StrategyTraceTable({
         </tr>
       </thead>
       <tbody>
-        ${trace.events.map((e: CascadeStrategyTraceEvent) => {
+        ${filtered.map((e: CascadeStrategyTraceEvent) => {
           const tone = traceKindTone(e.kind)
           return html`
           <tr class="border-b border-[var(--card-border)] last:border-b-0">
@@ -371,6 +394,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
 }
 
 export function CascadeConfigPanel() {
+  const traceSearch = useSignal('')
   const resourceRef = useRef<ManagedAsyncResource<CascadeData> | null>(null)
   if (resourceRef.current === null) {
     resourceRef.current = createManagedAsyncResource<CascadeData>()
@@ -476,7 +500,18 @@ export function CascadeConfigPanel() {
 
       <${Card} title="Strategy Decisions — cycle 추적">
         ${trace
-          ? html`<${StrategyTraceTable} trace=${trace} />`
+          ? html`
+            <div class="flex items-center gap-3 mb-3">
+              <${TextInput}
+                class="max-w-[280px]"
+                placeholder="검색 (cascade, strategy, 결과...)"
+                ariaLabel="strategy trace 검색"
+                value=${traceSearch.value}
+                onInput=${(e: Event) => { traceSearch.value = (e.target as HTMLInputElement).value }}
+              />
+            </div>
+            <${StrategyTraceTable} trace=${trace} searchQuery=${traceSearch} />
+          `
           : null}
       <//>
     </div>


### PR DESCRIPTION
## Summary
- Add text search input to Strategy Decisions card in CascadeConfigPanel
- `traceEventMatchesSearch` matches cascade_name, strategy, kind (EN + KR), cycle, candidates_in/out
- Export 12 pure functions (fmtPct, candidateTone, sourceLabel, sourceTone, providerTone, capacityTone, eventKindTone, eventKindLabel, capacityKindLabel, traceKindTone, traceKindLabel, traceEventMatchesSearch)
- 31 tests covering all exported functions

## Test plan
- [x] `vitest run src/components/cascade-config-panel.test.ts` — 31/31 pass
- [x] `tsc --noEmit` — no errors
- [ ] Dashboard UI: verify search input appears in Strategy Decisions card
- [ ] Dashboard UI: verify filtering works with cascade name, strategy, Korean labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)