### PR TITLE
docs(spec): drop room_strategy_get/set — purged with CP

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -169,7 +169,7 @@ Client Request
 
 | Family | Examples |
 |--------|----------|
-| Room & Cluster | set_room, init, join, leave, status, pause/resume, reset, room_strategy_get/set, room current helper |
+| Room & Cluster | set_room, init, join, leave, status, pause/resume, reset, room current helper |
 | Agent & Discovery | who, agents, heartbeat, agent_update, register_capabilities, find_by_capability, agent_fitness, select_agent |
 | Task Operations | add_task, batch_add_tasks, claim, claim_next, transition, done, release, cancel_task, tasks, archive_view, task_history |
 | Communication & Locks | broadcast, messages, listen, lock, unlock, progress |


### PR DESCRIPTION
## Summary

`rg "room_strategy" lib/ dashboard/` 결과 0 hit. SPEC.md의 "Room & Cluster" tool family 행이 마지막 non-illustrative 레퍼런스였음. 해당 툴군은 Command Plane purge (#7349) 과정에서 제거됨.

단일 docs 줄 수정.

## Gen1 Loop — `/loop 20m` 전체 진단 (참고용)

사용자가 대시보드에서 관찰한 4가지 증상을 추적한 결과:

### 1. `/api/v1/operator` 404 = **stale binary**

운영 중 서버의 `/health`:
```json
{ "version": "0.9.6", "build": { "commit": "b643d6adc", "started_at": "2026-04-16T14:46:59Z" } }
```

소스 HEAD: `37c6b2cb7` (0.9.7). Fix 커밋 `f0dec7ecf` ("restore /api/v1/operator HTTP routes lost in cp-purge", #7633) — 2026-04-17 01:02:55.

Running binary는 fix 이전 커밋(b643d6adc). 바이너리 파일(`main_eio.exe`)은 01:05에 재빌드되어 있으나 재시작 안 됨.

**즉시 조치**: 서버 재시작 (사용자 승인 필요 — running keepers 영향).

### 2. 룸 전략 기능 dead code = 이 PR이 처리

docs 2곳:
- `docs/SPEC.md:172` ← 제거 (factual claim)
- `docs/design/api-versioning-design.md:92` ← 보존 (deprecated 예시 illustration)

### 3. review_item 탭 count mismatch (Gen2 대상)

사용자 선언: "retired된 case tracking 대신 live judge 판단과 keeper HITL 승인만 표시". 즉 `review_item` 패널 자체 제거가 의도. 범위:

- Dashboard: `OperatorTargetType = 'review_item'` 제거, `components/ops/helpers.ts:370` review target builder 정리
- Backend: `lib/operator/operator_digest_review_types.ml` 제거 검토
- 보존: Live Judge + Keeper HITL 승인 패널

### 4. `/health`가 이미 drift 탐지 원재료 제공

`Build_identity` 모듈이 `release_version/commit/started_at/uptime_seconds` 노출. 대시보드가 이 정보를 소비하지 않음 = stale binary가 사용자에게만 보이고 시스템은 모름. Gen2/3 후보: 대시보드 header에 `build.commit` 표시 + CI 최신 HEAD 비교 경고.

## Test plan

- [x] `rg "room_strategy"` 전 레포 스캔 — 2 docs hit만 잔존 (이 PR 전)
- [x] PR 이후 `rg "room_strategy" lib/ dashboard/ test/` = 0 hit
- [x] `docs/design/api-versioning-design.md` deprecated-tool 예시는 의도적 보존 확인

## Non-goals (이 PR)

- `/api/v1/version` 신규 엔드포인트 — 기존 `/health`로 충분
- `/healthz` 별칭 — premature
- review_item 패널 제거 — Gen2 설계 후 별도 PR
- 바이너리 재시작 — 사용자 직접 판단