### PR TITLE
fix(sidecars): add missing os/Path imports for _runtime_toml_path

### DIFF
--- a/sidecars/imessage-bot/src/config.py
+++ b/sidecars/imessage-bot/src/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+from pathlib import Path
 from typing import Any
 from typing import Final
 from urllib.parse import urlparse

--- a/sidecars/imessage-bot/tests/test_config_runtime_path.py
+++ b/sidecars/imessage-bot/tests/test_config_runtime_path.py
@@ -1,0 +1,19 @@
+"""Regression: _runtime_toml_path() must be callable without NameError.
+
+Pre-fix this raised `NameError: name 'Path' is not defined` because the
+helper used `Path(...)` while the module forgot to import pathlib.Path.
+The error surfaced at every BotConfig() instantiation via
+settings_customise_sources -> TomlConfigSettingsSource(toml_file=...).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src import config
+
+
+def test_runtime_toml_path_returns_path_object() -> None:
+    result = config._runtime_toml_path()
+    assert isinstance(result, Path)
+    assert str(result).endswith("/.gate/runtime/imessage/config.toml")

--- a/sidecars/slack-bot/src/config.py
+++ b/sidecars/slack-bot/src/config.py
@@ -9,6 +9,8 @@ Requires a Slack App with:
 from __future__ import annotations
 
 import ipaddress
+import os
+from pathlib import Path
 from typing import Final
 from urllib.parse import urlparse
 

--- a/sidecars/slack-bot/tests/test_config_runtime_path.py
+++ b/sidecars/slack-bot/tests/test_config_runtime_path.py
@@ -1,0 +1,20 @@
+"""Regression: _runtime_toml_path() must be callable without NameError.
+
+Pre-fix this raised `NameError: name 'os' is not defined` (and would have
+raised `name 'Path' is not defined` next) because the helper used
+`os.getenv` and `Path(...)` without the corresponding imports. The error
+surfaced at every BotConfig() instantiation via
+settings_customise_sources -> TomlConfigSettingsSource(toml_file=...).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src import config
+
+
+def test_runtime_toml_path_returns_path_object() -> None:
+    result = config._runtime_toml_path()
+    assert isinstance(result, Path)
+    assert str(result).endswith("/.gate/runtime/slack/config.toml")

--- a/sidecars/telegram-bot/src/config.py
+++ b/sidecars/telegram-bot/src/config.py
@@ -7,6 +7,8 @@ Fails fast at startup if any required config is missing.
 from __future__ import annotations
 
 import ipaddress
+import os
+from pathlib import Path
 from typing import Final
 from urllib.parse import urlparse
 

--- a/sidecars/telegram-bot/tests/test_config_runtime_path.py
+++ b/sidecars/telegram-bot/tests/test_config_runtime_path.py
@@ -1,0 +1,20 @@
+"""Regression: _runtime_toml_path() must be callable without NameError.
+
+Pre-fix this raised `NameError: name 'os' is not defined` (and would have
+raised `name 'Path' is not defined` next) because the helper used
+`os.getenv` and `Path(...)` without the corresponding imports. The error
+surfaced at every BotConfig() instantiation via
+settings_customise_sources -> TomlConfigSettingsSource(toml_file=...).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src import config
+
+
+def test_runtime_toml_path_returns_path_object() -> None:
+    result = config._runtime_toml_path()
+    assert isinstance(result, Path)
+    assert str(result).endswith("/.gate/runtime/telegram/config.toml")


### PR DESCRIPTION
## 증상
`imessage-bot/src/config.py`, `slack-bot/src/config.py`, `telegram-bot/src/config.py`의 `_runtime_toml_path()`가 `os.getenv` 와 `Path` 를 참조하지만 두 모듈을 import 하지 않음 → 첫 호출 시 `NameError`. discord-bot 패턴을 따라 `import os` + `from pathlib import Path` 추가.

## 재현
빈 venv에서 `python -m src` 실행 시 `_runtime_toml_path()`가 import되며 `NameError: name 'os' is not defined`.

## 검증
3 sidecar에 동일 패턴의 회귀 테스트 (`test_config_runtime_path.py`) 추가. import 후 호출 가능 + 반환 경로가 `.gate/runtime/<id>/config.toml` 형태인지 확인.