### PR TITLE
fix(data-integrity): UTF-8-safe title truncation + delete_goal version bump (#7690)

### DIFF
--- a/lib/board_core_payload.ml
+++ b/lib/board_core_payload.ml
@@ -73,8 +73,12 @@ let derive_post_title (body : string) =
     |> List.find_opt (fun line -> line <> "")
     |> Option.value ~default:"Untitled post"
   in
-  if String.length first_line <= 80 then first_line
-  else String.sub first_line 0 77 ^ "..."
+  (* UTF-8-safe truncation: byte-based String.sub used to split multi-byte
+     characters, producing invalid UTF-8 lines in board_posts.jsonl
+     (Issue #7690). utf8_safe returns a variant so future callers can
+     observe/meter truncation events; here we just materialize. *)
+  String_util.utf8_safe ~max_bytes:80 ~suffix:"..." first_line
+  |> String_util.to_string
 
 let normalize_post_payload ~content ?title ?body ~post_kind ?meta_json () =
   let raw_body = Option.value body ~default:content in

--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -16,3 +16,51 @@ let contains_substring_ci haystack needle =
   contains_substring
     (String.lowercase_ascii haystack)
     (String.lowercase_ascii needle)
+
+type truncation =
+  | Untouched of string
+  | Truncated of { prefix : string; suffix : string; dropped_bytes : int }
+
+(* Find the largest k <= idx such that [String.sub s 0 k] ends at a valid
+   UTF-8 character boundary. Handles invalid UTF-8 on a best-effort basis:
+   walks back through continuation bytes and cuts before an incomplete lead. *)
+let utf8_char_boundary s idx =
+  let len = String.length s in
+  if idx >= len then len
+  else if idx <= 0 then 0
+  else
+    let is_continuation k = (Char.code s.[k] land 0xC0) = 0x80 in
+    if not (is_continuation idx) then
+      (* s.[idx] starts a new char — idx is already a boundary *)
+      idx
+    else
+      (* s.[idx] is a continuation; walk back to find the lead byte of the
+         incomplete character and cut before it. ASCII bytes encountered
+         before any lead are complete on their own, so cut *after* them. *)
+      let rec find k =
+        if k < 0 then 0
+        else
+          let b = Char.code s.[k] in
+          if (b land 0x80) = 0 then k + 1
+          else if (b land 0xC0) = 0xC0 then k
+          else find (k - 1)
+      in
+      find (idx - 1)
+
+let utf8_safe ~max_bytes ~suffix s =
+  let len = String.length s in
+  if len <= max_bytes then Untouched s
+  else
+    let suffix_len = String.length suffix in
+    let budget = max 0 (max_bytes - suffix_len) in
+    let cut = utf8_char_boundary s budget in
+    let prefix = String.sub s 0 cut in
+    Truncated { prefix; suffix; dropped_bytes = len - cut }
+
+let to_string = function
+  | Untouched s -> s
+  | Truncated { prefix; suffix; _ } -> prefix ^ suffix
+
+let was_truncated = function
+  | Untouched _ -> false
+  | Truncated _ -> true

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -9,3 +9,35 @@ val contains_substring_ci : string -> string -> bool
 (** Case-insensitive version of [contains_substring].
     Returns [false] when [needle] is empty, matching the behavior
     of the original per-module [contains_ci] helpers. *)
+
+type truncation =
+  | Untouched of string
+  | Truncated of { prefix : string; suffix : string; dropped_bytes : int }
+(** Result of a UTF-8-aware truncation attempt.
+    - [Untouched s]: input fit within the byte budget; [s] returned as-is.
+    - [Truncated \{prefix; suffix; dropped_bytes\}]: input exceeded budget.
+      [prefix] ends at a UTF-8 character boundary, [suffix] is the
+      caller-supplied ellipsis/marker, [dropped_bytes] counts how much
+      of the original was removed (useful for observability/metrics). *)
+
+val utf8_char_boundary : string -> int -> int
+(** [utf8_char_boundary s idx]: returns the largest [k <= idx] such that
+    [String.sub s 0 k] ends at a valid UTF-8 character boundary.
+    Exposed for callers that want boundary-only behavior without the
+    [truncation] variant wrapper. Invalid UTF-8 uses best-effort:
+    complete ASCII bytes are preserved, incomplete leads are excluded. *)
+
+val utf8_safe : max_bytes:int -> suffix:string -> string -> truncation
+(** [utf8_safe ~max_bytes ~suffix s]: if [s] fits within [max_bytes],
+    returns [Untouched s]. Otherwise returns [Truncated \{...\}] where
+    [prefix] is at most [max_bytes - String.length suffix] bytes and
+    ends at a UTF-8 character boundary. Invalid UTF-8 in [s] triggers
+    best-effort boundary detection. *)
+
+val to_string : truncation -> string
+(** Materialize a [truncation] as a single string.
+    For [Untouched s] returns [s]; for [Truncated \{prefix; suffix; _\}]
+    returns [prefix ^ suffix]. Use when the metadata isn't needed. *)
+
+val was_truncated : truncation -> bool
+(** [true] iff the argument is the [Truncated] constructor. *)

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -239,8 +239,13 @@ let delete_goal config ~goal_id =
   if not (List.exists (fun g -> g.id = goal_id) before.goals) then
     Error "Goal not found"
   else begin
+    (* Bump [version] so downstream replicas/snapshot consumers can detect
+       the change. The previous [{ st with ... }] form preserved [version]
+       unchanged, so 39 successive deletes all landed at v67 without a
+       single bump (Issue #7690). [refresh_all] and [review_goal] already
+       bump explicitly; match that convention here. *)
     ignore (update_state config (fun st ->
-      { st with
+      { version = st.version + 1;
         goals = List.filter (fun g -> g.id <> goal_id) st.goals;
         updated_at = Types.now_iso () }));
     Ok ()

--- a/test/dune
+++ b/test/dune
@@ -384,6 +384,9 @@
         test_governance_yojson_roundtrip
         test_eval_calibration
         test_goal_janitor
+        test_goal_store
+        test_string_util
+        test_board_core_payload
         test_voice_config)
  (modules
         test_runtime_params
@@ -532,6 +535,9 @@
         test_governance_yojson_roundtrip
         test_eval_calibration
         test_goal_janitor
+        test_goal_store
+        test_string_util
+        test_board_core_payload
         test_voice_config)
  (libraries masc_test_deps)
  (deps ../bin/main_eio.exe))

--- a/test/test_board_core_payload.ml
+++ b/test/test_board_core_payload.ml
@@ -1,0 +1,86 @@
+(** Regression tests for Board_core_payload.derive_post_title.
+
+    Issue #7690: byte-based String.sub of the title cut through multi-byte
+    UTF-8 characters (Korean, emoji), producing invalid UTF-8 lines in
+    board_posts.jsonl. These tests verify the UTF-8-safe behavior. *)
+
+open Alcotest
+open Masc_mcp
+module BP = Board_core_payload
+
+let is_valid_utf8 s =
+  try
+    let encoded = Yojson.Safe.to_string (`String s) in
+    let decoded = Yojson.Safe.from_string encoded in
+    match decoded with `String s' -> s' = s | _ -> false
+  with _ -> false
+
+let test_derive_short_title_returned_as_is () =
+  let title = BP.derive_post_title "Short title\nSecond line" in
+  check string "short" "Short title" title
+
+let test_derive_empty_body_uses_default () =
+  let title = BP.derive_post_title "" in
+  check string "default" "Untitled post" title
+
+let test_derive_long_ascii_truncated_with_ellipsis () =
+  let long = String.make 150 'a' in
+  let title = BP.derive_post_title long in
+  check bool "within 80 bytes" true (String.length title <= 80);
+  check bool "ends with ..." true
+    (let n = String.length title in
+     n >= 3 && String.sub title (n - 3) 3 = "...")
+
+let test_derive_long_korean_title_is_valid_utf8 () =
+  (* Build a 90-byte (30-char) Korean title that would have cut mid-char
+     under the old byte-based truncation. Repeat "가나다" (9 bytes). *)
+  let unit_str = "가나다" in
+  let body = String.concat "" (List.init 10 (fun _ -> unit_str)) in
+  (* String.length body = 90 *)
+  let title = BP.derive_post_title body in
+  check bool "title valid UTF-8" true (is_valid_utf8 title);
+  check bool "within 80 bytes" true (String.length title <= 80);
+  (* Regression: title MUST NOT end with a lone continuation byte or
+     incomplete lead. Yojson roundtrip already covers this, but also
+     validate with an explicit check on the non-suffix portion. *)
+  let suffix = "..." in
+  check bool "ends with ..." true
+    (let n = String.length title in
+     n >= 3 && String.sub title (n - 3) 3 = suffix);
+  let prefix =
+    String.sub title 0 (String.length title - String.length suffix)
+  in
+  check bool "prefix valid UTF-8" true (is_valid_utf8 prefix)
+
+let test_derive_korean_with_json_roundtrip () =
+  (* The actual failure mode: write a post, serialize to JSONL, then
+     decode as UTF-8. This is precisely what board_posts.jsonl reader
+     does at runtime. *)
+  let body =
+    "## Verdict: #7460 needs-evidence + #7464 needs-evidence \xe2\x80\x94 \
+     poe scan #5 나머지 리뷰 결과입니다 길게 이어지는 텍스트 추가"
+  in
+  let title = BP.derive_post_title body in
+  let json = `Assoc [("title", `String title)] in
+  let encoded = Yojson.Safe.to_string json in
+  (* Decode back: must not raise *)
+  let decoded = Yojson.Safe.from_string encoded in
+  (match decoded with
+   | `Assoc [("title", `String t)] ->
+       check string "roundtrip title" title t;
+       check bool "roundtrip valid UTF-8" true (is_valid_utf8 t)
+   | _ -> fail "unexpected JSON shape")
+
+let () =
+  run "Board_core_payload.derive_post_title"
+    [ ( "regression-7690",
+        [ test_case "short title unchanged" `Quick
+            test_derive_short_title_returned_as_is;
+          test_case "empty body -> default" `Quick
+            test_derive_empty_body_uses_default;
+          test_case "long ASCII truncated" `Quick
+            test_derive_long_ascii_truncated_with_ellipsis;
+          test_case "long Korean is valid UTF-8" `Quick
+            test_derive_long_korean_title_is_valid_utf8;
+          test_case "Korean JSON roundtrip" `Quick
+            test_derive_korean_with_json_roundtrip ] ) ]

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -1,0 +1,110 @@
+(** Tests for Goal_store.delete_goal — Issue #7690 regression.
+
+    Bug: the previous implementation used [{ st with goals = ...; updated_at }]
+    which preserves [version], so successive deletes all landed at the same
+    version. Replicas/snapshot consumers couldn't detect the change. This
+    test asserts the version is bumped on every delete, matching
+    [refresh_all] / [review_goal]. *)
+
+open Alcotest
+open Masc_mcp
+
+let temp_dir () =
+  let path = Filename.temp_file "goal_store_test" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path
+        |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  try rm dir with _ -> ()
+
+let with_room f =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = temp_dir () in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () ->
+    let config = Coord.default_config dir in
+    ignore (Coord.init config ~agent_name:(Some "test"));
+    f config)
+
+let iso_now () = Types.now_iso ()
+
+let make_goal id title =
+  let ts = iso_now () in
+  {
+    Goal_store.id; horizon = Short; title;
+    metric = None; target_value = None; due_date = None;
+    priority = 3; status = Active; parent_goal_id = None;
+    last_review_note = None; last_review_at = None;
+    created_at = ts; updated_at = ts;
+  }
+
+let test_delete_goal_bumps_version () =
+  with_room @@ fun config ->
+  let g = make_goal "g-1" "to delete" in
+  Goal_store.write_state config
+    { version = 10; updated_at = iso_now (); goals = [g] };
+  let v_before = (Goal_store.read_state config).version in
+  check int "initial version" 10 v_before;
+  (match Goal_store.delete_goal config ~goal_id:"g-1" with
+   | Ok () -> ()
+   | Error e -> fail ("delete_goal failed: " ^ e));
+  let v_after = (Goal_store.read_state config).version in
+  check int "version bumped by 1" (v_before + 1) v_after
+
+let test_multiple_deletes_each_bump () =
+  with_room @@ fun config ->
+  let goals = List.init 3 (fun i ->
+    make_goal (Printf.sprintf "g-%d" i) (Printf.sprintf "goal %d" i)) in
+  Goal_store.write_state config
+    { version = 5; updated_at = iso_now (); goals };
+  let v0 = (Goal_store.read_state config).version in
+  List.iter (fun i ->
+    let _ = Goal_store.delete_goal config
+              ~goal_id:(Printf.sprintf "g-%d" i) in ()) [0; 1; 2];
+  let v_final = (Goal_store.read_state config).version in
+  check int "three deletes = +3 versions" (v0 + 3) v_final;
+  check int "all goals removed" 0
+    (List.length (Goal_store.read_state config).goals)
+
+let test_delete_nonexistent_does_not_bump () =
+  with_room @@ fun config ->
+  let g = make_goal "exists" "one goal" in
+  Goal_store.write_state config
+    { version = 42; updated_at = iso_now (); goals = [g] };
+  let v_before = (Goal_store.read_state config).version in
+  (match Goal_store.delete_goal config ~goal_id:"ghost" with
+   | Error _ -> ()
+   | Ok () -> fail "expected error for missing goal");
+  let v_after = (Goal_store.read_state config).version in
+  check int "version unchanged on error" v_before v_after
+
+let test_updated_at_also_refreshed () =
+  with_room @@ fun config ->
+  let g = make_goal "g-1" "x" in
+  let stale_ts = "2020-01-01T00:00:00Z" in
+  Goal_store.write_state config
+    { version = 1; updated_at = stale_ts; goals = [g] };
+  let _ = Goal_store.delete_goal config ~goal_id:"g-1" in
+  let after = Goal_store.read_state config in
+  check bool "updated_at refreshed" true (after.updated_at <> stale_ts)
+
+let () =
+  run "Goal_store.delete_goal"
+    [ ( "regression-7690",
+        [ test_case "version bumps +1" `Quick test_delete_goal_bumps_version;
+          test_case "three deletes = +3" `Quick
+            test_multiple_deletes_each_bump;
+          test_case "missing goal: no bump" `Quick
+            test_delete_nonexistent_does_not_bump;
+          test_case "updated_at also refreshed" `Quick
+            test_updated_at_also_refreshed ] ) ]

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -1,0 +1,174 @@
+(** Tests for Masc_core.String_util UTF-8-safe truncation. *)
+
+open Alcotest
+module SU = String_util
+
+(* Regression fixture: the exact byte sequence that caused board_posts.jsonl
+   corruption (Issue #7690). `나머지 리뷰` = 15 bytes UTF-8. *)
+let korean_title = "나머지 리뷰"
+
+(* Emoji test: each 😀 is 4 bytes in UTF-8 (\xf0\x9f\x98\x80). *)
+let three_smileys = "😀😀😀"
+
+let is_valid_utf8 s =
+  (* Use Yojson's string encoder as a UTF-8 validator proxy:
+     Yojson.Safe.to_string accepts any OCaml string, but decoding
+     back and round-tripping confirms UTF-8 validity. *)
+  try
+    let encoded = Yojson.Safe.to_string (`String s) in
+    let decoded = Yojson.Safe.from_string encoded in
+    match decoded with
+    | `String s' -> s' = s
+    | _ -> false
+  with _ -> false
+
+(* ---- utf8_char_boundary ---- *)
+
+let test_boundary_ascii_in_bounds () =
+  (* ASCII: any index is a boundary *)
+  let s = "hello" in
+  check int "mid-ASCII" 3 (SU.utf8_char_boundary s 3);
+  check int "end" 5 (SU.utf8_char_boundary s 5);
+  check int "past-end clamped" 5 (SU.utf8_char_boundary s 99);
+  check int "zero" 0 (SU.utf8_char_boundary s 0)
+
+let test_boundary_korean_cuts_back () =
+  (* "나" = \xeb\x82\x98 (3 bytes), "머" = \xeb\xa8\xb8 (3 bytes) *)
+  let s = korean_title in
+  (* byte 0: start of "나" (lead) — clean boundary *)
+  check int "start" 0 (SU.utf8_char_boundary s 0);
+  (* byte 3: start of "머" — clean boundary *)
+  check int "after na" 3 (SU.utf8_char_boundary s 3);
+  (* byte 1: middle of "나" (continuation) — cut back to 0 *)
+  check int "mid-na-1" 0 (SU.utf8_char_boundary s 1);
+  (* byte 2: still in "나" — cut back to 0 *)
+  check int "mid-na-2" 0 (SU.utf8_char_boundary s 2);
+  (* byte 4: middle of "머" — cut back to 3 *)
+  check int "mid-meo-1" 3 (SU.utf8_char_boundary s 4)
+
+let test_boundary_emoji_4byte () =
+  (* Each 😀 is 4 bytes: F0 9F 98 80 *)
+  let s = three_smileys in
+  check int "start" 0 (SU.utf8_char_boundary s 0);
+  check int "after-first" 4 (SU.utf8_char_boundary s 4);
+  (* Any byte inside a 😀 sequence cuts back to nearest boundary *)
+  check int "mid-first-1" 0 (SU.utf8_char_boundary s 1);
+  check int "mid-first-2" 0 (SU.utf8_char_boundary s 2);
+  check int "mid-first-3" 0 (SU.utf8_char_boundary s 3);
+  check int "mid-second-5" 4 (SU.utf8_char_boundary s 5)
+
+(* ---- utf8_safe (the main variant API) ---- *)
+
+let test_safe_untouched_short () =
+  match SU.utf8_safe ~max_bytes:100 ~suffix:"..." "hi" with
+  | Untouched s -> check string "identity" "hi" s
+  | Truncated _ -> fail "unexpected truncation"
+
+let test_safe_truncated_ascii () =
+  match SU.utf8_safe ~max_bytes:8 ~suffix:"..." "abcdefghijklmno" with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated { prefix; suffix; dropped_bytes } ->
+      check string "prefix" "abcde" prefix;
+      check string "suffix" "..." suffix;
+      check int "dropped_bytes" 10 dropped_bytes;
+      check bool "total <= max" true
+        (String.length prefix + String.length suffix <= 8)
+
+let test_safe_truncated_korean_is_valid_utf8 () =
+  (* Budget 10 bytes incl. "..." (3 bytes) → prefix budget 7 bytes.
+     Korean chars are 3 bytes each, so prefix can fit 2 chars = 6 bytes.
+     (The 7th byte would be a lead byte we cannot complete.)
+     Result: valid UTF-8 "나머..." *)
+  match SU.utf8_safe ~max_bytes:10 ~suffix:"..." korean_title with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated { prefix; _ } as t ->
+      let s = SU.to_string t in
+      check bool "result valid UTF-8" true (is_valid_utf8 s);
+      (* prefix must be valid on its own *)
+      check bool "prefix valid UTF-8" true (is_valid_utf8 prefix);
+      (* Budget respected *)
+      check bool "within budget" true (String.length s <= 10)
+
+let test_safe_utf8_suffix () =
+  (* Use horizontal-ellipsis char (… = 3 bytes UTF-8) as suffix *)
+  let ellipsis = "\xe2\x80\xa6" in
+  match SU.utf8_safe ~max_bytes:12 ~suffix:ellipsis korean_title with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated _ as t ->
+      let s = SU.to_string t in
+      check bool "combined valid UTF-8" true (is_valid_utf8 s);
+      check bool "within budget" true (String.length s <= 12)
+
+let test_safe_emoji_4byte_boundary () =
+  (* Budget 5 bytes, 😀 is 4 bytes. Suffix "." (1 byte) leaves 4 bytes
+     for prefix. One 😀 fits exactly. *)
+  match SU.utf8_safe ~max_bytes:5 ~suffix:"." three_smileys with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated { prefix; dropped_bytes; _ } ->
+      check string "prefix is one emoji" "😀" prefix;
+      check int "dropped_bytes" 8 dropped_bytes
+
+let test_safe_empty_string () =
+  match SU.utf8_safe ~max_bytes:10 ~suffix:"..." "" with
+  | Untouched s -> check string "identity empty" "" s
+  | Truncated _ -> fail "empty should be untouched"
+
+let test_safe_zero_budget () =
+  (* max_bytes=0 with non-empty input → Truncated with empty prefix and
+     suffix as-is. to_string yields just the suffix. *)
+  match SU.utf8_safe ~max_bytes:0 ~suffix:"X" "abc" with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated { prefix; suffix; dropped_bytes } ->
+      check string "empty prefix" "" prefix;
+      check string "suffix kept" "X" suffix;
+      check int "dropped all 3" 3 dropped_bytes
+
+let test_safe_suffix_longer_than_budget () =
+  (* Suffix 5 bytes but max 3. budget becomes 0 → prefix empty. *)
+  match SU.utf8_safe ~max_bytes:3 ~suffix:"....." "abcdefg" with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated { prefix; _ } ->
+      check string "empty prefix when suffix>=max" "" prefix
+
+let test_was_truncated_and_to_string () =
+  let short = SU.utf8_safe ~max_bytes:100 ~suffix:"..." "hi" in
+  let long = SU.utf8_safe ~max_bytes:3 ~suffix:"..." "abcdefg" in
+  check bool "short not truncated" false (SU.was_truncated short);
+  check bool "long truncated" true (SU.was_truncated long);
+  check string "to_string short" "hi" (SU.to_string short)
+
+let test_safe_invalid_utf8_best_effort () =
+  (* Construct: valid "A" + lone lead byte \xe0 + some cont bytes.
+     Budget 2 bytes forces a cut. Any result must be valid UTF-8 or at
+     least not introduce new invalid sequences beyond the input. *)
+  let orphan = "A\xe0\x80\x80" in
+  match SU.utf8_safe ~max_bytes:2 ~suffix:"" orphan with
+  | Untouched _ -> fail "should have truncated"
+  | Truncated { prefix; _ } ->
+      (* Best-effort: ASCII "A" should be preserved, orphan dropped *)
+      check string "best-effort keeps ASCII" "A" prefix
+
+(* ---- Test runner ---- *)
+
+let () =
+  run "string_util UTF-8 safety"
+    [ ( "utf8_char_boundary",
+        [ test_case "ASCII in-bounds" `Quick test_boundary_ascii_in_bounds;
+          test_case "Korean cuts back" `Quick test_boundary_korean_cuts_back;
+          test_case "Emoji 4-byte" `Quick test_boundary_emoji_4byte ] );
+      ( "utf8_safe",
+        [ test_case "short untouched" `Quick test_safe_untouched_short;
+          test_case "ASCII truncated" `Quick test_safe_truncated_ascii;
+          test_case "Korean UTF-8 valid" `Quick
+            test_safe_truncated_korean_is_valid_utf8;
+          test_case "UTF-8 suffix (ellipsis)" `Quick test_safe_utf8_suffix;
+          test_case "emoji 4-byte boundary" `Quick
+            test_safe_emoji_4byte_boundary;
+          test_case "empty string" `Quick test_safe_empty_string;
+          test_case "zero budget" `Quick test_safe_zero_budget;
+          test_case "suffix >= budget" `Quick
+            test_safe_suffix_longer_than_budget;
+          test_case "was_truncated + to_string" `Quick
+            test_was_truncated_and_to_string;
+          test_case "invalid UTF-8 best-effort" `Quick
+            test_safe_invalid_utf8_best_effort ] ) ]


