### PR TITLE
chore(doc-truth): regression locks for retired surfaces (team_session / chain)

### DIFF
--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -116,6 +116,22 @@ require_not_contains docs/spec/10-dashboard.md '| `/api/v1/keepers/:name/config`
 require_not_contains docs/spec/10-dashboard.md '| `/api/v1/command-plane` | GET |'
 require_not_contains docs/spec/10-dashboard.md 'command-plane.ts         -- Command plane types'
 
+# Regression locks for retired surfaces (team_session / chain purge).
+# Each lock pins an already-merged PR claim so future doc edits
+# cannot silently re-introduce the stale description.
+
+# PR #7773: Team Session glossary marked retired (module purged)
+require_contains docs/spec/00-glossary.md '## Team Session (retired)'
+require_contains docs/spec/00-glossary.md '**Team Session** (retired)'
+
+# PR #7779: OAS-MASC boundary marks team-session bridge as Removed
+require_contains docs/OAS-MASC-BOUNDARY.md '| Team-session swarm | Removed |'
+require_not_contains docs/OAS-MASC-BOUNDARY.md '| `lib/team_session/team_session_oas_bridge.ml` | Acceptable'
+
+# PR #7747: 04-chain-engine.md archived with explicit banner
+require_contains docs/spec/04-chain-engine.md '# Chain Engine — ARCHIVED'
+require_contains docs/spec/04-chain-engine.md '| Status | Archived |'
+
 docs_to_scan=(
   README.md
   ROADMAP.md


### PR DESCRIPTION
## Summary

`check-doc-truth.sh`에 **6개 regression lock** 추가. 이 세션(Gen2-15)에서
merged된 drift cleanup PR이 미래에 silent drift로 되돌아오지 않도록
구조적 gate 강화.

## Motivation

Gen5 교훈: fresh-context agent (`/simplify`)가 "cleanup"이라는 명목으로
retired marker를 제거하는 **drift-for-drift 안티패턴**이 실제 발생.
`check-doc-truth.sh`의 `require_contains` assertion만이 궁극적 verification.

## Changes

`scripts/check-doc-truth.sh` 한 파일, 6 새 assertion:

### PR #7773 lock (Team Session glossary retired)
- `require_contains docs/spec/00-glossary.md '## Team Session (retired)'`
- `require_contains docs/spec/00-glossary.md '**Team Session** (retired)'`

### PR #7779 lock (OAS-MASC boundary team-session removed)
- `require_contains docs/OAS-MASC-BOUNDARY.md '| Team-session swarm | Removed |'`
- `require_not_contains docs/OAS-MASC-BOUNDARY.md '| \`lib/team_session/team_session_oas_bridge.ml\` | Acceptable'`

### PR #7747 lock (04-chain-engine archived)
- `require_contains docs/spec/04-chain-engine.md '# Chain Engine — ARCHIVED'`
- `require_contains docs/spec/04-chain-engine.md '| Status | Archived |'`

## Validation

- `bash scripts/check-doc-truth.sh` → `Doc truth OK`
- 추가된 모든 assertion 현재 repo에서 green
- Doc-truth CI job은 unchanged (같은 script 호출)

## Design Note

각 lock은 **single merged PR claim** 하나를 pin — 편집자가 실수로
retired marker를 제거하면 즉시 fail하며 어떤 PR이 역행했는지 주석으로
추적 가능. 전체 doc 재작성 등 의도적 archive policy 변경은 이 lock도 함께
제거하는 명시적 PR로 진행하면 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)