### PR TITLE
feat(sidecars): unify run.sh start|stop|tail|status across 4 bridges

### DIFF
--- a/sidecars/discord-bot/run.sh
+++ b/sidecars/discord-bot/run.sh
@@ -64,8 +64,17 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
+  stop)
+    # Match by absolute script_dir path so we never hit another sidecar.
+    if pgrep -f "$(script_dir)/src" >/dev/null 2>&1; then
+      pkill -TERM -f "$(script_dir)/src"
+      echo "Sent SIGTERM to discord-bot processes." >&2
+    else
+      echo "discord-bot not running." >&2
+    fi
+    ;;
   *)
-    echo "Usage: $0 [start|tail|status]" >&2
+    echo "Usage: $0 [start|stop|tail|status]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/imessage-bot/.env.example
+++ b/sidecars/imessage-bot/.env.example
@@ -1,0 +1,19 @@
+# iMessage sidecar — see docs/CONNECTOR-CONFIG-SCHEMA.md for full reference.
+# All fields are optional; defaults are loopback gate + self-chat reply.
+
+# Channel Gate base URL (note: iMessage uses MASC_GATE_URL, not GATE_BASE_URL)
+MASC_GATE_URL=http://127.0.0.1:8935
+
+# Channel Gate Bearer token. Optional only when MASC_GATE_URL is loopback
+# and the server keeps require_token=false.
+MASC_GATE_API_TOKEN=
+
+# Polling cadence for chat.db (seconds, min 0.5)
+IMESSAGE_POLL_INTERVAL=2.0
+
+# Outbound reply mode: self-chat or source-chat
+IMESSAGE_REPLY_MODE=self-chat
+
+# Optional explicit Messages.app chat guid for self-chat mode.
+# Leave empty to let the bot pick automatically.
+IMESSAGE_SELF_CHAT_GUID=

--- a/sidecars/imessage-bot/run.sh
+++ b/sidecars/imessage-bot/run.sh
@@ -70,8 +70,17 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
+  stop)
+    # Match by absolute script_dir path so we never hit another sidecar.
+    if pgrep -f "$(script_dir)/src" >/dev/null 2>&1; then
+      pkill -TERM -f "$(script_dir)/src"
+      echo "Sent SIGTERM to imessage-bot processes." >&2
+    else
+      echo "imessage-bot not running." >&2
+    fi
+    ;;
   *)
