### PR TITLE
test(dashboard): add 30 tests for keeper-phase-indicator and keeper-phase-strip

### DIFF
--- a/dashboard/src/components/keeper-phase-indicator.test.ts
+++ b/dashboard/src/components/keeper-phase-indicator.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { PHASE_STYLES, getPhaseStyle } from './keeper-phase-indicator'
+
+// ================================================================
+// PHASE_STYLES
+// ================================================================
+
+describe('PHASE_STYLES', () => {
+  it('has all 12 phases', () => {
+    const phases = Object.keys(PHASE_STYLES)
+    expect(phases).toHaveLength(12)
+    expect(phases).toContain('Offline')
+    expect(phases).toContain('Running')
+    expect(phases).toContain('Failing')
+    expect(phases).toContain('Overflowed')
+    expect(phases).toContain('Compacting')
+    expect(phases).toContain('HandingOff')
+    expect(phases).toContain('Draining')
+    expect(phases).toContain('Paused')
+    expect(phases).toContain('Stopped')
+    expect(phases).toContain('Crashed')
+    expect(phases).toContain('Restarting')
+    expect(phases).toContain('Dead')
+  })
+
+  it('each phase has label, color, bg, border, glow, icon', () => {
+    for (const [key, style] of Object.entries(PHASE_STYLES)) {
+      expect(style).toHaveProperty('label')
+      expect(style).toHaveProperty('color')
+      expect(style).toHaveProperty('bg')
+      expect(style).toHaveProperty('border')
+      expect(style).toHaveProperty('glow')
+      expect(style).toHaveProperty('icon')
+      expect(typeof style.label).toBe('string')
+      expect(typeof style.color).toBe('string')
+    }
+  })
+
+  it('each label is Korean', () => {
+    for (const style of Object.values(PHASE_STYLES)) {
+      expect(style.label.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ================================================================
+// getPhaseStyle
+// ================================================================
+
+describe('getPhaseStyle', () => {
+  it('returns Offline for null', () => {
+    expect(getPhaseStyle(null).label).toBe('오프라인')
+  })
+
+  it('returns Offline for undefined', () => {
+    expect(getPhaseStyle(undefined).label).toBe('오프라인')
+  })
+
+  it('returns Offline for empty string', () => {
+    expect(getPhaseStyle('').label).toBe('오프라인')
+  })
+
+  it('returns correct style for Running', () => {
+    expect(getPhaseStyle('Running').label).toBe('실행중')
+    expect(getPhaseStyle('Running').color).toBe('#34d399')
+  })
+
+  it('returns correct style for Crashed', () => {
+    expect(getPhaseStyle('Crashed').label).toBe('비정상종료')
+    expect(getPhaseStyle('Crashed').color).toBe('#ef4444')
+  })
+
+  it('returns Offline for unknown phase string', () => {
+    expect(getPhaseStyle('UnknownPhase').label).toBe('오프라인')
+  })
+
+  it('returns correct style for all 12 phases', () => {
+    const phases: string[] = ['Offline', 'Running', 'Failing', 'Overflowed', 'Compacting', 'HandingOff', 'Draining', 'Paused', 'Stopped', 'Crashed', 'Restarting', 'Dead']
+    for (const phase of phases) {
+      const style = getPhaseStyle(phase)
+      expect(style.label).toBeTruthy()
+      expect(style.color).toBeTruthy()
+    }
+  })
+})

--- a/dashboard/src/components/keeper-phase-indicator.test.ts
+++ b/dashboard/src/components/keeper-phase-indicator.test.ts
@@ -24,7 +24,7 @@ describe('PHASE_STYLES', () => {
   })
 
   it('each phase has label, color, bg, border, glow, icon', () => {
-    for (const [key, style] of Object.entries(PHASE_STYLES)) {
+    for (const [_key, style] of Object.entries(PHASE_STYLES)) {
       expect(style).toHaveProperty('label')
       expect(style).toHaveProperty('color')
       expect(style).toHaveProperty('bg')

--- a/dashboard/src/components/keeper-phase-strip.test.ts
+++ b/dashboard/src/components/keeper-phase-strip.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { toPascalPhase, eventLabel } from './keeper-phase-strip'
+
+// ================================================================
+// toPascalPhase
+// ================================================================
+
+describe('toPascalPhase', () => {
+  it('converts simple lowercase to PascalCase', () => {
+    expect(toPascalPhase('running')).toBe('Running')
+  })
+
+  it('converts snake_case to PascalCase', () => {
+    expect(toPascalPhase('handing_off')).toBe('HandingOff')
+  })
+
+  it('converts multi-segment snake_case', () => {
+    expect(toPascalPhase('a_b_c')).toBe('ABC')
+  })
+
+  it('handles already PascalCase input', () => {
+    expect(toPascalPhase('Running')).toBe('Running')
+  })
+
+  it('handles empty string', () => {
+    expect(toPascalPhase('')).toBe('')
+  })
+
+  it('handles mixed case', () => {
+    expect(toPascalPhase('HANDING_OFF')).toBe('HandingOff')
+  })
+
+  it('handles single underscore', () => {
+    expect(toPascalPhase('off_line')).toBe('OffLine')
+  })
+
+  it('handles no underscore', () => {
+    expect(toPascalPhase('dead')).toBe('Dead')
+  })
+
+  it('handles overflowing', () => {
+    expect(toPascalPhase('overflowed')).toBe('Overflowed')
+  })
+})
+
+// ================================================================
+// eventLabel
+// ================================================================
+
+describe('eventLabel', () => {
+  it('returns string as-is', () => {
+    expect(eventLabel('tool_call')).toBe('tool_call')
+  })
+
+  it('extracts type from object', () => {
+    expect(eventLabel({ type: 'cascade_select' })).toBe('cascade_select')
+  })
+
+  it('extracts type as string from number', () => {
+    expect(eventLabel({ type: 42 })).toBe('42')
+  })
+
+  it('returns ? for null', () => {
+    expect(eventLabel(null)).toBe('?')
+  })
+
+  it('returns ? for undefined', () => {
+    expect(eventLabel(undefined)).toBe('?')
+  })
+
+  it('returns ? for object without type', () => {
+    expect(eventLabel({ name: 'test' })).toBe('?')
+  })
+
+  it('returns ? for object with null type', () => {
+    expect(eventLabel({ type: null })).toBe('?')
+  })
+
+  it('returns ? for object with undefined type', () => {
+    expect(eventLabel({ type: undefined })).toBe('?')
+  })
+
+  it('returns ? for number', () => {
+    expect(eventLabel(123)).toBe('?')
+  })
+
+  it('returns ? for empty object', () => {
+    expect(eventLabel({})).toBe('?')
+  })
+
+  it('returns ? for array', () => {
+    expect(eventLabel([1, 2, 3])).toBe('?')
+  })
+})

--- a/dashboard/src/components/keeper-phase-strip.ts
+++ b/dashboard/src/components/keeper-phase-strip.ts
@@ -12,8 +12,8 @@ import { getPhaseStyle } from './keeper-phase-indicator'
 const transitionData = signal<Map<string, KeeperTransitionsResponse>>(new Map())
 const loading = signal(false)
 
-// Server sends lowercase (e.g. "running", "handing_off"); PHASE_STYLES uses PascalCase
-function toPascalPhase(phase: string): string {
+/** Server sends lowercase (e.g. "running", "handing_off"); PHASE_STYLES uses PascalCase. */
+export function toPascalPhase(phase: string): string {
   return phase.toLowerCase()
     .replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
     .replace(/^./, s => s.toUpperCase())
@@ -28,8 +28,8 @@ function phaseInlineStyle(phase: string): string {
   return `color: ${style.color}; background: ${style.bg}; border: 1px solid ${style.border};`
 }
 
-// selected_event comes as object {type: "...", ...} from the server
-function eventLabel(event: unknown): string {
+/** selected_event comes as object {type: "...", ...} from the server */
+export function eventLabel(event: unknown): string {
   if (typeof event === 'string') return event
   if (event && typeof event === 'object' && 'type' in event) {
     const type = (event as Record<string, unknown>).type


### PR DESCRIPTION
## Summary
- Add 10 tests for `PHASE_STYLES` and `getPhaseStyle` in keeper-phase-indicator
- Export and add 20 tests for `toPascalPhase` (9) and `eventLabel` (11) from keeper-phase-strip
- Both functions handle server → client data transformation (snake_case → PascalCase, unknown → string label)

## Test plan
- [x] Local: 30 tests pass
- [ ] CI: Dashboard + Build checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)