### PR TITLE
feat(dashboard/governance): Keeper HITL empty state with judge context

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -455,7 +455,6 @@ describe('Governance surface', () => {
     const empty = container.querySelector('[data-testid="live-judge-empty"]')
     expect(empty).toBeTruthy()
     expect(empty?.textContent).toContain('AI Judge 오프라인')
-    // Keeper name + model chip rendered even when offline so the operator knows which runtime is failing.
     expect(empty?.textContent).toContain('governance-judge')
     expect(empty?.textContent).toContain('qwen3.5:35b')
   }, 20000)
@@ -494,6 +493,80 @@ describe('Governance surface', () => {
     expect(empty).toBeTruthy()
     expect(empty?.textContent).toContain('새 입력 대기')
     expect(empty?.textContent).toContain('마지막 판단')
+    expect(empty?.textContent).not.toContain('오프라인')
+  }, 20000)
+
+  it('renders keeper HITL empty state with judge-offline context when queue is empty and judge is offline', async () => {
+    const hitlEmptyOffline: DashboardGovernanceResponse = {
+      generated_at: '2026-04-17T00:00:00Z',
+      case_tracking_available: false,
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0, judge_online: false },
+      items: [],
+      activity: [],
+      pending_actions: [],
+      judgments: [],
+      approval_queue: [],
+      judge: { judge_online: false, keeper_name: 'governance-judge', model_used: 'qwen3.5:35b' },
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(hitlEmptyOffline),
+      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    const empty = container.querySelector('[data-testid="keeper-hitl-empty"]')
+    expect(empty).toBeTruthy()
+    expect(empty?.textContent).toContain('AI Judge 오프라인')
+    expect(empty?.textContent).toContain('keeper 기동 여부')
+    expect(empty?.textContent).toContain('governance-judge')
+    expect(empty?.textContent).toContain('qwen3.5:35b')
+  }, 20000)
+
+  it('renders keeper HITL empty state with healthy-idle context when queue is empty and judge is active', async () => {
+    const hitlEmptyHealthy: DashboardGovernanceResponse = {
+      generated_at: '2026-04-17T00:00:00Z',
+      case_tracking_available: false,
+      summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0, judge_online: true },
+      items: [],
+      activity: [],
+      pending_actions: [],
+      judgments: [],
+      approval_queue: [],
+      judge: {
+        judge_online: true,
+        keeper_name: 'governance-judge',
+        generated_at: '2026-04-17T00:00:00Z',
+      },
+    }
+
+    const { Governance } = await loadComponentWithApi({
+      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
+      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(hitlEmptyHealthy),
+      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
+      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
+      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
+      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
+      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
+    })
+
+    render(html`<${Governance} />`, container)
+    await flushUi()
+
+    const empty = container.querySelector('[data-testid="keeper-hitl-empty"]')
+    expect(empty).toBeTruthy()
+    expect(empty?.textContent).toContain('위험도 threshold를 넘는 tool call이 없습니다')
+    expect(empty?.textContent).toContain('시스템이 정상 작동 중')
+    expect(empty?.textContent).toContain('마지막 judge 활동')
     expect(empty?.textContent).not.toContain('오프라인')
   }, 20000)
 })

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -549,6 +549,76 @@ function KeeperApprovalAlertBanner() {
   `
 }
 
+function KeeperApprovalEmptyState() {
+  const ctx = keeperHitlEmptyContext()
+  const judge = governanceData.value?.judge
+  const meta = [judge?.keeper_name, judge?.model_used]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join(' · ')
+  const chipClass = ctx.tone === 'warn'
+    ? 'border-warn/30 bg-warn/10 text-warn'
+    : ctx.tone === 'ok'
+      ? 'border-accent/20 bg-[var(--accent-10)] text-accent'
+      : 'border-white/10 bg-white/5 text-text-muted'
+  return html`
+    <div data-testid="keeper-hitl-empty">
+      <${EmptyState} message=${ctx.primary} compact />
+      ${ctx.secondary ? html`<div class="mt-0.5 text-center text-[11px] text-text-dim">${ctx.secondary}</div>` : null}
+      ${ctx.lastActivity || meta ? html`
+        <div class="mt-1.5 flex flex-wrap items-center justify-center gap-2 text-[11px] ${ctx.tone === 'warn' ? 'text-warn' : 'text-text-dim'}">
+          ${ctx.lastActivity ? html`<span class="inline-flex items-center rounded-md border ${chipClass} px-2 py-0.5 font-medium">
+            마지막 judge 활동 <${TimeAgo} timestamp=${ctx.lastActivity} />
+          </span>` : null}
+          ${meta ? html`<span class="font-mono opacity-75">${meta}</span>` : null}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
+export function keeperHitlEmptyContext(): {
+  primary: string
+  secondary: string | null
+  lastActivity: string | null
+  tone: 'ok' | 'warn' | 'default'
+} {
+  const judge = governanceData.value?.judge
+  const summary = governanceData.value?.summary
+  const lastError = judge?.last_error?.trim()
+  if (lastError) {
+    return {
+      primary: `AI Judge 오류로 HITL 평가가 멈춰 있을 수 있습니다: ${lastError}`,
+      secondary: '거부/승인 대기열은 judge가 복구된 뒤에 채워집니다.',
+      lastActivity: judge?.generated_at ?? summary?.judge_last_seen_at ?? null,
+      tone: 'warn',
+    }
+  }
+  const judgeOnline = judge?.judge_online ?? summary?.judge_online
+  if (judgeOnline === false) {
+    return {
+      primary: 'AI Judge 오프라인 — HITL 판정 생성이 중단되었습니다.',
+      secondary: 'keeper 기동 여부를 먼저 확인하세요.',
+      lastActivity: judge?.generated_at ?? summary?.judge_last_seen_at ?? null,
+      tone: 'warn',
+    }
+  }
+  const lastActivity = judge?.generated_at ?? summary?.judge_last_seen_at ?? null
+  if (lastActivity) {
+    return {
+      primary: '위험도 threshold를 넘는 tool call이 없습니다 — 시스템이 정상 작동 중입니다.',
+      secondary: '새 HITL 요청이 들어오면 여기에 자동 표시됩니다.',
+      lastActivity,
+      tone: 'ok',
+    }
+  }
+  return {
+    primary: '현재 대시보드에서 처리할 keeper 승인 요청이 없습니다.',
+    secondary: 'AI Judge가 HITL 평가를 시작하면 이 목록이 채워집니다.',
+    lastActivity: null,
+    tone: 'default',
+  }
+}
+
 function KeeperApprovalQueueSection() {
   const items = governanceData.value?.approval_queue ?? []
   const actingId = governanceApprovalActing.value
@@ -571,7 +641,7 @@ function KeeperApprovalQueueSection() {
         </span>
       </div>
       ${items.length === 0
-        ? html`<${EmptyState} message="현재 대시보드에서 처리할 keeper 승인 요청이 없습니다." compact />`
+        ? html`<${KeeperApprovalEmptyState} />`
         : html`
             <div class="flex flex-col gap-3.5" data-testid="governance-approval-queue">
               ${items.map(item => {


### PR DESCRIPTION
## Summary

Continuation of Gen3 (#7697). User's second "더 잘 보이게" ask targets the Keeper HITL approval queue, which previously rendered a single-line "현재 대시보드에서 처리할 keeper 승인 요청이 없습니다." with zero status signal.

This PR differentiates four states using the same `GovernanceJudgeSummary` signals Gen3 consumes, so both empty panels narrate the same judge health:

| Judge signal | Empty state |
|---|---|
| `judge.last_error` | `AI Judge 오류로 HITL 평가가 멈춰 있을 수 있습니다: <err>` (warn) |
| `judge_online === false` | `AI Judge 오프라인 — HITL 판정 생성이 중단되었습니다.` (warn) |
| online + past `generated_at` | `위험도 threshold를 넘는 tool call이 없습니다 — 시스템이 정상 작동 중입니다.` (ok) |
| cold start | `현재 대시보드에서 처리할 keeper 승인 요청이 없습니다.` (default, unchanged tone) |

Secondary sentence + keeper_name · model_used + `마지막 judge 활동 <TimeAgo>` chips surface which runtime is idle/failing.

## Gen4 loop context

`/loop 20m` Gen4. Prior gens: #7686 (merged — Gen1 room_strategy purge), #7693 (merged — Gen2 review_queue type purge), #7697 (Gen3 Live Judge empty state, still open).

## Implementation note

First attempt inlined the empty branch as an IIFE inside the html template literal. That timed out the pre-existing "renders and refreshes" test (>30s). Refactored to a proper `KeeperApprovalEmptyState` component. Pure predicate `keeperHitlEmptyContext()` is exported so future unit tests can target it without rendering.

## Test plan

- [x] `pnpm vitest run src/components/governance.test.ts` → 9/9 pass (7 existing + 2 new)
- [x] `pnpm typecheck` → 0 errors (post-#7688 main baseline)
- [x] "renders and refreshes" test confirmed passing with the helper-component refactor (regressed with IIFE)

## Follow-up candidates

1. Consume `activity[]` for "최근 처리" count in the empty state (count resolved approvals in last N hours). Deferred — needs activity event kind verification.
2. Link from empty state to RuntimeParamsPanel so operators can inspect the threshold setting when they see "시스템 정상" but want to tune it. Low priority until repeated UX feedback surfaces.
3. Backend `operator_digest.ml` review_item emission purge — Gen2 follow-up.
