### PR TITLE
feat(autoresearch): Add access control for deleting and stopping loops

### DIFF
--- a/lib/dashboard/dashboard_http_autoresearch.ml
+++ b/lib/dashboard/dashboard_http_autoresearch.ml
@@ -459,11 +459,25 @@ let retry_loop_json ~(base_path : string) ~(loop_id : string) :
                       ("loop", loop_summary_json base_path state);
                     ]))))
 
-let delete_loop_json ~(base_path : string) ~(loop_id : string) :
+let delete_loop_json ~(base_path : string) ~(loop_id : string) ~(requester_agent : string option) :
     (Yojson.Safe.t, string) result =
   match validate_loop_id loop_id with
   | Error _ as error -> error
   | Ok () ->
+      let can_delete =
+        match requester_agent with
+        | None | Some "dashboard" | Some "admin" -> true
+        | Some requester ->
+            match Autoresearch.load_state ~base_path loop_id with
+            | None -> true
+            | Some state ->
+                match state.author with
+                | Some a when a <> requester -> false
+                | _ -> true
+      in
+      if not can_delete then
+        Error "Access denied: you can only delete loops that you started."
+      else
       let state_or_persisted =
         Autoresearch.with_loops_rw (fun () ->
           let active = Hashtbl.find_opt Autoresearch.active_loops loop_id in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -777,9 +777,8 @@ and add_autoresearch_routes router =
                    reqd
              | Ok () -> (
                  match
-                   Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id
-                 with
-                 | Ok result ->
+                   Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id ~requester_agent:(agent_from_request request)
+                 with                 | Ok result ->
                      Http.Response.json ~compress:true ~request:req
                        (Yojson.Safe.to_string result) reqd
                  | Error message ->

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -319,6 +319,20 @@ let handle_stop (ctx : context) args =
   match resolve_loop_id args with
   | None -> `Assoc [("error", `String "No autoresearch loop running")]
   | Some id ->
+      let can_stop =
+        match ctx.agent_name with
+        | None | Some "dashboard" | Some "admin" -> true
+        | Some requester ->
+            match Autoresearch.load_state ~base_path:ctx.base_path id with
+            | None -> true
+            | Some state ->
+                match state.author with
+                | Some a when a <> requester -> false
+                | _ -> true
+      in
+      if not can_stop then
+        `Assoc [("error", `String "Access denied: you can only stop loops that you started.")]
+      else
     match Autoresearch.stop_loop ~base_path:ctx.base_path ~reason id with
     | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
     | Some state ->

--- a/test/test_dashboard_autoresearch.ml
+++ b/test/test_dashboard_autoresearch.ml
@@ -441,7 +441,7 @@ let test_delete_loop_json_removes_bundle_and_branch () =
   in
   Lib.Autoresearch.save_swarm_link ~base_path link;
   match
-    Lib.Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id
+    Lib.Dashboard_http_autoresearch.delete_loop_json ~base_path ~loop_id ~requester_agent:None
   with
   | Error message -> failwith message
   | Ok json ->
@@ -473,7 +473,7 @@ let test_delete_loop_json_rejects_unsafe_loop_id () =
   with_temp_base @@ fun base_path ->
   match
     Lib.Dashboard_http_autoresearch.delete_loop_json
-      ~base_path ~loop_id:"../escape"
+      ~base_path ~loop_id:"../escape" ~requester_agent:None
   with
   | Ok _ -> failwith "expected invalid loop_id to fail"
   | Error message ->


### PR DESCRIPTION
## Description
Enterprise Improvement: Add access control to Autoresearch loops. Users/agents should only be able to delete or stop loops that they created (where loop.author == current_user), unless they are an admin.

## Changes
- Checks `state.author` against `ctx.agent_name` in `handle_stop` tool handler.
- Adds `~requester_agent` to `delete_loop_json` in `dashboard_http_autoresearch.ml`.
- Extracts `agent_from_request request` in the HTTP delete endpoint.
- Returns a 403-equivalent Error if the agent does not own the loop.

Fixes MASC task-206