### PR TITLE
test(dashboard): align approvalRiskToneClass test with impl after CSS var migration

### DIFF
--- a/dashboard/src/components/governance-risk.test.ts
+++ b/dashboard/src/components/governance-risk.test.ts
@@ -15,15 +15,15 @@ describe('approvalRiskToneClass', () => {
   })
 
   it('returns muted tone for low', () => {
-    expect(approvalRiskToneClass('low')).toBe('border-white/10 bg-white/5 text-text-muted')
+    expect(approvalRiskToneClass('low')).toBe('border-white/10 bg-[var(--white-3)] text-text-muted')
   })
 
   it('returns muted tone for unknown', () => {
-    expect(approvalRiskToneClass('unknown')).toBe('border-white/10 bg-white/5 text-text-muted')
+    expect(approvalRiskToneClass('unknown')).toBe('border-white/10 bg-[var(--white-3)] text-text-muted')
   })
 
   it('returns muted tone for empty string', () => {
-    expect(approvalRiskToneClass('')).toBe('border-white/10 bg-white/5 text-text-muted')
+    expect(approvalRiskToneClass('')).toBe('border-white/10 bg-[var(--white-3)] text-text-muted')
   })
 
   it('is case-insensitive', () => {


### PR DESCRIPTION
## 증상
모든 dashboard 변경 PR이 `Dashboard` CI에서 3건 false-negative로 빨강.

```
FAIL src/components/governance-risk.test.ts > approvalRiskToneClass > returns muted tone for low
AssertionError: expected 'border-white/10 bg-[var(--white-3)] t…' to be 'border-white/10 bg-white/5 text-text-…'
```

## 원인
`governance.ts:approvalRiskToneClass` 가 CSS variable로 마이그레이션되며 default 분기 반환값이 `bg-white/5` → `bg-[var(--white-3)]` 로 바뀌었으나, `governance-risk.test.ts` 의 3건 (`low`, `unknown`, `empty string`) assertion이 옛 리터럴을 그대로 pinning.

## 수정
test의 expected 값을 현재 impl 출력에 맞춤 (`bg-[var(--white-3)]`). impl 변경 X — CSS var 사용이 의도된 신형.

## 검증
- 로컬: `pnpm vitest run src/components/governance-risk.test.ts` → 17/17 pass
- 재현 PR: #7831 Dashboard run 24548749335

## 영향
- 7825/7826/7828/7829: 이미 머지 가능 (영향 없음)
- 7831/7833 등 dashboard CI 거치는 PR: 이 PR 머지 후 재실행하면 governance 3 fail이 사라짐