### PR TITLE
feat(tasks): claim gate — refuse re-claim on do_not_reclaim_reason

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1256,11 +1256,32 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
             else begin
               let new_tasks = List.map (fun t ->
                 if t.id = task_id then
-                  { t with task_status = Types.Cancelled {
-                    cancelled_by = agent_name;
-                    cancelled_at = now_iso ();
-                    reason = if reason = "" then None else Some reason
-                  }}
+                  let new_cycle = t.cycle_count + 1 in
+                  (* Auto-set do_not_reclaim_reason when the operator flags
+                     a hard stop in the cancel reason, or after 3 cycles. *)
+                  let auto_dnr =
+                    match t.do_not_reclaim_reason with
+                    | Some _ as existing -> existing
+                    | None ->
+                        let lower = String.lowercase_ascii reason in
+                        let flagged =
+                          String_util.contains_substring lower "do not reclaim"
+                          || String_util.contains_substring lower "scope mismatch"
+                        in
+                        if flagged && reason <> "" then Some reason
+                        else if new_cycle >= 3 then
+                          Some (Printf.sprintf "auto: %d cancellations" new_cycle)
+                        else None
+                  in
+                  { t with
+                    task_status = Types.Cancelled {
+                      cancelled_by = agent_name;
+                      cancelled_at = now_iso ();
+                      reason = if reason = "" then None else Some reason
+                    };
+                    cycle_count = new_cycle;
+                    do_not_reclaim_reason = auto_dnr;
+                  }
                 else t
               ) backlog.tasks in
               let new_backlog = {

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -524,10 +524,16 @@ let claim_task config ~agent_name ~task_id =
       let backlog = read_backlog_or_raise config in
       let found = ref false in
       let already_claimed = ref None in
+      let blocked_reason = ref None in
       let new_tasks = List.map (fun task ->
         if task.id = task_id then begin
           found := true;
+          (* Cycle-prevention gate: see _r variant below for rationale. *)
+          (match task.do_not_reclaim_reason with
+           | Some r -> blocked_reason := Some r
+           | None -> ());
           match task.task_status with
+          | _ when !blocked_reason <> None -> task
           | Todo ->
               { task with task_status = Claimed { assignee = agent_name; claimed_at = now_iso () } }
           | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ }
@@ -538,7 +544,10 @@ let claim_task config ~agent_name ~task_id =
       ) backlog.tasks in
       if not !found then
         Printf.sprintf "❌ Task %s not found" task_id
-      else match !already_claimed with
+      else match !blocked_reason with
+        | Some r -> Printf.sprintf "🚫 Task %s blocked from re-claim: %s" task_id r
+        | None ->
+      (match !already_claimed with
         | Some other -> Printf.sprintf "⚠ Task %s is already claimed by %s" task_id other
         | None ->
             let new_backlog = {
@@ -570,7 +579,7 @@ let claim_task config ~agent_name ~task_id =
                      (Types.Claimed
                         { assignee = agent_name; claimed_at = now_iso () })
                    ());
-            Printf.sprintf "✅ %s claimed %s" agent_name task_id
+            Printf.sprintf "✅ %s claimed %s" agent_name task_id)
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | e ->
@@ -619,6 +628,17 @@ let claim_task_r config ~agent_name ~task_id
             actual = Types_core.role_to_string agent_role;
           })
         else Ok ()
