### PR TITLE
refactor(coord): eliminate mutable refs in coord_hooks using lock-free Atomic.t

### DIFF
--- a/lib/coord.ml
+++ b/lib/coord.ml
@@ -157,13 +157,11 @@ let observe_task_transition_event config ~agent_name ~task_id
   with Stdlib.Effect.Unhandled _ -> ())
 
 (* force_release_task — zombie cleanup needs task management logic *)
-let () = Coord_hooks.force_release_task_fn :=
-  (fun config ~agent_name ~task_id () ->
+let () = Atomic.set Coord_hooks.force_release_task_fn (fun config ~agent_name ~task_id () ->
     force_release_task_r config ~agent_name ~task_id ())
 
 (* Activity graph emit — wraps Activity_graph for room sub-modules *)
-let () = Coord_hooks.activity_emit_fn :=
-  (fun config ~actor ?subject ~kind ~payload ~tags () ->
+let () = Atomic.set Coord_hooks.activity_emit_fn (fun config ~actor ?subject ~kind ~payload ~tags () ->
     (try
       ignore (Activity_graph.emit config
         ~actor:(Activity_graph.entity ~kind:actor.Coord_hooks.kind actor.id)
@@ -175,31 +173,29 @@ let () = Coord_hooks.activity_emit_fn :=
      | exn -> Log.Coord.warn "activity_graph emit failed: %s" (Printexc.to_string exn)))
 
 (* Agent economy earn — wraps Agent_economy for task completion credits *)
-let () = Coord_hooks.agent_economy_earn_fn :=
-  (fun ~base_path ~agent_name ~reason ->
+let () = Atomic.set Coord_hooks.agent_economy_earn_fn (fun ~base_path ~agent_name ~reason ->
     match Agent_economy.earn ~base_path ~agent_name
       ~kind:Earn_task_done ~reason () with
     | Ok _bal -> ()
     | Error msg -> Log.Misc.error "task earn failed: %s" msg)
 
 (* Relation materializer — agent leave *)
-let () = Coord_hooks.relation_on_leave_fn := Relation_materializer.on_agent_leave
+let () = Atomic.set Coord_hooks.relation_on_leave_fn Relation_materializer.on_agent_leave
 
 (* Relation materializer — task done *)
-let () = Coord_hooks.relation_on_task_done_fn := Relation_materializer.on_task_done
+let () = Atomic.set Coord_hooks.relation_on_task_done_fn Relation_materializer.on_task_done
 
 (* Hebbian learning — strengthen on task completion.
    Also emits activity events so strengthens appear in the
    activity graph / telemetry surface alongside task events. *)
-let () = Coord_hooks.hebbian_on_task_done_fn :=
-  (fun config ~assignee ~active_agents ->
+let () = Atomic.set Coord_hooks.hebbian_on_task_done_fn (fun config ~assignee ~active_agents ->
     List.iter (fun peer ->
       if peer <> assignee then begin
         (try Hebbian_eio.strengthen config ~from_agent:assignee ~to_agent:peer ()
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Coord.warn "hebbian strengthen failed: %s" (Printexc.to_string exn));
         (try
-           !Coord_hooks.activity_emit_fn config
+           (Atomic.get Coord_hooks.activity_emit_fn) config
              ~actor:Coord_hooks.{ kind = "agent"; id = assignee }
              ~subject:Coord_hooks.{ kind = "agent"; id = peer }
              ~kind:"hebbian.strengthen"
@@ -214,15 +210,14 @@ let () = Coord_hooks.hebbian_on_task_done_fn :=
     ) active_agents)
 
 (* Hebbian learning — weaken on task cancellation. *)
-let () = Coord_hooks.hebbian_on_task_cancelled_fn :=
-  (fun config ~agent_name ~active_agents ->
+let () = Atomic.set Coord_hooks.hebbian_on_task_cancelled_fn (fun config ~agent_name ~active_agents ->
     List.iter (fun peer ->
       if peer <> agent_name then begin
         (try Hebbian_eio.weaken config ~from_agent:agent_name ~to_agent:peer ()
          with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
            Log.Coord.warn "hebbian weaken failed: %s" (Printexc.to_string exn));
         (try
-           !Coord_hooks.activity_emit_fn config
+           (Atomic.get Coord_hooks.activity_emit_fn) config
              ~actor:Coord_hooks.{ kind = "agent"; id = agent_name }
              ~subject:Coord_hooks.{ kind = "agent"; id = peer }
              ~kind:"hebbian.weaken"
@@ -236,18 +231,16 @@ let () = Coord_hooks.hebbian_on_task_cancelled_fn :=
       end
     ) active_agents)
 
-let () = Coord_hooks.observe_agent_lifecycle_fn :=
-  (fun config ~agent_id ~event_kind ~details ->
+let () = Atomic.set Coord_hooks.observe_agent_lifecycle_fn (fun config ~agent_id ~event_kind ~details ->
     observe_agent_lifecycle config ~agent_id ~event_kind ~details)
 
-let () = Coord_hooks.observe_task_transition_fn :=
-  (fun config ~agent_name ~task_id ~transition ~details ->
-    !Coord_hooks.on_task_mutation_fn ();
+let () = Atomic.set Coord_hooks.observe_task_transition_fn (fun config ~agent_name ~task_id ~transition ~details ->
+    (Atomic.get Coord_hooks.on_task_mutation_fn) ();
     observe_task_transition_event config ~agent_name ~task_id
       ~transition ~details)
 
 (* Board artifact cleanup — wraps Board_dispatch for GC *)
-let () = Coord_hooks.cleanup_board_artifacts_fn := (fun () ->
+let () = Atomic.set Coord_hooks.cleanup_board_artifacts_fn (fun () ->
   let stale_system_daily_sec = 12.0 *. 3600.0 in
   let board_artifact_title title =
     let title = String.lowercase_ascii (String.trim title) in
@@ -277,7 +270,7 @@ let () = Coord_hooks.cleanup_board_artifacts_fn := (fun () ->
        0)
 
 (* Subscription auto-subscribe on join — wraps Subscriptions for room_eio *)
-let () = Coord_hooks.subscribe_messages_fn := (fun ~subscriber ->
+let () = Atomic.set Coord_hooks.subscribe_messages_fn (fun ~subscriber ->
   let _ = Subscriptions.SubscriptionStore.subscribe
     ~subscriber ~resource:Subscriptions.Messages () in ())
 

--- a/lib/coord/coord_broadcast.ml
+++ b/lib/coord/coord_broadcast.ml
@@ -36,7 +36,7 @@ let emit_message_activity config ~from_agent ~content ~mention
   let actor = Coord_hooks.{ kind = "agent"; id = from_agent } in
   let emit ?subject ~kind ~tags () =
     try
-      !Coord_hooks.activity_emit_fn config
+      (Atomic.get Coord_hooks.activity_emit_fn) config
         ~actor ?subject ~kind ~payload ~tags ()
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/coord/coord_eio.ml
+++ b/lib/coord/coord_eio.ml
@@ -385,7 +385,7 @@ let register_agent config ~name ?(capabilities=[]) () =
       | Error msg -> Log.Coord.warn "join_agent: state update failed for %s: %s" name msg);
 
       (* Auto-subscribe to Messages for A2A communication (via hook) *)
-      !Coord_hooks.subscribe_messages_fn ~subscriber:name;
+      (Atomic.get Coord_hooks.subscribe_messages_fn) ~subscriber:name;
 
       (* Log join event only for new agents, skip for re-joins *)
       if not already_active then begin

--- a/lib/coord/coord_gc.ml
+++ b/lib/coord/coord_gc.ml
@@ -104,7 +104,7 @@ let cleanup_zombies
         (* Stop keeper fiber via hook to prevent zombie tool calls.
            Without this, the keeper fiber continues running (fiber_stop stays
            false) and makes tool calls indefinitely after cleanup. *)
-        (try !Coord_hooks.stop_keeper_fn name
+        (try (Atomic.get Coord_hooks.stop_keeper_fn) name
          with
          | Eio.Cancel.Cancelled _ as e -> raise e
          | exn -> Log.Gc.warn "gc stop_keeper_fn error for %s: %s" name (Printexc.to_string exn));
@@ -120,7 +120,7 @@ let cleanup_zombies
         | Types.Claimed { assignee; _ }
         | Types.InProgress { assignee; _ }
           when List.exists (fun (n, _) -> n = assignee) !zombie_entries ->
-            (match !Coord_hooks.force_release_task_fn config ~agent_name:"keeper-gc" ~task_id:task.id () with
+            (match (Atomic.get Coord_hooks.force_release_task_fn) config ~agent_name:"keeper-gc" ~task_id:task.id () with
              | Ok msg -> released_tasks := (task.id, msg) :: !released_tasks
              | Error e ->
                  if not (List.mem assignee !release_failed_agents) then
@@ -390,7 +390,7 @@ let gc config ?(days=7) () =
     results := "✅ No team sessions to archive" :: !results;
 
   (* 7. Hard-delete board artifacts (via hooks) *)
-  let board_artifact_count = !Coord_hooks.cleanup_board_artifacts_fn () in
+  let board_artifact_count = (Atomic.get Coord_hooks.cleanup_board_artifacts_fn) () in
   if board_artifact_count > 0 then
     results :=
       Printf.sprintf "🧽 Removed %d board artifact post(s)"

--- a/lib/coord/coord_hooks.ml
+++ b/lib/coord/coord_hooks.ml
@@ -23,8 +23,8 @@ type activity_entity = { kind: string; id: string }
 
 (** Force-release a task — avoids Coord_gc → Coord_task circular dep. *)
 let force_release_task_fn
-  : (Coord_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit -> string masc_result) ref
-  = ref (fun _config ~agent_name:_ ~task_id:_ () ->
+  : (Coord_utils_backend_setup.config -> agent_name:string -> task_id:string -> unit -> string masc_result) Atomic.t
+  = Atomic.make (fun _config ~agent_name:_ ~task_id:_ () ->
       Error (Types.TaskInvalidState "Coord_hooks: force_release_task_fn not connected"))
 
 (* ============================================ *)
@@ -40,42 +40,42 @@ let activity_emit_fn
      kind:string ->
      payload:Yojson.Safe.t ->
      tags:string list ->
-     unit -> unit) ref
-  = ref (fun _config ~actor:_ ?subject:_ ~kind:_ ~payload:_ ~tags:_ () -> ())
+     unit -> unit) Atomic.t
+  = Atomic.make (fun _config ~actor:_ ?subject:_ ~kind:_ ~payload:_ ~tags:_ () -> ())
 
 (** Agent economy earn — wraps Agent_economy.earn for task completion credits. *)
 let agent_economy_earn_fn
-  : (base_path:string -> agent_name:string -> reason:string -> unit) ref
-  = ref (fun ~base_path:_ ~agent_name:_ ~reason:_ -> ())
+  : (base_path:string -> agent_name:string -> reason:string -> unit) Atomic.t
+  = Atomic.make (fun ~base_path:_ ~agent_name:_ ~reason:_ -> ())
 
 (** Stop keeper keepalive fiber — avoids Coord_gc → Keeper_keepalive dep.
     Called during zombie cleanup to terminate keeper fibers that would
     otherwise continue making tool calls after agent removal. *)
 let stop_keeper_fn
-  : (string -> unit) ref
-  = ref (fun _name -> ())
+  : (string -> unit) Atomic.t
+  = Atomic.make (fun _name -> ())
 
 (** Relation materializer: agent leave — wraps Relation_materializer.on_agent_leave. *)
 let relation_on_leave_fn
-  : (leaving_agent:string -> active_agents:string list -> unit) ref
-  = ref (fun ~leaving_agent:_ ~active_agents:_ -> ())
+  : (leaving_agent:string -> active_agents:string list -> unit) Atomic.t
+  = Atomic.make (fun ~leaving_agent:_ ~active_agents:_ -> ())
 
 (** Relation materializer: task done — wraps Relation_materializer.on_task_done. *)
 let relation_on_task_done_fn
-  : (assignee:string -> active_agents:string list -> unit) ref
-  = ref (fun ~assignee:_ ~active_agents:_ -> ())
+  : (assignee:string -> active_agents:string list -> unit) Atomic.t
+  = Atomic.make (fun ~assignee:_ ~active_agents:_ -> ())
 
 (** Hebbian learning: strengthen collaboration on task completion. *)
 let hebbian_on_task_done_fn
   : (Coord_utils_backend_setup.config ->
-     assignee:string -> active_agents:string list -> unit) ref
-  = ref (fun _config ~assignee:_ ~active_agents:_ -> ())
+     assignee:string -> active_agents:string list -> unit) Atomic.t
+  = Atomic.make (fun _config ~assignee:_ ~active_agents:_ -> ())
 
 (** Hebbian learning: weaken collaboration on task cancellation. *)
 let hebbian_on_task_cancelled_fn
   : (Coord_utils_backend_setup.config ->
-     agent_name:string -> active_agents:string list -> unit) ref
-  = ref (fun _config ~agent_name:_ ~active_agents:_ -> ())
+     agent_name:string -> active_agents:string list -> unit) Atomic.t
+  = Atomic.make (fun _config ~agent_name:_ ~active_agents:_ -> ())
 
 (** Shared observability hook for join/rejoin/leave events.
     Upper layers can mirror state transitions to audit, telemetry, and logs
@@ -85,8 +85,8 @@ let observe_agent_lifecycle_fn
      agent_id:string ->
      event_kind:string ->
      details:Yojson.Safe.t ->
-     unit) ref
-  = ref
+     unit) Atomic.t
+  = Atomic.make
       (fun _config ~agent_id:_ ~event_kind:_ ~details:_ -> ())
 
 (** Shared observability hook for task transitions.
@@ -98,26 +98,26 @@ let observe_task_transition_fn
      task_id:string ->
      transition:string ->
      details:Yojson.Safe.t ->
-     unit) ref
-  = ref
+     unit) Atomic.t
+  = Atomic.make
       (fun _config ~agent_name:_ ~task_id:_ ~transition:_
            ~details:_ -> ())
 
 (** Board artifact cleanup — wraps Board_dispatch.list_posts + delete_post.
     Returns number of deleted posts. *)
 let cleanup_board_artifacts_fn
-  : (unit -> int) ref
-  = ref (fun () -> 0)
+  : (unit -> int) Atomic.t
+  = Atomic.make (fun () -> 0)
 
 (** Invalidate dashboard execution cache on task mutation (add, transition).
     Wired by server bootstrap to avoid circular dependency between
     Coord sub-modules and server dashboard surfaces. *)
 let on_task_mutation_fn
-  : (unit -> unit) ref
-  = ref (fun () -> ())
+  : (unit -> unit) Atomic.t
+  = Atomic.make (fun () -> ())
 
 
 (** Auto-subscribe agent to messages on join — wraps Subscriptions.SubscriptionStore. *)
 let subscribe_messages_fn
-  : (subscriber:string -> unit) ref
-  = ref (fun ~subscriber:_ -> ())
+  : (subscriber:string -> unit) Atomic.t
+  = Atomic.make (fun ~subscriber:_ -> ())

--- a/lib/coord/coord_lifecycle.ml
+++ b/lib/coord/coord_lifecycle.ml
@@ -107,7 +107,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
          log_event config (Printf.sprintf
            "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
            nickname agent_type new_session_id (now_iso ()));
-         !Coord_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname
+         (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
            ~event_kind:"rejoin"
            ~details:
              (`Assoc
@@ -171,7 +171,7 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     session_id
     (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
     (now_iso ()));
-  !Coord_hooks.observe_agent_lifecycle_fn config ~agent_id:nickname
+  (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:nickname
     ~event_kind:"join"
     ~details:
       (`Assoc
@@ -229,12 +229,12 @@ let leave config ~agent_name =
     log_event config (Printf.sprintf
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
       actual_name (now_iso ()));
-    !Coord_hooks.observe_agent_lifecycle_fn config ~agent_id:actual_name
+    (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) config ~agent_id:actual_name
       ~event_kind:"leave"
       ~details:`Null;
 
     (* Record co-presence relationships via hook (async, non-blocking) *)
-    (try !Coord_hooks.relation_on_leave_fn
+    (try (Atomic.get Coord_hooks.relation_on_leave_fn)
            ~leaving_agent:actual_name ~active_agents:peers_before_leave
      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
        Log.Coord.error "relation-materializer leave hook error: %s"

--- a/lib/coord/coord_query.ml
+++ b/lib/coord/coord_query.ml
@@ -37,7 +37,7 @@ let update_priority config ~task_id ~priority =
           log_event config (Printf.sprintf
             "{\"type\":\"priority_change\",\"task\":\"%s\",\"old\":%d,\"new\":%d,\"ts\":\"%s\"}"
             task_id old_priority priority (now_iso ()));
-          !Coord_hooks.on_task_mutation_fn ();
+          (Atomic.get Coord_hooks.on_task_mutation_fn) ();
 
           Printf.sprintf "✅ Task %s priority: P%d → P%d" task_id old_priority priority
     with

--- a/lib/coord/coord_task.ml
+++ b/lib/coord/coord_task.ml
@@ -167,7 +167,7 @@ let emit_task_activity ?correlation_id ?run_id
     merge_envelope_into_payload ?correlation_id ?run_id payload
   in
   try
-    !Coord_hooks.activity_emit_fn config
+    (Atomic.get Coord_hooks.activity_emit_fn) config
       ~actor:Coord_hooks.{ kind = task_actor_kind agent_name; id = agent_name }
       ~subject:Coord_hooks.{ kind = "task"; id = task_id }
       ~kind
@@ -233,7 +233,7 @@ let task_transition_details ~from_status ~to_status ?notes ?reason ?duration_ms
         (Option.map (fun value -> `Int value) duration_ms))
 
 let observe_task_transition config ~agent_name ~task_id ~transition ~details =
-  !Coord_hooks.observe_task_transition_fn config ~agent_name
+  (Atomic.get Coord_hooks.observe_task_transition_fn) config ~agent_name
     ~task_id ~transition ~details
 
 (** Transition log event taxonomy. Variant instead of free-form string
@@ -361,7 +361,7 @@ let add_task ?contract ?required_preset config ~title ~priority ~description =
                   | None -> false) );
             ]);
 
-      !Coord_hooks.on_task_mutation_fn ();
+      (Atomic.get Coord_hooks.on_task_mutation_fn) ();
       let _ = broadcast config ~from_agent:"system" ~content:(Printf.sprintf "📋 New quest: %s" title) in
       Printf.sprintf "✅ Added %s: %s" task_id title))
   with
@@ -489,7 +489,7 @@ let batch_add_tasks_internal config tasks =
                 ]))
         added_tasks;
       let summary = String.concat ", " (List.map (fun (t : Types.task) -> t.id) added_tasks) in
-      !Coord_hooks.on_task_mutation_fn ();
+      (Atomic.get Coord_hooks.on_task_mutation_fn) ();
       let msg = Printf.sprintf "📋 New batch of %d quests added: %s" (List.length added_tasks) summary in
       let _ = broadcast config ~from_agent:"system" ~content:msg in
       Printf.sprintf "✅ Added %d tasks: %s" (List.length added_tasks) summary
@@ -964,11 +964,11 @@ let transition_task_r config ~agent_name ~task_id ~action
          | Types.Done_action ->
            (try
               let active = (Coord_state.read_state config).active_agents in
-              !Coord_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active;
+              (Atomic.get Coord_hooks.relation_on_task_done_fn) ~assignee:agent_name ~active_agents:active;
               (* Hebbian: strengthen only against agents with active tasks,
                  not the full room. See working_agents doc for rationale. *)
               let workers = working_agents config in
-              !Coord_hooks.hebbian_on_task_done_fn config
+              (Atomic.get Coord_hooks.hebbian_on_task_done_fn) config
                 ~assignee:agent_name ~active_agents:workers
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.RoomTask.error "transition relation/hebbian done hook: %s"
@@ -976,7 +976,7 @@ let transition_task_r config ~agent_name ~task_id ~action
          | Types.Cancel ->
            (try
               let workers = working_agents config in
-              !Coord_hooks.hebbian_on_task_cancelled_fn config
+              (Atomic.get Coord_hooks.hebbian_on_task_cancelled_fn) config
                 ~agent_name ~active_agents:workers
             with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
               Log.RoomTask.error "transition hebbian cancel hook: %s"
@@ -1093,10 +1093,10 @@ let complete_task config ~agent_name ~task_id ~notes =
             (* Record task collaboration via hook (async, non-blocking) *)
             (try
                let active = (Coord_state.read_state config).active_agents in
-               !Coord_hooks.relation_on_task_done_fn ~assignee:agent_name ~active_agents:active;
+               (Atomic.get Coord_hooks.relation_on_task_done_fn) ~assignee:agent_name ~active_agents:active;
                (* Hebbian: strengthen only against agents with active tasks *)
                let workers = working_agents config in
-               !Coord_hooks.hebbian_on_task_done_fn config
+               (Atomic.get Coord_hooks.hebbian_on_task_done_fn) config
                  ~assignee:agent_name ~active_agents:workers
              with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                Log.RoomTask.error "relation/hebbian task hook error: %s"
@@ -1210,7 +1210,7 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
                              *. 1000.0)))
                      ());
               (* Agent Economy: earn credits via hook *)
