### PR TITLE
feat(dashboard/api): migrate transport-health endpoint to valibot schema

### DIFF
--- a/dashboard/src/api/schemas/transport-health.ts
+++ b/dashboard/src/api/schemas/transport-health.ts
@@ -1,0 +1,245 @@
+// Transport health schema — schema-at-boundary for
+// `GET /api/v1/dashboard/transport-health`.
+//
+// The largest endpoint on the dashboard: 10 nested transport surfaces
+// (summary, sse, grpc, websocket, webrtc, streamable_http, http2,
+// cluster, agent_health, plus optional projection_diagnostics). The
+// prior hand-rolled decoder returned `null` if ANY of the 9 required
+// subsections or `generated_at` was missing — this PR preserves that
+// contract via the thin null-returning wrapper in `api/transport-health.ts`.
+//
+// Uses the shared `SchemaDriftError` base landed in #7732.
+
+import {
+  boolean,
+  check,
+  fallback,
+  nullable,
+  number,
+  object,
+  optional,
+  pipe,
+  safeParse,
+  string,
+  unknown,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+
+import { SchemaDriftError, parseOrThrow } from './drift-error'
+
+// --- Hot session (per-entry lenient in sse.hot_sessions) ---
+
+const HotSessionSchema = object({
+  session_id: string(),
+  kind: fallback(string(), 'unknown'),
+  queue_depth: fallback(number(), 0),
+  last_event_id: fallback(number(), 0),
+  idle_seconds: fallback(number(), 0),
+})
+
+export type HotSession = InferOutput<typeof HotSessionSchema>
+
+// --- Subsection schemas (each field uses fallback matching the prior
+//     `asString(raw.X, DEFAULT)` / `asNumber(raw.X, 0)` decoder) ---
+
+const SummarySchema = object({
+  primary_path: fallback(string(), 'unknown'),
+  queue_pressure: fallback(string(), 'unknown'),
+  // `asNumber(x) ?? null` — absent/non-number → null, not undefined.
+  recent_messages: fallback(nullable(number()), null),
+  recent_messages_available: fallback(boolean(), false),
+  recent_messages_source: fallback(string(), 'unknown'),
+  external_fanout_targets: fallback(number(), 0),
+})
+
+const SseOuterSchema = object({
+  sessions_observer: fallback(number(), 0),
+  sessions_coordinator: fallback(number(), 0),
+  sessions_total: fallback(number(), 0),
+  external_subscribers: fallback(number(), 0),
+  broadcast_avg_seconds: fallback(number(), 0),
+  broadcast_count: fallback(number(), 0),
+  queue_avg_depth: fallback(number(), 0),
+  queue_max_depth: fallback(number(), 0),
+  // Lenient per-entry on hot_sessions handled in parseSse below.
+  hot_sessions: optional(unknown()),
+})
+
+interface SseSection {
+  sessions_observer: number
+  sessions_coordinator: number
+  sessions_total: number
+  external_subscribers: number
+  broadcast_avg_seconds: number
+  broadcast_count: number
+  queue_avg_depth: number
+  queue_max_depth: number
+  hot_sessions: HotSession[]
+}
+
+const GrpcSchema = object({
+  enabled: fallback(boolean(), false),
+  configured: fallback(boolean(), false),
+  listening: fallback(boolean(), false),
+  port: fallback(number(), 0),
+  active_streams: fallback(number(), 0),
+  subscribers: fallback(number(), 0),
+  heartbeat_avg_seconds: fallback(number(), 0),
+  events_delivered: fallback(number(), 0),
+})
+
+const WebsocketSchema = object({
+  enabled: fallback(boolean(), false),
+  configured: fallback(boolean(), false),
+  listening: fallback(boolean(), false),
+  mode: fallback(string(), 'unknown'),
+  port: fallback(number(), 0),
+  sessions: fallback(number(), 0),
+  relay_source: fallback(string(), 'unknown'),
+})
+
+const WebrtcSchema = object({
+  enabled: fallback(boolean(), false),
+  configured: fallback(boolean(), false),
+  signaling_available: fallback(boolean(), false),
+  signaling_mode: fallback(string(), 'unknown'),
+  pending_offers: fallback(number(), 0),
+  active_peers: fallback(number(), 0),
+  live_connections: fallback(number(), 0),
+  connected_channels: fallback(number(), 0),
+  ice_server_count: fallback(number(), 0),
+})
+
+const StreamableHttpSchema = object({
+  endpoint: fallback(string(), '/mcp'),
+  observer_stream: fallback(string(), '/mcp?sse_kind=observer'),
+  managed_endpoint: fallback(string(), '/mcp/managed'),
+  operator_endpoint: fallback(string(), '/mcp/operator'),
+  delete_endpoint: fallback(string(), '/mcp'),
+  legacy_sse_endpoint: fallback(string(), '/sse'),
+  legacy_messages_endpoint: fallback(string(), '/messages'),
+  default_transport: fallback(string(), 'unknown'),
+  supports_post: fallback(boolean(), false),
+  supports_sse_upgrade: fallback(boolean(), false),
+  supports_delete: fallback(boolean(), false),
+})
+
+const Http2Schema = object({
+  listener_mode: fallback(string(), 'unknown'),
+  multiplex_ready: fallback(boolean(), false),
+  prior_knowledge_path: fallback(string(), '/mcp'),
+})
+
+const ClusterSchema = object({
+  cluster: fallback(string(), 'default'),
+  room_id: fallback(string(), 'default'),
+  topology_available: fallback(boolean(), false),
+  topology_source: fallback(string(), 'unknown'),
+  // These five use `asNumber(x) ?? null` — absent → null, not undefined.
+  total_units: fallback(nullable(number()), null),
+  managed_units: fallback(nullable(number()), null),
+  live_agents: fallback(nullable(number()), null),
+  active_operations: fallback(nullable(number()), null),
+  stale_units: fallback(nullable(number()), null),
+})
+
+const AgentHealthSchema = object({
+  stale_total: fallback(number(), 0),
+})
+
+// `projection_diagnostics` is only present when the backend explicitly
+// includes it. When omitted, downstream sees `undefined` (matches prior
+// `projectionDiagnostics ? {...} : undefined`).
+const ProjectionDiagnosticsSchema = object({
+  source: fallback(string(), 'unknown'),
+  cache_state: fallback(string(), 'unknown'),
+  // Prior decoder: `asString(x) ?? null` — absent/non-string → null.
+  last_success_at: fallback(nullable(string()), null),
+  last_attempt_at: fallback(nullable(string()), null),
+  last_error_at: fallback(nullable(string()), null),
+  stale_reason: fallback(nullable(string()), null),
+  stale_age_ms: fallback(nullable(number()), null),
+})
+
+// --- Outer schema: all 9 subsections required + generated_at non-empty ---
+
+const TransportHealthOuterSchema = object({
+  summary: SummarySchema,
+  sse: SseOuterSchema,
+  grpc: GrpcSchema,
+  websocket: WebsocketSchema,
+  webrtc: WebrtcSchema,
+  streamable_http: StreamableHttpSchema,
+  http2: Http2Schema,
+  cluster: ClusterSchema,
+  agent_health: AgentHealthSchema,
+  // Prior decoder: `if (!generatedAt) return null` — empty string must
+  // also cause rejection, matching that guard exactly.
+  generated_at: pipe(
+    string(),
+    check(s => s.length > 0, 'generated_at must be non-empty'),
+  ),
+  projection_diagnostics: optional(ProjectionDiagnosticsSchema),
+})
+
+export interface TransportHealthData {
+  summary: InferOutput<typeof SummarySchema>
+  sse: SseSection
+  grpc: InferOutput<typeof GrpcSchema>
+  websocket: InferOutput<typeof WebsocketSchema>
+  webrtc: InferOutput<typeof WebrtcSchema>
+  streamable_http: InferOutput<typeof StreamableHttpSchema>
+  http2: InferOutput<typeof Http2Schema>
+  cluster: InferOutput<typeof ClusterSchema>
+  agent_health: InferOutput<typeof AgentHealthSchema>
+  generated_at: string
+  projection_diagnostics?: InferOutput<typeof ProjectionDiagnosticsSchema>
+}
+
+export class TransportHealthSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('transport-health', issues)
+  }
+}
+
+function parseSseHotSessions(raw: unknown): HotSession[] {
+  if (!Array.isArray(raw)) return []
+  const out: HotSession[] = []
+  for (const item of raw) {
+    const parsed = safeParse(HotSessionSchema, item, { abortEarly: true })
+    if (parsed.success) out.push(parsed.output)
+  }
+  return out
+}
+
+export function parseTransportHealthData(data: unknown): TransportHealthData {
+  const outer = parseOrThrow(
+    TransportHealthSchemaDriftError,
+    TransportHealthOuterSchema,
+    data,
+  )
+  return {
+    summary: outer.summary,
+    sse: {
+      sessions_observer: outer.sse.sessions_observer,
+      sessions_coordinator: outer.sse.sessions_coordinator,
+      sessions_total: outer.sse.sessions_total,
+      external_subscribers: outer.sse.external_subscribers,
+      broadcast_avg_seconds: outer.sse.broadcast_avg_seconds,
+      broadcast_count: outer.sse.broadcast_count,
+      queue_avg_depth: outer.sse.queue_avg_depth,
+      queue_max_depth: outer.sse.queue_max_depth,
+      hot_sessions: parseSseHotSessions(outer.sse.hot_sessions),
+    },
+    grpc: outer.grpc,
+    websocket: outer.websocket,
+    webrtc: outer.webrtc,
+    streamable_http: outer.streamable_http,
+    http2: outer.http2,
+    cluster: outer.cluster,
+    agent_health: outer.agent_health,
+    generated_at: outer.generated_at,
+    projection_diagnostics: outer.projection_diagnostics,
+  }
+}

