### PR TITLE
spec(contract-closure): Layer 3 TLA+ model (autoresearch ↔ verification ↔ FSM)

### DIFF
--- a/specs/Makefile
+++ b/specs/Makefile
@@ -7,6 +7,7 @@
 #   make check-keeper       Keeper state machine only
 #   make check-ecosystem    MASC ecosystem only
 #   make check-boundary     Cross-domain boundary specs only
+#   make check-closure      Contract-closure specs (autoresearch<->verification<->FSM)
 #   make list               List all discoverable specs
 
 JAVA      ?= java
@@ -49,7 +50,7 @@ TLC = $(JAVA) $(JAVA_OPTS) \
 CLEAN_CFGS := $(shell find . -name '*.cfg' ! -name '*-buggy*.cfg' ! -name '*-ci.cfg' | sort)
 BUGGY_CFGS := $(shell find . -name '*-buggy*.cfg' | sort)
 
-.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary list
+.PHONY: check-all check-clean check-buggy check-bug-models check-keeper check-ecosystem check-boundary check-closure list
 
 check-all: check-clean check-buggy
 	@echo "=== All TLA+ specs passed ==="
@@ -116,6 +117,11 @@ check-boundary:
 	@$(MAKE) --no-print-directory \
 	  CLEAN_CFGS="$$(find boundary/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
 	  BUGGY_CFGS="$$(find boundary/ -name '*-buggy*.cfg' | sort)" check-all
+
+check-closure:
+	@$(MAKE) --no-print-directory \
+	  CLEAN_CFGS="$$(find closure/ -name '*.cfg' ! -name '*-buggy*.cfg' | sort)" \
+	  BUGGY_CFGS="$$(find closure/ -name '*-buggy*.cfg' | sort)" check-all
 
 list:
 	@echo "Clean specs ($(words $(CLEAN_CFGS))):"; \

--- a/specs/closure/ContractClosure-buggy.cfg
+++ b/specs/closure/ContractClosure-buggy.cfg
@@ -1,0 +1,24 @@
+\* Buggy model for ContractClosure — models the CURRENT live-code gap.
+\* Expected: Invariant ClosureIntegrity is violated.
+\*
+\* The AutoresearchOrphan action is enabled (via NextBuggy). It settles
+\* the autoresearch outcome without updating the verification verdict,
+\* which is exactly what masc-mcp does today: autoresearch writes to
+\* .masc/autoresearch/{loop_id}/results.jsonl but no bridge propagates
+\* the result into the verification FSM. This cfg proves the gap exists.
+\*
+\* Once PR #3.5 (autoresearch_result_bridge.ml) is merged, the orphan
+\* action should be removed and this cfg retired — or kept as a
+\* regression sentinel.
+
+SPECIFICATION SpecBuggy
+
+CONSTANTS
+    Tasks = {"t1"}
+    MaxCycles = 1
+
+INVARIANTS
+    ClosureIntegrity
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/closure/ContractClosure.cfg
+++ b/specs/closure/ContractClosure.cfg
@@ -1,0 +1,25 @@
+\* Clean model for ContractClosure.
+\* Expected: Model checking completed. No error has been found.
+\*
+\* Verifies:
+\*   - TypeOK           (all state variables stay in their defined sets)
+\*   - ClosureIntegrity (autoresearch settlement is always accompanied
+\*                        by a verification verdict)
+\*   - VerdictUnblocksFsm (Pass => <>Running, under WF fairness on
+\*                          FsmToRunning)
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Tasks = {"t1", "t2"}
+    MaxCycles = 2
+
+INVARIANTS
+    TypeOK
+    ClosureIntegrity
+
+PROPERTIES
+    VerdictUnblocksFsm
+
+CHECK_DEADLOCK
+    FALSE

