### PR TITLE
feat(keeper): cap narrative fields on checkpoint load too (Gen12, stacks on #7692)

### DIFF
--- a/lib/keeper/keeper_types.ml
+++ b/lib/keeper/keeper_types.ml
@@ -1127,14 +1127,25 @@ let parse_keeper_state
   let last_social_transition_reason =
     Safe_ops.json_string ~default:"" "last_social_transition_reason" json
   in
+  (* Gen12: cap narrative fields on load so pre-Gen8 checkpoints
+     (written before the write-side cap) cannot bleed unbounded
+     strings back into meta.runtime. Same budget as cap_social_state. *)
+  let cap_loaded =
+    Keeper_social_model_types.truncate_string
+      ~max_chars:Keeper_social_model_types.default_option_field_max_chars
+  in
   let last_active_desire =
-    Safe_ops.json_string ~default:"" "last_active_desire" json
+    cap_loaded (Safe_ops.json_string ~default:"" "last_active_desire" json)
   in
   let last_current_intention =
-    Safe_ops.json_string ~default:"" "last_current_intention" json
+    cap_loaded (Safe_ops.json_string ~default:"" "last_current_intention" json)
   in
-  let last_blocker = Safe_ops.json_string ~default:"" "last_blocker" json in
-  let last_need = Safe_ops.json_string ~default:"" "last_need" json in
+  let last_blocker =
+    cap_loaded (Safe_ops.json_string ~default:"" "last_blocker" json)
+  in
+  let last_need =
+    cap_loaded (Safe_ops.json_string ~default:"" "last_need" json)
+  in
   let ps_paused = Safe_ops.json_bool ~default:false "paused" json in
   let ps_autoboot_enabled =
     Safe_ops.json_bool ~default:true "autoboot_enabled" json

--- a/lib/keeper/social_model/keeper_social_model_types.mli
+++ b/lib/keeper/social_model/keeper_social_model_types.mli
@@ -64,6 +64,11 @@ val transition_reason_to_string : transition_reason -> string
 val default_belief_summary_max_chars : int
 val default_option_field_max_chars : int
 
+(** Truncate a string to [max_chars] characters; append "…" when the
+    limit bites. Shared by [cap_social_state] and the checkpoint load
+    path so both directions honour the same budget. Idempotent. *)
+val truncate_string : max_chars:int -> string -> string
+
 (** Bound the narrative fields of a [social_state] before it leaves the
     speech model. Caps [belief_summary] and each option field with an
     ellipsis marker when they exceed the budget. Other fields pass

--- a/test/dune
+++ b/test/dune
@@ -729,6 +729,14 @@
  (modules test_social_state_cap)
  (libraries masc_test_deps))
 
+; Gen12 load-path guard: checkpoint JSON deserialization also
+; truncates narrative fields so pre-Gen8 snapshots do not
+; reintroduce unbounded strings into meta.runtime.
+(test
+ (name test_social_state_cap_on_load)
+ (modules test_social_state_cap_on_load)
+ (libraries masc_test_deps))
+
 ; Keeper_checkpoint_store.is_not_found_detail classifier
 ; regression (observed 334-retry loop on trace-1775487505102-6a347
 ; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)

--- a/test/test_social_state_cap_on_load.ml
+++ b/test/test_social_state_cap_on_load.ml
@@ -1,0 +1,59 @@
+(** Gen12: verify [truncate_string] primitive used at checkpoint load.
+
+    Gen8 caps social_state at the write side (to_social_state). Gen12
+    reuses the same primitive in Keeper_types.parse_keeper_state so
+    pre-Gen8 checkpoints with unbounded [last_active_desire],
+    [last_current_intention], [last_blocker], [last_need] are trimmed
+    when loaded back into meta.runtime. This test locks the primitive
+    so the load path and write path cannot drift. *)
+
+module T = Masc_mcp.Keeper_social_model_types
+
+let long n = String.make n 'x'
+
+let test_truncate_long () =
+  let result = T.truncate_string ~max_chars:100 (long 1000) in
+  Alcotest.(check bool) "within budget + ellipsis"
+    true (String.length result <= 103);
+  Alcotest.(check bool) "grew beyond raw cap by ellipsis only"
+    true (String.length result > 100)
+
+let test_truncate_short_unchanged () =
+  let result = T.truncate_string ~max_chars:100 "ok" in
+  Alcotest.(check string) "short passes through" "ok" result
+
+let test_truncate_at_exact_boundary () =
+  let s = long 100 in
+  let result = T.truncate_string ~max_chars:100 s in
+  Alcotest.(check string) "exactly at cap passes through" s result
+
+let test_truncate_idempotent () =
+  let s = long 1000 in
+  let once = T.truncate_string ~max_chars:100 s in
+  let twice = T.truncate_string ~max_chars:100 once in
+  Alcotest.(check string) "second application is noop" once twice
+
+let test_truncate_matches_default_option_budget () =
+  (* Gen12 load path uses T.default_option_field_max_chars. If Gen8
+     defaults change, this test proves the primitive still behaves. *)
+  let cap = T.default_option_field_max_chars in
+  let s = long (cap * 10) in
+  let result = T.truncate_string ~max_chars:cap s in
+  Alcotest.(check bool) "load-path default budget honoured"
+    true (String.length result <= cap + 3)
+
+let () =
+  Alcotest.run "social_state_cap_on_load"
+    [ ( "truncate_string",
+        [ Alcotest.test_case "truncates long string with ellipsis" `Quick
+            test_truncate_long;
+          Alcotest.test_case "short string unchanged" `Quick
+            test_truncate_short_unchanged;
+          Alcotest.test_case "exact boundary unchanged" `Quick
+            test_truncate_at_exact_boundary;
+          Alcotest.test_case "truncation is idempotent" `Quick
+            test_truncate_idempotent;
+          Alcotest.test_case "matches Gen8 default option budget" `Quick
+            test_truncate_matches_default_option_budget;
+        ] );
+    ]


### PR DESCRIPTION
## Gen12 — stacked on #7692 (Gen8)

**Until #7692 merges**, this PR's diff will show both Gen8 commits and this Gen12 commit. After #7692 merges, GitHub will auto-recompute and show only the Gen12 delta (+87/-4).

### Observation

Gen8 caps `social_state` at the write side via `to_social_state`. But the runtime persistence surface is `meta.runtime.last_active_desire` / `last_current_intention` / `last_blocker` / `last_need`, loaded through `Keeper_types.parse_keeper_state`. A checkpoint written before Gen8 landed could still contain unbounded strings. Loading it bypasses the write-side cap and bleeds the legacy growth back into `meta.runtime` on the next turn.

### Change (Gen12 delta only)

| File | Diff |
| --- | --- |
| `lib/keeper/social_model/keeper_social_model_types.mli` | Expose `truncate_string` so the load path and the write path share a single primitive and cannot drift. |
| `lib/keeper/keeper_types.ml:parse_keeper_state` | Wrap each of the four `last_*` string loads with `truncate_string ~max_chars:default_option_field_max_chars`. |
| `test/test_social_state_cap_on_load.ml` | 5 Alcotest cases — long capped, short unchanged, exact boundary, idempotent, default-budget parity. |

### Verification

- `dune build @check` clean
- `test_social_state_cap_on_load` 5/5 pass
- `test_social_state_cap` (Gen8 regression) 6/6 pass

### Why separate from #7692

Gen8's scope is the write-side cap at the speech-model boundary. Load-side restoration is a different surface (checkpoint JSON → runtime record) and a different code path (`keeper_types.ml`, not `keeper_social_model_bdi_speech_v1.ml`). Splitting keeps the review unit small.

### FSM contract

Gen8 + Gen12 together make `meta.runtime.last_*` length a bounded invariant regardless of whether the value entered via a live turn or a disk checkpoint. Policy layer remains the single plug point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)