### PR TITLE
feat(tasks): add cycle_count + do_not_reclaim_reason fields (schema only)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -337,6 +337,8 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
         stage = None;
         contract;
         handoff_context = None;
+        cycle_count = 0;
+        do_not_reclaim_reason = None;
       } in
 
       let new_backlog = {
@@ -398,6 +400,8 @@ let add_task_with_role ?contract config ~title ~priority ~description
         stage = None;
         contract;
         handoff_context = None;
+        cycle_count = 0;
+        do_not_reclaim_reason = None;
       } in
 
       let new_backlog = {
@@ -457,6 +461,8 @@ let batch_add_tasks_internal config tasks =
           stage = None;
           contract;
           handoff_context = None;
+          cycle_count = 0;
+          do_not_reclaim_reason = None;
         }
       ) tasks in
       let new_backlog = {

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -552,6 +552,8 @@ type task = {
   stage: Task_stage.t option; [@default None]  (** Coding task stage gate *)
   contract: task_contract option; [@default None]
   handoff_context: task_handoff_context option; [@default None]
+  cycle_count: int; [@default 0]
+  do_not_reclaim_reason: string option; [@default None]
 } [@@deriving show]
 
 (* Manual yojson for task *)
@@ -598,7 +600,16 @@ let task_to_yojson t =
         [ ( "handoff_context",
             task_handoff_context_to_yojson handoff_context ) ]
   in
-  let with_role = with_handoff_context in
+  (* cycle_count omitted when 0 for backward-compat on existing backlogs. *)
+  let with_cycle_count =
+    if t.cycle_count = 0 then with_handoff_context
+    else with_handoff_context @ [("cycle_count", `Int t.cycle_count)]
+  in
+  let with_do_not_reclaim = match t.do_not_reclaim_reason with
+    | None -> with_cycle_count
+    | Some r -> with_cycle_count @ [("do_not_reclaim_reason", `String r)]
+  in
+  let with_role = with_do_not_reclaim in
   (* Merge status fields into task *)
   match status_json with
   | `Assoc status_fields -> `Assoc (with_role @ status_fields)
@@ -646,6 +657,12 @@ let task_of_yojson json =
            | Ok handoff_context -> Some handoff_context
            | Error _ -> None)
     in
+    let cycle_count =
+      json |> member "cycle_count" |> to_int_option |> Option.value ~default:0
+    in
+    let do_not_reclaim_reason =
+      json |> member "do_not_reclaim_reason" |> to_string_option
+    in
     match task_status_of_yojson json with
     | Ok task_status ->
         Ok
@@ -663,6 +680,8 @@ let task_of_yojson json =
             stage;
             contract;
             handoff_context;
+            cycle_count;
+            do_not_reclaim_reason;
           }
     | Error e -> Error e
   with e -> Error (Printexc.to_string e)

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -158,7 +158,7 @@ let test_task_required_preset_roundtrip () =
     worktree = None;
     required_role = Types_core.Unassigned;
     required_preset = Some "delivery";
-    stage = None; contract = None; handoff_context = None;
+    stage = None; contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   match Types.task_of_yojson json with
@@ -174,7 +174,7 @@ let test_task_required_preset_none_compat () =
     worktree = None;
     required_role = Types_core.Unassigned;
     required_preset = None;
-    stage = None; contract = None; handoff_context = None;
+    stage = None; contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   let json_str = Yojson.Safe.to_string json in

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -1018,7 +1018,7 @@ let test_append_archive_tasks () =
       created_at = "2026-01-01T00:00:00Z";
       worktree = None;
       required_role = Types_core.Unassigned; required_preset = None; stage = None;
-      contract = None; handoff_context = None;
+      contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
     } in
     Coord.append_archive_tasks config [task];
 

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -68,7 +68,7 @@ let test_task_with_stage () =
     created_at = "2026-01-01T00:00:00Z";
     worktree = None; required_role = Unassigned; required_preset = None;
     stage = Some Task_stage.Implement;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types_core.task_to_yojson task in
   match Types_core.task_of_yojson json with
