### PR TITLE
docs(migration): drop retired tool_team_session rows from B-migration-targets

### DIFF
--- a/docs/spec/B-migration-targets.md
+++ b/docs/spec/B-migration-targets.md
@@ -47,7 +47,6 @@ Tier 4 (Experimental/Game)가 32%를 차지하며, 이 코드는 coordination과
 
 | File | Lines | Problem |
 |------|-------|---------|
-| `tool_team_session.ml` | 4,412 | 5-module 분할 설계 완료, 미실행 |
 | `tool_trpg.ml` | 1,934 | Coordination과 무관. 별도 패키지 대상 |
 | `tool_protocol_game_view.ml` | 1,674 | TRPG와 동일 |
 | `tool_mdal.ml` | 1,092 | Metric loop 단독 모듈. 분리 가능 |
@@ -86,7 +85,6 @@ Source: `ROADMAP.md` Short-term + `ARCHITECTURE-COMPLEXITY-ANALYSIS.md` Phase 2-
 | TRPG + protocol_game_view -> `masc-games` | tool_trpg, tool_protocol_game_view | 3,600+ | Not started | High |
 | risc + autoresearch + experiment -> `masc-experiments` | 3 tool modules | 2,700+ | Not started | High |
 | dune optional library separation | dune, lib/ | -- | Not started | Medium |
-| tool_team_session split (5 modules) | tool_team_session | 4,412 | Design done | High |
 | TRPG dm-keeper -> on-demand | keeper_autonomy | -- | Not started | Medium |
 | Test noise cleanup: 32 duplicate files | test/ | ~12K lines | Audit done | Medium |
 | 5 hollow test files 삭제 | test/ | -- | TODO에 기록 | Low |
@@ -198,7 +196,6 @@ lib/room/        lib/time_compat/ lib/types/
 
 | 대상 | 현재 | 목표 | 설계 상태 |
 |------|------|------|----------|
-| tool_team_session.ml | 4,412 LOC 단일 파일 | 5 modules (types/parse/spawn/handlers/dispatcher) | 설계 완료 (ARCHITECTURE-COMPLEXITY) |
 | lib/ flat files | 294개 | Sub-library 기반 조직 | 7-Team Design으로 매핑 완료 |
 | masc_mcp.ml facade | 전체 re-export | Team별 facade | drift 문제 해소 필요 |
 
@@ -209,7 +206,6 @@ lib/room/        lib/time_compat/ lib/types/
 | room.ml | High | Core lifecycle, 다른 모든 모듈이 의존 |
 | cascade.ml | High | OAS bridge의 핵심 계약 |
 | keeper_autonomy.ml | High | Keeper 자율 실행 계약 |
-| tool_team_session.ml | Medium | 분할 전 API 계약 고정 |
 | spawn.ml | Medium | 61 references, Swarm 핵심 |
 
 ---
@@ -294,7 +290,6 @@ SPEC-INDEX.md               -- Spec 목차
 | # | Target | Impact | Effort |
 |---|--------|--------|--------|
 | 1 | CI blocker 3건 해소 (#1980, #1981, #2186) | Feature 작업 재개 | Low (각 1-2 시간) |
-| 2 | tool_team_session 5-module 분할 | God file 해소, 테스트 격리 | Medium (설계 완료) |
-| 3 | masc-games + masc-experiments 패키지 분리 | Tier 4 코드 32% 격리 | Medium-High |
-| 4 | Mode/profile system 구현 | 에이전트 tool 노출 93% 감소 | Medium |
-| 5 | 32 duplicate test files 정리 | 빌드/CI 시간 절감, noise 제거 | Low |
+| 2 | masc-games + masc-experiments 패키지 분리 | Tier 4 코드 32% 격리 | Medium-High |
+| 3 | Mode/profile system 구현 | 에이전트 tool 노출 93% 감소 | Medium |
+| 4 | 32 duplicate test files 정리 | 빌드/CI 시간 절감, noise 제거 | Low |


### PR DESCRIPTION
## Summary

\`docs/spec/B-migration-targets.md\` listed \`tool_team_session.ml\` in 4 places as an active migration target — "5-module split, Design done". The entire \`team_session\` surface was retired rather than split, so those rows describe work whose target no longer exists.

## Scope

- §2.1 God Files table: \`tool_team_session.ml\` row removed
- §7 migration targets table: \`tool_team_session.ml\` row removed
- §7 .mli priority table: \`tool_team_session.ml\` row removed
- "Top 5 priorities" table: item 2 dropped, renumbered to Top 4

Companion to #7884 which marked the corresponding plan section obsolete in \`ARCHITECTURE-COMPLEXITY-ANALYSIS.md\`.

## Test plan
- [x] \`bash scripts/check-doc-truth.sh\` → Doc truth OK
- [x] \`grep -n team_session docs/spec/B-migration-targets.md\` → no match