### PR TITLE
chore(dashboard): drop dead review_resolve/review_defer OperatorActionType cases

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -158,7 +158,7 @@ export function workflowTargetReady(
 }
 
 export async function executeAction(input: {
-  action_type: 'broadcast' | 'namespace_pause' | 'namespace_resume' | 'room_pause' | 'room_resume' | 'task_inject' | 'keeper_message' | 'keeper_probe' | 'keeper_recover' | 'review_resolve' | 'review_defer'
+  action_type: 'broadcast' | 'namespace_pause' | 'namespace_resume' | 'room_pause' | 'room_resume' | 'task_inject' | 'keeper_message' | 'keeper_probe' | 'keeper_recover'
   target_type: 'root' | 'namespace' | 'room' | 'keeper' | 'review_item'
   target_id?: string
   payload: Record<string, unknown>

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -562,8 +562,6 @@ export type OperatorActionType =
   | 'keeper_message'
   | 'keeper_probe'
   | 'keeper_recover'
-  | 'review_resolve'
-  | 'review_defer'
 
 export type OperatorTargetType = 'root' | 'namespace' | 'room' | 'keeper' | 'review_item'
 


### PR DESCRIPTION
## Summary

`rg "action_type: '(review_resolve|review_defer)'" dashboard/src/` returns **zero call sites**. These action kinds were only surviving in:

| Location | After this PR |
|---|---|
| `OperatorActionType` union (`types/dashboard-mission.ts`) | **dropped** |
| `executeAction` local union (`ops/helpers.ts:161`) | **dropped** |
| `actionTypeLabel` switch cases for `'review_resolve'` / `'review_defer'` | **preserved** |

The label cases stay because `OperatorActionLogEntry.action_type: string` (loose typing) means the backend's historical action log may still carry these values for older entries. Keeping the `'검토 해결'` / `'검토 보류'` labels means legacy timeline rows still render prettily — we just can't construct new ones at compile time.

## Gen6 loop context

Continues the `/loop 20m` thread's cleanup layer:

| Gen | Target | Status |
|---|---|---|
| 2 | `review_queue` / `deferred_queue` / `review_summary` types | merged |
| 6 (this) | `review_resolve` / `review_defer` action types | this PR |
| 3+ | Backend `operator_digest.ml` emit (22 OCaml refs) | future |

## Test plan

- [x] `pnpm typecheck` → 0 errors (proves nothing constructs these at compile time)
- [x] `pnpm vitest run src/components/ops/index.test.ts` → 2/2 pass
- [x] `actionTypeLabel` label cases preserved — verified by reading

## Non-goals

- Backend emission — still OCaml-side. Backend review_item purge is a separate PR.
- Removing label switch branches — would regress historical entries to raw `"review_resolve"` display. Keep until backend stops emitting.
