### PR TITLE
feat(dashboard): A2A event timeline panel (LT-18)

### DIFF
--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -126,7 +126,10 @@ function FleetAndFsmHubPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <${FleetFsmMatrix} onSelectKeeper=${(name: string) => setPinned(name)} />
-      <${HandoffTimeline} />
+      <${HandoffTimeline}
+        onSelectKeeper=${(name: string) => setPinned(name)}
+        selectedKeeper=${pinned}
+      />
       <${CompositeFsmFlowchart} />
       <${FsmHub} selectedName=${pinned} />
     </div>

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -16,6 +16,7 @@ import { resolveRuntimeCounts } from '../runtime-counts'
 import { KeeperSpawnPanel } from './keeper-spawn/keeper-spawn-panel'
 import { FsmHub } from './fsm-hub'
 import { FleetFsmMatrix } from './fleet-fsm-matrix'
+import { HandoffTimeline } from './handoff-timeline'
 import { CompositeFsmFlowchart } from './composite-fsm-flowchart'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'fsm'
@@ -125,6 +126,7 @@ function FleetAndFsmHubPanel() {
   return html`
     <div class="flex flex-col gap-4">
       <${FleetFsmMatrix} onSelectKeeper=${(name: string) => setPinned(name)} />
+      <${HandoffTimeline} />
       <${CompositeFsmFlowchart} />
       <${FsmHub} selectedName=${pinned} />
     </div>

--- a/dashboard/src/components/handoff-timeline.test.ts
+++ b/dashboard/src/components/handoff-timeline.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import type { TelemetryEntry } from '../api/dashboard'
+import {
+  A2A_EVENT_TYPES,
+  CHIP_CLASS_BY_KIND,
+  deriveTimelineRows,
+  kindOfEventType,
+} from './handoff-timeline'
+
+function makeEntry(overrides: Partial<TelemetryEntry>): TelemetryEntry {
+  return {
+    source: 'oas_event',
+    event_type: 'agent_started',
+    agent_name: 'alpha',
+    ts_unix: 1_000_000,
+    ...overrides,
+  } as TelemetryEntry
+}
+
+describe('kindOfEventType', () => {
+  it('maps each declared A2A event type to a known kind', () => {
+    for (const et of A2A_EVENT_TYPES) {
+      const k = kindOfEventType(et)
+      expect(CHIP_CLASS_BY_KIND[k]).toBeDefined()
+      expect(k).not.toBe('unknown')
+    }
+  })
+
+  it('classifies failure separately from lifecycle', () => {
+    expect(kindOfEventType('agent_failed')).toBe('failure')
+    expect(kindOfEventType('agent_started')).toBe('lifecycle')
+    expect(kindOfEventType('turn_completed')).toBe('lifecycle')
+  })
+
+  it('classifies tool/handoff/context by prefix', () => {
+    expect(kindOfEventType('tool_called')).toBe('tool')
+    expect(kindOfEventType('handoff_requested')).toBe('handoff')
+    expect(kindOfEventType('context_compacted')).toBe('context')
+  })
+
+  it('falls back to unknown for unrecognised event types', () => {
+    expect(kindOfEventType('completely_new_event')).toBe('unknown')
+  })
+})
+
+describe('deriveTimelineRows', () => {
+  const WIN_START = 1_000_000_000
+  const WIN_END = 1_000_000_500
+  const WIN_START_MS = WIN_START * 1000
+  const WIN_END_MS = WIN_END * 1000
+
+  it('returns empty array when windowEnd <= windowStart', () => {
+    expect(deriveTimelineRows([], 100, 100)).toEqual([])
+    expect(deriveTimelineRows([], 200, 100)).toEqual([])
+  })
+
+  it('ignores entries that are not oas_event source', () => {
+    const entries = [
+      makeEntry({ source: 'keeper_metric' as TelemetryEntry['source'], ts_unix: WIN_START + 1 }),
+      makeEntry({ source: 'tool_usage' as TelemetryEntry['source'], ts_unix: WIN_START + 2 }),
+    ]
+    expect(deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)).toEqual([])
+  })
+
+  it('ignores entries with unknown event_type (not in A2A set)', () => {
+    const entries = [
+      makeEntry({ event_type: 'mystery_event', ts_unix: WIN_START + 1 }),
+    ]
+    expect(deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)).toEqual([])
+  })
+
+  it('ignores entries missing agent_name AND keeper_name', () => {
+    const entries = [
+      makeEntry({ agent_name: undefined, keeper_name: undefined, ts_unix: WIN_START + 1 }),
+    ]
+    expect(deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)).toEqual([])
+  })
+
+  it('groups events by agent_name and sorts chips ascending by timestamp', () => {
+    const entries = [
+      makeEntry({ agent_name: 'alpha', event_type: 'turn_completed', ts_unix: WIN_START + 10 }),
+      makeEntry({ agent_name: 'alpha', event_type: 'agent_started',  ts_unix: WIN_START + 5  }),
+      makeEntry({ agent_name: 'beta',  event_type: 'tool_called',     ts_unix: WIN_START + 20 }),
+    ]
+    const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
+    expect(rows.map(r => r.keeper)).toEqual(['alpha', 'beta'])
+    const alpha = rows[0]!
+    expect(alpha.chips.map(c => c.eventType)).toEqual(['agent_started', 'turn_completed'])
+    expect(alpha.chips[0]!.ts).toBeLessThan(alpha.chips[1]!.ts)
+  })
+
+  it('sorts rows by first-chip timestamp so earliest-active keeper is on top', () => {
+    const entries = [
+      makeEntry({ agent_name: 'late',    ts_unix: WIN_START + 100 }),
+      makeEntry({ agent_name: 'early',   ts_unix: WIN_START + 10  }),
+      makeEntry({ agent_name: 'middle',  ts_unix: WIN_START + 50  }),
+    ]
+    const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
+    expect(rows.map(r => r.keeper)).toEqual(['early', 'middle', 'late'])
+  })
+
+  it('filters chips outside [windowStart, windowEnd]', () => {
+    const entries = [
+      makeEntry({ agent_name: 'alpha', ts_unix: WIN_START - 1   }),
+      makeEntry({ agent_name: 'alpha', ts_unix: WIN_START + 10  }),
+      makeEntry({ agent_name: 'alpha', ts_unix: WIN_END   + 10  }),
+    ]
+    const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.chips).toHaveLength(1)
+  })
+
+  it('carries peerAgent from to_agent or from_agent for handoff events', () => {
+    const entries = [
+      makeEntry({
+        agent_name: 'alpha',
+        event_type: 'handoff_requested',
+        to_agent: 'beta',
+        ts_unix: WIN_START + 5,
+      }),
+      makeEntry({
+        agent_name: 'beta',
+        event_type: 'handoff_completed',
+        from_agent: 'alpha',
+        ts_unix: WIN_START + 8,
+      }),
+    ]
+    const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
+    const alphaPeer = rows.find(r => r.keeper === 'alpha')?.chips[0]?.peerAgent
+    const betaPeer  = rows.find(r => r.keeper === 'beta')?.chips[0]?.peerAgent
+    expect(alphaPeer).toBe('beta')
+    expect(betaPeer).toBe('alpha')
+  })
+
+  it('accepts keeper_name as a fallback when agent_name is missing', () => {
+    const entries = [
+      makeEntry({ agent_name: undefined, keeper_name: 'ani1999', ts_unix: WIN_START + 1 }),
+    ]
+    const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.keeper).toBe('ani1999')
+  })
+
+  it('classifies agent_failed chips as failure kind for red render', () => {
+    const entries = [
+      makeEntry({ event_type: 'agent_failed', ts_unix: WIN_START + 1 }),
+    ]
+    const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
+    expect(rows[0]!.chips[0]!.kind).toBe('failure')
+  })
+})

--- a/dashboard/src/components/handoff-timeline.test.ts
+++ b/dashboard/src/components/handoff-timeline.test.ts
@@ -3,8 +3,10 @@ import type { TelemetryEntry } from '../api/dashboard'
 import {
   A2A_EVENT_TYPES,
   CHIP_CLASS_BY_KIND,
+  deriveHandoffArcs,
   deriveTimelineRows,
   kindOfEventType,
+  type TimelineRow,
 } from './handoff-timeline'
 
 function makeEntry(overrides: Partial<TelemetryEntry>): TelemetryEntry {
@@ -147,5 +149,77 @@ describe('deriveTimelineRows', () => {
     ]
     const rows = deriveTimelineRows(entries, WIN_START_MS, WIN_END_MS)
     expect(rows[0]!.chips[0]!.kind).toBe('failure')
+  })
+})
+
+describe('deriveHandoffArcs', () => {
+  const WIN_START_MS = 1_000_000
+  const WIN_END_MS = 1_001_000
+
+  function row(keeper: string, chips: TimelineRow['chips']): TimelineRow {
+    return { keeper, chips }
+  }
+
+  it('returns empty when window is degenerate', () => {
+    expect(deriveHandoffArcs([], 100, 100)).toEqual([])
+    expect(deriveHandoffArcs([], 200, 100)).toEqual([])
+  })
+
+  it('produces one arc per handoff_requested with peer in rows', () => {
+    const rows: TimelineRow[] = [
+      row('alpha', [
+        { ts: WIN_START_MS + 200, eventType: 'handoff_requested', kind: 'handoff', peerAgent: 'beta' },
+      ]),
+      row('beta', [
+        { ts: WIN_START_MS + 400, eventType: 'handoff_completed', kind: 'handoff', peerAgent: 'alpha' },
+      ]),
+    ]
+    const arcs = deriveHandoffArcs(rows, WIN_START_MS, WIN_END_MS)
+    expect(arcs).toHaveLength(1)
+    expect(arcs[0]).toMatchObject({ fromIdx: 0, toIdx: 1, fromAgent: 'alpha', toAgent: 'beta' })
+    expect(arcs[0]!.xPct).toBeCloseTo(20, 2)
+  })
+
+  it('skips handoff_requested when peer is not in rows (peer drifted out of window)', () => {
+    const rows: TimelineRow[] = [
+      row('alpha', [
+        { ts: WIN_START_MS + 200, eventType: 'handoff_requested', kind: 'handoff', peerAgent: 'ghost' },
+      ]),
+    ]
+    expect(deriveHandoffArcs(rows, WIN_START_MS, WIN_END_MS)).toEqual([])
+  })
+
+  it('ignores handoff_completed — avoids double-drawing the mirror pair', () => {
+    const rows: TimelineRow[] = [
+      row('alpha', [
+        { ts: WIN_START_MS + 200, eventType: 'handoff_requested', kind: 'handoff', peerAgent: 'beta' },
+      ]),
+      row('beta', [
+        { ts: WIN_START_MS + 200, eventType: 'handoff_completed', kind: 'handoff', peerAgent: 'alpha' },
+      ]),
+    ]
+    const arcs = deriveHandoffArcs(rows, WIN_START_MS, WIN_END_MS)
+    expect(arcs).toHaveLength(1)
+  })
+
+  it('skips self-handoff (fromIdx == toIdx)', () => {
+    const rows: TimelineRow[] = [
+      row('alpha', [
+        { ts: WIN_START_MS + 200, eventType: 'handoff_requested', kind: 'handoff', peerAgent: 'alpha' },
+      ]),
+    ]
+    expect(deriveHandoffArcs(rows, WIN_START_MS, WIN_END_MS)).toEqual([])
+  })
+
+  it('ignores non-handoff chips on the same row', () => {
+    const rows: TimelineRow[] = [
+      row('alpha', [
+        { ts: WIN_START_MS + 100, eventType: 'tool_called',        kind: 'tool' },
+        { ts: WIN_START_MS + 200, eventType: 'handoff_requested', kind: 'handoff', peerAgent: 'beta' },
+      ]),
+      row('beta', []),
+    ]
+    const arcs = deriveHandoffArcs(rows, WIN_START_MS, WIN_END_MS)
+    expect(arcs).toHaveLength(1)
   })
 })

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -20,10 +20,10 @@
 //    matrix = "what state is entity E in?",
 //    timeline = "which events happened across entities, and when?".
 //
-// MVP scope: lifecycle chips per keeper row on a shared time axis.
-// Handoff arrow overlay (from_agent → to_agent) is out of scope for
-// this first iteration — the data flows through but renders as chips
-// on the relevant rows. Next iteration can add SVG arc overlays.
+// Iter 3: SVG arc overlay for `handoff_requested` chips. Each arc
+// links from_agent's row to to_agent's row at the handoff timestamp's
+// x-position. Dedup by requested-only (completed is the mirror pair).
+// `pointer-events: none` on the overlay so chips remain clickable.
 
 import { html } from 'htm/preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
@@ -139,6 +139,58 @@ export function deriveTimelineRows(
   return rows
 }
 
+export interface HandoffArc {
+  fromIdx: number
+  toIdx: number
+  xPct: number
+  ts: number
+  fromAgent: string
+  toAgent: string
+}
+
+// Pure arc deriver. Given the rendered rows (in their displayed order)
+// and the window, pick handoff_requested chips whose peerAgent exists
+// as another row, and return arcs with source/target row indices plus
+// the x% position. Single direction only (requested side) so each
+// logical handoff renders exactly once.
+export function deriveHandoffArcs(
+  rows: readonly TimelineRow[],
+  windowStart: number,
+  windowEnd: number,
+): HandoffArc[] {
+  const span = windowEnd - windowStart
+  if (span <= 0) return []
+  const idxByKeeper = new Map<string, number>()
+  rows.forEach((row, i) => idxByKeeper.set(row.keeper, i))
+  const arcs: HandoffArc[] = []
+  rows.forEach((row, fromIdx) => {
+    for (const chip of row.chips) {
+      if (chip.eventType !== 'handoff_requested') continue
+      const to = chip.peerAgent
+      if (!to) continue
+      const toIdx = idxByKeeper.get(to)
+      if (toIdx === undefined || toIdx === fromIdx) continue
+      arcs.push({
+        fromIdx,
+        toIdx,
+        xPct: ((chip.ts - windowStart) / span) * 100,
+        ts: chip.ts,
+        fromAgent: row.keeper,
+        toAgent: to,
+      })
+    }
+  })
+  return arcs
+}
+
+const ROW_HEIGHT_PX = 24
+const ROW_GAP_PX = 4
+const ROW_STRIDE_PX = ROW_HEIGHT_PX + ROW_GAP_PX
+
+function rowCenterY(idx: number): number {
+  return idx * ROW_STRIDE_PX + ROW_HEIGHT_PX / 2
+}
+
 interface Props {
   windowMs?: number
   pollMs?: number
@@ -226,7 +278,29 @@ export function HandoffTimeline({
         : rows.length === 0
           ? html`<p class="text-[11px] text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
           : html`
-              <div class="flex flex-col gap-1">
+              <div class="flex flex-col gap-1 relative">
+                ${(() => {
+                  const arcs = deriveHandoffArcs(rows, windowStart, windowEnd)
+                  if (arcs.length === 0) return null
+                  const totalH = rows.length * ROW_STRIDE_PX - ROW_GAP_PX
+                  return html`
+                    <svg
+                      class="absolute pointer-events-none"
+                      style=${`left: 140px; right: 0; top: 0; height: ${totalH}px`}
+                      preserveAspectRatio="none"
+                      aria-hidden="true"
+                    >
+                      ${arcs.map(a => html`
+                        <line
+                          x1=${`${a.xPct}%`} y1=${rowCenterY(a.fromIdx)}
+                          x2=${`${a.xPct}%`} y2=${rowCenterY(a.toIdx)}
+                          stroke="rgb(251 146 60)" stroke-width="1.5"
+                          stroke-dasharray="3,3" opacity="0.8"
+                        ><title>${`${a.fromAgent} → ${a.toAgent} · ${new Date(a.ts).toLocaleTimeString()}`}</title></line>
+                      `)}
+                    </svg>
+                  `
+                })()}
                 ${rows.map(row => {
                   const isSelected = selectedKeeper === row.keeper
                   const labelCls = isSelected

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -143,12 +143,16 @@ interface Props {
   windowMs?: number
   pollMs?: number
   maxEntries?: number
+  onSelectKeeper?: (name: string) => void
+  selectedKeeper?: string | null
 }
 
 export function HandoffTimeline({
   windowMs = 5 * 60 * 1000,
   pollMs = 5000,
   maxEntries = 500,
+  onSelectKeeper,
+  selectedKeeper = null,
 }: Props = {}) {
   const [entries, setEntries] = useState<TelemetryEntry[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -223,9 +227,22 @@ export function HandoffTimeline({
           ? html`<p class="text-[11px] text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
           : html`
               <div class="flex flex-col gap-1">
-                ${rows.map(row => html`
+                ${rows.map(row => {
+                  const isSelected = selectedKeeper === row.keeper
+                  const labelCls = isSelected
+                    ? 'text-text ring-1 ring-accent bg-accent/10'
+                    : 'text-text-muted hover:text-text hover:bg-bg-1/60'
+                  const clickable = typeof onSelectKeeper === 'function'
+                  const rowLabelCls =
+                    `w-32 shrink-0 truncate text-[11px] font-mono rounded px-1 ${labelCls}` +
+                    (clickable ? ' cursor-pointer' : '')
+                  return html`
                   <div class="flex items-center gap-3">
-                    <div class="w-32 shrink-0 truncate text-[11px] font-mono text-text-muted" title=${row.keeper}>
+                    <div
+                      class=${rowLabelCls}
+                      title=${row.keeper}
+                      onClick=${() => onSelectKeeper?.(row.keeper)}
+                    >
                       ${row.keeper}
                     </div>
                     <div class="relative flex-1 h-6 rounded-md bg-bg-1/40 border border-card-border/50">
@@ -244,7 +261,8 @@ export function HandoffTimeline({
                       })}
                     </div>
                   </div>
-                `)}
+                `
+                })}
               </div>
             `}
     </section>

--- a/dashboard/src/components/handoff-timeline.ts
+++ b/dashboard/src/components/handoff-timeline.ts
@@ -1,0 +1,252 @@
+// LT-18: A2A Event Timeline Panel.
+//
+// Multi-entity event sequence view. Rows are keepers; columns are time.
+// Companion to FleetFsmMatrix — matrix shows intra-entity orthogonal
+// FSM state, this panel shows inter-entity temporal relationships.
+//
+// Data source: OAS event_bus SSE relay (oas_sse_bridge.ml) which emits
+// agent_started/completed/failed, turn_started/completed, tool_called/
+// completed, handoff_requested/completed, context_compact_started/
+// context_compacted, context_overflow_imminent. Shipped via
+// /api/v1/dashboard/telemetry with source="oas_event".
+//
+// Design references:
+//  - Jaeger distributed-trace waterfall (entity row × time chip).
+//  - Bach et al. 2013 — small multiples beat animation for discrete
+//    state-change comprehension. This panel is juxtaposed with (not
+//    replacing) FleetFsmMatrix.
+//  - Harel 1987 orthogonal regions (matrix axes) × sequence diagram
+//    (this panel) = dual perspective on the same state space:
+//    matrix = "what state is entity E in?",
+//    timeline = "which events happened across entities, and when?".
+//
+// MVP scope: lifecycle chips per keeper row on a shared time axis.
+// Handoff arrow overlay (from_agent → to_agent) is out of scope for
+// this first iteration — the data flows through but renders as chips
+// on the relevant rows. Next iteration can add SVG arc overlays.
+
+import { html } from 'htm/preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+import { fetchTelemetry, type TelemetryEntry } from '../api/dashboard'
+
+export type A2aEventKind = 'lifecycle' | 'failure' | 'tool' | 'handoff' | 'context' | 'unknown'
+
+export const A2A_EVENT_TYPES = [
+  'agent_started',
+  'agent_completed',
+  'agent_failed',
+  'turn_started',
+  'turn_completed',
+  'tool_called',
+  'tool_completed',
+  'handoff_requested',
+  'handoff_completed',
+  'context_compact_started',
+  'context_compacted',
+  'context_overflow_imminent',
+] as const
+
+export function kindOfEventType(eventType: string): A2aEventKind {
+  if (eventType === 'agent_failed') return 'failure'
+  if (eventType.startsWith('tool_')) return 'tool'
+  if (eventType.startsWith('handoff_')) return 'handoff'
+  if (eventType.startsWith('context_')) return 'context'
+  if (eventType.startsWith('agent_') || eventType.startsWith('turn_')) return 'lifecycle'
+  return 'unknown'
+}
+
+export const CHIP_CLASS_BY_KIND: Record<A2aEventKind, string> = {
+  lifecycle: 'bg-emerald-400',
+  failure: 'bg-red-400',
+  tool: 'bg-sky-400',
+  handoff: 'bg-orange-400',
+  context: 'bg-purple-400',
+  unknown: 'bg-zinc-500',
+}
+
+export interface TimelineChip {
+  ts: number
+  eventType: string
+  kind: A2aEventKind
+  taskId?: string
+  peerAgent?: string
+}
+
+export interface TimelineRow {
+  keeper: string
+  chips: TimelineChip[]
+}
+
+function entryTimestampMs(entry: TelemetryEntry): number | null {
+  const rawUnix = entry.ts_unix ?? entry.ts ?? entry.timestamp
+  if (typeof rawUnix === 'number' && Number.isFinite(rawUnix)) {
+    return rawUnix < 1e12 ? rawUnix * 1000 : rawUnix
+  }
+  if (typeof entry.ts_iso === 'string') {
+    const parsed = Date.parse(entry.ts_iso)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function stringField(entry: TelemetryEntry, key: string): string | undefined {
+  const v = entry[key]
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+// Pure deriver — separated from the component so it can be structurally
+// unit-tested without rendering. Groups A2A events by keeper within the
+// given window and returns rows sorted by first-event time.
+export function deriveTimelineRows(
+  entries: readonly TelemetryEntry[],
+  windowStart: number,
+  windowEnd: number,
+): TimelineRow[] {
+  if (windowEnd <= windowStart) return []
+  const byKeeper = new Map<string, TimelineChip[]>()
+  for (const entry of entries) {
+    if (entry.source !== 'oas_event') continue
+    const eventType = stringField(entry, 'event_type')
+    if (!eventType) continue
+    if (!(A2A_EVENT_TYPES as ReadonlyArray<string>).includes(eventType)) continue
+    const ts = entryTimestampMs(entry)
+    if (ts === null || ts < windowStart || ts > windowEnd) continue
+    const keeper = stringField(entry, 'agent_name') ?? stringField(entry, 'keeper_name')
+    if (!keeper) continue
+    const chip: TimelineChip = {
+      ts,
+      eventType,
+      kind: kindOfEventType(eventType),
+      taskId: stringField(entry, 'task_id'),
+      peerAgent:
+        stringField(entry, 'to_agent') ??
+        stringField(entry, 'from_agent'),
+    }
+    const list = byKeeper.get(keeper)
+    if (list) list.push(chip)
+    else byKeeper.set(keeper, [chip])
+  }
+  const rows: TimelineRow[] = []
+  for (const [keeper, chips] of byKeeper) {
+    chips.sort((a, b) => a.ts - b.ts)
+    rows.push({ keeper, chips })
+  }
+  rows.sort((a, b) => {
+    const aFirst = a.chips[0]?.ts ?? Number.POSITIVE_INFINITY
+    const bFirst = b.chips[0]?.ts ?? Number.POSITIVE_INFINITY
+    return aFirst - bFirst || a.keeper.localeCompare(b.keeper)
+  })
+  return rows
+}
+
+interface Props {
+  windowMs?: number
+  pollMs?: number
+  maxEntries?: number
+}
+
+export function HandoffTimeline({
+  windowMs = 5 * 60 * 1000,
+  pollMs = 5000,
+  maxEntries = 500,
+}: Props = {}) {
+  const [entries, setEntries] = useState<TelemetryEntry[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [now, setNow] = useState<number>(() => Date.now())
+  const latestRequestId = useRef(0)
+
+  useEffect(() => {
+    let cancelled = false
+    const controller = new AbortController()
+    async function tick() {
+      const requestId = ++latestRequestId.current
+      try {
+        const res = await fetchTelemetry({
+          source: 'oas_event',
+          n: maxEntries,
+          signal: controller.signal,
+        })
+        if (cancelled || requestId !== latestRequestId.current) return
+        setEntries(res.entries)
+        setNow(Date.now())
+        setError(null)
+      } catch (e) {
+        if (cancelled) return
+        if ((e as Error).name === 'AbortError') return
+        setError(e instanceof Error ? e.message : String(e))
+      }
+    }
+    tick()
+    const id = window.setInterval(tick, pollMs)
+    return () => {
+      cancelled = true
+      controller.abort()
+      window.clearInterval(id)
+    }
+  }, [pollMs, maxEntries])
+
+  const windowEnd = now
+  const windowStart = now - windowMs
+  const rows = deriveTimelineRows(entries, windowStart, windowEnd)
+  const span = windowEnd - windowStart
+
+  return html`
+    <section class="rounded-xl border border-card-border bg-card-bg p-4 flex flex-col gap-3">
+      <header class="flex items-baseline justify-between">
+        <div>
+          <h3 class="text-sm font-semibold text-text">A2A Event Timeline</h3>
+          <p class="text-[11px] text-text-muted">
+            OAS event_bus → SSE relay. 최근 ${Math.round(windowMs / 1000 / 60)}분, keeper당 row.
+          </p>
+        </div>
+        <div class="flex gap-2 text-[10px] text-text-muted">
+          <span class="flex items-center gap-1">
+            <span class="w-2 h-2 rounded-full bg-emerald-400"></span>lifecycle
+          </span>
+          <span class="flex items-center gap-1">
+            <span class="w-2 h-2 rounded-full bg-sky-400"></span>tool
+          </span>
+          <span class="flex items-center gap-1">
+            <span class="w-2 h-2 rounded-full bg-orange-400"></span>handoff
+          </span>
+          <span class="flex items-center gap-1">
+            <span class="w-2 h-2 rounded-full bg-purple-400"></span>context
+          </span>
+          <span class="flex items-center gap-1">
+            <span class="w-2 h-2 rounded-full bg-red-400"></span>failure
+          </span>
+        </div>
+      </header>
+      ${error !== null
+        ? html`<p class="text-[11px] text-red-400">오류: ${error}</p>`
+        : rows.length === 0
+          ? html`<p class="text-[11px] text-text-dim">이 시간 범위에 A2A 이벤트 없음.</p>`
+          : html`
+              <div class="flex flex-col gap-1">
+                ${rows.map(row => html`
+                  <div class="flex items-center gap-3">
+                    <div class="w-32 shrink-0 truncate text-[11px] font-mono text-text-muted" title=${row.keeper}>
+                      ${row.keeper}
+                    </div>
+                    <div class="relative flex-1 h-6 rounded-md bg-bg-1/40 border border-card-border/50">
+                      ${row.chips.map(chip => {
+                        const pct = ((chip.ts - windowStart) / span) * 100
+                        const cls = CHIP_CLASS_BY_KIND[chip.kind]
+                        const peer = chip.peerAgent ? ` · ${chip.peerAgent}` : ''
+                        const task = chip.taskId ? ` · ${chip.taskId}` : ''
+                        return html`
+                          <span
+                            class="absolute top-1 bottom-1 w-[2px] ${cls} hover:w-1 transition-all cursor-default"
+                            style=${`left: ${pct}%;`}
+                            title=${`${new Date(chip.ts).toLocaleTimeString()} · ${chip.eventType}${peer}${task}`}
+                          ></span>
+                        `
+                      })}
+                    </div>
+                  </div>
+                `)}
+              </div>
+            `}
+    </section>
+  `
+}


### PR DESCRIPTION
## Summary

- Add **A2A Event Timeline** panel juxtaposed with the 6-axis FleetFsmMatrix. Matrix = intra-entity orthogonal state. Timeline = inter-entity temporal sequence.
- Consumes the OAS event_bus SSE relay (`lib/oas_sse_bridge.ml`) which now ships 12 event types (landed with #7812 / OAS#984 v0.155.0).
- Pure deriver `deriveTimelineRows` + thin `HandoffTimeline` component. 14 structural unit tests, 0 CSS, 0 SVG (SVG arc overlay deferred to next iteration).

## Visual model

```
FleetFsmMatrix   → 20 keepers × 6 axes × 30 chips  (intra-entity 4D)
   ↓
HandoffTimeline  → 20 keepers × 12 event types × time (inter-entity 4D)
   ↓
CompositeFsmFlowchart → static reference
   ↓
FsmHub → single-keeper detail
```

Wide → narrow scan order preserved.

## Design references

- Jaeger distributed-trace waterfall (entity row × time chip).
- Bach et al. 2013 — small multiples beat animation for discrete state-change comprehension; timeline is juxtaposed with (not replacing) the matrix.
- Harel 1987 orthogonal regions (matrix) × sequence diagram (timeline) = dual perspective on the same state space. Matrix answers *what state is entity E in?*; timeline answers *which events happened across entities, and when?*

## Scope

In:
- All 12 OAS event types relayed today (`agent_started/completed/failed`, `turn_started/completed`, `tool_called/completed`, `handoff_requested/completed`, `context_compact_started`, `context_compacted`, `context_overflow_imminent`).
- Keeper ordering by first-event time.
- 5-minute window, 5s polling.

Out:
- SVG arrow overlay between `from_agent` and `to_agent` rows for handoff events. Rationale: MASC keepers rarely emit OAS-level handoff today (MASC's own context handoff is a separate axis), so the arrow overlay adds limited immediate value. Peer agent is already carried on `chip.peerAgent` for the follow-up.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] 14/14 vitest structural cases pass on pure deriver
- [ ] CI green (Dashboard, Lint, Build and Test, Doc Truth, PR Hygiene)
- [ ] Manual smoke: `MASC server` running → open `/dashboard/` → Agents tab → timeline panel below matrix, populated with lifecycle chips as keepers run

🤖 Generated with [Claude Code](https://claude.com/claude-code)