### PR TITLE
feat(dashboard): add label filter to runtime signal rows in keeper-detail-runtime

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.test.ts
+++ b/dashboard/src/components/keeper-detail-runtime.test.ts
@@ -7,6 +7,7 @@ import type { DashboardMissionKeeperBrief, Keeper, KeeperConfig } from '../types
 import {
   AllowlistPreview,
   RuntimeSignals,
+  filterSignalGroups,
   resolveAllowlistPreview,
   resolveKeeperCurrentTaskLabel,
 } from './keeper-detail-runtime'
@@ -329,5 +330,139 @@ describe('RuntimeSignals', () => {
     expect(screen.getByText('masc_board_post')).toBeInTheDocument()
     expect(screen.getByText('gpt-5')).toBeInTheDocument()
     expect(screen.getByText('planning')).toBeInTheDocument()
+  })
+
+  it('filters runtime signal rows by label via the search input', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      metrics_window: {
+        fallback_rate: 0.12,
+        model_fallback_rate: 0.05,
+        memory_pass_rate: 0.88,
+        memory_avg_score: 0.73,
+      },
+    }
+
+    render(h(RuntimeSignals, { keeper }))
+
+    // Before filtering: labels from multiple groups are visible.
+    expect(screen.getByText('전체 폴백')).toBeInTheDocument()
+    expect(screen.getByText('메모리 통과율')).toBeInTheDocument()
+
+    const input = screen.getByPlaceholderText('신호 지표 필터 (예: 폴백, 메모리, 컴팩션)') as HTMLInputElement
+    fireEvent.input(input, { target: { value: '메모리' } })
+
+    // Non-matching labels are gone, matching ones remain.
+    expect(screen.queryByText('전체 폴백')).not.toBeInTheDocument()
+    expect(screen.getByText('메모리 통과율')).toBeInTheDocument()
+    expect(screen.getByText('메모리 평균 점수')).toBeInTheDocument()
+  })
+
+  it('shows the filter-specific empty state when no rows match', () => {
+    const keeper: Keeper = {
+      name: 'sangsu',
+      status: 'active',
+      metrics_window: {
+        fallback_rate: 0.12,
+      },
+    }
+
+    render(h(RuntimeSignals, { keeper }))
+
+    const input = screen.getByPlaceholderText('신호 지표 필터 (예: 폴백, 메모리, 컴팩션)') as HTMLInputElement
+    fireEvent.input(input, { target: { value: 'nonexistent-zzz' } })
+
+    expect(screen.getByText(/필터 결과 없음/)).toBeInTheDocument()
+  })
+})
+
+describe('filterSignalGroups', () => {
+  interface SampleGroup {
+    title: string
+    rows: Array<{ label: string; value: string | number }>
+  }
+  const sampleGroups: SampleGroup[] = [
+    {
+      title: '폴백',
+      rows: [
+        { label: '전체 폴백', value: '15.0%' },
+        { label: '모델 폴백', value: '5.0%' },
+      ],
+    },
+    {
+      title: 'LLM 응답 정렬',
+      rows: [
+        { label: '목표 일치도', value: '0.820' },
+        { label: '응답 일치도', value: '0.700' },
+      ],
+    },
+    {
+      title: '메모리 & 컴팩션',
+      rows: [
+        { label: '메모리 통과율', value: '88.0%' },
+        { label: '컴팩션 절감', value: '42.0%' },
+      ],
+    },
+  ]
+
+  it('returns the input reference when the query is empty', () => {
+    expect(filterSignalGroups(sampleGroups, '')).toBe(sampleGroups)
+  })
+
+  it('returns the input reference when the query is whitespace only', () => {
+    expect(filterSignalGroups(sampleGroups, '   \t ')).toBe(sampleGroups)
+  })
+
+  it('matches case-insensitive substrings on row labels', () => {
+    const result = filterSignalGroups(sampleGroups, '폴백')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.title).toBe('폴백')
+    expect(result[0]?.rows.map(r => r.label)).toEqual(['전체 폴백', '모델 폴백'])
+  })
+
+  it('preserves only the matching rows within a group', () => {
+    const result = filterSignalGroups(sampleGroups, '컴팩션')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.title).toBe('메모리 & 컴팩션')
+    expect(result[0]?.rows).toHaveLength(1)
+    expect(result[0]?.rows[0]?.label).toBe('컴팩션 절감')
+  })
+
+  it('drops groups that have zero matching rows', () => {
+    const result = filterSignalGroups(sampleGroups, '일치도')
+    expect(result.map(g => g.title)).toEqual(['LLM 응답 정렬'])
+  })
+
+  it('trims the query before matching', () => {
+    const result = filterSignalGroups(sampleGroups, '  메모리  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.rows.map(r => r.label)).toEqual(['메모리 통과율'])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    const result = filterSignalGroups(sampleGroups, 'zzz-no-match')
+    expect(result).toEqual([])
+  })
+
+  it('does not mutate the input groups or their row arrays', () => {
+    const snapshot = JSON.parse(JSON.stringify(sampleGroups))
+    filterSignalGroups(sampleGroups, '폴백')
+    expect(sampleGroups).toEqual(snapshot)
+  })
+
+  it('matches Latin characters case-insensitively', () => {
+    const groups = [
+      {
+        title: 'Mixed',
+        rows: [
+          { label: 'CPU Saturation', value: 0.4 },
+          { label: 'Disk IO', value: 0.9 },
+        ],
+      },
+    ]
+    const result = filterSignalGroups(groups, 'cpu')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.rows.map(r => r.label)).toEqual(['CPU Saturation'])
   })
 })

