### PR TITLE
docs(observability): promote KCB to landed 6th axis + flag snapshot-observability drift

### DIFF
--- a/docs/observability/composite-fsm-matrix-design.md
+++ b/docs/observability/composite-fsm-matrix-design.md
@@ -9,7 +9,7 @@
 
 ## 1. Problem
 
-The keeper runtime already exposes **5 orthogonal FSM axes** per entity and a **4-invariant joint specification** verifying their composition:
+The keeper runtime exposes **6 orthogonal FSM axes** per entity and a **4-invariant joint specification** verifying their composition:
 
 | Axis | Code site                           | States                                                                    | TLA+ spec                              |
 | ---- | ----------------------------------- | ------------------------------------------------------------------------- | -------------------------------------- |
@@ -18,6 +18,7 @@ The keeper runtime already exposes **5 orthogonal FSM axes** per entity and a **
 | KDP  | `keeper_registry.mli:decision_stage`| undecided / guard_ok / gate_rejected / tool_policy_selected               | `KeeperDecisionPipeline.tla`           |
 | KCL  | `keeper_registry.mli:cascade_state` | idle / selecting / trying / done / exhausted                              | `KeeperCascadeLifecycle.tla`           |
 | KMC  | `keeper_registry.mli:compaction_stage` | accumulating / compacting / done                                        | `KeeperCompactionLifecycle.tla`        |
+| KCB  | `keeper_failure_circuit_breaker.ml` (counter-based) | clean / warning / cooling — `tripped` is unobservable because the mutator resets `consecutive_count` during the trip transition | `KeeperCircuitBreaker.tla`             |
 
 The joint invariants (`phase_turn_alignment`, `no_cascade_before_measurement`, `compaction_atomicity`, `event_priority_monotone`) are already wired into `fsm-hub-types.ts:InvariantViolationCounts` and tracked in `HubState.invariantViolations`.
 
