### PR TITLE
feat(dashboard/api): migrate operator-action endpoints to valibot schema

### DIFF
--- a/dashboard/src/api/core.ts
+++ b/dashboard/src/api/core.ts
@@ -7,6 +7,7 @@ import type {
   OperatorDigest,
   OperatorSnapshot,
 } from '../types'
+import { parseOperatorActionResult } from './schemas/operator-action'
 import { resolveDashboardActorName, sanitizeDashboardActorName } from '../lib/dashboard-actor'
 
 // --- Auth ---
@@ -483,20 +484,27 @@ function operatorActionTimeoutMs(body: OperatorActionRequest): number {
   }
 }
 
-export function runOperatorAction(body: OperatorActionRequest): Promise<OperatorActionResult> {
-  return post('/api/v1/operator/action', body, undefined, operatorActionTimeoutMs(body))
+export async function runOperatorAction(body: OperatorActionRequest): Promise<OperatorActionResult> {
+  const raw = await post<unknown>(
+    '/api/v1/operator/action',
+    body,
+    undefined,
+    operatorActionTimeoutMs(body),
+  )
+  return parseOperatorActionResult(raw)
 }
 
-export function confirmOperatorAction(
+export async function confirmOperatorAction(
   actor: string,
   confirmToken: string,
   decision: 'confirm' | 'deny' = 'confirm',
 ): Promise<OperatorActionResult> {
-  return post('/api/v1/operator/confirm', {
+  const raw = await post<unknown>('/api/v1/operator/confirm', {
     actor,
     confirm_token: confirmToken,
     decision,
   })
+  return parseOperatorActionResult(raw)
 }
 
 export function fetchOperatorSnapshot(): Promise<OperatorSnapshot> {

--- a/dashboard/src/api/schemas/operator-action.test.ts
+++ b/dashboard/src/api/schemas/operator-action.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  OperatorActionSchemaDriftError,
+  parseOperatorActionResult,
+} from './operator-action'
+
+describe('parseOperatorActionResult', () => {
+  it('accepts a minimal executed result', () => {
+    const out = parseOperatorActionResult({ status: 'ok' })
+    expect(out.status).toBe('ok')
+    expect(out.confirm_required).toBeUndefined()
+  })
+
+  it('accepts a preview result with a confirm token', () => {
+    const out = parseOperatorActionResult({
+      status: 'preview',
+      confirm_required: true,
+      confirm_token: 'abc123',
+      preview: { summary: 'delete 3 tasks', reason: 'user request' },
+    })
+    expect(out.confirm_required).toBe(true)
+    expect(out.confirm_token).toBe('abc123')
+    expect(out.preview).toEqual({ summary: 'delete 3 tasks', reason: 'user request' })
+  })
+
+  it('preserves opaque result and executed_action as unknown', () => {
+    const out = parseOperatorActionResult({
+      status: 'executed',
+      tool_name: 'masc_broadcast',
+      result: { nested: { arbitrary: [1, 2, 3] } },
+      executed_action: 'keeper_message',
+    })
+    expect(out.tool_name).toBe('masc_broadcast')
+    expect(out.result).toEqual({ nested: { arbitrary: [1, 2, 3] } })
+    expect(out.executed_action).toBe('keeper_message')
+  })
+
+  it('accepts the deprecated delegated_tool_result field', () => {
+    const out = parseOperatorActionResult({
+      status: 'executed',
+      delegated_tool_result: { legacy: true },
+    })
+    expect(out.delegated_tool_result).toEqual({ legacy: true })
+  })
+
+  it('throws when status is missing', () => {
+    expect(() => parseOperatorActionResult({})).toThrow(OperatorActionSchemaDriftError)
+  })
+
+  it('throws when status is not a string', () => {
+    expect(() => parseOperatorActionResult({ status: 42 })).toThrow(
+      OperatorActionSchemaDriftError,
+    )
+  })
+
+  it('throws when confirm_required is not a boolean', () => {
+    expect(() => parseOperatorActionResult({ status: 'preview', confirm_required: 'yes' })).toThrow(
+      OperatorActionSchemaDriftError,
+    )
+  })
+
+  it('throws on non-object payload', () => {
+    expect(() => parseOperatorActionResult(null)).toThrow(OperatorActionSchemaDriftError)
+    expect(() => parseOperatorActionResult('oops')).toThrow(OperatorActionSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/operator-action.ts
+++ b/dashboard/src/api/schemas/operator-action.ts
@@ -1,0 +1,50 @@
+// Operator action result schema — schema-at-boundary for
+// `POST /api/v1/operator/action` and `/api/v1/operator/confirm`.
+//
+// `status` is the only always-present field (backend contract).
+// `confirm_required` / `confirm_token` drive the two-step confirm
+// flow. `preview`, `result`, `executed_action`, `delegated_tool_result`
+// are truly opaque — callers render them via JSON pretty-print without
+// branching on shape, so they stay as `unknown()`.
+//
+// Uses the shared `SchemaDriftError` base landed in #7732.
+
+import {
+  boolean,
+  object,
+  optional,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+export const OperatorActionResultSchema = object({
+  status: string(),
+  confirm_required: optional(boolean()),
+  confirm_token: optional(string()),
+  preview: optional(unknown()),
+  tool_name: optional(string()),
+  result: optional(unknown()),
+  /** @deprecated use `result`. Kept for backward compat during migration. */
+  delegated_tool_result: optional(unknown()),
+  executed_action: optional(unknown()),
+})
+
+export type OperatorActionResult = InferOutput<typeof OperatorActionResultSchema>
+
+export class OperatorActionSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('operator-action', issues)
+  }
+}
+
+export function parseOperatorActionResult(data: unknown): OperatorActionResult {
+  return parseOrThrow(
+    OperatorActionSchemaDriftError,
+    OperatorActionResultSchema,
+    data,
+  )
+}

--- a/dashboard/src/types/dashboard-mission.ts
+++ b/dashboard/src/types/dashboard-mission.ts
@@ -573,17 +573,7 @@ export interface OperatorActionRequest {
   payload: Record<string, unknown>
 }
 
-export interface OperatorActionResult {
-  status: string
-  confirm_required?: boolean
-  confirm_token?: string
-  preview?: unknown
-  tool_name?: string
-  result?: unknown
-  /** @deprecated Use result instead. Kept for backward compat during migration. */
-  delegated_tool_result?: unknown
-  executed_action?: unknown
-}
+export type { OperatorActionResult } from '../api/schemas/operator-action'
 
 export interface OperatorActionLogEntry {
   id: number


### PR DESCRIPTION
## Summary

Migrates the two operator mutation endpoints (\`POST /api/v1/operator/action\`, \`POST /api/v1/operator/confirm\`) to schema-at-boundary. Every dashboard-initiated operator action flows through these — previously unvalidated (cast via \`post<OperatorActionResult>\`).

- Adds \`src/api/schemas/operator-action.ts\` — schema + 3-line drift subclass (second consumer of \`SchemaDriftError\` base after #7776).
- \`types/dashboard-mission.ts\` re-exports the type from the schema module; barrel callers unchanged.
- \`api/core.ts\` — both functions route through \`parseOperatorActionResult\`.
- 8 shape tests.

## Drift policy

- \`status\` required; backend contract guarantees on every response.
- \`confirm_required\` / \`confirm_token\` optional (two-step confirm flow).
- \`preview\`, \`result\`, \`executed_action\`, \`delegated_tool_result\` stay \`unknown()\` — callers render them as JSON without branching, so strict typing would over-constrain without caller benefit.

## Caller impact

6 call sites import \`OperatorActionResult\` from \`../types\` barrel — re-export keeps them untouched. Existing \`api/core.test.ts\` (18 tests) passes unmodified.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/schemas/operator-action.test.ts src/api/core.test.ts\` — 26/26 pass (8 new + 18 existing)
- [ ] CI green

Part of #7441.