### PR TITLE
feat(attribution): Layer 4 backend — ring buffer + REST + 3 gate wire-up

### DIFF
--- a/lib/cdal_verdict_gate.ml
+++ b/lib/cdal_verdict_gate.ml
@@ -82,20 +82,11 @@ let lookup_latest_verdict ?(base_dir = default_base_path)
       limit task_id);
   result
 
-let gate_check ?(base_dir = default_base_path) ~task_id () : string option =
-  match lookup_latest_verdict ~base_dir ~task_id () with
-  | None ->
-    Some (Printf.sprintf
-      "No CDAL verdict found for task %s. Submit evidence before completing."
-      task_id)
-  | Some verdict ->
-    match check_verdict verdict with
-    | Allow -> None
-    | Reject msg -> Some msg
-
 (* --- Attribution envelope conversion ---
    Layer 1 of the attribution rollout. Lets emitters surface a typed
-   verdict envelope alongside the existing string-return gate_check. *)
+   verdict envelope alongside the existing string-return gate_check.
+   Defined before gate_check so the latter can record into the ring
+   buffer without forward-referencing. *)
 
 let blocking_gap_count (v : Cdal_types.contract_verdict) : int =
   List.length
@@ -129,3 +120,16 @@ let attribution_for_missing_verdict ~task_id : Attribution.t =
       (Printf.sprintf
          "No CDAL verdict found for task %s. Submit evidence before completing."
          task_id)
+
+let gate_check ?(base_dir = default_base_path) ~task_id () : string option =
+  match lookup_latest_verdict ~base_dir ~task_id () with
+  | None ->
+    Dashboard_attribution.record (attribution_for_missing_verdict ~task_id);
+    Some (Printf.sprintf
+      "No CDAL verdict found for task %s. Submit evidence before completing."
+      task_id)
+  | Some verdict ->
+    Dashboard_attribution.record (to_attribution verdict);
+    match check_verdict verdict with
+    | Allow -> None
+    | Reject msg -> Some msg

