### PR TITLE
feat(dashboard): add id/preview/summary filter to OAS snapshot history in keeper-detail

### DIFF
--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -24,9 +24,11 @@ vi.mock('../keeper-runtime', () => ({
 
 import {
   closeKeeperDetail,
+  filterCheckpointHistory,
   openKeeperDetail,
   selectedKeeper,
 } from './keeper-detail'
+import type { KeeperCheckpointSummary } from '../api/keeper'
 
 describe('openKeeperDetail', () => {
   beforeEach(() => {
@@ -60,5 +62,107 @@ describe('openKeeperDetail', () => {
 
     expect(selectedKeeper.value).toBeNull()
     expect(mocks.resetKeeperConfig).toHaveBeenCalledTimes(1)
+  })
+})
+
+function makeSummary(overrides: Partial<KeeperCheckpointSummary> = {}): KeeperCheckpointSummary {
+  return {
+    snapshot_id: 'snap-000',
+    source_kind: 'oas_history',
+    is_current: false,
+    path: '/tmp/snap-000.json',
+    created_at: 1_700_000_000,
+    generation: 1,
+    message_count: 10,
+    system_prompt_present: true,
+    latest_preview: null,
+    continuity_summary: null,
+    file_stat: null,
+    ...overrides,
+  }
+}
+
+describe('filterCheckpointHistory', () => {
+  const rows: readonly KeeperCheckpointSummary[] = [
+    makeSummary({
+      snapshot_id: 'snap-abc123',
+      source_kind: 'oas_history',
+      latest_preview: '유저 질문에 답변 완료',
+      continuity_summary: 'Keeper heartbeat stable',
+    }),
+    makeSummary({
+      snapshot_id: 'snap-def456',
+      source_kind: 'oas_current',
+      latest_preview: 'Compaction triggered',
+      continuity_summary: null,
+    }),
+    makeSummary({
+      snapshot_id: 'snap-ghi789',
+      source_kind: 'oas_history',
+      latest_preview: null,
+      continuity_summary: null,
+    }),
+  ]
+
+  it('returns the input reference for empty query (no allocation)', () => {
+    expect(filterCheckpointHistory(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterCheckpointHistory(rows, '   \t\n ')).toBe(rows)
+  })
+
+  it('matches by snapshot_id substring (case-insensitive)', () => {
+    const result = filterCheckpointHistory(rows, 'ABC')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.snapshot_id).toBe('snap-abc123')
+  })
+
+  it('matches by source_kind', () => {
+    const result = filterCheckpointHistory(rows, 'oas_current')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.snapshot_id).toBe('snap-def456')
+  })
+
+  it('matches by latest_preview text including Korean', () => {
+    const result = filterCheckpointHistory(rows, '답변')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.snapshot_id).toBe('snap-abc123')
+  })
+
+  it('matches by continuity_summary', () => {
+    const result = filterCheckpointHistory(rows, 'heartbeat')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.snapshot_id).toBe('snap-abc123')
+  })
+
+  it('trims the query before matching', () => {
+    const result = filterCheckpointHistory(rows, '  compaction  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.snapshot_id).toBe('snap-def456')
+  })
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterCheckpointHistory(rows, 'no-such-token')).toEqual([])
+  })
+
+  it('does not mutate the input array or its elements', () => {
+    const snapshot = rows.map(r => ({ ...r }))
+    filterCheckpointHistory(rows, 'abc')
+    expect(rows.map(r => ({ ...r }))).toEqual(snapshot)
+  })
+
+  it('handles rows with null preview and null continuity_summary without throwing', () => {
+    const onlyNulls: readonly KeeperCheckpointSummary[] = [
+      makeSummary({ snapshot_id: 'snap-null', latest_preview: null, continuity_summary: null }),
+    ]
+    expect(() => filterCheckpointHistory(onlyNulls, 'missing')).not.toThrow()
+    expect(filterCheckpointHistory(onlyNulls, 'missing')).toEqual([])
+    expect(filterCheckpointHistory(onlyNulls, 'null')).toHaveLength(1)
+  })
+
+  it('preserves the original order of matching rows', () => {
+    const result = filterCheckpointHistory(rows, 'snap-')
+    expect(result.map(r => r.snapshot_id)).toEqual(['snap-abc123', 'snap-def456', 'snap-ghi789'])
   })
 })

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -385,6 +385,34 @@ function formatCheckpointTime(timestamp: number): string {
   })
 }
 
