### PR TITLE
feat(dashboard/ops): stale-binary hint on operator 404/410 errors

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -184,4 +184,104 @@ describe('Ops surface', () => {
     expect(container.textContent).not.toContain('운영 판단')
     expect(container.textContent).not.toContain('매뉴얼 처리')
   }, 120000)
+
+  it('appends stale-binary hint when operatorErrorStatus is 404 (structured)', async () => {
+    const operatorStore = await import('../../operator-store')
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = 'GET /api/v1/operator: 404 Not Found'
+    operatorStore.operatorErrorStatus.value = 404
+    operatorDigestError.value = null
+    operatorStore.operatorDigestErrorStatus.value = null
+    operatorSnapshot.value = null as unknown as OperatorSnapshot
+    operatorRoomDigest.value = null as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const banner = container.querySelector('[data-testid="operator-error-banner"]')
+    expect(banner).toBeTruthy()
+    const hint = container.querySelector('[data-testid="operator-error-hint"]')
+    expect(hint).toBeTruthy()
+    expect(hint?.textContent).toContain('서버 바이너리')
+
+    operatorStore.operatorErrorStatus.value = null
+  }, 60000)
+
+  it('falls back to message regex when status is null (legacy string error)', async () => {
+    const operatorStore = await import('../../operator-store')
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = 'GET /api/v1/operator: 404 Not Found'
+    operatorStore.operatorErrorStatus.value = null
+    operatorDigestError.value = null
+    operatorStore.operatorDigestErrorStatus.value = null
+    operatorSnapshot.value = null as unknown as OperatorSnapshot
+    operatorRoomDigest.value = null as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const hint = container.querySelector('[data-testid="operator-error-hint"]')
+    expect(hint).toBeTruthy()
+    expect(hint?.textContent).toContain('서버 바이너리')
+  }, 60000)
+
+  it('does not show the stale-binary hint for non-route errors', async () => {
+    const operatorStore = await import('../../operator-store')
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorStore.operatorErrorStatus.value = null
+    operatorDigestError.value = 'GET /api/v1/operator/digest: 500 Internal Server Error'
+    operatorStore.operatorDigestErrorStatus.value = 500
+    operatorSnapshot.value = null as unknown as OperatorSnapshot
+    operatorRoomDigest.value = null as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const banner = container.querySelector('[data-testid="operator-error-banner"]')
+    expect(banner).toBeTruthy()
+    expect(banner?.textContent).toContain('500')
+    expect(container.querySelector('[data-testid="operator-error-hint"]')).toBeNull()
+
+    operatorStore.operatorDigestErrorStatus.value = null
+  }, 60000)
 })

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -8,7 +8,9 @@ import { route } from '../../router'
 import {
   operatorActionLog,
   operatorDigestError,
+  operatorDigestErrorStatus,
   operatorError,
+  operatorErrorStatus,
   operatorRoomDigest,
   operatorSnapshot,
 } from '../../operator-store'
@@ -28,6 +30,29 @@ import {
   workflowTargetReady,
 } from './helpers'
 import { FlowControlPanel } from '../flow-control/flow-control-panel'
+
+const OPERATOR_ROUTE_MISSING_PATTERN = /\b(?:404|410)\s+Not\s+Found\b/i
+const OPERATOR_ROUTE_MISSING_STATUSES = new Set<number>([404, 410])
+
+export function operatorErrorHint(message: string, status: number | null): string | null {
+  const routeMissing = status != null
+    ? OPERATOR_ROUTE_MISSING_STATUSES.has(status)
+    : OPERATOR_ROUTE_MISSING_PATTERN.test(message)
+  if (routeMissing) {
+    return '서버 바이너리가 최신 API 라우트를 포함하지 않을 수 있습니다. 우측 상단 빌드 배지에서 커밋을 확인하고 필요하면 서버를 재시작하세요.'
+  }
+  return null
+}
+
+function OperatorErrorBanner({ message, status }: { message: string; status: number | null }) {
+  const hint = operatorErrorHint(message, status)
+  return html`
+    <section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error" data-testid="operator-error-banner">
+      <div class="leading-relaxed">${message}</div>
+      ${hint ? html`<div class="mt-1.5 text-[12px] opacity-85" data-testid="operator-error-hint">${hint}</div>` : null}
+    </section>
+  `
+}
 
 type ActivityTone = 'default' | 'warn' | 'ok' | 'bad' | 'accent'
 
