### PR TITLE
feat(dashboard): add label filter to goal-tree

### DIFF
--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type { GoalTreeNode, GoalTreeTask } from '../../types'
+import { filterGoalTree } from './goal-tree'
+
+function makeTask(overrides: Partial<GoalTreeTask> = {}): GoalTreeTask {
+  return {
+    id: 'task-x',
+    title: 'task title',
+    status: 'todo',
+    status_color: '#fff',
+    priority: 0,
+    assignee: null,
+    is_terminal: false,
+    created_at: '2026-04-17T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeNode(overrides: Partial<GoalTreeNode> = {}): GoalTreeNode {
+  return {
+    id: 'node-x',
+    title: 'goal title',
+    horizon: 'quarterly',
+    status: 'active',
+    status_color: '#fff',
+    priority: 0,
+    metric: null,
+    target_value: null,
+    due_date: null,
+    parent_goal_id: null,
+    convergence: 0,
+    convergence_pct: 0,
+    tasks: [],
+    task_count: 0,
+    task_done_count: 0,
+    children: [],
+    child_count: 0,
+    created_at: '2026-04-17T00:00:00Z',
+    updated_at: '2026-04-17T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('filterGoalTree', () => {
+  it('returns the input reference when query is empty', () => {
+    const nodes: readonly GoalTreeNode[] = [makeNode({ id: 'a', title: 'Alpha' })]
+    expect(filterGoalTree(nodes, '')).toBe(nodes)
+  })
+
+  it('returns the input reference when query is whitespace only', () => {
+    const nodes: readonly GoalTreeNode[] = [makeNode({ id: 'a', title: 'Alpha' })]
+    expect(filterGoalTree(nodes, '   ')).toBe(nodes)
+  })
+
+  it('matches by node title (case-insensitive)', () => {
+    const nodes: readonly GoalTreeNode[] = [
+      makeNode({ id: 'a', title: 'Alpha Goal' }),
+      makeNode({ id: 'b', title: 'Beta Goal' }),
+    ]
+    const result = filterGoalTree(nodes, 'ALPHA')
+    expect(result.map(n => n.id)).toEqual(['a'])
+  })
+
+  it('trims the query before matching', () => {
+    const nodes: readonly GoalTreeNode[] = [makeNode({ id: 'a', title: 'Alpha' })]
+    expect(filterGoalTree(nodes, '  alp  ').map(n => n.id)).toEqual(['a'])
+  })
+
+  it('returns empty when nothing in the forest matches', () => {
+    const nodes: readonly GoalTreeNode[] = [
+      makeNode({ id: 'a', title: 'Alpha' }),
+      makeNode({ id: 'b', title: 'Beta' }),
+    ]
+    expect(filterGoalTree(nodes, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('preserves ancestors when a descendant matches', () => {
+    const leaf = makeNode({ id: 'leaf', title: 'Payment Flow Fix' })
+    const mid = makeNode({ id: 'mid', title: 'Checkout Refactor', children: [leaf] })
+    const root = makeNode({ id: 'root', title: 'Q2 Platform Goals', children: [mid] })
+
+    const result = filterGoalTree([root], 'payment')
+    expect(result).toHaveLength(1)
+    const rootOut = result[0]!
+    expect(rootOut.id).toBe('root')
+    expect(rootOut.children).toHaveLength(1)
+    const midOut = rootOut.children[0]!
+    expect(midOut.id).toBe('mid')
+    expect(midOut.children).toHaveLength(1)
+    expect(midOut.children[0]!.id).toBe('leaf')
+  })
+
+  it('keeps the entire subtree when an ancestor itself matches', () => {
+    const leafA = makeNode({ id: 'la', title: 'Leaf A' })
+    const leafB = makeNode({ id: 'lb', title: 'Leaf B' })
+    const root = makeNode({ id: 'root', title: 'Platform Migration', children: [leafA, leafB] })
+
+    const result = filterGoalTree([root], 'migration')
+    expect(result).toHaveLength(1)
+    // Self-match short-circuits — returns node as-is, children untouched.
+    expect(result[0]).toBe(root)
+    expect(result[0]!.children.map(c => c.id)).toEqual(['la', 'lb'])
+  })
+
+  it('matches by attached task title and prunes non-matching tasks', () => {
+    const root = makeNode({
+      id: 'root',
+      title: 'Unrelated Goal',
+      tasks: [
+        makeTask({ id: 't1', title: 'investigate FD leak' }),
+        makeTask({ id: 't2', title: 'refresh dashboard copy' }),
+      ],
+    })
+
+    const result = filterGoalTree([root], 'fd leak')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.tasks.map(t => t.id)).toEqual(['t1'])
+    // Should NOT mutate input.
+    expect(root.tasks).toHaveLength(2)
+  })
+
+  it('drops a node that has no match in title, tasks, or descendants', () => {
+    const sibling = makeNode({ id: 'keep', title: 'Alpha Goal' })
+    const dropped = makeNode({
+      id: 'drop',
+      title: 'Unrelated',
+      tasks: [makeTask({ id: 't1', title: 'also unrelated' })],
+      children: [makeNode({ id: 'drop-child', title: 'nothing here' })],
+    })
+    const result = filterGoalTree([sibling, dropped], 'alpha')
+    expect(result.map(n => n.id)).toEqual(['keep'])
+  })
+
+  it('does not mutate the input nodes or their children / tasks arrays', () => {
+    const leaf = makeNode({ id: 'leaf', title: 'Payment Work' })
+    const other = makeNode({ id: 'other', title: 'Unrelated' })
+    const root = makeNode({
+      id: 'root',
+      title: 'Root',
+      children: [leaf, other],
+      tasks: [makeTask({ id: 't1', title: 'payment followup' }), makeTask({ id: 't2', title: 'skip me' })],
+    })
+
+    const snapshotChildren = root.children.slice()
+    const snapshotTasks = root.tasks.slice()
+
+    filterGoalTree([root], 'payment')
+
+    expect(root.children).toEqual(snapshotChildren)
+    expect(root.tasks).toEqual(snapshotTasks)
+  })
+
+  it('treats empty or missing task titles as non-matches without crashing', () => {
+    const root = makeNode({
+      id: 'root',
+      title: 'Unrelated',
+      tasks: [
+        makeTask({ id: 't1', title: '' }),
+        // Simulate a backend-produced node whose title field is missing; the
+        // filter must fall through to children / tasks rather than throw.
+        makeTask({ id: 't2', title: undefined as unknown as string }),
+      ],
+    })
+    const result = filterGoalTree([root], 'anything')
+    expect(result).toHaveLength(0)
+  })
+})

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -2,7 +2,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import { fetchDashboardGoalsTree } from '../../api/dashboard'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
@@ -16,12 +16,77 @@ import type {
 } from '../../types'
 import { horizonLabel, horizonColor, priorityStars } from './goal-helpers'
 
+/**
+ * Pure hierarchy filter for goal tree nodes.
+ *
+ * Case-insensitive substring match on `node.title` and on `task.title` for
+ * any task attached to the node. Ancestors of matching nodes are preserved
+ * so the operator retains context (parent goal, horizon) — the tree shape
+ * is never broken by the filter.
+ *
+ * Pruning rules:
+ * - If a node's own title matches, the node and ALL its descendants / tasks
+ *   are kept verbatim (treat the match as "show me this subtree").
+ * - Otherwise, the node is kept only if any descendant matches, and only
+ *   those matching descendants (recursively pruned) are retained. Tasks
+ *   attached directly to this node are filtered down to matching tasks.
+ *
+ * Empty / whitespace query returns the input reference unchanged so
+ * memoisation preserves referential equality for the non-filtering path.
+ * Input is never mutated.
+ */
+export function filterGoalTree(
+  nodes: readonly GoalTreeNode[],
+  query: string,
+): readonly GoalTreeNode[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return nodes
+
+  const result: GoalTreeNode[] = []
+  for (const node of nodes) {
+    const pruned = pruneNode(node, needle)
+    if (pruned !== null) result.push(pruned)
+  }
+  return result
+}
+
+function pruneNode(node: GoalTreeNode, needle: string): GoalTreeNode | null {
+  const title = node.title ?? ''
+  const nodeMatches = title.toLowerCase().includes(needle)
+  if (nodeMatches) {
+    // Self match: keep the whole subtree as-is.
+    return node
+  }
+
+  const matchingTasks = node.tasks.filter(t =>
+    (t.title ?? '').toLowerCase().includes(needle),
+  )
+  const prunedChildren: GoalTreeNode[] = []
+  for (const child of node.children) {
+    const prunedChild = pruneNode(child, needle)
+    if (prunedChild !== null) prunedChildren.push(prunedChild)
+  }
+
+  if (matchingTasks.length === 0 && prunedChildren.length === 0) {
+    return null
+  }
+
+  // Ancestor retained for context: return a shallow copy with the pruned
+  // children / tasks so we never mutate the input node.
+  return {
+    ...node,
+    tasks: matchingTasks,
+    children: prunedChildren,
+  }
+}
+
 // --- State ---
 
 const treeData = signal<DashboardGoalsTreeResponse | null>(null)
 const treeLoading = signal(false)
 const treeError = signal<string | null>(null)
 const expandedNodes = signal<Set<string>>(new Set())
+const filterQuery = signal('')
 
 function toggleNode(id: string) {
   const next = new Set(expandedNodes.value)
@@ -210,6 +275,13 @@ export function GoalTree() {
   const data = treeData.value
   const loading = treeLoading.value
   const error = treeError.value
+  const query = filterQuery.value
+
+  const visibleTree = useMemo(
+    () => (data ? filterGoalTree(data.tree, query) : []),
+    [data, query],
+  )
+  const isFiltering = query.trim() !== ''
 
   return html`
     <div class="flex flex-col gap-5">
@@ -224,6 +296,14 @@ export function GoalTree() {
           </div>
           <div class="flex items-center gap-2">
             ${data && data.tree.length > 0 ? html`
+              <input
+                type="search"
+                value=${query}
+                placeholder="목표 / 태스크 제목 필터"
+                aria-label="목표 트리 필터"
+                onInput=${(e: Event) => { filterQuery.value = (e.target as HTMLInputElement).value }}
+                class="min-w-[180px] max-w-[260px] rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[12px] text-text-body placeholder:text-text-dim focus:outline-none focus:border-accent"
+              />
               <${ActionButton} variant="ghost" size="sm" onClick=${() => expandAll(data.tree)}>
                 모두 펼치기
               <//>
@@ -251,9 +331,13 @@ export function GoalTree() {
         <${LoadingState}>목표 트리 불러오는 중...<//>
       ` : data && data.tree.length === 0 ? html`
         <${EmptyState} message="등록된 목표가 없습니다. masc_goal_upsert 도구로 목표를 등록하세요." />
+      ` : data && isFiltering && visibleTree.length === 0 ? html`
+        <section class="py-4 text-center text-[12px] text-text-dim">
+          필터 결과 없음 (${data.tree.length} 목표)
+        </section>
       ` : data ? html`
         <section class="flex flex-col gap-2">
-          ${data.tree.map(node => html`<${TreeNode} key=${node.id} node=${node} depth=${0} />`)}
+          ${visibleTree.map(node => html`<${TreeNode} key=${node.id} node=${node} depth=${0} />`)}
         </section>
       ` : null}
     </div>


### PR DESCRIPTION
## 요약

`GoalTree` 컴포넌트(`dashboard/src/components/goals/goal-tree.ts`)에 목표/태스크 제목 기반 **계층 보존(hierarchy-preserving)** 필터를 추가합니다. 중첩 목표가 많은 프로젝트에서는 특정 goal branch 혹은 특정 task 제목을 빠르게 추릴 수 없어 스크롤이 길어지던 문제가 있습니다.

## 필터 종류: hierarchy (not flat)

평면 필터 대신 **조상 보존 필터**를 선택했습니다. 이유:
- goal tree는 depth 자체가 의미(horizon → sub-goal → leaf)를 담고 있어, 매칭 노드만 펼치면 맥락(상위 목표, horizon)이 끊깁니다.
- trees are small (보통 <수십 노드), O(n) 재귀 비용 무시 가능.

알고리즘 (순수 함수, `filterGoalTree(nodes, query)`):
- `node.title`이 매치하면 해당 노드와 **전체 subtree를 그대로** 반환 (input reference 유지 — "show me this subtree" 의도).
- 자기 자신은 안 맞지만 자식/태스크 중 하나라도 매치 → 현재 노드는 shallow copy로 유지하고, `tasks`는 매치 태스크만, `children`은 재귀 prune한 결과만 유지.
- 둘 다 없으면 `null` 반환 → 상위에서 drop.

## 변경

- `filterGoalTree(nodes, query)` 순수 함수를 `goal-tree.ts`에서 export.
  - Case-insensitive substring match on `node.title` 및 `task.title`.
  - 빈/공백 query → 입력 참조 그대로 반환 (`useMemo` 식별성 보존).
  - 입력 비변이. self-match 노드는 as-is 반환, ancestor-retained 노드만 shallow copy.
- 검색 input (`<input type="search">`, Korean placeholder `목표 / 태스크 제목 필터`)을 expand/collapse 버튼 옆에 배치.
- 필터가 모든 목표를 숨기면 별도 empty state: `필터 결과 없음 (N 목표)` — 등록된 목표가 0개인 기존 empty state와 구분.
- 단위 테스트 11건: 빈/공백/trim, case, node-title match, task-title match + task pruning, no-match, ancestor 보존, self-match subtree 보존, 형제 drop, 입력 비변이, task title 누락 내성.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/goals/goal-tree.test.ts`: 11/11 pass.
- `pnpm exec eslint .`: exit 0.

## 범위

Dashboard only, 파일 2개 (`goal-tree.ts` + 신규 `goal-tree.test.ts`). 백엔드/타입/API 변경 없음.

Follows the iter-7/8/12/13 seed-hint pattern. Dashboard-only, 2 files.