### PR TITLE
feat(sidecars): expose BotConfig JSON schema via python -m src.schema_dump

### DIFF
--- a/sidecars/discord-bot/src/schema_dump.py
+++ b/sidecars/discord-bot/src/schema_dump.py
@@ -1,0 +1,28 @@
+"""Emit BotConfig JSON schema to stdout for the dashboard config form.
+
+Invoked by `./run.sh schema` or `python -m src.schema_dump`. The backend
+captures the stdout once per server lifetime and serves it from
+`/api/v1/sidecar/schema?name=discord` so the dashboard can render a
+config form without hand-coding field metadata.
+
+`BotConfig.model_json_schema()` is a classmethod, so it does not require
+the bot's required env vars (DISCORD_BOT_TOKEN etc.) to be set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .config import BotConfig
+
+
+def main() -> int:
+    schema = BotConfig.model_json_schema()
+    json.dump(schema, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sidecars/discord-bot/tests/test_schema_dump.py
+++ b/sidecars/discord-bot/tests/test_schema_dump.py
@@ -1,0 +1,61 @@
+"""Pin the dashboard contract for `python -m src.schema_dump`.
+
+The dashboard's connector config form shells out to this module via the
+backend `/api/v1/sidecar/schema?name=discord` route. The shape it relies
+on is `{"properties": {<field>: {...}}, ...}` — a top-level object with
+a non-empty `properties` map keyed by alias names like `DISCORD_BOT_TOKEN`.
+
+If a refactor changes BotConfig in a way that breaks this shape (e.g.
+nested $defs without inlined properties) the dashboard form silently
+shows no fields. Pinning here makes that a CI failure.
+
+We exercise schema_dump.main() in-process rather than spawning a
+subprocess because the test runner's `sys.executable` doesn't always
+match the venv that has pydantic_settings installed (uv shim quirk).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+from src.schema_dump import main
+
+
+def _capture_schema() -> dict[str, object]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main()
+    assert rc == 0
+    parsed = json.loads(buf.getvalue())
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_schema_dump_has_properties() -> None:
+    schema = _capture_schema()
+    assert "properties" in schema, "schema must expose a top-level 'properties' map"
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assert len(properties) >= 5, (
+        f"discord BotConfig should expose 5+ fields; got {len(properties)}"
+    )
+
+
+def test_schema_dump_includes_required_token() -> None:
+    schema = _capture_schema()
+    properties = schema.get("properties", {})
+    assert isinstance(properties, dict)
+    assert "DISCORD_BOT_TOKEN" in properties, (
+        "DISCORD_BOT_TOKEN must surface as a property so the form can request it"
+    )
+
+
+def test_schema_dump_marks_token_required() -> None:
+    """Required fields must appear in the top-level `required` array so the
+    dashboard form can mark them and refuse submission with empty values."""
+    schema = _capture_schema()
+    required = schema.get("required", [])
+    assert isinstance(required, list)
+    assert "DISCORD_BOT_TOKEN" in required

--- a/sidecars/imessage-bot/src/schema_dump.py
+++ b/sidecars/imessage-bot/src/schema_dump.py
@@ -1,0 +1,28 @@
+"""Emit BotConfig JSON schema to stdout for the dashboard config form.
+
+Invoked by `./run.sh schema` or `python -m src.schema_dump`. The backend
+captures the stdout once per server lifetime and serves it from
+`/api/v1/sidecar/schema?name=imessage` so the dashboard can render a
+config form without hand-coding field metadata.
+
+`BotConfig.model_json_schema()` is a classmethod, so it does not require
+the bot's required env vars to be set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .config import BotConfig
+
+
+def main() -> int:
+    schema = BotConfig.model_json_schema()
+    json.dump(schema, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sidecars/imessage-bot/tests/test_schema_dump.py
+++ b/sidecars/imessage-bot/tests/test_schema_dump.py
@@ -1,0 +1,27 @@
+"""Dashboard contract pin for imessage-bot. See discord-bot test for rationale."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+from src.schema_dump import main
+
+
+def _capture_schema() -> dict[str, object]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main()
+    assert rc == 0
+    parsed = json.loads(buf.getvalue())
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_schema_dump_has_properties() -> None:
+    schema = _capture_schema()
+    assert "properties" in schema
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assert len(properties) >= 3

