### PR TITLE
feat(dashboard): render phase dwell time in Agent Modal header

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -15,6 +15,7 @@ import {
   clearKeeper,
   deleteKeeperHistorySnapshots,
   fetchKeeperCheckpoints,
+  fetchKeeperTransitions,
   pauseKeeper,
   resumeKeeper,
   shutdownKeeper,
@@ -775,11 +776,33 @@ export function KeeperDetailOverlay() {
   const [preserveSystemPrompt, setPreserveSystemPrompt] = useState(true)
   const [clearPending, setClearPending] = useState(false)
   const [checkpointRefreshToken, setCheckpointRefreshToken] = useState(0)
+  // Latest transition's wall_clock_at_decision, in unix seconds.  Used by
+  // the header KeeperPhaseAndStage to render "현재 phase에 머문 시간" without
+  // requiring a new backend field — derivation is plan-approved trade-off.
+  const [phaseEnteredAtSec, setPhaseEnteredAtSec] = useState<number | null>(null)
   const prevKeeperRef = useRef(keeper.name)
   if (prevKeeperRef.current !== keeper.name) {
     prevKeeperRef.current = keeper.name
     setDiagOpen(shouldOpenDiagnostics)
+    setPhaseEnteredAtSec(null)
   }
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchKeeperTransitions(keeper.name, 1, { signal: controller.signal })
+      .then(res => {
+        if (controller.signal.aborted) return
+        const head = res.transitions?.[0]
+        setPhaseEnteredAtSec(
+          typeof head?.wall_clock_at_decision === 'number' ? head.wall_clock_at_decision : null,
+        )
+      })
+      .catch(() => {
+        // transient fetch failure — leave dwell hidden rather than showing stale
+        if (controller.signal.aborted) return
+        setPhaseEnteredAtSec(null)
+      })
+    return () => controller.abort()
+  }, [keeper.name, keeper.phase])
   useEffect(() => {
     setClearDialogOpen(false)
     setClearReason('')
@@ -834,7 +857,7 @@ export function KeeperDetailOverlay() {
             <div class="flex flex-col gap-0.5">
               <div class="flex items-center gap-2.5">
                 <h2 id=${titleId} class="m-0 text-lg font-semibold text-[var(--text-strong)]">${keeper.name}</h2>
-                <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} />
+                <${KeeperPhaseAndStage} phase=${keeper.phase} pipelineStage=${keeper.pipeline_stage} phaseEnteredAtSec=${phaseEnteredAtSec} />
                 ${(() => {
                   const series = keeper.metrics_series ?? []
                   const lastUsed = series.length > 0 ? series[series.length - 1]?.model_used : null

--- a/dashboard/src/components/keeper-phase-indicator.ts
+++ b/dashboard/src/components/keeper-phase-indicator.ts
@@ -4,6 +4,7 @@
 
 import { html } from 'htm/preact'
 import type { KeeperPhase } from '../types'
+import { formatDuration } from '../lib/format-time'
 
 interface PhaseStyle {
   label: string
@@ -56,21 +57,38 @@ export function KeeperPhaseBadge({ phase, compact }: { phase?: KeeperPhase | str
   `
 }
 
-/** Dual indicator showing both phase (lifecycle) and pipeline_stage (activity). */
+/** Dual indicator showing both phase (lifecycle) and pipeline_stage (activity).
+ *
+ * When [phaseEnteredAtSec] is provided (unix seconds, e.g. the
+ * [wall_clock_at_decision] of the latest KeeperTransition), a dwell-time
+ * chip is rendered between the phase badge and the stage label — e.g.
+ * "● 실행중  · 2시간  executing".  The caller is responsible for fetching
+ * transitions; the indicator stays dumb and pure.  Dwell is recomputed on
+ * every render, so it refreshes along with the enclosing signal updates.
+ */
 export function KeeperPhaseAndStage({
   phase,
   pipelineStage,
+  phaseEnteredAtSec,
 }: {
   phase?: KeeperPhase | string | null
   pipelineStage?: string | null
+  phaseEnteredAtSec?: number | null
 }) {
   const stageLabel = pipelineStage && pipelineStage !== 'idle' && pipelineStage !== 'offline'
     ? pipelineStage.replace('_', ' ')
     : null
 
+  const dwellText = (typeof phaseEnteredAtSec === 'number' && Number.isFinite(phaseEnteredAtSec))
+    ? formatDuration(Math.max(0, Date.now() / 1000 - phaseEnteredAtSec))
+    : null
+
   return html`
     <div class="flex items-center gap-2">
       <${KeeperPhaseBadge} phase=${phase} />
+      ${dwellText ? html`
+        <span class="text-[10px] text-[var(--text-muted)] font-mono tracking-tight" title="현재 phase에 머문 시간">· ${dwellText}</span>
+      ` : null}
       ${stageLabel ? html`
         <span class="text-[10px] text-[var(--text-dim)] font-mono tracking-tight opacity-80">${stageLabel}</span>
       ` : null}


### PR DESCRIPTION
## 무엇

Keeper Agent Modal 헤더의 `KeeperPhaseAndStage`에 **dwell time chip** 추가. phase badge와 pipeline stage label 사이에 \"· 2시간\" 같은 머문 시간 표시.

## 왜

**배경**: Keeper Agent Modal 재설계 플랜(`.claude/plans/curried-moseying-whisper.md`) PR 2. 관찰자가 모달 열자마자 \"지금 Running인 건 알겠는데 **얼마나 오래** Running인가?\"가 보여야 PR 6 (divergent conditions) 같은 후속 기능의 맥락이 살아납니다. 예: \"Running 2h인데 `context_handoff_needed=true`면 이상한 거 아닌가?\"

## 설계 결정 — 프론트 derive

플랜 Trade-offs 표에 따라 **백엔드 스키마 추가 0**:
- 기존 transitions ring이 이미 `wall_clock_at_decision: float`를 싣고 있음
- `KeeperDetailOverlay`가 `fetchKeeperTransitions(name, 1)` 으로 1개만 가져와 head 추출
- 인디케이터 컴포넌트는 dumb/pure: props로 `phaseEnteredAtSec` 받아 `Date.now()/1000 - phaseEnteredAtSec` 계산 후 공용 `formatDuration` 렌더

## 변경 크기

`dashboard/src/components/keeper-phase-indicator.ts` | 20 insertions
`dashboard/src/components/keeper-detail.ts`         | 25 insertions

2 files, +43 lines net.

## Verification

- [x] `pnpm build`: tsc + vite 모두 pass (21s, 타입 에러 0)
- [x] `pnpm lint`: clean
- [x] AbortController 배선 — keeper 전환/닫기 시 in-flight fetch 취소
- [x] fetch 실패 시 dwell 숨김 (stale 보여주기 거부)

## 구현 세부

- State: `phaseEnteredAtSec: number | null`, keeper 전환 시 null로 리셋 후 재fetch
- useEffect deps: `[keeper.name, keeper.phase]` — phase 전환 시에도 refetch (새 wall_clock 반영)
- Refresh cadence: 키퍼 데이터 poll이 일어나면 자연히 re-render되면서 dwell 재계산. 별도 ticker 없음 (최소주의)

## Out of scope

- 실시간 1분 단위 ticker (현재 poll 주기로 충분, 필요 시 follow-up)
- Backend `phase_entered_at` 스탬프 (플랜에서 명시적으로 프론트 derive 결정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)