### PR TITLE
feat(dashboard): add metadata gap filter to mission-briefing-card

### DIFF
--- a/dashboard/src/components/mission-briefing-card.test.ts
+++ b/dashboard/src/components/mission-briefing-card.test.ts
@@ -366,3 +366,104 @@ describe('MissionBriefingCard', () => {
     expect(payload?.message).toContain('[상황 보고] mission-judge')
   }, 20000)
 })
+
+describe('filterMetadataGaps', () => {
+  type Gap = {
+    kind: string
+    summary: string
+    scope_type: 'session' | 'keeper' | 'agent'
+    scope_id?: string | null
+    severity: 'info' | 'watch'
+  }
+
+  const sampleGaps = (): Gap[] => [
+    {
+      kind: 'missing_model',
+      summary: '판단 키퍼 모델이 비어 있습니다.',
+      scope_type: 'keeper',
+      scope_id: 'live-judge',
+      severity: 'watch',
+    },
+    {
+      kind: 'stale_snapshot',
+      summary: '세션 스냅샷이 오래되었습니다.',
+      scope_type: 'session',
+      scope_id: 'ts-4242',
+      severity: 'info',
+    },
+    {
+      kind: 'no_briefing',
+      summary: 'Agent briefing has been missing for GraphRAG.',
+      scope_type: 'agent',
+      scope_id: null,
+      severity: 'info',
+    },
+  ]
+
+  it('returns the input reference when query is empty', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const gaps = sampleGaps()
+    expect(filterMetadataGaps(gaps, '')).toBe(gaps)
+  })
+
+  it('returns the input reference when query is whitespace only', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const gaps = sampleGaps()
+    expect(filterMetadataGaps(gaps, '   \t\n ')).toBe(gaps)
+  })
+
+  it('trims the query before matching', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const result = filterMetadataGaps(sampleGaps(), '  live-judge  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.scope_id).toBe('live-judge')
+  })
+
+  it('matches case-insensitively on summary', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const result = filterMetadataGaps(sampleGaps(), 'GRAPHRAG')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.kind).toBe('no_briefing')
+  })
+
+  it('matches a substring of scope_id', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const result = filterMetadataGaps(sampleGaps(), 'ts-42')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.scope_id).toBe('ts-4242')
+  })
+
+  it('matches a substring of kind', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const result = filterMetadataGaps(sampleGaps(), 'stale')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.kind).toBe('stale_snapshot')
+  })
+
+  it('matches severity exactly for watch keyword', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const result = filterMetadataGaps(sampleGaps(), 'watch')
+    expect(result).toHaveLength(1)
+    expect(result[0]?.severity).toBe('watch')
+  })
+
+  it('matches severity exactly for info keyword and returns both info gaps', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const result = filterMetadataGaps(sampleGaps(), 'info')
+    expect(result).toHaveLength(2)
+    expect(result.every(item => item.severity === 'info')).toBe(true)
+  })
+
+  it('returns an empty array when nothing matches', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    expect(filterMetadataGaps(sampleGaps(), 'zzzz-nonexistent')).toEqual([])
+  })
+
+  it('does not mutate the input array', async () => {
+    const { filterMetadataGaps } = await import('./mission-briefing-card')
+    const gaps = sampleGaps()
+    const snapshot = gaps.map(item => ({ ...item }))
+    filterMetadataGaps(gaps, 'live-judge')
+    expect(gaps).toEqual(snapshot)
+  })
+})

--- a/dashboard/src/components/mission-briefing-card.ts
+++ b/dashboard/src/components/mission-briefing-card.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useEffect } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import { Card } from './common/card'
 import { EmptyState } from './common/empty-state'
 import { TagBadge } from './common/tag-badge'
@@ -29,12 +29,44 @@ import {
 } from '../workflow-context'
 import type { DashboardWorkflowContext } from '../workflow-context'
 import type {
+  DashboardMissionBriefingMetadataGap,
   DashboardMissionBriefingResponse,
   DashboardMissionKeeperBrief,
   DashboardMissionResponse,
   Keeper,
   OperatorSnapshot,
 } from '../types'
