### PR TITLE
test(dashboard): add 33 tests for gate API decode functions

### DIFF
--- a/dashboard/src/api/gate.test.ts
+++ b/dashboard/src/api/gate.test.ts
@@ -1,0 +1,463 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decodeGateStatusData,
+  decodeGateKeepersData,
+  decodeGateConnectorsData,
+} from './gate'
+
+describe('decodeGateStatusData', () => {
+  it('returns null for null', () => {
+    expect(decodeGateStatusData(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(decodeGateStatusData(undefined)).toBeNull()
+  })
+
+  it('returns null for non-object', () => {
+    expect(decodeGateStatusData('string')).toBeNull()
+    expect(decodeGateStatusData(42)).toBeNull()
+  })
+
+  it('decodes empty status data', () => {
+    const raw = {}
+    const result = decodeGateStatusData(raw)
+    expect(result).not.toBeNull()
+    expect(result!.channels).toEqual([])
+    expect(result!.bindings).toEqual([])
+    expect(result!.recent_events).toEqual([])
+    expect(result!.total_messages).toBe(0)
+    expect(result!.total_success).toBe(0)
+    expect(result!.total_errors).toBe(0)
+    expect(result!.total_duplicates).toBe(0)
+    expect(result!.success_rate_pct).toBe(0)
+    expect(result!.dedup_table_size).toBe(0)
+    expect(result!.uptime_seconds).toBe(0)
+  })
+
+  it('decodes full status data with channels', () => {
+    const raw = {
+      channels: [
+        {
+          channel: 'discord:guild1:chan1',
+          message_count: 100,
+          success_count: 90,
+          error_count: 5,
+          duplicate_count: 5,
+          validation_error_count: 1,
+          keeper_error_count: 2,
+          dispatch_unavailable_count: 1,
+          internal_error_count: 1,
+          last_activity: '2026-04-17T10:00:00Z',
+          last_success: '2026-04-17T10:00:00Z',
+          last_error_at: '2026-04-17T09:50:00Z',
+          last_keeper: 'janitor',
+          last_room_id: 'room-1',
+          last_error: 'timeout',
+          last_error_kind: 'network',
+          last_outcome: 'error',
+          avg_duration_ms: 250,
+          max_duration_ms: 1200,
+          slow_count: 3,
+          slow_rate_pct: 3.0,
+          success_rate_pct: 90.0,
+          room_count: 2,
+          health: 'healthy',
+        },
+      ],
+      bindings: [],
+      recent_events: [],
+      total_messages: 100,
+      total_success: 90,
+      total_errors: 5,
+      total_duplicates: 5,
+      success_rate_pct: 90.0,
+      dedup_table_size: 42,
+      uptime_seconds: 86400,
+    }
+    const result = decodeGateStatusData(raw)
+    expect(result).not.toBeNull()
+    expect(result!.channels).toHaveLength(1)
+    expect(result!.channels[0].channel).toBe('discord:guild1:chan1')
+    expect(result!.channels[0].message_count).toBe(100)
+    expect(result!.channels[0].success_rate_pct).toBe(90.0)
+    expect(result!.channels[0].health).toBe('healthy')
+    expect(result!.dedup_table_size).toBe(42)
+    expect(result!.uptime_seconds).toBe(86400)
+  })
+
+  it('skips channel missing channel name', () => {
+    const raw = { channels: [{ message_count: 5 }] }
+    const result = decodeGateStatusData(raw)
+    expect(result).not.toBeNull()
+    expect(result!.channels).toEqual([])
+  })
+
+  it('decodes bindings', () => {
+    const raw = {
+      bindings: [
+        {
+          channel: 'discord:g:c',
+          room_id: 'room-1',
+          keeper: 'janitor',
+          message_count: 50,
+          success_count: 48,
+          error_count: 2,
+          duplicate_count: 0,
+          last_activity: '2026-04-17T10:00:00Z',
+          last_success: '2026-04-17T10:00:00Z',
+          last_error_at: '',
+          last_error: '',
+          last_error_kind: '',
+          last_outcome: 'ok',
+          avg_duration_ms: 100,
+          max_duration_ms: 500,
+          success_rate_pct: 96.0,
+          health: 'healthy',
+        },
+      ],
+    }
+    const result = decodeGateStatusData(raw)
+    expect(result!.bindings).toHaveLength(1)
+    expect(result!.bindings[0].channel).toBe('discord:g:c')
+    expect(result!.bindings[0].keeper).toBe('janitor')
+    expect(result!.bindings[0].room_id).toBe('room-1')
+  })
+
+  it('skips binding missing required fields', () => {
+    const raw = { bindings: [{ channel: 'discord:g:c' }] }
+    const result = decodeGateStatusData(raw)
+    expect(result!.bindings).toEqual([])
+  })
+
+  it('decodes recent_events', () => {
+    const raw = {
+      recent_events: [
+        {
+          seq: 1,
+          timestamp: '2026-04-17T10:00:00Z',
+          channel: 'discord:g:c',
+          room_id: 'room-1',
+          keeper: 'janitor',
+          outcome: 'success',
+          error_kind: '',
+          error: '',
+          duration_ms: 150,
+        },
+      ],
+    }
+    const result = decodeGateStatusData(raw)
+    expect(result!.recent_events).toHaveLength(1)
+    expect(result!.recent_events[0].seq).toBe(1)
+    expect(result!.recent_events[0].outcome).toBe('success')
+    expect(result!.recent_events[0].duration_ms).toBe(150)
+  })
+
+  it('skips event missing required fields', () => {
+    const raw = { recent_events: [{ seq: 1, channel: 'discord:g:c' }] }
+    const result = decodeGateStatusData(raw)
+    expect(result!.recent_events).toEqual([])
+  })
+
+  it('uses defaults for missing numeric fields', () => {
+    const raw = { total_messages: null, uptime_seconds: undefined }
+    const result = decodeGateStatusData(raw)
+    expect(result!.total_messages).toBe(0)
+    expect(result!.uptime_seconds).toBe(0)
+  })
+
+  it('handles channel with default health', () => {
+    const raw = { channels: [{ channel: 'test' }] }
+    const result = decodeGateStatusData(raw)
+    expect(result!.channels[0].health).toBe('idle')
+  })
+})
+
+describe('decodeGateKeepersData', () => {
+  it('returns null for null', () => {
+    expect(decodeGateKeepersData(null)).toBeNull()
+  })
+
+  it('returns null for non-object', () => {
+    expect(decodeGateKeepersData(42)).toBeNull()
+  })
+
+  it('decodes empty keepers data', () => {
+    const result = decodeGateKeepersData({})
+    expect(result).not.toBeNull()
+    expect(result!.count).toBe(0)
+    expect(result!.keepers).toEqual([])
+  })
+
+  it('decodes keepers with required name', () => {
+    const raw = {
+      count: 2,
+      keepers: [
+        { name: 'janitor', status: 'active', keepalive_running: true, last_turn_ago_s: 30 },
+        { name: 'dreamer', status: 'idle', agent_name: 'agent-1' },
+      ],
+    }
+    const result = decodeGateKeepersData(raw)
+    expect(result!.count).toBe(2)
+    expect(result!.keepers).toHaveLength(2)
+    expect(result!.keepers[0].name).toBe('janitor')
+    expect(result!.keepers[0].status).toBe('active')
+    expect(result!.keepers[0].keepalive_running).toBe(true)
+    expect(result!.keepers[0].last_turn_ago_s).toBe(30)
+    expect(result!.keepers[1].name).toBe('dreamer')
+    expect(result!.keepers[1].agent_name).toBe('agent-1')
+  })
+
+  it('skips keeper without name', () => {
+    const raw = { keepers: [{ status: 'active' }, { name: 'janitor' }] }
+    const result = decodeGateKeepersData(raw)
+    expect(result!.keepers).toHaveLength(1)
+    expect(result!.keepers[0].name).toBe('janitor')
+  })
+
+  it('handles missing optional fields as undefined', () => {
+    const raw = { keepers: [{ name: 'minimal' }] }
+    const result = decodeGateKeepersData(raw)
+    const keeper = result!.keepers[0]
+    expect(keeper.name).toBe('minimal')
+    expect(keeper.agent_name).toBeUndefined()
+    expect(keeper.status).toBeUndefined()
+    expect(keeper.model).toBeUndefined()
+    expect(keeper.keepalive_running).toBeUndefined()
+    expect(keeper.last_turn_ago_s).toBeNull()
+  })
+
+  it('handles null last_turn_ago_s', () => {
+    const raw = { keepers: [{ name: 'test', last_turn_ago_s: null }] }
+    const result = decodeGateKeepersData(raw)
+    expect(result!.keepers[0].last_turn_ago_s).toBeNull()
+  })
+
+  it('uses default count 0', () => {
+    const raw = { keepers: [{ name: 'test' }] }
+    const result = decodeGateKeepersData(raw)
+    expect(result!.count).toBe(0)
+  })
+})
+
+describe('decodeGateConnectorsData', () => {
+  it('returns null for null', () => {
+    expect(decodeGateConnectorsData(null)).toBeNull()
+  })
+
+  it('returns null for non-object', () => {
+    expect(decodeGateConnectorsData('x')).toBeNull()
+  })
+
+  it('returns null when generated_at is missing', () => {
+    const raw = { connectors: [], total: 0, active_count: 0 }
+    expect(decodeGateConnectorsData(raw)).toBeNull()
+  })
+
+  it('returns null when generated_at is empty', () => {
+    const raw = { generated_at: '', connectors: [] }
+    expect(decodeGateConnectorsData(raw)).toBeNull()
+  })
+
+  it('decodes minimal connectors data', () => {
+    const raw = { generated_at: '2026-04-17T10:00:00Z' }
+    const result = decodeGateConnectorsData(raw)
+    expect(result).not.toBeNull()
+    expect(result!.generated_at).toBe('2026-04-17T10:00:00Z')
+    expect(result!.connectors).toEqual([])
+    expect(result!.total).toBe(0)
+    expect(result!.active_count).toBe(0)
+  })
+
+  it('decodes full connector with bindings and audit', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      total: 1,
+      active_count: 1,
+      connectors: [
+        {
+          connector_id: 'discord-main',
+          display_name: 'Discord Main',
+          channel: 'discord',
+          capabilities: ['send', 'receive'],
+          status: 'connected',
+          available: true,
+          connected: true,
+          stale: false,
+          stale_after_sec: 120,
+          error: '',
+          configured_bindings: [
+            { channel_id: 'ch-1', keeper_name: 'janitor' },
+          ],
+          recent_audit: [
+            {
+              timestamp: '2026-04-17T09:00:00Z',
+              action: 'bind',
+              guild_id: 'g-1',
+              channel_id: 'ch-1',
+              keeper_name: 'janitor',
+              actor_id: 'actor-1',
+              actor_name: 'Admin',
+              previous_keeper: 'old-keeper',
+            },
+          ],
+          storage_paths: {
+            status_path: '/data/status.json',
+            binding_store_path: '/data/bindings.json',
+            audit_path: '/data/audit.jsonl',
+            names_path: '/data/names.json',
+          },
+          runtime_summary: {
+            available: true,
+            connected: true,
+            stale: false,
+            stale_after_sec: 120,
+            status: 'ready',
+            bot_user_name: 'TestBot',
+            bot_user_id: 'bot-123',
+            guild_count: 3,
+            pid: 12345,
+          },
+          binding_summary: {
+            binding_source: 'config',
+            runtime_bindings_count: 1,
+            configured_bindings_count: 1,
+          },
+          names: {
+            guild_names: { 'g-1': 'Test Guild' },
+            channel_names: { 'ch-1': 'general' },
+            channel_to_guild: { 'ch-1': 'g-1' },
+            updated_at: '2026-04-17T08:00:00Z',
+          },
+        },
+      ],
+    }
+    const result = decodeGateConnectorsData(raw)
+    expect(result!.connectors).toHaveLength(1)
+    const conn = result!.connectors[0]
+    expect(conn.connector_id).toBe('discord-main')
+    expect(conn.display_name).toBe('Discord Main')
+    expect(conn.channel).toBe('discord')
+    expect(conn.capabilities).toEqual(['send', 'receive'])
+    expect(conn.available).toBe(true)
+    expect(conn.configured_bindings).toHaveLength(1)
+    expect(conn.configured_bindings[0].channel_id).toBe('ch-1')
+    expect(conn.recent_audit).toHaveLength(1)
+    expect(conn.recent_audit[0].action).toBe('bind')
+    expect(conn.recent_audit[0].previous_keeper).toBe('old-keeper')
+    expect(conn.storage_paths.status_path).toBe('/data/status.json')
+    expect(conn.runtime_summary.bot_user_name).toBe('TestBot')
+    expect(conn.runtime_summary.guild_count).toBe(3)
+    expect(conn.binding_summary.binding_source).toBe('config')
+    expect(conn.names.guild_names['g-1']).toBe('Test Guild')
+    expect(conn.names.channel_names['ch-1']).toBe('general')
+  })
+
+  it('skips connector missing required fields', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [
+        { connector_id: 'x' },
+        { connector_id: 'y', display_name: 'Y' },
+        { connector_id: 'z', display_name: 'Z', channel: 'discord' },
+      ],
+    }
+    const result = decodeGateConnectorsData(raw)
+    expect(result!.connectors).toHaveLength(1)
+    expect(result!.connectors[0].connector_id).toBe('z')
+  })
+
+  it('skips configured_binding missing required fields', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [{
+        connector_id: 'c1',
+        display_name: 'C1',
+        channel: 'discord',
+        configured_bindings: [{ channel_id: 'ch-1' }],
+      }],
+    }
+    const result = decodeGateConnectorsData(raw)
+    expect(result!.connectors[0].configured_bindings).toEqual([])
+  })
+
+  it('skips audit entry missing required fields', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [{
+        connector_id: 'c1',
+        display_name: 'C1',
+        channel: 'discord',
+        recent_audit: [{ timestamp: '2026-04-17T09:00:00Z', action: 'bind' }],
+      }],
+    }
+    const result = decodeGateConnectorsData(raw)
+    expect(result!.connectors[0].recent_audit).toEqual([])
+  })
+
+  it('handles missing storage_paths gracefully', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [{
+        connector_id: 'c1',
+        display_name: 'C1',
+        channel: 'discord',
+      }],
+    }
+    const result = decodeGateConnectorsData(raw)
+    const sp = result!.connectors[0].storage_paths
+    expect(sp.status_path).toBe('')
+    expect(sp.binding_store_path).toBe('')
+  })
+
+  it('handles missing names gracefully', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [{
+        connector_id: 'c1',
+        display_name: 'C1',
+        channel: 'discord',
+      }],
+    }
+    const result = decodeGateConnectorsData(raw)
+    expect(result!.connectors[0].names.guild_names).toEqual({})
+    expect(result!.connectors[0].names.channel_names).toEqual({})
+  })
+
+  it('filters non-string values from string maps', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [{
+        connector_id: 'c1',
+        display_name: 'C1',
+        channel: 'discord',
+        names: {
+          guild_names: { valid: 'Guild A', invalid: 42, empty: '' },
+        },
+      }],
+    }
+    const result = decodeGateConnectorsData(raw)
+    const gn = result!.connectors[0].names.guild_names
+    expect(gn['valid']).toBe('Guild A')
+    expect('invalid' in gn).toBe(false)
+    expect('empty' in gn).toBe(false)
+  })
+
+  it('uses configured_bindings length as fallback for binding_summary count', () => {
+    const raw = {
+      generated_at: '2026-04-17T10:00:00Z',
+      connectors: [{
+        connector_id: 'c1',
+        display_name: 'C1',
+        channel: 'discord',
+        configured_bindings: [
+          { channel_id: 'ch-1', keeper_name: 'k1' },
+          { channel_id: 'ch-2', keeper_name: 'k2' },
+        ],
+      }],
+    }
+    const result = decodeGateConnectorsData(raw)
+    // binding_summary is missing, so configured_bindings_count should fallback to 2
+    expect(result!.connectors[0].binding_summary.configured_bindings_count).toBe(2)
+  })
+})

