### PR TITLE
feat(dashboard): surface KCB as 6th matrix axis (LT-16-KCB Phase 3)

### DIFF
--- a/dashboard/src/api/schemas/keeper-composite.test.ts
+++ b/dashboard/src/api/schemas/keeper-composite.test.ts
@@ -116,4 +116,30 @@ describe('parseKeeperCompositeSnapshot', () => {
       expect((e as CompositeSchemaDriftError).message).toContain('schema drift')
     }
   })
+
+  // LT-16-KCB Phase 3 — 6th axis parsing
+  it('accepts snapshot with circuit_breaker.state = warning', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      circuit_breaker: { state: 'warning' },
+    })
+    expect(result.circuit_breaker).toBeDefined()
+    expect(result.circuit_breaker!.state).toBe('warning')
+  })
+
+  it('falls back unknown circuit_breaker.state to clean', () => {
+    const result = parseKeeperCompositeSnapshot({
+      ...VALID_SNAPSHOT,
+      circuit_breaker: { state: 'completely-new-future-variant' },
+    })
+    expect(result.circuit_breaker!.state).toBe('clean')
+  })
+
+  it('tolerates missing circuit_breaker during Phase 2 → 3 rollout', () => {
+    // Pinned backends that have not yet picked up LT-16-KCB Phase 2
+    // emit snapshots without the key. The dashboard must keep
+    // rendering instead of hard-failing the parse.
+    const result = parseKeeperCompositeSnapshot(VALID_SNAPSHOT)
+    expect(result.circuit_breaker).toBeUndefined()
+  })
 })

--- a/dashboard/src/api/schemas/keeper-composite.ts
+++ b/dashboard/src/api/schemas/keeper-composite.ts
@@ -79,6 +79,16 @@ const KeeperCompositeCompactionStageSchema = fallback(
   'accumulating',
 )
 
