### PR TITLE
docs(spec): drop stale server_command_plane_http.ml row

### DIFF
--- a/docs/spec/09-server-transport.md
+++ b/docs/spec/09-server-transport.md
@@ -863,7 +863,6 @@ sequenceDiagram
 | `server_auth.ml` | 491 | HTTP 레벨 인증/권한 |
 | `server_routes_http.ml` | 17 | 라우트 조립 진입점 |
 | `server_dashboard_http.ml` | 566 | Dashboard API 핸들러 |
-| `server_command_plane_http.ml` | 56 | Retired compatibility lane removed-surface responder |
 | `server_utils.ml` | 120 | 공용 유틸리티 |
 
 ### 18.3 gRPC (lib/grpc/)

--- a/scripts/check-doc-truth.sh
+++ b/scripts/check-doc-truth.sh
@@ -116,7 +116,7 @@ require_contains docs/spec/01-system-overview.md 'Historical compatibility lane(
 require_contains docs/spec/09-server-transport.md 'GET /api/v1/activity/events'
 require_contains docs/spec/09-server-transport.md '`MASC_USE_H2` | `auto`'
 require_contains docs/spec/09-server-transport.md '`MASC_GRPC_ENABLED` | 1'
-require_contains docs/spec/09-server-transport.md '| `server_command_plane_http.ml` | 56 | Retired compatibility lane removed-surface responder |'
+require_not_contains docs/spec/09-server-transport.md '| `server_command_plane_http.ml` |'
 require_not_contains docs/spec/09-server-transport.md 'GET /api/v1/activity/feed'
 require_not_contains docs/spec/09-server-transport.md '| Room | `/api/v1/room/*`'
 require_not_contains docs/spec/09-server-transport.md '| Command Plane (R) |'

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -127,9 +127,9 @@ let test_doc_truth_guard_contracts () =
   check bool "doc truth script protects system overview front door wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
        "### 7.3 Dashboard and Operator Read Visibility");
-  check bool "doc truth script protects transport removed-surface wording" true
+  check bool "doc truth script forbids dead server_command_plane_http row" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
-       "Retired compatibility lane removed-surface responder");
+       "require_not_contains docs/spec/09-server-transport.md '| `server_command_plane_http.ml` |'");
   check bool "doc truth script forbids old dashboard command-plane type wording" true
     (file_contains_pattern "scripts/check-doc-truth.sh"
        "command-plane.ts         -- Command plane types")


### PR DESCRIPTION
## Summary

`docs/spec/09-server-transport.md` claimed a module that no longer exists:

```
| `server_command_plane_http.ml` | 56 | Retired compatibility lane removed-surface responder |
```

`ls lib/server/server_command_plane_http.ml` → not found. The file was removed in the Command Plane purge series, but the module index row survived and a \`require_contains\` gate in \`check-doc-truth.sh\` was pinning the stale claim.

## Fix

- \`docs/spec/09-server-transport.md\`: drop the orphaned row
- \`scripts/check-doc-truth.sh\`: flip the gate from \`require_contains\` to \`require_not_contains\`, so a future edit cannot resurrect the dead reference

## Test plan
- [x] \`bash scripts/check-doc-truth.sh\` → Doc truth OK
- [x] spot-checked other rows in the same table — \`server_command_plane_http\` is the only missing file