### PR TITLE
feat(attribution): Layer 1 envelope types + SSE field

### DIFF
--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -68,6 +68,39 @@ export type SSEEventType =
 export type JournalSeverity = 'debug' | 'info' | 'warn' | 'error' | 'unknown'
 export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 'sse'
 
+// --- Attribution envelope ---
+// Structured verdict metadata for gate decisions. Emitted alongside existing
+// reason/reason_code fields so dashboards can trace causality without breaking
+// consumers that don't understand the envelope.
+// OCaml SSOT: lib/attribution.mli (since 2.261.0)
+
+export type AttributionOrigin = 'det' | 'nondet'
+export type AttributionVerdict = 'pass' | 'fail' | 'partial'
+
+// Known gate identifiers. Kept open ('string') so new gates can emit without
+// a client update, but enumerating canonical values gives us autocomplete and
+// catches typos.
+export type AttributionGate =
+  | 'cdal_verdict'
+  | 'verification'
+  | 'accountability'
+  | 'keeper_fsm'
+  | 'oas_completion'
+  | 'agent_lifecycle'
+  | 'task_transition'
+  | 'worker_dev_tools'
+  | string
+
+export interface Attribution {
+  origin: AttributionOrigin
+  gate: AttributionGate
+  verdict: AttributionVerdict
+  evidence: Record<string, unknown>
+  blocked_from?: string
+  blocked_to?: string
+  rationale?: string
+}
+
 export interface SSEEvent {
   type: SSEEventType
   severity?: JournalSeverity | string
@@ -134,6 +167,10 @@ export interface SSEEvent {
   correlation_id?: string
   // OAS envelope per-run identifier (one per Agent.run invocation).
   run_id?: string
+  // Gate attribution envelope — structured verdict metadata. Emitters
+  // attach this alongside existing reason/reason_code fields since 2.261.0.
+  // See lib/attribution.mli for OCaml SSOT and evidence schema per gate.
+  attribution?: Attribution
 }
 
 // --- Journal ---

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -72,10 +72,13 @@ export type JournalSource = 'structured' | 'legacy_stderr' | 'legacy_traceln' | 
 // Structured verdict metadata for gate decisions. Emitted alongside existing
 // reason/reason_code fields so dashboards can trace causality without breaking
 // consumers that don't understand the envelope.
-// OCaml SSOT: lib/attribution.mli (since 2.261.0)
+//
+// OCaml SSOT: lib/attribution.mli (since 2.261.0).
+// AttributionOutcome is a discriminated union on 'kind' — each variant
+// carries exactly the fields relevant to that outcome (no optional fields
+// shared across variants).
 
 export type AttributionOrigin = 'det' | 'nondet'
-export type AttributionVerdict = 'pass' | 'fail' | 'partial'
 
 // Known gate identifiers. Kept open ('string') so new gates can emit without
 // a client update, but enumerating canonical values gives us autocomplete and
@@ -91,14 +94,18 @@ export type AttributionGate =
   | 'worker_dev_tools'
   | string
 
+// Gate decision outcome. Discriminated union — exhaustive switch on 'kind'.
+export type AttributionOutcome =
+  | { kind: 'passed' }
+  | { kind: 'policy_failed'; reason: string }
+  | { kind: 'transition_blocked'; from_state: string; to_state: string; reason: string }
+  | { kind: 'partial_pass'; score: number; rationale: string }
+
 export interface Attribution {
   origin: AttributionOrigin
   gate: AttributionGate
-  verdict: AttributionVerdict
   evidence: Record<string, unknown>
-  blocked_from?: string
-  blocked_to?: string
-  rationale?: string
+  outcome: AttributionOutcome
 }
 
 export interface SSEEvent {

--- a/lib/attribution.ml
+++ b/lib/attribution.ml
@@ -4,139 +4,163 @@ type origin = Det | NonDet
 
 let string_of_origin = function Det -> "det" | NonDet -> "nondet"
 
-let origin_to_yojson o : Yojson.Safe.t = `String (string_of_origin o)
-
-let origin_of_yojson = function
-  | `String "det" -> Ok Det
-  | `String "nondet" -> Ok NonDet
-  | json ->
+let origin_of_string = function
+  | "det" -> Ok Det
+  | "nondet" -> Ok NonDet
+  | other ->
     Error
       (Printf.sprintf
-         "attribution.origin: expected \"det\" | \"nondet\", got %s"
-         (Yojson.Safe.to_string json))
+         "attribution.origin: expected \"det\" | \"nondet\", got %S" other)
 
-type verdict = Pass | Fail | Partial
-
-let string_of_verdict = function
-  | Pass -> "pass"
-  | Fail -> "fail"
-  | Partial -> "partial"
-
-let verdict_to_yojson v : Yojson.Safe.t = `String (string_of_verdict v)
-
-let verdict_of_yojson = function
-  | `String "pass" -> Ok Pass
-  | `String "fail" -> Ok Fail
-  | `String "partial" -> Ok Partial
-  | json ->
-    Error
-      (Printf.sprintf
-         "attribution.verdict: expected \"pass\" | \"fail\" | \"partial\", got %s"
-         (Yojson.Safe.to_string json))
+type outcome =
+  | Passed
+  | Policy_failed of { reason : string }
+  | Transition_blocked of {
+      from_state : string;
+      to_state : string;
+      reason : string;
+    }
+  | Partial_pass of { score : float; rationale : string }
 
 type t = {
-  origin: origin;
-  gate: string;
-  verdict: verdict;
-  evidence: Yojson.Safe.t;
-  blocked_from: string option;
-  blocked_to: string option;
-  rationale: string option;
+  origin : origin;
+  gate : string;
+  evidence : Yojson.Safe.t;
+  outcome : outcome;
 }
 
+(* --- Serialization --- *)
+
+let outcome_to_yojson : outcome -> Yojson.Safe.t = function
+  | Passed -> `Assoc [ ("kind", `String "passed") ]
+  | Policy_failed { reason } ->
+    `Assoc [ ("kind", `String "policy_failed"); ("reason", `String reason) ]
+  | Transition_blocked { from_state; to_state; reason } ->
+    `Assoc
+      [
+        ("kind", `String "transition_blocked");
+        ("from_state", `String from_state);
+        ("to_state", `String to_state);
+        ("reason", `String reason);
+      ]
+  | Partial_pass { score; rationale } ->
+    `Assoc
+      [
+        ("kind", `String "partial_pass");
+        ("score", `Float score);
+        ("rationale", `String rationale);
+      ]
+
 let to_yojson (t : t) : Yojson.Safe.t =
-  let base = [
-    ("origin", origin_to_yojson t.origin);
-    ("gate", `String t.gate);
-    ("verdict", verdict_to_yojson t.verdict);
-    ("evidence", t.evidence);
-  ] in
-  let add_opt key = function
-    | None -> []
-    | Some v -> [ (key, `String v) ]
-  in
   `Assoc
-    (base
-    @ add_opt "blocked_from" t.blocked_from
-    @ add_opt "blocked_to" t.blocked_to
-    @ add_opt "rationale" t.rationale)
+    [
+      ("origin", `String (string_of_origin t.origin));
+      ("gate", `String t.gate);
+      ("evidence", t.evidence);
+      ("outcome", outcome_to_yojson t.outcome);
+    ]
+
+(* --- Parsing --- *)
 
 let ( let* ) = Result.bind
 
-let field_string ~gate_field fields key =
+let require_field fields key =
   match List.assoc_opt key fields with
-  | Some (`String s) -> Ok s
-  | Some other ->
-    Error
-      (Printf.sprintf "attribution.%s: expected string, got %s"
-         gate_field
-         (Yojson.Safe.to_string other))
-  | None ->
-    Error (Printf.sprintf "attribution: missing field %S" key)
+  | Some v -> Ok v
+  | None -> Error (Printf.sprintf "attribution: missing field %S" key)
 
-let opt_string fields key =
-  match List.assoc_opt key fields with
-  | None | Some `Null -> Ok None
-  | Some (`String s) -> Ok (Some s)
-  | Some other ->
+let require_string fields key =
+  let* v = require_field fields key in
+  match v with
+  | `String s -> Ok s
+  | other ->
     Error
-      (Printf.sprintf "attribution.%s: expected string or null, got %s"
-         key (Yojson.Safe.to_string other))
+      (Printf.sprintf "attribution.%s: expected string, got %s" key
+         (Yojson.Safe.to_string other))
+
+let require_float fields key =
+  let* v = require_field fields key in
+  match v with
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | other ->
+    Error
+      (Printf.sprintf "attribution.%s: expected number, got %s" key
+         (Yojson.Safe.to_string other))
+
+let outcome_of_yojson : Yojson.Safe.t -> (outcome, string) result = function
+  | `Assoc fields ->
+    let* kind = require_string fields "kind" in
+    (match kind with
+     | "passed" -> Ok Passed
+     | "policy_failed" ->
+       let* reason = require_string fields "reason" in
+       Ok (Policy_failed { reason })
+     | "transition_blocked" ->
+       let* from_state = require_string fields "from_state" in
+       let* to_state = require_string fields "to_state" in
+       let* reason = require_string fields "reason" in
+       Ok (Transition_blocked { from_state; to_state; reason })
+     | "partial_pass" ->
+       let* score = require_float fields "score" in
+       let* rationale = require_string fields "rationale" in
+       Ok (Partial_pass { score; rationale })
+     | other ->
+       Error
+         (Printf.sprintf
+            "attribution.outcome.kind: unknown %S (expected passed | \
+             policy_failed | transition_blocked | partial_pass)"
+            other))
+  | json ->
+    Error
+      (Printf.sprintf "attribution.outcome: expected JSON object, got %s"
+         (Yojson.Safe.to_string json))
 
 let of_yojson = function
   | `Assoc fields ->
-    let* origin_j =
-      match List.assoc_opt "origin" fields with
-      | Some j -> Ok j
-      | None -> Error "attribution: missing field \"origin\""
-    in
-    let* origin = origin_of_yojson origin_j in
-    let* gate = field_string ~gate_field:"gate" fields "gate" in
-    let* verdict_j =
-      match List.assoc_opt "verdict" fields with
-      | Some j -> Ok j
-      | None -> Error "attribution: missing field \"verdict\""
-    in
-    let* verdict = verdict_of_yojson verdict_j in
+    let* origin_s = require_string fields "origin" in
+    let* origin = origin_of_string origin_s in
+    let* gate = require_string fields "gate" in
     let evidence =
       match List.assoc_opt "evidence" fields with
       | None | Some `Null -> `Null
       | Some ev -> ev
     in
-    let* blocked_from = opt_string fields "blocked_from" in
-    let* blocked_to = opt_string fields "blocked_to" in
-    let* rationale = opt_string fields "rationale" in
-    Ok { origin; gate; verdict; evidence; blocked_from; blocked_to; rationale }
+    let* outcome_j = require_field fields "outcome" in
+    let* outcome = outcome_of_yojson outcome_j in
+    Ok { origin; gate; evidence; outcome }
   | json ->
     Error
       (Printf.sprintf "attribution: expected JSON object, got %s"
          (Yojson.Safe.to_string json))
 
+(* --- Show --- *)
+
+let string_of_outcome_kind = function
+  | Passed -> "passed"
+  | Policy_failed _ -> "policy_failed"
+  | Transition_blocked _ -> "transition_blocked"
+  | Partial_pass _ -> "partial_pass"
+
 let show (t : t) : string =
-  Printf.sprintf "Attribution{origin=%s; gate=%s; verdict=%s}"
-    (string_of_origin t.origin) t.gate (string_of_verdict t.verdict)
+  Printf.sprintf "Attribution{origin=%s; gate=%s; outcome=%s}"
+    (string_of_origin t.origin) t.gate
+    (string_of_outcome_kind t.outcome)
 
-let pass ~origin ~gate ~evidence =
+(* --- Smart constructors --- *)
+
+let passed ~origin ~gate ~evidence = { origin; gate; evidence; outcome = Passed }
+
+let policy_failed ~origin ~gate ~evidence ~reason =
+  { origin; gate; evidence; outcome = Policy_failed { reason } }
+
+let transition_blocked ~origin ~gate ~evidence ~from_state ~to_state ~reason =
   {
     origin;
     gate;
-    verdict = Pass;
     evidence;
-    blocked_from = None;
-    blocked_to = None;
-    rationale = None;
+    outcome = Transition_blocked { from_state; to_state; reason };
   }
 
-let fail ~origin ~gate ~evidence ?blocked_from ?blocked_to ?rationale () =
-  { origin; gate; verdict = Fail; evidence; blocked_from; blocked_to; rationale }
-
-let partial ~origin ~gate ~evidence ?rationale () =
-  {
-    origin;
-    gate;
-    verdict = Partial;
-    evidence;
-    blocked_from = None;
-    blocked_to = None;
-    rationale;
-  }
+let partial_pass ~origin ~gate ~evidence ~score ~rationale =
+  { origin; gate; evidence; outcome = Partial_pass { score; rationale } }

--- a/lib/attribution.ml
+++ b/lib/attribution.ml
@@ -1,0 +1,142 @@
+(** See [Attribution.mli] for documentation. *)
+
+type origin = Det | NonDet
+
+let string_of_origin = function Det -> "det" | NonDet -> "nondet"
+
+let origin_to_yojson o : Yojson.Safe.t = `String (string_of_origin o)
+
+let origin_of_yojson = function
+  | `String "det" -> Ok Det
+  | `String "nondet" -> Ok NonDet
+  | json ->
+    Error
+      (Printf.sprintf
+         "attribution.origin: expected \"det\" | \"nondet\", got %s"
+         (Yojson.Safe.to_string json))
+
+type verdict = Pass | Fail | Partial
+
+let string_of_verdict = function
+  | Pass -> "pass"
+  | Fail -> "fail"
+  | Partial -> "partial"
+
+let verdict_to_yojson v : Yojson.Safe.t = `String (string_of_verdict v)
+
+let verdict_of_yojson = function
+  | `String "pass" -> Ok Pass
+  | `String "fail" -> Ok Fail
+  | `String "partial" -> Ok Partial
+  | json ->
+    Error
+      (Printf.sprintf
+         "attribution.verdict: expected \"pass\" | \"fail\" | \"partial\", got %s"
+         (Yojson.Safe.to_string json))
+
+type t = {
+  origin: origin;
+  gate: string;
+  verdict: verdict;
+  evidence: Yojson.Safe.t;
+  blocked_from: string option;
+  blocked_to: string option;
+  rationale: string option;
+}
+
+let to_yojson (t : t) : Yojson.Safe.t =
+  let base = [
+    ("origin", origin_to_yojson t.origin);
+    ("gate", `String t.gate);
+    ("verdict", verdict_to_yojson t.verdict);
+    ("evidence", t.evidence);
+  ] in
+  let add_opt key = function
+    | None -> []
+    | Some v -> [ (key, `String v) ]
+  in
+  `Assoc
+    (base
+    @ add_opt "blocked_from" t.blocked_from
+    @ add_opt "blocked_to" t.blocked_to
+    @ add_opt "rationale" t.rationale)
+
+let ( let* ) = Result.bind
+
+let field_string ~gate_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`String s) -> Ok s
+  | Some other ->
+    Error
+      (Printf.sprintf "attribution.%s: expected string, got %s"
+         gate_field
+         (Yojson.Safe.to_string other))
+  | None ->
+    Error (Printf.sprintf "attribution: missing field %S" key)
+
+let opt_string fields key =
+  match List.assoc_opt key fields with
+  | None | Some `Null -> Ok None
+  | Some (`String s) -> Ok (Some s)
+  | Some other ->
+    Error
+      (Printf.sprintf "attribution.%s: expected string or null, got %s"
+         key (Yojson.Safe.to_string other))
+
+let of_yojson = function
+  | `Assoc fields ->
+    let* origin_j =
+      match List.assoc_opt "origin" fields with
+      | Some j -> Ok j
+      | None -> Error "attribution: missing field \"origin\""
+    in
+    let* origin = origin_of_yojson origin_j in
+    let* gate = field_string ~gate_field:"gate" fields "gate" in
+    let* verdict_j =
+      match List.assoc_opt "verdict" fields with
+      | Some j -> Ok j
+      | None -> Error "attribution: missing field \"verdict\""
+    in
+    let* verdict = verdict_of_yojson verdict_j in
+    let evidence =
+      match List.assoc_opt "evidence" fields with
+      | None | Some `Null -> `Null
+      | Some ev -> ev
+    in
+    let* blocked_from = opt_string fields "blocked_from" in
+    let* blocked_to = opt_string fields "blocked_to" in
+    let* rationale = opt_string fields "rationale" in
+    Ok { origin; gate; verdict; evidence; blocked_from; blocked_to; rationale }
+  | json ->
+    Error
+      (Printf.sprintf "attribution: expected JSON object, got %s"
+         (Yojson.Safe.to_string json))
+
+let show (t : t) : string =
+  Printf.sprintf "Attribution{origin=%s; gate=%s; verdict=%s}"
+    (string_of_origin t.origin) t.gate (string_of_verdict t.verdict)
+
+let pass ~origin ~gate ~evidence =
+  {
+    origin;
+    gate;
+    verdict = Pass;
+    evidence;
+    blocked_from = None;
+    blocked_to = None;
+    rationale = None;
+  }
+
+let fail ~origin ~gate ~evidence ?blocked_from ?blocked_to ?rationale () =
+  { origin; gate; verdict = Fail; evidence; blocked_from; blocked_to; rationale }
+
+let partial ~origin ~gate ~evidence ?rationale () =
+  {
+    origin;
+    gate;
+    verdict = Partial;
+    evidence;
+    blocked_from = None;
+    blocked_to = None;
+    rationale;
+  }

--- a/lib/attribution.mli
+++ b/lib/attribution.mli
@@ -10,8 +10,12 @@
     for backward compatibility. Emitters MAY additionally attach this
     typed envelope; consumers that don't understand it skip the field.
 
-    See [memory/audits/gate-attribution-baseline-2026-04-17.md] for
-    the per-gate evidence schema inventory this envelope targets.
+    Design note — sum types over products:
+    The outcome is a proper sum. Each case carries exactly the fields
+    relevant to that outcome (no optional / unused fields). A [Passed]
+    verdict cannot carry a [reason]; a [Transition_blocked] cannot omit
+    the from/to states. Illegal states are unrepresentable. See MEMORY
+    `parse-dont-validate`.
 
     @since 2.261.0 *)
 
@@ -25,70 +29,91 @@ type origin = Det | NonDet
 
     See MEMORY [deterministic-nondeterministic-boundary]. *)
 
-type verdict = Pass | Fail | Partial
-(** Decision outcome. [Partial] indicates a score-based gate where the
-    subject met some but not all criteria (score between fail and pass
-    thresholds). Detail lives in [evidence] and optionally [rationale]. *)
+type outcome =
+  | Passed
+      (** Gate allowed the subject through. [evidence] on the envelope
+          still captures what was checked (for audit). *)
+  | Policy_failed of { reason : string }
+      (** Non-transition gate rejection (content check, claim validity,
+          policy violation). The subject was not attempting a state
+          transition — it was proposing an action that got denied. *)
+  | Transition_blocked of {
+      from_state : string;
+      to_state : string;
+      reason : string;
+    }
+      (** Transition gate: the subject tried to move from [from_state]
+          to [to_state] and was blocked. Used by keeper_fsm,
+          agent_lifecycle, task_transition. *)
+  | Partial_pass of { score : float; rationale : string }
+      (** Score-based gate: the subject met some but not all criteria.
+          [score] is the gate's own scale (typically [[0.0, 1.0]]),
+          not normalized here. [rationale] explains the partial in
+          human-readable form. *)
 
 type t = {
-  origin: origin;
-  gate: string;
+  origin : origin;
+  gate : string;
       (** Gate identifier. One of [cdal_verdict], [verification],
           [accountability], [keeper_fsm], [oas_completion],
           [agent_lifecycle], [task_transition], [worker_dev_tools].
-          Future gates append to this list. *)
-  verdict: verdict;
-  evidence: Yojson.Safe.t;
-      (** Gate-specific structured evidence. Schema per gate defined in
-          the emitter; consumers treat as opaque JSON. *)
-  blocked_from: string option;
-      (** When [verdict = Fail] on a transition: the state the subject
-          was in before the block. [None] for non-transition gates. *)
-  blocked_to: string option;
-      (** When [verdict = Fail] on a transition: the state the subject
-          was trying to reach. [None] for non-transition gates. *)
-  rationale: string option;
-      (** Human-readable explanation. Primarily populated for
-          [NonDet] verdicts where the [evidence] alone is insufficient
-          to explain the decision. *)
+          Future gates append to this list.
+
+          Kept as [string] rather than a variant so new gates can emit
+          without a library-wide code change. Consumers that care about
+          the closed set should match on known values. *)
+  evidence : Yojson.Safe.t;
+      (** Gate-specific structured input data, always present regardless
+          of outcome (the gate saw something to decide on). Schema per
+          gate is defined in the emitter; consumers treat as opaque JSON
+          unless they know the gate. *)
+  outcome : outcome;
 }
 
 val to_yojson : t -> Yojson.Safe.t
-(** Serialize to JSON for SSE emission. Optional fields are omitted
-    (not emitted as [null]) to keep the wire format compact. *)
+(** Serialize to JSON for SSE emission.
+
+    Wire format: [outcome] is tagged by a ["kind"] field inside a nested
+    object:
+    - [Passed]             → [{"kind":"passed"}]
+    - [Policy_failed]      → [{"kind":"policy_failed","reason":"..."}]
+    - [Transition_blocked] → [{"kind":"transition_blocked",
+                               "from_state":"...","to_state":"...","reason":"..."}]
+    - [Partial_pass]       → [{"kind":"partial_pass",
+                               "score":0.85,"rationale":"..."}] *)
 
 val of_yojson : Yojson.Safe.t -> (t, string) result
 (** Parse from JSON. Returns [Error] with a human-readable message on
-    malformed input. Missing [evidence] defaults to [`Null]; other
-    required fields ([origin], [gate], [verdict]) must be present. *)
+    malformed input (missing field, unknown [kind], bad types).
+    Missing [evidence] defaults to [`Null]. *)
 
 val show : t -> string
 (** Single-line representation for debug logs. Elides [evidence] and
-    [rationale] to keep logs scannable. *)
+    long string fields to keep logs scannable. *)
 
-val pass : origin:origin -> gate:string -> evidence:Yojson.Safe.t -> t
-(** Smart constructor for a passing verdict. [blocked_from],
-    [blocked_to], [rationale] are [None]. *)
+(** {1 Smart constructors}
 
-val fail :
+    Prefer these over the raw record — they enforce the sum invariant
+    by construction (no way to build an illegal combination). *)
+
+val passed : origin:origin -> gate:string -> evidence:Yojson.Safe.t -> t
+
+val policy_failed :
+  origin:origin -> gate:string -> evidence:Yojson.Safe.t -> reason:string -> t
+
+val transition_blocked :
   origin:origin ->
   gate:string ->
   evidence:Yojson.Safe.t ->
-  ?blocked_from:string ->
-  ?blocked_to:string ->
-  ?rationale:string ->
-  unit ->
+  from_state:string ->
+  to_state:string ->
+  reason:string ->
   t
-(** Smart constructor for a failing verdict. All "why" fields are
-    optional — supply whichever apply to the gate in question. *)
 
-val partial :
+val partial_pass :
   origin:origin ->
   gate:string ->
   evidence:Yojson.Safe.t ->
-  ?rationale:string ->
-  unit ->
+  score:float ->
+  rationale:string ->
   t
-(** Smart constructor for a partial verdict (score-based gates).
-    [blocked_from] / [blocked_to] are [None] — partial verdicts don't
-    fit the block-on-transition model. *)

--- a/lib/attribution.mli
+++ b/lib/attribution.mli
@@ -1,0 +1,94 @@
+(** Structured attribution envelope for gate decisions.
+
+    Carries "who/where/what/why" for each pass/fail decision emitted
+    by the 8 verification gates (cdal_verdict, verification,
+    accountability, keeper_fsm, oas_completion, agent_lifecycle,
+    task_transition, worker_dev_tools). Propagates through SSE as an
+    optional field on every event so the dashboard can trace causality.
+
+    The existing [reason] / [reason_code] SSE fields remain untouched
+    for backward compatibility. Emitters MAY additionally attach this
+    typed envelope; consumers that don't understand it skip the field.
+
+    See [memory/audits/gate-attribution-baseline-2026-04-17.md] for
+    the per-gate evidence schema inventory this envelope targets.
+
+    @since 2.261.0 *)
+
+type origin = Det | NonDet
+(** Decision nature. [Det] is rule-based logic whose verdict follows
+    mechanically from the input (variant pattern matching, threshold
+    comparison). [NonDet] is model-based judgment (LLM scoring, human
+    verdict). The boundary is typed here because downstream consumers
+    treat them differently — Det verdicts are idempotent, NonDet
+    verdicts may vary across replays.
+
+    See MEMORY [deterministic-nondeterministic-boundary]. *)
+
+type verdict = Pass | Fail | Partial
+(** Decision outcome. [Partial] indicates a score-based gate where the
+    subject met some but not all criteria (score between fail and pass
+    thresholds). Detail lives in [evidence] and optionally [rationale]. *)
+
+type t = {
+  origin: origin;
+  gate: string;
+      (** Gate identifier. One of [cdal_verdict], [verification],
+          [accountability], [keeper_fsm], [oas_completion],
+          [agent_lifecycle], [task_transition], [worker_dev_tools].
+          Future gates append to this list. *)
+  verdict: verdict;
+  evidence: Yojson.Safe.t;
+      (** Gate-specific structured evidence. Schema per gate defined in
+          the emitter; consumers treat as opaque JSON. *)
+  blocked_from: string option;
+      (** When [verdict = Fail] on a transition: the state the subject
+          was in before the block. [None] for non-transition gates. *)
+  blocked_to: string option;
+      (** When [verdict = Fail] on a transition: the state the subject
+          was trying to reach. [None] for non-transition gates. *)
+  rationale: string option;
+      (** Human-readable explanation. Primarily populated for
+          [NonDet] verdicts where the [evidence] alone is insufficient
+          to explain the decision. *)
+}
+
+val to_yojson : t -> Yojson.Safe.t
+(** Serialize to JSON for SSE emission. Optional fields are omitted
+    (not emitted as [null]) to keep the wire format compact. *)
+
+val of_yojson : Yojson.Safe.t -> (t, string) result
+(** Parse from JSON. Returns [Error] with a human-readable message on
+    malformed input. Missing [evidence] defaults to [`Null]; other
+    required fields ([origin], [gate], [verdict]) must be present. *)
+
+val show : t -> string
+(** Single-line representation for debug logs. Elides [evidence] and
+    [rationale] to keep logs scannable. *)
+
+val pass : origin:origin -> gate:string -> evidence:Yojson.Safe.t -> t
+(** Smart constructor for a passing verdict. [blocked_from],
+    [blocked_to], [rationale] are [None]. *)
+
+val fail :
+  origin:origin ->
+  gate:string ->
+  evidence:Yojson.Safe.t ->
+  ?blocked_from:string ->
+  ?blocked_to:string ->
+  ?rationale:string ->
+  unit ->
+  t
+(** Smart constructor for a failing verdict. All "why" fields are
+    optional — supply whichever apply to the gate in question. *)
+
+val partial :
+  origin:origin ->
+  gate:string ->
+  evidence:Yojson.Safe.t ->
+  ?rationale:string ->
+  unit ->
+  t
+(** Smart constructor for a partial verdict (score-based gates).
+    [blocked_from] / [blocked_to] are [None] — partial verdicts don't
+    fit the block-on-transition model. *)

--- a/lib/dune
+++ b/lib/dune
@@ -15,6 +15,7 @@
    agent_tool_surfaces
    agent_registry_eio
    anti_rationalization
+   attribution
    auto_recall
    auto_responder
    auth

--- a/test/dune
+++ b/test/dune
@@ -27,7 +27,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
+ (names test_attribution test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -115,7 +115,7 @@
         test_warn_root_causes
         test_memory_hooks
         test_mid_turn_resume)
- (modules test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
+ (modules test_attribution test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_attribution.ml
+++ b/test/test_attribution.ml
@@ -1,143 +1,323 @@
 (** Tests for Attribution module.
 
-    Round-trip property for every variant combination, boundary cases
-    for missing fields, and smart constructor invariants. *)
+    Round-trip property for every outcome variant, wire-format tagged-union
+    shape, parse error paths, and smart-constructor invariants. *)
 
 module A = Masc_mcp.Attribution
 
 let evidence_sample : Yojson.Safe.t =
-  `Assoc [
-    ("check_id", `String "tool_limit");
-    ("observed", `Int 42);
-    ("threshold", `Int 30);
-  ]
+  `Assoc
+    [
+      ("check_id", `String "tool_limit");
+      ("observed", `Int 42);
+      ("threshold", `Int 30);
+    ]
+
+(* --- Outcome kind extractor for assertions --- *)
+
+let outcome_kind = function
+  | A.Passed -> "passed"
+  | A.Policy_failed _ -> "policy_failed"
+  | A.Transition_blocked _ -> "transition_blocked"
+  | A.Partial_pass _ -> "partial_pass"
+
+let origin_str = function A.Det -> "det" | A.NonDet -> "nondet"
 
 (* --- Round-trip --- *)
 
-let test_roundtrip_pass () =
-  let t = A.pass ~origin:Det ~gate:"cdal_verdict" ~evidence:evidence_sample in
+let test_roundtrip_passed () =
+  let t = A.passed ~origin:Det ~gate:"cdal_verdict" ~evidence:evidence_sample in
   let json = A.to_yojson t in
   match A.of_yojson json with
   | Ok t' ->
-    Alcotest.(check string) "origin" "det" (match t'.origin with Det -> "det" | NonDet -> "nondet");
+    Alcotest.(check string) "origin" "det" (origin_str t'.origin);
     Alcotest.(check string) "gate" t.gate t'.gate;
-    Alcotest.(check string) "verdict" "pass" (match t'.verdict with Pass -> "pass" | Fail -> "fail" | Partial -> "partial");
-    Alcotest.(check (option string)) "blocked_from" None t'.blocked_from;
-    Alcotest.(check (option string)) "rationale" None t'.rationale
-  | Error msg -> Alcotest.fail ("roundtrip pass failed: " ^ msg)
+    Alcotest.(check string) "outcome kind" "passed" (outcome_kind t'.outcome)
+  | Error msg -> Alcotest.fail ("roundtrip passed failed: " ^ msg)
 
-let test_roundtrip_fail_with_block () =
-  let t = A.fail ~origin:Det ~gate:"keeper_fsm" ~evidence:evidence_sample
-            ~blocked_from:"Idle" ~blocked_to:"Running"
-            ~rationale:"context overflow" ()
+let test_roundtrip_policy_failed () =
+  let t =
+    A.policy_failed ~origin:Det ~gate:"worker_dev_tools" ~evidence:`Null
+      ~reason:"command not allowed"
   in
   let json = A.to_yojson t in
   match A.of_yojson json with
   | Ok t' ->
-    Alcotest.(check (option string)) "blocked_from" (Some "Idle") t'.blocked_from;
-    Alcotest.(check (option string)) "blocked_to" (Some "Running") t'.blocked_to;
-    Alcotest.(check (option string)) "rationale" (Some "context overflow") t'.rationale
-  | Error msg -> Alcotest.fail ("roundtrip fail failed: " ^ msg)
+    (match t'.outcome with
+     | Policy_failed { reason } ->
+       Alcotest.(check string) "reason" "command not allowed" reason
+     | other ->
+       Alcotest.fail ("expected Policy_failed, got " ^ outcome_kind other))
+  | Error msg -> Alcotest.fail ("roundtrip policy_failed: " ^ msg)
 
-let test_roundtrip_partial_nondet () =
-  let t = A.partial ~origin:NonDet ~gate:"verification" ~evidence:evidence_sample
-            ~rationale:"output partially matches spec" ()
+let test_roundtrip_transition_blocked () =
+  let t =
+    A.transition_blocked ~origin:Det ~gate:"keeper_fsm"
+      ~evidence:evidence_sample ~from_state:"Idle" ~to_state:"Running"
+      ~reason:"context overflow"
   in
   let json = A.to_yojson t in
   match A.of_yojson json with
   | Ok t' ->
-    Alcotest.(check string) "origin" "nondet" (match t'.origin with Det -> "det" | NonDet -> "nondet");
-    Alcotest.(check string) "verdict" "partial" (match t'.verdict with Pass -> "pass" | Fail -> "fail" | Partial -> "partial");
-    Alcotest.(check (option string)) "rationale" (Some "output partially matches spec") t'.rationale
-  | Error msg -> Alcotest.fail ("roundtrip partial failed: " ^ msg)
+    (match t'.outcome with
+     | Transition_blocked { from_state; to_state; reason } ->
+       Alcotest.(check string) "from_state" "Idle" from_state;
+       Alcotest.(check string) "to_state" "Running" to_state;
+       Alcotest.(check string) "reason" "context overflow" reason
+     | other ->
+       Alcotest.fail
+         ("expected Transition_blocked, got " ^ outcome_kind other))
+  | Error msg -> Alcotest.fail ("roundtrip transition_blocked: " ^ msg)
+
+let test_roundtrip_partial_pass_nondet () =
+  let t =
+    A.partial_pass ~origin:NonDet ~gate:"verification" ~evidence:evidence_sample
+      ~score:0.85 ~rationale:"output partially matches spec"
+  in
+  let json = A.to_yojson t in
+  match A.of_yojson json with
+  | Ok t' ->
+    Alcotest.(check string) "origin" "nondet" (origin_str t'.origin);
+    (match t'.outcome with
+     | Partial_pass { score; rationale } ->
+       Alcotest.(check (float 0.0001)) "score" 0.85 score;
+       Alcotest.(check string) "rationale" "output partially matches spec"
+         rationale
+     | other ->
+       Alcotest.fail ("expected Partial_pass, got " ^ outcome_kind other))
+  | Error msg -> Alcotest.fail ("roundtrip partial_pass: " ^ msg)
 
 (* --- Wire format shape --- *)
 
-let test_wire_format_omits_none_fields () =
-  let t = A.pass ~origin:Det ~gate:"accountability" ~evidence:`Null in
-  let json = A.to_yojson t in
+let outcome_kind_in_json json =
   match json with
+  | `Assoc fields -> (
+    match List.assoc_opt "kind" fields with
+    | Some (`String s) -> s
+    | _ -> "<no kind>")
+  | _ -> "<not object>"
+
+let test_wire_format_tagged_union () =
+  let cases =
+    [
+      (A.passed ~origin:Det ~gate:"x" ~evidence:`Null, "passed");
+      ( A.policy_failed ~origin:Det ~gate:"x" ~evidence:`Null ~reason:"r",
+        "policy_failed" );
+      ( A.transition_blocked ~origin:Det ~gate:"x" ~evidence:`Null
+          ~from_state:"A" ~to_state:"B" ~reason:"r",
+        "transition_blocked" );
+      ( A.partial_pass ~origin:Det ~gate:"x" ~evidence:`Null ~score:0.5
+          ~rationale:"r",
+        "partial_pass" );
+    ]
+  in
+  List.iter
+    (fun (t, expected_kind) ->
+      let json = A.to_yojson t in
+      match json with
+      | `Assoc fields -> (
+        match List.assoc_opt "outcome" fields with
+        | Some oj ->
+          Alcotest.(check string)
+            ("outcome.kind for " ^ expected_kind)
+            expected_kind (outcome_kind_in_json oj)
+        | None -> Alcotest.fail "missing outcome field")
+      | _ -> Alcotest.fail "to_yojson must produce an object")
+    cases
+
+let test_wire_format_toplevel_shape () =
+  let t = A.passed ~origin:Det ~gate:"x" ~evidence:`Null in
+  match A.to_yojson t with
   | `Assoc fields ->
-    Alcotest.(check bool) "no blocked_from" false (List.mem_assoc "blocked_from" fields);
-    Alcotest.(check bool) "no blocked_to" false (List.mem_assoc "blocked_to" fields);
-    Alcotest.(check bool) "no rationale" false (List.mem_assoc "rationale" fields);
-    Alcotest.(check bool) "has origin" true (List.mem_assoc "origin" fields);
-    Alcotest.(check bool) "has gate" true (List.mem_assoc "gate" fields);
-    Alcotest.(check bool) "has verdict" true (List.mem_assoc "verdict" fields);
-    Alcotest.(check bool) "has evidence" true (List.mem_assoc "evidence" fields)
+    List.iter
+      (fun key ->
+        Alcotest.(check bool)
+          (key ^ " present") true
+          (List.mem_assoc key fields))
+      [ "origin"; "gate"; "evidence"; "outcome" ];
+    (* No leftover top-level fields from the old product-type design. *)
+    List.iter
+      (fun key ->
+        Alcotest.(check bool)
+          (key ^ " absent (sum type, not product)") false
+          (List.mem_assoc key fields))
+      [ "verdict"; "reason"; "blocked_from"; "blocked_to"; "rationale" ]
   | _ -> Alcotest.fail "to_yojson must produce an object"
 
-(* --- Error paths --- *)
+(* --- Parse errors --- *)
 
-let test_parse_rejects_missing_origin () =
-  let json = `Assoc [("gate", `String "x"); ("verdict", `String "pass")] in
+let expect_error name json =
   match A.of_yojson json with
-  | Ok _ -> Alcotest.fail "expected error on missing origin"
+  | Ok _ -> Alcotest.fail ("expected error for " ^ name)
   | Error _ -> ()
 
-let test_parse_rejects_unknown_origin () =
-  let json = `Assoc [
-    ("origin", `String "maybe");
-    ("gate", `String "x");
-    ("verdict", `String "pass");
-  ] in
-  match A.of_yojson json with
-  | Ok _ -> Alcotest.fail "expected error on unknown origin"
-  | Error msg ->
-    (* Message must mention the invalid value so operators can grep logs. *)
-    Alcotest.(check bool) "error mentions bad input"
-      true (Astring.String.is_infix ~affix:"maybe" msg)
+let test_parse_missing_origin () =
+  expect_error "missing origin"
+    (`Assoc
+       [
+         ("gate", `String "x");
+         ("evidence", `Null);
+         ("outcome", `Assoc [ ("kind", `String "passed") ]);
+       ])
 
-let test_parse_missing_evidence_defaults_to_null () =
-  let json = `Assoc [
-    ("origin", `String "det");
-    ("gate", `String "x");
-    ("verdict", `String "pass");
-  ] in
-  match A.of_yojson json with
-  | Ok t -> Alcotest.(check bool) "evidence=null" true (t.evidence = `Null)
+let test_parse_unknown_origin () =
+  match
+    A.of_yojson
+      (`Assoc
+         [
+           ("origin", `String "maybe");
+           ("gate", `String "x");
+           ("evidence", `Null);
+           ("outcome", `Assoc [ ("kind", `String "passed") ]);
+         ])
+  with
+  | Ok _ -> Alcotest.fail "expected error"
+  | Error msg ->
+    Alcotest.(check bool)
+      "error mentions bad input" true
+      (Astring.String.is_infix ~affix:"maybe" msg)
+
+let test_parse_unknown_outcome_kind () =
+  match
+    A.of_yojson
+      (`Assoc
+         [
+           ("origin", `String "det");
+           ("gate", `String "x");
+           ("evidence", `Null);
+           ("outcome", `Assoc [ ("kind", `String "shrug") ]);
+         ])
+  with
+  | Ok _ -> Alcotest.fail "expected error"
+  | Error msg ->
+    Alcotest.(check bool)
+      "error mentions bad kind" true
+      (Astring.String.is_infix ~affix:"shrug" msg)
+
+let test_parse_policy_failed_missing_reason () =
+  expect_error "policy_failed missing reason"
+    (`Assoc
+       [
+         ("origin", `String "det");
+         ("gate", `String "x");
+         ("evidence", `Null);
+         ("outcome", `Assoc [ ("kind", `String "policy_failed") ]);
+       ])
+
+let test_parse_transition_blocked_missing_field () =
+  (* Missing to_state. *)
+  expect_error "transition_blocked missing to_state"
+    (`Assoc
+       [
+         ("origin", `String "det");
+         ("gate", `String "x");
+         ("evidence", `Null);
+         ( "outcome",
+           `Assoc
+             [
+               ("kind", `String "transition_blocked");
+               ("from_state", `String "A");
+               ("reason", `String "r");
+             ] );
+       ])
+
+let test_parse_partial_pass_wrong_type () =
+  (* score as string instead of number. *)
+  expect_error "partial_pass score wrong type"
+    (`Assoc
+       [
+         ("origin", `String "det");
+         ("gate", `String "x");
+         ("evidence", `Null);
+         ( "outcome",
+           `Assoc
+             [
+               ("kind", `String "partial_pass");
+               ("score", `String "high");
+               ("rationale", `String "r");
+             ] );
+       ])
+
+let test_parse_missing_evidence_defaults_null () =
+  match
+    A.of_yojson
+      (`Assoc
+         [
+           ("origin", `String "det");
+           ("gate", `String "x");
+           ("outcome", `Assoc [ ("kind", `String "passed") ]);
+         ])
+  with
+  | Ok t ->
+    Alcotest.(check bool) "evidence=Null" true (t.evidence = `Null)
   | Error msg -> Alcotest.fail ("should tolerate missing evidence: " ^ msg)
 
-let test_parse_rejects_non_object () =
-  match A.of_yojson (`String "not an object") with
-  | Ok _ -> Alcotest.fail "expected error on non-object"
-  | Error _ -> ()
+let test_parse_non_object () =
+  expect_error "non-object" (`String "nope")
 
 (* --- Show --- *)
 
-let test_show_elides_evidence () =
-  let t = A.fail ~origin:NonDet ~gate:"verification"
-            ~evidence:(`String "very long evidence blob that should not appear")
-            ~rationale:"also long rationale"
-            ()
+let test_show_elides_long_fields () =
+  let t =
+    A.policy_failed ~origin:NonDet ~gate:"verification"
+      ~evidence:(`String "very long evidence blob that should not appear")
+      ~reason:"also long rationale text"
   in
   let s = A.show t in
-  Alcotest.(check bool) "no evidence in show" false
+  Alcotest.(check bool)
+    "no evidence in show" false
     (Astring.String.is_infix ~affix:"very long evidence" s);
-  Alcotest.(check bool) "no rationale in show" false
+  Alcotest.(check bool)
+    "no reason text in show" false
     (Astring.String.is_infix ~affix:"also long rationale" s);
-  Alcotest.(check bool) "has gate" true
-    (Astring.String.is_infix ~affix:"verification" s)
+  Alcotest.(check bool)
+    "has gate" true
+    (Astring.String.is_infix ~affix:"verification" s);
+  Alcotest.(check bool)
+    "has outcome kind" true
+    (Astring.String.is_infix ~affix:"policy_failed" s)
 
 (* --- Entry --- *)
 
 let () =
-  Alcotest.run "attribution" [
-    ("roundtrip", [
-      Alcotest.test_case "pass"                       `Quick test_roundtrip_pass;
-      Alcotest.test_case "fail with block info"       `Quick test_roundtrip_fail_with_block;
-      Alcotest.test_case "partial nondet"             `Quick test_roundtrip_partial_nondet;
-    ]);
-    ("wire format", [
-      Alcotest.test_case "omits None fields"          `Quick test_wire_format_omits_none_fields;
-    ]);
-    ("parse errors", [
-      Alcotest.test_case "missing origin"             `Quick test_parse_rejects_missing_origin;
-      Alcotest.test_case "unknown origin value"       `Quick test_parse_rejects_unknown_origin;
-      Alcotest.test_case "missing evidence defaults"  `Quick test_parse_missing_evidence_defaults_to_null;
-      Alcotest.test_case "non-object input"           `Quick test_parse_rejects_non_object;
-    ]);
-    ("show", [
-      Alcotest.test_case "elides evidence/rationale"  `Quick test_show_elides_evidence;
-    ]);
-  ]
+  Alcotest.run "attribution"
+    [
+      ( "roundtrip",
+        [
+          Alcotest.test_case "passed" `Quick test_roundtrip_passed;
+          Alcotest.test_case "policy_failed" `Quick
+            test_roundtrip_policy_failed;
+          Alcotest.test_case "transition_blocked" `Quick
+            test_roundtrip_transition_blocked;
+          Alcotest.test_case "partial_pass nondet" `Quick
+            test_roundtrip_partial_pass_nondet;
+        ] );
+      ( "wire format",
+        [
+          Alcotest.test_case "tagged union kind" `Quick
+            test_wire_format_tagged_union;
+          Alcotest.test_case "top-level shape (no leftover flat fields)"
+            `Quick test_wire_format_toplevel_shape;
+        ] );
+      ( "parse errors",
+        [
+          Alcotest.test_case "missing origin" `Quick test_parse_missing_origin;
+          Alcotest.test_case "unknown origin" `Quick test_parse_unknown_origin;
+          Alcotest.test_case "unknown outcome kind" `Quick
+            test_parse_unknown_outcome_kind;
+          Alcotest.test_case "policy_failed missing reason" `Quick
+            test_parse_policy_failed_missing_reason;
+          Alcotest.test_case "transition_blocked missing field" `Quick
+            test_parse_transition_blocked_missing_field;
+          Alcotest.test_case "partial_pass wrong type" `Quick
+            test_parse_partial_pass_wrong_type;
+          Alcotest.test_case "missing evidence defaults to null" `Quick
+            test_parse_missing_evidence_defaults_null;
+          Alcotest.test_case "non-object input" `Quick test_parse_non_object;
+        ] );
+      ( "show",
+        [
+          Alcotest.test_case "elides long fields" `Quick
+            test_show_elides_long_fields;
+        ] );
+    ]

--- a/test/test_attribution.ml
+++ b/test/test_attribution.ml
@@ -1,0 +1,143 @@
+(** Tests for Attribution module.
+
+    Round-trip property for every variant combination, boundary cases
+    for missing fields, and smart constructor invariants. *)
+
+module A = Masc_mcp.Attribution
+
+let evidence_sample : Yojson.Safe.t =
+  `Assoc [
+    ("check_id", `String "tool_limit");
+    ("observed", `Int 42);
+    ("threshold", `Int 30);
+  ]
+
+(* --- Round-trip --- *)
+
+let test_roundtrip_pass () =
+  let t = A.pass ~origin:Det ~gate:"cdal_verdict" ~evidence:evidence_sample in
+  let json = A.to_yojson t in
+  match A.of_yojson json with
+  | Ok t' ->
+    Alcotest.(check string) "origin" "det" (match t'.origin with Det -> "det" | NonDet -> "nondet");
+    Alcotest.(check string) "gate" t.gate t'.gate;
+    Alcotest.(check string) "verdict" "pass" (match t'.verdict with Pass -> "pass" | Fail -> "fail" | Partial -> "partial");
+    Alcotest.(check (option string)) "blocked_from" None t'.blocked_from;
+    Alcotest.(check (option string)) "rationale" None t'.rationale
+  | Error msg -> Alcotest.fail ("roundtrip pass failed: " ^ msg)
+
+let test_roundtrip_fail_with_block () =
+  let t = A.fail ~origin:Det ~gate:"keeper_fsm" ~evidence:evidence_sample
+            ~blocked_from:"Idle" ~blocked_to:"Running"
+            ~rationale:"context overflow" ()
+  in
+  let json = A.to_yojson t in
+  match A.of_yojson json with
+  | Ok t' ->
+    Alcotest.(check (option string)) "blocked_from" (Some "Idle") t'.blocked_from;
+    Alcotest.(check (option string)) "blocked_to" (Some "Running") t'.blocked_to;
+    Alcotest.(check (option string)) "rationale" (Some "context overflow") t'.rationale
+  | Error msg -> Alcotest.fail ("roundtrip fail failed: " ^ msg)
+
+let test_roundtrip_partial_nondet () =
+  let t = A.partial ~origin:NonDet ~gate:"verification" ~evidence:evidence_sample
+            ~rationale:"output partially matches spec" ()
+  in
+  let json = A.to_yojson t in
+  match A.of_yojson json with
+  | Ok t' ->
+    Alcotest.(check string) "origin" "nondet" (match t'.origin with Det -> "det" | NonDet -> "nondet");
+    Alcotest.(check string) "verdict" "partial" (match t'.verdict with Pass -> "pass" | Fail -> "fail" | Partial -> "partial");
+    Alcotest.(check (option string)) "rationale" (Some "output partially matches spec") t'.rationale
+  | Error msg -> Alcotest.fail ("roundtrip partial failed: " ^ msg)
+
+(* --- Wire format shape --- *)
+
+let test_wire_format_omits_none_fields () =
+  let t = A.pass ~origin:Det ~gate:"accountability" ~evidence:`Null in
+  let json = A.to_yojson t in
+  match json with
+  | `Assoc fields ->
+    Alcotest.(check bool) "no blocked_from" false (List.mem_assoc "blocked_from" fields);
+    Alcotest.(check bool) "no blocked_to" false (List.mem_assoc "blocked_to" fields);
+    Alcotest.(check bool) "no rationale" false (List.mem_assoc "rationale" fields);
+    Alcotest.(check bool) "has origin" true (List.mem_assoc "origin" fields);
+    Alcotest.(check bool) "has gate" true (List.mem_assoc "gate" fields);
+    Alcotest.(check bool) "has verdict" true (List.mem_assoc "verdict" fields);
+    Alcotest.(check bool) "has evidence" true (List.mem_assoc "evidence" fields)
+  | _ -> Alcotest.fail "to_yojson must produce an object"
+
+(* --- Error paths --- *)
+
+let test_parse_rejects_missing_origin () =
+  let json = `Assoc [("gate", `String "x"); ("verdict", `String "pass")] in
+  match A.of_yojson json with
+  | Ok _ -> Alcotest.fail "expected error on missing origin"
+  | Error _ -> ()
+
+let test_parse_rejects_unknown_origin () =
+  let json = `Assoc [
+    ("origin", `String "maybe");
+    ("gate", `String "x");
+    ("verdict", `String "pass");
+  ] in
+  match A.of_yojson json with
+  | Ok _ -> Alcotest.fail "expected error on unknown origin"
+  | Error msg ->
+    (* Message must mention the invalid value so operators can grep logs. *)
+    Alcotest.(check bool) "error mentions bad input"
+      true (Astring.String.is_infix ~affix:"maybe" msg)
+
+let test_parse_missing_evidence_defaults_to_null () =
+  let json = `Assoc [
+    ("origin", `String "det");
+    ("gate", `String "x");
+    ("verdict", `String "pass");
+  ] in
+  match A.of_yojson json with
+  | Ok t -> Alcotest.(check bool) "evidence=null" true (t.evidence = `Null)
+  | Error msg -> Alcotest.fail ("should tolerate missing evidence: " ^ msg)
+
+let test_parse_rejects_non_object () =
+  match A.of_yojson (`String "not an object") with
+  | Ok _ -> Alcotest.fail "expected error on non-object"
+  | Error _ -> ()
+
+(* --- Show --- *)
+
+let test_show_elides_evidence () =
+  let t = A.fail ~origin:NonDet ~gate:"verification"
+            ~evidence:(`String "very long evidence blob that should not appear")
+            ~rationale:"also long rationale"
+            ()
+  in
+  let s = A.show t in
+  Alcotest.(check bool) "no evidence in show" false
+    (Astring.String.is_infix ~affix:"very long evidence" s);
+  Alcotest.(check bool) "no rationale in show" false
+    (Astring.String.is_infix ~affix:"also long rationale" s);
+  Alcotest.(check bool) "has gate" true
+    (Astring.String.is_infix ~affix:"verification" s)
+
+(* --- Entry --- *)
+
+let () =
+  Alcotest.run "attribution" [
+    ("roundtrip", [
+      Alcotest.test_case "pass"                       `Quick test_roundtrip_pass;
+      Alcotest.test_case "fail with block info"       `Quick test_roundtrip_fail_with_block;
+      Alcotest.test_case "partial nondet"             `Quick test_roundtrip_partial_nondet;
+    ]);
+    ("wire format", [
+      Alcotest.test_case "omits None fields"          `Quick test_wire_format_omits_none_fields;
+    ]);
+    ("parse errors", [
+      Alcotest.test_case "missing origin"             `Quick test_parse_rejects_missing_origin;
+      Alcotest.test_case "unknown origin value"       `Quick test_parse_rejects_unknown_origin;
+      Alcotest.test_case "missing evidence defaults"  `Quick test_parse_missing_evidence_defaults_to_null;
+      Alcotest.test_case "non-object input"           `Quick test_parse_rejects_non_object;
+    ]);
+    ("show", [
+      Alcotest.test_case "elides evidence/rationale"  `Quick test_show_elides_evidence;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

Attribution 4-layer plan의 Layer 1 첫 커밋. 8개 gate의 pass/fail 결정을 typed로 SSE에 싣기 위한 envelope 도입.

**타입 정의만 포함.** 실제 gate emitter 마이그레이션은 후속 PR로 분리 (cdal_verdict / verification / keeper_state_machine 각각 1개씩).

## OCaml SSOT (`lib/attribution.mli`)

```ocaml
type origin = Det | NonDet
type verdict = Pass | Fail | Partial
type t = {
  origin; gate; verdict;
  evidence: Yojson.Safe.t;
  blocked_from; blocked_to; rationale;   (* all optional *)
}
val pass / fail / partial : smart constructors
```

- `to_yojson` omits `None` 필드 (wire format compact)
- `of_yojson` returns `Result` with human-readable parse errors (missing field, bad variant)

## TypeScript mirror (`dashboard/src/types/sse.ts`)

- `Attribution` interface (origin/gate/verdict/evidence/optional fields)
- `AttributionGate` canonical 8 string union, 열린 타입 (new gate 자유 추가)
- `SSEEvent.attribution?: Attribution` — 기존 `reason`/`reason_code` 필드는 **그대로 유지** (backward compat). 소비자가 envelope를 몰라도 무시 가능.

## 테스트 (9 cases, all pass)

- Roundtrip: pass / fail+block / partial+nondet
- Wire format: None 필드 omit 검증
- Parse errors: missing origin / unknown value / missing evidence (→ Null default) / non-object
- Show: evidence/rationale elision (로그 가독성)

## 왜 이 PR만 먼저 merge하나

Plan은 "types + 3 gate migration"이 한 PR이었으나 surgical changes 원칙에 맞춰 분할. 타입만 선착륙하면:
- Layer 2 (phantom type GADT) 작업이 이 타입 위에서 시작 가능
- Gate migration은 각각 독립 리뷰 (CodeRabbit scope 작음)

## Non-goals

- Gate emitter 변경 없음
- `lib/observability/` 서브디렉토리 신설 없음 (기존 `lib/observability_redact.ml` 평탄 구조 일관 유지)
- `reason`/`reason_code` 필드 삭제/변경 없음
- Dashboard UI 변경 없음

## 참고

- Plan: `planning/claude-plans/abundant-skipping-sutton.md`
- Baseline audit: me repo PR #1010 `memory/audits/gate-attribution-baseline-2026-04-17.md`

## Test plan

- [x] `dune build --root . @check` (OCaml lib)
- [x] `dune exec --root . test/test_attribution.exe` — 9/9 pass
- [x] `pnpm exec tsc --noEmit` (dashboard)
- [ ] CI 전체 통과 확인
- [ ] CodeRabbit review 대응