### PR TITLE
docs(frontmatter): A-category spec frontmatter (batch 1: 13 files)

### DIFF
--- a/docs/spec/00-glossary.md
+++ b/docs/spec/00-glossary.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/types/
+  - lib/tool_dispatch.ml
+  - lib/agent_identity.ml
+---
+
 # MASC Glossary
 
 > Version 2.0.0 | Supersedes: docs/GLOSSARY.md (v1.0.0)

--- a/docs/spec/01-system-overview.md
+++ b/docs/spec/01-system-overview.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - bin/main_eio.ml
+  - bin/main_stdio_eio.ml
+  - dune-project
+---
+
 # 01. System Overview
 
 > Part of: [SPEC-INDEX](./SPEC-INDEX.md)

--- a/docs/spec/02-types-and-invariants.md
+++ b/docs/spec/02-types-and-invariants.md
@@ -1,3 +1,13 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/types/
+  - lib/tool_dispatch.ml
+  - lib/agent_identity.ml
+  - lib/agent_ecosystem.ml
+---
+
 # Types and Invariants
 
 | 항목 | 값 |

--- a/docs/spec/05-keeper-agent.md
+++ b/docs/spec/05-keeper-agent.md
@@ -1,3 +1,10 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+---
+
 # Keeper Agent System
 
 | 항목 | 값 |

--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -1,3 +1,15 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/server/
+  - lib/grpc/
+  - lib/sse.ml
+  - lib/transport.ml
+  - bin/main_eio.ml
+  - bin/main_stdio_eio.ml
+---
+
 # Server & Transport
 
 | 항목 | 값 |

--- a/docs/spec/10-dashboard.md
+++ b/docs/spec/10-dashboard.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/dashboard/
+  - lib/dashboard.ml
+  - dashboard/
+---
+
 # Dashboard
 
 | 항목 | 값 |

--- a/docs/spec/11-board.md
+++ b/docs/spec/11-board.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/board.ml
+  - lib/board_types/
+  - lib/tool_board.ml
+---
+
 # Board System
 
 | 항목 | 값 |

--- a/docs/spec/13-oas-integration.md
+++ b/docs/spec/13-oas-integration.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/verifier_oas.ml
+  - lib/memory_oas_bridge.ml
+  - lib/worker_oas.ml
+---
+
 # OAS Integration
 
 | 항목 | 값 |

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/config/
+  - lib/env_config.mli
+  - config/
+---
+
 # Configuration
 
 | 항목 | 값 |

--- a/docs/spec/15-testing.md
+++ b/docs/spec/15-testing.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - test/
+  - lib/eval_gate.ml
+  - lib/eval_harness.ml
+---
+
 # Testing
 
 | 항목 | 값 |

--- a/docs/spec/A-existing-doc-index.md
+++ b/docs/spec/A-existing-doc-index.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - docs/
+  - docs/_audit/2026-04-17-doc-classification.md
+---
+
 # Appendix A: Existing Documentation Index
 
 > 목적: tracked 문서를 `front door / maintained reference / historical / archive / cleanup action`으로 다시 분류한다.

--- a/docs/spec/C-implementation-status.md
+++ b/docs/spec/C-implementation-status.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/
+  - dune-project
+  - lib/sdk_version.ml
+---
+
 # Appendix C: Implementation Status Report
 
 > Generated: 2026-03-23 | Updated: 2026-04-08 (sweep) | Baseline: v2.138.0

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - docs/spec/
+  - dune-project
+  - lib/sdk_version.ml
+---
+
 # MASC Specification Index
 
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`


### PR DESCRIPTION
## Summary

FRONTMATTER PR from docs/_audit/2026-04-17-doc-classification.md (step 4).
Adds YAML frontmatter to A-category spec files with verified code_refs.

Applied to **13 files** under docs/spec/:

- SPEC-INDEX.md
- 00-glossary.md
- 01-system-overview.md
- 02-types-and-invariants.md
- 05-keeper-agent.md
- 09-server-transport.md
- 10-dashboard.md
- 11-board.md
- 13-oas-integration.md
- 14-configuration.md
- 15-testing.md
- A-existing-doc-index.md
- C-implementation-status.md

Each file gets:

\`\`\`yaml
---
status: reference
last_verified: 2026-04-17
code_refs:
  - <verified path>
  - ...
---
\`\`\`

## Drift findings (surfaced, not silenced)

Three A-category spec files were **skipped** for re-classification:

| File | Reason |
|------|--------|
| 03-room-coordination.md | lib/room/ removed, moved into lib/coord/ |
| 04-chain-engine.md | Maps-to: lib/chain/ (removed). No lib/chain* present |
| 12-memory-systems.md | Partial drift in Maps-to paths |

## Scope

This is batch 1 of the FRONTMATTER step. Remaining 68 A-category docs
(top-level, design/, audits/, observability/, qa/, rfc/, etc.) are
separate follow-up batches.

## Test plan

- [x] All added code_refs exist (verified via [ -f ] / [ -d ] pre-commit)
- [x] Files remain valid markdown with YAML frontmatter block at top
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)