### PR TITLE
feat(dashboard): mount FleetFsmMatrix + drill-through (LT-16d, stacks on #7750)

### DIFF
--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -9,7 +9,9 @@ import type { KeeperConversationDetails } from '../types'
 import { currentDashboardActor, jsonHeaders, runOperatorAction, fetchWithTimeout, DEFAULT_GET_TIMEOUT_MS } from './core'
 import {
   parseKeeperCompositeSnapshot,
+  parseFleetCompositeSnapshot,
   type KeeperCompositeSnapshot,
+  type FleetCompositeSnapshot,
 } from './schemas/keeper-composite'
 
 export type {
@@ -22,10 +24,13 @@ export type {
   KeeperCompositeDecisionStage,
   KeeperCompositeCascadeState,
   KeeperCompositeCompactionStage,
+  FleetCompositeSnapshot,
 } from './schemas/keeper-composite'
 export {
   KeeperCompositeSnapshotSchema,
+  FleetCompositeSnapshotSchema,
   parseKeeperCompositeSnapshot,
+  parseFleetCompositeSnapshot,
   CompositeSchemaDriftError,
 } from './schemas/keeper-composite'
 
@@ -579,6 +584,23 @@ export async function fetchKeeperComposite(
   )
   if (!resp.ok) throw new Error(`composite fetch failed: ${resp.status}`)
   return parseKeeperCompositeSnapshot(await resp.json())
+}
+
+/**
+ * LT-16a: fetch the fleet-wide composite snapshot in one envelope.
+ * Backend reuses the same per-snapshot shape as fetchKeeperComposite,
+ * wrapped in { generated_at, count, snapshots: [...] }.
+ */
+export async function fetchKeepersComposite(
+  opts?: { signal?: AbortSignal },
+): Promise<FleetCompositeSnapshot> {
+  const resp = await fetchWithTimeout(
+    `/api/v1/keepers/composite`,
+    { headers: jsonHeaders(), signal: opts?.signal },
+    DEFAULT_GET_TIMEOUT_MS,
+  )
+  if (!resp.ok) throw new Error(`fleet composite fetch failed: ${resp.status}`)
+  return parseFleetCompositeSnapshot(await resp.json())
 }
 
 // --- Eval Quality (RFC-MASC-005 Phase 3) ---

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -19,6 +19,7 @@
  */
 
 import {
+  array,
   boolean,
   fallback,
   nullable,
@@ -150,6 +151,33 @@ export class CompositeSchemaDriftError extends Error {
 
 export function parseKeeperCompositeSnapshot(data: unknown): KeeperCompositeSnapshot {
   const result = safeParse(KeeperCompositeSnapshotSchema, data)
+  if (!result.success) {
+    throw new CompositeSchemaDriftError(result.issues)
+  }
+  return result.output
+}
+
+// ── Fleet composite (LT-16a) ─────────────────────────────
+//
+// Backend: GET /api/v1/keepers/composite returns every registered
+// keeper in one envelope. Reuses the per-keeper snapshot shape so the
+// matrix UI (LT-16b, dashboard/src/components/fleet-fsm-matrix.ts) can
+// share render logic between single-keeper detail and fleet views.
+//
+// Each poll bumps the masc_keeper_invariant_violations_total counter
+// for any violating keeper (documented poll-triggered behaviour,
+// docs/observability/cascade-metrics.md §masc_keeper_invariant_violations_total).
+
+export const FleetCompositeSnapshotSchema = object({
+  generated_at: number(),
+  count: number(),
+  snapshots: array(KeeperCompositeSnapshotSchema),
+})
+
+export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
+
+export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
+  const result = safeParse(FleetCompositeSnapshotSchema, data)
   if (!result.success) {
     throw new CompositeSchemaDriftError(result.issues)
   }

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -2,6 +2,7 @@
 // Absorbs: agent-roster + execution + keeper-roster + FSM hub into one view with chip toggle.
 
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
@@ -14,6 +15,7 @@ import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { FsmHub } from './fsm-hub'
+import { FleetFsmMatrix } from './fleet-fsm-matrix'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
 
@@ -97,7 +99,7 @@ export function AgentsUnified() {
       ` : null}
 
       ${currentView === 'fsm'
-        ? html`<${FsmHub} />`
+        ? html`<${FleetAndFsmHubPanel} />`
         : html`
           ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
 
@@ -107,6 +109,22 @@ export function AgentsUnified() {
               : 'all'}
           />
         `}
+    </div>
+  `
+}
+
+/**
+ * LT-16d: fleet matrix above, per-keeper FsmHub below. Clicking a row
+ * in the matrix pins that keeper in the detail hub. Local state keeps
+ * the two components loosely coupled — no new store signal is
+ * introduced for this drill-through.
+ */
+function FleetAndFsmHubPanel() {
+  const [pinned, setPinned] = useState<string | null>(null)
+  return html`
+    <div class="flex flex-col gap-4">
+      <${FleetFsmMatrix} onSelectKeeper=${(name: string) => setPinned(name)} />
+      <${FsmHub} selectedName=${pinned} />
     </div>
   `
 }

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest'
 
 import {
   chipClassFor,
+  FLEET_HISTORY_LEN,
   inferKeeperNameFrom,
+  pushObservation,
+  sparkClassFor,
   tallyInvariantViolations,
+  type KeeperFleetHistory,
 } from './fleet-fsm-matrix'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 
@@ -96,5 +100,59 @@ describe('tallyInvariantViolations', () => {
       compaction_atomicity: 0,
       event_priority_monotone: 0,
     })
+  })
+})
+
+describe('sparkClassFor', () => {
+  it('extracts a single bg-* utility from the full chip class', () => {
+    expect(sparkClassFor('Running')).toMatch(/^bg-emerald-900/)
+    expect(sparkClassFor('Failing')).toMatch(/^bg-red-900/)
+  })
+
+  it('falls back to a grey shade on unknown states', () => {
+    // DEFAULT_CHIP carries `bg-zinc-800`; sparkClassFor preserves it.
+    expect(sparkClassFor('__not_a_state__')).toMatch(/^bg-zinc-(700|800)/)
+  })
+})
+
+describe('pushObservation', () => {
+  it('seeds a new keeper with one observation per axis', () => {
+    const next = pushObservation({}, [snapshot({ name: 'alpha' })])
+    const alpha = next.alpha!
+    expect(alpha.phase).toEqual(['Running'])
+    expect(alpha.turn).toEqual(['idle'])
+    expect(alpha.decision).toEqual(['undecided'])
+    expect(alpha.cascade).toEqual(['idle'])
+    expect(alpha.compaction).toEqual(['accumulating'])
+  })
+
+  it('appends new observations while preserving prior ones', () => {
+    const t1 = pushObservation({}, [snapshot({ name: 'alpha', phase: 'Running' })])
+    const t2 = pushObservation(t1, [snapshot({ name: 'alpha', phase: 'Failing' })])
+    expect(t2.alpha!.phase).toEqual(['Running', 'Failing'])
+  })
+
+  it('caps each axis series at the history window', () => {
+    let h: KeeperFleetHistory = {}
+    for (let i = 0; i < FLEET_HISTORY_LEN + 7; i++) {
+      h = pushObservation(h, [snapshot({ name: 'a' })], FLEET_HISTORY_LEN)
+    }
+    expect(h.a!.phase.length).toBe(FLEET_HISTORY_LEN)
+  })
+
+  it('drops keepers that disappear from the latest snapshot', () => {
+    const t1 = pushObservation({}, [
+      snapshot({ name: 'alpha' }),
+      snapshot({ name: 'beta' }),
+    ])
+    expect(Object.keys(t1).sort()).toEqual(['alpha', 'beta'])
+    const t2 = pushObservation(t1, [snapshot({ name: 'alpha' })])
+    expect(Object.keys(t2)).toEqual(['alpha'])
+  })
+
+  it('returns a fresh top-level object for identity-based re-renders', () => {
+    const prior = {}
+    const next = pushObservation(prior, [snapshot({ name: 'alpha' })])
+    expect(next).not.toBe(prior)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  chipClassFor,
+  inferKeeperNameFrom,
+  tallyInvariantViolations,
+} from './fleet-fsm-matrix'
+import type { KeeperCompositeSnapshot } from '../api/keeper'
+
+function snapshot(
+  overrides: Partial<KeeperCompositeSnapshot> & {
+    name?: string
+    allHold?: boolean
+    violate?: Partial<KeeperCompositeSnapshot['invariants']>
+  } = {},
+): KeeperCompositeSnapshot {
+  const name = overrides.name ?? 'alpha'
+  const allHold = overrides.allHold ?? true
+  const base: KeeperCompositeSnapshot = {
+    correlation_id: `keeper:${name}:42`,
+    run_id: `r-0-${name}`,
+    ts: 1_713_000_000,
+    phase: 'Running',
+    turn_phase: 'idle',
+    decision: { stage: 'undecided' },
+    cascade: { state: 'idle' },
+    compaction: { stage: 'accumulating' },
+    measurement: { captured: true },
+    invariants: {
+      phase_turn_alignment: allHold,
+      no_cascade_before_measurement: allHold,
+      compaction_atomicity: allHold,
+      event_priority_monotone: allHold,
+      ...overrides.violate,
+    },
+    is_live: false,
+    last_outcome: null,
+  }
+  return { ...base, ...overrides }
+}
+
+describe('chipClassFor', () => {
+  it('maps known states to a distinct tailwind class', () => {
+    expect(chipClassFor('Running')).toMatch(/emerald/)
+    expect(chipClassFor('Failing')).toMatch(/red/)
+    expect(chipClassFor('Compacting')).toMatch(/amber/)
+    expect(chipClassFor('exhausted')).toMatch(/red/)
+  })
+
+  it('falls back to the default chip for unknown states', () => {
+    const cls = chipClassFor('unknown_state_variant')
+    expect(cls).toContain('bg-zinc-800')
+  })
+})
+
+describe('inferKeeperNameFrom', () => {
+  it('extracts the keeper name from a canonical correlation_id', () => {
+    const snap = snapshot({ name: 'gen12-payroll' })
+    expect(inferKeeperNameFrom(snap)).toBe('gen12-payroll')
+  })
+
+  it('falls back to the correlation_id verbatim on non-canonical ids', () => {
+    const snap = snapshot({ correlation_id: 'not-a-keeper-id' })
+    expect(inferKeeperNameFrom(snap)).toBe('not-a-keeper-id')
+  })
+})
+
+describe('tallyInvariantViolations', () => {
+  it('returns all zeros when every keeper satisfies every invariant', () => {
+    const s = [snapshot({ name: 'a' }), snapshot({ name: 'b' })]
+    expect(tallyInvariantViolations(s)).toEqual({
+      phase_turn_alignment: 0,
+      no_cascade_before_measurement: 0,
+      compaction_atomicity: 0,
+      event_priority_monotone: 0,
+    })
+  })
+
+  it('counts one per keeper per violated invariant', () => {
+    const s = [
+      snapshot({ name: 'a', violate: { phase_turn_alignment: false } }),
+      snapshot({ name: 'b', violate: { phase_turn_alignment: false, compaction_atomicity: false } }),
+      snapshot({ name: 'c' }),
+    ]
+    const t = tallyInvariantViolations(s)
+    expect(t.phase_turn_alignment).toBe(2)
+    expect(t.compaction_atomicity).toBe(1)
+    expect(t.no_cascade_before_measurement).toBe(0)
+    expect(t.event_priority_monotone).toBe(0)
+  })
+
+  it('treats an empty fleet as clean', () => {
+    expect(tallyInvariantViolations([])).toEqual({
+      phase_turn_alignment: 0,
+      no_cascade_before_measurement: 0,
+      compaction_atomicity: 0,
+      event_priority_monotone: 0,
+    })
+  })
+})

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -10,17 +10,15 @@
  * Backend: #7723 (LT-16a) → GET /api/v1/keepers/composite.
  * Spec↔code drift: docs/observability/fsm-spec-code-drift.md (LT-15).
  *
- * Scope of this PR:
- *   - Static snapshot view (current state only).
- *   - Time-axis sparkline is deferred to LT-16c which adds a client-
- *     side observation ring so the poll history stays visible without
- *     a backend change.
- *   - Click-through to the existing FsmHub drill-down is deferred to
- *     LT-16c; exposed via the caller passing `onSelectKeeper`.
+ * LT-16c added a per-(keeper, axis) observation ring and a horizontal
+ * sparkline renderer so each cell now carries its last 30 poll ticks.
+ * The ring lives client-side; the backend remains stateless. A keeper
+ * that disappears from a fleet poll is pruned from history on the next
+ * tick (operators care about currently-registered keepers).
  */
 
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import { fetchKeepersComposite } from '../api/keeper'
 import type {
@@ -36,6 +34,14 @@ import {
 } from './fsm-hub-types'
 
 const POLL_INTERVAL_MS = 10_000
+
+/**
+ * Time-axis window (LT-16c). 30 snapshots × 10s poll = 5-minute
+ * history per (keeper, axis). Matches MAX_OBSERVATIONS = 30 in
+ * fsm-hub-types.ts so the FsmHub drill-down and this matrix keep
+ * visually compatible timelines.
+ */
+export const FLEET_HISTORY_LEN = 30
 
 // Axis order is fixed by the TLA+ joint spec
 // (KeeperCompositeLifecycle.tla): KSM → KTC → KDP → KCL → KMC.
@@ -97,6 +103,57 @@ export function chipClassFor(value: string): string {
 }
 
 /**
+ * Reduce a chip class to a single `bg-...` Tailwind utility so the
+ * sparkline bars can be 2–3 px wide without losing their state
+ * encoding. Neutral grey on unknown values.
+ */
+export function sparkClassFor(value: string): string {
+  const full = chipClassFor(value)
+  const m = /\bbg-[a-z0-9/-]+/i.exec(full)
+  return m?.[0] ?? 'bg-zinc-700'
+}
+
+/** Per-axis observation ring keyed by keeper name. */
+export type KeeperFleetHistory = Record<string, Record<LaneKey, string[]>>
+
+const AXIS_KEYS: LaneKey[] = ['phase', 'turn', 'decision', 'cascade', 'compaction']
+
+/**
+ * Fold an incoming batch of snapshots into the running history, capping
+ * each axis series at [maxLen]. Returns a fresh top-level record so
+ * Preact's identity render path notices the change. Keepers that
+ * disappear from the latest snapshot are dropped — operators care
+ * about currently-registered keepers and a restart re-populates the
+ * name on the next poll.
+ */
+export function pushObservation(
+  history: KeeperFleetHistory,
+  snapshots: KeeperCompositeSnapshot[],
+  maxLen: number = FLEET_HISTORY_LEN,
+): KeeperFleetHistory {
+  const next: KeeperFleetHistory = {}
+  for (const snap of snapshots) {
+    const name = inferKeeperNameFrom(snap)
+    const prev = history[name]
+    const perAxis: Record<LaneKey, string[]> = {
+      phase:      prev?.phase      ? prev.phase.slice()      : [],
+      turn:       prev?.turn       ? prev.turn.slice()       : [],
+      decision:   prev?.decision   ? prev.decision.slice()   : [],
+      cascade:    prev?.cascade    ? prev.cascade.slice()    : [],
+      compaction: prev?.compaction ? prev.compaction.slice() : [],
+    }
+    for (const axis of AXIS_KEYS) {
+      perAxis[axis].push(extractLaneValue(snap, axis))
+      if (perAxis[axis].length > maxLen) {
+        perAxis[axis] = perAxis[axis].slice(-maxLen)
+      }
+    }
+    next[name] = perAxis
+  }
+  return next
+}
+
+/**
  * Sum invariant violations across the fleet. Value is the number of
  * keepers where the invariant is currently failing; matches the
  * denominator the operator cares about ("how many keepers are bad?"),
@@ -133,6 +190,10 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
+  // Observation ring. Ref rather than state because pushObservation
+  // returns a fresh record per tick and we pair it with a setData call
+  // which triggers the re-render — avoids a redundant state subscription.
+  const historyRef = useRef<KeeperFleetHistory>({})
 
   useEffect(() => {
     let cancelled = false
@@ -141,6 +202,11 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       try {
         const snap = await fetcher()
         if (!cancelled) {
+          historyRef.current = pushObservation(
+            historyRef.current,
+            snap.snapshots,
+            FLEET_HISTORY_LEN,
+          )
           setData(snap)
           setError(null)
           setLoading(false)
@@ -260,13 +326,31 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                   ${AXES.map(a => {
                     const raw = extractLaneValue(snap, a.key)
                     const cls = chipClassFor(raw)
+                    const series = historyRef.current[name]?.[a.key] ?? [raw]
                     return html`
-                      <td class="px-3 py-2">
-                        <span
-                          data-cell
-                          data-axis=${a.key}
-                          class="inline-block rounded border px-2 py-0.5 ${cls}"
-                        >${displayState(raw)}</span>
+                      <td class="px-3 py-2 align-top">
+                        <div class="flex flex-col gap-1">
+                          <span
+                            data-cell
+                            data-axis=${a.key}
+                            class="inline-block self-start rounded border px-2 py-0.5 ${cls}"
+                          >${displayState(raw)}</span>
+                          <div
+                            data-spark
+                            data-axis=${a.key}
+                            class="flex h-2 overflow-hidden rounded-sm border border-zinc-800 bg-zinc-950"
+                            title=${`last ${series.length}/${FLEET_HISTORY_LEN} ticks`}
+                          >
+                            ${series.map((v, i) => html`
+                              <span
+                                key=${i}
+                                data-spark-bar
+                                class="h-full w-0.5 ${sparkClassFor(v)}"
+                                title=${displayState(v)}
+                              ></span>
+                            `)}
+                          </div>
+                        </div>
                       </td>
                     `
                   })}

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -1,0 +1,297 @@
+/**
+ * FleetFsmMatrix (LT-16b)
+ *
+ * Small-multiples matrix of all registered keepers × 5 orthogonal FSM
+ * axes (KSM/KTC/KDP/KCL/KMC). One chip per (keeper, axis) cell showing
+ * the current state. A top strip summarises the 4 joint invariant
+ * counts from KeeperCompositeLifecycle.tla.
+ *
+ * Design: docs/observability/composite-fsm-matrix-design.md (LT-12).
+ * Backend: #7723 (LT-16a) → GET /api/v1/keepers/composite.
+ * Spec↔code drift: docs/observability/fsm-spec-code-drift.md (LT-15).
+ *
+ * Scope of this PR:
+ *   - Static snapshot view (current state only).
+ *   - Time-axis sparkline is deferred to LT-16c which adds a client-
+ *     side observation ring so the poll history stays visible without
+ *     a backend change.
+ *   - Click-through to the existing FsmHub drill-down is deferred to
+ *     LT-16c; exposed via the caller passing `onSelectKeeper`.
+ */
+
+import { html } from 'htm/preact'
+import { useEffect, useMemo, useState } from 'preact/hooks'
+
+import { fetchKeepersComposite } from '../api/keeper'
+import type {
+  FleetCompositeSnapshot,
+  KeeperCompositeSnapshot,
+} from '../api/keeper'
+import {
+  displayState,
+  extractLaneValue,
+  INVARIANT_LABELS,
+  TRANSITION_FIELDS,
+  type LaneKey,
+} from './fsm-hub-types'
+
+const POLL_INTERVAL_MS = 10_000
+
+// Axis order is fixed by the TLA+ joint spec
+// (KeeperCompositeLifecycle.tla): KSM → KTC → KDP → KCL → KMC.
+// Keep it identical to TRANSITION_FIELDS so an operator scanning
+// left-to-right sees "lifecycle → turn → decision → cascade →
+// compaction" — the natural causal order of a turn.
+const AXES: Array<{ key: LaneKey; label: string; acronym: string }> = [
+  { key: 'phase',      label: 'Lifecycle',   acronym: 'KSM' },
+  { key: 'turn',       label: 'Turn',        acronym: 'KTC' },
+  { key: 'decision',   label: 'Decision',    acronym: 'KDP' },
+  { key: 'cascade',    label: 'Cascade',     acronym: 'KCL' },
+  { key: 'compaction', label: 'Compaction',  acronym: 'KMC' },
+]
+
+const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<
+  keyof typeof INVARIANT_LABELS
+>
+
+// Tailwind-only chip palette. Colour groups mirror the drift-audit
+// recommendation: stable=gray, in-motion=amber/blue, terminal=red.
+const CHIP_CLASS_BY_STATE: Record<string, string> = {
+  // KSM
+  Running:      'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  Failing:      'bg-red-900/50 text-red-200 border-red-700',
+  Overflowed:   'bg-orange-900/50 text-orange-200 border-orange-700',
+  Compacting:   'bg-amber-900/50 text-amber-200 border-amber-700',
+  HandingOff:   'bg-blue-900/50 text-blue-200 border-blue-700',
+  Draining:     'bg-sky-900/40 text-sky-200 border-sky-700',
+  Paused:       'bg-zinc-800 text-zinc-300 border-zinc-600',
+  Stopped:      'bg-zinc-800 text-zinc-400 border-zinc-700',
+  Crashed:      'bg-red-950 text-red-300 border-red-800',
+  Restarting:   'bg-violet-900/50 text-violet-200 border-violet-700',
+  Dead:         'bg-black text-red-400 border-red-900',
+  Offline:      'bg-zinc-900 text-zinc-500 border-zinc-800',
+  // KTC
+  idle:         'bg-zinc-800 text-zinc-400 border-zinc-700',
+  prompting:    'bg-blue-900/40 text-blue-200 border-blue-700',
+  executing:    'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  compacting:   'bg-amber-900/50 text-amber-200 border-amber-700',
+  finalizing:   'bg-sky-900/40 text-sky-200 border-sky-700',
+  // KDP
+  undecided:          'bg-zinc-800 text-zinc-400 border-zinc-700',
+  guard_ok:           'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  gate_rejected:      'bg-red-900/40 text-red-200 border-red-700',
+  tool_policy_selected: 'bg-indigo-900/50 text-indigo-200 border-indigo-700',
+  // KCL
+  selecting:    'bg-blue-900/40 text-blue-200 border-blue-700',
+  trying:       'bg-amber-900/50 text-amber-200 border-amber-700',
+  done:         'bg-emerald-900/40 text-emerald-200 border-emerald-700',
+  exhausted:    'bg-red-900/50 text-red-200 border-red-700',
+  // KMC
+  accumulating: 'bg-zinc-800 text-zinc-400 border-zinc-700',
+}
+
+const DEFAULT_CHIP = 'bg-zinc-800 text-zinc-300 border-zinc-700'
+
+export function chipClassFor(value: string): string {
+  return CHIP_CLASS_BY_STATE[value] ?? DEFAULT_CHIP
+}
+
+/**
+ * Sum invariant violations across the fleet. Value is the number of
+ * keepers where the invariant is currently failing; matches the
+ * denominator the operator cares about ("how many keepers are bad?"),
+ * not the counter delta from #7708 (which is a rate).
+ */
+export function tallyInvariantViolations(
+  snapshots: KeeperCompositeSnapshot[],
+): Record<keyof typeof INVARIANT_LABELS, number> {
+  const counts = {
+    phase_turn_alignment: 0,
+    no_cascade_before_measurement: 0,
+    compaction_atomicity: 0,
+    event_priority_monotone: 0,
+  }
+  for (const s of snapshots) {
+    for (const k of INVARIANT_KEYS) {
+      // invariants[k] === true means *holds*, false means violated.
+      if (!s.invariants[k]) counts[k] += 1
+    }
+  }
+  return counts
+}
+
+export interface FleetFsmMatrixProps {
+  onSelectKeeper?: (name: string) => void
+  // Injectable for tests.
+  fetcher?: () => Promise<FleetCompositeSnapshot>
+  pollIntervalMs?: number
+}
+
+export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
+  const fetcher = props.fetcher ?? fetchKeepersComposite
+  const intervalMs = props.pollIntervalMs ?? POLL_INTERVAL_MS
+  const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const tick = async () => {
+      try {
+        const snap = await fetcher()
+        if (!cancelled) {
+          setData(snap)
+          setError(null)
+          setLoading(false)
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(String(e))
+          setLoading(false)
+        }
+      } finally {
+        if (!cancelled) {
+          timer = setTimeout(tick, intervalMs)
+        }
+      }
+    }
+    tick()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [fetcher, intervalMs])
+
+  const tallies = useMemo(
+    () => (data ? tallyInvariantViolations(data.snapshots) : null),
+    [data],
+  )
+
+  if (loading) {
+    return html`
+      <div
+        data-testid="fleet-fsm-matrix"
+        class="rounded border border-zinc-800 bg-zinc-950 p-4 text-sm text-zinc-400"
+      >
+        Loading fleet composite snapshot…
+      </div>
+    `
+  }
+
+  if (error) {
+    return html`
+      <div
+        data-testid="fleet-fsm-matrix"
+        class="rounded border border-red-800 bg-red-950/40 p-4 text-sm text-red-200"
+      >
+        Fleet snapshot failed: ${error}
+      </div>
+    `
+  }
+
+  if (!data || data.count === 0) {
+    return html`
+      <div
+        data-testid="fleet-fsm-matrix"
+        class="rounded border border-zinc-800 bg-zinc-950 p-4 text-sm text-zinc-400"
+      >
+        No keepers registered.
+      </div>
+    `
+  }
+
+  return html`
+    <section
+      data-testid="fleet-fsm-matrix"
+      class="rounded border border-zinc-800 bg-zinc-950"
+    >
+      <header class="flex flex-wrap items-baseline gap-3 border-b border-zinc-800 p-3">
+        <h2 class="text-sm font-semibold text-zinc-100">Fleet composite (KSM × KTC × KDP × KCL × KMC)</h2>
+        <span class="text-xs text-zinc-500">
+          ${data.count} keepers · updated ${new Date(data.generated_at * 1000).toLocaleTimeString()}
+        </span>
+        ${tallies
+          ? html`
+              <div class="ml-auto flex flex-wrap gap-2" data-testid="invariant-strip">
+                ${INVARIANT_KEYS.map(k => {
+                  const count = tallies[k]
+                  const tone = count === 0
+                    ? 'bg-emerald-900/30 text-emerald-200 border-emerald-800'
+                    : 'bg-red-900/40 text-red-200 border-red-700'
+                  return html`
+                    <span
+                      data-invariant=${k}
+                      class="rounded border px-2 py-0.5 text-xs ${tone}"
+                      title=${`Violating keepers: ${count}`}
+                    >
+                      ${INVARIANT_LABELS[k]}: ${count}
+                    </span>
+                  `
+                })}
+              </div>
+            `
+          : null}
+      </header>
+      <div class="overflow-x-auto">
+        <table class="min-w-full text-xs">
+          <thead class="bg-zinc-900 text-zinc-300">
+            <tr>
+              <th class="px-3 py-2 text-left font-semibold">Keeper</th>
+              ${AXES.map(a => html`
+                <th class="px-3 py-2 text-left font-semibold" title=${a.label}>
+                  ${a.acronym} <span class="text-zinc-500">${a.label}</span>
+                </th>
+              `)}
+            </tr>
+          </thead>
+          <tbody>
+            ${data.snapshots.map(snap => {
+              const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
+              const rowTone = anyViolated ? 'border-l-2 border-red-500' : ''
+              const name = inferKeeperNameFrom(snap)
+              return html`
+                <tr
+                  data-keeper=${name}
+                  class="border-t border-zinc-800 hover:bg-zinc-900 ${rowTone}"
+                  onClick=${props.onSelectKeeper ? () => props.onSelectKeeper?.(name) : undefined}
+                >
+                  <td class="px-3 py-2 font-mono text-zinc-200">${name}</td>
+                  ${AXES.map(a => {
+                    const raw = extractLaneValue(snap, a.key)
+                    const cls = chipClassFor(raw)
+                    return html`
+                      <td class="px-3 py-2">
+                        <span
+                          data-cell
+                          data-axis=${a.key}
+                          class="inline-block rounded border px-2 py-0.5 ${cls}"
+                        >${displayState(raw)}</span>
+                      </td>
+                    `
+                  })}
+                </tr>
+              `
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
+/**
+ * Best-effort keeper name extraction from the snapshot correlation id.
+ * Format: `keeper:<name>:<transition_seq>` (see keeper_composite_observer
+ * .ml:stable_correlation_id). Falls back to correlation_id verbatim so
+ * the UI never renders an empty cell.
+ */
+export function inferKeeperNameFrom(snap: KeeperCompositeSnapshot): string {
+  const m = /^keeper:([^:]+):/.exec(snap.correlation_id)
+  return m?.[1] ?? snap.correlation_id
+}
+
+// Re-exported helpers let tests target the pure slices without spinning
+// up the component. TRANSITION_FIELDS is re-exported for completeness
+// so a caller doesn't need to reach into fsm-hub-types for AXES parity.
+export { TRANSITION_FIELDS }

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -142,8 +142,22 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
  *
  * Data source: `/api/v1/keepers/:name/composite` (RFC-0003 S7).
  */
-export function FsmHub() {
-  const [selected, setSelected] = useState<string | null>(null)
+export interface FsmHubProps {
+  /** Optional externally-driven selection — used by the fleet matrix
+   *  (LT-16d) to drive drill-through. When it changes, the hub
+   *  switches to the requested keeper on the next render. */
+  selectedName?: string | null
+}
+
+export function FsmHub(props: FsmHubProps = {}) {
+  const [selected, setSelected] = useState<string | null>(props.selectedName ?? null)
+  useEffect(() => {
+    if (props.selectedName !== undefined && props.selectedName !== selected) {
+      setSelected(props.selectedName)
+    }
+    // Only react to external changes; local selection stays internal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.selectedName])
   const [hub, dispatch] = useReducer(reduceHubState, initialHubState)
   const [pollTick, setPollTick] = useState(0)
   const [now, setNow] = useState(() => Date.now() / 1000)

--- a/lib/keeper/keeper_composite_observer.ml
+++ b/lib/keeper/keeper_composite_observer.ml
@@ -406,6 +406,15 @@ let observe
        | None -> None);
   }
 
+(* Fleet fold — observe every currently-registered keeper under
+   [base_path] once. Preserves registry iteration order so downstream
+   matrix rendering stays stable across successive polls.
+
+   Used by GET /api/v1/keepers/composite (LT-16a). *)
+let all_snapshots ~(base_path : string) () : snapshot list =
+  Keeper_registry.all ~base_path ()
+  |> List.map (fun entry -> observe entry)
+
 (* JSON serialisation (RFC-0003 §7) *)
 
 let invariants_to_json (inv : invariants_check) : Yojson.Safe.t =

--- a/lib/keeper/keeper_composite_observer.mli
+++ b/lib/keeper/keeper_composite_observer.mli
@@ -160,6 +160,11 @@ val observe :
   Keeper_registry.registry_entry ->
   snapshot
 
+(** Observe every registered keeper under [base_path] once. Used by
+    [GET /api/v1/keepers/composite] to render fleet-level matrices
+    (LT-16a). Preserves registry iteration order. *)
+val all_snapshots : base_path:string -> unit -> snapshot list
+
 (** Stringify [turn_phase] for JSON serialisation. Mirrors the lowercase
     edge labels used in KeeperTurnCycle.tla. *)
 val ksm_phase_to_string : ksm_phase -> string

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -1200,6 +1200,35 @@ let handle_keeper_get_subroutes state req request reqd =
       ] in
       Http.Response.json ~compress:true ~request:req
         (Yojson.Safe.to_string json) reqd
+  else if req_path = prefix ^ "composite" then
+    (* LT-16a: fleet-wide composite snapshot. Enumerates every
+       registered keeper via [Keeper_registry.all] and projects each
+       through [Keeper_composite_observer.observe]. Same purity
+       contract as the per-keeper route below.
+
+       Shape:
+         { "generated_at": 1234567890.1,
+           "count": 3,
+           "snapshots": [ <snapshot JSON>, ... ] }
+
+       Consumed by [dashboard/src/components/fleet-fsm-matrix.ts]
+       (LT-16b, upcoming). *)
+    let base_path = state.Mcp_server.room_config.base_path in
+    let snapshots =
+      Keeper_composite_observer.all_snapshots ~base_path ()
+    in
+    let json =
+      `Assoc [
+        "generated_at", `Float (Unix.gettimeofday ());
+        "count", `Int (List.length snapshots);
+        "snapshots",
+          `List
+            (List.map
+               Keeper_composite_observer.snapshot_to_json snapshots);
+      ]
+    in
+    Http.Response.json ~compress:true ~request:req
+      (Yojson.Safe.to_string json) reqd
   else if ends_with "/composite" then
     (* RFC-0003 §7: composite lifecycle snapshot derived from the
        registry entry via the [Keeper_composite_observer] pure


### PR DESCRIPTION
## Summary

Puts the 4D fleet matrix on screen where operators already look — Monitoring → Agents → **FSM** chip — and wires row-click drill-through into the existing per-keeper \`FsmHub\` that lives underneath.

Stacks on #7750 (LT-16c). Completes the user-visible half of the LT-16 train.

## What changes

- \`FsmHub\` gains an optional \`selectedName\` prop. Internal selection state remains local; the prop is purely an external driver, applied via a minimal \`useEffect\` that re-syncs when the prop transitions. Callers without a prop see zero behavioural change.
- \`agents-unified.ts\` replaces the bare \`<FsmHub />\` under the \`fsm\` view with a new \`FleetAndFsmHubPanel\` that stacks the matrix above the hub and owns the pinned keeper state via plain \`useState\`. **No new store signal** — the coupling stays local so \`FsmHub\` remains independently usable on other tabs.

## Why no store signal

The drill-through needs one bit of state ("which keeper did the operator click in the matrix?") used only by this one panel. A global signal would lock the hub into matrix-driven semantics; local state keeps both components reusable and the surface area minimal.

## What's still deferred

| PR    | Scope |
|-------|-------|
| LT-16e | Mermaid flowchart panel rendering \`KeeperCompositeLifecycle.tla\` as a state diagram next to the matrix. Covers the "순서도까지 맵핑" part of the LT-12 brief. |
| LT-16f | DOM-level tests with happy-dom once the component surface stabilises. |

## Test plan

- [x] \`pnpm typecheck\` — clean.
- [x] \`pnpm test:serial fleet-fsm-matrix\` — 14/14 (all existing pure-function tests from LT-16b/c still pass).
- [ ] CI Dashboard — pending.
- [ ] Manual: navigate to Monitoring → Agents → FSM chip, click a row in the matrix, confirm FsmHub below switches to that keeper.

## References

- #7689 (LT-12) — design doc, §3 surface list.
- #7740 (LT-16b) — base component.
- #7750 (LT-16c) — time-axis sparkline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)