### PR TITLE
feat(dashboard): KeeperChatPanel search filter

### DIFF
--- a/dashboard/src/components/keeper-chat-panel.test.ts
+++ b/dashboard/src/components/keeper-chat-panel.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { KeeperChatStreamEvent } from '../api/keeper'
 import {
+  filterChatMessages,
   isKeeperTextContentEvent,
   normalizeKeeperChatErrorValue,
+  type ChatMessage,
 } from './keeper-chat-panel'
 
 describe('isKeeperTextContentEvent', () => {
@@ -49,5 +51,49 @@ describe('normalizeKeeperChatErrorValue', () => {
 
   it('falls back to a stable generic message', () => {
     expect(normalizeKeeperChatErrorValue({ code: 500 })).toBe('스트림 오류')
+  })
+})
+
+describe('filterChatMessages', () => {
+  const sample: ChatMessage[] = [
+    { role: 'user', content: 'Deploy the service to staging', timestamp: 1 },
+    { role: 'assistant', content: 'Starting deploy pipeline…', timestamp: 2 },
+    { role: 'user', content: '로그 확인 부탁해', timestamp: 3 },
+    { role: 'assistant', content: 'Checked logs: no errors', timestamp: 4 },
+    { role: 'user', content: 'Summarize status', timestamp: 5 },
+  ]
+
+  it('returns the input untouched for empty queries', () => {
+    expect(filterChatMessages(sample, '')).toBe(sample)
+  })
+
+  it('treats whitespace-only queries as empty', () => {
+    expect(filterChatMessages(sample, '   ')).toBe(sample)
+  })
+
+  it('filters messages case-insensitively on content', () => {
+    const result = filterChatMessages(sample, 'DEPLOY')
+    expect(result.map(m => m.timestamp)).toEqual([1, 2])
+  })
+
+  it('matches non-ASCII content', () => {
+    const result = filterChatMessages(sample, '로그')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.timestamp).toBe(3)
+  })
+
+  it('trims query whitespace before matching', () => {
+    const result = filterChatMessages(sample, '  status  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.timestamp).toBe(5)
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterChatMessages(sample, 'nonexistent_token')).toEqual([])
+  })
+
+  it('does not match on role labels', () => {
+    // 'user' must not match just because the role is 'user'
+    expect(filterChatMessages(sample, 'user')).toEqual([])
   })
 })

--- a/dashboard/src/components/keeper-chat-panel.ts
+++ b/dashboard/src/components/keeper-chat-panel.ts
@@ -11,12 +11,13 @@ import {
 } from '../api/keeper'
 import { asString, isRecord } from './common/normalize'
 import { showToast } from './common/toast'
+import { TextInput } from './common/input'
 import { ChatComposer, ChatTranscript } from './chat/primitives'
 import type { KeeperConversationEntry } from '../types'
 import { shellAuthSummary } from '../store'
 import { keeperDirectChatAccess } from '../lib/keeper-chat-access'
 
-interface ChatMessage {
+export interface ChatMessage {
   role: 'user' | 'assistant'
   content: string
   timestamp: number
@@ -28,6 +29,17 @@ const streaming = signal(false)
 const streamBuffer = signal('')
 const streamStartedAt = signal<number | null>(null)
 const chatError = signal('')
+const searchQuery = signal('')
+
+/**
+ * Pure filter: case-insensitive substring match over message content.
+ * Empty or whitespace-only queries return the input unchanged.
+ */
+export function filterChatMessages(messages: ChatMessage[], query: string): ChatMessage[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return messages
+  return messages.filter((m) => m.content.toLowerCase().includes(q))
+}
 
 let activeAbort: AbortController | null = null
 
@@ -139,6 +151,7 @@ export function KeeperChatPanel({ name }: { name: string }) {
     streamStartedAt.value = null
     chatError.value = ''
     chatMessages.value = []
+    searchQuery.value = ''
     let stale = false
     void fetchKeeperChatHistory(name).then((history) => {
       if (stale) return
@@ -156,7 +169,10 @@ export function KeeperChatPanel({ name }: { name: string }) {
   const messages = chatMessages.value
   const buffer = streamBuffer.value
   const isStreaming = streaming.value
-  const entries = messages.map((msg, index) => toConversationEntry(name, msg, index))
+  const query = searchQuery.value
+  const hasQuery = query.trim().length > 0
+  const filteredMessages = filterChatMessages(messages, query)
+  const entries = filteredMessages.map((msg, index) => toConversationEntry(name, msg, index))
   const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
   const transcriptEntries =
     isStreaming && buffer
@@ -188,8 +204,17 @@ export function KeeperChatPanel({ name }: { name: string }) {
           </div>
         </div>
         <div class="flex items-center gap-2">
+          <${TextInput}
+            class="max-w-[220px]"
+            name="keeper_chat_search"
+            ariaLabel="대화 내용 검색"
+            autoComplete="off"
+            placeholder="대화 검색..."
+            value=${query}
+            onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+          />
           <span class="inline-flex items-center rounded-full border border-[rgba(71,184,255,0.2)] bg-[var(--accent-10)] px-2.5 py-1 text-[11px] font-medium text-[var(--text-strong)]">
-            ${entries.length}개 메시지
+            ${hasQuery ? `${filteredMessages.length} / ${messages.length}개 메시지` : `${messages.length}개 메시지`}
           </span>
         </div>
       </div>
@@ -200,7 +225,9 @@ export function KeeperChatPanel({ name }: { name: string }) {
           : null}
         <${ChatTranscript}
           entries=${transcriptEntries}
-          emptyText="직접 프롬프트를 보내 키퍼 대화를 시작하세요."
+          emptyText=${hasQuery && messages.length > 0
+            ? '검색어와 일치하는 메시지가 없습니다.'
+            : '직접 프롬프트를 보내 키퍼 대화를 시작하세요.'}
           showMetadata=${false}
         />
       </div>


### PR DESCRIPTION
## Summary
- Direct keeper-chat histories had no search, making earlier messages hard to find once conversations grew past a screen.
- Added a pure `filterChatMessages(messages, query)` helper (case-insensitive substring, whitespace-trimmed) and wired a `TextInput` into the panel header.
- Live streaming buffer is rendered unconditionally so in-flight tokens stay visible even when the filter is active.
- Message-count chip now shows `filtered / total` while a query is active.
- Empty-state text switches to a filter-specific message when a query yields zero matches but history exists.
- Search signal resets on keeper change via the existing `useEffect`.

## Reference rhythm
Same shape as #7694, #7706, #7717, #7741, #7751, #7767 — panel-level search over an already-exported component, plus a pure filter function with targeted tests.

## Test plan
- [x] `pnpm -C dashboard typecheck` — clean
- [x] `pnpm -C dashboard lint` — clean
- [x] `pnpm -C dashboard test --run` — 169 files / 2589 tests pass
- [x] 7 new tests in `keeper-chat-panel.test.ts` (empty/whitespace queries, case folding, Korean content, trimming, no-match, role-label non-matching)

## Files
- `dashboard/src/components/keeper-chat-panel.ts` (+31 / -4)
- `dashboard/src/components/keeper-chat-panel.test.ts` (+46 / 0)