### PR TITLE
fix(oas-pin): sync to agent_sdk 0.155.0 payload/hook surface (#7802)

### DIFF
--- a/lib/oas_sse_bridge.ml
+++ b/lib/oas_sse_bridge.ml
@@ -199,16 +199,45 @@ let native_event_to_json (evt : Agent_sdk.Event_bus.event) : Yojson.Safe.t optio
           ]
       in
       Some (wrap ~event_type:"context_compacted" ~payload ~agent_name ())
-  | Agent_sdk.Event_bus.TaskStateChanged { task_id; from_state; to_state } ->
+  (* TaskStateChanged match arm removed: OAS refactor!
+     (d3434799 "remove dead Event_bus.TaskStateChanged variant") dropped
+     the constructor entirely — it was declared in OAS#104 as a future
+     bridge point that was never implemented, with zero emit sites and
+     zero subscribers. Re-adding A2a task lifecycle to the SSE stream
+     is a deliberate forward-looking change, not an incidental fix. *)
+  | Agent_sdk.Event_bus.AgentFailed { agent_name; task_id; error; elapsed } ->
       let payload =
         `Assoc
           [
+            ("agent_name", `String agent_name);
             ("task_id", `String task_id);
-            ("from_state", `String from_state);
-            ("to_state", `String to_state);
+            ("error", `String (Agent_sdk.Error.to_string error));
+            ("elapsed", `Float elapsed);
           ]
       in
-      Some (wrap ~event_type:"task_state_changed" ~payload ~task_id ())
+      Some (wrap ~event_type:"agent_failed" ~payload ~agent_name ~task_id ())
+  | Agent_sdk.Event_bus.HandoffRequested { from_agent; to_agent; reason } ->
+      let payload =
+        `Assoc
+          [
+            ("from_agent", `String from_agent);
+            ("to_agent", `String to_agent);
+            ("reason", `String reason);
+          ]
+      in
+      Some (wrap ~event_type:"handoff_requested" ~payload
+              ~agent_name:from_agent ())
+  | Agent_sdk.Event_bus.HandoffCompleted { from_agent; to_agent; elapsed } ->
+      let payload =
+        `Assoc
+          [
+            ("from_agent", `String from_agent);
+            ("to_agent", `String to_agent);
+            ("elapsed", `Float elapsed);
+          ]
+      in
+      Some (wrap ~event_type:"handoff_completed" ~payload
+              ~agent_name:to_agent ())
   | Agent_sdk.Event_bus.ElicitationCompleted _ ->
     None  (* Internal; no SSE relay needed *)
   | Agent_sdk.Event_bus.ContextOverflowImminent

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -209,7 +209,8 @@ let make_pre_tool_hook
     | Agent_sdk.Hooks.OnIdle _
     | Agent_sdk.Hooks.OnError _
     | Agent_sdk.Hooks.OnToolError _
-    | Agent_sdk.Hooks.PreCompact _ -> Agent_sdk.Hooks.Continue
+    | Agent_sdk.Hooks.PreCompact _
+    | Agent_sdk.Hooks.OnContextCompacted _ -> Agent_sdk.Hooks.Continue
 
 (** Install the verifier hook into an existing OAS hooks record.
 


### PR DESCRIPTION
## Summary

Fixes #7802. Pinned OAS (`agent_sdk 0.155.0` at `6c79cf3f`) has diverged from what masc-mcp's source files expect since the last pin bump (#7672, v0.153.0). Three specific drifts were blocking local `dune build`:

| # | OAS change                                                          | masc-mcp symptom                                        |
|---|---------------------------------------------------------------------|---------------------------------------------------------|
| 1 | `Event_bus.TaskStateChanged` removed as dead code (`d3434799`)      | `Error: Unbound constructor ... TaskStateChanged`      |
| 2 | `Event_bus.{AgentFailed, HandoffRequested, HandoffCompleted}` added in 0.154.0 | partial-match warning (bridge's exhaustive match broken) |
| 3 | `Hooks.OnContextCompacted` added as post-compaction hook variant    | partial-match warning in verifier's exhaustive ignore |

## Fix

### `lib/oas_sse_bridge.ml`
- Drop the `TaskStateChanged` match arm. A comment at the deletion site records the upstream rationale (`d3434799`: "never had emit sites or subscribers") so a future reader does not re-introduce it by reflex.
- Add relay arms for the three new variants. Payload shapes mirror the OAS record fields. `Agent_sdk.Error.to_string` serialises the `AgentFailed` error field.

### `lib/verifier_oas.ml`
- Append `OnContextCompacted _` to the exhaustive-ignore pattern, keeping the verifier hook's pass-through semantics consistent for every non-`PreToolUse` event.

## Why not bump the pin forward

The pin is already at `6c79cf3f` (v0.155.0) — **newer** than what masc-mcp main tracks. Bumping further would either land us back on a branch older than the drift-causing refactor (pointless) or pick up even newer unreleased OAS commits with their own drift risk. Matching the pin we already committed to is the minimum change that unblocks CI.

## Test plan

- [x] `dune build --root .` — clean (exit 0)
- [x] `dune exec test/test_circuit_breaker.exe` — 8/8 pass (baseline preserved)
- [ ] CI green
- [ ] Verify stacked PRs (#7793 Phase 1, #7801 Phase 2) can now build once this lands

## Discovered through

Working on LT-16-KCB Phase 2 (#7801) — local build broke on `oas_sse_bridge.ml:202` and `verifier_oas.ml:200-212` even though the Phase 2 diff did not touch either file. Traced the drift to `git show 6c79cf3f:lib/event_bus.mli | grep TaskStateChanged` returning no match.

## Follow-ups (out of scope)

- Relay payloads for `AgentFailed` / `HandoffRequested` / `HandoffCompleted` are currently "best-effort shape-for-shape" — downstream SSE consumers (dashboard, CLI) may want richer payloads (e.g. elapsed formatting, error detail). Separate PR.
- OAS pin procedure SSOT: consider adding a `scripts/verify-oas-pin-surface.sh` that exits non-zero when `grep -n 'Agent_sdk\..*\.\w' lib/` finds constructors missing from the pinned version — would have caught this on the same day as the original removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
