### PR TITLE
chore(governance): retire case_tracking_available flag across 4 layers (BE/types/FE/tests)

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -10,45 +10,10 @@ Vitest.vi.mock('./governance-panels', () => ({
   GuardrailPane: () => html`<div data-testid="guardrail-pane-stub">guardrail pane</div>`,
 }))
 
-const GOVERNANCE_RENDER_TIMEOUT_MS = 30000
-
 async function flushUi(): Promise<void> {
   for (let i = 0; i < 4; i += 1) {
     await Promise.resolve()
     await new Promise(resolve => setTimeout(resolve, 0))
-  }
-}
-
-function governanceResponse(): DashboardGovernanceResponse {
-  return {
-    generated_at: '2026-03-24T00:00:00Z',
-    summary: {
-      cases_open: 1,
-      pending_ruling: 1,
-      ready_auto_execute: 0,
-      needs_human_gate: 0,
-      executed: 0,
-      blocked: 0,
-      oldest_open_case_age_s: 120,
-      last_activity_age_s: 60,
-      judge_online: true,
-      judge_last_seen_at: '2026-03-24T00:00:00Z',
-    },
-    items: [
-      {
-        kind: 'case',
-        id: 'gov-case-1',
-        topic: 'command:governance 렌더링 오류',
-        status: 'pending_ruling',
-        related_agents: [],
-        evidence_refs: [],
-        brief_count: 0,
-        petition_count: 1,
-        truth_summary: '렌더링 중 insertBefore 예외가 발생합니다.',
-      },
-    ],
-    activity: [],
-    pending_actions: [],
   }
 }
 
@@ -110,86 +75,10 @@ describe('Governance surface', () => {
     Vitest.vi.doUnmock('../sse-store')
   })
 