+/**
+ * Pure filter for OAS snapshot history rows.
+ *
+ * Case-insensitive substring match on `snapshot_id`, `source_kind`,
+ * `latest_preview`, and `continuity_summary` so operators can locate a
+ * snapshot by partial id, by the preview/summary text that described the
+ * turn, or by its source kind (`oas_current` / `oas_history`).
+ *
+ * Empty/whitespace query returns the input reference unchanged (no new
+ * array allocation, preserves referential equality for memoisation).
+ *
+ * Input is never mutated. Treats `null` fields defensively.
+ */
+export function filterCheckpointHistory(
+  rows: readonly KeeperCheckpointSummary[],
+  query: string,
+): readonly KeeperCheckpointSummary[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter(row => {
+    if (row.snapshot_id.toLowerCase().includes(needle)) return true
+    if (row.source_kind && row.source_kind.toLowerCase().includes(needle)) return true
+    if (row.latest_preview && row.latest_preview.toLowerCase().includes(needle)) return true
+    if (row.continuity_summary && row.continuity_summary.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 function CheckpointSummaryCard({
   title,
   summary,
@@ -433,6 +461,7 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
   const [error, setError] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [deleting, setDeleting] = useState(false)
+  const [historyQuery, setHistoryQuery] = useState('')
 
   const loadInventory = () => {
     void (async () => {
@@ -548,14 +577,33 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
       />
 
       <div class="rounded-xl border border-[var(--card-border)] bg-[var(--white-2)]">
-        <div class="border-b border-[var(--card-border)] px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
-          OAS Snapshot History
+        <div class="flex flex-wrap items-center justify-between gap-2 border-b border-[var(--card-border)] px-3 py-2">
+          <div class="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            OAS Snapshot History
+            ${inventory && inventory.history.length > 0 && historyQuery.trim() !== ''
+              ? html`<span class="ml-2 text-[10px] font-normal normal-case tracking-normal text-[var(--text-dim)]">${filterCheckpointHistory(inventory.history, historyQuery).length}/${inventory.history.length}</span>`
+              : null}
+          </div>
+          <input
+            type="search"
+            value=${historyQuery}
+            placeholder="snapshot id / preview / 요약 필터"
+            aria-label="OAS snapshot history 필터"
+            onInput=${(e: Event) => { setHistoryQuery((e.target as HTMLInputElement).value) }}
+            class="min-w-[160px] max-w-[260px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
         </div>
         ${!inventory || inventory.history.length === 0
           ? html`<div class="px-3 py-3 text-[12px] text-[var(--text-muted)]">저장된 OAS history snapshot이 아직 없습니다.</div>`
-          : html`
+          : (() => {
+              const visibleHistory = filterCheckpointHistory(inventory.history, historyQuery)
+              const isFiltering = historyQuery.trim() !== ''
+              if (isFiltering && visibleHistory.length === 0) {
+                return html`<div class="px-3 py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${inventory.history.length} items)</div>`
+              }
+              return html`
               <div class="flex flex-col">
-                ${inventory.history.map(item => html`
+                ${visibleHistory.map(item => html`
                   <label class="flex gap-3 border-b border-[var(--card-border)] px-3 py-3 text-[12px] last:border-b-0">
                     <input
                       type="checkbox"
@@ -590,7 +638,8 @@ function KeeperCheckpointPanel({ keeperName, refreshToken }: { keeperName: strin
                   </label>
                 `)}
               </div>
-            `}
+            `
+            })()}
       </div>
     </div>
   `


### PR DESCRIPTION
## 요약

`keeper-detail.ts`의 `KeeperCheckpointPanel`이 렌더링하는 **OAS Snapshot History** 리스트에 search/filter를 추가했습니다. 이 파일은 1207 LOC, 5개의 `.map` 사이트를 가진 가장 큰 dashboard 컴포넌트입니다. `keeper-detail-panels.ts`(iter22 #7875)와는 **다른 파일**입니다.

## 대상 리스트

`KeeperCheckpointPanel` 안의 `inventory.history` — keeper별로 저장된 OAS snapshot history. 장기 실행 keeper에서는 이 리스트가 overlay 영역을 한참 넘어 스크롤되고, 특정 snapshot을 id 조각이나 preview/continuity 문구로 찾아낼 방법이 없었습니다.

각 row의 rich 필드:
- `snapshot_id` (e.g. `snap-abc123`)
- `source_kind` (`oas_current` / `oas_history`)
- `latest_preview` (turn의 마지막 내용 스니펫, 한국어 포함 가능)
- `continuity_summary` (keeper continuity 요약, 여러 줄)

## 구현

- `filterCheckpointHistory(rows, query)` — pure helper. `trim().toLowerCase()` 후 빈 문자열이면 입력 ref를 그대로 반환. `snapshot_id` → `source_kind` → `latest_preview` → `continuity_summary` 순으로 case-insensitive substring match, 첫 매치에서 통과.
- `historyQuery`는 `useState('')`. 이 파일은 이미 `useState`/`useEffect` 스타일을 쓰고 있으며 `useMemo`/`useSignal`은 사용하지 않습니다 (기존 스타일 준수).
- `<input type="search">` + 한국어 placeholder \`snapshot id / preview / 요약 필터\`, `aria-label="OAS snapshot history 필터"`.
- 섹션 헤더에 필터 활성 시 라이브 `N/total` 카운터.
- 필터 결과가 0이면 `필터 결과 없음 (N items)` 빈 상태 — 원본이 비어있을 때의 \`저장된 OAS history snapshot이 아직 없습니다\`와 구분됩니다.
- 기존 삭제/체크박스 로직은 filter 위에서 그대로 동작합니다 (id-based selection이라 안전).

## 후보 탈락 근거

- **`CheckpointSummaryCard` inventory.history.map과 유사한 `repos.map` (line 715 in `PlaygroundReposPanel`)**: 보통 1~3개 repo만 붙습니다. 카디널리티가 낮아 필터의 실효성이 없음.
- **`PlaygroundReposPanel`의 `prs.map` (line 736)**: PR history는 OAS history보다 훨씬 짧고, 실측에서 평균 수 개 수준.
- **`PlaygroundReposPanel`의 `worktrees.map` (line 752)**: flex-wrap 배지 UI라 wrap으로 전부 보입니다. 정리용 skill(`/worktree-cleanup`)이 따로 있음.
- **`KeeperConfigPanel`의 `profiles.map` (line 906)**: 이미 `<select>` 안의 `<option>` 드롭다운이라 브라우저 기본 검색 UI가 있음. 필터 중복.

## 테스트

`dashboard/src/components/keeper-detail.test.ts`에 `describe('filterCheckpointHistory', ...)` 11개:

1. empty query → 입력 ref 반환 (no allocation)
2. whitespace-only query → 입력 ref 반환
3. `snapshot_id` case-insensitive substring
4. `source_kind` 매치 (\`oas_current\` 분리)
5. 한국어 `latest_preview` 매치 (\`답변\`)
6. `continuity_summary` 매치
7. query trim
8. 매치 없음 → 빈 배열
9. 입력 non-mutation
10. null preview + null continuity_summary 핸들링
11. 매칭 결과 원본 순서 보존

## 검증

- \`pnpm exec tsc --noEmit\` → clean
- \`pnpm exec vitest run src/components/keeper-detail.test.ts\` → 13 pass (기존 2 + 신규 11)
- \`pnpm exec eslint .\` → 0 errors

## CI

main CI는 PR #7835 (OAS 0.155 floor bump) merge로 GREEN 상태입니다.

## 파일

- `dashboard/src/components/keeper-detail.ts` (+36 / -5)
- `dashboard/src/components/keeper-detail.test.ts` (+117 / 0)

Dashboard-only, 2 files, 1 list. iter-7/8/9/11/12의 seed-hint 패턴을 따랐습니다.