### PR TITLE
docs(spec): archive 04-chain-engine.md (chain subsystem purged)

### DIFF
--- a/docs/spec/04-chain-engine.md
+++ b/docs/spec/04-chain-engine.md
@@ -1,14 +1,20 @@
-# Chain Engine
+# Chain Engine — ARCHIVED
+
+> **이 spec은 chain subsystem이 존재하던 시절의 historical reference입니다.**
+>
+> `lib/chain/` 디렉토리와 `tool_command_plane_chain_*.ml` 모듈은 purge되었습니다. `masc_chain_snapshot` / `masc_chain_run_get` MCP tool도 등록되지 않습니다. 본 문서의 module / LOC / tool 숫자는 purge 이전 기준이며, 현재 runtime truth를 반영하지 않습니다.
+>
+> 이 spec은 migration 과정과 chain DSL 개념의 역사 기록으로만 남겨둡니다. 새 코드가 이 내용을 참조하지 않도록 주의하십시오.
 
 | 항목 | 값 |
 |------|-----|
-| Status | Draft |
-| Team | Chain |
-| Maps to | `lib/chain/` |
+| Status | Archived |
+| Team | Chain (dissolved) |
+| Maps to | `lib/chain/` (removed) |
 | Dependencies | 02-types-and-invariants |
-| Modules | 47 (36 `.ml` + 11 `.mli`) |
-| LOC | ~17,150 |
-| MCP Tools | `masc_chain_snapshot`, `masc_chain_run_get` |
+| Modules | 47 (36 `.ml` + 11 `.mli`) — historical |
+| LOC | ~17,150 — historical |
+| MCP Tools | `masc_chain_snapshot`, `masc_chain_run_get` — not registered |
 
 ---
 

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -51,7 +51,7 @@ graph TB
 | `01-system-overview.md` | System Overview | 문제 정의, 배포 모델, 기술 스택, sub-library 의존성 | Draft |
 | `02-types-and-invariants.md` | Types and Invariants | 핵심 타입 정의, 상태 전이, 불변식 | Draft |
 | `03-room-coordination.md` | Room Coordination | Room 생명주기, session 관리, agent join/leave | Draft |
-| `04-chain-engine.md` | Chain Engine | Multi-step chain DSL, execution, snapshot | Draft |
+| `04-chain-engine.md` | Chain Engine | Multi-step chain DSL, execution, snapshot | Historical |
 | `05-keeper-agent.md` | Keeper Engine | 자율 에이전트 루프, succession, context 관리 | Draft |
 | `06-command-plane.md` | Command Plane v2 | Internal command-plane reference and migration context | Historical |
 | `09-server-transport.md` | Server and Transport | HTTP transport, SSE, JSON-RPC dispatch, routing | Draft |


### PR DESCRIPTION
## Summary

`lib/chain/` and the chain subsystem were removed, but `docs/spec/04-chain-engine.md` continued to present itself as a live Draft spec. This PR adds an **ARCHIVED banner** + metadata annotations + flips the SPEC-INDEX row to `Historical`, matching the pattern already used for `06-command-plane.md`.

Metadata-level only — the 415 lines of spec body are left untouched as historical reference.

## What this fixes

| Field | Before | After |
|-------|--------|-------|
| `docs/spec/04-chain-engine.md` h1 | `# Chain Engine` | `# Chain Engine — ARCHIVED` |
| Status | `Draft` | `Archived` |
| Team | `Chain` | `Chain (dissolved)` |
| Maps to | `lib/chain/` | `lib/chain/` (removed) |
| Modules / LOC | `47 / ~17,150` | annotated `— historical` |
| MCP Tools | `masc_chain_snapshot, masc_chain_run_get` | annotated `— not registered` |
| `SPEC-INDEX.md` row Status | `Draft` | `Historical` |

Plus a 3-line blockquote explaining why the spec is preserved: new code should not reference it; it survives as a historical / migration reference, mirroring the 06-command-plane.md pattern.

## Verification

- `glob lib/chain*` → 0 files
- `glob lib/**/tool_command_plane_chain*` → 0 files
- `rg "masc_chain_snapshot|masc_chain_run_get" lib/` → 0 matches (tools not registered)
- `rg 04-chain-engine scripts/check-doc-truth.sh` → 0 refs (no assertion pinned)
- Local `bash scripts/check-doc-truth.sh` → `Doc truth OK`

## Why not delete / relocate?

- **Delete**: loses migration context + institutional memory of the DSL design.
- **Relocate to `docs/archive/`**: requires updating all cross-links (SPEC-INDEX, potentially other specs) and deciding on a repo archive convention.
- **In-place ARCHIVED banner**: lightweight, matches existing `06-command-plane.md` precedent, preserves git history, and lets readers who follow an old link still find the content with an explicit "do not use" header.

The archive-vs-relocate decision can be made separately if needed. This PR commits to the in-place archive pattern that the repo is already using.

## Continuation of

Same cleanup theme: #7715 (command_plane active-component claims), #7724 (routes_cp row), #7738 (LOC table absent rows) — all merged.