### PR TITLE
chore(docs/comments): retire "command plane" refs post-CP purge

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -151,7 +151,7 @@ describe('fetchKeeperConfig', () => {
         goal: 'Ship stable keeper ops',
         short_goal: 'Diagnose agent liveness',
         mid_goal: 'Reduce restart confusion',
-        long_goal: 'Keep command plane stable',
+        long_goal: 'Keep coordination stable',
         will: 'Stay on call',
         needs: 'Accurate runtime state',
         desires: 'Clear operator feedback',

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
       goal: 'Ship stable keeper ops',
       short_goal: 'Diagnose agent liveness',
       mid_goal: 'Reduce restart confusion',
-      long_goal: 'Keep command plane stable',
+      long_goal: 'Keep coordination stable',
       will: 'Stay on call',
       needs: 'Accurate runtime state',
       desires: 'Clear operator feedback',

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -187,7 +187,7 @@ let string_of_session_lifecycle = function
   | SL_unknown -> "unknown"
 
 (** Status/health classification predicates — single source of truth.
-    Used across dashboard, briefing, operator, command_plane modules. *)
+    Used across dashboard, briefing, and operator modules. *)
 
 let is_keeper_offline status =
   List.mem status [ "offline"; "inactive"; "error" ]

--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -441,7 +441,8 @@ let install ~config ~governance_level =
 
     When a tool exceeds the governance threshold, the agent fiber is
     suspended via [Keeper_approval_queue.submit_and_await] until an
-    operator resolves the approval via the command plane API.
+    operator resolves the approval via the dashboard approval HTTP
+    handler ([server_dashboard_http.ml]).
 
     Tools below the threshold are auto-approved. *)
 let to_oas_approval_callback

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -116,7 +116,8 @@ val to_oas_approval_callback :
 
     When a tool exceeds the governance threshold, the agent fiber
     suspends via [Keeper_approval_queue.submit_and_await]. An operator
-    resolves the approval via the command plane API, resuming the fiber.
+    resolves the approval via the dashboard approval HTTP handler
+    ([server_dashboard_http.ml]), resuming the fiber.
 
     Tools below the threshold are auto-approved.
 

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -2,8 +2,9 @@
 
     When a keeper's OAS Agent invokes a tool that requires approval,
     the agent fiber is suspended via [Eio.Promise.await].  An operator
-    can then approve/reject via the command plane API, which resolves
-    the promise and resumes the agent.
+    can then approve/reject via the dashboard approval HTTP handler
+    ([server_dashboard_http.ml]), which resolves the promise and
+    resumes the agent.
 
     This replaces the manual "pending_approval" state machine with
     actual execution-level suspension using Eio structured concurrency.
@@ -248,7 +249,8 @@ let submit_pending ~keeper_name ~tool_name ~input ~risk_level ~on_resolution
 (* ── Resolve (operator action) ────────────────────────────── *)
 
 (** Resolve a pending approval. Returns [Ok ()] if found, [Error msg] if not.
-    Called from the command plane HTTP handler. *)
+    Called from the dashboard approval HTTP handler
+    ([server_dashboard_http.ml]). *)
 let resolve ~id ~(decision : Oas.Hooks.approval_decision) : (unit, string) result =
   let result =
     Eio.Mutex.use_rw ~protect:true mu (fun () ->


### PR DESCRIPTION
## Summary

CP was purged in #7349, but **6 stale references** to "command plane API" / "command_plane modules" / "command plane stable" remained in OCaml docstrings and dashboard test fixtures. These claim a subsystem that no longer exists — a form of **context overstatement** (this week's cleanup theme, cf. #7684 fake-profiling fix).

## Changes

| File | Before | After |
|------|--------|-------|
| `lib/governance_pipeline.ml:444` | "via the command plane API" | "via the dashboard approval HTTP handler (server_dashboard_http.ml)" |
| `lib/governance_pipeline.mli:119` | same | same |
| `lib/keeper/keeper_approval_queue.ml:5` | same | same |
| `lib/keeper/keeper_approval_queue.ml:251` | "Called from the command plane HTTP handler" | "Called from the dashboard approval HTTP handler" |
| `lib/dashboard_utils/dashboard_utils.ml:190` | "dashboard, briefing, operator, command_plane modules" | "dashboard, briefing, and operator modules" |
| `dashboard/src/api/dashboard.test.ts:154` + `dashboard/src/components/keeper-config-panel.test.ts:14` | `long_goal: 'Keep command plane stable'` | `long_goal: 'Keep coordination stable'` |

The replacement name **"dashboard approval HTTP handler (server_dashboard_http.ml)"** corresponds to the **actual resolver** since #7349 — `Keeper_approval_queue.resolve` is called from `server_dashboard_http.ml:242` (grep-confirmed single caller after #7349).

## Verification

- `dune build @check --root .` — clean.
- `rg '\bcommand[_ ]plane\b' lib/ dashboard/` now matches only:
  - `server_h2_gateway.ml:655/694` — intentional `h2_respond_removed_surface ~surface:"command_plane"` (410 Gone handler).
  - `docs/spec/00-glossary.md` / `docs/spec/06-command-plane.md` — purge-history documentation.
- Test fixture: fixture value is pure input (nested in `prompt.long_goal`), not asserted on — `rg 'Keep command plane stable'` confirms only the two fixture sites had it.

## Not in scope (next generation)

- `docs/spec/SPEC-INDEX.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`, `docs/spec/01-system-overview.md`, `docs/design/external-agent-framework-patterns-rfc.md`, `docs/MDAL-LONG-TERM-PLAN-STATUS.md` still describe `command_plane` as present. Scope is larger and wording needs section-by-section decision.
- `docs/rfc/RFC-TOOL-SURFACE-SSOT.md` tier table mentions "command plane admin" — same bucket.

## Test plan

- [x] `dune build @check --root .` — clean
- [ ] CI: Dashboard / Build and Test / Lint green
- [ ] Fixture change doesn't affect test assertions (grep-confirmed)