### PR TITLE
feat(dashboard): add search + category filter to tool metrics panel

### DIFF
--- a/dashboard/src/components/tool-metrics.test.ts
+++ b/dashboard/src/components/tool-metrics.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  filterTools,
+  toolMatchesCategory,
+  toolMatchesSearch,
+} from './tool-metrics'
+
+// Minimal shape accepted by the pure helpers. Mirrors ToolMetricsTopEntry's
+// `name` field — extra `call_count` retained so tests look like real data.
+interface TestTool {
+  name: string
+  call_count: number
+}
+
+// Names chosen so each one maps to a distinct category label via
+// tool-call-shared.toolCategory(). toolCategory matchers use lowercase
+// substring checks (e.g. n.includes('edit')), so names here are lowercase.
+//   - bash_exec      -> 'shell'
+//   - github_...     -> 'git'
+//   - edit_file      -> 'edit'
+//   - fs_read_file   -> 'file'
+//   - board_post     -> 'board'
+//   - search_symbols -> 'search'
+//   - web_fetch      -> 'web'
+//   - masc_task_...  -> 'coord'
+//   - memory_recall  -> 'memory'
+const sample: TestTool[] = [
+  { name: 'bash_exec', call_count: 120 },
+  { name: 'github_create_pr', call_count: 60 },
+  { name: 'edit_file', call_count: 55 },
+  { name: 'fs_read_file', call_count: 40 },
+  { name: 'board_post', call_count: 32 },
+  { name: 'search_symbols', call_count: 25 },
+  { name: 'web_fetch', call_count: 18 },
+  { name: 'masc_task_claim', call_count: 12 },
+  { name: 'memory_recall', call_count: 8 },
+]
+
+describe('toolMatchesSearch', () => {
+  const item = sample[0]!
+
+  it('returns true for empty or whitespace-only query', () => {
+    expect(toolMatchesSearch(item, '')).toBe(true)
+    expect(toolMatchesSearch(item, '   ')).toBe(true)
+  })
+
+  it('matches substring in name (case-insensitive)', () => {
+    expect(toolMatchesSearch(item, 'bash')).toBe(true)
+    expect(toolMatchesSearch(item, 'BASH')).toBe(true)
+    expect(toolMatchesSearch(item, 'exec')).toBe(true)
+  })
+
+  it('returns false when the substring is absent', () => {
+    expect(toolMatchesSearch(item, 'github')).toBe(false)
+  })
+
+  it('ignores leading/trailing whitespace in the query', () => {
+    expect(toolMatchesSearch(item, '  bash  ')).toBe(true)
+  })
+})
+
+describe('toolMatchesCategory', () => {
+  it("accepts any item when category is 'all'", () => {
+    for (const item of sample) {
+      expect(toolMatchesCategory(item, 'all')).toBe(true)
+    }
+  })
+
+  it('matches the shell category for bash_exec', () => {
+    expect(toolMatchesCategory({ name: 'bash_exec' }, 'shell')).toBe(true)
+    expect(toolMatchesCategory({ name: 'bash_exec' }, 'git')).toBe(false)
+  })
+
+  it('matches the git category for github_ tools', () => {
+    expect(toolMatchesCategory({ name: 'github_create_pr' }, 'git')).toBe(true)
+    expect(toolMatchesCategory({ name: 'github_create_pr' }, 'edit')).toBe(false)
+  })
+
+  it('matches the file category for fs_read_ tools', () => {
+    expect(toolMatchesCategory({ name: 'fs_read_file' }, 'file')).toBe(true)
+  })
+
+  it('returns false when the category label does not match', () => {
+    expect(toolMatchesCategory({ name: 'edit_file' }, 'search')).toBe(false)
+  })
+})
+
+describe('filterTools', () => {
+  it("returns the original list when query is empty and category is 'all'", () => {
+    const out = filterTools(sample, '', 'all')
+    expect(out).toBe(sample) // same reference, no allocation
+  })
+
+  it("returns the original list when query is whitespace and category is 'all'", () => {
+    const out = filterTools(sample, '   ', 'all')
+    expect(out).toBe(sample)
+  })
+
+  it('narrows by search query only', () => {
+    const out = filterTools(sample, 'board', 'all')
+    expect(out.map((t) => t.name)).toEqual(['board_post'])
+  })
+
+  it('narrows by category only', () => {
+    const out = filterTools(sample, '', 'git')
+    expect(out.map((t) => t.name)).toEqual(['github_create_pr'])
+  })
+
+  it('applies both search and category as AND', () => {
+    // 'file' matches edit_file and fs_read_file, but only edit_file is in
+    // the 'edit' category (fs_read_file falls into 'file').
+    const out = filterTools(sample, 'file', 'edit')
+    expect(out.map((t) => t.name)).toEqual(['edit_file'])
+  })
+
+  it('returns empty array when no item matches', () => {
+    const out = filterTools(sample, 'zzz_no_such_tool', 'all')
+    expect(out).toEqual([])
+  })
+
+  it('returns empty array when category has no members in the input', () => {
+    // 'voice' category label exists in tool-call-shared but no sample item
+    // has 'voice' in its name.
+    const out = filterTools(sample, '', 'voice')
+    expect(out).toEqual([])
+  })
+})

--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -4,12 +4,49 @@ import { ErrorState } from './common/feedback-state'
 // Displays tool usage statistics from Tool_unified.summary_report()
 
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { fetchToolMetrics, type ToolMetricsResponse, type ToolMetricsTopEntry } from '../api'
 import { createAsyncResource } from '../lib/async-state'