--- a/dashboard/src/api/gate.test.ts
+++ b/dashboard/src/api/gate.test.ts
@@ -78,10 +78,10 @@ describe('decodeGateStatusData', () => {
     const result = decodeGateStatusData(raw)
     expect(result).not.toBeNull()
     expect(result!.channels).toHaveLength(1)
-    expect(result!.channels[0].channel).toBe('discord:guild1:chan1')
-    expect(result!.channels[0].message_count).toBe(100)
-    expect(result!.channels[0].success_rate_pct).toBe(90.0)
-    expect(result!.channels[0].health).toBe('healthy')
+    expect(result!.channels[0]!.channel).toBe('discord:guild1:chan1')
+    expect(result!.channels[0]!.message_count).toBe(100)
+    expect(result!.channels[0]!.success_rate_pct).toBe(90.0)
+    expect(result!.channels[0]!.health).toBe('healthy')
     expect(result!.dedup_table_size).toBe(42)
     expect(result!.uptime_seconds).toBe(86400)
   })
@@ -119,9 +119,9 @@ describe('decodeGateStatusData', () => {
     }
     const result = decodeGateStatusData(raw)
     expect(result!.bindings).toHaveLength(1)
-    expect(result!.bindings[0].channel).toBe('discord:g:c')
-    expect(result!.bindings[0].keeper).toBe('janitor')
-    expect(result!.bindings[0].room_id).toBe('room-1')
+    expect(result!.bindings[0]!.channel).toBe('discord:g:c')
+    expect(result!.bindings[0]!.keeper).toBe('janitor')
+    expect(result!.bindings[0]!.room_id).toBe('room-1')
   })
 
   it('skips binding missing required fields', () => {
@@ -148,9 +148,9 @@ describe('decodeGateStatusData', () => {
     }
     const result = decodeGateStatusData(raw)
     expect(result!.recent_events).toHaveLength(1)
-    expect(result!.recent_events[0].seq).toBe(1)
-    expect(result!.recent_events[0].outcome).toBe('success')
-    expect(result!.recent_events[0].duration_ms).toBe(150)
+    expect(result!.recent_events[0]!.seq).toBe(1)
+    expect(result!.recent_events[0]!.outcome).toBe('success')
+    expect(result!.recent_events[0]!.duration_ms).toBe(150)
   })
 
   it('skips event missing required fields', () => {
@@ -169,7 +169,7 @@ describe('decodeGateStatusData', () => {
   it('handles channel with default health', () => {
     const raw = { channels: [{ channel: 'test' }] }
     const result = decodeGateStatusData(raw)
-    expect(result!.channels[0].health).toBe('idle')
+    expect(result!.channels[0]!.health).toBe('idle')
   })
 })
 
@@ -200,25 +200,27 @@ describe('decodeGateKeepersData', () => {
     const result = decodeGateKeepersData(raw)
     expect(result!.count).toBe(2)
     expect(result!.keepers).toHaveLength(2)
-    expect(result!.keepers[0].name).toBe('janitor')
-    expect(result!.keepers[0].status).toBe('active')
-    expect(result!.keepers[0].keepalive_running).toBe(true)
-    expect(result!.keepers[0].last_turn_ago_s).toBe(30)
-    expect(result!.keepers[1].name).toBe('dreamer')
-    expect(result!.keepers[1].agent_name).toBe('agent-1')
+    expect(result!.keepers[0]!.name).toBe('janitor')
+    expect(result!.keepers[0]!.status).toBe('active')
+    expect(result!.keepers[0]!.keepalive_running).toBe(true)
+    expect(result!.keepers[0]!.last_turn_ago_s).toBe(30)
+    expect(result!.keepers[1]!.name).toBe('dreamer')
+    expect(result!.keepers[1]!.agent_name).toBe('agent-1')
   })
 
   it('skips keeper without name', () => {
     const raw = { keepers: [{ status: 'active' }, { name: 'janitor' }] }
     const result = decodeGateKeepersData(raw)
     expect(result!.keepers).toHaveLength(1)
-    expect(result!.keepers[0].name).toBe('janitor')
+    expect(result!.keepers[0]!.name).toBe('janitor')
   })
 
   it('handles missing optional fields as undefined', () => {
     const raw = { keepers: [{ name: 'minimal' }] }
     const result = decodeGateKeepersData(raw)
-    const keeper = result!.keepers[0]
+    expect(result).not.toBeNull()
+    expect(result!.keepers).toHaveLength(1)
+    const keeper = result!.keepers[0]!
     expect(keeper.name).toBe('minimal')
     expect(keeper.agent_name).toBeUndefined()
     expect(keeper.status).toBeUndefined()
@@ -230,7 +232,7 @@ describe('decodeGateKeepersData', () => {
   it('handles null last_turn_ago_s', () => {
     const raw = { keepers: [{ name: 'test', last_turn_ago_s: null }] }
     const result = decodeGateKeepersData(raw)
-    expect(result!.keepers[0].last_turn_ago_s).toBeNull()
+    expect(result!.keepers[0]!.last_turn_ago_s).toBeNull()
   })
 
   it('uses default count 0', () => {
@@ -334,17 +336,17 @@ describe('decodeGateConnectorsData', () => {
     }
     const result = decodeGateConnectorsData(raw)
     expect(result!.connectors).toHaveLength(1)
-    const conn = result!.connectors[0]
+    const conn = result!.connectors[0]!
     expect(conn.connector_id).toBe('discord-main')
     expect(conn.display_name).toBe('Discord Main')
     expect(conn.channel).toBe('discord')
     expect(conn.capabilities).toEqual(['send', 'receive'])
     expect(conn.available).toBe(true)
     expect(conn.configured_bindings).toHaveLength(1)
-    expect(conn.configured_bindings[0].channel_id).toBe('ch-1')
+    expect(conn.configured_bindings[0]!.channel_id).toBe('ch-1')
     expect(conn.recent_audit).toHaveLength(1)
-    expect(conn.recent_audit[0].action).toBe('bind')
-    expect(conn.recent_audit[0].previous_keeper).toBe('old-keeper')
+    expect(conn.recent_audit[0]!.action).toBe('bind')
+    expect(conn.recent_audit[0]!.previous_keeper).toBe('old-keeper')
     expect(conn.storage_paths.status_path).toBe('/data/status.json')
     expect(conn.runtime_summary.bot_user_name).toBe('TestBot')
     expect(conn.runtime_summary.guild_count).toBe(3)
@@ -364,7 +366,7 @@ describe('decodeGateConnectorsData', () => {
     }
     const result = decodeGateConnectorsData(raw)
     expect(result!.connectors).toHaveLength(1)
-    expect(result!.connectors[0].connector_id).toBe('z')
+    expect(result!.connectors[0]!.connector_id).toBe('z')
   })
 
   it('skips configured_binding missing required fields', () => {
@@ -378,7 +380,7 @@ describe('decodeGateConnectorsData', () => {
       }],
     }
     const result = decodeGateConnectorsData(raw)
-    expect(result!.connectors[0].configured_bindings).toEqual([])
+    expect(result!.connectors[0]!.configured_bindings).toEqual([])
   })
 
   it('skips audit entry missing required fields', () => {
@@ -392,7 +394,7 @@ describe('decodeGateConnectorsData', () => {
       }],
     }
     const result = decodeGateConnectorsData(raw)
-    expect(result!.connectors[0].recent_audit).toEqual([])
+    expect(result!.connectors[0]!.recent_audit).toEqual([])
   })
 
   it('handles missing storage_paths gracefully', () => {
@@ -405,7 +407,7 @@ describe('decodeGateConnectorsData', () => {
       }],
     }
     const result = decodeGateConnectorsData(raw)
-    const sp = result!.connectors[0].storage_paths
+    const sp = result!.connectors[0]!.storage_paths
     expect(sp.status_path).toBe('')
     expect(sp.binding_store_path).toBe('')
   })
@@ -420,8 +422,8 @@ describe('decodeGateConnectorsData', () => {
       }],
     }
     const result = decodeGateConnectorsData(raw)
-    expect(result!.connectors[0].names.guild_names).toEqual({})
-    expect(result!.connectors[0].names.channel_names).toEqual({})
+    expect(result!.connectors[0]!.names.guild_names).toEqual({})
+    expect(result!.connectors[0]!.names.channel_names).toEqual({})
   })
 
   it('filters non-string values from string maps', () => {
@@ -437,7 +439,7 @@ describe('decodeGateConnectorsData', () => {
       }],
     }
     const result = decodeGateConnectorsData(raw)
-    const gn = result!.connectors[0].names.guild_names
+    const gn = result!.connectors[0]!.names.guild_names
     expect(gn['valid']).toBe('Guild A')
     expect('invalid' in gn).toBe(false)
     expect('empty' in gn).toBe(false)
@@ -458,6 +460,6 @@ describe('decodeGateConnectorsData', () => {
     }
     const result = decodeGateConnectorsData(raw)
     // binding_summary is missing, so configured_bindings_count should fallback to 2
-    expect(result!.connectors[0].binding_summary.configured_bindings_count).toBe(2)
+    expect(result!.connectors[0]!.binding_summary.configured_bindings_count).toBe(2)
   })
 })

--- a/dashboard/src/api/transport-health.test.ts
+++ b/dashboard/src/api/transport-health.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest'
+import { decodeTransportHealthData } from './transport-health'
+
+/** Minimal valid raw payload with all required sub-objects. */
+function minimalRaw(overrides: Record<string, unknown> = {}) {
+  return {
+    summary: { primary_path: 'sse', queue_pressure: 'normal' },
+    sse: {},
+    grpc: {},
+    websocket: {},
+    webrtc: {},
+    streamable_http: {},
+    http2: {},
+    cluster: {},
+    agent_health: {},
+    generated_at: '2026-04-17T10:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('decodeTransportHealthData', () => {
+  it('returns null for null', () => {
+    expect(decodeTransportHealthData(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(decodeTransportHealthData(undefined)).toBeNull()
+  })
+
+  it('returns null when generated_at is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ generated_at: undefined }))).toBeNull()
+  })
+
+  it('returns null when generated_at is empty', () => {
+    expect(decodeTransportHealthData(minimalRaw({ generated_at: '' }))).toBeNull()
+  })
+
+  it('returns null when summary is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ summary: undefined }))).toBeNull()
+  })
+
+  it('returns null when sse is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ sse: undefined }))).toBeNull()
+  })
+
+  it('returns null when grpc is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ grpc: undefined }))).toBeNull()
+  })
+
+  it('returns null when websocket is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ websocket: undefined }))).toBeNull()
+  })
+
+  it('returns null when webrtc is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ webrtc: undefined }))).toBeNull()
+  })
+
+  it('returns null when streamable_http is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ streamable_http: undefined }))).toBeNull()
+  })
+
+  it('returns null when http2 is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ http2: undefined }))).toBeNull()
+  })
+
+  it('returns null when cluster is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ cluster: undefined }))).toBeNull()
+  })
+
+  it('returns null when agent_health is missing', () => {
+    expect(decodeTransportHealthData(minimalRaw({ agent_health: undefined }))).toBeNull()
+  })
+
+  it('decodes minimal payload with defaults', () => {
+    const result = decodeTransportHealthData(minimalRaw())
+    expect(result).not.toBeNull()
+    expect(result!.generated_at).toBe('2026-04-17T10:00:00Z')
+    // summary defaults
+    expect(result!.summary.primary_path).toBe('sse')
+    expect(result!.summary.queue_pressure).toBe('normal')
+    expect(result!.summary.recent_messages).toBeNull()
+    expect(result!.summary.recent_messages_available).toBe(false)
+    expect(result!.summary.external_fanout_targets).toBe(0)
+    // sse defaults
+    expect(result!.sse.sessions_total).toBe(0)
+    expect(result!.sse.hot_sessions).toEqual([])
+    // grpc defaults
+    expect(result!.grpc.enabled).toBe(false)
+    expect(result!.grpc.port).toBe(0)
+    // websocket defaults
+    expect(result!.websocket.mode).toBe('unknown')
+    // webrtc defaults
+    expect(result!.webrtc.signaling_mode).toBe('unknown')
+    // streamable_http defaults
+    expect(result!.streamable_http.default_transport).toBe('unknown')
+    // http2 defaults
+    expect(result!.http2.listener_mode).toBe('unknown')
+    // cluster defaults
+    expect(result!.cluster.cluster).toBe('default')
+    expect(result!.cluster.total_units).toBeNull()
+    // agent_health defaults
+    expect(result!.agent_health.stale_total).toBe(0)
+    // projection_diagnostics not present
+    expect(result!.projection_diagnostics).toBeUndefined()
+  })
+
+  it('decodes full payload with all fields', () => {
+    const raw = minimalRaw({
+      summary: {
+        primary_path: 'grpc',
+        queue_pressure: 'high',
+        recent_messages: 42,
+        recent_messages_available: true,
+        recent_messages_source: 'grpc',
+        external_fanout_targets: 3,
+      },
+      sse: {
+        sessions_observer: 2,
+        sessions_coordinator: 1,
+        sessions_total: 3,
+        external_subscribers: 5,
+        broadcast_avg_seconds: 0.5,
+        broadcast_count: 100,
+        queue_avg_depth: 2,
+        queue_max_depth: 10,
+        hot_sessions: [
+          { session_id: 'sess-1', kind: 'observer', queue_depth: 5, last_event_id: 99, idle_seconds: 3 },
+          { session_id: 'sess-2', kind: 'coordinator', queue_depth: 0, last_event_id: 50, idle_seconds: 30 },
+        ],
+      },
+      grpc: {
+        enabled: true,
+        configured: true,
+        listening: true,
+        port: 50051,
+        active_streams: 4,
+        subscribers: 10,
+        heartbeat_avg_seconds: 1.2,
+        events_delivered: 500,
+      },
+      websocket: {
+        enabled: true,
+        configured: true,
+        listening: false,
+        mode: 'relay',
+        port: 8080,
+        sessions: 2,
+        relay_source: 'sse',
+      },
+      webrtc: {
+        enabled: false,
+        configured: false,
+        signaling_available: false,
+        signaling_mode: 'none',
+        pending_offers: 0,
+        active_peers: 0,
+        live_connections: 0,
+        connected_channels: 0,
+        ice_server_count: 2,
+      },
+      streamable_http: {
+        endpoint: '/mcp',
+        observer_stream: '/mcp?sse_kind=observer',
+        managed_endpoint: '/mcp/managed',
+        operator_endpoint: '/mcp/operator',
+        delete_endpoint: '/mcp',
+        legacy_sse_endpoint: '/sse',
+        legacy_messages_endpoint: '/messages',
+        default_transport: 'streamable-http',
+        supports_post: true,
+        supports_sse_upgrade: true,
+        supports_delete: true,
+      },
+      http2: {
+        listener_mode: 'h2c',
+        multiplex_ready: true,
+        prior_knowledge_path: '/mcp',
+      },
+      cluster: {
+        cluster: 'prod',
+        room_id: 'room-1',
+        topology_available: true,
+        topology_source: 'file',
+        total_units: 5,
+        managed_units: 5,
+        live_agents: 3,
+        active_operations: 1,
+        stale_units: 0,
+      },
+      agent_health: { stale_total: 2 },
+    })
+    const result = decodeTransportHealthData(raw)
+    expect(result!.summary.primary_path).toBe('grpc')
+    expect(result!.summary.recent_messages).toBe(42)
+    expect(result!.sse.sessions_total).toBe(3)
+    expect(result!.sse.hot_sessions).toHaveLength(2)
+    expect(result!.sse.hot_sessions[0].session_id).toBe('sess-1')
+    expect(result!.sse.hot_sessions[0].kind).toBe('observer')
+    expect(result!.grpc.enabled).toBe(true)
+    expect(result!.grpc.port).toBe(50051)
+    expect(result!.websocket.mode).toBe('relay')
+    expect(result!.webrtc.ice_server_count).toBe(2)
+    expect(result!.streamable_http.supports_post).toBe(true)
+    expect(result!.http2.multiplex_ready).toBe(true)
+    expect(result!.cluster.total_units).toBe(5)
+    expect(result!.cluster.live_agents).toBe(3)
+    expect(result!.agent_health.stale_total).toBe(2)
+  })
+
+  it('decodes hot_sessions with defaults', () => {
+    const raw = minimalRaw({
+      sse: { hot_sessions: [{ session_id: 's1' }] },
+    })
+    const result = decodeTransportHealthData(raw)
+    const hs = result!.sse.hot_sessions
+    expect(hs).toHaveLength(1)
+    expect(hs[0].session_id).toBe('s1')
+    expect(hs[0].kind).toBe('unknown')
+    expect(hs[0].queue_depth).toBe(0)
+    expect(hs[0].idle_seconds).toBe(0)
+  })
+
+  it('skips hot_session without session_id', () => {
+    const raw = minimalRaw({
+      sse: { hot_sessions: [{ kind: 'observer' }, { session_id: 's1' }] },
+    })
+    const result = decodeTransportHealthData(raw)
+    expect(result!.sse.hot_sessions).toHaveLength(1)
+  })
+
+  it('decodes projection_diagnostics when present', () => {
+    const raw = minimalRaw({
+      projection_diagnostics: {
+        source: 'keeper_poll',
+        cache_state: 'warm',
+        last_success_at: '2026-04-17T09:00:00Z',
+        last_attempt_at: '2026-04-17T09:00:01Z',
+        last_error_at: null,
+        stale_reason: null,
+        stale_age_ms: 5000,
+      },
+    })
+    const result = decodeTransportHealthData(raw)
+    const pd = result!.projection_diagnostics!
+    expect(pd.source).toBe('keeper_poll')
+    expect(pd.cache_state).toBe('warm')
+    expect(pd.last_success_at).toBe('2026-04-17T09:00:00Z')
+    expect(pd.last_error_at).toBeNull()
+    expect(pd.stale_age_ms).toBe(5000)
+  })
+
+  it('omits projection_diagnostics when not present', () => {
+    const result = decodeTransportHealthData(minimalRaw())
+    expect(result!.projection_diagnostics).toBeUndefined()
+  })
+
+  it('handles cluster with null numeric fields', () => {
+    const raw = minimalRaw({
+      cluster: { total_units: null, live_agents: null },
+    })
+    const result = decodeTransportHealthData(raw)
+    expect(result!.cluster.total_units).toBeNull()
+    expect(result!.cluster.live_agents).toBeNull()
+  })
+})

