### PR TITLE
feat(cdal_verdict_gate): Attribution envelope conversion (L1 gate #1/3)

### DIFF
--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -92,3 +92,40 @@ let gate_check ?(base_dir = default_base_path) ~task_id () : string option =
     match check_verdict verdict with
     | Allow -> None
     | Reject msg -> Some msg
+
+(* --- Attribution envelope conversion ---
+   Layer 1 of the attribution rollout. Lets emitters surface a typed
+   verdict envelope alongside the existing string-return gate_check. *)
+
+let blocking_gap_count (v : Cdal_types.contract_verdict) : int =
+  List.length
+    (List.filter
+       (fun (g : Cdal_types.completeness_gap) ->
+         g.impact = Cdal_types.Blocks_verdict)
+       v.completeness_gaps)
+
+let evidence_of_verdict (v : Cdal_types.contract_verdict) : Yojson.Safe.t =
+  `Assoc [
+    ("run_id", `String v.run_id);
+    ("contract_id", `String v.contract_id);
+    ("status", `String (Cdal_types.contract_status_to_string v.status));
+    ("findings_count", `Int (List.length v.findings));
+    ("gaps_count", `Int (List.length v.completeness_gaps));
+    ("blocking_gaps_count", `Int (blocking_gap_count v));
+  ]
+
+let to_attribution (v : Cdal_types.contract_verdict) : Attribution.t =
+  let evidence = evidence_of_verdict v in
+  match check_verdict v with
+  | Allow ->
+    Attribution.passed ~origin:Det ~gate:"cdal_verdict" ~evidence
+  | Reject reason ->
+    Attribution.policy_failed ~origin:Det ~gate:"cdal_verdict" ~evidence ~reason
+
+let attribution_for_missing_verdict ~task_id : Attribution.t =
+  let evidence = `Assoc [ ("task_id", `String task_id) ] in
+  Attribution.policy_failed ~origin:Det ~gate:"cdal_verdict" ~evidence
+    ~reason:
+      (Printf.sprintf
+         "No CDAL verdict found for task %s. Submit evidence before completing."
+         task_id)

--- a/test/test_cdal_verdict_gate.ml
+++ b/test/test_cdal_verdict_gate.ml
@@ -210,6 +210,113 @@ let test_gate_latest_verdict_wins () =
       Alcotest.fail (Printf.sprintf "Latest Satisfied should allow, got: %s" msg))
 
 (* ================================================================ *)
+(* Attribution conversion tests                                      *)
+(* ================================================================ *)
+
+module A = Masc_mcp.Attribution
+
+let assert_gate_is_cdal_verdict (attr : A.t) =
+  Alcotest.(check string) "gate" "cdal_verdict" attr.gate;
+  Alcotest.(check bool) "origin=Det" true (attr.origin = A.Det)
+
+let evidence_int_field attr key : int option =
+  match attr.A.evidence with
+  | `Assoc fields -> (
+    match List.assoc_opt key fields with
+    | Some (`Int n) -> Some n
+    | _ -> None)
+  | _ -> None
+
+let evidence_string_field attr key : string option =
+  match attr.A.evidence with
+  | `Assoc fields -> (
+    match List.assoc_opt key fields with
+    | Some (`String s) -> Some s
+    | _ -> None)
+  | _ -> None
+
+let test_to_attribution_satisfied_is_passed () =
+  let v = make_verdict ~status:CT.Satisfied () in
+  let attr = CVG.to_attribution v in
+  assert_gate_is_cdal_verdict attr;
+  Alcotest.(check bool)
+    "outcome=Passed" true
+    (match attr.outcome with A.Passed -> true | _ -> false);
+  Alcotest.(check (option string))
+    "evidence.status" (Some "satisfied")
+    (evidence_string_field attr "status")
+
+let test_to_attribution_violated_is_policy_failed () =
+  let finding = make_finding ~check_id:"execution_mode" () in
+  let v = make_verdict ~status:CT.Violated ~findings:[ finding ] () in
+  let attr = CVG.to_attribution v in
+  assert_gate_is_cdal_verdict attr;
+  (match attr.outcome with
+   | A.Policy_failed { reason } ->
+     Alcotest.(check bool)
+       "reason mentions finding" true
+       (Astring.String.is_infix ~affix:"execution_mode" reason)
+   | other ->
+     let kind =
+       match other with
+       | A.Passed -> "passed"
+       | A.Transition_blocked _ -> "transition_blocked"
+       | A.Partial_pass _ -> "partial_pass"
+       | _ -> "?"
+     in
+     Alcotest.fail ("expected Policy_failed, got " ^ kind));
+  Alcotest.(check (option int))
+    "evidence.findings_count" (Some 1)
+    (evidence_int_field attr "findings_count")
+
+let test_to_attribution_inconclusive_blocking_is_policy_failed () =
+  let gap = make_gap ~impact:CT.Blocks_verdict () in
+  let v = make_verdict ~status:CT.Inconclusive ~gaps:[ gap ] () in
+  let attr = CVG.to_attribution v in
+  Alcotest.(check bool)
+    "outcome=Policy_failed" true
+    (match attr.outcome with A.Policy_failed _ -> true | _ -> false);
+  Alcotest.(check (option int))
+    "evidence.blocking_gaps_count" (Some 1)
+    (evidence_int_field attr "blocking_gaps_count")
+
+let test_to_attribution_inconclusive_no_gaps_is_passed () =
+  let v = make_verdict ~status:CT.Inconclusive ~gaps:[] () in
+  let attr = CVG.to_attribution v in
+  Alcotest.(check bool)
+    "outcome=Passed" true
+    (match attr.outcome with A.Passed -> true | _ -> false)
+
+let test_attribution_missing_verdict () =
+  let attr = CVG.attribution_for_missing_verdict ~task_id:"T-999" in
+  assert_gate_is_cdal_verdict attr;
+  (match attr.outcome with
+   | A.Policy_failed { reason } ->
+     Alcotest.(check bool)
+       "reason mentions task_id" true
+       (Astring.String.is_infix ~affix:"T-999" reason)
+   | _ -> Alcotest.fail "expected Policy_failed");
+  Alcotest.(check (option string))
+    "evidence.task_id" (Some "T-999")
+    (evidence_string_field attr "task_id")
+
+let test_attribution_roundtrips_to_json () =
+  (* Ensure the generated attribution serializes through Attribution.to_yojson
+     without loss (any validation bugs in our evidence shape show up here). *)
+  let v = make_verdict ~status:CT.Violated ~findings:[ make_finding () ] () in
+  let attr = CVG.to_attribution v in
+  let json = A.to_yojson attr in
+  match A.of_yojson json with
+  | Ok attr' ->
+    Alcotest.(check string) "gate" attr.gate attr'.gate;
+    Alcotest.(check bool)
+      "outcome kind preserved" true
+      (match (attr.outcome, attr'.outcome) with
+       | A.Policy_failed a, A.Policy_failed b -> a.reason = b.reason
+       | _ -> false)
+  | Error msg -> Alcotest.fail ("roundtrip failed: " ^ msg)
+
+(* ================================================================ *)
 (* Test suite                                                        *)
 (* ================================================================ *)
 
@@ -231,5 +338,19 @@ let () =
       Alcotest.test_case "violated verdict rejects" `Quick test_gate_violated_verdict_rejects;
       Alcotest.test_case "different task_id not found" `Quick test_gate_different_task_id_not_found;
       Alcotest.test_case "latest verdict wins" `Quick test_gate_latest_verdict_wins;
+    ]);
+    ("attribution", [
+      Alcotest.test_case "satisfied → Passed" `Quick
+        test_to_attribution_satisfied_is_passed;
+      Alcotest.test_case "violated → Policy_failed with reason" `Quick
+        test_to_attribution_violated_is_policy_failed;
+      Alcotest.test_case "inconclusive+blocking → Policy_failed" `Quick
+        test_to_attribution_inconclusive_blocking_is_policy_failed;
+      Alcotest.test_case "inconclusive+no-gaps → Passed" `Quick
+        test_to_attribution_inconclusive_no_gaps_is_passed;
+      Alcotest.test_case "missing verdict envelope" `Quick
+        test_attribution_missing_verdict;
+      Alcotest.test_case "yojson roundtrip" `Quick
+        test_attribution_roundtrips_to_json;
     ]);
   ]


### PR DESCRIPTION
## Summary

Layer 1 첫 번째 gate 마이그레이션 — CDAL verdict gate.

`to_attribution` + `attribution_for_missing_verdict` 추가. 기존 `check_verdict` / `gate_check`는 **untouched** (backward compat).

## Mapping

| CDAL 상태 | Attribution outcome |
|-----------|---------------------|
| `Satisfied` | `Passed` |
| `Violated` | `Policy_failed { reason = findings msg }` |
| `Inconclusive` + blocking gaps | `Policy_failed { reason = gaps msg }` |
| `Inconclusive` + no blocking | `Passed` |
| (no verdict in store) | `Policy_failed` (via `attribution_for_missing_verdict`) |

## Evidence schema (all Det)

```json
{
  "run_id": "...",
  "contract_id": "...",
  "status": "satisfied|violated|inconclusive",
  "findings_count": 0,
  "gaps_count": 0,
  "blocking_gaps_count": 0
}
```

Counts only — 전체 finding/gap payload은 원본 `cdal_verdicts/*.jsonl`에 이미 있음. run_id로 조인 가능.

## Tests

6 new cases in `test_cdal_verdict_gate.ml`:
- Satisfied → Passed
- Violated → Policy_failed + findings_count 검증
- Inconclusive+blocking → Policy_failed + blocking_gaps_count
- Inconclusive+no-gaps → Passed
- Missing verdict envelope → Policy_failed + task_id in evidence
- Yojson roundtrip through `Attribution.to_yojson`/`of_yojson`

전체: 19/19 pass.

## Sum type 준수

MEMORY feedback: "합타입 > 곱타입". 각 CDAL 상태가 Attribution sum의 정확한 branch로 매핑 — Satisfied가 우연히 reason을 가지거나 Violated에 reason이 빠지는 일이 타입 레벨로 불가능.

## Non-goals

- 기존 `gate_check`/`check_verdict` API 변경 없음
- `tool_task.ml` 호출 경로 변경 없음 (별도 PR에서 Attribution 경로로 전환)
- SSE emit 실제 wire-up 없음 (evidence schema 확정이 목표)

## Depends on

- #7736 (Attribution envelope types) — MERGED

## Plan

`planning/claude-plans/abundant-skipping-sutton.md` Layer 1 gate 1/3.
다음: verification.ml (Pass/Fail/Partial 이미 sum type — 직접 매핑 가능).

## Test plan

- [x] `dune build --root . @check`
- [x] `dune exec --root . -- test/test_cdal_verdict_gate.exe` (19/19)
- [ ] CI 전체 통과 확인