### PR TITLE
feat(dashboard/api): migrate gate-keepers endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/gate.ts
+++ b/dashboard/src/api/gate.ts
@@ -15,25 +15,16 @@ import {
   type GateEventInfo,
   type GateStatusData,
 } from './schemas/gate-status'
+import {
+  parseGateKeepersData,
+  type GateKeeperInfo,
+  type GateKeepersData,
+} from './schemas/gate-keepers'
 
 export type { BindingInfo, ChannelInfo, GateEventInfo, GateStatusData }
 export { GateStatusSchemaDriftError } from './schemas/gate-status'
-
-export interface GateKeeperInfo {
-  name: string
-  agent_name?: string
-  status?: string
-  model?: string
-  active_model?: string
-  primary_model?: string
-  keepalive_running?: boolean
-  last_turn_ago_s?: number | null
-}
-
-export interface GateKeepersData {
-  count: number
-  keepers: GateKeeperInfo[]
-}
+export type { GateKeeperInfo, GateKeepersData }
+export { GateKeepersSchemaDriftError } from './schemas/gate-keepers'
 
 export interface DiscordConfiguredBinding {
   channel_id: string
@@ -154,29 +145,13 @@ function decodeChannelInfo(raw: unknown): ChannelInfo | null {
   return result.success ? result.output : null
 }
 
-function decodeGateKeeperInfo(raw: unknown): GateKeeperInfo | null {
-  if (!isRecord(raw)) return null
-  const name = asString(raw.name)
-  if (!name) return null
-  return {
-    name,
-    agent_name: asString(raw.agent_name),
-    status: asString(raw.status),
-    model: asString(raw.model),
-    active_model: asString(raw.active_model),
-    primary_model: asString(raw.primary_model),
-    keepalive_running: asBoolean(raw.keepalive_running),
-    last_turn_ago_s: asNumber(raw.last_turn_ago_s) ?? null,
-  }
-}
-
+// Thin null-returning wrapper — `src/api/gate.test.ts` still asserts
+// null-on-drift. New call sites should use `parseGateKeepersData`.
 export function decodeGateKeepersData(raw: unknown): GateKeepersData | null {
-  if (!isRecord(raw)) return null
-  return {
-    count: asNumber(raw.count, 0),
-    keepers: asRecordArray(raw.keepers)
-      .map(decodeGateKeeperInfo)
-      .filter((item): item is GateKeeperInfo => item !== null),
+  try {
+    return parseGateKeepersData(raw)
+  } catch {
+    return null
   }
 }
 
@@ -355,9 +330,7 @@ export async function fetchGateConnectors(signal?: AbortSignal): Promise<GateCon
 }
 
 export async function fetchGateKeepers(signal?: AbortSignal): Promise<GateKeepersData> {
-  const raw = await get<Record<string, unknown>>('/api/v1/gate/keepers?limit=50&detailed=true', { signal })
-  const decoded = decodeGateKeepersData(raw)
-  if (!decoded) throw new Error('invalid gate keepers payload')
-  return decoded
+  const raw = await get<unknown>('/api/v1/gate/keepers?limit=50&detailed=true', { signal })
+  return parseGateKeepersData(raw)
 }
 

--- a/dashboard/src/api/schemas/gate-keepers.test.ts
+++ b/dashboard/src/api/schemas/gate-keepers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GateKeepersSchemaDriftError,
+  parseGateKeepersData,
+} from './gate-keepers'
+
+describe('parseGateKeepersData', () => {
+  it('accepts an empty payload', () => {
+    const out = parseGateKeepersData({})
+    expect(out.count).toBe(0)
+    expect(out.keepers).toHaveLength(0)
+  })
+
+  it('accepts a minimal keeper with only name', () => {
+    const out = parseGateKeepersData({
+      count: 1,
+      keepers: [{ name: 'greeter' }],
+    })
+    expect(out.keepers).toHaveLength(1)
+    expect(out.keepers[0]!.name).toBe('greeter')
+    expect(out.keepers[0]!.status).toBeUndefined()
+    // last_turn_ago_s collapses absent → null (matches prior decoder);
+    // downstream renders '—' uniformly whether the field is absent or
+    // explicitly null.
+    expect(out.keepers[0]!.last_turn_ago_s).toBeNull()
+  })
+
+  it('preserves explicit null last_turn_ago_s separate from absent', () => {
+    const out = parseGateKeepersData({
+      count: 1,
+      keepers: [{ name: 'cold-start', last_turn_ago_s: null }],
+    })
+    expect(out.keepers[0]!.last_turn_ago_s).toBeNull()
+  })
+
+  it('parses a populated keeper with all metadata', () => {
+    const out = parseGateKeepersData({
+      count: 1,
+      keepers: [
+        {
+          name: 'planner',
+          agent_name: 'planner',
+          status: 'running',
+          model: 'claude-opus-4-7',
+          active_model: 'claude-opus-4-7',
+          primary_model: 'claude-opus-4-7',
+          keepalive_running: true,
+          last_turn_ago_s: 42,
+        },
+      ],
+    })
+    expect(out.keepers[0]!.keepalive_running).toBe(true)
+    expect(out.keepers[0]!.last_turn_ago_s).toBe(42)
+  })
+
+  it('drops entries without name (lenient-per-entry)', () => {
+    const out = parseGateKeepersData({
+      count: 2,
+      keepers: [{ name: 'greeter' }, { status: 'orphan' }],
+    })
+    expect(out.keepers).toHaveLength(1)
+    expect(out.keepers[0]!.name).toBe('greeter')
+  })
+
+  it('tolerates non-array keepers field by returning empty list', () => {
+    const out = parseGateKeepersData({ count: 0, keepers: null })
+    expect(out.keepers).toHaveLength(0)
+  })
+
+  it('defaults count to 0 when backend omits it', () => {
+    const out = parseGateKeepersData({ keepers: [{ name: 'k1' }] })
+    expect(out.count).toBe(0)
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseGateKeepersData(null)).toThrow(GateKeepersSchemaDriftError)
+    expect(() => parseGateKeepersData('oops')).toThrow(GateKeepersSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/gate-keepers.ts
+++ b/dashboard/src/api/schemas/gate-keepers.ts
@@ -1,0 +1,73 @@
+// Gate keepers schema — schema-at-boundary for
+// `GET /api/v1/gate/keepers`.
+//
+// `name` is the only required field per-entry — matches the prior
+// decoder's `if (!name) return null` guard. Every other attribute is
+// optional because the backend probes them lazily and a keeper with
+// only name + status should still render as "exists but metadata
+// pending" rather than drop off the list.
+//
+// Outer shape is strict-with-fallbacks; per-entry is lenient (bad
+// rows drop silently so one corrupt keeper never blanks the whole
+// list). Same pattern as #7768 gate-status and #7746 logs.
+//
+// Uses the shared `SchemaDriftError` base landed in #7732.
+
+import {
+  boolean,
+  fallback,
+  nullable,
+  number,
+  object,
+  optional,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+const GateKeeperInfoSchema = object({
+  name: string(),
+  agent_name: optional(string()),
+  status: optional(string()),
+  model: optional(string()),
+  active_model: optional(string()),
+  primary_model: optional(string()),
+  keepalive_running: optional(boolean()),
+  // Original decoder: `asNumber(raw.last_turn_ago_s) ?? null`. Absent
+  // field collapses to `null` (never `undefined`) so downstream renders
+  // '—' uniformly.
+  last_turn_ago_s: fallback(nullable(number()), null),
+})
+
+export type GateKeeperInfo = InferOutput<typeof GateKeeperInfoSchema>
+
+const GateKeepersOuterSchema = object({
+  count: fallback(number(), 0),
+  keepers: optional(unknown()),
+})
+
+export interface GateKeepersData {
+  count: number
+  keepers: GateKeeperInfo[]
+}
+
+export class GateKeepersSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('gate-keepers', issues)
+  }
+}
+
+export function parseGateKeepersData(data: unknown): GateKeepersData {
+  const outer = parseOrThrow(GateKeepersSchemaDriftError, GateKeepersOuterSchema, data)
+  const rawEntries = Array.isArray(outer.keepers) ? outer.keepers : []
+  const keepers: GateKeeperInfo[] = []
+  for (const raw of rawEntries) {
+    const parsed = safeParse(GateKeeperInfoSchema, raw, { abortEarly: true })
+    if (parsed.success) keepers.push(parsed.output)
+  }
+  return { count: outer.count, keepers }
+}

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -90,11 +90,11 @@ const REAL_COMPOSITE_PAYLOAD = {
 const REAL_GATE_KEEPERS_SHAPE: GateKeepersData = {
   count: 5,
   keepers: [
-    { name: 'analyst', status: 'busy' },
-    { name: 'ani1999', status: 'inactive' },
-    { name: 'cheolsu', status: 'active' },
-    { name: 'janitor', status: 'active' },
-    { name: 'masc-improver', status: 'active' },
+    { name: 'analyst', status: 'busy', last_turn_ago_s: null },
+    { name: 'ani1999', status: 'inactive', last_turn_ago_s: null },
+    { name: 'cheolsu', status: 'active', last_turn_ago_s: null },
+    { name: 'janitor', status: 'active', last_turn_ago_s: null },
+    { name: 'masc-improver', status: 'active', last_turn_ago_s: null },
   ],
 }
 


### PR DESCRIPTION
## Summary

Second gate.ts endpoint extracted — \`GET /api/v1/gate/keepers\` goes through a valibot schema. **First migration to consume the shared \`SchemaDriftError\` base** landed in #7732: the per-domain drift error class collapses from ~15 lines to 3.

- Adds \`src/api/schemas/gate-keepers.ts\` — 1 entry schema, 1 outer schema, \`GateKeepersSchemaDriftError extends SchemaDriftError\`, \`parseGateKeepersData\`.
- Drops 2 interfaces + 2 decoder helpers from \`gate.ts\`.
- Strict outer + lenient per-entry: one bad keeper row drops silently, non-object outer payload throws.
- 8 shape tests covering every preserved behavior.

## Notable drift policy — \`last_turn_ago_s\`

Original decoder: \`asNumber(raw.last_turn_ago_s) ?? null\` — absent AND explicit-null both collapse to \`null\`. Replicated via \`fallback(nullable(number()), null)\`. The inferred type is \`number | null\` (required), which surfaced one typecheck error in the fsm-hub fixture (5 objects needed \`last_turn_ago_s: null\` added). Corrected in this PR to reflect the new contract.

This is an intentional type-narrowing: the previous \`number | null | undefined\` triple was indistinguishable to downstream consumers ('—' rendered on every falsy branch), and the interface's \`?:\` modifier was misleading since \`asNumber(x) ?? null\` always produced one of the two.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/gate-keepers.test.ts src/api/gate.test.ts src/components/fsm-hub.integration.test.ts\` — 56/56 pass (8 new + 12 existing gate + 36 existing fsm-hub integration)
- [ ] CI green

Part of #7441. Remaining in gate.ts: \`fetchGateConnectors\`.