### PR TITLE
feat(dashboard): add name/model/task filter to agent-roster

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -6,8 +6,18 @@ import {
   uniqueToolNames,
   keeperRuntimeName,
   mergeRosterAgent,
+  filterAgentRoster,
 } from './agent-roster'
 import type { Agent } from '../types'
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    name: 'agent-x',
+    status: 'active',
+    current_task: null,
+    ...overrides,
+  }
+}
 
 describe('runtimeBadgeClass', () => {
   it('returns green classes for active', () => {
@@ -200,5 +210,68 @@ describe('mergeRosterAgent', () => {
     const next: Agent = { ...nextAgent, capabilities: ['tool-b'] }
     const result = mergeRosterAgent(existing, next)
     expect(result.capabilities).toEqual(['tool-b'])
+  })
+})
+
+describe('filterAgentRoster', () => {
+  const rows: Agent[] = [
+    makeAgent({ name: 'keeper-alpha', model: 'gpt-5.4', current_task: 'review PR #42' }),
+    makeAgent({ name: 'keeper-beta', model: 'claude-sonnet-4-6', current_task: null, koreanName: '베타' }),
+    makeAgent({ name: 'watcher-gamma', current_task: 'compact memory' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterAgentRoster(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterAgentRoster(rows, '   ')).toBe(rows)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterAgentRoster(rows, '  alpha  ')).toHaveLength(1)
+  })
+
+  it('matches by name substring (case-insensitive)', () => {
+    const result = filterAgentRoster(rows, 'KEEPER')
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.name)).toEqual(['keeper-alpha', 'keeper-beta'])
+  })
+
+  it('matches by model substring', () => {
+    const result = filterAgentRoster(rows, 'claude')
+    expect(result.map(r => r.name)).toEqual(['keeper-beta'])
+  })
+
+  it('matches by current_task substring', () => {
+    const result = filterAgentRoster(rows, 'compact')
+    expect(result.map(r => r.name)).toEqual(['watcher-gamma'])
+  })
+
+  it('matches by koreanName substring', () => {
+    const result = filterAgentRoster(rows, '베타')
+    expect(result.map(r => r.name)).toEqual(['keeper-beta'])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterAgentRoster(rows, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = rows.slice()
+    filterAgentRoster(rows, 'alpha')
+    expect(rows).toEqual(copy)
+  })
+
+  it('handles rows with null / missing optional fields safely', () => {
+    const input: Agent[] = [makeAgent({ name: 'orphan' })]
+    expect(filterAgentRoster(input, 'orphan')).toHaveLength(1)
+    expect(filterAgentRoster(input, 'anything-else')).toHaveLength(0)
+  })
+
+  it('handles empty rows array', () => {
+    const empty: Agent[] = []
+    expect(filterAgentRoster(empty, 'foo')).toHaveLength(0)
+    expect(filterAgentRoster(empty, '')).toBe(empty)
   })
 })

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -182,6 +182,34 @@ const FILTER_META: Record<StatusFilter, { label: string; description: string }> 
   },
 }
 