--- a/lib/dashboard/dashboard_attribution.ml
+++ b/lib/dashboard/dashboard_attribution.ml
@@ -1,0 +1,110 @@
+(** See [Dashboard_attribution.mli]. *)
+
+let per_gate_cap = 200
+
+(* Guards [table]. Critical sections are short — queue push, fold, or clear.
+   Stdlib.Mutex is chosen over Eio.Mutex because record/read may be called
+   from different domains, and the section never yields to Eio. *)
+let mu = Mutex.create ()
+
+(* Per-gate FIFO. Head = oldest, tail = newest. *)
+let table : (string, (Attribution.t * float) Queue.t) Hashtbl.t =
+  Hashtbl.create 8
+
+let with_lock f =
+  Mutex.lock mu;
+  Fun.protect ~finally:(fun () -> Mutex.unlock mu) f
+
+let record_with_time ~now (attr : Attribution.t) =
+  with_lock (fun () ->
+      let q =
+        match Hashtbl.find_opt table attr.gate with
+        | Some q -> q
+        | None ->
+          let q = Queue.create () in
+          Hashtbl.add table attr.gate q;
+          q
+      in
+      Queue.push (attr, now) q;
+      while Queue.length q > per_gate_cap do
+        ignore (Queue.pop q)
+      done)
+
+let record attr = record_with_time ~now:(Unix.gettimeofday ()) attr
+
+(* Snapshot newest-first: fold accumulates as (new :: acc) reversed by
+   Queue.fold's left-fold over FIFO order, so a second reverse after take. *)
+let snapshot_newest_first q limit =
+  (* Queue.fold traverses oldest -> newest; prepend makes the list
+     newest-first without an extra reverse. *)
+  let all = Queue.fold (fun acc x -> x :: acc) [] q in
+  let rec take n = function
+    | [] -> []
+    | _ when n <= 0 -> []
+    | x :: xs -> x :: take (n - 1) xs
+  in
+  take limit all
+
+let recent ?gate ?(limit = 50) () =
+  let limit = max 0 limit in
+  with_lock (fun () ->
+      match gate with
+      | Some g ->
+        (match Hashtbl.find_opt table g with
+         | Some q -> snapshot_newest_first q limit
+         | None -> [])
+      | None ->
+        let all =
+          Hashtbl.fold
+            (fun _ q acc ->
+              Queue.fold (fun acc x -> x :: acc) acc q)
+            table []
+        in
+        (* Sort by timestamp descending. *)
+        let sorted =
+          List.sort (fun (_, t1) (_, t2) -> compare t2 t1) all
+        in
+        let rec take n = function
+          | [] -> []
+          | _ when n <= 0 -> []
+          | x :: xs -> x :: take (n - 1) xs
+        in
+        take limit sorted)
+
+type gate_summary = {
+  gate : string;
+  passed : int;
+  policy_failed : int;
+  transition_blocked : int;
+  partial_pass : int;
+  total : int;
+}
+
+let summary () =
+  with_lock (fun () ->
+      Hashtbl.fold
+        (fun gate q acc ->
+          let passed = ref 0
+          and pf = ref 0
+          and tb = ref 0
+          and pp = ref 0 in
+          Queue.iter
+            (fun (a, _ts) ->
+              match a.Attribution.outcome with
+              | Attribution.Passed -> incr passed
+              | Attribution.Policy_failed _ -> incr pf
+              | Attribution.Transition_blocked _ -> incr tb
+              | Attribution.Partial_pass _ -> incr pp)
+            q;
+          {
+            gate;
+            passed = !passed;
+            policy_failed = !pf;
+            transition_blocked = !tb;
+            partial_pass = !pp;
+            total = Queue.length q;
+          }
+          :: acc)
+        table [])
+
+let reset () = with_lock (fun () -> Hashtbl.clear table)

--- a/lib/dashboard/dashboard_attribution.mli
+++ b/lib/dashboard/dashboard_attribution.mli
@@ -1,0 +1,50 @@
+(** Per-gate attribution ring buffer backing the [/attribution] dashboard.
+
+    In-process, mutex-protected FIFO keyed by the attribution [gate]. The
+    buffer caps itself at a small bounded window per gate so recording is
+    O(1) amortized and memory stays bounded regardless of emit volume.
+
+    This is the *collector* side of the Layer 4 dashboard pipeline: producers
+    call {!record} from their gate sites (after producing an [Attribution.t]
+    via the gate's [to_attribution]), and the REST/SSE endpoints read from
+    {!recent} and {!summary}.
+
+    Cross-domain: guarded by [Stdlib.Mutex]. Eio fibers may call these
+    functions directly; the critical section is short (queue push or fold).
+
+    @since 2.264.0 *)
+
+val record : Attribution.t -> unit
+(** [record attr] appends [attr] to its gate's ring. Thread-safe. When the
+    per-gate cap is reached, the oldest entry is dropped. *)
+
+val recent :
+  ?gate:string -> ?limit:int -> unit -> (Attribution.t * float) list
+(** [recent ?gate ?limit ()] returns up to [limit] most recent events,
+    newest first. Each tuple is [(attribution, recorded_at)] where
+    [recorded_at] is [Unix.gettimeofday] at {!record} time.
+
+    - Default [limit] is 50.
+    - When [gate] is provided, only that gate's ring is scanned. Unknown
+      gates return [[]].
+    - When [gate] is absent, events are merged across gates and sorted by
+      timestamp descending. *)
+
+type gate_summary = {
+  gate : string;
+  passed : int;
+  policy_failed : int;
+  transition_blocked : int;
+  partial_pass : int;
+  total : int;
+}
+
+val summary : unit -> gate_summary list
+(** [summary ()] returns per-gate outcome counts over the current ring
+    window. Order is unspecified. *)
+
+val reset : unit -> unit
+(** Clear all rings. For tests only. *)
+
+val per_gate_cap : int
+(** The bounded window size per gate (exposed for tests). *)

--- a/lib/dune
+++ b/lib/dune
@@ -119,6 +119,7 @@
    server_routes_http_routes_provider_runs
    server_routes_http_routes_cascade
    server_routes_http_routes_verification
+   server_routes_http_routes_attribution
    server_routes_http_routes_activity
    server_routes_http_routes_channel_gate
    server_h2_gateway

--- a/lib/dune
+++ b/lib/dune
@@ -54,6 +54,7 @@
    dashboard_labels
    dashboard_agent_relations
    dashboard_attention
+   dashboard_attribution
    dashboard_cache
    dashboard_tool_host_events
    dashboard_governance

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -885,6 +885,8 @@ let dispatch_event_with_audit
         ~event
         ~now
     in
+    Dashboard_attribution.record
+      (Keeper_state_machine.attribution_of_transition ~event result);
     (match result with
      | Ok tr when tr.new_phase <> tr.prev_phase ->
        Log.Keeper.info "registry: phase transition name=%s old=%s new=%s event=%s"

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -17,5 +17,6 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_provider_runs.add_routes ~sw
   |> Server_routes_http_routes_cascade.add_routes
   |> Server_routes_http_routes_verification.add_routes
+  |> Server_routes_http_routes_attribution.add_routes
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_attribution.ml
+++ b/lib/server/server_routes_http_routes_attribution.ml
@@ -1,0 +1,70 @@
+(** HTTP routes for the attribution gate-chain dashboard.
+
+    Reads from the in-process ring buffer in {!Dashboard_attribution}.
+
+    - [GET /api/v1/attribution/recent?gate=X&limit=N] — latest events,
+      newest first. [gate] absent merges across gates.
+    - [GET /api/v1/attribution/summary] — per-gate outcome counts over the
+      current ring window, for the dashboard graph nodes. *)
+
+open Server_auth
+
+module Http = Http_server_eio
+module DA = Dashboard_attribution
+module A = Attribution
+
+let trimmed_query_param req key =
+  match Server_utils.query_param req key |> Option.map String.trim with
+  | Some v when v <> "" -> Some v
+  | _ -> None
+
+let event_json ((attr, recorded_at) : A.t * float) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("attribution", A.to_yojson attr);
+      ("recorded_at", `Float recorded_at);
+    ]
+
+let recent_json ?gate ?limit () : Yojson.Safe.t =
+  let events = DA.recent ?gate ?limit () in
+  `Assoc
+    [
+      ("events", `List (List.map event_json events));
+      ("count", `Int (List.length events));
+    ]
+
+let gate_summary_json (s : DA.gate_summary) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("gate", `String s.gate);
+      ("passed", `Int s.passed);
+      ("policy_failed", `Int s.policy_failed);
+      ("transition_blocked", `Int s.transition_blocked);
+      ("partial_pass", `Int s.partial_pass);
+      ("total", `Int s.total);
+    ]
+
+let summary_json () : Yojson.Safe.t =
+  `Assoc
+    [ ("gates", `List (List.map gate_summary_json (DA.summary ()))) ]
+
+let add_routes router =
+  router
+  |> Http.Router.get "/api/v1/attribution/recent" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let gate = trimmed_query_param req "gate" in
+         let limit =
+           match trimmed_query_param req "limit" with
+           | Some s -> int_of_string_opt s
+           | None -> None
+         in
+         let json = recent_json ?gate ?limit () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+  |> Http.Router.get "/api/v1/attribution/summary" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = summary_json () in
+         Http.Response.json ~compress:true ~request:req
+           (Yojson.Safe.to_string json) reqd
+       ) request reqd)

