### PR TITLE
feat(keeper): cap snapshot size before persistence (Gen7)

### DIFF
--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -305,6 +305,67 @@ let keeper_state_snapshot_to_summary_text (snapshot : keeper_state_snapshot) : s
   in
   if lines = [] then "No continuity snapshot available." else String.concat "\n" lines
 
+(* Gen7 (2026-04-17): snapshot size cap applied before persistence.
+
+   Gen3 (PR #7647) trimmed backward fields at prompt injection and
+   Gen4 (PR #7668) scrubbed [STATE] blocks in OAS compaction, both on
+   the consumption side. Growth of [meta.continuity_summary] itself
+   was still unbounded: if the LLM produces a longer [STATE] block
+   each turn (more decisions, longer goal prose), the parsed snapshot
+   and its rendered summary grow monotonically.
+
+   This cap runs in [keeper_post_turn.apply_continuity_summary] before
+   [keeper_state_snapshot_to_summary_text], bounding:
+     - each string field (goal / progress / done_summary / next_summary)
+       to [max_string_chars]
+     - each list field (next_items / decisions / open_questions /
+       constraints) to [max_list_items] items, with each item trimmed
+       to [max_item_chars]
+
+   Cap is applied post-parse, pre-render. Audit integrity is preserved
+   because we keep the same shape; what drops is just the tail of long
+   prose and surplus list items. *)
+
+let default_max_string_chars = 400
+let default_max_list_items = 5
+let default_max_item_chars = 200
+
+let cap_string ~max_chars = function
+  | None -> None
+  | Some s when String.length s <= max_chars -> Some s
+  | Some s -> Some (String.sub s 0 max_chars ^ "…")
+
+let cap_list ~max_items ~max_item_chars items =
+  let rec take n = function
+    | _ when n <= 0 -> []
+    | [] -> []
+    | x :: rest -> x :: take (n - 1) rest
+  in
+  take max_items items
+  |> List.map (fun item ->
+      if String.length item <= max_item_chars then item
+      else String.sub item 0 max_item_chars ^ "…")
+
+let cap_snapshot
+    ?(max_string_chars = default_max_string_chars)
+    ?(max_list_items = default_max_list_items)
+    ?(max_item_chars = default_max_item_chars)
+    (snapshot : keeper_state_snapshot) : keeper_state_snapshot =
+  {
+    goal = cap_string ~max_chars:max_string_chars snapshot.goal;
+    progress = cap_string ~max_chars:max_string_chars snapshot.progress;
+    done_summary = cap_string ~max_chars:max_string_chars snapshot.done_summary;
+    next_summary = cap_string ~max_chars:max_string_chars snapshot.next_summary;
+    next_items =
+      cap_list ~max_items:max_list_items ~max_item_chars snapshot.next_items;
+    decisions =
+      cap_list ~max_items:max_list_items ~max_item_chars snapshot.decisions;
+    open_questions =
+      cap_list ~max_items:max_list_items ~max_item_chars snapshot.open_questions;
+    constraints =
+      cap_list ~max_items:max_list_items ~max_item_chars snapshot.constraints;
+  }
+
 (* RFC-MASC-001 Phase 1 post-mortem (Gen3 2026-04-17):
    [keeper_state_snapshot_to_summary_text] renders every field for audit/persistence.
    Injecting it verbatim into the next prompt creates a prose-level echo loop:

--- a/lib/keeper/keeper_post_turn.ml
+++ b/lib/keeper/keeper_post_turn.ml
@@ -76,6 +76,11 @@ let apply_post_turn_lifecycle
     match snapshot with
     | None -> meta
     | Some snapshot ->
+        (* Gen7: cap snapshot size before rendering + persisting.
+           Bounds string prose and list items so meta.continuity_summary
+           cannot grow unboundedly even when the LLM produces a longer
+           [STATE] block each turn. *)
+        let snapshot = Keeper_memory_policy.cap_snapshot snapshot in
         {
           meta with
           continuity_summary = keeper_state_snapshot_to_summary_text snapshot;

--- a/test/dune
+++ b/test/dune
@@ -712,6 +712,13 @@
  (name test_keeper_summarizer)
  (libraries masc_test_deps))
 
+; Gen7 persistence-layer guard: cap_snapshot bounds string/list
+; growth before continuity_summary is rendered + persisted. Stops
+; monotonic growth when the LLM produces ever-longer [STATE] blocks.
+(test
+ (name test_snapshot_size_cap)
+ (libraries masc_test_deps))
+
 ; Keeper_checkpoint_store.is_not_found_detail classifier
 ; regression (observed 334-retry loop on trace-1775487505102-6a347
 ; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)

--- a/test/test_snapshot_size_cap.ml
+++ b/test/test_snapshot_size_cap.ml
@@ -1,0 +1,99 @@
+(** Verify cap_snapshot bounds string and list growth.
+
+    Gen7 persistence-layer guard against keeper_state_snapshot monotonic
+    growth. Gen3 closed the prompt injection side, Gen4 closed the OAS
+    compaction side; this caps the production side so meta.continuity_
+    summary itself stops growing unboundedly even if the LLM emits
+    longer [STATE] blocks turn after turn. *)
+
+module KMP = Masc_mcp.Keeper_memory_policy
+
+let long_string n ch = String.make n ch
+
+let make_snapshot
+    ?(goal = Some "short goal")
+    ?(progress = None)
+    ?(done_summary = None)
+    ?(next_summary = None)
+    ?(next_items = [])
+    ?(decisions = [])
+    ?(open_questions = [])
+    ?(constraints = [])
+    () : KMP.keeper_state_snapshot =
+  { goal; progress; done_summary; next_summary;
+    next_items; decisions; open_questions; constraints }
+
+let test_short_snapshot_unchanged () =
+  let s = make_snapshot ~goal:(Some "ok") ~next_items:[ "a"; "b" ] () in
+  let c = KMP.cap_snapshot s in
+  Alcotest.(check (option string)) "goal unchanged" (Some "ok") c.goal;
+  Alcotest.(check (list string)) "next_items unchanged" [ "a"; "b" ] c.next_items
+
+let test_cap_long_string () =
+  let s = make_snapshot ~goal:(Some (long_string 1000 'x')) () in
+  let c = KMP.cap_snapshot ~max_string_chars:100 s in
+  match c.goal with
+  | Some cg ->
+    (* 100 chars + 1 ellipsis codepoint (3 UTF-8 bytes in OCaml). *)
+    Alcotest.(check bool) "goal length near cap"
+      true (String.length cg <= 100 + 3);
+    Alcotest.(check bool) "ellipsis appended"
+      true (Astring.String.is_suffix ~affix:"…" cg)
+  | None -> Alcotest.fail "expected capped goal"
+
+let test_cap_long_list () =
+  let items = List.init 20 (fun i -> Printf.sprintf "item-%d" i) in
+  let s = make_snapshot ~decisions:items () in
+  let c = KMP.cap_snapshot ~max_list_items:5 s in
+  Alcotest.(check int) "decisions capped to 5"
+    5 (List.length c.decisions);
+  Alcotest.(check string) "first item preserved"
+    "item-0" (List.hd c.decisions)
+
+let test_cap_long_item_in_list () =
+  let long_item = long_string 1000 'z' in
+  let s = make_snapshot ~decisions:[ long_item ] () in
+  let c = KMP.cap_snapshot ~max_item_chars:50 s in
+  match c.decisions with
+  | [ item ] ->
+    Alcotest.(check bool) "item length near cap"
+      true (String.length item <= 50 + 3);
+    Alcotest.(check bool) "ellipsis appended"
+      true (Astring.String.is_suffix ~affix:"…" item)
+  | _ -> Alcotest.fail "expected single decision"
+
+let test_none_fields_stay_none () =
+  let s = make_snapshot () in
+  let c = KMP.cap_snapshot s in
+  Alcotest.(check (option string)) "progress stays None" None c.progress;
+  Alcotest.(check (option string)) "done stays None" None c.done_summary
+
+let test_idempotence () =
+  let items = List.init 20 (fun i -> Printf.sprintf "item-%d" i) in
+  let s = make_snapshot
+    ~goal:(Some (long_string 500 'q'))
+    ~decisions:items ()
+  in
+  let c1 = KMP.cap_snapshot s in
+  let c2 = KMP.cap_snapshot c1 in
+  Alcotest.(check (option string)) "goal idempotent" c1.goal c2.goal;
+  Alcotest.(check (list string)) "decisions idempotent"
+    c1.decisions c2.decisions
+
+let () =
+  Alcotest.run "snapshot_size_cap"
+    [ ( "cap_snapshot",
+        [ Alcotest.test_case "short snapshot unchanged" `Quick
+            test_short_snapshot_unchanged;
+          Alcotest.test_case "long string capped with ellipsis" `Quick
+            test_cap_long_string;
+          Alcotest.test_case "long list truncated" `Quick
+            test_cap_long_list;
+          Alcotest.test_case "long item in list capped" `Quick
+            test_cap_long_item_in_list;
+          Alcotest.test_case "None fields stay None" `Quick
+            test_none_fields_stay_none;
+          Alcotest.test_case "cap is idempotent" `Quick
+            test_idempotence;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Gen7 of the /loop-20m work. Closes the **production side** of the resonance loop. Gen3 and Gen4 closed consumption layers (prompt injection + OAS compaction); persistence growth was still unbounded.

## Empirical observation

`analyst.json` `continuity_summary` length across generations:

| Observation | Length | Context |
|-------------|--------|---------|
| Pre-retro-clean backup | 338 chars | `_backup-retro-clean-20260416-213904/` |
| Gen2 measurement | 1,462 chars | Before Gen3 |
| Gen6 measurement | 2,184 chars | After Gen3 + Gen4 merged |

Despite Gen3 (PR #7647) filtering `Done:` / `Decisions:` from prompt injection, the LLM still produces new `[STATE]` blocks each turn whose content lands in `meta.continuity_summary` via `keeper_post_turn.apply_continuity_summary`. The output of `keeper_state_snapshot_to_summary_text` grew because the parsed snapshot carried ever-longer prose.

## Change

| File | Role |
|------|------|
| `lib/keeper/keeper_memory_policy.ml` | `cap_snapshot : ?max_string_chars:int -> ?max_list_items:int -> ?max_item_chars:int -> snapshot -> snapshot`. Defaults: 400 chars per string field, 5 items per list, 200 chars per item. Appends `…` when truncated |
| `lib/keeper/keeper_post_turn.ml:78-86` | Apply `cap_snapshot` before `keeper_state_snapshot_to_summary_text` |
| `test/test_snapshot_size_cap.ml` (new) | 6 tests: short-pass-through, string cap + ellipsis, list truncation, per-item cap, None preservation, idempotence |

## FSM principle

Solid FSM, plug the judgment. `apply_continuity_summary` flow is unchanged — snapshot → render → store. One new decorator (`cap_snapshot`) bounds growth without schema or rendering changes. `cap_snapshot` is idempotent (test #6): applying it twice yields the same snapshot.

## Non-goals

- No change to snapshot schema, `keeper_state_snapshot_to_summary_text`, or prompt assembly.
- No change to how the LLM is prompted to emit `[STATE]` (RFC-MASC-001 Phase 2, larger generation).
- Cap thresholds are defaults, not env/config yet — thresholds can be externalized later if empirical evidence calls for it.

## Verification

```
dune build --root .                                → clean
dune exec --root . test/test_snapshot_size_cap.exe → 6/6 pass
```

## Stack (each gen: one clean ship)

| Gen | PR | Layer closed |
|-----|----|--------------|
| Gen3 | #7647 MERGED | prompt injection (consumption) |
| Gen4 | #7668 MERGED | OAS compaction (consumption) |
| Gen6 | #7672 DRAFT | OAS 0.153.0 pin + keeper_summarizer delegation |
| **Gen7** | **this PR** | **persistence (production)** |