### PR TITLE
feat(dashboard/governance): Live Judge empty state with judge status context

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -425,4 +425,75 @@ describe('Governance surface', () => {
     expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-1', 'approve')
     expect(fetchDashboardGovernance).toHaveBeenCalledTimes(2)
   }, 20000)
+
+  it('renders live judge empty state with offline message when retired + judge offline', async () => {
+    const retiredOffline: DashboardGovernanceResponse = {
+      generated_at: '2026-04-17T00:00:00Z',
+      case_tracking_available: false,
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0 },
+      items: [],
+      activity: [],
+      pending_actions: [],
+      judgments: [],
+      judge: { judge_online: false, keeper_name: 'governance-judge', model_used: 'qwen3.5:35b' },
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(retiredOffline),
+      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    const empty = container.querySelector('[data-testid="live-judge-empty"]')
+    expect(empty).toBeTruthy()
+    expect(empty?.textContent).toContain('AI Judge 오프라인')
+    // Keeper name + model chip rendered even when offline so the operator knows which runtime is failing.
+    expect(empty?.textContent).toContain('governance-judge')
+    expect(empty?.textContent).toContain('qwen3.5:35b')
+  }, 20000)
+
+  it('renders live judge empty state with idle message when retired + judge online but no judgments', async () => {
+    const retiredIdle: DashboardGovernanceResponse = {
+      generated_at: '2026-04-17T00:00:00Z',
+      case_tracking_available: false,
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0, judge_online: true },
+      items: [],
+      activity: [],
+      pending_actions: [],
+      judgments: [],
+      judge: {
+        judge_online: true,
+        keeper_name: 'governance-judge',
+        generated_at: '2026-04-17T00:00:00Z',
+      },
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(retiredIdle),
+      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    const empty = container.querySelector('[data-testid="live-judge-empty"]')
+    expect(empty).toBeTruthy()
+    expect(empty?.textContent).toContain('새 입력 대기')
+    expect(empty?.textContent).toContain('마지막 판단')
+    expect(empty?.textContent).not.toContain('오프라인')
+  }, 20000)
 })

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -393,11 +393,57 @@ function DecisionInbox() {
   `
 }
 
+export function judgmentsEmptyStateMessage(): { message: string; tone: 'warn' | 'default' } {
+  const judge = governanceData.value?.judge
+  const summary = governanceData.value?.summary
+  const lastError = judge?.last_error?.trim()
+  if (lastError) {
+    return { message: `AI Judge 오류: ${lastError}`, tone: 'warn' }
+  }
+  const judgeOnline = judge?.judge_online ?? summary?.judge_online
+  if (judgeOnline === false) {
+    return { message: 'AI Judge 오프라인 — keeper 기동 여부를 확인하세요.', tone: 'warn' }
+  }
+  const lastSeen = judge?.generated_at ?? summary?.judge_last_seen_at
+  if (lastSeen) {
+    return { message: '최근 판단 이후 새 입력 대기 중입니다. keeper가 새 판단을 올리면 여기 표시됩니다.', tone: 'default' }
+  }
+  return { message: 'AI Judge가 판단을 생성하면 자동으로 여기 표시됩니다. 현재 수집된 판단이 없습니다.', tone: 'default' }
+}
+
 function JudgmentsSection() {
   const judgments = governanceData.value?.judgments ?? []
-  if (judgments.length === 0) return null
+  const isRetired = governanceCaseTrackingRetired()
+  const title = isRetired ? 'AI Judge 판단 (live)' : 'AI Judge 판단'
+
+  if (judgments.length === 0) {
+    if (!isRetired) return null
+    const { message, tone } = judgmentsEmptyStateMessage()
+    const judge = governanceData.value?.judge
+    const lastSeen = judge?.generated_at ?? governanceData.value?.summary?.judge_last_seen_at
+    const meta = [judge?.keeper_name, judge?.model_used].filter((value): value is string => typeof value === 'string' && value.length > 0).join(' · ')
+    const chipClass = tone === 'warn'
+      ? 'border-warn/30 bg-warn/10 text-warn'
+      : 'border-[var(--card-border)] bg-[var(--white-3)] text-text-muted'
+    return html`
+      <div data-testid="live-judge-empty">
+        <${Card} title=${title} class="section mb-5" variant="compact">
+          <${EmptyState} message=${message} compact />
+          ${lastSeen || meta ? html`
+            <div class="mt-1 flex flex-wrap items-center justify-center gap-2 text-[11px] ${tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
+              ${lastSeen ? html`<span class="inline-flex items-center rounded-md border ${chipClass} px-2 py-0.5 font-medium">
+                마지막 판단 <${TimeAgo} timestamp=${lastSeen} />
+              </span>` : null}
+              ${meta ? html`<span class="font-mono opacity-75">${meta}</span>` : null}
+            </div>
+          ` : null}
+        <//>
+      </div>
+    `
+  }
+
   return html`
-    <${Card} title=${governanceCaseTrackingRetired() ? 'AI Judge 판단 (live)' : 'AI Judge 판단'} class="section mb-5" variant="compact">
+    <${Card} title=${title} class="section mb-5" variant="compact">
       <div class="flex flex-col gap-2.5">
         ${judgments.map(j => html`
           <div class="rounded-lg border border-card-border bg-card/34 p-3.5 text-[13px]" data-testid="judgment-item">


### PR DESCRIPTION
## Summary

When case tracking is retired (\`case_tracking_available === false\`) and no live judgments exist, \`JudgmentsSection()\` returned \`null\`, collapsing the governance page to only a thin "Live Judge" description bar + an empty Keeper HITL approval queue. User observed: "이거 더 잘 보이게 하시고".

This PR renders a contextual empty state in the retired path only (active case-tracking mode keeps the existing \`return null\` behavior for layout stability):

| Judge status signal | Rendered empty state |
|---|---|
| \`judge.last_error\` set | \`AI Judge 오류: <message>\` (warn tone) |
| \`judge.judge_online === false\` | \`AI Judge 오프라인 — keeper 기동 여부를 확인하세요\` (warn tone) |
| online + past \`generated_at\` | \`최근 판단 이후 새 입력 대기 중\` |
| cold start | \`AI Judge가 판단을 생성하면 자동으로 여기 표시됩니다\` |

Below the message: keeper_name · model_used · \`마지막 판단 <TimeAgo>\` chips surface the runtime identity so the operator can diagnose which judge is idle/failing.

## Gen3 loop context

Found during \`/loop 20m\` Gen3. Gen1 (#7686) traced the 404 observation to a stale binary. Gen2 (#7693) purged the orphan review_queue data pipeline. Gen3 turns to the "더 잘 보이게" half of the user's ask — the governance page body itself is empty-looking when retired mode has nothing live to show.

## Test plan

- [x] \`pnpm vitest run src/components/governance.test.ts\` → 9/9 pass (7 existing + 2 new)
- [x] Typecheck on touched files: no new errors (pre-existing #7688 failures untouched)
- [x] Offline test: DOM contains "AI Judge 오프라인" + keeper_name + model_used chips
- [x] Idle test: DOM contains "새 입력 대기" + "마지막 판단" timestamp chip
- [x] Active case-tracking path: behavior unchanged (empty judgments still hide)

## Non-goals

- Keeper HITL empty state enrichment (separate Gen3b or Gen4 candidate — current "현재 대시보드에서 처리할 keeper 승인 요청이 없습니다" stays for now)
- Backend \`GovernanceJudgeSummary\` wiring — already populated by server, just newly consumed
- Scroll-to-judgments shortcut from the Live Judge header (follow-up if helpful)

## Follow-up candidates

1. \`KeeperApprovalQueueSection\` empty state: surface recent-approved/rejected count in last N hours so "0건 대기" isn't the only signal
2. Dashboard commit display (Gen1 handoff): render \`/health\` build.commit in a header strip so stale binaries like the one that caused the original 404 are visible