### PR TITLE
chore(keeper_telemetry): remove pr_workflow_attempts (dead counter — tool never registered)

### DIFF
--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -16,7 +16,6 @@ type behavioral_stats = {
   unique_tools_used : string list;
   tool_utilization_rate : float;
   last_visible_action_age_sec : int;
-  pr_workflow_attempts : int;
   work_discovery_count : int;
 }
 
@@ -30,7 +29,6 @@ let empty_stats ~window_hours =
     unique_tools_used = [];
     tool_utilization_rate = 0.0;
     last_visible_action_age_sec = 0;
-    pr_workflow_attempts = 0;
     work_discovery_count = 0;
   }
 
@@ -122,12 +120,6 @@ let compute_stats ~decision_log_path ~window_hours =
     let total_tool_calls =
       List.fold_left (fun acc d -> acc + d.tool_call_count) 0 decisions
     in
-    let pr_workflow_attempts =
-      List.length (List.filter (fun d ->
-        List.exists (fun t ->
-          String.lowercase_ascii t = "keeper_pr_workflow") d.tools_used
-      ) decisions)
-    in
     let last_visible_ts =
       decisions
       |> List.filter (fun d -> not (is_silent d))
@@ -159,7 +151,6 @@ let compute_stats ~decision_log_path ~window_hours =
       unique_tools_used = unique_tools;
       tool_utilization_rate;
       last_visible_action_age_sec;
-      pr_workflow_attempts;
       work_discovery_count = 0;
     }
 

--- a/lib/keeper/keeper_telemetry_feedback.mli
+++ b/lib/keeper/keeper_telemetry_feedback.mli
@@ -16,7 +16,6 @@ type behavioral_stats = {
   unique_tools_used : string list;
   tool_utilization_rate : float;
   last_visible_action_age_sec : int;
-  pr_workflow_attempts : int;
   work_discovery_count : int;
 }
 

--- a/test/test_keeper_telemetry_feedback.ml
+++ b/test/test_keeper_telemetry_feedback.ml
@@ -50,7 +50,6 @@ let () =
   assert (stats.silent_turns = 1);
   assert (stats.tool_use_turns = 1);
   assert (stats.text_response_turns = 1);
-  assert (stats.pr_workflow_attempts = 1);
   assert (List.length stats.unique_tools_used = 2);
   assert (List.mem "keeper_board_list" stats.unique_tools_used);
   assert (List.mem "keeper_pr_workflow" stats.unique_tools_used);


### PR DESCRIPTION
## Summary

audit issue **#7696** follow-up (3/4 slice, after Gen18 #7805).

`keeper_pr_workflow`는 어떤 MCP tool dispatcher에도 등록된 적이 없다. 그러나 `lib/keeper/keeper_telemetry_feedback.ml`이 이 이름을 lowercase match로 세는 `pr_workflow_attempts` counter record field를 유지하고 있어:

- `.mli`에 exported되어 있지만 production 값은 항상 `0` (count 대상 tool 없음)
- Test에서만 synthetic input `tools_used:["keeper_pr_workflow"]`로 1을 assert (field 존재를 지키는 용도일 뿐 실제 telemetry 근거 없음)

Internal API (`Masc_mcp.Keeper_telemetry_feedback.behavioral_stats`)는 external consumer 없음. Safe clean removal.

## Changes (3 files, 11 deletions)

| File | Site | Removed |
|------|------|---------|
| `lib/keeper/keeper_telemetry_feedback.mli` | L19 | record field |
| `lib/keeper/keeper_telemetry_feedback.ml` | L19 | type field |
| `lib/keeper/keeper_telemetry_feedback.ml` | L33 | `empty_stats` initializer |
| `lib/keeper/keeper_telemetry_feedback.ml` | L125-130 | compute block (`List.length (List.filter ...)`) |
| `lib/keeper/keeper_telemetry_feedback.ml` | L162 | record construction |
| `test/test_keeper_telemetry_feedback.ml` | L53 | dead assert |

인근 `assert (List.mem \"keeper_pr_workflow\" stats.unique_tools_used)`은 유지 — generic \"lower-level `unique_tools_used` set가 input strings를 그대로 수집\" property이며 tool 이름이 무엇이든 pass.

## Audit issue #7696 상태

- ✅ `keeper_pr_submit` docstring + runtime hint (#7805 merged)
- ✅ `keeper_pr_workflow` telemetry counter (이 PR)
- ❌ `keeper_board_cleanup` / `keeper_board_delete`: admin-only tool (#4309), dispatch 등록되어 있음. Validator에 admin tier awareness를 추가하는 별도 PR 필요.

## Validation

- `rg 'pr_workflow_attempts' lib/ test/` → 0 matches
- External consumer audit: `.mli` field는 test만 참조 (no bin/ / no lib/ cross-references)
- 타입-consistent (3 files 동기화)

Refs: #7696

🤖 Generated with [Claude Code](https://claude.com/claude-code)