### PR DESCRIPTION
Closes part of #7690.

## Summary

- Silent data corruption in `~/me/.masc/board_posts.jsonl` (39/565 lines, ~6.9% broken) traced to byte-based UTF-8 truncation in `derive_post_title`.
- Silent version stall in `goals.json` (39 deletes at v67) traced to `{ st with goals = ... }` in `delete_goal`.
- Agent sweep of entire `.masc/` found the same truncation pattern in 4+ other writers (tool_calls 21% broken, system_log, keeper metrics, activity-events, audit) — 3061 lines total. **This PR is narrow**; those callsites tracked as follow-up.

## Design: variant-based API

New `Masc_core.String_util` surface:

```ocaml
type truncation =
  | Untouched of string
  | Truncated of { prefix : string; suffix : string; dropped_bytes : int }

val utf8_safe : max_bytes:int -> suffix:string -> string -> truncation
val utf8_char_boundary : string -> int -> int
val to_string : truncation -> string
val was_truncated : truncation -> bool
```

Variant forces callers to acknowledge truncation at the type level. `dropped_bytes` exposes a hook for per-callsite Prometheus counters (future). Boundary detection walks back through continuation bytes (0x80–0xBF) and cuts cleanly before incomplete leads (0xC0–0xFF) while preserving valid ASCII. Invalid UTF-8 input triggers best-effort truncation.