-              !Coord_hooks.agent_economy_earn_fn
+              (Atomic.get Coord_hooks.agent_economy_earn_fn)
                 ~base_path:config.base_path ~agent_name
                 ~reason:(Printf.sprintf "completed %s" task_id);
               Ok (Printf.sprintf "✅ %s completed %s" agent_name task_id)
@@ -1320,7 +1320,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
               (* Hebbian: weaken only against agents with active tasks *)
               (try
                  let workers = working_agents config in
-                 !Coord_hooks.hebbian_on_task_cancelled_fn config
+                 (Atomic.get Coord_hooks.hebbian_on_task_cancelled_fn) config
                    ~agent_name ~active_agents:workers
                with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                  Log.RoomTask.error "hebbian task_cancelled hook error: %s"

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -1968,7 +1968,7 @@ let run_turn
              in
              let emit_keeper_activity ~kind ~payload ~tags =
                try
-                 !Coord_hooks.activity_emit_fn config
+                 (Atomic.get Coord_hooks.activity_emit_fn) config
                    ~actor:Coord_hooks.{ kind = "agent"; id = meta.agent_name }
                    ?subject:task_subject
                    ~kind ~payload ~tags ()
@@ -2069,7 +2069,7 @@ let run_turn
                  (* Emit activity event so episode flushes appear in
                     the activity graph / telemetry surface. *)
                  (try
-                    !Coord_hooks.activity_emit_fn config
+                    (Atomic.get Coord_hooks.activity_emit_fn) config
                       ~actor:Coord_hooks.{ kind = "keeper"; id = meta.name }
                       ~kind:"episode.flush"
                       ~payload:(`Assoc [

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -11,7 +11,7 @@ let start_keeper_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   Progress.set_sse_callback Sse.broadcast;
   Sse.set_clock clock;
   (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
-  Coord_hooks.stop_keeper_fn := Keeper_keepalive.stop_keepalive;
+  Atomic.set Coord_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems. *)
   let event_bus = Agent_sdk.Event_bus.create () in
   (* Eio fiber isolation: each subsystem runs in its own fiber.

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -10,7 +10,7 @@ open Server_utils
 (* Wire task mutation hook: invalidate execution cache on any task
    add/transition so the dashboard serves fresh backlog data. *)
 let () =
-  Coord_hooks.on_task_mutation_fn := invalidate_execution_cache
+  Atomic.set Coord_hooks.on_task_mutation_fn invalidate_execution_cache
 
 
 let dashboard_namespace_truth_focus_json =

--- a/test/test_a2a_e2e.ml
+++ b/test/test_a2a_e2e.ml
@@ -16,7 +16,7 @@ let () = Mirage_crypto_rng_unix.use_default ()
 
 (* Wire Coord_hooks for subscribe — needed because Coord module side-effects
    may not execute in test binaries that don't reference Coord directly. *)
-let () = Coord_hooks.subscribe_messages_fn := (fun ~subscriber ->
+let () = Atomic.set Coord_hooks.subscribe_messages_fn (fun ~subscriber ->
   let _ = Subscriptions.SubscriptionStore.subscribe
     ~subscriber ~resource:Subscriptions.Messages () in ())
 

--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -453,10 +453,10 @@ let test_activity_surface_contracts () =
        "Activity_graph.emit config");
   check bool "coord task lifecycle emits activity events via hook" true
     (file_contains_pattern "lib/coord/coord_task.ml"
-       "!Coord_hooks.activity_emit_fn config");
+       "(Atomic.get Coord_hooks.activity_emit_fn) config");
   check bool "coord broadcast emits activity events via hook" true
     (file_contains_pattern "lib/coord/coord_broadcast.ml"
-       "!Coord_hooks.activity_emit_fn config");
+       "(Atomic.get Coord_hooks.activity_emit_fn) config");
   check bool "board success paths emit activity events" true
     (file_contains_pattern "lib/tool_inline_dispatch_extra.ml"
        "Activity_graph.emit config")

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -90,12 +90,11 @@ let find_latest_event_log config =
 let test_join_uses_default_namespace () =
   with_config (fun config ->
       let captured_event_kind = ref None in
-      let previous_hook = !Coord_hooks.observe_agent_lifecycle_fn in
+      let previous_hook = (Atomic.get Coord_hooks.observe_agent_lifecycle_fn) in
       Fun.protect
-        ~finally:(fun () -> Coord_hooks.observe_agent_lifecycle_fn := previous_hook)
+        ~finally:(fun () -> Atomic.set Coord_hooks.observe_agent_lifecycle_fn previous_hook)
         (fun () ->
-          Coord_hooks.observe_agent_lifecycle_fn :=
-            (fun _config ~agent_id:_ ~event_kind ~details:_ ->
+          Atomic.set Coord_hooks.observe_agent_lifecycle_fn (fun _config ~agent_id:_ ~event_kind ~details:_ ->
               captured_event_kind := Some event_kind);
           let result =
             Coord.join config ~agent_name:"claude"


### PR DESCRIPTION
## Description

Resolves the second major mutable state debt listed in the TODO:
`- lib/coord/coord_hooks.ml — 29 ref. Callback registry pattern — may need mutable, but verify.`

This PR:
- Replaces all 13 callback `ref` variables with `Atomic.t`.
- Replaces `:=` assignment with `Atomic.set`.
- Replaces `!` reads with `Atomic.get`.
- Eliminates thread-safety concerns when concurrent agents or subsystems register callbacks during startup or hot-reloading.
- Further reduces the footprint of global mutable state in the system.