### PR TITLE
feat(dashboard): task-level search in TaskBacklog kanban

### DIFF
--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -7,6 +7,9 @@ import {
   statusFilterLabel,
   sortByPriority,
   sortByTimeDesc,
+  filterTasksByQuery,
+  resetTaskSearch,
+  taskSearchQuery,
 } from './goal-helpers'
 import type { Task } from '../../types'
 
@@ -185,5 +188,69 @@ describe('sortByTimeDesc', () => {
     const a = makeTask('', '')
     const b = makeTask('', '')
     expect(sortByTimeDesc(a, b)).toBe(0)
+  })
+})
+
+// ================================================================
+// filterTasksByQuery
+// ================================================================
+
+describe('filterTasksByQuery', () => {
+  type Searchable = { id: string; title: string; description?: string | null; assignee?: string | null }
+  const tasks: Searchable[] = [
+    { id: 't1', title: '[masc-mcp] Fix keeper heartbeat', description: 'Eio timeout regression', assignee: 'claude' },
+    { id: 't2', title: '[oas] Add Groq provider', description: null, assignee: 'codex' },
+    { id: 't3', title: 'Dashboard polish', description: 'Tailwind migration cleanup', assignee: null },
+    { id: 't4', title: 'Write evidence record', description: 'BFCL 67 verification', assignee: 'gemini' },
+  ]
+
+  it('returns a copy of all tasks for an empty query', () => {
+    const result = filterTasksByQuery(tasks, '')
+    expect(result).toHaveLength(tasks.length)
+    expect(result).not.toBe(tasks)
+  })
+
+  it('treats whitespace-only query as empty', () => {
+    expect(filterTasksByQuery(tasks, '   ')).toHaveLength(tasks.length)
+  })
+
+  it('matches on title (case-insensitive)', () => {
+    const result = filterTasksByQuery(tasks, 'KEEPER')
+    expect(result.map(t => t.id)).toEqual(['t1'])
+  })
+
+  it('matches on description', () => {
+    const result = filterTasksByQuery(tasks, 'tailwind')
+    expect(result.map(t => t.id)).toEqual(['t3'])
+  })
+
+  it('matches on assignee', () => {
+    const result = filterTasksByQuery(tasks, 'codex')
+    expect(result.map(t => t.id)).toEqual(['t2'])
+  })
+
+  it('returns empty array on miss', () => {
+    expect(filterTasksByQuery(tasks, 'zzzz')).toEqual([])
+  })
+
+  it('handles null description and assignee without throwing', () => {
+    const result = filterTasksByQuery(tasks, 'dashboard')
+    expect(result.map(t => t.id)).toEqual(['t3'])
+  })
+
+  it('trims query before matching', () => {
+    expect(filterTasksByQuery(tasks, '  groq  ').map(t => t.id)).toEqual(['t2'])
+  })
+})
+
+// ================================================================
+// resetTaskSearch
+// ================================================================
+
+describe('resetTaskSearch', () => {
+  it('clears taskSearchQuery to empty string', () => {
+    taskSearchQuery.value = 'something'
+    resetTaskSearch()
+    expect(taskSearchQuery.value).toBe('')
   })
 })

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -14,6 +14,30 @@ export type StatusFilter = 'all' | 'active' | 'completed' | 'paused'
 export const horizonFilter = signal<HorizonFilter>('all')
 export const statusFilter = signal<StatusFilter>('all')
 
+// -- Task-level search (case-insensitive, title + description + assignee) --
+
+export const taskSearchQuery = signal<string>('')
+
+export function resetTaskSearch() {
+  taskSearchQuery.value = ''
+}
+
+export function filterTasksByQuery<T extends { title?: string; description?: string | null; assignee?: string | null }>(
+  tasks: readonly T[],
+  query: string,
+): T[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return [...tasks]
+  return tasks.filter(t => {
+    const title = (t.title ?? '').toLowerCase()
+    if (title.includes(q)) return true
+    const description = (t.description ?? '').toLowerCase()
+    if (description.includes(q)) return true
+    const assignee = (t.assignee ?? '').toLowerCase()
+    return assignee.includes(q)
+  })
+}
+
 // -- Expand state for task description previews ------------------
 
 export const expandedTasks = signal<Set<string>>(new Set())