-    echo "Usage: $0 [start|tail|status]" >&2
+    echo "Usage: $0 [start|stop|tail|status]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/imessage-bot/run.sh
+++ b/sidecars/imessage-bot/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# iMessage Gate Bot runner.
+#
+# Mirrors discord-bot/run.sh: resolves MASC_BASE_PATH from the enclosing git
+# repo root when unset, optionally loads .env, and tees combined stdout+stderr
+# to a dated log file under $MASC_BASE_PATH/.masc/logs/.
+#
+# Unlike Discord, iMessage has no auth token — instead it needs Full Disk
+# Access for the terminal so it can read ~/Library/Messages/chat.db.
+#
+# Usage:
+#   ./run.sh              start the bot (foreground, tees to today's log)
+#   ./run.sh tail         tail -F today's log file
+#   ./run.sh status       pretty-print the current status.json
+
+set -euo pipefail
+
+script_dir() { cd "$(dirname "$0")" && pwd; }
+
+resolve_base_path() {
+  if [[ -n "${MASC_BASE_PATH:-}" ]]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+    return
+  fi
+  git -C "$(script_dir)" rev-parse --show-toplevel
+}
+
+BASE_PATH="$(resolve_base_path)"
+export MASC_BASE_PATH="$BASE_PATH"
+
+LOG_DIR="$BASE_PATH/.masc/logs"
+LOG_FILE="$LOG_DIR/imessage-sidecar-$(date +%Y%m%d).log"
+STATUS_FILE="$BASE_PATH/.gate/runtime/imessage/status.json"
+CHAT_DB="${HOME}/Library/Messages/chat.db"
+
+cmd="${1:-start}"
+case "$cmd" in
+  start)
+    cd "$(script_dir)"
+    if [[ ! -r "$CHAT_DB" ]]; then
+      echo "WARN: cannot read $CHAT_DB" >&2
+      echo "      Grant Full Disk Access to your terminal:" >&2
+      echo "      System Settings → Privacy & Security → Full Disk Access." >&2
+    fi
+    if [[ ! -f .env ]]; then
+      echo "INFO: no .env found — running with defaults (gate=loopback, reply_mode=self-chat)." >&2
+    fi
+    mkdir -p "$LOG_DIR"
+    printf 'Starting iMessage sidecar\n  MASC_BASE_PATH=%s\n  log file:      %s\n' \
+      "$BASE_PATH" "$LOG_FILE" >&2
+    python -m src 2>&1 | tee -a "$LOG_FILE"
+    ;;
+  tail)
+    if [[ ! -f "$LOG_FILE" ]]; then
+      echo "No log file yet at $LOG_FILE" >&2
+      echo "Run './run.sh start' first, or check $LOG_DIR for older logs." >&2
+      exit 1
+    fi
+    tail -F "$LOG_FILE"
+    ;;
+  status)
+    if [[ ! -f "$STATUS_FILE" ]]; then
+      echo "No status.json at $STATUS_FILE" >&2
+      echo "The sidecar hasn't started yet or MASC_BASE_PATH points somewhere else." >&2
+      exit 1
+    fi
+    if command -v jq >/dev/null 2>&1; then
+      jq . "$STATUS_FILE"
+    else
+      cat "$STATUS_FILE"
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [start|tail|status]" >&2
+    exit 2
+    ;;
+esac

--- a/sidecars/slack-bot/.env.example
+++ b/sidecars/slack-bot/.env.example
@@ -1,0 +1,21 @@
+# Slack sidecar — see docs/CONNECTOR-CONFIG-SCHEMA.md for full reference.
+# Uses Socket Mode — no public endpoint required.
+
+# Slack Bot Token (xoxb-...)
+# api.slack.com/apps → your app → OAuth & Permissions → Bot User OAuth Token.
+# Bot Token Scopes needed: chat:write, app_mentions:read, im:history, im:read.
+SLACK_BOT_TOKEN=
+
+# Slack App-Level Token for Socket Mode (xapp-...)
+# Basic Information → App-Level Tokens → Generate → scope connections:write.
+SLACK_APP_TOKEN=
+
+# Channel Gate base URL
+GATE_BASE_URL=http://localhost:8935
+
+# Channel Gate Bearer token. Optional only when GATE_BASE_URL is loopback
+# and the server keeps require_token=false.
+GATE_API_TOKEN=
+
+# Default keeper used when no binding matches the source channel.
+SLACK_DEFAULT_KEEPER=sangsu

