### PR TITLE
docs(architecture-analysis): mark tool_team_session split plan obsolete

### DIFF
--- a/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
+++ b/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
@@ -133,6 +133,11 @@ They have been retired from the active runtime surface, so the current complexit
 
 ## tool_team_session.ml Split Plan (4412 lines)
 
+> **Obsolete.** The entire `tool_team_session` surface was retired rather than
+> split; the module and its dispatcher no longer exist. Kept below as historical
+> context for the decision path that led from "split the 4412-line module" to
+> "remove the swarm-start front door entirely".
+
 Recommended 4-module split:
 
 | New module | Lines | Content |


### PR DESCRIPTION
## Summary

\`docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md\` dedicates a section to a 5-module split plan for \`tool_team_session.ml\`. That plan never ran — the entire \`team_session\` surface was retired, not split. The section read as live guidance even though the target module no longer exists.

## Fix

Add a 4-line blockquote at the top of the \"tool_team_session.ml Split Plan\" section marking it obsolete and framing it as historical decision context. The body is preserved.

## Out of scope

Other sections of this doc (Tier classification, Phased Reduction Plan checkboxes, TRPG note) were written 2026-03-16 and likely drifted further, but systematically refreshing them is a separate audit. This PR only flags the single section whose target no longer exists.

## Test plan
- [x] \`bash scripts/check-doc-truth.sh\` — Doc truth OK