### PR TITLE
feat(dashboard): add keeper/tool/risk filter to governance approval queue

### DIFF
--- a/dashboard/src/components/governance.test.ts
+++ b/dashboard/src/components/governance.test.ts
@@ -1,7 +1,8 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import * as Vitest from 'vitest'
-import type { DashboardGovernanceResponse, GovernanceCaseBundle } from '../types'
+import type { DashboardGovernanceResponse, GovernanceCaseBundle, KeeperApprovalQueueItem } from '../types'
+import { filterApprovalQueue } from './governance'
 
 const { afterEach, beforeEach, describe, expect, it } = Vitest
 
@@ -569,4 +570,71 @@ describe('Governance surface', () => {
     expect(empty?.textContent).toContain('마지막 judge 활동')
     expect(empty?.textContent).not.toContain('오프라인')
   }, 20000)
+})
+
+describe('filterApprovalQueue', () => {
+  function makeItem(overrides: Partial<KeeperApprovalQueueItem> = {}): KeeperApprovalQueueItem {
+    return {
+      id: 'approval-x',
+      keeper_name: 'keeper-x',
+      tool_name: 'shell',
+      risk_level: 'medium',
+      requested_at: null,
+      waiting_s: 0,
+      ...overrides,
+    }
+  }
+
+  const items: readonly KeeperApprovalQueueItem[] = [
+    makeItem({ id: 'a', keeper_name: 'keeper-alpha', tool_name: 'shell', risk_level: 'critical' }),
+    makeItem({ id: 'b', keeper_name: 'keeper-beta', tool_name: 'fs_write', risk_level: 'high' }),
+    makeItem({ id: 'c', keeper_name: 'watcher-gamma', tool_name: 'shell', risk_level: 'medium' }),
+    makeItem({ id: 'd', keeper_name: 'watcher-delta', tool_name: 'http_fetch', risk_level: 'low' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterApprovalQueue(items, '')).toBe(items)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterApprovalQueue(items, '   ')).toBe(items)
+  })
+
+  it('matches by keeper_name substring (case-insensitive)', () => {
+    const result = filterApprovalQueue(items, 'KEEPER')
+    expect(result.map(item => item.id)).toEqual(['a', 'b'])
+  })
+
+  it('matches by tool_name substring', () => {
+    const result = filterApprovalQueue(items, 'shell')
+    expect(result.map(item => item.id)).toEqual(['a', 'c'])
+  })
+
+  it('matches by risk_level substring', () => {
+    const result = filterApprovalQueue(items, 'critical')
+    expect(result.map(item => item.id)).toEqual(['a'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterApprovalQueue(items, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterApprovalQueue(items, '  alpha  ')).toHaveLength(1)
+  })
+
+  it('matches high risk level without matching "high" in other fields', () => {
+    const result = filterApprovalQueue(items, 'high')
+    expect(result.map(item => item.id)).toEqual(['b'])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = items.slice()
+    filterApprovalQueue(items, 'alpha')
+    expect(items).toEqual(copy)
+  })
+
+  it('returns empty array for empty input with any query', () => {
+    expect(filterApprovalQueue([], 'anything')).toHaveLength(0)
+  })
 })

--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -1,6 +1,8 @@
 import { html } from 'htm/preact'
+import { useSignal } from '@preact/signals'
 import { AlertTriangle } from 'lucide-preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
+import type { KeeperApprovalQueueItem } from '../types'
 import { Card } from './common/card'
 import { KpiCard } from './common/stat-row'
 import { TimeAgo } from './common/time-ago'
@@ -471,6 +473,33 @@ function JudgmentsSection() {
   `
 }
 
+/**
+ * Pure filter for keeper HITL approval queue rows.
+ *
+ * Case-insensitive substring match on `keeper_name`, `tool_name`, and
+ * `risk_level` so operators can isolate one keeper, every pending call
+ * for a specific tool, or all rows at a given risk level (e.g. all
+ * `critical` approvals) from a long queue.
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * `useMemo` keeps referential equality on the non-filtering path.
+ *
+ * Input is never mutated; `KeeperApprovalQueueItem` is treated as readonly.
+ */
+export function filterApprovalQueue(
+  items: readonly KeeperApprovalQueueItem[],
+  query: string,
+): readonly KeeperApprovalQueueItem[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return items
+  return items.filter(item => {
+    if (item.keeper_name && item.keeper_name.toLowerCase().includes(needle)) return true
+    if (item.tool_name && item.tool_name.toLowerCase().includes(needle)) return true
+    if (item.risk_level && item.risk_level.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 export function approvalRiskToneClass(riskLevel: string): string {
   const normalized = riskLevel.trim().toLowerCase()
   if (normalized === 'critical') return 'border-bad/30 bg-bad/10 text-bad'
@@ -624,6 +653,12 @@ function KeeperApprovalQueueSection() {
   const actingId = governanceApprovalActing.value
   const maxRisk = maxApprovalRisk(items)
   const hasItems = items.length > 0
+  const query = useSignal('')
+  const visibleItems = useMemo(
+    () => filterApprovalQueue(items, query.value),
+    [items, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
   const countBadgeClass = hasItems
     ? (maxRisk === 'critical' || maxRisk === 'high'
         ? 'border-bad/40 bg-bad/15 text-bad text-[13px] px-3 py-1 font-extrabold'
@@ -640,11 +675,30 @@ function KeeperApprovalQueueSection() {
           ${items.length}건 대기
         </span>
       </div>
+      ${hasItems ? html`
+        <div class="mb-3 flex items-center gap-2">
+          <input
+            type="search"
+            value=${query.value}
+            placeholder="keeper / tool / 위험도 필터"
+            aria-label="Keeper HITL 승인 필터"
+            data-testid="keeper-hitl-approval-filter"
+            onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+            class="min-w-[160px] max-w-[280px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
+        </div>
+      ` : null}
       ${items.length === 0
         ? html`<${KeeperApprovalEmptyState} />`
-        : html`
+        : isFiltering && visibleItems.length === 0
+          ? html`
+              <div class="py-4 text-center text-[11px] text-[var(--text-dim)]" data-testid="keeper-hitl-approval-empty-filter">
+                필터 결과 없음 (${items.length} items)
+              </div>
+            `
+          : html`
             <div class="flex flex-col gap-3.5" data-testid="governance-approval-queue">
-              ${items.map(item => {
+              ${visibleItems.map(item => {
                 const disabled = actingId === item.id
                 return html`
                   <div class="rounded-xl border border-card-border bg-card/34 p-4 shadow-sm" data-testid="governance-approval-item">


### PR DESCRIPTION
## 요약

`governance.ts`의 **Keeper HITL 승인 대기** 리스트 (`approval_queue`, `KeeperApprovalQueueSection`)에 자유 텍스트 필터를 추가합니다. 여러 keeper가 동시에 threshold를 넘는 tool call을 올리면 대기열이 길어져, 특정 keeper·특정 tool·특정 위험도 행만 빠르게 좁힐 수단이 없었습니다.

## 왜 이 리스트인가

`governance.ts`의 4개 `.map` 사이트 중 후보:

- `governanceCaseDistribution` / `governanceStatusSegments` / `judgmentSignalDistribution` — aggregate 카운트, 리스트가 아님
- `DecisionInbox.items.map` — 이미 `FilterChips`(open/pending_ruling/needs_human_gate/executed/blocked) 로 상태 필터 존재
- `JudgmentsSection.judgments.map` — AI Judge 판단(최근 live feed), 사전 정렬/제한이 이미 서버측에서 수행됨
- `KeeperApprovalQueueSection.items.map` — **HITL 승인 큐, 고유 카디널리티 큼, `keeper_name`/`tool_name`/`risk_level` 모두 자유 텍스트, 필터 없음** ← 선택

위험도가 threshold를 넘은 tool call이 여러 건 쌓이면 operator가 스크롤로 해당 keeper를 찾아야 하므로, 이 리스트가 가장 필터 이득이 큽니다.

## 변경

- `filterApprovalQueue(items, query)` 순수 함수를 `governance.ts`에서 export. case-insensitive substring.
  - `keeper_name`, `tool_name`, `risk_level` 순서로 match; 하나라도 맞으면 포함.
- 빈/공백 query는 입력 참조를 그대로 반환 → `useMemo` 가 non-filter path에서 identity 유지.
- 입력 비변이 (`readonly KeeperApprovalQueueItem[]` 로 다룸).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 실제 큐 비어있음(`KeeperApprovalEmptyState`, judge 상태 안내) 과 구분.
- 검색 input은 큐에 항목이 있을 때만 표시. 빈 큐의 guidance(judge 오프라인/정상 등) 를 가리지 않도록.
- 한국어 placeholder: `keeper / tool / 위험도 필터`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/governance.test.ts`: 21/21 pass (기존 12 + 신규 9).
- `pnpm exec eslint .`: 0 errors.

신규 9건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive (`keeper_name`)
5. `tool_name` substring 매칭
6. `risk_level` 매칭 (`critical`)
7. no-match → 빈 배열
8. `risk_level` 단일 매치 (`high` — `critical`/`fs_write` 와 겹침 없는지 확인)
9. 입력 비변이
10. 빈 입력 배열 → 빈 결과

## CI 관련

**Main CI는 현재 agent_sdk version floor mismatch (#7870) 로 RED.** 이 PR은 해당 수정 병합 전까지 CI red를 상속합니다. Dashboard-only 변경이므로 OCaml/agent_sdk와 무관.

## 범위 제한

Dashboard 파일 2개만 수정. 다른 리스트(decision inbox, judgments) 는 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.