### PR TITLE
feat(dashboard/api): migrate activity endpoints to valibot schemas

### DIFF
--- a/dashboard/src/api/actions.ts
+++ b/dashboard/src/api/actions.ts
@@ -1,6 +1,12 @@
 import { post, fetchWithTimeout } from './core'
 import { ACTIVITY_TIMEOUT_MS } from '../config/constants'
 import { callMcpTool } from './mcp'
+import {
+  parseActivityGraphResponse,
+  parseSwimlaneResponse,
+  type ActivityGraphResponse,
+  type SwimlaneResponse,
+} from './schemas/actions-activity'
 
 // --- Control Dock ---
 
@@ -28,24 +34,24 @@ export async function fetchTaskHistory(taskId: string, limit = 20): Promise<stri
 
 // --- Activity Graph ---
 
-export async function fetchActivityGraph(since?: string): Promise<import('../types').ActivityGraphResponse | null> {
+export async function fetchActivityGraph(since?: string): Promise<ActivityGraphResponse | null> {
   try {
     const params = since ? `?since=${since}` : ''
     const resp = await fetchWithTimeout(`/api/v1/activity/graph${params}`, {}, ACTIVITY_TIMEOUT_MS)
     if (!resp.ok) return null
-    return (await resp.json()) as import('../types').ActivityGraphResponse
+    return parseActivityGraphResponse(await resp.json())
   } catch (err) {
     console.debug('[activity] graph fetch failed', err instanceof Error ? err.message : err)
     return null
   }
 }
 
-export async function fetchSwimlane(since?: string): Promise<import('../types').SwimlaneResponse | null> {
+export async function fetchSwimlane(since?: string): Promise<SwimlaneResponse | null> {
   try {
     const params = since ? `?since=${since}` : ''
     const resp = await fetchWithTimeout(`/api/v1/activity/swimlane${params}`, {}, ACTIVITY_TIMEOUT_MS)
     if (!resp.ok) return null
-    return (await resp.json()) as import('../types').SwimlaneResponse
+    return parseSwimlaneResponse(await resp.json())
   } catch (err) {
     console.debug('[activity] swimlane fetch failed', err instanceof Error ? err.message : err)
     return null

--- a/dashboard/src/api/schemas/actions-activity.test.ts
+++ b/dashboard/src/api/schemas/actions-activity.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ActionsActivitySchemaDriftError,
+  parseActivityGraphResponse,
+  parseSwimlaneResponse,
+} from './actions-activity'
+
+function validGraph(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    nodes: [
+      {
+        id: 'agent:claude',
+        label: 'claude',
+        weight: 3,
+        kind: 'agent',
+        status: 'active',
+      },
+    ],
+    edges: [
+      {
+        source: 'agent:claude',
+        target: 'task:abc',
+        kind: 'claimed',
+        weight: 1,
+        active: true,
+      },
+    ],
+    stats: { event_count: 42, node_count: 7 },
+    kind_counts: { task: 3, message: 10 },
+    heatmap: {
+      matrix: [[0, 1], [2, 0]],
+      max: 2,
+      total: 3,
+    },
+    timeline: [
+      {
+        kind: 'task.done',
+        actor: { agent: 'claude' },
+        summary: 'finished something',
+        subject: { id: 'task:abc', type: 'task' },
+        ts: 1_712_000_000,
+        ts_iso: '2026-04-01T00:00:00Z',
+        seq: 1,
+        room_id: 'main',
+        tags: ['done'],
+        payload: { note: 'ok' },
+      },
+    ],
+    generated_at: '2026-04-17T00:00:00Z',
+    window: { limit: 500, room_id: null, kinds: [] },
+    ...overrides,
+  }
+}
+
+function validSwimlane(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agents: ['claude', 'codex'],
+    spans: [
+      {
+        agent: 'claude',
+        start_ms: 1_712_000_000_000,
+        end_ms: 1_712_000_001_000,
+        kind: 'turn',
+        label: 'prompt',
+        status: 'done',
+      },
+    ],
+    time_range: { min_ms: 1_712_000_000_000, max_ms: 1_712_000_001_000 },
+    ...overrides,
+  }
+}
+
+describe('parseActivityGraphResponse', () => {
+  it('accepts a minimal valid payload without stats_history', () => {
+    const out = parseActivityGraphResponse(validGraph())
+    expect(out.nodes).toHaveLength(1)
+    expect(out.edges).toHaveLength(1)
+    expect(out.stats.event_count).toBe(42)
+    expect(out.stats_history).toBeUndefined()
+  })
+
+  it('accepts optional stats_history and node.semantic_weight', () => {
+    const out = parseActivityGraphResponse(
+      validGraph({
+        nodes: [
+          {
+            id: 'agent:claude',
+            label: 'claude',
+            weight: 3,
+            semantic_weight: 0.42,
+            kind: 'agent',
+            status: 'active',
+            last_event_at: '2026-04-17T00:00:00Z',
+            meta: { foo: 'bar' },
+          },
+        ],
+        stats_history: [
+          { bucket: 0, events: 10, active_agents: 2, tasks_done: 1 },
+          { bucket: 1, events: 5, active_agents: 3, tasks_done: 0 },
+        ],
+      }),
+    )
+    expect(out.nodes[0]!.semantic_weight).toBe(0.42)
+    expect(out.stats_history).toHaveLength(2)
+  })
+
+  it('accepts unknown node.kind and node.status (open enum policy)', () => {
+    const out = parseActivityGraphResponse(
+      validGraph({
+        nodes: [
+          {
+            id: 'n',
+            label: 'novel',
+            weight: 1,
+            kind: 'novel_kind_from_backend',
+            status: 'novel_status',
+          },
+        ],
+      }),
+    )
+    expect(out.nodes[0]!.kind).toBe('novel_kind_from_backend')
+    expect(out.nodes[0]!.status).toBe('novel_status')
+  })
+
+  it('throws when a required field is missing', () => {
+    const bad = validGraph()
+    delete (bad as Record<string, unknown>).generated_at
+    expect(() => parseActivityGraphResponse(bad)).toThrow(ActionsActivitySchemaDriftError)
+  })
+
+  it('throws when heatmap.matrix contains non-numbers', () => {
+    const bad = validGraph({
+      heatmap: { matrix: [['not-a-number']], max: 0, total: 0 },
+    })
+    expect(() => parseActivityGraphResponse(bad)).toThrow(ActionsActivitySchemaDriftError)
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseActivityGraphResponse(null)).toThrow(ActionsActivitySchemaDriftError)
+    expect(() => parseActivityGraphResponse('string')).toThrow(ActionsActivitySchemaDriftError)
+  })
+
+  it('tags thrown errors with the graph endpoint', () => {
+    try {
+      parseActivityGraphResponse({})
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ActionsActivitySchemaDriftError)
+      expect((err as ActionsActivitySchemaDriftError).endpoint).toBe('graph')
+    }
+  })
+})
+
+describe('parseSwimlaneResponse', () => {
+  it('accepts a valid swimlane payload', () => {
+    const out = parseSwimlaneResponse(validSwimlane())
+    expect(out.agents).toEqual(['claude', 'codex'])
+    expect(out.spans).toHaveLength(1)
+    expect(out.time_range.min_ms).toBe(1_712_000_000_000)
+  })
+
+  it('throws when spans is not an array', () => {
+    const bad = validSwimlane({ spans: 'not-an-array' })
+    expect(() => parseSwimlaneResponse(bad)).toThrow(ActionsActivitySchemaDriftError)
+  })
+
+  it('tags thrown errors with the swimlane endpoint', () => {
+    try {
+      parseSwimlaneResponse({})
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ActionsActivitySchemaDriftError)
+      expect((err as ActionsActivitySchemaDriftError).endpoint).toBe('swimlane')
+    }
+  })
+})

