### PR TITLE
feat(dashboard): add from/to agent filter to synapses table in memory-subsystems

### DIFF
--- a/dashboard/src/components/memory-subsystems.test.ts
+++ b/dashboard/src/components/memory-subsystems.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import type { MemorySubsystemsSynapse } from '../api/dashboard'
+import { filterSynapses } from './memory-subsystems'
+
+function makeSynapse(
+  overrides: Partial<MemorySubsystemsSynapse> = {},
+): MemorySubsystemsSynapse {
+  return {
+    from_agent: 'keeper-alpha',
+    to_agent: 'keeper-beta',
+    weight: 0.5,
+    success_count: 1,
+    failure_count: 0,
+    last_updated: 0,
+    created_at: 0,
+    ...overrides,
+  }
+}
+
+describe('filterSynapses', () => {
+  const rows: MemorySubsystemsSynapse[] = [
+    makeSynapse({ from_agent: 'keeper-alpha', to_agent: 'keeper-beta' }),
+    makeSynapse({ from_agent: 'keeper-beta', to_agent: 'watcher-gamma' }),
+    makeSynapse({ from_agent: 'router-delta', to_agent: 'keeper-alpha' }),
+    makeSynapse({ from_agent: 'planner-epsilon', to_agent: 'router-delta' }),
+  ]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterSynapses(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterSynapses(rows, '   ')).toBe(rows)
+  })
+
+  it('matches by from_agent substring (case-insensitive)', () => {
+    const result = filterSynapses(rows, 'ALPHA')
+    // keeper-alpha appears as from_agent in [0] and as to_agent in [2]
+    expect(result).toHaveLength(2)
+    expect(result.map(r => `${r.from_agent}->${r.to_agent}`)).toEqual([
+      'keeper-alpha->keeper-beta',
+      'router-delta->keeper-alpha',
+    ])
+  })
+
+  it('matches by to_agent substring', () => {
+    const result = filterSynapses(rows, 'gamma')
+    expect(result.map(r => r.to_agent)).toEqual(['watcher-gamma'])
+  })
+
+  it('matches a token shared across from and to fields', () => {
+    // keeper-* appears in 3 out of 4 rows
+    const result = filterSynapses(rows, 'keeper')
+    expect(result).toHaveLength(3)
+  })
+
+  it('returns empty when no field matches', () => {
+    expect(filterSynapses(rows, 'nonexistent-needle')).toHaveLength(0)
+  })
+
+  it('trims the query before matching', () => {
+    expect(filterSynapses(rows, '  router-delta  ')).toHaveLength(2)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = rows.slice()
+    filterSynapses(rows, 'keeper')
+    expect(rows).toEqual(copy)
+    expect(rows).toHaveLength(4)
+  })
+
+  it('handles an empty input array', () => {
+    expect(filterSynapses([], 'keeper')).toEqual([])
+    const empty: MemorySubsystemsSynapse[] = []
+    expect(filterSynapses(empty, '')).toBe(empty)
+  })
+
+  it('matches partial substrings at token boundaries', () => {
+    const result = filterSynapses(rows, 'router')
+    // router-delta appears as from_agent in [3] and as to_agent in [3]'s twin row
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.from_agent)).toContain('router-delta')
+    expect(result.map(r => r.to_agent)).toContain('router-delta')
+  })
+})

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { signal, useSignal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useMemo } from 'preact/hooks'
 import { LoadingState } from './common/feedback-state'
 import { MermaidGraph } from './common/mermaid-graph'
 import {
@@ -130,6 +130,32 @@ const weightBarClass = (w: number) => weightTier(w).tw
 // cells drawn at #1e293b. Floor and range are arbitrary — picked by eye,
 // not derived from a perceptual model. Tune if empty/low contrast is wrong.
 const weightOpacity = (w: number) => 0.25 + 0.75 * Math.sqrt(Math.max(0, Math.min(1, w)))
+
+/**
+ * Pure filter for the Hebbian synapses table rows.
+ *
+ * Case-insensitive substring match against `from_agent` then `to_agent`;
+ * first field match wins. Synapse pairs grow N² with fleet size so on a
+ * 10+ agent fleet the table has 100+ rows — operators need a quick way
+ * to isolate "every link involving keeper-foo".
+ *
+ * Empty/whitespace query returns the input reference unchanged (preserves
+ * referential equality for `useMemo`-memoised consumers).
+ *
+ * The input array is never mutated; callers may pass a readonly array.
+ */
+export function filterSynapses(
+  synapses: readonly MemorySubsystemsSynapse[],
+  query: string,
+): readonly MemorySubsystemsSynapse[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return synapses
+  return synapses.filter(s => {
+    if (s.from_agent.toLowerCase().includes(needle)) return true
+    if (s.to_agent.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 function HebbianMatrix({ synapses }: { synapses: MemorySubsystemsSynapse[] }) {
   if (synapses.length === 0) return null
@@ -440,6 +466,10 @@ export function MemorySubsystems() {
   const keeperFilter = useSignal<string>('')
   const outcomeFilter = useSignal<string>('')
   const searchQuery = useSignal<string>('')
+  // Client-side substring filter for the Hebbian synapses table. Independent
+  // from the episodes filter bar above — the synapses table is N² in fleet
+  // size and needs its own needle.
+  const synapseQuery = useSignal<string>('')
 
   async function refresh(signal?: AbortSignal) {
     try {
@@ -478,6 +508,12 @@ export function MemorySubsystems() {
 
   const synapses = data?.hebbian?.synapses ?? []
   const lastConsolidation = data?.hebbian?.last_consolidation ?? 0
+  const synapseQueryValue = synapseQuery.value
+  const visibleSynapses = useMemo(
+    () => filterSynapses(synapses, synapseQueryValue),
+    [synapses, synapseQueryValue],
+  )
+  const isSynapseFiltering = synapseQueryValue.trim() !== ''
   const episodes = data?.episodes?.items ?? []
   const totalEpisodes = data?.episodes?.total ?? 0
   const filteredTotal = data?.episodes?.filtered ?? episodes.length
@@ -572,26 +608,49 @@ export function MemorySubsystems() {
                 시냅스 데이터 없음. keeper task 완료 시 자동 생성됩니다.
               </div>`
             : html`
-                <div class="overflow-x-auto">
-                  <table class="w-full text-left">
-                    <thead>
-                      <tr class="border-b border-zinc-700 text-xs text-zinc-500">
-                        <th class="py-1.5 px-2">From</th>
-                        <th class="py-1.5 px-2"></th>
-                        <th class="py-1.5 px-2">To</th>
-                        <th class="py-1.5 px-2 text-right">Weight</th>
-                        <th class="py-1.5 px-2 text-center">성공</th>
-                        <th class="py-1.5 px-2 text-center">실패</th>
-                        <th class="py-1.5 px-2">마지막</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      ${synapses.map(
-                        (s: MemorySubsystemsSynapse) => html`<${SynapseRow} s=${s} />`,
-                      )}
-                    </tbody>
-                  </table>
+                <div class="flex items-center gap-2 mb-2 flex-wrap">
+                  <input
+                    type="search"
+                    value=${synapseQueryValue}
+                    placeholder="시냅스 검색 (from/to 에이전트 이름)"
+                    aria-label="시냅스 필터"
+                    onInput=${(e: Event) => {
+                      synapseQuery.value = (e.target as HTMLInputElement).value
+                    }}
+                    class="flex-1 min-w-[200px] bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-zinc-500 focus:outline-none"
+                  />
+                  ${
+                    isSynapseFiltering
+                      ? html`<span class="text-xs text-zinc-500">${visibleSynapses.length}/${synapses.length}</span>`
+                      : null
+                  }
                 </div>
+                ${
+                  isSynapseFiltering && visibleSynapses.length === 0
+                    ? html`<div class="text-sm text-zinc-500 bg-zinc-900 rounded-lg p-4 text-center">
+                        필터 결과 없음 (${synapses.length} items)
+                      </div>`
+                    : html`<div class="overflow-x-auto">
+                        <table class="w-full text-left">
+                          <thead>
+                            <tr class="border-b border-zinc-700 text-xs text-zinc-500">
+                              <th class="py-1.5 px-2">From</th>
+                              <th class="py-1.5 px-2"></th>
+                              <th class="py-1.5 px-2">To</th>
+                              <th class="py-1.5 px-2 text-right">Weight</th>
+                              <th class="py-1.5 px-2 text-center">성공</th>
+                              <th class="py-1.5 px-2 text-center">실패</th>
+                              <th class="py-1.5 px-2">마지막</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            ${visibleSynapses.map(
+                              (s: MemorySubsystemsSynapse) => html`<${SynapseRow} s=${s} />`,
+                            )}
+                          </tbody>
+                        </table>
+                      </div>`
+                }
               `
         }
       </section>


### PR DESCRIPTION
## 배경

Memory Subsystems 페이지 (`dashboard/src/components/memory-subsystems.ts`, 691 LOC / 13 `.map`·`.flatMap` 사이트) 의 **Hebbian 시냅스 그래프** 섹션 하단 표는 `from_agent → to_agent` 쌍을 모두 열거하므로 행 수가 fleet 크기에 대해 N² 로 증가한다. 10 개 이상 에이전트 fleet 에서는 100+ 행이 되고, "keeper-foo 와 연결된 모든 링크" 같은 단순 질의도 눈으로 훑어야 했다. 같은 파일의 **에피소드 리스트** 는 iter28 (#7888) 에서 `memory.ts` 의 `Memory` 컴포넌트가 이미 처리했고 (`keeper-memory-tier-panel.ts` 는 iter8 에서 처리), 본 파일의 시냅스 표는 아직 필터가 없었다.

iter-7/8/9/11/12/28 seed-hint 를 따라 `memory-subsystems.ts` 한 파일에서 한 리스트만 필터링한다.

## 후보 리스트 (13 `.map` / `.flatMap` 사이트)

| 후보 | 위치 | 선택 | 이유 |
|------|-----|------|------|
| **시냅스 표 행 (`synapses.map` → `SynapseRow`)** | L625, `MemorySubsystems()` | **선택** | unbounded cardinality (N² 스케일), `from_agent`·`to_agent` 두 개의 검색 가능한 string 필드 |
| `top.map` (HebbianTopLinks) | L311 | X | 이미 상위 5개로 bounded, 필터링 이득 적음 |
| `agents.map` (matrix 행/열 라벨) | L165, L180 | X | SVG matrix 기하학적 구조. 필터링하면 격자가 뒤틀림 — 리스트가 아니라 축 좌표 |
| `agents.flatMap` / `agents.map` (matrix 셀) | L195, L196 | X | 위와 동일 — SVG 셀 |
| `LEGEND_STOPS.map` | L240 | X | 고정 5개 레전드 스톱 |
| 스파크라인 내부 `.map` | L280 | X | SVG polyline point 생성, 리스트 아님 |
| `ep.participants.map` | L398 | X | EpisodeCard 내부, 카드당 1~5개 뱃지 |
| `ep.learnings.map` | L407 | X | EpisodeCard 내부, 카드당 0~3개 라인 |
| `Object.entries(ep.context).map` | L419 | X | EpisodeCard 내부 메타 태그 |
| `synapses.map` (thead 아래, 본 항목) | L625 | **선택** | — |
| `knownKeepers.map` | L637 | X | `<select>` 옵션 (UI 위젯) |
| `knownOutcomes.map` | L647 | X | `<select>` 옵션 (UI 위젯) |
| `visibleEpisodes.slice().reverse().map` | L675 | X | **에피소드 리스트 — #7888 처리 대상 (별도 파일) + 본 파일에도 이미 server-side `q` 필터 존재** |

→ 시냅스 표 한 개만 필터링. iter28 이 처리한 `memory.ts` 의 board posts 와도 다른 파일/다른 축, iter8 의 `keeper-memory-tier-panel.ts` 의 memory kind 행과도 다른 파일/다른 데이터 종류다.

## 변경

- 순수 함수 `filterSynapses(synapses: readonly MemorySubsystemsSynapse[], query: string): readonly MemorySubsystemsSynapse[]` 추가 (export).
  - Case-insensitive substring match on `from_agent` then `to_agent`; first field match wins.
  - Empty/whitespace query 는 입력 reference 를 그대로 반환 → `useMemo` identity 유지.
  - 입력 배열은 mutate 하지 않음.
- `MemorySubsystems()` 에 `synapseQuery = useSignal('')` + `useMemo` 로 `visibleSynapses` 계산 추가.
- Matrix SVG (`HebbianMatrix`) 와 Top Links (`HebbianTopLinks`) 는 **필터링하지 않고** 전체 synapse 집합을 계속 사용 — topology overview 의 안정성 유지. 필터는 표 하단 tabular list 에만 적용된다.
- 시냅스 표 위에 `<input type="search">` + 한국어 placeholder (`시냅스 검색 (from/to 에이전트 이름)`).
- 필터링 중이면 우측에 `visible/total` 카운트 표시.
- 매치 0개일 때 구분된 empty state (`필터 결과 없음 (N items)`) — 원본 데이터는 있음을 operator 가 인지.

## 검증

- `pnpm exec tsc --noEmit` — pass
- `pnpm exec vitest run src/components/memory-subsystems.test.ts` — 10 passed / 10
- `pnpm exec eslint .` — pass

## CI 주의

Main CI 는 #7835 이후 GREEN. 본 PR 은 dashboard 파일 2개 (`memory-subsystems.ts`, `memory-subsystems.test.ts`) 만 수정하며 OCaml 빌드에는 영향 없다.

## 테스트 플랜

- [ ] synapses 가 100+ 행일 때 검색창에 `keeper-`, 특정 keeper 이름을 입력해 행이 축소되는지 확인
- [ ] 매치 0개일 때 `필터 결과 없음 (N items)` 안내 확인
- [ ] 필터링 중 matrix SVG 와 Top Links 는 원본 topology 유지 확인 (의도된 설계)
- [ ] 검색어 지우면 표 전체가 복원되는지 확인
- [ ] 대소문자 섞어 입력 (`ALPHA` ↔ `alpha`) 가 동일 결과를 내는지 확인
- [ ] 에피소드 섹션의 기존 search 입력과 간섭이 없는지 확인 (서로 독립 signal)
