### PR TITLE
chore(operator): drop provenance_summary (surface contract has no consumer)

### DIFF
--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -953,7 +953,6 @@ let snapshot_json ?actor ?view ?(include_messages = true)
          ("operator_judge_runtime", operator_judge_runtime_json config);
          ("judgment_owner", `String "fallback_read_model");
          ("authoritative_judgment_available", `Bool false);
-         ("provenance_summary", operator_surface_contract_json);
          ("root", room_json config);
        ]
       @ (

--- a/lib/operator/operator_digest.ml
+++ b/lib/operator/operator_digest.ml
@@ -133,7 +133,6 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
           ("health", `String "ok");
           ("judgment_owner", `String "fallback_read_model");
           ("authoritative_judgment_available", `Bool false);
-          ("provenance_summary", operator_surface_contract_json);
           ("judgment", `Null);
           ("operator_judge_runtime", operator_judge_runtime_json config);
           ("attention_items", `List []);
@@ -182,7 +181,6 @@ let digest_json ?actor ?target_type ?target_id:_target_id ?include_workers:_incl
               ("target_type", `String "root");
               ("target_id", `Null);
               ("health", `String (health_from_attention_items attention_items));
-              ("provenance_summary", operator_surface_contract_json);
               ("operator_judge_runtime", operator_judge_runtime_json config);
               ("role_census", `Assoc []);
               ("runtime_pools", `Assoc []);

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -36,16 +36,6 @@ let normalized_actor ~context_actor = function
       let trimmed = String.trim context_actor in
       if trimmed = "" || String.equal trimmed "unknown" then "unknown" else trimmed
 
-let operator_surface_contract_json =
-  `Assoc
-    [
-      ("judgment", `String "judgment");
-      ("attention_items", `String "derived");
-      ("recommended_actions", `String "fallback");
-      ("active_recommended_actions", `String "judgment_or_fallback");
-      ("recent_reviews", `String "operator_state");
-    ]
-
 let operator_judge_runtime_json (config : Coord.config) =
   let runtime = Dashboard_operator_judge.runtime_status config.base_path in
   `Assoc

--- a/lib/operator/operator_pending_confirm.mli
+++ b/lib/operator/operator_pending_confirm.mli
@@ -14,7 +14,6 @@ val operator_dir : Coord.config -> string
 val pending_confirms_path : Coord.config -> string
 val trace_id : string -> string
 val normalized_actor : context_actor:string -> string option -> string
-val operator_surface_contract_json : Yojson.Safe.t
 val operator_judge_runtime_json : Coord.config -> Yojson.Safe.t
 
 type pending_confirm = {


### PR DESCRIPTION
## Summary

\`operator_surface_contract_json\` emits a fixed provenance-label map on every digest/snapshot response. Grep over \`dashboard/src/\` for either \`provenance_summary\` or \`operator_surface_contract\` returns **0 hits** — no frontend ever reads the field.

| File | Change |
|---|---|
| \`lib/operator/operator_pending_confirm.ml\` | drop \`operator_surface_contract_json\` value |
| \`lib/operator/operator_pending_confirm.mli\` | drop corresponding \`val\` export |
| \`lib/operator/operator_digest.ml\` | drop 2× \`provenance_summary\` emissions (fallback + root-target) |
| \`lib/operator/operator_control_snapshot.ml\` | drop 1× \`provenance_summary\` emission |

4 files · **-14 LOC, 0 additions**.

## Stacked on #7840

Base: \`chore/gen21-worker-cards-purge\`. Files intentionally overlap with Gen21 (\`operator_pending_confirm.ml\`, \`operator_digest.ml\`); stacking avoids the rebase merge conflict that would otherwise arise if opened against \`main\`.

## Non-goals

- \`dashboard_mission_briefing.ml\` has its own \`provenance_summary\` surface (\`mission_briefing_surface_contract_json\`) covered by \`test_dashboard_mission_briefing.ml\`. Left alone — different contract, different consumers.