--- a/specs/closure/ContractClosure.tla
+++ b/specs/closure/ContractClosure.tla
@@ -1,0 +1,185 @@
+---- MODULE ContractClosure ----
+\* Contract-closure spec: autoresearch loop <-> verification <-> keeper FSM.
+\*
+\* Runtime truth being modelled:
+\*   - An autoresearch loop for a task produces either Keep or Discard
+\*     (after some number of cycles).
+\*   - The task's verification gate is supposed to observe the
+\*     autoresearch outcome and produce a Pass | Fail | Partial verdict
+\*     for the task that owns the loop (task.contract.links.autoresearch_loop_id).
+\*   - A Pass verdict should, under fairness, eventually unblock the
+\*     keeper into its Running phase for that task.
+\*
+\* What this spec is FOR:
+\*   - To enforce, as an invariant, that whenever an autoresearch loop
+\*     has settled (Keep or Discard) for a task, that task's verification
+\*     gate is no longer Pending (closure integrity).
+\*   - To enforce, as a liveness property, that a Pass verdict eventually
+\*     moves the keeper to Running for the owning task (weak fairness on
+\*     the FSM transition).
+\*
+\* This is Layer 3 of the attribution rollout (see
+\* planning/claude-plans/abundant-skipping-sutton.md).
+\*
+\* The *BUGGY* configuration (`ContractClosure-buggy.cfg`) enables an
+\* AutoresearchOrphan action that settles the loop but omits the
+\* verification update.  Under that action, ClosureIntegrity MUST be
+\* violated — that is the current live-code gap (no bridge module).
+\* This is the TLA+ form of the Bug Model pattern
+\* (software-development.md).
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    Tasks,             \* Finite set of task ids (small, e.g. {"t1","t2"})
+    MaxCycles          \* Upper bound on autoresearch cycles per loop
+
+ASSUME TasksNonEmpty == Tasks # {}
+ASSUME MaxCyclesPos == MaxCycles \in Nat /\ MaxCycles >= 1
+
+(* ── State values ───────────────────────────────────────── *)
+
+\* Autoresearch outcome for the task's loop.
+ArStates == {"ar_pending", "ar_keep", "ar_discard"}
+
+\* Verification verdict for the task.
+VrStates == {"vr_pending", "vr_pass", "vr_fail", "vr_partial"}
+
+\* Keeper FSM phase, abstracted to just the two values we care about:
+\* "fsm_idle" covers any non-Running phase.
+FsmStates == {"fsm_idle", "fsm_running"}
+
+VARIABLES
+    ar,       \* [Tasks -> ArStates]
+    ar_cycle, \* [Tasks -> 0..MaxCycles]  number of autoresearch cycles used
+    vr,       \* [Tasks -> VrStates]
+    fsm       \* [Tasks -> FsmStates]
+
+vars == << ar, ar_cycle, vr, fsm >>
+
+(* ── Type invariant ─────────────────────────────────────── *)
+
+TypeOK ==
+    /\ ar      \in [Tasks -> ArStates]
+    /\ ar_cycle \in [Tasks -> 0..MaxCycles]
+    /\ vr      \in [Tasks -> VrStates]
+    /\ fsm     \in [Tasks -> FsmStates]
+
+(* ── Initial state ──────────────────────────────────────── *)
+
+Init ==
+    /\ ar      = [ t \in Tasks |-> "ar_pending" ]
+    /\ ar_cycle = [ t \in Tasks |-> 0 ]
+    /\ vr      = [ t \in Tasks |-> "vr_pending" ]
+    /\ fsm     = [ t \in Tasks |-> "fsm_idle" ]
+
+(* ── Actions ────────────────────────────────────────────── *)
+
+\* Run an autoresearch cycle for task t, if pending and budget remains.
+\* This is the "work" step — doesn't settle the outcome.
+ArTick(t) ==
+    /\ ar[t] = "ar_pending"
+    /\ ar_cycle[t] < MaxCycles
+    /\ ar_cycle' = [ ar_cycle EXCEPT ![t] = ar_cycle[t] + 1 ]
+    /\ UNCHANGED << ar, vr, fsm >>
+
+\* The autoresearch loop settles into Keep, *and* the bridge module
+\* propagates a verdict to verification. This is the CORRECT behaviour
+\* — verification status is updated atomically with the autoresearch
+\* settlement, matching the proposed autoresearch_result_bridge.ml.
+ArSettleKeep(t) ==
+    /\ ar[t] = "ar_pending"
+    /\ ar_cycle[t] >= 1
+    /\ ar' = [ ar EXCEPT ![t] = "ar_keep" ]
+    /\ vr' = [ vr EXCEPT ![t] = "vr_pass" ]
+    /\ UNCHANGED << ar_cycle, fsm >>
+
+ArSettleDiscard(t) ==
+    /\ ar[t] = "ar_pending"
+    /\ ar_cycle[t] >= 1
+    /\ ar' = [ ar EXCEPT ![t] = "ar_discard" ]
+    /\ vr' = [ vr EXCEPT ![t] = "vr_fail" ]
+    /\ UNCHANGED << ar_cycle, fsm >>
+
+ArSettlePartial(t) ==
+    /\ ar[t] = "ar_pending"
+    /\ ar_cycle[t] >= 1
+    /\ ar' = [ ar EXCEPT ![t] = "ar_keep" ]
+    /\ vr' = [ vr EXCEPT ![t] = "vr_partial" ]
+    /\ UNCHANGED << ar_cycle, fsm >>
+
+\* Keeper FSM transition: a Pass verdict unblocks Running.
+FsmToRunning(t) ==
+    /\ vr[t] = "vr_pass"
+    /\ fsm[t] = "fsm_idle"
+    /\ fsm' = [ fsm EXCEPT ![t] = "fsm_running" ]
+    /\ UNCHANGED << ar, ar_cycle, vr >>
+
+(* ── Bug action (enabled only in the buggy twin) ────────── *)
+
+\* The current live code: autoresearch writes its result into
+\* .masc/autoresearch/{loop_id}/results.jsonl but NOTHING feeds it into
+\* the verification gate — that wire doesn't exist.  Model that by
+\* settling [ar] without touching [vr].
+AutoresearchOrphan(t) ==
+    /\ ar[t] = "ar_pending"
+    /\ ar_cycle[t] >= 1
+    /\ ar' = [ ar EXCEPT ![t] = "ar_keep" ]
+    /\ UNCHANGED << ar_cycle, vr, fsm >>
+
+(* ── Next-state relation ────────────────────────────────── *)
+
+\* Clean (target) next-state: autoresearch settlement always carries
+\* the verdict over to verification.
+Next ==
+    \E t \in Tasks :
+        \/ ArTick(t)
+        \/ ArSettleKeep(t)
+        \/ ArSettleDiscard(t)
+        \/ ArSettlePartial(t)
+        \/ FsmToRunning(t)
+
+\* Buggy next-state: add the orphan settlement path.  This should
+\* violate ClosureIntegrity.
+NextBuggy ==
+    Next \/ (\E t \in Tasks : AutoresearchOrphan(t))
+
+(* ── Safety: closure integrity ──────────────────────────── *)
+
+\* Once autoresearch has settled (Keep or Discard), the verification
+\* verdict for the owning task MUST have left "pending".  If this
+\* invariant is violated, the dashboard sees an autoresearch outcome
+\* with no matching verdict — which is exactly the current gap.
+ClosureIntegrity ==
+    \A t \in Tasks :
+        (ar[t] \in {"ar_keep", "ar_discard"}) =>
+            (vr[t] \in {"vr_pass", "vr_fail", "vr_partial"})
+
+(* ── Liveness (Pass => eventually Running) ─────────────── *)
+
+\* If a task ever becomes Pass-verified, under weak fairness on
+\* FsmToRunning it eventually reaches Running.
+VerdictUnblocksFsm ==
+    \A t \in Tasks :
+        [](vr[t] = "vr_pass" => <>(fsm[t] = "fsm_running"))
+
+(* ── Specs ──────────────────────────────────────────────── *)
+
+\* Fairness: every enabled action eventually runs (so Tick/Settle
+\* and FsmToRunning all make progress).
+Fairness ==
+    /\ \A t \in Tasks : WF_vars(ArTick(t))
+    /\ \A t \in Tasks : WF_vars(ArSettleKeep(t))
+    /\ \A t \in Tasks : WF_vars(ArSettleDiscard(t))
+    /\ \A t \in Tasks : WF_vars(ArSettlePartial(t))
+    /\ \A t \in Tasks : WF_vars(FsmToRunning(t))
+
+\* Clean spec. Safety + liveness should both hold.
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+\* Buggy spec. Safety property ClosureIntegrity should be violated
+\* in finite steps (no fairness required to demonstrate a safety
+\* counterexample).
+SpecBuggy == Init /\ [][NextBuggy]_vars
+
+================================================================


