### PR TITLE
[codex] harden keeper shared-state concurrency

### DIFF
--- a/lib/cascade/cascade_config.ml
+++ b/lib/cascade/cascade_config.ml
@@ -358,10 +358,15 @@ type cascade_source = Named | Default_fallback | Hardcoded_defaults
     3. Selected item becomes first; rest sorted by weight desc
 
     @since 0.137.0 *)
-let weighted_shuffle_rng = lazy (Random.State.make_self_init ())
+(* Shared weighted-shuffle RNG.  Protect draws with Stdlib.Mutex because
+   [Random.State.int] mutates the state and this path can be hit from
+   concurrent server fibers. *)
+let weighted_shuffle_rng = Random.State.make_self_init ()
+let weighted_shuffle_rng_mu = Mutex.create ()
 
 let weighted_random_int bound =
-  Random.State.int (Lazy.force weighted_shuffle_rng) bound
+  Mutex.protect weighted_shuffle_rng_mu (fun () ->
+    Random.State.int weighted_shuffle_rng bound)
 
 let weighted_shuffle
     ?(rand_int = weighted_random_int)

--- a/lib/keeper/keeper_decision_audit.ml
+++ b/lib/keeper/keeper_decision_audit.ml
@@ -10,11 +10,26 @@
 (* ================================================================ *)
 
 (* These values are read from tests and module-init code that can run before an
-   Eio scheduler exists, so they must stay on Stdlib.Lazy. *)
-let decision_layer_level_cached =
-  lazy (Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
+   Eio scheduler exists, so they cannot depend on Eio.Lazy.  Use a
+   cross-context Atomic+Stdlib.Mutex memo rather than Stdlib.Lazy.force. *)
+let resolve_cached cache mu compute =
+  match Atomic.get cache with
+  | Some value -> value
+  | None ->
+      Mutex.protect mu (fun () ->
+        match Atomic.get cache with
+        | Some value -> value
+        | None ->
+            let value = compute () in
+            Atomic.set cache (Some value);
+            value)
 
-let decision_layer_level () = Lazy.force decision_layer_level_cached
+let decision_layer_level_cached : int option Atomic.t = Atomic.make None
+let decision_layer_level_mu = Mutex.create ()
+
+let decision_layer_level () =
+  resolve_cached decision_layer_level_cached decision_layer_level_mu
+    (fun () -> Env_config_core.get_int ~default:0 "MASC_DECISION_LAYER_LEVEL")
 
 let audit_enabled () = decision_layer_level () >= 1
 
@@ -78,10 +93,14 @@ let to_json (r : decision_record) : Yojson.Safe.t =
 (* Ring buffer                                                      *)
 (* ================================================================ *)
 
-let ring_capacity_cached =
-  lazy (Env_config_core.get_int ~default:50 "MASC_DECISION_AUDIT_RING_CAPACITY")
+let ring_capacity_cached : int option Atomic.t = Atomic.make None
+let ring_capacity_mu = Mutex.create ()
 
