### PR TITLE
feat(dashboard): composite FSM flowchart panel (LT-16e, stacks on #7761)

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -166,3 +166,30 @@ export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSc
 export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
   return parseOrThrow(CompositeSchemaDriftError, FleetCompositeSnapshotSchema, data)
 }
+
+// ── Fleet composite (LT-16a) ─────────────────────────────
+//
+// Backend: GET /api/v1/keepers/composite returns every registered
+// keeper in one envelope. Reuses the per-keeper snapshot shape so the
+// matrix UI (LT-16b, dashboard/src/components/fleet-fsm-matrix.ts) can
+// share render logic between single-keeper detail and fleet views.
+//
+// Each poll bumps the masc_keeper_invariant_violations_total counter
+// for any violating keeper (documented poll-triggered behaviour,
+// docs/observability/cascade-metrics.md §masc_keeper_invariant_violations_total).
+
+export const FleetCompositeSnapshotSchema = object({
+  generated_at: number(),
+  count: number(),
+  snapshots: array(KeeperCompositeSnapshotSchema),
+})
+
+export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
+
+export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
+  const result = safeParse(FleetCompositeSnapshotSchema, data)
+  if (!result.success) {
+    throw new CompositeSchemaDriftError(result.issues)
+  }
+  return result.output
+}

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -166,30 +166,3 @@ export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSc
 export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
   return parseOrThrow(CompositeSchemaDriftError, FleetCompositeSnapshotSchema, data)
 }
-
-// ── Fleet composite (LT-16a) ─────────────────────────────
-//
-// Backend: GET /api/v1/keepers/composite returns every registered
-// keeper in one envelope. Reuses the per-keeper snapshot shape so the
-// matrix UI (LT-16b, dashboard/src/components/fleet-fsm-matrix.ts) can
-// share render logic between single-keeper detail and fleet views.
-//
-// Each poll bumps the masc_keeper_invariant_violations_total counter
-// for any violating keeper (documented poll-triggered behaviour,
-// docs/observability/cascade-metrics.md §masc_keeper_invariant_violations_total).
-
-export const FleetCompositeSnapshotSchema = object({
-  generated_at: number(),
-  count: number(),
-  snapshots: array(KeeperCompositeSnapshotSchema),
-})
-
-export type FleetCompositeSnapshot = InferOutput<typeof FleetCompositeSnapshotSchema>
-
-export function parseFleetCompositeSnapshot(data: unknown): FleetCompositeSnapshot {
-  const result = safeParse(FleetCompositeSnapshotSchema, data)
-  if (!result.success) {
-    throw new CompositeSchemaDriftError(result.issues)
-  }
-  return result.output
-}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -2,6 +2,7 @@
 // Absorbs: agent-roster + execution + keeper-roster + FSM hub into one view with chip toggle.
 
 import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
 import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
@@ -14,6 +15,7 @@ import { namespaceTruth } from '../namespace-truth-store'
 import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { FsmHub } from './fsm-hub'
+import { FleetFsmMatrix } from './fleet-fsm-matrix'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
 
@@ -97,7 +99,7 @@ export function AgentsUnified() {
       ` : null}
 
       ${currentView === 'fsm'
-        ? html`<${FsmHub} />`
+        ? html`<${FleetAndFsmHubPanel} />`
         : html`
           ${currentView !== 'agents' ? html`<${KeeperSpawnPanel} />` : null}
 
@@ -107,6 +109,22 @@ export function AgentsUnified() {
               : 'all'}
           />
         `}
+    </div>
+  `
+}
+
+/**
+ * LT-16d: fleet matrix above, per-keeper FsmHub below. Clicking a row
+ * in the matrix pins that keeper in the detail hub. Local state keeps
+ * the two components loosely coupled — no new store signal is
+ * introduced for this drill-through.
+ */
+function FleetAndFsmHubPanel() {
+  const [pinned, setPinned] = useState<string | null>(null)
+  return html`
+    <div class="flex flex-col gap-4">
+      <${FleetFsmMatrix} onSelectKeeper=${(name: string) => setPinned(name)} />
+      <${FsmHub} selectedName=${pinned} />
     </div>
   `
 }

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -16,6 +16,7 @@ import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { FsmHub } from './fsm-hub'
 import { FleetFsmMatrix } from './fleet-fsm-matrix'
