### PR TITLE
feat(dashboard/api): expose FSM conditions in keeper JSON response

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -324,6 +324,12 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
             | Some entry -> Some (Keeper_state_machine.phase_to_string entry.phase)
             | None -> None
           in
+          let conditions_json =
+            match registry_entry with
+            | Some entry ->
+                Keeper_state_machine.conditions_to_json entry.conditions
+            | None -> `Null
+          in
           (* reconcile_status removed with manual_reconcile blocker system. *)
           let runtime_blocker_fields =
             runtime_blocker_fields_json config m
@@ -550,6 +556,7 @@ let keepers_dashboard_json ?(compact = false) (config : Coord.config) : Yojson.S
                 match phase with
                 | Some p -> `String p
                 | None -> `Null);
+              ("conditions", conditions_json);
             ] @ runtime_blocker_fields @ [
               ("supervisor_diagnostics", supervisor_diagnostics);
               ("agent_name", `String m.agent_name);


### PR DESCRIPTION
## 무엇

키퍼 대시보드 JSON 응답에 `conditions` 키를 `phase` 옆에 노출. 16개 FSM 술어(heartbeat_healthy, context_within_budget, context_handoff_needed, compaction_active, handoff_active, operator_paused, stop_requested, restart_budget_remaining, backoff_elapsed, guardrail_triggered, drain_complete, context_overflow, compact_retry_exhausted, launch_pending, fiber_alive, turn_healthy)를 그대로 바이패스.

## 왜

**배경**: Keeper Agent Modal 재설계 플랜(`.claude/plans/curried-moseying-whisper.md`)의 PR 1. 관찰자가 \"phase = Running인데 왜 handoff 안 하지?\" 같은 질문의 답을 얻으려면 phase와 divergent한 conditions(예: `context_handoff_needed=true && phase=Running`)가 보여야 합니다. 현재는 conditions가 registry entry에만 있고 응답 JSON엔 없음.

**변경 크기**: +7 라인, 단일 파일. `registry_entry.conditions`가 이미 메모리에 있고 `Keeper_state_machine.conditions_to_json`이 기존 public helper라 순수 wiring.

## 검증

- \`dune build\` 통과 (dashboard 서브트리 + 전체)
- \`registry_entry = None\` 케이스도 \`Null\`로 안전 처리

**수동 e2e 확인 방법**:
\`\`\`bash
curl http://localhost:PORT/api/v1/keepers | jq '.keepers[0].conditions'
# → { \"heartbeat_healthy\": true, \"context_handoff_needed\": false, ... }
\`\`\`

## 스코프 정정 (Plan 문서 대비)

플랜 Build Sequence에는 \"+ 런타임 contract에 \`Inv_counter_cause_present\` 추가\"도 포함되어 있었으나, 검토 결과 부적절:

- \`keeper_turn_cycle_contract.ml\`은 **\`KeeperTurnCycle.tla\` 전용 closed-variant label mapping** 모듈 (.mli 주석 참조)
- counter causality invariant는 #7757의 \`KeeperCounterCausality.tla\`와 짝이 되어야 하므로 **per-spec 원칙 유지** 위해 별도 contract 모듈이 맞음
- 카운터 stamping 코드(PR 7)와 함께 묶어야 dead code가 안 됨

따라서 contract 모듈은 PR 7로 이동. 이번 PR은 **conditions 직렬화만** 최소 변경.

## Out of scope

- `context_handoff_needed` divergent-only 필터 렌더 (PR 6)
- Counter causality OCaml contract (PR 7, with stamping)
- TLA+ pair for FSM divergence: `KeeperConditionsGovernPhase.tla` (PR 6a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)