### PR TITLE
feat(dashboard): search + category filter for agent timeline

### DIFF
--- a/dashboard/src/components/agent-detail-timeline.test.ts
+++ b/dashboard/src/components/agent-detail-timeline.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { timelineEventIcon, timelineEventLabel } from './agent-detail-timeline'
+import {
+  timelineEventIcon,
+  timelineEventLabel,
+  timelineEventCategory,
+  timelineEventSearchText,
+  timelineCategoryCounts,
+  filterTimelineEvents,
+} from './agent-detail-timeline'
+import type { AgentTimelineEvent } from '../api'
 
 describe('timelineEventIcon', () => {
   it('returns J for joined', () => {
@@ -53,5 +61,145 @@ describe('timelineEventLabel', () => {
     expect(timelineEventLabel('unknown')).toBe('unknown')
     expect(timelineEventLabel('')).toBe('')
     expect(timelineEventLabel('custom_event')).toBe('custom_event')
+  })
+})
+
+// Helpers for building fixtures.
+function evt(type: string, detail: Record<string, unknown> = {}): AgentTimelineEvent {
+  return { ts: '2026-04-17T01:00:00Z', type, detail }
+}
+
+describe('timelineEventCategory', () => {
+  it('maps task_ prefixed types to task', () => {
+    expect(timelineEventCategory('task_claimed')).toBe('task')
+    expect(timelineEventCategory('task_started')).toBe('task')
+    expect(timelineEventCategory('task_completed')).toBe('task')
+    expect(timelineEventCategory('task_anything')).toBe('task')
+  })
+
+  it('maps known types to their own category', () => {
+    expect(timelineEventCategory('tool_call')).toBe('tool_call')
+    expect(timelineEventCategory('broadcast')).toBe('broadcast')
+    expect(timelineEventCategory('joined')).toBe('joined')
+  })
+
+  it('maps unknown types to other', () => {
+    expect(timelineEventCategory('unknown')).toBe('other')
+    expect(timelineEventCategory('')).toBe('other')
+    expect(timelineEventCategory('heartbeat')).toBe('other')
+  })
+})
+
+describe('timelineEventSearchText', () => {
+  it('includes type and Korean label', () => {
+    const text = timelineEventSearchText(evt('broadcast'))
+    expect(text).toContain('broadcast')
+    expect(text).toContain('공지')
+  })
+
+  it('includes tool_name for tool_call events', () => {
+    const text = timelineEventSearchText(evt('tool_call', { tool_name: 'bash' }))
+    expect(text).toContain('bash')
+  })
+
+  it('includes title/content/error from detail', () => {
+    const text = timelineEventSearchText(evt('task_completed', {
+      title: 'Fix login bug',
+      content: 'oauth token refresh',
+      error: 'ECONNRESET',
+    }))
+    expect(text).toContain('fix login bug')
+    expect(text).toContain('oauth')
+    expect(text).toContain('econnreset')
+  })
+
+  it('returns lowercase string', () => {
+    const text = timelineEventSearchText(evt('task_started', { title: 'UPPER' }))
+    expect(text).toBe(text.toLowerCase())
+  })
+
+  it('ignores non-string detail fields', () => {
+    const text = timelineEventSearchText(evt('tool_call', {
+      tool_name: 'bash',
+      duration_ms: 123,
+      success: true,
+    }))
+    expect(text).toContain('bash')
+    expect(text).not.toContain('123')
+  })
+})
+
+describe('timelineCategoryCounts', () => {
+  it('counts each category', () => {
+    const events = [
+      evt('task_claimed'),
+      evt('task_started'),
+      evt('tool_call'),
+      evt('broadcast'),
+      evt('broadcast'),
+      evt('joined'),
+      evt('heartbeat'),
+    ]
+    expect(timelineCategoryCounts(events)).toEqual({
+      task: 2,
+      tool_call: 1,
+      broadcast: 2,
+      joined: 1,
+      other: 1,
+    })
+  })
+
+  it('returns zeros for empty input', () => {
+    expect(timelineCategoryCounts([])).toEqual({
+      task: 0,
+      tool_call: 0,
+      broadcast: 0,
+      joined: 0,
+      other: 0,
+    })
+  })
+})
+
+describe('filterTimelineEvents', () => {
+  const events: AgentTimelineEvent[] = [
+    evt('task_claimed', { title: 'Deploy dashboard' }),
+    evt('task_completed', { title: 'Deploy dashboard' }),
+    evt('tool_call', { tool_name: 'bash' }),
+    evt('tool_call', { tool_name: 'grep' }),
+    evt('broadcast', { content: 'server restart scheduled' }),
+    evt('joined'),
+  ]
+
+  it('returns all events when category=all and query empty', () => {
+    expect(filterTimelineEvents(events, 'all', '')).toBe(events)
+  })
+
+  it('filters by category', () => {
+    expect(filterTimelineEvents(events, 'task', '')).toHaveLength(2)
+    expect(filterTimelineEvents(events, 'tool_call', '')).toHaveLength(2)
+    expect(filterTimelineEvents(events, 'broadcast', '')).toHaveLength(1)
+    expect(filterTimelineEvents(events, 'joined', '')).toHaveLength(1)
+    expect(filterTimelineEvents(events, 'other', '')).toHaveLength(0)
+  })
+
+  it('filters by search query (case-insensitive)', () => {
+    expect(filterTimelineEvents(events, 'all', 'deploy')).toHaveLength(2)
+    expect(filterTimelineEvents(events, 'all', 'DEPLOY')).toHaveLength(2)
+    expect(filterTimelineEvents(events, 'all', 'bash')).toHaveLength(1)
+    expect(filterTimelineEvents(events, 'all', 'restart')).toHaveLength(1)
+  })
+
+  it('combines category and query (AND)', () => {
+    expect(filterTimelineEvents(events, 'tool_call', 'bash')).toHaveLength(1)
+    expect(filterTimelineEvents(events, 'task', 'deploy')).toHaveLength(2)
+    expect(filterTimelineEvents(events, 'broadcast', 'bash')).toHaveLength(0)
+  })
+
+  it('trims whitespace-only query', () => {
+    expect(filterTimelineEvents(events, 'all', '   ')).toHaveLength(events.length)
+  })
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterTimelineEvents(events, 'all', 'zzzzzz')).toEqual([])
   })
 })

