### PR TITLE
feat(tla): formalize social_state narrative-field cap (Gen15)

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -164,4 +164,25 @@ if [ -d "$BUG_MODELS_DIR" ]; then
   done
 fi
 
+# ── top-level tla/ ─────────────────────────────────────────────
+# Bounded-invariant specs complementing the OCaml cap primitives
+# (keeper_memory_policy, keeper_social_model_types). Same discovery
+# pattern as specs/bug-models above: any .tla with a matching .cfg
+# and/or -buggy.cfg is picked up automatically.
+TLA_DIR="$REPO_ROOT/tla"
+if [ -d "$TLA_DIR" ]; then
+  for tla_path in "$TLA_DIR"/*.tla; do
+    [ -e "$tla_path" ] || continue
+    [ -L "$tla_path" ] && continue
+    tla_name="$(basename "$tla_path")"
+    base="${tla_name%.tla}"
+    if [ -f "$TLA_DIR/${base}.cfg" ]; then
+      run_tlc "$TLA_DIR" "$tla_name"
+    fi
+    if [ -f "$TLA_DIR/${base}-buggy.cfg" ]; then
+      run_tlc_buggy "$TLA_DIR" "$tla_name"
+    fi
+  done
+fi
+
 echo "All TLA+ checks passed."

--- a/tla/SocialStateCap-buggy.cfg
+++ b/tla/SocialStateCap-buggy.cfg
@@ -1,0 +1,10 @@
+\* Buggy: CapHolds MUST be violated. If it passes, the invariant is too
+\* weak to detect an emission path that caps belief_summary but forgets
+\* the option fields (desire / intention / blocker / need).
+SPECIFICATION SpecBuggy
+CONSTANTS
+    BeliefCap = 400
+    OptionCap = 200
+    MaxRaw    = 1000
+    Turns     = 3
+INVARIANT CapHolds

--- a/tla/SocialStateCap.cfg
+++ b/tla/SocialStateCap.cfg
@@ -1,0 +1,10 @@
+\* Clean: CapHolds + PreservesEnum must both pass.
+\* A cap-respecting implementation cannot violate either invariant.
+SPECIFICATION SpecClean
+CONSTANTS
+    BeliefCap = 400
+    OptionCap = 200
+    MaxRaw    = 1000
+    Turns     = 3
+INVARIANT CapHolds
+INVARIANT PreservesEnum

--- a/tla/SocialStateCap.tla
+++ b/tla/SocialStateCap.tla
@@ -1,0 +1,140 @@
+------------------------------ MODULE SocialStateCap ------------------------------
+(* TLA+ spec for the keeper social_state narrative-field cap chain.
+
+   Models the bound established by PR #7692 (Gen8), #7704 (Gen12), and
+   #7709 (Gen13). For every speech model and every entry channel, the
+   emitted social_state must satisfy:
+
+     |belief_summary|        <= BeliefCap
+     |active_desire|         <= OptionCap
+     |current_intention|     <= OptionCap
+     |blocker|               <= OptionCap
+     |need|                  <= OptionCap
+
+   Bug Model pattern (feedback_tla-spec-audit-outcome-trichotomy):
+     Clean cfg: CapHolds + PreservesEnum must both pass
+     Buggy cfg: CapHolds MUST be violated — otherwise the invariant
+                is too weak to catch a cap-free emission path.
+*)
+
+EXTENDS Integers, Sequences, FiniteSets
+
+CONSTANTS
+    BeliefCap,    \* default 400
+    OptionCap,    \* default 200
+    MaxRaw,       \* largest input field length (e.g. 1000)
+    Turns         \* number of turns to model (e.g. 3)
+
+VARIABLES
+    state,        \* record {belief, desire, intention, blocker, need, speech, surface}
+    turn,         \* integer in 0..Turns
+    pc            \* "run" | "done"
+
+vars == <<state, turn, pc>>
+
+\* ── Enum domains ────────────────────────────
+
+Speeches == {"stay_silent", "inform", "request_help", "claim_task"}
+Surfaces == {"silent", "visible_reply", "board_post", "task_claim"}
+
+\* ── Cap primitive ──────────────────────────
+
+\* Minimum preserves Idempotence: capped twice == capped once.
+Cap(n, bound) == IF n <= bound THEN n ELSE bound
+
+\* ── Clean emission: bounded by construction ─
+
+EmitClean(raw) ==
+    [ belief     |-> Cap(raw.belief,    BeliefCap),
+      desire     |-> Cap(raw.desire,    OptionCap),
+      intention  |-> Cap(raw.intention, OptionCap),
+      blocker    |-> Cap(raw.blocker,   OptionCap),
+      need       |-> Cap(raw.need,      OptionCap),
+      speech     |-> raw.speech,
+      surface    |-> raw.surface ]
+
+\* ── Buggy emission: caps belief only, forgets option fields ─
+
+EmitBuggy(raw) ==
+    [ belief     |-> Cap(raw.belief,    BeliefCap),
+      desire     |-> raw.desire,
+      intention  |-> raw.intention,
+      blocker    |-> raw.blocker,
+      need       |-> raw.need,
+      speech     |-> raw.speech,
+      surface    |-> raw.surface ]
+
+\* ── Arbitrary raw input per turn ─
+
+\* Finite reduction: model each numeric field by a representative
+\* size from each regime (below cap / at cap / above cap / much
+\* above cap). Keeps the state space tractable while covering
+\* every meaningful branch of Cap.
+BeliefSizes == {0, 1, BeliefCap, BeliefCap + 1, MaxRaw}
+OptionSizes == {0, 1, OptionCap, OptionCap + 1, MaxRaw}
+
+RawInputs ==
+    [ belief:    BeliefSizes,
+      desire:    OptionSizes,
+      intention: OptionSizes,
+      blocker:   OptionSizes,
+      need:      OptionSizes,
+      speech:    Speeches,
+      surface:   Surfaces ]
+
+InitialState ==
+    [ belief |-> 0, desire |-> 0, intention |-> 0,
+      blocker |-> 0, need |-> 0,
+      speech |-> "stay_silent", surface |-> "silent" ]
+
+\* ── Init ───────────────────────────────────
+
+Init ==
+    /\ state = InitialState
+    /\ turn = 0
+    /\ pc = "run"
+
+\* ── Next (clean): each turn emits a new state from arbitrary raw input ─
+
+StepClean ==
+    /\ pc = "run"
+    /\ turn < Turns
+    /\ \E raw \in RawInputs:
+        state' = EmitClean(raw)
+    /\ turn' = turn + 1
+    /\ pc' = IF turn + 1 = Turns THEN "done" ELSE "run"
+
+\* ── Next (buggy): same but uses EmitBuggy ─
+
+StepBuggy ==
+    /\ pc = "run"
+    /\ turn < Turns
+    /\ \E raw \in RawInputs:
+        state' = EmitBuggy(raw)
+    /\ turn' = turn + 1
+    /\ pc' = IF turn + 1 = Turns THEN "done" ELSE "run"
+
+NextClean == StepClean \/ (pc = "done" /\ UNCHANGED vars)
+NextBuggy == StepBuggy \/ (pc = "done" /\ UNCHANGED vars)
+
+SpecClean == Init /\ [][NextClean]_vars
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+\* ── Safety invariants ─────────────────────
+
+CapHolds ==
+    /\ state.belief    <= BeliefCap
+    /\ state.desire    <= OptionCap
+    /\ state.intention <= OptionCap
+    /\ state.blocker   <= OptionCap
+    /\ state.need      <= OptionCap
+
+PreservesEnum ==
+    /\ state.speech  \in Speeches
+    /\ state.surface \in Surfaces
+
+\* ── Liveness ───────────────────────────────
+
+Terminates == <>(pc = "done")
+
+================================================================================


### PR DESCRIPTION
## Gen15 — TLA+ spec for the Gen8/12/13 bounded invariant

Independent of the OCaml chain (#7692, #7704, #7709). Runs in the existing TLA+ Model Checking CI job.

### Contract

For every speech model (BDI v1 ∪ Magentic v1) and every entry channel (live turn ∪ checkpoint load), every emitted `social_state` must satisfy:

```
|belief_summary|                        <= 400
|active_desire| |current_intention|
|blocker|       |need|                  <= 200
```

`tla/SocialStateCap.tla` models a keeper that emits one state per turn from arbitrary raw inputs (sizes chosen from {0, 1, cap, cap+1, MaxRaw}). Two specs:

- **SpecClean** — `EmitClean` caps every field (matches Gen8/13 implementation)
- **SpecBuggy** — `EmitBuggy` caps `belief` only (matches a regression where somebody adds a new speech model but forgets the option-field caps)

### Verification (local TLC, tla2tools-1.8.0)

```
Clean:  11,665 distinct states, depth 4, no invariant violation  (3m 09s)
Buggy:  CapHolds violated after 113 distinct states              (<1s)
```

Matches the outcome trichotomy from `feedback_tla-spec-audit-outcome-trichotomy`: clean passes and buggy fails, so the invariant has enough teeth to catch the intended class of bug.

### Bonus: discovery gap closed

`scripts/tla-check.sh` previously never walked the top-level `tla/` directory. `tla/CheckpointTrim.tla` had been orphaned since inception (`grep -rn CheckpointTrim` returned only the file itself). The new auto-discovery block wires both `CheckpointTrim` and `SocialStateCap` into CI without further manual registration. Any future top-level spec with a matching `.cfg` / `-buggy.cfg` picks up for free.

### Why a separate PR

Stack independence — Gen15 touches no OCaml. TLA+ Model Checking CI job validates it in isolation and future reviewers can evaluate it without re-reading the code PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)