### PR TITLE
feat(dashboard/api): migrate link-previews endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/link-previews.ts
+++ b/dashboard/src/api/link-previews.ts
@@ -1,21 +1,12 @@
 import { post } from './core'
-import { isRecord, asString } from '../components/common/normalize'
+import { isRecord } from '../components/common/normalize'
+import {
+  safeParseLinkPreview,
+  type LinkPreview,
+  type LinkPreviewKind,
+} from './schemas/link-previews'
 
-export type LinkPreviewKind = 'link' | 'image'
-
-export interface LinkPreview {
-  url: string
-  kind: LinkPreviewKind
-  canonical_url?: string | null
-  title?: string | null
-  description?: string | null
-  site_name?: string | null
-  image_url?: string | null
-  favicon_url?: string | null
-  content_type?: string | null
-  fetched_at?: string | null
-  cache_state?: string | null
-}
+export type { LinkPreview, LinkPreviewKind }
 
 interface LinkPreviewResponse {
   previews?: Record<string, unknown>
@@ -30,26 +21,6 @@ interface CacheEntry {
 const LOCAL_PREVIEW_TTL_MS = 15 * 60 * 1000
 const LOCAL_ERROR_TTL_MS = 5 * 60 * 1000
 const previewCache = new Map<string, CacheEntry>()
-
-function normalizeLinkPreview(raw: unknown): LinkPreview | null {
-  if (!isRecord(raw)) return null
-  const url = asString(raw.url)
-  const kind = asString(raw.kind)
-  if (!url || (kind !== 'link' && kind !== 'image')) return null
-  return {
-    url,
-    kind,
-    canonical_url: asString(raw.canonical_url) ?? null,
-    title: asString(raw.title) ?? null,
-    description: asString(raw.description) ?? null,
-    site_name: asString(raw.site_name) ?? null,
-    image_url: asString(raw.image_url) ?? null,
-    favicon_url: asString(raw.favicon_url) ?? null,
-    content_type: asString(raw.content_type) ?? null,
-    fetched_at: asString(raw.fetched_at) ?? null,
-    cache_state: asString(raw.cache_state) ?? null,
-  }
-}
 
 function shouldUseCached(entry: CacheEntry | undefined): entry is CacheEntry {
   return Boolean(entry && entry.expiresAt > Date.now())
@@ -78,10 +49,10 @@ export async function fetchLinkPreviews(urls: string[]): Promise<Record<string, 
   const errors = isRecord(raw.errors) ? raw.errors : {}
 
   for (const url of missing) {
-    const preview = normalizeLinkPreview(previews[url])
-    if (preview) {
-      previewCache.set(url, { preview, expiresAt: Date.now() + LOCAL_PREVIEW_TTL_MS })
-      result[url] = preview
+    const parsed = safeParseLinkPreview(previews[url])
+    if (parsed.success) {
+      previewCache.set(url, { preview: parsed.output, expiresAt: Date.now() + LOCAL_PREVIEW_TTL_MS })
+      result[url] = parsed.output
       continue
     }
 

--- a/dashboard/src/api/schemas/link-previews.test.ts
+++ b/dashboard/src/api/schemas/link-previews.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { safeParseLinkPreview } from './link-previews'
+
+describe('safeParseLinkPreview', () => {
+  it('accepts a minimal link preview', () => {
+    const result = safeParseLinkPreview({
+      url: 'https://example.com',
+      kind: 'link',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output.url).toBe('https://example.com')
+      expect(result.output.kind).toBe('link')
+      // optional fields are absent, not coerced to null
+      expect(result.output.title).toBeUndefined()
+    }
+  })
+
+  it('accepts an image preview with all optional fields populated', () => {
+    const result = safeParseLinkPreview({
+      url: 'https://cdn.example.com/pic.png',
+      kind: 'image',
+      canonical_url: 'https://cdn.example.com/pic.png',
+      title: 'A picture',
+      description: 'Scenic mountain view',
+      site_name: 'Example CDN',
+      image_url: 'https://cdn.example.com/pic.png',
+      favicon_url: 'https://example.com/favicon.ico',
+      content_type: 'image/png',
+      fetched_at: '2026-04-17T00:00:00Z',
+      cache_state: 'fresh',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output.kind).toBe('image')
+      expect(result.output.title).toBe('A picture')
+    }
+  })
+
+  it('accepts explicit null for optional fields (backend nullability signal)', () => {
+    const result = safeParseLinkPreview({
+      url: 'https://example.com',
+      kind: 'link',
+      title: null,
+      description: null,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.output.title).toBeNull()
+    }
+  })
+
+  it('rejects an unknown kind (not coerced — dropped by caller)', () => {
+    // kind is strict (not fallback): a preview the backend can't classify
+    // should be dropped, not displayed as a link/image the user can click.
+    const result = safeParseLinkPreview({
+      url: 'https://example.com',
+      kind: 'video',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing url', () => {
+    const result = safeParseLinkPreview({ kind: 'link' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-object payload', () => {
+    expect(safeParseLinkPreview(null).success).toBe(false)
+    expect(safeParseLinkPreview('string').success).toBe(false)
+    expect(safeParseLinkPreview(42).success).toBe(false)
+  })
+})

--- a/dashboard/src/api/schemas/link-previews.ts
+++ b/dashboard/src/api/schemas/link-previews.ts
@@ -1,0 +1,55 @@
+/**
+ * Link preview schema — schema-at-boundary for
+ * `POST /api/v1/dashboard/link-previews` entries.
+ *
+ * Contract (see dashboard/docs/API_CONTRACT.md):
+ * - The preview shape is declared once here; `LinkPreview` type is
+ *   derived via `InferOutput`.
+ * - `fetchLinkPreviews` passes each entry through `safeParseLinkPreview`
+ *   instead of the hand-rolled `normalizeLinkPreview` that previously
+ *   lived in `src/api/link-previews.ts`. Unparseable entries drop
+ *   silently (same behavior as the prior normalizer returning `null`)
+ *   but now the parse result records the drift for future diagnostics.
+ * - `kind` is strict (not fallback): entries with an unknown preview
+ *   kind are dropped rather than coerced, because a coercion would make
+ *   the operator view pretend a rich-media preview exists when the
+ *   backend sent something it couldn't classify.
+ *
+ * Rolled out as part of #7441 (P2 rollout) following pilot #7439.
+ */
+
+import {
+  nullable,
+  object,
+  optional,
+  picklist,
+  safeParse,
+  string,
+  type InferOutput,
+  type SafeParseResult,
+} from 'valibot'
+
+export const LinkPreviewKindSchema = picklist(['link', 'image'])
+
+export const LinkPreviewSchema = object({
+  url: string(),
+  kind: LinkPreviewKindSchema,
+  canonical_url: optional(nullable(string())),
+  title: optional(nullable(string())),
+  description: optional(nullable(string())),
+  site_name: optional(nullable(string())),
+  image_url: optional(nullable(string())),
+  favicon_url: optional(nullable(string())),
+  content_type: optional(nullable(string())),
+  fetched_at: optional(nullable(string())),
+  cache_state: optional(nullable(string())),
+})
+
+export type LinkPreviewKind = InferOutput<typeof LinkPreviewKindSchema>
+export type LinkPreview = InferOutput<typeof LinkPreviewSchema>
+
+export function safeParseLinkPreview(
+  data: unknown,
+): SafeParseResult<typeof LinkPreviewSchema> {
+  return safeParse(LinkPreviewSchema, data)
+}


### PR DESCRIPTION
## Summary

Migrates the \`POST /api/v1/dashboard/link-previews\` surface to the schema-at-boundary pattern, removing a second hand-rolled normalizer and extending the #7441 P2 rollout.

- Adds \`src/api/schemas/link-previews.ts\` — \`LinkPreviewSchema\`, derived \`LinkPreview\` / \`LinkPreviewKind\` types, \`safeParseLinkPreview\`.
- Rewrites \`src/api/link-previews.ts\` — drops the manual \`normalizeLinkPreview\`, routes each response entry through valibot, re-exports types so the single caller in \`common/rich-content.ts\` is unchanged.
- Adds \`src/api/schemas/link-previews.test.ts\` — 6 shape tests.

## Drift policy

- \`kind\` is **strict** (no fallback). An entry with an unknown kind would have to render as link or image anyway; the backend adding a new kind should block the preview from misclassifying until the dashboard ships support for it. Unparseable entries drop silently — same semantics as the prior normalizer returning \`null\`.
- All optional descriptor fields keep the \`string | null | undefined\` triple so the backend's \"tried but empty\" signal stays distinguishable from absence.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/link-previews.test.ts\` — 6/6 pass
- [ ] CI green

Part of #7441. Stacks after #7700 for the rollout sequencing but does not depend on it (no shared files).