### PR TITLE
test,grafana: invariant counter tests + Grafana panels (LT-13b, stacks on #7708)

### DIFF
--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -147,4 +147,48 @@ This is the spec → code → dashboard → metric consistency contract.
 - #7643 — Strategy decision trace (ring buffer, JSON)
 - #7645 — `masc_cascade_capacity_events_total` counter
 - #7649 — `masc_cascade_strategy_decisions_total` counter
-- (this) — alerting rules + doc
+- #7679 — SLO card (in-process burn-rate computation)
+- (LT-13) — `masc_keeper_invariant_violations_total` counter + alerts
+
+---
+
+## `masc_keeper_invariant_violations_total` (LT-13)
+
+| Label       | Values                                                                             |
+| ----------- | ---------------------------------------------------------------------------------- |
+| `keeper`    | Keeper name (bounded by keepers registered on host, typically < 50)                |
+| `invariant` | `PhaseTurnAlignment`, `NoCascadeBeforeMeasurement`, `CompactionAtomicity`, `EventPriorityMonotone` |
+
+Incremented from `Keeper_composite_observer.bump_invariant_violations`, invoked by `observe` on every snapshot. One counter tick **per violated invariant per snapshot**. A sustained rate means the FSM composition is wedged in an inconsistent cross-axis state.
+
+Label cardinality: `keepers × 4` (≤ 200 series in practice).
+
+### PromQL patterns
+
+```promql
+# Fleet-wide violation burst (5-minute window)
+sum by (invariant) (increase(masc_keeper_invariant_violations_total[5m]))
+
+# Which keeper is offending for a specific invariant
+topk(5, rate(masc_keeper_invariant_violations_total
+              {invariant="PhaseTurnAlignment"}[5m]))
+
+# Invariant health SLO (what fraction of snapshots satisfy all 4?)
+# Requires pairing with a snapshots_total counter in a follow-up; out of
+# scope for LT-13.
+```
+
+### Spec↔code↔counter contract
+
+Any renaming of the invariant constants must land in all **6 places** in the same PR — see `docs/observability/fsm-spec-code-drift.md` §4. Specifically:
+
+1. TLA+ invariant predicate in `specs/keeper-state-machine/KeeperCompositeLifecycle.tla`.
+2. OCaml `invariant_key` variant in `keeper_composite_observer.mli`.
+3. `invariant_key_to_string` (the Prometheus label source).
+4. `invariants_check` record field name (the OCaml result).
+5. Alert rule in `infrastructure/monitoring/cascade-alerts.yml`.
+6. Grafana panel (landing in LT-13b — follow-up).
+
+### Why one tick per snapshot instead of edge-triggered?
+
+A violated invariant that *persists* across multiple snapshots is a stronger signal than one that flips once — `rate()`/`increase()` reflect the persistence directly. Edge-triggering would require a prior-state cache on the observer, which conflicts with the observer's pure-projection contract (`keeper_composite_observer.mli:1-20`).

--- a/infrastructure/monitoring/cascade-alerts.yml
+++ b/infrastructure/monitoring/cascade-alerts.yml
@@ -10,6 +10,12 @@
 #       kind ∈ {ordered, filtered_empty, exhausted}
 #       See lib/cascade/cascade_strategy_trace.ml
 #
+#   - masc_keeper_invariant_violations_total{keeper, invariant}
+#       invariant ∈ {PhaseTurnAlignment, NoCascadeBeforeMeasurement,
+#                    CompactionAtomicity, EventPriorityMonotone}
+#       See lib/keeper/keeper_composite_observer.ml
+#       Spec:  specs/keeper-state-machine/KeeperCompositeLifecycle.tla
+#
 # Thresholds below are conservative starting points; tune per deployment.
 # Rate windows use 5m so a single transient event does not page; duration
 # guards (for:) require the condition to persist across two 5m windows.
@@ -130,3 +136,48 @@ groups:
             Cross-check /api/v1/cascade/client_capacity for the current
             snapshot — if that has entries but no events, the history
             ring buffer wiring regressed.
+
+  # Keeper composite lifecycle invariants (LT-13). Each counter tick is a
+  # per-snapshot violation of a KeeperCompositeLifecycle.tla safety
+  # property. Thresholds are conservative: any sustained violation pages.
+  - name: masc_keeper_composite_invariants
+    interval: 30s
+    rules:
+      - alert: KeeperCompositeInvariantViolationBurst
+        expr: |
+          sum by (invariant) (
+            increase(masc_keeper_invariant_violations_total[5m])
+          ) > 10
+        for: 10m
+        labels:
+          severity: warning
+          component: keeper
+          subsystem: composite_lifecycle
+        annotations:
+          summary: "Composite invariant {{ $labels.invariant }} violated > 10x/5m"
+          description: |
+            KeeperCompositeLifecycle.tla safety property {{ $labels.invariant }}
+            is failing at more than 10 snapshots per 5 minutes fleet-wide.
+            This signals a cross-axis FSM inconsistency (phase disagrees
+            with turn, cascade starts without measurement, compaction
+            straddles turn boundaries, or event priority ordering broke).
+            Cross-check /api/v1/keepers/<name>/composite to identify the
+            offending keeper; attach the raw snapshot to any follow-up.
+
+      - alert: KeeperCompositeInvariantSingleKeeperStuck
+        expr: |
+          rate(masc_keeper_invariant_violations_total[5m]) > 0.1
+        for: 15m
+        labels:
+          severity: warning
+          component: keeper
+          subsystem: composite_lifecycle
+        annotations:
+          summary: "Keeper {{ $labels.keeper }} stuck violating {{ $labels.invariant }}"
+          description: |
+            A single keeper has been violating {{ $labels.invariant }} at
+            > 0.1 samples/s for 15 minutes. Indicates a wedged FSM
+            composition on that keeper specifically — consider issuing
+            a supervised restart after capturing the snapshot for
+            post-mortem. Spec reference:
+            specs/keeper-state-machine/KeeperCompositeLifecycle.tla

--- a/infrastructure/monitoring/grafana-cascade-dashboard.json
+++ b/infrastructure/monitoring/grafana-cascade-dashboard.json
@@ -1,6 +1,6 @@
 {
   "__meta": {
-    "purpose": "MASC cascade observability — imports into Grafana 10+ via File → Import.",
+    "purpose": "MASC cascade observability \u2014 imports into Grafana 10+ via File \u2192 Import.",
     "metrics": [
       "masc_cascade_capacity_events_total{kind, key_type}",
       "masc_cascade_strategy_decisions_total{cascade, strategy, kind}"
@@ -12,7 +12,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": { "type": "datasource", "uid": "grafana" },
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -28,9 +31,17 @@
     {
       "id": 1,
       "type": "timeseries",
-      "title": "Capacity events by (kind, key_type) — rate / 5m",
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Capacity events by (kind, key_type) \u2014 rate / 5m",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Raw acquire / release / rejected_full rate. Spikes in rejected_full are the ollama/cli saturation signal wired by OllamaCapacityRejectionSurge + CliCapacityRejectionSurge alerts.",
       "targets": [
         {
@@ -42,19 +53,33 @@
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         }
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        }
       }
     },
     {
       "id": 2,
       "type": "timeseries",
-      "title": "Strategy decisions — rate by kind / 5m",
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Strategy decisions \u2014 rate by kind / 5m",
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Per-kind cycle decision rate. exhausted (red) == user-visible cascade failure; filtered_empty (yellow) == backoff + retry; ordered (green) == happy path.",
       "targets": [
         {
@@ -66,27 +91,80 @@
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "exhausted" },
-            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }] },
-          { "matcher": { "id": "byName", "options": "filtered_empty" },
-            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] },
-          { "matcher": { "id": "byName", "options": "ordered" },
-            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "exhausted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "filtered_empty"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ordered"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "showLegend": true }
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        }
       }
     },
     {
       "id": 3,
       "type": "stat",
-      "title": "Exhaustion events — last 24h",
-      "gridPos": { "x": 0, "y": 8, "w": 6, "h": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Exhaustion events \u2014 last 24h",
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 6,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Every count == one user-visible cascade failure. Paired with CascadeExhaustionBurst alert at rate > 0.1/s.",
       "targets": [
         {
@@ -100,9 +178,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": 0 },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 10 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
             ]
           }
         }
@@ -110,15 +197,29 @@
       "options": {
         "colorMode": "background",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       }
     },
     {
       "id": 4,
       "type": "stat",
-      "title": "Ollama rejections — last 1h",
-      "gridPos": { "x": 6, "y": 8, "w": 6, "h": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Ollama rejections \u2014 last 1h",
+      "gridPos": {
+        "x": 6,
+        "y": 8,
+        "w": 6,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Slot-full events for ollama URLs. OllamaCapacityRejectionSurge fires at rate > 0.5/s sustained.",
       "targets": [
         {
@@ -132,9 +233,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": 0 },
-              { "color": "yellow", "value": 10 },
-              { "color": "red", "value": 100 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
             ]
           }
         }
@@ -142,15 +252,29 @@
       "options": {
         "colorMode": "background",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       }
     },
     {
       "id": 5,
       "type": "stat",
-      "title": "CLI rejections — last 1h",
-      "gridPos": { "x": 12, "y": 8, "w": 6, "h": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "CLI rejections \u2014 last 1h",
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 6,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Slot-full events for CLI providers (claude_code / gemini_cli / codex_cli). CliCapacityRejectionSurge fires at rate > 1/s.",
       "targets": [
         {
@@ -164,9 +288,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": 0 },
-              { "color": "yellow", "value": 50 },
-              { "color": "red", "value": 500 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
             ]
           }
         }
@@ -174,15 +307,29 @@
       "options": {
         "colorMode": "background",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       }
     },
     {
       "id": 6,
       "type": "stat",
-      "title": "Strategy filter-empty ratio — 5m",
-      "gridPos": { "x": 18, "y": 8, "w": 6, "h": 6 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Strategy filter-empty ratio \u2014 5m",
+      "gridPos": {
+        "x": 18,
+        "y": 8,
+        "w": 6,
+        "h": 6
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "filtered_empty / total cycles. > 50% triggers StrategyFilteredEmptyStorm.",
       "targets": [
         {
@@ -196,9 +343,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": 0 },
-              { "color": "yellow", "value": 0.25 },
-              { "color": "red", "value": 0.5 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
             ]
           }
         }
@@ -206,15 +362,29 @@
       "options": {
         "colorMode": "background",
         "graphMode": "area",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
       }
     },
     {
       "id": 7,
       "type": "timeseries",
-      "title": "Exhaustion by cascade — rate / 5m",
-      "gridPos": { "x": 0, "y": 14, "w": 24, "h": 8 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "title": "Exhaustion by cascade \u2014 rate / 5m",
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "description": "Which cascades are failing? A persistent non-zero line for a specific cascade name is a config or provider-key problem.",
       "targets": [
         {
@@ -226,20 +396,34 @@
       "fieldConfig": {
         "defaults": {
           "unit": "ops",
-          "color": { "mode": "palette-classic" }
+          "color": {
+            "mode": "palette-classic"
+          }
         }
       },
       "options": {
-        "legend": { "displayMode": "table", "placement": "bottom", "showLegend": true }
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
       }
     },
     {
       "id": 8,
       "type": "table",
       "title": "Decision totals (24h) by (cascade, strategy, kind)",
-      "gridPos": { "x": 0, "y": 22, "w": 24, "h": 10 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "description": "Tabular view of every (cascade × strategy × kind) bucket over the last 24h. Useful for spotting strategy drift across deployments.",
+      "gridPos": {
+        "x": 0,
+        "y": 22,
+        "w": 24,
+        "h": 10
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Tabular view of every (cascade \u00d7 strategy \u00d7 kind) bucket over the last 24h. Useful for spotting strategy drift across deployments.",
       "targets": [
         {
           "expr": "sort_desc(sum by (cascade, strategy, kind) (increase(masc_cascade_strategy_decisions_total[24h])))",
@@ -250,33 +434,198 @@
       ],
       "fieldConfig": {
         "defaults": {
-          "custom": { "align": "left" }
+          "custom": {
+            "align": "left"
+          }
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Value" },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
             "properties": [
-              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
-              { "id": "custom.align", "value": "right" },
-              { "id": "thresholds", "value": {
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
                   "mode": "absolute",
                   "steps": [
-                    { "color": "green", "value": 0 },
-                    { "color": "yellow", "value": 100 },
-                    { "color": "red", "value": 1000 }
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 100
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
                   ]
-                } }
-            ] }
+                }
+              }
+            ]
+          }
         ]
       },
       "options": {
         "showHeader": true,
-        "sortBy": [{ "displayName": "Value", "desc": true }]
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Keeper composite invariant violations \u2014 rate / 5m",
+      "gridPos": {
+        "x": 0,
+        "y": 32,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "KeeperCompositeLifecycle.tla joint invariants (LT-13). Sustained non-zero means cross-axis FSM composition is wedged.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (invariant) (rate(masc_keeper_invariant_violations_total[5m]))",
+          "legendFormat": "{{invariant}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": "table",
+      "title": "Top violating keepers (5m)",
+      "gridPos": {
+        "x": 0,
+        "y": 40,
+        "w": 24,
+        "h": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Which keepers are driving the invariant violation rate. Use this list as the input for a targeted restart or composite snapshot grab.",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, sum by (keeper, invariant) (rate(masc_keeper_invariant_violations_total[5m])))",
+          "legendFormat": "{{keeper}} / {{invariant}}",
+          "format": "table",
+          "instant": true,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": 0
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 100
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
       }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["masc", "cascade", "observability"],
+  "tags": [
+    "masc",
+    "cascade",
+    "observability"
+  ],
   "templating": {
     "list": [
       {
@@ -293,7 +642,10 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "",
   "title": "MASC Cascade Observability",

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -336,6 +336,26 @@ let compute_invariants
     event_priority_monotone = check_event_priority_monotone entry;
   }
 
+(* Prometheus bump — one counter tick per violated invariant per snapshot.
+   Called from [observe]. PromQL rate/increase distinguishes transient
+   from steady-state violations. Labels bounded: keeper × invariant (4)
+   ≤ ~200 series on a 50-keeper host. Mirrors the naming pattern in
+   [Cascade_strategy_trace.bump_prometheus_counter]. *)
+let bump_invariant_violations ~(keeper_name : string) (inv : invariants_check) =
+  let bump key satisfied =
+    if not satisfied then
+      Prometheus.inc_counter "masc_keeper_invariant_violations_total"
+        ~labels:[
+          ("keeper", keeper_name);
+          ("invariant", invariant_key_to_string key);
+        ]
+        ()
+  in
+  bump Invariant_phase_turn_alignment inv.phase_turn_alignment;
+  bump Invariant_no_cascade_before_measurement inv.no_cascade_before_measurement;
+  bump Invariant_compaction_atomicity inv.compaction_atomicity;
+  bump Invariant_event_priority_monotone inv.event_priority_monotone
+
 (* Public API *)
 
 let stable_correlation_id (entry : Keeper_registry.registry_entry) : string =
@@ -381,6 +401,7 @@ let observe
       ~compaction_stage
       ~measurement_captured
   in
+  bump_invariant_violations ~keeper_name:entry.name invariants;
   {
     correlation_id;
     run_id;

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -111,6 +111,13 @@ type invariants_check = {
   event_priority_monotone : bool;
 }
 
+(** Increment [masc_keeper_invariant_violations_total\{keeper, invariant\}]
+    once per violated invariant. No-op when all invariants hold. Called
+    automatically from [observe]; exposed so unit tests can assert the
+    counter bump without going through the full snapshot pipeline. *)
+val bump_invariant_violations :
+  keeper_name:string -> invariants_check -> unit
+
 (** Frozen outcome of the most recently completed turn (RFC-0003
     Phase 2). Surfaces terminal data ([Done]/[Guard_ok]/...) without
     polluting the live sub-FSM fields. [None] until the first turn

--- a/test/dune
+++ b/test/dune
@@ -69,6 +69,7 @@
         test_keeper_unified
         test_decision_pipeline
         test_decision_pipeline_observer
+        test_keeper_composite_observer
         test_keeper_telemetry_feedback
         test_keeper_toml
         test_keeper_runtime_toml
@@ -157,6 +158,7 @@
           test_keeper_unified
           test_decision_pipeline
           test_decision_pipeline_observer
+          test_keeper_composite_observer
           test_keeper_telemetry_feedback
           test_keeper_toml
           test_keeper_runtime_toml

--- a/test/test_keeper_composite_observer.ml
+++ b/test/test_keeper_composite_observer.ml
@@ -1,0 +1,116 @@
+(** Tests for Keeper_composite_observer — isolated from the full
+    snapshot pipeline. Each test uses a keeper_name prefix unique to
+    the case so Prometheus global state does not cross-contaminate. *)
+
+open Alcotest
+
+module Obs = Masc_mcp.Keeper_composite_observer
+module P = Masc_mcp.Prometheus
+
+let counter_name = "masc_keeper_invariant_violations_total"
+
+let read ~keeper ~invariant =
+  P.metric_value_or_zero
+    counter_name
+    ~labels:[("keeper", keeper); ("invariant", invariant)]
+    ()
+
+let all_satisfied : Obs.invariants_check = {
+  phase_turn_alignment = true;
+  no_cascade_before_measurement = true;
+  compaction_atomicity = true;
+  event_priority_monotone = true;
+}
+
+let all_violated : Obs.invariants_check = {
+  phase_turn_alignment = false;
+  no_cascade_before_measurement = false;
+  compaction_atomicity = false;
+  event_priority_monotone = false;
+}
+
+(* --- bump: no-op when all satisfied ------------------------------- *)
+
+let test_bump_noop_when_all_satisfied () =
+  let keeper = "test-bump-noop" in
+  let before = read ~keeper ~invariant:"PhaseTurnAlignment" in
+  Obs.bump_invariant_violations ~keeper_name:keeper all_satisfied;
+  let after = read ~keeper ~invariant:"PhaseTurnAlignment" in
+  check (float 0.0001) "no bump on satisfied invariants" before after
+
+(* --- bump: increments every violated invariant -------------------- *)
+
+let test_bump_increments_each_violated () =
+  let keeper = "test-bump-all-violated" in
+  let invariants =
+    [ "PhaseTurnAlignment"; "NoCascadeBeforeMeasurement";
+      "CompactionAtomicity"; "EventPriorityMonotone" ]
+  in
+  let before = List.map (fun inv -> (inv, read ~keeper ~invariant:inv)) invariants in
+  Obs.bump_invariant_violations ~keeper_name:keeper all_violated;
+  List.iter (fun (inv, b) ->
+    let a = read ~keeper ~invariant:inv in
+    check (float 0.0001)
+      (Printf.sprintf "counter %s increments by 1" inv)
+      (b +. 1.0) a
+  ) before
+
+(* --- bump: only the violated labels move -------------------------- *)
+
+let test_bump_selective_increments () =
+  let keeper = "test-bump-mixed" in
+  let mixed : Obs.invariants_check = {
+    phase_turn_alignment = false;
+    no_cascade_before_measurement = true;  (* satisfied, no bump *)
+    compaction_atomicity = false;
+    event_priority_monotone = true;        (* satisfied, no bump *)
+  } in
+  let pt_before = read ~keeper ~invariant:"PhaseTurnAlignment" in
+  let nc_before = read ~keeper ~invariant:"NoCascadeBeforeMeasurement" in
+  let ca_before = read ~keeper ~invariant:"CompactionAtomicity" in
+  let ep_before = read ~keeper ~invariant:"EventPriorityMonotone" in
+  Obs.bump_invariant_violations ~keeper_name:keeper mixed;
+  check (float 0.0001) "phase_turn_alignment +1"
+    (pt_before +. 1.0) (read ~keeper ~invariant:"PhaseTurnAlignment");
+  check (float 0.0001) "no_cascade_before_measurement unchanged"
+    nc_before (read ~keeper ~invariant:"NoCascadeBeforeMeasurement");
+  check (float 0.0001) "compaction_atomicity +1"
+    (ca_before +. 1.0) (read ~keeper ~invariant:"CompactionAtomicity");
+  check (float 0.0001) "event_priority_monotone unchanged"
+    ep_before (read ~keeper ~invariant:"EventPriorityMonotone")
+
+(* --- bump: per-keeper isolation ----------------------------------- *)
+
+let test_bump_per_keeper_isolation () =
+  let k1 = "test-iso-alpha" in
+  let k2 = "test-iso-beta" in
+  let k2_before = read ~keeper:k2 ~invariant:"PhaseTurnAlignment" in
+  Obs.bump_invariant_violations ~keeper_name:k1 all_violated;
+  let k2_after = read ~keeper:k2 ~invariant:"PhaseTurnAlignment" in
+  check (float 0.0001)
+    "bumping keeper alpha does not touch keeper beta"
+    k2_before k2_after
+
+(* --- all invariant keys are covered ------------------------------- *)
+
+let test_all_invariant_keys_mapped () =
+  let strings =
+    List.map Obs.invariant_key_to_string Obs.all_invariant_keys
+  in
+  check int "4 invariant keys" 4 (List.length strings);
+  check (list string) "key names match alert-rule labels"
+    [ "PhaseTurnAlignment"; "NoCascadeBeforeMeasurement";
+      "CompactionAtomicity"; "EventPriorityMonotone" ]
+    strings
+
+let () =
+  run "keeper_composite_observer" [
+    "bump_invariant_violations",
+    [ test_case "no-op when satisfied" `Quick test_bump_noop_when_all_satisfied
+    ; test_case "increments each violated" `Quick test_bump_increments_each_violated
+    ; test_case "only violated labels move" `Quick test_bump_selective_increments
+    ; test_case "per-keeper isolation" `Quick test_bump_per_keeper_isolation
+    ];
+    "invariant_key mapping",
+    [ test_case "all keys present and named" `Quick test_all_invariant_keys_mapped ];
+  ]


### PR DESCRIPTION
## Summary

Completes the two follow-ups flagged as out-of-scope in #7708 (LT-13):

1. Unit test for \`Keeper_composite_observer.bump_invariant_violations\` (5 alcotest cases, all green locally).
2. Two Grafana panels for the new counter.

**Stacks on #7708** — merge that first, then rebase this onto main.

## Test cases

| Case | What it asserts |
|------|-----------------|
| no-op when satisfied | no bump on an all-\`true\` invariants_check |
| increments each violated | all-\`false\` bumps all 4 invariants by exactly 1 |
| only violated labels move | mixed check bumps only the \`false\` fields |
| per-keeper isolation | bumping keeper \`alpha\` does not touch keeper \`beta\` |
| invariant_key mapping | 4 keys map to exactly the label strings the alert rule expects |

Each test uses a unique \`keeper_name\` prefix so the Prometheus global registry doesn't cross-contaminate between runs.

## Grafana panels

| Panel | Query |
|-------|-------|
| Keeper composite invariant violations — rate / 5m (timeseries) | \`sum by (invariant) (rate(masc_keeper_invariant_violations_total[5m]))\` |
| Top violating keepers (5m) (table) | \`topk(10, sum by (keeper, invariant) (rate(masc_keeper_invariant_violations_total[5m])))\` |

Reuses existing \`\${DS_PROMETHEUS}\` datasource templating. JSON round-trip clean (python3 -c 'json.load(...)').

## Test plan

- [x] \`dune build --root . test/\` — passes.
- [x] \`dune exec --root . test/test_keeper_composite_observer.exe\` — 5/5 OK.
- [x] JSON validation — \`python3 -c 'json.load(open(dash))'\` passes.
- [ ] Grafana import smoke — import the JSON into a test Grafana instance, verify both panels render on an empty Prometheus.

## References

- #7708 (LT-13) — counter + alerts + docs this PR completes.
- #7689 (LT-12), #7703 (LT-15) — upstream design / audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)