--- a/dashboard/src/components/agent-detail-timeline.ts
+++ b/dashboard/src/components/agent-detail-timeline.ts
@@ -2,9 +2,12 @@
 // Includes tool_call events from Activity Graph integration.
 
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { TimeAgo } from './common/time-ago'
+import { FilterChips } from './common/filter-chips'
+import { TextInput } from './common/input'
 import { agentTimeline } from './agent-detail-state'
 import { trimText } from '../lib/truncate'
 import { toolCategory, durationColor, formatDuration, formatArgs } from './tool-call-shared'
@@ -30,6 +33,58 @@ export function timelineEventLabel(type: string): string {
     default: return type
   }
 }
+
+// ── Event categorization & filter (pure) ──────────────────────────
+// Used for FilterChips grouping and filtering. Categories are
+// deliberately coarse so chips stay compact even as new event types
+// are added server-side.
+
+export type TimelineEventCategory = 'all' | 'task' | 'tool_call' | 'broadcast' | 'joined' | 'other'
+
+export function timelineEventCategory(type: string): Exclude<TimelineEventCategory, 'all'> {
+  if (type.startsWith('task_')) return 'task'
+  if (type === 'tool_call') return 'tool_call'
+  if (type === 'broadcast') return 'broadcast'
+  if (type === 'joined') return 'joined'
+  return 'other'
+}
+
+export function timelineEventSearchText(evt: AgentTimelineEvent): string {
+  const parts: string[] = [evt.type, timelineEventLabel(evt.type)]
+  const d = evt.detail as Record<string, unknown> | undefined
+  if (d && typeof d === 'object') {
+    for (const key of ['title', 'content', 'tool_name', 'error']) {
+      const v = d[key]
+      if (typeof v === 'string' && v.length > 0) parts.push(v)
+    }
+  }
+  return parts.join(' ').toLowerCase()
+}
+
+export function filterTimelineEvents(
+  events: AgentTimelineEvent[],
+  category: TimelineEventCategory,
+  query: string,
+): AgentTimelineEvent[] {
+  const q = query.trim().toLowerCase()
+  if (category === 'all' && q === '') return events
+  return events.filter(evt => {
+    if (category !== 'all' && timelineEventCategory(evt.type) !== category) return false
+    if (q !== '' && !timelineEventSearchText(evt).includes(q)) return false
+    return true
+  })
+}
+
+export function timelineCategoryCounts(
+  events: AgentTimelineEvent[],
+): Record<Exclude<TimelineEventCategory, 'all'>, number> {
+  const counts = { task: 0, tool_call: 0, broadcast: 0, joined: 0, other: 0 }
+  for (const evt of events) counts[timelineEventCategory(evt.type)]++
+  return counts
+}
+
+const timelineCategoryFilter = signal<TimelineEventCategory>('all')
+const timelineSearchQuery = signal('')
 
 function ToolCallEventRow({ evt, idx }: { evt: AgentTimelineEvent; idx: number }) {
   const d = evt.detail as Record<string, unknown>
@@ -77,6 +132,11 @@ export function AgentTimelineSection() {
 
   const events = timeline.events ?? []
   const summary = timeline.summary
+  const counts = timelineCategoryCounts(events)
+  const activeCategory = timelineCategoryFilter.value
+  const query = timelineSearchQuery.value
+  const filtered = filterTimelineEvents(events, activeCategory, query)
+  const filterActive = activeCategory !== 'all' || query.trim() !== ''
 
   return html`
     <${Card} title="활동 타임라인 (${summary?.total_events ?? 0}건)">
@@ -92,23 +152,54 @@ export function AgentTimelineSection() {
       ${events.length === 0
         ? html`<${EmptyState} message="작업 기록이 아직 없습니다" compact />`
         : html`
-            <div class="flex flex-col gap-0.5 max-h-[400px] overflow-y-auto">
-              ${events.map((evt: AgentTimelineEvent, idx: number) => {
-                if (evt.type === 'tool_call') {
-                  return html`<${ToolCallEventRow} evt=${evt} idx=${idx} />`
-                }
-                const detail = evt.detail as Record<string, string | undefined>
-                const title = detail.title ?? detail.content ?? ''
-                return html`
-                  <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
-                    <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
-                    <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
-                    ${title ? html`<span class="agent-timeline-detail">${trimText(title, 80)}</span>` : null}
-                    ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
-                  </div>
-                `
-              })}
+            <div class="flex flex-wrap gap-2 items-center mb-2">
+              <${FilterChips}
+                chips=${[
+                  { key: 'all' as TimelineEventCategory, label: '전체', count: events.length },
+                  { key: 'task' as TimelineEventCategory, label: '태스크', count: counts.task },
+                  { key: 'tool_call' as TimelineEventCategory, label: '도구', count: counts.tool_call },
+                  { key: 'broadcast' as TimelineEventCategory, label: '공지', count: counts.broadcast },
+                  { key: 'joined' as TimelineEventCategory, label: '참가', count: counts.joined },
+                  { key: 'other' as TimelineEventCategory, label: '기타', count: counts.other },
+                ]}
+                active=${timelineCategoryFilter}
+                size="sm"
+                tone="accent"
+              />
+              <${TextInput}
+                class="max-w-[220px]"
+                name="agent_timeline_search"
+                ariaLabel="타임라인 검색"
+                autoComplete="off"
+                placeholder="내용·도구 검색..."
+                value=${query}
+                onInput=${(e: Event) => { timelineSearchQuery.value = (e.target as HTMLInputElement).value }}
+              />
+              ${filterActive
+                ? html`<span class="text-[10px] text-[var(--text-dim)] tabular-nums">${filtered.length} / ${events.length}</span>`
+                : null}
             </div>
+            ${filtered.length === 0
+              ? html`<${EmptyState} message="조건에 맞는 이벤트가 없습니다" compact />`
+              : html`
+                  <div class="flex flex-col gap-0.5 max-h-[400px] overflow-y-auto">
+                    ${filtered.map((evt: AgentTimelineEvent, idx: number) => {
+                      if (evt.type === 'tool_call') {
+                        return html`<${ToolCallEventRow} evt=${evt} idx=${idx} />`
+                      }
+                      const detail = evt.detail as Record<string, string | undefined>
+                      const title = detail.title ?? detail.content ?? ''
+                      return html`
+                        <div class="agent-timeline-event flex items-baseline gap-1.5 py-1 px-2 text-[13px] transition-[background] duration-100 rounded hover:bg-[var(--white-4)]" key=${idx}>
+                          <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
+                          <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
+                          ${title ? html`<span class="agent-timeline-detail">${trimText(title, 80)}</span>` : null}
+                          ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
+                        </div>
+                      `
+                    })}
+                  </div>
+                `}
           `}
     <//>
   `


### PR DESCRIPTION
## Summary

Adds FilterChips (task / tool_call / broadcast / joined / other) and a search input to `AgentTimelineSection`, matching the search-rhythm already landed in #7652, #7654, #7656, #7694, #7706, #7717, #7741.

Agent detail pages with hundreds of events previously forced linear scrolling. The chips give O(1) scoping by category; the search box does a case-insensitive contains-match against type, Korean label, and selected detail fields (`title`, `content`, `tool_name`, `error`).

## What changed

- `dashboard/src/components/agent-detail-timeline.ts`
  - New pure helpers: `timelineEventCategory`, `timelineEventSearchText`, `timelineCategoryCounts`, `filterTimelineEvents`.
  - Module-local signals `timelineCategoryFilter` / `timelineSearchQuery`.
  - Toolbar row above the event list with FilterChips + TextInput + "N / total" count when a filter is active.
  - Filtered empty state kept distinct from "no events" empty state.
- `dashboard/src/components/agent-detail-timeline.test.ts`
  - 14 new tests for the pure helpers (category mapping, search-text composition, counts, filter AND-semantics, whitespace handling, zero-match path).

## CI discipline

- `pnpm -C dashboard typecheck` — clean (baseline is clean; no new errors in diff).
- `pnpm -C dashboard lint` — clean.
- `pnpm -C dashboard test` — 26 passed in `agent-detail-timeline.test.ts` (was 12). Unrelated pre-existing flakes on `telemetry-unified`, `quick-intervene`, `overview`, `autoresearch` exist on `origin/main` as well and were verified against a stashed baseline.

## Scope

- Dashboard-only diff. 2 files. Zero OCaml.
- Not in collision zones: `agent-detail-timeline` is distinct from `keeper-trajectory-timeline` (#7706), observatory activity (#7726/#7727), and `agent-info` (#7711). Last touched by merged #7701, so the file is quiescent.

## Test plan

- [ ] Open an agent detail page with 50+ events; verify chips filter by category and counts match.
- [ ] Type a tool name in the search box; verify tool_call rows with matching `tool_name` show up, others hide.
- [ ] Clear filter; verify full event list returns.
- [ ] Confirm empty-category + empty-query returns identity (no re-rendered list identity churn).

## Follow-up seed

Extend the same pure-fn + FilterChips pattern to `agent-detail-session-report.ts` (session-scoped timeline) and the broadcast/keeper-chat-panel list — both still lack filter controls and hit similar event volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)