### PR TITLE
feat(dashboard): add search to task-detail-overlay event list

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -16,6 +16,8 @@ import {
   taskEvents,
   taskEventsLoading,
   taskEventsError,
+  taskEventsSearchQuery,
+  filterTaskEvents,
   assigneeGoalIds,
   activeTab,
   switchToActivityTab,
@@ -56,14 +58,37 @@ function TaskEventsSection() {
   const events = taskEvents.value
   const loading = taskEventsLoading.value
   const error = taskEventsError.value
+  const query = taskEventsSearchQuery.value
 
   if (loading) return html`<${LoadingState}>이벤트 불러오는 중...<//>`
   if (error) return html`<${ErrorState} message=${error} />`
   if (events.length === 0) return html`<${EmptyState} message="기록된 이벤트가 없습니다" compact />`
 
+  const visible = filterTaskEvents(events, query)
+  const trimmed = query.trim()
+
   return html`
-    <div class="flex flex-col gap-0.5">
-      ${events.map((evt: NormalizedTaskEvent, i: number) => {
+    <div class="flex flex-col gap-2">
+      <div class="flex flex-wrap items-center gap-2">
+        <input
+          type="search"
+          value=${query}
+          placeholder="이벤트 검색 (label/agent/notes)"
+          aria-label="이벤트 검색"
+          onInput=${(e: Event) => { taskEventsSearchQuery.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[180px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+        <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+          ${trimmed
+            ? `${visible.length} / ${events.length}`
+            : `${events.length}개`}
+        </span>
+      </div>
+      ${visible.length === 0
+        ? html`<${EmptyState} message="검색 조건에 맞는 이벤트가 없습니다" compact />`
+        : html`
+      <div class="flex flex-col gap-0.5">
+        ${visible.map((evt: NormalizedTaskEvent, i: number) => {
         const { icon, color } = eventBadge(evt.label)
         return html`
           <div key=${i} class="flex items-start gap-3 py-2 px-3 rounded-lg hover:bg-[var(--white-3)] transition-colors">
@@ -81,6 +106,8 @@ function TaskEventsSection() {
           </div>
         `
       })}
+      </div>
+        `}
     </div>
   `
 }

--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -8,6 +8,7 @@ import { StatusBadge } from '../common/status-badge'
 import { EmptyState } from '../common/empty-state'
 import { ErrorState, LoadingState } from '../common/feedback-state'
 import { RichContent } from '../common/rich-content'
+import { TextInput } from '../common/input'
 import { TimeAgo } from '../common/time-ago'
 import { findKeeper } from '../../lib/keeper-utils'
 import {
@@ -70,13 +71,13 @@ function TaskEventsSection() {
   return html`
     <div class="flex flex-col gap-2">
       <div class="flex flex-wrap items-center gap-2">
-        <input
+        <${TextInput}
           type="search"
           value=${query}
           placeholder="이벤트 검색 (label/agent/notes)"
-          aria-label="이벤트 검색"
+          ariaLabel="이벤트 검색"
           onInput=${(e: Event) => { taskEventsSearchQuery.value = (e.target as HTMLInputElement).value }}
-          class="min-w-[180px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          class="min-w-[180px] flex-1 !py-1 !text-[11px]"
         />
         <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
           ${trimmed
@@ -90,8 +91,9 @@ function TaskEventsSection() {
       <div class="flex flex-col gap-0.5">
         ${visible.map((evt: NormalizedTaskEvent, i: number) => {
         const { icon, color } = eventBadge(evt.label)
+        const key = evt.ts ? `${evt.ts}-${i}` : `${evt.label}-${i}`
         return html`
-          <div key=${i} class="flex items-start gap-3 py-2 px-3 rounded-lg hover:bg-[var(--white-3)] transition-colors">
+          <div key=${key} class="flex items-start gap-3 py-2 px-3 rounded-lg hover:bg-[var(--white-3)] transition-colors">
             <div class="size-7 shrink-0 rounded-md bg-[var(--white-5)] border border-[var(--white-8)] flex items-center justify-center text-[11px] font-mono font-bold ${color}">
               ${icon}
             </div>

--- a/dashboard/src/components/goals/task-detail-state.test.ts
+++ b/dashboard/src/components/goals/task-detail-state.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { filterTaskEvents } from './task-detail-state'
+import type { NormalizedTaskEvent } from './task-detail-state'
+
+const sample: NormalizedTaskEvent[] = [
+  {
+    label: 'claim',
+    agent: 'dreamer',
+    actorKind: 'keeper',
+    taskId: 't-1',
+    ts: '2026-04-17T00:00:00Z',
+    notes: 'picked up high-priority task',
+  },
+  {
+    label: 'done',
+    agent: 'executor',
+    actorKind: 'keeper',
+    taskId: 't-2',
+    ts: '2026-04-17T01:00:00Z',
+    notes: null,
+  },
+  {
+    label: 'cancelled',
+    agent: null,
+    actorKind: null,
+    taskId: 't-3',
+    ts: '2026-04-17T02:00:00Z',
+    notes: 'superseded by newer plan',
+  },
+  {
+    label: 'approve',
+    agent: 'verifier',
+    actorKind: 'human',
+    taskId: 't-4',
+    ts: null,
+    notes: 'looks good',
+  },
+  {
+    // row with only the required label field populated
+    label: 'unknown',
+    agent: null,
+    actorKind: null,
+    taskId: null,
+    ts: null,
+    notes: null,
+  },
+]
+
+describe('filterTaskEvents', () => {
+  it('returns the input reference when query is empty', () => {
+    expect(filterTaskEvents(sample, '')).toBe(sample)
+    expect(filterTaskEvents(sample, '   ')).toBe(sample)
+  })
+
+  it('matches case-insensitive substring on label', () => {
+    const out = filterTaskEvents(sample, 'CANCEL')
+    expect(out.map(e => e.label)).toEqual(['cancelled'])
+  })
+
+  it('matches on agent', () => {
+    const out = filterTaskEvents(sample, 'dreamer')
+    expect(out.map(e => e.label)).toEqual(['claim'])
+  })
+
+  it('matches on actorKind', () => {
+    const out = filterTaskEvents(sample, 'human')
+    expect(out.map(e => e.label)).toEqual(['approve'])
+  })
+
+  it('matches on notes substring', () => {
+    const out = filterTaskEvents(sample, 'superseded')
+    expect(out.map(e => e.label)).toEqual(['cancelled'])
+  })
+
+  it('trims whitespace around the query', () => {
+    const out = filterTaskEvents(sample, '  done  ')
+    expect(out.map(e => e.label)).toEqual(['done'])
+  })
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterTaskEvents(sample, 'no-such-needle')).toEqual([])
+  })
+
+  it('handles rows with missing optional fields without throwing', () => {
+    // label='unknown' row has every other field null; it must be filterable
+    const out = filterTaskEvents(sample, 'unknown')
+    expect(out.map(e => e.label)).toEqual(['unknown'])
+  })
+
+  it('does not mutate the input array', () => {
+    const before = sample.slice()
+    filterTaskEvents(sample, 'dreamer')
+    expect(sample).toEqual(before)
+  })
+
+  it('can match multiple rows when substring is shared', () => {
+    const out = filterTaskEvents(sample, 'keeper')
+    expect(out.map(e => e.label)).toEqual(['claim', 'done'])
+  })
+})

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -50,12 +50,37 @@ function normalizeTaskHistory(raw: TaskHistoryRow[]): NormalizedTaskEvent[] {
   }))
 }
 
