### PR TITLE
feat(dashboard): add hypothesis/decision/cycle filter to autoresearch

### DIFF
--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -7,6 +7,7 @@ import type {
   AutoresearchLoopSummary,
   AutoresearchLoopsResponse,
 } from '../api/autoresearch'
+import { filterCycles } from './autoresearch'
 
 void vi
 
@@ -449,5 +450,76 @@ describe('Autoresearch surface refresh', () => {
     const settledRetryButton = Array.from(container.querySelectorAll('button'))
       .find(button => button.textContent?.includes('재시도')) as HTMLButtonElement | undefined
     expect(settledRetryButton?.disabled).toBe(false)
+  })
+})
+
+describe('filterCycles', () => {
+  function makeCycle(overrides: Partial<AutoresearchCycleRecord> = {}): AutoresearchCycleRecord {
+    return {
+      cycle: 1,
+      hypothesis: 'increase learning rate',
+      score_before: 0.5,
+      score_after: 0.6,
+      delta: 0.1,
+      decision: 'keep',
+      commit_hash: null,
+      elapsed_ms: 10,
+      model_used: 'glm',
+      timestamp: 1_717_000_000,
+      ...overrides,
+    }
+  }
+
+  const cycles: AutoresearchCycleRecord[] = [
+    makeCycle({ cycle: 1, hypothesis: 'increase learning rate', decision: 'keep' }),
+    makeCycle({ cycle: 2, hypothesis: 'swap optimizer to AdamW', decision: 'discard' }),
+    makeCycle({ cycle: 12, hypothesis: 'prune dropout layers', decision: 'keep' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterCycles(cycles, '')).toBe(cycles)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterCycles(cycles, '   ')).toBe(cycles)
+  })
+
+  it('matches by hypothesis substring (case-insensitive)', () => {
+    const result = filterCycles(cycles, 'LEARNING')
+    expect(result.map(c => c.cycle)).toEqual([1])
+  })
+
+  it('matches by raw decision token', () => {
+    const result = filterCycles(cycles, 'discard')
+    expect(result.map(c => c.cycle)).toEqual([2])
+  })
+
+  it('matches by Korean decision label 유지', () => {
+    const result = filterCycles(cycles, '유지')
+    expect(result.map(c => c.cycle)).toEqual([1, 12])
+  })
+
+  it('matches by Korean decision label 삭제', () => {
+    const result = filterCycles(cycles, '삭제')
+    expect(result.map(c => c.cycle)).toEqual([2])
+  })
+
+  it('matches by cycle number coerced to string', () => {
+    const result = filterCycles(cycles, '12')
+    expect(result.map(c => c.cycle)).toEqual([12])
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterCycles(cycles, 'nonexistent-token')).toHaveLength(0)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterCycles(cycles, '  optimizer  ').map(c => c.cycle)).toEqual([2])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = cycles.slice()
+    filterCycles(cycles, 'keep')
+    expect(cycles).toEqual(copy)
   })
 })

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -2,7 +2,8 @@
 // Displays loop overview, keep/discard ratio, cycle history, insights, and warnings.
 
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+import { useEffect, useMemo } from 'preact/hooks'
 import { isLoaded } from '../lib/async-state'
 import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
