### PR TITLE
docs(frontmatter): add YAML metadata to 48 A-category docs (batch 2)

### DIFF
--- a/docs/ADAPTIVE-HEARTBEAT-PRODUCTION-RUNBOOK.md
+++ b/docs/ADAPTIVE-HEARTBEAT-PRODUCTION-RUNBOOK.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_config.ml
+  - lib/keeper/heartbeat_smart.ml
+---
+
 # Adaptive Heartbeat Production Runbook
 
 이 runbook은 canonical HTTP/file keeper path에서 adaptive heartbeat를 production에 올릴 때 사용하는 절차다.

--- a/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
+++ b/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/
+  - bin/
+---
+
 # MASC-MCP Architecture Complexity Analysis
 
 Date: 2026-03-16

--- a/docs/COMMON-PITFALLS.md
+++ b/docs/COMMON-PITFALLS.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/
+  - test/
+---
+
 # Common Pitfalls
 
 Recurring mistakes from commit history analysis. Check this before submitting PRs.

--- a/docs/DASHBOARD-INTEGRATION.md
+++ b/docs/DASHBOARD-INTEGRATION.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - dashboard/src/
+  - lib/
+---
+
 # Dashboard Integration Spec (Operator Console)
 
 ## Goal

--- a/docs/IMMORTAL-SERVER-ROADMAP.md
+++ b/docs/IMMORTAL-SERVER-ROADMAP.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/supervisor.ml
+  - lib/keeper/keeper_keepalive.ml
+  - lib/keeper/keeper_supervisor.ml
+---
+
 # MASC 고가용성 서버 로드맵
 
 > 목표: 장애 복구와 운영 안정성을 강화하는 MCP 서버

--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/mcp_server.ml
+  - lib/mcp_server_eio.ml
+  - lib/mcp_prompt_surface.ml
+---
+
 # MCP Surface Audit
 
 Current-state audit of `masc-mcp` MCP exposure, public design, and documentation boundaries.

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -1,3 +1,12 @@
+---
+status: live
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - lib/mcp_server.ml
+  - lib/keeper/keeper_supervisor.ml
+---
+
 # Product Operating Plan
 
 > Current package version: v0.9.9

--- a/docs/PRODUCT-REVIEW.md
+++ b/docs/PRODUCT-REVIEW.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_keepalive.ml
+  - lib/keeper/keeper_supervisor.ml
+  - lib/mcp_server.ml
+---
+
 # MASC-MCP Product Review
 
 ## Summary

--- a/docs/RELEASE-EVIDENCE.md
+++ b/docs/RELEASE-EVIDENCE.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/mcp_server.ml
+  - lib/keeper/
+  - lib/keeper/keeper_runtime.ml
+---
+
 # Release Evidence
 
 > Current package version: v0.9.4

--- a/docs/SWARM-DELIVERY-RUNBOOK.md
+++ b/docs/SWARM-DELIVERY-RUNBOOK.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_supervisor.ml
+  - lib/keeper/keeper_unified_turn.ml
+  - lib/supervisor.ml
+---
+
 # Swarm Delivery Runbook
 
 이 문서는 `MASC` 자체를 구현 substrate로 써서 기능 슬라이스를 계획하고 구현할 때의 표준 순서를 정리한다.

--- a/docs/audits/compaction-fsm-tla-audit-2026-04-16.md
+++ b/docs/audits/compaction-fsm-tla-audit-2026-04-16.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_compact_policy.ml
+  - specs/keeper-state-machine/KeeperCompactionLifecycle.tla
+---
+
 # Compaction FSM ↔ TLA+ Spec Audit (2026-04-16)
 
 **Status**: v2 — TLA+ side enumerated end-to-end, OCaml FSM core verified with direct reads (phases, events, compaction handlers).

--- a/docs/audits/memory-bank-compaction-audit-2026-04-16.md
+++ b/docs/audits/memory-bank-compaction-audit-2026-04-16.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_memory_bank.ml
+  - lib/keeper/keeper_compact_policy.ml
+  - specs/bug-models/MemoryCompaction.tla
+---
+
 # Memory Bank Compaction FSM / TLA+ Audit (2026-04-16)
 
 **Status**: v1 — TLA+ spec enumerated end-to-end, OCaml implementation verified with direct reads (compaction algorithm, kind_caps, trigger, priorities). Buggy model re-verified with TLC; clean model deferred (state explosion, see §5).

--- a/docs/compaction/COMPACTION-LIFECYCLE.md
+++ b/docs/compaction/COMPACTION-LIFECYCLE.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_compact_policy.ml
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_context_core.ml
+---
+
 # Context Compaction Lifecycle
 
 > Developer reference for how context compaction works end-to-end in masc-mcp.