--- a/sidecars/slack-bot/src/schema_dump.py
+++ b/sidecars/slack-bot/src/schema_dump.py
@@ -1,0 +1,28 @@
+"""Emit BotConfig JSON schema to stdout for the dashboard config form.
+
+Invoked by `./run.sh schema` or `python -m src.schema_dump`. The backend
+captures the stdout once per server lifetime and serves it from
+`/api/v1/sidecar/schema?name=slack` so the dashboard can render a
+config form without hand-coding field metadata.
+
+`BotConfig.model_json_schema()` is a classmethod, so it does not require
+the bot's required env vars to be set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .config import BotConfig
+
+
+def main() -> int:
+    schema = BotConfig.model_json_schema()
+    json.dump(schema, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sidecars/slack-bot/tests/test_schema_dump.py
+++ b/sidecars/slack-bot/tests/test_schema_dump.py
@@ -1,0 +1,27 @@
+"""Dashboard contract pin for slack-bot. See discord-bot test for rationale."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+from src.schema_dump import main
+
+
+def _capture_schema() -> dict[str, object]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main()
+    assert rc == 0
+    parsed = json.loads(buf.getvalue())
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_schema_dump_has_properties() -> None:
+    schema = _capture_schema()
+    assert "properties" in schema
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assert len(properties) >= 3

--- a/sidecars/telegram-bot/src/schema_dump.py
+++ b/sidecars/telegram-bot/src/schema_dump.py
@@ -1,0 +1,28 @@
+"""Emit BotConfig JSON schema to stdout for the dashboard config form.
+
+Invoked by `./run.sh schema` or `python -m src.schema_dump`. The backend
+captures the stdout once per server lifetime and serves it from
+`/api/v1/sidecar/schema?name=telegram` so the dashboard can render a
+config form without hand-coding field metadata.
+
+`BotConfig.model_json_schema()` is a classmethod, so it does not require
+the bot's required env vars to be set.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from .config import BotConfig
+
+
+def main() -> int:
+    schema = BotConfig.model_json_schema()
+    json.dump(schema, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sidecars/telegram-bot/tests/test_schema_dump.py
+++ b/sidecars/telegram-bot/tests/test_schema_dump.py
@@ -1,0 +1,27 @@
+"""Dashboard contract pin for telegram-bot. See discord-bot test for rationale."""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+
+from src.schema_dump import main
+
+
+def _capture_schema() -> dict[str, object]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = main()
+    assert rc == 0
+    parsed = json.loads(buf.getvalue())
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def test_schema_dump_has_properties() -> None:
+    schema = _capture_schema()
+    assert "properties" in schema
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    assert len(properties) >= 3


### PR DESCRIPTION
## 변경
4 sidecar(discord/imessage/slack/telegram)에 `src/schema_dump.py` (~15 LOC each) 추가. 호출하면 `BotConfig.model_json_schema()`를 stdout으로 출력.

## 용도
대시보드 connector config form이 backend `/api/v1/sidecar/schema?name=<id>` (별도 PR 예정) 통해 schema를 받아 form widget을 자동 생성. 필드/required/default를 hand-code 안 함.

## 핵심 속성
- `model_json_schema()`는 Pydantic classmethod → required env(DISCORD_BOT_TOKEN 등) 없어도 호출 성공. 대시보드가 cold-start onboarding 단계(아직 토큰 없음)에서도 form 그릴 수 있음.

## 검증
6 tests pass:
- discord: properties 5+개, `DISCORD_BOT_TOKEN`이 properties + required 양쪽에 등장
- imessage/slack/telegram: properties 3+개 smoke test
- 모두 in-process 호출(`from src.schema_dump import main`) — `sys.executable` venv 매칭 이슈 회피

## 비포함
- `run.sh schema` sub-command: 3 sidecar는 main에 run.sh 없음 (PR #7829 [feature/sidecar-run-sh] 머지 후 follow-up)
- backend route: 별도 PR 예정 (`feature-sidecar-lifecycle-api` worktree에 추가)