### PR TITLE
chore(gitignore): cover TLC trace artifacts outside specs/ (Gen21)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,15 @@ viewer/dist-build/
 specs/**/states/
 specs/**/*_TTrace_*.tla
 specs/**/TraceData.tla
+# Top-level tla/ dir (picked up by scripts/tla-check.sh auto-discovery).
+# TLC drops trace artifacts next to the .tla file it checked, and a
+# sibling states/ dir from any failing run.
+tla/*_TTrace_*.tla
+tla/*_TTrace_*.bin
+tla/states/
+# Fallback for tla/ checks invoked from the repo root with -dump
+# state-graph — TLC writes into cwd instead of the spec dir.
+/states/
 *.jar
 
 # Local Claude session scratch
@@ -108,6 +117,7 @@ config/personas/uranium666
 /pr_list.txt
 /scripts/changelog_unreleased.txt
 /specs/bug-models/*_TTrace_*.bin
+specs/**/*_TTrace_*.bin
 
 # Operator-local scratch (PR/CR dumps, temp edits)
 pr_*.json


### PR DESCRIPTION
## Gen21 — follow-up from Gen15 local observation

While running `tla/SocialStateCap.tla` locally (Gen15 PR #7721 / since merged), TLC dropped trace artifacts outside the existing `.gitignore` scope:

```
?? states/
?? tla/SocialStateCap_TTrace_1776389123.bin
?? tla/SocialStateCap_TTrace_1776389123.tla
```

`specs/**/states/` and `specs/**/*_TTrace_*.tla` cover `specs/` but miss the top-level `tla/` directory that Gen15 wired into `scripts/tla-check.sh` auto-discovery, and they also miss repo-root `states/` that TLC creates when invoked from the root.

### Change

Extend `.gitignore`:

- `tla/*_TTrace_*.{tla,bin}` and `tla/states/` — match `specs/**/` semantics for the top-level spec dir.
- `/states/` — repo-root fallback when TLC is driven from `$REPO_ROOT`.
- `specs/**/*_TTrace_*.bin` — the binary form was only pinned to `specs/bug-models/`, but any `specs/` subdirectory with a failing run produces one.

No spec content change. No build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)