-  it('renders and refreshes without corrupting the DOM tree', async () => {
-    const fetchDashboardGovernance = Vitest.vi.fn<() => Promise<DashboardGovernanceResponse>>()
-      .mockResolvedValue(governanceResponse())
-    const fetchGovernanceCaseStatus = Vitest.vi.fn<(caseId: string) => Promise<GovernanceCaseBundle>>()
-      .mockResolvedValue(governanceBundle())
-
-    const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance,
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
-      fetchGovernanceCaseStatus,
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
-      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
-    })
-
-    expect(() => {
-      render(html`<${Governance} />`, container)
-    }).not.toThrow()
-
-    await flushUi()
-
-    expect(container.textContent).toContain('거버넌스')
-    expect(container.textContent).toContain('Case Load Visualized')
-    expect(container.textContent).toContain('Case Status Mix')
-    expect(container.textContent).toContain('command:governance 렌더링 오류')
-    expect(fetchDashboardGovernance).toHaveBeenCalledTimes(1)
-    expect(fetchGovernanceCaseStatus).toHaveBeenCalledWith('gov-case-1')
-
-    const refreshButton = Array.from(container.querySelectorAll('button'))
-      .find(button => button.textContent?.includes('새로고침'))
-    refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    await flushUi()
-
-    expect(fetchDashboardGovernance).toHaveBeenCalledTimes(2)
-    expect(fetchGovernanceCaseStatus.mock.calls.filter(([caseId]) => caseId === 'gov-case-1').length)
-      .toBeGreaterThanOrEqual(2)
-    expect(container.textContent).toContain('command:governance 렌더링 오류')
-  }, GOVERNANCE_RENDER_TIMEOUT_MS)
-
-  it('shows keeper guidance when governance feed is empty', async () => {
-    const emptyResponse: DashboardGovernanceResponse = {
-      generated_at: '2026-03-26T00:00:00Z',
-      summary: {
-        cases_open: 0,
-        pending_ruling: 0,
-        ready_auto_execute: 0,
-        needs_human_gate: 0,
-        executed: 0,
-      },
-      items: [],
-      activity: [],
-      pending_actions: [],
-    }
-
-    const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(emptyResponse),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
-      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
-      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
-    })
-
-    render(html`<${Governance} />`, container)
-    await flushUi()
-
-    expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
-    // No approval queue items → banner must stay hidden so it's not noisy.
-    expect(container.querySelector('[data-testid="keeper-hitl-alert-banner"]')).toBeNull()
-  }, 20000)
-
   it('shows retired guidance when case tracking is disabled', async () => {
     const serverNote = 'Server says governance case tracking is retired; only live judge signals remain.'
     const retiredResponse: DashboardGovernanceResponse = {
       generated_at: '2026-03-26T00:00:00Z',
-      case_tracking_available: false,
       note: serverNote,
       summary: {
         judge_online: false,
@@ -309,44 +198,9 @@ describe('Governance surface', () => {
     expect(judgeStatus?.textContent).toContain('cascade failed')
   }, 20000)
 
-  it('shows last activity age when governance feed is empty but has past activity', async () => {
-    const emptyWithAge: DashboardGovernanceResponse = {
-      generated_at: '2026-03-26T00:00:00Z',
-      summary: {
-        cases_open: 0,
-        pending_ruling: 0,
-        ready_auto_execute: 0,
-        needs_human_gate: 0,
-        executed: 0,
-        last_activity_age_s: 7200,
-      },
-      items: [],
-      activity: [],
-      pending_actions: [],
-    }
-
-    const { Governance } = await loadComponentWithApi({
-      decideGovernanceExecutionOrder: Vitest.vi.fn().mockResolvedValue(undefined),
-      fetchDashboardGovernance: Vitest.vi.fn().mockResolvedValue(emptyWithAge),
-      fetchParamAudit: Vitest.vi.fn().mockResolvedValue({ entries: [] }),
-      fetchGovernanceCaseStatus: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      fetchRuntimeParams: Vitest.vi.fn().mockResolvedValue({ parameters: [], surfaces: [] }),
-      resolveGovernanceApproval: Vitest.vi.fn().mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' }),
-      submitGovernanceCaseBrief: Vitest.vi.fn().mockResolvedValue(governanceBundle()),
-      submitGovernancePetition: Vitest.vi.fn().mockResolvedValue({ case: { id: 'gov-case-1' } }),
-    })
-
-    render(html`<${Governance} />`, container)
-    await flushUi()
-
-    expect(container.textContent).toContain('마지막 활동: 2시간 전')
-    expect(container.textContent).toContain('keeper가 활동 중일 때 자동 생성됩니다')
-  }, 20000)
-
   it('renders keeper approval queue and resolves approval from the dashboard', async () => {
     const withApprovalQueue: DashboardGovernanceResponse = {
       generated_at: '2026-04-09T00:00:00Z',
-      case_tracking_available: false,
       note: 'Live judge surface with active keeper approval queue.',
       summary: {
         cases_open: 0,
@@ -429,7 +283,6 @@ describe('Governance surface', () => {
   it('renders live judge empty state with offline message when retired + judge offline', async () => {
     const retiredOffline: DashboardGovernanceResponse = {
       generated_at: '2026-04-17T00:00:00Z',
-      case_tracking_available: false,
       summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0 },
       items: [],
       activity: [],
@@ -462,7 +315,6 @@ describe('Governance surface', () => {
   it('renders live judge empty state with idle message when retired + judge online but no judgments', async () => {
     const retiredIdle: DashboardGovernanceResponse = {
       generated_at: '2026-04-17T00:00:00Z',
-      case_tracking_available: false,
       summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0, judge_online: true },
       items: [],
       activity: [],
@@ -499,7 +351,6 @@ describe('Governance surface', () => {
   it('renders keeper HITL empty state with judge-offline context when queue is empty and judge is offline', async () => {
     const hitlEmptyOffline: DashboardGovernanceResponse = {
       generated_at: '2026-04-17T00:00:00Z',
-      case_tracking_available: false,
       summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0, judge_online: false },
       items: [],
       activity: [],
@@ -534,7 +385,6 @@ describe('Governance surface', () => {
   it('renders keeper HITL empty state with healthy-idle context when queue is empty and judge is active', async () => {
     const hitlEmptyHealthy: DashboardGovernanceResponse = {
       generated_at: '2026-04-17T00:00:00Z',
-      case_tracking_available: false,
       summary: { cases_open: 0, pending_ruling: 0, ready_auto_execute: 0, needs_human_gate: 0, executed: 0, judge_online: true },
       items: [],
       activity: [],

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -43,8 +43,11 @@ import {
 // Re-export for consumers that import from './governance'
 export { refreshGovernance, loadRuntimeParams, loadParamAudit } from './governance-store'
 
+// Case tracking is permanently retired; the backend no longer emits
+// case_tracking_available. Helper retained so the existing retired
+// branches continue to read naturally.
 function governanceCaseTrackingRetired(): boolean {
-  return governanceData.value?.case_tracking_available === false
+  return true
 }
 
 function governanceRetiredMessage(): string {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -374,7 +374,6 @@ export interface DashboardMemoryResponse {
 
 export interface DashboardGovernanceResponse {
   generated_at?: string
-  case_tracking_available?: boolean
   note?: string
   summary?: {
     cases_open?: number

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -167,7 +167,6 @@ export interface BoardMonitoring {
 
 export interface GovernanceMonitoring {
   alert_level?: 'ok' | 'warn' | 'bad' | string
-  case_tracking_available?: boolean
   note?: string
   cases_open?: number
   pending_ruling?: number

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -9,7 +9,6 @@ let case_tracking_note =
 
 let retired_case_tracking_fields =
   [
-    ("case_tracking_available", `Bool false);
     ("note", `String case_tracking_note);
   ]
 

--- a/lib/dashboard/dashboard_http_monitoring.ml
+++ b/lib/dashboard/dashboard_http_monitoring.ml
@@ -194,7 +194,6 @@ let governance_monitoring_json ~(now_ts : float) ~(base_path : string)
     ("slo_target_case_age_s", `Int 0);
     ("slo_breached", `Bool false);
     ("judge_online", `Bool runtime.judge_online);
-    ("case_tracking_available", `Bool false);
     ("note", `String Dashboard_governance.case_tracking_note);
   ], true)
 

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -63,8 +63,6 @@ let test_empty_governance_structure () =
       in
       let open Yojson.Safe.Util in
       let _gen = json |> member "generated_at" |> to_string in
-      check bool "case tracking retired" false
-        (json |> member "case_tracking_available" |> to_bool);
       check bool "retirement note present" true
         (json |> member "note" |> to_string |> String.length > 0);
       let summary = json |> member "summary" in
@@ -105,8 +103,6 @@ let test_factual_snapshot_marks_surface_retired () =
     (fun () ->
       let json = Lib.Dashboard_governance.factual_snapshot_json ~base_path:dir in
       let open Yojson.Safe.Util in
-      check bool "factual snapshot marks case tracking retired" false
-        (json |> member "case_tracking_available" |> to_bool);
       check bool "factual snapshot includes note" true
         (json |> member "note" |> to_string |> String.length > 0))
 
@@ -236,8 +232,6 @@ let test_governance_monitoring_uses_live_runtime () =
       in
       let open Yojson.Safe.Util in
       check bool "monitoring call succeeds" true ok;
-      check bool "monitoring marks case tracking retired" false
-        (json |> member "case_tracking_available" |> to_bool);
       check string "monitoring includes retirement note"
         Lib.Dashboard_governance.case_tracking_note
         (json |> member "note" |> to_string);


### PR DESCRIPTION
## Summary

Backend has been unconditionally emitting \`case_tracking_available=false\` since Gen3 — the flag only signalled that a decision (permanent retirement) had already happened. This PR removes the now-dead optionality across all 4 layers at once.

| Layer | File | Change |
|---|---|---|
| BE | \`lib/dashboard/dashboard_governance.ml\` | drop flag from \`retired_case_tracking_fields\` (\`note\` retained for retired banner) |
| BE | \`lib/dashboard/dashboard_http_monitoring.ml\` | drop flag from monitoring summary response |
| Types | \`dashboard/src/types/dashboard-execution.ts\` | drop optional field from \`DashboardGovernanceResponse\` |
| Types | \`dashboard/src/types/governance.ts\` | drop optional field from \`GovernanceMonitoring\` |
| FE | \`dashboard/src/components/governance.ts\` | \`governanceCaseTrackingRetired()\` returns \`true\` (helper kept so existing branches read naturally; TS/Vite prune non-retired paths) |
| FE | \`dashboard/src/components/governance.test.ts\` | delete 3 tests validating unreachable non-retired UI; drop fixture from the 4 remaining retired tests; remove unused helpers |

## Diff size

6 files · **+4 / -155** — 151 LOC net removal, no net additions of logic.

## Why this was blocked until now

Gen18 attempted a FE-only version (helper hardcoded to \`true\`) and failed — 3 tests explicitly asserted live-UI text (\`Case Load Visualized\`, \`keeper가 활동 중일 때 자동 생성됩니다\`, \`마지막 활동: 2시간 전\`). Those tests were covering code paths that production never hits, because BE never emits the non-retired flag value. A proper purge has to remove the tests along with the branches — which is only safe when BE/types/FE/tests move together.

## Test plan

- [x] \`pnpm typecheck\` → 0 errors (after dropping unused \`GOVERNANCE_RENDER_TIMEOUT_MS\` and \`governanceResponse\`)
- [x] \`pnpm exec vitest run governance.test.ts\` → 8/8 tests pass (11 - 3 deleted)
- [x] \`rg case_tracking_available\` across \`src/\` + \`lib/\` → 0 hits
- [ ] CI \`dune build @check\` / \`@runtest\` (authoritative)

## Non-goals

- **Branch simplification**: the \`caseTrackingRetired ? A : B\` ternaries in \`governance.ts\` (8+ sites) are left intact; the helper returns a constant so the dead branches disappear at bundle time. A follow-up Gen can flatten them if the visual cost outweighs the readability cost.
- \`governanceRetiredMessage()\` + the \`note\` field — retained, they still drive the retired banner text.

## Gen chain

| Gen | PR | Layer |
|---|---|---|
| 3 | #7697 | FE retired banner + Live Judge empty state |
| 19 (this) | — | End-to-end purge of the stale \`case_tracking_available\` flag |