### PR TITLE
chore(dashboard): purge 8 dead type definitions (-71 LOC)

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -27,13 +27,6 @@ export function extractLaneValue(
   }
 }
 
-export type TransitionEntry = {
-  ts: number
-  from: string
-  to: string
-  field: string
-}
-
 export type TopTransition = {
   field: string
   from: string

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -222,54 +222,6 @@ export type KeeperLifecycleState =
   | 'unbooted'
   | 'stopped'
 
-// --- Keeper SSE Events ---
-
-export interface KeeperHeartbeatEvent {
-  type: 'keeper_heartbeat'
-  name: string
-  generation: number
-  context_ratio: number
-  ts_unix: number
-}
-
-export interface KeeperHandoffEvent {
-  type: 'keeper_handoff'
-  name: string
-  from_generation: number
-  to_generation: number
-  from_model: string
-  to_model: string
-  ts_unix: number
-}
-
-export interface KeeperCompactionEvent {
-  type: 'keeper_compaction'
-  name: string
-  generation: number
-  before_tokens: number
-  after_tokens: number
-  saved_tokens: number
-  trigger: string
-  ts_unix: number
-}
-
-export interface KeeperGuardrailEvent {
-  type: 'keeper_guardrail'
-  name: string
-  generation: number
-  reason: string
-  ts_unix: number
-}
-
-export interface KeeperPhaseChangedEvent {
-  type: 'keeper_phase_changed'
-  name: string
-  prev_phase: string
-  new_phase: string
-  event: string
-  ts_unix: number
-}
-
 export interface Goal {
   id: string
   horizon: 'short' | 'mid' | 'long'

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -444,21 +444,6 @@ export interface OperatorWorkerCard {
   last_turn_ts_iso?: string | null
 }
 
-export interface OperatorSessionCard {
-  session_id: string
-  goal?: string
-  status?: string
-  health?: string
-  scale_profile?: string
-  control_profile?: string
-  planned_worker_count?: number
-  active_agent_count?: number
-  last_turn_age_sec?: number | null
-  attention_count?: number
-  recommended_action_count?: number
-  top_attention?: OperatorAttentionItem | null
-  top_recommendation?: OperatorRecommendedAction | null
-}
 
 export interface OperatorJudgeRuntime {
   enabled?: boolean

--- a/dashboard/src/types/json-schema.ts
+++ b/dashboard/src/types/json-schema.ts
@@ -29,7 +29,3 @@ export interface McpToolSchema {
   }
 }
 
-export interface McpToolsListResponse {
-  tools: McpToolSchema[]
-  nextCursor?: string
-}


### PR DESCRIPTION
## Summary

8 exported types with **zero references** outside their own declaration, identified by whole-tree \`rg\` (\`count=1\`).

| File | Types | LOC |
|---|---|---|
| \`types/core.ts\` | 5 Keeper SSE event interfaces (\`KeeperHeartbeatEvent\`, \`KeeperHandoffEvent\`, \`KeeperCompactionEvent\`, \`KeeperGuardrailEvent\`, \`KeeperPhaseChangedEvent\`) | 47 |
| \`types/json-schema.ts\` | \`McpToolsListResponse\` | 4 |
| \`types/dashboard-mission.ts\` | \`OperatorSessionCard\` | 14 |
| \`components/fsm-hub-types.ts\` | \`TransitionEntry\` | 5 |

**Net: -71 LOC** across 4 files.

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test\` — 127 files / 1636 tests

Independent of #7666 / #7669 / #7675 / #7677.