+      in
+      (* Cycle-prevention gate: refuse claim when do_not_reclaim_reason is set.
+         The reason is populated by the cancel hook (3+ cancels or hard-stop
+         keywords) or by the operator directly. See PRs #7794 (schema),
+         #7798 (cancel hook). *)
+      let* () =
+        match task.do_not_reclaim_reason with
+        | None -> Ok ()
+        | Some r ->
+            Error (Types.TaskInvalidState
+              (Printf.sprintf "Task %s is blocked from re-claim: %s" task_id r))
       in
       (* fold_left to find+transform in a single pass without mutable refs.
          Uses polymorphic variants for inline state tracking. *)

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -337,6 +337,8 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
         stage = None;
         contract;
         handoff_context = None;
+        cycle_count = 0;
+        do_not_reclaim_reason = None;
       } in
 
       let new_backlog = {
@@ -398,6 +400,8 @@ let add_task_with_role ?contract config ~title ~priority ~description
         stage = None;
         contract;
         handoff_context = None;
+        cycle_count = 0;
+        do_not_reclaim_reason = None;
       } in
 
       let new_backlog = {
@@ -457,6 +461,8 @@ let batch_add_tasks_internal config tasks =
           stage = None;
           contract;
           handoff_context = None;
+          cycle_count = 0;
+          do_not_reclaim_reason = None;
         }
       ) tasks in
       let new_backlog = {

--- a/lib/types/types_core.ml
+++ b/lib/types/types_core.ml
@@ -552,6 +552,8 @@ type task = {
   stage: Task_stage.t option; [@default None]  (** Coding task stage gate *)
   contract: task_contract option; [@default None]
   handoff_context: task_handoff_context option; [@default None]
+  cycle_count: int; [@default 0]
+  do_not_reclaim_reason: string option; [@default None]
 } [@@deriving show]
 
 (* Manual yojson for task *)
@@ -598,7 +600,16 @@ let task_to_yojson t =
         [ ( "handoff_context",
             task_handoff_context_to_yojson handoff_context ) ]
   in
-  let with_role = with_handoff_context in
+  (* cycle_count omitted when 0 for backward-compat on existing backlogs. *)
+  let with_cycle_count =
+    if t.cycle_count = 0 then with_handoff_context
+    else with_handoff_context @ [("cycle_count", `Int t.cycle_count)]
+  in
+  let with_do_not_reclaim = match t.do_not_reclaim_reason with
+    | None -> with_cycle_count
+    | Some r -> with_cycle_count @ [("do_not_reclaim_reason", `String r)]
+  in
+  let with_role = with_do_not_reclaim in
   (* Merge status fields into task *)
   match status_json with
   | `Assoc status_fields -> `Assoc (with_role @ status_fields)
@@ -646,6 +657,12 @@ let task_of_yojson json =
            | Ok handoff_context -> Some handoff_context
            | Error _ -> None)
     in
+    let cycle_count =
+      json |> member "cycle_count" |> to_int_option |> Option.value ~default:0
+    in
+    let do_not_reclaim_reason =
+      json |> member "do_not_reclaim_reason" |> to_string_option
+    in
     match task_status_of_yojson json with
     | Ok task_status ->
         Ok
@@ -663,6 +680,8 @@ let task_of_yojson json =
             stage;
             contract;
             handoff_context;
+            cycle_count;
+            do_not_reclaim_reason;
           }
     | Error e -> Error e
   with e -> Error (Printexc.to_string e)

--- a/test/test_keeper_tool_policy_config.ml
+++ b/test/test_keeper_tool_policy_config.ml
@@ -158,7 +158,7 @@ let test_task_required_preset_roundtrip () =
     worktree = None;
     required_role = Types_core.Unassigned;
     required_preset = Some "delivery";
-    stage = None; contract = None; handoff_context = None;
+    stage = None; contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   match Types.task_of_yojson json with
@@ -174,7 +174,7 @@ let test_task_required_preset_none_compat () =
     worktree = None;
     required_role = Types_core.Unassigned;
     required_preset = None;
-    stage = None; contract = None; handoff_context = None;
+    stage = None; contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   let json_str = Yojson.Safe.to_string json in

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -1018,7 +1018,7 @@ let test_append_archive_tasks () =
       created_at = "2026-01-01T00:00:00Z";
       worktree = None;
       required_role = Types_core.Unassigned; required_preset = None; stage = None;
-      contract = None; handoff_context = None;
+      contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
     } in
     Coord.append_archive_tasks config [task];
 

--- a/test/test_task_stage.ml
+++ b/test/test_task_stage.ml
@@ -68,7 +68,7 @@ let test_task_with_stage () =
     created_at = "2026-01-01T00:00:00Z";
     worktree = None; required_role = Unassigned; required_preset = None;
     stage = Some Task_stage.Implement;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types_core.task_to_yojson task in
   match Types_core.task_of_yojson json with