@@ -26,7 +27,7 @@ The joint invariants (`phase_turn_alignment`, `no_cascade_before_measurement`, `
 - Backend endpoint: `GET /api/v1/keepers/<name>/composite` — one keeper per call.
 - Dashboard component: `FsmHub` in `agents-unified.ts:100` — renders the selected keeper only.
 
-An operator who wants to *compare* keeper A's 5-axis state to keeper B's, or see which lanes across the fleet are stuck, has to page through keepers one at a time. The orthogonal structure is present in the data but **invisible at the fleet level**.
+An operator who wants to *compare* keeper A's 6-axis state to keeper B's, or see which lanes across the fleet are stuck, has to page through keepers one at a time. The orthogonal structure is present in the data but **invisible at the fleet level**.
 
 ## 2. Design
 
@@ -35,16 +36,16 @@ An operator who wants to *compare* keeper A's 5-axis state to keeper B's, or see
 Four dimensions on a 2-D screen:
 
 ```
-            ┌─ axis 1 ─┬─ axis 2 ─┬─ axis 3 ─┬─ axis 4 ─┬─ axis 5 ─┐
-keeper A    │ ▮▮▮▮▮▯▯  │ ▮▮▮▯▮▮▮  │ ▯▮▮▮▮▮▮  │ ▮▮▮▮▮▮▮  │ ▮▮▯▮▮▮▮  │
-keeper B    │ ▯▮▮▮▮▮▮  │ ▯▯▯▮▮▮▮  │ ▮▮▮▯▯▮▮  │ ▮▮▮▮▯▯▯  │ ▮▮▮▮▮▮▮  │
-keeper C    │ ▮▮▮▮▮▮▮  │ ▯▯▮▮▮▮▮  │ ▮▮▮▮▯▮▮  │ ▮▯▯▮▮▮▮  │ ▮▮▮▮▮▮▮  │
-            └──────────┴──────────┴──────────┴──────────┴──────────┘
+            ┌─ axis 1 ─┬─ axis 2 ─┬─ axis 3 ─┬─ axis 4 ─┬─ axis 5 ─┬─ axis 6 ─┐
+keeper A    │ ▮▮▮▮▮▯▯  │ ▮▮▮▯▮▮▮  │ ▯▮▮▮▮▮▮  │ ▮▮▮▮▮▮▮  │ ▮▮▯▮▮▮▮  │ ▮▮▮▮▮▮▮  │
+keeper B    │ ▯▮▮▮▮▮▮  │ ▯▯▯▮▮▮▮  │ ▮▮▮▯▯▮▮  │ ▮▮▮▮▯▯▯  │ ▮▮▮▮▮▮▮  │ ▯▮▮▮▮▮▮  │
+keeper C    │ ▮▮▮▮▮▮▮  │ ▯▯▮▮▮▮▮  │ ▮▮▮▮▯▮▮  │ ▮▯▯▮▮▮▮  │ ▮▮▮▮▮▮▮  │ ▮▮▯▯▮▮▮  │
+            └──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
 row = keeper, col = FSM axis, cell = last N state chips (horizontal time axis).
 ```
 
 - **Row**: keeper identity.
-- **Column**: FSM axis (fixed order: KSM, KTC, KDP, KCL, KMC).
+- **Column**: FSM axis (fixed order: KSM, KTC, KDP, KCL, KMC, KCB).
 - **Cell**: N ≤ 30 horizontal chips, one per snapshot tick (oldest → newest left-to-right). Colour encodes state; non-transition ticks collapse to the same chip length so stalls become visibly wider blocks.
 - **Time**: per-cell horizontal (same domain as the existing `MAX_OBSERVATIONS = 30`).
 
@@ -122,7 +123,7 @@ Each PR carries its own test suite. No PR merges without a TLA+ reference if it 
 | Risk                                            | Mitigation                                                               |
 | ----------------------------------------------- | ------------------------------------------------------------------------ |
 | Fleet endpoint N+1: poll every keeper serially  | Observer fold at snapshot time; single JSON payload.                     |
-| Dashboard render cost for 20 keepers × 5 axes × 30 chips | 3,000 DOM nodes — handled. CSS grid + state-chip memoization.      |
+| Dashboard render cost for 20 keepers × 6 axes × 30 chips | 3,600 DOM nodes — handled. CSS grid + state-chip memoization.      |
 | Drift between spec and code                     | LT-15 produces drift table; any column with drift blocks its axis from matrix until resolved. |
 | OAS silent FSMs leak through envelope causality | LT-14 publishes only; does not change state. OAS must not know MASC remains enforced. |
 | Matrix overflows viewport at fleet > 50         | Row virtualisation + sort-by-violation-count. Defer until needed.        |

--- a/docs/observability/fsm-spec-code-drift.md
+++ b/docs/observability/fsm-spec-code-drift.md
@@ -1,9 +1,10 @@
 # FSM Spec ↔ Code Drift Audit (LT-15)
 
-Neutral diff between TLA+ specs, OCaml types, and the composite observer projection for the 5 keeper FSM axes, plus disposition of unpaired specs.
+Neutral diff between TLA+ specs, OCaml types, and the composite observer projection for the keeper FSM axes, plus disposition of unpaired specs.
 
-**Scope**: `specs/keeper-state-machine/` vs `lib/keeper/` as of commit `886abd2cc`.
-**Verdict**: 4 of 5 axes align exactly. 1 axis (KSM) carries a **documented lossy projection** at the observer layer. 4 specs are unpaired in code; 2 deserve a fate decision in-session.
+**Scope**: `specs/keeper-state-machine/` vs `lib/keeper/` as of commit `886abd2cc`. Post-audit update on 2026-04-17 folds in LT-16-KCB Phases 1–3 and promotes the circuit-breaker candidate to a landed 6th axis.
+
+**Verdict**: 4 of 5 original axes align exactly. 1 axis (KSM) carries a **documented lossy projection** at the observer layer. The newly admitted 6th axis (KCB) has its **own kind of drift** — snapshot-observability does not match the spec's classical state set — and the landed implementation renders the 3 observable states only (see §3 and §5). 4 specs are unpaired in code; 2 have disposition decisions.
 
 ---
 
@@ -87,11 +88,11 @@ Neutral diff between TLA+ specs, OCaml types, and the composite observer project
 
 ## 3. Candidate axes not currently on the matrix
 
-Spec+code pair exists, but `KeeperCompositeLifecycle.tla` does not cross them with the 5 core axes. Evaluate for admission as a 6th / 7th matrix column.
+Spec+code pair exists, but `KeeperCompositeLifecycle.tla` does not cross them with the core axes. Evaluate for admission as an additional matrix column.
 
 | Candidate                      | Spec                                | Code                                                | States                                          | Verdict                                                                  |
 | ------------------------------ | ----------------------------------- | --------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------ |
-| KCB — Circuit breaker          | `KeeperCircuitBreaker.tla`          | `keeper_failure_circuit_breaker.ml`                 | Closed, Open, Half_open                         | **Admit as column 6.** Orthogonal to all 5, cheap to observe, directly actionable (open breaker = stop trying). |
+| KCB — Circuit breaker          | `KeeperCircuitBreaker.tla`          | `keeper_failure_circuit_breaker.ml`                 | **Observable: clean, warning, cooling.** `tripped` is unobservable because the mutator resets `consecutive_count` during the trip transition. The spec's `Closed / Open / Half_open` triple does not survive the counter-based implementation as-is — `Open` is a transient step inside `record_failure`, not a stable state. | **Admitted as column 6** (LT-16-KCB Phase 1–3, 2026-04-17). Matrix, flowchart, and drift-audit all updated to the 3 observable states. `tripped` is marked with a dashed edge in the Mermaid panel to acknowledge the unobservable transition. |
 | KCF — Campaign lifecycle       | `KeeperCampaignLifecycle.tla`       | `keeper_campaign_fsm.mli`                           | Bootstrapping, Claiming_task, Advancing, …      | **Defer.** Redundant with KDP for most operational decisions; matrix is already wide.       |
 | KSM-Ledger — Magentic ledger   | `KeeperSocialModelMagenticLedger.tla` | `keeper_social_model_magentic_ledger_fsm.ml`      | Advancing, Reactive, …                          | **Defer.** Social-model signal, not an operational one; separate panel, not a core axis.   |
 
@@ -114,10 +115,16 @@ A CI rule enforcing this is out of scope for LT-15 but is the right follow-up (D
 
 ## 5. Conclusion
 
-- **4 of 5 axes are clean.** KTC/KDP/KCL/KMC are 1:1 between TLA+ and OCaml; the JSON schema handles prefix normalization.
+- **4 of 5 core axes are clean.** KTC/KDP/KCL/KMC are 1:1 between TLA+ and OCaml; the JSON schema handles prefix normalization.
 - **1 axis carries a documented lossy projection.** `ksm_phase` collapses 6 OCaml phases into `Ksm_stable`. This is **not** a bug, but it is a UX constraint: the matrix should bypass the observer projection for KSM and consume `Keeper_state_machine.phase` directly (12 states with semantic color grouping).
 - **4 unpaired specs** resolved: 2 retire, 1 formalize later, 1 demote to property test.
-- **1 candidate axis** (circuit breaker) admitted as matrix column 6 for LT-16.
+- **1 candidate axis** (circuit breaker) admitted as matrix column 6 and landed end-to-end through LT-16-KCB Phases 1–3 (#7793 / #7801 / #7822).
+
+### Post-audit update (2026-04-17)
+
+LT-16-KCB Phase 1 discovered that the KCB spec does not translate 1:1 to the implementation: the classical `Closed / Open / Half_open` triple names states that are either *unobservable at snapshot time* (`Open` = `tripped`, reset in the same critical section) or do not exist in the counter-based OCaml model. The landed axis therefore uses the **observable state set** (`clean / warning / cooling`) and the Mermaid flowchart notes the unobservable transition with a dashed edge.
+
+This is the first axis in the matrix where the spec **state set disagreed with what a fleet-level observer can actually see**, and the drift audit checklist should be extended in the next iteration to include a "snapshot-observability" column per state, so the same trap does not hide inside future admissions (KCF, KSM-Ledger).
 
 No code change in this PR. Next tick (T+3) is **LT-13**: wire `InvariantViolationCounts` to a Prometheus counter + alert rule + Grafana panel.
 


### PR DESCRIPTION
## Summary

LT-16-KCB Phases 1–3 (#7793 / #7801 / #7822) landed the circuit-breaker axis end-to-end on the composite-FSM matrix. The two observability design docs still described the "5-axis world"; this PR syncs them with what actually ships and records a **new kind of drift** the original LT-15 audit checklist did not cover.

## Change surface

### `docs/observability/composite-fsm-matrix-design.md`

- Opening sentence: "5 orthogonal FSM axes" → **"6 orthogonal FSM axes"**.
- Axes table grows a KCB row. States listed as the 3 **observable** ones (`clean` / `warning` / `cooling`), with a note that `tripped` is unobservable because the mutator resets `consecutive_count` during the trip transition.
- ASCII encoding sketch gains a 6th column.
- DOM-budget note: 20 keepers × 6 axes × 30 chips = **3,600 nodes**.

### `docs/observability/fsm-spec-code-drift.md`

- Verdict line updated: KCB is no longer "candidate" — it is a **landed axis** with its own kind of drift.
- Added "Post-audit update on 2026-04-17" provenance.
- §3 KCB row rewritten: the classical `Closed / Open / Half_open` triple **does not survive** the counter-based OCaml model. `Open` is a transient step inside `record_failure`, not a stable state. Landed axis uses the 3 observable states only. Mermaid panel marks the unobservable transition with a dashed edge.
- §5 Conclusion: new paragraph flagging **snapshot-observability** as a drift class the original checklist missed. Future candidate axes (KCF campaign lifecycle, KSM-Ledger social model) should be evaluated with a per-state observability column up front so the same trap does not hide inside their admission review.

## Why this matters

Docs that lag implementation rot fast. More importantly, LT-15's drift-audit framework only checked **state set equality** (spec states = code states) — it did not ask *which states are observable at snapshot time*. KCB tripped our blind spot because the spec state set was technically isomorphic (3 states either way), but the specific spec states named `Closed / Open / Half_open` mean something the counter can never expose. Future admissions should carry a "snapshot visible?" flag per state, not just a state list.

## Test plan

- [x] Markdown renders cleanly (no broken tables)
- [x] No cross-file link rot — `KeeperCircuitBreaker.tla`, `keeper_failure_circuit_breaker.ml`, and related filenames still exist at the referenced paths
- [ ] CI green (doc-truth, pr-hygiene)

Pure docs, no code change, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