@@ -182,8 +207,8 @@ export function Ops() {
 
   return html`
     <section class="flex flex-col gap-4">
-      ${operatorError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorError.value}</section>` : null}
-      ${operatorDigestError.value ? html`<section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] error">${operatorDigestError.value}</section>` : null}
+      ${operatorError.value ? html`<${OperatorErrorBanner} message=${operatorError.value} status=${operatorErrorStatus.value} />` : null}
+      ${operatorDigestError.value ? html`<${OperatorErrorBanner} message=${operatorDigestError.value} status=${operatorDigestErrorStatus.value} />` : null}
 
       ${workflowContext ? html`
         <section class="ops-banner rounded-xl py-3 px-3.5 border border-[var(--card-border)] ${workflowReady ? 'info' : 'warn'} grid gap-2">

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -5,8 +5,10 @@ export {
   operatorRoomDigest,
   operatorLoading,
   operatorError,
+  operatorErrorStatus,
   operatorDigestLoading,
   operatorDigestError,
+  operatorDigestErrorStatus,
   operatorActionBusy,
   operatorActionLog,
 } from './operator-signals'


### PR DESCRIPTION
## Summary

Closes the original `/loop 20m` observation loop.

User's session-start report was: `GET /api/v1/operator: 404 Not Found` shown as a raw error banner on the "운영 행동" page. Root cause (Gen1 diagnosis): the running server binary predated PR #7633 which restored `/api/v1/operator` routes after the Command Plane purge. The only fix was a server restart — but the dashboard UI gave operators no path to this conclusion.

This PR adds a context hint that detects `404` in `operatorError` / `operatorDigestError` and appends:

> 서버 바이너리가 최신 API 라우트를 포함하지 않을 수 있습니다. 우측 상단 빌드 배지에서 커밋을 확인하고 필요하면 서버를 재시작하세요.

Which points operators directly at the existing `BuildIdentityBadge` (already rendering `v0.9.6 · b643d6adc` in the header). Non-404 errors keep the original banner unchanged.

## Implementation

- Extracted `OperatorErrorBanner` component in `ops/index.ts` (was inline `<section>`)
- Pure predicate `operatorErrorHint(message: string): string | null` — testable without rendering
- Detection: regex `/\b404\b/` + `/\b(?:404|410)\s+Not\s+Found|\bNot\s+Found\b/i` (permissive — also catches 410 Gone if upstream ever uses it)
- `data-testid="operator-error-banner"` + `data-testid="operator-error-hint"` for tests

## Gen5 loop context

`/loop 20m` Gen5. Closes the diagnosis→fix→prevent arc:
- Gen1 #7686 (merged): diagnosed 404 as stale binary + docs cleanup
- Gen2 #7693 (merged): purged orphan review_queue types
- Gen3 #7697 (open): Live Judge empty state
- Gen4 #7705 (open): Keeper HITL empty state
- Gen5 (this PR): dashboard teaches operators how to recognize the Gen1 class of failure next time

## Test plan

- [x] `pnpm vitest run src/components/ops/index.test.ts` → 4/4 pass (2 existing + 2 new)
- [x] `pnpm typecheck` → 0 errors
- [x] 404 case: hint rendered with "서버 바이너리" + "빌드 배지" text
- [x] 500 case: no hint rendered (precision check)

## Non-goals

- Version comparison against a source-of-truth remote HEAD (would require extra fetch; the hint without comparison is already actionable)
- Automated restart button (out of scope; requires privileged path)
- Changing the banner when operator routes are healthy (unchanged banner for non-404 errors)
