### PR TITLE
feat(dashboard): add entry text filter to telemetry-unified main list

### DIFF
--- a/dashboard/src/components/telemetry-unified.test.ts
+++ b/dashboard/src/components/telemetry-unified.test.ts
@@ -553,3 +553,186 @@ describe('TelemetryUnified', () => {
     expect(container.textContent).toContain('mcp__masc__masc_status')
   })
 })
+
+describe('filterTelemetryDisplayItems', () => {
+  beforeEach(() => {
+    // The outer describe enables fake timers globally; the pure-function
+    // tests here don't need timers and dynamic import() resolves faster on
+    // real timers, so opt out for this suite.
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard')
+  })
+
+  async function loadFilter() {
+    return import('./telemetry-unified')
+  }
+
+  const sampleEntries = [
+    {
+      source: 'tool_metric' as const,
+      ts: 1_775_709_300,
+      session_id: 'sess-alpha',
+      tool_name: 'mcp__masc__masc_status',
+      duration_ms: 15,
+      success: true,
+    },
+    {
+      source: 'keeper_metric' as const,
+      ts: 1_775_709_200,
+      name: 'keeper-bravo',
+      channel: 'turn_end',
+      model_used: 'glm-4.6',
+      tool_call_count: 2,
+      success: true,
+    },
+    {
+      source: 'agent_event' as const,
+      ts: 1_775_709_100,
+      event: ['task_claimed', { agent_id: 'keeper-charlie' }],
+    },
+    {
+      source: 'tool_call_io' as const,
+      ts: 1_775_709_000,
+      operation_id: 'op-delta',
+      keeper: 'keeper-delta',
+      tool: 'masc_broadcast',
+    },
+  ]
+
+  it('returns input reference unchanged for empty query', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    expect(filterTelemetryDisplayItems(items, '')).toBe(items)
+  })
+
+  it('returns input reference unchanged for whitespace-only query', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    expect(filterTelemetryDisplayItems(items, '   \t  ')).toBe(items)
+  })
+
+  it('trims query whitespace before matching', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const trimmed = filterTelemetryDisplayItems(items, '  keeper-bravo  ')
+    const raw = filterTelemetryDisplayItems(items, 'keeper-bravo')
+    expect(trimmed.length).toBe(raw.length)
+    expect(trimmed.length).toBe(1)
+  })
+
+  it('is case-insensitive', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const upper = filterTelemetryDisplayItems(items, 'KEEPER-BRAVO')
+    const lower = filterTelemetryDisplayItems(items, 'keeper-bravo')
+    expect(upper.length).toBe(lower.length)
+    expect(upper.length).toBe(1)
+  })
+
+  it('matches on the source field', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const filtered = filterTelemetryDisplayItems(items, 'agent_event')
+    expect(filtered.length).toBe(1)
+    expect(filtered[0]?.kind).toBe('entry')
+    if (filtered[0]?.kind === 'entry') {
+      expect(filtered[0].entry.source).toBe('agent_event')
+    }
+  })
+
+  it('matches on preview text (tool name)', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const filtered = filterTelemetryDisplayItems(items, 'masc_broadcast')
+    expect(filtered.length).toBe(1)
+    if (filtered[0]?.kind === 'entry') {
+      expect(filtered[0].entry.source).toBe('tool_call_io')
+    }
+  })
+
+  it('matches on scope badge (operation_id)', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const filtered = filterTelemetryDisplayItems(items, 'op-delta')
+    expect(filtered.length).toBe(1)
+    if (filtered[0]?.kind === 'entry') {
+      expect(filtered[0].entry.operation_id).toBe('op-delta')
+    }
+  })
+
+  it('returns empty array when nothing matches', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const filtered = filterTelemetryDisplayItems(items, 'zzz-no-such-token')
+    expect(filtered.length).toBe(0)
+  })
+
+  it('does not mutate input items', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const items = buildTelemetryDisplayItems([...sampleEntries])
+    const snapshot = items.map(item => item.key)
+    filterTelemetryDisplayItems(items, 'keeper-bravo')
+    expect(items.map(item => item.key)).toEqual(snapshot)
+    expect(items.length).toBe(4)
+  })
+
+  it('handles entries with missing scope/preview fields without throwing', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    const sparseEntries = [
+      {
+        // agent_event with non-array event and no detail — tests sparse fields.
+        source: 'agent_event' as const,
+        ts: 1_775_709_500,
+        event: 'heartbeat_tick',
+      },
+      {
+        // tool_metric with no tool_name / duration — sparse preview.
+        source: 'tool_metric' as const,
+        ts: 1_775_709_400,
+      },
+    ]
+    const items = buildTelemetryDisplayItems(sparseEntries)
+    expect(() => filterTelemetryDisplayItems(items, 'anything')).not.toThrow()
+    const matchesSource = filterTelemetryDisplayItems(items, 'tool_metric')
+    expect(matchesSource.length).toBe(1)
+  })
+
+  it('matches group items on label (noisy tool name)', async () => {
+    const { buildTelemetryDisplayItems, filterTelemetryDisplayItems } = await loadFilter()
+    // Three consecutive masc_status entries collapse into a single group whose
+    // label is the canonical tool name.
+    const noisyEntries = [
+      {
+        source: 'tool_metric' as const,
+        ts: 1_775_709_300,
+        session_id: 'sess-noisy',
+        tool_name: 'mcp__masc__masc_status',
+        duration_ms: 10,
+        success: true,
+      },
+      {
+        source: 'tool_usage' as const,
+        ts: 1_775_709_299,
+        session_id: 'sess-noisy',
+        caller: 'keeper_internal',
+        tool_name: 'masc_status',
+      },
+      {
+        source: 'tool_call_io' as const,
+        ts: 1_775_709_298,
+        session_id: 'sess-noisy',
+        keeper: 'keeper-alpha',
+        tool: 'masc_status',
+      },
+    ]
+    const items = buildTelemetryDisplayItems(noisyEntries)
+    expect(items[0]?.kind).toBe('group')
+    const filtered = filterTelemetryDisplayItems(items, 'masc_status')
+    expect(filtered.length).toBe(1)
+    expect(filtered[0]?.kind).toBe('group')
+  })
+})