+/**
+ * Pure filter for task event rows.
+ *
+ * - `query` is case-insensitive substring match across `label`, `agent`,
+ *   `actorKind`, and `notes` (trimmed).
+ * - Empty/whitespace-only query returns the input reference unchanged
+ *   (zero-allocation fast path).
+ * - Does not mutate the input array.
+ */
+export function filterTaskEvents(
+  rows: readonly NormalizedTaskEvent[],
+  query: string,
+): readonly NormalizedTaskEvent[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(e => {
+    if (e.label.toLowerCase().includes(needle)) return true
+    if (e.agent && e.agent.toLowerCase().includes(needle)) return true
+    if (e.actorKind && e.actorKind.toLowerCase().includes(needle)) return true
+    if (e.notes && e.notes.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 // -- Overlay signals ------------------------------------------------
 
 export const selectedTask = signal<Task | null>(null)
 export const taskEvents = signal<NormalizedTaskEvent[]>([])
 export const taskEventsLoading = signal(false)
 export const taskEventsError = signal<string | null>(null)
+export const taskEventsSearchQuery = signal('')
 
 export type TaskDetailTab = 'overview' | 'activity'
 export const activeTab = signal<TaskDetailTab>('overview')

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -98,6 +98,7 @@ function resetState(): void {
   taskEvents.value = []
   taskEventsLoading.value = false
   taskEventsError.value = null
+  taskEventsSearchQuery.value = ''
   activityEvents.value = []
   activityLoading.value = false
   activityError.value = null


### PR DESCRIPTION
## Summary
- Task detail overlay's "최근 태스크 이벤트" section gains a case-insensitive substring search across `label`, `agent`, `actorKind`, and `notes` on `NormalizedTaskEvent`.
- Pure `filterTaskEvents(rows, query)` is extracted into `task-detail-state.ts`: empty query returns the input reference (zero-alloc), no mutation.
- UI adds a `type="search"` input with live "N / total" counter; empty-match swaps in `EmptyState` ("검색 조건에 맞는 이벤트가 없습니다").

## Scope
- 3 files, +154/-2.
- Dashboard-only, outside all active collision zones (target verified: zero `FilterChips|searchQuery|signal('')` markers pre-change; iter-11 seed list).

## Test plan
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` — 2696/2696 pass (179 files), including 10 new `filterTaskEvents` cases covering label/agent/actorKind/notes match, empty, trim, missing fields, immutability, multi-row.

Seed for iter-13 (task-detail siblings, still unblocked after this PR):
```
src/components/goals/task-activity-list.ts
```
(renders `events.map` with categorical `type` field; no `FilterChips|searchQuery|signal('')` markers yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)