### PR TITLE
feat(dashboard): add activity filter to agent-profile

### DIFF
--- a/dashboard/src/components/agent-profile.test.ts
+++ b/dashboard/src/components/agent-profile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { keeperChatTargetName } from './agent-profile'
+import { filterRoomActivity, keeperChatTargetName } from './agent-profile'
 
 describe('keeperChatTargetName', () => {
   it('prefers the canonical keeper name over the runtime agent name', () => {
@@ -10,5 +10,68 @@ describe('keeperChatTargetName', () => {
 
   it('falls back to the provided name when no keeper mapping exists', () => {
     expect(keeperChatTargetName('plain-agent', null)).toBe('plain-agent')
+  })
+})
+
+describe('filterRoomActivity', () => {
+  const lines: readonly string[] = [
+    '[task] dreamer claimed PK-12345 (auth flow)',
+    '[broadcast] keeper-alpha: GPU 온도 정상',
+    '[task] codex completed PK-12345',
+    'dreamer heartbeat @ 19:30',
+    '[broadcast] keeper-beta: restarting ollama',
+  ]
+
+  it('returns the input reference for an empty query', () => {
+    expect(filterRoomActivity(lines, '')).toBe(lines)
+  })
+
+  it('returns the input reference for a whitespace-only query', () => {
+    expect(filterRoomActivity(lines, '   ')).toBe(lines)
+  })
+
+  it('trims whitespace from the query before matching', () => {
+    expect(filterRoomActivity(lines, '  dreamer  ')).toHaveLength(2)
+  })
+
+  it('matches substrings case-insensitively', () => {
+    const result = filterRoomActivity(lines, 'DREAMER')
+    expect(result).toHaveLength(2)
+    expect(result.every(l => l.toLowerCase().includes('dreamer'))).toBe(true)
+  })
+
+  it('matches by task id substring', () => {
+    const result = filterRoomActivity(lines, 'PK-12345')
+    expect(result).toHaveLength(2)
+  })
+
+  it('matches by broadcast keyword', () => {
+    const result = filterRoomActivity(lines, 'broadcast')
+    expect(result).toHaveLength(2)
+    expect(result.map(l => l.slice(0, 11))).toEqual(['[broadcast]', '[broadcast]'])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterRoomActivity(lines, 'zzz-nonexistent')).toHaveLength(0)
+  })
+
+  it('does not mutate the input array', () => {
+    const copy = lines.slice()
+    filterRoomActivity(lines, 'dreamer')
+    expect(lines).toEqual(copy)
+  })
+
+  it('handles an empty input array', () => {
+    expect(filterRoomActivity([], 'anything')).toEqual([])
+    expect(filterRoomActivity([], '')).toEqual([])
+  })
+
+  it('tolerates non-ASCII query (Korean substring)', () => {
+    const korean: readonly string[] = [
+      '[broadcast] keeper-alpha: 정상 가동 중',
+      '[broadcast] keeper-beta: 재시작 필요',
+    ]
+    expect(filterRoomActivity(korean, '재시작')).toHaveLength(1)
+    expect(filterRoomActivity(korean, '정상')).toHaveLength(1)
   })
 })

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -63,6 +63,30 @@ const profileResource = createAsyncResource<ProfileData>()
 let profileLoadedName = ''
 const mentionText = signal('')
 const sendingMention = signal(false)
+const activityQuery = signal('')
+
+/**
+ * Pure filter for the "프로젝트 활동" (roomActivity) string list.
+ *
+ * Case-insensitive substring match on the full line. `fetchRoomMessages`
+ * returns rendered lines that already embed actor/target/text, so a
+ * substring pass is enough to isolate all lines mentioning a particular
+ * actor, task id, or keyword.
+ *
+ * Empty/whitespace query returns the input reference unchanged so the
+ * non-filtering render path preserves referential identity (no new
+ * array allocation).
+ *
+ * Input is never mutated; caller may pass a readonly array.
+ */
+export function filterRoomActivity(
+  lines: readonly string[],
+  query: string,
+): readonly string[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return lines
+  return lines.filter(line => line.toLowerCase().includes(needle))
+}
 
 function findAgent(name: string): Agent | null {
   return agents.value.find(a => a.name === name) ?? null
@@ -301,6 +325,9 @@ function CharacterPlate({ name }: { name: string }) {
 export function AgentProfile({ name }: { name: string }) {
   useEffect(() => {
     void loadProfile(name)
+    // Reset the activity filter when switching agents so a stale query
+    // from the previous profile does not leak into the new one.
+    activityQuery.value = ''
   }, [name])
 
   const ps = profileResource.state.value
@@ -405,8 +432,26 @@ export function AgentProfile({ name }: { name: string }) {
         <${Card} title="프로젝트 활동" class="ff-card rounded-xl">
           ${lines.length === 0
             ? html`<${EmptyState} message="관련 활동 없음" compact />`
-            : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${lines.map((line: string, idx: number) =>
-                html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[13px] text-[var(--text-body)] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
+            : (() => {
+                const visible = filterRoomActivity(lines, activityQuery.value)
+                const isFiltering = activityQuery.value.trim() !== ''
+                return html`
+                  <div class="flex flex-col gap-1.5">
+                    <input
+                      type="search"
+                      value=${activityQuery.value}
+                      placeholder="활동 필터 (메시지 본문)"
+                      aria-label="프로젝트 활동 필터"
+                      onInput=${(e: Event) => { activityQuery.value = (e.target as HTMLInputElement).value }}
+                      class="w-full rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+                    />
+                    ${isFiltering && visible.length === 0
+                      ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${lines.length} items)</div>`
+                      : html`<div class="max-h-[210px] overflow-y-auto flex flex-col gap-1.5">${visible.map((line: string, idx: number) =>
+                          html`<div key=${idx} class="border border-[var(--card-border)] bg-[var(--white-3)] px-2.5 py-2 font-[family-name:'IBM_Plex_Mono','Fira_Code',monospace] text-[13px] text-[var(--text-body)] leading-[1.4] rounded-lg">${line}</div>`)}</div>`}
+                  </div>
+                `
+              })()}
         <//>
 
         ${(profileData?.taskHistories ?? []).length > 0 ? html`


### PR DESCRIPTION
## 요약

`dashboard/src/components/agent-profile.ts` 의 **프로젝트 활동 (roomActivity)** 카드에 자유 텍스트 필터를 추가합니다. `fetchRoomMessages(80)` 이 반환한 80줄 중 현재 agent 이름이 포함된 최대 20줄이 표시되는데, 바쁜 룸에서는 특정 task id / broadcast 키워드 / 상대방 actor 를 찾으려면 여전히 스크롤이 필요했습니다.

## 왜 이 리스트인가

`agent-profile.ts` 의 7개 `.map` 사이트:

- `owned.map` (line 339, 태스크) — `assignedTasks(name).slice(0, 6)` 최대 6개, 카디널리티 낮음
- `collabs.map` (line 360, 관계/Collaborators) — relations API 결과, 수 적음
- `interests.slice(0, 12).map` (line 376, 관심사 태그) — 이미 12개 컷오프, 태그형 UI라 필터 부자연스러움
- `(timeline.events ?? []).map` (line 388, 타임라인) — 최대 20개, `type`+`detail.title` 혼합. time-ordered 스크롤이 자연스러움
- **`lines.map` (line 408, 프로젝트 활동)** — **최대 20줄의 렌더된 room-log 문자열, 자유 substring 이 가장 잘 맞음** ← 선택
- `(profileData?.taskHistories ?? []).map` (line 414, 태스크 이력) — 최대 6개 (owned 상한), 필터 이득 작음
- CharacterPlate 내부 StatGrid items (간접 map) — 4개 고정, 필터 대상 아님

roomActivity는 단일 문자열 배열이라 substring 한 번으로 actor / task id / broadcast 키워드를 동시에 걸러낼 수 있어 필터 이득이 가장 큽니다.

## 변경

- `filterRoomActivity(lines, query)` 순수 함수를 `agent-profile.ts` 에서 export. case-insensitive substring.
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지 (새 배열 할당 없음).
- 입력 비변이 (`readonly string[]`).
- 검색 input 은 활동이 비어있지 않을 때만 표시.
- 한국어 placeholder: `활동 필터 (메시지 본문)`.
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 원래 empty state (`관련 활동 없음`) 와 구분.
- agent 전환 시 `useEffect` 훅에서 `activityQuery` 를 `''` 로 리셋 → 이전 프로필의 stale query 누수 방지.
- 파일 스타일 유지: module-level `signal` (`mentionText`, `sendingMention` 과 동일 패턴), `useSignal`/`useMemo` 미사용.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/agent-profile.test.ts`: 12/12 pass (기존 2 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive 매칭
5. task id substring (`PK-12345`)
6. broadcast 키워드 매칭
7. no-match → 빈 배열
8. 입력 비변이 (shallow copy 비교)
9. 빈 입력 배열 허용 (쿼리 유무 모두)
10. 한국어 substring (`재시작`, `정상`)

## 범위 제한

Dashboard 파일 2개만 수정 (`agent-profile.ts` + `agent-profile.test.ts`). 다른 리스트 (태스크, 관계, 관심사, 타임라인, 태스크 이력) 는 건드리지 않음. iter-21 의 `agent-roster.ts` (#7877) 와 별개 컴포넌트. iter-7/8/9/11/12 seed-hint 패턴 유지.