+import { FilterChips } from './common/filter-chips'
+import { TextInput } from './common/input'
 import { toolCategory } from './tool-call-shared'
 
 const metricsResource = createAsyncResource<ToolMetricsResponse>()
+
+// Filter state (module-scoped so filters survive re-renders / refreshes).
+const categoryFilter = signal<string>('all')
+const searchQuery = signal('')
+
+// Pure filter helpers — exported for isolated testing.
+export function toolMatchesSearch(
+  item: Pick<ToolMetricsTopEntry, 'name'>,
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase()
+  if (q === '') return true
+  return item.name.toLowerCase().includes(q)
+}
+
+export function toolMatchesCategory(
+  item: Pick<ToolMetricsTopEntry, 'name'>,
+  category: string,
+): boolean {
+  if (category === 'all') return true
+  return toolCategory(item.name).label === category
+}
+
+export function filterTools<T extends Pick<ToolMetricsTopEntry, 'name'>>(
+  items: T[],
+  query: string,
+  category: string,
+): T[] {
+  const q = query.trim().toLowerCase()
+  if (q === '' && category === 'all') return items
+  return items.filter(
+    (it) => toolMatchesSearch(it, q) && toolMatchesCategory(it, category),
+  )
+}
 
 function loadMetrics() {
   return metricsResource.load(() => fetchToolMetrics())
@@ -140,10 +177,54 @@ export function ToolMetrics() {
           </div>
           <div>
             <h4 class="text-[var(--text-muted)] text-[11px] uppercase tracking-[0.05em] mb-2.5 mt-0">상위 20 도구</h4>
-            <${BarChart}
-              items=${data.top_20}
-              maxCount=${data.top_20.length > 0 ? data.top_20[0]!.call_count : 0}
-            />
+            ${(() => {
+              // Build category chips from labels actually present in top_20.
+              const labelCounts = new Map<string, number>()
+              for (const it of data.top_20) {
+                const label = toolCategory(it.name).label
+                labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1)
+              }
+              const categoryChips: { key: string; label: string; count: number }[] = [
+                { key: 'all', label: '전체', count: data.top_20.length },
+                ...Array.from(labelCounts.entries())
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([label, count]) => ({ key: label, label, count })),
+              ]
+              const filtered = filterTools(data.top_20, searchQuery.value, categoryFilter.value)
+              const filterMaxCount = filtered.length > 0 ? filtered[0]!.call_count : 0
+              return html`
+                <div class="flex flex-col gap-2 mb-3 sm:flex-row sm:items-center sm:justify-between">
+                  <${FilterChips}
+                    chips=${categoryChips}
+                    active=${categoryFilter}
+                  />
+                  <${TextInput}
+                    class="sm:max-w-[240px]"
+                    name="tool_metrics_search"
+                    ariaLabel="도구 이름 검색"
+                    autoComplete="off"
+                    placeholder="도구 이름 검색..."
+                    value=${searchQuery.value}
+                    onInput=${(e: Event) => {
+                      searchQuery.value = (e.target as HTMLInputElement).value
+                    }}
+                  />
+                </div>
+                ${(categoryFilter.value !== 'all' || searchQuery.value.trim() !== '') ? html`
+                  <div class="mb-2 text-[11px] text-[var(--text-muted)]">
+                    ${filtered.length} / ${data.top_20.length}개 도구
+                  </div>
+                ` : null}
+                ${filtered.length === 0 ? html`
+                  <p class="muted">조건에 맞는 도구가 없습니다.</p>
+                ` : html`
+                  <${BarChart}
+                    items=${filtered}
+                    maxCount=${filterMaxCount}
+                  />
+                `}
+              `
+            })()}
           </div>
         </div>
       ` : !loading ? html`


### PR DESCRIPTION
## Summary
- Adds `FilterChips` (tool category) and `TextInput` (name search) to the Tool Metrics panel Top-20 bar chart, which previously had no filtering.
- Extracts pure helpers `toolMatchesSearch`, `toolMatchesCategory`, `filterTools` for isolated testing.
- Adds `tool-metrics.test.ts` with 15 cases covering the three pure functions (empty / whitespace / case / AND composition / empty-result).

Category chips are derived live from `toolCategory().label` over `top_20` so only categories actually present show up, each with its per-bucket count. When no filter is active the full Top-20 bar chart renders unchanged; once a filter is applied a count header (`N / total`) appears, the bar chart is rescaled to the filtered max, and an empty-state message handles zero matches.

Follows the same iteration pattern as feature-health (#7717), tool-quality-panel (#7694), and prior iterations #7652/#7654/#7656.

## Files
- `dashboard/src/components/tool-metrics.ts` — +85 / -4
- `dashboard/src/components/tool-metrics.test.ts` — +128 (new)

## Test plan
- [x] `pnpm -C dashboard typecheck` clean (baseline was clean)
- [x] `pnpm -C dashboard lint` clean
- [x] `pnpm -C dashboard test` — 149 files / 2249 tests pass (incl. 15 new)
- [ ] Manual: load `/tools` (or wherever ToolMetrics is mounted), click category chip, type in search box, verify bar chart reacts and count header updates.

## Follow-up seed
Consider memoizing the `labelCounts` map and category chip list with `useMemo` against `data.top_20` identity — currently recomputed on every render. Low priority (Top-20 is bounded).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>