--- a/dashboard/src/api/transport-health.test.ts
+++ b/dashboard/src/api/transport-health.test.ts
@@ -194,8 +194,8 @@ describe('decodeTransportHealthData', () => {
     expect(result!.summary.recent_messages).toBe(42)
     expect(result!.sse.sessions_total).toBe(3)
     expect(result!.sse.hot_sessions).toHaveLength(2)
-    expect(result!.sse.hot_sessions[0].session_id).toBe('sess-1')
-    expect(result!.sse.hot_sessions[0].kind).toBe('observer')
+    expect(result!.sse.hot_sessions[0]!.session_id).toBe('sess-1')
+    expect(result!.sse.hot_sessions[0]!.kind).toBe('observer')
     expect(result!.grpc.enabled).toBe(true)
     expect(result!.grpc.port).toBe(50051)
     expect(result!.websocket.mode).toBe('relay')
@@ -214,10 +214,10 @@ describe('decodeTransportHealthData', () => {
     const result = decodeTransportHealthData(raw)
     const hs = result!.sse.hot_sessions
     expect(hs).toHaveLength(1)
-    expect(hs[0].session_id).toBe('s1')
-    expect(hs[0].kind).toBe('unknown')
-    expect(hs[0].queue_depth).toBe(0)
-    expect(hs[0].idle_seconds).toBe(0)
+    expect(hs[0]!.session_id).toBe('s1')
+    expect(hs[0]!.kind).toBe('unknown')
+    expect(hs[0]!.queue_depth).toBe(0)
+    expect(hs[0]!.idle_seconds).toBe(0)
   })
 
   it('skips hot_session without session_id', () => {

--- a/dashboard/src/components/fsm-hub-derivations.test.ts
+++ b/dashboard/src/components/fsm-hub-derivations.test.ts
@@ -1,0 +1,503 @@
+import { describe, it, expect } from 'vitest'
+import type { CompositeObservation } from './fsm-hub-types'
+
+import {
+  appendCompositeObservation,
+  deriveTransitionHistory,
+  deriveTopTransitions,
+  inferTransitionReason,
+  derivePhaseLog,
+  laneChangedAt,
+  laneTransitionCount,
+  deriveStateEntries,
+  deriveTimeAxisTicks,
+  deriveSwimlaneSegments,
+  deriveLaneDwellHistograms,
+} from './fsm-hub-derivations'
+
+// --- Helpers ---
+
+function obs(overrides: Partial<CompositeObservation> & { ts: number }): CompositeObservation {
+  return {
+    phase: 'Stable',
+    turn: 'idle',
+    decision: 'undecided',
+    cascade: 'idle',
+    compaction: 'accumulating',
+    ...overrides,
+  }
+}
+
+// --- Tests ---
+
+describe('appendCompositeObservation', () => {
+  it('appends to empty observations', () => {
+    const next = obs({ ts: 100 })
+    const result = appendCompositeObservation([], next)
+    expect(result).toEqual([next])
+  })
+
+  it('appends when last observation differs', () => {
+    const a = obs({ ts: 100, phase: 'Stable' })
+    const b = obs({ ts: 200, phase: 'Running' })
+    const result = appendCompositeObservation([a], b)
+    expect(result).toEqual([a, b])
+  })
+
+  it('deduplicates identical consecutive observations', () => {
+    const a = obs({ ts: 100 })
+    const b = obs({ ts: 200 }) // same values, different ts
+    const result = appendCompositeObservation([a], b)
+    expect(result).toEqual([a]) // b is dropped
+  })
+
+  it('trims to maxEntries', () => {
+    const phases = ['Stable', 'Running', 'Compacting', 'HandingOff', 'Failing', 'Draining', 'Overflowed'] as const
+    const observations = Array.from({ length: 30 }, (_, i) => obs({ ts: i, phase: phases[i % phases.length]! }))
+    const extra = obs({ ts: 100, phase: 'Failing' })
+    const result = appendCompositeObservation(observations, extra, 10)
+    expect(result).toHaveLength(10)
+    expect(result[result.length - 1]!.phase).toBe('Failing')
+  })
+})
+
+describe('deriveTransitionHistory', () => {
+  it('returns empty for single observation', () => {
+    expect(deriveTransitionHistory([obs({ ts: 100 })])).toEqual([])
+  })
+
+  it('detects phase transition', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+    ]
+    const result = deriveTransitionHistory(observations)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.field).toBe('KSM')
+    expect(result[0]!.from).toBe('Stable')
+    expect(result[0]!.to).toBe('Running')
+    expect(result[0]!.ts).toBe(200)
+  })
+
+  it('detects multiple field transitions in one step', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable', turn: 'idle' }),
+      obs({ ts: 200, phase: 'Running', turn: 'executing' }),
+    ]
+    const result = deriveTransitionHistory(observations)
+    expect(result).toHaveLength(2)
+  })
+
+  it('skips unchanged fields', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable', turn: 'idle' }),
+      obs({ ts: 200, phase: 'Running', turn: 'idle' }),
+    ]
+    const result = deriveTransitionHistory(observations)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.field).toBe('KSM')
+  })
+
+  it('returns most recent first (reversed)', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+      obs({ ts: 300, phase: 'Failing' }),
+    ]
+    const result = deriveTransitionHistory(observations)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.to).toBe('Failing')
+    expect(result[1]!.to).toBe('Running')
+  })
+
+  it('trims to maxEntries', () => {
+    const phases = ['Stable', 'Running', 'Compacting', 'HandingOff', 'Failing'] as const
+    const observations: CompositeObservation[] = []
+    for (let i = 0; i < 50; i++) {
+      observations.push(obs({ ts: i * 10, phase: phases[i % phases.length]! }))
+    }
+    const result = deriveTransitionHistory(observations, 5)
+    expect(result).toHaveLength(5)
+  })
+})
+
+describe('deriveTopTransitions', () => {
+  it('returns empty for insufficient observations', () => {
+    expect(deriveTopTransitions([obs({ ts: 100 })])).toEqual([])
+    expect(deriveTopTransitions([])).toEqual([])
+  })
+
+  it('counts repeated transitions', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+      obs({ ts: 300, phase: 'Stable' }),
+      obs({ ts: 400, phase: 'Running' }),
+      obs({ ts: 500, phase: 'Stable' }),
+    ]
+    const result = deriveTopTransitions(observations, 10)
+    const stableToRunning = result.find(t => t.from === 'Stable' && t.to === 'Running')
+    expect(stableToRunning!.count).toBe(2)
+  })
+
+  it('sorts by count descending', () => {
+    const observations = [
+      obs({ ts: 100, turn: 'idle' }),
+      obs({ ts: 200, turn: 'executing' }),
+      obs({ ts: 300, turn: 'idle' }),
+      obs({ ts: 400, phase: 'Running' }),
+    ]
+    const result = deriveTopTransitions(observations, 10)
+    expect(result.length).toBeGreaterThanOrEqual(1)
+    if (result.length > 1) {
+      expect(result[0]!.count).toBeGreaterThanOrEqual(result[1]!.count)
+    }
+  })
+
+  it('respects limit', () => {
+    const phases = ['Stable', 'Running', 'Compacting'] as const
+    const observations: CompositeObservation[] = []
+    for (let i = 0; i < 20; i++) {
+      observations.push(obs({ ts: i * 10, phase: phases[i % 3]! }))
+    }
+    const result = deriveTopTransitions(observations, 3)
+    expect(result.length).toBeLessThanOrEqual(3)
+  })
+})
+
+describe('inferTransitionReason', () => {
+  it('returns Korean reason for KTC idle→executing', () => {
+    const result = inferTransitionReason('KTC', 'idle', 'executing')
+    expect(result).toBeTruthy()
+    expect(result).toContain('턴')
+  })
+
+  it('returns Korean reason for KTC executing→idle', () => {
+    const result = inferTransitionReason('KTC', 'executing', 'idle')
+    expect(result).toContain('정상 종료')
+  })
+
+  it('returns Korean reason for KSM to Crashed', () => {
+    const result = inferTransitionReason('KSM', 'Failing', 'Crashed')
+    expect(result).toContain('비정상 종료')
+  })
+
+  it('returns Korean reason for KDP to gate_rejected', () => {
+    const result = inferTransitionReason('KDP', 'undecided', 'gate_rejected')
+    expect(result).toContain('게이트 차단')
+  })
+
+  it('returns Korean reason for KCL to exhausted', () => {
+    const result = inferTransitionReason('KCL', 'trying', 'exhausted')
+    expect(result).toContain('소진')
+  })
+
+  it('returns Korean reason for KMC compacting→accumulating', () => {
+    const result = inferTransitionReason('KMC', 'compacting', 'accumulating')
+    expect(result).toContain('압축 완료')
+  })
+
+  it('returns null for unknown field', () => {
+    expect(inferTransitionReason('UNKNOWN', 'a', 'b')).toBeNull()
+  })
+
+  it('returns null for unhandled transition within known field', () => {
+    expect(inferTransitionReason('KTC', 'compacting', 'idle')).toBeNull()
+  })
+
+  it('returns reason for KTC to compacting', () => {
+    const result = inferTransitionReason('KTC', 'executing', 'compacting')
+    expect(result).toContain('compaction')
+  })
+
+  it('returns reason for KSM to HandingOff', () => {
+    const result = inferTransitionReason('KSM', 'Running', 'HandingOff')
+    expect(result).toContain('인계')
+  })
+})
+
+describe('derivePhaseLog', () => {
+  it('returns empty for no observations', () => {
+    expect(derivePhaseLog([])).toEqual([])
+  })
+
+  it('returns single phase for identical observations', () => {
+    const observations = [obs({ ts: 100 }), obs({ ts: 200 })]
+    expect(derivePhaseLog(observations)).toEqual(['Stable'])
+  })
+
+  it('deduplicates consecutive identical phases', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Stable' }),
+      obs({ ts: 300, phase: 'Running' }),
+      obs({ ts: 400, phase: 'Running' }),
+      obs({ ts: 500, phase: 'Failing' }),
+    ]
+    expect(derivePhaseLog(observations)).toEqual(['Stable', 'Running', 'Failing'])
+  })
+
+  it('trims to maxEntries', () => {
+    const phases = ['Stable', 'Running', 'Compacting', 'HandingOff', 'Failing'] as const
+    const observations: CompositeObservation[] = []
+    for (let i = 0; i < 50; i++) {
+      observations.push(obs({ ts: i * 10, phase: phases[i % phases.length]! }))
+    }
+    const result = derivePhaseLog(observations, 10)
+    expect(result).toHaveLength(10)
+  })
+})
+
+describe('laneChangedAt', () => {
+  it('returns 0 for empty observations', () => {
+    expect(laneChangedAt([], 'phase')).toBe(0)
+  })
+
+  it('returns first ts when lane never changed', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Stable' }),
+    ]
+    expect(laneChangedAt(observations, 'phase')).toBe(100)
+  })
+
+  it('returns timestamp of last change', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+      obs({ ts: 300, phase: 'Running' }),
+    ]
+    expect(laneChangedAt(observations, 'phase')).toBe(200)
+  })
+
+  it('tracks turn lane independently', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable', turn: 'idle' }),
+      obs({ ts: 200, phase: 'Running', turn: 'idle' }),
+      obs({ ts: 300, phase: 'Running', turn: 'executing' }),
+    ]
+    expect(laneChangedAt(observations, 'phase')).toBe(200)
+    expect(laneChangedAt(observations, 'turn')).toBe(300)
+  })
+})
+
+describe('laneTransitionCount', () => {
+  it('returns 0 for empty observations', () => {
+    expect(laneTransitionCount([], 'phase')).toBe(0)
+  })
+
+  it('returns 0 for single observation', () => {
+    expect(laneTransitionCount([obs({ ts: 100 })], 'phase')).toBe(0)
+  })
+
+  it('counts transitions correctly', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+      obs({ ts: 300, phase: 'Stable' }),
+      obs({ ts: 400, phase: 'Running' }),
+    ]
+    expect(laneTransitionCount(observations, 'phase')).toBe(3)
+  })
+
+  it('ignores unchanged fields', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable', turn: 'idle' }),
+      obs({ ts: 200, phase: 'Running', turn: 'idle' }),
+    ]
+    expect(laneTransitionCount(observations, 'phase')).toBe(1)
+    expect(laneTransitionCount(observations, 'turn')).toBe(0)
+  })
+})
+
+describe('deriveStateEntries', () => {
+  it('returns null for empty observations', () => {
+    expect(deriveStateEntries([])).toBeNull()
+  })
+
+  it('returns first ts for all lanes when no changes', () => {
+    const observations = [
+      obs({ ts: 100 }),
+      obs({ ts: 200 }),
+    ]
+    const result = deriveStateEntries(observations)
+    expect(result!.phase).toBe(100)
+    expect(result!.turn).toBe(100)
+  })
+
+  it('detects last transition timestamp per lane', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable', turn: 'idle' }),
+      obs({ ts: 200, phase: 'Running', turn: 'idle' }),
+      obs({ ts: 300, phase: 'Running', turn: 'executing' }),
+    ]
+    const result = deriveStateEntries(observations)
+    expect(result!.phase).toBe(200)
+    expect(result!.turn).toBe(300)
+  })
+
+  it('handles all 5 lanes', () => {
+    const observations = [
+      obs({ ts: 100 }),
+      obs({ ts: 200, phase: 'Running', turn: 'executing', decision: 'guard_ok', cascade: 'trying', compaction: 'compacting' }),
+    ]
+    const result = deriveStateEntries(observations)
+    expect(result!.phase).toBe(200)
+    expect(result!.turn).toBe(200)
+    expect(result!.decision).toBe(200)
+    expect(result!.cascade).toBe(200)
+    expect(result!.compaction).toBe(200)
+  })
+})
+
+describe('deriveTimeAxisTicks', () => {
+  it('returns empty for zero span', () => {
+    expect(deriveTimeAxisTicks(100, 100)).toEqual([])
+  })
+
+  it('returns empty for negative span', () => {
+    expect(deriveTimeAxisTicks(200, 100)).toEqual([])
+  })
+
+  it('returns empty for maxTicks < 2', () => {
+    expect(deriveTimeAxisTicks(100, 200, 1)).toEqual([])
+  })
+
+  it('generates ticks within span', () => {
+    const ticks = deriveTimeAxisTicks(0, 3600, 6) // 1 hour span
+    expect(ticks.length).toBeGreaterThanOrEqual(1)
+    expect(ticks.length).toBeLessThanOrEqual(6)
+    for (const tick of ticks) {
+      expect(tick.ts).toBeGreaterThan(0)
+      expect(tick.ts).toBeLessThanOrEqual(3600)
+      expect(tick.label).toBeTruthy()
+    }
+  })
+
+  it('formats seconds for sub-minute steps', () => {
+    const ticks = deriveTimeAxisTicks(0, 30, 4) // 30 second span
+    expect(ticks.length).toBeGreaterThanOrEqual(1)
+    // With step < 60, labels should include seconds
+    expect(ticks[0]!.label).toContain(':')
+  })
+
+  it('formats HH:MM for larger steps', () => {
+    const ticks = deriveTimeAxisTicks(0, 86400, 6) // 1 day span
+    expect(ticks.length).toBeGreaterThanOrEqual(1)
+    expect(ticks[0]!.label).toBeTruthy()
+  })
+})
+
+describe('deriveSwimlaneSegments', () => {
+  it('returns empty for no observations', () => {
+    expect(deriveSwimlaneSegments([], 'phase', 100)).toEqual([])
+  })
+
+  it('creates single segment for constant lane', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Stable' }),
+    ]
+    const segments = deriveSwimlaneSegments(observations, 'phase', 300)
+    expect(segments).toHaveLength(1)
+    expect(segments[0]!.value).toBe('Stable')
+    expect(segments[0]!.from).toBe(100)
+    expect(segments[0]!.to).toBe(300) // extended to boundsEnd
+  })
+
+  it('splits on lane change', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+      obs({ ts: 300, phase: 'Running' }),
+    ]
+    const segments = deriveSwimlaneSegments(observations, 'phase', 400)
+    expect(segments).toHaveLength(2)
+    expect(segments[0]!.value).toBe('Stable')
+    expect(segments[0]!.from).toBe(100)
+    expect(segments[0]!.to).toBe(200)
+    expect(segments[1]!.value).toBe('Running')
+    expect(segments[1]!.to).toBe(400) // extended to boundsEnd
+  })
+
+  it('extends last segment to boundsEnd', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+    ]
+    const segments = deriveSwimlaneSegments(observations, 'phase', 500)
+    const last = segments[segments.length - 1]!
+    expect(last.to).toBe(500)
+  })
+
+  it('does not extend beyond boundsEnd', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+    ]
+    const segments = deriveSwimlaneSegments(observations, 'phase', 150)
+    // boundsEnd < last segment's to, so no extension
+    expect(segments).toHaveLength(2)
+  })
+})
+
+describe('deriveLaneDwellHistograms', () => {
+  it('returns empty for no observations', () => {
+    expect(deriveLaneDwellHistograms([], 100)).toEqual([])
+  })
+
+  it('computes dwell time for constant lane', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Stable' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 300)
+    const phaseLane = histograms.find(h => h.field === 'KSM')
+    expect(phaseLane).toBeTruthy()
+    expect(phaseLane!.entries).toHaveLength(1)
+    expect(phaseLane!.entries[0]!.value).toBe('Stable')
+    expect(phaseLane!.entries[0]!.seconds).toBe(200) // 300-100
+    expect(phaseLane!.entries[0]!.pct).toBe(100)
+  })
+
+  it('splits dwell across changed values', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 200, phase: 'Running' }),
+      obs({ ts: 300, phase: 'Stable' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 400)
+    const phaseLane = histograms.find(h => h.field === 'KSM')
+    expect(phaseLane).toBeTruthy()
+    // Stable: 100-200 + 300-400 = 200s, Running: 200-300 = 100s
+    const stableEntry = phaseLane!.entries.find(e => e.value === 'Stable')
+    const runningEntry = phaseLane!.entries.find(e => e.value === 'Running')
+    expect(stableEntry!.seconds).toBe(200)
+    expect(runningEntry!.seconds).toBe(100)
+  })
+
+  it('sorts entries by seconds descending', () => {
+    const observations = [
+      obs({ ts: 100, phase: 'Stable' }),
+      obs({ ts: 150, phase: 'Running' }),
+      obs({ ts: 400, phase: 'Stable' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 500)
+    const phaseLane = histograms.find(h => h.field === 'KSM')
+    expect(phaseLane!.entries[0]!.seconds).toBeGreaterThanOrEqual(
+      phaseLane!.entries[1]!.seconds,
+    )
+  })
+
+  it('returns lanes in TRANSITION_FIELDS order', () => {
+    const observations = [
+      obs({ ts: 100 }),
+      obs({ ts: 200, phase: 'Running', turn: 'executing', decision: 'guard_ok' }),
+    ]
+    const histograms = deriveLaneDwellHistograms(observations, 300)
+    const fields = histograms.map(h => h.field)
+    expect(fields).toContain('KSM')
+    expect(fields).toContain('KTC')
+    expect(fields).toContain('KDP')
+  })
+})

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractLaneValue,
+  displayState,
+  fmtDuration,
+  STATE_DISPLAY_NAMES,
+  LANE_LABELS,
+  INVARIANT_LABELS,
+  TRANSITION_FIELDS,
+  MAX_OBSERVATIONS,
+  MAX_TRANSITION_HISTORY,
+  initialHubState,
+} from './fsm-hub-types'
+import type { KeeperCompositeSnapshot } from '../api/keeper'
+
+// --- Helpers ---
+
+function snapshot(overrides: Partial<KeeperCompositeSnapshot> = {}): KeeperCompositeSnapshot {
+  return {
+    correlation_id: 'test-corr',
+    run_id: 'test-run',
+    ts: 1000,
+    phase: 'Stable',
+    turn_phase: 'idle',
+    decision: { stage: 'undecided' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: false },
+    invariants: {
+      phase_turn_alignment: true,
+      no_cascade_before_measurement: true,
+      compaction_atomicity: true,
+      event_priority_monotone: true,
+    },
+    is_live: false,
+    last_outcome: null,
+    ...overrides,
+  }
+}
+
+// --- Tests ---
+
+describe('extractLaneValue', () => {
+  it('extracts phase', () => {
+    expect(extractLaneValue(snapshot({ phase: 'Running' }), 'phase')).toBe('Running')
+  })
+
+  it('extracts turn', () => {
+    expect(extractLaneValue(snapshot({ turn_phase: 'executing' }), 'turn')).toBe('executing')
+  })
+
+  it('extracts decision', () => {
+    expect(extractLaneValue(snapshot({ decision: { stage: 'guard_ok' } }), 'decision')).toBe('guard_ok')
+  })
+
+  it('extracts cascade', () => {
+    expect(extractLaneValue(snapshot({ cascade: { state: 'trying' } }), 'cascade')).toBe('trying')
+  })
+
+  it('extracts compaction', () => {
+    expect(extractLaneValue(snapshot({ compaction: { stage: 'compacting' } }), 'compaction')).toBe('compacting')
+  })
+
+  it('handles all valid phase values', () => {
+    const phases: KeeperCompositeSnapshot['phase'][] = [
+      'Running', 'Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Stable',
+    ]
+    for (const phase of phases) {
+      expect(extractLaneValue(snapshot({ phase }), 'phase')).toBe(phase)
+    }
+  })
+
+  it('handles all valid turn values', () => {
+    const turns: KeeperCompositeSnapshot['turn_phase'][] = [
+      'idle', 'prompting', 'executing', 'compacting', 'finalizing',
+    ]
+    for (const turn of turns) {
+      expect(extractLaneValue(snapshot({ turn_phase: turn }), 'turn')).toBe(turn)
+    }
+  })
+})
+
+describe('displayState', () => {
+  it('returns Korean label for known states', () => {
+    expect(displayState('idle')).toBe('대기')
+    expect(displayState('executing')).toBe('실행 중')
+    expect(displayState('Crashed')).toBe('비정상 종료')
+    expect(displayState('Paused')).toBe('일시 중지')
+  })
+
+  it('returns raw value for unknown states', () => {
+    expect(displayState('unknown_state')).toBe('unknown_state')
+  })
+
+  it('covers all STATE_DISPLAY_NAMES keys', () => {
+    for (const key of Object.keys(STATE_DISPLAY_NAMES)) {
+      expect(displayState(key)).toBe(STATE_DISPLAY_NAMES[key])
+    }
+  })
+})
+
+describe('fmtDuration', () => {
+  it('formats seconds under 60', () => {
+    expect(fmtDuration(0)).toBe('0s')
+    expect(fmtDuration(30)).toBe('30s')
+    expect(fmtDuration(59)).toBe('59s')
+  })
+
+  it('formats minutes and seconds', () => {
+    expect(fmtDuration(60)).toBe('1m 0s')
+    expect(fmtDuration(90)).toBe('1m 30s')
+    expect(fmtDuration(3599)).toBe('59m 59s')
+  })
+
+  it('formats hours and minutes', () => {
+    expect(fmtDuration(3600)).toBe('1h 0m')
+    expect(fmtDuration(3661)).toBe('1h 1m')
+    expect(fmtDuration(86400)).toBe('24h 0m')
+  })
+
+  it('handles negative values', () => {
+    expect(fmtDuration(-1)).toBe('0s')
+    expect(fmtDuration(-100)).toBe('0s')
+  })
+
+  it('handles fractional seconds', () => {
+    expect(fmtDuration(1.5)).toBe('1s')
+    expect(fmtDuration(0.1)).toBe('0s')
+  })
+})
+
+describe('constants', () => {
+  it('TRANSITION_FIELDS has 5 entries', () => {
+    expect(TRANSITION_FIELDS).toHaveLength(5)
+    expect(TRANSITION_FIELDS.map(f => f.field)).toEqual(['KSM', 'KTC', 'KDP', 'KCL', 'KMC'])
+  })
+
+  it('LANE_LABELS has all 5 lanes', () => {
+    const keys = Object.keys(LANE_LABELS)
+    expect(keys).toEqual(['phase', 'turn', 'decision', 'cascade', 'compaction'])
+  })
+
+  it('INVARIANT_LABELS has all 4 invariants', () => {
+    const keys = Object.keys(INVARIANT_LABELS)
+    expect(keys).toHaveLength(4)
+    expect(keys).toContain('phase_turn_alignment')
+    expect(keys).toContain('compaction_atomicity')
+  })
+
+  it('MAX_OBSERVATIONS and MAX_TRANSITION_HISTORY are positive', () => {
+    expect(MAX_OBSERVATIONS).toBeGreaterThan(0)
+    expect(MAX_TRANSITION_HISTORY).toBeGreaterThan(0)
+  })
+})
+
+describe('initialHubState', () => {
+  it('has correct initial values', () => {
+    expect(initialHubState.keeperName).toBeNull()
+    expect(initialHubState.snapshot).toBeNull()
+    expect(initialHubState.loading).toBe(false)
+    expect(initialHubState.error).toBeNull()
+    expect(initialHubState.observations).toEqual([])
+    expect(initialHubState.invariantSampleCount).toBe(0)
+  })
+
+  it('has zero invariant violations', () => {
+    const violations = initialHubState.invariantViolations
+    for (const value of Object.values(violations)) {
+      expect(value).toBe(0)
+    }
+  })
+})