--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -334,7 +334,35 @@ interface SignalGroup {
   rows: Array<{ label: string; value: string | number }>
 }
 
+/**
+ * Filter SignalGroups by a case-insensitive substring match on row labels.
+ * Empty/whitespace query returns the input reference unchanged (no allocation).
+ * Groups with no matching rows are dropped. Input is not mutated.
+ */
+export function filterSignalGroups(
+  groups: readonly SignalGroup[],
+  query: string,
+): readonly SignalGroup[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return groups
+  const out: SignalGroup[] = []
+  for (const group of groups) {
+    const matchedRows = group.rows.filter(r => r.label.toLowerCase().includes(needle))
+    if (matchedRows.length > 0) {
+      out.push({ title: group.title, rows: matchedRows })
+    }
+  }
+  return out
+}
+
+function countSignalRows(groups: readonly SignalGroup[]): number {
+  let total = 0
+  for (const group of groups) total += group.rows.length
+  return total
+}
+
 export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
+  const [signalQuery, setSignalQuery] = useState('')
   const mw = keeper.metrics_window
 
   // Quality/rate metrics only — raw counts (handoffs, compactions, turns)
@@ -412,9 +440,42 @@ export function RuntimeSignals({ keeper }: { keeper: Keeper }) {
 
   if (visibleGroups.length === 0 && topListSections.length === 0) return null
 
+  const filteredGroups = filterSignalGroups(visibleGroups, signalQuery)
+  const totalRows = countSignalRows(visibleGroups)
+  const matchedRows = countSignalRows(filteredGroups)
+  const isFiltering = signalQuery.trim() !== ''
+  const showEmptyState = isFiltering && matchedRows === 0
+
   return html`
     <div class="flex flex-col gap-3">
-      ${visibleGroups.map(g => html`
+      ${totalRows > 0
+        ? html`
+            <div class="flex items-center gap-2">
+              <input
+                type="search"
+                class="flex-1 min-w-0 py-1.5 px-2 rounded-lg border border-[var(--card-border)] bg-[var(--white-3)] text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-muted)] focus:outline-none focus:border-[var(--accent-30)]"
+                placeholder="신호 지표 필터 (예: 폴백, 메모리, 컴팩션)"
+                aria-label="런타임 신호 지표 필터"
+                value=${signalQuery}
+                onInput=${(event: Event) => {
+                  const target = event.currentTarget as HTMLInputElement | null
+                  setSignalQuery(target?.value ?? '')
+                }}
+              />
+              ${isFiltering
+                ? html`<span class="text-[10px] text-[var(--text-muted)] tabular-nums whitespace-nowrap">${matchedRows}/${totalRows}</span>`
+                : null}
+            </div>
+          `
+        : null}
+      ${showEmptyState
+        ? html`
+            <div class="py-3 px-3 rounded-lg border border-dashed border-[var(--card-border)] text-[11px] text-[var(--text-muted)] italic">
+              필터 결과 없음 (${totalRows} items)
+            </div>
+          `
+        : null}
+      ${filteredGroups.map(g => html`
         <div class="flex flex-col gap-1">
           <span class="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)] px-1">${g.title}</span>
           <div class="flex flex-col gap-1">


### PR DESCRIPTION
## 배경

`dashboard/src/components/keeper-detail-runtime.ts` (614 LOC, 6개 `.map` 사이트)의 `RuntimeSignals` 패널은 `metrics_window` 에서 유도되는 quality/rate 지표를 5개 주제 그룹으로 묶어 렌더링합니다(폴백, LLM 응답 정렬, 자율 행동 & 반응, 드리프트 보정, 메모리 & 컴팩션). 각 그룹은 3~7개의 `SignalRow` 로 펼쳐지며 activity 가 많은 키퍼에서는 총 약 20~25행까지 나열되어, 특정 축(예: "폴백" 계열, "컴팩션" 계열)만 빠르게 확인할 방법이 없었습니다. iter-7/8/9/11/12/22/25 seed-hint 를 따라 이 파일 한 곳의 리스트 하나만 필터링 대상으로 잡습니다.

이 파일은 `keeper-detail.ts` (iter25, PR #7887) 와 `keeper-detail-panels.ts` (iter22, PR #7875) 와는 다른 파일입니다.

## 후보 리스트 (6개 `.map` 사이트)

| 후보 | 위치 | 선택 여부 | 이유 |
|------|------|-----------|------|
| `visibleGroups.map` + `g.rows.map` (SignalRow 세트) | L417/L421, `RuntimeSignals` | **선택** | metrics_window 가 충분히 채워지면 20~25 행까지 커지는 유일한 unbounded 리스트. label 은 한국어 자연어라 substring 필터가 효과적. |
| `visibleTools.map` (ToolChip) | L120, `AllowlistPreview` | X | 이미 expand/collapse UI + `+N` preview 가 존재. 필터 중복. |
| `tools.map` (ToolSection) | L154, 재사용 컴포넌트 | X | 관측된 도구는 일반적으로 0~5개. 카디널리티 부족. |
| `.map(g => ({...}))` | L397, `visibleGroups` 내부 transform | X | render 대상이 아닌 데이터 변환. |
| `topListSections.map` | L428, DistributionBars | X | 최대 3개 고정 섹션. |

→ `visibleGroups` 전개 시의 signal row 목록만 필터 대상. top-list (주요 도구/모델/작업 종류) 는 aggregation 축이 달라 필터 scope 밖에 둡니다.

## 변경

- 순수 함수 `filterSignalGroups(groups: readonly SignalGroup[], query: string): readonly SignalGroup[]` 추가 (export).
  - `query.trim().toLowerCase()` 가 빈 문자열이면 입력 ref 를 그대로 반환 → `useMemo`/동일성 가정 유지, non-filter path 에 추가 할당 없음.
  - Row 단위로 `label` substring match (case-insensitive). 남는 행이 없는 그룹은 드랍하고, 남는 행만 보존해 새 group 객체로 shallow copy 생성(입력 비변이).
  - 입력 배열/행 객체는 mutate 하지 않습니다.
- 헬퍼 `countSignalRows` 로 현재 matched/total 카운트 집계.
- `RuntimeSignals` 에 `useState<string>` 쿼리 상태 + `<input type=\"search\">` 추가. 이 파일은 이미 `useState`/`useEffect` 스타일이며 `useSignal`/`useMemo` 를 쓰지 않으므로 기존 스타일을 준수합니다.
- 한국어 placeholder: `신호 지표 필터 (예: 폴백, 메모리, 컴팩션)`. `aria-label=\"런타임 신호 지표 필터\"`.
- 필터 활성 시 검색창 옆에 `N/total` tabular-nums 카운터.
- 매치 0개일 때 `필터 결과 없음 (N items)` 전용 empty state. `metrics_window` 자체가 비어 `visibleGroups` 가 없는 경우(컴포넌트가 `null` 반환)와 구분됩니다.
- Top-list section (DistributionBars) 는 필터 scope 밖. Signal row 를 숨겨도 aggregation 막대는 유지됩니다.

## 테스트

`dashboard/src/components/keeper-detail-runtime.test.ts` 에 11건 추가 (기존 19 + 신규 11 = 30/30 pass):

`filterSignalGroups` 순수 로직 8건:
1. empty query → 입력 ref 반환 (allocation 없음)
2. whitespace-only query → 입력 ref 반환
3. 한국어 label case-insensitive substring (`'폴백'`) — 그룹 전체가 매치될 때
4. 그룹 내에서 일부 행만 매치 (`'컴팩션'`) — 매치된 행만 보존
5. 매치 row 0 인 그룹 드랍 (`'일치도'` 는 `LLM 응답 정렬` 에만 존재)
6. query trim
7. 매치 없음 → 빈 배열
8. 입력 non-mutation (JSON snapshot diff)
9. Latin case-insensitive (`'cpu'` → `'CPU Saturation'`)

`RuntimeSignals` 렌더 2건:
10. 검색어 입력 시 비매치 행 사라지고 매치 행만 유지 (`'메모리'`)
11. 비매치 쿼리 입력 시 `필터 결과 없음` empty state 노출

## 검증

- `pnpm exec tsc --noEmit` → 에러 0
- `pnpm exec vitest run src/components/keeper-detail-runtime.test.ts` → 30/30 pass
- `pnpm exec eslint .` → 에러 0

## CI 주의

Main CI 는 PR #7835 (OAS 0.155 floor bump) merge 로 GREEN. 본 PR 은 dashboard 파일 2개 (`keeper-detail-runtime.ts`, `keeper-detail-runtime.test.ts`) 만 수정하며 OCaml 빌드 / 타입 / API 에 영향 없습니다.

## 파일

- `dashboard/src/components/keeper-detail-runtime.ts` (+62 / -1)
- `dashboard/src/components/keeper-detail-runtime.test.ts` (+135 / 0)

Follows iter-7/8/9/11/12/22/25 seed-hint pattern.