### PR TITLE
feat(dashboard/tools): add source filter + search to prompt-registry-panel

### DIFF
--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -51,7 +51,108 @@ vi.mock('../../api', () => ({
   savePromptOverride: vi.fn(async () => ({ ok: true, message: 'override set' })),
 }))
 
-import { PromptRegistryPanel } from './prompt-registry-panel'
+import type { DashboardPromptItem } from '../../api'
+import { PromptRegistryPanel, filterPrompts, promptSourceCounts } from './prompt-registry-panel'
+
+function makePrompt(overrides: Partial<DashboardPromptItem>): DashboardPromptItem {
+  return {
+    key: 'keeper.system',
+    category: 'keeper',
+    description: 'Keeper system prompt',
+    current: '',
+    default: null,
+    effective: '',
+    file_value: null,
+    override_value: null,
+    file_path: null,
+    file_exists: true,
+    source: 'file',
+    has_override: false,
+    char_count: 0,
+    required_file: true,
+    template_variables: [],
+    ...overrides,
+  }
+}
+
+const HELPER_FIXTURES: DashboardPromptItem[] = [
+  makePrompt({ key: 'keeper.system', category: 'keeper', description: 'k1', source: 'file' }),
+  makePrompt({ key: 'keeper.turn', category: 'keeper', description: 'k2', source: 'override' }),
+  makePrompt({ key: 'planner.root', category: 'planner', description: 'p1', source: 'default' }),
+  makePrompt({ key: 'planner.step', category: 'planner', description: 'p2', source: 'missing' }),
+  makePrompt({
+    key: 'supervisor.brief',
+    category: 'supervisor',
+    description: 'supervisor briefing template',
+    source: 'file',
+  }),
+]
+
+describe('filterPrompts', () => {
+  it('returns all prompts when source is all and query is empty', () => {
+    expect(filterPrompts(HELPER_FIXTURES, 'all', '')).toHaveLength(5)
+  })
+
+  it('filters by source', () => {
+    const file = filterPrompts(HELPER_FIXTURES, 'file', '')
+    expect(file).toHaveLength(2)
+    expect(file.every(p => p.source === 'file')).toBe(true)
+    expect(filterPrompts(HELPER_FIXTURES, 'override', '')).toHaveLength(1)
+    expect(filterPrompts(HELPER_FIXTURES, 'missing', '')).toHaveLength(1)
+    expect(filterPrompts(HELPER_FIXTURES, 'default', '')).toHaveLength(1)
+  })
+
+  it('search matches key substring (case-insensitive)', () => {
+    const out = filterPrompts(HELPER_FIXTURES, 'all', 'KEEPER')
+    expect(out.map(p => p.key)).toEqual(['keeper.system', 'keeper.turn'])
+  })
+
+  it('search matches category', () => {
+    expect(filterPrompts(HELPER_FIXTURES, 'all', 'planner')).toHaveLength(2)
+  })
+
+  it('search matches description', () => {
+    const out = filterPrompts(HELPER_FIXTURES, 'all', 'briefing')
+    expect(out).toHaveLength(1)
+    expect(out[0]?.key).toBe('supervisor.brief')
+  })
+
+  it('source and query combine with AND', () => {
+    const out = filterPrompts(HELPER_FIXTURES, 'file', 'keeper')
+    expect(out).toHaveLength(1)
+    expect(out[0]?.key).toBe('keeper.system')
+  })
+
+  it('whitespace-only query is treated as empty', () => {
+    expect(filterPrompts(HELPER_FIXTURES, 'all', '   ')).toHaveLength(5)
+  })
+
+  it('returns empty when nothing matches', () => {
+    expect(filterPrompts(HELPER_FIXTURES, 'all', 'no-such-key')).toEqual([])
+  })
+})
+
+describe('promptSourceCounts', () => {
+  it('counts each source and total', () => {
+    expect(promptSourceCounts(HELPER_FIXTURES)).toEqual({
+      all: 5,
+      file: 2,
+      override: 1,
+      default: 1,
+      missing: 1,
+    })
+  })
+
+  it('returns zeros on empty input', () => {
+    expect(promptSourceCounts([])).toEqual({
+      all: 0,
+      file: 0,
+      override: 0,
+      default: 0,
+      missing: 0,
+    })
+  })
+})
 
 async function flush() {
   await new Promise(resolve => setTimeout(resolve, 0))

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -1,4 +1,5 @@
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import { Markdown } from "../common/markdown"
 import { useEffect, useState } from 'preact/hooks'
 import {
@@ -11,7 +12,20 @@ import {
 import { Card } from '../common/card'
 import { ErrorState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
-import { TextArea } from '../common/input'
+import { TextArea, TextInput } from '../common/input'
+import { FilterChips } from '../common/filter-chips'
+
+export type PromptSourceFilter = 'all' | PromptSource
+
+const SOURCE_CHIP_ORDER: PromptSourceFilter[] = ['all', 'file', 'override', 'default', 'missing']
+
+const SOURCE_LABELS: Record<PromptSourceFilter, string> = {
+  all: '전체',
+  file: '파일',
+  override: '오버라이드',
+  default: '기본값',
+  missing: '누락',
+}
 
 function sourceBadgeClass(source: PromptSource): string {
   switch (source) {
@@ -31,6 +45,43 @@ function normalizeDraft(prompt: DashboardPromptItem | null): string {
   return prompt.override_value ?? prompt.effective
 }
 
+// Pure helper: filter by source + substring search (case-insensitive).
+// Exported for unit testing.
+export function filterPrompts(
+  prompts: DashboardPromptItem[],
+  source: PromptSourceFilter,
+  query: string,
+): DashboardPromptItem[] {
+  const q = query.trim().toLowerCase()
+  return prompts.filter(p => {
+    if (source !== 'all' && p.source !== source) return false
+    if (!q) return true
+    return (
+      p.key.toLowerCase().includes(q) ||
+      p.category.toLowerCase().includes(q) ||
+      p.description.toLowerCase().includes(q)
+    )
+  })
+}
+
+// Exported for unit testing.
+export function promptSourceCounts(
+  prompts: DashboardPromptItem[],
+): Record<PromptSourceFilter, number> {
+  const counts: Record<PromptSourceFilter, number> = {
+    all: prompts.length,
+    file: 0,
+    override: 0,
+    default: 0,
+    missing: 0,
+  }
+  for (const p of prompts) counts[p.source] += 1
+  return counts
+}
+
+const sourceFilter = signal<PromptSourceFilter>('all')
+const searchQuery = signal('')
+
 export function PromptRegistryPanel() {
   const [prompts, setPrompts] = useState<DashboardPromptItem[]>([])
   const [loading, setLoading] = useState(false)
@@ -40,7 +91,9 @@ export function PromptRegistryPanel() {
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
 
+  const visiblePrompts = filterPrompts(prompts, sourceFilter.value, searchQuery.value)
   const selectedPrompt = prompts.find(prompt => prompt.key === selectedKey) ?? prompts[0] ?? null
+  const counts = promptSourceCounts(prompts)
 
   async function loadPrompts(preferredKey?: string | null) {
     setLoading(true)
@@ -123,13 +176,41 @@ export function PromptRegistryPanel() {
       <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
         <div class="min-h-[260px] rounded-xl border border-[var(--card-border)] bg-[var(--white-3)] p-2">
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
-            <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">등록된 프롬프트</div>
+            <div class="text-[11px] uppercase tracking-[0.08em] text-[var(--text-muted)]">
+              등록된 프롬프트
+              ${sourceFilter.value !== 'all' || searchQuery.value
+                ? html`<span class="ml-1 normal-case tracking-normal text-[var(--text-muted)]">${visiblePrompts.length} / ${prompts.length}</span>`
+                : null}
+            </div>
             <${ActionButton} variant="ghost" size="sm" disabled=${loading || saving} onClick=${() => { void loadPrompts(selectedPrompt?.key ?? null) }}>
               ${loading ? '새로고침 중' : '새로고침'}
             <//>
           </div>
+          <div class="mb-2 px-2">
+            <${FilterChips}
+              chips=${SOURCE_CHIP_ORDER.map(key => ({
+                key,
+                label: SOURCE_LABELS[key],
+                count: counts[key],
+              }))}
+              active=${sourceFilter}
+            />
+          </div>
+          <div class="mb-2 px-2">
+            <${TextInput}
+              placeholder="key / category / 설명 검색"
+              ariaLabel="프롬프트 검색"
+              value=${searchQuery.value}
+              onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+            />
+          </div>
           <div class="flex max-h-[520px] flex-col gap-2 overflow-y-auto pr-1">
-            ${prompts.map(prompt => html`
+            ${visiblePrompts.length === 0 ? html`
+              <div class="rounded-lg border border-dashed border-[var(--card-border)] px-3 py-6 text-center text-[11px] text-[var(--text-muted)]">
+                조건에 맞는 프롬프트가 없습니다.
+              </div>
+            ` : null}
+            ${visiblePrompts.map(prompt => html`
               <button
                 type="button"
                 class="rounded-lg border px-3 py-2 text-left transition-colors ${selectedPrompt?.key === prompt.key


### PR DESCRIPTION
## Summary
- Adds `source` FilterChips (all / file / override / default / missing) with live counts above the prompt list.
- Adds substring `TextInput` search across `key`, `category`, `description` (case-insensitive, whitespace-trimmed).
- Extracts pure helpers `filterPrompts()` and `promptSourceCounts()` so filter logic is unit-testable without DOM.
- Shows `N / total` badge in the list header when a filter is active; empty-state when nothing matches.

## Why
`prompt-registry-panel` rendered the full list with no filter/search. As prompt registry grows (keeper, planner, governance, supervisor), operators scroll to find the key they need or to see what's overridden vs file-backed. This is the same ergonomic pattern already applied to `verification-requests-panel` (iter-10).

## Scope
- 2 files, dashboard-only.
- No behavior change for existing mutation flow (override apply/clear/reset), no API changes.
- Existing render test still passes; 10 new unit tests added alongside it.

## Test plan
- [x] `pnpm typecheck` green
- [x] `pnpm lint` green
- [x] `pnpm test` — 2685/2685 passing (local run)
- [ ] CI green on PR