### PR TITLE
feat(dashboard): add provider filter to cascade-config-panel Health Tracker

### DIFF
--- a/dashboard/src/components/cascade-config-panel.test.ts
+++ b/dashboard/src/components/cascade-config-panel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   traceEventMatchesSearch,
+  filterHealthProviders,
   fmtPct,
   candidateTone,
   sourceLabel,
@@ -244,5 +245,84 @@ describe('traceEventMatchesSearch', () => {
   it('returns true for empty query (no filtering)', () => {
     const e = makeTraceEvent()
     expect(traceEventMatchesSearch(e, '')).toBe(true)
+  })
+})
+
+describe('filterHealthProviders', () => {
+  it('returns input reference unchanged for empty query', () => {
+    const providers = [makeProvider({ provider_key: 'groq' })]
+    expect(filterHealthProviders(providers, '')).toBe(providers)
+  })
+
+  it('returns input reference unchanged for whitespace-only query', () => {
+    const providers = [makeProvider({ provider_key: 'groq' })]
+    expect(filterHealthProviders(providers, '   ')).toBe(providers)
+  })
+
+  it('trims the query before matching', () => {
+    const providers = [
+      makeProvider({ provider_key: 'groq-llama' }),
+      makeProvider({ provider_key: 'ollama-local' }),
+    ]
+    const result = filterHealthProviders(providers, '  groq  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.provider_key).toBe('groq-llama')
+  })
+
+  it('is case-insensitive on provider_key', () => {
+    const providers = [makeProvider({ provider_key: 'Groq-LLaMA' })]
+    expect(filterHealthProviders(providers, 'groq')).toHaveLength(1)
+    expect(filterHealthProviders(providers, 'LLAMA')).toHaveLength(1)
+  })
+
+  it('matches substring in provider_key', () => {
+    const providers = [
+      makeProvider({ provider_key: 'anthropic-claude' }),
+      makeProvider({ provider_key: 'openai-gpt4' }),
+      makeProvider({ provider_key: 'groq-llama' }),
+    ]
+    const result = filterHealthProviders(providers, 'gpt')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.provider_key).toBe('openai-gpt4')
+  })
+
+  it('matches "cooldown" keyword when provider is in cooldown', () => {
+    const providers = [
+      makeProvider({ provider_key: 'groq', in_cooldown: false }),
+      makeProvider({ provider_key: 'openai', in_cooldown: true }),
+    ]
+    const result = filterHealthProviders(providers, 'cooldown')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.provider_key).toBe('openai')
+  })
+
+  it('does not match "cooldown" keyword for providers not in cooldown', () => {
+    const providers = [
+      makeProvider({ provider_key: 'groq', in_cooldown: false }),
+    ]
+    expect(filterHealthProviders(providers, 'cooldown')).toHaveLength(0)
+  })
+
+  it('returns empty array when nothing matches', () => {
+    const providers = [
+      makeProvider({ provider_key: 'groq' }),
+      makeProvider({ provider_key: 'openai' }),
+    ]
+    expect(filterHealthProviders(providers, 'nonexistent-xyz')).toHaveLength(0)
+  })
+
+  it('returns empty array for empty input even with query', () => {
+    expect(filterHealthProviders([], 'groq')).toHaveLength(0)
+  })
+
+  it('does not mutate the input array', () => {
+    const providers = [
+      makeProvider({ provider_key: 'groq' }),
+      makeProvider({ provider_key: 'openai' }),
+    ]
+    const before = providers.map(p => p.provider_key)
+    filterHealthProviders(providers, 'groq')
+    expect(providers.map(p => p.provider_key)).toEqual(before)
+    expect(providers).toHaveLength(2)
   })
 })

--- a/dashboard/src/components/cascade-config-panel.ts
+++ b/dashboard/src/components/cascade-config-panel.ts
@@ -173,47 +173,94 @@ export function providerTone(p: CascadeHealthProvider): 'ok' | 'warn' | 'bad' {
   return 'ok'
 }
 
