### PR TITLE
chore(dashboard): pin lodash-es >=4.18.1 via pnpm override (CVE fixes)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -52,5 +52,10 @@
     "typescript-eslint": "^8.58.1",
     "vite": "^7.3.2",
     "vitest": "^4.1.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "lodash-es": "^4.18.1"
+    }
   }
 }

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  lodash-es: ^4.18.1
+
 importers:
 
   .:
@@ -1945,8 +1948,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -2769,12 +2772,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.1.2
       '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   '@chevrotain/gast@11.1.2':
     dependencies:
       '@chevrotain/types': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   '@chevrotain/regexp-to-ast@11.1.2': {}
 
@@ -3639,7 +3642,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
       chevrotain: 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   chevrotain@11.1.2:
     dependencies:
@@ -3648,7 +3651,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.1.2
       '@chevrotain/types': 11.1.2
       '@chevrotain/utils': 11.1.2
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   color-convert@2.0.1:
     dependencies:
@@ -3884,7 +3887,7 @@ snapshots:
   dagre-d3-es@7.0.14:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
 
   dayjs@1.11.19: {}
 
@@ -4488,7 +4491,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.23: {}
+  lodash-es@4.18.1: {}
 
   lodash.merge@4.6.2: {}
 
@@ -4545,7 +4548,7 @@ snapshots:
       dompurify: 3.4.0
       katex: 0.16.37
       khroma: 2.1.0
-      lodash-es: 4.17.23
+      lodash-es: 4.18.1
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6


### PR DESCRIPTION
## Summary

Patches the two remaining Dependabot alerts on `pnpm-lock.yaml` by adding a pnpm `overrides` entry that pins every transitive `lodash-es` reference to `^4.18.1`.

## Alerts closed

| Alert | Severity | CVE | Vulnerable range | First patched |
|-------|----------|-----|------------------|---------------|
| #10 | medium | CVE-2026-2950 | `<= 4.17.23` | 4.18.0 |
| #11 | high   | CVE-2026-4800 | `>= 4.0.0, <= 4.17.23` | 4.18.0 |

#8 and #9 (matching alerts against `package-lock.json`) are closed by companion PR #7731 which removes that stale lockfile.

## Why an override, not a direct dep bump

`lodash-es` is **not** a direct dependency of `dashboard/package.json`. It is pulled transitively by:

- `chevrotain`, `@chevrotain/types`, `@chevrotain/utils`
- `d3`
- `khroma`
- `mermaid`

None of those expose `lodash-es` as a peer dep we can upgrade individually. `pnpm.overrides` is the supported mechanism to force a transitive version in pnpm workspaces.

## Mechanism

Added to `dashboard/package.json`:

```json
  "pnpm": {
    "overrides": {
      "lodash-es": "^4.18.1"
    }
  }
```

Ran `pnpm install --lockfile-only` (no `node_modules` write). Regenerated `pnpm-lock.yaml` now resolves every `lodash-es` reference to `4.18.1`.

## Compatibility

- `rg "from .lodash-es" dashboard/src` → 0 matches. We do not import lodash-es directly, so the override cannot break our own code.
- 4.17.23 → 4.18.1 is a minor bump within the 4.x line. Lodash has a strong backward-compat tradition; API-breaking changes would be 5.x.
- `_.template` and `_.unset` — the two surfaces the CVEs touch — have documented fixes, not removals, in 4.18.0.

## Local verification

```
$ pnpm install --lockfile-only
... 595 packages resolved, no errors ...
$ rg "lodash-es@" pnpm-lock.yaml
lodash-es@4.18.1:
  lodash-es@4.18.1: {}   # (all instances unified to 4.18.1)
```

Full typecheck / build validation is delegated to the Dashboard CI job (runs `tsc --noEmit` + `vite build`). Local runs would require `pnpm install` (~full node_modules download); skipped per token-miser rule — the lockfile-only change cannot affect typecheck unless it breaks transitive deps, which CI will catch.

## Test plan

- [ ] CI Dashboard job: `tsc --noEmit` + `vite build` green
- [ ] Dependabot: alerts #10 and #11 auto-dismiss after merge (pnpm-lock.yaml no longer contains vulnerable ranges)