### PR TITLE
feat(keeper): expand cascade profile type to recognize 8 live presets

### DIFF
--- a/lib/keeper/keeper_cascade_profile.ml
+++ b/lib/keeper/keeper_cascade_profile.ml
@@ -12,6 +12,14 @@ type t =
   | Local_only
   | Local_recovery
   | Tool_rerank
+  | Nick0cave
+  | Capacity_queue_trio
+  | Vendor_mix_balanced
+  | Cost_tier_ladder
+  | Oauth_cli_rotate
+  | Quality_sticky_glm51
+  | Tool_use_strict
+  | Resilient_breaker
 
 let to_string = function
   | Default -> "default"
@@ -20,8 +28,19 @@ let to_string = function
   | Local_only -> "local_only"
   | Local_recovery -> "local_recovery"
   | Tool_rerank -> "tool_rerank"
+  | Nick0cave -> "nick0cave"
+  | Capacity_queue_trio -> "capacity_queue_trio"
+  | Vendor_mix_balanced -> "vendor_mix_balanced"
+  | Cost_tier_ladder -> "cost_tier_ladder"
+  | Oauth_cli_rotate -> "oauth_cli_rotate"
+  | Quality_sticky_glm51 -> "quality_sticky_glm51"
+  | Tool_use_strict -> "tool_use_strict"
+  | Resilient_breaker -> "resilient_breaker"
 
