### PR TITLE
chore(doc-truth): add require_contains_if_exists wrapper (future-proofs regression locks)

### DIFF
--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -47,12 +47,8 @@ require_not_contains() {
 }
 
 # Like require_contains but silently skips when the file no longer exists.
-# Use for regression locks that pin retired-surface markers: if a later PR
-# chooses to delete the file entirely (rather than keep the archive banner),
-# the lock becomes a no-op instead of a CI blocker. Prior cases: PR #7790
-# (04-chain-engine.md archive banner) -> PR #7796 file deletion -> PR #7818
-# reactive drop. A file-existence precheck would have made that churn
-# unnecessary.
+# Use when a regression lock targets a file that may be legitimately
+# deleted by a later PR.
 require_contains_if_exists() {
   local file="$1"
   local needle="$2"

--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -46,6 +46,21 @@ require_not_contains() {
   fi
 }
 
+# Like require_contains but silently skips when the file no longer exists.
+# Use for regression locks that pin retired-surface markers: if a later PR
+# chooses to delete the file entirely (rather than keep the archive banner),
+# the lock becomes a no-op instead of a CI blocker. Prior cases: PR #7790
+# (04-chain-engine.md archive banner) -> PR #7796 file deletion -> PR #7818
+# reactive drop. A file-existence precheck would have made that churn
+# unnecessary.
+require_contains_if_exists() {
+  local file="$1"
+  local needle="$2"
+  if [ -f "$file" ]; then
+    require_contains "$file" "$needle"
+  fi
+}
+
 extract_single() {
   local pattern="$1"
   local file="$2"


### PR DESCRIPTION
## Motivation

`scripts/check-doc-truth.sh`의 regression lock이 **파일 삭제 정책 shift**에 brittle하다. 실측 churn:

| PR | Action |
|----|--------|
| #7747 | `docs/spec/04-chain-engine.md` archive-in-place (ARCHIVED banner) |
| #7790 | `require_contains <file> '# Chain Engine — ARCHIVED'` lock 추가 |
| #7796 | 같은 파일 **전체 삭제** (policy shift) |
| (multiple) | Doc Truth CI 실패: #7789, #7814, #7820 포함 |
| #7818 | reactive fix: require_contains 2줄 수동 drop |

## Change

새 helper:

```sh
require_contains_if_exists() {
  local file="$1"
  local needle="$2"
  if [ -f "$file" ]; then
    require_contains "$file" "$needle"
  fi
}
```

"retired-surface marker가 **파일이 아직 있는 동안만** 지켜져야 한다"는 의도를 정확히 표현. 파일 삭제 시 silent no-op.

## Scope

- 새 function 추가만 (15 lines, including motivation comment)
- 기존 6 lock은 그대로 유지 (behavior-preserving, no semantic shift)
- 현재 usage 0 — future assertion에 사용 권장
- 기존 lock을 이 wrapper로 변환하는 작업은 **semantic change**이므로 별도 PR에서 case-by-case 판단

## Meta note

Gen22 handoff memory 교훈 #8의 실전 적용:
> "Regression locks is a **time-bounded invariant**, not a universal truth. Policy shift 시 lock도 shift. file-existence precheck 추가 검토."

## Validation

- `bash scripts/check-doc-truth.sh` → `Doc truth OK`
- `rg 'require_contains_if_exists' scripts/` → 1 match (definition only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)