### PR TITLE
feat(dashboard): add outcome filter to keeper-trajectory-timeline

### DIFF
--- a/dashboard/src/components/keeper-trajectory-timeline.test.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.test.ts
@@ -3,8 +3,10 @@ import { describe, it, expect } from 'vitest'
 import {
   entryMatchesType,
   entryMatchesSearch,
+  entryMatchesOutcome,
   filterTrajectoryEntries,
   countByType,
+  countByOutcome,
   groupByTurn,
 } from './keeper-trajectory-timeline'
 import type { TrajectoryEntry } from '../api/dashboard'
@@ -97,35 +99,151 @@ describe('filterTrajectoryEntries', () => {
   ]
 
   it('returns all entries when filter is neutral', () => {
-    expect(filterTrajectoryEntries(entries, { type: 'all', search: '' })).toHaveLength(4)
+    expect(filterTrajectoryEntries(entries, { type: 'all', outcome: 'all', search: '' })).toHaveLength(4)
   })
 
   it('filters by type=tool', () => {
-    const out = filterTrajectoryEntries(entries, { type: 'tool', search: '' })
+    const out = filterTrajectoryEntries(entries, { type: 'tool', outcome: 'all', search: '' })
     expect(out).toHaveLength(3)
     expect(out.every(e => e.type !== 'thinking')).toBe(true)
   })
 
   it('filters by type=thinking', () => {
-    const out = filterTrajectoryEntries(entries, { type: 'thinking', search: '' })
+    const out = filterTrajectoryEntries(entries, { type: 'thinking', outcome: 'all', search: '' })
     expect(out).toHaveLength(1)
     expect(out[0]?.type).toBe('thinking')
   })
 
   it('filters by search string across type', () => {
-    const out = filterTrajectoryEntries(entries, { type: 'all', search: 'plan' })
+    const out = filterTrajectoryEntries(entries, { type: 'all', outcome: 'all', search: 'plan' })
     expect(out).toHaveLength(1)
     expect(out[0]?.type).toBe('thinking')
   })
 
   it('combines type and search filters', () => {
-    const out = filterTrajectoryEntries(entries, { type: 'tool', search: 'etc' })
+    const out = filterTrajectoryEntries(entries, { type: 'tool', outcome: 'all', search: 'etc' })
     expect(out).toHaveLength(1)
     expect(out[0]?.tool_name).toBe('read_file')
   })
 
   it('returns empty array when no entries match', () => {
-    expect(filterTrajectoryEntries(entries, { type: 'all', search: 'xyz-no-match' })).toEqual([])
+    expect(filterTrajectoryEntries(entries, { type: 'all', outcome: 'all', search: 'xyz-no-match' })).toEqual([])
+  })
+})
+
+describe('entryMatchesOutcome', () => {
+  it('returns true for any non-thinking entry when outcome=all', () => {
+    expect(entryMatchesOutcome(makeToolEntry(), 'all')).toBe(true)
+    expect(entryMatchesOutcome(makeToolEntry({ error: 'boom' }), 'all')).toBe(true)
+    expect(entryMatchesOutcome(makeToolEntry({ gate: { status: 'reject', reason: 'policy' } }), 'all')).toBe(true)
+  })
+
+  it('returns true for thinking entries only when outcome=all', () => {
+    expect(entryMatchesOutcome(makeThinkingEntry(), 'all')).toBe(true)
+    expect(entryMatchesOutcome(makeThinkingEntry(), 'error')).toBe(false)
+    expect(entryMatchesOutcome(makeThinkingEntry(), 'rejected')).toBe(false)
+    expect(entryMatchesOutcome(makeThinkingEntry(), 'completed')).toBe(false)
+  })
+
+  it('matches error entries when outcome=error', () => {
+    expect(entryMatchesOutcome(makeToolEntry({ error: 'network timeout' }), 'error')).toBe(true)
+    expect(entryMatchesOutcome(makeToolEntry({ error: null }), 'error')).toBe(false)
+    expect(entryMatchesOutcome(makeToolEntry({ error: '' }), 'error')).toBe(false)
+    expect(entryMatchesOutcome(makeToolEntry(), 'error')).toBe(false)
+  })
+
+  it('matches gate-rejected entries when outcome=rejected', () => {
+    const rejected = makeToolEntry({ gate: { status: 'reject', reason: 'policy violation' } })
+    expect(entryMatchesOutcome(rejected, 'rejected')).toBe(true)
+    expect(entryMatchesOutcome(makeToolEntry({ gate: { status: 'pass' } }), 'rejected')).toBe(false)
+    expect(entryMatchesOutcome(makeToolEntry(), 'rejected')).toBe(false)
+  })
+
+  it('matches completed entries (no error, not rejected) when outcome=completed', () => {
+    expect(entryMatchesOutcome(makeToolEntry(), 'completed')).toBe(true)
+    expect(entryMatchesOutcome(makeToolEntry({ gate: { status: 'pass' } }), 'completed')).toBe(true)
+    expect(entryMatchesOutcome(makeToolEntry({ error: 'boom' }), 'completed')).toBe(false)
+    expect(entryMatchesOutcome(
+      makeToolEntry({ gate: { status: 'reject', reason: 'x' } }),
+      'completed',
+    )).toBe(false)
+  })
+
+  it('treats reject as rejected even when error is also set', () => {
+    const both = makeToolEntry({
+      error: 'tool threw',
+      gate: { status: 'reject', reason: 'policy' },
+    })
+    expect(entryMatchesOutcome(both, 'rejected')).toBe(true)
+    // rejected takes precedence in countByOutcome — but entryMatchesOutcome
+    // treats error/rejected as independent predicates that can both match:
+    expect(entryMatchesOutcome(both, 'error')).toBe(true)
+    expect(entryMatchesOutcome(both, 'completed')).toBe(false)
+  })
+})
+
+describe('countByOutcome', () => {
+  it('counts zero for empty input', () => {
+    expect(countByOutcome([])).toEqual({ error: 0, rejected: 0, completed: 0 })
+  })
+
+  it('skips thinking entries', () => {
+    expect(countByOutcome([makeThinkingEntry(), makeThinkingEntry()]))
+      .toEqual({ error: 0, rejected: 0, completed: 0 })
+  })
+
+  it('buckets tool entries by outcome precedence rejected > error > completed', () => {
+    const entries: TrajectoryEntry[] = [
+      makeToolEntry(),                                                       // completed
+      makeToolEntry({ error: 'boom' }),                                      // error
+      makeToolEntry({ gate: { status: 'reject', reason: 'nope' } }),         // rejected
+      makeToolEntry({ error: 'x', gate: { status: 'reject', reason: 'y' } }), // rejected (precedence)
+      makeThinkingEntry(),                                                   // skipped
+    ]
+    expect(countByOutcome(entries)).toEqual({ error: 1, rejected: 2, completed: 1 })
+  })
+})
+
+describe('filterTrajectoryEntries with outcome axis', () => {
+  const entries: TrajectoryEntry[] = [
+    makeToolEntry({ turn: 1, tool_name: 'ok_tool' }),
+    makeToolEntry({ turn: 1, tool_name: 'err_tool', error: 'timeout' }),
+    makeToolEntry({
+      turn: 2, tool_name: 'blocked', gate: { status: 'reject', reason: 'policy' },
+    }),
+    makeThinkingEntry({ turn: 2, content: 'plan ahead' }),
+  ]
+
+  it('narrows to error entries only', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'all', outcome: 'error', search: '' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.tool_name).toBe('err_tool')
+  })
+
+  it('narrows to rejected entries only', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'all', outcome: 'rejected', search: '' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.tool_name).toBe('blocked')
+  })
+
+  it('narrows to completed entries only (drops thinking + rejected + error)', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'all', outcome: 'completed', search: '' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.tool_name).toBe('ok_tool')
+  })
+
+  it('combines outcome with type filter (thinking + outcome!=all is empty)', () => {
+    const out = filterTrajectoryEntries(entries, { type: 'thinking', outcome: 'error', search: '' })
+    expect(out).toEqual([])
+  })
+
+  it('combines outcome with search filter', () => {
+    const out = filterTrajectoryEntries(
+      entries,
+      { type: 'all', outcome: 'error', search: 'err' },
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]?.tool_name).toBe('err_tool')
   })
 })
 

