### PR TITLE
refactor(dashboard/api): extract SchemaDriftError base + parseOrThrow helper

### DIFF
--- a/dashboard/src/api/schemas/drift-error.test.ts
+++ b/dashboard/src/api/schemas/drift-error.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { number, object, string, type BaseIssue } from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+class TestDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('test', issues)
+  }
+}
+
+const PersonSchema = object({ name: string(), age: number() })
+
+describe('SchemaDriftError base', () => {
+  it('sets name from the subclass constructor', () => {
+    expect(() => parseOrThrow(TestDriftError, PersonSchema, {})).toThrow(TestDriftError)
+    try {
+      parseOrThrow(TestDriftError, PersonSchema, {})
+    } catch (err) {
+      expect(err).toBeInstanceOf(TestDriftError)
+      expect(err).toBeInstanceOf(SchemaDriftError)
+      expect((err as Error).name).toBe('TestDriftError')
+    }
+  })
+
+  it('carries domain on the error for programmatic branching', () => {
+    try {
+      parseOrThrow(TestDriftError, PersonSchema, { name: 1, age: 'x' })
+    } catch (err) {
+      expect((err as SchemaDriftError).domain).toBe('test')
+    }
+  })
+
+  it('formats the message with pathful issue summary', () => {
+    try {
+      parseOrThrow(TestDriftError, PersonSchema, { name: 'ok' })
+    } catch (err) {
+      expect((err as Error).message).toMatch(/^test schema drift:/)
+      expect((err as Error).message).toContain('age')
+    }
+  })
+
+  it('abortEarly default keeps issues array bounded to a single entry', () => {
+    // Memory bound per /simplify review: drifted payloads do not pin
+    // hundreds of issue objects on the thrown error.
+    try {
+      parseOrThrow(TestDriftError, PersonSchema, { name: 1, age: 'x' })
+    } catch (err) {
+      expect((err as SchemaDriftError).issues).toHaveLength(1)
+    }
+  })
+
+  it('returns the parsed value on success', () => {
+    const out = parseOrThrow(TestDriftError, PersonSchema, { name: 'Vincent', age: 36 })
+    expect(out).toEqual({ name: 'Vincent', age: 36 })
+  })
+})

--- a/dashboard/src/api/schemas/drift-error.ts
+++ b/dashboard/src/api/schemas/drift-error.ts
@@ -1,0 +1,55 @@
+// Shared base for schema-at-boundary parse errors.
+//
+// Subclasses are kept thin (2-line) so callers can keep writing
+// `instanceof CompositeSchemaDriftError` — there is a real test caller
+// in components/fsm-hub.integration.test.ts that relies on the
+// per-endpoint class identity.
+//
+// `parseOrThrow` wraps `v.safeParse` with `abortEarly: true` so a
+// fully-drifted payload does not retain hundreds of issue objects on
+// the thrown error (memory-bounded, matches the /simplify review
+// recommendation on #7720).
+
+import {
+  safeParse,
+  type BaseIssue,
+  type BaseSchema,
+  type Config,
+  type InferOutput,
+} from 'valibot'
+
+function formatIssues(issues: readonly BaseIssue<unknown>[]): string {
+  return issues
+    .map(issue => {
+      const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+      return `${path}: ${issue.message}`
+    })
+    .join('; ')
+}
+
+export abstract class SchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  readonly domain: string
+
+  constructor(domain: string, issues: readonly BaseIssue<unknown>[]) {
+    super(`${domain} schema drift: ${formatIssues(issues)}`)
+    this.name = new.target.name
+    this.domain = domain
+    this.issues = issues
+  }
+}
+
+export function parseOrThrow<
+  TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+>(
+  ErrorCtor: new (issues: readonly BaseIssue<unknown>[]) => SchemaDriftError,
+  schema: TSchema,
+  data: unknown,
+  config: Config<BaseIssue<unknown>> = { abortEarly: true },
+): InferOutput<TSchema> {
+  const result = safeParse(schema, data, config)
+  if (!result.success) {
+    throw new ErrorCtor(result.issues)
+  }
+  return result.output as InferOutput<TSchema>
+}

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -26,11 +26,12 @@ import {
   object,
   optional,
   picklist,
-  safeParse,
   string,
   type BaseIssue,
   type InferOutput,
 } from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
 
 // The FSM enums below use `fallback` (not hard-rejection) because
 // Keeper state machines evolve asymmetrically: the OCaml backend