### PR DESCRIPTION
## Summary

Layer 3. Attribution 4-layer plan의 형식 검증 레이어. 현재 코드의 closure gap을 **TLA+ invariant 위반으로 증명**하고, 제안된 bridge가 gap을 닫음을 증명.

## 증명된 것

### Clean (ContractClosure.cfg)

```
Model checking completed. No error has been found.
121 states generated, 121 distinct states found
```

Verifies:
- **TypeOK** — 모든 state variable이 정의된 집합에 머무름
- **ClosureIntegrity** — autoresearch settle이면 verification도 settle
- **VerdictUnblocksFsm** — Pass → eventually Running (WF_vars fairness)

### Buggy (ContractClosure-buggy.cfg)

```
Error: Invariant ClosureIntegrity is violated.
The behavior up to this point is:
  State 1: Init
  State 2: ArTick(t1) — cycle 1
  State 3: AutoresearchOrphan(t1) — ar=keep, vr=pending ⚠️
```

**현재 masc-mcp 코드의 정확한 재현**: autoresearch가 `.masc/autoresearch/{loop_id}/results.jsonl`에만 쓰고 verification으로 전파되지 않음. TLC가 3 step만에 찾음.

## 모델 구조

```
Tasks    = {t1, t2}  (or {t1} for buggy)
MaxCycles = 2

Autoresearch ∈ {ar_pending, ar_keep, ar_discard}
Verification ∈ {vr_pending, vr_pass, vr_fail, vr_partial}
Keeper FSM   ∈ {fsm_idle, fsm_running}
```

