### PR TITLE
feat(dashboard): type filter + search on keeper trajectory timeline

### DIFF
--- a/dashboard/src/components/keeper-trajectory-timeline.test.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  entryMatchesType,
+  entryMatchesSearch,
+  filterTrajectoryEntries,
+  countByType,
+  groupByTurn,
+} from './keeper-trajectory-timeline'
+import type { TrajectoryEntry } from '../api/dashboard'
+
+function makeToolEntry(overrides: Partial<TrajectoryEntry> = {}): TrajectoryEntry {
+  return {
+    ts: 1_700_000_000,
+    ts_iso: '2026-04-17T00:00:00Z',
+    turn: 1,
+    round: 1,
+    tool_name: 'bash',
+    args: { cmd: 'ls -la' },
+    duration_ms: 100,
+    ...overrides,
+  }
+}
+
+function makeThinkingEntry(overrides: Partial<TrajectoryEntry> = {}): TrajectoryEntry {
+  return {
+    type: 'thinking',
+    ts: 1_700_000_000,
+    ts_iso: '2026-04-17T00:00:00Z',
+    turn: 1,
+    content: 'thinking about the plan',
+    content_length: 22,
+    ...overrides,
+  }
+}
+
+describe('entryMatchesType', () => {
+  it('returns true for any entry when type=all', () => {
+    expect(entryMatchesType(makeToolEntry(), 'all')).toBe(true)
+    expect(entryMatchesType(makeThinkingEntry(), 'all')).toBe(true)
+  })
+
+  it('matches thinking entries with type=thinking', () => {
+    expect(entryMatchesType(makeThinkingEntry(), 'thinking')).toBe(true)
+    expect(entryMatchesType(makeToolEntry(), 'thinking')).toBe(false)
+  })
+
+  it('matches tool entries with type=tool (non-thinking)', () => {
+    expect(entryMatchesType(makeToolEntry(), 'tool')).toBe(true)
+    expect(entryMatchesType(makeThinkingEntry(), 'tool')).toBe(false)
+  })
+})
+
+describe('entryMatchesSearch', () => {
+  it('returns true for empty search string', () => {
+    expect(entryMatchesSearch(makeToolEntry(), '')).toBe(true)
+  })
+
+  it('matches tool_name case-insensitively', () => {
+    expect(entryMatchesSearch(makeToolEntry({ tool_name: 'BashExec' }), 'bashexec')).toBe(true)
+    expect(entryMatchesSearch(makeToolEntry({ tool_name: 'BashExec' }), 'exec')).toBe(true)
+    expect(entryMatchesSearch(makeToolEntry({ tool_name: 'BashExec' }), 'python')).toBe(false)
+  })
+
+  it('matches within args JSON payload', () => {
+    const entry = makeToolEntry({ args: { path: '/tmp/trace.log' } })
+    expect(entryMatchesSearch(entry, 'trace')).toBe(true)
+    expect(entryMatchesSearch(entry, '/tmp')).toBe(true)
+    expect(entryMatchesSearch(entry, 'missing')).toBe(false)
+  })
+
+  it('matches within string args', () => {
+    const entry = makeToolEntry({ args: 'echo hello world' })
+    expect(entryMatchesSearch(entry, 'hello')).toBe(true)
+    expect(entryMatchesSearch(entry, 'goodbye')).toBe(false)
+  })
+
+  it('matches thinking content', () => {
+    const entry = makeThinkingEntry({ content: 'should I retry the failed request?' })
+    expect(entryMatchesSearch(entry, 'retry')).toBe(true)
+    expect(entryMatchesSearch(entry, 'REQUEST')).toBe(true)
+    expect(entryMatchesSearch(entry, 'deploy')).toBe(false)
+  })
+
+  it('returns false when nothing in entry matches', () => {
+    const entry = makeToolEntry({ tool_name: undefined, args: undefined })
+    expect(entryMatchesSearch(entry, 'anything')).toBe(false)
+  })
+})
+
+describe('filterTrajectoryEntries', () => {
+  const entries: TrajectoryEntry[] = [
+    makeToolEntry({ turn: 1, tool_name: 'bash', args: { cmd: 'ls' } }),
+    makeToolEntry({ turn: 1, tool_name: 'read_file', args: { path: '/etc/hosts' } }),
+    makeThinkingEntry({ turn: 2, content: 'plan the next step' }),
+    makeToolEntry({ turn: 2, tool_name: 'grep', args: { pattern: 'TODO' } }),
+  ]
+
+  it('returns all entries when filter is neutral', () => {
+    expect(filterTrajectoryEntries(entries, { type: 'all', search: '' })).toHaveLength(4)
+  })
+
+  it('filters by type=tool', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'tool', search: '' })
+    expect(out).toHaveLength(3)
+    expect(out.every(e => e.type !== 'thinking')).toBe(true)
+  })
+
+  it('filters by type=thinking', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'thinking', search: '' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.type).toBe('thinking')
+  })
+
+  it('filters by search string across type', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'all', search: 'plan' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.type).toBe('thinking')
+  })
+
+  it('combines type and search filters', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'tool', search: 'etc' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.tool_name).toBe('read_file')
+  })
+
+  it('returns empty array when no entries match', () => {
+    expect(filterTrajectoryEntries(entries, { type: 'all', search: 'xyz-no-match' })).toEqual([])
+  })
+})
+
+describe('countByType', () => {
+  it('counts zero for empty input', () => {
+    expect(countByType([])).toEqual({ tool: 0, thinking: 0 })
+  })
+
+  it('counts tool vs thinking entries', () => {
+    const entries = [
+      makeToolEntry(),
+      makeToolEntry(),
+      makeThinkingEntry(),
+    ]
+    expect(countByType(entries)).toEqual({ tool: 2, thinking: 1 })
+  })
+
+  it('treats entries without type as tool', () => {
+    // Explicitly undefined type → classified as tool (non-thinking)
+    const entries = [makeToolEntry({ type: undefined })]
+    expect(countByType(entries)).toEqual({ tool: 1, thinking: 0 })
+  })
+})
+
+describe('groupByTurn', () => {
+  it('groups entries sharing a turn number', () => {
+    const entries = [
+      makeToolEntry({ turn: 1 }),
+      makeToolEntry({ turn: 1 }),
+      makeToolEntry({ turn: 2 }),
+    ]
+    const groups = groupByTurn(entries)
+    expect(groups.get(1)).toHaveLength(2)
+    expect(groups.get(2)).toHaveLength(1)
+  })
+
+  it('preserves insertion order within a turn', () => {
+    const a = makeToolEntry({ turn: 1, tool_name: 'first' })
+    const b = makeToolEntry({ turn: 1, tool_name: 'second' })
+    const groups = groupByTurn([a, b])
+    expect(groups.get(1)?.[0]?.tool_name).toBe('first')
+    expect(groups.get(1)?.[1]?.tool_name).toBe('second')
+  })
+
+  it('returns empty map for empty input', () => {
+    expect(groupByTurn([]).size).toBe(0)
+  })
+})

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -10,6 +10,8 @@ import type { TrajectoryEntry, TrajectoryResponse } from '../api/dashboard'
 import { truncate } from '../lib/truncate'
 import { TimeAgo } from './common/time-ago'
 import { toolCategory, durationColor, formatArgs, prettyArgs, formatDuration, summarizeEntries } from './tool-call-shared'
