### PR TITLE
[codex] Harden bash exec substrate semantics and compatibility

### DIFF
--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -687,6 +687,27 @@ function handleEvent(event: SSEEvent): void {
       )
       break
     }
+    case 'oas:agent_failed': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const agentName = asString(p.agent_name) ?? asString(event.agent_name) ?? agent
+      const taskId = asString(p.task_id)
+      const elapsed = asNumber(p.elapsed_s)
+      const error = asString(p.error)
+      addTypedJournalEntry(
+        agentName,
+        `OAS agent failed${taskId ? ` · ${taskId}` : ''}${elapsed != null ? ` · ${elapsed.toFixed(1)}s` : ''}${error ? ` · ${error}` : ''}`,
+        'oas',
+        'oas_event',
+        {
+          severity: event.severity,
+          source: event.source,
+          narrativeText: `${actorLabel(agentName)} OAS agent failed${taskId ? ` (${taskId})` : ''}${error ? `: ${error}` : ''}`,
+          preview: taskId ?? error,
+          ...envelopeFromEvent(event),
+        },
+      )
+      break
+    }
     case 'oas:tool_called':
     case 'oas:tool_completed': {
       const p = (event.payload ?? {}) as Record<string, unknown>
@@ -702,6 +723,29 @@ function handleEvent(event: SSEEvent): void {
           severity: event.severity,
           source: event.source,
           narrativeText: `${actorLabel(agentName)} OAS 도구 ${phase}: ${toolName}`,
+        },
+      )
+      break
+    }
+    case 'oas:handoff_requested':
+    case 'oas:handoff_completed': {
+      const p = (event.payload ?? {}) as Record<string, unknown>
+      const fromAgent = asString(p.from_agent) ?? asString(event.agent_name) ?? agent
+      const toAgent = asString(p.to_agent) ?? 'unknown'
+      const elapsed = asNumber(p.elapsed_s)
+      const reason = asString(p.reason)
+      const phase = type === 'oas:handoff_requested' ? 'requested' : 'completed'
+      addTypedJournalEntry(
+        fromAgent,
+        `OAS handoff ${phase} · ${fromAgent}→${toAgent}${elapsed != null ? ` · ${elapsed.toFixed(1)}s` : ''}${reason ? ` · ${reason}` : ''}`,
+        'oas',
+        'oas_event',
+        {
+          severity: event.severity,
+          source: event.source,
+          narrativeText: `OAS handoff ${phase}: ${actorLabel(fromAgent)} → ${actorLabel(toAgent)}${reason ? ` (${reason})` : ''}`,
+          preview: `${fromAgent}→${toAgent}`,
+          ...envelopeFromEvent(event),
         },
       )
       break

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -47,10 +47,13 @@ export type SSEEventType =
   | 'oas:masc:reputation_changed'
   | 'oas:agent_started'
   | 'oas:agent_completed'
+  | 'oas:agent_failed'
   | 'oas:tool_called'
   | 'oas:tool_completed'
   | 'oas:turn_started'
   | 'oas:turn_completed'
+  | 'oas:handoff_requested'
+  | 'oas:handoff_completed'
   | 'oas:context_compacted'
   | 'oas:task_state_changed'
   // Harness observability events (#3165)

--- a/lib/dune
+++ b/lib/dune
@@ -361,6 +361,7 @@
    trajectory
    eval_gate
    eval_harness
+   exec_core
    eval_calibration
    ;; Keeper contract
    keeper_schema

--- a/lib/exec_core.ml
+++ b/lib/exec_core.ml
@@ -1,0 +1,570 @@
+type command_family =
+  | Read
+  | Search
+  | List
+  | Build
+  | Test
+  | Git_read
+  | Git_write
+  | Package_install
+  | Network_read
+  | Clone
+  | Unknown
+
+type reversibility =
+  | Read_only
+  | Reversible
+  | Irreversible
+
+type risk =
+  | Low
+  | Medium
+  | High
+
+type semantic_status =
+  | Ok
+  | No_match
+  | Partial
+  | Blocked
+  | Timeout
+  | Runtime_error
+
+type retryability =
+  | None_
+  | Self_correct
+  | Operator_required
+
+type artifact_policy =
+  | Inline_only
+  | Persist_if_large
+
+type classification = {
+  family : command_family;
+  reversibility : reversibility;
+  risk : risk;
+  write_intent : bool;
+}
+
+type artifact_storage =
+  | Filesystem
+
+type artifact_ref = {
+  path : string;
+  bytes : int;
+  storage : artifact_storage;
+}
+
+type executed_result = {
+  command : string;
+  process_status : Unix.process_status;
+  output : string;
+  semantic_status : semantic_status;
+  classification : classification;
+  summary : string;
+  retryability : retryability;
+  artifact_refs : artifact_ref list;
+  recovery_hint : string option;
+}
+
+type blocked_result = {
+  command : string;
+  error : string;
+  reason : string;
+  hint : string;
+  classification : classification;
+  retryability : retryability;
+  summary : string;
+}
+
+type outcome =
+  | Executed of executed_result
+  | Blocked_result of blocked_result
+
+let env_int name default =
+  match Sys.getenv_opt name with
+  | Some value -> (match int_of_string_opt value with Some parsed -> parsed | None -> default)
+  | None -> default
+
+let artifact_threshold_bytes =
+  max 1024 (env_int "MASC_EXEC_ARTIFACT_THRESHOLD_BYTES" 16384)
+
+type quote_state =
+  | No_quote
+  | Single_quote
+  | Double_quote
+
+let strip_wrapping_quotes token =
+  let len = String.length token in
+  if len >= 2 then
+    match token.[0], token.[len - 1] with
+    | '\'', '\''
+    | '"', '"' ->
+        String.sub token 1 (len - 2)
+    | _ -> token
+  else
+    token
+
+let split_shell_fragments ~separator text =
+  let fragments = ref [] in
+  let buf = Buffer.create (String.length text) in
+  let quote_state = ref No_quote in
+  let escaped = ref false in
+  let push_fragment () =
+    let fragment = Buffer.contents buf |> String.trim in
+    Buffer.clear buf;
+    if fragment <> "" then fragments := fragment :: !fragments
+  in
+  String.iter
+    (fun ch ->
+      if !escaped then (
+        Buffer.add_char buf ch;
+        escaped := false)
+      else
+        match !quote_state, ch with
+        | Single_quote, '\'' ->
+            Buffer.add_char buf ch;
+            quote_state := No_quote
+        | Single_quote, _ ->
+            Buffer.add_char buf ch
+        | Double_quote, '"' ->
+            Buffer.add_char buf ch;
+            quote_state := No_quote
+        | Double_quote, '\\' ->
+            Buffer.add_char buf ch;
+            escaped := true
+        | Double_quote, _ ->
+            Buffer.add_char buf ch
+        | No_quote, '\\' ->
+            Buffer.add_char buf ch;
+            escaped := true
+        | No_quote, '\'' ->
+            Buffer.add_char buf ch;
+            quote_state := Single_quote
+        | No_quote, '"' ->
+            Buffer.add_char buf ch;
+            quote_state := Double_quote
+        | No_quote, _ when separator ch ->
+            push_fragment ()
+        | No_quote, _ ->
+            Buffer.add_char buf ch)
+    text;
+  push_fragment ();
+  List.rev !fragments
+
+let split_words text =
+  split_shell_fragments
+    ~separator:(function
+      | ' ' | '\t' | '\r' | '\n' -> true
+      | _ -> false)
+    text
+  |> List.map strip_wrapping_quotes
+
+let pipeline_segments cmd =
+  split_shell_fragments ~separator:(fun ch -> ch = '|') cmd
+
+let first_segment_tokens cmd =
+  match pipeline_segments cmd with
+  | [] -> []
+  | segment :: _ -> split_words segment
+
+let last_segment_tokens cmd =
+  match List.rev (pipeline_segments cmd) with
+  | [] -> []
+  | segment :: _ -> split_words segment
+
+let git_global_option_takes_value = function
+  | "-c" | "-C" | "--exec-path" | "--git-dir" | "--work-tree"
+  | "--namespace" | "--super-prefix" | "--config-env" -> true
+  | _ -> false
+
+let git_global_option_has_inline_value token =
+  List.exists (fun prefix -> String.starts_with ~prefix token)
+    [ "--exec-path="; "--git-dir="; "--work-tree="; "--namespace="; "--config-env=" ]
+
+let rec first_git_subcommand = function
+  | [] -> None
+  | token :: rest when git_global_option_takes_value token ->
+      (match rest with
+       | _value :: tail -> first_git_subcommand tail
+       | [] -> None)
+  | token :: rest when git_global_option_has_inline_value token ->
+      first_git_subcommand rest
+  | token :: rest when String.starts_with ~prefix:"-" token ->
+      first_git_subcommand rest
+  | token :: _ -> Some token
+
+let base_command_of_tokens = function
+  | [] -> None
+  | token :: _ -> Some (Filename.basename token)
+
+let last_base_command cmd =
+  last_segment_tokens cmd |> base_command_of_tokens
+
+let second_token = function
+  | _cmd :: sub :: _ -> Some sub
+  | _ -> None
+
+let looks_like_test_command ~base ~sub =
+  match String.lowercase_ascii base, Option.map String.lowercase_ascii sub with
+  | ("pytest" | "pyright" | "ruff"), _ -> true
+  | "cargo", Some ("test" | "check" | "clippy") -> true
+  | "dune", Some ("runtest" | "test") -> true
+  | "make", Some "test" -> true
+  | ("npm" | "pnpm" | "yarn"), Some ("test" | "lint" | "typecheck" | "check") -> true
+  | ("python" | "python3" | "node" | "go"), Some "test" -> true
+  | _ -> false
+
+let family_of_base_command ~cmd ~tokens ~base =
+  let sub = second_token tokens in
+  let write_intent = Worker_dev_tools.is_write_operation cmd in
+  match String.lowercase_ascii base with
+  | "git" ->
+      (match first_git_subcommand
+               (match tokens with
+                | _ :: rest -> rest
+                | [] -> [])
+       with
+       | Some "clone" -> Clone
+       | _ -> if write_intent then Git_write else Git_read)
+  | "rg" | "grep" | "find" -> Search
+  | "ls" | "tree" | "du" -> List
+  | "cat" | "head" | "tail" | "wc" | "pwd" | "env" | "which"
+  | "file" | "stat" | "cut" | "sort" | "uniq" | "tr" | "sed" ->
+      Read
+  | "curl" | "wget" -> Network_read
+  | "npm" | "pnpm" | "yarn" | "pip" | "opam" ->
+      if write_intent then Package_install
+      else if looks_like_test_command ~base ~sub then Test
+      else Build
+  | "cargo" | "dune" | "make" | "go" | "gofmt" | "gradle" | "mvn"
+  | "cmake" | "ninja" | "java" | "javac" | "node" | "npx"
+  | "python" | "python3" | "rustc" | "uv" ->
+      if looks_like_test_command ~base ~sub then Test else Build
+  | _ -> Unknown
+
+let reversibility_of_command ~cmd family =
+  if Worker_dev_tools.is_destructive_bash_operation cmd then Irreversible
+  else
+    match family with
+    | Read | Search | List | Build | Test | Git_read | Network_read -> Read_only
+    | Package_install | Clone | Git_write | Unknown -> Reversible
+
+let risk_of_command ~cmd ~write_intent family =
+  if Worker_dev_tools.is_destructive_bash_operation cmd then High
+  else
+    match family with
+    | Git_write | Package_install | Clone -> High
+    | Unknown when write_intent -> High
+    | Build | Test | Network_read | Unknown -> Medium
+    | Read | Search | List | Git_read -> Low
+
+let classify_command ~cmd =
+  let tokens = first_segment_tokens cmd in
+  let write_intent = Worker_dev_tools.is_write_operation cmd in
+  let family =
+    match base_command_of_tokens tokens with
+    | Some base -> family_of_base_command ~cmd ~tokens ~base
+    | None -> Unknown
+  in
+  {
+    family;
+    reversibility = reversibility_of_command ~cmd family;
+    risk = risk_of_command ~cmd ~write_intent family;
+    write_intent;
+  }
+
+let string_of_command_family = function
+  | Read -> "read"
+  | Search -> "search"
+  | List -> "list"
+  | Build -> "build"
+  | Test -> "test"
+  | Git_read -> "git_read"
+  | Git_write -> "git_write"
+  | Package_install -> "package_install"
+  | Network_read -> "network_read"
+  | Clone -> "clone"
+  | Unknown -> "unknown"
+
+let string_of_reversibility = function
+  | Read_only -> "read_only"
+  | Reversible -> "reversible"
+  | Irreversible -> "irreversible"
+
+let string_of_risk = function
+  | Low -> "low"
+  | Medium -> "medium"
+  | High -> "high"
+
+let classification_to_json classification =
+  `Assoc
+    [
+      ("family", `String (string_of_command_family classification.family));
+      ( "reversibility",
+        `String (string_of_reversibility classification.reversibility) );
+      ("risk", `String (string_of_risk classification.risk));
+      ("write_intent", `Bool classification.write_intent);
+    ]
+
+let process_status_is_timeout = function
+  | Unix.WSIGNALED sig_num -> sig_num = Sys.sigterm
+  | Unix.WEXITED 124 -> true
+  | _ -> false
+
+let string_of_semantic_status = function
+  | Ok -> "ok"
+  | No_match -> "no_match"
+  | Partial -> "partial"
+  | Blocked -> "blocked"
+  | Timeout -> "timeout"
+  | Runtime_error -> "runtime_error"
+
+let string_of_retryability = function
+  | None_ -> "none"
+  | Self_correct -> "self_correct"
+  | Operator_required -> "operator_required"
+
+let non_empty_lines output =
+  output
+  |> String.split_on_char '\n'
+  |> List.map String.trim
+  |> List.filter (fun line -> line <> "")
+
+let is_find_diagnostic_line line =
+  let trimmed = String.trim line in
+  String.starts_with ~prefix:"find:" trimmed
+  || String.starts_with ~prefix:"find " trimmed
+
+let semantic_status_of_find_output output =
+  let lines = non_empty_lines output in
+  let has_result_line =
+    List.exists (fun line -> not (is_find_diagnostic_line line)) lines
+  in
+  let has_diagnostic_line = List.exists is_find_diagnostic_line lines in
+  if has_result_line && has_diagnostic_line then Partial else Runtime_error
+
+let semantic_status_of_process ~cmd ~output status =
+  if process_status_is_timeout status then Timeout
+  else
+    match status with
+    | Unix.WEXITED 0 -> Ok
+    | Unix.WEXITED 1 ->
+        (match last_base_command cmd with
+         | Some ("rg" | "grep") -> No_match
+         | Some "find" -> semantic_status_of_find_output output
+         | _ -> Runtime_error)
+    | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> Runtime_error
+
+let retryability_of_semantic_status = function
+  | Ok -> None_
+  | Blocked | No_match | Partial | Timeout | Runtime_error -> Self_correct
+
+let semantic_status_is_success = function
+  | Ok | No_match -> true
+  | Blocked | Timeout | Runtime_error -> false
+  | Partial -> false
+
+let family_label = function
+  | Read -> "read"
+  | Search -> "search"
+  | List -> "list"
+  | Build -> "build"
+  | Test -> "test"
+  | Git_read -> "git inspection"
+  | Git_write -> "git write"
+  | Package_install -> "package management"
+  | Network_read -> "network"
+  | Clone -> "clone"
+  | Unknown -> "command"
+
+let summary_of_status classification semantic_status =
+  let label = family_label classification.family in
+  match semantic_status with
+  | Ok -> Printf.sprintf "%s command completed." (String.capitalize_ascii label)
+  | No_match -> Printf.sprintf "%s completed with no matches." (String.capitalize_ascii label)
+  | Partial -> Printf.sprintf "%s completed with partial results." (String.capitalize_ascii label)
+  | Blocked -> Printf.sprintf "%s command blocked before execution." (String.capitalize_ascii label)
+  | Timeout -> Printf.sprintf "%s command timed out." (String.capitalize_ascii label)
+  | Runtime_error -> Printf.sprintf "%s command failed at runtime." (String.capitalize_ascii label)
+
+let default_recovery_hint classification semantic_status =
+  match semantic_status with
+  | Ok -> None
+  | No_match ->
+      Some
+        (match classification.family with
+         | Search ->
+             "Adjust the search pattern or narrow the target path, then retry."
+         | _ ->
+             "Retry with a narrower command or switch to a structured shell op.")
+  | Partial ->
+      Some "Inspect the output for partial results and retry with a narrower scope if needed."
+  | Timeout ->
+      Some "Narrow the command scope, reduce output volume, or increase timeout_sec moderately."
+  | Runtime_error ->
+      Some "Inspect the command output, then retry with a narrower command or a structured shell op."
+  | Blocked ->
+      Some "Revise the command or switch to the structured shell tool that matches the intent."
+
+let ensure_exec_artifact_dir path =
+  try Fs_compat.mkdir_p path
+  with
+  | Sys_error msg ->
+      Logs.warn (fun f -> f "exec artifact mkdir failed: %s" msg)
+
+let persist_artifact_if_needed ~base_path ~keeper_name ~cmd ~output =
+  if String.length output <= artifact_threshold_bytes then
+    None
+  else
+    let now = Unix.gettimeofday () in
+    let tm = Unix.localtime now in
+    let keeper = Playground_paths.sanitize_keeper_name keeper_name in
+    let dir =
+      Filename.concat base_path
+        (Printf.sprintf ".masc/exec-artifacts/%s/%04d-%02d-%02d"
+           keeper
+           (tm.tm_year + 1900)
+           (tm.tm_mon + 1)
+           tm.tm_mday)
+    in
+    ensure_exec_artifact_dir dir;
+    let digest =
+      Digest.to_hex (Digest.string (cmd ^ "\n" ^ output ^ "\n" ^ string_of_float now))
+    in
+    let digest_prefix =
+      String.sub digest 0 (min 12 (String.length digest))
+    in
+    let path =
+      Filename.concat dir
+        (Printf.sprintf "%d-%s.txt"
+           (int_of_float (now *. 1000.0))
+           digest_prefix)
+    in
+    match Fs_compat.save_file_atomic path output with
+    | Ok () -> Some { path; bytes = String.length output; storage = Filesystem }
+    | Error err ->
+        Logs.warn (fun f -> f "exec artifact persist failed: %s" err);
+        None
+
+let string_of_artifact_storage = function
+  | Filesystem -> "filesystem"
+
+let artifact_ref_to_json artifact_ref =
+  `Assoc
+    [
+      ("kind", `String "full_output");
+      ("path", `String artifact_ref.path);
+      ("bytes", `Int artifact_ref.bytes);
+      ("storage", `String (string_of_artifact_storage artifact_ref.storage));
+    ]
+
+let artifact_refs_of_output ~artifact_policy ~base_path ~keeper_name ~cmd ~output =
+  match artifact_policy with
+  | Inline_only -> []
+  | Persist_if_large ->
+      (match persist_artifact_if_needed ~base_path ~keeper_name ~cmd ~output with
+       | Some artifact_ref -> [ artifact_ref ]
+       | None -> [])
+
+let build_process_outcome ~artifact_policy ~base_path ~keeper_name ~cmd ~status
+    ~output =
+  let classification = classify_command ~cmd in
+  let semantic_status = semantic_status_of_process ~cmd ~output status in
+  let summary = summary_of_status classification semantic_status in
+  let retryability = retryability_of_semantic_status semantic_status in
+  let artifact_refs =
+    artifact_refs_of_output ~artifact_policy ~base_path ~keeper_name ~cmd
+      ~output
+  in
+  let recovery_hint =
+    match default_recovery_hint classification semantic_status with
+    | Some hint -> Some hint
+    | None -> None
+  in
+  Executed
+    {
+      command = cmd;
+      process_status = status;
+      output;
+      semantic_status;
+      classification;
+      summary;
+      retryability;
+      artifact_refs;
+      recovery_hint;
+    }
+
+let build_blocked_outcome ~cmd ~error ~reason ?hint ?(retryability = Self_correct) () =
+  let classification = classify_command ~cmd in
+  let summary = summary_of_status classification Blocked in
+  let recovery_hint =
+    match hint with
+    | Some value -> value
+    | None ->
+        Option.value
+          ~default:"Revise the command or use a more specific shell tool."
+          (default_recovery_hint classification Blocked)
+  in
+  Blocked_result
+    {
+      command = cmd;
+      error;
+      reason;
+      hint = recovery_hint;
+      classification;
+      retryability;
+      summary;
+    }
+
+let outcome_to_json ?(extra = []) = function
+  | Executed result ->
+      let hint_fields =
+        match result.recovery_hint with
+        | Some hint ->
+            [ ("hint", `String hint); ("recovery_hint", `String hint) ]
+        | None -> []
+      in
+      `Assoc
+        ([
+           ("ok", `Bool (semantic_status_is_success result.semantic_status));
+         ]
+         @ extra
+         @ [
+             ( "status",
+               Keeper_alerting_path.process_status_to_json result.process_status );
+             ("output", `String result.output);
+             ( "semantic_status",
+               `String (string_of_semantic_status result.semantic_status) );
+             ("classification", classification_to_json result.classification);
+             ("retryability", `String (string_of_retryability result.retryability));
+             ("summary", `String result.summary);
+             ("artifact_refs", `List (List.map artifact_ref_to_json result.artifact_refs));
+           ]
+         @ hint_fields)
+  | Blocked_result result ->
+      `Assoc
+        ([
+           ("ok", `Bool false);
+           ("error", `String result.error);
+           ("reason", `String result.reason);
+         ]
+         @ extra
+         @ [
+             ("semantic_status", `String (string_of_semantic_status Blocked));
+             ("classification", classification_to_json result.classification);
+             ("retryability", `String (string_of_retryability result.retryability));
+             ("summary", `String result.summary);
+             ("hint", `String result.hint);
+             ("recovery_hint", `String result.hint);
+           ])
+
+let process_result_json ?(artifact_policy = Persist_if_large) ~base_path
+    ~keeper_name ~cmd ?(extra = []) ~status ~output () =
+  build_process_outcome ~artifact_policy ~base_path ~keeper_name ~cmd ~status
+    ~output
+  |> outcome_to_json ~extra
+
+let blocked_result_json ~cmd ~error ~reason ?hint ?(retryability = Self_correct)
+    ?(extra = []) () =
+  build_blocked_outcome ~cmd ~error ~reason ?hint ~retryability ()
+  |> outcome_to_json ~extra

--- a/lib/exec_core.mli
+++ b/lib/exec_core.mli
@@ -1,0 +1,137 @@
+type command_family =
+  | Read
+  | Search
+  | List
+  | Build
+  | Test
+  | Git_read
+  | Git_write
+  | Package_install
+  | Network_read
+  | Clone
+  | Unknown
+
+type reversibility =
+  | Read_only
+  | Reversible
+  | Irreversible
+
+type risk =
+  | Low
+  | Medium
+  | High
+
+type semantic_status =
+  | Ok
+  | No_match
+  | Partial
+  | Blocked
+  | Timeout
+  | Runtime_error
+
+type retryability =
+  | None_
+  | Self_correct
+  | Operator_required
+
+type artifact_policy =
+  | Inline_only
+  | Persist_if_large
+
+type classification = {
+  family : command_family;
+  reversibility : reversibility;
+  risk : risk;
+  write_intent : bool;
+}
+
+type artifact_storage =
+  | Filesystem
+
+type artifact_ref = {
+  path : string;
+  bytes : int;
+  storage : artifact_storage;
+}
+
+type executed_result = {
+  command : string;
+  process_status : Unix.process_status;
+  output : string;
+  semantic_status : semantic_status;
+  classification : classification;
+  summary : string;
+  retryability : retryability;
+  artifact_refs : artifact_ref list;
+  recovery_hint : string option;
+}
+
+type blocked_result = {
+  command : string;
+  error : string;
+  reason : string;
+  hint : string;
+  classification : classification;
+  retryability : retryability;
+  summary : string;
+}
+
+type outcome =
+  | Executed of executed_result
+  | Blocked_result of blocked_result
+
+val classify_command : cmd:string -> classification
+val classification_to_json : classification -> Yojson.Safe.t
+
+val string_of_semantic_status : semantic_status -> string
+val semantic_status_of_process :
+  cmd:string ->
+  output:string ->
+  Unix.process_status ->
+  semantic_status
+
+val string_of_retryability : retryability -> string
+
+val build_process_outcome :
+  artifact_policy:artifact_policy ->
+  base_path:string ->
+  keeper_name:string ->
+  cmd:string ->
+  status:Unix.process_status ->
+  output:string ->
+  outcome
+
+val build_blocked_outcome :
+  cmd:string ->
+  error:string ->
+  reason:string ->
+  ?hint:string ->
+  ?retryability:retryability ->
+  unit ->
+  outcome
+
+val outcome_to_json :
+  ?extra:(string * Yojson.Safe.t) list ->
+  outcome ->
+  Yojson.Safe.t
+
+val process_result_json :
+  ?artifact_policy:artifact_policy ->
+  base_path:string ->
+  keeper_name:string ->
+  cmd:string ->
+  ?extra:(string * Yojson.Safe.t) list ->
+  status:Unix.process_status ->
+  output:string ->
+  unit ->
+  Yojson.Safe.t
+
+val blocked_result_json :
+  cmd:string ->
+  error:string ->
+  reason:string ->
+  ?hint:string ->
+  ?retryability:retryability ->
+  ?extra:(string * Yojson.Safe.t) list ->
+  unit ->
+  Yojson.Safe.t

--- a/lib/keeper/keeper_exec_shell.ml
+++ b/lib/keeper/keeper_exec_shell.ml
@@ -342,6 +342,7 @@ let handle_keeper_bash
       ~(args : Yojson.Safe.t)
   =
   let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
+  let root = Keeper_alerting_path.project_root_of_config config in
   let cmd_for_log =
     cmd
     |> Worker_dev_tools.sanitize_command_for_log
@@ -372,7 +373,6 @@ let handle_keeper_bash
     let playground_rel =
       Keeper_alerting_path.playground_path_of_keeper meta.name
     in
-    let root = Keeper_alerting_path.project_root_of_config config in
     let playground_abs =
       normalize_path_for_containment (Filename.concat root playground_rel)
     in
@@ -388,15 +388,15 @@ let handle_keeper_bash
     then (
       Log.Keeper.warn "keeper_bash DESTRUCTIVE blocked: %s (keeper=%s)" cmd_for_log meta.name;
       Yojson.Safe.to_string
-        (`Assoc
-            [ "ok", `Bool false
-            ; "error", `String "destructive_operation_blocked"
-            ; ( "reason"
-              , `String
-                  "This command is destructive (force push, push to main, rm -rf, \
-                   etc.) and is blocked for all presets." )
-            ; "cmd", `String cmd_for_log
-            ]))
+        (Exec_core.blocked_result_json
+           ~cmd
+           ~error:"destructive_operation_blocked"
+           ~reason:
+             "This command is destructive (force push, push to main, rm -rf, \
+              etc.) and is blocked for all presets."
+           ~retryability:Exec_core.Operator_required
+           ~extra:[ "cmd", `String cmd_for_log ]
+           ()))
     else if use_docker then (
       (* Docker playground path: skip command whitelist and path validation.
          The container provides isolation — chaining, pipes, tee are safe.
@@ -413,12 +413,14 @@ let handle_keeper_bash
             container; "bash"; "-c"; cmd ^ " 2>&1" ]
       in
       Yojson.Safe.to_string
-        (`Assoc
-            [ "ok", `Bool (st = Unix.WEXITED 0)
-            ; "cwd", `String cwd
-            ; "status", Keeper_alerting_path.process_status_to_json st
-            ; "output", `String out
-            ]))
+        (Exec_core.process_result_json
+           ~base_path:root
+           ~keeper_name:meta.name
+           ~cmd
+           ~extra:[ "cwd", `String cwd ]
+           ~status:st
+           ~output:out
+           ()))
     else
       (* Local execution path: full validation applies *)
       let validate =
@@ -445,12 +447,12 @@ let handle_keeper_bash
             "Provide a non-empty command string."
         in
         Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool false
-              ; "error", `String "command_blocked"
-              ; "reason", `String reason_str
-              ; "hint", `String hint
-              ])
+          (Exec_core.blocked_result_json
+             ~cmd
+             ~error:"command_blocked"
+             ~reason:reason_str
+             ~hint
+             ())
       | Ok () ->
         (* Branch-switch guard *)
         if Worker_dev_tools.is_git_branch_switch cmd
