### PR TITLE
feat(oas-pin): ref-reachability guard to catch orphan SHAs

### DIFF
--- a/scripts/check-oas-pin.sh
+++ b/scripts/check-oas-pin.sh
@@ -62,6 +62,31 @@ if [[ "${pin_source}" == "${default_pin_source}" ]]; then
     if [[ "${OAS_AGENT_SDK_SHA}" != "${latest_main_sha}" ]]; then
       echo "::warning::OAS main drift: pinned ${OAS_AGENT_SDK_SHA}, upstream ${latest_main_sha} — update pin when API-compatible"
     fi
+
+    # Ref-reachability guard: the pin SHA must be an ancestor of
+    # OAS_AGENT_SDK_TRACK_REF on upstream. Orphan or diverged SHAs still
+    # exist as loose objects on GitHub for a grace period, but they are GC
+    # candidates and will silently break CI once collected. Checking
+    # ancestry here catches drift at review time instead of at incident time.
+    reachability_scratch="$(mktemp -d -t oas-pin-reachability.XXXXXX)"
+    if GIT_DIR="${reachability_scratch}" git init -q --bare \
+       && GIT_DIR="${reachability_scratch}" git fetch -q --no-tags \
+            "${OAS_AGENT_SDK_URL}" \
+            "+refs/heads/${OAS_AGENT_SDK_TRACK_REF}:refs/heads/${OAS_AGENT_SDK_TRACK_REF}" \
+            2>/dev/null; then
+      if ! GIT_DIR="${reachability_scratch}" git merge-base --is-ancestor \
+           "${OAS_AGENT_SDK_SHA}" \
+           "refs/heads/${OAS_AGENT_SDK_TRACK_REF}" 2>/dev/null; then
+        echo "OAS pin ${OAS_AGENT_SDK_SHA} is not reachable from ${OAS_AGENT_SDK_TRACK_REF} on ${OAS_AGENT_SDK_URL}" >&2
+        echo "  Orphan or diverged SHAs are GC candidates on GitHub and will silently break CI once collected." >&2
+        echo "  repair: bump OAS_AGENT_SDK_SHA in scripts/oas-agent-sdk-pin.sh to a commit on ${OAS_AGENT_SDK_TRACK_REF}" >&2
+        rm -rf "${reachability_scratch}"
+        exit 1
+      fi
+    else
+      echo "WARN: could not fetch ${OAS_AGENT_SDK_TRACK_REF} from ${OAS_AGENT_SDK_URL}; skipping ref-reachability check" >&2
+    fi
+    rm -rf "${reachability_scratch}"
   fi
 else
   echo "OAS pin override in use: ${pin_source}"


### PR DESCRIPTION
## Stacked on #7898

Base = \`fix/oas-pin-heal-orphan-sha\` (Step 1). Merge order: #7898 first, then retarget this PR to \`main\`.

## Why

The existing \`scripts/check-oas-pin.sh\` drift check only compares the pin SHA with the track_ref **HEAD**. If they differ it emits a \`::warning::\` and passes. It does **not** verify the pin SHA is reachable from the track_ref.

Result: orphan SHAs (commit objects with no branch/PR pointing at them) pass review. They exist on GitHub as loose objects for a grace period, then become GC candidates and break CI silently after collection.

Evidence (from #7835 incident, addressed in #7898):

\`\`\`
$ gh api repos/jeong-sik/oas/compare/f2387e2a...6c79cf3f --jq '{status}'
{\"status\":\"diverged\"}

$ gh api repos/jeong-sik/oas/commits/6c79cf3f/branches-where-head --jq '[.[].name]'
[]

$ gh api repos/jeong-sik/oas/commits/6c79cf3f/pulls --jq '[.[] | .number]'
[]
\`\`\`

Pre-guard: \`check-oas-pin.sh\` passes with drift warning even though \`6c79cf3f\` is not on any branch.

## What

Add ancestry verification after the drift warning block:

1. \`git init -q --bare\` on a \`mktemp -d\` scratch repo.
2. \`git fetch\` the track_ref into the scratch.
3. \`git merge-base --is-ancestor <pin_sha> <track_ref>\`.
4. Non-ancestor (orphan/diverged) → exit 1 with repair hint.
5. Fetch failure (offline/private) → warn and skip (permissive to avoid hard-blocking local dev).

## Verification

Negative test with orphan SHA \`6c79cf3f\` (the one healed in #7898):

\`\`\`
$ sed -i '' 's/f2387e2a.../6c79cf3f.../' scripts/oas-agent-sdk-pin.sh
$ bash scripts/check-oas-pin.sh
::warning::OAS main drift: pinned 6c79cf3f..., upstream 8d6e5478...
OAS pin 6c79cf3f... is not reachable from main on https://github.com/jeong-sik/oas.git
  Orphan or diverged SHAs are GC candidates on GitHub and will silently break CI once collected.
  repair: bump OAS_AGENT_SDK_SHA in scripts/oas-agent-sdk-pin.sh to a commit on main
$ echo \$?
1
\`\`\`

Positive test with ref-reachable \`f2387e2a\`: drift warning only, exit 0 (existing behavior preserved).

## Scope

- \`scripts/check-oas-pin.sh\`: +25 LOC, no other files.
- \`ci/check-oas-pin.sh\` (separate simpler script): not touched.
- \`--local-only\` flag: unchanged, network-free path preserved for Makefile/local dev.

## Why stacked, not independent

If this PR merges to main **before** #7898, the guard fails on main's current pin (\`6c79cf3f\`, orphan) and blocks all subsequent PRs. Must land after heal. Alternative: bundle both into one PR — kept separate because heal is urgent/small and guard is structural/reviewable independently.