### PR TITLE
feat(dashboard): per-cell time sparkline + observation ring (LT-16c, stacks on #7740)

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -166,3 +166,30 @@ export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSc
 export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
   return parseOrThrow(CompositeSchemaDriftError, FleetCompositeSnapshotSchema, data)
 }
+
+// ── Fleet composite (LT-16a) ─────────────────────────────
+//
+// Backend: GET /api/v1/keepers/composite returns every registered
+// keeper in one envelope. Reuses the per-keeper snapshot shape so the
+// matrix UI (LT-16b, dashboard/src/components/fleet-fsm-matrix.ts) can
+// share render logic between single-keeper detail and fleet views.
+//
+// Each poll bumps the masc_keeper_invariant_violations_total counter
+// for any violating keeper (documented poll-triggered behaviour,
+// docs/observability/cascade-metrics.md §masc_keeper_invariant_violations_total).
+
+export const FleetCompositeSnapshotSchema = object({
+  generated_at: number(),
+  count: number(),
+  snapshots: array(KeeperCompositeSnapshotSchema),
+})
+
+export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
+
+export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
+  const result = safeParse(FleetCompositeSnapshotSchema, data)
+  if (!result.success) {
+    throw new CompositeSchemaDriftError(result.issues)
+  }
+  return result.output
+}

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -166,30 +166,3 @@ export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSc
 export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
   return parseOrThrow(CompositeSchemaDriftError, FleetCompositeSnapshotSchema, data)
 }
-
-// ── Fleet composite (LT-16a) ─────────────────────────────
-//
-// Backend: GET /api/v1/keepers/composite returns every registered
-// keeper in one envelope. Reuses the per-keeper snapshot shape so the
-// matrix UI (LT-16b, dashboard/src/components/fleet-fsm-matrix.ts) can
-// share render logic between single-keeper detail and fleet views.
-//
-// Each poll bumps the masc_keeper_invariant_violations_total counter
-// for any violating keeper (documented poll-triggered behaviour,
-// docs/observability/cascade-metrics.md §masc_keeper_invariant_violations_total).
-
-export const FleetCompositeSnapshotSchema = object({
-  generated_at: number(),
-  count: number(),
-  snapshots: array(KeeperCompositeSnapshotSchema),
-})
-
-export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
-
-export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
-  const result = safeParse(FleetCompositeSnapshotSchema, data)
-  if (!result.success) {
-    throw new CompositeSchemaDriftError(result.issues)
-  }
-  return result.output
-}

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest'
 
 import {
   chipClassFor,
+  FLEET_HISTORY_LEN,
   inferKeeperNameFrom,
+  pushObservation,
+  sparkClassFor,
   tallyInvariantViolations,
+  type KeeperFleetHistory,
 } from './fleet-fsm-matrix'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 
@@ -96,5 +100,59 @@ describe('tallyInvariantViolations', () => {
       compaction_atomicity: 0,
       event_priority_monotone: 0,
     })
