### PR TITLE
feat(dashboard): add tool name search to tool quality panel

### DIFF
--- a/dashboard/src/components/tool-quality-panel.test.ts
+++ b/dashboard/src/components/tool-quality-panel.test.ts
@@ -3,6 +3,7 @@ import { render } from 'preact'
 import { act } from 'preact/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ToolQualityResponse } from '../api/dashboard'
+import { filterTools, toolMatchesSearch } from './tool-quality-panel'
 
 vi.setConfig({
   testTimeout: 40000,
@@ -271,5 +272,87 @@ describe('ToolQualityPanel', () => {
     await flushUi()
 
     expect(container.textContent).toContain('request timeout (35s)')
+  })
+})
+
+describe('toolMatchesSearch', () => {
+  const tool = { name: 'keeper_task_claim' }
+
+  it('returns true for empty query (no filter)', () => {
+    expect(toolMatchesSearch(tool, '')).toBe(true)
+    expect(toolMatchesSearch(tool, '   ')).toBe(true)
+  })
+
+  it('matches substring in the middle of the name', () => {
+    expect(toolMatchesSearch(tool, 'task')).toBe(true)
+    expect(toolMatchesSearch(tool, 'r_t')).toBe(true)
+  })
+
+  it('matches prefix and suffix', () => {
+    expect(toolMatchesSearch(tool, 'keeper')).toBe(true)
+    expect(toolMatchesSearch(tool, 'claim')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(toolMatchesSearch(tool, 'TASK')).toBe(true)
+    expect(toolMatchesSearch(tool, 'Keeper')).toBe(true)
+    expect(toolMatchesSearch({ name: 'MASC_ToolName' }, 'toolname')).toBe(true)
+  })
+
+  it('ignores surrounding whitespace in the query', () => {
+    expect(toolMatchesSearch(tool, '  task  ')).toBe(true)
+  })
+
+  it('returns false for non-matching substring', () => {
+    expect(toolMatchesSearch(tool, 'xyz')).toBe(false)
+    expect(toolMatchesSearch(tool, 'cascade')).toBe(false)
+  })
+})
+
+describe('filterTools', () => {
+  const tools = [
+    { name: 'keeper_task_claim' },
+    { name: 'keeper_task_done' },
+    { name: 'masc_broadcast' },
+    { name: 'cascade_route' },
+    { name: 'read_file' },
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterTools(tools, '')).toBe(tools)
+    expect(filterTools(tools, '   ')).toBe(tools)
+  })
+
+  it('returns only tools whose name contains the query', () => {
+    const result = filterTools(tools, 'task')
+    expect(result.map(t => t.name)).toEqual([
+      'keeper_task_claim',
+      'keeper_task_done',
+    ])
+  })
+
+  it('is case-insensitive', () => {
+    const result = filterTools(tools, 'KEEPER')
+    expect(result).toHaveLength(2)
+    expect(result.every(t => t.name.includes('keeper'))).toBe(true)
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterTools(tools, 'zzz')).toEqual([])
+  })
+
+  it('does not mutate the source array', () => {
+    const snapshot = tools.map(t => t.name)
+    filterTools(tools, 'task')
+    expect(tools.map(t => t.name)).toEqual(snapshot)
+  })
+
+  it('preserves extra fields on the input objects', () => {
+    const rich = [
+      { name: 'alpha', calls: 10 },
+      { name: 'beta', calls: 20 },
+    ]
+    const result = filterTools(rich, 'alpha')
+    expect(result).toEqual([{ name: 'alpha', calls: 10 }])
   })
 })

--- a/dashboard/src/components/tool-quality-panel.ts
+++ b/dashboard/src/components/tool-quality-panel.ts
@@ -1,10 +1,11 @@
 import { html } from 'htm/preact'