--- a/dashboard/src/components/goals/kanban-components.test.ts
+++ b/dashboard/src/components/goals/kanban-components.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { h } from 'preact'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/preact'
+import '@testing-library/jest-dom'
+import { TaskBacklog, resetTaskBacklogState } from './kanban-components'
+import { executionError, executionLoaded, executionLoading, tasks } from '../../store'
+import { resetTaskSearch } from './goal-helpers'
+import type { Task } from '../../types'
+
+vi.mock('@formkit/auto-animate', () => ({
+  default: vi.fn(),
+}))
+
+function makeDoneTask(index: number): Task {
+  const day = String(26 - index).padStart(2, '0')
+  const timestamp = `2026-04-${day}T00:00:00Z`
+  return {
+    id: `done-${index}`,
+    title: `Done task ${index}`,
+    status: 'done',
+    priority: 3,
+    description: `Description ${index}`,
+    created_at: timestamp,
+    updated_at: timestamp,
+    completed_at: timestamp,
+  }
+}
+
+describe('TaskBacklog', () => {
+  beforeEach(() => {
+    resetTaskBacklogState()
+    resetTaskSearch()
+    executionLoaded.value = true
+    executionLoading.value = false
+    executionError.value = null
+    tasks.value = Array.from({ length: 25 }, (_value, index) => makeDoneTask(index + 1))
+  })
+
+  afterEach(() => {
+    cleanup()
+    tasks.value = []
+    executionLoaded.value = false
+    executionLoading.value = false
+    executionError.value = null
+    resetTaskSearch()
+    resetTaskBacklogState()
+  })
+
+  it('preserves expanded done pagination after clearing search', async () => {
+    render(h(TaskBacklog, {}))
+
+    expect(screen.queryByText('Done task 25')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /완료 태스크 5개 더 보기/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Done task 25')).toBeInTheDocument()
+    })
+
+    fireEvent.input(screen.getByLabelText('태스크 검색'), {
+      target: { value: 'Done task 25' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Done task 25')).toBeInTheDocument()
+      expect(screen.queryByText('Done task 24')).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: '검색 초기화' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Done task 25')).toBeInTheDocument()
+      expect(screen.getByText('Done task 24')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /완료 태스크 .*더 보기/ })).not.toBeInTheDocument()
+    })
+  })
+})

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -8,6 +8,7 @@ import autoAnimate from '@formkit/auto-animate'
 import { EmptyState, ErrorState, LoadingState } from '../common/feedback-state'
 import { ActionButton } from '../common/button'
 import { Card } from '../common/card'
+import { TextInput } from '../common/input'
 import { TimeAgo } from '../common/time-ago'
 import { RichContent } from '../common/rich-content'
 import { showToast } from '../common/toast'
@@ -21,6 +22,9 @@ import {
   priorityLabel,
   sortByPriority,
   sortByTimeDesc,
+  taskSearchQuery,
+  resetTaskSearch,
+  filterTasksByQuery,
 } from './goal-helpers'
 import { openTaskDetail } from './task-detail-state'
 
