### PR TITLE
feat(dashboard): add channel/keeper/room filter to connector-status gate channels

### DIFF
--- a/dashboard/src/components/connector-status.test.ts
+++ b/dashboard/src/components/connector-status.test.ts
@@ -3,6 +3,9 @@ import { render } from 'preact'
 import { signal } from '@preact/signals'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ChannelInfo } from '../api/gate'
+import { filterGateChannels } from './connector-status'
+
 vi.setConfig({
   testTimeout: 40000,
   hookTimeout: 40000,
@@ -567,5 +570,100 @@ describe('ConnectorStatusPanel', () => {
     expect(novaText).toContain('status busy')
     expect(novaText).toContain('model gemini-2.5-flash')
     expect(novaText).toContain('runtime keeper-nova-agent')
+  })
+})
+
+function makeChannel(overrides: Partial<ChannelInfo> = {}): ChannelInfo {
+  return {
+    channel: 'discord',
+    message_count: 0,
+    success_count: 0,
+    error_count: 0,
+    duplicate_count: 0,
+    validation_error_count: 0,
+    keeper_error_count: 0,
+    dispatch_unavailable_count: 0,
+    internal_error_count: 0,
+    last_activity: '',
+    last_success: '',
+    last_error_at: '',
+    last_keeper: '',
+    last_room_id: '',
+    last_error: '',
+    last_error_kind: '',
+    last_outcome: '',
+    avg_duration_ms: 0,
+    max_duration_ms: 0,
+    slow_count: 0,
+    slow_rate_pct: 0,
+    success_rate_pct: 0,
+    room_count: 0,
+    health: 'idle',
+    ...overrides,
+  }
+}
+
+describe('filterGateChannels', () => {
+  const rows: ChannelInfo[] = [
+    makeChannel({ channel: 'discord', last_keeper: 'luna', last_room_id: '111111' }),
+    makeChannel({ channel: 'slack', last_keeper: 'nova', last_room_id: '222222' }),
+    makeChannel({ channel: 'telegram', last_keeper: 'orion', last_room_id: '333333' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterGateChannels(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterGateChannels(rows, '   ')).toBe(rows)
+  })
+
+  it('matches by channel substring (case-insensitive)', () => {
+    const result = filterGateChannels(rows, 'DISC')
+    expect(result.map(r => r.channel)).toEqual(['discord'])
+  })
+
+  it('matches by last_keeper substring', () => {
+    const result = filterGateChannels(rows, 'nova')
+    expect(result.map(r => r.channel)).toEqual(['slack'])
+  })
+
+  it('matches by last_room_id substring', () => {
+    const result = filterGateChannels(rows, '33333')
+    expect(result.map(r => r.channel)).toEqual(['telegram'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterGateChannels(rows, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterGateChannels(rows, '  luna  ').map(r => r.channel)).toEqual(['discord'])
+  })
+
+  it('safely handles rows with empty last_keeper / last_room_id fields', () => {
+    const sparse: ChannelInfo[] = [
+      makeChannel({ channel: 'imessage', last_keeper: '', last_room_id: '' }),
+      makeChannel({ channel: 'signal', last_keeper: '', last_room_id: '' }),
+    ]
+    expect(filterGateChannels(sparse, 'luna')).toHaveLength(0)
+    expect(filterGateChannels(sparse, 'signal').map(r => r.channel)).toEqual(['signal'])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = rows.slice()
+    filterGateChannels(rows, 'luna')
+    expect(rows).toEqual(copy)
+    expect(rows).toHaveLength(3)
+  })
+
+  it('preserves source order when multiple rows match', () => {
+    const multi: ChannelInfo[] = [
+      makeChannel({ channel: 'discord', last_keeper: 'shared-keeper' }),
+      makeChannel({ channel: 'slack', last_keeper: 'other' }),
+      makeChannel({ channel: 'telegram', last_keeper: 'shared-keeper' }),
+    ]
+    const result = filterGateChannels(multi, 'shared')
+    expect(result.map(r => r.channel)).toEqual(['discord', 'telegram'])
   })
 })

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -2,8 +2,8 @@
 // Keeper-first layout: each directory keeper is a primary section; bindings nest under.
 
 import { html } from 'htm/preact'
-import { signal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { signal, useSignal } from '@preact/signals'
+import { useEffect, useMemo } from 'preact/hooks'
 import { post } from '../api/core'
 import {
   fetchGateConnectors,
@@ -51,6 +51,34 @@ const EMPTY_SNAPSHOT: ConnectorStatusSnapshot = {
 }
 
 const connectorStatusResource = createManagedAsyncResource<ConnectorStatusSnapshot>(EMPTY_SNAPSHOT)
+
+/**
+ * Pure filter for the gate-observed channel list.
+ *
+ * The `d.channels` list on a busy gate may hold one entry per active
+ * connector/channel tuple (discord, slack, imessage, telegram, ...).
+ * Operators scan this list to find the one throwing errors. Filter by
+ * the three human-readable fields an operator actually remembers:
+ * `channel`, `last_keeper`, `last_room_id`. First match wins.
+ *
+ * - Case-insensitive substring match on `query` (trimmed).
+ * - Empty/whitespace query returns the input reference unchanged so
+ *   `useMemo` keeps identity for the non-filtering path.
+ * - Input is never mutated; empty/missing fields are skipped safely.
+ */
+export function filterGateChannels(
+  rows: readonly ChannelInfo[],
+  query: string,
+): readonly ChannelInfo[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(row => {
+    if (row.channel && row.channel.toLowerCase().includes(needle)) return true
+    if (row.last_keeper && row.last_keeper.toLowerCase().includes(needle)) return true
+    if (row.last_room_id && row.last_room_id.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 async function refresh() {
   await connectorStatusResource.load(async (signal, previous) => {
@@ -872,7 +900,27 @@ function EventRow({ event }: { event: GateEventInfo }) {
   `
 }
 
+function renderGateChannelList(
+  gateChannels: readonly ChannelInfo[],
+  visibleChannels: readonly ChannelInfo[],
+  isFilteringChannels: boolean,
+) {
+  if (gateChannels.length === 0) {
+    return html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">활성 커넥터 없음</div>`
+  }
+  if (isFilteringChannels && visibleChannels.length === 0) {
+    return html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${gateChannels.length} channels)</div>`
+  }
+  return html`
+    <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
+      ${visibleChannels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
+    </div>
+  `
+}
+
 export function ConnectorStatusPanel() {
+  const channelQuery = useSignal('')
+
   useEffect(() => {
     void refresh()
     return () => { connectorStatusResource.cancel() }
@@ -897,6 +945,12 @@ export function ConnectorStatusPanel() {
   const loading = connectorStatusResource.state.value.loading
   const d = snapshot.gate
   const allConnectors = snapshot.connectors?.connectors ?? []
+  const gateChannels = useMemo(() => d?.channels ?? [], [d])
+  const visibleChannels = useMemo(
+    () => filterGateChannels(gateChannels, channelQuery.value),
+    [gateChannels, channelQuery.value],
+  )
+  const isFilteringChannels = channelQuery.value.trim() !== ''
 
   if (loading && !d && allConnectors.length === 0) {
     return html`<${LoadingState}>커넥터 상태 불러오는 중...<//>`
@@ -996,13 +1050,19 @@ export function ConnectorStatusPanel() {
                 </div>
               </div>
 
-              ${d.channels.length === 0
-                ? html`<div class="py-4 text-center text-xs text-[var(--text-dim)]">활성 커넥터 없음</div>`
-                : html`
-                    <div class="grid grid-cols-2 gap-2 max-[900px]:grid-cols-1">
-                      ${d.channels.map(ch => html`<${ChannelCard} ch=${ch} />`)}
-                    </div>
-                  `}
+              <div class="mb-2 flex items-center justify-between gap-2">
+                <div class="text-[10px] uppercase tracking-[0.16em] text-[var(--text-dim)]">채널 헬스</div>
+                <input
+                  type="search"
+                  value=${channelQuery.value}
+                  placeholder="channel / keeper / room 필터"
+                  aria-label="채널 필터"
+                  onInput=${(e: Event) => { channelQuery.value = (e.target as HTMLInputElement).value }}
+                  class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                />
+              </div>
+
+              ${renderGateChannelList(gateChannels, visibleChannels, isFilteringChannels)}
             </div>
           `}
     </div>


### PR DESCRIPTION
## 요약

`ConnectorStatusPanel`의 하단 **Gate-observed 채널 그리드**(`d.channels`)에 channel/keeper/room 필터를 추가합니다. 이 리스트는 `discord`, `slack`, `imessage`, `telegram`, `signal` 등 활성 커넥터 채널마다 한 장의 `ChannelCard`를 렌더링하고, 에러 상태(`degraded`/`idle`/`healthy`)와 라스트 keeper/room 를 한눈에 보는 패널이라 operator가 가장 자주 스크롤하는 곳입니다.

## 어느 리스트를 골랐는지

`connector-status.ts`는 15개의 `.map` 호출이 있고 여러 리스트를 렌더링합니다:

| 리스트 | 위치 | 카디널리티 | 필터 후보성 |
|--------|------|-----------|----------|
| `livenessDots.map` | 헤더 | 고정 3 | ❌ |
| `knownGroups.map` | 커넥터당 keeper 그룹 | 보통 2-6 | △ |
| `group.bindings.map` | keeper 내부 | 중첩 | △ |
| `unknownGroups.map` | 경고 | 희소 | ❌ |
| `observedRooms.slice(0,8).map` | suggestion chips | 상한 8 | ❌ |
| `allConnectors.map` | 커넥터 상위 | 1-3 | ❌ |
| `d.bindings.slice(0,6).map` | gate bindings | 상한 6 | ❌ |
| `d.recent_events.slice(0,8).map` | 이벤트 로그 | 상한 8 | ❌ |
| **`d.channels.map`** | **채널 헬스 그리드** | **busy gate에서 가장 큼** | **✅** |

`ChannelInfo` 스키마가 가장 많은 검색 가능 필드를 갖고 있고 (`channel`, `last_keeper`, `last_room_id`, `last_error_kind`, `last_outcome` …), `slice()` 가드가 없는 유일한 큰 리스트라 가장 가치가 큽니다.

## 변경

- `filterGateChannels(rows, query)` 순수 함수를 `connector-status.ts`에서 export. case-insensitive substring, `row.channel` → `row.last_keeper` → `row.last_room_id` 순서로 첫 매치 승리.
- 빈/공백 query는 입력 참조를 그대로 반환 → `useMemo` identity 유지, non-filter path 추가 할당 없음.
- 입력 비변이 (`readonly ChannelInfo[]` 가정).
- `useSignal('')`로 query 상태 관리 (이미 `signal`을 import하는 파일 스타일에 맞춤).
- `<input type="search">` + placeholder `channel / keeper / room 필터`를 "채널 헬스" 헤더 옆에 배치. Tailwind 클래스는 iter12 fleet-telemetry-panel과 동일.
- 필터가 모든 채널을 숨기면 별도 empty-state: `필터 결과 없음 (N channels)` — 기존 "활성 커넥터 없음" (데이터 자체가 없는 경우)과 구분.
- 렌더 분기를 `renderGateChannelList()` 헬퍼로 분리 (3-way: empty source / filter-no-match / grid) — no-nested-ternary 린트 준수.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/connector-status.test.ts`: **21/21 pass** (기존 11 + 신규 10).
- `pnpm exec eslint .`: 에러 0.

신규 단위 테스트 10건:
1. 빈 query → 입력 참조 반환
2. 공백만 query → 입력 참조 반환 (trim)
3. `channel` 대소문자 무시 매칭
4. `last_keeper` substring 매칭
5. `last_room_id` substring 매칭
6. no-match 시 빈 배열
7. query trim 후 매칭
8. 빈 필드 안전성 (`last_keeper === ''` & `last_room_id === ''`)
9. 입력 배열 비변이 검증
10. 다건 매칭 시 source order 보존

## 범위

Dashboard만, 파일 2개(`connector-status.ts` + `connector-status.test.ts`). 백엔드/API/타입 변경 없음. ONE list만 필터 (다른 `.map` 호출들은 건드리지 않음).

Follows the iter-7/8/12/13 seed-hint pattern.