### PR TITLE
chore(dashboard/ops): drop retired review_* switch cases from label helpers (Gen27)

### DIFF
--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -55,10 +55,6 @@ export function actionTypeLabel(value?: string | null): string {
       return '키퍼 점검'
     case 'keeper_recover':
       return '키퍼 복구'
-    case 'review_resolve':
-      return '검토 해결'
-    case 'review_defer':
-      return '검토 보류'
     default:
       return value?.trim() || '액션'
   }
@@ -74,8 +70,6 @@ export function targetTypeLabel(value?: string | null): string {
       return '프로젝트 범위'
     case 'keeper':
       return '키퍼'
-    case 'review_item':
-      return '리뷰 항목'
     case 'swarm_run':
       return '스웜 실행'
     default:


### PR DESCRIPTION
## Summary
- Remove 3 unreachable switch cases in \`ops/helpers.ts\`:
  - \`actionTypeLabel\`: \`review_resolve\` / \`review_defer\`
  - \`targetTypeLabel\`: \`review_item\`
- Backend stopped emitting these \`action_type\` / \`target_type\` values in Gen6 (#25) and Gen7 (#26). The FE helpers still mapped them to Korean labels, but the code path is unreachable — the \`default\` branch echoes the raw string if a stray value ever arrives, which is the intended behavior now.

## Not touched
- \`ops/index.ts\` \`reviewDecisionLabel\` / \`reviewDecisionTone\` are **live** — they operate on the distinct \`decision\` field (\`resolved\` / \`deferred\`) emitted by \`recent_review_decisions_json\` in \`operator_digest.ml\`. Kept intact.

## Test plan
- [x] \`npx vitest run dashboard/src/components/ops/\` → 3 files / 7 tests pass
- [x] Existing \`not.toContain('review_item')\` assertion in \`ops/index.test.ts:126\` still passes

## Context
Gen27 follow-up to the Gen6/Gen7 retirement sweep. 4-layer purge model caught BE emit + types + FE component + FE test — but missed **helper label dictionaries**. Same pattern as Gen19's BE-test miss. Documenting the helper layer for future sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)