### PR TITLE
feat(dashboard): category filter + show-all for keeper-supervisor-diagnostics

### DIFF
--- a/dashboard/src/components/keeper-supervisor-diagnostics.ts
+++ b/dashboard/src/components/keeper-supervisor-diagnostics.ts
@@ -3,8 +3,22 @@
 // Extracted from keeper-detail.ts to reduce file size.
 
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { formatTimeAgo } from '../lib/format-time'
+import { FilterChips } from './common/filter-chips'
+import {
+  groupCrashCohorts,
+  filterCrashLog,
+  CRASH_CATEGORY_KEYS,
+  type CrashCategory,
+} from './keeper-supervisor-helpers'
 import type { Keeper, KeeperSupervisorCrashLogEntry } from '../types'
+
+type CrashFilterKey = 'all' | CrashCategory
+
+// Module-level signals (per-keeper instance ok — panel only renders for active keeper).
+const crashCategoryFilter = signal<CrashFilterKey>('all')
+const crashShowAll = signal<boolean>(false)
 
 // ── Helpers ──────────────────────────────────────────────
 
@@ -33,37 +47,35 @@ function registryStateBadge(state: string | null) {
   return html`<span class="inline-flex items-center py-0.5 px-2 rounded text-[10px] font-semibold ${c.bg} ${c.text}">${state}</span>`
 }
 
+const COHORT_COLORS: Record<CrashCategory, string> = {
+  heartbeat: '#f59e0b',
+  turn: '#ef4444',
+  fiber: '#8b5cf6',
+  exception: '#ec4899',
+  other: '#6b7280',
+}
+
 function CrashCohortBar({ crash_log }: { crash_log: KeeperSupervisorCrashLogEntry[] }) {
   if (!crash_log || crash_log.length === 0) return null
-  const cohorts: Record<string, number> = {}
-  for (const e of crash_log) {
-    const reason = e.reason ?? 'unknown'
-    const key = reason.startsWith('heartbeat') ? 'heartbeat'
-      : reason.startsWith('turn') ? 'turn'
-      : reason.startsWith('fiber') ? 'fiber'
-      : reason.startsWith('exception') ? 'exception'
-      : 'other'
-    cohorts[key] = (cohorts[key] ?? 0) + 1
-  }
+  const cohorts = groupCrashCohorts(crash_log)
   const total = crash_log.length
-  const colors: Record<string, string> = {
-    heartbeat: '#f59e0b', turn: '#ef4444', fiber: '#8b5cf6',
-    exception: '#ec4899', other: '#6b7280',
-  }
+  const entries = CRASH_CATEGORY_KEYS
+    .map((key) => [key, cohorts[key] ?? 0] as const)
+    .filter(([, count]) => count > 0)
   return html`
     <div>
       <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 유형 분포</div>
       <div class="flex w-full h-3 rounded-full overflow-hidden bg-[var(--white-5)]">
-        ${Object.entries(cohorts).map(([key, count]) => html`
-          <div style="width: ${(count / total * 100).toFixed(1)}%; background: ${colors[key] ?? '#6b7280'}"
+        ${entries.map(([key, count]) => html`
+          <div style="width: ${(count / total * 100).toFixed(1)}%; background: ${COHORT_COLORS[key]}"
                title="${key}: ${count}건 (${(count / total * 100).toFixed(0)}%)"
                class="h-full"></div>
         `)}
       </div>
       <div class="flex flex-wrap gap-x-3 gap-y-1 mt-1.5">
-        ${Object.entries(cohorts).map(([key, count]) => html`
+        ${entries.map(([key, count]) => html`
           <span class="text-[10px] text-[var(--text-muted)] flex items-center gap-1">
-            <span class="inline-block w-2 h-2 rounded-full" style="background: ${colors[key] ?? '#6b7280'}"></span>
+            <span class="inline-block w-2 h-2 rounded-full" style="background: ${COHORT_COLORS[key]}"></span>
             ${key} ${count}
           </span>
         `)}
@@ -154,19 +166,51 @@ export function SupervisorDiagnosticsPanel({ keeper }: { keeper: Keeper }) {
           </div>
         ` : null}
         <${CrashCohortBar} crash_log=${crash_log} />
-        ${crash_log && crash_log.length > 0 ? html`
-          <div>
-            <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)] mb-2">장애 이력</div>
-            <div class="space-y-1 max-h-32 overflow-y-auto">
-              ${crash_log.slice(0, 10).map((e: any) => html`
-                <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[var(--white-3)]">
-                  <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
-                  <span class="text-[#fb7185]">${e.reason ?? 'unknown'}</span>
-                </div>
-              `)}
+        ${crash_log && crash_log.length > 0 ? (() => {
+          const cohorts = groupCrashCohorts(crash_log)
+          const filtered = filterCrashLog(crash_log, crashCategoryFilter.value)
+          const visible = crashShowAll.value ? filtered : filtered.slice(0, 10)
+          const chips: { key: CrashFilterKey; label: string; count: number }[] = [
+            { key: 'all', label: '전체', count: crash_log.length },
+            ...CRASH_CATEGORY_KEYS
+              .filter((k) => (cohorts[k] ?? 0) > 0)
+              .map((k) => ({ key: k as CrashFilterKey, label: k, count: cohorts[k] ?? 0 })),
+          ]
+          return html`
+            <div>
+              <div class="flex items-center justify-between mb-2">
+                <div class="text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">장애 이력</div>
+                ${filtered.length > 10 ? html`
+                  <button type="button"
+                    class="text-[10px] font-medium px-2 py-0.5 rounded border border-[var(--white-10)] bg-[var(--white-4)] text-[var(--text-dim)] hover:bg-[var(--white-8)] hover:text-[var(--text-body)] transition-colors"
+                    onClick=${() => { crashShowAll.value = !crashShowAll.value }}
+                    aria-pressed=${crashShowAll.value}>
+                    ${crashShowAll.value ? `최근 10건 보기` : `전체 ${filtered.length}건 보기`}
+                  </button>
+                ` : null}
+              </div>
+              ${chips.length > 1 ? html`
+                <${FilterChips}
+                  chips=${chips}
+                  active=${crashCategoryFilter}
+                  size="sm"
+                  tone="accent"
+                  class="mb-2"
+                />
+              ` : null}
+              <div class="space-y-1 ${crashShowAll.value ? 'max-h-64' : 'max-h-32'} overflow-y-auto">
+                ${visible.length === 0 ? html`
+                  <div class="py-2 px-2 text-[11px] text-[var(--text-muted)] italic">선택된 카테고리에 해당하는 장애가 없습니다.</div>
+                ` : visible.map((e) => html`
+                  <div class="flex items-center justify-between py-1 px-2 rounded text-[11px] bg-[var(--white-3)]">
+                    <span class="font-mono text-[var(--text-muted)]">${formatTimeAgo(e.ts ?? 0)}</span>
+                    <span class="text-[#fb7185]">${e.reason ?? 'unknown'}</span>
+                  </div>
+                `)}
+              </div>
             </div>
-          </div>
-        ` : null}
+          `
+        })() : null}
         <${SpEventsPanel} sp_events=${sp_events} />
       </div>
     <//>

