### PR TITLE
docs(tool_shard): update team-session exclusion comment to reflect module removal

### DIFF
--- a/lib/tool_shard.mli
+++ b/lib/tool_shard.mli
@@ -98,7 +98,8 @@ val execute : string -> Yojson.Safe.t -> (bool * Yojson.Safe.t)
 
 val autoresearch_keeper_tools : Types.tool_schema list
 (** Autoresearch tools for keeper use.
-    Excludes team-session swarm-start front doors. *)
+    (Earlier revisions excluded team-session swarm-start front doors;
+    those front doors were removed along with the team_session module.) *)
 
 val shard_autoresearch : shard
 (** Autoresearch shard: start, cycle, status, inject, stop. *)


### PR DESCRIPTION
## Summary

`lib/tool_shard.mli:101`의 `autoresearch_keeper_tools` docstring이 현재
존재하지 않는 "team-session swarm-start front doors"를 exclude한다고
설명한다. team_session module 전체가 이미 purge되어 exclusion이 trivially
true한 상태다.

다른 code-level guard comment(`lib/tool_keeper.ml:509` *\"Team_session_oas_bridge removed\"*, `lib/server/server_runtime_bootstrap.ml:758` *\"Team_session_engine_eio removed\"* 등)와 동일한 패턴으로, docstring을 historical context로 다시 쓴다.

## Diff

```diff
 val autoresearch_keeper_tools : Types.tool_schema list
 (** Autoresearch tools for keeper use.
-    Excludes team-session swarm-start front doors. *)
+    (Earlier revisions excluded team-session swarm-start front doors;
+     those front doors were removed along with the team_session module.) *)
```

## Validation

- 타입/런타임 동작 영향 없음 (docstring-only)
- team-session swarm-start front door 존재 확인: `rg 'swarm.start|swarm_start' lib/ -g '*.ml' -g '*.mli'` → 매치 없음

## Context

Gen16 of /loop session (세션 누계: 12 merged + 2 open + 2 closed duplicates). 코드-레벨 team_session residue 30+ refs 중 **유일한 stale docstring claim** — 나머지는 모두 intentional retain (legacy module names, removal guard comments, JSON response keys for backward compat, filesystem paths for GC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)