@@ -460,33 +462,33 @@ let handle_keeper_bash
             "keeper_bash branch-switch blocked: %s (keeper=%s, write_enabled=%b, playground=%b)"
             cmd_for_log meta.name write_enabled in_playground;
           Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool false
-                ; "error", `String "branch_switch_blocked"
-                ; ( "reason"
-                  , `String
-                      "git checkout/switch/branch mutations require a write-enabled preset \
-                       (Coding/Delivery/Full) and a playground clone. \
-                       Clone into your playground first (keeper_shell op=git_clone), \
-                       then set cwd to the cloned repo path." )
-                ; "cmd", `String cmd_for_log
-                ; "hint", `String (Printf.sprintf "Use cwd=%srepos/REPO" (Playground_paths.bundle_root meta.name))
-                ]))
+            (Exec_core.blocked_result_json
+               ~cmd
+               ~error:"branch_switch_blocked"
+               ~reason:
+                 "git checkout/switch/branch mutations require a write-enabled preset \
+                  (Coding/Delivery/Full) and a playground clone. \
+                  Clone into your playground first (keeper_shell op=git_clone), \
+                  then set cwd to the cloned repo path."
+               ~hint:(Printf.sprintf "Use cwd=%srepos/REPO" (Playground_paths.bundle_root meta.name))
+               ~retryability:Exec_core.Operator_required
+               ~extra:[ "cmd", `String cmd_for_log ]
+               ()))
         (* Write gate — preset layer *)
         else if (not write_enabled) && Worker_dev_tools.is_write_operation cmd
         then (
           Log.Keeper.info "keeper_bash write-gate: %s (keeper=%s, playground=%b)"
             cmd_for_log meta.name in_playground;
           Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool false
-                ; "error", `String "write_operation_gated"
-                ; ( "reason"
-                  , `String
-                      "This command modifies state (git push/commit, make deploy, etc.). \
-                       A write-enabled preset (Coding/Delivery/Full) is required." )
-                ; "cmd", `String cmd_for_log
-                ]))
+            (Exec_core.blocked_result_json
+               ~cmd
+               ~error:"write_operation_gated"
+               ~reason:
+                 "This command modifies state (git push/commit, make deploy, etc.). \
+                  A write-enabled preset (Coding/Delivery/Full) is required."
+               ~retryability:Exec_core.Operator_required
+               ~extra:[ "cmd", `String cmd_for_log ]
+               ()))
         (* Write gate — playground containment layer (#6527 iter 3).
            A write-enabled keeper still must not mutate anything outside
            its own playground bundle. branch-switch already requires
@@ -503,22 +505,21 @@ let handle_keeper_bash
             "keeper_bash write-containment blocked: %s (keeper=%s, cwd=%s, playground=%b)"
             cmd_for_log meta.name cwd in_playground;
           Yojson.Safe.to_string
-            (`Assoc
-                [ "ok", `Bool false
-                ; "error", `String "write_outside_playground_blocked"
-                ; ( "reason"
-                  , `String
-                      (Printf.sprintf
-                         "Write operations (git push/commit, make deploy, etc.) \
-                          must run with cwd inside your playground \
-                          (%s). Open a worktree under \
-                          your playground clone first via masc_worktree_create, \
-                          then set cwd to the returned worktree path."
-                         (Playground_paths.bundle_root meta.name)) )
-                ; "cmd", `String cmd_for_log
-                ; "cwd", `String cwd
-                ; "hint", `String (Printf.sprintf "cwd must start with %s" (Playground_paths.bundle_root meta.name))
-                ]))
+            (Exec_core.blocked_result_json
+               ~cmd
+               ~error:"write_outside_playground_blocked"
+               ~reason:
+                 (Printf.sprintf
+                    "Write operations (git push/commit, make deploy, etc.) \
+                     must run with cwd inside your playground \
+                     (%s). Open a worktree under \
+                     your playground clone first via masc_worktree_create, \
+                     then set cwd to the returned worktree path."
+                    (Playground_paths.bundle_root meta.name))
+               ~hint:(Printf.sprintf "cwd must start with %s" (Playground_paths.bundle_root meta.name))
+               ~retryability:Exec_core.Operator_required
+               ~extra:[ "cmd", `String cmd_for_log; "cwd", `String cwd ]
+               ()))
         else (
             (match Worker_dev_tools.validate_command_paths ~workdir:cwd cmd with
              | Error e -> error_json e
@@ -532,12 +533,14 @@ let handle_keeper_bash
                    [ "/bin/bash"; "-lc"; cmd ^ " 2>&1" ]
                in
                Yojson.Safe.to_string
-                 (`Assoc
-                     [ "ok", `Bool (st = Unix.WEXITED 0)
-                     ; "cwd", `String cwd
-                     ; "status", Keeper_alerting_path.process_status_to_json st
-                     ; "output", `String out
-                     ])))
+                 (Exec_core.process_result_json
+                    ~base_path:root
+                    ~keeper_name:meta.name
+                    ~cmd
+                    ~extra:[ "cwd", `String cwd ]
+                    ~status:st
+                    ~output:out
+                    ())))
 ;;
 
 let handle_keeper_shell
@@ -575,17 +578,23 @@ let handle_keeper_shell
       Process_eio.run_argv_with_status ?cwd ~timeout_sec:io_timeout_sec argv
     in
     Yojson.Safe.to_string
-      (`Assoc
-          [ "ok", `Bool (st = Unix.WEXITED 0)
-          ; "op", `String op
-          ; "cmd", `String cmd
-          ; ( "cwd"
-            , match cwd with
-              | Some dir -> `String dir
-              | None -> `Null )
-          ; "status", Keeper_alerting_path.process_status_to_json st
-          ; "output", `String out
-          ])
+      (Exec_core.process_result_json
+         ~artifact_policy:Exec_core.Inline_only
+         ~base_path:root
+         ~keeper_name:meta.name
+         ~cmd
+         ~extra:
+           [
+             "op", `String op;
+             "cmd", `String cmd;
+             ( "cwd",
+               match cwd with
+               | Some dir -> `String dir
+               | None -> `Null );
+           ]
+         ~status:st
+         ~output:out
+         ())
   in
   match op with
   | "pwd" ->
@@ -895,14 +904,21 @@ let handle_keeper_shell
       | Some (pat, category) ->
         let hint = hint_of_category category in
         Yojson.Safe.to_string
-          (`Assoc
-              [ "ok", `Bool false
-              ; "op", `String op
-              ; "error", `String "command_blocked_readonly"
-              ; "blocked_pattern", `String pat
-              ; "category", `String category
-              ; "hint", `String hint
-              ])
+          (Exec_core.blocked_result_json
+             ~cmd:cmd_str
+             ~error:"command_blocked_readonly"
+             ~reason:
+               (Printf.sprintf
+                  "Readonly shell blocked pattern '%s' in category '%s'."
+                  pat category)
+             ~hint
+             ~extra:
+               [
+                 "op", `String op;
+                 "blocked_pattern", `String pat;
+                 "category", `String category;
+               ]
+             ())
       | None ->
         (match cwd_target () with
          | Error e -> path_error e
@@ -916,27 +932,38 @@ let handle_keeper_shell
               in
               if process_status_is_timeout st then
                 Yojson.Safe.to_string
-                  (`Assoc
-                      [ "ok", `Bool false
-                      ; "op", `String op
-                      ; "cwd", `String cwd
-                      ; "command", `String cmd_str
-                      ; "error", `String "command_timed_out"
-                      ; "timeout_sec", `Float timeout_sec
-                      ; "status", Keeper_alerting_path.process_status_to_json st
-                      ; "output", `String out
-                      ; "hint", `String "Narrow the scope or use structured ops like rg/find/ls instead of broad bash scans."
-                      ])
+                  (Exec_core.process_result_json
+                     ~artifact_policy:Exec_core.Inline_only
+                     ~base_path:root
+                     ~keeper_name:meta.name
+                     ~cmd:cmd_str
+                     ~extra:
+                       [
+                         "op", `String op;
+                         "cwd", `String cwd;
+                         "command", `String cmd_str;
+                         "error", `String "command_timed_out";
+                         "timeout_sec", `Float timeout_sec;
+                       ]
+                     ~status:st
+                     ~output:out
+                     ())
               else
                 Yojson.Safe.to_string
