### PR TITLE
feat(dashboard): SLO status card reading strategy_trace ring

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2044,3 +2044,35 @@ export function fetchCascadeStrategyTrace(opts?: {
     { signal: opts?.signal },
   )
 }
+
+export type CascadeSloStatus = 'ok' | 'warn' | 'violated'
+
+export interface CascadeSloTargets {
+  ordered_ratio_min: number
+  exhaustion_count_max: number
+  burn_rate_max: number
+}
+
+export interface CascadeSloCurrent {
+  ordered_ratio: number
+  exhaustion_count: number
+  burn_rate: number
+  total_events: number
+}
+
+export interface CascadeSloResponse {
+  updated_at: string
+  window_sample_size: number
+  targets: CascadeSloTargets
+  current: CascadeSloCurrent
+  status: CascadeSloStatus
+  violations: string[]
+}
+
+export function fetchCascadeSlo(
+  opts?: AbortableRequestOptions,
+): Promise<CascadeSloResponse> {
+  return get<CascadeSloResponse>('/api/v1/cascade/slo', {
+    signal: opts?.signal,
+  })
+}

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -14,6 +14,7 @@ import {
   fetchCascadeClientCapacity,
   fetchCascadeClientCapacityHistory,
   fetchCascadeStrategyTrace,
+  fetchCascadeSlo,
   fetchCascadeConfig,
   fetchCascadeHealth,
   type CascadeCandidate,
@@ -29,6 +30,8 @@ import {
   type CascadeStrategyTraceEvent,
   type CascadeStrategyTraceKind,
   type CascadeStrategyTraceResponse,
+  type CascadeSloResponse,
+  type CascadeSloStatus,
 } from '../api/dashboard'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
@@ -44,18 +47,20 @@ interface CascadeData {
   capacity: CascadeClientCapacityResponse | null
   history: CascadeClientCapacityHistoryResponse | null
   trace: CascadeStrategyTraceResponse | null
+  slo: CascadeSloResponse | null
 }
 
 async function loadCascadeData(resource: ManagedAsyncResource<CascadeData>) {
   await resource.load(async (signal) => {
-    const [config, health, capacity, history, trace] = await Promise.all([
+    const [config, health, capacity, history, trace, slo] = await Promise.all([
       fetchCascadeConfig({ signal }),
       fetchCascadeHealth({ signal }),
       fetchCascadeClientCapacity({ signal }),
       fetchCascadeClientCapacityHistory({ limit: 50, signal }),
       fetchCascadeStrategyTrace({ limit: 50, signal }),
+      fetchCascadeSlo({ signal }),
     ])
-    return { config, health, capacity, history, trace }
+    return { config, health, capacity, history, trace, slo }
   })
 }
 
@@ -283,6 +288,60 @@ export function traceEventMatchesSearch(
   return false
 }
 
+function sloStatusTone(status: CascadeSloStatus): 'ok' | 'warn' | 'bad' {
+  switch (status) {
+    case 'ok': return 'ok'
+    case 'warn': return 'warn'
+    case 'violated': return 'bad'
+  }
+}
+
+function sloStatusLabel(status: CascadeSloStatus): string {
+  switch (status) {
+    case 'ok': return '정상'
+    case 'warn': return '경고'
+    case 'violated': return '위반'
+  }
+}
+
+function SloCard({ slo }: { slo: CascadeSloResponse }) {
+  const tone = sloStatusTone(slo.status)
+  const ratioPct = (slo.current.ordered_ratio * 100).toFixed(2)
+  const targetPct = (slo.targets.ordered_ratio_min * 100).toFixed(0)
+  const burn = slo.current.burn_rate.toFixed(2)
+  const exh = slo.current.exhaustion_count
+  const exhTarget = slo.targets.exhaustion_count_max
+  const totalEvents = slo.current.total_events
+  return html`
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center gap-2 flex-wrap">
+        <${StatusChip} tone=${tone}>${sloStatusLabel(slo.status)}<//>
+        <span class="text-xs text-[var(--text-muted)]">sample ${totalEvents}/${slo.window_sample_size}</span>
+        ${slo.violations.length > 0
+          ? html`<span class="text-xs text-red-500">violating: ${slo.violations.join(', ')}</span>`
+          : null}
+      </div>
+      <div class="grid grid-cols-3 gap-3">
+        <${StatCell}
+          label="Ordered Ratio"
+          value=${`${ratioPct}%`}
+          detail=${`≥ ${targetPct}% 목표`}
+        />
+        <${StatCell}
+          label="Exhaustion (sample)"
+          value=${String(exh)}
+          detail=${`≤ ${exhTarget} 목표`}
+        />
+        <${StatCell}
+          label="Burn Rate"
+          value=${burn}
+          detail=${`≤ ${slo.targets.burn_rate_max.toFixed(1)} 목표`}
+        />
+      </div>
+    </div>
+  `
+}
+
 function StrategyTraceTable({
   trace,
   searchQuery,
@@ -413,6 +472,7 @@ export function CascadeConfigPanel() {
   const capacity = current.data?.capacity ?? null
   const history = current.data?.history ?? null
   const trace = current.data?.trace ?? null
+  const slo = current.data?.slo ?? null
 
   return html`
     <div class="flex flex-col gap-4">
@@ -496,6 +556,12 @@ export function CascadeConfigPanel() {
         ${history
           ? html`<${ClientCapacityHistoryTable} history=${history} />`
           : null}
+      <//>
+
+      <${Card} title="SLO Status">
+        ${slo
+          ? html`<${SloCard} slo=${slo} />`
+          : html`<${EmptyState}>SLO 데이터를 불러오는 중입니다.<//>`}
       <//>
 
       <${Card} title="Strategy Decisions — cycle 추적">

--- a/lib/dashboard_cascade.ml
+++ b/lib/dashboard_cascade.ml
@@ -217,3 +217,66 @@ let strategy_trace_json ?limit ?cascade () =
     ("total_events", `Int (List.length events));
     ("events", `List (List.map strategy_trace_event_to_json events));
   ]
+
+(* ── SLO projection (LT-11) ─────────────────────────────────
+
+   Targets mirror infrastructure/monitoring/cascade-slo.yml.  Computed
+   in-process from the live Cascade_strategy_trace ring so the MASC
+   dashboard can render SLO status without reaching Prometheus. *)
+
+let slo_sample_limit = 1000
+let slo_target_ordered_ratio = 0.99
+let slo_target_exhaustion_count = 10
+let slo_target_burn_rate = 1.0
+
+let compute_slo_counts (events : Cascade_strategy_trace.event list) =
+  List.fold_left
+    (fun (total, ordered, exhausted) (ev : Cascade_strategy_trace.event) ->
+       match ev.kind with
+       | Ordered -> (total + 1, ordered + 1, exhausted)
+       | Filtered_empty -> (total + 1, ordered, exhausted)
+       | Exhausted -> (total + 1, ordered, exhausted + 1))
+    (0, 0, 0) events
+
+let slo_json () =
+  let events = Cascade_strategy_trace.snapshot ~limit:slo_sample_limit () in
+  let total, ordered, exhausted = compute_slo_counts events in
+  let ordered_ratio =
+    if total = 0 then 1.0
+    else float_of_int ordered /. float_of_int total
+  in
+  let burn_rate = (1.0 -. ordered_ratio) /. 0.01 in
+  let ratio_violated = ordered_ratio < slo_target_ordered_ratio in
+  let exhaustion_violated = exhausted > slo_target_exhaustion_count in
+  let burn_violated = burn_rate > slo_target_burn_rate in
+  let violations =
+    List.filter_map (fun (name, violated) ->
+      if violated then Some (`String name) else None)
+      [
+        "ordered_ratio", ratio_violated;
+        "exhaustion_count", exhaustion_violated;
+        "burn_rate", burn_violated;
+      ]
+  in
+  let status =
+    if ratio_violated || exhaustion_violated then "violated"
+    else if burn_violated then "warn"
+    else "ok"
+  in
+  `Assoc [
+    "updated_at", `String (now_iso ());
+    "window_sample_size", `Int slo_sample_limit;
+    "targets", `Assoc [
+      "ordered_ratio_min", `Float slo_target_ordered_ratio;
+      "exhaustion_count_max", `Int slo_target_exhaustion_count;
+      "burn_rate_max", `Float slo_target_burn_rate;
+    ];
+    "current", `Assoc [
+      "ordered_ratio", `Float ordered_ratio;
+      "exhaustion_count", `Int exhausted;
+      "burn_rate", `Float burn_rate;
+      "total_events", `Int total;
+    ];
+    "status", `String status;
+    "violations", `List violations;
+  ]

--- a/lib/dashboard_cascade.mli
+++ b/lib/dashboard_cascade.mli
@@ -171,3 +171,46 @@ val strategy_trace_json :
   ?limit:int ->
   ?cascade:string ->
   unit -> Yojson.Safe.t
+
+(** Instantaneous SLO snapshot computed from the live
+    {!Cascade_strategy_trace} ring buffer.
+
+    Mirrors the SLO definitions codified in
+    {{:../../infrastructure/monitoring/cascade-slo.yml}cascade-slo.yml}
+    but evaluated in-process so the MASC dashboard can surface the
+    same targets without a Prometheus round-trip.
+
+    Shape:
+    {[
+      {
+        "updated_at": "ISO-8601",
+        "window_sample_size": 1000,
+        "targets": {
+          "ordered_ratio_min":    0.99,
+          "exhaustion_count_max": 10,
+          "burn_rate_max":        1.0
+        },
+        "current": {
+          "ordered_ratio":     0.987,
+          "exhaustion_count":  3,
+          "burn_rate":         1.3,
+          "total_events":      847
+        },
+        "status":        "ok" | "warn" | "violated",
+        "violations":    ["ordered_ratio", "burn_rate", ...]
+      }
+    ]}
+
+    Semantics:
+    - [ordered_ratio] is computed over the most recent {b up to 1000}
+      events (defensive cap matching the default ring limit).  When
+      the ring is empty the ratio defaults to [1.0] (treat idle as
+      healthy).
+    - [exhaustion_count] counts [Exhausted] events in the same sample.
+    - [burn_rate] is [(1 - ordered_ratio) / 0.01], matching the
+      Prometheus recording rule [masc:cascade_error_budget_burn].
+    - [status] derives from [violations]: empty → ["ok"], burn_rate
+      alone → ["warn"], any SLO hard-breach → ["violated"].
+
+    @since 0.9.11 *)
+val slo_json : unit -> Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_cascade.ml
+++ b/lib/server/server_routes_http_routes_cascade.ml
@@ -68,3 +68,9 @@ let add_routes router =
          Http.Response.json ~compress:true ~request:req
            (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/cascade/slo" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = Dashboard_cascade.slo_json () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)

--- a/test/test_dashboard_cascade.ml
+++ b/test/test_dashboard_cascade.ml
@@ -92,6 +92,114 @@ let test_health_serializable () =
   let reparsed = Yojson.Safe.from_string s in
   check json "roundtrip" j reparsed
 
+(* ── SLO (LT-11) ─────────────────────────────────────── *)
+
+module ST = Masc_mcp.Cascade_strategy_trace
+
+let mk_trace ?(ts = 0.0) ?(strategy = "failover") ~kind () =
+  { ST.ts; cascade_name = "c1"; strategy; cycle = 0;
+    candidates_in = 1; candidates_out = 1; backoff_ms = 0; kind }
+
+let assert_field name fields =
+  match List.assoc_opt name fields with
+  | Some v -> v
+  | None -> fail (Printf.sprintf "field %s missing" name)
+
+let slo_fields () =
+  match Masc_mcp.Dashboard_cascade.slo_json () with
+  | `Assoc fs -> fs
+  | _ -> fail "expected assoc"
+
+let current_field fields key =
+  match assert_field "current" fields with
+  | `Assoc cs ->
+    (match List.assoc_opt key cs with
+     | Some v -> v
+     | None -> fail (Printf.sprintf "current.%s missing" key))
+  | _ -> fail "current not assoc"
+
+let test_slo_empty_ring_is_ok () =
+  ST.clear ();
+  let fs = slo_fields () in
+  (match assert_field "status" fs with
+   | `String "ok" -> ()
+   | _ -> fail "expected status=ok on empty ring");
+  (match current_field fs "ordered_ratio" with
+   | `Float v -> check (float 0.0) "idle treated as 1.0" 1.0 v
+   | _ -> fail "ordered_ratio not float")
+
+let test_slo_all_ordered () =
+  ST.clear ();
+  for _ = 1 to 10 do
+    ST.record (mk_trace ~kind:ST.Ordered ())
+  done;
+  let fs = slo_fields () in
+  (match current_field fs "ordered_ratio" with
+   | `Float v -> check (float 0.0) "all ordered → 1.0" 1.0 v
+   | _ -> fail "ordered_ratio not float");
+  (match assert_field "status" fs with
+   | `String "ok" -> ()
+   | _ -> fail "expected status=ok")
+
+let test_slo_partial_filtered () =
+  ST.clear ();
+  for _ = 1 to 90 do
+    ST.record (mk_trace ~kind:ST.Ordered ())
+  done;
+  for _ = 1 to 10 do
+    ST.record (mk_trace ~kind:ST.Filtered_empty ())
+  done;
+  let fs = slo_fields () in
+  (match current_field fs "ordered_ratio" with
+   | `Float v ->
+     check bool "ratio ≈ 0.9 (< 0.99 target)" true (v < 0.99);
+     check bool "ratio > 0.8" true (v > 0.8)
+   | _ -> fail "ordered_ratio not float");
+  (match assert_field "status" fs with
+   | `String ("violated") -> ()
+   | `String "warn" -> ()  (* depending on exhaustion_count too *)
+   | `String other -> fail (Printf.sprintf "expected violated/warn, got %s" other)
+   | _ -> fail "status not string")
+
+let test_slo_exhaustion_breach () =
+  ST.clear ();
+  for _ = 1 to 11 do
+    ST.record (mk_trace ~kind:ST.Exhausted ())
+  done;
+  let fs = slo_fields () in
+  (match current_field fs "exhaustion_count" with
+   | `Int v -> check bool "exhaustion_count >= 11 (> 10 target)" true (v >= 11)
+   | _ -> fail "exhaustion_count not int");
+  (match assert_field "status" fs with
+   | `String "violated" -> ()
+   | _ -> fail "expected status=violated");
+  (match assert_field "violations" fs with
+   | `List xs ->
+     check bool "violations includes exhaustion_count" true
+       (List.exists (function `String "exhaustion_count" -> true | _ -> false) xs)
+   | _ -> fail "violations not list")
+
+let test_slo_burn_rate_math () =
+  ST.clear ();
+  (* 98 ordered + 2 filtered_empty → ratio = 0.98 → burn = 2.0 *)
+  for _ = 1 to 98 do ST.record (mk_trace ~kind:ST.Ordered ()) done;
+  for _ = 1 to 2 do ST.record (mk_trace ~kind:ST.Filtered_empty ()) done;
+  let fs = slo_fields () in
+  (match current_field fs "burn_rate" with
+   | `Float v ->
+     check bool "burn_rate ≈ 2.0 (> 1.0 target)" true (v > 1.9 && v < 2.1)
+   | _ -> fail "burn_rate not float")
+
+let test_slo_top_level_shape () =
+  ST.clear ();
+  let fs = slo_fields () in
+  check bool "has updated_at" true (List.mem_assoc "updated_at" fs);
+  check bool "has window_sample_size" true (List.mem_assoc "window_sample_size" fs);
+  check bool "has targets" true (List.mem_assoc "targets" fs);
+  check bool "has current" true (List.mem_assoc "current" fs);
+  check bool "has status" true (List.mem_assoc "status" fs);
+  check bool "has violations" true (List.mem_assoc "violations" fs)
+
 (* ── Suite ─────────────────────────────────────────── *)
 
 let () =
@@ -104,5 +212,13 @@ let () =
     "health_json", [
       test_case "top-level shape" `Quick test_health_shape;
       test_case "roundtrip serializable" `Quick test_health_serializable;
+    ];
+    "slo_json", [
+      test_case "top-level shape" `Quick test_slo_top_level_shape;
+      test_case "empty ring → status ok, ratio 1.0" `Quick test_slo_empty_ring_is_ok;
+      test_case "all ordered → ratio 1.0" `Quick test_slo_all_ordered;
+      test_case "partial filtered drops ratio" `Quick test_slo_partial_filtered;
+      test_case "exhaustion > 10 → violated" `Quick test_slo_exhaustion_breach;
+      test_case "burn_rate math" `Quick test_slo_burn_rate_math;
     ];
   ]


### PR DESCRIPTION
## Summary
Surfaces LT-10 cascade SLOs inside the MASC dashboard — `ordered_ratio`, `exhaustion_count`, `burn_rate` readable without switching to Grafana/Prometheus.

## Shape
- `lib/dashboard_cascade.ml/.mli` — `slo_json ()` computed in-process from `Cascade_strategy_trace.snapshot` (up to 1000 most recent events).
- `lib/server/server_routes_http_routes_cascade.ml` — new `GET /api/v1/cascade/slo`.
- `dashboard/src/api/dashboard.ts` — `CascadeSloResponse` types + `fetchCascadeSlo`.
- `dashboard/src/components/cascade-config-panel.ts` — new **SLO Status** card (StatusChip + 3 StatCells + violations list).
- `test/test_dashboard_cascade.ml` — 6 alcotest cases, 11/11 pass.

## Targets (mirror LT-10 recording rules)
- `ordered_ratio >= 0.99`
- `exhaustion_count <= 10` per 1000-sample window
- `burn_rate <= 1.0`

## Status derivation
- ratio OR exhaustion breached → `violated` (red)
- burn_rate alone breached → `warn` (orange)
- otherwise → `ok` (green)

## Why compute in-process (not Prometheus)
Prometheus recording rules depend on external TSDB scrape. Fresh deployments, local dev, and CI lack Prometheus but still need SLO visibility. Reading from the ring buffer is O(1000) per request — cheap enough for 30s dashboard polling. Grafana/alerts remain authoritative for long windows; this card is operator ergonomics.

## Test plan
- [x] `dune build` clean
- [x] `dune exec test/test_dashboard_cascade.exe` → 11/11 (6 new + 5 regression)
- [x] `pnpm typecheck` clean
- [ ] Reviewer: confirm "empty ring → ratio 1.0" is correct interpretation (idle = healthy)

Related: #7674 (SLO recording rules), #7643 (strategy trace), #7671 (Grafana), #7645/#7649 (counters).