### PR TITLE
feat(dashboard): add search to autoresearch cycles table

### DIFF
--- a/dashboard/src/components/autoresearch-state.ts
+++ b/dashboard/src/components/autoresearch-state.ts
@@ -9,6 +9,7 @@ import {
   fetchAutoresearchLoops,
   fetchAutoresearchLoopDetail,
   retryAutoresearchLoop,
+  type AutoresearchCycleRecord,
   type AutoresearchLoopsResponse,
   type AutoresearchLoopDetail,
   type AutoresearchLoopSummary,
@@ -34,6 +35,32 @@ let pendingRefreshDetail = false
 let detailRequestSeq = 0
 
 export const authorFilter = signal<string>('all')
+
+// --- Cycles table search ---
+
+export const cyclesSearchQuery = signal<string>('')
+
+function decisionLabelForFilter(decision: string): string {
+  return decision === 'keep' ? '유지' : '삭제'
+}
+
+export function filterCycles(
+  cycles: readonly AutoresearchCycleRecord[],
+  query: string,
+): readonly AutoresearchCycleRecord[] {
+  const normalized = query.trim().toLowerCase()
+  if (normalized.length === 0) return cycles
+  return cycles.filter(c => {
+    const hypothesis = c.hypothesis.toLowerCase()
+    const decisionRaw = c.decision.toLowerCase()
+    const decisionLocal = decisionLabelForFilter(c.decision)
+    return (
+      hypothesis.includes(normalized) ||
+      decisionRaw.includes(normalized) ||
+      decisionLocal.includes(normalized)
+    )
+  })
+}
 
 export const filteredLoops = computed<AutoresearchLoopSummary[]>(() => {
   const state = loopsResource.state.value
@@ -171,6 +198,8 @@ export function resetAutoresearchState(resetFormFields?: () => void): void {
   detailError.value = null
   loopActionBusy.value = false
   loopActionError.value = null
+  authorFilter.value = 'all'
+  cyclesSearchQuery.value = ''
   pendingRefreshDetail = false
   detailRequestSeq = 0
   if (resetFormFields) resetFormFields()

--- a/dashboard/src/components/autoresearch.test.ts
+++ b/dashboard/src/components/autoresearch.test.ts
@@ -7,6 +7,7 @@ import type {
   AutoresearchLoopSummary,
   AutoresearchLoopsResponse,
 } from '../api/autoresearch'
+import { filterCycles, cyclesSearchQuery } from './autoresearch-state'
 
 void vi
 
@@ -23,6 +24,13 @@ function cycleRecord(cycle: number): AutoresearchCycleRecord {
     model_used: 'glm',
     timestamp: 1_717_171_717 + cycle,
   }
+}
+
+function cycleWith(
+  cycle: number,
+  overrides: Partial<AutoresearchCycleRecord> = {},
+): AutoresearchCycleRecord {
+  return { ...cycleRecord(cycle), ...overrides }
 }
 
 function loopSummary(
@@ -449,5 +457,74 @@ describe('Autoresearch surface refresh', () => {
     const settledRetryButton = Array.from(container.querySelectorAll('button'))
       .find(button => button.textContent?.includes('재시도')) as HTMLButtonElement | undefined
     expect(settledRetryButton?.disabled).toBe(false)
+  })
+})
+
+describe('filterCycles', () => {
+  afterEach(() => {
+    cyclesSearchQuery.value = ''
+  })
+
+  const cycles: readonly AutoresearchCycleRecord[] = [
+    cycleWith(1, { hypothesis: 'Reduce memory footprint', decision: 'keep' }),
+    cycleWith(2, { hypothesis: 'Try CUDA kernel fusion', decision: 'discard' }),
+    cycleWith(3, { hypothesis: 'Cache embeddings in LRU', decision: 'keep' }),
+  ]
+
+  it('returns the input reference unchanged for an empty query', () => {
+    const result = filterCycles(cycles, '')
+    expect(result).toBe(cycles)
+  })
+
+  it('returns the input reference unchanged for a whitespace-only query', () => {
+    const result = filterCycles(cycles, '   ')
+    expect(result).toBe(cycles)
+  })
+
+  it('matches hypothesis substring (case-insensitive)', () => {
+    const result = filterCycles(cycles, 'CUDA')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.cycle).toBe(2)
+  })
+
+  it('matches hypothesis substring with mixed case query', () => {
+    const result = filterCycles(cycles, 'MEMORY')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.cycle).toBe(1)
+  })
+
+  it('matches raw decision keyword `keep`', () => {
+    const result = filterCycles(cycles, 'keep')
+    expect(result.map(c => c.cycle)).toEqual([1, 3])
+  })
+
+  it('matches raw decision keyword `discard`', () => {
+    const result = filterCycles(cycles, 'discard')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.decision).toBe('discard')
+  })
+
+  it('matches localized decision label (유지 / 삭제)', () => {
+    expect(filterCycles(cycles, '유지').map(c => c.cycle)).toEqual([1, 3])
+    const discard = filterCycles(cycles, '삭제')
+    expect(discard).toHaveLength(1)
+    expect(discard[0]?.decision).toBe('discard')
+  })
+
+  it('trims leading and trailing whitespace before matching', () => {
+    const result = filterCycles(cycles, '   cache   ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.cycle).toBe(3)
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    const result = filterCycles(cycles, 'nonexistent-term-zzz')
+    expect(result).toEqual([])
+  })
+
+  it('does not match numeric cycle or score fields', () => {
+    // cycle=1 exists, but "1" should not match as hypothesis/decision.
+    const result = filterCycles(cycles, '0.5')
+    expect(result).toEqual([])
   })
 })