-let ring_capacity () = max 1 (Lazy.force ring_capacity_cached)
+let ring_capacity () =
+  max 1
+    (resolve_cached ring_capacity_cached ring_capacity_mu (fun () ->
+         Env_config_core.get_int ~default:50
+           "MASC_DECISION_AUDIT_RING_CAPACITY"))
 
 type ring = {
   buf : decision_record option array;

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -1715,7 +1715,7 @@ let run_grpc_heartbeat_stream
       recv
   =
   let rec tick () =
-    if Atomic.get stop || !close_ref
+    if Atomic.get stop || Atomic.get close_ref
     then ()
     else (
       (try
@@ -1727,7 +1727,7 @@ let run_grpc_heartbeat_stream
        | Eio.Cancel.Cancelled _ as e -> raise e
        | End_of_file -> raise End_of_file
        | exn -> Log.Keeper.error "gRPC heartbeat tick error: %s" (Printexc.to_string exn));
-      if not (Atomic.get stop || !close_ref)
+      if not (Atomic.get stop || Atomic.get close_ref)
       then (
         let no_wakeup = Atomic.make false in
         interruptible_sleep ~clock ~stop ~wakeup:no_wakeup interval_sec;
@@ -1778,11 +1778,11 @@ let run_grpc_heartbeat_fiber
     Log.Keeper.warn "gRPC heartbeat: Eio context or env not available";
     None
   | Some grpc_sw, Some env ->
-    let close_ref = ref false in
+    let close_ref = Atomic.make false in
     Eio.Fiber.fork ~sw (fun () ->
       (* Outer loop: reconnect on stream failure *)
       let rec connect_loop attempts =
-        if Atomic.get stop || !close_ref
+        if Atomic.get stop || Atomic.get close_ref
         then ()
         else if attempts >= max_reconnect_attempts
         then
@@ -1814,13 +1814,13 @@ let run_grpc_heartbeat_fiber
            | exn ->
              log_grpc_heartbeat_stream_failure ~agent_name ~attempts (`Error exn);
              close_stream ());
-          if not (Atomic.get stop || !close_ref)
+          if not (Atomic.get stop || Atomic.get close_ref)
           then (
             Eio.Time.sleep clock reconnect_backoff_sec;
             connect_loop (attempts + 1)))
       in
       connect_loop 0);
-    Some (fun () -> close_ref := true)
+    Some (fun () -> Atomic.set close_ref true)
 ;;
 
 let start_keeper_grpc_heartbeat

--- a/lib/keeper/keeper_trace_emit.ml
+++ b/lib/keeper/keeper_trace_emit.ml
@@ -6,14 +6,28 @@
 module SM = Keeper_state_machine
 
 (* This flag is queried from registry/test code that can run before an Eio
-   scheduler exists, so the cache must stay on Stdlib.Lazy. *)
-let enabled_cache =
-  lazy
-    (match Sys.getenv_opt "MASC_TLA_TRACE" with
-     | Some ("1" | "true" | "yes") -> true
-     | _ -> false)
+   scheduler exists, so it cannot depend on Eio.Lazy.  Use a plain
+   Atomic+Stdlib.Mutex memo instead of Stdlib.Lazy.force, which is not the
+   concurrency primitive we use elsewhere in the Eio runtime. *)
+let enabled_cache : bool option Atomic.t = Atomic.make None
+let enabled_cache_mu = Mutex.create ()
 
-let enabled () = Lazy.force enabled_cache
+let compute_enabled () =
+  match Sys.getenv_opt "MASC_TLA_TRACE" with
+  | Some ("1" | "true" | "yes") -> true
+  | _ -> false
+
+let enabled () =
+  match Atomic.get enabled_cache with
+  | Some enabled -> enabled
+  | None ->
+      Mutex.protect enabled_cache_mu (fun () ->
+        match Atomic.get enabled_cache with
+        | Some enabled -> enabled
+        | None ->
+            let enabled = compute_enabled () in
+            Atomic.set enabled_cache (Some enabled);
+            enabled)
 
 let trace_path ~base_path ~keeper_name =
   Filename.concat
@@ -30,7 +44,7 @@ let emit_transition
     ~(conditions_after : SM.conditions)
     ~(restart_count : int)
   =
-  if not (Lazy.force enabled_cache) then ()
+  if not (enabled ()) then ()
   else
     let json = `Assoc [
       "seq", `Int seq;


### PR DESCRIPTION
## Summary
- replace `Stdlib.Lazy.force` feature/config caches in keeper trace and decision audit paths with `Atomic + Stdlib.Mutex` memoization
- serialize the shared weighted-shuffle RNG used by cascade selection
- switch the keeper gRPC heartbeat close flag from a plain `ref` to `Atomic.t`

## Why
These paths all sit on shared runtime state that can be touched from concurrent fibers or mixed init/runtime contexts. The previous implementations relied on primitives that were too loose for that boundary: lazy caches on hot runtime paths, a mutable global RNG without synchronization, and a cross-fiber shutdown flag stored in a plain ref.

## Impact
- reduces latent races in keeper telemetry/trace emission
- makes cascade weighted ordering deterministic under concurrent access
- makes heartbeat shutdown signaling explicit and atomic

## Root Cause
The code mixed single-context assumptions with shared process-wide state. That mostly works until the same values are touched from different fibers or from both pre-Eio init code and Eio runtime code.

## Validation
- `dune build --root . lib/keeper/keeper_trace_emit.ml lib/keeper/keeper_decision_audit.ml lib/keeper/keeper_keepalive.ml lib/cascade/cascade_config.ml`
- `./_build/default/test/test_decision_pipeline.exe`
- `./_build/default/test/test_cascade_strategy.exe`
- `./_build/default/test/test_smart_heartbeat_keepalive.exe`
