### PR TITLE
feat(dashboard/ops): paused-namespace hint in activity timeline empty state

### DIFF
--- a/dashboard/src/components/ops/index.test.ts
+++ b/dashboard/src/components/ops/index.test.ts
@@ -184,4 +184,89 @@ describe('Ops surface', () => {
     expect(container.textContent).not.toContain('운영 판단')
     expect(container.textContent).not.toContain('매뉴얼 처리')
   }, 120000)
+
+  it('shows paused-namespace hint in activity timeline empty state when namespace is paused', async () => {
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorDigestError.value = null
+    operatorSnapshot.value = {
+      root: { paused: true, namespace: 'default', pause_reason: '배포 윈도우', paused_by: 'vincent' },
+      sessions: [],
+      keepers: [],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+    operatorRoomDigest.value = {
+      target_type: 'namespace',
+      attention_items: [],
+      recommended_actions: [],
+      recent_reviews: [],
+      worker_cards: [],
+    } as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const empty = container.querySelector('[data-testid="ops-activity-timeline-empty"]')
+    expect(empty).toBeTruthy()
+    expect(empty?.textContent).toContain('namespace가 일시정지')
+    expect(empty?.textContent).toContain('배포 윈도우')
+    expect(empty?.textContent).toContain('by vincent')
+  }, 60000)
+
+  it('shows standard empty message when running namespace has no recent activity', async () => {
+    const {
+      Ops,
+      route,
+      operatorActionLog,
+      operatorDigestError,
+      operatorError,
+      operatorRoomDigest,
+      operatorSnapshot,
+      hydratedWorkflowId,
+    } = await loadOps()
+
+    route.value = { tab: 'command', params: { section: 'operations' }, postId: null } as RouteState
+    hydratedWorkflowId.value = null
+    operatorError.value = null
+    operatorDigestError.value = null
+    operatorSnapshot.value = {
+      root: { paused: false, namespace: 'default' },
+      sessions: [],
+      keepers: [],
+      recent_messages: [],
+      pending_confirms: [],
+      available_actions: [],
+    } as unknown as OperatorSnapshot
+    operatorRoomDigest.value = {
+      target_type: 'namespace',
+      attention_items: [],
+      recommended_actions: [],
+      recent_reviews: [],
+      worker_cards: [],
+    } as unknown as OperatorDigest
+    operatorActionLog.value = []
+
+    render(html`<${Ops} />`, container)
+    await flushUi()
+
+    const empty = container.querySelector('[data-testid="ops-activity-timeline-empty"]')
+    expect(empty).toBeTruthy()
+    expect(empty?.textContent).toContain('최근 운영 활동이 없습니다')
+    expect(empty?.textContent).not.toContain('일시정지')
+  }, 60000)
 })

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -125,10 +125,33 @@ function timelineEntries(limit = 10): OpsActivityTimelineEntry[] {
     .slice(0, limit)
 }
 
+export function activityTimelineEmptyState(): { message: string; hint: string | null } {
+  const root = operatorSnapshot.value?.root
+  if (root?.paused) {
+    const reason = root.pause_reason?.trim()
+    const by = root.paused_by?.trim()
+    const parts = [reason, by ? `by ${by}` : null].filter(Boolean).join(' · ')
+    return {
+      message: 'namespace가 일시정지 상태입니다. 재개 전까지 새 운영 활동이 기록되지 않습니다.',
+      hint: parts || null,
+    }
+  }
+  return {
+    message: '최근 운영 활동이 없습니다. 개입이 실행되거나 검토가 처리되면 자동 기록됩니다.',
+    hint: null,
+  }
+}
+
 function renderActivityTimeline() {
   const entries = timelineEntries()
   if (entries.length === 0) {
-    return html`<${EmptyState} message="아직 기록된 운영 활동이 없습니다." compact />`
+    const { message, hint } = activityTimelineEmptyState()
+    return html`
+      <div data-testid="ops-activity-timeline-empty">
+        <${EmptyState} message=${message} compact />
+        ${hint ? html`<div class="mt-0.5 text-center text-[11px] text-text-dim">${hint}</div>` : null}
+      </div>
+    `
   }
 
   return html`


### PR DESCRIPTION
## Summary

Third application of the user's "더 잘 보이게" ask. The ops page activity timeline collapsed to a single flat line `"아직 기록된 운영 활동이 없습니다."` whenever `recent_reviews` and `operatorActionLog` were both empty. In the common case the room is simply paused (explicit operator action), and the dashboard gave zero signal about that.

This PR reads `operatorSnapshot.value?.root.paused` / `pause_reason` / `paused_by` and differentiates two empty states:

| State | Message | Hint |
|---|---|---|
| `paused === true` | `namespace가 일시정지 상태입니다. 재개 전까지 새 운영 활동이 기록되지 않습니다.` | `<pause_reason> · by <paused_by>` (either or both, skipping null/empty) |
| `paused === false` or missing | `최근 운영 활동이 없습니다. 개입이 실행되거나 검토가 처리되면 자동 기록됩니다.` | none |

Pure function `activityTimelineEmptyState()` is exported so future unit tests can target it without rendering.

## Gen8 loop context

`/loop 20m` Gen8 — now the third empty-state enrichment after Gen3 (#7697, Live Judge) and Gen4 (#7705, Keeper HITL). Pattern: read ambient state signals (`judge_online`, `paused`, `last_error`) and produce a short tone-coded message + context hint beneath `<EmptyState>`.

## Test plan

- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm vitest run src/components/ops/index.test.ts` → 4/4 pass (2 existing + 2 new)
- [x] paused test asserts message, pause_reason `배포 윈도우`, `by vincent`
- [x] running test asserts standard message, no `일시정지` leak

## Non-goals

- Shared `readRootStatus()` helper mirroring Gen3/4 `readJudgeStatus` — worth extracting after all three panels (Gen3/4/8) merge. Consistent shape helps, but three panels isn't enough signal to force abstraction yet.
- Stale activity age ("N시간 전 마지막 기록") — `operatorActionLog` has entry timestamps but the empty path has no entries; adding recent-window context would need a separate signal (e.g. `summary.last_activity_age_s`). Deferred.
