### PR TITLE
feat(dashboard): add title/actor/subject filter to activity-graph

### DIFF
--- a/dashboard/src/components/activity-graph.test.ts
+++ b/dashboard/src/components/activity-graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { visibleNamespaceLabel } from './activity-graph'
+import { filterActionGroups, visibleNamespaceLabel } from './activity-graph'
+import type { ActionTimelineGroup } from '../types'
 
 describe('visibleNamespaceLabel', () => {
   it('hides empty and default namespaces', () => {
@@ -15,5 +16,84 @@ describe('visibleNamespaceLabel', () => {
   it('returns trimmed non-default namespaces', () => {
     expect(visibleNamespaceLabel('project-a')).toBe('project-a')
     expect(visibleNamespaceLabel(' project-b ')).toBe('project-b')
+  })
+})
+
+function makeGroup(overrides: Partial<ActionTimelineGroup>): ActionTimelineGroup {
+  return {
+    id: 'g1',
+    category: 'task',
+    actor: 'dreamer',
+    subjectId: null,
+    title: 'claim task PK-123',
+    summary: 'dreamer claimed task PK-123',
+    latestTs: '2026-04-17T00:00:00Z',
+    latestTsMs: 0,
+    rawCount: 1,
+    kinds: ['task.claim'],
+    rawEvents: [],
+    ...overrides,
+  }
+}
+
+describe('filterActionGroups', () => {
+  const groups: readonly ActionTimelineGroup[] = [
+    makeGroup({ id: 'a', title: 'claim task PK-123', actor: 'dreamer', subjectId: 'PK-123' }),
+    makeGroup({ id: 'b', title: 'session start', actor: 'keeper-1', subjectId: null, summary: 'keeper-1 joined room alpha' }),
+    makeGroup({ id: 'c', title: 'broadcast status', actor: 'Watcher', subjectId: 'room-beta', summary: 'Watcher posted status update' }),
+    makeGroup({ id: 'd', title: 'governance vote', actor: 'judge', subjectId: null, summary: '' }),
+  ]
+
+  it('returns input reference when query is empty', () => {
+    expect(filterActionGroups(groups, '')).toBe(groups)
+  })
+
+  it('returns input reference when query is whitespace only', () => {
+    expect(filterActionGroups(groups, '   ')).toBe(groups)
+  })
+
+  it('trims query before matching', () => {
+    const result = filterActionGroups(groups, '  claim  ')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe('a')
+  })
+
+  it('matches title case-insensitively', () => {
+    const result = filterActionGroups(groups, 'CLAIM')
+    expect(result.map(g => g.id)).toEqual(['a'])
+  })
+
+  it('matches actor substring', () => {
+    const result = filterActionGroups(groups, 'watch')
+    expect(result.map(g => g.id)).toEqual(['c'])
+  })
+
+  it('matches subjectId substring', () => {
+    const result = filterActionGroups(groups, 'room-beta')
+    expect(result.map(g => g.id)).toEqual(['c'])
+  })
+
+  it('matches summary substring', () => {
+    const result = filterActionGroups(groups, 'joined room')
+    expect(result.map(g => g.id)).toEqual(['b'])
+  })
+
+  it('returns empty array when no group matches', () => {
+    expect(filterActionGroups(groups, 'nonexistent-needle')).toEqual([])
+  })
+
+  it('handles null subjectId without crashing', () => {
+    const result = filterActionGroups(groups, 'judge')
+    expect(result.map(g => g.id)).toEqual(['d'])
+  })
+
+  it('does not mutate the input array', () => {
+    const snapshot = groups.slice()
+    filterActionGroups(groups, 'claim')
+    expect(groups).toEqual(snapshot)
+  })
+
+  it('returns empty result on empty input', () => {
+    expect(filterActionGroups([], 'claim')).toEqual([])
   })
 })

--- a/dashboard/src/components/activity-graph.ts
+++ b/dashboard/src/components/activity-graph.ts
@@ -40,6 +40,34 @@ const DEFAULT_ACTIVITY_RANGE: TimeRangePreset = '1h'
 const actionFilter = signal<ActionTimelineFilter>('all')
 const showLifecycle = signal(false)
 const expandedActionGroups = signal<Set<string>>(new Set())
+const actionQuery = signal('')
+
+/**
+ * Pure filter for action timeline groups.
+ *
+ * Case-insensitive substring match on `title`, `summary`, `actor`, and
+ * `subjectId` so operators can locate an action group by partial title,
+ * summary content, actor name, or subject id.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no
+ * new array allocation, preserves referential equality).
+ *
+ * Input is never mutated.
+ */
+export function filterActionGroups(
+  groups: readonly ActionTimelineGroup[],
+  query: string,
+): readonly ActionTimelineGroup[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return groups
+  return groups.filter(group => {
+    if (group.title.toLowerCase().includes(needle)) return true
+    if (group.summary.toLowerCase().includes(needle)) return true
+    if (group.actor && group.actor.toLowerCase().includes(needle)) return true
+    if (group.subjectId && group.subjectId.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 export function visibleNamespaceLabel(namespaceId: string | null | undefined): string | null {
   const value = typeof namespaceId === 'string' ? namespaceId.trim() : ''
@@ -120,9 +148,12 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
   const rawCounts = buildRawCategoryCounts(data.kind_counts)
   const lifecycleHiddenCount = showLifecycle.value ? 0 : rawCounts.lifecycle
   const filter = actionFilter.value
-  const filteredGroups = visibleBaseGroups.filter(group =>
+  const categoryFilteredGroups = visibleBaseGroups.filter(group =>
     filter === 'all' ? true : group.category === filter,
   )
+  const query = actionQuery.value
+  const filteredGroups = filterActionGroups(categoryFilteredGroups, query)
+  const isFiltering = query.trim() !== ''
   const chips = [
     { key: 'all', label: '전체', count: visibleBaseGroups.length },
     { key: 'task', label: '작업', count: baseCounts.task },
@@ -145,12 +176,20 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
         <div class="flex flex-col gap-1">
           <div class="text-[14px] font-semibold text-[var(--text-strong)]">원본 실행 이벤트를 최근 액션 단위로 묶어 보여줍니다.</div>
           <div class="text-[12px] text-[var(--text-muted)]">
-            액션 ${filteredGroups.length}개 · 원본 타임라인 ${data.timeline.length}건 · 분석 범위 ${data.stats.event_count ?? data.timeline.length}건
+            액션 ${isFiltering ? `${filteredGroups.length}/${categoryFilteredGroups.length}` : filteredGroups.length}개 · 원본 타임라인 ${data.timeline.length}건 · 분석 범위 ${data.stats.event_count ?? data.timeline.length}건
             ${lifecycleHiddenCount > 0 ? ` · 생명주기 ${lifecycleHiddenCount}건 숨김` : ''}
           </div>
         </div>
         <div class="flex flex-wrap items-center gap-2">
           <${FilterChips} chips=${chips} active=${actionFilter} tone="accent" />
+          <input
+            type="search"
+            value=${query}
+            placeholder="액션 필터 (title, actor, subject...)"
+            aria-label="액션 타임라인 필터"
+            onInput=${(e: Event) => { actionQuery.value = (e.target as HTMLInputElement).value }}
+            class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
           <button
             type="button"
             class="inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-[11px] transition-all duration-150 ${showLifecycle.value
@@ -165,7 +204,9 @@ function ActionTimeline({ data }: { data: ActivityGraphResponse }) {
       </div>
 
       ${filteredGroups.length === 0
-        ? html`<${EmptyState} message="선택한 필터에 맞는 액션 그룹이 없습니다." compact />`
+        ? (isFiltering && categoryFilteredGroups.length > 0
+          ? html`<div class="py-4 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${categoryFilteredGroups.length} items)</div>`
+          : html`<${EmptyState} message="선택한 필터에 맞는 액션 그룹이 없습니다." compact />`)
         : filteredGroups.map(group => {
             const expanded = expandedActionGroups.value.has(group.id)
             return html`


### PR DESCRIPTION
## 요약

`activity-graph.ts` 의 **ActionTimeline** (`buildActionTimelineGroups` → `filteredGroups.map`) 리스트에 자유 텍스트 필터를 추가합니다. 바쁜 플릿에서는 카테고리 칩(task/session/message/board/governance) 으로 범주는 좁힐 수 있지만, 특정 keeper 한 명이 낸 액션, 특정 `PK-XXX` subject, 또는 `claim` 같은 title 부분문자열을 카테고리 교차로 찾으려면 스크롤이 필요했습니다.

## 왜 이 리스트인가

`activity-graph.ts` 의 7개 `.map` 사이트:

- `h.map(b => b.events)` 등 3건 (line 65~67) — stats sparkline 입력 숫자 배열, UI 리스트 아님
- **`filteredGroups.map` (line 169, ActionTimeline)** — **category chip 으로만 필터되는 가장 큰 list, `title`/`summary`/`actor`/`subjectId` 모두 자유 텍스트 필드** ← 선택
- `group.kinds.slice(0, 4).map` (line 191) — 그룹 내부 inline chips (최대 4), 카디널리티 작음
- `group.rawEvents.map` (line 217) — expanded 시에만 보이는 원본 이벤트, scope 밖
- `agentNodes.map` (line 260, NodeLeaderboard) — 이미 top-15 로 slice, scroll 필요 없음

ActionTimeline 은 카테고리 필터 이후에도 group 수가 수십 건까지 늘어날 수 있고, 검색 가능한 필드가 4개(title/summary/actor/subjectId) 로 가장 풍부합니다.

## 변경

- `filterActionGroups(groups, query)` 순수 함수를 `activity-graph.ts` 에서 export. case-insensitive substring match on `title` → `summary` → `actor` → `subjectId`.
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지.
- 입력 비변이 (`readonly ActionTimelineGroup[]`).
- 카테고리 칩 오른쪽에 `<input type=\"search\">` 배치, 한국어 placeholder: `액션 필터 (title, actor, subject...)`.
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 카테고리 필터로 인해 비어있는 경우(`선택한 필터에 맞는 액션 그룹이 없습니다.`) 와 구분.
- 필터 중이면 `N/M개` 카운터 노출.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/activity-graph.test.ts`: 13/13 pass (기존 2 + 신규 11).
- `pnpm exec eslint .`: 0 errors.

신규 11건:
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive (title)
5. actor substring 매칭
6. subjectId substring 매칭
7. summary substring 매칭
8. no-match → 빈 배열
9. null subjectId 처리
10. 입력 비변이
11. 빈 입력 배열 → 빈 결과

## 범위 제한

Dashboard 파일 2개만 수정. 다른 리스트(stats sparkline, inline kinds, rawEvents, NodeLeaderboard) 는 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.