### PR TITLE
test(dashboard): sync governance risk muted tone expectations

### DIFF
--- a/dashboard/src/components/governance-risk.test.ts
+++ b/dashboard/src/components/governance-risk.test.ts
@@ -15,15 +15,15 @@ describe('approvalRiskToneClass', () => {
   })
 
   it('returns muted tone for low', () => {
-    expect(approvalRiskToneClass('low')).toBe('border-white/10 bg-white/5 text-text-muted')
+    expect(approvalRiskToneClass('low')).toBe('border-white/10 bg-[var(--white-3)] text-text-muted')
   })
 
   it('returns muted tone for unknown', () => {
-    expect(approvalRiskToneClass('unknown')).toBe('border-white/10 bg-white/5 text-text-muted')
+    expect(approvalRiskToneClass('unknown')).toBe('border-white/10 bg-[var(--white-3)] text-text-muted')
   })
 
   it('returns muted tone for empty string', () => {
-    expect(approvalRiskToneClass('')).toBe('border-white/10 bg-white/5 text-text-muted')
+    expect(approvalRiskToneClass('')).toBe('border-white/10 bg-[var(--white-3)] text-text-muted')
   })
 
   it('is case-insensitive', () => {


### PR DESCRIPTION
## Summary

Update `dashboard/src/components/governance-risk.test.ts` so the muted risk tone expectations match the current implementation in `approvalRiskToneClass`.

## Product impact

No runtime behavior change. This is a test-only fix that removes a baseline `Dashboard` CI failure affecting unrelated PRs.

## Evidence

- implementation currently returns `border-white/10 bg-[var(--white-3)] text-text-muted` for low / unknown / empty values in `dashboard/src/components/governance.ts`
- failing expectations were still asserting the older `bg-white/5` token in `dashboard/src/components/governance-risk.test.ts`
- reproduced on `main` before the fix with:
  - `cd dashboard && pnpm exec vitest run src/components/governance-risk.test.ts --no-file-parallelism --maxWorkers=1`

## Review evidence

Local verification on this branch:

- `cd dashboard && pnpm exec vitest run src/components/governance-risk.test.ts --no-file-parallelism --maxWorkers=1`
- `cd dashboard && pnpm run typecheck`

## Linked issue

Fixes #7873