+/**
+ * Pure filter for agent roster rows.
+ *
+ * Case-insensitive substring match on `row.name`, `row.model`,
+ * `row.current_task`, and `row.koreanName` so operators can locate an
+ * agent/keeper by display name, by the model it runs, by its current
+ * task text, or by the Korean alias shown on the card.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no new
+ * array allocation, preserves referential equality for memoisation).
+ *
+ * Input is never mutated; `Agent` is treated as readonly.
+ */
+export function filterAgentRoster(
+  rows: readonly Agent[],
+  query: string,
+): readonly Agent[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(row => {
+    if (row.name.toLowerCase().includes(needle)) return true
+    if (row.model && row.model.toLowerCase().includes(needle)) return true
+    if (row.current_task && row.current_task.toLowerCase().includes(needle)) return true
+    if (row.koreanName && row.koreanName.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 export function uniqueToolNames(...groups: Array<string[] | null | undefined>): string[] {
   const seen = new Set<string>()
   const names: string[] = []
@@ -418,8 +446,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       if (filter !== 'all' && bandByAgent.get(a.name)?.key !== filter) return false
       if (normalizedSearch) {
         const terms = searchTermsByAgent.get(a.name) ?? [a.name.toLowerCase()]
-        if (!terms.some(term => term.includes(normalizedSearch))) {
-          return false
+        const identityMatch = terms.some(term => term.includes(normalizedSearch))
+        if (!identityMatch) {
+          // Fall back to the pure roster filter (model / current_task / koreanName).
+          const fieldMatch = filterAgentRoster([a], search).length === 1
+          if (!fieldMatch) return false
         }
       }
       return true
@@ -500,13 +531,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             </div>
 
             <label class="flex w-full flex-col gap-2 text-[11px] font-semibold tracking-[0.08em] text-[var(--text-muted)] uppercase">
-              <span>이름 또는 Runtime Alias</span>
+              <span>이름 / model / 작업</span>
               <${TextInput}
                 class="rounded-2xl bg-[var(--white-3)] px-4 py-3 text-[14px] text-[var(--text-body)] shadow-[inset_0_1px_0_var(--white-3)] focus:border-[var(--accent)] focus:shadow-[0_0_0_2px_var(--accent-soft)]"
                 name="agent_search"
-                ariaLabel="키퍼 또는 런타임 이름 검색"
+                ariaLabel="에이전트 이름 · 모델 · 작업 검색"
                 autoComplete="off"
-                placeholder="키퍼 이름 또는 runtime alias로 찾기"
+                placeholder="이름 · runtime alias · model · 작업으로 찾기"
                 value=${search}
                 onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
               />
@@ -765,9 +796,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         ${filtered.length === 0 ? html`
           <div class="col-span-full rounded-[var(--radius-xl)] border border-dashed border-[var(--ff-border-subtle)] bg-[var(--white-2)] px-6 py-10">
             <${EmptyState}
-              message=${showExecutionFallbackState && expectedScopedCount > 0
-                ? `${fallbackStateTitle}: ${countSourceLabel} 기준 ${scopeLabel}가 보이지만, 현재 조건에 맞는 상세 카드는 아직 없습니다.`
-                : '조건에 맞는 에이전트가 없습니다.'}
+              message=${normalizedSearch && scopedAgents.length > 0
+                ? `필터 결과 없음 (${scopedAgents.length} items)`
+                : showExecutionFallbackState && expectedScopedCount > 0
+                  ? `${fallbackStateTitle}: ${countSourceLabel} 기준 ${scopeLabel}가 보이지만, 현재 조건에 맞는 상세 카드는 아직 없습니다.`
+                  : '조건에 맞는 에이전트가 없습니다.'}
               compact
             />
           </div>


### PR DESCRIPTION
## 요약

`AgentRoster`의 **유일한 리스트**(agent/keeper 카드 그리드, `scopedAgents` → `filtered.map`)에 기존 이름/alias 검색에 더해 `model`·`current_task`·`koreanName` 매칭을 추가합니다. 기존 필터는 `keeperIdentitySearchTerms`로 primary name + runtime alias만 보았기 때문에 "claude-sonnet에 있는 키퍼 전부"나 "지금 memory compaction 돌고 있는 에이전트"를 찾으려면 카드를 눈으로 훑어야 했습니다.

## 왜 이 리스트인가

`agent-roster.ts`(776 LOC)의 7개 `.map` 호출부 중 후보는:

- `filtered.map` — **에이전트/키퍼 카드 그리드, 고유 카디널리티 최대, 검색 가능한 문자열 필드 다수(name/model/current_task/koreanName), 현재는 identity 기반 검색만 지원** ← 선택
- `statusChips`·`Object.entries(FILTER_META).map` — ≤5개 정적 칩
- 카드 내부 `.map`(tools, badges) — 카드 내 장식용 · 별도 검색 불필요

컴포넌트의 유일한 "많은 행" 리스트입니다. 기존 search 인풋(`useState('')`)이 이미 존재하므로 새 인풋 없이 기존 인풋의 커버리지만 확장합니다.

## 변경

- `filterAgentRoster(rows: readonly Agent[], query: string): readonly Agent[]` 순수 함수를 `agent-roster.ts`에서 export. case-insensitive substring.
  - `row.name`, `row.model`, `row.current_task`, `row.koreanName` 중 하나라도 매치하면 포함.
  - 빈/공백 query는 입력 참조를 그대로 반환 → non-filter path 추가 할당 없음.
  - 입력 비변이 (`readonly Agent[]`로 다룸).
- 기존 `searchTermsByAgent`(primary + runtime alias) 매칭은 그대로 유지. identity 매칭 실패 시에만 `filterAgentRoster([a], search).length === 1`로 fallback → 이전 동작 보존 + 신규 필드 추가.
- 필터가 모든 카드를 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 실제 데이터 없음·execution fallback과 구분.
- 인풋 placeholder / aria-label / span 업데이트: `이름 · runtime alias · model · 작업으로 찾기`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/agent-roster.test.ts`: 49 pass (기존 39 + 신규 10).
  1. 빈 query → 입력 참조 동일
  2. 공백만 있는 query → 입력 참조 동일
  3. trim 적용
  4. name case-insensitive
  5. model 필드 매칭
  6. current_task 필드 매칭
  7. koreanName 필드 매칭
  8. no-match → 빈 배열
  9. 입력 비변이
  10. 누락/null optional 필드 안전
  11. 빈 rows 배열 처리
- `pnpm exec eslint .`: 에러 0.

## 범위

Dashboard만, 파일 2개(`agent-roster.ts` + `agent-roster.test.ts`). 백엔드/타입/API 변경 없음. 기존 `useMemo` 패턴 유지, 인라인 filter — 렌더당 최대 수십~수백 agents 위에서 substring 몇 번으로 O(n·k), 충분히 가볍습니다.

Main CI는 현재 별도 이슈(agent_sdk version floor mismatch, #7870에서 수정 중)로 red 상태이므로 이 PR도 해당 fix 머지까지 CI fail을 상속합니다. 로컬 tsc/vitest/eslint 모두 clean.

Follows the iter-7/8/12/13 seed-hint pattern. Dashboard-only, 2 files.