--- a/dashboard/src/components/autoresearch.ts
+++ b/dashboard/src/components/autoresearch.ts
@@ -6,6 +6,7 @@ import { useEffect } from 'preact/hooks'
 import { isLoaded } from '../lib/async-state'
 import { SurfaceCard } from './common/card'
 import { EmptyState } from './common/empty-state'
+import { TextInput } from './common/input'
 import { formatElapsedCompact, formatTimestampKo, formatDelta } from '../lib/format-time'
 import { statusLabel } from '../lib/status-label'
 import { navigate } from '../router'
@@ -28,6 +29,8 @@ import {
   authorFilter,
   filteredLoops,
   availableAuthors,
+  cyclesSearchQuery,
+  filterCycles,
   loadLoops,
   refreshAutoresearchSurface,
   selectLoop,
@@ -215,40 +218,62 @@ function CycleHistoryTable({ cycles }: { cycles: AutoresearchCycleRecord[] }) {
     return html`<${EmptyState} message="사이클 기록이 없습니다." compact />`
   }
 
+  const query = cyclesSearchQuery.value
+  const visible = filterCycles(cycles, query)
+
   return html`
-    <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded-lg border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
-      <table class="w-full text-xs">
-        <thead>
-          <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">#</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">가설</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이전</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이후</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">변화</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-center py-2.5 px-3 font-medium">판정</th>
-            <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${cycles.map(c => html`
-            <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
-              <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
-              <td class="py-2 px-3 text-[var(--text-body)] max-w-[200px] truncate" title=${c.hypothesis}>${c.hypothesis}</td>
-              <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
-              <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
-              <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
-              <td class="py-2 px-3 text-center">
-                <span class="px-1.5 py-0.5 rounded text-[10px] font-semibold ${
-                  c.decision === 'keep'
-                    ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
-                    : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
-                }">${decisionLabel(c.decision)}</span>
-              </td>
-              <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
+    <div class="flex flex-col gap-2">
+      <div class="flex justify-end">
+        <${TextInput}
+          type="search"
+          value=${query}
+          ariaLabel="사이클 검색"
+          placeholder="가설/판정 검색"
+          class="min-w-[220px] flex-1 !py-1 !text-[11px]"
+          onInput=${(e: Event) => {
+            const target = e.target as HTMLInputElement
+            cyclesSearchQuery.value = target.value
+          }}
+        />
+      </div>
+      <div class="overflow-x-auto overflow-y-auto max-h-[400px] custom-scrollbar rounded-lg border border-[var(--white-6)] bg-[rgba(0,0,0,0.1)]">
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="text-[var(--text-muted)] text-[10px] uppercase tracking-wider border-b border-[var(--white-10)]">
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">#</th>
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-left py-2.5 px-3 font-medium">가설</th>
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이전</th>
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">이후</th>
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium">변화</th>
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-center py-2.5 px-3 font-medium">판정</th>
+              <th scope="col" class="sticky top-0 z-10 bg-[rgba(10,18,34,0.95)] backdrop-blur-md text-right py-2.5 px-3 font-medium shadow-[1px_1px_2px_rgba(0,0,0,0.2)]">시간</th>
             </tr>
