### PR TITLE
chore(dashboard): drop dead review_item OperatorTargetType literal

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -159,7 +159,7 @@ export function workflowTargetReady(
 
 export async function executeAction(input: {
   action_type: 'broadcast' | 'namespace_pause' | 'namespace_resume' | 'room_pause' | 'room_resume' | 'task_inject' | 'keeper_message' | 'keeper_probe' | 'keeper_recover'
-  target_type: 'root' | 'namespace' | 'room' | 'keeper' | 'review_item'
+  target_type: 'root' | 'namespace' | 'room' | 'keeper'
   target_id?: string
   payload: Record<string, unknown>
   successMessage: string

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -563,7 +563,7 @@ export type OperatorActionType =
   | 'keeper_probe'
   | 'keeper_recover'
 
-export type OperatorTargetType = 'root' | 'namespace' | 'room' | 'keeper' | 'review_item'
+export type OperatorTargetType = 'root' | 'namespace' | 'room' | 'keeper'
 
 export interface OperatorActionRequest {
   actor: string


### PR DESCRIPTION
## Summary

Complementary to Gen6 (#7714). `OperatorTargetType` still had `'review_item'` as a valid input literal, but `rg "target_type: 'review_item'" dashboard/src/` returns **zero call sites**. This PR drops the literal from the input union while keeping the `targetTypeLabel` switch case that renders historical log entries as `'리뷰 항목'`.

| Location | After this PR |
|---|---|
| `OperatorTargetType` union (`types/dashboard-mission.ts:568`) | **dropped** |
| `executeAction` local union (`ops/helpers.ts:162`) | **dropped** |
| `targetTypeLabel` case `'review_item'` → `'리뷰 항목'` | **preserved** |

## Rationale

Same loose-typing contract as Gen6: `OperatorActionLogEntry.target_label: string` (not `OperatorTargetType`), so historical backend data can still render the friendly Korean label. Only the input side is tightened.

## Loop context

`/loop 20m` cleanup layer stacking:

| Gen | Target | Status |
|---|---|---|
| 2 | `review_queue` / `deferred_queue` / `review_summary` types | merged |
| 6 | `review_resolve` / `review_defer` action types | #7714 draft |
| 7 (this) | `review_item` target type literal | this PR |

Gen6 + Gen7 together complete the frontend type-union purge of the retired review surface. Backend emission (`operator_digest.ml`, 22 OCaml refs) is the remaining scope for a future gen.

## Test plan

- [x] `pnpm typecheck` → 0 errors (proves no caller constructs `target_type: 'review_item'` at compile time)
- [x] `pnpm vitest run src/components/ops/index.test.ts` → 2/2 pass
- [x] `targetTypeLabel` historical-render case preserved (verified by reading)

## Non-goals

- Backend `operator_digest.ml` emission purge — separate PR
- Removing `targetTypeLabel` case — would regress historical log entries to raw `review_item` display