+import { FilterChips } from './common/filter-chips'
+import { TextInput } from './common/input'
 import { keeperHeartbeats } from '../store'
 import { isConnected } from '../sse'
 import { TRAJECTORY_HEARTBEAT_STALE_MS, LIVENESS_TICK_MS, CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN } from '../config/constants'
@@ -20,6 +22,63 @@ const STAT_PILL = 'text-[10px] py-0.5 px-2 rounded-full bg-[var(--white-4)] bord
 // ── Constants ────────────────────────────────────────────
 
 const TRAJECTORY_DEFAULT_LIMIT = 50
+
+// ── Filter state (per-keeper) ────────────────────────────
+
+export type TrajectoryTypeFilter = 'all' | 'tool' | 'thinking'
+
+type TrajectoryFilterState = {
+  type: TrajectoryTypeFilter
+  search: string
+}
+
+const trajectoryFilters = signal<Record<string, TrajectoryFilterState>>({})
+
+function getFilterState(name: string): TrajectoryFilterState {
+  return trajectoryFilters.value[name] ?? { type: 'all', search: '' }
+}
+
+function setFilterState(name: string, patch: Partial<TrajectoryFilterState>): void {
+  const prev = getFilterState(name)
+  trajectoryFilters.value = { ...trajectoryFilters.value, [name]: { ...prev, ...patch } }
+}
+
+// ── Pure filter (exported for tests) ─────────────────────
+
+export function entryMatchesType(entry: TrajectoryEntry, type: TrajectoryTypeFilter): boolean {
+  if (type === 'all') return true
+  if (type === 'thinking') return entry.type === 'thinking'
+  // 'tool' = anything that isn't a thinking block
+  return entry.type !== 'thinking'
+}
+
+export function entryMatchesSearch(entry: TrajectoryEntry, search: string): boolean {
+  if (!search) return true
+  const q = search.toLowerCase()
+  if (entry.tool_name && entry.tool_name.toLowerCase().includes(q)) return true
+  if (entry.content && entry.content.toLowerCase().includes(q)) return true
+  if (entry.args) {
+    const argsStr = typeof entry.args === 'string' ? entry.args : JSON.stringify(entry.args)
+    if (argsStr.toLowerCase().includes(q)) return true
+  }
+  return false
+}
+
+export function filterTrajectoryEntries(
+  entries: TrajectoryEntry[],
+  filter: TrajectoryFilterState,
+): TrajectoryEntry[] {
+  return entries.filter(e => entryMatchesType(e, filter.type) && entryMatchesSearch(e, filter.search))
+}
+
+export function countByType(entries: TrajectoryEntry[]): { tool: number; thinking: number } {
+  let tool = 0, thinking = 0
+  for (const e of entries) {
+    if (e.type === 'thinking') thinking += 1
+    else tool += 1
+  }
+  return { tool, thinking }
+}
 
 // ── State (per-keeper to avoid cross-keeper corruption) ──
 
