### PR TITLE
feat(dashboard/api): migrate agent-timeline endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -15,6 +15,11 @@ import {
   parseAgentRelationsResponse,
   type AgentRelationsResponse,
 } from './schemas/agent-relations'
+import {
+  parseAgentTimelineResponse,
+  type AgentTimelineEvent,
+  type AgentTimelineResponse,
+} from './schemas/agent-timeline'
 import type {
   KeeperConfig,
   KeeperFeatureStatus,
@@ -144,32 +149,18 @@ export function reportToolHostFailure(
   return post('/api/v1/dashboard/logs/tool-host-failures', report, undefined, 3000)
 }
 
-export interface AgentTimelineEvent {
-  ts: string
-  type: string
-  detail: Record<string, unknown>
-}
+export type { AgentTimelineEvent, AgentTimelineResponse }
+export { AgentTimelineSchemaDriftError } from './schemas/agent-timeline'
 
-export interface AgentTimelineResponse {
-  agent: string
-  period: { from: string; to: string }
-  events: AgentTimelineEvent[]
-  summary: {
-    tasks_completed: number
-    tasks_claimed: number
-    messages_sent: number
-    tool_calls?: number
-    active_duration_minutes: number
-    total_events: number
-  }
-}
-
-export function fetchAgentTimeline(
+export async function fetchAgentTimeline(
   agentName: string,
   sinceHours = 4,
   limit = 20,
 ): Promise<AgentTimelineResponse> {
-  return get(`/api/v1/agent-timeline?agent_name=${encodeURIComponent(agentName)}&since_hours=${sinceHours}&limit=${limit}`)
+  const raw = await get<unknown>(
+    `/api/v1/agent-timeline?agent_name=${encodeURIComponent(agentName)}&since_hours=${sinceHours}&limit=${limit}`,
+  )
+  return parseAgentTimelineResponse(raw)
 }
 
 export type {

--- a/dashboard/src/api/schemas/agent-timeline.test.ts
+++ b/dashboard/src/api/schemas/agent-timeline.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AgentTimelineSchemaDriftError,
+  parseAgentTimelineResponse,
+} from './agent-timeline'
+
+function validResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent: 'dreamer',
+    period: { from: '2026-04-17T00:00:00Z', to: '2026-04-17T04:00:00Z' },
+    events: [
+      {
+        ts: '2026-04-17T00:05:00Z',
+        type: 'task_claimed',
+        detail: { task_id: 'T-1' },
+      },
+      {
+        ts: '2026-04-17T00:10:00Z',
+        type: 'tool_call',
+        detail: { tool: 'masc_check', duration_ms: 42 },
+      },
+    ],
+    summary: {
+      tasks_completed: 3,
+      tasks_claimed: 4,
+      messages_sent: 12,
+      tool_calls: 7,
+      active_duration_minutes: 38,
+      total_events: 24,
+    },
+    ...overrides,
+  }
+}
+
+describe('parseAgentTimelineResponse', () => {
+  it('accepts a well-formed response', () => {
+    const out = parseAgentTimelineResponse(validResponse())
+    expect(out.agent).toBe('dreamer')
+    expect(out.events).toHaveLength(2)
+    expect(out.summary.tool_calls).toBe(7)
+  })
+
+  it('accepts a response with no events', () => {
+    const out = parseAgentTimelineResponse(
+      validResponse({
+        events: [],
+        summary: {
+          tasks_completed: 0,
+          tasks_claimed: 0,
+          messages_sent: 0,
+          active_duration_minutes: 0,
+          total_events: 0,
+        },
+      }),
+    )
+    expect(out.events).toHaveLength(0)
+  })
+
+  it('accepts omitted optional tool_calls field', () => {
+    const out = parseAgentTimelineResponse(
+      validResponse({
+        summary: {
+          tasks_completed: 1,
+          tasks_claimed: 1,
+          messages_sent: 0,
+          active_duration_minutes: 10,
+          total_events: 2,
+        },
+      }),
+    )
+    expect(out.summary.tool_calls).toBeUndefined()
+  })
+
+  it('accepts unknown event types (backend evolves event taxonomy)', () => {
+    const out = parseAgentTimelineResponse(
+      validResponse({
+        events: [
+          {
+            ts: '2026-04-17T00:00:00Z',
+            type: 'brand_new_event_kind',
+            detail: {},
+          },
+        ],
+      }),
+    )
+    expect(out.events[0]!.type).toBe('brand_new_event_kind')
+  })
+
+  it('throws when summary is missing required fields', () => {
+    const bad = validResponse({
+      summary: { tasks_completed: 0 },
+    })
+    expect(() => parseAgentTimelineResponse(bad)).toThrow(AgentTimelineSchemaDriftError)
+  })
+
+  it('throws when period shape is wrong', () => {
+    const bad = validResponse({ period: { from: '2026-04-17T00:00:00Z' } })
+    expect(() => parseAgentTimelineResponse(bad)).toThrow(AgentTimelineSchemaDriftError)
+  })
+
+  it('throws when events has an entry missing ts', () => {
+    const bad = validResponse({
+      events: [{ type: 'task_claimed', detail: {} }],
+    })
+    expect(() => parseAgentTimelineResponse(bad)).toThrow(AgentTimelineSchemaDriftError)
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseAgentTimelineResponse(null)).toThrow(AgentTimelineSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/agent-timeline.ts
+++ b/dashboard/src/api/schemas/agent-timeline.ts
@@ -1,0 +1,74 @@
+// Agent timeline schema — schema-at-boundary for
+// `GET /api/v1/agent-timeline?agent_name=<name>&since_hours=<N>&limit=<K>`.
+//
+// `event.type` is open `string()` because the backend adds new event
+// kinds ahead of the dashboard; consumers dispatch on the string with a
+// default case, so a strict picklist would suppress legitimate events.
+// `event.detail` is `record(string, unknown)` — opaque structured
+// metadata, consumed defensively.
+
+import {
+  array,
+  number,
+  object,
+  optional,
+  record,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+export const AgentTimelineEventSchema = object({
+  ts: string(),
+  type: string(),
+  detail: record(string(), unknown()),
+})
+
+const AgentTimelinePeriodSchema = object({
+  from: string(),
+  to: string(),
+})
+
+const AgentTimelineSummarySchema = object({
+  tasks_completed: number(),
+  tasks_claimed: number(),
+  messages_sent: number(),
+  tool_calls: optional(number()),
+  active_duration_minutes: number(),
+  total_events: number(),
+})
+
+export const AgentTimelineResponseSchema = object({
+  agent: string(),
+  period: AgentTimelinePeriodSchema,
+  events: array(AgentTimelineEventSchema),
+  summary: AgentTimelineSummarySchema,
+})
+
+export type AgentTimelineEvent = InferOutput<typeof AgentTimelineEventSchema>
+export type AgentTimelineResponse = InferOutput<typeof AgentTimelineResponseSchema>
+
+export class AgentTimelineSchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`agent-timeline schema drift: ${summary}`)
+    this.name = AgentTimelineSchemaDriftError.name
+    this.issues = issues
+  }
+}
+
+export function parseAgentTimelineResponse(data: unknown): AgentTimelineResponse {
+  const result = safeParse(AgentTimelineResponseSchema, data, { abortEarly: true })
+  if (!result.success) {
+    throw new AgentTimelineSchemaDriftError(result.issues)
+  }
+  return result.output
+}


### PR DESCRIPTION
## Summary

Migrates \`GET /api/v1/agent-timeline\` to schema-at-boundary. Second endpoint extracted from \`api/dashboard.ts\` (after agent-relations in #7734 and logs in #7746).

- Adds \`src/api/schemas/agent-timeline.ts\` — 4 schemas, 2 \`InferOutput\` types, \`AgentTimelineSchemaDriftError\`, \`parseAgentTimelineResponse\`.
- Shrinks the \`dashboard.ts\` section from 27 lines of nested interfaces + unsafe cast to a schema re-export + parse call.
- 8 shape tests.

## Drift policy

- \`event.type\` → **open \`string()\`** (backend adds new event kinds ahead of the dashboard; a strict picklist would suppress legitimate events because consumers already dispatch with a default case).
- \`event.detail\` → \`record(string, unknown)\` (opaque metadata, consumed defensively).
- \`summary.tool_calls\` → \`optional(number())\` matches prior \`?:\` field.

## Caller impact

8 callers across \`agent-detail-*\`, \`agent-profile\`, \`session-trace-state\`, \`goals/task-detail-state\`, \`session-report\` all import by type name from \`../api\`. Re-exports keep every call site unchanged. Verified via:

- \`pnpm typecheck\` clean
- \`pnpm vitest run src/api/schemas/agent-timeline.test.ts src/components/agent-detail-session-report.test.ts\` — 17/17 pass

Part of #7441. Follow-up to adopt shared \`SchemaDriftError\` base once #7732 lands.