### PR TITLE
feat(attribution): worker_dev_tools wire-up + dashboard frontend (L4)

### DIFF
--- a/dashboard/src/api/attribution.ts
+++ b/dashboard/src/api/attribution.ts
@@ -1,0 +1,66 @@
+// MASC Dashboard — Attribution REST client (Layer 4).
+//
+// Reads from the in-process ring buffer in `lib/dashboard/dashboard_attribution.ml`
+// via /api/v1/attribution/{recent,summary}. Plain types — no valibot schema yet
+// because the envelope is frozen at the OCaml side (Attribution.to_yojson) and
+// the dashboard is the only consumer.
+
+import { get, type GetOptions } from './core'
+
+export type AttributionOrigin = 'det' | 'nondet'
+
+export type AttributionOutcome =
+  | { kind: 'passed' }
+  | { kind: 'policy_failed'; reason: string }
+  | { kind: 'transition_blocked'; from_state: string; to_state: string; reason: string }
+  | { kind: 'partial_pass'; score: number; rationale: string }
+
+export interface Attribution {
+  origin: AttributionOrigin
+  gate: string
+  evidence: unknown
+  outcome: AttributionOutcome
+}
+
+export interface AttributionEvent {
+  attribution: Attribution
+  recorded_at: number
+}
+
+export interface AttributionRecentResponse {
+  events: AttributionEvent[]
+  count: number
+}
+
+export interface GateSummary {
+  gate: string
+  passed: number
+  policy_failed: number
+  transition_blocked: number
+  partial_pass: number
+  total: number
+}
+
+export interface AttributionSummaryResponse {
+  gates: GateSummary[]
+}
+
+export async function fetchAttributionSummary(
+  opts: GetOptions = {},
+): Promise<AttributionSummaryResponse> {
+  return get<AttributionSummaryResponse>('/api/v1/attribution/summary', opts)
+}
+
+export async function fetchAttributionRecent(
+  params: { gate?: string; limit?: number } = {},
+  opts: GetOptions = {},
+): Promise<AttributionRecentResponse> {
+  const sp = new URLSearchParams()
+  if (params.gate) sp.set('gate', params.gate)
+  if (params.limit !== undefined) sp.set('limit', String(params.limit))
+  const query = sp.toString()
+  const path = query
+    ? `/api/v1/attribution/recent?${query}`
+    : '/api/v1/attribution/recent'
+  return get<AttributionRecentResponse>(path, opts)
+}

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -1,0 +1,300 @@
+// Attribution Panel — Layer 4 observation surface.
+//
+// 관찰 대시보드. 4-field per event: 누가(gate) / 어디서(origin) / 뭘(outcome) /
+// 왜(reason). Graph instead of sankey — actual events don't carry correlation
+// ids yet, so per-gate card + recent-event list is the honest view.
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import {
+  fetchAttributionRecent,
+  fetchAttributionSummary,
+  type Attribution,
+  type AttributionEvent,
+  type AttributionSummaryResponse,
+  type GateSummary,
+} from '../api/attribution'
+import { SurfaceCard } from './common/card'
+import { ErrorState, LoadingState } from './common/feedback-state'
+import { EmptyState } from './common/empty-state'
+
+const POLL_INTERVAL_MS = 5_000
+const RECENT_LIMIT = 50
+
+// Known gates. Gates not yet wired (accountability, coord_task, etc.) will
+// show zero counts so the operator sees which sources are live.
+const KNOWN_GATES = [
+  'cdal_verdict',
+  'verification',
+  'keeper_fsm',
+  'worker_dev_tools',
+  'accountability',
+  'autoresearch',
+  'oas_completion',
+  'agent_lifecycle',
+] as const
+
+function outcomeLabel(a: Attribution): string {
+  switch (a.outcome.kind) {
+    case 'passed': return '통과'
+    case 'policy_failed': return '정책 실패'
+    case 'transition_blocked': return '전이 차단'
+    case 'partial_pass': return '부분 통과'
+  }
+}
+
+function outcomeToneClass(kind: Attribution['outcome']['kind']): string {
+  switch (kind) {
+    case 'passed': return 'text-emerald-400'
+    case 'policy_failed': return 'text-rose-400'
+    case 'transition_blocked': return 'text-rose-400'
+    case 'partial_pass': return 'text-amber-400'
+  }
+}
+
+function originBadgeClass(origin: Attribution['origin']): string {
+  return origin === 'det'
+    ? 'bg-sky-500/20 text-sky-300 border border-sky-500/40'
+    : 'bg-violet-500/20 text-violet-300 border border-violet-500/40'
+}
+
+function formatTs(recordedAt: number): string {
+  const d = new Date(recordedAt * 1000)
+  return d.toLocaleTimeString('ko-KR', { hour12: false })
+}
+
+function reasonOf(a: Attribution): string {
+  switch (a.outcome.kind) {
+    case 'policy_failed': return a.outcome.reason
+    case 'transition_blocked':
+      return `${a.outcome.from_state} → ${a.outcome.to_state}: ${a.outcome.reason}`
+    case 'partial_pass': return a.outcome.rationale
+    case 'passed': return ''
+  }
+}
+
+function GateCard({
+  gate, summary, onSelect,
+}: {
+  gate: string
+  summary: GateSummary | null
+  onSelect: () => void
+}) {
+  const isLive = summary !== null && summary.total > 0
+  const toneClass = isLive ? '' : 'opacity-50'
+  const passed = summary?.passed ?? 0
+  const policyFailed = summary?.policy_failed ?? 0
+  const blocked = summary?.transition_blocked ?? 0
+  const partial = summary?.partial_pass ?? 0
+  const total = summary?.total ?? 0
+
+  return html`
+    <button
+      type="button"
+      class="text-left w-full focus:outline-none focus:ring-2 focus:ring-sky-500/50 rounded-xl ${toneClass}"
+      onClick=${onSelect}
+    >
+      <${SurfaceCard} variant="compact">
+        <div class="flex flex-col gap-2">
+          <div class="flex items-baseline justify-between">
+            <span class="text-[12px] font-semibold tracking-tight">${gate}</span>
+            <span class="text-[10px] text-[var(--text-muted)]">${total}건</span>
+          </div>
+          <div class="grid grid-cols-2 gap-1 text-[11px]">
+            <span class="text-emerald-400">✓ ${passed}</span>
+            <span class="text-amber-400">◐ ${partial}</span>
+            <span class="text-rose-400">✗ ${policyFailed}</span>
+            <span class="text-rose-400">⊘ ${blocked}</span>
+          </div>
+        </div>
+      </${SurfaceCard}>
+    </button>
+  `
+}
+
+function EventRow({
+  event, onSelect, active,
+}: {
+  event: AttributionEvent
+  onSelect: () => void
+  active: boolean
+}) {
+  const a = event.attribution
+  const rowBg = active
+    ? 'bg-white/5'
+    : 'hover:bg-white/5'
+  return html`
+    <button
+      type="button"
+      class="w-full text-left px-3 py-2 border-b border-[var(--card-border)] flex items-center gap-3 text-[12px] ${rowBg}"
+      onClick=${onSelect}
+    >
+      <span class="text-[11px] font-mono text-[var(--text-muted)] w-20 shrink-0">
+        ${formatTs(event.recorded_at)}
+      </span>
+      <span class="text-[10px] px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)} shrink-0">
+        ${a.origin}
+      </span>
+      <span class="font-mono text-[11px] w-36 shrink-0">${a.gate}</span>
+      <span class="${outcomeToneClass(a.outcome.kind)} shrink-0 w-20">
+        ${outcomeLabel(a)}
+      </span>
+      <span class="text-[var(--text-muted)] truncate grow min-w-0">
+        ${reasonOf(a) || '—'}
+      </span>
+    </button>
+  `
+}
+
+function EvidenceDetail({ event }: { event: AttributionEvent | null }) {
+  if (!event) {
+    return html`
+      <${SurfaceCard} variant="light">
+        <${EmptyState} message="이벤트를 선택하면 evidence가 여기 표시됩니다." />
+      </${SurfaceCard}>
+    `
+  }
+  const a = event.attribution
+  const evidenceJson = JSON.stringify(a.evidence, null, 2)
+  return html`
+    <${SurfaceCard} variant="compact">
+      <div class="flex flex-col gap-3">
+        <div class="flex items-baseline gap-3 flex-wrap">
+          <span class="text-[11px] text-[var(--text-muted)]">${formatTs(event.recorded_at)}</span>
+          <span class="font-mono text-[13px] font-semibold">${a.gate}</span>
+          <span class="text-[10px] px-1.5 py-0.5 rounded ${originBadgeClass(a.origin)}">
+            ${a.origin}
+          </span>
+          <span class="${outcomeToneClass(a.outcome.kind)} text-[12px]">
+            ${outcomeLabel(a)}
+          </span>
+        </div>
+        ${reasonOf(a)
+          ? html`<div class="text-[12px] text-[var(--text-muted)]">${reasonOf(a)}</div>`
+          : null}
+        <pre class="text-[11px] font-mono bg-black/30 rounded p-3 overflow-x-auto max-h-64 whitespace-pre-wrap">${evidenceJson}</pre>
+      </div>
+    </${SurfaceCard}>
+  `
+}
+
+export function AttributionPanel() {
+  const summary = useSignal<AttributionSummaryResponse | null>(null)
+  const recent = useSignal<AttributionEvent[]>([])
+  const loading = useSignal(true)
+  const error = useSignal<string | null>(null)
+  const selectedEventIdx = useSignal<number | null>(null)
+  const filterGate = useSignal<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const ctl = new AbortController()
+
+    const load = async () => {
+      try {
+        const [s, r] = await Promise.all([
+          fetchAttributionSummary({ signal: ctl.signal }),
+          fetchAttributionRecent(
+            {
+              limit: RECENT_LIMIT,
+              ...(filterGate.value ? { gate: filterGate.value } : {}),
+            },
+            { signal: ctl.signal },
+          ),
+        ])
+        if (cancelled) return
+        summary.value = s
+        recent.value = r.events
+        error.value = null
+      } catch (e) {
+        if (cancelled || (e as Error).name === 'AbortError') return
+        error.value = (e as Error).message || 'attribution fetch failed'
+      } finally {
+        if (!cancelled) loading.value = false
+      }
+    }
+
+    load()
+    const iv = window.setInterval(load, POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      ctl.abort()
+      window.clearInterval(iv)
+    }
+  }, [filterGate.value])
+
+  if (loading.value && !summary.value) {
+    return html`<${LoadingState} message="attribution 로딩 중…" />`
+  }
+  if (error.value && !summary.value) {
+    return html`<${ErrorState} message=${error.value} />`
+  }
+
+  const byGate = new Map<string, GateSummary>()
+  for (const g of summary.value?.gates ?? []) byGate.set(g.gate, g)
+
+  const selected = selectedEventIdx.value !== null
+    ? recent.value[selectedEventIdx.value] ?? null
+    : null
+
+  return html`
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-1">
+        <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          Attribution — gate chain 관찰
+        </div>
+        <p class="m-0 text-[12px] leading-[1.55] text-[var(--text-muted)]">
+          각 gate의 결과 카운트 + 최근 ${RECENT_LIMIT}건 이벤트. 5초마다 자동 갱신.
+        </p>
+      </div>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        ${KNOWN_GATES.map(gate => html`
+          <${GateCard}
+            gate=${gate}
+            summary=${byGate.get(gate) ?? null}
+            onSelect=${() => {
+              filterGate.value = filterGate.value === gate ? null : gate
+              selectedEventIdx.value = null
+            }}
+          />
+        `)}
+      </div>
+
+      ${filterGate.value
+        ? html`
+          <div class="text-[11px] text-[var(--text-muted)]">
+            필터: <span class="font-mono text-[var(--text-primary)]">${filterGate.value}</span>
+            <button
+              class="ml-2 underline"
+              onClick=${() => { filterGate.value = null }}
+            >
+              해제
+            </button>
+          </div>`
+        : null}
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <${SurfaceCard} variant="light">
+          <div class="flex flex-col">
+            <div class="px-3 py-2 border-b border-[var(--card-border)] text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+              최근 이벤트 (${recent.value.length})
+            </div>
+            ${recent.value.length === 0
+              ? html`<${EmptyState} message="이벤트가 없습니다." />`
+              : recent.value.map((ev, idx) => html`
+                <${EventRow}
+                  event=${ev}
+                  active=${selectedEventIdx.value === idx}
+                  onSelect=${() => { selectedEventIdx.value = idx }}
+                />
+              `)}
+          </div>
+        </${SurfaceCard}>
+
+        <${EvidenceDetail} event=${selected} />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -9,15 +9,20 @@ import { RuntimePanel } from './runtime-panel'
 import { MemorySubsystems } from './memory-subsystems'
 import { FleetHealthPanel } from './fleet-health-panel'
 import { Observatory } from './observatory/observatory'
+import { AttributionPanel } from './attribution-panel'
 
-type StatusSection = 'observatory' | 'agents' | 'runtime' | 'fleet-health' | 'memory-subsystems'
+type StatusSection =
+  | 'observatory' | 'agents' | 'runtime' | 'fleet-health'
+  | 'memory-subsystems' | 'attribution'
 
 function currentSection(): StatusSection {
   const section = route.value.params.section
   if (
     section === 'observatory'
     || section === 'runtime'
-    || section === 'fleet-health' || section === 'memory-subsystems'
+    || section === 'fleet-health'
+    || section === 'memory-subsystems'
+    || section === 'attribution'
   ) return section
   return 'agents'
 }
@@ -36,6 +41,8 @@ export function Status() {
             ? html`<${FleetHealthPanel} />`
           : section === 'memory-subsystems'
             ? html`<${MemorySubsystems} />`
+          : section === 'attribution'
+            ? html`<${AttributionPanel} />`
             : html`<${AgentsUnified} />`}
       </div>
     </div>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -8,6 +8,7 @@ export type SurfaceSectionId =
   | 'runtime'
   | 'fleet-health'   // Phase 1: absorbs telemetry + fleet + tool-quality + monitoring governance
   | 'memory-subsystems'
+  | 'attribution'     // Layer 4 gate-chain observation (per-gate outcome + recent events)
   // command
   | 'operations'     // Phase 1+6: absorbs intervene + governance + connectors + inspector
   // workspace
@@ -142,6 +143,12 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
       label: '기억 서브시스템',
       description: 'Hebbian 시냅스 그래프, 에피소드 기록, compaction 상태.',
       params: { section: 'memory-subsystems' },
+    },
+    {
+      id: 'attribution',
+      label: 'Attribution',
+      description: 'gate별 pass/fail 카운트와 최근 이벤트. 누가·어디서·뭘·왜 4축으로 본다.',
+      params: { section: 'attribution' },
     },
   ],
   command: [

--- a/lib/worker_dev_tools.ml
+++ b/lib/worker_dev_tools.ml
@@ -1243,6 +1243,52 @@ let make_file_write ?workdir ?on_exec () =
              Error { Agent_sdk.Types.message =
                Printf.sprintf "Cannot write: %s" msg; recoverable = false })
 
+(* --- Attribution envelope conversion (Layer 1) ---
+   Shell command validation is a Det policy gate. The 7 block_reason
+   variants map uniformly to Policy_failed (no transition involved —
+   this is a pre-execution allow/deny check).
+
+   Defined before [make_shell_exec_with_allowlist] so the tool's
+   validation callsite can record the attribution without forward
+   referencing. *)
+
+let block_reason_tag = function
+  | Empty_command -> "empty_command"
+  | Chain_or_redirect -> "chain_or_redirect"
+  | Injection -> "injection"
+  | Process_substitution -> "process_substitution"
+  | Unsafe_redirect -> "unsafe_redirect"
+  | Pipes_not_allowed -> "pipes_not_allowed"
+  | Command_not_allowed _ -> "command_not_allowed"
+
+let attribution_of_validation ~cmd
+    (result : (unit, block_reason) result) : Attribution.t =
+  match result with
+  | Ok () ->
+    let evidence : Yojson.Safe.t =
+      `Assoc [ ("cmd", `String cmd) ]
+    in
+    Attribution.passed ~origin:Det ~gate:"worker_dev_tools" ~evidence
+  | Error br ->
+    let command_name =
+      match br with
+      | Command_not_allowed name -> Some name
+      | _ -> None
+    in
+    let evidence : Yojson.Safe.t =
+      `Assoc
+        ([
+           ("cmd", `String cmd);
+           ("block_reason", `String (block_reason_tag br));
+         ]
+         @
+         match command_name with
+         | Some n -> [ ("command_name", `String n) ]
+         | None -> [])
+    in
+    Attribution.policy_failed ~origin:Det ~gate:"worker_dev_tools"
+      ~evidence ~reason:(block_reason_to_string br)
+
 let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_commands
     ~description () =
   Agent_sdk.Tool.create
@@ -1261,7 +1307,12 @@ let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_c
        | Error e ->
          Error { Agent_sdk.Types.message = e; recoverable = false }
        | Ok command ->
-         (match validate_command_with_allowlist ~allowed_commands command with
+         let validation =
+           validate_command_with_allowlist ~allowed_commands command
+         in
+         Dashboard_attribution.record
+           (attribution_of_validation ~cmd:command validation);
+         (match validation with
           | Error reason ->
             Error { Agent_sdk.Types.message = block_reason_to_string reason; recoverable = false }
           | Ok () ->
@@ -1367,44 +1418,3 @@ let make_readonly_tools ~proc_mgr ~clock ?workdir ?on_exec () : Agent_sdk.Tool.t
   [ make_file_read ?workdir ?on_exec ();
     make_shell_exec_readonly ~workdir ~on_exec ~proc_mgr ~clock ]
 
-(* --- Attribution envelope conversion (Layer 1) ---
-   Shell command validation is a Det policy gate. The 7 block_reason
-   variants map uniformly to Policy_failed (no transition involved —
-   this is a pre-execution allow/deny check). *)
-
-let block_reason_tag = function
-  | Empty_command -> "empty_command"
-  | Chain_or_redirect -> "chain_or_redirect"
-  | Injection -> "injection"
-  | Process_substitution -> "process_substitution"
-  | Unsafe_redirect -> "unsafe_redirect"
-  | Pipes_not_allowed -> "pipes_not_allowed"
-  | Command_not_allowed _ -> "command_not_allowed"
-
-let attribution_of_validation ~cmd
-    (result : (unit, block_reason) result) : Attribution.t =
-  match result with
-  | Ok () ->
-    let evidence : Yojson.Safe.t =
-      `Assoc [ ("cmd", `String cmd) ]
-    in
-    Attribution.passed ~origin:Det ~gate:"worker_dev_tools" ~evidence
-  | Error br ->
-    let command_name =
-      match br with
-      | Command_not_allowed name -> Some name
-      | _ -> None
-    in
-    let evidence : Yojson.Safe.t =
-      `Assoc
-        ([
-           ("cmd", `String cmd);
-           ("block_reason", `String (block_reason_tag br));
-         ]
-         @
-         match command_name with
-         | Some n -> [ ("command_name", `String n) ]
-         | None -> [])
-    in
-    Attribution.policy_failed ~origin:Det ~gate:"worker_dev_tools"
-      ~evidence ~reason:(block_reason_to_string br)


### PR DESCRIPTION
## Summary

Two pieces of the Layer 4 attribution dashboard:

1. **Backend wire-up**: `worker_dev_tools.make_shell_exec_with_allowlist` records every `validate_command` result into the ring. Dashboard data sources now 4/8: cdal_verdict, verification, keeper_fsm, worker_dev_tools.

2. **Frontend panel**: `/monitoring?section=attribution`. 8 gate cards + recent 50 events + evidence detail. Click a card to filter events by gate; click an event to show evidence.

## Why not cytoscape?

Attribution events don't carry correlation ids — "gate A → gate B flow" can't be derived without event join. Sankey would be fabricated edges. The honest view is per-gate counters + event list, which is what this panel does. 0 KB bundle overhead vs ~300 KB for cytoscape, and matches `tailwind-only-dashboard` MEMORY.

## Commits

| Commit | What |
|--------|------|
| `bb68889` | OCaml: wire worker_dev_tools validation into Dashboard_attribution ring |
| `c3148f3` | Frontend: attribution panel + API client + navigation wire-up |

## Test plan

- [ ] CI green (OCaml + pnpm typecheck + lint all clean locally).
- [ ] Manual smoke: dev server → http://localhost:5173/#monitoring?section=attribution → cards render, event list populates after keeper transitions, clicking events shows evidence JSON.

## Follow-ups

- accountability wire-up (needs lifecycle restructure).
- autoresearch bridge wire-up (pending #7797 merge).
- coord_task (needs Attribution sub-library extraction).
- OAS gates (cross-repo).
- Evidence schema-aware renderer (currently JSON blob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)