### PR TITLE
feat(dashboard): FleetFsmMatrix component (LT-16b, stacks on #7723)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -9,7 +9,9 @@ import type { KeeperConversationDetails } from '../types'
 import { currentDashboardActor, jsonHeaders, runOperatorAction, fetchWithTimeout, DEFAULT_GET_TIMEOUT_MS } from './core'
 import {
   parseKeeperCompositeSnapshot,
+  parseFleetCompositeSnapshot,
   type KeeperCompositeSnapshot,
+  type FleetCompositeSnapshot,
 } from './schemas/keeper-composite'
 
 export type {
@@ -22,10 +24,13 @@ export type {
   KeeperCompositeDecisionStage,
   KeeperCompositeCascadeState,
   KeeperCompositeCompactionStage,
+  FleetCompositeSnapshot,
 } from './schemas/keeper-composite'
 export {
   KeeperCompositeSnapshotSchema,
+  FleetCompositeSnapshotSchema,
   parseKeeperCompositeSnapshot,
+  parseFleetCompositeSnapshot,
   CompositeSchemaDriftError,
 } from './schemas/keeper-composite'
 
@@ -579,6 +584,23 @@ export async function fetchKeeperComposite(
   )
   if (!resp.ok) throw new Error(`composite fetch failed: ${resp.status}`)
   return parseKeeperCompositeSnapshot(await resp.json())
+}
+
+/**
+ * LT-16a: fetch the fleet-wide composite snapshot in one envelope.
+ * Backend reuses the same per-snapshot shape as fetchKeeperComposite,
+ * wrapped in { generated_at, count, snapshots: [...] }.
+ */
+export async function fetchKeepersComposite(
+  opts?: { signal?: AbortSignal },
+): Promise<FleetCompositeSnapshot> {
+  const resp = await fetchWithTimeout(
+    `/api/v1/keepers/composite`,
+    { headers: jsonHeaders(), signal: opts?.signal },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!resp.ok) throw new Error(`fleet composite fetch failed: ${resp.status}`)
+  return parseFleetCompositeSnapshot(await resp.json())
 }
 
 // --- Eval Quality (RFC-MASC-005 Phase 3) ---

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -19,6 +19,7 @@
  */
 
 import {
+  array,
   boolean,
   fallback,
   nullable,
@@ -150,6 +151,33 @@ export class CompositeSchemaDriftError extends Error {
 
 export function parseKeeperCompositeSnapshot(data: unknown): KeeperCompositeSnapshot {
   const result = safeParse(KeeperCompositeSnapshotSchema, data)
+  if (!result.success) {
+    throw new CompositeSchemaDriftError(result.issues)
+  }
+  return result.output
+}
+
+// ── Fleet composite (LT-16a) ─────────────────────────────
+//
+// Backend: GET /api/v1/keepers/composite returns every registered
+// keeper in one envelope. Reuses the per-keeper snapshot shape so the
+// matrix UI (LT-16b, dashboard/src/components/fleet-fsm-matrix.ts) can
+// share render logic between single-keeper detail and fleet views.
+//
+// Each poll bumps the masc_keeper_invariant_violations_total counter
+// for any violating keeper (documented poll-triggered behaviour,
+// docs/observability/cascade-metrics.md §masc_keeper_invariant_violations_total).
+
+export const FleetCompositeSnapshotSchema = object({
+  generated_at: number(),
+  count: number(),
+  snapshots: array(KeeperCompositeSnapshotSchema),
+})
+
+export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
+
+export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
+  const result = safeParse(FleetCompositeSnapshotSchema, data)
   if (!result.success) {
     throw new CompositeSchemaDriftError(result.issues)
   }

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  chipClassFor,
+  inferKeeperNameFrom,
+  tallyInvariantViolations,
+} from './fleet-fsm-matrix'
+import type { KeeperCompositeSnapshot } from '../api/keeper'
+
+function snapshot(
+  overrides: Partial<KeeperCompositeSnapshot> & {
+    name?: string
+    allHold?: boolean
+    violate?: Partial<KeeperCompositeSnapshot['invariants']>
+  } = {},
+): KeeperCompositeSnapshot {
+  const name = overrides.name ?? 'alpha'
+  const allHold = overrides.allHold ?? true
+  const base: KeeperCompositeSnapshot = {
+    correlation_id: `keeper:${name}:42`,
+    run_id: `r-0-${name}`,
+    ts: 1_713_000_000,
+    phase: 'Running',
+    turn_phase: 'idle',
+    decision: { stage: 'undecided' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: true },
+    invariants: {
+      phase_turn_alignment: allHold,
+      no_cascade_before_measurement: allHold,
+      compaction_atomicity: allHold,
+      event_priority_monotone: allHold,
+      ...overrides.violate,
+    },
+    is_live: false,
+    last_outcome: null,
+  }
+  return { ...base, ...overrides }
+}
+
+describe('chipClassFor', () => {
+  it('maps known states to a distinct tailwind class', () => {
+    expect(chipClassFor('Running')).toMatch(/emerald/)
+    expect(chipClassFor('Failing')).toMatch(/red/)
+    expect(chipClassFor('Compacting')).toMatch(/amber/)
+    expect(chipClassFor('exhausted')).toMatch(/red/)
+  })
+
+  it('falls back to the default chip for unknown states', () => {
+    const cls = chipClassFor('unknown_state_variant')
+    expect(cls).toContain('bg-zinc-800')
+  })
+})
+
+describe('inferKeeperNameFrom', () => {
+  it('extracts the keeper name from a canonical correlation_id', () => {
+    const snap = snapshot({ name: 'gen12-payroll' })
+    expect(inferKeeperNameFrom(snap)).toBe('gen12-payroll')
+  })
+
+  it('falls back to the correlation_id verbatim on non-canonical ids', () => {
+    const snap = snapshot({ correlation_id: 'not-a-keeper-id' })
+    expect(inferKeeperNameFrom(snap)).toBe('not-a-keeper-id')
+  })
+})
+
+describe('tallyInvariantViolations', () => {
+  it('returns all zeros when every keeper satisfies every invariant', () => {
+    const s = [snapshot({ name: 'a' }), snapshot({ name: 'b' })]
+    expect(tallyInvariantViolations(s)).toEqual({
+      phase_turn_alignment: 0,
+      no_cascade_before_measurement: 0,
+      compaction_atomicity: 0,
+      event_priority_monotone: 0,
+    })
+  })
+
+  it('counts one per keeper per violated invariant', () => {
+    const s = [
+      snapshot({ name: 'a', violate: { phase_turn_alignment: false } }),
+      snapshot({ name: 'b', violate: { phase_turn_alignment: false, compaction_atomicity: false } }),
+      snapshot({ name: 'c' }),
+    ]
+    const t = tallyInvariantViolations(s)
+    expect(t.phase_turn_alignment).toBe(2)
+    expect(t.compaction_atomicity).toBe(1)
+    expect(t.no_cascade_before_measurement).toBe(0)
+    expect(t.event_priority_monotone).toBe(0)
+  })
+
+  it('treats an empty fleet as clean', () => {
+    expect(tallyInvariantViolations([])).toEqual({
+      phase_turn_alignment: 0,
+      no_cascade_before_measurement: 0,
+      compaction_atomicity: 0,
+      event_priority_monotone: 0,
+    })
+  })
+})

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -1,0 +1,297 @@
+/**
+ * FleetFsmMatrix (LT-16b)
+ *
+ * Small-multiples matrix of all registered keepers × 5 orthogonal FSM
+ * axes (KSM/KTC/KDP/KCL/KMC). One chip per (keeper, axis) cell showing
+ * the current state. A top strip summarises the 4 joint invariant
+ * counts from KeeperCompositeLifecycle.tla.
+ *
+ * Design: docs/observability/composite-fsm-matrix-design.md (LT-12).
+ * Backend: #7723 (LT-16a) → GET /api/v1/keepers/composite.
+ * Spec↔code drift: docs/observability/fsm-spec-code-drift.md (LT-15).
+ *
+ * Scope of this PR:
+ *   - Static snapshot view (current state only).
+ *   - Time-axis sparkline is deferred to LT-16c which adds a client-
+ *     side observation ring so the poll history stays visible without
+ *     a backend change.
+ *   - Click-through to the existing FsmHub drill-down is deferred to
+ *     LT-16c; exposed via the caller passing `onSelectKeeper`.
+ */
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+
+import { fetchKeepersComposite } from '../api/keeper'
+import type {
+  FleetCompositeSnapshot,
+  KeeperCompositeSnapshot,
+} from '../api/keeper'
+import {
+  displayState,
+  extractLaneValue,
+  INVARIANT_LABELS,
+  TRANSITION_FIELDS,
+  type LaneKey,
+} from './fsm-hub-types'
+
+const POLL_INTERVAL_MS = 10_000
+
+// Axis order is fixed by the TLA+ joint spec
+// (KeeperCompositeLifecycle.tla): KSM → KTC → KDP → KCL → KMC.
+// Keep it identical to TRANSITION_FIELDS so an operator scanning
+// left-to-right sees "lifecycle → turn → decision → cascade →
+// compaction" — the natural causal order of a turn.
+const AXES: Array<{ key: LaneKey; label: string; acronym: string }> = [
+  { key: 'phase',      label: 'Lifecycle',   acronym: 'KSM' },
+  { key: 'turn',       label: 'Turn',        acronym: 'KTC' },
+  { key: 'decision',   label: 'Decision',    acronym: 'KDP' },
+  { key: 'cascade',    label: 'Cascade',     acronym: 'KCL' },
+  { key: 'compaction', label: 'Compaction',  acronym: 'KMC' },
+]
+
+const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<
+  keyof typeof INVARIANT_LABELS
+>
+
+// Tailwind-only chip palette. Colour groups mirror the drift-audit
+// recommendation: stable=gray, in-motion=amber/blue, terminal=red.
+const CHIP_CLASS_BY_STATE: Record<string, string> = {
+  // KSM
+  Running:      'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  Failing:      'bg-red-900/50 text-red-200 border-red-700',
+  Overflowed:   'bg-orange-900/50 text-orange-200 border-orange-700',
+  Compacting:   'bg-amber-900/50 text-amber-200 border-amber-700',
+  HandingOff:   'bg-blue-900/50 text-blue-200 border-blue-700',
+  Draining:     'bg-sky-900/40 text-sky-200 border-sky-700',
+  Paused:       'bg-zinc-800 text-zinc-300 border-zinc-600',
+  Stopped:      'bg-zinc-800 text-zinc-400 border-zinc-700',
+  Crashed:      'bg-red-950 text-red-300 border-red-800',
+  Restarting:   'bg-violet-900/50 text-violet-200 border-violet-700',
+  Dead:         'bg-black text-red-400 border-red-900',
+  Offline:      'bg-zinc-900 text-zinc-500 border-zinc-800',
+  // KTC
+  idle:         'bg-zinc-800 text-zinc-400 border-zinc-700',
+  prompting:    'bg-blue-900/40 text-blue-200 border-blue-700',
+  executing:    'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  compacting:   'bg-amber-900/50 text-amber-200 border-amber-700',
+  finalizing:   'bg-sky-900/40 text-sky-200 border-sky-700',
+  // KDP
+  undecided:          'bg-zinc-800 text-zinc-400 border-zinc-700',
+  guard_ok:           'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  gate_rejected:      'bg-red-900/40 text-red-200 border-red-700',
+  tool_policy_selected: 'bg-indigo-900/50 text-indigo-200 border-indigo-700',
+  // KCL
+  selecting:    'bg-blue-900/40 text-blue-200 border-blue-700',
+  trying:       'bg-amber-900/50 text-amber-200 border-amber-700',
+  done:         'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  exhausted:    'bg-red-900/50 text-red-200 border-red-700',
+  // KMC
+  accumulating: 'bg-zinc-800 text-zinc-400 border-zinc-700',
+}
+
+const DEFAULT_CHIP = 'bg-zinc-800 text-zinc-300 border-zinc-700'
+
+export function chipClassFor(value: string): string {
+  return CHIP_CLASS_BY_STATE[value] ?? DEFAULT_CHIP
+}
+
+/**
+ * Sum invariant violations across the fleet. Value is the number of
+ * keepers where the invariant is currently failing; matches the
+ * denominator the operator cares about ("how many keepers are bad?"),
+ * not the counter delta from #7708 (which is a rate).
+ */
+export function tallyInvariantViolations(
+  snapshots: KeeperCompositeSnapshot[],
+): Record<keyof typeof INVARIANT_LABELS, number> {
+  const counts = {
+    phase_turn_alignment: 0,
+    no_cascade_before_measurement: 0,
+    compaction_atomicity: 0,
+    event_priority_monotone: 0,
+  }
+  for (const s of snapshots) {
+    for (const k of INVARIANT_KEYS) {
+      // invariants[k] === true means *holds*, false means violated.
+      if (!s.invariants[k]) counts[k] += 1
+    }
+  }
+  return counts
+}
+
+export interface FleetFsmMatrixProps {
+  onSelectKeeper?: (name: string) => void
+  // Injectable for tests.
+  fetcher?: () => Promise<FleetCompositeSnapshot>
+  pollIntervalMs?: number
+}
+
+export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
+  const fetcher = props.fetcher ?? fetchKeepersComposite
+  const intervalMs = props.pollIntervalMs ?? POLL_INTERVAL_MS
+  const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const tick = async () => {
+      try {
+        const snap = await fetcher()
+        if (!cancelled) {
+          setData(snap)
+          setError(null)
+          setLoading(false)
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(String(e))
+          setLoading(false)
+        }
+      } finally {
+        if (!cancelled) {
+          timer = setTimeout(tick, intervalMs)
+        }
+      }
+    }
+    tick()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [fetcher, intervalMs])
+
+  const tallies = useMemo(
+    () => (data ? tallyInvariantViolations(data.snapshots) : null),
+    [data],
+  )
+
+  if (loading) {
+    return html`
+      <div
+        data-testid="fleet-fsm-matrix"
+        class="rounded border border-zinc-800 bg-zinc-950 p-4 text-sm text-zinc-400"
+      >
+        Loading fleet composite snapshot…
+      </div>
+    `
+  }
+
+  if (error) {
+    return html`
+      <div
+        data-testid="fleet-fsm-matrix"
+        class="rounded border border-red-800 bg-red-950/40 p-4 text-sm text-red-200"
+      >
+        Fleet snapshot failed: ${error}
+      </div>
+    `
+  }
+
+  if (!data || data.count === 0) {
+    return html`
+      <div
+        data-testid="fleet-fsm-matrix"
+        class="rounded border border-zinc-800 bg-zinc-950 p-4 text-sm text-zinc-400"
+      >
+        No keepers registered.
+      </div>
+    `
+  }
+
+  return html`
+    <section
+      data-testid="fleet-fsm-matrix"
+      class="rounded border border-zinc-800 bg-zinc-950"
+    >
+      <header class="flex flex-wrap items-baseline gap-3 border-b border-zinc-800 p-3">
+        <h2 class="text-sm font-semibold text-zinc-100">Fleet composite (KSM × KTC × KDP × KCL × KMC)</h2>
+        <span class="text-xs text-zinc-500">
+          ${data.count} keepers · updated ${new Date(data.generated_at * 1000).toLocaleTimeString()}
+        </span>
+        ${tallies
+          ? html`
+              <div class="ml-auto flex flex-wrap gap-2" data-testid="invariant-strip">
+                ${INVARIANT_KEYS.map(k => {
+                  const count = tallies[k]
+                  const tone = count === 0
+                    ? 'bg-emerald-900/30 text-emerald-200 border-emerald-800'
+                    : 'bg-red-900/40 text-red-200 border-red-700'
+                  return html`
+                    <span
+                      data-invariant=${k}
+                      class="rounded border px-2 py-0.5 text-xs ${tone}"
+                      title=${`Violating keepers: ${count}`}
+                    >
+                      ${INVARIANT_LABELS[k]}: ${count}
+                    </span>
+                  `
+                })}
+              </div>
+            `
+          : null}
+      </header>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-xs">
+          <thead class="bg-zinc-900 text-zinc-300">
+            <tr>
+              <th class="px-3 py-2 text-left font-semibold">Keeper</th>
+              ${AXES.map(a => html`
+                <th class="px-3 py-2 text-left font-semibold" title=${a.label}>
+                  ${a.acronym} <span class="text-zinc-500">${a.label}</span>
+                </th>
+              `)}
+            </tr>
+          </thead>
+          <tbody>
+            ${data.snapshots.map(snap => {
+              const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
+              const rowTone = anyViolated ? 'border-l-2 border-red-500' : ''
+              const name = inferKeeperNameFrom(snap)
+              return html`
+                <tr
+                  data-keeper=${name}
+                  class="border-t border-zinc-800 hover:bg-zinc-900 ${rowTone}"
+                  onClick=${props.onSelectKeeper ? () => props.onSelectKeeper?.(name) : undefined}
+                >
+                  <td class="px-3 py-2 font-mono text-zinc-200">${name}</td>
+                  ${AXES.map(a => {
+                    const raw = extractLaneValue(snap, a.key)
+                    const cls = chipClassFor(raw)
+                    return html`
+                      <td class="px-3 py-2">
+                        <span
+                          data-cell
+                          data-axis=${a.key}
+                          class="inline-block rounded border px-2 py-0.5 ${cls}"
+                        >${displayState(raw)}</span>
+                      </td>
+                    `
+                  })}
+                </tr>
+              `
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
+/**
+ * Best-effort keeper name extraction from the snapshot correlation id.
+ * Format: `keeper:<name>:<transition_seq>` (see keeper_composite_observer
+ * .ml:stable_correlation_id). Falls back to correlation_id verbatim so
+ * the UI never renders an empty cell.
+ */
+export function inferKeeperNameFrom(snap: KeeperCompositeSnapshot): string {
+  const m = /^keeper:([^:]+):/.exec(snap.correlation_id)
+  return m?.[1] ?? snap.correlation_id
+}
+
+// Re-exported helpers let tests target the pure slices without spinning
+// up the component. TRANSITION_FIELDS is re-exported for completeness
+// so a caller doesn't need to reach into fsm-hub-types for AXES parity.
+export { TRANSITION_FIELDS }

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -406,6 +406,15 @@ let observe
        | None -> None);
   }
 
+(* Fleet fold — observe every currently-registered keeper under
+   [base_path] once. Preserves registry iteration order so downstream
+   matrix rendering stays stable across successive polls.
+
+   Used by GET /api/v1/keepers/composite (LT-16a). *)
+let all_snapshots ~(base_path : string) () : snapshot list =
+  Keeper_registry.all ~base_path ()
+  |> List.map (fun entry -> observe entry)
+
 (* JSON serialisation (RFC-0003 §7) *)
 
 let invariants_to_json (inv : invariants_check) : Yojson.Safe.t =

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -160,6 +160,11 @@ val observe :
   Keeper_registry.registry_entry ->
   snapshot
 
+(** Observe every registered keeper under [base_path] once. Used by
+    [GET /api/v1/keepers/composite] to render fleet-level matrices
+    (LT-16a). Preserves registry iteration order. *)
+val all_snapshots : base_path:string -> unit -> snapshot list
+
 (** Stringify [turn_phase] for JSON serialisation. Mirrors the lowercase
     edge labels used in KeeperTurnCycle.tla. *)
 val ksm_phase_to_string : ksm_phase -> string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1200,6 +1200,35 @@ let handle_keeper_get_subroutes state req request reqd =
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if req_path = prefix ^ "composite" then
+    (* LT-16a: fleet-wide composite snapshot. Enumerates every
+       registered keeper via [Keeper_registry.all] and projects each
+       through [Keeper_composite_observer.observe]. Same purity
+       contract as the per-keeper route below.
+
+       Shape:
+         { "generated_at": 1234567890.1,
+           "count": 3,
+           "snapshots": [ <snapshot JSON>, ... ] }
+
+       Consumed by [dashboard/src/components/fleet-fsm-matrix.ts]
+       (LT-16b, upcoming). *)
+    let base_path = state.Mcp_server.room_config.base_path in
+    let snapshots =
+      Keeper_composite_observer.all_snapshots ~base_path ()
+    in
+    let json =
+      `Assoc [
+        "generated_at", `Float (Unix.gettimeofday ());
+        "count", `Int (List.length snapshots);
+        "snapshots",
+          `List
+            (List.map
+               Keeper_composite_observer.snapshot_to_json snapshots);
+      ]
+    in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
   else if ends_with "/composite" then
     (* RFC-0003 §7: composite lifecycle snapshot derived from the
        registry entry via the [Keeper_composite_observer] pure


### PR DESCRIPTION
## Summary

Frontend half of the fleet FSM matrix. Stacks on #7723 (LT-16a backend endpoint).

Rows = keepers, columns = 5 orthogonal FSM axes (KSM / KTC / KDP / KCL / KMC), cell = state chip. Top strip counts how many keepers violate each of the 4 joint invariants from \`KeeperCompositeLifecycle.tla\`.

## What's in this PR

- \`FleetCompositeSnapshotSchema\` + \`parseFleetCompositeSnapshot\` (valibot, drift-tolerant via \`fallback\`).
- \`fetchKeepersComposite()\` — one-envelope fleet poll via \`/api/v1/keepers/composite\` (from #7723).
- \`FleetFsmMatrix\` component — HTM/Preact, Tailwind-only. 10s polling via injectable \`fetcher\` + \`pollIntervalMs\` props (test hook).
- Pure helpers exported so tests target them directly:
  - \`tallyInvariantViolations(snapshots)\` — fleet-wide violation counts
  - \`chipClassFor(state)\` — Tailwind class by state name
  - \`inferKeeperNameFrom(snapshot)\` — extract name from correlation_id

## Why this layout

Harel 1987 orthogonal regions: 5 parallel regions per keeper, rendered as a table row. **Do not flatten the product state**. Bach et al. 2013: small-multiples beat animation for discrete state-change comprehension. See LT-12 design doc §2.1.

## Scope boundaries (deferred)

| Follow-up | What it adds |
|-----------|--------------|
| LT-16c    | Client-side observation ring → per-cell horizontal sparkline (time axis) |
| LT-16c    | Mount in \`agents-unified.ts\` or a new dashboard tab |
| LT-16c    | \`onSelectKeeper\` drill-through into the existing \`FsmHub\` |

## Test plan

- [x] \`pnpm typecheck\` — clean (new files only).
- [x] \`pnpm test:serial fleet-fsm-matrix\` — 7/7 OK locally.
- [ ] CI Dashboard — pending.
- [ ] Screenshot smoke once mounted in LT-16c.

## References

- #7689 (LT-12) — design doc.
- #7703 (LT-15) — spec↔code drift audit.
- #7708 (LT-13) + #7713 (LT-13b) — invariant counter + tests the \`invariants\` strip surfaces.
- #7723 (LT-16a) — backend endpoint this consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)