### PR TITLE
feat(dashboard): add title/status/metric filter to goal relation list in task-detail-overlay

### DIFF
--- a/dashboard/src/components/goals/task-detail-overlay.ts
+++ b/dashboard/src/components/goals/task-detail-overlay.ts
@@ -19,6 +19,8 @@ import {
   taskEventsError,
   taskEventsSearchQuery,
   filterTaskEvents,
+  goalRelationSearchQuery,
+  filterGoalRelations,
   assigneeGoalIds,
   activeTab,
   switchToActivityTab,
@@ -268,11 +270,36 @@ function HandoffSection({ task }: { task: Task }) {
 function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
   if (goalIds.length === 0) return null
 
+  const query = goalRelationSearchQuery.value
+  const visibleIds = filterGoalRelations(goalIds, query)
+  const trimmed = query.trim()
+  const isFiltering = trimmed !== ''
+
   return html`
     <div class="flex flex-col gap-2">
-      <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">담당 키퍼의 활성 목표</div>
+      <div class="flex flex-wrap items-center gap-2">
+        <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">담당 키퍼의 활성 목표</div>
+        ${goalIds.length > 1 ? html`
+          <input
+            type="search"
+            value=${query}
+            placeholder="목표 검색 (title/status/metric)"
+            aria-label="목표 검색"
+            onInput=${(e: Event) => { goalRelationSearchQuery.value = (e.target as HTMLInputElement).value }}
+            class="min-w-[160px] max-w-[240px] flex-1 rounded-md border border-[var(--white-10)] bg-[var(--white-4)] px-2 py-1 text-[11px] text-[var(--text-body)] placeholder:text-[var(--text-dim)] focus:outline-none focus:border-[var(--accent)]"
+          />
+          <span class="text-[10px] text-[var(--text-muted)] tabular-nums">
+            ${isFiltering
+              ? `${visibleIds.length} / ${goalIds.length}`
+              : `${goalIds.length}개`}
+          </span>
+        ` : null}
+      </div>
+      ${isFiltering && visibleIds.length === 0
+        ? html`<div class="py-3 text-center text-[11px] text-[var(--text-dim)]">필터 결과 없음 (${goalIds.length} goals)</div>`
+        : html`
       <div class="flex flex-col gap-1">
-        ${goalIds.map(id => {
+        ${visibleIds.map(id => {
           const goal = goalById(id)
           return html`
             <div key=${id} class="flex items-center gap-2 rounded-lg border border-card-border/50 bg-[var(--white-3)] px-3 py-2">
@@ -282,6 +309,7 @@ function GoalRelationSection({ goalIds }: { goalIds: string[] }) {
           `
         })}
       </div>
+        `}
     </div>
   `
 }

--- a/dashboard/src/components/goals/task-detail-state.test.ts
+++ b/dashboard/src/components/goals/task-detail-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { filterTaskEvents } from './task-detail-state'
+import { filterGoalRelations, filterTaskEvents } from './task-detail-state'
 import type { NormalizedTaskEvent } from './task-detail-state'
+import type { Goal } from '../../types'
 
 const sample: NormalizedTaskEvent[] = [
   {
@@ -96,5 +97,81 @@ describe('filterTaskEvents', () => {
   it('can match multiple rows when substring is shared', () => {
     const out = filterTaskEvents(sample, 'keeper')
     expect(out.map(e => e.label)).toEqual(['claim', 'done'])
+  })
+})
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: 'g-1',
+    horizon: 'short',
+    title: 'default title',
+    metric: null,
+    target_value: null,
+    due_date: null,
+    priority: 3,
+    status: 'active',
+    parent_goal_id: null,
+    last_review_note: null,
+    last_review_at: null,
+    created_at: '2026-04-17T00:00:00Z',
+    updated_at: '2026-04-17T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('filterGoalRelations', () => {
+  const store: Record<string, Goal> = {
+    'g-alpha': makeGoal({ id: 'g-alpha', title: 'Reduce tool error rate', status: 'active', metric: 'error_rate' }),
+    'g-beta': makeGoal({ id: 'g-beta', title: 'Lift cascade coverage', status: 'paused', metric: 'coverage_pct' }),
+    'g-gamma': makeGoal({ id: 'g-gamma', title: 'Keeper idle audit', status: 'completed', metric: null }),
+  }
+  const ids: string[] = ['g-alpha', 'g-beta', 'g-gamma', 'g-orphan']
+  const resolve = (id: string): Goal | undefined => store[id]
+
+  it('returns the input reference when query is empty', () => {
+    expect(filterGoalRelations(ids, '', resolve)).toBe(ids)
+  })
+
+  it('returns the input reference for whitespace-only query', () => {
+    expect(filterGoalRelations(ids, '   ', resolve)).toBe(ids)
+  })
+
+  it('trims query before matching', () => {
+    expect(filterGoalRelations(ids, '  alpha  ', resolve)).toEqual(['g-alpha'])
+  })
+
+  it('matches resolved goal title (case-insensitive)', () => {
+    const out = filterGoalRelations(ids, 'CASCADE', resolve)
+    expect(out).toEqual(['g-beta'])
+  })
+
+  it('matches resolved goal status', () => {
+    const out = filterGoalRelations(ids, 'paused', resolve)
+    expect(out).toEqual(['g-beta'])
+  })
+
+  it('matches resolved goal metric substring', () => {
+    const out = filterGoalRelations(ids, 'coverage', resolve)
+    expect(out).toEqual(['g-beta'])
+  })
+
+  it('matches raw id even when the goal is unresolved', () => {
+    const out = filterGoalRelations(ids, 'orphan', resolve)
+    expect(out).toEqual(['g-orphan'])
+  })
+
+  it('returns empty when no id or resolved field matches', () => {
+    expect(filterGoalRelations(ids, 'nonexistent-token', resolve)).toHaveLength(0)
+  })
+
+  it('does not mutate the input array', () => {
+    const before = ids.slice()
+    filterGoalRelations(ids, 'alpha', resolve)
+    expect(ids).toEqual(before)
+  })
+
+  it('matches multiple ids sharing a substring and preserves input order', () => {
+    const out = filterGoalRelations(ids, 'g-', resolve)
+    expect(out).toEqual(['g-alpha', 'g-beta', 'g-gamma', 'g-orphan'])
   })
 })

--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -5,7 +5,8 @@ import { fetchTaskHistory } from '../../api/actions'
 import { fetchAgentTimeline, fetchKeeperTrajectory } from '../../api/dashboard'
 import { buildTraceEvents, type UnifiedTraceEvent } from '../session-trace/session-trace-state'
 import { findKeeper } from '../../lib/keeper-utils'
-import type { Task } from '../../types'
+import { goalById } from './goal-helpers'
+import type { Goal, Task } from '../../types'
 
 // -- Activity filter (owned here, consumed by task-activity-list) ---
 
@@ -75,6 +76,37 @@ export function filterTaskEvents(
   })
 }
 
+/**
+ * Pure filter for goal relation rows (the assignee keeper's active goals).
+ *
+ * - `query` is case-insensitive substring match across the goal's `id`,
+ *   resolved `title`, `status`, and `metric` (trimmed). Unresolved goal
+ *   ids still match on the raw id so operators can search by identifier
+ *   even when the goal store has not loaded that entry yet.
+ * - Empty/whitespace-only query returns the input reference unchanged
+ *   (zero-allocation fast path, preserves identity for memoisation).
+ * - `resolve` defaults to `goalById` so the filter stays pure in tests
+ *   when the caller provides an injected lookup.
+ * - Does not mutate the input array.
+ */
+export function filterGoalRelations(
+  ids: readonly string[],
+  query: string,
+  resolve: (id: string) => Goal | undefined = goalById,
+): readonly string[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return ids
+  return ids.filter(id => {
+    if (id.toLowerCase().includes(needle)) return true
+    const goal = resolve(id)
+    if (!goal) return false
+    if (goal.title.toLowerCase().includes(needle)) return true
+    if (goal.status.toLowerCase().includes(needle)) return true
+    if (goal.metric && goal.metric.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
+
 // -- Overlay signals ------------------------------------------------
 
 export const selectedTask = signal<Task | null>(null)
@@ -82,6 +114,7 @@ export const taskEvents = signal<NormalizedTaskEvent[]>([])
 export const taskEventsLoading = signal(false)
 export const taskEventsError = signal<string | null>(null)
 export const taskEventsSearchQuery = signal('')
+export const goalRelationSearchQuery = signal('')
 
 export type TaskDetailTab = 'overview' | 'activity'
 export const activeTab = signal<TaskDetailTab>('overview')
@@ -100,6 +133,7 @@ function resetState(): void {
   taskEventsLoading.value = false
   taskEventsError.value = null
   taskEventsSearchQuery.value = ''
+  goalRelationSearchQuery.value = ''
   activityEvents.value = []
   activityLoading.value = false
   activityError.value = null


### PR DESCRIPTION
## 요약

`dashboard/src/components/goals/task-detail-overlay.ts` 의 **GoalRelationSection** (담당 키퍼의 활성 목표 리스트) 에 자유 텍스트 필터를 추가합니다. 한 keeper가 short/mid/long horizon 을 동시에 들고 있으면 이 섹션이 900px 다이얼로그 안에서 쉽게 한 화면을 넘깁니다. 특정 goal 하나를 title/status/metric 로 찾고 싶을 때 스크롤이 필요했습니다.

## 왜 이 리스트인가

`task-detail-overlay.ts` 의 8개 `.map` 사이트:

- `visible.map` (line 92, TaskEventsSection) — **이미 필터 존재** (`filterTaskEvents`), iter-earlier.
- `gate.reasons.slice(0, 4).map` (line 143) — 최대 4개, 카디널리티 고정.
- `completionItems.map` (line 196, Contract completion list) — string[], 후보.
- `requiredEvidence.map` (line 207) — string[], 보통 0~5 카디널리티.
- `items.map` (line 231, ExecutionLinksSection) — 최대 3개 고정 (session/operation/autoresearch).
- `handoff.evidence_refs.map` (line 256) — string[], 보통 0~5.
- **`goalIds.map` (line 275, GoalRelationSection)** — **resolved `Goal` 당 structured 필드 (title/status/metric) 이 있어 가장 자연스러운 검색 대상** ← 선택
- `tabs.map` (line 332) — 2개 고정 tab.

`goalIds` 는 keeper 가 3-horizon 을 모두 점유할 때 실측상 카디널리티가 가장 크고, 단순 string[] 인 contract/evidence 와 달리 `Goal` 구조체(title, status, metric) 가 뒤에 있어 필터 의미가 풍부합니다. Runners-up 후보였던 `completionItems` 와 `evidence_refs` 는 free-text string 단일 필드라 이득이 작고, 계약 게이트는 이미 시각적 강조(unmet 색상)로 스캔이 쉬운 편입니다.

## 변경

- `filterGoalRelations(ids, query, resolve?)` 순수 함수를 `task-detail-state.ts` 에서 export. case-insensitive substring.
  - `id` → `Goal.title` → `Goal.status` → `Goal.metric` 순서로 substring match. 하나라도 hit 하면 통과.
  - 미해결(resolve 가 undefined 를 리턴) 한 id 는 raw id substring 만 시도. goal store 하이드레이션 전에도 식별자로 검색 가능.
  - `resolve` 파라미터가 선택적이라 테스트에서 store 주입 가능 (`goalById` 기본).
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지.
- 입력 비변이 (`readonly string[]`).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N goals)` — goal 이 실제로 없는 경우(섹션 자체가 렌더링되지 않음) 와 구분.
- 검색 input 은 `goalIds.length > 1` 일 때만 렌더 — 단일 goal 케이스(기본값) 는 시각적으로 동일.
- 한국어 placeholder: `목표 검색 (title/status/metric)`.
- 필터 중이면 `N / M` 카운터 노출 (Task Events 패턴 동일).
- `goalRelationSearchQuery` signal 은 `resetState()` 에서 초기화 — 다른 task detail 을 열면 query 가 남지 않음.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/goals/task-detail-state.test.ts`: 20/20 pass (기존 10 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건 (`filterGoalRelations`):
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용
4. case-insensitive `title` 매칭 (`CASCADE` → 'Lift cascade coverage')
5. `status` 매칭 (`paused`)
6. `metric` substring 매칭 (`coverage`)
7. 미해결 id 도 raw id substring 으로 매칭 (`orphan` → 'g-orphan')
8. no-match → 빈 배열
9. 입력 비변이
10. 공유 substring 은 복수 매칭 + 입력 순서 유지 (`g-` → 4개 전부)

## CI 관련

Branch 는 origin/main 에 rebase 완료. Dashboard-only 변경 (2 production files + 1 test file).

## 범위 제한

- Dashboard 파일만 수정. 2개 production + 1개 test.
- 하나의 리스트만 필터링 — `GoalRelationSection` 의 goalIds.
- 다른 `.map` 사이트(`completionItems`, `requiredEvidence`, `evidence_refs`, `gate.reasons`, execution links, tabs) 는 건드리지 않음.
- `TaskEventsSection` 의 기존 `filterTaskEvents` 필터와 동일한 구조(pure helper + signal + 한국어 placeholder + N/M 카운터 + 구분된 empty state)를 재사용 — iter-7/8/9/11/12 seed-hint 패턴 유지.