### PR TITLE
feat(dashboard): add name/state filter to fleet-fsm-matrix

### DIFF
--- a/dashboard/src/components/fleet-fsm-matrix.test.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import {
   chipClassFor,
+  filterKeeperSnapshots,
   FLEET_HISTORY_LEN,
   inferKeeperNameFrom,
   pushObservation,
@@ -173,5 +174,70 @@ describe('pushObservation', () => {
     const t1 = pushObservation({}, [warn])
     const t2 = pushObservation(t1, [cool])
     expect(t2.beta!.breaker).toEqual(['warning', 'cooling'])
+  })
+})
+
+describe('filterKeeperSnapshots', () => {
+  const alpha = snapshot({ name: 'gen12-alpha' })
+  const beta = snapshot({
+    name: 'gen14-beta',
+    phase: 'Overflowed',
+    cascade: { state: 'trying' },
+  })
+  const gamma = snapshot({
+    name: 'gen12-gamma',
+    turn_phase: 'prompting',
+  })
+  const rows: readonly KeeperCompositeSnapshot[] = [alpha, beta, gamma]
+
+  it('returns the input reference unchanged on an empty query', () => {
+    expect(filterKeeperSnapshots(rows, '')).toBe(rows)
+  })
+
+  it('returns the input reference unchanged on a whitespace-only query', () => {
+    expect(filterKeeperSnapshots(rows, '   ')).toBe(rows)
+  })
+
+  it('matches keeper name substring case-insensitively', () => {
+    const out = filterKeeperSnapshots(rows, 'GEN12')
+    expect(out.map(inferKeeperNameFrom)).toEqual(['gen12-alpha', 'gen12-gamma'])
+  })
+
+  it('matches phase (KSM) axis value', () => {
+    const out = filterKeeperSnapshots(rows, 'overflowed')
+    expect(out.map(inferKeeperNameFrom)).toEqual(['gen14-beta'])
+  })
+
+  it('matches cascade (KCL) axis value', () => {
+    const out = filterKeeperSnapshots(rows, 'trying')
+    expect(out.map(inferKeeperNameFrom)).toEqual(['gen14-beta'])
+  })
+
+  it('matches turn (KTC) axis value', () => {
+    const out = filterKeeperSnapshots(rows, 'prompting')
+    expect(out.map(inferKeeperNameFrom)).toEqual(['gen12-gamma'])
+  })
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterKeeperSnapshots(rows, 'nothing-here')).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const input: KeeperCompositeSnapshot[] = [alpha, beta, gamma]
+    const before = input.slice()
+    filterKeeperSnapshots(input, 'gen12')
+    expect(input).toEqual(before)
+    expect(input.length).toBe(3)
+  })
+
+  it('trims the query before matching', () => {
+    const out = filterKeeperSnapshots(rows, '  gen14-beta  ')
+    expect(out.map(inferKeeperNameFrom)).toEqual(['gen14-beta'])
+  })
+
+  it('returns a new array (not input ref) when filtering actually runs', () => {
+    const out = filterKeeperSnapshots(rows, 'gen12')
+    expect(out).not.toBe(rows)
+    expect(out.length).toBe(2)
   })
 })