@@ -64,6 +65,33 @@ function statusColor(status: string): string {
 
 function decisionLabel(decision: string): string {
   return decision === 'keep' ? '유지' : '삭제'
+}
+
+/**
+ * Pure filter for autoresearch cycle history rows.
+ *
+ * Case-insensitive substring match on `hypothesis`, the decision label
+ * (both the raw `keep`/`discard` token and the Korean label `유지`/`삭제`),
+ * and the `cycle` number coerced to a string so operators can locate a
+ * cycle by partial hypothesis text, by keep/discard verdict, or by index.
+ *
+ * Empty/whitespace query returns the input reference unchanged so a
+ * useMemo-wrapped consumer keeps referential equality for the non-
+ * filtering path. Input is never mutated.
+ */
+export function filterCycles(
+  cycles: readonly AutoresearchCycleRecord[],
+  query: string,
+): readonly AutoresearchCycleRecord[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return cycles
+  return cycles.filter(cycle => {
+    if (cycle.hypothesis.toLowerCase().includes(needle)) return true
+    if (cycle.decision.toLowerCase().includes(needle)) return true
+    if (decisionLabel(cycle.decision).includes(needle)) return true
+    if (String(cycle.cycle).includes(needle)) return true
+    return false
+  })
 }
 
 function liveLabel(loop: Pick<AutoresearchLoopSummary, 'live'>): string {
@@ -211,44 +239,67 @@ function LoopOverview({ loop }: { loop: AutoresearchLoopSummary }) {
 }
 
 function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
+  const query = useSignal('')
+  const visibleCycles = useMemo(
+    () => filterCycles(cycles, query.value),
+    [cycles, query.value],
+  )
+  const isFiltering = query.value.trim() !== ''
+
   if (cycles.length === 0) {
     return html`<${EmptyState} message="사이클 기록이 없습니다." compact />`
   }
 
   return html`
-    <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded-lg border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
-      <table class="w-full text-xs">
-        <thead>
-          <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">#</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">가설</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이전</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이후</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">변화</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-center py-2.5 px-3 font-medium">판정</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${cycles.map(c => html`
-            <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
-              <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
-              <td class="py-2 px-3 text-[var(--text-body)] max-w-[200px] truncate" title=${c.hypothesis}>${c.hypothesis}</td>
-              <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
-              <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
-              <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
-              <td class="py-2 px-3 text-center">
-                <span class="px-1.5 py-0.5 rounded text-[10px] font-semibold ${
-                  c.decision === 'keep'
-                    ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
-                    : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
-                }">${decisionLabel(c.decision)}</span>
-              </td>
-              <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
-            </tr>
-          `)}
-        </tbody>
-      </table>
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-end">
+        <input
+          type="search"
+          value=${query.value}
+          placeholder="가설 / 판정 / # 필터"
+          aria-label="사이클 필터"
+          onInput=${(e: Event) => { query.value = (e.target as HTMLInputElement).value }}
+          class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && visibleCycles.length === 0
+        ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${cycles.length} cycles)</div>`
+        : html`
+          <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded-lg border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
+            <table class="w-full text-xs">
+              <thead>
+                <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">#</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">가설</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이전</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이후</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">변화</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-center py-2.5 px-3 font-medium">판정</th>
+                  <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
+                </tr>
+              </thead>
+              <tbody>
+                ${visibleCycles.map(c => html`
+                  <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
+                    <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
+                    <td class="py-2 px-3 text-[var(--text-body)] max-w-[200px] truncate" title=${c.hypothesis}>${c.hypothesis}</td>
+                    <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
+                    <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
+                    <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
+                    <td class="py-2 px-3 text-center">
+                      <span class="px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                        c.decision === 'keep'
+                          ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
+                          : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
+                      }">${decisionLabel(c.decision)}</span>
+                    </td>
+                    <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+          </div>
+        `}
     </div>
   `
 }


### PR DESCRIPTION
## 무엇이 바뀌나

Autoresearch surface의 `사이클 이력` 테이블에 검색/필터를 추가합니다. 장기 실행 autoresearch 루프는 수백 개의 cycle record을 쌓고, 지금은 400px 스크롤 컨테이너가 특정 hypothesis, 연속 discard 구간, 또는 cycle 번호를 찾는 유일한 수단입니다.

`dashboard/src/components/autoresearch.ts` (527 LOC, 5 `.map` 사이트) 중 `CycleHistoryTable`의 `cycles.map` 하나만 건드립니다 — 가장 카디널리티가 높고, 가장 풍부한 검색 가능 필드(hypothesis 자유 텍스트, decision verdict, cycle index)를 가진 리스트입니다.

## 구현

- 순수 함수 `filterCycles(cycles, query)` 추가 (파일 내 export).
  - Case-insensitive substring 매칭: `hypothesis`, raw `decision` 토큰 (`keep`/`discard`), 한국어 라벨 (`유지`/`삭제`), `cycle` 번호 → 문자열 강제.
  - 빈/공백 query는 입력 참조를 그대로 반환하여 useMemo의 참조 동등성을 유지.
  - 입력 불변. 반환 타입 `readonly AutoresearchCycleRecord[]`.
- `CycleHistoryTable`에 `useSignal('')` 쿼리 + `useMemo` visibleCycles + `<input type="search">`.
- 필터 결과 0건이면 테이블 대신 `필터 결과 없음 (N cycles)` 빈 상태 표시.

## 선택한 리스트 근거

| 후보 리스트 | 카디널리티 | 검색 필드 | 선택? |
|-----------|---------|---------|------|
| `authors.map` (LoopSelector) | 소수 저자 | string | ✗ 카디널리티 낮음 |
| `loops.map` (LoopSelector) | 중간 | loop_id/status | ✗ 이미 author 필터 존재 |
| **`cycles.map` (CycleHistoryTable)** | **수백개** | **hypothesis/decision/cycle** | **✓** |
| `insights.map` (InsightsList) | 소수 | string | ✗ 카디널리티 낮음 |
| `warnings.map` (WarningsList) | 소수 | string | ✗ 카디널리티 낮음 |

## 테스트

- `filterCycles` 단위 테스트 9건: 빈 query 참조 보존, 공백 trim, case-insensitive hypothesis, raw `discard`, 한국어 `유지`/`삭제`, cycle 번호, no-match, trim, 입력 non-mutation.
- 기존 surface 테스트 8건 그대로 통과.

```
Test Files  1 passed (1)
     Tests  18 passed (18)
```

## 검증

- `pnpm exec tsc --noEmit` → EXIT 0
- `pnpm exec vitest run src/components/autoresearch.test.ts` → 18 passed
- `pnpm exec eslint .` → EXIT 0

## 제약

- Dashboard 전용, 2 파일(`autoresearch.ts`, `autoresearch.test.ts`)만 수정.
- ONE list (cycle history) 만 필터 적용. 다른 4개 `.map` 사이트는 건드리지 않음.
- iter-8/11/12 seed-hint 패턴 (#7846, #7850) 추종.