### PR TITLE
fix(doc-truth): drop 04-chain-engine.md require_contains

### DIFF
--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -128,10 +128,6 @@ require_contains docs/spec/00-glossary.md '**Team Session** (retired)'
 require_contains docs/OAS-MASC-BOUNDARY.md '| Team-session swarm | Removed |'
 require_not_contains docs/OAS-MASC-BOUNDARY.md '| `lib/team_session/team_session_oas_bridge.ml` | Acceptable'
 
-# PR #7747: 04-chain-engine.md archived with explicit banner
-require_contains docs/spec/04-chain-engine.md '# Chain Engine — ARCHIVED'
-require_contains docs/spec/04-chain-engine.md '| Status | Archived |'
-
 docs_to_scan=(
   README.md
   ROADMAP.md


### PR DESCRIPTION
## 문제
#7796 머지로 `docs/spec/04-chain-engine.md` 파일 자체가 삭제되었으나, `scripts/check-doc-truth.sh`는 여전히 해당 파일의 archive banner 텍스트를 요구합니다:
```
doc truth check failed: docs/spec/04-chain-engine.md is missing expected text: # Chain Engine — ARCHIVED
```
이로 인해 CI Gate가 다수 PR(#7789, #7814 등)에서 실패.

## 해결
`require_contains` 3줄 제거 (#7747 archived banner 방식에서 #7796 완전 삭제로 전환된 상태에 맞춤).

## Test
- [x] `bash scripts/check-doc-truth.sh` 통과 확인 (CI)