--- a/dashboard/src/lib/dashboard-actor.test.ts
+++ b/dashboard/src/lib/dashboard-actor.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import {
+  sanitizeDashboardActorName,
+  readStoredDashboardActorName,
+  resolveDashboardActorName,
+  persistDashboardActorName,
+  DASHBOARD_AGENT_NAME_KEY,
+} from './dashboard-actor'
+
+// --- Helpers ---
+
+function mockStorage(getResult: string | null = null): Storage {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? getResult,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { for (const k of Object.keys(store)) delete store[k] },
+    key: (_index: number) => null,
+    get length() { return Object.keys(store).length },
+  }
+}
+
+// --- Tests ---
+
+describe('sanitizeDashboardActorName', () => {
+  it('returns null for null', () => {
+    expect(sanitizeDashboardActorName(null)).toBeNull()
+  })
+
+  it('returns null for undefined', () => {
+    expect(sanitizeDashboardActorName(undefined)).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(sanitizeDashboardActorName('')).toBeNull()
+  })
+
+  it('returns null for whitespace-only string', () => {
+    expect(sanitizeDashboardActorName('   ')).toBeNull()
+  })
+
+  it('trims whitespace', () => {
+    expect(sanitizeDashboardActorName('  hello  ')).toBe('hello')
+  })
+
+  it('removes non-alphanumeric characters', () => {
+    expect(sanitizeDashboardActorName('agent@#$name')).toBe('agentname')
+  })
+
+  it('allows dots, underscores, and dashes', () => {
+    expect(sanitizeDashboardActorName('my-agent_v2.1')).toBe('my-agent_v2.1')
+  })
+
+  it('truncates to 32 characters', () => {
+    const long = 'a'.repeat(50)
+    expect(sanitizeDashboardActorName(long)).toBe('a'.repeat(32))
+  })
+
+  it('handles Korean characters removal', () => {
+    expect(sanitizeDashboardActorName('안녕hello')).toBe('hello')
+  })
+})
+
+describe('readStoredDashboardActorName', () => {
+  it('returns null when storage has no value', () => {
+    expect(readStoredDashboardActorName(mockStorage())).toBeNull()
+  })
+
+  it('reads and sanitizes stored value', () => {
+    const storage = mockStorage()
+    storage.setItem(DASHBOARD_AGENT_NAME_KEY, 'test-agent')
+    expect(readStoredDashboardActorName(storage)).toBe('test-agent')
+  })
+
+  it('returns null for invalid stored value', () => {
+    const storage = mockStorage()
+    storage.setItem(DASHBOARD_AGENT_NAME_KEY, '@#$%')
+    expect(readStoredDashboardActorName(storage)).toBeNull()
+  })
+
+  it('handles null storage gracefully', () => {
+    expect(readStoredDashboardActorName(null)).toBeNull()
+  })
+})
+
+describe('resolveDashboardActorName', () => {
+  it('resolves from agent query param', () => {
+    expect(resolveDashboardActorName('?agent=my-agent', null)).toBe('my-agent')
+  })
+
+  it('resolves from agent_name query param', () => {
+    expect(resolveDashboardActorName('?agent_name=fallback', null)).toBe('fallback')
+  })
+
+  it('prefers agent over agent_name', () => {
+    expect(resolveDashboardActorName('?agent=first&agent_name=second', null)).toBe('first')
+  })
+
+  it('falls back to storage when no query params', () => {
+    const storage = mockStorage()
+    storage.setItem(DASHBOARD_AGENT_NAME_KEY, 'stored')
+    expect(resolveDashboardActorName('', storage)).toBe('stored')
+  })
+
+  it('returns null when nothing available', () => {
+    expect(resolveDashboardActorName('', null)).toBeNull()
+  })
+})
+
+describe('persistDashboardActorName', () => {
+  it('persists valid name to storage', () => {
+    const storage = mockStorage()
+    const result = persistDashboardActorName('my-agent', storage)
+    expect(result).toBe('my-agent')
+    expect(storage.getItem(DASHBOARD_AGENT_NAME_KEY)).toBe('my-agent')
+  })
+
+  it('defaults to "dashboard" for empty input', () => {
+    const storage = mockStorage()
+    const result = persistDashboardActorName('', storage)
+    expect(result).toBe('dashboard')
+  })
+
+  it('defaults to "dashboard" for invalid input', () => {
+    const storage = mockStorage()
+    const result = persistDashboardActorName('@#$%', storage)
+    expect(result).toBe('dashboard')
+  })
+
+  it('sanitizes before persisting', () => {
+    const storage = mockStorage()
+    const result = persistDashboardActorName('  hello world!!  ', storage)
+    expect(result).toBe('helloworld')
+    expect(storage.getItem(DASHBOARD_AGENT_NAME_KEY)).toBe('helloworld')
+  })
+
+  it('handles null storage gracefully', () => {
+    const result = persistDashboardActorName('test', null)
+    expect(result).toBe('test')
+  })
+})

