### PR TITLE
chore(backend/operator): remove review_item target + review_resolve/defer actions

### DIFF
--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -289,60 +289,6 @@ let execute_keeper_action (ctx : 'a context) (request : action_request) =
           ])
   | _ -> Error (Printf.sprintf "not a keeper action: %s" request.action_type)
 
-let execute_review_action (ctx : 'a context) (request : action_request) =
-  let* () = validate_target_type "review_item" request in
-  let* item_id =
-    require_payload_field request.payload "item_id"
-      "payload.item_id is required"
-  in
-  let* fingerprint =
-    require_payload_field request.payload "fingerprint"
-      "payload.fingerprint is required"
-  in
-  let* item_target_type =
-    require_payload_field request.payload "item_target_type"
-      "payload.item_target_type is required"
-  in
-  let reason =
-    get_string request.payload "reason" "" |> String.trim
-  in
-  if reason = "" then Error "payload.reason is required"
-  else
-    let decision =
-      if String.equal request.action_type "review_resolve"
-      then "resolved"
-      else "deferred"
-    in
-    let entry : Operator_review_state.review_decision =
-      {
-        item_id;
-        fingerprint;
-        decision;
-        actor = request.actor;
-        reason;
-        at = Types.now_iso ();
-        target_type = item_target_type;
-        target_id = get_string_opt request.payload "item_target_id";
-        recommended_action_type =
-          get_string_opt request.payload "recommended_action_type";
-      }
-    in
-    Operator_review_state.upsert_review_decision ctx.config entry;
-    Ok
-      (`Assoc
-        [
-          ("tool_name", `String "review_state");
-          ( "result",
-            `Assoc
-              [
-                ("item_id", `String item_id);
-                ("fingerprint", `String fingerprint);
-                ("decision", `String decision);
-                ("actor", `String request.actor);
-                ("reason", `String reason);
-              ] );
-        ])
-
 let execute_action (ctx : 'a context) (request : action_request) :
     (Yojson.Safe.t, string) result =
   (* Canonicalize legacy action_type aliases before dispatch. *)
@@ -359,8 +305,6 @@ let execute_action (ctx : 'a context) (request : action_request) :
       execute_team_action ctx request
   | "keeper_probe" | "keeper_recover" | "keeper_message" ->
       execute_keeper_action ctx request
-  | "review_resolve" | "review_defer" ->
-      execute_review_action ctx request
   | "" -> Error "action_type is required"
   | other -> Error (Printf.sprintf "unsupported action_type: %s" other)
 
@@ -373,8 +317,7 @@ let known_action_types =
   in
   (* autonomy_tick excluded: canonical_action_type maps it to social_sweep
      before validate_request runs, so it never reaches here as-is. *)
-  from_registry @ [ "social_sweep"; "team_turn";
-                    "review_resolve"; "review_defer" ]
+  from_registry @ [ "social_sweep"; "team_turn" ]
 
 let validate_request request =
   if request.action_type = "" then Error "action_type is required"

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -121,23 +121,20 @@ let canonical_action_type action_type =
   | "keeper_message" -> "keeper_message"
   | "keeper_probe" -> "keeper_probe"
   | "keeper_recover" -> "keeper_recover"
-  | "review_resolve" -> "review_resolve"
-  | "review_defer" -> "review_defer"
   | other -> other
 
 let normalize_action_target_type target_type =
   let normalized = String.trim target_type |> String.lowercase_ascii in
   if Operator_digest_types.is_root_alias normalized then Ok "root"
   else match normalized with
-  | "keeper" | "review_item" as value -> Ok value
+  | "keeper" as value -> Ok value
   | "" -> Ok ""
-  | _ -> Error "target_type must be root, keeper, or review_item"
+  | _ -> Error "target_type must be root or keeper"
 
 let default_target_type_for action_type =
   match action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "task_inject" | "social_sweep" -> "root"
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
-  | "review_resolve" | "review_defer" -> "review_item"
   | _ -> ""
 
 let generate_confirm_token ~(clock : _ Eio.Time.clock) config =
@@ -215,10 +212,7 @@ let delegated_tool_for action_type =
       Operator_pending_confirm.available_actions
   with
   | Some action -> action.tool_name
-  | None ->
-    (match action_type with
-     | "review_resolve" | "review_defer" -> "review_state"
-     | _ -> "unknown")
+  | None -> "unknown"
 
 let confirm_required = Operator_approval.confirm_required
 

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -43,9 +43,6 @@ let operator_surface_contract_json =
       ("attention_items", `String "derived");
       ("recommended_actions", `String "fallback");
       ("active_recommended_actions", `String "judgment_or_fallback");
-      ("review_queue", `String "derived");
-      ("deferred_queue", `String "derived");
-      ("review_summary", `String "derived");
       ("recent_reviews", `String "operator_state");
       ("worker_cards", `String "truth");
     ]

--- a/lib/operator/operator_review_state.ml
+++ b/lib/operator/operator_review_state.ml
@@ -72,27 +72,6 @@ let write_review_decisions config entries =
 
 let read_review_decisions config = raw_review_decisions config
 
-let upsert_review_decision config entry =
-  let remaining =
-    read_review_decisions config
-    |> List.filter (fun existing ->
-           not
-             (String.equal existing.item_id entry.item_id
-             && String.equal existing.fingerprint entry.fingerprint
-             && String.equal existing.decision entry.decision))
-  in
-  write_review_decisions config (entry :: remaining)
-
-let matching_review_decision config ~item_id ~fingerprint =
-  read_review_decisions config
-  |> List.find_opt (fun entry ->
-         String.equal entry.item_id item_id
-         && String.equal entry.fingerprint fingerprint)
-
-let latest_review_decision config ~item_id =
-  read_review_decisions config
-  |> List.find_opt (fun entry -> String.equal entry.item_id item_id)
-
 let recent_review_decisions ?limit ?target_type ?target_id config =
   let matches_target (entry : review_decision) =
     let target_type_ok =

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -14,8 +14,7 @@ let allowed_actions =
     "team_note"; "team_broadcast"; "team_task_inject";
     "team_worker_spawn_batch"; "team_stop";
     "keeper_message"; "keeper_probe"; "keeper_recover";
-    "task_inject";
-    "review_resolve"; "review_defer" ]
+    "task_inject" ]
 
 let risk_of_action action_type : Oas.Approval.risk_level =
   if List.mem action_type high_risk_actions then High

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -24,8 +24,6 @@ let strict_action_enums =
     `String "keeper_message";
     `String "keeper_probe";
     `String "keeper_recover";
-    `String "review_resolve";
-    `String "review_defer";
   ]
 
 let legacy_action_alias_enums =
@@ -37,7 +35,6 @@ let target_type_enums =
     `String "root";
     `String "namespace";
     `String "keeper";