--- a/lib/verification_protocol.ml
+++ b/lib/verification_protocol.ml
@@ -61,7 +61,9 @@ let on_approve_verification ~(config : Coord.config)
     match Verification.submit_verdict ~base_path
             ~req_id:verification_id ~verifier
             ~verdict:Verification.Pass with
-    | Ok _ -> ()
+    | Ok updated ->
+      Verification.attribution_of_request updated
+      |> Option.iter Dashboard_attribution.record
     | Error e ->
       Log.Task.error
         "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"
@@ -101,7 +103,9 @@ let on_reject_verification ~(config : Coord.config)
     match Verification.submit_verdict ~base_path
             ~req_id:verification_id ~verifier
             ~verdict:(Verification.Fail reason) with
-    | Ok _ -> ()
+    | Ok updated ->
+      Verification.attribution_of_request updated
+      |> Option.iter Dashboard_attribution.record
     | Error e ->
       Log.Task.error
         "verification submit_verdict failed (task=%s vrf=%s verifier=%s): %s"

--- a/test/dune
+++ b/test/dune
@@ -27,7 +27,7 @@
 ; Group 1: Pure synchronous tests
 ; ============================================================
 (tests
- (names test_attribution test_attribution_tagged test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
+ (names test_attribution test_attribution_tagged test_dashboard_attribution test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
         test_sse test_cancellation test_graphql_api
         test_graphql_endpoint
         test_subscriptions test_session test_progress test_spawn
@@ -117,7 +117,7 @@
         test_warn_root_causes
         test_memory_hooks
         test_mid_turn_resume)
- (modules test_attribution test_attribution_tagged test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
+ (modules test_attribution test_attribution_tagged test_dashboard_attribution test_room test_room_state_recovery test_types test_auth test_audit_log test_http_negotiation
           test_sse test_cancellation test_graphql_api
           test_graphql_endpoint
           test_subscriptions test_session test_progress test_spawn

--- a/test/test_dashboard_attribution.ml
+++ b/test/test_dashboard_attribution.ml
@@ -1,0 +1,159 @@
+(** Tests for [Dashboard_attribution].
+
+    Ring-buffer semantics: cap enforcement, newest-first ordering, gate
+    filter, summary outcome counts, reset. *)
+
+module DA = Masc_mcp.Dashboard_attribution
+module A = Masc_mcp.Attribution
+
+let ev = `Null
+
+let pass gate = A.passed ~origin:Det ~gate ~evidence:ev
+
+let fail_ gate reason =
+  A.policy_failed ~origin:Det ~gate ~evidence:ev ~reason
+
+let blocked gate =
+  A.transition_blocked ~origin:Det ~gate ~evidence:ev
+    ~from_state:"A" ~to_state:"B" ~reason:"denied"
+
+let partial gate =
+  A.partial_pass ~origin:NonDet ~gate ~evidence:ev ~score:0.7
+    ~rationale:"meh"
+
+let setup () = DA.reset ()
+
+(* --- record + recent basics --- *)
+
+let test_record_then_recent () =
+  setup ();
+  DA.record (pass "cdal_verdict");
+  let xs = DA.recent ~gate:"cdal_verdict" () in
+  Alcotest.(check int) "1 event" 1 (List.length xs)
+
+let test_unknown_gate_returns_empty () =
+  setup ();
+  DA.record (pass "cdal_verdict");
+  Alcotest.(check int) "unknown gate" 0
+    (List.length (DA.recent ~gate:"nope" ()))
+
+(* --- cap enforcement --- *)
+
+let test_cap_enforced () =
+  setup ();
+  let total = DA.per_gate_cap + 50 in
+  for _ = 1 to total do
+    DA.record (pass "verification")
+  done;
+  let xs = DA.recent ~gate:"verification" ~limit:1_000 () in
+  Alcotest.(check int) "cap enforced" DA.per_gate_cap (List.length xs)
+
+(* --- newest-first ordering --- *)
+
+let test_newest_first () =
+  setup ();
+  DA.record (pass "g");
+  Unix.sleepf 0.002;
+  DA.record (fail_ "g" "r2");
+  let xs = DA.recent ~gate:"g" () in
+  match xs with
+  | (a1, _) :: (a2, _) :: _ ->
+    Alcotest.(check string) "newest outcome" "policy_failed"
+      (match a1.outcome with
+       | A.Policy_failed _ -> "policy_failed"
+       | _ -> "other");
+    Alcotest.(check string) "older outcome" "passed"
+      (match a2.outcome with A.Passed -> "passed" | _ -> "other")
+  | _ -> Alcotest.fail "expected ≥2 events"
+
+(* --- gate filter --- *)
+
+let test_gate_filter () =
+  setup ();
+  DA.record (pass "a");
+  DA.record (pass "a");
+  DA.record (pass "b");
+  Alcotest.(check int) "gate a" 2 (List.length (DA.recent ~gate:"a" ()));
+  Alcotest.(check int) "gate b" 1 (List.length (DA.recent ~gate:"b" ()))
+
+let test_cross_gate_merge () =
+  setup ();
+  DA.record (pass "a");
+  DA.record (pass "b");
+  DA.record (pass "c");
+  Alcotest.(check int) "merged" 3 (List.length (DA.recent ()))
+
+let test_limit_zero () =
+  setup ();
+  DA.record (pass "a");
+  Alcotest.(check int) "limit=0 yields empty" 0
+    (List.length (DA.recent ~gate:"a" ~limit:0 ()))
+
+let test_negative_limit_treated_as_zero () =
+  setup ();
+  DA.record (pass "a");
+  Alcotest.(check int) "negative clamped" 0
+    (List.length (DA.recent ~gate:"a" ~limit:(-5) ()))
+
+(* --- summary --- *)
+
+let test_summary_outcome_counts () =
+  setup ();
+  DA.record (pass "g");
+  DA.record (pass "g");
+  DA.record (fail_ "g" "r");
+  DA.record (blocked "g");
+  DA.record (partial "g");
+  let s = DA.summary () in
+  match List.find_opt (fun (x : DA.gate_summary) -> x.gate = "g") s with
+  | None -> Alcotest.fail "gate g missing from summary"
+  | Some r ->
+    Alcotest.(check int) "passed" 2 r.passed;
+    Alcotest.(check int) "policy_failed" 1 r.policy_failed;
+    Alcotest.(check int) "transition_blocked" 1 r.transition_blocked;
+    Alcotest.(check int) "partial_pass" 1 r.partial_pass;
+    Alcotest.(check int) "total" 5 r.total
+
+let test_summary_multi_gate () =
+  setup ();
+  DA.record (pass "a");
+  DA.record (pass "b");
+  Alcotest.(check int) "two gates" 2 (List.length (DA.summary ()))
+
+(* --- reset --- *)
+
+let test_reset_clears () =
+  setup ();
+  DA.record (pass "g");
+  DA.reset ();
+  Alcotest.(check int) "empty after reset" 0 (List.length (DA.recent ()));
+  Alcotest.(check int) "summary empty" 0 (List.length (DA.summary ()))
+
+let () =
+  Alcotest.run "Dashboard_attribution"
+    [
+      ( "record_recent",
+        [
+          Alcotest.test_case "record + recent" `Quick test_record_then_recent;
+          Alcotest.test_case "unknown gate" `Quick
+            test_unknown_gate_returns_empty;
+          Alcotest.test_case "newest-first ordering" `Quick test_newest_first;
+          Alcotest.test_case "limit=0" `Quick test_limit_zero;
+          Alcotest.test_case "negative limit" `Quick
+            test_negative_limit_treated_as_zero;
+        ] );
+      ( "cap",
+        [ Alcotest.test_case "per-gate cap" `Quick test_cap_enforced ] );
+      ( "gate_filter",
+        [
+          Alcotest.test_case "gate filter" `Quick test_gate_filter;
+          Alcotest.test_case "cross-gate merge" `Quick test_cross_gate_merge;
+        ] );
+      ( "summary",
+        [
+          Alcotest.test_case "outcome counts" `Quick
+            test_summary_outcome_counts;
+          Alcotest.test_case "multi-gate rows" `Quick test_summary_multi_gate;
+        ] );
+      ("reset", [ Alcotest.test_case "reset clears" `Quick test_reset_clears ]);
+    ]


### PR DESCRIPTION
## Summary

Layer 4 backend for the `/attribution` dashboard. Four axes so the endpoint returns live data immediately:

1. **Collector** (`lib/dashboard/dashboard_attribution.ml`) — per-gate bounded ring buffer.
2. **REST endpoint** — `GET /api/v1/attribution/recent` + `/summary`.
3. **Wire-up** — `cdal_verdict_gate.gate_check`, `verification_protocol.{approve,reject}_verification`, and `keeper_registry.apply_event` all record into the ring.
4. **Tests** — 11 Alcotest cases for collector semantics.

Part of `planning/claude-plans/abundant-skipping-sutton.md` Layer 4.

## Commits

| Commit | What |
|--------|------|
| `85b625c` | Collector module + `.mli` + `lib/dune` |
| `41f47b1` | 11 Alcotest cases |
| `579b3581` | REST endpoint + cdal/verification wire-up |
| `5be52880` | keeper_fsm wire-up (registry, covers Ok + Error paths) |

## Design notes

- **Cap per gate**: 200 events, FIFO-drop.
- **Mutex**: `Stdlib.Mutex` — cross-domain, never yields (MEMORY `ocaml5-mutex-selection`).
- **Wire-up placement**: side effects live at caller/orchestration layer (registry, protocol), not inside pure state machines (`keeper_state_machine.apply_event` stays pure).
- **cdal_verdict_gate restructure**: attribution helpers moved above `gate_check` to resolve `record` without forward reference. `.mli`-less file so export surface is unchanged.
- **REST read-path decoupled from wire-up**: zero wired gates ⇒ `/recent` returns empty `events`, `/summary` returns empty `gates`.

## Follow-ups

- worker_dev_tools wire-up (needs `validate_and_record` wrapper across tool entrypoints).
- accountability wire-up (claim resolution transitions across several keeper turn paths).
- autoresearch bridge wire-up (#7797 once merged — record from `tool_autoresearch_cycle`).
- Frontend: `dashboard/src/pages/attribution.ts` + cytoscape 2D gate-chain graph.

## Test plan

- [x] 11 Alcotest cases for collector.
- [ ] CI green.
- [ ] Manual smoke: start server, trigger a keeper transition, `curl /api/v1/attribution/summary` → expect `keeper_fsm` row with `passed >= 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)