### PR TITLE
chore(dashboard): purge dead review_queue/deferred_queue types

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -80,13 +80,6 @@ describe('Ops surface', () => {
       target_type: 'namespace',
       attention_items: [],
       recommended_actions: [],
-      review_queue: [],
-      deferred_queue: [],
-      review_summary: {
-        active_count: 0,
-        deferred_count: 1,
-        recent_count: 2,
-      },
       recent_reviews: [
         {
           item_id: 'review-newest',
@@ -171,24 +164,6 @@ describe('Ops surface', () => {
       target_type: 'namespace',
       attention_items: [],
       recommended_actions: [],
-      review_queue: [
-        {
-          id: 'review-1',
-          kind: 'room_gate',
-          target_type: 'namespace',
-          severity: 'warn',
-          urgency: 'soon',
-          summary: '방 제어 상태를 재확인하세요',
-          why_now: 'pause 이후 후속 확인이 필요합니다.',
-          fingerprint: 'fp-review-1',
-        },
-      ],
-      deferred_queue: [],
-      review_summary: {
-        active_count: 1,
-        deferred_count: 0,
-        recent_count: 0,
-      },
       recent_reviews: [],
       worker_cards: [],
     } as unknown as OperatorDigest
@@ -201,8 +176,9 @@ describe('Ops surface', () => {
     expect(container.textContent).toContain('FlowControlPanel')
     expect(container.textContent).toContain('최근 운영 활동')
 
-    // The placeholder-heavy review queue panel no longer exists regardless of
-    // review_queue contents. review items surface via Governance / Live Judge.
+    // The placeholder-heavy review queue panel no longer exists, and the
+    // review_queue/deferred_queue/review_summary fields were dropped from
+    // OperatorDigest. review items surface via Governance / Live Judge.
     expect(container.textContent).not.toContain('방 제어 상태를 재확인하세요')
     expect(container.textContent).not.toContain('마찰 요인')
     expect(container.textContent).not.toContain('운영 판단')

--- a/dashboard/src/operator-normalizers.test.ts
+++ b/dashboard/src/operator-normalizers.test.ts
@@ -14,8 +14,6 @@ describe('normalizeOperatorDigest', () => {
     expect(result.health).toBeUndefined()
     expect(result.attention_items).toEqual([])
     expect(result.recommended_actions).toEqual([])
-    expect(result.review_queue).toEqual([])
-    expect(result.deferred_queue).toEqual([])
     expect(result.recent_reviews).toEqual([])
     expect(result.worker_cards).toEqual([])
   })
@@ -129,28 +127,6 @@ describe('normalizeOperatorDigest', () => {
       operator_judge_runtime: 'invalid',
     })
     expect(result.operator_judge_runtime).toBeNull()
-  })
-
-  it('extracts review_summary', () => {
-    const result = normalizeOperatorDigest({
-      review_summary: {
-        active_count: 5,
-        deferred_count: 2,
-        recent_count: 10,
-      },
-    })
-    expect(result.review_summary).not.toBeNull()
-    expect(result.review_summary!.active_count).toBe(5)
-    expect(result.review_summary!.deferred_count).toBe(2)
-  })
-
-  it('defaults review_summary counts to 0', () => {
-    const result = normalizeOperatorDigest({
-      review_summary: {},
-    })
-    expect(result.review_summary).not.toBeNull()
-    expect(result.review_summary!.active_count).toBe(0)
-    expect(result.review_summary!.deferred_count).toBe(0)
   })
 
   it('extracts worker_cards', () => {

--- a/dashboard/src/operator-normalizers.ts
+++ b/dashboard/src/operator-normalizers.ts
@@ -15,8 +15,6 @@ import type {
   OperatorKeeperSnapshot,
   OperatorLinkedAutoresearch,
   OperatorReviewDecision,
-  OperatorReviewItem,
-  OperatorReviewSummary,
   OperatorRecommendedAction,
   OperatorJudgeRuntime,
   OperatorSessionSnapshot,
@@ -148,61 +146,6 @@ function normalizeReviewDecision(raw: unknown): OperatorReviewDecision | null {
   }
 }
 
-function normalizeReviewItem(raw: unknown): OperatorReviewItem | null {
-  if (!isRecord(raw)) return null
-  const id = asString(raw.id)
-  const kind = asString(raw.kind)
-  const targetType = asString(raw.target_type)
-  const severity = asString(raw.severity)
-  const urgency = asString(raw.urgency)
-  const summary = asString(raw.summary)
-  const whyNow = asString(raw.why_now)
-  const fingerprint = asString(raw.fingerprint)
-  if (!id || !kind || !targetType || !severity || !urgency || !summary || !whyNow || !fingerprint) return null
-  const adviceRaw = isRecord(raw.advice) ? raw.advice : null
-  const truthRefRaw = isRecord(raw.truth_ref) ? raw.truth_ref : null
-  return {
-    id,
-    kind,
-    target_type: targetType,
-    target_id: asString(raw.target_id) ?? null,
-    severity,
-    urgency,
-    summary,
-    why_now: whyNow,
-    source: asString(raw.source),
-    authoritative: asBoolean(raw.authoritative),
-    fingerprint,
-    stale_sec: asNumber(raw.stale_sec) ?? null,
-    confirm_required: asBoolean(raw.confirm_required),
-    recommended_action: normalizeRecommendedAction(raw.recommended_action),
-    truth_ref: truthRefRaw
-      ? {
-          target_type: asString(truthRefRaw.target_type) ?? null,
-          target_id: asString(truthRefRaw.target_id) ?? null,
-        }
-      : null,
-    friction: raw.friction,
-    advice: adviceRaw
-      ? {
-          active_summary: normalizeGuidanceSummary(adviceRaw.active_summary),
-          active_guidance_layer: asString(adviceRaw.active_guidance_layer) ?? null,
-          authoritative_judgment_available: asBoolean(adviceRaw.authoritative_judgment_available),
-        }
-      : null,
-  }
-}
-
-function normalizeReviewSummary(raw: unknown): OperatorReviewSummary | null {
-  if (!isRecord(raw)) return null
-  return {
-    active_count: asNumber(raw.active_count) ?? 0,
-    deferred_count: asNumber(raw.deferred_count) ?? 0,
-    recent_count: asNumber(raw.recent_count) ?? 0,
-    top_item: normalizeReviewItem(raw.top_item),
-  }
-}
-
 function normalizeOperatorJudgment(raw: unknown): OperatorJudgment | null {
   if (!isRecord(raw)) return null
   return {
@@ -309,13 +252,6 @@ export function normalizeOperatorDigest(raw: unknown): OperatorDigest {
     recommended_actions: extractArray(root.recommended_actions)
       .map(normalizeRecommendedAction)
       .filter((item): item is OperatorRecommendedAction => item !== null),
-    review_queue: extractArray(root.review_queue)
-      .map(normalizeReviewItem)
-      .filter((item): item is OperatorReviewItem => item !== null),
-    deferred_queue: extractArray(root.deferred_queue)
-      .map(normalizeReviewItem)
-      .filter((item): item is OperatorReviewItem => item !== null),
-    review_summary: normalizeReviewSummary(root.review_summary),
     recent_reviews: extractArray(root.recent_reviews)
       .map(normalizeReviewDecision)
       .filter((item): item is OperatorReviewDecision => item !== null),

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -501,37 +501,6 @@ export interface OperatorReviewDecision {
   recommended_action_type?: string | null
 }
 
-export interface OperatorReviewItem {
-  id: string
-  kind: 'pending_confirm' | 'namespace_gate' | 'room_gate' | 'session_risk' | 'keeper_pressure' | string
-  target_type: 'root' | 'namespace' | 'room' | 'keeper' | string
-  target_id?: string | null
-  severity: string
-  urgency: 'now' | 'soon' | string
-  summary: string
-  why_now: string
-  source?: string
-  authoritative?: boolean
-  fingerprint: string
-  stale_sec?: number | null
-  confirm_required?: boolean
-  recommended_action?: OperatorRecommendedAction | null
-  truth_ref?: { target_type?: string | null; target_id?: string | null } | null
-  friction?: unknown
-  advice?: {
-    active_summary?: OperatorGuidanceSummary | null
-    active_guidance_layer?: string | null
-    authoritative_judgment_available?: boolean
-  } | null
-}
-
-export interface OperatorReviewSummary {
-  active_count: number
-  deferred_count: number
-  recent_count: number
-  top_item?: OperatorReviewItem | null
-}
-
 export interface OperatorDigest {
   trace_id?: string
   target_type: 'root' | 'namespace' | 'room' | string
@@ -551,9 +520,6 @@ export interface OperatorDigest {
   root?: OperatorNamespaceSnapshot
   attention_items: OperatorAttentionItem[]
   recommended_actions: OperatorRecommendedAction[]
-  review_queue: OperatorReviewItem[]
-  deferred_queue: OperatorReviewItem[]
-  review_summary?: OperatorReviewSummary | null
   recent_reviews: OperatorReviewDecision[]
   worker_cards: OperatorWorkerCard[]
 }


### PR DESCRIPTION
## Summary

PR #7640 (b2670e4d9) dropped the Ops page review queue UI ('운영 행동' placeholder-heavy 3-column branch). The **backing data pipeline was left behind**:

| Surface | Status after #7640 | This PR |
|---|---|---|
| \`OperatorReviewItem\` interface | defined, never rendered | **deleted** |
| \`OperatorReviewSummary\` interface | defined, never rendered | **deleted** |
| \`normalizeReviewItem\` / \`normalizeReviewSummary\` | parse backend JSON, output never read | **deleted** |
| \`review_queue\` / \`deferred_queue\` / \`review_summary\` on \`OperatorDigest\` | populated, never read | **deleted** |
| \`OperatorReviewDecision\` / \`recent_reviews\` | actively rendered in activity timeline | **preserved** |
| \`'review_item'\` in \`OperatorTargetType\` | legacy label for historical records | **preserved** |

Pre-PR grep confirms zero non-test rendering consumers of the deleted surfaces. The backend (\`operator_digest.ml\`) still emits these JSON fields — they just no longer have typed/parsed landing in the dashboard. A Gen3 follow-up (backend purge) can remove emission; for now the extra fields are silently ignored.

## Findings (Gen2 loop context)

Found during /loop 20m Gen2, investigating user's observation of "즉시 검토 8 / 보류 0 / 최근 처리 12" tab with "이 탭에는 review item이 없습니다" empty body. Root cause:

1. **User observation = stale binary** (running 0.9.6 @ b643d6adc, before #7640 merge at 01:37)
2. **Dead pipeline**: backend still emits review_queue etc. but frontend UI already gone → zombie types/normalizers left in source

Restart resolves the user-visible symptom. This PR removes the source-level dead weight.

## Test plan

- [x] \`rg "review_queue|deferred_queue|review_summary|OperatorReviewItem|OperatorReviewSummary" dashboard/src/ --type ts\` → 0 non-comment hits after edit
- [x] \`pnpm vitest run src/operator-normalizers.test.ts src/components/ops/index.test.ts\` → 36/36 pass
- [x] No typecheck errors in edited files (pre-existing #7688 failures untouched and unrelated)
- [x] Net: -146 LOC / 4 files

## Non-goals

- Backend emission removal (\`lib/operator/operator_digest.ml\` 22 review_item refs, \`operator_digest_review_types.ml\`, etc.) → Gen3 follow-up
- \`OperatorReviewDecision\` / \`recent_reviews\` → actively used in activity timeline
- \`review_resolve\` / \`review_defer\` action types → historical action log entries still labeled
- \`'review_item'\` in \`OperatorTargetType\` → historical target labels still rendered

## Follow-up

Gen3 (backend): strip review_queue / deferred_queue / review_summary / review_item emission from operator_digest.ml. Heavier scope (~10 OCaml files + tests) — separate PR.