### PR TITLE
feat(tasks): cancel hook — bump cycle_count + auto-set DNR (v2)

### DIFF
--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -1256,11 +1256,32 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
             else begin
               let new_tasks = List.map (fun t ->
                 if t.id = task_id then
-                  { t with task_status = Types.Cancelled {
-                    cancelled_by = agent_name;
-                    cancelled_at = now_iso ();
-                    reason = if reason = "" then None else Some reason
-                  }}
+                  let new_cycle = t.cycle_count + 1 in
+                  (* Auto-set do_not_reclaim_reason when the operator flags
+                     a hard stop in the cancel reason, or after 3 cycles. *)
+                  let auto_dnr =
+                    match t.do_not_reclaim_reason with
+                    | Some _ as existing -> existing
+                    | None ->
+                        let lower = String.lowercase_ascii reason in
+                        let flagged =
+                          String_util.contains_substring lower "do not reclaim"
+                          || String_util.contains_substring lower "scope mismatch"
+                        in
+                        if flagged && reason <> "" then Some reason
+                        else if new_cycle >= 3 then
+                          Some (Printf.sprintf "auto: %d cancellations" new_cycle)
+                        else None
+                  in
+                  { t with
+                    task_status = Types.Cancelled {
+                      cancelled_by = agent_name;
+                      cancelled_at = now_iso ();
+                      reason = if reason = "" then None else Some reason
+                    };
+                    cycle_count = new_cycle;
+                    do_not_reclaim_reason = auto_dnr;
+                  }
                 else t
               ) backlog.tasks in
               let new_backlog = {


### PR DESCRIPTION
## Summary

Reopens the cycle-prevention track's cancel hook after #7798 auto-closed during the #7794 squash merge + rebase sequence (GitHub tagged #7798 as "merged" against a stale hash; actual hook code did not land in main).

Extends `Coord_task.cancel_task_r`:

- Increment `cycle_count` on every cancel.
- When the cancel `reason` contains "do not reclaim" or "scope mismatch" (case-insensitive), copy it into `do_not_reclaim_reason`.
- After 3 cycles, auto-populate `do_not_reclaim_reason = "auto: N cancellations"`.
- Existing `do_not_reclaim_reason` values are preserved.

Identical diff to the previous #7798; the only reason for a new PR is the closed-branch artifact.

## Stack
Schema (#7794) is merged. This PR can merge on its own. Claim gate (#7803) still pending and depends on this.

## Test plan
- `dune build _build/default/lib/coord/masc_coord.cma` → pass (local).
- CI for runtest + full build.

## Motivation
sojin metrics task-108/117 (30+ episode claim→release cycles). Structured bookkeeping for the forthcoming claim gate.