-import { computed } from '@preact/signals'
+import { computed, signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { type ToolQualityResponse } from '../api/dashboard'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../config/constants'
 import { formatAutoRefreshLabel, setupVisibleAutoRefresh } from '../lib/auto-refresh'
 import { ErrorState, LoadingState } from './common/feedback-state'
+import { TextInput } from './common/input'
 import {
   cancelSharedToolQuality,
   refreshSharedToolQuality,
@@ -98,6 +99,23 @@ const successColor = computed(() => {
   return 'text-red-400'
 })
 
+// Per-tool search (case-insensitive substring on raw tool name).
+// Kept as a pure function so it can be tested in isolation and re-used if the
+// tool table later moves out of this panel.
+const toolSearchQuery = signal('')
+
+export function toolMatchesSearch(tool: Pick<ToolStat, 'name'>, query: string): boolean {
+  const q = query.trim().toLowerCase()
+  if (q === '') return true
+  return tool.name.toLowerCase().includes(q)
+}
+
+export function filterTools<T extends Pick<ToolStat, 'name'>>(tools: T[], query: string): T[] {
+  const q = query.trim().toLowerCase()
+  if (q === '') return tools
+  return tools.filter(t => t.name.toLowerCase().includes(q))
+}
+
 function RateGauge({ rate, label }: { rate: number; label: string }) {
   const color = rate >= 95 ? 'bg-emerald-500' : rate >= 90 ? 'bg-yellow-500' : 'bg-red-500'
   return html`
@@ -113,12 +131,27 @@ function RateGauge({ rate, label }: { rate: number; label: string }) {
   `
 }
 
-function ToolTable({ tools, highlightTool }: { tools: ToolStat[]; highlightTool?: string }) {
-  const top = tools.slice(0, 15)
+function ToolTable({
+  tools,
+  highlightTool,
+  query,
+}: {
+  tools: ToolStat[]
+  highlightTool?: string
+  query: string
+}) {
+  const filtered = filterTools(tools, query)
+  const top = filtered.slice(0, 15)
   const displayed = top
   if (highlightTool && !top.some(t => t.name === highlightTool)) {
-    const pinned = tools.find(t => t.name === highlightTool)
+    const pinned = filtered.find(t => t.name === highlightTool)
     if (pinned) displayed.unshift(pinned)
+  }
+  const hasQuery = query.trim() !== ''
+  if (hasQuery && filtered.length === 0) {
+    return html`
+      <div class="text-[11px] text-[var(--text-dim)] py-2">조건에 맞는 도구가 없습니다.</div>
+    `
   }
   return html`
     <div class="overflow-x-auto">
@@ -316,8 +349,23 @@ export function ToolQualityPanel() {
       </div>
 
       <div>
-        <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider mb-1">도구별 성공률</div>
-        <${ToolTable} tools=${d.by_tool} highlightTool=${route.value.params.tool} />
+        <div class="flex items-center justify-between mb-1 gap-2">
+          <div class="text-[10px] text-[var(--text-dim)] uppercase tracking-wider">도구별 성공률</div>
+          <${TextInput}
+            class="max-w-[180px]"
+            name="tool_quality_search"
+            ariaLabel="도구 이름 검색"
+            autoComplete="off"
+            placeholder="도구 이름 검색..."
+            value=${toolSearchQuery.value}
+            onInput=${(e: Event) => { toolSearchQuery.value = (e.target as HTMLInputElement).value }}
+          />
+        </div>
+        <${ToolTable}
+          tools=${d.by_tool}
+          highlightTool=${route.value.params.tool}
+          query=${toolSearchQuery.value}
+        />
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- Add a case-insensitive substring search input above the per-tool success-rate table in `ToolQualityPanel`.
- Filter runs **before** the top-15 slice, so operators can pin a long-tail tool into view by typing its name.
- Extract `toolMatchesSearch` and `filterTools` as pure functions; add 12 unit tests.

## Why
The `도구별 성공률` table slices to top-15 by volume. When a long-tail tool (e.g. a specific cascade route or keeper tool) regresses, the operator can't see its row without a different view. Adding search keeps the existing top-15 layout but gives an escape hatch for targeted inspection.

Follows the established panel-search rhythm: #7652 (verification specs), #7654 (prometheus), #7656 (cascade strategy trace).

## Changes
- `dashboard/src/components/tool-quality-panel.ts` (+54 / -6): search signal, `toolMatchesSearch` + `filterTools` pure exports, `TextInput` wiring, filtered empty state, `highlightTool` pin through filter.
- `dashboard/src/components/tool-quality-panel.test.ts` (+83): 12 new pure-function tests.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` — no new errors on touched files (pre-existing failures in `api/board.test.ts`, `execution/shared.test.ts`, `goal-helpers.test.ts`, `anomaly-utils.test.ts`, `tool-call-shared.test.ts` are orphan tests left over from #7669/#7675/#7677 dead-code purges, unrelated)
- [x] `pnpm test tool-quality-panel` — 19/19 pass (7 existing + 12 new)
- [ ] Manual: search "keeper" filters to keeper_* tools; empty query shows top-15 as before

## Notes / Follow-up
- Pre-existing: 5 orphan test files (`api/board.test.ts`, `execution/shared.test.ts`, `goals/goal-helpers.test.ts`, `observatory/anomaly-utils.test.ts`, `tool-call-shared.test.ts`) reference modules/exports removed by #7669/#7675/#7677. Separate cleanup PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)