### PR TITLE
fix(proactive_refresh): keep default timeout_s < interval_s (drops 3 silent clamp WARNs)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -325,7 +325,7 @@ let start_operator_snapshot_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"operator_snapshot"
                  ~interval_s:_operator_refresh_interval_s)
-              with timeout_s = 45.0;
+              with timeout_s = _operator_refresh_interval_s *. 0.8;
                    warm_delay_s = 120.0 }
     ~compute
     ~on_result:(fun json ->
@@ -372,7 +372,7 @@ let start_operator_digest_refresh_loop ~state ~sw ~clock =
     ~config:{ (Proactive_refresh.default_config
                  ~label:"operator_digest"
                  ~interval_s:_operator_refresh_interval_s)
-              with timeout_s = 45.0;
+              with timeout_s = _operator_refresh_interval_s *. 0.8;
                    warm_delay_s = 150.0 }
     ~compute
     ~on_result:(fun json ->

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -277,9 +277,12 @@ let _broadcast_namespace_truth_ref : (Mcp_server.server_state -> unit) ref =
 let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
   let room_config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
+  (* Default keeps timeout < interval (60s) so Proactive_refresh's clamp
+     at start does not fire every boot. Env var override can still push
+     above interval; runtime clamp remains the safety net. *)
   let execution_refresh_timeout_s =
     float_of_env_default "MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S"
-      ~default:75.0 ~min_v:30.0 ~max_v:300.0
+      ~default:48.0 ~min_v:30.0 ~max_v:300.0
   in
   let compute () =
     mark_cached_surface_attempt _execution_cache;


### PR DESCRIPTION
## Summary

audit issue **#7695** fix (Option B — defaults change).

Three proactive-refresh loops boot with `timeout_s >= interval_s`, so
`Proactive_refresh.start` clamps silently and emits three WARNs every restart:

```
WARN  execution:         timeout_s (75) >= interval_s (60), clamping to 48s
WARN  operator_digest:   timeout_s (45) >= interval_s (30), clamping to 24s
WARN  operator_snapshot: timeout_s (45) >= interval_s (30), clamping to 24s
```

The clamp is a #7164 safety net — correct to keep — but the defaults themselves
violate the invariant. Per #7695 this combination is a fake-heuristic anti-pattern:
*bad default + silent auto-correction + magic ratio*.

## Changes (2 files, 6+/3-, 3 call-sites)

### `execution` (execution_surfaces.ml:282)

```diff
+  (* Default keeps timeout < interval (60s) so Proactive_refresh's clamp
+     at start does not fire every boot. Env var override can still push
+     above interval; runtime clamp remains the safety net. *)
   let execution_refresh_timeout_s =
     float_of_env_default "MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S"
-      ~default:75.0 ~min_v:30.0 ~max_v:300.0
+      ~default:48.0 ~min_v:30.0 ~max_v:300.0
```

Interval is hardcoded 60.0 (line 308). New default (48) stays under. Env var override path preserved.

### `operator_snapshot` + `operator_digest` (core.ml:328, 375)

```diff
-              with timeout_s = 45.0;
+              with timeout_s = _operator_refresh_interval_s *. 0.8;
```

`_operator_refresh_interval_s` is env-driven (min 10, max 600, default 60).
Ratio-based timeout stays below interval across the whole range.

## Out of scope (follow-up)

- **Option A** (config-load validator refusing to boot on violation) is the deeper fix. Separate PR.
- **Magic 0.8** — still unverified. Leaves parity with runtime clamp factor; ratio justification is a separate concern.

## Validation

- Type-preserving (same `float` expressions)
- Post-fix behavior: 3 clamp WARNs disappear from boot log with default env
- Env var override path preserved (operators who consciously raise env var still get the runtime clamp)

Refs: #7695, #7164

🤖 Generated with [Claude Code](https://claude.com/claude-code)