### PR TITLE
fix(data-integrity): sweep remaining 44 String.sub truncation callsites (#7690)

### DIFF
--- a/lib/activity_feed.ml
+++ b/lib/activity_feed.ml
@@ -160,8 +160,11 @@ let board_post_activities (config : Coord.config) : activity_item list =
       if id = "" then None
       else
         let preview = if title <> "" then title
-          else if String.length content > 80 then String.sub content 0 80 ^ "..."
-          else content
+          else
+            (* UTF-8-safe truncation (#7690): byte-based String.sub
+               corrupted activity-events/*.jsonl for Korean content. *)
+            String_util.utf8_safe ~max_bytes:83 ~suffix:"..." content
+            |> String_util.to_string
         in
         Some {
           id = "act-post-" ^ id;
@@ -190,8 +193,9 @@ let board_comment_activities (config : Coord.config) : activity_item list =
       if id = "" then None
       else
         let preview =
-          if String.length content > 80 then String.sub content 0 80 ^ "..."
-          else content
+          (* UTF-8-safe truncation (#7690). *)
+          String_util.utf8_safe ~max_bytes:83 ~suffix:"..." content
+          |> String_util.to_string
         in
         Some {
           id = "act-comment-" ^ id;
@@ -225,9 +229,9 @@ let mention_activities (config : Coord.config) : activity_item list =
         agent_name = source_agent;
         summary = Printf.sprintf "@%s mentioned @%s: %s"
                     source_agent target_agent
-                    (if String.length content_preview > 60
-                     then String.sub content_preview 0 60 ^ "..."
-                     else content_preview);
+                    (String_util.utf8_safe ~max_bytes:63 ~suffix:"..."
+                       content_preview
+                     |> String_util.to_string);
         detail_json = json;
         created_at;
       })

--- a/lib/anti_rationalization.ml
+++ b/lib/anti_rationalization.ml
@@ -166,13 +166,11 @@ let find_excuse_pattern (notes : string) : (string * string) option =
 let build_prompt ?(few_shot_block = "") (req : review_request) : string =
   let desc = req.task_description in
   let desc_truncated =
-    if String.length desc > 300 then String.sub desc 0 300 ^ "..."
-    else desc
+    String_util.utf8_safe ~max_bytes:303 ~suffix:"..." desc |> String_util.to_string
   in
   let notes_truncated =
-    if String.length req.completion_notes > 500
-    then String.sub req.completion_notes 0 500 ^ "..."
-    else req.completion_notes
+    String_util.utf8_safe ~max_bytes:503 ~suffix:"..." req.completion_notes
+    |> String_util.to_string
   in
   let calibration_section =
     if few_shot_block = "" then ""
@@ -299,7 +297,7 @@ let parse_verdict (text : string) : (verdict, string) result =
        Previous behavior defaulted to Approve here — this was a
        D3 + Unknown→Permissive double violation. *)
     Error (sprintf "unrecognized review format: %s"
-      (if String.length trimmed > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
+      (String_util.utf8_safe ~max_bytes:83 ~suffix:"..." trimmed |> String_util.to_string))
 
 (* ================================================================ *)
 (* Cross-model cascade selection (#3067)                             *)

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -50,8 +50,11 @@ type audit_entry = {
 }
 
 let preview ?(max_len = 200) (value : string) =
-  let len = String.length value in
-  if len <= max_len then value else String.sub value 0 max_len ^ "..."
+  (* UTF-8-safe truncation: byte-based String.sub split multi-byte chars in
+     audit/*.jsonl. See Issue #7690. Use [max_bytes:(max_len + 3)] so that
+     output length cap matches the original (prefix + suffix). *)
+  String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." value
+  |> String_util.to_string
 
 (** {1 Serialization} *)
 

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -149,7 +149,7 @@ let run_cli_agent ~agent_type ~prompt =
     in
     let preview =
       let s = String.trim output in
-      if String.length s > 200 then String.sub s 0 200 ^ "..." else s
+      String_util.utf8_safe ~max_bytes:203 ~suffix:"..." s |> String_util.to_string
     in
     debug_log (Printf.sprintf "SPAWN_DONE %s output=%s" status_s preview)
 
@@ -260,7 +260,7 @@ let extract_nickname (response_text : string) : string option =
 let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
   let response = call_model_direct_sync ~agent_type ~prompt in
   debug_log (Printf.sprintf "MODEL_RESPONSE: %s"
-    (if String.length response > 100 then String.sub response 0 100 ^ "..." else response));
+    (String_util.utf8_safe ~max_bytes:103 ~suffix:"..." response |> String_util.to_string));
   if response = "" || response = "no response" then
     Log.AutoResponder.info "MODEL returned empty response"
   else begin
@@ -276,7 +276,7 @@ let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
         Log.AutoResponder.error "Failed to join MASC (%s)" e
     | Ok join_resp -> (
         debug_log (Printf.sprintf "MASC_JOIN: %s"
-          (if String.length join_resp > 200 then String.sub join_resp 0 200 ^ "..." else join_resp));
+          (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." join_resp |> String_util.to_string));
         match extract_nickname join_resp with
         | None ->
             debug_log "MASC_JOIN_FAILED: Could not extract nickname";
@@ -293,7 +293,7 @@ let call_model_and_broadcast ~sw ~agent_type ~prompt ~mention =
              with
              | Eio.Cancel.Cancelled _ as e -> raise e
              | exn -> Log.AutoResponder.error "leave failed: %s" (Printexc.to_string exn));
-            let short_resp = if String.length response > 50 then String.sub response 0 50 ^ "..." else response in
+            let short_resp = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." response |> String_util.to_string in
             Log.AutoResponder.info "%s: %s" nickname short_resp
       )
   end

--- a/lib/autoresearch/autoresearch_metric.ml
+++ b/lib/autoresearch/autoresearch_metric.ml
@@ -20,8 +20,7 @@ let dangerous_shell_chars =
 type quote_mode = Single | Double
 
 let clip text max_len =
-  if String.length text <= max_len then text
-  else String.sub text 0 max_len ^ "..."
+  String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." text |> String_util.to_string
 
 let is_blank = function
   | ' ' | '\t' -> true

--- a/lib/autoresearch_codegen.ml
+++ b/lib/autoresearch_codegen.ml
@@ -91,9 +91,7 @@ let parse_model_code_response response =
         |> String.concat " "
         |> String.trim
         |> fun normalized ->
-        if String.length normalized > 80
-        then String.sub normalized 0 80 ^ "..."
-        else normalized
+        String_util.utf8_safe ~max_bytes:83 ~suffix:"..." normalized |> String_util.to_string
       in
       Result.error (Printf.sprintf "MODEL response is not valid JSON after lenient recovery: %s" preview)
     | `Assoc _ as json ->

--- a/lib/cascade/cascade_fsm.ml
+++ b/lib/cascade/cascade_fsm.ml
@@ -45,9 +45,10 @@ let format_exhausted_error last_err =
   let msg = match last_err with
     | Some (Llm_provider.Http_client.HttpError { code; body }) ->
       Printf.sprintf "HTTP %d: %s" code
-        (if String.length body > Llm_provider.Constants.Truncation.max_error_body_length
-         then String.sub body 0 Llm_provider.Constants.Truncation.max_error_body_length ^ "..."
-         else body)
+        (String_util.utf8_safe
+           ~max_bytes:(Llm_provider.Constants.Truncation.max_error_body_length + 3)
+           ~suffix:"..." body
+         |> String_util.to_string)
     | Some (Llm_provider.Http_client.AcceptRejected { reason }) -> reason
     | Some (Llm_provider.Http_client.NetworkError { message }) -> message
     | None -> "No providers available"

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -67,7 +67,7 @@ let first_sentence (s : string) =
   in
   match cut_at with
   | Some pos when pos <= max_len -> String.sub s 0 pos
-  | _ -> if String.length s > max_len then String.sub s 0 max_len ^ "..." else s
+  | _ -> String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." s |> String_util.to_string
 
 let tool_names_by_id (msgs : Agent_sdk.Types.message list) : (string * string) list =
   let add_tool_name acc (m : Agent_sdk.Types.message) =

--- a/lib/core/safe_ops.ml
+++ b/lib/core/safe_ops.ml
@@ -63,7 +63,7 @@ let handle f handler =
 let parse_json_safe ~context str : (Yojson.Safe.t, string) result =
   try Ok (Yojson.Safe.from_string str)
   with Yojson.Json_error msg ->
-    let preview = if String.length str > 50 then String.sub str 0 50 ^ "..." else str in
+    let preview = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." str |> String_util.to_string in
     Error (Printf.sprintf "[%s] JSON parse error: %s (input: %s)" context msg preview)
 
 (** Read file contents with error handling.

--- a/lib/core/validation.ml
+++ b/lib/core/validation.ml
@@ -31,9 +31,7 @@ let log_rejection ~validator ~input ~reason =
   Atomic.incr rejection_count;
   last_rejection_time := Time_compat.now ();
   (* Truncate input for log safety *)
-  let safe_input = if String.length input > 32
-    then String.sub input 0 32 ^ "..."
-    else input in
+  let safe_input = String_util.utf8_safe ~max_bytes:35 ~suffix:"..." input |> String_util.to_string in
   Log.Misc.warn "%s rejected input '%s': %s"
     validator safe_input reason
 

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -84,10 +84,8 @@ let truncate_path (path : string) : string =
 
 let truncate_message (msg : string) : string =
   let limit = max_message_length () in
-  if String.length msg > limit then
-    let prefix_len = limit - 3 in
-    String.sub msg 0 prefix_len ^ "..."
-  else msg
+  String_util.utf8_safe ~max_bytes:limit ~suffix:"..." msg
+  |> String_util.to_string
 
 let agent_lines now (agents : Types.agent list) =
   List.map (fun (agent : Types.agent) ->

--- a/lib/dashboard/briefing_json_helpers.ml
+++ b/lib/dashboard/briefing_json_helpers.ml
@@ -5,8 +5,7 @@ let compact_text ?(max_len = 96) raw =
     String.trim raw |> String.split_on_char '\n' |> String.concat " " |> String.trim
   in
   if normalized = "" then ""
-  else if String.length normalized <= max_len then normalized
-  else String.sub normalized 0 (max_len - 1) ^ "…"
+  else String_util.utf8_safe ~max_bytes:((max_len - 1) + 3) ~suffix:"…" normalized |> String_util.to_string
 
 let member_assoc key json =
   match json with

--- a/lib/dashboard/dashboard_execution_helpers.ml
+++ b/lib/dashboard/dashboard_execution_helpers.ml
@@ -124,8 +124,7 @@ let compact_text ?(max_len = 160) raw =
     |> String.trim
   in
   if normalized = "" then ""
-  else if String.length normalized <= max_len then normalized
-  else String.sub normalized 0 (max_len - 1) ^ "…"
+  else String_util.utf8_safe ~max_bytes:((max_len - 1) + 3) ~suffix:"…" normalized |> String_util.to_string
 
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 let string_list_of_json = Dashboard_utils.string_list_of_json

--- a/lib/dashboard_utils/dashboard_utils.ml
+++ b/lib/dashboard_utils/dashboard_utils.ml
@@ -99,8 +99,7 @@ let compact_text ?(max_len = 160) raw =
     |> String.trim
   in
   if normalized = "" then ""
-  else if String.length normalized <= max_len then normalized
-  else String.sub normalized 0 (max_len - 1) ^ "\xe2\x80\xa6"
+  else String_util.utf8_safe ~max_bytes:((max_len - 1) + 3) ~suffix:"\xe2\x80\xa6" normalized |> String_util.to_string
 
 let string_list_json values =
   `List (List.map (fun v -> `String v) values)

--- a/lib/dashboard_utils/dune
+++ b/lib/dashboard_utils/dune
@@ -5,4 +5,4 @@
  (public_name masc_mcp.dashboard_utils)
  (modules dashboard_utils)
  (wrapped false)
- (libraries masc_types base unix))
+ (libraries masc_types masc_core base unix))

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -577,8 +577,7 @@ let format_for_welcome (inst : institution) : string =
   let mission = String.trim inst.identity.mission in
   let mission_short =
     if mission = "" then "(not defined)"
-    else if String.length mission > 80 then String.sub mission 0 77 ^ "..."
-    else mission
+    else String_util.utf8_safe ~max_bytes:80 ~suffix:"..." mission |> String_util.to_string
   in
   Buffer.add_string buf ("🏛️ Mission: " ^ mission_short ^ "\n");
 

--- a/lib/keeper/keeper_exec_board.ml
+++ b/lib/keeper/keeper_exec_board.ml
@@ -69,7 +69,7 @@ let handle_keeper_board_tool
     Log.Keeper.info
       "handle_tool result: ok=%b msg=%s"
       ok
-      (if String.length msg > 200 then String.sub msg 0 200 ^ "..." else msg);
+      (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." msg |> String_util.to_string);
     tool_result_or_error result
   | "keeper_board_list" -> dispatch "masc_board_list" args
   | "keeper_board_get" -> dispatch "masc_board_get" args

--- a/lib/keeper/keeper_handoff_delta.ml
+++ b/lib/keeper/keeper_handoff_delta.ml
@@ -122,8 +122,7 @@ let build
     List.map (fun (sha, msg) ->
       { ref_type = "commit"; ref_id = sha;
         description =
-          if String.length msg <= 120 then msg
-          else String.sub msg 0 117 ^ "..." }
+          String_util.utf8_safe ~max_bytes:120 ~suffix:"..." msg |> String_util.to_string }
     ) commits
   in
   let open_loops =

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -332,8 +332,9 @@ let default_max_item_chars = 200
 
 let cap_string ~max_chars = function
   | None -> None
-  | Some s when String.length s <= max_chars -> Some s
-  | Some s -> Some (String.sub s 0 max_chars ^ "…")
+  | Some s ->
+      Some (String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" s
+            |> String_util.to_string)
 
 let cap_list ~max_items ~max_item_chars items =
   let rec take n = function
@@ -343,8 +344,7 @@ let cap_list ~max_items ~max_item_chars items =
   in
   take max_items items
   |> List.map (fun item ->
-      if String.length item <= max_item_chars then item
-      else String.sub item 0 max_item_chars ^ "…")
+      String_util.utf8_safe ~max_bytes:(max_item_chars + 3) ~suffix:"…" item |> String_util.to_string)
 
 let cap_snapshot
     ?(max_string_chars = default_max_string_chars)
@@ -586,10 +586,10 @@ let synthesize_state_from_run_result
   in
   let response_hint =
     let trimmed = String.trim response_text in
-    if String.length trimmed > 100 then
-      Some (String.sub trimmed 0 100 ^ "...")
-    else if trimmed <> "" then Some trimmed
-    else None
+    if trimmed = "" then None
+    else
+      Some (String_util.utf8_safe ~max_bytes:103 ~suffix:"..." trimmed
+            |> String_util.to_string)
   in
   let decisions =
     match response_hint with

--- a/lib/keeper/keeper_tools_oas.ml
+++ b/lib/keeper/keeper_tools_oas.ml
@@ -232,8 +232,7 @@ let make_tools
                  ignore (Tool_dispatch.run_post_hooks tr));
                 let detail =
                   let s = String.trim result in
-                  if String.length s <= sse_error_preview_max_chars then s
-                  else String.sub s 0 sse_error_preview_max_chars ^ "..."
+                  String_util.utf8_safe ~max_bytes:(sse_error_preview_max_chars + 3) ~suffix:"..." s |> String_util.to_string
                 in
                 let ts = Time_compat.now () in
                 (try Sse.broadcast

--- a/lib/keeper/social_model/keeper_social_model_types.ml
+++ b/lib/keeper/social_model/keeper_social_model_types.ml
@@ -164,13 +164,13 @@ let default_belief_summary_max_chars = 400
 let default_option_field_max_chars = 200
 
 let truncate_string ~max_chars s =
-  if String.length s <= max_chars then s
-  else String.sub s 0 max_chars ^ "…"
+  String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" s |> String_util.to_string
 
 let truncate_option ~max_chars = function
   | None -> None
-  | Some s when String.length s <= max_chars -> Some s
-  | Some s -> Some (String.sub s 0 max_chars ^ "…")
+  | Some s ->
+      Some (String_util.utf8_safe ~max_bytes:(max_chars + 3) ~suffix:"…" s
+            |> String_util.to_string)
 
 let cap_social_state
     ?(belief_max_chars = default_belief_summary_max_chars)

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -265,8 +265,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     else
       let truncated =
         let error_preview_max = 200 in
-        if String.length message > error_preview_max then String.sub message 0 error_preview_max ^ "..."
-        else message
+        String_util.utf8_safe ~max_bytes:(error_preview_max + 3) ~suffix:"..." message |> String_util.to_string
       in
       Some (Printf.sprintf "timeout=%d|duration_ms=%d|detail=%s"
               (if !timeout_hit then 1 else 0) duration_ms truncated)
@@ -414,9 +413,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
 
   (* Log result *)
   let preview =
-    if String.length message > 80
-    then String.sub message 0 80 ^ "..."
-    else message
+    String_util.utf8_safe ~max_bytes:83 ~suffix:"..." message |> String_util.to_string
   in
   let preview = String.map (function '\n' -> ' ' | c -> c) preview in
   Log.Mcp.info "%s -> %s" name preview;

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -239,8 +239,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     Tool_catalog.is_on_surface Tool_catalog.System_internal name
   in
   let preview ?(max_len = 240) text =
-    if String.length text <= max_len then text
-    else String.sub text 0 max_len ^ "..."
+    String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." text |> String_util.to_string
   in
   let argument_keys_json =
     match arguments with

--- a/lib/mcp_server_eio_resource.ml
+++ b/lib/mcp_server_eio_resource.ml
@@ -58,7 +58,7 @@ let handle_read_resource_eio state id params =
               match Yojson.Safe.from_string line with
               | json -> Some json
               | exception Yojson.Json_error msg ->
-                let preview = if String.length line > 50 then String.sub line 0 50 ^ "..." else line in
+                let preview = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." line |> String_util.to_string in
                 Log.legacy_traceln ~level:Log.Warn ~module_name:"MCP"
                   (Printf.sprintf
                      "[WARN] Failed to parse event JSON: %s (line: %s)" msg

--- a/lib/meta_cognition_types.ml
+++ b/lib/meta_cognition_types.ml
@@ -153,8 +153,7 @@ let preview ?(max_len = 120) text =
     |> List.filter (fun chunk -> chunk <> "")
     |> String.concat " "
   in
-  if String.length text <= max_len then text
-  else String.sub text 0 (max 0 (max_len - 1)) ^ "…"
+  String_util.utf8_safe ~max_bytes:((max 0 (max_len - 1)) + 3) ~suffix:"…" text |> String_util.to_string
 
 let contains_ci haystack needle =
   String_util.contains_substring

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -170,11 +170,11 @@ let read_metrics_file file : task_metric list =
         match task_metric_of_yojson json with
         | Ok m -> Some m
         | Error e ->
-          let preview = if String.length line > 50 then String.sub line 0 50 ^ "..." else line in
+          let preview = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." line |> String_util.to_string in
           Log.Metrics.error "Failed to parse metric: %s (line: %s)" e preview;
           None
       with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        let preview = if String.length line > 50 then String.sub line 0 50 ^ "..." else line in
+        let preview = String_util.utf8_safe ~max_bytes:53 ~suffix:"..." line |> String_util.to_string in
         Log.Metrics.error "JSON parse error: %s (line: %s)"
           (Printexc.to_string exn) preview;
         None

--- a/lib/oas_worker_named.ml
+++ b/lib/oas_worker_named.ml
@@ -402,7 +402,7 @@ let run_named
       let err_msg = match last_err with
         | Some (Llm_provider.Http_client.HttpError { code; body }) ->
           Printf.sprintf "HTTP %d: %s" code
-            (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
+            (String_util.utf8_safe ~max_bytes:203 ~suffix:"..." body |> String_util.to_string)
         | Some (Llm_provider.Http_client.AcceptRejected { reason }) -> reason
         | Some (Llm_provider.Http_client.NetworkError { message }) -> message
         | None -> "no providers available"

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -306,7 +306,9 @@ let truncate_text ~max_chars text =
   let len = String.length text in
   if len <= max_chars then text
   else if max_chars <= 1 then String.sub text 0 (max 0 max_chars)
-  else String.sub text 0 (max_chars - 1) ^ "…"
+  else
+    String_util.utf8_safe ~max_bytes:max_chars ~suffix:"…" text
+    |> String_util.to_string
 
 let latest_preview_of_messages (messages : Agent_sdk.Types.message list) =
   messages

--- a/lib/tool_autoresearch_cycle.ml
+++ b/lib/tool_autoresearch_cycle.ml
@@ -7,8 +7,7 @@ open Tool_autoresearch_broadcast
 let autoresearch_lesson_agent_name = "autoresearch-reviewer"
 
 let clip text max_len =
-  if String.length text <= max_len then text
-  else String.sub text 0 max_len ^ "..."
+  String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." text |> String_util.to_string
 
 let resolve_loop_id args =
   match get_string_opt args "loop_id" with

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -343,8 +343,7 @@ let handle_code_search ctx args =
         in
         (false, Printf.sprintf "❌ %s\nrg output: %s" hint
            (if trimmed_out = "" then "(empty)"
-            else if String.length trimmed_out > 300 then String.sub trimmed_out 0 300 ^ "..."
-            else trimmed_out))
+            else String_util.utf8_safe ~max_bytes:303 ~suffix:"..." trimmed_out |> String_util.to_string))
     | status, output ->
         let code = match status with
           | Unix.WEXITED n -> Printf.sprintf "exit %d" n

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -47,10 +47,7 @@ let first_sentence text =
   loop 0 |> String.trim
 
 let truncate ~max_len text =
-  if String.length text <= max_len then
-    text
-  else
-    String.sub text 0 (max 0 (max_len - 1)) ^ "…"
+  String_util.utf8_safe ~max_bytes:((max 0 (max_len - 1)) + 3) ~suffix:"…" text |> String_util.to_string
 
 let help_doc_refs name =
   if

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -133,8 +133,10 @@ let entry_to_json ?(result_max_len = default_result_truncation) (e : tool_call_e
       (match e.result with
        | None -> `Null
        | Some r ->
-           if result_max_len > 0 && String.length r > result_max_len then
-             `String (String.sub r 0 result_max_len ^ "...")
+           if result_max_len > 0 then
+             `String (String_util.utf8_safe
+                        ~max_bytes:(result_max_len + 3) ~suffix:"..." r
+                      |> String_util.to_string)
            else `String r));
     ("duration_ms", `Int e.duration_ms);
     ("error", Json_util.string_opt_to_json e.error);
@@ -145,8 +147,10 @@ let default_thinking_truncation = 2000
 
 let thinking_entry_to_json ?(content_max_len = default_thinking_truncation) (e : thinking_entry) : Yojson.Safe.t =
   let content =
-    if content_max_len > 0 && String.length e.content > content_max_len then
-      String.sub e.content 0 content_max_len ^ "..."
+    if content_max_len > 0 then
+      String_util.utf8_safe ~max_bytes:(content_max_len + 3) ~suffix:"..."
+        e.content
+      |> String_util.to_string
     else e.content
   in
   `Assoc [

--- a/lib/verifier_core.ml
+++ b/lib/verifier_core.ml
@@ -101,7 +101,9 @@ let parse_verdict (text : string) : (verdict, string) result =
     Error "empty verifier output"
   else
     Error (sprintf "unrecognized verdict format: %s"
-      (if len > 80 then String.sub trimmed 0 80 ^ "..." else trimmed))
+      (let _ = len in
+       String_util.utf8_safe ~max_bytes:83 ~suffix:"..." trimmed
+       |> String_util.to_string))
 
 (* ================================================================ *)
 (* Structured Verdict: Tool Schema + JSON Parsing (ADR D3)          *)

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -51,13 +51,11 @@ FAIL: <reason> - if the action is wrong or harmful
 
 One line only.|}
     req.goal
-    (if String.length req.context_summary > 300
-     then String.sub req.context_summary 0 300 ^ "..."
-     else req.context_summary)
+    (String_util.utf8_safe ~max_bytes:303 ~suffix:"..." req.context_summary
+     |> String_util.to_string)
     req.action_description
-    (if String.length req.action_result > 500
-     then String.sub req.action_result 0 500 ^ "..."
-     else req.action_result)
+    (String_util.utf8_safe ~max_bytes:503 ~suffix:"..." req.action_result
+     |> String_util.to_string)
 
 (* ================================================================ *)
 (* Core: verify                                                     *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -637,8 +637,7 @@ let sanitize_command_for_log cmd =
   redact false [] parts
 
 let truncate_for_log ?(max_len = 240) s =
-  if String.length s <= max_len then s
-  else String.sub s 0 max_len ^ "..."
+  String_util.utf8_safe ~max_bytes:(max_len + 3) ~suffix:"..." s |> String_util.to_string
 
 (* --- gh CLI validation for keeper_shell op=gh / PR workflow helpers --- *)
 


### PR DESCRIPTION
Follows #7745 (must merge first).

## Summary

- Completes the `String.sub X 0 N ^ "..."` sweep identified during Issue #7690 investigation.
- Agent sweep found **3061 UTF-8-broken lines** across 44 jsonl files on a live `.masc/` instance; patterns traced to 44+ callsites reimplementing byte-based truncation.
- This PR migrates **all 44 remaining sites** (PR #7745 handled 4: `derive_post_title`, `delete_goal`, + the shared helper) to `String_util.utf8_safe` + `to_string`.

## Stacked on #7745

Branched from `fix/data-integrity-7690`, so `String_util.utf8_safe` helper is available here. Must merge #7745 first; this PR should rebase cleanly onto main afterward.

## Files changed (35)

| Area | Files | Sites |
|------|-------|-------|
| **JSONL writers** (cause of observed corruption) | `activity_feed.ml`, `audit_log.ml`, `trajectory.ml` | 6 |
| **compact_text duplicates** | `dashboard_utils/`, `dashboard/briefing_json_helpers`, `dashboard/dashboard_execution_helpers` | 3 |
| **LLM prompt contexts** | `verifier_oas`, `verifier_core`, `anti_rationalization` | 5 |
| **Error / response previews** | `mcp_server_eio_*`, `auto_responder`, `cascade_fsm`, `metrics_store_eio`, `worker_dev_tools`, `core/safe_ops`, `core/validation`, `mcp_server_eio_resource` | 13 |
| **Keeper state / memory** | `keeper_memory_policy`, `keeper_handoff_delta`, `keeper_tools_oas`, `keeper_exec_board`, `social_model/keeper_social_model_types` | 7 |
| **Misc preview** | `dashboard`, `autoresearch_codegen`, `autoresearch/autoresearch_metric`, `tool_autoresearch_cycle`, `tool_code`, `tool_help_registry`, `context_compact_oas`, `institution_eio`, `meta_cognition_types`, `oas_worker_named`, `server/server_dashboard_http_keeper_api` | 10 |
| **Dune** | `lib/dashboard_utils/dune` | +1 library dep (`masc_core`) |

## Migration pattern

```ocaml
(* Before *)
if String.length x > 80 then String.sub x 0 80 ^ "..." else x

(* After *)
String_util.utf8_safe ~max_bytes:83 ~suffix:"..." x |> String_util.to_string
```

- `max_bytes = cut + String.length suffix` preserves the original output byte cap.
- Unicode ellipsis (`…`, `"\xe2\x80\xa6"` — 3 bytes UTF-8) and ASCII `"..."` (3 bytes) both supported via the `suffix` parameter.
- Untouched case is slightly more lenient than the original (3 extra bytes without truncation), which is strictly safer for all affected callers (log/preview/prompt-context paths).

## Build / test

- [x] `dune build` clean after all 44 migrations
- [x] `test_string_util` 13/13 (the helper)
- [x] `test_board_core_payload` 5/5
- [x] `test_goal_store` 4/4
- [x] Regression: `test_audit_log` 1/1, `test_board_dispatch` 26/26, `test_trajectory` 30/30, `test_autoresearch_codegen` 5/5, `test_dashboard` 16/16, `test_goal_janitor` 4/4

## Not in scope

- Prometheus counter wiring via `Truncated { dropped_bytes; _ }` branch. Deferred for a future PR that establishes a single observability standard for truncation metrics.
- Test coverage expansion for the 44 migrated sites — these are preview/log paths whose behavior is exercised by their existing callers. The Korean-safety invariant is covered at the helper level.
- `.masc/` runtime data repair: already completed separately (42 files filter-repaired, `verdict.json` surgically fixed, archived).

Refs: #7690, #7745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
