### PR TITLE
feat(dashboard/api): migrate keeper chat history endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -11,6 +11,10 @@ import {
   parseKeeperCompositeSnapshot,
   type KeeperCompositeSnapshot,
 } from './schemas/keeper-composite'
+import {
+  safeParseKeeperChatHistoryMessage,
+  type KeeperChatHistoryMessage,
+} from './schemas/keeper-chat-history'
 
 export type {
   KeeperCompositeSnapshot,
@@ -28,6 +32,11 @@ export {
   parseKeeperCompositeSnapshot,
   CompositeSchemaDriftError,
 } from './schemas/keeper-composite'
+export type { KeeperChatHistoryMessage } from './schemas/keeper-chat-history'
+export {
+  KeeperChatHistoryMessageSchema,
+  safeParseKeeperChatHistoryMessage,
+} from './schemas/keeper-chat-history'
 
 // --- Types ---
 
@@ -206,12 +215,6 @@ export async function streamKeeperMessage(
 
 // --- Chat history ---
 
-export interface KeeperChatHistoryMessage {
-  role: string
-  content: string
-  ts: number
-}
-
 export async function fetchKeeperChatHistory(
   name: string,
 ): Promise<KeeperChatHistoryMessage[]> {
@@ -223,13 +226,12 @@ export async function fetchKeeperChatHistory(
     if (!resp.ok) return []
     const data: unknown = await resp.json()
     if (!Array.isArray(data)) return []
-    return data.filter(
-      (m): m is KeeperChatHistoryMessage =>
-        isRecord(m) &&
-        typeof m.role === 'string' &&
-        typeof m.content === 'string' &&
-        typeof m.ts === 'number',
-    )
+    // Per-item safeParse: drop invalid entries silently to match the prior
+    // hand-rolled type guard. Individual failures are non-fatal; operators
+    // keep seeing a clean transcript during backend drift windows.
+    return data
+      .map(safeParseKeeperChatHistoryMessage)
+      .filter((m): m is KeeperChatHistoryMessage => m !== null)
   } catch {
     return []
   }

--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  safeParseKeeperChatHistoryMessage,
+  type KeeperChatHistoryMessage,
+} from './keeper-chat-history'
+
+function validMessage(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    role: 'user',
+    content: 'hello keeper',
+    ts: 1_712_000_000.25,
+    ...overrides,
+  }
+}
+
+describe('safeParseKeeperChatHistoryMessage', () => {
+  it('accepts a well-formed message and returns a typed output', () => {
+    const out = safeParseKeeperChatHistoryMessage(validMessage())
+    expect(out).not.toBeNull()
+    expect(out?.role).toBe('user')
+    expect(out?.content).toBe('hello keeper')
+    expect(out?.ts).toBeCloseTo(1_712_000_000.25)
+  })
+
+  it('accepts unknown role strings (open enum for backend-ahead deploys)', () => {
+    const out = safeParseKeeperChatHistoryMessage(
+      validMessage({ role: 'tool-result-v2' }),
+    )
+    expect(out?.role).toBe('tool-result-v2')
+  })
+
+  it('returns null when a required field is missing', () => {
+    const { ts: _ts, ...withoutTs } = validMessage()
+    expect(safeParseKeeperChatHistoryMessage(withoutTs)).toBeNull()
+  })
+
+  it('returns null when a field has the wrong type', () => {
+    expect(
+      safeParseKeeperChatHistoryMessage(validMessage({ ts: '1712000000' })),
+    ).toBeNull()
+    expect(
+      safeParseKeeperChatHistoryMessage(validMessage({ content: 42 })),
+    ).toBeNull()
+  })
+
+  it('returns null for non-object inputs', () => {
+    expect(safeParseKeeperChatHistoryMessage(null)).toBeNull()
+    expect(safeParseKeeperChatHistoryMessage('string')).toBeNull()
+    expect(safeParseKeeperChatHistoryMessage(42)).toBeNull()
+    expect(safeParseKeeperChatHistoryMessage(undefined)).toBeNull()
+  })
+
+  it('composes in a filter chain — drops garbage entries silently', () => {
+    const raw: unknown[] = [
+      validMessage(),
+      validMessage({ role: 'assistant', content: 'hi', ts: 1 }),
+      { role: 'user', content: 'missing ts' },
+      'not an object',
+      null,
+      validMessage({ role: 'system', content: 'bye', ts: 2 }),
+    ]
+    const cleaned = raw
+      .map(safeParseKeeperChatHistoryMessage)
+      .filter((m): m is KeeperChatHistoryMessage => m !== null)
+    expect(cleaned).toHaveLength(3)
+    expect(cleaned.map(m => m.role)).toEqual(['user', 'assistant', 'system'])
+  })
+})

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -1,0 +1,40 @@
+/**
+ * Keeper chat history schema — schema-at-boundary for
+ * `GET /api/v1/keepers/:name/chat/history`.
+ *
+ * Contract (see dashboard/docs/API_CONTRACT.md):
+ * - Types derived via `InferOutput`; no hand-typed interface remains.
+ * - The endpoint returns a list whose individual items may drift; the
+ *   existing caller silently drops garbage entries so operators keep
+ *   seeing a clean transcript. We preserve that behaviour here with a
+ *   per-item `safeParse` helper — no drift error class is needed since
+ *   individual failures are non-fatal.
+ * - `role` is left as open `string()` because the backend can introduce
+ *   a new role (e.g. a new tool role) ahead of the dashboard; a strict
+ *   enum would silently drop valid messages during the deploy window.
+ *
+ * Rolled out as part of #7441 (P2 rollout) following pilot #7439.
+ */
+
+import {
+  number,
+  object,
+  safeParse,
+  string,
+  type InferOutput,
+} from 'valibot'
+
+export const KeeperChatHistoryMessageSchema = object({
+  role: string(),
+  content: string(),
+  ts: number(),
+})
+
+export type KeeperChatHistoryMessage = InferOutput<typeof KeeperChatHistoryMessageSchema>
+
+export function safeParseKeeperChatHistoryMessage(
+  data: unknown,
+): KeeperChatHistoryMessage | null {
+  const result = safeParse(KeeperChatHistoryMessageSchema, data)
+  return result.success ? result.output : null
+}


### PR DESCRIPTION
## Summary
Migrates `GET /api/v1/keepers/:name/chat/history` (`fetchKeeperChatHistory`) to the schema-at-boundary pattern established by pilot #7439 and continued in #7700 / #7710 / #7720. Part of #7441 P2 rollout.

## Changes
- `dashboard/src/api/schemas/keeper-chat-history.ts` — new `KeeperChatHistoryMessageSchema`, `KeeperChatHistoryMessage` type via `InferOutput`, `safeParseKeeperChatHistoryMessage` helper returning `T | null`.
- `dashboard/src/api/keeper.ts` — removes the local `KeeperChatHistoryMessage` interface, re-exports the type from the schema module, and rewrites `fetchKeeperChatHistory` to use per-item `safeParse` in a `map(...).filter(Boolean)` chain. No other code in this file touched (stays out of the way of #7720 which edits lines 505-518).
- `dashboard/src/api/schemas/keeper-chat-history.test.ts` — 6 shape tests (valid / open role / missing field / wrong type / non-object / filter-chain composition).

## Drift policy
This endpoint returns a list where the prior caller silently dropped garbage entries with a hand-rolled type guard. We preserve that behaviour — individual item failures are non-fatal, so no drift error class is introduced. `role` stays an open `string()` since the backend can ship a new role ahead of the dashboard; a strict enum would silently drop valid messages during the deploy window.

## LOC
- `keeper-chat-history.ts`: 40 lines
- `keeper-chat-history.test.ts`: 69 lines
- `keeper.ts`: +15 / -13 (net +2)

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/api/schemas/keeper-chat-history.test.ts src/api/keeper.test.ts` — 17/17 pass
- [ ] CI green on PR

Part of #7441.