### PR TITLE
feat(dashboard): CTX Composition latest breakdown에 세그먼트 필터 추가

### DIFF
--- a/dashboard/src/components/keeper-detail-panels.test.ts
+++ b/dashboard/src/components/keeper-detail-panels.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import type { PromptSegmentTelemetry } from '../types'
 import {
   ctxColor,
   ctxSegmentLabel,
@@ -8,6 +9,7 @@ import {
   formatFingerprint,
   formatSegmentLabel,
   miniSparkline,
+  filterCtxCompositionEntries,
 } from './keeper-detail-panels'
 
 // ── ctxColor ──────────────────────────────────────────────────
@@ -204,5 +206,88 @@ describe('miniSparkline', () => {
     // Math.max(...data, 1) = 1, so y = H - pad - (0/1)*(H-2*pad) = H-pad
     expect(result).toBeTruthy()
     expect(result.split(' ')).toHaveLength(3)
+  })
+})
+
+// ── filterCtxCompositionEntries ───────────────────────────────
+
+function seg(tokens: number): PromptSegmentTelemetry {
+  return { bytes: tokens * 4, estimated_tokens: tokens, fingerprint: null }
+}
+
+const ctxSample: ReadonlyArray<readonly [string, PromptSegmentTelemetry]> = [
+  ['system_prompt', seg(500)],
+  ['memory_context', seg(1200)],
+  ['history_tool_use', seg(800)],
+  ['history_tool_result', seg(3400)],
+  ['history_assistant_text', seg(200)],
+  ['user_message', seg(150)],
+  ['unattributed', seg(90)],
+  ['some_new_segment', seg(40)],
+]
+
+describe('filterCtxCompositionEntries', () => {
+  it('returns the input reference when query is empty', () => {
+    expect(filterCtxCompositionEntries(ctxSample, '')).toBe(ctxSample)
+  })
+
+  it('returns the input reference when query is whitespace', () => {
+    expect(filterCtxCompositionEntries(ctxSample, '   ')).toBe(ctxSample)
+  })
+
+  it('matches case-insensitive substring on raw key', () => {
+    const out = filterCtxCompositionEntries(ctxSample, 'HISTORY')
+    expect(out.map(([k]) => k)).toEqual([
+      'history_tool_use',
+      'history_tool_result',
+      'history_assistant_text',
+    ])
+  })
+
+  it('trims the query before matching', () => {
+    const out = filterCtxCompositionEntries(ctxSample, '  memory  ')
+    expect(out.map(([k]) => k)).toEqual(['memory_context'])
+  })
+
+  it('matches human label when raw key misses', () => {
+    // Raw key is `system_prompt`, label is `System prompt`.
+    // Searching for exactly `system prompt` (with the space) only hits the label.
+    const out = filterCtxCompositionEntries(ctxSample, 'system prompt')
+    expect(out.map(([k]) => k)).toEqual(['system_prompt'])
+  })
+
+  it('matches label for unknown keys via underscore-to-space fallback', () => {
+    // `some_new_segment` label is `some new segment` after fallback.
+    const out = filterCtxCompositionEntries(ctxSample, 'new segment')
+    expect(out.map(([k]) => k)).toEqual(['some_new_segment'])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterCtxCompositionEntries(ctxSample, 'nonexistent_bucket')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const snapshot = ctxSample.slice()
+    filterCtxCompositionEntries(ctxSample, 'history')
+    expect(ctxSample).toEqual(snapshot)
+    expect(ctxSample).toHaveLength(snapshot.length)
+  })
+
+  it('preserves original order of matched entries', () => {
+    const out = filterCtxCompositionEntries(ctxSample, 'history')
+    expect(out[0]?.[0]).toBe('history_tool_use')
+    expect(out[out.length - 1]?.[0]).toBe('history_assistant_text')
+  })
+
+  it('matches entries with non-matching tokens when the key contains the needle', () => {
+    // `unattributed` segment value is low but key still matches `attrib`.
+    const out = filterCtxCompositionEntries(ctxSample, 'attrib')
+    expect(out.map(([k]) => k)).toEqual(['unattributed'])
+  })
+
+  it('handles an empty input list', () => {
+    const empty: ReadonlyArray<readonly [string, PromptSegmentTelemetry]> = []
+    expect(filterCtxCompositionEntries(empty, 'history')).toEqual([])
+    expect(filterCtxCompositionEntries(empty, '')).toBe(empty)
   })
 })