@@ -84,7 +84,7 @@ let test_task_without_stage () =
     created_at = "2026-01-01T00:00:00Z";
     worktree = None; required_role = Unassigned; required_preset = None;
     stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types_core.task_to_yojson task in
   match Types_core.task_of_yojson json with

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -124,7 +124,7 @@ let make_task ~id ~status : Types.task = {
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
   required_role = Types_core.Unassigned; required_preset = None; stage = None;
-  contract = None; handoff_context = None;
+  contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
 }
 
 let test_is_pending_task_todo () =
@@ -161,7 +161,7 @@ let make_task_with_priority ~id ~priority : Types.task = {
   created_at = "2024-01-01T00:00:00Z";
   worktree = None;
   required_role = Types_core.Unassigned; required_preset = None; stage = None;
-  contract = None; handoff_context = None;
+  contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
 }
 
 let test_calculate_adaptive_tempo_empty () =

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -561,7 +561,7 @@ let test_backlog_to_yojson_with_tasks () =
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let b : Types.backlog = { tasks = [task]; last_updated = "2024-01-15T12:00:00Z"; version = 2 } in
   let json = Types.backlog_to_yojson b in
@@ -1246,7 +1246,7 @@ let test_task_to_yojson () =
     created_at = "2024-01-15T12:00:00Z";
     worktree = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson t in
   match json with
@@ -1273,7 +1273,7 @@ let test_task_to_yojson_with_worktree () =
     created_at = "2024-01-15T12:00:00Z";
     worktree = Some wt;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson t in
   match json with

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -443,7 +443,7 @@ let test_task_roundtrip () =
     created_at = "2024-01-01T00:00:00Z";
     worktree = None;
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   let result = Types.task_of_yojson json in
@@ -465,7 +465,7 @@ let test_task_with_worktree () =
       repo_name = "project";
     };
     required_role = Types_core.Unassigned; required_preset = None; stage = None;
-    contract = None; handoff_context = None;
+    contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None;
   } in
   let json = Types.task_to_yojson task in
   let result = Types.task_of_yojson json in
@@ -482,12 +482,12 @@ let test_backlog_roundtrip () =
         task_status = Todo; priority = 1; files = [];
         created_at = "2024-01-01T00:00:00Z"; worktree = None;
         required_role = Types_core.Unassigned; required_preset = None; stage = None;
-        contract = None; handoff_context = None };
+        contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
       { id = "t2"; title = "Task 2"; description = "Desc 2";
         task_status = Done { assignee = "a"; completed_at = "2024-01-02T00:00:00Z"; notes = None };
         priority = 2; files = []; created_at = "2024-01-01T01:00:00Z"; worktree = None;
         required_role = Types_core.Unassigned; required_preset = None; stage = None;
-        contract = None; handoff_context = None };
+        contract = None; handoff_context = None; cycle_count = 0; do_not_reclaim_reason = None };
     ];
     last_updated = "2024-01-02T00:00:00Z";
     version = 5;


### PR DESCRIPTION
## Summary

Completes the cycle-prevention track. `Coord_task.claim_task_r` and the legacy `Coord_task.claim_task` now refuse any claim when `task.do_not_reclaim_reason` is `Some _`, returning `TaskInvalidState` with the stored reason.

## Stack
This is PR 3 of 3. It aggregates all three commits because GitHub didn't index the `feat/task-cycle-cancel-hook` branch in time for a stacked base. Squash-merge order if merging individually: #7794 → #7798 → this.

- Commit 1 (b734a3a): schema fields (also in #7794).
- Commit 2 (252bd99): cancel hook increments + auto-DNR (also in #7798).
- Commit 3 (23685fb): **this PR's unique change** — claim gate.

Reviewers should focus on commit 3; the earlier two are already under review in #7794 and #7798.

## Effect
After this PR lands, the sojin-metric class — task-108 "Already released 4+ times across 30+ episodes", task-117 "30 episode claim→release cycle" — becomes impossible at the runtime layer.

## Test plan
- `dune build _build/default/lib/coord/masc_coord.cma` → pass (local).
- Full-repo build shares the unrelated `verifier_oas.ml` exhaustive-match upstream issue already hitting every open PR.

## Related
- Design sketch: jeong-sik/me#1011