### PR TITLE
docs(observability): cascade Prometheus alerting rules + playbook

### DIFF
--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -1,0 +1,97 @@
+# Cascade Observability Metrics
+
+How to read the cascade counters exposed by `/metrics` and the alerting rules that turn them into pages.
+
+## Background
+
+After the LT-* series (LT-1 through LT-7) every cycle of `Oas_worker_named.cycle_loop` produces observable state on **five surfaces**:
+
+| Surface | Location | Use case |
+|---------|----------|----------|
+| 1. Snapshot JSON | `GET /api/v1/cascade/config`, `/cascade/client_capacity` | Current state polling (dashboard refresh) |
+| 2. Ring buffer JSON | `GET /api/v1/cascade/client_capacity/history`, `/cascade/strategy_trace` | Recent-event audit (debugging) |
+| 3. Dashboard cards | `dashboard/src/components/cascade-config-panel.ts` | Human operator view |
+| 4. Prometheus counters | `GET /metrics` | Time-series + alerting (this doc) |
+| 5. TLA+ specs | `specs/boundary/CascadeStrategy*.tla` | Formal correctness (offline) |
+
+The Prometheus surface binds the runtime events to alerting rules; the TLA+ surface guarantees the state machine variant labels (`ordered`, `filtered_empty`, `exhausted`) stay consistent.
+
+## Counters
+
+### `masc_cascade_capacity_events_total`
+
+| Label | Values |
+|-------|--------|
+| `kind` | `acquired`, `released`, `rejected_full` |
+| `key_type` | `cli`, `ollama`, `other` |
+
+Incremented from `Cascade_client_capacity_history.record`. One event per semaphore transition. `rejected_full` is the saturation signal — a caller could not acquire a slot and moved on to the next cascade candidate.
+
+Label cardinality: `3 × 3 = 9 series`.
+
+### `masc_cascade_strategy_decisions_total`
+
+| Label | Values |
+|-------|--------|
+| `cascade` | cascade profile name (bounded by `cascade.json`, typically < 20) |
+| `strategy` | `failover`, `capacity_aware`, `weighted_random`, `circuit_breaker_cycling`, `priority_tier`, `sticky`, `round_robin` |
+| `kind` | `ordered`, `filtered_empty`, `exhausted` |
+
+Incremented from `Cascade_strategy_trace.record`. One event per cycle iteration of `cycle_loop`. `exhausted` is the terminal variant — cascade gave up after `max_cycles` without a successful provider pick.
+
+Label cardinality: `≈ 20 × 7 × 3 = 420 series` upper bound.
+
+Both counter names and label tuples are shared with the JSON projection + dashboard card, so Grafana queries join cleanly with the same identifiers that operators see.
+
+## Alerting Rules
+
+`infrastructure/monitoring/cascade-alerts.yml` carries four rules. Load them into your Prometheus instance via:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - /path/to/masc-mcp/infrastructure/monitoring/cascade-alerts.yml
+```
+
+| Alert | Severity | Fires when |
+|-------|----------|------------|
+| `OllamaCapacityRejectionSurge` | warning | ollama `rejected_full` > 0.5/s for 10m |
+| `CliCapacityRejectionSurge` | warning | CLI provider `rejected_full` > 1/s for 10m |
+| `CascadeExhaustionBurst` | **critical** | Any cascade `exhausted` > 0.1/s for 15m |
+| `StrategyFilteredEmptyStorm` | warning | `filtered_empty` / total > 50% for 10m |
+| `NoCapacityEventsInLastHour` | info | No capacity events for 1h (broken wiring vs idle) |
+
+### Response playbooks
+
+**OllamaCapacityRejectionSurge** — either `MASC_OLLAMA_MAX_CONCURRENT` is mis-sized or a runaway keeper is hammering the same model. Check `/api/v1/cascade/strategy_trace?cascade=<name>` to identify the saturating cascade. Either raise the semaphore (risks ollama thrash) or add a different provider to the cascade.
+
+**CascadeExhaustionBurst** — every hit is a user-visible cascade failure. Inspect `/api/v1/cascade/health` (provider health) + `/api/v1/cascade/config` (candidate list). If all providers are cooling down, the underlying issue is upstream (API key, rate limit, network).
+
+**StrategyFilteredEmptyStorm** — the strategy is rejecting >50% of cycles. Usually means `Capacity_aware` or `Circuit_breaker_cycling` is too restrictive, or cooldowns are saturated. Cross-reference with `OllamaCapacityRejectionSurge` to separate root cause.
+
+## Formal correctness link
+
+The `kind` label values are not ad-hoc strings — they mirror the `event_kind` variant in `lib/cascade/cascade_strategy_trace.mli`:
+
+```ocaml
+type event_kind = Ordered | Filtered_empty | Exhausted
+```
+
+Phase B TLA+ spec (`specs/boundary/CascadeStrategyStateful.tla`, PR #7632) models the same state machine with `Ordered` / `FilteredEmpty` / `Exhausted` transitions. Any spec change that adds a variant **must** update:
+
+1. The OCaml `event_kind` type + `kind_to_string` serialiser.
+2. The `.mli` docstring listing kinds.
+3. The alerting rules in this directory (new thresholds if the variant is operationally significant).
+4. The dashboard card legend (`verification-specs-panel.ts` classifier).
+
+This is the spec → code → dashboard → metric consistency contract.
+
+## Related PRs
+
+- #7630 — Phase D client capacity history (ring buffer, JSON)
+- #7632 — TLA+ Phase B Sticky/RR spec
+- #7637 — TLA+ spec index dashboard
+- #7643 — Strategy decision trace (ring buffer, JSON)
+- #7645 — `masc_cascade_capacity_events_total` counter
+- #7649 — `masc_cascade_strategy_decisions_total` counter
+- (this) — alerting rules + doc

--- a/infrastructure/monitoring/cascade-alerts.yml
+++ b/infrastructure/monitoring/cascade-alerts.yml
@@ -1,0 +1,132 @@
+# Prometheus alerting rules for MASC cascade observability.
+#
+# Companion metrics (exposed via /metrics):
+#   - masc_cascade_capacity_events_total{kind, key_type}
+#       kind ∈ {acquired, released, rejected_full}
+#       key_type ∈ {cli, ollama, other}
+#       See lib/cascade/cascade_client_capacity_history.ml
+#
+#   - masc_cascade_strategy_decisions_total{cascade, strategy, kind}
+#       kind ∈ {ordered, filtered_empty, exhausted}
+#       See lib/cascade/cascade_strategy_trace.ml
+#
+# Thresholds below are conservative starting points; tune per deployment.
+# Rate windows use 5m so a single transient event does not page; duration
+# guards (for:) require the condition to persist across two 5m windows.
+#
+# Label cardinality is bounded:
+#   - key_type: 3 values
+#   - kind (capacity): 3 values
+#   - kind (strategy): 3 values
+#   - strategy: 7 values (S1..S7)
+#   - cascade: bounded by cascade.json entries (typically < 20)
+# Total series < 3*3 + 3*7*20 = 429.
+
+groups:
+  - name: masc_cascade_capacity
+    interval: 30s
+    rules:
+      - alert: OllamaCapacityRejectionSurge
+        expr: |
+          rate(masc_cascade_capacity_events_total{kind="rejected_full",key_type="ollama"}[5m]) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          component: cascade
+          subsystem: capacity
+        annotations:
+          summary: "Ollama slot rejections > 0.5/s for 10m"
+          description: |
+            Ollama capacity semaphore is rejecting cascade attempts at
+            rate {{ $value }}/s for 10 minutes. Suggests either a
+            mis-sized MASC_OLLAMA_MAX_CONCURRENT or a runaway keeper
+            hammering the same model. Check cascade strategy trace
+            (/api/v1/cascade/strategy_trace?cascade=<name>) to see
+            which cascade is saturating.
+
+      - alert: CliCapacityRejectionSurge
+        expr: |
+          rate(masc_cascade_capacity_events_total{kind="rejected_full",key_type="cli"}[5m]) > 1
+        for: 10m
+        labels:
+          severity: warning
+          component: cascade
+          subsystem: capacity
+        annotations:
+          summary: "CLI provider rejections > 1/s for 10m"
+          description: |
+            CLI provider (claude_code / gemini_cli / codex_cli) slot
+            rejections at {{ $value }}/s. Indicates multi-keeper
+            contention on shared local processes. Either raise
+            MASC_CLI_MAX_CONCURRENT (risks process thrash) or
+            add a different provider to the cascade.
+
+  - name: masc_cascade_strategy
+    interval: 30s
+    rules:
+      - alert: CascadeExhaustionBurst
+        expr: |
+          rate(masc_cascade_strategy_decisions_total{kind="exhausted"}[5m]) > 0.1
+        for: 15m
+        labels:
+          severity: critical
+          component: cascade
+          subsystem: strategy
+        annotations:
+          summary: "Cascade exhaustion > 0.1/s for 15m — providers failing"
+          description: |
+            Cascade {{ $labels.cascade }} (strategy {{ $labels.strategy }})
+            is hitting max_cycles without a successful provider pick at
+            {{ $value }}/s. Every hit is a user-visible cascade failure.
+            Inspect /api/v1/cascade/health and /api/v1/cascade/config for
+            the offending cascade. Bug-model spec pattern (LT-1 TLA+ Phase B)
+            documents the Exhausted variant as a terminal state — if this
+            is firing, the spec invariant holds but operationally providers
+            are unusable.
+
+      - alert: StrategyFilteredEmptyStorm
+        expr: |
+          rate(masc_cascade_strategy_decisions_total{kind="filtered_empty"}[5m])
+          /
+          ignoring(kind)
+          sum without (kind) (
+            rate(masc_cascade_strategy_decisions_total[5m])
+          ) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          component: cascade
+          subsystem: strategy
+        annotations:
+          summary: "Strategy {{ $labels.strategy }} filtering > 50% of cycles"
+          description: |
+            Cascade {{ $labels.cascade }} running {{ $labels.strategy }}
+            is filtering more than half of cycles as filtered_empty.
+            Either cooldown / capacity signals are saturated (check
+            adjacent OllamaCapacityRejectionSurge) or the strategy
+            configuration is too restrictive. Capacity_aware +
+            Circuit_breaker_cycling are the usual culprits.
+
+  - name: masc_cascade_health
+    interval: 30s
+    rules:
+      - alert: NoCapacityEventsInLastHour
+        expr: |
+          (
+            sum(increase(masc_cascade_capacity_events_total[1h])) == 0
+            or
+            absent(masc_cascade_capacity_events_total)
+          )
+        for: 10m
+        labels:
+          severity: info
+          component: cascade
+          subsystem: capacity
+        annotations:
+          summary: "No cascade capacity events for 1h"
+          description: |
+            No acquired / released / rejected events in the last hour.
+            Either the server is idle, or capacity tracing is broken.
+            Cross-check /api/v1/cascade/client_capacity for the current
+            snapshot — if that has entries but no events, the history
+            ring buffer wiring regressed.


### PR DESCRIPTION
## Summary
Turns the LT-6/LT-7 cascade counters into actionable alerts with documented response playbooks. Closes the observability loop: event → counter → **alert** → operator action.

## Files
- `infrastructure/monitoring/cascade-alerts.yml` — 5 Prometheus rules across 3 groups (capacity / strategy / health).
- `docs/observability/cascade-metrics.md` — counter reference, cardinality bounds, per-alert playbook, formal-correctness link between TLA+ variants ↔ metric labels.

## Alerts
| Alert | Severity | Trigger |
|-------|----------|---------|
| OllamaCapacityRejectionSurge | warning | ollama `rejected_full` > 0.5/s for 10m |
| CliCapacityRejectionSurge | warning | CLI `rejected_full` > 1/s for 10m |
| CascadeExhaustionBurst | **critical** | cascade `exhausted` > 0.1/s for 15m |
| StrategyFilteredEmptyStorm | warning | `filtered_empty` / total > 50% for 10m |
| NoCapacityEventsInLastHour | info | no events 1h (catches broken wiring vs idle) |

## Spec → code → dashboard → metric contract
Doc makes explicit: any TLA+ variant change (e.g. new strategy kind) must update (1) OCaml `event_kind`, (2) `.mli` docstring, (3) this alerting file if operationally significant, (4) dashboard card legend. Four-surface drift prevention written down.

## Cardinality
Upper bound ≈ 429 series: `3×3 capacity + 20×7×3 strategy` (20 cascades × 7 strategies × 3 kinds).

## Test plan
- [x] YAML parses (pyyaml safe_load, 3 groups / 5 rules)
- [x] Expressions copy-paste ready for `rule_files:` include
- [ ] Reviewer: threshold values — I picked conservative starting points; tune per deployment baseline

Related: #7630 (LT-2 ring buffer), #7632 (TLA+ Phase B), #7645 (capacity counter), #7649 (strategy counter).