--- a/dashboard/src/components/keeper-detail-panels.ts
+++ b/dashboard/src/components/keeper-detail-panels.ts
@@ -6,7 +6,7 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { formatPct, formatTokens } from '../lib/format-number'
 import { TextInput } from './common/input'
-import type { Keeper, KeeperMetricPoint } from '../types'
+import type { Keeper, KeeperMetricPoint, PromptSegmentTelemetry } from '../types'
 
 // ── Context pressure thresholds (shared across KPIs, charts) ─
 const CTX_CRITICAL_PCT = 85
@@ -60,6 +60,30 @@ export function ctxSegmentLabel(key: string): string {
 
 export function ctxSegmentColor(key: string): string {
   return CTX_SEGMENT_COLORS[key] ?? '#94a3b8'
+}
+
+/**
+ * Pure filter for CTX composition "latest breakdown" entries.
+ *
+ * Case-insensitive substring match against either the raw segment key
+ * (e.g. `history_tool_result`) or its human label (e.g. `History · tool result`).
+ * This lets operators search by either form — raw key is what shows up in
+ * backend logs, label is what the dashboard renders.
+ *
+ * Empty/whitespace query returns the input reference unchanged so the
+ * default render path avoids an unnecessary array allocation. Does not
+ * mutate the input.
+ */
+export function filterCtxCompositionEntries(
+  entries: ReadonlyArray<readonly [string, PromptSegmentTelemetry]>,
+  query: string,
+): ReadonlyArray<readonly [string, PromptSegmentTelemetry]> {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return entries
+  return entries.filter(([key]) => {
+    if (key.toLowerCase().includes(needle)) return true
+    return ctxSegmentLabel(key).toLowerCase().includes(needle)
+  })
 }
 
 
@@ -552,6 +576,7 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
     .filter(([, segment]) => (segment?.estimated_tokens ?? 0) > 0)
     .sort(([, left], [, right]) => (right.estimated_tokens ?? 0) - (left.estimated_tokens ?? 0))
   if (latestEntries.length === 0 || latestTotal <= 0) return null
+  const visibleCtxEntries = filterCtxCompositionEntries(latestEntries, ctxCompositionSearch.value)
 
   const allKeys = Array.from(
     new Set(points.flatMap((point: KeeperMetricPoint) => Object.keys(point.ctx_composition?.segments ?? {}))),
@@ -651,9 +676,25 @@ export function CtxCompositionPanel({ keeper }: { keeper: Keeper }) {
         </div>
 
         <div class="p-3 rounded-xl border border-[var(--card-border)] bg-[var(--white-3)]">
-          <div class="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-2">latest breakdown</div>
+          <div class="flex items-center justify-between gap-2 mb-2">
+            <span class="text-[10px] uppercase tracking-wider text-[var(--text-muted)]">latest breakdown</span>
+            <span class="text-[9px] font-mono text-[var(--text-dim)]">${visibleCtxEntries.length}/${latestEntries.length}</span>
+          </div>
+          <input
+            type="search"
+            value=${ctxCompositionSearch.value}
+            placeholder="세그먼트 필터 (예: history, memory)"
+            aria-label="context composition 세그먼트 필터"
+            onInput=${(e: Event) => { ctxCompositionSearch.value = (e.target as HTMLInputElement).value }}
+            class="mb-2 w-full rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
+          ${visibleCtxEntries.length === 0 ? html`
+            <div class="py-4 text-center text-[11px] text-[var(--text-dim)]">
+              필터 결과 없음 (${latestEntries.length} items)
+            </div>
+          ` : null}
           <div class="flex flex-col gap-1.5">
-            ${latestEntries.map(([key, segment]) => {
+            ${visibleCtxEntries.map(([key, segment]) => {
               const pct = latestTotal > 0 ? (segment.estimated_tokens / latestTotal) * 100 : 0
               return html`
                 <div class="flex items-center justify-between gap-2 text-[11px]">
@@ -878,6 +919,7 @@ export function MetricsCharts({ keeper }: { keeper: Keeper }) {
 // Primary display is handled by Header, KpiGrid, Profile, and Config sections.
 
 const fieldSearch = signal('')
+const ctxCompositionSearch = signal('')
 
 export function RawDataDebug({ keeper }: { keeper: Keeper }) {
   const filter = fieldSearch.value.toLowerCase()


### PR DESCRIPTION
## 요약

`CtxCompositionPanel`의 "latest breakdown" 카드에 세그먼트 필터를 추가했습니다. `keeper-detail-panels.ts`는 33개의 `.map` 사이트를 가진 996 LOC 파일이지만, 이 iteration에서는 **한 개의 리스트만** 대상으로 삼았습니다.

## 대상 리스트

`CtxCompositionPanel` 안의 `latestEntries` — 최근 turn의 context 구성을 세그먼트 단위로 풀어놓은 breakdown (라벨 + % + 토큰 수).

전형적으로 11개 이상의 세그먼트가 동시에 표시됩니다:
- `system_prompt`, `dynamic_context`, `memory_context`, `temporal_context`
- `user_message`
- `history_user`, `history_assistant_text`, `history_tool_use`, `history_tool_result`, `history_other`
- `unattributed`
- 알 수 없는 키가 추가되면 그대로 노출

Context bloat 원인을 찾을 때 tool_result나 memory 계열만 격리해서 보고 싶은 일이 반복적으로 생기지만 현재는 스크롤로만 처리할 수 있었습니다.

## 구현

- `filterCtxCompositionEntries(entries, query)` — pure helper. `trim().toLowerCase()` 후 빈 문자열이면 입력 ref를 그대로 반환. 첫 단계로 raw key에 substring match를 시도하고, 실패하면 `ctxSegmentLabel(key)`에 substring match. 둘 중 하나라도 통과하면 유지.
- `ctxCompositionSearch = signal('')` — 기존 `fieldSearch = signal('')` 과 같은 모듈 레벨 signal 스타일을 따릅니다. (이 파일은 `useState`/`useMemo`를 쓰지 않습니다.)
- `<input type="search">` + 한국어 placeholder `세그먼트 필터 (예: history, memory)`.
- 카드 헤더에 `N/total` 라이브 카운터.
- 필터 결과가 0일 때 `필터 결과 없음 (N items)` 빈 상태 — breakdown 자체의 `null` 케이스(`latestEntries.length === 0`)와 구분됩니다.

## 후보 탈락 근거

- **`PromptTelemetryPanel` latestSegments (line 513)**: Prompt segment는 보통 `system`/`tools` 수준 2–3개만 나옵니다. 카디널리티가 낮아서 필터의 실효성이 없음.
- **`MetricsCharts` modelSwitches (line 847)**: 전환이 발생한 turn만 모은 리스트라 이미 자체적으로 pruned. 필터를 얹으면 "전환만 본다"는 기존 UX와 충돌.
- **`MetricsCharts` fallback events (line 864)**: `.slice(-10)`으로 이미 컴팩트하게 잘라냅니다.

## 테스트

`dashboard/src/components/keeper-detail-panels.test.ts`에 `describe('filterCtxCompositionEntries', ...)` 11개:

1. empty query → 입력 ref 반환
2. whitespace query → 입력 ref 반환
3. case-insensitive raw-key 매치
4. query trim
5. raw-key 미스 + label 히트 (`system prompt`)
6. 알 수 없는 키의 underscore→space fallback 라벨 히트
7. 매치 없음 → 빈 배열
8. 입력 미변경 (snapshot 비교)
9. 매칭 결과의 원래 순서 보존
10. key에만 히트하는 짧은 토큰 (`attrib` → `unattributed`)
11. 빈 입력 리스트 처리

## 검증

- `pnpm exec tsc --noEmit` → clean
- `pnpm exec vitest run src/components/keeper-detail-panels.test.ts` → 46 pass (기존 35 + 신규 11)
- `pnpm exec eslint .` → 0 errors

## CI 주의

main CI는 별개의 `agent_sdk` version floor 이슈로 RED 상태입니다 (#7870에서 수정 중). 이 PR의 CI 실패는 상속 받은 것이며, 로컬 검증은 모두 통과합니다.

## 파일

- `dashboard/src/components/keeper-detail-panels.ts`
- `dashboard/src/components/keeper-detail-panels.test.ts`

Dashboard-only, 2 files. iter-8 / iter-12 패턴을 따름.