### PR TITLE
feat(dashboard/api): migrate agent-relations endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -11,6 +11,10 @@ import {
   normalizePendingConfirmation,
 } from './board'
 import { get, post, patch, withRetries, NAMESPACE_TRUTH_GET_TIMEOUT_MS } from './core'
+import {
+  parseAgentRelationsResponse,
+  type AgentRelationsResponse,
+} from './schemas/agent-relations'
 import type {
   KeeperConfig,
   KeeperFeatureStatus,
@@ -168,29 +172,16 @@ export function fetchAgentTimeline(
   return get(`/api/v1/agent-timeline?agent_name=${encodeURIComponent(agentName)}&since_hours=${sinceHours}&limit=${limit}`)
 }
 
-export type AgentCollaborator = {
-  name: string
-  collaborations: number
-  last_collab: string | null
-}
+export type {
+  AgentCollaborator,
+  AgentRelation,
+  AgentRelationsResponse,
+} from './schemas/agent-relations'
+export { AgentRelationsSchemaDriftError } from './schemas/agent-relations'
 
-export type AgentRelation = {
-  type: string
-  category: string | null
-  confidence: number | null
-  note: string | null
-  participants: { kind: string; display_name: string | null; role: string | null }[]
-}
-
-export type AgentRelationsResponse = {
-  agent_name: string
-  collaborators: AgentCollaborator[]
-  interests: string[]
-  relations: AgentRelation[]
-}
-
-export function fetchAgentRelations(agentName: string): Promise<AgentRelationsResponse> {
-  return get(`/api/v1/agent-relations?agent_name=${encodeURIComponent(agentName)}`)
+export async function fetchAgentRelations(agentName: string): Promise<AgentRelationsResponse> {
+  const raw = await get<unknown>(`/api/v1/agent-relations?agent_name=${encodeURIComponent(agentName)}`)
+  return parseAgentRelationsResponse(raw)
 }
 
 export interface ConfigEntry {

--- a/dashboard/src/api/schemas/agent-relations.test.ts
+++ b/dashboard/src/api/schemas/agent-relations.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AgentRelationsSchemaDriftError,
+  parseAgentRelationsResponse,
+} from './agent-relations'
+
+function validResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent_name: 'dreamer',
+    collaborators: [
+      { name: 'planner', collaborations: 7, last_collab: '2026-04-17T00:00:00Z' },
+      { name: 'critic', collaborations: 2, last_collab: null },
+    ],
+    interests: ['code-review', 'security'],
+    relations: [
+      {
+        type: 'reviews',
+        category: 'technical',
+        confidence: 0.87,
+        note: null,
+        participants: [
+          { kind: 'agent', display_name: 'dreamer', role: 'author' },
+          { kind: 'agent', display_name: 'critic', role: 'reviewer' },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('parseAgentRelationsResponse', () => {
+  it('accepts a well-formed response', () => {
+    const out = parseAgentRelationsResponse(validResponse())
+    expect(out.agent_name).toBe('dreamer')
+    expect(out.collaborators).toHaveLength(2)
+    expect(out.relations[0]!.participants).toHaveLength(2)
+  })
+
+  it('accepts empty collections', () => {
+    const out = parseAgentRelationsResponse({
+      agent_name: 'new-agent',
+      collaborators: [],
+      interests: [],
+      relations: [],
+    })
+    expect(out.agent_name).toBe('new-agent')
+  })
+
+  it('accepts unknown relation type values', () => {
+    const out = parseAgentRelationsResponse(
+      validResponse({
+        relations: [
+          {
+            type: 'brand-new-relation-kind',
+            category: null,
+            confidence: null,
+            note: null,
+            participants: [],
+          },
+        ],
+      }),
+    )
+    expect(out.relations[0]!.type).toBe('brand-new-relation-kind')
+  })
+
+  it('throws when agent_name is missing', () => {
+    const bad = validResponse({ agent_name: undefined })
+    expect(() => parseAgentRelationsResponse(bad)).toThrow(AgentRelationsSchemaDriftError)
+  })
+
+  it('throws when relations has a non-object entry', () => {
+    const bad = validResponse({ relations: ['not-an-object'] })
+    expect(() => parseAgentRelationsResponse(bad)).toThrow(AgentRelationsSchemaDriftError)
+  })
+
+  it('throws when a collaborator is missing the name field', () => {
+    const bad = validResponse({
+      collaborators: [{ collaborations: 1, last_collab: null }],
+    })
+    expect(() => parseAgentRelationsResponse(bad)).toThrow(AgentRelationsSchemaDriftError)
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseAgentRelationsResponse(null)).toThrow(AgentRelationsSchemaDriftError)
+    expect(() => parseAgentRelationsResponse('oops')).toThrow(AgentRelationsSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/agent-relations.ts
+++ b/dashboard/src/api/schemas/agent-relations.ts
@@ -1,0 +1,72 @@
+// Agent relations schema — schema-at-boundary for
+// `GET /api/v1/agent-relations?agent_name=<name>`.
+//
+// `type`, `category`, `role`, `kind` are kept as open `string()` because
+// relation taxonomy evolves in the backend (`agent_relations_*.ml`)
+// ahead of the dashboard. Strict enums here would brick the agent
+// profile page during a backend-ahead deploy window.
+
+import {
+  array,
+  nullable,
+  number,
+  object,
+  safeParse,
+  string,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+const AgentCollaboratorSchema = object({
+  name: string(),
+  collaborations: number(),
+  last_collab: nullable(string()),
+})
+
+const AgentRelationParticipantSchema = object({
+  kind: string(),
+  display_name: nullable(string()),
+  role: nullable(string()),
+})
+
+const AgentRelationSchema = object({
+  type: string(),
+  category: nullable(string()),
+  confidence: nullable(number()),
+  note: nullable(string()),
+  participants: array(AgentRelationParticipantSchema),
+})
+
+export const AgentRelationsResponseSchema = object({
+  agent_name: string(),
+  collaborators: array(AgentCollaboratorSchema),
+  interests: array(string()),
+  relations: array(AgentRelationSchema),
+})
+
+export type AgentCollaborator = InferOutput<typeof AgentCollaboratorSchema>
+export type AgentRelation = InferOutput<typeof AgentRelationSchema>
+export type AgentRelationsResponse = InferOutput<typeof AgentRelationsResponseSchema>
+
+export class AgentRelationsSchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`agent-relations schema drift: ${summary}`)
+    this.name = AgentRelationsSchemaDriftError.name
+    this.issues = issues
+  }
+}
+
+export function parseAgentRelationsResponse(data: unknown): AgentRelationsResponse {
+  const result = safeParse(AgentRelationsResponseSchema, data, { abortEarly: true })
+  if (!result.success) {
+    throw new AgentRelationsSchemaDriftError(result.issues)
+  }
+  return result.output
+}


### PR DESCRIPTION
## Summary

Migrates \`GET /api/v1/agent-relations\` to the schema-at-boundary pattern. First endpoint extracted from the 2072-line \`api/dashboard.ts\` mega-file.

- Adds \`src/api/schemas/agent-relations.ts\` — 4 schemas, 3 \`InferOutput\` types, \`AgentRelationsSchemaDriftError\`, \`parseAgentRelationsResponse\` with \`abortEarly: true\`.
- Shrinks the \`dashboard.ts\` section from 24 lines of hand-typed types + unsafe cast to a schema re-export + parse call.
- Adds 7 shape tests.

## Drift policy

Relation taxonomy fields (\`type\`, \`category\`, \`role\`, \`kind\`) are **open \`string()\`** — backend evolves kinds ahead of the dashboard, strict enums would brick the agent profile page during a backend-ahead deploy window. Same reasoning as #7720's phase names.

## Follow-up noted in commit

Will migrate \`AgentRelationsSchemaDriftError\` to the shared \`SchemaDriftError\` base once #7732 lands (3-line thin subclass, same pattern as other 4 sites).

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/agent-relations.test.ts\` — 7/7 pass
- [ ] CI green

Part of #7441.