### PR TITLE
feat(dashboard/api): migrate gate-status endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/gate.ts
+++ b/dashboard/src/api/gate.ts
@@ -7,78 +7,17 @@ import {
   asStringArray,
   isRecord,
 } from '../components/common/normalize'
+import {
+  parseGateStatusData,
+  safeParseChannelInfo,
+  type BindingInfo,
+  type ChannelInfo,
+  type GateEventInfo,
+  type GateStatusData,
+} from './schemas/gate-status'
 
-export interface ChannelInfo {
-  channel: string
-  message_count: number
-  success_count: number
-  error_count: number
-  duplicate_count: number
-  validation_error_count: number
-  keeper_error_count: number
-  dispatch_unavailable_count: number
-  internal_error_count: number
-  last_activity: string
-  last_success: string
-  last_error_at: string
-  last_keeper: string
-  last_room_id: string
-  last_error: string
-  last_error_kind: string
-  last_outcome: string
-  avg_duration_ms: number
-  max_duration_ms: number
-  slow_count: number
-  slow_rate_pct: number
-  success_rate_pct: number
-  room_count: number
-  health: string
-}
-
-export interface BindingInfo {
-  channel: string
-  room_id: string
-  keeper: string
-  message_count: number
-  success_count: number
-  error_count: number
-  duplicate_count: number
-  last_activity: string
-  last_success: string
-  last_error_at: string
-  last_error: string
-  last_error_kind: string
-  last_outcome: string
-  avg_duration_ms: number
-  max_duration_ms: number
-  success_rate_pct: number
-  health: string
-}
-
-export interface GateEventInfo {
-  seq: number
-  timestamp: string
-  channel: string
-  room_id: string
-  keeper: string
-  outcome: string
-  error_kind: string
-  error: string
-  duration_ms: number
-}
-
-export interface GateStatusData {
-  channels: ChannelInfo[]
-  bindings: BindingInfo[]
-  recent_events: GateEventInfo[]
-  total_messages: number
-  total_success: number
-  total_errors: number
-  total_duplicates: number
-  success_rate_pct: number
-  dedup_table_size: number
-  uptime_seconds: number
-}
+export type { BindingInfo, ChannelInfo, GateEventInfo, GateStatusData }
+export { GateStatusSchemaDriftError } from './schemas/gate-status'
 
 export interface GateKeeperInfo {
   name: string
@@ -196,105 +135,23 @@ export interface GateConnectorsData {
   generated_at: string
 }
 
-function decodeChannelInfo(raw: unknown): ChannelInfo | null {
-  if (!isRecord(raw)) return null
-  const channel = asString(raw.channel)
-  if (!channel) return null
-  return {
-    channel,
-    message_count: asNumber(raw.message_count, 0),
-    success_count: asNumber(raw.success_count, 0),
-    error_count: asNumber(raw.error_count, 0),
-    duplicate_count: asNumber(raw.duplicate_count, 0),
-    validation_error_count: asNumber(raw.validation_error_count, 0),
-    keeper_error_count: asNumber(raw.keeper_error_count, 0),
-    dispatch_unavailable_count: asNumber(raw.dispatch_unavailable_count, 0),
-    internal_error_count: asNumber(raw.internal_error_count, 0),
-    last_activity: asString(raw.last_activity, ''),
-    last_success: asString(raw.last_success, ''),
-    last_error_at: asString(raw.last_error_at, ''),
-    last_keeper: asString(raw.last_keeper, ''),
-    last_room_id: asString(raw.last_room_id, ''),
-    last_error: asString(raw.last_error, ''),
-    last_error_kind: asString(raw.last_error_kind, ''),
-    last_outcome: asString(raw.last_outcome, ''),
-    avg_duration_ms: asNumber(raw.avg_duration_ms, 0),
-    max_duration_ms: asNumber(raw.max_duration_ms, 0),
-    slow_count: asNumber(raw.slow_count, 0),
-    slow_rate_pct: asNumber(raw.slow_rate_pct, 0),
-    success_rate_pct: asNumber(raw.success_rate_pct, 0),
-    room_count: asNumber(raw.room_count, 0),
-    health: asString(raw.health, 'idle'),
-  }
-}
-
-function decodeBindingInfo(raw: unknown): BindingInfo | null {
-  if (!isRecord(raw)) return null
-  const channel = asString(raw.channel)
-  const roomId = asString(raw.room_id)
-  const keeper = asString(raw.keeper)
-  if (!channel || !roomId || !keeper) return null
-  return {
-    channel,
-    room_id: roomId,
-    keeper,
-    message_count: asNumber(raw.message_count, 0),
-    success_count: asNumber(raw.success_count, 0),
-    error_count: asNumber(raw.error_count, 0),
-    duplicate_count: asNumber(raw.duplicate_count, 0),
-    last_activity: asString(raw.last_activity, ''),
-    last_success: asString(raw.last_success, ''),
-    last_error_at: asString(raw.last_error_at, ''),
-    last_error: asString(raw.last_error, ''),
-    last_error_kind: asString(raw.last_error_kind, ''),
-    last_outcome: asString(raw.last_outcome, ''),
-    avg_duration_ms: asNumber(raw.avg_duration_ms, 0),
-    max_duration_ms: asNumber(raw.max_duration_ms, 0),
-    success_rate_pct: asNumber(raw.success_rate_pct, 0),
-    health: asString(raw.health, 'idle'),
-  }
-}
-
-function decodeGateEventInfo(raw: unknown): GateEventInfo | null {
-  if (!isRecord(raw)) return null
-  const channel = asString(raw.channel)
-  const roomId = asString(raw.room_id)
-  const keeper = asString(raw.keeper)
-  const timestamp = asString(raw.timestamp)
-  if (!channel || !roomId || !keeper || !timestamp) return null
-  return {
-    seq: asNumber(raw.seq, 0),
-    timestamp,
-    channel,
-    room_id: roomId,
-    keeper,
-    outcome: asString(raw.outcome, ''),
-    error_kind: asString(raw.error_kind, ''),
-    error: asString(raw.error, ''),
-    duration_ms: asNumber(raw.duration_ms, 0),
-  }
-}
-
+// Thin null-returning wrappers preserving the pre-migration contract.
+// `src/api/gate.test.ts` still asserts `null` on non-object payloads,
+// and `decodeGateConnectorInfo` (the sibling connector decoder that
+// this PR intentionally does not touch) consumes single-channel
+// payloads via `decodeChannelInfo`. New call sites should use the
+// throw-on-drift parsers directly.
 export function decodeGateStatusData(raw: unknown): GateStatusData | null {
-  if (!isRecord(raw)) return null
-  return {
-    channels: asRecordArray(raw.channels)
-      .map(decodeChannelInfo)
-      .filter((item): item is ChannelInfo => item !== null),
-    bindings: asRecordArray(raw.bindings)
-      .map(decodeBindingInfo)
-      .filter((item): item is BindingInfo => item !== null),
-    recent_events: asRecordArray(raw.recent_events)
-      .map(decodeGateEventInfo)
-      .filter((item): item is GateEventInfo => item !== null),
-    total_messages: asNumber(raw.total_messages, 0),
-    total_success: asNumber(raw.total_success, 0),
-    total_errors: asNumber(raw.total_errors, 0),
-    total_duplicates: asNumber(raw.total_duplicates, 0),
-    success_rate_pct: asNumber(raw.success_rate_pct, 0),
-    dedup_table_size: asNumber(raw.dedup_table_size, 0),
-    uptime_seconds: asNumber(raw.uptime_seconds, 0),
+  try {
+    return parseGateStatusData(raw)
+  } catch {
+    return null
   }
+}
+
+function decodeChannelInfo(raw: unknown): ChannelInfo | null {
+  const result = safeParseChannelInfo(raw)
+  return result.success ? result.output : null
 }
 
 function decodeGateKeeperInfo(raw: unknown): GateKeeperInfo | null {
@@ -486,10 +343,8 @@ export function decodeGateConnectorsData(raw: unknown): GateConnectorsData | nul
 }
 
 export async function fetchGateStatus(signal?: AbortSignal): Promise<GateStatusData> {
-  const raw = await get<Record<string, unknown>>('/api/v1/gate/status', { signal })
-  const decoded = decodeGateStatusData(raw)
-  if (!decoded) throw new Error('invalid gate status payload')
-  return decoded
+  const raw = await get<unknown>('/api/v1/gate/status', { signal })
+  return parseGateStatusData(raw)
 }
 
 export async function fetchGateConnectors(signal?: AbortSignal): Promise<GateConnectorsData> {

--- a/dashboard/src/api/schemas/gate-status.test.ts
+++ b/dashboard/src/api/schemas/gate-status.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GateStatusSchemaDriftError,
+  parseGateStatusData,
+} from './gate-status'
+
+function validChannel(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    channel: 'slack',
+    message_count: 42,
+    ...overrides,
+  }
+}
+
+function validBinding(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    channel: 'slack',
+    room_id: 'C123',
+    keeper: 'greeter',
+    ...overrides,
+  }
+}
+
+function validEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    timestamp: '2026-04-17T00:00:00Z',
+    channel: 'slack',
+    room_id: 'C123',
+    keeper: 'greeter',
+    ...overrides,
+  }
+}
+
+describe('parseGateStatusData', () => {
+  it('accepts an empty response with all counts defaulting to 0', () => {
+    const out = parseGateStatusData({})
+    expect(out.channels).toHaveLength(0)
+    expect(out.bindings).toHaveLength(0)
+    expect(out.recent_events).toHaveLength(0)
+    expect(out.total_messages).toBe(0)
+    expect(out.uptime_seconds).toBe(0)
+  })
+
+  it('applies fallbacks on sparse channel entries', () => {
+    const out = parseGateStatusData({
+      channels: [validChannel()],
+    })
+    expect(out.channels).toHaveLength(1)
+    expect(out.channels[0]!.channel).toBe('slack')
+    expect(out.channels[0]!.success_count).toBe(0)
+    expect(out.channels[0]!.health).toBe('idle')
+    expect(out.channels[0]!.last_activity).toBe('')
+  })
+
+  it('drops channel rows missing the required channel field (lenient-per-entry)', () => {
+    const out = parseGateStatusData({
+      channels: [validChannel(), { message_count: 5 }],
+    })
+    expect(out.channels).toHaveLength(1)
+  })
+
+  it('drops binding rows missing any of channel/room_id/keeper', () => {
+    const out = parseGateStatusData({
+      bindings: [
+        validBinding(),
+        { channel: 'slack', room_id: 'C1' }, // missing keeper
+        { channel: 'slack', keeper: 'k1' }, // missing room_id
+      ],
+    })
+    expect(out.bindings).toHaveLength(1)
+  })
+
+  it('drops event rows missing timestamp', () => {
+    const out = parseGateStatusData({
+      recent_events: [
+        validEvent(),
+        { channel: 'slack', room_id: 'C1', keeper: 'k1' }, // missing timestamp
+      ],
+    })
+    expect(out.recent_events).toHaveLength(1)
+  })
+
+  it('parses a fully-populated response', () => {
+    const out = parseGateStatusData({
+      channels: [validChannel({ message_count: 100, success_count: 95, health: 'healthy' })],
+      bindings: [validBinding({ message_count: 50, success_count: 48 })],
+      recent_events: [validEvent({ seq: 1, outcome: 'success', duration_ms: 120 })],
+      total_messages: 100,
+      total_success: 95,
+      total_errors: 5,
+      total_duplicates: 0,
+      success_rate_pct: 95,
+      dedup_table_size: 0,
+      uptime_seconds: 3600,
+    })
+    expect(out.total_messages).toBe(100)
+    expect(out.channels[0]!.success_count).toBe(95)
+    expect(out.bindings[0]!.message_count).toBe(50)
+    expect(out.recent_events[0]!.outcome).toBe('success')
+  })
+
+  it('tolerates non-array entries fields by returning empty lists', () => {
+    const out = parseGateStatusData({ channels: null, bindings: 'oops', recent_events: {} })
+    expect(out.channels).toHaveLength(0)
+    expect(out.bindings).toHaveLength(0)
+    expect(out.recent_events).toHaveLength(0)
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseGateStatusData(null)).toThrow(GateStatusSchemaDriftError)
+    expect(() => parseGateStatusData('oops')).toThrow(GateStatusSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/gate-status.ts
+++ b/dashboard/src/api/schemas/gate-status.ts
@@ -1,0 +1,169 @@
+// Gate status schema — schema-at-boundary for
+// `GET /api/v1/gate/status`.
+//
+// Every number field carries `fallback(number(), 0)` and every string
+// field carries `fallback(string(), '')` (or `'idle'` for the health
+// flag) to match the prior hand-rolled `asString(raw.X, '')` /
+// `asNumber(raw.X, 0)` decoder semantics exactly.
+//
+// Per-entry leniency is preserved: a channel/binding/event row with
+// a missing required field drops silently from the array, while the
+// outer payload must still be a record (else throws).
+
+import {
+  fallback,
+  number,
+  object,
+  optional,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+const ChannelInfoRawSchema = object({
+  channel: string(),
+  message_count: fallback(number(), 0),
+  success_count: fallback(number(), 0),
+  error_count: fallback(number(), 0),
+  duplicate_count: fallback(number(), 0),
+  validation_error_count: fallback(number(), 0),
+  keeper_error_count: fallback(number(), 0),
+  dispatch_unavailable_count: fallback(number(), 0),
+  internal_error_count: fallback(number(), 0),
+  last_activity: fallback(string(), ''),
+  last_success: fallback(string(), ''),
+  last_error_at: fallback(string(), ''),
+  last_keeper: fallback(string(), ''),
+  last_room_id: fallback(string(), ''),
+  last_error: fallback(string(), ''),
+  last_error_kind: fallback(string(), ''),
+  last_outcome: fallback(string(), ''),
+  avg_duration_ms: fallback(number(), 0),
+  max_duration_ms: fallback(number(), 0),
+  slow_count: fallback(number(), 0),
+  slow_rate_pct: fallback(number(), 0),
+  success_rate_pct: fallback(number(), 0),
+  room_count: fallback(number(), 0),
+  health: fallback(string(), 'idle'),
+})
+
+export type ChannelInfo = InferOutput<typeof ChannelInfoRawSchema>
+
+const BindingInfoRawSchema = object({
+  channel: string(),
+  room_id: string(),
+  keeper: string(),
+  message_count: fallback(number(), 0),
+  success_count: fallback(number(), 0),
+  error_count: fallback(number(), 0),
+  duplicate_count: fallback(number(), 0),
+  last_activity: fallback(string(), ''),
+  last_success: fallback(string(), ''),
+  last_error_at: fallback(string(), ''),
+  last_error: fallback(string(), ''),
+  last_error_kind: fallback(string(), ''),
+  last_outcome: fallback(string(), ''),
+  avg_duration_ms: fallback(number(), 0),
+  max_duration_ms: fallback(number(), 0),
+  success_rate_pct: fallback(number(), 0),
+  health: fallback(string(), 'idle'),
+})
+
+export type BindingInfo = InferOutput<typeof BindingInfoRawSchema>
+
+const GateEventInfoRawSchema = object({
+  seq: fallback(number(), 0),
+  timestamp: string(),
+  channel: string(),
+  room_id: string(),
+  keeper: string(),
+  outcome: fallback(string(), ''),
+  error_kind: fallback(string(), ''),
+  error: fallback(string(), ''),
+  duration_ms: fallback(number(), 0),
+})
+
+export type GateEventInfo = InferOutput<typeof GateEventInfoRawSchema>
+
+const GateStatusOuterSchema = object({
+  channels: optional(unknown()),
+  bindings: optional(unknown()),
+  recent_events: optional(unknown()),
+  total_messages: fallback(number(), 0),
+  total_success: fallback(number(), 0),
+  total_errors: fallback(number(), 0),
+  total_duplicates: fallback(number(), 0),
+  success_rate_pct: fallback(number(), 0),
+  dedup_table_size: fallback(number(), 0),
+  uptime_seconds: fallback(number(), 0),
+})
+
+export interface GateStatusData {
+  channels: ChannelInfo[]
+  bindings: BindingInfo[]
+  recent_events: GateEventInfo[]
+  total_messages: number
+  total_success: number
+  total_errors: number
+  total_duplicates: number
+  success_rate_pct: number
+  dedup_table_size: number
+  uptime_seconds: number
+}
+
+export class GateStatusSchemaDriftError extends Error {
+  readonly issues: readonly BaseIssue<unknown>[]
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    const summary = issues
+      .map(issue => {
+        const path = issue.path?.map(p => String(p.key)).join('.') ?? '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .join('; ')
+    super(`gate-status schema drift: ${summary}`)
+    this.name = GateStatusSchemaDriftError.name
+    this.issues = issues
+  }
+}
+
+function parseArrayOfEntries<TSchema extends typeof ChannelInfoRawSchema
+  | typeof BindingInfoRawSchema
+  | typeof GateEventInfoRawSchema>(
+  schema: TSchema,
+  raw: unknown,
+): InferOutput<TSchema>[] {
+  if (!Array.isArray(raw)) return []
+  const result: InferOutput<TSchema>[] = []
+  for (const item of raw) {
+    const parsed = safeParse(schema, item, { abortEarly: true })
+    if (parsed.success) result.push(parsed.output as InferOutput<TSchema>)
+  }
+  return result
+}
+
+// Exposed for `api/gate.ts`'s sibling connector decoder, which still
+// consumes a single channel payload through a null-returning wrapper.
+export function safeParseChannelInfo(data: unknown) {
+  return safeParse(ChannelInfoRawSchema, data, { abortEarly: true })
+}
+
+export function parseGateStatusData(data: unknown): GateStatusData {
+  const outer = safeParse(GateStatusOuterSchema, data, { abortEarly: true })
+  if (!outer.success) {
+    throw new GateStatusSchemaDriftError(outer.issues)
+  }
+  return {
+    channels: parseArrayOfEntries(ChannelInfoRawSchema, outer.output.channels),
+    bindings: parseArrayOfEntries(BindingInfoRawSchema, outer.output.bindings),
+    recent_events: parseArrayOfEntries(GateEventInfoRawSchema, outer.output.recent_events),
+    total_messages: outer.output.total_messages,
+    total_success: outer.output.total_success,
+    total_errors: outer.output.total_errors,
+    total_duplicates: outer.output.total_duplicates,
+    success_rate_pct: outer.output.success_rate_pct,
+    dedup_table_size: outer.output.dedup_table_size,
+    uptime_seconds: outer.output.uptime_seconds,
+  }
+}


### PR DESCRIPTION
## Summary

First endpoint extracted from \`api/gate.ts\` — \`GET /api/v1/gate/status\` now goes through a valibot schema at the boundary. Replaces 4 interfaces + 4 hand-rolled decoder helpers (~120 LOC of \`asString(raw.X, '')\` / \`asNumber(raw.X, 0)\` defaulting) with a declarative schema that preserves every fallback value exactly.

- Adds \`src/api/schemas/gate-status.ts\` — 4 schemas, 3 exported types + \`GateStatusData\` interface (the outer shape), \`GateStatusSchemaDriftError\`, \`parseGateStatusData\`, \`safeParseChannelInfo\` (exposed for the sibling connector decoder).
- Strict outer + lenient per-entry pattern: one malformed channel/binding/event row drops silently, non-object payload throws.
- Keeps null-returning \`decodeGateStatusData\` / \`decodeChannelInfo\` wrappers as thin adapters because \`gate.test.ts\` and the untouched \`decodeGateConnectorInfo\` still depend on that contract.
- 10 shape tests covering every preserved semantic.

## Scope

\`fetchGateStatus\` only. Sibling endpoints (\`fetchGateConnectors\`, \`fetchGateKeepers\`) stay on their hand-rolled decoders in this PR — they'll migrate in a follow-up once this pattern lands clean.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/gate-status.test.ts src/api/gate.test.ts src/components/connector-status.test.ts\` — 52/52 pass (10 new + 34 existing gate + 8 existing connector-status)
- [ ] CI green

Part of #7441. Follow-ups: (a) migrate \`GateStatusSchemaDriftError\` to shared \`SchemaDriftError\` base now that #7732 has landed; (b) migrate \`fetchGateConnectors\` / \`fetchGateKeepers\` similarly.