### PR TITLE
feat(dashboard): add tool name/category filter to keeper-tool-telemetry

### DIFF
--- a/dashboard/src/components/keeper-tool-telemetry.test.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { filterToolStats } from './keeper-tool-telemetry'
+import type { ToolStat } from '../api/dashboard'
+
+function mkStat(name: string, overrides: Partial<ToolStat> = {}): ToolStat {
+  return {
+    name,
+    call_count: 1,
+    success_count: 1,
+    failure_count: 0,
+    avg_duration_ms: 10,
+    p95_duration_ms: 20,
+    max_duration_ms: 30,
+    total_cost_usd: 0,
+    last_used_at: '2026-04-17T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const sample: readonly ToolStat[] = [
+  mkStat('masc_status'),
+  mkStat('masc_dashboard'),
+  mkStat('keeper_stay_silent'),
+  mkStat('fs_read'),
+  mkStat('browser_navigate'),
+  mkStat('playwright_click'),
+  mkStat('write_file'),
+]
+
+describe('filterToolStats', () => {
+  it('returns the input reference when query is empty', () => {
+    expect(filterToolStats(sample, '')).toBe(sample)
+    expect(filterToolStats(sample, '   ')).toBe(sample)
+  })
+
+  it('matches case-insensitive substring on name', () => {
+    const out = filterToolStats(sample, 'MASC')
+    expect(out.map(s => s.name)).toEqual(['masc_status', 'masc_dashboard'])
+  })
+
+  it('matches exact name segments', () => {
+    const out = filterToolStats(sample, 'stay_silent')
+    expect(out.map(s => s.name)).toEqual(['keeper_stay_silent'])
+  })
+
+  it('matches via substring on name (read)', () => {
+    const out = filterToolStats(sample, 'read')
+    // fs_read matches by name
+    expect(out.map(s => s.name)).toEqual(['fs_read'])
+  })
+
+  it('matches via derived category label (browser)', () => {
+    const out = filterToolStats(sample, 'browser')
+    const names = out.map(s => s.name)
+    // browser_navigate matches by name; playwright_click matches via category=browser label
+    expect(names).toContain('browser_navigate')
+    expect(names).toContain('playwright_click')
+  })
+
+  it('matches via derived category label (status)', () => {
+    // 'masc_status' matches by name-substring AND category='status'.
+    // keeper_stay_silent has no 'status' in its name; category defaults to 'tool'.
+    // So only masc_status should match.
+    const out = filterToolStats(sample, 'status')
+    expect(out.map(s => s.name)).toEqual(['masc_status'])
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    const out = filterToolStats(sample, '  masc_dashboard  ')
+    expect(out.map(s => s.name)).toEqual(['masc_dashboard'])
+  })
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterToolStats(sample, 'no-such-token-xyz')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const snapshot = sample.slice()
+    filterToolStats(sample, 'masc')
+    expect(sample).toEqual(snapshot)
+  })
+
+  it('returns a fresh array (not the input) when filtering narrows rows', () => {
+    const out = filterToolStats(sample, 'masc')
+    expect(out).not.toBe(sample)
+    expect(out.length).toBeLessThan(sample.length)
+  })
+
+  it('tolerates empty rows input', () => {
+    const empty: readonly ToolStat[] = []
+    expect(filterToolStats(empty, 'masc')).toEqual([])
+    expect(filterToolStats(empty, '')).toBe(empty)
+  })
+})

--- a/dashboard/src/components/keeper-tool-telemetry.ts
+++ b/dashboard/src/components/keeper-tool-telemetry.ts
@@ -3,7 +3,7 @@
 // cross-trace aggregation, and hourly timeline sparklines.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import { fetchKeeperToolStats } from '../api/dashboard'
 import type { ToolStat, HourlyBucket, ToolStatsResponse } from '../api/dashboard'
 import { toolCategory, formatDuration, durationColor } from './tool-call-shared'
@@ -16,6 +16,30 @@ interface TelemetryState {
   timeline: HourlyBucket[]
   totalEntries: number
   windowHours: number
+}
+
+/**
+ * Pure filter for tool-telemetry rows.
+ *
+ * - `query` is case-insensitive substring match on `stat.name` OR the
+ *   derived category label from `toolCategory(stat.name)` (e.g. "read",
+ *   "browser", "masc"). Query is trimmed.
+ * - Empty/whitespace-only query returns the input reference unchanged
+ *   (zero-allocation fast path).
+ * - Does not mutate the input array.
+ */
+export function filterToolStats(
+  rows: readonly ToolStat[],
+  query: string,
+): readonly ToolStat[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(stat => {
+    if (stat.name.toLowerCase().includes(needle)) return true
+    const label = toolCategory(stat.name).label
+    if (label.toLowerCase().includes(needle)) return true
+    return false
+  })
 }
 
 // ── Sparkline ─────────────────────────────────────────