@@ -132,26 +133,12 @@ export type KeeperCompositeDecisionStage = InferOutput<typeof KeeperCompositeDec
 export type KeeperCompositeCascadeState = InferOutput<typeof KeeperCompositeCascadeStateSchema>
 export type KeeperCompositeCompactionStage = InferOutput<typeof KeeperCompositeCompactionStageSchema>
 
-export class CompositeSchemaDriftError extends Error {
-  readonly issues: readonly BaseIssue<unknown>[]
+export class CompositeSchemaDriftError extends SchemaDriftError {
   constructor(issues: readonly BaseIssue<unknown>[]) {
-    const summary = issues
-      .slice(0, 3)
-      .map(issue => {
-        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
-        return `${path}: ${issue.message}`
-      })
-      .join('; ')
-    super(`composite schema drift: ${summary}`)
-    this.name = 'CompositeSchemaDriftError'
-    this.issues = issues
+    super('composite', issues)
   }
 }
 
 export function parseKeeperCompositeSnapshot(data: unknown): KeeperCompositeSnapshot {
-  const result = safeParse(KeeperCompositeSnapshotSchema, data)
-  if (!result.success) {
-    throw new CompositeSchemaDriftError(result.issues)
-  }
-  return result.output
+  return parseOrThrow(CompositeSchemaDriftError, KeeperCompositeSnapshotSchema, data)
 }


### PR DESCRIPTION
## Summary

The #7441 valibot rollout is producing a 4th near-identical schema-drift error class (\`ActionsActivitySchemaDriftError\` in #7726). With 4 copies the \`≥2 copies\` DRY bar is cleanly crossed — this PR extracts the shared base and a thin parse helper without collapsing the per-endpoint classes that a real test caller already depends on.

### New module — \`src/api/schemas/drift-error.ts\`

- \`abstract class SchemaDriftError extends Error\` owns summary formatting, stores \`domain\` + \`issues\`, sets \`name\` from the concrete subclass via \`new.target.name\` — no stringly-typed literal.
- \`parseOrThrow(ErrorCtor, schema, data)\` wraps \`v.safeParse\` with \`abortEarly: true\` by default, bounding the \`issues\` array retained on the thrown error (per /simplify review against hundreds of pinned issue objects from a total-drift payload).

### Pilot migration

\`CompositeSchemaDriftError\` collapses from 15 lines to 3:

\`\`\`ts
export class CompositeSchemaDriftError extends SchemaDriftError {
  constructor(issues) { super('composite', issues) }
}
\`\`\`

Kept as an explicit subclass because \`components/fsm-hub.integration.test.ts\` contains \`expect(err).toBeInstanceOf(CompositeSchemaDriftError)\` — collapsing to a single \`SchemaDriftError\` would force a caller-facing contract change for no gain.

## Design rationale (why Option C over A/B)

An earlier draft proposed either a helper function (\`schemaDrift(domain, issues)\` returning plain \`Error\`) or a single concrete class. Both were dismissed once \`fsm-hub.integration.test.ts\` turned up a real \`instanceof CompositeSchemaDriftError\` caller. Thin subclasses over a shared abstract base keep the \`instanceof\` contract while extracting 95% of the body.

## Follow-ups (one per sibling PR after merge)

- #7700 — migrate \`AutoresearchSchemaDriftError\` to subclass
- #7720 — migrate \`KeeperTransitionsSchemaDriftError\` to subclass
- #7726 — migrate \`ActionsActivitySchemaDriftError\` to subclass

Each follow-up is ~15-line deletion + 3-line subclass, no behavior change.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/drift-error.test.ts src/components/fsm-hub.integration.test.ts\` — 20/20 pass (5 new + 15 existing integration including the \`instanceof\` assertion)
- [ ] CI green