### PR TITLE
feat(keeper): cap social_state narrative fields before persistence (Gen8)

### DIFF
--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -46,16 +46,20 @@ let state_of_social_state (state : Types.social_state) : state =
   }
 
 let to_social_state (state : state) (output : output) : Types.social_state =
-  {
-    social_model = state.social_model;
-    belief_summary = state.belief_summary;
-    active_desire = state.active_desire;
-    current_intention = state.current_intention;
-    blocker = state.blocker;
-    need = state.need;
-    speech_act = output.speech_act;
-    delivery_surface = output.delivery_surface;
-  }
+  (* Gen8: cap narrative fields so previous_state on the next turn does
+     not keep growing when speech_act=Stay_silent preserves state across
+     turns. See Types.cap_social_state doc. *)
+  Types.cap_social_state
+    {
+      social_model = state.social_model;
+      belief_summary = state.belief_summary;
+      active_desire = state.active_desire;
+      current_intention = state.current_intention;
+      blocker = state.blocker;
+      need = state.need;
+      speech_act = output.speech_act;
+      delivery_surface = output.delivery_surface;
+    }
 
 let belief_summary_of_observation
     (observation : Keeper_world_observation.world_observation) : string =

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -146,3 +146,44 @@ let transition_reason_to_string = function
   | Protocol_violation_no_tools_no_social_headers ->
       "protocol_violation:no_tool_calls_and_no_social_headers"
   | Failure_run_error -> "failure:run_error"
+
+(* Gen8 persistence-layer cap for social_state narrative fields.
+
+   Gen7 (#7676) capped keeper_state_snapshot before continuity_summary
+   rendering. The social_state record (belief_summary, active_desire,
+   current_intention, blocker, need) follows a parallel accumulation
+   path: BDI speech v1 carries these through previous_state into the
+   next turn's prompt. Without an explicit bound, a keeper repeating
+   "stay_silent" can still grow belief_summary monotonically because
+   speech_act=Stay_silent clears response_text but preserves state.
+
+   Same budget discipline as cap_snapshot (400 char primary, 200 char
+   option fields) kept as labeled-optional knobs so a cascade-level
+   policy can plug different budgets per speech model. *)
+let default_belief_summary_max_chars = 400
+let default_option_field_max_chars = 200
+
+let truncate_string ~max_chars s =
+  if String.length s <= max_chars then s
+  else String.sub s 0 max_chars ^ "…"
+
+let truncate_option ~max_chars = function
+  | None -> None
+  | Some s when String.length s <= max_chars -> Some s
+  | Some s -> Some (String.sub s 0 max_chars ^ "…")
+
+let cap_social_state
+    ?(belief_max_chars = default_belief_summary_max_chars)
+    ?(option_max_chars = default_option_field_max_chars)
+    (state : social_state) : social_state =
+  {
+    state with
+    belief_summary =
+      truncate_string ~max_chars:belief_max_chars state.belief_summary;
+    active_desire =
+      truncate_option ~max_chars:option_max_chars state.active_desire;
+    current_intention =
+      truncate_option ~max_chars:option_max_chars state.current_intention;
+    blocker = truncate_option ~max_chars:option_max_chars state.blocker;
+    need = truncate_option ~max_chars:option_max_chars state.need;
+  }

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -60,3 +60,15 @@ val is_known_social_model : string -> bool
 val fallback_social_model : string -> string option
 val normalize_social_model : string -> string
 val transition_reason_to_string : transition_reason -> string
+
+val default_belief_summary_max_chars : int
+val default_option_field_max_chars : int
+
+(** Bound the narrative fields of a [social_state] before it leaves the
+    speech model. Caps [belief_summary] and each option field with an
+    ellipsis marker when they exceed the budget. Other fields pass
+    through unchanged. Idempotent. *)
+val cap_social_state :
+  ?belief_max_chars:int ->
+  ?option_max_chars:int ->
+  social_state -> social_state

--- a/test/dune
+++ b/test/dune
@@ -719,6 +719,16 @@
  (name test_snapshot_size_cap)
  (libraries masc_test_deps))
 
+; Gen8 persistence-layer guard: cap_social_state bounds the BDI
+; speech v1 narrative fields (belief_summary, active_desire,
+; current_intention, blocker, need) carried across turns via
+; previous_state. Stays silent does not clear state, so without
+; this cap the narrative accumulates monotonically.
+(test
+ (name test_social_state_cap)
+ (modules test_social_state_cap)
+ (libraries masc_test_deps))
+
 ; Keeper_checkpoint_store.is_not_found_detail classifier
 ; regression (observed 334-retry loop on trace-1775487505102-6a347
 ; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)

