### PR TITLE
chore(telemetry): drop always-zero work_discovery_count from behavioral_stats

### DIFF
--- a/lib/keeper/keeper_telemetry_feedback.ml
+++ b/lib/keeper/keeper_telemetry_feedback.ml
@@ -16,7 +16,6 @@ type behavioral_stats = {
   unique_tools_used : string list;
   tool_utilization_rate : float;
   last_visible_action_age_sec : int;
-  work_discovery_count : int;
 }
 
 let empty_stats ~window_hours =
@@ -29,7 +28,6 @@ let empty_stats ~window_hours =
     unique_tools_used = [];
     tool_utilization_rate = 0.0;
     last_visible_action_age_sec = 0;
-    work_discovery_count = 0;
   }
 
 (* ------------------------------------------------------------------ *)
@@ -151,7 +149,6 @@ let compute_stats ~decision_log_path ~window_hours =
       unique_tools_used = unique_tools;
       tool_utilization_rate;
       last_visible_action_age_sec;
-      work_discovery_count = 0;
     }
 
 (* ------------------------------------------------------------------ *)

--- a/lib/keeper/keeper_telemetry_feedback.mli
+++ b/lib/keeper/keeper_telemetry_feedback.mli
@@ -16,7 +16,6 @@ type behavioral_stats = {
   unique_tools_used : string list;
   tool_utilization_rate : float;
   last_visible_action_age_sec : int;
-  work_discovery_count : int;
 }
 
 val empty_stats : window_hours:int -> behavioral_stats


### PR DESCRIPTION
## Summary

`behavioral_stats.work_discovery_count` was advertised in the telemetry type but never computed — both `empty_stats` and the `compute_stats` terminal record both set it to literal `0`, and no caller reads it. Dead surface that makes the prompt-block schema claim a signal it never produces.

## Scope

- `lib/keeper/keeper_telemetry_feedback.ml`: remove field from `behavioral_stats`, from `empty_stats` initializer, from `compute_stats` terminal record (3 lines)
- `lib/keeper/keeper_telemetry_feedback.mli`: remove field declaration (1 line)

## Out of scope

`rt.proactive_rt.work_discovery_count` (`lib/keeper/keeper_types.ml`) is a **separate, live** field that `keeper_unified_turn.ml:1083-1086` actually increments on `work_discovery_due && has_substantive_tools` cycles. A prior audit hit (and an earlier `/simplify` Agent-2 pass) flagged this alongside the dead one — false positive; not touched here.

## Test plan
- [x] `dune build --root . @check` clean
- [x] `dune build --root . @runtest` — 111 tests pass, including `test_keeper_telemetry_feedback.ml`