### PR TITLE
feat(dashboard): add name/source/gate filter to keeper-config-panel 훅 슬롯

### DIFF
--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -1,8 +1,82 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { KeeperHookSlot } from '../types'
+import { filterHookSlots, type HookSlotEntry } from './keeper-config-panel'
 
 void vi
+
+function makeSlot(overrides: Partial<KeeperHookSlot> = {}): KeeperHookSlot {
+  return {
+    active: true,
+    source: 'default',
+    ...overrides,
+  }
+}
+
+describe('filterHookSlots', () => {
+  const entries: HookSlotEntry[] = [
+    ['pre_tool_call', makeSlot({ source: 'builtin', gates: ['destructive_check', 'path_scope'] })],
+    ['post_turn', makeSlot({ source: 'override', effects: ['handoff_auto'] })],
+    ['compaction_watcher', makeSlot({ source: 'persona', features: ['ratio_gate'] })],
+    ['orphan', makeSlot({ source: 'builtin' })],
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterHookSlots(entries, '')).toBe(entries)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterHookSlots(entries, '   ')).toBe(entries)
+  })
+
+  it('matches by slot name substring (case-insensitive)', () => {
+    const result = filterHookSlots(entries, 'POST')
+    expect(result.map(([name]) => name)).toEqual(['post_turn'])
+  })
+
+  it('matches by source substring', () => {
+    const result = filterHookSlots(entries, 'persona')
+    expect(result.map(([name]) => name)).toEqual(['compaction_watcher'])
+  })
+
+  it('matches by gates entry', () => {
+    const result = filterHookSlots(entries, 'destructive_check')
+    expect(result.map(([name]) => name)).toEqual(['pre_tool_call'])
+  })
+
+  it('matches by effects entry', () => {
+    const result = filterHookSlots(entries, 'handoff_auto')
+    expect(result.map(([name]) => name)).toEqual(['post_turn'])
+  })
+
+  it('matches by features entry', () => {
+    const result = filterHookSlots(entries, 'ratio_gate')
+    expect(result.map(([name]) => name)).toEqual(['compaction_watcher'])
+  })
+
+  it('returns empty when nothing matches', () => {
+    expect(filterHookSlots(entries, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterHookSlots(entries, '  orphan  ')).toHaveLength(1)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = entries.slice()
+    filterHookSlots(entries, 'pre_tool')
+    expect(entries).toEqual(copy)
+  })
+
+  it('handles slots with missing gates/effects/features safely', () => {
+    const sparse: HookSlotEntry[] = [
+      ['bare', makeSlot({ source: '' })],
+    ]
+    expect(filterHookSlots(sparse, 'bare')).toHaveLength(1)
+    expect(filterHookSlots(sparse, 'anything-else')).toHaveLength(0)
+  })
+})
 
 const mocks = vi.hoisted(() => ({
   fetchKeeperConfig: vi.fn(async () => ({

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -6,7 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { fetchKeeperConfig, patchKeeperConfig } from '../api/dashboard'
 import type { KeeperConfigUpdatePayload } from '../api/dashboard'
-import type { KeeperConfig } from '../types'
+import type { KeeperConfig, KeeperHookSlot } from '../types'
 import type { KeeperConfigLoadStatus } from './keeper-detail-source'
 import { formatTokens } from '../lib/format-number'
 import { showToast } from './common/toast'
@@ -35,6 +35,40 @@ type EditDraft = {
 }
 
 const editDraft = signal<EditDraft | null>(null)
+const hookFilterQuery = signal<string>('')
+
+// ── Hook slot filter ─────────────────────────────────────
+
+export type HookSlotEntry = readonly [name: string, slot: KeeperHookSlot]
+
+/**
+ * Pure filter for hook slot entries.
+ *
+ * Case-insensitive substring match against, in order:
+ * - slot name (the `Record<string, KeeperHookSlot>` key)
+ * - `slot.source`
+ * - any string in `slot.gates`, `slot.effects`, or `slot.features`
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * `useMemo` preserves referential equality when no filter is active.
+ * Input is never mutated.
+ */
+export function filterHookSlots(
+  entries: readonly HookSlotEntry[],
+  query: string,
+): readonly HookSlotEntry[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return entries
+  return entries.filter(([name, slot]) => {
+    if (name.toLowerCase().includes(needle)) return true
+    if (slot.source && slot.source.toLowerCase().includes(needle)) return true
+    const tags = slot.gates ?? slot.effects ?? slot.features ?? []
+    for (const tag of tags) {
+      if (tag && tag.toLowerCase().includes(needle)) return true
+    }
+    return false
+  })
+}
 
 function initDraftFromConfig(c: KeeperConfig): EditDraft {
   return {
@@ -146,6 +180,7 @@ export function resetKeeperConfig(): void {
   saveError.value = null
   runtimeDraft.value = null
   runtimeSaving.value = false
+  hookFilterQuery.value = ''
 }
 
 export function peekLoadedKeeperConfig(name: string): KeeperConfig | null {
@@ -683,30 +718,48 @@ export function KeeperConfigPanel({ keeperName }: { keeperName: string }) {
         </div>
       ` : null}
 
-      ${c.hooks ? html`
-        <${SectionHeader} title="훅 슬롯" />
-        ${Object.entries(c.hooks.slots).map(([name, slot]) => html`
-          <div class="flex items-start gap-2 py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 mb-1.5">
-            <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--text-dim)]'}"></span>
-            <div class="flex-1 min-w-0">
-              <div class="flex justify-between">
-                <span class="text-[12px] font-semibold text-text-strong">${name}</span>
-                <span class="text-[10px] text-text-muted">${slot.source}</span>
-              </div>
-              ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
-                <div class="flex flex-wrap gap-1 mt-1">
-                  ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
-                    <span class="text-[9px] px-1.5 py-0.5 rounded-md ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
-                  `)}
-                </div>
-              ` : null}
-            </div>
+      ${c.hooks ? (() => {
+        const allEntries: readonly HookSlotEntry[] = Object.entries(c.hooks.slots) as HookSlotEntry[]
+        const visibleEntries = filterHookSlots(allEntries, hookFilterQuery.value)
+        const isFiltering = hookFilterQuery.value.trim() !== ''
+        return html`
+          <${SectionHeader} title="훅 슬롯" />
+          <div class="flex items-center justify-between gap-2 mb-2">
+            <span class="text-[10px] text-text-muted">${allEntries.length} slots</span>
+            <input
+              type="search"
+              value=${hookFilterQuery.value}
+              placeholder="슬롯 이름 / source / gate 필터"
+              aria-label="훅 슬롯 필터"
+              onInput=${(e: Event) => { hookFilterQuery.value = (e.target as HTMLInputElement).value }}
+              class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            />
           </div>
-        `)}
-        <${ConfigRow} label="거부 목록 수" value=${String(c.hooks.deny_list_count)} />
-        <${ConfigRow} label="파괴 검사 도구" value=${formatHookDestructiveTools(c.hooks.destructive_check_tools)} />
-        <${ConfigRow} label="비용 예산" value=${c.hooks.cost_budget.active ? '$' + (c.hooks.cost_budget.max_cost_usd ?? 0).toFixed(2) : '비활성'} />
-      ` : null}
+          ${isFiltering && visibleEntries.length === 0 && allEntries.length > 0
+            ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${allEntries.length} slots)</div>`
+            : visibleEntries.map(([name, slot]) => html`
+                <div class="flex items-start gap-2 py-2 px-3 rounded-xl border border-card-border/50 bg-card/20 mb-1.5">
+                  <span class="mt-1 w-2 h-2 rounded-full shrink-0 ${slot.active ? 'bg-[var(--ok)] shadow-[0_0_6px_var(--ok-48)]' : 'bg-[var(--text-dim)]'}"></span>
+                  <div class="flex-1 min-w-0">
+                    <div class="flex justify-between">
+                      <span class="text-[12px] font-semibold text-text-strong">${name}</span>
+                      <span class="text-[10px] text-text-muted">${slot.source}</span>
+                    </div>
+                    ${(slot.gates ?? slot.effects ?? slot.features ?? []).length > 0 ? html`
+                      <div class="flex flex-wrap gap-1 mt-1">
+                        ${(slot.gates ?? slot.effects ?? slot.features ?? []).map((d: string) => html`
+                          <span class="text-[9px] px-1.5 py-0.5 rounded-md ${d.endsWith('_off') ? 'bg-[var(--white-10)] text-[var(--text-dim)]' : 'bg-[var(--accent-10)] text-[var(--accent)] opacity-80'}">${d}</span>
+                        `)}
+                      </div>
+                    ` : null}
+                  </div>
+                </div>
+              `)}
+          <${ConfigRow} label="거부 목록 수" value=${String(c.hooks.deny_list_count)} />
+          <${ConfigRow} label="파괴 검사 도구" value=${formatHookDestructiveTools(c.hooks.destructive_check_tools)} />
+          <${ConfigRow} label="비용 예산" value=${c.hooks.cost_budget.active ? '$' + (c.hooks.cost_budget.max_cost_usd ?? 0).toFixed(2) : '비활성'} />
+        `
+      })() : null}
 
       ${'' /* Metrics removed — duplicates KpiGrid, MetricsCharts, and header model badge */}
     </div>


### PR DESCRIPTION
## 요약

`KeeperConfigPanel`의 **훅 슬롯** 섹션(`c.hooks.slots`)에 name/source/gate 필터를 추가합니다. 필터가 없어 hook wiring이 풍부한 keeper에서 특정 슬롯, `source`, 또는 같은 gate/effect/feature 태그에 연결된 슬롯을 빠르게 추리기 어려웠습니다.

## 변경

- `filterHookSlots(entries, query)` 순수 함수를 `keeper-config-panel.ts`에서 export. case-insensitive substring, 슬롯 이름(map key) → `slot.source` → `slot.gates` / `slot.effects` / `slot.features` 중 하나라도 매치하면 포함.
- 빈/공백 query는 입력 참조를 그대로 반환 → non-filter path 추가 할당 없음.
- 입력 비변이 (`readonly HookSlotEntry[]` 가정).
- 필터가 모든 슬롯을 숨기면 별도 empty-state: `필터 결과 없음 (N slots)` — 데이터 자체가 없는 경우와 구분.
- 단위 테스트 11건: 빈/공백/trim, case, per-field 매칭(name/source/gates/effects/features), no-match, 입력 비변이, gates/effects/features 전부 누락된 sparse 슬롯.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/keeper-config-panel.test.ts`: 13/13 pass (기존 2 + 신규 11).
- `pnpm exec eslint .`: 에러 0.

## 범위

Dashboard만, 파일 2개(panel + test). 백엔드/타입/API 변경 없음. `useMemo` 대신 인라인 계산 사용 — 컴포넌트가 이미 loaded 이전에 early-return 경로가 있고 훅 슬롯은 보통 ≤20개라 O(n) filter cost가 무시 가능.

Follows the iter-7/8/12 seed-hint pattern.