### PR TITLE
feat(dashboard/api): migrate keeper transitions endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -17,6 +17,11 @@ import {
   safeParseKeeperChatHistoryMessage,
   type KeeperChatHistoryMessage,
 } from './schemas/keeper-chat-history'
+import {
+  parseKeeperTransitionsResponse,
+  type KeeperTransition,
+  type KeeperTransitionsResponse,
+} from './schemas/keeper-transitions'
 
 export type {
   KeeperCompositeSnapshot,
@@ -42,6 +47,8 @@ export {
   KeeperChatHistoryMessageSchema,
   safeParseKeeperChatHistoryMessage,
 } from './schemas/keeper-chat-history'
+export type { KeeperTransition, KeeperTransitionsResponse }
+export { KeeperTransitionsSchemaDriftError } from './schemas/keeper-transitions'
 
 // --- Types ---
 
@@ -509,21 +516,6 @@ export async function editKeeperTools(
 
 // --- Keeper observability API ---
 
-export interface KeeperTransition {
-  prev_phase: string
-  new_phase: string
-  selected_event: unknown
-  wall_clock_at_decision: number
-  transition_outcome: string
-}
-
-export interface KeeperTransitionsResponse {
-  keeper: string
-  current_phase: string | null
-  count: number
-  transitions: KeeperTransition[]
-}
-
 export interface MemoryKindUsageEntry {
   kind: string
   used: number
@@ -559,7 +551,7 @@ export async function fetchKeeperTransitions(
     DEFAULT_GET_TIMEOUT_MS,
   )
   if (!resp.ok) throw new Error(`transitions fetch failed: ${resp.status}`)
-  return resp.json() as Promise<KeeperTransitionsResponse>
+  return parseKeeperTransitionsResponse(await resp.json())
 }
 
 export async function fetchKeeperStateDiagram(

--- a/dashboard/src/api/schemas/keeper-transitions.test.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  KeeperTransitionsSchemaDriftError,
+  parseKeeperTransitionsResponse,
+} from './keeper-transitions'
+
+function validTransition(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    prev_phase: 'Running',
+    new_phase: 'Compacting',
+    selected_event: null,
+    wall_clock_at_decision: 1_712_000_000.5,
+    transition_outcome: 'ok',
+    ...overrides,
+  }
+}
+
+describe('parseKeeperTransitionsResponse', () => {
+  it('accepts an empty transitions list', () => {
+    const out = parseKeeperTransitionsResponse({
+      keeper: 'greeter',
+      current_phase: 'Running',
+      count: 0,
+      transitions: [],
+    })
+    expect(out.keeper).toBe('greeter')
+    expect(out.transitions).toHaveLength(0)
+  })
+
+  it('accepts a populated list with opaque selected_event', () => {
+    // selected_event is stored as unknown on purpose — callers render
+    // it for diagnostics only, not for branching.
+    const out = parseKeeperTransitionsResponse({
+      keeper: 'greeter',
+      current_phase: 'Running',
+      count: 2,
+      transitions: [
+        validTransition(),
+        validTransition({
+          prev_phase: 'Compacting',
+          new_phase: 'Running',
+          selected_event: { kind: 'tool_result', tool: 'masc_check' },
+        }),
+      ],
+    })
+    expect(out.transitions).toHaveLength(2)
+    expect(out.transitions[1]!.new_phase).toBe('Running')
+  })
+
+  it('accepts null current_phase (just-booted keeper with no decisions yet)', () => {
+    const out = parseKeeperTransitionsResponse({
+      keeper: 'cold-start',
+      current_phase: null,
+      count: 0,
+      transitions: [],
+    })
+    expect(out.current_phase).toBeNull()
+  })
+
+  it('accepts unknown phase values (backend evolves new phases ahead of dashboard)', () => {
+    // Phases are open `string()` — a new backend phase should not
+    // brick the transition strip during a backend-ahead deploy window.
+    const out = parseKeeperTransitionsResponse({
+      keeper: 'g',
+      current_phase: 'NovelPhase',
+      count: 1,
+      transitions: [validTransition({ new_phase: 'NovelPhase' })],
+    })
+    expect(out.current_phase).toBe('NovelPhase')
+  })
+
+  it('throws when a required field is missing', () => {
+    const bad = {
+      keeper: 'g',
+      current_phase: null,
+      count: 1,
+      transitions: [validTransition({ wall_clock_at_decision: undefined })],
+    }
+    expect(() => parseKeeperTransitionsResponse(bad)).toThrow(
+      KeeperTransitionsSchemaDriftError,
+    )
+  })
+
+  it('throws when transitions is not an array', () => {
+    const bad = {
+      keeper: 'g',
+      current_phase: null,
+      count: 0,
+      transitions: 'not-an-array',
+    }
+    expect(() => parseKeeperTransitionsResponse(bad)).toThrow(
+      KeeperTransitionsSchemaDriftError,
+    )
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseKeeperTransitionsResponse(null)).toThrow(
+      KeeperTransitionsSchemaDriftError,
+    )
+  })
+})

