### PR TITLE
feat(dashboard): add request/task/submitter filter to verification-requests-panel

### DIFF
--- a/dashboard/src/components/verification-requests-panel.test.ts
+++ b/dashboard/src/components/verification-requests-panel.test.ts
@@ -88,7 +88,10 @@ vi.mock('./common/input', () => ({
 
 // ── Import after mocks ────────────────────────────────
 
-import { VerificationRequestsPanel } from './verification-requests-panel'
+import {
+  VerificationRequestsPanel,
+  filterVerificationRequests,
+} from './verification-requests-panel'
 
 function makeRequest(overrides: Partial<VerificationRequest> = {}): VerificationRequest {
   return {
@@ -232,7 +235,91 @@ describe('VerificationRequestsPanel', () => {
     const searchInput = screen.getByTestId('search-input')
     fireEvent.input(searchInput, { target: { value: 'nonexistent' } })
     await waitFor(() => {
-      expect(screen.getByTestId('empty-state')).toBeTruthy()
+      const empty = screen.getByTestId('empty-state')
+      expect(empty).toBeTruthy()
+      expect(empty.textContent).toContain('필터 결과 없음')
+      expect(empty.textContent).toContain('1 items')
     })
+  })
+})
+
+// ── filterVerificationRequests pure helper ─────────────
+
+describe('filterVerificationRequests', () => {
+  const r1 = makeRequest({
+    request_id: 'req-ALPHA',
+    task_id: 'task-001',
+    submitted_by: 'keeper-x',
+    approved_by: 'gatekeeper-9',
+  })
+  const r2 = makeRequest({
+    request_id: 'req-beta',
+    task_id: 'task-002',
+    submitted_by: 'agent-foo',
+    approved_by: null,
+  })
+  const r3 = makeRequest({
+    request_id: 'req-gamma',
+    task_id: 'task-003',
+    submitted_by: 'agent-bar',
+    approved_by: 'keeper-z',
+  })
+  const rows = [r1, r2, r3]
+
+  it('empty query returns input reference unchanged', () => {
+    const out = filterVerificationRequests(rows, '')
+    expect(out).toBe(rows)
+  })
+
+  it('whitespace-only query returns input reference unchanged', () => {
+    const out = filterVerificationRequests(rows, '   \t')
+    expect(out).toBe(rows)
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    const out = filterVerificationRequests(rows, '  alpha  ')
+    expect(out).toEqual([r1])
+  })
+
+  it('case-insensitive match on request_id', () => {
+    const out = filterVerificationRequests(rows, 'ALPHA')
+    expect(out).toEqual([r1])
+    const out2 = filterVerificationRequests(rows, 'alpha')
+    expect(out2).toEqual([r1])
+  })
+
+  it('matches on task_id substring', () => {
+    const out = filterVerificationRequests(rows, 'task-002')
+    expect(out).toEqual([r2])
+  })
+
+  it('matches on submitted_by substring', () => {
+    const out = filterVerificationRequests(rows, 'agent-')
+    expect(out).toEqual([r2, r3])
+  })
+
+  it('matches on approved_by substring', () => {
+    const out = filterVerificationRequests(rows, 'gatekeeper')
+    expect(out).toEqual([r1])
+  })
+
+  it('skips null approved_by without throwing', () => {
+    const out = filterVerificationRequests(rows, 'keeper')
+    // r1.approved_by=gatekeeper-9, r3.approved_by=keeper-z, r1 also has submitted_by=keeper-x
+    expect(out).toContain(r1)
+    expect(out).toContain(r3)
+    expect(out).not.toContain(r2)
+  })
+
+  it('no match returns empty array', () => {
+    const out = filterVerificationRequests(rows, 'nonexistent-needle')
+    expect(out).toEqual([])
+  })
+
+  it('does not mutate input array', () => {
+    const snapshot = [...rows]
+    filterVerificationRequests(rows, 'alpha')
+    expect(rows).toEqual(snapshot)
+    expect(rows.length).toBe(3)
   })
 })

--- a/dashboard/src/components/verification-requests-panel.ts
+++ b/dashboard/src/components/verification-requests-panel.ts
@@ -9,7 +9,7 @@
 // component-local state plumbing for a read-only table.
 
 import { html } from 'htm/preact'
-import { useEffect, useRef } from 'preact/hooks'
+import { useEffect, useMemo, useRef } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import {
   fetchVerificationRequests,
@@ -31,6 +31,34 @@ import {
 
 const AUTO_REFRESH_MS = 15_000
 const DEFAULT_LIMIT = 100
+
+/**
+ * Pure filter for verification requests.
+ *
+ * Case-insensitive substring match on `request_id`, `task_id`,
+ * `submitted_by`, and `approved_by` so operators can locate a request
+ * by partial id, by the owning task, or by the agent that submitted /
+ * approved it.
+ *
+ * Empty/whitespace query returns the input reference unchanged (no
+ * new array allocation, preserves referential equality for memoisation).
+ *
+ * Input is never mutated.
+ */
+export function filterVerificationRequests(
+  rows: readonly VerificationRequest[],
+  query: string,
+): readonly VerificationRequest[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === '') return rows
+  return rows.filter((row) => {
+    if (row.request_id.toLowerCase().includes(needle)) return true
+    if (row.task_id.toLowerCase().includes(needle)) return true
+    if (row.submitted_by.toLowerCase().includes(needle)) return true
+    if (row.approved_by && row.approved_by.toLowerCase().includes(needle)) return true
+    return false
+  })
+}
 
 type StatusFilter = VerificationRequestStatus | 'all'
 
@@ -203,14 +231,25 @@ function VerificationRow({ row }: { row: VerificationRequest }) {
 
 // ── Table ─────────────────────────────────────────────
 
-function RequestsTable({ requests }: { requests: VerificationRequest[] }) {
+function RequestsTable({
+  requests,
+  totalBeforeFilter,
+}: {
+  requests: readonly VerificationRequest[]
+  totalBeforeFilter: number
+}) {
   if (requests.length === 0) {
-    const hasFilter = statusFilter.value !== 'all' || searchQuery.value
+    const hasFilter = statusFilter.value !== 'all' || searchQuery.value.trim() !== ''
+    if (hasFilter && totalBeforeFilter > 0) {
+      return html`
+        <${EmptyState}>
+          필터 결과 없음 (${totalBeforeFilter} items)
+        <//>
+      `
+    }
     return html`
       <${EmptyState}>
-        ${hasFilter
-          ? '조건에 맞는 검증 요청이 없습니다.'
-          : '현재 대기중이거나 완료된 검증 요청이 없습니다.'}
+        현재 대기중이거나 완료된 검증 요청이 없습니다.
       <//>
     `
   }
@@ -261,21 +300,14 @@ export function VerificationRequestsPanel() {
 
   const current = resource.state.value
   const data = current.data ?? null
-  const filtered = data
-    ? data.requests.filter((r) => {
-        if (statusFilter.value !== 'all' && r.status !== statusFilter.value) return false
-        if (searchQuery.value) {
-          const q = searchQuery.value.toLowerCase()
-          if (
-            !r.request_id.toLowerCase().includes(q) &&
-            !r.task_id.toLowerCase().includes(q) &&
-            !r.submitted_by.toLowerCase().includes(q) &&
-            !(r.approved_by ?? '').toLowerCase().includes(q)
-          ) return false
-        }
-        return true
-      })
-    : []
+  const rows = data?.requests ?? []
+  const filtered = useMemo(() => {
+    const byStatus =
+      statusFilter.value === 'all'
+        ? rows
+        : rows.filter((r) => r.status === statusFilter.value)
+    return filterVerificationRequests(byStatus, searchQuery.value)
+  }, [rows, statusFilter.value, searchQuery.value])
 
   return html`
     <div class="flex flex-col gap-4">
@@ -317,9 +349,10 @@ export function VerificationRequestsPanel() {
       />
 
       <${TextInput}
+        type="search"
         class="max-w-[260px]"
-        placeholder="검색 (request, task, 제출자...)"
-        ariaLabel="검증 요청 검색"
+        placeholder="request / task / 제출자 / 승인자 필터"
+        ariaLabel="검증 요청 필터"
         value=${searchQuery.value}
         onInput=${(e: Event) => { searchQuery.value = (e.target as HTMLInputElement).value }}
       />
@@ -331,7 +364,12 @@ export function VerificationRequestsPanel() {
         : null}
 
       <${Card} title="검증 요청">
-        ${data ? html`<${RequestsTable} requests=${filtered} />` : null}
+        ${data
+          ? html`<${RequestsTable}
+              requests=${filtered}
+              totalBeforeFilter=${data.requests.length}
+            />`
+          : null}
       <//>
     </div>
   `


### PR DESCRIPTION
## 요약

`verification-requests-panel.ts` 의 **검증 요청 큐** (`RequestsTable`) 에서 사용하는 자유 텍스트 필터를, 컴포넌트 본문에 인라인으로 있던 `data.requests.filter(...)` 로직 대신 순수 함수 `filterVerificationRequests(rows, query)` 로 분리합니다. iter-7..12 seed-hint 패턴(순수 helper + `useMemo` + 필터 전용 empty state)과 동일한 구조입니다.

## 왜 이 리스트인가

`verification-requests-panel.ts` 의 4개 `.map` 사이트:

- `row.completion_contract.map` (line 168) — 행 내부 계약 항목, 카디널리티 작음
- `row.required_evidence.map` (line 180) — 행 내부 evidence 항목, 카디널리티 작음
- **`requests.map` (line 233, `RequestsTable` 본문)** — **검증 요청 큐 전체, cross-agent 승인 대기/완료 기록이 누적되는 유일한 리스트** ← 선택
- `FILTER_OPTIONS.map` (line 307) — 고정 길이 5개 status chip

검증 요청 큐는 `DEFAULT_LIMIT=100` 까지 로드되고 pending/approved/rejected/timed_out 4개 status 가 섞여 있어, status chip 하나만으로는 특정 keeper/task 한 줄을 집어내기 어렵습니다. 기존 인라인 filter 는 같은 4개 필드를 보고 있었지만 helper 분리와 memoisation 이 되어 있지 않아 이 PR 에서 정리합니다.

## 변경

- `filterVerificationRequests(rows, query)` 순수 함수를 `verification-requests-panel.ts` 에서 export. case-insensitive substring.
  - `request_id` → `task_id` → `submitted_by` → `approved_by` 순서로 첫 매치 승리.
- 빈/공백 query 는 입력 참조 그대로 반환 → 비필터 경로는 identity 유지.
- 입력 비변이 (`readonly VerificationRequest[]`).
- `VerificationRequestsPanel` 본문에서 status 필터 + 텍스트 필터를 `useMemo([rows, status, query])` 로 감싸 매 렌더마다 재계산하지 않도록 변경.
- 필터가 모든 행을 숨기면 별도 empty-state: `필터 결과 없음 (N items)` — 실제 비어있음 (`현재 대기중이거나 완료된 검증 요청이 없습니다.`) 과 구분.
- `TextInput` 에 `type="search"` (네이티브 clear 버튼) 적용.
- Placeholder: `request / task / 제출자 / 승인자 필터`, aria-label: `검증 요청 필터`.

## 테스트

- `pnpm exec tsc --noEmit`: 에러 없음.
- `pnpm exec vitest run src/components/verification-requests-panel.test.ts`: 21/21 pass (기존 11 + 신규 10).
- `pnpm exec eslint .`: 0 errors.

신규 10건 (`filterVerificationRequests` 대상):
1. 빈 query → 입력 참조 동일
2. 공백만 있는 query → 입력 참조 동일
3. trim 적용 (앞뒤 공백)
4. case-insensitive (`request_id`, 대/소문자 양쪽 검증)
5. `task_id` substring 매칭
6. `submitted_by` substring 매칭 (다중 매치)
7. `approved_by` substring 매칭
8. null `approved_by` 를 포함한 행이 throw 없이 스킵
9. no-match → 빈 배열
10. 입력 배열 비변이 (snapshot equality)

기존 `shows filter-specific empty state with search` 테스트에 `필터 결과 없음` + `1 items` 문구 assertion 추가.

## CI 관련

Main CI: GREEN. Dashboard-only 변경 (파일 2개, 리스트 1개).