--- a/dashboard/src/api/transport-health.ts
+++ b/dashboard/src/api/transport-health.ts
@@ -1,255 +1,35 @@
 import { get } from './core'
 import {
-  asBoolean,
-  asNumber,
-  asRecordArray,
-  asString,
-  isRecord,
-} from '../components/common/normalize'
+  parseTransportHealthData,
+  type HotSession,
+  type TransportHealthData,
+} from './schemas/transport-health'
 
-export interface HotSession {
-  session_id: string
-  kind: string
-  queue_depth: number
-  last_event_id: number
-  idle_seconds: number
-}
-
-export interface TransportHealthData {
-  summary: {
-    primary_path: string
-    queue_pressure: string
-    recent_messages: number | null
-    recent_messages_available: boolean
-    recent_messages_source: string
-    external_fanout_targets: number
-  }
-  sse: {
-    sessions_observer: number
-    sessions_coordinator: number
-    sessions_total: number
-    external_subscribers: number
-    broadcast_avg_seconds: number
-    broadcast_count: number
-    queue_avg_depth: number
-    queue_max_depth: number
-    hot_sessions: HotSession[]
-  }
-  grpc: {
-    enabled: boolean
-    configured: boolean
-    listening: boolean
-    port: number
-    active_streams: number
-    subscribers: number
-    heartbeat_avg_seconds: number
-    events_delivered: number
-  }
-  websocket: {
-    enabled: boolean
-    configured: boolean
-    listening: boolean
-    mode: string
-    port: number
-    sessions: number
-    relay_source: string
-  }
-  webrtc: {
-    enabled: boolean
-    configured: boolean
-    signaling_available: boolean
-    signaling_mode: string
-    pending_offers: number
-    active_peers: number
-    live_connections: number
-    connected_channels: number
-    ice_server_count: number
-  }
-  streamable_http: {
-    endpoint: string
-    observer_stream: string
-    managed_endpoint: string
-    operator_endpoint: string
-    delete_endpoint: string
-    legacy_sse_endpoint: string
-    legacy_messages_endpoint: string
-    default_transport: string
-    supports_post: boolean
-    supports_sse_upgrade: boolean
-    supports_delete: boolean
-  }
-  http2: {
-    listener_mode: string
-    multiplex_ready: boolean
-    prior_knowledge_path: string
-  }
-  cluster: {
-    cluster: string
-    room_id: string
-    topology_available: boolean
-    topology_source: string
-    total_units: number | null
-    managed_units: number | null
-    live_agents: number | null
-    active_operations: number | null
-    stale_units: number | null
-  }
-  agent_health: {
-    stale_total: number
-  }
-  generated_at: string
-  projection_diagnostics?: {
-    source: string
-    cache_state: string
-    last_success_at: string | null
-    last_attempt_at: string | null
-    last_error_at: string | null
-    stale_reason: string | null
-    stale_age_ms: number | null
-  }
-}
+export type { HotSession, TransportHealthData }
+export { TransportHealthSchemaDriftError } from './schemas/transport-health'
 
 type AbortableRequestOptions = {
   signal?: AbortSignal
 }
 