+import { CompositeFsmFlowchart } from './composite-fsm-flowchart'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
 
@@ -114,16 +115,17 @@ export function AgentsUnified() {
 }
 
 /**
- * LT-16d: fleet matrix above, per-keeper FsmHub below. Clicking a row
- * in the matrix pins that keeper in the detail hub. Local state keeps
- * the two components loosely coupled — no new store signal is
- * introduced for this drill-through.
+ * LT-16d+e: matrix (live fleet state) → spec flowchart (structural
+ * reference) → FsmHub (per-keeper drill-down). Wide-to-narrow scan.
+ * Row-click in the matrix pins the keeper in the hub below. Local
+ * state keeps coupling minimal — no new store signal.
  */
 function FleetAndFsmHubPanel() {
   const [pinned, setPinned] = useState<string | null>(null)
   return html`
     <div class="flex flex-col gap-4">
       <${FleetFsmMatrix} onSelectKeeper=${(name: string) => setPinned(name)} />
+      <${CompositeFsmFlowchart} />
       <${FsmHub} selectedName=${pinned} />
     </div>
   `

--- a/dashboard/src/components/composite-fsm-flowchart.test.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildCompositeFsmMermaid } from './composite-fsm-flowchart'
+
+describe('buildCompositeFsmMermaid', () => {
+  const src = buildCompositeFsmMermaid()
+
+  it('is a flowchart with a top-to-bottom direction', () => {
+    expect(src.startsWith('flowchart TB')).toBe(true)
+  })
+
+  it('declares a subgraph per axis', () => {
+    for (const axis of ['KSM', 'KTC', 'KDP', 'KCL', 'KMC']) {
+      // `subgraph KSM ["..."]` etc.
+      expect(src).toMatch(new RegExp(`subgraph ${axis} `))
+    }
+  })
+
+  it('prefixes every state node to avoid collisions between axes', () => {
+    // KTC and KCL both declare an "idle" state; the diagram must show
+    // them as distinct nodes.
+    expect(src).toContain('ktc_idle["idle"]')
+    expect(src).toContain('kcl_idle["idle"]')
+  })
+
+  it('covers the full KSM state surface (12 phases)', () => {
+    const ksm = [
+      'Offline', 'Running', 'Failing', 'Overflowed', 'Compacting',
+      'HandingOff', 'Draining', 'Paused', 'Stopped', 'Crashed',
+      'Restarting', 'Dead',
+    ]
+    for (const label of ksm) {
+      expect(src).toContain(`"${label}"`)
+    }
+  })
+
+  it('does not emit duplicate top-level node ids (no un-prefixed collisions)', () => {
+    // Heuristic: every declared `id["label"]` anchored on word chars
+    // should have at most one bracket declaration when the id is
+    // prefixed. We extract ids and check that each appears exactly
+    // once in an initial declaration.
+    const declRe = /(\b[a-z0-9_]+)\[["][^"]+["]\]/g
+    const seen = new Map<string, number>()
+    for (const m of src.matchAll(declRe)) {
+      const id = m[1]!
+      seen.set(id, (seen.get(id) ?? 0) + 1)
+    }
+    const duplicates = [...seen.entries()].filter(([, n]) => n > 1)
+    expect(duplicates).toEqual([])
+  })
+
+  it('tags at least one terminal state', () => {
+    expect(src).toMatch(/class ksm_stopped.*terminal/)
+  })
+
+  it('tags KDP gate_rejected as an error state', () => {
+    expect(src).toMatch(/class .*kdp_gate_rejected.*error/)
+  })
+})

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -1,0 +1,147 @@
+/**
+ * CompositeFsmFlowchart (LT-16e)
+ *
+ * Static Mermaid rendering of the 5 orthogonal keeper FSM axes from
+ * KeeperCompositeLifecycle.tla, side by side. Each subgraph is one
+ * region (Harel parallel region); the subgraphs do not share edges
+ * because the axes are orthogonal by design — the invariants that
+ * tie them together live in the matrix's top strip (LT-16b) and in
+ * the masc_keeper_invariant_violations_total counter (LT-13).
+ *
+ * Design: docs/observability/composite-fsm-matrix-design.md (LT-12)
+ * covers the "순서도까지 맵핑" ("map the flowcharts") portion of the
+ * user's brief — this panel is the flowchart companion to the matrix.
+ *
+ * The transitions below are hand-extracted from:
+ *   specs/keeper-state-machine/KeeperStateMachine.tla
+ *   specs/keeper-state-machine/KeeperTurnCycle.tla
+ *   specs/keeper-state-machine/KeeperDecisionPipeline.tla
+ *   specs/keeper-state-machine/KeeperCascadeLifecycle.tla
+ *   specs/keeper-state-machine/KeeperCompactionLifecycle.tla
+ *
+ * Only the common-case edges are rendered — a full enumeration of
+ * every guarded transition would be unreadable and is what the TLA+
+ * model-checker is for. Operators read this diagram to build a
+ * mental model, not to exhaustively validate the state machine.
+ */
+
+import { html } from 'htm/preact'
+
+import { MermaidGraph } from './common/mermaid-graph'
+
+// Every node ID carries an axis prefix so Mermaid's global-id rule
+// does not collapse e.g. two "idle" nodes (KTC and KCL both have one).
+// Labels displayed to the operator stay bare for readability.
+const MERMAID_COMPOSITE: string = `flowchart TB
+  %% ─ KSM (Lifecycle, 12 states) ──────────────────────────
+  subgraph KSM ["Lifecycle · KSM"]
+    direction LR
+    ksm_offline["Offline"] --> ksm_running["Running"]
+    ksm_running --> ksm_failing["Failing"]
+    ksm_failing --> ksm_running
+    ksm_running --> ksm_overflowed["Overflowed"]
+    ksm_overflowed --> ksm_compacting["Compacting"]
+    ksm_compacting --> ksm_running
+    ksm_running --> ksm_handingoff["HandingOff"]
+    ksm_handingoff --> ksm_running
+    ksm_running --> ksm_paused["Paused"]
+    ksm_paused --> ksm_running
+    ksm_running --> ksm_draining["Draining"]
+    ksm_draining --> ksm_stopped["Stopped"]
+    ksm_stopped --> ksm_dead["Dead"]
+    ksm_running --> ksm_crashed["Crashed"]
+    ksm_crashed --> ksm_restarting["Restarting"]
+    ksm_restarting --> ksm_running
+    ksm_restarting --> ksm_dead
+  end
+
+  %% ─ KTC (Turn cycle, 5 states) ──────────────────────────
+  subgraph KTC ["Turn · KTC"]
+    direction LR
+    ktc_idle["idle"] --> ktc_prompting["prompting"]
+    ktc_prompting --> ktc_executing["executing"]
+    ktc_executing --> ktc_compacting["compacting"]
+    ktc_executing --> ktc_finalizing["finalizing"]
+    ktc_compacting --> ktc_finalizing
+    ktc_finalizing --> ktc_idle
+  end
+
+  %% ─ KDP (Decision pipeline, 4 states) ───────────────────
+  subgraph KDP ["Decision · KDP"]
+    direction LR
+    kdp_undecided["undecided"] --> kdp_guard_ok["guard_ok"]
+    kdp_undecided --> kdp_gate_rejected["gate_rejected"]
+    kdp_guard_ok --> kdp_tool_policy["tool_policy_selected"]
+  end
+
+  %% ─ KCL (Cascade lifecycle, 5 states) ───────────────────
+  subgraph KCL ["Cascade · KCL"]
+    direction LR
+    kcl_idle["idle"] --> kcl_selecting["selecting"]
+    kcl_selecting --> kcl_trying["trying"]
+    kcl_trying --> kcl_selecting
+    kcl_trying --> kcl_done["done"]
+    kcl_trying --> kcl_exhausted["exhausted"]
+  end
+
+  %% ─ KMC (Memory compaction, 3 states) ───────────────────
+  subgraph KMC ["Compaction · KMC"]
+    direction LR
+    kmc_accumulating["accumulating"] --> kmc_compacting["compacting"]
+    kmc_compacting --> kmc_done["done"]
+    kmc_done --> kmc_accumulating
+  end
+
+  classDef terminal fill:#1f0f0f,stroke:#7f1d1d,color:#fca5a5
+  classDef stable   fill:#0f1a0f,stroke:#166534,color:#86efac
+  classDef motion   fill:#1a1305,stroke:#a16207,color:#fde68a
+  classDef error    fill:#1e0a0a,stroke:#b91c1c,color:#fca5a5
+
+  class ksm_stopped,ksm_dead terminal
+  class ksm_running,ksm_paused,ktc_idle,kcl_idle,kmc_accumulating stable
+  class ksm_compacting,ksm_handingoff,ksm_overflowed,ksm_draining,ksm_restarting,ktc_prompting,ktc_executing,ktc_compacting,ktc_finalizing,kcl_selecting,kcl_trying,kmc_compacting motion
+  class ksm_failing,ksm_crashed,kdp_gate_rejected,kcl_exhausted error
+`
+
+/**
+ * Return the Mermaid source for the composite FSM panel. Exposed as a
+ * pure function so a test can regex-check invariants (every axis
+ * present, every axis has a subgraph header, no bare-id collisions)
+ * without mounting a renderer.
+ */
+export function buildCompositeFsmMermaid(): string {
+  return MERMAID_COMPOSITE
+}
+
+export interface CompositeFsmFlowchartProps {
+  class?: string
+}
+
+export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
+  return html`
+    <section
+      data-testid="composite-fsm-flowchart"
+      class="rounded border border-zinc-800 bg-zinc-950 ${props.class ?? ''}"
+    >
+      <header class="border-b border-zinc-800 p-3">
+        <h2 class="text-sm font-semibold text-zinc-100">
+          Composite FSM flowchart (TLA+ spec)
+        </h2>
+        <p class="mt-1 text-xs text-zinc-400">
+          5 orthogonal axes rendered as Harel parallel regions. Source:
+          <code class="text-zinc-300">specs/keeper-state-machine/*.tla</code>.
+          Transitions here are the common-case edges; the TLA+
+          model-checker owns the exhaustive enumeration.
+        </p>
+      </header>
+      <div class="p-3">
+        <${MermaidGraph}
+          source=${MERMAID_COMPOSITE}
+          prefix="composite-fsm"
+          minHeightClass="min-h-[320px]"
+          fallbackText="Flowchart render failed — see browser console."
+        />
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest'
 
 import {
   chipClassFor,
+  FLEET_HISTORY_LEN,
   inferKeeperNameFrom,
+  pushObservation,
+  sparkClassFor,
   tallyInvariantViolations,
+  type KeeperFleetHistory,
 } from './fleet-fsm-matrix'
 import type { KeeperCompositeSnapshot } from '../api/keeper'
 
@@ -96,5 +100,59 @@ describe('tallyInvariantViolations', () => {
       compaction_atomicity: 0,
       event_priority_monotone: 0,
     })
+  })
+})
+
+describe('sparkClassFor', () => {
+  it('extracts a single bg-* utility from the full chip class', () => {
+    expect(sparkClassFor('Running')).toMatch(/^bg-emerald-900/)
+    expect(sparkClassFor('Failing')).toMatch(/^bg-red-900/)
+  })
+
+  it('falls back to a grey shade on unknown states', () => {
+    // DEFAULT_CHIP carries `bg-zinc-800`; sparkClassFor preserves it.
+    expect(sparkClassFor('__not_a_state__')).toMatch(/^bg-zinc-(700|800)/)
+  })
+})
+
+describe('pushObservation', () => {
+  it('seeds a new keeper with one observation per axis', () => {
+    const next = pushObservation({}, [snapshot({ name: 'alpha' })])
+    const alpha = next.alpha!
+    expect(alpha.phase).toEqual(['Running'])
+    expect(alpha.turn).toEqual(['idle'])
+    expect(alpha.decision).toEqual(['undecided'])
+    expect(alpha.cascade).toEqual(['idle'])
+    expect(alpha.compaction).toEqual(['accumulating'])
+  })
+
+  it('appends new observations while preserving prior ones', () => {
+    const t1 = pushObservation({}, [snapshot({ name: 'alpha', phase: 'Running' })])
+    const t2 = pushObservation(t1, [snapshot({ name: 'alpha', phase: 'Failing' })])
+    expect(t2.alpha!.phase).toEqual(['Running', 'Failing'])
+  })
+
+  it('caps each axis series at the history window', () => {
+    let h: KeeperFleetHistory = {}
+    for (let i = 0; i < FLEET_HISTORY_LEN + 7; i++) {
+      h = pushObservation(h, [snapshot({ name: 'a' })], FLEET_HISTORY_LEN)
+    }
+    expect(h.a!.phase.length).toBe(FLEET_HISTORY_LEN)
+  })
+
+  it('drops keepers that disappear from the latest snapshot', () => {
+    const t1 = pushObservation({}, [
+      snapshot({ name: 'alpha' }),
+      snapshot({ name: 'beta' }),
+    ])
+    expect(Object.keys(t1).sort()).toEqual(['alpha', 'beta'])
+    const t2 = pushObservation(t1, [snapshot({ name: 'alpha' })])
+    expect(Object.keys(t2)).toEqual(['alpha'])
+  })
+
+  it('returns a fresh top-level object for identity-based re-renders', () => {
+    const prior = {}
+    const next = pushObservation(prior, [snapshot({ name: 'alpha' })])
+    expect(next).not.toBe(prior)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -10,17 +10,15 @@
  * Backend: #7723 (LT-16a) → GET /api/v1/keepers/composite.
  * Spec↔code drift: docs/observability/fsm-spec-code-drift.md (LT-15).
  *
- * Scope of this PR:
- *   - Static snapshot view (current state only).
- *   - Time-axis sparkline is deferred to LT-16c which adds a client-
- *     side observation ring so the poll history stays visible without
- *     a backend change.
- *   - Click-through to the existing FsmHub drill-down is deferred to
- *     LT-16c; exposed via the caller passing `onSelectKeeper`.
+ * LT-16c added a per-(keeper, axis) observation ring and a horizontal
+ * sparkline renderer so each cell now carries its last 30 poll ticks.
+ * The ring lives client-side; the backend remains stateless. A keeper
+ * that disappears from a fleet poll is pruned from history on the next
+ * tick (operators care about currently-registered keepers).
  */
 
 import { html } from 'htm/preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 
 import { fetchKeepersComposite } from '../api/keeper'
 import type {
@@ -36,6 +34,14 @@ import {
 } from './fsm-hub-types'
 
 const POLL_INTERVAL_MS = 10_000
+
+/**
+ * Time-axis window (LT-16c). 30 snapshots × 10s poll = 5-minute
+ * history per (keeper, axis). Matches MAX_OBSERVATIONS = 30 in
+ * fsm-hub-types.ts so the FsmHub drill-down and this matrix keep
+ * visually compatible timelines.
+ */
+export const FLEET_HISTORY_LEN = 30
 
 // Axis order is fixed by the TLA+ joint spec
 // (KeeperCompositeLifecycle.tla): KSM → KTC → KDP → KCL → KMC.
@@ -97,6 +103,57 @@ export function chipClassFor(value: string): string {
 }
 
 /**
+ * Reduce a chip class to a single `bg-...` Tailwind utility so the
+ * sparkline bars can be 2–3 px wide without losing their state
+ * encoding. Neutral grey on unknown values.
+ */
+export function sparkClassFor(value: string): string {
+  const full = chipClassFor(value)
+  const m = /\bbg-[a-z0-9/-]+/i.exec(full)
+  return m?.[0] ?? 'bg-zinc-700'
+}
+
+/** Per-axis observation ring keyed by keeper name. */
+export type KeeperFleetHistory = Record<string, Record<LaneKey, string[]>>
+
+const AXIS_KEYS: LaneKey[] = ['phase', 'turn', 'decision', 'cascade', 'compaction']
+
+/**
+ * Fold an incoming batch of snapshots into the running history, capping
+ * each axis series at [maxLen]. Returns a fresh top-level record so
+ * Preact's identity render path notices the change. Keepers that
+ * disappear from the latest snapshot are dropped — operators care
+ * about currently-registered keepers and a restart re-populates the
+ * name on the next poll.
+ */
+export function pushObservation(
+  history: KeeperFleetHistory,
+  snapshots: KeeperCompositeSnapshot[],
+  maxLen: number = FLEET_HISTORY_LEN,
+): KeeperFleetHistory {
+  const next: KeeperFleetHistory = {}
+  for (const snap of snapshots) {
+    const name = inferKeeperNameFrom(snap)
+    const prev = history[name]
+    const perAxis: Record<LaneKey, string[]> = {
+      phase:      prev?.phase      ? prev.phase.slice()      : [],
+      turn:       prev?.turn       ? prev.turn.slice()       : [],
+      decision:   prev?.decision   ? prev.decision.slice()   : [],
+      cascade:    prev?.cascade    ? prev.cascade.slice()    : [],
+      compaction: prev?.compaction ? prev.compaction.slice() : [],
+    }
+    for (const axis of AXIS_KEYS) {
+      perAxis[axis].push(extractLaneValue(snap, axis))
+      if (perAxis[axis].length > maxLen) {
+        perAxis[axis] = perAxis[axis].slice(-maxLen)
+      }
+    }
+    next[name] = perAxis
+  }
+  return next
+}
+
+/**
  * Sum invariant violations across the fleet. Value is the number of
  * keepers where the invariant is currently failing; matches the
  * denominator the operator cares about ("how many keepers are bad?"),
@@ -133,6 +190,10 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
+  // Observation ring. Ref rather than state because pushObservation
+  // returns a fresh record per tick and we pair it with a setData call
+  // which triggers the re-render — avoids a redundant state subscription.
+  const historyRef = useRef<KeeperFleetHistory>({})
 
   useEffect(() => {
     let cancelled = false
@@ -141,6 +202,11 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
       try {
         const snap = await fetcher()
         if (!cancelled) {
+          historyRef.current = pushObservation(
+            historyRef.current,
+            snap.snapshots,
+            FLEET_HISTORY_LEN,
+          )
           setData(snap)
           setError(null)
           setLoading(false)
@@ -260,13 +326,31 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
                   ${AXES.map(a => {
                     const raw = extractLaneValue(snap, a.key)
                     const cls = chipClassFor(raw)
+                    const series = historyRef.current[name]?.[a.key] ?? [raw]
                     return html`
-                      <td class="px-3 py-2">
-                        <span
-                          data-cell
-                          data-axis=${a.key}
-                          class="inline-block rounded border px-2 py-0.5 ${cls}"
-                        >${displayState(raw)}</span>
+                      <td class="px-3 py-2 align-top">
+                        <div class="flex flex-col gap-1">
+                          <span
+                            data-cell
+                            data-axis=${a.key}
+                            class="inline-block self-start rounded border px-2 py-0.5 ${cls}"
+                          >${displayState(raw)}</span>
+                          <div
+                            data-spark
+                            data-axis=${a.key}
+                            class="flex h-2 overflow-hidden rounded-sm border border-zinc-800 bg-zinc-950"
+                            title=${`last ${series.length}/${FLEET_HISTORY_LEN} ticks`}
+                          >
+                            ${series.map((v, i) => html`
+                              <span
+                                key=${i}
+                                data-spark-bar
+                                class="h-full w-0.5 ${sparkClassFor(v)}"
+                                title=${displayState(v)}
+                              ></span>
+                            `)}
+                          </div>
+                        </div>
                       </td>
                     `
                   })}

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -142,8 +142,22 @@ function reduceHubState(state: HubState, action: HubAction): HubState {
  *
  * Data source: `/api/v1/keepers/:name/composite` (RFC-0003 S7).
  */
-export function FsmHub() {
-  const [selected, setSelected] = useState<string | null>(null)
+export interface FsmHubProps {
+  /** Optional externally-driven selection — used by the fleet matrix
+   *  (LT-16d) to drive drill-through. When it changes, the hub
+   *  switches to the requested keeper on the next render. */
+  selectedName?: string | null
+}
+
+export function FsmHub(props: FsmHubProps = {}) {
+  const [selected, setSelected] = useState<string | null>(props.selectedName ?? null)
+  useEffect(() => {
+    if (props.selectedName !== undefined && props.selectedName !== selected) {
+      setSelected(props.selectedName)
+    }
+    // Only react to external changes; local selection stays internal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.selectedName])
   const [hub, dispatch] = useReducer(reduceHubState, initialHubState)
   const [pollTick, setPollTick] = useState(0)
   const [now, setNow] = useState(() => Date.now() / 1000)


### PR DESCRIPTION
## Summary

Covers the "**순서도까지 맵핑**" part of the LT-12 brief: a static Mermaid rendering of the 5 orthogonal keeper FSM axes side by side as Harel parallel regions.

Stacks on #7761 (LT-16d mount). Wide-to-narrow scan on one screen: live fleet matrix → spec flowchart → per-keeper FsmHub.

## Why static, not live-driven

The matrix already carries live state. This flowchart is the **structural reference** — the shape of the state machine itself, extracted from the TLA+ specs. When operators wonder "can a keeper go from Failing to Compacting directly?" they look at the flowchart, not the matrix. Static content means zero runtime cost and no backend coupling.

## Design choices

- **Axis-prefixed node ids** (\`ksm_idle\`, \`ktc_idle\`, \`kcl_idle\`) so Mermaid's global-id rule never collapses same-name states across axes. KTC and KCL both declare an \"idle\"; without prefixes Mermaid would render a single node spanning both subgraphs.
- **Common-case edges only.** A full enumeration of every guarded transition is unreadable and is what the TLA+ model-checker is for.
- **Four semantic \`classDef\`s** (terminal / stable / motion / error) applied per node — operators can read the diagram at colour level before reading text.

## Tests

- 7/7 vitest on \`buildCompositeFsmMermaid\`:
  - flowchart TB direction
  - all 5 subgraphs present (\`KSM\`, \`KTC\`, \`KDP\`, \`KCL\`, \`KMC\`)
  - prefix-collision check (ktc_idle, kcl_idle both present)
  - full KSM state coverage (12 phases)
  - terminal and error \`classDef\` tagging
  - no duplicate un-prefixed node-id declarations
- 14/14 (LT-16c) still pass.
- \`pnpm typecheck\` clean.

## What the LT-16 train now delivers on one screen (Monitoring → Agents → FSM)

| Section | Purpose |
|---------|---------|
| FleetFsmMatrix (LT-16b) | 5 orthogonal axes × N keepers, current state chips |
| + invariant strip (LT-13/16b) | how many keepers violate each joint invariant |
| + time sparkline (LT-16c) | last 30 ticks (5 min) per (keeper, axis) |
| + CompositeFsmFlowchart (this PR) | the spec itself — structural mental model |
| + FsmHub (LT-16d) | per-keeper drill-down, pinned from matrix row click |

4 dimensions (keeper × axis × state × time) + spec = the operator goal from the LT-12 design doc.

## References

- #7689 (LT-12 design, §2.1 encoding).
- #7740 / #7750 / #7761 (LT-16b/c/d).
- \`specs/keeper-state-machine/*.tla\` — transitions hand-extracted from these.
- Harel 1987, "Statecharts: A Visual Formalism for Complex Systems".

🤖 Generated with [Claude Code](https://claude.com/claude-code)