### PR TITLE
fix(dashboard): align parseFleetCompositeSnapshot with parseOrThrow pattern

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -164,9 +164,5 @@ export const FleetCompositeSnapshotSchema = object({
 export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
 
 export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
-  const result = safeParse(FleetCompositeSnapshotSchema, data)
-  if (!result.success) {
-    throw new CompositeSchemaDriftError(result.issues)
-  }
-  return result.output
+  return parseOrThrow(CompositeSchemaDriftError, FleetCompositeSnapshotSchema, data)
 }


### PR DESCRIPTION
## 문제
main의 `keeper-composite.ts#167`에서 `safeParse`를 호출하지만 valibot에서 import하지 않아 TypeScript 컴파일 오류:
```
src/api/schemas/keeper-composite.ts(167,18): error TS2304: Cannot find name 'safeParse'.
```

#7723 머지 시 포함된 코드에서 drift-error 헬퍼 사용으로 전환되었으나 이 함수만 구 패턴이 남아있었습니다. 그 결과 CI Gate가 실패해 rebase된 모든 PR(#7719, #7750 등)의 merge가 차단되었습니다.

## 해결
동일 파일의 `parseKeeperCompositeSnapshot` (line 144)과 동일하게 `parseOrThrow(CompositeSchemaDriftError, Schema, data)` 패턴으로 통일.

## Test Plan
- [x] tsc --noEmit 통과 (CI에서 검증)
- [x] 기존 parseKeeperCompositeSnapshot 패턴과 일치