-let all = [ Default; Keeper_unified; Sangsu; Local_only; Local_recovery; Tool_rerank ]
+let all =
+  [ Default; Keeper_unified; Sangsu; Local_only; Local_recovery; Tool_rerank;
+    Nick0cave; Capacity_queue_trio; Vendor_mix_balanced; Cost_tier_ladder;
+    Oauth_cli_rotate; Quality_sticky_glm51; Tool_use_strict; Resilient_breaker ]
 
 (** All known cascade profile names, derived from the variant. Consumers
     that still operate on strings can use this list; new code should
@@ -47,6 +66,14 @@ let of_string_opt (raw : string) : t option =
   | "local_only" -> Some Local_only
   | "local_recovery" -> Some Local_recovery
   | "tool_rerank" -> Some Tool_rerank
+  | "nick0cave" -> Some Nick0cave
+  | "capacity_queue_trio" -> Some Capacity_queue_trio
+  | "vendor_mix_balanced" -> Some Vendor_mix_balanced
+  | "cost_tier_ladder" -> Some Cost_tier_ladder
+  | "oauth_cli_rotate" -> Some Oauth_cli_rotate
+  | "quality_sticky_glm51" -> Some Quality_sticky_glm51
+  | "tool_use_strict" -> Some Tool_use_strict
+  | "resilient_breaker" -> Some Resilient_breaker
   | _ -> None
 
 let canonical (raw : string) : t =

--- a/lib/keeper/keeper_cascade_profile.mli
+++ b/lib/keeper/keeper_cascade_profile.mli
@@ -21,6 +21,19 @@ type t =
   | Local_only
   | Local_recovery
   | Tool_rerank
+  (* v1 active catalog (2026-04-17): keepers route through these via
+     [config/cascade.json] presets. Adding a profile here unlocks lookup
+     for [<name>_models]/[<name>_temperature]/[<name>_max_tokens] keys.
+     Without the variant, [canonicalize] silently collapses the name to
+     [Keeper_unified] and the runtime never reads the user's preset. *)
+  | Nick0cave
+  | Capacity_queue_trio
+  | Vendor_mix_balanced
+  | Cost_tier_ladder
+  | Oauth_cli_rotate
+  | Quality_sticky_glm51
+  | Tool_use_strict
+  | Resilient_breaker
 
 val all : t list
 (** [all] is exhaustive: every variant constructor of {!t} appears

--- a/test/dune
+++ b/test/dune
@@ -44,6 +44,7 @@
         test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
         test_post_verifier
         test_swarm_checkpoint test_swarm_goal_loop
+        test_keeper_cascade_profile
         test_keeper_memory
         test_keeper_accountability
         test_keeper_exec_status
@@ -133,6 +134,7 @@
           test_heartbeat_qw test_sse_qw test_sse_stream test_agent_health
           test_post_verifier
           test_swarm_checkpoint test_swarm_goal_loop
+          test_keeper_cascade_profile
           test_keeper_memory
           test_keeper_accountability
           test_keeper_exec_status

--- a/test/test_keeper_cascade_profile.ml
+++ b/test/test_keeper_cascade_profile.ml
@@ -1,0 +1,64 @@
+open Alcotest
+
+module Profile = Masc_mcp.Keeper_cascade_profile
+
+(* Names that must round-trip [of_string_opt] -> [to_string] without
+   collapsing to default. Pre-2026-04-17 only the first 6 worked; the
+   rest silently fell back to Keeper_unified, so cascade.json presets
+   like vendor_mix_balanced were dead config. *)
+let active_names =
+  [ "default";
+    "keeper_unified";
+    "sangsu";
+    "local_only";
+    "local_recovery";
+    "tool_rerank";
+    "nick0cave";
+    "capacity_queue_trio";
+    "vendor_mix_balanced";
+    "cost_tier_ladder";
+    "oauth_cli_rotate";
+    "quality_sticky_glm51";
+    "tool_use_strict";
+    "resilient_breaker" ]
+
+let test_round_trip () =
+  List.iter
+    (fun name ->
+      let canon = Profile.canonicalize name in
+      check string ("round-trip " ^ name) name canon)
+    active_names
+
+let test_known_cascades_covers_active () =
+  List.iter
+    (fun name ->
+      let listed = List.mem name Profile.known_cascades in
+      check bool ("known_cascades contains " ^ name) true listed)
+    active_names
+
+let test_legacy_aliases_collapse_to_keeper_unified () =
+  let aliases = [ "oas-keeper_unified"; "coding_first"; "oas-coding_first";
+                  "keeper_turn"; "keeper_reply"; "" ] in
+  List.iter
+    (fun raw ->
+      let canon = Profile.canonicalize raw in
+      check string ("alias " ^ raw ^ " -> keeper_unified") "keeper_unified" canon)
+    aliases
+
+let test_unknown_falls_back_to_default () =
+  check (option (testable (fun fmt _ -> Format.fprintf fmt "<profile>") (=)))
+    "unknown returns None from of_string_opt"
+    None
+    (Profile.of_string_opt "definitely_not_a_real_cascade_xyz");
+  check string "canonicalize forces fallback to keeper_unified"
+    "keeper_unified"
+    (Profile.canonicalize "definitely_not_a_real_cascade_xyz")
+
+let () =
+  run "keeper_cascade_profile"
+    [ ( "ssot",
+        [ test_case "active names round-trip" `Quick test_round_trip;
+          test_case "known_cascades covers active" `Quick test_known_cascades_covers_active;
+          test_case "legacy aliases collapse" `Quick test_legacy_aliases_collapse_to_keeper_unified;
+          test_case "unknown falls back to default" `Quick test_unknown_falls_back_to_default ] )
+    ]


### PR DESCRIPTION
## Summary

- cascade.json의 17개 프로필 중 코드가 실제로 인식하던 건 6개뿐이었습니다. `keeper_cascade_profile.of_string_opt`가 그 외 이름을 모두 `None → canonicalize → Keeper_unified`로 collapse해서, `vendor_mix_balanced`, `cost_tier_ladder`, `capacity_queue_trio`, `oauth_cli_rotate`, `quality_sticky_glm51`, `tool_use_strict`, `resilient_breaker`, `nick0cave` 프리셋은 dead config였습니다.
- 결과: keeper TOML에서 cascade_name을 무엇으로 적든 `keeper_unified_*` 키가 lookup되어 대시보드↔런타임↔cascade.json이 서로 다른 상태를 보여주는 SSOT 위반.
- 이 PR은 type t에 8개 variant를 추가하여 cascade.json의 v1 catalog가 코드 레벨에서도 동작하도록 합니다.

## Changes

- `lib/keeper/keeper_cascade_profile.{ml,mli}`: type t에 `Nick0cave, Capacity_queue_trio, Vendor_mix_balanced, Cost_tier_ladder, Oauth_cli_rotate, Quality_sticky_glm51, Tool_use_strict, Resilient_breaker` 8 variant 추가. `to_string`, `of_string_opt`, `all` 동기화.
- `test/test_keeper_cascade_profile.ml` 신설 (Alcotest 4 case): 14개 active name round-trip, known_cascades 커버리지, legacy alias(`oas-keeper_unified`, `coding_first`, `keeper_turn`, `keeper_reply`, `""`) → keeper_unified collapse, unknown name → default fallback.
- `test/dune`: 새 테스트 두 군데 names + modules 리스트에 추가.

## Compatibility

- 6개 기존 variant의 canonicalize 결과는 동일. 기존 keeper는 동일 문자열로 round-trip.
- 레거시 alias도 그대로 keeper_unified로 collapse.
- 새 variant들은 cascade.json에 동일 이름의 `<name>_models` 키가 정의되어 있으므로 실제 lookup이 정상 경로로 연결됩니다 (기존: 모두 keeper_unified_models로 fallback).

## Test plan

- [x] Local: `lib/keeper/keeper_cascade_profile.{ml,mli}` 컴파일 검증 (type t + to_string + of_string_opt 일관성).
- [x] Local: `test/test_keeper_cascade_profile.ml` 4 case 작성.
- [ ] CI: `dune test @keeper_cascade_profile` 통과 대기.
- [ ] CI: 전체 test suite 회귀 없음 확인.

## 배경

`~/me/.masc/config/cascade.json`에서 사용자가 v1 catalog(17 프리셋)을 정의했으나 코드가 이를 인식하지 못해 실질 사용률이 ~12%. 이 PR이 머지되면 keeper TOML의 cascade_name으로 `vendor_mix_balanced` 등을 선언하는 순간 실제 해당 프리셋의 models/temperature/max_tokens가 적용됩니다. keeper 로스터를 1개 cascade(keeper_unified)에 몰아넣던 1-slot semaphore 경합이 자연스럽게 8 cascade로 분산됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)