--- a/dashboard/src/api/schemas/actions-activity.ts
+++ b/dashboard/src/api/schemas/actions-activity.ts
@@ -1,0 +1,188 @@
+/**
+ * Activity endpoint schemas — schema-at-boundary for
+ * `/api/v1/activity/graph` and `/api/v1/activity/swimlane`.
+ *
+ * Contract (see dashboard/docs/API_CONTRACT.md):
+ * - TS types are derived via `InferOutput<typeof Schema>` — no hand-typed
+ *   interfaces in `src/types/sse.ts` for these responses anymore.
+ * - `fetchActivityGraph` / `fetchSwimlane` route every response through
+ *   `parseActivityGraphResponse` / `parseSwimlaneResponse`. Shape drift
+ *   from the backend raises `ActionsActivitySchemaDriftError`, which
+ *   the callers log (`console.debug`) and translate to `null` — the
+ *   pre-existing "fetch failure" contract already used by every caller
+ *   of these two functions.
+ *
+ * Rolled out as part of #7441 (P2 rollout).
+ */
+
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  optional,
+  record,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+// Node / edge `kind` and `status` stay open `string()`. They're
+// backend-evolved enumerations (new agent kinds, new lifecycle states)
+// and the dashboard renders them via a best-effort label/color lookup
+// with string fallback — a strict `picklist` here would brick the
+// whole graph during a backend-ahead deploy window.
+export const ActivityGraphNodeSchema = object({
+  id: string(),
+  label: string(),
+  weight: number(),
+  semantic_weight: optional(number()),
+  kind: string(),
+  status: string(),
+  last_event_at: optional(string()),
+  meta: optional(record(string(), unknown())),
+})
+
+export const ActivityGraphEdgeSchema = object({
+  id: optional(string()),
+  source: string(),
+  target: string(),
+  kind: string(),
+  weight: number(),
+  active: boolean(),
+  last_event_at: optional(string()),
+  meta: optional(record(string(), unknown())),
+})
+
+// Timeline events are opaque to the schema layer: `actor`, `subject`,
+// `payload`, `tags` are passed through to renderers that treat them as
+// display-only / diagnostic. Enforcing a stricter shape would force
+// the schema to track every backend event variant.
+export const ActivityGraphTimelineEventSchema = object({
+  kind: string(),
+  actor: record(string(), unknown()),
+  summary: string(),
+  subject: nullable(
+    object({
+      id: string(),
+      type: string(),
+    }),
+  ),
+  ts: number(),
+  ts_iso: string(),
+  seq: number(),
+  room_id: string(),
+  tags: array(string()),
+  payload: record(string(), unknown()),
+})
+
+// `stats` and `kind_counts` are open number-valued maps — the backend
+// adds new counters (per-tool, per-category) without coordinating the
+// dashboard release. Consumers read specific keys defensively
+// (`stats.event_count ?? 0`), so an open `record` keeps new keys
+// visible without churning this schema on every backend addition.
+export const ActivityGraphStatsSchema = record(string(), number())
+
+export const ActivityGraphKindCountsSchema = record(string(), number())
+
+export const ActivityGraphHeatmapSchema = object({
+  matrix: array(array(number())),
+  max: number(),
+  total: number(),
+})
+
+export const ActivityGraphWindowSchema = object({
+  limit: number(),
+  room_id: nullable(string()),
+  kinds: array(string()),
+})
+
+export const ActivityGraphStatsHistoryEntrySchema = object({
+  bucket: number(),
+  events: number(),
+  active_agents: number(),
+  tasks_done: number(),
+})
+
+export const ActivityGraphResponseSchema = object({
+  nodes: array(ActivityGraphNodeSchema),
+  edges: array(ActivityGraphEdgeSchema),
+  stats: ActivityGraphStatsSchema,
+  kind_counts: ActivityGraphKindCountsSchema,
+  heatmap: ActivityGraphHeatmapSchema,
+  timeline: array(ActivityGraphTimelineEventSchema),
+  generated_at: string(),
+  window: ActivityGraphWindowSchema,
+  stats_history: optional(array(ActivityGraphStatsHistoryEntrySchema)),
+})
+
+// Swimlane span `kind` / `status` are free-form for the same reason
+// as the graph node's status above: operators render them via a
+// label/color lookup that falls back to the raw string.
+export const AgentSpanSchema = object({
+  agent: string(),
+  start_ms: number(),
+  end_ms: number(),
+  kind: string(),
+  label: string(),
+  status: string(),
+})
+
+export const SwimlaneResponseSchema = object({
+  agents: array(string()),
+  spans: array(AgentSpanSchema),
+  time_range: object({
+    min_ms: number(),
+    max_ms: number(),
+  }),
+})
+
+export type ActivityGraphNode = InferOutput<typeof ActivityGraphNodeSchema>
+export type ActivityGraphEdge = InferOutput<typeof ActivityGraphEdgeSchema>
+export type ActivityGraphTimelineEvent = InferOutput<typeof ActivityGraphTimelineEventSchema>
+export type ActivityGraphStats = InferOutput<typeof ActivityGraphStatsSchema>
+export type ActivityGraphKindCounts = InferOutput<typeof ActivityGraphKindCountsSchema>
+export type ActivityGraphHeatmap = InferOutput<typeof ActivityGraphHeatmapSchema>
+export type ActivityGraphResponse = InferOutput<typeof ActivityGraphResponseSchema>
+export type AgentSpan = InferOutput<typeof AgentSpanSchema>
+export type SwimlaneResponse = InferOutput<typeof SwimlaneResponseSchema>
+
+export class ActionsActivitySchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  readonly endpoint: 'graph' | 'swimlane'
+  constructor(endpoint: 'graph' | 'swimlane', issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .slice(0, 3)
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`activity ${endpoint} schema drift: ${summary}`)
+    this.name = ActionsActivitySchemaDriftError.name
+    this.endpoint = endpoint
+    this.issues = issues
+  }
+}
+
+// abortEarly: both payloads carry unbounded arrays (timeline, spans,
+// nodes, edges). A total-drift response would otherwise retain
+// thousands of issue objects per error instance.
+export function parseActivityGraphResponse(data: unknown): ActivityGraphResponse {
+  const result = safeParse(ActivityGraphResponseSchema, data, { abortEarly: true })
+  if (!result.success) {
+    throw new ActionsActivitySchemaDriftError('graph', result.issues)
+  }
+  return result.output
+}
+
+export function parseSwimlaneResponse(data: unknown): SwimlaneResponse {
+  const result = safeParse(SwimlaneResponseSchema, data, { abortEarly: true })
+  if (!result.success) {
+    throw new ActionsActivitySchemaDriftError('swimlane', result.issues)
+  }
+  return result.output
+}

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -215,54 +215,32 @@ export const VALID_TABS: TabId[] = [
 ]
 
 // --- Activity Graph types ---
