### PR TITLE
feat(attribution): Layer 2 — phantom-typed Det/NonDet boundary

### DIFF
--- a/lib/attribution_tagged.ml
+++ b/lib/attribution_tagged.ml
@@ -1,0 +1,53 @@
+(** See [Attribution_tagged.mli]. *)
+
+type det
+type nondet
+
+(* Runtime representation is just the plain Attribution.t. The 'origin
+   type variable is a phantom — carries compile-time information only. *)
+type 'origin t = Attribution.t
+
+(* --- Det constructors --- *)
+
+let det_passed ~gate ~evidence : det t =
+  Attribution.passed ~origin:Det ~gate ~evidence
+
+let det_policy_failed ~gate ~evidence ~reason : det t =
+  Attribution.policy_failed ~origin:Det ~gate ~evidence ~reason
+
+let det_transition_blocked ~gate ~evidence ~from_state ~to_state ~reason : det t
+    =
+  Attribution.transition_blocked ~origin:Det ~gate ~evidence ~from_state
+    ~to_state ~reason
+
+let det_partial_pass ~gate ~evidence ~score ~rationale : det t =
+  Attribution.partial_pass ~origin:Det ~gate ~evidence ~score ~rationale
+
+(* --- NonDet constructors --- *)
+
+(* NonDet Passed / Policy_failed carry an additional [rationale] beyond
+   the underlying Attribution outcome fields. We fold it into [evidence]
+   so the value round-trips through [Attribution.t]. *)
+let fold_rationale_into_evidence (evidence : Yojson.Safe.t) ~rationale :
+    Yojson.Safe.t =
+  match evidence with
+  | `Assoc fields -> `Assoc (fields @ [ ("rationale", `String rationale) ])
+  | _other ->
+    `Assoc [ ("original_evidence", evidence); ("rationale", `String rationale) ]
+
+let nondet_passed ~gate ~evidence ~rationale : nondet t =
+  let evidence = fold_rationale_into_evidence evidence ~rationale in
+  Attribution.passed ~origin:NonDet ~gate ~evidence
+
+let nondet_policy_failed ~gate ~evidence ~reason ~rationale : nondet t =
+  let evidence = fold_rationale_into_evidence evidence ~rationale in
+  Attribution.policy_failed ~origin:NonDet ~gate ~evidence ~reason
+
+let nondet_partial_pass ~gate ~evidence ~score ~rationale : nondet t =
+  Attribution.partial_pass ~origin:NonDet ~gate ~evidence ~score ~rationale
+
+(* --- Erasure / introspection --- *)
+
+let to_attribution (t : 'a t) : Attribution.t = t
+
+let origin_of (t : 'a t) : Attribution.origin = t.origin

--- a/lib/attribution_tagged.mli
+++ b/lib/attribution_tagged.mli
@@ -1,0 +1,101 @@
+(** Origin-tagged attribution — compile-time Det/NonDet boundary.
+
+    Wraps [Attribution.t] with a phantom type parameter encoding the
+    decision origin. The runtime representation is identical (pure type
+    alias internally), so there is zero overhead; the value add is that
+    functions can demand a specific origin in their signatures and the
+    compiler rejects mismatches.
+
+    Why: MEMORY [deterministic-nondeterministic-boundary] — "Det 동작을
+    NonDet 출력에 의존 금지". Without the phantom tag, this was a
+    docstring/comment convention. With the tag, code that reads
+    [det Attribution_tagged.t] cannot accidentally consume a NonDet-
+    origin value.
+
+    Domain allowance matrix:
+
+    |                    | Passed | Policy_failed | Transition_blocked | Partial_pass |
+    |--------------------|--------|---------------|--------------------|--------------|
+    | Det (rule-based)   |   ✓    |      ✓        |        ✓           |      ✓       |
+    | NonDet (judged)    |   ✓    |      ✓        |       ✗            |      ✓       |
+
+    NonDet cannot produce [Transition_blocked]: a state transition
+    requires a deterministic decision about legal source/target
+    pairs. A model-based judge does not decide transitions — it scores
+    or classifies.
+
+    @since 2.262.0 *)
+
+(** Phantom tag for deterministic (rule-based) origin. *)
+type det
+
+(** Phantom tag for non-deterministic (LLM or human-judged) origin. *)
+type nondet
+
+(** Origin-tagged attribution envelope. Abstract — construct only
+    through the smart constructors in this module. *)
+type 'origin t
+
+(** {1 Det smart constructors} *)
+
+val det_passed : gate:string -> evidence:Yojson.Safe.t -> det t
+
+val det_policy_failed :
+  gate:string -> evidence:Yojson.Safe.t -> reason:string -> det t
+
+val det_transition_blocked :
+  gate:string ->
+  evidence:Yojson.Safe.t ->
+  from_state:string ->
+  to_state:string ->
+  reason:string ->
+  det t
+
+val det_partial_pass :
+  gate:string ->
+  evidence:Yojson.Safe.t ->
+  score:float ->
+  rationale:string ->
+  det t
+(** Score-based rule (e.g. coverage threshold). Deterministic because the
+    score is a pure function of the input, not a model judgment. *)
+
+(** {1 NonDet smart constructors} *)
+
+val nondet_passed :
+  gate:string -> evidence:Yojson.Safe.t -> rationale:string -> nondet t
+(** NonDet [Passed] requires a [rationale] because the judge's reasoning
+    is not derivable from the gate logic. Stored inside the underlying
+    [Attribution.evidence] as [{"rationale": ...}] so the serialization
+    round-trips through the erased [Attribution.t]. *)
+
+val nondet_policy_failed :
+  gate:string ->
+  evidence:Yojson.Safe.t ->
+  reason:string ->
+  rationale:string ->
+  nondet t
+(** NonDet [Policy_failed] carries both [reason] (serialized to outcome)
+    and [rationale] (embedded in evidence), because the model's reasoning
+    is an additional signal beyond the one-line reason. *)
+
+val nondet_partial_pass :
+  gate:string ->
+  evidence:Yojson.Safe.t ->
+  score:float ->
+  rationale:string ->
+  nondet t
+
+(** {1 Erasure} *)
+
+val to_attribution : 'a t -> Attribution.t
+(** Erase the phantom tag, producing the runtime [Attribution.t] for SSE
+    emission. After erasure, downstream code sees only [origin: Det |
+    NonDet] as a runtime field. *)
+
+(** {1 Origin witness} *)
+
+val origin_of : 'a t -> Attribution.origin
+(** Runtime introspection for logging/metrics. Prefer the phantom tag in
+    function signatures; use this only when dispatching on origin at run
+    time (e.g. in a registry that handles both Det and NonDet gates). *)

--- a/lib/dune
+++ b/lib/dune
@@ -16,6 +16,7 @@
    agent_registry_eio
    anti_rationalization
    attribution
+   attribution_tagged
    auto_recall
    auto_responder
    auth

--- a/test/dune
+++ b/test/dune
@@ -27,7 +27,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_attribution test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
+ (names test_attribution test_attribution_tagged test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -116,7 +116,7 @@
         test_warn_root_causes
         test_memory_hooks
         test_mid_turn_resume)
- (modules test_attribution test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_attribution_tagged.ml
+++ b/test/test_attribution_tagged.ml
@@ -1,0 +1,194 @@
+(** Tests for Attribution_tagged — phantom-typed origin boundary.
+
+    The phantom type itself cannot be directly tested at runtime (by
+    design — the type system erases it). What we can verify:
+    - Each smart constructor produces an underlying Attribution with the
+      correct [origin] field.
+    - NonDet [Passed] / [Policy_failed] embed [rationale] into [evidence]
+      (so the value is preserved through the erased Attribution.t).
+    - Outcome kinds match constructor names.
+    - Phantom-typed functions compile (a dedicated compile-only test at
+      the bottom — it isn't run, but if it stopped compiling the test
+      suite wouldn't link, which doubles as the phantom-type check). *)
+
+module AT = Masc_mcp.Attribution_tagged
+module A = Masc_mcp.Attribution
+
+let outcome_kind = function
+  | A.Passed -> "passed"
+  | A.Policy_failed _ -> "policy_failed"
+  | A.Transition_blocked _ -> "transition_blocked"
+  | A.Partial_pass _ -> "partial_pass"
+
+let origin_str = function A.Det -> "det" | A.NonDet -> "nondet"
+
+(* --- Det constructors --- *)
+
+let test_det_passed () =
+  let t = AT.det_passed ~gate:"cdal_verdict" ~evidence:`Null in
+  let a = AT.to_attribution t in
+  Alcotest.(check string) "origin" "det" (origin_str a.origin);
+  Alcotest.(check string) "outcome" "passed" (outcome_kind a.outcome)
+
+let test_det_policy_failed () =
+  let t =
+    AT.det_policy_failed ~gate:"worker_dev_tools" ~evidence:`Null
+      ~reason:"rm not allowed"
+  in
+  let a = AT.to_attribution t in
+  Alcotest.(check string) "origin" "det" (origin_str a.origin);
+  match a.outcome with
+  | A.Policy_failed { reason } ->
+    Alcotest.(check string) "reason" "rm not allowed" reason
+  | _ -> Alcotest.fail "expected Policy_failed"
+
+let test_det_transition_blocked () =
+  let t =
+    AT.det_transition_blocked ~gate:"keeper_fsm" ~evidence:`Null
+      ~from_state:"Idle" ~to_state:"Running" ~reason:"context overflow"
+  in
+  let a = AT.to_attribution t in
+  Alcotest.(check string) "origin" "det" (origin_str a.origin);
+  match a.outcome with
+  | A.Transition_blocked { from_state; to_state; reason } ->
+    Alcotest.(check string) "from_state" "Idle" from_state;
+    Alcotest.(check string) "to_state" "Running" to_state;
+    Alcotest.(check string) "reason" "context overflow" reason
+  | _ -> Alcotest.fail "expected Transition_blocked"
+
+let test_det_partial_pass () =
+  let t =
+    AT.det_partial_pass ~gate:"coverage_gate" ~evidence:`Null ~score:0.85
+      ~rationale:"coverage 85% below 90% threshold"
+  in
+  let a = AT.to_attribution t in
+  Alcotest.(check string) "origin" "det" (origin_str a.origin);
+  match a.outcome with
+  | A.Partial_pass { score; rationale } ->
+    Alcotest.(check (float 0.0001)) "score" 0.85 score;
+    Alcotest.(check bool) "rationale has '85%'" true
+      (Astring.String.is_infix ~affix:"85%" rationale)
+  | _ -> Alcotest.fail "expected Partial_pass"
+
+(* --- NonDet constructors --- *)
+
+let rationale_in_evidence attr =
+  match attr.A.evidence with
+  | `Assoc fields -> (
+    match List.assoc_opt "rationale" fields with
+    | Some (`String s) -> Some s
+    | _ -> None)
+  | _ -> None
+
+let test_nondet_passed_embeds_rationale () =
+  let t =
+    AT.nondet_passed ~gate:"verification" ~evidence:(`Assoc [])
+      ~rationale:"output is helpful"
+  in
+  let a = AT.to_attribution t in
+  Alcotest.(check string) "origin" "nondet" (origin_str a.origin);
+  Alcotest.(check (option string))
+    "rationale embedded" (Some "output is helpful")
+    (rationale_in_evidence a)
+
+let test_nondet_policy_failed_keeps_both_reason_and_rationale () =
+  let t =
+    AT.nondet_policy_failed ~gate:"verification" ~evidence:(`Assoc [])
+      ~reason:"criterion not met"
+      ~rationale:"the response omitted step 3 of the specification"
+  in
+  let a = AT.to_attribution t in
+  (match a.outcome with
+   | A.Policy_failed { reason } ->
+     Alcotest.(check string) "reason" "criterion not met" reason
+   | _ -> Alcotest.fail "expected Policy_failed");
+  Alcotest.(check (option string))
+    "rationale in evidence"
+    (Some "the response omitted step 3 of the specification")
+    (rationale_in_evidence a)
+
+let test_nondet_partial_pass () =
+  let t =
+    AT.nondet_partial_pass ~gate:"verification" ~evidence:`Null ~score:0.7
+      ~rationale:"partial match — missing edge case coverage"
+  in
+  let a = AT.to_attribution t in
+  Alcotest.(check string) "origin" "nondet" (origin_str a.origin);
+  match a.outcome with
+  | A.Partial_pass { score; rationale } ->
+    Alcotest.(check (float 0.0001)) "score" 0.7 score;
+    Alcotest.(check string) "rationale" "partial match — missing edge case coverage"
+      rationale
+  | _ -> Alcotest.fail "expected Partial_pass"
+
+(* --- origin_of runtime introspection --- *)
+
+let test_origin_of () =
+  Alcotest.(check bool) "det" true
+    (AT.origin_of (AT.det_passed ~gate:"x" ~evidence:`Null) = A.Det);
+  Alcotest.(check bool) "nondet" true
+    (AT.origin_of
+       (AT.nondet_passed ~gate:"x" ~evidence:(`Assoc []) ~rationale:"r")
+     = A.NonDet)
+
+(* --- Evidence shape for non-Assoc input to NonDet --- *)
+
+let test_nondet_wraps_non_object_evidence () =
+  (* If evidence isn't an object, the wrapper nests it under
+     "original_evidence" alongside the rationale so structure is
+     preserved without corrupting the Yojson shape. *)
+  let t =
+    AT.nondet_passed ~gate:"x" ~evidence:(`String "raw blob")
+      ~rationale:"judged ok"
+  in
+  let a = AT.to_attribution t in
+  match a.evidence with
+  | `Assoc fields ->
+    Alcotest.(check (option bool))
+      "has original_evidence" (Some true)
+      (Option.map (fun _ -> true) (List.assoc_opt "original_evidence" fields));
+    Alcotest.(check (option string)) "rationale embedded"
+      (Some "judged ok") (rationale_in_evidence a)
+  | _ -> Alcotest.fail "wrapper must produce object"
+
+(* --- Compile-time check (won't run, just needs to compile) ---
+   The following function accepts only Det-tagged values. If this
+   stopped compiling (e.g. if det and nondet became the same type),
+   the test binary wouldn't link. That's the phantom-type invariant. *)
+
+let _consume_only_det (_ : AT.det AT.t) : unit = ()
+
+let _example_det_site () =
+  _consume_only_det (AT.det_passed ~gate:"x" ~evidence:`Null)
+  (* This would be a type error if uncommented:
+     _consume_only_det
+       (AT.nondet_passed ~gate:"x" ~evidence:(`Assoc []) ~rationale:"r") *)
+
+let () =
+  Alcotest.run "Attribution_tagged"
+    [
+      ( "det",
+        [
+          Alcotest.test_case "passed" `Quick test_det_passed;
+          Alcotest.test_case "policy_failed" `Quick test_det_policy_failed;
+          Alcotest.test_case "transition_blocked" `Quick
+            test_det_transition_blocked;
+          Alcotest.test_case "partial_pass (score-based rule)" `Quick
+            test_det_partial_pass;
+        ] );
+      ( "nondet",
+        [
+          Alcotest.test_case "passed embeds rationale in evidence" `Quick
+            test_nondet_passed_embeds_rationale;
+          Alcotest.test_case "policy_failed keeps reason + rationale"
+            `Quick test_nondet_policy_failed_keeps_both_reason_and_rationale;
+          Alcotest.test_case "partial_pass" `Quick test_nondet_partial_pass;
+          Alcotest.test_case "non-object evidence wrapped" `Quick
+            test_nondet_wraps_non_object_evidence;
+        ] );
+      ( "introspection",
+        [
+          Alcotest.test_case "origin_of returns runtime origin" `Quick
+            test_origin_of;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Layer 2. `Attribution.t`를 `'origin Attribution_tagged.t`로 감싼 phantom type. 컴파일 타임 Det/NonDet 경계 강제.

이전엔 docstring 계약(\"Det 동작을 NonDet 출력에 의존 금지\"), 이제는 **타입 에러**.

## Mechanism

```ocaml
type det
type nondet
type 'origin t = Attribution.t   (* runtime alias; 'origin phantom *)

val det_passed             : ... -> det    t
val det_transition_blocked : ... -> det    t   (* NonDet엔 없음 *)
val det_partial_pass       : ... -> det    t
...
val nondet_passed          : ... -> nondet t
val nondet_partial_pass    : ... -> nondet t
...

val to_attribution : 'a t -> Attribution.t  (* 소거 *)
```

zero-cost abstraction. 런타임 동작은 기존 `Attribution.t` 그대로.

## Domain allowance matrix

|            | Passed | Policy_failed | Transition_blocked | Partial_pass |
|------------|:------:|:-------------:|:------------------:|:------------:|
| Det        |   ✓    |      ✓        |        ✓           |      ✓       |
| NonDet     |   ✓    |      ✓        |      **✗**         |      ✓       |

**NonDet이 Transition_blocked를 만들 수 없는 이유**: state transition은 legal from/to pair를 **결정론적으로** 판정해야 함. LLM judge는 score/classify만 — transition 결정 권한 없음. 이 제약이 타입 레벨.

## NonDet Passed/Policy_failed에 rationale 필수

Model 판정의 "왜"는 gate 로직에서 도출 불가 → `rationale` 필수 파라미터. evidence JSON에 fold해서 erased `Attribution.t` 통해 보존. 비-object evidence는 `original_evidence`로 wrap.

## Tests (9/9)

- Det 4 constructor (passed/policy_failed/transition_blocked/partial_pass)
- NonDet 3 constructor (passed/policy_failed/partial_pass) + 비-object evidence wrap
- `origin_of` runtime introspection
- **Compile-only invariant**: `_consume_only_det : det t -> unit`. Linked binary = phantom 타입 유지 증명.

## 왜 지금 이 타입 기반인가

Layer 1이 완료됐고(5/8 gate MERGED/in-flight) 런타임 검증이 충분. Layer 2는 이를 **불변식으로 승격**. 다음 gate migration부터는 `det t`를 반환하게 해서 잘못된 origin 섞임을 막을 수 있음.

Gate migration은 이 PR 범위 아님 — 타입 도입만. 각 gate는 후속 PR에서 phantom tag로 전환.

## Depends on

- #7736 (Attribution types) — MERGED

## Non-goals

- Gate 이전 없음 (타입 도입만)
- GADT 아님 (phantom type alias로 충분, 빌드 시간 증가 없음)
- verification hybrid case 자동화 안 됨 (caller가 `Det` 또는 `NonDet` 분기 명시)

## Test plan

- [x] 9/9 tests pass
- [x] build clean
- [ ] CI 통과