--- a/dashboard/src/components/keeper-supervisor-helpers.test.ts
+++ b/dashboard/src/components/keeper-supervisor-helpers.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CRASH_CATEGORY_KEYS,
+  categorizeCrashReason,
+  filterCrashLog,
+  groupCrashCohorts,
+} from './keeper-supervisor-helpers'
+import type { KeeperSupervisorCrashLogEntry } from '../types'
+
+describe('categorizeCrashReason', () => {
+  it('classifies known prefixes', () => {
+    expect(categorizeCrashReason('heartbeat_timeout')).toBe('heartbeat')
+    expect(categorizeCrashReason('turn_budget_exceeded')).toBe('turn')
+    expect(categorizeCrashReason('fiber_panic')).toBe('fiber')
+    expect(categorizeCrashReason('exception_unhandled')).toBe('exception')
+  })
+
+  it('falls back to other for unknown / empty / nullish reasons', () => {
+    expect(categorizeCrashReason('mystery')).toBe('other')
+    expect(categorizeCrashReason('')).toBe('other')
+    expect(categorizeCrashReason(null)).toBe('other')
+    expect(categorizeCrashReason(undefined)).toBe('other')
+  })
+
+  it('exposes a stable category key list including all branches', () => {
+    expect(CRASH_CATEGORY_KEYS).toEqual([
+      'heartbeat', 'turn', 'fiber', 'exception', 'other',
+    ])
+  })
+})
+
+describe('groupCrashCohorts', () => {
+  it('returns empty object for empty input', () => {
+    expect(groupCrashCohorts([])).toEqual({})
+  })
+
+  it('tallies cohorts and omits zero categories', () => {
+    const log: KeeperSupervisorCrashLogEntry[] = [
+      { ts: 1, reason: 'heartbeat_timeout' },
+      { ts: 2, reason: 'heartbeat_lost' },
+      { ts: 3, reason: 'turn_budget_exceeded' },
+      { ts: 4, reason: 'unknown' },
+      { ts: 5 },
+    ]
+    expect(groupCrashCohorts(log)).toEqual({
+      heartbeat: 2,
+      turn: 1,
+      other: 2,
+    })
+  })
+})
+
+describe('filterCrashLog', () => {
+  const log: KeeperSupervisorCrashLogEntry[] = [
+    { ts: 1, reason: 'heartbeat_timeout' },
+    { ts: 2, reason: 'turn_budget_exceeded' },
+    { ts: 3, reason: 'fiber_panic' },
+    { ts: 4, reason: 'heartbeat_lost' },
+  ]
+
+  it('returns a copy of the full log when category is "all"', () => {
+    const out = filterCrashLog(log, 'all')
+    expect(out).toEqual(log)
+    expect(out).not.toBe(log)
+  })
+
+  it('filters by category and preserves order', () => {
+    expect(filterCrashLog(log, 'heartbeat').map((e) => e.ts)).toEqual([1, 4])
+    expect(filterCrashLog(log, 'fiber').map((e) => e.ts)).toEqual([3])
+  })
+
+  it('returns an empty array when no entries match', () => {
+    expect(filterCrashLog(log, 'exception')).toEqual([])
+  })
+
+  it('does not mutate the input', () => {
+    const before = log.slice()
+    filterCrashLog(log, 'heartbeat')
+    expect(log).toEqual(before)
+  })
+})

