### PR TITLE
docs(spec): drop server_h2_gateway_routes_cp.ml row (file absent)

### DIFF
--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -845,7 +845,6 @@ sequenceDiagram
 | `server_mcp_transport_http_headers.ml` | 204 | HTTP 헤더 유틸리티 |
 | `server_mcp_transport_http_protocol.ml` | 135 | 프로토콜 버전/세션 유효성 |
 | `server_h2_gateway.ml` | 740 | HTTP/2 게이트웨이 (전체 라우팅) |
-| `server_h2_gateway_routes_cp.ml` | 579 | H2 Command Plane 라우트 |
 | `server_h2_gateway_routes_extra.ml` | 171 | H2 추가 라우트 |
 | `server_mcp_transport_ws.ml` | 160 | WebSocket 트랜스포트 |
 | `server_webrtc_transport.ml` | 183 | WebRTC signaling |


### PR DESCRIPTION
## Summary

`lib/server/server_h2_gateway_routes_cp.ml` does not exist on disk — another CP-purge drift residue in specs. Single row removal from 09-server-transport.md section 18.2.

## Change

```diff
 | `server_h2_gateway.ml` | 740 | HTTP/2 게이트웨이 (전체 라우팅) |
-| `server_h2_gateway_routes_cp.ml` | 579 | H2 Command Plane 라우트 |
 | `server_h2_gateway_routes_extra.ml` | 171 | H2 추가 라우트 |
```

## Why this row is drift while the next-but-one row is kept

Line 855 in the same table, `server_command_plane_http.ml | 56 | Retired compatibility lane removed-surface responder`, is **required** by `scripts/check-doc-truth.sh:108`. That row is an intentional claim-removal SSOT: the file is absent, but the doc explicitly records that "this surface was retired", which is what downstream readers need. The `routes_cp.ml` row says nothing about being retired — it just asserts the file exists. Drift, not SSOT.

## Verification

- `find lib -name server_h2_gateway_routes_cp.ml` → 0 results
- `lib/server/server_h2_gateway_routes_extra.ml` — exists (kept)
- `lib/server/server_h2_gateway.ml` — exists, actual 733 LOC vs docs' 740 (close enough; separate LOC-truth PR)
- `scripts/check-doc-truth.sh` does not mention `routes_cp.ml` (grep confirms)
- Local `bash scripts/check-doc-truth.sh` passes

## Companion to #7715

Same cleanup theme (post-CP-purge doc drift). This PR is a single-file single-line change, split out to keep #7715's review diff focused.