--- a/dashboard/src/components/fleet-fsm-matrix.ts
+++ b/dashboard/src/components/fleet-fsm-matrix.ts
@@ -170,6 +170,38 @@ export function pushObservation(
 }
 
 /**
+ * Pure filter for fleet keeper snapshots.
+ *
+ * Case-insensitive substring match on the keeper name (as derived
+ * from the canonical correlation_id) and on the current value of
+ * each of the six FSM axes so an operator can isolate a single
+ * keeper by name, or every keeper currently in a specific state
+ * (e.g. `trying`, `Overflowed`, `warning`).
+ *
+ * Empty/whitespace query returns the input reference unchanged so
+ * useMemo callers keep identity for the non-filtering path and
+ * skip a downstream render pass.
+ *
+ * Input is never mutated.
+ */
+export function filterKeeperSnapshots(
+  snapshots: readonly KeeperCompositeSnapshot[],
+  query: string,
+): readonly KeeperCompositeSnapshot[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return snapshots
+  return snapshots.filter(snap => {
+    const name = inferKeeperNameFrom(snap)
+    if (name.toLowerCase().includes(needle)) return true
+    for (const axis of AXIS_KEYS) {
+      const value = extractLaneValue(snap, axis)
+      if (value && value.toLowerCase().includes(needle)) return true
+    }
+    return false
+  })
+}
+
+/**
  * Sum invariant violations across the fleet. Value is the number of
  * keepers where the invariant is currently failing; matches the
  * denominator the operator cares about ("how many keepers are bad?"),
@@ -206,6 +238,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
   const [data, setData] = useState<FleetCompositeSnapshot | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
+  const [query, setQuery] = useState<string>('')
   // Observation ring. Ref rather than state because pushObservation
   // returns a fresh record per tick and we pair it with a setData call
   // which triggers the re-render — avoids a redundant state subscription.
@@ -249,6 +282,11 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
     () => (data ? tallyInvariantViolations(data.snapshots) : null),
     [data],
   )
+  const visibleSnapshots = useMemo(
+    () => (data ? filterKeeperSnapshots(data.snapshots, query) : []),
+    [data, query],
+  )
+  const isFiltering = query.trim() !== ''
 
   if (loading) {
     return html`
@@ -293,6 +331,15 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
         <span class="text-xs text-zinc-500">
           ${data.count} keepers · updated ${new Date(data.generated_at * 1000).toLocaleTimeString()}
         </span>
+        <input
+          type="search"
+          value=${query}
+          placeholder="name / 상태 필터 (예: gen12, trying)"
+          aria-label="Keeper 필터"
+          data-testid="fleet-fsm-matrix-filter"
+          onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+          class="min-w-[160px] max-w-[260px] rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-200 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none"
+        />
         ${tallies
           ? html`
               <div class="ml-auto flex flex-wrap gap-2" data-testid="invariant-strip">
@@ -315,6 +362,16 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
             `
           : null}
       </header>
+      ${isFiltering && visibleSnapshots.length === 0
+        ? html`
+            <div
+              data-testid="fleet-fsm-matrix-empty"
+              class="p-4 text-center text-xs text-zinc-500"
+            >
+              필터 결과 없음 (${data.snapshots.length} keepers)
+            </div>
+          `
+        : null}
       <div class="overflow-x-auto">
         <table class="min-w-full text-xs">
           <thead class="bg-zinc-900 text-zinc-300">
@@ -328,7 +385,7 @@ export function FleetFsmMatrix(props: FleetFsmMatrixProps = {}) {
             </tr>
           </thead>
           <tbody>
-            ${data.snapshots.map(snap => {
+            ${visibleSnapshots.map(snap => {
               const anyViolated = INVARIANT_KEYS.some(k => !snap.invariants[k])
               const rowTone = anyViolated ? 'border-l-2 border-red-500' : ''
               const name = inferKeeperNameFrom(snap)


### PR DESCRIPTION
## 요약

`fleet-fsm-matrix.ts` 의 **플릿 composite** 테이블 (keeper × 6 FSM axes) 에 자유 텍스트 필터를 추가합니다. 등록된 keeper가 늘어나면 이 매트릭스가 세로로 길어지고, 특정 keeper 한 줄이나 같은 상태(`trying`, `Overflowed`, `warning` 등)인 keeper 전체를 빠르게 좁히려면 스크롤/브라우저 find 를 써야 했습니다.

## 왜 이 리스트인가

`fleet-fsm-matrix.ts` 의 5개 `.map` 사이트:

- `INVARIANT_KEYS.map` — 상단 invariant strip, 4개 고정 라벨 → 필터 이득 없음
- `AXES.map` (thead) — 6개 고정 컬럼 헤더 → 필터 이득 없음
- `AXES.map` (cell render) — 행 내부 렌더링, 행 자체는 아님
- `series.map` (sparkline) — 30-tick 셀 내부 바 → 필터 대상 아님
- **`data.snapshots.map` (tbody) — keeper 행. fleet 규모에 따라 선형으로 커지는 유일한 리스트** ← 선택

`snapshots.map` 이 fleet 크기와 1:1로 증가하는 유일한 축이고, 운영자가 실제로 필터를 원하는 "한 keeper 찾기 / 같은 상태인 것 모으기" 니즈가 여기에 걸립니다.

## 변경

- `filterKeeperSnapshots(snapshots, query)` 순수 함수를 `fleet-fsm-matrix.ts` 에서 export.
  - 1차: keeper name (= `inferKeeperNameFrom(snap)`) 에 case-insensitive substring.
  - 2차: 6개 axis(`phase`, `turn`, `decision`, `cascade`, `compaction`, `breaker`) 의 현재 값 중 하나라도 substring 매치.
  - 첫 매치 승. 짧은 needle(`trying`)은 cascade 상태만 잡고 keeper name을 오염시키지 않음.
- 빈/공백 query → 입력 참조 그대로 반환. 비필터 경로에서 useMemo 가 identity 유지.
- 입력 비변이 (`readonly KeeperCompositeSnapshot[]`).
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N keepers)` — 원래 "No keepers registered" 와 구분.
- 한국어 placeholder: `name / 상태 필터 (예: gen12, trying)`.
- 매트릭스 렌더는 `visibleSnapshots` 로 바꾸고 history ring / invariant tally 는 기존대로 전체 `data.snapshots` 기준 유지 (filter 는 표시 레이어).

## 테스트

- `pnpm exec tsc --noEmit`: 0 errors.
- `pnpm exec vitest run src/components/fleet-fsm-matrix.test.ts`: 26/26 pass (기존 17 + 신규 9).
- `pnpm exec eslint .`: 0 errors.

신규 9건:
1. 빈 query → 입력 참조 동일 (`.toBe(rows)`)
2. 공백 query → 입력 참조 동일
3. keeper name substring, case-insensitive
4. KSM 축 (`phase: Overflowed`) 매치
5. KCL 축 (`cascade: trying`) 매치
6. KTC 축 (`turn_phase: prompting`) 매치
7. no-match → 빈 배열
8. 입력 비변이 (length/contents 불변 확인)
9. trim 적용 + 필터 실행 시 새 배열 반환 (`.not.toBe(rows)`)

## CI 관련

Main CI는 GREEN 상태. Dashboard-only 변경, 백엔드/OAS pin 변경 없음.

## 범위 제한

Dashboard 파일 2개만 수정 (`fleet-fsm-matrix.ts`, `fleet-fsm-matrix.test.ts`). 다른 리스트는 건드리지 않음. `fleet-telemetry-panel.ts` 는 iter-12 (#7846) 에서 이미 name/model/blocker 필터가 있으므로 건드리지 않음. iter-7/8/9/11/12 seed-hint 패턴 유지.