### PR TITLE
feat(dashboard): add title/body filter to board posts in memory

### DIFF
--- a/dashboard/src/components/memory.test.ts
+++ b/dashboard/src/components/memory.test.ts
@@ -1,7 +1,7 @@
 import { h } from 'preact'
 import { render, screen } from '@testing-library/preact'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Memory } from './memory'
+import { Memory, filterBoardPosts } from './memory'
 import { boardPosts, boardLoading, boardSortMode, boardExcludeSystem, boardExcludeAutomation, boardHiddenCategories, boardAuthorFilter } from '../store'
 import { route } from '../router'
 import { contentCategory } from './memory-state'
@@ -171,5 +171,59 @@ describe('Memory Component', () => {
     ]
     render(h(Memory, null))
     expect(screen.queryByText('System Post')).not.toBeInTheDocument()
+  })
+})
+
+// ── filterBoardPosts pure-function tests ──────────────────────────
+describe('filterBoardPosts', () => {
+  const a = makePost({ id: 'p1', title: 'GraphRAG 기술 탐색', body: 'hybrid retrieval notes', author: 'ani1999' })
+  const b = makePost({ id: 'p2', title: 'PR 리뷰: #7106', body: 'refactor of cascade router', author: 'sojin' })
+  const c = makePost({ id: 'p3', title: 'Sprint 상태 업데이트', body: 'budget stable, GraphRAG shipped', author: 'poe' })
+  const d = makePost({ id: 'p4', title: 'Verdict: 7건 일괄 판정', body: '', author: 'verdict' })
+  const rows = [a, b, c, d] as const
+
+  it('returns the input reference unchanged for an empty query', () => {
+    expect(filterBoardPosts(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference unchanged for a whitespace-only query', () => {
+    expect(filterBoardPosts(rows, '   ')).toBe(rows)
+  })
+
+  it('matches on title (case-insensitive)', () => {
+    expect(filterBoardPosts(rows, 'graphrag').map(p => p.id)).toEqual(['p1', 'p3'])
+  })
+
+  it('matches on body (case-insensitive)', () => {
+    expect(filterBoardPosts(rows, 'CASCADE').map(p => p.id)).toEqual(['p2'])
+  })
+
+  it('matches Korean substring on title', () => {
+    expect(filterBoardPosts(rows, '리뷰').map(p => p.id)).toEqual(['p2'])
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(filterBoardPosts(rows, '   verdict   ').map(p => p.id)).toEqual(['p4'])
+  })
+
+  it('returns an empty array when no post matches', () => {
+    expect(filterBoardPosts(rows, 'nonexistent-needle-xyz')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = [...rows]
+    filterBoardPosts(rows, 'graphrag')
+    expect(rows).toEqual(copy)
+  })
+
+  it('handles posts with empty body without throwing', () => {
+    const result = filterBoardPosts(rows, 'verdict')
+    expect(result.map(p => p.id)).toEqual(['p4'])
+  })
+
+  it('title match takes precedence when both title and body could match', () => {
+    // Post c has "GraphRAG" in both title-adjacent context and body; both should count as match.
+    const onlyC = makePost({ id: 'only-c', title: 'stable', body: 'graphrag shipped', author: 'x' })
+    expect(filterBoardPosts([onlyC], 'graphrag').map(p => p.id)).toEqual(['only-c'])
   })
 })

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect, useRef, useCallback } from 'preact/hooks'
+import { useEffect, useRef, useCallback, useMemo, useState } from 'preact/hooks'
 import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
@@ -59,6 +59,33 @@ import {
   deleteBoardPost,
 } from './memory-state'
 import type { BoardPost, ContentCategory } from './memory-state'
+
+/**
+ * Pure filter for board posts.
+ *
+ * Case-insensitive substring match on `post.title` and `post.body` so the
+ * operator can locate a post by a keyword in the headline or anywhere in
+ * the content. Title is checked first (cheapest, strongest signal), then
+ * body. Existing server-side `boardAuthorFilter` handles the author axis,
+ * so this client-side filter is intentionally scoped to textual content.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no new
+ * array allocation, preserves referential equality for memoisation).
+ *
+ * Input is never mutated; BoardPost is treated as readonly.
+ */
+export function filterBoardPosts(
+  posts: readonly BoardPost[],
+  query: string,
+): readonly BoardPost[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return posts
+  return posts.filter(post => {
+    if (post.title && post.title.toLowerCase().includes(needle)) return true
+    if (post.body && post.body.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 // ── Scroll sentinel (IntersectionObserver auto-load) ──────────────
 function ScrollSentinel({ onVisible }: { onVisible: () => void }) {
@@ -435,7 +462,14 @@ function PostCard({ post }: { post: BoardPost }) {
 // ── Main Memory component (public API) ─────────────────────────────
 export function Memory() {
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
-  const grouped = splitVisiblePosts(boardPosts.value)
+  const [contentQuery, setContentQuery] = useState('')
+  const rawPosts = boardPosts.value
+  const filteredPosts = useMemo(
+    () => filterBoardPosts(rawPosts, contentQuery),
+    [rawPosts, contentQuery],
+  )
+  const isFiltering = contentQuery.trim() !== ''
+  const grouped = splitVisiblePosts(filteredPosts as BoardPost[])
   const posts = grouped.groups.flatMap(g => g.posts)
   const hint = filterHint(grouped)
   const postId = route.value.params.post ?? null
@@ -479,16 +513,28 @@ export function Memory() {
       <div class="mb-4">
         <${NewPostForm} />
       </div>
-      ${posts.length === 0 && boardLoading.value
-        ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
-        : posts.length === 0
-          ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
-          : html`
-              ${boardLoading.value ? html`<div class="mb-2 text-[11px] text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
-              ${grouped.groups.map(g => html`
-                <${CategorySection} key=${g.category} group=${g} />
-              `)}
-            `}
+      <div class="mb-3 flex items-center gap-2">
+        <input
+          type="search"
+          value=${contentQuery}
+          placeholder="제목/본문에서 검색"
+          aria-label="게시글 본문 필터"
+          onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
+          class="min-w-[180px] max-w-[320px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[12px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+        />
+      </div>
+      ${isFiltering && posts.length === 0 && rawPosts.length > 0
+        ? html`<div class="py-4 text-center text-[12px] text-[var(--text-dim)]">필터 결과 없음 (${rawPosts.length} items)</div>`
+        : posts.length === 0 && boardLoading.value
+          ? html`<${LoadingState}>메모리 피드 불러오는 중...<//>`
+          : posts.length === 0
+            ? html`<${EmptyState} message="아직 게시글이 없습니다. 에이전트가 활동하면 소통과 지식 공유 글이 여기에 나타납니다." compact />`
+            : html`
+                ${boardLoading.value ? html`<div class="mb-2 text-[11px] text-[var(--text-muted)] animate-pulse">업데이트 중...</div>` : null}
+                ${grouped.groups.map(g => html`
+                  <${CategorySection} key=${g.category} group=${g} />
+                `)}
+              `}
     </div>
   `
 }


### PR DESCRIPTION
## 배경

Memory 페이지 (`dashboard/src/components/memory.ts`, 494 LOC / 5 `.map` 사이트) 의 게시글 목록은 기존에 **author 축** 필터 (`boardAuthorFilter`, 서버 사이드) 만 있었다. `GraphRAG`, `cascade`, `#7106` 같은 키워드로 모든 카테고리 섹션을 한 번에 찾으려면 눈으로 훑어야 했다. iter-7/8/9/11/12 seed-hint 를 따라 `memory.ts` 한 개 파일에 하나의 리스트만 필터링한다.

## 후보 리스트 (5 `.map` 사이트)

| 후보 | 위치 | 선택 여부 | 이유 |
|------|-----|-----------|------|
| 게시글 목록 (`grouped.groups.flatMap(g => g.posts)`) | L466, `Memory()` | **선택** | unbounded cardinality, title/body 가 가장 긴 텍스트 필드 |
| `SORT_MODES.map` | L211 (SortBar) | X | 정적 상수 3개 |
| `grouped.groups.map` 카테고리 칩 | L231 (SortBar) | X | 4개 고정, 이미 toggle UI 존재 |
| `grouped.groups.map` 요약 뱃지 | L307 (MemorySummary) | X | 카테고리별 집계 뱃지, 리스트 아님 |
| `posts.slice(0, limit).map` PostCard | L133 (renderCategorySection) | X | 위 "게시글 목록" 과 같은 원본의 paginated slice |

→ 게시글 목록 한 개만 필터링 대상. iter8 이 이미 처리한 `keeper-memory-tier-panel.ts` (메모리 tier 행, 다른 파일/다른 데이터 축) 와 명확히 구분된다.

## 변경

- 순수 함수 `filterBoardPosts(posts: readonly BoardPost[], query: string): readonly BoardPost[]` 추가 (export).
  - Case-insensitive substring match on `post.title` then `post.body`; first match wins.
  - Author 축은 기존 서버사이드 `boardAuthorFilter` 가 담당하므로 client filter 는 textual content 전용.
  - Empty/whitespace query 는 입력 reference 를 그대로 반환 → `useMemo` identity 유지.
  - 입력 배열은 mutate 하지 않음.
- `Memory()` 에 `useState<string>` 로 query state + `useMemo` 로 filter 적용 추가.
- Filter 는 `splitVisiblePosts` **이전** 에 적용되어 카테고리 그룹 집계와 summary count 가 일관되게 filtered slice 를 반영한다.
- 입력 위 `<input type="search">` + 한국어 placeholder (`제목/본문에서 검색`).
- 필터링 중 매치 0개일 때 구분된 empty state (`필터 결과 없음 (N items)`) — 원본 데이터는 존재한다는 것을 operator 가 인지.

## 검증

- `pnpm exec tsc --noEmit` — pass
- `pnpm exec vitest run src/components/memory.test.ts` — 24 passed (기존 14 + 신규 10)
- `pnpm exec eslint .` — pass

## CI 주의

Main CI 는 #7835 이후 GREEN. 본 PR 은 dashboard 파일 2개 (`memory.ts`, `memory.test.ts`) 만 수정하며 OCaml 빌드에는 영향 없다.

## 테스트 플랜

- [ ] boardPosts 가 수십 건 이상일 때 검색창에 `GraphRAG`, `PR`, `cascade` 등을 입력해 카테고리 섹션이 축소되는지 확인
- [ ] 매치 0개일 때 `필터 결과 없음 (N items)` 안내 확인
- [ ] 필터 입력 상태에서 MemorySummary 의 `N개 표시 중` 카운트가 filtered 기준으로 갱신되는지 확인
- [ ] 검색어 지우면 기존 카테고리 섹션이 그대로 복원되는지 확인
- [ ] 한국어 substring ("리뷰", "탐색") 이 정상 매치되는지 확인