### PR TITLE
chore(dashboard): drop 8 pure-orphan component exports (-93 LOC)

### DIFF
--- a/dashboard/src/components/agent-detail-state.ts
+++ b/dashboard/src/components/agent-detail-state.ts
@@ -47,7 +47,6 @@ export type AgentFitness = {
   [key: string]: unknown
 }
 export const agentFitness = signal<AgentFitness | null>(null)
-export const fitnessLoading = signal(false)
 
 // --- Selectors ---
 

--- a/dashboard/src/components/common/keeper-identity.ts
+++ b/dashboard/src/components/common/keeper-identity.ts
@@ -28,14 +28,6 @@ export function keeperIdentitySearchTerms(
   return [primary, runtime].filter((value): value is string => Boolean(value))
 }
 
-export function keeperRuntimeLabel(
-  keeperName: string | null | undefined,
-  agentName: string | null | undefined,
-): string | null {
-  const runtime = runtimeAgentName(keeperName, agentName)
-  return runtime ? `runtime · ${runtime}` : null
-}
-
 export function keeperIdentityHint(
   keeperName: string | null | undefined,
   agentName: string | null | undefined,

--- a/dashboard/src/components/common/stat-row.ts
+++ b/dashboard/src/components/common/stat-row.ts
@@ -54,26 +54,4 @@ export function StatGrid({ cols = 2, class: cx, children }: StatGridProps) {
   `
 }
 
-// ── Field dictionary (alternating-row table) ──
-interface FieldDictEntry {
-  key: string
-  value: ComponentChildren
-}
 
-interface FieldDictProps {
-  entries: FieldDictEntry[]
-  class?: string
-}
-
-export function FieldDict({ entries, class: cx }: FieldDictProps) {
-  return html`
-    <div class="flex flex-col ${cx ?? ''}">
-      ${entries.map((e, i) => html`
-        <div class="flex items-start justify-between gap-4 py-1.5 px-2 text-[11px] ${i % 2 === 0 ? 'bg-[var(--white-3)]' : ''} rounded">
-          <span class="text-[var(--text-muted)] shrink-0">${e.key}</span>
-          <span class="text-[var(--text-body)] text-right break-all">${e.value}</span>
-        </div>
-      `)}
-    </div>
-  `
-}

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -77,10 +77,6 @@ export function horizonColor(h: string): string {
   }
 }
 
-export function formatMetric(value: number): string {
-  return value.toFixed(4)
-}
-
 export function priorityLabel(p: number): string {
   switch (p) {
     case 1: return 'P1'

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -1,7 +1,6 @@
 import { signal } from '@preact/signals'
 import { navigate } from '../router'
 import { missionSnapshot } from '../mission-store'
-import { findKeeper } from '../lib/keeper-utils'
 import type {
   Agent,
   DashboardMissionAttentionQueueItem,
@@ -149,29 +148,6 @@ export function attentionAsIncident(item: DashboardMissionAttentionQueueItem): O
   }
 }
 
-export function enrichedKeeperRow(brief: DashboardMissionKeeperBrief): EnrichedKeeperRow {
-  const keeper =
-    findKeeper(brief.name) ?? findKeeper(brief.agent_name)
-  return {
-    brief,
-    keeper,
-    currentWork:
-      trimText(brief.current_work, 110)
-      ?? trimText(keeper?.skill_primary, 110)
-      ?? trimText(keeper?.last_proactive_reason, 110)
-      ?? '명시된 키퍼 초점 없음',
-    recentInput:
-      trimText(keeper?.recent_input_preview, 120) ?? null,
-    recentOutput:
-      trimText(keeper?.recent_output_preview, 120)
-      ?? trimText(keeper?.last_proactive_preview, 120)
-      ?? null,
-    recentEvent:
-      trimText(keeper?.last_proactive_reason, 120)
-      ?? null,
-    recentTools: keeper?.recent_tool_names ?? [],
-  }
-}
 
 export function sessionLookupById() {
   const mission = missionSnapshot.value

--- a/dashboard/src/components/observatory/anomaly-utils.ts
+++ b/dashboard/src/components/observatory/anomaly-utils.ts
@@ -53,14 +53,3 @@ export function detectAnomalies(
   })
 }
 
-export function anomalySummary(results: AnomalyResult[]): {
-  count: number
-  worstDrop: AnomalyResult | null
-} {
-  const anomalies = results.filter(r => r.isAnomaly)
-  const drops = anomalies.filter(r => r.zScore < 0).sort((a, b) => a.zScore - b.zScore)
-  return {
-    count: anomalies.length,
-    worstDrop: drops[0] ?? null,
-  }
-}

--- a/dashboard/src/components/task-manage/task-manage-state.ts
+++ b/dashboard/src/components/task-manage/task-manage-state.ts
@@ -27,23 +27,6 @@ export async function createTask(input: TaskCreateInput): Promise<boolean> {
   }
 }
 
-export const taskClaiming = signal<Record<string, boolean>>({})
-
-export async function claimTask(taskId: string): Promise<void> {
-  taskClaiming.value = { ...taskClaiming.value, [taskId]: true }
-  try {
-    await callMcpTool('masc_claim_next', { task_id: taskId })
-    showToast(`태스크 ${taskId} 클레임 완료`, 'success')
-    await refreshExecution({ force: true })
-  } catch (err) {
-    showToast(`클레임 실패: ${err instanceof Error ? err.message : String(err)}`, 'error')
-  } finally {
-    const next = { ...taskClaiming.value }
-    delete next[taskId]
-    taskClaiming.value = next
-  }
-}
-
 export async function updateTaskPriority(taskId: string, priority: number): Promise<void> {
   try {
     await callMcpTool('masc_update_priority', { task_id: taskId, priority })

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -117,12 +117,6 @@ export function formatArgs(args: Record<string, unknown> | string): string {
   return keys.length > ARGS_MAX_KEYS ? `{${preview}, ...}` : `{${preview}}`
 }
 
-export function formatResult(result: string | null, error: string | null, maxLen = 80): string {
-  if (error) return `err: ${truncate(error, maxLen)}`
-  if (!result) return '-'
-  return truncate(result, maxLen)
-}
-
 export function prettyArgs(args: Record<string, unknown> | string): string {
   if (typeof args === 'string') return args
   try { return JSON.stringify(args, null, 2) } catch { return String(args) }


### PR DESCRIPTION
## Summary

Whole-tree \`rg\` scan for symbols with **total reference count = 1** (only their own declaration) turned up 8 component-level orphans. Removed in a single surgical sweep.

## What's removed

| File | Export | Payload |
|---|---|---|
| \`task-manage/task-manage-state.ts\` | \`claimTask\` | + orphan \`taskClaiming\` signal |
| \`common/stat-row.ts\` | \`FieldDict\` | + local \`FieldDictEntry\` interface |
| \`agent-detail-state.ts\` | \`fitnessLoading\` | signal |
| \`goals/goal-helpers.ts\` | \`formatMetric\` | |
| \`tool-call-shared.ts\` | \`formatResult\` | |
| \`common/keeper-identity.ts\` | \`keeperRuntimeLabel\` | |
| \`observatory/anomaly-utils.ts\` | \`anomalySummary\` | |
| \`mission-utils.ts\` | \`enrichedKeeperRow\` | + orphan \`findKeeper\` import |

## Verification

Each export was verified pure-dead with:

\`\`\`
rg -c '\\b<sym>\\b' dashboard/src/   # count = 1 (self-declaration only)
\`\`\`

Typecheck caught two follow-on dangling references (\`FieldDictEntry\`, \`findKeeper\` import) which are cleaned in the same commit.

## Diff

\`\`\`
8 files changed, 93 deletions(-)
\`\`\`

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` — **127 files / 1636 tests** pass

## Context

Part of the ongoing dead-code sweep (previous PRs: #7633, #7636, #7640, #7642, #7644, #7648, #7666, #7669, #7675). Independent of all other open PRs in this series.