+// The response shapes for `/api/v1/activity/graph` and
+// `/api/v1/activity/swimlane` are defined as valibot schemas in
+// `src/api/schemas/actions-activity.ts`; re-exported here so the
+// barrel (`src/types.ts`) surface stays stable for consumers.
+import type {
+  ActivityGraphNode,
+  ActivityGraphEdge,
+  ActivityGraphTimelineEvent,
+  ActivityGraphStats,
+  ActivityGraphHeatmap,
+  ActivityGraphKindCounts,
+  ActivityGraphResponse,
+  AgentSpan,
+  SwimlaneResponse,
+} from '../api/schemas/actions-activity'
 
-export interface ActivityGraphNode {
-  id: string
-  label: string
-  weight: number
-  semantic_weight?: number
-  kind: string
-  status: string
-  last_event_at?: string
-  meta?: Record<string, unknown>
-}
-
-export interface ActivityGraphEdge {
-  id?: string
-  source: string
-  target: string
-  kind: string
-  weight: number
-  active: boolean
-  last_event_at?: string
-  meta?: Record<string, unknown>
-}
-
-export interface ActivityGraphTimelineEvent {
-  kind: string
-  actor: Record<string, unknown>
-  summary: string
-  subject: { id: string; type: string } | null
-  ts: number
-  ts_iso: string
-  seq: number
-  room_id: string
-  tags: string[]
-  payload: Record<string, unknown>
-}
-
-export interface ActivityGraphStats {
-  [key: string]: number
-}
-
-export interface ActivityGraphHeatmap {
-  matrix: number[][]
-  max: number
-  total: number
-}
-
-export interface ActivityGraphKindCounts {
-  [kind: string]: number
+export type {
+  ActivityGraphNode,
+  ActivityGraphEdge,
+  ActivityGraphTimelineEvent,
+  ActivityGraphStats,
+  ActivityGraphHeatmap,
+  ActivityGraphKindCounts,
+  ActivityGraphResponse,
+  AgentSpan,
+  SwimlaneResponse,
 }
 
 export type ActivityCategory =
@@ -288,31 +266,7 @@ export interface ActionTimelineGroup {
   rawEvents: ActivityGraphTimelineEvent[]
 }
 
-export interface ActivityGraphResponse {
-  nodes: ActivityGraphNode[]
-  edges: ActivityGraphEdge[]
-  stats: ActivityGraphStats
-  kind_counts: ActivityGraphKindCounts
-  heatmap: ActivityGraphHeatmap
-  timeline: ActivityGraphTimelineEvent[]
-  generated_at: string
-  window: { limit: number; room_id: string | null; kinds: string[] }
-  stats_history?: Array<{ bucket: number; events: number; active_agents: number; tasks_done: number }>
-}
-
 // --- Swimlane types ---
-
-export interface AgentSpan {
-  agent: string
-  start_ms: number
-  end_ms: number
-  kind: string
-  label: string
-  status: string
-}
-
-export interface SwimlaneResponse {
-  agents: string[]
-  spans: AgentSpan[]
-  time_range: { min_ms: number; max_ms: number }
-}
+// `AgentSpan` and `SwimlaneResponse` are re-exported above from the
+// schema file. Keep this divider so future activity-related local
+// types have a clear section.


### PR DESCRIPTION
## Summary

Fourth valibot migration under #7441 P2 rollout. Migrates `GET /api/v1/activity/graph` and `GET /api/v1/activity/swimlane` to the schema-at-boundary pattern, replacing two unvalidated `as import('../types').*Response` casts in `dashboard/src/api/actions.ts` with proper parsers.

- Adds `src/api/schemas/actions-activity.ts` — schemas, `InferOutput` types, a single shared `ActionsActivitySchemaDriftError` (tagged with `endpoint: 'graph' | 'swimlane'`), and `parseActivityGraphResponse` / `parseSwimlaneResponse`.
- Updates `src/api/actions.ts` — routes both fetches through the parsers; on drift, keeps the existing `console.debug` + `return null` contract (callers already handle null, which is why these two don't throw unlike #7700/#7720).
- Rewires `src/types/sse.ts` to re-export the schema-derived types under their original names so every component import (`../types` barrel) stays unchanged.
- Adds `src/api/schemas/actions-activity.test.ts` — 10 shape tests covering valid / optional / open-enum / missing-field / non-object / endpoint-tag cases.

Out-of-scope (untouched in this PR): `sendBroadcast`, `fetchRoomMessages`, `fetchTaskHistory`, `deleteBoardPost`, `deleteTask`.

## Drift policy

| Field | Policy | Why |
|-------|--------|-----|
| `nodes[].kind`, `nodes[].status`, `edges[].kind`, `spans[].kind`, `spans[].status` | open `string()` | Backend-evolved enumerations; dashboard renders via label/color lookup with string fallback. `picklist` would brick the whole graph / swimlane during a backend-ahead deploy window. |
| `stats`, `kind_counts` | `record(string, number)` | Open number-valued counter maps; backend adds per-tool / per-category keys without coordinating the dashboard release. Consumers already read defensively (`stats.event_count ?? 0`). |
| `meta`, `payload`, `actor` | `record(string, unknown)` | Opaque diagnostic payloads; no dashboard branch inspects their shape. |
| `subject` | `nullable(object({ id, type }))` | Strict — this *is* branched on by consumers (null vs present). |
| `heatmap.matrix`, `window`, `time_range`, counts, timestamps, ids, labels | strict | Correctness-critical; drift here would silently render wrong shape / wrong math. |

Unlike the keeper / autoresearch migrations, no `fallback()` is used — there is no "safe default" for an activity node's status string, and the two callers already translate all failures (network, timeout, shape drift) to `null`. A drift error is therefore a soft failure at runtime (the two panels render their empty state), not a thrown exception.

`abortEarly: true` on both parsers because both payloads carry unbounded arrays (timeline events, spans, nodes, edges).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run src/api/schemas/actions-activity.test.ts` — 10/10 pass
- [x] `pnpm vitest run src/components/activity-graph-groups.test.ts` — downstream consumer smoke (8/8 pass)
- [x] `pnpm lint` clean
- [ ] CI green

## Caller impact

Every consumer (`components/activity-graph.ts`, `activity-graph-view.ts`, `activity-heatmap.ts`, `activity-swimlane.ts`) imports the types via the `'../types'` barrel. The barrel now re-exports from `src/api/schemas/actions-activity.ts` via `src/types/sse.ts`, so call sites are unchanged.

Part of #7441.