### PR TITLE
chore(dashboard/mission-briefing): drop mission_briefing_surface_contract_json

### DIFF
--- a/lib/dashboard/dashboard_mission_briefing.ml
+++ b/lib/dashboard/dashboard_mission_briefing.ml
@@ -9,14 +9,6 @@ open Briefing_json_helpers
 
 let cache_ttl_sec = Env_config.InternalTimers.briefing_cache_ttl_sec
 
-let mission_briefing_surface_contract_json =
-  `Assoc
-    [
-      ("summary", `String "narrative");
-      ("sections", `String "narrative");
-      ("basis", `String "truth");
-    ]
-
 let mission_briefing_criteria =
   [
     "deterministic_rules_only";
@@ -88,7 +80,6 @@ let pending_json ~now ~last_error =
       ("summary", `String "Generating mission briefing from the latest snapshot.");
       ("provenance", `String "narrative");
       ("authoritative", `Bool false);
-      ("provenance_summary", mission_briefing_surface_contract_json);
       ("model", `Null);
       ("ttl_sec", `Int (int_of_float cache_ttl_sec));
       ("criteria", criteria_json ());
@@ -213,7 +204,6 @@ let compute_briefing_json ~actor_name ~config ~sw ~clock ~proc_mgr () =
           ("summary", `String watch_summary);
           ("provenance", `String "narrative");
           ("authoritative", `Bool false);
-          ("provenance_summary", mission_briefing_surface_contract_json);
           ("model", `String "deterministic");
           ("ttl_sec", `Int (int_of_float cache_ttl_sec));
           ("criteria", criteria_json ());

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -150,7 +150,6 @@ let test_force_refresh_with_cached_result_returns_stale_cached_payload () =
             ("summary", `String "cached summary");
             ("provenance", `String "narrative");
             ("authoritative", `Bool false);
-            ("provenance_summary", `Assoc []);
             ("model", `String "deterministic");
             ("ttl_sec", `Int 300);
             ("criteria", `List []);


### PR DESCRIPTION
## Summary

Same pattern as #7844. \`mission_briefing\` emits a fixed label map as \`provenance_summary\` on every response, but grep over \`dashboard/src/\` returns **0 consumers** for either \`provenance_summary\` or \`mission_briefing_surface_contract\`.

## Diff

| File | Change |
|---|---|
| \`lib/dashboard/dashboard_mission_briefing.ml\` | drop constant + 2 emissions (pending + ok paths) |
| \`test/test_dashboard_mission_briefing.ml\` | drop the orphan \`provenance_summary: Assoc []\` seed — the seed was a JSON placeholder; no assertion ever referenced it |

2 files · **-11 LOC, 0 additions**.

## Test plan

- [x] \`dune build --root . lib/dashboard/\` → 0 errors
- [x] test L166-175 assertions confirmed to never check \`provenance_summary\` — only \`status\`/\`cached\`/\`stale\`/\`refreshing\`/\`summary\`
- [x] \`rg provenance_summary lib/\` post-patch → only dashboard_mission_briefing gone; operator side was removed in #7844
- [ ] CI \`dune build @runtest\` (authoritative)

## Gen chain

| Gen | PR | Scope |
|---|---|---|
| 22 | #7844 merged (into Gen21 branch) | operator_surface_contract_json |
| 23 (this) | — | mission_briefing_surface_contract_json — the twin dead-metadata |