### PR TITLE
fix(dashboard): remove hardcoded zero fields from profiling WARN output

### DIFF
--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -272,17 +272,15 @@ let json_render ~effective_actor ~light ~config ~sw ~clock ~proc_mgr () =
       ] in
       let t_end = Time_compat.now () in
       let total_ms = (t_end -. t_start) *. 1000.0 in
-      let snapshot_ms = 0.0 in
-      let render_ms = total_ms in
       if total_ms > 10000.0 then
         Log.Dashboard.warn
-          "[dashboard_execution] slow render: total=%.0fms snapshot=%.0fms render=%.0fms (keepers=%d)"
-          total_ms snapshot_ms render_ms
+          "[dashboard_execution] slow render: total=%.0fms (keepers=%d)"
+          total_ms
           (List.length keepers)
       else
         Log.Dashboard.debug
-          "[dashboard_execution] timing: total=%.0fms snapshot=%.0fms render=%.0fms"
-          total_ms snapshot_ms render_ms;
+          "[dashboard_execution] timing: total=%.0fms"
+          total_ms;
       if light then
         `Assoc (base_fields @ task_fields)
       else

--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -310,8 +310,8 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
           let dt_total = Unix.gettimeofday () -. started_at in
           if dt_total >= 5.0 then
             Log.Dashboard.warn
-              "[operator_snapshot profile] total=%.1fs sessions=%.1fs(%d) snapshot=%.1fs"
-              dt_total 0.0 0 dt_snapshot;
+              "[operator_snapshot profile] total=%.1fs snapshot=%.1fs"
+              dt_total dt_snapshot;
           json
           |> with_projection_diagnostics ~surface:"operator_snapshot" ~started_at
                ~extra:(operator_snapshot_extra ()))


### PR DESCRIPTION
## Summary

- `lib/dashboard/dashboard_execution.ml:275` drops `snapshot_ms=0.0` and the `render_ms = total_ms` tautology. The slow/debug WARN strings now report only the measured `total_ms` + keepers count.
- `lib/server/server_dashboard_http_core.ml:313` drops the `sessions=%.1fs(%d)` fragment that was fed literal `0.0 0`. `dt_snapshot` (line 309) stays because it is actually measured.

Both sites created [fake instrumentation](https://en.wikipedia.org/wiki/Potemkin_village) that misdirected performance debugging — a slow 23 s render looked like "snapshot is instant, render is the bottleneck", but neither `snapshot_ms` nor `sessions_ms` was ever wired to a real timer. Removing the fake fields keeps the honest measurements visible.

Applies the `feedback_placeholder-over-fake-state` rule: if a field cannot be measured, it should not appear in the output.

Fixes #7682.

## Test plan

- [x] `dune build @check` — clean
- [x] `dune exec test/test_dashboard_execution.exe` — 12 tests pass
- [ ] CI green