@@ -109,6 +133,7 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
     })
   }
   const resource = resourceRef.current
+  const [query, setQuery] = useState('')
 
   useEffect(() => {
     void resource.load(async (signal) => {
@@ -145,6 +170,11 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
 
   // Find tools with highest p95
   const slowest = [...s.tools].sort((a, b) => b.p95_duration_ms - a.p95_duration_ms).slice(0, 3)
+
+  // Inline filter — s.tools is typically ≤ 50 rows so O(n) is fine and
+  // keeps all hooks above early-return paths.
+  const visibleTools = filterToolStats(s.tools, query)
+  const trimmedQuery = query.trim()
 
   return html`
     <div class="p-5 rounded-2xl border border-card-border bg-card/40 backdrop-blur-md shadow-sm transition-[border-color,box-shadow] duration-200 hover:border-accent/30 hover:shadow-md">
@@ -184,8 +214,29 @@ export function KeeperToolTelemetry({ keeperName }: KeeperToolTelemetryProps) {
 
       ${'' /* Per-tool bar chart */}
       <div class="flex flex-col gap-1">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)] mb-1">호출 빈도</div>
-        ${s.tools.slice(0, 15).map(stat => {
+        <div class="flex items-center justify-between gap-2 mb-1">
+          <div class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-dim)]">호출 빈도</div>
+          <div class="flex items-center gap-2">
+            <input
+              type="search"
+              value=${query}
+              placeholder="도구 검색 (이름/카테고리)"
+              aria-label="도구 텔레메트리 검색"
+              onInput=${(e: Event) => { setQuery((e.target as HTMLInputElement).value) }}
+              class="min-w-[160px] rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+            />
+            <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+              ${trimmedQuery
+                ? `${visibleTools.length} / ${s.tools.length}`
+                : `${s.tools.length}개`}
+            </span>
+          </div>
+        </div>
+        ${visibleTools.length === 0 ? html`
+          <div class="text-[11px] text-[var(--text-muted)] py-2 px-2">
+            필터 결과 없음 (${s.tools.length} items)
+          </div>
+        ` : visibleTools.slice(0, 15).map(stat => {
           const cat = toolCategory(stat.name)
           const barWidth = (stat.call_count / maxCount) * 100
           return html`


### PR DESCRIPTION
## 요약

`KeeperToolTelemetry`의 **호출 빈도** 리스트(`s.tools`)에 검색 필터를 추가합니다. 키퍼가 많은 도구를 사용할 때(masc_*, keeper_*, fs_*, browser/playwright 계열 15+ 도구) 운영자가 특정 도구나 카테고리(예: read, browser, edit, status)에 묶인 도구를 빠르게 추리기 어려웠습니다.

## 변경

- `filterToolStats(rows, query)` 순수 함수를 `keeper-tool-telemetry.ts`에서 export. case-insensitive substring, `stat.name` 또는 `toolCategory(stat.name).label`(예: 'read', 'browser', 'status', 'edit') 중 하나라도 매치하면 포함.
- 빈/공백 query는 입력 참조를 그대로 반환 → non-filter path 추가 할당 없음.
- 입력 비변이 (`readonly ToolStat[]`).
- 필터가 모든 도구를 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 데이터 자체가 없는 경우와 구분.
- UI는 기존 "호출 빈도" 섹션 헤더 우측에 `type="search"` 입력(한국어 placeholder) + `N / total` 카운터 추가.
- `useState('')`로 query 관리, `useMemo` 대신 인라인 계산 — s.tools는 보통 ≤ 50 rows라 O(n) 비용이 무시 가능하고, 모든 훅을 early-return 경로 위로 유지.
- 단위 테스트 11건: 빈/공백/trim, case, name 매칭(masc/stay_silent/read), 카테고리 label 매칭(browser, status), no-match, 입력 비변이, fresh array 반환, empty rows.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/keeper-tool-telemetry.test.ts`: 11/11 pass (전부 신규).
- `pnpm exec eslint .`: 에러 0.

## 범위

Dashboard만, 파일 2개(`keeper-tool-telemetry.ts` + 신규 `keeper-tool-telemetry.test.ts`). 백엔드/타입/API 변경 없음. "성공률"과 "P95 지연 시간" 섹션은 건드리지 않음 — 본 PR은 메인 리스트("호출 빈도") 한 곳만 필터링.

Follows the iter-7/8/12/13 seed-hint pattern.