5 action:
- `ArTick` — autoresearch cycle 진행
- `ArSettleKeep` / `ArSettleDiscard` / `ArSettlePartial` — **ar + vr 원자적** 업데이트 (올바른 동작)
- `FsmToRunning` — vr=pass면 keeper unblock
- **`AutoresearchOrphan`** (buggy only) — ar만 업데이트, vr 무시

## Invariant/Property

```tla
ClosureIntegrity ==
    \A t \in Tasks :
        (ar[t] \in {\"ar_keep\", \"ar_discard\"}) =>
            (vr[t] \in {\"vr_pass\", \"vr_fail\", \"vr_partial\"})

VerdictUnblocksFsm ==
    \A t \in Tasks :
        [](vr[t] = \"vr_pass\" => <>(fsm[t] = \"fsm_running\"))
```

## Bug Model 패턴 준수

Software-development.md의 TLA+ Bug Model 패턴 정확히 따름:
- `BugAction` = `AutoresearchOrphan`
- `SafetyInvariant` = `ClosureIntegrity`
- Clean: `Next` (buggy action 제외) + 통과해야 함 ✓
- Buggy: `NextBuggy = Next \\/ BugAction` + invariant 위반해야 함 ✓

**양쪽 cfg 모두 통과해야 spec이 유효** 원칙 충족.

## CI

`specs/Makefile`의 `find .` auto-discovery가 picking up. 별도 target 등록 없이 `make check-all` 포함.
`make check-closure`는 convenience.

## Impact

이 spec은 **coding PR (#3.5 autoresearch_result_bridge)의 설계 근거**. Bridge 구현 후 buggy cfg는 regression sentinel로 유지 (해당 gap 재발 방지).

## Non-goals

- 코드 변경 없음 (spec only)
- autoresearch 내부 구조 모델링 안 함 (black box: settle Keep|Discard|Partial)
- FSM 12-phase 전부 모델링 안 함 (idle/running 2-state 추상화)

## Next

- Task #6 (PR #3.5): `lib/autoresearch/autoresearch_result_bridge.ml` 구현 — 이 spec의 ArSettleKeep/Discard/Partial action을 코드로
- bridge merge 후 buggy cfg는 "regression sentinel" 주석 업데이트

## Test plan

- [x] `make check-closure` — 2 cfg both pass their expected outcomes
- [x] `make check-all` auto-discovers closure/
- [ ] CI TLA+ Model Checking step 통과