--- a/dashboard/src/api/schemas/keeper-transitions.test.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.test.ts
@@ -29,8 +29,6 @@ describe('parseKeeperTransitionsResponse', () => {
   })
 
   it('accepts a populated list with opaque selected_event', () => {
-    // selected_event is stored as unknown on purpose — callers render
-    // it for diagnostics only, not for branching.
     const out = parseKeeperTransitionsResponse({
       keeper: 'greeter',
       current_phase: 'Running',
@@ -48,7 +46,7 @@ describe('parseKeeperTransitionsResponse', () => {
     expect(out.transitions[1]!.new_phase).toBe('Running')
   })
 
-  it('accepts null current_phase (just-booted keeper with no decisions yet)', () => {
+  it('accepts null current_phase', () => {
     const out = parseKeeperTransitionsResponse({
       keeper: 'cold-start',
       current_phase: null,
@@ -58,9 +56,7 @@ describe('parseKeeperTransitionsResponse', () => {
     expect(out.current_phase).toBeNull()
   })
 
-  it('accepts unknown phase values (backend evolves new phases ahead of dashboard)', () => {
-    // Phases are open `string()` — a new backend phase should not
-    // brick the transition strip during a backend-ahead deploy window.
+  it('accepts unknown phase values', () => {
     const out = parseKeeperTransitionsResponse({
       keeper: 'g',
       current_phase: 'NovelPhase',

--- a/dashboard/src/api/schemas/keeper-transitions.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.ts
@@ -1,0 +1,74 @@
+/**
+ * Keeper transitions schema — schema-at-boundary for
+ * `GET /api/v1/keepers/:name/transitions`.
+ *
+ * Contract (see dashboard/docs/API_CONTRACT.md):
+ * - Types derived via `InferOutput`; no hand-typed interface remains.
+ * - `fetchKeeperTransitions` passes the response through
+ *   `parseKeeperTransitionsResponse`. Shape drift raises
+ *   `KeeperTransitionsSchemaDriftError` rather than leaving callers
+ *   with `.transitions[0].new_phase` being `undefined`.
+ * - Phase names and outcomes are left as open `string()` because the
+ *   backend emits new values ahead of the dashboard; strict enums here
+ *   would brick the strip / diagram during a backend-ahead deploy
+ *   window. `selected_event` is `unknown()` since downstream already
+ *   treats it opaquely for diagnostics.
+ *
+ * Rolled out as part of #7441 (P2 rollout) following pilot #7439.
+ */
+
+import {
+  array,
+  nullable,
+  number,
+  object,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+export const KeeperTransitionSchema = object({
+  prev_phase: string(),
+  new_phase: string(),
+  selected_event: unknown(),
+  wall_clock_at_decision: number(),
+  transition_outcome: string(),
+})
+
+export const KeeperTransitionsResponseSchema = object({
+  keeper: string(),
+  current_phase: nullable(string()),
+  count: number(),
+  transitions: array(KeeperTransitionSchema),
+})
+
+export type KeeperTransition = InferOutput<typeof KeeperTransitionSchema>
+export type KeeperTransitionsResponse = InferOutput<typeof KeeperTransitionsResponseSchema>
+
+export class KeeperTransitionsSchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .slice(0, 3)
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`keeper transitions schema drift: ${summary}`)
+    this.name = 'KeeperTransitionsSchemaDriftError'
+    this.issues = issues
+  }
+}
+
+export function parseKeeperTransitionsResponse(
+  data: unknown,
+): KeeperTransitionsResponse {
+  const result = safeParse(KeeperTransitionsResponseSchema, data)
+  if (!result.success) {
+    throw new KeeperTransitionsSchemaDriftError(result.issues)
+  }
+  return result.output
+}

--- a/dashboard/src/api/schemas/keeper-transitions.ts
+++ b/dashboard/src/api/schemas/keeper-transitions.ts
@@ -1,21 +1,9 @@
-/**
- * Keeper transitions schema — schema-at-boundary for
- * `GET /api/v1/keepers/:name/transitions`.
- *
- * Contract (see dashboard/docs/API_CONTRACT.md):
- * - Types derived via `InferOutput`; no hand-typed interface remains.
- * - `fetchKeeperTransitions` passes the response through
- *   `parseKeeperTransitionsResponse`. Shape drift raises
- *   `KeeperTransitionsSchemaDriftError` rather than leaving callers
- *   with `.transitions[0].new_phase` being `undefined`.
- * - Phase names and outcomes are left as open `string()` because the
- *   backend emits new values ahead of the dashboard; strict enums here
- *   would brick the strip / diagram during a backend-ahead deploy
- *   window. `selected_event` is `unknown()` since downstream already
- *   treats it opaquely for diagnostics.
- *
- * Rolled out as part of #7441 (P2 rollout) following pilot #7439.
- */
+// Phase names and outcomes are kept open (`string()`) because the
+// backend ships new phase variants ahead of the dashboard. A strict
+// `picklist` here would brick the transition strip and state diagram
+// during a backend-ahead deploy window.
+// `selected_event` stays `unknown()` — callers render it opaquely for
+// diagnostics and never branch on its shape.
 
 import {
   array,
@@ -51,14 +39,13 @@ export class KeeperTransitionsSchemaDriftError extends Error {
   readonly issues: readonly BaseIssue<unknown>[]
   constructor(issues: readonly BaseIssue<unknown>[]) {
     const summary = issues
-      .slice(0, 3)
       .map(issue => {
         const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
         return `${path}: ${issue.message}`
       })
       .join('; ')
     super(`keeper transitions schema drift: ${summary}`)
-    this.name = 'KeeperTransitionsSchemaDriftError'
+    this.name = KeeperTransitionsSchemaDriftError.name
     this.issues = issues
   }
 }
@@ -66,7 +53,10 @@ export class KeeperTransitionsSchemaDriftError extends Error {
 export function parseKeeperTransitionsResponse(
   data: unknown,
 ): KeeperTransitionsResponse {
-  const result = safeParse(KeeperTransitionsResponseSchema, data)
+  // abortEarly bounds both the parse cost and the retained `issues`
+  // array on thrown errors — a 30-transition total-drift payload would
+  // otherwise pin ~150 issue objects per error instance.
+  const result = safeParse(KeeperTransitionsResponseSchema, data, { abortEarly: true })
   if (!result.success) {
     throw new KeeperTransitionsSchemaDriftError(result.issues)
   }


### PR DESCRIPTION
## Summary

Third valibot migration under #7441 P2 rollout. Migrates \`GET /api/v1/keepers/:name/transitions\` to the schema-at-boundary pattern, replacing an **unvalidated raw cast** (\`resp.json() as Promise<...>\`) with a proper parser.

- Adds \`src/api/schemas/keeper-transitions.ts\` — 2 schemas, 2 \`InferOutput\` types, \`KeeperTransitionsSchemaDriftError\`, \`parseKeeperTransitionsResponse\`.
- Updates \`src/api/keeper.ts\` — drops 2 hand-typed interfaces, re-exports the schema types under the same names, routes the fetch through the parser.
- Adds \`src/api/schemas/keeper-transitions.test.ts\` — 7 shape tests.

## Drift policy

- **Phase names stay open \`string()\`** (not \`picklist\`). The backend is the source of phase truth and ships new variants ahead of the dashboard; a strict enum here would brick the transition strip and state diagram during a backend-ahead deploy window. Same reasoning as #7700's \`recent_cycles[].status\` fallback, but expressed as an open domain instead of fallback because there is no \"safe default phase\" — the raw string is already what the dashboard renders.
- **\`selected_event\` stays \`unknown()\`** — callers treat it opaquely for diagnostics only.
- Everything else is strict; drift raises \`KeeperTransitionsSchemaDriftError\`.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/keeper-transitions.test.ts src/api/keeper.test.ts\` — 18/18 pass
- [ ] CI green

## Caller impact

\`components/keeper-state-diagram.ts\` and \`components/keeper-phase-strip.ts\` import \`KeeperTransition\` / \`KeeperTransitionsResponse\` by type name — re-exports keep both call sites unchanged.

Part of #7441.