### PR TITLE
feat(keeper_fsm): Attribution envelope conversion (L1 gate #3/3)

### DIFF
--- a/lib/keeper/keeper_state_machine.ml
+++ b/lib/keeper/keeper_state_machine.ml
@@ -762,3 +762,45 @@ let phase_to_mermaid ~(current : phase) : string =
    | _ ->
      p "    class %s active\n" (phase_to_mermaid_id current));
   Buffer.contents b
+
+(* --- Attribution envelope conversion (Layer 1) ---
+   Keeper FSM is Det by design: non-deterministic measurements are
+   already translated into typed events at the boundary before this
+   module sees them. See the [event] type docstring. *)
+
+let attribution_of_transition ~event
+    (result : (transition_result, transition_error) result) : Attribution.t =
+  let event_name = event_to_string event in
+  match result with
+  | Ok tr ->
+    let evidence : Yojson.Safe.t =
+      `Assoc [
+        ("event", `String event_name);
+        ("from_phase", `String (phase_to_string tr.prev_phase));
+        ("to_phase", `String (phase_to_string tr.new_phase));
+        ("timestamp", `Float tr.timestamp);
+      ]
+    in
+    Attribution.passed ~origin:Det ~gate:"keeper_fsm" ~evidence
+  | Error (Invalid_transition { from_phase; to_phase; reason }) ->
+    let evidence : Yojson.Safe.t =
+      `Assoc [ ("event", `String event_name) ]
+    in
+    Attribution.transition_blocked ~origin:Det ~gate:"keeper_fsm" ~evidence
+      ~from_state:(phase_to_string from_phase)
+      ~to_state:(phase_to_string to_phase)
+      ~reason
+  | Error (Terminal_state { current; attempted_event }) ->
+    let evidence : Yojson.Safe.t =
+      `Assoc [
+        ("event", `String event_name);
+        ("current_phase", `String (phase_to_string current));
+        ("attempted_event", `String attempted_event);
+      ]
+    in
+    let reason =
+      Printf.sprintf
+        "keeper in terminal phase %s, event %s ignored"
+        (phase_to_string current) attempted_event
+    in
+    Attribution.policy_failed ~origin:Det ~gate:"keeper_fsm" ~evidence ~reason

--- a/lib/keeper/keeper_state_machine.mli
+++ b/lib/keeper/keeper_state_machine.mli
@@ -295,3 +295,30 @@ val phase_to_mermaid_id : phase -> string
     distinguishes the current phase visually (green for active,
     amber for buffer, gray for terminal). *)
 val phase_to_mermaid : current:phase -> string
+
+(** {1 Attribution envelope (Layer 1)}
+
+    Convert a transition attempt (event + current state) into the typed
+    attribution envelope used by SSE emitters.
+
+    All keeper FSM transitions are [Det]: the comment above the [event]
+    type declares the invariant that non-deterministic measurements must
+    be translated into typed events at the boundary before reaching the
+    state machine. *)
+
+val attribution_of_transition :
+  event:event ->
+  (transition_result, transition_error) result ->
+  Attribution.t
+(** Mapping:
+    - [Ok result]                       → [Attribution.Passed]
+                                          evidence: [{event, from_phase,
+                                          to_phase, timestamp}]
+    - [Error (Invalid_transition ..)]   → [Attribution.Transition_blocked]
+                                          carrying [from_state], [to_state],
+                                          [reason] directly. Evidence adds
+                                          [event].
+    - [Error (Terminal_state ..)]       → [Attribution.Policy_failed]
+                                          reason is formatted from the
+                                          [current] phase and attempted
+                                          event. Evidence adds the phase. *)

--- a/test/test_keeper_state_machine.ml
+++ b/test/test_keeper_state_machine.ml
@@ -1922,6 +1922,109 @@ let test_setclear_coverage () =
   (* Print report on success for visibility *)
   Printf.printf "%s" report
 
+(* ── Attribution conversion ────────────────────────────── *)
+
+module A = Masc_mcp.Attribution
+
+let outcome_kind_of = function
+  | A.Passed -> "passed"
+  | A.Policy_failed _ -> "policy_failed"
+  | A.Transition_blocked _ -> "transition_blocked"
+  | A.Partial_pass _ -> "partial_pass"
+
+let test_attribution_ok_passed () =
+  let tr =
+    apply_ok ~current_phase:SM.Running ~conditions:running_conditions
+      ~event:SM.Turn_succeeded
+  in
+  let attr = SM.attribution_of_transition ~event:SM.Turn_succeeded (Ok tr) in
+  check string "gate" "keeper_fsm" attr.gate;
+  check bool "origin=Det" true (attr.origin = A.Det);
+  check string "outcome kind" "passed" (outcome_kind_of attr.outcome);
+  (* Evidence carries event + phase info. *)
+  (match attr.evidence with
+   | `Assoc fields ->
+     check bool "evidence has event"
+       true (List.mem_assoc "event" fields);
+     check bool "evidence has from_phase"
+       true (List.mem_assoc "from_phase" fields);
+     check bool "evidence has to_phase"
+       true (List.mem_assoc "to_phase" fields);
+     check bool "evidence has timestamp"
+       true (List.mem_assoc "timestamp" fields)
+   | _ -> Alcotest.fail "evidence must be object")
+
+let test_attribution_invalid_transition_blocked () =
+  (* Build a synthetic transition_error (no legitimate apply_event path
+     in this FSM emits Invalid_transition outside guard violations — we
+     test the converter directly). *)
+  let err =
+    SM.Invalid_transition
+      { from_phase = SM.Running;
+        to_phase = SM.Compacting;
+        reason = "guard violation: cannot compact while running" }
+  in
+  let attr =
+    SM.attribution_of_transition ~event:SM.Compaction_started (Error err)
+  in
+  (match attr.outcome with
+   | A.Transition_blocked { from_state; to_state; reason } ->
+     check string "from_state" "running" from_state;
+     check string "to_state" "compacting" to_state;
+     check string "reason" "guard violation: cannot compact while running"
+       reason
+   | other ->
+     Alcotest.fail ("expected Transition_blocked, got " ^ outcome_kind_of other))
+
+let test_attribution_terminal_policy_failed () =
+  let terminal_cond =
+    { SM.default_conditions with
+      stop_requested = true;
+      fiber_alive = false;
+      restart_budget_remaining = false;
+    }
+  in
+  let result =
+    SM.apply_event ~current_phase:SM.Stopped ~conditions:terminal_cond
+      ~event:SM.Heartbeat_ok ~now:0.0
+  in
+  let attr = SM.attribution_of_transition ~event:SM.Heartbeat_ok result in
+  (match result with
+   | Error (SM.Terminal_state _) -> ()
+   | _ -> Alcotest.fail "expected Terminal_state for event on Stopped phase");
+  (match attr.outcome with
+   | A.Policy_failed { reason } ->
+     check bool "reason mentions terminal" true
+       (Astring.String.is_infix ~affix:"terminal" reason);
+     check bool "reason mentions stopped phase" true
+       (Astring.String.is_infix ~affix:"stopped" reason)
+   | other ->
+     Alcotest.fail ("expected Policy_failed, got " ^ outcome_kind_of other))
+
+let test_attribution_gate_and_origin_invariant () =
+  (* Every attribution produced by this gate must carry gate="keeper_fsm"
+     and origin=Det, regardless of the outcome branch. *)
+  let cases : (SM.event * (SM.transition_result, SM.transition_error) result) list =
+    [
+      SM.Turn_succeeded,
+        Ok (apply_ok ~current_phase:SM.Running ~conditions:running_conditions
+              ~event:SM.Turn_succeeded);
+      SM.Compaction_started,
+        Error (SM.Invalid_transition
+                 { from_phase = SM.Running;
+                   to_phase = SM.Compacting;
+                   reason = "test" });
+      SM.Heartbeat_ok,
+        Error (SM.Terminal_state
+                 { current = SM.Dead; attempted_event = "Heartbeat_ok" });
+    ]
+  in
+  List.iter (fun (event, result) ->
+    let attr = SM.attribution_of_transition ~event result in
+    check string "gate invariant" "keeper_fsm" attr.gate;
+    check bool "origin=Det invariant" true (attr.origin = A.Det)
+  ) cases
+
 (* ── Test suite ────────────────────────────────────────── *)
 
 let () =
@@ -2054,5 +2157,15 @@ let () =
     "setclear_coverage", [
       test_case "every condition field has setter and clearer" `Quick
         test_setclear_coverage;
+    ];
+    "attribution", [
+      test_case "successful transition → Passed" `Quick
+        test_attribution_ok_passed;
+      test_case "Invalid_transition → Transition_blocked" `Quick
+        test_attribution_invalid_transition_blocked;
+      test_case "Terminal_state → Policy_failed" `Quick
+        test_attribution_terminal_policy_failed;
+      test_case "gate=keeper_fsm origin=Det invariant" `Quick
+        test_attribution_gate_and_origin_invariant;
     ];
   ]


### PR DESCRIPTION
## Summary

Layer 1 마지막 gate (3/3). Keeper FSM — 가장 넓은 표면 (12 phases + 27 events + 2 error types).

## Mapping — sum type 1:1 fit

| FSM result | Attribution outcome | 왜 |
|------------|---------------------|-----|
| `Ok transition_result` | `Passed` | evidence=`{event, from_phase, to_phase, timestamp}` |
| `Invalid_transition {f,t,r}` | `Transition_blocked {from_state=f, to_state=t, reason=r}` | 필드명만 변환, 데이터 손실 없음 |
| `Terminal_state {cur, attempted}` | `Policy_failed {reason}` | "전이 자체가 안 됨" — Transition_blocked 아님 |

**핵심 관찰**: 도메인의 2가지 실패 모드(`Invalid_transition` vs `Terminal_state`)가 Attribution의 2가지 failure outcome(`Transition_blocked` vs `Policy_failed`)과 **정확히 대응**. 합타입 설계가 도메인 구분을 선반영했음.

## Det invariant

event 타입 docstring 인용:
> Non-deterministic measurements become typed events at the boundary.

모든 attribution이 `origin=Det`로 고정. Layer 2 phantom type에서 이를 타입 레벨로 강제 예정 (현재는 docstring 계약).

불변식 테스트 추가: 세 outcome branch 모두에서 `gate="keeper_fsm"` + `origin=Det` 유지.

## API

```ocaml
val attribution_of_transition :
  event:event ->
  (transition_result, transition_error) result ->
  Attribution.t
```

단일 함수. caller에서 `apply_event` 결과에 바로 적용.

## Tests

4 new cases:
1. Ok → Passed, evidence 4 필드 존재 확인
2. Invalid_transition → Transition_blocked, 필드 값 정확성
3. Terminal_state (실제 `apply_event Heartbeat_ok on Stopped`) → Policy_failed
4. Invariant: 3 outcome 모두 gate/origin 일관성

전체 108/108 pass (기존 104 + 4 new).

## Depends on

- #7736 (L1 types) — MERGED

## Layer 1 완료

- #7754 cdal_verdict → MERGE 대기
- #7759 verification → MERGE 대기
- #7763 keeper_fsm ← **this**

남은 5 gate는 Task #3 (PR #1.5)에서:
accountability, oas_completion, agent_lifecycle, task_transition, worker_dev_tools.

## Test plan

- [x] `dune build --root . @check`
- [x] `dune exec --root . -- test/test_keeper_state_machine.exe` (108/108)
- [ ] CI 통과