+  })
+})
+
+describe('sparkClassFor', () => {
+  it('extracts a single bg-* utility from the full chip class', () => {
+    expect(sparkClassFor('Running')).toMatch(/^bg-emerald-900/)
+    expect(sparkClassFor('Failing')).toMatch(/^bg-red-900/)
+  })
+
+  it('falls back to a grey shade on unknown states', () => {
+    // DEFAULT_CHIP carries `bg-zinc-800`; sparkClassFor preserves it.
+    expect(sparkClassFor('__not_a_state__')).toMatch(/^bg-zinc-(700|800)/)
+  })
+})
+
+describe('pushObservation', () => {
+  it('seeds a new keeper with one observation per axis', () => {
+    const next = pushObservation({}, [snapshot({ name: 'alpha' })])
+    const alpha = next.alpha!
+    expect(alpha.phase).toEqual(['Running'])
+    expect(alpha.turn).toEqual(['idle'])
+    expect(alpha.decision).toEqual(['undecided'])
+    expect(alpha.cascade).toEqual(['idle'])
+    expect(alpha.compaction).toEqual(['accumulating'])
+  })
+
+  it('appends new observations while preserving prior ones', () => {
+    const t1 = pushObservation({}, [snapshot({ name: 'alpha', phase: 'Running' })])
+    const t2 = pushObservation(t1, [snapshot({ name: 'alpha', phase: 'Failing' })])
+    expect(t2.alpha!.phase).toEqual(['Running', 'Failing'])
+  })
+
+  it('caps each axis series at the history window', () => {
+    let h: KeeperFleetHistory = {}
+    for (let i = 0; i < FLEET_HISTORY_LEN + 7; i++) {
+      h = pushObservation(h, [snapshot({ name: 'a' })], FLEET_HISTORY_LEN)
+    }
+    expect(h.a!.phase.length).toBe(FLEET_HISTORY_LEN)
+  })
+
+  it('drops keepers that disappear from the latest snapshot', () => {
+    const t1 = pushObservation({}, [
+      snapshot({ name: 'alpha' }),
+      snapshot({ name: 'beta' }),
+    ])
+    expect(Object.keys(t1).sort()).toEqual(['alpha', 'beta'])
+    const t2 = pushObservation(t1, [snapshot({ name: 'alpha' })])
+    expect(Object.keys(t2)).toEqual(['alpha'])
+  })
+
+  it('returns a fresh top-level object for identity-based re-renders', () => {
+    const prior = {}
+    const next = pushObservation(prior, [snapshot({ name: 'alpha' })])
+    expect(next).not.toBe(prior)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -10,17 +10,15 @@
  * Backend: #7723 (LT-16a) → GET /api/v1/keepers/composite.
  * Spec↔code drift: docs/observability/fsm-spec-code-drift.md (LT-15).
  *
- * Scope of this PR:
- *   - Static snapshot view (current state only).
- *   - Time-axis sparkline is deferred to LT-16c which adds a client-
- *     side observation ring so the poll history stays visible without
- *     a backend change.
- *   - Click-through to the existing FsmHub drill-down is deferred to
- *     LT-16c; exposed via the caller passing `onSelectKeeper`.
+ * LT-16c added a per-(keeper, axis) observation ring and a horizontal
+ * sparkline renderer so each cell now carries its last 30 poll ticks.
+ * The ring lives client-side; the backend remains stateless. A keeper
+ * that disappears from a fleet poll is pruned from history on the next
+ * tick (operators care about currently-registered keepers).
  */
 
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import { fetchKeepersComposite } from '../api/keeper'
 import type {
@@ -36,6 +34,14 @@ import {
 } from './fsm-hub-types'
 
 const POLL_INTERVAL_MS = 10_000
+
+/**
+ * Time-axis window (LT-16c). 30 snapshots × 10s poll = 5-minute
+ * history per (keeper, axis). Matches MAX_OBSERVATIONS = 30 in
+ * fsm-hub-types.ts so the FsmHub drill-down and this matrix keep
+ * visually compatible timelines.
+ */
+export const FLEET_HISTORY_LEN = 30
 
 // Axis order is fixed by the TLA+ joint spec
 // (KeeperCompositeLifecycle.tla): KSM → KTC → KDP → KCL → KMC.
@@ -97,6 +103,57 @@ export function chipClassFor(value: string): string {
 }
 
 /**
+ * Reduce a chip class to a single `bg-...` Tailwind utility so the
+ * sparkline bars can be 2–3 px wide without losing their state
+ * encoding. Neutral grey on unknown values.
+ */
+export function sparkClassFor(value: string): string {
+  const full = chipClassFor(value)
+  const m = /\bbg-[a-z0-9/-]+/i.exec(full)
+  return m?.[0] ?? 'bg-zinc-700'
+}
+
+/** Per-axis observation ring keyed by keeper name. */
+export type KeeperFleetHistory = Record<string, Record<LaneKey, string[]>>
+
+const AXIS_KEYS: LaneKey[] = ['phase', 'turn', 'decision', 'cascade', 'compaction']
+
+/**
+ * Fold an incoming batch of snapshots into the running history, capping
+ * each axis series at [maxLen]. Returns a fresh top-level record so
+ * Preact's identity render path notices the change. Keepers that
+ * disappear from the latest snapshot are dropped — operators care
+ * about currently-registered keepers and a restart re-populates the
+ * name on the next poll.
+ */
+export function pushObservation(
+  history: KeeperFleetHistory,
+  snapshots: KeeperCompositeSnapshot[],
+  maxLen: number = FLEET_HISTORY_LEN,
+): KeeperFleetHistory {
+  const next: KeeperFleetHistory = {}
+  for (const snap of snapshots) {
+    const name = inferKeeperNameFrom(snap)
+    const prev = history[name]
+    const perAxis: Record<LaneKey, string[]> = {
+      phase:      prev?.phase      ? prev.phase.slice()      : [],
+      turn:       prev?.turn       ? prev.turn.slice()       : [],
+      decision:   prev?.decision   ? prev.decision.slice()   : [],
+      cascade:    prev?.cascade    ? prev.cascade.slice()    : [],
+      compaction: prev?.compaction ? prev.compaction.slice() : [],
+    }
+    for (const axis of AXIS_KEYS) {
+      perAxis[axis].push(extractLaneValue(snap, axis))
+      if (perAxis[axis].length > maxLen) {
+        perAxis[axis] = perAxis[axis].slice(-maxLen)
+      }
+    }
+    next[name] = perAxis
+  }
+  return next
+}
+
+/**
  * Sum invariant violations across the fleet. Value is the number of
  * keepers where the invariant is currently failing; matches the
  * denominator the operator cares about ("how many keepers are bad?"),
@@ -133,6 +190,10 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
+  // Observation ring. Ref rather than state because pushObservation
+  // returns a fresh record per tick and we pair it with a setData call
+  // which triggers the re-render — avoids a redundant state subscription.
+  const historyRef = useRef<KeeperFleetHistory>({})
 
   useEffect(() => {
     let cancelled = false
@@ -141,6 +202,11 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       try {
         const snap = await fetcher()
         if (!cancelled) {
+          historyRef.current = pushObservation(
+            historyRef.current,
+            snap.snapshots,
+            FLEET_HISTORY_LEN,
+          )
           setData(snap)
           setError(null)
           setLoading(false)
@@ -260,13 +326,31 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                   ${AXES.map(a => {
                     const raw = extractLaneValue(snap, a.key)
                     const cls = chipClassFor(raw)
+                    const series = historyRef.current[name]?.[a.key] ?? [raw]
                     return html`
-                      <td class="px-3 py-2">
-                        <span
-                          data-cell
-                          data-axis=${a.key}
-                          class="inline-block rounded border px-2 py-0.5 ${cls}"
-                        >${displayState(raw)}</span>
+                      <td class="px-3 py-2 align-top">
+                        <div class="flex flex-col gap-1">
+                          <span
+                            data-cell
+                            data-axis=${a.key}
+                            class="inline-block self-start rounded border px-2 py-0.5 ${cls}"
+                          >${displayState(raw)}</span>
+                          <div
+                            data-spark
+                            data-axis=${a.key}
+                            class="flex h-2 overflow-hidden rounded-sm border border-zinc-800 bg-zinc-950"
+                            title=${`last ${series.length}/${FLEET_HISTORY_LEN} ticks`}
+                          >
+                            ${series.map((v, i) => html`
+                              <span
+                                key=${i}
+                                data-spark-bar
+                                class="h-full w-0.5 ${sparkClassFor(v)}"
+                                title=${displayState(v)}
+                              ></span>
+                            `)}
+                          </div>
+                        </div>
                       </td>
                     `
                   })}


### PR DESCRIPTION
## Summary

Adds the **4th dimension (time)** to the fleet FSM matrix — each cell now carries its last 30 poll ticks as a 2-px horizontal sparkline under the current-state chip.

Stacks on #7740 (LT-16b). Backend is unchanged; history is kept client-side.

## Dimensional encoding

| Axis | Visual |
|------|--------|
| keeper identity | row |
| FSM axis (5 orthogonal) | column |
| current state | state-chip colour + label |
| time (last 5 min) | 30 narrow bars underneath the chip |

This is the full LT-12 design §2.1 layout realised: Harel 1987 orthogonal regions rendered side-by-side, time as a per-cell within-dimension sub-axis. **Explicitly rejects 3-D rotation** in favour of Bach et al. 2013's finding that small multiples beat animation for discrete state-change comprehension.

## Observation ring

- \`pushObservation(history, snapshots, maxLen = 30)\` — pure fold; drops keepers missing from the latest snapshot so the matrix only shows currently-registered rows.
- \`useRef\` holds the mutable history; paired with \`setData\` which already triggers a re-render, so we avoid a duplicate state subscription.
- Window size matches \`MAX_OBSERVATIONS = 30\` in \`fsm-hub-types.ts\` so the FsmHub drill-down and the fleet matrix stay visually compatible.

## Tests

14/14 vitest:
- (7 existing) chipClassFor / inferKeeperNameFrom / tallyInvariantViolations basics.
- **+2** sparkClassFor: bg-* extraction + grey fallback.
- **+5** pushObservation: seeding, append, window cap, keeper pruning on poll disappearance, fresh-top-level-record contract.

## Scope boundaries

Still deferred (LT-16d, next tick):
- Mount in \`agents-unified.ts\` or a dedicated tab.
- Drill-through (\`onSelectKeeper\` → existing \`FsmHub\` via store).
- DOM-level rendering tests with happy-dom.

## References

- #7689 (LT-12 design) — specifically §2.1 cell encoding.
- #7740 (LT-16b) — base component this extends.
- #7708 / #7713 — Prometheus invariant counter the top strip summarises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)