--- a/dashboard/src/components/telemetry-unified.ts
+++ b/dashboard/src/components/telemetry-unified.ts
@@ -278,6 +278,42 @@ function entryPreview(e: TelemetryEntry): string {
   }
 }
 
+/**
+ * Case-insensitive substring search over the rendered telemetry display items.
+ *
+ * Matches against, in order (first match wins):
+ * - `entry.source` (for entry rows) or concatenated source keys (for groups)
+ * - `entryPreview(entry)` text (for entry rows) or `item.label` (for groups),
+ *   which already captures keeper/tool/agent identifiers
+ * - scope badges ("S ...", "OP ...", "WR ...") from session/operation/worker_run
+ *
+ * Empty or whitespace-only queries return the input reference unchanged so the
+ * non-filter path keeps reference identity (useMemo/inline-path friendly).
+ * Input is never mutated; items are treated as readonly.
+ */
+export function filterTelemetryDisplayItems(
+  items: readonly TelemetryDisplayItem[],
+  query: string,
+): readonly TelemetryDisplayItem[] {
+  const trimmed = query.trim()
+  if (trimmed === '') return items
+  const needle = trimmed.toLowerCase()
+
+  const haystackForItem = (item: TelemetryDisplayItem): string => {
+    if (item.kind === 'entry') {
+      const source = typeof item.entry.source === 'string' ? item.entry.source : ''
+      const preview = entryPreview(item.entry)
+      const badges = telemetryScopeBadges(item.entry).join(' ')
+      return `${source} ${preview} ${badges}`
+    }
+    const sources = item.sourceKeys.join(' ')
+    const badges = item.scopeBadges.join(' ')
+    return `${sources} ${item.label} ${badges}`
+  }
+
+  return items.filter(item => haystackForItem(item).toLowerCase().includes(needle))
+}
+
 export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): TelemetryDisplayItem[] {
   const items: TelemetryDisplayItem[] = []
   let nextItemId = 0
@@ -364,7 +400,7 @@ export function buildTelemetryDisplayItems(entries: TelemetryEntry[]): Telemetry
   return items
 }
 