-    `String "review_item";
   ]
 
 let snapshot_schema ~remote =


### PR DESCRIPTION
## Summary

Gen13 (#7786) removed the `review_item` JSON emission and producer graph. This PR completes the purge by removing the dispatcher-layer acceptance of `review_item` target type and `review_resolve`/`review_defer` action types — with no caller and no emission, these were just dead dispatch branches and schema noise.

| Removed | File | Why dead |
|---|---|---|
| \`review_item\` target enum + \`review_resolve\`/\`review_defer\` action enums | \`tool_operator.ml\` | exposed schema no caller uses |
| \`review_resolve\`/\`review_defer\` from approval allowed list | \`operator_approval.ml\` | actions never dispatch |
| Canonical action-name parsing branches, \`normalize_action_target_type "review_item"\`, \`default_target_type_for review_*\`, \`delegated_tool_for review_*\` | \`operator_control_action.ml\` | call-site gone |
| \`execute_review_action\` (~53 LOC) + review_* cases in \`execute_action\` + \`known_action_types\` | \`operator_control.ml\` | the only consumer of upsert_review_decision |
| \`upsert_review_decision\`, \`matching_review_decision\`, \`latest_review_decision\` | \`operator_review_state.ml\` | called only by the removed handler; read path (\`recent_review_decisions_json\`) preserved |
| \`review_queue\`/\`deferred_queue\`/\`review_summary\` provenance markers | \`operator_pending_confirm.ml\` | no longer emitted |

Error message in \`normalize_action_target_type\` tightens from \`"root, keeper, or review_item"\` to \`"root or keeper"\`.

## Diff size

6 files · **+5 / -96** — caller-free purge.

## Gen chain

| Gen | PR | Layer | Status |
|---|---|---|---|
| 2 | #7684 | frontend types | merged |
| 6 | #7715 | frontend \`OperatorActionType\` (review_resolve/defer) | merged |
| 7 | #7731 | frontend \`OperatorTargetType\` (review_item) | merged |
| 12 | #7770 | backend emission | merged |
| 13 | #7786 | backend producer graph + \`Operator_digest_review_types\` | merged |
| 17 (this) | — | backend dispatcher + approval + review_state write path | — |

## Test plan

- [x] \`git grep -n review_resolve|review_defer|review_item test/\` → 0 invocations, 1 comment (Gen13 follow-up note)
- [x] Diff is additive-free (no new helpers or abstractions)
- [ ] CI \`dune build @check\` / \`@runtest\` (local env has unrelated OAS pin drift; CI is authoritative)

## Non-goals

- \`Operator_review_state.recent_review_decisions_json\` + \`recent_review_decisions\` read path — retained, \`operator_digest\` still emits \`recent_reviews\`
- \`review_decision\` type — retained (used by the read path)