### PR TITLE
feat(observability): masc_keeper_invariant_violations_total counter (LT-13)

### DIFF
--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -147,4 +147,48 @@ This is the spec → code → dashboard → metric consistency contract.
 - #7643 — Strategy decision trace (ring buffer, JSON)
 - #7645 — `masc_cascade_capacity_events_total` counter
 - #7649 — `masc_cascade_strategy_decisions_total` counter
-- (this) — alerting rules + doc
+- #7679 — SLO card (in-process burn-rate computation)
+- (LT-13) — `masc_keeper_invariant_violations_total` counter + alerts
+
+---
+
+## `masc_keeper_invariant_violations_total` (LT-13)
+
+| Label       | Values                                                                             |
+| ----------- | ---------------------------------------------------------------------------------- |
+| `keeper`    | Keeper name (bounded by keepers registered on host, typically < 50)                |
+| `invariant` | `PhaseTurnAlignment`, `NoCascadeBeforeMeasurement`, `CompactionAtomicity`, `EventPriorityMonotone` |
+
+Incremented from `Keeper_composite_observer.bump_invariant_violations`, invoked by `observe` on every snapshot. One counter tick **per violated invariant per snapshot**. A sustained rate means the FSM composition is wedged in an inconsistent cross-axis state.
+
+Label cardinality: `keepers × 4` (≤ 200 series in practice).
+
+### PromQL patterns
+
+```promql
+# Fleet-wide violation burst (5-minute window)
+sum by (invariant) (increase(masc_keeper_invariant_violations_total[5m]))
+
+# Which keeper is offending for a specific invariant
+topk(5, rate(masc_keeper_invariant_violations_total
+              {invariant="PhaseTurnAlignment"}[5m]))
+
+# Invariant health SLO (what fraction of snapshots satisfy all 4?)
+# Requires pairing with a snapshots_total counter in a follow-up; out of
+# scope for LT-13.
+```
+
+### Spec↔code↔counter contract
+
+Any renaming of the invariant constants must land in all **6 places** in the same PR — see `docs/observability/fsm-spec-code-drift.md` §4. Specifically:
+
+1. TLA+ invariant predicate in `specs/keeper-state-machine/KeeperCompositeLifecycle.tla`.
+2. OCaml `invariant_key` variant in `keeper_composite_observer.mli`.
+3. `invariant_key_to_string` (the Prometheus label source).
+4. `invariants_check` record field name (the OCaml result).
+5. Alert rule in `infrastructure/monitoring/cascade-alerts.yml`.
+6. Grafana panel (landing in LT-13b — follow-up).
+
+### Why one tick per snapshot instead of edge-triggered?
+
+A violated invariant that *persists* across multiple snapshots is a stronger signal than one that flips once — `rate()`/`increase()` reflect the persistence directly. Edge-triggering would require a prior-state cache on the observer, which conflicts with the observer's pure-projection contract (`keeper_composite_observer.mli:1-20`).

--- a/infrastructure/monitoring/cascade-alerts.yml
+++ b/infrastructure/monitoring/cascade-alerts.yml
@@ -10,6 +10,12 @@
 #       kind ∈ {ordered, filtered_empty, exhausted}
 #       See lib/cascade/cascade_strategy_trace.ml
 #
+#   - masc_keeper_invariant_violations_total{keeper, invariant}
+#       invariant ∈ {PhaseTurnAlignment, NoCascadeBeforeMeasurement,
+#                    CompactionAtomicity, EventPriorityMonotone}
+#       See lib/keeper/keeper_composite_observer.ml
+#       Spec:  specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+#
 # Thresholds below are conservative starting points; tune per deployment.
 # Rate windows use 5m so a single transient event does not page; duration
 # guards (for:) require the condition to persist across two 5m windows.
@@ -130,3 +136,48 @@ groups:
             Cross-check /api/v1/cascade/client_capacity for the current
             snapshot — if that has entries but no events, the history
             ring buffer wiring regressed.
+
+  # Keeper composite lifecycle invariants (LT-13). Each counter tick is a
+  # per-snapshot violation of a KeeperCompositeLifecycle.tla safety
+  # property. Thresholds are conservative: any sustained violation pages.
+  - name: masc_keeper_composite_invariants
+    interval: 30s
+    rules:
+      - alert: KeeperCompositeInvariantViolationBurst
+        expr: |
+          sum by (invariant) (
+            increase(masc_keeper_invariant_violations_total[5m])
+          ) > 10
+        for: 10m
+        labels:
+          severity: warning
+          component: keeper
+          subsystem: composite_lifecycle
+        annotations:
+          summary: "Composite invariant {{ $labels.invariant }} violated > 10x/5m"
+          description: |
+            KeeperCompositeLifecycle.tla safety property {{ $labels.invariant }}
+            is failing at more than 10 snapshots per 5 minutes fleet-wide.
+            This signals a cross-axis FSM inconsistency (phase disagrees
+            with turn, cascade starts without measurement, compaction
+            straddles turn boundaries, or event priority ordering broke).
+            Cross-check /api/v1/keepers/<name>/composite to identify the
+            offending keeper; attach the raw snapshot to any follow-up.
+
+      - alert: KeeperCompositeInvariantSingleKeeperStuck
+        expr: |
+          rate(masc_keeper_invariant_violations_total[5m]) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+          component: keeper
+          subsystem: composite_lifecycle
+        annotations:
+          summary: "Keeper {{ $labels.keeper }} stuck violating {{ $labels.invariant }}"
+          description: |
+            A single keeper has been violating {{ $labels.invariant }} at
+            > 0.1 samples/s for 15 minutes. Indicates a wedged FSM
+            composition on that keeper specifically — consider issuing
+            a supervised restart after capturing the snapshot for
+            post-mortem. Spec reference:
+            specs/keeper-state-machine/KeeperCompositeLifecycle.tla

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -336,6 +336,26 @@ let compute_invariants
     event_priority_monotone = check_event_priority_monotone entry;
   }
 