--- a/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
+++ b/docs/design/CDAL-PHASE1A-TEAM-START-HERE.md
@@ -1,3 +1,12 @@
+---
+status: live
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/
+  - lib/keeper/keeper_agent_run.ml
+---
+
 # CDAL Phase-1A Team Start Here
 
 **Audience**: An experienced implementation team joining with no prior CDAL context

--- a/docs/design/adaptive-heartbeat-grpc-and-phi-rollout-rfc.md
+++ b/docs/design/adaptive-heartbeat-grpc-and-phi-rollout-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/heartbeat_smart.ml
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_config.ml
+---
+
 # Adaptive Heartbeat gRPC and Phi Rollout RFC
 
 **Status**: Draft, follow-up production gate

--- a/docs/design/adaptive-heartbeat-observability-slo-spec.md
+++ b/docs/design/adaptive-heartbeat-observability-slo-spec.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_accountability.ml
+  - lib/keeper/keeper_alerting.ml
+  - lib/keeper/keeper_composite_observer.ml
+---
+
 # Adaptive Heartbeat Observability and SLO Spec
 
 **Status**: Draft, production prerequisite

--- a/docs/design/adaptive-heartbeat-phi-enforcement-rfc.md
+++ b/docs/design/adaptive-heartbeat-phi-enforcement-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_config.ml
+  - lib/keeper/heartbeat_smart.ml
+---
+
 # Adaptive Heartbeat Phi Enforcement RFC
 
 **Status**: Draft, follow-up enforcement gate

--- a/docs/design/adaptive-heartbeat-production-rollout-rfc.md
+++ b/docs/design/adaptive-heartbeat-production-rollout-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_config.ml
+  - lib/keeper/keeper_campaign_fsm.ml
+---
+
 # Adaptive Heartbeat Production Rollout RFC
 
 **Status**: Draft, production gate

--- a/docs/design/adaptive-heartbeat-safety-harness-spec.md
+++ b/docs/design/adaptive-heartbeat-safety-harness-spec.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - scripts/harness/
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_composite_observer.ml
+---
+
 # Adaptive Heartbeat Safety Harness Spec
 
 **Status**: Draft, implementation spec

--- a/docs/design/adaptive-heartbeat-scheduling-rfc.md
+++ b/docs/design/adaptive-heartbeat-scheduling-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_config.ml
+  - lib/keeper/keeper_cascade_routing.ml
+---
+
 # Adaptive Heartbeat and Cascade Scheduling RFC
 
 **Status**: Draft

--- a/docs/design/adaptive-heartbeat-validation-and-alert-wiring-spec.md
+++ b/docs/design/adaptive-heartbeat-validation-and-alert-wiring-spec.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_alerting.ml
+  - lib/keeper/keeper_composite_observer.ml
+  - lib/keeper/keeper_accountability.ml
+---
+
 # Adaptive Heartbeat Validation and Alert Wiring Spec
 
 **Status**: Draft, production prerequisite

--- a/docs/design/api-versioning-design.md
+++ b/docs/design/api-versioning-design.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/
+  - bin/main_eio.ml
+---
+
 # H3: API Versioning Design
 
 > Status: Draft

--- a/docs/design/canonical-architecture-cleanup-rfc.md
+++ b/docs/design/canonical-architecture-cleanup-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - lib/a2a_tools.ml
+  - bin/
+---
+
 # Canonical Architecture Cleanup RFC
 
 **Status**: Draft

--- a/docs/design/cdal-contract-kernel-and-advisory-split.md
+++ b/docs/design/cdal-contract-kernel-and-advisory-split.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/keeper_cdal_contract.ml
+  - lib/keeper/keeper_accountability.ml
+---
+
 # CDAL Contract Kernel and Advisory Split
 
 **Status**: Draft, design-ready

--- a/docs/design/check-evaluation-spec.md
+++ b/docs/design/check-evaluation-spec.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/keeper_accountability.ml
+  - lib/eval_gate.ml
+---
+
 # CDAL Check Evaluation Spec
 
 **Status**: Draft, pre-production scope

--- a/docs/design/checkpoint-truth-and-replay-rfc.md
+++ b/docs/design/checkpoint-truth-and-replay-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_agent_run.ml
+  - lib/keeper/keeper_post_turn.ml
+  - lib/keeper/keeper_checkpoint_store.ml
+---
+
 # Checkpoint Truth and Replay RFC
 
 **Status**: Draft

--- a/docs/design/checkpoint-truth-replay-implementation-checklist.md
+++ b/docs/design/checkpoint-truth-replay-implementation-checklist.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_checkpoint_store.ml
+  - lib/keeper/keeper_agent_run.ml
+  - lib/keeper/keeper_post_turn.ml
+---
+
 # Checkpoint Truth and Replay Implementation Checklist
 
 **Status**: Draft  