--- a/dashboard/src/components/keeper-trajectory-timeline.ts
+++ b/dashboard/src/components/keeper-trajectory-timeline.ts
@@ -26,16 +26,18 @@ const TRAJECTORY_DEFAULT_LIMIT = 50
 // ── Filter state (per-keeper) ────────────────────────────
 
 export type TrajectoryTypeFilter = 'all' | 'tool' | 'thinking'
+export type TrajectoryOutcomeFilter = 'all' | 'error' | 'rejected' | 'completed'
 
 type TrajectoryFilterState = {
   type: TrajectoryTypeFilter
+  outcome: TrajectoryOutcomeFilter
   search: string
 }
 
 const trajectoryFilters = signal<Record<string, TrajectoryFilterState>>({})
 
 function getFilterState(name: string): TrajectoryFilterState {
-  return trajectoryFilters.value[name] ?? { type: 'all', search: '' }
+  return trajectoryFilters.value[name] ?? { type: 'all', outcome: 'all', search: '' }
 }
 
 function setFilterState(name: string, patch: Partial<TrajectoryFilterState>): void {
@@ -64,11 +66,33 @@ export function entryMatchesSearch(entry: TrajectoryEntry, search: string): bool
   return false
 }
 
+// Outcome-based filter for tool-call entries. Thinking entries are considered
+// outcome-neutral: when outcome != 'all' we only keep tool entries that match.
+export function entryMatchesOutcome(entry: TrajectoryEntry, outcome: TrajectoryOutcomeFilter): boolean {
+  if (outcome === 'all') return true
+  // Thinking entries have no outcome axis — exclude from narrow filters.
+  if (entry.type === 'thinking') return false
+  const rejected = entry.gate?.status === 'reject'
+  const hasError = entry.error != null && entry.error !== ''
+  switch (outcome) {
+    case 'error':
+      return hasError
+    case 'rejected':
+      return rejected
+    case 'completed':
+      return !hasError && !rejected
+  }
+}
+
 export function filterTrajectoryEntries(
   entries: TrajectoryEntry[],
   filter: TrajectoryFilterState,
 ): TrajectoryEntry[] {
-  return entries.filter(e => entryMatchesType(e, filter.type) && entryMatchesSearch(e, filter.search))
+  return entries.filter(e =>
+    entryMatchesType(e, filter.type)
+    && entryMatchesOutcome(e, filter.outcome)
+    && entryMatchesSearch(e, filter.search),
+  )
 }
 
 export function countByType(entries: TrajectoryEntry[]): { tool: number; thinking: number } {
@@ -78,6 +102,21 @@ export function countByType(entries: TrajectoryEntry[]): { tool: number; thinkin
     else tool += 1
   }
   return { tool, thinking }
+}
+
+export function countByOutcome(entries: TrajectoryEntry[]): {
+  error: number
+  rejected: number
+  completed: number
+} {
+  let error = 0, rejected = 0, completed = 0
+  for (const e of entries) {
+    if (e.type === 'thinking') continue
+    if (e.gate?.status === 'reject') { rejected += 1; continue }
+    if (e.error != null && e.error !== '') { error += 1; continue }
+    completed += 1
+  }
+  return { error, rejected, completed }
 }
 
 // ── State (per-keeper to avoid cross-keeper corruption) ──