-function decodeHotSession(raw: unknown): HotSession | null {
-  if (!isRecord(raw)) return null
-  const sessionId = asString(raw.session_id)
-  if (!sessionId) return null
-  return {
-    session_id: sessionId,
-    kind: asString(raw.kind, 'unknown'),
-    queue_depth: asNumber(raw.queue_depth, 0),
-    last_event_id: asNumber(raw.last_event_id, 0),
-    idle_seconds: asNumber(raw.idle_seconds, 0),
-  }
-}
-
+// Thin null-returning wrapper preserving the pre-migration contract —
+// `src/api/transport-health.test.ts` has many assertions on
+// `decodeTransportHealthData(x) === null` for missing subsections.
+// New call sites should use `parseTransportHealthData` directly for
+// throw-on-drift semantics.
 export function decodeTransportHealthData(raw: unknown): TransportHealthData | null {
-  if (!isRecord(raw)) return null
-  const summary = isRecord(raw.summary) ? raw.summary : null
-  const sse = isRecord(raw.sse) ? raw.sse : null
-  const grpc = isRecord(raw.grpc) ? raw.grpc : null
-  const websocket = isRecord(raw.websocket) ? raw.websocket : null
-  const webrtc = isRecord(raw.webrtc) ? raw.webrtc : null
-  const streamableHttp = isRecord(raw.streamable_http) ? raw.streamable_http : null
-  const http2 = isRecord(raw.http2) ? raw.http2 : null
-  const cluster = isRecord(raw.cluster) ? raw.cluster : null
-  const agentHealth = isRecord(raw.agent_health) ? raw.agent_health : null
-  const projectionDiagnostics = isRecord(raw.projection_diagnostics)
-    ? raw.projection_diagnostics
-    : null
-  const generatedAt = asString(raw.generated_at)
-
-  if (!summary || !sse || !grpc || !websocket || !webrtc || !streamableHttp || !http2 || !cluster || !agentHealth || !generatedAt) {
+  try {
+    return parseTransportHealthData(raw)
+  } catch {
     return null
   }
-
-  return {
-    summary: {
-      primary_path: asString(summary.primary_path, 'unknown'),
-      queue_pressure: asString(summary.queue_pressure, 'unknown'),
-      recent_messages: asNumber(summary.recent_messages) ?? null,
-      recent_messages_available: asBoolean(summary.recent_messages_available, false),
-      recent_messages_source: asString(summary.recent_messages_source, 'unknown'),
-      external_fanout_targets: asNumber(summary.external_fanout_targets, 0),
-    },
-    sse: {
-      sessions_observer: asNumber(sse.sessions_observer, 0),
-      sessions_coordinator: asNumber(sse.sessions_coordinator, 0),
-      sessions_total: asNumber(sse.sessions_total, 0),
-      external_subscribers: asNumber(sse.external_subscribers, 0),
-      broadcast_avg_seconds: asNumber(sse.broadcast_avg_seconds, 0),
-      broadcast_count: asNumber(sse.broadcast_count, 0),
-      queue_avg_depth: asNumber(sse.queue_avg_depth, 0),
-      queue_max_depth: asNumber(sse.queue_max_depth, 0),
-      hot_sessions: asRecordArray(sse.hot_sessions)
-        .map(decodeHotSession)
-        .filter((session): session is HotSession => session !== null),
-    },
-    grpc: {
-      enabled: asBoolean(grpc.enabled, false),
-      configured: asBoolean(grpc.configured, false),
-      listening: asBoolean(grpc.listening, false),
-      port: asNumber(grpc.port, 0),
-      active_streams: asNumber(grpc.active_streams, 0),
-      subscribers: asNumber(grpc.subscribers, 0),
-      heartbeat_avg_seconds: asNumber(grpc.heartbeat_avg_seconds, 0),
-      events_delivered: asNumber(grpc.events_delivered, 0),
-    },
-    websocket: {
-      enabled: asBoolean(websocket.enabled, false),
-      configured: asBoolean(websocket.configured, false),
-      listening: asBoolean(websocket.listening, false),
-      mode: asString(websocket.mode, 'unknown'),
-      port: asNumber(websocket.port, 0),
-      sessions: asNumber(websocket.sessions, 0),
-      relay_source: asString(websocket.relay_source, 'unknown'),
-    },
-    webrtc: {
-      enabled: asBoolean(webrtc.enabled, false),
-      configured: asBoolean(webrtc.configured, false),
-      signaling_available: asBoolean(webrtc.signaling_available, false),
-      signaling_mode: asString(webrtc.signaling_mode, 'unknown'),
-      pending_offers: asNumber(webrtc.pending_offers, 0),
-      active_peers: asNumber(webrtc.active_peers, 0),
-      live_connections: asNumber(webrtc.live_connections, 0),
-      connected_channels: asNumber(webrtc.connected_channels, 0),
-      ice_server_count: asNumber(webrtc.ice_server_count, 0),
-    },
-    streamable_http: {
-      endpoint: asString(streamableHttp.endpoint, '/mcp'),
-      observer_stream: asString(streamableHttp.observer_stream, '/mcp?sse_kind=observer'),
-      managed_endpoint: asString(streamableHttp.managed_endpoint, '/mcp/managed'),
-      operator_endpoint: asString(streamableHttp.operator_endpoint, '/mcp/operator'),
-      delete_endpoint: asString(streamableHttp.delete_endpoint, '/mcp'),
-      legacy_sse_endpoint: asString(streamableHttp.legacy_sse_endpoint, '/sse'),
-      legacy_messages_endpoint: asString(streamableHttp.legacy_messages_endpoint, '/messages'),
-      default_transport: asString(streamableHttp.default_transport, 'unknown'),
-      supports_post: asBoolean(streamableHttp.supports_post, false),
-      supports_sse_upgrade: asBoolean(streamableHttp.supports_sse_upgrade, false),
-      supports_delete: asBoolean(streamableHttp.supports_delete, false),
-    },
-    http2: {
-      listener_mode: asString(http2.listener_mode, 'unknown'),
-      multiplex_ready: asBoolean(http2.multiplex_ready, false),
-      prior_knowledge_path: asString(http2.prior_knowledge_path, '/mcp'),
-    },
-    cluster: {
-      cluster: asString(cluster.cluster, 'default'),
-      room_id: asString(cluster.room_id, 'default'),
-      topology_available: asBoolean(cluster.topology_available, false),
-      topology_source: asString(cluster.topology_source, 'unknown'),
-      total_units: asNumber(cluster.total_units) ?? null,
-      managed_units: asNumber(cluster.managed_units) ?? null,
-      live_agents: asNumber(cluster.live_agents) ?? null,
-      active_operations: asNumber(cluster.active_operations) ?? null,
-      stale_units: asNumber(cluster.stale_units) ?? null,
-    },
-    agent_health: {
-      stale_total: asNumber(agentHealth.stale_total, 0),
-    },
-    generated_at: generatedAt,
-    projection_diagnostics: projectionDiagnostics
-      ? {
-          source: asString(projectionDiagnostics.source, 'unknown'),
-          cache_state: asString(projectionDiagnostics.cache_state, 'unknown'),
-          last_success_at: asString(projectionDiagnostics.last_success_at) ?? null,
-          last_attempt_at: asString(projectionDiagnostics.last_attempt_at) ?? null,
-          last_error_at: asString(projectionDiagnostics.last_error_at) ?? null,
-          stale_reason: asString(projectionDiagnostics.stale_reason) ?? null,
-          stale_age_ms: asNumber(projectionDiagnostics.stale_age_ms) ?? null,
-        }
-      : undefined,
-  }
 }
 
-export async function fetchTransportHealth(opts?: AbortableRequestOptions): Promise<TransportHealthData> {
-  const raw = await get<Record<string, unknown>>('/api/v1/dashboard/transport-health', { signal: opts?.signal })
-  const decoded = decodeTransportHealthData(raw)
-  if (!decoded) {
-    throw new Error('invalid transport health payload')
-  }
-  return decoded
+export async function fetchTransportHealth(
+  opts?: AbortableRequestOptions,
+): Promise<TransportHealthData> {
+  const raw = await get<unknown>('/api/v1/dashboard/transport-health', {
+    signal: opts?.signal,
+  })
+  return parseTransportHealthData(raw)
 }


### PR DESCRIPTION
## Summary

**Completes the #7441 P2 rollout.** The final and largest hand-rolled decoder in the dashboard (130 LOC across 11 nested transport surfaces) now goes through a valibot schema at the boundary.

- Adds \`src/api/schemas/transport-health.ts\` — 11 schemas, 1 per-entry-lenient array (sse.hot_sessions), non-empty check on \`generated_at\`, 4th consumer of shared \`SchemaDriftError\` base (#7732).
- Rewrites \`src/api/transport-health.ts\`: **255 LOC → 35 LOC** (thin facade: imports, re-exports, null-returning compat wrapper, parser-routed fetch). Dependency on \`../components/common/normalize\` eliminated.
- Every field's fallback value preserved verbatim (\`'unknown'\`, \`'/mcp'\`, \`0\`, \`false\`, etc.).

## Drift policy

- **Outer strict**: all 9 subsections + non-empty \`generated_at\` required. Any missing → null via compat wrapper (matches prior \`if (!summary || !sse || ... || !generatedAt) return null\`).
- **Every subsection field**: \`fallback(T, DEFAULT)\` with exact defaults from prior decoder.
- **Nullable numerics** (\`recent_messages\`, cluster \`total_units\` etc., \`stale_age_ms\`): \`fallback(nullable(number()), null)\` matches \`asNumber(x) ?? null\`.
- **sse.hot_sessions**: per-entry lenient — rows missing \`session_id\` drop silently.
- **projection_diagnostics**: strictly optional; when present its internal fields fallback or resolve to null.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run src/api/transport-health.test.ts src/components/transport-health.test.ts\` — 24/24 pass (existing, unmodified)
- [ ] CI green

Part of #7441. With this PR, the P2 rollout covers every dashboard REST endpoint that previously used a hand-rolled decoder or an unvalidated cast.