### PR TITLE
docs(mcp_prompt): mark command_truth prompt as deprecated (command plane removed)

### DIFF
--- a/lib/mcp_prompt_surface.ml
+++ b/lib/mcp_prompt_surface.ml
@@ -41,7 +41,7 @@ let prompt_defs =
     {
       name = "command_truth";
       title = "Command Truth";
-      description = "Summarize managed command-plane evidence for an operation or run.";
+      description = "Summarize managed command-plane evidence for an operation or run (deprecated: command plane layer removed).";
       icons = [ Mcp_server.themed_icon ~label:"CT" ~bg:"#9A3412" ~fg:"#FFF7ED" ];
       arguments =
         [
@@ -182,8 +182,9 @@ let command_truth_text ~config:_ ?operation_id ?run_id () =
   in
   String.concat "\n"
     [
-      "Summarize the managed execution truth from the command-plane evidence below.";
-      "Distinguish planned state from observed traces.";
+      "Command plane evidence is not available (command plane layer removed).";
+      "The summary and traces below reflect the stub state retained for";
+      "backward compatibility with pre-purge MCP clients; they carry no live data.";
       (match run_id with Some value -> "Focus run_id: " ^ value | None -> "");
       "";
       "Summary:";


### PR DESCRIPTION
## Summary

`lib/mcp_prompt_surface.ml`의 `command_truth` MCP prompt가 이미 purge된
command-plane layer의 "evidence"를 약속한다. `command_truth_text` body는
이미 empty traces(\`{\"events\": []}\`)만 반환하므로, MCP client(LLM)는
stale 지시문 + 빈 JSON을 받아 혼란에 빠진다.

같은 파일의 `execution_session_proof` prompt가 "(deprecated: team session
layer removed)" 마커 + body의 "not available" 패턴으로 이미 정리되어
있어, `command_truth`도 동일 패턴으로 맞춘다.

## Diff (4+/3-, string-literal only)

### Description marker (line 44)
```diff
-      description = "Summarize managed command-plane evidence for an operation or run.";
+      description = "Summarize managed command-plane evidence for an operation or run (deprecated: command plane layer removed).";
```

### Body template (line 185-187)
```diff
-      "Summarize the managed execution truth from the command-plane evidence below.";
-      "Distinguish planned state from observed traces.";
+      "Command plane evidence is not available (command plane layer removed).";
+      "The summary and traces below reflect the stub state retained for";
+      "backward compatibility with pre-purge MCP clients; they carry no live data.";
```

## Scope note

기존 JSON summary/traces 블록은 backward-compat 유지 (MCP schema 호출자
파손 방지). 완전 제거 + helper(`filter_traces_json_by_run_id`, `run_tokens`,
`json_contains_run_tokens`) 삭제는 별도 PR에서 처리.

## Validation

- Type/runtime 로직 불변 (string literal only)
- `test/`에 `command_truth_text` 또는 `"command_truth"` 직접 참조 없음
- `execution_session_proof` 패턴과 vocabulary 일관 (비교 ground truth 있음)

## Context

Gen17 of /loop session. 코드 레벨 command-plane residue 스캔에서 발견된
유일한 live MCP surface drift (tool descriptions는 별도 audit scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)