### PR TITLE
feat(dashboard): add keeper-name filter to fsm-hub status bar

### DIFF
--- a/dashboard/src/components/fsm-hub.test.ts
+++ b/dashboard/src/components/fsm-hub.test.ts
@@ -12,6 +12,7 @@ import {
   deriveTimeAxisTicks,
   deriveTopTransitions,
   deriveTransitionHistory,
+  filterKeeperNames,
   flagTooltip,
   inferTransitionReason,
   invariantDescription,
@@ -576,5 +577,71 @@ describe('invariantDescription', () => {
 
   it('falls back to generic text for unknown keys', () => {
     expect(invariantDescription('mystery_invariant')).toMatch(/^Invariant defined by/)
+  })
+})
+
+describe('filterKeeperNames', () => {
+  const fleet: readonly string[] = [
+    'keeper-planner-agent',
+    'keeper-critic-agent',
+    'keeper-router-agent',
+    'keeper-autoresearch-agent',
+    'governance-keeper',
+  ]
+
+  it('returns the same reference when query is empty', () => {
+    expect(filterKeeperNames(fleet, '')).toBe(fleet)
+  })
+
+  it('returns the same reference when query is whitespace only', () => {
+    expect(filterKeeperNames(fleet, '   ')).toBe(fleet)
+  })
+
+  it('performs case-insensitive substring match', () => {
+    expect(filterKeeperNames(fleet, 'PLAN')).toEqual(['keeper-planner-agent'])
+    expect(filterKeeperNames(fleet, 'Critic')).toEqual(['keeper-critic-agent'])
+  })
+
+  it('matches multiple rows on a shared substring', () => {
+    const out = filterKeeperNames(fleet, 'keeper-')
+    expect(out).toHaveLength(4)
+    expect(out).toContain('keeper-planner-agent')
+    expect(out).not.toContain('governance-keeper')
+  })
+
+  it('matches substring that does not anchor on prefix', () => {
+    expect(filterKeeperNames(fleet, 'research')).toEqual(['keeper-autoresearch-agent'])
+    expect(filterKeeperNames(fleet, 'governance')).toEqual(['governance-keeper'])
+  })
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterKeeperNames(fleet, 'xyz-no-such-keeper')).toEqual([])
+  })
+
+  it('trims surrounding whitespace from the query', () => {
+    expect(filterKeeperNames(fleet, '  router  ')).toEqual(['keeper-router-agent'])
+  })
+
+  it('preserves input order of surviving rows', () => {
+    const out = filterKeeperNames(fleet, 'agent')
+    expect(out).toEqual([
+      'keeper-planner-agent',
+      'keeper-critic-agent',
+      'keeper-router-agent',
+      'keeper-autoresearch-agent',
+    ])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [...fleet]
+    const snapshot = [...input]
+    filterKeeperNames(input, 'critic')
+    expect(input).toEqual(snapshot)
+  })
+
+  it('returns input reference unchanged for empty query even when input is empty', () => {
+    const empty: readonly string[] = []
+    expect(filterKeeperNames(empty, '')).toBe(empty)
+    expect(filterKeeperNames(empty, 'anything')).toEqual([])
   })
 })

--- a/dashboard/src/components/fsm-hub.ts
+++ b/dashboard/src/components/fsm-hub.ts
@@ -83,6 +83,28 @@ export function shouldUseGateKeeperFallback(
   return !executionLoadedValue && storeNames.length === 0
 }
 
+/**
+ * Pure filter for the keeper tab list rendered in the FSM Hub status bar.
+ *
+ * Case-insensitive substring match on the full keeper name. Operators on a
+ * fleet with many keepers (keeper-planner-agent, keeper-critic-agent,
+ * keeper-router-agent, ...) otherwise scan the whole tab row to pick one.
+ *
+ * Empty/whitespace query returns the input reference unchanged so the
+ * caller's useMemo identity is preserved for the non-filtering path (no
+ * new array allocation, stable reference for downstream deps).
+ *
+ * Input is never mutated.
+ */
+export function filterKeeperNames(
+  names: readonly string[],
+  query: string,
+): readonly string[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return names
+  return names.filter(name => name.toLowerCase().includes(needle))
+}
+
 export function isCompositeFetchNotFound(err: unknown): boolean {
   return err instanceof Error && /composite fetch failed: 404$/.test(err.message)
 }
