### PR TITLE
docs(frontmatter): A-category top-level runbooks (batch 2: 8 files)

### DIFF
--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - scripts/harness_keeper_campaign.sh
+  - scripts/harness_agent_swarm_live.sh
+  - test/
+---
+
 # Benchmark Runbook
 
 이 문서는 `single-agent baseline`과 managed-operation swarm lane을 같은 workload에 걸어 비교할 때 쓰는 운영 레시피다.

--- a/docs/BOOT-ENV-STATE-INVENTORY.md
+++ b/docs/BOOT-ENV-STATE-INVENTORY.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/config/
+  - lib/env_config.mli
+  - start-masc-mcp.sh
+---
+
 # Boot, Path, and Runtime State Inventory
 
 This document answers four operator questions:

--- a/docs/KEEPER-CAMPAIGN-HARNESS.md
+++ b/docs/KEEPER-CAMPAIGN-HARNESS.md
@@ -1,3 +1,11 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - scripts/harness_keeper_campaign.sh
+  - lib/keeper/
+---
+
 # Keeper Campaign Harness
 
 `keeper campaign harness`는 기존 keeper 하나가 장기 goal을 들고 task를 claim한 뒤,

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -1,3 +1,11 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - config/
+---
+
 # MASC Keeper 사용자 매뉴얼
 
 **Version**: 1.0.0

--- a/docs/MCP-TEMPLATE.md
+++ b/docs/MCP-TEMPLATE.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - bin/main_stdio_eio.ml
+  - start-masc-mcp.sh
+---
+
 # MCP Config Template
 
 `~/.mcp.json`에 아래 항목을 추가하세요. 이미 `mcpServers`가 있으면 병합합니다.

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - start-masc-mcp.sh
+  - bin/main_eio.ml
+  - bin/main_stdio_eio.ml
+---
+
 # MASC Quick Start
 
 이 문서는 `처음 띄우고`, `연결하고`, `첫 작업을 시작하는` 데 필요한 최소 절차만 모은다.

--- a/docs/SUPERVISOR-MODE.md
+++ b/docs/SUPERVISOR-MODE.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/supervisor.ml
+  - bin/masc_tui.ml
+  - scripts/harness_supervisor_execution_session.sh
+---
+
 # Supervisor Mode
 
 Supervisor Mode is the interactive TUI operating model for steering a MASC supervised execution session through MCP.

--- a/docs/TUI-GUIDE.md
+++ b/docs/TUI-GUIDE.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - bin/masc_tui.ml
+  - bin/masc_tui_render.ml
+  - bin/masc_tui_loader.ml
+---
+
 # MASC TUI Guide
 
 Terminal UI for monitoring and interacting with MASC keepers.


### PR DESCRIPTION
## Summary

Batch 2 of FRONTMATTER PR from `docs/_audit/2026-04-17-doc-classification.md`.

Adds YAML frontmatter to 8 operator-facing top-level docs:

- QUICK-START.md
- SUPERVISOR-MODE.md
- TUI-GUIDE.md
- KEEPER-USER-MANUAL.md
- KEEPER-CAMPAIGN-HARNESS.md
- BENCHMARK-RUNBOOK.md
- BOOT-ENV-STATE-INVENTORY.md
- MCP-TEMPLATE.md

All `code_refs` verified against the current tree:

- `start-masc-mcp.sh`
- `lib/supervisor.ml`
- `bin/masc_tui*.ml`
- `scripts/harness_keeper_campaign.sh`, `scripts/harness_agent_swarm_live.sh`, `scripts/harness_supervisor_execution_session.sh`
- `lib/keeper/`, `lib/config/`

## Status values

- `runbook` — operator procedures (setup, benchmarking, supervised ops)
- `reference` — configuration / inventory

## Scope

Batch 1 (spec) is #7784 (still draft). Remaining A-category docs in
`design/`, `audits/`, `observability/`, `qa/`, `rfc/`, `tla-audit/`,
and the rest of top-level are separate follow-up batches.

## Test plan

- [x] Every `code_refs` path verified with `[ -e ]`
- [x] YAML frontmatter block placed at very top of each file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)