### PR TITLE
feat(server): fleet composite endpoint /api/v1/keepers/composite (LT-16a)

### DIFF
--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -406,6 +406,15 @@ let observe
        | None -> None);
   }
 
+(* Fleet fold — observe every currently-registered keeper under
+   [base_path] once. Preserves registry iteration order so downstream
+   matrix rendering stays stable across successive polls.
+
+   Used by GET /api/v1/keepers/composite (LT-16a). *)
+let all_snapshots ~(base_path : string) () : snapshot list =
+  Keeper_registry.all ~base_path ()
+  |> List.map (fun entry -> observe entry)
+
 (* JSON serialisation (RFC-0003 §7) *)
 
 let invariants_to_json (inv : invariants_check) : Yojson.Safe.t =

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -160,6 +160,11 @@ val observe :
   Keeper_registry.registry_entry ->
   snapshot
 
+(** Observe every registered keeper under [base_path] once. Used by
+    [GET /api/v1/keepers/composite] to render fleet-level matrices
+    (LT-16a). Preserves registry iteration order. *)
+val all_snapshots : base_path:string -> unit -> snapshot list
+
 (** Stringify [turn_phase] for JSON serialisation. Mirrors the lowercase
     edge labels used in KeeperTurnCycle.tla. *)
 val ksm_phase_to_string : ksm_phase -> string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1200,6 +1200,35 @@ let handle_keeper_get_subroutes state req request reqd =
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if req_path = prefix ^ "composite" then
+    (* LT-16a: fleet-wide composite snapshot. Enumerates every
+       registered keeper via [Keeper_registry.all] and projects each
+       through [Keeper_composite_observer.observe]. Same purity
+       contract as the per-keeper route below.
+
+       Shape:
+         { "generated_at": 1234567890.1,
+           "count": 3,
+           "snapshots": [ <snapshot JSON>, ... ] }
+
+       Consumed by [dashboard/src/components/fleet-fsm-matrix.ts]
+       (LT-16b, upcoming). *)
+    let base_path = state.Mcp_server.room_config.base_path in
+    let snapshots =
+      Keeper_composite_observer.all_snapshots ~base_path ()
+    in
+    let json =
+      `Assoc [
+        "generated_at", `Float (Unix.gettimeofday ());
+        "count", `Int (List.length snapshots);
+        "snapshots",
+          `List
+            (List.map
+               Keeper_composite_observer.snapshot_to_json snapshots);
+      ]
+    in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
   else if ends_with "/composite" then
     (* RFC-0003 §7: composite lifecycle snapshot derived from the
        registry entry via the [Keeper_composite_observer] pure


### PR DESCRIPTION
## Summary

Backend endpoint for the fleet-level FSM matrix designed in LT-12 (#7689). +43 LOC across 3 files.

## Shape

\`\`\`
GET /api/v1/keepers/composite
{
  "generated_at": 1713384000.123,
  "count": 3,
  "snapshots": [ <same shape as /api/v1/keepers/<name>/composite>, ... ]
}
\`\`\`

Each element is identical to the per-keeper snapshot JSON (reuses \`snapshot_to_json\`), so the frontend can share a valibot schema between the two endpoints.

## Implementation

- \`Keeper_composite_observer.all_snapshots ~base_path () : snapshot list\` — registry fold, preserves insertion order.
- New if-branch in \`handle_keeper_get_subroutes\` matched by \`req_path = prefix ^ "composite"\` (exact path, no trailing name). Path-disjoint from the existing \`ends_with "/composite"\` route, so placement in the dispatch chain is cosmetic.

## Purity contract

Same as the per-keeper route — no mutation, no I/O, no provider/token access. Each call re-evaluates invariants, so fleet polling drives the \`masc_keeper_invariant_violations_total\` counter introduced in #7708 (LT-13). That is the intended poll-triggered behaviour.

## Explicit non-goals

- Frontend (LT-16b) lands in a follow-up PR: schema + \`fetchKeepersComposite\` + \`FleetFsmMatrix\` component + tests.
- No backend unit test in this PR; will either follow on 16b or come in a dedicated test-only PR.

## Test plan

- [x] \`dune build --root .\` — passes.
- [ ] CI \`dune runtest\` — pending.
- [ ] Smoke — \`curl -s http://localhost:PORT/api/v1/keepers/composite | jq .count\` returns the registry size.

## References

- #7689 (LT-12) — design doc §3 surface list.
- #7703 (LT-15) — spec↔code drift audit, confirms matrix reads raw phase.
- #7708 (LT-13) — invariant counter the polling feeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)