+/**
+ * Pure filter for Health Tracker provider rows.
+ *
+ * Case-insensitive substring match on `provider_key`. Also matches the
+ * literal keyword `cooldown` when `in_cooldown` is true so operators can
+ * isolate all providers currently being blocked.
+ *
+ * Empty/whitespace query returns the input reference unchanged so the
+ * non-filter path preserves referential equality (stable render).
+ *
+ * Input is never mutated.
+ */
+export function filterHealthProviders(
+  providers: readonly CascadeHealthProvider[],
+  query: string,
+): readonly CascadeHealthProvider[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return providers
+  return providers.filter(p => {
+    if (p.provider_key.toLowerCase().includes(needle)) return true
+    if (p.in_cooldown && 'cooldown'.includes(needle)) return true
+    return false
+  })
+}
+
 const TONE_DOT: Record<string, string> = {
   ok: 'bg-[var(--ok)]',
   warn: 'bg-[var(--warn)]',
   bad: 'bg-[var(--bad)]',
 }
 
-function HealthTable({ health }: { health: CascadeHealthResponse }) {
+function HealthTable({
+  health,
+  searchQuery,
+}: { health: CascadeHealthResponse; searchQuery: { value: string } }) {
   if (health.providers.length === 0) {
     return html`<${EmptyState}>아직 기록된 provider 이벤트가 없습니다.<//>`
   }
+  const filtered = filterHealthProviders(health.providers, searchQuery.value)
+  const isFiltering = searchQuery.value.trim() !== ''
   return html`
-    <table class="w-full text-xs">
-      <thead>
-        <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
-          <th class="text-left py-1 w-4"></th>
-          <th class="text-left py-1">Provider</th>
-          <th class="text-right py-1">Success</th>
-          <th class="text-right py-1">Consec. fail</th>
-          <th class="text-right py-1">Events</th>
-          <th class="text-right py-1">Cooldown</th>
-        </tr>
-      </thead>
-      <tbody>
-        ${health.providers.map((p: CascadeHealthProvider) => {
-          const tone = providerTone(p)
-          return html`
-          <tr class="border-b border-[var(--card-border)] last:border-b-0">
-            <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
-            <td class="py-1"><code class="text-[var(--text-strong)]">${p.provider_key}</code></td>
-            <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
-            <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
-            <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
-            <td class="py-1 text-right">
-              ${p.in_cooldown
-                ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`
-                : html`<span class="text-[var(--text-muted)]">—</span>`}
-            </td>
-          </tr>
-        `})}
-      </tbody>
-    </table>
+    <div class="flex items-center gap-3 mb-2">
+      <${TextInput}
+        type="search"
+        class="max-w-[280px]"
+        placeholder="provider 필터 (key, cooldown...)"
+        ariaLabel="health provider 검색"
+        value=${searchQuery.value}
+        onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
+      />
+      ${isFiltering
+        ? html`<span class="text-xs text-[var(--text-muted)]">${filtered.length}/${health.providers.length}건</span>`
+        : null}
+    </div>
+    ${isFiltering && filtered.length === 0
+      ? html`<div class="py-4 text-center text-[11px] text-[var(--text-muted)]">필터 결과 없음 (${health.providers.length} providers)</div>`
+      : html`
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="text-[var(--text-muted)] border-b border-[var(--card-border)]">
+              <th class="text-left py-1 w-4"></th>
+              <th class="text-left py-1">Provider</th>
+              <th class="text-right py-1">Success</th>
+              <th class="text-right py-1">Consec. fail</th>
+              <th class="text-right py-1">Events</th>
+              <th class="text-right py-1">Cooldown</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${filtered.map((p: CascadeHealthProvider) => {
+              const tone = providerTone(p)
+              return html`
+              <tr class="border-b border-[var(--card-border)] last:border-b-0">
+                <td class="py-1"><span class=${`inline-block w-2 h-2 rounded-full ${TONE_DOT[tone]}`}></span></td>
+                <td class="py-1"><code class="text-[var(--text-strong)]">${p.provider_key}</code></td>
+                <td class="py-1 text-right tabular-nums">${fmtPct(p.success_rate)}</td>
+                <td class="py-1 text-right tabular-nums">${p.consecutive_failures}</td>
+                <td class="py-1 text-right tabular-nums">${p.events_in_window}</td>
+                <td class="py-1 text-right">
+                  ${p.in_cooldown
+                    ? html`<${StatusChip} tone="bad">${fmtCooldownExpiry(p.cooldown_expires_at)}<//>`
+                    : html`<span class="text-[var(--text-muted)]">—</span>`}
+                </td>
+              </tr>
+            `})}
+          </tbody>
+        </table>
+      `}
   `
 }
 
@@ -454,6 +501,7 @@ function ClientCapacityTable({ capacity }: { capacity: CascadeClientCapacityResp
 
 export function CascadeConfigPanel() {
   const traceSearch = useSignal('')
+  const healthSearch = useSignal('')
   const resourceRef = useRef<ManagedAsyncResource<CascadeData> | null>(null)
   if (resourceRef.current === null) {
     resourceRef.current = createManagedAsyncResource<CascadeData>()
@@ -541,7 +589,7 @@ export function CascadeConfigPanel() {
                 detail="활성 시 차단 시간"
               />
             </div>
-            <${HealthTable} health=${health} />
+            <${HealthTable} health=${health} searchQuery=${healthSearch} />
           `
           : null}
       <//>


