### PR TITLE
fix(dashboard): implement missing exports for orphan test files

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -196,6 +196,28 @@ export function normalizeGovernanceTimelineEvent(raw: unknown): GovernanceTimeli
   }
 }
 
+export function normalizeGovernanceExecutionOrder(raw: unknown): {
+  id: string
+  case_id: string
+  status: string
+  risk_class?: string
+  created_at?: string
+  actor?: string
+} | null {
+  if (!isRecord(raw)) return null
+  const id = asNullableString(raw.id)
+  const case_id = asNullableString(raw.case_id)
+  if (!id || !case_id) return null
+  return {
+    id,
+    case_id,
+    status: asNullableString(raw.status) ?? 'blocked',
+    risk_class: asNullableString(raw.risk_class) ?? undefined,
+    created_at: asNullableString(raw.created_at) ?? undefined,
+    actor: asNullableString(raw.actor) ?? undefined,
+  }
+}
+
 export function normalizeGovernanceJudgeSummary(raw: unknown): GovernanceJudgeSummary | undefined {
   if (!isRecord(raw)) return undefined
   return {

--- a/dashboard/src/components/execution/shared.ts
+++ b/dashboard/src/components/execution/shared.ts
@@ -1,0 +1,76 @@
+// Execution panel shared pure functions
+
+import type { DashboardExecutionContinuityBrief } from '../../types'
+
+const TERMINAL_STATUSES = new Set(['completed', 'interrupted', 'failed', 'cancelled'])
+
+export function isTerminalStatus(status: string | null | undefined): boolean {
+  if (status == null) return false
+  return TERMINAL_STATUSES.has(status.trim().toLowerCase())
+}
+
+export function partitionByTerminal<T>(
+  items: T[],
+  getStatus: (item: T) => string | null | undefined,
+): [T[], T[]] {
+  const active: T[] = []
+  const terminal: T[] = []
+  for (const item of items) {
+    if (isTerminalStatus(getStatus(item))) {
+      terminal.push(item)
+    } else {
+      active.push(item)
+    }
+  }
+  return [active, terminal]
+}
+
+export function queueKindLabel(kind: string): string {
+  if (kind === 'session') return '세션'
+  if (kind === 'operation') return '작전'
+  return kind
+}
+
+export function keeperFromBrief(brief: DashboardExecutionContinuityBrief): {
+  name: string
+  agent_name: string
+  status: string
+  emoji: string
+} {
+  return {
+    name: brief.name,
+    agent_name: brief.agent_name?.trim() || brief.name,
+    status: brief.status ?? 'unknown',
+    emoji: brief.emoji ?? '',
+  }
+}
+
+export function agentStateLabel(state: string): string {
+  if (state === 'working') return '작업 중'
+  if (state === 'watching') return '대기 중'
+  if (state === 'quiet') return '조용함'
+  if (state === 'offline') return '오프라인'
+  return state
+}
+
+export function signalTruthLabel(truth: string | null | undefined): string {
+  if (truth == null) return 'signal 미상'
+  if (truth === 'live') return '최근 신호(≤5m)'
+  if (truth === 'stale') return '오래된 신호(>5m)'
+  if (truth === 'absent') return 'signal 없음'
+  return truth
+}
+
+export function evidenceSourceLabel(source: string | null | undefined): string {
+  if (source == null) return '근거 미상'
+  if (source === 'message') return '최근 출력'
+  if (source === 'presence') return 'presence/하트비트'
+  if (source === 'none') return '근거 없음'
+  return source
+}
+
+export function continuityStateLabel(state: string): string {
+  if (state === 'critical') return '위험'
+  if (state === 'warning') return '주의'
+  return '정상'
+}

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -18,6 +18,10 @@ export const statusFilter = signal<StatusFilter>('all')
 
 export const expandedTasks = signal<Set<string>>(new Set())
 
+export function formatMetric(value: number): string {
+  return value.toFixed(4)
+}
+
 export function toggleTaskExpand(id: string) {
   const next = new Set(expandedTasks.value)
   if (next.has(id)) next.delete(id)

--- a/dashboard/src/components/observatory/anomaly-utils.ts
+++ b/dashboard/src/components/observatory/anomaly-utils.ts
@@ -15,6 +15,20 @@ export interface AnomalyResult {
 
 const DEFAULT_THRESHOLD = 2.0
 
+export interface AnomalySummary {
+  count: number
+  worstDrop: AnomalyResult | null
+}
+
+export function anomalySummary(results: AnomalyResult[]): AnomalySummary {
+  const anomalies = results.filter(r => r.isAnomaly)
+  const drops = anomalies.filter(r => r.zScore < 0)
+  const worstDrop = drops.length > 0
+    ? drops.reduce((worst, cur) => cur.zScore < worst.zScore ? cur : worst)
+    : null
+  return { count: anomalies.length, worstDrop }
+}
+
 export function detectAnomalies(
   windowed: Array<{ point: ToolQualityHourlyPoint; ts: number }>,
   threshold: number = DEFAULT_THRESHOLD,

--- a/dashboard/src/components/tool-call-shared.ts
+++ b/dashboard/src/components/tool-call-shared.ts
@@ -121,3 +121,15 @@ export function prettyArgs(args: Record<string, unknown> | string): string {
   if (typeof args === 'string') return args
   try { return JSON.stringify(args, null, 2) } catch { return String(args) }
 }
+
+const RESULT_PREVIEW_MAX_CHARS = 80
+
+export function formatResult(
+  result: string | null,
+  error: string | null,
+  maxLen: number = RESULT_PREVIEW_MAX_CHARS,
+): string {
+  if (error) return `err: ${error}`
+  if (result == null) return '-'
+  return truncate(result, maxLen)
+}


### PR DESCRIPTION
## Summary
- Fix 5 CI-breaking TypeScript errors caused by test files referencing unimplemented exports
- Add `normalizeGovernanceExecutionOrder` to board.ts
- Create `execution/shared.ts` with 8 pure functions (isTerminalStatus, partitionByTerminal, queueKindLabel, keeperFromBrief, agentStateLabel, signalTruthLabel, evidenceSourceLabel, continuityStateLabel)
- Add `formatMetric` to goals/goal-helpers.ts
- Add `anomalySummary` to observatory/anomaly-utils.ts
- Add `formatResult` to tool-call-shared.ts

## Test plan
- [x] All 188 affected tests pass
- [x] TypeScript `--noEmit` clean (0 errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)