### PR TITLE
feat(keeper): register [STATE]-aware summarizer via OAS Builder (0.152.0)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -432,6 +432,7 @@
    keeper_identity
    keeper_checkpoint_store
    keeper_text_processing
+   keeper_summarizer
    keeper_context_core
    keeper_compact_policy
    keeper_compact_audit
@@ -602,6 +603,7 @@
   keeper_identity
   keeper_checkpoint_store
   keeper_text_processing
+  keeper_summarizer
   keeper_context_core
   keeper_compact_policy
   keeper_compact_audit

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1710,6 +1710,7 @@ let run_turn
            ~initial_messages:history_messages
            ~hooks
            ~context_reducer:reducer
+           ~summarizer:Keeper_summarizer.keeper_summarizer
            ~memory
              (* Keepers use turn-level retry for transient errors but benefit
                from OAS per-call retry for validation errors (malformed tool

--- a/lib/keeper/keeper_summarizer.ml
+++ b/lib/keeper/keeper_summarizer.ml
@@ -1,0 +1,76 @@
+(** [STATE]-aware summarizer for OAS compaction.
+
+    OAS [Budget_strategy.reduce_for_budget] calls its summarizer with the
+    oldest-N messages when the context ratio crosses the Emergency
+    threshold. The default summarizer takes the first 100 chars of each
+    message's first Text block and prefixes `[role]`. If a message begins
+    with `[STATE]\n...`, those characters land verbatim in the produced
+    summary, which the LLM then re-reads the next turn as the prefix of
+    `[Summary of N earlier messages]`. That is the compaction-layer half
+    of the resonance loop that Gen3 (PR #7647) closed only at the prompt
+    injection layer.
+
+    This module wraps the default summarizer after scrubbing
+    `[STATE]...[/STATE]` blocks from every Text block. Consumers register
+    it via [Agent_sdk.Builder.with_summarizer] on the agent they build.
+
+    OAS/MASC boundary: OAS knows nothing about [STATE] markers (see
+    feedback_oas-must-not-know-masc). This module lives on the MASC side
+    and supplies the domain-aware callback through OAS's generic
+    [Agent.options.summarizer] API added in OAS 0.152.0 (PR #973). *)
+
+let scrub_text_blocks (msg : Agent_sdk.Types.message) : Agent_sdk.Types.message =
+  let content' =
+    List.map
+      (function
+        | Agent_sdk.Types.Text s ->
+          Agent_sdk.Types.Text (Keeper_text_processing.strip_state_blocks_text s)
+        | other -> other)
+      msg.content
+  in
+  { msg with content = content' }
+
+(** Re-implementation of OAS [Budget_strategy.default_summarizer], which
+    is not exported in the .mli as of 0.152.0. Mirrors the original
+    extractive logic: first Text block per message, truncated at 100
+    chars, prefixed with role. Kept in sync with OAS contract; if OAS
+    ever exports the function, this fallback can be deleted. *)
+let default_extractive_summary (messages : Agent_sdk.Types.message list) : string =
+  let lines =
+    List.filter_map
+      (fun (msg : Agent_sdk.Types.message) ->
+        let role_str =
+          match msg.role with
+          | Agent_sdk.Types.User -> "User"
+          | Agent_sdk.Types.Assistant -> "Assistant"
+          | Agent_sdk.Types.System -> "System"
+          | Agent_sdk.Types.Tool -> "Tool"
+        in
+        let first_text =
+          List.find_map
+            (function
+              | Agent_sdk.Types.Text s when String.length s > 0 ->
+                let truncated =
+                  if String.length s > 100 then String.sub s 0 100 ^ "..." else s
+                in
+                Some truncated
+              | _ -> None)
+            msg.content
+        in
+        match first_text with
+        | Some t -> Some (Printf.sprintf "[%s] %s" role_str t)
+        | None -> None)
+      messages
+  in
+  match lines with
+  | [] -> "[No prior context]"
+  | _ ->
+    Printf.sprintf "[Summary of %d earlier messages]\n%s"
+      (List.length messages)
+      (String.concat "\n" lines)
+
+(** Scrub [STATE] blocks from each message's Text before summarization.
+    Callers pass this to [Agent_sdk.Builder.with_summarizer]. *)
+let keeper_summarizer (messages : Agent_sdk.Types.message list) : string =
+  let scrubbed = List.map scrub_text_blocks messages in
+  default_extractive_summary scrubbed

--- a/lib/oas_worker.mli
+++ b/lib/oas_worker.mli
@@ -121,6 +121,7 @@ val run_named :
   ?approval:Oas.Hooks.approval_callback ->
   ?exit_condition:(int -> bool) ->
   ?exit_condition_result:(int -> stop_reason * string option) ->
+  ?summarizer:(Oas.Types.message list -> string) ->
   ?oas_checkpoint:Oas.Checkpoint.t ->
   ?event_bus:Oas.Event_bus.t ->
   ?sw:Eio.Switch.t ->

--- a/lib/oas_worker_exec.ml
+++ b/lib/oas_worker_exec.ml
@@ -53,6 +53,11 @@ type config = {
   approval : Oas.Hooks.approval_callback option;
   exit_condition : (int -> bool) option;
   exit_condition_result : (int -> stop_reason * string option) option;
+  summarizer : (Oas.Types.message list -> string) option;
+      (** Custom summarizer for OAS [Budget_strategy.reduce_for_budget]
+          Emergency-phase compaction. Defaults to OAS's extractive
+          default. Keeper workers inject [Keeper_summarizer.keeper_summarizer]
+          to scrub [STATE] blocks before the 100-char truncation. *)
 }
 
 let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
@@ -88,6 +93,7 @@ let default_config ~name ~provider ~model_id ~system_prompt ~tools : config =
     approval = None;
     exit_condition = None;
     exit_condition_result = None;
+    summarizer = None;
   }
 
 type run_result = {
@@ -320,6 +326,10 @@ let build
   in
   let builder = match config.exit_condition with
     | Some cond -> Oas.Builder.with_exit_condition cond builder
+    | None -> builder
+  in
+  let builder = match config.summarizer with
+    | Some s -> Oas.Builder.with_summarizer s builder
     | None -> builder
   in
   Oas.Builder.build_safe builder

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -290,6 +290,7 @@ let run_named
     ?approval
     ?exit_condition
     ?exit_condition_result
+    ?summarizer
     ?oas_checkpoint
     ?event_bus
     ?sw
@@ -366,6 +367,7 @@ let run_named
         approval;
         exit_condition;
         exit_condition_result;
+        summarizer;
         initial_messages; raw_trace; yield_on_tool;
       }
     in

--- a/test/dune
+++ b/test/dune
@@ -705,6 +705,13 @@
  (name test_continuity_forward_filter)
  (libraries masc_test_deps))
 
+; Gen4 compaction-layer [STATE] guard: keeper_summarizer scrubs
+; [STATE]...[/STATE] from Text blocks before OAS default extractive
+; summarization. Registered via Builder.with_summarizer (OAS 0.152.0).
+(test
+ (name test_keeper_summarizer)
+ (libraries masc_test_deps))
+
 ; Keeper_checkpoint_store.is_not_found_detail classifier
 ; regression (observed 334-retry loop on trace-1775487505102-6a347
 ; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)

--- a/test/test_keeper_summarizer.ml
+++ b/test/test_keeper_summarizer.ml
@@ -1,0 +1,82 @@
+(** Verify keeper_summarizer scrubs [STATE] blocks before summarization.
+
+    Gen4 closure of the compaction-layer resonance. Gen3 (PR #7647) closed
+    the prompt-injection layer; this test guards the OAS
+    Budget_strategy.reduce_for_budget Emergency-phase compaction, which
+    uses the summarizer injected via Builder.with_summarizer. *)
+
+module KS = Masc_mcp.Keeper_summarizer
+
+let msg ~role ~text : Agent_sdk.Types.message =
+  { role; content = [ Agent_sdk.Types.Text text ]; name = None; tool_call_id = None }
+
+let test_scrub_text_blocks_removes_state () =
+  let input =
+    msg ~role:Agent_sdk.Types.Assistant
+      ~text:"Some reasoning.\n[STATE]\nDONE: 5.6B+ ep verified\nNEXT: idle\n[/STATE]\nmore text"
+  in
+  let scrubbed = KS.scrub_text_blocks input in
+  let text =
+    match scrubbed.content with
+    | [ Agent_sdk.Types.Text s ] -> s
+    | _ -> Alcotest.fail "expected single Text block"
+  in
+  Alcotest.(check bool) "[STATE] marker removed"
+    false (Astring.String.is_infix ~affix:"[STATE]" text);
+  Alcotest.(check bool) "DONE: removed"
+    false (Astring.String.is_infix ~affix:"DONE:" text);
+  Alcotest.(check bool) "surrounding prose preserved"
+    true (Astring.String.is_infix ~affix:"Some reasoning." text);
+  Alcotest.(check bool) "post-block prose preserved"
+    true (Astring.String.is_infix ~affix:"more text" text)
+
+let test_summarizer_strips_state () =
+  let messages =
+    [ msg ~role:Agent_sdk.Types.User ~text:"please verify";
+      msg ~role:Agent_sdk.Types.Assistant
+        ~text:"[STATE]\nDONE: 5.6B+ ep verified across 30 episodes\n[/STATE]";
+    ]
+  in
+  let summary = KS.keeper_summarizer messages in
+  Alcotest.(check bool) "summary omits [STATE]"
+    false (Astring.String.is_infix ~affix:"[STATE]" summary);
+  Alcotest.(check bool) "summary omits DONE: 5.6B"
+    false (Astring.String.is_infix ~affix:"DONE: 5.6B" summary);
+  Alcotest.(check bool) "summary contains user fragment"
+    true (Astring.String.is_infix ~affix:"please verify" summary)
+
+let test_non_text_blocks_untouched () =
+  let tool_use : Agent_sdk.Types.content_block =
+    Agent_sdk.Types.ToolUse
+      { id = "t1"; name = "bash"; input = `Assoc [ ("cmd", `String "ls") ] }
+  in
+  let m : Agent_sdk.Types.message =
+    { role = Agent_sdk.Types.Assistant;
+      content = [ Agent_sdk.Types.Text "[STATE]\nDONE\n[/STATE]"; tool_use ];
+      name = None; tool_call_id = None }
+  in
+  let scrubbed = KS.scrub_text_blocks m in
+  let has_tool_use =
+    List.exists (function Agent_sdk.Types.ToolUse _ -> true | _ -> false)
+      scrubbed.content
+  in
+  Alcotest.(check bool) "ToolUse block preserved" true has_tool_use
+
+let test_empty_messages () =
+  let summary = KS.keeper_summarizer [] in
+  Alcotest.(check string) "empty → No prior context marker"
+    "[No prior context]" summary
+
+let () =
+  Alcotest.run "keeper_summarizer"
+    [ ( "scrub + summarize",
+        [ Alcotest.test_case "scrub_text_blocks removes [STATE]" `Quick
+            test_scrub_text_blocks_removes_state;
+          Alcotest.test_case "keeper_summarizer output omits [STATE]" `Quick
+            test_summarizer_strips_state;
+          Alcotest.test_case "non-Text blocks preserved" `Quick
+            test_non_text_blocks_untouched;
+          Alcotest.test_case "empty messages" `Quick
+            test_empty_messages;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Gen4 of the /loop-20m resonance work. Closes the **OAS compaction layer** echo that Gen3 (PR #7647) couldn't reach from the prompt-injection side.

## Layer diagram

```
Turn N produces [STATE]…[/STATE] in assistant message
            ↓
Two loop layers:

  Layer 1 (prompt injection, closed by Gen3 PR #7647)
    structured snapshot → summary prose → next-turn prompt
    ↓ Gen3 trims Done/Decisions fields before injection

  Layer 2 (OAS compaction, closed by THIS PR)
    messages → Budget_strategy.reduce_for_budget (Emergency @ ratio > 0.85)
      → default_summarizer takes first 100 chars → "[STATE]\nDONE: …" verbatim
      → [Summary of N earlier messages] → next-turn context
    ↓ This PR registers keeper_summarizer via Builder.with_summarizer
      which scrubs [STATE]…[/STATE] before the 100-char truncation
```

## Change

| File | Role |
|------|------|
| `lib/keeper/keeper_summarizer.ml` (new) | `keeper_summarizer = scrub_text_blocks → default_extractive_summary`. Scrub reuses `Keeper_text_processing.strip_state_blocks_text` |
| `lib/oas_worker_exec.ml` | `config.summarizer` field + `Builder.with_summarizer` wiring |
| `lib/oas_worker.mli` + `lib/oas_worker_named.ml` | `?summarizer` plumbed through `run_named` |
| `lib/keeper/keeper_agent_run.ml:1713` | Pass `~summarizer:Keeper_summarizer.keeper_summarizer` on keeper run |
| `test/test_keeper_summarizer.ml` (new) | 4 tests: scrub, summarize-over-scrub, non-Text preservation, empty input |

## OAS/MASC boundary

Respected per `feedback_oas-must-not-know-masc`. OAS stays unaware of `[STATE]` markers; MASC supplies the callback through OAS's generic `Agent.options.summarizer` API added in 0.152.0 (PR #973).

## Verification

```
dune build --root .                                 → clean
dune exec --root . test/test_keeper_summarizer.exe  → 4/4 pass
```

## Follow-up (separate PR)

`default_extractive_summary` in `keeper_summarizer.ml` is a re-implementation because OAS 0.152.0 does not export `Budget_strategy.default_summarizer` in its `.mli`. An OAS-side PR to export it would allow deleting the local copy. Out of scope for this PR.