-          `)}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            ${visible.length === 0 ? html`
+              <tr>
+                <td colspan="7" class="py-4 px-3 text-center text-[var(--text-muted)]">검색 결과 없음</td>
+              </tr>
+            ` : visible.map(c => html`
+              <tr key=${c.cycle} class="border-b border-[var(--white-5)] hover:bg-[var(--white-4)] transition-colors duration-150">
+                <td class="py-2 px-3 font-mono text-[var(--text-muted)]">${c.cycle}</td>
+                <td class="py-2 px-3 text-[var(--text-body)] max-w-[200px] truncate" title=${c.hypothesis}>${c.hypothesis}</td>
+                <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_before.toFixed(4)}</td>
+                <td class="py-2 px-3 text-right font-mono text-[var(--text-body)]">${c.score_after.toFixed(4)}</td>
+                <td class="py-2 px-3 text-right font-mono ${c.delta >= 0 ? 'text-[var(--ok)]' : 'text-[var(--bad)]'}">${formatDelta(c.delta)}</td>
+                <td class="py-2 px-3 text-center">
+                  <span class="px-1.5 py-0.5 rounded text-[10px] font-semibold ${
+                    c.decision === 'keep'
+                      ? 'bg-[var(--ok-soft)] text-[var(--ok)] border border-[var(--ok-20)]'
+                      : 'bg-[var(--bad-soft)] text-[var(--bad)] border border-[var(--bad-20)]'
+                  }">${decisionLabel(c.decision)}</span>
+                </td>
+                <td class="py-2 px-3 text-right text-[var(--text-muted)] font-mono">${formatTimestampKo(c.timestamp)}</td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      </div>
     </div>
   `
 }


### PR DESCRIPTION
## Summary
- Add case-insensitive substring search to the `cycles` table in `dashboard/src/components/autoresearch.ts`, matching `hypothesis`, raw `decision` (`keep`/`discard`), and localized label (`유지`/`삭제`). Does not match numeric fields.
- New `cyclesSearchQuery` signal + pure `filterCycles()` helper live in the sidecar `autoresearch-state.ts`. Empty/whitespace query returns the input reference unchanged (no copy). Signal is reset in `resetAutoresearchState()` to avoid stale-carryover between sessions.
- Use `TextInput` from `common/input.ts` above the `<table>` (right-aligned, `type="search"`, `ariaLabel="사이클 검색"`, `placeholder="가설/판정 검색"`). Empty filter result shows a `검색 결과 없음` row via `<tr><td colspan=7>`; `key=\${c.cycle}` preserved.

## Tests
- 10 new `filterCycles` unit cases: empty ref-equal, whitespace ref-equal, hypothesis substring (case-insensitive x2), raw `keep`/`discard`, localized `유지`/`삭제`, trim, no-match, no numeric-field match.
- `pnpm typecheck` clean.
- `pnpm test` full suite: 179 files / 2741 tests pass (including both known baseline-flake files `governance-risk.test.ts` and `telemetry-unified.test.ts`; no new failures).

## Collision zone
- No files modified outside `autoresearch-state.ts`, `autoresearch.ts`, `autoresearch.test.ts`.
- Collision-listed panels (tool-quality, keeper-trajectory, fleet-telemetry, etc.) untouched.

## Test plan
- [x] pnpm typecheck
- [x] pnpm test autoresearch.test.ts
- [x] pnpm test (full suite)
- [ ] Manual: paste hypothesis substring / "keep" / "유지" / whitespace-only into search box; verify live filtering + empty-state row + stable row order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)