--- a/dashboard/src/lib/status-utils.test.ts
+++ b/dashboard/src/lib/status-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { isOfflineStatus } from './status-utils'
+
+describe('isOfflineStatus', () => {
+  it('returns true for offline', () => {
+    expect(isOfflineStatus('offline')).toBe(true)
+  })
+
+  it('returns true for inactive', () => {
+    expect(isOfflineStatus('inactive')).toBe(true)
+  })
+
+  it('returns true for unbooted', () => {
+    expect(isOfflineStatus('unbooted')).toBe(true)
+  })
+
+  it('returns true for stopped', () => {
+    expect(isOfflineStatus('stopped')).toBe(true)
+  })
+
+  it('returns false for active', () => {
+    expect(isOfflineStatus('active')).toBe(false)
+  })
+
+  it('returns false for running', () => {
+    expect(isOfflineStatus('running')).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isOfflineStatus(null)).toBe(false)
+  })
+
+  it('returns false for undefined', () => {
+    expect(isOfflineStatus(undefined)).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isOfflineStatus('')).toBe(false)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isOfflineStatus('OFFLINE')).toBe(true)
+    expect(isOfflineStatus('Inactive')).toBe(true)
+    expect(isOfflineStatus('UNBOOTED')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add comprehensive tests for `decodeGateStatusData`, `decodeGateKeepersData`, `decodeGateConnectorsData`
- 33 tests covering null/undefined inputs, missing required fields, default values, string map filtering, configured_bindings fallback

## Test plan
- [x] All 33 tests pass locally (`npx vitest run src/api/gate.test.ts`)
- [ ] CI Dashboard check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)