+
+/**
+ * Pure filter for mission briefing metadata gaps.
+ *
+ * Case-insensitive substring match on `summary`, `scope_id`, and `kind` so
+ * the operator can locate a gap by a keyword from either the description
+ * text, the scope identifier (session/keeper/agent id), or the gap kind
+ * string. Severity is matched exactly when the query equals `info` or
+ * `watch` — partial tokens like `wa` do not collapse severity matches,
+ * which keeps the keyword axis clear.
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * `useMemo` keeps identity for the non-filtering path.
+ *
+ * Input is never mutated; the gap array is treated as readonly.
+ */
+export function filterMetadataGaps(
+  gaps: readonly DashboardMissionBriefingMetadataGap[],
+  query: string,
+): readonly DashboardMissionBriefingMetadataGap[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return gaps
+  const severityMatch = needle === 'info' || needle === 'watch'
+  return gaps.filter(gap => {
+    if (severityMatch && gap.severity === needle) return true
+    if (gap.summary && gap.summary.toLowerCase().includes(needle)) return true
+    if (gap.scope_id && gap.scope_id.toLowerCase().includes(needle)) return true
+    if (gap.kind && gap.kind.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 export interface LiveJudgeTarget {
   name: string
@@ -230,6 +262,14 @@ export function MissionBriefingCard() {
     briefing?.status === 'error'
     || (briefing?.status === 'unavailable' && !briefing?.cached)
 
+  const [gapQuery, setGapQuery] = useState('')
+  const rawGaps = briefing?.metadata_gaps ?? []
+  const filteredGaps = useMemo(
+    () => filterMetadataGaps(rawGaps, gapQuery),
+    [rawGaps, gapQuery],
+  )
+  const isFilteringGaps = gapQuery.trim() !== ''
+
   useEffect(() => {
     if (briefing || missionBriefingLoading.value || missionBriefingError.value) return
     const controller = new AbortController()
@@ -318,18 +358,34 @@ export function MissionBriefingCard() {
       ${briefing && briefing.metadata_gaps.length > 0
         ? html`
             <details class="pt-2 border-t border-[var(--white-6)] mt-4">
-              <summary>관측 공백 (${briefing.metadata_gap_count ?? briefing.metadata_gaps.length})</summary>
-              <div class="flex flex-col gap-3 mt-3">
-                ${briefing.metadata_gaps.map(item => html`
-                  <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] grid gap-3 ${item.severity === 'watch' ? 'warn' : ''}">
-                    <div class="flex justify-between gap-3 items-start flex-wrap">
-                      <strong>${missionTargetTypeLabel(item.scope_type)}${item.scope_id ? ` · ${item.scope_id}` : ''}</strong>
-                      <${StatusChip} label=${statusLabel(item.severity)} tone=${item.severity === 'watch' ? 'warn' : ''} />
-                    </div>
-                    <p class="m-0 text-[var(--text-body)] leading-snug">${item.summary}</p>
-                  </article>
-                `)}
+              <summary>관측 공백 (${isFilteringGaps
+                ? `${filteredGaps.length}/${briefing.metadata_gap_count ?? briefing.metadata_gaps.length}`
+                : (briefing.metadata_gap_count ?? briefing.metadata_gaps.length)})</summary>
+              <div class="mt-3">
+                <input
+                  type="search"
+                  value=${gapQuery}
+                  onInput=${(event: Event) => setGapQuery((event.currentTarget as HTMLInputElement).value)}
+                  placeholder="관측 공백 필터 (summary, scope, info/watch...)"
+                  class="w-full px-3 py-2 rounded-lg border border-[var(--white-8)] bg-[var(--white-2)] text-[var(--text-body)] text-sm"
+                  aria-label="관측 공백 필터"
+                />
               </div>
+              ${filteredGaps.length === 0
+                ? html`<${EmptyState} message=${`필터 결과 없음 (${briefing.metadata_gaps.length} items)`} compact />`
+                : html`
+                    <div class="flex flex-col gap-3 mt-3">
+                      ${filteredGaps.map(item => html`
+                        <article class="p-4 rounded-xl border border-[var(--white-8)] bg-[var(--white-3)] grid gap-3 ${item.severity === 'watch' ? 'warn' : ''}">
+                          <div class="flex justify-between gap-3 items-start flex-wrap">
+                            <strong>${missionTargetTypeLabel(item.scope_type)}${item.scope_id ? ` · ${item.scope_id}` : ''}</strong>
+                            <${StatusChip} label=${statusLabel(item.severity)} tone=${item.severity === 'watch' ? 'warn' : ''} />
+                          </div>
+                          <p class="m-0 text-[var(--text-body)] leading-snug">${item.summary}</p>
+                        </article>
+                      `)}
+                    </div>
+                  `}
             </details>
           `
         : null}


### PR DESCRIPTION
## 요약

`mission-briefing-card.ts` 의 **관측 공백** (metadata gaps, `briefing.metadata_gaps` → `<details>` 안의 article 리스트) 에 자유 텍스트 필터를 추가합니다. sessions/keepers/agents 전반에서 누적된 gap들을 특정 scope(`live-judge`, `ts-4242`) 나 severity(`watch`) 로 좁혀 보고 싶을 때 기존에는 전체 목록을 눈으로 훑어야 했습니다.

## 왜 이 리스트인가

`mission-briefing-card.ts` 의 5개 `.map` 사이트:

- `keeper_briefs.map` (line 143) — 데이터 셰이핑 헬퍼, 렌더 리스트 아님
- `sections.slice(0, 3).map` (line 164) — text 보고 빌더, 렌더 아님, 하드캡 3
- `briefing.sections.slice(0, 3).map` (line 283) — 섹션 카드, **하드캡 3** 이라 스크롤 비대상
- `section.evidence.map` (line 301) — 섹션 안에 중첩된 태그, 섹션당 소수
- **`briefing.metadata_gaps.map` (line 323)** — **gap 배열, 전체 mission 범위에서 누적, scope/severity/kind 축으로 카디널리티 가장 큼** ← 선택

`metadata_gap_count` 는 섹션 수와 무관하게 mission scope 전체 관측에서 집계됩니다 (type: `DashboardMissionBriefingMetadataGap[]`). 다른 4개 map 사이트는 전부 하드캡이거나 중첩 소량이라 필터 이득이 없습니다.

## 변경

- `filterMetadataGaps(gaps, query)` 순수 함수를 `mission-briefing-card.ts` 에서 export.
  - `summary`, `scope_id`, `kind` 에 case-insensitive substring match.
  - Severity 는 query 가 정확히 `info` 또는 `watch` 일 때만 정확 일치. `wa` 같은 부분 토큰이 severity 매칭을 먹지 않도록 고정 — 키워드 축을 명확히 유지.
- 빈/공백 query 는 입력 참조 그대로 반환 → `useMemo` 가 identity 유지.
- 입력 비변이 (`readonly DashboardMissionBriefingMetadataGap[]`).
- 필터가 모든 gap 을 숨기면 별도 empty state: `필터 결과 없음 (N items)` — 실제 비어있음 (`metadata_gaps.length === 0`) 과 구분됩니다.
- 검색 input 은 기존 `<details>` 안쪽에만 렌더 → 접힌 기본 UI 에는 영향 없음.
- `<summary>` 카운터는 필터 중이면 `N/M` 으로 전환 (iter-7/8/9/11/12 seed-hint 패턴 동일).
- 한국어 placeholder: `관측 공백 필터 (summary, scope, info/watch...)`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/mission-briefing-card.test.ts`: 16/16 pass (기존 6 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive (`summary`)
5. `scope_id` substring 매칭
6. `kind` substring 매칭
7. `watch` 키워드 → watch severity 만
8. `info` 키워드 → info severity 두 건 모두
9. no-match → 빈 배열
10. 입력 비변이

## 범위 제한

Dashboard 파일 2개 (`mission-briefing-card.ts` + `mission-briefing-card.test.ts`) 만 수정. 다른 4개 map 사이트 (`keeper_briefs`, `sections` ×2, `section.evidence`) 는 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.