### PR TITLE
fix(costs): add provider field to .masc/costs.jsonl entries

### DIFF
--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -41,10 +41,13 @@ let keeper_denied_tools =
     heuristic over known bare-name shapes. Returns [unknown] rather
     than guessing when no rule fits, so analysis queries can filter
     those rows out rather than miscount them. *)
+let known_providers = [
+  "glm-coding"; "glm"; "claude"; "claude_code";
+  "gemini"; "gemini_cli"; "codex_cli"; "ollama";
+]
+
 let provider_of_model (model : string) : string =
-  match String.index_opt model ':' with
-  | Some i -> String.sub model 0 i
-  | None ->
+  let bare_heuristic () =
     let starts_with prefix =
       String.length model >= String.length prefix
       && String.sub model 0 (String.length prefix) = prefix
@@ -55,6 +58,13 @@ let provider_of_model (model : string) : string =
     else if starts_with "gpt-" then "openai"
     else if starts_with "qwen" || starts_with "llama" then "ollama"
     else "unknown"
+  in
+  match String.index_opt model ':' with
+  | Some i ->
+    let prefix = String.sub model 0 i in
+    if List.mem prefix known_providers then prefix
+    else bare_heuristic ()
+  | None -> bare_heuristic ()
 
 (** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
     Schema matches bin/masc_cost.ml with an additional "source" field to

--- a/lib/keeper/keeper_hooks_oas.ml
+++ b/lib/keeper/keeper_hooks_oas.ml
@@ -28,6 +28,34 @@ let keeper_denied_tools =
    them there avoids a circular dependency and concentrates the
    gate-level concerns in one module. *)
 
+(** Derive a provider label from a model id.
+
+    Benchmarking downstream (e.g. 15-keeper cascade weighted_random turns)
+    needs to group costs.jsonl rows by provider. The raw [model] field
+    mixes two conventions:
+    - prefixed: [glm-coding:glm-5-turbo], [claude:claude-haiku-4-5-20251001]
+    - bare: [glm-5-turbo], [claude-haiku-4-5-20251001] (emitted by some
+      OAS transports that strip the scheme before reporting)
+
+    Prefer the prefix when present; otherwise fall back to a minimal
+    heuristic over known bare-name shapes. Returns [unknown] rather
+    than guessing when no rule fits, so analysis queries can filter
+    those rows out rather than miscount them. *)
+let provider_of_model (model : string) : string =
+  match String.index_opt model ':' with
+  | Some i -> String.sub model 0 i
+  | None ->
+    let starts_with prefix =
+      String.length model >= String.length prefix
+      && String.sub model 0 (String.length prefix) = prefix
+    in
+    if starts_with "glm-" then "glm-coding"
+    else if starts_with "claude-" then "claude"
+    else if starts_with "gemini-" then "gemini"
+    else if starts_with "gpt-" then "openai"
+    else if starts_with "qwen" || starts_with "llama" then "ollama"
+    else "unknown"
+
 (** Append a cost event to .masc/costs.jsonl for per-task cost attribution.
     Schema matches bin/masc_cost.ml with an additional "source" field to
     distinguish automatic entries from manual CLI entries.
@@ -59,6 +87,7 @@ let emit_cost_event
   let entry = `Assoc ([
     ("agent", `String agent_name);
     ("task_id", Json_util.string_opt_to_json task_id);
+    ("provider", `String (provider_of_model model));
     ("model", `String model);
     ("input_tokens", `Int input_tokens);
     ("output_tokens", `Int output_tokens);

--- a/test/dune
+++ b/test/dune
@@ -46,6 +46,7 @@
         test_post_verifier
         test_swarm_checkpoint test_swarm_goal_loop
         test_keeper_cascade_profile
+        test_keeper_hooks_oas_provider
         test_keeper_memory
         test_keeper_accountability
         test_keeper_exec_status
@@ -137,6 +138,7 @@
           test_post_verifier
           test_swarm_checkpoint test_swarm_goal_loop
           test_keeper_cascade_profile
+          test_keeper_hooks_oas_provider
           test_keeper_memory
           test_keeper_accountability
           test_keeper_exec_status

