### PR TITLE
chore(backend/operator): drop 8 always-empty fields from digest/snapshot responses

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -997,18 +997,7 @@ let snapshot_json ?actor ?view ?(include_messages = true)
            ("persistent_agents", !persistent_ref);
          ]
       )
-      (* Team sessions removed — aggregate metrics are always empty. *)
       @ [
-           ("role_census", `Assoc []);
-           ("runtime_pools", `Assoc []);
-           ("lane_census", `Assoc []);
-           ("controller_census", `Assoc []);
-           ("control_domains", `Assoc []);
-           ("task_profiles", `Assoc []);
-           ("escalation_count", `Int 0);
-         ]
-      @ [
-         ("local_runtime", `Null);
          ( "recent_messages",
            if initialized && include_messages && not lightweight_summary then
              recent_messages_json config

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -185,14 +185,6 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
               ("health", `String (health_from_attention_items attention_items));
               ("provenance_summary", operator_surface_contract_json);
               ("operator_judge_runtime", operator_judge_runtime_json config);
-              ("role_census", `Assoc []);
-              ("runtime_pools", `Assoc []);
-              ("lane_census", `Assoc []);
-              ("controller_census", `Assoc []);
-              ("control_domains", `Assoc []);
-              ("task_profiles", `Assoc []);
-              ("escalation_count", `Int 0);
-              ("local_runtime", `Null);
               ("attention_items", `List (List.map attention_item_to_yojson attention_items));
               ("attention_summary", summary_of_attention_items attention_items);
               ("pending_confirm_summary", pending_confirm_summary_json_of_scope confirm_scope);


### PR DESCRIPTION
## Summary

Eight JSON fields are emitted as literal empty/null values in every response and have **zero consumers** on the frontend. Grep over \`dashboard/src/\` returns 0 hits for each of them. Backend has no producer either — they are pure placeholders left over from a retired aggregate-metrics design (team sessions were removed long ago; see the deleted comment in \`operator_control_snapshot.ml\`).

| Field | BE emit value |
|---|---|
| \`role_census\` | \`{}\` |
| \`runtime_pools\` | \`{}\` |
| \`lane_census\` | \`{}\` |
| \`controller_census\` | \`{}\` |
| \`control_domains\` | \`{}\` |
| \`task_profiles\` | \`{}\` |
| \`escalation_count\` | \`0\` |
| \`local_runtime\` | \`null\` |

## Diff

| File | Change |
|---|---|
| \`lib/operator/operator_digest.ml\` | drop 8 fields from root-target digest response |
| \`lib/operator/operator_control_snapshot.ml\` | drop same 8 fields from snapshot response |

2 files · **-19 LOC**, no additions.

## Test plan

- [x] \`dune build --root . lib/operator/\` → 0 errors
- [x] \`rg role_census\|runtime_pools\|lane_census\|controller_census\|control_domains\|task_profiles\|escalation_count\|local_runtime\` in \`dashboard/src/\` → 0 FE consumers
- [ ] CI \`dune build @check\` / \`@runtest\` (authoritative)

## Non-goals

- \`worker_cards\` — still emitted as \`List []\` but has an FE consumer (\`operator-normalizers.ts\`); untouched.
- \`attention_items\` / \`pending_confirm_summary\` / \`recommended_actions\` — populated with actual data; untouched.