### PR TITLE
docs(frontmatter): A-category architecture/boundary refs (batch 3: 12 files)

### DIFF
--- a/docs/ADR-003-FEATURE-FLAG-REGISTRY-MANAGEMENT.md
+++ b/docs/ADR-003-FEATURE-FLAG-REGISTRY-MANAGEMENT.md
@@ -1,3 +1,10 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/config/feature_flag_registry.ml
+---
+
 # ADR-003: Feature Flag Registry Management - 중복과 불일치 방지 전략
 
 **Status**: Accepted

--- a/docs/CAPABILITY-REGISTRY-SSOT.md
+++ b/docs/CAPABILITY-REGISTRY-SSOT.md
@@ -1,3 +1,10 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/capability_registry.ml
+---
+
 # Capability Registry SSOT
 
 This document defines the canonical split between:

--- a/docs/CELLULAR-AGENT.md
+++ b/docs/CELLULAR-AGENT.md
@@ -1,3 +1,10 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/handover_eio.ml
+---
+
 # Context Handoff Pattern
 
 **Legacy name**: Cellular Agent Pattern

--- a/docs/CONFIG-DOCTOR.md
+++ b/docs/CONFIG-DOCTOR.md
@@ -1,3 +1,11 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - bin/main_eio.ml
+  - lib/config/
+---
+
 # Config Doctor
 
 `main_eio.exe doctor` is the canonical operator path for answering:

--- a/docs/ENV-CONTRACT.md
+++ b/docs/ENV-CONTRACT.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/env_config.mli
+  - lib/config/
+---
+
 # Environment Variable Contract
 
 This document defines the operator-facing contract for environment variables in

--- a/docs/KEEPER-CAPABILITY-MATRIX.md
+++ b/docs/KEEPER-CAPABILITY-MATRIX.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - lib/tool_dispatch.ml
+---
+
 # Keeper Capability Matrix
 
 Keepers do not receive the full public MCP surface.

--- a/docs/KEEPER-FILE-MODEL.md
+++ b/docs/KEEPER-FILE-MODEL.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - config/
+---
+
 # Keeper File Model
 
 **Status**: Active  

--- a/docs/OAS-MASC-BOUNDARY.md
+++ b/docs/OAS-MASC-BOUNDARY.md
@@ -1,3 +1,13 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/oas.ml
+  - lib/oas_worker.ml
+  - lib/verifier_oas.ml
+  - lib/memory_oas_bridge.ml
+---
+
 # OAS-MASC Boundary Contract
 
 OAS (OCaml Agent SDK)와 MASC-MCP 사이의 역할 경계를 정의한다.

--- a/docs/PROVIDER-ADAPTER-RUNBOOK.md
+++ b/docs/PROVIDER-ADAPTER-RUNBOOK.md
@@ -1,3 +1,11 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/provider_adapter.ml
+  - lib/provider_adapter.mli
+---
+
 # Provider Adapter Runbook
 
 이 문서는 `MASC`에서 provider/runtime/auth를 어떻게 나누는지에 대한 SSOT다.

--- a/docs/TOML-RELOAD-MATRIX.md
+++ b/docs/TOML-RELOAD-MATRIX.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - scripts/check-doc-truth.sh
+  - config/
+---
+
 # TOML Reload Matrix
 
 This document separates TOML-backed configuration by load point and reload

--- a/docs/VERSIONED-ROADMAP.md
+++ b/docs/VERSIONED-ROADMAP.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - ROADMAP.md
+  - dune-project
+  - CHANGELOG.md
+---
+
 # masc-mcp Versioned Roadmap — Feature Trains First
 
 > Last updated: 2026-04-09

--- a/docs/architecture-boundary.md
+++ b/docs/architecture-boundary.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/oas.ml
+  - lib/oas_worker.ml
+  - lib/verifier_oas.ml
+---
+
 # MASC-OAS Architecture Boundary
 
 This document defines the boundary between MASC (coordination layer) and OAS (agent execution layer).


### PR DESCRIPTION
## Summary

Batch 3 of FRONTMATTER PR from `docs/_audit/2026-04-17-doc-classification.md`.

Adds YAML frontmatter to 12 architecture, boundary, and SSOT reference docs.

## Files

- ADR-003-FEATURE-FLAG-REGISTRY-MANAGEMENT.md
- architecture-boundary.md
- CAPABILITY-REGISTRY-SSOT.md
- CELLULAR-AGENT.md
- CONFIG-DOCTOR.md
- ENV-CONTRACT.md
- KEEPER-CAPABILITY-MATRIX.md
- KEEPER-FILE-MODEL.md
- OAS-MASC-BOUNDARY.md
- PROVIDER-ADAPTER-RUNBOOK.md
- TOML-RELOAD-MATRIX.md
- VERSIONED-ROADMAP.md

## Verified code_refs

- `lib/oas.ml`, `lib/oas_worker.ml`, `lib/verifier_oas.ml`
- `lib/capability_registry.ml`
- `lib/handover_eio.ml`
- `lib/provider_adapter.ml` + `.mli`
- `lib/config/feature_flag_registry.ml`
- `lib/env_config.mli`, `lib/config/`
- `lib/keeper/`
- `bin/main_eio.ml`
- `scripts/check-doc-truth.sh`
- `ROADMAP.md`, `CHANGELOG.md`, `dune-project`

Every path validated with `[ -e ]` before commit. Audit's Maps-to drift
found in earlier batches (lib/room/, lib/chain/, lib/mode.ml) does not
apply to this batch.

## Batch progress so far

| Batch | PR | Files |
|-------|-----|-------|
| 1 spec | #7784 | 13 |
| 2 runbooks | #7791 | 8 |
| 3 arch (this) | — | 12 |
| remaining | — | ~48 |

## Test plan

- [x] Every `code_refs` path verified with `[ -e ]`
- [x] YAML frontmatter at top of each file
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)