### PR TITLE
chore(dashboard/api): drop 6 pure-orphan API exports (-62 LOC)

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -64,7 +64,3 @@ export async function deleteTask(taskId: string): Promise<boolean> {
   return resp.ok
 }
 
-export async function deleteGoal(goalId: string): Promise<boolean> {
-  const resp = await post<{ ok: boolean }>('/api/v1/dashboard/goals/delete', { goal_id: goalId })
-  return resp.ok
-}

--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -3,7 +3,7 @@ import { isRecord, asNullableString, asString, asNumber, asInt, asStringList } f
 import type {
   BoardPost, BoardComment, BoardSortMode,
   GovernanceContextRef,
-  GovernanceDecisionItem, GovernanceExecutedRoute, GovernanceExecutionOrder,
+  GovernanceDecisionItem, GovernanceExecutedRoute,
   GovernanceGuardrailState, GovernanceJudgeSummary, GovernanceJudgment,
   KeeperApprovalQueueItem,
   GovernanceResolvedAction, GovernanceTimelineEvent, PendingConfirmation,
@@ -176,25 +176,6 @@ export function normalizeGovernanceDecisionItem(raw: unknown): GovernanceDecisio
     executed_route: normalizeGovernanceExecutedRoute(raw.executed_route),
     guardrail_state: normalizeGovernanceGuardrailState(raw.guardrail_state),
     evidence_refs: asStringList(raw.evidence_refs),
-  }
-}
-
-export function normalizeGovernanceExecutionOrder(raw: unknown): GovernanceExecutionOrder | null {
-  if (!isRecord(raw)) return null
-  const id = asString(raw.id, '').trim()
-  const caseId = asString(raw.case_id, '').trim()
-  if (!id || !caseId) return null
-  return {
-    id,
-    case_id: caseId,
-    status: asString(raw.status, 'blocked'),
-    risk_class: asNullableString(raw.risk_class),
-    action_request: normalizeGovernanceResolvedAction(raw.action_request),
-    created_at: asNullableIsoTimestamp(raw.created_at),
-    updated_at: asNullableIsoTimestamp(raw.updated_at),
-    execution_ref: asNullableString(raw.execution_ref),
-    result_summary: asNullableString(raw.result_summary),
-    actor: asNullableString(raw.actor),
   }
 }
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -797,12 +797,6 @@ export async function fetchRuntimeModelMetrics(
   return decoded
 }
 
-export interface DashboardVerificationRef {
-  kind: string
-  label: string
-  value: string
-}
-
 export function fetchDashboardMissionBriefing(
   force = false,
   opts?: { signal?: AbortSignal },

--- a/dashboard/src/api/mcp.ts
+++ b/dashboard/src/api/mcp.ts
@@ -297,36 +297,3 @@ function parseMcpJsonText(text: string): Record<string, unknown> {
   return JSON.parse(trimmed) as Record<string, unknown>
 }
 
-// --- Autoresearch ---
-
-export async function fetchAutoresearchStatus(loopId: string): Promise<Record<string, unknown>> {
-  return parseMcpJsonText(await callMcpTool('masc_autoresearch_status', { loop_id: loopId }))
-}
-
-export async function injectAutoresearchHypothesis(
-  loopId: string,
-  hypothesis: string,
-): Promise<Record<string, unknown>> {
-  return parseMcpJsonText(
-    await callMcpTool('masc_autoresearch_inject', {
-      loop_id: loopId,
-      hypothesis,
-    }),
-  )
-}
-
-export async function runAutoresearchCycle(loopId: string): Promise<Record<string, unknown>> {
-  return parseMcpJsonText(await callMcpTool('masc_autoresearch_cycle', { loop_id: loopId }))
-}
-
-export async function stopAutoresearchLoop(
-  loopId: string,
-  reason?: string,
-): Promise<Record<string, unknown>> {
-  return parseMcpJsonText(
-    await callMcpTool('masc_autoresearch_stop', {
-      loop_id: loopId,
-      ...(reason ? { reason } : {}),
-    }),
-  )
-}


### PR DESCRIPTION
## Summary

Whole-tree \`rg\` scan (no \`api/\` exclusion — critical, because api modules cross-import freely) turned up **7 API symbols whose only reference is their own declaration**. The 6 truly-dead ones are removed here.

## What's removed

| File | Symbol | Why dead |
|---|---|---|
| \`api/actions.ts\` | \`deleteGoal\` | Goal deletion flow replaced elsewhere — no consumer |
| \`api/board.ts\` | \`normalizeGovernanceExecutionOrder\` | Normalizer never wired up; \`GovernanceExecutionOrder\` type import cleaned at same time |
| \`api/dashboard.ts\` | \`DashboardVerificationRef\` | Interface never imported |
| \`api/mcp.ts\` | \`fetchAutoresearchStatus\`, \`injectAutoresearchHypothesis\`, \`runAutoresearchCycle\`, \`stopAutoresearchLoop\` | Entire Autoresearch section — backend MCP tools remain registered but no dashboard surface calls them |

## What was NOT removed (initial scan false positive)

**\`reportToolHostFailure\` + \`ToolHostFailureReport\`** looked orphan until typecheck caught that \`api/mcp.ts\` cross-imports \`reportToolHostFailure\` for tool-host failure telemetry. The earlier "external to \`api/\`" scan missed this because it excluded the \`api/\` directory outright.

## Lessons captured for the next orphan sweep

1. **Whole-tree scan only** — excluding the module's own directory hides sibling cross-imports.
2. **Type inference can keep "orphan" types alive** — function return types and interface sub-field types are used via inference even when no consumer imports the type name. Only safe to drop when total ref count = 1 (own declaration).

## Diff

\`\`\`
4 files changed, 1 insertion(+), 63 deletions(-)
\`\`\`

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` — 117 files / 1184 tests pass

## Context

Part of the ongoing dead-code sweep (previous PRs: #7636, #7640, #7642, #7644, #7648, #7666, #7669). Independent of all other open PRs in this series.