### PR DESCRIPTION
## 요약

`cascade-config-panel.ts` 의 **Health Tracker** 테이블 (`health.providers`, `HealthTable`) 에 자유 텍스트 필터를 추가합니다. 여러 cascade에 걸쳐 관찰된 모든 provider_key가 한 테이블에 누적되기 때문에, 바쁜 플릿에서는 특정 provider 한 줄을 찾거나 지금 cooldown 중인 provider만 보고 싶을 때 스크롤이 필요했습니다.

## 왜 이 리스트인가

`cascade-config-panel.ts` 의 7개 `.map` 사이트:

- `profile.candidates.map` (line 120) — 프로필별 candidate 목록, 카디널리티는 프로필당 2~5
- `mapping.map` (line 153, Keeper→Cascade Mapping) — keeper 수 = 소수
- **`health.providers.map` (line 199, HealthTable)** — **cascade 전체에서 집계된 provider_key, 카디널리티 가장 큼, `provider_key` 자유 텍스트 + cooldown 상태** ← 선택
- `filtered.map` (line 371, StrategyTraceTable) — 이미 필터 존재
- `history.events.map` (line 406, ClientCapacityHistoryTable) — 최근 이벤트 50개, time-ordered 로 스크롤이 덜 불편
- `capacity.entries.map` (line 438, ClientCapacityTable) — CLI/Ollama 슬롯, 수가 적음
- `config.profiles.map` (line 514, Cascade Profiles grid) — 프로필 수 자체는 적음

Health Tracker는 cascade 수 × provider 수 만큼 누적되는 유일한 테이블이라 필터 이득이 가장 큽니다.

## 변경

- `filterHealthProviders(providers, query)` 순수 함수를 `cascade-config-panel.ts` 에서 export. case-insensitive substring.
  - `provider_key` 에 substring match, 또는 query가 `cooldown` 의 부분 문자열이고 provider가 실제로 `in_cooldown=true` 일 때 match.
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지.
- 입력 비변이 (`readonly CascadeHealthProvider[]`).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N providers)` — 실제 비어있음(`아직 기록된 provider 이벤트가 없습니다.`) 과 구분.
- 검색 input은 Health Tracker가 비어있지 않을 때만 표시.
- 한국어 placeholder: `provider 필터 (key, cooldown...)`.
- 필터 중이면 `N/M건` 카운터 노출 (Strategy Decisions 패턴 동일).

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/cascade-config-panel.test.ts`: 41/41 pass (기존 31 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive (`provider_key`)
5. `provider_key` substring 매칭
6. `cooldown` 키워드 → `in_cooldown=true` 만 매칭
7. `cooldown` 키워드 → `in_cooldown=false` 매칭 안 함
8. no-match → 빈 배열
9. 빈 입력 배열 → 빈 결과
10. 입력 비변이

## CI 관련

Main CI는 현재 GREEN (#7835 OAS 0.155 floor bump 머지 후). Dashboard-only 변경.

## 범위 제한

Dashboard 파일 2개만 수정. 다른 리스트(candidates, mapping, capacity, history, strategy trace, profiles) 는 건드리지 않음. `keeper-config-panel.ts` 는 iter-13 (#7850) 에서 이미 처리되었으므로 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.