### PR TITLE
fix(dashboard/goals): render event.detail in task activity expanded view

### DIFF
--- a/dashboard/src/components/goals/task-activity-list.test.ts
+++ b/dashboard/src/components/goals/task-activity-list.test.ts
@@ -122,6 +122,36 @@ describe('TaskActivityList', () => {
     expect(text).toContain('"ok":true')
   })
 
+  it('renders event.detail when expanded for lifecycle events without toolArgs/toolResult', async () => {
+    const { container } = render(h(TaskActivityList, {
+      events: [sampleToolCallEvent({
+        kind: 'lifecycle',
+        toolArgs: undefined,
+        toolResult: null,
+        detail: { agent: 'keeper-sojin-agent', event: 'turn_completed', turn: 42 },
+      })],
+      loading: false,
+      error: null,
+      showToolCalls: true,
+    }))
+
+    const details = container.querySelector('details')
+    expect(details).not.toBeNull()
+    if (!details) return
+
+    details.open = true
+    fireEvent(details, new Event('toggle', { bubbles: true }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('json-viewer-card')).toBeInTheDocument()
+    })
+    const card = screen.getByTestId('json-viewer-card')
+    expect(card).toHaveAttribute('data-title', 'Detail')
+    const text = card.textContent ?? ''
+    expect(text).toContain('keeper-sojin-agent')
+    expect(text).toContain('turn_completed')
+  })
+
   it('marks decorative icons as hidden from assistive tech', () => {
     const { container } = render(h(TaskActivityList, {
       events: [sampleToolCallEvent({ toolArgs: undefined, toolResult: null })],

--- a/dashboard/src/components/goals/task-activity-list.ts
+++ b/dashboard/src/components/goals/task-activity-list.ts
@@ -106,6 +106,11 @@ function ActivityEntry({ event }: { event: UnifiedTraceEvent }) {
               <${JsonViewerCard} data=${parseJsonLikeData(event.toolResult)} title="Result" />
             </div>
           ` : null}
+          ${event.toolArgs == null && event.toolResult == null && event.detail && Object.keys(event.detail).length > 0 ? html`
+            <div class="mb-1">
+              <${JsonViewerCard} data=${event.detail} title="Detail" />
+            </div>
+          ` : null}
           ${event.error ? html`<div class="text-[11px] text-[var(--bad-light)] mt-1">${event.error}</div>` : null}
           ${event.cost_usd != null ? html`<div class="text-[10px] text-text-dim mt-1">cost: $${event.cost_usd.toFixed(4)}</div>` : null}
         </div>


### PR DESCRIPTION
## Summary
- Task 상세보기 → 담당자 최근 활동 탭에서 \`turn_completed\` / \`joined\` / \`claimed\` 같은 lifecycle 이벤트를 열면 빈 패널이 나오던 버그 수정
- \`hasDetail\` 판정과 expanded 렌더링의 **필드 조건 불일치** 문제: \`hasDetail\`은 \`event.detail\`을 포함해 "펼칠 수 있다" UI 표시했지만 \`<details>\` 본문은 \`toolArgs/toolResult/error/cost_usd\`만 렌더링해서 \`detail\`만 있는 이벤트는 펼치면 아무것도 안 나옴

## Fix
- \`toolArgs\` 및 \`toolResult\`이 모두 null이고 \`event.detail\`에 키가 있을 때 \`JsonViewerCard\` (title: "Detail")로 렌더링
- tool_call 이벤트의 기존 Args/Result 렌더링은 그대로 유지

## Reproduce (before fix)
1. Dashboard → Workspace → Planning → Task 선택
2. "담당자 최근 활동" 탭
3. \`turn_completed\`류 행 클릭 → ChevronRight 있어서 펼쳐지는 것처럼 보이지만 빈 div

## Test plan
- [x] \`npx vitest run src/components/goals/task-activity-list.test.ts\` → 12/12 pass (기존 11 + regression 1 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)