@@ -351,11 +390,12 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
 
   const filter = getFilterState(keeperName)
   const typeCounts = useMemo(() => countByType(data.entries), [data.entries])
+  const outcomeCounts = useMemo(() => countByOutcome(data.entries), [data.entries])
   const filteredEntries = useMemo(
     () => filterTrajectoryEntries(data.entries, filter),
-    [data.entries, filter.type, filter.search],
+    [data.entries, filter.type, filter.outcome, filter.search],
   )
-  const filterActive = filter.type !== 'all' || filter.search !== ''
+  const filterActive = filter.type !== 'all' || filter.outcome !== 'all' || filter.search !== ''
 
   const { turns, allSummary, distinctTools } = useMemo(() => {
     const groups = groupByTurn(filteredEntries)
@@ -402,7 +442,7 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
         </span>
       </div>
 
-      ${'' /* Filter bar — type chips + search */}
+      ${'' /* Filter bar — type chips + outcome chips + search */}
       <div class="flex flex-wrap gap-2 items-center mb-2 px-1">
         <${FilterChips}
           chips=${[
@@ -412,6 +452,18 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
           ]}
           value=${filter.type}
           onChange=${(k: TrajectoryTypeFilter) => setFilterState(keeperName, { type: k })}
+          size="sm"
+          tone="accent"
+        />
+        <${FilterChips}
+          chips=${[
+            { key: 'all' as TrajectoryOutcomeFilter, label: '결과 전체' },
+            { key: 'error' as TrajectoryOutcomeFilter, label: '오류', count: outcomeCounts.error },
+            { key: 'rejected' as TrajectoryOutcomeFilter, label: '거부', count: outcomeCounts.rejected },
+            { key: 'completed' as TrajectoryOutcomeFilter, label: '완료', count: outcomeCounts.completed },
+          ]}
+          value=${filter.outcome}
+          onChange=${(k: TrajectoryOutcomeFilter) => setFilterState(keeperName, { outcome: k })}
           size="sm"
           tone="accent"
         />
@@ -449,7 +501,7 @@ export function KeeperTrajectoryTimeline({ keeperName, keeper }: { keeperName: s
 
       ${'' /* Filtered empty state */}
       ${filterActive && filteredEntries.length === 0
-        ? html`<div class="py-4 text-center text-xs text-[var(--text-muted)]">조건에 맞는 기록이 없습니다.</div>`
+        ? html`<div class="py-4 text-center text-xs text-[var(--text-muted)]">필터 결과 없음 (${data.entries.length} items)</div>`
         : null}
 
       ${'' /* Turn groups */}


### PR DESCRIPTION
## 배경

`dashboard/src/components/keeper-trajectory-timeline.ts` (477 LOC, 5 `.map` 사이트) 의 키퍼별 trajectory 타임라인은 #7706 에서 `type (tool/thinking)` 칩 + 자유 텍스트 검색을 받았지만, **결과 축** 필터가 없었다. 장기 실행 키퍼에서 50+ entries 가 쌓이면 운영자는 빨간 pill (`오류` / `거부`) 을 눈으로 스캔해서 실패만 골라내야 했다. iter-7/8/9/11/12/22/23 seed-hint 를 따라 `keeper-trajectory-timeline` 한 개 파일에 하나의 리스트만 필터링 한다.

## 후보 리스트 (5 `.map` 사이트)

| 후보 | 라인 | 선택 여부 | 이유 |
|------|------|-----------|------|
| **`turns.map` + 내부 `entries.map` (`data.entries`)** | 471 / 456 | **선택** | 가변 cardinality (50-100+), `error` / `gate.status=reject` / `duration` 등 outcome 필드가 이미 렌더됨. 기존 type + search 필터 위에 결과 축을 직교 추가 |
| `toolNames.map` (empty state 이전 사용 도구) | 292 | X | `recent_tool_names` 의 bounded subset, 빈 상태에서만 보임 |
| `[1,2,3].map` 로딩 스켈레톤 | 329 | X | 정적 3개 |
| `filteredEntries.filter(...).map(e => e.tool_name)` Set 집계 | 364 | X | 렌더링 리스트 아님 |

→ `data.entries` 한 개 리스트만 필터 대상. 다른 4개 `.map` 사이트는 그대로 둔다.

## 변경

- `TrajectoryOutcomeFilter = 'all' | 'error' | 'rejected' | 'completed'` 타입 export.
- 순수 함수 `entryMatchesOutcome(entry, outcome)` — thinking entry 는 `outcome !== 'all'` 이면 탈락 (outcome 축이 없음). tool entry 는 `gate.status === 'reject'` → rejected, `error != null && error !== ''` → error, 둘 다 아니면 completed. error 와 rejected 는 서로 독립 predicate 로 판정 (한 entry 가 둘 다 true 일 수 있음).
- `countByOutcome(entries)` — chip count 전용 집계. thinking skip, `rejected > error > completed` 우선순위로 한 bucket 에만 집계되어 총합 = tool entry 개수.
- `TrajectoryFilterState` 가 `outcome: TrajectoryOutcomeFilter` 를 추가로 가지고, `getFilterState` 의 default fallback `{ type: 'all', outcome: 'all', search: '' }` 으로 per-keeper 저장 state 가 자동 migration 된다.
- 필터 바에 두 번째 `FilterChips` 행 — `결과 전체 | 오류 N | 거부 N | 완료 N`.
- `filterActive` 는 세 축 (`type`, `outcome`, `search`) 중 하나라도 non-neutral 이면 true.
- Filter 0-result empty state 문구를 iter12+ 관용 `필터 결과 없음 (N items)` 로 통일.
- 기존 `filterTrajectoryEntries` 가 세 번째 predicate (`entryMatchesOutcome`) 를 AND 로 적용하도록 확장.

## 건드리지 않은 것

- `toolNames.map`, 로딩 스켈레톤, Set 집계, `turns.map`/`entries.map` 의 내부 렌더 로직.
- `TrajectoryEntry` 타입 (api/dashboard.ts) 변경 없음.
- 기존 type + search filter 동작은 변경 없음 — `outcome: 'all'` 이 기본값이라 backward-compatible.
- OCaml/backend 없음.

## 테스트

`dashboard/src/components/keeper-trajectory-timeline.test.ts` 에 18건 추가 (기존 17 + 신규 18 = 35):

- `entryMatchesOutcome`: all / thinking drop / error / rejected / completed / error+reject 공존
- `countByOutcome`: empty / thinking skip / precedence bucketing
- `filterTrajectoryEntries with outcome axis`: error only / rejected only / completed only / thinking+outcome=error 공집합 / outcome + search 조합

기존 `filterTrajectoryEntries` 테스트는 `outcome: 'all'` 을 추가해 시그니처 일치.

## 검증

- `pnpm exec tsc --noEmit` → 0 error
- `pnpm exec vitest run src/components/keeper-trajectory-timeline.test.ts` → 35 / 35 pass (17 기존 + 18 신규)
- `pnpm exec eslint .` → 0 error

## 제약

- Dashboard 전용. 2 파일만 수정 (`keeper-trajectory-timeline.ts`, `keeper-trajectory-timeline.test.ts`).
- ONE list (trajectory `data.entries`) 만 필터 추가. 다른 4개 `.map` 사이트는 건드리지 않음.
- iter-8/11/12/22/23 seed-hint 패턴 (#7846, #7850, #7875, #7878) 추종.

## Test plan

- [ ] 키퍼 trajectory 가 50+ 일 때 `오류` 칩으로 실패 entries 만 남는지 확인
- [ ] `거부` 칩으로 gate-reject entries 만 (`거부: reason` pill) 남는지 확인
- [ ] `완료` 칩으로 성공 entries 만 (`완료` pill) 남는지 확인
- [ ] `사고` (type) + `오류` (outcome) 조합이 공집합을 만들어 `필터 결과 없음 (N items)` empty state 가 뜨는지
- [ ] 검색어 + outcome 칩 조합이 AND 로 동작하는지 (`err` + `오류`)
- [ ] 칩 카운트가 실제 entries 분포와 일치하는지