--- a/docs/design/contract-driven-agent-loop-implementation-checklist.md
+++ b/docs/design/contract-driven-agent-loop-implementation-checklist.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/
+  - lib/server/
+---
+
 # Contract-Driven Agent Loop Implementation Checklist
 
 **Status**: Pre-implementation gate

--- a/docs/design/contract-driven-agent-loop-labeling-protocol.md
+++ b/docs/design/contract-driven-agent-loop-labeling-protocol.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/keeper_accountability.ml
+  - lib/eval_gate.ml
+---
+
 # Contract-Driven Agent Loop Labeling Protocol
 
 **Version**: v0

--- a/docs/design/contract-driven-agent-loop-rfc-review.md
+++ b/docs/design/contract-driven-agent-loop-rfc-review.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/
+  - lib/keeper/keeper_context_core.ml
+---
+
 # Contract-Driven Agent Loop RFC Review
 
 **Date**: 2026-03-27

--- a/docs/design/contract-driven-agent-loop-rfc.md
+++ b/docs/design/contract-driven-agent-loop-rfc.md
@@ -1,3 +1,12 @@
+---
+status: live
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/
+  - lib/server/
+---
+
 # Contract-Driven Agent Loop RFC
 
 **Status**: Design-complete for pre-production single-run scope; production-incomplete

--- a/docs/design/cross-run-loader-and-window-spec.md
+++ b/docs/design/cross-run-loader-and-window-spec.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/proof_artifact_reader.ml
+  - lib/keeper/keeper_agent_run.ml
+---
+
 # Cross-Run Loader and Window Spec
 
 **Status**: Draft (v2 — late-arrival, schema compat, API signatures added)

--- a/docs/design/dashboard-fsm-redesign.md
+++ b/docs/design/dashboard-fsm-redesign.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_decision_audit.ml
+  - lib/server/
+  - dashboard/src/
+---
+
 # Dashboard FSM Visibility Redesign
 
 **Status**: Design (기획 단계)

--- a/docs/design/delta-checkpoint-read-path.md
+++ b/docs/design/delta-checkpoint-read-path.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_checkpoint_store.ml
+  - lib/keeper/keeper_fs.ml
+  - lib/keeper/
+---
+
 # Delta Checkpoint Read Path (Stage 3)
 
 Design decisions for the delta checkpoint restore path.

--- a/docs/design/error-handling-and-operations-spec.md
+++ b/docs/design/error-handling-and-operations-spec.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cdal/
+  - lib/keeper/
+  - lib/eval_gate.ml
+---
+
 # Error Handling and Operations Spec
 
 **Status**: Draft, production prerequisite

--- a/docs/design/external-agent-framework-patterns-rfc.md
+++ b/docs/design/external-agent-framework-patterns-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - lib/keeper/keeper_agent_run.ml
+  - lib/proof_artifact_reader.ml
+---
+
 # External Agent Framework Patterns RFC
 
 Status: draft

--- a/docs/design/handoff-ssot-adr.md
+++ b/docs/design/handoff-ssot-adr.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_memory_policy.ml
+  - lib/keeper/keeper_agent_run.ml
+  - lib/drift_guard.ml
+---
+
 # ADR: Handoff SSOT (D-0)
 
 **Status**: Proposed

--- a/docs/design/inventory-gap-analysis-rfc.md
+++ b/docs/design/inventory-gap-analysis-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - lib/tool_dispatch.ml
+  - lib/server/
+---
+
 # Inventory Gap Analysis RFC
 
 **Status**: Draft

--- a/docs/design/keeper-social-model-inventory.md
+++ b/docs/design/keeper-social-model-inventory.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_social_model.ml
+  - lib/keeper/keeper_registry.ml
+  - lib/keeper/keeper_exec_status.ml
+---
+
 # Keeper Social Model Inventory
 
 Status: active implementations + research inventory

--- a/docs/design/masc-capsule-execution-plan.md
+++ b/docs/design/masc-capsule-execution-plan.md
@@ -1,3 +1,12 @@
+---
+status: live
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/
+  - lib/keeper/keeper_turn_lifecycle.ml
+  - lib/mcp_server.ml
+---
+
 # MASC Capsule Execution Plan
 
 Updated: 2026-04-02

--- a/docs/design/tool-calling-quality-and-self-healing-rfc.md
+++ b/docs/design/tool-calling-quality-and-self-healing-rfc.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_decision_pipeline_contract.ml
+  - lib/keeper/keeper_composite_observer.ml
+  - lib/keeper/keeper_measurement.ml
+---
+
 # Tool Calling Quality and Self-Healing RFC
 
 **Status**: Internal-runtime scope implemented in local worktrees; benchmark/program work remains partially unimplemented