@@ -159,6 +181,7 @@ export function FsmHub(props: FsmHubProps = {}) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.selectedName])
   const [hub, dispatch] = useReducer(reduceHubState, initialHubState)
+  const [keeperFilter, setKeeperFilter] = useState('')
   const [pollTick, setPollTick] = useState(0)
   const [now, setNow] = useState(() => Date.now() / 1000)
   const [graphOpen, setGraphOpen] = useState(false)
@@ -306,6 +329,10 @@ export function FsmHub(props: FsmHubProps = {}) {
   const keeperNames = shouldUseGateKeeperFallback(executionLoadedValue, storeNames)
     ? gateKeeperNames
     : storeNames
+  const visibleKeeperNames = useMemo(
+    () => filterKeeperNames(keeperNames, keeperFilter),
+    [keeperNames, keeperFilter],
+  )
   const activeSelected = useMemo(() => {
     if (selected && keeperNames.includes(selected)) return selected
     return keeperNames[0] ?? null
@@ -422,6 +449,9 @@ export function FsmHub(props: FsmHubProps = {}) {
         density=${density}
         onDensityToggle=${() => setDensity(d => d === 'comfortable' ? 'compact' : 'comfortable')}
         keeperNames=${keeperNames}
+        visibleKeeperNames=${visibleKeeperNames}
+        keeperFilter=${keeperFilter}
+        onKeeperFilterChange=${setKeeperFilter}
         selected=${activeSelected}
         onSelect=${setSelected}
         loading=${loading}
@@ -576,6 +606,9 @@ function StatusBar({
   density,
   onDensityToggle,
   keeperNames,
+  visibleKeeperNames,
+  keeperFilter,
+  onKeeperFilterChange,
   selected,
   onSelect,
   loading,
@@ -591,6 +624,9 @@ function StatusBar({
   density: 'comfortable' | 'compact'
   onDensityToggle: () => void
   keeperNames: string[]
+  visibleKeeperNames: readonly string[]
+  keeperFilter: string
+  onKeeperFilterChange: (q: string) => void
   selected: string | null
   onSelect: (n: string) => void
   loading: boolean
@@ -600,6 +636,9 @@ function StatusBar({
   transitionCount: number
   observationCount: number
 }) {
+  const isFilteringKeepers = keeperFilter.trim() !== ''
+  const keeperFilterHasNoMatch =
+    isFilteringKeepers && visibleKeeperNames.length === 0 && keeperNames.length > 0
   const idleDuration = snapshot && !snapshot.is_live
     ? fmtDuration(Math.max(0, now - (snapshot.last_outcome?.ended_at ?? snapshot.ts)))
     : null
@@ -676,7 +715,21 @@ function StatusBar({
           ` : null}
         </div>
         <div class="flex items-center gap-1.5 flex-wrap" role="tablist" aria-label="Keeper 선택">
-          ${keeperNames.map((name, i) => {
+          ${keeperNames.length > 0 ? html`
+            <input
+              type="search"
+              value=${keeperFilter}
+              placeholder="keeper 이름 필터"
+              aria-label="Keeper 이름 필터"
+              onInput=${(e: Event) => onKeeperFilterChange((e.target as HTMLInputElement).value)}
+              class="min-w-[120px] max-w-[180px] rounded-full border border-[var(--white-10)] bg-[var(--white-3)] px-2.5 py-0.5 text-[10px] font-mono text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent-30)]"
+            />
+          ` : null}
+          ${keeperFilterHasNoMatch ? html`
+            <span class="text-[10px] font-mono text-[var(--text-dim)]">
+              필터 결과 없음 (${keeperNames.length} keepers)
+            </span>
+          ` : visibleKeeperNames.map((name, i) => {
             const active = name === selected
             const cls = active
               ? 'bg-[var(--accent-10)] border-[var(--accent-30)] text-[var(--accent)]'
@@ -691,13 +744,13 @@ function StatusBar({
                 title=${i < 9 ? `${name} — 단축키 ${i + 1}` : name}
                 onKeyDown=${(e: KeyboardEvent) => {
                   let next = -1
-                  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (i + 1) % keeperNames.length
-                  else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (i - 1 + keeperNames.length) % keeperNames.length
+                  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (i + 1) % visibleKeeperNames.length
+                  else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (i - 1 + visibleKeeperNames.length) % visibleKeeperNames.length
                   else if (e.key === 'Home') next = 0
-                  else if (e.key === 'End') next = keeperNames.length - 1
+                  else if (e.key === 'End') next = visibleKeeperNames.length - 1
                   if (next >= 0) {
                     e.preventDefault()
-                    const nextName = keeperNames[next]
+                    const nextName = visibleKeeperNames[next]
                     if (nextName) {
                       onSelect(nextName);
                       (e.currentTarget as HTMLElement)?.parentElement?.querySelectorAll<HTMLElement>('[role=tab]')[next]?.focus()


### PR DESCRIPTION
## 배경

FSM Hub 상태 바의 keeper tab 목록 (`dashboard/src/components/fsm-hub.ts:679`, 총 889 LOC / 9 `.map` 사이트) 은 fleet 규모가 커지면 가로 스크롤만 남고, 특정 keeper 를 빠르게 찾을 방법이 없었다. 이미 1-9 단축키와 방향키 내비게이션이 있지만 `keeper-planner-agent`, `keeper-critic-agent`, `keeper-router-agent`, `keeper-autoresearch-agent`, `governance-keeper` 처럼 prefix 가 겹치는 이름이 많을 때 여전히 눈으로 훑어야 한다. iter-7/8/9/11/12 seed-hint 를 따라 `fsm-hub` 한 개 파일에 하나의 리스트만 필터링한다.

## 후보 리스트

| 후보 | 출현 라인 | 선택 여부 | 이유 |
|------|-----------|-----------|------|
| keeper tab 목록 | 679 (StatusBar) | **선택** | 가장 상단 내비게이션, fleet 커질수록 필수 |
| shortcut 팝업 rows | 556 | X | 정적 리스트 5-10개, 필터 불필요 |
| broken invariants entries | 619 | X | 파생 리스트, StatusBar 뱃지용 |
| storeKeeperList, gateKeeperNames | 282, 292 | X | 이미 위 keeper tab 의 원본, 위에서 파생 |
| skeleton loaders (4곳) | 781/789/803/814 | X | 상수 placeholder |

→ keeper tab 목록 한 개만 필터링 대상.

## 변경

- 순수 함수 `filterKeeperNames(names, query): readonly string[]` 추가 (export).
  - Case-insensitive substring match on full keeper name.
  - Empty/whitespace query 는 입력 reference 를 그대로 반환하여 `useMemo` identity 를 유지.
  - 입력 배열은 mutate 하지 않음.
- `FsmHub` 에 `keeperFilter` useState + `visibleKeeperNames` useMemo 추가.
- `StatusBar` 에 `keeper 이름 필터` 검색 input 과 구분된 empty state (`필터 결과 없음 (N keepers)`) 추가.
- 방향키/Home/End 내비게이션이 filter 후 목록 기준으로 index 를 계산하므로 숨겨진 탭으로 focus 가 이동하지 않는다.
- `activeSelected` 계산은 unfiltered `keeperNames` 를 사용 — 필터를 지웠을 때 선택이 유지된다.

## 검증

- `pnpm exec tsc --noEmit` — pass
- `pnpm exec vitest run src/components/fsm-hub.test.ts` — 59 passed (기존 49 + 신규 10)
- `pnpm exec eslint .` — pass

## CI 주의

Main CI 가 현재 `agent_sdk` version floor 이슈 (#7870) 로 RED. 이 PR 도 머지 전까지 같은 OCaml 빌드 실패를 상속한다. Dashboard 변경만 포함하며 OCaml 코드는 건드리지 않는다.

## 테스트 플랜

- [ ] fleet 이 5+ keeper 일 때 입력 상자에 `planner`, `agent`, `governance` 등을 입력해 tab 축소 확인
- [ ] 필터 입력 후 매치 0개일 때 `필터 결과 없음 (N keepers)` 안내가 나오는지 확인
- [ ] 필터 적용 상태에서 방향키/Home/End 로 탐색 시 숨겨진 탭에 focus 가 들어가지 않는지 확인
- [ ] 필터를 지운 뒤 이전 선택이 유지되는지 확인