@@ -243,7 +302,7 @@ function TrajectoryEmptyState({ keeper }: { keeper?: Keeper }) {
   `
 }
 
-function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]> {
+export function groupByTurn(entries: TrajectoryEntry[]): Map<number, TrajectoryEntry[]> {
   const groups = new Map<number, TrajectoryEntry[]>()
   for (const e of entries) {
     const existing = groups.get(e.turn)
@@ -290,13 +349,21 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
     return html`<${TrajectoryEmptyState} keeper=${keeper} />`
   }
 
+  const filter = getFilterState(keeperName)
+  const typeCounts = useMemo(() => countByType(data.entries), [data.entries])
+  const filteredEntries = useMemo(
+    () => filterTrajectoryEntries(data.entries, filter),
+    [data.entries, filter.type, filter.search],
+  )
+  const filterActive = filter.type !== 'all' || filter.search !== ''
+
   const { turns, allSummary, distinctTools } = useMemo(() => {
-    const groups = groupByTurn(data.entries)
+    const groups = groupByTurn(filteredEntries)
     const sorted = Array.from(groups.entries()).sort(([a], [b]) => b - a)
-    const summary = summarizeEntries(data.entries)
-    const distinct = new Set(data.entries.filter(e => e.tool_name).map(e => e.tool_name)).size
+    const summary = summarizeEntries(filteredEntries)
+    const distinct = new Set(filteredEntries.filter(e => e.tool_name).map(e => e.tool_name)).size
     return { turns: sorted, allSummary: summary, distinctTools: distinct }
-  }, [data.entries])
+  }, [filteredEntries])
   // Tick every LIVENESS_TICK_MS so isLive transitions from true→false
   // when heartbeat goes stale while the component is mounted.
   const now = useSignal(Date.now())
@@ -329,14 +396,40 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
             : null}
         </div>
         <span class="text-[10px] text-[var(--text-dim)]">
-          ${data.showing}/${data.total_entries} entries
+          ${filterActive
+            ? `${filteredEntries.length} / ${data.total_entries} entries`
+            : `${data.showing}/${data.total_entries} entries`}
         </span>
+      </div>
+
+      ${'' /* Filter bar — type chips + search */}
+      <div class="flex flex-wrap gap-2 items-center mb-2 px-1">
+        <${FilterChips}
+          chips=${[
+            { key: 'all' as TrajectoryTypeFilter, label: '전체', count: data.entries.length },
+            { key: 'tool' as TrajectoryTypeFilter, label: '도구', count: typeCounts.tool },
+            { key: 'thinking' as TrajectoryTypeFilter, label: '사고', count: typeCounts.thinking },
+          ]}
+          value=${filter.type}
+          onChange=${(k: TrajectoryTypeFilter) => setFilterState(keeperName, { type: k })}
+          size="sm"
+          tone="accent"
+        />
+        <${TextInput}
+          class="max-w-[200px]"
+          name="trajectory_search"
+          ariaLabel="도구/사고 내용 검색"
+          autoComplete="off"
+          placeholder="tool·args·content 검색..."
+          value=${filter.search}
+          onInput=${(e: Event) => setFilterState(keeperName, { search: (e.target as HTMLInputElement).value })}
+        />
       </div>
 
       ${'' /* Summary stats bar */}
       <div class="flex gap-3 flex-wrap mb-2 px-1">
         <span class="${STAT_PILL}">${turns.length} turns</span>
-        <span class="${STAT_PILL}">${data.entries.length} calls</span>
+        <span class="${STAT_PILL}">${filteredEntries.length} calls</span>
         <span class="${STAT_PILL}">${distinctTools} tools</span>
         <span class="${STAT_PILL} font-mono ${durationColor(allSummary.totalMs)}">${formatDuration(allSummary.totalMs)}</span>
         ${allSummary.errorCount > 0
@@ -353,6 +446,11 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
           <span class="text-[10px] text-[var(--text-dim)] font-mono">SSE</span>
         </div>
       ` : null}