-                  (`Assoc
-                      [ "ok", `Bool (st = Unix.WEXITED 0)
-                      ; "op", `String op
-                      ; "cwd", `String cwd
-                      ; "command", `String cmd_str
-                      ; "status", Keeper_alerting_path.process_status_to_json st
-                      ; "output", `String out
-                      ]))))
+                  (Exec_core.process_result_json
+                     ~artifact_policy:Exec_core.Inline_only
+                     ~base_path:root
+                     ~keeper_name:meta.name
+                     ~cmd:cmd_str
+                     ~extra:
+                       [
+                         "op", `String op;
+                         "cwd", `String cwd;
+                         "command", `String cmd_str;
+                       ]
+                     ~status:st
+                     ~output:out
+                     ()))))
   | "git_clone" ->
     (* Clone a repo into this keeper's playground repos directory.
        Sandboxed: always targets .masc/playground/<keeper_name>/repos/<repo_name>.

--- a/test/dune
+++ b/test/dune
@@ -78,6 +78,7 @@
         test_keeper_runtime_toml
         test_keeper_tool_policy_config
         test_keeper_toml_config_validation
+        test_exec_core
         test_keeper_bash_safety
         test_hitl_approval
         test_keeper_discovered_tools
@@ -171,6 +172,7 @@
           test_keeper_runtime_toml
           test_keeper_tool_policy_config
           test_keeper_toml_config_validation
+          test_exec_core
           test_keeper_bash_safety
           test_hitl_approval
           test_keeper_discovered_tools

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -1,0 +1,181 @@
+open Alcotest
+open Yojson.Safe.Util
+
+let get_string_field json key =
+  json |> member key |> to_string
+
+let test_rg_no_match_is_semantic_success () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"exec-core"
+      ~cmd:"rg missing_pattern lib/"
+      ~status:(Unix.WEXITED 1)
+      ~output:""
+      ()
+  in
+  check bool "ok" true (json |> member "ok" |> to_bool);
+  check string "semantic_status" "no_match"
+    (get_string_field json "semantic_status");
+  check string "family" "search"
+    (json |> member "classification" |> member "family" |> to_string)
+
+let test_find_partial_is_semantic_success () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"exec-core"
+      ~cmd:"find lib -name '*.ml'"
+      ~status:(Unix.WEXITED 1)
+      ~output:"lib/exec_core.ml\nfind: lib/private: Permission denied"
+      ()
+  in
+  check bool "ok" false (json |> member "ok" |> to_bool);
+  check string "semantic_status" "partial"
+    (get_string_field json "semantic_status")
+
+let test_find_missing_path_is_runtime_error () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"exec-core"
+      ~cmd:"find /tmp /definitely-missing-path-xyz"
+      ~status:(Unix.WEXITED 1)
+      ~output:"find: /definitely-missing-path-xyz: No such file or directory"
+      ()
+  in
+  check bool "ok" false (json |> member "ok" |> to_bool);
+  check string "semantic_status" "runtime_error"
+    (get_string_field json "semantic_status")
+
+let test_blocked_json_adds_classification () =
+  let json =
+    Masc_mcp.Exec_core.blocked_result_json
+      ~cmd:"git push origin main"
+      ~error:"write_operation_gated"
+      ~reason:"write preset required"
+      ~retryability:Masc_mcp.Exec_core.Operator_required
+      ()
+  in
+  check string "error" "write_operation_gated"
+    (get_string_field json "error");
+  check string "semantic_status" "blocked"
+    (get_string_field json "semantic_status");
+  check string "family" "git_write"
+    (json |> member "classification" |> member "family" |> to_string);
+  check string "risk" "high"
+    (json |> member "classification" |> member "risk" |> to_string);
+  check string "hint"
+    "Revise the command or switch to the structured shell tool that matches the intent."
+    (get_string_field json "hint");
+  check string "recovery_hint"
+    "Revise the command or switch to the structured shell tool that matches the intent."
+    (get_string_field json "recovery_hint");
+  check string "retryability" "operator_required"
+    (get_string_field json "retryability")
+
+let test_regex_pipe_inside_quotes_keeps_no_match_semantics () =
+  let json =
+    Masc_mcp.Exec_core.process_result_json
+      ~base_path:"/tmp"
+      ~keeper_name:"exec-core"
+      ~cmd:"rg 'a|b' lib/"
+      ~status:(Unix.WEXITED 1)
+      ~output:""
+      ()
+  in
+  check bool "ok" true (json |> member "ok" |> to_bool);
+  check string "semantic_status" "no_match"
+    (get_string_field json "semantic_status")
+
+let test_unknown_write_is_not_git_write () =
+  let classification =
+    Masc_mcp.Exec_core.classify_command ~cmd:"mkdir tmp/generated"
+  in
+  check string "family" "unknown"
+    (Masc_mcp.Exec_core.classification_to_json classification
+     |> member "family" |> to_string);
+  check bool "write_intent" true classification.write_intent
+
+let temp_dir () =
+  let path = Filename.temp_file "exec_core_" "" in
+  Sys.remove path;
+  Unix.mkdir path 0o755;
+  path
+
+let rec remove_tree path =
+  match (Unix.lstat path).Unix.st_kind with
+  | Unix.S_DIR ->
+      Sys.readdir path
+      |> Array.iter (fun entry -> remove_tree (Filename.concat path entry));
+      Unix.rmdir path
+  | _ ->
+      Unix.unlink path
+
+let test_large_output_persists_artifact () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+      let output = String.make 17000 'x' in
+      let json =
+        Masc_mcp.Exec_core.process_result_json
+          ~artifact_policy:Masc_mcp.Exec_core.Persist_if_large
+          ~base_path
+          ~keeper_name:"exec-core"
+          ~cmd:"cat README.md"
+          ~status:(Unix.WEXITED 0)
+          ~output
+          ()
+      in
+      let refs = json |> member "artifact_refs" |> to_list in
+      check int "one artifact ref" 1 (List.length refs);
+      let artifact_path = List.hd refs |> member "path" |> to_string in
+      check bool "artifact exists" true (Sys.file_exists artifact_path);
+      check int "artifact bytes" (String.length output)
+        ((List.hd refs |> member "bytes" |> to_int));
+      check string "persisted contents" output
+        (Fs_compat.load_file artifact_path))
+
+let test_inline_only_keeps_artifact_refs_empty () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () ->
+      let output = String.make 17000 'x' in
+      let json =
+        Masc_mcp.Exec_core.process_result_json
+          ~artifact_policy:Masc_mcp.Exec_core.Inline_only
+          ~base_path
+          ~keeper_name:"exec-core"
+          ~cmd:"cat README.md"
+          ~status:(Unix.WEXITED 0)
+          ~output
+          ()
+      in
+      let refs = json |> member "artifact_refs" |> to_list in
+      check int "no artifact ref" 0 (List.length refs))
+
+let () =
+  run "exec_core"
+    [
+      ( "semantic_status",
+        [
+          test_case "rg no match is semantic success" `Quick
+            test_rg_no_match_is_semantic_success;
+          test_case "find partial is recoverable but not success" `Quick
+            test_find_partial_is_semantic_success;
+          test_case "find missing path is runtime error" `Quick
+            test_find_missing_path_is_runtime_error;
+          test_case "quoted regex pipe keeps no-match semantics" `Quick
+            test_regex_pipe_inside_quotes_keeps_no_match_semantics;
+          test_case "blocked json adds classification" `Quick
+            test_blocked_json_adds_classification;
+          test_case "unknown write is not git_write" `Quick
+            test_unknown_write_is_not_git_write;
+          test_case "large output persists artifact" `Quick
+            test_large_output_persists_artifact;
+          test_case "inline only keeps artifact refs empty" `Quick
+            test_inline_only_keeps_artifact_refs_empty;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add a shared `Exec_core` substrate for bash/process execution with typed OCaml variants for classification, semantic status, retryability, and artifact policy
- harden shell result semantics and contract compatibility by preserving `hint` while adding `recovery_hint`, tightening `find`/quoted-pipe handling, and avoiding false `git_write` classification for unknown mutating commands
- align readonly shell and dashboard behavior by disabling artifact persistence for readonly shell paths and teaching the dashboard about the newer OAS SSE lifecycle events already emitted by the bridge

## Why
The previous pass improved the shell surface but still had several correctness and contract issues from review:
- `find` exit code `1` could be treated as a successful partial result even for real failures
- unknown write commands such as `mkdir` could be mislabeled as `git_write`
- the JSON migration was not additive because `hint` disappeared in favor of `recovery_hint`
- readonly shell paths could unexpectedly mutate `.masc/exec-artifacts`
- the dashboard did not understand the newer `oas:agent_failed` / handoff events emitted by the SSE bridge

## Impact
- bash/exec callers now get a more honest semantic model from `Exec_core`
- readonly shell remains readonly with respect to artifact persistence
- downstream consumers can keep reading `hint` while adopting `recovery_hint`
- dashboard observability no longer drops the new OAS lifecycle events on the floor

## Root Cause
The first implementation still relied too heavily on naive string splitting and broad fallback heuristics. That made the new variants look typed without actually owning the truth at the command/result boundary.

## Validation
- `dune build --root . lib/exec_core.ml lib/keeper/keeper_exec_shell.ml test/test_exec_core.exe test/test_keeper_bash_safety.exe lib/oas_sse_bridge.ml lib/verifier_oas.ml`
- `dune exec --root . ./test/test_exec_core.exe`
- `./_build/default/test/test_keeper_bash_safety.exe`
- `dune exec --root . ./test/test_tool_quality_classify.exe`
- `pnpm typecheck` (in `dashboard/`)
- `pnpm lint` (in `dashboard/`)
- `git diff --check`
