### PR TITLE
chore(keeper): drop keeper_pr_submit references (never-registered tool)

### DIFF
--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -1051,8 +1051,8 @@ let handle_keeper_shell
       (* Reversibility gate (Thariq / Anthropic auto-mode principle):
          - R0 read / R1 reversible mutation: allowed; R1 is audit-logged.
          - R2 irreversible: rejected with a structured-tool hint so the
-           LLM can self-recover toward keeper_pr_submit / operator
-           approval without a second round-trip. *)
+           LLM can self-recover toward an operator-approval path without
+           a second round-trip. *)
       let reversibility = Worker_dev_tools.classify_gh_reversibility cmd_str in
       let rev_tag = Worker_dev_tools.string_of_gh_reversibility reversibility in
       let gh_cmd_display = Printf.sprintf "gh %s" cmd_str in
@@ -1073,9 +1073,8 @@ let handle_keeper_shell
              (Worker_dev_tools.structured_tool_hint_for_r2 cmd_str)
              ~default:
                "This gh command mutates state that gh itself cannot \
-                restore. Route through a structured keeper tool \
-                (keeper_pr_submit for PR ops) or post on the board \
-                for operator approval."
+                restore. Route through the appropriate structured \
+                keeper tool or post on the board for operator approval."
          in
          Log.Keeper.warn
            "keeper_shell op=gh R2 blocked: %s (keeper=%s)"

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -667,8 +667,8 @@ let gh_allowed_commands =
       repo delete/archive/transfer/rename, release delete, secret
       delete, auth logout/token, ssh-key delete, workflow disable,
       api --method DELETE, graphql mutation delete*/remove*/transfer*.
-      Must route through a structured keeper tool (keeper_pr_submit,
-      etc.) that carries operator-approval semantics. *)
+      Must route through a structured keeper tool that carries
+      operator-approval semantics. *)
 type gh_reversibility =
   | R0_Read
   | R1_Reversible


### PR DESCRIPTION
## Summary

Partial fix for audit issue #7696 (4 orphan tool names).
`keeper_pr_submit`는 **어떤 MCP tool dispatcher에도 등록되어 있지 않다**.
그러나 세 곳에서 guidance/docstring으로 등장하며, 특히 하나는 **LLM에게 직접
노출되는 runtime error hint**다.

## Files + Impact

| File | Line | Type | LLM-visible |
|------|------|------|-------------|
| `lib/worker_dev_tools.ml` | 670-671 | Type docstring comment | ❌ |
| `lib/keeper/keeper_exec_shell.ml` | 1053-1055 | Internal implementation comment | ❌ |
| `lib/keeper/keeper_exec_shell.ml` | 1074-1078 | R2_Irreversible fallback hint | ✅ **LLM runtime message** |

**Bug severity**: (3)은 실제 R2 gh 명령 차단 시 LLM에게 반환되는 error 본문이다. `structured_tool_hint_for_r2`가 `None`을 반환하는 fallback 경로에서 LLM은 존재하지 않는 `keeper_pr_submit` tool을 시도 → error loop 유발.

## Changes (3 sites, string-literal only)

```diff
-      Must route through a structured keeper tool (keeper_pr_submit,
-      etc.) that carries operator-approval semantics. *)
+      Must route through a structured keeper tool that carries
+      operator-approval semantics. *)
```

```diff
-         - R2 irreversible: rejected with a structured-tool hint so the
-           LLM can self-recover toward keeper_pr_submit / operator
-           approval without a second round-trip. *)
+         - R2 irreversible: rejected with a structured-tool hint so the
+           LLM can self-recover toward an operator-approval path without
+           a second round-trip. *)
```

```diff
              ~default:
                "This gh command mutates state that gh itself cannot \
-                restore. Route through a structured keeper tool \
-                (keeper_pr_submit for PR ops) or post on the board \
-                for operator approval."
+                restore. Route through the appropriate structured \
+                keeper tool or post on the board for operator approval."
```

## Out of scope (follow-up)

- `config/tool_policy.toml:79`의 `keeper_board_cleanup`/`keeper_board_delete` — validator blind spot; 실제 keeper-reachable 여부 결정 필요 (다른 PR)
- `lib/keeper/keeper_telemetry_feedback.ml:128`의 `keeper_pr_workflow` match + `pr_workflow_attempts` record field — `.mli` exported라 public API 변경 scope (다른 PR)

## Validation

- `rg 'keeper_pr_submit' lib/ -g '*.ml' -g '*.mli'` → 0 matches
- String literal + comment only, 타입/런타임 로직 불변
- 2 files, 6/7 insert/delete

Refs: #7696

🤖 Generated with [Claude Code](https://claude.com/claude-code)