### PR TITLE
feat(attribution): migrate accountability + worker_dev_tools (L1 gates 4-5/8)

### DIFF
--- a/lib/keeper/keeper_accountability.ml
+++ b/lib/keeper/keeper_accountability.ml
@@ -667,3 +667,39 @@ let accountability_risk_is_high config ~keeper_name ~agent_name =
       | Some (`String "high") -> true
       | _ -> false)
   | _ -> false
+
+(* --- Attribution envelope conversion (Layer 1) ---
+   All accountability verdicts are Det — [effective_status] is a pure
+   function of snapshot + time. The claim_snapshot type stays private to
+   this module; callers provide their own evidence payload. *)
+
+let attribution_from_status (status : claim_status) ~evidence
+    ?resolution_reason ?(evidence_refs_count = 0) () : Attribution.t option =
+  match status with
+  | Pending -> None
+  | Supported ->
+    Some (Attribution.passed ~origin:Det ~gate:"accountability" ~evidence)
+  | Unsupported ->
+    let reason = Option.value resolution_reason
+                   ~default:"claim not supported by evidence"
+    in
+    Some (Attribution.policy_failed ~origin:Det ~gate:"accountability"
+            ~evidence ~reason)
+  | Expired ->
+    let reason = Option.value resolution_reason
+                   ~default:"claim expired"
+    in
+    Some (Attribution.policy_failed ~origin:Det ~gate:"accountability"
+            ~evidence ~reason)
+  | Partial ->
+    (* Score from evidence_refs_count: heuristic 0.5 baseline, +0.1 per
+       evidence ref up to 1.0. No domain-specific normalization available
+       here — dashboard aggregates the raw count separately. *)
+    let score =
+      Float.min 1.0 (0.5 +. 0.1 *. Float.of_int evidence_refs_count)
+    in
+    let rationale = Option.value resolution_reason
+                      ~default:"claim partially supported"
+    in
+    Some (Attribution.partial_pass ~origin:Det ~gate:"accountability"
+            ~evidence ~score ~rationale)

--- a/lib/keeper/keeper_accountability.mli
+++ b/lib/keeper/keeper_accountability.mli
@@ -43,3 +43,33 @@ val accountability_risk_is_high :
   keeper_name:string ->
   agent_name:string ->
   bool
+
+(** {1 Attribution envelope (Layer 1)}
+
+    Convert a [claim_status] into the typed attribution envelope used by
+    SSE emitters. Accountability is [Det]: status is derived from
+    resolution events or deterministic time-based expiry.
+
+    The caller is expected to have already collected the claim snapshot
+    and built its own evidence payload — this keeps [claim_snapshot] and
+    its constituent types private to this module. *)
+
+val attribution_from_status :
+  claim_status ->
+  evidence:Yojson.Safe.t ->
+  ?resolution_reason:string ->
+  ?evidence_refs_count:int ->
+  unit ->
+  Attribution.t option
+(** Mapping:
+    - [Supported]    → [Attribution.Passed]
+    - [Unsupported]  → [Attribution.Policy_failed { reason }]
+                        (uses [resolution_reason] if given, else default)
+    - [Expired]      → [Attribution.Policy_failed { reason = "expired" }]
+    - [Partial]      → [Attribution.Partial_pass { score; rationale }]
+                        (score = clamp 0.5 + 0.1 × [evidence_refs_count]
+                         at 1.0; rationale from [resolution_reason] or
+                         default)
+    - [Pending]      → [None] (no verdict yet — consistent with verification)
+
+    Returns [None] only for [Pending]. All other statuses yield [Some]. *)

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1367,3 +1367,45 @@ let make_tools ~proc_mgr ~clock ?workdir ?on_exec () : Agent_sdk.Tool.t list =
 let make_readonly_tools ~proc_mgr ~clock ?workdir ?on_exec () : Agent_sdk.Tool.t list =
   [ make_file_read ?workdir ?on_exec ();
     make_shell_exec_readonly ~workdir ~on_exec ~proc_mgr ~clock ]
+
+(* --- Attribution envelope conversion (Layer 1) ---
+   Shell command validation is a Det policy gate. The 7 block_reason
+   variants map uniformly to Policy_failed (no transition involved —
+   this is a pre-execution allow/deny check). *)
+
+let block_reason_tag = function
+  | Empty_command -> "empty_command"
+  | Chain_or_redirect -> "chain_or_redirect"
+  | Injection -> "injection"
+  | Process_substitution -> "process_substitution"
+  | Unsafe_redirect -> "unsafe_redirect"
+  | Pipes_not_allowed -> "pipes_not_allowed"
+  | Command_not_allowed _ -> "command_not_allowed"
+
+let attribution_of_validation ~cmd
+    (result : (unit, block_reason) result) : Attribution.t =
+  match result with
+  | Ok () ->
+    let evidence : Yojson.Safe.t =
+      `Assoc [ ("cmd", `String cmd) ]
+    in
+    Attribution.passed ~origin:Det ~gate:"worker_dev_tools" ~evidence
+  | Error br ->
+    let command_name =
+      match br with
+      | Command_not_allowed name -> Some name
+      | _ -> None
+    in
+    let evidence : Yojson.Safe.t =
+      `Assoc
+        ([
+           ("cmd", `String cmd);
+           ("block_reason", `String (block_reason_tag br));
+         ]
+         @
+         match command_name with
+         | Some n -> [ ("command_name", `String n) ]
+         | None -> [])
+    in
+    Attribution.policy_failed ~origin:Det ~gate:"worker_dev_tools"
+      ~evidence ~reason:(block_reason_to_string br)

--- a/test/test_keeper_accountability.ml
+++ b/test/test_keeper_accountability.ml
@@ -258,6 +258,85 @@ let test_synthetic_claims_do_not_dilute_unsupported_rate () =
       check string "risk band should be high" "high"
         (string_member "risk_band" summary))
 
+(* --- Attribution tests --- *)
+
+module A = Masc_mcp.Attribution
+module KA = Masc_mcp.Keeper_accountability
+
+let outcome_kind = function
+  | A.Passed -> "passed"
+  | A.Policy_failed _ -> "policy_failed"
+  | A.Transition_blocked _ -> "transition_blocked"
+  | A.Partial_pass _ -> "partial_pass"
+
+let sample_evidence : Yojson.Safe.t =
+  `Assoc [ ("claim_id", `String "acct-test"); ("agent", `String "t-agent") ]
+
+let test_attr_pending_none () =
+  check bool "Pending yields None" true
+    (KA.attribution_from_status KA.Pending ~evidence:sample_evidence () = None)
+
+let test_attr_supported () =
+  match
+    KA.attribution_from_status KA.Supported ~evidence:sample_evidence ()
+  with
+  | Some attr ->
+    check string "gate" "accountability" attr.gate;
+    check string "outcome" "passed" (outcome_kind attr.outcome)
+  | None -> Alcotest.fail "expected Some for Supported"
+
+let test_attr_unsupported_with_reason () =
+  match
+    KA.attribution_from_status KA.Unsupported ~evidence:sample_evidence
+      ~resolution_reason:"conflicting evidence" ()
+  with
+  | Some { outcome = A.Policy_failed { reason }; _ } ->
+    check string "reason uses resolution_reason" "conflicting evidence" reason
+  | _ -> Alcotest.fail "expected Policy_failed"
+
+let test_attr_unsupported_default_reason () =
+  match
+    KA.attribution_from_status KA.Unsupported ~evidence:sample_evidence ()
+  with
+  | Some { outcome = A.Policy_failed { reason }; _ } ->
+    check bool "default reason mentions evidence" true
+      (Astring.String.is_infix ~affix:"evidence" reason)
+  | _ -> Alcotest.fail "expected Policy_failed"
+
+let test_attr_expired () =
+  match
+    KA.attribution_from_status KA.Expired ~evidence:sample_evidence ()
+  with
+  | Some { outcome = A.Policy_failed { reason }; _ } ->
+    check bool "reason mentions expired" true
+      (Astring.String.is_infix ~affix:"expired" reason)
+  | _ -> Alcotest.fail "expected Policy_failed"
+
+let test_attr_partial_score_clamped () =
+  (* 0 evidence → 0.5; 10+ evidence → clamped to 1.0. *)
+  let get_score refs_count =
+    match
+      KA.attribution_from_status KA.Partial ~evidence:sample_evidence
+        ~evidence_refs_count:refs_count ()
+    with
+    | Some { outcome = A.Partial_pass { score; _ }; _ } -> score
+    | _ -> Alcotest.fail "expected Partial_pass"
+  in
+  check (float 0.0001) "0 refs → 0.5 baseline" 0.5 (get_score 0);
+  check (float 0.0001) "3 refs → 0.8" 0.8 (get_score 3);
+  check (float 0.0001) "10 refs → clamped to 1.0" 1.0 (get_score 10);
+  check (float 0.0001) "50 refs → still 1.0" 1.0 (get_score 50)
+
+let test_attr_gate_invariants () =
+  List.iter
+    (fun status ->
+      match KA.attribution_from_status status ~evidence:sample_evidence () with
+      | Some attr ->
+        check string "gate=accountability" "accountability" attr.gate;
+        check bool "origin=Det" true (attr.origin = A.Det)
+      | None -> () (* Pending is legit None *))
+    [ KA.Pending; KA.Supported; KA.Unsupported; KA.Expired; KA.Partial ]
+
 let () =
   let base_path = Masc_test_deps.find_project_root () in
   ignore (Result.get_ok (Keeper_exec_tools.init_policy_config ~base_path));
@@ -273,5 +352,19 @@ let () =
             `Quick test_claim_tool_exposes_routing_warning_for_high_risk_keeper;
           test_case "synthetic claims do not dilute unsupported rate" `Quick
             test_synthetic_claims_do_not_dilute_unsupported_rate;
+        ] );
+      ( "attribution",
+        [
+          test_case "Pending → None" `Quick test_attr_pending_none;
+          test_case "Supported → Passed" `Quick test_attr_supported;
+          test_case "Unsupported → Policy_failed (resolution reason)"
+            `Quick test_attr_unsupported_with_reason;
+          test_case "Unsupported → Policy_failed (default reason)" `Quick
+            test_attr_unsupported_default_reason;
+          test_case "Expired → Policy_failed" `Quick test_attr_expired;
+          test_case "Partial score clamped [0.5, 1.0]" `Quick
+            test_attr_partial_score_clamped;
+          test_case "gate=accountability origin=Det invariant" `Quick
+            test_attr_gate_invariants;
         ] );
     ]

--- a/test/test_worker_dev_tools.ml
+++ b/test/test_worker_dev_tools.ml
@@ -897,4 +897,68 @@ let () =
           None
           (Worker_dev_tools.structured_tool_hint_for_r2 "workflow disable x.yml"));
     ];
+    "attribution", [
+      Alcotest.test_case "Ok () → Passed with cmd in evidence" `Quick (fun () ->
+        let attr =
+          Worker_dev_tools.attribution_of_validation ~cmd:"ls -la" (Ok ())
+        in
+        Alcotest.(check string) "gate" "worker_dev_tools" attr.gate;
+        Alcotest.(check bool) "origin=Det" true
+          (attr.origin = Attribution.Det);
+        Alcotest.(check bool) "outcome=Passed" true
+          (match attr.outcome with Attribution.Passed -> true | _ -> false));
+      Alcotest.test_case "Empty_command → Policy_failed" `Quick (fun () ->
+        let attr =
+          Worker_dev_tools.attribution_of_validation ~cmd:""
+            (Error Worker_dev_tools.Empty_command)
+        in
+        match attr.outcome with
+        | Attribution.Policy_failed { reason } ->
+          Alcotest.(check bool) "reason mentions empty" true
+            (contains_substring reason "empty")
+        | _ -> Alcotest.fail "expected Policy_failed");
+      Alcotest.test_case "Command_not_allowed carries command_name in evidence"
+        `Quick (fun () ->
+        let attr =
+          Worker_dev_tools.attribution_of_validation
+            ~cmd:"rm -rf /"
+            (Error (Worker_dev_tools.Command_not_allowed "rm"))
+        in
+        match attr.evidence with
+        | `Assoc fields ->
+          Alcotest.(check (option string)) "command_name=rm"
+            (Some "rm")
+            (match List.assoc_opt "command_name" fields with
+             | Some (`String s) -> Some s
+             | _ -> None);
+          Alcotest.(check (option string)) "block_reason tag"
+            (Some "command_not_allowed")
+            (match List.assoc_opt "block_reason" fields with
+             | Some (`String s) -> Some s
+             | _ -> None)
+        | _ -> Alcotest.fail "evidence must be object");
+      Alcotest.test_case "all 7 block_reason variants → Policy_failed" `Quick
+        (fun () ->
+        let variants =
+          [
+            Worker_dev_tools.Empty_command;
+            Worker_dev_tools.Chain_or_redirect;
+            Worker_dev_tools.Injection;
+            Worker_dev_tools.Process_substitution;
+            Worker_dev_tools.Unsafe_redirect;
+            Worker_dev_tools.Pipes_not_allowed;
+            Worker_dev_tools.Command_not_allowed "foo";
+          ]
+        in
+        List.iter (fun br ->
+          let attr =
+            Worker_dev_tools.attribution_of_validation ~cmd:"test"
+              (Error br)
+          in
+          Alcotest.(check bool) "always Policy_failed" true
+            (match attr.outcome with
+             | Attribution.Policy_failed _ -> true
+             | _ -> false)
+        ) variants);
+    ];
   ]


### PR DESCRIPTION
## Summary

Layer 1 2차 배치. masc-mcp 내 남은 3개 중 2개 처리.

| Gate | 매핑 규모 |
|------|----------|
| keeper_accountability | 5 claim_status → 4 outcome (Pending=None) |
| worker_dev_tools | 7 block_reason → 1 outcome (Policy_failed), Ok → Passed |

## 스코프 제한 — coord_task 보류 이유

`coord_task.ml`은 별도 sub-library `masc_coord`에 속함. Attribution 모듈이 main `masc_mcp` library에 있어 cross-library 접근 불가. 해결은 Attribution을 공용 sub-library로 추출하는 재편이 필요 — 별도 PR.

OAS 쪽 2 gate (`completion_contract`, `agent_lifecycle`)도 repo 경계 때문에 OAS 쪽 PR로 분리.

## Accountability

**Sum type 준수**: `claim_status` 5 variant가 Attribution outcome에 자연 매핑.

| claim_status | outcome |
|--------------|---------|
| Pending | None |
| Supported | Passed |
| Unsupported | Policy_failed (resolution_reason or default) |
| Expired | Policy_failed |
| Partial | Partial_pass (score = clamp 0.5 + 0.1*refs at [0.5, 1.0]) |

**Private type 유지**: `claim_snapshot`은 계속 .mli에서 비공개. API는 `claim_status` 단위로 받아 호출자가 evidence 구성 — mli 변경 최소.

## Worker_dev_tools

**7 block_reason flat mapping**:
- 모든 Error → Policy_failed (transition 없음, 정책 게이트)
- block_reason tag를 evidence에 포함해 consumer가 dashboard에서 원인별 분류 가능

Command_not_allowed는 `command_name` 필드도 evidence에 넣어 어떤 command가 막혔는지 쉽게 필터링 가능.

## Tests (11 + 4 new)

Accountability:
- Pending→None, Supported→Passed, Unsupported (2가지 reason 소스), Expired, Partial score clamp
- Gate/origin invariant 5 status 전체

Worker_dev_tools:
- Ok→Passed, Empty_command→Policy_failed, Command_not_allowed evidence, 7-variant invariant

전체: 11/11 + 111/111 pass.

## 합산 Layer 1 진행

| Gate | Status |
|------|--------|
| 1. cdal_verdict | ✅ #7754 |
| 2. verification | ✅ #7759 |
| 3. keeper_fsm | ✅ #7765 |
| 4. accountability | ✅ **this PR** |
| 5. worker_dev_tools | ✅ **this PR** |
| 6. task_transition | 보류 (sub-library 재편 필요) |
| 7. agent_lifecycle | OAS repo 별도 |
| 8. oas_completion | OAS repo 별도 |

masc-mcp 내부 3/3 완료. 전체 5/8 (OAS 2개 + sub-library 재편 1개 남음).

## Depends on

- #7736 (Attribution types) — MERGED

## Test plan

- [x] dune build lib/ clean
- [x] test_keeper_accountability: 11/11
- [x] test_worker_dev_tools: 111/111
- [ ] CI full