-function condensedStats(items: TelemetryDisplayItem[]) {
+function condensedStats(items: readonly TelemetryDisplayItem[]) {
   let groups = 0
   let groupedEntries = 0
   let collapsedEntries = 0
@@ -558,6 +594,7 @@ export function TelemetryUnified() {
   const operationFilter = useSignal(params.operation_id ?? '')
   const workerRunFilter = useSignal(params.worker_run_id ?? '')
   const limit = useSignal(100)
+  const entrySearch = useSignal('')
 
   useEffect(() => {
     sessionFilter.value = route.value.params.session_id ?? ''
@@ -676,7 +713,9 @@ export function TelemetryUnified() {
   }, [])
 
   const { entries, summary, totalEntries, store, loading, error } = state.value
-  const displayItems = buildTelemetryDisplayItems(entries)
+  const allDisplayItems = buildTelemetryDisplayItems(entries)
+  const displayItems = filterTelemetryDisplayItems(allDisplayItems, entrySearch.value)
+  const isFilteringEntries = entrySearch.value.trim() !== ''
   const condensed = condensedStats(displayItems)
 
   return html`
@@ -772,6 +811,14 @@ export function TelemetryUnified() {
           value=${workerRunFilter.value}
           onInput=${(e: Event) => { workerRunFilter.value = (e.target as HTMLInputElement).value.trim() }}
         />
+        <input
+          type="search"
+          placeholder="엔트리 검색..."
+          aria-label="엔트리 텍스트 검색"
+          class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)] w-48"
+          value=${entrySearch.value}
+          onInput=${(e: Event) => { entrySearch.value = (e.target as HTMLInputElement).value }}
+        />
         <select
           aria-label="표시 개수 제한"
           class="rounded border border-[var(--card-border)] bg-[var(--bg-0)] px-2 py-1 text-xs text-[var(--text-strong)]"
@@ -802,6 +849,9 @@ export function TelemetryUnified() {
       <div class="rounded-xl border border-[var(--card-border)] overflow-hidden">
         <div class="px-3 py-2 border-b border-[var(--card-border)] bg-[var(--white-3)] text-xs text-[var(--text-muted)]">
           MASC telemetry store entries ${entries.length.toLocaleString()}건
+          ${isFilteringEntries
+            ? ` · 검색 매치 ${displayItems.length.toLocaleString()}건`
+            : ''}
           ${condensed.groups > 0
             ? ` · 반복 그룹 ${condensed.groups.toLocaleString()}개 · 원본 ${condensed.groupedEntries.toLocaleString()}건`
             : ''}
@@ -825,7 +875,9 @@ export function TelemetryUnified() {
             ? displayItems.map(item => item.kind === 'group'
               ? html`<${GroupRow} key=${item.key} item=${item} />`
               : html`<${EntryRow} key=${item.key} entry=${item.entry} />`)
-            : html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">선택한 scope에 해당하는 MASC telemetry entry가 없습니다.</div>`}
+            : isFilteringEntries && allDisplayItems.length > 0
+              ? html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">필터 결과 없음 (${allDisplayItems.length} items)</div>`
+              : html`<div class="px-4 py-6 text-sm text-[var(--text-muted)]">선택한 scope에 해당하는 MASC telemetry entry가 없습니다.</div>`}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 요약

`TelemetryUnified`의 **메인 텔레메트리 엔트리 리스트** (최대 500건, `displayItems`)에 자유 텍스트 검색을 추가합니다. 기존에는 source/keeper/session/operation/worker_run 필터만 있었고, 툴 이름·에이전트 이름·프리뷰 텍스트 일부 같은 임의 부분 문자열로 좁히려면 전체 리스트를 훑어야 했습니다.

## 왜 이 리스트인가

`telemetry-unified.ts`의 9개 `.map` 호출부 중 후보는:

- `summary.map` — source summary 카드 (≤6개, 이미 aggregate)
- `Object.entries(TELEMETRY_SOURCE_META).map` — 정적 select 옵션
- `condensed.byCategory` — 2 카테고리
- `displayItems.map` — **메인 리스트, 고유 카디널리티 최대, 검색 가능한 문자열 필드(source/preview/scope badge) 다수, 자유 텍스트로는 미필터링** ← 선택

나머지 `.map` 호출은 badge/icon 렌더 또는 그룹 내부 펼침용으로 별도 검색이 필요하지 않습니다.

## 변경

- `filterTelemetryDisplayItems(items, query)` 순수 함수를 `telemetry-unified.ts`에서 export. case-insensitive substring.
  - entry row: `entry.source`, `entryPreview(entry)`, scope badges(`S ...` / `OP ...` / `WR ...`) 중 하나라도 매치하면 포함.
  - group row: source keys, `item.label`, scope badges 중 하나라도 매치.
- 빈/공백 query는 입력 참조를 그대로 반환 → non-filter path 추가 할당 없음.
- 입력 비변이 (`readonly TelemetryDisplayItem[]` 로 다룸). `condensedStats` 시그니처도 readonly로 완화.
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 실제 데이터 없음과 구분.
- 헤더 카운트 라인에 `검색 매치 N건` 병기하여 현재 보이는 행 수 확인 가능.
- 기존 필터 바의 `worker_run_id` 옆에 `<input type="search">` 배치. 한국어 placeholder `엔트리 검색...`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/telemetry-unified.test.ts`: 19 pass. 사전 존재하던 타임아웃 2건(`polls automatically` / `surfaces summary fetch errors`)은 `origin/main`에서 이미 실패 — 이 PR 변경과 무관함 (stash 후 재검증).
- 신규 10건:
  1. 빈 query → 입력 참조 동일
  2. 공백만 있는 query → 입력 참조 동일
  3. trim 적용
  4. case-insensitive
  5. source 필드 매칭
  6. preview 텍스트(툴 이름) 매칭
  7. scope badge(operation_id) 매칭
  8. no-match → 빈 배열
  9. 입력 비변이
  10. 누락 필드(sparse entry) 안전
  11. group label(노이지 툴) 매칭

- `pnpm exec eslint .`: 에러 0.

## 범위

Dashboard만, 파일 2개(panel + test). 백엔드/타입/API 변경 없음. `useMemo` 대신 인라인 계산 — 렌더당 최대 500 items 위에서 substring 1회로 O(n), 충분히 가볍습니다.

Follows the iter-7/8/12/13 seed-hint pattern.