### PR TITLE
feat(dashboard/api): migrate autoresearch endpoints to valibot schemas

### DIFF
--- a/dashboard/src/api/autoresearch.ts
+++ b/dashboard/src/api/autoresearch.ts
@@ -1,68 +1,31 @@
 // MASC Dashboard — Autoresearch API client
 // Fetches loop list and detail from dedicated HTTP endpoints.
+//
+// Response shapes are defined by `src/api/schemas/autoresearch.ts` and
+// every response is validated through `v.parse` at the boundary.
+// Shape drift from the backend raises `AutoresearchSchemaDriftError`,
+// never `undefined` access downstream.
 
 import { get, post } from './core'
+import {
+  parseAutoresearchLoopActionResponse,
+  parseAutoresearchLoopDetail,
+  parseAutoresearchLoopsResponse,
+  type AutoresearchCycleRecord,
+  type AutoresearchLoopActionResponse,
+  type AutoresearchLoopDetail,
+  type AutoresearchLoopsResponse,
+  type AutoresearchLoopSummary,
+} from './schemas/autoresearch'
 
-export interface AutoresearchCycleRecord {
-  cycle: number
-  hypothesis: string
-  score_before: number
-  score_after: number
-  delta: number
-  decision: 'keep' | 'discard'
-  commit_hash: string | null
-  elapsed_ms: number
-  model_used: string
-  timestamp: number
+export type {
+  AutoresearchCycleRecord,
+  AutoresearchLoopActionResponse,
+  AutoresearchLoopDetail,
+  AutoresearchLoopsResponse,
+  AutoresearchLoopSummary,
 }
-
-export interface AutoresearchLoopSummary {
-  loop_id: string
-  goal: string
-  metric_fn: string
-  model_model: string
-  target_file: string
-  status: 'running' | 'completed' | 'stopped' | 'error'
-  current_cycle: number
-  max_cycles: number
-  baseline: number
-  best_score: number
-  best_cycle: number
-  total_keeps: number
-  total_discards: number
-  elapsed_s: number
-  updated_at: number | null
-  live: boolean
-  workdir: string
-  source_workdir: string
-  program_note: string | null
-  warnings: string[]
-  insights: string[]
-  recent_cycles: AutoresearchCycleRecord[]
-  error: string | null
-  session_id: string | null
-  operation_id: string | null
-  linked_at: number | null
-  queued_hypothesis: string | null
-}
-
-export interface AutoresearchLoopsResponse {
-  loops: AutoresearchLoopSummary[]
-  total: number
-}
-
-export interface AutoresearchLoopDetail extends AutoresearchLoopSummary {
-  history: AutoresearchCycleRecord[]
-  history_count: number
-}
-
-export interface AutoresearchLoopActionResponse {
-  ok: boolean
-  action?: 'retry' | 'delete' | 'start'
-  loop_id?: string
-  loop?: AutoresearchLoopSummary
-  error?: string
-}
+export { AutoresearchSchemaDriftError } from './schemas/autoresearch'
 
 export interface StartAutoresearchLoopParams {
   goal: string
@@ -77,27 +40,33 @@ export interface StartAutoresearchLoopParams {
   build_verify_fn?: string
 }
 
-export function fetchAutoresearchLoops(): Promise<AutoresearchLoopsResponse> {
-  return get('/api/v1/autoresearch/loops')
+export async function fetchAutoresearchLoops(): Promise<AutoresearchLoopsResponse> {
+  const raw = await get<unknown>('/api/v1/autoresearch/loops')
+  return parseAutoresearchLoopsResponse(raw)
 }
 
-export function fetchAutoresearchLoopDetail(
+export async function fetchAutoresearchLoopDetail(
   loopId: string,
   historyLimit = 100,
 ): Promise<AutoresearchLoopDetail> {
-  return get(`/api/v1/autoresearch/loops/${encodeURIComponent(loopId)}?history_limit=${historyLimit}`)
+  const url = `/api/v1/autoresearch/loops/${encodeURIComponent(loopId)}?history_limit=${historyLimit}`
+  const raw = await get<unknown>(url)
+  return parseAutoresearchLoopDetail(raw)
 }
 
-export function retryAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
-  return post('/api/v1/autoresearch/loops/retry', { loop_id: loopId })
+export async function retryAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
+  const raw = await post<unknown>('/api/v1/autoresearch/loops/retry', { loop_id: loopId })
+  return parseAutoresearchLoopActionResponse(raw)
 }
 
-export function deleteAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
-  return post('/api/v1/autoresearch/loops/delete', { loop_id: loopId })
+export async function deleteAutoresearchLoop(loopId: string): Promise<AutoresearchLoopActionResponse> {
+  const raw = await post<unknown>('/api/v1/autoresearch/loops/delete', { loop_id: loopId })
+  return parseAutoresearchLoopActionResponse(raw)
 }
 
-export function startAutoresearchLoop(
+export async function startAutoresearchLoop(
   params: StartAutoresearchLoopParams,
 ): Promise<AutoresearchLoopActionResponse> {
-  return post('/api/v1/autoresearch/loops/start', params)
+  const raw = await post<unknown>('/api/v1/autoresearch/loops/start', params)
+  return parseAutoresearchLoopActionResponse(raw)
 }

--- a/dashboard/src/api/schemas/autoresearch.test.ts
+++ b/dashboard/src/api/schemas/autoresearch.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AutoresearchSchemaDriftError,
+  parseAutoresearchLoopActionResponse,
+  parseAutoresearchLoopDetail,
+  parseAutoresearchLoopsResponse,
+} from './autoresearch'
+
+function validSummary(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    loop_id: 'loop-1',
+    goal: 'maximize coverage',
+    metric_fn: 'coverage.sh',
+    model_model: 'claude-opus-4-7',
+    target_file: 'lib/foo.ml',
+    status: 'running',
+    current_cycle: 3,
+    max_cycles: 20,
+    baseline: 0.5,
+    best_score: 0.82,
+    best_cycle: 2,
+    total_keeps: 2,
+    total_discards: 1,
+    elapsed_s: 135.4,
+    updated_at: 1_712_000_000,
+    live: true,
+    workdir: '/tmp/wd',
+    source_workdir: '/tmp/src',
+    program_note: null,
+    warnings: [],
+    insights: ['insight-1'],
+    recent_cycles: [],
+    error: null,
+    session_id: 'sess-1',
+    operation_id: null,
+    linked_at: null,
+    queued_hypothesis: null,
+    ...overrides,
+  }
+}
+
+describe('parseAutoresearchLoopsResponse', () => {
+  it('accepts a well-formed response with zero loops', () => {
+    const out = parseAutoresearchLoopsResponse({ loops: [], total: 0 })
+    expect(out.total).toBe(0)
+    expect(out.loops).toHaveLength(0)
+  })
+
+  it('accepts a populated list and infers summary types', () => {
+    const out = parseAutoresearchLoopsResponse({
+      loops: [validSummary(), validSummary({ loop_id: 'loop-2', status: 'completed' })],
+      total: 2,
+    })
+    expect(out.loops).toHaveLength(2)
+    expect(out.loops[1]!.status).toBe('completed')
+  })
+
+  it('falls back to status=error when backend ships an unknown lifecycle value', () => {
+    // Hard-rejection would brick the operator view during a backend-ahead
+    // deploy window; unknown values render as "error" instead.
+    const out = parseAutoresearchLoopsResponse({
+      loops: [validSummary({ status: 'defragmenting' })],
+      total: 1,
+    })
+    expect(out.loops[0]!.status).toBe('error')
+  })
+
+  it('throws AutoresearchSchemaDriftError when a required field is missing', () => {
+    const bad = { loops: [validSummary({ loop_id: undefined })], total: 1 }
+    expect(() => parseAutoresearchLoopsResponse(bad)).toThrow(AutoresearchSchemaDriftError)
+  })
+
+  it('throws when the response is a primitive', () => {
+    expect(() => parseAutoresearchLoopsResponse('not an object')).toThrow(
+      AutoresearchSchemaDriftError,
+    )
+  })
+})
+
+describe('parseAutoresearchLoopDetail', () => {
+  it('accepts detail payload with history', () => {
+    const detail = {
+      ...validSummary(),
+      history: [
+        {
+          cycle: 1,
+          hypothesis: 'try smaller batch',
+          score_before: 0.5,
+          score_after: 0.6,
+          delta: 0.1,
+          decision: 'keep',
+          commit_hash: 'abc123',
+          elapsed_ms: 4200,
+          model_used: 'claude-opus-4-7',
+          timestamp: 1_712_000_100,
+        },
+      ],
+      history_count: 1,
+    }
+    const out = parseAutoresearchLoopDetail(detail)
+    expect(out.history).toHaveLength(1)
+    expect(out.history[0]!.decision).toBe('keep')
+  })
+
+  it('throws when history is missing', () => {
+    expect(() => parseAutoresearchLoopDetail(validSummary())).toThrow(
+      AutoresearchSchemaDriftError,
+    )
+  })
+})
+
+describe('parseAutoresearchLoopActionResponse', () => {
+  it('accepts ok with action and loop_id', () => {
+    const out = parseAutoresearchLoopActionResponse({
+      ok: true,
+      action: 'retry',
+      loop_id: 'loop-1',
+    })
+    expect(out.ok).toBe(true)
+    expect(out.action).toBe('retry')
+  })
+
+  it('accepts a minimal response with just ok', () => {
+    const out = parseAutoresearchLoopActionResponse({ ok: false, error: 'no such loop' })
+    expect(out.ok).toBe(false)
+    expect(out.error).toBe('no such loop')
+  })
+
+  it('throws when the shape is not an object', () => {
+    expect(() => parseAutoresearchLoopActionResponse(null)).toThrow(
+      AutoresearchSchemaDriftError,
+    )
+  })
+})

--- a/dashboard/src/api/schemas/autoresearch.ts
+++ b/dashboard/src/api/schemas/autoresearch.ts
@@ -1,0 +1,165 @@
+/**
+ * Autoresearch API schemas — schema-at-boundary for
+ * `/api/v1/autoresearch/loops` and `/api/v1/autoresearch/loops/:id`.
+ *
+ * Contract (see dashboard/docs/API_CONTRACT.md):
+ * - TS types are derived via `InferOutput<typeof Schema>` — no hand-typed
+ *   interface for these endpoints.
+ * - `fetchAutoresearchLoops` / `fetchAutoresearchLoopDetail` pass raw
+ *   responses through `parseAutoresearchLoopsResponse` /
+ *   `parseAutoresearchLoopDetail`. Shape drift from the backend
+ *   (`autoresearch_serde.ml`) raises `AutoresearchSchemaDriftError`, not
+ *   `undefined` access downstream.
+ * - Action endpoints (`retry` / `delete` / `start`) accept partial
+ *   responses and parse through `parseAutoresearchLoopActionResponse`.
+ *
+ * Rolled out as part of #7441 (P2 rollout) following the pilot #7439.
+ */
+
+import {
+  array,
+  boolean,
+  fallback,
+  nullable,
+  number,
+  object,
+  optional,
+  picklist,
+  safeParse,
+  string,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+// Loop status evolves on the backend (new terminal states may ship
+// ahead of the dashboard). Unknown values fall back to `'error'` — the
+// safest visible state for an unrecognized lifecycle value (operators
+// see "something went wrong" rather than an empty or healthy badge).
+const AutoresearchLoopStatusSchema = fallback(
+  picklist(['running', 'completed', 'stopped', 'error']),
+  'error',
+)
+
+const AutoresearchCycleDecisionSchema = fallback(
+  picklist(['keep', 'discard']),
+  'discard',
+)
+
+export const AutoresearchCycleRecordSchema = object({
+  cycle: number(),
+  hypothesis: string(),
+  score_before: number(),
+  score_after: number(),
+  delta: number(),
+  decision: AutoresearchCycleDecisionSchema,
+  commit_hash: nullable(string()),
+  elapsed_ms: number(),
+  model_used: string(),
+  timestamp: number(),
+})
+
+export const AutoresearchLoopSummarySchema = object({
+  loop_id: string(),
+  goal: string(),
+  metric_fn: string(),
+  model_model: string(),
+  target_file: string(),
+  status: AutoresearchLoopStatusSchema,
+  current_cycle: number(),
+  max_cycles: number(),
+  baseline: number(),
+  best_score: number(),
+  best_cycle: number(),
+  total_keeps: number(),
+  total_discards: number(),
+  elapsed_s: number(),
+  updated_at: nullable(number()),
+  // The backend sometimes omits `live` on just-started loops; default
+  // to `false` rather than drifting into "is live" on an absent field.
+  live: fallback(boolean(), false),
+  workdir: string(),
+  source_workdir: string(),
+  program_note: nullable(string()),
+  warnings: array(string()),
+  insights: array(string()),
+  recent_cycles: array(AutoresearchCycleRecordSchema),
+  error: nullable(string()),
+  session_id: nullable(string()),
+  operation_id: nullable(string()),
+  linked_at: nullable(number()),
+  queued_hypothesis: nullable(string()),
+})
+
+export const AutoresearchLoopsResponseSchema = object({
+  loops: array(AutoresearchLoopSummarySchema),
+  total: number(),
+})
+
+export const AutoresearchLoopDetailSchema = object({
+  ...AutoresearchLoopSummarySchema.entries,
+  history: array(AutoresearchCycleRecordSchema),
+  history_count: number(),
+})
+
+// Action responses are heterogeneous (retry/delete/start each set a
+// different subset of fields). Every field past `ok` is optional on
+// purpose — the backend contract documents that.
+export const AutoresearchLoopActionResponseSchema = object({
+  ok: fallback(boolean(), false),
+  action: optional(picklist(['retry', 'delete', 'start'])),
+  loop_id: optional(string()),
+  loop: optional(AutoresearchLoopSummarySchema),
+  error: optional(string()),
+})
+
+export type AutoresearchCycleRecord = InferOutput<typeof AutoresearchCycleRecordSchema>
+export type AutoresearchLoopSummary = InferOutput<typeof AutoresearchLoopSummarySchema>
+export type AutoresearchLoopsResponse = InferOutput<typeof AutoresearchLoopsResponseSchema>
+export type AutoresearchLoopDetail = InferOutput<typeof AutoresearchLoopDetailSchema>
+export type AutoresearchLoopActionResponse = InferOutput<typeof AutoresearchLoopActionResponseSchema>
+
+export class AutoresearchSchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  constructor(endpoint: string, issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .slice(0, 3)
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`autoresearch schema drift at ${endpoint}: ${summary}`)
+    this.name = 'AutoresearchSchemaDriftError'
+    this.issues = issues
+  }
+}
+
+function parseOrThrow<TSchema extends Parameters<typeof safeParse>[0]>(
+  endpoint: string,
+  schema: TSchema,
+  data: unknown,
+): InferOutput<TSchema> {
+  const result = safeParse(schema, data)
+  if (!result.success) {
+    throw new AutoresearchSchemaDriftError(endpoint, result.issues)
+  }
+  return result.output as InferOutput<TSchema>
+}
+
+export function parseAutoresearchLoopsResponse(data: unknown): AutoresearchLoopsResponse {
+  return parseOrThrow('/api/v1/autoresearch/loops', AutoresearchLoopsResponseSchema, data)
+}
+
+export function parseAutoresearchLoopDetail(data: unknown): AutoresearchLoopDetail {
+  return parseOrThrow('/api/v1/autoresearch/loops/:id', AutoresearchLoopDetailSchema, data)
+}
+
+export function parseAutoresearchLoopActionResponse(
+  data: unknown,
+): AutoresearchLoopActionResponse {
+  return parseOrThrow(
+    '/api/v1/autoresearch/loops/:action',
+    AutoresearchLoopActionResponseSchema,
+    data,
+  )
+}


### PR DESCRIPTION
## Summary

Migrates the autoresearch surface to the schema-at-boundary pattern from pilot #7439, extending the #7441 P2 rollout.

- Adds \`src/api/schemas/autoresearch.ts\` — 5 valibot schemas, 5 \`InferOutput\` types, \`AutoresearchSchemaDriftError\`.
- Rewrites \`src/api/autoresearch.ts\` — hand-typed \`interface\` declarations replaced with schema re-exports; every fetch routes through \`v.parse\`.
- Adds \`src/api/schemas/autoresearch.test.ts\` — 10 tests covering valid payloads, unknown enum fallback, and drift rejection.

## Drift policy

\`status\`, \`decision\`, and \`live\` use \`v.fallback\` so unknown values render as a safe default (\`error\` / \`discard\` / \`false\`) rather than bricking the operator view during a backend-ahead deploy window. All other fields require exact shape; drift raises \`AutoresearchSchemaDriftError\`.

## Test plan

- [x] \`pnpm typecheck\` — no new errors on the touched files (pre-existing baseline errors are fixed by #7688)
- [x] \`pnpm vitest run src/api/schemas/autoresearch.test.ts\` — 10/10 pass
- [ ] CI green (gated on #7688)

## Dependencies

Depends on #7688 (main CI baseline fix for orphan tests from prior dead-code purges). CI on this branch will stay red until #7688 lands.

Part of #7441.