### PR TITLE
feat(autoresearch): Add author tracking to loops for enterprise auditability

### DIFF
--- a/dashboard/src/api/schemas/autoresearch.test.ts
+++ b/dashboard/src/api/schemas/autoresearch.test.ts
@@ -10,6 +10,7 @@ import {
 function validSummary(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     loop_id: 'loop-1',
+    author: null,
     goal: 'maximize coverage',
     metric_fn: 'coverage.sh',
     model_model: 'claude-opus-4-7',

--- a/dashboard/src/api/schemas/autoresearch.ts
+++ b/dashboard/src/api/schemas/autoresearch.ts
@@ -60,6 +60,7 @@ export const AutoresearchCycleRecordSchema = object({
 
 export const AutoresearchLoopSummarySchema = object({
   loop_id: string(),
+  author: nullable(string()),
   goal: string(),
   metric_fn: string(),
   model_model: string(),

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -31,6 +31,7 @@ function loopSummary(
 ): AutoresearchLoopSummary {
   return {
     loop_id,
+    author: null,
     goal: `Goal ${loop_id}`,
     metric_fn: 'echo 1',
     model_model: 'glm',

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -119,6 +119,10 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
             <div class="text-[var(--text-body)] text-sm font-mono">${formatElapsedCompact(loop.elapsed_s)}</div>
           </div>
           <div>
+            <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">실행자</div>
+            <div class="text-[var(--text-body)] text-sm font-mono">${loop.author ?? '알 수 없음'}</div>
+          </div>
+          <div>
             <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-0.5">모델</div>
             <div class="text-[var(--text-body)] text-sm font-mono">${loop.model_model}</div>
           </div>

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -147,7 +147,7 @@ let generate_code_change = Autoresearch_codegen.generate_code_change
 (* Loop State Management                                             *)
 (* ================================================================ *)
 
-let create_state ~goal ~metric_fn ?model_model ~target_file ?target_score
+let create_state ~goal ~metric_fn ?model_model ?author ~target_file ?target_score
     ~cycle_timeout_s ~max_cycles ?patience ?build_verify_fn
     ?(lower_is_better = false) ~workdir () =
   let model_model = match model_model with
@@ -161,6 +161,7 @@ let create_state ~goal ~metric_fn ?model_model ~target_file ?target_score
   in
   {
     loop_id = generate_loop_id ();
+    author;
     goal;
     metric_fn;
     model_model;
@@ -314,6 +315,7 @@ let stop_loop ~base_path ?reason loop_id =
             let state =
               {
                 loop_id = persisted.loop_id;
+                author = persisted.author;
                 goal = persisted.goal;
                 metric_fn = persisted.metric_fn;
                 model_model = persisted.model_model;

--- a/lib/autoresearch/autoresearch_serde.ml
+++ b/lib/autoresearch/autoresearch_serde.ml
@@ -194,6 +194,7 @@ let cycle_of_yojson (json : Yojson.Safe.t) : cycle_record =
 let state_to_yojson (s : loop_state) : Yojson.Safe.t =
   `Assoc [
     ("loop_id", `String s.loop_id);
+    ("author", Json_util.string_opt_to_json s.author);
     ("goal", `String s.goal);
     ("metric_fn", `String s.metric_fn);
     ("model_model", `String s.model_model);
@@ -228,6 +229,7 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
 let state_of_yojson_result (json : Yojson.Safe.t) : (persisted_summary, string) result =
   let kind = "persisted_summary" in
   let* loop_id = required_string_field kind json "loop_id" in
+  let* author = optional_string_field json "author" in
   let* status =
     match Yojson.Safe.Util.member "status" json with
     | `String value -> status_of_string_result (String.trim value)
@@ -305,6 +307,7 @@ let state_of_yojson_result (json : Yojson.Safe.t) : (persisted_summary, string) 
   Ok
     {
       loop_id;
+      author;
       status;
       current_cycle;
       baseline;

--- a/lib/autoresearch/autoresearch_types.ml
+++ b/lib/autoresearch/autoresearch_types.ml
@@ -21,6 +21,7 @@ type status = Running | Completed | Stopped | Error
 
 type loop_state = {
   loop_id : string;
+  author : string option;
   goal : string;
   metric_fn : string;
   model_model : string;
@@ -64,6 +65,7 @@ type swarm_link = {
 
 type persisted_summary = {
   loop_id : string;
+  author : string option;
   status : status;
   current_cycle : int;
   baseline : float;

--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -290,6 +290,7 @@ let rehydrate_persisted_loop (persisted : Autoresearch_types.persisted_summary) 
   let now = Time_compat.now () in
   {
     Autoresearch_types.loop_id = persisted.loop_id;
+    author = persisted.author;
     goal = persisted.goal;
     metric_fn = persisted.metric_fn;
     model_model = persisted.model_model;

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -168,6 +168,7 @@ let prepare_managed_target_file ~source_workdir ~managed_workdir target_file =
 let setup_running_loop (ctx : context) (params : start_params) =
   let state =
     Autoresearch.create_state ~goal:params.goal ~metric_fn:params.metric_fn
+      ?author:ctx.agent_name
       ~model_model:params.model_model ~target_file:params.target_file
       ?target_score:params.target_score
       ~cycle_timeout_s:params.cycle_timeout_s ~max_cycles:params.max_cycles


### PR DESCRIPTION
## Description
Enterprise Improvement: Track and display the author (user/agent) of autoresearch loops. In enterprise environments, auditing who triggered an autonomous experiment is crucial for resource tracking and security.

## Changes
- Add `author: string option` to `loop_state` and `persisted_summary` in `autoresearch_types.ml`.
- Serialize and deserialize `author` in `autoresearch_serde.ml`.
- Initialize `author` when setting up a running loop in `tool_autoresearch.ml` using `ctx.agent_name`.
- Update API responses and the dashboard frontend React UI (`AutoresearchLoopSummary`, `autoresearch.ts`) to display the author field.

Fixes MASC Issue: task-194