### PR TITLE
feat(dashboard): add name/model/blocker filter to fleet-telemetry-panel

### DIFF
--- a/dashboard/src/components/fleet-telemetry-panel.test.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.test.ts
@@ -5,6 +5,82 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TelemetrySummaryResponse, ToolQualityResponse } from '../api/dashboard'
 import { normalizeKeepers } from '../keeper-store-normalize'
 import type { DashboardExecutionResponse } from '../types'
+import { filterFleetRows } from './fleet-telemetry-panel'
+import type { FleetRow } from './fleet-telemetry-utils'
+
+function makeRow(overrides: Partial<FleetRow> = {}): FleetRow {
+  return {
+    name: 'keeper-x',
+    status: 'active',
+    keepalive_running: true,
+    context_ratio: 0.3,
+    turn_count: 0,
+    last_latency_ms: 0,
+    last_activity_ago_s: null,
+    model: '',
+    tool_calls: 0,
+    tool_success_pct: null,
+    tool_activity_known: false,
+    recent_tools: [],
+    runtime_blocker_class: null,
+    runtime_blocker_summary: null,
+    tool_audit_at: null,
+    budget_source: null,
+    ...overrides,
+  }
+}
+
+describe('filterFleetRows', () => {
+  const rows: FleetRow[] = [
+    makeRow({ name: 'keeper-alpha', model: 'gpt-5.4' }),
+    makeRow({ name: 'keeper-beta', model: 'claude-sonnet-4-6' }),
+    makeRow({ name: 'watcher-gamma', model: 'gpt-5.4', runtime_blocker_class: 'turn_timeout' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterFleetRows(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterFleetRows(rows, '   ')).toBe(rows)
+  })
+
+  it('matches by name substring (case-insensitive)', () => {
+    const result = filterFleetRows(rows, 'KEEPER')
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.name)).toEqual(['keeper-alpha', 'keeper-beta'])
+  })
+
+  it('matches by model substring', () => {
+    const result = filterFleetRows(rows, 'claude')
+    expect(result.map(r => r.name)).toEqual(['keeper-beta'])
+  })
+
+  it('matches by runtime_blocker_class substring', () => {
+    const result = filterFleetRows(rows, 'turn_timeout')
+    expect(result.map(r => r.name)).toEqual(['watcher-gamma'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterFleetRows(rows, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterFleetRows(rows, '  alpha  ')).toHaveLength(1)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = rows.slice()
+    filterFleetRows(rows, 'alpha')
+    expect(rows).toEqual(copy)
+  })
+
+  it('handles rows with null model and null blocker safely', () => {
+    const input: FleetRow[] = [makeRow({ name: 'orphan', model: '', runtime_blocker_class: null })]
+    expect(filterFleetRows(input, 'orphan')).toHaveLength(1)
+    expect(filterFleetRows(input, 'anything-else')).toHaveLength(0)
+  })
+})
 
 const executionResponse = {
   generated_at: '2026-04-09T08:10:00Z',

--- a/dashboard/src/components/fleet-telemetry-panel.ts
+++ b/dashboard/src/components/fleet-telemetry-panel.ts
@@ -47,6 +47,32 @@ import {
 
 export { buildFleetRows }
 
+/**
+ * Pure filter for fleet rows.
+ *
+ * Case-insensitive substring match on `row.name`, `row.model`, and
+ * `row.runtime_blocker_class` so operators can locate a keeper by
+ * partial name, by the model it is running, or by its current blocker.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no
+ * new array allocation, preserves referential equality for memoisation).
+ *
+ * Input is never mutated.
+ */
+export function filterFleetRows(
+  rows: readonly FleetRow[],
+  query: string,
+): readonly FleetRow[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(row => {
+    if (row.name.toLowerCase().includes(needle)) return true
+    if (row.model && row.model.toLowerCase().includes(needle)) return true
+    if (row.runtime_blocker_class && row.runtime_blocker_class.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 // Whether "up" is bad for a given metric. context_ratio and latency going up = bad.
 function isUpBad(metric: MetricKey): boolean {
   return metric === 'context_ratio' || metric === 'last_latency_ms'
@@ -327,6 +353,7 @@ export function FleetTelemetryPanel() {
   const latestRequestId = useRef(0)
   const activeController = useRef<AbortController | null>(null)
   const state = useSignal<FleetTelemetryState>(emptyState())
+  const query = useSignal('')
 
   const loadFleetTelemetry = async () => {
     activeController.current?.abort()
@@ -419,6 +446,11 @@ export function FleetTelemetryPanel() {
 
   const value = state.value
   const counts = useMemo(() => summaryCounts(value.rows), [value.rows])
+  const visibleRows = useMemo(
+    () => filterFleetRows(value.rows, query.value),
+    [value.rows, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
   const liveTone: 'neutral' | 'ok' | 'warn' =
     value.rows.length === 0
       ? 'neutral'
@@ -524,8 +556,20 @@ export function FleetTelemetryPanel() {
       </div>
 
       <div>
-        <div class="mb-1 text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Keeper 비교</div>
-        <${FleetComparisonTable} rows=${value.rows} onReset=${handleReset} />
+        <div class="mb-1 flex items-center justify-between gap-2">
+          <div class="text-[10px] uppercase tracking-wider text-[var(--text-dim)]">Keeper 비교</div>
+          <input
+            type="search"
+            value=${query.value}
+            placeholder="name / model / blocker 필터"
+            aria-label="Keeper 필터"
+            onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+            class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
+        </div>
+        ${isFiltering && visibleRows.length === 0 && value.rows.length > 0
+          ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${value.rows.length} keepers)</div>`
+          : html`<${FleetComparisonTable} rows=${visibleRows} onReset=${handleReset} />`}
       </div>
 
       <div>


### PR DESCRIPTION
## 요약

주 키퍼 비교 테이블(`FleetTelemetryPanel` > `FleetComparisonTable`)에 name/model/blocker 필터를 추가합니다. 필터가 없어 키퍼가 많을 때 특정 키퍼, 모델 변형, 또는 같은 `runtime_blocker_class`에 걸린 전체 키퍼를 빠르게 추리기 어려웠습니다.

## 변경

- `filterFleetRows(rows, query)` 순수 함수를 `fleet-telemetry-panel.ts`에서 export. case-insensitive substring, `name` → `model` → `runtime_blocker_class` 순서로 first-match.
- 빈/공백 query는 입력 참조를 그대로 반환 → `useMemo` 동일성 유지, non-filter path 추가 할당 없음.
- 입력 비변이 (readonly 가정 유지).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N keepers)` — 데이터 자체가 없는 경우와 구분.
- 단위 테스트 9건: 빈/공백, case, per-field 매칭, no-match, null/empty 필드, 입력 비변이.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/fleet-telemetry-panel.test.ts`: 24/24 pass (기존 15 + 신규 9).
- `pnpm exec eslint .`: 에러 0.

## 범위

Dashboard만, 파일 2개(panel + test). 백엔드/타입/API 변경 없음.

Follows the iter-7/8/9/11 seed-hint pattern.