+(* Prometheus bump — one counter tick per violated invariant per snapshot.
+   Called from [observe]. PromQL rate/increase distinguishes transient
+   from steady-state violations. Labels bounded: keeper × invariant (4)
+   ≤ ~200 series on a 50-keeper host. Mirrors the naming pattern in
+   [Cascade_strategy_trace.bump_prometheus_counter]. *)
+let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
+  let bump key satisfied =
+    if not satisfied then
+      Prometheus.inc_counter "masc_keeper_invariant_violations_total"
+        ~labels:[
+          ("keeper", keeper_name);
+          ("invariant", invariant_key_to_string key);
+        ]
+        ()
+  in
+  bump Invariant_phase_turn_alignment inv.phase_turn_alignment;
+  bump Invariant_no_cascade_before_measurement inv.no_cascade_before_measurement;
+  bump Invariant_compaction_atomicity inv.compaction_atomicity;
+  bump Invariant_event_priority_monotone inv.event_priority_monotone
+
 (* Public API *)
 
 let stable_correlation_id (entry : Keeper_registry.registry_entry) : string =
@@ -381,6 +401,7 @@ let observe
       ~compaction_stage
       ~measurement_captured
   in
+  bump_invariant_violations ~keeper_name:entry.name invariants;
   {
     correlation_id;
     run_id;

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -111,6 +111,13 @@ type invariants_check = {
   event_priority_monotone : bool;
 }
 
+(** Increment [masc_keeper_invariant_violations_total\{keeper, invariant\}]
+    once per violated invariant. No-op when all invariants hold. Called
+    automatically from [observe]; exposed so unit tests can assert the
+    counter bump without going through the full snapshot pipeline. *)
+val bump_invariant_violations :
+  keeper_name:string -> invariants_check -> unit
+
 (** Frozen outcome of the most recently completed turn (RFC-0003
     Phase 2). Surfaces terminal data ([Done]/[Guard_ok]/...) without
     polluting the live sub-FSM fields. [None] until the first turn


### PR DESCRIPTION
## Summary

Wire the 4 joint safety invariants from \`KeeperCompositeLifecycle.tla\` to a Prometheus counter so the dashboard and alerting stack can see cross-axis FSM inconsistencies in real time.

Follows LT-12 (#7689) and LT-15 (#7703). Feeds LT-16 matrix overlay.

## What's in this PR

- \`Keeper_composite_observer.bump_invariant_violations\` — pure side-effect, called from \`observe\` after \`compute_invariants\`. One counter tick per violated invariant per snapshot.
- Alert rules: \`KeeperCompositeInvariantViolationBurst\` (fleet) and \`KeeperCompositeInvariantSingleKeeperStuck\` (per-keeper).
- \`docs/observability/cascade-metrics.md\` — new counter section with PromQL patterns and the 6-place spec↔code↔counter edit contract.

## Counter shape

\`masc_keeper_invariant_violations_total{keeper, invariant}\`

| Label     | Values |
|-----------|--------|
| keeper    | keeper name (≤ ~50 in practice) |
| invariant | \`PhaseTurnAlignment\`, \`NoCascadeBeforeMeasurement\`, \`CompactionAtomicity\`, \`EventPriorityMonotone\` |

Label cardinality ≤ 200 series.

## Explicitly out of scope

- **Grafana panel** — LT-13b, next tick.
- **Unit test** — LT-13c, next tick. Uses the existing Prometheus registry to assert the bump without going through the full snapshot pipeline (via the new \`bump_invariant_violations\` export).

## Why poll-triggered instead of edge-triggered?

A persisted violation is a stronger signal than a one-off flip; \`rate()\`/\`increase()\` reflect persistence directly. Edge-triggering would require a prior-state cache on the observer and conflict with its pure-projection contract.

## Test plan

- [x] \`dune build --root .\` — passes.
- [ ] CI \`dune runtest\` — pending.
- [ ] promtool check rules infrastructure/monitoring/cascade-alerts.yml — CI-side.
- [ ] Smoke — boot server, trigger a deliberate invariant violation, verify \`/metrics\` surfaces \`masc_keeper_invariant_violations_total\` with the offending label tuple.

## References

- \`specs/keeper-state-machine/KeeperCompositeLifecycle.tla\` — SSOT for the invariant set.
- \`lib/keeper/keeper_composite_observer.ml\` — the pure projection being extended.
- \`docs/observability/composite-fsm-matrix-design.md\` (LT-12) — surface plan.
- \`docs/observability/fsm-spec-code-drift.md\` (LT-15) — 6-place edit contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)