### PR TITLE
feat(verification): Attribution envelope conversion (L1 gate #2/3)

### DIFF
--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -373,3 +373,61 @@ let pending_for_agent ~base_path ~agent =
            | None -> not (String.equal req.worker agent))
       | Assigned v -> String.equal v agent
       | Completed _ -> false)
+
+(* --- Attribution envelope conversion (Layer 1) ---
+   Verification is hybrid: Schema_match / Contains / Not_contains are Det
+   (rule-based), Custom is NonDet (LLM judge). Origin is derived from
+   criteria. *)
+
+let is_custom_criterion = function
+  | Custom _ -> true
+  | Schema_match _ | Contains _ | Not_contains _ -> false
+
+let origin_of_criteria (criteria : criterion list) : Attribution.origin =
+  if List.exists is_custom_criterion criteria then NonDet else Det
+
+(* Count criteria by kind — keeps evidence compact while signalling the
+   Det/NonDet mix behind the verdict. *)
+let criteria_counts (criteria : criterion list) : Yojson.Safe.t =
+  let schema = ref 0 and contains = ref 0 and not_contains = ref 0 and custom = ref 0 in
+  List.iter (function
+    | Schema_match _ -> incr schema
+    | Contains _ -> incr contains
+    | Not_contains _ -> incr not_contains
+    | Custom _ -> incr custom
+  ) criteria;
+  `Assoc [
+    ("schema_match", `Int !schema);
+    ("contains", `Int !contains);
+    ("not_contains", `Int !not_contains);
+    ("custom", `Int !custom);
+  ]
+
+let to_attribution ~origin ~evidence (v : verdict) : Attribution.t =
+  match v with
+  | Pass ->
+    Attribution.passed ~origin ~gate:"verification" ~evidence
+  | Fail reason ->
+    Attribution.policy_failed ~origin ~gate:"verification" ~evidence ~reason
+  | Partial (score, rationale) ->
+    Attribution.partial_pass ~origin ~gate:"verification" ~evidence
+      ~score ~rationale
+
+let evidence_of_request (req : verification_request) : Yojson.Safe.t =
+  `Assoc [
+    ("request_id", `String req.id);
+    ("task_id", `String req.task_id);
+    ("worker", `String req.worker);
+    ("verifier", (match req.verifier with
+                  | Some v -> `String v
+                  | None -> `Null));
+    ("criteria_counts", criteria_counts req.criteria);
+  ]
+
+let attribution_of_request (req : verification_request) : Attribution.t option =
+  match req.status with
+  | Pending | Assigned _ -> None
+  | Completed verdict ->
+    let origin = origin_of_criteria req.criteria in
+    let evidence = evidence_of_request req in
+    Some (to_attribution ~origin ~evidence verdict)

--- a/lib/verification.mli
+++ b/lib/verification.mli
@@ -94,3 +94,41 @@ val pending_for_agent :
   base_path:string ->
   agent:string ->
   verification_request list
+
+(** {1 Attribution envelope (Layer 1)}
+
+    Convert verification verdicts into the typed attribution envelope used
+    by SSE emitters. Verification is hybrid: rule-based criteria
+    ([Schema_match], [Contains], [Not_contains]) are [Det], while [Custom]
+    invokes an LLM judge and is [NonDet]. Origin is derived from the
+    criteria set. *)
+
+val origin_of_criteria : criterion list -> Attribution.origin
+(** [Det] when all criteria are rule-based, [NonDet] if any [Custom]
+    criterion is present. *)
+
+val criteria_counts : criterion list -> Yojson.Safe.t
+(** Count criteria by kind ({schema_match, contains, not_contains, custom}).
+    Used as compact evidence payload — signals the Det/NonDet mix without
+    dumping full criterion contents. *)
+
+val to_attribution :
+  origin:Attribution.origin ->
+  evidence:Yojson.Safe.t ->
+  verdict ->
+  Attribution.t
+(** Direct verdict → Attribution conversion. Caller supplies [origin]
+    (typically via [origin_of_criteria]) and [evidence]. Mapping:
+    - [Pass]                → [Attribution.Passed]
+    - [Fail reason]         → [Attribution.Policy_failed { reason }]
+    - [Partial (s, reason)] → [Attribution.Partial_pass { score = s;
+                                 rationale = reason }] *)
+
+val evidence_of_request : verification_request -> Yojson.Safe.t
+(** Standard evidence shape for a verification request:
+    [{ request_id, task_id, worker, verifier, criteria_counts }]. *)
+
+val attribution_of_request : verification_request -> Attribution.t option
+(** Returns [Some attribution] when the request carries a [Completed]
+    verdict (origin derived from criteria, standard evidence shape).
+    [None] for [Pending] / [Assigned] — there is no verdict yet. *)

--- a/test/test_verification.ml
+++ b/test/test_verification.ml
@@ -247,6 +247,69 @@ let test_pending_for_agent () =
     let pending_claude = V.pending_for_agent ~base_path ~agent:"claude" in
     Alcotest.(check int) "claude sees 0 (own work filtered)" 0 (List.length pending_claude))
 
+(* --- Attribution conversion tests --- *)
+
+module A = Masc_mcp.Attribution
+
+let test_origin_det_for_rule_based () =
+  let cs = [ V.Contains "x"; V.Not_contains "y"; V.Schema_match (`Assoc []) ] in
+  Alcotest.(check bool) "Det" true (V.origin_of_criteria cs = A.Det)
+
+let test_origin_nondet_for_custom () =
+  let cs = [ V.Contains "x"; V.Custom "is it good?" ] in
+  Alcotest.(check bool) "NonDet" true (V.origin_of_criteria cs = A.NonDet)
+
+let test_verdict_pass_to_attribution () =
+  let attr = V.to_attribution ~origin:Det ~evidence:`Null V.Pass in
+  Alcotest.(check string) "gate" "verification" attr.gate;
+  Alcotest.(check bool) "outcome=Passed" true
+    (match attr.outcome with A.Passed -> true | _ -> false)
+
+let test_verdict_fail_to_attribution () =
+  let attr =
+    V.to_attribution ~origin:Det ~evidence:`Null
+      (V.Fail "output does not match schema")
+  in
+  match attr.outcome with
+  | A.Policy_failed { reason } ->
+    Alcotest.(check string) "reason" "output does not match schema" reason
+  | _ -> Alcotest.fail "expected Policy_failed"
+
+let test_verdict_partial_to_attribution () =
+  let attr =
+    V.to_attribution ~origin:NonDet ~evidence:`Null
+      (V.Partial (0.75, "partial match"))
+  in
+  match attr.outcome with
+  | A.Partial_pass { score; rationale } ->
+    Alcotest.(check (float 0.0001)) "score" 0.75 score;
+    Alcotest.(check string) "rationale" "partial match" rationale
+  | _ -> Alcotest.fail "expected Partial_pass"
+
+let test_attribution_of_request_none_for_pending () =
+  with_temp_dir (fun base_path ->
+    match V.create_request ~base_path ~task_id:"t1" ~output:`Null
+            ~criteria:[ V.Contains "x" ] ~worker:"w" () with
+    | Error e -> Alcotest.fail ("create failed: " ^ e)
+    | Ok req ->
+      Alcotest.(check bool) "None for Pending" true
+        (V.attribution_of_request req = None))
+
+let test_attribution_of_request_derives_origin () =
+  with_temp_dir (fun base_path ->
+    (* Build a request with a Custom criterion and a Completed Pass verdict. *)
+    match V.create_request ~base_path ~task_id:"t2" ~output:`Null
+            ~criteria:[ V.Contains "hello"; V.Custom "must be kind" ]
+            ~worker:"claude" ~verifier:"codex" () with
+    | Error e -> Alcotest.fail ("create failed: " ^ e)
+    | Ok req ->
+      let completed = { req with status = V.Completed V.Pass } in
+      match V.attribution_of_request completed with
+      | Some attr ->
+        Alcotest.(check bool) "origin=NonDet (Custom present)" true
+          (attr.A.origin = A.NonDet)
+      | None -> Alcotest.fail "expected Some attribution")
+
 let () =
   Alcotest.run "Verification" [
     "criterion", [
@@ -282,5 +345,21 @@ let () =
       Alcotest.test_case "auto verify" `Quick test_auto_verify;
       Alcotest.test_case "auto verify custom fails" `Quick test_auto_verify_with_custom_fails;
       Alcotest.test_case "pending for agent" `Quick test_pending_for_agent;
+    ];
+    "attribution", [
+      Alcotest.test_case "origin=Det for rule-based criteria" `Quick
+        test_origin_det_for_rule_based;
+      Alcotest.test_case "origin=NonDet when Custom present" `Quick
+        test_origin_nondet_for_custom;
+      Alcotest.test_case "Pass → Attribution.Passed" `Quick
+        test_verdict_pass_to_attribution;
+      Alcotest.test_case "Fail → Attribution.Policy_failed" `Quick
+        test_verdict_fail_to_attribution;
+      Alcotest.test_case "Partial → Attribution.Partial_pass" `Quick
+        test_verdict_partial_to_attribution;
+      Alcotest.test_case "attribution_of_request None for Pending" `Quick
+        test_attribution_of_request_none_for_pending;
+      Alcotest.test_case "attribution_of_request derives origin" `Quick
+        test_attribution_of_request_derives_origin;
     ];
   ]


### PR DESCRIPTION
## Summary

Layer 1 두 번째 gate 마이그레이션 — verification (hybrid gate).

**Det/NonDet 경계 타입 레벨로 노출**: `origin_of_criteria` — criteria에 `Custom`(LLM 판정) 있으면 NonDet, 전부 rule-based면 Det.

## Mapping

| verdict | outcome |
|---------|---------|
| `Pass` | `Attribution.Passed` |
| `Fail reason` | `Attribution.Policy_failed { reason }` |
| `Partial (score, msg)` | `Attribution.Partial_pass { score; rationale = msg }` |

기존 sum type(`Pass | Fail | Partial`)이 이미 합타입이라 **direct mapping**. 곱타입 변환 없음.

## Evidence schema

```json
{
  "request_id": "...",
  "task_id": "...",
  "worker": "...",
  "verifier": "..." | null,
  "criteria_counts": {
    "schema_match": 1, "contains": 2, "not_contains": 0, "custom": 1
  }
}
```

Criterion 내용 자체는 omit — 원본 request store에 이미 있음. counts만으로 Det/NonDet 비율 확인 가능.

## 추가 API

```ocaml
val origin_of_criteria : criterion list -> Attribution.origin
val criteria_counts : criterion list -> Yojson.Safe.t
val to_attribution : origin:_ -> evidence:_ -> verdict -> Attribution.t
val evidence_of_request : verification_request -> Yojson.Safe.t
val attribution_of_request : verification_request -> Attribution.t option
```

`attribution_of_request` returns `None` for Pending/Assigned (verdict 없음), `Some` for Completed. 이 변환 논리 자체가 FSM 상태 일관성 체크.

## .mli updated

verification.mli에 5개 새 val 선언 추가. 외부 consumer 노출 + unused warning 회피.

## Tests (29/29 pass, 7 new)

- origin=Det for rule-based criteria (Schema+Contains+Not_contains)
- origin=NonDet when Custom present
- 3 verdict → outcome mapping cases
- attribution_of_request returns None for Pending
- attribution_of_request derives NonDet origin through full chain

## Depends on

- #7736 (Attribution types) — MERGED
- #7754 (cdal_verdict migration) — in-flight

## Plan

Layer 1 gate 2/3. 남은 것: keeper_state_machine (27 event variants, 규모 더 큼).

## Test plan

- [x] `dune build --root . @check`
- [x] `dune exec --root . -- test/test_verification.exe` (29/29)
- [ ] CI 전체 통과