--- a/test/test_social_state_cap.ml
+++ b/test/test_social_state_cap.ml
@@ -1,0 +1,104 @@
+(** Verify cap_social_state bounds narrative fields.
+
+    Gen8 persistence-layer guard parallel to Gen7 cap_snapshot. Gen7
+    (#7676) capped keeper_state_snapshot; this caps social_state so
+    previous_state carried across turns by BDI speech v1 cannot grow
+    monotonically when speech_act=Stay_silent preserves state. *)
+
+module T = Masc_mcp.Keeper_social_model_types
+
+let long n = String.make n 'x'
+
+let base : T.social_state =
+  {
+    social_model = "bdi_speech_v1";
+    belief_summary = "quiet_room";
+    active_desire = None;
+    current_intention = None;
+    blocker = None;
+    need = None;
+    speech_act = T.Stay_silent;
+    delivery_surface = T.Silent;
+  }
+
+let test_short_unchanged () =
+  let c = T.cap_social_state base in
+  Alcotest.(check string) "belief_summary unchanged" "quiet_room" c.belief_summary;
+  Alcotest.(check (option string)) "blocker stays None" None c.blocker
+
+let test_belief_capped () =
+  let s = { base with belief_summary = long 1000 } in
+  let c = T.cap_social_state ~belief_max_chars:100 s in
+  (* 100 ASCII chars + "…" (3 UTF-8 bytes). *)
+  Alcotest.(check bool) "belief near cap"
+    true (String.length c.belief_summary <= 103);
+  Alcotest.(check bool) "ellipsis appended"
+    true (String.length c.belief_summary > 100)
+
+let test_option_fields_capped () =
+  let s =
+    { base with
+      active_desire = Some (long 500);
+      current_intention = Some (long 500);
+      blocker = Some (long 500);
+      need = Some (long 500);
+    }
+  in
+  let c = T.cap_social_state ~option_max_chars:50 s in
+  let check_opt label = function
+    | Some v ->
+        Alcotest.(check bool)
+          (label ^ " near cap") true (String.length v <= 53)
+    | None -> Alcotest.fail (label ^ " should be Some")
+  in
+  check_opt "active_desire" c.active_desire;
+  check_opt "current_intention" c.current_intention;
+  check_opt "blocker" c.blocker;
+  check_opt "need" c.need
+
+let test_none_fields_stay_none () =
+  let s = { base with belief_summary = long 600 } in
+  let c = T.cap_social_state s in
+  Alcotest.(check (option string)) "active_desire stays None" None c.active_desire;
+  Alcotest.(check (option string)) "blocker stays None" None c.blocker
+
+let test_idempotent () =
+  let s =
+    { base with
+      belief_summary = long 1000;
+      blocker = Some (long 1000);
+    }
+  in
+  let c1 = T.cap_social_state s in
+  let c2 = T.cap_social_state c1 in
+  Alcotest.(check string) "belief idempotent" c1.belief_summary c2.belief_summary;
+  Alcotest.(check (option string)) "blocker idempotent" c1.blocker c2.blocker
+
+let test_speech_and_surface_pass_through () =
+  let s =
+    { base with
+      belief_summary = long 800;
+      speech_act = T.Request_help;
+      delivery_surface = T.Board_post;
+    }
+  in
+  let c = T.cap_social_state s in
+  Alcotest.(check string) "speech_act preserved"
+    "request_help" (T.speech_act_to_string c.speech_act);
+  Alcotest.(check string) "delivery_surface preserved"
+    "board_post" (T.delivery_surface_to_string c.delivery_surface)
+
+let () =
+  Alcotest.run "social_state_cap"
+    [ ( "cap_social_state",
+        [ Alcotest.test_case "short state unchanged" `Quick test_short_unchanged;
+          Alcotest.test_case "belief_summary capped" `Quick test_belief_capped;
+          Alcotest.test_case "option fields capped" `Quick
+            test_option_fields_capped;
+          Alcotest.test_case "None fields stay None" `Quick
+            test_none_fields_stay_none;
+          Alcotest.test_case "cap is idempotent" `Quick test_idempotent;
+          Alcotest.test_case "speech/surface pass through" `Quick
+            test_speech_and_surface_pass_through;
+        ] );
+    ]


### PR DESCRIPTION
## Gen8 of /loop-20m

Closes the BDI speech v1 persistence path that Gen3/Gen4/Gen7 did not cover.

### Observed shape

Keeper emits `speech_act=stay_silent` / `delivery_surface=silent`. `apply_output_to_result` clears `response_text` but returns the `social_state` record unchanged:

```ocaml
| Stay_silent, Silent when result.tools_used = [] ->
    ({ result with response_text = "" }, state)
```

The caller persists that state as `previous_state`, and the next turn's `transition` reads back the full `belief_summary` / `active_desire` / `current_intention` / `blocker` / `need` strings as context. With no bound, a keeper that repeats `stay_silent` across turns keeps accumulating narrative into these fields (BDI envelope length is not tied to speech surface visibility).

Empirical trigger: a keeper's BDI envelope carried multi-paragraph `BELIEF_SUMMARY` with "20가지 증명 완료" self-citation while `SPEECH_ACT: stay_silent` and `DELIVERY_SURFACE: silent`.

### Prior art on adjacent channels

- Gen3 (#7647) stripped backward-looking fields at prompt injection
- Gen4 (#7668) scrubbed `[STATE]` blocks in OAS compaction
- Gen7 (#7676) capped `keeper_state_snapshot` before `continuity_summary`

All three sit on the snapshot / prompt path. `social_state` is a parallel carrier — same bloat vector, different channel.

### Change

- `lib/keeper/social_model/keeper_social_model_types.ml{,.mli}` — add `cap_social_state` with the same 400 char / 200 char budget discipline as `cap_snapshot`. Labeled optional args so a cascade-level policy can plug different budgets per speech model.
- `lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml` — wrap `to_social_state` with `Types.cap_social_state` so every `social_state` leaving this model is bounded. Single choke point covers the normal path and `derive_failure_state`.
- `test/test_social_state_cap.ml` — 6 Alcotest cases.

### Test

```
test_social_state_cap           6 tests OK
test_snapshot_size_cap          6 tests OK (Gen7 regression)
test_continuity_forward_filter  4 tests OK (Gen3 regression)
test_keeper_summarizer          4 tests OK (Gen4 regression)
test_keeper_exec_status        19 tests OK
test_keeper_meta_listing        5 tests OK
test_keeper_runtime_config_ssot 15 tests OK
test_keeper_unified           164 tests OK
```

### FSM note

Transition logic untouched. Only the outgoing-state serializer is bounded — policy plug, not transition change. If a future speech model (e.g. `bdi_speech_v2`) needs a different budget, it can override via the labeled optional args without touching `to_social_state` or the transition graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)