--- a/docs/observability/cascade-metrics.md
+++ b/docs/observability/cascade-metrics.md
@@ -1,3 +1,11 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/cascade/
+  - lib/cascade_inference.ml
+---
+
 # Cascade Observability Metrics
 
 How to read the cascade counters exposed by `/metrics` and the alerting rules that turn them into pages.

--- a/docs/observability/composite-fsm-matrix-design.md
+++ b/docs/observability/composite-fsm-matrix-design.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_composite_observer.ml
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_registry.ml
+---
+
 # Composite FSM Matrix — Design
 
 **Status**: Draft, iteration 1 (cron `cbf0ca92`, 20 min loop).

--- a/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
+++ b/docs/qa/OAS-BOUNDARY-HEALTHCHECK-2026-03-31.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_exec_masc.ml
+  - lib/cascade/
+  - lib/mcp_server.ml
+---
+
 # OAS Boundary Health Check - 2026-03-31
 
 Scope: `masc-mcp` to OAS boundary health snapshot on commit `aade21ba7402baede95e565c503d3e38a923558b`

--- a/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
+++ b/docs/qa/OAS-OBSERVABILITY-TRUTH-AUDIT-2026-04-15.md
@@ -1,3 +1,12 @@
+---
+status: runbook
+last_verified: 2026-04-17
+code_refs:
+  - lib/oas_events.ml
+  - lib/oas_sse_bridge.ml
+  - lib/telemetry_unified.ml
+---
+
 # OAS Observability Truth Audit (2026-04-15)
 
 ## Scope

--- a/docs/rfc/RFC-0002-keeper-state-machine.md
+++ b/docs/rfc/RFC-0002-keeper-state-machine.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_state_machine.ml
+  - lib/keeper/keeper_registry.ml
+  - lib/keeper/keeper_supervisor.ml
+---
+
 # RFC-0002: Keeper 11-State Machine + Det/NonDet Boundary Formalization
 
 **Status**: Draft

--- a/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
+++ b/docs/rfc/RFC-0003-keeper-composite-lifecycle.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_composite_observer.ml
+  - lib/keeper/keeper_registry.ml
+  - lib/keeper/keeper_turn_lifecycle.ml
+---
+
 # RFC-0003: Keeper Composite Lifecycle Observer
 
 **Status**: Draft

--- a/docs/rfc/RFC-0003-phase-2-turn-observation-lifecycle.md
+++ b/docs/rfc/RFC-0003-phase-2-turn-observation-lifecycle.md
@@ -1,3 +1,12 @@
+---
+status: reference
+last_verified: 2026-04-17
+code_refs:
+  - lib/keeper/keeper_composite_observer.ml
+  - lib/keeper/keeper_unified_turn.ml
+  - lib/keeper/keeper_registry.ml
+---
+
 # RFC-0003 Phase 2: Turn-Scoped Observation Lifecycle
 
 **Status**: Draft


### PR DESCRIPTION
Adds YAML frontmatter (`status` / `last_verified` / `code_refs`) to the remaining 48 A-category markdowns per `docs/_audit/2026-04-17-doc-classification.md`.

**Batch 2 scope (48 files)**
- `design/` RFCs and specs (26 files)
- `rfc/` numbered RFCs (3 files)
- `audits/` FSM + memory bank audits (2 files)
- `observability/` metrics + FSM matrix (2 files)
- `qa/` boundary/observability audits (2 files)
- `compaction/`, top-level runbooks, arch analyses (rest)

**Frontmatter template**
```yaml
---
status: live | reference | runbook
last_verified: 2026-04-17
code_refs:
  - lib/<module>.ml
  - lib/<dir>/
---
```

**Status classification**
- `runbook` — operational runbooks (PRODUCTION-RUNBOOK, *-checklist, SWARM-DELIVERY-RUNBOOK, etc.)
- `live` — docs actively consumed / authoritative (PRODUCT-OPERATING-PLAN, CDAL Phase1A, CDAL RFC, masc-capsule plan)
- `reference` — design docs, RFCs, audit snapshots

**Verification**
- All code_refs paths exist in current tree (verified via `[ -e ]` check in apply script)
- `bash scripts/check-doc-truth.sh` — pass
- `bash scripts/sync-oas-pin-docs.sh --check` — pass (exit 0)

**Batch 1 (already merged): PRs #7784, #7791, #7792, #7796** — 33 files  
**Batch 2 (this PR): 48 files** — total A-frontmatter coverage: 81/81 ✅

No content changes beyond frontmatter prepend.