+
+      ${'' /* Filtered empty state */}
+      ${filterActive && filteredEntries.length === 0
+        ? html`<div class="py-4 text-center text-xs text-[var(--text-muted)]">조건에 맞는 기록이 없습니다.</div>`
+        : null}
 
       ${'' /* Turn groups */}
       ${turns.map(([turnNum, entries]) => {


### PR DESCRIPTION
## Summary

Add type filter chips (all / tool / thinking) and a search input to the keeper trajectory timeline panel, following the pattern established by #7652 (verification-specs) and #7694 (tool-quality).

- Extract pure filter functions: \`entryMatchesType\`, \`entryMatchesSearch\`, \`filterTrajectoryEntries\`, \`countByType\`
- Export \`groupByTurn\` for testing
- Per-keeper filter state (signal map) so drawers remain independent
- Empty state when filter produces no matches
- Count pill in header reflects filtered/total when filter is active
- 21 unit tests cover every filter branch (type, search across tool_name/args/content, combined)

## Scope

- Dashboard-only, 2 files: \`src/components/keeper-trajectory-timeline.ts\` (+105/-7), new test file (+176).
- Zero OCaml, no API or type changes.

## Verification

- \`pnpm typecheck\`: clean (baseline on origin/main is also clean after #7688 orphan purge landed)
- \`pnpm lint\`: clean
- \`pnpm test keeper-trajectory-timeline.test.ts\`: 21/21 pass

## Test plan

- [ ] CI green on typecheck/lint/test jobs
- [ ] Visual: load keeper detail drawer, confirm chips render and filter entries live
- [ ] Search matches tool_name substring, args JSON payload, and thinking content

🤖 Generated with [Claude Code](https://claude.com/claude-code)