@@ -84,7 +84,7 @@ let test_task_without_stage () =
     created_at = "2026-01-01T00:00:00Z";
     worktree = None; required_role = Unassigned; required_preset = None;
     stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types_core.task_to_yojson task in
   match Types_core.task_of_yojson json with

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -124,7 +124,7 @@ let make_task ~id ~status : Types.task = {
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
   required_role = Types_core.Unassigned; required_preset = None; stage = None;
-  contract = None; handoff_context = None;
+  contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
 }
 
 let test_is_pending_task_todo () =
@@ -161,7 +161,7 @@ let make_task_with_priority ~id ~priority : Types.task = {
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
   required_role = Types_core.Unassigned; required_preset = None; stage = None;
-  contract = None; handoff_context = None;
+  contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
 }
 
 let test_calculate_adaptive_tempo_empty () =

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -561,7 +561,7 @@ let test_backlog_to_yojson_with_tasks () =
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let b : Types.backlog = { tasks = [task]; last_updated = "2024-01-15T12:00:00Z"; version = 2 } in
   let json = Types.backlog_to_yojson b in
@@ -1246,7 +1246,7 @@ let test_task_to_yojson () =
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson t in
   match json with
@@ -1273,7 +1273,7 @@ let test_task_to_yojson_with_worktree () =
     created_at = "2024-01-15T12:00:00Z";
     worktree = Some wt;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson t in
   match json with

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -443,7 +443,7 @@ let test_task_roundtrip () =
     created_at = "2024-01-01T00:00:00Z";
     worktree = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   let result = Types.task_of_yojson json in
@@ -465,7 +465,7 @@ let test_task_with_worktree () =
       repo_name = "project";
     };
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   let result = Types.task_of_yojson json in
@@ -482,12 +482,12 @@ let test_backlog_roundtrip () =
         task_status = Todo; priority = 1; files = [];
         created_at = "2024-01-01T00:00:00Z"; worktree = None;
         required_role = Types_core.Unassigned; required_preset = None; stage = None;
-        contract = None; handoff_context = None };
+        contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         priority = 2; files = []; created_at = "2024-01-01T01:00:00Z"; worktree = None;
         required_role = Types_core.Unassigned; required_preset = None; stage = None;
-        contract = None; handoff_context = None };
+        contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
     ];
     last_updated = "2024-01-02T00:00:00Z";
     version = 5;


### PR DESCRIPTION
## Summary

Adds two optional fields to `Types.task` to unblock upcoming cycle-prevention logic. Schema-only change: no runtime behavior shifts.

- `cycle_count: int [@default 0]` — claim→cancel cycles observed.
- `do_not_reclaim_reason: string option [@default None]` — populated manually or by the forthcoming cancel hook; a future claim gate rejects re-claim when set.

`to_yojson` omits both when they hold default values, so existing `backlog.json` rows serialize identically.

## Why

sojin metrics show the assigner ignores natural-language "DO NOT RECLAIM" markers in `error_message`:
- `task-108` — "Already released 4+ times across 30+ episodes"
- `task-117` — "30 episode claim→release cycle confirmed"

Structured fields let the runtime enforce later.

## Scope
PR 1 of 3:
1. **This PR** — fields + yojson + test-literal fixups.
2. Cancel hook: increments `cycle_count`; auto-sets `do_not_reclaim_reason` after 3 cancels.
3. Claim gate: rejects claim when `do_not_reclaim_reason = Some _`.

## Test plan
- Local `dune build --root .` → exit 0.
- `dune runtest` in progress (draft, CI takes over).
- Backward compat: existing `.masc/tasks/backlog.json` (201 entries) parse unchanged — fields default to 0/None; serialize unchanged when defaults hold.

## Related
- Design sketch: jeong-sik/me#1011
- Local A/B (poe zero-delta gate): `~/me/.masc/config/keepers/poe.toml` (gitignored).