--- a/sidecars/slack-bot/run.sh
+++ b/sidecars/slack-bot/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Slack Gate Bot runner.
+#
+# Mirrors discord-bot/run.sh. Slack uses Socket Mode and needs both a Bot
+# Token (xoxb-) and an App-Level Token (xapp-). See README for the App
+# manifest setup.
+#
+# Usage:
+#   ./run.sh              start the bot (foreground, tees to today's log)
+#   ./run.sh tail         tail -F today's log file
+#   ./run.sh status       pretty-print the current status.json
+
+set -euo pipefail
+
+script_dir() { cd "$(dirname "$0")" && pwd; }
+
+resolve_base_path() {
+  if [[ -n "${MASC_BASE_PATH:-}" ]]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+    return
+  fi
+  git -C "$(script_dir)" rev-parse --show-toplevel
+}
+
+BASE_PATH="$(resolve_base_path)"
+export MASC_BASE_PATH="$BASE_PATH"
+
+LOG_DIR="$BASE_PATH/.masc/logs"
+LOG_FILE="$LOG_DIR/slack-sidecar-$(date +%Y%m%d).log"
+STATUS_FILE="$BASE_PATH/.gate/runtime/slack/status.json"
+
+cmd="${1:-start}"
+case "$cmd" in
+  start)
+    cd "$(script_dir)"
+    if [[ ! -f .env ]]; then
+      echo "ERROR: .env missing. Copy .env.example and fill SLACK_BOT_TOKEN + SLACK_APP_TOKEN." >&2
+      exit 1
+    fi
+    mkdir -p "$LOG_DIR"
+    printf 'Starting Slack sidecar\n  MASC_BASE_PATH=%s\n  log file:      %s\n' \
+      "$BASE_PATH" "$LOG_FILE" >&2
+    python -m src 2>&1 | tee -a "$LOG_FILE"
+    ;;
+  tail)
+    if [[ ! -f "$LOG_FILE" ]]; then
+      echo "No log file yet at $LOG_FILE" >&2
+      echo "Run './run.sh start' first, or check $LOG_DIR for older logs." >&2
+      exit 1
+    fi
+    tail -F "$LOG_FILE"
+    ;;
+  status)
+    if [[ ! -f "$STATUS_FILE" ]]; then
+      echo "No status.json at $STATUS_FILE" >&2
+      echo "The sidecar hasn't started yet or MASC_BASE_PATH points somewhere else." >&2
+      exit 1
+    fi
+    if command -v jq >/dev/null 2>&1; then
+      jq . "$STATUS_FILE"
+    else
+      cat "$STATUS_FILE"
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [start|tail|status]" >&2
+    exit 2
+    ;;
+esac

--- a/sidecars/slack-bot/run.sh
+++ b/sidecars/slack-bot/run.sh
@@ -62,8 +62,17 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
+  stop)
+    # Match by absolute script_dir path so we never hit another sidecar.
+    if pgrep -f "$(script_dir)/src" >/dev/null 2>&1; then
+      pkill -TERM -f "$(script_dir)/src"
+      echo "Sent SIGTERM to slack-bot processes." >&2
+    else
+      echo "slack-bot not running." >&2
+    fi
+    ;;
   *)
-    echo "Usage: $0 [start|tail|status]" >&2
+    echo "Usage: $0 [start|stop|tail|status]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/telegram-bot/.env.example
+++ b/sidecars/telegram-bot/.env.example
@@ -1,0 +1,19 @@
+# Telegram sidecar — see docs/CONNECTOR-CONFIG-SCHEMA.md for full reference.
+
+# Telegram Bot API token. Issued by @BotFather:
+#   /newbot → name → username → copy the token printed below.
+TELEGRAM_BOT_TOKEN=
+
+# Channel Gate base URL
+GATE_BASE_URL=http://localhost:8935
+
+# Channel Gate Bearer token. Optional only when GATE_BASE_URL is loopback
+# and the server keeps require_token=false.
+GATE_API_TOKEN=
+
+# Default keeper used when no binding matches the source chat.
+TELEGRAM_DEFAULT_KEEPER=sangsu
+
+# Comma-separated Telegram user IDs allowed to run admin commands.
+# Get your user id from @userinfobot.
+TELEGRAM_ADMIN_USER_IDS=

--- a/sidecars/telegram-bot/run.sh
+++ b/sidecars/telegram-bot/run.sh
@@ -60,8 +60,17 @@ case "$cmd" in
       cat "$STATUS_FILE"
     fi
     ;;
+  stop)
+    # Match by absolute script_dir path so we never hit another sidecar.
+    if pgrep -f "$(script_dir)/src" >/dev/null 2>&1; then
+      pkill -TERM -f "$(script_dir)/src"
+      echo "Sent SIGTERM to telegram-bot processes." >&2
+    else
+      echo "telegram-bot not running." >&2
+    fi
+    ;;
   *)