--- a/test/test_keeper_hooks_oas_provider.ml
+++ b/test/test_keeper_hooks_oas_provider.ml
@@ -1,0 +1,64 @@
+open Alcotest
+
+module Hooks = Masc_mcp.Keeper_hooks_oas
+
+(* Verify provider_of_model handles the three patterns live costs.jsonl
+   currently mixes: prefixed schemes, bare model ids emitted by some OAS
+   transports, and truly unrecognised strings (should route to "unknown"
+   rather than guess). *)
+let cases_prefix = [
+  "glm-coding:glm-5-turbo",                "glm-coding";
+  "glm-coding:glm-5.1",                    "glm-coding";
+  "glm:glm-5-turbo",                       "glm";
+  "claude:claude-haiku-4-5-20251001",      "claude";
+  "claude_code:haiku",                     "claude_code";
+  "gemini:gemini-2.5-flash",               "gemini";
+  "gemini_cli:gemini-2.5-flash",           "gemini_cli";
+  "codex_cli:gpt-5.4",                     "codex_cli";
+  "ollama:qwen3.5:35b-a3b-nvfp4",          "ollama";
+]
+
+let cases_bare = [
+  "glm-5-turbo",                           "glm-coding";
+  "glm-4.7",                               "glm-coding";
+  "claude-haiku-4-5-20251001",             "claude";
+  "gemini-2.5-flash",                      "gemini";
+  "gpt-5.4",                               "openai";
+  "qwen3.5:35b-a3b-nvfp4",                 "ollama";
+  "llama-3.1-70b",                         "ollama";
+]
+
+let cases_unknown = [
+  "",                                      "unknown";
+  "definitely-not-a-real-model",           "unknown";
+  "mystery-xyz-4",                         "unknown";
+]
+
+let test_prefix () =
+  List.iter
+    (fun (input, want) ->
+      let got = Hooks.provider_of_model input in
+      check string ("prefix: " ^ input) want got)
+    cases_prefix
+
+let test_bare () =
+  List.iter
+    (fun (input, want) ->
+      let got = Hooks.provider_of_model input in
+      check string ("bare: " ^ input) want got)
+    cases_bare
+
+let test_unknown () =
+  List.iter
+    (fun (input, want) ->
+      let got = Hooks.provider_of_model input in
+      check string ("unknown: " ^ input) want got)
+    cases_unknown
+
+let () =
+  run "keeper_hooks_oas/provider_of_model"
+    [ ( "provider_classification",
+        [ test_case "prefixed schemes" `Quick test_prefix;
+          test_case "bare model ids" `Quick test_bare;
+          test_case "unknown routes to unknown" `Quick test_unknown ] )
+    ]


### PR DESCRIPTION
## Summary

라이브 `costs.jsonl` 232/232 행에 `provider` 필드가 없어서 벤치마크/비용 귀속 분석이 `model` 문자열 prefix에 의존해야 했습니다. 일부 OAS transport가 scheme prefix를 벗겨 `glm-5-turbo`처럼 bare id만 남기면 provider 구분이 깨집니다. 이 PR은 모든 cost event에 `provider` 필드를 자동으로 쓰게 합니다.

## Changes

- `lib/keeper/keeper_hooks_oas.ml`:
  - `provider_of_model` 헬퍼 추가. `:` prefix가 있으면 앞부분을 그대로 사용. 없으면 알려진 bare shape(`glm-/claude-/gemini-/gpt-/qwen/llama`)로 fallback. 그 외는 `unknown`으로 라우팅 (추측 금지).
  - `emit_cost_event` entry에 `("provider", \`String ...)` 추가.
- `test/test_keeper_hooks_oas_provider.ml` (신규, Alcotest 3 case): prefixed 9건, bare 7건, unknown 3건.
- `test/dune`: 신규 테스트 2 군데 등록.

## Compatibility

- Caller 시그니처 변경 없음. `emit_cost_event`는 기존 인자 그대로.
- 기존 필드 보존 — `agent/task_id/model/input_tokens/output_tokens/cost_usd/timestamp/source/reasoning_tokens/cache_n/request_latency_ms` 그대로.
- 기존 costs.jsonl reader가 unknown field를 무시하면 forward-compatible.

## Test plan

- [x] Local: `provider_of_model` 19 assertion 작성 (prefix/bare/unknown).
- [ ] CI: `dune test test_keeper_hooks_oas_provider` 통과.
- [ ] CI: 전체 suite regress 없음.

## Followups (out of scope)

이 PR은 스키마만 수정합니다. **`request_latency_ms`, `cost_usd`, `duration_ms`** 가 0/null로 쌓이는 문제는 caller/OAS 쪽 telemetry 전달 버그로 별도 PR이 필요합니다:
- `request_latency_ms` 0 — OAS `response.telemetry` 가 None 혹은 `t.request_latency_ms=0`으로 전달됨. 이미 `masc_after_turn_telemetry_zero_latency_total` / `masc_after_turn_telemetry_missing_total` Prometheus 카운터가 존재하므로 어느 쪽인지 먼저 진단.
- `cost_usd` 0.0 — OAS Pricing.annotate_response_cost가 GLM 가격 테이블을 갖고 있지 않을 가능성.
- `duration_ms` 필드 자체 없음 — turn_duration_sec 로그엔 있지만 costs.jsonl에 안 전달됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)