### PR TITLE
feat(dashboard): persona-browser search + pure filter fn (iter-10)

### DIFF
--- a/dashboard/src/components/keeper-spawn/persona-browser.test.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { filterPersonas } from './persona-browser'
+import type { PersonaSummary } from './keeper-spawn-state'
+
+const sample: PersonaSummary[] = [
+  { name: 'analyst',  displayName: 'Analyst',  role: 'analysis',  mode: 'observer', description: 'inspects harness metrics' },
+  { name: 'executor', displayName: 'Executor', role: 'action',    mode: 'writer',   description: 'runs code edits' },
+  { name: 'scholar',  displayName: 'Scholar',  role: 'research',  mode: 'observer', description: 'reads papers and memory' },
+  { name: 'verifier', displayName: 'Verifier', role: 'guard',     mode: 'checker',  description: 'validates outputs' },
+  { name: 'uranium666', role: 'lab', description: 'experimental sandbox persona' },
+  { name: 'bare-persona' },
+]
+
+describe('filterPersonas', () => {
+  it('returns the input reference when query is empty', () => {
+    expect(filterPersonas(sample, '')).toBe(sample)
+    expect(filterPersonas(sample, '   ')).toBe(sample)
+  })
+
+  it('matches case-insensitive substring on name', () => {
+    const out = filterPersonas(sample, 'URANIUM')
+    expect(out.map(p => p.name)).toEqual(['uranium666'])
+  })
+
+  it('matches on displayName', () => {
+    const out = filterPersonas(sample, 'Scholar')
+    expect(out.map(p => p.name)).toEqual(['scholar'])
+  })
+
+  it('matches on role', () => {
+    const out = filterPersonas(sample, 'research')
+    expect(out.map(p => p.name)).toEqual(['scholar'])
+  })
+
+  it('matches on mode', () => {
+    const out = filterPersonas(sample, 'observer')
+    expect(out.map(p => p.name)).toEqual(['analyst', 'scholar'])
+  })
+
+  it('matches on description', () => {
+    const out = filterPersonas(sample, 'papers')
+    expect(out.map(p => p.name)).toEqual(['scholar'])
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    const out = filterPersonas(sample, '  action  ')
+    expect(out.map(p => p.name)).toEqual(['executor'])
+  })
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterPersonas(sample, 'no-such-token-xyz')).toEqual([])
+  })
+
+  it('tolerates personas missing optional fields', () => {
+    const out = filterPersonas(sample, 'bare')
+    expect(out.map(p => p.name)).toEqual(['bare-persona'])
+  })
+
+  it('does not mutate the input array', () => {
+    const snapshot = sample.slice()
+    filterPersonas(sample, 'analyst')
+    expect(sample).toEqual(snapshot)
+  })
+
+  it('returns a fresh array (not the input) when filtering narrows rows', () => {
+    const out = filterPersonas(sample, 'observer')
+    expect(out).not.toBe(sample)
+    expect(out.length).toBeLessThan(sample.length)
+  })
+})

--- a/dashboard/src/components/keeper-spawn/persona-browser.ts
+++ b/dashboard/src/components/keeper-spawn/persona-browser.ts
@@ -6,6 +6,32 @@ import { ActionButton } from '../common/button'
 import { personas, personasLoading, personasError, loadPersonas, spawnKeeperFromPersona, spawning, spawnResult, type PersonaSummary } from './keeper-spawn-state'
 
 const confirmTarget = signal<string | null>(null)
+const searchQuery = signal('')
+
+/**
+ * Pure filter for persona rows.
+ *
+ * - `query` is case-insensitive substring match across `name`, `displayName`,
+ *   `role`, `mode`, and `description` (trimmed).
+ * - Empty/whitespace-only query returns the input reference unchanged
+ *   (zero-allocation fast path).
+ * - Does not mutate the input array.
+ */
+export function filterPersonas(
+  rows: readonly PersonaSummary[],
+  query: string,
+): readonly PersonaSummary[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(p => {
+    if (p.name.toLowerCase().includes(needle)) return true
+    if (p.displayName && p.displayName.toLowerCase().includes(needle)) return true
+    if (p.role && p.role.toLowerCase().includes(needle)) return true
+    if (p.mode && p.mode.toLowerCase().includes(needle)) return true
+    if (p.description && p.description.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 function PersonaCard({ persona }: { persona: PersonaSummary }) {
   const isConfirming = confirmTarget.value === persona.name
@@ -45,11 +71,31 @@ export function PersonaBrowser() {
       <${ActionButton} variant="ghost" size="sm" onClick=${() => void loadPersonas()}>재시도<//>
     </div>`
   if (personas.value.length === 0) return html`<p class="text-[12px] text-[var(--text-muted)] py-4">등록된 페르소나가 없습니다.</p>`
+  const visible = filterPersonas(personas.value, searchQuery.value)
   return html`
     <div>
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-3">
-        ${personas.value.map(p => html`<${PersonaCard} key=${p.name} persona=${p} />`)}
+      <div class="flex flex-wrap items-center gap-2 mb-3">
+        <input
+          type="search"
+          value=${searchQuery.value}
+          placeholder="페르소나 검색 (이름/역할/모드/설명)"
+          aria-label="페르소나 검색"
+          onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[180px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+        <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+          ${searchQuery.value.trim()
+            ? `${visible.length} / ${personas.value.length}`
+            : `${personas.value.length}개`}
+        </span>
       </div>
+      ${visible.length === 0
+        ? html`<p class="text-[12px] text-[var(--text-muted)] py-4">검색 조건에 맞는 페르소나가 없습니다.</p>`
+        : html`
+          <div class="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-3">
+            ${visible.map(p => html`<${PersonaCard} key=${p.name} persona=${p} />`)}
+          </div>
+        `}
       ${spawnResult.value ? html`
         <${SurfaceCard} class="mt-3" variant="compact">
           <pre class="text-[11px] font-mono overflow-x-auto max-h-[200px] overflow-y-auto


### PR DESCRIPTION
## Summary
- Adds case-insensitive search across persona name / displayName / role / mode / description to the keeper-spawn PersonaBrowser grid.
- Extracts `filterPersonas(rows, query)` as a pure fn — zero-alloc fast path on empty query, no input mutation — directly unit-testable without mounting the component.
- UI adds a `type=\"search\"` input + live \"visible / total\" counter and a distinct empty-message when search narrows to zero.
- 10 new vitest cases (per searchable field, whitespace trim, empty match, tolerance for missing optional fields, immutability).

## Target + why
- `dashboard/src/components/keeper-spawn/persona-browser.ts` — rendered a flat grid of personas with no search. As persona catalogs grow (shared/ + per-agent + symlinked remotes like `uranium666`), finding the right persona before spawning a keeper was purely visual.
- Outside every listed collision zone (keeper-* panels targeted by prior iter PRs are distinct modules).

## Files
- `dashboard/src/components/keeper-spawn/persona-browser.ts` (+48 / -2)
- `dashboard/src/components/keeper-spawn/persona-browser.test.ts` (+70, new)

## Iter rhythm
Follows #7694, #7706, #7717, #7741, #7751, #7767, #7775, #7783 (all merged) and #7804 (iter-9 in-flight). Same recipe: pure filter fn + search input + dedicated test file, dashboard-only, small surface.

## Test plan
- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (clean)
- [x] `pnpm test` — 177 files / 2677 tests pass (new 10 included)
- [ ] CI green on required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)