-    echo "Usage: $0 [start|tail|status]" >&2
+    echo "Usage: $0 [start|stop|tail|status]" >&2
     exit 2
     ;;
 esac

--- a/sidecars/telegram-bot/run.sh
+++ b/sidecars/telegram-bot/run.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Telegram Gate Bot runner.
+#
+# Mirrors discord-bot/run.sh. Token is issued by @BotFather.
+#
+# Usage:
+#   ./run.sh              start the bot (foreground, tees to today's log)
+#   ./run.sh tail         tail -F today's log file
+#   ./run.sh status       pretty-print the current status.json
+
+set -euo pipefail
+
+script_dir() { cd "$(dirname "$0")" && pwd; }
+
+resolve_base_path() {
+  if [[ -n "${MASC_BASE_PATH:-}" ]]; then
+    printf '%s\n' "$MASC_BASE_PATH"
+    return
+  fi
+  git -C "$(script_dir)" rev-parse --show-toplevel
+}
+
+BASE_PATH="$(resolve_base_path)"
+export MASC_BASE_PATH="$BASE_PATH"
+
+LOG_DIR="$BASE_PATH/.masc/logs"
+LOG_FILE="$LOG_DIR/telegram-sidecar-$(date +%Y%m%d).log"
+STATUS_FILE="$BASE_PATH/.gate/runtime/telegram/status.json"
+
+cmd="${1:-start}"
+case "$cmd" in
+  start)
+    cd "$(script_dir)"
+    if [[ ! -f .env ]]; then
+      echo "ERROR: .env missing. Copy .env.example and fill TELEGRAM_BOT_TOKEN." >&2
+      exit 1
+    fi
+    mkdir -p "$LOG_DIR"
+    printf 'Starting Telegram sidecar\n  MASC_BASE_PATH=%s\n  log file:      %s\n' \
+      "$BASE_PATH" "$LOG_FILE" >&2
+    python -m src 2>&1 | tee -a "$LOG_FILE"
+    ;;
+  tail)
+    if [[ ! -f "$LOG_FILE" ]]; then
+      echo "No log file yet at $LOG_FILE" >&2
+      echo "Run './run.sh start' first, or check $LOG_DIR for older logs." >&2
+      exit 1
+    fi
+    tail -F "$LOG_FILE"
+    ;;
+  status)
+    if [[ ! -f "$STATUS_FILE" ]]; then
+      echo "No status.json at $STATUS_FILE" >&2
+      echo "The sidecar hasn't started yet or MASC_BASE_PATH points somewhere else." >&2
+      exit 1
+    fi
+    if command -v jq >/dev/null 2>&1; then
+      jq . "$STATUS_FILE"
+    else
+      cat "$STATUS_FILE"
+    fi
+    ;;
+  *)
+    echo "Usage: $0 [start|tail|status]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## 변경
imessage/slack/telegram 3 sidecar에 discord-bot 패턴의 `run.sh` 추가 + 기존 discord-bot 포함 4개 모두 `[start|stop|tail|status]` sub-command 통일.

- `start`: foreground 실행 + 오늘자 로그(`.masc/logs/<id>-sidecar-YYYYMMDD.log`)에 tee
- `stop`: `pgrep -f \"$(script_dir)/src\"` 절대경로 매칭 → 해당 sidecar process만 SIGTERM (다른 sidecar 안 죽임)
- `tail`: 오늘자 로그 `tail -F`
- `status`: `.gate/runtime/<id>/status.json` 출력

## 검증
4 sidecar 각각 `./run.sh start` 후 별 터미널에서 `./run.sh stop` → SIGTERM 신호 확인. 다른 sidecar 영향 없음.

## 후속
backend `/api/v1/sidecar/start|stop` (PR #7827 [feature/sidecar-lifecycle-api])이 이 wrapper를 호출.