--- a/dashboard/src/components/keeper-supervisor-helpers.ts
+++ b/dashboard/src/components/keeper-supervisor-helpers.ts
@@ -1,0 +1,54 @@
+// Pure helpers for keeper-supervisor-diagnostics.
+// Kept separate so they are unit-testable without preact rendering.
+
+import type { KeeperSupervisorCrashLogEntry } from '../types'
+
+export type CrashCategory = 'heartbeat' | 'turn' | 'fiber' | 'exception' | 'other'
+
+export const CRASH_CATEGORY_KEYS: readonly CrashCategory[] = [
+  'heartbeat',
+  'turn',
+  'fiber',
+  'exception',
+  'other',
+] as const
+
+/**
+ * Classify a crash reason string into a coarse cohort.
+ * `null`/`undefined`/empty → 'other'.
+ * Matches existing prefix-based cohort assignment in CrashCohortBar.
+ */
+export function categorizeCrashReason(reason: string | null | undefined): CrashCategory {
+  if (!reason) return 'other'
+  if (reason.startsWith('heartbeat')) return 'heartbeat'
+  if (reason.startsWith('turn')) return 'turn'
+  if (reason.startsWith('fiber')) return 'fiber'
+  if (reason.startsWith('exception')) return 'exception'
+  return 'other'
+}
+
+/**
+ * Tally crash entries by cohort. Categories with zero entries are omitted.
+ */
+export function groupCrashCohorts(
+  crash_log: readonly KeeperSupervisorCrashLogEntry[],
+): Partial<Record<CrashCategory, number>> {
+  const cohorts: Partial<Record<CrashCategory, number>> = {}
+  for (const e of crash_log) {
+    const key = categorizeCrashReason(e.reason)
+    cohorts[key] = (cohorts[key] ?? 0) + 1
+  }
+  return cohorts
+}
+
+/**
+ * Filter crash entries by selected category. `'all'` returns the input unchanged.
+ * Returns a new array (does not mutate input).
+ */
+export function filterCrashLog(
+  crash_log: readonly KeeperSupervisorCrashLogEntry[],
+  category: 'all' | CrashCategory,
+): KeeperSupervisorCrashLogEntry[] {
+  if (category === 'all') return crash_log.slice()
+  return crash_log.filter((e) => categorizeCrashReason(e.reason) === category)
+}


### PR DESCRIPTION
## Summary
- Extract pure helpers (`groupCrashCohorts`, `filterCrashLog`, `categorizeCrashReason`, `CrashCategory` type) into `keeper-supervisor-helpers.ts`.
- Replace hardcoded `.slice(0, 10)` in `keeper-supervisor-diagnostics.ts` with `FilterChips` (all / heartbeat / turn / fiber / exception / other) + show-all toggle.
- Add 9 unit tests covering category mapping, filtering, and non-mutation.

## Why
Operators investigating structural failure patterns were losing tail entries. Continuation of panel-upgrade rhythm (#7694, #7706, #7717, #7741, #7751, #7767, #7775, #7783 all merged).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm exec vitest run src/components/keeper-supervisor-helpers.test.ts` → 9/9 pass
- [ ] CI Dashboard check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)