@@ -196,16 +200,28 @@ function TaskColumn({
 export function TaskBacklog() {
   const { todo, inProgress, done } = tasksByStatus.value
   const totalTasks = todo.length + inProgress.length + done.length
-  const sortedTodo = [...todo].sort(sortByPriority)
-  const sortedInProgress = [...inProgress].sort(sortByPriority)
-  const sortedDone = [...done].sort(sortByTimeDesc)
+  const query = taskSearchQuery.value
+  const hasSearch = query.trim().length > 0
+  const filteredTodo = filterTasksByQuery(todo, query)
+  const filteredInProgress = filterTasksByQuery(inProgress, query)
+  const filteredDone = filterTasksByQuery(done, query)
+  const filteredTotal = filteredTodo.length + filteredInProgress.length + filteredDone.length
+  const sortedTodo = [...filteredTodo].sort(sortByPriority)
+  const sortedInProgress = [...filteredInProgress].sort(sortByPriority)
+  const sortedDone = [...filteredDone].sort(sortByTimeDesc)
   const visibleDone = sortedDone.slice(0, doneVisibleCount.value)
   const hasMoreDone = sortedDone.length > doneVisibleCount.value
   const remainingDone = sortedDone.length - doneVisibleCount.value
+  const emptyColumnMessage = hasSearch ? '검색 결과 없음' : null
 
-  // Reset pagination when data refreshes and count shrinks below current page
+  // Reset pagination when data (or filter) shrinks below current page
   if (doneVisibleCount.value > sortedDone.length && doneVisibleCount.value > DONE_PAGE_SIZE) {
     doneVisibleCount.value = Math.max(DONE_PAGE_SIZE, sortedDone.length)
+  }
+
+  function handleSearchInput(e: Event) {
+    const target = e.target as HTMLInputElement
+    taskSearchQuery.value = target.value
   }
 
   const isLoading = executionLoading.value && !executionLoaded.value
@@ -236,35 +252,53 @@ export function TaskBacklog() {
       ${hasError && hasData ? html`
         <div class="mb-3 rounded-lg border border-warn/25 bg-warn/10 px-3 py-2 text-[12px] text-warn">마지막 갱신에 실패했습니다. 표시된 데이터가 오래되었을 수 있습니다.</div>
       ` : null}
+      <div class="mb-4 flex flex-wrap items-center gap-2">
+        <div class="min-w-[220px] flex-1">
+          <${TextInput}
+            value=${query}
+            placeholder="태스크 제목/설명/담당자 검색..."
+            ariaLabel="태스크 검색"
+            onInput=${handleSearchInput}
+          />
+        </div>
+        ${hasSearch ? html`
+          <button
+            type="button"
+            class="rounded-lg border border-card-border/70 bg-white/4 px-3 py-2 text-[12px] text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
+            onClick=${() => resetTaskSearch()}
+          >검색 초기화</button>
+          <span class="text-[12px] text-text-muted">${filteredTotal}/${totalTasks}</span>
+        ` : null}
+      </div>
       <div class="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-4 items-start">
         <${TaskColumn}
           title="할 일"
-          count=${todo.length}
+          count=${sortedTodo.length}
           description="아직 claim되지 않은 태스크입니다. 우선순위가 높은 순서대로 위에 옵니다."
           badgeClass="border border-bad/25 bg-bad/10 text-bad"
         >
           ${sortedTodo.length === 0
-            ? html`<${EmptyState} message="대기 중인 태스크가 없습니다" compact />`
+            ? html`<${EmptyState} message=${emptyColumnMessage ?? '대기 중인 태스크가 없습니다'} compact />`
             : sortedTodo.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         <//>
         <${TaskColumn}
           title="진행 중"
-          count=${inProgress.length}
+          count=${sortedInProgress.length}
           description="현재 어떤 작업이 실행 중인지 확인하는 칸입니다."
           badgeClass="border border-warn/25 bg-warn/10 text-warn"
         >
           ${sortedInProgress.length === 0
-            ? html`<${EmptyState} message="진행 중인 태스크가 없습니다" compact />`
+            ? html`<${EmptyState} message=${emptyColumnMessage ?? '진행 중인 태스크가 없습니다'} compact />`
             : sortedInProgress.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
         <//>
         <${TaskColumn}
           title="완료"
-          count=${done.length}
+          count=${sortedDone.length}
           description="최근 완료된 태스크만 우선 노출합니다."
           badgeClass="border border-ok/25 bg-ok/10 text-ok"
         >
           ${sortedDone.length === 0
-            ? html`<${EmptyState} message="완료된 태스크가 없습니다" compact />`
+            ? html`<${EmptyState} message=${emptyColumnMessage ?? '완료된 태스크가 없습니다'} compact />`
             : visibleDone.map(t => html`<${KanbanCard} key=${t.id} task=${t} />`)}
           ${hasMoreDone ? html`
             <button

--- a/dashboard/src/components/goals/kanban-components.ts
+++ b/dashboard/src/components/goals/kanban-components.ts
@@ -30,8 +30,14 @@ import { openTaskDetail } from './task-detail-state'
 
 const deletingTaskId = signal<string | null>(null)
 const doneVisibleCount = signal(20)
+const searchDoneVisibleCount = signal(20)
 const DONE_PAGE_SIZE = 20
 const REPO_ISSUES_BASE = 'https://github.com/jeong-sik/masc-mcp/issues'
+
+export function resetTaskBacklogState() {
+  doneVisibleCount.value = DONE_PAGE_SIZE
+  searchDoneVisibleCount.value = DONE_PAGE_SIZE
+}
 
 function priorityToneClass(priority: number): string {
   switch (priority) {
@@ -209,19 +215,29 @@ export function TaskBacklog() {
   const sortedTodo = [...filteredTodo].sort(sortByPriority)
   const sortedInProgress = [...filteredInProgress].sort(sortByPriority)
   const sortedDone = [...filteredDone].sort(sortByTimeDesc)
-  const visibleDone = sortedDone.slice(0, doneVisibleCount.value)
-  const hasMoreDone = sortedDone.length > doneVisibleCount.value
-  const remainingDone = sortedDone.length - doneVisibleCount.value
+  const activeDoneVisibleCount = hasSearch ? searchDoneVisibleCount.value : doneVisibleCount.value
+  const effectiveDoneVisibleCount = Math.min(activeDoneVisibleCount, sortedDone.length)
+  const visibleDone = sortedDone.slice(0, effectiveDoneVisibleCount)
+  const hasMoreDone = sortedDone.length > effectiveDoneVisibleCount
+  const remainingDone = sortedDone.length - effectiveDoneVisibleCount
   const emptyColumnMessage = hasSearch ? '검색 결과 없음' : null
 
-  // Reset pagination when data (or filter) shrinks below current page
-  if (doneVisibleCount.value > sortedDone.length && doneVisibleCount.value > DONE_PAGE_SIZE) {
+  // Reset pagination only for the base done list when data shrinks.
+  if (!hasSearch && doneVisibleCount.value > sortedDone.length && doneVisibleCount.value > DONE_PAGE_SIZE) {
     doneVisibleCount.value = Math.max(DONE_PAGE_SIZE, sortedDone.length)
+  }
+
+  function setSearchQuery(nextQuery: string) {
+    const nextHasSearch = nextQuery.trim().length > 0
+    if (!nextHasSearch) {
+      searchDoneVisibleCount.value = DONE_PAGE_SIZE
+    }
+    taskSearchQuery.value = nextQuery
   }
 
   function handleSearchInput(e: Event) {
     const target = e.target as HTMLInputElement
-    taskSearchQuery.value = target.value
+    setSearchQuery(target.value)
   }
 
   const isLoading = executionLoading.value && !executionLoaded.value
@@ -265,7 +281,10 @@ export function TaskBacklog() {
           <button
             type="button"
             class="rounded-lg border border-card-border/70 bg-white/4 px-3 py-2 text-[12px] text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
-            onClick=${() => resetTaskSearch()}
+            onClick=${() => {
+              resetTaskSearch()
+              searchDoneVisibleCount.value = DONE_PAGE_SIZE
+            }}
           >검색 초기화</button>
           <span class="text-[12px] text-text-muted">${filteredTotal}/${totalTasks}</span>
         ` : null}
@@ -304,7 +323,10 @@ export function TaskBacklog() {
             <button
               type="button"
               class="w-full rounded-lg border border-card-border/60 bg-white/3 px-3 py-2 text-[12px] font-medium text-text-muted transition-colors hover:border-accent/35 hover:text-text-strong"
-              onClick=${() => { doneVisibleCount.value += DONE_PAGE_SIZE }}
+              onClick=${() => {
+                if (hasSearch) searchDoneVisibleCount.value += DONE_PAGE_SIZE
+                else doneVisibleCount.value += DONE_PAGE_SIZE
+              }}
             >
               완료 태스크 ${remainingDone}개 더 보기
             </button>


### PR DESCRIPTION
## Summary
- Adds a search input to the kanban TaskBacklog that filters across 할 일 / 진행 중 / 완료 columns by title, description, or assignee (case-insensitive, trimmed).
- New pure helper `filterTasksByQuery(tasks, query)` + signal `taskSearchQuery` + `resetTaskSearch()` in `goal-helpers.ts` — testable in isolation.
- Column counts switch to filtered counts; empty-state message becomes `검색 결과 없음` when a search yields no matches.

## Quality checklist (iter-13 simplify findings)
- **Lifecycle reset**: exported `resetTaskSearch()`; signals follow existing module-scope pattern used by `horizonFilter`/`statusFilter`. Reset is user-triggered via the "검색 초기화" button.
- **Stable Preact keys**: unchanged — kanban already uses `key=${t.id}`; filter shrinks the list but keys stay anchored to task IDs.
- **TextInput reuse**: uses `../common/input` `TextInput`. No hand-rolled input.

## Files
- `dashboard/src/components/goals/goal-helpers.ts` (+23)
- `dashboard/src/components/goals/goal-helpers.test.ts` (+61, 9 new tests)
- `dashboard/src/components/goals/kanban-components.ts` (~30 touched)

## Checks
- `pnpm typecheck` green
- `pnpm lint` green
- `pnpm vitest run goal-helpers.test.ts` → 38/38 pass
- `pnpm test` overall: 2718 pass; 3 pre-existing failures in `governance-risk.test.ts` (tailwind class drift) — confirmed present on `origin/main` before my changes.

## Test plan
- [ ] Open dashboard → 태스크 백로그 → type a keyword; verify all 3 columns filter live.
- [ ] Clear with "검색 초기화" button; column counts restore.
- [ ] Search a term only present in 완료 column; 할 일/진행 중 show `검색 결과 없음`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)