### PR TITLE
feat(dashboard): sticky connector overview + ✨ celebration when all 4 up

### DIFF
--- a/dashboard/src/components/connector-overview-strip.test.ts
+++ b/dashboard/src/components/connector-overview-strip.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
-import { ConnectorOverviewStrip, _testResetBulkInflight } from './connector-overview-strip'
+import { ConnectorOverviewStrip, _testResetBulkInflight, countConnectedSidecars } from './connector-overview-strip'
 import type { GateConnectorInfo } from '../api/gate'
 
 const mkConnector = (overrides: Partial<GateConnectorInfo> = {}): GateConnectorInfo => ({
@@ -103,5 +103,44 @@ describe('ConnectorOverviewStrip', () => {
     const discordTile = container.querySelector('[data-overview-tile="discord"]')!
     const pills = discordTile.querySelectorAll('[data-rail-pill]')
     expect(pills.length).toBe(4)
+  })
+
+  it('strip root has sticky positioning so it stays visible while scrolling', () => {
+    render(html`<${ConnectorOverviewStrip} connectors=${[]} keeperCount=${0} />`, container)
+    const root = container.querySelector('[data-overview-strip-root]') as HTMLElement
+    expect(root).toBeTruthy()
+    expect(root.className).toContain('sticky')
+    expect(root.className).toContain('top-0')
+  })
+
+  it('celebration banner hidden when fewer than 4 sidecars are up', () => {
+    _testResetBulkInflight()
+    const threeUp = ['discord', 'imessage', 'slack'].map(id => mkConnector({ connector_id: id, available: true }))
+    render(html`<${ConnectorOverviewStrip} connectors=${threeUp} keeperCount=${0} />`, container)
+    expect(container.querySelector('[data-celebration]')).toBeNull()
+  })
+
+  it('celebration banner shows when all 4 sidecars are up', () => {
+    _testResetBulkInflight()
+    const allUp = ['discord', 'imessage', 'slack', 'telegram'].map(id => mkConnector({ connector_id: id, available: true }))
+    render(html`<${ConnectorOverviewStrip} connectors=${allUp} keeperCount=${0} />`, container)
+    const banner = container.querySelector('[data-celebration="all-connected"]')
+    expect(banner).toBeTruthy()
+    expect(banner?.textContent).toContain('4/4')
+  })
+})
+
+describe('countConnectedSidecars', () => {
+  it('returns 0 for empty list', () => {
+    expect(countConnectedSidecars([])).toBe(0)
+  })
+
+  it('counts only available=true known sidecars', () => {
+    const list = [
+      mkConnector({ connector_id: 'discord', available: true }),
+      mkConnector({ connector_id: 'slack', available: false }),
+      mkConnector({ connector_id: 'unknown-bridge', available: true }),
+    ]
+    expect(countConnectedSidecars(list)).toBe(1)
   })
 })

--- a/dashboard/src/components/connector-overview-strip.ts
+++ b/dashboard/src/components/connector-overview-strip.ts
@@ -144,9 +144,38 @@ function BulkActions({ connectors }: { connectors: GateConnectorInfo[] }) {
   `
 }
 
-export function ConnectorOverviewStrip({ connectors, keeperCount }: OverviewProps) {
+/** Pure: count of KNOWN sidecars currently up. Exposed for unit tests
+    so the celebration banner condition can be pinned without DOM. */
+export function countConnectedSidecars(connectors: GateConnectorInfo[]): number {
+  return KNOWN_CONNECTOR_IDS.filter(id => findConnector(connectors, id)?.available === true).length
+}
+
+function CelebrationBanner({ connectedCount }: { connectedCount: number }) {
+  if (connectedCount < KNOWN_CONNECTOR_IDS.length) return null
   return html`
-    <div class="mb-4">
+    <div
+      class="mb-2 flex items-center justify-center gap-2 rounded-md border border-emerald-400/40 bg-emerald-500/10 px-3 py-1.5 text-[11px] font-semibold text-emerald-100"
+      data-celebration="all-connected"
+    >
+      <span aria-hidden="true">✨</span>
+      <span>${connectedCount}/${KNOWN_CONNECTOR_IDS.length} 커넥터 모두 정상 — 운영 준비 완료</span>
+      <span aria-hidden="true">✨</span>
+    </div>
+  `
+}
+
+export function ConnectorOverviewStrip({ connectors, keeperCount }: OverviewProps) {
+  // Sticky so the rail rows stay visible while the operator scrolls
+  // through the stacked detail panels — they can always see "what's
+  // broken" without scrolling back up. backdrop-blur keeps the strip
+  // legible when card content slides under it.
+  const connectedCount = countConnectedSidecars(connectors)
+  return html`
+    <div
+      class="sticky top-0 z-10 mb-4 -mx-4 border-b border-[var(--card-border)] bg-[var(--bg-0)]/95 px-4 pt-2 pb-3 backdrop-blur supports-[backdrop-filter]:bg-[var(--bg-0)]/80"
+      data-overview-strip-root
+    >
+      <${CelebrationBanner} connectedCount=${connectedCount} />
       <${BulkActions} connectors=${connectors} />
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         ${KNOWN_CONNECTOR_IDS.map(id => html`


### PR DESCRIPTION
## Summary
- Connector overview strip is now `sticky top-0` so the 4-tile status stays visible while the operator scrolls through detail panels below. `backdrop-blur` + translucent `bg-[var(--bg-0)]/95` keeps it readable as content slides under.
- When `countConnectedSidecars(connectors) === 4`, an emerald celebration banner surfaces above the tiles (`✨ 4/4 커넥터 모두 정상 — 운영 준비 완료 ✨`).
- New pure helper `countConnectedSidecars()` exported for unit test isolation.

## Motivation
Follows `docs/CONNECTOR-UI-DESIGN.md` § 1 (status visible at a glance) — after the recent stack (PR #7833) operators still had to scroll back to the top to re-check status. Sticky strip closes that loop.

## Test plan
- [x] 4 new vitest cases (sticky class, celebration hidden<4, celebration shown=4, pure-fn cases). Suite: 11/11.
- [x] typecheck clean
- [ ] empirical: open `/connectors`, scroll, verify strip stays; up all 4 sidecars → celebration appears

## Related
- Builds on #7833 (feature/dash-connectors-toplevel)
- Reuses `KNOWN_CONNECTOR_IDS`, `BulkActions`, existing rail/tile components — no new APIs.