+// LT-16-KCB Phase 3: 6th axis. KCB is counter-based, not a classical
+// Closed/Open/Half_open FSM — only three states are observable between
+// tool calls because `record_failure` resets `consecutive_count` to 0
+// inside the trip transition. See
+// `lib/keeper/keeper_failure_circuit_breaker.mli`.
+const KeeperCompositeCircuitBreakerStateSchema = fallback(
+  picklist(['clean', 'warning', 'cooling']),
+  'clean',
+)
+
 const KeeperCompositeAutoRulesSchema = object({
   reflect: boolean(),
   plan: boolean(),
@@ -118,6 +128,16 @@ export const KeeperCompositeSnapshotSchema = object({
   decision: object({ stage: KeeperCompositeDecisionStageSchema }),
   cascade: object({ state: KeeperCompositeCascadeStateSchema }),
   compaction: object({ stage: KeeperCompositeCompactionStageSchema }),
+  // `circuit_breaker` is `optional` during the Phase 2 → Phase 3
+  // rollout window: pinned backends that have not yet picked up
+  // PR #7801 emit snapshots without this key, and the dashboard must
+  // keep rendering instead of hard-failing the parse. Once the
+  // backend pin catches up everywhere, a follow-up can drop
+  // `optional` (promote the key to required with the `clean` fallback
+  // alone).
+  circuit_breaker: optional(
+    object({ state: KeeperCompositeCircuitBreakerStateSchema }),
+  ),
   measurement: KeeperCompositeMeasurementSchema,
   invariants: KeeperCompositeInvariantsSchema,
   is_live: boolean(),
@@ -133,6 +153,7 @@ export type KeeperCompositeTurnPhase = InferOutput<typeof KeeperCompositeTurnPha
 export type KeeperCompositeDecisionStage = InferOutput<typeof KeeperCompositeDecisionStageSchema>
 export type KeeperCompositeCascadeState = InferOutput<typeof KeeperCompositeCascadeStateSchema>
 export type KeeperCompositeCompactionStage = InferOutput<typeof KeeperCompositeCompactionStageSchema>
+export type KeeperCompositeCircuitBreakerState = InferOutput<typeof KeeperCompositeCircuitBreakerStateSchema>
 
 export class CompositeSchemaDriftError extends SchemaDriftError {
   constructor(issues: readonly BaseIssue<unknown>[]) {

--- a/dashboard/src/components/composite-fsm-flowchart.test.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.test.ts
@@ -9,8 +9,8 @@ describe('buildCompositeFsmMermaid', () => {
     expect(src.startsWith('flowchart TB')).toBe(true)
   })
 
-  it('declares a subgraph per axis', () => {
-    for (const axis of ['KSM', 'KTC', 'KDP', 'KCL', 'KMC']) {
+  it('declares a subgraph per axis (6 including KCB)', () => {
+    for (const axis of ['KSM', 'KTC', 'KDP', 'KCL', 'KMC', 'KCB']) {
       // `subgraph KSM ["..."]` etc.
       expect(src).toMatch(new RegExp(`subgraph ${axis} `))
     }
@@ -55,5 +55,22 @@ describe('buildCompositeFsmMermaid', () => {
 
   it('tags KDP gate_rejected as an error state', () => {
     expect(src).toMatch(/class .*kdp_gate_rejected.*error/)
+  })
+
+  it('renders the 3 observable KCB states and omits tripped', () => {
+    // The unobservable-by-design "tripped" state must not appear as a
+    // node — the mutator resets consecutive_count before any snapshot
+    // can see it. See display_state.mli.
+    expect(src).toContain('kcb_clean["clean"]')
+    expect(src).toContain('kcb_warning["warning"]')
+    expect(src).toContain('kcb_cooling["cooling"]')
+    // Bracket-declaration check: no node named tripped at all.
+    expect(src).not.toMatch(/kcb_tripped\[/)
+  })
+
+  it('uses a dashed edge for warning → cooling (acknowledging the transient Trip)', () => {
+    // Dashed arrow is a visual note that the transition exists inside
+    // the mutator's read-modify-write but is not directly renderable.
+    expect(src).toMatch(/kcb_warning\s*-\.->\s*kcb_cooling/)
   })
 })

--- a/dashboard/src/components/composite-fsm-flowchart.ts
+++ b/dashboard/src/components/composite-fsm-flowchart.ts
@@ -1,7 +1,7 @@
 /**
- * CompositeFsmFlowchart (LT-16e)
+ * CompositeFsmFlowchart (LT-16e + LT-16-KCB Phase 3)
  *
- * Static Mermaid rendering of the 5 orthogonal keeper FSM axes from
+ * Static Mermaid rendering of the 6 orthogonal keeper FSM axes from
  * KeeperCompositeLifecycle.tla, side by side. Each subgraph is one
  * region (Harel parallel region); the subgraphs do not share edges
  * because the axes are orthogonal by design — the invariants that
@@ -92,15 +92,31 @@ const MERMAID_COMPOSITE: string = `flowchart TB
     kmc_done --> kmc_accumulating
   end
 
+  %% ─ KCB (Circuit breaker, 3 observable states) ──────────
+  %% Tripped is deliberately absent — see display_state.mli: the
+  %% mutator resets consecutive_count on trip, so no snapshot taken
+  %% between tool calls can observe Tripped. The dashed arrow is a
+  %% reminder that the unobservable transition exists inside the
+  %% counter's read-modify-write, not that it's a state we render.
+  subgraph KCB ["Circuit breaker · KCB"]
+    direction LR
+    kcb_clean["clean"] --> kcb_warning["warning"]
+    kcb_warning --> kcb_clean
+    kcb_warning -.-> kcb_cooling["cooling"]
+    kcb_cooling --> kcb_warning
+    kcb_cooling --> kcb_clean
+  end
+
   classDef terminal fill:#1f0f0f,stroke:#7f1d1d,color:#fca5a5
   classDef stable   fill:#0f1a0f,stroke:#166534,color:#86efac
   classDef motion   fill:#1a1305,stroke:#a16207,color:#fde68a
   classDef error    fill:#1e0a0a,stroke:#b91c1c,color:#fca5a5
 
   class ksm_stopped,ksm_dead terminal
-  class ksm_running,ksm_paused,ktc_idle,kcl_idle,kmc_accumulating stable
-  class ksm_compacting,ksm_handingoff,ksm_overflowed,ksm_draining,ksm_restarting,ktc_prompting,ktc_executing,ktc_compacting,ktc_finalizing,kcl_selecting,kcl_trying,kmc_compacting motion
+  class ksm_running,ksm_paused,ktc_idle,kcl_idle,kmc_accumulating,kcb_clean stable
+  class ksm_compacting,ksm_handingoff,ksm_overflowed,ksm_draining,ksm_restarting,ktc_prompting,ktc_executing,ktc_compacting,ktc_finalizing,kcl_selecting,kcl_trying,kmc_compacting,kcb_warning motion
   class ksm_failing,ksm_crashed,kdp_gate_rejected,kcl_exhausted error
+  class kcb_cooling motion
 `
 
 /**
@@ -128,7 +144,7 @@ export function CompositeFsmFlowchart(props: CompositeFsmFlowchartProps = {}) {
           Composite FSM flowchart (TLA+ spec)
         </h2>
         <p class="mt-1 text-xs text-zinc-400">
-          5 orthogonal axes rendered as Harel parallel regions. Source:
+          6 orthogonal axes rendered as Harel parallel regions. Source:
           <code class="text-zinc-300">specs/keeper-state-machine/*.tla</code>.
           Transitions here are the common-case edges; the TLA+
           model-checker owns the exhaustive enumeration.

--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -49,6 +49,9 @@ describe('chipClassFor', () => {
     expect(chipClassFor('Failing')).toMatch(/red/)
     expect(chipClassFor('Compacting')).toMatch(/amber/)
     expect(chipClassFor('exhausted')).toMatch(/red/)
+    // KCB (LT-16-KCB Phase 3)
+    expect(chipClassFor('warning')).toMatch(/amber/)
+    expect(chipClassFor('cooling')).toMatch(/sky/)
   })
 
   it('falls back to the default chip for unknown states', () => {
@@ -154,5 +157,21 @@ describe('pushObservation', () => {
     const prior = {}
     const next = pushObservation(prior, [snapshot({ name: 'alpha' })])
     expect(next).not.toBe(prior)
+  })
+
+  it('includes the KCB breaker axis in a fresh seed (default=clean)', () => {
+    const next = pushObservation({}, [snapshot({ name: 'alpha' })])
+    // The snapshot helper omits `circuit_breaker`, mirroring a pinned
+    // backend that has not yet shipped LT-16-KCB Phase 2. The matrix
+    // must still seed a value instead of leaving the axis undefined.
+    expect(next.alpha!.breaker).toEqual(['clean'])
+  })
+
+  it('tracks KCB warning→cooling over successive polls', () => {
+    const warn = snapshot({ name: 'beta', circuit_breaker: { state: 'warning' } })
+    const cool = snapshot({ name: 'beta', circuit_breaker: { state: 'cooling' } })
+    const t1 = pushObservation({}, [warn])
+    const t2 = pushObservation(t1, [cool])
+    expect(t2.beta!.breaker).toEqual(['warning', 'cooling'])
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -48,12 +48,18 @@ export const FLEET_HISTORY_LEN = 30
 // Keep it identical to TRANSITION_FIELDS so an operator scanning
 // left-to-right sees "lifecycle → turn → decision → cascade →
 // compaction" — the natural causal order of a turn.
+// 6 axes (LT-16-KCB Phase 3 added KCB). Causal order: lifecycle →
+// turn → decision → cascade → compaction → circuit-breaker. KCB sits
+// at the tail because its state is derived from the *outcome* of the
+// cascade's tool calls (failure streak counter), so it is temporally
+// downstream of the other five for any given turn.
 const AXES: Array<{ key: LaneKey; label: string; acronym: string }> = [
   { key: 'phase',      label: 'Lifecycle',   acronym: 'KSM' },
   { key: 'turn',       label: 'Turn',        acronym: 'KTC' },
   { key: 'decision',   label: 'Decision',    acronym: 'KDP' },
   { key: 'cascade',    label: 'Cascade',     acronym: 'KCL' },
   { key: 'compaction', label: 'Compaction',  acronym: 'KMC' },
+  { key: 'breaker',    label: 'Breaker',     acronym: 'KCB' },
 ]
 
 const INVARIANT_KEYS = Object.keys(INVARIANT_LABELS) as Array<
@@ -94,6 +100,15 @@ const CHIP_CLASS_BY_STATE: Record<string, string> = {
   exhausted:    'bg-red-900/50 text-red-200 border-red-700',
   // KMC
   accumulating: 'bg-zinc-800 text-zinc-400 border-zinc-700',
+  // KCB (LT-16-KCB Phase 3). Clean = baseline grey same as any other
+  // "nothing happening" state; warning = amber (partial failure
+  // streak); cooling = blue (at least one past trip, currently
+  // recovered). "tripped" is unobservable at snapshot time and has no
+  // chip colour by design — the mutator resets the count before any
+  // observer can see it.
+  clean:   'bg-zinc-800 text-zinc-400 border-zinc-700',
+  warning: 'bg-amber-900/50 text-amber-200 border-amber-700',
+  cooling: 'bg-sky-900/40 text-sky-200 border-sky-700',
 }
 
 const DEFAULT_CHIP = 'bg-zinc-800 text-zinc-300 border-zinc-700'
@@ -116,7 +131,7 @@ export function sparkClassFor(value: string): string {
 /** Per-axis observation ring keyed by keeper name. */
 export type KeeperFleetHistory = Record<string, Record<LaneKey, string[]>>
 
-const AXIS_KEYS: LaneKey[] = ['phase', 'turn', 'decision', 'cascade', 'compaction']
+const AXIS_KEYS: LaneKey[] = ['phase', 'turn', 'decision', 'cascade', 'compaction', 'breaker']
 
 /**
  * Fold an incoming batch of snapshots into the running history, capping
@@ -141,6 +156,7 @@ export function pushObservation(
       decision:   prev?.decision   ? prev.decision.slice()   : [],
       cascade:    prev?.cascade    ? prev.cascade.slice()    : [],
       compaction: prev?.compaction ? prev.compaction.slice() : [],
+      breaker:    prev?.breaker    ? prev.breaker.slice()    : [],
     }
     for (const axis of AXIS_KEYS) {
       perAxis[axis].push(extractLaneValue(snap, axis))

--- a/dashboard/src/components/fsm-hub-derivations.test.ts
+++ b/dashboard/src/components/fsm-hub-derivations.test.ts
@@ -24,6 +24,7 @@ function obs(overrides: Partial<CompositeObservation> & { ts: number }): Composi
     decision: 'undecided',
     cascade: 'idle',
     compaction: 'accumulating',
+    breaker: 'clean',
     ...overrides,
   }
 }

--- a/dashboard/src/components/fsm-hub-derivations.ts
+++ b/dashboard/src/components/fsm-hub-derivations.ts
@@ -25,6 +25,10 @@ export function observeSnapshot(
     decision: snapshot.decision.stage,
     cascade: snapshot.cascade.state,
     compaction: snapshot.compaction.stage,
+    // LT-16-KCB Phase 3: default to 'clean' when the backend has not
+    // yet emitted circuit_breaker. Matches extractLaneValue's
+    // defaulting so history rings and lane derivations agree.
+    breaker: snapshot.circuit_breaker?.state ?? 'clean',
   }
 }
 

--- a/dashboard/src/components/fsm-hub-lane-analysis.ts
+++ b/dashboard/src/components/fsm-hub-lane-analysis.ts
@@ -124,6 +124,19 @@ function laneMeaning(
         default:
           return { tone: 'info', meaning: 'compaction state observed' }
       }
+    case 'breaker':
+      // LT-16-KCB Phase 3. Tripped is not representable here because
+      // it is never observed at snapshot time (see display_state.mli).
+      switch (value) {
+        case 'clean':
+          return { tone: 'ok', meaning: 'circuit breaker is clean — no recent tool failure streak' }
+        case 'warning':
+          return { tone: 'warn', meaning: 'consecutive tool failures are accumulating — a trip is possible if the class stays the same' }
+        case 'cooling':
+          return { tone: 'info', meaning: 'breaker has tripped in the past; currently reset with no active streak' }
+        default:
+          return { tone: 'info', meaning: 'circuit breaker state observed' }
+      }
     }
   })()
 

--- a/dashboard/src/components/fsm-hub-types.test.ts
+++ b/dashboard/src/components/fsm-hub-types.test.ts
@@ -130,14 +130,14 @@ describe('fmtDuration', () => {
 })
 
 describe('constants', () => {
-  it('TRANSITION_FIELDS has 5 entries', () => {
-    expect(TRANSITION_FIELDS).toHaveLength(5)
-    expect(TRANSITION_FIELDS.map(f => f.field)).toEqual(['KSM', 'KTC', 'KDP', 'KCL', 'KMC'])
+  it('TRANSITION_FIELDS has 6 entries', () => {
+    expect(TRANSITION_FIELDS).toHaveLength(6)
+    expect(TRANSITION_FIELDS.map(f => f.field)).toEqual(['KSM', 'KTC', 'KDP', 'KCL', 'KMC', 'KCB'])
   })
 
-  it('LANE_LABELS has all 5 lanes', () => {
+  it('LANE_LABELS has all 6 lanes', () => {
     const keys = Object.keys(LANE_LABELS)
-    expect(keys).toEqual(['phase', 'turn', 'decision', 'cascade', 'compaction'])
+    expect(keys).toEqual(['phase', 'turn', 'decision', 'cascade', 'compaction', 'breaker'])
   })
 
   it('INVARIANT_LABELS has all 4 invariants', () => {

--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -10,6 +10,10 @@ export type CompositeObservation = {
   decision: KeeperCompositeSnapshot['decision']['stage']
   cascade: KeeperCompositeSnapshot['cascade']['state']
   compaction: KeeperCompositeSnapshot['compaction']['stage']
+  // 6th axis (LT-16-KCB Phase 3). `'clean'` when the backend omits
+  // `circuit_breaker` — Phase 2 backends that have not yet picked up
+  // the schema still render a sensible cell rather than a blank.
+  breaker: 'clean' | 'warning' | 'cooling'
 }
 
 export type LaneKey = keyof Omit<CompositeObservation, 'ts'>
@@ -24,6 +28,7 @@ export function extractLaneValue(
     case 'decision': return snapshot.decision.stage
     case 'cascade': return snapshot.cascade.state
     case 'compaction': return snapshot.compaction.stage
+    case 'breaker': return snapshot.circuit_breaker?.state ?? 'clean'
   }
 }
 
@@ -113,6 +118,7 @@ export const TRANSITION_FIELDS: Array<{ field: string; key: LaneKey }> = [
   { field: 'KDP', key: 'decision' },
   { field: 'KCL', key: 'cascade' },
   { field: 'KMC', key: 'compaction' },
+  { field: 'KCB', key: 'breaker' },
 ]
 
 export const INVARIANT_LABELS: Record<keyof KeeperCompositeInvariants, string> = {
@@ -128,6 +134,7 @@ export const LANE_LABELS: Record<LaneKey, string> = {
   decision: '의사결정',
   cascade: '캐스케이드',
   compaction: '컨텍스트 압축',
+  breaker: '서킷 브레이커',
 }
 
 /** Korean display names for raw FSM state values.

--- a/dashboard/src/components/fsm-hub.integration.test.ts
+++ b/dashboard/src/components/fsm-hub.integration.test.ts
@@ -188,6 +188,7 @@ describe('FSM Hub integration — API response shape', () => {
       decision: snap.decision.stage,
       cascade: snap.cascade.state,
       compaction: snap.compaction.stage,
+      breaker: snap.circuit_breaker?.state ?? 'clean',
     })
 
     it('deriveStateEntries returns a structure when given real-shape data', () => {

--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -31,6 +31,7 @@ function observation(
     decision: 'undecided',
     cascade: 'idle',
     compaction: 'accumulating',
+    breaker: 'clean',
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

Stacks on #7801 (Phase 2). Surfaces the `circuit_breaker` field from Phase 2 through the dashboard render path so the composite-FSM matrix and flowchart now show **6 axes** (KSM / KTC / KDP / KCL / KMC / **KCB**) instead of 5.

```
Before:                                  After:
┌─────────────────────────────────┐     ┌──────────────────────────────────────┐
│ keeper │ KSM │ KTC │ KDP │ KCL │ KMC │     │ keeper │ KSM │ KTC │ KDP │ KCL │ KMC │ KCB │
├────────┼─────┼─────┼─────┼─────┼─────┤     ├────────┼─────┼─────┼─────┼─────┼─────┼─────┤
│ alpha  │ Run │ idle│ und │ idle│ acc │     │ alpha  │ Run │ idle│ und │ idle│ acc │clean│
└────────┴─────┴─────┴─────┴─────┴─────┘     └────────┴─────┴─────┴─────┴─────┴─────┴─────┘
```

## Axis semantics

Three observable states, matching Phase 1/2's `display_state`:

| State     | Chip       | Meaning                                                  |
|-----------|------------|----------------------------------------------------------|
| `clean`   | zinc grey  | baseline — no failure streak, no past trips              |
| `warning` | amber      | 1 ≤ count < threshold in the same error class             |
| `cooling` | sky blue   | at least one past trip; currently reset                   |

`tripped` is **not** a matrix state: the mutator resets `consecutive_count` to 0 before any snapshot can observe it (see `display_state.mli`). The flowchart marks the warning → cooling edge as **dashed** to note that the unobservable trip transition exists inside the counter's read-modify-write, not as a visible state.

## Forward-compat during rollout

`circuit_breaker` is declared **optional** in the valibot schema. Pinned backends that have not yet picked up #7801 emit snapshots without the key; the parser returns `undefined` instead of raising `CompositeSchemaDriftError`, and `extractLaneValue` falls back to `'clean'`. Once Phase 2 is merged and deployed everywhere, a follow-up can promote the key to required (the `fallback('clean')` on the enum keeps drift tolerance for unknown state values, separate from missing-key tolerance).

## Change surface (12 files, +150 / -8)

- **Schema**: `api/schemas/keeper-composite.ts` — `KeeperCompositeCircuitBreakerStateSchema` + optional field
- **Types**: `components/fsm-hub-types.ts` — `breaker` lane on `CompositeObservation`, `TRANSITION_FIELDS` entry, Korean `LANE_LABELS.breaker`
- **Matrix**: `components/fleet-fsm-matrix.ts` — 6th `AXES` entry, chip palette (clean/warning/cooling), `AXIS_KEYS` extension, `pushObservation` seeds `breaker: []`
- **Flowchart**: `components/composite-fsm-flowchart.ts` — `subgraph KCB` with 3 nodes + dashed warning→cooling edge + classDef wiring
- **Callsite propagation**: `fsm-hub-derivations.ts`, `fsm-hub-lane-analysis.ts` (tones: clean→ok, warning→warn, cooling→info), 3 test helpers

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] **39/39** vitest in the directly-touched files:
  - schema parse cases (warning round-trip, unknown fallback, missing-key tolerance)
  - matrix chip mapping (warning→amber, cooling→sky)
  - matrix ring initialisation (`breaker: ['clean']`)
  - matrix time series (`breaker: ['warning', 'cooling']`)
  - flowchart all 6 subgraphs present
  - flowchart dashed edge warning→cooling, tripped never declared
- [x] **120/120** vitest in downstream hub files (no regression)
- [ ] CI green
- [ ] End-to-end: `dashboard` polling against a Phase 2 backend shows a live `clean` chip for every keeper

## Stack

```
main
  ↑ #7812 (OAS pin drift fix)              fix/oas-pin-drift  (Ready)
  ↑ #7793 (Phase 1: derive classifier)     feat/kcb-display-state  (Draft)
    ↑ #7801 (Phase 2: observer integration) feat/kcb-composite-observer  (Draft)
      ↑ THIS (Phase 3: dashboard 6th axis) feat/kcb-dashboard-axis  (Draft)
```

Review bottom-up. Do not merge Phase 3 before Phase 2 — without the backend emitting `circuit_breaker`, the axis will be permanently `clean` for every keeper, defeating the purpose of the visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