## Changes

| File | Change |
|------|--------|
| `lib/core/string_util.ml` + `.mli` | `truncation` type + `utf8_safe` + `utf8_char_boundary` + `to_string` + `was_truncated` |
| `lib/board_core_payload.ml` | `derive_post_title` now calls `String_util.utf8_safe ~max_bytes:80 ~suffix:"..."` |
| `lib/goal/goal_store.ml` | `delete_goal` explicitly `{ version = st.version + 1; ... }` matching `refresh_all` / `review_goal` |
| `test/test_string_util.ml` (new) | 13 cases: ASCII/Korean/emoji boundary, zero/overfull budget, invalid UTF-8, untouched, roundtrip |
| `test/test_board_core_payload.ml` (new) | 5 cases: empty body default, long ASCII, long Korean valid-UTF-8 + JSON roundtrip |
| `test/test_goal_store.ml` (new) | 4 cases: single bump, 3× delete = +3, missing goal no bump, updated_at refreshed |
| `test/dune` | added the 3 new test modules |

## Test plan

- [x] `dune exec test/test_string_util.exe` — 13/13 pass
- [x] `dune exec test/test_board_core_payload.exe` — 5/5 pass
- [x] `dune exec test/test_goal_store.exe` — 4/4 pass
- [x] Regression `dune exec test/test_goal_janitor.exe` — 4/4 pass
- [x] Regression `dune exec test/test_board_dispatch.exe` — 26/26 pass
- [x] `dune build` clean (no warnings)

## Out of scope (→ follow-up PR)

- Sweep of 20+ other `String.sub ... ^ "..."` callsites: `lib/tool_calls/*`, `lib/logs/system_log*`, `lib/keepers/*/metrics*`, `lib/activity_feed.ml`, `lib/audit_log.ml`, `lib/dashboard_utils/dashboard_utils.ml` (`compact_text`), `lib/dashboard/briefing_json_helpers.ml` (`compact_text` duplicate).
- Prometheus counter wiring via the `Truncated { dropped_bytes; _ }` branch — deferred so this PR stays narrow; follow-up will add counters en-masse with one observability standard.
- `.masc/` runtime data repair: already completed outside the repo (42 files filter-repaired, `verdict.json` surgically fixed, archived to `.backup-corrupted-20260417/corrupted-snapshot.tar.gz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
